### PR TITLE
feat(tui): add native composer keymap modes (standard/vim)

### DIFF
--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -1370,6 +1370,15 @@
           "description": "Enable animations (welcome screen, shimmer effects, spinners). Defaults to `true`.",
           "type": "boolean"
         },
+        "keymap": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/TuiKeymap"
+            }
+          ],
+          "default": "standard",
+          "description": "Composer input keymap mode.\n\n- `standard` (default): current non-modal editing behavior. - `vim`: vim-style modal editing in the composer input."
+        },
         "notification_method": {
           "allOf": [
             {
@@ -1408,6 +1417,13 @@
         }
       },
       "type": "object"
+    },
+    "TuiKeymap": {
+      "enum": [
+        "standard",
+        "vim"
+      ],
+      "type": "string"
     },
     "UriBasedFileOpener": {
       "oneOf": [

--- a/codex-rs/core/src/config/types.rs
+++ b/codex-rs/core/src/config/types.rs
@@ -639,6 +639,14 @@ impl fmt::Display for NotificationMethod {
     }
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, JsonSchema, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum TuiKeymap {
+    #[default]
+    Standard,
+    Vim,
+}
+
 /// Collection of settings that are specific to the TUI.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default, JsonSchema)]
 #[schemars(deny_unknown_fields)]
@@ -688,6 +696,13 @@ pub struct Tui {
     /// Use `/theme` in the TUI or see `$CODEX_HOME/themes` for custom themes.
     #[serde(default)]
     pub theme: Option<String>,
+
+    /// Composer input keymap mode.
+    ///
+    /// - `standard` (default): current non-modal editing behavior.
+    /// - `vim`: vim-style modal editing in the composer input.
+    #[serde(default)]
+    pub keymap: TuiKeymap,
 }
 
 const fn default_true() -> bool {

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -3690,13 +3690,13 @@ impl ChatComposer {
                         show_shortcuts_hint,
                         show_queue_hint,
                     );
-                }
-
-                // Render vim mode indicator at the far left of the footer.
-                if let Some(label) = self.textarea.vim_mode_label() {
-                    let vim_line = Line::from(format!("-- {label} --")).dim();
-                    let area = inset_footer_hint_area(hint_rect);
-                    vim_line.render(area, buf);
+                    // Render vim mode indicator only in the default footer path so it does not
+                    // obscure flash/status/override content.
+                    if let Some(label) = self.textarea.vim_mode_label() {
+                        let vim_line = Line::from(format!("-- {label} --")).dim();
+                        let area = inset_footer_hint_area(hint_rect);
+                        vim_line.render(area, buf);
+                    }
                 }
 
                 if show_right && let Some(line) = &right_line {

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -109,6 +109,12 @@
 //! edits and renders a placeholder prompt instead of the editable textarea. This is part of the
 //! overall state machine, since it affects which transitions are even possible from a given UI
 //! state.
+//!
+//! # Edit Modes
+//!
+//! The composer supports Emacs-style input (default) and Vim-style modal input. Vim mode uses the
+//! textarea's normal/insert states; paste-burst detection is disabled while in Vim normal mode so
+//! rapid command keystrokes are not buffered as paste.
 use crate::bottom_pane::footer::mode_indicator_line;
 use crate::bottom_pane::selection_popup_common::truncate_line_with_ellipsis_if_overflow;
 use crate::key_hint;
@@ -764,6 +770,12 @@ impl ChatComposer {
         self.relabel_attached_images_and_update_placeholders();
         self.textarea.set_cursor(self.textarea.text().len());
         self.sync_popups();
+    }
+
+    pub(crate) fn set_vim_enabled(&mut self, enabled: bool) {
+        self.textarea.set_vim_enabled(enabled);
+        self.paste_burst.clear_after_explicit_paste();
+        self.footer_mode = reset_mode_after_activity(self.footer_mode);
     }
 
     pub(crate) fn current_text_with_pending(&self) -> String {
@@ -2511,7 +2523,7 @@ impl ChatComposer {
             return (InputResult::None, true);
         }
         if key_event.code == KeyCode::Esc {
-            if self.is_empty() {
+            if self.is_empty() && !self.textarea.is_vim_insert() {
                 let next_mode = esc_hint_mode(self.footer_mode, self.is_task_running);
                 if next_mode != self.footer_mode {
                     self.footer_mode = next_mode;
@@ -2669,7 +2681,7 @@ impl ChatComposer {
         } = input
         {
             let has_ctrl_or_alt = has_ctrl_or_alt(modifiers);
-            if !has_ctrl_or_alt && !self.disable_paste_burst {
+            if !has_ctrl_or_alt && !self.disable_paste_burst && self.textarea.allows_paste_burst() {
                 // Non-ASCII characters (e.g., from IMEs) can arrive in quick bursts, so avoid
                 // holding the first char while still allowing burst detection for paste input.
                 if !ch.is_ascii() {
@@ -3680,6 +3692,13 @@ impl ChatComposer {
                     );
                 }
 
+                // Render vim mode indicator at the far left of the footer.
+                if let Some(label) = self.textarea.vim_mode_label() {
+                    let vim_line = Line::from(format!("-- {label} --")).dim();
+                    let area = inset_footer_hint_area(hint_rect);
+                    vim_line.render(area, buf);
+                }
+
                 if show_right && let Some(line) = &right_line {
                     render_context_right(hint_rect, buf, line);
                 }
@@ -3693,10 +3712,12 @@ impl ChatComposer {
                 .render_ref(remote_images_rect, buf);
         }
         if !textarea_rect.is_empty() {
-            let prompt = if self.input_enabled {
-                "›".bold()
-            } else {
+            let prompt = if !self.input_enabled {
                 "›".dim()
+            } else if self.textarea.vim_mode_label().is_some() && !self.textarea.is_vim_insert() {
+                "·".bold()
+            } else {
+                "›".bold()
             };
             buf.set_span(
                 textarea_rect.x - LIVE_PREFIX_COLS,

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -297,6 +297,11 @@ impl BottomPane {
         self.request_redraw();
     }
 
+    pub(crate) fn set_vim_enabled(&mut self, enabled: bool) {
+        self.composer.set_vim_enabled(enabled);
+        self.request_redraw();
+    }
+
     pub fn status_widget(&self) -> Option<&StatusIndicatorWidget> {
         self.status.as_ref()
     }

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -15,6 +15,7 @@ pub enum SlashCommand {
     Model,
     Approvals,
     Permissions,
+    Keymap,
     #[strum(serialize = "setup-default-sandbox")]
     ElevateSandbox,
     #[strum(serialize = "sandbox-add-read-dir")]
@@ -90,6 +91,7 @@ impl SlashCommand {
             SlashCommand::Agent => "switch the active agent thread",
             SlashCommand::Approvals => "choose what Codex is allowed to do",
             SlashCommand::Permissions => "choose what Codex is allowed to do",
+            SlashCommand::Keymap => "switch composer keymap: /keymap standard|vim",
             SlashCommand::ElevateSandbox => "set up elevated agent sandbox",
             SlashCommand::SandboxReadRoot => {
                 "let sandbox read a directory: /sandbox-add-read-dir <absolute_path>"
@@ -117,6 +119,7 @@ impl SlashCommand {
                 | SlashCommand::Rename
                 | SlashCommand::Plan
                 | SlashCommand::SandboxReadRoot
+                | SlashCommand::Keymap
         )
     }
 
@@ -157,6 +160,7 @@ impl SlashCommand {
             | SlashCommand::Exit => true,
             SlashCommand::Rollout => true,
             SlashCommand::TestApproval => true,
+            SlashCommand::Keymap => true,
             SlashCommand::Collab => true,
             SlashCommand::Agent => true,
             SlashCommand::Statusline => false,
@@ -179,4 +183,28 @@ pub fn built_in_slash_commands() -> Vec<(&'static str, SlashCommand)> {
         .filter(|command| command.is_visible())
         .map(|c| (c.command(), c))
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn keymap_command_metadata_is_wired() {
+        assert_eq!(SlashCommand::Keymap.command(), "keymap");
+        assert!(SlashCommand::Keymap.supports_inline_args());
+        assert!(SlashCommand::Keymap.available_during_task());
+        assert!(
+            SlashCommand::Keymap
+                .description()
+                .contains("/keymap standard|vim")
+        );
+    }
+
+    #[test]
+    fn built_in_slash_commands_include_keymap() {
+        let commands = built_in_slash_commands();
+        assert!(commands.contains(&("keymap", SlashCommand::Keymap)));
+    }
 }

--- a/docs/tui-chat-composer.md
+++ b/docs/tui-chat-composer.md
@@ -38,6 +38,17 @@ The solution is to detect paste-like _bursts_ and buffer them into a single expl
 2. **Paste burst**: transient detection state for non-bracketed paste.
    - implemented by `PasteBurst`
 
+`ChatComposer` also coordinates the textarea input mode:
+
+- **Vim mode**: modal editing (normal/insert). While in Vim normal mode, paste-burst detection
+  is disabled so rapid command keystrokes are never buffered as paste.
+- Slash command `/keymap vim` enables vim mode in the TUI composer; `/keymap standard` restores
+  the default keymap. The `/keymap` toggle is session-scoped: it does **not** persist across
+  restarts. To enable vim mode permanently, set `tui.keymap = "vim"` in your config file.
+- Scope note: this keymap support is for the in-app composer input only; it does not change key
+  behavior in external editors launched for message editing.
+- `/keymap` can be toggled while a task is running.
+
 ### Key event routing
 
 `ChatComposer::handle_key_event` dispatches based on `active_popup`:


### PR DESCRIPTION
## What
- Add native Vim-style modal editing for the in-app TUI composer input.
- Keep current behavior as default (`standard`), with opt-in Vim keymap.
- Add persistent config:
  - `[tui] keymap = "standard" | "vim"` (default: `standard`)
- Add runtime command:
  - `/keymap vim`
  - `/keymap standard`
- Add mode indication in composer UI (footer and prompt glyph changes in normal mode).
- Update config schema and docs.

## Why
- Current Vim workflows rely on external editor flow for modal editing, which is slower for quick turns.
- Native modal editing in the composer removes context switches and aligns with terminal-first usage.
- Keeping `standard` as default avoids regressions for existing users and preserves backward compatibility.

## Scope
- In scope: in-app composer input behavior only.
- Out of scope: external editor behavior and full Vim parity.

## How
- Introduce `TuiKeymap` config enum and wire it through runtime config:
  - `standard` (default)
  - `vim`
- Initialize composer keymap from config on widget setup.
- Add `/keymap` command parsing with explicit usage errors.
- Implement modal editing in `TextArea`:
  - modes: `NORMAL`, `INSERT`, `REPLACE-CHAR`
  - motions/operators for core editing (`h/j/k/l`, `w/b/e`, `0/^/$`, `d/c/y`, `x`, `p`, `u`, etc.)
  - linewise register semantics for `yy`/`dd` with `p`
- Keep paste-burst logic safe in Vim mode:
  - enabled in insert mode
  - disabled in normal mode

## Human + AI Calibration Process
- We started from issue-driven intent and constrained the first version to composer-only behavior.
- We aligned on compatibility defaults (`standard` default, `vim` opt-in) before coding.
- During implementation, we iterated through compiler/test feedback loops:
  - fixed exhaustive enum/match gaps
  - corrected linewise paste semantics for `yy` + `p`
  - removed hidden dependency in `/keymap` arg handling
- We ran targeted tests first, then full crate verification to ensure no broad regressions.
- We documented explicit non-goals and scope boundaries to reduce review ambiguity.

## Reviewer Notes
- Default user behavior remains unchanged unless `tui.keymap = "vim"` is set or `/keymap vim` is used.
- `/keymap` usage errors are explicit (`Usage: /keymap standard|vim`).
- This PR intentionally does not claim full Vim feature parity.

