### PR TITLE
Include logs migrations in Bazel state target

### DIFF
--- a/codex-rs/state/BUILD.bazel
+++ b/codex-rs/state/BUILD.bazel
@@ -3,5 +3,8 @@ load("//:defs.bzl", "codex_rust_crate")
 codex_rust_crate(
     name = "state",
     crate_name = "codex_state",
-    compile_data = glob(["migrations/**"]),
+    compile_data = glob([
+        "logs_migrations/**",
+        "migrations/**",
+    ]),
 )


### PR DESCRIPTION
## Summary
- add `logs_migrations/**` to the `codex-rs/state` Bazel target's `compile_data`
- fix remote Bazel builds that compile `codex-state` with `sqlx::migrate!("./logs_migrations")`
- keep the change scoped to Bazel packaging only

## Testing
- bazel build //codex-rs/state:state
- cargo test -p codex-state
