### PR TITLE
Feature-flag request_user_input outside plan mode

### DIFF
--- a/codex-rs/app-server/src/message_processor.rs
+++ b/codex-rs/app-server/src/message_processor.rs
@@ -177,6 +177,9 @@ impl MessageProcessor {
             auth_manager.clone(),
             SessionSource::VSCode,
             config.model_catalog.clone(),
+            config
+                .features
+                .enabled(codex_core::features::Feature::RequestUserInputOutsidePlanMode),
         ));
         let cloud_requirements = Arc::new(RwLock::new(cloud_requirements));
         let codex_message_processor = CodexMessageProcessor::new(CodexMessageProcessorArgs {

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -373,6 +373,9 @@
             "request_rule": {
               "type": "boolean"
             },
+            "request_user_input_outside_plan_mode": {
+              "type": "boolean"
+            },
             "responses_websockets": {
               "type": "boolean"
             },
@@ -1658,6 +1661,9 @@
           "type": "boolean"
         },
         "request_rule": {
+          "type": "boolean"
+        },
+        "request_user_input_outside_plan_mode": {
           "type": "boolean"
         },
         "responses_websockets": {

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -8068,6 +8068,9 @@ mod tests {
             config.codex_home.clone(),
             auth_manager.clone(),
             None,
+            config
+                .features
+                .enabled(Feature::RequestUserInputOutsidePlanMode),
         ));
         let model = ModelsManager::get_model_offline_for_tests(config.model.as_deref());
         let model_info =
@@ -8143,6 +8146,9 @@ mod tests {
             config.codex_home.clone(),
             auth_manager.clone(),
             None,
+            config
+                .features
+                .enabled(Feature::RequestUserInputOutsidePlanMode),
         ));
         let agent_control = AgentControl::default();
         let exec_policy = ExecPolicyManager::default();
@@ -8298,6 +8304,9 @@ mod tests {
             config.codex_home.clone(),
             auth_manager.clone(),
             None,
+            config
+                .features
+                .enabled(Feature::RequestUserInputOutsidePlanMode),
         ));
         let agent_control = AgentControl::default();
         let exec_policy = ExecPolicyManager::default();

--- a/codex-rs/core/src/features.rs
+++ b/codex-rs/core/src/features.rs
@@ -138,6 +138,8 @@ pub enum Feature {
     /// Enable collaboration modes (Plan, Default).
     /// Kept for config backward compatibility; behavior is always collaboration-modes-enabled.
     CollaborationModes,
+    /// Allow request_user_input outside plan mode.
+    RequestUserInputOutsidePlanMode,
     /// Enable personality selection in the TUI.
     Personality,
     /// Enable voice transcription in the TUI composer.
@@ -630,6 +632,16 @@ pub const FEATURES: &[FeatureSpec] = &[
         key: "collaboration_modes",
         stage: Stage::Removed,
         default_enabled: true,
+    },
+    FeatureSpec {
+        id: Feature::RequestUserInputOutsidePlanMode,
+        key: "request_user_input_outside_plan_mode",
+        stage: Stage::Experimental {
+            name: "Request user input outside Plan mode",
+            menu_description: "Allow Codex to use request_user_input in Default mode too.",
+            announcement: "NEW: request_user_input can be enabled outside Plan mode in /experimental.",
+        },
+        default_enabled: false,
     },
     FeatureSpec {
         id: Feature::Personality,

--- a/codex-rs/core/src/test_support.rs
+++ b/codex-rs/core/src/test_support.rs
@@ -85,5 +85,5 @@ pub fn all_model_presets() -> &'static Vec<ModelPreset> {
 }
 
 pub fn builtin_collaboration_mode_presets() -> Vec<CollaborationModeMask> {
-    collaboration_mode_presets::builtin_collaboration_mode_presets()
+    collaboration_mode_presets::builtin_collaboration_mode_presets(false)
 }

--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -143,6 +143,7 @@ impl ThreadManager {
         auth_manager: Arc<AuthManager>,
         session_source: SessionSource,
         model_catalog: Option<ModelsResponse>,
+        request_user_input_outside_plan_mode: bool,
     ) -> Self {
         let (thread_created_tx, _) = broadcast::channel(THREAD_CREATED_CHANNEL_CAPACITY);
         let skills_manager = Arc::new(SkillsManager::new(codex_home.clone()));
@@ -155,6 +156,7 @@ impl ThreadManager {
                     codex_home,
                     auth_manager.clone(),
                     model_catalog,
+                    request_user_input_outside_plan_mode,
                 )),
                 skills_manager,
                 file_watcher,

--- a/codex-rs/core/src/tools/handlers/mod.rs
+++ b/codex-rs/core/src/tools/handlers/mod.rs
@@ -31,6 +31,7 @@ pub use multi_agents::MultiAgentHandler;
 pub use plan::PlanHandler;
 pub use read_file::ReadFileHandler;
 pub use request_user_input::RequestUserInputHandler;
+pub(crate) use request_user_input::request_user_input_allowed_for_mode;
 pub(crate) use request_user_input::request_user_input_tool_description;
 pub(crate) use search_tool_bm25::DEFAULT_LIMIT as SEARCH_TOOL_BM25_DEFAULT_LIMIT;
 pub(crate) use search_tool_bm25::SEARCH_TOOL_BM25_TOOL_NAME;

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -584,6 +584,9 @@ async fn prefers_apikey_when_config_prefers_apikey_even_with_chatgpt_tokens() {
         auth_manager,
         SessionSource::Exec,
         config.model_catalog.clone(),
+        config
+            .features
+            .enabled(Feature::RequestUserInputOutsidePlanMode),
     );
     let NewThread { thread: codex, .. } = thread_manager
         .start_thread(config)

--- a/codex-rs/core/tests/suite/model_info_overrides.rs
+++ b/codex-rs/core/tests/suite/model_info_overrides.rs
@@ -12,7 +12,7 @@ async fn offline_model_info_without_tool_output_override() {
     let auth_manager = codex_core::test_support::auth_manager_from_auth(
         CodexAuth::create_dummy_chatgpt_auth_for_testing(),
     );
-    let manager = ModelsManager::new(config.codex_home.clone(), auth_manager, None);
+    let manager = ModelsManager::new(config.codex_home.clone(), auth_manager, None, false);
 
     let model_info = manager.get_model_info("gpt-5.1", &config).await;
 
@@ -30,7 +30,7 @@ async fn offline_model_info_with_tool_output_override() {
     let auth_manager = codex_core::test_support::auth_manager_from_auth(
         CodexAuth::create_dummy_chatgpt_auth_for_testing(),
     );
-    let manager = ModelsManager::new(config.codex_home.clone(), auth_manager, None);
+    let manager = ModelsManager::new(config.codex_home.clone(), auth_manager, None, false);
 
     let model_info = manager.get_model_info("gpt-5.1-codex", &config).await;
 

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -374,6 +374,9 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         auth_manager.clone(),
         SessionSource::Exec,
         config.model_catalog.clone(),
+        config
+            .features
+            .enabled(codex_core::features::Feature::RequestUserInputOutsidePlanMode),
     ));
     let default_model = thread_manager
         .get_models_manager()

--- a/codex-rs/mcp-server/src/message_processor.rs
+++ b/codex-rs/mcp-server/src/message_processor.rs
@@ -62,6 +62,9 @@ impl MessageProcessor {
             auth_manager,
             SessionSource::Mcp,
             config.model_catalog.clone(),
+            config
+                .features
+                .enabled(codex_core::features::Feature::RequestUserInputOutsidePlanMode),
         ));
         Self {
             outgoing,

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -1234,6 +1234,9 @@ impl App {
             auth_manager.clone(),
             SessionSource::Cli,
             config.model_catalog.clone(),
+            config
+                .features
+                .enabled(codex_core::features::Feature::RequestUserInputOutsidePlanMode),
         ));
         let mut model = thread_manager
             .get_models_manager()

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -1632,7 +1632,12 @@ async fn make_chatwidget_manual(
     let auth_manager =
         codex_core::test_support::auth_manager_from_auth(CodexAuth::from_api_key("test"));
     let codex_home = cfg.codex_home.clone();
-    let models_manager = Arc::new(ModelsManager::new(codex_home, auth_manager.clone(), None));
+    let models_manager = Arc::new(ModelsManager::new(
+        codex_home,
+        auth_manager.clone(),
+        None,
+        false,
+    ));
     let reasoning_effort = None;
     let base_mode = CollaborationMode {
         mode: ModeKind::Default,
@@ -1755,6 +1760,7 @@ fn set_chatgpt_auth(chat: &mut ChatWidget) {
         chat.config.codex_home.clone(),
         chat.auth_manager.clone(),
         None,
+        false,
     ));
 }
 


### PR DESCRIPTION
- add an experimental flag to allow request_user_input in non-Plan collaboration modes
- keep default behavior unchanged while updating tool descriptions, mode instructions, and tests