### PR TITLE
fix: normalize skill permission paths with AbsolutePathBufGuard

### DIFF
--- a/codex-rs/core/src/skills/model.rs
+++ b/codex-rs/core/src/skills/model.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::config::Permissions;
-use codex_protocol::models::PermissionProfile;
+use crate::skills::permissions::SkillPermissionProfile;
 use codex_protocol::protocol::SkillScope;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -15,7 +15,7 @@ pub struct SkillMetadata {
     pub interface: Option<SkillInterface>,
     pub dependencies: Option<SkillDependencies>,
     pub policy: Option<SkillPolicy>,
-    pub permission_profile: Option<PermissionProfile>,
+    pub permission_profile: Option<SkillPermissionProfile>,
     // This is an experimental field.
     pub permissions: Option<Permissions>,
     /// Path to the SKILLS.md file that declares this skill.

--- a/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
+++ b/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
@@ -241,7 +241,8 @@ impl CoreShellActionProvider {
             .or_else(|| {
                 skill
                     .permission_profile
-                    .clone()
+                    .as_ref()
+                    .map(PermissionProfile::from)
                     .map(EscalationPermissions::PermissionProfile)
                     .map(EscalationExecution::Permissions)
             })
@@ -486,7 +487,10 @@ impl EscalationPolicy for CoreShellActionProvider {
                     program,
                     argv,
                     workdir,
-                    skill.permission_profile.clone(),
+                    skill
+                        .permission_profile
+                        .as_ref()
+                        .map(PermissionProfile::from),
                     Self::skill_escalation_execution(&skill),
                     decision_source,
                 )

--- a/codex-rs/core/tests/suite/skill_approval.rs
+++ b/codex-rs/core/tests/suite/skill_approval.rs
@@ -291,6 +291,12 @@ permissions:
     .await?;
 
     let (script_path_str, command) = skill_script_command(&test, "hello-mbolin.sh")?;
+    let skill_dir = PathBuf::from(&script_path_str)
+        .parent()
+        .expect("skill script parent")
+        .parent()
+        .expect("skill root")
+        .to_path_buf();
     let arguments = shell_command_arguments(&command)?;
     let mocks =
         mount_function_call_agent_response(&server, tool_call_id, &arguments, "shell_command")
@@ -331,8 +337,8 @@ permissions:
         approval.additional_permissions,
         Some(PermissionProfile {
             file_system: Some(FileSystemPermissions {
-                read: Some(vec![PathBuf::from("./data")]),
-                write: Some(vec![PathBuf::from("./output")]),
+                read: Some(vec![skill_dir.join("data")]),
+                write: Some(vec![skill_dir.join("output")]),
             }),
             ..Default::default()
         })


### PR DESCRIPTION
## Summary

This change normalizes skill permission paths at load time so skill-defined filesystem permissions are stored as absolute paths anchored to the skill root. That removes the ambiguity of carrying relative `PathBuf` values deeper into permission handling and makes the skill permission model safer to build on for the follow-up work to merge skill permissions with the current sandbox instead of replacing it.

## What changed

- Introduced `SkillPermissionProfile` and `SkillFileSystemPermissions` in `core/src/skills/permissions.rs` so skill-local filesystem permissions use `AbsolutePathBuf`.
- Parsed `agents/openai.yaml` under `AbsolutePathBufGuard` in `core/src/skills/loader.rs`, which resolves relative permission paths against the skill directory during deserialization.
- Updated skill metadata and the shell escalation path to convert the skill-local profile back to the protocol `PermissionProfile` only at the boundary where additional permissions are passed through.
- Updated the skill approval coverage to assert absolute skill-root paths rather than relative `./...` entries.

## Testing

- `cargo test -p codex-core loads_skill_permissions_from_yaml -- --nocapture`
- `cargo test -p codex-core --test all skill_approval::shell_zsh_fork_ -- --nocapture`
- `cargo test -p codex-core` (the current tree still has unrelated failures in existing `grep_files`, `rmcp_client`, `search_tool`, and `truncation` tests; the skill-permission coverage above passed)
