### PR TITLE
Log service tier resume mismatches

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -6380,6 +6380,14 @@ fn collect_resume_override_mismatches(
             config_snapshot.model_provider_id
         ));
     }
+    if let Some(requested_service_tier) = request.service_tier.as_ref()
+        && requested_service_tier != &config_snapshot.service_tier
+    {
+        mismatch_details.push(format!(
+            "service_tier requested={requested_service_tier:?} active={:?}",
+            config_snapshot.service_tier
+        ));
+    }
     if let Some(requested_cwd) = request.cwd.as_deref() {
         let requested_cwd_path = std::path::PathBuf::from(requested_cwd);
         if requested_cwd_path != config_snapshot.cwd {
@@ -7102,6 +7110,43 @@ mod tests {
             input_schema: json!({"properties": {}}),
         }];
         validate_dynamic_tools(&tools).expect("valid schema");
+    }
+
+    #[test]
+    fn collect_resume_override_mismatches_includes_service_tier() {
+        let request = ThreadResumeParams {
+            thread_id: "thread-1".to_string(),
+            history: None,
+            path: None,
+            model: None,
+            model_provider: None,
+            service_tier: Some(Some(codex_protocol::config_types::ServiceTier::Fast)),
+            cwd: None,
+            approval_policy: None,
+            sandbox: None,
+            config: None,
+            base_instructions: None,
+            developer_instructions: None,
+            personality: None,
+            persist_extended_history: false,
+        };
+        let config_snapshot = ThreadConfigSnapshot {
+            model: "gpt-5".to_string(),
+            model_provider_id: "openai".to_string(),
+            service_tier: Some(codex_protocol::config_types::ServiceTier::Flex),
+            approval_policy: codex_protocol::protocol::AskForApproval::OnRequest,
+            sandbox_policy: codex_protocol::protocol::SandboxPolicy::DangerFullAccess,
+            cwd: PathBuf::from("/tmp"),
+            ephemeral: false,
+            reasoning_effort: None,
+            personality: None,
+            session_source: SessionSource::Cli,
+        };
+
+        assert_eq!(
+            collect_resume_override_mismatches(&request, &config_snapshot),
+            vec!["service_tier requested=Some(Fast) active=Some(Flex)".to_string()]
+        );
     }
 
     #[test]

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -801,7 +801,8 @@ impl App {
         history_cell::SessionHeaderHistoryCell::new(
             self.chat_widget.current_model().to_string(),
             self.chat_widget.current_reasoning_effort(),
-            self.chat_widget.current_service_tier(),
+            self.chat_widget
+                .should_show_fast_status(self.chat_widget.current_service_tier()),
             self.config.cwd.clone(),
             version,
         )
@@ -4394,6 +4395,7 @@ mod tests {
                 is_first,
                 None,
                 None,
+                false,
             )) as Arc<dyn HistoryCell>
         };
 
@@ -5032,6 +5034,7 @@ mod tests {
                 is_first,
                 None,
                 None,
+                false,
             )) as Arc<dyn HistoryCell>
         };
 

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -801,6 +801,7 @@ impl App {
         history_cell::SessionHeaderHistoryCell::new(
             self.chat_widget.current_model().to_string(),
             self.chat_widget.current_reasoning_effort(),
+            self.chat_widget.current_service_tier(),
             self.config.cwd.clone(),
             version,
         )

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -7394,6 +7394,7 @@ impl ChatWidget {
             DEFAULT_MODEL_DISPLAY_NAME.to_string(),
             placeholder_style,
             None,
+            config.service_tier,
             config.cwd.clone(),
             CODEX_CLI_VERSION,
         ))

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1189,6 +1189,7 @@ impl ChatWidget {
         self.sync_fast_command_enabled();
         self.sync_personality_command_enabled();
         let startup_tooltip_override = self.startup_tooltip_override.take();
+        let show_fast_status = self.should_show_fast_status(event.service_tier);
         let session_info_cell = history_cell::new_session_info(
             &self.config,
             &model_for_header,
@@ -1198,6 +1199,7 @@ impl ChatWidget {
             self.auth_manager
                 .auth_cached()
                 .and_then(|auth| auth.account_plan_type()),
+            show_fast_status,
         );
         self.apply_session_info_cell(session_info_cell);
 
@@ -7060,6 +7062,15 @@ impl ChatWidget {
         self.config.service_tier
     }
 
+    pub(crate) fn should_show_fast_status(&self, service_tier: Option<ServiceTier>) -> bool {
+        matches!(service_tier, Some(ServiceTier::Fast))
+            && self
+                .auth_manager
+                .auth_cached()
+                .as_ref()
+                .is_some_and(|auth| auth.is_chatgpt_auth())
+    }
+
     fn fast_mode_enabled(&self) -> bool {
         self.config.features.enabled(Feature::FastMode)
     }
@@ -7394,7 +7405,7 @@ impl ChatWidget {
             DEFAULT_MODEL_DISPLAY_NAME.to_string(),
             placeholder_style,
             None,
-            config.service_tier,
+            false,
             config.cwd.clone(),
             CODEX_CLI_VERSION,
         ))

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -7265,6 +7265,26 @@ async fn user_turn_carries_service_tier_after_fast_toggle() {
 }
 
 #[tokio::test]
+async fn fast_status_indicator_requires_chatgpt_auth() {
+    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(Some("gpt-5.3-codex")).await;
+    chat.set_service_tier(Some(ServiceTier::Fast));
+
+    assert!(!chat.should_show_fast_status(chat.current_service_tier()));
+
+    set_chatgpt_auth(&mut chat);
+
+    assert!(chat.should_show_fast_status(chat.current_service_tier()));
+}
+
+#[tokio::test]
+async fn fast_status_indicator_is_hidden_when_fast_mode_is_off() {
+    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(Some("gpt-5.3-codex")).await;
+    set_chatgpt_auth(&mut chat);
+
+    assert!(!chat.should_show_fast_status(chat.current_service_tier()));
+}
+
+#[tokio::test]
 async fn approvals_popup_shows_disabled_presets() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual(None).await;
 

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -1256,7 +1256,7 @@ impl HistoryCell for SessionHeaderHistoryCell {
             }
             if self.show_fast_status {
                 spans.push("  ".into());
-                spans.push(Span::styled("fast", self.model_style));
+                spans.push(Span::styled("fast", self.model_style.magenta().bold()));
             }
             spans.push("   ".dim());
             spans.push(CHANGE_MODEL_HINT_COMMAND.cyan());

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -1255,8 +1255,8 @@ impl HistoryCell for SessionHeaderHistoryCell {
                 spans.push(Span::from(reasoning));
             }
             if self.show_fast_status {
-                spans.push("  ".into());
-                spans.push(Span::styled("fast", self.model_style.magenta().bold()));
+                spans.push("   ".into());
+                spans.push(Span::styled("fast", self.model_style.magenta()));
             }
             spans.push("   ".dim());
             spans.push(CHANGE_MODEL_HINT_COMMAND.cyan());
@@ -3300,7 +3300,7 @@ mod tests {
             .find(|line| line.contains("model:"))
             .expect("model line");
 
-        assert!(model_line.contains("gpt-4o high  fast"));
+        assert!(model_line.contains("gpt-4o high   fast"));
         assert!(model_line.contains("/model to change"));
     }
 

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -44,6 +44,7 @@ use codex_core::plugins::PluginsManager;
 use codex_core::web_search::web_search_detail;
 use codex_otel::RuntimeMetricsSummary;
 use codex_protocol::account::PlanType;
+use codex_protocol::config_types::ServiceTier;
 use codex_protocol::mcp::Resource;
 use codex_protocol::mcp::ResourceTemplate;
 use codex_protocol::models::WebSearchAction;
@@ -1056,6 +1057,7 @@ pub(crate) fn new_session_info(
     let header = SessionHeaderHistoryCell::new(
         model.clone(),
         reasoning_effort,
+        config.service_tier,
         config.cwd.clone(),
         CODEX_CLI_VERSION,
     );
@@ -1137,6 +1139,7 @@ pub(crate) struct SessionHeaderHistoryCell {
     model: String,
     model_style: Style,
     reasoning_effort: Option<ReasoningEffortConfig>,
+    service_tier: Option<ServiceTier>,
     directory: PathBuf,
 }
 
@@ -1144,6 +1147,7 @@ impl SessionHeaderHistoryCell {
     pub(crate) fn new(
         model: String,
         reasoning_effort: Option<ReasoningEffortConfig>,
+        service_tier: Option<ServiceTier>,
         directory: PathBuf,
         version: &'static str,
     ) -> Self {
@@ -1151,6 +1155,7 @@ impl SessionHeaderHistoryCell {
             model,
             Style::default(),
             reasoning_effort,
+            service_tier,
             directory,
             version,
         )
@@ -1160,6 +1165,7 @@ impl SessionHeaderHistoryCell {
         model: String,
         model_style: Style,
         reasoning_effort: Option<ReasoningEffortConfig>,
+        service_tier: Option<ServiceTier>,
         directory: PathBuf,
         version: &'static str,
     ) -> Self {
@@ -1168,6 +1174,7 @@ impl SessionHeaderHistoryCell {
             model,
             model_style,
             reasoning_effort,
+            service_tier,
             directory,
         }
     }
@@ -1209,6 +1216,13 @@ impl SessionHeaderHistoryCell {
             ReasoningEffortConfig::None => "none",
         })
     }
+
+    fn speed_label(&self) -> &'static str {
+        match self.service_tier {
+            Some(ServiceTier::Fast) => "Fast",
+            _ => "Standard",
+        }
+    }
 }
 
 impl HistoryCell for SessionHeaderHistoryCell {
@@ -1229,6 +1243,8 @@ impl HistoryCell for SessionHeaderHistoryCell {
 
         const CHANGE_MODEL_HINT_COMMAND: &str = "/model";
         const CHANGE_MODEL_HINT_EXPLANATION: &str = " to change";
+        const CHANGE_SPEED_HINT_COMMAND: &str = "/fast";
+        const CHANGE_SPEED_HINT_EXPLANATION: &str = " to change";
         const DIR_LABEL: &str = "directory:";
         let label_width = DIR_LABEL.len();
 
@@ -1260,10 +1276,24 @@ impl HistoryCell for SessionHeaderHistoryCell {
         let dir = self.format_directory(Some(dir_max_width));
         let dir_spans = vec![Span::from(dir_prefix).dim(), Span::from(dir)];
 
+        let speed_label = format!(
+            "{speed_label:<label_width$}",
+            speed_label = "speed:",
+            label_width = label_width
+        );
+        let speed_spans = vec![
+            Span::from(format!("{speed_label} ")).dim(),
+            Span::styled(self.speed_label(), self.model_style),
+            "   ".dim(),
+            CHANGE_SPEED_HINT_COMMAND.cyan(),
+            CHANGE_SPEED_HINT_EXPLANATION.dim(),
+        ];
+
         let lines = vec![
             make_row(title_spans),
             make_row(Vec::new()),
             make_row(model_spans),
+            make_row(speed_spans),
             make_row(dir_spans),
         ];
 
@@ -3274,18 +3304,25 @@ mod tests {
         let cell = SessionHeaderHistoryCell::new(
             "gpt-4o".to_string(),
             Some(ReasoningEffortConfig::High),
+            Some(ServiceTier::Fast),
             std::env::temp_dir(),
             "test",
         );
 
         let lines = render_lines(&cell.display_lines(80));
         let model_line = lines
-            .into_iter()
+            .iter()
             .find(|line| line.contains("model:"))
             .expect("model line");
+        let speed_line = lines
+            .iter()
+            .find(|line| line.contains("speed:"))
+            .expect("speed line");
 
         assert!(model_line.contains("gpt-4o high"));
         assert!(model_line.contains("/model to change"));
+        assert!(speed_line.contains("Fast"));
+        assert!(speed_line.contains("/fast to change"));
     }
 
     #[test]

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -1254,6 +1254,12 @@ impl HistoryCell for SessionHeaderHistoryCell {
             label_width = label_width
         );
         let reasoning_label = self.reasoning_label();
+        let model_value_width = UnicodeWidthStr::width(self.model.as_str())
+            + reasoning_label
+                .map(|reasoning| 1 + UnicodeWidthStr::width(reasoning))
+                .unwrap_or_default();
+        let speed_value_width = UnicodeWidthStr::width(self.speed_label());
+        let hint_column_width = model_value_width.max(speed_value_width) + 3;
         let model_spans: Vec<Span<'static>> = {
             let mut spans = vec![
                 Span::from(format!("{model_label} ")).dim(),
@@ -1263,7 +1269,7 @@ impl HistoryCell for SessionHeaderHistoryCell {
                 spans.push(Span::from(" "));
                 spans.push(Span::from(reasoning));
             }
-            spans.push("   ".dim());
+            spans.push(" ".repeat(hint_column_width - model_value_width).dim());
             spans.push(CHANGE_MODEL_HINT_COMMAND.cyan());
             spans.push(CHANGE_MODEL_HINT_EXPLANATION.dim());
             spans
@@ -1284,7 +1290,7 @@ impl HistoryCell for SessionHeaderHistoryCell {
         let speed_spans = vec![
             Span::from(format!("{speed_label} ")).dim(),
             Span::styled(self.speed_label(), self.model_style),
-            "   ".dim(),
+            " ".repeat(hint_column_width - speed_value_width).dim(),
             CHANGE_SPEED_HINT_COMMAND.cyan(),
             CHANGE_SPEED_HINT_EXPLANATION.dim(),
         ];
@@ -3323,6 +3329,7 @@ mod tests {
         assert!(model_line.contains("/model to change"));
         assert!(speed_line.contains("Fast"));
         assert!(speed_line.contains("/fast to change"));
+        assert_eq!(model_line.find("/model"), speed_line.find("/fast"));
     }
 
     #[test]

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -44,7 +44,6 @@ use codex_core::plugins::PluginsManager;
 use codex_core::web_search::web_search_detail;
 use codex_otel::RuntimeMetricsSummary;
 use codex_protocol::account::PlanType;
-use codex_protocol::config_types::ServiceTier;
 use codex_protocol::mcp::Resource;
 use codex_protocol::mcp::ResourceTemplate;
 use codex_protocol::models::WebSearchAction;
@@ -1047,6 +1046,7 @@ pub(crate) fn new_session_info(
     is_first_event: bool,
     tooltip_override: Option<String>,
     auth_plan: Option<PlanType>,
+    show_fast_status: bool,
 ) -> SessionInfoCell {
     let SessionConfiguredEvent {
         model,
@@ -1057,7 +1057,7 @@ pub(crate) fn new_session_info(
     let header = SessionHeaderHistoryCell::new(
         model.clone(),
         reasoning_effort,
-        config.service_tier,
+        show_fast_status,
         config.cwd.clone(),
         CODEX_CLI_VERSION,
     );
@@ -1139,7 +1139,7 @@ pub(crate) struct SessionHeaderHistoryCell {
     model: String,
     model_style: Style,
     reasoning_effort: Option<ReasoningEffortConfig>,
-    service_tier: Option<ServiceTier>,
+    show_fast_status: bool,
     directory: PathBuf,
 }
 
@@ -1147,7 +1147,7 @@ impl SessionHeaderHistoryCell {
     pub(crate) fn new(
         model: String,
         reasoning_effort: Option<ReasoningEffortConfig>,
-        service_tier: Option<ServiceTier>,
+        show_fast_status: bool,
         directory: PathBuf,
         version: &'static str,
     ) -> Self {
@@ -1155,7 +1155,7 @@ impl SessionHeaderHistoryCell {
             model,
             Style::default(),
             reasoning_effort,
-            service_tier,
+            show_fast_status,
             directory,
             version,
         )
@@ -1165,7 +1165,7 @@ impl SessionHeaderHistoryCell {
         model: String,
         model_style: Style,
         reasoning_effort: Option<ReasoningEffortConfig>,
-        service_tier: Option<ServiceTier>,
+        show_fast_status: bool,
         directory: PathBuf,
         version: &'static str,
     ) -> Self {
@@ -1174,7 +1174,7 @@ impl SessionHeaderHistoryCell {
             model,
             model_style,
             reasoning_effort,
-            service_tier,
+            show_fast_status,
             directory,
         }
     }
@@ -1216,13 +1216,6 @@ impl SessionHeaderHistoryCell {
             ReasoningEffortConfig::None => "none",
         })
     }
-
-    fn speed_label(&self) -> &'static str {
-        match self.service_tier {
-            Some(ServiceTier::Fast) => "fast",
-            _ => "standard",
-        }
-    }
 }
 
 impl HistoryCell for SessionHeaderHistoryCell {
@@ -1243,8 +1236,6 @@ impl HistoryCell for SessionHeaderHistoryCell {
 
         const CHANGE_MODEL_HINT_COMMAND: &str = "/model";
         const CHANGE_MODEL_HINT_EXPLANATION: &str = " to change";
-        const CHANGE_SPEED_HINT_COMMAND: &str = "/fast";
-        const CHANGE_SPEED_HINT_EXPLANATION: &str = " to change";
         const DIR_LABEL: &str = "directory:";
         let label_width = DIR_LABEL.len();
 
@@ -1254,12 +1245,6 @@ impl HistoryCell for SessionHeaderHistoryCell {
             label_width = label_width
         );
         let reasoning_label = self.reasoning_label();
-        let model_value_width = UnicodeWidthStr::width(self.model.as_str())
-            + reasoning_label
-                .map(|reasoning| 1 + UnicodeWidthStr::width(reasoning))
-                .unwrap_or_default();
-        let speed_value_width = UnicodeWidthStr::width(self.speed_label());
-        let hint_column_width = model_value_width.max(speed_value_width) + 3;
         let model_spans: Vec<Span<'static>> = {
             let mut spans = vec![
                 Span::from(format!("{model_label} ")).dim(),
@@ -1269,7 +1254,11 @@ impl HistoryCell for SessionHeaderHistoryCell {
                 spans.push(Span::from(" "));
                 spans.push(Span::from(reasoning));
             }
-            spans.push(" ".repeat(hint_column_width - model_value_width).dim());
+            if self.show_fast_status {
+                spans.push("  ".into());
+                spans.push(Span::styled("fast", self.model_style));
+            }
+            spans.push("   ".dim());
             spans.push(CHANGE_MODEL_HINT_COMMAND.cyan());
             spans.push(CHANGE_MODEL_HINT_EXPLANATION.dim());
             spans
@@ -1282,24 +1271,10 @@ impl HistoryCell for SessionHeaderHistoryCell {
         let dir = self.format_directory(Some(dir_max_width));
         let dir_spans = vec![Span::from(dir_prefix).dim(), Span::from(dir)];
 
-        let speed_label = format!(
-            "{speed_label:<label_width$}",
-            speed_label = "speed:",
-            label_width = label_width
-        );
-        let speed_spans = vec![
-            Span::from(format!("{speed_label} ")).dim(),
-            Span::styled(self.speed_label(), self.model_style),
-            " ".repeat(hint_column_width - speed_value_width).dim(),
-            CHANGE_SPEED_HINT_COMMAND.cyan(),
-            CHANGE_SPEED_HINT_EXPLANATION.dim(),
-        ];
-
         let lines = vec![
             make_row(title_spans),
             make_row(Vec::new()),
             make_row(model_spans),
-            make_row(speed_spans),
             make_row(dir_spans),
         ];
 
@@ -2627,6 +2602,7 @@ mod tests {
             false,
             Some("Model just became available".to_string()),
             Some(PlanType::Free),
+            false,
         );
 
         let rendered = render_transcript(&cell).join("\n");
@@ -2644,6 +2620,7 @@ mod tests {
             false,
             Some("Model just became available".to_string()),
             Some(PlanType::Free),
+            false,
         );
 
         let rendered = render_transcript(&cell).join("\n");
@@ -2660,6 +2637,7 @@ mod tests {
             true,
             Some("Model just became available".to_string()),
             Some(PlanType::Free),
+            false,
         );
 
         let rendered = render_transcript(&cell).join("\n");
@@ -2678,6 +2656,7 @@ mod tests {
             false,
             Some("Model just became available".to_string()),
             Some(PlanType::Free),
+            false,
         );
 
         let rendered = render_transcript(&cell).join("\n");
@@ -3310,7 +3289,7 @@ mod tests {
         let cell = SessionHeaderHistoryCell::new(
             "gpt-4o".to_string(),
             Some(ReasoningEffortConfig::High),
-            Some(ServiceTier::Fast),
+            true,
             std::env::temp_dir(),
             "test",
         );
@@ -3320,16 +3299,29 @@ mod tests {
             .iter()
             .find(|line| line.contains("model:"))
             .expect("model line");
-        let speed_line = lines
+
+        assert!(model_line.contains("gpt-4o high  fast"));
+        assert!(model_line.contains("/model to change"));
+    }
+
+    #[test]
+    fn session_header_hides_fast_status_when_disabled() {
+        let cell = SessionHeaderHistoryCell::new(
+            "gpt-4o".to_string(),
+            Some(ReasoningEffortConfig::High),
+            false,
+            std::env::temp_dir(),
+            "test",
+        );
+
+        let lines = render_lines(&cell.display_lines(80));
+        let model_line = lines
             .iter()
-            .find(|line| line.contains("speed:"))
-            .expect("speed line");
+            .find(|line| line.contains("model:"))
+            .expect("model line");
 
         assert!(model_line.contains("gpt-4o high"));
-        assert!(model_line.contains("/model to change"));
-        assert!(speed_line.contains("fast"));
-        assert!(speed_line.contains("/fast to change"));
-        assert_eq!(model_line.find("/model"), speed_line.find("/fast"));
+        assert!(!model_line.contains("fast"));
     }
 
     #[test]

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -1219,8 +1219,8 @@ impl SessionHeaderHistoryCell {
 
     fn speed_label(&self) -> &'static str {
         match self.service_tier {
-            Some(ServiceTier::Fast) => "Fast",
-            _ => "Standard",
+            Some(ServiceTier::Fast) => "fast",
+            _ => "standard",
         }
     }
 }
@@ -3327,7 +3327,7 @@ mod tests {
 
         assert!(model_line.contains("gpt-4o high"));
         assert!(model_line.contains("/model to change"));
-        assert!(speed_line.contains("Fast"));
+        assert!(speed_line.contains("fast"));
         assert!(speed_line.contains("/fast to change"));
         assert_eq!(model_line.find("/model"), speed_line.find("/fast"));
     }

--- a/codex-rs/tui/src/snapshots/codex_tui__app__tests__clear_ui_after_long_transcript_fresh_header_only.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__app__tests__clear_ui_after_long_transcript_fresh_header_only.snap
@@ -7,6 +7,6 @@ expression: rendered
 │ >_ OpenAI Codex (v<VERSION>)                │
 │                                             │
 │ model:     gpt-test high   /model to change │
-│ speed:     Standard        /fast to change  │
+│ speed:     standard        /fast to change  │
 │ directory: /tmp/project                     │
 ╰─────────────────────────────────────────────╯

--- a/codex-rs/tui/src/snapshots/codex_tui__app__tests__clear_ui_after_long_transcript_fresh_header_only.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__app__tests__clear_ui_after_long_transcript_fresh_header_only.snap
@@ -1,12 +1,10 @@
 ---
 source: tui/src/app.rs
-assertion_line: 4441
 expression: rendered
 ---
 ╭─────────────────────────────────────────────╮
 │ >_ OpenAI Codex (v<VERSION>)                │
 │                                             │
 │ model:     gpt-test high   /model to change │
-│ speed:     standard        /fast to change  │
 │ directory: /tmp/project                     │
 ╰─────────────────────────────────────────────╯

--- a/codex-rs/tui/src/snapshots/codex_tui__app__tests__clear_ui_after_long_transcript_fresh_header_only.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__app__tests__clear_ui_after_long_transcript_fresh_header_only.snap
@@ -7,5 +7,6 @@ expression: rendered
 │ >_ OpenAI Codex (v<VERSION>)                │
 │                                             │
 │ model:     gpt-test high   /model to change │
+│ speed:     Standard   /fast to change       │
 │ directory: /tmp/project                     │
 ╰─────────────────────────────────────────────╯

--- a/codex-rs/tui/src/snapshots/codex_tui__app__tests__clear_ui_after_long_transcript_fresh_header_only.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__app__tests__clear_ui_after_long_transcript_fresh_header_only.snap
@@ -1,12 +1,12 @@
 ---
 source: tui/src/app.rs
-assertion_line: 3452
+assertion_line: 4441
 expression: rendered
 ---
 ╭─────────────────────────────────────────────╮
 │ >_ OpenAI Codex (v<VERSION>)                │
 │                                             │
 │ model:     gpt-test high   /model to change │
-│ speed:     Standard   /fast to change       │
+│ speed:     Standard        /fast to change  │
 │ directory: /tmp/project                     │
 ╰─────────────────────────────────────────────╯

--- a/codex-rs/tui/src/snapshots/codex_tui__history_cell__tests__session_info_availability_nux_tooltip_snapshot.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__history_cell__tests__session_info_availability_nux_tooltip_snapshot.snap
@@ -1,14 +1,12 @@
 ---
 source: tui/src/history_cell.rs
-assertion_line: 2650
 expression: rendered
 ---
-╭────────────────────────────────────────╮
-│ >_ OpenAI Codex (v0.0.0)               │
-│                                        │
-│ model:     gpt-5      /model to change │
-│ speed:     standard   /fast to change  │
-│ directory: /tmp/project                │
-╰────────────────────────────────────────╯
+╭─────────────────────────────────────╮
+│ >_ OpenAI Codex (v0.0.0)            │
+│                                     │
+│ model:     gpt-5   /model to change │
+│ directory: /tmp/project             │
+╰─────────────────────────────────────╯
 
   Tip: Model just became available

--- a/codex-rs/tui/src/snapshots/codex_tui__history_cell__tests__session_info_availability_nux_tooltip_snapshot.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__history_cell__tests__session_info_availability_nux_tooltip_snapshot.snap
@@ -3,11 +3,12 @@ source: tui/src/history_cell.rs
 assertion_line: 2608
 expression: rendered
 ---
-╭─────────────────────────────────────╮
-│ >_ OpenAI Codex (v0.0.0)            │
-│                                     │
-│ model:     gpt-5   /model to change │
-│ directory: /tmp/project             │
-╰─────────────────────────────────────╯
+╭───────────────────────────────────────╮
+│ >_ OpenAI Codex (v0.0.0)              │
+│                                       │
+│ model:     gpt-5   /model to change   │
+│ speed:     Standard   /fast to change │
+│ directory: /tmp/project               │
+╰───────────────────────────────────────╯
 
   Tip: Model just became available

--- a/codex-rs/tui/src/snapshots/codex_tui__history_cell__tests__session_info_availability_nux_tooltip_snapshot.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__history_cell__tests__session_info_availability_nux_tooltip_snapshot.snap
@@ -1,14 +1,14 @@
 ---
 source: tui/src/history_cell.rs
-assertion_line: 2608
+assertion_line: 2650
 expression: rendered
 ---
-╭───────────────────────────────────────╮
-│ >_ OpenAI Codex (v0.0.0)              │
-│                                       │
-│ model:     gpt-5   /model to change   │
-│ speed:     Standard   /fast to change │
-│ directory: /tmp/project               │
-╰───────────────────────────────────────╯
+╭────────────────────────────────────────╮
+│ >_ OpenAI Codex (v0.0.0)               │
+│                                        │
+│ model:     gpt-5      /model to change │
+│ speed:     Standard   /fast to change  │
+│ directory: /tmp/project                │
+╰────────────────────────────────────────╯
 
   Tip: Model just became available

--- a/codex-rs/tui/src/snapshots/codex_tui__history_cell__tests__session_info_availability_nux_tooltip_snapshot.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__history_cell__tests__session_info_availability_nux_tooltip_snapshot.snap
@@ -7,7 +7,7 @@ expression: rendered
 │ >_ OpenAI Codex (v0.0.0)               │
 │                                        │
 │ model:     gpt-5      /model to change │
-│ speed:     Standard   /fast to change  │
+│ speed:     standard   /fast to change  │
 │ directory: /tmp/project                │
 ╰────────────────────────────────────────╯
 


### PR DESCRIPTION
## Summary
- include service tier in running-thread resume mismatch warnings
- add a unit test covering the missing service tier mismatch case

## Testing
- cargo test --manifest-path /Users/pash/code/codex/codex-rs/Cargo.toml -p codex-app-server collect_resume_override_mismatches_includes_service_tier