### PR TITLE
app-server: experimental thread listener cleanup and archive state teardown

### DIFF
--- a/codex-rs/core/src/features.rs
+++ b/codex-rs/core/src/features.rs
@@ -139,6 +139,8 @@ pub enum Feature {
     Personality,
     /// Prevent idle system sleep while a turn is actively running.
     PreventIdleSleep,
+    /// Clear app-server thread listeners when the last subscriber disconnects.
+    ThreadListenerCleanup,
     /// Use the Responses API WebSocket transport for OpenAI by default.
     ResponsesWebsockets,
     /// Enable Responses API websocket v2 mode.
@@ -637,6 +639,16 @@ pub const FEATURES: &[FeatureSpec] = &[
             }
         } else {
             Stage::UnderDevelopment
+        },
+        default_enabled: false,
+    },
+    FeatureSpec {
+        id: Feature::ThreadListenerCleanup,
+        key: "thread_listener_cleanup",
+        stage: Stage::Experimental {
+            name: "Thread listener cleanup",
+            menu_description: "Release app-server thread listeners when no clients are subscribed.",
+            announcement: "NEW: Thread listener cleanup can reduce idle memory usage in long app sessions. Enable in /experimental and restart Codex.",
         },
         default_enabled: false,
     },


### PR DESCRIPTION
## Summary
- add experimental feature flag `features.thread_listener_cleanup` (default `false`)
- when enabled, clear per-thread listener state when the last subscriber disconnects or unsubscribes
- always clear `ThreadStateManager` state during archive teardown, even if the thread was already removed from `ThreadManager`
- skip event JSON serialization work when no subscribers are attached

## Scope and relationship
- complementary to #12373 (`retain thread listener across disconnects`): default behavior remains unchanged
- adds a controlled `/experimental` option for high-memory-pressure sessions where listener retention may be costly
- focused on app-server in-memory retention only (does not attempt MCP process lifecycle cleanup in the desktop app process)

## Why
- targets retained thread/listener state and background memory pressure patterns reported in app sessions with many threads (including my local 5+ concurrent thread usage)
- low risk: default behavior is unchanged unless experimental flag is enabled

Fixes: #12491
Related: #12414

## Local validation
- `just fmt`
- did not run full test/build locally in this pass
