### PR TITLE
Add experimental realtime websocket URL override

### DIFF
--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -1541,6 +1541,10 @@
     "experimental_compact_prompt_file": {
       "$ref": "#/definitions/AbsolutePathBuf"
     },
+    "experimental_realtime_ws_base_url": {
+      "description": "Experimental / do not use. Overrides only the realtime conversation websocket transport base URL (the `Op::RealtimeConversation` `/ws` connection) without changing normal provider HTTP requests.",
+      "type": "string"
+    },
     "experimental_use_freeform_apply_patch": {
       "type": "boolean"
     },

--- a/codex-rs/core/src/realtime_conversation.rs
+++ b/codex-rs/core/src/realtime_conversation.rs
@@ -169,7 +169,11 @@ pub(crate) async fn handle_start(
 ) -> CodexResult<()> {
     let provider = sess.provider().await;
     let auth = sess.services.auth_manager.auth().await;
-    let api_provider = provider.to_api_provider(auth.as_ref().map(CodexAuth::auth_mode))?;
+    let mut api_provider = provider.to_api_provider(auth.as_ref().map(CodexAuth::auth_mode))?;
+    let config = sess.get_config().await;
+    if let Some(realtime_ws_base_url) = &config.experimental_realtime_ws_base_url {
+        api_provider.base_url = realtime_ws_base_url.clone();
+    }
 
     let requested_session_id = params
         .session_id


### PR DESCRIPTION
- add top-level `experimental_realtime_ws_base_url` config key (experimental / do not use) and include it in config schema
- apply the override only to `Op::RealtimeConversation` websocket transport, with config + realtime tests