### PR TITLE
tui: restore visible line numbers for hidden file links

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -2399,6 +2399,7 @@ dependencies = [
  "codex-utils-pty",
  "codex-utils-sandbox-summary",
  "codex-utils-sleep-inhibitor",
+ "codex-utils-string",
  "codex-windows-sandbox",
  "color-eyre",
  "cpal",

--- a/codex-rs/tui/Cargo.toml
+++ b/codex-rs/tui/Cargo.toml
@@ -50,6 +50,7 @@ codex-utils-fuzzy-match = { workspace = true }
 codex-utils-oss = { workspace = true }
 codex-utils-sandbox-summary = { workspace = true }
 codex-utils-sleep-inhibitor = { workspace = true }
+codex-utils-string = { workspace = true }
 color-eyre = { workspace = true }
 crossterm = { workspace = true, features = ["bracketed-paste", "event-stream"] }
 derive_more = { workspace = true, features = ["is_variant"] }

--- a/codex-rs/tui/src/markdown_render.rs
+++ b/codex-rs/tui/src/markdown_render.rs
@@ -600,11 +600,13 @@ where
                 let label_text = self
                     .current_line_content
                     .as_ref()
-                    .map(|line| {
-                        line.spans[link.label_start_span_idx..]
-                            .iter()
-                            .map(|span| span.content.as_ref())
-                            .collect::<String>()
+                    .and_then(|line| {
+                        line.spans.get(link.label_start_span_idx..).map(|spans| {
+                            spans
+                                .iter()
+                                .map(|span| span.content.as_ref())
+                                .collect::<String>()
+                        })
                     })
                     .unwrap_or_default();
                 if extract_location_suffix(&label_text).is_none() {

--- a/codex-rs/tui/src/markdown_render.rs
+++ b/codex-rs/tui/src/markdown_render.rs
@@ -89,10 +89,22 @@ pub(crate) fn render_markdown_text_with_width(input: &str, width: Option<usize>)
 struct LinkState {
     destination: String,
     show_destination: bool,
+    hidden_line_number: Option<String>,
+    label_start_span_idx: usize,
 }
 
 fn should_render_link_destination(dest_url: &str) -> bool {
     !is_local_path_like_link(dest_url)
+}
+
+fn hidden_local_link_line_number(dest_url: &str) -> Option<String> {
+    if !is_local_path_like_link(dest_url) {
+        return None;
+    }
+
+    parse_hash_line_anchor(dest_url)
+        .or_else(|| parse_colon_line_suffix(dest_url))
+        .map(std::string::ToString::to_string)
 }
 
 fn is_local_path_like_link(dest_url: &str) -> bool {
@@ -107,6 +119,37 @@ fn is_local_path_like_link(dest_url: &str) -> bool {
             [drive, b':', separator, ..]
                 if drive.is_ascii_alphabetic() && matches!(separator, b'/' | b'\\')
         )
+}
+
+fn parse_hash_line_anchor(dest_url: &str) -> Option<&str> {
+    let (_, fragment) = dest_url.rsplit_once('#')?;
+    let line_part = fragment.strip_prefix('L')?;
+    let line = line_part.split('C').next()?;
+    (!line.is_empty() && line.bytes().all(|b| b.is_ascii_digit())).then_some(line)
+}
+
+fn parse_colon_line_suffix(dest_url: &str) -> Option<&str> {
+    let (prefix, tail) = dest_url.rsplit_once(':')?;
+    if !tail.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+
+    if let Some((_, line)) = prefix.rsplit_once(':')
+        && line.bytes().all(|b| b.is_ascii_digit())
+    {
+        return Some(line);
+    }
+
+    Some(tail)
+}
+
+fn label_already_mentions_line(label_text: &str, line_number: &str) -> bool {
+    if label_text.contains(&format!("(line {line_number})")) {
+        return true;
+    }
+
+    parse_hash_line_anchor(label_text).or_else(|| parse_colon_line_suffix(label_text))
+        == Some(line_number)
 }
 
 struct Writer<'a, I>
@@ -492,19 +535,40 @@ where
 
     fn push_link(&mut self, dest_url: String) {
         self.push_inline_style(self.styles.link);
+        let label_start_span_idx = self
+            .current_line_content
+            .as_ref()
+            .map(|line| line.spans.len())
+            .unwrap_or(0);
         self.link = Some(LinkState {
             show_destination: should_render_link_destination(&dest_url),
+            hidden_line_number: hidden_local_link_line_number(&dest_url),
+            label_start_span_idx,
             destination: dest_url,
         });
     }
 
     fn pop_link(&mut self) {
         if let Some(link) = self.link.take() {
+            let visible_label_text = self
+                .current_line_content
+                .as_ref()
+                .map(|line| {
+                    line.spans[link.label_start_span_idx..]
+                        .iter()
+                        .map(|span| span.content.as_ref())
+                        .collect::<String>()
+                })
+                .unwrap_or_default();
             self.pop_inline_style();
             if link.show_destination {
                 self.push_span(" (".into());
                 self.push_span(Span::styled(link.destination, self.styles.link));
                 self.push_span(")".into());
+            } else if let Some(line_number) = link.hidden_line_number
+                && !label_already_mentions_line(&visible_label_text, &line_number)
+            {
+                self.push_span(format!(" (line {line_number})").into());
             }
         }
     }

--- a/codex-rs/tui/src/markdown_render.rs
+++ b/codex-rs/tui/src/markdown_render.rs
@@ -100,13 +100,19 @@ fn should_render_link_destination(dest_url: &str) -> bool {
     !is_local_path_like_link(dest_url)
 }
 
-static COLON_LOCATION_SUFFIX_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r":\d+(?::\d+)?(?:[-–]\d+(?::\d+)?)?$").expect("valid location suffix regex")
-});
+static COLON_LOCATION_SUFFIX_RE: LazyLock<Regex> =
+    LazyLock::new(
+        || match Regex::new(r":\d+(?::\d+)?(?:[-–]\d+(?::\d+)?)?$") {
+            Ok(regex) => regex,
+            Err(error) => panic!("invalid location suffix regex: {error}"),
+        },
+    );
 
-static HASH_LOCATION_SUFFIX_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"^L\d+(?:C\d+)?(?:-L\d+(?:C\d+)?)?$").expect("valid hash location regex")
-});
+static HASH_LOCATION_SUFFIX_RE: LazyLock<Regex> =
+    LazyLock::new(|| match Regex::new(r"^L\d+(?:C\d+)?(?:-L\d+(?:C\d+)?)?$") {
+        Ok(regex) => regex,
+        Err(error) => panic!("invalid hash location regex: {error}"),
+    });
 
 fn is_local_path_like_link(dest_url: &str) -> bool {
     dest_url.starts_with("file://")

--- a/codex-rs/tui/src/markdown_render.rs
+++ b/codex-rs/tui/src/markdown_render.rs
@@ -90,6 +90,7 @@ struct LinkState {
     destination: String,
     show_destination: bool,
     hidden_line_number: Option<String>,
+    label_styled: bool,
 }
 
 fn should_render_link_destination(dest_url: &str) -> bool {
@@ -524,17 +525,24 @@ where
     }
 
     fn push_link(&mut self, dest_url: String) {
-        self.push_inline_style(self.styles.link);
+        let show_destination = should_render_link_destination(&dest_url);
+        let label_styled = !show_destination;
+        if label_styled {
+            self.push_inline_style(self.styles.code);
+        }
         self.link = Some(LinkState {
-            show_destination: should_render_link_destination(&dest_url),
+            show_destination,
             hidden_line_number: hidden_local_link_line_number(&dest_url),
+            label_styled,
             destination: dest_url,
         });
     }
 
     fn pop_link(&mut self) {
         if let Some(link) = self.link.take() {
-            self.pop_inline_style();
+            if link.label_styled {
+                self.pop_inline_style();
+            }
             if link.show_destination {
                 self.push_span(" (".into());
                 self.push_span(Span::styled(link.destination, self.styles.link));

--- a/codex-rs/tui/src/markdown_render_tests.rs
+++ b/codex-rs/tui/src/markdown_render_tests.rs
@@ -661,9 +661,10 @@ fn file_link_hides_destination() {
 }
 
 #[test]
-fn file_link_shows_line_number_from_hidden_destination() {
-    let text =
-        render_markdown_text("[markdown_render.rs](/Users/example/code/codex/codex-rs/tui/src/markdown_render.rs:74)");
+fn file_link_appends_line_number_when_label_lacks_it() {
+    let text = render_markdown_text(
+        "[markdown_render.rs](/Users/example/code/codex/codex-rs/tui/src/markdown_render.rs:74)",
+    );
     let expected = Text::from(Line::from_iter([
         "markdown_render.rs".cyan(),
         ":74".cyan(),
@@ -672,7 +673,16 @@ fn file_link_shows_line_number_from_hidden_destination() {
 }
 
 #[test]
-fn file_link_shows_line_number_from_hash_anchor() {
+fn file_link_uses_label_for_line_number() {
+    let text = render_markdown_text(
+        "[markdown_render.rs:74](/Users/example/code/codex/codex-rs/tui/src/markdown_render.rs:74)",
+    );
+    let expected = Text::from(Line::from_iter(["markdown_render.rs:74".cyan()]));
+    assert_eq!(text, expected);
+}
+
+#[test]
+fn file_link_appends_hash_anchor_when_label_lacks_it() {
     let text = render_markdown_text(
         "[markdown_render.rs](file:///Users/example/code/codex/codex-rs/tui/src/markdown_render.rs#L74C3)",
     );
@@ -684,7 +694,16 @@ fn file_link_shows_line_number_from_hash_anchor() {
 }
 
 #[test]
-fn file_link_shows_range_from_hidden_destination() {
+fn file_link_uses_label_for_hash_anchor() {
+    let text = render_markdown_text(
+        "[markdown_render.rs#L74C3](file:///Users/example/code/codex/codex-rs/tui/src/markdown_render.rs#L74C3)",
+    );
+    let expected = Text::from(Line::from_iter(["markdown_render.rs#L74C3".cyan()]));
+    assert_eq!(text, expected);
+}
+
+#[test]
+fn file_link_appends_range_when_label_lacks_it() {
     let text = render_markdown_text(
         "[markdown_render.rs](/Users/example/code/codex/codex-rs/tui/src/markdown_render.rs:74:3-76:9)",
     );
@@ -696,7 +715,16 @@ fn file_link_shows_range_from_hidden_destination() {
 }
 
 #[test]
-fn file_link_shows_hash_range_from_hidden_destination() {
+fn file_link_uses_label_for_range() {
+    let text = render_markdown_text(
+        "[markdown_render.rs:74:3-76:9](/Users/example/code/codex/codex-rs/tui/src/markdown_render.rs:74:3-76:9)",
+    );
+    let expected = Text::from(Line::from_iter(["markdown_render.rs:74:3-76:9".cyan()]));
+    assert_eq!(text, expected);
+}
+
+#[test]
+fn file_link_appends_hash_range_when_label_lacks_it() {
     let text = render_markdown_text(
         "[markdown_render.rs](file:///Users/example/code/codex/codex-rs/tui/src/markdown_render.rs#L74C3-L76C9)",
     );
@@ -704,6 +732,15 @@ fn file_link_shows_hash_range_from_hidden_destination() {
         "markdown_render.rs".cyan(),
         "#L74C3-L76C9".cyan(),
     ]));
+    assert_eq!(text, expected);
+}
+
+#[test]
+fn file_link_uses_label_for_hash_range() {
+    let text = render_markdown_text(
+        "[markdown_render.rs#L74C3-L76C9](file:///Users/example/code/codex/codex-rs/tui/src/markdown_render.rs#L74C3-L76C9)",
+    );
+    let expected = Text::from(Line::from_iter(["markdown_render.rs#L74C3-L76C9".cyan()]));
     assert_eq!(text, expected);
 }
 
@@ -722,7 +759,7 @@ fn url_link_shows_destination() {
 #[test]
 fn markdown_render_file_link_snapshot() {
     let text = render_markdown_text(
-        "See [markdown_render.rs](/Users/example/code/codex/codex-rs/tui/src/markdown_render.rs:74).",
+        "See [markdown_render.rs:74](/Users/example/code/codex/codex-rs/tui/src/markdown_render.rs:74).",
     );
     let rendered = text
         .lines

--- a/codex-rs/tui/src/markdown_render_tests.rs
+++ b/codex-rs/tui/src/markdown_render_tests.rs
@@ -643,7 +643,7 @@ fn strong_emphasis() {
 fn link() {
     let text = render_markdown_text("[Link](https://example.com)");
     let expected = Text::from(Line::from_iter([
-        "Link".cyan().underlined(),
+        "Link".into(),
         " (".into(),
         "https://example.com".cyan().underlined(),
         ")".into(),
@@ -656,7 +656,7 @@ fn file_link_hides_destination() {
     let text =
         render_markdown_text("[markdown_render.rs:74](/Users/example/code/codex/codex-rs/tui/src/markdown_render.rs:74)");
     let expected = Text::from(Line::from_iter([
-        "markdown_render.rs:74".cyan().underlined(),
+        "markdown_render.rs:74".cyan(),
         " (line 74)".into(),
     ]));
     assert_eq!(text, expected);
@@ -667,7 +667,7 @@ fn file_link_shows_line_number_from_hidden_destination() {
     let text =
         render_markdown_text("[markdown_render.rs](/Users/example/code/codex/codex-rs/tui/src/markdown_render.rs:74)");
     let expected = Text::from(Line::from_iter([
-        "markdown_render.rs".cyan().underlined(),
+        "markdown_render.rs".cyan(),
         " (line 74)".into(),
     ]));
     assert_eq!(text, expected);
@@ -679,7 +679,7 @@ fn file_link_shows_line_number_from_hash_anchor() {
         "[markdown_render.rs](file:///Users/example/code/codex/codex-rs/tui/src/markdown_render.rs#L74C3)",
     );
     let expected = Text::from(Line::from_iter([
-        "markdown_render.rs".cyan().underlined(),
+        "markdown_render.rs".cyan(),
         " (line 74)".into(),
     ]));
     assert_eq!(text, expected);
@@ -689,7 +689,7 @@ fn file_link_shows_line_number_from_hash_anchor() {
 fn url_link_shows_destination() {
     let text = render_markdown_text("[docs](https://example.com/docs)");
     let expected = Text::from(Line::from_iter([
-        "docs".cyan().underlined(),
+        "docs".into(),
         " (".into(),
         "https://example.com/docs".cyan().underlined(),
         ")".into(),

--- a/codex-rs/tui/src/markdown_render_tests.rs
+++ b/codex-rs/tui/src/markdown_render_tests.rs
@@ -655,7 +655,10 @@ fn link() {
 fn file_link_hides_destination() {
     let text =
         render_markdown_text("[markdown_render.rs:74](/Users/example/code/codex/codex-rs/tui/src/markdown_render.rs:74)");
-    let expected = Text::from(Line::from("markdown_render.rs:74".cyan().underlined()));
+    let expected = Text::from(Line::from_iter([
+        "markdown_render.rs:74".cyan().underlined(),
+        " (line 74)".into(),
+    ]));
     assert_eq!(text, expected);
 }
 

--- a/codex-rs/tui/src/markdown_render_tests.rs
+++ b/codex-rs/tui/src/markdown_render_tests.rs
@@ -688,7 +688,7 @@ fn file_link_appends_hash_anchor_when_label_lacks_it() {
     );
     let expected = Text::from(Line::from_iter([
         "markdown_render.rs".cyan(),
-        "#L74C3".cyan(),
+        ":74:3".cyan(),
     ]));
     assert_eq!(text, expected);
 }
@@ -730,7 +730,7 @@ fn file_link_appends_hash_range_when_label_lacks_it() {
     );
     let expected = Text::from(Line::from_iter([
         "markdown_render.rs".cyan(),
-        "#L74C3-L76C9".cyan(),
+        ":74:3-76:9".cyan(),
     ]));
     assert_eq!(text, expected);
 }

--- a/codex-rs/tui/src/markdown_render_tests.rs
+++ b/codex-rs/tui/src/markdown_render_tests.rs
@@ -653,12 +653,10 @@ fn link() {
 
 #[test]
 fn file_link_hides_destination() {
-    let text =
-        render_markdown_text("[markdown_render.rs:74](/Users/example/code/codex/codex-rs/tui/src/markdown_render.rs:74)");
-    let expected = Text::from(Line::from_iter([
-        "markdown_render.rs:74".cyan(),
-        " (line 74)".into(),
-    ]));
+    let text = render_markdown_text(
+        "[codex-rs/tui/src/markdown_render.rs](/Users/example/code/codex/codex-rs/tui/src/markdown_render.rs)",
+    );
+    let expected = Text::from(Line::from_iter(["codex-rs/tui/src/markdown_render.rs".cyan()]));
     assert_eq!(text, expected);
 }
 
@@ -668,7 +666,7 @@ fn file_link_shows_line_number_from_hidden_destination() {
         render_markdown_text("[markdown_render.rs](/Users/example/code/codex/codex-rs/tui/src/markdown_render.rs:74)");
     let expected = Text::from(Line::from_iter([
         "markdown_render.rs".cyan(),
-        " (line 74)".into(),
+        ":74".cyan(),
     ]));
     assert_eq!(text, expected);
 }
@@ -680,7 +678,31 @@ fn file_link_shows_line_number_from_hash_anchor() {
     );
     let expected = Text::from(Line::from_iter([
         "markdown_render.rs".cyan(),
-        " (line 74)".into(),
+        "#L74C3".cyan(),
+    ]));
+    assert_eq!(text, expected);
+}
+
+#[test]
+fn file_link_shows_range_from_hidden_destination() {
+    let text = render_markdown_text(
+        "[markdown_render.rs](/Users/example/code/codex/codex-rs/tui/src/markdown_render.rs:74:3-76:9)",
+    );
+    let expected = Text::from(Line::from_iter([
+        "markdown_render.rs".cyan(),
+        ":74:3-76:9".cyan(),
+    ]));
+    assert_eq!(text, expected);
+}
+
+#[test]
+fn file_link_shows_hash_range_from_hidden_destination() {
+    let text = render_markdown_text(
+        "[markdown_render.rs](file:///Users/example/code/codex/codex-rs/tui/src/markdown_render.rs#L74C3-L76C9)",
+    );
+    let expected = Text::from(Line::from_iter([
+        "markdown_render.rs".cyan(),
+        "#L74C3-L76C9".cyan(),
     ]));
     assert_eq!(text, expected);
 }

--- a/codex-rs/tui/src/markdown_render_tests.rs
+++ b/codex-rs/tui/src/markdown_render_tests.rs
@@ -4,6 +4,8 @@ use ratatui::text::Line;
 use ratatui::text::Span;
 use ratatui::text::Text;
 
+use crate::markdown_render::COLON_LOCATION_SUFFIX_RE;
+use crate::markdown_render::HASH_LOCATION_SUFFIX_RE;
 use crate::markdown_render::render_markdown_text;
 use insta::assert_snapshot;
 
@@ -649,6 +651,12 @@ fn link() {
         ")".into(),
     ]));
     assert_eq!(text, expected);
+}
+
+#[test]
+fn load_location_suffix_regexes() {
+    let _colon = &*COLON_LOCATION_SUFFIX_RE;
+    let _hash = &*HASH_LOCATION_SUFFIX_RE;
 }
 
 #[test]

--- a/codex-rs/tui/src/markdown_render_tests.rs
+++ b/codex-rs/tui/src/markdown_render_tests.rs
@@ -660,6 +660,29 @@ fn file_link_hides_destination() {
 }
 
 #[test]
+fn file_link_shows_line_number_from_hidden_destination() {
+    let text =
+        render_markdown_text("[markdown_render.rs](/Users/example/code/codex/codex-rs/tui/src/markdown_render.rs:74)");
+    let expected = Text::from(Line::from_iter([
+        "markdown_render.rs".cyan().underlined(),
+        " (line 74)".into(),
+    ]));
+    assert_eq!(text, expected);
+}
+
+#[test]
+fn file_link_shows_line_number_from_hash_anchor() {
+    let text = render_markdown_text(
+        "[markdown_render.rs](file:///Users/example/code/codex/codex-rs/tui/src/markdown_render.rs#L74C3)",
+    );
+    let expected = Text::from(Line::from_iter([
+        "markdown_render.rs".cyan().underlined(),
+        " (line 74)".into(),
+    ]));
+    assert_eq!(text, expected);
+}
+
+#[test]
 fn url_link_shows_destination() {
     let text = render_markdown_text("[docs](https://example.com/docs)");
     let expected = Text::from(Line::from_iter([
@@ -674,7 +697,7 @@ fn url_link_shows_destination() {
 #[test]
 fn markdown_render_file_link_snapshot() {
     let text = render_markdown_text(
-        "See [markdown_render.rs:74](/Users/example/code/codex/codex-rs/tui/src/markdown_render.rs:74).",
+        "See [markdown_render.rs](/Users/example/code/codex/codex-rs/tui/src/markdown_render.rs:74).",
     );
     let rendered = text
         .lines

--- a/codex-rs/tui/src/markdown_render_tests.rs
+++ b/codex-rs/tui/src/markdown_render_tests.rs
@@ -736,6 +736,18 @@ fn file_link_appends_hash_range_when_label_lacks_it() {
 }
 
 #[test]
+fn multiline_file_link_label_after_styled_prefix_does_not_panic() {
+    let text = render_markdown_text(
+        "**bold** plain [foo\nbar](file:///Users/example/code/codex/codex-rs/tui/src/markdown_render.rs#L74C3)",
+    );
+    let expected = Text::from_iter([
+        Line::from_iter(["bold".bold(), " plain ".into(), "foo".cyan()]),
+        Line::from_iter(["bar".cyan(), ":74:3".cyan()]),
+    ]);
+    assert_eq!(text, expected);
+}
+
+#[test]
 fn file_link_uses_label_for_hash_range() {
     let text = render_markdown_text(
         "[markdown_render.rs#L74C3-L76C9](file:///Users/example/code/codex/codex-rs/tui/src/markdown_render.rs#L74C3-L76C9)",

--- a/codex-rs/tui/src/snapshots/codex_tui__markdown_render__markdown_render_tests__markdown_render_file_link_snapshot.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__markdown_render__markdown_render_tests__markdown_render_file_link_snapshot.snap
@@ -3,4 +3,4 @@ source: tui/src/markdown_render_tests.rs
 assertion_line: 714
 expression: rendered
 ---
-See markdown_render.rs (line 74).
+See markdown_render.rs:74.

--- a/codex-rs/tui/src/snapshots/codex_tui__markdown_render__markdown_render_tests__markdown_render_file_link_snapshot.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__markdown_render__markdown_render_tests__markdown_render_file_link_snapshot.snap
@@ -1,5 +1,6 @@
 ---
 source: tui/src/markdown_render_tests.rs
+assertion_line: 714
 expression: rendered
 ---
-See markdown_render.rs:74.
+See markdown_render.rs (line 74).


### PR DESCRIPTION
we recently changed file linking so the model uses markdown links when it wants something to be clickable.

This works well across the GUI surfaces because they can render markdown cleanly and use the full absolute path in the anchor target.

A previous pass hid the absolute path in the TUI (and only showed the label), but that also meant we could lose useful location info when the model put the line number or range in the anchor target instead of the label.

This follow-up keeps the TUI behavior simple while making local file links feel closer to the old TUI file reference style.

key changes:
- Local markdown file links in the TUI keep the old file-ref feel: code styling, no underline, no visible absolute path.
- If the hidden local anchor target includes a location suffix and the label does not already include one, we append that suffix to the visible label.
- This works for single lines, line/column references, and ranges.
- If the label already includes the location, we leave it alone.
- normal web links keep the old TUI markdown-link behavior

some examples:
- `[foo.rs](/abs/path/foo.rs)` renders as `foo.rs`
- `[foo.rs](/abs/path/foo.rs:45)` renders as `foo.rs:45`
- `[foo.rs](/abs/path/foo.rs:45:3-48:9)` renders as `foo.rs:45:3-48:9`
- `[foo.rs:45](/abs/path/foo.rs:45)` stays `foo.rs:45`
- `[docs](https://example.com/docs)` still renders like a normal web link

how it looks:
<img width="732" height="813" alt="Screenshot 2026-02-26 at 9 27 55 AM" src="https://github.com/user-attachments/assets/d51bf236-653a-4e83-96e4-9427f0804471" />

