### PR TITLE
Reduce realtime audio submission log noise

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -124,6 +124,7 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
 use tracing::debug;
+use tracing::debug_span;
 use tracing::error;
 use tracing::field;
 use tracing::info;
@@ -3890,7 +3891,12 @@ async fn submission_loop(sess: Arc<Session>, config: Arc<Config>, rx_sub: Receiv
 }
 
 fn submission_dispatch_span(sub: &Submission) -> tracing::Span {
-    let dispatch_span = info_span!("submission_dispatch", submission.id = sub.id.as_str());
+    let dispatch_span = match &sub.op {
+        Op::RealtimeConversationAudio(_) => {
+            debug_span!("submission_dispatch", submission.id = sub.id.as_str())
+        }
+        _ => info_span!("submission_dispatch", submission.id = sub.id.as_str()),
+    };
     if let Some(trace) = sub.trace.as_ref()
         && !set_parent_from_w3c_trace_context(&dispatch_span, trace)
     {
@@ -8576,6 +8582,29 @@ mod tests {
         assert_eq!(
             trace_id,
             TraceId::from_hex("00000000000000000000000000000055").expect("trace id")
+        );
+    }
+
+    #[test]
+    fn submission_dispatch_span_uses_debug_for_realtime_audio() {
+        init_test_tracing();
+
+        let dispatch_span = submission_dispatch_span(&Submission {
+            id: "sub-1".into(),
+            op: Op::RealtimeConversationAudio(ConversationAudioParams {
+                frame: RealtimeAudioFrame {
+                    data: "ZmFrZQ==".into(),
+                    sample_rate: 16_000,
+                    num_channels: 1,
+                    samples_per_channel: Some(160),
+                },
+            }),
+            trace: None,
+        });
+
+        assert_eq!(
+            dispatch_span.metadata().expect("span metadata").level(),
+            &tracing::Level::DEBUG
         );
     }
 

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -6678,6 +6678,8 @@ mod tests {
     use codex_protocol::models::ResponseInputItem;
     use codex_protocol::models::ResponseItem;
     use codex_protocol::openai_models::ModelsResponse;
+    use codex_protocol::protocol::ConversationAudioParams;
+    use codex_protocol::protocol::RealtimeAudioFrame;
     use codex_protocol::protocol::Submission;
     use codex_protocol::protocol::W3cTraceContext;
     use opentelemetry::trace::TraceContextExt;


### PR DESCRIPTION
- lower `submission_dispatch` span logging to debug for realtime audio submissions only
- keep other submission spans at info and add a targeted test for the level selection