### PR TITLE
Reduce app-server test timeout pressure

### DIFF
--- a/codex-rs/app-server/tests/suite/auth.rs
+++ b/codex-rs/app-server/tests/suite/auth.rs
@@ -33,6 +33,9 @@ sandbox_mode = "danger-full-access"
 
 model_provider = "mock_provider"
 
+[features]
+shell_snapshot = false
+
 [model_providers.mock_provider]
 name = "Mock provider for test"
 base_url = "http://127.0.0.1:0/v1"
@@ -53,6 +56,9 @@ fn create_config_toml(codex_home: &Path) -> std::io::Result<()> {
 model = "mock-model"
 approval_policy = "never"
 sandbox_mode = "danger-full-access"
+
+[features]
+shell_snapshot = false
 "#,
     )
 }
@@ -65,6 +71,9 @@ model = "mock-model"
 approval_policy = "never"
 sandbox_mode = "danger-full-access"
 forced_login_method = "{forced_method}"
+
+[features]
+shell_snapshot = false
 "#
     );
     std::fs::write(config_toml, contents)

--- a/codex-rs/app-server/tests/suite/fuzzy_file_search.rs
+++ b/codex-rs/app-server/tests/suite/fuzzy_file_search.rs
@@ -7,6 +7,7 @@ use codex_app_server_protocol::JSONRPCResponse;
 use codex_app_server_protocol::RequestId;
 use pretty_assertions::assert_eq;
 use serde_json::json;
+use std::path::Path;
 use tempfile::TempDir;
 use tokio::time::timeout;
 
@@ -23,7 +24,23 @@ enum FileExpectation {
     NonEmpty,
 }
 
+fn create_config_toml(codex_home: &Path) -> std::io::Result<()> {
+    let config_toml = codex_home.join("config.toml");
+    std::fs::write(
+        config_toml,
+        r#"
+model = "mock-model"
+approval_policy = "never"
+sandbox_mode = "danger-full-access"
+
+[features]
+shell_snapshot = false
+"#,
+    )
+}
+
 async fn initialized_mcp(codex_home: &TempDir) -> Result<McpProcess> {
+    create_config_toml(codex_home.path())?;
     let mut mcp = McpProcess::new(codex_home.path()).await?;
     timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
     Ok(mcp)
@@ -164,6 +181,7 @@ async fn assert_no_session_updates_for(
 async fn test_fuzzy_file_search_sorts_and_includes_indices() -> Result<()> {
     // Prepare a temporary Codex home and a separate root with test files.
     let codex_home = TempDir::new()?;
+    create_config_toml(codex_home.path())?;
     let root = TempDir::new()?;
 
     // Create files designed to have deterministic ordering for query "abe".
@@ -235,6 +253,7 @@ async fn test_fuzzy_file_search_sorts_and_includes_indices() -> Result<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_fuzzy_file_search_accepts_cancellation_token() -> Result<()> {
     let codex_home = TempDir::new()?;
+    create_config_toml(codex_home.path())?;
     let root = TempDir::new()?;
 
     std::fs::write(root.path().join("alpha.txt"), "contents")?;
@@ -434,7 +453,7 @@ async fn test_fuzzy_file_search_session_update_after_stop_fails() -> Result<()> 
 async fn test_fuzzy_file_search_session_stops_sending_updates_after_stop() -> Result<()> {
     let codex_home = TempDir::new()?;
     let root = TempDir::new()?;
-    for i in 0..2_000 {
+    for i in 0..512 {
         let file_path = root.path().join(format!("file-{i:04}.txt"));
         std::fs::write(file_path, "contents")?;
     }

--- a/codex-rs/app-server/tests/suite/v2/account.rs
+++ b/codex-rs/app-server/tests/suite/v2/account.rs
@@ -83,6 +83,9 @@ sandbox_mode = "danger-full-access"
 
 model_provider = "mock_provider"
 
+[features]
+shell_snapshot = false
+
 [model_providers.mock_provider]
 name = "Mock provider for test"
 base_url = "{base_url}"


### PR DESCRIPTION
## What changed
- The auth/account/fuzzy-file-search test configs disable unrelated `shell_snapshot` setup.
- The fuzzy-file-search fixture set was reduced so the stop-updates test does less incidental work before reaching the assertion.

## Why this fixes the flake
- These failures were caused by cumulative timeout pressure, not by a missing product-level delay.
- The old tests were paying for shell snapshot initialization and extra fixture volume that were not part of the behavior being validated.
- Removing that incidental work keeps the same coverage but shortens the critical path enough that the tests finish comfortably inside the existing timeout budget, which is the right fix versus simply extending the timeout.

## Scope
- Test-only change.
