### PR TITLE
feat: enforce skill permission overlays in zsh exec bridge approvals

### DIFF
--- a/codex-rs/app-server-test-client/src/lib.rs
+++ b/codex-rs/app-server-test-client/src/lib.rs
@@ -975,7 +975,11 @@ fn parse_skill_selection(
 ) -> Result<Option<SkillSelection>> {
     match (skill_name, skill_path) {
         (None, None) => Ok(None),
-        (Some(name), Some(path)) => Ok(Some(SkillSelection { name, path })),
+        (Some(name), Some(path)) => {
+            let path = fs::canonicalize(&path)
+                .with_context(|| format!("canonicalize --skill-path {}", path.display()))?;
+            Ok(Some(SkillSelection { name, path }))
+        }
         (Some(_), None) => bail!("--skill-name requires --skill-path"),
         (None, Some(_)) => bail!("--skill-path requires --skill-name"),
     }

--- a/codex-rs/app-server-test-client/src/lib.rs
+++ b/codex-rs/app-server-test-client/src/lib.rs
@@ -2,6 +2,7 @@ use std::collections::VecDeque;
 use std::ffi::OsString;
 use std::fs;
 use std::fs::OpenOptions;
+use std::io;
 use std::io::BufRead;
 use std::io::BufReader;
 use std::io::Write;
@@ -32,6 +33,7 @@ use codex_app_server_protocol::CommandExecutionRequestApprovalParams;
 use codex_app_server_protocol::CommandExecutionRequestApprovalResponse;
 use codex_app_server_protocol::CommandExecutionStatus;
 use codex_app_server_protocol::DynamicToolSpec;
+use codex_app_server_protocol::ExecPolicyAmendment;
 use codex_app_server_protocol::FileChangeApprovalDecision;
 use codex_app_server_protocol::FileChangeRequestApprovalParams;
 use codex_app_server_protocol::FileChangeRequestApprovalResponse;
@@ -143,8 +145,26 @@ struct Cli {
     #[arg(long, value_name = "json-or-@file", global = true)]
     dynamic_tools: Option<String>,
 
+    /// Attach a skill input item to V2 turn/start requests.
+    ///
+    /// Must be paired with --skill-path.
+    #[arg(long, value_name = "skill-name", global = true)]
+    skill_name: Option<String>,
+
+    /// Path to the SKILL.md file for --skill-name.
+    ///
+    /// Must be paired with --skill-name.
+    #[arg(long, value_name = "path-to-skill-md", global = true)]
+    skill_path: Option<PathBuf>,
+
     #[command(subcommand)]
     command: CliCommand,
+}
+
+#[derive(Clone, Debug)]
+struct SkillSelection {
+    name: String,
+    path: PathBuf,
 }
 
 #[derive(Subcommand)]
@@ -241,25 +261,36 @@ pub fn run() -> Result<()> {
         url,
         config_overrides,
         dynamic_tools,
+        skill_name,
+        skill_path,
         command,
     } = Cli::parse();
 
     let dynamic_tools = parse_dynamic_tools_arg(&dynamic_tools)?;
+    let skill_selection = parse_skill_selection(skill_name, skill_path)?;
 
     match command {
         CliCommand::Serve { listen, kill } => {
             ensure_dynamic_tools_unused(&dynamic_tools, "serve")?;
+            ensure_skill_unused(&skill_selection, "serve")?;
             let codex_bin = codex_bin.unwrap_or_else(|| PathBuf::from("codex"));
             serve(&codex_bin, &config_overrides, &listen, kill)
         }
         CliCommand::SendMessage { user_message } => {
             ensure_dynamic_tools_unused(&dynamic_tools, "send-message")?;
+            ensure_skill_unused(&skill_selection, "send-message")?;
             let endpoint = resolve_endpoint(codex_bin, url)?;
             send_message(&endpoint, &config_overrides, user_message)
         }
         CliCommand::SendMessageV2 { user_message } => {
             let endpoint = resolve_endpoint(codex_bin, url)?;
-            send_message_v2_endpoint(&endpoint, &config_overrides, user_message, &dynamic_tools)
+            send_message_v2_endpoint(
+                &endpoint,
+                &config_overrides,
+                user_message,
+                &dynamic_tools,
+                skill_selection.as_ref(),
+            )
         }
         CliCommand::ResumeMessageV2 {
             thread_id,
@@ -272,24 +303,43 @@ pub fn run() -> Result<()> {
                 thread_id,
                 user_message,
                 &dynamic_tools,
+                skill_selection.as_ref(),
             )
         }
         CliCommand::ThreadResume { thread_id } => {
             ensure_dynamic_tools_unused(&dynamic_tools, "thread-resume")?;
+            ensure_skill_unused(&skill_selection, "thread-resume")?;
             let endpoint = resolve_endpoint(codex_bin, url)?;
             thread_resume_follow(&endpoint, &config_overrides, thread_id)
         }
         CliCommand::TriggerCmdApproval { user_message } => {
             let endpoint = resolve_endpoint(codex_bin, url)?;
-            trigger_cmd_approval(&endpoint, &config_overrides, user_message, &dynamic_tools)
+            trigger_cmd_approval(
+                &endpoint,
+                &config_overrides,
+                user_message,
+                &dynamic_tools,
+                skill_selection.as_ref(),
+            )
         }
         CliCommand::TriggerPatchApproval { user_message } => {
             let endpoint = resolve_endpoint(codex_bin, url)?;
-            trigger_patch_approval(&endpoint, &config_overrides, user_message, &dynamic_tools)
+            trigger_patch_approval(
+                &endpoint,
+                &config_overrides,
+                user_message,
+                &dynamic_tools,
+                skill_selection.as_ref(),
+            )
         }
         CliCommand::NoTriggerCmdApproval => {
             let endpoint = resolve_endpoint(codex_bin, url)?;
-            no_trigger_cmd_approval(&endpoint, &config_overrides, &dynamic_tools)
+            no_trigger_cmd_approval(
+                &endpoint,
+                &config_overrides,
+                &dynamic_tools,
+                skill_selection.as_ref(),
+            )
         }
         CliCommand::SendFollowUpV2 {
             first_message,
@@ -302,6 +352,7 @@ pub fn run() -> Result<()> {
                 first_message,
                 follow_up_message,
                 &dynamic_tools,
+                skill_selection.as_ref(),
             )
         }
         CliCommand::TriggerZshForkMultiCmdApproval {
@@ -321,21 +372,25 @@ pub fn run() -> Result<()> {
         }
         CliCommand::TestLogin => {
             ensure_dynamic_tools_unused(&dynamic_tools, "test-login")?;
+            ensure_skill_unused(&skill_selection, "test-login")?;
             let endpoint = resolve_endpoint(codex_bin, url)?;
             test_login(&endpoint, &config_overrides)
         }
         CliCommand::GetAccountRateLimits => {
             ensure_dynamic_tools_unused(&dynamic_tools, "get-account-rate-limits")?;
+            ensure_skill_unused(&skill_selection, "get-account-rate-limits")?;
             let endpoint = resolve_endpoint(codex_bin, url)?;
             get_account_rate_limits(&endpoint, &config_overrides)
         }
         CliCommand::ModelList => {
             ensure_dynamic_tools_unused(&dynamic_tools, "model-list")?;
+            ensure_skill_unused(&skill_selection, "model-list")?;
             let endpoint = resolve_endpoint(codex_bin, url)?;
             model_list(&endpoint, &config_overrides)
         }
         CliCommand::ThreadList { limit } => {
             ensure_dynamic_tools_unused(&dynamic_tools, "thread-list")?;
+            ensure_skill_unused(&skill_selection, "thread-list")?;
             let endpoint = resolve_endpoint(codex_bin, url)?;
             thread_list(&endpoint, &config_overrides, limit)
         }
@@ -505,7 +560,13 @@ pub fn send_message_v2(
     dynamic_tools: &Option<Vec<DynamicToolSpec>>,
 ) -> Result<()> {
     let endpoint = Endpoint::SpawnCodex(codex_bin.to_path_buf());
-    send_message_v2_endpoint(&endpoint, config_overrides, user_message, dynamic_tools)
+    send_message_v2_endpoint(
+        &endpoint,
+        config_overrides,
+        user_message,
+        dynamic_tools,
+        None,
+    )
 }
 
 fn send_message_v2_endpoint(
@@ -513,6 +574,7 @@ fn send_message_v2_endpoint(
     config_overrides: &[String],
     user_message: String,
     dynamic_tools: &Option<Vec<DynamicToolSpec>>,
+    skill_selection: Option<&SkillSelection>,
 ) -> Result<()> {
     send_message_v2_with_policies(
         endpoint,
@@ -521,6 +583,7 @@ fn send_message_v2_endpoint(
         None,
         None,
         dynamic_tools,
+        skill_selection,
     )
 }
 
@@ -625,6 +688,7 @@ fn resume_message_v2(
     thread_id: String,
     user_message: String,
     dynamic_tools: &Option<Vec<DynamicToolSpec>>,
+    skill_selection: Option<&SkillSelection>,
 ) -> Result<()> {
     ensure_dynamic_tools_unused(dynamic_tools, "resume-message-v2")?;
 
@@ -641,10 +705,7 @@ fn resume_message_v2(
 
     let turn_response = client.turn_start(TurnStartParams {
         thread_id: resume_response.thread.id.clone(),
-        input: vec![V2UserInput::Text {
-            text: user_message,
-            text_elements: Vec::new(),
-        }],
+        input: build_v2_input(user_message, skill_selection),
         ..Default::default()
     })?;
     println!("< turn/start response: {turn_response:?}");
@@ -679,6 +740,7 @@ fn trigger_cmd_approval(
     config_overrides: &[String],
     user_message: Option<String>,
     dynamic_tools: &Option<Vec<DynamicToolSpec>>,
+    skill_selection: Option<&SkillSelection>,
 ) -> Result<()> {
     let default_prompt =
         "Run `touch /tmp/should-trigger-approval` so I can confirm the file exists.";
@@ -692,6 +754,7 @@ fn trigger_cmd_approval(
             access: ReadOnlyAccess::FullAccess,
         }),
         dynamic_tools,
+        skill_selection,
     )
 }
 
@@ -700,6 +763,7 @@ fn trigger_patch_approval(
     config_overrides: &[String],
     user_message: Option<String>,
     dynamic_tools: &Option<Vec<DynamicToolSpec>>,
+    skill_selection: Option<&SkillSelection>,
 ) -> Result<()> {
     let default_prompt =
         "Create a file named APPROVAL_DEMO.txt containing a short hello message using apply_patch.";
@@ -713,6 +777,7 @@ fn trigger_patch_approval(
             access: ReadOnlyAccess::FullAccess,
         }),
         dynamic_tools,
+        skill_selection,
     )
 }
 
@@ -720,6 +785,7 @@ fn no_trigger_cmd_approval(
     endpoint: &Endpoint,
     config_overrides: &[String],
     dynamic_tools: &Option<Vec<DynamicToolSpec>>,
+    skill_selection: Option<&SkillSelection>,
 ) -> Result<()> {
     let prompt = "Run `touch should_not_trigger_approval.txt`";
     send_message_v2_with_policies(
@@ -729,6 +795,7 @@ fn no_trigger_cmd_approval(
         None,
         None,
         dynamic_tools,
+        skill_selection,
     )
 }
 
@@ -739,6 +806,7 @@ fn send_message_v2_with_policies(
     approval_policy: Option<AskForApproval>,
     sandbox_policy: Option<SandboxPolicy>,
     dynamic_tools: &Option<Vec<DynamicToolSpec>>,
+    skill_selection: Option<&SkillSelection>,
 ) -> Result<()> {
     let mut client = CodexClient::connect(endpoint, config_overrides)?;
 
@@ -752,11 +820,7 @@ fn send_message_v2_with_policies(
     println!("< thread/start response: {thread_response:?}");
     let mut turn_params = TurnStartParams {
         thread_id: thread_response.thread.id.clone(),
-        input: vec![V2UserInput::Text {
-            text: user_message,
-            // Test client sends plain text without UI element ranges.
-            text_elements: Vec::new(),
-        }],
+        input: build_v2_input(user_message, skill_selection),
         ..Default::default()
     };
     turn_params.approval_policy = approval_policy;
@@ -776,6 +840,7 @@ fn send_follow_up_v2(
     first_message: String,
     follow_up_message: String,
     dynamic_tools: &Option<Vec<DynamicToolSpec>>,
+    skill_selection: Option<&SkillSelection>,
 ) -> Result<()> {
     let mut client = CodexClient::connect(endpoint, config_overrides)?;
 
@@ -790,11 +855,7 @@ fn send_follow_up_v2(
 
     let first_turn_params = TurnStartParams {
         thread_id: thread_response.thread.id.clone(),
-        input: vec![V2UserInput::Text {
-            text: first_message,
-            // Test client sends plain text without UI element ranges.
-            text_elements: Vec::new(),
-        }],
+        input: build_v2_input(first_message, skill_selection),
         ..Default::default()
     };
     let first_turn_response = client.turn_start(first_turn_params)?;
@@ -803,11 +864,7 @@ fn send_follow_up_v2(
 
     let follow_up_params = TurnStartParams {
         thread_id: thread_response.thread.id.clone(),
-        input: vec![V2UserInput::Text {
-            text: follow_up_message,
-            // Test client sends plain text without UI element ranges.
-            text_elements: Vec::new(),
-        }],
+        input: build_v2_input(follow_up_message, skill_selection),
         ..Default::default()
     };
     let follow_up_response = client.turn_start(follow_up_params)?;
@@ -903,6 +960,47 @@ fn ensure_dynamic_tools_unused(
     Ok(())
 }
 
+fn ensure_skill_unused(skill_selection: &Option<SkillSelection>, command: &str) -> Result<()> {
+    if skill_selection.is_some() {
+        bail!(
+            "skill input is only supported for v2 turn/start commands; remove --skill-name/--skill-path for {command}"
+        );
+    }
+    Ok(())
+}
+
+fn parse_skill_selection(
+    skill_name: Option<String>,
+    skill_path: Option<PathBuf>,
+) -> Result<Option<SkillSelection>> {
+    match (skill_name, skill_path) {
+        (None, None) => Ok(None),
+        (Some(name), Some(path)) => Ok(Some(SkillSelection { name, path })),
+        (Some(_), None) => bail!("--skill-name requires --skill-path"),
+        (None, Some(_)) => bail!("--skill-path requires --skill-name"),
+    }
+}
+
+fn build_v2_input(
+    user_message: String,
+    skill_selection: Option<&SkillSelection>,
+) -> Vec<V2UserInput> {
+    let mut input = vec![V2UserInput::Text {
+        text: user_message,
+        // Test client sends plain text without UI element ranges.
+        text_elements: Vec::new(),
+    }];
+
+    if let Some(skill_selection) = skill_selection {
+        input.push(V2UserInput::Skill {
+            name: skill_selection.name.clone(),
+            path: skill_selection.path.clone(),
+        });
+    }
+
+    input
+}
+
 fn parse_dynamic_tools_arg(dynamic_tools: &Option<String>) -> Result<Option<Vec<DynamicToolSpec>>> {
     let Some(raw_arg) = dynamic_tools.as_deref() else {
         return Ok(None);
@@ -949,6 +1047,7 @@ struct CodexClient {
 
 #[derive(Debug, Clone, Copy)]
 enum CommandApprovalBehavior {
+    Prompt,
     AlwaysAccept,
     AbortOn(usize),
 }
@@ -999,7 +1098,7 @@ impl CodexClient {
                 stdout: BufReader::new(stdout),
             },
             pending_notifications: VecDeque::new(),
-            command_approval_behavior: CommandApprovalBehavior::AlwaysAccept,
+            command_approval_behavior: CommandApprovalBehavior::Prompt,
             command_approval_count: 0,
             command_approval_item_ids: Vec::new(),
             command_execution_statuses: Vec::new(),
@@ -1020,7 +1119,7 @@ impl CodexClient {
                 socket: Box::new(socket),
             },
             pending_notifications: VecDeque::new(),
-            command_approval_behavior: CommandApprovalBehavior::AlwaysAccept,
+            command_approval_behavior: CommandApprovalBehavior::Prompt,
             command_approval_count: 0,
             command_approval_item_ids: Vec::new(),
             command_execution_statuses: Vec::new(),
@@ -1522,19 +1621,20 @@ impl CodexClient {
         }
 
         let decision = match self.command_approval_behavior {
+            CommandApprovalBehavior::Prompt => {
+                self.command_approval_decision(proposed_execpolicy_amendment)?
+            }
             CommandApprovalBehavior::AlwaysAccept => CommandExecutionApprovalDecision::Accept,
             CommandApprovalBehavior::AbortOn(index) if self.command_approval_count == index => {
                 CommandExecutionApprovalDecision::Cancel
             }
             CommandApprovalBehavior::AbortOn(_) => CommandExecutionApprovalDecision::Accept,
         };
-        let response = CommandExecutionRequestApprovalResponse {
-            decision: decision.clone(),
-        };
+        let response = CommandExecutionRequestApprovalResponse { decision };
         self.send_server_request_response(request_id, &response)?;
         println!(
             "< commandExecution decision for approval #{} on item {item_id}: {:?}",
-            self.command_approval_count, decision
+            self.command_approval_count, response.decision
         );
         Ok(())
     }
@@ -1562,12 +1662,37 @@ impl CodexClient {
             println!("< grant root: {}", grant_root.display());
         }
 
-        let response = FileChangeRequestApprovalResponse {
-            decision: FileChangeApprovalDecision::Accept,
-        };
+        let decision = self.file_change_approval_decision()?;
+        let response = FileChangeRequestApprovalResponse { decision };
         self.send_server_request_response(request_id, &response)?;
-        println!("< approved fileChange request for item {item_id}");
+        println!(
+            "< responded to fileChange request for item {item_id}: {:?}",
+            response.decision
+        );
         Ok(())
+    }
+
+    fn command_approval_decision(
+        &self,
+        proposed_execpolicy_amendment: Option<ExecPolicyAmendment>,
+    ) -> Result<CommandExecutionApprovalDecision> {
+        if let Some(execpolicy_amendment) = proposed_execpolicy_amendment {
+            return prompt_for_command_approval_with_amendment(execpolicy_amendment);
+        }
+
+        if prompt_for_yes_no("Approve command execution request? [y/n] ")? {
+            Ok(CommandExecutionApprovalDecision::Accept)
+        } else {
+            Ok(CommandExecutionApprovalDecision::Decline)
+        }
+    }
+
+    fn file_change_approval_decision(&self) -> Result<FileChangeApprovalDecision> {
+        if prompt_for_yes_no("Approve file-change request? [y/n] ")? {
+            Ok(FileChangeApprovalDecision::Accept)
+        } else {
+            Ok(FileChangeApprovalDecision::Decline)
+        }
     }
 
     fn send_server_request_response<T>(&mut self, request_id: RequestId, response: &T) -> Result<()>
@@ -1641,6 +1766,59 @@ impl CodexClient {
 fn print_multiline_with_prefix(prefix: &str, payload: &str) {
     for line in payload.lines() {
         println!("{prefix}{line}");
+    }
+}
+
+fn prompt_for_yes_no(prompt: &str) -> Result<bool> {
+    loop {
+        print!("{prompt}");
+        io::stdout()
+            .flush()
+            .context("failed to flush approval prompt")?;
+
+        let mut line = String::new();
+        io::stdin()
+            .read_line(&mut line)
+            .context("failed to read approval input")?;
+        let input = line.trim().to_ascii_lowercase();
+        if matches!(input.as_str(), "y" | "yes") {
+            return Ok(true);
+        }
+        if matches!(input.as_str(), "n" | "no") {
+            return Ok(false);
+        }
+        println!("please answer y or n");
+    }
+}
+
+fn prompt_for_command_approval_with_amendment(
+    execpolicy_amendment: ExecPolicyAmendment,
+) -> Result<CommandExecutionApprovalDecision> {
+    loop {
+        print!("Approve command execution request? [y/n/a] (a=always allow) ");
+        io::stdout()
+            .flush()
+            .context("failed to flush approval prompt")?;
+
+        let mut line = String::new();
+        io::stdin()
+            .read_line(&mut line)
+            .context("failed to read approval input")?;
+        let input = line.trim().to_ascii_lowercase();
+        if matches!(input.as_str(), "y" | "yes") {
+            return Ok(CommandExecutionApprovalDecision::Accept);
+        }
+        if matches!(input.as_str(), "n" | "no") {
+            return Ok(CommandExecutionApprovalDecision::Decline);
+        }
+        if matches!(input.as_str(), "a" | "always" | "always allow") {
+            return Ok(
+                CommandExecutionApprovalDecision::AcceptWithExecpolicyAmendment {
+                    execpolicy_amendment: execpolicy_amendment.clone(),
+                },
+            );
+        }
+        println!("please answer y, n, or a");
     }
 }
 

--- a/codex-rs/core/src/sandboxing/mod.rs
+++ b/codex-rs/core/src/sandboxing/mod.rs
@@ -6,6 +6,8 @@ sandbox placement and transformation of portable CommandSpec into a
 ready‑to‑spawn environment.
 */
 
+pub(crate) mod policy_merge;
+
 use crate::exec::ExecExpiration;
 use crate::exec::ExecToolCallOutput;
 use crate::exec::SandboxType;

--- a/codex-rs/core/src/sandboxing/policy_merge.rs
+++ b/codex-rs/core/src/sandboxing/policy_merge.rs
@@ -1,0 +1,396 @@
+use std::collections::HashSet;
+
+use codex_utils_absolute_path::AbsolutePathBuf;
+
+use crate::protocol::NetworkAccess;
+use crate::protocol::ReadOnlyAccess;
+use crate::protocol::SandboxPolicy;
+
+pub(crate) fn extend_sandbox_policy(
+    base: &SandboxPolicy,
+    extension: &SandboxPolicy,
+) -> SandboxPolicy {
+    // Merge by intersection of capabilities: the combined policy must satisfy
+    // restrictions from both `base` and `extension`.
+    match (base, extension) {
+        (SandboxPolicy::DangerFullAccess, other) | (other, SandboxPolicy::DangerFullAccess) => {
+            other.clone()
+        }
+        (
+            SandboxPolicy::ExternalSandbox {
+                network_access: base_network,
+            },
+            SandboxPolicy::ExternalSandbox {
+                network_access: extension_network,
+            },
+        ) => SandboxPolicy::ExternalSandbox {
+            network_access: restrict_network_access(*base_network, *extension_network),
+        },
+        (SandboxPolicy::ExternalSandbox { .. }, SandboxPolicy::ReadOnly { access })
+        | (SandboxPolicy::ReadOnly { access }, SandboxPolicy::ExternalSandbox { .. }) => {
+            SandboxPolicy::ReadOnly {
+                access: access.clone(),
+            }
+        }
+        (
+            SandboxPolicy::ExternalSandbox {
+                network_access: external_network_access,
+            },
+            SandboxPolicy::WorkspaceWrite {
+                writable_roots,
+                read_only_access,
+                network_access,
+                exclude_tmpdir_env_var,
+                exclude_slash_tmp,
+            },
+        )
+        | (
+            SandboxPolicy::WorkspaceWrite {
+                writable_roots,
+                read_only_access,
+                network_access,
+                exclude_tmpdir_env_var,
+                exclude_slash_tmp,
+            },
+            SandboxPolicy::ExternalSandbox {
+                network_access: external_network_access,
+            },
+        ) => SandboxPolicy::WorkspaceWrite {
+            writable_roots: writable_roots.clone(),
+            read_only_access: read_only_access.clone(),
+            network_access: *network_access && external_network_access.is_enabled(),
+            exclude_tmpdir_env_var: *exclude_tmpdir_env_var,
+            exclude_slash_tmp: *exclude_slash_tmp,
+        },
+        (
+            SandboxPolicy::ReadOnly {
+                access: base_access,
+            },
+            SandboxPolicy::ReadOnly {
+                access: extension_access,
+            },
+        ) => SandboxPolicy::ReadOnly {
+            access: intersect_read_only_access(base_access, extension_access),
+        },
+        (
+            SandboxPolicy::ReadOnly {
+                access: base_access,
+            },
+            SandboxPolicy::WorkspaceWrite {
+                read_only_access, ..
+            },
+        ) => SandboxPolicy::ReadOnly {
+            access: intersect_read_only_access(base_access, read_only_access),
+        },
+        (
+            SandboxPolicy::WorkspaceWrite {
+                read_only_access, ..
+            },
+            SandboxPolicy::ReadOnly {
+                access: extension_access,
+            },
+        ) => SandboxPolicy::ReadOnly {
+            access: intersect_read_only_access(read_only_access, extension_access),
+        },
+        (
+            SandboxPolicy::WorkspaceWrite {
+                writable_roots: base_writable_roots,
+                read_only_access: base_read_only_access,
+                network_access: base_network_access,
+                exclude_tmpdir_env_var: base_exclude_tmpdir_env_var,
+                exclude_slash_tmp: base_exclude_slash_tmp,
+            },
+            SandboxPolicy::WorkspaceWrite {
+                writable_roots: extension_writable_roots,
+                read_only_access: extension_read_only_access,
+                network_access: extension_network_access,
+                exclude_tmpdir_env_var: extension_exclude_tmpdir_env_var,
+                exclude_slash_tmp: extension_exclude_slash_tmp,
+            },
+        ) => SandboxPolicy::WorkspaceWrite {
+            writable_roots: intersect_absolute_roots(base_writable_roots, extension_writable_roots),
+            read_only_access: intersect_read_only_access(
+                base_read_only_access,
+                extension_read_only_access,
+            ),
+            network_access: *base_network_access && *extension_network_access,
+            exclude_tmpdir_env_var: *base_exclude_tmpdir_env_var
+                || *extension_exclude_tmpdir_env_var,
+            exclude_slash_tmp: *base_exclude_slash_tmp || *extension_exclude_slash_tmp,
+        },
+    }
+}
+
+fn restrict_network_access(base: NetworkAccess, extension: NetworkAccess) -> NetworkAccess {
+    if base.is_enabled() && extension.is_enabled() {
+        NetworkAccess::Enabled
+    } else {
+        NetworkAccess::Restricted
+    }
+}
+
+fn intersect_read_only_access(base: &ReadOnlyAccess, extension: &ReadOnlyAccess) -> ReadOnlyAccess {
+    match (base, extension) {
+        (ReadOnlyAccess::FullAccess, access) | (access, ReadOnlyAccess::FullAccess) => {
+            access.clone()
+        }
+        (
+            ReadOnlyAccess::Restricted {
+                include_platform_defaults: base_include_platform_defaults,
+                readable_roots: base_readable_roots,
+            },
+            ReadOnlyAccess::Restricted {
+                include_platform_defaults: extension_include_platform_defaults,
+                readable_roots: extension_readable_roots,
+            },
+        ) => ReadOnlyAccess::Restricted {
+            include_platform_defaults: *base_include_platform_defaults
+                && *extension_include_platform_defaults,
+            readable_roots: intersect_absolute_roots(base_readable_roots, extension_readable_roots),
+        },
+    }
+}
+
+fn intersect_absolute_roots(
+    base_roots: &[AbsolutePathBuf],
+    extension_roots: &[AbsolutePathBuf],
+) -> Vec<AbsolutePathBuf> {
+    let extension_roots_set: HashSet<_> = extension_roots
+        .iter()
+        .map(AbsolutePathBuf::to_path_buf)
+        .collect();
+    let mut roots = Vec::new();
+    let mut seen = HashSet::new();
+    for root in base_roots {
+        let root_path = root.to_path_buf();
+        if extension_roots_set.contains(&root_path) && seen.insert(root_path) {
+            roots.push(root.clone());
+        }
+    }
+    roots
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extend_sandbox_policy;
+    use crate::protocol::NetworkAccess;
+    use crate::protocol::ReadOnlyAccess;
+    use crate::protocol::SandboxPolicy;
+    use codex_utils_absolute_path::AbsolutePathBuf;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn extend_sandbox_policy_combines_read_only_and_workspace_write_as_read_only() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let base_read_root =
+            AbsolutePathBuf::try_from(tempdir.path().join("base-read")).expect("absolute path");
+
+        let merged = extend_sandbox_policy(
+            &SandboxPolicy::ReadOnly {
+                access: ReadOnlyAccess::Restricted {
+                    include_platform_defaults: false,
+                    readable_roots: vec![base_read_root],
+                },
+            },
+            &SandboxPolicy::WorkspaceWrite {
+                writable_roots: vec![],
+                read_only_access: ReadOnlyAccess::Restricted {
+                    include_platform_defaults: true,
+                    readable_roots: Vec::new(),
+                },
+                network_access: true,
+                exclude_tmpdir_env_var: false,
+                exclude_slash_tmp: false,
+            },
+        );
+
+        assert_eq!(
+            merged,
+            SandboxPolicy::ReadOnly {
+                access: ReadOnlyAccess::Restricted {
+                    include_platform_defaults: false,
+                    readable_roots: Vec::new(),
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn extend_sandbox_policy_uses_extension_when_base_is_danger_full_access() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let extension_root =
+            AbsolutePathBuf::try_from(tempdir.path().join("extension")).expect("absolute path");
+
+        let merged = extend_sandbox_policy(
+            &SandboxPolicy::DangerFullAccess,
+            &SandboxPolicy::WorkspaceWrite {
+                writable_roots: vec![extension_root.clone()],
+                read_only_access: ReadOnlyAccess::FullAccess,
+                network_access: false,
+                exclude_tmpdir_env_var: false,
+                exclude_slash_tmp: true,
+            },
+        );
+
+        assert_eq!(
+            merged,
+            SandboxPolicy::WorkspaceWrite {
+                writable_roots: vec![extension_root],
+                read_only_access: ReadOnlyAccess::FullAccess,
+                network_access: false,
+                exclude_tmpdir_env_var: false,
+                exclude_slash_tmp: true,
+            }
+        );
+    }
+
+    #[test]
+    fn extend_sandbox_policy_external_and_workspace_write_keeps_workspace_write_restrictions() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let workspace_root =
+            AbsolutePathBuf::try_from(tempdir.path().join("workspace")).expect("absolute path");
+        let read_root = AbsolutePathBuf::try_from(tempdir.path().join("read")).expect("absolute");
+
+        let merged = extend_sandbox_policy(
+            &SandboxPolicy::ExternalSandbox {
+                network_access: NetworkAccess::Restricted,
+            },
+            &SandboxPolicy::WorkspaceWrite {
+                writable_roots: vec![workspace_root.clone()],
+                read_only_access: ReadOnlyAccess::Restricted {
+                    include_platform_defaults: true,
+                    readable_roots: vec![read_root.clone()],
+                },
+                network_access: true,
+                exclude_tmpdir_env_var: false,
+                exclude_slash_tmp: false,
+            },
+        );
+
+        assert_eq!(
+            merged,
+            SandboxPolicy::WorkspaceWrite {
+                writable_roots: vec![workspace_root],
+                read_only_access: ReadOnlyAccess::Restricted {
+                    include_platform_defaults: true,
+                    readable_roots: vec![read_root],
+                },
+                network_access: false,
+                exclude_tmpdir_env_var: false,
+                exclude_slash_tmp: false,
+            }
+        );
+    }
+
+    #[test]
+    fn extend_sandbox_policy_external_and_read_only_returns_read_only() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let read_root = AbsolutePathBuf::try_from(tempdir.path().join("read")).expect("absolute");
+
+        let merged = extend_sandbox_policy(
+            &SandboxPolicy::ExternalSandbox {
+                network_access: NetworkAccess::Enabled,
+            },
+            &SandboxPolicy::ReadOnly {
+                access: ReadOnlyAccess::Restricted {
+                    include_platform_defaults: true,
+                    readable_roots: vec![read_root.clone()],
+                },
+            },
+        );
+
+        assert_eq!(
+            merged,
+            SandboxPolicy::ReadOnly {
+                access: ReadOnlyAccess::Restricted {
+                    include_platform_defaults: true,
+                    readable_roots: vec![read_root],
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn extend_sandbox_policy_intersects_workspace_roots_and_restricts_network_access() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let shared_root =
+            AbsolutePathBuf::try_from(tempdir.path().join("shared")).expect("absolute path");
+        let base_root =
+            AbsolutePathBuf::try_from(tempdir.path().join("base")).expect("absolute path");
+        let extension_root =
+            AbsolutePathBuf::try_from(tempdir.path().join("extension")).expect("absolute path");
+
+        let merged = extend_sandbox_policy(
+            &SandboxPolicy::WorkspaceWrite {
+                writable_roots: vec![shared_root.clone(), base_root],
+                read_only_access: ReadOnlyAccess::FullAccess,
+                network_access: false,
+                exclude_tmpdir_env_var: true,
+                exclude_slash_tmp: true,
+            },
+            &SandboxPolicy::WorkspaceWrite {
+                writable_roots: vec![shared_root.clone(), extension_root.clone()],
+                read_only_access: ReadOnlyAccess::Restricted {
+                    include_platform_defaults: false,
+                    readable_roots: vec![extension_root.clone()],
+                },
+                network_access: true,
+                exclude_tmpdir_env_var: false,
+                exclude_slash_tmp: false,
+            },
+        );
+
+        assert_eq!(
+            merged,
+            SandboxPolicy::WorkspaceWrite {
+                writable_roots: vec![shared_root],
+                read_only_access: ReadOnlyAccess::Restricted {
+                    include_platform_defaults: false,
+                    readable_roots: vec![extension_root],
+                },
+                network_access: false,
+                exclude_tmpdir_env_var: true,
+                exclude_slash_tmp: true,
+            }
+        );
+    }
+
+    #[test]
+    fn extend_sandbox_policy_keeps_network_access_enabled_only_when_both_policies_enable_it() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let shared_root =
+            AbsolutePathBuf::try_from(tempdir.path().join("shared")).expect("absolute path");
+        let base_root =
+            AbsolutePathBuf::try_from(tempdir.path().join("base")).expect("absolute path");
+        let extension_root =
+            AbsolutePathBuf::try_from(tempdir.path().join("extension")).expect("absolute path");
+
+        let merged = extend_sandbox_policy(
+            &SandboxPolicy::WorkspaceWrite {
+                writable_roots: vec![base_root, shared_root.clone()],
+                read_only_access: ReadOnlyAccess::FullAccess,
+                network_access: true,
+                exclude_tmpdir_env_var: true,
+                exclude_slash_tmp: true,
+            },
+            &SandboxPolicy::WorkspaceWrite {
+                writable_roots: vec![shared_root.clone(), extension_root],
+                read_only_access: ReadOnlyAccess::FullAccess,
+                network_access: true,
+                exclude_tmpdir_env_var: true,
+                exclude_slash_tmp: true,
+            },
+        );
+
+        assert_eq!(
+            merged,
+            SandboxPolicy::WorkspaceWrite {
+                writable_roots: vec![shared_root],
+                read_only_access: ReadOnlyAccess::FullAccess,
+                network_access: true,
+                exclude_tmpdir_env_var: true,
+                exclude_slash_tmp: true,
+            }
+        );
+    }
+}


### PR DESCRIPTION
 ## Summary

  This PR makes zsh_exec_bridge respect skill-defined permissions when executing skill scripts.

  ## What changed

  - Build a per-turn registry of skill script prefixes (scripts/*) to skill Permissions.
  - Store/copy that registry on TurnContext (including review threads).
  - In zsh_exec_bridge, evaluate exec-policy using the resolved executable path (not just original argv[0]).
  - Add an exec-policy overlay path that injects prompt-only prefix rules in-memory for skill scripts.
  - Ensure overlays do not mutate the session exec-policy and do not override explicit base policy matches.
  - Merge matching skill sandbox policy with the turn sandbox policy using a restrictive intersection (policy_merge).
  - Pass through approval reason / proposed exec-policy amendment from the new exec-policy evaluation flow.

## Skill Sandbox Extension Test Plan
1. Create demo files and directories.

```
cd /Users/celia/code/codex
bash .tmp/skill-sandbox-demo/setup_demo.sh
```

  2. Configure skill permissions (read-only is fine; this mainly exercises skill metadata loading + matching).
```
  # /Users/celia/code/codex/.agents/skills/sandbox-approval-demo/agents/openai.yaml
  permissions:
    network: true
    file_system:
      read:
        - "./workspace"
```
  3. Set and verify custom interceptable zsh.

```
INTERCEPTABLE_ZSH=/Users/celia/.local/codex-zsh-77045ef/bin/zsh
"$INTERCEPTABLE_ZSH" -fc '/usr/bin/true'
EXEC_WRAPPER=/usr/bin/false "$INTERCEPTABLE_ZSH" -fc '/usr/bin/true'  # should fail if intercept works
```

  4. Build binaries used by the test.

```
cd /Users/celia/code/codex/codex-rs
cargo build -p codex -p codex-app-server-test-client
```

  5. Clean test artifacts.

```
cd /Users/celia/code/codex
rm -f .agents/skills/sandbox-approval-demo/workspace/runs.log
rm -f .tmp/skill-sandbox-demo/should_be_blocked.txt
rm -f .tmp/skill-sandbox-demo/should_be_allowed.txt
```

  6. Baseline control: zsh fork disabled (no zsh-bridge overlay behavior).
```
  cd /Users/celia/code/codex/codex-rs
  cargo run -p codex-app-server-test-client -- \
    --codex-bin ./target/debug/codex \
    --config 'features.shell_zsh_fork=false' \
    --config 'approval_policy="on-request"' \
    --config 'sandbox_mode="danger-full-access"' \
    --skill-name sandbox-approval-demo \
    --skill-path ../.agents/skills/sandbox-approval-demo/SKILL.md \
    send-message-v2 'Run this exact command once: ../.agents/skills/sandbox-approval-demo/scripts/skill_action.sh'
```
 Observed that:
  - Command runs successfully.
  - No zsh-bridge skill approval overlay behavior is expected in this control path.

  7. Main test (normalization regression): zsh fork enabled, invoke skill script with a relative path that includes ./.
```
  cd /Users/celia/code/codex/codex-rs
  cargo run -p codex-app-server-test-client -- \
    --codex-bin ./target/debug/codex \
    --config 'features.shell_zsh_fork=true' \
    --config "zsh_path=\"$INTERCEPTABLE_ZSH\"" \
    --config 'approval_policy="on-request"' \
    --config 'sandbox_mode="danger-full-access"' \
    --skill-name sandbox-approval-demo \
    --skill-path ../.agents/skills/sandbox-approval-demo/SKILL.md \
    send-message-v2 'Run this exact command once with no wrapper changes: ../.agents/skills/sandbox-approval-demo/scripts/./skill_action.sh'
```

Saw an approval block like this:
```
< {
<   "id": 0,
<   "method": "item/commandExecution/requestApproval",
<   "params": {
<     "approvalId": "92016c70-7b1b-421c-974d-859a8f877953",
<     "command": "/Users/celia/.local/codex-zsh-77045ef/bin/zsh -c ../.agents/skills/sandbox-approval-demo/scripts/./skill_action.sh",
<     "commandActions": [
<       {
<         "command": "../.agents/skills/sandbox-approval-demo/scripts/./skill_action.sh",
<         "type": "unknown"
<       }
<     ],
<     "cwd": "/Users/celia/code/codex/codex-rs",
<     "itemId": "call_VqW2702rYIaQxcSFgvPE5fPd",
<     "proposedExecpolicyAmendment": [
<       "../.agents/skills/sandbox-approval-demo/scripts/./skill_action.sh"
<     ],
<     "reason": "Do you want to allow running the requested demo skill script once with escalated sandbox permissions?",
<     "threadId": "019c7e23-550d-7cb2-a2a4-4327d56cf925",
<     "turnId": "019c7e23-5552-7243-9ec9-cf1280377b53"
<   }
< }
```
When choosing "always allow", this prefix rule was generated on disk:
```
prefix_rule(pattern=["../.agents/skills/sandbox-approval-demo/scripts/./skill_action.sh"], decision="allow")
```
and the second run passed without prompting for approval.

When declining, I saw this:
```
{
<   "method": "item/completed",
<   "params": {
<     "item": {
<       "aggregatedOutput": "exec command rejected by user",
<       "command": "/Users/celia/.local/codex-zsh-77045ef/bin/zsh -lc ../.agents/skills/sandbox-approval-demo/scripts/./skill_action.sh",
<       "commandActions": [
<         {
<           "command": "../.agents/skills/sandbox-approval-demo/scripts/./skill_action.sh",
<           "type": "unknown"
<         }
<       ],
<       "cwd": "/Users/celia/code/codex/codex-rs",
<       "durationMs": 0,
<       "exitCode": -1,
<       "id": "call_SS6YN137jQUvsIMj07thvdLe",
<       "processId": null,
<       "status": "declined",
<       "type": "commandExecution"
<     },
<     "threadId": "019c7e25-924a-7d82-82ef-9bd6f4dc872c",
<     "turnId": "019c7e25-9282-7d01-9be0-462495ef6ed0"
<   }
< }
```

  8. Control: non-skill script with zsh fork enabled.
```
  cd /Users/celia/code/codex/codex-rs
  cargo run -p codex-app-server-test-client -- \
    --codex-bin ./target/debug/codex \
    --config 'features.shell_zsh_fork=true' \
    --config "zsh_path=\"$INTERCEPTABLE_ZSH\"" \
    --config 'approval_policy="on-request"' \
    --config 'sandbox_mode="danger-full-access"' \
    send-message-v2 'Run this exact command once: ../.tmp/skill-sandbox-demo/non_skill_action.sh'
```
Observed that:
  - Command succeeds.
  - No skill-based approval overlay should be applied.