### PR TITLE
Stabilize unicode shell command test

### DIFF
--- a/codex-rs/core/tests/suite/shell_command.rs
+++ b/codex-rs/core/tests/suite/shell_command.rs
@@ -266,7 +266,7 @@ async fn unicode_output(login: bool) -> anyhow::Result<()> {
     mount_shell_responses_with_timeout(
         &harness,
         call_id,
-        "git -c alias.say='!printf \"%s\" \"naïve_café\"' say",
+        "echo 'naïve_café'",
         Some(login),
         MEDIUM_TIMEOUT,
     )


### PR DESCRIPTION
## What changed
- change the unicode-output test in `core/tests/suite/shell_command.rs` from a git-alias command to a direct `echo 'naïve_café'` command\n\n## Why this fixes flakiness\nThe previous command exercised git startup and alias parsing on top of unicode output. On slower Windows login-shell runs that extra setup time was enough to hit intermittent timeouts, even though the behavior under test was just unicode stdout handling. Using a direct shell command keeps the assertion focused on unicode transport and output while removing unrelated git startup variance.\n\n## Scope\n- test-only\n- no production logic change