### PR TITLE
Enable request_user_input in Default mode

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -208,6 +208,7 @@ use codex_core::find_thread_path_by_id_str;
 use codex_core::git_info::git_diff_to_remote;
 use codex_core::mcp::collect_mcp_snapshot;
 use codex_core::mcp::group_tools_by_server;
+use codex_core::models_manager::collaboration_mode_presets::CollaborationModesConfig;
 use codex_core::parse_cursor;
 use codex_core::read_head_for_summary;
 use codex_core::read_session_meta_line;
@@ -449,15 +450,13 @@ impl CodexMessageProcessor {
     fn normalize_turn_start_collaboration_mode(
         &self,
         mut collaboration_mode: CollaborationMode,
-        default_mode_request_user_input: bool,
+        collaboration_modes_config: CollaborationModesConfig,
     ) -> CollaborationMode {
         if collaboration_mode.settings.developer_instructions.is_none()
             && let Some(instructions) = self
                 .thread_manager
                 .get_models_manager()
-                .list_collaboration_modes_for_default_mode_request_user_input(
-                    default_mode_request_user_input,
-                )
+                .list_collaboration_modes_for_config(collaboration_modes_config)
                 .into_iter()
                 .find(|preset| preset.mode == Some(collaboration_mode.mode))
                 .and_then(|preset| preset.developer_instructions.flatten())
@@ -5354,9 +5353,10 @@ impl CodexMessageProcessor {
             }
         };
 
-        let default_mode_request_user_input = thread.enabled(Feature::DefaultModeRequestUserInput);
+        let collaboration_modes_config =
+            CollaborationModesConfig::new(thread.enabled(Feature::DefaultModeRequestUserInput));
         let collaboration_mode = params.collaboration_mode.map(|mode| {
-            self.normalize_turn_start_collaboration_mode(mode, default_mode_request_user_input)
+            self.normalize_turn_start_collaboration_mode(mode, collaboration_modes_config)
         });
 
         // Map v2 input items to core input items.

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -449,11 +449,15 @@ impl CodexMessageProcessor {
     fn normalize_turn_start_collaboration_mode(
         &self,
         mut collaboration_mode: CollaborationMode,
+        default_mode_request_user_input: bool,
     ) -> CollaborationMode {
         if collaboration_mode.settings.developer_instructions.is_none()
             && let Some(instructions) = self
                 .thread_manager
-                .list_collaboration_modes()
+                .get_models_manager()
+                .list_collaboration_modes_for_default_mode_request_user_input(
+                    default_mode_request_user_input,
+                )
                 .into_iter()
                 .find(|preset| preset.mode == Some(collaboration_mode.mode))
                 .and_then(|preset| preset.developer_instructions.flatten())
@@ -5350,9 +5354,10 @@ impl CodexMessageProcessor {
             }
         };
 
-        let collaboration_mode = params
-            .collaboration_mode
-            .map(|mode| self.normalize_turn_start_collaboration_mode(mode));
+        let default_mode_request_user_input = thread.enabled(Feature::DefaultModeRequestUserInput);
+        let collaboration_mode = params.collaboration_mode.map(|mode| {
+            self.normalize_turn_start_collaboration_mode(mode, default_mode_request_user_input)
+        });
 
         // Map v2 input items to core input items.
         let mapped_items: Vec<CoreInputItem> = params

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -5353,8 +5353,9 @@ impl CodexMessageProcessor {
             }
         };
 
-        let collaboration_modes_config =
-            CollaborationModesConfig::new(thread.enabled(Feature::DefaultModeRequestUserInput));
+        let collaboration_modes_config = CollaborationModesConfig {
+            default_mode_request_user_input: thread.enabled(Feature::DefaultModeRequestUserInput),
+        };
         let collaboration_mode = params.collaboration_mode.map(|mode| {
             self.normalize_turn_start_collaboration_mode(mode, collaboration_modes_config)
         });

--- a/codex-rs/app-server/src/message_processor.rs
+++ b/codex-rs/app-server/src/message_processor.rs
@@ -178,11 +178,11 @@ impl MessageProcessor {
             auth_manager.clone(),
             SessionSource::VSCode,
             config.model_catalog.clone(),
-            CollaborationModesConfig::new(
-                config
+            CollaborationModesConfig {
+                default_mode_request_user_input: config
                     .features
                     .enabled(codex_core::features::Feature::DefaultModeRequestUserInput),
-            ),
+            },
         ));
         let cloud_requirements = Arc::new(RwLock::new(cloud_requirements));
         let codex_message_processor = CodexMessageProcessor::new(CodexMessageProcessorArgs {

--- a/codex-rs/app-server/src/message_processor.rs
+++ b/codex-rs/app-server/src/message_processor.rs
@@ -177,6 +177,9 @@ impl MessageProcessor {
             auth_manager.clone(),
             SessionSource::VSCode,
             config.model_catalog.clone(),
+            config
+                .features
+                .enabled(codex_core::features::Feature::DefaultModeRequestUserInput),
         ));
         let cloud_requirements = Arc::new(RwLock::new(cloud_requirements));
         let codex_message_processor = CodexMessageProcessor::new(CodexMessageProcessorArgs {

--- a/codex-rs/app-server/src/message_processor.rs
+++ b/codex-rs/app-server/src/message_processor.rs
@@ -46,6 +46,7 @@ use codex_core::default_client::USER_AGENT_SUFFIX;
 use codex_core::default_client::get_codex_user_agent;
 use codex_core::default_client::set_default_client_residency_requirement;
 use codex_core::default_client::set_default_originator;
+use codex_core::models_manager::collaboration_mode_presets::CollaborationModesConfig;
 use codex_feedback::CodexFeedback;
 use codex_protocol::ThreadId;
 use codex_protocol::protocol::SessionSource;
@@ -177,9 +178,11 @@ impl MessageProcessor {
             auth_manager.clone(),
             SessionSource::VSCode,
             config.model_catalog.clone(),
-            config
-                .features
-                .enabled(codex_core::features::Feature::DefaultModeRequestUserInput),
+            CollaborationModesConfig::new(
+                config
+                    .features
+                    .enabled(codex_core::features::Feature::DefaultModeRequestUserInput),
+            ),
         ));
         let cloud_requirements = Arc::new(RwLock::new(cloud_requirements));
         let codex_message_processor = CodexMessageProcessor::new(CodexMessageProcessorArgs {

--- a/codex-rs/app-server/tests/suite/v2/request_user_input.rs
+++ b/codex-rs/app-server/tests/suite/v2/request_user_input.rs
@@ -123,9 +123,6 @@ sandbox_mode = "read-only"
 
 model_provider = "mock_provider"
 
-[features]
-collaboration_modes = true
-
 [model_providers.mock_provider]
 name = "Mock provider for test"
 base_url = "{server_uri}/v1"

--- a/codex-rs/app-server/tests/suite/v2/turn_start.rs
+++ b/codex-rs/app-server/tests/suite/v2/turn_start.rs
@@ -352,7 +352,7 @@ async fn turn_start_accepts_collaboration_mode_override_v2() -> Result<()> {
         codex_home.path(),
         &server.uri(),
         "never",
-        &BTreeMap::default(),
+        &BTreeMap::from([(Feature::DefaultModeRequestUserInput, true)]),
     )?;
 
     let mut mcp = McpProcess::new(codex_home.path()).await?;

--- a/codex-rs/app-server/tests/suite/v2/turn_start.rs
+++ b/codex-rs/app-server/tests/suite/v2/turn_start.rs
@@ -48,7 +48,9 @@ use codex_protocol::openai_models::ReasoningEffort;
 use core_test_support::responses;
 use core_test_support::skip_if_no_network;
 use pretty_assertions::assert_eq;
+use serde_json::json;
 use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::path::Path;
 use tempfile::TempDir;
 use tokio::time::timeout;
@@ -412,6 +414,91 @@ async fn turn_start_accepts_collaboration_mode_override_v2() -> Result<()> {
     let payload = request.body_json();
     assert_eq!(payload["model"].as_str(), Some("mock-model-collab"));
     let payload_text = payload.to_string();
+    assert!(payload_text.contains("The `request_user_input` tool is available in Default mode."));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn turn_start_uses_thread_feature_overrides_for_collaboration_mode_instructions_v2()
+-> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = responses::start_mock_server().await;
+    let body = responses::sse(vec![
+        responses::ev_response_created("resp-1"),
+        responses::ev_assistant_message("msg-1", "Done"),
+        responses::ev_completed("resp-1"),
+    ]);
+    let response_mock = responses::mount_sse_once(&server, body).await;
+
+    let codex_home = TempDir::new()?;
+    create_config_toml(
+        codex_home.path(),
+        &server.uri(),
+        "never",
+        &BTreeMap::default(),
+    )?;
+
+    let mut mcp = McpProcess::new(codex_home.path()).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let thread_req = mcp
+        .send_thread_start_request(ThreadStartParams {
+            model: Some("gpt-5.2-codex".to_string()),
+            config: Some(HashMap::from([(
+                "features.default_mode_request_user_input".to_string(),
+                json!(true),
+            )])),
+            ..Default::default()
+        })
+        .await?;
+    let thread_resp: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(thread_req)),
+    )
+    .await??;
+    let ThreadStartResponse { thread, .. } = to_response::<ThreadStartResponse>(thread_resp)?;
+
+    let collaboration_mode = CollaborationMode {
+        mode: ModeKind::Default,
+        settings: Settings {
+            model: "mock-model-collab".to_string(),
+            reasoning_effort: Some(ReasoningEffort::High),
+            developer_instructions: None,
+        },
+    };
+
+    let turn_req = mcp
+        .send_turn_start_request(TurnStartParams {
+            thread_id: thread.id.clone(),
+            input: vec![V2UserInput::Text {
+                text: "Hello".to_string(),
+                text_elements: Vec::new(),
+            }],
+            model: Some("mock-model-override".to_string()),
+            effort: Some(ReasoningEffort::Low),
+            summary: Some(ReasoningSummary::Auto),
+            output_schema: None,
+            collaboration_mode: Some(collaboration_mode),
+            ..Default::default()
+        })
+        .await?;
+    let turn_resp: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(turn_req)),
+    )
+    .await??;
+    let _turn: TurnStartResponse = to_response::<TurnStartResponse>(turn_resp)?;
+
+    timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_notification_message("turn/completed"),
+    )
+    .await??;
+
+    let request = response_mock.single_request();
+    let payload_text = request.body_json().to_string();
     assert!(payload_text.contains("The `request_user_input` tool is available in Default mode."));
 
     Ok(())

--- a/codex-rs/app-server/tests/suite/v2/turn_start.rs
+++ b/codex-rs/app-server/tests/suite/v2/turn_start.rs
@@ -412,7 +412,7 @@ async fn turn_start_accepts_collaboration_mode_override_v2() -> Result<()> {
     let payload = request.body_json();
     assert_eq!(payload["model"].as_str(), Some("mock-model-collab"));
     let payload_text = payload.to_string();
-    assert!(payload_text.contains("The `request_user_input` tool is unavailable in Default mode."));
+    assert!(payload_text.contains("The `request_user_input` tool is available in Default mode."));
 
     Ok(())
 }

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -334,6 +334,9 @@
             "connectors": {
               "type": "boolean"
             },
+            "default_mode_request_user_input": {
+              "type": "boolean"
+            },
             "elevated_windows_sandbox": {
               "type": "boolean"
             },
@@ -1625,6 +1628,9 @@
           "type": "boolean"
         },
         "connectors": {
+          "type": "boolean"
+        },
+        "default_mode_request_user_input": {
           "type": "boolean"
         },
         "elevated_windows_sandbox": {

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -29,6 +29,8 @@ use crate::features::FEATURES;
 use crate::features::Feature;
 use crate::features::Features;
 use crate::features::maybe_push_unstable_features_warning;
+#[cfg(test)]
+use crate::models_manager::collaboration_mode_presets::CollaborationModesConfig;
 use crate::models_manager::manager::ModelsManager;
 use crate::parse_command::parse_command;
 use crate::parse_turn_item;
@@ -8059,7 +8061,7 @@ mod tests {
             config.codex_home.clone(),
             auth_manager.clone(),
             None,
-            false,
+            CollaborationModesConfig::default(),
         ));
         let model = ModelsManager::get_model_offline_for_tests(config.model.as_deref());
         let model_info =
@@ -8135,7 +8137,7 @@ mod tests {
             config.codex_home.clone(),
             auth_manager.clone(),
             None,
-            false,
+            CollaborationModesConfig::default(),
         ));
         let agent_control = AgentControl::default();
         let exec_policy = ExecPolicyManager::default();
@@ -8291,7 +8293,7 @@ mod tests {
             config.codex_home.clone(),
             auth_manager.clone(),
             None,
-            false,
+            CollaborationModesConfig::default(),
         ));
         let agent_control = AgentControl::default();
         let exec_policy = ExecPolicyManager::default();

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -8059,6 +8059,7 @@ mod tests {
             config.codex_home.clone(),
             auth_manager.clone(),
             None,
+            false,
         ));
         let model = ModelsManager::get_model_offline_for_tests(config.model.as_deref());
         let model_info =
@@ -8134,6 +8135,7 @@ mod tests {
             config.codex_home.clone(),
             auth_manager.clone(),
             None,
+            false,
         ));
         let agent_control = AgentControl::default();
         let exec_policy = ExecPolicyManager::default();
@@ -8289,6 +8291,7 @@ mod tests {
             config.codex_home.clone(),
             auth_manager.clone(),
             None,
+            false,
         ));
         let agent_control = AgentControl::default();
         let exec_policy = ExecPolicyManager::default();

--- a/codex-rs/core/src/features.rs
+++ b/codex-rs/core/src/features.rs
@@ -137,6 +137,8 @@ pub enum Feature {
     SkillApproval,
     /// Steer feature flag - when enabled, Enter submits immediately instead of queuing.
     Steer,
+    /// Allow request_user_input in Default collaboration mode.
+    DefaultModeRequestUserInput,
     /// Enable collaboration modes (Plan, Default).
     /// Kept for config backward compatibility; behavior is always collaboration-modes-enabled.
     CollaborationModes,
@@ -634,6 +636,12 @@ pub const FEATURES: &[FeatureSpec] = &[
         key: "steer",
         stage: Stage::Stable,
         default_enabled: true,
+    },
+    FeatureSpec {
+        id: Feature::DefaultModeRequestUserInput,
+        key: "default_mode_request_user_input",
+        stage: Stage::UnderDevelopment,
+        default_enabled: false,
     },
     FeatureSpec {
         id: Feature::CollaborationModes,

--- a/codex-rs/core/src/models_manager/collaboration_mode_presets.rs
+++ b/codex-rs/core/src/models_manager/collaboration_mode_presets.rs
@@ -21,14 +21,6 @@ pub struct CollaborationModesConfig {
     pub default_mode_request_user_input: bool,
 }
 
-impl CollaborationModesConfig {
-    pub const fn new(default_mode_request_user_input: bool) -> Self {
-        Self {
-            default_mode_request_user_input,
-        }
-    }
-}
-
 pub(crate) fn builtin_collaboration_mode_presets(
     collaboration_modes_config: CollaborationModesConfig,
 ) -> Vec<CollaborationModeMask> {
@@ -130,10 +122,12 @@ mod tests {
 
     #[test]
     fn default_mode_instructions_replace_mode_names_placeholder() {
-        let default_instructions = default_preset(CollaborationModesConfig::new(true))
-            .developer_instructions
-            .expect("default preset should include instructions")
-            .expect("default instructions should be set");
+        let default_instructions = default_preset(CollaborationModesConfig {
+            default_mode_request_user_input: true,
+        })
+        .developer_instructions
+        .expect("default preset should include instructions")
+        .expect("default instructions should be set");
 
         assert!(!default_instructions.contains(KNOWN_MODE_NAMES_PLACEHOLDER));
         assert!(!default_instructions.contains(REQUEST_USER_INPUT_AVAILABILITY_PLACEHOLDER));

--- a/codex-rs/core/src/models_manager/collaboration_mode_presets.rs
+++ b/codex-rs/core/src/models_manager/collaboration_mode_presets.rs
@@ -8,6 +8,7 @@ const COLLABORATION_MODE_DEFAULT: &str =
     include_str!("../../templates/collaboration_mode/default.md");
 const KNOWN_MODE_NAMES_PLACEHOLDER: &str = "{{KNOWN_MODE_NAMES}}";
 const REQUEST_USER_INPUT_AVAILABILITY_PLACEHOLDER: &str = "{{REQUEST_USER_INPUT_AVAILABILITY}}";
+const QUESTION_STRATEGY_PLACEHOLDER: &str = "{{QUESTION_STRATEGY}}";
 
 pub(crate) fn builtin_collaboration_mode_presets(
     default_mode_request_user_input: bool,
@@ -44,12 +45,14 @@ fn default_mode_instructions(default_mode_request_user_input: bool) -> String {
     let known_mode_names = format_mode_names(&TUI_VISIBLE_COLLABORATION_MODES);
     let request_user_input_availability =
         request_user_input_availability_message(ModeKind::Default, default_mode_request_user_input);
+    let question_strategy = question_strategy_message(default_mode_request_user_input);
     COLLABORATION_MODE_DEFAULT
         .replace(KNOWN_MODE_NAMES_PLACEHOLDER, &known_mode_names)
         .replace(
             REQUEST_USER_INPUT_AVAILABILITY_PLACEHOLDER,
             &request_user_input_availability,
         )
+        .replace(QUESTION_STRATEGY_PLACEHOLDER, &question_strategy)
 }
 
 fn format_mode_names(modes: &[ModeKind]) -> String {
@@ -78,6 +81,14 @@ fn request_user_input_availability_message(
     }
 }
 
+fn question_strategy_message(default_mode_request_user_input: bool) -> String {
+    if default_mode_request_user_input {
+        "In Default mode, strongly prefer making reasonable assumptions and executing the user's request rather than stopping to ask questions. If you absolutely must ask a question because the answer cannot be discovered from local context and a reasonable assumption would be risky, prefer using the `request_user_input` tool rather than writing a multiple choice question as a textual assistant message. Never write a multiple choice question as a textual assistant message.".to_string()
+    } else {
+        "In Default mode, strongly prefer making reasonable assumptions and executing the user's request rather than stopping to ask questions. If you absolutely must ask a question because the answer cannot be discovered from local context and a reasonable assumption would be risky, ask the user directly with a concise plain-text question. Never write a multiple choice question as a textual assistant message.".to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -102,6 +113,7 @@ mod tests {
 
         assert!(!default_instructions.contains(KNOWN_MODE_NAMES_PLACEHOLDER));
         assert!(!default_instructions.contains(REQUEST_USER_INPUT_AVAILABILITY_PLACEHOLDER));
+        assert!(!default_instructions.contains(QUESTION_STRATEGY_PLACEHOLDER));
 
         let known_mode_names = format_mode_names(&TUI_VISIBLE_COLLABORATION_MODES);
         let expected_snippet = format!("Known mode names are {known_mode_names}.");
@@ -110,5 +122,20 @@ mod tests {
         let expected_availability_message =
             request_user_input_availability_message(ModeKind::Default, true);
         assert!(default_instructions.contains(&expected_availability_message));
+        assert!(default_instructions.contains("prefer using the `request_user_input` tool"));
+    }
+
+    #[test]
+    fn default_mode_instructions_use_plain_text_questions_when_feature_disabled() {
+        let default_instructions = default_preset(false)
+            .developer_instructions
+            .expect("default preset should include instructions")
+            .expect("default instructions should be set");
+
+        assert!(!default_instructions.contains("prefer using the `request_user_input` tool"));
+        assert!(
+            default_instructions
+                .contains("ask the user directly with a concise plain-text question")
+        );
     }
 }

--- a/codex-rs/core/src/models_manager/collaboration_mode_presets.rs
+++ b/codex-rs/core/src/models_manager/collaboration_mode_presets.rs
@@ -8,7 +8,7 @@ const COLLABORATION_MODE_DEFAULT: &str =
     include_str!("../../templates/collaboration_mode/default.md");
 const KNOWN_MODE_NAMES_PLACEHOLDER: &str = "{{KNOWN_MODE_NAMES}}";
 const REQUEST_USER_INPUT_AVAILABILITY_PLACEHOLDER: &str = "{{REQUEST_USER_INPUT_AVAILABILITY}}";
-const QUESTION_STRATEGY_PLACEHOLDER: &str = "{{QUESTION_STRATEGY}}";
+const ASKING_QUESTIONS_GUIDANCE_PLACEHOLDER: &str = "{{ASKING_QUESTIONS_GUIDANCE}}";
 
 /// Stores feature flags that control collaboration-mode behavior.
 ///
@@ -61,15 +61,19 @@ fn default_mode_instructions(collaboration_modes_config: CollaborationModesConfi
         ModeKind::Default,
         collaboration_modes_config.default_mode_request_user_input,
     );
-    let question_strategy =
-        question_strategy_message(collaboration_modes_config.default_mode_request_user_input);
+    let asking_questions_guidance = asking_questions_guidance_message(
+        collaboration_modes_config.default_mode_request_user_input,
+    );
     COLLABORATION_MODE_DEFAULT
         .replace(KNOWN_MODE_NAMES_PLACEHOLDER, &known_mode_names)
         .replace(
             REQUEST_USER_INPUT_AVAILABILITY_PLACEHOLDER,
             &request_user_input_availability,
         )
-        .replace(QUESTION_STRATEGY_PLACEHOLDER, &question_strategy)
+        .replace(
+            ASKING_QUESTIONS_GUIDANCE_PLACEHOLDER,
+            &asking_questions_guidance,
+        )
 }
 
 fn format_mode_names(modes: &[ModeKind]) -> String {
@@ -98,7 +102,7 @@ fn request_user_input_availability_message(
     }
 }
 
-fn question_strategy_message(default_mode_request_user_input: bool) -> String {
+fn asking_questions_guidance_message(default_mode_request_user_input: bool) -> String {
     if default_mode_request_user_input {
         "In Default mode, strongly prefer making reasonable assumptions and executing the user's request rather than stopping to ask questions. If you absolutely must ask a question because the answer cannot be discovered from local context and a reasonable assumption would be risky, prefer using the `request_user_input` tool rather than writing a multiple choice question as a textual assistant message. Never write a multiple choice question as a textual assistant message.".to_string()
     } else {
@@ -133,7 +137,7 @@ mod tests {
 
         assert!(!default_instructions.contains(KNOWN_MODE_NAMES_PLACEHOLDER));
         assert!(!default_instructions.contains(REQUEST_USER_INPUT_AVAILABILITY_PLACEHOLDER));
-        assert!(!default_instructions.contains(QUESTION_STRATEGY_PLACEHOLDER));
+        assert!(!default_instructions.contains(ASKING_QUESTIONS_GUIDANCE_PLACEHOLDER));
 
         let known_mode_names = format_mode_names(&TUI_VISIBLE_COLLABORATION_MODES);
         let expected_snippet = format!("Known mode names are {known_mode_names}.");

--- a/codex-rs/core/src/models_manager/collaboration_mode_presets.rs
+++ b/codex-rs/core/src/models_manager/collaboration_mode_presets.rs
@@ -10,8 +10,14 @@ const KNOWN_MODE_NAMES_PLACEHOLDER: &str = "{{KNOWN_MODE_NAMES}}";
 const REQUEST_USER_INPUT_AVAILABILITY_PLACEHOLDER: &str = "{{REQUEST_USER_INPUT_AVAILABILITY}}";
 const QUESTION_STRATEGY_PLACEHOLDER: &str = "{{QUESTION_STRATEGY}}";
 
+/// Stores feature flags that control collaboration-mode behavior.
+///
+/// Keep mode-related flags here so new collaboration-mode capabilities can be
+/// added without large cross-cutting diffs to constructor and call-site
+/// signatures.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct CollaborationModesConfig {
+    /// Enables `request_user_input` availability in Default mode.
     pub default_mode_request_user_input: bool,
 }
 

--- a/codex-rs/core/src/models_manager/manager.rs
+++ b/codex-rs/core/src/models_manager/manager.rs
@@ -46,6 +46,7 @@ pub enum RefreshStrategy {
 pub struct ModelsManager {
     remote_models: RwLock<Vec<ModelInfo>>,
     has_custom_model_catalog: bool,
+    default_mode_request_user_input: bool,
     auth_manager: Arc<AuthManager>,
     etag: RwLock<Option<String>>,
     cache_manager: ModelsCacheManager,
@@ -62,6 +63,7 @@ impl ModelsManager {
         codex_home: PathBuf,
         auth_manager: Arc<AuthManager>,
         model_catalog: Option<ModelsResponse>,
+        default_mode_request_user_input: bool,
     ) -> Self {
         let cache_path = codex_home.join(MODEL_CACHE_FILE);
         let cache_manager = ModelsCacheManager::new(cache_path, DEFAULT_MODEL_CACHE_TTL);
@@ -75,6 +77,7 @@ impl ModelsManager {
         Self {
             remote_models: RwLock::new(remote_models),
             has_custom_model_catalog,
+            default_mode_request_user_input,
             auth_manager,
             etag: RwLock::new(None),
             cache_manager,
@@ -97,7 +100,7 @@ impl ModelsManager {
     ///
     /// Returns a static set of presets seeded with the configured model.
     pub fn list_collaboration_modes(&self) -> Vec<CollaborationModeMask> {
-        builtin_collaboration_mode_presets()
+        builtin_collaboration_mode_presets(self.default_mode_request_user_input)
     }
 
     /// Attempt to list models without blocking, using the current cached state.
@@ -365,6 +368,7 @@ impl ModelsManager {
                     .unwrap_or_else(|err| panic!("failed to load bundled models.json: {err}")),
             ),
             has_custom_model_catalog: false,
+            default_mode_request_user_input: false,
             auth_manager,
             etag: RwLock::new(None),
             cache_manager,
@@ -491,7 +495,8 @@ mod tests {
             .expect("load default test config");
         let auth_manager =
             AuthManager::from_auth_for_testing(CodexAuth::from_api_key("Test API Key"));
-        let manager = ModelsManager::new(codex_home.path().to_path_buf(), auth_manager, None);
+        let manager =
+            ModelsManager::new(codex_home.path().to_path_buf(), auth_manager, None, false);
         let known_slug = manager
             .get_remote_models()
             .await
@@ -528,6 +533,7 @@ mod tests {
             Some(ModelsResponse {
                 models: vec![remote_model("gpt-overlay", "Overlay", 0)],
             }),
+            false,
         );
 
         let model_info = manager
@@ -551,7 +557,8 @@ mod tests {
             .expect("load default test config");
         let auth_manager =
             AuthManager::from_auth_for_testing(CodexAuth::from_api_key("Test API Key"));
-        let manager = ModelsManager::new(codex_home.path().to_path_buf(), auth_manager, None);
+        let manager =
+            ModelsManager::new(codex_home.path().to_path_buf(), auth_manager, None, false);
         let known_slug = manager
             .get_remote_models()
             .await
@@ -577,7 +584,8 @@ mod tests {
             .expect("load default test config");
         let auth_manager =
             AuthManager::from_auth_for_testing(CodexAuth::from_api_key("Test API Key"));
-        let manager = ModelsManager::new(codex_home.path().to_path_buf(), auth_manager, None);
+        let manager =
+            ModelsManager::new(codex_home.path().to_path_buf(), auth_manager, None, false);
         let known_slug = manager
             .get_remote_models()
             .await

--- a/codex-rs/core/src/models_manager/manager.rs
+++ b/codex-rs/core/src/models_manager/manager.rs
@@ -8,6 +8,7 @@ use crate::default_client::build_reqwest_client;
 use crate::error::CodexErr;
 use crate::error::Result as CoreResult;
 use crate::model_provider_info::ModelProviderInfo;
+use crate::models_manager::collaboration_mode_presets::CollaborationModesConfig;
 use crate::models_manager::collaboration_mode_presets::builtin_collaboration_mode_presets;
 use crate::models_manager::model_info;
 use codex_api::ModelsClient;
@@ -46,7 +47,7 @@ pub enum RefreshStrategy {
 pub struct ModelsManager {
     remote_models: RwLock<Vec<ModelInfo>>,
     has_custom_model_catalog: bool,
-    default_mode_request_user_input: bool,
+    collaboration_modes_config: CollaborationModesConfig,
     auth_manager: Arc<AuthManager>,
     etag: RwLock<Option<String>>,
     cache_manager: ModelsCacheManager,
@@ -63,7 +64,7 @@ impl ModelsManager {
         codex_home: PathBuf,
         auth_manager: Arc<AuthManager>,
         model_catalog: Option<ModelsResponse>,
-        default_mode_request_user_input: bool,
+        collaboration_modes_config: CollaborationModesConfig,
     ) -> Self {
         let cache_path = codex_home.join(MODEL_CACHE_FILE);
         let cache_manager = ModelsCacheManager::new(cache_path, DEFAULT_MODEL_CACHE_TTL);
@@ -77,7 +78,7 @@ impl ModelsManager {
         Self {
             remote_models: RwLock::new(remote_models),
             has_custom_model_catalog,
-            default_mode_request_user_input,
+            collaboration_modes_config,
             auth_manager,
             etag: RwLock::new(None),
             cache_manager,
@@ -100,16 +101,14 @@ impl ModelsManager {
     ///
     /// Returns a static set of presets seeded with the configured model.
     pub fn list_collaboration_modes(&self) -> Vec<CollaborationModeMask> {
-        self.list_collaboration_modes_for_default_mode_request_user_input(
-            self.default_mode_request_user_input,
-        )
+        self.list_collaboration_modes_for_config(self.collaboration_modes_config)
     }
 
-    pub fn list_collaboration_modes_for_default_mode_request_user_input(
+    pub fn list_collaboration_modes_for_config(
         &self,
-        default_mode_request_user_input: bool,
+        collaboration_modes_config: CollaborationModesConfig,
     ) -> Vec<CollaborationModeMask> {
-        builtin_collaboration_mode_presets(default_mode_request_user_input)
+        builtin_collaboration_mode_presets(collaboration_modes_config)
     }
 
     /// Attempt to list models without blocking, using the current cached state.
@@ -377,7 +376,7 @@ impl ModelsManager {
                     .unwrap_or_else(|err| panic!("failed to load bundled models.json: {err}")),
             ),
             has_custom_model_catalog: false,
-            default_mode_request_user_input: false,
+            collaboration_modes_config: CollaborationModesConfig::default(),
             auth_manager,
             etag: RwLock::new(None),
             cache_manager,
@@ -504,8 +503,12 @@ mod tests {
             .expect("load default test config");
         let auth_manager =
             AuthManager::from_auth_for_testing(CodexAuth::from_api_key("Test API Key"));
-        let manager =
-            ModelsManager::new(codex_home.path().to_path_buf(), auth_manager, None, false);
+        let manager = ModelsManager::new(
+            codex_home.path().to_path_buf(),
+            auth_manager,
+            None,
+            CollaborationModesConfig::default(),
+        );
         let known_slug = manager
             .get_remote_models()
             .await
@@ -542,7 +545,7 @@ mod tests {
             Some(ModelsResponse {
                 models: vec![remote_model("gpt-overlay", "Overlay", 0)],
             }),
-            false,
+            CollaborationModesConfig::default(),
         );
 
         let model_info = manager
@@ -566,8 +569,12 @@ mod tests {
             .expect("load default test config");
         let auth_manager =
             AuthManager::from_auth_for_testing(CodexAuth::from_api_key("Test API Key"));
-        let manager =
-            ModelsManager::new(codex_home.path().to_path_buf(), auth_manager, None, false);
+        let manager = ModelsManager::new(
+            codex_home.path().to_path_buf(),
+            auth_manager,
+            None,
+            CollaborationModesConfig::default(),
+        );
         let known_slug = manager
             .get_remote_models()
             .await
@@ -593,8 +600,12 @@ mod tests {
             .expect("load default test config");
         let auth_manager =
             AuthManager::from_auth_for_testing(CodexAuth::from_api_key("Test API Key"));
-        let manager =
-            ModelsManager::new(codex_home.path().to_path_buf(), auth_manager, None, false);
+        let manager = ModelsManager::new(
+            codex_home.path().to_path_buf(),
+            auth_manager,
+            None,
+            CollaborationModesConfig::default(),
+        );
         let known_slug = manager
             .get_remote_models()
             .await

--- a/codex-rs/core/src/models_manager/manager.rs
+++ b/codex-rs/core/src/models_manager/manager.rs
@@ -100,7 +100,16 @@ impl ModelsManager {
     ///
     /// Returns a static set of presets seeded with the configured model.
     pub fn list_collaboration_modes(&self) -> Vec<CollaborationModeMask> {
-        builtin_collaboration_mode_presets(self.default_mode_request_user_input)
+        self.list_collaboration_modes_for_default_mode_request_user_input(
+            self.default_mode_request_user_input,
+        )
+    }
+
+    pub fn list_collaboration_modes_for_default_mode_request_user_input(
+        &self,
+        default_mode_request_user_input: bool,
+    ) -> Vec<CollaborationModeMask> {
+        builtin_collaboration_mode_presets(default_mode_request_user_input)
     }
 
     /// Attempt to list models without blocking, using the current cached state.

--- a/codex-rs/core/src/test_support.rs
+++ b/codex-rs/core/src/test_support.rs
@@ -85,5 +85,5 @@ pub fn all_model_presets() -> &'static Vec<ModelPreset> {
 }
 
 pub fn builtin_collaboration_mode_presets() -> Vec<CollaborationModeMask> {
-    collaboration_mode_presets::builtin_collaboration_mode_presets()
+    collaboration_mode_presets::builtin_collaboration_mode_presets(false)
 }

--- a/codex-rs/core/src/test_support.rs
+++ b/codex-rs/core/src/test_support.rs
@@ -85,5 +85,7 @@ pub fn all_model_presets() -> &'static Vec<ModelPreset> {
 }
 
 pub fn builtin_collaboration_mode_presets() -> Vec<CollaborationModeMask> {
-    collaboration_mode_presets::builtin_collaboration_mode_presets(false)
+    collaboration_mode_presets::builtin_collaboration_mode_presets(
+        collaboration_mode_presets::CollaborationModesConfig::default(),
+    )
 }

--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -143,6 +143,7 @@ impl ThreadManager {
         auth_manager: Arc<AuthManager>,
         session_source: SessionSource,
         model_catalog: Option<ModelsResponse>,
+        default_mode_request_user_input: bool,
     ) -> Self {
         let (thread_created_tx, _) = broadcast::channel(THREAD_CREATED_CHANNEL_CAPACITY);
         let skills_manager = Arc::new(SkillsManager::new(codex_home.clone()));
@@ -155,6 +156,7 @@ impl ThreadManager {
                     codex_home,
                     auth_manager.clone(),
                     model_catalog,
+                    default_mode_request_user_input,
                 )),
                 skills_manager,
                 file_watcher,

--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -11,6 +11,7 @@ use crate::error::CodexErr;
 use crate::error::Result as CodexResult;
 use crate::file_watcher::FileWatcher;
 use crate::file_watcher::FileWatcherEvent;
+use crate::models_manager::collaboration_mode_presets::CollaborationModesConfig;
 use crate::models_manager::manager::ModelsManager;
 use crate::protocol::Event;
 use crate::protocol::EventMsg;
@@ -143,7 +144,7 @@ impl ThreadManager {
         auth_manager: Arc<AuthManager>,
         session_source: SessionSource,
         model_catalog: Option<ModelsResponse>,
-        default_mode_request_user_input: bool,
+        collaboration_modes_config: CollaborationModesConfig,
     ) -> Self {
         let (thread_created_tx, _) = broadcast::channel(THREAD_CREATED_CHANNEL_CAPACITY);
         let skills_manager = Arc::new(SkillsManager::new(codex_home.clone()));
@@ -156,7 +157,7 @@ impl ThreadManager {
                     codex_home,
                     auth_manager.clone(),
                     model_catalog,
-                    default_mode_request_user_input,
+                    collaboration_modes_config,
                 )),
                 skills_manager,
                 file_watcher,

--- a/codex-rs/core/src/tools/handlers/request_user_input.rs
+++ b/codex-rs/core/src/tools/handlers/request_user_input.rs
@@ -117,9 +117,9 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     #[test]
-    fn request_user_input_mode_availability_is_plan_only() {
+    fn request_user_input_mode_availability_includes_default_mode() {
         assert!(ModeKind::Plan.allows_request_user_input());
-        assert!(!ModeKind::Default.allows_request_user_input());
+        assert!(ModeKind::Default.allows_request_user_input());
         assert!(!ModeKind::Execute.allows_request_user_input());
         assert!(!ModeKind::PairProgramming.allows_request_user_input());
     }
@@ -129,7 +129,7 @@ mod tests {
         assert_eq!(request_user_input_unavailable_message(ModeKind::Plan), None);
         assert_eq!(
             request_user_input_unavailable_message(ModeKind::Default),
-            Some("request_user_input is unavailable in Default mode".to_string())
+            None
         );
         assert_eq!(
             request_user_input_unavailable_message(ModeKind::Execute),
@@ -142,10 +142,10 @@ mod tests {
     }
 
     #[test]
-    fn request_user_input_tool_description_mentions_plan_only() {
+    fn request_user_input_tool_description_mentions_default_and_plan() {
         assert_eq!(
             request_user_input_tool_description(),
-            "Request user input for one to three short questions and wait for the response. This tool is only available in Plan mode.".to_string()
+            "Request user input for one to three short questions and wait for the response. This tool is only available in Default or Plan mode.".to_string()
         );
     }
 }

--- a/codex-rs/core/src/tools/handlers/request_user_input.rs
+++ b/codex-rs/core/src/tools/handlers/request_user_input.rs
@@ -12,10 +12,15 @@ use codex_protocol::config_types::ModeKind;
 use codex_protocol::config_types::TUI_VISIBLE_COLLABORATION_MODES;
 use codex_protocol::request_user_input::RequestUserInputArgs;
 
-fn format_allowed_modes() -> String {
+fn request_user_input_is_available(mode: ModeKind, default_mode_request_user_input: bool) -> bool {
+    mode.allows_request_user_input()
+        || (default_mode_request_user_input && mode == ModeKind::Default)
+}
+
+fn format_allowed_modes(default_mode_request_user_input: bool) -> String {
     let mode_names: Vec<&str> = TUI_VISIBLE_COLLABORATION_MODES
         .into_iter()
-        .filter(|mode| mode.allows_request_user_input())
+        .filter(|mode| request_user_input_is_available(*mode, default_mode_request_user_input))
         .map(ModeKind::display_name)
         .collect();
 
@@ -27,8 +32,11 @@ fn format_allowed_modes() -> String {
     }
 }
 
-pub(crate) fn request_user_input_unavailable_message(mode: ModeKind) -> Option<String> {
-    if mode.allows_request_user_input() {
+pub(crate) fn request_user_input_unavailable_message(
+    mode: ModeKind,
+    default_mode_request_user_input: bool,
+) -> Option<String> {
+    if request_user_input_is_available(mode, default_mode_request_user_input) {
         None
     } else {
         let mode_name = mode.display_name();
@@ -38,14 +46,16 @@ pub(crate) fn request_user_input_unavailable_message(mode: ModeKind) -> Option<S
     }
 }
 
-pub(crate) fn request_user_input_tool_description() -> String {
-    let allowed_modes = format_allowed_modes();
+pub(crate) fn request_user_input_tool_description(default_mode_request_user_input: bool) -> String {
+    let allowed_modes = format_allowed_modes(default_mode_request_user_input);
     format!(
         "Request user input for one to three short questions and wait for the response. This tool is only available in {allowed_modes}."
     )
 }
 
-pub struct RequestUserInputHandler;
+pub struct RequestUserInputHandler {
+    pub default_mode_request_user_input: bool,
+}
 
 #[async_trait]
 impl ToolHandler for RequestUserInputHandler {
@@ -72,7 +82,9 @@ impl ToolHandler for RequestUserInputHandler {
         };
 
         let mode = session.collaboration_mode().await.mode;
-        if let Some(message) = request_user_input_unavailable_message(mode) {
+        if let Some(message) =
+            request_user_input_unavailable_message(mode, self.default_mode_request_user_input)
+        {
             return Err(FunctionCallError::RespondToModel(message));
         }
 
@@ -117,34 +129,45 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     #[test]
-    fn request_user_input_mode_availability_includes_default_mode() {
+    fn request_user_input_mode_availability_defaults_to_plan_only() {
         assert!(ModeKind::Plan.allows_request_user_input());
-        assert!(ModeKind::Default.allows_request_user_input());
+        assert!(!ModeKind::Default.allows_request_user_input());
         assert!(!ModeKind::Execute.allows_request_user_input());
         assert!(!ModeKind::PairProgramming.allows_request_user_input());
     }
 
     #[test]
-    fn request_user_input_unavailable_messages_use_default_name_for_default_modes() {
-        assert_eq!(request_user_input_unavailable_message(ModeKind::Plan), None);
+    fn request_user_input_unavailable_messages_respect_default_mode_feature_flag() {
         assert_eq!(
-            request_user_input_unavailable_message(ModeKind::Default),
+            request_user_input_unavailable_message(ModeKind::Plan, false),
             None
         );
         assert_eq!(
-            request_user_input_unavailable_message(ModeKind::Execute),
+            request_user_input_unavailable_message(ModeKind::Default, false),
+            Some("request_user_input is unavailable in Default mode".to_string())
+        );
+        assert_eq!(
+            request_user_input_unavailable_message(ModeKind::Default, true),
+            None
+        );
+        assert_eq!(
+            request_user_input_unavailable_message(ModeKind::Execute, false),
             Some("request_user_input is unavailable in Execute mode".to_string())
         );
         assert_eq!(
-            request_user_input_unavailable_message(ModeKind::PairProgramming),
+            request_user_input_unavailable_message(ModeKind::PairProgramming, false),
             Some("request_user_input is unavailable in Pair Programming mode".to_string())
         );
     }
 
     #[test]
-    fn request_user_input_tool_description_mentions_default_and_plan() {
+    fn request_user_input_tool_description_mentions_available_modes() {
         assert_eq!(
-            request_user_input_tool_description(),
+            request_user_input_tool_description(false),
+            "Request user input for one to three short questions and wait for the response. This tool is only available in Plan mode.".to_string()
+        );
+        assert_eq!(
+            request_user_input_tool_description(true),
             "Request user input for one to three short questions and wait for the response. This tool is only available in Default or Plan mode.".to_string()
         );
     }

--- a/codex-rs/core/templates/collaboration_mode/default.md
+++ b/codex-rs/core/templates/collaboration_mode/default.md
@@ -8,4 +8,4 @@ Your active mode changes only when new developer instructions with a different `
 
 {{REQUEST_USER_INPUT_AVAILABILITY}}
 
-If a decision is necessary and cannot be discovered from local context, ask the user directly. However, in Default mode you should strongly prefer executing the user's request rather than stopping to ask questions.
+In Default mode, strongly prefer making reasonable assumptions and executing the user's request rather than stopping to ask questions. If you absolutely must ask a question because the answer cannot be discovered from local context and a reasonable assumption would be risky, prefer using the `request_user_input` tool rather than writing a multiple choice question as a textual assistant message. Never write a multiple choice question as a textual assistant message.

--- a/codex-rs/core/templates/collaboration_mode/default.md
+++ b/codex-rs/core/templates/collaboration_mode/default.md
@@ -8,4 +8,4 @@ Your active mode changes only when new developer instructions with a different `
 
 {{REQUEST_USER_INPUT_AVAILABILITY}}
 
-{{QUESTION_STRATEGY}}
+{{ASKING_QUESTIONS_GUIDANCE}}

--- a/codex-rs/core/templates/collaboration_mode/default.md
+++ b/codex-rs/core/templates/collaboration_mode/default.md
@@ -8,4 +8,4 @@ Your active mode changes only when new developer instructions with a different `
 
 {{REQUEST_USER_INPUT_AVAILABILITY}}
 
-In Default mode, strongly prefer making reasonable assumptions and executing the user's request rather than stopping to ask questions. If you absolutely must ask a question because the answer cannot be discovered from local context and a reasonable assumption would be risky, prefer using the `request_user_input` tool rather than writing a multiple choice question as a textual assistant message. Never write a multiple choice question as a textual assistant message.
+{{QUESTION_STRATEGY}}

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -12,6 +12,7 @@ use codex_core::built_in_model_providers;
 use codex_core::default_client::originator;
 use codex_core::error::CodexErr;
 use codex_core::features::Feature;
+use codex_core::models_manager::collaboration_mode_presets::CollaborationModesConfig;
 use codex_otel::OtelManager;
 use codex_otel::TelemetryAuthMode;
 use codex_protocol::ThreadId;
@@ -584,9 +585,11 @@ async fn prefers_apikey_when_config_prefers_apikey_even_with_chatgpt_tokens() {
         auth_manager,
         SessionSource::Exec,
         config.model_catalog.clone(),
-        config
-            .features
-            .enabled(Feature::DefaultModeRequestUserInput),
+        CollaborationModesConfig::new(
+            config
+                .features
+                .enabled(Feature::DefaultModeRequestUserInput),
+        ),
     );
     let NewThread { thread: codex, .. } = thread_manager
         .start_thread(config)

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -584,6 +584,9 @@ async fn prefers_apikey_when_config_prefers_apikey_even_with_chatgpt_tokens() {
         auth_manager,
         SessionSource::Exec,
         config.model_catalog.clone(),
+        config
+            .features
+            .enabled(Feature::DefaultModeRequestUserInput),
     );
     let NewThread { thread: codex, .. } = thread_manager
         .start_thread(config)

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -585,11 +585,11 @@ async fn prefers_apikey_when_config_prefers_apikey_even_with_chatgpt_tokens() {
         auth_manager,
         SessionSource::Exec,
         config.model_catalog.clone(),
-        CollaborationModesConfig::new(
-            config
+        CollaborationModesConfig {
+            default_mode_request_user_input: config
                 .features
                 .enabled(Feature::DefaultModeRequestUserInput),
-        ),
+        },
     );
     let NewThread { thread: codex, .. } = thread_manager
         .start_thread(config)

--- a/codex-rs/core/tests/suite/model_info_overrides.rs
+++ b/codex-rs/core/tests/suite/model_info_overrides.rs
@@ -12,7 +12,7 @@ async fn offline_model_info_without_tool_output_override() {
     let auth_manager = codex_core::test_support::auth_manager_from_auth(
         CodexAuth::create_dummy_chatgpt_auth_for_testing(),
     );
-    let manager = ModelsManager::new(config.codex_home.clone(), auth_manager, None);
+    let manager = ModelsManager::new(config.codex_home.clone(), auth_manager, None, false);
 
     let model_info = manager.get_model_info("gpt-5.1", &config).await;
 
@@ -30,7 +30,7 @@ async fn offline_model_info_with_tool_output_override() {
     let auth_manager = codex_core::test_support::auth_manager_from_auth(
         CodexAuth::create_dummy_chatgpt_auth_for_testing(),
     );
-    let manager = ModelsManager::new(config.codex_home.clone(), auth_manager, None);
+    let manager = ModelsManager::new(config.codex_home.clone(), auth_manager, None, false);
 
     let model_info = manager.get_model_info("gpt-5.1-codex", &config).await;
 

--- a/codex-rs/core/tests/suite/model_info_overrides.rs
+++ b/codex-rs/core/tests/suite/model_info_overrides.rs
@@ -1,4 +1,5 @@
 use codex_core::CodexAuth;
+use codex_core::models_manager::collaboration_mode_presets::CollaborationModesConfig;
 use codex_core::models_manager::manager::ModelsManager;
 use codex_protocol::openai_models::TruncationPolicyConfig;
 use core_test_support::load_default_config_for_test;
@@ -12,7 +13,12 @@ async fn offline_model_info_without_tool_output_override() {
     let auth_manager = codex_core::test_support::auth_manager_from_auth(
         CodexAuth::create_dummy_chatgpt_auth_for_testing(),
     );
-    let manager = ModelsManager::new(config.codex_home.clone(), auth_manager, None, false);
+    let manager = ModelsManager::new(
+        config.codex_home.clone(),
+        auth_manager,
+        None,
+        CollaborationModesConfig::default(),
+    );
 
     let model_info = manager.get_model_info("gpt-5.1", &config).await;
 
@@ -30,7 +36,12 @@ async fn offline_model_info_with_tool_output_override() {
     let auth_manager = codex_core::test_support::auth_manager_from_auth(
         CodexAuth::create_dummy_chatgpt_auth_for_testing(),
     );
-    let manager = ModelsManager::new(config.codex_home.clone(), auth_manager, None, false);
+    let manager = ModelsManager::new(
+        config.codex_home.clone(),
+        auth_manager,
+        None,
+        CollaborationModesConfig::default(),
+    );
 
     let model_info = manager.get_model_info("gpt-5.1-codex", &config).await;
 

--- a/codex-rs/core/tests/suite/model_tools.rs
+++ b/codex-rs/core/tests/suite/model_tools.rs
@@ -1,6 +1,5 @@
 #![allow(clippy::unwrap_used)]
 
-use codex_core::features::Feature;
 use codex_protocol::config_types::WebSearchMode;
 use core_test_support::responses;
 use core_test_support::responses::start_mock_server;
@@ -40,7 +39,6 @@ async fn collect_tool_identifiers_for_model(model: &str) -> Vec<String> {
                 .web_search_mode
                 .set(WebSearchMode::Cached)
                 .expect("test web_search_mode should satisfy constraints");
-            config.features.enable(Feature::CollaborationModes);
         });
     let test = builder
         .build(&server)

--- a/codex-rs/core/tests/suite/request_user_input.rs
+++ b/codex-rs/core/tests/suite/request_user_input.rs
@@ -86,8 +86,10 @@ async fn request_user_input_round_trip_for_mode(mode: ModeKind) -> anyhow::Resul
         session_configured,
         ..
     } = builder
-        .with_config(|config| {
-            config.features.enable(Feature::CollaborationModes);
+        .with_config(move |config| {
+            if mode == ModeKind::Default {
+                config.features.enable(Feature::DefaultModeRequestUserInput);
+            }
         })
         .build(&server)
         .await?;
@@ -198,18 +200,13 @@ where
 
     let server = start_mock_server().await;
 
-    let builder = test_codex();
+    let mut builder = test_codex();
     let TestCodex {
         codex,
         cwd,
         session_configured,
         ..
-    } = builder
-        .with_config(|config| {
-            config.features.enable(Feature::CollaborationModes);
-        })
-        .build(&server)
-        .await?;
+    } = builder.build(&server).await?;
 
     let mode_slug = mode_name.to_lowercase().replace(' ', "-");
     let call_id = format!("user-input-{mode_slug}-call");
@@ -290,7 +287,20 @@ async fn request_user_input_rejected_in_execute_mode_alias() -> anyhow::Result<(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn request_user_input_round_trip_in_default_mode() -> anyhow::Result<()> {
+async fn request_user_input_rejected_in_default_mode_by_default() -> anyhow::Result<()> {
+    assert_request_user_input_rejected("Default", |model| CollaborationMode {
+        mode: ModeKind::Default,
+        settings: Settings {
+            model,
+            reasoning_effort: None,
+            developer_instructions: None,
+        },
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn request_user_input_round_trip_in_default_mode_with_feature() -> anyhow::Result<()> {
     request_user_input_round_trip_for_mode(ModeKind::Default).await
 }
 

--- a/codex-rs/core/tests/suite/request_user_input.rs
+++ b/codex-rs/core/tests/suite/request_user_input.rs
@@ -290,16 +290,8 @@ async fn request_user_input_rejected_in_execute_mode_alias() -> anyhow::Result<(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn request_user_input_rejected_in_default_mode() -> anyhow::Result<()> {
-    assert_request_user_input_rejected("Default", |model| CollaborationMode {
-        mode: ModeKind::Default,
-        settings: Settings {
-            model,
-            reasoning_effort: None,
-            developer_instructions: None,
-        },
-    })
-    .await
+async fn request_user_input_round_trip_in_default_mode() -> anyhow::Result<()> {
+    request_user_input_round_trip_for_mode(ModeKind::Default).await
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -396,6 +396,9 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         auth_manager.clone(),
         SessionSource::Exec,
         config.model_catalog.clone(),
+        config
+            .features
+            .enabled(codex_core::features::Feature::DefaultModeRequestUserInput),
     ));
     let default_model = thread_manager
         .get_models_manager()

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -31,6 +31,7 @@ use codex_core::config_loader::ConfigLoadError;
 use codex_core::config_loader::format_config_error_with_source;
 use codex_core::format_exec_policy_error_with_source;
 use codex_core::git_info::get_git_repo_root;
+use codex_core::models_manager::collaboration_mode_presets::CollaborationModesConfig;
 use codex_core::models_manager::manager::RefreshStrategy;
 use codex_protocol::approvals::ElicitationAction;
 use codex_protocol::config_types::SandboxMode;
@@ -396,9 +397,11 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         auth_manager.clone(),
         SessionSource::Exec,
         config.model_catalog.clone(),
-        config
-            .features
-            .enabled(codex_core::features::Feature::DefaultModeRequestUserInput),
+        CollaborationModesConfig::new(
+            config
+                .features
+                .enabled(codex_core::features::Feature::DefaultModeRequestUserInput),
+        ),
     ));
     let default_model = thread_manager
         .get_models_manager()

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -397,11 +397,11 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         auth_manager.clone(),
         SessionSource::Exec,
         config.model_catalog.clone(),
-        CollaborationModesConfig::new(
-            config
+        CollaborationModesConfig {
+            default_mode_request_user_input: config
                 .features
                 .enabled(codex_core::features::Feature::DefaultModeRequestUserInput),
-        ),
+        },
     ));
     let default_model = thread_manager
         .get_models_manager()

--- a/codex-rs/mcp-server/src/message_processor.rs
+++ b/codex-rs/mcp-server/src/message_processor.rs
@@ -63,11 +63,11 @@ impl MessageProcessor {
             auth_manager,
             SessionSource::Mcp,
             config.model_catalog.clone(),
-            CollaborationModesConfig::new(
-                config
+            CollaborationModesConfig {
+                default_mode_request_user_input: config
                     .features
                     .enabled(codex_core::features::Feature::DefaultModeRequestUserInput),
-            ),
+            },
         ));
         Self {
             outgoing,

--- a/codex-rs/mcp-server/src/message_processor.rs
+++ b/codex-rs/mcp-server/src/message_processor.rs
@@ -6,6 +6,7 @@ use codex_core::ThreadManager;
 use codex_core::config::Config;
 use codex_core::default_client::USER_AGENT_SUFFIX;
 use codex_core::default_client::get_codex_user_agent;
+use codex_core::models_manager::collaboration_mode_presets::CollaborationModesConfig;
 use codex_protocol::ThreadId;
 use codex_protocol::protocol::SessionSource;
 use codex_protocol::protocol::Submission;
@@ -62,9 +63,11 @@ impl MessageProcessor {
             auth_manager,
             SessionSource::Mcp,
             config.model_catalog.clone(),
-            config
-                .features
-                .enabled(codex_core::features::Feature::DefaultModeRequestUserInput),
+            CollaborationModesConfig::new(
+                config
+                    .features
+                    .enabled(codex_core::features::Feature::DefaultModeRequestUserInput),
+            ),
         ));
         Self {
             outgoing,

--- a/codex-rs/mcp-server/src/message_processor.rs
+++ b/codex-rs/mcp-server/src/message_processor.rs
@@ -62,6 +62,9 @@ impl MessageProcessor {
             auth_manager,
             SessionSource::Mcp,
             config.model_catalog.clone(),
+            config
+                .features
+                .enabled(codex_core::features::Feature::DefaultModeRequestUserInput),
         ));
         Self {
             outgoing,

--- a/codex-rs/protocol/src/config_types.rs
+++ b/codex-rs/protocol/src/config_types.rs
@@ -210,7 +210,7 @@ impl ModeKind {
     }
 
     pub const fn allows_request_user_input(self) -> bool {
-        matches!(self, Self::Plan)
+        matches!(self, Self::Plan | Self::Default)
     }
 }
 

--- a/codex-rs/protocol/src/config_types.rs
+++ b/codex-rs/protocol/src/config_types.rs
@@ -210,7 +210,7 @@ impl ModeKind {
     }
 
     pub const fn allows_request_user_input(self) -> bool {
-        matches!(self, Self::Plan | Self::Default)
+        matches!(self, Self::Plan)
     }
 }
 

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -1248,11 +1248,11 @@ impl App {
             auth_manager.clone(),
             SessionSource::Cli,
             config.model_catalog.clone(),
-            CollaborationModesConfig::new(
-                config
+            CollaborationModesConfig {
+                default_mode_request_user_input: config
                     .features
                     .enabled(codex_core::features::Feature::DefaultModeRequestUserInput),
-            ),
+            },
         ));
         let mut model = thread_manager
             .get_models_manager()

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -47,6 +47,7 @@ use codex_core::config::edit::ConfigEdit;
 use codex_core::config::edit::ConfigEditsBuilder;
 use codex_core::config_loader::ConfigLayerStackOrdering;
 use codex_core::features::Feature;
+use codex_core::models_manager::collaboration_mode_presets::CollaborationModesConfig;
 use codex_core::models_manager::manager::RefreshStrategy;
 use codex_core::models_manager::model_presets::HIDE_GPT_5_1_CODEX_MAX_MIGRATION_PROMPT_CONFIG;
 use codex_core::models_manager::model_presets::HIDE_GPT5_1_MIGRATION_PROMPT_CONFIG;
@@ -1247,9 +1248,11 @@ impl App {
             auth_manager.clone(),
             SessionSource::Cli,
             config.model_catalog.clone(),
-            config
-                .features
-                .enabled(codex_core::features::Feature::DefaultModeRequestUserInput),
+            CollaborationModesConfig::new(
+                config
+                    .features
+                    .enabled(codex_core::features::Feature::DefaultModeRequestUserInput),
+            ),
         ));
         let mut model = thread_manager
             .get_models_manager()

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -1247,6 +1247,9 @@ impl App {
             auth_manager.clone(),
             SessionSource::Cli,
             config.model_catalog.clone(),
+            config
+                .features
+                .enabled(codex_core::features::Feature::DefaultModeRequestUserInput),
         ));
         let mut model = thread_manager
             .get_models_manager()

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -24,6 +24,7 @@ use codex_core::config::ConstraintError;
 use codex_core::config::types::WindowsSandboxModeToml;
 use codex_core::config_loader::RequirementSource;
 use codex_core::features::Feature;
+use codex_core::models_manager::collaboration_mode_presets::CollaborationModesConfig;
 use codex_core::models_manager::manager::ModelsManager;
 use codex_core::skills::model::SkillMetadata;
 use codex_core::terminal::TerminalName;
@@ -1637,7 +1638,7 @@ async fn make_chatwidget_manual(
         codex_home,
         auth_manager.clone(),
         None,
-        false,
+        CollaborationModesConfig::default(),
     ));
     let reasoning_effort = None;
     let base_mode = CollaborationMode {
@@ -1764,7 +1765,7 @@ fn set_chatgpt_auth(chat: &mut ChatWidget) {
         chat.config.codex_home.clone(),
         chat.auth_manager.clone(),
         None,
-        false,
+        CollaborationModesConfig::default(),
     ));
 }
 

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -1633,7 +1633,12 @@ async fn make_chatwidget_manual(
     let auth_manager =
         codex_core::test_support::auth_manager_from_auth(CodexAuth::from_api_key("test"));
     let codex_home = cfg.codex_home.clone();
-    let models_manager = Arc::new(ModelsManager::new(codex_home, auth_manager.clone(), None));
+    let models_manager = Arc::new(ModelsManager::new(
+        codex_home,
+        auth_manager.clone(),
+        None,
+        false,
+    ));
     let reasoning_effort = None;
     let base_mode = CollaborationMode {
         mode: ModeKind::Default,
@@ -1759,6 +1764,7 @@ fn set_chatgpt_auth(chat: &mut ChatWidget) {
         chat.config.codex_home.clone(),
         chat.auth_manager.clone(),
         None,
+        false,
     ));
 }
 


### PR DESCRIPTION
## Summary
- allow `request_user_input` in Default collaboration mode as well as Plan
- update the Default-mode instructions to prefer assumptions first and use `request_user_input` only when a question is unavoidable
- update request_user_input and app-server tests to match the new Default-mode behavior

## Testing
- just fmt
- cargo test -p codex-protocol
- cargo test -p codex-core request_user_input
- cargo test -p codex-app-server turn_start_accepts_collaboration_mode_override_v2