### PR TITLE
core: Update repository root discovery to honor configured project markers

### DIFF
--- a/codex-rs/core/src/config_loader/tests.rs
+++ b/codex-rs/core/src/config_loader/tests.rs
@@ -1248,6 +1248,14 @@ async fn project_root_markers_supports_alternate_markers() -> std::io::Result<()
     Ok(())
 }
 
+#[test]
+fn default_project_root_markers_include_git_only() {
+    assert_eq!(
+        super::default_project_root_markers(),
+        vec![".git".to_string()]
+    );
+}
+
 mod requirements_exec_policy_tests {
     use crate::config_loader::ConfigLayerEntry;
     use crate::config_loader::ConfigLayerStack;

--- a/codex-rs/core/src/skills/loader.rs
+++ b/codex-rs/core/src/skills/loader.rs
@@ -295,7 +295,9 @@ fn repo_agents_skill_roots(config_layer_stack: &ConfigLayerStack, cwd: &Path) ->
     roots
 }
 
-fn project_root_markers_from_stack(config_layer_stack: &ConfigLayerStack) -> Vec<String> {
+pub(crate) fn project_root_markers_from_stack(
+    config_layer_stack: &ConfigLayerStack,
+) -> Vec<String> {
     let mut merged = TomlValue::Table(toml::map::Map::new());
     for layer in
         config_layer_stack.get_layers(ConfigLayerStackOrdering::LowestPrecedenceFirst, false)


### PR DESCRIPTION
I don't think repository root discovery has been considering
`project_root_markers` in `$CODEX_HOME/config.toml`. That's normally
fine, but I work in a Sapling repository, so I would like to be able
to configure the project root markers to include `.hg` and `.sl`,
if-possible.

I don't want to change any behavior in this commit though, I *just* want
to fix the consideration of this configuration option. We could expand
the default configuration to other source control systems later.

I tested the whole thing end-to-end before/after with a local Sapling repo:

Note the AGENTS.md discovery from `/status` while starting Codex in a subdirectory of the repo. I added `project_root_markers = [".git", ".sl"]` to my `~/.codex/config.toml` beforehand.

## Before

<img width="2880" height="1920" alt="Screenshot From 2026-02-22 20-00-22" src="https://github.com/user-attachments/assets/3e1767dd-3e19-4741-a9ec-d93ca145dc4d" />

## After

<img width="2880" height="1920" alt="Screenshot From 2026-02-22 20-12-12" src="https://github.com/user-attachments/assets/6f16292f-8430-4369-834e-28db0f981205" />


