### PR TITLE
fix: sort codex features list alphabetically

### DIFF
--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -808,6 +808,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
                     stage_width = stage_width.max(stage.len());
                     rows.push((name, stage, enabled));
                 }
+                rows.sort_unstable_by_key(|(name, _, _)| *name);
 
                 for (name, stage, enabled) in rows {
                     println!("{name:<name_width$}  {stage:<stage_width$}  {enabled}");


### PR DESCRIPTION
## Why

`codex features list` currently prints features in declaration order from `codex_core::features::FEATURES`. That makes the output harder to scan when looking for a specific flag, and the order can change for reasons unrelated to the CLI.

## What changed

- Sort the `codex features list` rows by feature key before printing them in `codex-rs/cli/src/main.rs`.
- Add an integration test in `codex-rs/cli/tests/features.rs` that runs `codex features list` and asserts the feature-name column is alphabetized.

## Verification

- Added `features_list_is_sorted_alphabetically_by_feature_name`.
- Ran `cargo test -p codex-cli`.
