### PR TITLE
feat: make sub-agent nicknames configurable via config.toml

### DIFF
--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -6,6 +6,13 @@
       "description": "A path that is guaranteed to be absolute and normalized (though it is not guaranteed to be canonicalized or exist on the filesystem).\n\nIMPORTANT: When deserializing an `AbsolutePathBuf`, a base path must be set using [AbsolutePathBufGuard::new]. If no base path is set, the deserialization will fail unless the path being deserialized is already absolute.",
       "type": "string"
     },
+    "AgentNicknameMode": {
+      "enum": [
+        "append",
+        "replace"
+      ],
+      "type": "string"
+    },
     "AgentRoleToml": {
       "additionalProperties": false,
       "properties": {
@@ -46,6 +53,18 @@
           "format": "uint",
           "minimum": 1.0,
           "type": "integer"
+        },
+        "nickname_mode": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/AgentNicknameMode"
+            }
+          ],
+          "description": "How `nicknames` should apply to the built-in nickname list."
+        },
+        "nicknames": {
+          "description": "Comma-separated custom nicknames for spawned sub-agents.\n\nExample: `nicknames = \"Atlas, Nova, Vega\"`",
+          "type": "string"
         }
       },
       "type": "object"


### PR DESCRIPTION
## Summary

- Add `nicknames` (comma-separated string) and `nickname_mode` (`"append"` | `"replace"`) to the `[agents]` section in `~/.codex/config.toml`, allowing users to customize the sub-agent nickname pool.
- `append` (default) adds custom names after the built-in list; `replace` uses only the custom names. When `nicknames` is unset, behavior is unchanged.
- Includes config parsing with deduplication/trimming, updated schema, unit tests for both modes, config round-trip test, and a spawn integration test.

### Example

```toml
[agents]
nicknames = "Atlas, Nova, Vega"
nickname_mode = "replace"
```

## Test plan

- [x] `agent_nickname_list_appends_custom_names` — verifies append mode includes both built-in and custom names
- [x] `agent_nickname_list_replaces_builtin_names` — verifies replace mode returns only custom names
- [x] `load_config_parses_agents_nickname_csv_and_mode` — verifies CSV parsing, trimming, dedup, and mode round-trip
- [x] `spawn_thread_subagent_uses_replaced_custom_nickname_pool` — end-to-end: spawned agent gets a nickname from the custom pool


Made with [Cursor](https://cursor.com)