### PR TITLE
app-server: box request dispatch future to reduce stack pressure

### DIFF
--- a/codex-rs/app-server/src/message_processor.rs
+++ b/codex-rs/app-server/src/message_processor.rs
@@ -49,6 +49,7 @@ use codex_core::default_client::set_default_originator;
 use codex_feedback::CodexFeedback;
 use codex_protocol::ThreadId;
 use codex_protocol::protocol::SessionSource;
+use futures::FutureExt;
 use tokio::sync::broadcast;
 use tokio::time::Duration;
 use tokio::time::timeout;
@@ -386,8 +387,12 @@ impl MessageProcessor {
                 .await;
             }
             other => {
+                // Box the delegated future so this wrapper's async state machine does not
+                // inline the full `CodexMessageProcessor::process_request` future, which
+                // can otherwise push worker-thread stack usage over the edge.
                 self.codex_message_processor
                     .process_request(connection_id, other)
+                    .boxed()
                     .await;
             }
         }


### PR DESCRIPTION
## Summary
- box the delegated `CodexMessageProcessor::process_request(...)` future inside `MessageProcessor::process_request`
- reduce stack pressure in the app-server request dispatcher without changing request behavior
- document/confirm the root cause path for the detached-review stack overflow regression introduced on main by `#11786`

## Root Cause (high confidence)
I bisected `main` using a deterministic low-stack repro and found the first bad commit:
- `1f54496c48ffb9678095cc91d40556faa57c99fb` — `app-server: expose loaded thread status via read/list and notifications (#11786)`

Why that commit can trigger overflows:
- `MessageProcessor::process_request` is a large `async fn` that sometimes delegates to the even larger `CodexMessageProcessor::process_request`.
- Awaiting that delegated future inline makes the outer `MessageProcessor::process_request` future type include the full delegated future state machine.
- `#11786` significantly grew the delegated future (new thread-status tracking + additional async work), which increased stack usage for the wrapper future enough to cross the threshold on smaller Tokio worker stacks.
- This matches the prior LLDB crash frame in `message_processor.rs` and explains why even initialization-only paths became more stack-sensitive.

## Why This Fix
This is a small, behavior-preserving stack-footprint reduction at the source:
- We heap-box the delegated future (`.boxed().await`) in the `other =>` branch.
- That prevents the wrapper future from inlining the full `CodexMessageProcessor::process_request` future state machine.
- It reduces per-request stack usage while preserving control flow and request semantics.

This complements (but does not replace) the runtime worker stack-size mitigation already added in `codex-arg0`.

## Validation
### Local targeted tests (current branch)
- `just fmt`
- `cargo test -p codex-app-server --test all suite::user_agent::get_user_agent_returns_current_codex_user_agent -- --nocapture`
- `cargo test -p codex-app-server --test all suite::v2::review::review_start_with_detached_delivery_returns_new_thread_id -- --nocapture`

### Deterministic before/after repro on the culprit commit (`1f54496c48`)
I validated the patch directly against the bisected culprit commit in a throwaway worktree.

1. **Detached review low-stack repro (matches reported failure path):**
- Before patch:
  - `CARGO_TARGET_DIR=/tmp/codex-bisect-target RUST_MIN_STACK=2031616 cargo test -q -p codex-app-server --test all suite::v2::review::review_start_with_detached_delivery_returns_new_thread_id -- --nocapture`
  - Result: `tokio-runtime-worker` stack overflow (`fatal runtime error: stack overflow`)
- After applying this patch:
  - same command
  - Result: test passes (`ok`)

2. **Initialization-only repro (shows wrapper future stack reduction directly):**
- Before patch on `1f54496c48`:
  - run `codex-app-server` with a minimal `initialize` request and `RUST_MIN_STACK=294912`
  - Result: `tokio-runtime-worker` stack overflow
- After applying this patch:
  - same command
  - Result: process exits successfully

### Bisect result
`git bisect` (good=`e00080cea`, bad=`d87cf7794`) identified:
- first bad commit: `1f54496c48ffb9678095cc91d40556faa57c99fb`

## Risk
Low:
- No protocol/schema changes
- No request handling behavior changes
- Only changes how the delegated async future is stored (heap allocation instead of being inlined into the wrapper future state machine)

## Codex author
`codex resume 019c7e1f-4cd9-72b3-aa74-826e9d38c218`
