### PR TITLE
feat: discourage the use of the --all-features flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ In the codex-rs folder where the rust code lives:
 Run `just fmt` (in `codex-rs` directory) automatically after you have finished making Rust code changes; do not ask for approval to run it. Additionally, run the tests:
 
 1. Run the test for the specific project that was changed. For example, if changes were made in `codex-rs/tui`, run `cargo test -p codex-tui`.
-2. Once those pass, if any changes were made in common, core, or protocol, run the complete test suite with `cargo test --all-features`. project-specific or individual tests can be run without asking the user, but do ask the user before running the complete test suite.
+2. Once those pass, if any changes were made in common, core, or protocol, run the complete test suite with `cargo test` (or `just test` if `cargo-nextest` is installed). Avoid `--all-features` for routine local runs because it expands the build matrix and can significantly increase `target/` disk usage; use it only when you specifically need full feature coverage. project-specific or individual tests can be run without asking the user, but do ask the user before running the complete test suite.
 
 Before finalizing a large change to `codex-rs`, run `just fix -p <project>` (in `codex-rs` directory) to fix any linter issues in the code. Prefer scoping with `-p` to avoid slow workspace‑wide Clippy builds; only run `just fix` without `-p` if you changed shared crates. Do not re-run tests after running `fix` or `fmt`.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -43,7 +43,9 @@ just fix -p <crate-you-touched>
 cargo test -p codex-tui
 # If you have cargo-nextest installed, `just test` runs the test suite via nextest:
 just test
-# If you specifically want the full `--all-features` matrix, use:
+# Avoid `--all-features` for routine local runs because it increases build
+# time and `target/` disk usage by compiling additional feature combinations.
+# If you specifically want full feature coverage, use:
 cargo test --all-features
 ```
 

--- a/justfile
+++ b/justfile
@@ -28,10 +28,10 @@ fmt:
     cargo fmt -- --config imports_granularity=Item 2>/dev/null
 
 fix *args:
-    cargo clippy --fix --all-features --tests --allow-dirty "$@"
+    cargo clippy --fix --tests --allow-dirty "$@"
 
 clippy:
-    cargo clippy --all-features --tests "$@"
+    cargo clippy --tests "$@"
 
 install:
     rustup show active-toolchain
@@ -41,6 +41,8 @@ install:
 # --no-fail-fast is important to ensure all tests are run.
 #
 # Run `cargo install cargo-nextest` if you don't have it installed.
+# Prefer this for routine local runs; use explicit `cargo test --all-features`
+# only when you specifically need full feature coverage.
 test:
     cargo nextest run --no-fail-fast
 


### PR DESCRIPTION
## Why

Developers are frequently running low on disk space, and routine use of `--all-features` contributes to larger Cargo build caches in `target/` by compiling additional feature combinations.

This change updates local workflow guidance to avoid `--all-features` by default and reserve it for cases where full feature coverage is specifically needed.

## What Changed

- Updated `AGENTS.md` guidance for `codex-rs` to recommend `cargo test` / `just test` for full-suite local runs, and to call out the disk-usage cost of routine `--all-features` usage.
- Updated the root `justfile` so `just fix` and `just clippy` no longer pass `--all-features` by default.
- Updated `docs/install.md` to explicitly describe `cargo test --all-features` as an optional heavier-weight run (more build time and `target/` disk usage).

## Verification

- Confirmed the `justfile` parses and the recipes list successfully with `just --list`.
