### PR TITLE
tui: use thread_id for resume/fork cwd resolution

### DIFF
--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -914,18 +914,7 @@ async fn run_ratatui_app(
     app_result
 }
 
-pub(crate) fn parse_thread_id_from_rollout_path(path: &Path) -> Option<ThreadId> {
-    let file_name = path.file_name()?.to_str()?;
-    let core = file_name.strip_prefix("rollout-")?.strip_suffix(".jsonl")?;
-    core.match_indices('-')
-        .rev()
-        .find_map(|(index, _)| ThreadId::from_string(&core[index + 1..]).ok())
-}
-
 pub(crate) async fn resolve_thread_id_for_session_path(path: &Path) -> Option<ThreadId> {
-    if let Some(thread_id) = parse_thread_id_from_rollout_path(path) {
-        return Some(thread_id);
-    }
     read_session_meta_line(path)
         .await
         .ok()

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -705,7 +705,24 @@ async fn run_ratatui_app(
                                     thread_id,
                                 },
                             ),
-                            None => resume_picker::SessionSelection::StartFresh,
+                            None => {
+                                let rollout_path = item.path.display();
+                                error!(
+                                    "Error reading session metadata from latest rollout: {rollout_path}"
+                                );
+                                restore();
+                                session_log::log_session_end();
+                                let _ = tui.terminal.clear();
+                                return Ok(AppExitInfo {
+                                    token_usage: codex_protocol::protocol::TokenUsage::default(),
+                                    thread_id: None,
+                                    thread_name: None,
+                                    update_action: None,
+                                    exit_reason: ExitReason::Fatal(format!(
+                                        "Found latest saved session at {rollout_path}, but failed to read its metadata. Run `codex fork` to choose from existing sessions."
+                                    )),
+                                });
+                            }
                         }
                     }
                     None => resume_picker::SessionSelection::StartFresh,
@@ -781,7 +798,22 @@ async fn run_ratatui_app(
                         thread_id,
                     })
                 }
-                None => resume_picker::SessionSelection::StartFresh,
+                None => {
+                    let rollout_path = path.display();
+                    error!("Error reading session metadata from latest rollout: {rollout_path}");
+                    restore();
+                    session_log::log_session_end();
+                    let _ = tui.terminal.clear();
+                    return Ok(AppExitInfo {
+                        token_usage: codex_protocol::protocol::TokenUsage::default(),
+                        thread_id: None,
+                        thread_name: None,
+                        update_action: None,
+                        exit_reason: ExitReason::Fatal(format!(
+                            "Found latest saved session at {rollout_path}, but failed to read its metadata. Run `codex resume` to choose from existing sessions."
+                        )),
+                    });
+                }
             },
             _ => resume_picker::SessionSelection::StartFresh,
         }

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -675,7 +675,11 @@ async fn run_ratatui_app(
                             Err(_) => return missing_session_exit(id_str, "fork"),
                         }
                     } else {
-                        match resolve_thread_id_for_session_path(path.as_path()).await {
+                        match read_session_meta_line(path.as_path())
+                            .await
+                            .ok()
+                            .map(|meta_line| meta_line.meta.id)
+                        {
                             Some(thread_id) => thread_id,
                             None => return missing_session_exit(id_str, "fork"),
                         }
@@ -702,7 +706,11 @@ async fn run_ratatui_app(
             {
                 Ok(page) => match page.items.first() {
                     Some(item) => {
-                        match resolve_thread_id_for_session_path(item.path.as_path()).await {
+                        match read_session_meta_line(item.path.as_path())
+                            .await
+                            .ok()
+                            .map(|meta_line| meta_line.meta.id)
+                        {
                             Some(thread_id) => resume_picker::SessionSelection::Fork(
                                 resume_picker::SessionTarget {
                                     path: item.path.clone(),
@@ -749,7 +757,11 @@ async fn run_ratatui_app(
                         Err(_) => return missing_session_exit(id_str, "resume"),
                     }
                 } else {
-                    match resolve_thread_id_for_session_path(path.as_path()).await {
+                    match read_session_meta_line(path.as_path())
+                        .await
+                        .ok()
+                        .map(|meta_line| meta_line.meta.id)
+                    {
                         Some(thread_id) => thread_id,
                         None => return missing_session_exit(id_str, "resume"),
                     }
@@ -780,7 +792,11 @@ async fn run_ratatui_app(
         )
         .await
         {
-            Ok(Some(path)) => match resolve_thread_id_for_session_path(path.as_path()).await {
+            Ok(Some(path)) => match read_session_meta_line(path.as_path())
+                .await
+                .ok()
+                .map(|meta_line| meta_line.meta.id)
+            {
                 Some(thread_id) => {
                     resume_picker::SessionSelection::Resume(resume_picker::SessionTarget {
                         path,
@@ -912,13 +928,6 @@ async fn run_ratatui_app(
     session_log::log_session_end();
     // ignore error when collecting usage – report underlying error instead
     app_result
-}
-
-pub(crate) async fn resolve_thread_id_for_session_path(path: &Path) -> Option<ThreadId> {
-    read_session_meta_line(path)
-        .await
-        .ok()
-        .map(|meta_line| meta_line.meta.id)
 }
 
 pub(crate) async fn read_session_cwd(

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -1153,9 +1153,9 @@ mod tests {
     use codex_core::config::ConfigBuilder;
     use codex_core::config::ConfigOverrides;
     use codex_core::config::ProjectConfig;
-    use codex_protocol::protocol::AskForApproval;
     use codex_core::features::Feature;
     use codex_protocol::ThreadId;
+    use codex_protocol::protocol::AskForApproval;
     use codex_protocol::protocol::RolloutItem;
     use codex_protocol::protocol::RolloutLine;
     use codex_protocol::protocol::SessionMeta;

--- a/codex-rs/tui/src/resume_picker.rs
+++ b/codex-rs/tui/src/resume_picker.rs
@@ -21,7 +21,6 @@ use codex_core::ThreadsPage;
 use codex_core::config::Config;
 use codex_core::find_thread_names_by_ids;
 use codex_core::path_utils;
-use codex_core::read_session_meta_line;
 use codex_protocol::ThreadId;
 use color_eyre::eyre::Result;
 use crossterm::event::KeyCode;
@@ -413,10 +412,7 @@ impl PickerState {
                     let path = row.path.clone();
                     let thread_id = match row.thread_id {
                         Some(thread_id) => Some(thread_id),
-                        None => read_session_meta_line(path.as_path())
-                            .await
-                            .ok()
-                            .map(|meta_line| meta_line.meta.id),
+                        None => crate::resolve_session_thread_id(path.as_path(), None).await,
                     };
                     if let Some(thread_id) = thread_id {
                         return Ok(Some(self.action.selection(path, thread_id)));

--- a/codex-rs/tui/src/resume_picker.rs
+++ b/codex-rs/tui/src/resume_picker.rs
@@ -39,11 +39,18 @@ use unicode_width::UnicodeWidthStr;
 
 const PAGE_SIZE: usize = 25;
 const LOAD_NEAR_THRESHOLD: usize = 5;
+
+#[derive(Debug, Clone)]
+pub struct SessionTarget {
+    pub path: PathBuf,
+    pub thread_id: Option<ThreadId>,
+}
+
 #[derive(Debug, Clone)]
 pub enum SessionSelection {
     StartFresh,
-    Resume(PathBuf),
-    Fork(PathBuf),
+    Resume(SessionTarget),
+    Fork(SessionTarget),
     Exit,
 }
 
@@ -68,10 +75,11 @@ impl SessionPickerAction {
         }
     }
 
-    fn selection(self, path: PathBuf) -> SessionSelection {
+    fn selection(self, path: PathBuf, thread_id: Option<ThreadId>) -> SessionSelection {
+        let target = SessionTarget { path, thread_id };
         match self {
-            SessionPickerAction::Resume => SessionSelection::Resume(path),
-            SessionPickerAction::Fork => SessionSelection::Fork(path),
+            SessionPickerAction::Resume => SessionSelection::Resume(target),
+            SessionPickerAction::Fork => SessionSelection::Fork(target),
         }
     }
 }
@@ -401,7 +409,7 @@ impl PickerState {
             }
             KeyCode::Enter => {
                 if let Some(row) = self.filtered_rows.get(self.selected) {
-                    return Ok(Some(self.action.selection(row.path.clone())));
+                    return Ok(Some(self.action.selection(row.path.clone(), row.thread_id)));
                 }
             }
             KeyCode::Up => {

--- a/codex-rs/tui/src/resume_picker.rs
+++ b/codex-rs/tui/src/resume_picker.rs
@@ -21,6 +21,7 @@ use codex_core::ThreadsPage;
 use codex_core::config::Config;
 use codex_core::find_thread_names_by_ids;
 use codex_core::path_utils;
+use codex_core::read_session_meta_line;
 use codex_protocol::ThreadId;
 use color_eyre::eyre::Result;
 use crossterm::event::KeyCode;
@@ -412,7 +413,10 @@ impl PickerState {
                     let path = row.path.clone();
                     let thread_id = match row.thread_id {
                         Some(thread_id) => Some(thread_id),
-                        None => crate::resolve_thread_id_for_session_path(path.as_path()).await,
+                        None => read_session_meta_line(path.as_path())
+                            .await
+                            .ok()
+                            .map(|meta_line| meta_line.meta.id),
                     };
                     if let Some(thread_id) = thread_id {
                         return Ok(Some(self.action.selection(path, thread_id)));

--- a/codex-rs/tui/src/snapshots/codex_tui__resume_picker__tests__resume_picker_search_error.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__resume_picker__tests__resume_picker_search_error.snap
@@ -1,0 +1,5 @@
+---
+source: tui/src/resume_picker.rs
+expression: snapshot
+---
+Failed to read session metadata from /tmp/missing.jsonl


### PR DESCRIPTION
## Summary
- make resume/fork targets explicit and typed as `SessionTarget { path, thread_id }` (non-optional `thread_id`)
- resolve `thread_id` centrally via `resolve_session_thread_id(...)`:
  - use CLI input directly when it is a UUID (`--resume <uuid>` / `--fork <uuid>`)
  - otherwise read `thread_id` from rollout `SessionMeta` for path-based selections (picker, `--resume-last`, name-based resume/fork)
- use `thread_id` to read cwd from SQLite first during resume/fork cwd resolution
- keep rollout fallback for cwd resolution when SQLite is unavailable or does not return thread metadata (`TurnContext` tail, then `SessionMeta`)
- keep the resume picker open when a selected row has unreadable session metadata, and show an inline recoverable error instead of aborting the TUI

## Why
This removes ad-hoc rollout filename parsing and makes resume/fork target identity explicit. The resume/fork cwd check can use indexed SQLite lookup by `thread_id` in the common path, while preserving rollout-based fallback behavior. It also keeps malformed legacy rows recoverable in the picker instead of letting a selection failure unwind the app.

## Notes
- minimal TUI-only change; no schema/protocol changes
- includes TUI test coverage for SQLite cwd precedence when `thread_id` is available
- includes TUI regression coverage for picker inline error rendering / non-fatal unreadable session rows

## Codex author
`codex resume 019c9205-7f8b-7173-a2a2-f082d4df3de3`
