### PR TITLE
Fix steers during plan stream by relying on pending queue

### DIFF
--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -3659,8 +3659,7 @@ impl ChatWidget {
                     else {
                         return;
                     };
-                    let should_submit_now =
-                        self.is_session_configured() && !self.is_plan_streaming_in_tui();
+                    let should_submit_now = self.is_session_configured();
                     if should_submit_now {
                         // Submitted is emitted when user submits.
                         // Reset any reasoning header only when we are actually submitting a turn.

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -3849,7 +3849,7 @@ async fn unified_exec_begin_restores_working_status_snapshot() {
 }
 
 #[tokio::test]
-async fn steer_enter_queues_while_plan_stream_is_active() {
+async fn steer_enter_uses_pending_steers_while_plan_stream_is_active() {
     let (mut chat, mut rx, mut op_rx) = make_chatwidget_manual(None).await;
     chat.thread_id = Some(ThreadId::new());
     chat.set_feature_enabled(Feature::CollaborationModes, true);
@@ -3866,13 +3866,16 @@ async fn steer_enter_queues_while_plan_stream_is_active() {
     chat.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
 
     assert_eq!(chat.active_collaboration_mode_kind(), ModeKind::Plan);
-    assert_eq!(chat.queued_user_messages.len(), 1);
+    assert!(chat.queued_user_messages.is_empty());
+    assert_eq!(chat.pending_steers.len(), 1);
     assert_eq!(
-        chat.queued_user_messages.front().unwrap().text,
+        chat.pending_steers.front().unwrap().user_message.text,
         "queued submission"
     );
-    assert!(chat.pending_steers.is_empty());
-    assert_no_submit_op(&mut op_rx);
+    match next_submit_op(&mut op_rx) {
+        Op::UserTurn { .. } => {}
+        other => panic!("expected Op::UserTurn, got {other:?}"),
+    }
     assert!(drain_insert_history(&mut rx).is_empty());
 }
 


### PR DESCRIPTION
Restore immediate steer submit on Enter (regression)

Fixes #13595.

Restore the TUI steer behavior where `Enter` submits immediately and `Tab`
queues the message. PR #12868 split mid-turn steers into `pending_steers`
vs `queued_user_messages`, but the active Plan-stream path also started
routing `Enter` through the queue, so both keys queued drafts.

This change sends `Enter` back through the immediate submit path while
keeping `Tab` on the queued-message path.
