### PR TITLE
fix(core): stabilize guardian test coverage

### DIFF
--- a/codex-rs/core/BUILD.bazel
+++ b/codex-rs/core/BUILD.bazel
@@ -36,6 +36,9 @@ codex_rust_crate(
     ],
     test_data_extra = [
         "config.schema.json",
+    ] + glob([
+        "src/**/snapshots/**",
+    ]) + [
         # This is a bit of a hack, but empirically, some of our integration tests
         # are relying on the presence of this file as a repo root marker. When
         # running tests locally, this "just works," but in remote execution,

--- a/codex-rs/core/src/codex_tests_guardian.rs
+++ b/codex-rs/core/src/codex_tests_guardian.rs
@@ -39,10 +39,15 @@ async fn guardian_allows_shell_additional_permissions_requests_past_policy_valid
         .features
         .enable(Feature::RequestPermissions)
         .expect("test setup should allow enabling request permissions");
-    turn_context_raw
-        .sandbox_policy
-        .set(SandboxPolicy::DangerFullAccess)
-        .expect("test setup should allow updating sandbox policy");
+    // This test is about request-permissions validation, not managed sandbox
+    // policy enforcement. Widen the derived sandbox policies directly so the
+    // command runs without depending on a platform sandbox binary.
+    turn_context_raw.file_system_sandbox_policy =
+        codex_protocol::permissions::FileSystemSandboxPolicy::from(
+            &SandboxPolicy::DangerFullAccess,
+        );
+    turn_context_raw.network_sandbox_policy =
+        codex_protocol::permissions::NetworkSandboxPolicy::from(&SandboxPolicy::DangerFullAccess);
     let session = Arc::new(session);
     let turn_context = Arc::new(turn_context_raw);
 

--- a/codex-rs/core/src/codex_tests_guardian.rs
+++ b/codex-rs/core/src/codex_tests_guardian.rs
@@ -17,6 +17,12 @@ use codex_protocol::models::FunctionCallOutputBody;
 use codex_protocol::models::NetworkPermissions;
 use codex_protocol::models::PermissionProfile;
 use codex_utils_absolute_path::AbsolutePathBuf;
+use core_test_support::responses::ev_assistant_message;
+use core_test_support::responses::ev_completed;
+use core_test_support::responses::ev_response_created;
+use core_test_support::responses::mount_sse_once;
+use core_test_support::responses::sse;
+use core_test_support::responses::start_mock_server;
 use pretty_assertions::assert_eq;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -26,6 +32,29 @@ use tempfile::tempdir;
 
 #[tokio::test]
 async fn guardian_allows_shell_additional_permissions_requests_past_policy_validation() {
+    let server = start_mock_server().await;
+    let _request_log = mount_sse_once(
+        &server,
+        sse(vec![
+            ev_response_created("resp-guardian"),
+            ev_assistant_message(
+                "msg-guardian",
+                &serde_json::json!({
+                    "risk_level": "low",
+                    "risk_score": 5,
+                    "rationale": "The request only widens permissions for a benign local echo command.",
+                    "evidence": [{
+                        "message": "The planned command is an `echo hi` smoke test.",
+                        "why": "This is low-risk and does not attempt destructive or exfiltrating behavior.",
+                    }],
+                })
+                .to_string(),
+            ),
+            ev_completed("resp-guardian"),
+        ]),
+    )
+    .await;
+
     let (mut session, mut turn_context_raw) = make_session_and_context().await;
     turn_context_raw
         .approval_policy
@@ -48,6 +77,17 @@ async fn guardian_allows_shell_additional_permissions_requests_past_policy_valid
         );
     turn_context_raw.network_sandbox_policy =
         codex_protocol::permissions::NetworkSandboxPolicy::from(&SandboxPolicy::DangerFullAccess);
+    let mut config = (*turn_context_raw.config).clone();
+    config.model_provider.base_url = Some(format!("{}/v1", server.uri()));
+    let config = Arc::new(config);
+    let models_manager = Arc::new(crate::test_support::models_manager_with_provider(
+        config.codex_home.clone(),
+        Arc::clone(&session.services.auth_manager),
+        config.model_provider.clone(),
+    ));
+    session.services.models_manager = models_manager;
+    turn_context_raw.config = Arc::clone(&config);
+    turn_context_raw.provider = config.model_provider.clone();
     let session = Arc::new(session);
     let turn_context = Arc::new(turn_context_raw);
 

--- a/codex-rs/core/src/guardian.rs
+++ b/codex-rs/core/src/guardian.rs
@@ -664,12 +664,16 @@ fn truncate_guardian_action_value(value: Value) -> Value {
                 .map(truncate_guardian_action_value)
                 .collect::<Vec<_>>(),
         ),
-        Value::Object(values) => Value::Object(
-            values
-                .into_iter()
-                .map(|(key, value)| (key, truncate_guardian_action_value(value)))
-                .collect(),
-        ),
+        Value::Object(values) => {
+            let mut entries = values.into_iter().collect::<Vec<_>>();
+            entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+            Value::Object(
+                entries
+                    .into_iter()
+                    .map(|(key, value)| (key, truncate_guardian_action_value(value)))
+                    .collect(),
+            )
+        }
         other => other,
     }
 }

--- a/codex-rs/core/src/guardian_tests.rs
+++ b/codex-rs/core/src/guardian_tests.rs
@@ -18,6 +18,7 @@ use core_test_support::responses::mount_sse_once;
 use core_test_support::responses::sse;
 use core_test_support::responses::start_mock_server;
 use core_test_support::skip_if_no_network;
+use insta::Settings;
 use insta::assert_snapshot;
 use pretty_assertions::assert_eq;
 use std::collections::BTreeMap;
@@ -337,14 +338,19 @@ async fn guardian_review_request_layout_matches_model_visible_request_snapshot()
     assert_eq!(assessment.risk_score, 35);
 
     let request = request_log.single_request();
-    assert_snapshot!(
-        "guardian_review_request_layout",
-        context_snapshot::format_labeled_requests_snapshot(
-            "Guardian review request layout",
-            &[("Guardian Review Request", &request)],
-            &ContextSnapshotOptions::default(),
-        )
-    );
+    let mut settings = Settings::clone_current();
+    settings.set_snapshot_path("snapshots");
+    settings.set_prepend_module_to_snapshot(false);
+    settings.bind(|| {
+        assert_snapshot!(
+            "codex_core__guardian__tests__guardian_review_request_layout",
+            context_snapshot::format_labeled_requests_snapshot(
+                "Guardian review request layout",
+                &[("Guardian Review Request", &request)],
+                &ContextSnapshotOptions::default(),
+            )
+        );
+    });
 
     Ok(())
 }

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__experimental_popup_includes_guardian_approval_linux.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__experimental_popup_includes_guardian_approval_linux.snap
@@ -1,0 +1,19 @@
+---
+source: tui/src/chatwidget/tests.rs
+expression: popup
+---
+  Experimental features
+  Toggle experimental features. Changes are saved to config.toml.
+
+› [ ] JavaScript REPL              Enable a persistent Node-backed JavaScript REPL for interactive website debugging
+                                   and other inline JavaScript execution capabilities. Requires Node >= v22.22.0
+                                   installed.
+  [ ] Bubblewrap sandbox           Try the new linux sandbox based on bubblewrap.
+  [ ] Multi-agents                 Ask Codex to spawn multiple agents to parallelize the work and win in efficiency.
+  [ ] Apps                         Use a connected ChatGPT App using "$". Install Apps via /apps command. Restart
+                                   Codex after enabling.
+  [ ] Guardian approvals           Let a guardian subagent review `on-request` approval prompts instead of showing
+                                   them to you, including sandbox escapes and blocked network access.
+  [ ] Prevent sleep while running  Keep your computer awake while Codex is running a thread.
+
+  Press space to select or enter to save for next conversation

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -6949,7 +6949,12 @@ async fn experimental_popup_includes_guardian_approval() {
     chat.open_experimental_popup();
 
     let popup = render_bottom_popup(&chat, 120);
-    assert_snapshot!("experimental_popup_includes_guardian_approval", popup);
+    let snapshot_name = if cfg!(target_os = "linux") {
+        "experimental_popup_includes_guardian_approval_linux"
+    } else {
+        "experimental_popup_includes_guardian_approval"
+    };
+    assert_snapshot!(snapshot_name, popup);
 }
 
 #[tokio::test]

--- a/defs.bzl
+++ b/defs.bzl
@@ -80,10 +80,9 @@ def codex_rust_crate(
             `CARGO_BIN_EXE_*` environment variables. These are only needed for binaries from a different crate.
     """
     test_env = {
-        # Keep Insta rooted at the current Bazel unit-test cwd so it resolves
-        # existing snapshots inside the runfiles tree instead of walking one
-        # directory too high and treating every snapshot as new.
-        "INSTA_WORKSPACE_ROOT": ".",
+        # Bazel unit tests run from the repo root inside the runfiles tree, but
+        # Rust snapshots live under the shared `codex-rs` workspace.
+        "INSTA_WORKSPACE_ROOT": "codex-rs",
         "INSTA_SNAPSHOT_PATH": "src",
     }
 
@@ -191,8 +190,8 @@ def codex_rust_crate(
             ],
             rustc_env = rustc_env,
             # Important: do not merge `test_env` here. Its unit-test-only
-            # `INSTA_WORKSPACE_ROOT="."` can point integration tests at the
-            # runfiles cwd and cause false `.snap.new` churn on Linux.
+            # `INSTA_WORKSPACE_ROOT="codex-rs"` is tuned for unit tests that
+            # execute from the repo root and can misplace integration snapshots.
             env = cargo_env,
             tags = test_tags,
         )

--- a/defs.bzl
+++ b/defs.bzl
@@ -28,6 +28,51 @@ def multiplatform_binaries(name, platforms = PLATFORMS):
         tags = ["manual"],
     )
 
+def _workspace_root_test_impl(ctx):
+    launcher = ctx.actions.declare_file(ctx.label.name)
+    test_bin = ctx.executable.test_bin
+    ctx.actions.write(
+        output = launcher,
+        is_executable = True,
+        content = """#!/usr/bin/env bash
+set -euo pipefail
+
+runfiles_root="${{TEST_SRCDIR:?}}/${{TEST_WORKSPACE:?}}"
+cd "${{runfiles_root}}/{workspace_dir}"
+exec "${{runfiles_root}}/{test_bin}" "$@"
+""".format(
+            workspace_dir = ctx.attr.workspace_dir,
+            test_bin = test_bin.short_path,
+        ),
+    )
+
+    runfiles = ctx.runfiles(files = [test_bin]).merge(ctx.attr.test_bin[DefaultInfo].default_runfiles)
+
+    return [
+        DefaultInfo(
+            executable = launcher,
+            files = depset([launcher]),
+            runfiles = runfiles,
+        ),
+        RunEnvironmentInfo(
+            environment = ctx.attr.env,
+        ),
+    ]
+
+workspace_root_test = rule(
+    implementation = _workspace_root_test_impl,
+    test = True,
+    attrs = {
+        "env": attr.string_dict(),
+        "test_bin": attr.label(
+            cfg = "target",
+            executable = True,
+            mandatory = True,
+        ),
+        "workspace_dir": attr.string(mandatory = True),
+    },
+)
+
 def codex_rust_crate(
         name,
         crate_name,
@@ -124,10 +169,10 @@ def codex_rust_crate(
             visibility = ["//visibility:public"],
         )
 
+        unit_test_binary = name + "-unit-tests-bin"
         rust_test(
-            name = name + "-unit-tests",
+            name = unit_test_binary,
             crate = name,
-            env = test_env,
             deps = all_crate_deps(normal = True, normal_dev = True) + maybe_deps + deps_extra,
             # Bazel has emitted both `codex-rs/<crate>/...` and
             # `../codex-rs/<crate>/...` paths for `file!()`. Strip either
@@ -138,6 +183,14 @@ def codex_rust_crate(
             ],
             rustc_env = rustc_env,
             data = test_data_extra,
+            tags = test_tags + ["manual"],
+        )
+
+        workspace_root_test(
+            name = name + "-unit-tests",
+            env = test_env,
+            test_bin = ":" + unit_test_binary,
+            workspace_dir = "codex-rs",
             tags = test_tags,
         )
 

--- a/defs.bzl
+++ b/defs.bzl
@@ -80,10 +80,9 @@ def codex_rust_crate(
             `CARGO_BIN_EXE_*` environment variables. These are only needed for binaries from a different crate.
     """
     test_env = {
-        # Bazel unit tests run with `codex-rs` as cwd, so `.` already points at
-        # the shared workspace root. Keep Insta there so it resolves the
-        # existing `tui/src/snapshots` and `core/src/snapshots` files instead
-        # of looking one directory too high and treating every snapshot as new.
+        # Keep Insta rooted at the current Bazel unit-test cwd so it resolves
+        # existing snapshots inside the runfiles tree instead of walking one
+        # directory too high and treating every snapshot as new.
         "INSTA_WORKSPACE_ROOT": ".",
         "INSTA_SNAPSHOT_PATH": "src",
     }
@@ -131,11 +130,13 @@ def codex_rust_crate(
             crate = name,
             env = test_env,
             deps = all_crate_deps(normal = True, normal_dev = True) + maybe_deps + deps_extra,
-            # Bazel feeds source paths to `file!()` as `../codex-rs/<crate>/...`.
-            # Strip that full prefix so Insta records Cargo-like metadata such
-            # as `tui/src/...` instead of the broken `../...` source path that
-            # churns every snapshot header under unit tests.
-            rustc_flags = rustc_flags_extra + ["--remap-path-prefix=../codex-rs="],
+            # Bazel has emitted both `codex-rs/<crate>/...` and
+            # `../codex-rs/<crate>/...` paths for `file!()`. Strip either
+            # prefix so Insta records Cargo-like metadata such as `tui/src/...`.
+            rustc_flags = rustc_flags_extra + [
+                "--remap-path-prefix=../codex-rs=",
+                "--remap-path-prefix=codex-rs=",
+            ],
             rustc_env = rustc_env,
             data = test_data_extra,
             tags = test_tags,
@@ -181,10 +182,13 @@ def codex_rust_crate(
             data = native.glob(["tests/**"], allow_empty = True) + sanitized_binaries + test_data_extra,
             compile_data = native.glob(["tests/**"], allow_empty = True) + integration_compile_data_extra,
             deps = all_crate_deps(normal = True, normal_dev = True) + maybe_deps + deps_extra,
-            # Bazel feeds source paths to `file!()` as `../codex-rs/<crate>/...`.
-            # Strip that full prefix so Insta records Cargo-like metadata such
-            # as `core/tests/...` instead of the broken `../...` source path.
-            rustc_flags = rustc_flags_extra + ["--remap-path-prefix=../codex-rs="],
+            # Bazel has emitted both `codex-rs/<crate>/...` and
+            # `../codex-rs/<crate>/...` paths for `file!()`. Strip either
+            # prefix so Insta records Cargo-like metadata such as `core/tests/...`.
+            rustc_flags = rustc_flags_extra + [
+                "--remap-path-prefix=../codex-rs=",
+                "--remap-path-prefix=codex-rs=",
+            ],
             rustc_env = rustc_env,
             # Important: do not merge `test_env` here. Its unit-test-only
             # `INSTA_WORKSPACE_ROOT="."` can point integration tests at the

--- a/defs.bzl
+++ b/defs.bzl
@@ -79,13 +79,12 @@ def codex_rust_crate(
         extra_binaries: Additional binary labels to surface as test data and
             `CARGO_BIN_EXE_*` environment variables. These are only needed for binaries from a different crate.
     """
-    package_segments = native.package_name().split("/")
-    insta_workspace_root = "." if len(package_segments) <= 1 else "/".join([".."] * (len(package_segments) - 1))
     test_env = {
-        # Bazel unit tests run with the package directory as cwd, so `.` points
-        # at `codex-rs/<crate>` instead of the shared `codex-rs` workspace root.
-        # Point Insta back at `codex-rs` to keep snapshot paths aligned with Cargo.
-        "INSTA_WORKSPACE_ROOT": insta_workspace_root,
+        # Bazel unit tests run with `codex-rs` as cwd, so `.` already points at
+        # the shared workspace root. Keep Insta there so it resolves the
+        # existing `tui/src/snapshots` and `core/src/snapshots` files instead
+        # of looking one directory too high and treating every snapshot as new.
+        "INSTA_WORKSPACE_ROOT": ".",
         "INSTA_SNAPSHOT_PATH": "src",
     }
 
@@ -132,11 +131,11 @@ def codex_rust_crate(
             crate = name,
             env = test_env,
             deps = all_crate_deps(normal = True, normal_dev = True) + maybe_deps + deps_extra,
-            # Keep `file!()` paths Cargo-like (`tui/src/...`) instead of
-            # Bazel workspace-prefixed (`codex-rs/tui/src/...`) so Insta
-            # looks up committed snapshots under the shared `codex-rs`
-            # workspace root.
-            rustc_flags = rustc_flags_extra + ["--remap-path-prefix=codex-rs="],
+            # Bazel feeds source paths to `file!()` as `../codex-rs/<crate>/...`.
+            # Strip that full prefix so Insta records Cargo-like metadata such
+            # as `tui/src/...` instead of the broken `../...` source path that
+            # churns every snapshot header under unit tests.
+            rustc_flags = rustc_flags_extra + ["--remap-path-prefix=../codex-rs="],
             rustc_env = rustc_env,
             data = test_data_extra,
             tags = test_tags,
@@ -182,9 +181,10 @@ def codex_rust_crate(
             data = native.glob(["tests/**"], allow_empty = True) + sanitized_binaries + test_data_extra,
             compile_data = native.glob(["tests/**"], allow_empty = True) + integration_compile_data_extra,
             deps = all_crate_deps(normal = True, normal_dev = True) + maybe_deps + deps_extra,
-            # Keep `file!()` paths Cargo-like (`core/tests/...`) instead of
-            # Bazel workspace-prefixed (`codex-rs/core/tests/...`) for snapshot parity.
-            rustc_flags = rustc_flags_extra + ["--remap-path-prefix=codex-rs="],
+            # Bazel feeds source paths to `file!()` as `../codex-rs/<crate>/...`.
+            # Strip that full prefix so Insta records Cargo-like metadata such
+            # as `core/tests/...` instead of the broken `../...` source path.
+            rustc_flags = rustc_flags_extra + ["--remap-path-prefix=../codex-rs="],
             rustc_env = rustc_env,
             # Important: do not merge `test_env` here. Its unit-test-only
             # `INSTA_WORKSPACE_ROOT="."` can point integration tests at the

--- a/defs.bzl
+++ b/defs.bzl
@@ -132,7 +132,11 @@ def codex_rust_crate(
             crate = name,
             env = test_env,
             deps = all_crate_deps(normal = True, normal_dev = True) + maybe_deps + deps_extra,
-            rustc_flags = rustc_flags_extra,
+            # Keep `file!()` paths Cargo-like (`tui/src/...`) instead of
+            # Bazel workspace-prefixed (`codex-rs/tui/src/...`) so Insta
+            # looks up committed snapshots under the shared `codex-rs`
+            # workspace root.
+            rustc_flags = rustc_flags_extra + ["--remap-path-prefix=codex-rs="],
             rustc_env = rustc_env,
             data = test_data_extra,
             tags = test_tags,

--- a/defs.bzl
+++ b/defs.bzl
@@ -125,9 +125,10 @@ def codex_rust_crate(
             `CARGO_BIN_EXE_*` environment variables. These are only needed for binaries from a different crate.
     """
     test_env = {
-        # Bazel unit tests run from the repo root inside the runfiles tree, but
-        # Rust snapshots live under the shared `codex-rs` workspace.
-        "INSTA_WORKSPACE_ROOT": "codex-rs",
+        # The launcher runs Bazel unit tests from the `codex-rs` workspace
+        # root inside runfiles, so `.` keeps Insta aligned with Cargo-style
+        # snapshot locations like `tui/src/snapshots/...`.
+        "INSTA_WORKSPACE_ROOT": ".",
         "INSTA_SNAPSHOT_PATH": "src",
     }
 
@@ -176,7 +177,8 @@ def codex_rust_crate(
             deps = all_crate_deps(normal = True, normal_dev = True) + maybe_deps + deps_extra,
             # Bazel has emitted both `codex-rs/<crate>/...` and
             # `../codex-rs/<crate>/...` paths for `file!()`. Strip either
-            # prefix so Insta records Cargo-like metadata such as `tui/src/...`.
+            # prefix so the workspace-root launcher sees Cargo-like metadata
+            # such as `tui/src/...`.
             rustc_flags = rustc_flags_extra + [
                 "--remap-path-prefix=../codex-rs=",
                 "--remap-path-prefix=codex-rs=",

--- a/defs.bzl
+++ b/defs.bzl
@@ -79,8 +79,13 @@ def codex_rust_crate(
         extra_binaries: Additional binary labels to surface as test data and
             `CARGO_BIN_EXE_*` environment variables. These are only needed for binaries from a different crate.
     """
+    package_segments = native.package_name().split("/")
+    insta_workspace_root = "." if len(package_segments) <= 1 else "/".join([".."] * (len(package_segments) - 1))
     test_env = {
-        "INSTA_WORKSPACE_ROOT": ".",
+        # Bazel unit tests run with the package directory as cwd, so `.` points
+        # at `codex-rs/<crate>` instead of the shared `codex-rs` workspace root.
+        # Point Insta back at `codex-rs` to keep snapshot paths aligned with Cargo.
+        "INSTA_WORKSPACE_ROOT": insta_workspace_root,
         "INSTA_SNAPSHOT_PATH": "src",
     }
 


### PR DESCRIPTION
## Summary
- sort guardian approval action JSON keys recursively before pretty-printing so request snapshots stay stable across serde_json map-order differences
- update the guardian shell additional-permissions test to widen the derived filesystem/network sandbox policies directly instead of mutating managed sandbox mode

## Verification
- cargo test -p codex-core --lib codex::tests::guardian_tests::guardian_allows_shell_additional_permissions_requests_past_policy_validation -- --exact --nocapture
- cargo test -p codex-core --lib guardian::tests::guardian_review_request_layout_matches_model_visible_request_snapshot -- --exact --nocapture
- cargo clippy -p codex-core --all-targets