### PR TITLE
fix: disable Bazel builds in CI on ubuntu-24.04-arm until we can stabilize them

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -28,14 +28,17 @@ jobs:
             target: x86_64-apple-darwin
 
           # Linux
-          - os: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-gnu
           - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
-          - os: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-musl
           - os: ubuntu-24.04
             target: x86_64-unknown-linux-musl
+          # 2026-02-27 Bazel tests have been flaky on arm in CI.
+          # Disable until we can investigate and stabilize them.
+          # - os: ubuntu-24.04-arm
+          #   target: aarch64-unknown-linux-musl
+          # - os: ubuntu-24.04-arm
+          #   target: aarch64-unknown-linux-gnu
+
           # TODO: Enable Windows once we fix the toolchain issues there.
           #- os: windows-latest
           #  target: x86_64-pc-windows-gnullvm


### PR DESCRIPTION
The other three Bazel builds have experienced low flakiness in my experience whereas I find myself re-running the `ubuntu-24.04-arm` jobs often to shake out the flakes. Disabling for now.