### PR TITLE
Add subagent field to notify payload

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -4783,6 +4783,10 @@ pub(crate) async fn run_turn(
                                 event: HookEventAfterAgent {
                                     thread_id: sess.conversation_id,
                                     turn_id: turn_context.sub_id.clone(),
+                                    subagent: matches!(
+                                        &turn_context.session_source,
+                                        SessionSource::SubAgent(_)
+                                    ),
                                     input_messages: sampling_request_input_messages,
                                     last_assistant_message: last_agent_message.clone(),
                                 },

--- a/codex-rs/core/tests/suite/user_notification.rs
+++ b/codex-rs/core/tests/suite/user_notification.rs
@@ -73,6 +73,7 @@ echo -n "${@: -1}" > $(dirname "${0}")/notify.txt"#,
     let payload: Value = serde_json::from_str(&notify_payload_raw)?;
 
     assert_eq!(payload["type"], json!("agent-turn-complete"));
+    assert_eq!(payload["subagent"], json!(false));
     assert_eq!(payload["input-messages"], json!(["hello world"]));
     assert_eq!(payload["last-assistant-message"], json!("Done"));
 

--- a/codex-rs/hooks/src/registry.rs
+++ b/codex-rs/hooks/src/registry.rs
@@ -112,6 +112,7 @@ mod tests {
                 event: HookEventAfterAgent {
                     thread_id: ThreadId::new(),
                     turn_id: format!("turn-{label}"),
+                    subagent: false,
                     input_messages: vec![INPUT_MESSAGE.to_string()],
                     last_assistant_message: Some("hi".to_string()),
                 },

--- a/codex-rs/hooks/src/types.rs
+++ b/codex-rs/hooks/src/types.rs
@@ -75,6 +75,7 @@ pub struct HookPayload {
 pub struct HookEventAfterAgent {
     pub thread_id: ThreadId,
     pub turn_id: String,
+    pub subagent: bool,
     pub input_messages: Vec<String>,
     pub last_assistant_message: Option<String>,
 }
@@ -189,6 +190,7 @@ mod tests {
                 event: HookEventAfterAgent {
                     thread_id,
                     turn_id: "turn-1".to_string(),
+                    subagent: false,
                     input_messages: vec!["hello".to_string()],
                     last_assistant_message: Some("hi".to_string()),
                 },
@@ -204,6 +206,7 @@ mod tests {
                 "event_type": "after_agent",
                 "thread_id": thread_id.to_string(),
                 "turn_id": "turn-1",
+                "subagent": false,
                 "input_messages": ["hello"],
                 "last_assistant_message": "hi",
             },

--- a/codex-rs/hooks/src/user_notification.rs
+++ b/codex-rs/hooks/src/user_notification.rs
@@ -19,6 +19,7 @@ enum UserNotification {
         thread_id: String,
         turn_id: String,
         cwd: String,
+        subagent: bool,
 
         /// Messages that the user sent to the agent to initiate the turn.
         input_messages: Vec<String>,
@@ -35,6 +36,7 @@ pub fn legacy_notify_json(hook_event: &HookEvent, cwd: &Path) -> Result<String, 
                 thread_id: event.thread_id.to_string(),
                 turn_id: event.turn_id.clone(),
                 cwd: cwd.display().to_string(),
+                subagent: event.subagent,
                 input_messages: event.input_messages.clone(),
                 last_assistant_message: event.last_assistant_message.clone(),
             })
@@ -91,6 +93,7 @@ mod tests {
             "thread-id": "b5f6c1c2-1111-2222-3333-444455556666",
             "turn-id": "12345",
             "cwd": "/Users/example/project",
+            "subagent": false,
             "input-messages": ["Rename `foo` to `bar` and update the callsites."],
             "last-assistant-message": "Rename complete and verified `cargo build` succeeds.",
         })
@@ -102,6 +105,7 @@ mod tests {
             thread_id: "b5f6c1c2-1111-2222-3333-444455556666".to_string(),
             turn_id: "12345".to_string(),
             cwd: "/Users/example/project".to_string(),
+            subagent: false,
             input_messages: vec!["Rename `foo` to `bar` and update the callsites.".to_string()],
             last_assistant_message: Some(
                 "Rename complete and verified `cargo build` succeeds.".to_string(),
@@ -120,6 +124,7 @@ mod tests {
                 thread_id: ThreadId::from_string("b5f6c1c2-1111-2222-3333-444455556666")
                     .expect("valid thread id"),
                 turn_id: "12345".to_string(),
+                subagent: false,
                 input_messages: vec!["Rename `foo` to `bar` and update the callsites.".to_string()],
                 last_assistant_message: Some(
                     "Rename complete and verified `cargo build` succeeds.".to_string(),


### PR DESCRIPTION
For notify events, a notifier may want to behave differently for subagents than for the main thread, so we can expose that info in the notify payload.
