### PR TITLE
Add a background job to refresh the requirements local cache

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -186,7 +186,6 @@ use codex_arg0::Arg0DispatchPaths;
 use codex_backend_client::Client as BackendClient;
 use codex_chatgpt::connectors;
 use codex_cloud_requirements::cloud_requirements_loader;
-use codex_cloud_requirements::stop_cloud_requirements_refresher;
 use codex_core::AuthManager;
 use codex_core::CodexAuth;
 use codex_core::CodexThread;
@@ -1452,7 +1451,6 @@ impl CodexMessageProcessor {
                 data: None,
             });
         }
-        stop_cloud_requirements_refresher();
 
         // Reflect the current auth method after logout (likely None).
         Ok(self

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -186,6 +186,7 @@ use codex_arg0::Arg0DispatchPaths;
 use codex_backend_client::Client as BackendClient;
 use codex_chatgpt::connectors;
 use codex_cloud_requirements::cloud_requirements_loader;
+use codex_cloud_requirements::stop_cloud_requirements_refresher;
 use codex_core::AuthManager;
 use codex_core::CodexAuth;
 use codex_core::CodexThread;
@@ -1451,17 +1452,7 @@ impl CodexMessageProcessor {
                 data: None,
             });
         }
-        replace_cloud_requirements_loader(
-            self.cloud_requirements.as_ref(),
-            self.auth_manager.clone(),
-            self.config.chatgpt_base_url.clone(),
-            self.config.codex_home.clone(),
-        );
-        sync_default_client_residency_requirement(
-            &self.cli_overrides,
-            self.cloud_requirements.as_ref(),
-        )
-        .await;
+        stop_cloud_requirements_refresher();
 
         // Reflect the current auth method after logout (likely None).
         Ok(self

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -1451,6 +1451,17 @@ impl CodexMessageProcessor {
                 data: None,
             });
         }
+        replace_cloud_requirements_loader(
+            self.cloud_requirements.as_ref(),
+            self.auth_manager.clone(),
+            self.config.chatgpt_base_url.clone(),
+            self.config.codex_home.clone(),
+        );
+        sync_default_client_residency_requirement(
+            &self.cli_overrides,
+            self.cloud_requirements.as_ref(),
+        )
+        .await;
 
         // Reflect the current auth method after logout (likely None).
         Ok(self

--- a/codex-rs/cloud-requirements/src/lib.rs
+++ b/codex-rs/cloud-requirements/src/lib.rs
@@ -291,8 +291,7 @@ impl CloudRequirementsService {
         }
 
         self.fetch_with_retries(&auth, chatgpt_user_id, account_id)
-            .await
-            .flatten()
+            .await?
     }
 
     async fn fetch_with_retries(

--- a/codex-rs/cloud-requirements/src/lib.rs
+++ b/codex-rs/cloud-requirements/src/lib.rs
@@ -55,6 +55,16 @@ fn refresher_task_slot() -> &'static Mutex<Option<JoinHandle<()>>> {
     REFRESHER_TASK.get_or_init(|| Mutex::new(None))
 }
 
+pub fn stop_cloud_requirements_refresher() {
+    let mut refresher_guard = refresher_task_slot().lock().unwrap_or_else(|err| {
+        tracing::warn!("cloud requirements refresher task slot was poisoned");
+        err.into_inner()
+    });
+    if let Some(existing_task) = refresher_guard.take() {
+        existing_task.abort();
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum FetchCloudRequirementsStatus {
     BackendClientInit,


### PR DESCRIPTION
- Update the cloud requirements cache TTL to 30 minutes.
- Add a background job to refresh the cache every 5 minutes.
- Ensure there is only one refresh job per process.