### PR TITLE
fix: accept two macOS automation input shapes  for approval payload compatibility

### DIFF
--- a/codex-rs/app-server-protocol/schema/json/EventMsg.json
+++ b/codex-rs/app-server-protocol/schema/json/EventMsg.json
@@ -3794,24 +3794,30 @@
     "MacOsSeatbeltProfileExtensions": {
       "properties": {
         "macos_accessibility": {
+          "default": false,
           "type": "boolean"
         },
         "macos_automation": {
-          "$ref": "#/definitions/MacOsAutomationPermission"
+          "allOf": [
+            {
+              "$ref": "#/definitions/MacOsAutomationPermission"
+            }
+          ],
+          "default": "none"
         },
         "macos_calendar": {
+          "default": false,
           "type": "boolean"
         },
         "macos_preferences": {
-          "$ref": "#/definitions/MacOsPreferencesPermission"
+          "allOf": [
+            {
+              "$ref": "#/definitions/MacOsPreferencesPermission"
+            }
+          ],
+          "default": "read_only"
         }
       },
-      "required": [
-        "macos_accessibility",
-        "macos_automation",
-        "macos_calendar",
-        "macos_preferences"
-      ],
       "type": "object"
     },
     "McpAuthStatus": {

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
@@ -5277,24 +5277,30 @@
     "MacOsSeatbeltProfileExtensions": {
       "properties": {
         "macos_accessibility": {
+          "default": false,
           "type": "boolean"
         },
         "macos_automation": {
-          "$ref": "#/definitions/MacOsAutomationPermission"
+          "allOf": [
+            {
+              "$ref": "#/definitions/MacOsAutomationPermission"
+            }
+          ],
+          "default": "none"
         },
         "macos_calendar": {
+          "default": false,
           "type": "boolean"
         },
         "macos_preferences": {
-          "$ref": "#/definitions/MacOsPreferencesPermission"
+          "allOf": [
+            {
+              "$ref": "#/definitions/MacOsPreferencesPermission"
+            }
+          ],
+          "default": "read_only"
         }
       },
-      "required": [
-        "macos_accessibility",
-        "macos_automation",
-        "macos_calendar",
-        "macos_preferences"
-      ],
       "type": "object"
     },
     "McpInvocation": {

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
@@ -7412,24 +7412,30 @@
     "MacOsSeatbeltProfileExtensions": {
       "properties": {
         "macos_accessibility": {
+          "default": false,
           "type": "boolean"
         },
         "macos_automation": {
-          "$ref": "#/definitions/MacOsAutomationPermission"
+          "allOf": [
+            {
+              "$ref": "#/definitions/MacOsAutomationPermission"
+            }
+          ],
+          "default": "none"
         },
         "macos_calendar": {
+          "default": false,
           "type": "boolean"
         },
         "macos_preferences": {
-          "$ref": "#/definitions/MacOsPreferencesPermission"
+          "allOf": [
+            {
+              "$ref": "#/definitions/MacOsPreferencesPermission"
+            }
+          ],
+          "default": "read_only"
         }
       },
-      "required": [
-        "macos_accessibility",
-        "macos_automation",
-        "macos_calendar",
-        "macos_preferences"
-      ],
       "type": "object"
     },
     "McpAuthStatus": {

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -4551,6 +4551,46 @@ mod tests {
     }
 
     #[test]
+    fn command_execution_request_approval_accepts_macos_automation_bundle_ids_object() {
+        let params = serde_json::from_value::<CommandExecutionRequestApprovalParams>(json!({
+            "threadId": "thr_123",
+            "turnId": "turn_123",
+            "itemId": "call_123",
+            "command": "cat file",
+            "cwd": "/tmp",
+            "commandActions": null,
+            "reason": null,
+            "networkApprovalContext": null,
+            "additionalPermissions": {
+                "network": null,
+                "fileSystem": null,
+                "macos": {
+                    "preferences": "read_only",
+                    "automations": {
+                        "bundle_ids": ["com.apple.Notes"]
+                    },
+                    "accessibility": false,
+                    "calendar": false
+                }
+            },
+            "proposedExecpolicyAmendment": null,
+            "proposedNetworkPolicyAmendments": null,
+            "availableDecisions": null
+        }))
+        .expect("bundle_ids object should deserialize");
+
+        assert_eq!(
+            params
+                .additional_permissions
+                .and_then(|permissions| permissions.macos)
+                .map(|macos| macos.automations),
+            Some(CoreMacOsAutomationPermission::BundleIds(vec![
+                "com.apple.Notes".to_string(),
+            ]))
+        );
+    }
+
+    #[test]
     fn sandbox_policy_round_trips_external_sandbox_network_access() {
         let v2_policy = SandboxPolicy::ExternalSandbox {
             network_access: NetworkAccess::Enabled,

--- a/codex-rs/protocol/src/models.rs
+++ b/codex-rs/protocol/src/models.rs
@@ -147,6 +147,7 @@ pub enum MacOsAutomationPermission {
 enum MacOsAutomationPermissionDe {
     Mode(String),
     BundleIds(Vec<String>),
+    BundleIdsObject { bundle_ids: Vec<String> },
 }
 
 impl TryFrom<MacOsAutomationPermissionDe> for MacOsAutomationPermission {
@@ -155,6 +156,7 @@ impl TryFrom<MacOsAutomationPermissionDe> for MacOsAutomationPermission {
     /// Accepts one of:
     /// - `"none"` or `"all"`
     /// - a plain list of bundle IDs, e.g. `["com.apple.Notes"]`
+    /// - an object with bundle IDs, e.g. `{"bundle_ids": ["com.apple.Notes"]}`
     fn try_from(value: MacOsAutomationPermissionDe) -> Result<Self, Self::Error> {
         let permission = match value {
             MacOsAutomationPermissionDe::Mode(value) => {
@@ -169,7 +171,8 @@ impl TryFrom<MacOsAutomationPermissionDe> for MacOsAutomationPermission {
                     ));
                 }
             }
-            MacOsAutomationPermissionDe::BundleIds(bundle_ids) => {
+            MacOsAutomationPermissionDe::BundleIds(bundle_ids)
+            | MacOsAutomationPermissionDe::BundleIdsObject { bundle_ids } => {
                 let bundle_ids = bundle_ids
                     .into_iter()
                     .map(|bundle_id| bundle_id.trim().to_string())
@@ -1483,6 +1486,19 @@ mod tests {
 
         assert_eq!(all, MacOsAutomationPermission::All);
         assert_eq!(none, MacOsAutomationPermission::None);
+    }
+
+    #[test]
+    fn macos_automation_permission_deserializes_bundle_ids_object() {
+        let permission = serde_json::from_value::<MacOsAutomationPermission>(serde_json::json!({
+            "bundle_ids": ["com.apple.Notes"]
+        }))
+        .expect("deserialize bundle_ids object automation permission");
+
+        assert_eq!(
+            permission,
+            MacOsAutomationPermission::BundleIds(vec!["com.apple.Notes".to_string(),])
+        );
     }
 
     #[test]

--- a/codex-rs/protocol/src/models.rs
+++ b/codex-rs/protocol/src/models.rs
@@ -188,6 +188,7 @@ impl TryFrom<MacOsAutomationPermissionDe> for MacOsAutomationPermission {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Hash, Serialize, Deserialize, JsonSchema, TS)]
+#[serde(default)]
 pub struct MacOsSeatbeltProfileExtensions {
     pub macos_preferences: MacOsPreferencesPermission,
     pub macos_automation: MacOsAutomationPermission,
@@ -1448,6 +1449,27 @@ mod tests {
                     macos_accessibility: true,
                     macos_calendar: true,
                 }),
+            }
+        );
+    }
+
+    #[test]
+    fn macos_seatbelt_profile_extensions_deserializes_missing_fields_to_defaults() {
+        let permissions =
+            serde_json::from_value::<MacOsSeatbeltProfileExtensions>(serde_json::json!({
+                "macos_automation": ["com.apple.Notes"]
+            }))
+            .expect("deserialize macos permissions");
+
+        assert_eq!(
+            permissions,
+            MacOsSeatbeltProfileExtensions {
+                macos_preferences: MacOsPreferencesPermission::ReadOnly,
+                macos_automation: MacOsAutomationPermission::BundleIds(vec![
+                    "com.apple.Notes".to_string(),
+                ]),
+                macos_accessibility: false,
+                macos_calendar: false,
             }
         );
     }


### PR DESCRIPTION
## Summary
This PR:
1. fixes a deserialization mismatch for macOS automation permissions in approval payloads by making core parsing accept both supported wire shapes for bundle IDs.
2. added `#[serde(default)]` to `MacOsSeatbeltProfileExtensions` so omitted fields deserialize to secure defaults.


## Why this change is needed
`MacOsAutomationPermission` uses `#[serde(try_from = "MacOsAutomationPermissionDe")]`, so deserialization is controlled by `MacOsAutomationPermissionDe`. After we aligned v2 `additionalPermissions.macos.automations` to the core shape, approval payloads started including `{ "bundle_ids": [...] }` in some paths. `MacOsAutomationPermissionDe` previously accepted only `"none" | "all"` or a plain array, so object-shaped bundle IDs failed with `data did not match any variant of untagged enum MacOsAutomationPermissionDe`. This change restores compatibility by accepting both forms while preserving existing normalization behavior (trim values and map empty bundle lists to `None`).

## Validation

saw this error went away when running
```
cargo run -p codex-app-server-test-client -- \
    --codex-bin ./target/debug/codex \
    -c 'approval_policy="on-request"' \
    -c 'features.shell_zsh_fork=true' \
    -c 'zsh_path="/tmp/codex-zsh-fork/package/vendor/aarch64-apple-darwin/zsh/macos-15/zsh"' \
    send-message-v2 --experimental-api \
    'Use $apple-notes and run scripts/notes_info now.'
```
:
```
Error: failed to deserialize ServerRequest from JSONRPCRequest

Caused by:
    data did not match any variant of untagged enum MacOsAutomationPermissionDe
```