### PR TITLE
fix(core) default RejectConfig.request_permissions

### DIFF
--- a/codex-rs/app-server-protocol/schema/json/ClientRequest.json
+++ b/codex-rs/app-server-protocol/schema/json/ClientRequest.json
@@ -58,6 +58,7 @@
                   "type": "boolean"
                 },
                 "request_permissions": {
+                  "default": false,
                   "type": "boolean"
                 },
                 "rules": {
@@ -69,7 +70,6 @@
               },
               "required": [
                 "mcp_elicitations",
-                "request_permissions",
                 "rules",
                 "sandbox_approval"
               ],

--- a/codex-rs/app-server-protocol/schema/json/EventMsg.json
+++ b/codex-rs/app-server-protocol/schema/json/EventMsg.json
@@ -4684,6 +4684,7 @@
           "type": "boolean"
         },
         "request_permissions": {
+          "default": false,
           "description": "Reject approval prompts related to built-in permission requests.",
           "type": "boolean"
         },
@@ -4698,7 +4699,6 @@
       },
       "required": [
         "mcp_elicitations",
-        "request_permissions",
         "rules",
         "sandbox_approval"
       ],

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
@@ -6753,6 +6753,7 @@
           "type": "boolean"
         },
         "request_permissions": {
+          "default": false,
           "description": "Reject approval prompts related to built-in permission requests.",
           "type": "boolean"
         },
@@ -6767,7 +6768,6 @@
       },
       "required": [
         "mcp_elicitations",
-        "request_permissions",
         "rules",
         "sandbox_approval"
       ],
@@ -9238,6 +9238,7 @@
                     "type": "boolean"
                   },
                   "request_permissions": {
+                    "default": false,
                     "type": "boolean"
                   },
                   "rules": {
@@ -9249,7 +9250,6 @@
                 },
                 "required": [
                   "mcp_elicitations",
-                  "request_permissions",
                   "rules",
                   "sandbox_approval"
                 ],

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
@@ -732,6 +732,7 @@
                   "type": "boolean"
                 },
                 "request_permissions": {
+                  "default": false,
                   "type": "boolean"
                 },
                 "rules": {
@@ -743,7 +744,6 @@
               },
               "required": [
                 "mcp_elicitations",
-                "request_permissions",
                 "rules",
                 "sandbox_approval"
               ],

--- a/codex-rs/app-server-protocol/schema/json/v2/ConfigReadResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ConfigReadResponse.json
@@ -149,6 +149,7 @@
                   "type": "boolean"
                 },
                 "request_permissions": {
+                  "default": false,
                   "type": "boolean"
                 },
                 "rules": {
@@ -160,7 +161,6 @@
               },
               "required": [
                 "mcp_elicitations",
-                "request_permissions",
                 "rules",
                 "sandbox_approval"
               ],

--- a/codex-rs/app-server-protocol/schema/json/v2/ConfigRequirementsReadResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ConfigRequirementsReadResponse.json
@@ -21,6 +21,7 @@
                   "type": "boolean"
                 },
                 "request_permissions": {
+                  "default": false,
                   "type": "boolean"
                 },
                 "rules": {
@@ -32,7 +33,6 @@
               },
               "required": [
                 "mcp_elicitations",
-                "request_permissions",
                 "rules",
                 "sandbox_approval"
               ],

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadForkParams.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadForkParams.json
@@ -21,6 +21,7 @@
                   "type": "boolean"
                 },
                 "request_permissions": {
+                  "default": false,
                   "type": "boolean"
                 },
                 "rules": {
@@ -32,7 +33,6 @@
               },
               "required": [
                 "mcp_elicitations",
-                "request_permissions",
                 "rules",
                 "sandbox_approval"
               ],

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadForkResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadForkResponse.json
@@ -25,6 +25,7 @@
                   "type": "boolean"
                 },
                 "request_permissions": {
+                  "default": false,
                   "type": "boolean"
                 },
                 "rules": {
@@ -36,7 +37,6 @@
               },
               "required": [
                 "mcp_elicitations",
-                "request_permissions",
                 "rules",
                 "sandbox_approval"
               ],

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadResumeParams.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadResumeParams.json
@@ -21,6 +21,7 @@
                   "type": "boolean"
                 },
                 "request_permissions": {
+                  "default": false,
                   "type": "boolean"
                 },
                 "rules": {
@@ -32,7 +33,6 @@
               },
               "required": [
                 "mcp_elicitations",
-                "request_permissions",
                 "rules",
                 "sandbox_approval"
               ],

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadResumeResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadResumeResponse.json
@@ -25,6 +25,7 @@
                   "type": "boolean"
                 },
                 "request_permissions": {
+                  "default": false,
                   "type": "boolean"
                 },
                 "rules": {
@@ -36,7 +37,6 @@
               },
               "required": [
                 "mcp_elicitations",
-                "request_permissions",
                 "rules",
                 "sandbox_approval"
               ],

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadStartParams.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadStartParams.json
@@ -21,6 +21,7 @@
                   "type": "boolean"
                 },
                 "request_permissions": {
+                  "default": false,
                   "type": "boolean"
                 },
                 "rules": {
@@ -32,7 +33,6 @@
               },
               "required": [
                 "mcp_elicitations",
-                "request_permissions",
                 "rules",
                 "sandbox_approval"
               ],

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadStartResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadStartResponse.json
@@ -25,6 +25,7 @@
                   "type": "boolean"
                 },
                 "request_permissions": {
+                  "default": false,
                   "type": "boolean"
                 },
                 "rules": {
@@ -36,7 +37,6 @@
               },
               "required": [
                 "mcp_elicitations",
-                "request_permissions",
                 "rules",
                 "sandbox_approval"
               ],

--- a/codex-rs/app-server-protocol/schema/json/v2/TurnStartParams.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/TurnStartParams.json
@@ -25,6 +25,7 @@
                   "type": "boolean"
                 },
                 "request_permissions": {
+                  "default": false,
                   "type": "boolean"
                 },
                 "rules": {
@@ -36,7 +37,6 @@
               },
               "required": [
                 "mcp_elicitations",
-                "request_permissions",
                 "rules",
                 "sandbox_approval"
               ],

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -193,6 +193,7 @@ pub enum AskForApproval {
     Reject {
         sandbox_approval: bool,
         rules: bool,
+        #[serde(default)]
         request_permissions: bool,
         mcp_elicitations: bool,
     },
@@ -5858,6 +5859,28 @@ mod tests {
 
         let back_to_v2 = AskForApproval::from(core_policy);
         assert_eq!(back_to_v2, v2_policy);
+    }
+
+    #[test]
+    fn ask_for_approval_reject_defaults_missing_request_permissions_to_false() {
+        let decoded = serde_json::from_value::<AskForApproval>(serde_json::json!({
+            "reject": {
+                "sandbox_approval": true,
+                "rules": false,
+                "mcp_elicitations": true,
+            }
+        }))
+        .expect("legacy reject approval policy should deserialize");
+
+        assert_eq!(
+            decoded,
+            AskForApproval::Reject {
+                sandbox_approval: true,
+                rules: false,
+                request_permissions: false,
+                mcp_elicitations: true,
+            }
+        );
     }
 
     #[test]

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -1317,6 +1317,7 @@
           "type": "boolean"
         },
         "request_permissions": {
+          "default": false,
           "description": "Reject approval prompts related to built-in permission requests.",
           "type": "boolean"
         },
@@ -1331,7 +1332,6 @@
       },
       "required": [
         "mcp_elicitations",
-        "request_permissions",
         "rules",
         "sandbox_approval"
       ],

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -527,6 +527,7 @@ pub struct RejectConfig {
     /// Reject prompts triggered by execpolicy `prompt` rules.
     pub rules: bool,
     /// Reject approval prompts related to built-in permission requests.
+    #[serde(default)]
     pub request_permissions: bool,
     /// Reject MCP elicitation prompts.
     pub mcp_elicitations: bool,
@@ -3391,6 +3392,26 @@ mod tests {
                 mcp_elicitations: false,
             }
             .rejects_request_permissions()
+        );
+    }
+
+    #[test]
+    fn reject_config_defaults_missing_request_permissions_to_false() {
+        let decoded = serde_json::from_value::<RejectConfig>(serde_json::json!({
+            "sandbox_approval": true,
+            "rules": false,
+            "mcp_elicitations": true,
+        }))
+        .expect("legacy reject config should deserialize");
+
+        assert_eq!(
+            decoded,
+            RejectConfig {
+                sandbox_approval: true,
+                rules: false,
+                request_permissions: false,
+                mcp_elicitations: true,
+            }
         );
     }
 


### PR DESCRIPTION
## Summary
Adds a default here so existing config deserializes

## Testing
- [x] Added a unit test