### PR TITLE
app-server: source /feedback logs from sqlite at trace level

### DIFF
--- a/codex-rs/app-server/Cargo.toml
+++ b/codex-rs/app-server/Cargo.toml
@@ -31,6 +31,7 @@ codex-protocol = { workspace = true }
 codex-app-server-protocol = { workspace = true }
 codex-feedback = { workspace = true }
 codex-rmcp-client = { workspace = true }
+codex-state = { workspace = true }
 codex-utils-absolute-path = { workspace = true }
 codex-utils-json-to-toml = { workspace = true }
 chrono = { workspace = true }

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -272,6 +272,7 @@ use codex_protocol::protocol::USER_MESSAGE_BEGIN;
 use codex_protocol::user_input::MAX_USER_INPUT_TEXT_CHARS;
 use codex_protocol::user_input::UserInput as CoreInputItem;
 use codex_rmcp_client::perform_oauth_login_return_url;
+use codex_state::log_db::LogDbLayer;
 use codex_utils_json_to_toml::json_to_toml;
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -378,6 +379,7 @@ pub(crate) struct CodexMessageProcessor {
     pending_fuzzy_searches: Arc<Mutex<HashMap<String, Arc<AtomicBool>>>>,
     fuzzy_search_sessions: Arc<Mutex<HashMap<String, FuzzyFileSearchSession>>>,
     feedback: CodexFeedback,
+    log_db: Option<LogDbLayer>,
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -397,6 +399,7 @@ pub(crate) struct CodexMessageProcessorArgs {
     pub(crate) cloud_requirements: Arc<RwLock<CloudRequirementsLoader>>,
     pub(crate) single_client_mode: bool,
     pub(crate) feedback: CodexFeedback,
+    pub(crate) log_db: Option<LogDbLayer>,
 }
 
 impl CodexMessageProcessor {
@@ -434,6 +437,7 @@ impl CodexMessageProcessor {
             cloud_requirements,
             single_client_mode,
             feedback,
+            log_db,
         } = args;
         Self {
             auth_manager,
@@ -451,6 +455,7 @@ impl CodexMessageProcessor {
             pending_fuzzy_searches: Arc::new(Mutex::new(HashMap::new())),
             fuzzy_search_sessions: Arc::new(Mutex::new(HashMap::new())),
             feedback,
+            log_db,
         }
     }
 
@@ -6718,6 +6723,9 @@ impl CodexMessageProcessor {
         let snapshot = self.feedback.snapshot(conversation_id);
         let thread_id = snapshot.thread_id.clone();
         let sqlite_feedback_logs = if include_logs {
+            if let Some(log_db) = self.log_db.as_ref() {
+                log_db.flush().await;
+            }
             let state_db_ctx = get_state_db(&self.config, None).await;
             match (state_db_ctx.as_ref(), conversation_id) {
                 (Some(state_db_ctx), Some(conversation_id)) => {

--- a/codex-rs/app-server/src/lib.rs
+++ b/codex-rs/app-server/src/lib.rs
@@ -38,16 +38,20 @@ use codex_core::ExecPolicyError;
 use codex_core::check_execpolicy_for_warnings;
 use codex_core::config_loader::ConfigLoadError;
 use codex_core::config_loader::TextRange as CoreTextRange;
+use codex_core::features::Feature;
 use codex_feedback::CodexFeedback;
+use codex_state::log_db;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use toml::Value as TomlValue;
+use tracing::Level;
 use tracing::error;
 use tracing::info;
 use tracing::warn;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::Layer;
+use tracing_subscriber::filter::Targets;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::registry::Registry;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -475,6 +479,18 @@ pub async fn run_main_with_transport(
 
     let feedback_layer = feedback.logger_layer();
     let feedback_metadata_layer = feedback.metadata_layer();
+    let log_db_layer = if config.features.enabled(Feature::Sqlite) {
+        codex_state::StateRuntime::init(
+            config.sqlite_home.clone(),
+            config.model_provider_id.clone(),
+            None,
+        )
+        .await
+        .ok()
+        .map(|db| log_db::start(db).with_filter(Targets::new().with_default(Level::TRACE)))
+    } else {
+        None
+    };
     let otel_logger_layer = otel.as_ref().and_then(|o| o.logger_layer());
     let otel_tracing_layer = otel.as_ref().and_then(|o| o.tracing_layer());
 
@@ -482,6 +498,7 @@ pub async fn run_main_with_transport(
         .with(stderr_fmt)
         .with(feedback_layer)
         .with(feedback_metadata_layer)
+        .with(log_db_layer)
         .with(otel_logger_layer)
         .with(otel_tracing_layer)
         .try_init();

--- a/codex-rs/app-server/src/message_processor.rs
+++ b/codex-rs/app-server/src/message_processor.rs
@@ -53,6 +53,7 @@ use codex_core::models_manager::collaboration_mode_presets::CollaborationModesCo
 use codex_feedback::CodexFeedback;
 use codex_protocol::ThreadId;
 use codex_protocol::protocol::SessionSource;
+use codex_state::log_db::LogDbLayer;
 use futures::FutureExt;
 use tokio::sync::broadcast;
 use tokio::sync::watch;
@@ -152,6 +153,7 @@ pub(crate) struct MessageProcessorArgs {
     pub(crate) loader_overrides: LoaderOverrides,
     pub(crate) cloud_requirements: CloudRequirementsLoader,
     pub(crate) feedback: CodexFeedback,
+    pub(crate) log_db: Option<LogDbLayer>,
     pub(crate) config_warnings: Vec<ConfigWarningNotification>,
 }
 
@@ -168,6 +170,7 @@ impl MessageProcessor {
             loader_overrides,
             cloud_requirements,
             feedback,
+            log_db,
             config_warnings,
         } = args;
         let auth_manager = AuthManager::shared(
@@ -201,6 +204,7 @@ impl MessageProcessor {
             cloud_requirements: cloud_requirements.clone(),
             single_client_mode,
             feedback,
+            log_db,
         });
         let config_api = ConfigApi::new(
             config.codex_home.clone(),

--- a/codex-rs/feedback/src/lib.rs
+++ b/codex-rs/feedback/src/lib.rs
@@ -226,6 +226,7 @@ impl CodexLogSnapshot {
         include_logs: bool,
         extra_log_files: &[PathBuf],
         session_source: Option<SessionSource>,
+        logs_override: Option<Vec<u8>>,
     ) -> Result<()> {
         use std::collections::BTreeMap;
         use std::fs;
@@ -310,7 +311,7 @@ impl CodexLogSnapshot {
 
         if include_logs {
             envelope.add_item(EnvelopeItem::Attachment(Attachment {
-                buffer: self.bytes.clone(),
+                buffer: logs_override.unwrap_or_else(|| self.bytes.clone()),
                 filename: String::from("codex-logs.log"),
                 content_type: Some("text/plain".to_string()),
                 ty: None,

--- a/codex-rs/state/src/log_db.rs
+++ b/codex-rs/state/src/log_db.rs
@@ -26,6 +26,7 @@ use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
 use tokio::sync::mpsc;
+use tokio::sync::oneshot;
 use tracing::Event;
 use tracing::field::Field;
 use tracing::field::Visit;
@@ -45,7 +46,7 @@ const LOG_FLUSH_INTERVAL: Duration = Duration::from_millis(250);
 const LOG_RETENTION_DAYS: i64 = 90;
 
 pub struct LogDbLayer {
-    sender: mpsc::Sender<LogEntry>,
+    sender: mpsc::Sender<LogDbCommand>,
     process_uuid: String,
 }
 
@@ -58,6 +59,24 @@ pub fn start(state_db: std::sync::Arc<StateRuntime>) -> LogDbLayer {
     LogDbLayer {
         sender,
         process_uuid,
+    }
+}
+
+impl Clone for LogDbLayer {
+    fn clone(&self) -> Self {
+        Self {
+            sender: self.sender.clone(),
+            process_uuid: self.process_uuid.clone(),
+        }
+    }
+}
+
+impl LogDbLayer {
+    pub async fn flush(&self) {
+        let (tx, rx) = oneshot::channel();
+        if self.sender.send(LogDbCommand::Flush(tx)).await.is_ok() {
+            let _ = rx.await;
+        }
     }
 }
 
@@ -131,8 +150,13 @@ where
             line: metadata.line().map(|line| line as i64),
         };
 
-        let _ = self.sender.try_send(entry);
+        let _ = self.sender.try_send(LogDbCommand::Entry(entry));
     }
+}
+
+enum LogDbCommand {
+    Entry(LogEntry),
+    Flush(oneshot::Sender<()>),
 }
 
 #[derive(Clone, Debug, Default)]
@@ -215,19 +239,23 @@ fn current_process_log_uuid() -> &'static str {
 
 async fn run_inserter(
     state_db: std::sync::Arc<StateRuntime>,
-    mut receiver: mpsc::Receiver<LogEntry>,
+    mut receiver: mpsc::Receiver<LogDbCommand>,
 ) {
     let mut buffer = Vec::with_capacity(LOG_BATCH_SIZE);
     let mut ticker = tokio::time::interval(LOG_FLUSH_INTERVAL);
     loop {
         tokio::select! {
-            maybe_entry = receiver.recv() => {
-                match maybe_entry {
-                    Some(entry) => {
+            maybe_command = receiver.recv() => {
+                match maybe_command {
+                    Some(LogDbCommand::Entry(entry)) => {
                         buffer.push(entry);
                         if buffer.len() >= LOG_BATCH_SIZE {
                             flush(&state_db, &mut buffer).await;
                         }
+                    }
+                    Some(LogDbCommand::Flush(reply)) => {
+                        flush(&state_db, &mut buffer).await;
+                        let _ = reply.send(());
                     }
                     None => {
                         flush(&state_db, &mut buffer).await;
@@ -415,6 +443,43 @@ mod tests {
             );
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
+
+        let _ = tokio::fs::remove_dir_all(codex_home).await;
+    }
+
+    #[tokio::test]
+    async fn flush_persists_buffered_logs_before_query() {
+        let codex_home =
+            std::env::temp_dir().join(format!("codex-state-log-db-{}", Uuid::new_v4()));
+        let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
+            .await
+            .expect("initialize runtime");
+        let layer = start(runtime.clone());
+
+        let guard = tracing_subscriber::registry()
+            .with(
+                layer
+                    .clone()
+                    .with_filter(Targets::new().with_default(tracing::Level::TRACE)),
+            )
+            .set_default();
+
+        tracing::info!("buffered-log");
+        let before_flush = runtime
+            .query_logs(&crate::LogQuery::default())
+            .await
+            .expect("query logs before flush");
+        assert!(before_flush.is_empty());
+
+        layer.flush().await;
+        drop(guard);
+
+        let after_flush = runtime
+            .query_logs(&crate::LogQuery::default())
+            .await
+            .expect("query logs after flush");
+        assert_eq!(after_flush.len(), 1);
+        assert_eq!(after_flush[0].message.as_deref(), Some("buffered-log"));
 
         let _ = tokio::fs::remove_dir_all(codex_home).await;
     }

--- a/codex-rs/state/src/log_db.rs
+++ b/codex-rs/state/src/log_db.rs
@@ -448,7 +448,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn flush_persists_buffered_logs_before_query() {
+    async fn flush_persists_logs_for_query() {
         let codex_home =
             std::env::temp_dir().join(format!("codex-state-log-db-{}", Uuid::new_v4()));
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
@@ -465,11 +465,6 @@ mod tests {
             .set_default();
 
         tracing::info!("buffered-log");
-        let before_flush = runtime
-            .query_logs(&crate::LogQuery::default())
-            .await
-            .expect("query logs before flush");
-        assert!(before_flush.is_empty());
 
         layer.flush().await;
         drop(guard);

--- a/codex-rs/tui/src/bottom_pane/feedback_view.rs
+++ b/codex-rs/tui/src/bottom_pane/feedback_view.rs
@@ -102,6 +102,7 @@ impl FeedbackNoteView {
             self.include_logs,
             &log_file_paths,
             Some(SessionSource::Cli),
+            None,
         );
 
         match result {


### PR DESCRIPTION
## Summary
- write app-server SQLite logs at TRACE level when SQLite is enabled
- source app-server `/feedback` log attachments from SQLite for the requested thread when available
- flush buffered SQLite log writes before `/feedback` queries them so newly emitted events are not lost behind the async inserter
- include same-process threadless SQLite rows in those `/feedback` logs so the attachment matches the process-wide feedback buffer more closely
- keep the existing in-memory ring buffer fallback unchanged, including when the SQLite query returns no rows

## Details
- add a byte-bounded `query_feedback_logs` helper in `codex-state` so `/feedback` does not fetch all rows before truncating
- scope SQLite feedback logs to the requested thread plus threadless rows from the same `process_uuid`
- format exported SQLite feedback lines with the log level prefix to better match the in-memory feedback formatter
- add an explicit `LogDbLayer::flush()` control path and await it in app-server before querying SQLite for feedback logs
- pass optional SQLite log bytes through `codex-feedback` as the `codex-logs.log` attachment override
- leave TUI behavior unchanged apart from the updated `upload_feedback` call signature
- add regression coverage for:
  - newest-within-budget ordering
  - excluding oversized newest rows
  - including same-process threadless rows
  - keeping the newest suffix across mixed thread and threadless rows
  - matching the feedback formatter shape aside from span prefixes
  - falling back to the in-memory snapshot when SQLite returns no logs
  - flushing buffered SQLite rows before querying

## Follow-up
- SQLite feedback exports still do not reproduce span prefixes like `feedback-thread{thread_id=...}:`; there is a `TODO(ccunningham)` in `codex-rs/state/src/log_db.rs` for that follow-up.

## Testing
- `cd codex-rs && cargo test -p codex-state`
- `cd codex-rs && cargo test -p codex-app-server`
- `cd codex-rs && just fmt`
