### PR TITLE
Fix unified exec test output assertion

### DIFF
--- a/codex-rs/core/src/unified_exec/mod.rs
+++ b/codex-rs/core/src/unified_exec/mod.rs
@@ -444,7 +444,7 @@ mod tests {
             "pause should block the unified exec yield timeout"
         );
         assert!(
-            response.output.contains("unified-exec-done"),
+            response.truncated_output().contains("unified-exec-done"),
             "exec_command should wait for output after the pause lifts"
         );
         assert!(


### PR DESCRIPTION
## Summary
- update the unified exec test to use truncated_output() instead of the removed output field
- fix the compile failure on latest main after ExecCommandToolOutput changed shape