### PR TITLE
Make shell detection tests
     robust to Nix shell paths

### DIFF
--- a/codex-rs/core/src/shell.rs
+++ b/codex-rs/core/src/shell.rs
@@ -343,7 +343,6 @@ mod detect_shell_type_tests {
 #[cfg(unix)]
 mod tests {
     use super::*;
-    use std::path::Path;
     use std::path::PathBuf;
     use std::process::Command;
 
@@ -354,7 +353,7 @@ mod tests {
 
         let shell_path = zsh_shell.shell_path;
 
-        assert_eq!(shell_path, Path::new("/bin/zsh"));
+        assert_eq!(shell_path, std::path::Path::new("/bin/zsh"));
     }
 
     #[test]
@@ -364,7 +363,7 @@ mod tests {
 
         let shell_path = zsh_shell.shell_path;
 
-        assert_eq!(shell_path, Path::new("/bin/zsh"));
+        assert_eq!(shell_path, std::path::Path::new("/bin/zsh"));
     }
 
     #[test]
@@ -373,9 +372,7 @@ mod tests {
         let shell_path = bash_shell.shell_path;
 
         assert!(
-            shell_path == Path::new("/bin/bash")
-                || shell_path == Path::new("/usr/bin/bash")
-                || shell_path == Path::new("/usr/local/bin/bash"),
+            shell_path.file_name().and_then(|name| name.to_str()) == Some("bash"),
             "shell path: {shell_path:?}",
         );
     }
@@ -385,7 +382,7 @@ mod tests {
         let sh_shell = get_shell(ShellType::Sh, None).unwrap();
         let shell_path = sh_shell.shell_path;
         assert!(
-            shell_path == Path::new("/bin/sh") || shell_path == Path::new("/usr/bin/sh"),
+            shell_path.file_name().and_then(|name| name.to_str()) == Some("sh"),
             "shell path: {shell_path:?}",
         );
     }


### PR DESCRIPTION
## Summary
- Updated `codex-rs/core/src/shell.rs` tests for shell detection to stop asserting hardcoded shell paths.
- `detects_bash` and `detects_sh` now assert executable basenames (`bash`, `sh`) rather than `/bin/*`/`/usr/bin/*` absolute paths.
- This keeps behavior the same while avoiding failures in Nix environments where shells are resolved from `/nix/store/.../bin`.

## Testing
- `nix develop .#default --command sh -lc 'export PKG_CONFIG_PATH=/nix/store/6az1q591wwlgazzskngr6rl7gmhpyvnc-libcap-2.77-dev/lib/pkgconfig:/nix/store/fgm3pz8486ksh3f94629lpb7xjr2wjp7-openssl-3.6.0-dev/lib/pkgconfig:$PKG_CONFIG_PATH; export PKG_CONFIG_PATH_FOR_TARGET=$PKG_CONFIG_PATH; cd /home/alex/workspace/openai/codex/codex-rs && cargo test -p codex-core --lib detects_bash && cargo test -p codex-core --lib detects_sh'`

## Why
The two failing tests previously hardcoded fixed paths and failed under the Nix shell due to Nix-provided shell binary locations.

## Links
- Bug report / enhancement request: not publicly filed yet; this was reproduced in the local Nix environment.
