### PR TITLE
feat(core, tracing): add a span representing a turn

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -4066,8 +4066,13 @@ mod handlers {
             sess.refresh_mcp_servers_if_requested(&current_context)
                 .await;
             let regular_task = sess.take_startup_regular_task().await.unwrap_or_default();
-            sess.spawn_task(Arc::clone(&current_context), items, regular_task)
-                .await;
+            sess.spawn_task(
+                Arc::clone(&current_context),
+                items,
+                regular_task,
+                Some("turn/start"),
+            )
+            .await;
         }
     }
 
@@ -4094,6 +4099,7 @@ mod handlers {
             Arc::clone(&turn_context),
             Vec::new(),
             UserShellCommandTask::new(command),
+            None,
         )
         .await;
     }
@@ -4420,7 +4426,7 @@ mod handlers {
 
     pub async fn undo(sess: &Arc<Session>, sub_id: String) {
         let turn_context = sess.new_default_turn_with_sub_id(sub_id).await;
-        sess.spawn_task(turn_context, Vec::new(), UndoTask::new())
+        sess.spawn_task(turn_context, Vec::new(), UndoTask::new(), None)
             .await;
     }
 
@@ -4435,6 +4441,7 @@ mod handlers {
                 text_elements: Vec::new(),
             }],
             CompactTask,
+            None,
         )
         .await;
     }
@@ -4825,7 +4832,8 @@ async fn spawn_review_thread(
     // TODO(ccunningham): Review turns currently rely on `spawn_task` for TurnComplete but do not
     // emit a parent TurnStarted. Consider giving review a full parent turn lifecycle
     // (TurnStarted + TurnComplete) for consistency with other standalone tasks.
-    sess.spawn_task(tc.clone(), input, ReviewTask::new()).await;
+    sess.spawn_task(tc.clone(), input, ReviewTask::new(), Some("review/start"))
+        .await;
 
     // Announce entering review mode so UIs can switch modes.
     let review_request = ReviewRequest {
@@ -8589,6 +8597,106 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn spawn_task_turn_span_inherits_dispatch_trace_context() {
+        struct TraceCaptureTask {
+            captured_trace: Arc<std::sync::Mutex<Option<W3cTraceContext>>>,
+        }
+
+        #[async_trait::async_trait]
+        impl SessionTask for TraceCaptureTask {
+            fn kind(&self) -> TaskKind {
+                TaskKind::Regular
+            }
+
+            async fn run(
+                self: Arc<Self>,
+                _session: Arc<SessionTaskContext>,
+                _ctx: Arc<TurnContext>,
+                _input: Vec<UserInput>,
+                _cancellation_token: CancellationToken,
+            ) -> Option<String> {
+                let mut trace = self
+                    .captured_trace
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                *trace = current_span_w3c_trace_context();
+                None
+            }
+        }
+
+        let subscriber = test_tracing_subscriber();
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let request_parent = W3cTraceContext {
+            traceparent: Some("00-00000000000000000000000000000011-0000000000000022-01".into()),
+            tracestate: Some("vendor=value".into()),
+        };
+        let request_span = tracing::info_span!("app_server.request");
+        assert!(set_parent_from_w3c_trace_context(
+            &request_span,
+            &request_parent
+        ));
+
+        let submission_trace = async {
+            current_span_w3c_trace_context().expect("request span should have trace context")
+        }
+        .instrument(request_span)
+        .await;
+
+        let dispatch_span = submission_dispatch_span(&Submission {
+            id: "sub-1".into(),
+            op: Op::Interrupt,
+            trace: Some(submission_trace.clone()),
+        });
+        let dispatch_span_id = dispatch_span.context().span().span_context().span_id();
+
+        let (sess, tc, rx) = make_session_and_context_with_rx().await;
+        let captured_trace = Arc::new(std::sync::Mutex::new(None));
+
+        async {
+            sess.spawn_task(
+                Arc::clone(&tc),
+                vec![UserInput::Text {
+                    text: "hello".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                TraceCaptureTask {
+                    captured_trace: Arc::clone(&captured_trace),
+                },
+                Some("turn/start"),
+            )
+            .await;
+        }
+        .instrument(dispatch_span)
+        .await;
+
+        let evt = tokio::time::timeout(StdDuration::from_secs(2), rx.recv())
+            .await
+            .expect("timeout waiting for turn completion")
+            .expect("event");
+        assert!(matches!(evt.msg, EventMsg::TurnComplete(_)));
+
+        let task_trace = captured_trace
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+            .expect("turn task should capture the current span trace context");
+        let submission_context =
+            codex_otel::context_from_w3c_trace_context(&submission_trace).expect("submission");
+        let task_context =
+            codex_otel::context_from_w3c_trace_context(&task_trace).expect("task trace");
+
+        assert_eq!(
+            task_context.span().span_context().trace_id(),
+            submission_context.span().span_context().trace_id()
+        );
+        assert_ne!(
+            task_context.span().span_context().span_id(),
+            dispatch_span_id
+        );
+    }
+
     pub(crate) async fn make_session_and_context_with_dynamic_tools_and_rx(
         dynamic_tools: Vec<DynamicToolSpec>,
     ) -> (
@@ -8854,6 +8962,7 @@ mod tests {
                 kind: TaskKind::Regular,
                 listen_to_cancellation_token: true,
             },
+            None,
         )
         .await;
 
@@ -9425,6 +9534,7 @@ mod tests {
                 kind: TaskKind::Regular,
                 listen_to_cancellation_token: false,
             },
+            None,
         )
         .await;
 
@@ -9458,6 +9568,7 @@ mod tests {
                 kind: TaskKind::Regular,
                 listen_to_cancellation_token: true,
             },
+            None,
         )
         .await;
 
@@ -9491,6 +9602,7 @@ mod tests {
                 kind: TaskKind::Regular,
                 listen_to_cancellation_token: false,
             },
+            None,
         )
         .await;
 
@@ -9618,6 +9730,7 @@ mod tests {
                 kind: TaskKind::Regular,
                 listen_to_cancellation_token: false,
             },
+            None,
         )
         .await;
 
@@ -9655,6 +9768,7 @@ mod tests {
                 kind: TaskKind::Regular,
                 listen_to_cancellation_token: false,
             },
+            None,
         )
         .await;
 
@@ -9678,7 +9792,7 @@ mod tests {
             text: "start review".to_string(),
             text_elements: Vec::new(),
         }];
-        sess.spawn_task(Arc::clone(&tc), input, ReviewTask::new())
+        sess.spawn_task(Arc::clone(&tc), input, ReviewTask::new(), None)
             .await;
 
         sess.abort_all_tasks(TurnAbortReason::Interrupted).await;

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -4066,13 +4066,8 @@ mod handlers {
             sess.refresh_mcp_servers_if_requested(&current_context)
                 .await;
             let regular_task = sess.take_startup_regular_task().await.unwrap_or_default();
-            sess.spawn_task(
-                Arc::clone(&current_context),
-                items,
-                regular_task,
-                Some("turn/start"),
-            )
-            .await;
+            sess.spawn_task(Arc::clone(&current_context), items, regular_task)
+                .await;
         }
     }
 
@@ -4099,7 +4094,6 @@ mod handlers {
             Arc::clone(&turn_context),
             Vec::new(),
             UserShellCommandTask::new(command),
-            None,
         )
         .await;
     }
@@ -4426,7 +4420,7 @@ mod handlers {
 
     pub async fn undo(sess: &Arc<Session>, sub_id: String) {
         let turn_context = sess.new_default_turn_with_sub_id(sub_id).await;
-        sess.spawn_task(turn_context, Vec::new(), UndoTask::new(), None)
+        sess.spawn_task(turn_context, Vec::new(), UndoTask::new())
             .await;
     }
 
@@ -4441,7 +4435,6 @@ mod handlers {
                 text_elements: Vec::new(),
             }],
             CompactTask,
-            None,
         )
         .await;
     }
@@ -4832,8 +4825,7 @@ async fn spawn_review_thread(
     // TODO(ccunningham): Review turns currently rely on `spawn_task` for TurnComplete but do not
     // emit a parent TurnStarted. Consider giving review a full parent turn lifecycle
     // (TurnStarted + TurnComplete) for consistency with other standalone tasks.
-    sess.spawn_task(tc.clone(), input, ReviewTask::new(), Some("review/start"))
-        .await;
+    sess.spawn_task(tc.clone(), input, ReviewTask::new()).await;
 
     // Announce entering review mode so UIs can switch modes.
     let review_request = ReviewRequest {
@@ -8609,6 +8601,10 @@ mod tests {
                 TaskKind::Regular
             }
 
+            fn span_name(&self) -> &'static str {
+                "session_task.trace_capture"
+            }
+
             async fn run(
                 self: Arc<Self>,
                 _session: Arc<SessionTaskContext>,
@@ -8664,7 +8660,6 @@ mod tests {
                 TraceCaptureTask {
                     captured_trace: Arc::clone(&captured_trace),
                 },
-                Some("turn/start"),
             )
             .await;
         }
@@ -8962,7 +8957,6 @@ mod tests {
                 kind: TaskKind::Regular,
                 listen_to_cancellation_token: true,
             },
-            None,
         )
         .await;
 
@@ -9502,6 +9496,10 @@ mod tests {
             self.kind
         }
 
+        fn span_name(&self) -> &'static str {
+            "session_task.never_ending"
+        }
+
         async fn run(
             self: Arc<Self>,
             _session: Arc<SessionTaskContext>,
@@ -9534,7 +9532,6 @@ mod tests {
                 kind: TaskKind::Regular,
                 listen_to_cancellation_token: false,
             },
-            None,
         )
         .await;
 
@@ -9568,7 +9565,6 @@ mod tests {
                 kind: TaskKind::Regular,
                 listen_to_cancellation_token: true,
             },
-            None,
         )
         .await;
 
@@ -9602,7 +9598,6 @@ mod tests {
                 kind: TaskKind::Regular,
                 listen_to_cancellation_token: false,
             },
-            None,
         )
         .await;
 
@@ -9730,7 +9725,6 @@ mod tests {
                 kind: TaskKind::Regular,
                 listen_to_cancellation_token: false,
             },
-            None,
         )
         .await;
 
@@ -9768,7 +9762,6 @@ mod tests {
                 kind: TaskKind::Regular,
                 listen_to_cancellation_token: false,
             },
-            None,
         )
         .await;
 
@@ -9792,7 +9785,7 @@ mod tests {
             text: "start review".to_string(),
             text_elements: Vec::new(),
         }];
-        sess.spawn_task(Arc::clone(&tc), input, ReviewTask::new(), None)
+        sess.spawn_task(Arc::clone(&tc), input, ReviewTask::new())
             .await;
 
         sess.abort_all_tasks(TurnAbortReason::Interrupted).await;

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -6710,6 +6710,7 @@ mod tests {
     use serde_json::json;
     use std::path::PathBuf;
     use std::sync::Arc;
+    use std::sync::Once;
     use std::time::Duration as StdDuration;
 
     struct InstructionsTestCase {
@@ -8176,10 +8177,16 @@ mod tests {
         })
     }
 
-    fn test_tracing_subscriber() -> impl tracing::Subscriber + Send + Sync {
-        let provider = SdkTracerProvider::builder().build();
-        let tracer = provider.tracer("codex-core-tests");
-        tracing_subscriber::registry().with(tracing_opentelemetry::layer().with_tracer(tracer))
+    fn init_test_tracing() {
+        static INIT: Once = Once::new();
+        INIT.call_once(|| {
+            let provider = SdkTracerProvider::builder().build();
+            let tracer = provider.tracer("codex-core-tests");
+            let subscriber = tracing_subscriber::registry()
+                .with(tracing_opentelemetry::layer().with_tracer(tracer));
+            tracing::subscriber::set_global_default(subscriber)
+                .expect("global tracing subscriber should only be installed once");
+        });
     }
 
     async fn build_test_config(codex_home: &Path) -> Config {
@@ -8522,8 +8529,7 @@ mod tests {
             session: Arc::new(session),
         };
 
-        let subscriber = test_tracing_subscriber();
-        let _guard = tracing::subscriber::set_default(subscriber);
+        init_test_tracing();
 
         let request_parent = W3cTraceContext {
             traceparent: Some("00-00000000000000000000000000000011-0000000000000022-01".into()),
@@ -8557,8 +8563,7 @@ mod tests {
 
     #[test]
     fn submission_dispatch_span_prefers_submission_trace_context() {
-        let subscriber = test_tracing_subscriber();
-        let _guard = tracing::subscriber::set_default(subscriber);
+        init_test_tracing();
 
         let ambient_parent = W3cTraceContext {
             traceparent: Some("00-00000000000000000000000000000033-0000000000000044-01".into()),
@@ -8621,8 +8626,7 @@ mod tests {
             }
         }
 
-        let subscriber = test_tracing_subscriber();
-        let _guard = tracing::subscriber::set_default(subscriber);
+        init_test_tracing();
 
         let request_parent = W3cTraceContext {
             traceparent: Some("00-00000000000000000000000000000011-0000000000000022-01".into()),

--- a/codex-rs/core/src/tasks/compact.rs
+++ b/codex-rs/core/src/tasks/compact.rs
@@ -17,6 +17,10 @@ impl SessionTask for CompactTask {
         TaskKind::Compact
     }
 
+    fn span_name(&self) -> &'static str {
+        "session_task.compact"
+    }
+
     async fn run(
         self: Arc<Self>,
         session: Arc<SessionTaskContext>,

--- a/codex-rs/core/src/tasks/ghost_snapshot.rs
+++ b/codex-rs/core/src/tasks/ghost_snapshot.rs
@@ -32,6 +32,10 @@ impl SessionTask for GhostSnapshotTask {
         TaskKind::Regular
     }
 
+    fn span_name(&self) -> &'static str {
+        "session_task.ghost_snapshot"
+    }
+
     async fn run(
         self: Arc<Self>,
         session: Arc<SessionTaskContext>,

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -14,7 +14,6 @@ use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
 use tracing::Instrument;
-use tracing::Span;
 use tracing::info_span;
 use tracing::trace;
 use tracing::warn;
@@ -89,6 +88,9 @@ pub(crate) trait SessionTask: Send + Sync + 'static {
     /// surface it in telemetry and UI.
     fn kind(&self) -> TaskKind;
 
+    /// Returns the tracing name for a spawned task span.
+    fn span_name(&self) -> &'static str;
+
     /// Executes the task until completion or cancellation.
     ///
     /// Implementations typically stream protocol events using `session` and
@@ -121,13 +123,13 @@ impl Session {
         turn_context: Arc<TurnContext>,
         input: Vec<UserInput>,
         task: T,
-        turn_operation: Option<&'static str>,
     ) {
         self.abort_all_tasks(TurnAbortReason::Replaced).await;
         self.clear_connector_selection().await;
 
         let task: Arc<dyn SessionTask> = Arc::new(task);
         let task_kind = task.kind();
+        let span_name = task.span_name();
 
         let cancellation_token = CancellationToken::new();
         let done = Arc::new(Notify::new());
@@ -138,19 +140,15 @@ impl Session {
             let ctx = Arc::clone(&turn_context);
             let task_for_run = Arc::clone(&task);
             let task_cancellation_token = cancellation_token.child_token();
-            let task_span = if let Some(turn_operation) = turn_operation {
-                // Turn-producing APIs keep a core-owned span open for the full
-                // task lifecycle after the submission dispatch span ends.
-                info_span!(
-                    "turn",
-                    otel.name = turn_operation,
-                    thread.id = %self.conversation_id,
-                    turn.id = %turn_context.sub_id,
-                    model = %turn_context.model_info.slug,
-                )
-            } else {
-                Span::current()
-            };
+            // Task-owned turn spans keep a core-owned span open for the
+            // full task lifecycle after the submission dispatch span ends.
+            let task_span = info_span!(
+                "turn",
+                otel.name = span_name,
+                thread.id = %self.conversation_id,
+                turn.id = %turn_context.sub_id,
+                model = %turn_context.model_info.slug,
+            );
             tokio::spawn(
                 async move {
                     let ctx_for_finish = Arc::clone(&ctx);

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -15,6 +15,7 @@ use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
 use tracing::Instrument;
 use tracing::Span;
+use tracing::info_span;
 use tracing::trace;
 use tracing::warn;
 
@@ -120,6 +121,7 @@ impl Session {
         turn_context: Arc<TurnContext>,
         input: Vec<UserInput>,
         task: T,
+        turn_operation: Option<&'static str>,
     ) {
         self.abort_all_tasks(TurnAbortReason::Replaced).await;
         self.clear_connector_selection().await;
@@ -136,7 +138,19 @@ impl Session {
             let ctx = Arc::clone(&turn_context);
             let task_for_run = Arc::clone(&task);
             let task_cancellation_token = cancellation_token.child_token();
-            let session_span = Span::current();
+            let task_span = if let Some(turn_operation) = turn_operation {
+                // Turn-producing APIs keep a core-owned span open for the full
+                // task lifecycle after the submission dispatch span ends.
+                info_span!(
+                    "turn",
+                    otel.name = turn_operation,
+                    thread.id = %self.conversation_id,
+                    turn.id = %turn_context.sub_id,
+                    model = %turn_context.model_info.slug,
+                )
+            } else {
+                Span::current()
+            };
             tokio::spawn(
                 async move {
                     let ctx_for_finish = Arc::clone(&ctx);
@@ -157,7 +171,7 @@ impl Session {
                     }
                     done_clone.notify_waiters();
                 }
-                .instrument(session_span),
+                .instrument(task_span),
             )
         };
 

--- a/codex-rs/core/src/tasks/regular.rs
+++ b/codex-rs/core/src/tasks/regular.rs
@@ -68,6 +68,10 @@ impl SessionTask for RegularTask {
         TaskKind::Regular
     }
 
+    fn span_name(&self) -> &'static str {
+        "session_task.turn"
+    }
+
     async fn run(
         self: Arc<Self>,
         session: Arc<SessionTaskContext>,

--- a/codex-rs/core/src/tasks/review.rs
+++ b/codex-rs/core/src/tasks/review.rs
@@ -43,6 +43,10 @@ impl SessionTask for ReviewTask {
         TaskKind::Review
     }
 
+    fn span_name(&self) -> &'static str {
+        "session_task.review"
+    }
+
     async fn run(
         self: Arc<Self>,
         session: Arc<SessionTaskContext>,

--- a/codex-rs/core/src/tasks/undo.rs
+++ b/codex-rs/core/src/tasks/undo.rs
@@ -31,6 +31,10 @@ impl SessionTask for UndoTask {
         TaskKind::Regular
     }
 
+    fn span_name(&self) -> &'static str {
+        "session_task.undo"
+    }
+
     async fn run(
         self: Arc<Self>,
         session: Arc<SessionTaskContext>,

--- a/codex-rs/core/src/tasks/user_shell.rs
+++ b/codex-rs/core/src/tasks/user_shell.rs
@@ -66,6 +66,10 @@ impl SessionTask for UserShellCommandTask {
         TaskKind::Regular
     }
 
+    fn span_name(&self) -> &'static str {
+        "session_task.user_shell"
+    }
+
     async fn run(
         self: Arc<Self>,
         session: Arc<SessionTaskContext>,


### PR DESCRIPTION
This is PR 3 of the app-server tracing rollout.

PRs https://github.com/openai/codex/pull/13285 and https://github.com/openai/codex/pull/13368 gave us inbound request spans in app-server and propagated trace context through Submission. This change finishes the next piece in core: when a request actually starts a turn, we now create a core-owned long-lived span that stays open for the real lifetime of the turn.

What changed:
- `Session::spawn_task` can now optionally create a long-lived turn span and run the spawned task inside it
- `turn/start` uses that path, so normal turn execution stays under a single core-owned span after the async handoff
- `review/start` uses the same pattern
- added a unit test that verifies the spawned turn task inherits the submission dispatch trace ancestry

**Why**
The app-server request span is intentionally short-lived. Once work crosses into core, we still want one span that covers the actual execution window until completion or interruption. This keeps that ownership where it belongs: in the layer that owns the runtime lifecycle.
