### PR TITLE
fix: make realtime conversation flake test order-insensitive

### DIFF
--- a/codex-rs/core/tests/suite/realtime_conversation.rs
+++ b/codex-rs/core/tests/suite/realtime_conversation.rs
@@ -120,7 +120,7 @@ async fn conversation_start_audio_text_close_round_trip() -> Result<()> {
             .as_deref()
             .expect("started session id should be present")
     );
-    let request_types = [
+    let mut request_types = [
         connection[1].body_json()["type"]
             .as_str()
             .expect("request type")
@@ -130,6 +130,7 @@ async fn conversation_start_audio_text_close_round_trip() -> Result<()> {
             .expect("request type")
             .to_string(),
     ];
+    request_types.sort();
     assert_eq!(
         request_types,
         [


### PR DESCRIPTION
## Why

`codex-core::all` has a flaky test, `suite::realtime_conversation::conversation_start_audio_text_close_round_trip`, that assumes a fixed ordering between `conversation.item.create` and `response.input_audio.delta` requests.

That ordering is not guaranteed: realtime text and audio input are forwarded through separate queues and a background task, so either request can be observed first while still being correct behavior.

## What Changed

- Updated the assertion in `codex-rs/core/tests/suite/realtime_conversation.rs` to compare the two observed request types order-independently.
- Kept the existing checks that `session.create` is sent first and that exactly two follow-up requests are recorded.

## Verification

- Re-ran `cargo test -p codex-core --test all conversation_start_audio_text_close_round_trip` 10 times locally.
