### PR TITLE
tui: add ctrl-x composer clear

### DIFF
--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -1081,6 +1081,13 @@ impl ChatComposer {
         Some(previous)
     }
 
+    pub(crate) fn clear(&mut self) {
+        self.set_text_content(String::new(), Vec::new(), Vec::new());
+        self.remote_image_urls.clear();
+        self.selected_remote_image_index = None;
+        self.history.reset_navigation();
+    }
+
     /// Get the current composer text.
     pub(crate) fn current_text(&self) -> String {
         self.textarea.text().to_string()

--- a/codex-rs/tui/src/bottom_pane/footer.rs
+++ b/codex-rs/tui/src/bottom_pane/footer.rs
@@ -748,6 +748,7 @@ fn shortcut_overlay_lines(state: ShortcutsState) -> Vec<Line<'static>> {
     let mut file_paths = Line::from("");
     let mut paste_image = Line::from("");
     let mut external_editor = Line::from("");
+    let mut clear_composer = Line::from("");
     let mut edit_previous = Line::from("");
     let mut quit = Line::from("");
     let mut show_transcript = Line::from("");
@@ -763,6 +764,7 @@ fn shortcut_overlay_lines(state: ShortcutsState) -> Vec<Line<'static>> {
                 ShortcutId::FilePaths => file_paths = text,
                 ShortcutId::PasteImage => paste_image = text,
                 ShortcutId::ExternalEditor => external_editor = text,
+                ShortcutId::ClearComposer => clear_composer = text,
                 ShortcutId::EditPrevious => edit_previous = text,
                 ShortcutId::Quit => quit = text,
                 ShortcutId::ShowTranscript => show_transcript = text,
@@ -779,6 +781,7 @@ fn shortcut_overlay_lines(state: ShortcutsState) -> Vec<Line<'static>> {
         file_paths,
         paste_image,
         external_editor,
+        clear_composer,
         edit_previous,
         quit,
     ];
@@ -861,6 +864,7 @@ enum ShortcutId {
     FilePaths,
     PasteImage,
     ExternalEditor,
+    ClearComposer,
     EditPrevious,
     Quit,
     ShowTranscript,
@@ -1010,6 +1014,15 @@ const SHORTCUTS: &[ShortcutDescriptor] = &[
         }],
         prefix: "",
         label: " to edit in external editor",
+    },
+    ShortcutDescriptor {
+        id: ShortcutId::ClearComposer,
+        bindings: &[ShortcutBinding {
+            key: key_hint::ctrl(KeyCode::Char('x')),
+            condition: DisplayCondition::Always,
+        }],
+        prefix: "",
+        label: " to clear input",
     },
     ShortcutDescriptor {
         id: ShortcutId::EditPrevious,

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -570,6 +570,11 @@ impl BottomPane {
         self.request_redraw();
     }
 
+    pub(crate) fn clear_composer(&mut self) {
+        self.composer.clear();
+        self.request_redraw();
+    }
+
     /// Get the current composer text (for tests and programmatic checks).
     pub(crate) fn composer_text(&self) -> String {
         self.composer.current_text()

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_mode_shortcut_overlay.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_mode_shortcut_overlay.snap
@@ -1,6 +1,6 @@
 ---
 source: tui/src/bottom_pane/chat_composer.rs
-assertion_line: 1795
+assertion_line: 4683
 expression: terminal.backend()
 ---
 "                                                                                                    "
@@ -16,4 +16,4 @@ expression: terminal.backend()
 "  @ for file paths                           ctrl + v to paste images                               "
 "  ctrl + g to edit in external editor        ctrl + x to clear input                                "
 "  esc again to edit previous message         ctrl + c to exit                                       "
-"  ctrl + t to view transcript                                                                       "
+"                                             ctrl + t to view transcript                            "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_mode_shortcut_overlay.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_mode_shortcut_overlay.snap
@@ -1,5 +1,6 @@
 ---
 source: tui/src/bottom_pane/chat_composer.rs
+assertion_line: 1795
 expression: terminal.backend()
 ---
 "                                                                                                    "
@@ -13,6 +14,6 @@ expression: terminal.backend()
 "  / for commands                             ! for shell commands                                   "
 "  shift + enter for newline                  tab to queue message                                   "
 "  @ for file paths                           ctrl + v to paste images                               "
-"  ctrl + g to edit in external editor        esc again to edit previous message                     "
-"  ctrl + c to exit                                                                                  "
+"  ctrl + g to edit in external editor        ctrl + x to clear input                                "
+"  esc again to edit previous message         ctrl + c to exit                                       "
 "  ctrl + t to view transcript                                                                       "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_shortcuts_collaboration_modes_enabled.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_shortcuts_collaboration_modes_enabled.snap
@@ -1,11 +1,12 @@
 ---
 source: tui/src/bottom_pane/footer.rs
-assertion_line: 535
+assertion_line: 1251
 expression: terminal.backend()
 ---
 "  / for commands                             ! for shell commands               "
 "  ctrl + j for newline                       tab to queue message               "
 "  @ for file paths                           ctrl + v to paste images           "
-"  ctrl + g to edit in external editor        esc esc to edit previous message   "
-"  ctrl + c to exit                           shift + tab to change mode         "
-"                                             ctrl + t to view transcript        "
+"  ctrl + g to edit in external editor        ctrl + x to clear input            "
+"  esc esc to edit previous message           ctrl + c to exit                   "
+"  shift + tab to change mode                                                    "
+"  ctrl + t to view transcript                                                   "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_shortcuts_shift_and_esc.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_shortcuts_shift_and_esc.snap
@@ -1,6 +1,6 @@
 ---
 source: tui/src/bottom_pane/footer.rs
-assertion_line: 402
+assertion_line: 1251
 expression: terminal.backend()
 ---
 "  / for commands                             ! for shell commands               "
@@ -8,4 +8,4 @@ expression: terminal.backend()
 "  @ for file paths                           ctrl + v to paste images           "
 "  ctrl + g to edit in external editor        ctrl + x to clear input            "
 "  esc again to edit previous message         ctrl + c to exit                   "
-"  ctrl + t to view transcript                                                   "
+"                                             ctrl + t to view transcript        "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_shortcuts_shift_and_esc.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_shortcuts_shift_and_esc.snap
@@ -1,10 +1,11 @@
 ---
 source: tui/src/bottom_pane/footer.rs
+assertion_line: 402
 expression: terminal.backend()
 ---
 "  / for commands                             ! for shell commands               "
 "  shift + enter for newline                  tab to queue message               "
 "  @ for file paths                           ctrl + v to paste images           "
-"  ctrl + g to edit in external editor        esc again to edit previous message "
-"  ctrl + c to exit                                                              "
+"  ctrl + g to edit in external editor        ctrl + x to clear input            "
+"  esc again to edit previous message         ctrl + c to exit                   "
 "  ctrl + t to view transcript                                                   "

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -3742,6 +3742,20 @@ impl ChatWidget {
                 modifiers,
                 kind: KeyEventKind::Press,
                 ..
+            } if modifiers.contains(KeyModifiers::CONTROL) && c.eq_ignore_ascii_case(&'x') => {
+                self.bottom_pane.clear_quit_shortcut_hint();
+                self.quit_shortcut_expires_at = None;
+                self.quit_shortcut_key = None;
+                if !self.bottom_pane.composer_is_empty() {
+                    self.bottom_pane.clear_composer();
+                }
+                return;
+            }
+            KeyEvent {
+                code: KeyCode::Char(c),
+                modifiers,
+                kind: KeyEventKind::Press,
+                ..
             } if modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
                 && c.eq_ignore_ascii_case(&'v') =>
             {

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -4731,6 +4731,21 @@ async fn ctrl_d_with_modal_open_does_not_quit() {
 }
 
 #[tokio::test]
+async fn ctrl_x_clears_composer_without_emitting_ops() {
+    let (mut chat, mut rx, mut op_rx) = make_chatwidget_manual(None).await;
+
+    chat.bottom_pane
+        .set_composer_text("clear me\nentirely".to_string(), Vec::new(), Vec::new());
+
+    chat.handle_key_event(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::CONTROL));
+
+    assert!(chat.composer_is_empty());
+    assert_matches!(rx.try_recv(), Err(TryRecvError::Empty));
+    assert_matches!(op_rx.try_recv(), Err(TryRecvError::Empty));
+    assert!(!chat.bottom_pane.quit_shortcut_hint_visible());
+}
+
+#[tokio::test]
 async fn ctrl_c_cleared_prompt_is_recoverable_via_history() {
     let (mut chat, _rx, mut op_rx) = make_chatwidget_manual(None).await;
 


### PR DESCRIPTION
## Summary
- add a dedicated `Ctrl-X` shortcut to clear the composer without affecting transcript or quit behavior
- show the new shortcut in the footer shortcut overlay
- add a regression test and update the affected snapshots

## Testing
- `cargo test -p codex-tui ctrl_x_clears_composer_without_emitting_ops -- --exact`
- `cargo test -p codex-tui footer -- --nocapture`
