### PR TITLE
feat(hooks): add `client` field to notify hook payload

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -4779,6 +4779,7 @@ pub(crate) async fn run_turn(
                             session_id: sess.conversation_id,
                             cwd: turn_context.cwd.clone(),
                             triggered_at: chrono::Utc::now(),
+                            client: session_source_to_client_string(&turn_context.session_source),
                             hook_event: HookEvent::AfterAgent {
                                 event: HookEventAfterAgent {
                                     thread_id: sess.conversation_id,
@@ -6088,6 +6089,19 @@ pub(super) fn get_last_assistant_message_from_turn(responses: &[ResponseItem]) -
 }
 
 use crate::memories::prompts::build_memory_tool_developer_instructions;
+
+/// Convert a [`SessionSource`] into the string used in hook payloads.
+pub(crate) fn session_source_to_client_string(source: &SessionSource) -> String {
+    match source {
+        SessionSource::Cli => "cli".to_string(),
+        SessionSource::VSCode => "vscode".to_string(),
+        SessionSource::Exec => "exec".to_string(),
+        SessionSource::Mcp => "mcp".to_string(),
+        SessionSource::SubAgent(_) => "sub-agent".to_string(),
+        SessionSource::Unknown => "unknown".to_string(),
+    }
+}
+
 #[cfg(test)]
 pub(crate) use tests::make_session_and_context;
 #[cfg(test)]

--- a/codex-rs/core/src/tools/registry.rs
+++ b/codex-rs/core/src/tools/registry.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use std::time::Instant;
 
 use crate::client_common::tools::ToolSpec;
+use crate::codex::session_source_to_client_string;
 use crate::features::Feature;
 use crate::function_tool::FunctionCallError;
 use crate::memories::usage::emit_metric_for_tool_read;
@@ -380,6 +381,7 @@ async fn dispatch_after_tool_use_hook(
             session_id: session.conversation_id,
             cwd: turn.cwd.clone(),
             triggered_at: chrono::Utc::now(),
+            client: session_source_to_client_string(&turn.session_source),
             hook_event: HookEvent::AfterToolUse {
                 event: HookEventAfterToolUse {
                     turn_id: turn.sub_id.clone(),

--- a/codex-rs/hooks/src/registry.rs
+++ b/codex-rs/hooks/src/registry.rs
@@ -108,6 +108,7 @@ mod tests {
                 .with_ymd_and_hms(2025, 1, 1, 0, 0, 0)
                 .single()
                 .expect("valid timestamp"),
+            client: "cli".to_string(),
             hook_event: HookEvent::AfterAgent {
                 event: HookEventAfterAgent {
                     thread_id: ThreadId::new(),
@@ -176,6 +177,7 @@ mod tests {
                 .with_ymd_and_hms(2025, 1, 1, 0, 0, 0)
                 .single()
                 .expect("valid timestamp"),
+            client: "cli".to_string(),
             hook_event: HookEvent::AfterToolUse {
                 event: HookEventAfterToolUse {
                     turn_id: format!("turn-{label}"),

--- a/codex-rs/hooks/src/types.rs
+++ b/codex-rs/hooks/src/types.rs
@@ -67,6 +67,8 @@ pub struct HookPayload {
     pub cwd: PathBuf,
     #[serde(serialize_with = "serialize_triggered_at")]
     pub triggered_at: DateTime<Utc>,
+    /// Which client surface initiated the session (e.g. "cli", "vscode").
+    pub client: String,
     pub hook_event: HookEvent,
 }
 
@@ -185,6 +187,7 @@ mod tests {
                 .with_ymd_and_hms(2025, 1, 1, 0, 0, 0)
                 .single()
                 .expect("valid timestamp"),
+            client: "cli".to_string(),
             hook_event: HookEvent::AfterAgent {
                 event: HookEventAfterAgent {
                     thread_id,
@@ -200,6 +203,7 @@ mod tests {
             "session_id": session_id.to_string(),
             "cwd": "tmp",
             "triggered_at": "2025-01-01T00:00:00Z",
+            "client": "cli",
             "hook_event": {
                 "event_type": "after_agent",
                 "thread_id": thread_id.to_string(),
@@ -222,6 +226,7 @@ mod tests {
                 .with_ymd_and_hms(2025, 1, 1, 0, 0, 0)
                 .single()
                 .expect("valid timestamp"),
+            client: "cli".to_string(),
             hook_event: HookEvent::AfterToolUse {
                 event: HookEventAfterToolUse {
                     turn_id: "turn-2".to_string(),
@@ -254,6 +259,7 @@ mod tests {
             "session_id": session_id.to_string(),
             "cwd": "tmp",
             "triggered_at": "2025-01-01T00:00:00Z",
+            "client": "cli",
             "hook_event": {
                 "event_type": "after_tool_use",
                 "turn_id": "turn-2",


### PR DESCRIPTION
## Summary

The notify hook payload currently doesn't indicate which client (CLI, VS Code extension, macOS app) triggered the event. This makes it difficult for notification tools like [codex-notify](https://github.com/paultendo/codex-notify) to activate the correct application when a user clicks a notification.

- Adds a `client` field to both the legacy notify JSON payload and the modern `HookPayload` struct
- Populated from the existing `SessionSource` on the session — no new state needed
- Field values: `"cli"`, `"vscode"`, `"exec"`, `"mcp"`, `"sub-agent"`, `"unknown"`

Wire format after this change:

```json
{
  "type": "agent-turn-complete",
  "thread-id": "...",
  "turn-id": "...",
  "cwd": "/path/to/project",
  "client": "cli",
  "input-messages": ["..."],
  "last-assistant-message": "..."
}
```

## Motivation

Users of the Codex CLI, VS Code extension, and macOS app all share the same `~/.codex/config.toml` and notify hook. External notification tools need to know which client surface triggered the notification to activate the correct application on click (e.g., VS Code vs. the Codex macOS app).

The `SessionSource` enum already distinguishes these clients internally — this PR simply exposes that information in the hook payload.

## Test plan

- [x] `cargo build -p codex-hooks` — compiles cleanly
- [x] `cargo test -p codex-hooks` — all 15 tests pass
- [x] `cargo check -p codex-core` — compiles cleanly
- [x] `cargo clippy -p codex-hooks` — no warnings
- [ ] Verify end-to-end: configure a notify hook, run a task from CLI and VS Code extension, confirm the `client` field is present and correct in both cases