### PR TITLE
Gate ChatGPT user ID metrics to app surfaces

### DIFF
--- a/codex-rs/core/src/auth.rs
+++ b/codex-rs/core/src/auth.rs
@@ -262,6 +262,12 @@ impl CodexAuth {
         self.get_current_token_data().and_then(|t| t.id_token.email)
     }
 
+    /// Returns `None` if `is_chatgpt_auth()` is false.
+    pub fn get_chatgpt_user_id(&self) -> Option<String> {
+        self.get_current_token_data()
+            .and_then(|t| t.id_token.chatgpt_user_id)
+    }
+
     /// Account-facing plan classification derived from the current token.
     /// Returns a high-level `AccountPlanType` (e.g., Free/Plus/Pro/Team/…)
     /// mapped from the ID token's internal plan value. Prefer this when you

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1282,6 +1282,9 @@ impl Session {
         let account_id = auth.and_then(CodexAuth::get_account_id);
         let account_email = auth.and_then(CodexAuth::get_account_email);
         let originator = crate::default_client::originator().value;
+        let chatgpt_user_id = auth.and_then(CodexAuth::get_chatgpt_user_id).filter(|_| {
+            crate::default_client::should_emit_chatgpt_user_id_metrics(originator.as_str())
+        });
         let terminal_type = terminal::user_agent();
         let session_model = session_configuration.collaboration_mode.model().to_string();
         let mut otel_manager = OtelManager::new(
@@ -1296,6 +1299,9 @@ impl Session {
             terminal_type.clone(),
             session_configuration.session_source.clone(),
         );
+        if let Some(chatgpt_user_id) = chatgpt_user_id.as_deref() {
+            otel_manager = otel_manager.with_chatgpt_user_id(chatgpt_user_id);
+        }
         if let Some(service_name) = session_configuration.metrics_service_name.as_deref() {
             otel_manager = otel_manager.with_metrics_service_name(service_name);
         }

--- a/codex-rs/otel/src/lib.rs
+++ b/codex-rs/otel/src/lib.rs
@@ -44,6 +44,7 @@ pub struct OtelEventMetadata {
     pub(crate) auth_mode: Option<String>,
     pub(crate) account_id: Option<String>,
     pub(crate) account_email: Option<String>,
+    pub(crate) chatgpt_user_id: Option<String>,
     pub(crate) originator: String,
     pub(crate) service_name: Option<String>,
     pub(crate) session_source: String,
@@ -70,6 +71,11 @@ impl OtelManager {
 
     pub fn with_metrics_service_name(mut self, service_name: &str) -> Self {
         self.metadata.service_name = Some(sanitize_metric_tag_value(service_name));
+        self
+    }
+
+    pub fn with_chatgpt_user_id(mut self, chatgpt_user_id: &str) -> Self {
+        self.metadata.chatgpt_user_id = Some(sanitize_metric_tag_value(chatgpt_user_id));
         self
     }
 
@@ -203,7 +209,7 @@ impl OtelManager {
         if !self.metrics_use_metadata_tags {
             return Ok(Vec::new());
         }
-        let mut tags = Vec::with_capacity(7);
+        let mut tags = Vec::with_capacity(9);
         Self::push_metadata_tag(&mut tags, "auth_mode", self.metadata.auth_mode.as_deref())?;
         Self::push_metadata_tag(
             &mut tags,
@@ -221,6 +227,16 @@ impl OtelManager {
             self.metadata.service_name.as_deref(),
         )?;
         Self::push_metadata_tag(&mut tags, "model", Some(self.metadata.model.as_str()))?;
+        Self::push_metadata_tag(
+            &mut tags,
+            "enduser.id",
+            self.metadata.chatgpt_user_id.as_deref(),
+        )?;
+        Self::push_metadata_tag(
+            &mut tags,
+            "user_id",
+            self.metadata.chatgpt_user_id.as_deref(),
+        )?;
         Self::push_metadata_tag(&mut tags, "app.version", Some(self.metadata.app_version))?;
         Ok(tags)
     }

--- a/codex-rs/otel/src/traces/otel_manager.rs
+++ b/codex-rs/otel/src/traces/otel_manager.rs
@@ -78,6 +78,7 @@ impl OtelManager {
                 auth_mode: auth_mode.map(|m| m.to_string()),
                 account_id,
                 account_email,
+                chatgpt_user_id: None,
                 originator: sanitize_metric_tag_value(originator.as_str()),
                 service_name: None,
                 session_source: session_source.to_string(),

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -1560,18 +1560,27 @@ impl App {
         let auth_mode = auth_ref
             .map(CodexAuth::auth_mode)
             .map(TelemetryAuthMode::from);
-        let otel_manager = OtelManager::new(
+        let originator = codex_core::default_client::originator().value;
+        let chatgpt_user_id = auth_ref
+            .and_then(CodexAuth::get_chatgpt_user_id)
+            .filter(|_| {
+                codex_core::default_client::should_emit_chatgpt_user_id_metrics(originator.as_str())
+            });
+        let mut otel_manager = OtelManager::new(
             ThreadId::new(),
             model.as_str(),
             model.as_str(),
             auth_ref.and_then(CodexAuth::get_account_id),
             auth_ref.and_then(CodexAuth::get_account_email),
             auth_mode,
-            codex_core::default_client::originator().value,
+            originator,
             config.otel.log_user_prompt,
             codex_core::terminal::user_agent(),
             SessionSource::Cli,
         );
+        if let Some(chatgpt_user_id) = chatgpt_user_id.as_deref() {
+            otel_manager = otel_manager.with_chatgpt_user_id(chatgpt_user_id);
+        }
         if config
             .tui_status_line
             .as_ref()


### PR DESCRIPTION
## Summary
- add a ChatGPT user ID accessor in auth and thread it into OTLP metrics metadata
- gate user ID emission behind an app-only opt-in env and a narrow originator allowlist so standalone OSS CLI stays unchanged
- emit both `enduser.id` and `user_id` metric tags and add a focused metrics test

## Tests
- `cargo fmt --manifest-path codex-rs/Cargo.toml --all`
- `cargo test --manifest-path codex-rs/Cargo.toml -p codex-otel manager_attaches_chatgpt_user_id_tags_when_present` *(blocked in this fresh clone by git dependency fetch/setup)*
- `cargo test --manifest-path codex-rs/Cargo.toml -p codex-core app_originator_allowlist_for_chatgpt_user_id_metrics_is_narrow` *(blocked in this fresh clone by git dependency fetch/setup)*

## Notes
- Paired with openai/openai#726938 for the app-side opt-in env plumbing.