### PR TITLE
Prefix handoff messages with role

### DIFF
--- a/codex-rs/core/src/realtime_conversation.rs
+++ b/codex-rs/core/src/realtime_conversation.rs
@@ -376,7 +376,7 @@ fn realtime_text_from_handoff_request(handoff: &RealtimeHandoffRequested) -> Opt
     let messages = handoff
         .messages
         .iter()
-        .map(|message| message.text.as_str())
+        .map(|message| format!("{}: {}", message.role, message.text))
         .collect::<Vec<_>>()
         .join("\n");
     (!messages.is_empty()).then_some(messages).or_else(|| {
@@ -605,7 +605,7 @@ mod tests {
         };
         assert_eq!(
             realtime_text_from_handoff_request(&handoff),
-            Some("hello\nhi there".to_string())
+            Some("user: hello\nassistant: hi there".to_string())
         );
     }
 

--- a/codex-rs/core/src/sandboxing/mod.rs
+++ b/codex-rs/core/src/sandboxing/mod.rs
@@ -326,12 +326,11 @@ impl SandboxManager {
             use_linux_sandbox_bwrap,
             windows_sandbox_level,
         } = request;
-        let policy = policy.clone();
         let effective_policy =
             if let Some(additional_permissions) = spec.additional_permissions.take() {
-                sandbox_policy_with_additional_permissions(&policy, &additional_permissions)?
+                sandbox_policy_with_additional_permissions(policy, &additional_permissions)?
             } else {
-                policy
+                policy.clone()
             };
         let mut env = spec.env;
         if !effective_policy.has_full_network_access() {

--- a/codex-rs/core/src/sandboxing/mod.rs
+++ b/codex-rs/core/src/sandboxing/mod.rs
@@ -330,7 +330,7 @@ impl SandboxManager {
             if let Some(additional_permissions) = spec.additional_permissions.take() {
                 sandbox_policy_with_additional_permissions(policy, &additional_permissions)?
             } else {
-                policy.clone()
+                policy
             };
         let mut env = spec.env;
         if !effective_policy.has_full_network_access() {

--- a/codex-rs/core/src/sandboxing/mod.rs
+++ b/codex-rs/core/src/sandboxing/mod.rs
@@ -326,9 +326,10 @@ impl SandboxManager {
             use_linux_sandbox_bwrap,
             windows_sandbox_level,
         } = request;
+        let policy = policy.clone();
         let effective_policy =
             if let Some(additional_permissions) = spec.additional_permissions.take() {
-                sandbox_policy_with_additional_permissions(policy, &additional_permissions)?
+                sandbox_policy_with_additional_permissions(&policy, &additional_permissions)?
             } else {
                 policy
             };

--- a/codex-rs/core/tests/suite/realtime_conversation.rs
+++ b/codex-rs/core/tests/suite/realtime_conversation.rs
@@ -1588,11 +1588,7 @@ async fn inbound_handoff_request_starts_turn_and_does_not_block_realtime_audio()
     let first_body: Value = serde_json::from_slice(&requests[0]).expect("parse first request");
     let first_texts = message_input_texts(&first_body, "user");
     let expected_text = format!("user: {}", delegated_text);
-    assert!(
-        first_texts
-            .iter()
-            .any(|text| text == &expected_text)
-    );
+    assert!(first_texts.iter().any(|text| text == &expected_text));
 
     realtime_server.shutdown().await;
     api_server.shutdown().await;

--- a/codex-rs/core/tests/suite/realtime_conversation.rs
+++ b/codex-rs/core/tests/suite/realtime_conversation.rs
@@ -912,9 +912,11 @@ async fn inbound_handoff_request_starts_turn() -> Result<()> {
 
     let request = response_mock.single_request();
     let user_texts = request.message_input_texts("user");
-    assert!(user_texts
-        .iter()
-        .any(|text| text == "user: text from realtime"));
+    assert!(
+        user_texts
+            .iter()
+            .any(|text| text == "user: text from realtime")
+    );
 
     realtime_server.shutdown().await;
     Ok(())
@@ -984,11 +986,8 @@ async fn inbound_handoff_request_uses_all_messages() -> Result<()> {
 
     let request = response_mock.single_request();
     let user_texts = request.message_input_texts("user");
-    assert!(
-        user_texts
-            .iter()
-            .any(|text| text == "assistant: assistant context\nuser: delegated query\nassistant: assist confirm")
-    );
+    assert!(user_texts.iter().any(|text| text
+        == "assistant: assistant context\nuser: delegated query\nassistant: assist confirm"));
 
     realtime_server.shutdown().await;
     Ok(())
@@ -1470,13 +1469,17 @@ async fn inbound_handoff_request_steers_active_turn() -> Result<()> {
     let second_texts = message_input_texts(&second_body, "user");
 
     assert!(first_texts.iter().any(|text| text == "first prompt"));
-    assert!(!first_texts
-        .iter()
-        .any(|text| text == "user: steer via realtime"));
+    assert!(
+        !first_texts
+            .iter()
+            .any(|text| text == "user: steer via realtime")
+    );
     assert!(second_texts.iter().any(|text| text == "first prompt"));
-    assert!(second_texts
-        .iter()
-        .any(|text| text == "user: steer via realtime"));
+    assert!(
+        second_texts
+            .iter()
+            .any(|text| text == "user: steer via realtime")
+    );
 
     realtime_server.shutdown().await;
     api_server.shutdown().await;
@@ -1584,9 +1587,11 @@ async fn inbound_handoff_request_starts_turn_and_does_not_block_realtime_audio()
     assert_eq!(requests.len(), 1);
     let first_body: Value = serde_json::from_slice(&requests[0]).expect("parse first request");
     let first_texts = message_input_texts(&first_body, "user");
-    assert!(first_texts
-        .iter()
-        .any(|text| text == format!("user: {}", delegated_text)));
+    assert!(
+        first_texts
+            .iter()
+            .any(|text| text == format!("user: {}", delegated_text))
+    );
 
     realtime_server.shutdown().await;
     api_server.shutdown().await;

--- a/codex-rs/core/tests/suite/realtime_conversation.rs
+++ b/codex-rs/core/tests/suite/realtime_conversation.rs
@@ -1588,7 +1588,11 @@ async fn inbound_handoff_request_starts_turn_and_does_not_block_realtime_audio()
     let first_body: Value = serde_json::from_slice(&requests[0]).expect("parse first request");
     let first_texts = message_input_texts(&first_body, "user");
     let expected_text = format!("user: {}", delegated_text);
-    assert!(first_texts.iter().any(|text| text == &expected_text));
+    assert!(
+        first_texts
+            .iter()
+            .any(|text| text == &expected_text)
+    );
 
     realtime_server.shutdown().await;
     api_server.shutdown().await;

--- a/codex-rs/core/tests/suite/realtime_conversation.rs
+++ b/codex-rs/core/tests/suite/realtime_conversation.rs
@@ -912,7 +912,9 @@ async fn inbound_handoff_request_starts_turn() -> Result<()> {
 
     let request = response_mock.single_request();
     let user_texts = request.message_input_texts("user");
-    assert!(user_texts.iter().any(|text| text == "text from realtime"));
+    assert!(user_texts
+        .iter()
+        .any(|text| text == "user: text from realtime"));
 
     realtime_server.shutdown().await;
     Ok(())
@@ -985,7 +987,7 @@ async fn inbound_handoff_request_uses_all_messages() -> Result<()> {
     assert!(
         user_texts
             .iter()
-            .any(|text| text == "assistant context\ndelegated query\nassist confirm")
+            .any(|text| text == "assistant: assistant context\nuser: delegated query\nassistant: assist confirm")
     );
 
     realtime_server.shutdown().await;
@@ -1468,9 +1470,13 @@ async fn inbound_handoff_request_steers_active_turn() -> Result<()> {
     let second_texts = message_input_texts(&second_body, "user");
 
     assert!(first_texts.iter().any(|text| text == "first prompt"));
-    assert!(!first_texts.iter().any(|text| text == "steer via realtime"));
+    assert!(!first_texts
+        .iter()
+        .any(|text| text == "user: steer via realtime"));
     assert!(second_texts.iter().any(|text| text == "first prompt"));
-    assert!(second_texts.iter().any(|text| text == "steer via realtime"));
+    assert!(second_texts
+        .iter()
+        .any(|text| text == "user: steer via realtime"));
 
     realtime_server.shutdown().await;
     api_server.shutdown().await;
@@ -1578,7 +1584,9 @@ async fn inbound_handoff_request_starts_turn_and_does_not_block_realtime_audio()
     assert_eq!(requests.len(), 1);
     let first_body: Value = serde_json::from_slice(&requests[0]).expect("parse first request");
     let first_texts = message_input_texts(&first_body, "user");
-    assert!(first_texts.iter().any(|text| text == delegated_text));
+    assert!(first_texts
+        .iter()
+        .any(|text| text == format!("user: {}", delegated_text)));
 
     realtime_server.shutdown().await;
     api_server.shutdown().await;

--- a/codex-rs/core/tests/suite/realtime_conversation.rs
+++ b/codex-rs/core/tests/suite/realtime_conversation.rs
@@ -1587,7 +1587,7 @@ async fn inbound_handoff_request_starts_turn_and_does_not_block_realtime_audio()
     assert_eq!(requests.len(), 1);
     let first_body: Value = serde_json::from_slice(&requests[0]).expect("parse first request");
     let first_texts = message_input_texts(&first_body, "user");
-    let expected_text = format!("user: {}", delegated_text);
+    let expected_text = format!("user: {delegated_text}");
     assert!(first_texts.iter().any(|text| text == &expected_text));
 
     realtime_server.shutdown().await;

--- a/codex-rs/core/tests/suite/realtime_conversation.rs
+++ b/codex-rs/core/tests/suite/realtime_conversation.rs
@@ -1587,10 +1587,11 @@ async fn inbound_handoff_request_starts_turn_and_does_not_block_realtime_audio()
     assert_eq!(requests.len(), 1);
     let first_body: Value = serde_json::from_slice(&requests[0]).expect("parse first request");
     let first_texts = message_input_texts(&first_body, "user");
+    let expected_text = format!("user: {}", delegated_text);
     assert!(
         first_texts
             .iter()
-            .any(|text| text == format!("user: {}", delegated_text))
+            .any(|text| text == &expected_text)
     );
 
     realtime_server.shutdown().await;


### PR DESCRIPTION
Format handoff context by prefixing each message with its role (for example "user:" and "assistant:") before forwarding to the agent.