### PR TITLE
fix(collab): mark wait with empty statuses as failed

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol/thread_history.rs
+++ b/codex-rs/app-server-protocol/src/protocol/thread_history.rs
@@ -556,7 +556,8 @@ impl ThreadHistoryBuilder {
         &mut self,
         payload: &codex_protocol::protocol::CollabWaitingEndEvent,
     ) {
-        let status = if payload
+        let status = if payload.statuses.is_empty()
+            || payload
             .statuses
             .values()
             .any(|status| matches!(status, AgentStatus::Errored(_) | AgentStatus::NotFound))
@@ -2031,6 +2032,45 @@ mod tests {
                 )]
                 .into_iter()
                 .collect(),
+            }
+        );
+    }
+
+    #[test]
+    fn reconstructs_collab_wait_item_with_empty_statuses_as_failed() {
+        let events = vec![
+            EventMsg::UserMessage(UserMessageEvent {
+                message: "wait team".into(),
+                images: None,
+                text_elements: Vec::new(),
+                local_images: Vec::new(),
+            }),
+            EventMsg::CollabWaitingEnd(codex_protocol::protocol::CollabWaitingEndEvent {
+                sender_thread_id: ThreadId::try_from("00000000-0000-0000-0000-000000000001")
+                    .expect("valid sender thread id"),
+                call_id: "wait-1".into(),
+                agent_statuses: Vec::new(),
+                statuses: HashMap::new(),
+            }),
+        ];
+
+        let items = events
+            .into_iter()
+            .map(RolloutItem::EventMsg)
+            .collect::<Vec<_>>();
+        let turns = build_turns_from_rollout_items(&items);
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].items.len(), 2);
+        assert_eq!(
+            turns[0].items[1],
+            ThreadItem::CollabAgentToolCall {
+                id: "wait-1".into(),
+                tool: CollabAgentTool::Wait,
+                status: CollabAgentToolCallStatus::Failed,
+                sender_thread_id: "00000000-0000-0000-0000-000000000001".into(),
+                receiver_thread_ids: Vec::new(),
+                prompt: None,
+                agents_states: HashMap::new(),
             }
         );
     }

--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -608,13 +608,15 @@ pub(crate) async fn apply_bespoke_event_handling(
                 .await;
         }
         EventMsg::CollabWaitingEnd(end_event) => {
-            let status = if end_event.statuses.values().any(|status| {
-                matches!(
-                    status,
-                    codex_protocol::protocol::AgentStatus::Errored(_)
-                        | codex_protocol::protocol::AgentStatus::NotFound
-                )
-            }) {
+            let status = if end_event.statuses.is_empty()
+                || end_event.statuses.values().any(|status| {
+                    matches!(
+                        status,
+                        codex_protocol::protocol::AgentStatus::Errored(_)
+                            | codex_protocol::protocol::AgentStatus::NotFound
+                    )
+                })
+            {
                 V2CollabToolCallStatus::Failed
             } else {
                 V2CollabToolCallStatus::Completed

--- a/codex-rs/exec/src/event_processor_with_jsonl_output.rs
+++ b/codex-rs/exec/src/event_processor_with_jsonl_output.rs
@@ -500,7 +500,7 @@ impl EventProcessorWithJsonOutput {
     }
 
     fn handle_collab_wait_end(&mut self, ev: &CollabWaitingEndEvent) -> Vec<ThreadEvent> {
-        let status = if ev.statuses.values().any(is_collab_failure) {
+        let status = if ev.statuses.is_empty() || ev.statuses.values().any(is_collab_failure) {
             CollabToolCallStatus::Failed
         } else {
             CollabToolCallStatus::Completed

--- a/codex-rs/exec/tests/event_processor_with_json_output.rs
+++ b/codex-rs/exec/tests/event_processor_with_json_output.rs
@@ -666,6 +666,39 @@ fn collab_wait_end_without_begin_synthesizes_failed_item() {
 }
 
 #[test]
+fn collab_wait_end_with_empty_statuses_is_failed() {
+    let mut ep = EventProcessorWithJsonOutput::new(None);
+    let sender_thread_id = ThreadId::from_string("67e55044-10b1-426f-9247-bb680e5fe0c8").unwrap();
+
+    let end = event(
+        "c4",
+        EventMsg::CollabWaitingEnd(CollabWaitingEndEvent {
+            sender_thread_id,
+            call_id: "call-12".to_string(),
+            agent_statuses: Vec::new(),
+            statuses: std::collections::HashMap::new(),
+        }),
+    );
+    let events = ep.collect_thread_events(&end);
+    assert_eq!(
+        events,
+        vec![ThreadEvent::ItemCompleted(ItemCompletedEvent {
+            item: ThreadItem {
+                id: "item_0".to_string(),
+                details: ThreadItemDetails::CollabToolCall(CollabToolCallItem {
+                    tool: CollabTool::Wait,
+                    sender_thread_id: sender_thread_id.to_string(),
+                    receiver_thread_ids: Vec::new(),
+                    prompt: None,
+                    agents_states: std::collections::HashMap::new(),
+                    status: CollabToolCallStatus::Failed,
+                }),
+            },
+        })]
+    );
+}
+
+#[test]
 fn plan_update_after_complete_starts_new_todo_list_with_new_id() {
     let mut ep = EventProcessorWithJsonOutput::new(None);
 


### PR DESCRIPTION
## Summary
Treat `CollabWaitingEnd` events with an empty `statuses` map as `Failed` instead of `Completed`.

This aligns wait-end behavior across thread history reconstruction, app-server notifications, and JSON output processing.

### Changes
- `app-server-protocol/thread_history`: `handle_collab_waiting_end` now fails when `statuses` is empty.
- `app-server/bespoke_event_handling`: same failure rule for emitted v2 items.
- `exec/event_processor_with_jsonl_output`: same failure rule for JSON output.
- Added regression tests:
  - `reconstructs_collab_wait_item_with_empty_statuses_as_failed`
  - `collab_wait_end_with_empty_statuses_is_failed`

## Why
An empty `statuses` payload indicates that wait results are missing/incomplete. Marking such events as completed can mislead users and downstream consumers.

## Validation
- Added targeted unit tests for reconstruction and exec JSON event processing.
