### PR TITLE
feat(tui): rerender scrollback on terminal resize (feature-flag)

### DIFF
--- a/codex-rs/core/src/features.rs
+++ b/codex-rs/core/src/features.rs
@@ -152,6 +152,8 @@ pub enum Feature {
     ResponsesWebsockets,
     /// Enable Responses API websocket v2 mode.
     ResponsesWebsocketsV2,
+    /// Preserve scrollback history across terminal resizes in inline mode.
+    ScrollbackPreserve,
 }
 
 impl Feature {
@@ -691,6 +693,16 @@ pub const FEATURES: &[FeatureSpec] = &[
         id: Feature::ResponsesWebsocketsV2,
         key: "responses_websockets_v2",
         stage: Stage::UnderDevelopment,
+        default_enabled: false,
+    },
+    FeatureSpec {
+        id: Feature::ScrollbackPreserve,
+        key: "scrollback_preserve",
+        stage: Stage::Experimental {
+            name: "Scrollback preserve",
+            menu_description: "Preserve conversation scrollback across terminal resizes in inline (non-alt-screen) mode. Clears pre-session history on resize.",
+            announcement: "NEW: Scrollback preserve fixes ghost lines on terminal resize. Enable in /experimental.",
+        },
         default_enabled: false,
     },
 ];

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -827,6 +827,11 @@ async fn run_ratatui_app(
 
     let use_alt_screen = determine_alt_screen_mode(no_alt_screen, config.tui_alternate_screen);
     tui.set_alt_screen_enabled(use_alt_screen);
+    tui.set_scrollback_preserve(
+        config
+            .features
+            .enabled(codex_core::features::Feature::ScrollbackPreserve),
+    );
 
     let app_result = App::run(
         &mut tui,


### PR DESCRIPTION
# Description

Fixes https://github.com/openai/codex/issues/5259 and is behind a feature flag.

for no-alt-screen (which is the default behavior rn), this clears scrollback and re-renders when you resize the terminal.

Tested on `alacritty, archlinux/kde-wayland`

Enable with `scrollback_preserve = true` in the `[features]`, `config.toml`.

Before:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/3f1e3076-0ecb-439b-bc55-268f6a2b390f" />

After:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/a1755625-8bc0-43c5-8070-15395b15c980" />

--

I have read the CLA Document and I hereby sign the CLA