### PR TITLE
docs: use --locked when installing cargo-nextest

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -27,7 +27,7 @@ rustup component add clippy
 # Install helper tools used by the workspace justfile:
 cargo install just
 # Optional: install nextest for the `just test` helper
-cargo install cargo-nextest
+cargo install --locked cargo-nextest
 
 # Build Codex.
 cargo build


### PR DESCRIPTION
## What

Updates the optional `cargo-nextest` install command in `docs/install.md`:

- `cargo install cargo-nextest` -> `cargo install --locked cargo-nextest`

## Why

The current docs command can fail during source install because recent `cargo-nextest` releases intentionally require `--locked`.

Repro (macOS, but likely not platform-specific):
- `cargo install cargo-nextest`
- Fails with a compile error from `locked-tripwire` indicating:
  - `Nextest does not support being installed without --locked`
  - suggests `cargo install --locked cargo-nextest`

Using the locked command succeeds:
- `cargo install --locked cargo-nextest`

## How

Single-line docs change in `docs/install.md` to match current `cargo-nextest` install requirements.

## Validation

- Reproduced failure locally using a temporary `CARGO_HOME` directory (clean Cargo home)
- Example command used: `CARGO_HOME=/tmp/cargo-home-test cargo install cargo-nextest`
- Confirmed success with `cargo install --locked cargo-nextest`