### PR TITLE
app-server: fallback interrupt to clean background terminals when idle

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/turn_interrupt.rs
+++ b/codex-rs/app-server/tests/suite/v2/turn_interrupt.rs
@@ -120,6 +120,47 @@ async fn turn_interrupt_aborts_running_turn() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn turn_interrupt_without_active_turn_returns_immediately() -> Result<()> {
+    let tmp = TempDir::new()?;
+    let codex_home = tmp.path().join("codex_home");
+    std::fs::create_dir(&codex_home)?;
+
+    let server = create_mock_responses_server_sequence(Vec::new()).await;
+    create_config_toml(&codex_home, &server.uri())?;
+
+    let mut mcp = McpProcess::new(&codex_home).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let thread_req = mcp
+        .send_thread_start_request(ThreadStartParams {
+            model: Some("mock-model".to_string()),
+            ..Default::default()
+        })
+        .await?;
+    let thread_resp: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(thread_req)),
+    )
+    .await??;
+    let ThreadStartResponse { thread, .. } = to_response::<ThreadStartResponse>(thread_resp)?;
+
+    let interrupt_id = mcp
+        .send_turn_interrupt_request(TurnInterruptParams {
+            thread_id: thread.id,
+            turn_id: "turn-not-running".to_string(),
+        })
+        .await?;
+    let interrupt_resp: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(interrupt_id)),
+    )
+    .await??;
+    let _resp: TurnInterruptResponse = to_response::<TurnInterruptResponse>(interrupt_resp)?;
+
+    Ok(())
+}
+
 // Helper to create a config.toml pointing at the mock model server.
 fn create_config_toml(codex_home: &std::path::Path, server_uri: &str) -> std::io::Result<()> {
     let config_toml = codex_home.join("config.toml");


### PR DESCRIPTION
## Summary
- update v1 `interruptConversation` and v2 `turn/interrupt` handling to detect when no turn is in progress
- in the no-active-turn path, clean background terminals and return a response immediately instead of waiting for a `TurnAborted` event
- add regression tests for both APIs so idle interrupt requests do not hang

## Scope
- intentionally narrow to stop/no-op behavior from #12478
- does not change experimental API gating or fuzzy file search behavior

## Why
- addresses app behavior where pressing Stop can appear to do nothing when no turn is currently active but background terminals are still present

Fixes: #12478
Related: #12491

## Local validation
- `just fmt`
- did not run full test/build locally in this pass
