### PR TITLE
memories: make branch applicability explicit

### DIFF
--- a/codex-rs/core/src/memories/README.md
+++ b/codex-rs/core/src/memories/README.md
@@ -71,6 +71,9 @@ What it does:
 - syncs local memory artifacts under the memories root:
   - `raw_memories.md` (merged raw memories, latest first)
   - `rollout_summaries/` (one summary file per retained rollout)
+  - these artifacts preserve rollout provenance such as `cwd` and `git_branch`
+    so consolidation can
+    keep branch-specific tasks separate
 - prunes stale rollout summaries that are no longer retained
 - if there are no inputs, marks the job successful and exits
 

--- a/codex-rs/core/src/memories/phase1.rs
+++ b/codex-rs/core/src/memories/phase1.rs
@@ -241,6 +241,7 @@ mod job {
             session,
             &thread.rollout_path,
             &thread.cwd,
+            thread.git_branch.as_deref(),
             stage_one_context,
         )
         .await
@@ -288,6 +289,7 @@ mod job {
         session: &Session,
         rollout_path: &Path,
         rollout_cwd: &Path,
+        rollout_git_branch: Option<&str>,
         stage_one_context: &RequestContext,
     ) -> anyhow::Result<(StageOneOutput, Option<TokenUsage>)> {
         let (rollout_items, _, _) = RolloutRecorder::load_rollout_items(rollout_path).await?;
@@ -302,6 +304,7 @@ mod job {
                         &stage_one_context.model_info,
                         rollout_path,
                         rollout_cwd,
+                        rollout_git_branch,
                         &rollout_contents,
                     )?,
                 }],

--- a/codex-rs/core/src/memories/prompts.rs
+++ b/codex-rs/core/src/memories/prompts.rs
@@ -24,6 +24,7 @@ struct ConsolidationPromptTemplate<'a> {
 struct StageOneInputTemplate<'a> {
     rollout_path: &'a str,
     rollout_cwd: &'a str,
+    rollout_git_branch: &'a str,
     rollout_contents: &'a str,
 }
 
@@ -100,8 +101,10 @@ fn render_selected_input_line(item: &Stage1Output, retained: bool) -> String {
         )
     );
     format!(
-        "- [{status}] thread_id={}, rollout_summary_file={rollout_summary_file}",
-        item.thread_id
+        "- [{status}] thread_id={}, rollout_summary_file={rollout_summary_file}, cwd={}, git_branch={}",
+        item.thread_id,
+        item.cwd.display(),
+        item.git_branch.as_deref().unwrap_or("unknown"),
     )
 }
 
@@ -128,6 +131,7 @@ pub(super) fn build_stage_one_input_message(
     model_info: &ModelInfo,
     rollout_path: &Path,
     rollout_cwd: &Path,
+    rollout_git_branch: Option<&str>,
     rollout_contents: &str,
 ) -> anyhow::Result<String> {
     let rollout_token_limit = model_info
@@ -144,9 +148,11 @@ pub(super) fn build_stage_one_input_message(
 
     let rollout_path = rollout_path.display().to_string();
     let rollout_cwd = rollout_cwd.display().to_string();
+    let rollout_git_branch = rollout_git_branch.unwrap_or("unknown").to_string();
     Ok(StageOneInputTemplate {
         rollout_path: &rollout_path,
         rollout_cwd: &rollout_cwd,
+        rollout_git_branch: &rollout_git_branch,
         rollout_contents: &truncated_rollout_contents,
     }
     .render()?)
@@ -182,6 +188,10 @@ pub(crate) async fn build_memory_tool_developer_instructions(codex_home: &Path) 
 mod tests {
     use super::*;
     use crate::models_manager::model_info::model_info_from_slug;
+    use chrono::TimeZone;
+    use chrono::Utc;
+    use codex_protocol::ThreadId;
+    use std::path::PathBuf;
 
     #[test]
     fn build_stage_one_input_message_truncates_rollout_using_model_context_window() {
@@ -202,6 +212,7 @@ mod tests {
             &model_info,
             Path::new("/tmp/rollout.jsonl"),
             Path::new("/tmp"),
+            Some("feature/test"),
             &input,
         )
         .unwrap();
@@ -210,6 +221,7 @@ mod tests {
         assert!(expected_truncated.starts_with('a'));
         assert!(expected_truncated.ends_with('z'));
         assert!(message.contains(&expected_truncated));
+        assert!(message.contains("rollout_git_branch: feature/test"));
     }
 
     #[test]
@@ -225,10 +237,40 @@ mod tests {
             &model_info,
             Path::new("/tmp/rollout.jsonl"),
             Path::new("/tmp"),
+            None,
             &input,
         )
         .unwrap();
 
         assert!(message.contains(&expected_truncated));
+        assert!(message.contains("rollout_git_branch: unknown"));
+    }
+
+    #[test]
+    fn build_consolidation_prompt_lists_repo_and_branch_provenance() {
+        let thread_id =
+            ThreadId::try_from("0194f5a6-89ab-7cde-8123-456789abcdef").expect("valid thread id");
+        let selection = Phase2InputSelection {
+            selected: vec![Stage1Output {
+                thread_id,
+                rollout_path: PathBuf::from("/tmp/rollout.jsonl"),
+                source_updated_at: Utc.timestamp_opt(1_735_689_600, 0).single().expect("time"),
+                raw_memory: "raw".to_string(),
+                rollout_summary: "summary".to_string(),
+                rollout_slug: Some("branch-memory".to_string()),
+                cwd: PathBuf::from("/tmp/workspace"),
+                git_branch: Some("feature/branch-memory".to_string()),
+                generated_at: Utc.timestamp_opt(1_735_689_601, 0).single().expect("time"),
+            }],
+            previous_selected: Vec::new(),
+            retained_thread_ids: Vec::new(),
+            removed: Vec::new(),
+        };
+
+        let prompt = build_consolidation_prompt(Path::new("/tmp/memories"), &selection);
+
+        assert!(prompt.contains("git_branch=feature/branch-memory"));
+        assert!(prompt.contains("applies_to: repo="));
+        assert!(prompt.contains(&format!("thread_id={thread_id}, rollout_summary_file=")));
     }
 }

--- a/codex-rs/core/src/memories/storage.rs
+++ b/codex-rs/core/src/memories/storage.rs
@@ -82,6 +82,8 @@ async fn rebuild_raw_memories_file(
         )
         .map_err(raw_memories_format_error)?;
         writeln!(body, "cwd: {}", memory.cwd.display()).map_err(raw_memories_format_error)?;
+        let git_branch = memory.git_branch.as_deref().unwrap_or("unknown");
+        writeln!(body, "git_branch: {git_branch}").map_err(raw_memories_format_error)?;
         writeln!(body, "rollout_path: {}", memory.rollout_path.display())
             .map_err(raw_memories_format_error)?;
         let rollout_summary_file = format!("{}.md", rollout_summary_file_stem(memory));
@@ -143,9 +145,8 @@ async fn write_rollout_summary_for_thread(
     writeln!(body, "rollout_path: {}", memory.rollout_path.display())
         .map_err(rollout_summary_format_error)?;
     writeln!(body, "cwd: {}", memory.cwd.display()).map_err(rollout_summary_format_error)?;
-    if let Some(git_branch) = memory.git_branch.as_deref() {
-        writeln!(body, "git_branch: {git_branch}").map_err(rollout_summary_format_error)?;
-    }
+    let git_branch = memory.git_branch.as_deref().unwrap_or("unknown");
+    writeln!(body, "git_branch: {git_branch}").map_err(rollout_summary_format_error)?;
     writeln!(body).map_err(rollout_summary_format_error)?;
     body.push_str(&memory.rollout_summary);
     body.push('\n');

--- a/codex-rs/core/src/memories/tests.rs
+++ b/codex-rs/core/src/memories/tests.rs
@@ -297,7 +297,7 @@ task_outcome: success
         rollout_slug: Some("Unsafe Slug/With Spaces & Symbols + EXTRA_LONG_12345".to_string()),
         rollout_path: PathBuf::from("/tmp/rollout-200.jsonl"),
         cwd: PathBuf::from("/tmp/workspace"),
-        git_branch: None,
+        git_branch: Some("feature/memory-branch".to_string()),
         generated_at: Utc.timestamp_opt(201, 0).single().expect("timestamp"),
     }];
 
@@ -339,6 +339,7 @@ task_outcome: success
     assert!(raw_memories.contains(&format!(
         "rollout_summary_file: {canonical_rollout_summary_file}"
     )));
+    assert!(raw_memories.contains("git_branch: feature/memory-branch"));
     assert!(raw_memories.contains("description: Added a migration test"));
     assert!(raw_memories.contains("### Task 1: migration-test"));
     assert!(raw_memories.contains("task: add-migration-test"));

--- a/codex-rs/core/templates/memories/consolidation.md
+++ b/codex-rs/core/templates/memories/consolidation.md
@@ -106,7 +106,7 @@ Under `{{ memory_root }}/`:
     context.
   - source of rollout-level metadata needed for MEMORY.md `### rollout_summary_files`
     annotations;
-    you should be able to find `cwd`, `rollout_path`, and `updated_at` there.
+    you should be able to find `cwd`, `rollout_path`, `updated_at`, and `git_branch` there.
 - `MEMORY.md`
   - merged memories; produce a lightly clustered version if applicable
 - `rollout_summaries/*.md`
@@ -141,6 +141,9 @@ Incremental update and forgetting mechanism:
   threads intact.
 - After `MEMORY.md` cleanup is done, revisit `memory_summary.md` and remove or rewrite stale
   summary/index content that was only supported by removed thread ids.
+- Treat repo / branch provenance as a first-class clustering key, not optional decoration.
+  Similar tasks from different repos or branches should stay separate unless the stored
+  guidance is genuinely branch-agnostic and you say so explicitly.
 
 Outputs:
 Under `{{ memory_root }}/`:
@@ -171,10 +174,13 @@ Each memory block MUST start with:
 # Task Group: <repo / project / workflow / detail-task family; broad but distinguishable>
 
 scope: <what this block covers, when to use it, and notable boundaries>
+applies_to: repo=<canonical repo identity or workflow scope>; branches=<branch names, branch families, or `unknown`>; reuse_rule=<when this memory is safe to reuse vs when to treat it as branch-specific>
 
 - `Task Group` is for retrieval. Choose granularity based on memory density:
   repo / project / workflow / detail-task family.
 - `scope:` is for scanning. Keep it short and operational.
+- `applies_to:` is mandatory. Use it to preserve repo / branch boundaries so future
+  agents do not confuse similar tasks from different checkouts.
 
 Body format (strict):
 
@@ -192,7 +198,7 @@ Required task-oriented body shape (strict):
 ## Task 1: <task description, outcome>
 
 ### rollout_summary_files
-- <rollout_summaries/file1.md> (cwd=<path>, rollout_path=<path>, updated_at=<timestamp>, thread_id=<thread_id>, <optional status/usefulness note>)
+- <rollout_summaries/file1.md> (cwd=<path>, rollout_path=<path>, updated_at=<timestamp>, thread_id=<thread_id>, git_branch=<branch-or-unknown>, <optional status/usefulness note>)
 
 ### keywords
 
@@ -231,8 +237,8 @@ Required task-oriented body shape (strict):
 
 Schema rules (strict):
 - A) Structure and consistency
-  - Exact block shape: `# Task Group`, `scope:`, one or more `## Task <n>`, and
-    `## General Tips`.
+  - Exact block shape: `# Task Group`, `scope:`, `applies_to:`, one or more
+    `## Task <n>`, and `## General Tips`.
   - Keep all tasks and tips inside the task family implied by the block header.
   - Keep entries retrieval-friendly, but not shallow.
   - Do not emit placeholder values (`# Task Group: misc`, `scope: general`, `## Task 1: task`, etc.).
@@ -252,6 +258,10 @@ Schema rules (strict):
   - If a rollout summary is reused across tasks/blocks, each placement should add distinct
     task-local learnings or routing value (not copy-pasted repetition).
   - Do not cluster on keyword overlap alone.
+  - Default to separating memories across different repos or git branches, even when the
+    task wording looks similar.
+  - Merge across branches only when the evidence is clearly branch-agnostic, and state that
+    explicitly in `applies_to:` or the task learnings.
   - When in doubt, preserve boundaries (separate tasks/blocks) rather than over-cluster.
 - C) Provenance and metadata
   - Every `## Task <n>` section must include `### rollout_summary_files`, `### keywords`,
@@ -259,6 +269,7 @@ Schema rules (strict):
   - `### rollout_summary_files` must be task-local (not a block-wide catch-all list).
   - Each rollout annotation must include `cwd=<path>`, `rollout_path=<path>`, and
     `updated_at=<timestamp>`.
+    Include `git_branch=<...>` whenever known.
     If missing from a rollout summary, recover them from `raw_memories.md`.
   - Major learnings should be traceable to rollout summaries listed in the same task section.
   - Order rollout references by freshness and practical usefulness.
@@ -291,6 +302,9 @@ What to write:
   verification steps, and failure shields (symptom -> cause -> fix).
 - Capture stable user preferences/details that generalize so they can also inform
   `memory_summary.md`.
+- Preserve repo / branch applicability in the block header and task details. If a task was
+  done on a feature branch, unmerged checkout, or different repo than the current one, make
+  that easy for future agents to notice before they reuse the memory.
 - `MEMORY.md` should support related-but-not-identical tasks: slightly more general than a
   rollout summary, but still operational and concrete.
 - Use `raw_memories.md` as the routing layer and task inventory.
@@ -305,6 +319,7 @@ What to write:
 - Each block should be useful on its own and materially richer than `memory_summary.md`:
   - include concrete triggers, commands/paths, and failure shields,
   - include outcome-specific notes (what worked, what failed, what remains uncertain),
+  - include repo / branch scope and mismatch warnings when they affect reuse,
   - include scope boundaries / anti-drift notes when they affect future task success,
   - include stale/conflict notes when newer evidence changes prior guidance.
 
@@ -369,6 +384,12 @@ Topic selection and quality rules:
 - Keywords must be representative and directly searchable in `MEMORY.md`.
   Prefer exact strings that a future agent can grep for (repo/project names, user query phrases,
   tool names, error strings, commands, file paths, APIs/contracts). Avoid vague synonyms.
+- When repo / branch context matters, include those handles in keywords or in the topic
+  description so the routing layer can distinguish otherwise-similar memories.
+- For checkout-sensitive work, topic descriptions must explicitly state repo and branch
+  applicability using concrete wording such as `repo=<name or path>; branches=<branch list or unknown>`.
+  Do not omit branch applicability just because the branch is unknown; write `branches=unknown`
+  so future agents can notice the uncertainty.
 
 Required subsection structure (in this order):
 
@@ -394,8 +415,8 @@ Recent Active Memory Window behavior (day-ordered):
 
 Recent-topic format:
 - <topic>: <keyword1>, <keyword2>, <keyword3>, ...
-  - desc: <clear and specific description of what tasks are inside this topic; what future task/user goal this helps with; what kinds of outcomes/artifacts/procedures are covered; and when to search this topic first>
-  - learnings: <some concise, topic-local recent takeaways / decision triggers / updates worth checking first; include useful specifics, but avoid overlap with `## General Tips` (cross-topic, broadly reusable guidance belongs there)>
+  - desc: <clear and specific description of what tasks are inside this topic; what future task/user goal this helps with; what kinds of outcomes/artifacts/procedures are covered; when to search this topic first; and explicit applicability text including `repo=...; branches=...` when the work is checkout-sensitive>
+  - learnings: <some concise, topic-local recent takeaways / decision triggers / updates worth checking first; include useful specifics, including repo / branch mismatch caveats when important; avoid overlap with `## General Tips` (cross-topic, broadly reusable guidance belongs there)>
 
 
 ### <2nd most recent memory day: YYYY-MM-DD>
@@ -413,7 +434,7 @@ Avoid duplicating recent topics. Keep these compact and retrieval-oriented.
 
 Older-topic format (compact):
 - <topic>: <keyword1>, <keyword2>, <keyword3>, ...
-  - desc: <clear and specific description of what is inside this topic and when to use it>
+  - desc: <clear and specific description of what is inside this topic, when to use it, and explicit applicability text including `repo=...; branches=...` when checkout-sensitive>
 
 Notes:
 - Do not include large snippets; push details into MEMORY.md and rollout summaries.

--- a/codex-rs/core/templates/memories/read_path.md
+++ b/codex-rs/core/templates/memories/read_path.md
@@ -33,6 +33,7 @@ Memory layout (general -> specific):
 Quick memory pass (when applicable):
 
 1. Skim the MEMORY_SUMMARY below and extract task-relevant keywords.
+   Pay special attention to repo names, git branches, worktree names, and checkout-specific paths.
 2. Search {{ base_path }}/MEMORY.md using those keywords.
 3. Only if MEMORY.md directly points to rollout summaries/skills, open the 1-2
    most relevant files under {{ base_path }}/rollout_summaries/ or
@@ -47,6 +48,22 @@ Quick-pass budget:
 
 During execution: if you hit repeated errors, confusing behavior, or suspect
 relevant prior context, redo the quick memory pass.
+
+Branch / repo matching rules:
+
+- Treat repo and git branch applicability as part of memory relevance, not background metadata.
+- Before relying on a memory for task planning, compare the memory's repo / branch hints against
+  the current environment.
+- Strong match: same repo and same branch, or the memory explicitly says it is branch-agnostic.
+- Weak match: same repo but different branch. Use only if the guidance is clearly generic; otherwise
+  call out the mismatch and prefer current checkout evidence.
+- Mismatch: different repo, or branch-sensitive memory from a different branch. Do not let it override
+  the current checkout state.
+- If the current task is about diffs, local state, merge status, or "compare against the checkout",
+  prefer current checkout evidence over memories from other threads unless those memories explicitly
+  match the same repo / branch.
+- When branch / repo metadata is missing, treat the memory as lower-confidence and verify with the
+  current checkout before reusing it for environment-specific reasoning.
 
 How to decide whether to verify memory:
 

--- a/codex-rs/core/templates/memories/stage_one_input.md
+++ b/codex-rs/core/templates/memories/stage_one_input.md
@@ -3,6 +3,7 @@ Analyze this rollout and produce JSON with `raw_memory`, `rollout_summary`, and 
 rollout_context:
 - rollout_path: {{ rollout_path }}
 - rollout_cwd: {{ rollout_cwd }}
+- rollout_git_branch: {{ rollout_git_branch }}
 
 rendered conversation (pre-rendered from rollout `.jsonl`; filtered response items):
 {{ rollout_contents }}

--- a/codex-rs/core/templates/memories/stage_one_system.md
+++ b/codex-rs/core/templates/memories/stage_one_system.md
@@ -265,6 +265,8 @@ description: concise but information-dense description of the primary task(s), o
 task: <primary_task_signature>
 task_group: <repo_or_workflow_bucket>
 task_outcome: <success|partial|fail|uncertain>
+git_branch: <branch name when known; `unknown` when not known>
+git_repo: <canonical repo identifier; prefer git remote URL when known, otherwise the repo/worktree path>
 keywords: k1, k2, k3, ... <searchable handles (tool names, error names, repo concepts, contracts)>
 ---
 
@@ -273,6 +275,8 @@ Then write task-grouped body content (required):
 task: <task signature for this task>
 task_group: <project/workflow topic>
 task_outcome: <success|partial|fail|uncertain>
+git_branch: <branch name when known; `unknown` when not known>
+git_repo: <canonical repo identifier for this task; prefer git remote URL when known>
 - <useful memory bullet>
 - ...
 
@@ -286,6 +290,7 @@ Preferred task-block body shape (strongly recommended):
 - `### Task <n>` blocks should preserve task-specific retrieval signal and consolidation-ready detail.
 - Within each task block, include bullets that explicitly cover (when applicable):
   - user goal / expected outcome,
+  - repo / branch applicability and whether the task was specific to that checkout,
   - what worked (key steps, commands, code paths, artifacts),
   - what did not work or drifted (and what pivot worked),
   - validation state (user confirmation, tests, runtime checks, or missing validation),
@@ -320,6 +325,13 @@ For each task block, include enough detail to be useful for future agent referen
 - what evidence validates the outcome (user feedback, environment/test feedback, or lack of both),
 - reusable procedures/checklists and failure shields that should survive future similar tasks,
 - artifacts and retrieval handles (commands, file paths, error strings, IDs) that make the task easy to rediscover.
+- Treat repo/branch provenance as first-class memory. If the rollout context names a
+  git branch or repo, preserve it in both the top-level frontmatter and each task block.
+- If multiple tasks are similar but tied to different repos or branches, keep them
+  separate rather than blending them into one generic task.
+- When a task is branch-specific (for example comparing against checkout state, working
+  in an unmerged feature branch, or reasoning about local diffs), say that explicitly so
+  Phase 2 can avoid reusing it in the wrong environment.
 
 
 ============================================================

--- a/codex-rs/state/src/runtime/memories.rs
+++ b/codex-rs/state/src/runtime/memories.rs
@@ -1,4 +1,3 @@
-use super::threads::push_thread_filters;
 use super::threads::push_thread_order_and_limit;
 use super::*;
 use crate::model::Phase2InputSelection;
@@ -191,15 +190,20 @@ LEFT JOIN jobs
    AND jobs.job_key = threads.id
             "#,
         );
-        push_thread_filters(
-            &mut builder,
-            false,
-            allowed_sources,
-            None,
-            None,
-            SortKey::UpdatedAt,
-            None,
-        );
+        // Phase-1 startup should not depend on preview extraction quality.
+        // Older or partially parsed rollouts can legitimately miss
+        // `first_user_message`, and gating on that field prevents those
+        // threads from ever generating memories.
+        builder.push(" WHERE 1 = 1");
+        builder.push(" AND threads.archived = 0");
+        if !allowed_sources.is_empty() {
+            builder.push(" AND threads.source IN (");
+            let mut separated = builder.separated(", ");
+            for source in allowed_sources {
+                separated.push_bind(source);
+            }
+            separated.push_unseparated(")");
+        }
         builder.push(" AND threads.memory_mode = 'enabled'");
         builder
             .push(" AND id != ")
@@ -1736,6 +1740,65 @@ mod tests {
 
         assert_eq!(claims.len(), 1);
         assert_eq!(claims[0].thread.id, enabled_thread_id);
+
+        let _ = tokio::fs::remove_dir_all(codex_home).await;
+    }
+
+    #[tokio::test]
+    async fn claim_stage1_jobs_allows_threads_without_first_user_message_preview() {
+        let codex_home = unique_temp_dir();
+        let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
+            .await
+            .expect("initialize runtime");
+
+        let now = Utc::now();
+        let eligible_at = now - Duration::hours(13);
+
+        let current_thread_id =
+            ThreadId::from_string(&Uuid::new_v4().to_string()).expect("current thread id");
+        let previewless_thread_id =
+            ThreadId::from_string(&Uuid::new_v4().to_string()).expect("previewless thread id");
+
+        let mut current =
+            test_thread_metadata(&codex_home, current_thread_id, codex_home.join("current"));
+        current.created_at = now;
+        current.updated_at = now;
+        runtime
+            .upsert_thread(&current)
+            .await
+            .expect("upsert current thread");
+
+        let mut previewless = test_thread_metadata(
+            &codex_home,
+            previewless_thread_id,
+            codex_home.join("previewless"),
+        );
+        previewless.created_at = eligible_at;
+        previewless.updated_at = eligible_at;
+        previewless.first_user_message = None;
+        runtime
+            .upsert_thread(&previewless)
+            .await
+            .expect("upsert previewless thread");
+
+        let allowed_sources = vec!["cli".to_string()];
+        let claims = runtime
+            .claim_stage1_jobs_for_startup(
+                current_thread_id,
+                Stage1StartupClaimParams {
+                    scan_limit: 10,
+                    max_claimed: 10,
+                    max_age_days: 30,
+                    min_rollout_idle_hours: 12,
+                    allowed_sources: allowed_sources.as_slice(),
+                    lease_seconds: 3600,
+                },
+            )
+            .await
+            .expect("claim stage1 startup jobs");
+
+        assert_eq!(claims.len(), 1);
+        assert_eq!(claims[0].thread.id, previewless_thread_id);
 
         let _ = tokio::fs::remove_dir_all(codex_home).await;
     }


### PR DESCRIPTION
## Summary
- make startup raw memories include git branch metadata and carry branch context into stage 1 inputs
- require branch-aware applicability in consolidation artifacts and strengthen the read-path prompt to treat branch mismatches as weaker evidence than the live checkout
- stop startup phase1 from depending on first-user-message previews so older or partially parsed rollouts can still generate memories

## Testing
- cargo test -p codex-state
- CARGO_TARGET_DIR=/tmp/codex-core-memory-target cargo test -p codex-core memories
