### PR TITLE
Put Default-mode request_user_input back in /experimental

### DIFF
--- a/codex-rs/core/src/features.rs
+++ b/codex-rs/core/src/features.rs
@@ -686,8 +686,12 @@ pub const FEATURES: &[FeatureSpec] = &[
     FeatureSpec {
         id: Feature::DefaultModeRequestUserInput,
         key: "default_mode_request_user_input",
-        stage: Stage::Stable,
-        default_enabled: true,
+        stage: Stage::Experimental {
+            name: "Default mode request_user_input",
+            menu_description: "Allow Codex to use the request_user_input tool in Default mode when it truly cannot proceed safely with a reasonable assumption. Restart Codex after enabling.",
+            announcement: "NEW: Allow request_user_input in Default mode. Enable it in /experimental and restart Codex!",
+        },
+        default_enabled: false,
     },
     FeatureSpec {
         id: Feature::CollaborationModes,
@@ -882,6 +886,28 @@ mod tests {
             ))
         );
         assert_eq!(Feature::JsRepl.default_enabled(), false);
+    }
+
+    #[test]
+    fn default_mode_request_user_input_is_experimental_and_user_toggleable() {
+        let spec = Feature::DefaultModeRequestUserInput.info();
+        let stage = spec.stage;
+
+        assert!(matches!(stage, Stage::Experimental { .. }));
+        assert_eq!(
+            stage.experimental_menu_name(),
+            Some("Default mode request_user_input")
+        );
+        assert_eq!(
+            stage.experimental_menu_description(),
+            Some(
+                "Allow Codex to use the request_user_input tool in Default mode when it truly cannot proceed safely with a reasonable assumption. Restart Codex after enabling."
+            )
+        );
+        assert_eq!(
+            Feature::DefaultModeRequestUserInput.default_enabled(),
+            false
+        );
     }
 
     #[test]

--- a/codex-rs/core/src/features.rs
+++ b/codex-rs/core/src/features.rs
@@ -686,8 +686,8 @@ pub const FEATURES: &[FeatureSpec] = &[
     FeatureSpec {
         id: Feature::DefaultModeRequestUserInput,
         key: "default_mode_request_user_input",
-        stage: Stage::UnderDevelopment,
-        default_enabled: false,
+        stage: Stage::Stable,
+        default_enabled: true,
     },
     FeatureSpec {
         id: Feature::CollaborationModes,

--- a/codex-rs/core/src/tools/spec.rs
+++ b/codex-rs/core/src/tools/spec.rs
@@ -2262,7 +2262,9 @@ mod tests {
             create_exec_command_tool(true, false),
             create_write_stdin_tool(),
             PLAN_TOOL.clone(),
-            create_request_user_input_tool(CollaborationModesConfig::default()),
+            create_request_user_input_tool(CollaborationModesConfig {
+                default_mode_request_user_input: true,
+            }),
             create_apply_patch_freeform_tool(),
             ToolSpec::WebSearch {
                 external_web_access: Some(true),
@@ -2381,10 +2383,12 @@ mod tests {
         let request_user_input_tool = find_tool(&tools, "request_user_input");
         assert_eq!(
             request_user_input_tool.spec,
-            create_request_user_input_tool(CollaborationModesConfig::default())
+            create_request_user_input_tool(CollaborationModesConfig {
+                default_mode_request_user_input: true,
+            })
         );
 
-        features.enable(Feature::DefaultModeRequestUserInput);
+        features.disable(Feature::DefaultModeRequestUserInput);
         let tools_config = ToolsConfig::new(&ToolsConfigParams {
             model_info: &model_info,
             features: &features,
@@ -2395,9 +2399,7 @@ mod tests {
         let request_user_input_tool = find_tool(&tools, "request_user_input");
         assert_eq!(
             request_user_input_tool.spec,
-            create_request_user_input_tool(CollaborationModesConfig {
-                default_mode_request_user_input: true,
-            })
+            create_request_user_input_tool(CollaborationModesConfig::default())
         );
     }
 

--- a/codex-rs/core/src/tools/spec.rs
+++ b/codex-rs/core/src/tools/spec.rs
@@ -2262,9 +2262,7 @@ mod tests {
             create_exec_command_tool(true, false),
             create_write_stdin_tool(),
             PLAN_TOOL.clone(),
-            create_request_user_input_tool(CollaborationModesConfig {
-                default_mode_request_user_input: true,
-            }),
+            create_request_user_input_tool(CollaborationModesConfig::default()),
             create_apply_patch_freeform_tool(),
             ToolSpec::WebSearch {
                 external_web_access: Some(true),
@@ -2383,12 +2381,10 @@ mod tests {
         let request_user_input_tool = find_tool(&tools, "request_user_input");
         assert_eq!(
             request_user_input_tool.spec,
-            create_request_user_input_tool(CollaborationModesConfig {
-                default_mode_request_user_input: true,
-            })
+            create_request_user_input_tool(CollaborationModesConfig::default())
         );
 
-        features.disable(Feature::DefaultModeRequestUserInput);
+        features.enable(Feature::DefaultModeRequestUserInput);
         let tools_config = ToolsConfig::new(&ToolsConfigParams {
             model_info: &model_info,
             features: &features,
@@ -2399,7 +2395,9 @@ mod tests {
         let request_user_input_tool = find_tool(&tools, "request_user_input");
         assert_eq!(
             request_user_input_tool.spec,
-            create_request_user_input_tool(CollaborationModesConfig::default())
+            create_request_user_input_tool(CollaborationModesConfig {
+                default_mode_request_user_input: true,
+            })
         );
     }
 

--- a/codex-rs/core/tests/suite/request_user_input.rs
+++ b/codex-rs/core/tests/suite/request_user_input.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 
+use codex_core::config::Config;
 use codex_core::features::Feature;
 use codex_protocol::config_types::CollaborationMode;
 use codex_protocol::config_types::ModeKind;
@@ -78,24 +79,13 @@ async fn request_user_input_round_trip_for_mode(mode: ModeKind) -> anyhow::Resul
 
     let server = start_mock_server().await;
 
-    let builder = test_codex();
-    #[allow(clippy::expect_used)]
+    let mut builder = test_codex();
     let TestCodex {
         codex,
         cwd,
         session_configured,
         ..
-    } = builder
-        .with_config(move |config| {
-            if mode == ModeKind::Default {
-                config
-                    .features
-                    .enable(Feature::DefaultModeRequestUserInput)
-                    .expect("test config should allow feature update");
-            }
-        })
-        .build(&server)
-        .await?;
+    } = builder.build(&server).await?;
 
     let call_id = "user-input-call";
     let request_args = json!({
@@ -196,15 +186,20 @@ async fn request_user_input_round_trip_for_mode(mode: ModeKind) -> anyhow::Resul
     Ok(())
 }
 
-async fn assert_request_user_input_rejected<F>(mode_name: &str, build_mode: F) -> anyhow::Result<()>
+async fn assert_request_user_input_rejected_with_config<F, C>(
+    mode_name: &str,
+    build_mode: F,
+    configure: C,
+) -> anyhow::Result<()>
 where
     F: FnOnce(String) -> CollaborationMode,
+    C: FnOnce(&mut Config) + Send + 'static,
 {
     skip_if_no_network!(Ok(()));
 
     let server = start_mock_server().await;
 
-    let mut builder = test_codex();
+    let mut builder = test_codex().with_config(configure);
     let TestCodex {
         codex,
         cwd,
@@ -278,6 +273,13 @@ where
     Ok(())
 }
 
+async fn assert_request_user_input_rejected<F>(mode_name: &str, build_mode: F) -> anyhow::Result<()>
+where
+    F: FnOnce(String) -> CollaborationMode,
+{
+    assert_request_user_input_rejected_with_config(mode_name, build_mode, |_| {}).await
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn request_user_input_rejected_in_execute_mode_alias() -> anyhow::Result<()> {
     assert_request_user_input_rejected("Execute", |model| CollaborationMode {
@@ -292,21 +294,31 @@ async fn request_user_input_rejected_in_execute_mode_alias() -> anyhow::Result<(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn request_user_input_rejected_in_default_mode_by_default() -> anyhow::Result<()> {
-    assert_request_user_input_rejected("Default", |model| CollaborationMode {
-        mode: ModeKind::Default,
-        settings: Settings {
-            model,
-            reasoning_effort: None,
-            developer_instructions: None,
-        },
-    })
-    .await
+async fn request_user_input_round_trip_in_default_mode_by_default() -> anyhow::Result<()> {
+    request_user_input_round_trip_for_mode(ModeKind::Default).await
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn request_user_input_round_trip_in_default_mode_with_feature() -> anyhow::Result<()> {
-    request_user_input_round_trip_for_mode(ModeKind::Default).await
+async fn request_user_input_rejected_in_default_mode_when_feature_disabled() -> anyhow::Result<()> {
+    assert_request_user_input_rejected_with_config(
+        "Default",
+        |model| CollaborationMode {
+            mode: ModeKind::Default,
+            settings: Settings {
+                model,
+                reasoning_effort: None,
+                developer_instructions: None,
+            },
+        },
+        |config| {
+            #[allow(clippy::expect_used)]
+            config
+                .features
+                .disable(Feature::DefaultModeRequestUserInput)
+                .expect("test config should allow feature update");
+        },
+    )
+    .await
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/codex-rs/core/tests/suite/request_user_input.rs
+++ b/codex-rs/core/tests/suite/request_user_input.rs
@@ -71,15 +71,21 @@ fn call_output_content_and_success(
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn request_user_input_round_trip_resolves_pending() -> anyhow::Result<()> {
-    request_user_input_round_trip_for_mode(ModeKind::Plan).await
+    request_user_input_round_trip_for_mode(ModeKind::Plan, |_| {}).await
 }
 
-async fn request_user_input_round_trip_for_mode(mode: ModeKind) -> anyhow::Result<()> {
+async fn request_user_input_round_trip_for_mode<C>(
+    mode: ModeKind,
+    configure: C,
+) -> anyhow::Result<()>
+where
+    C: FnOnce(&mut Config) + Send + 'static,
+{
     skip_if_no_network!(Ok(()));
 
     let server = start_mock_server().await;
 
-    let mut builder = test_codex();
+    let mut builder = test_codex().with_config(configure);
     let TestCodex {
         codex,
         cwd,
@@ -294,30 +300,28 @@ async fn request_user_input_rejected_in_execute_mode_alias() -> anyhow::Result<(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn request_user_input_round_trip_in_default_mode_by_default() -> anyhow::Result<()> {
-    request_user_input_round_trip_for_mode(ModeKind::Default).await
+async fn request_user_input_rejected_in_default_mode_by_default() -> anyhow::Result<()> {
+    assert_request_user_input_rejected("Default", |model| CollaborationMode {
+        mode: ModeKind::Default,
+        settings: Settings {
+            model,
+            reasoning_effort: None,
+            developer_instructions: None,
+        },
+    })
+    .await
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn request_user_input_rejected_in_default_mode_when_feature_disabled() -> anyhow::Result<()> {
-    assert_request_user_input_rejected_with_config(
-        "Default",
-        |model| CollaborationMode {
-            mode: ModeKind::Default,
-            settings: Settings {
-                model,
-                reasoning_effort: None,
-                developer_instructions: None,
-            },
-        },
-        |config| {
-            #[allow(clippy::expect_used)]
-            config
-                .features
-                .disable(Feature::DefaultModeRequestUserInput)
-                .expect("test config should allow feature update");
-        },
-    )
+async fn request_user_input_round_trip_in_default_mode_when_feature_enabled() -> anyhow::Result<()>
+{
+    request_user_input_round_trip_for_mode(ModeKind::Default, |config| {
+        #[allow(clippy::expect_used)]
+        config
+            .features
+            .enable(Feature::DefaultModeRequestUserInput)
+            .expect("test config should allow feature update");
+    })
     .await
 }
 

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -6932,8 +6932,13 @@ async fn experimental_popup_shows_js_repl_node_requirement() {
     chat.open_experimental_popup();
 
     let popup = render_bottom_popup(&chat, 120);
+    let normalized_popup = popup.split_whitespace().collect::<Vec<_>>().join(" ");
+    let normalized_requirement = node_requirement
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
     assert!(
-        popup.contains(node_requirement),
+        normalized_popup.contains(&normalized_requirement),
         "expected js_repl feature description to mention the required Node version, got:\n{popup}"
     );
 }


### PR DESCRIPTION
## Summary
- move `DefaultModeRequestUserInput` back to `Stage::Experimental`
- keep it default-off and add `/experimental` menu metadata so users can opt in explicitly
- preserve the canonical feature key `default_mode_request_user_input` and the normal `features.default_mode_request_user_input` override path
- update core tests to restore default-off behavior while keeping explicit opt-in coverage for Default mode

## Statsig compatibility
- this PR does not add Statsig gate wiring in `codex-rs`
- it keeps the feature compatible with the existing app/desktop Statsig override flow because overrides already materialize as `features.<key>` config entries on `thread/start`
- when ready, `codex-apps` can wire a Statsig gate or layer to `default_mode_request_user_input` through the existing `statsig_default_enable_features` / feature-overrides plumbing

## Testing
- `just fmt`
- `cargo test -p codex-core`
  - locally red in this environment for unrelated existing issues:
    - missing `test_stdio_server` helper binary breaks several `rmcp_client` / plugin / truncation tests
    - unrelated `search_tool::*` tests also failed locally
- `cargo test -p codex-core features::tests::default_mode_request_user_input_is_experimental_and_user_toggleable -- --exact`
- `cargo test -p codex-core tools::spec::tests::request_user_input_description_reflects_default_mode_feature_flag -- --exact`
- `cargo test -p codex-app-server experimental_feature_list -- --nocapture`
