### PR TITLE
core: preserve ghost snapshot tails and guard stalled compaction

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -3358,6 +3358,15 @@ impl Session {
         state.replace_history(items, reference_context_item);
     }
 
+    /// Replaces session history with a compacted transcript and preserves any
+    /// append-only concurrent `GhostSnapshot` tail seen under the same state
+    /// lock.
+    ///
+    /// Returns `true` when live history was unchanged or when the only
+    /// concurrent writes were appended `GhostSnapshot` items that were merged
+    /// into `items` before replacement. Returns `false` when live history
+    /// diverged in any other way, in which case replacement still happens but
+    /// no concurrent tail is merged.
     pub(crate) async fn replace_compacted_history(
         &self,
         mut items: Vec<ResponseItem>,

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -3360,12 +3360,26 @@ impl Session {
 
     pub(crate) async fn replace_compacted_history(
         &self,
-        items: Vec<ResponseItem>,
+        mut items: Vec<ResponseItem>,
         reference_context_item: Option<TurnContextItem>,
-        compacted_item: CompactedItem,
-    ) {
-        self.replace_history(items, reference_context_item.clone())
-            .await;
+        mut compacted_item: CompactedItem,
+        base_history: &[ResponseItem],
+    ) -> bool {
+        // Compaction snapshots history and waits on a model/API call. Preserve
+        // any append-only ghost snapshot tail while holding the same lock that
+        // replaces history so detached `/undo` metadata writes are not lost in
+        // the gap before replacement.
+        let merged_ghost_snapshot_tail = {
+            let mut state = self.state.lock().await;
+            let merged = compact::append_concurrent_ghost_snapshot_tail_if_append_only(
+                &mut items,
+                base_history,
+                state.history.raw_items(),
+            );
+            state.replace_history(items.clone(), reference_context_item.clone());
+            merged
+        };
+        compacted_item.replacement_history = Some(items);
 
         self.persist_rollout_items(&[RolloutItem::Compacted(compacted_item)])
             .await;
@@ -3373,6 +3387,7 @@ impl Session {
             self.persist_rollout_items(&[RolloutItem::TurnContext(turn_context_item)])
                 .await;
         }
+        merged_ghost_snapshot_tail
     }
 
     async fn persist_rollout_response_items(&self, items: &[ResponseItem]) {

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -379,7 +379,7 @@ pub(crate) const SUBMISSION_CHANNEL_CAPACITY: usize = 512;
 const CYBER_VERIFY_URL: &str = "https://chatgpt.com/cyber";
 const CYBER_SAFETY_URL: &str = "https://developers.openai.com/codex/concepts/cyber-safety";
 const DIRECT_APP_TOOL_EXPOSURE_THRESHOLD: usize = 100;
-const MAX_MID_TURN_COMPACTION_ATTEMPTS: u32 = 3;
+const MAX_MID_TURN_AUTO_COMPACTION_ATTEMPTS: u32 = 3;
 
 impl Codex {
     /// Spawn a new [`Codex`] and initialize the session.
@@ -5680,7 +5680,7 @@ pub(crate) async fn run_turn(
     // many turns, from the perspective of the user, it is a single turn.
     let turn_diff_tracker = Arc::new(tokio::sync::Mutex::new(TurnDiffTracker::new()));
     let mut server_model_warning_emitted_for_turn = false;
-    let mut mid_turn_compaction_attempts = 0_u32;
+    let mut mid_turn_auto_compaction_attempts = 0_u32;
 
     // `ModelClientSession` is turn-scoped and caches WebSocket + sticky routing state, so we reuse
     // one instance across retries within this turn.
@@ -5818,19 +5818,30 @@ pub(crate) async fn run_turn(
                     "post sampling token usage"
                 );
 
-                // as long as compaction works well in getting us way below the token limit, we shouldn't worry about being in an infinite loop.
+                // Guard against a pathological loop where mid-turn auto-compaction
+                // keeps succeeding, but the turn still remains over the token
+                // threshold and still needs follow-up. Treat that as stalled
+                // auto-compaction so we fail explicitly instead of hot-looping.
                 if token_limit_reached && needs_follow_up {
-                    mid_turn_compaction_attempts += 1;
-                    if mid_turn_compaction_attempts > MAX_MID_TURN_COMPACTION_ATTEMPTS {
+                    mid_turn_auto_compaction_attempts += 1;
+                    if mid_turn_auto_compaction_attempts > MAX_MID_TURN_AUTO_COMPACTION_ATTEMPTS {
+                        let _ = sess.services.session_telemetry.counter(
+                            "codex.auto_compaction.stalled",
+                            1,
+                            &[("phase", "mid_turn")],
+                        );
                         error!(
                             turn_id = %turn_context.sub_id,
-                            mid_turn_compaction_attempts,
-                            "mid-turn compaction exceeded retry limit"
+                            mid_turn_auto_compaction_attempts,
+                            total_usage_tokens,
+                            estimated_token_count = ?estimated_token_count,
+                            auto_compact_limit,
+                            "mid-turn auto-compaction stalled"
                         );
                         let event = EventMsg::Error(CodexErr::ContextWindowExceeded.to_error_event(
                             Some(
                                 format!(
-                                    "Mid-turn compaction exceeded retry limit ({MAX_MID_TURN_COMPACTION_ATTEMPTS} attempts); start a new thread or compact manually"
+                                    "Mid-turn auto-compaction stalled after {MAX_MID_TURN_AUTO_COMPACTION_ATTEMPTS} attempts without getting this turn back under the token threshold. Start a new thread or compact manually."
                                 ),
                             ),
                         ));
@@ -5849,7 +5860,7 @@ pub(crate) async fn run_turn(
                     }
                     continue;
                 }
-                mid_turn_compaction_attempts = 0;
+                mid_turn_auto_compaction_attempts = 0;
 
                 if !needs_follow_up {
                     last_agent_message = sampling_request_last_agent_message;

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -3381,6 +3381,9 @@ impl Session {
             );
             state.replace_history(items.clone(), reference_context_item.clone());
         }
+        // `items` may have gained a concurrent ghost snapshot tail under the
+        // state lock, so refresh the persisted replacement history to match the
+        // in-memory install.
         compacted_item.replacement_history = Some(items);
 
         self.persist_rollout_items(&[RolloutItem::Compacted(compacted_item)])

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -3362,18 +3362,17 @@ impl Session {
     /// append-only concurrent `GhostSnapshot` tail seen under the same state
     /// lock.
     ///
-    /// Returns `true` when live history was unchanged or when the only
-    /// concurrent writes were appended `GhostSnapshot` items that were merged
-    /// into `items` before replacement. Returns `false` when live history
-    /// diverged in any other way, in which case replacement still happens but
-    /// no concurrent tail is merged.
+    /// When live history diverges in any other way, replacement still happens,
+    /// concurrent writes are dropped, and a warning is emitted instead of
+    /// propagating that detail through the return value.
     pub(crate) async fn replace_compacted_history(
         &self,
         mut items: Vec<ResponseItem>,
         reference_context_item: Option<TurnContextItem>,
         mut compacted_item: CompactedItem,
         base_history: &[ResponseItem],
-    ) -> bool {
+        turn_id: &str,
+    ) {
         // Compaction snapshots history and waits on a model/API call. Preserve
         // any append-only ghost snapshot tail while holding the same lock that
         // replaces history so detached `/undo` metadata writes are not lost in
@@ -3396,7 +3395,12 @@ impl Session {
             self.persist_rollout_items(&[RolloutItem::TurnContext(turn_context_item)])
                 .await;
         }
-        merged_ghost_snapshot_tail
+        if !merged_ghost_snapshot_tail {
+            warn!(
+                turn_id,
+                "session history changed beyond append-only ghost snapshots during compaction; dropping concurrent writes"
+            );
+        }
     }
 
     async fn persist_rollout_response_items(&self, items: &[ResponseItem]) {

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -5846,7 +5846,7 @@ pub(crate) async fn run_turn(
                     if mid_turn_auto_compaction_attempts > MAX_MID_TURN_AUTO_COMPACTION_ATTEMPTS {
                         sess.services.session_telemetry.counter(
                             "codex.auto_compaction.stalled",
-                            1,
+                            /*inc*/ 1,
                             &[("phase", "mid_turn")],
                         );
                         error!(

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -5840,7 +5840,7 @@ pub(crate) async fn run_turn(
                 if token_limit_reached && needs_follow_up {
                     mid_turn_auto_compaction_attempts += 1;
                     if mid_turn_auto_compaction_attempts > MAX_MID_TURN_AUTO_COMPACTION_ATTEMPTS {
-                        let _ = sess.services.session_telemetry.counter(
+                        sess.services.session_telemetry.counter(
                             "codex.auto_compaction.stalled",
                             1,
                             &[("phase", "mid_turn")],

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -379,6 +379,7 @@ pub(crate) const SUBMISSION_CHANNEL_CAPACITY: usize = 512;
 const CYBER_VERIFY_URL: &str = "https://chatgpt.com/cyber";
 const CYBER_SAFETY_URL: &str = "https://developers.openai.com/codex/concepts/cyber-safety";
 const DIRECT_APP_TOOL_EXPOSURE_THRESHOLD: usize = 100;
+const MAX_MID_TURN_COMPACTION_ATTEMPTS: u32 = 3;
 
 impl Codex {
     /// Spawn a new [`Codex`] and initialize the session.
@@ -5679,6 +5680,7 @@ pub(crate) async fn run_turn(
     // many turns, from the perspective of the user, it is a single turn.
     let turn_diff_tracker = Arc::new(tokio::sync::Mutex::new(TurnDiffTracker::new()));
     let mut server_model_warning_emitted_for_turn = false;
+    let mut mid_turn_compaction_attempts = 0_u32;
 
     // `ModelClientSession` is turn-scoped and caches WebSocket + sticky routing state, so we reuse
     // one instance across retries within this turn.
@@ -5818,6 +5820,23 @@ pub(crate) async fn run_turn(
 
                 // as long as compaction works well in getting us way below the token limit, we shouldn't worry about being in an infinite loop.
                 if token_limit_reached && needs_follow_up {
+                    mid_turn_compaction_attempts += 1;
+                    if mid_turn_compaction_attempts > MAX_MID_TURN_COMPACTION_ATTEMPTS {
+                        error!(
+                            turn_id = %turn_context.sub_id,
+                            mid_turn_compaction_attempts,
+                            "mid-turn compaction exceeded retry limit"
+                        );
+                        let event = EventMsg::Error(CodexErr::ContextWindowExceeded.to_error_event(
+                            Some(
+                                format!(
+                                    "Mid-turn compaction exceeded retry limit ({MAX_MID_TURN_COMPACTION_ATTEMPTS} attempts); start a new thread or compact manually"
+                                ),
+                            ),
+                        ));
+                        sess.send_event(&turn_context, event).await;
+                        break;
+                    }
                     if run_auto_compact(
                         &sess,
                         &turn_context,
@@ -5830,6 +5849,7 @@ pub(crate) async fn run_turn(
                     }
                     continue;
                 }
+                mid_turn_compaction_attempts = 0;
 
                 if !needs_follow_up {
                     last_agent_message = sampling_request_last_agent_message;

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -3358,34 +3358,29 @@ impl Session {
         state.replace_history(items, reference_context_item);
     }
 
-    /// Replaces session history with a compacted transcript and preserves any
-    /// append-only concurrent `GhostSnapshot` tail seen under the same state
-    /// lock.
-    ///
-    /// When live history diverges in any other way, replacement still happens,
-    /// concurrent writes are dropped, and a warning is emitted.
+    /// Replaces session history with a compacted transcript and, under the same
+    /// state lock, preserves a concurrent append-only `GhostSnapshot` tail when
+    /// the live history still extends the compacted prefix.
     pub(crate) async fn replace_compacted_history(
         &self,
         mut items: Vec<ResponseItem>,
         reference_context_item: Option<TurnContextItem>,
         mut compacted_item: CompactedItem,
         base_history: &[ResponseItem],
-        turn_id: &str,
     ) {
         // Compaction snapshots history and waits on a model/API call. Preserve
         // any append-only ghost snapshot tail while holding the same lock that
         // replaces history so detached `/undo` metadata writes are not lost in
         // the gap before replacement.
-        let merged_ghost_snapshot_tail = {
+        {
             let mut state = self.state.lock().await;
-            let merged = compact::append_concurrent_ghost_snapshot_tail_if_append_only(
+            compact::append_concurrent_ghost_snapshot_tail(
                 &mut items,
                 base_history,
                 state.history.raw_items(),
             );
             state.replace_history(items.clone(), reference_context_item.clone());
-            merged
-        };
+        }
         compacted_item.replacement_history = Some(items);
 
         self.persist_rollout_items(&[RolloutItem::Compacted(compacted_item)])
@@ -3393,12 +3388,6 @@ impl Session {
         if let Some(turn_context_item) = reference_context_item {
             self.persist_rollout_items(&[RolloutItem::TurnContext(turn_context_item)])
                 .await;
-        }
-        if !merged_ghost_snapshot_tail {
-            warn!(
-                turn_id,
-                "session history changed beyond append-only ghost snapshots during compaction; dropping concurrent writes"
-            );
         }
     }
 

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -3363,8 +3363,7 @@ impl Session {
     /// lock.
     ///
     /// When live history diverges in any other way, replacement still happens,
-    /// concurrent writes are dropped, and a warning is emitted instead of
-    /// propagating that detail through the return value.
+    /// concurrent writes are dropped, and a warning is emitted.
     pub(crate) async fn replace_compacted_history(
         &self,
         mut items: Vec<ResponseItem>,

--- a/codex-rs/core/src/codex_tests.rs
+++ b/codex-rs/core/src/codex_tests.rs
@@ -799,19 +799,18 @@ async fn replace_compacted_history_persists_merged_ghost_snapshot_tail() {
     sess.record_conversation_items(tc.as_ref(), std::slice::from_ref(&ghost_snapshot))
         .await;
 
-    let merged = sess
-        .replace_compacted_history(
-            vec![summary_item.clone()],
-            Some(tc.to_turn_context_item()),
-            CompactedItem {
-                message: String::new(),
-                replacement_history: Some(vec![summary_item.clone()]),
-            },
-            &base_history,
-        )
-        .await;
+    sess.replace_compacted_history(
+        vec![summary_item.clone()],
+        Some(tc.to_turn_context_item()),
+        CompactedItem {
+            message: String::new(),
+            replacement_history: Some(vec![summary_item.clone()]),
+        },
+        &base_history,
+        &tc.sub_id,
+    )
+    .await;
 
-    assert!(merged);
     let expected_history = vec![summary_item.clone(), ghost_snapshot.clone()];
     assert_eq!(sess.clone_history().await.raw_items(), expected_history);
 

--- a/codex-rs/core/src/codex_tests.rs
+++ b/codex-rs/core/src/codex_tests.rs
@@ -807,7 +807,6 @@ async fn replace_compacted_history_persists_merged_ghost_snapshot_tail() {
             replacement_history: Some(vec![summary_item.clone()]),
         },
         &base_history,
-        &tc.sub_id,
     )
     .await;
 

--- a/codex-rs/core/src/codex_tests.rs
+++ b/codex-rs/core/src/codex_tests.rs
@@ -780,6 +780,53 @@ async fn reconstruct_history_uses_replacement_history_verbatim() {
 }
 
 #[tokio::test]
+async fn replace_compacted_history_persists_merged_ghost_snapshot_tail() {
+    let (sess, tc, _rx) = make_session_and_context_with_rx().await;
+    let rollout_path = attach_rollout_recorder(&sess).await;
+    let base_history = vec![user_message("before compact")];
+    let summary_item = user_message("summary");
+    let ghost_snapshot = ResponseItem::GhostSnapshot {
+        ghost_commit: codex_git::GhostCommit::new(
+            "ghost-123".to_string(),
+            None,
+            Vec::new(),
+            Vec::new(),
+        ),
+    };
+
+    sess.replace_history(base_history.clone(), Some(tc.to_turn_context_item()))
+        .await;
+    sess.record_conversation_items(tc.as_ref(), std::slice::from_ref(&ghost_snapshot))
+        .await;
+
+    let merged = sess
+        .replace_compacted_history(
+            vec![summary_item.clone()],
+            Some(tc.to_turn_context_item()),
+            CompactedItem {
+                message: String::new(),
+                replacement_history: Some(vec![summary_item.clone()]),
+            },
+            &base_history,
+        )
+        .await;
+
+    assert!(merged);
+    let expected_history = vec![summary_item.clone(), ghost_snapshot.clone()];
+    assert_eq!(sess.clone_history().await.raw_items(), expected_history);
+
+    sess.flush_rollout().await;
+    let (rollout_items, _, _) = RolloutRecorder::load_rollout_items(&rollout_path)
+        .await
+        .expect("load rollout items");
+    let reconstructed = sess
+        .reconstruct_history_from_rollout(tc.as_ref(), &rollout_items)
+        .await;
+
+    assert_eq!(reconstructed.history, expected_history);
+}
+
+#[tokio::test]
 async fn record_initial_history_reconstructs_resumed_transcript() {
     let (session, turn_context) = make_session_and_context().await;
     let (rollout_items, expected) = sample_rollout(&session, &turn_context).await;

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -223,7 +223,6 @@ async fn run_compact_task_inner(
         reference_context_item,
         compacted_item,
         history_items,
-        &turn_context.sub_id,
     )
     .await;
     sess.recompute_token_usage(&turn_context).await;
@@ -276,41 +275,28 @@ pub(crate) fn is_summary_message(message: &str) -> bool {
     message.starts_with(format!("{SUMMARY_PREFIX}\n").as_str())
 }
 
-/// Appends ghost snapshots added after `base_history` only when
-/// `latest_history` still preserves `base_history` as an exact prefix.
+/// Appends ghost snapshots added after `base_history` when `latest_history`
+/// still preserves `base_history` as an exact prefix and only appends
+/// `GhostSnapshot` items.
 ///
 /// Ghost snapshots are appended by detached background tasks for `/undo`, but
 /// `ContextManager::for_prompt()` strips them before any model request. That
-/// makes it safe to preserve a concurrent append-only ghost-snapshot tail while
+/// makes it safe to preserve the concurrent ghost-snapshot-only case while
 /// avoiding model-visible items that the compaction request never saw.
-///
-/// Returns `true` when no concurrent history change occurred or when the newer
-/// history differs only by append-only ghost snapshots, in which case that tail
-/// is appended to `new_history`. Returns `false` when concurrent history
-/// mutation rewrote or removed earlier items, or appended any non-ghost item,
-/// since this helper cannot safely merge those shapes.
-pub(crate) fn append_concurrent_ghost_snapshot_tail_if_append_only(
+pub(crate) fn append_concurrent_ghost_snapshot_tail(
     new_history: &mut Vec<ResponseItem>,
     base_history: &[ResponseItem],
     latest_history: &[ResponseItem],
-) -> bool {
-    if latest_history == base_history {
-        return true;
-    }
-    if !latest_history.starts_with(base_history) {
-        return false;
-    }
-
-    let appended_items = &latest_history[base_history.len()..];
-    if !appended_items
+) {
+    let Some(appended_items) = latest_history.strip_prefix(base_history) else {
+        return;
+    };
+    if appended_items
         .iter()
         .all(|item| matches!(item, ResponseItem::GhostSnapshot { .. }))
     {
-        return false;
+        new_history.extend_from_slice(appended_items);
     }
-
-    new_history.extend_from_slice(appended_items);
-    true
 }
 
 /// Inserts canonical initial context into compacted replacement history at the

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -211,23 +211,6 @@ async fn run_compact_task_inner(
         .cloned()
         .collect();
     new_history.extend(ghost_snapshots);
-    // Compaction snapshots history, waits on a model call, then replaces
-    // session history wholesale. Detached ghost snapshot tasks can finish in
-    // that window and append `/undo` metadata directly into session history.
-    // Those entries are stripped from `for_prompt()`, so re-snapshot here to
-    // preserve an append-only ghost-snapshot tail without reintroducing
-    // model-visible items that were never compacted.
-    let latest_history_snapshot = sess.clone_history().await;
-    if !append_concurrent_ghost_snapshot_tail_if_append_only(
-        &mut new_history,
-        history_items,
-        latest_history_snapshot.raw_items(),
-    ) {
-        warn!(
-            turn_id = %turn_context.sub_id,
-            "session history changed beyond append-only ghost snapshots during compaction; skipping concurrent ghost snapshot merge"
-        );
-    }
     let reference_context_item = match initial_context_injection {
         InitialContextInjection::DoNotInject => None,
         InitialContextInjection::BeforeLastUserMessage => Some(turn_context.to_turn_context_item()),
@@ -236,8 +219,20 @@ async fn run_compact_task_inner(
         message: summary_text.clone(),
         replacement_history: Some(new_history.clone()),
     };
-    sess.replace_compacted_history(new_history, reference_context_item, compacted_item)
-        .await;
+    if !sess
+        .replace_compacted_history(
+            new_history,
+            reference_context_item,
+            compacted_item,
+            history_items,
+        )
+        .await
+    {
+        warn!(
+            turn_id = %turn_context.sub_id,
+            "session history changed beyond append-only ghost snapshots during compaction; skipping concurrent ghost snapshot merge"
+        );
+    }
     sess.recompute_token_usage(&turn_context).await;
 
     sess.emit_turn_item_completed(&turn_context, compaction_item)

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -211,6 +211,9 @@ async fn run_compact_task_inner(
         .cloned()
         .collect();
     new_history.extend(ghost_snapshots);
+    // Compaction snapshots history, waits on a model call, then replaces
+    // session history wholesale. Background writers can append during that
+    // window, so re-snapshot here and preserve any append-only tail items.
     let latest_history_snapshot = sess.clone_history().await;
     if !append_concurrent_history_tail_if_append_only(
         &mut new_history,

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -27,6 +27,7 @@ use codex_protocol::models::ResponseItem;
 use codex_protocol::user_input::UserInput;
 use futures::prelude::*;
 use tracing::error;
+use tracing::warn;
 
 pub const SUMMARIZATION_PROMPT: &str = include_str!("../templates/compact/prompt.md");
 pub const SUMMARY_PREFIX: &str = include_str!("../templates/compact/summary_prefix.md");
@@ -210,6 +211,19 @@ async fn run_compact_task_inner(
         .cloned()
         .collect();
     new_history.extend(ghost_snapshots);
+    let latest_history_snapshot = sess.clone_history().await;
+    if merge_appended_history_items(
+        &mut new_history,
+        history_items,
+        latest_history_snapshot.raw_items(),
+    )
+    .is_none()
+    {
+        warn!(
+            turn_id = %turn_context.sub_id,
+            "session history changed non-append-only during compaction; skipping concurrent tail merge"
+        );
+    }
     let reference_context_item = match initial_context_injection {
         InitialContextInjection::DoNotInject => None,
         InitialContextInjection::BeforeLastUserMessage => Some(turn_context.to_turn_context_item()),
@@ -268,6 +282,23 @@ pub(crate) fn collect_user_messages(items: &[ResponseItem]) -> Vec<String> {
 
 pub(crate) fn is_summary_message(message: &str) -> bool {
     message.starts_with(format!("{SUMMARY_PREFIX}\n").as_str())
+}
+
+pub(crate) fn merge_appended_history_items(
+    new_history: &mut Vec<ResponseItem>,
+    base_history: &[ResponseItem],
+    latest_history: &[ResponseItem],
+) -> Option<usize> {
+    if latest_history == base_history {
+        return Some(0);
+    }
+    if !latest_history.starts_with(base_history) {
+        return None;
+    }
+
+    let appended_count = latest_history.len() - base_history.len();
+    new_history.extend_from_slice(&latest_history[base_history.len()..]);
+    Some(appended_count)
 }
 
 /// Inserts canonical initial context into compacted replacement history at the

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -212,17 +212,20 @@ async fn run_compact_task_inner(
         .collect();
     new_history.extend(ghost_snapshots);
     // Compaction snapshots history, waits on a model call, then replaces
-    // session history wholesale. Background writers can append during that
-    // window, so re-snapshot here and preserve any append-only tail items.
+    // session history wholesale. Detached ghost snapshot tasks can finish in
+    // that window and append `/undo` metadata directly into session history.
+    // Those entries are stripped from `for_prompt()`, so re-snapshot here to
+    // preserve an append-only ghost-snapshot tail without reintroducing
+    // model-visible items that were never compacted.
     let latest_history_snapshot = sess.clone_history().await;
-    if !append_concurrent_history_tail_if_append_only(
+    if !append_concurrent_ghost_snapshot_tail_if_append_only(
         &mut new_history,
         history_items,
         latest_history_snapshot.raw_items(),
     ) {
         warn!(
             turn_id = %turn_context.sub_id,
-            "session history changed non-append-only during compaction; skipping concurrent tail merge"
+            "session history changed beyond append-only ghost snapshots during compaction; skipping concurrent ghost snapshot merge"
         );
     }
     let reference_context_item = match initial_context_injection {
@@ -285,15 +288,20 @@ pub(crate) fn is_summary_message(message: &str) -> bool {
     message.starts_with(format!("{SUMMARY_PREFIX}\n").as_str())
 }
 
-/// Appends items added after `base_history` only when `latest_history` still
-/// preserves `base_history` as an exact prefix.
+/// Appends ghost snapshots added after `base_history` only when
+/// `latest_history` still preserves `base_history` as an exact prefix.
+///
+/// Ghost snapshots are appended by detached background tasks for `/undo`, but
+/// `ContextManager::for_prompt()` strips them before any model request. That
+/// makes it safe to preserve a concurrent append-only ghost-snapshot tail while
+/// avoiding model-visible items that the compaction request never saw.
 ///
 /// Returns `true` when no concurrent history change occurred or when the newer
-/// history differs only by append-only tail growth, in which case that tail is
-/// appended to `new_history`. Returns `false` when concurrent history mutation
-/// rewrote or removed earlier items, since this helper cannot safely merge that
-/// shape.
-pub(crate) fn append_concurrent_history_tail_if_append_only(
+/// history differs only by append-only ghost snapshots, in which case that tail
+/// is appended to `new_history`. Returns `false` when concurrent history
+/// mutation rewrote or removed earlier items, or appended any non-ghost item,
+/// since this helper cannot safely merge those shapes.
+pub(crate) fn append_concurrent_ghost_snapshot_tail_if_append_only(
     new_history: &mut Vec<ResponseItem>,
     base_history: &[ResponseItem],
     latest_history: &[ResponseItem],
@@ -305,7 +313,15 @@ pub(crate) fn append_concurrent_history_tail_if_append_only(
         return false;
     }
 
-    new_history.extend_from_slice(&latest_history[base_history.len()..]);
+    let appended_items = &latest_history[base_history.len()..];
+    if !appended_items
+        .iter()
+        .all(|item| matches!(item, ResponseItem::GhostSnapshot { .. }))
+    {
+        return false;
+    }
+
+    new_history.extend_from_slice(appended_items);
     true
 }
 

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -27,7 +27,6 @@ use codex_protocol::models::ResponseItem;
 use codex_protocol::user_input::UserInput;
 use futures::prelude::*;
 use tracing::error;
-use tracing::warn;
 
 pub const SUMMARIZATION_PROMPT: &str = include_str!("../templates/compact/prompt.md");
 pub const SUMMARY_PREFIX: &str = include_str!("../templates/compact/summary_prefix.md");
@@ -219,20 +218,14 @@ async fn run_compact_task_inner(
         message: summary_text.clone(),
         replacement_history: Some(new_history.clone()),
     };
-    if !sess
-        .replace_compacted_history(
-            new_history,
-            reference_context_item,
-            compacted_item,
-            history_items,
-        )
-        .await
-    {
-        warn!(
-            turn_id = %turn_context.sub_id,
-            "session history changed beyond append-only ghost snapshots during compaction; skipping concurrent ghost snapshot merge"
-        );
-    }
+    sess.replace_compacted_history(
+        new_history,
+        reference_context_item,
+        compacted_item,
+        history_items,
+        &turn_context.sub_id,
+    )
+    .await;
     sess.recompute_token_usage(&turn_context).await;
 
     sess.emit_turn_item_completed(&turn_context, compaction_item)

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -212,13 +212,11 @@ async fn run_compact_task_inner(
         .collect();
     new_history.extend(ghost_snapshots);
     let latest_history_snapshot = sess.clone_history().await;
-    if merge_appended_history_items(
+    if !append_concurrent_history_tail_if_append_only(
         &mut new_history,
         history_items,
         latest_history_snapshot.raw_items(),
-    )
-    .is_none()
-    {
+    ) {
         warn!(
             turn_id = %turn_context.sub_id,
             "session history changed non-append-only during compaction; skipping concurrent tail merge"
@@ -284,21 +282,28 @@ pub(crate) fn is_summary_message(message: &str) -> bool {
     message.starts_with(format!("{SUMMARY_PREFIX}\n").as_str())
 }
 
-pub(crate) fn merge_appended_history_items(
+/// Appends items added after `base_history` only when `latest_history` still
+/// preserves `base_history` as an exact prefix.
+///
+/// Returns `true` when no concurrent history change occurred or when the newer
+/// history differs only by append-only tail growth, in which case that tail is
+/// appended to `new_history`. Returns `false` when concurrent history mutation
+/// rewrote or removed earlier items, since this helper cannot safely merge that
+/// shape.
+pub(crate) fn append_concurrent_history_tail_if_append_only(
     new_history: &mut Vec<ResponseItem>,
     base_history: &[ResponseItem],
     latest_history: &[ResponseItem],
-) -> Option<usize> {
+) -> bool {
     if latest_history == base_history {
-        return Some(0);
+        return true;
     }
     if !latest_history.starts_with(base_history) {
-        return None;
+        return false;
     }
 
-    let appended_count = latest_history.len() - base_history.len();
     new_history.extend_from_slice(&latest_history[base_history.len()..]);
-    Some(appended_count)
+    true
 }
 
 /// Inserts canonical initial context into compacted replacement history at the

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -6,7 +6,7 @@ use crate::codex::Session;
 use crate::codex::TurnContext;
 use crate::codex::built_tools;
 use crate::compact::InitialContextInjection;
-use crate::compact::append_concurrent_history_tail_if_append_only;
+use crate::compact::append_concurrent_ghost_snapshot_tail_if_append_only;
 use crate::compact::insert_initial_context_before_last_real_user_or_summary;
 use crate::context_manager::ContextManager;
 use crate::context_manager::TotalTokenUsageBreakdown;
@@ -152,17 +152,20 @@ async fn run_remote_compact_task_inner_impl(
         new_history.extend(ghost_snapshots);
     }
     // Remote compaction snapshots history, waits on an API call, then replaces
-    // session history wholesale. Background writers can append during that
-    // window, so re-snapshot here and preserve any append-only tail items.
+    // session history wholesale. Detached ghost snapshot tasks can finish in
+    // that window and append `/undo` metadata directly into session history.
+    // Those entries are stripped from `for_prompt()`, so re-snapshot here to
+    // preserve an append-only ghost-snapshot tail without reintroducing
+    // model-visible items that were never compacted.
     let latest_history_snapshot = sess.clone_history().await;
-    if !append_concurrent_history_tail_if_append_only(
+    if !append_concurrent_ghost_snapshot_tail_if_append_only(
         &mut new_history,
         history_snapshot.raw_items(),
         latest_history_snapshot.raw_items(),
     ) {
         warn!(
             turn_id = %turn_context.sub_id,
-            "session history changed non-append-only during remote compaction; skipping concurrent tail merge"
+            "session history changed beyond append-only ghost snapshots during remote compaction; skipping concurrent ghost snapshot merge"
         );
     }
     let reference_context_item = match initial_context_injection {

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -6,8 +6,8 @@ use crate::codex::Session;
 use crate::codex::TurnContext;
 use crate::codex::built_tools;
 use crate::compact::InitialContextInjection;
+use crate::compact::append_concurrent_history_tail_if_append_only;
 use crate::compact::insert_initial_context_before_last_real_user_or_summary;
-use crate::compact::merge_appended_history_items;
 use crate::context_manager::ContextManager;
 use crate::context_manager::TotalTokenUsageBreakdown;
 use crate::context_manager::estimate_response_item_model_visible_bytes;
@@ -152,13 +152,11 @@ async fn run_remote_compact_task_inner_impl(
         new_history.extend(ghost_snapshots);
     }
     let latest_history_snapshot = sess.clone_history().await;
-    if merge_appended_history_items(
+    if !append_concurrent_history_tail_if_append_only(
         &mut new_history,
         history_snapshot.raw_items(),
         latest_history_snapshot.raw_items(),
-    )
-    .is_none()
-    {
+    ) {
         warn!(
             turn_id = %turn_context.sub_id,
             "session history changed non-append-only during remote compaction; skipping concurrent tail merge"

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -24,7 +24,6 @@ use futures::TryFutureExt;
 use tokio_util::sync::CancellationToken;
 use tracing::error;
 use tracing::info;
-use tracing::warn;
 
 pub(crate) async fn run_inline_remote_auto_compact_task(
     sess: Arc<Session>,
@@ -158,20 +157,14 @@ async fn run_remote_compact_task_inner_impl(
         message: String::new(),
         replacement_history: Some(new_history.clone()),
     };
-    if !sess
-        .replace_compacted_history(
-            new_history,
-            reference_context_item,
-            compacted_item,
-            history_snapshot.raw_items(),
-        )
-        .await
-    {
-        warn!(
-            turn_id = %turn_context.sub_id,
-            "session history changed beyond append-only ghost snapshots during remote compaction; skipping concurrent ghost snapshot merge"
-        );
-    }
+    sess.replace_compacted_history(
+        new_history,
+        reference_context_item,
+        compacted_item,
+        history_snapshot.raw_items(),
+        &turn_context.sub_id,
+    )
+    .await;
     sess.recompute_token_usage(turn_context).await;
 
     sess.emit_turn_item_completed(turn_context, compaction_item)

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -151,6 +151,9 @@ async fn run_remote_compact_task_inner_impl(
     if !ghost_snapshots.is_empty() {
         new_history.extend(ghost_snapshots);
     }
+    // Remote compaction snapshots history, waits on an API call, then replaces
+    // session history wholesale. Background writers can append during that
+    // window, so re-snapshot here and preserve any append-only tail items.
     let latest_history_snapshot = sess.clone_history().await;
     if !append_concurrent_history_tail_if_append_only(
         &mut new_history,

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -7,6 +7,7 @@ use crate::codex::TurnContext;
 use crate::codex::built_tools;
 use crate::compact::InitialContextInjection;
 use crate::compact::insert_initial_context_before_last_real_user_or_summary;
+use crate::compact::merge_appended_history_items;
 use crate::context_manager::ContextManager;
 use crate::context_manager::TotalTokenUsageBreakdown;
 use crate::context_manager::estimate_response_item_model_visible_bytes;
@@ -24,6 +25,7 @@ use futures::TryFutureExt;
 use tokio_util::sync::CancellationToken;
 use tracing::error;
 use tracing::info;
+use tracing::warn;
 
 pub(crate) async fn run_inline_remote_auto_compact_task(
     sess: Arc<Session>,
@@ -73,7 +75,8 @@ async fn run_remote_compact_task_inner_impl(
     let compaction_item = TurnItem::ContextCompaction(ContextCompactionItem::new());
     sess.emit_turn_item_started(turn_context, &compaction_item)
         .await;
-    let mut history = sess.clone_history().await;
+    let history_snapshot = sess.clone_history().await;
+    let mut history = history_snapshot.clone();
     let base_instructions = sess.get_base_instructions().await;
     let deleted_items = trim_function_call_history_to_fit_context_window(
         &mut history,
@@ -147,6 +150,19 @@ async fn run_remote_compact_task_inner_impl(
 
     if !ghost_snapshots.is_empty() {
         new_history.extend(ghost_snapshots);
+    }
+    let latest_history_snapshot = sess.clone_history().await;
+    if merge_appended_history_items(
+        &mut new_history,
+        history_snapshot.raw_items(),
+        latest_history_snapshot.raw_items(),
+    )
+    .is_none()
+    {
+        warn!(
+            turn_id = %turn_context.sub_id,
+            "session history changed non-append-only during remote compaction; skipping concurrent tail merge"
+        );
     }
     let reference_context_item = match initial_context_injection {
         InitialContextInjection::DoNotInject => None,

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -162,7 +162,6 @@ async fn run_remote_compact_task_inner_impl(
         reference_context_item,
         compacted_item,
         history_snapshot.raw_items(),
-        &turn_context.sub_id,
     )
     .await;
     sess.recompute_token_usage(turn_context).await;

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -6,7 +6,6 @@ use crate::codex::Session;
 use crate::codex::TurnContext;
 use crate::codex::built_tools;
 use crate::compact::InitialContextInjection;
-use crate::compact::append_concurrent_ghost_snapshot_tail_if_append_only;
 use crate::compact::insert_initial_context_before_last_real_user_or_summary;
 use crate::context_manager::ContextManager;
 use crate::context_manager::TotalTokenUsageBreakdown;
@@ -151,23 +150,6 @@ async fn run_remote_compact_task_inner_impl(
     if !ghost_snapshots.is_empty() {
         new_history.extend(ghost_snapshots);
     }
-    // Remote compaction snapshots history, waits on an API call, then replaces
-    // session history wholesale. Detached ghost snapshot tasks can finish in
-    // that window and append `/undo` metadata directly into session history.
-    // Those entries are stripped from `for_prompt()`, so re-snapshot here to
-    // preserve an append-only ghost-snapshot tail without reintroducing
-    // model-visible items that were never compacted.
-    let latest_history_snapshot = sess.clone_history().await;
-    if !append_concurrent_ghost_snapshot_tail_if_append_only(
-        &mut new_history,
-        history_snapshot.raw_items(),
-        latest_history_snapshot.raw_items(),
-    ) {
-        warn!(
-            turn_id = %turn_context.sub_id,
-            "session history changed beyond append-only ghost snapshots during remote compaction; skipping concurrent ghost snapshot merge"
-        );
-    }
     let reference_context_item = match initial_context_injection {
         InitialContextInjection::DoNotInject => None,
         InitialContextInjection::BeforeLastUserMessage => Some(turn_context.to_turn_context_item()),
@@ -176,8 +158,20 @@ async fn run_remote_compact_task_inner_impl(
         message: String::new(),
         replacement_history: Some(new_history.clone()),
     };
-    sess.replace_compacted_history(new_history, reference_context_item, compacted_item)
-        .await;
+    if !sess
+        .replace_compacted_history(
+            new_history,
+            reference_context_item,
+            compacted_item,
+            history_snapshot.raw_items(),
+        )
+        .await
+    {
+        warn!(
+            turn_id = %turn_context.sub_id,
+            "session history changed beyond append-only ghost snapshots during remote compaction; skipping concurrent ghost snapshot merge"
+        );
+    }
     sess.recompute_token_usage(turn_context).await;
 
     sess.emit_turn_item_completed(turn_context, compaction_item)

--- a/codex-rs/core/src/compact_tests.rs
+++ b/codex-rs/core/src/compact_tests.rs
@@ -185,6 +185,105 @@ fn build_token_limited_compacted_history_appends_summary_message() {
     assert_eq!(summary, summary_text);
 }
 
+#[test]
+fn merge_appended_history_items_appends_concurrent_tail() {
+    let base_history = vec![ResponseItem::Message {
+        id: None,
+        role: "user".to_string(),
+        content: vec![ContentItem::InputText {
+            text: "before compact".to_string(),
+        }],
+        end_turn: None,
+        phase: None,
+    }];
+    let appended_item = ResponseItem::GhostSnapshot {
+        ghost_commit: codex_git::GhostCommit::new(
+            "ghost-123".to_string(),
+            None,
+            Vec::new(),
+            Vec::new(),
+        ),
+    };
+    let latest_history = vec![base_history[0].clone(), appended_item.clone()];
+    let mut compacted_history = vec![ResponseItem::Message {
+        id: None,
+        role: "user".to_string(),
+        content: vec![ContentItem::InputText {
+            text: "summary".to_string(),
+        }],
+        end_turn: None,
+        phase: None,
+    }];
+
+    let merged =
+        merge_appended_history_items(&mut compacted_history, &base_history, &latest_history);
+
+    assert_eq!(merged, Some(1));
+    assert_eq!(
+        compacted_history,
+        vec![
+            ResponseItem::Message {
+                id: None,
+                role: "user".to_string(),
+                content: vec![ContentItem::InputText {
+                    text: "summary".to_string(),
+                }],
+                end_turn: None,
+                phase: None,
+            },
+            appended_item,
+        ]
+    );
+}
+
+#[test]
+fn merge_appended_history_items_rejects_non_append_only_changes() {
+    let base_history = vec![ResponseItem::Message {
+        id: None,
+        role: "user".to_string(),
+        content: vec![ContentItem::InputText {
+            text: "before compact".to_string(),
+        }],
+        end_turn: None,
+        phase: None,
+    }];
+    let latest_history = vec![ResponseItem::Message {
+        id: None,
+        role: "user".to_string(),
+        content: vec![ContentItem::InputText {
+            text: "rewritten".to_string(),
+        }],
+        end_turn: None,
+        phase: None,
+    }];
+    let mut compacted_history = vec![ResponseItem::Message {
+        id: None,
+        role: "user".to_string(),
+        content: vec![ContentItem::InputText {
+            text: "summary".to_string(),
+        }],
+        end_turn: None,
+        phase: None,
+    }];
+
+    let merged =
+        merge_appended_history_items(&mut compacted_history, &base_history, &latest_history);
+
+    assert_eq!(merged, None);
+    assert_eq!(
+        compacted_history,
+        vec![ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![ContentItem::InputText {
+                text: "summary".to_string(),
+            }],
+            end_turn: None,
+            phase: None,
+        }]
+    );
+}
+
 #[tokio::test]
 async fn process_compacted_history_replaces_developer_messages() {
     let compacted_history = vec![

--- a/codex-rs/core/src/compact_tests.rs
+++ b/codex-rs/core/src/compact_tests.rs
@@ -186,7 +186,7 @@ fn build_token_limited_compacted_history_appends_summary_message() {
 }
 
 #[test]
-fn append_concurrent_ghost_snapshot_tail_if_append_only_appends_concurrent_tail() {
+fn append_concurrent_ghost_snapshot_tail_appends_concurrent_tail() {
     let base_history = vec![ResponseItem::Message {
         id: None,
         role: "user".to_string(),
@@ -215,13 +215,7 @@ fn append_concurrent_ghost_snapshot_tail_if_append_only_appends_concurrent_tail(
         phase: None,
     }];
 
-    let merged = append_concurrent_ghost_snapshot_tail_if_append_only(
-        &mut compacted_history,
-        &base_history,
-        &latest_history,
-    );
-
-    assert!(merged);
+    append_concurrent_ghost_snapshot_tail(&mut compacted_history, &base_history, &latest_history);
     assert_eq!(
         compacted_history,
         vec![
@@ -240,7 +234,7 @@ fn append_concurrent_ghost_snapshot_tail_if_append_only_appends_concurrent_tail(
 }
 
 #[test]
-fn append_concurrent_ghost_snapshot_tail_if_append_only_rejects_model_visible_tail() {
+fn append_concurrent_ghost_snapshot_tail_ignores_model_visible_tail() {
     let base_history = vec![ResponseItem::Message {
         id: None,
         role: "user".to_string(),
@@ -272,13 +266,7 @@ fn append_concurrent_ghost_snapshot_tail_if_append_only_rejects_model_visible_ta
         phase: None,
     }];
 
-    let merged = append_concurrent_ghost_snapshot_tail_if_append_only(
-        &mut compacted_history,
-        &base_history,
-        &latest_history,
-    );
-
-    assert!(!merged);
+    append_concurrent_ghost_snapshot_tail(&mut compacted_history, &base_history, &latest_history);
     assert_eq!(
         compacted_history,
         vec![ResponseItem::Message {
@@ -294,7 +282,7 @@ fn append_concurrent_ghost_snapshot_tail_if_append_only_rejects_model_visible_ta
 }
 
 #[test]
-fn append_concurrent_ghost_snapshot_tail_if_append_only_rejects_non_append_only_changes() {
+fn append_concurrent_ghost_snapshot_tail_ignores_non_append_only_changes() {
     let base_history = vec![ResponseItem::Message {
         id: None,
         role: "user".to_string(),
@@ -323,13 +311,7 @@ fn append_concurrent_ghost_snapshot_tail_if_append_only_rejects_non_append_only_
         phase: None,
     }];
 
-    let merged = append_concurrent_ghost_snapshot_tail_if_append_only(
-        &mut compacted_history,
-        &base_history,
-        &latest_history,
-    );
-
-    assert!(!merged);
+    append_concurrent_ghost_snapshot_tail(&mut compacted_history, &base_history, &latest_history);
     assert_eq!(
         compacted_history,
         vec![ResponseItem::Message {

--- a/codex-rs/core/src/compact_tests.rs
+++ b/codex-rs/core/src/compact_tests.rs
@@ -186,7 +186,7 @@ fn build_token_limited_compacted_history_appends_summary_message() {
 }
 
 #[test]
-fn append_concurrent_history_tail_if_append_only_appends_concurrent_tail() {
+fn append_concurrent_ghost_snapshot_tail_if_append_only_appends_concurrent_tail() {
     let base_history = vec![ResponseItem::Message {
         id: None,
         role: "user".to_string(),
@@ -215,7 +215,7 @@ fn append_concurrent_history_tail_if_append_only_appends_concurrent_tail() {
         phase: None,
     }];
 
-    let merged = append_concurrent_history_tail_if_append_only(
+    let merged = append_concurrent_ghost_snapshot_tail_if_append_only(
         &mut compacted_history,
         &base_history,
         &latest_history,
@@ -240,7 +240,61 @@ fn append_concurrent_history_tail_if_append_only_appends_concurrent_tail() {
 }
 
 #[test]
-fn append_concurrent_history_tail_if_append_only_rejects_non_append_only_changes() {
+fn append_concurrent_ghost_snapshot_tail_if_append_only_rejects_model_visible_tail() {
+    let base_history = vec![ResponseItem::Message {
+        id: None,
+        role: "user".to_string(),
+        content: vec![ContentItem::InputText {
+            text: "before compact".to_string(),
+        }],
+        end_turn: None,
+        phase: None,
+    }];
+    let latest_history = vec![
+        base_history[0].clone(),
+        ResponseItem::Message {
+            id: None,
+            role: "assistant".to_string(),
+            content: vec![ContentItem::OutputText {
+                text: "not compacted".to_string(),
+            }],
+            end_turn: None,
+            phase: None,
+        },
+    ];
+    let mut compacted_history = vec![ResponseItem::Message {
+        id: None,
+        role: "user".to_string(),
+        content: vec![ContentItem::InputText {
+            text: "summary".to_string(),
+        }],
+        end_turn: None,
+        phase: None,
+    }];
+
+    let merged = append_concurrent_ghost_snapshot_tail_if_append_only(
+        &mut compacted_history,
+        &base_history,
+        &latest_history,
+    );
+
+    assert!(!merged);
+    assert_eq!(
+        compacted_history,
+        vec![ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![ContentItem::InputText {
+                text: "summary".to_string(),
+            }],
+            end_turn: None,
+            phase: None,
+        }]
+    );
+}
+
+#[test]
+fn append_concurrent_ghost_snapshot_tail_if_append_only_rejects_non_append_only_changes() {
     let base_history = vec![ResponseItem::Message {
         id: None,
         role: "user".to_string(),
@@ -269,7 +323,7 @@ fn append_concurrent_history_tail_if_append_only_rejects_non_append_only_changes
         phase: None,
     }];
 
-    let merged = append_concurrent_history_tail_if_append_only(
+    let merged = append_concurrent_ghost_snapshot_tail_if_append_only(
         &mut compacted_history,
         &base_history,
         &latest_history,

--- a/codex-rs/core/src/compact_tests.rs
+++ b/codex-rs/core/src/compact_tests.rs
@@ -186,7 +186,7 @@ fn build_token_limited_compacted_history_appends_summary_message() {
 }
 
 #[test]
-fn merge_appended_history_items_appends_concurrent_tail() {
+fn append_concurrent_history_tail_if_append_only_appends_concurrent_tail() {
     let base_history = vec![ResponseItem::Message {
         id: None,
         role: "user".to_string(),
@@ -215,10 +215,13 @@ fn merge_appended_history_items_appends_concurrent_tail() {
         phase: None,
     }];
 
-    let merged =
-        merge_appended_history_items(&mut compacted_history, &base_history, &latest_history);
+    let merged = append_concurrent_history_tail_if_append_only(
+        &mut compacted_history,
+        &base_history,
+        &latest_history,
+    );
 
-    assert_eq!(merged, Some(1));
+    assert!(merged);
     assert_eq!(
         compacted_history,
         vec![
@@ -237,7 +240,7 @@ fn merge_appended_history_items_appends_concurrent_tail() {
 }
 
 #[test]
-fn merge_appended_history_items_rejects_non_append_only_changes() {
+fn append_concurrent_history_tail_if_append_only_rejects_non_append_only_changes() {
     let base_history = vec![ResponseItem::Message {
         id: None,
         role: "user".to_string(),
@@ -266,10 +269,13 @@ fn merge_appended_history_items_rejects_non_append_only_changes() {
         phase: None,
     }];
 
-    let merged =
-        merge_appended_history_items(&mut compacted_history, &base_history, &latest_history);
+    let merged = append_concurrent_history_tail_if_append_only(
+        &mut compacted_history,
+        &base_history,
+        &latest_history,
+    );
 
-    assert_eq!(merged, None);
+    assert!(!merged);
     assert_eq!(
         compacted_history,
         vec![ResponseItem::Message {

--- a/codex-rs/core/tests/suite/compact.rs
+++ b/codex-rs/core/tests/suite/compact.rs
@@ -2589,6 +2589,103 @@ async fn auto_compact_allows_multiple_attempts_when_interleaved_with_other_turn_
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mid_turn_auto_compaction_stall_emits_specific_error_after_limit() {
+    skip_if_no_network!();
+
+    let server = start_mock_server().await;
+
+    let context_window = 100;
+    let limit = context_window * 90 / 100;
+    let over_limit_tokens = context_window * 95 / 100 + 1;
+    let responses = vec![
+        sse(vec![
+            ev_function_call("call-stall-1", DUMMY_FUNCTION_NAME, "{}"),
+            ev_completed_with_tokens("r1", over_limit_tokens),
+        ]),
+        sse(vec![
+            ev_assistant_message("m2", &auto_summary("STALL_SUMMARY_1")),
+            ev_completed_with_tokens("r2", 10),
+        ]),
+        sse(vec![
+            ev_function_call("call-stall-2", DUMMY_FUNCTION_NAME, "{}"),
+            ev_completed_with_tokens("r3", over_limit_tokens),
+        ]),
+        sse(vec![
+            ev_assistant_message("m4", &auto_summary("STALL_SUMMARY_2")),
+            ev_completed_with_tokens("r4", 10),
+        ]),
+        sse(vec![
+            ev_function_call("call-stall-3", DUMMY_FUNCTION_NAME, "{}"),
+            ev_completed_with_tokens("r5", over_limit_tokens),
+        ]),
+        sse(vec![
+            ev_assistant_message("m6", &auto_summary("STALL_SUMMARY_3")),
+            ev_completed_with_tokens("r6", 10),
+        ]),
+        sse(vec![
+            ev_function_call("call-stall-4", DUMMY_FUNCTION_NAME, "{}"),
+            ev_completed_with_tokens("r7", over_limit_tokens),
+        ]),
+    ];
+    let request_log = mount_sse_sequence(&server, responses).await;
+
+    let model_provider = non_openai_model_provider(&server);
+    let codex = test_codex()
+        .with_config(move |config| {
+            config.model_provider = model_provider;
+            set_test_compact_prompt(config);
+            config.model_context_window = Some(context_window);
+            config.model_auto_compact_token_limit = Some(limit);
+        })
+        .build(&server)
+        .await
+        .expect("build codex")
+        .codex;
+
+    codex
+        .submit(Op::UserInput {
+            items: vec![UserInput::Text {
+                text: "STALL_AUTO_COMPACT".into(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+        })
+        .await
+        .expect("submit stalled auto compact turn");
+
+    let error_message = wait_for_event_match(&codex, |event| match event {
+        EventMsg::Error(err) => Some(err.message.clone()),
+        _ => None,
+    })
+    .await;
+    wait_for_event(&codex, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+
+    assert!(
+        error_message.contains("Mid-turn auto-compaction stalled after 3 attempts"),
+        "expected stalled auto-compaction error, got {error_message}"
+    );
+
+    let request_bodies: Vec<String> = request_log
+        .requests()
+        .into_iter()
+        .map(|request| request.body_json().to_string())
+        .collect();
+    assert_eq!(
+        request_bodies.len(),
+        7,
+        "expected three auto compactions and no fourth compaction request"
+    );
+    assert_eq!(
+        request_bodies
+            .iter()
+            .filter(|body| body_contains_text(body, SUMMARIZATION_PROMPT))
+            .count(),
+        3,
+        "stalled safeguard should stop before a fourth auto compaction request"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn snapshot_request_shape_mid_turn_continuation_compaction() {
     skip_if_no_network!();
 


### PR DESCRIPTION
## Summary
- preserve concurrent append-only `GhostSnapshot` tail items that land during local or remote compaction, merging them inside `replace_compacted_history` so the live history and persisted `replacement_history` stay aligned
- add a stalled mid-turn auto-compaction safeguard so turns do not hot-loop forever when repeated successful compact-and-continue cycles never converge

## Notes
- The history merge is intentionally narrow: it only preserves an append-only `GhostSnapshot` tail, and only when the live history still extends the compacted prefix.
- `GhostSnapshot` items are detached `/undo` metadata and are stripped from `for_prompt()`, so this preserves checkpoint state without reintroducing model-visible items that the compaction request never saw.
- The ghost-snapshot merge happens while holding the same session-state lock that performs `replace_history`, which closes the final snapshot-to-replace gap called out in review.
- After that merge, `CompactedItem.replacement_history` is refreshed from the final installed history so rollout reconstruction stays consistent with the live session.
- The stalled safeguard is not about compaction request failure. Actual compaction failures already abort eagerly. This only handles repeated successful compact-and-continue cycles that stay over budget and still need follow-up.
- When that safeguard trips, we emit explicit stalled auto-compaction telemetry (`codex.auto_compaction.stalled`) and fail the turn instead of looping indefinitely.

## Testing
- `just fmt`
- `cargo test -p codex-core` *(one unrelated local failure: `tools::js_repl::tests::js_repl_imported_local_files_can_access_repl_globals` due sandbox tempdir permissions while bootstrapping dotslash in this sandbox)*
