### PR TITLE
Reduce SQLite log retention to 10 days

### DIFF
--- a/codex-rs/state/src/log_db.rs
+++ b/codex-rs/state/src/log_db.rs
@@ -43,7 +43,7 @@ use crate::StateRuntime;
 const LOG_QUEUE_CAPACITY: usize = 512;
 const LOG_BATCH_SIZE: usize = 128;
 const LOG_FLUSH_INTERVAL: Duration = Duration::from_secs(2);
-const LOG_RETENTION_DAYS: i64 = 90;
+const LOG_RETENTION_DAYS: i64 = 10;
 
 pub struct LogDbLayer {
     sender: mpsc::Sender<LogDbCommand>,


### PR DESCRIPTION
## Summary
- reduce the SQLite-backed log retention window from 90 days to 10 days

## Testing
- just fmt
- cargo test -p codex-state