### PR TITLE
Add sgp-proxy crate: Agentex <-> Responses API translation proxy

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -2215,6 +2215,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-sgp-proxy"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "bytes",
+ "clap",
+ "codex-process-hardening",
+ "ctor 0.6.3",
+ "futures",
+ "libc",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "uuid",
+ "zeroize",
+]
+
+[[package]]
 name = "codex-shell-command"
 version = "0.0.0"
 dependencies = [

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -37,6 +37,7 @@ members = [
     "protocol",
     "rmcp-client",
     "responses-api-proxy",
+    "sgp-proxy",
     "stdio-to-uds",
     "otel",
     "tui",
@@ -110,6 +111,7 @@ codex-otel = { path = "otel" }
 codex-process-hardening = { path = "process-hardening" }
 codex-protocol = { path = "protocol" }
 codex-responses-api-proxy = { path = "responses-api-proxy" }
+codex-sgp-proxy = { path = "sgp-proxy" }
 codex-rmcp-client = { path = "rmcp-client" }
 codex-secrets = { path = "secrets" }
 codex-shell-command = { path = "shell-command" }

--- a/codex-rs/sgp-proxy/Cargo.toml
+++ b/codex-rs/sgp-proxy/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "codex-sgp-proxy"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+name = "codex_sgp_proxy"
+path = "src/lib.rs"
+
+[[bin]]
+name = "codex-sgp-proxy"
+path = "src/main.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+axum = { workspace = true, features = ["tokio", "http1"] }
+bytes = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+codex-process-hardening = { workspace = true }
+ctor = { workspace = true }
+futures = { workspace = true, features = ["std", "async-await"] }
+libc = { workspace = true }
+reqwest = { workspace = true, features = ["json", "stream", "rustls-tls"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+tokio-stream = { workspace = true }
+tracing = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
+zeroize = { workspace = true }

--- a/codex-rs/sgp-proxy/src/agentex_client.rs
+++ b/codex-rs/sgp-proxy/src/agentex_client.rs
@@ -1,0 +1,220 @@
+use futures::Stream;
+use futures::StreamExt;
+use reqwest::Client;
+use reqwest::header::AUTHORIZATION;
+use reqwest::header::HeaderValue;
+use tokio_stream::wrappers::ReceiverStream;
+
+use crate::error::AgentexError;
+use crate::translate::types::CreateTaskParams;
+use crate::translate::types::JsonRpcRequest;
+use crate::translate::types::JsonRpcResponse;
+use crate::translate::types::MessageSendParams;
+use crate::translate::types::MessageSendResult;
+use crate::translate::types::Task;
+use crate::translate::types::TaskMessageUpdate;
+
+/// HTTP client for Agentex JSON-RPC endpoints.
+pub struct AgentexClient {
+    client: Client,
+    base_url: String,
+    auth_header: &'static str,
+}
+
+impl AgentexClient {
+    pub fn new(base_url: String, auth_header: &'static str) -> Self {
+        let client = Client::builder()
+            .build()
+            .unwrap_or_default();
+
+        Self {
+            client,
+            base_url,
+            auth_header,
+        }
+    }
+
+    fn rpc_url(&self) -> String {
+        format!("{}/rpc", self.base_url.trim_end_matches('/'))
+    }
+
+    fn auth_value(&self) -> HeaderValue {
+        let mut v = HeaderValue::from_static(self.auth_header);
+        v.set_sensitive(true);
+        v
+    }
+
+    /// Create a new task on the Agentex agent.
+    pub async fn task_create(
+        &self,
+        name: &str,
+        agent_id: &str,
+    ) -> Result<String, AgentexError> {
+        let rpc = JsonRpcRequest::new(
+            uuid::Uuid::new_v4().to_string(),
+            "task/create",
+            CreateTaskParams {
+                name: name.to_string(),
+                agent_id: agent_id.to_string(),
+            },
+        );
+
+        let resp = self
+            .client
+            .post(self.rpc_url())
+            .header(AUTHORIZATION, self.auth_value())
+            .json(&rpc)
+            .send()
+            .await?;
+
+        let body: JsonRpcResponse<Task> = resp.json().await?;
+
+        if let Some(err) = body.error {
+            return Err(AgentexError::Rpc {
+                code: err.code,
+                message: err.message,
+            });
+        }
+
+        body.result
+            .map(|t| t.id)
+            .ok_or_else(|| AgentexError::Parse("missing result in task/create response".into()))
+    }
+
+    /// Send a message and receive the full response (non-streaming).
+    pub async fn message_send(
+        &self,
+        params: MessageSendParams,
+    ) -> Result<MessageSendResult, AgentexError> {
+        let rpc = JsonRpcRequest::new(
+            uuid::Uuid::new_v4().to_string(),
+            "message/send",
+            params,
+        );
+
+        let resp = self
+            .client
+            .post(self.rpc_url())
+            .header(AUTHORIZATION, self.auth_value())
+            .json(&rpc)
+            .send()
+            .await?;
+
+        let body: JsonRpcResponse<MessageSendResult> = resp.json().await?;
+
+        if let Some(err) = body.error {
+            return Err(AgentexError::Rpc {
+                code: err.code,
+                message: err.message,
+            });
+        }
+
+        body.result.ok_or_else(|| {
+            AgentexError::Parse("missing result in message/send response".into())
+        })
+    }
+
+    /// Send a message and receive a stream of `TaskMessageUpdate` events.
+    ///
+    /// The implementation handles both NDJSON and SSE-style `data:` prefixed
+    /// lines from the response body, accommodating either Agentex wire format.
+    pub async fn message_send_stream(
+        &self,
+        params: MessageSendParams,
+    ) -> Result<impl Stream<Item = Result<TaskMessageUpdate, AgentexError>> + Send + 'static, AgentexError> {
+        let rpc = JsonRpcRequest::new(
+            uuid::Uuid::new_v4().to_string(),
+            "message/send",
+            params,
+        );
+
+        let resp = self
+            .client
+            .post(self.rpc_url())
+            .header(AUTHORIZATION, self.auth_value())
+            .json(&rpc)
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            return Err(AgentexError::Stream(format!(
+                "HTTP {status}: {text}"
+            )));
+        }
+
+        let mut byte_stream = resp.bytes_stream();
+        let (tx, rx) = tokio::sync::mpsc::channel::<Result<TaskMessageUpdate, AgentexError>>(64);
+
+        tokio::spawn(async move {
+            let mut line_buf = String::new();
+
+            while let Some(chunk_result) = byte_stream.next().await {
+                let chunk = match chunk_result {
+                    Ok(c) => c,
+                    Err(e) => {
+                        let _ = tx.send(Err(AgentexError::Http(e))).await;
+                        return;
+                    }
+                };
+
+                let text = match std::str::from_utf8(&chunk) {
+                    Ok(t) => t,
+                    Err(e) => {
+                        let _ = tx
+                            .send(Err(AgentexError::Parse(format!("invalid UTF-8: {e}"))))
+                            .await;
+                        return;
+                    }
+                };
+
+                line_buf.push_str(text);
+
+                // Process complete lines.
+                while let Some(newline_pos) = line_buf.find('\n') {
+                    let line: String = line_buf.drain(..=newline_pos).collect();
+                    let line = line.trim();
+
+                    if line.is_empty() {
+                        continue;
+                    }
+
+                    // Handle SSE `data: {...}` or raw NDJSON `{...}`.
+                    let json_str = line.strip_prefix("data:").map(str::trim).unwrap_or(line);
+
+                    // Skip SSE event-type lines like `event: ...`
+                    if json_str.starts_with("event:") {
+                        continue;
+                    }
+
+                    match serde_json::from_str::<TaskMessageUpdate>(json_str) {
+                        Ok(update) => {
+                            if tx.send(Ok(update)).await.is_err() {
+                                return;
+                            }
+                        }
+                        Err(e) => {
+                            // Skip lines that don't parse (e.g., SSE comments).
+                            tracing::debug!("skipping unparseable stream line: {e}");
+                        }
+                    }
+                }
+            }
+
+            // Process any remaining data in the buffer.
+            let remaining = line_buf.trim();
+            if !remaining.is_empty() {
+                let json_str = remaining
+                    .strip_prefix("data:")
+                    .map(str::trim)
+                    .unwrap_or(remaining);
+                if let Ok(update) = serde_json::from_str::<TaskMessageUpdate>(json_str) {
+                    let _ = tx.send(Ok(update)).await;
+                }
+            }
+        });
+
+        Ok(ReceiverStream::new(rx))
+    }
+}

--- a/codex-rs/sgp-proxy/src/config.rs
+++ b/codex-rs/sgp-proxy/src/config.rs
@@ -1,0 +1,52 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+use clap::ValueEnum;
+
+/// CLI arguments for the SGP proxy.
+#[derive(Debug, Clone, Parser)]
+#[command(
+    name = "codex-sgp-proxy",
+    about = "Translation proxy: Responses API <-> Agentex JSON-RPC"
+)]
+pub struct Args {
+    /// Port to listen on. If not set, an ephemeral port is used.
+    #[arg(long)]
+    pub port: Option<u16>,
+
+    /// Path to a JSON file to write startup info (single line). Includes {"port": <u16>}.
+    #[arg(long, value_name = "FILE")]
+    pub server_info: Option<PathBuf>,
+
+    /// Enable HTTP shutdown endpoint at GET /shutdown
+    #[arg(long)]
+    pub http_shutdown: bool,
+
+    /// Agentex API base URL (e.g. https://agentex.example.com).
+    #[arg(long)]
+    pub agentex_url: String,
+
+    /// Agentex agent ID to route requests to.
+    #[arg(long)]
+    pub agent_id: String,
+
+    /// Task lifecycle mode.
+    #[arg(long, value_enum, default_value_t = TaskLifecycleMode::PerSession)]
+    pub task_lifecycle: TaskLifecycleMode,
+
+    /// Comma-separated list of tool names that the Agentex agent handles
+    /// internally. All other tool calls from the agent are emitted as
+    /// FunctionCall items for Codex to execute locally.
+    #[arg(long, value_delimiter = ',')]
+    pub agent_tools: Vec<String>,
+}
+
+/// Controls whether each Codex session maps to a single Agentex task
+/// (preserving cross-turn memory) or spawns a fresh task per request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum TaskLifecycleMode {
+    /// First request creates a task; subsequent requests reuse it.
+    PerSession,
+    /// Every request creates a new task.
+    PerRequest,
+}

--- a/codex-rs/sgp-proxy/src/error.rs
+++ b/codex-rs/sgp-proxy/src/error.rs
@@ -1,0 +1,33 @@
+use thiserror::Error;
+
+/// Top-level proxy error.
+#[derive(Debug, Error)]
+pub enum ProxyError {
+    #[error("agentex error: {0}")]
+    Agentex(#[from] AgentexError),
+
+    #[error("request parse error: {0}")]
+    RequestParse(String),
+
+    #[error("session error: {0}")]
+    Session(String),
+
+    #[error("internal error: {0}")]
+    Internal(String),
+}
+
+/// Errors originating from the Agentex JSON-RPC interaction.
+#[derive(Debug, Error)]
+pub enum AgentexError {
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+
+    #[error("JSON-RPC error {code}: {message}")]
+    Rpc { code: i64, message: String },
+
+    #[error("stream error: {0}")]
+    Stream(String),
+
+    #[error("parse error: {0}")]
+    Parse(String),
+}

--- a/codex-rs/sgp-proxy/src/lib.rs
+++ b/codex-rs/sgp-proxy/src/lib.rs
@@ -1,0 +1,75 @@
+use std::fs;
+use std::fs::File;
+use std::io::Write;
+use std::net::SocketAddr;
+use std::path::Path;
+
+use anyhow::Context;
+use anyhow::Result;
+use serde::Serialize;
+use tokio::net::TcpListener;
+
+pub mod agentex_client;
+pub mod config;
+pub mod error;
+mod read_api_key;
+pub mod server;
+pub mod sse_writer;
+pub mod state;
+pub mod tool_routing;
+pub mod translate;
+
+pub use config::Args;
+use read_api_key::read_auth_header_from_stdin;
+
+#[derive(Serialize)]
+struct ServerInfo {
+    port: u16,
+    pid: u32,
+}
+
+/// Main entry point for the proxy library.
+pub async fn run_main(args: Args) -> Result<()> {
+    let auth_header = read_auth_header_from_stdin()?;
+
+    let proxy_state = state::ProxyState::new(&args, auth_header);
+    let router = server::build_router(proxy_state);
+
+    let addr = SocketAddr::from(([127, 0, 0, 1], args.port.unwrap_or(0)));
+    let listener = TcpListener::bind(addr)
+        .await
+        .with_context(|| format!("failed to bind {addr}"))?;
+    let bound = listener
+        .local_addr()
+        .context("failed to read local_addr")?;
+
+    if let Some(path) = args.server_info.as_ref() {
+        write_server_info(path, bound.port())?;
+    }
+
+    eprintln!("codex-sgp-proxy listening on {bound}");
+
+    axum::serve(listener, router.into_make_service())
+        .await
+        .context("axum server error")?;
+
+    Ok(())
+}
+
+fn write_server_info(path: &Path, port: u16) -> Result<()> {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent)?;
+    }
+
+    let info = ServerInfo {
+        port,
+        pid: std::process::id(),
+    };
+    let mut data = serde_json::to_string(&info)?;
+    data.push('\n');
+    let mut f = File::create(path)?;
+    f.write_all(data.as_bytes())?;
+    Ok(())
+}

--- a/codex-rs/sgp-proxy/src/main.rs
+++ b/codex-rs/sgp-proxy/src/main.rs
@@ -1,0 +1,13 @@
+use clap::Parser;
+use codex_sgp_proxy::Args;
+
+#[ctor::ctor]
+fn pre_main() {
+    codex_process_hardening::pre_main_hardening();
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    codex_sgp_proxy::run_main(args).await
+}

--- a/codex-rs/sgp-proxy/src/read_api_key.rs
+++ b/codex-rs/sgp-proxy/src/read_api_key.rs
@@ -1,0 +1,193 @@
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::anyhow;
+use zeroize::Zeroize;
+
+/// Use a generous buffer size to avoid truncation and to allow for longer API
+/// keys in the future.
+const BUFFER_SIZE: usize = 1024;
+const AUTH_HEADER_PREFIX: &[u8] = b"Bearer ";
+
+/// Reads the auth token from stdin and returns a static `Authorization` header
+/// value with the auth token used with `Bearer`. The header value is returned
+/// as a `&'static str` whose bytes are locked in memory to avoid accidental
+/// exposure.
+#[cfg(unix)]
+pub(crate) fn read_auth_header_from_stdin() -> Result<&'static str> {
+    read_auth_header_with(read_from_unix_stdin)
+}
+
+#[cfg(windows)]
+pub(crate) fn read_auth_header_from_stdin() -> Result<&'static str> {
+    use std::io::Read;
+
+    read_auth_header_with(|buffer| std::io::stdin().read(buffer))
+}
+
+/// We perform a low-level read with `read(2)` because `stdio::io::stdin()` has
+/// an internal BufReader that can end up retaining a copy of stdin data in
+/// memory with no way to zero it out, whereas we aim to guarantee there is
+/// exactly one copy of the API key in memory, protected by mlock(2).
+#[cfg(unix)]
+fn read_from_unix_stdin(buffer: &mut [u8]) -> std::io::Result<usize> {
+    use libc::c_void;
+    use libc::read;
+
+    loop {
+        let result = unsafe {
+            read(
+                libc::STDIN_FILENO,
+                buffer.as_mut_ptr().cast::<c_void>(),
+                buffer.len(),
+            )
+        };
+
+        if result == 0 {
+            return Ok(0);
+        }
+
+        if result < 0 {
+            let err = std::io::Error::last_os_error();
+            if err.kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(err);
+        }
+
+        return Ok(result as usize);
+    }
+}
+
+fn read_auth_header_with<F>(mut read_fn: F) -> Result<&'static str>
+where
+    F: FnMut(&mut [u8]) -> std::io::Result<usize>,
+{
+    let mut buf = [0u8; BUFFER_SIZE];
+    buf[..AUTH_HEADER_PREFIX.len()].copy_from_slice(AUTH_HEADER_PREFIX);
+
+    let prefix_len = AUTH_HEADER_PREFIX.len();
+    let capacity = buf.len() - prefix_len;
+    let mut total_read = 0usize;
+    let mut saw_newline = false;
+    let mut saw_eof = false;
+
+    while total_read < capacity {
+        let slice = &mut buf[prefix_len + total_read..];
+        let read = match read_fn(slice) {
+            Ok(n) => n,
+            Err(err) => {
+                buf.zeroize();
+                return Err(err.into());
+            }
+        };
+
+        if read == 0 {
+            saw_eof = true;
+            break;
+        }
+
+        let newly_written = &slice[..read];
+        if let Some(pos) = newly_written.iter().position(|&b| b == b'\n') {
+            total_read += pos + 1;
+            saw_newline = true;
+            break;
+        }
+
+        total_read += read;
+    }
+
+    if total_read == capacity && !saw_newline && !saw_eof {
+        buf.zeroize();
+        return Err(anyhow!(
+            "API key is too large to fit in the {BUFFER_SIZE}-byte buffer"
+        ));
+    }
+
+    let mut total = prefix_len + total_read;
+    while total > prefix_len && (buf[total - 1] == b'\n' || buf[total - 1] == b'\r') {
+        total -= 1;
+    }
+
+    if total == AUTH_HEADER_PREFIX.len() {
+        buf.zeroize();
+        return Err(anyhow!(
+            "API key must be provided via stdin (e.g. printenv AGENTEX_API_KEY | codex-sgp-proxy)"
+        ));
+    }
+
+    if let Err(err) = validate_auth_header_bytes(&buf[AUTH_HEADER_PREFIX.len()..total]) {
+        buf.zeroize();
+        return Err(err);
+    }
+
+    let header_str = match std::str::from_utf8(&buf[..total]) {
+        Ok(value) => value,
+        Err(err) => {
+            buf.zeroize();
+            return Err(err).context("reading Authorization header from stdin as UTF-8");
+        }
+    };
+
+    let header_value = String::from(header_str);
+    buf.zeroize();
+
+    let leaked: &'static mut str = header_value.leak();
+    mlock_str(leaked);
+
+    Ok(leaked)
+}
+
+#[cfg(unix)]
+fn mlock_str(value: &str) {
+    use libc::_SC_PAGESIZE;
+    use libc::c_void;
+    use libc::mlock;
+    use libc::sysconf;
+
+    if value.is_empty() {
+        return;
+    }
+
+    let page_size = unsafe { sysconf(_SC_PAGESIZE) };
+    if page_size <= 0 {
+        return;
+    }
+    let page_size = page_size as usize;
+    if page_size == 0 {
+        return;
+    }
+
+    let addr = value.as_ptr() as usize;
+    let len = value.len();
+    let start = addr & !(page_size - 1);
+    let addr_end = match addr.checked_add(len) {
+        Some(v) => match v.checked_add(page_size - 1) {
+            Some(total) => total,
+            None => return,
+        },
+        None => return,
+    };
+    let end = addr_end & !(page_size - 1);
+    let size = end.saturating_sub(start);
+    if size == 0 {
+        return;
+    }
+
+    let _ = unsafe { mlock(start as *const c_void, size) };
+}
+
+#[cfg(not(unix))]
+fn mlock_str(_value: &str) {}
+
+fn validate_auth_header_bytes(key_bytes: &[u8]) -> Result<()> {
+    if key_bytes
+        .iter()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+    {
+        return Ok(());
+    }
+
+    Err(anyhow!(
+        "API key may only contain ASCII letters, numbers, '-' or '_'"
+    ))
+}

--- a/codex-rs/sgp-proxy/src/server.rs
+++ b/codex-rs/sgp-proxy/src/server.rs
@@ -1,0 +1,354 @@
+use std::sync::Arc;
+
+use axum::Router;
+use axum::body::Body;
+use axum::extract::State;
+use axum::http::HeaderMap;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::response::Response;
+use axum::routing::get;
+use axum::routing::post;
+use bytes::Bytes;
+use futures::StreamExt;
+use futures::stream;
+use tokio_stream::wrappers::ReceiverStream;
+
+use crate::config::TaskLifecycleMode;
+use crate::error::ProxyError;
+use crate::sse_writer::SseEvent;
+use crate::state::ProxyState;
+use crate::state::SessionContext;
+use crate::translate::request::translate_request;
+use crate::translate::response::ToolDeltaBuffer;
+use crate::translate::response::translate_stream_event;
+use crate::translate::response::translate_task_messages;
+use crate::translate::types::MessageSendParams;
+
+/// Build the Axum router.
+pub fn build_router(state: Arc<ProxyState>) -> Router {
+    Router::new()
+        .route("/v1/responses", post(handle_responses))
+        .route("/shutdown", get(handle_shutdown))
+        .with_state(state)
+}
+
+async fn handle_shutdown(State(state): State<Arc<ProxyState>>) -> impl IntoResponse {
+    if state.http_shutdown {
+        // Spawn shutdown in a separate task so the response can be sent first.
+        tokio::spawn(async {
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            std::process::exit(0);
+        });
+        StatusCode::OK
+    } else {
+        StatusCode::NOT_FOUND
+    }
+}
+
+async fn handle_responses(
+    State(state): State<Arc<ProxyState>>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    match handle_responses_inner(state, headers, body).await {
+        Ok(response) => response,
+        Err(err) => {
+            let event = SseEvent::response_failed("proxy_error", &err.to_string());
+            let body_bytes = event.to_bytes();
+            Response::builder()
+                .status(StatusCode::OK)
+                .header("content-type", "text/event-stream")
+                .header("cache-control", "no-cache")
+                .body(Body::from(body_bytes))
+                .unwrap_or_else(|_| {
+                    Response::builder()
+                        .status(StatusCode::INTERNAL_SERVER_ERROR)
+                        .body(Body::empty())
+                        .unwrap_or_default()
+                })
+        }
+    }
+}
+
+async fn handle_responses_inner(
+    state: Arc<ProxyState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, ProxyError> {
+    // Parse request body.
+    let request_body: serde_json::Value = serde_json::from_slice(&body)
+        .map_err(|e| ProxyError::RequestParse(format!("invalid JSON: {e}")))?;
+
+    let wants_stream = request_body
+        .get("stream")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(true);
+
+    // Resolve session.
+    let session_id = headers
+        .get("x-session-id")
+        .or_else(|| headers.get("session-id"))
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("default")
+        .to_string();
+
+    let (task_id, is_first_turn) = resolve_session(&state, &session_id).await?;
+
+    // Translate request.
+    let mut agentex_messages = translate_request(&request_body, is_first_turn)?;
+
+    // Fill in tool names for ToolResponse items from session state.
+    {
+        let sessions = state.sessions.read().await;
+        if let Some(ctx) = sessions.get(&session_id) {
+            for msg in &mut agentex_messages {
+                for content in &mut msg.content {
+                    if let crate::translate::types::TaskMessageContent::ToolResponse {
+                        tool_call_id,
+                        name,
+                        ..
+                    } = content
+                        && name.is_empty()
+                        && let Some(resolved) = ctx.tool_name_by_call_id.get(tool_call_id)
+                    {
+                        name.clone_from(resolved);
+                    }
+                }
+            }
+        }
+    }
+
+    let response_id = format!("resp_{}", uuid::Uuid::new_v4());
+
+    let params = MessageSendParams {
+        task_id: task_id.clone(),
+        messages: agentex_messages,
+        stream: Some(wants_stream),
+    };
+
+    if wants_stream {
+        build_streaming_response(state, session_id, params, response_id).await
+    } else {
+        build_non_streaming_response(state, session_id, params, response_id).await
+    }
+}
+
+async fn resolve_session(
+    state: &ProxyState,
+    session_id: &str,
+) -> Result<(String, bool), ProxyError> {
+    match state.task_lifecycle {
+        TaskLifecycleMode::PerSession => {
+            // Check if session already exists.
+            {
+                let sessions = state.sessions.read().await;
+                if let Some(ctx) = sessions.get(session_id) {
+                    return Ok((ctx.task_id.clone(), false));
+                }
+            }
+
+            // Create a new task.
+            let task_id = state
+                .client
+                .task_create(&format!("codex-session-{session_id}"), &state.agent_id)
+                .await
+                .map_err(ProxyError::Agentex)?;
+
+            let ctx = SessionContext {
+                task_id: task_id.clone(),
+                tool_name_by_call_id: std::collections::HashMap::new(),
+                is_first_turn: true,
+            };
+
+            state
+                .sessions
+                .write()
+                .await
+                .insert(session_id.to_string(), ctx);
+
+            Ok((task_id, true))
+        }
+
+        TaskLifecycleMode::PerRequest => {
+            let task_id = state
+                .client
+                .task_create(
+                    &format!("codex-request-{}", uuid::Uuid::new_v4()),
+                    &state.agent_id,
+                )
+                .await
+                .map_err(ProxyError::Agentex)?;
+
+            Ok((task_id, true))
+        }
+    }
+}
+
+async fn build_streaming_response(
+    state: Arc<ProxyState>,
+    session_id: String,
+    params: MessageSendParams,
+    response_id: String,
+) -> Result<Response, ProxyError> {
+    // Obtain the stream via a separate client reference so that `state` is not
+    // borrowed when we later move it into the spawned task.
+    let agentex_stream = {
+        let stream = state
+            .client
+            .message_send_stream(params)
+            .await
+            .map_err(ProxyError::Agentex)?;
+        Box::pin(stream)
+    };
+
+    let (tx, rx) = tokio::sync::mpsc::channel::<Result<Bytes, std::convert::Infallible>>(64);
+
+    // Send response.created first.
+    let created_bytes = SseEvent::response_created(&response_id).to_bytes();
+    let _ = tx.send(Ok(created_bytes)).await;
+
+    let agent_tools = state.agent_tools.clone();
+    let rid = response_id.clone();
+
+    tokio::spawn(async move {
+        let mut buffer = ToolDeltaBuffer::default();
+        let mut item_index: u32 = 0;
+        let mut agentex_stream = agentex_stream;
+
+        while let Some(update_result) = agentex_stream.next().await {
+            match update_result {
+                Ok(update) => {
+                    // Track tool names from tool requests.
+                    track_tool_names(&state, &session_id, &update).await;
+
+                    let events = translate_stream_event(
+                        &update,
+                        &agent_tools,
+                        &mut buffer,
+                        &rid,
+                        &mut item_index,
+                    );
+
+                    for event in events {
+                        if tx.send(Ok(event.to_bytes())).await.is_err() {
+                            return;
+                        }
+                    }
+                }
+                Err(e) => {
+                    let event = SseEvent::response_failed("agentex_error", &e.to_string());
+                    let _ = tx.send(Ok(event.to_bytes())).await;
+                    return;
+                }
+            }
+        }
+
+        // Mark session as no longer first turn.
+        mark_not_first_turn(&state, &session_id).await;
+
+        // Send response.completed.
+        let completed = SseEvent::response_completed(&rid).to_bytes();
+        let _ = tx.send(Ok(completed)).await;
+    });
+
+    let body_stream = ReceiverStream::new(rx);
+    let response = Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", "text/event-stream")
+        .header("cache-control", "no-cache")
+        .body(Body::from_stream(body_stream))
+        .map_err(|e| ProxyError::Internal(format!("building response: {e}")))?;
+
+    Ok(response)
+}
+
+async fn build_non_streaming_response(
+    state: Arc<ProxyState>,
+    session_id: String,
+    params: MessageSendParams,
+    response_id: String,
+) -> Result<Response, ProxyError> {
+    let result = state
+        .client
+        .message_send(params)
+        .await
+        .map_err(ProxyError::Agentex)?;
+
+    // Track tool names.
+    for msg in &result.messages {
+        for content in &msg.content {
+            if let crate::translate::types::TaskMessageContent::ToolRequest {
+                tool_call_id,
+                name,
+                ..
+            } = content
+            {
+                let mut sessions = state.sessions.write().await;
+                if let Some(ctx) = sessions.get_mut(&session_id) {
+                    ctx.tool_name_by_call_id
+                        .insert(tool_call_id.clone(), name.clone());
+                }
+            }
+        }
+    }
+
+    mark_not_first_turn(&state, &session_id).await;
+
+    let mut events = vec![SseEvent::response_created(&response_id)];
+    events.extend(translate_task_messages(
+        &result.messages,
+        &state.agent_tools,
+        &response_id,
+    ));
+    events.push(SseEvent::response_completed(&response_id));
+
+    let body_stream = stream::iter(events.into_iter().map(|e| Ok::<_, std::convert::Infallible>(e.to_bytes())));
+
+    let response = Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", "text/event-stream")
+        .header("cache-control", "no-cache")
+        .body(Body::from_stream(body_stream))
+        .map_err(|e| ProxyError::Internal(format!("building response: {e}")))?;
+
+    Ok(response)
+}
+
+async fn track_tool_names(
+    state: &ProxyState,
+    session_id: &str,
+    update: &crate::translate::types::TaskMessageUpdate,
+) {
+    let messages = match update {
+        crate::translate::types::TaskMessageUpdate::Full { message }
+        | crate::translate::types::TaskMessageUpdate::Done { message } => {
+            std::slice::from_ref(message)
+        }
+        _ => return,
+    };
+
+    for msg in messages {
+        for content in &msg.content {
+            if let crate::translate::types::TaskMessageContent::ToolRequest {
+                tool_call_id,
+                name,
+                ..
+            } = content
+            {
+                let mut sessions = state.sessions.write().await;
+                if let Some(ctx) = sessions.get_mut(session_id) {
+                    ctx.tool_name_by_call_id
+                        .insert(tool_call_id.clone(), name.clone());
+                }
+            }
+        }
+    }
+}
+
+async fn mark_not_first_turn(state: &ProxyState, session_id: &str) {
+    let mut sessions = state.sessions.write().await;
+    if let Some(ctx) = sessions.get_mut(session_id) {
+        ctx.is_first_turn = false;
+    }
+}

--- a/codex-rs/sgp-proxy/src/sse_writer.rs
+++ b/codex-rs/sgp-proxy/src/sse_writer.rs
@@ -1,0 +1,282 @@
+use bytes::Bytes;
+use serde_json::Value;
+use serde_json::json;
+
+use crate::translate::types::ReasoningContentEntry;
+use crate::translate::types::ReasoningSummaryEntry;
+
+/// A single SSE event ready for serialization.
+#[derive(Debug, Clone)]
+pub struct SseEvent {
+    pub event_type: String,
+    pub data: Value,
+}
+
+impl SseEvent {
+    /// Serialize to SSE wire format: `event: <type>\ndata: <json>\n\n`
+    pub fn to_bytes(&self) -> Bytes {
+        let line = format!(
+            "event: {}\ndata: {}\n\n",
+            self.event_type,
+            serde_json::to_string(&self.data).unwrap_or_default()
+        );
+        Bytes::from(line)
+    }
+
+    /// Return the data as a `serde_json::Value` (for tests).
+    pub fn data_json(&self) -> &Value {
+        &self.data
+    }
+
+    // ------------------------------------------------------------------
+    // Builder methods
+    // ------------------------------------------------------------------
+
+    pub fn response_created(response_id: &str) -> Self {
+        Self {
+            event_type: "response.created".to_string(),
+            data: json!({
+                "type": "response.created",
+                "response": {
+                    "id": response_id,
+                }
+            }),
+        }
+    }
+
+    pub fn response_completed(response_id: &str) -> Self {
+        Self {
+            event_type: "response.completed".to_string(),
+            data: json!({
+                "type": "response.completed",
+                "response": {
+                    "id": response_id,
+                    "usage": {
+                        "input_tokens": 0,
+                        "input_tokens_details": null,
+                        "output_tokens": 0,
+                        "output_tokens_details": null,
+                        "total_tokens": 0
+                    }
+                }
+            }),
+        }
+    }
+
+    pub fn response_failed(code: &str, message: &str) -> Self {
+        Self {
+            event_type: "response.failed".to_string(),
+            data: json!({
+                "type": "response.failed",
+                "response": {
+                    "error": {
+                        "code": code,
+                        "message": message
+                    }
+                }
+            }),
+        }
+    }
+
+    pub fn output_item_done_message(item_id: &str, role: &str, text: &str) -> Self {
+        Self {
+            event_type: "response.output_item.done".to_string(),
+            data: json!({
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "message",
+                    "role": role,
+                    "id": item_id,
+                    "content": [{"type": "output_text", "text": text}]
+                }
+            }),
+        }
+    }
+
+    pub fn output_item_done_function_call(call_id: &str, name: &str, arguments: &str) -> Self {
+        Self {
+            event_type: "response.output_item.done".to_string(),
+            data: json!({
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "function_call",
+                    "call_id": call_id,
+                    "name": name,
+                    "arguments": arguments
+                }
+            }),
+        }
+    }
+
+    pub fn output_item_done_reasoning(
+        item_id: &str,
+        summary: &[ReasoningSummaryEntry],
+        content: &[ReasoningContentEntry],
+    ) -> Self {
+        let summary_entries: Vec<Value> = summary
+            .iter()
+            .map(|s| json!({"type": "summary_text", "text": s.text}))
+            .collect();
+
+        let mut item = json!({
+            "type": "reasoning",
+            "id": item_id,
+            "summary": summary_entries,
+        });
+
+        if !content.is_empty() {
+            let content_entries: Vec<Value> = content
+                .iter()
+                .map(|c| json!({"type": "reasoning_text", "text": c.text}))
+                .collect();
+            item["content"] = Value::Array(content_entries);
+        }
+
+        Self {
+            event_type: "response.output_item.done".to_string(),
+            data: json!({
+                "type": "response.output_item.done",
+                "item": item,
+            }),
+        }
+    }
+
+    pub fn output_text_delta(delta: &str) -> Self {
+        Self {
+            event_type: "response.output_text.delta".to_string(),
+            data: json!({
+                "type": "response.output_text.delta",
+                "delta": delta,
+            }),
+        }
+    }
+
+    pub fn reasoning_summary_text_delta(delta: &str, summary_index: u32) -> Self {
+        Self {
+            event_type: "response.reasoning_summary_text.delta".to_string(),
+            data: json!({
+                "type": "response.reasoning_summary_text.delta",
+                "delta": delta,
+                "summary_index": summary_index,
+            }),
+        }
+    }
+
+    pub fn reasoning_text_delta(delta: &str, content_index: u32) -> Self {
+        Self {
+            event_type: "response.reasoning_text.delta".to_string(),
+            data: json!({
+                "type": "response.reasoning_text.delta",
+                "delta": delta,
+                "content_index": content_index,
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sse_wire_format() {
+        let event = SseEvent::output_text_delta("Hello");
+        let bytes = event.to_bytes();
+        let s = std::str::from_utf8(&bytes).unwrap();
+        assert!(s.starts_with("event: response.output_text.delta\n"));
+        assert!(s.contains("data: "));
+        assert!(s.ends_with("\n\n"));
+
+        let data_line = s.lines().nth(1).unwrap();
+        let json_str = data_line.strip_prefix("data: ").unwrap();
+        let parsed: Value = serde_json::from_str(json_str).unwrap();
+        assert_eq!(parsed["type"], "response.output_text.delta");
+        assert_eq!(parsed["delta"], "Hello");
+    }
+
+    #[test]
+    fn test_response_created() {
+        let event = SseEvent::response_created("resp_123");
+        let data = event.data_json();
+        assert_eq!(data["type"], "response.created");
+        assert_eq!(data["response"]["id"], "resp_123");
+    }
+
+    #[test]
+    fn test_response_completed() {
+        let event = SseEvent::response_completed("resp_123");
+        let data = event.data_json();
+        assert_eq!(data["type"], "response.completed");
+        assert_eq!(data["response"]["id"], "resp_123");
+        assert_eq!(data["response"]["usage"]["total_tokens"], 0);
+    }
+
+    #[test]
+    fn test_function_call_event() {
+        let event = SseEvent::output_item_done_function_call("call_1", "read_file", "{\"path\":\"/tmp\"}");
+        let data = event.data_json();
+        assert_eq!(data["item"]["type"], "function_call");
+        assert_eq!(data["item"]["call_id"], "call_1");
+        assert_eq!(data["item"]["name"], "read_file");
+        assert_eq!(data["item"]["arguments"], "{\"path\":\"/tmp\"}");
+    }
+
+    #[test]
+    fn test_assistant_message_event() {
+        let event = SseEvent::output_item_done_message("item_0", "assistant", "Hi there");
+        let data = event.data_json();
+        assert_eq!(data["item"]["type"], "message");
+        assert_eq!(data["item"]["role"], "assistant");
+        assert_eq!(data["item"]["content"][0]["type"], "output_text");
+        assert_eq!(data["item"]["content"][0]["text"], "Hi there");
+    }
+
+    #[test]
+    fn test_reasoning_event() {
+        use crate::translate::types::ReasoningContentEntry;
+        use crate::translate::types::ReasoningSummaryEntry;
+
+        let event = SseEvent::output_item_done_reasoning(
+            "item_0",
+            &[ReasoningSummaryEntry {
+                entry_type: "summary_text".to_string(),
+                text: "thinking".to_string(),
+            }],
+            &[ReasoningContentEntry {
+                entry_type: "reasoning_text".to_string(),
+                text: "deep thought".to_string(),
+            }],
+        );
+        let data = event.data_json();
+        assert_eq!(data["item"]["type"], "reasoning");
+        assert_eq!(data["item"]["summary"][0]["text"], "thinking");
+        assert_eq!(data["item"]["content"][0]["text"], "deep thought");
+    }
+
+    #[test]
+    fn test_response_failed() {
+        let event = SseEvent::response_failed("server_error", "something went wrong");
+        let data = event.data_json();
+        assert_eq!(data["type"], "response.failed");
+        assert_eq!(data["response"]["error"]["code"], "server_error");
+        assert_eq!(data["response"]["error"]["message"], "something went wrong");
+    }
+
+    #[test]
+    fn test_reasoning_summary_delta() {
+        let event = SseEvent::reasoning_summary_text_delta("thinking", 0);
+        let data = event.data_json();
+        assert_eq!(data["type"], "response.reasoning_summary_text.delta");
+        assert_eq!(data["delta"], "thinking");
+        assert_eq!(data["summary_index"], 0);
+    }
+
+    #[test]
+    fn test_reasoning_text_delta() {
+        let event = SseEvent::reasoning_text_delta("deep", 0);
+        let data = event.data_json();
+        assert_eq!(data["type"], "response.reasoning_text.delta");
+        assert_eq!(data["delta"], "deep");
+        assert_eq!(data["content_index"], 0);
+    }
+}

--- a/codex-rs/sgp-proxy/src/state.rs
+++ b/codex-rs/sgp-proxy/src/state.rs
@@ -1,0 +1,45 @@
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+
+use crate::agentex_client::AgentexClient;
+use crate::config::Args;
+use crate::config::TaskLifecycleMode;
+
+/// Per-session context tracking the Agentex task and tool-call metadata.
+#[derive(Debug)]
+pub struct SessionContext {
+    pub task_id: String,
+    /// Maps tool call_id → tool name so we can populate ToolResponseContent
+    /// when Codex sends back FunctionCallOutput.
+    pub tool_name_by_call_id: HashMap<String, String>,
+    pub is_first_turn: bool,
+}
+
+/// Shared proxy state accessible from Axum handlers.
+pub struct ProxyState {
+    pub sessions: RwLock<HashMap<String, SessionContext>>,
+    pub client: AgentexClient,
+    pub agent_id: String,
+    pub task_lifecycle: TaskLifecycleMode,
+    pub agent_tools: HashSet<String>,
+    pub http_shutdown: bool,
+}
+
+impl ProxyState {
+    pub fn new(args: &Args, auth_header: &'static str) -> Arc<Self> {
+        let client = AgentexClient::new(args.agentex_url.clone(), auth_header);
+        let agent_tools: HashSet<String> = args.agent_tools.iter().cloned().collect();
+
+        Arc::new(Self {
+            sessions: RwLock::new(HashMap::new()),
+            client,
+            agent_id: args.agent_id.clone(),
+            task_lifecycle: args.task_lifecycle,
+            agent_tools,
+            http_shutdown: args.http_shutdown,
+        })
+    }
+}

--- a/codex-rs/sgp-proxy/src/tool_routing.rs
+++ b/codex-rs/sgp-proxy/src/tool_routing.rs
@@ -1,0 +1,44 @@
+use std::collections::HashSet;
+
+/// Where a tool call should be handled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolRoute {
+    /// The Agentex agent handles this tool internally.
+    Agent,
+    /// The tool call is emitted as a FunctionCall for Codex to execute locally.
+    CodexLocal,
+}
+
+/// Determine whether a tool call should be handled by the agent or by Codex.
+pub fn route_tool(name: &str, agent_tools: &HashSet<String>) -> ToolRoute {
+    if agent_tools.contains(name) {
+        ToolRoute::Agent
+    } else {
+        ToolRoute::CodexLocal
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_route_agent_tool() {
+        let mut tools = HashSet::new();
+        tools.insert("search".to_string());
+        assert_eq!(route_tool("search", &tools), ToolRoute::Agent);
+    }
+
+    #[test]
+    fn test_route_codex_local_tool() {
+        let tools = HashSet::new();
+        assert_eq!(route_tool("read_file", &tools), ToolRoute::CodexLocal);
+    }
+
+    #[test]
+    fn test_route_unknown_tool_is_codex_local() {
+        let mut tools = HashSet::new();
+        tools.insert("search".to_string());
+        assert_eq!(route_tool("write_file", &tools), ToolRoute::CodexLocal);
+    }
+}

--- a/codex-rs/sgp-proxy/src/translate/mod.rs
+++ b/codex-rs/sgp-proxy/src/translate/mod.rs
@@ -1,0 +1,3 @@
+pub mod request;
+pub mod response;
+pub mod types;

--- a/codex-rs/sgp-proxy/src/translate/request.rs
+++ b/codex-rs/sgp-proxy/src/translate/request.rs
@@ -1,0 +1,354 @@
+use serde_json::Value;
+
+use super::types::TaskMessage;
+use super::types::TaskMessageContent;
+use crate::error::ProxyError;
+
+/// Translate a Responses API request body into Agentex `TaskMessage` items.
+///
+/// The function walks the `input` array and the optional `instructions` field,
+/// producing content entries that can be sent via `message/send`.
+pub fn translate_request(
+    body: &Value,
+    is_first_turn: bool,
+) -> Result<Vec<TaskMessage>, ProxyError> {
+    let mut messages: Vec<TaskMessage> = Vec::new();
+
+    // Inject instructions as first user text on first turn (or always in per-request mode).
+    if is_first_turn
+        && let Some(instructions) = body.get("instructions").and_then(Value::as_str)
+        && !instructions.is_empty()
+    {
+        messages.push(TaskMessage {
+            role: "user".to_string(),
+            content: vec![TaskMessageContent::Text {
+                text: instructions.to_string(),
+                author: Some("user".to_string()),
+                format: Some("markdown".to_string()),
+            }],
+        });
+    }
+
+    let input = body
+        .get("input")
+        .and_then(Value::as_array)
+        .ok_or_else(|| ProxyError::RequestParse("missing or invalid 'input' array".into()))?;
+
+    for item in input {
+        let item_type = item.get("type").and_then(Value::as_str).unwrap_or("");
+
+        match item_type {
+            "message" => {
+                let role = item
+                    .get("role")
+                    .and_then(Value::as_str)
+                    .unwrap_or("user");
+                let author = match role {
+                    "assistant" => "agent",
+                    "developer" => "user",
+                    _ => "user",
+                };
+                let agentex_role = match role {
+                    "assistant" => "assistant",
+                    _ => "user",
+                };
+
+                let mut content_items = Vec::new();
+                if let Some(content_arr) = item.get("content").and_then(Value::as_array) {
+                    for c in content_arr {
+                        let c_type = c.get("type").and_then(Value::as_str).unwrap_or("");
+                        match c_type {
+                            "input_text" | "output_text" => {
+                                if let Some(text) = c.get("text").and_then(Value::as_str) {
+                                    let mut tc = TaskMessageContent::Text {
+                                        text: text.to_string(),
+                                        author: Some(author.to_string()),
+                                        format: None,
+                                    };
+                                    if role == "developer"
+                                        && let TaskMessageContent::Text {
+                                            ref mut format, ..
+                                        } = tc
+                                    {
+                                        *format = Some("markdown".to_string());
+                                    }
+                                    content_items.push(tc);
+                                }
+                            }
+                            _ => {
+                                // Skip unsupported content types (input_image, etc.)
+                            }
+                        }
+                    }
+                }
+
+                if !content_items.is_empty() {
+                    messages.push(TaskMessage {
+                        role: agentex_role.to_string(),
+                        content: content_items,
+                    });
+                }
+            }
+
+            "function_call" => {
+                let call_id = item
+                    .get("call_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                let name = item
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                let arguments = item
+                    .get("arguments")
+                    .and_then(Value::as_str)
+                    .unwrap_or("{}")
+                    .to_string();
+
+                messages.push(TaskMessage {
+                    role: "assistant".to_string(),
+                    content: vec![TaskMessageContent::ToolRequest {
+                        tool_call_id: call_id,
+                        name,
+                        arguments,
+                    }],
+                });
+            }
+
+            "function_call_output" => {
+                let call_id = item
+                    .get("call_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                // The output can be a string or a nested object with "output" field.
+                let output = if let Some(s) = item.get("output").and_then(Value::as_str) {
+                    s.to_string()
+                } else if let Some(obj) = item.get("output") {
+                    serde_json::to_string(obj).unwrap_or_default()
+                } else {
+                    String::new()
+                };
+
+                // We need the tool name for Agentex. It may not be in the
+                // output item itself, so we use a placeholder that the caller
+                // can resolve from session state.
+                messages.push(TaskMessage {
+                    role: "user".to_string(),
+                    content: vec![TaskMessageContent::ToolResponse {
+                        tool_call_id: call_id,
+                        name: String::new(), // resolved by caller from session state
+                        content: output,
+                    }],
+                });
+            }
+
+            "reasoning" => {
+                let summary = item
+                    .get("summary")
+                    .and_then(Value::as_array)
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|s| {
+                                Some(super::types::ReasoningSummaryEntry {
+                                    entry_type: "summary_text".to_string(),
+                                    text: s.get("text").and_then(Value::as_str)?.to_string(),
+                                })
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
+
+                let content = item
+                    .get("content")
+                    .and_then(Value::as_array)
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|c| {
+                                Some(super::types::ReasoningContentEntry {
+                                    entry_type: "reasoning_text".to_string(),
+                                    text: c.get("text").and_then(Value::as_str)?.to_string(),
+                                })
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
+
+                messages.push(TaskMessage {
+                    role: "assistant".to_string(),
+                    content: vec![TaskMessageContent::Reasoning { summary, content }],
+                });
+            }
+
+            // Skip local_shell_call, web_search_call, etc.
+            _ => {}
+        }
+    }
+
+    Ok(messages)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_translate_user_message() {
+        let body = json!({
+            "instructions": "You are a helpful assistant.",
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "Hello"}]
+                }
+            ]
+        });
+
+        let messages = translate_request(&body, true).unwrap();
+        assert_eq!(messages.len(), 2);
+
+        // First message: instructions
+        match &messages[0].content[0] {
+            TaskMessageContent::Text {
+                text,
+                author,
+                format,
+            } => {
+                assert_eq!(text, "You are a helpful assistant.");
+                assert_eq!(author.as_deref(), Some("user"));
+                assert_eq!(format.as_deref(), Some("markdown"));
+            }
+            _ => panic!("expected Text"),
+        }
+
+        // Second message: user input
+        assert_eq!(messages[1].role, "user");
+        match &messages[1].content[0] {
+            TaskMessageContent::Text { text, author, .. } => {
+                assert_eq!(text, "Hello");
+                assert_eq!(author.as_deref(), Some("user"));
+            }
+            _ => panic!("expected Text"),
+        }
+    }
+
+    #[test]
+    fn test_translate_assistant_message() {
+        let body = json!({
+            "input": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "Hi there"}]
+                }
+            ]
+        });
+
+        let messages = translate_request(&body, false).unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].role, "assistant");
+        match &messages[0].content[0] {
+            TaskMessageContent::Text { text, author, .. } => {
+                assert_eq!(text, "Hi there");
+                assert_eq!(author.as_deref(), Some("agent"));
+            }
+            _ => panic!("expected Text"),
+        }
+    }
+
+    #[test]
+    fn test_translate_function_call_and_output() {
+        let body = json!({
+            "input": [
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "read_file",
+                    "arguments": "{\"path\":\"/tmp/foo\"}"
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": "file contents"
+                }
+            ]
+        });
+
+        let messages = translate_request(&body, false).unwrap();
+        assert_eq!(messages.len(), 2);
+
+        match &messages[0].content[0] {
+            TaskMessageContent::ToolRequest {
+                tool_call_id,
+                name,
+                arguments,
+            } => {
+                assert_eq!(tool_call_id, "call_1");
+                assert_eq!(name, "read_file");
+                assert_eq!(arguments, "{\"path\":\"/tmp/foo\"}");
+            }
+            _ => panic!("expected ToolRequest"),
+        }
+
+        match &messages[1].content[0] {
+            TaskMessageContent::ToolResponse {
+                tool_call_id,
+                content,
+                ..
+            } => {
+                assert_eq!(tool_call_id, "call_1");
+                assert_eq!(content, "file contents");
+            }
+            _ => panic!("expected ToolResponse"),
+        }
+    }
+
+    #[test]
+    fn test_translate_reasoning() {
+        let body = json!({
+            "input": [
+                {
+                    "type": "reasoning",
+                    "id": "r1",
+                    "summary": [{"type": "summary_text", "text": "thinking"}],
+                    "content": [{"type": "reasoning_text", "text": "deep thought"}]
+                }
+            ]
+        });
+
+        let messages = translate_request(&body, false).unwrap();
+        assert_eq!(messages.len(), 1);
+        match &messages[0].content[0] {
+            TaskMessageContent::Reasoning { summary, content } => {
+                assert_eq!(summary.len(), 1);
+                assert_eq!(summary[0].text, "thinking");
+                assert_eq!(content.len(), 1);
+                assert_eq!(content[0].text, "deep thought");
+            }
+            _ => panic!("expected Reasoning"),
+        }
+    }
+
+    #[test]
+    fn test_skip_instructions_on_non_first_turn() {
+        let body = json!({
+            "instructions": "You are a helpful assistant.",
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "Hello"}]
+                }
+            ]
+        });
+
+        let messages = translate_request(&body, false).unwrap();
+        // Instructions should be skipped on non-first turn
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].role, "user");
+    }
+}

--- a/codex-rs/sgp-proxy/src/translate/response.rs
+++ b/codex-rs/sgp-proxy/src/translate/response.rs
@@ -1,0 +1,340 @@
+use std::collections::HashMap;
+use std::collections::HashSet;
+
+use super::types::StreamDelta;
+use super::types::TaskMessage;
+use super::types::TaskMessageContent;
+use super::types::TaskMessageUpdate;
+use crate::sse_writer::SseEvent;
+use crate::tool_routing::ToolRoute;
+use crate::tool_routing::route_tool;
+
+/// State buffer for accumulating streamed tool-call deltas until the full
+/// tool request is available.
+#[derive(Debug, Default)]
+pub struct ToolDeltaBuffer {
+    /// tool_call_id -> (name, arguments_so_far)
+    pub pending: HashMap<String, (String, String)>,
+}
+
+/// Translate a complete (non-streaming) Agentex response into SSE events.
+pub fn translate_task_messages(
+    messages: &[TaskMessage],
+    agent_tools: &HashSet<String>,
+    response_id: &str,
+) -> Vec<SseEvent> {
+    let mut events = Vec::new();
+    let mut item_index: u32 = 0;
+
+    for msg in messages {
+        for content in &msg.content {
+            match content {
+                TaskMessageContent::Text { text, author, .. } => {
+                    if author.as_deref() == Some("agent")
+                        || author.as_deref() == Some("assistant")
+                        || msg.role == "assistant"
+                    {
+                        let item_id = format!("{response_id}_item_{item_index}");
+                        events.push(SseEvent::output_item_done_message(
+                            &item_id, "assistant", text,
+                        ));
+                        item_index += 1;
+                    }
+                }
+
+                TaskMessageContent::ToolRequest {
+                    tool_call_id,
+                    name,
+                    arguments,
+                } => match route_tool(name, agent_tools) {
+                    ToolRoute::CodexLocal => {
+                        events.push(SseEvent::output_item_done_function_call(
+                            tool_call_id,
+                            name,
+                            arguments,
+                        ));
+                        item_index += 1;
+                    }
+                    ToolRoute::Agent => {
+                        // Suppressed — agent handles internally
+                    }
+                },
+
+                TaskMessageContent::Reasoning { summary, content } => {
+                    let item_id = format!("{response_id}_item_{item_index}");
+                    events.push(SseEvent::output_item_done_reasoning(
+                        &item_id, summary, content,
+                    ));
+                    item_index += 1;
+                }
+
+                TaskMessageContent::ToolResponse { .. } => {
+                    // Tool responses from the agent are not emitted as SSE events.
+                }
+            }
+        }
+    }
+
+    events
+}
+
+/// Translate a single streaming update into zero or more SSE events.
+pub fn translate_stream_event(
+    update: &TaskMessageUpdate,
+    agent_tools: &HashSet<String>,
+    buffer: &mut ToolDeltaBuffer,
+    response_id: &str,
+    item_index: &mut u32,
+) -> Vec<SseEvent> {
+    match update {
+        TaskMessageUpdate::Delta { delta } => match delta {
+            StreamDelta::TextDelta { text } => {
+                vec![SseEvent::output_text_delta(text)]
+            }
+
+            StreamDelta::ReasoningSummaryDelta { text } => {
+                vec![SseEvent::reasoning_summary_text_delta(text, 0)]
+            }
+
+            StreamDelta::ReasoningContentDelta { text } => {
+                vec![SseEvent::reasoning_text_delta(text, 0)]
+            }
+
+            StreamDelta::ToolRequestDelta {
+                tool_call_id,
+                name,
+                arguments,
+            } => {
+                let entry = buffer
+                    .pending
+                    .entry(tool_call_id.clone())
+                    .or_insert_with(|| (String::new(), String::new()));
+                if let Some(n) = name {
+                    entry.0.clone_from(n);
+                }
+                if let Some(args) = arguments {
+                    entry.1.push_str(args);
+                }
+                vec![]
+            }
+        },
+
+        TaskMessageUpdate::Full { message } | TaskMessageUpdate::Done { message } => {
+            let mut events = Vec::new();
+
+            for content in &message.content {
+                match content {
+                    TaskMessageContent::Text { text, author, .. } => {
+                        if author.as_deref() == Some("agent")
+                            || author.as_deref() == Some("assistant")
+                            || message.role == "assistant"
+                        {
+                            let item_id = format!("{response_id}_item_{item_index}");
+                            events.push(SseEvent::output_item_done_message(
+                                &item_id, "assistant", text,
+                            ));
+                            *item_index += 1;
+                        }
+                    }
+
+                    TaskMessageContent::ToolRequest {
+                        tool_call_id,
+                        name,
+                        arguments,
+                    } => {
+                        // Flush any buffered delta for this tool call.
+                        buffer.pending.remove(tool_call_id);
+
+                        match route_tool(name, agent_tools) {
+                            ToolRoute::CodexLocal => {
+                                events.push(SseEvent::output_item_done_function_call(
+                                    tool_call_id,
+                                    name,
+                                    arguments,
+                                ));
+                                *item_index += 1;
+                            }
+                            ToolRoute::Agent => {}
+                        }
+                    }
+
+                    TaskMessageContent::Reasoning { summary, content } => {
+                        let item_id = format!("{response_id}_item_{item_index}");
+                        events.push(SseEvent::output_item_done_reasoning(
+                            &item_id, summary, content,
+                        ));
+                        *item_index += 1;
+                    }
+
+                    TaskMessageContent::ToolResponse { .. } => {}
+                }
+            }
+
+            // Flush any remaining buffered tool-call deltas on Done.
+            if matches!(update, TaskMessageUpdate::Done { .. }) {
+                for (call_id, (name, arguments)) in buffer.pending.drain() {
+                    match route_tool(&name, agent_tools) {
+                        ToolRoute::CodexLocal => {
+                            events.push(SseEvent::output_item_done_function_call(
+                                &call_id,
+                                &name,
+                                &arguments,
+                            ));
+                            *item_index += 1;
+                        }
+                        ToolRoute::Agent => {}
+                    }
+                }
+            }
+
+            events
+        }
+
+        TaskMessageUpdate::Start { .. } => {
+            // Start events don't produce SSE output.
+            vec![]
+        }
+
+        TaskMessageUpdate::Error { message } => {
+            vec![SseEvent::response_failed("proxy_error", message)]
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::translate::types::ReasoningContentEntry;
+    use crate::translate::types::ReasoningSummaryEntry;
+
+    #[test]
+    fn test_translate_text_message() {
+        let messages = vec![TaskMessage {
+            role: "assistant".to_string(),
+            content: vec![TaskMessageContent::Text {
+                text: "Hello!".to_string(),
+                author: Some("agent".to_string()),
+                format: None,
+            }],
+        }];
+
+        let events = translate_task_messages(&messages, &HashSet::new(), "resp_1");
+        assert_eq!(events.len(), 1);
+        let data = events[0].data_json();
+        assert_eq!(data["type"], "response.output_item.done");
+        assert_eq!(data["item"]["type"], "message");
+        assert_eq!(data["item"]["content"][0]["text"], "Hello!");
+    }
+
+    #[test]
+    fn test_translate_function_call_codex_local() {
+        let messages = vec![TaskMessage {
+            role: "assistant".to_string(),
+            content: vec![TaskMessageContent::ToolRequest {
+                tool_call_id: "call_1".to_string(),
+                name: "read_file".to_string(),
+                arguments: "{\"path\":\"/tmp\"}".to_string(),
+            }],
+        }];
+
+        let events = translate_task_messages(&messages, &HashSet::new(), "resp_1");
+        assert_eq!(events.len(), 1);
+        let data = events[0].data_json();
+        assert_eq!(data["item"]["type"], "function_call");
+        assert_eq!(data["item"]["call_id"], "call_1");
+    }
+
+    #[test]
+    fn test_agent_tool_suppressed() {
+        let mut agent_tools = HashSet::new();
+        agent_tools.insert("search".to_string());
+
+        let messages = vec![TaskMessage {
+            role: "assistant".to_string(),
+            content: vec![TaskMessageContent::ToolRequest {
+                tool_call_id: "call_1".to_string(),
+                name: "search".to_string(),
+                arguments: "{}".to_string(),
+            }],
+        }];
+
+        let events = translate_task_messages(&messages, &agent_tools, "resp_1");
+        assert_eq!(events.len(), 0);
+    }
+
+    #[test]
+    fn test_translate_reasoning() {
+        let messages = vec![TaskMessage {
+            role: "assistant".to_string(),
+            content: vec![TaskMessageContent::Reasoning {
+                summary: vec![ReasoningSummaryEntry {
+                    entry_type: "summary_text".to_string(),
+                    text: "thinking".to_string(),
+                }],
+                content: vec![ReasoningContentEntry {
+                    entry_type: "reasoning_text".to_string(),
+                    text: "deep thought".to_string(),
+                }],
+            }],
+        }];
+
+        let events = translate_task_messages(&messages, &HashSet::new(), "resp_1");
+        assert_eq!(events.len(), 1);
+        let data = events[0].data_json();
+        assert_eq!(data["item"]["type"], "reasoning");
+    }
+
+    #[test]
+    fn test_stream_text_delta() {
+        let update = TaskMessageUpdate::Delta {
+            delta: StreamDelta::TextDelta {
+                text: "Hello".to_string(),
+            },
+        };
+
+        let mut buffer = ToolDeltaBuffer::default();
+        let mut idx = 0;
+        let events =
+            translate_stream_event(&update, &HashSet::new(), &mut buffer, "resp_1", &mut idx);
+        assert_eq!(events.len(), 1);
+        let data = events[0].data_json();
+        assert_eq!(data["type"], "response.output_text.delta");
+        assert_eq!(data["delta"], "Hello");
+    }
+
+    #[test]
+    fn test_stream_tool_delta_buffering() {
+        let agent_tools = HashSet::new();
+        let mut buffer = ToolDeltaBuffer::default();
+        let mut idx = 0;
+
+        // First delta — accumulates, no output.
+        let update1 = TaskMessageUpdate::Delta {
+            delta: StreamDelta::ToolRequestDelta {
+                tool_call_id: "call_1".to_string(),
+                name: Some("read_file".to_string()),
+                arguments: Some("{\"pa".to_string()),
+            },
+        };
+        let events =
+            translate_stream_event(&update1, &agent_tools, &mut buffer, "resp_1", &mut idx);
+        assert!(events.is_empty());
+
+        // Done with full message — flushes.
+        let update2 = TaskMessageUpdate::Done {
+            message: TaskMessage {
+                role: "assistant".to_string(),
+                content: vec![TaskMessageContent::ToolRequest {
+                    tool_call_id: "call_1".to_string(),
+                    name: "read_file".to_string(),
+                    arguments: "{\"path\":\"/tmp\"}".to_string(),
+                }],
+            },
+        };
+        let events =
+            translate_stream_event(&update2, &agent_tools, &mut buffer, "resp_1", &mut idx);
+        assert_eq!(events.len(), 1);
+        let data = events[0].data_json();
+        assert_eq!(data["item"]["type"], "function_call");
+    }
+}

--- a/codex-rs/sgp-proxy/src/translate/types.rs
+++ b/codex-rs/sgp-proxy/src/translate/types.rs
@@ -1,0 +1,176 @@
+use serde::Deserialize;
+use serde::Serialize;
+
+// ---------------------------------------------------------------------------
+// JSON-RPC 2.0 envelope
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize)]
+pub struct JsonRpcRequest<T: Serialize> {
+    pub jsonrpc: &'static str,
+    pub id: String,
+    pub method: String,
+    pub params: T,
+}
+
+impl<T: Serialize> JsonRpcRequest<T> {
+    pub fn new(id: impl Into<String>, method: impl Into<String>, params: T) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            id: id.into(),
+            method: method.into(),
+            params,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct JsonRpcResponse<T> {
+    #[allow(dead_code)]
+    pub jsonrpc: String,
+    #[allow(dead_code)]
+    pub id: Option<String>,
+    pub result: Option<T>,
+    pub error: Option<JsonRpcError>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct JsonRpcError {
+    pub code: i64,
+    pub message: String,
+}
+
+// ---------------------------------------------------------------------------
+// task/create
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CreateTaskParams {
+    pub name: String,
+    pub agent_id: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Task {
+    pub id: String,
+}
+
+// ---------------------------------------------------------------------------
+// message/send
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MessageSendParams {
+    pub task_id: String,
+    pub messages: Vec<TaskMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskMessage {
+    pub role: String,
+    pub content: Vec<TaskMessageContent>,
+}
+
+// ---------------------------------------------------------------------------
+// Message content types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum TaskMessageContent {
+    Text {
+        text: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        author: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        format: Option<String>,
+    },
+    ToolRequest {
+        tool_call_id: String,
+        name: String,
+        arguments: String,
+    },
+    ToolResponse {
+        tool_call_id: String,
+        name: String,
+        content: String,
+    },
+    Reasoning {
+        #[serde(default)]
+        summary: Vec<ReasoningSummaryEntry>,
+        #[serde(default)]
+        content: Vec<ReasoningContentEntry>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReasoningSummaryEntry {
+    #[serde(rename = "type")]
+    pub entry_type: String,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReasoningContentEntry {
+    #[serde(rename = "type")]
+    pub entry_type: String,
+    pub text: String,
+}
+
+// ---------------------------------------------------------------------------
+// Streaming response types (from Agentex)
+// ---------------------------------------------------------------------------
+
+/// Envelope for streamed task-message updates (NDJSON lines).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum TaskMessageUpdate {
+    Start {
+        message: TaskMessage,
+    },
+    Delta {
+        delta: StreamDelta,
+    },
+    Full {
+        message: TaskMessage,
+    },
+    Done {
+        message: TaskMessage,
+    },
+    Error {
+        #[serde(default)]
+        message: String,
+    },
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum StreamDelta {
+    TextDelta {
+        text: String,
+    },
+    ToolRequestDelta {
+        tool_call_id: String,
+        #[serde(default)]
+        name: Option<String>,
+        #[serde(default)]
+        arguments: Option<String>,
+    },
+    ReasoningSummaryDelta {
+        text: String,
+    },
+    ReasoningContentDelta {
+        text: String,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Non-streaming message/send response
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct MessageSendResult {
+    pub messages: Vec<TaskMessage>,
+}


### PR DESCRIPTION
Implements a translation proxy that sits between Codex and an Agentex agent, accepting Responses API requests (POST /v1/responses with SSE streaming) and translating them to/from Agentex JSON-RPC 2.0 calls.

Key features:
- Full bidirectional protocol translation (request and streaming response)
- Per-session and per-request task lifecycle modes
- Hybrid tool routing: agent-handled vs Codex-local tools
- Streaming support with delta buffering for tool call fragments
- Process hardening and secure API key handling via stdin/mlock

# External (non-OpenAI) Pull Request Requirements

Before opening this Pull Request, please read the dedicated "Contributing" markdown file or your PR may be closed:
https://github.com/openai/codex/blob/main/docs/contributing.md

If your PR conforms to our contribution guidelines, replace this text with a detailed and high quality description of your changes.

Include a link to a bug report or enhancement request.
