### PR TITLE
fix(tui): keep status line visible while drafting text

### DIFF
--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -4218,6 +4218,12 @@ impl ChatComposer {
                     can_show_left_with_context(hint_rect, left_width, right_width);
                 let has_override =
                     self.footer_flash_visible() || self.footer_hint_override.is_some();
+                // Bypass the single-line collapse algorithm when a flash, hint
+                // override, or status line is active.  The collapse path can resolve
+                // to `SummaryLeft::None` (render nothing) when no mode indicator is
+                // present, which would hide the status line.  Falling through to the
+                // priority chain (flash > hint override > status line > default)
+                // ensures the status line is always rendered.
                 let single_line_layout = if has_override || status_line_active {
                     None
                 } else {
@@ -4258,20 +4264,12 @@ impl ChatComposer {
                 if let Some((summary_left, _)) = single_line_layout {
                     match summary_left {
                         SummaryLeft::Default => {
-                            if status_line_active {
-                                if let Some(line) = truncated_status_line.clone() {
-                                    render_footer_line(hint_rect, buf, line);
-                                } else {
-                                    render_footer_from_props(
-                                        hint_rect,
-                                        buf,
-                                        &footer_props,
-                                        left_mode_indicator,
-                                        show_cycle_hint,
-                                        show_shortcuts_hint,
-                                        show_queue_hint,
-                                    );
-                                }
+                            // Defensive fallback: `single_line_layout` should be `None` when the
+                            // status line is active, but if future refactors violate that
+                            // invariant, render the status line instead of dropping footer output.
+                            if status_line_active && let Some(line) = truncated_status_line.clone()
+                            {
+                                render_footer_line(hint_rect, buf, line);
                             } else {
                                 render_footer_from_props(
                                     hint_rect,
@@ -4580,6 +4578,36 @@ mod tests {
         );
     }
 
+    #[test]
+    fn footer_priority_snapshots() {
+        snapshot_composer_state(
+            "footer_priority_status_line_vs_hint_override",
+            false,
+            |composer| {
+                composer.set_status_line_enabled(true);
+                composer.set_status_line(Some(Line::from("status line content")));
+                composer.set_footer_hint_override(Some(vec![
+                    ("K".to_string(), "override".to_string()),
+                    ("J".to_string(), "other".to_string()),
+                ]));
+            },
+        );
+
+        snapshot_composer_state(
+            "footer_priority_flash_vs_hint_override_and_status_line",
+            false,
+            |composer| {
+                composer.set_status_line_enabled(true);
+                composer.set_status_line(Some(Line::from("status line content")));
+                composer.set_footer_hint_override(Some(vec![
+                    ("K".to_string(), "override".to_string()),
+                    ("J".to_string(), "other".to_string()),
+                ]));
+                composer.show_footer_flash(Line::from("FLASH"), Duration::from_secs(10));
+            },
+        );
+    }
+
     fn snapshot_composer_state_with_width<F>(
         name: &str,
         width: u16,
@@ -4845,8 +4873,11 @@ mod tests {
             },
         );
 
-        // Draft text with a configured status line should keep rendering the
-        // status line even when no collaboration mode indicator is shown.
+        // Regression: draft text with a configured status line but no
+        // collaboration mode indicator previously fell through the collapse
+        // algorithm to `SummaryLeft::None`, hiding the status line.  This
+        // snapshot locks the corrected behavior where the status line stays
+        // visible on the bottom row.
         snapshot_composer_state_with_width(
             "footer_collapse_status_line_draft_no_mode",
             120,

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -4606,6 +4606,20 @@ mod tests {
                 composer.show_footer_flash(Line::from("FLASH"), Duration::from_secs(10));
             },
         );
+
+        // When a task is running and the user has draft text, the queue hint
+        // ("tab to add to queue") should be shown instead of the status line.
+        snapshot_composer_state_with_width(
+            "footer_priority_queue_hint_vs_status_line",
+            120,
+            true,
+            |composer| {
+                composer.set_status_line_enabled(true);
+                composer.set_status_line(Some(Line::from("model: gpt-5 · cwd: codex-rs")));
+                composer.set_task_running(true);
+                composer.set_text_content("Test".to_string(), Vec::new(), Vec::new());
+            },
+        );
     }
 
     fn snapshot_composer_state_with_width<F>(

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -4844,6 +4844,19 @@ mod tests {
                 composer.set_text_content("Test".to_string(), Vec::new(), Vec::new());
             },
         );
+
+        // Draft text with a configured status line should keep rendering the
+        // status line even when no collaboration mode indicator is shown.
+        snapshot_composer_state_with_width(
+            "footer_collapse_status_line_draft_no_mode",
+            120,
+            true,
+            |composer| {
+                composer.set_status_line_enabled(true);
+                composer.set_status_line(Some(Line::from("model: gpt-5 · cwd: codex-rs")));
+                composer.set_text_content("Test".to_string(), Vec::new(), Vec::new());
+            },
+        );
     }
 
     #[test]

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_collapse_status_line_draft_no_mode.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_collapse_status_line_draft_no_mode.snap
@@ -1,0 +1,13 @@
+---
+source: tui/src/bottom_pane/chat_composer.rs
+expression: terminal.backend()
+---
+"                                                                                                                        "
+"› Test                                                                                                                  "
+"                                                                                                                        "
+"                                                                                                                        "
+"                                                                                                                        "
+"                                                                                                                        "
+"                                                                                                                        "
+"                                                                                                                        "
+"  model: gpt-5 · cwd: codex-rs                                                                                          "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_priority_flash_vs_hint_override_and_status_line.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_priority_flash_vs_hint_override_and_status_line.snap
@@ -1,0 +1,13 @@
+---
+source: tui/src/bottom_pane/chat_composer.rs
+expression: terminal.backend()
+---
+"                                                                                                    "
+"› Ask Codex to do anything                                                                          "
+"                                                                                                    "
+"                                                                                                    "
+"                                                                                                    "
+"                                                                                                    "
+"                                                                                                    "
+"                                                                                                    "
+"  FLASH                                                                                             "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_priority_queue_hint_vs_status_line.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_priority_queue_hint_vs_status_line.snap
@@ -1,0 +1,14 @@
+---
+source: tui/src/bottom_pane/chat_composer.rs
+assertion_line: 4654
+expression: terminal.backend()
+---
+"                                                                                                                        "
+"› Test                                                                                                                  "
+"                                                                                                                        "
+"                                                                                                                        "
+"                                                                                                                        "
+"                                                                                                                        "
+"                                                                                                                        "
+"                                                                                                                        "
+"  tab to queue message                                                                               100% context left  "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_priority_status_line_vs_hint_override.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_priority_status_line_vs_hint_override.snap
@@ -1,0 +1,13 @@
+---
+source: tui/src/bottom_pane/chat_composer.rs
+expression: terminal.backend()
+---
+"                                                                                                    "
+"› Ask Codex to do anything                                                                          "
+"                                                                                                    "
+"                                                                                                    "
+"                                                                                                    "
+"                                                                                                    "
+"                                                                                                    "
+"                                                                                                    "
+"   K override    J other                                                                            "


### PR DESCRIPTION
## Problem

When the user has a configured status line and begins typing a draft message, the status line disappears. The footer enters `FooterMode::ComposerHasDraft`, which runs `single_line_footer_layout` — a collapse algorithm that can resolve to `SummaryLeft::None` when no collaboration mode indicator is present, hiding the entire left side of the footer including the status line.

## Mental model

The footer has two rendering paths:

1. **Single-line collapse path** (`single_line_layout = Some(...)`) — a waterfall of progressively shorter footer variants that shed elements as terminal width shrinks. This path does not know about the status line; its `SummaryLeft::None` outcome renders nothing.

2. **Priority-chain path** (`single_line_layout = None`) — a straight cascade: flash > hint override > status line > default props. This path correctly renders the status line when active.

Before this fix, `status_line_active` gated the right-side indicator and the left-width calculation, but did _not_ prevent entry into the collapse path. When the collapse algorithm ran without a mode indicator to anchor on, it returned `SummaryLeft::None`, silently discarding the status line.

## Non-goals

- No change to collapse behavior when the status line is inactive.
- No change to flash or hint-override priority — they still win over the status line.
- No refactor of the collapse algorithm itself.
- When a task is running and the user starts typing, the queue hint ("Tab to queue") is preserved instead of the status line. This is by design: `status_line_candidate` is `false` when `is_task_running` is true in `ComposerHasDraft` mode, so the normal collapse path runs and the queue hint takes precedence.

## Tradeoffs

`single_line_footer_layout` in `footer.rs` has no concept of the status line. Bypassing it entirely when `status_line_active` is correct but coarse — if future work wants the status line to participate in width-collapse (e.g. progressive truncation), the collapse algorithm would need an overhaul. Accepted as a known limitation.

## Architecture

Two changes in `chat_composer.rs`:

1. **Bypass collapse when status line is active** — add `|| status_line_active` to the guard that sets `single_line_layout = None`, routing rendering through the priority chain (flash > hint override > status line > default) where the status line is handled explicitly.

```rust
// Before
let single_line_layout = if has_override {
// After
let single_line_layout = if has_override || status_line_active {
```

2. **Simplify `SummaryLeft::Default` fallback** — the duplicated `status_line_active` branch inside the collapse-path rendering arm was nominally unreachable after change (1). Simplified to a single defensive check: if `status_line_active` is somehow true, render the status line instead of dropping footer output; otherwise fall through to `render_footer_from_props`. This avoids the previous two-level nesting and removes the duplicate call site while keeping a safe fallback if the invariant is ever violated by future refactors.

## Observability

The status line is user-visible in the bottom bar. When it disappears during drafting, users see an empty footer row — the fix makes the status line persist.

## Tests

- `footer_collapse_status_line_draft_no_mode` — locks the fix: composer with `status_line_enabled`, a status line value, and draft text renders the status line on the bottom row (width 120, confirms `model: gpt-5 · cwd: codex-rs`).
- `footer_priority_status_line_vs_hint_override` — hint override wins over the status line when both are active.
- `footer_priority_flash_vs_hint_override_and_status_line` — flash wins over both hint override and status line.
- `footer_priority_queue_hint_vs_status_line` — when a task is running and the user has draft text, the queue hint is shown instead of the status line.