### PR TITLE
fix(bazel) add missing app-server-client BUILD.bazel

### DIFF
--- a/codex-rs/app-server-client/BUILD.bazel
+++ b/codex-rs/app-server-client/BUILD.bazel
@@ -1,0 +1,6 @@
+load("//:defs.bzl", "codex_rust_crate")
+
+codex_rust_crate(
+    name = "app-server-client",
+    crate_name = "codex_app_server_client",
+)


### PR DESCRIPTION
## Summary
Adds missing BUILD.bazel file for the new app-server-client crate to fix bazel CI after #14005
## Testing
- [x] 🤞 that this gets bazel ci to pass