### PR TITLE
refactor(app-server-client): remove clientsurface startup enum

### DIFF
--- a/codex-rs/app-server-client/README.md
+++ b/codex-rs/app-server-client/README.md
@@ -12,16 +12,12 @@ This crate centralizes startup and lifecycle management for an in-process
 
 - app-server bootstrap and initialize handshake
 - in-memory request/event transport wiring
-- session source selection per client surface
 - graceful shutdown behavior
 
-## Client surfaces and session source
+## Session source
 
-`ClientSurface` controls which `SessionSource` is used when starting
-app-server:
-
-- `ClientSurface::Exec` -> `SessionSource::Exec`
-- `ClientSurface::Tui` -> `SessionSource::Cli`
+Callers pass the `SessionSource` they want stamped into app-server thread
+metadata when starting the runtime.
 
 This ensures thread metadata (for example in `thread/list` and `thread/read`)
 matches the originating runtime.

--- a/codex-rs/app-server-client/src/lib.rs
+++ b/codex-rs/app-server-client/src/lib.rs
@@ -4,7 +4,7 @@
 //! used by surfaces like TUI and exec. It centralizes:
 //!
 //! - Runtime startup and initialize-capabilities handshake.
-//! - Surface-to-session-source policy ([`ClientSurface`] → [`SessionSource`]).
+//! - Startup policy for initialize metadata and session source.
 //! - Typed and raw request/notification dispatch.
 //! - Server request resolution and rejection.
 //! - Event consumption with backpressure signaling ([`InProcessServerEvent::Lagged`]).
@@ -104,34 +104,6 @@ impl Error for TypedRequestError {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum ClientSurface {
-    /// Non-interactive execution surface.
-    Exec,
-    /// Interactive terminal UI surface.
-    Tui,
-}
-
-/// Maps facade surface identity to app-server `SessionSource`.
-///
-/// `ClientSurface::Tui` intentionally maps to `SessionSource::Cli` because the
-/// TUI is the interactive CLI surface from the server's perspective.
-pub fn session_source_for_surface(surface: ClientSurface) -> SessionSource {
-    match surface {
-        ClientSurface::Exec => SessionSource::Exec,
-        ClientSurface::Tui => SessionSource::Cli,
-    }
-}
-
-impl ClientSurface {
-    fn default_client_name(self) -> &'static str {
-        match self {
-            ClientSurface::Exec => "codex-exec",
-            ClientSurface::Tui => "codex-tui",
-        }
-    }
-}
-
 #[derive(Clone)]
 pub struct InProcessClientStartArgs {
     /// Resolved argv0 dispatch paths used by command execution internals.
@@ -148,10 +120,10 @@ pub struct InProcessClientStartArgs {
     pub feedback: CodexFeedback,
     /// Startup warnings emitted after initialize succeeds.
     pub config_warnings: Vec<ConfigWarningNotification>,
-    /// Surface identity that drives session source and default client name.
-    pub surface: ClientSurface,
-    /// Optional explicit client name; falls back to surface default.
-    pub client_name: Option<String>,
+    /// Session source stamped into thread/session metadata.
+    pub session_source: SessionSource,
+    /// Client name reported during initialize.
+    pub client_name: String,
     /// Client version reported during initialize.
     pub client_version: String,
     /// Whether experimental APIs are requested at initialize time.
@@ -163,16 +135,8 @@ pub struct InProcessClientStartArgs {
 }
 
 impl InProcessClientStartArgs {
-    /// Builds initialize params from surface and caller-provided metadata.
-    ///
-    /// This keeps the initialize handshake policy in one place so TUI and exec
-    /// do not drift on client naming, experimental opt-in, or notification
-    /// suppression.
+    /// Builds initialize params from caller-provided metadata.
     pub fn initialize_params(&self) -> InitializeParams {
-        let client_name = self
-            .client_name
-            .clone()
-            .unwrap_or_else(|| self.surface.default_client_name().to_string());
         let capabilities = InitializeCapabilities {
             experimental_api: self.experimental_api,
             opt_out_notification_methods: if self.opt_out_notification_methods.is_empty() {
@@ -184,7 +148,7 @@ impl InProcessClientStartArgs {
 
         InitializeParams {
             client_info: ClientInfo {
-                name: client_name,
+                name: self.client_name.clone(),
                 title: None,
                 version: self.client_version.clone(),
             },
@@ -202,7 +166,7 @@ impl InProcessClientStartArgs {
             cloud_requirements: self.cloud_requirements,
             feedback: self.feedback,
             config_warnings: self.config_warnings,
-            session_source: session_source_for_surface(self.surface),
+            session_source: self.session_source,
             initialize,
             channel_capacity: self.channel_capacity,
         }
@@ -587,7 +551,7 @@ mod tests {
     }
 
     async fn start_test_client_with_capacity(
-        surface: ClientSurface,
+        session_source: SessionSource,
         channel_capacity: usize,
     ) -> InProcessAppServerClient {
         InProcessAppServerClient::start(InProcessClientStartArgs {
@@ -598,8 +562,8 @@ mod tests {
             cloud_requirements: CloudRequirementsLoader::default(),
             feedback: CodexFeedback::new(),
             config_warnings: Vec::new(),
-            surface,
-            client_name: Some("codex-app-server-client-test".to_string()),
+            session_source,
+            client_name: "codex-app-server-client-test".to_string(),
             client_version: "0.0.0-test".to_string(),
             experimental_api: true,
             opt_out_notification_methods: Vec::new(),
@@ -609,13 +573,13 @@ mod tests {
         .expect("in-process app-server client should start")
     }
 
-    async fn start_test_client(surface: ClientSurface) -> InProcessAppServerClient {
-        start_test_client_with_capacity(surface, DEFAULT_IN_PROCESS_CHANNEL_CAPACITY).await
+    async fn start_test_client(session_source: SessionSource) -> InProcessAppServerClient {
+        start_test_client_with_capacity(session_source, DEFAULT_IN_PROCESS_CHANNEL_CAPACITY).await
     }
 
     #[tokio::test]
     async fn typed_request_roundtrip_works() {
-        let client = start_test_client(ClientSurface::Exec).await;
+        let client = start_test_client(SessionSource::Exec).await;
         let _response: ConfigRequirementsReadResponse = client
             .request_typed(ClientRequest::ConfigRequirementsRead {
                 request_id: RequestId::Integer(1),
@@ -628,7 +592,7 @@ mod tests {
 
     #[tokio::test]
     async fn typed_request_reports_json_rpc_errors() {
-        let client = start_test_client(ClientSurface::Exec).await;
+        let client = start_test_client(SessionSource::Exec).await;
         let err = client
             .request_typed::<ConfigRequirementsReadResponse>(ClientRequest::ThreadRead {
                 request_id: RequestId::Integer(99),
@@ -647,12 +611,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn surface_to_session_source_mapping_is_applied() {
-        for (surface, expected_source) in [
-            (ClientSurface::Exec, ApiSessionSource::Exec),
-            (ClientSurface::Tui, ApiSessionSource::Cli),
+    async fn start_args_session_source_is_applied() {
+        for (session_source, expected_source) in [
+            (SessionSource::Exec, ApiSessionSource::Exec),
+            (SessionSource::Cli, ApiSessionSource::Cli),
         ] {
-            let client = start_test_client(surface).await;
+            let client = start_test_client(session_source).await;
             let parsed: ThreadStartResponse = client
                 .request_typed(ClientRequest::ThreadStart {
                     request_id: RequestId::Integer(2),
@@ -670,7 +634,7 @@ mod tests {
 
     #[tokio::test]
     async fn tiny_channel_capacity_still_supports_request_roundtrip() {
-        let client = start_test_client_with_capacity(ClientSurface::Exec, 1).await;
+        let client = start_test_client_with_capacity(SessionSource::Exec, 1).await;
         let _response: ConfigRequirementsReadResponse = client
             .request_typed(ClientRequest::ConfigRequirementsRead {
                 request_id: RequestId::Integer(1),

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -13,7 +13,6 @@ pub mod exec_events;
 pub use cli::Cli;
 pub use cli::Command;
 pub use cli::ReviewArgs;
-use codex_app_server_client::ClientSurface;
 use codex_app_server_client::DEFAULT_IN_PROCESS_CHANNEL_CAPACITY;
 use codex_app_server_client::InProcessAppServerClient;
 use codex_app_server_client::InProcessClientStartArgs;
@@ -70,6 +69,7 @@ use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::ReviewRequest;
 use codex_protocol::protocol::ReviewTarget;
 use codex_protocol::protocol::SessionConfiguredEvent;
+use codex_protocol::protocol::SessionSource;
 use codex_protocol::user_input::UserInput;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use codex_utils_oss::ensure_oss_provider_ready;
@@ -435,8 +435,8 @@ pub async fn run_main(cli: Cli, arg0_paths: Arg0DispatchPaths) -> anyhow::Result
         cloud_requirements: run_cloud_requirements,
         feedback: CodexFeedback::new(),
         config_warnings,
-        surface: ClientSurface::Exec,
-        client_name: Some("codex-exec".to_string()),
+        session_source: SessionSource::Exec,
+        client_name: "codex-exec".to_string(),
         client_version: env!("CARGO_PKG_VERSION").to_string(),
         experimental_api: true,
         opt_out_notification_methods: Vec::new(),


### PR DESCRIPTION
## Summary
- remove `ClientSurface` from `codex-app-server-client`
- require callers to pass `session_source` and `client_name` directly
- update exec and the client docs/tests to match the simplified API

## Why
`ClientSurface` was only acting as a thin mapping layer to `SessionSource` plus default naming. Making the caller provide the concrete startup metadata keeps the facade aligned with what app-server actually consumes and avoids leaking a partial abstraction.