### PR TITLE
Map mouse scroll to Up/Down keys in TuiEventStream and add tests

### DIFF
--- a/codex-rs/tui/src/tui/event_stream.rs
+++ b/codex-rs/tui/src/tui/event_stream.rs
@@ -26,6 +26,10 @@ use std::task::Context;
 use std::task::Poll;
 
 use crossterm::event::Event;
+use crossterm::event::KeyCode;
+use crossterm::event::KeyEvent;
+use crossterm::event::KeyModifiers;
+use crossterm::event::MouseEventKind;
 use tokio::sync::broadcast;
 use tokio::sync::watch;
 use tokio_stream::Stream;
@@ -233,7 +237,7 @@ impl<S: EventSource + Default + Unpin> TuiEventStream<S> {
         }
     }
 
-    /// Map a crossterm event to a [`TuiEvent`], skipping events we don't use (mouse events, etc.).
+    /// Map a crossterm event to a [`TuiEvent`], skipping events we don't use.
     fn map_crossterm_event(&mut self, event: Event) -> Option<TuiEvent> {
         match event {
             Event::Key(key_event) => {
@@ -255,6 +259,17 @@ impl<S: EventSource + Default + Unpin> TuiEventStream<S> {
                 self.terminal_focused.store(false, Ordering::Relaxed);
                 None
             }
+            Event::Mouse(mouse_event) => match mouse_event.kind {
+                MouseEventKind::ScrollUp => Some(TuiEvent::Key(KeyEvent::new(
+                    KeyCode::Up,
+                    KeyModifiers::NONE,
+                ))),
+                MouseEventKind::ScrollDown => Some(TuiEvent::Key(KeyEvent::new(
+                    KeyCode::Down,
+                    KeyModifiers::NONE,
+                ))),
+                _ => None,
+            },
             _ => None,
         }
     }
@@ -297,6 +312,9 @@ mod tests {
     use crossterm::event::KeyCode;
     use crossterm::event::KeyEvent;
     use crossterm::event::KeyModifiers;
+    use crossterm::event::MouseButton;
+    use crossterm::event::MouseEvent;
+    use crossterm::event::MouseEventKind;
     use pretty_assertions::assert_eq;
     use std::task::Context;
     use std::task::Poll;
@@ -507,5 +525,60 @@ mod tests {
             Some(TuiEvent::Key(key)) => assert_eq!(key, expected_key),
             other => panic!("expected key event, got {other:?}"),
         }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn non_scroll_mouse_events_are_ignored() {
+        let (broker, handle, _draw_tx, draw_rx, terminal_focused) = setup();
+        let mut stream = make_stream(broker, draw_rx, terminal_focused);
+
+        handle.send(Ok(Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 2,
+            row: 2,
+            modifiers: KeyModifiers::NONE,
+        })));
+        let expected_key = KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE);
+        handle.send(Ok(Event::Key(expected_key)));
+
+        let event = stream.next().await;
+        assert_eq!(event, Some(TuiEvent::Key(expected_key)));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn mouse_scroll_maps_to_up_down_keys() {
+        let (broker, handle, _draw_tx, draw_rx, terminal_focused) = setup();
+        let mut stream = make_stream(broker, draw_rx, terminal_focused);
+
+        handle.send(Ok(Event::Mouse(MouseEvent {
+            kind: MouseEventKind::ScrollUp,
+            column: 0,
+            row: 0,
+            modifiers: KeyModifiers::NONE,
+        })));
+        handle.send(Ok(Event::Mouse(MouseEvent {
+            kind: MouseEventKind::ScrollDown,
+            column: 0,
+            row: 0,
+            modifiers: KeyModifiers::NONE,
+        })));
+
+        let first = stream.next().await;
+        let second = stream.next().await;
+
+        assert_eq!(
+            first,
+            Some(TuiEvent::Key(KeyEvent::new(
+                KeyCode::Up,
+                KeyModifiers::NONE
+            )))
+        );
+        assert_eq!(
+            second,
+            Some(TuiEvent::Key(KeyEvent::new(
+                KeyCode::Down,
+                KeyModifiers::NONE
+            )))
+        );
     }
 }


### PR DESCRIPTION
### Motivation

- Scrolling for the review files tab was not working, the scroll was not visible and scrolling did not work.

### Description

- Added imports for `KeyCode`, `KeyEvent`, `KeyModifiers`, and `MouseEventKind` and implemented `Event::Mouse` handling in `map_crossterm_event` to map `ScrollUp` and `ScrollDown` to `TuiEvent::Key(KeyEvent::new(KeyCode::Up/Down, KeyModifiers::NONE))` and ignore other mouse kinds.
- Kept focus and paste/resize handling unchanged and still return `None` for unhandled events.
- Added tests `non_scroll_mouse_events_are_ignored` and `mouse_scroll_maps_to_up_down_keys` to validate ignoring non-scroll mouse events and mapping scroll events to up/down keys.

### Testing

- Ran the test suite with `cargo test` which executed the async tests including `non_scroll_mouse_events_are_ignored` and `mouse_scroll_maps_to_up_down_keys` and they passed.
- Existing tests such as `resume_wakes_pending_stream` also ran and passed, indicating no regressions in event stream behavior.



------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_69a7522e7ca08329969c7beb6e303506)