### PR TITLE
Fix error conversion in exec fork path resolution

### DIFF
--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -858,9 +858,13 @@ async fn resolve_thread_path_by_id_or_name(
     id_or_name: &str,
 ) -> anyhow::Result<Option<PathBuf>> {
     if Uuid::parse_str(id_or_name).is_ok() {
-        find_thread_path_by_id_str(&config.codex_home, id_or_name).await
+        find_thread_path_by_id_str(&config.codex_home, id_or_name)
+            .await
+            .map_err(anyhow::Error::from)
     } else {
-        find_thread_path_by_name_str(&config.codex_home, id_or_name).await
+        find_thread_path_by_name_str(&config.codex_home, id_or_name)
+            .await
+            .map_err(anyhow::Error::from)
     }
 }
 


### PR DESCRIPTION
### Motivation
- Fix a type mismatch that caused `codex-exec` to fail compiling when resolving a fork/resume target path because underlying `std::io::Error` results were returned from helpers while the caller expected `anyhow::Error`.

### Description
- Update `resolve_thread_path_by_id_or_name` in `codex-rs/exec/src/lib.rs` to convert the `std::io::Error` returned by `find_thread_path_by_id_str` and `find_thread_path_by_name_str` into `anyhow::Error` using `.map_err(anyhow::Error::from)`, so the function returns `anyhow::Result<Option<PathBuf>>` consistently.

### Testing
- Ran `just fmt` in `codex-rs`, which completed successfully. 
- Attempted `cargo test -p codex-exec`, but the build could not complete in this environment because `codex-linux-sandbox` requires the system `libcap` library (pkg-config could not find `libcap.pc`), so the test suite did not finish.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_69a92230d0c08323b0417fbae810e6e0)