### PR TITLE
Add support for local cwd mcp.json MCP server config

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -12,6 +12,13 @@ Codex can connect to MCP servers configured in `~/.codex/config.toml`. See the c
 
 - https://developers.openai.com/codex/config-reference
 
+Codex also supports a local `mcp.json` file in the current working directory for project-scoped MCP servers. Supported shapes are either:
+
+- `{ "mcpServers": { ... } }`
+- `{ ... }` (direct server map)
+
+When `mcp.json` and `mcp_servers` define the same server name, `mcp.json` wins for that session. Local project config is trust-gated the same way as other project config.
+
 ## Apps (Connectors)
 
 Use `$` in the composer to insert a ChatGPT connector; the popover lists accessible


### PR DESCRIPTION
## Summary

This PR adds support for a project-local `mcp.json` file in the current working directory (`cwd/mcp.json`) so MCP server launchers can be configured per-repo/session without modifying global `~/.codex/config.toml`.

### Supported `mcp.json` shapes

- `{ "mcpServers": { ... } }`
- `{ ... }` (direct server map)

## Motivation

Enhancement request: support local MCP server configuration for the current directory.

This enables project-scoped MCP setup with lower friction and cleaner separation from global user config.

## What changed

1. Config loader now reads `cwd/mcp.json` (CWD only) and maps it into `mcp_servers`.
2. Local `mcp.json` entries are merged into the CWD project layer and override same-name `mcp_servers` entries from other layers for the active session.
3. Loading is trust-gated using existing project trust logic:
   - trusted project: local config is active
   - untrusted/unknown project: layer is disabled, local MCP config not applied
4. Error handling follows trust model:
   - trusted + invalid `mcp.json`: fail config load with file-specific parse error
   - untrusted/unknown + invalid `mcp.json`: ignored with disabled layer behavior
5. Docs updated to describe local `mcp.json`, supported shapes, precedence, and trust gating.

## Tests

Added loader tests covering:

- local override precedence over user/project `mcp_servers`
- direct-map JSON shape support
- use without `.codex/config.toml` in CWD
- untrusted project disable behavior
- invalid trusted `mcp.json` failure
- invalid untrusted `mcp.json` ignored
- inline `bearer_token` rejection in local config

## Notes on local validation

- `just fmt` could not be run in this environment because `just` is not installed and network access is unavailable for installing it.
- touched Rust files were formatted with `rustfmt` directly.
- `cargo test -p codex-core` could not run because local Cargo is `1.83.0` and this workspace requires `edition2024` support from a newer toolchain.
