### PR TITLE
fix: include libcap-dev dependency when creating a devcontainer for building Codex

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     build-essential curl git ca-certificates \
-    pkg-config clang musl-tools libssl-dev just && \
+    pkg-config libcap-dev clang musl-tools libssl-dev just && \
     rm -rf /var/lib/apt/lists/*
 
 # Ubuntu 24.04 ships with user 'ubuntu' already created with UID 1000.


### PR DESCRIPTION
I mainly use the devcontainer to be able to run `cargo clippy --tests` locally for Linux.

We still need to make it possible to run clippy from Bazel so I don't need to do this!