### PR TITLE
feat: add email login status

### DIFF
--- a/codex-rs/cli/src/login.rs
+++ b/codex-rs/cli/src/login.rs
@@ -237,7 +237,11 @@ pub async fn run_login_status(cli_config_overrides: CliConfigOverrides) -> ! {
                 }
             },
             AuthMode::Chatgpt => {
-                eprintln!("Logged in using ChatGPT");
+                if let Some(email) = auth.get_account_email() {
+                    eprintln!("Logged in using ChatGPT ({email})");
+                } else {
+                    eprintln!("Logged in using ChatGPT");
+                }
                 std::process::exit(0);
             }
         },


### PR DESCRIPTION
## Context

Right now, I have two primary Codex accounts (personal and work), and I can not tell what account I am actually using. Such small change will help me to understand