### PR TITLE
fix: use https://git.savannah.gnu.org/git/bash instead of https://github.com/bolinfest/bash

### DIFF
--- a/.github/workflows/shell-tool-mcp.yml
+++ b/.github/workflows/shell-tool-mcp.yml
@@ -146,9 +146,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          git clone --depth 1 https://github.com/bolinfest/bash /tmp/bash
+          git clone https://git.savannah.gnu.org/git/bash /tmp/bash
           cd /tmp/bash
-          git fetch --depth 1 origin a8a1c2fac029404d3f42cd39f5a20f24b6e4fe4b
           git checkout a8a1c2fac029404d3f42cd39f5a20f24b6e4fe4b
           git apply "${GITHUB_WORKSPACE}/shell-tool-mcp/patches/bash-exec-wrapper.patch"
           ./configure --without-bash-malloc
@@ -188,9 +187,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          git clone --depth 1 https://github.com/bolinfest/bash /tmp/bash
+          git clone https://git.savannah.gnu.org/git/bash /tmp/bash
           cd /tmp/bash
-          git fetch --depth 1 origin a8a1c2fac029404d3f42cd39f5a20f24b6e4fe4b
           git checkout a8a1c2fac029404d3f42cd39f5a20f24b6e4fe4b
           git apply "${GITHUB_WORKSPACE}/shell-tool-mcp/patches/bash-exec-wrapper.patch"
           ./configure --without-bash-malloc

--- a/codex-rs/shell-escalation/README.md
+++ b/codex-rs/shell-escalation/README.md
@@ -20,7 +20,7 @@ decision to the shell-escalation protocol over a shared file descriptor (specifi
 We carry a small patch to `execute_cmd.c` (see `patches/bash-exec-wrapper.patch`) that adds support for `EXEC_WRAPPER`. The original commit message is “add support for BASH_EXEC_WRAPPER” and the patch applies cleanly to `a8a1c2fac029404d3f42cd39f5a20f24b6e4fe4b` from https://github.com/bminor/bash. To rebuild manually:
 
 ```bash
-git clone https://github.com/bminor/bash
+git clone https://git.savannah.gnu.org/git/bash
 git checkout a8a1c2fac029404d3f42cd39f5a20f24b6e4fe4b
 git apply /path/to/patches/bash-exec-wrapper.patch
 ./configure --without-bash-malloc


### PR DESCRIPTION
Historically, we cloned the Bash repo from https://github.com/bminor/bash, but for whatever reason, it was removed at some point.

I had a local clone of it, so I pushed it to https://github.com/bolinfest/bash so that we could continue running our CI job. I did this in https://github.com/openai/codex/pull/9563, and as you can see, I did not tamper with the commit hash we used as the basis of this build.

Using a personal fork is not great, so this PR changes the CI job to use what appears to be considered the source of truth for Bash, which is https://git.savannah.gnu.org/git/bash.git.

Though in testing this out, it appears this Git server does not support the combination of `git clone --depth 1 https://git.savannah.gnu.org/git/bash` and `git fetch --depth 1 origin a8a1c2fac029404d3f42cd39f5a20f24b6e4fe4b`, as it fails with the following error:

```
error: Server does not allow request for unadvertised object a8a1c2fac029404d3f42cd39f5a20f24b6e4fe4b
```

so unfortunately this means that we have to do a full clone instead of a shallow clone in our CI jobs, which will be a bit slower.

Also updated `codex-rs/shell-escalation/README.md` to reflect this change.