### PR TITLE
[WIP] feat(core) SandboxPolicy::Custom

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -885,6 +885,9 @@ impl From<codex_protocol::protocol::SandboxPolicy> for SandboxPolicy {
                 exclude_tmpdir_env_var,
                 exclude_slash_tmp,
             },
+            codex_protocol::protocol::SandboxPolicy::Custom { .. } => {
+                panic!("SandboxPolicy::Custom is internal-only and not supported in app-server v2")
+            }
         }
     }
 }

--- a/codex-rs/config/src/config_requirements.rs
+++ b/codex-rs/config/src/config_requirements.rs
@@ -451,6 +451,13 @@ impl TryFrom<ConfigRequirementsWithSources> for ConfigRequirements {
                         SandboxPolicy::ExternalSandbox { .. } => {
                             SandboxModeRequirement::ExternalSandbox
                         }
+                        SandboxPolicy::Custom { writable_roots, .. } => {
+                            if writable_roots.is_empty() {
+                                SandboxModeRequirement::ReadOnly
+                            } else {
+                                SandboxModeRequirement::WorkspaceWrite
+                            }
+                        }
                     };
                     if modes.contains(&mode) {
                         Ok(())

--- a/codex-rs/core/src/exec_policy.rs
+++ b/codex-rs/core/src/exec_policy.rs
@@ -493,7 +493,9 @@ pub fn render_decision_for_unmatched_command(
                     // command has not been flagged as dangerous.
                     Decision::Allow
                 }
-                SandboxPolicy::ReadOnly { .. } | SandboxPolicy::WorkspaceWrite { .. } => {
+                SandboxPolicy::ReadOnly { .. }
+                | SandboxPolicy::WorkspaceWrite { .. }
+                | SandboxPolicy::Custom { .. } => {
                     // In restricted sandboxes (ReadOnly/WorkspaceWrite), do not prompt for
                     // non‑escalated, non‑dangerous commands — let the sandbox enforce
                     // restrictions (e.g., block network/write) without a user prompt.
@@ -511,7 +513,9 @@ pub fn render_decision_for_unmatched_command(
                 // by `prompt_is_rejected_by_policy`.
                 Decision::Allow
             }
-            SandboxPolicy::ReadOnly { .. } | SandboxPolicy::WorkspaceWrite { .. } => {
+            SandboxPolicy::ReadOnly { .. }
+            | SandboxPolicy::WorkspaceWrite { .. }
+            | SandboxPolicy::Custom { .. } => {
                 if sandbox_permissions.requires_escalated_permissions() {
                     Decision::Prompt
                 } else {

--- a/codex-rs/core/src/safety.rs
+++ b/codex-rs/core/src/safety.rs
@@ -133,7 +133,9 @@ fn is_write_patch_constrained_to_writable_paths(
         SandboxPolicy::DangerFullAccess | SandboxPolicy::ExternalSandbox { .. } => {
             return true;
         }
-        SandboxPolicy::WorkspaceWrite { .. } => sandbox_policy.get_writable_roots_with_cwd(cwd),
+        SandboxPolicy::WorkspaceWrite { .. } | SandboxPolicy::Custom { .. } => {
+            sandbox_policy.get_writable_roots_with_cwd(cwd)
+        }
     };
 
     // Normalize a path by removing `.` and resolving `..` without touching the

--- a/codex-rs/core/src/tools/registry.rs
+++ b/codex-rs/core/src/tools/registry.rs
@@ -310,6 +310,7 @@ fn sandbox_policy_tag(policy: &SandboxPolicy) -> &'static str {
     match policy {
         SandboxPolicy::ReadOnly { .. } => "read-only",
         SandboxPolicy::WorkspaceWrite { .. } => "workspace-write",
+        SandboxPolicy::Custom { .. } => "custom",
         SandboxPolicy::DangerFullAccess => "danger-full-access",
         SandboxPolicy::ExternalSandbox { .. } => "external-sandbox",
     }

--- a/codex-rs/protocol/src/models.rs
+++ b/codex-rs/protocol/src/models.rs
@@ -321,6 +321,14 @@ impl DeveloperInstructions {
                 let roots = sandbox_policy.get_writable_roots_with_cwd(cwd);
                 (SandboxMode::WorkspaceWrite, Some(roots))
             }
+            SandboxPolicy::Custom { .. } => {
+                let roots = sandbox_policy.get_writable_roots_with_cwd(cwd);
+                if roots.is_empty() {
+                    (SandboxMode::ReadOnly, None)
+                } else {
+                    (SandboxMode::WorkspaceWrite, Some(roots))
+                }
+            }
         };
 
         DeveloperInstructions::from_permissions_with_network(

--- a/codex-rs/tui/src/additional_dirs.rs
+++ b/codex-rs/tui/src/additional_dirs.rs
@@ -16,7 +16,9 @@ pub fn add_dir_warning_message(
         SandboxPolicy::WorkspaceWrite { .. }
         | SandboxPolicy::DangerFullAccess
         | SandboxPolicy::ExternalSandbox { .. } => None,
-        SandboxPolicy::ReadOnly { .. } => Some(format_warning(additional_dirs)),
+        SandboxPolicy::ReadOnly { .. } | SandboxPolicy::Custom { .. } => {
+            Some(format_warning(additional_dirs))
+        }
     }
 }
 

--- a/codex-rs/tui/src/status/card.rs
+++ b/codex-rs/tui/src/status/card.rs
@@ -202,6 +202,13 @@ impl StatusHistoryCell {
                 ..
             } => "workspace-write with network access".to_string(),
             SandboxPolicy::WorkspaceWrite { .. } => "workspace-write".to_string(),
+            SandboxPolicy::Custom { network_access, .. } => {
+                if matches!(network_access, NetworkAccess::Enabled) {
+                    "custom sandbox with network access".to_string()
+                } else {
+                    "custom sandbox".to_string()
+                }
+            }
             SandboxPolicy::ExternalSandbox { network_access } => {
                 if matches!(network_access, NetworkAccess::Enabled) {
                     "external-sandbox (network access enabled)".to_string()

--- a/codex-rs/windows-sandbox-rs/src/command_runner_win.rs
+++ b/codex-rs/windows-sandbox-rs/src/command_runner_win.rs
@@ -140,6 +140,13 @@ pub fn main() -> Result<()> {
             SandboxPolicy::WorkspaceWrite { .. } => {
                 create_workspace_write_token_with_caps_from(base, &cap_psids)
             }
+            SandboxPolicy::Custom { writable_roots, .. } => {
+                if writable_roots.is_empty() {
+                    create_readonly_token_with_caps_from(base, &cap_psids)
+                } else {
+                    create_workspace_write_token_with_caps_from(base, &cap_psids)
+                }
+            }
             SandboxPolicy::DangerFullAccess | SandboxPolicy::ExternalSandbox { .. } => {
                 unreachable!()
             }

--- a/codex-rs/windows-sandbox-rs/src/elevated_impl.rs
+++ b/codex-rs/windows-sandbox-rs/src/elevated_impl.rs
@@ -256,6 +256,22 @@ mod windows_impl {
                     crate::cap::workspace_cap_sid_for_cwd(codex_home, cwd)?,
                 ],
             ),
+            SandboxPolicy::Custom { writable_roots, .. } => {
+                if writable_roots.is_empty() {
+                    (
+                        unsafe { convert_string_sid_to_sid(&caps.readonly).unwrap() },
+                        vec![caps.readonly.clone()],
+                    )
+                } else {
+                    (
+                        unsafe { convert_string_sid_to_sid(&caps.workspace).unwrap() },
+                        vec![
+                            caps.workspace.clone(),
+                            crate::cap::workspace_cap_sid_for_cwd(codex_home, cwd)?,
+                        ],
+                    )
+                }
+            }
             SandboxPolicy::DangerFullAccess | SandboxPolicy::ExternalSandbox { .. } => {
                 unreachable!("DangerFullAccess handled above")
             }

--- a/codex-rs/windows-sandbox-rs/src/setup_orchestrator.rs
+++ b/codex-rs/windows-sandbox-rs/src/setup_orchestrator.rs
@@ -264,10 +264,20 @@ pub(crate) fn gather_read_roots(command_cwd: &Path, policy: &SandboxPolicy) -> V
         roots.push(PathBuf::from(up));
     }
     roots.push(command_cwd.to_path_buf());
-    if let SandboxPolicy::WorkspaceWrite { writable_roots, .. } = policy {
-        for root in writable_roots {
-            roots.push(root.to_path_buf());
+    match policy {
+        SandboxPolicy::WorkspaceWrite { writable_roots, .. } => {
+            for root in writable_roots {
+                roots.push(root.to_path_buf());
+            }
         }
+        SandboxPolicy::Custom { writable_roots, .. } => {
+            for root in writable_roots {
+                roots.push(root.root.to_path_buf());
+            }
+        }
+        SandboxPolicy::ReadOnly { .. }
+        | SandboxPolicy::DangerFullAccess
+        | SandboxPolicy::ExternalSandbox { .. } => {}
     }
     canonical_existing(&roots)
 }


### PR DESCRIPTION
NOT READY FOR REVIEW OR MERGE AT THIS TIME

## Summary
As we move towards fine-grained Permissions control, we need a more expressive SandboxPolicy that can encapsulate a more specific set of controls. This PR is an attempt to start to define an internal mechanism for this, so we can iterate before fully exposing a set of APIs (e.g. in config.toml).

## Testing
- [x] Added unit tests
- [ ] TODO: integration tests