### PR TITLE
fix: MacOSAutomationPermission::BundleIDs should allow communicating …

### DIFF
--- a/codex-rs/core/src/seatbelt_permissions.rs
+++ b/codex-rs/core/src/seatbelt_permissions.rs
@@ -82,7 +82,7 @@ pub(crate) fn build_seatbelt_extensions(
         MacOsAutomationPermission::BundleIds(bundle_ids) => {
             if !bundle_ids.is_empty() {
                 clauses.push(
-                    "(allow mach-lookup (global-name \"com.apple.coreservices.appleevents\"))"
+                    "(allow mach-lookup\n  (global-name \"com.apple.coreservices.launchservicesd\")\n  (global-name \"com.apple.coreservices.appleevents\"))"
                         .to_string(),
                 );
                 let destinations = bundle_ids


### PR DESCRIPTION
…with launchservicesd

Add mach lookup for `launchservicesd` when extending the sandbox for `MacOSAutomationPermission::BundleIDs`. This is necessary so that the target application can be launched for automation.

This omission was due to a spec error in a document, which has been fixed.