### PR TITLE
Validate Exec CLI in multitool wrapper and update fork/resume test

### DIFF
--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -578,7 +578,11 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
             let exit_info = run_interactive_tui(interactive, arg0_paths.clone()).await?;
             handle_app_exit(exit_info)?;
         }
-        Some(Subcommand::Exec(mut exec_cli)) => {
+        Some(Subcommand::Exec(exec_cli)) => {
+            let mut exec_cli = match exec_cli.validate() {
+                Ok(exec_cli) => exec_cli,
+                Err(err) => err.exit(),
+            };
             prepend_config_flags(
                 &mut exec_cli.config_overrides,
                 root_config_overrides.clone(),
@@ -1224,9 +1228,16 @@ mod tests {
 
     #[test]
     fn exec_fork_conflicts_with_resume_subcommand() {
-        let parse_result =
-            MultitoolCli::try_parse_from(["codex", "exec", "--fork", "session-123", "resume"]);
-        assert!(parse_result.is_err());
+        let cli =
+            MultitoolCli::try_parse_from(["codex", "exec", "--fork", "session-123", "resume"])
+                .expect("parse should succeed");
+
+        let Some(Subcommand::Exec(exec)) = cli.subcommand else {
+            panic!("expected exec subcommand");
+        };
+
+        let validate_result = exec.validate();
+        assert!(validate_result.is_err());
     }
 
     fn app_server_from_args(args: &[&str]) -> AppServerCommand {


### PR DESCRIPTION
### Motivation
- Ensure the multitool `codex` wrapper enforces the same `ExecCli` validation rules as the standalone `codex-exec` binary so `codex exec --fork <id> resume` is rejected consistently and the related unit test no longer fails.

### Description
- Call `ExecCli::validate()` in the multitool dispatch path before forwarding to `codex_exec::run_main` and handle validation errors by exiting appropriately; change located in `codex-rs/cli/src/main.rs`.
- Update the unit test `exec_fork_conflicts_with_resume_subcommand` to parse the CLI and assert that `exec.validate()` returns an error (parse succeeds but validation fails) to reflect where the conflict is enforced.

### Testing
- Ran formatting with `just fmt` in the workspace and it completed successfully.
- Executed the failing unit case with: `PKG_CONFIG_PATH=/tmp/libcap-shim/lib/pkgconfig NO_PROXY=127.0.0.1,localhost cargo test -p codex-cli tests::exec_fork_conflicts_with_resume_subcommand`, and the test passed.
- Ran the `codex-exec` and `codex-cli` test suites with the same environment shim (`PKG_CONFIG_PATH=/tmp/libcap-shim/lib/pkgconfig NO_PROXY=127.0.0.1,localhost`) and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_69a9e5053e448323965a3c030a90e154)