### PR TITLE
test(app-server-protocol): serialize schema export tests

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1349,6 +1349,7 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "serde_json",
+ "serial_test",
  "shlex",
  "similar",
  "strum_macros 0.27.2",

--- a/codex-rs/app-server-protocol/Cargo.toml
+++ b/codex-rs/app-server-protocol/Cargo.toml
@@ -31,5 +31,6 @@ uuid = { workspace = true, features = ["serde", "v7"] }
 anyhow = { workspace = true }
 codex-utils-cargo-bin = { workspace = true }
 pretty_assertions = { workspace = true }
+serial_test = { workspace = true }
 similar = { workspace = true }
 tempfile = { workspace = true }

--- a/codex-rs/app-server-protocol/src/export.rs
+++ b/codex-rs/app-server-protocol/src/export.rs
@@ -1402,12 +1402,14 @@ mod tests {
     use crate::protocol::v2;
     use anyhow::Result;
     use pretty_assertions::assert_eq;
+    use serial_test::serial;
     use std::collections::BTreeSet;
     use std::fs;
     use std::path::PathBuf;
     use uuid::Uuid;
 
     #[test]
+    #[serial(app_server_protocol_ts)]
     fn generated_ts_optional_nullable_fields_only_in_params() -> Result<()> {
         // Assert that "?: T | null" only appears in generated *Params types.
         let output_dir = std::env::temp_dir().join(format!("codex_ts_types_{}", Uuid::now_v7()));
@@ -1642,6 +1644,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(app_server_protocol_ts)]
     fn generate_ts_with_experimental_api_retains_experimental_entries() -> Result<()> {
         let output_dir =
             std::env::temp_dir().join(format!("codex_ts_types_experimental_{}", Uuid::now_v7()));

--- a/codex-rs/app-server-protocol/tests/schema_fixtures.rs
+++ b/codex-rs/app-server-protocol/tests/schema_fixtures.rs
@@ -2,10 +2,12 @@ use anyhow::Context;
 use anyhow::Result;
 use codex_app_server_protocol::read_schema_fixture_tree;
 use codex_app_server_protocol::write_schema_fixtures;
+use serial_test::serial;
 use similar::TextDiff;
 use std::path::Path;
 
 #[test]
+#[serial(app_server_protocol_ts)]
 fn schema_fixtures_match_generated() -> Result<()> {
     let schema_root = schema_root()?;
     let fixture_tree = read_tree(&schema_root)?;


### PR DESCRIPTION
## Summary
- serialize the heavy `codex-app-server-protocol` TypeScript export and schema fixture tests so they don't overlap under parallel test execution
- add `serial_test` as a crate dev-dependency and update `Cargo.lock`

## Root Cause
These tests all regenerate app-server protocol TypeScript/JSON schemas and contend on the `ts-rs` export path mutex plus filesystem writes when the test runner runs them concurrently. Under load, that contention can push individual tests past the 30s timeout.

## Testing
- `just fmt`
- `cargo test -p codex-app-server-protocol`
- `cargo clippy -p codex-app-server-protocol --tests`
- `just bazel-lock-update`
- `just bazel-lock-check`
