### PR TITLE
Mitigate @react-router/node CVE via workspace override

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,11 +10,13 @@
     "prettier": "^3.5.3"
   },
   "resolutions": {
+    "@react-router/node": "^7.9.4",
     "braces": "^3.0.3",
     "micromatch": "^4.0.8",
     "semver": "^7.7.1"
   },
   "overrides": {
+    "@react-router/node": "^7.9.4",
     "punycode": "^2.3.1"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@react-router/node': ^7.9.4
   braces: ^3.0.3
   micromatch: ^4.0.8
   semver: ^7.7.1


### PR DESCRIPTION
### Motivation
- Force transitive resolutions to a patched `@react-router/node` (>= `7.9.4`) to mitigate the reported CVE affecting `7.0.0`–`7.9.3` without needing per-package edits.

### Description
- Added a workspace-level `resolutions` and `overrides` entry for `@react-router/node: ^7.9.4` in `package.json` and the corresponding `overrides` entry in `pnpm-lock.yaml` so transitive dependency resolution is forced to the fixed range.

### Testing
- Attempted to regenerate the lockfile with `pnpm install --lockfile-only`, which failed due to network access being blocked (`ERR_PNPM_FETCH_403`), so dependency fetch could not be validated; files were updated and committed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_69aeee2b4e3083269be35e41d8ce8470)