### PR TITLE
Skip history metadata scan for subagents

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1124,7 +1124,7 @@ impl Session {
         //
         // - initialize RolloutRecorder with new or resumed session info
         // - perform default shell discovery
-        // - load history metadata
+        // - load history metadata (skipped for subagents)
         let rollout_fut = async {
             if config.ephemeral {
                 Ok::<_, anyhow::Error>((None, None))
@@ -1141,7 +1141,16 @@ impl Session {
             }
         };
 
-        let history_meta_fut = crate::message_history::history_metadata(&config);
+        let history_meta_fut = async {
+            if matches!(
+                session_configuration.session_source,
+                SessionSource::SubAgent(_)
+            ) {
+                (0, 0)
+            } else {
+                crate::message_history::history_metadata(&config).await
+            }
+        };
         let auth_manager_clone = Arc::clone(&auth_manager);
         let config_for_mcp = Arc::clone(&config);
         let auth_and_mcp_fut = async move {


### PR DESCRIPTION
Summary
- Skip `history_metadata` scanning when spawning subagents to avoid expensive per-spawn history scans.
- Keeps behavior unchanged for normal sessions.

Testing
  - `cd codex-rs && cargo test -p codex-core` 
  -  Failing in this environment (pre-existing and I don't think something I did?):   
  -  `suite::cli_stream::responses_mode_stream_cli` (SIGKILL + OTEL export error to http://localhost:14318/v1/logs)
  - `suite::grep_files::grep_files_tool_collects_matches` (unsupported call: grep_files)   
  -  `suite::grep_files::grep_files_tool_reports_empty_results` (unsupported call: grep_files)