### PR TITLE
chore: rm --all-features flag from rust-analyzer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "rust-analyzer.checkOnSave": true,
     "rust-analyzer.check.command": "clippy",
-    "rust-analyzer.check.extraArgs": ["--all-features", "--tests"],
+    "rust-analyzer.check.extraArgs": ["--tests"],
     "rust-analyzer.rustfmt.extraArgs": ["--config", "imports_granularity=Item"],
     "rust-analyzer.cargo.targetDir": "${workspaceFolder}/codex-rs/target/rust-analyzer",
     "[rust]": {


### PR DESCRIPTION
follows up on #12429; rm `--all-features` from flags used with `rust-analyzer` on save to prevent disk space bloat under `target/`.