### PR TITLE
feat(tui): add native team command + Shift+Down agent picker

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -1882,8 +1882,8 @@ impl App {
                     if size.width <= 1 || size.height <= 1 {
                         // Some terminals briefly report 0x0/1x1 while a new tab is
                         // initializing. Skip rendering for that transient state so we
-                        // don't draw a one-column, left-edge-stacked UI.
-                        tui.frame_requester().schedule_frame();
+                        // don't draw a one-column, left-edge-stacked UI. A redraw will
+                        // happen naturally on the next terminal event (for example resize).
                         return Ok(AppRunControl::Continue);
                     }
                     if self.backtrack_render_pending {

--- a/codex-rs/tui/src/bottom_pane/footer.rs
+++ b/codex-rs/tui/src/bottom_pane/footer.rs
@@ -689,6 +689,7 @@ fn shortcut_overlay_lines(state: ShortcutsState) -> Vec<Line<'static>> {
     let mut quit = Line::from("");
     let mut show_transcript = Line::from("");
     let mut change_mode = Line::from("");
+    let mut agents = Line::from("");
 
     for descriptor in SHORTCUTS {
         if let Some(text) = descriptor.overlay_entry(state) {
@@ -704,6 +705,7 @@ fn shortcut_overlay_lines(state: ShortcutsState) -> Vec<Line<'static>> {
                 ShortcutId::Quit => quit = text,
                 ShortcutId::ShowTranscript => show_transcript = text,
                 ShortcutId::ChangeMode => change_mode = text,
+                ShortcutId::Agents => agents = text,
             }
         }
     }
@@ -721,6 +723,9 @@ fn shortcut_overlay_lines(state: ShortcutsState) -> Vec<Line<'static>> {
     ];
     if change_mode.width() > 0 {
         ordered.push(change_mode);
+    }
+    if agents.width() > 0 {
+        ordered.push(agents);
     }
     ordered.push(Line::from(""));
     ordered.push(show_transcript);
@@ -802,6 +807,7 @@ enum ShortcutId {
     Quit,
     ShowTranscript,
     ChangeMode,
+    Agents,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -983,6 +989,15 @@ const SHORTCUTS: &[ShortcutDescriptor] = &[
         }],
         prefix: "",
         label: " to change mode",
+    },
+    ShortcutDescriptor {
+        id: ShortcutId::Agents,
+        bindings: &[ShortcutBinding {
+            key: key_hint::shift(KeyCode::Down),
+            condition: DisplayCondition::Always,
+        }],
+        prefix: "",
+        label: " for agents",
     },
 ];
 

--- a/codex-rs/tui/src/bottom_pane/pending_thread_approvals.rs
+++ b/codex-rs/tui/src/bottom_pane/pending_thread_approvals.rs
@@ -61,7 +61,7 @@ impl PendingThreadApprovals {
             Line::from(vec![
                 "    ".into(),
                 "/agent".cyan().bold(),
-                " to switch threads".dim(),
+                " or Shift+Down to switch threads".dim(),
             ])
             .dim(),
         );
@@ -118,9 +118,10 @@ mod tests {
 
         assert_snapshot!(
             snapshot_rows(&widget, 40).replace(' ', "."),
-            @r"
-..!.Approval.needed.in.Robie.[explorer].
-..../agent.to.switch.threads............"
+            @"
+        ..!.Approval.needed.in.Robie.[explorer].
+        ..../agent.or.Shift+Down.to.switch.threa
+        "
         );
     }
 
@@ -141,7 +142,7 @@ mod tests {
 ..!.Approval.needed.in.Robie.[explorer].....
 ..!.Approval.needed.in.Inspector............
 ............................................
-..../agent.to.switch.threads................"
+..../agent.or.Shift+Down.to.switch.threads.."
         );
     }
 }

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_mode_shortcut_overlay.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_mode_shortcut_overlay.snap
@@ -14,5 +14,5 @@ expression: terminal.backend()
 "  shift + enter for newline                  tab to queue message                                   "
 "  @ for file paths                           ctrl + v to paste images                               "
 "  ctrl + g to edit in external editor        esc again to edit previous message                     "
-"  ctrl + c to exit                                                                                  "
-"  ctrl + t to view transcript                                                                       "
+"  ctrl + c to exit                           shift + ↓ for agents                                   "
+"                                             ctrl + t to view transcript                            "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_shortcuts_collaboration_modes_enabled.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_shortcuts_collaboration_modes_enabled.snap
@@ -1,6 +1,5 @@
 ---
 source: tui/src/bottom_pane/footer.rs
-assertion_line: 535
 expression: terminal.backend()
 ---
 "  / for commands                             ! for shell commands               "
@@ -8,4 +7,5 @@ expression: terminal.backend()
 "  @ for file paths                           ctrl + v to paste images           "
 "  ctrl + g to edit in external editor        esc esc to edit previous message   "
 "  ctrl + c to exit                           shift + tab to change mode         "
-"                                             ctrl + t to view transcript        "
+"  shift + ↓ for agents                                                          "
+"  ctrl + t to view transcript                                                   "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_shortcuts_shift_and_esc.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_shortcuts_shift_and_esc.snap
@@ -6,5 +6,5 @@ expression: terminal.backend()
 "  shift + enter for newline                  tab to queue message               "
 "  @ for file paths                           ctrl + v to paste images           "
 "  ctrl + g to edit in external editor        esc again to edit previous message "
-"  ctrl + c to exit                                                              "
-"  ctrl + t to view transcript                                                   "
+"  ctrl + c to exit                           shift + ↓ for agents               "
+"                                             ctrl + t to view transcript        "

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -3934,7 +3934,19 @@ impl ChatWidget {
                 self.bottom_pane.drain_pending_submission_state();
             }
             SlashCommand::Team if !trimmed.is_empty() => {
-                let mut parts = trimmed.splitn(2, char::is_whitespace);
+                let prepared_args = self.bottom_pane.composer_text_with_pending();
+                let normalized_args = prepared_args
+                    .trim()
+                    .strip_prefix("/team")
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .unwrap_or(trimmed);
+                if normalized_args.is_empty() {
+                    self.dispatch_command(SlashCommand::Team);
+                    return;
+                }
+
+                let mut parts = normalized_args.splitn(2, char::is_whitespace);
                 let Some(subcommand) = parts.next() else {
                     self.dispatch_command(SlashCommand::Team);
                     return;

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -3304,6 +3304,15 @@ impl ChatWidget {
                 self.quit_shortcut_key = None;
             }
             KeyEvent {
+                code: KeyCode::Down,
+                modifiers: KeyModifiers::SHIFT,
+                kind: KeyEventKind::Press,
+                ..
+            } if self.bottom_pane.no_modal_or_popup_active() => {
+                self.app_event_tx.send(AppEvent::OpenAgentPicker);
+                return;
+            }
+            KeyEvent {
                 code: KeyCode::Char(c),
                 modifiers,
                 kind: KeyEventKind::Press,

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -4498,6 +4498,15 @@ async fn team_slash_command_without_args_shows_usage() {
 }
 
 #[tokio::test]
+async fn shift_down_opens_agent_picker() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(None).await;
+
+    chat.handle_key_event(KeyEvent::new(KeyCode::Down, KeyModifiers::SHIFT));
+
+    assert_matches!(rx.try_recv(), Ok(AppEvent::OpenAgentPicker));
+}
+
+#[tokio::test]
 async fn team_slash_list_submits_list_teams_prompt() {
     let (mut chat, _rx, mut op_rx) = make_chatwidget_manual(None).await;
     configure_session(&mut chat);

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -31,6 +31,7 @@ pub enum SlashCommand {
     Plan,
     Collab,
     Agent,
+    Team,
     // Undo,
     Diff,
     Copy,
@@ -94,6 +95,7 @@ impl SlashCommand {
             SlashCommand::Plan => "switch to Plan mode",
             SlashCommand::Collab => "change collaboration mode (experimental)",
             SlashCommand::Agent => "switch the active agent thread",
+            SlashCommand::Team => "run team operations: /team <subcommand>",
             SlashCommand::Approvals => "choose what Codex is allowed to do",
             SlashCommand::Permissions => "choose what Codex is allowed to do",
             SlashCommand::ElevateSandbox => "set up elevated agent sandbox",
@@ -123,6 +125,7 @@ impl SlashCommand {
                 | SlashCommand::Rename
                 | SlashCommand::Plan
                 | SlashCommand::SandboxReadRoot
+                | SlashCommand::Team
         )
     }
 
@@ -168,6 +171,7 @@ impl SlashCommand {
             SlashCommand::Settings => true,
             SlashCommand::Collab => true,
             SlashCommand::Agent => true,
+            SlashCommand::Team => false,
             SlashCommand::Statusline => false,
             SlashCommand::Theme => false,
         }


### PR DESCRIPTION
## Summary
- add `/team` slash command bridge in chat widget and command enum
- add native `Shift+Down` keybinding to open the agent picker
- surface the new shortcut in footer and pending-approval hints
- update TUI snapshots for the changed shortcut overlays
- include the wrapping/app startup hardening fix used by this fork

## Validation
- `cargo check -p codex-core -p codex-tui`
- `cargo test -p codex-tui`
