### PR TITLE
Publish codex-app-server in GitHub releases

### DIFF
--- a/.github/actions/linux-code-sign/action.yml
+++ b/.github/actions/linux-code-sign/action.yml
@@ -30,7 +30,7 @@ runs:
           exit 1
         fi
 
-        for binary in codex codex-responses-api-proxy; do
+        for binary in codex codex-responses-api-proxy codex-app-server; do
           artifact="${dest}/${binary}"
           if [[ ! -f "$artifact" ]]; then
             echo "Binary $artifact not found"

--- a/.github/actions/macos-code-sign/action.yml
+++ b/.github/actions/macos-code-sign/action.yml
@@ -130,7 +130,7 @@ runs:
           keychain_args+=(--keychain "${APPLE_CODESIGN_KEYCHAIN}")
         fi
 
-        for binary in codex codex-responses-api-proxy; do
+        for binary in codex codex-responses-api-proxy codex-app-server; do
           path="codex-rs/target/${{ inputs.target }}/release/${binary}"
           codesign --force --options runtime --timestamp --sign "$APPLE_CODESIGN_IDENTITY" "${keychain_args[@]}" "$path"
         done
@@ -179,6 +179,7 @@ runs:
 
         notarize_binary "codex"
         notarize_binary "codex-responses-api-proxy"
+        notarize_binary "codex-app-server"
 
     - name: Sign and notarize macOS dmg
       if: ${{ inputs.sign-dmg == 'true' }}

--- a/.github/actions/windows-code-sign/action.yml
+++ b/.github/actions/windows-code-sign/action.yml
@@ -53,5 +53,6 @@ runs:
         files: |
           ${{ github.workspace }}/codex-rs/target/${{ inputs.target }}/release/codex.exe
           ${{ github.workspace }}/codex-rs/target/${{ inputs.target }}/release/codex-responses-api-proxy.exe
+          ${{ github.workspace }}/codex-rs/target/${{ inputs.target }}/release/codex-app-server.exe
           ${{ github.workspace }}/codex-rs/target/${{ inputs.target }}/release/codex-windows-sandbox-setup.exe
           ${{ github.workspace }}/codex-rs/target/${{ inputs.target }}/release/codex-command-runner.exe

--- a/.github/workflows/rust-release-windows.yml
+++ b/.github/workflows/rust-release-windows.yml
@@ -40,14 +40,14 @@ jobs:
           - runner: windows-x64
             target: x86_64-pc-windows-msvc
             bundle: primary
-            build_args: --bin codex --bin codex-responses-api-proxy
+            build_args: --bin codex --bin codex-responses-api-proxy --bin codex-app-server
             runs_on:
               group: codex-runners
               labels: codex-windows-x64
           - runner: windows-arm64
             target: aarch64-pc-windows-msvc
             bundle: primary
-            build_args: --bin codex --bin codex-responses-api-proxy
+            build_args: --bin codex --bin codex-responses-api-proxy --bin codex-app-server
             runs_on:
               group: codex-runners
               labels: codex-windows-arm64
@@ -106,6 +106,7 @@ jobs:
           if [[ "${{ matrix.bundle }}" == "primary" ]]; then
             cp target/${{ matrix.target }}/release/codex.exe "$output_dir/codex.exe"
             cp target/${{ matrix.target }}/release/codex-responses-api-proxy.exe "$output_dir/codex-responses-api-proxy.exe"
+            cp target/${{ matrix.target }}/release/codex-app-server.exe "$output_dir/codex-app-server.exe"
           else
             cp target/${{ matrix.target }}/release/codex-windows-sandbox-setup.exe "$output_dir/codex-windows-sandbox-setup.exe"
             cp target/${{ matrix.target }}/release/codex-command-runner.exe "$output_dir/codex-command-runner.exe"
@@ -167,6 +168,7 @@ jobs:
           set -euo pipefail
           ls -lh target/${{ matrix.target }}/release/codex.exe
           ls -lh target/${{ matrix.target }}/release/codex-responses-api-proxy.exe
+          ls -lh target/${{ matrix.target }}/release/codex-app-server.exe
           ls -lh target/${{ matrix.target }}/release/codex-windows-sandbox-setup.exe
           ls -lh target/${{ matrix.target }}/release/codex-command-runner.exe
 
@@ -189,6 +191,7 @@ jobs:
 
           cp target/${{ matrix.target }}/release/codex.exe "$dest/codex-${{ matrix.target }}.exe"
           cp target/${{ matrix.target }}/release/codex-responses-api-proxy.exe "$dest/codex-responses-api-proxy-${{ matrix.target }}.exe"
+          cp target/${{ matrix.target }}/release/codex-app-server.exe "$dest/codex-app-server-${{ matrix.target }}.exe"
           cp target/${{ matrix.target }}/release/codex-windows-sandbox-setup.exe "$dest/codex-windows-sandbox-setup-${{ matrix.target }}.exe"
           cp target/${{ matrix.target }}/release/codex-command-runner.exe "$dest/codex-command-runner-${{ matrix.target }}.exe"
 

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -214,7 +214,7 @@ jobs:
         shell: bash
         run: |
           echo "CARGO_PROFILE_RELEASE_LTO: ${CARGO_PROFILE_RELEASE_LTO}"
-          cargo build --target ${{ matrix.target }} --release --timings --bin codex --bin codex-responses-api-proxy
+          cargo build --target ${{ matrix.target }} --release --timings --bin codex --bin codex-responses-api-proxy --bin codex-app-server
 
       - name: Upload Cargo timings
         uses: actions/upload-artifact@v7
@@ -310,10 +310,12 @@ jobs:
 
           cp target/${{ matrix.target }}/release/codex "$dest/codex-${{ matrix.target }}"
           cp target/${{ matrix.target }}/release/codex-responses-api-proxy "$dest/codex-responses-api-proxy-${{ matrix.target }}"
+          cp target/${{ matrix.target }}/release/codex-app-server "$dest/codex-app-server-${{ matrix.target }}"
 
           if [[ "${{ matrix.target }}" == *linux* ]]; then
             cp target/${{ matrix.target }}/release/codex.sigstore "$dest/codex-${{ matrix.target }}.sigstore"
             cp target/${{ matrix.target }}/release/codex-responses-api-proxy.sigstore "$dest/codex-responses-api-proxy-${{ matrix.target }}.sigstore"
+            cp target/${{ matrix.target }}/release/codex-app-server.sigstore "$dest/codex-app-server-${{ matrix.target }}.sigstore"
           fi
 
           if [[ "${{ matrix.target }}" == *apple-darwin ]]; then


### PR DESCRIPTION
Add codex-app-server to the existing release build, signing, and staging paths so tagged releases upload app-server binaries alongside the other published artifacts.