### PR TITLE
app-server: support caller-supplied thread and turn IDs

### DIFF
--- a/codex-rs/app-server-protocol/schema/json/ClientRequest.json
+++ b/codex-rs/app-server-protocol/schema/json/ClientRequest.json
@@ -2973,6 +2973,13 @@
               "type": "null"
             }
           ]
+        },
+        "threadId": {
+          "description": "Optional caller-supplied thread ID (UUID). If omitted, the server generates a new thread ID.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "type": "object"
@@ -3085,6 +3092,13 @@
         },
         "threadId": {
           "type": "string"
+        },
+        "turnId": {
+          "description": "Optional caller-supplied turn ID (UUID). If omitted, the server generates a new turn ID.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
@@ -16625,6 +16625,13 @@
                 "type": "null"
               }
             ]
+          },
+          "threadId": {
+            "description": "Optional caller-supplied thread ID (UUID). If omitted, the server generates a new thread ID.",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "title": "ThreadStartParams",
@@ -17204,6 +17211,13 @@
           },
           "threadId": {
             "type": "string"
+          },
+          "turnId": {
+            "description": "Optional caller-supplied turn ID (UUID). If omitted, the server generates a new turn ID.",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "required": [

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadStartParams.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadStartParams.json
@@ -150,6 +150,13 @@
           "type": "null"
         }
       ]
+    },
+    "threadId": {
+      "description": "Optional caller-supplied thread ID (UUID). If omitted, the server generates a new thread ID.",
+      "type": [
+        "string",
+        "null"
+      ]
     }
   },
   "title": "ThreadStartParams",

--- a/codex-rs/app-server-protocol/schema/json/v2/TurnStartParams.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/TurnStartParams.json
@@ -552,6 +552,13 @@
     },
     "threadId": {
       "type": "string"
+    },
+    "turnId": {
+      "description": "Optional caller-supplied turn ID (UUID). If omitted, the server generates a new turn ID.",
+      "type": [
+        "string",
+        "null"
+      ]
     }
   },
   "required": [

--- a/codex-rs/app-server-protocol/schema/typescript/v2/ThreadStartParams.ts
+++ b/codex-rs/app-server-protocol/schema/typescript/v2/ThreadStartParams.ts
@@ -6,7 +6,11 @@ import type { JsonValue } from "../serde_json/JsonValue";
 import type { AskForApproval } from "./AskForApproval";
 import type { SandboxMode } from "./SandboxMode";
 
-export type ThreadStartParams = {model?: string | null, modelProvider?: string | null, cwd?: string | null, approvalPolicy?: AskForApproval | null, sandbox?: SandboxMode | null, config?: { [key in string]?: JsonValue } | null, baseInstructions?: string | null, developerInstructions?: string | null, personality?: Personality | null, ephemeral?: boolean | null, /**
+export type ThreadStartParams = {/**
+ * Optional caller-supplied thread ID (UUID). If omitted, the server
+ * generates a new thread ID.
+ */
+threadId?: string | null, model?: string | null, modelProvider?: string | null, cwd?: string | null, approvalPolicy?: AskForApproval | null, sandbox?: SandboxMode | null, config?: { [key in string]?: JsonValue } | null, baseInstructions?: string | null, developerInstructions?: string | null, personality?: Personality | null, ephemeral?: boolean | null, /**
  * If true, opt into emitting raw Responses API items on the event stream.
  * This is for internal use only (e.g. Codex Cloud).
  */

--- a/codex-rs/app-server-protocol/schema/typescript/v2/TurnStartParams.ts
+++ b/codex-rs/app-server-protocol/schema/typescript/v2/TurnStartParams.ts
@@ -10,7 +10,11 @@ import type { AskForApproval } from "./AskForApproval";
 import type { SandboxPolicy } from "./SandboxPolicy";
 import type { UserInput } from "./UserInput";
 
-export type TurnStartParams = {threadId: string, input: Array<UserInput>, /**
+export type TurnStartParams = {threadId: string, /**
+ * Optional caller-supplied turn ID (UUID). If omitted, the server
+ * generates a new turn ID.
+ */
+turnId?: string | null, input: Array<UserInput>, /**
  * Override the working directory for this turn and subsequent turns.
  */
 cwd?: string | null, /**

--- a/codex-rs/app-server-protocol/src/protocol/thread_history.rs
+++ b/codex-rs/app-server-protocol/src/protocol/thread_history.rs
@@ -100,6 +100,13 @@ impl ThreadHistoryBuilder {
             .or_else(|| self.turns.last().cloned())
     }
 
+    pub fn active_turn_id(&self) -> Option<&str> {
+        self.current_turn
+            .as_ref()
+            .map(|turn| turn.id.as_str())
+            .or_else(|| self.turns.last().map(|turn| turn.id.as_str()))
+    }
+
     pub fn has_active_turn(&self) -> bool {
         self.current_turn.is_some()
     }

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -1483,6 +1483,10 @@ pub struct CommandExecResponse {
 #[serde(rename_all = "camelCase")]
 #[ts(export_to = "v2/")]
 pub struct ThreadStartParams {
+    /// Optional caller-supplied thread ID (UUID). If omitted, the server
+    /// generates a new thread ID.
+    #[ts(optional = nullable)]
+    pub thread_id: Option<String>,
     #[ts(optional = nullable)]
     pub model: Option<String>,
     #[ts(optional = nullable)]
@@ -2339,6 +2343,10 @@ pub enum TurnStatus {
 #[ts(export_to = "v2/")]
 pub struct TurnStartParams {
     pub thread_id: String,
+    /// Optional caller-supplied turn ID (UUID). If omitted, the server
+    /// generates a new turn ID.
+    #[ts(optional = nullable)]
+    pub turn_id: Option<String>,
     pub input: Vec<UserInput>,
     /// Override the working directory for this turn and subsequent turns.
     #[ts(optional = nullable)]

--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -114,7 +114,7 @@ Example with notification opt-out:
 
 ## API Overview
 
-- `thread/start` — create a new thread; emits `thread/started` and auto-subscribes you to turn/item events for that thread.
+- `thread/start` — create a new thread; optionally supply `threadId` (UUID) to pre-assign the thread id. Emits `thread/started` and auto-subscribes you to turn/item events for that thread.
 - `thread/resume` — reopen an existing thread by id so subsequent `turn/start` calls append to it.
 - `thread/fork` — fork an existing thread into a new thread id by copying the stored history; emits `thread/started` and auto-subscribes you to turn/item events for the new thread.
 - `thread/list` — page through stored rollouts; supports cursor-based pagination and optional `modelProviders`, `sourceKinds`, `archived`, and `cwd` filters. Each returned `thread` includes `status` (`ThreadStatus`), defaulting to `notLoaded` when the thread is not currently loaded.
@@ -127,7 +127,7 @@ Example with notification opt-out:
 - `thread/compact/start` — trigger conversation history compaction for a thread; returns `{}` immediately while progress streams through standard turn/item notifications.
 - `thread/backgroundTerminals/clean` — terminate all running background terminals for a thread (experimental; requires `capabilities.experimentalApi`); returns `{}` when the cleanup request is accepted.
 - `thread/rollback` — drop the last N turns from the agent’s in-memory context and persist a rollback marker in the rollout so future resumes see the pruned history; returns the updated `thread` (with `turns` populated) on success.
-- `turn/start` — add user input to a thread and begin Codex generation; responds with the initial `turn` object and streams `turn/started`, `item/*`, and `turn/completed` notifications. For `collaborationMode`, `settings.developer_instructions: null` means "use built-in instructions for the selected mode".
+- `turn/start` — add user input to a thread and begin Codex generation; optionally supply `turnId` (UUID) to pre-assign the turn id. Responds with the initial `turn` object and streams `turn/started`, `item/*`, and `turn/completed` notifications. For `collaborationMode`, `settings.developer_instructions: null` means "use built-in instructions for the selected mode".
 - `turn/steer` — add user input to an already in-flight turn without starting a new turn; returns the active `turnId` that accepted the input.
 - `turn/interrupt` — request cancellation of an in-flight turn by `(thread_id, turn_id)`; success is an empty `{}` response and the turn finishes with `status: "interrupted"`.
 - `review/start` — kick off Codex’s automated reviewer for a thread; responds like `turn/start` and emits `item/started`/`item/completed` notifications with `enteredReviewMode` and `exitedReviewMode` items, plus a final assistant `agentMessage` containing the review.
@@ -158,6 +158,8 @@ Start a fresh thread when you need a new Codex conversation.
 
 ```json
 { "method": "thread/start", "id": 10, "params": {
+    // Optionally pre-assign the thread id (must be a UUID string).
+    "threadId": "018f2b7a-5d5d-7c39-9d6b-9f3f88d4f1c2",
     // Optionally set config settings. If not specified, will use the user's
     // current config settings.
     "model": "gpt-5.1-codex",
@@ -339,6 +341,8 @@ You can optionally specify config overrides on the new turn. If specified, these
 ```json
 { "method": "turn/start", "id": 30, "params": {
     "threadId": "thr_123",
+    // Optionally pre-assign the turn id (must be a UUID string).
+    "turnId": "018f2b7a-5d5d-7c39-9d6b-9f3f88d4f1c3",
     "input": [ { "type": "text", "text": "Run tests" } ],
     // Below are optional config overrides
     "cwd": "/Users/me/project",

--- a/codex-rs/app-server/src/thread_state.rs
+++ b/codex-rs/app-server/src/thread_state.rs
@@ -49,6 +49,8 @@ pub(crate) struct ThreadState {
     pub(crate) experimental_raw_events: bool,
     listener_command_tx: Option<mpsc::UnboundedSender<ThreadListenerCommand>>,
     current_turn_history: ThreadHistoryBuilder,
+    known_turn_ids: HashSet<String>,
+    known_turn_ids_seeded: bool,
     listener_thread: Option<Weak<CodexThread>>,
     subscribed_connections: HashSet<ConnectionId>,
 }
@@ -110,8 +112,35 @@ impl ThreadState {
         self.current_turn_history.active_turn_snapshot()
     }
 
+    pub(crate) fn active_turn_id(&self) -> Option<&str> {
+        self.current_turn_history.active_turn_id()
+    }
+
+    pub(crate) fn has_known_turn_id(&self, turn_id: &str) -> bool {
+        self.known_turn_ids.contains(turn_id)
+    }
+
+    pub(crate) fn known_turn_ids_seeded(&self) -> bool {
+        self.known_turn_ids_seeded
+    }
+
+    pub(crate) fn seed_known_turn_ids(&mut self, turn_ids: impl IntoIterator<Item = String>) {
+        if self.known_turn_ids_seeded {
+            return;
+        }
+        self.known_turn_ids.extend(turn_ids);
+        self.known_turn_ids_seeded = true;
+    }
+
+    pub(crate) fn remember_turn_id(&mut self, turn_id: impl Into<String>) {
+        self.known_turn_ids.insert(turn_id.into());
+    }
+
     pub(crate) fn track_current_turn_event(&mut self, event: &EventMsg) {
         self.current_turn_history.handle_event(event);
+        if let Some(active_turn_id) = self.current_turn_history.active_turn_id() {
+            self.known_turn_ids.insert(active_turn_id.to_string());
+        }
         if !self.current_turn_history.has_active_turn() {
             self.current_turn_history.reset();
         }

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -300,6 +300,7 @@ impl Codex {
         agent_control: AgentControl,
         dynamic_tools: Vec<DynamicToolSpec>,
         persist_extended_history: bool,
+        requested_thread_id: Option<ThreadId>,
     ) -> CodexResult<CodexSpawnOk> {
         let (tx_sub, rx_sub) = async_channel::bounded(SUBMISSION_CHANNEL_CAPACITY);
         let (tx_event, rx_event) = async_channel::unbounded();
@@ -429,6 +430,7 @@ impl Codex {
             skills_manager,
             file_watcher,
             agent_control,
+            requested_thread_id,
         )
         .instrument(session_init_span)
         .await
@@ -469,6 +471,7 @@ impl Codex {
     /// Use sparingly: prefer `submit()` so Codex is responsible for generating
     /// unique IDs for each submission.
     pub async fn submit_with_id(&self, sub: Submission) -> CodexResult<()> {
+        self.session.reserve_submission_id(&sub.id).await?;
         self.tx_sub
             .send(sub)
             .await
@@ -524,6 +527,7 @@ pub(crate) struct Session {
     features: Features,
     pending_mcp_server_refresh_config: Mutex<Option<McpServerRefreshConfig>>,
     pub(crate) active_turn: Mutex<Option<ActiveTurn>>,
+    submitted_ids: Mutex<HashSet<String>>,
     pub(crate) services: SessionServices,
     js_repl: Arc<JsReplHandle>,
     next_internal_sub_id: AtomicU64,
@@ -1001,6 +1005,7 @@ impl Session {
         skills_manager: Arc<SkillsManager>,
         file_watcher: Arc<FileWatcher>,
         agent_control: AgentControl,
+        requested_thread_id: Option<ThreadId>,
     ) -> anyhow::Result<Arc<Self>> {
         debug!(
             "Configuring session: model={}; provider={:?}",
@@ -1018,7 +1023,7 @@ impl Session {
 
         let (conversation_id, rollout_params) = match &initial_history {
             InitialHistory::New | InitialHistory::Forked(_) => {
-                let conversation_id = ThreadId::default();
+                let conversation_id = requested_thread_id.unwrap_or_default();
                 (
                     conversation_id,
                     RolloutRecorderParams::new(
@@ -1356,6 +1361,7 @@ impl Session {
             features: config.features.clone(),
             pending_mcp_server_refresh_config: Mutex::new(None),
             active_turn: Mutex::new(None),
+            submitted_ids: Mutex::new(HashSet::new()),
             services,
             js_repl,
             next_internal_sub_id: AtomicU64::new(0),
@@ -1770,6 +1776,17 @@ impl Session {
     pub(crate) async fn set_previous_model(&self, previous_model: Option<String>) {
         let mut state = self.state.lock().await;
         state.set_previous_model(previous_model);
+    }
+
+    async fn reserve_submission_id(&self, submission_id: &str) -> CodexResult<()> {
+        let mut submitted_ids = self.submitted_ids.lock().await;
+        if submitted_ids.insert(submission_id.to_string()) {
+            return Ok(());
+        }
+
+        Err(CodexErr::InvalidRequest(format!(
+            "duplicate submission id: {submission_id}"
+        )))
     }
 
     fn maybe_refresh_shell_snapshot_for_cwd(
@@ -7312,6 +7329,7 @@ mod tests {
             Arc::new(SkillsManager::new(config.codex_home.clone())),
             Arc::new(FileWatcher::noop()),
             AgentControl::default(),
+            None,
         )
         .await;
 
@@ -7466,6 +7484,7 @@ mod tests {
             features: config.features.clone(),
             pending_mcp_server_refresh_config: Mutex::new(None),
             active_turn: Mutex::new(None),
+            submitted_ids: Mutex::new(HashSet::new()),
             services,
             js_repl,
             next_internal_sub_id: AtomicU64::new(0),
@@ -7622,6 +7641,7 @@ mod tests {
             features: config.features.clone(),
             pending_mcp_server_refresh_config: Mutex::new(None),
             active_turn: Mutex::new(None),
+            submitted_ids: Mutex::new(HashSet::new()),
             services,
             js_repl,
             next_internal_sub_id: AtomicU64::new(0),

--- a/codex-rs/core/src/codex_delegate.rs
+++ b/codex-rs/core/src/codex_delegate.rs
@@ -59,6 +59,7 @@ pub(crate) async fn run_codex_thread_interactive(
         parent_session.services.agent_control.clone(),
         Vec::new(),
         false,
+        None,
     )
     .await?;
     let codex = Arc::new(codex);


### PR DESCRIPTION
Add optional threadId/turnId fields to the v2 app-server API and document them as UUIDs.

Validate caller-supplied IDs in the app server, reject duplicates, and route custom turn IDs through submit_with_id while surfacing invalid-request errors correctly. Canonicalize caller-supplied turn IDs to hyphenated UUID strings so case variants cannot bypass duplicate checks.

Plumb requested thread IDs through core thread spawning and add duplicate-ID guards in core (session-level duplicate submission IDs and ThreadManager thread-ID collision checks).

Cache known turn IDs per loaded thread so rollout history is only parsed once when validating custom turn IDs, and track active turn IDs without cloning full turn state on each streamed event.

Update docs/schema fixtures and add app-server tests for caller-supplied IDs, UUID validation, and duplicate-turn rejection.