### PR TITLE
Stabilize app list update ordering test

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/app_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/app_list.rs
@@ -501,16 +501,6 @@ async fn list_apps_waits_for_accessible_data_before_emitting_directory_updates()
         })
         .await?;
 
-    let maybe_update = timeout(
-        Duration::from_millis(150),
-        read_app_list_updated_notification(&mut mcp),
-    )
-    .await;
-    assert!(
-        maybe_update.is_err(),
-        "unexpected directory-only app/list update before accessible apps loaded"
-    );
-
     let expected = vec![
         AppInfo {
             id: "beta".to_string(),
@@ -544,8 +534,17 @@ async fn list_apps_waits_for_accessible_data_before_emitting_directory_updates()
         },
     ];
 
-    let update = read_app_list_updated_notification(&mut mcp).await?;
-    assert_eq!(update.data, expected);
+    loop {
+        let update = read_app_list_updated_notification(&mut mcp).await?;
+        if update.data == expected {
+            break;
+        }
+
+        assert!(
+            !update.data.is_empty() && update.data.iter().all(|connector| connector.is_accessible),
+            "unexpected directory-only app/list update before accessible apps loaded"
+        );
+    }
 
     let response: JSONRPCResponse = timeout(
         DEFAULT_TIMEOUT,


### PR DESCRIPTION
## Summary
- make `list_apps_waits_for_accessible_data_before_emitting_directory_updates` accept the two valid notification paths the server can emit
- keep rejecting the real bug this test is meant to catch: a directory-only `app/list/updated` notification before accessible app data is available

## Why this fixes the flake
The old test used a fixed `150ms` silence window and assumed the first notification after that window had to be the fully merged final update. In CI, scheduling occasionally lets accessible app data arrive before directory data, so the first valid notification can be an accessible-only interim update. That made the test fail even though the server behavior was correct.

This change makes the test deterministic by reading notifications until the final merged payload arrives. Any interim update is only accepted if it contains accessible apps only; if the server ever emits inaccessible directory data before accessible data is ready, the test still fails immediately.

## Change type
- test-only; no production app-list logic changes