### PR TITLE
Fix wait_agent expectations in core tests

### DIFF
--- a/codex-rs/core/src/tools/spec_tests.rs
+++ b/codex-rs/core/src/tools/spec_tests.rs
@@ -1192,7 +1192,7 @@ fn test_build_specs_gpt5_codex_default() {
             "spawn_agent",
             "send_input",
             "resume_agent",
-            "wait",
+            "wait_agent",
             "close_agent",
         ],
     );
@@ -1215,7 +1215,7 @@ fn test_build_specs_gpt51_codex_default() {
             "spawn_agent",
             "send_input",
             "resume_agent",
-            "wait",
+            "wait_agent",
             "close_agent",
         ],
     );
@@ -1240,7 +1240,7 @@ fn test_build_specs_gpt5_codex_unified_exec_web_search() {
             "spawn_agent",
             "send_input",
             "resume_agent",
-            "wait",
+            "wait_agent",
             "close_agent",
         ],
     );
@@ -1265,7 +1265,7 @@ fn test_build_specs_gpt51_codex_unified_exec_web_search() {
             "spawn_agent",
             "send_input",
             "resume_agent",
-            "wait",
+            "wait_agent",
             "close_agent",
         ],
     );
@@ -1288,7 +1288,7 @@ fn test_gpt_5_1_codex_max_defaults() {
             "spawn_agent",
             "send_input",
             "resume_agent",
-            "wait",
+            "wait_agent",
             "close_agent",
         ],
     );
@@ -1311,7 +1311,7 @@ fn test_codex_5_1_mini_defaults() {
             "spawn_agent",
             "send_input",
             "resume_agent",
-            "wait",
+            "wait_agent",
             "close_agent",
         ],
     );
@@ -1333,7 +1333,7 @@ fn test_gpt_5_defaults() {
             "spawn_agent",
             "send_input",
             "resume_agent",
-            "wait",
+            "wait_agent",
             "close_agent",
         ],
     );
@@ -1356,7 +1356,7 @@ fn test_gpt_5_1_defaults() {
             "spawn_agent",
             "send_input",
             "resume_agent",
-            "wait",
+            "wait_agent",
             "close_agent",
         ],
     );
@@ -1381,7 +1381,7 @@ fn test_gpt_5_1_codex_max_unified_exec_web_search() {
             "spawn_agent",
             "send_input",
             "resume_agent",
-            "wait",
+            "wait_agent",
             "close_agent",
         ],
     );

--- a/codex-rs/core/tests/suite/prompt_caching.rs
+++ b/codex-rs/core/tests/suite/prompt_caching.rs
@@ -180,7 +180,7 @@ async fn prompt_tools_are_consistent_across_requests() -> anyhow::Result<()> {
         "spawn_agent",
         "send_input",
         "resume_agent",
-        "wait",
+        "wait_agent",
         "close_agent",
     ]);
     let body0 = req1.single_request().body_json();


### PR DESCRIPTION
## Summary
- update stale core tool-spec expectations from `wait` to `wait_agent`
- update the prompt-caching tool-name assertion to match the renamed tool
- fix the Bazel regressions introduced after #14631 renamed the multi-agent wait tool

## Testing
- cargo test -p codex-core tools::spec::tests
- cargo test -p codex-core suite::prompt_caching::prompt_tools_are_consistent_across_requests