### PR TITLE
fix: support managed network allowlist controls

### DIFF
--- a/codex-rs/app-server/src/config_api.rs
+++ b/codex-rs/app-server/src/config_api.rs
@@ -231,7 +231,7 @@ mod tests {
                 dangerously_allow_non_loopback_proxy: Some(false),
                 dangerously_allow_all_unix_sockets: Some(true),
                 allowed_domains: Some(vec!["api.openai.com".to_string()]),
-                allow_user_allowlist_expansion: Some(false),
+                managed_allowed_domains_only: Some(false),
                 denied_domains: Some(vec!["example.com".to_string()]),
                 allow_unix_sockets: Some(vec!["/tmp/proxy.sock".to_string()]),
                 allow_local_binding: Some(true),

--- a/codex-rs/app-server/src/config_api.rs
+++ b/codex-rs/app-server/src/config_api.rs
@@ -231,6 +231,7 @@ mod tests {
                 dangerously_allow_non_loopback_proxy: Some(false),
                 dangerously_allow_all_unix_sockets: Some(true),
                 allowed_domains: Some(vec!["api.openai.com".to_string()]),
+                allow_user_allowlist_expansion: Some(false),
                 denied_domains: Some(vec!["example.com".to_string()]),
                 allow_unix_sockets: Some(vec!["/tmp/proxy.sock".to_string()]),
                 allow_local_binding: Some(true),

--- a/codex-rs/config/src/config_requirements.rs
+++ b/codex-rs/config/src/config_requirements.rs
@@ -138,6 +138,7 @@ pub struct NetworkRequirementsToml {
     pub dangerously_allow_non_loopback_proxy: Option<bool>,
     pub dangerously_allow_all_unix_sockets: Option<bool>,
     pub allowed_domains: Option<Vec<String>>,
+    pub allow_user_allowlist_expansion: Option<bool>,
     pub denied_domains: Option<Vec<String>>,
     pub allow_unix_sockets: Option<Vec<String>>,
     pub allow_local_binding: Option<bool>,
@@ -153,6 +154,7 @@ pub struct NetworkConstraints {
     pub dangerously_allow_non_loopback_proxy: Option<bool>,
     pub dangerously_allow_all_unix_sockets: Option<bool>,
     pub allowed_domains: Option<Vec<String>>,
+    pub allow_user_allowlist_expansion: Option<bool>,
     pub denied_domains: Option<Vec<String>>,
     pub allow_unix_sockets: Option<Vec<String>>,
     pub allow_local_binding: Option<bool>,
@@ -168,6 +170,7 @@ impl From<NetworkRequirementsToml> for NetworkConstraints {
             dangerously_allow_non_loopback_proxy,
             dangerously_allow_all_unix_sockets,
             allowed_domains,
+            allow_user_allowlist_expansion,
             denied_domains,
             allow_unix_sockets,
             allow_local_binding,
@@ -180,6 +183,7 @@ impl From<NetworkRequirementsToml> for NetworkConstraints {
             dangerously_allow_non_loopback_proxy,
             dangerously_allow_all_unix_sockets,
             allowed_domains,
+            allow_user_allowlist_expansion,
             denied_domains,
             allow_unix_sockets,
             allow_local_binding,
@@ -1118,6 +1122,7 @@ mod tests {
             allow_upstream_proxy = false
             dangerously_allow_all_unix_sockets = true
             allowed_domains = ["api.example.com", "*.openai.com"]
+            allow_user_allowlist_expansion = false
             denied_domains = ["blocked.example.com"]
             allow_unix_sockets = ["/tmp/example.sock"]
             allow_local_binding = false
@@ -1145,6 +1150,10 @@ mod tests {
                 "api.example.com".to_string(),
                 "*.openai.com".to_string()
             ])
+        );
+        assert_eq!(
+            sourced_network.value.allow_user_allowlist_expansion,
+            Some(false)
         );
         assert_eq!(
             sourced_network.value.denied_domains.as_ref(),

--- a/codex-rs/config/src/config_requirements.rs
+++ b/codex-rs/config/src/config_requirements.rs
@@ -138,7 +138,9 @@ pub struct NetworkRequirementsToml {
     pub dangerously_allow_non_loopback_proxy: Option<bool>,
     pub dangerously_allow_all_unix_sockets: Option<bool>,
     pub allowed_domains: Option<Vec<String>>,
-    pub allow_user_allowlist_expansion: Option<bool>,
+    /// When true, only managed `allowed_domains` are respected while managed
+    /// network enforcement is active. User allowlist entries are ignored.
+    pub managed_allowed_domains_only: Option<bool>,
     pub denied_domains: Option<Vec<String>>,
     pub allow_unix_sockets: Option<Vec<String>>,
     pub allow_local_binding: Option<bool>,
@@ -154,7 +156,9 @@ pub struct NetworkConstraints {
     pub dangerously_allow_non_loopback_proxy: Option<bool>,
     pub dangerously_allow_all_unix_sockets: Option<bool>,
     pub allowed_domains: Option<Vec<String>>,
-    pub allow_user_allowlist_expansion: Option<bool>,
+    /// When true, only managed `allowed_domains` are respected while managed
+    /// network enforcement is active. User allowlist entries are ignored.
+    pub managed_allowed_domains_only: Option<bool>,
     pub denied_domains: Option<Vec<String>>,
     pub allow_unix_sockets: Option<Vec<String>>,
     pub allow_local_binding: Option<bool>,
@@ -170,7 +174,7 @@ impl From<NetworkRequirementsToml> for NetworkConstraints {
             dangerously_allow_non_loopback_proxy,
             dangerously_allow_all_unix_sockets,
             allowed_domains,
-            allow_user_allowlist_expansion,
+            managed_allowed_domains_only,
             denied_domains,
             allow_unix_sockets,
             allow_local_binding,
@@ -183,7 +187,7 @@ impl From<NetworkRequirementsToml> for NetworkConstraints {
             dangerously_allow_non_loopback_proxy,
             dangerously_allow_all_unix_sockets,
             allowed_domains,
-            allow_user_allowlist_expansion,
+            managed_allowed_domains_only,
             denied_domains,
             allow_unix_sockets,
             allow_local_binding,
@@ -1122,7 +1126,7 @@ mod tests {
             allow_upstream_proxy = false
             dangerously_allow_all_unix_sockets = true
             allowed_domains = ["api.example.com", "*.openai.com"]
-            allow_user_allowlist_expansion = false
+            managed_allowed_domains_only = true
             denied_domains = ["blocked.example.com"]
             allow_unix_sockets = ["/tmp/example.sock"]
             allow_local_binding = false
@@ -1152,8 +1156,8 @@ mod tests {
             ])
         );
         assert_eq!(
-            sourced_network.value.allow_user_allowlist_expansion,
-            Some(false)
+            sourced_network.value.managed_allowed_domains_only,
+            Some(true)
         );
         assert_eq!(
             sourced_network.value.denied_domains.as_ref(),

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -2103,6 +2103,7 @@ impl Config {
         let network = NetworkProxySpec::from_config_and_constraints(
             configured_network_proxy_config,
             network_requirements,
+            constrained_sandbox_policy.get(),
         )
         .map_err(|err| {
             if let Some(source) = network_requirements_source.as_ref() {

--- a/codex-rs/core/src/config/network_proxy_spec.rs
+++ b/codex-rs/core/src/config/network_proxy_spec.rs
@@ -83,9 +83,10 @@ impl NetworkProxySpec {
     pub(crate) fn from_config_and_constraints(
         config: NetworkProxyConfig,
         requirements: Option<NetworkConstraints>,
+        sandbox_policy: &SandboxPolicy,
     ) -> std::io::Result<Self> {
         let (config, constraints) = if let Some(requirements) = requirements {
-            Self::apply_requirements(config, &requirements)
+            Self::apply_requirements(config, &requirements, sandbox_policy)
         } else {
             (config, NetworkProxyConstraints::default())
         };
@@ -158,8 +159,12 @@ impl NetworkProxySpec {
     fn apply_requirements(
         mut config: NetworkProxyConfig,
         requirements: &NetworkConstraints,
+        sandbox_policy: &SandboxPolicy,
     ) -> (NetworkProxyConfig, NetworkProxyConstraints) {
         let mut constraints = NetworkProxyConstraints::default();
+        let allow_user_allowlist_expansion =
+            Self::allow_user_allowlist_expansion(requirements, sandbox_policy);
+        let allow_user_denylist_expansion = Self::allow_user_denylist_expansion(sandbox_policy);
 
         if let Some(enabled) = requirements.enabled {
             config.network.enabled = enabled;
@@ -191,23 +196,25 @@ impl NetworkProxySpec {
                 Some(dangerously_allow_all_unix_sockets);
         }
         if let Some(allowed_domains) = requirements.allowed_domains.clone() {
-            // Requirements define the managed baseline; user config may add
-            // narrower entries that still fit within that managed boundary.
-            let mut effective_allowed_domains = allowed_domains.clone();
-            for entry in &config.network.allowed_domains {
-                if !effective_allowed_domains
-                    .iter()
-                    .any(|managed_entry| managed_entry.eq_ignore_ascii_case(entry))
-                {
-                    effective_allowed_domains.push(entry.clone());
-                }
-            }
-            config.network.allowed_domains = effective_allowed_domains;
+            // Managed requirements seed the baseline allowlist. Restricted
+            // sandbox modes may layer user additions on top, while yolo and
+            // enterprise-locked default mode stay pinned to the managed set.
+            config.network.allowed_domains = if allow_user_allowlist_expansion {
+                Self::merge_domain_lists(allowed_domains.clone(), &config.network.allowed_domains)
+            } else {
+                allowed_domains.clone()
+            };
             constraints.allowed_domains = Some(allowed_domains);
+            constraints.allow_user_allowlist_expansion = Some(allow_user_allowlist_expansion);
         }
         if let Some(denied_domains) = requirements.denied_domains.clone() {
-            config.network.denied_domains = denied_domains.clone();
+            config.network.denied_domains = if allow_user_denylist_expansion {
+                Self::merge_domain_lists(denied_domains.clone(), &config.network.denied_domains)
+            } else {
+                denied_domains.clone()
+            };
             constraints.denied_domains = Some(denied_domains);
+            constraints.allow_user_denylist_expansion = Some(allow_user_denylist_expansion);
         }
         if let Some(allow_unix_sockets) = requirements.allow_unix_sockets.clone() {
             config.network.allow_unix_sockets = allow_unix_sockets.clone();
@@ -219,6 +226,35 @@ impl NetworkProxySpec {
         }
 
         (config, constraints)
+    }
+
+    fn allow_user_allowlist_expansion(
+        requirements: &NetworkConstraints,
+        sandbox_policy: &SandboxPolicy,
+    ) -> bool {
+        matches!(
+            sandbox_policy,
+            SandboxPolicy::ReadOnly { .. } | SandboxPolicy::WorkspaceWrite { .. }
+        ) && requirements.allow_user_allowlist_expansion.unwrap_or(true)
+    }
+
+    fn allow_user_denylist_expansion(sandbox_policy: &SandboxPolicy) -> bool {
+        matches!(
+            sandbox_policy,
+            SandboxPolicy::ReadOnly { .. } | SandboxPolicy::WorkspaceWrite { .. }
+        )
+    }
+
+    fn merge_domain_lists(mut managed: Vec<String>, user_entries: &[String]) -> Vec<String> {
+        for entry in user_entries {
+            if !managed
+                .iter()
+                .any(|managed_entry| managed_entry.eq_ignore_ascii_case(entry))
+            {
+                managed.push(entry.clone());
+            }
+        }
+        managed
     }
 }
 
@@ -255,8 +291,12 @@ mod tests {
             ..Default::default()
         };
 
-        let spec = NetworkProxySpec::from_config_and_constraints(config, Some(requirements))
-            .expect("config should stay within the managed allowlist");
+        let spec = NetworkProxySpec::from_config_and_constraints(
+            config,
+            Some(requirements),
+            &SandboxPolicy::new_read_only_policy(),
+        )
+        .expect("config should stay within the managed allowlist");
 
         assert_eq!(
             spec.config.network.allowed_domains,
@@ -266,25 +306,86 @@ mod tests {
             spec.constraints.allowed_domains,
             Some(vec!["*.example.com".to_string()])
         );
+        assert_eq!(spec.constraints.allow_user_allowlist_expansion, Some(true));
     }
 
     #[test]
-    fn requirements_allowed_domains_reject_user_widening() {
+    fn danger_full_access_keeps_managed_allowlist_and_denylist_fixed() {
         let mut config = NetworkProxyConfig::default();
         config.network.allowed_domains = vec!["evil.com".to_string()];
+        config.network.denied_domains = vec!["more-blocked.example.com".to_string()];
         let requirements = NetworkConstraints {
             allowed_domains: Some(vec!["*.example.com".to_string()]),
+            denied_domains: Some(vec!["blocked.example.com".to_string()]),
             ..Default::default()
         };
 
-        let err = NetworkProxySpec::from_config_and_constraints(config, Some(requirements))
-            .expect_err("config outside the managed allowlist should be rejected");
+        let spec = NetworkProxySpec::from_config_and_constraints(
+            config,
+            Some(requirements),
+            &SandboxPolicy::DangerFullAccess,
+        )
+        .expect("yolo mode should pin the effective policy to the managed baseline");
 
-        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
-        assert!(
-            err.to_string()
-                .contains("subset of managed allowed_domains"),
-            "unexpected error: {err}"
+        assert_eq!(
+            spec.config.network.allowed_domains,
+            vec!["*.example.com".to_string()]
         );
+        assert_eq!(
+            spec.config.network.denied_domains,
+            vec!["blocked.example.com".to_string()]
+        );
+        assert_eq!(spec.constraints.allow_user_allowlist_expansion, Some(false));
+        assert_eq!(spec.constraints.allow_user_denylist_expansion, Some(false));
+    }
+
+    #[test]
+    fn requirements_can_disable_default_mode_allowlist_expansion() {
+        let mut config = NetworkProxyConfig::default();
+        config.network.allowed_domains = vec!["api.example.com".to_string()];
+        let requirements = NetworkConstraints {
+            allowed_domains: Some(vec!["*.example.com".to_string()]),
+            allow_user_allowlist_expansion: Some(false),
+            ..Default::default()
+        };
+
+        let spec = NetworkProxySpec::from_config_and_constraints(
+            config,
+            Some(requirements),
+            &SandboxPolicy::new_workspace_write_policy(),
+        )
+        .expect("managed baseline should still load");
+
+        assert_eq!(
+            spec.config.network.allowed_domains,
+            vec!["*.example.com".to_string()]
+        );
+        assert_eq!(spec.constraints.allow_user_allowlist_expansion, Some(false));
+    }
+
+    #[test]
+    fn requirements_denied_domains_are_a_baseline_for_default_mode() {
+        let mut config = NetworkProxyConfig::default();
+        config.network.denied_domains = vec!["blocked.example.com".to_string()];
+        let requirements = NetworkConstraints {
+            denied_domains: Some(vec!["managed-blocked.example.com".to_string()]),
+            ..Default::default()
+        };
+
+        let spec = NetworkProxySpec::from_config_and_constraints(
+            config,
+            Some(requirements),
+            &SandboxPolicy::new_workspace_write_policy(),
+        )
+        .expect("default mode should merge managed and user deny entries");
+
+        assert_eq!(
+            spec.config.network.denied_domains,
+            vec![
+                "managed-blocked.example.com".to_string(),
+                "blocked.example.com".to_string()
+            ]
+        );
+        assert_eq!(spec.constraints.allow_user_denylist_expansion, Some(true));
     }
 }

--- a/codex-rs/core/src/config/network_proxy_spec.rs
+++ b/codex-rs/core/src/config/network_proxy_spec.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 pub struct NetworkProxySpec {
     config: NetworkProxyConfig,
     constraints: NetworkProxyConstraints,
+    hard_deny_allowlist_misses: bool,
 }
 
 pub struct StartedNetworkProxy {
@@ -85,8 +86,16 @@ impl NetworkProxySpec {
         requirements: Option<NetworkConstraints>,
         sandbox_policy: &SandboxPolicy,
     ) -> std::io::Result<Self> {
+        let hard_deny_allowlist_misses = requirements
+            .as_ref()
+            .is_some_and(Self::managed_allowed_domains_only);
         let (config, constraints) = if let Some(requirements) = requirements {
-            Self::apply_requirements(config, &requirements, sandbox_policy)
+            Self::apply_requirements(
+                config,
+                &requirements,
+                sandbox_policy,
+                hard_deny_allowlist_misses,
+            )
         } else {
             (config, NetworkProxyConstraints::default())
         };
@@ -99,6 +108,7 @@ impl NetworkProxySpec {
         Ok(Self {
             config,
             constraints,
+            hard_deny_allowlist_misses,
         })
     }
 
@@ -113,6 +123,7 @@ impl NetworkProxySpec {
         let state = self.build_state_with_audit_metadata(audit_metadata)?;
         let mut builder = NetworkProxy::builder().state(Arc::new(state));
         if enable_network_approval_flow
+            && !self.hard_deny_allowlist_misses
             && matches!(
                 sandbox_policy,
                 SandboxPolicy::ReadOnly { .. } | SandboxPolicy::WorkspaceWrite { .. }
@@ -160,10 +171,11 @@ impl NetworkProxySpec {
         mut config: NetworkProxyConfig,
         requirements: &NetworkConstraints,
         sandbox_policy: &SandboxPolicy,
+        hard_deny_allowlist_misses: bool,
     ) -> (NetworkProxyConfig, NetworkProxyConstraints) {
         let mut constraints = NetworkProxyConstraints::default();
         let allow_user_allowlist_expansion =
-            Self::allow_user_allowlist_expansion(requirements, sandbox_policy);
+            Self::allow_user_allowlist_expansion(sandbox_policy, hard_deny_allowlist_misses);
         let allow_user_denylist_expansion = Self::allow_user_denylist_expansion(sandbox_policy);
 
         if let Some(enabled) = requirements.enabled {
@@ -195,10 +207,15 @@ impl NetworkProxySpec {
             constraints.dangerously_allow_all_unix_sockets =
                 Some(dangerously_allow_all_unix_sockets);
         }
-        if let Some(allowed_domains) = requirements.allowed_domains.clone() {
-            // Managed requirements seed the baseline allowlist. Restricted
-            // sandbox modes may layer user additions on top, while yolo and
-            // enterprise-locked default mode stay pinned to the managed set.
+        let managed_allowed_domains = if hard_deny_allowlist_misses {
+            Some(requirements.allowed_domains.clone().unwrap_or_default())
+        } else {
+            requirements.allowed_domains.clone()
+        };
+        if let Some(allowed_domains) = managed_allowed_domains {
+            // Managed requirements seed the baseline allowlist. User additions
+            // can extend that baseline unless managed-only mode pins the
+            // effective allowlist to the managed set.
             config.network.allowed_domains = if allow_user_allowlist_expansion {
                 Self::merge_domain_lists(allowed_domains.clone(), &config.network.allowed_domains)
             } else {
@@ -229,13 +246,17 @@ impl NetworkProxySpec {
     }
 
     fn allow_user_allowlist_expansion(
-        requirements: &NetworkConstraints,
         sandbox_policy: &SandboxPolicy,
+        hard_deny_allowlist_misses: bool,
     ) -> bool {
         matches!(
             sandbox_policy,
             SandboxPolicy::ReadOnly { .. } | SandboxPolicy::WorkspaceWrite { .. }
-        ) && requirements.allow_user_allowlist_expansion.unwrap_or(true)
+        ) && !hard_deny_allowlist_misses
+    }
+
+    fn managed_allowed_domains_only(requirements: &NetworkConstraints) -> bool {
+        requirements.managed_allowed_domains_only.unwrap_or(false)
     }
 
     fn allow_user_denylist_expansion(sandbox_policy: &SandboxPolicy) -> bool {
@@ -340,12 +361,12 @@ mod tests {
     }
 
     #[test]
-    fn requirements_can_disable_default_mode_allowlist_expansion() {
+    fn managed_allowed_domains_only_disables_default_mode_allowlist_expansion() {
         let mut config = NetworkProxyConfig::default();
         config.network.allowed_domains = vec!["api.example.com".to_string()];
         let requirements = NetworkConstraints {
             allowed_domains: Some(vec!["*.example.com".to_string()]),
-            allow_user_allowlist_expansion: Some(false),
+            managed_allowed_domains_only: Some(true),
             ..Default::default()
         };
 
@@ -361,6 +382,79 @@ mod tests {
             vec!["*.example.com".to_string()]
         );
         assert_eq!(spec.constraints.allow_user_allowlist_expansion, Some(false));
+    }
+
+    #[test]
+    fn managed_allowed_domains_only_ignores_user_allowlist_and_hard_denies_misses() {
+        let mut config = NetworkProxyConfig::default();
+        config.network.allowed_domains = vec!["api.example.com".to_string()];
+        let requirements = NetworkConstraints {
+            allowed_domains: Some(vec!["managed.example.com".to_string()]),
+            managed_allowed_domains_only: Some(true),
+            ..Default::default()
+        };
+
+        let spec = NetworkProxySpec::from_config_and_constraints(
+            config,
+            Some(requirements),
+            &SandboxPolicy::new_workspace_write_policy(),
+        )
+        .expect("managed-only allowlist should still load");
+
+        assert_eq!(
+            spec.config.network.allowed_domains,
+            vec!["managed.example.com".to_string()]
+        );
+        assert_eq!(
+            spec.constraints.allowed_domains,
+            Some(vec!["managed.example.com".to_string()])
+        );
+        assert_eq!(spec.constraints.allow_user_allowlist_expansion, Some(false));
+        assert!(spec.hard_deny_allowlist_misses);
+    }
+
+    #[test]
+    fn managed_allowed_domains_only_without_managed_allowlist_blocks_all_user_domains() {
+        let mut config = NetworkProxyConfig::default();
+        config.network.allowed_domains = vec!["api.example.com".to_string()];
+        let requirements = NetworkConstraints {
+            managed_allowed_domains_only: Some(true),
+            ..Default::default()
+        };
+
+        let spec = NetworkProxySpec::from_config_and_constraints(
+            config,
+            Some(requirements),
+            &SandboxPolicy::new_workspace_write_policy(),
+        )
+        .expect("managed-only mode should treat missing managed allowlist as empty");
+
+        assert!(spec.config.network.allowed_domains.is_empty());
+        assert_eq!(spec.constraints.allowed_domains, Some(Vec::new()));
+        assert_eq!(spec.constraints.allow_user_allowlist_expansion, Some(false));
+        assert!(spec.hard_deny_allowlist_misses);
+    }
+
+    #[test]
+    fn managed_allowed_domains_only_blocks_all_user_domains_in_full_access_without_managed_list() {
+        let mut config = NetworkProxyConfig::default();
+        config.network.allowed_domains = vec!["api.example.com".to_string()];
+        let requirements = NetworkConstraints {
+            managed_allowed_domains_only: Some(true),
+            ..Default::default()
+        };
+
+        let spec = NetworkProxySpec::from_config_and_constraints(
+            config,
+            Some(requirements),
+            &SandboxPolicy::DangerFullAccess,
+        )
+        .expect("managed-only mode should treat missing managed allowlist as empty");
+
+        assert!(spec.config.network.allowed_domains.is_empty());
+        assert_eq!(spec.constraints.allowed_domains, Some(Vec::new()));
+        assert_eq!(spec.constraints.allow_user_allowlist_expansion, Some(false));
+        assert!(spec.hard_deny_allowlist_misses);
     }
 
     #[test]

--- a/codex-rs/core/src/config/network_proxy_spec.rs
+++ b/codex-rs/core/src/config/network_proxy_spec.rs
@@ -191,7 +191,18 @@ impl NetworkProxySpec {
                 Some(dangerously_allow_all_unix_sockets);
         }
         if let Some(allowed_domains) = requirements.allowed_domains.clone() {
-            config.network.allowed_domains = allowed_domains.clone();
+            // Requirements define the managed baseline; user config may add
+            // narrower entries that still fit within that managed boundary.
+            let mut effective_allowed_domains = allowed_domains.clone();
+            for entry in &config.network.allowed_domains {
+                if !effective_allowed_domains
+                    .iter()
+                    .any(|managed_entry| managed_entry.eq_ignore_ascii_case(entry))
+                {
+                    effective_allowed_domains.push(entry.clone());
+                }
+            }
+            config.network.allowed_domains = effective_allowed_domains;
             constraints.allowed_domains = Some(allowed_domains);
         }
         if let Some(denied_domains) = requirements.denied_domains.clone() {
@@ -233,5 +244,47 @@ mod tests {
             .build_state_with_audit_metadata(metadata.clone())
             .expect("state should build");
         assert_eq!(state.audit_metadata(), &metadata);
+    }
+
+    #[test]
+    fn requirements_allowed_domains_are_a_baseline_for_user_allowlist() {
+        let mut config = NetworkProxyConfig::default();
+        config.network.allowed_domains = vec!["api.example.com".to_string()];
+        let requirements = NetworkConstraints {
+            allowed_domains: Some(vec!["*.example.com".to_string()]),
+            ..Default::default()
+        };
+
+        let spec = NetworkProxySpec::from_config_and_constraints(config, Some(requirements))
+            .expect("config should stay within the managed allowlist");
+
+        assert_eq!(
+            spec.config.network.allowed_domains,
+            vec!["*.example.com".to_string(), "api.example.com".to_string()]
+        );
+        assert_eq!(
+            spec.constraints.allowed_domains,
+            Some(vec!["*.example.com".to_string()])
+        );
+    }
+
+    #[test]
+    fn requirements_allowed_domains_reject_user_widening() {
+        let mut config = NetworkProxyConfig::default();
+        config.network.allowed_domains = vec!["evil.com".to_string()];
+        let requirements = NetworkConstraints {
+            allowed_domains: Some(vec!["*.example.com".to_string()]),
+            ..Default::default()
+        };
+
+        let err = NetworkProxySpec::from_config_and_constraints(config, Some(requirements))
+            .expect_err("config outside the managed allowlist should be rejected");
+
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(
+            err.to_string()
+                .contains("subset of managed allowed_domains"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/codex-rs/core/src/config/network_proxy_spec.rs
+++ b/codex-rs/core/src/config/network_proxy_spec.rs
@@ -174,9 +174,9 @@ impl NetworkProxySpec {
         hard_deny_allowlist_misses: bool,
     ) -> (NetworkProxyConfig, NetworkProxyConstraints) {
         let mut constraints = NetworkProxyConstraints::default();
-        let allow_user_allowlist_expansion =
-            Self::allow_user_allowlist_expansion(sandbox_policy, hard_deny_allowlist_misses);
-        let allow_user_denylist_expansion = Self::allow_user_denylist_expansion(sandbox_policy);
+        let allowlist_expansion_enabled =
+            Self::allowlist_expansion_enabled(sandbox_policy, hard_deny_allowlist_misses);
+        let denylist_expansion_enabled = Self::denylist_expansion_enabled(sandbox_policy);
 
         if let Some(enabled) = requirements.enabled {
             config.network.enabled = enabled;
@@ -216,22 +216,22 @@ impl NetworkProxySpec {
             // Managed requirements seed the baseline allowlist. User additions
             // can extend that baseline unless managed-only mode pins the
             // effective allowlist to the managed set.
-            config.network.allowed_domains = if allow_user_allowlist_expansion {
+            config.network.allowed_domains = if allowlist_expansion_enabled {
                 Self::merge_domain_lists(allowed_domains.clone(), &config.network.allowed_domains)
             } else {
                 allowed_domains.clone()
             };
             constraints.allowed_domains = Some(allowed_domains);
-            constraints.allow_user_allowlist_expansion = Some(allow_user_allowlist_expansion);
+            constraints.allowlist_expansion_enabled = Some(allowlist_expansion_enabled);
         }
         if let Some(denied_domains) = requirements.denied_domains.clone() {
-            config.network.denied_domains = if allow_user_denylist_expansion {
+            config.network.denied_domains = if denylist_expansion_enabled {
                 Self::merge_domain_lists(denied_domains.clone(), &config.network.denied_domains)
             } else {
                 denied_domains.clone()
             };
             constraints.denied_domains = Some(denied_domains);
-            constraints.allow_user_denylist_expansion = Some(allow_user_denylist_expansion);
+            constraints.denylist_expansion_enabled = Some(denylist_expansion_enabled);
         }
         if let Some(allow_unix_sockets) = requirements.allow_unix_sockets.clone() {
             config.network.allow_unix_sockets = allow_unix_sockets.clone();
@@ -245,7 +245,7 @@ impl NetworkProxySpec {
         (config, constraints)
     }
 
-    fn allow_user_allowlist_expansion(
+    fn allowlist_expansion_enabled(
         sandbox_policy: &SandboxPolicy,
         hard_deny_allowlist_misses: bool,
     ) -> bool {
@@ -259,7 +259,7 @@ impl NetworkProxySpec {
         requirements.managed_allowed_domains_only.unwrap_or(false)
     }
 
-    fn allow_user_denylist_expansion(sandbox_policy: &SandboxPolicy) -> bool {
+    fn denylist_expansion_enabled(sandbox_policy: &SandboxPolicy) -> bool {
         matches!(
             sandbox_policy,
             SandboxPolicy::ReadOnly { .. } | SandboxPolicy::WorkspaceWrite { .. }
@@ -289,6 +289,7 @@ mod tests {
         let spec = NetworkProxySpec {
             config: NetworkProxyConfig::default(),
             constraints: NetworkProxyConstraints::default(),
+            hard_deny_allowlist_misses: false,
         };
         let metadata = NetworkProxyAuditMetadata {
             conversation_id: Some("conversation-1".to_string()),
@@ -327,7 +328,7 @@ mod tests {
             spec.constraints.allowed_domains,
             Some(vec!["*.example.com".to_string()])
         );
-        assert_eq!(spec.constraints.allow_user_allowlist_expansion, Some(true));
+        assert_eq!(spec.constraints.allowlist_expansion_enabled, Some(true));
     }
 
     #[test]
@@ -356,8 +357,8 @@ mod tests {
             spec.config.network.denied_domains,
             vec!["blocked.example.com".to_string()]
         );
-        assert_eq!(spec.constraints.allow_user_allowlist_expansion, Some(false));
-        assert_eq!(spec.constraints.allow_user_denylist_expansion, Some(false));
+        assert_eq!(spec.constraints.allowlist_expansion_enabled, Some(false));
+        assert_eq!(spec.constraints.denylist_expansion_enabled, Some(false));
     }
 
     #[test]
@@ -381,7 +382,7 @@ mod tests {
             spec.config.network.allowed_domains,
             vec!["*.example.com".to_string()]
         );
-        assert_eq!(spec.constraints.allow_user_allowlist_expansion, Some(false));
+        assert_eq!(spec.constraints.allowlist_expansion_enabled, Some(false));
     }
 
     #[test]
@@ -409,7 +410,7 @@ mod tests {
             spec.constraints.allowed_domains,
             Some(vec!["managed.example.com".to_string()])
         );
-        assert_eq!(spec.constraints.allow_user_allowlist_expansion, Some(false));
+        assert_eq!(spec.constraints.allowlist_expansion_enabled, Some(false));
         assert!(spec.hard_deny_allowlist_misses);
     }
 
@@ -431,7 +432,7 @@ mod tests {
 
         assert!(spec.config.network.allowed_domains.is_empty());
         assert_eq!(spec.constraints.allowed_domains, Some(Vec::new()));
-        assert_eq!(spec.constraints.allow_user_allowlist_expansion, Some(false));
+        assert_eq!(spec.constraints.allowlist_expansion_enabled, Some(false));
         assert!(spec.hard_deny_allowlist_misses);
     }
 
@@ -453,7 +454,7 @@ mod tests {
 
         assert!(spec.config.network.allowed_domains.is_empty());
         assert_eq!(spec.constraints.allowed_domains, Some(Vec::new()));
-        assert_eq!(spec.constraints.allow_user_allowlist_expansion, Some(false));
+        assert_eq!(spec.constraints.allowlist_expansion_enabled, Some(false));
         assert!(spec.hard_deny_allowlist_misses);
     }
 
@@ -480,6 +481,6 @@ mod tests {
                 "blocked.example.com".to_string()
             ]
         );
-        assert_eq!(spec.constraints.allow_user_denylist_expansion, Some(true));
+        assert_eq!(spec.constraints.denylist_expansion_enabled, Some(true));
     }
 }

--- a/codex-rs/network-proxy/README.md
+++ b/codex-rs/network-proxy/README.md
@@ -45,7 +45,7 @@ denied_domains = ["evil.example"]
 # If false, local/private networking is rejected. Explicit allowlisting of local IP literals
 # (or `localhost`) is required to permit them.
 # Hostnames that resolve to local/private IPs are still blocked even if allowlisted.
-allow_local_binding = true
+allow_local_binding = false
 
 # macOS-only: allows proxying to a unix socket when request includes `x-unix-socket: /path`.
 allow_unix_sockets = ["/tmp/example.sock"]

--- a/codex-rs/network-proxy/src/config.rs
+++ b/codex-rs/network-proxy/src/config.rs
@@ -60,7 +60,7 @@ impl Default for NetworkProxySettings {
             allowed_domains: Vec::new(),
             denied_domains: Vec::new(),
             allow_unix_sockets: Vec::new(),
-            allow_local_binding: true,
+            allow_local_binding: false,
             mitm: false,
         }
     }
@@ -374,7 +374,7 @@ mod tests {
                 allowed_domains: Vec::new(),
                 denied_domains: Vec::new(),
                 allow_unix_sockets: Vec::new(),
-                allow_local_binding: true,
+                allow_local_binding: false,
                 mitm: false,
             }
         );

--- a/codex-rs/network-proxy/src/runtime.rs
+++ b/codex-rs/network-proxy/src/runtime.rs
@@ -905,7 +905,7 @@ mod tests {
         };
         let constraints = NetworkProxyConstraints {
             allowed_domains: Some(vec!["managed.example.com".to_string()]),
-            allow_user_allowlist_expansion: Some(true),
+            allowlist_expansion_enabled: Some(true),
             ..NetworkProxyConstraints::default()
         };
         let state = NetworkProxyState::with_reloader(
@@ -937,7 +937,7 @@ mod tests {
         };
         let constraints = NetworkProxyConstraints {
             allowed_domains: Some(vec!["managed.example.com".to_string()]),
-            allow_user_allowlist_expansion: Some(false),
+            allowlist_expansion_enabled: Some(false),
             ..NetworkProxyConstraints::default()
         };
         let state = NetworkProxyState::with_reloader(
@@ -967,7 +967,7 @@ mod tests {
         };
         let constraints = NetworkProxyConstraints {
             denied_domains: Some(vec!["managed.example.com".to_string()]),
-            allow_user_denylist_expansion: Some(false),
+            denylist_expansion_enabled: Some(false),
             ..NetworkProxyConstraints::default()
         };
         let state = NetworkProxyState::with_reloader(
@@ -1213,7 +1213,7 @@ mod tests {
     fn validate_policy_against_constraints_allows_expanding_allowed_domains_when_enabled() {
         let constraints = NetworkProxyConstraints {
             allowed_domains: Some(vec!["example.com".to_string()]),
-            allow_user_allowlist_expansion: Some(true),
+            allowlist_expansion_enabled: Some(true),
             ..NetworkProxyConstraints::default()
         };
 
@@ -1360,7 +1360,7 @@ mod tests {
     fn validate_policy_against_constraints_disallows_expanding_denied_domains_when_fixed() {
         let constraints = NetworkProxyConstraints {
             denied_domains: Some(vec!["evil.com".to_string()]),
-            allow_user_denylist_expansion: Some(false),
+            denylist_expansion_enabled: Some(false),
             ..NetworkProxyConstraints::default()
         };
 

--- a/codex-rs/network-proxy/src/runtime.rs
+++ b/codex-rs/network-proxy/src/runtime.rs
@@ -895,6 +895,98 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn add_allowed_domain_succeeds_when_managed_baseline_allows_expansion() {
+        let config = NetworkProxyConfig {
+            network: NetworkProxySettings {
+                enabled: true,
+                allowed_domains: vec!["managed.example.com".to_string()],
+                ..NetworkProxySettings::default()
+            },
+        };
+        let constraints = NetworkProxyConstraints {
+            allowed_domains: Some(vec!["managed.example.com".to_string()]),
+            allow_user_allowlist_expansion: Some(true),
+            ..NetworkProxyConstraints::default()
+        };
+        let state = NetworkProxyState::with_reloader(
+            build_config_state(config, constraints).unwrap(),
+            Arc::new(NoopReloader),
+        );
+
+        state.add_allowed_domain("user.example.com").await.unwrap();
+
+        let (allowed, denied) = state.current_patterns().await.unwrap();
+        assert_eq!(
+            allowed,
+            vec![
+                "managed.example.com".to_string(),
+                "user.example.com".to_string()
+            ]
+        );
+        assert!(denied.is_empty());
+    }
+
+    #[tokio::test]
+    async fn add_allowed_domain_rejects_expansion_when_managed_baseline_is_fixed() {
+        let config = NetworkProxyConfig {
+            network: NetworkProxySettings {
+                enabled: true,
+                allowed_domains: vec!["managed.example.com".to_string()],
+                ..NetworkProxySettings::default()
+            },
+        };
+        let constraints = NetworkProxyConstraints {
+            allowed_domains: Some(vec!["managed.example.com".to_string()]),
+            allow_user_allowlist_expansion: Some(false),
+            ..NetworkProxyConstraints::default()
+        };
+        let state = NetworkProxyState::with_reloader(
+            build_config_state(config, constraints).unwrap(),
+            Arc::new(NoopReloader),
+        );
+
+        let err = state
+            .add_allowed_domain("user.example.com")
+            .await
+            .expect_err("managed baseline should reject allowlist expansion");
+
+        assert!(
+            format!("{err:#}").contains("network.allowed_domains constrained by managed config"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[tokio::test]
+    async fn add_denied_domain_rejects_expansion_when_managed_baseline_is_fixed() {
+        let config = NetworkProxyConfig {
+            network: NetworkProxySettings {
+                enabled: true,
+                denied_domains: vec!["managed.example.com".to_string()],
+                ..NetworkProxySettings::default()
+            },
+        };
+        let constraints = NetworkProxyConstraints {
+            denied_domains: Some(vec!["managed.example.com".to_string()]),
+            allow_user_denylist_expansion: Some(false),
+            ..NetworkProxyConstraints::default()
+        };
+        let state = NetworkProxyState::with_reloader(
+            build_config_state(config, constraints).unwrap(),
+            Arc::new(NoopReloader),
+        );
+
+        let err = state
+            .add_denied_domain("user.example.com")
+            .await
+            .expect_err("managed baseline should reject denylist expansion");
+
+        assert!(
+            format!("{err:#}").contains("network.denied_domains constrained by managed config"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[tokio::test]
     async fn blocked_snapshot_does_not_consume_entries() {
         let state = network_proxy_state_for_policy(NetworkProxySettings::default());
 
@@ -1118,6 +1210,25 @@ mod tests {
     }
 
     #[test]
+    fn validate_policy_against_constraints_allows_expanding_allowed_domains_when_enabled() {
+        let constraints = NetworkProxyConstraints {
+            allowed_domains: Some(vec!["example.com".to_string()]),
+            allow_user_allowlist_expansion: Some(true),
+            ..NetworkProxyConstraints::default()
+        };
+
+        let config = NetworkProxyConfig {
+            network: NetworkProxySettings {
+                enabled: true,
+                allowed_domains: vec!["example.com".to_string(), "api.openai.com".to_string()],
+                ..NetworkProxySettings::default()
+            },
+        };
+
+        assert!(validate_policy_against_constraints(&config, &constraints).is_ok());
+    }
+
+    #[test]
     fn validate_policy_against_constraints_disallows_widening_mode() {
         let constraints = NetworkProxyConstraints {
             mode: Some(NetworkMode::Limited),
@@ -1238,6 +1349,25 @@ mod tests {
             network: NetworkProxySettings {
                 enabled: true,
                 denied_domains: vec![],
+                ..NetworkProxySettings::default()
+            },
+        };
+
+        assert!(validate_policy_against_constraints(&config, &constraints).is_err());
+    }
+
+    #[test]
+    fn validate_policy_against_constraints_disallows_expanding_denied_domains_when_fixed() {
+        let constraints = NetworkProxyConstraints {
+            denied_domains: Some(vec!["evil.com".to_string()]),
+            allow_user_denylist_expansion: Some(false),
+            ..NetworkProxyConstraints::default()
+        };
+
+        let config = NetworkProxyConfig {
+            network: NetworkProxySettings {
+                enabled: true,
+                denied_domains: vec!["evil.com".to_string(), "more-evil.com".to_string()],
                 ..NetworkProxySettings::default()
             },
         };

--- a/codex-rs/network-proxy/src/state.rs
+++ b/codex-rs/network-proxy/src/state.rs
@@ -24,9 +24,9 @@ pub struct NetworkProxyConstraints {
     pub dangerously_allow_non_loopback_proxy: Option<bool>,
     pub dangerously_allow_all_unix_sockets: Option<bool>,
     pub allowed_domains: Option<Vec<String>>,
-    pub allow_user_allowlist_expansion: Option<bool>,
+    pub allowlist_expansion_enabled: Option<bool>,
     pub denied_domains: Option<Vec<String>>,
-    pub allow_user_denylist_expansion: Option<bool>,
+    pub denylist_expansion_enabled: Option<bool>,
     pub allow_unix_sockets: Option<Vec<String>>,
     pub allow_local_binding: Option<bool>,
 }
@@ -209,7 +209,7 @@ pub fn validate_policy_against_constraints(
 
     if let Some(allowed_domains) = &constraints.allowed_domains {
         validate_domain_patterns("network.allowed_domains", allowed_domains)?;
-        match constraints.allow_user_allowlist_expansion {
+        match constraints.allowlist_expansion_enabled {
             Some(true) => {
                 let required_set: HashSet<String> = allowed_domains
                     .iter()
@@ -293,7 +293,7 @@ pub fn validate_policy_against_constraints(
             .iter()
             .map(|s| s.to_ascii_lowercase())
             .collect();
-        match constraints.allow_user_denylist_expansion {
+        match constraints.denylist_expansion_enabled {
             Some(false) => {
                 validate(config.network.denied_domains.clone(), move |candidate| {
                     let candidate_set: HashSet<String> = candidate

--- a/codex-rs/network-proxy/src/state.rs
+++ b/codex-rs/network-proxy/src/state.rs
@@ -24,7 +24,9 @@ pub struct NetworkProxyConstraints {
     pub dangerously_allow_non_loopback_proxy: Option<bool>,
     pub dangerously_allow_all_unix_sockets: Option<bool>,
     pub allowed_domains: Option<Vec<String>>,
+    pub allow_user_allowlist_expansion: Option<bool>,
     pub denied_domains: Option<Vec<String>>,
+    pub allow_user_denylist_expansion: Option<bool>,
     pub allow_unix_sockets: Option<Vec<String>>,
     pub allow_local_binding: Option<bool>,
 }
@@ -207,31 +209,82 @@ pub fn validate_policy_against_constraints(
 
     if let Some(allowed_domains) = &constraints.allowed_domains {
         validate_domain_patterns("network.allowed_domains", allowed_domains)?;
-        let managed_patterns: Vec<DomainPattern> = allowed_domains
-            .iter()
-            .map(|entry| DomainPattern::parse_for_constraints(entry))
-            .collect();
-        validate(config.network.allowed_domains.clone(), move |candidate| {
-            let mut invalid = Vec::new();
-            for entry in candidate {
-                let candidate_pattern = DomainPattern::parse_for_constraints(entry);
-                if !managed_patterns
+        match constraints.allow_user_allowlist_expansion {
+            Some(true) => {
+                let required_set: HashSet<String> = allowed_domains
                     .iter()
-                    .any(|managed| managed.allows(&candidate_pattern))
-                {
-                    invalid.push(entry.clone());
-                }
+                    .map(|entry| entry.to_ascii_lowercase())
+                    .collect();
+                validate(config.network.allowed_domains.clone(), move |candidate| {
+                    let candidate_set: HashSet<String> = candidate
+                        .iter()
+                        .map(|entry| entry.to_ascii_lowercase())
+                        .collect();
+                    let missing: Vec<String> = required_set
+                        .iter()
+                        .filter(|entry| !candidate_set.contains(*entry))
+                        .cloned()
+                        .collect();
+                    if missing.is_empty() {
+                        Ok(())
+                    } else {
+                        Err(invalid_value(
+                            "network.allowed_domains",
+                            "missing managed allowed_domains entries",
+                            format!("{missing:?}"),
+                        ))
+                    }
+                })?;
             }
-            if invalid.is_empty() {
-                Ok(())
-            } else {
-                Err(invalid_value(
-                    "network.allowed_domains",
-                    format!("{invalid:?}"),
-                    "subset of managed allowed_domains",
-                ))
+            Some(false) => {
+                let required_set: HashSet<String> = allowed_domains
+                    .iter()
+                    .map(|entry| entry.to_ascii_lowercase())
+                    .collect();
+                validate(config.network.allowed_domains.clone(), move |candidate| {
+                    let candidate_set: HashSet<String> = candidate
+                        .iter()
+                        .map(|entry| entry.to_ascii_lowercase())
+                        .collect();
+                    if candidate_set == required_set {
+                        Ok(())
+                    } else {
+                        Err(invalid_value(
+                            "network.allowed_domains",
+                            format!("{candidate:?}"),
+                            "must match managed allowed_domains",
+                        ))
+                    }
+                })?;
             }
-        })?;
+            None => {
+                let managed_patterns: Vec<DomainPattern> = allowed_domains
+                    .iter()
+                    .map(|entry| DomainPattern::parse_for_constraints(entry))
+                    .collect();
+                validate(config.network.allowed_domains.clone(), move |candidate| {
+                    let mut invalid = Vec::new();
+                    for entry in candidate {
+                        let candidate_pattern = DomainPattern::parse_for_constraints(entry);
+                        if !managed_patterns
+                            .iter()
+                            .any(|managed| managed.allows(&candidate_pattern))
+                        {
+                            invalid.push(entry.clone());
+                        }
+                    }
+                    if invalid.is_empty() {
+                        Ok(())
+                    } else {
+                        Err(invalid_value(
+                            "network.allowed_domains",
+                            format!("{invalid:?}"),
+                            "subset of managed allowed_domains",
+                        ))
+                    }
+                })?;
+            }
+        }
     }
 
     if let Some(denied_domains) = &constraints.denied_domains {
@@ -240,24 +293,45 @@ pub fn validate_policy_against_constraints(
             .iter()
             .map(|s| s.to_ascii_lowercase())
             .collect();
-        validate(config.network.denied_domains.clone(), move |candidate| {
-            let candidate_set: HashSet<String> =
-                candidate.iter().map(|s| s.to_ascii_lowercase()).collect();
-            let missing: Vec<String> = required_set
-                .iter()
-                .filter(|entry| !candidate_set.contains(*entry))
-                .cloned()
-                .collect();
-            if missing.is_empty() {
-                Ok(())
-            } else {
-                Err(invalid_value(
-                    "network.denied_domains",
-                    "missing managed denied_domains entries",
-                    format!("{missing:?}"),
-                ))
+        match constraints.allow_user_denylist_expansion {
+            Some(false) => {
+                validate(config.network.denied_domains.clone(), move |candidate| {
+                    let candidate_set: HashSet<String> = candidate
+                        .iter()
+                        .map(|entry| entry.to_ascii_lowercase())
+                        .collect();
+                    if candidate_set == required_set {
+                        Ok(())
+                    } else {
+                        Err(invalid_value(
+                            "network.denied_domains",
+                            format!("{candidate:?}"),
+                            "must match managed denied_domains",
+                        ))
+                    }
+                })?;
             }
-        })?;
+            Some(true) | None => {
+                validate(config.network.denied_domains.clone(), move |candidate| {
+                    let candidate_set: HashSet<String> =
+                        candidate.iter().map(|s| s.to_ascii_lowercase()).collect();
+                    let missing: Vec<String> = required_set
+                        .iter()
+                        .filter(|entry| !candidate_set.contains(*entry))
+                        .cloned()
+                        .collect();
+                    if missing.is_empty() {
+                        Ok(())
+                    } else {
+                        Err(invalid_value(
+                            "network.denied_domains",
+                            "missing managed denied_domains entries",
+                            format!("{missing:?}"),
+                        ))
+                    }
+                })?;
+            }
+        }
     }
 
     if let Some(allow_unix_sockets) = &constraints.allow_unix_sockets {

--- a/codex-rs/tui/src/debug_config.rs
+++ b/codex-rs/tui/src/debug_config.rs
@@ -331,7 +331,7 @@ fn format_network_constraints(network: &NetworkConstraints) -> String {
         dangerously_allow_non_loopback_proxy,
         dangerously_allow_all_unix_sockets,
         allowed_domains,
-        allow_user_allowlist_expansion,
+        managed_allowed_domains_only,
         denied_domains,
         allow_unix_sockets,
         allow_local_binding,
@@ -362,9 +362,9 @@ fn format_network_constraints(network: &NetworkConstraints) -> String {
     if let Some(allowed_domains) = allowed_domains {
         parts.push(format!("allowed_domains=[{}]", allowed_domains.join(", ")));
     }
-    if let Some(allow_user_allowlist_expansion) = allow_user_allowlist_expansion {
+    if let Some(managed_allowed_domains_only) = managed_allowed_domains_only {
         parts.push(format!(
-            "allow_user_allowlist_expansion={allow_user_allowlist_expansion}"
+            "managed_allowed_domains_only={managed_allowed_domains_only}"
         ));
     }
     if let Some(denied_domains) = denied_domains {

--- a/codex-rs/tui/src/debug_config.rs
+++ b/codex-rs/tui/src/debug_config.rs
@@ -331,6 +331,7 @@ fn format_network_constraints(network: &NetworkConstraints) -> String {
         dangerously_allow_non_loopback_proxy,
         dangerously_allow_all_unix_sockets,
         allowed_domains,
+        allow_user_allowlist_expansion,
         denied_domains,
         allow_unix_sockets,
         allow_local_binding,
@@ -360,6 +361,11 @@ fn format_network_constraints(network: &NetworkConstraints) -> String {
     }
     if let Some(allowed_domains) = allowed_domains {
         parts.push(format!("allowed_domains=[{}]", allowed_domains.join(", ")));
+    }
+    if let Some(allow_user_allowlist_expansion) = allow_user_allowlist_expansion {
+        parts.push(format!(
+            "allow_user_allowlist_expansion={allow_user_allowlist_expansion}"
+        ));
     }
     if let Some(denied_domains) = denied_domains {
         parts.push(format!("denied_domains=[{}]", denied_domains.join(", ")));


### PR DESCRIPTION
## Summary
- treat `requirements.toml` `allowed_domains` and `denied_domains` as managed network baselines for the proxy
- in restricted modes by default, build the effective runtime policy from the managed baseline plus user-configured allowlist and denylist entries, so common hosts can be pre-approved without blocking later user expansion
- add `experimental_network.managed_allowed_domains_only = true` to pin the effective allowlist to managed entries, ignore user allowlist additions, and hard-deny non-managed domains without prompting
- apply `managed_allowed_domains_only` anywhere managed network enforcement is active, including full access, while continuing to respect denied domains from all sources
- add regression coverage for merged-baseline behavior, managed-only behavior, and full-access managed-only enforcement

## Behavior
Assuming `requirements.toml` defines both `experimental_network.allowed_domains` and `experimental_network.denied_domains`.

### Default mode
- By default, the effective allowlist is `experimental_network.allowed_domains` plus user or persisted allowlist additions.
- By default, the effective denylist is `experimental_network.denied_domains` plus user or persisted denylist additions.
- Allowlist misses can go through the network approval flow.
- Explicit denylist hits and local or private-network blocks are still hard-denied.
- When `experimental_network.managed_allowed_domains_only = true`, only managed `allowed_domains` are respected, user allowlist additions are ignored, and non-managed domains are hard-denied without prompting.
- Denied domains continue to be respected from all sources.

### Full access
- With managed requirements present, the effective allowlist is pinned to `experimental_network.allowed_domains`.
- With managed requirements present, the effective denylist is pinned to `experimental_network.denied_domains`.
- There is no allowlist-miss approval path in full access.
- Explicit denylist hits are hard-denied.
- `experimental_network.managed_allowed_domains_only = true` now also applies in full access, so managed-only behavior remains in effect anywhere managed network enforcement is active.
