### PR TITLE
app-server: Add an ability to watch events in the test client

### DIFF
--- a/codex-rs/app-server-test-client/README.md
+++ b/codex-rs/app-server-test-client/README.md
@@ -18,6 +18,15 @@ cargo run -p codex-app-server-test-client -- \
 cargo run -p codex-app-server-test-client -- model-list
 ```
 
+## Watching Raw Inbound Traffic
+
+Initialize a connection, then print every inbound JSON-RPC message until you stop it with
+`Ctrl+C`:
+
+```bash
+cargo run -p codex-app-server-test-client -- watch
+```
+
 ## Testing Thread Rejoin Behavior
 
 Build and start an app server using commands above. The app-server log is written to `/tmp/codex-app-server-test-client/app-server.log`


### PR DESCRIPTION
Add a `watch` subcommand to `codex-app-server-test-client` binary to help in manual testing of events flow.
