### PR TITLE
chore: use DotSlash-pinned zsh fixture for zsh-fork integration tests

### DIFF
--- a/codex-rs/app-server/tests/common/lib.rs
+++ b/codex-rs/app-server/tests/common/lib.rs
@@ -11,6 +11,7 @@ pub use auth_fixtures::ChatGptIdTokenClaims;
 pub use auth_fixtures::encode_id_token;
 pub use auth_fixtures::write_chatgpt_auth;
 use codex_app_server_protocol::JSONRPCResponse;
+use codex_utils_cargo_bin::find_resource;
 pub use config::write_mock_responses_config_toml;
 pub use core_test_support::format_with_current_shell;
 pub use core_test_support::format_with_current_shell_display;
@@ -36,9 +37,93 @@ pub use rollout::create_fake_rollout_with_source;
 pub use rollout::create_fake_rollout_with_text_elements;
 pub use rollout::rollout_path;
 use serde::de::DeserializeOwned;
+use std::path::Path;
+use std::path::PathBuf;
+use tokio::process::Command;
 
 pub fn to_response<T: DeserializeOwned>(response: JSONRPCResponse) -> anyhow::Result<T> {
     let value = serde_json::to_value(response.result)?;
     let codex_response = serde_json::from_value(value)?;
     Ok(codex_response)
+}
+
+pub struct TestZshExecutable {
+    pub path: PathBuf,
+    dotslash_cache_dir: Option<PathBuf>,
+}
+
+impl TestZshExecutable {
+    pub async fn new_mcp_process(&self, codex_home: &Path) -> anyhow::Result<McpProcess> {
+        if let Some(dotslash_cache_dir) = &self.dotslash_cache_dir {
+            let dotslash_cache = dotslash_cache_dir.to_string_lossy().into_owned();
+            return McpProcess::new_with_env(
+                codex_home,
+                &[("DOTSLASH_CACHE", Some(&dotslash_cache))],
+            )
+            .await;
+        }
+
+        McpProcess::new(codex_home).await
+    }
+}
+
+pub async fn find_dotslash_test_zsh() -> anyhow::Result<TestZshExecutable> {
+    let zsh = find_resource!("../suite/zsh")?;
+    if !zsh.is_file() {
+        anyhow::bail!("zsh fork test fixture not found: {}", zsh.display());
+    }
+
+    let dotslash_cache_dir = create_dotslash_cache_dir()?;
+    let status = Command::new("dotslash")
+        .arg("--")
+        .arg("fetch")
+        .arg(&zsh)
+        .env("DOTSLASH_CACHE", &dotslash_cache_dir)
+        .status()
+        .await?;
+    if !status.success() {
+        anyhow::bail!("dotslash fetch failed for {}: {status}", zsh.display());
+    }
+
+    let zsh = TestZshExecutable {
+        path: zsh,
+        dotslash_cache_dir: Some(dotslash_cache_dir),
+    };
+    if !supports_exec_wrapper_intercept(&zsh) {
+        anyhow::bail!(
+            "zsh fork test fixture does not support EXEC_WRAPPER intercepts: {}",
+            zsh.path.display()
+        );
+    }
+
+    eprintln!("using zsh path for zsh-fork test: {}", zsh.path.display());
+
+    Ok(zsh)
+}
+
+fn create_dotslash_cache_dir() -> anyhow::Result<PathBuf> {
+    let timestamp_nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)?
+        .as_nanos();
+    let dotslash_cache_dir = std::env::temp_dir().join(format!(
+        "codex-zsh-dotslash-cache-{}-{timestamp_nanos}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dotslash_cache_dir)?;
+    Ok(dotslash_cache_dir)
+}
+
+fn supports_exec_wrapper_intercept(zsh: &TestZshExecutable) -> bool {
+    let mut cmd = std::process::Command::new(&zsh.path);
+    cmd.arg("-fc")
+        .arg("/usr/bin/true")
+        .env("EXEC_WRAPPER", "/usr/bin/false");
+    if let Some(dotslash_cache_dir) = &zsh.dotslash_cache_dir {
+        cmd.env("DOTSLASH_CACHE", dotslash_cache_dir);
+    }
+    let status = cmd.status();
+    match status {
+        Ok(status) => !status.success(),
+        Err(_) => false,
+    }
 }

--- a/codex-rs/app-server/tests/suite/zsh
+++ b/codex-rs/app-server/tests/suite/zsh
@@ -1,0 +1,72 @@
+#!/usr/bin/env dotslash
+
+// This is an instance of the fork of zsh that we bundle with
+// https://www.npmjs.com/package/@openai/codex-shell-tool-mcp.
+// Fetching the prebuilt version via DotSlash makes it easier to write
+// integration tests for the MCP server.
+//
+// TODO(mbolin): Currently, we use a .tgz artifact that includes binaries for
+// multiple platforms, but we could save a bit of space by making arch-specific
+// artifacts available in the GitHub releases and referencing those here.
+{
+  "name": "codex-zsh",
+  "platforms": {
+    // macOS 13 builds (and therefore x86_64) were dropped in
+    // https://github.com/openai/codex/pull/7295, so we only provide an
+    // Apple Silicon build for now.
+    "macos-aarch64": {
+      "size": 53771483,
+      "hash": "blake3",
+      "digest": "ff664f63f5e1fa62762c9aff0aafa66cf196faf9b157f98ec98f59c152fc7bd3",
+      "format": "tar.gz",
+      "path": "package/vendor/aarch64-apple-darwin/zsh/macos-15/zsh",
+      "providers": [
+        {
+          "url": "https://github.com/openai/codex/releases/download/rust-v0.104.0/codex-shell-tool-mcp-npm-0.104.0.tgz"
+        },
+        {
+          "type": "github-release",
+          "repo": "openai/codex",
+          "tag": "rust-v0.104.0",
+          "name": "codex-shell-tool-mcp-npm-0.104.0.tgz"
+        }
+      ]
+    },
+    "linux-x86_64": {
+      "size": 53771483,
+      "hash": "blake3",
+      "digest": "ff664f63f5e1fa62762c9aff0aafa66cf196faf9b157f98ec98f59c152fc7bd3",
+      "format": "tar.gz",
+      "path": "package/vendor/x86_64-unknown-linux-musl/zsh/ubuntu-24.04/zsh",
+      "providers": [
+        {
+          "url": "https://github.com/openai/codex/releases/download/rust-v0.104.0/codex-shell-tool-mcp-npm-0.104.0.tgz"
+        },
+        {
+          "type": "github-release",
+          "repo": "openai/codex",
+          "tag": "rust-v0.104.0",
+          "name": "codex-shell-tool-mcp-npm-0.104.0.tgz"
+        }
+      ]
+    },
+    "linux-aarch64": {
+      "size": 53771483,
+      "hash": "blake3",
+      "digest": "ff664f63f5e1fa62762c9aff0aafa66cf196faf9b157f98ec98f59c152fc7bd3",
+      "format": "tar.gz",
+      "path": "package/vendor/aarch64-unknown-linux-musl/zsh/ubuntu-24.04/zsh",
+      "providers": [
+        {
+          "url": "https://github.com/openai/codex/releases/download/rust-v0.104.0/codex-shell-tool-mcp-npm-0.104.0.tgz"
+        },
+        {
+          "type": "github-release",
+          "repo": "openai/codex",
+          "tag": "rust-v0.104.0",
+          "name": "codex-shell-tool-mcp-npm-0.104.0.tgz"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This PR makes the app-server zsh-fork integration tests use a checked-in DotSlash fixture (`codex-rs/app-server/tests/suite/zsh`) instead of relying on CODEX_TEST_ZSH_PATH or whatever zsh happens to be installed locally.