### PR TITLE
fix: preserve root path '/' in short_display_path

### DIFF
--- a/codex-rs/shell-command/src/parse_command.rs
+++ b/codex-rs/shell-command/src/parse_command.rs
@@ -425,6 +425,17 @@ mod tests {
     }
 
     #[test]
+    fn supports_ls_root_path() {
+        assert_parsed(
+            &shlex_split_safe("ls /"),
+            vec![ParsedCommand::ListFiles {
+                cmd: "ls /".to_string(),
+                path: Some("/".to_string()),
+            }],
+        );
+    }
+
+    #[test]
     fn supports_eza_exa_tree_du() {
         assert_parsed(
             &shlex_split_safe("eza --color=always src"),
@@ -1580,6 +1591,9 @@ fn short_display_path(path: &str) -> String {
     // Normalize separators and drop any trailing slash for display.
     let normalized = path.replace('\\', "/");
     let trimmed = normalized.trim_end_matches('/');
+    if trimmed.is_empty() {
+        return "/".to_string();
+    }
     let mut parts = trimmed.split('/').rev().filter(|p| {
         !p.is_empty() && *p != "build" && *p != "dist" && *p != "node_modules" && *p != "src"
     });


### PR DESCRIPTION
## What
Modified `short_display_path` to preserve the root path `"/"` instead of collapsing it to an empty string.

## Why
When displaying the root directory as a path, the function previously returned an empty string, which is confusing in UI displays and logs.

## How
Added a check: if the trimmed path is empty, return `"/"` instead.