### PR TITLE
fix: clear terminal on /new for a clean start

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -1787,6 +1787,8 @@ impl App {
     async fn handle_event(&mut self, tui: &mut tui::Tui, event: AppEvent) -> Result<AppRunControl> {
         match event {
             AppEvent::NewSession => {
+                self.clear_terminal_ui(tui, false)?;
+                self.reset_app_ui_state_after_clear();
                 self.start_fresh_session_with_summary_hint(tui).await;
             }
             AppEvent::ClearUi => {


### PR DESCRIPTION
## Summary

- `/new` starts a fresh conversation but leaves the previous session's output visible, resulting in a cluttered terminal
- This adds `clear_terminal_ui()` and `reset_app_ui_state_after_clear()` before `start_fresh_session_with_summary_hint()` in the `NewSession` handler, matching what `/clear` already does
- Starting a new conversation should feel like a clean slate — keeping stale output on screen is confusing and defeats the purpose of "new"

## Change

2 lines added to `codex-rs/tui/src/app.rs` — the `AppEvent::NewSession` handler now clears the terminal before starting the fresh session.

## Test plan

- [ ] Run `codex`, have a conversation, then type `/new`
- [ ] Verify the terminal is cleared and a fresh session starts with no leftover output
- [ ] Verify `/clear` still works as before
- [ ] Verify `/fork` is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)