### PR TITLE
Add experimental startup auto-update

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1493,6 +1493,7 @@ dependencies = [
  "codex-tui",
  "codex-utils-cargo-bin",
  "codex-utils-cli",
+ "codex-utils-pty",
  "codex-windows-sandbox",
  "libc",
  "owo-colors",

--- a/codex-rs/cli/Cargo.toml
+++ b/codex-rs/cli/Cargo.toml
@@ -60,5 +60,6 @@ codex_windows_sandbox = { package = "codex-windows-sandbox", path = "../windows-
 assert_cmd = { workspace = true }
 assert_matches = { workspace = true }
 codex-utils-cargo-bin = { workspace = true }
+codex-utils-pty = { workspace = true }
 predicates = { workspace = true }
 pretty_assertions = { workspace = true }

--- a/codex-rs/cli/tests/auto_update_startup.rs
+++ b/codex-rs/cli/tests/auto_update_startup.rs
@@ -1,3 +1,10 @@
+//! End-to-end PTY coverage for the startup auto-update handoff.
+//!
+//! This test seeds cached update state and a fake `npm` on `PATH`, then runs
+//! the real `codex` binary. Its job is to document and enforce the contract
+//! that startup reuses the existing updater path and preserves the updater
+//! working directory and argv.
+
 use std::collections::HashMap;
 use std::time::Duration;
 

--- a/codex-rs/cli/tests/auto_update_startup.rs
+++ b/codex-rs/cli/tests/auto_update_startup.rs
@@ -1,0 +1,180 @@
+use std::collections::HashMap;
+use std::time::Duration;
+
+use pretty_assertions::assert_eq;
+use tokio::select;
+use tokio::time::timeout;
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+#[tokio::test]
+#[cfg_attr(
+    debug_assertions,
+    ignore = "update checks are disabled in debug builds (cfg(not(debug_assertions)))"
+)]
+/// Runs the real CLI startup path with a seeded cached update result and a
+/// mocked `npm` binary so the auto-update branch is exercised end to end.
+async fn startup_auto_update_runs_detected_npm_command() -> anyhow::Result<()> {
+    if cfg!(windows) {
+        // This test installs a POSIX shell script as the mocked updater.
+        return Ok(());
+    }
+
+    let tmp = tempfile::tempdir()?;
+    let codex_home = tmp.path().join("codex-home");
+    std::fs::create_dir_all(&codex_home)?;
+
+    let cwd = std::env::current_dir()?;
+    let config_contents = format!(
+        r#"
+model_provider = "ollama"
+
+[projects]
+"{cwd}" = {{ trust_level = "trusted" }}
+
+[features]
+startup_auto_update = true
+"#,
+        cwd = cwd.display()
+    );
+    std::fs::write(codex_home.join("config.toml"), config_contents)?;
+
+    // Seed a cached "newer version" result so startup takes the normal update
+    // flow without depending on a live version check.
+    let version_json = serde_json::json!({
+        "latest_version": "999.0.0",
+        "last_checked_at": "9999-01-01T00:00:00Z",
+        "dismissed_version": serde_json::Value::Null,
+    });
+    std::fs::write(
+        codex_home.join("version.json"),
+        format!("{}\n", serde_json::to_string(&version_json)?),
+    )?;
+
+    // Put a fake `npm` first on PATH and record the exact working directory and
+    // arguments the CLI uses.
+    let bin_dir = tmp.path().join("bin");
+    std::fs::create_dir_all(&bin_dir)?;
+    let npm_log_path = tmp.path().join("mock-npm.log");
+    let npm_script_path = bin_dir.join("npm");
+    std::fs::write(
+        &npm_script_path,
+        format!(
+            r#"#!/bin/sh
+set -eu
+{{
+  printf 'cwd=%s\n' "$(pwd)"
+  for arg in "$@"; do
+    printf 'arg=%s\n' "$arg"
+  done
+}} > "{}"
+"#,
+            npm_log_path.display()
+        ),
+    )?;
+    #[cfg(unix)]
+    {
+        let mut perms = std::fs::metadata(&npm_script_path)?.permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&npm_script_path, perms)?;
+    }
+
+    let codex_cli = codex_utils_cargo_bin::cargo_bin("codex")?;
+    let mut env = HashMap::new();
+    env.insert("CODEX_HOME".to_string(), codex_home.display().to_string());
+    env.insert("CODEX_MANAGED_BY_NPM".to_string(), "1".to_string());
+    env.insert(
+        "PATH".to_string(),
+        match std::env::var("PATH") {
+            Ok(path) => format!("{}:{path}", bin_dir.display()),
+            Err(_) => bin_dir.display().to_string(),
+        },
+    );
+
+    let args = vec!["-c".to_string(), "analytics.enabled=false".to_string()];
+    let spawned = codex_utils_pty::spawn_pty_process(
+        codex_cli.to_string_lossy().as_ref(),
+        &args,
+        &cwd,
+        &env,
+        &None,
+    )
+    .await?;
+    let mut output = Vec::new();
+    let mut output_rx = spawned.output_rx;
+    let mut exit_rx = spawned.exit_rx;
+    let writer_tx = spawned.session.writer_sender();
+
+    let exit_code_result = timeout(Duration::from_secs(20), async {
+        loop {
+            select! {
+                result = output_rx.recv() => match result {
+                    Ok(chunk) => {
+                        if chunk.windows(4).any(|window| window == b"\x1b[6n") {
+                            // The TUI asks the terminal for cursor position
+                            // during startup; reply so the PTY session can
+                            // finish initializing.
+                            let _ = writer_tx.send(b"\x1b[1;1R".to_vec()).await;
+                        }
+                        output.extend_from_slice(&chunk);
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break exit_rx.await,
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
+                },
+                result = &mut exit_rx => break result,
+            }
+        }
+    })
+    .await;
+
+    let exit_code = match exit_code_result {
+        Ok(Ok(code)) => code,
+        Ok(Err(err)) => return Err(err.into()),
+        Err(_) => {
+            spawned.session.terminate();
+            anyhow::bail!("timed out waiting for codex CLI to exit");
+        }
+    };
+
+    while let Ok(chunk) = output_rx.try_recv() {
+        output.extend_from_slice(&chunk);
+    }
+
+    let output = String::from_utf8_lossy(&output).to_string();
+    assert_eq!(
+        exit_code, 0,
+        "Codex should exit successfully. Output:\n{output}"
+    );
+    assert!(
+        output.contains("Updating Codex via `npm install -g @openai/codex`..."),
+        "expected auto-update execution message, got: {output}"
+    );
+    assert!(
+        output.contains("Update ran successfully! Please restart Codex."),
+        "expected successful update message, got: {output}"
+    );
+
+    let npm_log = std::fs::read_to_string(&npm_log_path)?;
+    let cwd_line = format!("cwd={}", cwd.display());
+    assert!(
+        npm_log.lines().any(|line| line == cwd_line),
+        "expected npm to run in cwd {}, got log:\n{npm_log}",
+        cwd.display(),
+    );
+
+    let args_seen: Vec<String> = npm_log
+        .lines()
+        .filter_map(|line| line.strip_prefix("arg=").map(ToString::to_string))
+        .collect();
+    assert_eq!(
+        args_seen,
+        vec![
+            "install".to_string(),
+            "-g".to_string(),
+            "@openai/codex".to_string(),
+        ]
+    );
+
+    Ok(())
+}

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -403,6 +403,9 @@
             "sqlite": {
               "type": "boolean"
             },
+            "startup_auto_update": {
+              "type": "boolean"
+            },
             "steer": {
               "type": "boolean"
             },
@@ -1682,6 +1685,9 @@
           "type": "boolean"
         },
         "sqlite": {
+          "type": "boolean"
+        },
+        "startup_auto_update": {
           "type": "boolean"
         },
         "steer": {

--- a/codex-rs/core/src/features.rs
+++ b/codex-rs/core/src/features.rs
@@ -139,6 +139,9 @@ pub enum Feature {
     Personality,
     /// Prevent idle system sleep while a turn is actively running.
     PreventIdleSleep,
+    /// Automatically take the existing startup "Update now" path and run the
+    /// detected package-manager update command.
+    StartupAutoUpdate,
     /// Use the Responses API WebSocket transport for OpenAI by default.
     ResponsesWebsockets,
     /// Enable Responses API websocket v2 mode.
@@ -641,6 +644,16 @@ pub const FEATURES: &[FeatureSpec] = &[
         default_enabled: false,
     },
     FeatureSpec {
+        id: Feature::StartupAutoUpdate,
+        key: "startup_auto_update",
+        stage: Stage::Experimental {
+            name: "Auto-update on startup",
+            menu_description: "Automatically run the detected npm/bun/brew update command when a newer Codex version is already known.",
+            announcement: "NEW: Auto-update on startup can automatically run the detected npm, bun, or Homebrew update command when a new Codex version is available.",
+        },
+        default_enabled: false,
+    },
+    FeatureSpec {
         id: Feature::ResponsesWebsockets,
         key: "responses_websockets",
         stage: Stage::UnderDevelopment,
@@ -757,6 +770,15 @@ mod tests {
             Stage::UnderDevelopment
         );
         assert_eq!(Feature::UseLinuxSandboxBwrap.default_enabled(), false);
+    }
+
+    #[test]
+    fn startup_auto_update_is_experimental_and_disabled_by_default() {
+        assert!(matches!(
+            Feature::StartupAutoUpdate.stage(),
+            Stage::Experimental { .. }
+        ));
+        assert_eq!(Feature::StartupAutoUpdate.default_enabled(), false);
     }
 
     #[test]

--- a/codex-rs/tui/src/update_prompt.rs
+++ b/codex-rs/tui/src/update_prompt.rs
@@ -1,4 +1,9 @@
 #![cfg(not(debug_assertions))]
+//! Renders the startup update prompt and reports which startup path to take.
+//!
+//! This module owns the selection layer for update prompts. It decides whether
+//! startup should continue normally or hand control back to the CLI to run an
+//! updater command, but it does not execute the updater itself.
 
 use crate::history_cell::padded_emoji;
 use crate::key_hint;
@@ -28,8 +33,15 @@ use ratatui::widgets::Clear;
 use ratatui::widgets::WidgetRef;
 use tokio_stream::StreamExt;
 
+/// Describes what startup should do after resolving update prompt state.
+///
+/// The TUI returns this instead of spawning updater processes directly so the
+/// CLI remains the single owner of command execution, exit behavior, and
+/// update status messaging.
 pub(crate) enum UpdatePromptOutcome {
+    /// Proceed into the normal TUI startup path.
     Continue,
+    /// Exit startup and run the detected updater command through the CLI.
     RunUpdate(UpdateAction),
 }
 


### PR DESCRIPTION
## Problem

Codex already had all of the mechanics required to self-update: it could detect that a newer version was available, choose an installer command based on how it was installed, and execute that command. The missing piece was policy. Startup always stopped at an interactive prompt, so the user had to explicitly choose "Update now" before any update command would run.

This change adds an experimental, opt-in `startup_auto_update` feature that changes only that startup decision. When startup already knows that a newer version exists and already knows which updater command to run, Codex can now automatically take the same update path that the manual prompt previously exposed.

## Mental model

The clean way to think about this PR is that it does not introduce a second updater. Update detection remains where it already lived, install-source detection remains where it already lived, and process execution remains where it already lived. The only new behavior is that the TUI can choose the existing `RunUpdate` path without waiting for a human selection when the feature flag is enabled.

That means the feature is best understood as "auto-select the existing startup update action," not "implement automatic background updates." The CLI still owns actually running the updater command and printing the result.

## Non-goals

This PR does not change how Codex checks for updates, does not add a background or detached updater, does not expand install-source detection beyond the existing npm, bun, and Homebrew heuristics, and does not change dismissal or cache semantics. It is intentionally narrow: it wires an automatic decision into an existing flow instead of redesigning the update system.

## Tradeoffs

Reusing the existing `RunUpdate` path is the main design choice here. The benefit is that manual and automatic updates stay coupled, so there is only one execution path to reason about and test. The cost is that the feature inherits the current startup-exit UX. When auto-update triggers, Codex still exits into the updater flow rather than updating in the background. That is why the feature is introduced behind an experimental flag and remains off by default.

## Architecture

The new `startup_auto_update` feature is registered in the feature table as experimental and disabled by default. At startup, the TUI still asks the existing update code whether a newer version is already known and whether there is a supported update action for the current installation. If either answer is no, startup proceeds exactly as before.

If both answers are yes, `run_update_prompt_if_needed()` now has two branches. With the feature disabled, it renders the existing prompt and waits for the user to choose. With the feature enabled, it skips the prompt and returns the same `UpdatePromptOutcome::RunUpdate(update_action)` that the manual "Update now" branch already returns. The CLI then executes the updater command through the existing updater path, so command spawning, stdout messaging, and exit behavior remain centralized in one place.

## Observability

The most useful way to debug this behavior is to follow the same boundaries the implementation uses. First confirm that startup sees a cached newer version through the existing update-state logic. Then confirm that install-source detection produces an `UpdateAction`. After that, the TUI decision point is whether `run_update_prompt_if_needed()` returns `Continue` or `RunUpdate`. Once the updater path begins, the user-visible output is intentionally unchanged: the CLI still prints the exact updater command it is running and the same success or failure messaging it already used for manual updates.

The end-to-end PTY integration test documents that handoff explicitly by seeding cached version state, putting a fake `npm` first on `PATH`, running the real `codex` binary, and asserting both the visible update message and the exact working directory and argv used for the updater process.

## Tests

The change is covered at three levels. `just write-config-schema` and `just fmt` keep the config surface and Rust formatting in sync. `cargo test -p codex-tui` and `cargo test -p codex-cli` both pass and cover the changed crates, with the CLI suite including the release-only `auto_update_startup` integration test as part of the test target even though it is intentionally ignored in debug builds. `cargo test -p codex-core` still fails on an unrelated pre-existing test, `tools::js_repl::tests::js_repl_can_attach_image_via_view_image_tool`, and this PR does not touch that area.
