### PR TITLE
Log non-audio realtime events

### DIFF
--- a/codex-rs/core/src/realtime_conversation.rs
+++ b/codex-rs/core/src/realtime_conversation.rs
@@ -326,7 +326,13 @@ pub(crate) async fn handle_start(
             msg,
         };
         while let Ok(event) = events_rx.recv().await {
-            debug!(conversation_id = %sess_clone.conversation_id, "received realtime conversation event");
+            // if not audio out, log the event
+            if !matches!(event, RealtimeEvent::AudioOut(_)) {
+                info!(
+                    event = ?event,
+                    "received realtime conversation event"
+                );
+            }
             let maybe_routed_text = match &event {
                 RealtimeEvent::HandoffRequested(handoff) => {
                     realtime_text_from_handoff_request(handoff)


### PR DESCRIPTION
Improve observability of realtime conversation event handling by logging non-audio events with payload details in the event loop, while skipping audio-out events to reduce noise.