### PR TITLE
Add codex_apps MCP tool filter overrides

### DIFF
--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -2,6 +2,7 @@ use crate::auth::AuthCredentialsStoreMode;
 use crate::config::edit::ConfigEdit;
 use crate::config::edit::ConfigEditsBuilder;
 use crate::config::types::AppsConfigToml;
+use crate::config::types::CodexAppsMcpConfigToml;
 use crate::config::types::DEFAULT_OTEL_ENVIRONMENT;
 use crate::config::types::History;
 use crate::config::types::McpServerConfig;
@@ -1246,6 +1247,10 @@ pub struct ConfigToml {
     /// Settings for app-specific controls.
     #[serde(default)]
     pub apps: Option<AppsConfigToml>,
+
+    /// Config overrides for the synthesized `codex_apps` MCP server.
+    #[serde(default)]
+    pub codex_apps_mcp: Option<CodexAppsMcpConfigToml>,
 
     /// OTEL configuration.
     pub otel: Option<crate::config::types::OtelConfigToml>,

--- a/codex-rs/core/src/config/types.rs
+++ b/codex-rs/core/src/config/types.rs
@@ -530,6 +530,19 @@ pub struct AppsConfigToml {
     pub apps: HashMap<String, AppConfig>,
 }
 
+/// Config overrides for the synthesized `codex_apps` MCP server.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub struct CodexAppsMcpConfigToml {
+    /// Explicit allow-list of tools exposed from the synthesized `codex_apps` server.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enabled_tools: Option<Vec<String>>,
+
+    /// Explicit deny-list of tools exposed from the synthesized `codex_apps` server.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disabled_tools: Option<Vec<String>>,
+}
+
 // ===== OTEL configuration =====
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]


### PR DESCRIPTION
## Summary

Expose a top-level `codex_apps_mcp` config section so Codex can apply explicit enabled/disabled tool filters to the synthesized `codex_apps` MCP server.

## Why

## What

- add `codex_apps_mcp.enabled_tools` / `codex_apps_mcp.disabled_tools` config types
- load the new top-level config section through the normal CLI config path
- merge those overrides into the synthesized `codex_apps` MCP server config before tools are exposed
- add coverage proving the CLI override reaches the server config and that per-server tool filtering still behaves as expected

## Context

## Validation

