### PR TITLE
fix: preserve zsh-fork escalation fds across unified-exec spawn paths

### DIFF
--- a/codex-rs/core/src/tools/runtimes/shell/zsh_fork_backend.rs
+++ b/codex-rs/core/src/tools/runtimes/shell/zsh_fork_backend.rs
@@ -46,6 +46,7 @@ mod imp {
     use super::*;
     use crate::tools::runtimes::shell::unix_escalation;
     use crate::unified_exec::SpawnLifecycle;
+    use codex_shell_escalation::ESCALATE_SOCKET_ENV_VAR;
     use codex_shell_escalation::EscalationSession;
 
     #[derive(Debug)]
@@ -54,6 +55,15 @@ mod imp {
     }
 
     impl SpawnLifecycle for ZshForkSpawnLifecycle {
+        fn inherited_fds(&self) -> Vec<i32> {
+            self.escalation_session
+                .env()
+                .get(ESCALATE_SOCKET_ENV_VAR)
+                .and_then(|fd| fd.parse().ok())
+                .into_iter()
+                .collect()
+        }
+
         fn after_spawn(&mut self) {
             self.escalation_session.close_client_socket();
         }

--- a/codex-rs/core/src/unified_exec/process.rs
+++ b/codex-rs/core/src/unified_exec/process.rs
@@ -26,6 +26,15 @@ use super::UnifiedExecError;
 use super::head_tail_buffer::HeadTailBuffer;
 
 pub(crate) trait SpawnLifecycle: std::fmt::Debug + Send + Sync {
+    /// Returns file descriptors that must stay open across the child `exec()`.
+    ///
+    /// The returned descriptors must already be valid in the parent process and
+    /// stay valid until `after_spawn()` runs, which is the first point where
+    /// the parent may release its copies.
+    fn inherited_fds(&self) -> Vec<i32> {
+        Vec::new()
+    }
+
     fn after_spawn(&mut self) {}
 }
 

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -537,24 +537,27 @@ impl UnifiedExecProcessManager {
             .command
             .split_first()
             .ok_or(UnifiedExecError::MissingCommandLine)?;
+        let inherited_fds = spawn_lifecycle.inherited_fds();
 
         let spawn_result = if tty {
-            codex_utils_pty::pty::spawn_process(
+            codex_utils_pty::pty::spawn_process_with_inherited_fds(
                 program,
                 args,
                 env.cwd.as_path(),
                 &env.env,
                 &env.arg0,
                 codex_utils_pty::TerminalSize::default(),
+                &inherited_fds,
             )
             .await
         } else {
-            codex_utils_pty::pipe::spawn_process_no_stdin(
+            codex_utils_pty::pipe::spawn_process_no_stdin_with_inherited_fds(
                 program,
                 args,
                 env.cwd.as_path(),
                 &env.env,
                 &env.arg0,
+                &inherited_fds,
             )
             .await
         };

--- a/codex-rs/shell-escalation/src/lib.rs
+++ b/codex-rs/shell-escalation/src/lib.rs
@@ -28,6 +28,8 @@ pub use unix::ShellCommandExecutor;
 #[cfg(unix)]
 pub use unix::Stopwatch;
 #[cfg(unix)]
+pub use unix::escalate_protocol::ESCALATE_SOCKET_ENV_VAR;
+#[cfg(unix)]
 pub use unix::main_execve_wrapper;
 #[cfg(unix)]
 pub use unix::run_shell_escalation_execve_wrapper;

--- a/codex-rs/shell-escalation/src/unix/escalate_client.rs
+++ b/codex-rs/shell-escalation/src/unix/escalate_client.rs
@@ -1,6 +1,6 @@
 use std::io;
+use std::os::fd::AsFd;
 use std::os::fd::AsRawFd;
-use std::os::fd::FromRawFd as _;
 use std::os::fd::OwnedFd;
 
 use anyhow::Context as _;
@@ -26,6 +26,12 @@ fn get_escalate_client() -> anyhow::Result<AsyncDatagramSocket> {
         ));
     }
     Ok(unsafe { AsyncDatagramSocket::from_raw_fd(client_fd) }?)
+}
+
+fn duplicate_fd_for_transfer(fd: impl AsFd, name: &str) -> anyhow::Result<OwnedFd> {
+    fd.as_fd()
+        .try_clone_to_owned()
+        .with_context(|| format!("failed to duplicate {name} for escalation transfer"))
 }
 
 pub async fn run_shell_escalation_execve_wrapper(
@@ -62,11 +68,18 @@ pub async fn run_shell_escalation_execve_wrapper(
         .context("failed to receive EscalateResponse")?;
     match message.action {
         EscalateAction::Escalate => {
-            // TODO: maybe we should send ALL open FDs (except the escalate client)?
+            // Duplicate stdio before transferring ownership to the server. The
+            // wrapper must keep using its own stdin/stdout/stderr until the
+            // escalated child takes over.
+            let destination_fds = [
+                io::stdin().as_raw_fd(),
+                io::stdout().as_raw_fd(),
+                io::stderr().as_raw_fd(),
+            ];
             let fds_to_send = [
-                unsafe { OwnedFd::from_raw_fd(io::stdin().as_raw_fd()) },
-                unsafe { OwnedFd::from_raw_fd(io::stdout().as_raw_fd()) },
-                unsafe { OwnedFd::from_raw_fd(io::stderr().as_raw_fd()) },
+                duplicate_fd_for_transfer(io::stdin(), "stdin")?,
+                duplicate_fd_for_transfer(io::stdout(), "stdout")?,
+                duplicate_fd_for_transfer(io::stderr(), "stderr")?,
             ];
 
             // TODO: also forward signals over the super-exec socket
@@ -74,7 +87,7 @@ pub async fn run_shell_escalation_execve_wrapper(
             client
                 .send_with_fds(
                     SuperExecMessage {
-                        fds: fds_to_send.iter().map(AsRawFd::as_raw_fd).collect(),
+                        fds: destination_fds.into_iter().collect(),
                     },
                     &fds_to_send,
                 )
@@ -113,5 +126,25 @@ pub async fn run_shell_escalation_execve_wrapper(
             }
             Ok(1)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::fd::AsRawFd;
+    use std::os::unix::net::UnixStream;
+
+    #[test]
+    fn duplicate_fd_for_transfer_does_not_close_original() {
+        let (left, _right) = UnixStream::pair().expect("socket pair");
+        let original_fd = left.as_raw_fd();
+
+        let duplicate = duplicate_fd_for_transfer(&left, "test fd").expect("duplicate fd");
+        assert_ne!(duplicate.as_raw_fd(), original_fd);
+
+        drop(duplicate);
+
+        assert_ne!(unsafe { libc::fcntl(original_fd, libc::F_GETFD) }, -1);
     }
 }

--- a/codex-rs/shell-escalation/src/unix/escalate_server.rs
+++ b/codex-rs/shell-escalation/src/unix/escalate_server.rs
@@ -319,16 +319,6 @@ async fn handle_escalate_session_with_policy(
                 ));
             }
 
-            if msg
-                .fds
-                .iter()
-                .any(|src_fd| fds.iter().any(|dst_fd| dst_fd.as_raw_fd() == *src_fd))
-            {
-                return Err(anyhow::anyhow!(
-                    "overlapping fds not yet supported in SuperExecMessage"
-                ));
-            }
-
             let PreparedExec {
                 command,
                 cwd,
@@ -398,6 +388,7 @@ mod tests {
     use codex_utils_absolute_path::AbsolutePathBuf;
     use pretty_assertions::assert_eq;
     use std::collections::HashMap;
+    use std::io::Write;
     use std::os::fd::AsRawFd;
     use std::os::fd::FromRawFd;
     use std::path::PathBuf;
@@ -808,6 +799,126 @@ mod tests {
 
         let result = client.receive::<SuperExecResult>().await?;
         assert_eq!(42, result.exit_code);
+
+        server_task.await?
+    }
+
+    /// Saves a target descriptor, closes it, and restores it when dropped.
+    ///
+    /// The overlap regression test needs the next received `SCM_RIGHTS` handle
+    /// to land on a specific descriptor number such as stdin. Temporarily
+    /// closing the descriptor makes that allocation possible while still
+    /// letting the test put the process back the way it found it.
+    struct RestoredFd {
+        target_fd: i32,
+        original_fd: std::os::fd::OwnedFd,
+    }
+
+    impl RestoredFd {
+        /// Duplicates `target_fd`, then closes the original descriptor number.
+        ///
+        /// The duplicate is kept alive so `Drop` can restore the original
+        /// process state after the test finishes.
+        fn close_temporarily(target_fd: i32) -> anyhow::Result<Self> {
+            let original_fd = unsafe { libc::dup(target_fd) };
+            if original_fd == -1 {
+                return Err(std::io::Error::last_os_error().into());
+            }
+            if unsafe { libc::close(target_fd) } == -1 {
+                let err = std::io::Error::last_os_error();
+                unsafe {
+                    libc::close(original_fd);
+                }
+                return Err(err.into());
+            }
+            Ok(Self {
+                target_fd,
+                original_fd: unsafe { std::os::fd::OwnedFd::from_raw_fd(original_fd) },
+            })
+        }
+    }
+
+    /// Restores the original descriptor back onto its original fd number.
+    ///
+    /// This keeps the overlap test self-contained even though it mutates the
+    /// current process's stdio table.
+    impl Drop for RestoredFd {
+        fn drop(&mut self) {
+            unsafe {
+                libc::dup2(self.original_fd.as_raw_fd(), self.target_fd);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn handle_escalate_session_accepts_received_fds_that_overlap_destinations()
+    -> anyhow::Result<()> {
+        let _guard = ESCALATE_SERVER_TEST_LOCK.lock().await;
+        let mut pipe_fds = [0; 2];
+        if unsafe { libc::pipe(pipe_fds.as_mut_ptr()) } == -1 {
+            return Err(std::io::Error::last_os_error().into());
+        }
+        let read_end = unsafe { std::os::fd::OwnedFd::from_raw_fd(pipe_fds[0]) };
+        let mut write_end = unsafe { std::fs::File::from_raw_fd(pipe_fds[1]) };
+
+        // Force the receive-side overlap case for stdin.
+        //
+        // SCM_RIGHTS installs received descriptors into the lowest available fd
+        // numbers in the receiving process. The pipe is opened first so its
+        // read end does not consume fd 0. After stdin is temporarily closed,
+        // receiving `read_end` should reuse descriptor 0. The message below
+        // also asks the server to map that received fd to destination fd 0, so
+        // the pre-exec dup2 loop exercises the src_fd == dst_fd case.
+        let stdin_restore = RestoredFd::close_temporarily(libc::STDIN_FILENO)?;
+        let (server, client) = AsyncSocket::pair()?;
+        let server_task = tokio::spawn(handle_escalate_session_with_policy(
+            server,
+            Arc::new(DeterministicEscalationPolicy {
+                decision: EscalationDecision::escalate(EscalationExecution::Unsandboxed),
+            }),
+            Arc::new(ForwardingShellCommandExecutor),
+            CancellationToken::new(),
+            CancellationToken::new(),
+        ));
+
+        client
+            .send(EscalateRequest {
+                file: PathBuf::from("/bin/sh"),
+                argv: vec![
+                    "sh".to_string(),
+                    "-c".to_string(),
+                    "IFS= read -r line && [ \"$line\" = overlap-ok ]".to_string(),
+                ],
+                workdir: AbsolutePathBuf::current_dir()?,
+                env: HashMap::new(),
+            })
+            .await?;
+
+        let response = client.receive::<EscalateResponse>().await?;
+        assert_eq!(
+            EscalateResponse {
+                action: EscalateAction::Escalate,
+            },
+            response
+        );
+
+        client
+            .send_with_fds(
+                SuperExecMessage {
+                    fds: vec![libc::STDIN_FILENO],
+                },
+                &[read_end],
+            )
+            .await?;
+        write_end.write_all(b"overlap-ok\n")?;
+        drop(write_end);
+
+        let result = client.receive::<SuperExecResult>().await?;
+        assert_eq!(
+            0, result.exit_code,
+            "expected the escalated child to read the sent stdin payload even when the received fd reuses fd 0"
+        );
+        drop(stdin_restore);
 
         server_task.await?
     }

--- a/codex-rs/utils/pty/src/pipe.rs
+++ b/codex-rs/utils/pty/src/pipe.rs
@@ -102,10 +102,14 @@ async fn spawn_process_with_stdin_mode(
     env: &HashMap<String, String>,
     arg0: &Option<String>,
     stdin_mode: PipeStdinMode,
+    inherited_fds: &[i32],
 ) -> Result<SpawnedProcess> {
     if program.is_empty() {
         anyhow::bail!("missing program for pipe spawn");
     }
+
+    #[cfg(not(unix))]
+    let _ = inherited_fds;
 
     let mut command = Command::new(program);
     #[cfg(unix)]
@@ -115,11 +119,14 @@ async fn spawn_process_with_stdin_mode(
     #[cfg(target_os = "linux")]
     let parent_pid = unsafe { libc::getpid() };
     #[cfg(unix)]
+    let inherited_fds = inherited_fds.to_vec();
+    #[cfg(unix)]
     unsafe {
         command.pre_exec(move || {
             crate::process_group::detach_from_tty()?;
             #[cfg(target_os = "linux")]
             crate::process_group::set_parent_death_signal(parent_pid)?;
+            crate::pty::close_inherited_fds_except(&inherited_fds);
             Ok(())
         });
     }
@@ -250,7 +257,7 @@ pub async fn spawn_process(
     env: &HashMap<String, String>,
     arg0: &Option<String>,
 ) -> Result<SpawnedProcess> {
-    spawn_process_with_stdin_mode(program, args, cwd, env, arg0, PipeStdinMode::Piped).await
+    spawn_process_with_stdin_mode(program, args, cwd, env, arg0, PipeStdinMode::Piped, &[]).await
 }
 
 /// Spawn a process using regular pipes, but close stdin immediately.
@@ -261,5 +268,27 @@ pub async fn spawn_process_no_stdin(
     env: &HashMap<String, String>,
     arg0: &Option<String>,
 ) -> Result<SpawnedProcess> {
-    spawn_process_with_stdin_mode(program, args, cwd, env, arg0, PipeStdinMode::Null).await
+    spawn_process_no_stdin_with_inherited_fds(program, args, cwd, env, arg0, &[]).await
+}
+
+/// Spawn a process using regular pipes, close stdin immediately, and preserve
+/// selected inherited file descriptors across exec on Unix.
+pub async fn spawn_process_no_stdin_with_inherited_fds(
+    program: &str,
+    args: &[String],
+    cwd: &Path,
+    env: &HashMap<String, String>,
+    arg0: &Option<String>,
+    inherited_fds: &[i32],
+) -> Result<SpawnedProcess> {
+    spawn_process_with_stdin_mode(
+        program,
+        args,
+        cwd,
+        env,
+        arg0,
+        PipeStdinMode::Null,
+        inherited_fds,
+    )
+    .await
 }

--- a/codex-rs/utils/pty/src/process.rs
+++ b/codex-rs/utils/pty/src/process.rs
@@ -1,5 +1,7 @@
 use core::fmt;
 use std::io;
+#[cfg(unix)]
+use std::os::fd::RawFd;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
@@ -41,9 +43,24 @@ impl From<TerminalSize> for PtySize {
     }
 }
 
+#[cfg(unix)]
+pub(crate) trait PtyHandleKeepAlive: Send {}
+
+#[cfg(unix)]
+impl<T: Send + ?Sized> PtyHandleKeepAlive for T {}
+
+pub(crate) enum PtyMasterHandle {
+    Resizable(Box<dyn MasterPty + Send>),
+    #[cfg(unix)]
+    Opaque {
+        raw_fd: RawFd,
+        _handle: Box<dyn PtyHandleKeepAlive>,
+    },
+}
+
 pub struct PtyHandles {
     pub _slave: Option<Box<dyn SlavePty + Send>>,
-    pub _master: Box<dyn MasterPty + Send>,
+    pub(crate) _master: PtyMasterHandle,
 }
 
 impl fmt::Debug for PtyHandles {
@@ -131,7 +148,11 @@ impl ProcessHandle {
         let handles = handles
             .as_ref()
             .ok_or_else(|| anyhow!("process is not attached to a PTY"))?;
-        handles._master.resize(size.into())
+        match &handles._master {
+            PtyMasterHandle::Resizable(master) => master.resize(size.into()),
+            #[cfg(unix)]
+            PtyMasterHandle::Opaque { raw_fd, .. } => resize_raw_pty(*raw_fd, size),
+        }
     }
 
     /// Close the child's stdin channel.
@@ -182,6 +203,21 @@ impl Drop for ProcessHandle {
     fn drop(&mut self) {
         self.terminate();
     }
+}
+
+#[cfg(unix)]
+fn resize_raw_pty(raw_fd: RawFd, size: TerminalSize) -> anyhow::Result<()> {
+    let mut winsize = libc::winsize {
+        ws_row: size.rows,
+        ws_col: size.cols,
+        ws_xpixel: 0,
+        ws_ypixel: 0,
+    };
+    let result = unsafe { libc::ioctl(raw_fd, libc::TIOCSWINSZ, &mut winsize) };
+    if result == -1 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    Ok(())
 }
 
 /// Combine split stdout/stderr receivers into a single broadcast receiver.

--- a/codex-rs/utils/pty/src/pty.rs
+++ b/codex-rs/utils/pty/src/pty.rs
@@ -1,6 +1,20 @@
 use std::collections::HashMap;
+#[cfg(unix)]
+use std::fs::File;
 use std::io::ErrorKind;
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
+#[cfg(unix)]
+use std::os::fd::FromRawFd;
+#[cfg(unix)]
+use std::os::fd::RawFd;
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
 use std::path::Path;
+#[cfg(unix)]
+use std::process::Command as StdCommand;
+#[cfg(unix)]
+use std::process::Stdio;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
@@ -17,6 +31,7 @@ use tokio::task::JoinHandle;
 use crate::process::ChildTerminator;
 use crate::process::ProcessHandle;
 use crate::process::PtyHandles;
+use crate::process::PtyMasterHandle;
 use crate::process::SpawnedProcess;
 use crate::process::TerminalSize;
 
@@ -59,6 +74,18 @@ impl ChildTerminator for PtyChildTerminator {
     }
 }
 
+#[cfg(unix)]
+struct RawPidTerminator {
+    process_group_id: u32,
+}
+
+#[cfg(unix)]
+impl ChildTerminator for RawPidTerminator {
+    fn kill(&mut self) -> std::io::Result<()> {
+        crate::process_group::kill_process_group(self.process_group_id)
+    }
+}
+
 fn platform_native_pty_system() -> Box<dyn portable_pty::PtySystem + Send> {
     #[cfg(windows)]
     {
@@ -80,10 +107,44 @@ pub async fn spawn_process(
     arg0: &Option<String>,
     size: TerminalSize,
 ) -> Result<SpawnedProcess> {
+    spawn_process_with_inherited_fds(program, args, cwd, env, arg0, size, &[]).await
+}
+
+/// Spawn a process attached to a PTY, preserving any inherited file
+/// descriptors listed in `inherited_fds` across exec on Unix.
+pub async fn spawn_process_with_inherited_fds(
+    program: &str,
+    args: &[String],
+    cwd: &Path,
+    env: &HashMap<String, String>,
+    arg0: &Option<String>,
+    size: TerminalSize,
+    inherited_fds: &[i32],
+) -> Result<SpawnedProcess> {
     if program.is_empty() {
         anyhow::bail!("missing program for PTY spawn");
     }
 
+    #[cfg(not(unix))]
+    let _ = inherited_fds;
+
+    #[cfg(unix)]
+    if !inherited_fds.is_empty() {
+        return spawn_process_preserving_fds(program, args, cwd, env, arg0, size, inherited_fds)
+            .await;
+    }
+
+    spawn_process_portable(program, args, cwd, env, arg0, size).await
+}
+
+async fn spawn_process_portable(
+    program: &str,
+    args: &[String],
+    cwd: &Path,
+    env: &HashMap<String, String>,
+    arg0: &Option<String>,
+    size: TerminalSize,
+) -> Result<SpawnedProcess> {
     let pty_system = platform_native_pty_system();
     let pair = pty_system.openpty(size.into())?;
 
@@ -164,7 +225,7 @@ pub async fn spawn_process(
         } else {
             None
         },
-        _master: pair.master,
+        _master: PtyMasterHandle::Resizable(pair.master),
     };
 
     let handle = ProcessHandle::new(
@@ -189,4 +250,232 @@ pub async fn spawn_process(
         stderr_rx,
         exit_rx,
     })
+}
+
+#[cfg(unix)]
+async fn spawn_process_preserving_fds(
+    program: &str,
+    args: &[String],
+    cwd: &Path,
+    env: &HashMap<String, String>,
+    arg0: &Option<String>,
+    size: TerminalSize,
+    inherited_fds: &[RawFd],
+) -> Result<SpawnedProcess> {
+    let (master, slave) = open_unix_pty(size)?;
+    let mut command = StdCommand::new(program);
+    if let Some(arg0) = arg0 {
+        command.arg0(arg0);
+    }
+    command.current_dir(cwd);
+    command.env_clear();
+    for arg in args {
+        command.arg(arg);
+    }
+    for (key, value) in env {
+        command.env(key, value);
+    }
+
+    // The child should see one terminal on all three stdio streams. Cloning
+    // the slave fd gives us three owned handles to the same PTY slave device
+    // so Command can wire them up independently as stdin/stdout/stderr.
+    let stdin = slave.try_clone()?;
+    let stdout = slave.try_clone()?;
+    let stderr = slave.try_clone()?;
+    let inherited_fds = inherited_fds.to_vec();
+
+    unsafe {
+        command
+            .stdin(Stdio::from(stdin))
+            .stdout(Stdio::from(stdout))
+            .stderr(Stdio::from(stderr))
+            .pre_exec(move || {
+                for signo in &[
+                    libc::SIGCHLD,
+                    libc::SIGHUP,
+                    libc::SIGINT,
+                    libc::SIGQUIT,
+                    libc::SIGTERM,
+                    libc::SIGALRM,
+                ] {
+                    libc::signal(*signo, libc::SIG_DFL);
+                }
+
+                let empty_set: libc::sigset_t = std::mem::zeroed();
+                libc::sigprocmask(libc::SIG_SETMASK, &empty_set, std::ptr::null_mut());
+
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+
+                // stdin now refers to the PTY slave, so make that fd the
+                // controlling terminal for the child's new session. stdout and
+                // stderr point at clones of the same slave device.
+                #[allow(clippy::cast_lossless)]
+                if libc::ioctl(0, libc::TIOCSCTTY as _, 0) == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+
+                close_inherited_fds_except(&inherited_fds);
+                Ok(())
+            });
+    }
+
+    let mut child = command.spawn()?;
+    drop(slave);
+    let process_group_id = child.id();
+
+    let (writer_tx, mut writer_rx) = mpsc::channel::<Vec<u8>>(128);
+    let (stdout_tx, stdout_rx) = mpsc::channel::<Vec<u8>>(128);
+    let (_stderr_tx, stderr_rx) = mpsc::channel::<Vec<u8>>(1);
+    let mut reader = master.try_clone()?;
+    let reader_handle: JoinHandle<()> = tokio::task::spawn_blocking(move || {
+        let mut buf = [0u8; 8_192];
+        loop {
+            match std::io::Read::read(&mut reader, &mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    let _ = stdout_tx.blocking_send(buf[..n].to_vec());
+                }
+                Err(ref e) if e.kind() == ErrorKind::Interrupted => continue,
+                Err(ref e) if e.kind() == ErrorKind::WouldBlock => {
+                    std::thread::sleep(Duration::from_millis(5));
+                    continue;
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    let writer = Arc::new(tokio::sync::Mutex::new(master.try_clone()?));
+    let writer_handle: JoinHandle<()> = tokio::spawn({
+        let writer = Arc::clone(&writer);
+        async move {
+            while let Some(bytes) = writer_rx.recv().await {
+                let mut guard = writer.lock().await;
+                use std::io::Write;
+                let _ = guard.write_all(&bytes);
+                let _ = guard.flush();
+            }
+        }
+    });
+
+    let (exit_tx, exit_rx) = oneshot::channel::<i32>();
+    let exit_status = Arc::new(AtomicBool::new(false));
+    let wait_exit_status = Arc::clone(&exit_status);
+    let exit_code = Arc::new(StdMutex::new(None));
+    let wait_exit_code = Arc::clone(&exit_code);
+    let wait_handle: JoinHandle<()> = tokio::task::spawn_blocking(move || {
+        let code = match child.wait() {
+            Ok(status) => status.code().unwrap_or(-1),
+            Err(_) => -1,
+        };
+        wait_exit_status.store(true, std::sync::atomic::Ordering::SeqCst);
+        if let Ok(mut guard) = wait_exit_code.lock() {
+            *guard = Some(code);
+        }
+        let _ = exit_tx.send(code);
+    });
+
+    let handles = PtyHandles {
+        _slave: None,
+        _master: PtyMasterHandle::Opaque {
+            raw_fd: master.as_raw_fd(),
+            _handle: Box::new(master),
+        },
+    };
+
+    let handle = ProcessHandle::new(
+        writer_tx,
+        Box::new(RawPidTerminator { process_group_id }),
+        reader_handle,
+        Vec::new(),
+        writer_handle,
+        wait_handle,
+        exit_status,
+        exit_code,
+        Some(handles),
+    );
+
+    Ok(SpawnedProcess {
+        session: handle,
+        stdout_rx,
+        stderr_rx,
+        exit_rx,
+    })
+}
+
+#[cfg(unix)]
+fn open_unix_pty(size: TerminalSize) -> Result<(File, File)> {
+    let mut master: RawFd = -1;
+    let mut slave: RawFd = -1;
+    let mut size = libc::winsize {
+        ws_row: size.rows,
+        ws_col: size.cols,
+        ws_xpixel: 0,
+        ws_ypixel: 0,
+    };
+    let winp = std::ptr::addr_of_mut!(size);
+
+    let result = unsafe {
+        libc::openpty(
+            &mut master,
+            &mut slave,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            winp,
+        )
+    };
+    if result != 0 {
+        anyhow::bail!("failed to openpty: {:?}", std::io::Error::last_os_error());
+    }
+
+    set_cloexec(master)?;
+    set_cloexec(slave)?;
+
+    Ok(unsafe { (File::from_raw_fd(master), File::from_raw_fd(slave)) })
+}
+
+#[cfg(unix)]
+fn set_cloexec(fd: RawFd) -> std::io::Result<()> {
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+    if flags == -1 {
+        return Err(std::io::Error::last_os_error());
+    }
+    let result = unsafe { libc::fcntl(fd, libc::F_SETFD, flags | libc::FD_CLOEXEC) };
+    if result == -1 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+pub(crate) fn close_inherited_fds_except(preserved_fds: &[RawFd]) {
+    if let Ok(dir) = std::fs::read_dir("/dev/fd") {
+        let mut fds = Vec::new();
+        for entry in dir {
+            let num = entry
+                .ok()
+                .map(|entry| entry.file_name())
+                .and_then(|name| name.into_string().ok())
+                .and_then(|name| name.parse::<RawFd>().ok());
+            if let Some(num) = num {
+                if num <= 2 || preserved_fds.contains(&num) {
+                    continue;
+                }
+                // Keep CLOEXEC descriptors open so std::process can still use
+                // its internal exec-error pipe to report spawn failures.
+                let flags = unsafe { libc::fcntl(num, libc::F_GETFD) };
+                if flags == -1 || flags & libc::FD_CLOEXEC != 0 {
+                    continue;
+                }
+                fds.push(num);
+            }
+        }
+        for fd in fds {
+            unsafe {
+                libc::close(fd);
+            }
+        }
+    }
 }

--- a/codex-rs/utils/pty/src/tests.rs
+++ b/codex-rs/utils/pty/src/tests.rs
@@ -4,6 +4,10 @@ use std::path::Path;
 use pretty_assertions::assert_eq;
 
 use crate::combine_output_receivers;
+#[cfg(unix)]
+use crate::pipe::spawn_process_no_stdin_with_inherited_fds;
+#[cfg(unix)]
+use crate::pty::spawn_process_with_inherited_fds;
 use crate::spawn_pipe_process;
 use crate::spawn_pipe_process_no_stdin;
 use crate::spawn_pty_process;
@@ -135,6 +139,42 @@ async fn collect_output_until_exit(
     }
 }
 
+#[cfg(unix)]
+async fn wait_for_output_contains(
+    output_rx: &mut tokio::sync::broadcast::Receiver<Vec<u8>>,
+    needle: &str,
+    timeout_ms: u64,
+) -> anyhow::Result<Vec<u8>> {
+    let mut collected = Vec::new();
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_millis(timeout_ms);
+
+    while tokio::time::Instant::now() < deadline {
+        let now = tokio::time::Instant::now();
+        let remaining = deadline.saturating_duration_since(now);
+        match tokio::time::timeout(remaining, output_rx.recv()).await {
+            Ok(Ok(chunk)) => {
+                collected.extend_from_slice(&chunk);
+                if String::from_utf8_lossy(&collected).contains(needle) {
+                    return Ok(collected);
+                }
+            }
+            Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => continue,
+            Ok(Err(tokio::sync::broadcast::error::RecvError::Closed)) => {
+                anyhow::bail!(
+                    "PTY output closed while waiting for {needle:?}: {:?}",
+                    String::from_utf8_lossy(&collected)
+                );
+            }
+            Err(_) => break,
+        }
+    }
+
+    anyhow::bail!(
+        "timed out waiting for {needle:?} in PTY output: {:?}",
+        String::from_utf8_lossy(&collected)
+    );
+}
+
 async fn wait_for_python_repl_ready(
     output_rx: &mut tokio::sync::broadcast::Receiver<Vec<u8>>,
     timeout_ms: u64,
@@ -166,6 +206,58 @@ async fn wait_for_python_repl_ready(
 
     anyhow::bail!(
         "timed out waiting for Python REPL readiness marker {ready_marker:?} in PTY: {:?}",
+        String::from_utf8_lossy(&collected)
+    );
+}
+
+#[cfg(unix)]
+async fn wait_for_python_repl_ready_via_probe(
+    writer: &tokio::sync::mpsc::Sender<Vec<u8>>,
+    output_rx: &mut tokio::sync::broadcast::Receiver<Vec<u8>>,
+    timeout_ms: u64,
+    newline: &str,
+) -> anyhow::Result<Vec<u8>> {
+    let mut collected = Vec::new();
+    let marker = "__codex_pty_ready__";
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_millis(timeout_ms);
+    let probe_window = tokio::time::Duration::from_millis(if cfg!(windows) { 750 } else { 250 });
+
+    while tokio::time::Instant::now() < deadline {
+        writer
+            .send(format!("print('{marker}'){newline}").into_bytes())
+            .await?;
+
+        let probe_deadline = tokio::time::Instant::now() + probe_window;
+        loop {
+            let now = tokio::time::Instant::now();
+            if now >= deadline || now >= probe_deadline {
+                break;
+            }
+            let remaining = std::cmp::min(
+                deadline.saturating_duration_since(now),
+                probe_deadline.saturating_duration_since(now),
+            );
+            match tokio::time::timeout(remaining, output_rx.recv()).await {
+                Ok(Ok(chunk)) => {
+                    collected.extend_from_slice(&chunk);
+                    if String::from_utf8_lossy(&collected).contains(marker) {
+                        return Ok(collected);
+                    }
+                }
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => continue,
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Closed)) => {
+                    anyhow::bail!(
+                        "PTY output closed while waiting for Python REPL readiness: {:?}",
+                        String::from_utf8_lossy(&collected)
+                    );
+                }
+                Err(_) => break,
+            }
+        }
+    }
+
+    anyhow::bail!(
+        "timed out waiting for Python REPL readiness in PTY: {:?}",
         String::from_utf8_lossy(&collected)
     );
 }
@@ -209,16 +301,26 @@ async fn wait_for_marker_pid(
         collected.extend_from_slice(&chunk);
 
         let text = String::from_utf8_lossy(&collected);
-        if let Some(marker_idx) = text.find(marker) {
-            let suffix = &text[marker_idx + marker.len()..];
-            let digits: String = suffix
+        let mut offset = 0;
+        while let Some(pos) = text[offset..].find(marker) {
+            let marker_start = offset + pos;
+            let suffix = &text[marker_start + marker.len()..];
+            let digits_len = suffix
                 .chars()
-                .skip_while(|ch| !ch.is_ascii_digit())
                 .take_while(char::is_ascii_digit)
-                .collect();
-            if !digits.is_empty() {
-                return Ok(digits.parse()?);
+                .map(char::len_utf8)
+                .sum::<usize>();
+            if digits_len == 0 {
+                offset = marker_start + marker.len();
+                continue;
             }
+
+            let pid_str = &suffix[..digits_len];
+            let trailing = &suffix[digits_len..];
+            if trailing.is_empty() {
+                break;
+            }
+            return Ok(pid_str.parse()?);
         }
     }
 }
@@ -566,6 +668,279 @@ async fn pty_terminate_kills_background_children_in_same_process_group() -> anyh
         exited,
         "background child pid {bg_pid} survived PTY terminate()"
     );
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pty_spawn_can_preserve_inherited_fds() -> anyhow::Result<()> {
+    use std::io::Read;
+    use std::os::fd::AsRawFd;
+    use std::os::fd::FromRawFd;
+
+    let mut fds = [0; 2];
+    let result = unsafe { libc::pipe(fds.as_mut_ptr()) };
+    if result != 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+
+    let mut read_end = unsafe { std::fs::File::from_raw_fd(fds[0]) };
+    let write_end = unsafe { std::fs::File::from_raw_fd(fds[1]) };
+
+    let mut env_map: HashMap<String, String> = std::env::vars().collect();
+    env_map.insert(
+        "PRESERVED_FD".to_string(),
+        write_end.as_raw_fd().to_string(),
+    );
+
+    let script = "printf __preserved__ >\"/dev/fd/$PRESERVED_FD\"";
+    let spawned = spawn_process_with_inherited_fds(
+        "/bin/sh",
+        &["-c".to_string(), script.to_string()],
+        Path::new("."),
+        &env_map,
+        &None,
+        TerminalSize::default(),
+        &[write_end.as_raw_fd()],
+    )
+    .await?;
+
+    drop(write_end);
+
+    let (_session, output_rx, exit_rx) = combine_spawned_output(spawned);
+    let (_, code) = collect_output_until_exit(output_rx, exit_rx, 2_000).await;
+    assert_eq!(code, 0, "expected preserved-fd PTY child to exit cleanly");
+
+    let mut pipe_output = String::new();
+    read_end.read_to_string(&mut pipe_output)?;
+    assert_eq!(pipe_output, "__preserved__");
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pty_preserving_inherited_fds_keeps_python_repl_running() -> anyhow::Result<()> {
+    use std::os::fd::AsRawFd;
+    use std::os::fd::FromRawFd;
+
+    let Some(python) = find_python() else {
+        eprintln!(
+            "python not found; skipping pty_preserving_inherited_fds_keeps_python_repl_running"
+        );
+        return Ok(());
+    };
+
+    let mut fds = [0; 2];
+    let result = unsafe { libc::pipe(fds.as_mut_ptr()) };
+    if result != 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+
+    let read_end = unsafe { std::fs::File::from_raw_fd(fds[0]) };
+    let preserved_fd = unsafe { std::fs::File::from_raw_fd(fds[1]) };
+
+    let mut env_map: HashMap<String, String> = std::env::vars().collect();
+    env_map.insert(
+        "PRESERVED_FD".to_string(),
+        preserved_fd.as_raw_fd().to_string(),
+    );
+
+    let spawned = spawn_process_with_inherited_fds(
+        &python,
+        &[],
+        Path::new("."),
+        &env_map,
+        &None,
+        TerminalSize::default(),
+        &[preserved_fd.as_raw_fd()],
+    )
+    .await?;
+    drop(read_end);
+    drop(preserved_fd);
+
+    let (session, mut output_rx, exit_rx) = combine_spawned_output(spawned);
+    let writer = session.writer_sender();
+    let newline = "\n";
+    let mut output =
+        wait_for_python_repl_ready_via_probe(&writer, &mut output_rx, 5_000, newline).await?;
+    let marker = "__codex_preserved_py_pid:";
+    writer
+        .send(format!("import os; print('{marker}' + str(os.getpid())){newline}").into_bytes())
+        .await?;
+
+    let python_pid = match wait_for_marker_pid(&mut output_rx, marker, 2_000).await {
+        Ok(pid) => pid,
+        Err(err) => {
+            session.terminate();
+            return Err(err);
+        }
+    };
+    assert!(
+        process_exists(python_pid)?,
+        "expected python pid {python_pid} to stay alive after prompt output"
+    );
+
+    writer.send(format!("exit(){newline}").into_bytes()).await?;
+    let (remaining_output, code) = collect_output_until_exit(output_rx, exit_rx, 5_000).await;
+    output.extend_from_slice(&remaining_output);
+
+    assert_eq!(code, 0, "expected python to exit cleanly");
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pty_spawn_with_inherited_fds_reports_exec_failures() -> anyhow::Result<()> {
+    use std::os::fd::AsRawFd;
+    use std::os::fd::FromRawFd;
+
+    let mut fds = [0; 2];
+    let result = unsafe { libc::pipe(fds.as_mut_ptr()) };
+    if result != 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+
+    let read_end = unsafe { std::fs::File::from_raw_fd(fds[0]) };
+    let write_end = unsafe { std::fs::File::from_raw_fd(fds[1]) };
+
+    let env_map: HashMap<String, String> = std::env::vars().collect();
+    let spawn_result = spawn_process_with_inherited_fds(
+        "/definitely/missing/command",
+        &[],
+        Path::new("."),
+        &env_map,
+        &None,
+        TerminalSize::default(),
+        &[write_end.as_raw_fd()],
+    )
+    .await;
+
+    drop(read_end);
+    drop(write_end);
+
+    let err = match spawn_result {
+        Ok(spawned) => {
+            spawned.session.terminate();
+            anyhow::bail!("missing executable unexpectedly spawned");
+        }
+        Err(err) => err,
+    };
+    let err_text = err.to_string();
+    assert!(
+        err_text.contains("No such file")
+            || err_text.contains("not found")
+            || err_text.contains("os error 2"),
+        "expected spawn error for missing executable, got: {err_text}",
+    );
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pty_spawn_with_inherited_fds_supports_resize() -> anyhow::Result<()> {
+    use std::os::fd::AsRawFd;
+    use std::os::fd::FromRawFd;
+
+    let mut fds = [0; 2];
+    let result = unsafe { libc::pipe(fds.as_mut_ptr()) };
+    if result != 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+
+    let read_end = unsafe { std::fs::File::from_raw_fd(fds[0]) };
+    let write_end = unsafe { std::fs::File::from_raw_fd(fds[1]) };
+
+    let env_map: HashMap<String, String> = std::env::vars().collect();
+    let script =
+        "stty -echo; printf 'start:%s\\n' \"$(stty size)\"; IFS= read _line; printf 'after:%s\\n' \"$(stty size)\"";
+    let spawned = spawn_process_with_inherited_fds(
+        "/bin/sh",
+        &["-c".to_string(), script.to_string()],
+        Path::new("."),
+        &env_map,
+        &None,
+        TerminalSize {
+            rows: 31,
+            cols: 101,
+        },
+        &[write_end.as_raw_fd()],
+    )
+    .await?;
+
+    let (session, mut output_rx, exit_rx) = combine_spawned_output(spawned);
+    let writer = session.writer_sender();
+    let mut output = wait_for_output_contains(&mut output_rx, "start:31 101\r\n", 5_000).await?;
+
+    session.resize(TerminalSize {
+        rows: 45,
+        cols: 132,
+    })?;
+    writer.send(b"go\n".to_vec()).await?;
+    session.close_stdin();
+
+    let (remaining_output, code) = collect_output_until_exit(output_rx, exit_rx, 5_000).await;
+    output.extend_from_slice(&remaining_output);
+    let text = String::from_utf8_lossy(&output);
+    let normalized = text.replace("\r\n", "\n");
+
+    assert!(
+        normalized.contains("after:45 132\n"),
+        "expected resized PTY dimensions in output: {text:?}"
+    );
+    assert_eq!(code, 0, "expected shell to exit cleanly after resize");
+
+    drop(read_end);
+    drop(write_end);
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pipe_spawn_no_stdin_can_preserve_inherited_fds() -> anyhow::Result<()> {
+    use std::io::Read;
+    use std::os::fd::AsRawFd;
+    use std::os::fd::FromRawFd;
+
+    let mut fds = [0; 2];
+    let result = unsafe { libc::pipe(fds.as_mut_ptr()) };
+    if result != 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+
+    let mut read_end = unsafe { std::fs::File::from_raw_fd(fds[0]) };
+    let write_end = unsafe { std::fs::File::from_raw_fd(fds[1]) };
+
+    let mut env_map: HashMap<String, String> = std::env::vars().collect();
+    env_map.insert(
+        "PRESERVED_FD".to_string(),
+        write_end.as_raw_fd().to_string(),
+    );
+
+    let script = "printf __pipe_preserved__ >\"/dev/fd/$PRESERVED_FD\"";
+    let spawned = spawn_process_no_stdin_with_inherited_fds(
+        "/bin/sh",
+        &["-c".to_string(), script.to_string()],
+        Path::new("."),
+        &env_map,
+        &None,
+        &[write_end.as_raw_fd()],
+    )
+    .await?;
+
+    drop(write_end);
+
+    let (_session, output_rx, exit_rx) = combine_spawned_output(spawned);
+    let (_, code) = collect_output_until_exit(output_rx, exit_rx, 2_000).await;
+    assert_eq!(code, 0, "expected preserved-fd pipe child to exit cleanly");
+
+    let mut pipe_output = String::new();
+    read_end.read_to_string(&mut pipe_output)?;
+    assert_eq!(pipe_output, "__pipe_preserved__");
 
     Ok(())
 }


### PR DESCRIPTION
## Why

`zsh-fork` sessions launched through unified-exec need the escalation socket to survive the wrapper -> server -> child handoff so later intercepted `exec()` calls can still reach the escalation server.

The inherited-fd spawn path also needs to avoid closing Rust's internal exec-error pipe, and the shell-escalation handoff needs to tolerate the receive-side case where a transferred fd is installed into the same stdio slot it will be mapped onto.

## What Changed

- Added `SpawnLifecycle::inherited_fds()` in `codex-rs/core/src/unified_exec/process.rs` and threaded inherited fds through `codex-rs/core/src/unified_exec/process_manager.rs` so unified-exec can preserve required descriptors across both PTY and no-stdin pipe spawn paths.
- Updated `codex-rs/core/src/tools/runtimes/shell/zsh_fork_backend.rs` to expose the escalation socket fd through the spawn lifecycle.
- Added inherited-fd-aware spawn helpers in `codex-rs/utils/pty/src/pty.rs` and `codex-rs/utils/pty/src/pipe.rs`, including Unix pre-exec fd pruning that preserves requested inherited fds while leaving `FD_CLOEXEC` descriptors alone. The pruning helper is now named `close_inherited_fds_except()` to better describe that behavior.
- Updated `codex-rs/shell-escalation/src/unix/escalate_client.rs` to duplicate local stdio before transfer and send destination stdio numbers in `SuperExecMessage`, so the wrapper keeps using its own `stdin`/`stdout`/`stderr` until the escalated child takes over.
- Updated `codex-rs/shell-escalation/src/unix/escalate_server.rs` so the server accepts the overlap case where a received fd reuses the same stdio descriptor number that the child setup will target with `dup2`.
- Added comments around the PTY stdio wiring and the overlap regression helper to make the fd handoff and controlling-terminal setup easier to follow.

## Verification

- `cargo test -p codex-utils-pty`
  - covers preserved-fd PTY spawn behavior, PTY resize, Python REPL continuity, exec-failure reporting, and the no-stdin pipe path
- `cargo test -p codex-shell-escalation`
  - covers duplicated-fd transfer on the client side and verifies the overlap case by passing a pipe-backed stdin payload through the server-side `dup2` path

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/13644).
* #14624
* __->__ #13644