### PR TITLE
Promote js_repl to experimental with Node requirement

### DIFF
--- a/codex-rs/core/src/features.rs
+++ b/codex-rs/core/src/features.rs
@@ -460,7 +460,11 @@ pub const FEATURES: &[FeatureSpec] = &[
     FeatureSpec {
         id: Feature::JsRepl,
         key: "js_repl",
-        stage: Stage::UnderDevelopment,
+        stage: Stage::Experimental {
+            name: "JavaScript REPL",
+            menu_description: "Enable a persistent Node-backed JavaScript REPL for interactive website debugging and other inline JavaScript execution capabilities. Requires Node >= v24.13.1 installed.",
+            announcement: "NEW: JavaScript REPL is now available in /experimental. Enable it, then start a new chat or restart Codex to use it.",
+        },
         default_enabled: false,
     },
     FeatureSpec {
@@ -793,6 +797,23 @@ mod tests {
             Stage::UnderDevelopment
         );
         assert_eq!(Feature::UseLinuxSandboxBwrap.default_enabled(), false);
+    }
+
+    #[test]
+    fn js_repl_is_experimental_and_user_toggleable() {
+        let spec = Feature::JsRepl.info();
+        let stage = spec.stage;
+        let expected_node_version = include_str!("../../node-version.txt").trim_end();
+
+        assert!(matches!(stage, Stage::Experimental { .. }));
+        assert_eq!(stage.experimental_menu_name(), Some("JavaScript REPL"));
+        assert_eq!(
+            stage.experimental_menu_description().map(str::to_owned),
+            Some(format!(
+                "Enable a persistent Node-backed JavaScript REPL for interactive website debugging and other inline JavaScript execution capabilities. Requires Node >= v{expected_node_version} installed."
+            ))
+        );
+        assert_eq!(Feature::JsRepl.default_enabled(), false);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Promote `js_repl` to an experimental feature that users can enable from `/experimental`.
- Add `js_repl` experimental metadata, including the Node prerequisite and activation guidance.
- Add regression coverage for the feature metadata and the `/experimental` popup.

## What Changed

- Changed `Feature::JsRepl` from `Stage::UnderDevelopment` to `Stage::Experimental`.
- Added experimental metadata for `js_repl` in `core/src/features.rs`:
  - name: `JavaScript REPL`
  - description: calls out interactive website debugging, inline JavaScript execution, and the required Node version (`>= v24.13.1`)
  - announcement: tells users to enable it, then start a new chat or restart Codex
- Added a core unit test that verifies:
  - `js_repl` is experimental
  - `js_repl` is disabled by default
  - the hardcoded Node version in the description matches `node-version.txt`
- Added a TUI test that opens the `/experimental` popup and verifies the rendered `js_repl` entry includes the Node requirement text.

## Testing

- `just fmt`
- `cargo test -p codex-tui`
- `cargo test -p codex-core` (unit-test phase passed; stopped during the long `tests/all.rs` integration suite)
