### PR TITLE
Stabilize RMCP pid file cleanup test

### DIFF
--- a/codex-rs/rmcp-client/tests/process_group_cleanup.rs
+++ b/codex-rs/rmcp-client/tests/process_group_cleanup.rs
@@ -24,8 +24,13 @@ async fn wait_for_pid_file(path: &Path) -> Result<u32> {
     for _ in 0..50 {
         match fs::read_to_string(path) {
             Ok(content) => {
-                let pid = content
-                    .trim()
+                let trimmed = content.trim();
+                if trimmed.is_empty() {
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    continue;
+                }
+
+                let pid = trimmed
                     .parse::<u32>()
                     .with_context(|| format!("failed to parse pid from {}", path.display()))?;
                 return Ok(pid);


### PR DESCRIPTION
## What changed
- The pid-file cleanup test now keeps polling when the pid file exists but is still empty.
- Assertions only proceed once the wrapper has actually written the child pid.

## Why this fixes the flake
- File creation and pid writing are not atomic as one logical action from the test’s point of view.
- The previous test sometimes won the race and read the file in the tiny window after creation but before the pid bytes were flushed.
- Treating “empty file” as “not ready yet” synchronizes the test on the real event we need: the wrapper has finished publishing the child pid.

## Scope
- Test-only change.
