### PR TITLE
Surface error on WS close, only retry retryable errors

### DIFF
--- a/codex-rs/codex-api/src/error.rs
+++ b/codex-rs/codex-api/src/error.rs
@@ -12,6 +12,8 @@ pub enum ApiError {
     Api { status: StatusCode, message: String },
     #[error("stream error: {0}")]
     Stream(String),
+    #[error("stream error: {0}")]
+    NonRetryableStream(String),
     #[error("context window exceeded")]
     ContextWindowExceeded,
     #[error("quota exceeded")]

--- a/codex-rs/core/src/api_bridge.rs
+++ b/codex-rs/core/src/api_bridge.rs
@@ -23,6 +23,7 @@ pub(crate) fn map_api_error(err: ApiError) -> CodexErr {
         ApiError::UsageNotIncluded => CodexErr::UsageNotIncluded,
         ApiError::Retryable { message, delay } => CodexErr::Stream(message, delay),
         ApiError::Stream(msg) => CodexErr::Stream(msg, None),
+        ApiError::NonRetryableStream(msg) => CodexErr::NonRetryableStream(msg),
         ApiError::ServerOverloaded => CodexErr::ServerOverloaded,
         ApiError::Api { status, message } => CodexErr::UnexpectedStatus(UnexpectedResponseError {
             status,

--- a/codex-rs/core/src/error.rs
+++ b/codex-rs/core/src/error.rs
@@ -74,6 +74,11 @@ pub enum CodexErr {
     #[error("stream disconnected before completion: {0}")]
     Stream(String, Option<Duration>),
 
+    /// Returned when the stream terminated in a way that should be surfaced immediately instead
+    /// of retried automatically.
+    #[error("stream disconnected before completion: {0}")]
+    NonRetryableStream(String),
+
     #[error(
         "Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying."
     )]
@@ -208,6 +213,7 @@ impl CodexErr {
             | CodexErr::LandlockSandboxExecutableNotProvided
             | CodexErr::RetryLimit(_)
             | CodexErr::ContextWindowExceeded
+            | CodexErr::NonRetryableStream(_)
             | CodexErr::ThreadNotFound(_)
             | CodexErr::AgentLimitReached { .. }
             | CodexErr::Spawn

--- a/codex-rs/core/tests/suite/agent_websocket.rs
+++ b/codex-rs/core/tests/suite/agent_websocket.rs
@@ -130,6 +130,7 @@ async fn websocket_first_turn_handles_handshake_delay_with_preconnect() -> Resul
         response_headers: Vec::new(),
         // Delay handshake so turn processing must tolerate websocket startup latency.
         accept_delay: Some(Duration::from_millis(150)),
+        close_frame: None,
     }])
     .await;
 

--- a/codex-rs/core/tests/suite/turn_state.rs
+++ b/codex-rs/core/tests/suite/turn_state.rs
@@ -104,6 +104,7 @@ async fn websocket_turn_state_persists_within_turn_and_resets_after() -> Result<
             ]],
             response_headers: vec![(TURN_STATE_HEADER.to_string(), "ts-1".to_string())],
             accept_delay: None,
+            close_frame: None,
         },
         WebSocketConnectionConfig {
             requests: vec![vec![
@@ -113,6 +114,7 @@ async fn websocket_turn_state_persists_within_turn_and_resets_after() -> Result<
             ]],
             response_headers: Vec::new(),
             accept_delay: None,
+            close_frame: None,
         },
         WebSocketConnectionConfig {
             requests: vec![vec![
@@ -122,6 +124,7 @@ async fn websocket_turn_state_persists_within_turn_and_resets_after() -> Result<
             ]],
             response_headers: Vec::new(),
             accept_delay: None,
+            close_frame: None,
         },
     ])
     .await;


### PR DESCRIPTION
Two fixes for websocket error conditions:
1. When we close the websocket on the server, we sometimes provide additional context in the close message. We should surface this to the client so they can act on it. Typically this would be validation failures that the client needs to act on.
2. When we hit one of those conditions, the websocket client will retry 5 times by default. This is not useful if we get a non-retryable error back.

This PR encodes a list of retryable websocket codes. All other codes will break from the retry loop and surface the client-provided error.
<img width="915" height="203" alt="Screenshot 2026-02-27 at 20 02 28" src="https://github.com/user-attachments/assets/845a0a64-8368-4248-8364-204d3fa232db" />

