### PR TITLE
Fix stale create_wait_tool reference

### DIFF
--- a/codex-rs/core/src/tools/spec_tests.rs
+++ b/codex-rs/core/src/tools/spec_tests.rs
@@ -462,7 +462,7 @@ fn test_full_toolset_specs_for_gpt5_codex_unified_exec_web_search() {
         create_spawn_agent_tool(&config),
         create_send_input_tool(),
         create_resume_agent_tool(),
-        create_exec_wait_tool(),
+        create_wait_agent_tool(),
         create_close_agent_tool(),
     ] {
         expected.insert(tool_name(&spec).to_string(), spec);


### PR DESCRIPTION
## Summary
- replace the stale `create_wait_tool()` reference in `spec_tests.rs`
- use `create_wait_agent_tool()` to match the actual multi-agent tool rename from `#14631`
- fix the resulting `codex-core` spec-test compile failure on current `main`

## Context
`#14631` renamed the model-facing multi-agent tool from `wait` to `wait_agent` and renamed the corresponding spec helper to `create_wait_agent_tool()`.

One `spec_tests.rs` call site was left behind, so current `main` fails to compile `codex-core` tests with:
- `cannot find function create_wait_tool`

Using `create_wait_agent_tool()` is the correct fix here; `create_exec_wait_tool()` would point at the separate exec wait tool and would not match the renamed multi-agent toolset.

## Testing
- not rerun locally after the rebase
