### PR TITLE
Add TUI realtime conversation mode

### DIFF
--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -367,6 +367,9 @@
             "prevent_idle_sleep": {
               "type": "boolean"
             },
+            "realtime_conversation": {
+              "type": "boolean"
+            },
             "remote_models": {
               "type": "boolean"
             },
@@ -1652,6 +1655,9 @@
           "type": "boolean"
         },
         "prevent_idle_sleep": {
+          "type": "boolean"
+        },
+        "realtime_conversation": {
           "type": "boolean"
         },
         "remote_models": {

--- a/codex-rs/core/src/features.rs
+++ b/codex-rs/core/src/features.rs
@@ -142,6 +142,8 @@ pub enum Feature {
     Personality,
     /// Enable voice transcription in the TUI composer.
     VoiceTranscription,
+    /// Enable experimental realtime voice conversation mode in the TUI.
+    RealtimeConversation,
     /// Prevent idle system sleep while a turn is actively running.
     PreventIdleSleep,
     /// Use the Responses API WebSocket transport for OpenAI by default.
@@ -640,6 +642,12 @@ pub const FEATURES: &[FeatureSpec] = &[
     FeatureSpec {
         id: Feature::VoiceTranscription,
         key: "voice_transcription",
+        stage: Stage::UnderDevelopment,
+        default_enabled: false,
+    },
+    FeatureSpec {
+        id: Feature::RealtimeConversation,
+        key: "realtime_conversation",
         stage: Stage::UnderDevelopment,
         default_enabled: false,
     },

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -389,6 +389,7 @@ pub(crate) struct ChatComposer {
     collaboration_mode_indicator: Option<CollaborationModeIndicator>,
     connectors_enabled: bool,
     personality_command_enabled: bool,
+    realtime_conversation_enabled: bool,
     windows_degraded_sandbox_active: bool,
     status_line_value: Option<Line<'static>>,
     status_line_enabled: bool,
@@ -494,6 +495,7 @@ impl ChatComposer {
             collaboration_mode_indicator: None,
             connectors_enabled: false,
             personality_command_enabled: false,
+            realtime_conversation_enabled: false,
             windows_degraded_sandbox_active: false,
             status_line_value: None,
             status_line_enabled: false,
@@ -576,6 +578,10 @@ impl ChatComposer {
 
     pub fn set_personality_command_enabled(&mut self, enabled: bool) {
         self.personality_command_enabled = enabled;
+    }
+
+    pub fn set_realtime_conversation_enabled(&mut self, enabled: bool) {
+        self.realtime_conversation_enabled = enabled;
     }
 
     pub fn set_voice_transcription_enabled(&mut self, enabled: bool) {
@@ -2245,6 +2251,7 @@ impl ChatComposer {
                     self.collaboration_modes_enabled,
                     self.connectors_enabled,
                     self.personality_command_enabled,
+                    self.realtime_conversation_enabled,
                     self.windows_degraded_sandbox_active,
                 )
                 .is_some();
@@ -2444,6 +2451,7 @@ impl ChatComposer {
                 self.collaboration_modes_enabled,
                 self.connectors_enabled,
                 self.personality_command_enabled,
+                self.realtime_conversation_enabled,
                 self.windows_degraded_sandbox_active,
             )
         {
@@ -2478,6 +2486,7 @@ impl ChatComposer {
             self.collaboration_modes_enabled,
             self.connectors_enabled,
             self.personality_command_enabled,
+            self.realtime_conversation_enabled,
             self.windows_degraded_sandbox_active,
         )?;
 
@@ -3310,6 +3319,7 @@ impl ChatComposer {
             self.collaboration_modes_enabled,
             self.connectors_enabled,
             self.personality_command_enabled,
+            self.realtime_conversation_enabled,
             self.windows_degraded_sandbox_active,
         )
         .is_some();
@@ -3371,6 +3381,7 @@ impl ChatComposer {
             self.collaboration_modes_enabled,
             self.connectors_enabled,
             self.personality_command_enabled,
+            self.realtime_conversation_enabled,
             self.windows_degraded_sandbox_active,
         ) {
             return true;
@@ -3424,12 +3435,14 @@ impl ChatComposer {
                     let collaboration_modes_enabled = self.collaboration_modes_enabled;
                     let connectors_enabled = self.connectors_enabled;
                     let personality_command_enabled = self.personality_command_enabled;
+                    let realtime_conversation_enabled = self.realtime_conversation_enabled;
                     let mut command_popup = CommandPopup::new(
                         self.custom_prompts.clone(),
                         CommandPopupFlags {
                             collaboration_modes_enabled,
                             connectors_enabled,
                             personality_command_enabled,
+                            realtime_conversation_enabled,
                             windows_degraded_sandbox_active: self.windows_degraded_sandbox_active,
                         },
                     );
@@ -3938,6 +3951,13 @@ impl ChatComposer {
 
     pub fn update_transcription_in_place(&mut self, id: &str, text: &str) -> bool {
         self.textarea.update_named_element_by_id(id, text)
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    pub fn insert_transcription_placeholder(&mut self, text: &str) -> String {
+        let id = self.next_id();
+        self.textarea.insert_named_element(text, id.clone());
+        id
     }
 
     pub fn remove_transcription_placeholder(&mut self, id: &str) {

--- a/codex-rs/tui/src/bottom_pane/command_popup.rs
+++ b/codex-rs/tui/src/bottom_pane/command_popup.rs
@@ -39,6 +39,7 @@ pub(crate) struct CommandPopupFlags {
     pub(crate) collaboration_modes_enabled: bool,
     pub(crate) connectors_enabled: bool,
     pub(crate) personality_command_enabled: bool,
+    pub(crate) realtime_conversation_enabled: bool,
     pub(crate) windows_degraded_sandbox_active: bool,
 }
 
@@ -49,6 +50,7 @@ impl CommandPopup {
             flags.collaboration_modes_enabled,
             flags.connectors_enabled,
             flags.personality_command_enabled,
+            flags.realtime_conversation_enabled,
             flags.windows_degraded_sandbox_active,
         )
         .into_iter()
@@ -495,6 +497,7 @@ mod tests {
                 collaboration_modes_enabled: true,
                 connectors_enabled: false,
                 personality_command_enabled: true,
+                realtime_conversation_enabled: false,
                 windows_degraded_sandbox_active: false,
             },
         );
@@ -514,6 +517,7 @@ mod tests {
                 collaboration_modes_enabled: true,
                 connectors_enabled: false,
                 personality_command_enabled: true,
+                realtime_conversation_enabled: false,
                 windows_degraded_sandbox_active: false,
             },
         );
@@ -533,6 +537,7 @@ mod tests {
                 collaboration_modes_enabled: true,
                 connectors_enabled: false,
                 personality_command_enabled: false,
+                realtime_conversation_enabled: false,
                 windows_degraded_sandbox_active: false,
             },
         );
@@ -560,6 +565,7 @@ mod tests {
                 collaboration_modes_enabled: true,
                 connectors_enabled: false,
                 personality_command_enabled: true,
+                realtime_conversation_enabled: false,
                 windows_degraded_sandbox_active: false,
             },
         );

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -292,6 +292,11 @@ impl BottomPane {
         self.request_redraw();
     }
 
+    pub fn set_realtime_conversation_enabled(&mut self, enabled: bool) {
+        self.composer.set_realtime_conversation_enabled(enabled);
+        self.request_redraw();
+    }
+
     pub fn set_voice_transcription_enabled(&mut self, enabled: bool) {
         self.composer.set_voice_transcription_enabled(enabled);
         self.request_redraw();
@@ -1007,6 +1012,13 @@ impl BottomPane {
 
 #[cfg(not(target_os = "linux"))]
 impl BottomPane {
+    pub(crate) fn insert_transcription_placeholder(&mut self, text: &str) -> String {
+        let id = self.composer.insert_transcription_placeholder(text);
+        self.composer.sync_popups();
+        self.request_redraw();
+        id
+    }
+
     pub(crate) fn replace_transcription(&mut self, id: &str, text: &str) {
         self.composer.replace_transcription(id, text);
         self.composer.sync_popups();

--- a/codex-rs/tui/src/bottom_pane/slash_commands.rs
+++ b/codex-rs/tui/src/bottom_pane/slash_commands.rs
@@ -88,4 +88,12 @@ mod tests {
             Some(SlashCommand::Clear)
         );
     }
+
+    #[test]
+    fn realtime_command_is_hidden_when_realtime_is_disabled() {
+        assert_eq!(
+            find_builtin_command("realtime", true, true, true, false, false),
+            None
+        );
+    }
 }

--- a/codex-rs/tui/src/bottom_pane/slash_commands.rs
+++ b/codex-rs/tui/src/bottom_pane/slash_commands.rs
@@ -13,6 +13,7 @@ pub(crate) fn builtins_for_input(
     collaboration_modes_enabled: bool,
     connectors_enabled: bool,
     personality_command_enabled: bool,
+    realtime_conversation_enabled: bool,
     allow_elevate_sandbox: bool,
 ) -> Vec<(&'static str, SlashCommand)> {
     built_in_slash_commands()
@@ -24,6 +25,7 @@ pub(crate) fn builtins_for_input(
         })
         .filter(|(_, cmd)| connectors_enabled || *cmd != SlashCommand::Apps)
         .filter(|(_, cmd)| personality_command_enabled || *cmd != SlashCommand::Personality)
+        .filter(|(_, cmd)| realtime_conversation_enabled || *cmd != SlashCommand::Realtime)
         .collect()
 }
 
@@ -33,12 +35,14 @@ pub(crate) fn find_builtin_command(
     collaboration_modes_enabled: bool,
     connectors_enabled: bool,
     personality_command_enabled: bool,
+    realtime_conversation_enabled: bool,
     allow_elevate_sandbox: bool,
 ) -> Option<SlashCommand> {
     builtins_for_input(
         collaboration_modes_enabled,
         connectors_enabled,
         personality_command_enabled,
+        realtime_conversation_enabled,
         allow_elevate_sandbox,
     )
     .into_iter()
@@ -52,12 +56,14 @@ pub(crate) fn has_builtin_prefix(
     collaboration_modes_enabled: bool,
     connectors_enabled: bool,
     personality_command_enabled: bool,
+    realtime_conversation_enabled: bool,
     allow_elevate_sandbox: bool,
 ) -> bool {
     builtins_for_input(
         collaboration_modes_enabled,
         connectors_enabled,
         personality_command_enabled,
+        realtime_conversation_enabled,
         allow_elevate_sandbox,
     )
     .into_iter()
@@ -71,14 +77,14 @@ mod tests {
 
     #[test]
     fn debug_command_still_resolves_for_dispatch() {
-        let cmd = find_builtin_command("debug-config", true, true, true, false);
+        let cmd = find_builtin_command("debug-config", true, true, true, false, false);
         assert_eq!(cmd, Some(SlashCommand::DebugConfig));
     }
 
     #[test]
     fn clear_command_resolves_for_dispatch() {
         assert_eq!(
-            find_builtin_command("clear", true, true, true, false),
+            find_builtin_command("clear", true, true, true, false, false),
             Some(SlashCommand::Clear)
         );
     }

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -45,7 +45,6 @@ use crate::status::format_tokens_compact;
 use crate::status::rate_limit_snapshot_display_for_limit;
 use crate::text_formatting::proper_join;
 use crate::version::CODEX_CLI_VERSION;
-#[cfg(not(target_os = "linux"))]
 use codex_app_server_protocol::ConfigLayerSource;
 use codex_backend_client::Client as BackendClient;
 use codex_chatgpt::connectors;
@@ -93,7 +92,6 @@ use codex_protocol::protocol::AgentReasoningRawContentEvent;
 use codex_protocol::protocol::ApplyPatchApprovalRequestEvent;
 use codex_protocol::protocol::BackgroundEventEvent;
 use codex_protocol::protocol::CodexErrorInfo;
-#[cfg(not(target_os = "linux"))]
 use codex_protocol::protocol::ConversationStartParams;
 use codex_protocol::protocol::CreditsSnapshot;
 use codex_protocol::protocol::DeprecationNoticeEvent;

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -94,6 +94,7 @@ use codex_protocol::protocol::AgentReasoningRawContentEvent;
 use codex_protocol::protocol::ApplyPatchApprovalRequestEvent;
 use codex_protocol::protocol::BackgroundEventEvent;
 use codex_protocol::protocol::CodexErrorInfo;
+#[cfg(not(target_os = "linux"))]
 use codex_protocol::protocol::ConversationAudioParams;
 use codex_protocol::protocol::ConversationStartParams;
 use codex_protocol::protocol::CreditsSnapshot;

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -552,7 +552,7 @@ impl RealtimeConversationUiState {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 struct RenderedUserMessageEvent {
     message: String,
     remote_image_urls: Vec<String>,

--- a/codex-rs/tui/src/chatwidget/realtime.rs
+++ b/codex-rs/tui/src/chatwidget/realtime.rs
@@ -1,0 +1,299 @@
+use super::*;
+use codex_protocol::protocol::ConversationStartParams;
+use codex_protocol::protocol::RealtimeAudioFrame;
+use codex_protocol::protocol::RealtimeConversationClosedEvent;
+use codex_protocol::protocol::RealtimeConversationRealtimeEvent;
+use codex_protocol::protocol::RealtimeConversationStartedEvent;
+use codex_protocol::protocol::RealtimeEvent;
+use tracing::warn;
+
+const REALTIME_CONVERSATION_PROMPT: &str = "You are in a realtime voice conversation in the Codex TUI. Respond conversationally and concisely.";
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(super) enum RealtimeConversationPhase {
+    #[default]
+    Inactive,
+    Starting,
+    Active,
+    Stopping,
+}
+
+#[derive(Default)]
+pub(super) struct RealtimeConversationUiState {
+    phase: RealtimeConversationPhase,
+    requested_close: bool,
+    session_id: Option<String>,
+    warned_audio_only_submission: bool,
+    meter_placeholder_id: Option<String>,
+    #[cfg(not(target_os = "linux"))]
+    capture_stop_flag: Option<Arc<AtomicBool>>,
+    #[cfg(not(target_os = "linux"))]
+    capture: Option<crate::voice::VoiceCapture>,
+    #[cfg(not(target_os = "linux"))]
+    audio_player: Option<crate::voice::RealtimeAudioPlayer>,
+}
+
+impl RealtimeConversationUiState {
+    pub(super) fn is_live(&self) -> bool {
+        matches!(
+            self.phase,
+            RealtimeConversationPhase::Starting
+                | RealtimeConversationPhase::Active
+                | RealtimeConversationPhase::Stopping
+        )
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(super) struct RenderedUserMessageEvent {
+    message: String,
+    remote_image_urls: Vec<String>,
+    local_images: Vec<PathBuf>,
+    text_elements: Vec<TextElement>,
+}
+
+impl ChatWidget {
+    pub(super) fn rendered_user_message_event_from_parts(
+        message: String,
+        text_elements: Vec<TextElement>,
+        local_images: Vec<PathBuf>,
+        remote_image_urls: Vec<String>,
+    ) -> RenderedUserMessageEvent {
+        RenderedUserMessageEvent {
+            message,
+            remote_image_urls,
+            local_images,
+            text_elements,
+        }
+    }
+
+    pub(super) fn rendered_user_message_event_from_event(
+        event: &UserMessageEvent,
+    ) -> RenderedUserMessageEvent {
+        Self::rendered_user_message_event_from_parts(
+            event.message.clone(),
+            event.text_elements.clone(),
+            event.local_images.clone(),
+            event.images.clone().unwrap_or_default(),
+        )
+    }
+
+    pub(super) fn should_render_realtime_user_message_event(
+        &self,
+        event: &UserMessageEvent,
+    ) -> bool {
+        if !self.realtime_conversation.is_live() {
+            return false;
+        }
+        let key = Self::rendered_user_message_event_from_event(event);
+        self.last_rendered_user_message_event.as_ref() != Some(&key)
+    }
+
+    pub(super) fn maybe_defer_user_message_for_realtime(
+        &mut self,
+        user_message: UserMessage,
+    ) -> Option<UserMessage> {
+        if !self.realtime_conversation.is_live() {
+            return Some(user_message);
+        }
+
+        self.restore_user_message_to_composer(user_message);
+        if !self.realtime_conversation.warned_audio_only_submission {
+            self.realtime_conversation.warned_audio_only_submission = true;
+            self.add_info_message(
+                "Realtime voice mode is audio-only. Use /realtime to stop.".to_string(),
+                None,
+            );
+        } else {
+            self.request_redraw();
+        }
+
+        None
+    }
+
+    fn realtime_footer_hint_items() -> Vec<(String, String)> {
+        vec![("/realtime".to_string(), "stop live voice".to_string())]
+    }
+
+    pub(super) fn start_realtime_conversation(&mut self) {
+        self.realtime_conversation.phase = RealtimeConversationPhase::Starting;
+        self.realtime_conversation.requested_close = false;
+        self.realtime_conversation.session_id = None;
+        self.realtime_conversation.warned_audio_only_submission = false;
+        self.set_footer_hint_override(Some(Self::realtime_footer_hint_items()));
+        self.submit_op(Op::RealtimeConversationStart(ConversationStartParams {
+            prompt: REALTIME_CONVERSATION_PROMPT.to_string(),
+            session_id: None,
+        }));
+        self.request_redraw();
+    }
+
+    pub(super) fn request_realtime_conversation_close(&mut self, info_message: Option<String>) {
+        if !self.realtime_conversation.is_live() {
+            if let Some(message) = info_message {
+                self.add_info_message(message, None);
+            }
+            return;
+        }
+
+        self.realtime_conversation.requested_close = true;
+        self.realtime_conversation.phase = RealtimeConversationPhase::Stopping;
+        self.submit_op(Op::RealtimeConversationClose);
+        self.stop_realtime_local_audio();
+        self.set_footer_hint_override(None);
+
+        if let Some(message) = info_message {
+            self.add_info_message(message, None);
+        } else {
+            self.request_redraw();
+        }
+    }
+
+    pub(super) fn reset_realtime_conversation_state(&mut self) {
+        self.stop_realtime_local_audio();
+        self.set_footer_hint_override(None);
+        self.realtime_conversation.phase = RealtimeConversationPhase::Inactive;
+        self.realtime_conversation.requested_close = false;
+        self.realtime_conversation.session_id = None;
+        self.realtime_conversation.warned_audio_only_submission = false;
+    }
+
+    pub(super) fn on_realtime_conversation_started(
+        &mut self,
+        ev: RealtimeConversationStartedEvent,
+    ) {
+        if !self.realtime_conversation_enabled() {
+            self.submit_op(Op::RealtimeConversationClose);
+            self.reset_realtime_conversation_state();
+            return;
+        }
+        self.realtime_conversation.phase = RealtimeConversationPhase::Active;
+        self.realtime_conversation.session_id = ev.session_id;
+        self.realtime_conversation.warned_audio_only_submission = false;
+        self.set_footer_hint_override(Some(Self::realtime_footer_hint_items()));
+        self.start_realtime_local_audio();
+        self.request_redraw();
+    }
+
+    pub(super) fn on_realtime_conversation_realtime(
+        &mut self,
+        ev: RealtimeConversationRealtimeEvent,
+    ) {
+        match ev.payload {
+            RealtimeEvent::SessionCreated { session_id } => {
+                self.realtime_conversation.session_id = Some(session_id);
+            }
+            RealtimeEvent::SessionUpdated { .. } => {}
+            RealtimeEvent::AudioOut(frame) => self.enqueue_realtime_audio_out(&frame),
+            RealtimeEvent::ConversationItemAdded(_item) => {}
+            RealtimeEvent::Error(message) => {
+                self.add_error_message(format!("Realtime voice error: {message}"));
+                self.reset_realtime_conversation_state();
+            }
+        }
+    }
+
+    pub(super) fn on_realtime_conversation_closed(&mut self, ev: RealtimeConversationClosedEvent) {
+        let requested = self.realtime_conversation.requested_close;
+        let reason = ev.reason;
+        self.reset_realtime_conversation_state();
+        if !requested && let Some(reason) = reason {
+            self.add_info_message(format!("Realtime voice mode closed: {reason}"), None);
+        }
+        self.request_redraw();
+    }
+
+    fn enqueue_realtime_audio_out(&mut self, frame: &RealtimeAudioFrame) {
+        #[cfg(not(target_os = "linux"))]
+        {
+            if self.realtime_conversation.audio_player.is_none() {
+                self.realtime_conversation.audio_player =
+                    crate::voice::RealtimeAudioPlayer::start().ok();
+            }
+            if let Some(player) = &self.realtime_conversation.audio_player
+                && let Err(err) = player.enqueue_frame(frame)
+            {
+                warn!("failed to play realtime audio: {err}");
+            }
+        }
+        #[cfg(target_os = "linux")]
+        {
+            let _ = frame;
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn start_realtime_local_audio(&mut self) {
+        if self.realtime_conversation.capture_stop_flag.is_some() {
+            return;
+        }
+
+        let placeholder_id = self.bottom_pane.insert_transcription_placeholder("⠤⠤⠤⠤");
+        self.realtime_conversation.meter_placeholder_id = Some(placeholder_id.clone());
+        self.request_redraw();
+
+        let capture = match crate::voice::VoiceCapture::start_realtime(self.app_event_tx.clone()) {
+            Ok(capture) => capture,
+            Err(err) => {
+                self.remove_transcription_placeholder(&placeholder_id);
+                self.realtime_conversation.meter_placeholder_id = None;
+                self.add_error_message(format!("Failed to start microphone capture: {err}"));
+                return;
+            }
+        };
+
+        let stop_flag = capture.stopped_flag();
+        let peak = capture.last_peak_arc();
+        let meter_placeholder_id = placeholder_id;
+        let app_event_tx = self.app_event_tx.clone();
+
+        self.realtime_conversation.capture_stop_flag = Some(stop_flag.clone());
+        self.realtime_conversation.capture = Some(capture);
+        if self.realtime_conversation.audio_player.is_none() {
+            self.realtime_conversation.audio_player =
+                crate::voice::RealtimeAudioPlayer::start().ok();
+        }
+
+        std::thread::spawn(move || {
+            let mut meter = crate::voice::RecordingMeterState::new();
+
+            loop {
+                if stop_flag.load(Ordering::Relaxed) {
+                    break;
+                }
+
+                let meter_text = meter.next_text(peak.load(Ordering::Relaxed));
+                app_event_tx.send(AppEvent::UpdateRecordingMeter {
+                    id: meter_placeholder_id.clone(),
+                    text: meter_text,
+                });
+
+                std::thread::sleep(Duration::from_millis(60));
+            }
+        });
+    }
+
+    #[cfg(target_os = "linux")]
+    fn start_realtime_local_audio(&mut self) {}
+
+    #[cfg(not(target_os = "linux"))]
+    fn stop_realtime_local_audio(&mut self) {
+        if let Some(flag) = self.realtime_conversation.capture_stop_flag.take() {
+            flag.store(true, Ordering::Relaxed);
+        }
+        if let Some(capture) = self.realtime_conversation.capture.take() {
+            let _ = capture.stop();
+        }
+        if let Some(id) = self.realtime_conversation.meter_placeholder_id.take() {
+            self.remove_transcription_placeholder(&id);
+        }
+        if let Some(player) = self.realtime_conversation.audio_player.take() {
+            player.clear();
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn stop_realtime_local_audio(&mut self) {
+        self.realtime_conversation.meter_placeholder_id = None;
+    }
+}

--- a/codex-rs/tui/src/chatwidget/realtime.rs
+++ b/codex-rs/tui/src/chatwidget/realtime.rs
@@ -5,7 +5,6 @@ use codex_protocol::protocol::RealtimeConversationClosedEvent;
 use codex_protocol::protocol::RealtimeConversationRealtimeEvent;
 use codex_protocol::protocol::RealtimeConversationStartedEvent;
 use codex_protocol::protocol::RealtimeEvent;
-use tracing::warn;
 
 const REALTIME_CONVERSATION_PROMPT: &str = "You are in a realtime voice conversation in the Codex TUI. Respond conversationally and concisely.";
 

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -1720,6 +1720,7 @@ async fn make_chatwidget_manual(
         status_line_branch_pending: false,
         status_line_branch_lookup_complete: false,
         external_editor_state: ExternalEditorState::Closed,
+        realtime_conversation: RealtimeConversationUiState::default(),
     };
     widget.set_model(&resolved_model);
     (widget, rx, op_rx)

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -1721,6 +1721,7 @@ async fn make_chatwidget_manual(
         status_line_branch_lookup_complete: false,
         external_editor_state: ExternalEditorState::Closed,
         realtime_conversation: RealtimeConversationUiState::default(),
+        last_rendered_user_message_event: None,
     };
     widget.set_model(&resolved_model);
     (widget, rx, op_rx)

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -120,6 +120,7 @@ mod voice;
 mod voice {
     use crate::app_event::AppEvent;
     use crate::app_event_sender::AppEventSender;
+    use codex_protocol::protocol::RealtimeAudioFrame;
     use std::sync::Arc;
     use std::sync::Mutex;
     use std::sync::atomic::AtomicBool;
@@ -134,6 +135,8 @@ mod voice {
     pub struct VoiceCapture;
 
     pub(crate) struct RecordingMeterState;
+
+    pub(crate) struct RealtimeAudioPlayer;
 
     impl VoiceCapture {
         pub fn start() -> Result<Self, String> {
@@ -173,6 +176,18 @@ mod voice {
         pub(crate) fn next_text(&mut self, _peak: u16) -> String {
             "⠤⠤⠤⠤".to_string()
         }
+    }
+
+    impl RealtimeAudioPlayer {
+        pub(crate) fn start() -> Result<Self, String> {
+            Err("voice output is unavailable in this build".to_string())
+        }
+
+        pub(crate) fn enqueue_frame(&self, _frame: &RealtimeAudioFrame) -> Result<(), String> {
+            Err("voice output is unavailable in this build".to_string())
+        }
+
+        pub(crate) fn clear(&self) {}
     }
 
     pub fn transcribe_async(

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -143,6 +143,10 @@ mod voice {
             Err("voice input is unavailable in this build".to_string())
         }
 
+        pub fn start_realtime(_tx: AppEventSender) -> Result<Self, String> {
+            Err("voice input is unavailable in this build".to_string())
+        }
+
         pub fn stop(self) -> Result<RecordedAudio, String> {
             Err("voice input is unavailable in this build".to_string())
         }

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -49,6 +49,7 @@ pub enum SlashCommand {
     Clean,
     Clear,
     Personality,
+    Realtime,
     TestApproval,
     // Debugging commands.
     #[strum(serialize = "debug-m-drop")]
@@ -85,6 +86,7 @@ impl SlashCommand {
             SlashCommand::MemoryUpdate => "DO NOT USE",
             SlashCommand::Model => "choose what model and reasoning effort to use",
             SlashCommand::Personality => "choose a communication style for Codex",
+            SlashCommand::Realtime => "toggle realtime voice mode (experimental)",
             SlashCommand::Plan => "switch to Plan mode",
             SlashCommand::Collab => "change collaboration mode (experimental)",
             SlashCommand::Agent => "switch the active agent thread",
@@ -157,6 +159,7 @@ impl SlashCommand {
             | SlashCommand::Exit => true,
             SlashCommand::Rollout => true,
             SlashCommand::TestApproval => true,
+            SlashCommand::Realtime => true,
             SlashCommand::Collab => true,
             SlashCommand::Agent => true,
             SlashCommand::Statusline => false,

--- a/codex-rs/tui/src/voice.rs
+++ b/codex-rs/tui/src/voice.rs
@@ -517,6 +517,7 @@ impl RealtimeAudioPlayer {
             .queue
             .lock()
             .map_err(|_| "failed to lock output audio queue".to_string())?;
+        // TODO(aibrahim): Cap or trim this queue if we observe producer bursts outrunning playback.
         guard.extend(converted);
         Ok(())
     }

--- a/codex-rs/tui/src/voice.rs
+++ b/codex-rs/tui/src/voice.rs
@@ -1,11 +1,13 @@
 use crate::app_event::AppEvent;
 use crate::app_event_sender::AppEventSender;
+use base64::Engine;
 use codex_core::auth::AuthCredentialsStoreMode;
 use codex_core::config::Config;
 use codex_core::config::find_codex_home;
 use codex_core::default_client::get_codex_user_agent;
 use codex_login::AuthMode;
 use codex_login::CodexAuth;
+use codex_protocol::protocol::RealtimeAudioFrame;
 use cpal::traits::DeviceTrait;
 use cpal::traits::HostTrait;
 use cpal::traits::StreamTrait;
@@ -336,6 +338,206 @@ fn convert_u16_to_i16_and_peak(input: &[u16], out: &mut Vec<i16>) -> u16 {
         out.push(v_i16);
     }
     peak as u16
+}
+
+// -------------------------
+// Realtime audio playback helpers
+// -------------------------
+
+pub(crate) struct RealtimeAudioPlayer {
+    _stream: cpal::Stream,
+    queue: Arc<Mutex<VecDeque<i16>>>,
+    output_sample_rate: u32,
+    output_channels: u16,
+}
+
+impl RealtimeAudioPlayer {
+    pub(crate) fn start() -> Result<Self, String> {
+        let host = cpal::default_host();
+        let device = host
+            .default_output_device()
+            .ok_or_else(|| "no output audio device available".to_string())?;
+        let config = device
+            .default_output_config()
+            .map_err(|e| format!("failed to get default output config: {e}"))?;
+        let output_sample_rate = config.sample_rate().0;
+        let output_channels = config.channels();
+        let queue = Arc::new(Mutex::new(VecDeque::new()));
+        let stream = build_output_stream(&device, &config, Arc::clone(&queue))?;
+        stream
+            .play()
+            .map_err(|e| format!("failed to start output stream: {e}"))?;
+        Ok(Self {
+            _stream: stream,
+            queue,
+            output_sample_rate,
+            output_channels,
+        })
+    }
+
+    pub(crate) fn enqueue_frame(&self, frame: &RealtimeAudioFrame) -> Result<(), String> {
+        if frame.num_channels == 0 || frame.sample_rate == 0 {
+            return Err("invalid realtime audio frame format".to_string());
+        }
+        let raw_bytes = base64::engine::general_purpose::STANDARD
+            .decode(&frame.data)
+            .map_err(|e| format!("failed to decode realtime audio: {e}"))?;
+        if raw_bytes.len() % 2 != 0 {
+            return Err("realtime audio frame had odd byte length".to_string());
+        }
+        let mut pcm = Vec::with_capacity(raw_bytes.len() / 2);
+        for pair in raw_bytes.chunks_exact(2) {
+            pcm.push(i16::from_le_bytes([pair[0], pair[1]]));
+        }
+        let converted = convert_pcm16_for_output(
+            &pcm,
+            frame.sample_rate,
+            frame.num_channels,
+            self.output_sample_rate,
+            self.output_channels,
+        );
+        if converted.is_empty() {
+            return Ok(());
+        }
+        let mut guard = self
+            .queue
+            .lock()
+            .map_err(|_| "failed to lock output audio queue".to_string())?;
+        guard.extend(converted);
+        Ok(())
+    }
+
+    pub(crate) fn clear(&self) {
+        if let Ok(mut guard) = self.queue.lock() {
+            guard.clear();
+        }
+    }
+}
+
+fn build_output_stream(
+    device: &cpal::Device,
+    config: &cpal::SupportedStreamConfig,
+    queue: Arc<Mutex<VecDeque<i16>>>,
+) -> Result<cpal::Stream, String> {
+    let config_any: cpal::StreamConfig = config.clone().into();
+    match config.sample_format() {
+        cpal::SampleFormat::F32 => device
+            .build_output_stream(
+                &config_any,
+                move |output: &mut [f32], _| fill_output_f32(output, &queue),
+                move |err| error!("audio output error: {err}"),
+                None,
+            )
+            .map_err(|e| format!("failed to build f32 output stream: {e}")),
+        cpal::SampleFormat::I16 => device
+            .build_output_stream(
+                &config_any,
+                move |output: &mut [i16], _| fill_output_i16(output, &queue),
+                move |err| error!("audio output error: {err}"),
+                None,
+            )
+            .map_err(|e| format!("failed to build i16 output stream: {e}")),
+        cpal::SampleFormat::U16 => device
+            .build_output_stream(
+                &config_any,
+                move |output: &mut [u16], _| fill_output_u16(output, &queue),
+                move |err| error!("audio output error: {err}"),
+                None,
+            )
+            .map_err(|e| format!("failed to build u16 output stream: {e}")),
+        other => Err(format!("unsupported output sample format: {other:?}")),
+    }
+}
+
+fn fill_output_i16(output: &mut [i16], queue: &Arc<Mutex<VecDeque<i16>>>) {
+    if let Ok(mut guard) = queue.lock() {
+        for sample in output {
+            *sample = guard.pop_front().unwrap_or(0);
+        }
+        return;
+    }
+    output.fill(0);
+}
+
+fn fill_output_f32(output: &mut [f32], queue: &Arc<Mutex<VecDeque<i16>>>) {
+    if let Ok(mut guard) = queue.lock() {
+        for sample in output {
+            let v = guard.pop_front().unwrap_or(0);
+            *sample = (v as f32) / (i16::MAX as f32);
+        }
+        return;
+    }
+    output.fill(0.0);
+}
+
+fn fill_output_u16(output: &mut [u16], queue: &Arc<Mutex<VecDeque<i16>>>) {
+    if let Ok(mut guard) = queue.lock() {
+        for sample in output {
+            let v = guard.pop_front().unwrap_or(0);
+            *sample = (v as i32 + 32768).clamp(0, u16::MAX as i32) as u16;
+        }
+        return;
+    }
+    output.fill(32768);
+}
+
+fn convert_pcm16_for_output(
+    input: &[i16],
+    input_sample_rate: u32,
+    input_channels: u16,
+    output_sample_rate: u32,
+    output_channels: u16,
+) -> Vec<i16> {
+    if input.is_empty() || input_channels == 0 || output_channels == 0 {
+        return Vec::new();
+    }
+
+    let in_channels = input_channels as usize;
+    let out_channels = output_channels as usize;
+    let in_frames = input.len() / in_channels;
+    if in_frames == 0 {
+        return Vec::new();
+    }
+
+    let out_frames = if input_sample_rate == output_sample_rate {
+        in_frames
+    } else {
+        (((in_frames as u64) * (output_sample_rate as u64)) / (input_sample_rate as u64)).max(1)
+            as usize
+    };
+
+    let mut out = Vec::with_capacity(out_frames.saturating_mul(out_channels));
+    for out_frame_idx in 0..out_frames {
+        let src_frame_idx = if out_frames <= 1 || in_frames <= 1 {
+            0
+        } else {
+            ((out_frame_idx as u64) * ((in_frames - 1) as u64) / ((out_frames - 1) as u64)) as usize
+        };
+        let src_start = src_frame_idx.saturating_mul(in_channels);
+        let src = &input[src_start..src_start + in_channels];
+        match (in_channels, out_channels) {
+            (1, 1) => out.push(src[0]),
+            (1, n) => {
+                for _ in 0..n {
+                    out.push(src[0]);
+                }
+            }
+            (n, 1) if n >= 2 => {
+                let sum: i32 = src.iter().map(|s| *s as i32).sum();
+                out.push((sum / (n as i32)) as i16);
+            }
+            (n, m) if n == m => out.extend_from_slice(src),
+            (n, m) if n > m => out.extend_from_slice(&src[..m]),
+            (n, m) => {
+                out.extend_from_slice(src);
+                let last = *src.last().unwrap_or(&0);
+                for _ in n..m {
+                    out.push(last);
+                }
+            }
+        }
+    }
+    out
 }
 
 // -------------------------


### PR DESCRIPTION
- Add a hidden `realtime_conversation` feature flag and `/realtime` slash command for start/stop live voice sessions.
- Reuse transcription composer/footer UI for live metering, stream mic audio, play assistant audio, render realtime user text events, and force-close on feature disable.