### PR TITLE
fix(app-server): fix turn_start_shell_zsh_fork_executes_command_v2 flake

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/turn_start_zsh_fork.rs
+++ b/codex-rs/app-server/tests/suite/v2/turn_start_zsh_fork.rs
@@ -61,13 +61,22 @@ async fn turn_start_shell_zsh_fork_executes_command_v2() -> Result<()> {
     };
     eprintln!("using zsh path for zsh-fork test: {}", zsh_path.display());
 
-    let responses = vec![create_shell_command_sse_response(
+    let response = create_shell_command_sse_response(
         vec!["echo".to_string(), "hi".to_string()],
         None,
         Some(5000),
         "call-zsh-fork",
-    )?];
-    let server = create_mock_responses_server_sequence(responses).await;
+    )?;
+    let no_op_response = responses::sse(vec![
+        responses::ev_response_created("resp-2"),
+        responses::ev_completed("resp-2"),
+    ]);
+    // Interrupting after the shell item starts can race with the follow-up
+    // model request that reports the aborted tool call. This test only cares
+    // that zsh-fork launches the expected command, so allow one extra no-op
+    // `/responses` POST instead of asserting an exact request count.
+    let server =
+        create_mock_responses_server_sequence_unchecked(vec![response, no_op_response]).await;
     create_config_toml(
         &codex_home,
         &server.uri(),


### PR DESCRIPTION
This fixes a flaky `turn_start_shell_zsh_fork_executes_command_v2` test.

The interrupt path can race with the follow-up `/responses` request that reports the aborted tool call, so the test now allows that extra no-op response instead of assuming there will only ever be one request. The assertions still stay focused on the behavior the test actually cares about: starting the zsh-forked command correctly.

Testing:
- `just fmt`
- `cargo test -p codex-app-server --test all suite::v2::turn_start_zsh_fork::turn_start_shell_zsh_fork_executes_command_v2 -- --exact --nocapture`
