### PR TITLE
Add timestamps to feedback log lines

### DIFF
--- a/codex-rs/feedback/src/lib.rs
+++ b/codex-rs/feedback/src/lib.rs
@@ -71,6 +71,7 @@ impl CodexFeedback {
     {
         tracing_subscriber::fmt::layer()
             .with_writer(self.make_writer())
+            .with_timer(tracing_subscriber::fmt::time::SystemTime)
             .with_ansi(false)
             .with_target(false)
             // Capture everything, regardless of the caller's `RUST_LOG`, so feedback includes the


### PR DESCRIPTION
`/feedback` uploads can include `codex-logs.log` from the in-memory feedback logger path. That logger was emitting level + message without a timestamp, which made some uploaded logs much harder to inspect. This change makes the feedback logger use an explicit timer so feedback-captured log lines include timestamps consistently.

This is not Windows-specific code. The bug showed up in Windows reports because those uploads were hitting the feedback-buffer path more often, while Linux/macOS reports were typically coming from the SQLite feedback export, which already prefixes timestamps.

Here's an example of a log that is missing the timestamps:

```
TRACE app-server request: getAuthStatus
TRACE app-server request: model/list
 INFO models cache: evaluating cache eligibility
 INFO models cache: attempting load_fresh
 INFO models cache: loaded cache file
 INFO models cache: cache version mismatch
 INFO models cache: no usable cache entry
DEBUG 
 INFO models cache: cache miss, fetching remote models
TRACE windows::current_platform is called
TRACE Returning Info { os_type: Windows, version: Semantic(10, 0, 26200), edition: Some("Windows 11 Professional"), codename: None, bitness: X64, architecture: Some("x86_64") }
```
