### PR TITLE
Do not allow unified_exec for sandboxed scenarios on Windows

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -869,6 +869,8 @@ impl TurnContext {
             features: &features,
             web_search_mode: self.tools_config.web_search_mode,
             session_source: self.session_source.clone(),
+            sandbox_policy: self.sandbox_policy.get(),
+            windows_sandbox_level: self.windows_sandbox_level,
         })
         .with_web_search_config(self.tools_config.web_search_config.clone())
         .with_allow_login_shell(self.tools_config.allow_login_shell)
@@ -1279,6 +1281,8 @@ impl Session {
             features: &per_turn_config.features,
             web_search_mode: Some(per_turn_config.web_search_mode.value()),
             session_source: session_source.clone(),
+            sandbox_policy: session_configuration.sandbox_policy.get(),
+            windows_sandbox_level: session_configuration.windows_sandbox_level,
         })
         .with_web_search_config(per_turn_config.web_search_config.clone())
         .with_allow_login_shell(per_turn_config.permissions.allow_login_shell)
@@ -5166,6 +5170,8 @@ async fn spawn_review_thread(
         features: &review_features,
         web_search_mode: Some(review_web_search_mode),
         session_source: parent_turn_context.session_source.clone(),
+        sandbox_policy: parent_turn_context.sandbox_policy.get(),
+        windows_sandbox_level: parent_turn_context.windows_sandbox_level,
     })
     .with_web_search_config(None)
     .with_allow_login_shell(config.permissions.allow_login_shell)

--- a/codex-rs/core/src/tools/spec.rs
+++ b/codex-rs/core/src/tools/spec.rs
@@ -32,6 +32,7 @@ use crate::tools::registry::ToolRegistryBuilder;
 use crate::tools::registry::tool_handler_key;
 use codex_protocol::config_types::WebSearchConfig;
 use codex_protocol::config_types::WebSearchMode;
+use codex_protocol::config_types::WindowsSandboxLevel;
 use codex_protocol::dynamic_tools::DynamicToolSpec;
 use codex_protocol::models::VIEW_IMAGE_TOOL_NAME;
 use codex_protocol::openai_models::ApplyPatchToolType;
@@ -40,6 +41,7 @@ use codex_protocol::openai_models::InputModality;
 use codex_protocol::openai_models::ModelInfo;
 use codex_protocol::openai_models::ModelPreset;
 use codex_protocol::openai_models::WebSearchToolType;
+use codex_protocol::protocol::SandboxPolicy;
 use codex_protocol::protocol::SessionSource;
 use codex_protocol::protocol::SubAgentSource;
 use serde::Deserialize;
@@ -136,6 +138,21 @@ pub(crate) struct ToolsConfigParams<'a> {
     pub(crate) features: &'a Features,
     pub(crate) web_search_mode: Option<WebSearchMode>,
     pub(crate) session_source: SessionSource,
+    pub(crate) sandbox_policy: &'a SandboxPolicy,
+    pub(crate) windows_sandbox_level: WindowsSandboxLevel,
+}
+
+fn unified_exec_allowed_in_environment(
+    is_windows: bool,
+    sandbox_policy: &SandboxPolicy,
+    windows_sandbox_level: WindowsSandboxLevel,
+) -> bool {
+    !(is_windows
+        && windows_sandbox_level != WindowsSandboxLevel::Disabled
+        && !matches!(
+            sandbox_policy,
+            SandboxPolicy::DangerFullAccess | SandboxPolicy::ExternalSandbox { .. }
+        ))
 }
 
 impl ToolsConfig {
@@ -146,6 +163,8 @@ impl ToolsConfig {
             features,
             web_search_mode,
             session_source,
+            sandbox_policy,
+            windows_sandbox_level,
         } = params;
         let include_apply_patch_tool = features.enabled(Feature::ApplyPatchFreeform);
         let include_code_mode = features.enabled(Feature::CodeMode);
@@ -179,17 +198,25 @@ impl ToolsConfig {
                 UnifiedExecBackendConfig::Direct
             };
 
+        let unified_exec_allowed = unified_exec_allowed_in_environment(
+            cfg!(target_os = "windows"),
+            sandbox_policy,
+            *windows_sandbox_level,
+        );
         let shell_type = if !features.enabled(Feature::ShellTool) {
             ConfigShellToolType::Disabled
         } else if features.enabled(Feature::ShellZshFork) {
             ConfigShellToolType::ShellCommand
-        } else if features.enabled(Feature::UnifiedExec) {
+        } else if features.enabled(Feature::UnifiedExec) && unified_exec_allowed {
             // If ConPTY not supported (for old Windows versions), fallback on ShellCommand.
             if codex_utils_pty::conpty_supported() {
                 ConfigShellToolType::UnifiedExec
             } else {
                 ConfigShellToolType::ShellCommand
             }
+        } else if model_info.shell_type == ConfigShellToolType::UnifiedExec && !unified_exec_allowed
+        {
+            ConfigShellToolType::ShellCommand
         } else {
             model_info.shell_type
         };

--- a/codex-rs/core/src/tools/spec_tests.rs
+++ b/codex-rs/core/src/tools/spec_tests.rs
@@ -353,6 +353,54 @@ fn model_info_from_models_json(slug: &str) -> ModelInfo {
 }
 
 #[test]
+fn unified_exec_is_blocked_for_windows_sandboxed_policies_only() {
+    assert!(!unified_exec_allowed_in_environment(
+        true,
+        &SandboxPolicy::new_read_only_policy(),
+        WindowsSandboxLevel::RestrictedToken,
+    ));
+    assert!(!unified_exec_allowed_in_environment(
+        true,
+        &SandboxPolicy::new_workspace_write_policy(),
+        WindowsSandboxLevel::RestrictedToken,
+    ));
+    assert!(unified_exec_allowed_in_environment(
+        true,
+        &SandboxPolicy::DangerFullAccess,
+        WindowsSandboxLevel::RestrictedToken,
+    ));
+    assert!(unified_exec_allowed_in_environment(
+        true,
+        &SandboxPolicy::DangerFullAccess,
+        WindowsSandboxLevel::Disabled,
+    ));
+}
+
+#[test]
+fn model_provided_unified_exec_is_blocked_for_windows_sandboxed_policies() {
+    let mut model_info = model_info_from_models_json("gpt-5-codex");
+    model_info.shell_type = ConfigShellToolType::UnifiedExec;
+    let features = Features::with_defaults();
+    let available_models = Vec::new();
+    let config = ToolsConfig::new(&ToolsConfigParams {
+        model_info: &model_info,
+        available_models: &available_models,
+        features: &features,
+        web_search_mode: Some(WebSearchMode::Cached),
+        session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::new_workspace_write_policy(),
+        windows_sandbox_level: WindowsSandboxLevel::RestrictedToken,
+    });
+
+    let expected_shell_type = if cfg!(target_os = "windows") {
+        ConfigShellToolType::ShellCommand
+    } else {
+        ConfigShellToolType::UnifiedExec
+    };
+    assert_eq!(config.shell_type, expected_shell_type);
+}
+
+#[test]
 fn test_full_toolset_specs_for_gpt5_codex_unified_exec_web_search() {
     let model_info = model_info_from_models_json("gpt-5-codex");
     let mut features = Features::with_defaults();
@@ -364,6 +412,8 @@ fn test_full_toolset_specs_for_gpt5_codex_unified_exec_web_search() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Live),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
     let (tools, _) = build_specs(&config, None, None, &[]).build();
 
@@ -436,6 +486,8 @@ fn test_build_specs_collab_tools_enabled() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
     let (tools, _) = build_specs(&tools_config, None, None, &[]).build();
     assert_contains_tool_names(
@@ -459,6 +511,8 @@ fn test_build_specs_spawn_csv_enables_agent_jobs_and_collab_tools() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
     let (tools, _) = build_specs(&tools_config, None, None, &[]).build();
     assert_contains_tool_names(
@@ -487,6 +541,8 @@ fn view_image_tool_omits_detail_without_original_detail_feature() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
     let (tools, _) = build_specs(&tools_config, None, None, &[]).build();
     let view_image = find_tool(&tools, VIEW_IMAGE_TOOL_NAME);
@@ -514,6 +570,8 @@ fn view_image_tool_includes_detail_with_original_detail_feature() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
     let (tools, _) = build_specs(&tools_config, None, None, &[]).build();
     let view_image = find_tool(&tools, VIEW_IMAGE_TOOL_NAME);
@@ -549,6 +607,8 @@ fn test_build_specs_artifact_tool_enabled() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
     let (tools, _) = build_specs(&tools_config, None, None, &[]).build();
     assert_contains_tool_names(&tools, &["artifacts"]);
@@ -571,6 +631,8 @@ fn test_build_specs_agent_job_worker_tools_enabled() {
         session_source: SessionSource::SubAgent(SubAgentSource::Other(
             "agent_job:test".to_string(),
         )),
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
     let (tools, _) = build_specs(&tools_config, None, None, &[]).build();
     assert_contains_tool_names(
@@ -600,6 +662,8 @@ fn request_user_input_description_reflects_default_mode_feature_flag() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
     let (tools, _) = build_specs(&tools_config, None, None, &[]).build();
     let request_user_input_tool = find_tool(&tools, "request_user_input");
@@ -616,6 +680,8 @@ fn request_user_input_description_reflects_default_mode_feature_flag() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
     let (tools, _) = build_specs(&tools_config, None, None, &[]).build();
     let request_user_input_tool = find_tool(&tools, "request_user_input");
@@ -639,6 +705,8 @@ fn request_permissions_requires_feature_flag() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
     let (tools, _) = build_specs(&tools_config, None, None, &[]).build();
     assert_lacks_tool_name(&tools, "request_permissions");
@@ -652,6 +720,8 @@ fn request_permissions_requires_feature_flag() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
     let (tools, _) = build_specs(&tools_config, None, None, &[]).build();
     let request_permissions_tool = find_tool(&tools, "request_permissions");
@@ -674,6 +744,8 @@ fn request_permissions_tool_is_independent_from_additional_permissions() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
     let (tools, _) = build_specs(&tools_config, None, None, &[]).build();
 
@@ -693,6 +765,8 @@ fn get_memory_requires_feature_flag() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
     let (tools, _) = build_specs(&tools_config, None, None, &[]).build();
     assert!(
@@ -714,6 +788,8 @@ fn js_repl_requires_feature_flag() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
     let (tools, _) = build_specs(&tools_config, None, None, &[]).build();
 
@@ -741,6 +817,8 @@ fn js_repl_enabled_adds_tools() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
     let (tools, _) = build_specs(&tools_config, None, None, &[]).build();
     assert_contains_tool_names(&tools, &["js_repl", "js_repl_reset"]);
@@ -765,6 +843,8 @@ fn image_generation_tools_require_feature_and_supported_model() {
         features: &default_features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
     let (default_tools, _) = build_specs(&default_tools_config, None, None, &[]).build();
     assert!(
@@ -780,6 +860,8 @@ fn image_generation_tools_require_feature_and_supported_model() {
         features: &image_generation_features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
     let (supported_tools, _) = build_specs(&supported_tools_config, None, None, &[]).build();
     assert_contains_tool_names(&supported_tools, &["image_generation"]);
@@ -798,6 +880,8 @@ fn image_generation_tools_require_feature_and_supported_model() {
         features: &image_generation_features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
     let (tools, _) = build_specs(&tools_config, None, None, &[]).build();
     assert!(
@@ -838,6 +922,8 @@ fn assert_model_tools(
         features,
         web_search_mode,
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
     let (tools, _) = build_specs(&tools_config, None, None, &[]).build();
     let tool_names = tools.iter().map(|t| t.spec.name()).collect::<Vec<_>>();
@@ -873,6 +959,8 @@ fn web_search_mode_cached_sets_external_web_access_false() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
     let (tools, _) = build_specs(&tools_config, None, None, &[]).build();
 
@@ -902,6 +990,8 @@ fn web_search_mode_live_sets_external_web_access_true() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Live),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
     let (tools, _) = build_specs(&tools_config, None, None, &[]).build();
 
@@ -944,6 +1034,8 @@ fn web_search_config_is_forwarded_to_tool_spec() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Live),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     })
     .with_web_search_config(Some(web_search_config.clone()));
     let (tools, _) = build_specs(&tools_config, None, None, &[]).build();
@@ -980,6 +1072,8 @@ fn web_search_tool_type_text_and_image_sets_search_content_types() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Live),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
     let (tools, _) = build_specs(&tools_config, None, None, &[]).build();
 
@@ -1013,6 +1107,8 @@ fn mcp_resource_tools_are_hidden_without_mcp_servers() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
     let (tools, _) = build_specs(&tools_config, None, None, &[]).build();
 
@@ -1037,6 +1133,8 @@ fn mcp_resource_tools_are_included_when_mcp_servers_are_present() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
     let (tools, _) = build_specs(&tools_config, Some(HashMap::new()), None, &[]).build();
 
@@ -1230,6 +1328,8 @@ fn test_build_specs_default_shell_present() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Live),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
     let (tools, _) = build_specs(&tools_config, Some(HashMap::new()), None, &[]).build();
 
@@ -1256,6 +1356,8 @@ fn shell_zsh_fork_prefers_shell_command_over_unified_exec() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Live),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
 
     assert_eq!(tools_config.shell_type, ConfigShellToolType::ShellCommand);
@@ -1283,6 +1385,8 @@ fn test_parallel_support_flags() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
     let (tools, _) = build_specs(&tools_config, None, None, &[]).build();
 
@@ -1311,6 +1415,8 @@ fn test_test_model_info_includes_sync_tool() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
     let (tools, _) = build_specs(&tools_config, None, None, &[]).build();
 
@@ -1345,6 +1451,8 @@ fn test_build_specs_mcp_tools_converted() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Live),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
     let (tools, _) = build_specs(
         &tools_config,
@@ -1436,6 +1544,8 @@ fn test_build_specs_mcp_tools_sorted_by_name() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
 
     // Intentionally construct a map with keys that would sort alphabetically.
@@ -1483,6 +1593,8 @@ fn search_tool_description_includes_only_codex_apps_connector_names() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
 
     let (tools, _) = build_specs(
@@ -1576,6 +1688,8 @@ fn search_tool_requires_apps_feature_flag_only() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
     let (tools, _) = build_specs(&tools_config, None, app_tools.clone(), &[]).build();
     assert_lacks_tool_name(&tools, TOOL_SEARCH_TOOL_NAME);
@@ -1588,6 +1702,8 @@ fn search_tool_requires_apps_feature_flag_only() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
     let (tools, _) = build_specs(&tools_config, None, app_tools, &[]).build();
     assert_contains_tool_names(&tools, &[TOOL_SEARCH_TOOL_NAME]);
@@ -1606,6 +1722,8 @@ fn tool_suggest_is_not_registered_without_feature_flag() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
     let (tools, _) = build_specs_with_discoverable_tools(
         &tools_config,
@@ -1640,6 +1758,8 @@ fn search_tool_description_handles_no_enabled_apps() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
 
     let (tools, _) = build_specs(&tools_config, None, Some(HashMap::new()), &[]).build();
@@ -1665,6 +1785,8 @@ fn search_tool_registers_namespaced_app_tool_aliases() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
 
     let (_, registry) = build_specs(
@@ -1730,6 +1852,8 @@ fn tool_suggest_description_lists_discoverable_tools() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
 
     let discoverable_tools = vec![
@@ -1808,6 +1932,8 @@ fn test_mcp_tool_property_missing_type_defaults_to_string() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
 
     let (tools, _) = build_specs(
@@ -1866,6 +1992,8 @@ fn test_mcp_tool_integer_normalized_to_number() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
 
     let (tools, _) = build_specs(
@@ -1921,6 +2049,8 @@ fn test_mcp_tool_array_without_items_gets_default_string_items() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
 
     let (tools, _) = build_specs(
@@ -1978,6 +2108,8 @@ fn test_mcp_tool_anyof_defaults_to_string() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
 
     let (tools, _) = build_specs(
@@ -2187,6 +2319,8 @@ fn test_get_openai_tools_mcp_tools_with_additional_properties_schema() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
     let (tools, _) = build_specs(
         &tools_config,
@@ -2296,6 +2430,8 @@ fn code_mode_augments_builtin_tool_descriptions_with_typed_sample() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
 
     let (tools, _) = build_specs(&tools_config, None, None, &[]).build();
@@ -2325,6 +2461,8 @@ fn code_mode_augments_mcp_tool_descriptions_with_namespaced_sample() {
         features: &features,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
 
     let (tools, _) = build_specs(


### PR DESCRIPTION
as reported in https://github.com/openai/codex/issues/14367 users can explicitly enable unified_exec which will bypass the sandbox even when it should be enabled.

Until we support unified_exec with the Windows Sandbox, we will disallow it unless the sandbox is disabled
