### PR TITLE
memories: tighten consolidation prompt schema and indexing guidance

### DIFF
--- a/codex-rs/core/templates/memories/consolidation.md
+++ b/codex-rs/core/templates/memories/consolidation.md
@@ -260,6 +260,16 @@ Schema rules (strict):
   - If evidence conflicts and validation is unclear, preserve the uncertainty explicitly.
   - In `## General Tips`, cite task references (`[Task 1]`, `[Task 2]`, etc.) when
     merging, deduplicating, or resolving evidence.
+- F) Coverage and uniqueness invariants
+  - INIT mode: every `rollout_summary_file:` listed in `raw_memories.md` must appear in
+    `MEMORY.md` exactly once in some task’s `### rollout_summary_files` list.
+    If you cannot place a rollout cleanly, create a small, low-churn task section for it
+    instead of dropping it.
+  - Both modes: a rollout summary file must not appear in multiple tasks’ rollout lists.
+    If one rollout spans multiple tasks, cite it once under the most primary task and
+    reference it elsewhere only via prose (do not duplicate the file entry).
+  - A single task may cite multiple rollout summaries when they are iterative attempts
+    or follow-ups for the same task.
 
 What to write:
 - Extract the takeaways from rollout summaries and raw_memories, especially sections like
@@ -272,8 +282,10 @@ What to write:
   rollout summary, but still operational and concrete.
 - Use `raw_memories.md` as the routing layer and task inventory.
 - Before writing `MEMORY.md`, build a scratch mapping of `rollout_summary_file -> target
-  task group/task` from the full raw inventory so you can have a better overview. 
-  Note that each rollout summary file can belong to multiple tasks.
+  task group/task` from the full raw inventory so you can have a better overview.
+  Default: each rollout summary file should be assigned to exactly one `## Task <n>`
+  section (pick the primary intent), so the `### rollout_summary_files` index stays
+  deduplicated and usable.
 - Then deep-dive into `rollout_summaries/*.md` when:
   - the task is high-value and needs richer detail,
   - multiple rollouts overlap and need conflict/staleness resolution,
@@ -479,6 +491,10 @@ WORKFLOW
    - Use your best efforts to get the most high-quality memory files
    - Do not be lazy at browsing files in INIT mode; deep-dive high-value rollouts and
      conflicting task families until MEMORY blocks are richer and more useful than raw memories
+   - Mandatory validation (INIT):
+     - After writing, compute set coverage: confirm every `rollout_summary_file:` from
+       `raw_memories.md` appears in `MEMORY.md`, and that no rollout summary file is listed
+       in multiple tasks. If the check fails, fix the file and re-check until it passes.
 
 3) INCREMENTAL UPDATE behavior:
    - Treat `raw_memories.md` as the primary source of NEW signal.

--- a/codex-rs/core/templates/memories/consolidation.md
+++ b/codex-rs/core/templates/memories/consolidation.md
@@ -260,16 +260,6 @@ Schema rules (strict):
   - If evidence conflicts and validation is unclear, preserve the uncertainty explicitly.
   - In `## General Tips`, cite task references (`[Task 1]`, `[Task 2]`, etc.) when
     merging, deduplicating, or resolving evidence.
-- F) Coverage and uniqueness invariants
-  - INIT mode: every `rollout_summary_file:` listed in `raw_memories.md` must appear in
-    `MEMORY.md` exactly once in some task’s `### rollout_summary_files` list.
-    If you cannot place a rollout cleanly, create a small, low-churn task section for it
-    instead of dropping it.
-  - Both modes: a rollout summary file must not appear in multiple tasks’ rollout lists.
-    If one rollout spans multiple tasks, cite it once under the most primary task and
-    reference it elsewhere only via prose (do not duplicate the file entry).
-  - A single task may cite multiple rollout summaries when they are iterative attempts
-    or follow-ups for the same task.
 
 What to write:
 - Extract the takeaways from rollout summaries and raw_memories, especially sections like
@@ -282,10 +272,8 @@ What to write:
   rollout summary, but still operational and concrete.
 - Use `raw_memories.md` as the routing layer and task inventory.
 - Before writing `MEMORY.md`, build a scratch mapping of `rollout_summary_file -> target
-  task group/task` from the full raw inventory so you can have a better overview.
-  Default: each rollout summary file should be assigned to exactly one `## Task <n>`
-  section (pick the primary intent), so the `### rollout_summary_files` index stays
-  deduplicated and usable.
+  task group/task` from the full raw inventory so you can have a better overview. 
+  Note that each rollout summary file can belong to multiple tasks.
 - Then deep-dive into `rollout_summaries/*.md` when:
   - the task is high-value and needs richer detail,
   - multiple rollouts overlap and need conflict/staleness resolution,
@@ -491,10 +479,6 @@ WORKFLOW
    - Use your best efforts to get the most high-quality memory files
    - Do not be lazy at browsing files in INIT mode; deep-dive high-value rollouts and
      conflicting task families until MEMORY blocks are richer and more useful than raw memories
-   - Mandatory validation (INIT):
-     - After writing, compute set coverage: confirm every `rollout_summary_file:` from
-       `raw_memories.md` appears in `MEMORY.md`, and that no rollout summary file is listed
-       in multiple tasks. If the check fails, fix the file and re-check until it passes.
 
 3) INCREMENTAL UPDATE behavior:
    - Treat `raw_memories.md` as the primary source of NEW signal.

--- a/codex-rs/core/templates/memories/consolidation.md
+++ b/codex-rs/core/templates/memories/consolidation.md
@@ -171,8 +171,7 @@ Required task-oriented body shape (strict):
 ## Task 1: <task description, outcome>
 
 ### rollout_summary_files
-
-- <rollout_summaries/file1.md> (cwd=<path>, updated_at=<timestamp>, <optional status/usefulness note>)
+- <rollout_summaries/file1.md> (cwd=<path>, updated_at=<timestamp>, thread_id=<thread_id>, <optional status/usefulness note>)
 
 ### keywords
 
@@ -188,8 +187,6 @@ Required task-oriented body shape (strict):
 - <uncertainty explicitly preserved if unresolved>
 
 ## Task 2: <task description, outcome>
-
-task: <specific, searchable task signature; avoid fluff>
 
 ### rollout_summary_files
 
@@ -217,7 +214,7 @@ Schema rules (strict):
     `## General Tips`.
   - Keep all tasks and tips inside the task family implied by the block header.
   - Keep entries retrieval-friendly, but not shallow.
-  - Do not emit placeholder values (`task: task`, `# Task Group: misc`, `scope: general`, etc.).
+  - Do not emit placeholder values (`# Task Group: misc`, `scope: general`, `## Task 1: task`, etc.).
 - B) Task boundaries and clustering
   - Primary organization unit is the task (`## Task <n>`), not the rollout file.
   - Default mapping: one coherent rollout summary -> one MEMORY block -> one `## Task 1`.
@@ -228,6 +225,11 @@ Schema rules (strict):
     task group and the task intent, technical context, and outcome pattern align.
   - A single `## Task <n>` section may cite multiple rollout summaries when they are
     iterative attempts or follow-up runs for the same task.
+  - A rollout summary file may appear in multiple `## Task <n>` sections (including across
+    different `# Task Group` blocks) when the same rollout contains reusable evidence for
+    distinct task angles; this is allowed.
+  - If a rollout summary is reused across tasks/blocks, each placement should add distinct
+    task-local learnings or routing value (not copy-pasted repetition).
   - Do not cluster on keyword overlap alone.
   - When in doubt, preserve boundaries (separate tasks/blocks) rather than over-cluster.
 - C) Provenance and metadata
@@ -239,7 +241,6 @@ Schema rules (strict):
   - Major learnings should be traceable to rollout summaries listed in the same task section.
   - Order rollout references by freshness and practical usefulness.
 - D) Retrieval and references
-  - `task:` lines must be specific and searchable.
   - `### keywords` should be discriminative and task-local (tool names, error strings,
     repo concepts, APIs/contracts).
   - Put task-specific detail in `## Task <n>` and only deduplicated cross-task guidance in
@@ -332,14 +333,20 @@ For example, include (when known):
 ## What's in Memory
 This is a compact index to help future agents quickly find details in `MEMORY.md`,
 `skills/`, and `rollout_summaries/`.
-Organize by topic and split the index into a recent high-utility window and older topics.
-Each topic bullet must include: topic, keywords, and a clear description. Keywords must be
-representative and directly searchable in `MEMORY.md` (prefer exact strings: repo/project names, user query, tool names, error
-strings, commands, file paths, APIs/contracts; avoid vague synonyms).
-Order topics by utility, using `updated_at` recency as a strong default proxy unless there is
-strong contrary evidence.
-Do not target a fixed topic count. Cover the real high-signal areas and omit low-signal noise.
-Prefer grouping by task family / workflow intent, not by incidental tools alone.
+Treat it as a routing/index layer, not a mini-handbook:
+- tell future agents what to search first,
+- preserve enough specificity to route into the right `MEMORY.md` block quickly.
+
+Topic selection and quality rules:
+- Organize by topic and split the index into a recent high-utility window and older topics.
+- Do not target a fixed topic count. Include informative topics and omit low-signal noise.
+- Prefer grouping by task family / workflow intent, not by incidental tool overlap alone.
+- Order topics by utility, using `updated_at` recency as a strong default proxy unless there is
+  strong contrary evidence.
+- Each topic bullet must include: topic, keywords, and a clear description.
+- Keywords must be representative and directly searchable in `MEMORY.md`.
+  Prefer exact strings that a future agent can grep for (repo/project names, user query phrases,
+  tool names, error strings, commands, file paths, APIs/contracts). Avoid vague synonyms.
 
 Required subsection structure (in this order):
 
@@ -351,18 +358,22 @@ Recent Active Memory Window behavior (day-ordered):
 - Recent Active Memory Window = the most recent 3 distinct memory days present in the current
   memory inventory (`updated_at` dates), skipping empty date gaps (do not require consecutive dates).
 - If fewer than 3 memory days exist, include all available memory days.
-- For each of the 3 recent day subsections, include only the informative, likely-to-recur
-  topics touched on that day.
-- If a topic spans multiple recent days, list it under the most recent day it appears and do not
-  duplicate it under multiple days.
-- These entries should be more comprehensive than older-topic entries: richer keywords,
-  stronger / more detail descriptions, and concise recent learnings/change notes.
-- Group similar tasks / topics together.
+- For each recent-day subsection, prioritize informative, likely-to-recur topics and make
+  those entries richer (better keywords, clearer descriptions, and useful recent learnings);
+  do not spend much space on trivial tasks touched that day.
+- Preserve routing coverage for `MEMORY.md` in the overall index. If a recent day includes
+  less useful topics, include shorter/compact entries for routing rather than dropping them.
+- If a topic spans multiple recent days, list it under the most recent day it appears; do not
+  duplicate it under multiple day sections.
+- Recent-day entries should be richer than older-topic entries: stronger keywords, clearer
+  descriptions, and concise recent learnings/change notes.
+- Group similar tasks/topics together when it improves routing clarity.
+- Do not over cluster topics together, especially when they contain distinct task intents.
 
 Recent-topic format:
 - <topic>: <keyword1>, <keyword2>, <keyword3>, ...
-  - desc: <clear and specific description of what tasks are inside this topic>
-  - learnings: <concise recent takeaways / decision triggers worth checking first>
+  - desc: <clear and specific description of what tasks are inside this topic; what future task/user goal this helps with; what kinds of outcomes/artifacts/procedures are covered; and when to search this topic first>
+  - learnings: <some concise, topic-local recent takeaways / decision triggers / updates worth checking first; include useful specifics, but avoid overlap with `## General Tips` (cross-topic, broadly reusable guidance belongs there)>
 
 
 ### <2nd most recent memory day: YYYY-MM-DD>
@@ -376,7 +387,7 @@ Use the same format and keep it informative.
 ### Older Memory Topics
 
 All remaining high-signal topics not placed in the recent day subsections.
-Avoid duplicating recent topics.
+Avoid duplicating recent topics. Keep these compact and retrieval-oriented.
 
 Older-topic format (compact):
 - <topic>: <keyword1>, <keyword2>, <keyword3>, ...
@@ -386,6 +397,11 @@ Notes:
 - Do not include large snippets; push details into MEMORY.md and rollout summaries.
 - Prefer topics/keywords that help a future agent search MEMORY.md efficiently.
 - Prefer clear topic taxonomy over verbose drill-down pointers.
+- This section is primarily an index to `MEMORY.md`; mention `skills/` / `rollout_summaries/`
+  only when they materially improve routing.
+- Separation rule: recent-topic `learnings` should emphasize topic-local recent deltas,
+  caveats, and decision triggers; move cross-topic, stable, broadly reusable guidance to
+  `## General Tips`.
 - Coverage guardrail: ensure every top-level `# Task Group` in `MEMORY.md` is represented by
   at least one topic bullet in this index (either directly or via a clearly subsuming topic).
 - Keep descriptions explicit: what is inside, when to use it, and what kind of
@@ -497,8 +513,11 @@ WORKFLOW
      - rebuilding the `memory_summary.md` recent active window (last 3 memory days) from current `updated_at` coverage
      - updating existing skills or adding new skills only when there is clear new reusable procedure
      - update `memory_summary.md` last to reflect the final state of the memory folder
-   - Minimize churn in incremental mode: unchanged blocks should stay mostly unchanged in
-     wording/order unless you are fixing an actual problem (staleness, ambiguity, schema drift).
+   - Minimize churn in incremental mode: if an existing `MEMORY.md` block or `## What's in Memory`
+     topic still reflects the current evidence and points to the same task family / retrieval
+     target, keep its wording, label, and relative order mostly stable. Rewrite/reorder/rename/
+     split/merge only when fixing a real problem (staleness, ambiguity, schema drift, wrong
+     boundaries) or when meaningful new evidence materially improves retrieval clarity/searchability.
 
 4) Evidence deep-dive rule (both modes):
    - `raw_memories.md` is the routing layer, not always the final authority for detail.
@@ -520,15 +539,22 @@ WORKFLOW
    - if multiple summaries overlap for the same thread, keep the best one
 
 7) Final pass:
-   - remove duplication in memory_summary, skills/, and MEMORY.md
-   - remove stale or low-signal blocks that are less likely to be useful in the future
-   - run a global rollout-reference audit on final `MEMORY.md` and fix duplicates before finishing
-   - ensure any referenced skills/summaries actually exist
-   - ensure MEMORY blocks and "What's in Memory" use a consistent task-oriented taxonomy
-   - ensure recent important task families are easy to find (description + keywords + topic wording)
-   - verify `MEMORY.md` block order and `What's in Memory` section order reflect current
+  - remove duplication in memory_summary, skills/, and MEMORY.md
+  - remove stale or low-signal blocks that are less likely to be useful in the future
+  - run a global rollout-reference audit on final `MEMORY.md` and fix accidental duplicate
+    entries / redundant repetition, while preserving intentional multi-task or multi-block
+    reuse when it adds distinct task-local value
+  - ensure any referenced skills/summaries actually exist
+  - ensure MEMORY blocks and "What's in Memory" use a consistent task-oriented taxonomy
+  - ensure recent important task families are easy to find (description + keywords + topic wording)
+  - verify `MEMORY.md` block order and `What's in Memory` section order reflect current
      utility/recency priorities (especially the recent active memory window)
-   - if there is no net-new or higher-quality signal to add, keep changes minimal (no
+  - verify `## What's in Memory` quality checks:
+    - recent-day headings are correctly day-ordered
+    - no accidental duplicate topic bullets across recent-day sections and `### Older Memory Topics`
+    - topic coverage still represents all top-level `# Task Group` blocks in `MEMORY.md`
+    - topic keywords are grep-friendly and likely searchable in `MEMORY.md`
+  - if there is no net-new or higher-quality signal to add, keep changes minimal (no
      churn for its own sake).
 
 You should dive deep and make sure you didn't miss any important information that might


### PR DESCRIPTION
## Summary
- tighten the Phase 2 consolidation prompt for task-oriented `MEMORY.md` generation
- address Phase 2 under-coverage / "laziness" with stronger workflow + final-pass checks
- improve recency/ordering behavior for `MEMORY.md` and `memory_summary.md`
- rewrite `## What's in Memory` as a clearer routing index with explicit recent-3-day structure

## Key Changes
- `MEMORY.md` schema cleanup:
  - align on `## Task <n>` task sections (remove stale `task:` rule/example references)
  - include `thread_id` in rollout provenance examples
  - compact comma-separated `### keywords` format
- Phase 2 completeness guardrails:
  - chunked INIT coverage pass over `raw_memories.md`
  - incremental net-new indexing / routing steps
  - stronger final checks (day ordering, topic coverage, keyword searchability, accidental duplication)
- Recency / ordering rules:
  - clearer scan-order guidance for raw memories (newest-first bias in incremental mode)
  - utility+recency ordering guidance for `MEMORY.md` task groups and summary topics
  - rebuild recent active window from current `updated_at` coverage
- `## What's in Memory` rewrite:
  - index/routing-layer framing (not a mini-handbook)
  - explicit recent 3 distinct memory-day layout
  - richer recent-topic entries + compact lower-priority routing entries
  - clearer `desc` / `learnings` expectations and separation from `## General Tips`
- Explicitly allow rollout-summary reuse across multiple tasks/blocks when it supports distinct task angles (with distinct task-local value)

## Notes
- Prompt-template only: `codex-rs/core/templates/memories/consolidation.md`
- No runtime/code changes

## Validation
- Manual diff review only
