### PR TITLE
Codex docs: update repo install docs for native installers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><strong>Mac/Linux:</strong> <code>curl -fsSL https://chatgpt.com/codex/install.sh | sh</code><br /><strong>Windows:</strong> <code>powershell -c "irm https://chatgpt.com/codex/install.ps1|iex"</code><br />or <code>npm i -g @openai/codex</code><br />or <code>brew install --cask codex</code></p>
+<p align="center"><strong>Mac/Linux:</strong> <code>curl -fsSL https://chatgpt.com/codex/install.sh | sh</code><br /><strong>Windows:</strong> <code>powershell -c "irm https://chatgpt.com/codex/install.ps1|iex"</code></p>
 <p align="center"><strong>Codex CLI</strong> is a coding agent from OpenAI that runs locally on your computer.
 <p align="center">
   <img src="https://github.com/openai/codex/blob/main/.github/codex-cli-splash.png" alt="Codex CLI splash" width="80%" />
@@ -26,14 +26,8 @@ curl -fsSL https://chatgpt.com/codex/install.sh | sh
 powershell -c "irm https://chatgpt.com/codex/install.ps1|iex"
 ```
 
-If you prefer a package manager, you can also install with npm or Homebrew:
-
-```shell
-# Install using npm
-npm install -g @openai/codex
-# Install using Homebrew
-brew install --cask codex
-```
+> [!NOTE]
+> If you prefer a package manager, you can also install with `npm install -g @openai/codex` or `brew install --cask codex`.
 
 Then simply run `codex` to get started.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><code>curl -fsSL https://chatgpt.com/codex/install.sh | sh</code><br /><code>powershell -c "irm https://chatgpt.com/codex/install.ps1|iex"</code><br />or <code>npm i -g @openai/codex</code><br />or <code>brew install --cask codex</code></p>
+<p align="center"><strong>Mac/Linux:</strong> <code>curl -fsSL https://chatgpt.com/codex/install.sh | sh</code><br /><strong>Windows:</strong> <code>powershell -c "irm https://chatgpt.com/codex/install.ps1|iex"</code><br />or <code>npm i -g @openai/codex</code><br />or <code>brew install --cask codex</code></p>
 <p align="center"><strong>Codex CLI</strong> is a coding agent from OpenAI that runs locally on your computer.
 <p align="center">
   <img src="https://github.com/openai/codex/blob/main/.github/codex-cli-splash.png" alt="Codex CLI splash" width="80%" />

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><code>npm i -g @openai/codex</code><br />or <code>brew install --cask codex</code></p>
+<p align="center"><code>curl -fsSL https://chatgpt.com/codex/install.sh | sh</code><br /><code>powershell -c "irm https://chatgpt.com/codex/install.ps1|iex"</code><br />or <code>npm i -g @openai/codex</code><br />or <code>brew install --cask codex</code></p>
 <p align="center"><strong>Codex CLI</strong> is a coding agent from OpenAI that runs locally on your computer.
 <p align="center">
   <img src="https://github.com/openai/codex/blob/main/.github/codex-cli-splash.png" alt="Codex CLI splash" width="80%" />
@@ -14,14 +14,23 @@ If you want Codex in your code editor (VS Code, Cursor, Windsurf), <a href="http
 
 ### Installing and running Codex CLI
 
-Install globally with your preferred package manager:
+Install with the native installer for your platform:
+
+```shell
+# macOS or Linux
+curl -fsSL https://chatgpt.com/codex/install.sh | sh
+```
+
+```powershell
+# Windows (PowerShell)
+powershell -c "irm https://chatgpt.com/codex/install.ps1|iex"
+```
+
+If you prefer a package manager, you can also install with npm or Homebrew:
 
 ```shell
 # Install using npm
 npm install -g @openai/codex
-```
-
-```shell
 # Install using Homebrew
 brew install --cask codex
 ```
@@ -39,6 +48,8 @@ Each GitHub Release contains many executables, but in practice, you likely want 
 - Linux
   - x86_64: `codex-x86_64-unknown-linux-musl.tar.gz`
   - arm64: `codex-aarch64-unknown-linux-musl.tar.gz`
+- Windows
+  - Use `install.ps1` or download the appropriate Windows `.zip` asset from the release page.
 
 Each archive contains a single entry with the platform baked into the name (e.g., `codex-x86_64-unknown-linux-musl`), so you likely want to rename it to `codex` after extracting it.
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ If you want Codex in your code editor (VS Code, Cursor, Windsurf), <a href="http
 Install with the native installer for your platform:
 
 ```shell
-# macOS or Linux
+# Mac + Linux
 curl -fsSL https://chatgpt.com/codex/install.sh | sh
 ```
 
 ```powershell
-# Windows (PowerShell)
+# Windows
 powershell -c "irm https://chatgpt.com/codex/install.ps1|iex"
 ```
 

--- a/codex-cli/README.md
+++ b/codex-cli/README.md
@@ -4,8 +4,8 @@
 <p align="center"><code>curl -fsSL https://chatgpt.com/codex/install.sh | sh</code><br /><code>powershell -c "irm https://chatgpt.com/codex/install.ps1|iex"</code></p>
 
 > [!IMPORTANT]
-> This is the documentation for the _legacy_ TypeScript implementation of the Codex CLI. It has been superseded by the _Rust_ implementation. See the [README in the root of the Codex repository](https://github.com/openai/codex/blob/main/README.md) for details.
-> Use the native installers above for the maintained Codex CLI. If you specifically need the legacy TypeScript CLI described in this document, install it with `npm install -g @openai/codex`.
+> This directory contains the npm package entrypoint for Codex. For the primary Codex CLI docs and native installers, see the [README in the root of the Codex repository](https://github.com/openai/codex/blob/main/README.md).
+> If you want to install Codex from npm instead of the native installers, use `npm install -g @openai/codex`.
 
 ![Codex demo GIF using: codex "explain this codebase to me"](../.github/demo.gif)
 
@@ -75,7 +75,7 @@ Help us improve by filing issues or submitting PRs (see the section below for ho
 
 ## Quickstart
 
-For the maintained Codex CLI, use the native installers above or the root README. If you specifically need the legacy TypeScript CLI, install it globally with npm:
+For the primary Codex CLI install docs, use the native installers above or the root README. If you want to install Codex from npm, install it globally with npm:
 
 ```shell
 npm install -g @openai/codex
@@ -285,7 +285,7 @@ Below are a few bite-size examples you can copy-paste. Replace the text in quote
 ## Installation
 
 <details open>
-<summary><strong>Legacy TypeScript CLI via npm / yarn / bun / pnpm</strong></summary>
+<summary><strong>From npm / yarn / bun / pnpm</strong></summary>
 
 ```bash
 npm install -g @openai/codex

--- a/codex-cli/README.md
+++ b/codex-cli/README.md
@@ -1,10 +1,11 @@
 <h1 align="center">OpenAI Codex CLI</h1>
 <p align="center">Lightweight coding agent that runs in your terminal</p>
 
-<p align="center"><code>npm i -g @openai/codex</code></p>
+<p align="center"><code>curl -fsSL https://chatgpt.com/codex/install.sh | sh</code><br /><code>powershell -c "irm https://chatgpt.com/codex/install.ps1|iex"</code></p>
 
 > [!IMPORTANT]
 > This is the documentation for the _legacy_ TypeScript implementation of the Codex CLI. It has been superseded by the _Rust_ implementation. See the [README in the root of the Codex repository](https://github.com/openai/codex/blob/main/README.md) for details.
+> Use the native installers above for the maintained Codex CLI. If you specifically need the legacy TypeScript CLI described in this document, install it with `npm install -g @openai/codex`.
 
 ![Codex demo GIF using: codex "explain this codebase to me"](../.github/demo.gif)
 
@@ -74,7 +75,7 @@ Help us improve by filing issues or submitting PRs (see the section below for ho
 
 ## Quickstart
 
-Install globally:
+For the maintained Codex CLI, use the native installers above or the root README. If you specifically need the legacy TypeScript CLI, install it globally with npm:
 
 ```shell
 npm install -g @openai/codex
@@ -284,7 +285,7 @@ Below are a few bite-size examples you can copy-paste. Replace the text in quote
 ## Installation
 
 <details open>
-<summary><strong>From npm (Recommended)</strong></summary>
+<summary><strong>Legacy TypeScript CLI via npm / yarn / bun / pnpm</strong></summary>
 
 ```bash
 npm install -g @openai/codex

--- a/codex-rs/README.md
+++ b/codex-rs/README.md
@@ -27,7 +27,7 @@ If you prefer a package manager, you can also install via npm (`npm install -g @
 
 ## What's new in the Rust CLI
 
-The Rust implementation is the maintained Codex CLI and serves as the default experience.
+The Rust implementation is now the maintained Codex CLI and serves as the default experience. It includes a number of features that the legacy TypeScript CLI never supported.
 
 ### Config
 

--- a/codex-rs/README.md
+++ b/codex-rs/README.md
@@ -4,14 +4,21 @@ We provide Codex CLI as a standalone, native executable to ensure a zero-depende
 
 ## Installing Codex
 
-Today, the easiest way to install Codex is via `npm`:
+The easiest way to install Codex is with the native installer for your platform:
 
-```shell
-npm i -g @openai/codex
-codex
+```bash
+# macOS or Linux
+curl -fsSL https://chatgpt.com/codex/install.sh | sh
 ```
 
-You can also install via Homebrew (`brew install --cask codex`) or download a platform-specific release directly from our [GitHub Releases](https://github.com/openai/codex/releases).
+```powershell
+# Windows (PowerShell)
+powershell -c "irm https://chatgpt.com/codex/install.ps1|iex"
+```
+
+Then run `codex`.
+
+If you prefer a package manager, you can also install via npm (`npm install -g @openai/codex`) or Homebrew (`brew install --cask codex`). You can also download a platform-specific release directly from our [GitHub Releases](https://github.com/openai/codex/releases).
 
 ## Documentation quickstart
 

--- a/codex-rs/README.md
+++ b/codex-rs/README.md
@@ -7,12 +7,12 @@ We provide Codex CLI as a standalone, native executable to ensure a zero-depende
 The easiest way to install Codex is with the native installer for your platform:
 
 ```bash
-# macOS or Linux
+# Mac + Linux
 curl -fsSL https://chatgpt.com/codex/install.sh | sh
 ```
 
 ```powershell
-# Windows (PowerShell)
+# Windows
 powershell -c "irm https://chatgpt.com/codex/install.ps1|iex"
 ```
 

--- a/codex-rs/README.md
+++ b/codex-rs/README.md
@@ -27,7 +27,7 @@ If you prefer a package manager, you can also install via npm (`npm install -g @
 
 ## What's new in the Rust CLI
 
-The Rust implementation is now the maintained Codex CLI and serves as the default experience. It includes a number of features that the legacy TypeScript CLI never supported.
+The Rust implementation is the maintained Codex CLI and serves as the default experience.
 
 ### Config
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -13,12 +13,12 @@
 Use the native installer for your platform:
 
 ```bash
-# macOS or Linux
+# Mac + Linux
 curl -fsSL https://chatgpt.com/codex/install.sh | sh
 ```
 
 ```powershell
-# Windows (PowerShell)
+# Windows
 powershell -c "irm https://chatgpt.com/codex/install.ps1|iex"
 ```
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -4,9 +4,25 @@
 
 | Requirement                 | Details                                                         |
 | --------------------------- | --------------------------------------------------------------- |
-| Operating systems           | macOS 12+, Ubuntu 20.04+/Debian 10+, or Windows 11 **via WSL2** |
+| Operating systems           | macOS 12+, Ubuntu 20.04+/Debian 10+, or Windows 11              |
 | Git (optional, recommended) | 2.23+ for built-in PR helpers                                   |
 | RAM                         | 4-GB minimum (8-GB recommended)                                 |
+
+## Install Codex
+
+Use the native installer for your platform:
+
+```bash
+# macOS or Linux
+curl -fsSL https://chatgpt.com/codex/install.sh | sh
+```
+
+```powershell
+# Windows (PowerShell)
+powershell -c "irm https://chatgpt.com/codex/install.ps1|iex"
+```
+
+If you prefer a package manager, you can also install via npm (`npm install -g @openai/codex`) or Homebrew (`brew install --cask codex`).
 
 ### DotSlash
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -2,11 +2,11 @@
 
 ### System requirements
 
-| Requirement                 | Details                                                         |
-| --------------------------- | --------------------------------------------------------------- |
-| Operating systems           | macOS 12+, Ubuntu 20.04+/Debian 10+, or Windows 11              |
-| Git (optional, recommended) | 2.23+ for built-in PR helpers                                   |
-| RAM                         | 4-GB minimum (8-GB recommended)                                 |
+| Requirement                 | Details                                            |
+| --------------------------- | -------------------------------------------------- |
+| Operating systems           | macOS 12+, Ubuntu 20.04+/Debian 10+, or Windows 11 |
+| Git (optional, recommended) | 2.23+ for built-in PR helpers                      |
+| RAM                         | 4-GB minimum (8-GB recommended)                    |
 
 ## Install Codex
 


### PR DESCRIPTION
## Summary

We're migrating to native curl and powershell install commands. This PR updates our documentation to prioritize native CLI install commands over package manager install commands. 


We keep npm and Homebrew documented as fallback install methods instead of the primary path.
