### PR TITLE
Set memories phase reasoning effort constants

### DIFF
--- a/codex-rs/core/src/memories/mod.rs
+++ b/codex-rs/core/src/memories/mod.rs
@@ -13,6 +13,8 @@ mod storage;
 mod tests;
 pub(crate) mod usage;
 
+use codex_protocol::openai_models::ReasoningEffort;
+
 /// Starts the memory startup pipeline for eligible root sessions.
 /// This is the single entrypoint that `codex` uses to trigger memory startup.
 ///
@@ -28,6 +30,8 @@ mod artifacts {
 mod phase_one {
     /// Default model used for phase 1.
     pub(super) const MODEL: &str = "gpt-5.1-codex-mini";
+    /// Default reasoning effort used for phase 1.
+    pub(super) const REASONING_EFFORT: super::ReasoningEffort = super::ReasoningEffort::Low;
     /// Prompt used for phase 1.
     pub(super) const PROMPT: &str = include_str!("../../templates/memories/stage_one_system.md");
     /// Concurrency cap for startup memory extraction and consolidation scheduling.
@@ -56,6 +60,8 @@ mod phase_one {
 mod phase_two {
     /// Default model used for phase 2.
     pub(super) const MODEL: &str = "gpt-5.3-codex";
+    /// Default reasoning effort used for phase 2.
+    pub(super) const REASONING_EFFORT: super::ReasoningEffort = super::ReasoningEffort::Medium;
     /// Lease duration (seconds) for phase-2 consolidation job ownership.
     pub(super) const JOB_LEASE_SECONDS: i64 = 3_600;
     /// Backoff delay (seconds) before retrying a failed phase-2 consolidation

--- a/codex-rs/core/src/memories/phase1.rs
+++ b/codex-rs/core/src/memories/phase1.rs
@@ -142,7 +142,7 @@ impl RequestContext {
             model_info,
             turn_metadata_header,
             otel_manager: turn_context.otel_manager.clone(),
-            reasoning_effort: turn_context.reasoning_effort,
+            reasoning_effort: Some(phase_one::REASONING_EFFORT),
             reasoning_summary: turn_context.reasoning_summary,
         }
     }

--- a/codex-rs/core/src/memories/phase2.rs
+++ b/codex-rs/core/src/memories/phase2.rs
@@ -258,6 +258,7 @@ mod agent {
                 .clone()
                 .unwrap_or(phase_two::MODEL.to_string()),
         );
+        agent_config.model_reasoning_effort = Some(phase_two::REASONING_EFFORT);
 
         Some(agent_config)
     }


### PR DESCRIPTION
## Summary
- add reasoning effort constants for the memories phase one and phase two agents
- wire the constants into phase1 request creation and phase2 agent configuration so the default efforts are always applied

## Testing
- Not run (not requested)