### PR TITLE
feat(tui): add "clean context and implement" option to Plan Mode popup

### DIFF
--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -359,6 +359,11 @@ pub(crate) enum AppEvent {
         collaboration_mode: CollaborationModeMask,
     },
 
+    /// Start a fresh session with only the plan text and implement it.
+    CleanContextAndImplementPlan {
+        plan_text: String,
+    },
+
     /// Open the approval popup.
     FullScreenApprovalRequest(ApprovalRequest),
 

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plan_implementation_popup.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plan_implementation_popup.snap
@@ -4,7 +4,12 @@ expression: popup
 ---
   Implement this plan?
 
-› 1. Yes, implement this plan  Switch to Default and start coding.
-  2. No, stay in Plan mode     Continue planning with the model.
+› 1. Yes, clean context and implement (disabled)  Start fresh session with
+                                                  only the plan. (disabled: No
+                                                  plan text available)
+  2. Yes, implement this plan                     Switch to Default and start
+                                                  coding.
+  3. No, stay in Plan mode                        Continue planning with the
+                                                  model.
 
   Press enter to confirm or esc to go back

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plan_implementation_popup_clean_context_selected.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plan_implementation_popup_clean_context_selected.snap
@@ -1,0 +1,11 @@
+---
+source: tui/src/chatwidget/tests.rs
+expression: popup
+---
+  Implement this plan?
+
+› 1. Yes, clean context and implement  Start fresh session with only the plan.
+  2. Yes, implement this plan          Switch to Default and start coding.
+  3. No, stay in Plan mode             Continue planning with the model.
+
+  Press enter to confirm or esc to go back

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plan_implementation_popup_no_selected.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plan_implementation_popup_no_selected.snap
@@ -4,7 +4,12 @@ expression: popup
 ---
   Implement this plan?
 
-  1. Yes, implement this plan  Switch to Default and start coding.
-› 2. No, stay in Plan mode     Continue planning with the model.
+  1. Yes, clean context and implement (disabled)  Start fresh session with
+                                                  only the plan. (disabled: No
+                                                  plan text available)
+  2. Yes, implement this plan                     Switch to Default and start
+                                                  coding.
+› 3. No, stay in Plan mode                        Continue planning with the
+                                                  model.
 
   Press enter to confirm or esc to go back


### PR DESCRIPTION
## Summary
- Adds a third option to the Plan Mode implementation popup: **"Yes, clean context and implement"**
- Captures the finalized plan text, starts a completely new session (clean context), and auto-submits "Implement the following plan:" as the first message in Default mode
- The option is disabled with a visible reason when no plan text is available
- Follows the existing "compact and continue" pattern already used in the codebase

## Changes
- `app_event.rs`: New `CleanContextAndImplementPlan` event variant
- `chatwidget.rs`: Store `last_plan_text` on plan completion, add third popup item
- `app.rs`: Handler + `start_clean_context_implement()` method (modeled after `start_fresh_session_with_summary_hint`)
- `tests.rs`: 4 new tests, 2 existing tests adjusted for new item order
- Snapshots updated

## Test plan
- [x] `cargo build -p codex-tui` compiles without warnings
- [x] `cargo test -p codex-tui -- plan_implementation` — all 13 tests pass
- [x] Manual test: Plan mode → create plan → popup shows 3 options → "clean context" starts fresh session with plan auto-submitted