### PR TITLE
rename spawn_csv feature flag to enable_fanout

### DIFF
--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -363,6 +363,9 @@
             "enable_experimental_windows_sandbox": {
               "type": "boolean"
             },
+            "enable_fanout": {
+              "type": "boolean"
+            },
             "enable_request_compression": {
               "type": "boolean"
             },
@@ -457,9 +460,6 @@
               "type": "boolean"
             },
             "skill_mcp_dependency_install": {
-              "type": "boolean"
-            },
-            "spawn_csv": {
               "type": "boolean"
             },
             "sqlite": {
@@ -1868,6 +1868,9 @@
         "enable_experimental_windows_sandbox": {
           "type": "boolean"
         },
+        "enable_fanout": {
+          "type": "boolean"
+        },
         "enable_request_compression": {
           "type": "boolean"
         },
@@ -1962,9 +1965,6 @@
           "type": "boolean"
         },
         "skill_mcp_dependency_install": {
-          "type": "boolean"
-        },
-        "spawn_csv": {
           "type": "boolean"
         },
         "sqlite": {

--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -5350,7 +5350,7 @@ async fn feature_requirements_normalize_runtime_feature_mutations() -> std::io::
 }
 
 #[tokio::test]
-async fn feature_requirements_reject_legacy_aliases() {
+async fn feature_requirements_reject_collab_legacy_alias() {
     let codex_home = TempDir::new().expect("tempdir");
 
     let err = ConfigBuilder::default()

--- a/codex-rs/core/src/features.rs
+++ b/codex-rs/core/src/features.rs
@@ -700,7 +700,7 @@ pub const FEATURES: &[FeatureSpec] = &[
     },
     FeatureSpec {
         id: Feature::SpawnCsv,
-        key: "spawn_csv",
+        key: "enable_fanout",
         stage: Stage::UnderDevelopment,
         default_enabled: false,
     },

--- a/codex-rs/core/src/features_tests.rs
+++ b/codex-rs/core/src/features_tests.rs
@@ -115,18 +115,18 @@ fn collab_is_legacy_alias_for_multi_agent() {
 }
 
 #[test]
-fn spawn_csv_is_under_development() {
+fn enable_fanout_is_under_development() {
     assert_eq!(Feature::SpawnCsv.stage(), Stage::UnderDevelopment);
     assert_eq!(Feature::SpawnCsv.default_enabled(), false);
 }
 
 #[test]
-fn spawn_csv_normalization_enables_multi_agent_one_way() {
-    let mut spawn_csv_features = Features::with_defaults();
-    spawn_csv_features.enable(Feature::SpawnCsv);
-    spawn_csv_features.normalize_dependencies();
-    assert_eq!(spawn_csv_features.enabled(Feature::SpawnCsv), true);
-    assert_eq!(spawn_csv_features.enabled(Feature::Collab), true);
+fn enable_fanout_normalization_enables_multi_agent_one_way() {
+    let mut enable_fanout_features = Features::with_defaults();
+    enable_fanout_features.enable(Feature::SpawnCsv);
+    enable_fanout_features.normalize_dependencies();
+    assert_eq!(enable_fanout_features.enabled(Feature::SpawnCsv), true);
+    assert_eq!(enable_fanout_features.enabled(Feature::Collab), true);
 
     let mut collab_features = Features::with_defaults();
     collab_features.enable(Feature::Collab);

--- a/codex-rs/core/src/tools/spec_tests.rs
+++ b/codex-rs/core/src/tools/spec_tests.rs
@@ -446,7 +446,7 @@ fn test_build_specs_collab_tools_enabled() {
 }
 
 #[test]
-fn test_build_specs_spawn_csv_enables_agent_jobs_and_collab_tools() {
+fn test_build_specs_enable_fanout_enables_agent_jobs_and_collab_tools() {
     let config = test_config();
     let model_info = ModelsManager::construct_model_info_offline_for_tests("gpt-5-codex", &config);
     let mut features = Features::with_defaults();


### PR DESCRIPTION
## Summary
- rename the public feature flag for `spawn_agents_on_csv()` from `spawn_csv` to `enable_fanout`
- regenerate the config schema so only `enable_fanout` is advertised
- keep the behavior the same: enabling `enable_fanout` still pulls in `multi_agent`

## Notes
- this is a hard rename with no `spawn_csv` compatibility alias
- the internal enum remains `Feature::SpawnCsv` to keep the patch small

## Testing
- `cd codex-rs && just fmt`
- `cd codex-rs && cargo test -p codex-core` (running locally; `suite::agent_jobs::*` and rename-specific coverage passed so far)
