### PR TITLE
Clarify locked role settings in spawn prompt

### DIFF
--- a/codex-rs/core/src/agent/role.rs
+++ b/codex-rs/core/src/agent/role.rs
@@ -180,10 +180,7 @@ pub(crate) mod spawn_tool_spec {
         }
 
         format!(
-            r#"Optional type name for the new agent. If omitted, `{DEFAULT_ROLE_NAME}` is used.
-Available roles:
-{}
-            "#,
+            "Optional type name for the new agent. If omitted, `{DEFAULT_ROLE_NAME}` is used.\nAvailable roles:\n{}",
             formatted_roles.join("\n"),
         )
     }

--- a/codex-rs/core/src/agent/role.rs
+++ b/codex-rs/core/src/agent/role.rs
@@ -190,48 +190,36 @@ Available roles:
 
     fn format_role(name: &str, declaration: &AgentRoleConfig) -> String {
         if let Some(description) = &declaration.description {
-            let locked_settings_note = locked_settings_note(declaration);
+            let locked_settings_note = declaration
+                .config_file
+                .as_ref()
+                .and_then(|config_file| {
+                    built_in::config_file_contents(config_file)
+                        .map(str::to_owned)
+                        .or_else(|| std::fs::read_to_string(config_file).ok())
+                })
+                .and_then(|contents| toml::from_str::<TomlValue>(&contents).ok())
+                .map(|role_toml| {
+                    let locks_model = role_toml.get("model").is_some();
+                    let locks_reasoning_effort =
+                        role_toml.get("model_reasoning_effort").is_some();
+
+                    match (locks_model, locks_reasoning_effort) {
+                        (true, true) => "\n- This role's model and reasoning effort are set by the role and cannot be changed.",
+                        (true, false) => {
+                            "\n- This role's model is set by the role and cannot be changed."
+                        }
+                        (false, true) => {
+                            "\n- This role's reasoning effort is set by the role and cannot be changed."
+                        }
+                        (false, false) => "",
+                    }
+                })
+                .unwrap_or_default();
             format!("{name}: {{\n{description}{locked_settings_note}\n}}")
         } else {
             format!("{name}: no description")
         }
-    }
-
-    fn locked_settings_note(declaration: &AgentRoleConfig) -> String {
-        let Some(config_file) = declaration.config_file.as_ref() else {
-            return String::new();
-        };
-
-        let Some(contents) = role_config_contents(config_file) else {
-            return String::new();
-        };
-
-        let Ok(role_toml) = toml::from_str::<TomlValue>(&contents) else {
-            return String::new();
-        };
-
-        let locks_model = role_toml.get("model").is_some();
-        let locks_reasoning_effort = role_toml.get("model_reasoning_effort").is_some();
-
-        match (locks_model, locks_reasoning_effort) {
-            (true, true) => {
-                "\n- This role's model and reasoning effort are set by the role and cannot be changed.".to_string()
-            }
-            (true, false) => {
-                "\n- This role's model is set by the role and cannot be changed.".to_string()
-            }
-            (false, true) => {
-                "\n- This role's reasoning effort is set by the role and cannot be changed."
-                    .to_string()
-            }
-            (false, false) => String::new(),
-        }
-    }
-
-    fn role_config_contents(config_file: &Path) -> Option<String> {
-        built_in::config_file_contents(config_file)
-            .map(str::to_owned)
-            .or_else(|| std::fs::read_to_string(config_file).ok())
     }
 }
 

--- a/codex-rs/core/src/agent/role.rs
+++ b/codex-rs/core/src/agent/role.rs
@@ -200,19 +200,28 @@ Available roles:
                 })
                 .and_then(|contents| toml::from_str::<TomlValue>(&contents).ok())
                 .map(|role_toml| {
-                    let locks_model = role_toml.get("model").is_some();
-                    let locks_reasoning_effort =
-                        role_toml.get("model_reasoning_effort").is_some();
+                    let model = role_toml
+                        .get("model")
+                        .and_then(TomlValue::as_str);
+                    let reasoning_effort = role_toml
+                        .get("model_reasoning_effort")
+                        .and_then(TomlValue::as_str);
 
-                    match (locks_model, locks_reasoning_effort) {
-                        (true, true) => "\n- This role's model and reasoning effort are set by the role and cannot be changed.",
-                        (true, false) => {
-                            "\n- This role's model is set by the role and cannot be changed."
+                    match (model, reasoning_effort) {
+                        (Some(model), Some(reasoning_effort)) => format!(
+                            "\n- This role's model is set to `{model}` and its reasoning effort is set to `{reasoning_effort}`. These settings cannot be changed."
+                        ),
+                        (Some(model), None) => {
+                            format!(
+                                "\n- This role's model is set to `{model}` and cannot be changed."
+                            )
                         }
-                        (false, true) => {
-                            "\n- This role's reasoning effort is set by the role and cannot be changed."
+                        (None, Some(reasoning_effort)) => {
+                            format!(
+                                "\n- This role's reasoning effort is set to `{reasoning_effort}` and cannot be changed."
+                            )
                         }
-                        (false, false) => "",
+                        (None, None) => String::new(),
                     }
                 })
                 .unwrap_or_default();

--- a/codex-rs/core/src/agent/role.rs
+++ b/codex-rs/core/src/agent/role.rs
@@ -190,10 +190,48 @@ Available roles:
 
     fn format_role(name: &str, declaration: &AgentRoleConfig) -> String {
         if let Some(description) = &declaration.description {
-            format!("{name}: {{\n{description}\n}}")
+            let locked_settings_note = locked_settings_note(declaration);
+            format!("{name}: {{\n{description}{locked_settings_note}\n}}")
         } else {
             format!("{name}: no description")
         }
+    }
+
+    fn locked_settings_note(declaration: &AgentRoleConfig) -> String {
+        let Some(config_file) = declaration.config_file.as_ref() else {
+            return String::new();
+        };
+
+        let Some(contents) = role_config_contents(config_file) else {
+            return String::new();
+        };
+
+        let Ok(role_toml) = toml::from_str::<TomlValue>(&contents) else {
+            return String::new();
+        };
+
+        let locks_model = role_toml.get("model").is_some();
+        let locks_reasoning_effort = role_toml.get("model_reasoning_effort").is_some();
+
+        match (locks_model, locks_reasoning_effort) {
+            (true, true) => {
+                "\n- This role's model and reasoning effort are set by the role and cannot be changed.".to_string()
+            }
+            (true, false) => {
+                "\n- This role's model is set by the role and cannot be changed.".to_string()
+            }
+            (false, true) => {
+                "\n- This role's reasoning effort is set by the role and cannot be changed."
+                    .to_string()
+            }
+            (false, false) => String::new(),
+        }
+    }
+
+    fn role_config_contents(config_file: &Path) -> Option<String> {
+        built_in::config_file_contents(config_file)
+            .map(str::to_owned)
+            .or_else(|| std::fs::read_to_string(config_file).ok())
     }
 }
 
@@ -899,6 +937,56 @@ enabled = false
             .expect("find built-in role");
 
         assert!(user_index < built_in_index);
+    }
+
+    #[test]
+    fn spawn_tool_spec_marks_role_locked_model_and_reasoning_effort() {
+        let tempdir = TempDir::new().expect("create temp dir");
+        let role_path = tempdir.path().join("researcher.toml");
+        fs::write(
+            &role_path,
+            "developer_instructions = \"Research carefully\"\nmodel = \"gpt-5\"\nmodel_reasoning_effort = \"high\"\n",
+        )
+        .expect("write role config");
+        let user_defined_roles = BTreeMap::from([(
+            "researcher".to_string(),
+            AgentRoleConfig {
+                description: Some("Research carefully.".to_string()),
+                config_file: Some(role_path),
+                nickname_candidates: None,
+            },
+        )]);
+
+        let spec = spawn_tool_spec::build(&user_defined_roles);
+
+        assert!(spec.contains(
+            "Research carefully.\n- This role's model and reasoning effort are set by the role and cannot be changed."
+        ));
+    }
+
+    #[test]
+    fn spawn_tool_spec_marks_role_locked_reasoning_effort_only() {
+        let tempdir = TempDir::new().expect("create temp dir");
+        let role_path = tempdir.path().join("reviewer.toml");
+        fs::write(
+            &role_path,
+            "developer_instructions = \"Review carefully\"\nmodel_reasoning_effort = \"medium\"\n",
+        )
+        .expect("write role config");
+        let user_defined_roles = BTreeMap::from([(
+            "reviewer".to_string(),
+            AgentRoleConfig {
+                description: Some("Review carefully.".to_string()),
+                config_file: Some(role_path),
+                nickname_candidates: None,
+            },
+        )]);
+
+        let spec = spawn_tool_spec::build(&user_defined_roles);
+
+        assert!(spec.contains(
+            "Review carefully.\n- This role's reasoning effort is set by the role and cannot be changed."
+        ));
     }
 
     #[test]

--- a/codex-rs/core/src/agent/role.rs
+++ b/codex-rs/core/src/agent/role.rs
@@ -957,7 +957,7 @@ enabled = false
         let spec = spawn_tool_spec::build(&user_defined_roles);
 
         assert!(spec.contains(
-            "Research carefully.\n- This role's model and reasoning effort are set by the role and cannot be changed."
+            "Research carefully.\n- This role's model is set to `gpt-5` and its reasoning effort is set to `high`. These settings cannot be changed."
         ));
     }
 
@@ -982,7 +982,7 @@ enabled = false
         let spec = spawn_tool_spec::build(&user_defined_roles);
 
         assert!(spec.contains(
-            "Review carefully.\n- This role's reasoning effort is set by the role and cannot be changed."
+            "Review carefully.\n- This role's reasoning effort is set to `medium` and cannot be changed."
         ));
     }
 

--- a/codex-rs/core/tests/suite/subagent_notifications.rs
+++ b/codex-rs/core/tests/suite/subagent_notifications.rs
@@ -87,6 +87,20 @@ fn tool_parameter_description(
         })
 }
 
+fn role_block(description: &str, role_name: &str) -> Option<String> {
+    let role_header = format!("{role_name}: {{");
+    let mut lines = description.lines().skip_while(|line| *line != role_header);
+    let first_line = lines.next()?;
+    let mut block = vec![first_line];
+    for line in lines {
+        if line.ends_with(": {") {
+            break;
+        }
+        block.push(line);
+    }
+    Some(block.join("\n"))
+}
+
 async fn wait_for_spawned_thread_id(test: &TestCodex) -> Result<String> {
     let deadline = Instant::now() + Duration::from_secs(2);
     loop {
@@ -505,9 +519,11 @@ async fn spawn_agent_tool_description_mentions_role_locked_settings() -> Result<
     let request = resp_mock.single_request();
     let agent_type_description = tool_parameter_description(&request, "spawn_agent", "agent_type")
         .expect("spawn_agent agent_type description");
+    let custom_role_description =
+        role_block(&agent_type_description, "custom").expect("custom role description");
     assert_eq!(
-        agent_type_description,
-        "Optional type name for the new agent. If omitted, `default` is used.\nAvailable roles:\ncustom: {\nCustom role\n- This role's model is set to `gpt-5.1-codex-max` and its reasoning effort is set to `high`. These settings cannot be changed.\n}\ndefault: {\nDefault agent.\n}\nexplorer: {\nUse `explorer` for specific codebase questions.\nExplorers are fast and authoritative.\nThey must be used to ask specific, well-scoped questions on the codebase.\nRules:\n- In order to avoid redundant work, you should avoid exploring the same problem that explorers have already covered. Typically, you should trust the explorer results without additional verification. You are still allowed to inspect the code yourself to gain the needed context!\n- You are encouraged to spawn up multiple explorers in parallel when you have multiple distinct questions to ask about the codebase that can be answered independently. This allows you to get more information faster without waiting for one question to finish before asking the next. While waiting for the explorer results, you can continue working on other local tasks that do not depend on those results. This parallelism is a key advantage of delegation, so use it whenever you have multiple questions to ask.\n- Reuse existing explorers for related questions.\n}\nworker: {\nUse for execution and production work.\nTypical tasks:\n- Implement part of a feature\n- Fix tests or bugs\n- Split large refactors into independent chunks\nRules:\n- Explicitly assign **ownership** of the task (files / responsibility). When the subtask involves code changes, you should clearly specify which files or modules the worker is responsible for. This helps avoid merge conflicts and ensures accountability. For example, you can say \"Worker 1 is responsible for updating the authentication module, while Worker 2 will handle the database layer.\" By defining clear ownership, you can delegate more effectively and reduce coordination overhead.\n- Always tell workers they are **not alone in the codebase**, and they should not revert the edits made by others, and they should adjust their implementation to accommodate the changes made by others. This is important because there may be multiple workers making changes in parallel, and they need to be aware of each other's work to avoid conflicts and ensure a cohesive final product.\n}"
+        custom_role_description,
+        "custom: {\nCustom role\n- This role's model is set to `gpt-5.1-codex-max` and its reasoning effort is set to `high`. These settings cannot be changed.\n}"
     );
 
     Ok(())

--- a/codex-rs/core/tests/suite/subagent_notifications.rs
+++ b/codex-rs/core/tests/suite/subagent_notifications.rs
@@ -498,15 +498,13 @@ async fn spawn_agent_tool_description_mentions_role_locked_settings() -> Result<
     let request = resp_mock.single_request();
     let spawn_description =
         tool_description(&request, "spawn_agent").expect("spawn_agent description");
-    let custom_role_entry = spawn_description
+    let custom_role_locked_settings_note = spawn_description
         .lines()
-        .skip_while(|line| *line != "custom: {")
-        .take_while(|line| *line != "default: {")
-        .collect::<Vec<_>>()
-        .join("\n");
+        .find(|line| line.contains("This role's model is set to"))
+        .expect("custom role locked settings note");
     assert_eq!(
-        custom_role_entry,
-        "custom: {\nCustom role\n- This role's model is set to `gpt-5.1-codex-max` and its reasoning effort is set to `high`. These settings cannot be changed.\n}"
+        custom_role_locked_settings_note,
+        "- This role's model is set to `gpt-5.1-codex-max` and its reasoning effort is set to `high`. These settings cannot be changed."
     );
 
     Ok(())

--- a/codex-rs/core/tests/suite/subagent_notifications.rs
+++ b/codex-rs/core/tests/suite/subagent_notifications.rs
@@ -63,6 +63,23 @@ fn has_subagent_notification(req: &ResponsesRequest) -> bool {
         .any(|text| text.contains("<subagent_notification>"))
 }
 
+fn tool_description(req: &ResponsesRequest, tool_name: &str) -> Option<String> {
+    req.body_json()
+        .get("tools")
+        .and_then(serde_json::Value::as_array)
+        .and_then(|tools| {
+            tools.iter().find_map(|tool| {
+                if tool.get("name").and_then(serde_json::Value::as_str) == Some(tool_name) {
+                    tool.get("description")
+                        .and_then(serde_json::Value::as_str)
+                        .map(str::to_string)
+                } else {
+                    None
+                }
+            })
+        })
+}
+
 async fn wait_for_spawned_thread_id(test: &TestCodex) -> Result<String> {
     let deadline = Instant::now() + Duration::from_secs(2);
     loop {
@@ -432,6 +449,61 @@ async fn spawn_agent_role_overrides_requested_model_and_reasoning_settings() -> 
 
     assert_eq!(child_snapshot.model, ROLE_MODEL);
     assert_eq!(child_snapshot.reasoning_effort, Some(ROLE_REASONING_EFFORT));
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn spawn_agent_tool_description_mentions_role_locked_settings() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let resp_mock = mount_sse_once_match(
+        &server,
+        |req: &wiremock::Request| body_contains(req, TURN_1_PROMPT),
+        sse(vec![
+            ev_response_created("resp-turn1-1"),
+            ev_assistant_message("msg-turn1-1", "done"),
+            ev_completed("resp-turn1-1"),
+        ]),
+    )
+    .await;
+
+    let mut builder = test_codex().with_config(|config| {
+        config
+            .features
+            .enable(Feature::Collab)
+            .expect("test config should allow feature update");
+        let role_path = config.codex_home.join("custom-role.toml");
+        std::fs::write(
+            &role_path,
+            format!(
+                "developer_instructions = \"Stay focused\"\nmodel = \"{ROLE_MODEL}\"\nmodel_reasoning_effort = \"{ROLE_REASONING_EFFORT}\"\n",
+            ),
+        )
+        .expect("write role config");
+        config.agent_roles.insert(
+            "custom".to_string(),
+            AgentRoleConfig {
+                description: Some("Custom role".to_string()),
+                config_file: Some(role_path),
+                nickname_candidates: None,
+            },
+        );
+    });
+    let test = builder.build(&server).await?;
+
+    test.submit_turn(TURN_1_PROMPT).await?;
+
+    let request = resp_mock.single_request();
+    let spawn_description =
+        tool_description(&request, "spawn_agent").expect("spawn_agent description");
+    assert!(
+        spawn_description.contains(
+            "Custom role\n- This role's model and reasoning effort are set by the role and cannot be changed."
+        ),
+        "expected locked-setting note in spawn_agent tool description: {spawn_description}"
+    );
 
     Ok(())
 }

--- a/codex-rs/core/tests/suite/subagent_notifications.rs
+++ b/codex-rs/core/tests/suite/subagent_notifications.rs
@@ -505,9 +505,7 @@ async fn spawn_agent_tool_description_mentions_role_locked_settings() -> Result<
         .expect("custom role entry");
     assert_eq!(
         custom_role_entry,
-        format!(
-            "custom: {{\nCustom role\n- This role's model is set to `{ROLE_MODEL}` and its reasoning effort is set to `{ROLE_REASONING_EFFORT}`. These settings cannot be changed.\n}}"
-        )
+        "custom: {\nCustom role\n- This role's model is set to `gpt-5.1-codex-max` and its reasoning effort is set to `high`. These settings cannot be changed.\n}"
     );
 
     Ok(())

--- a/codex-rs/core/tests/suite/subagent_notifications.rs
+++ b/codex-rs/core/tests/suite/subagent_notifications.rs
@@ -499,12 +499,11 @@ async fn spawn_agent_tool_description_mentions_role_locked_settings() -> Result<
     let spawn_description =
         tool_description(&request, "spawn_agent").expect("spawn_agent description");
     let custom_role_entry = spawn_description
-        .split_once("custom: {\n")
-        .and_then(|(_, rest)| {
-            rest.split_once("\ndefault: {")
-                .map(|(custom_entry, _)| format!("custom: {{\n{custom_entry}"))
-        })
-        .expect("custom role entry");
+        .lines()
+        .skip_while(|line| *line != "custom: {")
+        .take_while(|line| *line != "default: {")
+        .collect::<Vec<_>>()
+        .join("\n");
     assert_eq!(
         custom_role_entry,
         "custom: {\nCustom role\n- This role's model is set to `gpt-5.1-codex-max` and its reasoning effort is set to `high`. These settings cannot be changed.\n}"

--- a/codex-rs/core/tests/suite/subagent_notifications.rs
+++ b/codex-rs/core/tests/suite/subagent_notifications.rs
@@ -499,9 +499,11 @@ async fn spawn_agent_tool_description_mentions_role_locked_settings() -> Result<
     let spawn_description =
         tool_description(&request, "spawn_agent").expect("spawn_agent description");
     let custom_role_entry = spawn_description
-        .split("\n}\n")
-        .find(|entry| entry.starts_with("custom: {\n"))
-        .map(|entry| format!("{entry}\n}}"))
+        .split_once("custom: {\n")
+        .and_then(|(_, rest)| {
+            rest.split_once("\ndefault: {")
+                .map(|(custom_entry, _)| format!("custom: {{\n{custom_entry}"))
+        })
         .expect("custom role entry");
     assert_eq!(
         custom_role_entry,

--- a/codex-rs/core/tests/suite/subagent_notifications.rs
+++ b/codex-rs/core/tests/suite/subagent_notifications.rs
@@ -63,16 +63,23 @@ fn has_subagent_notification(req: &ResponsesRequest) -> bool {
         .any(|text| text.contains("<subagent_notification>"))
 }
 
-fn tool_description(req: &ResponsesRequest, tool_name: &str) -> Option<String> {
+fn tool_parameter_description(
+    req: &ResponsesRequest,
+    tool_name: &str,
+    parameter_name: &str,
+) -> Option<String> {
     req.body_json()
         .get("tools")
         .and_then(serde_json::Value::as_array)
         .and_then(|tools| {
             tools.iter().find_map(|tool| {
                 if tool.get("name").and_then(serde_json::Value::as_str) == Some(tool_name) {
-                    tool.get("description")
+                    tool.get("parameters")
+                        .and_then(|parameters| parameters.get("properties"))
+                        .and_then(|properties| properties.get(parameter_name))
+                        .and_then(|parameter| parameter.get("description"))
                         .and_then(serde_json::Value::as_str)
-                        .map(str::to_string)
+                        .map(str::to_owned)
                 } else {
                     None
                 }
@@ -496,15 +503,11 @@ async fn spawn_agent_tool_description_mentions_role_locked_settings() -> Result<
     test.submit_turn(TURN_1_PROMPT).await?;
 
     let request = resp_mock.single_request();
-    let spawn_description =
-        tool_description(&request, "spawn_agent").expect("spawn_agent description");
-    let custom_role_locked_settings_note = spawn_description
-        .lines()
-        .find(|line| line.contains("This role's model is set to"))
-        .expect("custom role locked settings note");
+    let agent_type_description = tool_parameter_description(&request, "spawn_agent", "agent_type")
+        .expect("spawn_agent agent_type description");
     assert_eq!(
-        custom_role_locked_settings_note,
-        "- This role's model is set to `gpt-5.1-codex-max` and its reasoning effort is set to `high`. These settings cannot be changed."
+        agent_type_description,
+        "Optional type name for the new agent. If omitted, `default` is used.\nAvailable roles:\ncustom: {\nCustom role\n- This role's model is set to `gpt-5.1-codex-max` and its reasoning effort is set to `high`. These settings cannot be changed.\n}\ndefault: {\nDefault agent.\n}\nexplorer: {\nUse `explorer` for specific codebase questions.\nExplorers are fast and authoritative.\nThey must be used to ask specific, well-scoped questions on the codebase.\nRules:\n- In order to avoid redundant work, you should avoid exploring the same problem that explorers have already covered. Typically, you should trust the explorer results without additional verification. You are still allowed to inspect the code yourself to gain the needed context!\n- You are encouraged to spawn up multiple explorers in parallel when you have multiple distinct questions to ask about the codebase that can be answered independently. This allows you to get more information faster without waiting for one question to finish before asking the next. While waiting for the explorer results, you can continue working on other local tasks that do not depend on those results. This parallelism is a key advantage of delegation, so use it whenever you have multiple questions to ask.\n- Reuse existing explorers for related questions.\n}\nworker: {\nUse for execution and production work.\nTypical tasks:\n- Implement part of a feature\n- Fix tests or bugs\n- Split large refactors into independent chunks\nRules:\n- Explicitly assign **ownership** of the task (files / responsibility). When the subtask involves code changes, you should clearly specify which files or modules the worker is responsible for. This helps avoid merge conflicts and ensures accountability. For example, you can say \"Worker 1 is responsible for updating the authentication module, while Worker 2 will handle the database layer.\" By defining clear ownership, you can delegate more effectively and reduce coordination overhead.\n- Always tell workers they are **not alone in the codebase**, and they should not revert the edits made by others, and they should adjust their implementation to accommodate the changes made by others. This is important because there may be multiple workers making changes in parallel, and they need to be aware of each other's work to avoid conflicts and ensure a cohesive final product.\n}"
     );
 
     Ok(())

--- a/codex-rs/core/tests/suite/subagent_notifications.rs
+++ b/codex-rs/core/tests/suite/subagent_notifications.rs
@@ -498,13 +498,16 @@ async fn spawn_agent_tool_description_mentions_role_locked_settings() -> Result<
     let request = resp_mock.single_request();
     let spawn_description =
         tool_description(&request, "spawn_agent").expect("spawn_agent description");
-    assert!(
-        spawn_description.contains(
-            &format!(
-                "Custom role\n- This role's model is set to `{ROLE_MODEL}` and its reasoning effort is set to `{ROLE_REASONING_EFFORT}`. These settings cannot be changed."
-            )
-        ),
-        "expected locked-setting note in spawn_agent tool description: {spawn_description}"
+    let custom_role_entry = spawn_description
+        .split("\n}\n")
+        .find(|entry| entry.starts_with("custom: {\n"))
+        .map(|entry| format!("{entry}\n}}"))
+        .expect("custom role entry");
+    assert_eq!(
+        custom_role_entry,
+        format!(
+            "custom: {{\nCustom role\n- This role's model is set to `{ROLE_MODEL}` and its reasoning effort is set to `{ROLE_REASONING_EFFORT}`. These settings cannot be changed.\n}}"
+        )
     );
 
     Ok(())

--- a/codex-rs/core/tests/suite/subagent_notifications.rs
+++ b/codex-rs/core/tests/suite/subagent_notifications.rs
@@ -500,7 +500,9 @@ async fn spawn_agent_tool_description_mentions_role_locked_settings() -> Result<
         tool_description(&request, "spawn_agent").expect("spawn_agent description");
     assert!(
         spawn_description.contains(
-            "Custom role\n- This role's model and reasoning effort are set by the role and cannot be changed."
+            &format!(
+                "Custom role\n- This role's model is set to `{ROLE_MODEL}` and its reasoning effort is set to `{ROLE_REASONING_EFFORT}`. These settings cannot be changed."
+            )
         ),
         "expected locked-setting note in spawn_agent tool description: {spawn_description}"
     );


### PR DESCRIPTION
- tell agents when a role pins model or reasoning effort so they know those settings are not changeable
- add prompt-builder coverage for the locked-setting notes