### PR TITLE
feat: rehydrate MCP sessions from disk on codex-reply

### DIFF
--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -222,6 +222,10 @@ impl ThreadManager {
         self.state.session_source.clone()
     }
 
+    pub fn auth_manager(&self) -> Arc<AuthManager> {
+        Arc::clone(&self.state.auth_manager)
+    }
+
     pub fn skills_manager(&self) -> Arc<SkillsManager> {
         self.state.skills_manager.clone()
     }


### PR DESCRIPTION
## motivation

i use codex as an MCP server inside claude code a lot. the two work really well as a team — claude handles the high-level orchestration and codex does the heavy lifting with shell access, file edits, etc.

the problem is when i've been working with just codex directly and it already has all the context for what i'm doing. i want to tell claude "go chat with codex `019c7616-b3e9-7782-9ea8-b53e6bb09329`" and have it pick up right where i left off. but if the MCP server has restarted since that session (which happens all the time), `codex-reply` just returns "Session not found" — even though the full JSONL transcript is still sitting on disk at `~/.codex/sessions/`.

this is frustrating because the data is RIGHT THERE. all the building blocks to fix it already exist in the codebase, they just aren't wired together in the error path.

## what this does

adds a fallback in the `codex-reply` error path — if a thread isn't found in memory, it tries to load it from the persisted rollout file and resume the session with the full conversation history.

## how it works

basically chains three functions that already existed but weren't connected:

- `find_thread_path_by_id_str` — locates the JSONL rollout file for the threadId
- `read_session_meta_line` — recovers the original cwd from session metadata
- `resume_thread_from_rollout` — replays the conversation history into a new thread

if no rollout file exists on disk, the original "Session not found" error is returned unchanged — so this is purely additive, no behavior change for the normal case.

the response already includes `threadId` in the output, so the client automatically picks up the new ID for subsequent calls.

## files changed

| file | change |
|------|--------|
| `codex-rs/core/src/thread_manager.rs` | added `pub fn auth_manager()` getter (+4 lines) |
| `codex-rs/mcp-server/src/message_processor.rs` | added `codex_home` field, `try_rehydrate_from_disk()` method, modified error path (+75/-10 lines) |

## test plan

- [x] `cargo build -p codex-mcp-server` — compiles
- [x] `cargo test -p codex-mcp-server` — all 11 existing tests pass
- [ ] manual test: start session → restart MCP server → `codex-reply` with old threadId → session resumes from disk
- [ ] edge case: threadId with no JSONL file → still returns "Session not found"