### PR TITLE
docs: add Windows IDE local-link troubleshooting for vscode-resource URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ You can also use Codex with an API key, but this requires [additional setup](htt
 - [**Codex Documentation**](https://developers.openai.com/codex)
 - [**Contributing**](./docs/contributing.md)
 - [**Installing & building**](./docs/install.md)
+- [**IDE link troubleshooting (Windows)**](./docs/ide-link-troubleshooting.md)
 - [**Open source fund**](./docs/open-source-fund.md)
 
 This repository is licensed under the [Apache-2.0 License](LICENSE).

--- a/docs/ide-link-troubleshooting.md
+++ b/docs/ide-link-troubleshooting.md
@@ -1,0 +1,62 @@
+# IDE Link Troubleshooting (Windows)
+
+If local file links in the Codex IDE sidebar open in your browser (or fail with a `file+.vscode-resource.vscode-cdn.net/...` URL), use the checks and workarounds below.
+
+This has been reported by multiple users in:
+
+- https://github.com/openai/codex/issues/12661
+- https://github.com/openai/codex/issues/12984
+
+## Symptoms
+
+- Clicking a local file link opens Edge/Chrome instead of an editor tab.
+- Clicking a link opens a URL like:
+  - `https://file+.vscode-resource.vscode-cdn.net/c%3A/...`
+- The URL may include `#` and does not open the expected file.
+
+## Quick checks
+
+1. Confirm the issue is in the IDE extension webview (not terminal output links).
+2. Confirm the same link opens correctly if pasted as a plain local path in:
+   - VS Code/Cursor command palette: `File: Open File...`
+3. If this only happens in one old thread, try a new thread to rule out stale webview state.
+
+## Workarounds
+
+### Workaround A: Use plain absolute file paths in responses
+
+When sharing file references, prefer plain absolute paths:
+
+```text
+C:\Users\name\project\src\app.ts:42
+```
+
+Avoid relying on markdown-style local links in affected builds.
+
+### Workaround B: Decode `file+.vscode-resource...` links and open locally
+
+PowerShell helper:
+
+```powershell
+$u = "https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/name/project/src/app.ts#"
+$p = [System.Uri]::UnescapeDataString(($u -replace '^https://file\+\.vscode-resource\.vscode-cdn\.net/', '')) `
+  -replace '[?#].*$','' `
+  -replace '/', '\'
+code --goto $p
+```
+
+If you use Cursor CLI instead of VS Code CLI:
+
+```powershell
+cursor --goto $p
+```
+
+## When reporting
+
+Include:
+
+- OS and version
+- IDE and version (VS Code/Cursor/Windsurf)
+- Extension version (for example `openai.chatgpt 0.5.78`)
+- One failing sample URL and expected file path
+- Whether the issue reproduces in a brand-new thread


### PR DESCRIPTION
## Summary
Add a short troubleshooting guide for Windows users when local links in the Codex IDE webview open in the browser (or resolve to `file+.vscode-resource.vscode-cdn.net/...`) instead of opening in editor tabs.

## What changed
- Add `docs/ide-link-troubleshooting.md`
- Link the guide from the docs list in `README.md`

## Why
This behavior is reported by multiple users and is currently a workflow blocker in IDE extension usage:
- Context for #12661
- Related to #12984

This PR is docs-only and provides immediate user-facing mitigations while an extension code fix is being shipped.

## Validation
- Confirmed commands and path-decoding examples are valid in Windows PowerShell
- Includes both VS Code (`code --goto`) and Cursor (`cursor --goto`) variants