### PR TITLE
exec: add --quiet mode for scripting-friendly output

### DIFF
--- a/codex-rs/README.md
+++ b/codex-rs/README.md
@@ -53,6 +53,7 @@ You can enable notifications by configuring a script that is run whenever the ag
 To run Codex non-interactively, run `codex exec PROMPT` (you can also pass the prompt via `stdin`) and Codex will work on your task until it decides that it is done and exits. Output is printed to the terminal directly. You can set the `RUST_LOG` environment variable to see more about what's going on.
 For a shortcut from the top-level CLI, use `codex -P "PROMPT"` (or `codex --prompt "PROMPT"`), which is equivalent to running a one-shot `exec` prompt and exiting.
 Use `--quiet` with non-interactive runs to suppress progress/status chatter and print only the final response to stdout (for example: `codex -P "..." --quiet` or `codex exec --quiet "..."`).
+Use `--json` for JSONL event output in non-interactive runs, including `codex -P "..." --json`.
 Use `codex exec --ephemeral ...` to run without persisting session rollout files to disk.
 
 ### Experimenting with the Codex Sandbox

--- a/codex-rs/README.md
+++ b/codex-rs/README.md
@@ -51,6 +51,7 @@ You can enable notifications by configuring a script that is run whenever the ag
 ### `codex exec` to run Codex programmatically/non-interactively
 
 To run Codex non-interactively, run `codex exec PROMPT` (you can also pass the prompt via `stdin`) and Codex will work on your task until it decides that it is done and exits. Output is printed to the terminal directly. You can set the `RUST_LOG` environment variable to see more about what's going on.
+For a shortcut from the top-level CLI, use `codex -P "PROMPT"` (or `codex --prompt "PROMPT"`), which is equivalent to running a one-shot `exec` prompt and exiting.
 Use `codex exec --ephemeral ...` to run without persisting session rollout files to disk.
 
 ### Experimenting with the Codex Sandbox

--- a/codex-rs/README.md
+++ b/codex-rs/README.md
@@ -52,6 +52,7 @@ You can enable notifications by configuring a script that is run whenever the ag
 
 To run Codex non-interactively, run `codex exec PROMPT` (you can also pass the prompt via `stdin`) and Codex will work on your task until it decides that it is done and exits. Output is printed to the terminal directly. You can set the `RUST_LOG` environment variable to see more about what's going on.
 For a shortcut from the top-level CLI, use `codex -P "PROMPT"` (or `codex --prompt "PROMPT"`), which is equivalent to running a one-shot `exec` prompt and exiting.
+Use `--quiet` with non-interactive runs to suppress progress/status chatter and print only the final response to stdout (for example: `codex -P "..." --quiet` or `codex exec --quiet "..."`).
 Use `codex exec --ephemeral ...` to run without persisting session rollout files to disk.
 
 ### Experimenting with the Codex Sandbox

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -80,6 +80,10 @@ struct MultitoolCli {
     #[arg(long = "quiet", default_value_t = false)]
     quiet: bool,
 
+    /// Print events to stdout as JSONL in non-interactive mode.
+    #[arg(long = "json", alias = "experimental-json", default_value_t = false)]
+    json_output: bool,
+
     #[clap(flatten)]
     interactive: TuiCli,
 
@@ -564,6 +568,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
         feature_toggles,
         one_shot_prompt,
         quiet,
+        json_output,
         mut interactive,
         subcommand,
     } = MultitoolCli::parse();
@@ -578,20 +583,19 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
     if one_shot_prompt.is_some() && interactive.prompt.is_some() {
         anyhow::bail!("Use either positional `PROMPT` or `-P`/`--prompt`, not both.");
     }
-    if quiet && one_shot_prompt.is_none() && subcommand.is_none() {
+    let non_interactive_invocation = one_shot_prompt.is_some()
+        || matches!(
+            &subcommand,
+            Some(Subcommand::Exec(_)) | Some(Subcommand::Review(_))
+        );
+    if quiet && !non_interactive_invocation {
         anyhow::bail!(
             "`--quiet` is only supported with `codex -P`, `codex exec`, or `codex review`."
         );
     }
-    if quiet
-        && one_shot_prompt.is_none()
-        && !matches!(
-            &subcommand,
-            Some(Subcommand::Exec(_)) | Some(Subcommand::Review(_))
-        )
-    {
+    if json_output && !non_interactive_invocation {
         anyhow::bail!(
-            "`--quiet` is only supported with `codex -P`, `codex exec`, or `codex review`."
+            "`--json` is only supported with `codex -P`, `codex exec`, or `codex review`."
         );
     }
 
@@ -611,6 +615,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
                 exec_cli.cwd = interactive.cwd;
                 exec_cli.add_dir = interactive.add_dir;
                 exec_cli.quiet = quiet;
+                exec_cli.json = json_output;
                 exec_cli.prompt = Some(prompt.replace("\r\n", "\n").replace('\r', "\n"));
                 if interactive.web_search {
                     exec_cli
@@ -634,6 +639,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
         }
         Some(Subcommand::Exec(mut exec_cli)) => {
             exec_cli.quiet |= quiet;
+            exec_cli.json |= json_output;
             prepend_config_flags(
                 &mut exec_cli.config_overrides,
                 root_config_overrides.clone(),
@@ -644,6 +650,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
             let mut exec_cli = ExecCli::try_parse_from(["codex", "exec"])?;
             exec_cli.command = Some(ExecCommand::Review(review_args));
             exec_cli.quiet = quiet;
+            exec_cli.json = json_output;
             prepend_config_flags(
                 &mut exec_cli.config_overrides,
                 root_config_overrides.clone(),
@@ -1112,6 +1119,7 @@ mod tests {
             feature_toggles: _,
             one_shot_prompt: _,
             quiet: _,
+            json_output: _,
         } = cli;
 
         let Subcommand::Resume(ResumeCommand {
@@ -1143,6 +1151,7 @@ mod tests {
             feature_toggles: _,
             one_shot_prompt: _,
             quiet: _,
+            json_output: _,
         } = cli;
 
         let Subcommand::Fork(ForkCommand {
@@ -1221,6 +1230,16 @@ mod tests {
 
         assert_eq!(cli.one_shot_prompt.as_deref(), Some("say hi"));
         assert!(cli.quiet);
+        assert!(cli.subcommand.is_none());
+    }
+
+    #[test]
+    fn one_shot_prompt_flag_accepts_json() {
+        let cli = MultitoolCli::try_parse_from(["codex", "-P", "say hi", "--json"])
+            .expect("parse should succeed");
+
+        assert_eq!(cli.one_shot_prompt.as_deref(), Some("say hi"));
+        assert!(cli.json_output);
         assert!(cli.subcommand.is_none());
     }
 

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -63,7 +63,7 @@ use codex_core::terminal::TerminalName;
     // `codex-x86_64-unknown-linux-musl`, but the help output should always use
     // the generic `codex` command name that users run.
     bin_name = "codex",
-    override_usage = "codex [OPTIONS] [PROMPT]\n       codex [OPTIONS] <COMMAND> [ARGS]"
+    override_usage = "codex [OPTIONS] [PROMPT]\n       codex -P <PROMPT> [OPTIONS]\n       codex [OPTIONS] <COMMAND> [ARGS]"
 )]
 struct MultitoolCli {
     #[clap(flatten)]
@@ -71,6 +71,10 @@ struct MultitoolCli {
 
     #[clap(flatten)]
     pub feature_toggles: FeatureToggles,
+
+    /// Run a single prompt non-interactively and exit.
+    #[arg(short = 'P', long = "prompt", value_name = "PROMPT")]
+    one_shot_prompt: Option<String>,
 
     #[clap(flatten)]
     interactive: TuiCli,
@@ -554,6 +558,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
     let MultitoolCli {
         config_overrides: mut root_config_overrides,
         feature_toggles,
+        one_shot_prompt,
         mut interactive,
         subcommand,
     } = MultitoolCli::parse();
@@ -562,14 +567,48 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
     let toggle_overrides = feature_toggles.to_overrides()?;
     root_config_overrides.raw_overrides.extend(toggle_overrides);
 
+    if one_shot_prompt.is_some() && subcommand.is_some() {
+        anyhow::bail!("`-P`/`--prompt` cannot be used with subcommands.");
+    }
+    if one_shot_prompt.is_some() && interactive.prompt.is_some() {
+        anyhow::bail!("Use either positional `PROMPT` or `-P`/`--prompt`, not both.");
+    }
+
     match subcommand {
         None => {
-            prepend_config_flags(
-                &mut interactive.config_overrides,
-                root_config_overrides.clone(),
-            );
-            let exit_info = run_interactive_tui(interactive, arg0_paths.clone()).await?;
-            handle_app_exit(exit_info)?;
+            if let Some(prompt) = one_shot_prompt {
+                let mut exec_cli = ExecCli::try_parse_from(["codex", "exec"])?;
+                exec_cli.images = interactive.images;
+                exec_cli.model = interactive.model;
+                exec_cli.oss = interactive.oss;
+                exec_cli.oss_provider = interactive.oss_provider;
+                exec_cli.sandbox_mode = interactive.sandbox_mode;
+                exec_cli.config_profile = interactive.config_profile;
+                exec_cli.full_auto = interactive.full_auto;
+                exec_cli.dangerously_bypass_approvals_and_sandbox =
+                    interactive.dangerously_bypass_approvals_and_sandbox;
+                exec_cli.cwd = interactive.cwd;
+                exec_cli.add_dir = interactive.add_dir;
+                exec_cli.prompt = Some(prompt.replace("\r\n", "\n").replace('\r', "\n"));
+                if interactive.web_search {
+                    exec_cli
+                        .config_overrides
+                        .raw_overrides
+                        .push("web_search=\"live\"".to_string());
+                }
+                prepend_config_flags(
+                    &mut exec_cli.config_overrides,
+                    root_config_overrides.clone(),
+                );
+                codex_exec::run_main(exec_cli, arg0_paths.clone()).await?;
+            } else {
+                prepend_config_flags(
+                    &mut interactive.config_overrides,
+                    root_config_overrides.clone(),
+                );
+                let exit_info = run_interactive_tui(interactive, arg0_paths.clone()).await?;
+                handle_app_exit(exit_info)?;
+            }
         }
         Some(Subcommand::Exec(mut exec_cli)) => {
             prepend_config_flags(
@@ -1047,6 +1086,7 @@ mod tests {
             config_overrides: root_overrides,
             subcommand,
             feature_toggles: _,
+            one_shot_prompt: _,
         } = cli;
 
         let Subcommand::Resume(ResumeCommand {
@@ -1076,6 +1116,7 @@ mod tests {
             config_overrides: root_overrides,
             subcommand,
             feature_toggles: _,
+            one_shot_prompt: _,
         } = cli;
 
         let Subcommand::Fork(ForkCommand {
@@ -1135,6 +1176,16 @@ mod tests {
         );
         assert_eq!(args.session_id.as_deref(), Some("session-123"));
         assert_eq!(args.prompt.as_deref(), Some("re-review"));
+    }
+
+    #[test]
+    fn one_shot_prompt_flag_parses_without_subcommand() {
+        let cli =
+            MultitoolCli::try_parse_from(["codex", "-P", "say hi"]).expect("parse should succeed");
+
+        assert_eq!(cli.one_shot_prompt.as_deref(), Some("say hi"));
+        assert!(cli.subcommand.is_none());
+        assert_eq!(cli.interactive.prompt, None);
     }
 
     fn app_server_from_args(args: &[&str]) -> AppServerCommand {

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -76,6 +76,10 @@ struct MultitoolCli {
     #[arg(short = 'P', long = "prompt", value_name = "PROMPT")]
     one_shot_prompt: Option<String>,
 
+    /// Suppress non-essential non-interactive output and print only the final response.
+    #[arg(long = "quiet", default_value_t = false)]
+    quiet: bool,
+
     #[clap(flatten)]
     interactive: TuiCli,
 
@@ -559,6 +563,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
         config_overrides: mut root_config_overrides,
         feature_toggles,
         one_shot_prompt,
+        quiet,
         mut interactive,
         subcommand,
     } = MultitoolCli::parse();
@@ -572,6 +577,22 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
     }
     if one_shot_prompt.is_some() && interactive.prompt.is_some() {
         anyhow::bail!("Use either positional `PROMPT` or `-P`/`--prompt`, not both.");
+    }
+    if quiet && one_shot_prompt.is_none() && subcommand.is_none() {
+        anyhow::bail!(
+            "`--quiet` is only supported with `codex -P`, `codex exec`, or `codex review`."
+        );
+    }
+    if quiet
+        && one_shot_prompt.is_none()
+        && !matches!(
+            &subcommand,
+            Some(Subcommand::Exec(_)) | Some(Subcommand::Review(_))
+        )
+    {
+        anyhow::bail!(
+            "`--quiet` is only supported with `codex -P`, `codex exec`, or `codex review`."
+        );
     }
 
     match subcommand {
@@ -589,6 +610,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
                     interactive.dangerously_bypass_approvals_and_sandbox;
                 exec_cli.cwd = interactive.cwd;
                 exec_cli.add_dir = interactive.add_dir;
+                exec_cli.quiet = quiet;
                 exec_cli.prompt = Some(prompt.replace("\r\n", "\n").replace('\r', "\n"));
                 if interactive.web_search {
                     exec_cli
@@ -611,6 +633,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
             }
         }
         Some(Subcommand::Exec(mut exec_cli)) => {
+            exec_cli.quiet |= quiet;
             prepend_config_flags(
                 &mut exec_cli.config_overrides,
                 root_config_overrides.clone(),
@@ -620,6 +643,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
         Some(Subcommand::Review(review_args)) => {
             let mut exec_cli = ExecCli::try_parse_from(["codex", "exec"])?;
             exec_cli.command = Some(ExecCommand::Review(review_args));
+            exec_cli.quiet = quiet;
             prepend_config_flags(
                 &mut exec_cli.config_overrides,
                 root_config_overrides.clone(),
@@ -1087,6 +1111,7 @@ mod tests {
             subcommand,
             feature_toggles: _,
             one_shot_prompt: _,
+            quiet: _,
         } = cli;
 
         let Subcommand::Resume(ResumeCommand {
@@ -1117,6 +1142,7 @@ mod tests {
             subcommand,
             feature_toggles: _,
             one_shot_prompt: _,
+            quiet: _,
         } = cli;
 
         let Subcommand::Fork(ForkCommand {
@@ -1186,6 +1212,16 @@ mod tests {
         assert_eq!(cli.one_shot_prompt.as_deref(), Some("say hi"));
         assert!(cli.subcommand.is_none());
         assert_eq!(cli.interactive.prompt, None);
+    }
+
+    #[test]
+    fn one_shot_prompt_flag_accepts_quiet() {
+        let cli = MultitoolCli::try_parse_from(["codex", "-P", "say hi", "--quiet"])
+            .expect("parse should succeed");
+
+        assert_eq!(cli.one_shot_prompt.as_deref(), Some("say hi"));
+        assert!(cli.quiet);
+        assert!(cli.subcommand.is_none());
     }
 
     fn app_server_from_args(args: &[&str]) -> AppServerCommand {

--- a/codex-rs/exec/src/cli.rs
+++ b/codex-rs/exec/src/cli.rs
@@ -99,6 +99,10 @@ pub struct Cli {
     )]
     pub json: bool,
 
+    /// Suppress non-essential stderr output and print only the final response to stdout.
+    #[arg(long = "quiet", default_value_t = false, global = true)]
+    pub quiet: bool,
+
     /// Specifies file where the last message from the agent should be written.
     #[arg(
         long = "output-last-message",
@@ -314,5 +318,12 @@ mod tests {
         };
         assert_eq!(args.session_id.as_deref(), Some("session-123"));
         assert_eq!(args.prompt.as_deref(), Some(PROMPT));
+    }
+
+    #[test]
+    fn quiet_flag_parses() {
+        let cli = Cli::parse_from(["codex-exec", "--quiet", "echo hello"]);
+        assert!(cli.quiet);
+        assert_eq!(cli.prompt.as_deref(), Some("echo hello"));
     }
 }

--- a/codex-rs/exec/src/event_processor_with_jsonl_output.rs
+++ b/codex-rs/exec/src/event_processor_with_jsonl_output.rs
@@ -755,6 +755,9 @@ impl EventProcessorWithJsonOutput {
                 input_tokens: u.input_tokens,
                 cached_input_tokens: u.cached_input_tokens,
                 output_tokens: u.output_tokens,
+                reasoning_output_tokens: u.reasoning_output_tokens,
+                total_tokens: u.total_tokens,
+                blended_total_tokens: u.blended_total(),
             }
         } else {
             Usage::default()

--- a/codex-rs/exec/src/exec_events.rs
+++ b/codex-rs/exec/src/exec_events.rs
@@ -65,6 +65,12 @@ pub struct Usage {
     pub cached_input_tokens: i64,
     /// The number of output tokens used during the turn.
     pub output_tokens: i64,
+    /// The number of reasoning output tokens used during the turn.
+    pub reasoning_output_tokens: i64,
+    /// The provider-reported total tokens used during the turn.
+    pub total_tokens: i64,
+    /// The blended total used by human-readable output: non-cached input + output.
+    pub blended_total_tokens: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, TS)]

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -112,6 +112,7 @@ pub async fn run_main(cli: Cli, arg0_paths: Arg0DispatchPaths) -> anyhow::Result
         color,
         last_message_file,
         json: json_mode,
+        quiet,
         sandbox_mode: sandbox_mode_cli_arg,
         prompt,
         output_schema: output_schema_path,
@@ -344,6 +345,7 @@ pub async fn run_main(cli: Cli, arg0_paths: Arg0DispatchPaths) -> anyhow::Result
             stderr_with_ansi,
             cursor_ansi,
             &config,
+            quiet,
             last_message_file.clone(),
         )),
     };

--- a/codex-rs/exec/tests/event_processor_with_json_output.rs
+++ b/codex-rs/exec/tests/event_processor_with_json_output.rs
@@ -1304,6 +1304,9 @@ fn task_complete_produces_turn_completed_with_usage() {
                 input_tokens: 1200,
                 cached_input_tokens: 200,
                 output_tokens: 345,
+                reasoning_output_tokens: 0,
+                total_tokens: 0,
+                blended_total_tokens: 1345,
             },
         })]
     );


### PR DESCRIPTION
Adds a non-interactive --quiet mode that suppresses human-oriented stderr scaffolding (banner, config summary, thinking/tool chatter, token summary) and leaves only the final assistant response on stdout.

What this includes:
- codex exec --quiet support
- top-level codex -P ... --quiet wiring
- validation that root-level --quiet is only accepted for non-interactive invocations (codex -P, codex exec, codex review)
- docs update in codex-rs/README.md

Note: this branch is stacked on top of PR #12736. Once #12736 merges, this PR will contain only the quiet-mode delta.