### PR TITLE
Clarify cumulative proposed_plan behavior in Plan mode

### DIFF
--- a/codex-rs/core/templates/collaboration_mode/plan.md
+++ b/codex-rs/core/templates/collaboration_mode/plan.md
@@ -120,7 +120,3 @@ Do not ask "should I proceed?" in the final output. The user can easily switch o
 Only produce at most one `<proposed_plan>` block per turn, and only when you are presenting a complete spec.
 
 If the user stays in Plan mode and asks for revisions after a prior `<proposed_plan>`, any new `<proposed_plan>` must be a complete replacement.
-
-This cumulative replacement rule applies only within the current planning session. Don't inherit `<proposed_plan>` from previous Plan mode sessions (e.g. after which the user switched to Default mode to implement), unless the user asks you to.
-
-If the user asks for a new plan, you can break the cumulative replacement rule to follow their request.

--- a/codex-rs/core/templates/collaboration_mode/plan.md
+++ b/codex-rs/core/templates/collaboration_mode/plan.md
@@ -118,3 +118,9 @@ plan content should be human and agent digestible. The final plan must be plan-o
 Do not ask "should I proceed?" in the final output. The user can easily switch out of Plan mode and request implementation if you have included a `<proposed_plan>` block in your response. Alternatively, they can decide to stay in Plan mode and continue refining the plan.
 
 Only produce at most one `<proposed_plan>` block per turn, and only when you are presenting a complete spec.
+
+If the user stays in Plan mode and asks for revisions after a prior `<proposed_plan>`, any new `<proposed_plan>` must be a complete replacement.
+
+This cumulative replacement rule applies only within the current planning session. Don't inherit `<proposed_plan>` from previous Plan mode sessions (e.g. after which the user switched to Default mode to implement), unless the user asks you to.
+
+If the user asks for a new plan, you can break the cumulative replacement rule to follow their request.


### PR DESCRIPTION
## Summary
- Require revised `<proposed_plan>` blocks in the same planning session to be complete replacements, not partial/delta plans.
- Scope that cumulative replacement rule to the current planning session only.
- Clarify that after leaving Plan mode (for example switching to Default mode to implement) or when explicitly asked for a new plan, the model should produce a new self-contained plan without inheriting prior plan blocks unless requested.

## Testing
- Not run (prompt/template text-only change).
