### PR TITLE
Skip nested tool call parallel test on Windows

### DIFF
--- a/codex-rs/core/tests/suite/code_mode.rs
+++ b/codex-rs/core/tests/suite/code_mode.rs
@@ -233,6 +233,7 @@ add_content(JSON.stringify(await exec_command({ cmd: "printf code_mode_exec_mark
     Ok(())
 }
 
+#[cfg_attr(windows, ignore = "no exec_command on Windows")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn code_mode_nested_tool_calls_can_run_in_parallel() -> Result<()> {
     skip_if_no_network!(Ok(()));

--- a/codex-rs/core/tests/suite/code_mode.rs
+++ b/codex-rs/core/tests/suite/code_mode.rs
@@ -233,7 +233,7 @@ add_content(JSON.stringify(await exec_command({ cmd: "printf code_mode_exec_mark
     Ok(())
 }
 
-#[cfg_attr(windows, ignore = "no exec_command on Windows")]
+#[cfg_attr(windows, ignore = "flaky on windows")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn code_mode_nested_tool_calls_can_run_in_parallel() -> Result<()> {
     skip_if_no_network!(Ok(()));


### PR DESCRIPTION
**Summary**
- disable the `code_mode_nested_tool_calls_can_run_in_parallel` test on Windows where `exec_command` is unavailable

**Testing**
- Not run (not requested)