### PR TITLE
Fix @mention token parsing in chat composer

### DIFF
--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -2019,7 +2019,7 @@ impl ChatComposer {
             return if prefix_starts_token {
                 right_prefixed.or(left_prefixed)
             } else {
-                left_prefixed.or(right_prefixed)
+                left_prefixed
             };
         }
         left_prefixed.or(right_prefixed)
@@ -5484,6 +5484,28 @@ mod tests {
             let result = ChatComposer::current_at_token(&textarea);
             assert!(
                 result.is_some(),
+                "Failed for case: {description} - input: '{input}', cursor: {cursor_pos}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_current_at_token_ignores_mid_word_at() {
+        let input = "foo@bar";
+        let at_pos = input.find('@').expect("@ present");
+        let test_cases = vec![
+            (at_pos, "Cursor at mid-word @"),
+            (input.len(), "Cursor at end of word containing @"),
+        ];
+
+        for (cursor_pos, description) in test_cases {
+            let mut textarea = TextArea::new();
+            textarea.insert_str(input);
+            textarea.set_cursor(cursor_pos);
+
+            let result = ChatComposer::current_at_token(&textarea);
+            assert_eq!(
+                result, None,
                 "Failed for case: {description} - input: '{input}', cursor: {cursor_pos}"
             );
         }


### PR DESCRIPTION
Fixes #12175

If a user types an npm package name with multiple `@` symbols like `npx -y @foo/bar@latest`, the TUI currently treats this as though it's attempting to invoke the file picker.

### What changed

- **Generalized `@` token parsing**
  - `current_prefixed_token(...)` now treats `@` as a token start **only at a whitespace boundary** (or start-of-line).
  - If the cursor is on a nested `@` inside an existing whitespace-delimited token (for example `@scope/pkg@latest`), it keeps the surrounding token active instead of starting a new token at the second `@`.
  - It also avoids misclassifying mid-word usages like `foo@bar` as an `@` file token.

- **Enter behavior with file popup**
  - If the file-search popup is open but has **no selected match**, pressing `Enter` now closes the popup and falls through to normal submit behavior.
  - This prevents pasted strings containing `@...` from blocking submission just because file-search was active with no actionable selection.

### Testing
I manually built and tested the scenarios involved with the bug report and related use of `@` mentions to verify no regressions
