### PR TITLE
docs(config): document agents.max_threads default and usage

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -42,3 +42,19 @@ override), not "inherit the global default". There is currently no separate
 config value for "follow the global default in Plan mode".
 
 Ctrl+C/Ctrl+D quitting uses a ~1 second double-press hint (`ctrl + c again to quit`).
+
+## Multi-agent thread limit
+
+Codex supports limiting how many child agent threads can run concurrently via
+`agents.max_threads` in `config.toml`.
+
+- Default: `6`
+- Minimum valid value: `1`
+- To use the built-in default, omit the setting.
+
+Example:
+
+```toml
+[agents]
+max_threads = 4
+```


### PR DESCRIPTION
## Summary
Document `agents.max_threads` in `docs/config.md` so users can discover and tune multi-agent concurrency without digging into code.

## Changes
- Added a new **Multi-agent thread limit** section to `docs/config.md`
- Documents:
  - config key: `agents.max_threads`
  - default value: `6`
  - minimum valid value: `1`
  - simple `config.toml` example

## Why
Recent multi-agent usage patterns make concurrency tuning more important. This PR adds a concise in-repo note for a commonly adjusted setting.

## Scope
- Docs only
- No behavior changes
