### PR TITLE
refactor: remove unused seatbelt unix socket arg

### DIFF
--- a/codex-rs/core/src/sandboxing/mod.rs
+++ b/codex-rs/core/src/sandboxing/mod.rs
@@ -353,7 +353,6 @@ impl SandboxManager {
                     sandbox_policy_cwd,
                     enforce_managed_network,
                     network,
-                    &[],
                 );
                 let mut full_command = Vec::with_capacity(1 + args.len());
                 full_command.push(MACOS_PATH_TO_SEATBELT_EXECUTABLE.to_string());

--- a/codex-rs/core/src/seatbelt.rs
+++ b/codex-rs/core/src/seatbelt.rs
@@ -42,14 +42,8 @@ pub async fn spawn_command_under_seatbelt(
     network: Option<&NetworkProxy>,
     mut env: HashMap<String, String>,
 ) -> std::io::Result<Child> {
-    let args = create_seatbelt_command_args(
-        command,
-        sandbox_policy,
-        sandbox_policy_cwd,
-        false,
-        network,
-        &[],
-    );
+    let args =
+        create_seatbelt_command_args(command, sandbox_policy, sandbox_policy_cwd, false, network);
     let arg0 = None;
     env.insert(CODEX_SANDBOX_ENV_VAR.to_string(), "seatbelt".to_string());
     spawn_child_async(SpawnChildRequest {
@@ -292,7 +286,6 @@ pub(crate) fn create_seatbelt_command_args(
     sandbox_policy_cwd: &Path,
     enforce_managed_network: bool,
     network: Option<&NetworkProxy>,
-    allowed_unix_socket_paths: &[PathBuf],
 ) -> Vec<String> {
     create_seatbelt_command_args_with_extensions(
         command,
@@ -301,7 +294,6 @@ pub(crate) fn create_seatbelt_command_args(
         enforce_managed_network,
         network,
         None,
-        allowed_unix_socket_paths,
     )
 }
 
@@ -312,7 +304,6 @@ pub(crate) fn create_seatbelt_command_args_with_extensions(
     enforce_managed_network: bool,
     network: Option<&NetworkProxy>,
     extensions: Option<&MacOsSeatbeltProfileExtensions>,
-    allowed_unix_socket_paths: &[PathBuf],
 ) -> Vec<String> {
     let (file_write_policy, file_write_dir_params) = {
         if sandbox_policy.has_full_disk_write_access() {
@@ -409,8 +400,6 @@ pub(crate) fn create_seatbelt_command_args_with_extensions(
 
     let proxy = proxy_policy_inputs(network);
     let network_policy = dynamic_network_policy(sandbox_policy, enforce_managed_network, &proxy);
-    let (unix_socket_policy, unix_socket_params) =
-        unix_socket_policy_and_params(allowed_unix_socket_paths);
     let seatbelt_extensions = extensions.map_or_else(
         || {
             // Backward-compatibility default when no extension profile is provided.
@@ -429,9 +418,6 @@ pub(crate) fn create_seatbelt_command_args_with_extensions(
     if include_platform_defaults {
         policy_sections.push(MACOS_SEATBELT_PLATFORM_DEFAULTS.to_string());
     }
-    if !unix_socket_policy.is_empty() {
-        policy_sections.push(unix_socket_policy);
-    }
     if !seatbelt_extensions.policy.is_empty() {
         policy_sections.push(seatbelt_extensions.policy.clone());
     }
@@ -441,7 +427,6 @@ pub(crate) fn create_seatbelt_command_args_with_extensions(
     let dir_params = [
         file_read_dir_params,
         file_write_dir_params,
-        unix_socket_params,
         macos_dir_params(),
         unix_socket_dir_params(&proxy),
         seatbelt_extensions.dir_params,
@@ -456,27 +441,6 @@ pub(crate) fn create_seatbelt_command_args_with_extensions(
     seatbelt_args.push("--".to_string());
     seatbelt_args.extend(command);
     seatbelt_args
-}
-
-fn unix_socket_policy_and_params(
-    allowed_unix_socket_paths: &[PathBuf],
-) -> (String, Vec<(String, PathBuf)>) {
-    if allowed_unix_socket_paths.is_empty() {
-        return (String::new(), Vec::new());
-    }
-
-    let mut policy = String::from("; allow outbound connect to explicitly-approved unix sockets\n");
-    let mut params = Vec::with_capacity(allowed_unix_socket_paths.len());
-
-    for (index, path) in allowed_unix_socket_paths.iter().enumerate() {
-        let key = format!("ALLOWED_UNIX_SOCKET_{index}");
-        policy.push_str(&format!(
-            "(allow network-outbound (remote unix-socket (path (param \"{key}\"))))\n"
-        ));
-        params.push((key, path.clone()));
-    }
-
-    (policy, params)
 }
 
 /// Wraps libc::confstr to return a String.
@@ -608,7 +572,6 @@ mod tests {
                 macos_accessibility: true,
                 macos_calendar: true,
             }),
-            &[],
         );
         let policy = &args[1];
 
@@ -627,7 +590,6 @@ mod tests {
             cwd.as_path(),
             false,
             None,
-            &[],
         );
         let policy = &args[1];
         assert!(policy.contains("(allow user-preference-read)"));
@@ -644,7 +606,6 @@ mod tests {
             false,
             None,
             Some(&MacOsSeatbeltProfileExtensions::default()),
-            &[],
         );
         let policy = &args[1];
         assert!(!policy.contains("appleevent-send"));
@@ -652,32 +613,6 @@ mod tests {
         assert!(!policy.contains("com.apple.CalendarAgent"));
         assert!(policy.contains("(allow user-preference-read)"));
         assert!(!policy.contains("user-preference-write"));
-    }
-
-    #[test]
-    fn seatbelt_args_allow_explicit_wrapper_unix_socket_path() {
-        let cwd = std::env::temp_dir();
-        let socket_path = std::env::temp_dir().join("codex-zsh-wrapper-test.sock");
-        let args = create_seatbelt_command_args(
-            vec!["echo".to_string(), "ok".to_string()],
-            &SandboxPolicy::new_read_only_policy(),
-            cwd.as_path(),
-            false,
-            None,
-            std::slice::from_ref(&socket_path),
-        );
-        let policy = &args[1];
-        let param_key = "ALLOWED_UNIX_SOCKET_0";
-
-        assert!(
-            policy.contains("(allow network-outbound (remote unix-socket (path (param \"ALLOWED_UNIX_SOCKET_0\"))))"),
-            "policy should contain explicit unix-socket allow rule:\n{policy}"
-        );
-        assert!(
-            args.iter()
-                .any(|arg| arg == &format!("-D{param_key}={}", socket_path.to_string_lossy())),
-            "args should include unix-socket path param"
-        );
     }
 
     #[test]
@@ -935,8 +870,7 @@ mod tests {
         .iter()
         .map(std::string::ToString::to_string)
         .collect();
-        let args =
-            create_seatbelt_command_args(shell_command.clone(), &policy, &cwd, false, None, &[]);
+        let args = create_seatbelt_command_args(shell_command.clone(), &policy, &cwd, false, None);
 
         // Build the expected policy text using a raw string for readability.
         // Note that the policy includes:
@@ -1033,7 +967,7 @@ mod tests {
         .map(std::string::ToString::to_string)
         .collect();
         let write_hooks_file_args =
-            create_seatbelt_command_args(shell_command_git, &policy, &cwd, false, None, &[]);
+            create_seatbelt_command_args(shell_command_git, &policy, &cwd, false, None);
         let output = Command::new(MACOS_PATH_TO_SEATBELT_EXECUTABLE)
             .args(&write_hooks_file_args)
             .current_dir(&cwd)
@@ -1064,7 +998,7 @@ mod tests {
         .map(std::string::ToString::to_string)
         .collect();
         let write_allowed_file_args =
-            create_seatbelt_command_args(shell_command_allowed, &policy, &cwd, false, None, &[]);
+            create_seatbelt_command_args(shell_command_allowed, &policy, &cwd, false, None);
         let output = Command::new(MACOS_PATH_TO_SEATBELT_EXECUTABLE)
             .args(&write_allowed_file_args)
             .current_dir(&cwd)
@@ -1125,7 +1059,7 @@ mod tests {
         .iter()
         .map(std::string::ToString::to_string)
         .collect();
-        let args = create_seatbelt_command_args(shell_command, &policy, &cwd, false, None, &[]);
+        let args = create_seatbelt_command_args(shell_command, &policy, &cwd, false, None);
 
         let output = Command::new(MACOS_PATH_TO_SEATBELT_EXECUTABLE)
             .args(&args)
@@ -1156,7 +1090,7 @@ mod tests {
         .map(std::string::ToString::to_string)
         .collect();
         let gitdir_args =
-            create_seatbelt_command_args(shell_command_gitdir, &policy, &cwd, false, None, &[]);
+            create_seatbelt_command_args(shell_command_gitdir, &policy, &cwd, false, None);
         let output = Command::new(MACOS_PATH_TO_SEATBELT_EXECUTABLE)
             .args(&gitdir_args)
             .current_dir(&cwd)
@@ -1219,7 +1153,6 @@ mod tests {
             vulnerable_root.as_path(),
             false,
             None,
-            &[],
         );
 
         let tmpdir_env_var = std::env::var("TMPDIR")


### PR DESCRIPTION
https://github.com/openai/codex/pull/12052 introduced an `allowed_unix_socket_paths` parameter to `create_seatbelt_command_args()`, but https://github.com/openai/codex/pull/12649 removed the abstraction that #12052 introduced, so this parameter is no longer necessary as it is always an empty slice.