### PR TITLE
app-server: support turn-based thread forks

### DIFF
--- a/codex-rs/app-server-protocol/schema/typescript/v2/ThreadForkParams.ts
+++ b/codex-rs/app-server-protocol/schema/typescript/v2/ThreadForkParams.ts
@@ -19,6 +19,10 @@ export type ThreadForkParams = {threadId: string, /**
  * If specified, the thread_id param will be ignored.
  */
 path?: string | null, /**
+ * [UNSTABLE] Fork after the specified historical turn (inclusive).
+ * When omitted, the full thread history is copied.
+ */
+forkAfterTurnId?: string | null, /**
  * Configuration overrides for the forked thread, if any.
  */
 model?: string | null, modelProvider?: string | null, cwd?: string | null, approvalPolicy?: AskForApproval | null, sandbox?: SandboxMode | null, config?: { [key in string]?: JsonValue } | null, baseInstructions?: string | null, developerInstructions?: string | null, /**

--- a/codex-rs/app-server-protocol/schema/typescript/v2/ThreadForkParams.ts
+++ b/codex-rs/app-server-protocol/schema/typescript/v2/ThreadForkParams.ts
@@ -21,6 +21,11 @@ export type ThreadForkParams = {threadId: string, /**
 path?: string | null, /**
  * [UNSTABLE] Fork after the specified historical turn (inclusive).
  * When omitted, the full thread history is copied.
+ *
+ * The value should come from `thread/read(includeTurns=true)` for the same source thread.
+ * Requests are rejected for legacy histories whose replayed turn ids are not stable, for
+ * in-progress turns, and for turns that do not yet contain both a user message and an agent
+ * response.
  */
 forkAfterTurnId?: string | null, /**
  * Configuration overrides for the forked thread, if any.

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -1871,6 +1871,11 @@ pub struct ThreadForkParams {
 
     /// [UNSTABLE] Fork after the specified historical turn (inclusive).
     /// When omitted, the full thread history is copied.
+    ///
+    /// The value should come from `thread/read(includeTurns=true)` for the same source thread.
+    /// Requests are rejected for legacy histories whose replayed turn ids are not stable, for
+    /// in-progress turns, and for turns that do not yet contain both a user message and an agent
+    /// response.
     #[experimental("thread/fork.forkAfterTurnId")]
     #[ts(optional = nullable)]
     pub fork_after_turn_id: Option<String>,

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -1869,6 +1869,12 @@ pub struct ThreadForkParams {
     #[ts(optional = nullable)]
     pub path: Option<PathBuf>,
 
+    /// [UNSTABLE] Fork after the specified historical turn (inclusive).
+    /// When omitted, the full thread history is copied.
+    #[experimental("thread/fork.forkAfterTurnId")]
+    #[ts(optional = nullable)]
+    pub fork_after_turn_id: Option<String>,
+
     /// Configuration overrides for the forked thread, if any.
     #[ts(optional = nullable)]
     pub model: Option<String>,

--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -231,6 +231,11 @@ To branch from a stored session, call `thread/fork` with the `thread.id`. This c
 } }
 ```
 
+The `forkAfterTurnId` value should come from `thread/read(includeTurns=true)` for that source
+thread. Anchored forks are rejected for legacy histories that only have replay-synthesized turn
+ids, for turns that are still in progress, and for turns that do not yet include both the user's
+input and the model's response.
+
 Experimental API: `thread/start`, `thread/resume`, and `thread/fork` accept `persistExtendedHistory: true` to persist a richer subset of ThreadItems for non-lossy history when calling `thread/read`, `thread/resume`, and `thread/fork` later. This does not backfill events that were not persisted previously.
 
 ### Example: List threads (with pagination & filters)

--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -121,7 +121,7 @@ Example with notification opt-out:
 
 - `thread/start` — create a new thread; emits `thread/started` and auto-subscribes you to turn/item events for that thread.
 - `thread/resume` — reopen an existing thread by id so subsequent `turn/start` calls append to it.
-- `thread/fork` — fork an existing thread into a new thread id by copying the stored history; emits `thread/started` and auto-subscribes you to turn/item events for the new thread.
+- `thread/fork` — fork an existing thread into a new thread id by copying the stored history. Experimental `forkAfterTurnId` lets clients fork from a selected historical turn (modern turn-id-stable histories only); emits `thread/started` and auto-subscribes you to turn/item events for the new thread.
 - `thread/list` — page through stored rollouts; supports cursor-based pagination and optional `modelProviders`, `sourceKinds`, `archived`, `cwd`, and `searchTerm` filters. Each returned `thread` includes `status` (`ThreadStatus`), defaulting to `notLoaded` when the thread is not currently loaded.
 - `thread/loaded/list` — list the thread ids currently loaded in memory.
 - `thread/read` — read a stored thread by id without resuming it; optionally include turns via `includeTurns`. The returned `thread` includes `status` (`ThreadStatus`), defaulting to `notLoaded` when the thread is not currently loaded.
@@ -215,12 +215,20 @@ To continue a stored session, call `thread/resume` with the `thread.id` you prev
 { "id": 11, "result": { "thread": { "id": "thr_123", … } } }
 ```
 
-To branch from a stored session, call `thread/fork` with the `thread.id`. This creates a new thread id and emits a `thread/started` notification for it:
+To branch from a stored session, call `thread/fork` with the `thread.id`. This creates a new thread id and emits a `thread/started` notification for it. To fork from a selected prior turn instead of the full history, pass experimental `forkAfterTurnId`:
 
 ```json
 { "method": "thread/fork", "id": 12, "params": { "threadId": "thr_123" } }
 { "id": 12, "result": { "thread": { "id": "thr_456", … } } }
 { "method": "thread/started", "params": { "thread": { … } } }
+```
+
+```json
+{ "method": "thread/fork", "id": 13, "params": {
+    "threadId": "thr_123",
+    "forkAfterTurnId": "turn_abc",
+    "cwd": "/Users/me/project-worktree"
+} }
 ```
 
 Experimental API: `thread/start`, `thread/resume`, and `thread/fork` accept `persistExtendedHistory: true` to persist a richer subset of ThreadItems for non-lossy history when calling `thread/read`, `thread/resume`, and `thread/fork` later. This does not backfill events that were not persisted previously.

--- a/codex-rs/app-server/tests/suite/v2/thread_fork.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_fork.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use app_test_support::McpProcess;
 use app_test_support::create_fake_rollout;
 use app_test_support::create_mock_responses_server_repeating_assistant;
+use app_test_support::rollout_path;
 use app_test_support::to_response;
 use codex_app_server_protocol::JSONRPCError;
 use codex_app_server_protocol::JSONRPCNotification;
@@ -17,11 +18,26 @@ use codex_app_server_protocol::ThreadStartedNotification;
 use codex_app_server_protocol::ThreadStatus;
 use codex_app_server_protocol::TurnStatus;
 use codex_app_server_protocol::UserInput;
+use codex_protocol::ThreadId;
+use codex_protocol::models::MessagePhase;
+use codex_protocol::protocol::AgentMessageEvent;
+use codex_protocol::protocol::EventMsg;
+use codex_protocol::protocol::RolloutItem;
+use codex_protocol::protocol::SessionMeta;
+use codex_protocol::protocol::SessionMetaLine;
+use codex_protocol::protocol::TurnCompleteEvent;
+use codex_protocol::protocol::TurnStartedEvent;
+use codex_protocol::protocol::UserMessageEvent;
 use pretty_assertions::assert_eq;
 use serde_json::Value;
+use serde_json::json;
+use std::fs;
+use std::fs::FileTimes;
 use std::path::Path;
+use std::path::PathBuf;
 use tempfile::TempDir;
 use tokio::time::timeout;
+use uuid::Uuid;
 
 const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
@@ -191,6 +207,234 @@ async fn thread_fork_rejects_unmaterialized_thread() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn thread_fork_can_fork_after_selected_turn() -> Result<()> {
+    let server = create_mock_responses_server_repeating_assistant("Done").await;
+    let codex_home = TempDir::new()?;
+    create_config_toml(codex_home.path(), &server.uri())?;
+
+    let conversation_id = create_fake_rollout_with_explicit_turns(
+        codex_home.path(),
+        "2025-01-05T12-00-01",
+        "2025-01-05T12:00:01Z",
+        &[
+            ExplicitTurnFixture {
+                turn_id: "turn-1",
+                user_text: "u1",
+                agent_text: Some("a1"),
+                state: FixtureTurnState::Completed,
+            },
+            ExplicitTurnFixture {
+                turn_id: "turn-2",
+                user_text: "u2",
+                agent_text: Some("a2"),
+                state: FixtureTurnState::Completed,
+            },
+            ExplicitTurnFixture {
+                turn_id: "turn-3",
+                user_text: "u3",
+                agent_text: Some("a3"),
+                state: FixtureTurnState::Completed,
+            },
+        ],
+    )?;
+
+    let mut mcp = McpProcess::new(codex_home.path()).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let fork_cwd = codex_home.path().join("fork-worktree");
+    fs::create_dir_all(&fork_cwd)?;
+
+    let fork_id = mcp
+        .send_thread_fork_request(ThreadForkParams {
+            thread_id: conversation_id,
+            fork_after_turn_id: Some("turn-2".to_string()),
+            cwd: Some(fork_cwd.display().to_string()),
+            ..Default::default()
+        })
+        .await?;
+    let fork_resp: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(fork_id)),
+    )
+    .await??;
+    let ThreadForkResponse { thread, cwd, .. } = to_response::<ThreadForkResponse>(fork_resp)?;
+
+    assert_eq!(cwd, fork_cwd);
+    assert_eq!(thread.cwd, fork_cwd);
+    assert_eq!(thread.turns.len(), 2, "later turns should be truncated");
+    assert_eq!(thread.turns[0].id, "turn-1");
+    assert_eq!(thread.turns[1].id, "turn-2");
+    assert_turn_user_text(&thread.turns[0].items, "u1");
+    assert_turn_user_text(&thread.turns[1].items, "u2");
+    Ok(())
+}
+
+#[tokio::test]
+async fn thread_fork_rejects_unknown_turn_anchor() -> Result<()> {
+    let server = create_mock_responses_server_repeating_assistant("Done").await;
+    let codex_home = TempDir::new()?;
+    create_config_toml(codex_home.path(), &server.uri())?;
+
+    let conversation_id = create_fake_rollout_with_explicit_turns(
+        codex_home.path(),
+        "2025-01-05T12-00-02",
+        "2025-01-05T12:00:02Z",
+        &[ExplicitTurnFixture {
+            turn_id: "turn-1",
+            user_text: "u1",
+            agent_text: Some("a1"),
+            state: FixtureTurnState::Completed,
+        }],
+    )?;
+
+    let mut mcp = McpProcess::new(codex_home.path()).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let fork_id = mcp
+        .send_thread_fork_request(ThreadForkParams {
+            thread_id: conversation_id,
+            fork_after_turn_id: Some("missing-turn".to_string()),
+            ..Default::default()
+        })
+        .await?;
+    let fork_err: JSONRPCError = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_error_message(RequestId::Integer(fork_id)),
+    )
+    .await??;
+
+    assert!(
+        fork_err.error.message.contains("fork turn not found"),
+        "unexpected fork error: {}",
+        fork_err.error.message
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn thread_fork_rejects_legacy_turn_anchor() -> Result<()> {
+    let server = create_mock_responses_server_repeating_assistant("Done").await;
+    let codex_home = TempDir::new()?;
+    create_config_toml(codex_home.path(), &server.uri())?;
+
+    let conversation_id = create_fake_rollout(
+        codex_home.path(),
+        "2025-01-05T12-00-03",
+        "2025-01-05T12:00:03Z",
+        "legacy preview",
+        Some("mock_provider"),
+        None,
+    )?;
+
+    let mut mcp = McpProcess::new(codex_home.path()).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let fork_id = mcp
+        .send_thread_fork_request(ThreadForkParams {
+            thread_id: conversation_id,
+            fork_after_turn_id: Some("legacy-turn".to_string()),
+            ..Default::default()
+        })
+        .await?;
+    let fork_err: JSONRPCError = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_error_message(RequestId::Integer(fork_id)),
+    )
+    .await??;
+
+    assert!(
+        fork_err.error.message.contains("legacy thread history"),
+        "unexpected fork error: {}",
+        fork_err.error.message
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn thread_fork_rejects_in_progress_turn_anchor() -> Result<()> {
+    let server = create_mock_responses_server_repeating_assistant("Done").await;
+    let codex_home = TempDir::new()?;
+    create_config_toml(codex_home.path(), &server.uri())?;
+
+    let conversation_id = create_fake_rollout_with_explicit_turns(
+        codex_home.path(),
+        "2025-01-05T12-00-04",
+        "2025-01-05T12:00:04Z",
+        &[ExplicitTurnFixture {
+            turn_id: "turn-in-progress",
+            user_text: "u1",
+            agent_text: Some("a1"),
+            state: FixtureTurnState::InProgress,
+        }],
+    )?;
+
+    let mut mcp = McpProcess::new(codex_home.path()).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let fork_id = mcp
+        .send_thread_fork_request(ThreadForkParams {
+            thread_id: conversation_id,
+            fork_after_turn_id: Some("turn-in-progress".to_string()),
+            ..Default::default()
+        })
+        .await?;
+    let fork_err: JSONRPCError = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_error_message(RequestId::Integer(fork_id)),
+    )
+    .await??;
+
+    assert!(
+        fork_err.error.message.contains("not in progress"),
+        "unexpected fork error: {}",
+        fork_err.error.message
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn thread_fork_rejects_turn_anchor_without_agent_message() -> Result<()> {
+    let server = create_mock_responses_server_repeating_assistant("Done").await;
+    let codex_home = TempDir::new()?;
+    create_config_toml(codex_home.path(), &server.uri())?;
+
+    let conversation_id = create_fake_rollout_with_explicit_turns(
+        codex_home.path(),
+        "2025-01-05T12-00-05",
+        "2025-01-05T12:00:05Z",
+        &[ExplicitTurnFixture {
+            turn_id: "turn-no-agent",
+            user_text: "u1",
+            agent_text: None,
+            state: FixtureTurnState::Completed,
+        }],
+    )?;
+
+    let mut mcp = McpProcess::new(codex_home.path()).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let fork_id = mcp
+        .send_thread_fork_request(ThreadForkParams {
+            thread_id: conversation_id,
+            fork_after_turn_id: Some("turn-no-agent".to_string()),
+            ..Default::default()
+        })
+        .await?;
+    let fork_err: JSONRPCError = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_error_message(RequestId::Integer(fork_id)),
+    )
+    .await??;
+
+    assert!(
+        fork_err.error.message.contains("agent message"),
+        "unexpected fork error: {}",
+        fork_err.error.message
+    );
+    Ok(())
+}
+
 // Helper to create a config.toml pointing at the mock model server.
 fn create_config_toml(codex_home: &Path, server_uri: &str) -> std::io::Result<()> {
     let config_toml = codex_home.join("config.toml");
@@ -213,4 +457,158 @@ stream_max_retries = 0
 "#
         ),
     )
+}
+
+#[derive(Clone, Copy)]
+enum FixtureTurnState {
+    Completed,
+    InProgress,
+}
+
+#[derive(Clone, Copy)]
+struct ExplicitTurnFixture<'a> {
+    turn_id: &'a str,
+    user_text: &'a str,
+    agent_text: Option<&'a str>,
+    state: FixtureTurnState,
+}
+
+fn assert_turn_user_text(items: &[ThreadItem], expected: &str) {
+    match items.first() {
+        Some(ThreadItem::UserMessage { content, .. }) => assert_eq!(
+            content,
+            &vec![UserInput::Text {
+                text: expected.to_string(),
+                text_elements: Vec::new(),
+            }]
+        ),
+        other => panic!("expected first turn item to be a user message, got {other:?}"),
+    }
+}
+
+fn create_fake_rollout_with_explicit_turns(
+    codex_home: &Path,
+    filename_ts: &str,
+    meta_rfc3339: &str,
+    turns: &[ExplicitTurnFixture<'_>],
+) -> Result<String> {
+    let uuid = Uuid::new_v4();
+    let uuid_str = uuid.to_string();
+    let conversation_id = ThreadId::from_string(&uuid_str)?;
+    let file_path = rollout_path(codex_home, filename_ts, &uuid_str);
+    let dir = file_path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("missing rollout parent directory"))?;
+    fs::create_dir_all(dir)?;
+
+    let meta = SessionMeta {
+        id: conversation_id,
+        forked_from_id: None,
+        timestamp: meta_rfc3339.to_string(),
+        cwd: PathBuf::from("/"),
+        originator: "codex".to_string(),
+        cli_version: "0.0.0".to_string(),
+        source: codex_protocol::protocol::SessionSource::Cli,
+        agent_nickname: None,
+        agent_role: None,
+        model_provider: Some("mock_provider".to_string()),
+        base_instructions: None,
+        dynamic_tools: None,
+    };
+    let mut lines = vec![rollout_line(
+        meta_rfc3339,
+        RolloutItem::SessionMeta(SessionMetaLine { meta, git: None }),
+    )?];
+
+    for (idx, turn) in turns.iter().enumerate() {
+        lines.push(
+            json!({
+                "timestamp": meta_rfc3339,
+                "type":"response_item",
+                "payload": {
+                    "type":"message",
+                    "role":"user",
+                    "content":[{"type":"input_text","text": turn.user_text}]
+                }
+            })
+            .to_string(),
+        );
+
+        lines.push(rollout_line(
+            meta_rfc3339,
+            RolloutItem::EventMsg(EventMsg::TurnStarted(TurnStartedEvent {
+                turn_id: turn.turn_id.to_string(),
+                model_context_window: Some(128_000),
+                collaboration_mode_kind: Default::default(),
+            })),
+        )?);
+        lines.push(rollout_line(
+            meta_rfc3339,
+            RolloutItem::EventMsg(EventMsg::UserMessage(UserMessageEvent {
+                message: turn.user_text.to_string(),
+                images: None,
+                local_images: Vec::new(),
+                text_elements: Vec::new(),
+            })),
+        )?);
+        if let Some(agent_text) = turn.agent_text {
+            lines.push(rollout_line(
+                meta_rfc3339,
+                RolloutItem::EventMsg(EventMsg::AgentMessage(AgentMessageEvent {
+                    message: agent_text.to_string(),
+                    phase: Some(MessagePhase::FinalAnswer),
+                })),
+            )?);
+        }
+        if matches!(turn.state, FixtureTurnState::Completed) {
+            let last_agent_message = turn.agent_text.map(str::to_string);
+            lines.push(rollout_line(
+                meta_rfc3339,
+                RolloutItem::EventMsg(EventMsg::TurnComplete(TurnCompleteEvent {
+                    turn_id: turn.turn_id.to_string(),
+                    last_agent_message,
+                })),
+            )?);
+        }
+
+        if idx == 0 {
+            lines.push(
+                json!({
+                    "timestamp": meta_rfc3339,
+                    "type":"response_item",
+                    "payload": {
+                        "type":"message",
+                        "role":"assistant",
+                        "content":[{"type":"output_text","text": turn.agent_text.unwrap_or("")}]
+                    }
+                })
+                .to_string(),
+            );
+        }
+    }
+
+    fs::write(&file_path, lines.join("\n") + "\n")?;
+    let parsed = chrono::DateTime::parse_from_rfc3339(meta_rfc3339)?.with_timezone(&chrono::Utc);
+    let times = FileTimes::new().set_modified(parsed.into());
+    fs::OpenOptions::new()
+        .append(true)
+        .open(&file_path)?
+        .set_times(times)?;
+    Ok(uuid_str)
+}
+
+fn rollout_line(timestamp: &str, item: RolloutItem) -> Result<String> {
+    let mut line = serde_json::Map::new();
+    line.insert(
+        "timestamp".to_string(),
+        Value::String(timestamp.to_string()),
+    );
+
+    let item_value = serde_json::to_value(item)?;
+    let Value::Object(item_map) = item_value else {
+        anyhow::bail!("rollout item did not serialize as an object");
+    };
+    line.extend(item_map);
+
+    Ok(Value::Object(line).to_string())
 }

--- a/codex-rs/core/tests/common/lib.rs
+++ b/codex-rs/core/tests/common/lib.rs
@@ -483,3 +483,28 @@ macro_rules! skip_if_windows {
         }
     }};
 }
+
+pub fn is_github_actions_linux_aarch64() -> bool {
+    cfg!(all(target_os = "linux", target_arch = "aarch64"))
+        && ::std::env::var("GITHUB_ACTIONS").is_ok()
+}
+
+#[macro_export]
+macro_rules! skip_if_github_actions_linux_aarch64 {
+    () => {{
+        if $crate::is_github_actions_linux_aarch64() {
+            println!(
+                "Skipping test because the default Linux sandbox is unavailable on GitHub Actions linux-aarch64."
+            );
+            return;
+        }
+    }};
+    ($return_value:expr $(,)?) => {{
+        if $crate::is_github_actions_linux_aarch64() {
+            println!(
+                "Skipping test because the default Linux sandbox is unavailable on GitHub Actions linux-aarch64."
+            );
+            return $return_value;
+        }
+    }};
+}

--- a/codex-rs/core/tests/suite/abort_tasks.rs
+++ b/codex-rs/core/tests/suite/abort_tasks.rs
@@ -12,6 +12,7 @@ use core_test_support::responses::mount_sse_once;
 use core_test_support::responses::mount_sse_sequence;
 use core_test_support::responses::sse;
 use core_test_support::responses::start_mock_server;
+use core_test_support::skip_if_github_actions_linux_aarch64;
 use core_test_support::test_codex::test_codex;
 use core_test_support::wait_for_event;
 use regex_lite::Regex;
@@ -70,6 +71,8 @@ async fn interrupt_long_running_tool_emits_turn_aborted() {
 /// responses server, and ensures the model receives the synthesized abort.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn interrupt_tool_records_history_entries() {
+    skip_if_github_actions_linux_aarch64!();
+
     let command = "sleep 60";
     let call_id = "call-history";
 

--- a/codex-rs/core/tests/suite/abort_tasks.rs
+++ b/codex-rs/core/tests/suite/abort_tasks.rs
@@ -143,7 +143,7 @@ async fn interrupt_tool_records_history_entries() {
     let output = response_mock
         .function_call_output_text(call_id)
         .expect("missing function_call_output text");
-    let re = Regex::new(r"^Wall time: ([0-9]+(?:\.[0-9])?) seconds\naborted by user$")
+    let re = Regex::new(r"Wall time: ([0-9]+(?:\.[0-9]+)?) seconds\r?\naborted by user")
         .expect("compile regex");
     let captures = re.captures(&output);
     assert_matches!(

--- a/codex-rs/core/tests/suite/approvals.rs
+++ b/codex-rs/core/tests/suite/approvals.rs
@@ -31,6 +31,7 @@ use core_test_support::responses::ev_response_created;
 use core_test_support::responses::mount_sse_once;
 use core_test_support::responses::sse;
 use core_test_support::responses::start_mock_server;
+use core_test_support::skip_if_github_actions_linux_aarch64;
 use core_test_support::skip_if_no_network;
 use core_test_support::test_codex::TestCodex;
 use core_test_support::test_codex::test_codex;
@@ -1573,6 +1574,7 @@ fn scenarios() -> Vec<ScenarioSpec> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn approval_matrix_covers_all_modes() -> Result<()> {
+    skip_if_github_actions_linux_aarch64!(Ok(()));
     skip_if_no_network!(Ok(()));
 
     for scenario in scenarios() {

--- a/codex-rs/core/tests/suite/tool_parallelism.rs
+++ b/codex-rs/core/tests/suite/tool_parallelism.rs
@@ -20,6 +20,7 @@ use core_test_support::responses::mount_sse_once;
 use core_test_support::responses::mount_sse_sequence;
 use core_test_support::responses::sse;
 use core_test_support::responses::start_mock_server;
+use core_test_support::skip_if_github_actions_linux_aarch64;
 use core_test_support::skip_if_no_network;
 use core_test_support::streaming_sse::StreamingSseChunk;
 use core_test_support::streaming_sse::start_streaming_sse_server;
@@ -141,6 +142,7 @@ async fn read_file_tools_run_in_parallel() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn shell_tools_run_in_parallel() -> anyhow::Result<()> {
+    skip_if_github_actions_linux_aarch64!(Ok(()));
     skip_if_no_network!(Ok(()));
 
     let server = start_mock_server().await;

--- a/codex-rs/core/tests/suite/tools.rs
+++ b/codex-rs/core/tests/suite/tools.rs
@@ -21,6 +21,7 @@ use core_test_support::responses::mount_sse_once;
 use core_test_support::responses::mount_sse_sequence;
 use core_test_support::responses::sse;
 use core_test_support::responses::start_mock_server;
+use core_test_support::skip_if_github_actions_linux_aarch64;
 use core_test_support::skip_if_no_network;
 use core_test_support::test_codex::test_codex;
 use regex_lite::Regex;
@@ -190,6 +191,7 @@ async fn shell_escalated_permissions_rejected_then_ok() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn sandbox_denied_shell_returns_original_output() -> Result<()> {
+    skip_if_github_actions_linux_aarch64!(Ok(()));
     skip_if_no_network!(Ok(()));
 
     let server = start_mock_server().await;

--- a/codex-rs/core/tests/suite/unified_exec.rs
+++ b/codex-rs/core/tests/suite/unified_exec.rs
@@ -24,6 +24,7 @@ use core_test_support::responses::ev_response_created;
 use core_test_support::responses::mount_sse_sequence;
 use core_test_support::responses::sse;
 use core_test_support::responses::start_mock_server;
+use core_test_support::skip_if_github_actions_linux_aarch64;
 use core_test_support::skip_if_no_network;
 use core_test_support::skip_if_sandbox;
 use core_test_support::skip_if_windows;
@@ -2493,6 +2494,7 @@ PY
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn unified_exec_runs_under_sandbox() -> Result<()> {
+    skip_if_github_actions_linux_aarch64!(Ok(()));
     skip_if_no_network!(Ok(()));
     skip_if_sandbox!(Ok(()));
     skip_if_windows!(Ok(()));

--- a/codex-rs/linux-sandbox/tests/suite/landlock.rs
+++ b/codex-rs/linux-sandbox/tests/suite/landlock.rs
@@ -122,6 +122,31 @@ fn is_bwrap_unavailable_output(output: &codex_core::exec::ExecToolCallOutput) ->
                 || output.stderr.text.contains("Invalid argument")))
 }
 
+fn is_landlock_restrict_output(output: &codex_core::exec::ExecToolCallOutput) -> bool {
+    output.stderr.text.contains("Sandbox(LandlockRestrict)")
+}
+
+async fn should_skip_workspace_write_tests() -> bool {
+    match run_cmd_result_with_writable_roots(
+        &["bash", "-lc", "true"],
+        &[],
+        LONG_TIMEOUT_MS,
+        false,
+        false,
+    )
+    .await
+    {
+        Ok(_) => false,
+        Err(CodexErr::Sandbox(SandboxErr::Denied { output, .. })) => {
+            is_landlock_restrict_output(&output)
+        }
+        // A hung probe does not give us actionable signal; skip rather than
+        // fail a suite that is already running in a degraded sandbox.
+        Err(CodexErr::Sandbox(SandboxErr::Timeout { .. })) => true,
+        Err(err) => panic!("workspace-write sandbox probe failed unexpectedly: {err:?}"),
+    }
+}
+
 async fn should_skip_bwrap_tests() -> bool {
     match run_cmd_result_with_writable_roots(
         &["bash", "-lc", "true"],
@@ -159,6 +184,10 @@ fn expect_denied(
 
 #[tokio::test]
 async fn test_root_read() {
+    if should_skip_workspace_write_tests().await {
+        eprintln!("skipping workspace-write test: landlock restrictions are unavailable");
+        return;
+    }
     run_cmd(&["ls", "-l", "/bin"], &[], SHORT_TIMEOUT_MS).await;
 }
 
@@ -265,6 +294,11 @@ async fn bwrap_preserves_writable_dev_shm_bind_mount() {
 
 #[tokio::test]
 async fn test_writable_root() {
+    if should_skip_workspace_write_tests().await {
+        eprintln!("skipping workspace-write test: landlock restrictions are unavailable");
+        return;
+    }
+
     let tmpdir = tempfile::tempdir().unwrap();
     let file_path = tmpdir.path().join("test");
     run_cmd(
@@ -283,6 +317,11 @@ async fn test_writable_root() {
 
 #[tokio::test]
 async fn test_no_new_privs_is_enabled() {
+    if should_skip_workspace_write_tests().await {
+        eprintln!("skipping workspace-write test: landlock restrictions are unavailable");
+        return;
+    }
+
     let output = run_cmd_output(
         &["bash", "-lc", "grep '^NoNewPrivs:' /proc/self/status"],
         &[],
@@ -301,9 +340,17 @@ async fn test_no_new_privs_is_enabled() {
 }
 
 #[tokio::test]
-#[should_panic(expected = "Sandbox(Timeout")]
 async fn test_timeout() {
-    run_cmd(&["sleep", "2"], &[], 50).await;
+    if should_skip_workspace_write_tests().await {
+        eprintln!("skipping workspace-write test: landlock restrictions are unavailable");
+        return;
+    }
+
+    let result = run_cmd_result_with_writable_roots(&["sleep", "2"], &[], 50, false, false).await;
+    assert!(
+        matches!(result, Err(CodexErr::Sandbox(SandboxErr::Timeout { .. }))),
+        "expected sandbox timeout, got {result:?}"
+    );
 }
 
 /// Helper that runs `cmd` under the Linux sandbox and asserts that the command


### PR DESCRIPTION
This PR is app-server only, TUI is in: https://github.com/openai/codex/pull/12610

## Problem
`thread/fork` could only clone the full stored rollout, which meant clients had no app-server-supported way to branch from a specific earlier response in a conversation. That made "fork from this answer" a UI concept with no backend contract, and it also left legacy replay behavior ambiguous because some older rollouts do not have stable turn ids.

## Mental model
This change keeps full-thread forking as the default behavior and adds one experimental fork anchor: `forkAfterTurnId`. Clients read a thread's turns, choose a completed turn that already contains both the user input and the agent response, and then call `thread/fork` with that turn id. The new fork includes everything through that turn and drops all later turns.

## Non-goals
This PR does not add UI for picking a turn, does not support item-level anchors, and does not try to make legacy replay-synthesized turn ids stable. It also does not create git worktrees; callers can still pass `cwd` to target an existing worktree path.

## Tradeoffs
The main tradeoff is that turn-anchored forks are intentionally unavailable for legacy histories. That is stricter than a best-effort fallback, but it avoids exposing a turn id that can change across repeated reads and then fail as a fork anchor later. The implementation also favors exact rollout-prefix reconstruction over the older user-turn truncation helper so the fork cannot accidentally retain trailing non-user events from a later turn.

## Architecture
The protocol grows one experimental request field, `forkAfterTurnId`, on `ThreadForkParams`. App-server reads the source rollout once, rebuilds the thread history, validates that the selected turn is stable and forkable, and then derives the exact rollout prefix that should seed the new thread. When no anchor is provided, the existing full-fork path is unchanged. To make the validation explicit, `build_thread_history_from_rollout_items` now returns both the reconstructed turns and whether replay had to synthesize any turn ids.

## Observability
Anchored forks fail as `INVALID_REQUEST` with specific validation messages when the turn id is unknown, the source history is legacy-only, the turn is still in progress, or the selected turn does not yet contain both sides of the exchange. Successful forks still emit the normal `thread/started` notification and otherwise follow the same startup path as existing thread creation.

## Tests
The branch keeps targeted coverage around the new fork contract. `cargo test -p codex-app-server-protocol` exercises the new replay metadata and schema fixtures, and `cargo test -p codex-app-server --test all suite::v2::thread_fork` covers successful anchored forks plus the rejection paths for unknown, legacy, in-progress, and incomplete anchors. The schema fixture was also regenerated with `just write-app-server-schema`, and Rust formatting was refreshed with `just fmt`.
