### PR TITLE
request_user_input: partially submit committed answers on interrupt

### DIFF
--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -587,6 +587,7 @@ pub(crate) async fn apply_bespoke_event_handling(
                 );
                 let empty = CoreRequestUserInputResponse {
                     answers: HashMap::new(),
+                    interrupted: false,
                 };
                 if let Err(err) = conversation
                     .submit(Op::UserInputAnswer {
@@ -1916,6 +1917,7 @@ async fn on_request_user_input_response(
             error!("request failed with client error: {err:?}");
             let empty = CoreRequestUserInputResponse {
                 answers: HashMap::new(),
+                interrupted: false,
             };
             if let Err(err) = conversation
                 .submit(Op::UserInputAnswer {
@@ -1932,6 +1934,7 @@ async fn on_request_user_input_response(
             error!("request failed: {err:?}");
             let empty = CoreRequestUserInputResponse {
                 answers: HashMap::new(),
+                interrupted: false,
             };
             if let Err(err) = conversation
                 .submit(Op::UserInputAnswer {
@@ -1966,6 +1969,7 @@ async fn on_request_user_input_response(
                 )
             })
             .collect(),
+        interrupted: false,
     };
 
     if let Err(err) = conversation

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -270,6 +270,7 @@ use crate::tasks::SessionTask;
 use crate::tasks::SessionTaskContext;
 use crate::tools::ToolRouter;
 use crate::tools::context::SharedTurnDiffTracker;
+use crate::tools::context::ToolDispatchOutput;
 use crate::tools::handlers::SEARCH_TOOL_BM25_TOOL_NAME;
 use crate::tools::js_repl::JsReplHandle;
 use crate::tools::js_repl::resolve_compatible_node;
@@ -2782,14 +2783,6 @@ impl Session {
         sub_id: &str,
         response: RequestUserInputResponse,
     ) {
-        if response.interrupted {
-            let mut active = self.active_turn.lock().await;
-            if let Some(at) = active.as_mut() {
-                let mut ts = at.turn_state.lock().await;
-                ts.mark_request_user_input_interrupted();
-            }
-        }
-
         let entry = {
             let mut active = self.active_turn.lock().await;
             match active.as_mut() {
@@ -2807,17 +2800,6 @@ impl Session {
             None => {
                 warn!("No pending user input found for sub_id: {sub_id}");
             }
-        }
-    }
-
-    pub async fn take_request_user_input_interrupted(&self) -> bool {
-        let mut active = self.active_turn.lock().await;
-        match active.as_mut() {
-            Some(at) => {
-                let mut ts = at.turn_state.lock().await;
-                ts.take_request_user_input_interrupted()
-            }
-            None => false,
         }
     }
 
@@ -5054,10 +5036,10 @@ pub(crate) async fn run_turn(
             Ok(sampling_request_output) => {
                 let SamplingRequestResult {
                     needs_follow_up,
-                    request_user_input_interrupted,
+                    interrupted_tool_result,
                     last_agent_message: sampling_request_last_agent_message,
                 } = sampling_request_output;
-                if request_user_input_interrupted {
+                if interrupted_tool_result {
                     cancellation_token.cancel();
                     sess.finish_turn_without_completion_event(turn_context.as_ref())
                         .await;
@@ -5664,7 +5646,7 @@ async fn built_tools(
 #[derive(Debug)]
 struct SamplingRequestResult {
     needs_follow_up: bool,
-    request_user_input_interrupted: bool,
+    interrupted_tool_result: bool,
     last_agent_message: Option<String>,
 }
 
@@ -6180,22 +6162,24 @@ async fn handle_assistant_item_done_in_plan_mode(
 }
 
 async fn drain_in_flight(
-    in_flight: &mut FuturesOrdered<BoxFuture<'static, CodexResult<ResponseInputItem>>>,
+    in_flight: &mut FuturesOrdered<BoxFuture<'static, CodexResult<ToolDispatchOutput>>>,
     sess: Arc<Session>,
     turn_context: Arc<TurnContext>,
-) -> CodexResult<()> {
+) -> CodexResult<bool> {
+    let mut interrupted_tool_result = false;
     while let Some(res) = in_flight.next().await {
         match res {
-            Ok(response_input) => {
-                sess.record_conversation_items(&turn_context, &[response_input.into()])
+            Ok(output) => {
+                sess.record_conversation_items(&turn_context, &[output.response_input.into()])
                     .await;
+                interrupted_tool_result |= output.interrupt_turn;
             }
             Err(err) => {
                 error_or_panic(format!("in-flight tool future failed during drain: {err}"));
             }
         }
     }
-    Ok(())
+    Ok(interrupted_tool_result)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -6244,7 +6228,7 @@ async fn try_run_sampling_request(
         Arc::clone(&turn_context),
         Arc::clone(&turn_diff_tracker),
     );
-    let mut in_flight: FuturesOrdered<BoxFuture<'static, CodexResult<ResponseInputItem>>> =
+    let mut in_flight: FuturesOrdered<BoxFuture<'static, CodexResult<ToolDispatchOutput>>> =
         FuturesOrdered::new();
     let mut needs_follow_up = false;
     let mut last_agent_message: Option<String> = None;
@@ -6428,7 +6412,7 @@ async fn try_run_sampling_request(
 
                 break Ok(SamplingRequestResult {
                     needs_follow_up,
-                    request_user_input_interrupted: false,
+                    interrupted_tool_result: false,
                     last_agent_message,
                 });
             }
@@ -6520,12 +6504,13 @@ async fn try_run_sampling_request(
     )
     .await;
 
-    drain_in_flight(&mut in_flight, sess.clone(), turn_context.clone()).await?;
+    let interrupted_tool_result =
+        drain_in_flight(&mut in_flight, sess.clone(), turn_context.clone()).await?;
     if let Ok(result) = outcome.as_mut()
-        && sess.take_request_user_input_interrupted().await
+        && interrupted_tool_result
     {
         result.needs_follow_up = false;
-        result.request_user_input_interrupted = true;
+        result.interrupted_tool_result = true;
     }
 
     if should_emit_turn_diff {

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -5044,6 +5044,10 @@ pub(crate) async fn run_turn(
                 } = sampling_request_output;
                 if interrupted_tool_result {
                     cancellation_token.cancel();
+                    // Keep interrupt cleanup consistent with abort_all_tasks(): a parallel
+                    // unified-exec tool call may still be running when request_user_input
+                    // returns an interrupted result.
+                    sess.close_unified_exec_processes().await;
                     sess.finish_turn_without_completion_event(turn_context.as_ref())
                         .await;
                     // Defer TurnAborted emission until run_turn unwinds so the caller can

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -6187,6 +6187,17 @@ async fn drain_in_flight(
             Ok(indexed) => {
                 let IndexedToolDispatchOutput { seq, output } = indexed;
                 if output.interrupt_turn {
+                    // Preserve any already-completed earlier tool outputs before short-circuiting.
+                    // FuturesUnordered may yield the interrupting result before lower-sequence
+                    // completions that were buffered waiting on an even earlier slow tool.
+                    let _dropped_later_ready = ready.split_off(&seq);
+                    for (_ready_seq, ready_output) in std::mem::take(&mut ready) {
+                        sess.record_conversation_items(
+                            &turn_context,
+                            &[ready_output.response_input.into()],
+                        )
+                        .await;
+                    }
                     sess.record_conversation_items(&turn_context, &[output.response_input.into()])
                         .await;
                     return Ok(true);
@@ -6624,6 +6635,7 @@ mod tests {
     use crate::tasks::SessionTask;
     use crate::tasks::SessionTaskContext;
     use crate::tools::ToolRouter;
+    use crate::tools::context::ToolDispatchOutput;
     use crate::tools::context::ToolInvocation;
     use crate::tools::context::ToolOutput;
     use crate::tools::context::ToolPayload;
@@ -9291,6 +9303,108 @@ mod tests {
         }
         // No extra events should be emitted after an abort.
         assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn drain_in_flight_flushes_buffered_earlier_results_before_interrupt() {
+        let (sess, tc, _rx) = make_session_and_context_with_rx().await;
+
+        let mut in_flight: FuturesUnordered<
+            BoxFuture<'static, CodexResult<IndexedToolDispatchOutput>>,
+        > = FuturesUnordered::new();
+
+        let (slow_tx, slow_rx) = tokio::sync::oneshot::channel::<()>();
+        let _slow_tx = slow_tx;
+        in_flight.push(Box::pin(async move {
+            let _ = slow_rx.await;
+            Ok(IndexedToolDispatchOutput {
+                seq: 0,
+                output: ToolDispatchOutput {
+                    response_input: ResponseInputItem::FunctionCallOutput {
+                        call_id: "slow-call".to_string(),
+                        output: FunctionCallOutputPayload {
+                            body: FunctionCallOutputBody::Text("slow".to_string()),
+                            ..Default::default()
+                        },
+                    },
+                    interrupt_turn: false,
+                },
+            })
+        }));
+
+        in_flight.push(Box::pin(async move {
+            Ok(IndexedToolDispatchOutput {
+                seq: 1,
+                output: ToolDispatchOutput {
+                    response_input: ResponseInputItem::FunctionCallOutput {
+                        call_id: "fast-call".to_string(),
+                        output: FunctionCallOutputPayload {
+                            body: FunctionCallOutputBody::Text("fast".to_string()),
+                            ..Default::default()
+                        },
+                    },
+                    interrupt_turn: false,
+                },
+            })
+        }));
+
+        let (interrupt_tx, interrupt_rx) = tokio::sync::oneshot::channel::<()>();
+        tokio::spawn(async move {
+            sleep(Duration::from_millis(10)).await;
+            let _ = interrupt_tx.send(());
+        });
+        in_flight.push(Box::pin(async move {
+            let _ = interrupt_rx.await;
+            Ok(IndexedToolDispatchOutput {
+                seq: 2,
+                output: ToolDispatchOutput {
+                    response_input: ResponseInputItem::FunctionCallOutput {
+                        call_id: "interrupt-call".to_string(),
+                        output: FunctionCallOutputPayload {
+                            body: FunctionCallOutputBody::Text("interrupt".to_string()),
+                            ..Default::default()
+                        },
+                    },
+                    interrupt_turn: true,
+                },
+            })
+        }));
+
+        let interrupted = drain_in_flight(&mut in_flight, Arc::clone(&sess), Arc::clone(&tc))
+            .await
+            .expect("drain_in_flight should succeed");
+        assert!(interrupted);
+
+        let history = sess.clone_history().await;
+        let fast_item = ResponseItem::from(ResponseInputItem::FunctionCallOutput {
+            call_id: "fast-call".to_string(),
+            output: FunctionCallOutputPayload {
+                body: FunctionCallOutputBody::Text("fast".to_string()),
+                ..Default::default()
+            },
+        });
+        let interrupt_item = ResponseItem::from(ResponseInputItem::FunctionCallOutput {
+            call_id: "interrupt-call".to_string(),
+            output: FunctionCallOutputPayload {
+                body: FunctionCallOutputBody::Text("interrupt".to_string()),
+                ..Default::default()
+            },
+        });
+
+        let fast_idx = history
+            .raw_items()
+            .iter()
+            .position(|item| item == &fast_item)
+            .expect("buffered earlier tool result should be recorded");
+        let interrupt_idx = history
+            .raw_items()
+            .iter()
+            .position(|item| item == &interrupt_item)
+            .expect("interrupting tool result should be recorded");
+        assert!(
+            fast_idx < interrupt_idx,
+            "buffered earlier tool result should be recorded before interrupt result"
+        );
     }
 
     #[tokio::test]

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -6187,6 +6187,22 @@ async fn drain_in_flight(
             Ok(indexed) => {
                 let IndexedToolDispatchOutput { seq, output } = indexed;
                 if output.interrupt_turn {
+                    // Drain any completions that are already ready but not yet yielded by
+                    // FuturesUnordered so earlier outputs are not lost when we return below.
+                    loop {
+                        match in_flight.next().now_or_never() {
+                            Some(Some(Ok(indexed))) => {
+                                let IndexedToolDispatchOutput { seq, output } = indexed;
+                                ready.insert(seq, output);
+                            }
+                            Some(Some(Err(err))) => {
+                                error_or_panic(format!(
+                                    "in-flight tool future failed during interrupt drain: {err}"
+                                ));
+                            }
+                            Some(None) | None => break,
+                        }
+                    }
                     // Preserve any already-completed earlier tool outputs before short-circuiting.
                     // FuturesUnordered may yield the interrupting result before lower-sequence
                     // completions that were buffered waiting on an even earlier slow tool.
@@ -9404,6 +9420,105 @@ mod tests {
         assert!(
             fast_idx < interrupt_idx,
             "buffered earlier tool result should be recorded before interrupt result"
+        );
+    }
+
+    #[tokio::test]
+    async fn drain_in_flight_flushes_ready_unyielded_earlier_results_before_interrupt() {
+        let (sess, tc, _rx) = make_session_and_context_with_rx().await;
+
+        let mut in_flight: FuturesUnordered<
+            BoxFuture<'static, CodexResult<IndexedToolDispatchOutput>>,
+        > = FuturesUnordered::new();
+
+        let (slow_tx, slow_rx) = tokio::sync::oneshot::channel::<()>();
+        let _slow_tx = slow_tx;
+        in_flight.push(Box::pin(async move {
+            let _ = slow_rx.await;
+            Ok(IndexedToolDispatchOutput {
+                seq: 0,
+                output: ToolDispatchOutput {
+                    response_input: ResponseInputItem::FunctionCallOutput {
+                        call_id: "slow-call-2".to_string(),
+                        output: FunctionCallOutputPayload {
+                            body: FunctionCallOutputBody::Text("slow".to_string()),
+                            ..Default::default()
+                        },
+                    },
+                    interrupt_turn: false,
+                },
+            })
+        }));
+
+        let (fast_tx, fast_rx) = tokio::sync::oneshot::channel::<()>();
+        in_flight.push(Box::pin(async move {
+            let _ = fast_rx.await;
+            Ok(IndexedToolDispatchOutput {
+                seq: 1,
+                output: ToolDispatchOutput {
+                    response_input: ResponseInputItem::FunctionCallOutput {
+                        call_id: "fast-call-2".to_string(),
+                        output: FunctionCallOutputPayload {
+                            body: FunctionCallOutputBody::Text("fast".to_string()),
+                            ..Default::default()
+                        },
+                    },
+                    interrupt_turn: false,
+                },
+            })
+        }));
+
+        in_flight.push(Box::pin(async move {
+            let _ = fast_tx.send(());
+            Ok(IndexedToolDispatchOutput {
+                seq: 2,
+                output: ToolDispatchOutput {
+                    response_input: ResponseInputItem::FunctionCallOutput {
+                        call_id: "interrupt-call-2".to_string(),
+                        output: FunctionCallOutputPayload {
+                            body: FunctionCallOutputBody::Text("interrupt".to_string()),
+                            ..Default::default()
+                        },
+                    },
+                    interrupt_turn: true,
+                },
+            })
+        }));
+
+        let interrupted = drain_in_flight(&mut in_flight, Arc::clone(&sess), Arc::clone(&tc))
+            .await
+            .expect("drain_in_flight should succeed");
+        assert!(interrupted);
+
+        let history = sess.clone_history().await;
+        let fast_item = ResponseItem::from(ResponseInputItem::FunctionCallOutput {
+            call_id: "fast-call-2".to_string(),
+            output: FunctionCallOutputPayload {
+                body: FunctionCallOutputBody::Text("fast".to_string()),
+                ..Default::default()
+            },
+        });
+        let interrupt_item = ResponseItem::from(ResponseInputItem::FunctionCallOutput {
+            call_id: "interrupt-call-2".to_string(),
+            output: FunctionCallOutputPayload {
+                body: FunctionCallOutputBody::Text("interrupt".to_string()),
+                ..Default::default()
+            },
+        });
+
+        let fast_idx = history
+            .raw_items()
+            .iter()
+            .position(|item| item == &fast_item)
+            .expect("ready-but-unyielded earlier tool result should be recorded");
+        let interrupt_idx = history
+            .raw_items()
+            .iter()
+            .position(|item| item == &interrupt_item)
+            .expect("interrupting tool result should be recorded");
+        assert!(
+            fast_idx < interrupt_idx,
+            "ready-but-unyielded earlier tool result should be recorded before interrupt result"
         );
     }
 

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt::Debug;
@@ -105,7 +106,7 @@ use codex_utils_stream_parser::extract_proposed_plan_text;
 use codex_utils_stream_parser::strip_citations;
 use futures::future::BoxFuture;
 use futures::prelude::*;
-use futures::stream::FuturesOrdered;
+use futures::stream::FuturesUnordered;
 use rmcp::model::ListResourceTemplatesResult;
 use rmcp::model::ListResourcesResult;
 use rmcp::model::PaginatedRequestParams;
@@ -5650,6 +5651,12 @@ struct SamplingRequestResult {
     last_agent_message: Option<String>,
 }
 
+#[derive(Debug)]
+struct IndexedToolDispatchOutput {
+    seq: usize,
+    output: ToolDispatchOutput,
+}
+
 /// Ephemeral per-response state for streaming a single proposed plan.
 /// This is intentionally not persisted or stored in session/state since it
 /// only exists while a response is actively streaming. The final plan text
@@ -6162,24 +6169,41 @@ async fn handle_assistant_item_done_in_plan_mode(
 }
 
 async fn drain_in_flight(
-    in_flight: &mut FuturesOrdered<BoxFuture<'static, CodexResult<ToolDispatchOutput>>>,
+    in_flight: &mut FuturesUnordered<BoxFuture<'static, CodexResult<IndexedToolDispatchOutput>>>,
     sess: Arc<Session>,
     turn_context: Arc<TurnContext>,
 ) -> CodexResult<bool> {
-    let mut interrupted_tool_result = false;
+    let mut next_seq = 0usize;
+    let mut ready = BTreeMap::<usize, ToolDispatchOutput>::new();
     while let Some(res) = in_flight.next().await {
         match res {
-            Ok(output) => {
-                sess.record_conversation_items(&turn_context, &[output.response_input.into()])
-                    .await;
-                interrupted_tool_result |= output.interrupt_turn;
+            Ok(indexed) => {
+                let IndexedToolDispatchOutput { seq, output } = indexed;
+                if output.interrupt_turn {
+                    sess.record_conversation_items(&turn_context, &[output.response_input.into()])
+                        .await;
+                    return Ok(true);
+                }
+
+                ready.insert(seq, output);
+                while let Some(output) = ready.remove(&next_seq) {
+                    sess.record_conversation_items(&turn_context, &[output.response_input.into()])
+                        .await;
+                    next_seq += 1;
+                }
             }
             Err(err) => {
                 error_or_panic(format!("in-flight tool future failed during drain: {err}"));
             }
         }
     }
-    Ok(interrupted_tool_result)
+    if !ready.is_empty() {
+        for (_seq, output) in ready {
+            sess.record_conversation_items(&turn_context, &[output.response_input.into()])
+                .await;
+        }
+    }
+    Ok(false)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -6228,8 +6252,10 @@ async fn try_run_sampling_request(
         Arc::clone(&turn_context),
         Arc::clone(&turn_diff_tracker),
     );
-    let mut in_flight: FuturesOrdered<BoxFuture<'static, CodexResult<ToolDispatchOutput>>> =
-        FuturesOrdered::new();
+    let mut in_flight: FuturesUnordered<
+        BoxFuture<'static, CodexResult<IndexedToolDispatchOutput>>,
+    > = FuturesUnordered::new();
+    let mut next_in_flight_seq = 0usize;
     let mut needs_follow_up = false;
     let mut last_agent_message: Option<String> = None;
     let mut active_item: Option<TurnItem> = None;
@@ -6313,7 +6339,12 @@ async fn try_run_sampling_request(
                     .instrument(handle_responses)
                     .await?;
                 if let Some(tool_future) = output_result.tool_future {
-                    in_flight.push_back(tool_future);
+                    let seq = next_in_flight_seq;
+                    next_in_flight_seq += 1;
+                    in_flight.push(Box::pin(async move {
+                        let output = tool_future.await?;
+                        Ok(IndexedToolDispatchOutput { seq, output })
+                    }));
                 }
                 if let Some(agent_message) = output_result.last_agent_message {
                     last_agent_message = Some(agent_message);

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -2782,6 +2782,14 @@ impl Session {
         sub_id: &str,
         response: RequestUserInputResponse,
     ) {
+        if response.interrupted {
+            let mut active = self.active_turn.lock().await;
+            if let Some(at) = active.as_mut() {
+                let mut ts = at.turn_state.lock().await;
+                ts.mark_request_user_input_interrupted();
+            }
+        }
+
         let entry = {
             let mut active = self.active_turn.lock().await;
             match active.as_mut() {
@@ -2799,6 +2807,17 @@ impl Session {
             None => {
                 warn!("No pending user input found for sub_id: {sub_id}");
             }
+        }
+    }
+
+    pub async fn take_request_user_input_interrupted(&self) -> bool {
+        let mut active = self.active_turn.lock().await;
+        match active.as_mut() {
+            Some(at) => {
+                let mut ts = at.turn_state.lock().await;
+                ts.take_request_user_input_interrupted()
+            }
+            None => false,
         }
     }
 
@@ -5035,8 +5054,20 @@ pub(crate) async fn run_turn(
             Ok(sampling_request_output) => {
                 let SamplingRequestResult {
                     needs_follow_up,
+                    request_user_input_interrupted,
                     last_agent_message: sampling_request_last_agent_message,
                 } = sampling_request_output;
+                if request_user_input_interrupted {
+                    cancellation_token.cancel();
+                    sess.finish_turn_without_completion_event(turn_context.as_ref())
+                        .await;
+                    sess.emit_turn_aborted_without_rollout_flush(
+                        &turn_context,
+                        TurnAbortReason::Interrupted,
+                    )
+                    .await;
+                    break;
+                }
                 let total_usage_tokens = sess.get_total_token_usage().await;
                 let token_limit_reached = total_usage_tokens >= auto_compact_limit;
 
@@ -5633,6 +5664,7 @@ async fn built_tools(
 #[derive(Debug)]
 struct SamplingRequestResult {
     needs_follow_up: bool,
+    request_user_input_interrupted: bool,
     last_agent_message: Option<String>,
 }
 
@@ -6222,7 +6254,7 @@ async fn try_run_sampling_request(
     let mut assistant_message_stream_parsers = AssistantMessageStreamParsers::new(plan_mode);
     let mut plan_mode_state = plan_mode.then(|| PlanModeStreamState::new(&turn_context.sub_id));
     let receiving_span = trace_span!("receiving_stream");
-    let outcome: CodexResult<SamplingRequestResult> = loop {
+    let mut outcome: CodexResult<SamplingRequestResult> = loop {
         let handle_responses = trace_span!(
             parent: &receiving_span,
             "handle_responses",
@@ -6396,6 +6428,7 @@ async fn try_run_sampling_request(
 
                 break Ok(SamplingRequestResult {
                     needs_follow_up,
+                    request_user_input_interrupted: false,
                     last_agent_message,
                 });
             }
@@ -6488,6 +6521,12 @@ async fn try_run_sampling_request(
     .await;
 
     drain_in_flight(&mut in_flight, sess.clone(), turn_context.clone()).await?;
+    if let Ok(result) = outcome.as_mut()
+        && sess.take_request_user_input_interrupted().await
+    {
+        result.needs_follow_up = false;
+        result.request_user_input_interrupted = true;
+    }
 
     if should_emit_turn_diff {
         let unified_diff = {

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -269,6 +269,7 @@ use crate::tasks::RegularTask;
 use crate::tasks::ReviewTask;
 use crate::tasks::SessionTask;
 use crate::tasks::SessionTaskContext;
+use crate::tasks::TaskRunOutput;
 use crate::tools::ToolRouter;
 use crate::tools::context::SharedTurnDiffTracker;
 use crate::tools::context::ToolDispatchOutput;
@@ -4811,9 +4812,9 @@ pub(crate) async fn run_turn(
     input: Vec<UserInput>,
     prewarmed_client_session: Option<ModelClientSession>,
     cancellation_token: CancellationToken,
-) -> Option<String> {
+) -> TaskRunOutput {
     if input.is_empty() {
-        return None;
+        return TaskRunOutput::default();
     }
 
     let model_info = turn_context.model_info.clone();
@@ -4834,7 +4835,7 @@ pub(crate) async fn run_turn(
         .is_err()
     {
         error!("Failed to run pre-sampling compact");
-        return None;
+        return TaskRunOutput::default();
     }
 
     let skills_outcome = Some(turn_context.turn_skills.outcome.as_ref());
@@ -4853,7 +4854,7 @@ pub(crate) async fn run_turn(
             .await
         {
             Ok(mcp_tools) => mcp_tools,
-            Err(_) => return None,
+            Err(_) => return TaskRunOutput::default(),
         };
         connectors::with_app_enabled_state(
             connectors::accessible_connectors_from_mcp_tools(&mcp_tools),
@@ -4967,6 +4968,7 @@ pub(crate) async fn run_turn(
     // many turns, from the perspective of the user, it is a single turn.
     let turn_diff_tracker = Arc::new(tokio::sync::Mutex::new(TurnDiffTracker::new()));
     let mut server_model_warning_emitted_for_turn = false;
+    let mut abort_reason = None;
 
     // `ModelClientSession` is turn-scoped and caches WebSocket + sticky routing state, so we reuse
     // one instance across retries within this turn.
@@ -5044,11 +5046,9 @@ pub(crate) async fn run_turn(
                     cancellation_token.cancel();
                     sess.finish_turn_without_completion_event(turn_context.as_ref())
                         .await;
-                    sess.emit_turn_aborted_without_rollout_flush(
-                        &turn_context,
-                        TurnAbortReason::Interrupted,
-                    )
-                    .await;
+                    // Defer TurnAborted emission until run_turn unwinds so the caller can
+                    // flush the rollout marker without blocking the in-flight tool loop.
+                    abort_reason = Some(TurnAbortReason::Interrupted);
                     break;
                 }
                 let total_usage_tokens = sess.get_total_token_usage().await;
@@ -5077,7 +5077,7 @@ pub(crate) async fn run_turn(
                     .await
                     .is_err()
                     {
-                        return None;
+                        return TaskRunOutput::default();
                     }
                     continue;
                 }
@@ -5140,7 +5140,7 @@ pub(crate) async fn run_turn(
                             }),
                         )
                         .await;
-                        return None;
+                        return TaskRunOutput::default();
                     }
                     break;
                 }
@@ -5176,7 +5176,10 @@ pub(crate) async fn run_turn(
         }
     }
 
-    last_agent_message
+    TaskRunOutput {
+        last_agent_message,
+        abort_reason,
+    }
 }
 
 async fn run_pre_sampling_compact(
@@ -9241,10 +9244,10 @@ mod tests {
             _ctx: Arc<TurnContext>,
             _input: Vec<UserInput>,
             cancellation_token: CancellationToken,
-        ) -> Option<String> {
+        ) -> TaskRunOutput {
             if self.listen_to_cancellation_token {
                 cancellation_token.cancelled().await;
-                return None;
+                return TaskRunOutput::default();
             }
             loop {
                 sleep(Duration::from_secs(60)).await;

--- a/codex-rs/core/src/codex_delegate.rs
+++ b/codex-rs/core/src/codex_delegate.rs
@@ -430,6 +430,7 @@ where
         _ = cancel_token.cancelled() => {
             let empty = RequestUserInputResponse {
                 answers: HashMap::new(),
+                interrupted: false,
             };
             parent_session
                 .notify_user_input_response(sub_id, empty.clone())
@@ -438,6 +439,7 @@ where
         }
         response = fut => response.unwrap_or_else(|| RequestUserInputResponse {
             answers: HashMap::new(),
+            interrupted: false,
         }),
     }
 }

--- a/codex-rs/core/src/mcp/skill_dependencies.rs
+++ b/codex-rs/core/src/mcp/skill_dependencies.rs
@@ -104,12 +104,14 @@ async fn should_install_mcp_dependencies(
         _ = cancellation_token.cancelled() => {
             let empty = RequestUserInputResponse {
                 answers: HashMap::new(),
+                interrupted: false,
             };
             sess.notify_user_input_response(sub_id, empty.clone()).await;
             empty
         }
         response = response_fut => response.unwrap_or_else(|| RequestUserInputResponse {
             answers: HashMap::new(),
+            interrupted: false,
         }),
     };
 

--- a/codex-rs/core/src/skills/env_var_dependencies.rs
+++ b/codex-rs/core/src/skills/env_var_dependencies.rs
@@ -133,6 +133,7 @@ pub(crate) async fn request_skill_dependencies(
         .await
         .unwrap_or_else(|| RequestUserInputResponse {
             answers: HashMap::new(),
+            interrupted: false,
         });
 
     if response.answers.is_empty() {

--- a/codex-rs/core/src/state/turn.rs
+++ b/codex-rs/core/src/state/turn.rs
@@ -73,7 +73,6 @@ pub(crate) struct TurnState {
     pending_user_input: HashMap<String, oneshot::Sender<RequestUserInputResponse>>,
     pending_dynamic_tools: HashMap<String, oneshot::Sender<DynamicToolResponse>>,
     pending_input: Vec<ResponseInputItem>,
-    request_user_input_interrupted: bool,
 }
 
 impl TurnState {
@@ -97,7 +96,6 @@ impl TurnState {
         self.pending_user_input.clear();
         self.pending_dynamic_tools.clear();
         self.pending_input.clear();
-        self.request_user_input_interrupted = false;
     }
 
     pub(crate) fn insert_pending_user_input(
@@ -146,14 +144,6 @@ impl TurnState {
 
     pub(crate) fn has_pending_input(&self) -> bool {
         !self.pending_input.is_empty()
-    }
-
-    pub(crate) fn mark_request_user_input_interrupted(&mut self) {
-        self.request_user_input_interrupted = true;
-    }
-
-    pub(crate) fn take_request_user_input_interrupted(&mut self) -> bool {
-        std::mem::take(&mut self.request_user_input_interrupted)
     }
 }
 

--- a/codex-rs/core/src/state/turn.rs
+++ b/codex-rs/core/src/state/turn.rs
@@ -73,6 +73,7 @@ pub(crate) struct TurnState {
     pending_user_input: HashMap<String, oneshot::Sender<RequestUserInputResponse>>,
     pending_dynamic_tools: HashMap<String, oneshot::Sender<DynamicToolResponse>>,
     pending_input: Vec<ResponseInputItem>,
+    request_user_input_interrupted: bool,
 }
 
 impl TurnState {
@@ -96,6 +97,7 @@ impl TurnState {
         self.pending_user_input.clear();
         self.pending_dynamic_tools.clear();
         self.pending_input.clear();
+        self.request_user_input_interrupted = false;
     }
 
     pub(crate) fn insert_pending_user_input(
@@ -144,6 +146,14 @@ impl TurnState {
 
     pub(crate) fn has_pending_input(&self) -> bool {
         !self.pending_input.is_empty()
+    }
+
+    pub(crate) fn mark_request_user_input_interrupted(&mut self) {
+        self.request_user_input_interrupted = true;
+    }
+
+    pub(crate) fn take_request_user_input_interrupted(&mut self) -> bool {
+        std::mem::take(&mut self.request_user_input_interrupted)
     }
 }
 

--- a/codex-rs/core/src/state/turn.rs
+++ b/codex-rs/core/src/state/turn.rs
@@ -56,8 +56,11 @@ impl ActiveTurn {
         self.tasks.insert(sub_id, task);
     }
 
-    pub(crate) fn remove_task(&mut self, sub_id: &str) -> bool {
-        self.tasks.swap_remove(sub_id);
+    pub(crate) fn remove_task(&mut self, sub_id: &str) -> Option<RunningTask> {
+        self.tasks.swap_remove(sub_id)
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
         self.tasks.is_empty()
     }
 

--- a/codex-rs/core/src/stream_events_utils.rs
+++ b/codex-rs/core/src/stream_events_utils.rs
@@ -14,6 +14,7 @@ use crate::function_tool::FunctionCallError;
 use crate::memories::citations::get_thread_id_from_citations;
 use crate::parse_turn_item;
 use crate::state_db;
+use crate::tools::context::ToolDispatchOutput;
 use crate::tools::parallel::ToolCallRuntime;
 use crate::tools::router::ToolRouter;
 use codex_protocol::models::FunctionCallOutputBody;
@@ -106,7 +107,7 @@ async fn record_stage1_output_usage_for_completed_item(
 /// queuing any tool execution futures. This records items immediately so
 /// history and rollout stay in sync even if the turn is later cancelled.
 pub(crate) type InFlightFuture<'f> =
-    Pin<Box<dyn Future<Output = Result<ResponseInputItem>> + Send + 'f>>;
+    Pin<Box<dyn Future<Output = Result<ToolDispatchOutput>> + Send + 'f>>;
 
 #[derive(Default)]
 pub(crate) struct OutputItemResult {

--- a/codex-rs/core/src/tasks/compact.rs
+++ b/codex-rs/core/src/tasks/compact.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use super::SessionTask;
 use super::SessionTaskContext;
+use super::TaskRunOutput;
 use crate::codex::TurnContext;
 use crate::state::TaskKind;
 use async_trait::async_trait;
@@ -23,7 +24,7 @@ impl SessionTask for CompactTask {
         ctx: Arc<TurnContext>,
         input: Vec<UserInput>,
         _cancellation_token: CancellationToken,
-    ) -> Option<String> {
+    ) -> TaskRunOutput {
         let session = session.clone_session();
         let _ = if crate::compact::should_use_remote_compact_task(&ctx.provider) {
             let _ = session.services.otel_manager.counter(
@@ -39,7 +40,11 @@ impl SessionTask for CompactTask {
                 &[("type", "local")],
             );
             crate::compact::run_compact_task(session.clone(), ctx, input).await
+        }
+
+        TaskRunOutput::default()
         };
-        None
+
+        TaskRunOutput::default()
     }
 }

--- a/codex-rs/core/src/tasks/compact.rs
+++ b/codex-rs/core/src/tasks/compact.rs
@@ -40,9 +40,6 @@ impl SessionTask for CompactTask {
                 &[("type", "local")],
             );
             crate::compact::run_compact_task(session.clone(), ctx, input).await
-        }
-
-        TaskRunOutput::default()
         };
 
         TaskRunOutput::default()

--- a/codex-rs/core/src/tasks/ghost_snapshot.rs
+++ b/codex-rs/core/src/tasks/ghost_snapshot.rs
@@ -4,6 +4,7 @@ use crate::protocol::WarningEvent;
 use crate::state::TaskKind;
 use crate::tasks::SessionTask;
 use crate::tasks::SessionTaskContext;
+use crate::tasks::TaskRunOutput;
 use async_trait::async_trait;
 use codex_git::CreateGhostCommitOptions;
 use codex_git::GhostSnapshotReport;
@@ -38,7 +39,7 @@ impl SessionTask for GhostSnapshotTask {
         ctx: Arc<TurnContext>,
         _input: Vec<UserInput>,
         cancellation_token: CancellationToken,
-    ) -> Option<String> {
+    ) -> TaskRunOutput {
         tokio::task::spawn(async move {
             let token = self.token;
             let warnings_enabled = !ctx.ghost_snapshot.disable_warnings;
@@ -152,7 +153,7 @@ impl SessionTask for GhostSnapshotTask {
                 Err(err) => warn!("failed to mark ghost snapshot ready: {err}"),
             }
         });
-        None
+        TaskRunOutput::default()
     }
 }
 

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -144,7 +144,6 @@ impl Session {
             tokio::spawn(
                 async move {
                     let ctx_for_finish = Arc::clone(&ctx);
-                    let model_slug = ctx_for_finish.model_info.slug.clone();
                     let TaskRunOutput {
                         last_agent_message,
                         abort_reason,
@@ -158,9 +157,6 @@ impl Session {
                         .await;
                     let sess = session_ctx.clone_session();
                     sess.flush_rollout().await;
-                    // Update previous model before TurnComplete is emitted so
-                    // immediately following turns observe the correct switch state.
-                    sess.set_previous_model(Some(model_slug)).await;
                     if let Some(reason) = abort_reason {
                         ctx_for_finish
                             .turn_metadata_state

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -162,6 +162,9 @@ impl Session {
                     // immediately following turns observe the correct switch state.
                     sess.set_previous_model(Some(model_slug)).await;
                     if let Some(reason) = abort_reason {
+                        ctx_for_finish
+                            .turn_metadata_state
+                            .cancel_git_enrichment_task();
                         // Emit TurnAborted from the spawn site so the rollout flush above
                         // makes the interrupt marker durable before clients observe the event.
                         sess.emit_turn_aborted(ctx_for_finish.as_ref(), reason)

--- a/codex-rs/core/src/tasks/regular.rs
+++ b/codex-rs/core/src/tasks/regular.rs
@@ -16,6 +16,7 @@ use tracing::trace_span;
 
 use super::SessionTask;
 use super::SessionTaskContext;
+use super::TaskRunOutput;
 
 pub(crate) struct RegularTask {
     prewarmed_session: Mutex<Option<ModelClientSession>>,
@@ -73,7 +74,7 @@ impl SessionTask for RegularTask {
         ctx: Arc<TurnContext>,
         input: Vec<UserInput>,
         cancellation_token: CancellationToken,
-    ) -> Option<String> {
+    ) -> TaskRunOutput {
         let sess = session.clone_session();
         let run_turn_span = trace_span!("run_turn");
         sess.set_server_reasoning_included(false).await;

--- a/codex-rs/core/src/tasks/review.rs
+++ b/codex-rs/core/src/tasks/review.rs
@@ -27,6 +27,7 @@ use codex_protocol::user_input::UserInput;
 
 use super::SessionTask;
 use super::SessionTaskContext;
+use super::TaskRunOutput;
 
 #[derive(Clone, Copy)]
 pub(crate) struct ReviewTask;
@@ -49,7 +50,7 @@ impl SessionTask for ReviewTask {
         ctx: Arc<TurnContext>,
         input: Vec<UserInput>,
         cancellation_token: CancellationToken,
-    ) -> Option<String> {
+    ) -> TaskRunOutput {
         let _ = session
             .session
             .services
@@ -71,7 +72,7 @@ impl SessionTask for ReviewTask {
         if !cancellation_token.is_cancelled() {
             exit_review_mode(session.clone_session(), output.clone(), ctx.clone()).await;
         }
-        None
+        TaskRunOutput::default()
     }
 
     async fn abort(&self, session: Arc<SessionTaskContext>, ctx: Arc<TurnContext>) {

--- a/codex-rs/core/src/tasks/undo.rs
+++ b/codex-rs/core/src/tasks/undo.rs
@@ -7,6 +7,7 @@ use crate::protocol::UndoStartedEvent;
 use crate::state::TaskKind;
 use crate::tasks::SessionTask;
 use crate::tasks::SessionTaskContext;
+use crate::tasks::TaskRunOutput;
 use async_trait::async_trait;
 use codex_git::RestoreGhostCommitOptions;
 use codex_git::restore_ghost_commit_with_options;
@@ -37,7 +38,7 @@ impl SessionTask for UndoTask {
         ctx: Arc<TurnContext>,
         _input: Vec<UserInput>,
         cancellation_token: CancellationToken,
-    ) -> Option<String> {
+    ) -> TaskRunOutput {
         let _ = session
             .session
             .services
@@ -61,7 +62,7 @@ impl SessionTask for UndoTask {
                 }),
             )
             .await;
-            return None;
+            return TaskRunOutput::default();
         }
 
         let history = sess.clone_history().await;
@@ -86,7 +87,7 @@ impl SessionTask for UndoTask {
             completed.message = Some("No ghost snapshot available to undo.".to_string());
             sess.send_event(ctx.as_ref(), EventMsg::UndoCompleted(completed))
                 .await;
-            return None;
+            return TaskRunOutput::default();
         };
 
         let commit_id = ghost_commit.id().to_string();
@@ -122,6 +123,6 @@ impl SessionTask for UndoTask {
 
         sess.send_event(ctx.as_ref(), EventMsg::UndoCompleted(completed))
             .await;
-        None
+        TaskRunOutput::default()
     }
 }

--- a/codex-rs/core/src/tasks/user_shell.rs
+++ b/codex-rs/core/src/tasks/user_shell.rs
@@ -33,6 +33,7 @@ use crate::user_shell_command::user_shell_command_record_item;
 
 use super::SessionTask;
 use super::SessionTaskContext;
+use super::TaskRunOutput;
 use crate::codex::Session;
 use codex_protocol::models::ResponseInputItem;
 use codex_protocol::models::ResponseItem;
@@ -72,7 +73,7 @@ impl SessionTask for UserShellCommandTask {
         turn_context: Arc<TurnContext>,
         _input: Vec<UserInput>,
         cancellation_token: CancellationToken,
-    ) -> Option<String> {
+    ) -> TaskRunOutput {
         execute_user_shell_command(
             session.clone_session(),
             turn_context,
@@ -81,7 +82,7 @@ impl SessionTask for UserShellCommandTask {
             UserShellCommandMode::StandaloneTurn,
         )
         .await;
-        None
+        TaskRunOutput::default()
     }
 }
 

--- a/codex-rs/core/src/tools/context.rs
+++ b/codex-rs/core/src/tools/context.rs
@@ -74,6 +74,12 @@ pub enum ToolOutput {
     },
 }
 
+#[derive(Clone, Debug)]
+pub struct ToolDispatchOutput {
+    pub response_input: ResponseInputItem,
+    pub interrupt_turn: bool,
+}
+
 impl ToolOutput {
     pub fn log_preview(&self) -> String {
         match self {

--- a/codex-rs/core/src/tools/context.rs
+++ b/codex-rs/core/src/tools/context.rs
@@ -69,6 +69,13 @@ pub enum ToolOutput {
         body: FunctionCallOutputBody,
         success: Option<bool>,
     },
+    FunctionWithControl {
+        // Canonical output body for function-style tools plus internal control
+        // metadata consumed by core dispatch (not exposed on the wire).
+        body: FunctionCallOutputBody,
+        success: Option<bool>,
+        interrupt_turn: bool,
+    },
     Mcp {
         result: Result<CallToolResult, String>,
     },
@@ -83,7 +90,7 @@ pub struct ToolDispatchOutput {
 impl ToolOutput {
     pub fn log_preview(&self) -> String {
         match self {
-            ToolOutput::Function { body, .. } => {
+            ToolOutput::Function { body, .. } | ToolOutput::FunctionWithControl { body, .. } => {
                 telemetry_preview(&body.to_text().unwrap_or_default())
             }
             ToolOutput::Mcp { result } => format!("{result:?}"),
@@ -92,14 +99,23 @@ impl ToolOutput {
 
     pub fn success_for_logging(&self) -> bool {
         match self {
-            ToolOutput::Function { success, .. } => success.unwrap_or(true),
+            ToolOutput::Function { success, .. }
+            | ToolOutput::FunctionWithControl { success, .. } => success.unwrap_or(true),
             ToolOutput::Mcp { result } => result.is_ok(),
+        }
+    }
+
+    pub fn interrupt_turn_hint(&self) -> bool {
+        match self {
+            ToolOutput::FunctionWithControl { interrupt_turn, .. } => *interrupt_turn,
+            ToolOutput::Function { .. } | ToolOutput::Mcp { .. } => false,
         }
     }
 
     pub fn into_response(self, call_id: &str, payload: &ToolPayload) -> ResponseInputItem {
         match self {
-            ToolOutput::Function { body, success } => {
+            ToolOutput::Function { body, success }
+            | ToolOutput::FunctionWithControl { body, success, .. } => {
                 // `custom_tool_call` is the Responses API item type for freeform
                 // tools (`ToolSpec::Freeform`, e.g. freeform `apply_patch` or
                 // `js_repl`).
@@ -210,6 +226,30 @@ mod tests {
                 assert_eq!(call_id, "fn-1");
                 assert_eq!(output.text_content(), Some("ok"));
                 assert!(output.content_items().is_none());
+                assert_eq!(output.success, Some(true));
+            }
+            other => panic!("expected FunctionCallOutput, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn function_with_control_interrupt_hint_is_internal_only() {
+        let payload = ToolPayload::Function {
+            arguments: "{}".to_string(),
+        };
+        let output = ToolOutput::FunctionWithControl {
+            body: FunctionCallOutputBody::Text("ok".to_string()),
+            success: Some(true),
+            interrupt_turn: true,
+        };
+
+        assert!(output.interrupt_turn_hint());
+
+        let response = output.into_response("fn-ctrl", &payload);
+        match response {
+            ResponseInputItem::FunctionCallOutput { call_id, output } => {
+                assert_eq!(call_id, "fn-ctrl");
+                assert_eq!(output.text_content(), Some("ok"));
                 assert_eq!(output.success, Some(true));
             }
             other => panic!("expected FunctionCallOutput, got {other:?}"),

--- a/codex-rs/core/src/tools/handlers/js_repl.rs
+++ b/codex-rs/core/src/tools/handlers/js_repl.rs
@@ -155,6 +155,7 @@ impl ToolHandler for JsReplHandler {
         };
 
         let content = result.output;
+        let interrupt_turn = result.interrupt_turn;
         let mut items = Vec::with_capacity(result.content_items.len() + 1);
         if !content.is_empty() {
             items.push(FunctionCallOutputContentItem::InputText {
@@ -173,14 +174,24 @@ impl ToolHandler for JsReplHandler {
         )
         .await;
 
-        Ok(ToolOutput::Function {
-            body: if items.is_empty() {
-                FunctionCallOutputBody::Text(content)
-            } else {
-                FunctionCallOutputBody::ContentItems(items)
-            },
-            success: Some(true),
-        })
+        let body = if items.is_empty() {
+            FunctionCallOutputBody::Text(content)
+        } else {
+            FunctionCallOutputBody::ContentItems(items)
+        };
+
+        if interrupt_turn {
+            Ok(ToolOutput::FunctionWithControl {
+                body,
+                success: Some(true),
+                interrupt_turn: true,
+            })
+        } else {
+            Ok(ToolOutput::Function {
+                body,
+                success: Some(true),
+            })
+        }
     }
 }
 

--- a/codex-rs/core/src/tools/handlers/request_user_input.rs
+++ b/codex-rs/core/src/tools/handlers/request_user_input.rs
@@ -186,7 +186,9 @@ mod tests {
 
     #[test]
     fn interrupted_response_interrupts_turn() {
-        let handler = RequestUserInputHandler;
+        let handler = RequestUserInputHandler {
+            default_mode_request_user_input: false,
+        };
         let output = ToolOutput::Function {
             body: FunctionCallOutputBody::Text(r#"{"answers":{},"interrupted":true}"#.to_string()),
             success: Some(true),
@@ -197,7 +199,9 @@ mod tests {
 
     #[test]
     fn non_interrupted_response_does_not_interrupt_turn() {
-        let handler = RequestUserInputHandler;
+        let handler = RequestUserInputHandler {
+            default_mode_request_user_input: false,
+        };
         let output = ToolOutput::Function {
             body: FunctionCallOutputBody::Text(r#"{"answers":{}}"#.to_string()),
             success: Some(true),

--- a/codex-rs/core/src/tools/js_repl/mod.rs
+++ b/codex-rs/core/src/tools/js_repl/mod.rs
@@ -105,6 +105,7 @@ pub struct JsReplArgs {
 pub struct JsExecResult {
     pub output: String,
     pub content_items: Vec<FunctionCallOutputContentItem>,
+    pub interrupt_turn: bool,
 }
 
 struct KernelState {
@@ -127,6 +128,7 @@ struct ExecContext {
 struct ExecToolCalls {
     in_flight: usize,
     content_items: Vec<FunctionCallOutputContentItem>,
+    interrupted: bool,
     notify: Arc<Notify>,
     cancel: CancellationToken,
 }
@@ -409,6 +411,24 @@ impl JsReplManager {
         if let Some(notify) = notify {
             notify.notify_waiters();
         }
+    }
+
+    async fn mark_exec_tool_call_interrupted(
+        exec_tool_calls: &Arc<Mutex<HashMap<String, ExecToolCalls>>>,
+        exec_id: &str,
+    ) {
+        let mut calls = exec_tool_calls.lock().await;
+        if let Some(state) = calls.get_mut(exec_id) {
+            state.interrupted = true;
+        }
+    }
+
+    async fn exec_tool_calls_interrupted(
+        exec_tool_calls: &Arc<Mutex<HashMap<String, ExecToolCalls>>>,
+        exec_id: &str,
+    ) -> bool {
+        let calls = exec_tool_calls.lock().await;
+        calls.get(exec_id).is_some_and(|state| state.interrupted)
     }
 
     async fn wait_for_exec_tool_calls_map(
@@ -794,11 +814,15 @@ impl JsReplManager {
         };
 
         match response {
-            ExecResultMessage::Ok { content_items } => {
+            ExecResultMessage::Ok {
+                content_items,
+                interrupt_turn,
+            } => {
                 let (output, content_items) = split_exec_result_content_items(content_items);
                 Ok(JsExecResult {
                     output,
                     content_items,
+                    interrupt_turn,
                 })
             }
             ExecResultMessage::Err { message } => Err(FunctionCallError::RespondToModel(message)),
@@ -1111,6 +1135,8 @@ impl JsReplManager {
                             .map(|state| state.content_items.clone())
                             .unwrap_or_default()
                     };
+                    let interrupt_turn =
+                        JsReplManager::exec_tool_calls_interrupted(&exec_tool_calls, &id).await;
                     let mut pending = pending_execs.lock().await;
                     if let Some(tx) = pending.remove(&id) {
                         let payload = if ok {
@@ -1119,6 +1145,7 @@ impl JsReplManager {
                                     output,
                                     content_items,
                                 ),
+                                interrupt_turn,
                             }
                         } else {
                             ExecResultMessage::Err {
@@ -1142,6 +1169,7 @@ impl JsReplManager {
                             ok: false,
                             response: None,
                             error: Some("js_repl exec context not found".to_string()),
+                            interrupt_turn: false,
                         });
                         if let Err(err) = JsReplManager::write_message(&stdin, &payload).await {
                             let snapshot =
@@ -1175,6 +1203,7 @@ impl JsReplManager {
                                         ok: false,
                                         response: None,
                                         error: Some("js_repl execution reset".to_string()),
+                                        interrupt_turn: false,
                                     },
                                     result = JsReplManager::run_tool_request(
                                         ctx,
@@ -1188,8 +1217,16 @@ impl JsReplManager {
                                 ok: false,
                                 response: None,
                                 error: Some("js_repl exec context not found".to_string()),
+                                interrupt_turn: false,
                             },
                         };
+                        if result.interrupt_turn {
+                            JsReplManager::mark_exec_tool_call_interrupted(
+                                &exec_tool_calls_for_task,
+                                &exec_id,
+                            )
+                            .await;
+                        }
                         JsReplManager::finish_exec_tool_call(&exec_tool_calls_for_task, &exec_id)
                             .await;
                         let payload = HostToKernel::RunToolResult(result);
@@ -1288,6 +1325,7 @@ impl JsReplManager {
                 ok: false,
                 response: None,
                 error: Some(error),
+                interrupt_turn: false,
             };
         }
 
@@ -1369,25 +1407,7 @@ impl JsReplManager {
                             ok: true,
                             response: Some(value),
                             error: None,
-=======
-            Ok(output) => {
-                if let ResponseInputItem::FunctionCallOutput { output, .. } = &output.response_input
-                    && let Some(items) = output.content_items()
-                {
-                    let mut has_image = false;
-                    let mut content = Vec::with_capacity(items.len());
-                    for item in items {
-                        match item {
-                            FunctionCallOutputContentItem::InputText { text } => {
-                                content.push(ContentItem::InputText { text: text.clone() });
-                            }
-                            FunctionCallOutputContentItem::InputImage { image_url } => {
-                                has_image = true;
-                                content.push(ContentItem::InputImage {
-                                    image_url: image_url.clone(),
-                                });
-                            }
->>>>>>> 2fbcb2ec4 (core: generalize interrupted tool-result handling)
+                            interrupt_turn: output.interrupt_turn,
                         }
                     }
                     Err(err) => {
@@ -1399,6 +1419,7 @@ impl JsReplManager {
                             ok: false,
                             response: None,
                             error: Some(error),
+                            interrupt_turn: false,
                         }
                     }
                 }
@@ -1412,6 +1433,7 @@ impl JsReplManager {
                     ok: false,
                     response: None,
                     error: Some(error),
+                    interrupt_turn: false,
                 }
             }
         }
@@ -1546,12 +1568,15 @@ struct RunToolResult {
     response: Option<JsonValue>,
     #[serde(default)]
     error: Option<String>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    interrupt_turn: bool,
 }
 
 #[derive(Debug)]
 enum ExecResultMessage {
     Ok {
         content_items: Vec<FunctionCallOutputContentItem>,
+        interrupt_turn: bool,
     },
     Err {
         message: String,

--- a/codex-rs/core/src/tools/js_repl/mod.rs
+++ b/codex-rs/core/src/tools/js_repl/mod.rs
@@ -1350,8 +1350,8 @@ impl JsReplManager {
             )
             .await
         {
-            Ok(response) => {
-                if let Some(items) = response_content_items(&response) {
+            Ok(output) => {
+                if let Some(items) = response_content_items(&output.response_input) {
                     Self::record_exec_tool_call_content_items(
                         &exec_tool_calls,
                         &req.exec_id,
@@ -1360,8 +1360,8 @@ impl JsReplManager {
                     .await;
                 }
 
-                let summary = Self::summarize_tool_call_response(&response);
-                match serde_json::to_value(response) {
+                let summary = Self::summarize_tool_call_response(&output.response_input);
+                match serde_json::to_value(output.response_input) {
                     Ok(value) => {
                         Self::log_tool_call_response(&req, true, &summary, Some(&value), None);
                         RunToolResult {
@@ -1369,6 +1369,25 @@ impl JsReplManager {
                             ok: true,
                             response: Some(value),
                             error: None,
+=======
+            Ok(output) => {
+                if let ResponseInputItem::FunctionCallOutput { output, .. } = &output.response_input
+                    && let Some(items) = output.content_items()
+                {
+                    let mut has_image = false;
+                    let mut content = Vec::with_capacity(items.len());
+                    for item in items {
+                        match item {
+                            FunctionCallOutputContentItem::InputText { text } => {
+                                content.push(ContentItem::InputText { text: text.clone() });
+                            }
+                            FunctionCallOutputContentItem::InputImage { image_url } => {
+                                has_image = true;
+                                content.push(ContentItem::InputImage {
+                                    image_url: image_url.clone(),
+                                });
+                            }
+>>>>>>> 2fbcb2ec4 (core: generalize interrupted tool-result handling)
                         }
                     }
                     Err(err) => {

--- a/codex-rs/core/src/tools/parallel.rs
+++ b/codex-rs/core/src/tools/parallel.rs
@@ -14,6 +14,7 @@ use crate::codex::TurnContext;
 use crate::error::CodexErr;
 use crate::function_tool::FunctionCallError;
 use crate::tools::context::SharedTurnDiffTracker;
+use crate::tools::context::ToolDispatchOutput;
 use crate::tools::context::ToolPayload;
 use crate::tools::router::ToolCall;
 use crate::tools::router::ToolRouter;
@@ -51,7 +52,7 @@ impl ToolCallRuntime {
         self,
         call: ToolCall,
         cancellation_token: CancellationToken,
-    ) -> impl std::future::Future<Output = Result<ResponseInputItem, CodexErr>> {
+    ) -> impl std::future::Future<Output = Result<ToolDispatchOutput, CodexErr>> {
         let supports_parallel = self.router.tool_supports_parallel(&call.tool_name);
 
         let router = Arc::clone(&self.router);
@@ -69,7 +70,7 @@ impl ToolCallRuntime {
             aborted = false,
         );
 
-        let handle: AbortOnDropHandle<Result<ResponseInputItem, FunctionCallError>> =
+        let handle: AbortOnDropHandle<Result<ToolDispatchOutput, FunctionCallError>> =
             AbortOnDropHandle::new(tokio::spawn(async move {
                 tokio::select! {
                     _ = cancellation_token.cancelled() => {
@@ -113,8 +114,8 @@ impl ToolCallRuntime {
 }
 
 impl ToolCallRuntime {
-    fn aborted_response(call: &ToolCall, secs: f32) -> ResponseInputItem {
-        match &call.payload {
+    fn aborted_response(call: &ToolCall, secs: f32) -> ToolDispatchOutput {
+        let response_input = match &call.payload {
             ToolPayload::Custom { .. } => ResponseInputItem::CustomToolCallOutput {
                 call_id: call.call_id.clone(),
                 output: FunctionCallOutputPayload {
@@ -133,6 +134,10 @@ impl ToolCallRuntime {
                     ..Default::default()
                 },
             },
+        };
+        ToolDispatchOutput {
+            response_input,
+            interrupt_turn: false,
         }
     }
 

--- a/codex-rs/core/src/tools/registry.rs
+++ b/codex-rs/core/src/tools/registry.rs
@@ -186,7 +186,8 @@ impl ToolRegistry {
                             Ok(output) => {
                                 let preview = output.log_preview();
                                 let success = output.success_for_logging();
-                                let interrupt_turn = handler.should_interrupt_turn(&output);
+                                let interrupt_turn = output.interrupt_turn_hint()
+                                    || handler.should_interrupt_turn(&output);
                                 let mut guard = output_cell.lock().await;
                                 *guard = Some((output, interrupt_turn));
                                 Ok((preview, success))

--- a/codex-rs/core/src/tools/router.rs
+++ b/codex-rs/core/src/tools/router.rs
@@ -5,6 +5,7 @@ use crate::function_tool::FunctionCallError;
 use crate::mcp_connection_manager::ToolInfo;
 use crate::sandboxing::SandboxPermissions;
 use crate::tools::context::SharedTurnDiffTracker;
+use crate::tools::context::ToolDispatchOutput;
 use crate::tools::context::ToolInvocation;
 use crate::tools::context::ToolPayload;
 use crate::tools::registry::ConfiguredToolSpec;
@@ -144,7 +145,7 @@ impl ToolRouter {
         tracker: SharedTurnDiffTracker,
         call: ToolCall,
         source: ToolCallSource,
-    ) -> Result<ResponseInputItem, FunctionCallError> {
+    ) -> Result<ToolDispatchOutput, FunctionCallError> {
         let ToolCall {
             tool_name,
             call_id,
@@ -161,7 +162,7 @@ impl ToolRouter {
                 "direct tool calls are disabled; use js_repl and codex.tool(...) instead"
                     .to_string(),
             );
-            return Ok(Self::failure_response(
+            return Ok(Self::failure_output(
                 failure_call_id,
                 payload_outputs_custom,
                 err,
@@ -180,7 +181,7 @@ impl ToolRouter {
         match self.registry.dispatch(invocation).await {
             Ok(response) => Ok(response),
             Err(FunctionCallError::Fatal(message)) => Err(FunctionCallError::Fatal(message)),
-            Err(err) => Ok(Self::failure_response(
+            Err(err) => Ok(Self::failure_output(
                 failure_call_id,
                 payload_outputs_custom,
                 err,
@@ -188,13 +189,13 @@ impl ToolRouter {
         }
     }
 
-    fn failure_response(
+    fn failure_output(
         call_id: String,
         payload_outputs_custom: bool,
         err: FunctionCallError,
-    ) -> ResponseInputItem {
+    ) -> ToolDispatchOutput {
         let message = err.to_string();
-        if payload_outputs_custom {
+        let response_input = if payload_outputs_custom {
             ResponseInputItem::CustomToolCallOutput {
                 call_id,
                 output: codex_protocol::models::FunctionCallOutputPayload {
@@ -210,6 +211,10 @@ impl ToolRouter {
                     success: Some(false),
                 },
             }
+        };
+        ToolDispatchOutput {
+            response_input,
+            interrupt_turn: false,
         }
     }
 }
@@ -265,7 +270,7 @@ mod tests {
             .dispatch_tool_call(session, turn, tracker, call, ToolCallSource::Direct)
             .await?;
 
-        match response {
+        match response.response_input {
             ResponseInputItem::FunctionCallOutput { output, .. } => {
                 let content = output.text_content().unwrap_or_default();
                 assert!(
@@ -318,7 +323,7 @@ mod tests {
             .dispatch_tool_call(session, turn, tracker, call, ToolCallSource::JsRepl)
             .await?;
 
-        match response {
+        match response.response_input {
             ResponseInputItem::FunctionCallOutput { output, .. } => {
                 let content = output.text_content().unwrap_or_default();
                 assert!(

--- a/codex-rs/core/tests/suite/request_user_input.rs
+++ b/codex-rs/core/tests/suite/request_user_input.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::unwrap_used)]
 
 use std::collections::HashMap;
+use std::time::Duration;
 
 use codex_core::features::Feature;
 use codex_protocol::config_types::CollaborationMode;
@@ -348,6 +349,107 @@ async fn request_user_input_interrupted_response_preserves_tool_output() -> anyh
             "interrupted": true
         })
     );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn request_user_input_interrupt_not_blocked_by_earlier_tool() -> anyhow::Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+
+    let builder = test_codex().with_model("test-gpt-5.1-codex");
+    let TestCodex {
+        codex,
+        cwd,
+        session_configured,
+        ..
+    } = builder
+        .with_config(|config| {
+            config.features.enable(Feature::CollaborationModes);
+        })
+        .build(&server)
+        .await?;
+
+    let call_id = "user-input-call-fast-interrupt";
+    let slow_tool_args = json!({
+        "sleep_after_ms": 2_000
+    })
+    .to_string();
+    let request_args = json!({
+        "questions": [{
+            "id": "confirm_path",
+            "header": "Confirm",
+            "question": "Proceed with the plan?",
+            "options": [{
+                "label": "Yes (Recommended)",
+                "description": "Continue the current plan."
+            }, {
+                "label": "No",
+                "description": "Stop and revisit the approach."
+            }]
+        }]
+    })
+    .to_string();
+
+    let first_response = sse(vec![
+        ev_response_created("resp-1"),
+        ev_function_call("slow-call-1", "test_sync_tool", &slow_tool_args),
+        ev_function_call(call_id, "request_user_input", &request_args),
+        ev_completed("resp-1"),
+    ]);
+    responses::mount_sse_once(&server, first_response).await;
+
+    let session_model = session_configured.model.clone();
+
+    codex
+        .submit(Op::UserTurn {
+            items: vec![UserInput::Text {
+                text: "please confirm".into(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+            cwd: cwd.path().to_path_buf(),
+            approval_policy: AskForApproval::Never,
+            sandbox_policy: SandboxPolicy::DangerFullAccess,
+            model: session_model,
+            effort: None,
+            summary: ReasoningSummary::Auto,
+            collaboration_mode: Some(CollaborationMode {
+                mode: ModeKind::Plan,
+                settings: Settings {
+                    model: session_configured.model.clone(),
+                    reasoning_effort: None,
+                    developer_instructions: None,
+                },
+            }),
+            personality: None,
+        })
+        .await?;
+
+    let request = wait_for_event_match(&codex, |event| match event {
+        EventMsg::RequestUserInput(request) => Some(request.clone()),
+        _ => None,
+    })
+    .await;
+    assert_eq!(request.call_id, call_id);
+
+    codex
+        .submit(Op::UserInputAnswer {
+            id: request.turn_id.clone(),
+            response: RequestUserInputResponse {
+                answers: HashMap::new(),
+                interrupted: true,
+            },
+        })
+        .await?;
+
+    tokio::time::timeout(Duration::from_millis(750), async {
+        wait_for_event(&codex, |event| matches!(event, EventMsg::TurnAborted(_))).await;
+    })
+    .await
+    .expect("interrupting request_user_input should abort promptly");
 
     Ok(())
 }

--- a/codex-rs/core/tests/suite/request_user_input.rs
+++ b/codex-rs/core/tests/suite/request_user_input.rs
@@ -19,6 +19,7 @@ use core_test_support::responses::ev_assistant_message;
 use core_test_support::responses::ev_completed;
 use core_test_support::responses::ev_function_call;
 use core_test_support::responses::ev_response_created;
+use core_test_support::responses::mount_sse_sequence;
 use core_test_support::responses::sse;
 use core_test_support::responses::start_mock_server;
 use core_test_support::skip_if_no_network;
@@ -166,7 +167,10 @@ async fn request_user_input_round_trip_for_mode(mode: ModeKind) -> anyhow::Resul
             answers: vec!["yes".to_string()],
         },
     );
-    let response = RequestUserInputResponse { answers };
+    let response = RequestUserInputResponse {
+        answers,
+        interrupted: false,
+    };
     codex
         .submit(Op::UserInputAnswer {
             id: request.turn_id.clone(),
@@ -185,6 +189,163 @@ async fn request_user_input_round_trip_for_mode(mode: ModeKind) -> anyhow::Resul
             "answers": {
                 "confirm_path": { "answers": ["yes"] }
             }
+        })
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn request_user_input_interrupted_response_preserves_tool_output() -> anyhow::Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+
+    let builder = test_codex();
+    let TestCodex {
+        codex,
+        cwd,
+        session_configured,
+        ..
+    } = builder
+        .with_config(|config| {
+            config.features.enable(Feature::CollaborationModes);
+        })
+        .build(&server)
+        .await?;
+
+    let call_id = "user-input-call-interrupt";
+    let request_args = json!({
+        "questions": [{
+            "id": "confirm_path",
+            "header": "Confirm",
+            "question": "Proceed with the plan?",
+            "options": [{
+                "label": "Yes (Recommended)",
+                "description": "Continue the current plan."
+            }, {
+                "label": "No",
+                "description": "Stop and revisit the approach."
+            }]
+        }]
+    })
+    .to_string();
+
+    let first_response = sse(vec![
+        ev_response_created("resp-1"),
+        ev_function_call(call_id, "request_user_input", &request_args),
+        ev_completed("resp-1"),
+    ]);
+    let follow_up_response = sse(vec![
+        ev_assistant_message("msg-1", "next turn"),
+        ev_completed("resp-2"),
+    ]);
+    let response_mock = mount_sse_sequence(&server, vec![first_response, follow_up_response]).await;
+
+    let session_model = session_configured.model.clone();
+
+    codex
+        .submit(Op::UserTurn {
+            items: vec![UserInput::Text {
+                text: "please confirm".into(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+            cwd: cwd.path().to_path_buf(),
+            approval_policy: AskForApproval::Never,
+            sandbox_policy: SandboxPolicy::DangerFullAccess,
+            model: session_model.clone(),
+            effort: None,
+            summary: ReasoningSummary::Auto,
+            collaboration_mode: Some(CollaborationMode {
+                mode: ModeKind::Plan,
+                settings: Settings {
+                    model: session_configured.model.clone(),
+                    reasoning_effort: None,
+                    developer_instructions: None,
+                },
+            }),
+            personality: None,
+        })
+        .await?;
+
+    let request = wait_for_event_match(&codex, |event| match event {
+        EventMsg::RequestUserInput(request) => Some(request.clone()),
+        _ => None,
+    })
+    .await;
+    assert_eq!(request.call_id, call_id);
+
+    let mut answers = HashMap::new();
+    answers.insert(
+        "confirm_path".to_string(),
+        RequestUserInputAnswer {
+            answers: vec!["yes".to_string()],
+        },
+    );
+    codex
+        .submit(Op::UserInputAnswer {
+            id: request.turn_id.clone(),
+            response: RequestUserInputResponse {
+                answers,
+                interrupted: true,
+            },
+        })
+        .await?;
+
+    let terminal_event = wait_for_event_match(&codex, |event| match event {
+        EventMsg::TurnAborted(_) => Some("aborted"),
+        EventMsg::TurnComplete(_) => Some("complete"),
+        _ => None,
+    })
+    .await;
+    assert_eq!(terminal_event, "aborted", "expected interrupted turn");
+
+    codex
+        .submit(Op::UserTurn {
+            items: vec![UserInput::Text {
+                text: "follow up".into(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+            cwd: cwd.path().to_path_buf(),
+            approval_policy: AskForApproval::Never,
+            sandbox_policy: SandboxPolicy::DangerFullAccess,
+            model: session_model,
+            effort: None,
+            summary: ReasoningSummary::Auto,
+            collaboration_mode: Some(CollaborationMode {
+                mode: ModeKind::Plan,
+                settings: Settings {
+                    model: session_configured.model.clone(),
+                    reasoning_effort: None,
+                    developer_instructions: None,
+                },
+            }),
+            personality: None,
+        })
+        .await?;
+
+    wait_for_event(&codex, |event| matches!(event, EventMsg::TurnComplete(_))).await;
+
+    let requests = response_mock.requests();
+    let request_with_output = requests
+        .iter()
+        .find(|req| req.function_call_output_text(call_id).is_some())
+        .expect("expected request_user_input function_call_output in later request");
+    let output_text = call_output(request_with_output, call_id);
+    assert!(
+        !output_text.contains("aborted by user"),
+        "request_user_input output should not be replaced by synthetic abort text"
+    );
+    let output_json: Value = serde_json::from_str(&output_text)?;
+    assert_eq!(
+        output_json,
+        json!({
+            "answers": {
+                "confirm_path": { "answers": ["yes"] }
+            },
+            "interrupted": true
         })
     );
 

--- a/codex-rs/core/tests/suite/request_user_input.rs
+++ b/codex-rs/core/tests/suite/request_user_input.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use codex_core::features::Feature;
 use codex_protocol::config_types::CollaborationMode;
 use codex_protocol::config_types::ModeKind;
+use codex_protocol::config_types::ReasoningSummary;
 use codex_protocol::config_types::Settings;
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::EventMsg;
@@ -257,7 +258,7 @@ async fn request_user_input_interrupted_response_preserves_tool_output() -> anyh
             sandbox_policy: SandboxPolicy::DangerFullAccess,
             model: session_model.clone(),
             effort: None,
-            summary: ReasoningSummary::Auto,
+            summary: Some(ReasoningSummary::Auto),
             collaboration_mode: Some(CollaborationMode {
                 mode: ModeKind::Plan,
                 settings: Settings {
@@ -314,7 +315,7 @@ async fn request_user_input_interrupted_response_preserves_tool_output() -> anyh
             sandbox_policy: SandboxPolicy::DangerFullAccess,
             model: session_model,
             effort: None,
-            summary: ReasoningSummary::Auto,
+            summary: Some(ReasoningSummary::Auto),
             collaboration_mode: Some(CollaborationMode {
                 mode: ModeKind::Plan,
                 settings: Settings {
@@ -415,7 +416,7 @@ async fn request_user_input_interrupt_not_blocked_by_earlier_tool() -> anyhow::R
             sandbox_policy: SandboxPolicy::DangerFullAccess,
             model: session_model,
             effort: None,
-            summary: ReasoningSummary::Auto,
+            summary: Some(ReasoningSummary::Auto),
             collaboration_mode: Some(CollaborationMode {
                 mode: ModeKind::Plan,
                 settings: Settings {

--- a/codex-rs/protocol/src/request_user_input.rs
+++ b/codex-rs/protocol/src/request_user_input.rs
@@ -41,6 +41,8 @@ pub struct RequestUserInputAnswer {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, JsonSchema, TS)]
 pub struct RequestUserInputResponse {
     pub answers: HashMap<String, RequestUserInputAnswer>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub interrupted: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, JsonSchema, TS)]

--- a/codex-rs/tui/src/app/pending_interactive_replay.rs
+++ b/codex-rs/tui/src/app/pending_interactive_replay.rs
@@ -375,6 +375,7 @@ mod tests {
             id: "turn-1".to_string(),
             response: codex_protocol::request_user_input::RequestUserInputResponse {
                 answers: HashMap::new(),
+                interrupted: false,
             },
         });
 
@@ -439,6 +440,7 @@ mod tests {
             id: "turn-1".to_string(),
             response: codex_protocol::request_user_input::RequestUserInputResponse {
                 answers: HashMap::new(),
+                interrupted: false,
             },
         });
 
@@ -489,6 +491,7 @@ mod tests {
             id: "turn-1".to_string(),
             response: codex_protocol::request_user_input::RequestUserInputResponse {
                 answers: HashMap::new(),
+                interrupted: false,
             },
         });
 


### PR DESCRIPTION
## Summary
- add `interrupted: bool` to `RequestUserInputResponse` (default false on wire)
- in the TUI `request_user_input` overlay, send `Op::UserInputAnswer` with `interrupted: true` on Esc/Ctrl-C and include only already-committed answers
- ensure uncommitted freeform draft text is not submitted during interrupt
- add generic core plumbing so tool outputs can request: "persist this output, then stop sampling"
  - `ToolHandler::should_interrupt_turn(&ToolOutput)` (default false)
  - `ToolDispatchOutput { response_input, interrupt_turn }` through registry/router/runtime/in-flight drain
  - `run_sampling_request` now aborts the turn based on drained tool-output control, not a `request_user_input`-specific turn-state flag
- implement `should_interrupt_turn` for `request_user_input` by decoding its output payload and checking `interrupted`
- keep fallback/synthetic response constructors explicit with `interrupted: false`

<img width="904" height="413" alt="Screenshot 2026-02-19 at 8 59 31 PM" src="https://github.com/user-attachments/assets/443a7b26-5774-48db-809f-8a077238943c" />

## Why
- keeps interrupt behavior simple and surgical
- matches UI semantics where Esc should not implicitly commit draft answers
- avoids tool-specific turn-state plumbing; the same mechanism can be reused for future partial-result interruptions (for example, shell/unified-exec cancellation paths)

## Tests
- `just fmt`
- `just fix -p codex-core -p codex-tui -p codex-protocol -p codex-app-server`
- `cargo test -p codex-core --test all request_user_input`
- `cargo test -p codex-tui request_user_input`
