### PR TITLE
Clarify escalation guidance for sandbox-related network failures

### DIFF
--- a/codex-rs/protocol/src/prompts/permissions/approval_policy/on_request_rule.md
+++ b/codex-rs/protocol/src/prompts/permissions/approval_policy/on_request_rule.md
@@ -27,7 +27,7 @@ IMPORTANT: To request approval to execute a command that will require escalated 
 - Include a short question asking the user if they want to allow the action in `justification` parameter. e.g. "Do you want to download and install dependencies for this project?"
 - Optionally suggest a `prefix_rule` - this will be shown to the user with an option to persist the rule approval for future sessions.
 
-If you run a command that is important to solving the user's query, but it fails because of sandboxing, rerun the command with "require_escalated". ALWAYS proceed to use the `justification` parameter - do not message the user before requesting approval for the command.
+If you run a command that is important to solving the user's query, but it fails because of sandboxing or with a likely sandbox-related network error (for example DNS/host resolution, registry/index access, or dependency download failure), rerun the command with "require_escalated". ALWAYS proceed to use the `justification` parameter - do not message the user before requesting approval for the command.
 
 ## When to request escalation
 
@@ -35,7 +35,7 @@ While commands are running inside the sandbox, here are some scenarios that will
 
 - You need to run a command that writes to a directory that requires it (e.g. running tests that write to /var)
 - You need to run a GUI app (e.g., open/xdg-open/osascript) to open browsers or files.
-- If you run a command that is important to solving the user's query, but it fails because of sandboxing, rerun the command with `require_escalated`. ALWAYS proceed to use the `sandbox_permissions` and `justification` parameters. do not message the user before requesting approval for the command.
+- If you run a command that is important to solving the user's query, but it fails because of sandboxing or with a likely sandbox-related network error (for example DNS/host resolution, registry/index access, or dependency download failure), rerun the command with `require_escalated`. ALWAYS proceed to use the `sandbox_permissions` and `justification` parameters. do not message the user before requesting approval for the command.
 - You are about to take a potentially destructive action such as an `rm` or `git reset` that the user did not explicitly ask for.
 - Be judicious with escalating, but if completing the user's request requires it, you should do so - don't try and circumvent approvals by using other tools.
 
@@ -54,4 +54,3 @@ Good examples of prefixes:
 - ["gh", "pr", "check"]
 - ["pytest"]
 - ["cargo", "test"]
-


### PR DESCRIPTION
This updates the on-request permissions instructions so likely sandbox-related network failures during dependency installation are treated as escalation candidates.

Repro:
- Run `codex -a on-request -s workspace-write` in a fresh temp dir.
- Prompt: `Build a new rust app with one dependency, anyhow, and try installing the dependency`.
- Before this change, DNS/registry failures like `Could not resolve host: index.crates.io` could be treated like ordinary transient failures and not escalate.

Fix:
- Clarify that likely sandbox-related network errors such as DNS/host resolution, registry/index access, and dependency download failures should trigger escalation.

Validation:
- Rebuild the CLI and rerun the same repro. The same instructions should now be more likely to trigger escalation instead of silently stopping.

Related Slack canvas:
- https://openai.enterprise.slack.com/docs/T0BQTNSUF/F0ACVNJAV09