### PR TITLE
Unify rollback baseline replay with history reconstruction

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1622,10 +1622,16 @@ impl Session {
                     .reconstruct_history_from_rollout(&turn_context, &rollout_items)
                     .await;
                 let previous_model = reconstructed.previous_model.clone();
+                let reference_context_item = reconstructed
+                    .user_turn_baselines
+                    .last()
+                    .filter(|frame| !frame.invalidated_by_following_compaction)
+                    .map(|frame| frame.turn_context_item.clone());
                 let curr = turn_context.model_info.slug.as_str();
                 {
                     let mut state = self.state.lock().await;
                     state.set_user_turn_baselines(reconstructed.user_turn_baselines.clone());
+                    state.set_reference_context_item(reference_context_item);
                     state.set_previous_model(previous_model.clone());
                 }
 
@@ -1673,6 +1679,7 @@ impl Session {
                 {
                     let mut state = self.state.lock().await;
                     state.set_user_turn_baselines(reconstructed.user_turn_baselines.clone());
+                    state.set_reference_context_item(None);
                     state.set_previous_model(reconstructed.previous_model.clone());
                 }
 

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -86,8 +86,6 @@ impl ContextManager {
 
     pub(crate) fn set_user_turn_baselines(&mut self, baselines: Vec<UserTurnBaselineFrame>) {
         self.user_turn_baselines = baselines;
-        self.reference_context_item =
-            self.effective_reference_context_item_from_user_turn_baselines();
     }
 
     pub(crate) fn user_turn_baselines(&self) -> Vec<UserTurnBaselineFrame> {

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -100,7 +100,11 @@ impl ContextManager {
 
     pub(crate) fn record_regular_turn_baseline(&mut self, item: TurnContextItem) {
         if let Some(top) = self.user_turn_baselines.last_mut()
-            && top.turn_context_item.turn_id == item.turn_id
+            && let (Some(top_turn_id), Some(item_turn_id)) = (
+                top.turn_context_item.turn_id.as_deref(),
+                item.turn_id.as_deref(),
+            )
+            && top_turn_id == item_turn_id
         {
             top.turn_context_item = item.clone();
             top.invalidated_by_following_compaction = false;

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -313,6 +313,7 @@ impl ContextManager {
         let user_positions = user_message_positions(&snapshot);
         let Some(&first_user_idx) = user_positions.first() else {
             self.replace(snapshot);
+            self.truncate_user_turn_baselines_from_end(num_turns);
             return;
         };
 

--- a/codex-rs/core/src/context_manager/mod.rs
+++ b/codex-rs/core/src/context_manager/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod updates;
 
 pub(crate) use history::ContextManager;
 pub(crate) use history::TotalTokenUsageBreakdown;
+pub(crate) use history::UserTurnBaselineFrame;
 pub(crate) use history::estimate_response_item_model_visible_bytes;
 pub(crate) use history::is_codex_generated_item;
 pub(crate) use history::is_user_turn_boundary;

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -6,6 +6,7 @@ use std::collections::HashSet;
 
 use crate::codex::SessionConfiguration;
 use crate::context_manager::ContextManager;
+use crate::context_manager::UserTurnBaselineFrame;
 use crate::protocol::RateLimitSnapshot;
 use crate::protocol::TokenUsage;
 use crate::protocol::TokenUsageInfo;
@@ -76,7 +77,7 @@ impl SessionState {
     ) {
         self.history.replace(items);
         self.history
-            .set_reference_context_item(reference_context_item);
+            .sync_reference_context_after_history_replacement(reference_context_item);
     }
 
     pub(crate) fn set_token_info(&mut self, info: Option<TokenUsageInfo>) {
@@ -89,6 +90,19 @@ impl SessionState {
 
     pub(crate) fn reference_context_item(&self) -> Option<TurnContextItem> {
         self.history.reference_context_item()
+    }
+
+    pub(crate) fn set_user_turn_baselines(&mut self, baselines: Vec<UserTurnBaselineFrame>) {
+        self.history.set_user_turn_baselines(baselines);
+    }
+
+    pub(crate) fn record_regular_turn_baseline(&mut self, item: TurnContextItem) {
+        self.history.record_regular_turn_baseline(item);
+    }
+
+    pub(crate) fn rollback_user_turns(&mut self, num_turns: u32) {
+        self.history.drop_last_n_user_turns(num_turns);
+        self.previous_model = self.history.latest_user_turn_model();
     }
 
     // Token/rate limit helpers


### PR DESCRIPTION
## Summary
- unify resume/fork baseline hydration with `reconstruct_history_from_rollout(...)` so history reconstruction and baseline parsing share one rollout traversal
- maintain a rollback-aware in-memory user-turn baseline stack alongside `ContextManager` history
- remove the rollback-time rollout file reread and recompute rollback baselines from in-memory state

## What Changed
- `reconstruct_history_from_rollout(...)` now also replays turn lifecycle / `TurnContextItem` / `Compacted` / `ThreadRolledBack` markers to produce:
  - reconstructed model-visible history
  - previous user-turn model
  - rollback-aware user-turn baseline stack
- resume/fork seed the in-memory user-turn baseline stack from that replay result (instead of a separate `last_rollout_regular_turn_context_lookup(...)` parser)
- `thread_rollback(...)` now trims in-memory history/baseline state directly and refreshes `previous_model` from the in-memory baseline stack
- `ContextManager` now tracks user-turn baseline frames with `invalidated_by_following_compaction` so standalone/pre-turn compaction invalidation survives rollback
- `replace_history(..., None)` invalidates the top user-turn baseline (safeguard against stale diff reuse after history replacement)

## Why
The earlier patch fixed rollback correctness by rereading the rollout file after rollback, but that duplicated rollout parsing and made rollback depend on extra file I/O. This version keeps rollback metadata in memory and makes resume/fork hydration and rollback use the same reconstruction path.

## Validation
- `just fmt`
- `cargo test -p codex-core --all-features thread_rollback`
- `cargo test -p codex-core --all-features rollback_skips_only_user_turns`
- `cargo test -p codex-core --all-features record_initial_history_resumed`

## Notes
- No full `cargo test --all-features` run yet (targeted coverage only).