### PR TITLE
Propagate session ID when compacting

### DIFF
--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -315,7 +315,10 @@ impl ModelClient {
             instructions: &instructions,
         };
 
-        let extra_headers = self.build_subagent_headers();
+        let mut extra_headers = self.build_subagent_headers();
+        extra_headers.extend(build_conversation_headers(Some(
+            self.state.conversation_id.to_string(),
+        )));
         client
             .compact_input(&payload, extra_headers)
             .await

--- a/codex-rs/core/tests/suite/compact_remote.rs
+++ b/codex-rs/core/tests/suite/compact_remote.rs
@@ -244,7 +244,10 @@ async fn remote_compact_runs_automatically() -> Result<()> {
     assert!(message);
     assert_eq!(compact_mock.requests().len(), 1);
     assert_eq!(
-        compact_mock.single_request().header("session_id").as_deref(),
+        compact_mock
+            .single_request()
+            .header("session_id")
+            .as_deref(),
         Some(session_id.as_str())
     );
     let follow_up_request = responses_mock.single_request();

--- a/codex-rs/core/tests/suite/compact_remote.rs
+++ b/codex-rs/core/tests/suite/compact_remote.rs
@@ -77,6 +77,7 @@ async fn remote_compact_replaces_history_for_followups() -> Result<()> {
     )
     .await?;
     let codex = harness.test().codex.clone();
+    let session_id = harness.test().session_configured.session_id.to_string();
 
     let responses_mock = responses::mount_sse_sequence(
         harness.server(),
@@ -137,6 +138,10 @@ async fn remote_compact_replaces_history_for_followups() -> Result<()> {
         compact_request.header("authorization").as_deref(),
         Some("Bearer Access Token")
     );
+    assert_eq!(
+        compact_request.header("session_id").as_deref(),
+        Some(session_id.as_str())
+    );
     let compact_body = compact_request.body_json();
     assert_eq!(
         compact_body.get("model").and_then(|v| v.as_str()),
@@ -195,6 +200,7 @@ async fn remote_compact_runs_automatically() -> Result<()> {
     )
     .await?;
     let codex = harness.test().codex.clone();
+    let session_id = harness.test().session_configured.session_id.to_string();
 
     mount_sse_once(
         harness.server(),
@@ -237,6 +243,10 @@ async fn remote_compact_runs_automatically() -> Result<()> {
     wait_for_event(&codex, |event| matches!(event, EventMsg::TurnComplete(_))).await;
     assert!(message);
     assert_eq!(compact_mock.requests().len(), 1);
+    assert_eq!(
+        compact_mock.single_request().header("session_id").as_deref(),
+        Some(session_id.as_str())
+    );
     let follow_up_request = responses_mock.single_request();
     let follow_up_body = follow_up_request.body_json().to_string();
     assert!(follow_up_body.contains("REMOTE_COMPACTED_SUMMARY"));


### PR DESCRIPTION
We propagate the session ID when sending requests for inference but we don't do the same for compaction requests. This makes it hard to link compaction requests to their session for debugging purposes
