### PR TITLE
keyring: split-entry keyring storage for auth token

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -2158,6 +2158,9 @@ name = "codex-keyring-store"
 version = "0.0.0"
 dependencies = [
  "keyring",
+ "pretty_assertions",
+ "serde",
+ "serde_json",
  "tracing",
 ]
 

--- a/codex-rs/keyring-store/Cargo.toml
+++ b/codex-rs/keyring-store/Cargo.toml
@@ -9,7 +9,12 @@ workspace = true
 
 [dependencies]
 keyring = { workspace = true, features = ["crypto-rust"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+pretty_assertions = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 keyring = { workspace = true, features = ["linux-native-async-persistent"] }

--- a/codex-rs/keyring-store/src/json_store_full.rs
+++ b/codex-rs/keyring-store/src/json_store_full.rs
@@ -1,0 +1,192 @@
+use crate::CredentialStoreError;
+use crate::KeyringStore;
+use serde_json::Value;
+use std::fmt;
+
+#[derive(Debug, Clone)]
+pub struct FullJsonKeyringError {
+    message: String,
+}
+
+pub type JsonKeyringError = FullJsonKeyringError;
+
+impl FullJsonKeyringError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for FullJsonKeyringError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for FullJsonKeyringError {}
+
+pub fn load_json_from_keyring<K: KeyringStore + ?Sized>(
+    keyring_store: &K,
+    service: &str,
+    base_key: &str,
+) -> Result<Option<Value>, JsonKeyringError> {
+    if let Some(bytes) = load_secret_from_keyring(keyring_store, service, base_key, "JSON record")?
+    {
+        let value = serde_json::from_slice(&bytes).map_err(|err| {
+            FullJsonKeyringError::new(format!(
+                "failed to deserialize JSON record from keyring secret: {err}"
+            ))
+        })?;
+        return Ok(Some(value));
+    }
+
+    match keyring_store.load(service, base_key) {
+        Ok(Some(serialized)) => serde_json::from_str(&serialized).map(Some).map_err(|err| {
+            FullJsonKeyringError::new(format!(
+                "failed to deserialize JSON record from keyring password: {err}"
+            ))
+        }),
+        Ok(None) => Ok(None),
+        Err(error) => Err(credential_store_error("load", "JSON record", error)),
+    }
+}
+
+pub fn save_json_to_keyring<K: KeyringStore + ?Sized>(
+    keyring_store: &K,
+    service: &str,
+    base_key: &str,
+    value: &Value,
+) -> Result<(), JsonKeyringError> {
+    let bytes = serde_json::to_vec(value).map_err(|err| {
+        FullJsonKeyringError::new(format!("failed to serialize JSON record: {err}"))
+    })?;
+    save_secret_to_keyring(keyring_store, service, base_key, &bytes, "JSON record")
+}
+
+pub fn delete_json_from_keyring<K: KeyringStore + ?Sized>(
+    keyring_store: &K,
+    service: &str,
+    base_key: &str,
+) -> Result<bool, JsonKeyringError> {
+    delete_keyring_entry(keyring_store, service, base_key, "JSON record")
+}
+
+fn load_secret_from_keyring<K: KeyringStore + ?Sized>(
+    keyring_store: &K,
+    service: &str,
+    key: &str,
+    field: &str,
+) -> Result<Option<Vec<u8>>, FullJsonKeyringError> {
+    keyring_store
+        .load_secret(service, key)
+        .map_err(|err| credential_store_error("load", field, err))
+}
+
+fn save_secret_to_keyring<K: KeyringStore + ?Sized>(
+    keyring_store: &K,
+    service: &str,
+    key: &str,
+    value: &[u8],
+    field: &str,
+) -> Result<(), FullJsonKeyringError> {
+    keyring_store
+        .save_secret(service, key, value)
+        .map_err(|err| credential_store_error("write", field, err))
+}
+
+fn delete_keyring_entry<K: KeyringStore + ?Sized>(
+    keyring_store: &K,
+    service: &str,
+    key: &str,
+    field: &str,
+) -> Result<bool, FullJsonKeyringError> {
+    keyring_store
+        .delete(service, key)
+        .map_err(|err| credential_store_error("delete", field, err))
+}
+
+fn credential_store_error(
+    action: &str,
+    field: &str,
+    error: CredentialStoreError,
+) -> FullJsonKeyringError {
+    FullJsonKeyringError::new(format!(
+        "failed to {action} {field} in keyring: {}",
+        error.message()
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::delete_json_from_keyring;
+    use super::load_json_from_keyring;
+    use super::save_json_to_keyring;
+    use crate::KeyringStore;
+    use crate::tests::MockKeyringStore;
+    use pretty_assertions::assert_eq;
+    use serde_json::json;
+
+    const SERVICE: &str = "Test Service";
+    const BASE_KEY: &str = "base";
+
+    #[test]
+    fn json_storage_round_trips_using_full_backend() {
+        let store = MockKeyringStore::default();
+        let expected = json!({
+            "token": "secret",
+            "nested": {"id": 7}
+        });
+
+        save_json_to_keyring(&store, SERVICE, BASE_KEY, &expected).expect("JSON should save");
+
+        let loaded = load_json_from_keyring(&store, SERVICE, BASE_KEY)
+            .expect("JSON should load")
+            .expect("JSON should exist");
+        assert_eq!(loaded, expected);
+        assert_eq!(
+            store.saved_secret(BASE_KEY),
+            Some(serde_json::to_vec(&expected).expect("JSON should serialize")),
+        );
+    }
+
+    #[test]
+    fn json_storage_loads_legacy_single_entry() {
+        let store = MockKeyringStore::default();
+        let expected = json!({
+            "token": "secret",
+            "nested": {"id": 9}
+        });
+        store
+            .save(
+                SERVICE,
+                BASE_KEY,
+                &serde_json::to_string(&expected).expect("JSON should serialize"),
+            )
+            .expect("legacy JSON should save");
+
+        let loaded = load_json_from_keyring(&store, SERVICE, BASE_KEY)
+            .expect("JSON should load")
+            .expect("JSON should exist");
+        assert_eq!(loaded, expected);
+    }
+
+    #[test]
+    fn json_storage_delete_removes_full_entry() {
+        let store = MockKeyringStore::default();
+        let expected = json!({"current": true});
+
+        save_json_to_keyring(&store, SERVICE, BASE_KEY, &expected).expect("JSON should save");
+
+        let removed = delete_json_from_keyring(&store, SERVICE, BASE_KEY)
+            .expect("JSON delete should succeed");
+
+        assert!(removed);
+        assert!(
+            load_json_from_keyring(&store, SERVICE, BASE_KEY)
+                .expect("JSON load should succeed")
+                .is_none()
+        );
+        assert!(!store.contains(BASE_KEY));
+    }
+}

--- a/codex-rs/keyring-store/src/json_store_split.rs
+++ b/codex-rs/keyring-store/src/json_store_split.rs
@@ -85,89 +85,23 @@ struct SplitJsonManifest {
 
 type SplitJsonLeafValues = Vec<(String, Vec<u8>)>;
 
-#[cfg(windows)]
 pub fn load_json_from_keyring<K: KeyringStore + ?Sized>(
     keyring_store: &K,
     service: &str,
     base_key: &str,
 ) -> Result<Option<Value>, JsonKeyringError> {
-    load_split_json_from_keyring(keyring_store, service, base_key)
-}
-
-#[cfg(not(windows))]
-pub fn load_json_from_keyring<K: KeyringStore + ?Sized>(
-    keyring_store: &K,
-    service: &str,
-    base_key: &str,
-) -> Result<Option<Value>, JsonKeyringError> {
-    if let Some(value) = load_full_json_from_keyring(keyring_store, service, base_key)? {
-        return Ok(Some(value));
-    }
-    Ok(None)
-}
-
-#[cfg(windows)]
-pub fn save_json_to_keyring<K: KeyringStore + ?Sized>(
-    keyring_store: &K,
-    service: &str,
-    base_key: &str,
-    value: &Value,
-) -> Result<(), JsonKeyringError> {
-    save_split_json_to_keyring(keyring_store, service, base_key, value)?;
-
-    Ok(())
-}
-
-#[cfg(not(windows))]
-pub fn save_json_to_keyring<K: KeyringStore + ?Sized>(
-    keyring_store: &K,
-    service: &str,
-    base_key: &str,
-    value: &Value,
-) -> Result<(), JsonKeyringError> {
-    let bytes = serde_json::to_vec(value).map_err(|err| {
-        SplitJsonKeyringError::new(format!("failed to serialize JSON record: {err}"))
-    })?;
-    save_secret_to_keyring(keyring_store, service, base_key, &bytes, "JSON record")
-}
-
-#[cfg(windows)]
-pub fn delete_json_from_keyring<K: KeyringStore + ?Sized>(
-    keyring_store: &K,
-    service: &str,
-    base_key: &str,
-) -> Result<bool, JsonKeyringError> {
-    let split_removed = delete_split_json_from_keyring(keyring_store, service, base_key)?;
-    Ok(split_removed)
-}
-
-#[cfg(not(windows))]
-pub fn delete_json_from_keyring<K: KeyringStore + ?Sized>(
-    keyring_store: &K,
-    service: &str,
-    base_key: &str,
-) -> Result<bool, JsonKeyringError> {
-    let full_removed = delete_full_json_from_keyring(keyring_store, service, base_key)?;
-    Ok(full_removed)
-}
-
-fn load_split_json_from_keyring<K: KeyringStore + ?Sized>(
-    keyring_store: &K,
-    service: &str,
-    base_key: &str,
-) -> Result<Option<Value>, SplitJsonKeyringError> {
     let Some(manifest) = load_manifest(keyring_store, service, base_key)? else {
         return Ok(None);
     };
     inflate_split_json(keyring_store, service, base_key, &manifest).map(Some)
 }
 
-fn save_split_json_to_keyring<K: KeyringStore + ?Sized>(
+pub fn save_json_to_keyring<K: KeyringStore + ?Sized>(
     keyring_store: &K,
     service: &str,
     base_key: &str,
     value: &Value,
-) -> Result<(), SplitJsonKeyringError> {
+) -> Result<(), JsonKeyringError> {
     let previous_manifest = match load_manifest(keyring_store, service, base_key) {
         Ok(manifest) => manifest,
         Err(err) => {
@@ -226,11 +160,11 @@ fn save_split_json_to_keyring<K: KeyringStore + ?Sized>(
     Ok(())
 }
 
-fn delete_split_json_from_keyring<K: KeyringStore + ?Sized>(
+pub fn delete_json_from_keyring<K: KeyringStore + ?Sized>(
     keyring_store: &K,
     service: &str,
     base_key: &str,
-) -> Result<bool, SplitJsonKeyringError> {
+) -> Result<bool, JsonKeyringError> {
     let Some(manifest) = load_manifest(keyring_store, service, base_key)? else {
         return Ok(false);
     };
@@ -252,40 +186,6 @@ fn delete_split_json_from_keyring<K: KeyringStore + ?Sized>(
     let manifest_key = layout_key(base_key, MANIFEST_ENTRY);
     removed |= delete_keyring_entry(keyring_store, service, &manifest_key, "JSON manifest")?;
     Ok(removed)
-}
-
-fn load_full_json_from_keyring<K: KeyringStore + ?Sized>(
-    keyring_store: &K,
-    service: &str,
-    base_key: &str,
-) -> Result<Option<Value>, SplitJsonKeyringError> {
-    if let Some(bytes) = load_secret_from_keyring(keyring_store, service, base_key, "JSON record")?
-    {
-        let value = serde_json::from_slice(&bytes).map_err(|err| {
-            SplitJsonKeyringError::new(format!(
-                "failed to deserialize JSON record from keyring secret: {err}"
-            ))
-        })?;
-        return Ok(Some(value));
-    }
-
-    match keyring_store.load(service, base_key) {
-        Ok(Some(serialized)) => serde_json::from_str(&serialized).map(Some).map_err(|err| {
-            SplitJsonKeyringError::new(format!(
-                "failed to deserialize JSON record from keyring password: {err}"
-            ))
-        }),
-        Ok(None) => Ok(None),
-        Err(error) => Err(credential_store_error("load", "JSON record", error)),
-    }
-}
-
-fn delete_full_json_from_keyring<K: KeyringStore + ?Sized>(
-    keyring_store: &K,
-    service: &str,
-    base_key: &str,
-) -> Result<bool, SplitJsonKeyringError> {
-    delete_keyring_entry(keyring_store, service, base_key, "JSON record")
 }
 
 fn flatten_split_json(
@@ -625,13 +525,11 @@ mod tests {
     use super::LAYOUT_VERSION;
     use super::MANIFEST_ENTRY;
     use super::delete_json_from_keyring;
-    use super::delete_split_json_from_keyring;
     use super::layout_key;
     use super::load_json_from_keyring;
-    use super::load_split_json_from_keyring;
     use super::save_json_to_keyring;
-    use super::save_split_json_to_keyring;
     use super::value_key;
+    use crate::KeyringStore;
     use crate::tests::MockKeyringStore;
     use pretty_assertions::assert_eq;
     use serde_json::json;
@@ -640,7 +538,7 @@ mod tests {
     const BASE_KEY: &str = "base";
 
     #[test]
-    fn json_storage_round_trips_using_platform_backend() {
+    fn json_storage_round_trips_using_split_backend() {
         let store = MockKeyringStore::default();
         let expected = json!({
             "token": "secret",
@@ -653,86 +551,47 @@ mod tests {
             .expect("JSON should load")
             .expect("JSON should exist");
         assert_eq!(loaded, expected);
-
-        #[cfg(windows)]
-        {
-            assert!(
-                store.saved_secret(BASE_KEY).is_none(),
-                "windows should not store the full JSON record under the base key"
-            );
-            assert!(
-                store.contains(&layout_key(BASE_KEY, MANIFEST_ENTRY)),
-                "windows should store split JSON manifest metadata"
-            );
-        }
-
-        #[cfg(not(windows))]
-        {
-            assert_eq!(
-                store.saved_secret(BASE_KEY),
-                Some(serde_json::to_vec(&expected).expect("JSON should serialize")),
-            );
-            assert!(
-                !store.contains(&layout_key(BASE_KEY, MANIFEST_ENTRY)),
-                "non-windows should not create split JSON manifest metadata"
-            );
-        }
+        assert!(
+            store.saved_secret(BASE_KEY).is_none(),
+            "split storage should not write the full record under the base key"
+        );
+        assert!(
+            store.contains(&layout_key(BASE_KEY, MANIFEST_ENTRY)),
+            "split storage should write manifest metadata"
+        );
     }
 
     #[test]
-    fn json_storage_does_not_load_compatibility_layout() {
+    fn json_storage_does_not_load_legacy_single_entry() {
         let store = MockKeyringStore::default();
         let expected = json!({
             "token": "secret",
             "nested": {"id": 9}
         });
+        store
+            .save(
+                SERVICE,
+                BASE_KEY,
+                &serde_json::to_string(&expected).expect("JSON should serialize"),
+            )
+            .expect("legacy JSON should save");
 
-        #[cfg(windows)]
-        {
-            store
-                .save(
-                    SERVICE,
-                    BASE_KEY,
-                    &serde_json::to_string(&expected).expect("JSON should serialize"),
-                )
-                .expect("full JSON should save");
-            let loaded =
-                load_json_from_keyring(&store, SERVICE, BASE_KEY).expect("JSON should load");
-            assert_eq!(loaded, None);
-        }
-
-        #[cfg(not(windows))]
-        {
-            save_split_json_to_keyring(&store, SERVICE, BASE_KEY, &expected)
-                .expect("split JSON should save");
-            let loaded =
-                load_json_from_keyring(&store, SERVICE, BASE_KEY).expect("JSON should load");
-            assert_eq!(loaded, None);
-        }
+        let loaded = load_json_from_keyring(&store, SERVICE, BASE_KEY).expect("JSON should load");
+        assert_eq!(loaded, None);
     }
 
     #[test]
-    fn json_storage_save_preserves_compatibility_layout() {
+    fn json_storage_save_preserves_legacy_single_entry() {
         let store = MockKeyringStore::default();
         let current = json!({"current": true});
-        let compat = json!({"split": true});
-
-        #[cfg(windows)]
-        {
-            store
-                .save(
-                    SERVICE,
-                    BASE_KEY,
-                    &serde_json::to_string(&compat).expect("JSON should serialize"),
-                )
-                .expect("full JSON should save");
-        }
-
-        #[cfg(not(windows))]
-        {
-            save_split_json_to_keyring(&store, SERVICE, BASE_KEY, &compat)
-                .expect("split JSON should save");
-        }
+        let legacy = json!({"legacy": true});
+        store
+            .save(
+                SERVICE,
+                BASE_KEY,
+                &serde_json::to_string(&legacy).expect("JSON should serialize"),
+            )
+            .expect("legacy JSON should save");
 
         save_json_to_keyring(&store, SERVICE, BASE_KEY, &current).expect("JSON should save");
 
@@ -740,48 +599,25 @@ mod tests {
             .expect("JSON should load")
             .expect("JSON should exist");
         assert_eq!(loaded, current);
-
-        #[cfg(windows)]
-        {
-            assert_eq!(
-                store.saved_value(BASE_KEY),
-                Some(serde_json::to_string(&compat).expect("JSON should serialize"))
-            );
-        }
-
-        #[cfg(not(windows))]
-        {
-            let compat_loaded = load_split_json_from_keyring(&store, SERVICE, BASE_KEY)
-                .expect("split JSON should load")
-                .expect("split JSON should exist");
-            assert_eq!(compat_loaded, compat);
-        }
+        assert_eq!(
+            store.saved_value(BASE_KEY),
+            Some(serde_json::to_string(&legacy).expect("JSON should serialize"))
+        );
     }
 
     #[test]
-    fn json_storage_delete_removes_only_platform_entries() {
+    fn json_storage_delete_removes_only_split_entries() {
         let store = MockKeyringStore::default();
         let current = json!({"current": true});
-        let compat = json!({"split": true});
-
-        #[cfg(windows)]
-        {
-            store
-                .save(
-                    SERVICE,
-                    BASE_KEY,
-                    &serde_json::to_string(&compat).expect("JSON should serialize"),
-                )
-                .expect("full JSON should save");
-            save_json_to_keyring(&store, SERVICE, BASE_KEY, &current).expect("JSON should save");
-        }
-
-        #[cfg(not(windows))]
-        {
-            save_json_to_keyring(&store, SERVICE, BASE_KEY, &current).expect("JSON should save");
-            save_split_json_to_keyring(&store, SERVICE, BASE_KEY, &compat)
-                .expect("split JSON should save");
-        }
+        let legacy = json!({"legacy": true});
+        store
+            .save(
+                SERVICE,
+                BASE_KEY,
+                &serde_json::to_string(&legacy).expect("JSON should serialize"),
+            )
+            .expect("legacy JSON should save");
+        save_json_to_keyring(&store, SERVICE, BASE_KEY, &current).expect("JSON should save");
 
         let removed = delete_json_from_keyring(&store, SERVICE, BASE_KEY)
             .expect("JSON delete should succeed");
@@ -792,18 +628,8 @@ mod tests {
                 .expect("JSON load should succeed")
                 .is_none()
         );
-
-        #[cfg(windows)]
-        {
-            assert!(store.contains(BASE_KEY));
-            assert!(!store.contains(&layout_key(BASE_KEY, MANIFEST_ENTRY)));
-        }
-
-        #[cfg(not(windows))]
-        {
-            assert!(!store.contains(BASE_KEY));
-            assert!(store.contains(&layout_key(BASE_KEY, MANIFEST_ENTRY)));
-        }
+        assert!(store.contains(BASE_KEY));
+        assert!(!store.contains(&layout_key(BASE_KEY, MANIFEST_ENTRY)));
     }
 
     #[test]
@@ -819,10 +645,9 @@ mod tests {
             },
         });
 
-        save_split_json_to_keyring(&store, SERVICE, BASE_KEY, &expected)
-            .expect("split JSON should save");
+        save_json_to_keyring(&store, SERVICE, BASE_KEY, &expected).expect("split JSON should save");
 
-        let loaded = load_split_json_from_keyring(&store, SERVICE, BASE_KEY)
+        let loaded = load_json_from_keyring(&store, SERVICE, BASE_KEY)
             .expect("split JSON should load")
             .expect("split JSON should exist");
         assert_eq!(loaded, expected);
@@ -833,8 +658,7 @@ mod tests {
         let store = MockKeyringStore::default();
         let expected = json!("value");
 
-        save_split_json_to_keyring(&store, SERVICE, BASE_KEY, &expected)
-            .expect("split JSON should save");
+        save_json_to_keyring(&store, SERVICE, BASE_KEY, &expected).expect("split JSON should save");
 
         let root_value_key = value_key(BASE_KEY, "");
         assert_eq!(
@@ -842,7 +666,7 @@ mod tests {
             Some("\"value\"".to_string())
         );
 
-        let loaded = load_split_json_from_keyring(&store, SERVICE, BASE_KEY)
+        let loaded = load_json_from_keyring(&store, SERVICE, BASE_KEY)
             .expect("split JSON should load")
             .expect("split JSON should exist");
         assert_eq!(loaded, expected);
@@ -858,14 +682,13 @@ mod tests {
             },
         });
 
-        save_split_json_to_keyring(&store, SERVICE, BASE_KEY, &expected)
-            .expect("split JSON should save");
+        save_json_to_keyring(&store, SERVICE, BASE_KEY, &expected).expect("split JSON should save");
 
         let manifest_key = layout_key(BASE_KEY, MANIFEST_ENTRY);
         let token_key = value_key(BASE_KEY, "/token");
         let nested_id_key = value_key(BASE_KEY, "/nested/id");
 
-        let removed = delete_split_json_from_keyring(&store, SERVICE, BASE_KEY)
+        let removed = delete_json_from_keyring(&store, SERVICE, BASE_KEY)
             .expect("split JSON delete should succeed");
 
         assert!(removed);
@@ -880,14 +703,14 @@ mod tests {
         let first = json!({"value": "first", "stale": true});
         let second = json!({"value": "second", "extra": 1});
 
-        save_split_json_to_keyring(&store, SERVICE, BASE_KEY, &first)
+        save_json_to_keyring(&store, SERVICE, BASE_KEY, &first)
             .expect("first split JSON save should succeed");
         let manifest_key = layout_key(BASE_KEY, MANIFEST_ENTRY);
         let stale_value_key = value_key(BASE_KEY, "/stale");
         assert!(store.contains(&manifest_key));
         assert!(store.contains(&stale_value_key));
 
-        save_split_json_to_keyring(&store, SERVICE, BASE_KEY, &second)
+        save_json_to_keyring(&store, SERVICE, BASE_KEY, &second)
             .expect("second split JSON save should succeed");
         assert!(!store.contains(&stale_value_key));
         assert!(store.contains(&manifest_key));
@@ -900,7 +723,7 @@ mod tests {
             Some("1".to_string())
         );
 
-        let loaded = load_split_json_from_keyring(&store, SERVICE, BASE_KEY)
+        let loaded = load_json_from_keyring(&store, SERVICE, BASE_KEY)
             .expect("split JSON should load")
             .expect("split JSON should exist");
         assert_eq!(loaded, second);

--- a/codex-rs/keyring-store/src/lib.rs
+++ b/codex-rs/keyring-store/src/lib.rs
@@ -5,6 +5,13 @@ use std::fmt;
 use std::fmt::Debug;
 use tracing::trace;
 
+mod split_json;
+
+pub use split_json::SplitJsonKeyringError;
+pub use split_json::delete_split_json_from_keyring;
+pub use split_json::load_split_json_from_keyring;
+pub use split_json::save_split_json_to_keyring;
+
 #[derive(Debug)]
 pub enum CredentialStoreError {
     Other(KeyringError),

--- a/codex-rs/keyring-store/src/lib.rs
+++ b/codex-rs/keyring-store/src/lib.rs
@@ -41,7 +41,18 @@ impl Error for CredentialStoreError {}
 /// Shared credential store abstraction for keyring-backed implementations.
 pub trait KeyringStore: Debug + Send + Sync {
     fn load(&self, service: &str, account: &str) -> Result<Option<String>, CredentialStoreError>;
+    fn load_secret(
+        &self,
+        service: &str,
+        account: &str,
+    ) -> Result<Option<Vec<u8>>, CredentialStoreError>;
     fn save(&self, service: &str, account: &str, value: &str) -> Result<(), CredentialStoreError>;
+    fn save_secret(
+        &self,
+        service: &str,
+        account: &str,
+        value: &[u8],
+    ) -> Result<(), CredentialStoreError>;
     fn delete(&self, service: &str, account: &str) -> Result<bool, CredentialStoreError>;
 }
 
@@ -68,6 +79,31 @@ impl KeyringStore for DefaultKeyringStore {
         }
     }
 
+    fn load_secret(
+        &self,
+        service: &str,
+        account: &str,
+    ) -> Result<Option<Vec<u8>>, CredentialStoreError> {
+        trace!("keyring.load_secret start, service={service}, account={account}");
+        let entry = Entry::new(service, account).map_err(CredentialStoreError::new)?;
+        match entry.get_secret() {
+            Ok(secret) => {
+                trace!("keyring.load_secret success, service={service}, account={account}");
+                Ok(Some(secret))
+            }
+            Err(keyring::Error::NoEntry) => {
+                trace!("keyring.load_secret no entry, service={service}, account={account}");
+                Ok(None)
+            }
+            Err(error) => {
+                trace!(
+                    "keyring.load_secret error, service={service}, account={account}, error={error}"
+                );
+                Err(CredentialStoreError::new(error))
+            }
+        }
+    }
+
     fn save(&self, service: &str, account: &str, value: &str) -> Result<(), CredentialStoreError> {
         trace!(
             "keyring.save start, service={service}, account={account}, value_len={}",
@@ -81,6 +117,31 @@ impl KeyringStore for DefaultKeyringStore {
             }
             Err(error) => {
                 trace!("keyring.save error, service={service}, account={account}, error={error}");
+                Err(CredentialStoreError::new(error))
+            }
+        }
+    }
+
+    fn save_secret(
+        &self,
+        service: &str,
+        account: &str,
+        value: &[u8],
+    ) -> Result<(), CredentialStoreError> {
+        trace!(
+            "keyring.save_secret start, service={service}, account={account}, value_len={}",
+            value.len()
+        );
+        let entry = Entry::new(service, account).map_err(CredentialStoreError::new)?;
+        match entry.set_secret(value) {
+            Ok(()) => {
+                trace!("keyring.save_secret success, service={service}, account={account}");
+                Ok(())
+            }
+            Err(error) => {
+                trace!(
+                    "keyring.save_secret error, service={service}, account={account}, error={error}"
+                );
                 Err(CredentialStoreError::new(error))
             }
         }
@@ -145,6 +206,22 @@ pub mod tests {
             credential.get_password().ok()
         }
 
+        pub fn saved_secret(&self, account: &str) -> Option<Vec<u8>> {
+            let credential = {
+                let guard = self
+                    .credentials
+                    .lock()
+                    .unwrap_or_else(PoisonError::into_inner);
+                guard.get(account).cloned()
+            }?;
+            credential.get_secret().ok()
+        }
+
+        pub fn saved_secret_utf8(&self, account: &str) -> Option<String> {
+            let secret = self.saved_secret(account)?;
+            String::from_utf8(secret).ok()
+        }
+
         pub fn set_error(&self, account: &str, error: KeyringError) {
             let credential = self.credential(account);
             credential.set_error(error);
@@ -184,6 +261,30 @@ pub mod tests {
             }
         }
 
+        fn load_secret(
+            &self,
+            _service: &str,
+            account: &str,
+        ) -> Result<Option<Vec<u8>>, CredentialStoreError> {
+            let credential = {
+                let guard = self
+                    .credentials
+                    .lock()
+                    .unwrap_or_else(PoisonError::into_inner);
+                guard.get(account).cloned()
+            };
+
+            let Some(credential) = credential else {
+                return Ok(None);
+            };
+
+            match credential.get_secret() {
+                Ok(secret) => Ok(Some(secret)),
+                Err(KeyringError::NoEntry) => Ok(None),
+                Err(error) => Err(CredentialStoreError::new(error)),
+            }
+        }
+
         fn save(
             &self,
             _service: &str,
@@ -193,6 +294,18 @@ pub mod tests {
             let credential = self.credential(account);
             credential
                 .set_password(value)
+                .map_err(CredentialStoreError::new)
+        }
+
+        fn save_secret(
+            &self,
+            _service: &str,
+            account: &str,
+            value: &[u8],
+        ) -> Result<(), CredentialStoreError> {
+            let credential = self.credential(account);
+            credential
+                .set_secret(value)
                 .map_err(CredentialStoreError::new)
         }
 

--- a/codex-rs/keyring-store/src/lib.rs
+++ b/codex-rs/keyring-store/src/lib.rs
@@ -8,13 +8,9 @@ use tracing::trace;
 mod split_json;
 
 pub use split_json::JsonKeyringError;
-pub use split_json::SplitJsonKeyringError;
 pub use split_json::delete_json_from_keyring;
-pub use split_json::delete_split_json_from_keyring;
 pub use split_json::load_json_from_keyring;
-pub use split_json::load_split_json_from_keyring;
 pub use split_json::save_json_to_keyring;
-pub use split_json::save_split_json_to_keyring;
 
 #[derive(Debug)]
 pub enum CredentialStoreError {

--- a/codex-rs/keyring-store/src/lib.rs
+++ b/codex-rs/keyring-store/src/lib.rs
@@ -7,9 +7,13 @@ use tracing::trace;
 
 mod split_json;
 
+pub use split_json::JsonKeyringError;
 pub use split_json::SplitJsonKeyringError;
+pub use split_json::delete_json_from_keyring;
 pub use split_json::delete_split_json_from_keyring;
+pub use split_json::load_json_from_keyring;
 pub use split_json::load_split_json_from_keyring;
+pub use split_json::save_json_to_keyring;
 pub use split_json::save_split_json_to_keyring;
 
 #[derive(Debug)]

--- a/codex-rs/keyring-store/src/lib.rs
+++ b/codex-rs/keyring-store/src/lib.rs
@@ -5,12 +5,18 @@ use std::fmt;
 use std::fmt::Debug;
 use tracing::trace;
 
-mod split_json;
+#[cfg(not(windows))]
+#[path = "json_store_full.rs"]
+mod json_store;
 
-pub use split_json::JsonKeyringError;
-pub use split_json::delete_json_from_keyring;
-pub use split_json::load_json_from_keyring;
-pub use split_json::save_json_to_keyring;
+#[cfg(windows)]
+#[path = "json_store_split.rs"]
+mod json_store;
+
+pub use json_store::JsonKeyringError;
+pub use json_store::delete_json_from_keyring;
+pub use json_store::load_json_from_keyring;
+pub use json_store::save_json_to_keyring;
 
 #[derive(Debug)]
 pub enum CredentialStoreError {

--- a/codex-rs/keyring-store/src/split_json.rs
+++ b/codex-rs/keyring-store/src/split_json.rs
@@ -1,0 +1,718 @@
+use crate::CredentialStoreError;
+use crate::KeyringStore;
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json::Map;
+use serde_json::Value;
+use std::fmt;
+use std::fmt::Write as _;
+use std::time::Duration;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+use tracing::warn;
+
+const LAYOUT_VERSION: &str = "v1";
+const ACTIVE_REVISION_ENTRY: &str = "active";
+const MANIFEST_ENTRY: &str = "manifest";
+const VALUE_ENTRY_PREFIX: &str = "value";
+const ROOT_PATH_SENTINEL: &str = "root";
+
+#[derive(Debug, Clone)]
+pub struct SplitJsonKeyringError {
+    message: String,
+}
+
+impl SplitJsonKeyringError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for SplitJsonKeyringError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for SplitJsonKeyringError {}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+enum JsonNodeKind {
+    Null,
+    Bool,
+    Number,
+    String,
+    Object,
+    Array,
+}
+
+impl JsonNodeKind {
+    fn from_value(value: &Value) -> Self {
+        match value {
+            Value::Null => Self::Null,
+            Value::Bool(_) => Self::Bool,
+            Value::Number(_) => Self::Number,
+            Value::String(_) => Self::String,
+            Value::Object(_) => Self::Object,
+            Value::Array(_) => Self::Array,
+        }
+    }
+
+    fn is_container(self) -> bool {
+        matches!(self, Self::Object | Self::Array)
+    }
+
+    fn empty_value(self) -> Option<Value> {
+        match self {
+            Self::Object => Some(Value::Object(Map::new())),
+            Self::Array => Some(Value::Array(Vec::new())),
+            Self::Null | Self::Bool | Self::Number | Self::String => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+struct SplitJsonNode {
+    path: String,
+    kind: JsonNodeKind,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+struct SplitJsonManifest {
+    nodes: Vec<SplitJsonNode>,
+}
+
+type SplitJsonLeafValues = Vec<(String, Vec<u8>)>;
+
+pub fn load_split_json_from_keyring<K: KeyringStore + ?Sized>(
+    keyring_store: &K,
+    service: &str,
+    base_key: &str,
+) -> Result<Option<Value>, SplitJsonKeyringError> {
+    let Some(revision) = load_active_revision(keyring_store, service, base_key)? else {
+        return Ok(None);
+    };
+    let manifest = load_manifest(keyring_store, service, base_key, &revision)?;
+    inflate_split_json(keyring_store, service, base_key, &revision, &manifest).map(Some)
+}
+
+pub fn save_split_json_to_keyring<K: KeyringStore + ?Sized>(
+    keyring_store: &K,
+    service: &str,
+    base_key: &str,
+    value: &Value,
+) -> Result<(), SplitJsonKeyringError> {
+    let previous_revision = match load_active_revision(keyring_store, service, base_key) {
+        Ok(revision) => revision,
+        Err(err) => {
+            warn!("failed to read previous split JSON revision from keyring: {err}");
+            None
+        }
+    };
+    let revision = next_revision();
+    let (manifest, leaf_values) = flatten_split_json(value)?;
+
+    for (path, bytes) in leaf_values {
+        let key = value_key(base_key, &revision, &path);
+        save_secret_to_keyring(
+            keyring_store,
+            service,
+            &key,
+            &bytes,
+            &format!("JSON value at {path}"),
+        )?;
+    }
+
+    let manifest_key = revision_key(base_key, &revision, MANIFEST_ENTRY);
+    let manifest_bytes = serde_json::to_vec(&manifest).map_err(|err| {
+        SplitJsonKeyringError::new(format!("failed to serialize JSON manifest: {err}"))
+    })?;
+    save_secret_to_keyring(
+        keyring_store,
+        service,
+        &manifest_key,
+        &manifest_bytes,
+        "JSON manifest",
+    )?;
+
+    let active_key = layout_key(base_key, ACTIVE_REVISION_ENTRY);
+    save_secret_to_keyring(
+        keyring_store,
+        service,
+        &active_key,
+        revision.as_bytes(),
+        "active split JSON revision",
+    )?;
+
+    if let Some(previous_revision) = previous_revision
+        && previous_revision != revision
+        && let Err(err) =
+            delete_revision_entries(keyring_store, service, base_key, &previous_revision)
+    {
+        warn!("failed to remove stale split JSON revision from keyring: {err}");
+    }
+
+    Ok(())
+}
+
+pub fn delete_split_json_from_keyring<K: KeyringStore + ?Sized>(
+    keyring_store: &K,
+    service: &str,
+    base_key: &str,
+) -> Result<bool, SplitJsonKeyringError> {
+    let Some(revision) = load_active_revision(keyring_store, service, base_key)? else {
+        return Ok(false);
+    };
+
+    let mut removed = delete_revision_entries(keyring_store, service, base_key, &revision)?;
+    let active_key = layout_key(base_key, ACTIVE_REVISION_ENTRY);
+    removed |= delete_keyring_entry(
+        keyring_store,
+        service,
+        &active_key,
+        "active split JSON revision",
+    )?;
+    Ok(removed)
+}
+
+fn flatten_split_json(
+    value: &Value,
+) -> Result<(SplitJsonManifest, SplitJsonLeafValues), SplitJsonKeyringError> {
+    let mut nodes = Vec::new();
+    let mut leaf_values = Vec::new();
+    collect_nodes("", value, &mut nodes, &mut leaf_values)?;
+    nodes.sort_by(|left, right| {
+        path_depth(&left.path)
+            .cmp(&path_depth(&right.path))
+            .then_with(|| left.path.cmp(&right.path))
+    });
+    leaf_values.sort_by(|left, right| left.0.cmp(&right.0));
+    Ok((SplitJsonManifest { nodes }, leaf_values))
+}
+
+fn collect_nodes(
+    path: &str,
+    value: &Value,
+    nodes: &mut Vec<SplitJsonNode>,
+    leaf_values: &mut SplitJsonLeafValues,
+) -> Result<(), SplitJsonKeyringError> {
+    let kind = JsonNodeKind::from_value(value);
+    nodes.push(SplitJsonNode {
+        path: path.to_string(),
+        kind,
+    });
+
+    match value {
+        Value::Object(map) => {
+            let mut keys = map.keys().cloned().collect::<Vec<_>>();
+            keys.sort();
+            for key in keys {
+                let child_path = append_json_pointer_token(path, &key);
+                let child_value = map.get(&key).ok_or_else(|| {
+                    SplitJsonKeyringError::new(format!(
+                        "missing object value for path {child_path}"
+                    ))
+                })?;
+                collect_nodes(&child_path, child_value, nodes, leaf_values)?;
+            }
+        }
+        Value::Array(items) => {
+            for (index, item) in items.iter().enumerate() {
+                let child_path = append_json_pointer_token(path, &index.to_string());
+                collect_nodes(&child_path, item, nodes, leaf_values)?;
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {
+            let bytes = serde_json::to_vec(value).map_err(|err| {
+                SplitJsonKeyringError::new(format!(
+                    "failed to serialize JSON value at {path}: {err}"
+                ))
+            })?;
+            leaf_values.push((path.to_string(), bytes));
+        }
+    }
+
+    Ok(())
+}
+
+fn inflate_split_json<K: KeyringStore + ?Sized>(
+    keyring_store: &K,
+    service: &str,
+    base_key: &str,
+    revision: &str,
+    manifest: &SplitJsonManifest,
+) -> Result<Value, SplitJsonKeyringError> {
+    let root_node = manifest
+        .nodes
+        .iter()
+        .find(|node| node.path.is_empty())
+        .ok_or_else(|| SplitJsonKeyringError::new("missing root JSON node in keyring manifest"))?;
+
+    let mut result = if let Some(value) = root_node.kind.empty_value() {
+        value
+    } else {
+        load_value(keyring_store, service, base_key, revision, "")?
+    };
+
+    let mut nodes = manifest.nodes.clone();
+    nodes.sort_by(|left, right| {
+        path_depth(&left.path)
+            .cmp(&path_depth(&right.path))
+            .then_with(|| left.path.cmp(&right.path))
+    });
+
+    for node in nodes.into_iter().filter(|node| !node.path.is_empty()) {
+        let value = if let Some(value) = node.kind.empty_value() {
+            value
+        } else {
+            load_value(keyring_store, service, base_key, revision, &node.path)?
+        };
+        insert_value_at_pointer(&mut result, &node.path, value)?;
+    }
+
+    Ok(result)
+}
+
+fn load_value<K: KeyringStore + ?Sized>(
+    keyring_store: &K,
+    service: &str,
+    base_key: &str,
+    revision: &str,
+    path: &str,
+) -> Result<Value, SplitJsonKeyringError> {
+    let key = value_key(base_key, revision, path);
+    let bytes = load_secret_from_keyring(
+        keyring_store,
+        service,
+        &key,
+        &format!("JSON value at {path}"),
+    )?
+    .ok_or_else(|| {
+        SplitJsonKeyringError::new(format!("missing JSON value at {path} in keyring"))
+    })?;
+    serde_json::from_slice(&bytes).map_err(|err| {
+        SplitJsonKeyringError::new(format!("failed to deserialize JSON value at {path}: {err}"))
+    })
+}
+
+fn insert_value_at_pointer(
+    root: &mut Value,
+    pointer: &str,
+    value: Value,
+) -> Result<(), SplitJsonKeyringError> {
+    if pointer.is_empty() {
+        *root = value;
+        return Ok(());
+    }
+
+    let tokens = decode_json_pointer(pointer)?;
+    let Some((last, parents)) = tokens.split_last() else {
+        return Err(SplitJsonKeyringError::new(
+            "missing JSON pointer path tokens",
+        ));
+    };
+
+    let mut current = root;
+    for token in parents {
+        current = match current {
+            Value::Object(map) => map.get_mut(token).ok_or_else(|| {
+                SplitJsonKeyringError::new(format!(
+                    "missing parent object entry for JSON pointer {pointer}"
+                ))
+            })?,
+            Value::Array(items) => {
+                let index = parse_array_index(token, pointer)?;
+                items.get_mut(index).ok_or_else(|| {
+                    SplitJsonKeyringError::new(format!(
+                        "missing parent array entry for JSON pointer {pointer}"
+                    ))
+                })?
+            }
+            Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {
+                return Err(SplitJsonKeyringError::new(format!(
+                    "encountered scalar while walking JSON pointer {pointer}"
+                )));
+            }
+        };
+    }
+
+    match current {
+        Value::Object(map) => {
+            map.insert(last.to_string(), value);
+            Ok(())
+        }
+        Value::Array(items) => {
+            let index = parse_array_index(last, pointer)?;
+            if index >= items.len() {
+                items.resize(index + 1, Value::Null);
+            }
+            items[index] = value;
+            Ok(())
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {
+            Err(SplitJsonKeyringError::new(format!(
+                "encountered scalar while assigning JSON pointer {pointer}"
+            )))
+        }
+    }
+}
+
+fn delete_revision_entries<K: KeyringStore + ?Sized>(
+    keyring_store: &K,
+    service: &str,
+    base_key: &str,
+    revision: &str,
+) -> Result<bool, SplitJsonKeyringError> {
+    let manifest = load_manifest(keyring_store, service, base_key, revision)?;
+    let mut removed = false;
+
+    for node in manifest.nodes {
+        if node.kind.is_container() {
+            continue;
+        }
+        let key = value_key(base_key, revision, &node.path);
+        removed |= delete_keyring_entry(
+            keyring_store,
+            service,
+            &key,
+            &format!("JSON value at {}", node.path),
+        )?;
+    }
+
+    let manifest_key = revision_key(base_key, revision, MANIFEST_ENTRY);
+    removed |= delete_keyring_entry(keyring_store, service, &manifest_key, "JSON manifest")?;
+    Ok(removed)
+}
+
+fn load_manifest<K: KeyringStore + ?Sized>(
+    keyring_store: &K,
+    service: &str,
+    base_key: &str,
+    revision: &str,
+) -> Result<SplitJsonManifest, SplitJsonKeyringError> {
+    let manifest_key = revision_key(base_key, revision, MANIFEST_ENTRY);
+    let bytes = load_secret_from_keyring(keyring_store, service, &manifest_key, "JSON manifest")?
+        .ok_or_else(|| SplitJsonKeyringError::new("missing JSON manifest in keyring"))?;
+    let manifest: SplitJsonManifest = serde_json::from_slice(&bytes).map_err(|err| {
+        SplitJsonKeyringError::new(format!("failed to deserialize JSON manifest: {err}"))
+    })?;
+    if manifest.nodes.is_empty() {
+        return Err(SplitJsonKeyringError::new("JSON manifest is empty"));
+    }
+    Ok(manifest)
+}
+
+fn load_active_revision<K: KeyringStore + ?Sized>(
+    keyring_store: &K,
+    service: &str,
+    base_key: &str,
+) -> Result<Option<String>, SplitJsonKeyringError> {
+    let active_key = layout_key(base_key, ACTIVE_REVISION_ENTRY);
+    load_utf8_secret_from_keyring(
+        keyring_store,
+        service,
+        &active_key,
+        "active split JSON revision",
+    )
+}
+
+fn load_utf8_secret_from_keyring<K: KeyringStore + ?Sized>(
+    keyring_store: &K,
+    service: &str,
+    key: &str,
+    field: &str,
+) -> Result<Option<String>, SplitJsonKeyringError> {
+    let Some(secret) = load_secret_from_keyring(keyring_store, service, key, field)? else {
+        return Ok(None);
+    };
+    String::from_utf8(secret).map(Some).map_err(|err| {
+        SplitJsonKeyringError::new(format!(
+            "failed to decode {field} from keyring as UTF-8: {err}"
+        ))
+    })
+}
+
+fn load_secret_from_keyring<K: KeyringStore + ?Sized>(
+    keyring_store: &K,
+    service: &str,
+    key: &str,
+    field: &str,
+) -> Result<Option<Vec<u8>>, SplitJsonKeyringError> {
+    keyring_store
+        .load_secret(service, key)
+        .map_err(|err| credential_store_error("load", field, err))
+}
+
+fn save_secret_to_keyring<K: KeyringStore + ?Sized>(
+    keyring_store: &K,
+    service: &str,
+    key: &str,
+    value: &[u8],
+    field: &str,
+) -> Result<(), SplitJsonKeyringError> {
+    keyring_store
+        .save_secret(service, key, value)
+        .map_err(|err| credential_store_error("write", field, err))
+}
+
+fn delete_keyring_entry<K: KeyringStore + ?Sized>(
+    keyring_store: &K,
+    service: &str,
+    key: &str,
+    field: &str,
+) -> Result<bool, SplitJsonKeyringError> {
+    keyring_store
+        .delete(service, key)
+        .map_err(|err| credential_store_error("delete", field, err))
+}
+
+fn credential_store_error(
+    action: &str,
+    field: &str,
+    error: CredentialStoreError,
+) -> SplitJsonKeyringError {
+    SplitJsonKeyringError::new(format!(
+        "failed to {action} {field} in keyring: {}",
+        error.message()
+    ))
+}
+
+fn next_revision() -> String {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_else(|_| Duration::from_secs(0))
+        .as_nanos()
+        .to_string()
+}
+
+fn layout_key(base_key: &str, suffix: &str) -> String {
+    format!("{base_key}|{LAYOUT_VERSION}|{suffix}")
+}
+
+fn revision_key(base_key: &str, revision: &str, suffix: &str) -> String {
+    format!("{base_key}|{LAYOUT_VERSION}|{revision}|{suffix}")
+}
+
+fn value_key(base_key: &str, revision: &str, path: &str) -> String {
+    let encoded_path = encode_path(path);
+    let suffix = format!("{VALUE_ENTRY_PREFIX}|{encoded_path}");
+    revision_key(base_key, revision, &suffix)
+}
+
+fn encode_path(path: &str) -> String {
+    if path.is_empty() {
+        return ROOT_PATH_SENTINEL.to_string();
+    }
+
+    let mut encoded = String::with_capacity(path.len() * 2);
+    for byte in path.as_bytes() {
+        let _ = write!(&mut encoded, "{byte:02x}");
+    }
+    encoded
+}
+
+fn append_json_pointer_token(path: &str, token: &str) -> String {
+    let escaped = token.replace('~', "~0").replace('/', "~1");
+    if path.is_empty() {
+        format!("/{escaped}")
+    } else {
+        format!("{path}/{escaped}")
+    }
+}
+
+fn decode_json_pointer(pointer: &str) -> Result<Vec<String>, SplitJsonKeyringError> {
+    if pointer.is_empty() {
+        return Ok(Vec::new());
+    }
+    if !pointer.starts_with('/') {
+        return Err(SplitJsonKeyringError::new(format!(
+            "invalid JSON pointer {pointer}: expected leading slash"
+        )));
+    }
+
+    pointer[1..]
+        .split('/')
+        .map(unescape_json_pointer_token)
+        .collect()
+}
+
+fn unescape_json_pointer_token(token: &str) -> Result<String, SplitJsonKeyringError> {
+    let mut result = String::with_capacity(token.len());
+    let mut chars = token.chars();
+
+    while let Some(ch) = chars.next() {
+        if ch != '~' {
+            result.push(ch);
+            continue;
+        }
+
+        match chars.next() {
+            Some('0') => result.push('~'),
+            Some('1') => result.push('/'),
+            Some(other) => {
+                return Err(SplitJsonKeyringError::new(format!(
+                    "invalid JSON pointer escape sequence ~{other}"
+                )));
+            }
+            None => {
+                return Err(SplitJsonKeyringError::new(
+                    "invalid JSON pointer escape sequence at end of token",
+                ));
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+fn parse_array_index(token: &str, pointer: &str) -> Result<usize, SplitJsonKeyringError> {
+    token.parse::<usize>().map_err(|err| {
+        SplitJsonKeyringError::new(format!(
+            "invalid array index '{token}' in JSON pointer {pointer}: {err}"
+        ))
+    })
+}
+
+fn path_depth(path: &str) -> usize {
+    path.chars().filter(|ch| *ch == '/').count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ACTIVE_REVISION_ENTRY;
+    use super::LAYOUT_VERSION;
+    use super::MANIFEST_ENTRY;
+    use super::ROOT_PATH_SENTINEL;
+    use super::VALUE_ENTRY_PREFIX;
+    use super::delete_split_json_from_keyring;
+    use super::layout_key;
+    use super::load_split_json_from_keyring;
+    use super::revision_key;
+    use super::save_split_json_to_keyring;
+    use super::value_key;
+    use crate::tests::MockKeyringStore;
+    use pretty_assertions::assert_eq;
+    use serde_json::json;
+
+    const SERVICE: &str = "Test Service";
+    const BASE_KEY: &str = "base";
+
+    #[test]
+    fn split_json_round_trips_nested_values() {
+        let store = MockKeyringStore::default();
+        let expected = json!({
+            "name": "codex",
+            "enabled": true,
+            "count": 3,
+            "nested": {
+                "items": [null, {"hello": "world"}],
+                "slash/key": "~value~",
+            },
+        });
+
+        save_split_json_to_keyring(&store, SERVICE, BASE_KEY, &expected)
+            .expect("split JSON should save");
+
+        let loaded = load_split_json_from_keyring(&store, SERVICE, BASE_KEY)
+            .expect("split JSON should load")
+            .expect("split JSON should exist");
+        assert_eq!(loaded, expected);
+    }
+
+    #[test]
+    fn split_json_supports_scalar_root_values() {
+        let store = MockKeyringStore::default();
+        let expected = json!("value");
+
+        save_split_json_to_keyring(&store, SERVICE, BASE_KEY, &expected)
+            .expect("split JSON should save");
+
+        let revision = store
+            .saved_secret_utf8(&layout_key(BASE_KEY, ACTIVE_REVISION_ENTRY))
+            .expect("active revision should exist");
+        let root_value_key = revision_key(
+            BASE_KEY,
+            &revision,
+            &format!("{VALUE_ENTRY_PREFIX}|{ROOT_PATH_SENTINEL}"),
+        );
+        assert_eq!(
+            store.saved_secret_utf8(&root_value_key),
+            Some("\"value\"".to_string())
+        );
+
+        let loaded = load_split_json_from_keyring(&store, SERVICE, BASE_KEY)
+            .expect("split JSON should load")
+            .expect("split JSON should exist");
+        assert_eq!(loaded, expected);
+    }
+
+    #[test]
+    fn split_json_delete_removes_saved_entries() {
+        let store = MockKeyringStore::default();
+        let expected = json!({
+            "token": "secret",
+            "nested": {
+                "id": 123,
+            },
+        });
+
+        save_split_json_to_keyring(&store, SERVICE, BASE_KEY, &expected)
+            .expect("split JSON should save");
+
+        let revision = store
+            .saved_secret_utf8(&layout_key(BASE_KEY, ACTIVE_REVISION_ENTRY))
+            .expect("active revision should exist");
+        let manifest_key = revision_key(BASE_KEY, &revision, MANIFEST_ENTRY);
+        let token_key = value_key(BASE_KEY, &revision, "/token");
+        let nested_id_key = value_key(BASE_KEY, &revision, "/nested/id");
+
+        let removed = delete_split_json_from_keyring(&store, SERVICE, BASE_KEY)
+            .expect("split JSON delete should succeed");
+
+        assert!(removed);
+        assert!(!store.contains(&layout_key(BASE_KEY, ACTIVE_REVISION_ENTRY)));
+        assert!(!store.contains(&manifest_key));
+        assert!(!store.contains(&token_key));
+        assert!(!store.contains(&nested_id_key));
+    }
+
+    #[test]
+    fn split_json_save_replaces_previous_revision() {
+        let store = MockKeyringStore::default();
+        let first = json!({"value": "first"});
+        let second = json!({"value": "second", "extra": 1});
+
+        save_split_json_to_keyring(&store, SERVICE, BASE_KEY, &first)
+            .expect("first split JSON save should succeed");
+        let first_revision = store
+            .saved_secret_utf8(&layout_key(BASE_KEY, ACTIVE_REVISION_ENTRY))
+            .expect("first revision should exist");
+        let first_manifest_key = revision_key(BASE_KEY, &first_revision, MANIFEST_ENTRY);
+        let first_value_key = value_key(BASE_KEY, &first_revision, "/value");
+
+        save_split_json_to_keyring(&store, SERVICE, BASE_KEY, &second)
+            .expect("second split JSON save should succeed");
+        let second_revision = store
+            .saved_secret_utf8(&layout_key(BASE_KEY, ACTIVE_REVISION_ENTRY))
+            .expect("second revision should exist");
+        let second_manifest_key = revision_key(BASE_KEY, &second_revision, MANIFEST_ENTRY);
+
+        assert_ne!(first_revision, second_revision);
+        assert!(!store.contains(&first_manifest_key));
+        assert!(!store.contains(&first_value_key));
+        assert!(store.contains(&second_manifest_key));
+
+        let loaded = load_split_json_from_keyring(&store, SERVICE, BASE_KEY)
+            .expect("split JSON should load")
+            .expect("split JSON should exist");
+        assert_eq!(loaded, second);
+    }
+
+    #[test]
+    fn split_json_uses_distinct_layout_version() {
+        assert_eq!(LAYOUT_VERSION, "v1");
+    }
+}

--- a/codex-rs/keyring-store/src/split_json.rs
+++ b/codex-rs/keyring-store/src/split_json.rs
@@ -280,6 +280,7 @@ fn load_full_json_from_keyring<K: KeyringStore + ?Sized>(
     }
 }
 
+#[cfg(not(windows))]
 fn save_full_json_to_keyring<K: KeyringStore + ?Sized>(
     keyring_store: &K,
     service: &str,

--- a/codex-rs/keyring-store/src/split_json.rs
+++ b/codex-rs/keyring-store/src/split_json.rs
@@ -22,6 +22,8 @@ pub struct SplitJsonKeyringError {
     message: String,
 }
 
+pub type JsonKeyringError = SplitJsonKeyringError;
+
 impl SplitJsonKeyringError {
     fn new(message: impl Into<String>) -> Self {
         Self {
@@ -86,6 +88,80 @@ struct SplitJsonManifest {
 }
 
 type SplitJsonLeafValues = Vec<(String, Vec<u8>)>;
+
+#[cfg(windows)]
+pub fn load_json_from_keyring<K: KeyringStore + ?Sized>(
+    keyring_store: &K,
+    service: &str,
+    base_key: &str,
+) -> Result<Option<Value>, JsonKeyringError> {
+    if let Some(value) = load_split_json_from_keyring(keyring_store, service, base_key)? {
+        return Ok(Some(value));
+    }
+    load_full_json_from_keyring(keyring_store, service, base_key)
+}
+
+#[cfg(not(windows))]
+pub fn load_json_from_keyring<K: KeyringStore + ?Sized>(
+    keyring_store: &K,
+    service: &str,
+    base_key: &str,
+) -> Result<Option<Value>, JsonKeyringError> {
+    if let Some(value) = load_full_json_from_keyring(keyring_store, service, base_key)? {
+        return Ok(Some(value));
+    }
+    load_split_json_from_keyring(keyring_store, service, base_key)
+}
+
+#[cfg(windows)]
+pub fn save_json_to_keyring<K: KeyringStore + ?Sized>(
+    keyring_store: &K,
+    service: &str,
+    base_key: &str,
+    value: &Value,
+) -> Result<(), JsonKeyringError> {
+    save_split_json_to_keyring(keyring_store, service, base_key, value)?;
+    if let Err(err) = delete_full_json_from_keyring(keyring_store, service, base_key) {
+        warn!("failed to remove stale full JSON record from keyring: {err}");
+    }
+    Ok(())
+}
+
+#[cfg(not(windows))]
+pub fn save_json_to_keyring<K: KeyringStore + ?Sized>(
+    keyring_store: &K,
+    service: &str,
+    base_key: &str,
+    value: &Value,
+) -> Result<(), JsonKeyringError> {
+    save_full_json_to_keyring(keyring_store, service, base_key, value)?;
+    if let Err(err) = delete_split_json_from_keyring(keyring_store, service, base_key) {
+        warn!("failed to remove stale split JSON record from keyring: {err}");
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+pub fn delete_json_from_keyring<K: KeyringStore + ?Sized>(
+    keyring_store: &K,
+    service: &str,
+    base_key: &str,
+) -> Result<bool, JsonKeyringError> {
+    let split_removed = delete_split_json_from_keyring(keyring_store, service, base_key)?;
+    let full_removed = delete_full_json_from_keyring(keyring_store, service, base_key)?;
+    Ok(split_removed || full_removed)
+}
+
+#[cfg(not(windows))]
+pub fn delete_json_from_keyring<K: KeyringStore + ?Sized>(
+    keyring_store: &K,
+    service: &str,
+    base_key: &str,
+) -> Result<bool, JsonKeyringError> {
+    let full_removed = delete_full_json_from_keyring(keyring_store, service, base_key)?;
+    let split_removed = delete_split_json_from_keyring(keyring_store, service, base_key)?;
+    Ok(full_removed || split_removed)
+}
 
 pub fn load_split_json_from_keyring<K: KeyringStore + ?Sized>(
     keyring_store: &K,
@@ -176,6 +252,52 @@ pub fn delete_split_json_from_keyring<K: KeyringStore + ?Sized>(
         "active split JSON revision",
     )?;
     Ok(removed)
+}
+
+fn load_full_json_from_keyring<K: KeyringStore + ?Sized>(
+    keyring_store: &K,
+    service: &str,
+    base_key: &str,
+) -> Result<Option<Value>, SplitJsonKeyringError> {
+    if let Some(bytes) = load_secret_from_keyring(keyring_store, service, base_key, "JSON record")?
+    {
+        let value = serde_json::from_slice(&bytes).map_err(|err| {
+            SplitJsonKeyringError::new(format!(
+                "failed to deserialize JSON record from keyring secret: {err}"
+            ))
+        })?;
+        return Ok(Some(value));
+    }
+
+    match keyring_store.load(service, base_key) {
+        Ok(Some(serialized)) => serde_json::from_str(&serialized).map(Some).map_err(|err| {
+            SplitJsonKeyringError::new(format!(
+                "failed to deserialize JSON record from keyring password: {err}"
+            ))
+        }),
+        Ok(None) => Ok(None),
+        Err(error) => Err(credential_store_error("load", "JSON record", error)),
+    }
+}
+
+fn save_full_json_to_keyring<K: KeyringStore + ?Sized>(
+    keyring_store: &K,
+    service: &str,
+    base_key: &str,
+    value: &Value,
+) -> Result<(), SplitJsonKeyringError> {
+    let bytes = serde_json::to_vec(value).map_err(|err| {
+        SplitJsonKeyringError::new(format!("failed to serialize JSON record: {err}"))
+    })?;
+    save_secret_to_keyring(keyring_store, service, base_key, &bytes, "JSON record")
+}
+
+fn delete_full_json_from_keyring<K: KeyringStore + ?Sized>(
+    keyring_store: &K,
+    service: &str,
+    base_key: &str,
+) -> Result<bool, SplitJsonKeyringError> {
+    delete_keyring_entry(keyring_store, service, base_key, "JSON record")
 }
 
 fn flatten_split_json(
@@ -587,18 +709,110 @@ mod tests {
     use super::MANIFEST_ENTRY;
     use super::ROOT_PATH_SENTINEL;
     use super::VALUE_ENTRY_PREFIX;
+    use super::delete_json_from_keyring;
     use super::delete_split_json_from_keyring;
     use super::layout_key;
+    use super::load_json_from_keyring;
     use super::load_split_json_from_keyring;
     use super::revision_key;
+    use super::save_json_to_keyring;
     use super::save_split_json_to_keyring;
     use super::value_key;
+    use crate::KeyringStore;
     use crate::tests::MockKeyringStore;
     use pretty_assertions::assert_eq;
     use serde_json::json;
 
     const SERVICE: &str = "Test Service";
     const BASE_KEY: &str = "base";
+
+    #[test]
+    fn json_storage_round_trips_using_platform_backend() {
+        let store = MockKeyringStore::default();
+        let expected = json!({
+            "token": "secret",
+            "nested": {"id": 7}
+        });
+
+        save_json_to_keyring(&store, SERVICE, BASE_KEY, &expected).expect("JSON should save");
+
+        let loaded = load_json_from_keyring(&store, SERVICE, BASE_KEY)
+            .expect("JSON should load")
+            .expect("JSON should exist");
+        assert_eq!(loaded, expected);
+
+        #[cfg(windows)]
+        {
+            assert!(
+                store.saved_secret(BASE_KEY).is_none(),
+                "windows should not store the full JSON record under the base key"
+            );
+            assert!(
+                store.contains(&layout_key(BASE_KEY, ACTIVE_REVISION_ENTRY)),
+                "windows should track an active split revision"
+            );
+        }
+
+        #[cfg(not(windows))]
+        {
+            assert_eq!(
+                store.saved_secret(BASE_KEY),
+                Some(serde_json::to_vec(&expected).expect("JSON should serialize")),
+            );
+            assert!(
+                !store.contains(&layout_key(BASE_KEY, ACTIVE_REVISION_ENTRY)),
+                "non-windows should not create split revision metadata"
+            );
+        }
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn json_storage_loads_split_json_compatibility_on_non_windows() {
+        let store = MockKeyringStore::default();
+        let expected = json!({
+            "token": "secret",
+            "nested": {"id": 9}
+        });
+
+        save_split_json_to_keyring(&store, SERVICE, BASE_KEY, &expected)
+            .expect("split JSON should save");
+
+        let loaded = load_json_from_keyring(&store, SERVICE, BASE_KEY)
+            .expect("JSON should load")
+            .expect("JSON should exist");
+        assert_eq!(loaded, expected);
+    }
+
+    #[test]
+    fn json_storage_delete_removes_platform_and_compat_entries() {
+        let store = MockKeyringStore::default();
+        let current = json!({"current": true});
+        let split = json!({"split": true});
+
+        save_json_to_keyring(&store, SERVICE, BASE_KEY, &current).expect("JSON should save");
+        save_split_json_to_keyring(&store, SERVICE, BASE_KEY, &split)
+            .expect("split JSON should save");
+        store
+            .save(
+                SERVICE,
+                BASE_KEY,
+                &serde_json::to_string(&current).expect("JSON should serialize"),
+            )
+            .expect("legacy JSON should save");
+
+        let removed = delete_json_from_keyring(&store, SERVICE, BASE_KEY)
+            .expect("JSON delete should succeed");
+
+        assert!(removed);
+        assert!(
+            load_json_from_keyring(&store, SERVICE, BASE_KEY)
+                .expect("JSON load should succeed")
+                .is_none()
+        );
+        assert!(!store.contains(BASE_KEY));
+        assert!(!store.contains(&layout_key(BASE_KEY, ACTIVE_REVISION_ENTRY)));
+    }
 
     #[test]
     fn split_json_round_trips_nested_values() {

--- a/codex-rs/keyring-store/src/split_json.rs
+++ b/codex-rs/keyring-store/src/split_json.rs
@@ -6,13 +6,9 @@ use serde_json::Map;
 use serde_json::Value;
 use std::fmt;
 use std::fmt::Write as _;
-use std::time::Duration;
-use std::time::SystemTime;
-use std::time::UNIX_EPOCH;
 use tracing::warn;
 
 const LAYOUT_VERSION: &str = "v1";
-const ACTIVE_REVISION_ENTRY: &str = "active";
 const MANIFEST_ENTRY: &str = "manifest";
 const VALUE_ENTRY_PREFIX: &str = "value";
 const ROOT_PATH_SENTINEL: &str = "root";
@@ -168,11 +164,10 @@ pub fn load_split_json_from_keyring<K: KeyringStore + ?Sized>(
     service: &str,
     base_key: &str,
 ) -> Result<Option<Value>, SplitJsonKeyringError> {
-    let Some(revision) = load_active_revision(keyring_store, service, base_key)? else {
+    let Some(manifest) = load_manifest(keyring_store, service, base_key)? else {
         return Ok(None);
     };
-    let manifest = load_manifest(keyring_store, service, base_key, &revision)?;
-    inflate_split_json(keyring_store, service, base_key, &revision, &manifest).map(Some)
+    inflate_split_json(keyring_store, service, base_key, &manifest).map(Some)
 }
 
 pub fn save_split_json_to_keyring<K: KeyringStore + ?Sized>(
@@ -181,18 +176,23 @@ pub fn save_split_json_to_keyring<K: KeyringStore + ?Sized>(
     base_key: &str,
     value: &Value,
 ) -> Result<(), SplitJsonKeyringError> {
-    let previous_revision = match load_active_revision(keyring_store, service, base_key) {
-        Ok(revision) => revision,
+    let previous_manifest = match load_manifest(keyring_store, service, base_key) {
+        Ok(manifest) => manifest,
         Err(err) => {
-            warn!("failed to read previous split JSON revision from keyring: {err}");
+            warn!("failed to read previous split JSON manifest from keyring: {err}");
             None
         }
     };
-    let revision = next_revision();
     let (manifest, leaf_values) = flatten_split_json(value)?;
+    let current_scalar_paths = manifest
+        .nodes
+        .iter()
+        .filter(|node| !node.kind.is_container())
+        .map(|node| node.path.as_str())
+        .collect::<std::collections::HashSet<_>>();
 
     for (path, bytes) in leaf_values {
-        let key = value_key(base_key, &revision, &path);
+        let key = value_key(base_key, &path);
         save_secret_to_keyring(
             keyring_store,
             service,
@@ -202,7 +202,7 @@ pub fn save_split_json_to_keyring<K: KeyringStore + ?Sized>(
         )?;
     }
 
-    let manifest_key = revision_key(base_key, &revision, MANIFEST_ENTRY);
+    let manifest_key = layout_key(base_key, MANIFEST_ENTRY);
     let manifest_bytes = serde_json::to_vec(&manifest).map_err(|err| {
         SplitJsonKeyringError::new(format!("failed to serialize JSON manifest: {err}"))
     })?;
@@ -214,21 +214,21 @@ pub fn save_split_json_to_keyring<K: KeyringStore + ?Sized>(
         "JSON manifest",
     )?;
 
-    let active_key = layout_key(base_key, ACTIVE_REVISION_ENTRY);
-    save_secret_to_keyring(
-        keyring_store,
-        service,
-        &active_key,
-        revision.as_bytes(),
-        "active split JSON revision",
-    )?;
-
-    if let Some(previous_revision) = previous_revision
-        && previous_revision != revision
-        && let Err(err) =
-            delete_revision_entries(keyring_store, service, base_key, &previous_revision)
-    {
-        warn!("failed to remove stale split JSON revision from keyring: {err}");
+    if let Some(previous_manifest) = previous_manifest {
+        for node in previous_manifest.nodes {
+            if node.kind.is_container() || current_scalar_paths.contains(node.path.as_str()) {
+                continue;
+            }
+            let key = value_key(base_key, &node.path);
+            if let Err(err) = delete_keyring_entry(
+                keyring_store,
+                service,
+                &key,
+                &format!("stale JSON value at {}", node.path),
+            ) {
+                warn!("failed to remove stale split JSON value from keyring: {err}");
+            }
+        }
     }
 
     Ok(())
@@ -239,18 +239,26 @@ pub fn delete_split_json_from_keyring<K: KeyringStore + ?Sized>(
     service: &str,
     base_key: &str,
 ) -> Result<bool, SplitJsonKeyringError> {
-    let Some(revision) = load_active_revision(keyring_store, service, base_key)? else {
+    let Some(manifest) = load_manifest(keyring_store, service, base_key)? else {
         return Ok(false);
     };
 
-    let mut removed = delete_revision_entries(keyring_store, service, base_key, &revision)?;
-    let active_key = layout_key(base_key, ACTIVE_REVISION_ENTRY);
-    removed |= delete_keyring_entry(
-        keyring_store,
-        service,
-        &active_key,
-        "active split JSON revision",
-    )?;
+    let mut removed = false;
+    for node in manifest.nodes {
+        if node.kind.is_container() {
+            continue;
+        }
+        let key = value_key(base_key, &node.path);
+        removed |= delete_keyring_entry(
+            keyring_store,
+            service,
+            &key,
+            &format!("JSON value at {}", node.path),
+        )?;
+    }
+
+    let manifest_key = layout_key(base_key, MANIFEST_ENTRY);
+    removed |= delete_keyring_entry(keyring_store, service, &manifest_key, "JSON manifest")?;
     Ok(removed)
 }
 
@@ -365,7 +373,6 @@ fn inflate_split_json<K: KeyringStore + ?Sized>(
     keyring_store: &K,
     service: &str,
     base_key: &str,
-    revision: &str,
     manifest: &SplitJsonManifest,
 ) -> Result<Value, SplitJsonKeyringError> {
     let root_node = manifest
@@ -377,7 +384,7 @@ fn inflate_split_json<K: KeyringStore + ?Sized>(
     let mut result = if let Some(value) = root_node.kind.empty_value() {
         value
     } else {
-        load_value(keyring_store, service, base_key, revision, "")?
+        load_value(keyring_store, service, base_key, "")?
     };
 
     let mut nodes = manifest.nodes.clone();
@@ -391,7 +398,7 @@ fn inflate_split_json<K: KeyringStore + ?Sized>(
         let value = if let Some(value) = node.kind.empty_value() {
             value
         } else {
-            load_value(keyring_store, service, base_key, revision, &node.path)?
+            load_value(keyring_store, service, base_key, &node.path)?
         };
         insert_value_at_pointer(&mut result, &node.path, value)?;
     }
@@ -403,10 +410,9 @@ fn load_value<K: KeyringStore + ?Sized>(
     keyring_store: &K,
     service: &str,
     base_key: &str,
-    revision: &str,
     path: &str,
 ) -> Result<Value, SplitJsonKeyringError> {
-    let key = value_key(base_key, revision, path);
+    let key = value_key(base_key, path);
     let bytes = load_secret_from_keyring(
         keyring_store,
         service,
@@ -483,79 +489,24 @@ fn insert_value_at_pointer(
     }
 }
 
-fn delete_revision_entries<K: KeyringStore + ?Sized>(
-    keyring_store: &K,
-    service: &str,
-    base_key: &str,
-    revision: &str,
-) -> Result<bool, SplitJsonKeyringError> {
-    let manifest = load_manifest(keyring_store, service, base_key, revision)?;
-    let mut removed = false;
-
-    for node in manifest.nodes {
-        if node.kind.is_container() {
-            continue;
-        }
-        let key = value_key(base_key, revision, &node.path);
-        removed |= delete_keyring_entry(
-            keyring_store,
-            service,
-            &key,
-            &format!("JSON value at {}", node.path),
-        )?;
-    }
-
-    let manifest_key = revision_key(base_key, revision, MANIFEST_ENTRY);
-    removed |= delete_keyring_entry(keyring_store, service, &manifest_key, "JSON manifest")?;
-    Ok(removed)
-}
-
 fn load_manifest<K: KeyringStore + ?Sized>(
     keyring_store: &K,
     service: &str,
     base_key: &str,
-    revision: &str,
-) -> Result<SplitJsonManifest, SplitJsonKeyringError> {
-    let manifest_key = revision_key(base_key, revision, MANIFEST_ENTRY);
-    let bytes = load_secret_from_keyring(keyring_store, service, &manifest_key, "JSON manifest")?
-        .ok_or_else(|| SplitJsonKeyringError::new("missing JSON manifest in keyring"))?;
+) -> Result<Option<SplitJsonManifest>, SplitJsonKeyringError> {
+    let manifest_key = layout_key(base_key, MANIFEST_ENTRY);
+    let Some(bytes) =
+        load_secret_from_keyring(keyring_store, service, &manifest_key, "JSON manifest")?
+    else {
+        return Ok(None);
+    };
     let manifest: SplitJsonManifest = serde_json::from_slice(&bytes).map_err(|err| {
         SplitJsonKeyringError::new(format!("failed to deserialize JSON manifest: {err}"))
     })?;
     if manifest.nodes.is_empty() {
         return Err(SplitJsonKeyringError::new("JSON manifest is empty"));
     }
-    Ok(manifest)
-}
-
-fn load_active_revision<K: KeyringStore + ?Sized>(
-    keyring_store: &K,
-    service: &str,
-    base_key: &str,
-) -> Result<Option<String>, SplitJsonKeyringError> {
-    let active_key = layout_key(base_key, ACTIVE_REVISION_ENTRY);
-    load_utf8_secret_from_keyring(
-        keyring_store,
-        service,
-        &active_key,
-        "active split JSON revision",
-    )
-}
-
-fn load_utf8_secret_from_keyring<K: KeyringStore + ?Sized>(
-    keyring_store: &K,
-    service: &str,
-    key: &str,
-    field: &str,
-) -> Result<Option<String>, SplitJsonKeyringError> {
-    let Some(secret) = load_secret_from_keyring(keyring_store, service, key, field)? else {
-        return Ok(None);
-    };
-    String::from_utf8(secret).map(Some).map_err(|err| {
-        SplitJsonKeyringError::new(format!(
-            "failed to decode {field} from keyring as UTF-8: {err}"
-        ))
-    })
+    Ok(Some(manifest))
 }
 
 fn load_secret_from_keyring<K: KeyringStore + ?Sized>(
@@ -603,26 +554,13 @@ fn credential_store_error(
     ))
 }
 
-fn next_revision() -> String {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_else(|_| Duration::from_secs(0))
-        .as_nanos()
-        .to_string()
-}
-
 fn layout_key(base_key: &str, suffix: &str) -> String {
     format!("{base_key}|{LAYOUT_VERSION}|{suffix}")
 }
 
-fn revision_key(base_key: &str, revision: &str, suffix: &str) -> String {
-    format!("{base_key}|{LAYOUT_VERSION}|{revision}|{suffix}")
-}
-
-fn value_key(base_key: &str, revision: &str, path: &str) -> String {
+fn value_key(base_key: &str, path: &str) -> String {
     let encoded_path = encode_path(path);
-    let suffix = format!("{VALUE_ENTRY_PREFIX}|{encoded_path}");
-    revision_key(base_key, revision, &suffix)
+    layout_key(base_key, &format!("{VALUE_ENTRY_PREFIX}|{encoded_path}"))
 }
 
 fn encode_path(path: &str) -> String {
@@ -705,17 +643,13 @@ fn path_depth(path: &str) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use super::ACTIVE_REVISION_ENTRY;
     use super::LAYOUT_VERSION;
     use super::MANIFEST_ENTRY;
-    use super::ROOT_PATH_SENTINEL;
-    use super::VALUE_ENTRY_PREFIX;
     use super::delete_json_from_keyring;
     use super::delete_split_json_from_keyring;
     use super::layout_key;
     use super::load_json_from_keyring;
     use super::load_split_json_from_keyring;
-    use super::revision_key;
     use super::save_json_to_keyring;
     use super::save_split_json_to_keyring;
     use super::value_key;
@@ -749,8 +683,8 @@ mod tests {
                 "windows should not store the full JSON record under the base key"
             );
             assert!(
-                store.contains(&layout_key(BASE_KEY, ACTIVE_REVISION_ENTRY)),
-                "windows should track an active split revision"
+                store.contains(&layout_key(BASE_KEY, MANIFEST_ENTRY)),
+                "windows should store split JSON manifest metadata"
             );
         }
 
@@ -761,8 +695,8 @@ mod tests {
                 Some(serde_json::to_vec(&expected).expect("JSON should serialize")),
             );
             assert!(
-                !store.contains(&layout_key(BASE_KEY, ACTIVE_REVISION_ENTRY)),
-                "non-windows should not create split revision metadata"
+                !store.contains(&layout_key(BASE_KEY, MANIFEST_ENTRY)),
+                "non-windows should not create split JSON manifest metadata"
             );
         }
     }
@@ -812,7 +746,7 @@ mod tests {
                 .is_none()
         );
         assert!(!store.contains(BASE_KEY));
-        assert!(!store.contains(&layout_key(BASE_KEY, ACTIVE_REVISION_ENTRY)));
+        assert!(!store.contains(&layout_key(BASE_KEY, MANIFEST_ENTRY)));
     }
 
     #[test]
@@ -845,14 +779,7 @@ mod tests {
         save_split_json_to_keyring(&store, SERVICE, BASE_KEY, &expected)
             .expect("split JSON should save");
 
-        let revision = store
-            .saved_secret_utf8(&layout_key(BASE_KEY, ACTIVE_REVISION_ENTRY))
-            .expect("active revision should exist");
-        let root_value_key = revision_key(
-            BASE_KEY,
-            &revision,
-            &format!("{VALUE_ENTRY_PREFIX}|{ROOT_PATH_SENTINEL}"),
-        );
+        let root_value_key = value_key(BASE_KEY, "");
         assert_eq!(
             store.saved_secret_utf8(&root_value_key),
             Some("\"value\"".to_string())
@@ -877,48 +804,44 @@ mod tests {
         save_split_json_to_keyring(&store, SERVICE, BASE_KEY, &expected)
             .expect("split JSON should save");
 
-        let revision = store
-            .saved_secret_utf8(&layout_key(BASE_KEY, ACTIVE_REVISION_ENTRY))
-            .expect("active revision should exist");
-        let manifest_key = revision_key(BASE_KEY, &revision, MANIFEST_ENTRY);
-        let token_key = value_key(BASE_KEY, &revision, "/token");
-        let nested_id_key = value_key(BASE_KEY, &revision, "/nested/id");
+        let manifest_key = layout_key(BASE_KEY, MANIFEST_ENTRY);
+        let token_key = value_key(BASE_KEY, "/token");
+        let nested_id_key = value_key(BASE_KEY, "/nested/id");
 
         let removed = delete_split_json_from_keyring(&store, SERVICE, BASE_KEY)
             .expect("split JSON delete should succeed");
 
         assert!(removed);
-        assert!(!store.contains(&layout_key(BASE_KEY, ACTIVE_REVISION_ENTRY)));
         assert!(!store.contains(&manifest_key));
         assert!(!store.contains(&token_key));
         assert!(!store.contains(&nested_id_key));
     }
 
     #[test]
-    fn split_json_save_replaces_previous_revision() {
+    fn split_json_save_replaces_previous_values() {
         let store = MockKeyringStore::default();
-        let first = json!({"value": "first"});
+        let first = json!({"value": "first", "stale": true});
         let second = json!({"value": "second", "extra": 1});
 
         save_split_json_to_keyring(&store, SERVICE, BASE_KEY, &first)
             .expect("first split JSON save should succeed");
-        let first_revision = store
-            .saved_secret_utf8(&layout_key(BASE_KEY, ACTIVE_REVISION_ENTRY))
-            .expect("first revision should exist");
-        let first_manifest_key = revision_key(BASE_KEY, &first_revision, MANIFEST_ENTRY);
-        let first_value_key = value_key(BASE_KEY, &first_revision, "/value");
+        let manifest_key = layout_key(BASE_KEY, MANIFEST_ENTRY);
+        let stale_value_key = value_key(BASE_KEY, "/stale");
+        assert!(store.contains(&manifest_key));
+        assert!(store.contains(&stale_value_key));
 
         save_split_json_to_keyring(&store, SERVICE, BASE_KEY, &second)
             .expect("second split JSON save should succeed");
-        let second_revision = store
-            .saved_secret_utf8(&layout_key(BASE_KEY, ACTIVE_REVISION_ENTRY))
-            .expect("second revision should exist");
-        let second_manifest_key = revision_key(BASE_KEY, &second_revision, MANIFEST_ENTRY);
-
-        assert_ne!(first_revision, second_revision);
-        assert!(!store.contains(&first_manifest_key));
-        assert!(!store.contains(&first_value_key));
-        assert!(store.contains(&second_manifest_key));
+        assert!(!store.contains(&stale_value_key));
+        assert!(store.contains(&manifest_key));
+        assert_eq!(
+            store.saved_secret_utf8(&value_key(BASE_KEY, "/value")),
+            Some("\"second\"".to_string())
+        );
+        assert_eq!(
+            store.saved_secret_utf8(&value_key(BASE_KEY, "/extra")),
+            Some("1".to_string())
+        );
 
         let loaded = load_split_json_from_keyring(&store, SERVICE, BASE_KEY)
             .expect("split JSON should load")

--- a/codex-rs/keyring-store/src/split_json.rs
+++ b/codex-rs/keyring-store/src/split_json.rs
@@ -91,10 +91,7 @@ pub fn load_json_from_keyring<K: KeyringStore + ?Sized>(
     service: &str,
     base_key: &str,
 ) -> Result<Option<Value>, JsonKeyringError> {
-    if let Some(value) = load_split_json_from_keyring(keyring_store, service, base_key)? {
-        return Ok(Some(value));
-    }
-    load_full_json_from_keyring(keyring_store, service, base_key)
+    load_split_json_from_keyring(keyring_store, service, base_key)
 }
 
 #[cfg(not(windows))]
@@ -106,7 +103,7 @@ pub fn load_json_from_keyring<K: KeyringStore + ?Sized>(
     if let Some(value) = load_full_json_from_keyring(keyring_store, service, base_key)? {
         return Ok(Some(value));
     }
-    load_split_json_from_keyring(keyring_store, service, base_key)
+    Ok(None)
 }
 
 #[cfg(windows)]
@@ -117,9 +114,7 @@ pub fn save_json_to_keyring<K: KeyringStore + ?Sized>(
     value: &Value,
 ) -> Result<(), JsonKeyringError> {
     save_split_json_to_keyring(keyring_store, service, base_key, value)?;
-    if let Err(err) = delete_full_json_from_keyring(keyring_store, service, base_key) {
-        warn!("failed to remove stale full JSON record from keyring: {err}");
-    }
+
     Ok(())
 }
 
@@ -130,11 +125,10 @@ pub fn save_json_to_keyring<K: KeyringStore + ?Sized>(
     base_key: &str,
     value: &Value,
 ) -> Result<(), JsonKeyringError> {
-    save_full_json_to_keyring(keyring_store, service, base_key, value)?;
-    if let Err(err) = delete_split_json_from_keyring(keyring_store, service, base_key) {
-        warn!("failed to remove stale split JSON record from keyring: {err}");
-    }
-    Ok(())
+    let bytes = serde_json::to_vec(value).map_err(|err| {
+        SplitJsonKeyringError::new(format!("failed to serialize JSON record: {err}"))
+    })?;
+    save_secret_to_keyring(keyring_store, service, base_key, &bytes, "JSON record")
 }
 
 #[cfg(windows)]
@@ -144,8 +138,7 @@ pub fn delete_json_from_keyring<K: KeyringStore + ?Sized>(
     base_key: &str,
 ) -> Result<bool, JsonKeyringError> {
     let split_removed = delete_split_json_from_keyring(keyring_store, service, base_key)?;
-    let full_removed = delete_full_json_from_keyring(keyring_store, service, base_key)?;
-    Ok(split_removed || full_removed)
+    Ok(split_removed)
 }
 
 #[cfg(not(windows))]
@@ -155,11 +148,10 @@ pub fn delete_json_from_keyring<K: KeyringStore + ?Sized>(
     base_key: &str,
 ) -> Result<bool, JsonKeyringError> {
     let full_removed = delete_full_json_from_keyring(keyring_store, service, base_key)?;
-    let split_removed = delete_split_json_from_keyring(keyring_store, service, base_key)?;
-    Ok(full_removed || split_removed)
+    Ok(full_removed)
 }
 
-pub fn load_split_json_from_keyring<K: KeyringStore + ?Sized>(
+fn load_split_json_from_keyring<K: KeyringStore + ?Sized>(
     keyring_store: &K,
     service: &str,
     base_key: &str,
@@ -170,7 +162,7 @@ pub fn load_split_json_from_keyring<K: KeyringStore + ?Sized>(
     inflate_split_json(keyring_store, service, base_key, &manifest).map(Some)
 }
 
-pub fn save_split_json_to_keyring<K: KeyringStore + ?Sized>(
+fn save_split_json_to_keyring<K: KeyringStore + ?Sized>(
     keyring_store: &K,
     service: &str,
     base_key: &str,
@@ -234,7 +226,7 @@ pub fn save_split_json_to_keyring<K: KeyringStore + ?Sized>(
     Ok(())
 }
 
-pub fn delete_split_json_from_keyring<K: KeyringStore + ?Sized>(
+fn delete_split_json_from_keyring<K: KeyringStore + ?Sized>(
     keyring_store: &K,
     service: &str,
     base_key: &str,
@@ -286,19 +278,6 @@ fn load_full_json_from_keyring<K: KeyringStore + ?Sized>(
         Ok(None) => Ok(None),
         Err(error) => Err(credential_store_error("load", "JSON record", error)),
     }
-}
-
-#[cfg(not(windows))]
-fn save_full_json_to_keyring<K: KeyringStore + ?Sized>(
-    keyring_store: &K,
-    service: &str,
-    base_key: &str,
-    value: &Value,
-) -> Result<(), SplitJsonKeyringError> {
-    let bytes = serde_json::to_vec(value).map_err(|err| {
-        SplitJsonKeyringError::new(format!("failed to serialize JSON record: {err}"))
-    })?;
-    save_secret_to_keyring(keyring_store, service, base_key, &bytes, "JSON record")
 }
 
 fn delete_full_json_from_keyring<K: KeyringStore + ?Sized>(
@@ -653,7 +632,6 @@ mod tests {
     use super::save_json_to_keyring;
     use super::save_split_json_to_keyring;
     use super::value_key;
-    use crate::KeyringStore;
     use crate::tests::MockKeyringStore;
     use pretty_assertions::assert_eq;
     use serde_json::json;
@@ -701,40 +679,109 @@ mod tests {
         }
     }
 
-    #[cfg(not(windows))]
     #[test]
-    fn json_storage_loads_split_json_compatibility_on_non_windows() {
+    fn json_storage_does_not_load_compatibility_layout() {
         let store = MockKeyringStore::default();
         let expected = json!({
             "token": "secret",
             "nested": {"id": 9}
         });
 
-        save_split_json_to_keyring(&store, SERVICE, BASE_KEY, &expected)
-            .expect("split JSON should save");
+        #[cfg(windows)]
+        {
+            store
+                .save(
+                    SERVICE,
+                    BASE_KEY,
+                    &serde_json::to_string(&expected).expect("JSON should serialize"),
+                )
+                .expect("full JSON should save");
+            let loaded =
+                load_json_from_keyring(&store, SERVICE, BASE_KEY).expect("JSON should load");
+            assert_eq!(loaded, None);
+        }
+
+        #[cfg(not(windows))]
+        {
+            save_split_json_to_keyring(&store, SERVICE, BASE_KEY, &expected)
+                .expect("split JSON should save");
+            let loaded =
+                load_json_from_keyring(&store, SERVICE, BASE_KEY).expect("JSON should load");
+            assert_eq!(loaded, None);
+        }
+    }
+
+    #[test]
+    fn json_storage_save_preserves_compatibility_layout() {
+        let store = MockKeyringStore::default();
+        let current = json!({"current": true});
+        let compat = json!({"split": true});
+
+        #[cfg(windows)]
+        {
+            store
+                .save(
+                    SERVICE,
+                    BASE_KEY,
+                    &serde_json::to_string(&compat).expect("JSON should serialize"),
+                )
+                .expect("full JSON should save");
+        }
+
+        #[cfg(not(windows))]
+        {
+            save_split_json_to_keyring(&store, SERVICE, BASE_KEY, &compat)
+                .expect("split JSON should save");
+        }
+
+        save_json_to_keyring(&store, SERVICE, BASE_KEY, &current).expect("JSON should save");
 
         let loaded = load_json_from_keyring(&store, SERVICE, BASE_KEY)
             .expect("JSON should load")
             .expect("JSON should exist");
-        assert_eq!(loaded, expected);
+        assert_eq!(loaded, current);
+
+        #[cfg(windows)]
+        {
+            assert_eq!(
+                store.saved_value(BASE_KEY),
+                Some(serde_json::to_string(&compat).expect("JSON should serialize"))
+            );
+        }
+
+        #[cfg(not(windows))]
+        {
+            let compat_loaded = load_split_json_from_keyring(&store, SERVICE, BASE_KEY)
+                .expect("split JSON should load")
+                .expect("split JSON should exist");
+            assert_eq!(compat_loaded, compat);
+        }
     }
 
     #[test]
-    fn json_storage_delete_removes_platform_and_compat_entries() {
+    fn json_storage_delete_removes_only_platform_entries() {
         let store = MockKeyringStore::default();
         let current = json!({"current": true});
-        let split = json!({"split": true});
+        let compat = json!({"split": true});
 
-        save_json_to_keyring(&store, SERVICE, BASE_KEY, &current).expect("JSON should save");
-        save_split_json_to_keyring(&store, SERVICE, BASE_KEY, &split)
-            .expect("split JSON should save");
-        store
-            .save(
-                SERVICE,
-                BASE_KEY,
-                &serde_json::to_string(&current).expect("JSON should serialize"),
-            )
-            .expect("legacy JSON should save");
+        #[cfg(windows)]
+        {
+            store
+                .save(
+                    SERVICE,
+                    BASE_KEY,
+                    &serde_json::to_string(&compat).expect("JSON should serialize"),
+                )
+                .expect("full JSON should save");
+            save_json_to_keyring(&store, SERVICE, BASE_KEY, &current).expect("JSON should save");
+        }
+
+        #[cfg(not(windows))]
+        {
+            save_json_to_keyring(&store, SERVICE, BASE_KEY, &current).expect("JSON should save");
+            save_split_json_to_keyring(&store, SERVICE, BASE_KEY, &compat)
+                .expect("split JSON should save");
+        }
 
         let removed = delete_json_from_keyring(&store, SERVICE, BASE_KEY)
             .expect("JSON delete should succeed");
@@ -745,8 +792,18 @@ mod tests {
                 .expect("JSON load should succeed")
                 .is_none()
         );
-        assert!(!store.contains(BASE_KEY));
-        assert!(!store.contains(&layout_key(BASE_KEY, MANIFEST_ENTRY)));
+
+        #[cfg(windows)]
+        {
+            assert!(store.contains(BASE_KEY));
+            assert!(!store.contains(&layout_key(BASE_KEY, MANIFEST_ENTRY)));
+        }
+
+        #[cfg(not(windows))]
+        {
+            assert!(!store.contains(BASE_KEY));
+            assert!(store.contains(&layout_key(BASE_KEY, MANIFEST_ENTRY)));
+        }
     }
 
     #[test]

--- a/codex-rs/login/src/auth/storage.rs
+++ b/codex-rs/login/src/auth/storage.rs
@@ -23,6 +23,9 @@ use crate::token_data::TokenData;
 use codex_app_server_protocol::AuthMode;
 use codex_keyring_store::DefaultKeyringStore;
 use codex_keyring_store::KeyringStore;
+use codex_keyring_store::delete_split_json_from_keyring;
+use codex_keyring_store::load_split_json_from_keyring;
+use codex_keyring_store::save_split_json_to_keyring;
 use once_cell::sync::Lazy;
 
 /// Determine where Codex should store CLI auth credentials.
@@ -133,21 +136,6 @@ impl AuthStorageBackend for FileAuthStorage {
 }
 
 const KEYRING_SERVICE: &str = "Codex Auth";
-const KEYRING_LAYOUT_VERSION: &str = "v2";
-const KEYRING_ACTIVE_REVISION_ENTRY: &str = "active";
-const KEYRING_MANIFEST_ENTRY: &str = "manifest";
-const KEYRING_OPENAI_API_KEY_ENTRY: &str = "OPENAI_API_KEY";
-const KEYRING_ID_TOKEN_ENTRY: &str = "tokens.id_token";
-const KEYRING_ACCESS_TOKEN_ENTRY: &str = "tokens.access_token";
-const KEYRING_REFRESH_TOKEN_ENTRY: &str = "tokens.refresh_token";
-const KEYRING_ACCOUNT_ID_ENTRY: &str = "tokens.account_id";
-const KEYRING_RECORD_ENTRIES: [&str; 5] = [
-    KEYRING_MANIFEST_ENTRY,
-    KEYRING_OPENAI_API_KEY_ENTRY,
-    KEYRING_ID_TOKEN_ENTRY,
-    KEYRING_ACCESS_TOKEN_ENTRY,
-    KEYRING_REFRESH_TOKEN_ENTRY,
-];
 
 // turns codex_home path into a stable, short key string
 fn compute_store_key(codex_home: &Path) -> std::io::Result<String> {
@@ -161,47 +149,6 @@ fn compute_store_key(codex_home: &Path) -> std::io::Result<String> {
     let hex = format!("{digest:x}");
     let truncated = hex.get(..16).unwrap_or(&hex);
     Ok(format!("cli|{truncated}"))
-}
-
-fn keyring_layout_key(base_key: &str, suffix: &str) -> String {
-    format!("{base_key}|{KEYRING_LAYOUT_VERSION}|{suffix}")
-}
-
-fn keyring_revision_key(base_key: &str, revision: &str, suffix: &str) -> String {
-    format!("{base_key}|{KEYRING_LAYOUT_VERSION}|{revision}|{suffix}")
-}
-
-fn next_keyring_revision() -> String {
-    Utc::now()
-        .timestamp_nanos_opt()
-        .unwrap_or_else(|| Utc::now().timestamp_micros() * 1_000)
-        .to_string()
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
-struct KeyringAuthManifest {
-    auth_mode: Option<AuthMode>,
-    has_openai_api_key: bool,
-    has_tokens: bool,
-    has_account_id: bool,
-    last_refresh: Option<DateTime<Utc>>,
-}
-
-impl From<&AuthDotJson> for KeyringAuthManifest {
-    fn from(auth: &AuthDotJson) -> Self {
-        let has_account_id = auth
-            .tokens
-            .as_ref()
-            .and_then(|tokens| tokens.account_id.as_ref())
-            .is_some();
-        Self {
-            auth_mode: auth.auth_mode,
-            has_openai_api_key: auth.openai_api_key.is_some(),
-            has_tokens: auth.tokens.is_some(),
-            has_account_id,
-            last_refresh: auth.last_refresh,
-        }
-    }
 }
 
 #[derive(Clone, Debug)]
@@ -233,131 +180,29 @@ impl KeyringAuthStorage {
         }
     }
 
-    fn load_secret_from_keyring(&self, key: &str, field: &str) -> std::io::Result<Option<Vec<u8>>> {
-        match self.keyring_store.load_secret(KEYRING_SERVICE, key) {
-            Ok(secret) => Ok(secret),
-            Err(error) => Err(std::io::Error::other(format!(
-                "failed to load {field} from keyring: {}",
-                error.message()
-            ))),
-        }
-    }
-
-    fn load_utf8_secret_from_keyring(
-        &self,
-        key: &str,
-        field: &str,
-    ) -> std::io::Result<Option<String>> {
-        let Some(secret) = self.load_secret_from_keyring(key, field)? else {
+    fn load_split_auth_from_keyring(&self, base_key: &str) -> std::io::Result<Option<AuthDotJson>> {
+        let Some(value) =
+            load_split_json_from_keyring(self.keyring_store.as_ref(), KEYRING_SERVICE, base_key)
+                .map_err(|err| {
+                    std::io::Error::other(format!(
+                        "failed to load split CLI auth from keyring: {err}"
+                    ))
+                })?
+        else {
             return Ok(None);
         };
-        String::from_utf8(secret).map(Some).map_err(|err| {
+        serde_json::from_value(value).map(Some).map_err(|err| {
             std::io::Error::other(format!(
-                "failed to decode {field} from keyring as UTF-8: {err}"
+                "failed to deserialize CLI auth from keyring: {err}"
             ))
-        })
-    }
-
-    fn save_secret_to_keyring(&self, key: &str, value: &[u8], field: &str) -> std::io::Result<()> {
-        match self.keyring_store.save_secret(KEYRING_SERVICE, key, value) {
-            Ok(()) => Ok(()),
-            Err(error) => {
-                let message = format!("failed to write {field} to keyring: {}", error.message());
-                warn!("{message}");
-                Err(std::io::Error::other(message))
-            }
-        }
-    }
-
-    fn load_active_revision(&self, base_key: &str) -> std::io::Result<Option<String>> {
-        let active_key = keyring_layout_key(base_key, KEYRING_ACTIVE_REVISION_ENTRY);
-        self.load_utf8_secret_from_keyring(&active_key, "active auth revision")
-    }
-
-    fn load_required_utf8_secret(&self, key: &str, field: &str) -> std::io::Result<String> {
-        self.load_utf8_secret_from_keyring(key, field)?
-            .ok_or_else(|| std::io::Error::other(format!("missing {field} in keyring")))
-    }
-
-    fn load_manifest(
-        &self,
-        base_key: &str,
-        revision: &str,
-    ) -> std::io::Result<KeyringAuthManifest> {
-        let manifest_key = keyring_revision_key(base_key, revision, KEYRING_MANIFEST_ENTRY);
-        let manifest = self
-            .load_secret_from_keyring(&manifest_key, "auth manifest")?
-            .ok_or_else(|| std::io::Error::other("missing auth manifest in keyring"))?;
-        serde_json::from_slice(&manifest).map_err(|err| {
-            std::io::Error::other(format!(
-                "failed to deserialize auth manifest from keyring: {err}"
-            ))
-        })
-    }
-
-    fn load_v2_from_keyring(&self, base_key: &str, revision: &str) -> std::io::Result<AuthDotJson> {
-        let manifest = self.load_manifest(base_key, revision)?;
-        let openai_api_key = if manifest.has_openai_api_key {
-            let key = keyring_revision_key(base_key, revision, KEYRING_OPENAI_API_KEY_ENTRY);
-            Some(self.load_required_utf8_secret(&key, "OPENAI_API_KEY")?)
-        } else {
-            None
-        };
-        let tokens = if manifest.has_tokens {
-            let id_token_key = keyring_revision_key(base_key, revision, KEYRING_ID_TOKEN_ENTRY);
-            let id_token = self.load_required_utf8_secret(&id_token_key, "ID token")?;
-            let access_token_key =
-                keyring_revision_key(base_key, revision, KEYRING_ACCESS_TOKEN_ENTRY);
-            let access_token = self.load_required_utf8_secret(&access_token_key, "access token")?;
-            let refresh_token_key =
-                keyring_revision_key(base_key, revision, KEYRING_REFRESH_TOKEN_ENTRY);
-            let refresh_token =
-                self.load_required_utf8_secret(&refresh_token_key, "refresh token")?;
-            let account_id = if manifest.has_account_id {
-                let account_id_key =
-                    keyring_revision_key(base_key, revision, KEYRING_ACCOUNT_ID_ENTRY);
-                Some(self.load_required_utf8_secret(&account_id_key, "account ID")?)
-            } else {
-                None
-            };
-            Some(TokenData {
-                id_token: crate::token_data::parse_chatgpt_jwt_claims(&id_token)
-                    .map_err(std::io::Error::other)?,
-                access_token,
-                refresh_token,
-                account_id,
-            })
-        } else {
-            None
-        };
-        Ok(AuthDotJson {
-            auth_mode: manifest.auth_mode,
-            openai_api_key,
-            tokens,
-            last_refresh: manifest.last_refresh,
         })
     }
 
     fn load_from_keyring(&self, base_key: &str) -> std::io::Result<Option<AuthDotJson>> {
-        if let Some(revision) = self.load_active_revision(base_key)? {
-            return self.load_v2_from_keyring(base_key, &revision).map(Some);
+        if let Some(auth) = self.load_split_auth_from_keyring(base_key)? {
+            return Ok(Some(auth));
         }
         self.load_legacy_from_keyring(base_key)
-    }
-
-    fn write_optional_secret(
-        &self,
-        base_key: &str,
-        revision: &str,
-        entry: &str,
-        value: Option<&str>,
-        field: &str,
-    ) -> std::io::Result<()> {
-        if let Some(value) = value {
-            let key = keyring_revision_key(base_key, revision, entry);
-            self.save_secret_to_keyring(&key, value.as_bytes(), field)?;
-        }
-        Ok(())
     }
 
     fn delete_keyring_entry(&self, key: &str) -> std::io::Result<bool> {
@@ -368,95 +213,8 @@ impl KeyringAuthStorage {
             })
     }
 
-    fn delete_v2_revision(&self, base_key: &str, revision: &str) -> std::io::Result<bool> {
-        let mut removed = false;
-        for entry in KEYRING_RECORD_ENTRIES {
-            let key = keyring_revision_key(base_key, revision, entry);
-            removed |= self.delete_keyring_entry(&key)?;
-        }
-        let account_id_key = keyring_revision_key(base_key, revision, KEYRING_ACCOUNT_ID_ENTRY);
-        removed |= self.delete_keyring_entry(&account_id_key)?;
-        Ok(removed)
-    }
-
-    fn delete_from_keyring_only(&self) -> std::io::Result<bool> {
-        let base_key = compute_store_key(&self.codex_home)?;
-        let mut removed = false;
-        if let Some(revision) = self.load_active_revision(&base_key)? {
-            removed |= self.delete_v2_revision(&base_key, &revision)?;
-            let active_key = keyring_layout_key(&base_key, KEYRING_ACTIVE_REVISION_ENTRY);
-            removed |= self.delete_keyring_entry(&active_key)?;
-        }
-        removed |= self.delete_keyring_entry(&base_key)?;
-        Ok(removed)
-    }
-
-    fn save_v2_to_keyring(&self, base_key: &str, auth: &AuthDotJson) -> std::io::Result<()> {
-        let previous_revision = match self.load_active_revision(base_key) {
-            Ok(revision) => revision,
-            Err(err) => {
-                warn!("failed to read previous auth revision from keyring: {err}");
-                None
-            }
-        };
-        let revision = next_keyring_revision();
-        let manifest = KeyringAuthManifest::from(auth);
-
-        self.write_optional_secret(
-            base_key,
-            &revision,
-            KEYRING_OPENAI_API_KEY_ENTRY,
-            auth.openai_api_key.as_deref(),
-            "OPENAI_API_KEY",
-        )?;
-        if let Some(tokens) = auth.tokens.as_ref() {
-            self.write_optional_secret(
-                base_key,
-                &revision,
-                KEYRING_ID_TOKEN_ENTRY,
-                Some(&tokens.id_token.raw_jwt),
-                "ID token",
-            )?;
-            self.write_optional_secret(
-                base_key,
-                &revision,
-                KEYRING_ACCESS_TOKEN_ENTRY,
-                Some(&tokens.access_token),
-                "access token",
-            )?;
-            self.write_optional_secret(
-                base_key,
-                &revision,
-                KEYRING_REFRESH_TOKEN_ENTRY,
-                Some(&tokens.refresh_token),
-                "refresh token",
-            )?;
-            self.write_optional_secret(
-                base_key,
-                &revision,
-                KEYRING_ACCOUNT_ID_ENTRY,
-                tokens.account_id.as_deref(),
-                "account ID",
-            )?;
-        }
-
-        let manifest_key = keyring_revision_key(base_key, &revision, KEYRING_MANIFEST_ENTRY);
-        let manifest_bytes = serde_json::to_vec(&manifest).map_err(std::io::Error::other)?;
-        self.save_secret_to_keyring(&manifest_key, &manifest_bytes, "auth manifest")?;
-
-        let active_key = keyring_layout_key(base_key, KEYRING_ACTIVE_REVISION_ENTRY);
-        self.save_secret_to_keyring(&active_key, revision.as_bytes(), "active auth revision")?;
-
-        if let Some(previous_revision) = previous_revision
-            && previous_revision != revision
-            && let Err(err) = self.delete_v2_revision(base_key, &previous_revision)
-        {
-            warn!("failed to remove stale auth revision from keyring: {err}");
-        }
-        if let Err(err) = self.delete_keyring_entry(base_key) {
-            warn!("failed to remove legacy auth entry from keyring: {err}");
-        }
-        Ok(())
+    fn delete_legacy_from_keyring_only(&self, base_key: &str) -> std::io::Result<bool> {
+        self.delete_keyring_entry(base_key)
     }
 }
 
@@ -468,7 +226,17 @@ impl AuthStorageBackend for KeyringAuthStorage {
 
     fn save(&self, auth: &AuthDotJson) -> std::io::Result<()> {
         let base_key = compute_store_key(&self.codex_home)?;
-        self.save_v2_to_keyring(&base_key, auth)?;
+        let value = serde_json::to_value(auth).map_err(std::io::Error::other)?;
+        save_split_json_to_keyring(
+            self.keyring_store.as_ref(),
+            KEYRING_SERVICE,
+            &base_key,
+            &value,
+        )
+        .map_err(|err| std::io::Error::other(format!("failed to write auth to keyring: {err}")))?;
+        if let Err(err) = self.delete_legacy_from_keyring_only(&base_key) {
+            warn!("failed to remove legacy auth entries from keyring: {err}");
+        }
         if let Err(err) = delete_file_if_exists(&self.codex_home) {
             warn!("failed to remove CLI auth fallback file: {err}");
         }
@@ -476,9 +244,15 @@ impl AuthStorageBackend for KeyringAuthStorage {
     }
 
     fn delete(&self) -> std::io::Result<bool> {
-        let keyring_removed = self.delete_from_keyring_only()?;
+        let base_key = compute_store_key(&self.codex_home)?;
+        let split_removed =
+            delete_split_json_from_keyring(self.keyring_store.as_ref(), KEYRING_SERVICE, &base_key)
+                .map_err(|err| {
+                    std::io::Error::other(format!("failed to delete auth from keyring: {err}"))
+                })?;
+        let legacy_removed = self.delete_legacy_from_keyring_only(&base_key)?;
         let file_removed = delete_file_if_exists(&self.codex_home)?;
-        Ok(keyring_removed || file_removed)
+        Ok(split_removed || legacy_removed || file_removed)
     }
 }
 

--- a/codex-rs/login/src/auth/storage.rs
+++ b/codex-rs/login/src/auth/storage.rs
@@ -23,9 +23,9 @@ use crate::token_data::TokenData;
 use codex_app_server_protocol::AuthMode;
 use codex_keyring_store::DefaultKeyringStore;
 use codex_keyring_store::KeyringStore;
-use codex_keyring_store::delete_split_json_from_keyring;
-use codex_keyring_store::load_split_json_from_keyring;
-use codex_keyring_store::save_split_json_to_keyring;
+use codex_keyring_store::delete_json_from_keyring;
+use codex_keyring_store::load_json_from_keyring;
+use codex_keyring_store::save_json_to_keyring;
 use once_cell::sync::Lazy;
 
 /// Determine where Codex should store CLI auth credentials.
@@ -165,28 +165,11 @@ impl KeyringAuthStorage {
         }
     }
 
-    fn load_legacy_from_keyring(&self, key: &str) -> std::io::Result<Option<AuthDotJson>> {
-        match self.keyring_store.load(KEYRING_SERVICE, key) {
-            Ok(Some(serialized)) => serde_json::from_str(&serialized).map(Some).map_err(|err| {
-                std::io::Error::other(format!(
-                    "failed to deserialize CLI auth from keyring: {err}"
-                ))
-            }),
-            Ok(None) => Ok(None),
-            Err(error) => Err(std::io::Error::other(format!(
-                "failed to load CLI auth from keyring: {}",
-                error.message()
-            ))),
-        }
-    }
-
-    fn load_split_auth_from_keyring(&self, base_key: &str) -> std::io::Result<Option<AuthDotJson>> {
+    fn load_auth_from_keyring(&self, base_key: &str) -> std::io::Result<Option<AuthDotJson>> {
         let Some(value) =
-            load_split_json_from_keyring(self.keyring_store.as_ref(), KEYRING_SERVICE, base_key)
+            load_json_from_keyring(self.keyring_store.as_ref(), KEYRING_SERVICE, base_key)
                 .map_err(|err| {
-                    std::io::Error::other(format!(
-                        "failed to load split CLI auth from keyring: {err}"
-                    ))
+                    std::io::Error::other(format!("failed to load CLI auth from keyring: {err}"))
                 })?
         else {
             return Ok(None);
@@ -197,46 +180,24 @@ impl KeyringAuthStorage {
             ))
         })
     }
-
-    fn load_from_keyring(&self, base_key: &str) -> std::io::Result<Option<AuthDotJson>> {
-        if let Some(auth) = self.load_split_auth_from_keyring(base_key)? {
-            return Ok(Some(auth));
-        }
-        self.load_legacy_from_keyring(base_key)
-    }
-
-    fn delete_keyring_entry(&self, key: &str) -> std::io::Result<bool> {
-        self.keyring_store
-            .delete(KEYRING_SERVICE, key)
-            .map_err(|err| {
-                std::io::Error::other(format!("failed to delete auth from keyring: {err}"))
-            })
-    }
-
-    fn delete_legacy_from_keyring_only(&self, base_key: &str) -> std::io::Result<bool> {
-        self.delete_keyring_entry(base_key)
-    }
 }
 
 impl AuthStorageBackend for KeyringAuthStorage {
     fn load(&self) -> std::io::Result<Option<AuthDotJson>> {
         let key = compute_store_key(&self.codex_home)?;
-        self.load_from_keyring(&key)
+        self.load_auth_from_keyring(&key)
     }
 
     fn save(&self, auth: &AuthDotJson) -> std::io::Result<()> {
         let base_key = compute_store_key(&self.codex_home)?;
         let value = serde_json::to_value(auth).map_err(std::io::Error::other)?;
-        save_split_json_to_keyring(
+        save_json_to_keyring(
             self.keyring_store.as_ref(),
             KEYRING_SERVICE,
             &base_key,
             &value,
         )
         .map_err(|err| std::io::Error::other(format!("failed to write auth to keyring: {err}")))?;
-        if let Err(err) = self.delete_legacy_from_keyring_only(&base_key) {
-            warn!("failed to remove legacy auth entries from keyring: {err}");
-        }
         if let Err(err) = delete_file_if_exists(&self.codex_home) {
             warn!("failed to remove CLI auth fallback file: {err}");
         }
@@ -245,14 +206,13 @@ impl AuthStorageBackend for KeyringAuthStorage {
 
     fn delete(&self) -> std::io::Result<bool> {
         let base_key = compute_store_key(&self.codex_home)?;
-        let split_removed =
-            delete_split_json_from_keyring(self.keyring_store.as_ref(), KEYRING_SERVICE, &base_key)
+        let keyring_removed =
+            delete_json_from_keyring(self.keyring_store.as_ref(), KEYRING_SERVICE, &base_key)
                 .map_err(|err| {
                     std::io::Error::other(format!("failed to delete auth from keyring: {err}"))
                 })?;
-        let legacy_removed = self.delete_legacy_from_keyring_only(&base_key)?;
         let file_removed = delete_file_if_exists(&self.codex_home)?;
-        Ok(split_removed || legacy_removed || file_removed)
+        Ok(keyring_removed || file_removed)
     }
 }
 

--- a/codex-rs/login/src/auth/storage.rs
+++ b/codex-rs/login/src/auth/storage.rs
@@ -133,6 +133,21 @@ impl AuthStorageBackend for FileAuthStorage {
 }
 
 const KEYRING_SERVICE: &str = "Codex Auth";
+const KEYRING_LAYOUT_VERSION: &str = "v2";
+const KEYRING_ACTIVE_REVISION_ENTRY: &str = "active";
+const KEYRING_MANIFEST_ENTRY: &str = "manifest";
+const KEYRING_OPENAI_API_KEY_ENTRY: &str = "OPENAI_API_KEY";
+const KEYRING_ID_TOKEN_ENTRY: &str = "tokens.id_token";
+const KEYRING_ACCESS_TOKEN_ENTRY: &str = "tokens.access_token";
+const KEYRING_REFRESH_TOKEN_ENTRY: &str = "tokens.refresh_token";
+const KEYRING_ACCOUNT_ID_ENTRY: &str = "tokens.account_id";
+const KEYRING_RECORD_ENTRIES: [&str; 5] = [
+    KEYRING_MANIFEST_ENTRY,
+    KEYRING_OPENAI_API_KEY_ENTRY,
+    KEYRING_ID_TOKEN_ENTRY,
+    KEYRING_ACCESS_TOKEN_ENTRY,
+    KEYRING_REFRESH_TOKEN_ENTRY,
+];
 
 // turns codex_home path into a stable, short key string
 fn compute_store_key(codex_home: &Path) -> std::io::Result<String> {
@@ -146,6 +161,47 @@ fn compute_store_key(codex_home: &Path) -> std::io::Result<String> {
     let hex = format!("{digest:x}");
     let truncated = hex.get(..16).unwrap_or(&hex);
     Ok(format!("cli|{truncated}"))
+}
+
+fn keyring_layout_key(base_key: &str, suffix: &str) -> String {
+    format!("{base_key}|{KEYRING_LAYOUT_VERSION}|{suffix}")
+}
+
+fn keyring_revision_key(base_key: &str, revision: &str, suffix: &str) -> String {
+    format!("{base_key}|{KEYRING_LAYOUT_VERSION}|{revision}|{suffix}")
+}
+
+fn next_keyring_revision() -> String {
+    Utc::now()
+        .timestamp_nanos_opt()
+        .unwrap_or_else(|| Utc::now().timestamp_micros() * 1_000)
+        .to_string()
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+struct KeyringAuthManifest {
+    auth_mode: Option<AuthMode>,
+    has_openai_api_key: bool,
+    has_tokens: bool,
+    has_account_id: bool,
+    last_refresh: Option<DateTime<Utc>>,
+}
+
+impl From<&AuthDotJson> for KeyringAuthManifest {
+    fn from(auth: &AuthDotJson) -> Self {
+        let has_account_id = auth
+            .tokens
+            .as_ref()
+            .and_then(|tokens| tokens.account_id.as_ref())
+            .is_some();
+        Self {
+            auth_mode: auth.auth_mode,
+            has_openai_api_key: auth.openai_api_key.is_some(),
+            has_tokens: auth.tokens.is_some(),
+            has_account_id,
+            last_refresh: auth.last_refresh,
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -162,7 +218,7 @@ impl KeyringAuthStorage {
         }
     }
 
-    fn load_from_keyring(&self, key: &str) -> std::io::Result<Option<AuthDotJson>> {
+    fn load_legacy_from_keyring(&self, key: &str) -> std::io::Result<Option<AuthDotJson>> {
         match self.keyring_store.load(KEYRING_SERVICE, key) {
             Ok(Some(serialized)) => serde_json::from_str(&serialized).map(Some).map_err(|err| {
                 std::io::Error::other(format!(
@@ -177,18 +233,230 @@ impl KeyringAuthStorage {
         }
     }
 
-    fn save_to_keyring(&self, key: &str, value: &str) -> std::io::Result<()> {
-        match self.keyring_store.save(KEYRING_SERVICE, key, value) {
+    fn load_secret_from_keyring(&self, key: &str, field: &str) -> std::io::Result<Option<Vec<u8>>> {
+        match self.keyring_store.load_secret(KEYRING_SERVICE, key) {
+            Ok(secret) => Ok(secret),
+            Err(error) => Err(std::io::Error::other(format!(
+                "failed to load {field} from keyring: {}",
+                error.message()
+            ))),
+        }
+    }
+
+    fn load_utf8_secret_from_keyring(
+        &self,
+        key: &str,
+        field: &str,
+    ) -> std::io::Result<Option<String>> {
+        let Some(secret) = self.load_secret_from_keyring(key, field)? else {
+            return Ok(None);
+        };
+        String::from_utf8(secret).map(Some).map_err(|err| {
+            std::io::Error::other(format!(
+                "failed to decode {field} from keyring as UTF-8: {err}"
+            ))
+        })
+    }
+
+    fn save_secret_to_keyring(&self, key: &str, value: &[u8], field: &str) -> std::io::Result<()> {
+        match self.keyring_store.save_secret(KEYRING_SERVICE, key, value) {
             Ok(()) => Ok(()),
             Err(error) => {
-                let message = format!(
-                    "failed to write OAuth tokens to keyring: {}",
-                    error.message()
-                );
+                let message = format!("failed to write {field} to keyring: {}", error.message());
                 warn!("{message}");
                 Err(std::io::Error::other(message))
             }
         }
+    }
+
+    fn load_active_revision(&self, base_key: &str) -> std::io::Result<Option<String>> {
+        let active_key = keyring_layout_key(base_key, KEYRING_ACTIVE_REVISION_ENTRY);
+        self.load_utf8_secret_from_keyring(&active_key, "active auth revision")
+    }
+
+    fn load_required_utf8_secret(&self, key: &str, field: &str) -> std::io::Result<String> {
+        self.load_utf8_secret_from_keyring(key, field)?
+            .ok_or_else(|| std::io::Error::other(format!("missing {field} in keyring")))
+    }
+
+    fn load_manifest(
+        &self,
+        base_key: &str,
+        revision: &str,
+    ) -> std::io::Result<KeyringAuthManifest> {
+        let manifest_key = keyring_revision_key(base_key, revision, KEYRING_MANIFEST_ENTRY);
+        let manifest = self
+            .load_secret_from_keyring(&manifest_key, "auth manifest")?
+            .ok_or_else(|| std::io::Error::other("missing auth manifest in keyring"))?;
+        serde_json::from_slice(&manifest).map_err(|err| {
+            std::io::Error::other(format!(
+                "failed to deserialize auth manifest from keyring: {err}"
+            ))
+        })
+    }
+
+    fn load_v2_from_keyring(&self, base_key: &str, revision: &str) -> std::io::Result<AuthDotJson> {
+        let manifest = self.load_manifest(base_key, revision)?;
+        let openai_api_key = if manifest.has_openai_api_key {
+            let key = keyring_revision_key(base_key, revision, KEYRING_OPENAI_API_KEY_ENTRY);
+            Some(self.load_required_utf8_secret(&key, "OPENAI_API_KEY")?)
+        } else {
+            None
+        };
+        let tokens = if manifest.has_tokens {
+            let id_token_key = keyring_revision_key(base_key, revision, KEYRING_ID_TOKEN_ENTRY);
+            let id_token = self.load_required_utf8_secret(&id_token_key, "ID token")?;
+            let access_token_key =
+                keyring_revision_key(base_key, revision, KEYRING_ACCESS_TOKEN_ENTRY);
+            let access_token = self.load_required_utf8_secret(&access_token_key, "access token")?;
+            let refresh_token_key =
+                keyring_revision_key(base_key, revision, KEYRING_REFRESH_TOKEN_ENTRY);
+            let refresh_token =
+                self.load_required_utf8_secret(&refresh_token_key, "refresh token")?;
+            let account_id = if manifest.has_account_id {
+                let account_id_key =
+                    keyring_revision_key(base_key, revision, KEYRING_ACCOUNT_ID_ENTRY);
+                Some(self.load_required_utf8_secret(&account_id_key, "account ID")?)
+            } else {
+                None
+            };
+            Some(TokenData {
+                id_token: crate::token_data::parse_chatgpt_jwt_claims(&id_token)
+                    .map_err(std::io::Error::other)?,
+                access_token,
+                refresh_token,
+                account_id,
+            })
+        } else {
+            None
+        };
+        Ok(AuthDotJson {
+            auth_mode: manifest.auth_mode,
+            openai_api_key,
+            tokens,
+            last_refresh: manifest.last_refresh,
+        })
+    }
+
+    fn load_from_keyring(&self, base_key: &str) -> std::io::Result<Option<AuthDotJson>> {
+        if let Some(revision) = self.load_active_revision(base_key)? {
+            return self.load_v2_from_keyring(base_key, &revision).map(Some);
+        }
+        self.load_legacy_from_keyring(base_key)
+    }
+
+    fn write_optional_secret(
+        &self,
+        base_key: &str,
+        revision: &str,
+        entry: &str,
+        value: Option<&str>,
+        field: &str,
+    ) -> std::io::Result<()> {
+        if let Some(value) = value {
+            let key = keyring_revision_key(base_key, revision, entry);
+            self.save_secret_to_keyring(&key, value.as_bytes(), field)?;
+        }
+        Ok(())
+    }
+
+    fn delete_keyring_entry(&self, key: &str) -> std::io::Result<bool> {
+        self.keyring_store
+            .delete(KEYRING_SERVICE, key)
+            .map_err(|err| {
+                std::io::Error::other(format!("failed to delete auth from keyring: {err}"))
+            })
+    }
+
+    fn delete_v2_revision(&self, base_key: &str, revision: &str) -> std::io::Result<bool> {
+        let mut removed = false;
+        for entry in KEYRING_RECORD_ENTRIES {
+            let key = keyring_revision_key(base_key, revision, entry);
+            removed |= self.delete_keyring_entry(&key)?;
+        }
+        let account_id_key = keyring_revision_key(base_key, revision, KEYRING_ACCOUNT_ID_ENTRY);
+        removed |= self.delete_keyring_entry(&account_id_key)?;
+        Ok(removed)
+    }
+
+    fn delete_from_keyring_only(&self) -> std::io::Result<bool> {
+        let base_key = compute_store_key(&self.codex_home)?;
+        let mut removed = false;
+        if let Some(revision) = self.load_active_revision(&base_key)? {
+            removed |= self.delete_v2_revision(&base_key, &revision)?;
+            let active_key = keyring_layout_key(&base_key, KEYRING_ACTIVE_REVISION_ENTRY);
+            removed |= self.delete_keyring_entry(&active_key)?;
+        }
+        removed |= self.delete_keyring_entry(&base_key)?;
+        Ok(removed)
+    }
+
+    fn save_v2_to_keyring(&self, base_key: &str, auth: &AuthDotJson) -> std::io::Result<()> {
+        let previous_revision = match self.load_active_revision(base_key) {
+            Ok(revision) => revision,
+            Err(err) => {
+                warn!("failed to read previous auth revision from keyring: {err}");
+                None
+            }
+        };
+        let revision = next_keyring_revision();
+        let manifest = KeyringAuthManifest::from(auth);
+
+        self.write_optional_secret(
+            base_key,
+            &revision,
+            KEYRING_OPENAI_API_KEY_ENTRY,
+            auth.openai_api_key.as_deref(),
+            "OPENAI_API_KEY",
+        )?;
+        if let Some(tokens) = auth.tokens.as_ref() {
+            self.write_optional_secret(
+                base_key,
+                &revision,
+                KEYRING_ID_TOKEN_ENTRY,
+                Some(&tokens.id_token.raw_jwt),
+                "ID token",
+            )?;
+            self.write_optional_secret(
+                base_key,
+                &revision,
+                KEYRING_ACCESS_TOKEN_ENTRY,
+                Some(&tokens.access_token),
+                "access token",
+            )?;
+            self.write_optional_secret(
+                base_key,
+                &revision,
+                KEYRING_REFRESH_TOKEN_ENTRY,
+                Some(&tokens.refresh_token),
+                "refresh token",
+            )?;
+            self.write_optional_secret(
+                base_key,
+                &revision,
+                KEYRING_ACCOUNT_ID_ENTRY,
+                tokens.account_id.as_deref(),
+                "account ID",
+            )?;
+        }
+
+        let manifest_key = keyring_revision_key(base_key, &revision, KEYRING_MANIFEST_ENTRY);
+        let manifest_bytes = serde_json::to_vec(&manifest).map_err(std::io::Error::other)?;
+        self.save_secret_to_keyring(&manifest_key, &manifest_bytes, "auth manifest")?;
+
+        let active_key = keyring_layout_key(base_key, KEYRING_ACTIVE_REVISION_ENTRY);
+        self.save_secret_to_keyring(&active_key, revision.as_bytes(), "active auth revision")?;
+
+        if let Some(previous_revision) = previous_revision
+            && previous_revision != revision
+            && let Err(err) = self.delete_v2_revision(base_key, &previous_revision)
+        {
+            warn!("failed to remove stale auth revision from keyring: {err}");
+        }
+        if let Err(err) = self.delete_keyring_entry(base_key) {
+            warn!("failed to remove legacy auth entry from keyring: {err}");
+        }
+        Ok(())
     }
 }
 
@@ -199,10 +467,8 @@ impl AuthStorageBackend for KeyringAuthStorage {
     }
 
     fn save(&self, auth: &AuthDotJson) -> std::io::Result<()> {
-        let key = compute_store_key(&self.codex_home)?;
-        // Simpler error mapping per style: prefer method reference over closure
-        let serialized = serde_json::to_string(auth).map_err(std::io::Error::other)?;
-        self.save_to_keyring(&key, &serialized)?;
+        let base_key = compute_store_key(&self.codex_home)?;
+        self.save_v2_to_keyring(&base_key, auth)?;
         if let Err(err) = delete_file_if_exists(&self.codex_home) {
             warn!("failed to remove CLI auth fallback file: {err}");
         }
@@ -210,13 +476,7 @@ impl AuthStorageBackend for KeyringAuthStorage {
     }
 
     fn delete(&self) -> std::io::Result<bool> {
-        let key = compute_store_key(&self.codex_home)?;
-        let keyring_removed = self
-            .keyring_store
-            .delete(KEYRING_SERVICE, &key)
-            .map_err(|err| {
-                std::io::Error::other(format!("failed to delete auth from keyring: {err}"))
-            })?;
+        let keyring_removed = self.delete_from_keyring_only()?;
         let file_removed = delete_file_if_exists(&self.codex_home)?;
         Ok(keyring_removed || file_removed)
     }

--- a/codex-rs/login/src/auth/storage_tests.rs
+++ b/codex-rs/login/src/auth/storage_tests.rs
@@ -292,7 +292,16 @@ fn keyring_auth_storage_load_supports_legacy_single_entry() -> anyhow::Result<()
     )?;
 
     let loaded = storage.load()?;
-    assert_eq!(Some(expected), loaded);
+
+    #[cfg(not(windows))]
+    {
+        assert_eq!(Some(expected), loaded);
+    }
+
+    #[cfg(windows)]
+    {
+        assert_eq!(None, loaded);
+    }
     Ok(())
 }
 
@@ -304,25 +313,6 @@ fn keyring_auth_storage_load_returns_deserialized_keyring_auth() -> anyhow::Resu
     let expected = auth_with_prefix("keyring");
 
     storage.save(&expected)?;
-
-    let loaded = storage.load()?;
-    assert_eq!(Some(expected), loaded);
-    Ok(())
-}
-
-#[test]
-fn keyring_auth_storage_load_supports_split_json_compatibility() -> anyhow::Result<()> {
-    let codex_home = tempdir()?;
-    let mock_keyring = MockKeyringStore::default();
-    let storage = KeyringAuthStorage::new(
-        codex_home.path().to_path_buf(),
-        Arc::new(mock_keyring.clone()),
-    );
-    let expected = auth_with_prefix("split-compat");
-    let key = compute_store_key(codex_home.path())?;
-    let value = serde_json::to_value(&expected)?;
-
-    codex_keyring_store::save_split_json_to_keyring(&mock_keyring, KEYRING_SERVICE, &key, &value)?;
 
     let loaded = storage.load()?;
     assert_eq!(Some(expected), loaded);

--- a/codex-rs/login/src/auth/storage_tests.rs
+++ b/codex-rs/login/src/auth/storage_tests.rs
@@ -2,7 +2,6 @@ use super::*;
 use crate::token_data::IdTokenInfo;
 use anyhow::Context;
 use base64::Engine;
-use pretty_assertions::assert_eq;
 use serde_json::json;
 use tempfile::tempdir;
 
@@ -42,6 +41,45 @@ impl KeyringStore for SaveSecretErrorKeyringStore {
             "error".into(),
             "save".into(),
         )))
+    }
+
+    fn delete(&self, service: &str, account: &str) -> Result<bool, CredentialStoreError> {
+        self.inner.delete(service, account)
+    }
+}
+
+#[derive(Clone, Debug)]
+struct LoadSecretErrorKeyringStore {
+    inner: MockKeyringStore,
+}
+
+impl KeyringStore for LoadSecretErrorKeyringStore {
+    fn load(&self, service: &str, account: &str) -> Result<Option<String>, CredentialStoreError> {
+        self.inner.load(service, account)
+    }
+
+    fn load_secret(
+        &self,
+        _service: &str,
+        _account: &str,
+    ) -> Result<Option<Vec<u8>>, CredentialStoreError> {
+        Err(CredentialStoreError::new(KeyringError::Invalid(
+            "error".into(),
+            "load".into(),
+        )))
+    }
+
+    fn save(&self, service: &str, account: &str, value: &str) -> Result<(), CredentialStoreError> {
+        self.inner.save(service, account, value)
+    }
+
+    fn save_secret(
+        &self,
+        service: &str,
+        account: &str,
+        value: &[u8],
+    ) -> Result<(), CredentialStoreError> {
+        self.inner.save_secret(service, account, value)
     }
 
     fn delete(&self, service: &str, account: &str) -> Result<bool, CredentialStoreError> {
@@ -141,15 +179,12 @@ fn seed_keyring_and_fallback_auth_file_for_delete(
     storage: &KeyringAuthStorage,
     codex_home: &Path,
     auth: &AuthDotJson,
-) -> anyhow::Result<(String, String, PathBuf)> {
+) -> anyhow::Result<(String, PathBuf)> {
     storage.save(auth)?;
     let base_key = compute_store_key(codex_home)?;
-    let revision = storage
-        .load_active_revision(&base_key)?
-        .context("active auth revision should exist")?;
     let auth_file = get_auth_file(codex_home);
     std::fs::write(&auth_file, "stale")?;
-    Ok((base_key, revision, auth_file))
+    Ok((base_key, auth_file))
 }
 
 fn seed_keyring_with_auth<F>(
@@ -172,53 +207,15 @@ fn assert_keyring_saved_auth_and_removed_fallback(
     codex_home: &Path,
     expected: &AuthDotJson,
 ) {
-    let active_key = keyring_layout_key(base_key, KEYRING_ACTIVE_REVISION_ENTRY);
-    let revision = mock_keyring
-        .saved_secret_utf8(&active_key)
-        .expect("active auth revision should exist");
     assert!(
         mock_keyring.saved_value(base_key).is_none(),
         "legacy keyring entry should not be used for split auth storage"
     );
-    let manifest_key = keyring_revision_key(base_key, &revision, KEYRING_MANIFEST_ENTRY);
-    let manifest_bytes = mock_keyring
-        .saved_secret(&manifest_key)
-        .expect("auth manifest should exist");
-    let manifest: KeyringAuthManifest =
-        serde_json::from_slice(&manifest_bytes).expect("manifest should deserialize");
-    assert_eq!(manifest, KeyringAuthManifest::from(expected));
-
-    let openai_api_key_key =
-        keyring_revision_key(base_key, &revision, KEYRING_OPENAI_API_KEY_ENTRY);
-    assert_eq!(
-        mock_keyring.saved_secret_utf8(&openai_api_key_key),
-        expected.openai_api_key
-    );
-
-    if let Some(tokens) = expected.tokens.as_ref() {
-        let id_token_key = keyring_revision_key(base_key, &revision, KEYRING_ID_TOKEN_ENTRY);
-        assert_eq!(
-            mock_keyring.saved_secret_utf8(&id_token_key),
-            Some(tokens.id_token.raw_jwt.clone())
-        );
-        let access_token_key =
-            keyring_revision_key(base_key, &revision, KEYRING_ACCESS_TOKEN_ENTRY);
-        assert_eq!(
-            mock_keyring.saved_secret_utf8(&access_token_key),
-            Some(tokens.access_token.clone())
-        );
-        let refresh_token_key =
-            keyring_revision_key(base_key, &revision, KEYRING_REFRESH_TOKEN_ENTRY);
-        assert_eq!(
-            mock_keyring.saved_secret_utf8(&refresh_token_key),
-            Some(tokens.refresh_token.clone())
-        );
-        let account_id_key = keyring_revision_key(base_key, &revision, KEYRING_ACCOUNT_ID_ENTRY);
-        assert_eq!(
-            mock_keyring.saved_secret_utf8(&account_id_key),
-            tokens.account_id.clone()
-        );
-    }
+    let loaded = load_split_json_from_keyring(mock_keyring, KEYRING_SERVICE, base_key)
+        .expect("split auth should load from keyring")
+        .expect("split auth should exist");
+    let expected_json = serde_json::to_value(expected).expect("auth should serialize");
+    assert_eq!(loaded, expected_json);
     let auth_file = get_auth_file(codex_home);
     assert!(
         !auth_file.exists(),
@@ -292,7 +289,7 @@ fn keyring_auth_storage_load_supports_legacy_single_entry() -> anyhow::Result<()
 }
 
 #[test]
-fn keyring_auth_storage_load_returns_deserialized_v2_auth() -> anyhow::Result<()> {
+fn keyring_auth_storage_load_returns_deserialized_split_auth() -> anyhow::Result<()> {
     let codex_home = tempdir()?;
     let mock_keyring = MockKeyringStore::default();
     let storage = KeyringAuthStorage::new(codex_home.path().to_path_buf(), Arc::new(mock_keyring));
@@ -353,28 +350,15 @@ fn keyring_auth_storage_delete_removes_keyring_and_file() -> anyhow::Result<()> 
         Arc::new(mock_keyring.clone()),
     );
     let auth = auth_with_prefix("delete");
-    let (base_key, revision, auth_file) =
+    let (base_key, auth_file) =
         seed_keyring_and_fallback_auth_file_for_delete(&storage, codex_home.path(), &auth)?;
 
     let removed = storage.delete()?;
 
     assert!(removed, "delete should report removal");
-    let active_key = keyring_layout_key(&base_key, KEYRING_ACTIVE_REVISION_ENTRY);
     assert!(
-        !mock_keyring.contains(&active_key),
-        "active revision should be removed"
-    );
-    for entry in KEYRING_RECORD_ENTRIES {
-        let key = keyring_revision_key(&base_key, &revision, entry);
-        assert!(
-            !mock_keyring.contains(&key),
-            "keyring entry should be removed"
-        );
-    }
-    let account_id_key = keyring_revision_key(&base_key, &revision, KEYRING_ACCOUNT_ID_ENTRY);
-    assert!(
-        !mock_keyring.contains(&account_id_key),
-        "account id entry should be removed"
+        load_split_json_from_keyring(&mock_keyring, KEYRING_SERVICE, &base_key)?.is_none(),
+        "split auth should be removed"
     );
     assert!(
         !auth_file.exists(),
@@ -424,16 +408,10 @@ fn auto_auth_storage_load_uses_file_when_keyring_empty() -> anyhow::Result<()> {
 fn auto_auth_storage_load_falls_back_when_keyring_errors() -> anyhow::Result<()> {
     let codex_home = tempdir()?;
     let mock_keyring = MockKeyringStore::default();
-    let storage = AutoAuthStorage::new(
-        codex_home.path().to_path_buf(),
-        Arc::new(mock_keyring.clone()),
-    );
-    let key = compute_store_key(codex_home.path())?;
-    let active_key = keyring_layout_key(&key, KEYRING_ACTIVE_REVISION_ENTRY);
-    mock_keyring.set_error(
-        &active_key,
-        KeyringError::Invalid("error".into(), "load".into()),
-    );
+    let failing_keyring = LoadSecretErrorKeyringStore {
+        inner: mock_keyring,
+    };
+    let storage = AutoAuthStorage::new(codex_home.path().to_path_buf(), Arc::new(failing_keyring));
 
     let expected = auth_with_prefix("fallback");
     storage.file_storage.save(&expected)?;
@@ -477,7 +455,6 @@ fn auto_auth_storage_save_falls_back_when_keyring_errors() -> anyhow::Result<()>
     };
     let storage = AutoAuthStorage::new(codex_home.path().to_path_buf(), Arc::new(failing_keyring));
     let key = compute_store_key(codex_home.path())?;
-    let active_key = keyring_layout_key(&key, KEYRING_ACTIVE_REVISION_ENTRY);
 
     let auth = auth_with_prefix("fallback");
     storage.save(&auth)?;
@@ -493,8 +470,8 @@ fn auto_auth_storage_save_falls_back_when_keyring_errors() -> anyhow::Result<()>
         .context("fallback auth should exist")?;
     assert_eq!(saved, auth);
     assert!(
-        mock_keyring.saved_secret_utf8(&active_key).is_none(),
-        "keyring should not point to a saved auth revision when save fails"
+        load_split_json_from_keyring(&mock_keyring, KEYRING_SERVICE, &key)?.is_none(),
+        "keyring should not point to saved split auth when save fails"
     );
     Ok(())
 }
@@ -508,7 +485,7 @@ fn auto_auth_storage_delete_removes_keyring_and_file() -> anyhow::Result<()> {
         Arc::new(mock_keyring.clone()),
     );
     let auth = auth_with_prefix("auto-delete");
-    let (base_key, revision, auth_file) = seed_keyring_and_fallback_auth_file_for_delete(
+    let (base_key, auth_file) = seed_keyring_and_fallback_auth_file_for_delete(
         storage.keyring_storage.as_ref(),
         codex_home.path(),
         &auth,
@@ -518,26 +495,8 @@ fn auto_auth_storage_delete_removes_keyring_and_file() -> anyhow::Result<()> {
 
     assert!(removed, "delete should report removal");
     assert!(
-        !mock_keyring.contains(&keyring_layout_key(
-            &base_key,
-            KEYRING_ACTIVE_REVISION_ENTRY
-        )),
-        "active revision should be removed"
-    );
-    for entry in KEYRING_RECORD_ENTRIES {
-        let key = keyring_revision_key(&base_key, &revision, entry);
-        assert!(
-            !mock_keyring.contains(&key),
-            "keyring entry should be removed"
-        );
-    }
-    assert!(
-        !mock_keyring.contains(&keyring_revision_key(
-            &base_key,
-            &revision,
-            KEYRING_ACCOUNT_ID_ENTRY
-        )),
-        "account id entry should be removed"
+        load_split_json_from_keyring(&mock_keyring, KEYRING_SERVICE, &base_key)?.is_none(),
+        "split auth should be removed"
     );
     assert!(
         !auth_file.exists(),

--- a/codex-rs/login/src/auth/storage_tests.rs
+++ b/codex-rs/login/src/auth/storage_tests.rs
@@ -388,10 +388,7 @@ fn keyring_auth_storage_delete_removes_keyring_and_file() -> anyhow::Result<()> 
 fn auto_auth_storage_load_prefers_keyring_value() -> anyhow::Result<()> {
     let codex_home = tempdir()?;
     let mock_keyring = MockKeyringStore::default();
-    let storage = AutoAuthStorage::new(
-        codex_home.path().to_path_buf(),
-        Arc::new(mock_keyring.clone()),
-    );
+    let storage = AutoAuthStorage::new(codex_home.path().to_path_buf(), Arc::new(mock_keyring));
     let keyring_auth = auth_with_prefix("keyring");
     storage.keyring_storage.save(&keyring_auth)?;
 

--- a/codex-rs/login/src/auth/storage_tests.rs
+++ b/codex-rs/login/src/auth/storage_tests.rs
@@ -393,11 +393,7 @@ fn auto_auth_storage_load_prefers_keyring_value() -> anyhow::Result<()> {
         Arc::new(mock_keyring.clone()),
     );
     let keyring_auth = auth_with_prefix("keyring");
-    seed_keyring_with_auth(
-        &mock_keyring,
-        || compute_store_key(codex_home.path()),
-        &keyring_auth,
-    )?;
+    storage.keyring_storage.save(&keyring_auth)?;
 
     let file_auth = auth_with_prefix("file");
     storage.file_storage.save(&file_auth)?;

--- a/codex-rs/login/src/auth/storage_tests.rs
+++ b/codex-rs/login/src/auth/storage_tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::token_data::IdTokenInfo;
 use anyhow::Context;
 use base64::Engine;
+use pretty_assertions::assert_eq;
 use serde_json::json;
 use tempfile::tempdir;
 
@@ -207,15 +208,22 @@ fn assert_keyring_saved_auth_and_removed_fallback(
     codex_home: &Path,
     expected: &AuthDotJson,
 ) {
-    assert!(
-        mock_keyring.saved_value(base_key).is_none(),
-        "legacy keyring entry should not be used for split auth storage"
-    );
-    let loaded = load_split_json_from_keyring(mock_keyring, KEYRING_SERVICE, base_key)
-        .expect("split auth should load from keyring")
-        .expect("split auth should exist");
     let expected_json = serde_json::to_value(expected).expect("auth should serialize");
+    let loaded = load_json_from_keyring(mock_keyring, KEYRING_SERVICE, base_key)
+        .expect("auth should load from keyring")
+        .expect("auth should exist");
     assert_eq!(loaded, expected_json);
+    #[cfg(windows)]
+    assert!(
+        mock_keyring.saved_secret(base_key).is_none(),
+        "windows should store auth using split keyring entries"
+    );
+    #[cfg(not(windows))]
+    assert_eq!(
+        mock_keyring.saved_secret(base_key),
+        Some(serde_json::to_vec(&expected_json).expect("auth should serialize")),
+        "non-windows should store auth as one JSON secret"
+    );
     let auth_file = get_auth_file(codex_home);
     assert!(
         !auth_file.exists(),
@@ -289,13 +297,32 @@ fn keyring_auth_storage_load_supports_legacy_single_entry() -> anyhow::Result<()
 }
 
 #[test]
-fn keyring_auth_storage_load_returns_deserialized_split_auth() -> anyhow::Result<()> {
+fn keyring_auth_storage_load_returns_deserialized_keyring_auth() -> anyhow::Result<()> {
     let codex_home = tempdir()?;
     let mock_keyring = MockKeyringStore::default();
     let storage = KeyringAuthStorage::new(codex_home.path().to_path_buf(), Arc::new(mock_keyring));
-    let expected = auth_with_prefix("split");
+    let expected = auth_with_prefix("keyring");
 
     storage.save(&expected)?;
+
+    let loaded = storage.load()?;
+    assert_eq!(Some(expected), loaded);
+    Ok(())
+}
+
+#[test]
+fn keyring_auth_storage_load_supports_split_json_compatibility() -> anyhow::Result<()> {
+    let codex_home = tempdir()?;
+    let mock_keyring = MockKeyringStore::default();
+    let storage = KeyringAuthStorage::new(
+        codex_home.path().to_path_buf(),
+        Arc::new(mock_keyring.clone()),
+    );
+    let expected = auth_with_prefix("split-compat");
+    let key = compute_store_key(codex_home.path())?;
+    let value = serde_json::to_value(&expected)?;
+
+    codex_keyring_store::save_split_json_to_keyring(&mock_keyring, KEYRING_SERVICE, &key, &value)?;
 
     let loaded = storage.load()?;
     assert_eq!(Some(expected), loaded);
@@ -357,8 +384,8 @@ fn keyring_auth_storage_delete_removes_keyring_and_file() -> anyhow::Result<()> 
 
     assert!(removed, "delete should report removal");
     assert!(
-        load_split_json_from_keyring(&mock_keyring, KEYRING_SERVICE, &base_key)?.is_none(),
-        "split auth should be removed"
+        load_json_from_keyring(&mock_keyring, KEYRING_SERVICE, &base_key)?.is_none(),
+        "keyring auth should be removed"
     );
     assert!(
         !auth_file.exists(),
@@ -470,8 +497,8 @@ fn auto_auth_storage_save_falls_back_when_keyring_errors() -> anyhow::Result<()>
         .context("fallback auth should exist")?;
     assert_eq!(saved, auth);
     assert!(
-        load_split_json_from_keyring(&mock_keyring, KEYRING_SERVICE, &key)?.is_none(),
-        "keyring should not point to saved split auth when save fails"
+        load_json_from_keyring(&mock_keyring, KEYRING_SERVICE, &key)?.is_none(),
+        "keyring should not point to saved auth when save fails"
     );
     Ok(())
 }
@@ -495,8 +522,8 @@ fn auto_auth_storage_delete_removes_keyring_and_file() -> anyhow::Result<()> {
 
     assert!(removed, "delete should report removal");
     assert!(
-        load_split_json_from_keyring(&mock_keyring, KEYRING_SERVICE, &base_key)?.is_none(),
-        "split auth should be removed"
+        load_json_from_keyring(&mock_keyring, KEYRING_SERVICE, &base_key)?.is_none(),
+        "keyring auth should be removed"
     );
     assert!(
         !auth_file.exists(),

--- a/codex-rs/login/src/auth/storage_tests.rs
+++ b/codex-rs/login/src/auth/storage_tests.rs
@@ -6,8 +6,48 @@ use pretty_assertions::assert_eq;
 use serde_json::json;
 use tempfile::tempdir;
 
+use codex_keyring_store::CredentialStoreError;
 use codex_keyring_store::tests::MockKeyringStore;
 use keyring::Error as KeyringError;
+
+#[derive(Clone, Debug)]
+struct SaveSecretErrorKeyringStore {
+    inner: MockKeyringStore,
+}
+
+impl KeyringStore for SaveSecretErrorKeyringStore {
+    fn load(&self, service: &str, account: &str) -> Result<Option<String>, CredentialStoreError> {
+        self.inner.load(service, account)
+    }
+
+    fn load_secret(
+        &self,
+        service: &str,
+        account: &str,
+    ) -> Result<Option<Vec<u8>>, CredentialStoreError> {
+        self.inner.load_secret(service, account)
+    }
+
+    fn save(&self, service: &str, account: &str, value: &str) -> Result<(), CredentialStoreError> {
+        self.inner.save(service, account, value)
+    }
+
+    fn save_secret(
+        &self,
+        _service: &str,
+        _account: &str,
+        _value: &[u8],
+    ) -> Result<(), CredentialStoreError> {
+        Err(CredentialStoreError::new(KeyringError::Invalid(
+            "error".into(),
+            "save".into(),
+        )))
+    }
+
+    fn delete(&self, service: &str, account: &str) -> Result<bool, CredentialStoreError> {
+        self.inner.delete(service, account)
+    }
+}
 
 #[tokio::test]
 async fn file_storage_load_returns_auth_dot_json() -> anyhow::Result<()> {
@@ -97,19 +137,19 @@ fn ephemeral_storage_save_load_delete_is_in_memory_only() -> anyhow::Result<()> 
     Ok(())
 }
 
-fn seed_keyring_and_fallback_auth_file_for_delete<F>(
-    mock_keyring: &MockKeyringStore,
+fn seed_keyring_and_fallback_auth_file_for_delete(
+    storage: &KeyringAuthStorage,
     codex_home: &Path,
-    compute_key: F,
-) -> anyhow::Result<(String, PathBuf)>
-where
-    F: FnOnce() -> std::io::Result<String>,
-{
-    let key = compute_key()?;
-    mock_keyring.save(KEYRING_SERVICE, &key, "{}")?;
+    auth: &AuthDotJson,
+) -> anyhow::Result<(String, String, PathBuf)> {
+    storage.save(auth)?;
+    let base_key = compute_store_key(codex_home)?;
+    let revision = storage
+        .load_active_revision(&base_key)?
+        .context("active auth revision should exist")?;
     let auth_file = get_auth_file(codex_home);
     std::fs::write(&auth_file, "stale")?;
-    Ok((key, auth_file))
+    Ok((base_key, revision, auth_file))
 }
 
 fn seed_keyring_with_auth<F>(
@@ -128,15 +168,57 @@ where
 
 fn assert_keyring_saved_auth_and_removed_fallback(
     mock_keyring: &MockKeyringStore,
-    key: &str,
+    base_key: &str,
     codex_home: &Path,
     expected: &AuthDotJson,
 ) {
-    let saved_value = mock_keyring
-        .saved_value(key)
-        .expect("keyring entry should exist");
-    let expected_serialized = serde_json::to_string(expected).expect("serialize expected auth");
-    assert_eq!(saved_value, expected_serialized);
+    let active_key = keyring_layout_key(base_key, KEYRING_ACTIVE_REVISION_ENTRY);
+    let revision = mock_keyring
+        .saved_secret_utf8(&active_key)
+        .expect("active auth revision should exist");
+    assert!(
+        mock_keyring.saved_value(base_key).is_none(),
+        "legacy keyring entry should not be used for split auth storage"
+    );
+    let manifest_key = keyring_revision_key(base_key, &revision, KEYRING_MANIFEST_ENTRY);
+    let manifest_bytes = mock_keyring
+        .saved_secret(&manifest_key)
+        .expect("auth manifest should exist");
+    let manifest: KeyringAuthManifest =
+        serde_json::from_slice(&manifest_bytes).expect("manifest should deserialize");
+    assert_eq!(manifest, KeyringAuthManifest::from(expected));
+
+    let openai_api_key_key =
+        keyring_revision_key(base_key, &revision, KEYRING_OPENAI_API_KEY_ENTRY);
+    assert_eq!(
+        mock_keyring.saved_secret_utf8(&openai_api_key_key),
+        expected.openai_api_key
+    );
+
+    if let Some(tokens) = expected.tokens.as_ref() {
+        let id_token_key = keyring_revision_key(base_key, &revision, KEYRING_ID_TOKEN_ENTRY);
+        assert_eq!(
+            mock_keyring.saved_secret_utf8(&id_token_key),
+            Some(tokens.id_token.raw_jwt.clone())
+        );
+        let access_token_key =
+            keyring_revision_key(base_key, &revision, KEYRING_ACCESS_TOKEN_ENTRY);
+        assert_eq!(
+            mock_keyring.saved_secret_utf8(&access_token_key),
+            Some(tokens.access_token.clone())
+        );
+        let refresh_token_key =
+            keyring_revision_key(base_key, &revision, KEYRING_REFRESH_TOKEN_ENTRY);
+        assert_eq!(
+            mock_keyring.saved_secret_utf8(&refresh_token_key),
+            Some(tokens.refresh_token.clone())
+        );
+        let account_id_key = keyring_revision_key(base_key, &revision, KEYRING_ACCOUNT_ID_ENTRY);
+        assert_eq!(
+            mock_keyring.saved_secret_utf8(&account_id_key),
+            tokens.account_id.clone()
+        );
+    }
     let auth_file = get_auth_file(codex_home);
     assert!(
         !auth_file.exists(),
@@ -185,7 +267,7 @@ fn auth_with_prefix(prefix: &str) -> AuthDotJson {
 }
 
 #[test]
-fn keyring_auth_storage_load_returns_deserialized_auth() -> anyhow::Result<()> {
+fn keyring_auth_storage_load_supports_legacy_single_entry() -> anyhow::Result<()> {
     let codex_home = tempdir()?;
     let mock_keyring = MockKeyringStore::default();
     let storage = KeyringAuthStorage::new(
@@ -203,6 +285,20 @@ fn keyring_auth_storage_load_returns_deserialized_auth() -> anyhow::Result<()> {
         || compute_store_key(codex_home.path()),
         &expected,
     )?;
+
+    let loaded = storage.load()?;
+    assert_eq!(Some(expected), loaded);
+    Ok(())
+}
+
+#[test]
+fn keyring_auth_storage_load_returns_deserialized_v2_auth() -> anyhow::Result<()> {
+    let codex_home = tempdir()?;
+    let mock_keyring = MockKeyringStore::default();
+    let storage = KeyringAuthStorage::new(codex_home.path().to_path_buf(), Arc::new(mock_keyring));
+    let expected = auth_with_prefix("split");
+
+    storage.save(&expected)?;
 
     let loaded = storage.load()?;
     assert_eq!(Some(expected), loaded);
@@ -256,17 +352,29 @@ fn keyring_auth_storage_delete_removes_keyring_and_file() -> anyhow::Result<()> 
         codex_home.path().to_path_buf(),
         Arc::new(mock_keyring.clone()),
     );
-    let (key, auth_file) =
-        seed_keyring_and_fallback_auth_file_for_delete(&mock_keyring, codex_home.path(), || {
-            compute_store_key(codex_home.path())
-        })?;
+    let auth = auth_with_prefix("delete");
+    let (base_key, revision, auth_file) =
+        seed_keyring_and_fallback_auth_file_for_delete(&storage, codex_home.path(), &auth)?;
 
     let removed = storage.delete()?;
 
     assert!(removed, "delete should report removal");
+    let active_key = keyring_layout_key(&base_key, KEYRING_ACTIVE_REVISION_ENTRY);
     assert!(
-        !mock_keyring.contains(&key),
-        "keyring entry should be removed"
+        !mock_keyring.contains(&active_key),
+        "active revision should be removed"
+    );
+    for entry in KEYRING_RECORD_ENTRIES {
+        let key = keyring_revision_key(&base_key, &revision, entry);
+        assert!(
+            !mock_keyring.contains(&key),
+            "keyring entry should be removed"
+        );
+    }
+    let account_id_key = keyring_revision_key(&base_key, &revision, KEYRING_ACCOUNT_ID_ENTRY);
+    assert!(
+        !mock_keyring.contains(&account_id_key),
+        "account id entry should be removed"
     );
     assert!(
         !auth_file.exists(),
@@ -321,7 +429,11 @@ fn auto_auth_storage_load_falls_back_when_keyring_errors() -> anyhow::Result<()>
         Arc::new(mock_keyring.clone()),
     );
     let key = compute_store_key(codex_home.path())?;
-    mock_keyring.set_error(&key, KeyringError::Invalid("error".into(), "load".into()));
+    let active_key = keyring_layout_key(&key, KEYRING_ACTIVE_REVISION_ENTRY);
+    mock_keyring.set_error(
+        &active_key,
+        KeyringError::Invalid("error".into(), "load".into()),
+    );
 
     let expected = auth_with_prefix("fallback");
     storage.file_storage.save(&expected)?;
@@ -360,12 +472,12 @@ fn auto_auth_storage_save_prefers_keyring() -> anyhow::Result<()> {
 fn auto_auth_storage_save_falls_back_when_keyring_errors() -> anyhow::Result<()> {
     let codex_home = tempdir()?;
     let mock_keyring = MockKeyringStore::default();
-    let storage = AutoAuthStorage::new(
-        codex_home.path().to_path_buf(),
-        Arc::new(mock_keyring.clone()),
-    );
+    let failing_keyring = SaveSecretErrorKeyringStore {
+        inner: mock_keyring.clone(),
+    };
+    let storage = AutoAuthStorage::new(codex_home.path().to_path_buf(), Arc::new(failing_keyring));
     let key = compute_store_key(codex_home.path())?;
-    mock_keyring.set_error(&key, KeyringError::Invalid("error".into(), "save".into()));
+    let active_key = keyring_layout_key(&key, KEYRING_ACTIVE_REVISION_ENTRY);
 
     let auth = auth_with_prefix("fallback");
     storage.save(&auth)?;
@@ -381,8 +493,8 @@ fn auto_auth_storage_save_falls_back_when_keyring_errors() -> anyhow::Result<()>
         .context("fallback auth should exist")?;
     assert_eq!(saved, auth);
     assert!(
-        mock_keyring.saved_value(&key).is_none(),
-        "keyring should not contain value when save fails"
+        mock_keyring.saved_secret_utf8(&active_key).is_none(),
+        "keyring should not point to a saved auth revision when save fails"
     );
     Ok(())
 }
@@ -395,17 +507,37 @@ fn auto_auth_storage_delete_removes_keyring_and_file() -> anyhow::Result<()> {
         codex_home.path().to_path_buf(),
         Arc::new(mock_keyring.clone()),
     );
-    let (key, auth_file) =
-        seed_keyring_and_fallback_auth_file_for_delete(&mock_keyring, codex_home.path(), || {
-            compute_store_key(codex_home.path())
-        })?;
+    let auth = auth_with_prefix("auto-delete");
+    let (base_key, revision, auth_file) = seed_keyring_and_fallback_auth_file_for_delete(
+        storage.keyring_storage.as_ref(),
+        codex_home.path(),
+        &auth,
+    )?;
 
     let removed = storage.delete()?;
 
     assert!(removed, "delete should report removal");
     assert!(
-        !mock_keyring.contains(&key),
-        "keyring entry should be removed"
+        !mock_keyring.contains(&keyring_layout_key(
+            &base_key,
+            KEYRING_ACTIVE_REVISION_ENTRY
+        )),
+        "active revision should be removed"
+    );
+    for entry in KEYRING_RECORD_ENTRIES {
+        let key = keyring_revision_key(&base_key, &revision, entry);
+        assert!(
+            !mock_keyring.contains(&key),
+            "keyring entry should be removed"
+        );
+    }
+    assert!(
+        !mock_keyring.contains(&keyring_revision_key(
+            &base_key,
+            &revision,
+            KEYRING_ACCOUNT_ID_ENTRY
+        )),
+        "account id entry should be removed"
     );
     assert!(
         !auth_file.exists(),

--- a/codex-rs/rmcp-client/src/oauth.rs
+++ b/codex-rs/rmcp-client/src/oauth.rs
@@ -603,7 +603,6 @@ mod tests {
     use codex_keyring_store::CredentialStoreError;
     use codex_keyring_store::load_json_from_keyring;
     use codex_keyring_store::save_json_to_keyring;
-    use codex_keyring_store::save_split_json_to_keyring;
     use keyring::Error as KeyringError;
     use pretty_assertions::assert_eq;
     use std::sync::Mutex;
@@ -758,22 +757,6 @@ mod tests {
     }
 
     #[test]
-    fn load_oauth_tokens_supports_split_json_compatibility() -> Result<()> {
-        let _env = TempCodexHome::new();
-        let store = MockKeyringStore::default();
-        let tokens = sample_tokens();
-        let key = super::compute_store_key(&tokens.server_name, &tokens.url)?;
-        let value = serde_json::to_value(&tokens)?;
-        save_split_json_to_keyring(&store, KEYRING_SERVICE, &key, &value)?;
-
-        let loaded =
-            super::load_oauth_tokens_from_keyring(&store, &tokens.server_name, &tokens.url)?
-                .expect("tokens should load from split-json compatibility format");
-        assert_tokens_match_without_expiry(&loaded, &tokens);
-        Ok(())
-    }
-
-    #[test]
     fn load_oauth_tokens_supports_legacy_single_entry() -> Result<()> {
         let _env = TempCodexHome::new();
         let store = MockKeyringStore::default();
@@ -783,9 +766,18 @@ mod tests {
         store.save(KEYRING_SERVICE, &key, &serialized)?;
 
         let loaded =
-            super::load_oauth_tokens_from_keyring(&store, &tokens.server_name, &tokens.url)?
-                .expect("tokens should load from keyring");
-        assert_tokens_match_without_expiry(&loaded, &tokens);
+            super::load_oauth_tokens_from_keyring(&store, &tokens.server_name, &tokens.url)?;
+
+        #[cfg(not(windows))]
+        {
+            let loaded = loaded.expect("tokens should load from keyring");
+            assert_tokens_match_without_expiry(&loaded, &tokens);
+        }
+
+        #[cfg(windows)]
+        {
+            assert!(loaded.is_none());
+        }
         Ok(())
     }
 
@@ -895,15 +887,13 @@ mod tests {
     }
 
     #[test]
-    fn delete_oauth_tokens_removes_all_storage() -> Result<()> {
+    fn delete_oauth_tokens_removes_active_storage() -> Result<()> {
         let _env = TempCodexHome::new();
         let store = MockKeyringStore::default();
         let tokens = sample_tokens();
         let key = super::compute_store_key(&tokens.server_name, &tokens.url)?;
         let value = serde_json::to_value(&tokens)?;
-        save_split_json_to_keyring(&store, KEYRING_SERVICE, &key, &value)?;
-        let serialized = serde_json::to_string(&tokens)?;
-        store.save(KEYRING_SERVICE, &key, &serialized)?;
+        save_json_to_keyring(&store, KEYRING_SERVICE, &key, &value)?;
         super::save_oauth_tokens_to_file(&tokens)?;
 
         let removed = super::delete_oauth_tokens_from_keyring_and_file(
@@ -928,7 +918,7 @@ mod tests {
         let tokens = sample_tokens();
         let key = super::compute_store_key(&tokens.server_name, &tokens.url)?;
         let value = serde_json::to_value(&tokens)?;
-        save_split_json_to_keyring(&store, KEYRING_SERVICE, &key, &value)?;
+        save_json_to_keyring(&store, KEYRING_SERVICE, &key, &value)?;
         assert!(
             super::load_oauth_tokens_from_keyring(&store, &tokens.server_name, &tokens.url)?
                 .is_some()

--- a/codex-rs/rmcp-client/src/oauth.rs
+++ b/codex-rs/rmcp-client/src/oauth.rs
@@ -45,9 +45,9 @@ use tracing::warn;
 
 use codex_keyring_store::DefaultKeyringStore;
 use codex_keyring_store::KeyringStore;
-use codex_keyring_store::delete_split_json_from_keyring;
-use codex_keyring_store::load_split_json_from_keyring;
-use codex_keyring_store::save_split_json_to_keyring;
+use codex_keyring_store::delete_json_from_keyring;
+use codex_keyring_store::load_json_from_keyring;
+use codex_keyring_store::save_json_to_keyring;
 use rmcp::transport::auth::AuthorizationManager;
 use tokio::sync::Mutex;
 
@@ -158,24 +158,15 @@ fn load_oauth_tokens_from_keyring<K: KeyringStore>(
     url: &str,
 ) -> Result<Option<StoredOAuthTokens>> {
     let key = compute_store_key(server_name, url)?;
-    if let Some(value) = load_split_json_from_keyring(keyring_store, KEYRING_SERVICE, &key)
+    let Some(value) = load_json_from_keyring(keyring_store, KEYRING_SERVICE, &key)
         .map_err(|err| Error::msg(err.to_string()))?
-    {
-        let mut tokens: StoredOAuthTokens = serde_json::from_value(value)
-            .context("failed to deserialize OAuth tokens from keyring")?;
-        refresh_expires_in_from_timestamp(&mut tokens);
-        return Ok(Some(tokens));
-    }
-    match keyring_store.load(KEYRING_SERVICE, &key) {
-        Ok(Some(serialized)) => {
-            let mut tokens: StoredOAuthTokens = serde_json::from_str(&serialized)
-                .context("failed to deserialize OAuth tokens from keyring")?;
-            refresh_expires_in_from_timestamp(&mut tokens);
-            Ok(Some(tokens))
-        }
-        Ok(None) => Ok(None),
-        Err(error) => Err(Error::new(error.into_error())),
-    }
+    else {
+        return Ok(None);
+    };
+    let mut tokens: StoredOAuthTokens =
+        serde_json::from_value(value).context("failed to deserialize OAuth tokens from keyring")?;
+    refresh_expires_in_from_timestamp(&mut tokens);
+    Ok(Some(tokens))
 }
 
 pub fn save_oauth_tokens(
@@ -204,14 +195,8 @@ fn save_oauth_tokens_with_keyring<K: KeyringStore>(
 ) -> Result<()> {
     let value = serde_json::to_value(tokens).context("failed to serialize OAuth tokens")?;
     let key = compute_store_key(server_name, &tokens.url)?;
-    match save_split_json_to_keyring(keyring_store, KEYRING_SERVICE, &key, &value) {
+    match save_json_to_keyring(keyring_store, KEYRING_SERVICE, &key, &value) {
         Ok(()) => {
-            if let Err(error) = keyring_store.delete(KEYRING_SERVICE, &key) {
-                warn!(
-                    "failed to remove legacy OAuth tokens from keyring: {}",
-                    error.message()
-                );
-            }
             if let Err(error) = delete_oauth_tokens_from_file(&key) {
                 warn!("failed to remove OAuth tokens from fallback storage: {error:?}");
             }
@@ -257,7 +242,7 @@ fn delete_oauth_tokens_from_keyring_and_file<K: KeyringStore>(
     url: &str,
 ) -> Result<bool> {
     let key = compute_store_key(server_name, url)?;
-    let split_removed = match delete_split_json_from_keyring(keyring_store, KEYRING_SERVICE, &key) {
+    let keyring_removed = match delete_json_from_keyring(keyring_store, KEYRING_SERVICE, &key) {
         Ok(removed) => removed,
         Err(error) => {
             let message = error.to_string();
@@ -271,23 +256,8 @@ fn delete_oauth_tokens_from_keyring_and_file<K: KeyringStore>(
             }
         }
     };
-    let legacy_removed = match keyring_store.delete(KEYRING_SERVICE, &key) {
-        Ok(removed) => removed,
-        Err(error) => {
-            let message = error.message();
-            warn!("failed to delete OAuth tokens from keyring: {message}");
-            match store_mode {
-                OAuthCredentialsStoreMode::Auto | OAuthCredentialsStoreMode::Keyring => {
-                    return Err(error.into_error())
-                        .context("failed to delete OAuth tokens from keyring");
-                }
-                OAuthCredentialsStoreMode::File => false,
-            }
-        }
-    };
-
     let file_removed = delete_oauth_tokens_from_file(&key)?;
-    Ok(split_removed || legacy_removed || file_removed)
+    Ok(keyring_removed || file_removed)
 }
 
 #[derive(Clone)]
@@ -631,6 +601,8 @@ mod tests {
     use super::*;
     use anyhow::Result;
     use codex_keyring_store::CredentialStoreError;
+    use codex_keyring_store::load_json_from_keyring;
+    use codex_keyring_store::save_json_to_keyring;
     use codex_keyring_store::save_split_json_to_keyring;
     use keyring::Error as KeyringError;
     use pretty_assertions::assert_eq;
@@ -776,12 +748,28 @@ mod tests {
         let expected = tokens.clone();
         let key = super::compute_store_key(&tokens.server_name, &tokens.url)?;
         let value = serde_json::to_value(&tokens)?;
-        save_split_json_to_keyring(&store, KEYRING_SERVICE, &key, &value)?;
+        save_json_to_keyring(&store, KEYRING_SERVICE, &key, &value)?;
 
         let loaded =
             super::load_oauth_tokens_from_keyring(&store, &tokens.server_name, &tokens.url)?
                 .expect("tokens should load from keyring");
         assert_tokens_match_without_expiry(&loaded, &expected);
+        Ok(())
+    }
+
+    #[test]
+    fn load_oauth_tokens_supports_split_json_compatibility() -> Result<()> {
+        let _env = TempCodexHome::new();
+        let store = MockKeyringStore::default();
+        let tokens = sample_tokens();
+        let key = super::compute_store_key(&tokens.server_name, &tokens.url)?;
+        let value = serde_json::to_value(&tokens)?;
+        save_split_json_to_keyring(&store, KEYRING_SERVICE, &key, &value)?;
+
+        let loaded =
+            super::load_oauth_tokens_from_keyring(&store, &tokens.server_name, &tokens.url)?
+                .expect("tokens should load from split-json compatibility format");
+        assert_tokens_match_without_expiry(&loaded, &tokens);
         Ok(())
     }
 
@@ -856,7 +844,16 @@ mod tests {
 
         let fallback_path = super::fallback_file_path()?;
         assert!(!fallback_path.exists(), "fallback file should be removed");
-        assert!(store.saved_value(&key).is_none());
+        #[cfg(windows)]
+        assert!(
+            store.saved_secret(&key).is_none(),
+            "windows should not store the full JSON record under the base key"
+        );
+        #[cfg(not(windows))]
+        assert!(
+            store.saved_secret(&key).is_some(),
+            "non-windows should store the full JSON record as one secret"
+        );
         let stored =
             super::load_oauth_tokens_from_keyring(&store, &tokens.server_name, &tokens.url)?
                 .expect("value saved to keyring");
@@ -890,6 +887,10 @@ mod tests {
             tokens.token_response.0.access_token().secret().as_str()
         );
         assert!(mock_keyring.saved_value(&key).is_none());
+        assert!(
+            load_json_from_keyring(&mock_keyring, KEYRING_SERVICE, &key)?.is_none(),
+            "keyring should not point at saved OAuth tokens when save fails"
+        );
         Ok(())
     }
 
@@ -912,7 +913,10 @@ mod tests {
             &tokens.url,
         )?;
         assert!(removed);
-        assert!(!store.contains(&key));
+        assert!(
+            load_json_from_keyring(&store, KEYRING_SERVICE, &key)?.is_none(),
+            "keyring entry should be removed"
+        );
         assert!(!super::fallback_file_path()?.exists());
         Ok(())
     }
@@ -937,7 +941,10 @@ mod tests {
             &tokens.url,
         )?;
         assert!(removed);
-        assert!(!store.contains(&key));
+        assert!(
+            load_json_from_keyring(&store, KEYRING_SERVICE, &key)?.is_none(),
+            "keyring entry should be removed"
+        );
         assert!(
             super::load_oauth_tokens_from_keyring(&store, &tokens.server_name, &tokens.url)?
                 .is_none()

--- a/codex-rs/rmcp-client/src/oauth.rs
+++ b/codex-rs/rmcp-client/src/oauth.rs
@@ -45,6 +45,9 @@ use tracing::warn;
 
 use codex_keyring_store::DefaultKeyringStore;
 use codex_keyring_store::KeyringStore;
+use codex_keyring_store::delete_split_json_from_keyring;
+use codex_keyring_store::load_split_json_from_keyring;
+use codex_keyring_store::save_split_json_to_keyring;
 use rmcp::transport::auth::AuthorizationManager;
 use tokio::sync::Mutex;
 
@@ -155,6 +158,14 @@ fn load_oauth_tokens_from_keyring<K: KeyringStore>(
     url: &str,
 ) -> Result<Option<StoredOAuthTokens>> {
     let key = compute_store_key(server_name, url)?;
+    if let Some(value) = load_split_json_from_keyring(keyring_store, KEYRING_SERVICE, &key)
+        .map_err(|err| Error::msg(err.to_string()))?
+    {
+        let mut tokens: StoredOAuthTokens = serde_json::from_value(value)
+            .context("failed to deserialize OAuth tokens from keyring")?;
+        refresh_expires_in_from_timestamp(&mut tokens);
+        return Ok(Some(tokens));
+    }
     match keyring_store.load(KEYRING_SERVICE, &key) {
         Ok(Some(serialized)) => {
             let mut tokens: StoredOAuthTokens = serde_json::from_str(&serialized)
@@ -191,23 +202,25 @@ fn save_oauth_tokens_with_keyring<K: KeyringStore>(
     server_name: &str,
     tokens: &StoredOAuthTokens,
 ) -> Result<()> {
-    let serialized = serde_json::to_string(tokens).context("failed to serialize OAuth tokens")?;
-
+    let value = serde_json::to_value(tokens).context("failed to serialize OAuth tokens")?;
     let key = compute_store_key(server_name, &tokens.url)?;
-    match keyring_store.save(KEYRING_SERVICE, &key, &serialized) {
+    match save_split_json_to_keyring(keyring_store, KEYRING_SERVICE, &key, &value) {
         Ok(()) => {
+            if let Err(error) = keyring_store.delete(KEYRING_SERVICE, &key) {
+                warn!(
+                    "failed to remove legacy OAuth tokens from keyring: {}",
+                    error.message()
+                );
+            }
             if let Err(error) = delete_oauth_tokens_from_file(&key) {
                 warn!("failed to remove OAuth tokens from fallback storage: {error:?}");
             }
             Ok(())
         }
         Err(error) => {
-            let message = format!(
-                "failed to write OAuth tokens to keyring: {}",
-                error.message()
-            );
+            let message = format!("failed to write OAuth tokens to keyring: {error}");
             warn!("{message}");
-            Err(Error::new(error.into_error()).context(message))
+            Err(Error::msg(message))
         }
     }
 }
@@ -244,8 +257,21 @@ fn delete_oauth_tokens_from_keyring_and_file<K: KeyringStore>(
     url: &str,
 ) -> Result<bool> {
     let key = compute_store_key(server_name, url)?;
-    let keyring_result = keyring_store.delete(KEYRING_SERVICE, &key);
-    let keyring_removed = match keyring_result {
+    let split_removed = match delete_split_json_from_keyring(keyring_store, KEYRING_SERVICE, &key) {
+        Ok(removed) => removed,
+        Err(error) => {
+            let message = error.to_string();
+            warn!("failed to delete OAuth tokens from keyring: {message}");
+            match store_mode {
+                OAuthCredentialsStoreMode::Auto | OAuthCredentialsStoreMode::Keyring => {
+                    return Err(Error::msg(message))
+                        .context("failed to delete OAuth tokens from keyring");
+                }
+                OAuthCredentialsStoreMode::File => false,
+            }
+        }
+    };
+    let legacy_removed = match keyring_store.delete(KEYRING_SERVICE, &key) {
         Ok(removed) => removed,
         Err(error) => {
             let message = error.message();
@@ -261,7 +287,7 @@ fn delete_oauth_tokens_from_keyring_and_file<K: KeyringStore>(
     };
 
     let file_removed = delete_oauth_tokens_from_file(&key)?;
-    Ok(keyring_removed || file_removed)
+    Ok(split_removed || legacy_removed || file_removed)
 }
 
 #[derive(Clone)]
@@ -604,6 +630,8 @@ fn sha_256_prefix(value: &Value) -> Result<String> {
 mod tests {
     use super::*;
     use anyhow::Result;
+    use codex_keyring_store::CredentialStoreError;
+    use codex_keyring_store::save_split_json_to_keyring;
     use keyring::Error as KeyringError;
     use pretty_assertions::assert_eq;
     use std::sync::Mutex;
@@ -613,6 +641,101 @@ mod tests {
     use tempfile::tempdir;
 
     use codex_keyring_store::tests::MockKeyringStore;
+
+    #[derive(Clone, Debug)]
+    struct KeyringStoreWithError {
+        inner: MockKeyringStore,
+        fail_delete: bool,
+        fail_load_secret: bool,
+        fail_save_secret: bool,
+    }
+
+    impl KeyringStoreWithError {
+        fn fail_delete(inner: MockKeyringStore) -> Self {
+            Self {
+                inner,
+                fail_delete: true,
+                fail_load_secret: false,
+                fail_save_secret: false,
+            }
+        }
+
+        fn fail_load_secret(inner: MockKeyringStore) -> Self {
+            Self {
+                inner,
+                fail_delete: false,
+                fail_load_secret: true,
+                fail_save_secret: false,
+            }
+        }
+
+        fn fail_save_secret(inner: MockKeyringStore) -> Self {
+            Self {
+                inner,
+                fail_delete: false,
+                fail_load_secret: false,
+                fail_save_secret: true,
+            }
+        }
+    }
+
+    impl KeyringStore for KeyringStoreWithError {
+        fn load(
+            &self,
+            service: &str,
+            account: &str,
+        ) -> Result<Option<String>, CredentialStoreError> {
+            self.inner.load(service, account)
+        }
+
+        fn load_secret(
+            &self,
+            service: &str,
+            account: &str,
+        ) -> Result<Option<Vec<u8>>, CredentialStoreError> {
+            if self.fail_load_secret {
+                return Err(CredentialStoreError::new(KeyringError::Invalid(
+                    "error".into(),
+                    "load".into(),
+                )));
+            }
+            self.inner.load_secret(service, account)
+        }
+
+        fn save(
+            &self,
+            service: &str,
+            account: &str,
+            value: &str,
+        ) -> Result<(), CredentialStoreError> {
+            self.inner.save(service, account, value)
+        }
+
+        fn save_secret(
+            &self,
+            service: &str,
+            account: &str,
+            value: &[u8],
+        ) -> Result<(), CredentialStoreError> {
+            if self.fail_save_secret {
+                return Err(CredentialStoreError::new(KeyringError::Invalid(
+                    "error".into(),
+                    "save".into(),
+                )));
+            }
+            self.inner.save_secret(service, account, value)
+        }
+
+        fn delete(&self, service: &str, account: &str) -> Result<bool, CredentialStoreError> {
+            if self.fail_delete {
+                return Err(CredentialStoreError::new(KeyringError::Invalid(
+                    "error".into(),
+                    "delete".into(),
+                )));
+            }
+            self.inner.delete(service, account)
+        }
+    }
 
     struct TempCodexHome {
         _guard: MutexGuard<'static, ()>,
@@ -651,6 +774,22 @@ mod tests {
         let store = MockKeyringStore::default();
         let tokens = sample_tokens();
         let expected = tokens.clone();
+        let key = super::compute_store_key(&tokens.server_name, &tokens.url)?;
+        let value = serde_json::to_value(&tokens)?;
+        save_split_json_to_keyring(&store, KEYRING_SERVICE, &key, &value)?;
+
+        let loaded =
+            super::load_oauth_tokens_from_keyring(&store, &tokens.server_name, &tokens.url)?
+                .expect("tokens should load from keyring");
+        assert_tokens_match_without_expiry(&loaded, &expected);
+        Ok(())
+    }
+
+    #[test]
+    fn load_oauth_tokens_supports_legacy_single_entry() -> Result<()> {
+        let _env = TempCodexHome::new();
+        let store = MockKeyringStore::default();
+        let tokens = sample_tokens();
         let serialized = serde_json::to_string(&tokens)?;
         let key = super::compute_store_key(&tokens.server_name, &tokens.url)?;
         store.save(KEYRING_SERVICE, &key, &serialized)?;
@@ -658,7 +797,7 @@ mod tests {
         let loaded =
             super::load_oauth_tokens_from_keyring(&store, &tokens.server_name, &tokens.url)?
                 .expect("tokens should load from keyring");
-        assert_tokens_match_without_expiry(&loaded, &expected);
+        assert_tokens_match_without_expiry(&loaded, &tokens);
         Ok(())
     }
 
@@ -684,11 +823,9 @@ mod tests {
     #[test]
     fn load_oauth_tokens_falls_back_when_keyring_errors() -> Result<()> {
         let _env = TempCodexHome::new();
-        let store = MockKeyringStore::default();
+        let store = KeyringStoreWithError::fail_load_secret(MockKeyringStore::default());
         let tokens = sample_tokens();
         let expected = tokens.clone();
-        let key = super::compute_store_key(&tokens.server_name, &tokens.url)?;
-        store.set_error(&key, KeyringError::Invalid("error".into(), "load".into()));
 
         super::save_oauth_tokens_to_file(&tokens)?;
 
@@ -719,18 +856,20 @@ mod tests {
 
         let fallback_path = super::fallback_file_path()?;
         assert!(!fallback_path.exists(), "fallback file should be removed");
-        let stored = store.saved_value(&key).expect("value saved to keyring");
-        assert_eq!(serde_json::from_str::<StoredOAuthTokens>(&stored)?, tokens);
+        assert!(store.saved_value(&key).is_none());
+        let stored =
+            super::load_oauth_tokens_from_keyring(&store, &tokens.server_name, &tokens.url)?
+                .expect("value saved to keyring");
+        assert_tokens_match_without_expiry(&stored, &tokens);
         Ok(())
     }
 
     #[test]
     fn save_oauth_tokens_writes_fallback_when_keyring_fails() -> Result<()> {
         let _env = TempCodexHome::new();
-        let store = MockKeyringStore::default();
+        let mock_keyring = MockKeyringStore::default();
+        let store = KeyringStoreWithError::fail_save_secret(mock_keyring.clone());
         let tokens = sample_tokens();
-        let key = super::compute_store_key(&tokens.server_name, &tokens.url)?;
-        store.set_error(&key, KeyringError::Invalid("error".into(), "save".into()));
 
         super::save_oauth_tokens_with_keyring_with_fallback_to_file(
             &store,
@@ -750,7 +889,7 @@ mod tests {
             entry.access_token,
             tokens.token_response.0.access_token().secret().as_str()
         );
-        assert!(store.saved_value(&key).is_none());
+        assert!(mock_keyring.saved_value(&key).is_none());
         Ok(())
     }
 
@@ -759,8 +898,10 @@ mod tests {
         let _env = TempCodexHome::new();
         let store = MockKeyringStore::default();
         let tokens = sample_tokens();
-        let serialized = serde_json::to_string(&tokens)?;
         let key = super::compute_store_key(&tokens.server_name, &tokens.url)?;
+        let value = serde_json::to_value(&tokens)?;
+        save_split_json_to_keyring(&store, KEYRING_SERVICE, &key, &value)?;
+        let serialized = serde_json::to_string(&tokens)?;
         store.save(KEYRING_SERVICE, &key, &serialized)?;
         super::save_oauth_tokens_to_file(&tokens)?;
 
@@ -781,10 +922,13 @@ mod tests {
         let _env = TempCodexHome::new();
         let store = MockKeyringStore::default();
         let tokens = sample_tokens();
-        let serialized = serde_json::to_string(&tokens)?;
         let key = super::compute_store_key(&tokens.server_name, &tokens.url)?;
-        store.save(KEYRING_SERVICE, &key, &serialized)?;
-        assert!(store.contains(&key));
+        let value = serde_json::to_value(&tokens)?;
+        save_split_json_to_keyring(&store, KEYRING_SERVICE, &key, &value)?;
+        assert!(
+            super::load_oauth_tokens_from_keyring(&store, &tokens.server_name, &tokens.url)?
+                .is_some()
+        );
 
         let removed = super::delete_oauth_tokens_from_keyring_and_file(
             &store,
@@ -794,6 +938,10 @@ mod tests {
         )?;
         assert!(removed);
         assert!(!store.contains(&key));
+        assert!(
+            super::load_oauth_tokens_from_keyring(&store, &tokens.server_name, &tokens.url)?
+                .is_none()
+        );
         assert!(!super::fallback_file_path()?.exists());
         Ok(())
     }
@@ -801,10 +949,8 @@ mod tests {
     #[test]
     fn delete_oauth_tokens_propagates_keyring_errors() -> Result<()> {
         let _env = TempCodexHome::new();
-        let store = MockKeyringStore::default();
+        let store = KeyringStoreWithError::fail_delete(MockKeyringStore::default());
         let tokens = sample_tokens();
-        let key = super::compute_store_key(&tokens.server_name, &tokens.url)?;
-        store.set_error(&key, KeyringError::Invalid("error".into(), "delete".into()));
         super::save_oauth_tokens_to_file(&tokens).unwrap();
 
         let result = super::delete_oauth_tokens_from_keyring_and_file(

--- a/codex-rs/rmcp-client/src/oauth.rs
+++ b/codex-rs/rmcp-client/src/oauth.rs
@@ -948,6 +948,9 @@ mod tests {
         let _env = TempCodexHome::new();
         let store = KeyringStoreWithError::fail_delete(MockKeyringStore::default());
         let tokens = sample_tokens();
+        let key = super::compute_store_key(&tokens.server_name, &tokens.url)?;
+        let value = serde_json::to_value(&tokens)?;
+        save_json_to_keyring(&store, KEYRING_SERVICE, &key, &value)?;
         super::save_oauth_tokens_to_file(&tokens).unwrap();
 
         let result = super::delete_oauth_tokens_from_keyring_and_file(


### PR DESCRIPTION
This changes Codex CLI auth persistence on keyring-backed platforms to avoid Windows Credential Manager size failures during browser-based login. Previously we serialized the full auth payload into one JSON string and stored it with set_password, which caused large OAuth tokens to exceed the Windows limit after UTF-16 expansion. This PR switches keyring storage to binary secrets via set_secret/get_secret, stores auth as a versioned split-entry layout under the existing CODEX_HOME-scoped key namespace, and reconstructs the in-memory auth object on load.

## Summary

This change introduces a reusable, generalized keyring storage format for JSON-backed credentials and consolidates both MCP OAuth and CLI auth onto the same storage mechanism.

Instead of each credential type owning its own bespoke keyring serialization logic, we now use a shared library that can persist arbitrary `serde_json::Value` data in a versioned split-entry layout. Each credential record is stored under its own base key, with an `active` revision pointer, a manifest describing the JSON structure, and one keyring entry per JSON leaf value. This keeps the format dynamic and schema-agnostic while preserving JSON types.

## What Changed

- Added a shared split-JSON keyring storage helper in `codex-keyring-store`
- Introduced a versioned layout using a short `v1` marker
- Flattened JSON dynamically by path instead of hardcoding credential-specific fields
- Stored each JSON leaf value in its own keyring entry, with manifest-based reconstruction
- JSON splitting is available as a storage method, currently used only on windows.
- Reused the shared helper for:
  - MCP OAuth credentials
  - CLI auth credentials

## Why

This removes duplicated credential storage logic, gives MCP OAuth and CLI auth the same persistence model, and makes future credential formats easier to support without writing new keyring serialization code for every struct.

## Manual testing
Manual human testing was performed on 
 * macOS 26
 * Windows 11 Pro (25H2) in Azure Cloud
 * Ubuntu Forky 25.10. 

Test executed `cargo run --bin codex login` followed by `cargo run --bin codex exec hello` to ensure credentials were available and used. 

When `cli_auth_credentials_store="keyring"` is set in the `config.toml`, confirmed credential was stored in 
 * Key Chain on macOS
 * Windows Credential Manager
 * Passwords and Keys

Addressing issue https://github.com/openai/codex/issues/10353