### PR TITLE
Promote image_detail_original to experimental

### DIFF
--- a/codex-rs/core/src/features.rs
+++ b/codex-rs/core/src/features.rs
@@ -618,7 +618,11 @@ pub const FEATURES: &[FeatureSpec] = &[
     FeatureSpec {
         id: Feature::ImageDetailOriginal,
         key: "image_detail_original",
-        stage: Stage::UnderDevelopment,
+        stage: Stage::Experimental {
+            name: "Original image detail",
+            menu_description: "Allow the model to request `detail: \"original\"` for tool-emitted images on supported models so it sees the full-resolution image instead of a resized approximation. This affects tools like `view_image` and `js_repl`, not images attached directly in the UI. It is particularly important for localization and precise UI targeting, for reading small text, and for reasoning about precise layout.",
+            announcement: "NEW: Original image detail is now available in /experimental. Enable it to let tools request full-resolution image detail on supported models for CUA and localization tasks.",
+        },
         default_enabled: false,
     },
     FeatureSpec {

--- a/codex-rs/core/src/features_tests.rs
+++ b/codex-rs/core/src/features_tests.rs
@@ -121,10 +121,26 @@ fn image_generation_is_under_development() {
 }
 
 #[test]
-fn image_detail_original_feature_is_under_development() {
+fn image_detail_original_is_experimental_and_user_toggleable() {
+    let spec = Feature::ImageDetailOriginal.info();
+    let stage = spec.stage;
+
+    assert!(matches!(stage, Stage::Experimental { .. }));
     assert_eq!(
-        Feature::ImageDetailOriginal.stage(),
-        Stage::UnderDevelopment
+        stage.experimental_menu_name(),
+        Some("Original image detail")
+    );
+    assert_eq!(
+        stage.experimental_menu_description(),
+        Some(
+            "Allow the model to request `detail: \"original\"` for tool-emitted images on supported models so it sees the full-resolution image instead of a resized approximation. This affects tools like `view_image` and `js_repl`, not images attached directly in the UI. It is particularly important for localization and precise UI targeting, for reading small text, and for reasoning about precise layout."
+        )
+    );
+    assert_eq!(
+        stage.experimental_announcement(),
+        Some(
+            "NEW: Original image detail is now available in /experimental. Enable it to let tools request full-resolution image detail on supported models for CUA and localization tasks."
+        )
     );
     assert_eq!(Feature::ImageDetailOriginal.default_enabled(), false);
 }

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -7404,6 +7404,36 @@ async fn experimental_popup_includes_guardian_approval() {
 }
 
 #[tokio::test]
+async fn experimental_popup_includes_image_detail_original() {
+    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(None).await;
+
+    let image_detail_stage = FEATURES
+        .iter()
+        .find(|spec| spec.id == Feature::ImageDetailOriginal)
+        .map(|spec| spec.stage)
+        .expect("expected image_detail_original feature metadata");
+    let image_detail_name = image_detail_stage
+        .experimental_menu_name()
+        .expect("expected image_detail_original experimental name");
+    let image_detail_description = image_detail_stage
+        .experimental_menu_description()
+        .expect("expected image_detail_original experimental description");
+
+    chat.open_experimental_popup();
+
+    let popup = render_bottom_popup(&chat, 120);
+    let normalized_popup = popup.split_whitespace().collect::<Vec<_>>().join(" ");
+    assert!(
+        popup.contains(image_detail_name),
+        "expected original image detail entry in experimental popup, got:\n{popup}"
+    );
+    assert!(
+        normalized_popup.contains(image_detail_description),
+        "expected original image detail description in experimental popup, got:\n{popup}"
+    );
+}
+
+#[tokio::test]
 async fn multi_agent_enable_prompt_snapshot() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual(None).await;
 


### PR DESCRIPTION
## Summary
- Adds `image_detail_original` to the `/experimental` menu as "Original image detail".
- Defines the current experimental copy and announcement for the feature.
- Covers the feature metadata in `codex-core` tests.
- Verifies the `/experimental` popup includes the image detail entry in `codex-tui` tests.
