### PR TITLE
feat(core): persist native teams and add team task tools

### DIFF
--- a/codex-rs/core/Cargo.toml
+++ b/codex-rs/core/Cargo.toml
@@ -108,7 +108,7 @@ toml = { workspace = true }
 toml_edit = { workspace = true }
 tracing = { workspace = true, features = ["log"] }
 url = { workspace = true }
-uuid = { workspace = true, features = ["serde", "v4", "v5"] }
+uuid = { workspace = true, features = ["serde", "v4", "v5", "v7"] }
 which = { workspace = true }
 wildmatch = { workspace = true }
 zip = { workspace = true }

--- a/codex-rs/core/src/session_prefix.rs
+++ b/codex-rs/core/src/session_prefix.rs
@@ -13,6 +13,23 @@ pub(crate) fn format_subagent_notification_message(agent_id: &str, status: &Agen
     SUBAGENT_NOTIFICATION_FRAGMENT.wrap(payload_json)
 }
 
+pub(crate) fn format_team_notification_message(
+    team_id: &str,
+    member_name: &str,
+    agent_id: &str,
+    status: &AgentStatus,
+) -> String {
+    let payload_json = serde_json::json!({
+        "type": "teammate_idle",
+        "team_id": team_id,
+        "member_name": member_name,
+        "agent_id": agent_id,
+        "status": status,
+    })
+    .to_string();
+    SUBAGENT_NOTIFICATION_FRAGMENT.wrap(payload_json)
+}
+
 pub(crate) fn format_subagent_context_line(agent_id: &str, agent_nickname: Option<&str>) -> String {
     match agent_nickname.filter(|nickname| !nickname.is_empty()) {
         Some(agent_nickname) => format!("- {agent_id}: {agent_nickname}"),

--- a/codex-rs/core/src/state/mod.rs
+++ b/codex-rs/core/src/state/mod.rs
@@ -1,10 +1,15 @@
 mod service;
 mod session;
+mod task_store;
 mod team_registry;
 mod turn;
 
 pub(crate) use service::SessionServices;
 pub(crate) use session::SessionState;
+pub(crate) use task_store::NewTask;
+pub(crate) use task_store::TaskStatus;
+pub(crate) use task_store::TaskStore;
+pub(crate) use task_store::TaskUpdate;
 pub(crate) use team_registry::TeamMember;
 pub(crate) use team_registry::TeamRegistry;
 pub(crate) use team_registry::TeamState;

--- a/codex-rs/core/src/state/mod.rs
+++ b/codex-rs/core/src/state/mod.rs
@@ -1,9 +1,13 @@
 mod service;
 mod session;
+mod team_registry;
 mod turn;
 
 pub(crate) use service::SessionServices;
 pub(crate) use session::SessionState;
+pub(crate) use team_registry::TeamMember;
+pub(crate) use team_registry::TeamRegistry;
+pub(crate) use team_registry::TeamState;
 pub(crate) use turn::ActiveTurn;
 pub(crate) use turn::RunningTask;
 pub(crate) use turn::TaskKind;

--- a/codex-rs/core/src/state/task_store.rs
+++ b/codex-rs/core/src/state/task_store.rs
@@ -1,0 +1,449 @@
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json::Value;
+use std::collections::BTreeMap;
+use std::collections::HashSet;
+use std::fs;
+use std::fs::OpenOptions;
+use std::path::Path;
+use std::path::PathBuf;
+use std::time::Duration;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+use uuid::Uuid;
+
+const TASK_ROOT_DIR: &str = "tasks";
+const LOCK_FILENAME: &str = ".lock";
+const LOCK_RETRIES: usize = 10;
+const LOCK_RETRY_SLEEP: Duration = Duration::from_millis(50);
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum TaskStatus {
+    Pending,
+    InProgress,
+    Blocked,
+    Completed,
+    Cancelled,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub(crate) struct Task {
+    pub(crate) id: String,
+    pub(crate) subject: String,
+    pub(crate) description: Option<String>,
+    pub(crate) status: TaskStatus,
+    pub(crate) owner: Option<String>,
+    pub(crate) active_form: Option<String>,
+    pub(crate) blocks: Vec<String>,
+    pub(crate) blocked_by: Vec<String>,
+    pub(crate) metadata: BTreeMap<String, Value>,
+    pub(crate) created_at: i64,
+    pub(crate) updated_at: i64,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct NewTask {
+    pub(crate) subject: String,
+    pub(crate) description: Option<String>,
+    pub(crate) owner: Option<String>,
+    pub(crate) active_form: Option<String>,
+    pub(crate) blocks: Vec<String>,
+    pub(crate) blocked_by: Vec<String>,
+    pub(crate) metadata: BTreeMap<String, Value>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub(crate) struct TaskUpdate {
+    pub(crate) status: Option<TaskStatus>,
+    pub(crate) owner: Option<Option<String>>,
+    pub(crate) subject: Option<String>,
+    pub(crate) description: Option<Option<String>>,
+    pub(crate) active_form: Option<Option<String>>,
+    pub(crate) blocks: Option<Vec<String>>,
+    pub(crate) blocked_by: Option<Vec<String>>,
+    pub(crate) metadata: Option<BTreeMap<String, Value>>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct TaskStore {
+    team_dir: PathBuf,
+}
+
+impl TaskStore {
+    pub(crate) fn new(codex_home: &Path, team_name: &str) -> Self {
+        Self {
+            team_dir: codex_home.join(TASK_ROOT_DIR).join(slugify(team_name)),
+        }
+    }
+
+    pub(crate) fn create_task(&self, mut input: NewTask) -> Result<Task, String> {
+        self.with_exclusive_lock(|| {
+            input.subject = sanitize_required(&input.subject, "subject")?;
+            input.description = normalize_optional_string(input.description);
+            input.owner = normalize_optional_string(input.owner);
+            input.active_form = normalize_optional_string(input.active_form);
+            input.blocks = normalize_dependencies(input.blocks)?;
+            input.blocked_by = normalize_dependencies(input.blocked_by)?;
+
+            let now = now_unix_seconds()?;
+            let task = Task {
+                id: format!("task-{}", Uuid::now_v7()),
+                subject: input.subject,
+                description: input.description,
+                status: TaskStatus::Pending,
+                owner: input.owner,
+                active_form: input.active_form,
+                blocks: input.blocks,
+                blocked_by: input.blocked_by,
+                metadata: input.metadata,
+                created_at: now,
+                updated_at: now,
+            };
+            self.write_task(&task)?;
+            Ok(task)
+        })
+    }
+
+    pub(crate) fn list_tasks(&self) -> Result<Vec<Task>, String> {
+        self.with_shared_lock(|| {
+            self.ensure_team_dir()?;
+            let mut tasks = Vec::new();
+            let entries = fs::read_dir(&self.team_dir)
+                .map_err(|err| format!("failed to read {}: {err}", self.team_dir.display()))?;
+            for entry in entries {
+                let Ok(entry) = entry else {
+                    continue;
+                };
+                let path = entry.path();
+                if !path.is_file() {
+                    continue;
+                }
+                if path.file_name().is_some_and(|name| name == LOCK_FILENAME) {
+                    continue;
+                }
+                if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+                    continue;
+                }
+                let payload = fs::read_to_string(&path)
+                    .map_err(|err| format!("failed to read {}: {err}", path.display()))?;
+                let task: Task = serde_json::from_str(&payload)
+                    .map_err(|err| format!("failed to parse {}: {err}", path.display()))?;
+                tasks.push(task);
+            }
+            tasks.sort_by(|left, right| {
+                left.created_at
+                    .cmp(&right.created_at)
+                    .then_with(|| left.id.cmp(&right.id))
+            });
+            Ok(tasks)
+        })
+    }
+
+    pub(crate) fn get_task(&self, task_id: &str) -> Result<Option<Task>, String> {
+        self.with_shared_lock(|| {
+            let path = self.task_path(task_id);
+            if !path.exists() {
+                return Ok(None);
+            }
+            let payload = fs::read_to_string(&path)
+                .map_err(|err| format!("failed to read {}: {err}", path.display()))?;
+            let task = serde_json::from_str(&payload)
+                .map_err(|err| format!("failed to parse {}: {err}", path.display()))?;
+            Ok(Some(task))
+        })
+    }
+
+    pub(crate) fn update_task(
+        &self,
+        task_id: &str,
+        update: TaskUpdate,
+    ) -> Result<Option<Task>, String> {
+        self.with_exclusive_lock(|| {
+            let path = self.task_path(task_id);
+            if !path.exists() {
+                return Ok(None);
+            }
+
+            let payload = fs::read_to_string(&path)
+                .map_err(|err| format!("failed to read {}: {err}", path.display()))?;
+            let mut task: Task = serde_json::from_str(&payload)
+                .map_err(|err| format!("failed to parse {}: {err}", path.display()))?;
+
+            if let Some(status) = update.status {
+                task.status = status;
+            }
+            if let Some(owner) = update.owner {
+                task.owner = normalize_optional_string(owner);
+            }
+            if let Some(subject) = update.subject {
+                task.subject = sanitize_required(&subject, "subject")?;
+            }
+            if let Some(description) = update.description {
+                task.description = normalize_optional_string(description);
+            }
+            if let Some(active_form) = update.active_form {
+                task.active_form = normalize_optional_string(active_form);
+            }
+            if let Some(blocks) = update.blocks {
+                task.blocks = normalize_dependencies(blocks)?;
+            }
+            if let Some(blocked_by) = update.blocked_by {
+                task.blocked_by = normalize_dependencies(blocked_by)?;
+            }
+            if let Some(metadata) = update.metadata {
+                task.metadata = metadata;
+            }
+            task.updated_at = now_unix_seconds()?;
+
+            self.write_task(&task)?;
+            Ok(Some(task))
+        })
+    }
+
+    fn with_exclusive_lock<T>(
+        &self,
+        work: impl FnOnce() -> Result<T, String>,
+    ) -> Result<T, String> {
+        self.with_lock(false, work)
+    }
+
+    fn with_shared_lock<T>(&self, work: impl FnOnce() -> Result<T, String>) -> Result<T, String> {
+        self.with_lock(true, work)
+    }
+
+    fn with_lock<T>(
+        &self,
+        shared: bool,
+        work: impl FnOnce() -> Result<T, String>,
+    ) -> Result<T, String> {
+        self.ensure_team_dir()?;
+
+        let lock_path = self.team_dir.join(LOCK_FILENAME);
+        let lock_file = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&lock_path)
+            .map_err(|err| format!("failed to open lock file {}: {err}", lock_path.display()))?;
+
+        for _ in 0..LOCK_RETRIES {
+            let lock_result = if shared {
+                lock_file.try_lock_shared().map_err(std::io::Error::from)
+            } else {
+                lock_file.try_lock().map_err(std::io::Error::from)
+            };
+            match lock_result {
+                Ok(()) => {
+                    let result = work();
+                    return result;
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                    std::thread::sleep(LOCK_RETRY_SLEEP);
+                }
+                Err(err) => {
+                    return Err(format!(
+                        "failed to lock task store {}: {err}",
+                        lock_path.display()
+                    ));
+                }
+            }
+        }
+
+        Err(format!(
+            "could not acquire task store lock {} after {} retries",
+            lock_path.display(),
+            LOCK_RETRIES
+        ))
+    }
+
+    fn ensure_team_dir(&self) -> Result<(), String> {
+        fs::create_dir_all(&self.team_dir)
+            .map_err(|err| format!("failed to create {}: {err}", self.team_dir.display()))
+    }
+
+    fn write_task(&self, task: &Task) -> Result<(), String> {
+        let path = self.task_path(&task.id);
+        let payload = serde_json::to_vec_pretty(task)
+            .map_err(|err| format!("failed to serialize task {}: {err}", task.id))?;
+        fs::write(&path, payload)
+            .map_err(|err| format!("failed to write {}: {err}", path.display()))
+    }
+
+    fn task_path(&self, task_id: &str) -> PathBuf {
+        self.team_dir.join(format!("{task_id}.json"))
+    }
+}
+
+fn now_unix_seconds() -> Result<i64, String> {
+    let duration = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|err| format!("system clock error: {err}"))?;
+    i64::try_from(duration.as_secs()).map_err(|err| format!("timestamp overflow: {err}"))
+}
+
+fn sanitize_required(value: &str, field: &str) -> Result<String, String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(format!("{field} cannot be empty"));
+    }
+    Ok(trimmed.to_string())
+}
+
+fn normalize_optional_string(value: Option<String>) -> Option<String> {
+    value.and_then(|raw| {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+        Some(trimmed.to_string())
+    })
+}
+
+fn normalize_dependencies(values: Vec<String>) -> Result<Vec<String>, String> {
+    let mut normalized = Vec::new();
+    let mut seen = HashSet::new();
+    for value in values {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            return Err("dependency values cannot be empty".to_string());
+        }
+        if seen.insert(trimmed.to_string()) {
+            normalized.push(trimmed.to_string());
+        }
+    }
+    Ok(normalized)
+}
+
+fn slugify(name: &str) -> String {
+    let mut slug = String::new();
+    let mut pending_dash = false;
+    for ch in name.trim().chars() {
+        if ch.is_ascii_alphanumeric() {
+            if pending_dash && !slug.is_empty() {
+                slug.push('-');
+            }
+            slug.push(ch.to_ascii_lowercase());
+            pending_dash = false;
+        } else {
+            pending_dash = true;
+        }
+    }
+    if slug.is_empty() {
+        return "team".to_string();
+    }
+    slug
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use tempfile::tempdir;
+
+    #[test]
+    fn create_list_get_update_round_trip() {
+        let home = tempdir().expect("tempdir");
+        let store = TaskStore::new(home.path(), "Alpha Team");
+
+        let created = store
+            .create_task(NewTask {
+                subject: "Implement persistence".to_string(),
+                description: Some("Write config.json to disk".to_string()),
+                owner: Some("lead".to_string()),
+                active_form: Some("implementing".to_string()),
+                blocks: vec!["task-2".to_string()],
+                blocked_by: vec![],
+                metadata: BTreeMap::from([("priority".to_string(), Value::from("high"))]),
+            })
+            .expect("task should be created");
+
+        assert_eq!(created.status, TaskStatus::Pending);
+        assert_eq!(created.subject, "Implement persistence");
+
+        let listed = store.list_tasks().expect("list tasks");
+        assert_eq!(listed, vec![created.clone()]);
+
+        let fetched = store
+            .get_task(&created.id)
+            .expect("get task")
+            .expect("task should exist");
+        assert_eq!(fetched, created);
+
+        let updated = store
+            .update_task(
+                &fetched.id,
+                TaskUpdate {
+                    status: Some(TaskStatus::InProgress),
+                    owner: Some(Some("worker-1".to_string())),
+                    subject: Some("Implement team persistence".to_string()),
+                    description: Some(Some("Persist teams under ~/.codex/teams".to_string())),
+                    active_form: Some(None),
+                    blocks: Some(vec!["task-3".to_string(), "task-3".to_string()]),
+                    blocked_by: Some(vec!["task-1".to_string()]),
+                    metadata: Some(BTreeMap::from([(
+                        "priority".to_string(),
+                        Value::from("critical"),
+                    )])),
+                },
+            )
+            .expect("update task")
+            .expect("task should exist");
+
+        assert_eq!(updated.status, TaskStatus::InProgress);
+        assert_eq!(updated.owner, Some("worker-1".to_string()));
+        assert_eq!(updated.subject, "Implement team persistence");
+        assert_eq!(updated.active_form, None);
+        assert_eq!(updated.blocks, vec!["task-3".to_string()]);
+        assert_eq!(updated.blocked_by, vec!["task-1".to_string()]);
+        assert_eq!(
+            updated.metadata.get("priority"),
+            Some(&Value::from("critical"))
+        );
+        assert!(updated.updated_at >= updated.created_at);
+    }
+
+    #[test]
+    fn create_rejects_empty_subject() {
+        let home = tempdir().expect("tempdir");
+        let store = TaskStore::new(home.path(), "alpha");
+
+        let result = store.create_task(NewTask {
+            subject: "   ".to_string(),
+            description: None,
+            owner: None,
+            active_form: None,
+            blocks: vec![],
+            blocked_by: vec![],
+            metadata: BTreeMap::new(),
+        });
+        assert_eq!(result, Err("subject cannot be empty".to_string()));
+    }
+
+    #[test]
+    fn update_missing_task_returns_none() {
+        let home = tempdir().expect("tempdir");
+        let store = TaskStore::new(home.path(), "alpha");
+
+        let updated = store
+            .update_task(
+                "task-missing",
+                TaskUpdate {
+                    status: Some(TaskStatus::Completed),
+                    ..TaskUpdate::default()
+                },
+            )
+            .expect("update should succeed");
+        assert_eq!(updated, None);
+    }
+
+    #[test]
+    fn list_returns_empty_when_no_tasks_exist() {
+        let home = tempdir().expect("tempdir");
+        let store = TaskStore::new(home.path(), "alpha");
+
+        let listed = store.list_tasks().expect("list should succeed");
+        assert_eq!(listed, Vec::<Task>::new());
+    }
+}

--- a/codex-rs/core/src/state/team_registry.rs
+++ b/codex-rs/core/src/state/team_registry.rs
@@ -1,0 +1,232 @@
+use codex_protocol::ThreadId;
+use std::collections::HashMap;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct TeamMember {
+    pub(crate) name: String,
+    pub(crate) thread_id: ThreadId,
+    pub(crate) nickname: Option<String>,
+    pub(crate) role: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct TeamState {
+    pub(crate) team_id: String,
+    pub(crate) team_name: String,
+    pub(crate) lead_name: String,
+    pub(crate) lead_thread_id: ThreadId,
+    pub(crate) auto_cleanup: bool,
+    members: HashMap<String, TeamMember>,
+}
+
+#[derive(Default, Debug)]
+pub(crate) struct TeamRegistry {
+    teams: HashMap<String, TeamState>,
+    next_team_id: u64,
+}
+
+impl TeamState {
+    pub(crate) fn member(&self, name: &str) -> Option<&TeamMember> {
+        self.members.get(&normalize_name(name))
+    }
+
+    pub(crate) fn member_by_thread_id(&self, thread_id: ThreadId) -> Option<&TeamMember> {
+        self.members
+            .values()
+            .find(|member| member.thread_id == thread_id)
+    }
+
+    pub(crate) fn members(&self) -> impl Iterator<Item = &TeamMember> {
+        self.members.values()
+    }
+
+    pub(crate) fn member_count(&self) -> usize {
+        self.members.len()
+    }
+}
+
+impl TeamRegistry {
+    pub(crate) fn create_team(
+        &mut self,
+        team_name: Option<&str>,
+        lead: TeamMember,
+        workers: Vec<TeamMember>,
+        auto_cleanup: bool,
+    ) -> Result<TeamState, String> {
+        let lead_name = sanitize_non_empty(&lead.name, "lead_name")?;
+        let normalized_lead_name = normalize_name(&lead_name);
+        let lead_thread_id = lead.thread_id;
+
+        let mut members = HashMap::new();
+        members.insert(
+            normalized_lead_name.clone(),
+            TeamMember {
+                name: lead_name.clone(),
+                ..lead
+            },
+        );
+
+        for worker in workers {
+            let worker_name = sanitize_non_empty(&worker.name, "member_name")?;
+            let key = normalize_name(&worker_name);
+            if members.contains_key(&key) {
+                return Err(format!("duplicate team member name: {worker_name}"));
+            }
+            members.insert(
+                key,
+                TeamMember {
+                    name: worker_name,
+                    ..worker
+                },
+            );
+        }
+
+        self.next_team_id = self.next_team_id.saturating_add(1);
+        let team_id = format!("team-{}", self.next_team_id);
+        let normalized_team_name = team_name
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| format!("team-{}", self.next_team_id));
+        let state = TeamState {
+            team_id: team_id.clone(),
+            team_name: normalized_team_name,
+            lead_name,
+            lead_thread_id,
+            auto_cleanup,
+            members,
+        };
+        self.teams.insert(team_id, state.clone());
+        Ok(state)
+    }
+
+    pub(crate) fn team(&self, team_id: &str) -> Option<TeamState> {
+        self.teams.get(team_id).cloned()
+    }
+
+    pub(crate) fn remove_team(&mut self, team_id: &str) -> Option<TeamState> {
+        self.teams.remove(team_id)
+    }
+
+    pub(crate) fn teams(&self) -> Vec<TeamState> {
+        self.teams.values().cloned().collect()
+    }
+}
+
+fn normalize_name(name: &str) -> String {
+    name.trim().to_ascii_lowercase()
+}
+
+fn sanitize_non_empty(value: &str, field: &str) -> Result<String, String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(format!("{field} cannot be empty"));
+    }
+    Ok(trimmed.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codex_protocol::ThreadId;
+    use pretty_assertions::assert_eq;
+
+    fn thread(id: &str) -> ThreadId {
+        ThreadId::from_string(id).expect("valid thread id")
+    }
+
+    #[test]
+    fn create_team_rejects_duplicate_names_case_insensitively() {
+        let mut registry = TeamRegistry::default();
+        let result = registry.create_team(
+            Some("alpha"),
+            TeamMember {
+                name: "Lead".to_string(),
+                thread_id: thread("019ca37e-d7fb-75d1-bf05-afc056f49305"),
+                nickname: None,
+                role: Some("team-lead".to_string()),
+            },
+            vec![TeamMember {
+                name: "lead".to_string(),
+                thread_id: thread("019ca381-3a17-77b0-aa54-1161c2033360"),
+                nickname: None,
+                role: Some("runtime-agent".to_string()),
+            }],
+            false,
+        );
+        assert_eq!(result, Err("duplicate team member name: lead".to_string()));
+    }
+
+    #[test]
+    fn create_team_and_lookup_by_name_and_thread() {
+        let lead_id = thread("019ca37e-d7fb-75d1-bf05-afc056f49305");
+        let worker_id = thread("019ca381-3a17-77b0-aa54-1161c2033360");
+
+        let mut registry = TeamRegistry::default();
+        let team = registry
+            .create_team(
+                Some("alpha"),
+                TeamMember {
+                    name: "orchestrator".to_string(),
+                    thread_id: lead_id,
+                    nickname: None,
+                    role: Some("team-lead".to_string()),
+                },
+                vec![TeamMember {
+                    name: "Feynman".to_string(),
+                    thread_id: worker_id,
+                    nickname: Some("Feynman".to_string()),
+                    role: Some("runtime-agent".to_string()),
+                }],
+                true,
+            )
+            .expect("team should be created");
+
+        assert_eq!(team.lead_thread_id, lead_id);
+        assert_eq!(team.auto_cleanup, true);
+        assert_eq!(team.member_count(), 2);
+        assert_eq!(
+            team.member("feynman").map(|member| member.thread_id),
+            Some(worker_id)
+        );
+        assert_eq!(
+            team.member_by_thread_id(lead_id)
+                .map(|member| member.name.as_str()),
+            Some("orchestrator")
+        );
+    }
+
+    #[test]
+    fn teams_lists_created_teams() {
+        let mut registry = TeamRegistry::default();
+        let _ = registry.create_team(
+            Some("alpha"),
+            TeamMember {
+                name: "lead".to_string(),
+                thread_id: thread("019ca37e-d7fb-75d1-bf05-afc056f49305"),
+                nickname: None,
+                role: Some("team-lead".to_string()),
+            },
+            vec![],
+            false,
+        );
+        let _ = registry.create_team(
+            Some("beta"),
+            TeamMember {
+                name: "lead2".to_string(),
+                thread_id: thread("019ca381-3a17-77b0-aa54-1161c2033360"),
+                nickname: None,
+                role: Some("team-lead".to_string()),
+            },
+            vec![],
+            true,
+        );
+        let mut teams = registry.teams();
+        teams.sort_by(|left, right| left.team_name.cmp(&right.team_name));
+        assert_eq!(teams.len(), 2);
+        assert_eq!(teams[0].team_name, "alpha");
+        assert_eq!(teams[1].team_name, "beta");
+        assert_eq!(teams[0].auto_cleanup, false);
+        assert_eq!(teams[1].auto_cleanup, true);
+    }
+}

--- a/codex-rs/core/src/state/team_registry.rs
+++ b/codex-rs/core/src/state/team_registry.rs
@@ -1,5 +1,15 @@
 use codex_protocol::ThreadId;
+use serde::Deserialize;
+use serde::Serialize;
 use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+use uuid::Uuid;
+
+const TEAM_PERSIST_DIR: &str = "teams";
+const TEAM_CONFIG_FILENAME: &str = "config.json";
+const TEAM_PERSIST_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct TeamMember {
@@ -19,10 +29,41 @@ pub(crate) struct TeamState {
     members: HashMap<String, TeamMember>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct TeamMembershipInfo {
+    pub(crate) team_id: String,
+    pub(crate) member_name: String,
+    pub(crate) lead_thread_id: ThreadId,
+}
+
 #[derive(Default, Debug)]
 pub(crate) struct TeamRegistry {
     teams: HashMap<String, TeamState>,
+    team_dirs: HashMap<String, PathBuf>,
     next_team_id: u64,
+    persist_dir: Option<PathBuf>,
+    loaded_from_disk: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+struct PersistedTeamMember {
+    name: String,
+    thread_id: String,
+    nickname: Option<String>,
+    role: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+struct PersistedTeamConfig {
+    schema_version: u32,
+    team_id: String,
+    team_name: String,
+    lead_name: String,
+    lead_thread_id: String,
+    auto_cleanup: bool,
+    members: Vec<PersistedTeamMember>,
 }
 
 impl TeamState {
@@ -46,6 +87,16 @@ impl TeamState {
 }
 
 impl TeamRegistry {
+    pub(crate) fn configure_persistence(&mut self, codex_home: &Path) -> Result<(), String> {
+        let persist_dir = codex_home.join(TEAM_PERSIST_DIR);
+        if self.persist_dir.as_ref() == Some(&persist_dir) && self.loaded_from_disk {
+            return Ok(());
+        }
+        self.persist_dir = Some(persist_dir);
+        self.loaded_from_disk = false;
+        self.load_from_disk_if_needed()
+    }
+
     pub(crate) fn create_team(
         &mut self,
         team_name: Option<&str>,
@@ -53,13 +104,15 @@ impl TeamRegistry {
         workers: Vec<TeamMember>,
         auto_cleanup: bool,
     ) -> Result<TeamState, String> {
+        self.load_from_disk_if_needed()?;
+
         let lead_name = sanitize_non_empty(&lead.name, "lead_name")?;
         let normalized_lead_name = normalize_name(&lead_name);
         let lead_thread_id = lead.thread_id;
 
         let mut members = HashMap::new();
         members.insert(
-            normalized_lead_name.clone(),
+            normalized_lead_name,
             TeamMember {
                 name: lead_name.clone(),
                 ..lead
@@ -97,6 +150,7 @@ impl TeamRegistry {
             members,
         };
         self.teams.insert(team_id, state.clone());
+        self.persist_team(&state)?;
         Ok(state)
     }
 
@@ -105,12 +159,239 @@ impl TeamRegistry {
     }
 
     pub(crate) fn remove_team(&mut self, team_id: &str) -> Option<TeamState> {
-        self.teams.remove(team_id)
+        let removed = self.teams.remove(team_id);
+        if removed.is_some()
+            && let Err(err) = self.remove_persisted_team(team_id)
+        {
+            tracing::warn!(team_id, %err, "failed to remove persisted team");
+        }
+        removed
     }
 
     pub(crate) fn teams(&self) -> Vec<TeamState> {
         self.teams.values().cloned().collect()
     }
+
+    /// Cheap lookup: is this thread_id a member of any team?
+    /// Returns (team_id, member_name, lead_thread_id) if found.
+    /// Skips members whose thread_id matches the lead (the lead doesn't need self-notification).
+    pub(crate) fn team_membership(&self, thread_id: ThreadId) -> Option<TeamMembershipInfo> {
+        self.teams.values().find_map(|team| {
+            if thread_id == team.lead_thread_id {
+                return None;
+            }
+            team.member_by_thread_id(thread_id)
+                .map(|member| TeamMembershipInfo {
+                    team_id: team.team_id.clone(),
+                    member_name: member.name.clone(),
+                    lead_thread_id: team.lead_thread_id,
+                })
+        })
+    }
+
+    fn load_from_disk_if_needed(&mut self) -> Result<(), String> {
+        if self.loaded_from_disk {
+            return Ok(());
+        }
+        let Some(persist_dir) = self.persist_dir.clone() else {
+            self.loaded_from_disk = true;
+            return Ok(());
+        };
+        self.load_from_disk(&persist_dir)
+    }
+
+    fn load_from_disk(&mut self, persist_dir: &Path) -> Result<(), String> {
+        fs::create_dir_all(persist_dir).map_err(|err| {
+            format!(
+                "failed to create team persistence directory {}: {err}",
+                persist_dir.display()
+            )
+        })?;
+
+        for team in self.teams.values() {
+            if let Some(id) = parse_team_numeric_id(&team.team_id) {
+                self.next_team_id = self.next_team_id.max(id);
+            }
+        }
+
+        let entries = fs::read_dir(persist_dir).map_err(|err| {
+            format!(
+                "failed to read team persistence directory {}: {err}",
+                persist_dir.display()
+            )
+        })?;
+        for entry in entries {
+            let Ok(entry) = entry else {
+                continue;
+            };
+            let team_dir = entry.path();
+            if !team_dir.is_dir() {
+                continue;
+            }
+            let config_path = team_dir.join(TEAM_CONFIG_FILENAME);
+            if !config_path.exists() {
+                continue;
+            }
+            let serialized = match fs::read_to_string(&config_path) {
+                Ok(content) => content,
+                Err(err) => {
+                    tracing::warn!(path = %config_path.display(), %err, "failed to read team config");
+                    continue;
+                }
+            };
+            let persisted = match serde_json::from_str::<PersistedTeamConfig>(&serialized) {
+                Ok(config) => config,
+                Err(err) => {
+                    tracing::warn!(path = %config_path.display(), %err, "failed to parse team config");
+                    continue;
+                }
+            };
+            let team = match team_from_persisted(persisted) {
+                Ok(team) => team,
+                Err(err) => {
+                    tracing::warn!(path = %config_path.display(), %err, "failed to decode team config");
+                    continue;
+                }
+            };
+            if let Some(id) = parse_team_numeric_id(&team.team_id) {
+                self.next_team_id = self.next_team_id.max(id);
+            }
+            if self.teams.contains_key(&team.team_id) {
+                continue;
+            }
+            self.team_dirs.insert(team.team_id.clone(), team_dir);
+            self.teams.insert(team.team_id.clone(), team);
+        }
+        self.loaded_from_disk = true;
+        Ok(())
+    }
+
+    fn persist_team(&mut self, team: &TeamState) -> Result<(), String> {
+        let Some(persist_root) = self.persist_dir.clone() else {
+            return Ok(());
+        };
+        fs::create_dir_all(&persist_root).map_err(|err| {
+            format!(
+                "failed to create team persistence directory {}: {err}",
+                persist_root.display()
+            )
+        })?;
+
+        let team_dir = if let Some(existing) = self.team_dirs.get(&team.team_id) {
+            existing.clone()
+        } else {
+            let dir = persist_root.join(format!("{}-{}", slugify(&team.team_name), team.team_id));
+            self.team_dirs.insert(team.team_id.clone(), dir.clone());
+            dir
+        };
+        fs::create_dir_all(&team_dir).map_err(|err| {
+            format!(
+                "failed to create team directory {}: {err}",
+                team_dir.display()
+            )
+        })?;
+
+        let persisted = persisted_from_team(team);
+        let serialized = serde_json::to_vec_pretty(&persisted)
+            .map_err(|err| format!("failed to serialize team config {}: {err}", team.team_id))?;
+        let config_path = team_dir.join(TEAM_CONFIG_FILENAME);
+        write_json_atomic(&config_path, &serialized)
+    }
+
+    fn remove_persisted_team(&mut self, team_id: &str) -> Result<(), String> {
+        let Some(team_dir) = self.team_dirs.remove(team_id) else {
+            return Ok(());
+        };
+        if !team_dir.exists() {
+            return Ok(());
+        }
+        fs::remove_dir_all(&team_dir).map_err(|err| {
+            format!(
+                "failed to remove team directory {}: {err}",
+                team_dir.display()
+            )
+        })
+    }
+}
+
+fn team_from_persisted(persisted: PersistedTeamConfig) -> Result<TeamState, String> {
+    if persisted.schema_version > TEAM_PERSIST_SCHEMA_VERSION {
+        return Err(format!(
+            "unsupported team config schema_version {}",
+            persisted.schema_version
+        ));
+    }
+    let lead_name = sanitize_non_empty(&persisted.lead_name, "lead_name")?;
+    let lead_thread_id = ThreadId::from_string(&persisted.lead_thread_id)
+        .map_err(|err| format!("invalid lead_thread_id: {err}"))?;
+    let team_id = sanitize_non_empty(&persisted.team_id, "team_id")?;
+    let team_name = sanitize_non_empty(&persisted.team_name, "team_name")?;
+
+    let mut members = HashMap::new();
+    for member in persisted.members {
+        let member_name = sanitize_non_empty(&member.name, "member_name")?;
+        let key = normalize_name(&member_name);
+        if members.contains_key(&key) {
+            return Err(format!("duplicate team member name: {member_name}"));
+        }
+        let thread_id = ThreadId::from_string(&member.thread_id)
+            .map_err(|err| format!("invalid member thread_id for {member_name}: {err}"))?;
+        members.insert(
+            key,
+            TeamMember {
+                name: member_name,
+                thread_id,
+                nickname: member.nickname,
+                role: member.role,
+            },
+        );
+    }
+
+    let normalized_lead_name = normalize_name(&lead_name);
+    members
+        .entry(normalized_lead_name)
+        .or_insert_with(|| TeamMember {
+            name: lead_name.clone(),
+            thread_id: lead_thread_id,
+            nickname: None,
+            role: Some("team-lead".to_string()),
+        });
+
+    Ok(TeamState {
+        team_id,
+        team_name,
+        lead_name,
+        lead_thread_id,
+        auto_cleanup: persisted.auto_cleanup,
+        members,
+    })
+}
+
+fn persisted_from_team(team: &TeamState) -> PersistedTeamConfig {
+    let mut members = team
+        .members()
+        .map(|member| PersistedTeamMember {
+            name: member.name.clone(),
+            thread_id: member.thread_id.to_string(),
+            nickname: member.nickname.clone(),
+            role: member.role.clone(),
+        })
+        .collect::<Vec<_>>();
+    members.sort_by(|left, right| left.name.cmp(&right.name));
+
+    PersistedTeamConfig {
+        schema_version: TEAM_PERSIST_SCHEMA_VERSION,
+        team_id: team.team_id.clone(),
+        team_name: team.team_name.clone(),
+        lead_name: team.lead_name.clone(),
+        lead_thread_id: team.lead_thread_id.to_string(),
+        auto_cleanup: team.auto_cleanup,
+        members,
+    }
+}
+
+fn parse_team_numeric_id(team_id: &str) -> Option<u64> {
+    team_id.strip_prefix("team-")?.parse::<u64>().ok()
 }
 
 fn normalize_name(name: &str) -> String {
@@ -125,11 +406,47 @@ fn sanitize_non_empty(value: &str, field: &str) -> Result<String, String> {
     Ok(trimmed.to_string())
 }
 
+fn slugify(name: &str) -> String {
+    let mut slug = String::new();
+    let mut pending_dash = false;
+    for ch in name.trim().chars() {
+        if ch.is_ascii_alphanumeric() {
+            if pending_dash && !slug.is_empty() {
+                slug.push('-');
+            }
+            slug.push(ch.to_ascii_lowercase());
+            pending_dash = false;
+        } else {
+            pending_dash = true;
+        }
+    }
+    if slug.is_empty() {
+        return "team".to_string();
+    }
+    slug
+}
+
+fn write_json_atomic(path: &Path, payload: &[u8]) -> Result<(), String> {
+    let tmp_path = path.with_extension(format!("tmp-{}", Uuid::new_v4()));
+    fs::write(&tmp_path, payload)
+        .map_err(|err| format!("failed to write temp file {}: {err}", tmp_path.display()))?;
+    if let Err(err) = fs::rename(&tmp_path, path) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(format!(
+            "failed to rename {} to {}: {err}",
+            tmp_path.display(),
+            path.display()
+        ));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use codex_protocol::ThreadId;
     use pretty_assertions::assert_eq;
+    use tempfile::tempdir;
 
     fn thread(id: &str) -> ThreadId {
         ThreadId::from_string(id).expect("valid thread id")
@@ -228,5 +545,139 @@ mod tests {
         assert_eq!(teams[1].team_name, "beta");
         assert_eq!(teams[0].auto_cleanup, false);
         assert_eq!(teams[1].auto_cleanup, true);
+    }
+
+    #[test]
+    fn configure_persistence_restores_teams_from_disk() {
+        let home = tempdir().expect("tempdir");
+        let lead_id = thread("019ca37e-d7fb-75d1-bf05-afc056f49305");
+        let worker_id = thread("019ca381-3a17-77b0-aa54-1161c2033360");
+
+        let team_id = {
+            let mut registry = TeamRegistry::default();
+            registry
+                .configure_persistence(home.path())
+                .expect("configure persistence");
+            registry
+                .create_team(
+                    Some("alpha"),
+                    TeamMember {
+                        name: "lead".to_string(),
+                        thread_id: lead_id,
+                        nickname: None,
+                        role: Some("team-lead".to_string()),
+                    },
+                    vec![TeamMember {
+                        name: "worker".to_string(),
+                        thread_id: worker_id,
+                        nickname: Some("Worker".to_string()),
+                        role: Some("runtime-agent".to_string()),
+                    }],
+                    false,
+                )
+                .expect("team should be created")
+                .team_id
+        };
+
+        let mut restored = TeamRegistry::default();
+        restored
+            .configure_persistence(home.path())
+            .expect("configure persistence");
+        let restored_team = restored.team(&team_id).expect("team should be restored");
+        assert_eq!(restored_team.team_name, "alpha");
+        assert_eq!(
+            restored_team
+                .member_by_thread_id(worker_id)
+                .map(|member| member.name.as_str()),
+            Some("worker")
+        );
+
+        let next = restored
+            .create_team(
+                Some("beta"),
+                TeamMember {
+                    name: "lead-2".to_string(),
+                    thread_id: ThreadId::new(),
+                    nickname: None,
+                    role: Some("team-lead".to_string()),
+                },
+                vec![],
+                false,
+            )
+            .expect("second team should be created");
+        assert_eq!(next.team_id, "team-2");
+    }
+
+    #[test]
+    fn remove_team_deletes_persisted_state() {
+        let home = tempdir().expect("tempdir");
+
+        let (team_id, team_dir) = {
+            let mut registry = TeamRegistry::default();
+            registry
+                .configure_persistence(home.path())
+                .expect("configure persistence");
+            let team = registry
+                .create_team(
+                    Some("alpha"),
+                    TeamMember {
+                        name: "lead".to_string(),
+                        thread_id: ThreadId::new(),
+                        nickname: None,
+                        role: Some("team-lead".to_string()),
+                    },
+                    vec![],
+                    false,
+                )
+                .expect("team should be created");
+            let team_dir = home.path().join(TEAM_PERSIST_DIR).join(format!(
+                "{}-{}",
+                slugify(&team.team_name),
+                team.team_id
+            ));
+            (team.team_id, team_dir)
+        };
+
+        let mut registry = TeamRegistry::default();
+        registry
+            .configure_persistence(home.path())
+            .expect("configure persistence");
+        assert!(registry.remove_team(&team_id).is_some());
+        assert!(!team_dir.exists(), "team directory should be removed");
+    }
+
+    #[test]
+    fn team_membership_finds_non_lead_members() {
+        let lead_id = thread("019ca37e-d7fb-75d1-bf05-afc056f49305");
+        let worker_id = thread("019ca381-3a17-77b0-aa54-1161c2033360");
+        let mut registry = TeamRegistry::default();
+        let team = registry
+            .create_team(
+                Some("alpha"),
+                TeamMember {
+                    name: "lead".to_string(),
+                    thread_id: lead_id,
+                    nickname: None,
+                    role: Some("team-lead".to_string()),
+                },
+                vec![TeamMember {
+                    name: "worker".to_string(),
+                    thread_id: worker_id,
+                    nickname: None,
+                    role: Some("runtime-agent".to_string()),
+                }],
+                false,
+            )
+            .expect("team should be created");
+
+        assert_eq!(
+            registry.team_membership(worker_id),
+            Some(TeamMembershipInfo {
+                team_id: team.team_id,
+                member_name: "worker".to_string(),
+                lead_thread_id: lead_id,
+            })
+        );
+        assert_eq!(registry.team_membership(lead_id), None);
     }
 }

--- a/codex-rs/core/src/tools/handlers/multi_agents.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents.rs
@@ -1541,13 +1541,14 @@ mod task {
         registry
             .configure_persistence(turn.config.codex_home.as_path())
             .map_err(FunctionCallError::Fatal)?;
-        let team_name = registry
-            .team(team_id)
-            .map(|team| team.team_name.clone())
-            .ok_or_else(|| {
-                FunctionCallError::RespondToModel(format!("team not found: {team_id}"))
-            })?;
-        Ok(TaskStore::new(turn.config.codex_home.as_path(), &team_name))
+        let team = registry.team(team_id).ok_or_else(|| {
+            FunctionCallError::RespondToModel(format!("team not found: {team_id}"))
+        })?;
+        Ok(TaskStore::new(
+            turn.config.codex_home.as_path(),
+            &team.team_id,
+            &team.team_name,
+        ))
     }
 }
 

--- a/codex-rs/core/src/tools/spec.rs
+++ b/codex-rs/core/src/tools/spec.rs
@@ -1402,6 +1402,12 @@ fn create_team_cleanup_tool() -> ToolSpec {
 fn create_task_create_tool() -> ToolSpec {
     let properties = BTreeMap::from([
         (
+            "team_id".to_string(),
+            JsonSchema::String {
+                description: Some("Team id returned by spawn_team.".to_string()),
+            },
+        ),
+        (
             "subject".to_string(),
             JsonSchema::String {
                 description: Some("A brief, actionable title for the task.".to_string()),
@@ -1425,48 +1431,90 @@ fn create_task_create_tool() -> ToolSpec {
                 ),
             },
         ),
+        (
+            "owner".to_string(),
+            JsonSchema::String {
+                description: Some("Optional owner for the task.".to_string()),
+            },
+        ),
+        (
+            "blocks".to_string(),
+            JsonSchema::Array {
+                description: Some("Task IDs that this task blocks.".to_string()),
+                items: Box::new(JsonSchema::String { description: None }),
+            },
+        ),
+        (
+            "blocked_by".to_string(),
+            JsonSchema::Array {
+                description: Some("Task IDs that currently block this task.".to_string()),
+                items: Box::new(JsonSchema::String { description: None }),
+            },
+        ),
+        (
+            "metadata".to_string(),
+            JsonSchema::Object {
+                properties: BTreeMap::new(),
+                required: None,
+                additional_properties: Some(AdditionalProperties::Boolean(true)),
+            },
+        ),
     ]);
 
     ToolSpec::Function(ResponsesApiTool {
         name: "task_create".to_string(),
-        description: "Create a new task to track work in the current session.".to_string(),
+        description: "Create a new task for a team.".to_string(),
         strict: false,
         parameters: JsonSchema::Object {
             properties,
-            required: Some(vec!["subject".to_string()]),
+            required: Some(vec!["team_id".to_string(), "subject".to_string()]),
             additional_properties: Some(false.into()),
         },
     })
 }
 
 fn create_task_list_tool() -> ToolSpec {
+    let properties = BTreeMap::from([(
+        "team_id".to_string(),
+        JsonSchema::String {
+            description: Some("Team id returned by spawn_team.".to_string()),
+        },
+    )]);
     ToolSpec::Function(ResponsesApiTool {
         name: "task_list".to_string(),
-        description: "List all tasks in the current session.".to_string(),
+        description: "List all tasks for a team.".to_string(),
         strict: false,
         parameters: JsonSchema::Object {
-            properties: BTreeMap::new(),
-            required: Some(vec![]),
+            properties,
+            required: Some(vec!["team_id".to_string()]),
             additional_properties: Some(false.into()),
         },
     })
 }
 
 fn create_task_get_tool() -> ToolSpec {
-    let properties = BTreeMap::from([(
-        "task_id".to_string(),
-        JsonSchema::String {
-            description: Some("The ID of the task to retrieve.".to_string()),
-        },
-    )]);
+    let properties = BTreeMap::from([
+        (
+            "team_id".to_string(),
+            JsonSchema::String {
+                description: Some("Team id returned by spawn_team.".to_string()),
+            },
+        ),
+        (
+            "task_id".to_string(),
+            JsonSchema::String {
+                description: Some("The ID of the task to retrieve.".to_string()),
+            },
+        ),
+    ]);
 
     ToolSpec::Function(ResponsesApiTool {
         name: "task_get".to_string(),
-        description: "Retrieve full details of a task by its ID.".to_string(),
+        description: "Retrieve full details of a team task by its ID.".to_string(),
         strict: false,
         parameters: JsonSchema::Object {
             properties,
-            required: Some(vec!["task_id".to_string()]),
+            required: Some(vec!["team_id".to_string(), "task_id".to_string()]),
             additional_properties: Some(false.into()),
         },
     })
@@ -1474,6 +1522,12 @@ fn create_task_get_tool() -> ToolSpec {
 
 fn create_task_update_tool() -> ToolSpec {
     let properties = BTreeMap::from([
+        (
+            "team_id".to_string(),
+            JsonSchema::String {
+                description: Some("Team id returned by spawn_team.".to_string()),
+            },
+        ),
         (
             "task_id".to_string(),
             JsonSchema::String {
@@ -1516,16 +1570,16 @@ fn create_task_update_tool() -> ToolSpec {
             },
         ),
         (
-            "add_blocks".to_string(),
+            "blocks".to_string(),
             JsonSchema::Array {
-                description: Some("Task IDs that this task blocks.".to_string()),
+                description: Some("Replace with task IDs that this task blocks.".to_string()),
                 items: Box::new(JsonSchema::String { description: None }),
             },
         ),
         (
-            "add_blocked_by".to_string(),
+            "blocked_by".to_string(),
             JsonSchema::Array {
-                description: Some("Task IDs that block this task.".to_string()),
+                description: Some("Replace with task IDs that block this task.".to_string()),
                 items: Box::new(JsonSchema::String { description: None }),
             },
         ),
@@ -1545,7 +1599,7 @@ fn create_task_update_tool() -> ToolSpec {
         strict: false,
         parameters: JsonSchema::Object {
             properties,
-            required: Some(vec!["task_id".to_string()]),
+            required: Some(vec!["team_id".to_string(), "task_id".to_string()]),
             additional_properties: Some(false.into()),
         },
     })


### PR DESCRIPTION
## Summary
- add persistent `TeamRegistry` loading/saving under `~/.codex/teams`
- add team-aware task tools (`task_create`, `task_list`, `task_get`, `task_update`) with file-backed storage under `~/.codex/tasks/<team-name>`
- wire team idle notifications through `agent/control` + `session_prefix` formatting
- register new task tool specs/handlers and extend multi-agent handler tests

## Validation
- `cargo check -p codex-core -p codex-tui`
- `cargo test -p codex-core task_tools_`
- `cargo test -p codex-core` *(currently has pre-existing unrelated integration failures in this environment, including rmcp/search/shell snapshot suites)*
