### PR TITLE
Add simple realtime text logs

### DIFF
--- a/codex-rs/core/src/realtime_conversation.rs
+++ b/codex-rs/core/src/realtime_conversation.rs
@@ -218,7 +218,7 @@ pub(crate) async fn handle_start(
                 _ => None,
             };
             if let Some(text) = maybe_routed_text {
-                debug!(text = %text, "[realtime-text] Text output: extracted realtime conversation text output");
+                debug!(text = %text, "[realtime-text] realtime conversation text output");
                 let sess_for_routed_text = Arc::clone(&sess_clone);
                 sess_for_routed_text.route_realtime_text_input(text).await;
             }
@@ -281,7 +281,7 @@ pub(crate) async fn handle_text(
     sub_id: String,
     params: ConversationTextParams,
 ) {
-    debug!(text = %params.text, "[realtime-text] Text input: appending realtime conversation text input");
+    debug!(text = %params.text, "[realtime-text] appending realtime conversation text input");
 
     if let Err(err) = sess.conversation.text_in(params.text).await {
         send_conversation_error(sess, sub_id, err.to_string(), CodexErrorInfo::BadRequest).await;

--- a/codex-rs/core/src/realtime_conversation.rs
+++ b/codex-rs/core/src/realtime_conversation.rs
@@ -36,7 +36,6 @@ use tracing::warn;
 const AUDIO_IN_QUEUE_CAPACITY: usize = 256;
 const TEXT_IN_QUEUE_CAPACITY: usize = 64;
 const OUTPUT_EVENTS_QUEUE_CAPACITY: usize = 256;
-const REALTIME_TEXT_LOG_TARGET: &str = "codex.realtime.text";
 
 pub(crate) struct RealtimeConversationManager {
     state: Mutex<Option<ConversationState>>,
@@ -220,7 +219,6 @@ pub(crate) async fn handle_start(
             };
             if let Some(text) = maybe_routed_text {
                 debug!(
-                    target: REALTIME_TEXT_LOG_TARGET,
                     "[realtime-text-out] extracted realtime conversation text output"
                 );
                 let sess_for_routed_text = Arc::clone(&sess_clone);
@@ -286,11 +284,6 @@ pub(crate) async fn handle_text(
     params: ConversationTextParams,
 ) {
     debug!(
-        target: REALTIME_TEXT_LOG_TARGET,
-        direction = "in",
-        thread_id = %sess.conversation_id,
-        sub_id = %sub_id,
-        text_len = params.text.len(),
         "[realtime-text-in] appending realtime conversation text input"
     );
 

--- a/codex-rs/core/src/realtime_conversation.rs
+++ b/codex-rs/core/src/realtime_conversation.rs
@@ -218,7 +218,7 @@ pub(crate) async fn handle_start(
                 _ => None,
             };
             if let Some(text) = maybe_routed_text {
-                debug!("[realtime-text] Text output: extracted realtime conversation text output");
+                debug!(text = %text, "[realtime-text] Text output: extracted realtime conversation text output");
                 let sess_for_routed_text = Arc::clone(&sess_clone);
                 sess_for_routed_text.route_realtime_text_input(text).await;
             }
@@ -281,7 +281,7 @@ pub(crate) async fn handle_text(
     sub_id: String,
     params: ConversationTextParams,
 ) {
-    debug!("[realtime-text] Text input: appending realtime conversation text input");
+    debug!(text = %params.text, "[realtime-text] Text input: appending realtime conversation text input");
 
     if let Err(err) = sess.conversation.text_in(params.text).await {
         send_conversation_error(sess, sub_id, err.to_string(), CodexErrorInfo::BadRequest).await;

--- a/codex-rs/core/src/realtime_conversation.rs
+++ b/codex-rs/core/src/realtime_conversation.rs
@@ -218,9 +218,7 @@ pub(crate) async fn handle_start(
                 _ => None,
             };
             if let Some(text) = maybe_routed_text {
-                debug!(
-                    "[realtime-text-out] extracted realtime conversation text output"
-                );
+                debug!("[realtime-text-out] extracted realtime conversation text output");
                 let sess_for_routed_text = Arc::clone(&sess_clone);
                 sess_for_routed_text.route_realtime_text_input(text).await;
             }
@@ -283,9 +281,7 @@ pub(crate) async fn handle_text(
     sub_id: String,
     params: ConversationTextParams,
 ) {
-    debug!(
-        "[realtime-text-in] appending realtime conversation text input"
-    );
+    debug!("[realtime-text-in] appending realtime conversation text input");
 
     if let Err(err) = sess.conversation.text_in(params.text).await {
         send_conversation_error(sess, sub_id, err.to_string(), CodexErrorInfo::BadRequest).await;

--- a/codex-rs/core/src/realtime_conversation.rs
+++ b/codex-rs/core/src/realtime_conversation.rs
@@ -218,7 +218,7 @@ pub(crate) async fn handle_start(
                 _ => None,
             };
             if let Some(text) = maybe_routed_text {
-                debug!("[realtime-text-out] extracted realtime conversation text output");
+                debug!("[realtime-text] Text output: extracted realtime conversation text output");
                 let sess_for_routed_text = Arc::clone(&sess_clone);
                 sess_for_routed_text.route_realtime_text_input(text).await;
             }
@@ -281,7 +281,7 @@ pub(crate) async fn handle_text(
     sub_id: String,
     params: ConversationTextParams,
 ) {
-    debug!("[realtime-text-in] appending realtime conversation text input");
+    debug!("[realtime-text] Text input: appending realtime conversation text input");
 
     if let Err(err) = sess.conversation.text_in(params.text).await {
         send_conversation_error(sess, sub_id, err.to_string(), CodexErrorInfo::BadRequest).await;


### PR DESCRIPTION
Update realtime debug logs to include the actual text payloads in both input and output paths.

- In `core/src/realtime_conversation.rs`:
  - `handle_start`: add extracted assistant text output to the `[realtime-text]` debug log.
  - `handle_text`: add incoming text input (`params.text`) to the `[realtime-text]` debug log.

No tests were run (per request).
