### PR TITLE
fix: correct spelling in error message (psuedo → pseudo)

### DIFF
--- a/codex-rs/utils/pty/src/win/psuedocon.rs
+++ b/codex-rs/utils/pty/src/win/psuedocon.rs
@@ -143,7 +143,7 @@ impl PsuedoCon {
         };
         ensure!(
             result == S_OK,
-            "failed to create psuedo console: HRESULT {result}"
+            "failed to create pseudo console: HRESULT {result}"
         );
         Ok(Self { con })
     }


### PR DESCRIPTION
## Summary
- Fixed a spelling error in an error message in the Windows PTY implementation
- Changed "psuedo console" to "pseudo console" in `codex-rs/utils/pty/src/win/psuedocon.rs`

## Details
The error message at line 146 contained the misspelling "psuedo" which has been corrected to "pseudo". This is a straightforward spelling fix that improves code quality and makes the error message consistent with standard English spelling.

Note: The struct name `PsuedoCon` was intentionally left unchanged as it:
- Is an identifier used throughout the codebase
- Originates from an external library (wezterm)
- Would require breaking changes to rename

## Testing
This change only affects an error message string and does not modify any code logic. The change is cosmetic and improves developer experience when debugging Windows PTY-related issues.