### PR TITLE
Raw output instead of output

### DIFF
--- a/codex-rs/core/src/unified_exec/mod.rs
+++ b/codex-rs/core/src/unified_exec/mod.rs
@@ -444,7 +444,7 @@ mod tests {
             "pause should block the unified exec yield timeout"
         );
         assert!(
-            response.output.contains("unified-exec-done"),
+            response.truncated_output().contains("unified-exec-done"),
             "exec_command should wait for output after the pause lifts"
         );
         assert!(


### PR DESCRIPTION
Resolves a merge issue from c6343e0649676579f174b6cd0da617d42ab1c58f
