### PR TITLE
Allow bool web_search in ToolsToml

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/config_rpc.rs
+++ b/codex-rs/app-server/tests/suite/v2/config_rpc.rs
@@ -219,6 +219,38 @@ location = { country = "US", city = "New York", timezone = "America/New_York" }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn config_read_ignores_bool_web_search_tool_config() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    write_config(
+        &codex_home,
+        r#"
+[tools]
+web_search = true
+"#,
+    )?;
+
+    let mut mcp = McpProcess::new(codex_home.path()).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let request_id = mcp
+        .send_config_read_request(ConfigReadParams {
+            include_layers: false,
+            cwd: None,
+        })
+        .await?;
+    let resp: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+    let ConfigReadResponse { config, .. } = to_response(resp)?;
+
+    assert_eq!(config.tools.expect("tools present").web_search, None,);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn config_read_includes_apps() -> Result<()> {
     let codex_home = TempDir::new()?;
     write_config(

--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -176,6 +176,44 @@ enabled = false
 }
 
 #[test]
+fn tools_web_search_true_deserializes_to_none() {
+    let cfg: ConfigToml = toml::from_str(
+        r#"
+[tools]
+web_search = true
+"#,
+    )
+    .expect("TOML deserialization should succeed");
+
+    assert_eq!(
+        cfg.tools,
+        Some(ToolsToml {
+            web_search: None,
+            view_image: None,
+        })
+    );
+}
+
+#[test]
+fn tools_web_search_false_deserializes_to_none() {
+    let cfg: ConfigToml = toml::from_str(
+        r#"
+[tools]
+web_search = false
+"#,
+    )
+    .expect("TOML deserialization should succeed");
+
+    assert_eq!(
+        cfg.tools,
+        Some(ToolsToml {
+            web_search: None,
+            view_image: None,
+        })
+    );
+}
+
+#[test]
 fn config_toml_deserializes_model_availability_nux() {
     let toml = r#"
 [tui.model_availability_nux]

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -1393,10 +1393,6 @@ pub struct RealtimeAudioToml {
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, JsonSchema)]
 #[schemars(deny_unknown_fields)]
 pub struct ToolsToml {
-    /// Additional parameters for the web search tool when it is enabled.
-    ///
-    /// Accepts either a nested table/object or a bare boolean. Boolean values
-    /// are accepted for compatibility but otherwise ignored.
     #[serde(
         default,
         deserialize_with = "deserialize_optional_web_search_tool_config"
@@ -1424,7 +1420,11 @@ where
     let value = Option::<WebSearchToolConfigInput>::deserialize(deserializer)?;
 
     Ok(match value {
-        None | Some(WebSearchToolConfigInput::Enabled(_)) => None,
+        None => None,
+        Some(WebSearchToolConfigInput::Enabled(enabled)) => {
+            let _ = enabled;
+            None
+        }
         Some(WebSearchToolConfigInput::Config(config)) => Some(config),
     })
 }

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -82,6 +82,7 @@ use codex_utils_absolute_path::AbsolutePathBuf;
 use codex_utils_absolute_path::AbsolutePathBufGuard;
 use schemars::JsonSchema;
 use serde::Deserialize;
+use serde::Deserializer;
 use serde::Serialize;
 use similar::DiffableStr;
 use std::collections::BTreeMap;
@@ -1392,12 +1393,40 @@ pub struct RealtimeAudioToml {
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, JsonSchema)]
 #[schemars(deny_unknown_fields)]
 pub struct ToolsToml {
-    #[serde(default)]
+    /// Additional parameters for the web search tool when it is enabled.
+    ///
+    /// Accepts either a nested table/object or a bare boolean. Boolean values
+    /// are accepted for compatibility but otherwise ignored.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_web_search_tool_config"
+    )]
     pub web_search: Option<WebSearchToolConfig>,
 
     /// Enable the `view_image` tool that lets the agent attach local images.
     #[serde(default)]
     pub view_image: Option<bool>,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum WebSearchToolConfigInput {
+    Enabled(bool),
+    Config(WebSearchToolConfig),
+}
+
+fn deserialize_optional_web_search_tool_config<'de, D>(
+    deserializer: D,
+) -> Result<Option<WebSearchToolConfig>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Option::<WebSearchToolConfigInput>::deserialize(deserializer)?;
+
+    Ok(match value {
+        None | Some(WebSearchToolConfigInput::Enabled(_)) => None,
+        Some(WebSearchToolConfigInput::Config(config)) => Some(config),
+    })
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq, JsonSchema)]

--- a/codex-rs/core/src/config/service.rs
+++ b/codex-rs/core/src/config/service.rs
@@ -168,10 +168,13 @@ impl ConfigService {
         };
 
         let effective = layers.effective_config();
-        validate_config(&effective)
+
+        let effective_config_toml: ConfigToml = effective
+            .clone()
+            .try_into()
             .map_err(|err| ConfigServiceError::toml("invalid configuration", err))?;
 
-        let json_value = serde_json::to_value(&effective)
+        let json_value = serde_json::to_value(&effective_config_toml)
             .map_err(|err| ConfigServiceError::json("failed to serialize configuration", err))?;
         let config: ApiConfig = serde_json::from_value(json_value)
             .map_err(|err| ConfigServiceError::json("failed to deserialize configuration", err))?;

--- a/codex-rs/core/src/config/service.rs
+++ b/codex-rs/core/src/config/service.rs
@@ -170,7 +170,6 @@ impl ConfigService {
         let effective = layers.effective_config();
 
         let effective_config_toml: ConfigToml = effective
-            .clone()
             .try_into()
             .map_err(|err| ConfigServiceError::toml("invalid configuration", err))?;
 


### PR DESCRIPTION
Summary
- add a custom deserializer so `[tools].web_search` can be a bool (treated as disabled) or a config object
- extend core and app-server tests to cover bool handling in TOML config

Testing
- Not run (not requested)