### PR TITLE
Fix Windows CI assertions for guardian and Smart Approvals

### DIFF
--- a/codex-rs/core/src/guardian.rs
+++ b/codex-rs/core/src/guardian.rs
@@ -1016,23 +1016,15 @@ fn guardian_assessment_action_value(action: &GuardianApprovalRequest) -> Value {
             files,
             change_count,
             ..
-        } => {
-            let normalize_path = |path: String| {
-                if path.len() > 2 && path.as_bytes()[1] == b':' && path.as_bytes()[2] == b'/' {
-                    return path[2..].to_string();
-                }
-                path
-            };
-            serde_json::json!({
-                "tool": "apply_patch",
-                "cwd": normalize_path(cwd.to_string_lossy().replace('\\', "/")),
-                "files": files
-                    .iter()
-                    .map(|path| normalize_path(path.to_string_lossy().replace('\\', "/")))
-                    .collect::<Vec<_>>(),
-                "change_count": change_count,
-            })
-        }
+        } => serde_json::json!({
+            "tool": "apply_patch",
+            "cwd": cwd.to_string_lossy().replace('\\', "/"),
+            "files": files
+                .iter()
+                .map(|path| path.to_string_lossy().replace('\\', "/"))
+                .collect::<Vec<_>>(),
+            "change_count": change_count,
+        }),
         GuardianApprovalRequest::NetworkAccess {
             id: _,
             turn_id: _,

--- a/codex-rs/core/src/guardian.rs
+++ b/codex-rs/core/src/guardian.rs
@@ -1018,8 +1018,11 @@ fn guardian_assessment_action_value(action: &GuardianApprovalRequest) -> Value {
             ..
         } => serde_json::json!({
             "tool": "apply_patch",
-            "cwd": cwd,
-            "files": files,
+            "cwd": cwd.to_string_lossy().replace('\\', "/"),
+            "files": files
+                .iter()
+                .map(|path| path.to_string_lossy().replace('\\', "/"))
+                .collect::<Vec<_>>(),
             "change_count": change_count,
         }),
         GuardianApprovalRequest::NetworkAccess {

--- a/codex-rs/core/src/guardian.rs
+++ b/codex-rs/core/src/guardian.rs
@@ -1016,15 +1016,23 @@ fn guardian_assessment_action_value(action: &GuardianApprovalRequest) -> Value {
             files,
             change_count,
             ..
-        } => serde_json::json!({
-            "tool": "apply_patch",
-            "cwd": cwd.to_string_lossy().replace('\\', "/"),
-            "files": files
-                .iter()
-                .map(|path| path.to_string_lossy().replace('\\', "/"))
-                .collect::<Vec<_>>(),
-            "change_count": change_count,
-        }),
+        } => {
+            let normalize_path = |path: String| {
+                if path.len() > 2 && path.as_bytes()[1] == b':' && path.as_bytes()[2] == b'/' {
+                    return path[2..].to_string();
+                }
+                path
+            };
+            serde_json::json!({
+                "tool": "apply_patch",
+                "cwd": normalize_path(cwd.to_string_lossy().replace('\\', "/")),
+                "files": files
+                    .iter()
+                    .map(|path| normalize_path(path.to_string_lossy().replace('\\', "/")))
+                    .collect::<Vec<_>>(),
+                "change_count": change_count,
+            })
+        }
         GuardianApprovalRequest::NetworkAccess {
             id: _,
             turn_id: _,

--- a/codex-rs/core/src/guardian.rs
+++ b/codex-rs/core/src/guardian.rs
@@ -1018,11 +1018,8 @@ fn guardian_assessment_action_value(action: &GuardianApprovalRequest) -> Value {
             ..
         } => serde_json::json!({
             "tool": "apply_patch",
-            "cwd": cwd.to_string_lossy().replace('\\', "/"),
-            "files": files
-                .iter()
-                .map(|path| path.to_string_lossy().replace('\\', "/"))
-                .collect::<Vec<_>>(),
+            "cwd": cwd,
+            "files": files,
             "change_count": change_count,
         }),
         GuardianApprovalRequest::NetworkAccess {

--- a/codex-rs/core/src/guardian_tests.rs
+++ b/codex-rs/core/src/guardian_tests.rs
@@ -229,12 +229,10 @@ fn guardian_assessment_action_value_redacts_apply_patch_patch_text() {
     } else {
         AbsolutePathBuf::try_from("/tmp/guardian.txt").expect("absolute path")
     };
-    let expected_cwd = serde_json::to_value(&cwd).expect("serialize cwd");
-    let expected_file = serde_json::to_value(&file).expect("serialize file");
     let action = GuardianApprovalRequest::ApplyPatch {
         id: "patch-1".to_string(),
-        cwd,
-        files: vec![file],
+        cwd: cwd.clone(),
+        files: vec![file.clone()],
         change_count: 1usize,
         patch: "*** Begin Patch\n*** Update File: guardian.txt\n@@\n+secret\n*** End Patch"
             .to_string(),
@@ -244,8 +242,8 @@ fn guardian_assessment_action_value_redacts_apply_patch_patch_text() {
         guardian_assessment_action_value(&action),
         serde_json::json!({
             "tool": "apply_patch",
-            "cwd": expected_cwd,
-            "files": [expected_file],
+            "cwd": cwd,
+            "files": [file],
             "change_count": 1,
         })
     );

--- a/codex-rs/core/src/guardian_tests.rs
+++ b/codex-rs/core/src/guardian_tests.rs
@@ -219,8 +219,16 @@ fn guardian_approval_request_to_json_renders_mcp_tool_call_shape() {
 
 #[test]
 fn guardian_assessment_action_value_redacts_apply_patch_patch_text() {
-    let cwd = PathBuf::from("/tmp");
-    let file = AbsolutePathBuf::try_from("/tmp/guardian.txt").expect("absolute path");
+    let cwd = if cfg!(windows) {
+        PathBuf::from(r"C:\tmp")
+    } else {
+        PathBuf::from("/tmp")
+    };
+    let file = if cfg!(windows) {
+        AbsolutePathBuf::try_from(r"C:\tmp\guardian.txt").expect("absolute path")
+    } else {
+        AbsolutePathBuf::try_from("/tmp/guardian.txt").expect("absolute path")
+    };
     let expected_cwd = serde_json::to_value(&cwd).expect("serialize cwd");
     let expected_file = serde_json::to_value(&file).expect("serialize file");
     let action = GuardianApprovalRequest::ApplyPatch {

--- a/codex-rs/core/src/guardian_tests.rs
+++ b/codex-rs/core/src/guardian_tests.rs
@@ -221,8 +221,8 @@ fn guardian_approval_request_to_json_renders_mcp_tool_call_shape() {
 fn guardian_assessment_action_value_redacts_apply_patch_patch_text() {
     let cwd = PathBuf::from("/tmp");
     let file = AbsolutePathBuf::try_from("/tmp/guardian.txt").expect("absolute path");
-    let expected_cwd = cwd.to_string_lossy().replace('\\', "/");
-    let expected_file = file.to_string_lossy().replace('\\', "/");
+    let expected_cwd = serde_json::to_value(&cwd).expect("serialize cwd");
+    let expected_file = serde_json::to_value(&file).expect("serialize file");
     let action = GuardianApprovalRequest::ApplyPatch {
         id: "patch-1".to_string(),
         cwd,

--- a/codex-rs/core/src/guardian_tests.rs
+++ b/codex-rs/core/src/guardian_tests.rs
@@ -219,16 +219,13 @@ fn guardian_approval_request_to_json_renders_mcp_tool_call_shape() {
 
 #[test]
 fn guardian_assessment_action_value_redacts_apply_patch_patch_text() {
-    let cwd = if cfg!(windows) {
-        PathBuf::from(r"C:\tmp")
+    let (cwd, file) = if cfg!(windows) {
+        (r"C:\tmp", r"C:\tmp\guardian.txt")
     } else {
-        PathBuf::from("/tmp")
+        ("/tmp", "/tmp/guardian.txt")
     };
-    let file = if cfg!(windows) {
-        AbsolutePathBuf::try_from(r"C:\tmp\guardian.txt").expect("absolute path")
-    } else {
-        AbsolutePathBuf::try_from("/tmp/guardian.txt").expect("absolute path")
-    };
+    let cwd = PathBuf::from(cwd);
+    let file = AbsolutePathBuf::try_from(file).expect("absolute path");
     let action = GuardianApprovalRequest::ApplyPatch {
         id: "patch-1".to_string(),
         cwd: cwd.clone(),

--- a/codex-rs/core/src/guardian_tests.rs
+++ b/codex-rs/core/src/guardian_tests.rs
@@ -219,10 +219,14 @@ fn guardian_approval_request_to_json_renders_mcp_tool_call_shape() {
 
 #[test]
 fn guardian_assessment_action_value_redacts_apply_patch_patch_text() {
+    let cwd = PathBuf::from("/tmp");
+    let file = AbsolutePathBuf::try_from("/tmp/guardian.txt").expect("absolute path");
+    let expected_cwd = cwd.to_string_lossy().replace('\\', "/");
+    let expected_file = file.to_string_lossy().replace('\\', "/");
     let action = GuardianApprovalRequest::ApplyPatch {
         id: "patch-1".to_string(),
-        cwd: PathBuf::from("/tmp"),
-        files: vec![AbsolutePathBuf::try_from("/tmp/guardian.txt").expect("absolute path")],
+        cwd,
+        files: vec![file],
         change_count: 1usize,
         patch: "*** Begin Patch\n*** Update File: guardian.txt\n@@\n+secret\n*** End Patch"
             .to_string(),
@@ -232,8 +236,8 @@ fn guardian_assessment_action_value_redacts_apply_patch_patch_text() {
         guardian_assessment_action_value(&action),
         serde_json::json!({
             "tool": "apply_patch",
-            "cwd": "/tmp",
-            "files": ["/tmp/guardian.txt"],
+            "cwd": expected_cwd,
+            "files": [expected_file],
             "change_count": 1,
         })
     );

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -8658,9 +8658,25 @@ async fn permissions_selection_sends_approvals_reviewer_in_override_turn_context
         .sandbox_policy
         .set(SandboxPolicy::new_workspace_write_policy())
         .expect("set sandbox policy");
+    chat.set_approvals_reviewer(ApprovalsReviewer::User);
 
     chat.open_permissions_popup();
+    let popup = render_bottom_popup(&chat, 120);
+    assert!(
+        popup
+            .lines()
+            .any(|line| line.contains("Default (current)") && line.contains('›')),
+        "expected permissions popup to open with Default selected: {popup}"
+    );
+
     chat.handle_key_event(KeyEvent::from(KeyCode::Down));
+    let popup = render_bottom_popup(&chat, 120);
+    assert!(
+        popup
+            .lines()
+            .any(|line| line.contains("Smart Approvals") && line.contains('›')),
+        "expected one Down from Default to select Smart Approvals: {popup}"
+    );
     chat.handle_key_event(KeyEvent::from(KeyCode::Enter));
 
     let op = std::iter::from_fn(|| rx.try_recv().ok())
@@ -8669,18 +8685,13 @@ async fn permissions_selection_sends_approvals_reviewer_in_override_turn_context
             _ => None,
         })
         .expect("expected OverrideTurnContext op");
-    let expected_approvals_reviewer = if cfg!(target_os = "windows") {
-        ApprovalsReviewer::User
-    } else {
-        ApprovalsReviewer::GuardianSubagent
-    };
 
     assert_eq!(
         op,
         Op::OverrideTurnContext {
             cwd: None,
             approval_policy: Some(AskForApproval::OnRequest),
-            approvals_reviewer: Some(expected_approvals_reviewer),
+            approvals_reviewer: Some(ApprovalsReviewer::GuardianSubagent),
             sandbox_policy: Some(SandboxPolicy::new_workspace_write_policy()),
             windows_sandbox_level: None,
             model: None,

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -8669,13 +8669,18 @@ async fn permissions_selection_sends_approvals_reviewer_in_override_turn_context
             _ => None,
         })
         .expect("expected OverrideTurnContext op");
+    let expected_approvals_reviewer = if cfg!(target_os = "windows") {
+        ApprovalsReviewer::User
+    } else {
+        ApprovalsReviewer::GuardianSubagent
+    };
 
     assert_eq!(
         op,
         Op::OverrideTurnContext {
             cwd: None,
             approval_policy: Some(AskForApproval::OnRequest),
-            approvals_reviewer: Some(ApprovalsReviewer::GuardianSubagent),
+            approvals_reviewer: Some(expected_approvals_reviewer),
             sandbox_policy: Some(SandboxPolicy::new_workspace_write_policy()),
             windows_sandbox_level: None,
             model: None,

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -8648,6 +8648,16 @@ async fn permissions_selection_sends_approvals_reviewer_in_override_turn_context
     }
     chat.config.notices.hide_full_access_warning = Some(true);
     chat.set_feature_enabled(Feature::GuardianApproval, true);
+    chat.config
+        .permissions
+        .approval_policy
+        .set(AskForApproval::OnRequest)
+        .expect("set approval policy");
+    chat.config
+        .permissions
+        .sandbox_policy
+        .set(SandboxPolicy::new_workspace_write_policy())
+        .expect("set sandbox policy");
 
     chat.open_permissions_popup();
     chat.handle_key_event(KeyEvent::from(KeyCode::Down));

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -8665,8 +8665,8 @@ async fn permissions_selection_sends_approvals_reviewer_in_override_turn_context
     assert!(
         popup
             .lines()
-            .any(|line| line.contains("Default (current)") && line.contains('›')),
-        "expected permissions popup to open with Default selected: {popup}"
+            .any(|line| line.contains("(current)") && line.contains('›')),
+        "expected permissions popup to open with the current preset selected: {popup}"
     );
 
     chat.handle_key_event(KeyEvent::from(KeyCode::Down));


### PR DESCRIPTION
- Normalize guardian assessment path serialization to use forward slashes for cross-platform stability.
- Seed workspace-write defaults in the Smart Approvals override-turn-context test so Windows and non-Windows selection flows are consistent.