### PR TITLE
core: make collab wait diagnostics observable in structured session logs

### DIFF
--- a/codex-rs/core/src/tools/handlers/multi_agents.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents.rs
@@ -454,6 +454,7 @@ pub(crate) mod wait {
     use std::time::Duration;
     use tokio::sync::watch::Receiver;
     use tokio::time::Instant;
+    use tracing::warn;
 
     use tokio::time::timeout_at;
 
@@ -467,6 +468,14 @@ pub(crate) mod wait {
     pub(crate) struct WaitResult {
         pub(crate) status: HashMap<ThreadId, AgentStatus>,
         pub(crate) timed_out: bool,
+    }
+
+    pub(super) fn should_emit_wait_none_diagnostic(diagnostic_emitted: bool) -> bool {
+        !diagnostic_emitted
+    }
+
+    pub(super) fn should_emit_sender_close_non_final_diagnostic(latest: &AgentStatus) -> bool {
+        !is_final(latest)
     }
 
     pub async fn handle(
@@ -574,6 +583,7 @@ pub(crate) mod wait {
                 futures.push(wait_for_final_status(session, id, rx));
             }
             let mut results = Vec::new();
+            let mut wait_none_diagnostic_emitted = false;
             let deadline = Instant::now() + Duration::from_millis(timeout_ms as u64);
             loop {
                 match timeout_at(deadline, futures.next()).await {
@@ -581,7 +591,19 @@ pub(crate) mod wait {
                         results.push(result);
                         break;
                     }
-                    Ok(Some(None)) => continue,
+                    Ok(Some(None)) => {
+                        if should_emit_wait_none_diagnostic(wait_none_diagnostic_emitted) {
+                            warn!(
+                                diagnostic_event = "collab_wait_continue_on_none",
+                                sender_thread_id = %session.conversation_id,
+                                receiver_count = receiver_thread_ids.len(),
+                                timeout_ms,
+                                "collab wait loop continued after non-final status stream result"
+                            );
+                            wait_none_diagnostic_emitted = true;
+                        }
+                        continue;
+                    }
                     Ok(None) | Err(_) => break,
                 }
             }
@@ -601,6 +623,15 @@ pub(crate) mod wait {
         // Convert payload.
         let statuses_map = statuses.clone().into_iter().collect::<HashMap<_, _>>();
         let agent_statuses = build_wait_agent_statuses(&statuses_map, &receiver_agents);
+        if statuses.is_empty() {
+            warn!(
+                diagnostic_event = "collab_wait_empty_status_map_timeout_like",
+                sender_thread_id = %session.conversation_id,
+                receiver_count = receiver_thread_ids.len(),
+                timeout_ms,
+                "collab wait finished with empty status map (timeout-like outcome)"
+            );
+        }
         let result = WaitResult {
             status: statuses_map.clone(),
             timed_out: statuses.is_empty(),
@@ -642,8 +673,20 @@ pub(crate) mod wait {
 
         loop {
             if status_rx.changed().await.is_err() {
+                let last_observed_status = status.clone();
                 let latest = session.services.agent_control.get_status(thread_id).await;
-                return is_final(&latest).then_some((thread_id, latest));
+                let latest_is_final = is_final(&latest);
+                if should_emit_sender_close_non_final_diagnostic(&latest) {
+                    warn!(
+                        diagnostic_event = "collab_wait_status_stream_closed_non_final",
+                        thread_id = %thread_id,
+                        last_observed_status = ?last_observed_status,
+                        fallback_status = ?latest,
+                        latest_is_final,
+                        "collab wait status stream closed before final status"
+                    );
+                }
+                return latest_is_final.then_some((thread_id, latest));
             }
             status = status_rx.borrow().clone();
             if is_final(&status) {
@@ -1657,6 +1700,25 @@ mod tests {
             err,
             FunctionCallError::RespondToModel("ids must be non-empty".to_string())
         );
+    }
+
+    #[test]
+    fn wait_none_diagnostic_helper_emits_once() {
+        assert!(wait::should_emit_wait_none_diagnostic(false));
+        assert!(!wait::should_emit_wait_none_diagnostic(true));
+    }
+
+    #[test]
+    fn sender_close_non_final_diagnostic_helper_matches_finality() {
+        assert!(wait::should_emit_sender_close_non_final_diagnostic(
+            &AgentStatus::PendingInit
+        ));
+        assert!(wait::should_emit_sender_close_non_final_diagnostic(
+            &AgentStatus::Running
+        ));
+        assert!(!wait::should_emit_sender_close_non_final_diagnostic(
+            &AgentStatus::Shutdown
+        ));
     }
 
     #[tokio::test]

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -2842,6 +2842,30 @@ pub struct CollabWaitingBeginEvent {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, JsonSchema, TS)]
+pub struct CollabWaitDiagnosticEvent {
+    /// Stable machine-readable diagnostic marker for collab wait behavior.
+    pub diagnostic_event: String,
+    /// Optional thread id associated with this diagnostic.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<ThreadId>,
+    /// Receiver count for the wait call when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub receiver_count: Option<usize>,
+    /// Effective timeout for the wait call in milliseconds when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_ms: Option<i64>,
+    /// Last observed status before status stream closure (if applicable).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_observed_status: Option<AgentStatus>,
+    /// Fallback status sampled after stream closure (if applicable).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fallback_status: Option<AgentStatus>,
+    /// Whether fallback status was final when sampled.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latest_is_final: Option<bool>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, JsonSchema, TS)]
 pub struct CollabWaitingEndEvent {
     /// Thread ID of the sender.
     pub sender_thread_id: ThreadId,
@@ -2852,6 +2876,9 @@ pub struct CollabWaitingEndEvent {
     pub agent_statuses: Vec<CollabAgentStatusEntry>,
     /// Last known status of the receiver agents reported to the sender agent.
     pub statuses: HashMap<ThreadId, AgentStatus>,
+    /// Structured diagnostics captured during wait execution.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub diagnostics: Vec<CollabWaitDiagnosticEvent>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, JsonSchema, TS)]

--- a/codex-rs/tui/src/multi_agents.rs
+++ b/codex-rs/tui/src/multi_agents.rs
@@ -119,6 +119,7 @@ pub(crate) fn waiting_end(ev: CollabWaitingEndEvent) -> PlainHistoryCell {
         sender_thread_id: _,
         agent_statuses,
         statuses,
+        ..
     } = ev;
     let details = wait_complete_lines(&statuses, &agent_statuses);
     collab_event(title_text("Finished waiting"), details)


### PR DESCRIPTION
# Phase 21.18 Upstream PR-Ready Option 1 (Diagnosability-First, Documentation-Only)

GeneratedUtc: 2026-02-20T13:23:19Z  
Source evidence: Phase 21.12 + Phase 21.18 same-session CTX artifacts  
Alignment status carried into proposal: `CONSTRAINED`

## Candidate Upstream PR Titles
1. `multi-agents: add explicit diagnostics for non-final status-stream closure`
2. `session-init diagnostics: mark pre-final initialization failures`
3. `wait diagnostics: distinguish empty-status timeout-like outcomes from stream-closure paths`

## Problem Statement (Strict, Evidence-Gated)
Same-session CTX evidence consistently shows spawn/wait proxy activity and failures, but current local traces cannot prove sender-close/status-map transition causality because internal same-session logs are unavailable in this environment.

Evidence pointers:
- `artifacts/frep/phase-21.18/ctx/CTX__summary.json:115` (`event_msg/collab_waiting_begin`, count `14`)
- `artifacts/frep/phase-21.18/ctx/CTX__summary.json:119` (`event_msg/collab_waiting_end`, count `14`)
- `artifacts/frep/phase-21.18/ctx/CTX__summary.json:123` (`event_msg/collab_agent_spawn_begin`, count `12`)
- `artifacts/frep/phase-21.18/ctx/CTX__summary.json:127` (`event_msg/collab_agent_spawn_end`, count `12`)
- `artifacts/frep/phase-21.18/ctx/CTX__fails.json` (`99` failure anchors)
- `artifacts/frep/phase-21.18/internal/INTERNAL__alignment_report.md` (`AlignmentStatus=CONSTRAINED`)

Verdict discipline preserved:
- `H1=AMBIGUOUS`
- `H2=AMBIGUOUS`
- `H3=AMBIGUOUS`
- `H4=NOT SUPPORTED`

## Pinned Upstream Anchors
Pinned SHA:
- `03ff04cd658bc34750ab74d2041e616d8aa6bb33`
- source: `artifacts/frep/phase-21.12/upstream/UPSTREAM__openai_codex_main_sha.txt`

### `codex-rs/core/src/tools/handlers/multi_agents.rs`
- `:549` wait loop continue-on-none: `Ok(Some(None)) => continue,`
- `:570` timeout-like flag derivation: `timed_out: statuses.is_empty(),`
- `:596-616` `wait_for_final_status(...)`
- `:607-609` sender-close fallback branch:
  - `if status_rx.changed().await.is_err() {`
  - `let latest = ...get_status(thread_id)...`
  - `return is_final(&latest).then_some((thread_id, latest));`
- `:40-42` wait timeout bounds constants

### `codex-rs/core/src/codex.rs`
- `:416` `watch::channel(AgentStatus::PendingInit)`
- `:419` `Session::new(...)` call site
- `:435-437` initialization failure mapping path (`map_session_init_error(...)`)

### `codex-rs/core/src/agent/status.rs`
- `:17-18` final-state predicate excludes `PendingInit` and `Running`

## Option 1 Proposal (Diagnosability-First, No Behavior Change)
Add explicit diagnostic markers only; do not change wait semantics in this PR.

### Proposed Marker A — `status_stream_closed_non_final`
- File: `multi_agents.rs` around `:607-609`
- Trigger: `status_rx.changed().await.is_err()` and latest status is non-final
- Payload (proposed): `thread_id`, `latest_status`, `source="wait_for_final_status"`, `cause="status_stream_closed"`
- Risk: low

### Proposed Marker B — `session_init_failed_before_final_status`
- File: `codex.rs` around `:435-437`
- Trigger: `Session::new(...)` returns error before final status emission
- Payload (proposed): `session_source`, `cwd`, `mapped_error_class`, `source="session_init"`
- Risk: low

### Proposed Marker C — `wait_result_empty_status_map_diagnostic`
- File: `multi_agents.rs` around `:570`
- Trigger: `timed_out=true` due `statuses.is_empty()`
- Payload (proposed): `thread_count`, `timeout_ms`, `source="multi_agents.wait"`
- Risk: low

## Minimal Test Plan (Upstream)
Unit tests:
1. sender-close + non-final latest emits `status_stream_closed_non_final`
2. sender-close + final latest does not emit false-positive non-final marker
3. Session::new failure path emits `session_init_failed_before_final_status`
4. empty wait status map emits `wait_result_empty_status_map_diagnostic`

Integration tests:
1. normal multi-agent completion path unchanged
2. true timeout behavior unchanged
3. diagnostic markers are present in event stream and include thread/session identifiers

## Post-Landing Evidence Required to Promote H1-H3
After Option 1 lands, collect same-session traces that correlate:
1. `status_stream_closed_non_final` with timeout-like empty status-map outcomes
2. `session_init_failed_before_final_status` with missing final status emission patterns
3. marker timestamps/thread ids with `collab_waiting_*` and `collab_agent_spawn_*`

Only then can H1/H2/H3 move from AMBIGUOUS to VERIFIED.

## Risk and Rollback
- Risk level: low (diagnostic emission only)
- Rollback: upstream revert of diagnostics commit(s) if noise/volume is unacceptable
- Local scope: no upstream code edits, no patch files, no upstream PR execution in this phase
