### PR TITLE
Move voice transcription to experimental

### DIFF
--- a/codex-rs/core/src/features.rs
+++ b/codex-rs/core/src/features.rs
@@ -663,7 +663,11 @@ pub const FEATURES: &[FeatureSpec] = &[
     FeatureSpec {
         id: Feature::VoiceTranscription,
         key: "voice_transcription",
-        stage: Stage::UnderDevelopment,
+        stage: Stage::Experimental {
+            name: "Voice transcription",
+            menu_description: "Hold space to record, release to transcribe.",
+            announcement: "NEW: Voice transcription is now available in /experimental.",
+        },
         default_enabled: false,
     },
     FeatureSpec {


### PR DESCRIPTION
## Summary
- move `voice_transcription` from `UnderDevelopment` to `Experimental`
- add `/experimental` menu metadata and announcement copy
- use the reviewed menu description: `Hold space to record, release to transcribe.`

## Testing
- `just fmt`
- `cargo test -p codex-core` *(fails in unrelated existing tests: `shell_snapshot::tests::snapshot_shell_does_not_inherit_stdin` and multiple `tools::js_repl::*` failures due local Node `v22.15.1` being below the required `>= v22.22.0`)*
