### PR TITLE
Increase sdk workflow timeout to 15 minutes

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -7,8 +7,8 @@ on:
 
 jobs:
   sdks:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -7,7 +7,9 @@ on:
 
 jobs:
   sdks:
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: codex-runners
+      labels: codex-linux-x64
     timeout-minutes: 10
     steps:
       - name: Checkout repository

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   sdks:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
- raise the sdk workflow job timeout from 10 to 15 minutes to reduce false cancellations near the current limit