### PR TITLE
Fix MCP OAuth refresh-token races across Codex processes

### DIFF
--- a/codex-rs/rmcp-client/src/rmcp_client.rs
+++ b/codex-rs/rmcp-client/src/rmcp_client.rs
@@ -361,6 +361,12 @@ impl RmcpClient {
             }
         };
 
+        if let Some(runtime) = &oauth_persistor
+            && let Err(error) = runtime.refresh_if_needed().await
+        {
+            warn!("failed to refresh OAuth tokens before initialize: {error}");
+        }
+
         let service = match timeout {
             Some(duration) => time::timeout(duration, transport)
                 .await


### PR DESCRIPTION
Addresses https://github.com/openai/codex/issues/12755

Token refresh for MCP OAuth suffered from the same problem that our main Codex ChatGPT auth had until recently. This PR updates the MCP logic to mirror the solution in place for ChatGPT auth token refresh.

MCP OAuth credentials are shared across processes via keyring or
`CODEX_HOME/.credentials.json`, but each process kept its own in-memory
snapshot and refreshed from that local copy. That meant one process could
rotate the refresh token while another still tried to use the stale token,
causing `refresh_token_reused` failures.

This changes the MCP refresh path to use a guarded reload flow modeled on
the main ChatGPT auth fix:
- reload shared MCP OAuth credentials before any refresh attempt
- compare persisted credentials to the in-memory cached snapshot with
  refresh-specific equality
- if persisted credentials changed, adopt them into the live RMCP auth runtime
  and skip the local refresh
- if persisted credentials are unchanged, perform the refresh and persist the
  rotated credentials
- if persisted credentials are missing, treat that as logged out and clear the
  live runtime auth instead of using a stale refresh token

To keep the running RMCP auth stack in sync without reconnecting, the client
now owns the `AuthorizationManager` credential store and can update the live
runtime in place when reloaded credentials win.

Also adds:
- unit tests for guarded reload decision logic in `codex-rs/rmcp-client/src/oauth.rs`
- an end-to-end two-client integration test in
  `codex-rs/core/tests/suite/rmcp_client.rs`
- refresh-token support in the streamable HTTP MCP test server fixture
