### PR TITLE
Improve tool call approval footer in request input UI

### DIFF
--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -558,9 +558,6 @@ fn build_mcp_tool_approval_header(
 
 fn format_mcp_tool_label(tool_name: &str, tool_title: Option<&str>) -> String {
     match tool_title {
-        Some(tool_title) if tool_title != tool_name => {
-            format!("\"{tool_title}\" ({tool_name})")
-        }
         Some(tool_title) => format!("\"{tool_title}\""),
         None => format!("\"{tool_name}\""),
     }
@@ -811,7 +808,7 @@ mod tests {
         assert_eq!(question.header, "Approve custom_server: Run Action?");
         assert_eq!(
             question.question,
-            "The custom_server MCP server wants to run the tool \"Run Action\" (run_action), which may modify or delete data.\n\nAllow this action?"
+            "The custom_server MCP server wants to run the tool \"Run Action\", which may modify or delete data.\n\nAllow this action?"
         );
         assert!(
             question
@@ -875,7 +872,7 @@ mod tests {
         assert_eq!(question.header, "Approve Linear: Create Issue?");
         assert_eq!(
             question.question,
-            "The Linear app wants to run the tool \"Create Issue\" (create_issue), which may modify data and access external systems.\n\nTool call details:\n- projectId: \"proj_123\"\n- title: \"Approval prompt follow-up\"\n- body: \"Draft email body\"\n- description: \"Audit approval prompt copy\"\n\nAllow this action?"
+            "The Linear app wants to run the tool \"Create Issue\", which may modify data and access external systems.\n\nTool call details:\n- projectId: \"proj_123\"\n- title: \"Approval prompt follow-up\"\n- body: \"Draft email body\"\n- description: \"Audit approval prompt copy\"\n\nAllow this action?"
         );
     }
 

--- a/codex-rs/tui/src/bottom_pane/request_user_input/layout.rs
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/layout.rs
@@ -6,6 +6,7 @@ use super::RequestUserInputOverlay;
 pub(super) struct LayoutSections {
     pub(super) progress_area: Rect,
     pub(super) question_area: Rect,
+    pub(super) header_lines: Vec<String>,
     // Wrapped question text lines to render in the question area.
     pub(super) question_lines: Vec<String>,
     pub(super) options_area: Rect,
@@ -21,37 +22,42 @@ impl RequestUserInputOverlay {
         let notes_visible = !has_options || self.notes_ui_visible();
         let footer_pref = self.footer_required_height(area.width);
         let notes_pref_height = self.notes_input_height(area.width);
+        let mut header_lines = self.wrapped_header_lines(area.width);
         let mut question_lines = self.wrapped_question_lines(area.width);
+        let header_height = header_lines.len() as u16;
         let question_height = question_lines.len() as u16;
+        let prompt_height = header_height.saturating_add(question_height);
 
         let layout = if has_options {
             self.layout_with_options(
                 OptionsLayoutArgs {
                     available_height: area.height,
                     width: area.width,
-                    question_height,
+                    prompt_height,
                     notes_pref_height,
                     footer_pref,
                     notes_visible,
                 },
+                &mut header_lines,
                 &mut question_lines,
             )
         } else {
             self.layout_without_options(
                 area.height,
-                question_height,
+                prompt_height,
                 notes_pref_height,
                 footer_pref,
+                &mut header_lines,
                 &mut question_lines,
             )
         };
-
         let (progress_area, question_area, options_area, notes_area) =
             self.build_layout_areas(area, layout);
 
         LayoutSections {
             progress_area,
             question_area,
+            header_lines,
             question_lines,
             options_area,
             notes_area,
@@ -63,26 +69,44 @@ impl RequestUserInputOverlay {
     fn layout_with_options(
         &self,
         args: OptionsLayoutArgs,
+        header_lines: &mut Vec<String>,
         question_lines: &mut Vec<String>,
     ) -> LayoutPlan {
         let OptionsLayoutArgs {
             available_height,
             width,
-            mut question_height,
+            prompt_height,
             notes_pref_height,
             footer_pref,
             notes_visible,
         } = args;
         let min_options_height = available_height.min(1);
-        let max_question_height = available_height.saturating_sub(min_options_height);
-        if question_height > max_question_height {
-            question_height = max_question_height;
-            question_lines.truncate(question_height as usize);
+        let max_prompt_height = available_height.saturating_sub(min_options_height);
+        if prompt_height > max_prompt_height {
+            let overflow = prompt_height.saturating_sub(max_prompt_height);
+            let question_overflow = overflow.min(question_lines.len() as u16);
+            if question_overflow > 0 {
+                let remaining_questions = question_lines
+                    .len()
+                    .saturating_sub(question_overflow as usize);
+                question_lines.truncate(remaining_questions);
+            }
+
+            let header_overflow = overflow.saturating_sub(question_overflow);
+            if header_overflow > 0 {
+                let remaining_headers = header_lines.len().saturating_sub(header_overflow as usize);
+                header_lines.truncate(remaining_headers);
+            }
         }
+        let prompt_height = header_lines
+            .len()
+            .saturating_add(question_lines.len())
+            .try_into()
+            .unwrap_or(u16::MAX);
         self.layout_with_options_normal(
             OptionsNormalArgs {
                 available_height,
-                question_height,
+                prompt_height,
                 notes_pref_height,
                 footer_pref,
                 notes_visible,
@@ -103,18 +127,18 @@ impl RequestUserInputOverlay {
     ) -> LayoutPlan {
         let OptionsNormalArgs {
             available_height,
-            question_height,
+            prompt_height,
             notes_pref_height,
             footer_pref,
             notes_visible,
         } = args;
-        let max_options_height = available_height.saturating_sub(question_height);
+        let max_options_height = available_height.saturating_sub(prompt_height);
         let min_options_height = max_options_height.min(1);
         let mut options_height = options
             .preferred
             .min(max_options_height)
             .max(min_options_height);
-        let used = question_height.saturating_add(options_height);
+        let used = prompt_height.saturating_add(options_height);
         let mut remaining = available_height.saturating_sub(used);
 
         // When notes are hidden, prefer to reserve room for progress, footer,
@@ -159,7 +183,7 @@ impl RequestUserInputOverlay {
             let grow_by = remaining.min(options.full.saturating_sub(options_height));
             options_height = options_height.saturating_add(grow_by);
             return LayoutPlan {
-                question_height,
+                prompt_height,
                 progress_height,
                 spacer_after_question,
                 options_height,
@@ -185,7 +209,7 @@ impl RequestUserInputOverlay {
         notes_height = notes_height.saturating_add(remaining);
 
         LayoutPlan {
-            question_height,
+            prompt_height,
             progress_height,
             spacer_after_question,
             options_height,
@@ -203,18 +227,24 @@ impl RequestUserInputOverlay {
     fn layout_without_options(
         &self,
         available_height: u16,
-        question_height: u16,
+        prompt_height: u16,
         notes_pref_height: u16,
         footer_pref: u16,
+        header_lines: &mut Vec<String>,
         question_lines: &mut Vec<String>,
     ) -> LayoutPlan {
-        let required = question_height;
+        let required = prompt_height;
         if required > available_height {
-            self.layout_without_options_tight(available_height, question_height, question_lines)
+            self.layout_without_options_tight(
+                available_height,
+                prompt_height,
+                header_lines,
+                question_lines,
+            )
         } else {
             self.layout_without_options_normal(
                 available_height,
-                question_height,
+                prompt_height,
                 notes_pref_height,
                 footer_pref,
             )
@@ -225,15 +255,36 @@ impl RequestUserInputOverlay {
     fn layout_without_options_tight(
         &self,
         available_height: u16,
-        question_height: u16,
+        prompt_height: u16,
+        header_lines: &mut Vec<String>,
         question_lines: &mut Vec<String>,
     ) -> LayoutPlan {
-        let max_question_height = available_height;
-        let adjusted_question_height = question_height.min(max_question_height);
-        question_lines.truncate(adjusted_question_height as usize);
+        let max_prompt_height = available_height;
+        if prompt_height > max_prompt_height {
+            let overflow = prompt_height.saturating_sub(max_prompt_height);
+            let question_overflow = overflow.min(question_lines.len() as u16);
+            if question_overflow > 0 {
+                let remaining_questions = question_lines
+                    .len()
+                    .saturating_sub(question_overflow as usize);
+                question_lines.truncate(remaining_questions);
+            }
+
+            let header_overflow = overflow.saturating_sub(question_overflow);
+            if header_overflow > 0 {
+                let remaining_headers = header_lines.len().saturating_sub(header_overflow as usize);
+                header_lines.truncate(remaining_headers);
+            }
+        }
+
+        let prompt_height = header_lines
+            .len()
+            .saturating_add(question_lines.len())
+            .try_into()
+            .unwrap_or(u16::MAX);
 
         LayoutPlan {
-            question_height: adjusted_question_height,
+            prompt_height,
             progress_height: 0,
             spacer_after_question: 0,
             options_height: 0,
@@ -247,11 +298,11 @@ impl RequestUserInputOverlay {
     fn layout_without_options_normal(
         &self,
         available_height: u16,
-        question_height: u16,
+        prompt_height: u16,
         notes_pref_height: u16,
         footer_pref: u16,
     ) -> LayoutPlan {
-        let required = question_height;
+        let required = prompt_height;
         let mut remaining = available_height.saturating_sub(required);
         let mut notes_height = notes_pref_height.min(remaining);
         remaining = remaining.saturating_sub(notes_height);
@@ -268,7 +319,7 @@ impl RequestUserInputOverlay {
         notes_height = notes_height.saturating_add(remaining);
 
         LayoutPlan {
-            question_height,
+            prompt_height,
             progress_height,
             spacer_after_question: 0,
             options_height: 0,
@@ -301,9 +352,9 @@ impl RequestUserInputOverlay {
             x: area.x,
             y: cursor_y,
             width: area.width,
-            height: heights.question_height,
+            height: heights.prompt_height,
         };
-        cursor_y = cursor_y.saturating_add(heights.question_height);
+        cursor_y = cursor_y.saturating_add(heights.prompt_height);
         cursor_y = cursor_y.saturating_add(heights.spacer_after_question);
 
         let options_area = Rect {
@@ -329,7 +380,7 @@ impl RequestUserInputOverlay {
 #[derive(Clone, Copy, Debug)]
 struct LayoutPlan {
     progress_height: u16,
-    question_height: u16,
+    prompt_height: u16,
     spacer_after_question: u16,
     options_height: u16,
     spacer_after_options: u16,
@@ -341,7 +392,7 @@ struct LayoutPlan {
 struct OptionsLayoutArgs {
     available_height: u16,
     width: u16,
-    question_height: u16,
+    prompt_height: u16,
     notes_pref_height: u16,
     footer_pref: u16,
     notes_visible: bool,
@@ -350,7 +401,7 @@ struct OptionsLayoutArgs {
 #[derive(Clone, Copy, Debug)]
 struct OptionsNormalArgs {
     available_height: u16,
-    question_height: u16,
+    prompt_height: u16,
     notes_pref_height: u16,
     footer_pref: u16,
     notes_visible: bool,

--- a/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
@@ -35,6 +35,7 @@ use codex_protocol::request_user_input::RequestUserInputAnswer;
 use codex_protocol::request_user_input::RequestUserInputEvent;
 use codex_protocol::request_user_input::RequestUserInputResponse;
 use codex_protocol::user_input::TextElement;
+use textwrap::Options;
 use unicode_width::UnicodeWidthStr;
 
 const NOTES_PLACEHOLDER: &str = "Add notes";
@@ -248,12 +249,13 @@ impl RequestUserInputOverlay {
 
     pub(super) fn wrapped_question_lines(&self, width: u16) -> Vec<String> {
         self.current_question()
-            .map(|q| {
-                textwrap::wrap(&q.question, width.max(1) as usize)
-                    .into_iter()
-                    .map(|line| line.to_string())
-                    .collect::<Vec<_>>()
-            })
+            .map(|question| wrap_plain_text_lines(&question.question, width))
+            .unwrap_or_default()
+    }
+
+    pub(super) fn wrapped_header_lines(&self, width: u16) -> Vec<String> {
+        self.current_question()
+            .map(|question| wrap_plain_text_lines(&question.header, width))
             .unwrap_or_default()
     }
 
@@ -985,6 +987,28 @@ impl RequestUserInputOverlay {
     }
 }
 
+fn wrap_plain_text_lines(text: &str, width: u16) -> Vec<String> {
+    let width = width.max(1) as usize;
+    text.split('\n')
+        .flat_map(|line| {
+            let line = line.trim_end_matches('\r');
+            if line.is_empty() {
+                return vec![String::new()];
+            }
+
+            let options = if line.starts_with("- ") {
+                Options::new(width).subsequent_indent("  ")
+            } else {
+                Options::new(width)
+            };
+            textwrap::wrap(line, options)
+                .into_iter()
+                .map(|wrapped| wrapped.into_owned())
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
 impl BottomPaneView for RequestUserInputOverlay {
     fn prefer_esc_to_handle_key_event(&self) -> bool {
         true
@@ -1447,6 +1471,30 @@ mod tests {
             is_other: false,
             is_secret: false,
             options: None,
+        }
+    }
+
+    fn approval_style_question(id: &str) -> RequestUserInputQuestion {
+        RequestUserInputQuestion {
+            id: id.to_string(),
+            header: "Approve Gmail: Send Email?".to_string(),
+            question: "The Gmail app wants to run the tool \"Send Email\" (send_email), which may modify data and access external systems.\n\nTool call details:\n- to: [\"user@example.com\"]\n- subject: \"Quarterly update\"\n- body: \"Draft email body\"\n\nAllow this action?".to_string(),
+            is_other: false,
+            is_secret: false,
+            options: Some(vec![
+                RequestUserInputQuestionOption {
+                    label: "Approve Once".to_string(),
+                    description: "Run the tool and continue.".to_string(),
+                },
+                RequestUserInputQuestionOption {
+                    label: "Deny".to_string(),
+                    description: "Decline this tool call and continue.".to_string(),
+                },
+                RequestUserInputQuestionOption {
+                    label: "Cancel".to_string(),
+                    description: "Cancel this tool call.".to_string(),
+                },
+            ]),
         }
     }
 
@@ -2520,12 +2568,16 @@ mod tests {
         );
 
         let width = 48u16;
-        let question_height = overlay.wrapped_question_lines(width).len() as u16;
+        let prompt_height = overlay
+            .wrapped_header_lines(width)
+            .len()
+            .saturating_add(overlay.wrapped_question_lines(width).len())
+            as u16;
         let options_height = overlay.options_required_height(width);
         let extras = 1u16 // progress
             .saturating_add(DESIRED_SPACERS_BETWEEN_SECTIONS)
             .saturating_add(overlay.footer_required_height(width));
-        let height = question_height
+        let height = prompt_height
             .saturating_add(options_height)
             .saturating_add(extras);
         let sections = overlay.layout_sections(Rect::new(0, 0, width, height));
@@ -2619,15 +2671,36 @@ mod tests {
         }
 
         let width = 110u16;
-        let question_height = overlay.wrapped_question_lines(width).len() as u16;
+        let prompt_height = overlay
+            .wrapped_header_lines(width)
+            .len()
+            .saturating_add(overlay.wrapped_question_lines(width).len())
+            as u16;
         let options_height = overlay.options_required_height(width);
         let height = 1u16
-            .saturating_add(question_height)
+            .saturating_add(prompt_height)
             .saturating_add(options_height)
             .saturating_add(8);
         let area = Rect::new(0, 0, width, height);
         insta::assert_snapshot!(
             "request_user_input_wrapped_options",
+            render_snapshot(&overlay, area)
+        );
+    }
+
+    #[test]
+    fn request_user_input_multiline_approval_snapshot() {
+        let (tx, _rx) = test_sender();
+        let overlay = RequestUserInputOverlay::new(
+            request_event("turn-1", vec![approval_style_question("q1")]),
+            tx,
+            true,
+            false,
+            false,
+        );
+        let area = Rect::new(0, 0, 100, 18);
+        insta::assert_snapshot!(
+            "request_user_input_multiline_approval",
             render_snapshot(&overlay, area)
         );
     }

--- a/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
@@ -1003,7 +1003,7 @@ fn wrap_plain_text_lines(text: &str, width: u16) -> Vec<String> {
             };
             textwrap::wrap(line, options)
                 .into_iter()
-                .map(|wrapped| wrapped.into_owned())
+                .map(std::borrow::Cow::into_owned)
                 .collect::<Vec<_>>()
         })
         .collect()

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_footer_wrap.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_footer_wrap.snap
@@ -1,10 +1,10 @@
 ---
 source: tui/src/bottom_pane/request_user_input/mod.rs
-assertion_line: 2600
 expression: "render_snapshot(&overlay, area)"
 ---
                                                     
   Question 1/2 (2 unanswered)                       
+  Pick one                                          
   Choose an option.                                 
                                                     
     1. Option 1  First choice.                      

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_freeform.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_freeform.snap
@@ -4,10 +4,10 @@ expression: "render_snapshot(&overlay, area)"
 ---
                                                                                                                         
   Question 1/1 (1 unanswered)                                                                                           
+  Goal                                                                                                                  
   Share details.                                                                                                        
                                                                                                                         
   › Type your answer (optional)                                                                                         
-                                                                                                                        
                                                                                                                         
                                                                                                                         
   enter to submit answer | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_hidden_options_footer.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_hidden_options_footer.snap
@@ -4,9 +4,9 @@ expression: "render_snapshot(&overlay, area)"
 ---
                                                                                 
   Question 1/1 (1 unanswered)                                                   
+  Next Step                                                                     
   What would you like to do next?                                               
                                                                                 
-    2. Run tests      Pick a crate and run its tests.                           
     3. Review a diff  Summarize or review current changes.                      
   › 4. Refactor       Tighten structure and remove dead code.                   
                                                                                 

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_long_option_text.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_long_option_text.snap
@@ -4,6 +4,7 @@ expression: "render_snapshot(&overlay, area)"
 ---
                                                                                                                         
   Question 1/1 (1 unanswered)                                                                                           
+  Status                                                                                                                
   Choose one option.                                                                                                    
                                                                                                                         
   › 1. Job: running/completed/failed/expired; Run/Experiment: succeeded/failed/    Keep async job statuses for          

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_multi_question_first.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_multi_question_first.snap
@@ -1,10 +1,10 @@
 ---
 source: tui/src/bottom_pane/request_user_input/mod.rs
-assertion_line: 2744
 expression: "render_snapshot(&overlay, area)"
 ---
                                                                                                                         
   Question 1/2 (2 unanswered)                                                                                           
+  Area                                                                                                                  
   Choose an option.                                                                                                     
                                                                                                                         
   › 1. Option 1  First choice.                                                                                          

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_multi_question_last.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_multi_question_last.snap
@@ -1,14 +1,13 @@
 ---
 source: tui/src/bottom_pane/request_user_input/mod.rs
-assertion_line: 2770
 expression: "render_snapshot(&overlay, area)"
 ---
                                                                                                                         
   Question 2/2 (2 unanswered)                                                                                           
+  Goal                                                                                                                  
   Share details.                                                                                                        
                                                                                                                         
   › Type your answer (optional)                                                                                         
-                                                                                                                        
                                                                                                                         
                                                                                                                         
                                                                                                                         

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_multiline_approval.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_multiline_approval.snap
@@ -1,0 +1,21 @@
+---
+source: tui/src/bottom_pane/request_user_input/mod.rs
+expression: "render_snapshot(&overlay, area)"
+---
+                                                                                                    
+  Question 1/1 (1 unanswered)                                                                       
+  Approve Gmail: Send Email?                                                                        
+  The Gmail app wants to run the tool "Send Email" (send_email), which may modify data and access   
+  external systems.                                                                                 
+                                                                                                    
+  Tool call details:                                                                                
+  - to: ["user@example.com"]                                                                        
+  - subject: "Quarterly update"                                                                     
+  - body: "Draft email body"                                                                        
+                                                                                                    
+  Allow this action?                                                                                
+                                                                                                    
+  › 1. Approve Once  Run the tool and continue.                                                     
+    2. Deny          Decline this tool call and continue.                                           
+                                                                                                    
+  option 1/3 | tab to add notes | enter to submit answer | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_options.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_options.snap
@@ -4,6 +4,7 @@ expression: "render_snapshot(&overlay, area)"
 ---
                                                                                                                         
   Question 1/1 (1 unanswered)                                                                                           
+  Area                                                                                                                  
   Choose an option.                                                                                                     
                                                                                                                         
   › 1. Option 1  First choice.                                                                                          

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_options_notes_visible.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_options_notes_visible.snap
@@ -1,10 +1,10 @@
 ---
 source: tui/src/bottom_pane/request_user_input/mod.rs
-assertion_line: 2321
 expression: "render_snapshot(&overlay, area)"
 ---
                                                                                                                         
   Question 1/1 (1 unanswered)                                                                                           
+  Area                                                                                                                  
   Choose an option.                                                                                                     
                                                                                                                         
   › 1. Option 1  First choice.                                                                                          
@@ -12,7 +12,6 @@ expression: "render_snapshot(&overlay, area)"
     3. Option 3  Third choice.                                                                                          
                                                                                                                         
   › Add notes                                                                                                           
-                                                                                                                        
                                                                                                                         
                                                                                                                         
                                                                                                                         

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_scrolling_options.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_scrolling_options.snap
@@ -4,12 +4,12 @@ expression: "render_snapshot(&overlay, area)"
 ---
                                                                                                                         
   Question 1/1 (1 unanswered)                                                                                           
+  Next Step                                                                                                             
   What would you like to do next?                                                                                       
                                                                                                                         
     1. Discuss a code change (Recommended)  Walk through a plan and edit code together.                                 
     2. Run tests                            Pick a crate and run its tests.                                             
     3. Review a diff                        Summarize or review current changes.                                        
   › 4. Refactor                             Tighten structure and remove dead code.                                     
-    5. Ship it                              Finalize and open a PR.                                                     
                                                                                                                         
-  tab to add notes | enter to submit answer | esc to interrupt
+  option 4/5 | tab to add notes | enter to submit answer | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_tight_height.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_tight_height.snap
@@ -4,10 +4,10 @@ expression: "render_snapshot(&overlay, area)"
 ---
                                                                                                                         
   Question 1/1 (1 unanswered)                                                                                           
+  Area                                                                                                                  
   Choose an option.                                                                                                     
                                                                                                                         
   › 1. Option 1  First choice.                                                                                          
     2. Option 2  Second choice.                                                                                         
-    3. Option 3  Third choice.                                                                                          
                                                                                                                         
-  tab to add notes | enter to submit answer | esc to interrupt
+  option 1/3 | tab to add notes | enter to submit answer | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_wrapped_options.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_wrapped_options.snap
@@ -4,6 +4,7 @@ expression: "render_snapshot(&overlay, area)"
 ---
                                                                                                               
   Question 1/1 (1 unanswered)                                                                                 
+  Next Step                                                                                                   
   Choose the next step for this task.                                                                         
                                                                                                               
   › 1. Discuss a code change  Walk through a plan, then implement it together with careful checks.            


### PR DESCRIPTION
Summary
- clarify approval indicator text and layout in `mcp_tool_call` so the TUI knows when to show the footer.
- adjust request user input layout/rendering to use the new approval hints and adapt the footer wrapping behavior.
- refresh the associated `instagram` snapshots to capture the updated footer and option rendering.

Testing
- Not run (not requested)