### PR TITLE
Add code_mode_only feature

### DIFF
--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -339,6 +339,9 @@
             "code_mode": {
               "type": "boolean"
             },
+            "code_mode_only": {
+              "type": "boolean"
+            },
             "codex_git_commit": {
               "type": "boolean"
             },
@@ -1866,6 +1869,9 @@
           "type": "boolean"
         },
         "code_mode": {
+          "type": "boolean"
+        },
+        "code_mode_only": {
           "type": "boolean"
         },
         "codex_git_commit": {

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -6122,7 +6122,7 @@ fn build_prompt(
 ) -> Prompt {
     Prompt {
         input,
-        tools: router.specs(),
+        tools: router.model_visible_specs(),
         parallel_tool_calls: turn_context.model_info.supports_parallel_tool_calls,
         base_instructions,
         personality: turn_context.personality,

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -107,7 +107,7 @@ async fn run_remote_compact_task_inner_impl(
     .await?;
     let prompt = Prompt {
         input: prompt_input,
-        tools: tool_router.specs(),
+        tools: tool_router.model_visible_specs(),
         parallel_tool_calls: turn_context.model_info.supports_parallel_tool_calls,
         base_instructions,
         personality: turn_context.personality,

--- a/codex-rs/core/src/features.rs
+++ b/codex-rs/core/src/features.rs
@@ -87,6 +87,8 @@ pub enum Feature {
     JsRepl,
     /// Enable a minimal JavaScript mode backed by Node's built-in vm runtime.
     CodeMode,
+    /// Restrict model-visible tools to code mode entrypoints (`exec`, `exec_wait`).
+    CodeModeOnly,
     /// Only expose js_repl tools directly to the model.
     JsReplToolsOnly,
     /// Use the single unified PTY-backed exec tool.
@@ -431,6 +433,9 @@ impl Features {
         if self.enabled(Feature::SpawnCsv) && !self.enabled(Feature::Collab) {
             self.enable(Feature::Collab);
         }
+        if self.enabled(Feature::CodeModeOnly) && !self.enabled(Feature::CodeMode) {
+            self.enable(Feature::CodeMode);
+        }
         if self.enabled(Feature::JsReplToolsOnly) && !self.enabled(Feature::JsRepl) {
             tracing::warn!("js_repl_tools_only requires js_repl; disabling js_repl_tools_only");
             self.disable(Feature::JsReplToolsOnly);
@@ -557,6 +562,12 @@ pub const FEATURES: &[FeatureSpec] = &[
     FeatureSpec {
         id: Feature::CodeMode,
         key: "code_mode",
+        stage: Stage::UnderDevelopment,
+        default_enabled: false,
+    },
+    FeatureSpec {
+        id: Feature::CodeModeOnly,
+        key: "code_mode_only",
         stage: Stage::UnderDevelopment,
         default_enabled: false,
     },

--- a/codex-rs/core/src/features_tests.rs
+++ b/codex-rs/core/src/features_tests.rs
@@ -59,6 +59,16 @@ fn js_repl_is_experimental_and_user_toggleable() {
 }
 
 #[test]
+fn code_mode_only_requires_code_mode() {
+    let mut features = Features::with_defaults();
+    features.enable(Feature::CodeModeOnly);
+    features.normalize_dependencies();
+
+    assert_eq!(features.enabled(Feature::CodeModeOnly), true);
+    assert_eq!(features.enabled(Feature::CodeMode), true);
+}
+
+#[test]
 fn guardian_approval_is_experimental_and_user_toggleable() {
     let spec = Feature::GuardianApproval.info();
     let stage = spec.stage;

--- a/codex-rs/core/src/tools/code_mode/mod.rs
+++ b/codex-rs/core/src/tools/code_mode/mod.rs
@@ -62,14 +62,27 @@ enum CodeModeExecutionStatus {
     Terminated,
 }
 
-pub(crate) fn tool_description(enabled_tool_names: &[String]) -> String {
-    let enabled_list = if enabled_tool_names.is_empty() {
-        "none".to_string()
-    } else {
-        enabled_tool_names.join(", ")
-    };
+pub(crate) fn tool_description(enabled_tools: &[(String, String)]) -> String {
+    if enabled_tools.is_empty() {
+        return format!(
+            "{}\n- Enabled nested tools: none.",
+            CODE_MODE_DESCRIPTION_TEMPLATE.trim_end()
+        );
+    }
+
+    let nested_tool_reference = enabled_tools
+        .iter()
+        .map(|(name, nested_description)| {
+            let global_name = normalize_code_mode_identifier(name);
+            format!(
+                "### `{global_name}` (`{name}`)\n{}",
+                nested_description.trim()
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n");
     format!(
-        "{}\n- Enabled nested tools: {enabled_list}.",
+        "{}\n\n{nested_tool_reference}",
         CODE_MODE_DESCRIPTION_TEMPLATE.trim_end()
     )
 }

--- a/codex-rs/core/src/tools/code_mode/mod.rs
+++ b/codex-rs/core/src/tools/code_mode/mod.rs
@@ -34,9 +34,14 @@ const CODE_MODE_BRIDGE_SOURCE: &str = include_str!("bridge.js");
 const CODE_MODE_DESCRIPTION_TEMPLATE: &str = include_str!("description.md");
 const CODE_MODE_WAIT_DESCRIPTION_TEMPLATE: &str = include_str!("wait_description.md");
 const CODE_MODE_PRAGMA_PREFIX: &str = "// @exec:";
+const CODE_MODE_ONLY_PREFACE: &str = "Use `exec/exec_wait` tool to run all other tools, do not attempt to use any other tools directly";
 
 pub(crate) const PUBLIC_TOOL_NAME: &str = "exec";
 pub(crate) const WAIT_TOOL_NAME: &str = "exec_wait";
+
+pub(crate) fn is_code_mode_tool(tool_name: &str) -> bool {
+    tool_name == PUBLIC_TOOL_NAME || tool_name == WAIT_TOOL_NAME
+}
 pub(crate) const DEFAULT_EXEC_YIELD_TIME_MS: u64 = 10_000;
 pub(crate) const DEFAULT_WAIT_YIELD_TIME_MS: u64 = 10_000;
 
@@ -62,29 +67,35 @@ enum CodeModeExecutionStatus {
     Terminated,
 }
 
-pub(crate) fn tool_description(enabled_tools: &[(String, String)]) -> String {
-    if enabled_tools.is_empty() {
-        return format!(
+pub(crate) fn tool_description(enabled_tools: &[(String, String)], code_mode_only: bool) -> String {
+    let body = if enabled_tools.is_empty() {
+        format!(
             "{}\n- Enabled nested tools: none.",
             CODE_MODE_DESCRIPTION_TEMPLATE.trim_end()
-        );
-    }
+        )
+    } else {
+        let nested_tool_reference = enabled_tools
+            .iter()
+            .map(|(name, nested_description)| {
+                let global_name = normalize_code_mode_identifier(name);
+                format!(
+                    "### `{global_name}` (`{name}`)\n{}",
+                    nested_description.trim()
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        format!(
+            "{}\n\n{nested_tool_reference}",
+            CODE_MODE_DESCRIPTION_TEMPLATE.trim_end()
+        )
+    };
 
-    let nested_tool_reference = enabled_tools
-        .iter()
-        .map(|(name, nested_description)| {
-            let global_name = normalize_code_mode_identifier(name);
-            format!(
-                "### `{global_name}` (`{name}`)\n{}",
-                nested_description.trim()
-            )
-        })
-        .collect::<Vec<_>>()
-        .join("\n\n");
-    format!(
-        "{}\n\n{nested_tool_reference}",
-        CODE_MODE_DESCRIPTION_TEMPLATE.trim_end()
-    )
+    if code_mode_only {
+        format!("{CODE_MODE_ONLY_PREFACE}\n\n{body}")
+    } else {
+        body
+    }
 }
 
 pub(crate) fn wait_tool_description() -> &'static str {
@@ -231,7 +242,7 @@ async fn build_enabled_tools(exec: &ExecContext) -> Vec<protocol::EnabledTool> {
 
 fn enabled_tool_from_spec(spec: ToolSpec) -> Option<protocol::EnabledTool> {
     let tool_name = spec.name().to_string();
-    if tool_name == PUBLIC_TOOL_NAME || tool_name == WAIT_TOOL_NAME {
+    if is_code_mode_tool(&tool_name) {
         return None;
     }
 

--- a/codex-rs/core/src/tools/code_mode/mod.rs
+++ b/codex-rs/core/src/tools/code_mode/mod.rs
@@ -39,8 +39,8 @@ const CODE_MODE_ONLY_PREFACE: &str = "Use `exec/exec_wait` tool to run all other
 pub(crate) const PUBLIC_TOOL_NAME: &str = "exec";
 pub(crate) const WAIT_TOOL_NAME: &str = "exec_wait";
 
-pub(crate) fn is_code_mode_tool(tool_name: &str) -> bool {
-    tool_name == PUBLIC_TOOL_NAME || tool_name == WAIT_TOOL_NAME
+pub(crate) fn is_code_mode_nested_tool(tool_name: &str) -> bool {
+    tool_name != PUBLIC_TOOL_NAME && tool_name != WAIT_TOOL_NAME
 }
 pub(crate) const DEFAULT_EXEC_YIELD_TIME_MS: u64 = 10_000;
 pub(crate) const DEFAULT_WAIT_YIELD_TIME_MS: u64 = 10_000;
@@ -68,12 +68,17 @@ enum CodeModeExecutionStatus {
 }
 
 pub(crate) fn tool_description(enabled_tools: &[(String, String)], code_mode_only: bool) -> String {
-    let body = if enabled_tools.is_empty() {
-        format!(
-            "{}\n- Enabled nested tools: none.",
-            CODE_MODE_DESCRIPTION_TEMPLATE.trim_end()
-        )
-    } else {
+    let description_template = CODE_MODE_DESCRIPTION_TEMPLATE.trim_end();
+    if !code_mode_only {
+        return description_template.to_string();
+    }
+
+    let mut sections = vec![
+        CODE_MODE_ONLY_PREFACE.to_string(),
+        description_template.to_string(),
+    ];
+
+    if !enabled_tools.is_empty() {
         let nested_tool_reference = enabled_tools
             .iter()
             .map(|(name, nested_description)| {
@@ -85,17 +90,10 @@ pub(crate) fn tool_description(enabled_tools: &[(String, String)], code_mode_onl
             })
             .collect::<Vec<_>>()
             .join("\n\n");
-        format!(
-            "{}\n\n{nested_tool_reference}",
-            CODE_MODE_DESCRIPTION_TEMPLATE.trim_end()
-        )
-    };
-
-    if code_mode_only {
-        format!("{CODE_MODE_ONLY_PREFACE}\n\n{body}")
-    } else {
-        body
+        sections.push(nested_tool_reference);
     }
+
+    sections.join("\n\n")
 }
 
 pub(crate) fn wait_tool_description() -> &'static str {
@@ -242,7 +240,7 @@ async fn build_enabled_tools(exec: &ExecContext) -> Vec<protocol::EnabledTool> {
 
 fn enabled_tool_from_spec(spec: ToolSpec) -> Option<protocol::EnabledTool> {
     let tool_name = spec.name().to_string();
-    if is_code_mode_tool(&tool_name) {
+    if !is_code_mode_nested_tool(&tool_name) {
         return None;
     }
 

--- a/codex-rs/core/src/tools/router.rs
+++ b/codex-rs/core/src/tools/router.rs
@@ -4,7 +4,7 @@ use crate::codex::TurnContext;
 use crate::function_tool::FunctionCallError;
 use crate::mcp_connection_manager::ToolInfo;
 use crate::sandboxing::SandboxPermissions;
-use crate::tools::code_mode::is_code_mode_tool;
+use crate::tools::code_mode::is_code_mode_nested_tool;
 use crate::tools::context::FunctionToolOutput;
 use crate::tools::context::SharedTurnDiffTracker;
 use crate::tools::context::ToolInvocation;
@@ -70,7 +70,7 @@ impl ToolRouter {
             specs
                 .iter()
                 .filter_map(|configured_tool| {
-                    if is_code_mode_tool(configured_tool.spec.name()) {
+                    if !is_code_mode_nested_tool(configured_tool.spec.name()) {
                         Some(configured_tool.spec.clone())
                     } else {
                         None

--- a/codex-rs/core/src/tools/router.rs
+++ b/codex-rs/core/src/tools/router.rs
@@ -4,6 +4,7 @@ use crate::codex::TurnContext;
 use crate::function_tool::FunctionCallError;
 use crate::mcp_connection_manager::ToolInfo;
 use crate::sandboxing::SandboxPermissions;
+use crate::tools::code_mode::is_code_mode_tool;
 use crate::tools::context::FunctionToolOutput;
 use crate::tools::context::SharedTurnDiffTracker;
 use crate::tools::context::ToolInvocation;
@@ -39,6 +40,7 @@ pub struct ToolCall {
 pub struct ToolRouter {
     registry: ToolRegistry,
     specs: Vec<ConfiguredToolSpec>,
+    model_visible_specs: Vec<ToolSpec>,
 }
 
 pub(crate) struct ToolRouterParams<'a> {
@@ -64,8 +66,29 @@ impl ToolRouter {
             dynamic_tools,
         );
         let (specs, registry) = builder.build();
+        let model_visible_specs = if config.code_mode_only_enabled {
+            specs
+                .iter()
+                .filter_map(|configured_tool| {
+                    if is_code_mode_tool(configured_tool.spec.name()) {
+                        Some(configured_tool.spec.clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        } else {
+            specs
+                .iter()
+                .map(|configured_tool| configured_tool.spec.clone())
+                .collect()
+        };
 
-        Self { registry, specs }
+        Self {
+            registry,
+            specs,
+            model_visible_specs,
+        }
     }
 
     pub fn specs(&self) -> Vec<ToolSpec> {
@@ -73,6 +96,10 @@ impl ToolRouter {
             .iter()
             .map(|config| config.spec.clone())
             .collect()
+    }
+
+    pub fn model_visible_specs(&self) -> Vec<ToolSpec> {
+        self.model_visible_specs.clone()
     }
 
     pub fn find_spec(&self, tool_name: &str) -> Option<ToolSpec> {

--- a/codex-rs/core/src/tools/spec.rs
+++ b/codex-rs/core/src/tools/spec.rs
@@ -1999,7 +1999,10 @@ fn create_js_repl_reset_tool() -> ToolSpec {
     })
 }
 
-fn create_code_mode_tool(enabled_tools: &[(String, String)]) -> ToolSpec {
+fn create_code_mode_tool(
+    enabled_tools: &[(String, String)],
+    code_mode_only_enabled: bool,
+) -> ToolSpec {
     const CODE_MODE_FREEFORM_GRAMMAR: &str = r#"
 start: pragma_source | plain_source
 pragma_source: PRAGMA_LINE NEWLINE SOURCE
@@ -2012,7 +2015,7 @@ SOURCE: /[\s\S]+/
 
     ToolSpec::Freeform(FreeformTool {
         name: PUBLIC_TOOL_NAME.to_string(),
-        description: code_mode_tool_description(enabled_tools),
+        description: code_mode_tool_description(enabled_tools, code_mode_only_enabled),
         format: FreeformToolFormat {
             r#type: "grammar".to_string(),
             syntax: "lark".to_string(),
@@ -2498,7 +2501,7 @@ pub(crate) fn build_specs_with_discoverable_tools(
         enabled_tools.dedup_by(|left, right| left.0 == right.0);
         push_tool_spec(
             &mut builder,
-            create_code_mode_tool(&enabled_tools),
+            create_code_mode_tool(&enabled_tools, config.code_mode_only_enabled),
             false,
             config.code_mode_enabled,
         );
@@ -2510,10 +2513,6 @@ pub(crate) fn build_specs_with_discoverable_tools(
             config.code_mode_enabled,
         );
         builder.register_handler(WAIT_TOOL_NAME, code_mode_wait_handler);
-
-        if config.code_mode_only_enabled {
-            return builder;
-        }
     }
 
     match &config.shell_type {

--- a/codex-rs/core/src/tools/spec.rs
+++ b/codex-rs/core/src/tools/spec.rs
@@ -10,6 +10,7 @@ use crate::models_manager::collaboration_mode_presets::CollaborationModesConfig;
 use crate::original_image_detail::can_request_original_image_detail;
 use crate::tools::code_mode::PUBLIC_TOOL_NAME;
 use crate::tools::code_mode::WAIT_TOOL_NAME;
+use crate::tools::code_mode::is_code_mode_nested_tool;
 use crate::tools::code_mode::tool_description as code_mode_tool_description;
 use crate::tools::code_mode::wait_tool_description as code_mode_wait_tool_description;
 use crate::tools::code_mode_description::augment_tool_spec_for_code_mode;
@@ -2024,22 +2025,6 @@ SOURCE: /[\s\S]+/
     })
 }
 
-fn code_mode_nested_tool_details(spec: ToolSpec) -> Option<(String, String)> {
-    match spec {
-        ToolSpec::Function(tool)
-            if tool.name != PUBLIC_TOOL_NAME && tool.name != WAIT_TOOL_NAME =>
-        {
-            Some((tool.name, tool.description))
-        }
-        ToolSpec::Freeform(tool)
-            if tool.name != PUBLIC_TOOL_NAME && tool.name != WAIT_TOOL_NAME =>
-        {
-            Some((tool.name, tool.description))
-        }
-        _ => None,
-    }
-}
-
 fn create_list_mcp_resources_tool() -> ToolSpec {
     let properties = BTreeMap::from([
         (
@@ -2494,8 +2479,14 @@ pub(crate) fn build_specs_with_discoverable_tools(
         .build();
         let mut enabled_tools = nested_specs
             .into_iter()
-            .map(|spec| augment_tool_spec_for_code_mode(spec.spec, true))
-            .filter_map(code_mode_nested_tool_details)
+            .filter_map(|spec| {
+                let (name, description) = match augment_tool_spec_for_code_mode(spec.spec, true) {
+                    ToolSpec::Function(tool) => (tool.name, tool.description),
+                    ToolSpec::Freeform(tool) => (tool.name, tool.description),
+                    _ => return None,
+                };
+                is_code_mode_nested_tool(&name).then_some((name, description))
+            })
             .collect::<Vec<_>>();
         enabled_tools.sort_by(|left, right| left.0.cmp(&right.0));
         enabled_tools.dedup_by(|left, right| left.0 == right.0);

--- a/codex-rs/core/src/tools/spec.rs
+++ b/codex-rs/core/src/tools/spec.rs
@@ -226,6 +226,7 @@ pub(crate) struct ToolsConfig {
     pub exec_permission_approvals_enabled: bool,
     pub request_permissions_tool_enabled: bool,
     pub code_mode_enabled: bool,
+    pub code_mode_only_enabled: bool,
     pub js_repl_enabled: bool,
     pub js_repl_tools_only: bool,
     pub can_request_original_image_detail: bool,
@@ -274,6 +275,7 @@ impl ToolsConfig {
         } = params;
         let include_apply_patch_tool = features.enabled(Feature::ApplyPatchFreeform);
         let include_code_mode = features.enabled(Feature::CodeMode);
+        let include_code_mode_only = include_code_mode && features.enabled(Feature::CodeModeOnly);
         let include_js_repl = features.enabled(Feature::JsRepl);
         let include_js_repl_tools_only =
             include_js_repl && features.enabled(Feature::JsReplToolsOnly);
@@ -363,6 +365,7 @@ impl ToolsConfig {
             exec_permission_approvals_enabled,
             request_permissions_tool_enabled,
             code_mode_enabled: include_code_mode,
+            code_mode_only_enabled: include_code_mode_only,
             js_repl_enabled: include_js_repl,
             js_repl_tools_only: include_js_repl_tools_only,
             can_request_original_image_detail: include_original_image_detail,
@@ -394,6 +397,7 @@ impl ToolsConfig {
     pub fn for_code_mode_nested_tools(&self) -> Self {
         let mut nested = self.clone();
         nested.code_mode_enabled = false;
+        nested.code_mode_only_enabled = false;
         nested
     }
 }
@@ -1995,7 +1999,7 @@ fn create_js_repl_reset_tool() -> ToolSpec {
     })
 }
 
-fn create_code_mode_tool(enabled_tool_names: &[String]) -> ToolSpec {
+fn create_code_mode_tool(enabled_tools: &[(String, String)]) -> ToolSpec {
     const CODE_MODE_FREEFORM_GRAMMAR: &str = r#"
 start: pragma_source | plain_source
 pragma_source: PRAGMA_LINE NEWLINE SOURCE
@@ -2008,7 +2012,7 @@ SOURCE: /[\s\S]+/
 
     ToolSpec::Freeform(FreeformTool {
         name: PUBLIC_TOOL_NAME.to_string(),
-        description: code_mode_tool_description(enabled_tool_names),
+        description: code_mode_tool_description(enabled_tools),
         format: FreeformToolFormat {
             r#type: "grammar".to_string(),
             syntax: "lark".to_string(),
@@ -2017,10 +2021,20 @@ SOURCE: /[\s\S]+/
     })
 }
 
-fn is_code_mode_nested_tool(spec: &ToolSpec) -> bool {
-    spec.name() != PUBLIC_TOOL_NAME
-        && spec.name() != WAIT_TOOL_NAME
-        && matches!(spec, ToolSpec::Function(_) | ToolSpec::Freeform(_))
+fn code_mode_nested_tool_details(spec: ToolSpec) -> Option<(String, String)> {
+    match spec {
+        ToolSpec::Function(tool)
+            if tool.name != PUBLIC_TOOL_NAME && tool.name != WAIT_TOOL_NAME =>
+        {
+            Some((tool.name, tool.description))
+        }
+        ToolSpec::Freeform(tool)
+            if tool.name != PUBLIC_TOOL_NAME && tool.name != WAIT_TOOL_NAME =>
+        {
+            Some((tool.name, tool.description))
+        }
+        _ => None,
+    }
 }
 
 fn create_list_mcp_resources_tool() -> ToolSpec {
@@ -2475,17 +2489,16 @@ pub(crate) fn build_specs_with_discoverable_tools(
             dynamic_tools,
         )
         .build();
-        let mut enabled_tool_names = nested_specs
+        let mut enabled_tools = nested_specs
             .into_iter()
-            .map(|spec| spec.spec)
-            .filter(is_code_mode_nested_tool)
-            .map(|spec| spec.name().to_string())
+            .map(|spec| augment_tool_spec_for_code_mode(spec.spec, true))
+            .filter_map(code_mode_nested_tool_details)
             .collect::<Vec<_>>();
-        enabled_tool_names.sort();
-        enabled_tool_names.dedup();
+        enabled_tools.sort_by(|left, right| left.0.cmp(&right.0));
+        enabled_tools.dedup_by(|left, right| left.0 == right.0);
         push_tool_spec(
             &mut builder,
-            create_code_mode_tool(&enabled_tool_names),
+            create_code_mode_tool(&enabled_tools),
             false,
             config.code_mode_enabled,
         );
@@ -2497,6 +2510,10 @@ pub(crate) fn build_specs_with_discoverable_tools(
             config.code_mode_enabled,
         );
         builder.register_handler(WAIT_TOOL_NAME, code_mode_wait_handler);
+
+        if config.code_mode_only_enabled {
+            return builder;
+        }
     }
 
     match &config.shell_type {

--- a/codex-rs/core/src/tools/spec_tests.rs
+++ b/codex-rs/core/src/tools/spec_tests.rs
@@ -2,7 +2,9 @@ use crate::client_common::tools::FreeformTool;
 use crate::config::test_config;
 use crate::models_manager::manager::ModelsManager;
 use crate::models_manager::model_info::with_config_overrides;
+use crate::tools::ToolRouter;
 use crate::tools::registry::ConfiguredToolSpec;
+use crate::tools::router::ToolRouterParams;
 use codex_app_server_protocol::AppInfo;
 use codex_protocol::openai_models::InputModality;
 use codex_protocol::openai_models::ModelInfo;
@@ -933,8 +935,20 @@ fn assert_model_tools(
         sandbox_policy: &SandboxPolicy::DangerFullAccess,
         windows_sandbox_level: WindowsSandboxLevel::Disabled,
     });
-    let (tools, _) = build_specs(&tools_config, None, None, &[]).build();
-    let tool_names = tools.iter().map(|t| t.spec.name()).collect::<Vec<_>>();
+    let router = ToolRouter::from_config(
+        &tools_config,
+        ToolRouterParams {
+            mcp_tools: None,
+            app_tools: None,
+            discoverable_tools: None,
+            dynamic_tools: &[],
+        },
+    );
+    let model_visible_specs = router.model_visible_specs();
+    let tool_names = model_visible_specs
+        .iter()
+        .map(ToolSpec::name)
+        .collect::<Vec<_>>();
     assert_eq!(&tool_names, &expected_tools,);
 }
 
@@ -2528,6 +2542,9 @@ fn code_mode_only_exec_description_includes_full_nested_tool_details() {
 
     assert!(!description.contains("Enabled nested tools:"));
     assert!(!description.contains("Nested tool reference:"));
+    assert!(description.starts_with(
+        "Use `exec/exec_wait` tool to run all other tools, do not attempt to use any other tools directly"
+    ));
     assert!(description.contains("### `update_plan` (`update_plan`)"));
     assert!(description.contains("### `view_image` (`view_image`)"));
     assert!(description.contains("Code mode declaration:"));

--- a/codex-rs/core/src/tools/spec_tests.rs
+++ b/codex-rs/core/src/tools/spec_tests.rs
@@ -2551,6 +2551,36 @@ fn code_mode_only_exec_description_includes_full_nested_tool_details() {
 }
 
 #[test]
+fn code_mode_exec_description_omits_nested_tool_details_when_not_code_mode_only() {
+    let config = test_config();
+    let model_info = ModelsManager::construct_model_info_offline_for_tests("gpt-5-codex", &config);
+    let mut features = Features::with_defaults();
+    features.enable(Feature::CodeMode);
+    let available_models = Vec::new();
+    let tools_config = ToolsConfig::new(&ToolsConfigParams {
+        model_info: &model_info,
+        available_models: &available_models,
+        features: &features,
+        web_search_mode: Some(WebSearchMode::Cached),
+        session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
+    });
+
+    let (tools, _) = build_specs(&tools_config, None, None, &[]).build();
+    let ToolSpec::Freeform(FreeformTool { description, .. }) = &find_tool(&tools, "exec").spec
+    else {
+        panic!("expected freeform tool");
+    };
+
+    assert!(!description.starts_with(
+        "Use `exec/exec_wait` tool to run all other tools, do not attempt to use any other tools directly"
+    ));
+    assert!(!description.contains("### `update_plan` (`update_plan`)"));
+    assert!(!description.contains("### `view_image` (`view_image`)"));
+}
+
+#[test]
 fn chat_tools_include_top_level_name() {
     let properties =
         BTreeMap::from([("foo".to_string(), JsonSchema::String { description: None })]);

--- a/codex-rs/core/src/tools/spec_tests.rs
+++ b/codex-rs/core/src/tools/spec_tests.rs
@@ -2489,6 +2489,51 @@ fn code_mode_augments_mcp_tool_descriptions_with_namespaced_sample() {
 }
 
 #[test]
+fn code_mode_only_restricts_model_tools_to_exec_tools() {
+    let mut features = Features::with_defaults();
+    features.enable(Feature::CodeMode);
+    features.enable(Feature::CodeModeOnly);
+
+    assert_model_tools(
+        "gpt-5.1-codex",
+        &features,
+        Some(WebSearchMode::Live),
+        &["exec", "exec_wait"],
+    );
+}
+
+#[test]
+fn code_mode_only_exec_description_includes_full_nested_tool_details() {
+    let config = test_config();
+    let model_info = ModelsManager::construct_model_info_offline_for_tests("gpt-5-codex", &config);
+    let mut features = Features::with_defaults();
+    features.enable(Feature::CodeMode);
+    features.enable(Feature::CodeModeOnly);
+    let available_models = Vec::new();
+    let tools_config = ToolsConfig::new(&ToolsConfigParams {
+        model_info: &model_info,
+        available_models: &available_models,
+        features: &features,
+        web_search_mode: Some(WebSearchMode::Cached),
+        session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
+    });
+
+    let (tools, _) = build_specs(&tools_config, None, None, &[]).build();
+    let ToolSpec::Freeform(FreeformTool { description, .. }) = &find_tool(&tools, "exec").spec
+    else {
+        panic!("expected freeform tool");
+    };
+
+    assert!(!description.contains("Enabled nested tools:"));
+    assert!(!description.contains("Nested tool reference:"));
+    assert!(description.contains("### `update_plan` (`update_plan`)"));
+    assert!(description.contains("### `view_image` (`view_image`)"));
+    assert!(description.contains("Code mode declaration:"));
+}
+
+#[test]
 fn chat_tools_include_top_level_name() {
     let properties =
         BTreeMap::from([("foo".to_string(), JsonSchema::String { description: None })]);

--- a/codex-rs/core/src/tools/spec_tests.rs
+++ b/codex-rs/core/src/tools/spec_tests.rs
@@ -2547,7 +2547,6 @@ fn code_mode_only_exec_description_includes_full_nested_tool_details() {
     ));
     assert!(description.contains("### `update_plan` (`update_plan`)"));
     assert!(description.contains("### `view_image` (`view_image`)"));
-    assert!(description.contains("Code mode declaration:"));
 }
 
 #[test]

--- a/codex-rs/core/tests/suite/code_mode.rs
+++ b/codex-rs/core/tests/suite/code_mode.rs
@@ -37,6 +37,23 @@ fn custom_tool_output_items(req: &ResponsesRequest, call_id: &str) -> Vec<Value>
     }
 }
 
+fn tool_names(body: &Value) -> Vec<String> {
+    body.get("tools")
+        .and_then(Value::as_array)
+        .map(|tools| {
+            tools
+                .iter()
+                .filter_map(|tool| {
+                    tool.get("name")
+                        .or_else(|| tool.get("type"))
+                        .and_then(Value::as_str)
+                        .map(str::to_string)
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 fn function_tool_output_items(req: &ResponsesRequest, call_id: &str) -> Vec<Value> {
     match req.function_call_output(call_id).get("output") {
         Some(Value::Array(items)) => items.clone(),
@@ -229,6 +246,36 @@ text(JSON.stringify(await tools.exec_command({ cmd: "printf code_mode_exec_marke
     assert_eq!(parsed.get("exit_code").and_then(Value::as_i64), Some(0));
     assert!(parsed.get("wall_time_seconds").is_some());
     assert!(parsed.get("session_id").is_none());
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn code_mode_only_restricts_prompt_tools() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = responses::start_mock_server().await;
+    let resp_mock = responses::mount_sse_once(
+        &server,
+        sse(vec![
+            ev_response_created("resp-1"),
+            ev_assistant_message("msg-1", "done"),
+            ev_completed("resp-1"),
+        ]),
+    )
+    .await;
+
+    let mut builder = test_codex().with_config(|config| {
+        let _ = config.features.enable(Feature::CodeModeOnly);
+    });
+    let test = builder.build(&server).await?;
+    test.submit_turn("list tools in code mode only").await?;
+
+    let first_body = resp_mock.single_request().body_json();
+    assert_eq!(
+        tool_names(&first_body),
+        vec!["exec".to_string(), "exec_wait".to_string()]
+    );
 
     Ok(())
 }

--- a/codex-rs/core/tests/suite/code_mode.rs
+++ b/codex-rs/core/tests/suite/code_mode.rs
@@ -280,6 +280,56 @@ async fn code_mode_only_restricts_prompt_tools() -> Result<()> {
     Ok(())
 }
 
+#[cfg_attr(windows, ignore = "no exec_command on Windows")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn code_mode_only_can_call_nested_tools() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = responses::start_mock_server().await;
+    responses::mount_sse_once(
+        &server,
+        sse(vec![
+            ev_response_created("resp-1"),
+            ev_custom_tool_call(
+                "call-1",
+                "exec",
+                r#"
+const output = await tools.exec_command({ cmd: "printf code_mode_only_nested_tool_marker" });
+text(output.output);
+"#,
+            ),
+            ev_completed("resp-1"),
+        ]),
+    )
+    .await;
+    let follow_up_mock = responses::mount_sse_once(
+        &server,
+        sse(vec![
+            ev_assistant_message("msg-1", "done"),
+            ev_completed("resp-2"),
+        ]),
+    )
+    .await;
+
+    let mut builder = test_codex().with_config(|config| {
+        let _ = config.features.enable(Feature::CodeModeOnly);
+    });
+    let test = builder.build(&server).await?;
+    test.submit_turn("use exec to run nested tool in code mode only")
+        .await?;
+
+    let request = follow_up_mock.single_request();
+    let (output, success) = custom_tool_output_body_and_success(&request, "call-1");
+    assert_ne!(
+        success,
+        Some(false),
+        "code_mode_only nested tool call failed unexpectedly: {output}"
+    );
+    assert_eq!(output, "code_mode_only_nested_tool_marker");
+
+    Ok(())
+}
+
 #[cfg_attr(windows, ignore = "flaky on windows")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn code_mode_nested_tool_calls_can_run_in_parallel() -> Result<()> {


### PR DESCRIPTION
Summary
- add the code_mode_only feature flag/config schema and wire its dependency on code_mode
- update code mode tool descriptions to list nested tools with detailed headers
- restrict available tools for prompt and exec descriptions when code_mode_only is enabled and test the behavior

Testing
- Not run (not requested)