### PR TITLE
tui: sort resume picker by last updated time

### DIFF
--- a/codex-rs/tui/src/resume_picker.rs
+++ b/codex-rs/tui/src/resume_picker.rs
@@ -390,7 +390,7 @@ impl PickerState {
             show_all,
             filter_cwd,
             action,
-            sort_key: ThreadSortKey::CreatedAt,
+            sort_key: ThreadSortKey::UpdatedAt,
             thread_name_cache: HashMap::new(),
             inline_error: None,
         }
@@ -2108,7 +2108,7 @@ mod tests {
         {
             let guard = recorded_requests.lock().unwrap();
             assert_eq!(guard.len(), 1);
-            assert_eq!(guard[0].sort_key, ThreadSortKey::CreatedAt);
+            assert_eq!(guard[0].sort_key, ThreadSortKey::UpdatedAt);
         }
 
         state
@@ -2118,7 +2118,7 @@ mod tests {
 
         let guard = recorded_requests.lock().unwrap();
         assert_eq!(guard.len(), 2);
-        assert_eq!(guard[1].sort_key, ThreadSortKey::UpdatedAt);
+        assert_eq!(guard[1].sort_key, ThreadSortKey::CreatedAt);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- default the resume picker sort key to UpdatedAt instead of CreatedAt
- keep Tab sort toggling behavior and update the test expectation for the new default

## Testing
- just fmt
- cargo test -p codex-tui