### PR TITLE
Fix inverted Windows PTY `TerminateProcess` handling

### DIFF
--- a/codex-rs/utils/pty/src/win/mod.rs
+++ b/codex-rs/utils/pty/src/win/mod.rs
@@ -67,9 +67,8 @@ impl WinChild {
     fn do_kill(&mut self) -> IoResult<()> {
         let proc = self.proc.lock().unwrap().try_clone().unwrap();
         let res = unsafe { TerminateProcess(proc.as_raw_handle() as _, 1) };
-        let err = IoError::last_os_error();
-        if res != 0 {
-            Err(err)
+        if res == 0 {
+            Err(IoError::last_os_error())
         } else {
             Ok(())
         }
@@ -96,9 +95,8 @@ pub struct WinChildKiller {
 impl ChildKiller for WinChildKiller {
     fn kill(&mut self) -> IoResult<()> {
         let res = unsafe { TerminateProcess(self.proc.as_raw_handle() as _, 1) };
-        let err = IoError::last_os_error();
-        if res != 0 {
-            Err(err)
+        if res == 0 {
+            Err(IoError::last_os_error())
         } else {
             Ok(())
         }

--- a/codex-rs/utils/pty/src/win/mod.rs
+++ b/codex-rs/utils/pty/src/win/mod.rs
@@ -21,8 +21,10 @@
 // Local modifications:
 // - Fix Codex bug #13945 in the Windows PTY kill path. The vendored code treated
 //   `TerminateProcess`'s nonzero success return as failure and `0` as success,
-//   which inverted kill outcomes for both `WinChild::do_kill` and
+//   which inverts kill outcomes for both `WinChild::do_kill` and
 //   `WinChildKiller::kill`.
+// - This bug still exists in the original WezTerm source as of 2026-03-08, so
+//   this is an intentional divergence from upstream.
 
 use anyhow::Context as _;
 use filedescriptor::OwnedHandle;

--- a/codex-rs/utils/pty/src/win/mod.rs
+++ b/codex-rs/utils/pty/src/win/mod.rs
@@ -18,6 +18,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+// Local modifications:
+// - Fix Codex bug #13945 in the Windows PTY kill path. The vendored code treated
+//   `TerminateProcess`'s nonzero success return as failure and `0` as success,
+//   which inverted kill outcomes for both `WinChild::do_kill` and
+//   `WinChildKiller::kill`.
+
 use anyhow::Context as _;
 use filedescriptor::OwnedHandle;
 use portable_pty::Child;
@@ -67,6 +73,7 @@ impl WinChild {
     fn do_kill(&mut self) -> IoResult<()> {
         let proc = self.proc.lock().unwrap().try_clone().unwrap();
         let res = unsafe { TerminateProcess(proc.as_raw_handle() as _, 1) };
+        // Codex bug #13945: Win32 returns nonzero on success, so only `0` is an error.
         if res == 0 {
             Err(IoError::last_os_error())
         } else {
@@ -95,6 +102,7 @@ pub struct WinChildKiller {
 impl ChildKiller for WinChildKiller {
     fn kill(&mut self) -> IoResult<()> {
         let res = unsafe { TerminateProcess(self.proc.as_raw_handle() as _, 1) };
+        // Codex bug #13945: Win32 returns nonzero on success, so only `0` is an error.
         if res == 0 {
             Err(IoError::last_os_error())
         } else {


### PR DESCRIPTION
Addresses #13945

The vendored WezTerm ConPTY backend in `codex-rs/utils/pty/src/win/mod.rs` treated `TerminateProcess` return values backwards: nonzero success was handled as failure, and `0` failure was handled as success.

This is likely causing a number of bugs reported against Codex running on Windows native where processes are not cleaned up.