### PR TITLE
Enforce MCP requirements for plugin-provided MCP servers

### DIFF
--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -727,7 +727,7 @@ fn load_model_catalog(
         .transpose()
 }
 
-fn filter_mcp_servers_by_requirements(
+pub(crate) fn filter_mcp_servers_by_requirements(
     mcp_servers: &mut HashMap<String, McpServerConfig>,
     mcp_requirements: Option<&Sourced<BTreeMap<String, McpServerRequirement>>>,
 ) {

--- a/codex-rs/core/src/mcp/mod.rs
+++ b/codex-rs/core/src/mcp/mod.rs
@@ -19,6 +19,7 @@ use serde_json::Value;
 use crate::AuthManager;
 use crate::CodexAuth;
 use crate::config::Config;
+use crate::config::filter_mcp_servers_by_requirements;
 use crate::config::types::McpServerConfig;
 use crate::config::types::McpServerTransportConfig;
 use crate::features::Feature;
@@ -193,6 +194,14 @@ fn configured_mcp_servers(
     for (name, plugin_server) in loaded_plugins.effective_mcp_servers() {
         servers.entry(name).or_insert(plugin_server);
     }
+    filter_mcp_servers_by_requirements(
+        &mut servers,
+        config
+            .config_layer_stack
+            .requirements()
+            .mcp_servers
+            .as_ref(),
+    );
     servers
 }
 
@@ -407,6 +416,8 @@ mod tests {
     use super::*;
     use crate::config::CONFIG_TOML_FILE;
     use crate::config::ConfigBuilder;
+    use crate::config_loader::CloudRequirementsLoader;
+    use crate::config_loader::ConfigRequirementsToml;
     use pretty_assertions::assert_eq;
     use std::fs;
     use std::path::Path;
@@ -611,6 +622,59 @@ mod tests {
 
         let expected_url = format!("{OPENAI_CONNECTORS_MCP_BASE_URL}{OPENAI_CONNECTORS_MCP_PATH}");
         assert_eq!(url, &expected_url);
+    }
+
+    #[tokio::test]
+    async fn configured_mcp_servers_apply_requirements_to_plugin_servers() {
+        let codex_home = tempfile::tempdir().expect("tempdir");
+        let plugin_root = codex_home.path().join("plugin-sample");
+        write_file(
+            &plugin_root.join(".codex-plugin/plugin.json"),
+            r#"{"name":"sample"}"#,
+        );
+        write_file(
+            &plugin_root.join(".mcp.json"),
+            r#"{
+  "mcpServers": {
+    "docs": {
+      "type": "http",
+      "url": "https://docs.example/mcp"
+    }
+  }
+}"#,
+        );
+        write_file(
+            &codex_home.path().join(CONFIG_TOML_FILE),
+            &plugin_config_toml(&plugin_root),
+        );
+
+        let config = ConfigBuilder::default()
+            .codex_home(codex_home.path().to_path_buf())
+            .cloud_requirements(CloudRequirementsLoader::new(async {
+                Ok(Some(ConfigRequirementsToml {
+                    mcp_servers: Some(Default::default()),
+                    ..Default::default()
+                }))
+            }))
+            .build()
+            .await
+            .expect("config should load");
+
+        let mcp_manager = McpManager::new(Arc::new(PluginsManager::new(config.codex_home.clone())));
+        let configured = mcp_manager.configured_servers(&config);
+
+        let docs = configured.get("docs").expect("plugin server should exist");
+        assert!(
+            !docs.enabled,
+            "plugin server should be disabled by requirements"
+        );
+        assert!(
+            matches!(
+                docs.disabled_reason,
+                Some(crate::config::types::McpServerDisabledReason::Requirements { .. })
+            ),
+            "plugin server should record requirements disabled reason"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- Plugin-provided MCP servers were merged into the configured MCP server map after managed requirements/allowlist filtering, allowing plugins to introduce enabled MCP servers that bypass operator policies.

### Description
- Exposed the existing requirements filter as `pub(crate) fn filter_mcp_servers_by_requirements` in `codex-rs/core/src/config/mod.rs` so it can be reused without duplicating policy logic.
- Re-applied `filter_mcp_servers_by_requirements` after merging plugin MCP servers in `codex-rs/core/src/mcp/mod.rs::configured_mcp_servers`, ensuring plugin entries are subject to the same allowlist enforcement as user-configured servers.
- Added a regression test `configured_mcp_servers_apply_requirements_to_plugin_servers` to `codex-rs/core/src/mcp/mod.rs` that loads a plugin MCP server and verifies it becomes disabled when the managed MCP allowlist is empty.
- Ran formatting (`just fmt`) to keep code style consistent.

### Testing
- Ran `just fmt`, which completed successfully.
- Attempted `cargo test -p codex-core`, but the build failed in this environment because the `codex-linux-sandbox` crate's build script requires the system library `libcap` (pkg-config `libcap.pc`) which is not available, so the test suite could not complete here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_69a491ebda28832da5b1d580131b5dcb)