### PR TITLE
Add realtime audio device picker

### DIFF
--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -277,6 +277,32 @@
         }
       ]
     },
+    "BidiAudioToml": {
+      "additionalProperties": false,
+      "properties": {
+        "microphone": {
+          "type": "string"
+        },
+        "speaker": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "BidiToml": {
+      "additionalProperties": false,
+      "properties": {
+        "audio": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/BidiAudioToml"
+            }
+          ],
+          "default": null
+        }
+      },
+      "type": "object"
+    },
     "ConfigProfile": {
       "additionalProperties": false,
       "description": "Collection of common configuration options that a user can define as a unit in `config.toml`.",
@@ -1540,6 +1566,15 @@
       "format": "uint64",
       "minimum": 0.0,
       "type": "integer"
+    },
+    "bidi": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/BidiToml"
+        }
+      ],
+      "default": null,
+      "description": "Machine-local bidi audio device preferences used by realtime voice."
     },
     "chatgpt_base_url": {
       "description": "Base URL for requests to ChatGPT (as opposed to the OpenAI API).",

--- a/codex-rs/core/src/config/edit.rs
+++ b/codex-rs/core/src/config/edit.rs
@@ -839,6 +839,38 @@ impl ConfigEditsBuilder {
         self
     }
 
+    pub fn set_bidi_microphone(mut self, microphone: Option<&str>) -> Self {
+        let segments = vec![
+            "bidi".to_string(),
+            "audio".to_string(),
+            "microphone".to_string(),
+        ];
+        match microphone {
+            Some(microphone) => self.edits.push(ConfigEdit::SetPath {
+                segments,
+                value: value(microphone),
+            }),
+            None => self.edits.push(ConfigEdit::ClearPath { segments }),
+        }
+        self
+    }
+
+    pub fn set_bidi_speaker(mut self, speaker: Option<&str>) -> Self {
+        let segments = vec![
+            "bidi".to_string(),
+            "audio".to_string(),
+            "speaker".to_string(),
+        ];
+        match speaker {
+            Some(speaker) => self.edits.push(ConfigEdit::SetPath {
+                segments,
+                value: value(speaker),
+            }),
+            None => self.edits.push(ConfigEdit::ClearPath { segments }),
+        }
+        self
+    }
+
     pub fn clear_legacy_windows_sandbox_keys(mut self) -> Self {
         for key in [
             "experimental_windows_sandbox",
@@ -1802,6 +1834,54 @@ model_reasoning_effort = "high"
             .and_then(|tbl| tbl.get("hide_full_access_warning"))
             .and_then(toml::Value::as_bool);
         assert_eq!(notice, Some(true));
+    }
+
+    #[test]
+    fn blocking_builder_set_bidi_audio_persists_and_clears() {
+        let tmp = tempdir().expect("tmpdir");
+        let codex_home = tmp.path();
+
+        ConfigEditsBuilder::new(codex_home)
+            .set_bidi_microphone(Some("USB Mic"))
+            .set_bidi_speaker(Some("Desk Speakers"))
+            .apply_blocking()
+            .expect("persist bidi audio");
+
+        let raw = std::fs::read_to_string(codex_home.join(CONFIG_TOML_FILE)).expect("read config");
+        let config: TomlValue = toml::from_str(&raw).expect("parse config");
+        let bidi_audio = config
+            .get("bidi")
+            .and_then(TomlValue::as_table)
+            .and_then(|bidi| bidi.get("audio"))
+            .and_then(TomlValue::as_table)
+            .expect("bidi.audio table should exist");
+        assert_eq!(
+            bidi_audio.get("microphone").and_then(TomlValue::as_str),
+            Some("USB Mic")
+        );
+        assert_eq!(
+            bidi_audio.get("speaker").and_then(TomlValue::as_str),
+            Some("Desk Speakers")
+        );
+
+        ConfigEditsBuilder::new(codex_home)
+            .set_bidi_microphone(None)
+            .apply_blocking()
+            .expect("clear bidi microphone");
+
+        let raw = std::fs::read_to_string(codex_home.join(CONFIG_TOML_FILE)).expect("read config");
+        let config: TomlValue = toml::from_str(&raw).expect("parse config");
+        let bidi_audio = config
+            .get("bidi")
+            .and_then(TomlValue::as_table)
+            .and_then(|bidi| bidi.get("audio"))
+            .and_then(TomlValue::as_table)
+            .expect("bidi.audio table should exist");
+        assert_eq!(bidi_audio.get("microphone"), None);
+        assert_eq!(
+            bidi_audio.get("speaker").and_then(TomlValue::as_str),
+            Some("Desk Speakers")
+        );
     }
 
     #[test]

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -30,6 +30,29 @@ use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::SandboxPolicy;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BidiAudioDeviceKind {
+    Microphone,
+    Speaker,
+}
+
+impl BidiAudioDeviceKind {
+    pub(crate) fn title(self) -> &'static str {
+        match self {
+            Self::Microphone => "Microphone",
+            Self::Speaker => "Speaker",
+        }
+    }
+
+    #[cfg(all(not(target_os = "linux"), feature = "voice-input"))]
+    pub(crate) fn noun(self) -> &'static str {
+        match self {
+            Self::Microphone => "microphone",
+            Self::Speaker => "speaker",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
 pub(crate) enum WindowsSandboxEnableMode {
     Elevated,
@@ -164,6 +187,24 @@ pub(crate) enum AppEvent {
     /// Persist the selected personality to the appropriate config.
     PersistPersonalitySelection {
         personality: Personality,
+    },
+
+    /// Open the device picker for a realtime microphone or speaker.
+    OpenBidiAudioDeviceSelection {
+        kind: BidiAudioDeviceKind,
+    },
+
+    /// Persist the selected realtime microphone or speaker to top-level config.
+    #[cfg(all(not(target_os = "linux"), feature = "voice-input"))]
+    PersistBidiAudioDeviceSelection {
+        kind: BidiAudioDeviceKind,
+        name: Option<String>,
+    },
+
+    /// Restart the selected realtime microphone or speaker locally.
+    #[cfg(all(not(target_os = "linux"), feature = "voice-input"))]
+    RestartBidiAudioDevice {
+        kind: BidiAudioDeviceKind,
     },
 
     /// Open the reasoning selection popup after picking a model.

--- a/codex-rs/tui/src/audio_device.rs
+++ b/codex-rs/tui/src/audio_device.rs
@@ -1,0 +1,122 @@
+use codex_core::config::Config;
+use cpal::traits::DeviceTrait;
+use cpal::traits::HostTrait;
+use tracing::warn;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AudioDeviceKind {
+    Input,
+    Output,
+}
+
+impl AudioDeviceKind {
+    fn noun(self) -> &'static str {
+        match self {
+            Self::Input => "input",
+            Self::Output => "output",
+        }
+    }
+
+    fn configured_name(self, config: &Config) -> Option<&str> {
+        match self {
+            Self::Input => config.bidi_audio.microphone.as_deref(),
+            Self::Output => config.bidi_audio.speaker.as_deref(),
+        }
+    }
+}
+
+pub(crate) fn select_configured_input_device_and_config(
+    config: &Config,
+) -> Result<(cpal::Device, cpal::SupportedStreamConfig), String> {
+    select_device_and_config(AudioDeviceKind::Input, config)
+}
+
+pub(crate) fn select_configured_output_device_and_config(
+    config: &Config,
+) -> Result<(cpal::Device, cpal::SupportedStreamConfig), String> {
+    select_device_and_config(AudioDeviceKind::Output, config)
+}
+
+fn select_device_and_config(
+    kind: AudioDeviceKind,
+    config: &Config,
+) -> Result<(cpal::Device, cpal::SupportedStreamConfig), String> {
+    let host = cpal::default_host();
+    let configured_name = kind.configured_name(config);
+    let selected = configured_name
+        .and_then(|name| find_device_by_name(&host, kind, name))
+        .or_else(|| {
+            let default_device = default_device(&host, kind);
+            if let Some(name) = configured_name
+                && default_device.is_some()
+            {
+                warn!(
+                    "configured {} audio device `{name}` was unavailable; falling back to system default",
+                    kind.noun()
+                );
+            }
+            default_device
+        })
+        .ok_or_else(|| missing_device_error(kind, configured_name))?;
+
+    let stream_config = default_config(&selected, kind)?;
+    Ok((selected, stream_config))
+}
+
+fn find_device_by_name(
+    host: &cpal::Host,
+    kind: AudioDeviceKind,
+    name: &str,
+) -> Option<cpal::Device> {
+    let devices = devices(host, kind).ok()?;
+    devices
+        .into_iter()
+        .find(|device| device.name().ok().as_deref() == Some(name))
+}
+
+fn devices(host: &cpal::Host, kind: AudioDeviceKind) -> Result<Vec<cpal::Device>, String> {
+    match kind {
+        AudioDeviceKind::Input => host
+            .input_devices()
+            .map(|devices| devices.collect())
+            .map_err(|err| format!("failed to enumerate input audio devices: {err}")),
+        AudioDeviceKind::Output => host
+            .output_devices()
+            .map(|devices| devices.collect())
+            .map_err(|err| format!("failed to enumerate output audio devices: {err}")),
+    }
+}
+
+fn default_device(host: &cpal::Host, kind: AudioDeviceKind) -> Option<cpal::Device> {
+    match kind {
+        AudioDeviceKind::Input => host.default_input_device(),
+        AudioDeviceKind::Output => host.default_output_device(),
+    }
+}
+
+fn default_config(
+    device: &cpal::Device,
+    kind: AudioDeviceKind,
+) -> Result<cpal::SupportedStreamConfig, String> {
+    match kind {
+        AudioDeviceKind::Input => device
+            .default_input_config()
+            .map_err(|err| format!("failed to get default input config: {err}")),
+        AudioDeviceKind::Output => device
+            .default_output_config()
+            .map_err(|err| format!("failed to get default output config: {err}")),
+    }
+}
+
+fn missing_device_error(kind: AudioDeviceKind, configured_name: Option<&str>) -> String {
+    match (kind, configured_name) {
+        (AudioDeviceKind::Input, Some(name)) => format!(
+            "configured input audio device `{name}` was unavailable and no default input audio device was found"
+        ),
+        (AudioDeviceKind::Output, Some(name)) => format!(
+            "configured output audio device `{name}` was unavailable and no default output audio device was found"
+        ),
+        (AudioDeviceKind::Input, None) => "no input audio device available".to_string(),
+        (AudioDeviceKind::Output, None) => "no output audio device available".to_string(),
+    }
+}

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -390,6 +390,7 @@ pub(crate) struct ChatComposer {
     connectors_enabled: bool,
     personality_command_enabled: bool,
     realtime_conversation_enabled: bool,
+    audio_device_selection_enabled: bool,
     windows_degraded_sandbox_active: bool,
     status_line_value: Option<Line<'static>>,
     status_line_enabled: bool,
@@ -496,6 +497,7 @@ impl ChatComposer {
             connectors_enabled: false,
             personality_command_enabled: false,
             realtime_conversation_enabled: false,
+            audio_device_selection_enabled: false,
             windows_degraded_sandbox_active: false,
             status_line_value: None,
             status_line_enabled: false,
@@ -582,6 +584,10 @@ impl ChatComposer {
 
     pub fn set_realtime_conversation_enabled(&mut self, enabled: bool) {
         self.realtime_conversation_enabled = enabled;
+    }
+
+    pub fn set_audio_device_selection_enabled(&mut self, enabled: bool) {
+        self.audio_device_selection_enabled = enabled;
     }
 
     pub fn set_voice_transcription_enabled(&mut self, enabled: bool) {
@@ -2267,6 +2273,7 @@ impl ChatComposer {
                     self.connectors_enabled,
                     self.personality_command_enabled,
                     self.realtime_conversation_enabled,
+                    self.audio_device_selection_enabled,
                     self.windows_degraded_sandbox_active,
                 )
                 .is_some();
@@ -2467,6 +2474,7 @@ impl ChatComposer {
                 self.connectors_enabled,
                 self.personality_command_enabled,
                 self.realtime_conversation_enabled,
+                self.audio_device_selection_enabled,
                 self.windows_degraded_sandbox_active,
             )
         {
@@ -2502,6 +2510,7 @@ impl ChatComposer {
             self.connectors_enabled,
             self.personality_command_enabled,
             self.realtime_conversation_enabled,
+            self.audio_device_selection_enabled,
             self.windows_degraded_sandbox_active,
         )?;
 
@@ -3335,6 +3344,7 @@ impl ChatComposer {
             self.connectors_enabled,
             self.personality_command_enabled,
             self.realtime_conversation_enabled,
+            self.audio_device_selection_enabled,
             self.windows_degraded_sandbox_active,
         )
         .is_some();
@@ -3397,6 +3407,7 @@ impl ChatComposer {
             self.connectors_enabled,
             self.personality_command_enabled,
             self.realtime_conversation_enabled,
+            self.audio_device_selection_enabled,
             self.windows_degraded_sandbox_active,
         ) {
             return true;
@@ -3451,6 +3462,7 @@ impl ChatComposer {
                     let connectors_enabled = self.connectors_enabled;
                     let personality_command_enabled = self.personality_command_enabled;
                     let realtime_conversation_enabled = self.realtime_conversation_enabled;
+                    let audio_device_selection_enabled = self.audio_device_selection_enabled;
                     let mut command_popup = CommandPopup::new(
                         self.custom_prompts.clone(),
                         CommandPopupFlags {
@@ -3458,6 +3470,7 @@ impl ChatComposer {
                             connectors_enabled,
                             personality_command_enabled,
                             realtime_conversation_enabled,
+                            audio_device_selection_enabled,
                             windows_degraded_sandbox_active: self.windows_degraded_sandbox_active,
                         },
                     );

--- a/codex-rs/tui/src/bottom_pane/command_popup.rs
+++ b/codex-rs/tui/src/bottom_pane/command_popup.rs
@@ -40,6 +40,7 @@ pub(crate) struct CommandPopupFlags {
     pub(crate) connectors_enabled: bool,
     pub(crate) personality_command_enabled: bool,
     pub(crate) realtime_conversation_enabled: bool,
+    pub(crate) audio_device_selection_enabled: bool,
     pub(crate) windows_degraded_sandbox_active: bool,
 }
 
@@ -51,6 +52,7 @@ impl CommandPopup {
             flags.connectors_enabled,
             flags.personality_command_enabled,
             flags.realtime_conversation_enabled,
+            flags.audio_device_selection_enabled,
             flags.windows_degraded_sandbox_active,
         )
         .into_iter()
@@ -498,6 +500,7 @@ mod tests {
                 connectors_enabled: false,
                 personality_command_enabled: true,
                 realtime_conversation_enabled: false,
+                audio_device_selection_enabled: false,
                 windows_degraded_sandbox_active: false,
             },
         );
@@ -518,6 +521,7 @@ mod tests {
                 connectors_enabled: false,
                 personality_command_enabled: true,
                 realtime_conversation_enabled: false,
+                audio_device_selection_enabled: false,
                 windows_degraded_sandbox_active: false,
             },
         );
@@ -538,6 +542,7 @@ mod tests {
                 connectors_enabled: false,
                 personality_command_enabled: false,
                 realtime_conversation_enabled: false,
+                audio_device_selection_enabled: false,
                 windows_degraded_sandbox_active: false,
             },
         );
@@ -566,6 +571,7 @@ mod tests {
                 connectors_enabled: false,
                 personality_command_enabled: true,
                 realtime_conversation_enabled: false,
+                audio_device_selection_enabled: false,
                 windows_degraded_sandbox_active: false,
             },
         );
@@ -575,6 +581,36 @@ mod tests {
             Some(CommandItem::Builtin(cmd)) => assert_eq!(cmd.command(), "personality"),
             other => panic!("expected personality to be selected for exact match, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn audio_command_hidden_when_audio_device_selection_is_disabled() {
+        let mut popup = CommandPopup::new(
+            Vec::new(),
+            CommandPopupFlags {
+                collaboration_modes_enabled: false,
+                connectors_enabled: false,
+                personality_command_enabled: true,
+                realtime_conversation_enabled: true,
+                audio_device_selection_enabled: false,
+                windows_degraded_sandbox_active: false,
+            },
+        );
+        popup.on_composer_text_change("/aud".to_string());
+
+        let cmds: Vec<&str> = popup
+            .filtered_items()
+            .into_iter()
+            .filter_map(|item| match item {
+                CommandItem::Builtin(cmd) => Some(cmd.command()),
+                CommandItem::UserPrompt(_) => None,
+            })
+            .collect();
+
+        assert!(
+            !cmds.contains(&"audio"),
+            "expected '/audio' to be hidden when audio device selection is disabled, got {cmds:?}"
+        );
     }
 
     #[test]

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -302,6 +302,11 @@ impl BottomPane {
         self.request_redraw();
     }
 
+    pub fn set_audio_device_selection_enabled(&mut self, enabled: bool) {
+        self.composer.set_audio_device_selection_enabled(enabled);
+        self.request_redraw();
+    }
+
     pub fn set_voice_transcription_enabled(&mut self, enabled: bool) {
         self.composer.set_voice_transcription_enabled(enabled);
         self.request_redraw();

--- a/codex-rs/tui/src/bottom_pane/slash_commands.rs
+++ b/codex-rs/tui/src/bottom_pane/slash_commands.rs
@@ -14,6 +14,7 @@ pub(crate) fn builtins_for_input(
     connectors_enabled: bool,
     personality_command_enabled: bool,
     realtime_conversation_enabled: bool,
+    audio_device_selection_enabled: bool,
     allow_elevate_sandbox: bool,
 ) -> Vec<(&'static str, SlashCommand)> {
     built_in_slash_commands()
@@ -26,6 +27,7 @@ pub(crate) fn builtins_for_input(
         .filter(|(_, cmd)| connectors_enabled || *cmd != SlashCommand::Apps)
         .filter(|(_, cmd)| personality_command_enabled || *cmd != SlashCommand::Personality)
         .filter(|(_, cmd)| realtime_conversation_enabled || *cmd != SlashCommand::Realtime)
+        .filter(|(_, cmd)| audio_device_selection_enabled || *cmd != SlashCommand::Audio)
         .collect()
 }
 
@@ -36,6 +38,7 @@ pub(crate) fn find_builtin_command(
     connectors_enabled: bool,
     personality_command_enabled: bool,
     realtime_conversation_enabled: bool,
+    audio_device_selection_enabled: bool,
     allow_elevate_sandbox: bool,
 ) -> Option<SlashCommand> {
     builtins_for_input(
@@ -43,6 +46,7 @@ pub(crate) fn find_builtin_command(
         connectors_enabled,
         personality_command_enabled,
         realtime_conversation_enabled,
+        audio_device_selection_enabled,
         allow_elevate_sandbox,
     )
     .into_iter()
@@ -57,6 +61,7 @@ pub(crate) fn has_builtin_prefix(
     connectors_enabled: bool,
     personality_command_enabled: bool,
     realtime_conversation_enabled: bool,
+    audio_device_selection_enabled: bool,
     allow_elevate_sandbox: bool,
 ) -> bool {
     builtins_for_input(
@@ -64,6 +69,7 @@ pub(crate) fn has_builtin_prefix(
         connectors_enabled,
         personality_command_enabled,
         realtime_conversation_enabled,
+        audio_device_selection_enabled,
         allow_elevate_sandbox,
     )
     .into_iter()
@@ -77,14 +83,14 @@ mod tests {
 
     #[test]
     fn debug_command_still_resolves_for_dispatch() {
-        let cmd = find_builtin_command("debug-config", true, true, true, false, false);
+        let cmd = find_builtin_command("debug-config", true, true, true, false, false, false);
         assert_eq!(cmd, Some(SlashCommand::DebugConfig));
     }
 
     #[test]
     fn clear_command_resolves_for_dispatch() {
         assert_eq!(
-            find_builtin_command("clear", true, true, true, false, false),
+            find_builtin_command("clear", true, true, true, false, false, false),
             Some(SlashCommand::Clear)
         );
     }
@@ -92,7 +98,23 @@ mod tests {
     #[test]
     fn realtime_command_is_hidden_when_realtime_is_disabled() {
         assert_eq!(
-            find_builtin_command("realtime", true, true, true, false, false),
+            find_builtin_command("realtime", true, true, true, false, true, false),
+            None
+        );
+    }
+
+    #[test]
+    fn audio_command_is_hidden_when_realtime_is_disabled() {
+        assert_eq!(
+            find_builtin_command("audio", true, true, true, false, false, false),
+            None
+        );
+    }
+
+    #[test]
+    fn audio_command_is_hidden_when_audio_device_selection_is_disabled() {
+        assert_eq!(
+            find_builtin_command("audio", true, true, true, true, false, false),
             None
         );
     }

--- a/codex-rs/tui/src/chatwidget/realtime.rs
+++ b/codex-rs/tui/src/chatwidget/realtime.rs
@@ -207,7 +207,7 @@ impl ChatWidget {
         {
             if self.realtime_conversation.audio_player.is_none() {
                 self.realtime_conversation.audio_player =
-                    crate::voice::RealtimeAudioPlayer::start().ok();
+                    crate::voice::RealtimeAudioPlayer::start(&self.config).ok();
             }
             if let Some(player) = &self.realtime_conversation.audio_player
                 && let Err(err) = player.enqueue_frame(frame)
@@ -231,7 +231,10 @@ impl ChatWidget {
         self.realtime_conversation.meter_placeholder_id = Some(placeholder_id.clone());
         self.request_redraw();
 
-        let capture = match crate::voice::VoiceCapture::start_realtime(self.app_event_tx.clone()) {
+        let capture = match crate::voice::VoiceCapture::start_realtime(
+            &self.config,
+            self.app_event_tx.clone(),
+        ) {
             Ok(capture) => capture,
             Err(err) => {
                 self.remove_transcription_placeholder(&placeholder_id);
@@ -250,7 +253,7 @@ impl ChatWidget {
         self.realtime_conversation.capture = Some(capture);
         if self.realtime_conversation.audio_player.is_none() {
             self.realtime_conversation.audio_player =
-                crate::voice::RealtimeAudioPlayer::start().ok();
+                crate::voice::RealtimeAudioPlayer::start(&self.config).ok();
         }
 
         std::thread::spawn(move || {

--- a/codex-rs/tui/src/chatwidget/realtime.rs
+++ b/codex-rs/tui/src/chatwidget/realtime.rs
@@ -278,8 +278,45 @@ impl ChatWidget {
     #[cfg(target_os = "linux")]
     fn start_realtime_local_audio(&mut self) {}
 
+    #[cfg(all(not(target_os = "linux"), feature = "voice-input"))]
+    pub(crate) fn restart_bidi_audio_device(&mut self, kind: BidiAudioDeviceKind) {
+        if !self.realtime_conversation.is_live() {
+            return;
+        }
+
+        match kind {
+            BidiAudioDeviceKind::Microphone => {
+                self.stop_realtime_microphone();
+                self.start_realtime_local_audio();
+            }
+            BidiAudioDeviceKind::Speaker => {
+                self.stop_realtime_speaker();
+                match crate::voice::RealtimeAudioPlayer::start(&self.config) {
+                    Ok(player) => {
+                        self.realtime_conversation.audio_player = Some(player);
+                    }
+                    Err(err) => {
+                        self.add_error_message(format!("Failed to start speaker output: {err}"));
+                    }
+                }
+            }
+        }
+        self.request_redraw();
+    }
+
     #[cfg(not(target_os = "linux"))]
     fn stop_realtime_local_audio(&mut self) {
+        self.stop_realtime_microphone();
+        self.stop_realtime_speaker();
+    }
+
+    #[cfg(target_os = "linux")]
+    fn stop_realtime_local_audio(&mut self) {
+        self.realtime_conversation.meter_placeholder_id = None;
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn stop_realtime_microphone(&mut self) {
         if let Some(flag) = self.realtime_conversation.capture_stop_flag.take() {
             flag.store(true, Ordering::Relaxed);
         }
@@ -289,13 +326,12 @@ impl ChatWidget {
         if let Some(id) = self.realtime_conversation.meter_placeholder_id.take() {
             self.remove_transcription_placeholder(&id);
         }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn stop_realtime_speaker(&mut self) {
         if let Some(player) = self.realtime_conversation.audio_player.take() {
             player.clear();
         }
-    }
-
-    #[cfg(target_os = "linux")]
-    fn stop_realtime_local_audio(&mut self) {
-        self.realtime_conversation.meter_placeholder_id = None;
     }
 }

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__bidi_audio_selection_popup.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__bidi_audio_selection_popup.snap
@@ -1,0 +1,11 @@
+---
+source: tui/src/chatwidget/tests.rs
+expression: popup
+---
+  Realtime audio
+  Choose microphone and speaker for realtime voice.
+
+› 1. Microphone  Current: System default
+  2. Speaker     Current: System default
+
+  Press enter to confirm or esc to go back

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__bidi_microphone_picker_popup.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__bidi_microphone_picker_popup.snap
@@ -1,0 +1,18 @@
+---
+source: tui/src/chatwidget/tests.rs
+expression: popup
+---
+  Select Microphone
+  Saved devices apply to realtime voice only.
+
+  1. System default                                Use your operating system
+                                                   default device.
+› 2. Unavailable: Studio Mic (current) (disabled)  Configured device is not
+                                                   currently available.
+                                                   (disabled: Reconnect the
+                                                   device or choose another
+                                                   one.)
+  3. Built-in Mic
+  4. USB Mic
+
+  Press enter to confirm or esc to go back

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -61,6 +61,8 @@ mod app_backtrack;
 mod app_event;
 mod app_event_sender;
 mod ascii_animation;
+#[cfg(all(not(target_os = "linux"), feature = "voice-input"))]
+mod audio_device;
 mod bottom_pane;
 mod chatwidget;
 mod cli;
@@ -121,6 +123,7 @@ mod voice;
 mod voice {
     use crate::app_event::AppEvent;
     use crate::app_event_sender::AppEventSender;
+    use codex_core::config::Config;
     use codex_protocol::protocol::RealtimeAudioFrame;
     use std::sync::Arc;
     use std::sync::Mutex;
@@ -144,7 +147,7 @@ mod voice {
             Err("voice input is unavailable in this build".to_string())
         }
 
-        pub fn start_realtime(_tx: AppEventSender) -> Result<Self, String> {
+        pub fn start_realtime(_config: &Config, _tx: AppEventSender) -> Result<Self, String> {
             Err("voice input is unavailable in this build".to_string())
         }
 
@@ -184,7 +187,7 @@ mod voice {
     }
 
     impl RealtimeAudioPlayer {
-        pub(crate) fn start() -> Result<Self, String> {
+        pub(crate) fn start(_config: &Config) -> Result<Self, String> {
             Err("voice output is unavailable in this build".to_string())
         }
 

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -51,6 +51,7 @@ pub enum SlashCommand {
     Clear,
     Personality,
     Realtime,
+    Audio,
     TestApproval,
     // Debugging commands.
     #[strum(serialize = "debug-m-drop")]
@@ -89,6 +90,7 @@ impl SlashCommand {
             SlashCommand::Model => "choose what model and reasoning effort to use",
             SlashCommand::Personality => "choose a communication style for Codex",
             SlashCommand::Realtime => "toggle realtime voice mode (experimental)",
+            SlashCommand::Audio => "select microphone/speaker for realtime voice",
             SlashCommand::Plan => "switch to Plan mode",
             SlashCommand::Collab => "change collaboration mode (experimental)",
             SlashCommand::Agent => "switch the active agent thread",
@@ -163,6 +165,7 @@ impl SlashCommand {
             SlashCommand::Rollout => true,
             SlashCommand::TestApproval => true,
             SlashCommand::Realtime => true,
+            SlashCommand::Audio => true,
             SlashCommand::Collab => true,
             SlashCommand::Agent => true,
             SlashCommand::Statusline => false,


### PR DESCRIPTION
## Summary
- add a dedicated /audio picker for realtime microphone and speaker selection
- persist realtime audio choices and prompt to restart only local audio when voice is live
- add snapshot coverage for the new picker surfaces

## Validation
- cargo test -p codex-tui
- cargo insta accept
- just fix -p codex-tui
- just fmt
