### PR TITLE
[MCP] Add support for cimd oauth authorization

### DIFF
--- a/codex-rs/README.md
+++ b/codex-rs/README.md
@@ -32,6 +32,8 @@ Codex supports a rich set of configuration options. Note that the Rust CLI uses 
 
 Codex CLI functions as an MCP client that allows the Codex CLI and IDE extension to connect to MCP servers on startup. See the [`configuration documentation`](../docs/config.md#connecting-to-mcp-servers) for details.
 
+For OAuth MCP servers that disable dynamic client registration but support Client ID Metadata Documents (SEP-991/CIMD), Codex automatically retries login with its built-in client metadata document at [`client-metadata.json`](./client-metadata.json). By default, Codex binds the local OAuth callback listener to `127.0.0.1:33418` so the redirect URI matches the built-in metadata document.
+
 #### MCP server (experimental)
 
 Codex can be launched as an MCP _server_ by running `codex mcp-server`. This allows _other_ MCP clients to use Codex as a tool for another agent.

--- a/codex-rs/client-metadata.json
+++ b/codex-rs/client-metadata.json
@@ -1,0 +1,19 @@
+{
+  "client_name": "Codex",
+  "grant_types": [
+    "authorization_code",
+    "refresh_token",
+    "urn:ietf:params:oauth:grant-type:device_code"
+  ],
+  "response_types": [
+    "code"
+  ],
+  "token_endpoint_auth_method": "none",
+  "application_type": "native",
+  "client_id": "https://raw.githubusercontent.com/openai/codex/main/codex-rs/client-metadata.json",
+  "client_uri": "https://github.com/openai/codex",
+  "redirect_uris": [
+    "http://127.0.0.1:33418/",
+    "http://127.0.0.1:33418/callback"
+  ]
+}

--- a/codex-rs/rmcp-client/src/perform_oauth_login.rs
+++ b/codex-rs/rmcp-client/src/perform_oauth_login.rs
@@ -364,27 +364,32 @@ fn callback_path_from_redirect_uri(redirect_uri: &str) -> Result<String> {
     Ok(parsed.path().to_string())
 }
 
+fn uses_default_cimd_redirect_uri(redirect_uri: &str) -> bool {
+    matches!(
+        redirect_uri,
+        DEFAULT_CIMD_REDIRECT_URI_ROOT | DEFAULT_CIMD_REDIRECT_URI_CALLBACK
+    )
+}
+
 fn validate_callback_listener_settings(
     callback_port: Option<u16>,
     callback_url: Option<&str>,
 ) -> Result<()> {
-    let Some(callback_port) = callback_port else {
-        return Ok(());
-    };
     let Some(callback_url) = callback_url else {
         return Ok(());
     };
-    let parsed = Url::parse(callback_url)
-        .with_context(|| format!("invalid MCP OAuth callback URL `{callback_url}`"))?;
-    let Some(callback_url_port) = parsed.port() else {
+    if !uses_default_cimd_redirect_uri(callback_url) {
+        return Ok(());
+    };
+    let Some(callback_port) = callback_port else {
         return Ok(());
     };
 
-    if callback_url_port == callback_port {
+    if callback_port == DEFAULT_CIMD_CALLBACK_PORT {
         Ok(())
     } else {
         Err(anyhow!(
-            "MCP OAuth callback URL `{callback_url}` uses port `{callback_url_port}` but `mcp_oauth_callback_port` is set to `{callback_port}`"
+            "MCP OAuth callback URL `{callback_url}` is a built-in Codex client metadata redirect URI, so `mcp_oauth_callback_port` must be `{DEFAULT_CIMD_CALLBACK_PORT}` or unset"
         ))
     }
 }
@@ -473,12 +478,16 @@ impl OauthLoginFlow {
         let supports_default_cimd_metadata = client_id_metadata_document_supported(&metadata);
         let callback_port_is_explicitly_set = callback_port.is_some();
         let callback_url_is_explicitly_set = callback_url.is_some();
+        let callback_url_uses_default_cimd_redirect = callback_url
+            .map(uses_default_cimd_redirect_uri)
+            .unwrap_or(false);
         let should_rebind_callback_for_cimd_fallback =
             !callback_port_is_explicitly_set && !callback_url_is_explicitly_set;
+        let should_bind_to_default_cimd_port = should_start_with_default_cimd_metadata
+            || (!callback_port_is_explicitly_set && callback_url_uses_default_cimd_redirect);
 
         let bind_host = callback_bind_host(callback_url);
-        let callback_port =
-            resolve_callback_port(callback_port, should_start_with_default_cimd_metadata)?;
+        let callback_port = resolve_callback_port(callback_port, should_bind_to_default_cimd_port)?;
         let mut callback_listener =
             start_callback_listener(&bind_host, callback_port, callback_url)?;
 
@@ -498,28 +507,16 @@ impl OauthLoginFlow {
                     && supports_default_cimd_metadata
                     && matches!(dynamic_registration_err, AuthError::RegistrationFailed(_)) =>
             {
-                let redirect_uri_is_compatible_with_default_cimd_metadata =
-                    validate_redirect_uri_for_default_cimd_metadata(
-                        &callback_listener.redirect_uri,
-                    )
-                    .is_ok();
-                let should_rebind_for_compatible_explicit_callback_url =
-                    !callback_port_is_explicitly_set
-                        && callback_url_is_explicitly_set
-                        && redirect_uri_is_compatible_with_default_cimd_metadata;
                 if should_rebind_callback_listener_for_cimd_fallback(
                     should_rebind_callback_for_cimd_fallback,
                     &callback_listener.redirect_uri,
-                ) || should_rebind_for_compatible_explicit_callback_url
-                {
-                    let explicit_callback_url = should_rebind_for_compatible_explicit_callback_url
-                        .then_some(callback_listener.redirect_uri.clone());
+                ) {
                     callback_listener = start_callback_listener(
                         "127.0.0.1",
                         Some(default_cimd_callback_port_nonzero().context(
                             "invalid built-in CIMD callback port for fallback listener",
                         )?),
-                        explicit_callback_url.as_deref(),
+                        None,
                     )
                     .context("failed to rebind OAuth callback listener for CIMD fallback")?;
                 } else if callback_port_is_explicitly_set || callback_url_is_explicitly_set {
@@ -710,10 +707,7 @@ fn client_id_metadata_document_supported(metadata: &AuthorizationMetadata) -> bo
 }
 
 fn validate_redirect_uri_for_default_cimd_metadata(redirect_uri: &str) -> Result<()> {
-    if matches!(
-        redirect_uri,
-        DEFAULT_CIMD_REDIRECT_URI_ROOT | DEFAULT_CIMD_REDIRECT_URI_CALLBACK
-    ) {
+    if uses_default_cimd_redirect_uri(redirect_uri) {
         Ok(())
     } else {
         Err(anyhow!(

--- a/codex-rs/rmcp-client/src/perform_oauth_login.rs
+++ b/codex-rs/rmcp-client/src/perform_oauth_login.rs
@@ -303,7 +303,7 @@ struct OauthLoginFlow {
 struct CallbackListener {
     guard: CallbackServerGuard,
     redirect_uri: String,
-    rx: oneshot::Receiver<(String, String)>,
+    rx: oneshot::Receiver<CallbackResult>,
 }
 
 fn default_cimd_callback_port_nonzero() -> Result<NonZeroU16> {
@@ -742,6 +742,5 @@ fn append_query_param(url: &str, key: &str, value: Option<&str>) -> String {
 }
 
 #[cfg(test)]
-
 #[path = "perform_oauth_login.rs_tests.rs"]
 mod tests;

--- a/codex-rs/rmcp-client/src/perform_oauth_login.rs
+++ b/codex-rs/rmcp-client/src/perform_oauth_login.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::num::NonZeroU16;
 use std::string::String;
 use std::sync::Arc;
 use std::time::Duration;
@@ -9,6 +10,9 @@ use anyhow::anyhow;
 use anyhow::bail;
 use reqwest::ClientBuilder;
 use reqwest::Url;
+use rmcp::transport::auth::AuthError;
+use rmcp::transport::auth::AuthorizationManager;
+use rmcp::transport::auth::AuthorizationMetadata;
 use rmcp::transport::auth::OAuthState;
 use tiny_http::Response;
 use tiny_http::Server;
@@ -23,6 +27,18 @@ use crate::oauth::compute_expires_at_millis;
 use crate::save_oauth_tokens;
 use crate::utils::apply_default_headers;
 use crate::utils::build_default_headers;
+
+/// Built-in Client ID Metadata Document used for SEP-991/CIMD fallback.
+///
+/// This intentionally tracks the `main` branch so clients can pick up metadata updates
+/// without requiring a binary release.
+const DEFAULT_CIMD_CLIENT_METADATA_URL: &str =
+    "https://raw.githubusercontent.com/openai/codex/main/codex-rs/client-metadata.json";
+const CLIENT_ID_METADATA_DOCUMENT_SUPPORTED_FIELD: &str = "client_id_metadata_document_supported";
+/// Fixed loopback callback port required by Codex's built-in CIMD redirect URIs.
+const DEFAULT_CIMD_CALLBACK_PORT: u16 = 33418;
+const DEFAULT_CIMD_REDIRECT_URI_ROOT: &str = "http://127.0.0.1:33418/";
+const DEFAULT_CIMD_REDIRECT_URI_CALLBACK: &str = "http://127.0.0.1:33418/callback";
 
 struct OauthHeaders {
     http_headers: Option<HashMap<String, String>>,
@@ -284,17 +300,36 @@ struct OauthLoginFlow {
     timeout: Duration,
 }
 
-fn resolve_callback_port(callback_port: Option<u16>) -> Result<Option<u16>> {
-    if let Some(config_port) = callback_port {
-        if config_port == 0 {
-            bail!(
-                "invalid MCP OAuth callback port `{config_port}`: port must be between 1 and 65535"
-            );
-        }
-        return Ok(Some(config_port));
+struct CallbackListener {
+    guard: CallbackServerGuard,
+    redirect_uri: String,
+    rx: oneshot::Receiver<(String, String)>,
+}
+
+fn default_cimd_callback_port_nonzero() -> Result<NonZeroU16> {
+    NonZeroU16::new(DEFAULT_CIMD_CALLBACK_PORT).ok_or_else(|| {
+        anyhow!(
+            "invalid built-in CIMD callback port `{DEFAULT_CIMD_CALLBACK_PORT}`: port must be between 1 and 65535"
+        )
+    })
+}
+
+fn resolve_callback_port(
+    callback_port: Option<u16>,
+    use_default_cimd_metadata: bool,
+) -> Result<Option<NonZeroU16>> {
+    if let Some(port) = callback_port {
+        let Some(port) = NonZeroU16::new(port) else {
+            bail!("invalid MCP OAuth callback port `{port}`: port must be between 1 and 65535");
+        };
+        return Ok(Some(port));
     }
 
-    Ok(None)
+    if use_default_cimd_metadata {
+        Ok(Some(default_cimd_callback_port_nonzero()?))
+    } else {
+        Ok(None)
+    }
 }
 
 fn local_redirect_uri(server: &Server) -> Result<String> {
@@ -329,19 +364,82 @@ fn callback_path_from_redirect_uri(redirect_uri: &str) -> Result<String> {
     Ok(parsed.path().to_string())
 }
 
-fn callback_bind_host(callback_url: Option<&str>) -> &'static str {
+fn validate_callback_listener_settings(
+    callback_port: Option<u16>,
+    callback_url: Option<&str>,
+) -> Result<()> {
+    let Some(callback_port) = callback_port else {
+        return Ok(());
+    };
     let Some(callback_url) = callback_url else {
-        return "127.0.0.1";
+        return Ok(());
+    };
+    let parsed = Url::parse(callback_url)
+        .with_context(|| format!("invalid MCP OAuth callback URL `{callback_url}`"))?;
+    let Some(callback_url_port) = parsed.port() else {
+        return Ok(());
+    };
+
+    if callback_url_port == callback_port {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "MCP OAuth callback URL `{callback_url}` uses port `{callback_url_port}` but `mcp_oauth_callback_port` is set to `{callback_port}`"
+        ))
+    }
+}
+
+fn callback_bind_host(callback_url: Option<&str>) -> String {
+    let Some(callback_url) = callback_url else {
+        return "127.0.0.1".to_string();
     };
 
     let Ok(parsed) = Url::parse(callback_url) else {
-        return "127.0.0.1";
+        return "127.0.0.1".to_string();
     };
 
-    match parsed.host_str() {
-        Some("localhost" | "127.0.0.1" | "::1") | None => "127.0.0.1",
-        Some(_) => "0.0.0.0",
+    let Some(host) = parsed.host_str() else {
+        return "127.0.0.1".to_string();
+    };
+
+    if host.eq_ignore_ascii_case("localhost") {
+        return "127.0.0.1".to_string();
     }
+    let host = host.trim_matches(['[', ']']);
+
+    match host.parse::<std::net::IpAddr>() {
+        Ok(std::net::IpAddr::V4(ip)) if ip.is_loopback() => ip.to_string(),
+        Ok(std::net::IpAddr::V6(ip)) if ip.is_loopback() => format!("[{ip}]"),
+        Ok(_) | Err(_) => "0.0.0.0".to_string(),
+    }
+}
+
+fn start_callback_listener(
+    bind_host: &str,
+    callback_port: Option<NonZeroU16>,
+    callback_url: Option<&str>,
+) -> Result<CallbackListener> {
+    let bind_addr = match callback_port {
+        Some(port) => format!("{bind_host}:{}", port.get()),
+        None => format!("{bind_host}:0"),
+    };
+
+    let server = Arc::new(Server::http(&bind_addr).map_err(|err| anyhow!(err))?);
+    let guard = CallbackServerGuard {
+        server: Arc::clone(&server),
+    };
+
+    let redirect_uri = resolve_redirect_uri(&server, callback_url)?;
+    let callback_path = callback_path_from_redirect_uri(&redirect_uri)?;
+
+    let (tx, rx) = oneshot::channel();
+    spawn_callback_server(server, tx, callback_path);
+
+    Ok(CallbackListener {
+        guard,
+        redirect_uri,
+        rx,
+    })
 }
 
 impl OauthLoginFlow {
@@ -360,23 +458,7 @@ impl OauthLoginFlow {
     ) -> Result<Self> {
         const DEFAULT_OAUTH_TIMEOUT_SECS: i64 = 300;
 
-        let bind_host = callback_bind_host(callback_url);
-        let callback_port = resolve_callback_port(callback_port)?;
-        let bind_addr = match callback_port {
-            Some(port) => format!("{bind_host}:{port}"),
-            None => format!("{bind_host}:0"),
-        };
-
-        let server = Arc::new(Server::http(&bind_addr).map_err(|err| anyhow!(err))?);
-        let guard = CallbackServerGuard {
-            server: Arc::clone(&server),
-        };
-
-        let redirect_uri = resolve_redirect_uri(&server, callback_url)?;
-        let callback_path = callback_path_from_redirect_uri(&redirect_uri)?;
-
-        let (tx, rx) = oneshot::channel();
-        spawn_callback_server(server, tx, callback_path);
+        validate_callback_listener_settings(callback_port, callback_url)?;
 
         let OauthHeaders {
             http_headers,
@@ -384,12 +466,90 @@ impl OauthLoginFlow {
         } = headers;
         let default_headers = build_default_headers(http_headers, env_http_headers)?;
         let http_client = apply_default_headers(ClientBuilder::new(), &default_headers).build()?;
+        let metadata = discover_oauth_authorization_metadata(server_url, http_client.clone())
+            .await
+            .context("failed to discover OAuth authorization metadata")?;
+        let should_start_with_default_cimd_metadata = should_use_default_cimd_metadata(&metadata);
+        let supports_default_cimd_metadata = client_id_metadata_document_supported(&metadata);
+        let callback_port_is_explicitly_set = callback_port.is_some();
+        let callback_url_is_explicitly_set = callback_url.is_some();
+        let should_rebind_callback_for_cimd_fallback =
+            !callback_port_is_explicitly_set && !callback_url_is_explicitly_set;
 
-        let mut oauth_state = OAuthState::new(server_url, Some(http_client)).await?;
+        let bind_host = callback_bind_host(callback_url);
+        let callback_port =
+            resolve_callback_port(callback_port, should_start_with_default_cimd_metadata)?;
+        let mut callback_listener =
+            start_callback_listener(&bind_host, callback_port, callback_url)?;
+
         let scope_refs: Vec<&str> = scopes.iter().map(String::as_str).collect();
-        oauth_state
-            .start_authorization(&scope_refs, &redirect_uri, Some("Codex"))
-            .await?;
+        let oauth_state = match start_oauth_authorization(
+            server_url,
+            &http_client,
+            &scope_refs,
+            &callback_listener.redirect_uri,
+            should_start_with_default_cimd_metadata,
+        )
+        .await
+        {
+            Ok(oauth_state) => oauth_state,
+            Err(dynamic_registration_err)
+                if !should_start_with_default_cimd_metadata
+                    && supports_default_cimd_metadata
+                    && matches!(dynamic_registration_err, AuthError::RegistrationFailed(_)) =>
+            {
+                let redirect_uri_is_compatible_with_default_cimd_metadata =
+                    validate_redirect_uri_for_default_cimd_metadata(
+                        &callback_listener.redirect_uri,
+                    )
+                    .is_ok();
+                let should_rebind_for_compatible_explicit_callback_url =
+                    !callback_port_is_explicitly_set
+                        && callback_url_is_explicitly_set
+                        && redirect_uri_is_compatible_with_default_cimd_metadata;
+                if should_rebind_callback_listener_for_cimd_fallback(
+                    should_rebind_callback_for_cimd_fallback,
+                    &callback_listener.redirect_uri,
+                ) || should_rebind_for_compatible_explicit_callback_url
+                {
+                    let explicit_callback_url = should_rebind_for_compatible_explicit_callback_url
+                        .then_some(callback_listener.redirect_uri.clone());
+                    callback_listener = start_callback_listener(
+                        "127.0.0.1",
+                        Some(default_cimd_callback_port_nonzero().context(
+                            "invalid built-in CIMD callback port for fallback listener",
+                        )?),
+                        explicit_callback_url.as_deref(),
+                    )
+                    .context("failed to rebind OAuth callback listener for CIMD fallback")?;
+                } else if callback_port_is_explicitly_set || callback_url_is_explicitly_set {
+                    validate_redirect_uri_for_default_cimd_metadata(
+                        &callback_listener.redirect_uri,
+                    )?;
+                }
+
+                start_oauth_authorization(
+                    server_url,
+                    &http_client,
+                    &scope_refs,
+                    &callback_listener.redirect_uri,
+                    true,
+                )
+                .await
+                .map_err(anyhow::Error::from)
+                .context(
+                    "failed to start OAuth authorization with default client metadata URL after dynamic registration failed",
+                )?
+            }
+            Err(err) if should_start_with_default_cimd_metadata => {
+                return Err(anyhow::Error::from(err).context(
+                    "failed to start OAuth authorization with default client metadata URL",
+                ));
+            }
+            Err(err) => {
+                return Err(anyhow::Error::from(err).context("failed to start OAuth authorization"));
+            }
+        };
         let auth_url = append_query_param(
             &oauth_state.get_authorization_url().await?,
             "resource",
@@ -401,8 +561,8 @@ impl OauthLoginFlow {
         Ok(Self {
             auth_url,
             oauth_state,
-            rx,
-            guard,
+            rx: callback_listener.rx,
+            guard: callback_listener.guard,
             server_name: server_name.to_string(),
             server_url: server_url.to_string(),
             store_mode,
@@ -492,6 +652,84 @@ impl OauthLoginFlow {
     }
 }
 
+async fn start_oauth_authorization(
+    server_url: &str,
+    http_client: &reqwest::Client,
+    scope_refs: &[&str],
+    redirect_uri: &str,
+    use_default_cimd_metadata: bool,
+) -> std::result::Result<OAuthState, AuthError> {
+    let mut oauth_state = OAuthState::new(server_url, Some(http_client.clone())).await?;
+
+    if use_default_cimd_metadata {
+        validate_redirect_uri_for_default_cimd_metadata(redirect_uri)
+            .map_err(|err| AuthError::InternalError(err.to_string()))?;
+        oauth_state
+            .start_authorization_with_metadata_url(
+                scope_refs,
+                redirect_uri,
+                Some("Codex"),
+                Some(DEFAULT_CIMD_CLIENT_METADATA_URL),
+            )
+            .await?;
+    } else {
+        oauth_state
+            .start_authorization(scope_refs, redirect_uri, Some("Codex"))
+            .await?;
+    }
+
+    Ok(oauth_state)
+}
+
+async fn discover_oauth_authorization_metadata(
+    server_url: &str,
+    http_client: reqwest::Client,
+) -> Result<AuthorizationMetadata> {
+    let mut manager = AuthorizationManager::new(server_url)
+        .await
+        .context("failed to create OAuth authorization manager")?;
+    manager
+        .with_client(http_client)
+        .context("failed to configure OAuth HTTP client")?;
+    manager
+        .discover_metadata()
+        .await
+        .context("failed to discover OAuth server metadata")
+}
+
+fn should_use_default_cimd_metadata(metadata: &AuthorizationMetadata) -> bool {
+    metadata.registration_endpoint.is_none() && client_id_metadata_document_supported(metadata)
+}
+
+fn client_id_metadata_document_supported(metadata: &AuthorizationMetadata) -> bool {
+    metadata
+        .additional_fields
+        .get(CLIENT_ID_METADATA_DOCUMENT_SUPPORTED_FIELD)
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
+}
+
+fn validate_redirect_uri_for_default_cimd_metadata(redirect_uri: &str) -> Result<()> {
+    if matches!(
+        redirect_uri,
+        DEFAULT_CIMD_REDIRECT_URI_ROOT | DEFAULT_CIMD_REDIRECT_URI_CALLBACK
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "MCP OAuth callback URL `{redirect_uri}` is incompatible with built-in Codex client metadata; use `{DEFAULT_CIMD_REDIRECT_URI_ROOT}` or `{DEFAULT_CIMD_REDIRECT_URI_CALLBACK}`"
+        ))
+    }
+}
+
+fn should_rebind_callback_listener_for_cimd_fallback(
+    should_rebind_callback_for_cimd_fallback: bool,
+    redirect_uri: &str,
+) -> bool {
+    should_rebind_callback_for_cimd_fallback
+        && validate_redirect_uri_for_default_cimd_metadata(redirect_uri).is_err()
+}
+
 fn append_query_param(url: &str, key: &str, value: Option<&str>) -> String {
     let Some(value) = value else {
         return url.to_string();
@@ -510,85 +748,6 @@ fn append_query_param(url: &str, key: &str, value: Option<&str>) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use pretty_assertions::assert_eq;
 
-    use super::CallbackOutcome;
-    use super::OAuthProviderError;
-    use super::append_query_param;
-    use super::callback_path_from_redirect_uri;
-    use super::parse_oauth_callback;
-
-    #[test]
-    fn parse_oauth_callback_accepts_default_path() {
-        let parsed = parse_oauth_callback("/callback?code=abc&state=xyz", "/callback");
-        assert!(matches!(parsed, CallbackOutcome::Success(_)));
-    }
-
-    #[test]
-    fn parse_oauth_callback_accepts_custom_path() {
-        let parsed = parse_oauth_callback("/oauth/callback?code=abc&state=xyz", "/oauth/callback");
-        assert!(matches!(parsed, CallbackOutcome::Success(_)));
-    }
-
-    #[test]
-    fn parse_oauth_callback_rejects_wrong_path() {
-        let parsed = parse_oauth_callback("/callback?code=abc&state=xyz", "/oauth/callback");
-        assert!(matches!(parsed, CallbackOutcome::Invalid));
-    }
-
-    #[test]
-    fn parse_oauth_callback_returns_provider_error() {
-        let parsed = parse_oauth_callback(
-            "/callback?error=invalid_scope&error_description=scope%20rejected",
-            "/callback",
-        );
-
-        assert_eq!(
-            parsed,
-            CallbackOutcome::Error(OAuthProviderError::new(
-                Some("invalid_scope".to_string()),
-                Some("scope rejected".to_string()),
-            ))
-        );
-    }
-
-    #[test]
-    fn callback_path_comes_from_redirect_uri() {
-        let path = callback_path_from_redirect_uri("https://example.com/oauth/callback")
-            .expect("redirect URI should parse");
-        assert_eq!(path, "/oauth/callback");
-    }
-
-    #[test]
-    fn append_query_param_adds_resource_to_absolute_url() {
-        let url = append_query_param(
-            "https://example.com/authorize?scope=read",
-            "resource",
-            Some("https://api.example.com"),
-        );
-
-        assert_eq!(
-            url,
-            "https://example.com/authorize?scope=read&resource=https%3A%2F%2Fapi.example.com"
-        );
-    }
-
-    #[test]
-    fn append_query_param_ignores_empty_values() {
-        let url = append_query_param(
-            "https://example.com/authorize?scope=read",
-            "resource",
-            Some("   "),
-        );
-
-        assert_eq!(url, "https://example.com/authorize?scope=read");
-    }
-
-    #[test]
-    fn append_query_param_handles_unparseable_url() {
-        let url = append_query_param("not a url", "resource", Some("api/resource"));
-
-        assert_eq!(url, "not a url?resource=api%2Fresource");
-    }
-}
+#[path = "perform_oauth_login.rs_tests.rs"]
+mod tests;

--- a/codex-rs/rmcp-client/src/perform_oauth_login.rs_tests.rs
+++ b/codex-rs/rmcp-client/src/perform_oauth_login.rs_tests.rs
@@ -14,11 +14,11 @@ use tokio::task::JoinHandle;
 
 use super::CLIENT_ID_METADATA_DOCUMENT_SUPPORTED_FIELD;
 use super::CallbackOutcome;
-use super::OAuthProviderError;
 use super::DEFAULT_CIMD_CLIENT_METADATA_URL;
 use super::DEFAULT_CIMD_REDIRECT_URI_CALLBACK;
 use super::DEFAULT_CIMD_REDIRECT_URI_ROOT;
 use super::OAuthCredentialsStoreMode;
+use super::OAuthProviderError;
 use super::append_query_param;
 use super::callback_bind_host;
 use super::callback_path_from_redirect_uri;
@@ -226,24 +226,6 @@ fn cimd_support_requires_metadata_flag_and_missing_registration_endpoint() {
 }
 
 #[test]
-fn parse_oauth_callback_accepts_default_path() {
-    let parsed = parse_oauth_callback("/callback?code=abc&state=xyz", "/callback");
-    assert!(matches!(parsed, CallbackOutcome::Success(_)));
-}
-
-#[test]
-fn parse_oauth_callback_accepts_custom_path() {
-    let parsed = parse_oauth_callback("/oauth/callback?code=abc&state=xyz", "/oauth/callback");
-    assert!(matches!(parsed, CallbackOutcome::Success(_)));
-}
-
-#[test]
-fn parse_oauth_callback_rejects_wrong_path() {
-    let parsed = parse_oauth_callback("/callback?code=abc&state=xyz", "/oauth/callback");
-    assert!(matches!(parsed, CallbackOutcome::Invalid));
-}
-
-#[test]
 fn parse_oauth_callback_returns_provider_error() {
     let parsed = parse_oauth_callback(
         "/callback?error=invalid_scope&error_description=scope%20rejected",
@@ -257,45 +239,6 @@ fn parse_oauth_callback_returns_provider_error() {
             Some("scope rejected".to_string()),
         ))
     );
-}
-
-#[test]
-fn callback_path_comes_from_redirect_uri() {
-    let path = callback_path_from_redirect_uri("https://example.com/oauth/callback")
-        .expect("redirect URI should parse");
-    assert_eq!(path, "/oauth/callback");
-}
-
-#[test]
-fn append_query_param_adds_resource_to_absolute_url() {
-    let url = append_query_param(
-        "https://example.com/authorize?scope=read",
-        "resource",
-        Some("https://api.example.com"),
-    );
-
-    assert_eq!(
-        url,
-        "https://example.com/authorize?scope=read&resource=https%3A%2F%2Fapi.example.com"
-    );
-}
-
-#[test]
-fn append_query_param_ignores_empty_values() {
-    let url = append_query_param(
-        "https://example.com/authorize?scope=read",
-        "resource",
-        Some("   "),
-    );
-
-    assert_eq!(url, "https://example.com/authorize?scope=read");
-}
-
-#[test]
-fn append_query_param_handles_unparseable_url() {
-    let url = append_query_param("not a url", "resource", Some("api/resource"));
-
-    assert_eq!(url, "not a url?resource=api%2Fresource");
 }
 
 #[tokio::test]

--- a/codex-rs/rmcp-client/src/perform_oauth_login.rs_tests.rs
+++ b/codex-rs/rmcp-client/src/perform_oauth_login.rs_tests.rs
@@ -137,7 +137,17 @@ fn callback_port_defaults_to_cimd_port_for_cimd_metadata() {
 }
 
 #[test]
-fn callback_listener_settings_allow_matching_explicit_port() {
+fn callback_listener_settings_allow_proxied_callback_url_with_different_local_port() {
+    let result = validate_callback_listener_settings(
+        Some(5678),
+        Some("https://login.example.com:8443/callback"),
+    );
+
+    assert_eq!(result.is_ok(), true);
+}
+
+#[test]
+fn callback_listener_settings_allow_matching_explicit_port_for_cimd_callback_url() {
     let result =
         validate_callback_listener_settings(Some(33418), Some(DEFAULT_CIMD_REDIRECT_URI_CALLBACK));
 
@@ -145,14 +155,13 @@ fn callback_listener_settings_allow_matching_explicit_port() {
 }
 
 #[test]
-fn callback_listener_settings_reject_conflicting_explicit_port() {
+fn callback_listener_settings_reject_non_default_port_for_cimd_callback_url() {
     let err =
         validate_callback_listener_settings(Some(5678), Some(DEFAULT_CIMD_REDIRECT_URI_CALLBACK))
-            .expect_err("conflicting callback URL and port should be rejected");
+            .expect_err("built-in CIMD callback URL should reject non-default port");
 
     assert!(
-        err.to_string()
-            .contains("`mcp_oauth_callback_port` is set to `5678`"),
+        err.to_string().contains("must be `33418` or unset"),
         "unexpected callback listener settings error: {err:#}"
     );
 }
@@ -382,12 +391,55 @@ async fn oauth_login_rejects_conflicting_explicit_callback_url_and_port_for_non_
     )
     .await
     .err()
-    .expect("oauth login should fail when callback URL and port conflict");
+    .expect("oauth login should fail when built-in CIMD callback URL uses a non-default port");
 
     assert!(
-        err.to_string()
-            .contains("`mcp_oauth_callback_port` is set to `5678`"),
+        err.to_string().contains("must be `33418` or unset"),
         "unexpected oauth setup error: {err:#}"
+    );
+
+    server_handle.abort();
+}
+
+#[tokio::test]
+async fn oauth_login_allows_proxied_callback_url_with_different_local_port() {
+    let _lock = callback_port_test_lock().lock().await;
+    let (server_url, server_handle) = start_oauth_metadata_server(false, true, false).await;
+    let local_callback_port = available_loopback_port();
+
+    let login_handle = perform_oauth_login_return_url(
+        "rmcp-http",
+        &server_url,
+        OAuthCredentialsStoreMode::File,
+        None,
+        None,
+        &[],
+        None,
+        Some(1),
+        Some(local_callback_port),
+        Some("https://login.example.com:8443/callback"),
+    )
+    .await
+    .expect("oauth login should start for proxied callback URL");
+    let (authorization_url, completion) = login_handle.into_parts();
+
+    let parsed = Url::parse(&authorization_url).expect("authorization URL should parse");
+    let params = parsed
+        .query_pairs()
+        .collect::<std::collections::HashMap<_, _>>();
+    assert_eq!(
+        params.get("redirect_uri").map(std::convert::AsRef::as_ref),
+        Some("https://login.example.com:8443/callback")
+    );
+
+    let err = completion
+        .await
+        .expect("oauth completion receiver should resolve")
+        .expect_err("oauth should time out in test without proxy callback");
+    assert!(
+        err.to_string()
+            .contains("timed out waiting for OAuth callback"),
+        "unexpected oauth completion error: {err}"
     );
 
     server_handle.abort();
@@ -547,6 +599,72 @@ async fn oauth_login_fallback_rebinds_compatible_explicit_callback_without_port(
     )
     .await
     .expect("oauth login should start with compatible explicit callback URL");
+    let (authorization_url, completion) = login_handle.into_parts();
+
+    let parsed = Url::parse(&authorization_url).expect("authorization URL should parse");
+    let params = parsed
+        .query_pairs()
+        .collect::<std::collections::HashMap<_, _>>();
+    assert_eq!(
+        params.get("redirect_uri").map(std::convert::AsRef::as_ref),
+        Some(DEFAULT_CIMD_REDIRECT_URI_CALLBACK)
+    );
+    let state = params
+        .get("state")
+        .map(std::convert::AsRef::as_ref)
+        .expect("authorization URL should include state");
+
+    let mut callback_url =
+        Url::parse(DEFAULT_CIMD_REDIRECT_URI_CALLBACK).expect("callback URL should parse");
+    callback_url
+        .query_pairs_mut()
+        .append_pair("code", "test-code")
+        .append_pair("state", state);
+    let callback_response = reqwest::get(callback_url)
+        .await
+        .expect("callback request should reach local listener");
+    assert_eq!(callback_response.status(), StatusCode::OK);
+    let callback_response_body = callback_response
+        .text()
+        .await
+        .expect("callback response body should be readable");
+    assert_eq!(
+        callback_response_body,
+        "Authentication complete. You may close this window."
+    );
+
+    let err = tokio::time::timeout(Duration::from_secs(5), completion)
+        .await
+        .expect("oauth completion should resolve after callback")
+        .expect("oauth completion receiver should resolve")
+        .expect_err("oauth completion should fail in test without token endpoint");
+    assert!(
+        err.to_string().contains("failed to handle OAuth callback"),
+        "unexpected oauth completion error: {err:#}"
+    );
+
+    server_handle.abort();
+}
+
+#[tokio::test]
+async fn oauth_login_dynamic_registration_uses_default_port_for_explicit_cimd_callback() {
+    let _lock = callback_port_test_lock().lock().await;
+    let (server_url, server_handle) = start_oauth_metadata_server(true, true, false).await;
+
+    let login_handle = perform_oauth_login_return_url(
+        "rmcp-http",
+        &server_url,
+        OAuthCredentialsStoreMode::File,
+        None,
+        None,
+        &[],
+        None,
+        Some(1),
+        None,
+        Some(DEFAULT_CIMD_REDIRECT_URI_CALLBACK),
+    )
+    .await
+    .expect("oauth login should start with explicit built-in CIMD callback URL");
     let (authorization_url, completion) = login_handle.into_parts();
 
     let parsed = Url::parse(&authorization_url).expect("authorization URL should parse");

--- a/codex-rs/rmcp-client/src/perform_oauth_login.rs_tests.rs
+++ b/codex-rs/rmcp-client/src/perform_oauth_login.rs_tests.rs
@@ -1,0 +1,695 @@
+use axum::Json;
+use axum::Router;
+use axum::http::StatusCode;
+use axum::routing::get;
+use axum::routing::post;
+use pretty_assertions::assert_eq;
+use reqwest::Url;
+use serde_json::json;
+use std::io::ErrorKind;
+use std::net::TcpListener;
+use std::sync::OnceLock;
+use std::time::Duration;
+use tokio::task::JoinHandle;
+
+use super::CLIENT_ID_METADATA_DOCUMENT_SUPPORTED_FIELD;
+use super::CallbackOutcome;
+use super::OAuthProviderError;
+use super::DEFAULT_CIMD_CLIENT_METADATA_URL;
+use super::DEFAULT_CIMD_REDIRECT_URI_CALLBACK;
+use super::DEFAULT_CIMD_REDIRECT_URI_ROOT;
+use super::OAuthCredentialsStoreMode;
+use super::append_query_param;
+use super::callback_bind_host;
+use super::callback_path_from_redirect_uri;
+use super::client_id_metadata_document_supported;
+use super::parse_oauth_callback;
+use super::perform_oauth_login_return_url;
+use super::should_rebind_callback_listener_for_cimd_fallback;
+use super::should_use_default_cimd_metadata;
+use super::validate_callback_listener_settings;
+use super::validate_redirect_uri_for_default_cimd_metadata;
+use rmcp::transport::auth::AuthorizationMetadata;
+
+fn callback_port_test_lock() -> &'static tokio::sync::Mutex<()> {
+    static LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
+fn available_loopback_port() -> u16 {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).expect("ephemeral listener should bind");
+    listener
+        .local_addr()
+        .expect("listener should have local addr")
+        .port()
+}
+
+#[test]
+fn parse_oauth_callback_accepts_default_path() {
+    let parsed = parse_oauth_callback("/callback?code=abc&state=xyz", "/callback");
+    assert!(matches!(parsed, CallbackOutcome::Success(_)));
+}
+
+#[test]
+fn parse_oauth_callback_accepts_custom_path() {
+    let parsed = parse_oauth_callback("/oauth/callback?code=abc&state=xyz", "/oauth/callback");
+    assert!(matches!(parsed, CallbackOutcome::Success(_)));
+}
+
+#[test]
+fn parse_oauth_callback_rejects_wrong_path() {
+    let parsed = parse_oauth_callback("/callback?code=abc&state=xyz", "/oauth/callback");
+    assert!(matches!(parsed, CallbackOutcome::Invalid));
+}
+
+#[test]
+fn callback_path_comes_from_redirect_uri() {
+    let path = callback_path_from_redirect_uri("https://example.com/oauth/callback")
+        .expect("redirect URI should parse");
+    assert_eq!(path, "/oauth/callback");
+}
+
+#[test]
+fn callback_bind_host_preserves_ipv6_loopback() {
+    let bind_host = callback_bind_host(Some("http://[::1]:33418/callback"));
+    assert_eq!(bind_host, "[::1]");
+}
+
+#[test]
+fn callback_bind_host_preserves_ipv4_loopback_alias() {
+    let bind_host = callback_bind_host(Some("http://127.0.0.2:33418/callback"));
+    assert_eq!(bind_host, "127.0.0.2");
+}
+
+#[test]
+fn callback_bind_host_maps_localhost_to_ipv4_loopback() {
+    let bind_host = callback_bind_host(Some("http://localhost:33418/callback"));
+    assert_eq!(bind_host, "127.0.0.1");
+}
+
+#[test]
+fn append_query_param_adds_resource_to_absolute_url() {
+    let url = append_query_param(
+        "https://example.com/authorize?scope=read",
+        "resource",
+        Some("https://api.example.com"),
+    );
+
+    assert_eq!(
+        url,
+        "https://example.com/authorize?scope=read&resource=https%3A%2F%2Fapi.example.com"
+    );
+}
+
+#[test]
+fn append_query_param_ignores_empty_values() {
+    let url = append_query_param(
+        "https://example.com/authorize?scope=read",
+        "resource",
+        Some("   "),
+    );
+
+    assert_eq!(url, "https://example.com/authorize?scope=read");
+}
+
+#[test]
+fn append_query_param_handles_unparseable_url() {
+    let url = append_query_param("not a url", "resource", Some("api/resource"));
+
+    assert_eq!(url, "not a url?resource=api%2Fresource");
+}
+
+#[test]
+fn callback_port_defaults_to_ephemeral_for_non_cimd() {
+    let port =
+        super::resolve_callback_port(None, false).expect("default callback port should resolve");
+    assert_eq!(port.map(std::num::NonZeroU16::get), None);
+}
+
+#[test]
+fn callback_port_defaults_to_cimd_port_for_cimd_metadata() {
+    let port =
+        super::resolve_callback_port(None, true).expect("default callback port should resolve");
+    assert_eq!(
+        port.map(std::num::NonZeroU16::get),
+        Some(super::DEFAULT_CIMD_CALLBACK_PORT)
+    );
+}
+
+#[test]
+fn callback_listener_settings_allow_matching_explicit_port() {
+    let result =
+        validate_callback_listener_settings(Some(33418), Some(DEFAULT_CIMD_REDIRECT_URI_CALLBACK));
+
+    assert_eq!(result.is_ok(), true);
+}
+
+#[test]
+fn callback_listener_settings_reject_conflicting_explicit_port() {
+    let err =
+        validate_callback_listener_settings(Some(5678), Some(DEFAULT_CIMD_REDIRECT_URI_CALLBACK))
+            .expect_err("conflicting callback URL and port should be rejected");
+
+    assert!(
+        err.to_string()
+            .contains("`mcp_oauth_callback_port` is set to `5678`"),
+        "unexpected callback listener settings error: {err:#}"
+    );
+}
+
+#[test]
+fn default_cimd_redirect_uri_validation_accepts_supported_uris() {
+    let result_root =
+        validate_redirect_uri_for_default_cimd_metadata(DEFAULT_CIMD_REDIRECT_URI_ROOT);
+    let result_callback =
+        validate_redirect_uri_for_default_cimd_metadata(DEFAULT_CIMD_REDIRECT_URI_CALLBACK);
+
+    assert_eq!(result_root.is_ok(), true);
+    assert_eq!(result_callback.is_ok(), true);
+}
+
+#[test]
+fn default_cimd_redirect_uri_validation_rejects_other_uris() {
+    let err = validate_redirect_uri_for_default_cimd_metadata("http://127.0.0.1:43210/")
+        .expect_err("unexpected success for unsupported redirect URI");
+
+    assert!(
+        err.to_string()
+            .contains("incompatible with built-in Codex client metadata"),
+        "unexpected redirect validation error: {err:#}"
+    );
+}
+
+#[test]
+fn cimd_fallback_skips_rebind_when_existing_listener_is_compatible() {
+    let should_rebind =
+        should_rebind_callback_listener_for_cimd_fallback(true, DEFAULT_CIMD_REDIRECT_URI_CALLBACK);
+
+    assert_eq!(should_rebind, false);
+}
+
+#[test]
+fn cimd_fallback_rebinds_when_existing_listener_is_incompatible() {
+    let should_rebind =
+        should_rebind_callback_listener_for_cimd_fallback(true, "http://127.0.0.1:43210/");
+
+    assert_eq!(should_rebind, true);
+}
+
+#[test]
+fn cimd_fallback_never_rebinds_when_rebind_not_requested() {
+    let should_rebind =
+        should_rebind_callback_listener_for_cimd_fallback(false, "http://127.0.0.1:43210/");
+
+    assert_eq!(should_rebind, false);
+}
+
+#[test]
+fn cimd_support_requires_metadata_flag_and_missing_registration_endpoint() {
+    let supported = authorization_metadata(None, true);
+    let missing_flag = authorization_metadata(None, false);
+    let with_registration = authorization_metadata(Some("https://example.com/register"), true);
+
+    assert_eq!(client_id_metadata_document_supported(&supported), true);
+    assert_eq!(should_use_default_cimd_metadata(&supported), true);
+    assert_eq!(should_use_default_cimd_metadata(&missing_flag), false);
+    assert_eq!(should_use_default_cimd_metadata(&with_registration), false);
+}
+
+#[test]
+fn parse_oauth_callback_accepts_default_path() {
+    let parsed = parse_oauth_callback("/callback?code=abc&state=xyz", "/callback");
+    assert!(matches!(parsed, CallbackOutcome::Success(_)));
+}
+
+#[test]
+fn parse_oauth_callback_accepts_custom_path() {
+    let parsed = parse_oauth_callback("/oauth/callback?code=abc&state=xyz", "/oauth/callback");
+    assert!(matches!(parsed, CallbackOutcome::Success(_)));
+}
+
+#[test]
+fn parse_oauth_callback_rejects_wrong_path() {
+    let parsed = parse_oauth_callback("/callback?code=abc&state=xyz", "/oauth/callback");
+    assert!(matches!(parsed, CallbackOutcome::Invalid));
+}
+
+#[test]
+fn parse_oauth_callback_returns_provider_error() {
+    let parsed = parse_oauth_callback(
+        "/callback?error=invalid_scope&error_description=scope%20rejected",
+        "/callback",
+    );
+
+    assert_eq!(
+        parsed,
+        CallbackOutcome::Error(OAuthProviderError::new(
+            Some("invalid_scope".to_string()),
+            Some("scope rejected".to_string()),
+        ))
+    );
+}
+
+#[test]
+fn callback_path_comes_from_redirect_uri() {
+    let path = callback_path_from_redirect_uri("https://example.com/oauth/callback")
+        .expect("redirect URI should parse");
+    assert_eq!(path, "/oauth/callback");
+}
+
+#[test]
+fn append_query_param_adds_resource_to_absolute_url() {
+    let url = append_query_param(
+        "https://example.com/authorize?scope=read",
+        "resource",
+        Some("https://api.example.com"),
+    );
+
+    assert_eq!(
+        url,
+        "https://example.com/authorize?scope=read&resource=https%3A%2F%2Fapi.example.com"
+    );
+}
+
+#[test]
+fn append_query_param_ignores_empty_values() {
+    let url = append_query_param(
+        "https://example.com/authorize?scope=read",
+        "resource",
+        Some("   "),
+    );
+
+    assert_eq!(url, "https://example.com/authorize?scope=read");
+}
+
+#[test]
+fn append_query_param_handles_unparseable_url() {
+    let url = append_query_param("not a url", "resource", Some("api/resource"));
+
+    assert_eq!(url, "not a url?resource=api%2Fresource");
+}
+
+#[tokio::test]
+async fn oauth_login_uses_default_cimd_metadata_when_dynamic_registration_unsupported() {
+    let _lock = callback_port_test_lock().lock().await;
+    let (server_url, server_handle) = start_oauth_metadata_server(true, false, false).await;
+
+    let login_handle = perform_oauth_login_return_url(
+        "rmcp-http",
+        &server_url,
+        OAuthCredentialsStoreMode::File,
+        None,
+        None,
+        &[],
+        None,
+        Some(1),
+        None,
+        None,
+    )
+    .await
+    .expect("oauth login should start with default CIMD metadata URL");
+    let (authorization_url, completion) = login_handle.into_parts();
+
+    let parsed = Url::parse(&authorization_url).expect("authorization URL should parse");
+    let params = parsed
+        .query_pairs()
+        .collect::<std::collections::HashMap<_, _>>();
+    assert_eq!(
+        params.get("client_id").map(std::convert::AsRef::as_ref),
+        Some(DEFAULT_CIMD_CLIENT_METADATA_URL)
+    );
+
+    let err = completion
+        .await
+        .expect("oauth completion receiver should resolve")
+        .expect_err("oauth should time out in test without callback");
+    assert!(
+        err.to_string()
+            .contains("timed out waiting for OAuth callback"),
+        "unexpected oauth completion error: {err}"
+    );
+
+    server_handle.abort();
+}
+
+#[tokio::test]
+async fn oauth_login_rejects_incompatible_callback_for_default_cimd_metadata() {
+    let _lock = callback_port_test_lock().lock().await;
+    let (server_url, server_handle) = start_oauth_metadata_server(true, false, false).await;
+    let incompatible_port = available_loopback_port();
+
+    let err = perform_oauth_login_return_url(
+        "rmcp-http",
+        &server_url,
+        OAuthCredentialsStoreMode::File,
+        None,
+        None,
+        &[],
+        None,
+        Some(1),
+        Some(incompatible_port),
+        None,
+    )
+    .await
+    .err()
+    .expect("oauth login should fail when callback URI is incompatible with fallback metadata");
+    let err_text = format!("{err:#}");
+
+    assert!(
+        err_text.contains("incompatible with built-in Codex client metadata"),
+        "unexpected oauth setup error: {err:#}"
+    );
+
+    server_handle.abort();
+}
+
+#[tokio::test]
+async fn oauth_login_rejects_conflicting_explicit_callback_url_and_port_for_non_cimd() {
+    let _lock = callback_port_test_lock().lock().await;
+    let (server_url, server_handle) = start_oauth_metadata_server(false, true, false).await;
+
+    let err = perform_oauth_login_return_url(
+        "rmcp-http",
+        &server_url,
+        OAuthCredentialsStoreMode::File,
+        None,
+        None,
+        &[],
+        None,
+        Some(1),
+        Some(5678),
+        Some(DEFAULT_CIMD_REDIRECT_URI_CALLBACK),
+    )
+    .await
+    .err()
+    .expect("oauth login should fail when callback URL and port conflict");
+
+    assert!(
+        err.to_string()
+            .contains("`mcp_oauth_callback_port` is set to `5678`"),
+        "unexpected oauth setup error: {err:#}"
+    );
+
+    server_handle.abort();
+}
+
+#[tokio::test]
+async fn oauth_login_non_cimd_starts_when_cimd_default_port_is_occupied() {
+    let _lock = callback_port_test_lock().lock().await;
+    let _occupied_port_listener =
+        match TcpListener::bind(("127.0.0.1", super::DEFAULT_CIMD_CALLBACK_PORT)) {
+            Ok(listener) => Some(listener),
+            Err(err) if err.kind() == ErrorKind::AddrInUse => None,
+            Err(err) => panic!("failed to bind default CIMD callback port: {err}"),
+        };
+    let (server_url, server_handle) = start_oauth_metadata_server(false, true, false).await;
+
+    let login_handle = perform_oauth_login_return_url(
+        "rmcp-http",
+        &server_url,
+        OAuthCredentialsStoreMode::File,
+        None,
+        None,
+        &[],
+        None,
+        Some(1),
+        None,
+        None,
+    )
+    .await
+    .expect("oauth login should start on an ephemeral callback port");
+    let (authorization_url, completion) = login_handle.into_parts();
+
+    let parsed = Url::parse(&authorization_url).expect("authorization URL should parse");
+    let params = parsed
+        .query_pairs()
+        .collect::<std::collections::HashMap<_, _>>();
+    let redirect_uri = params
+        .get("redirect_uri")
+        .map(std::convert::AsRef::as_ref)
+        .expect("authorization URL should include redirect_uri");
+    assert!(
+        redirect_uri.starts_with("http://127.0.0.1:"),
+        "unexpected redirect URI: {redirect_uri}"
+    );
+    assert!(
+        !redirect_uri.contains(":33418/"),
+        "expected non-CIMD redirect URI to avoid default CIMD callback port: {redirect_uri}"
+    );
+
+    let err = completion
+        .await
+        .expect("oauth completion receiver should resolve")
+        .expect_err("oauth should time out in test without callback");
+    assert!(
+        err.to_string()
+            .contains("timed out waiting for OAuth callback"),
+        "unexpected oauth completion error: {err}"
+    );
+
+    server_handle.abort();
+}
+
+#[tokio::test]
+async fn oauth_login_falls_back_to_default_cimd_metadata_when_registration_fails() {
+    let _lock = callback_port_test_lock().lock().await;
+    let (server_url, server_handle) = start_oauth_metadata_server(true, true, true).await;
+
+    let login_handle = perform_oauth_login_return_url(
+        "rmcp-http",
+        &server_url,
+        OAuthCredentialsStoreMode::File,
+        None,
+        None,
+        &[],
+        None,
+        Some(1),
+        None,
+        None,
+    )
+    .await
+    .expect("oauth login should fall back to default CIMD metadata URL");
+    let (authorization_url, completion) = login_handle.into_parts();
+
+    let parsed = Url::parse(&authorization_url).expect("authorization URL should parse");
+    let params = parsed
+        .query_pairs()
+        .collect::<std::collections::HashMap<_, _>>();
+    assert_eq!(
+        params.get("client_id").map(std::convert::AsRef::as_ref),
+        Some(DEFAULT_CIMD_CLIENT_METADATA_URL)
+    );
+    assert_eq!(
+        params.get("redirect_uri").map(std::convert::AsRef::as_ref),
+        Some(DEFAULT_CIMD_REDIRECT_URI_CALLBACK)
+    );
+
+    let err = completion
+        .await
+        .expect("oauth completion receiver should resolve")
+        .expect_err("oauth should time out in test without callback");
+    assert!(
+        err.to_string()
+            .contains("timed out waiting for OAuth callback"),
+        "unexpected oauth completion error: {err}"
+    );
+
+    server_handle.abort();
+}
+
+#[tokio::test]
+async fn oauth_login_fallback_rejects_incompatible_explicit_callback_after_registration_failure() {
+    let _lock = callback_port_test_lock().lock().await;
+    let (server_url, server_handle) = start_oauth_metadata_server(true, true, true).await;
+    let incompatible_port = available_loopback_port();
+
+    let err = perform_oauth_login_return_url(
+        "rmcp-http",
+        &server_url,
+        OAuthCredentialsStoreMode::File,
+        None,
+        None,
+        &[],
+        None,
+        Some(1),
+        Some(incompatible_port),
+        None,
+    )
+    .await
+    .err()
+    .expect("oauth login should fail when explicit callback is incompatible with CIMD fallback");
+
+    assert!(
+        err.to_string()
+            .contains("incompatible with built-in Codex client metadata"),
+        "unexpected oauth setup error: {err:#}"
+    );
+
+    server_handle.abort();
+}
+
+#[tokio::test]
+async fn oauth_login_fallback_rebinds_compatible_explicit_callback_without_port() {
+    let _lock = callback_port_test_lock().lock().await;
+    let (server_url, server_handle) = start_oauth_metadata_server(true, true, true).await;
+
+    let login_handle = perform_oauth_login_return_url(
+        "rmcp-http",
+        &server_url,
+        OAuthCredentialsStoreMode::File,
+        None,
+        None,
+        &[],
+        None,
+        Some(1),
+        None,
+        Some(DEFAULT_CIMD_REDIRECT_URI_CALLBACK),
+    )
+    .await
+    .expect("oauth login should start with compatible explicit callback URL");
+    let (authorization_url, completion) = login_handle.into_parts();
+
+    let parsed = Url::parse(&authorization_url).expect("authorization URL should parse");
+    let params = parsed
+        .query_pairs()
+        .collect::<std::collections::HashMap<_, _>>();
+    assert_eq!(
+        params.get("redirect_uri").map(std::convert::AsRef::as_ref),
+        Some(DEFAULT_CIMD_REDIRECT_URI_CALLBACK)
+    );
+    let state = params
+        .get("state")
+        .map(std::convert::AsRef::as_ref)
+        .expect("authorization URL should include state");
+
+    let mut callback_url =
+        Url::parse(DEFAULT_CIMD_REDIRECT_URI_CALLBACK).expect("callback URL should parse");
+    callback_url
+        .query_pairs_mut()
+        .append_pair("code", "test-code")
+        .append_pair("state", state);
+    let callback_response = reqwest::get(callback_url)
+        .await
+        .expect("callback request should reach local listener");
+    assert_eq!(callback_response.status(), StatusCode::OK);
+    let callback_response_body = callback_response
+        .text()
+        .await
+        .expect("callback response body should be readable");
+    assert_eq!(
+        callback_response_body,
+        "Authentication complete. You may close this window."
+    );
+
+    let err = tokio::time::timeout(Duration::from_secs(5), completion)
+        .await
+        .expect("oauth completion should resolve after callback")
+        .expect("oauth completion receiver should resolve")
+        .expect_err("oauth completion should fail in test without token endpoint");
+    assert!(
+        err.to_string().contains("failed to handle OAuth callback"),
+        "unexpected oauth completion error: {err:#}"
+    );
+
+    server_handle.abort();
+}
+
+fn authorization_metadata(
+    registration_endpoint: Option<&str>,
+    client_metadata_document_supported: bool,
+) -> AuthorizationMetadata {
+    let mut additional_fields = serde_json::Map::new();
+    additional_fields.insert(
+        CLIENT_ID_METADATA_DOCUMENT_SUPPORTED_FIELD.to_string(),
+        serde_json::Value::Bool(client_metadata_document_supported),
+    );
+
+    AuthorizationMetadata {
+        authorization_endpoint: "https://example.com/authorize".to_string(),
+        token_endpoint: "https://example.com/token".to_string(),
+        registration_endpoint: registration_endpoint.map(str::to_string),
+        issuer: None,
+        jwks_uri: None,
+        scopes_supported: None,
+        response_types_supported: Some(vec!["code".to_string()]),
+        additional_fields: additional_fields.into_iter().collect(),
+    }
+}
+
+async fn start_oauth_metadata_server(
+    client_id_metadata_document_supported: bool,
+    include_registration_endpoint: bool,
+    registration_fails: bool,
+) -> (String, JoinHandle<()>) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("listener should bind");
+    let addr = listener
+        .local_addr()
+        .expect("listener should have local addr");
+    let base_url = format!("http://{addr}");
+    let mut metadata = json!({
+        "authorization_endpoint": format!("{base_url}/oauth/authorize"),
+        "token_endpoint": format!("{base_url}/oauth/token"),
+        "response_types_supported": ["code"],
+        "code_challenge_methods_supported": ["S256"],
+        "client_id_metadata_document_supported": client_id_metadata_document_supported,
+    });
+    if include_registration_endpoint && let Some(metadata_obj) = metadata.as_object_mut() {
+        metadata_obj.insert(
+            "registration_endpoint".to_string(),
+            json!(format!("{base_url}/oauth/register")),
+        );
+    }
+
+    let app = Router::new()
+        .route(
+            "/.well-known/oauth-authorization-server/mcp",
+            get({
+                let metadata = metadata.clone();
+                move || async move { Json(metadata.clone()) }
+            }),
+        )
+        .route(
+            "/mcp/.well-known/oauth-authorization-server",
+            get({
+                let metadata = metadata.clone();
+                move || async move { Json(metadata.clone()) }
+            }),
+        )
+        .route(
+            "/.well-known/oauth-authorization-server",
+            get(move || async move { Json(metadata.clone()) }),
+        )
+        .route(
+            "/oauth/register",
+            post(move || async move {
+                if registration_fails {
+                    return (
+                        StatusCode::FORBIDDEN,
+                        Json(json!({
+                            "error": "access_denied",
+                            "error_description": "dynamic registration denied by policy",
+                        })),
+                    );
+                }
+                (
+                    StatusCode::CREATED,
+                    Json(json!({
+                        "client_id": "codex-test-client-id",
+                        "client_secret": null,
+                        "client_name": "Codex Test Client",
+                        "redirect_uris": [],
+                    })),
+                )
+            }),
+        );
+
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("oauth metadata server should run");
+    });
+
+    (format!("{base_url}/mcp"), handle)
+}


### PR DESCRIPTION
Authored by @ethriel3695 but he wasn't able to open it due to our current external contributor policy.

This PR adds support for CIMD as a fallback MCP oauth method if dynamic client registration fails. Validated against the storybook MCP.