### PR TITLE
Fix status indicator wrapping for background terminals

### DIFF
--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__tests__status_and_composer_fill_height_without_bottom_padding.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__tests__status_and_composer_fill_height_without_bottom_padding.snap
@@ -1,8 +1,10 @@
 ---
 source: tui/src/bottom_pane/mod.rs
+assertion_line: 1201
 expression: "render_snapshot(&pane, area)"
 ---
-• Working (0s • esc to interru
+• Working (0s • esc to        
+interrupt)                    
                               
                               
 › Ask Codex to do anything    

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__unified_exec_begin_restores_working_status.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__unified_exec_begin_restores_working_status.snap
@@ -1,9 +1,11 @@
 ---
 source: tui/src/chatwidget/tests.rs
+assertion_line: 3373
 expression: terminal.backend()
 ---
 "                                                                                "
 "• Working (0s • esc to interrupt) · 1 background terminal running · /ps to view "
+"· /clean to close                                                               "
 "                                                                                "
 "                                                                                "
 "› Ask Codex to do anything                                                      "

--- a/codex-rs/tui/src/snapshots/codex_tui__status_indicator_widget__tests__renders_truncated.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__status_indicator_widget__tests__renders_truncated.snap
@@ -1,6 +1,7 @@
 ---
 source: tui/src/status_indicator_widget.rs
+assertion_line: 346
 expression: terminal.backend()
 ---
 "• Working (0s • esc "
-"                    "
+"to interrupt)       "

--- a/codex-rs/tui/src/snapshots/codex_tui__status_indicator_widget__tests__renders_wrapped_long_waiting_header.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__status_indicator_widget__tests__renders_wrapped_long_waiting_header.snap
@@ -1,0 +1,9 @@
+---
+source: tui/src/status_indicator_widget.rs
+assertion_line: 386
+expression: terminal.backend()
+---
+"• Waiting for background terminal · "
+"cargo test -p codex-core (0s)       "
+"                                    "
+"                                    "


### PR DESCRIPTION
Summary
- update the status indicator header rendering to wrap long messages and maintain interrupt hints in a stable position
- add a unit snapshot that covers the wrapped background-terminal message and refresh related snapshots
