### PR TITLE
core: reuse parent shell snapshot for thread-spawn subagents

### DIFF
--- a/codex-rs/core/src/codex_delegate.rs
+++ b/codex-rs/core/src/codex_delegate.rs
@@ -60,6 +60,7 @@ pub(crate) async fn run_codex_thread_interactive(
         Vec::new(),
         false,
         None,
+        None,
     )
     .await?;
     let codex = Arc::new(codex);

--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -18,6 +18,7 @@ use crate::protocol::EventMsg;
 use crate::protocol::SessionConfiguredEvent;
 use crate::rollout::RolloutRecorder;
 use crate::rollout::truncation;
+use crate::shell_snapshot::ShellSnapshot;
 use crate::skills::SkillsManager;
 use codex_protocol::ThreadId;
 use codex_protocol::config_types::CollaborationModeMask;
@@ -453,6 +454,7 @@ impl ThreadManagerState {
             self.session_source.clone(),
             false,
             None,
+            None,
         )
         .await
     }
@@ -464,6 +466,7 @@ impl ThreadManagerState {
         session_source: SessionSource,
         persist_extended_history: bool,
         metrics_service_name: Option<String>,
+        inherited_shell_snapshot: Option<Arc<ShellSnapshot>>,
     ) -> CodexResult<NewThread> {
         self.spawn_thread_with_source(
             config,
@@ -474,6 +477,7 @@ impl ThreadManagerState {
             Vec::new(),
             persist_extended_history,
             metrics_service_name,
+            inherited_shell_snapshot,
         )
         .await
     }
@@ -484,6 +488,7 @@ impl ThreadManagerState {
         rollout_path: PathBuf,
         agent_control: AgentControl,
         session_source: SessionSource,
+        inherited_shell_snapshot: Option<Arc<ShellSnapshot>>,
     ) -> CodexResult<NewThread> {
         let initial_history = RolloutRecorder::get_rollout_history(&rollout_path).await?;
         self.spawn_thread_with_source(
@@ -495,6 +500,7 @@ impl ThreadManagerState {
             Vec::new(),
             false,
             None,
+            inherited_shell_snapshot,
         )
         .await
     }
@@ -506,6 +512,7 @@ impl ThreadManagerState {
         agent_control: AgentControl,
         session_source: SessionSource,
         persist_extended_history: bool,
+        inherited_shell_snapshot: Option<Arc<ShellSnapshot>>,
     ) -> CodexResult<NewThread> {
         self.spawn_thread_with_source(
             config,
@@ -516,6 +523,7 @@ impl ThreadManagerState {
             Vec::new(),
             persist_extended_history,
             None,
+            inherited_shell_snapshot,
         )
         .await
     }
@@ -541,6 +549,7 @@ impl ThreadManagerState {
             dynamic_tools,
             persist_extended_history,
             metrics_service_name,
+            None,
         )
         .await
     }
@@ -556,6 +565,7 @@ impl ThreadManagerState {
         dynamic_tools: Vec<codex_protocol::dynamic_tools::DynamicToolSpec>,
         persist_extended_history: bool,
         metrics_service_name: Option<String>,
+        inherited_shell_snapshot: Option<Arc<ShellSnapshot>>,
     ) -> CodexResult<NewThread> {
         let watch_registration = self.file_watcher.register_config(&config);
         let CodexSpawnOk {
@@ -572,6 +582,7 @@ impl ThreadManagerState {
             dynamic_tools,
             persist_extended_history,
             metrics_service_name,
+            inherited_shell_snapshot,
         )
         .await?;
         self.finalize_thread_spawn(codex, thread_id, watch_registration)


### PR DESCRIPTION
## Summary
- reuse the parent shell snapshot when spawning/forking/resuming `SessionSource::SubAgent(SubAgentSource::ThreadSpawn { .. })` sessions
- plumb inherited snapshot through `AgentControl -> ThreadManager -> Codex::spawn -> SessionConfiguration`
- skip shell snapshot refresh on cwd updates for thread-spawn subagents so inherited snapshots are not replaced

## Why
- avoids per-subagent shell snapshot creation and cleanup work
- keeps thread-spawn subagents on the parent snapshot path, matching the intended parent/child snapshot model

## Validation
- `just fmt` (in `codex-rs`)
- `cargo test -p codex-core --no-run`
- `cargo test -p codex-core spawn_agent -- --nocapture`
- `cargo test -p codex-core --test all suite::agent_jobs::spawn_agents_on_csv_runs_and_exports`

## Notes
- full `cargo test -p codex-core --test all` was left running separately for broader verification
