### PR TITLE
fix(exec) Patch resume test race condition

### DIFF
--- a/codex-rs/exec/tests/suite/resume.rs
+++ b/codex-rs/exec/tests/suite/resume.rs
@@ -258,6 +258,10 @@ fn exec_resume_last_respects_cwd_filter_and_all_flag() -> anyhow::Result<()> {
     let path_b = find_session_file_containing_marker(&sessions_dir, &marker_b)
         .expect("no session file found for marker_b");
 
+    // `updated_at` is second-granularity, so ensure the touch lands in a later second
+    // than the initial session creation on fast CI (especially Windows).
+    std::thread::sleep(std::time::Duration::from_millis(1100));
+
     // Make thread B deterministically newest according to rollout metadata.
     let session_id_b = extract_conversation_id(&path_b);
     let marker_b_touch = format!("resume-cwd-b-touch-{}", Uuid::new_v4());


### PR DESCRIPTION
## Summary
The test exec_resume_last_respects_cwd_filter_and_all_flag makes one session “newest” by resuming it, but rollout updated_at is stored/sorted at second precision. On fast CI (especially Windows), the touch could land in the same second as initial session creation, making ordering nondeterministic.

This change adds a short sleep before the recency-touch step so the resumed session is guaranteed to have a later updated_at, preserving the intended assertion without changing product behavior.