### PR TITLE
Apply argument comment lint across codex-rs

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -14,6 +14,8 @@ jobs:
     name: Detect changed areas
     runs-on: ubuntu-24.04
     outputs:
+      argument_comment_lint: ${{ steps.detect.outputs.argument_comment_lint }}
+      argument_comment_lint_package: ${{ steps.detect.outputs.argument_comment_lint_package }}
       codex: ${{ steps.detect.outputs.codex }}
       workflows: ${{ steps.detect.outputs.workflows }}
     steps:
@@ -39,12 +41,18 @@ jobs:
           fi
 
           codex=false
+          argument_comment_lint=false
+          argument_comment_lint_package=false
           workflows=false
           for f in "${files[@]}"; do
             [[ $f == codex-rs/* ]] && codex=true
+            [[ $f == codex-rs/* || $f == tools/argument-comment-lint/* || $f == justfile ]] && argument_comment_lint=true
+            [[ $f == tools/argument-comment-lint/* || $f == .github/workflows/rust-ci.yml ]] && argument_comment_lint_package=true
             [[ $f == .github/* ]] && workflows=true
           done
 
+          echo "argument_comment_lint=$argument_comment_lint" >> "$GITHUB_OUTPUT"
+          echo "argument_comment_lint_package=$argument_comment_lint_package" >> "$GITHUB_OUTPUT"
           echo "codex=$codex" >> "$GITHUB_OUTPUT"
           echo "workflows=$workflows" >> "$GITHUB_OUTPUT"
 
@@ -82,6 +90,44 @@ jobs:
           version: 1.5.1
       - name: cargo shear
         run: cargo shear
+
+  argument_comment_lint:
+    name: Argument comment lint
+    runs-on: ubuntu-24.04
+    needs: changed
+    if: ${{ needs.changed.outputs.argument_comment_lint == 'true' || needs.changed.outputs.workflows == 'true' || github.event_name == 'push' }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Linux sandbox build dependencies
+        run: |
+          sudo DEBIAN_FRONTEND=noninteractive apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends pkg-config libcap-dev
+      - uses: dtolnay/rust-toolchain@1.93.0
+        with:
+          toolchain: nightly-2025-09-18
+          components: llvm-tools-preview, rustc-dev, rust-src
+      - name: Cache cargo-dylint tooling
+        id: cargo_dylint_cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/bin/cargo-dylint
+            ~/.cargo/bin/dylint-link
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: argument-comment-lint-${{ runner.os }}-${{ hashFiles('tools/argument-comment-lint/Cargo.lock', 'tools/argument-comment-lint/rust-toolchain', '.github/workflows/rust-ci.yml') }}
+      - name: Install cargo-dylint tooling
+        if: ${{ steps.cargo_dylint_cache.outputs.cache-hit != 'true' }}
+        run: cargo install --locked cargo-dylint dylint-link
+      - name: Test argument comment lint package
+        if: ${{ needs.changed.outputs.argument_comment_lint_package == 'true' || github.event_name == 'push' }}
+        working-directory: tools/argument-comment-lint
+        run: cargo test
+      - name: Run argument comment lint on codex-rs
+        run: |
+          bash -n tools/argument-comment-lint/run.sh
+          ./tools/argument-comment-lint/run.sh
 
   # --- CI to validate on different os/targets --------------------------------
   lint_build:
@@ -657,13 +703,15 @@ jobs:
   # --- Gatherer job that you mark as the ONLY required status -----------------
   results:
     name: CI results (required)
-    needs: [changed, general, cargo_shear, lint_build, tests]
+    needs:
+      [changed, general, cargo_shear, argument_comment_lint, lint_build, tests]
     if: always()
     runs-on: ubuntu-24.04
     steps:
       - name: Summarize
         shell: bash
         run: |
+          echo "arglint: ${{ needs.argument_comment_lint.result }}"
           echo "general: ${{ needs.general.result }}"
           echo "shear  : ${{ needs.cargo_shear.result }}"
           echo "lint   : ${{ needs.lint_build.result }}"
@@ -671,16 +719,21 @@ jobs:
 
           # If nothing relevant changed (PR touching only root README, etc.),
           # declare success regardless of other jobs.
-          if [[ '${{ needs.changed.outputs.codex }}' != 'true' && '${{ needs.changed.outputs.workflows }}' != 'true' && '${{ github.event_name }}' != 'push' ]]; then
+          if [[ '${{ needs.changed.outputs.argument_comment_lint }}' != 'true' && '${{ needs.changed.outputs.codex }}' != 'true' && '${{ needs.changed.outputs.workflows }}' != 'true' && '${{ github.event_name }}' != 'push' ]]; then
             echo 'No relevant changes -> CI not required.'
             exit 0
           fi
 
-          # Otherwise require the jobs to have succeeded
-          [[ '${{ needs.general.result }}' == 'success' ]] || { echo 'general failed'; exit 1; }
-          [[ '${{ needs.cargo_shear.result }}' == 'success' ]] || { echo 'cargo_shear failed'; exit 1; }
-          [[ '${{ needs.lint_build.result }}' == 'success' ]] || { echo 'lint_build failed'; exit 1; }
-          [[ '${{ needs.tests.result }}' == 'success' ]] || { echo 'tests failed'; exit 1; }
+          if [[ '${{ needs.changed.outputs.argument_comment_lint }}' == 'true' || '${{ needs.changed.outputs.workflows }}' == 'true' || '${{ github.event_name }}' == 'push' ]]; then
+            [[ '${{ needs.argument_comment_lint.result }}' == 'success' ]] || { echo 'argument_comment_lint failed'; exit 1; }
+          fi
+
+          if [[ '${{ needs.changed.outputs.codex }}' == 'true' || '${{ needs.changed.outputs.workflows }}' == 'true' || '${{ github.event_name }}' == 'push' ]]; then
+            [[ '${{ needs.general.result }}' == 'success' ]] || { echo 'general failed'; exit 1; }
+            [[ '${{ needs.cargo_shear.result }}' == 'success' ]] || { echo 'cargo_shear failed'; exit 1; }
+            [[ '${{ needs.lint_build.result }}' == 'success' ]] || { echo 'lint_build failed'; exit 1; }
+            [[ '${{ needs.tests.result }}' == 'success' ]] || { echo 'tests failed'; exit 1; }
+          fi
 
       - name: sccache summary note
         if: always()

--- a/codex-rs/app-server-protocol/src/export.rs
+++ b/codex-rs/app-server-protocol/src/export.rs
@@ -182,7 +182,7 @@ pub fn generate_ts_with_options(
 }
 
 pub fn generate_json(out_dir: &Path) -> Result<()> {
-    generate_json_with_experimental(out_dir, false)
+    generate_json_with_experimental(out_dir, /*experimental_api*/ false)
 }
 
 pub fn generate_json_with_experimental(out_dir: &Path, experimental_api: bool) -> Result<()> {
@@ -1984,7 +1984,7 @@ pub(crate) fn generate_index_ts_tree(tree: &mut BTreeMap<PathBuf, String>) {
     if !v2_entries.is_empty() {
         tree.insert(
             PathBuf::from("v2").join("index.ts"),
-            index_ts_entries(&v2_entries, false),
+            index_ts_entries(&v2_entries, /*has_v2_ts*/ false),
         );
     }
 }

--- a/codex-rs/app-server-protocol/src/protocol/thread_history.rs
+++ b/codex-rs/app-server-protocol/src/protocol/thread_history.rs
@@ -201,7 +201,7 @@ impl ThreadHistoryBuilder {
         let mut turn = self
             .current_turn
             .take()
-            .unwrap_or_else(|| self.new_turn(None));
+            .unwrap_or_else(|| self.new_turn(/*id*/ None));
         let id = self.next_item_id();
         let content = self.build_user_inputs(payload);
         turn.items.push(ThreadItem::UserMessage { id, content });
@@ -937,7 +937,7 @@ impl ThreadHistoryBuilder {
 
     fn ensure_turn(&mut self) -> &mut PendingTurn {
         if self.current_turn.is_none() {
-            let turn = self.new_turn(None);
+            let turn = self.new_turn(/*id*/ None);
             return self.current_turn.insert(turn);
         }
 

--- a/codex-rs/app-server-test-client/src/lib.rs
+++ b/codex-rs/app-server-test-client/src/lib.rs
@@ -657,7 +657,7 @@ pub async fn send_message_v2(
         &endpoint,
         config_overrides,
         user_message,
-        true,
+        /*experimental_api*/ true,
         dynamic_tools,
     )
     .await
@@ -1510,7 +1510,7 @@ impl CodexClient {
     }
 
     fn initialize(&mut self) -> Result<InitializeResponse> {
-        self.initialize_with_experimental_api(true)
+        self.initialize_with_experimental_api(/*experimental_api*/ true)
     }
 
     fn initialize_with_experimental_api(

--- a/codex-rs/app-server/src/app_server_tracing.rs
+++ b/codex-rs/app-server/src/app_server_tracing.rs
@@ -78,7 +78,7 @@ pub(crate) fn typed_request_span(
             .or(session.client_version.as_deref()),
     );
 
-    attach_parent_context(&span, &method, request.id(), None);
+    attach_parent_context(&span, &method, request.id(), /*parent_trace*/ None);
     span
 }
 

--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -1988,7 +1988,7 @@ async fn handle_turn_interrupted(
         conversation_id,
         event_turn_id,
         TurnStatus::Interrupted,
-        None,
+        /*error*/ None,
         outgoing,
     )
     .await;
@@ -2379,7 +2379,7 @@ fn render_review_output_text(output: &ReviewOutputEvent) -> String {
         sections.push(explanation.to_string());
     }
     if !output.findings.is_empty() {
-        let findings = format_review_findings_block(&output.findings, None);
+        let findings = format_review_findings_block(&output.findings, /*selection*/ None);
         let trimmed = findings.trim();
         if !trimmed.is_empty() {
             sections.push(trimmed.to_string());
@@ -2577,7 +2577,7 @@ async fn on_command_execution_request_approval_response(
             item_id.clone(),
             completion_item.command,
             completion_item.cwd,
-            None,
+            /*process_id*/ None,
             completion_item.command_actions,
             status,
             &outgoing,

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -446,7 +446,7 @@ impl CodexMessageProcessor {
     }
 
     pub(crate) async fn maybe_start_curated_repo_sync_for_latest_config(&self) {
-        match self.load_latest_config(None).await {
+        match self.load_latest_config(/*fallback_cwd*/ None).await {
             Ok(config) => self
                 .thread_manager
                 .plugins_manager()
@@ -1623,7 +1623,10 @@ impl CodexMessageProcessor {
         }
 
         let cwd = cwd.unwrap_or_else(|| self.config.cwd.clone());
-        let mut env = create_env(&self.config.permissions.shell_environment_policy, None);
+        let mut env = create_env(
+            &self.config.permissions.shell_environment_policy,
+            /*thread_id*/ None,
+        );
         if let Some(env_overrides) = env_overrides {
             for (key, value) in env_overrides {
                 match value {
@@ -1659,8 +1662,8 @@ impl CodexMessageProcessor {
             Some(spec) => match spec
                 .start_proxy(
                     self.config.permissions.sandbox_policy.get(),
-                    None,
-                    None,
+                    /*policy_decider*/ None,
+                    /*blocked_request_observer*/ None,
                     managed_network_requirements_enabled,
                     NetworkProxyAuditMetadata::default(),
                 )
@@ -2092,7 +2095,7 @@ impl CodexMessageProcessor {
                             otel.name = "app_server.thread_start.resolve_status",
                         ))
                         .await,
-                    false,
+                    /*has_in_progress_turn*/ false,
                 );
 
                 let response = ThreadStartResponse {
@@ -2541,7 +2544,7 @@ impl CodexMessageProcessor {
             self.thread_watch_manager
                 .loaded_status_for_thread(&thread.id)
                 .await,
-            false,
+            /*has_in_progress_turn*/ false,
         );
 
         self.outgoing
@@ -2592,10 +2595,10 @@ impl CodexMessageProcessor {
                 Some(state_db_ctx),
                 rollout_path.as_path(),
                 self.config.model_provider_id.as_str(),
-                None,
+                /*builder*/ None,
                 &[],
-                None,
-                None,
+                /*archived_only*/ None,
+                /*new_thread_memory_mode*/ None,
             )
             .await;
 
@@ -2663,10 +2666,10 @@ impl CodexMessageProcessor {
             Some(state_db_ctx),
             rollout_path.as_path(),
             self.config.model_provider_id.as_str(),
-            None,
+            /*builder*/ None,
             &[],
-            None,
-            None,
+            /*archived_only*/ None,
+            /*new_thread_memory_mode*/ None,
         )
         .await;
 
@@ -2853,7 +2856,7 @@ impl CodexMessageProcessor {
                     self.thread_watch_manager
                         .loaded_status_for_thread(&thread.id)
                         .await,
-                    false,
+                    /*has_in_progress_turn*/ false,
                 );
                 self.attach_thread_name(thread_id, &mut thread).await;
                 let thread_id = thread.id.clone();
@@ -3327,8 +3330,13 @@ impl CodexMessageProcessor {
 
         for connection_id in connection_ids {
             Self::log_listener_attach_result(
-                self.ensure_conversation_listener(thread_id, connection_id, false, ApiVersion::V2)
-                    .await,
+                self.ensure_conversation_listener(
+                    thread_id,
+                    connection_id,
+                    /*raw_events_enabled*/ false,
+                    ApiVersion::V2,
+                )
+                .await,
                 thread_id,
                 connection_id,
                 "thread",
@@ -3463,7 +3471,7 @@ impl CodexMessageProcessor {
                     self.ensure_conversation_listener(
                         thread_id,
                         request_id.connection_id,
-                        false,
+                        /*raw_events_enabled*/ false,
                         ApiVersion::V2,
                     )
                     .await,
@@ -3495,7 +3503,11 @@ impl CodexMessageProcessor {
                     .loaded_status_for_thread(&thread.id)
                     .await;
 
-                set_thread_status_and_interrupt_stale_turns(&mut thread, thread_status, false);
+                set_thread_status_and_interrupt_stale_turns(
+                    &mut thread,
+                    thread_status,
+                    /*has_live_in_progress_turn*/ false,
+                );
 
                 let response = ThreadResumeResponse {
                     thread,
@@ -3813,7 +3825,7 @@ impl CodexMessageProcessor {
         if let Err(message) = populate_thread_turns(
             &mut thread,
             ThreadTurnSource::HistoryItems(&history_items),
-            None,
+            /*active_turn*/ None,
         )
         .await
         {
@@ -3930,7 +3942,7 @@ impl CodexMessageProcessor {
             sandbox,
             base_instructions,
             developer_instructions,
-            None,
+            /*personality*/ None,
         );
         typesafe_overrides.ephemeral = ephemeral.then_some(true);
         // Derive a Config using the same logic as new conversation, honoring overrides if provided.
@@ -4001,7 +4013,7 @@ impl CodexMessageProcessor {
             self.ensure_conversation_listener(
                 thread_id,
                 request_id.connection_id,
-                false,
+                /*raw_events_enabled*/ false,
                 ApiVersion::V2,
             )
             .await,
@@ -4035,7 +4047,8 @@ impl CodexMessageProcessor {
         } else {
             let config_snapshot = forked_thread.config_snapshot().await;
             // forked thread names do not inherit the source thread name
-            let mut thread = build_thread_from_snapshot(thread_id, &config_snapshot, None);
+            let mut thread =
+                build_thread_from_snapshot(thread_id, &config_snapshot, /*path*/ None);
             let history_items = match read_rollout_items_from_rollout(rollout_path.as_path()).await
             {
                 Ok(items) => items,
@@ -4055,7 +4068,7 @@ impl CodexMessageProcessor {
             if let Err(message) = populate_thread_turns(
                 &mut thread,
                 ThreadTurnSource::HistoryItems(&history_items),
-                None,
+                /*active_turn*/ None,
             )
             .await
             {
@@ -4069,7 +4082,7 @@ impl CodexMessageProcessor {
             && let Err(message) = populate_thread_turns(
                 &mut thread,
                 ThreadTurnSource::RolloutPath(fork_rollout_path.as_path()),
-                None,
+                /*active_turn*/ None,
             )
             .await
         {
@@ -4085,7 +4098,7 @@ impl CodexMessageProcessor {
             self.thread_watch_manager
                 .loaded_status_for_thread(&thread.id)
                 .await,
-            false,
+            /*has_in_progress_turn*/ false,
         );
 
         let response = ThreadForkResponse {
@@ -4398,7 +4411,7 @@ impl CodexMessageProcessor {
         params: ExperimentalFeatureListParams,
     ) {
         let ExperimentalFeatureListParams { cursor, limit } = params;
-        let config = match self.load_latest_config(None).await {
+        let config = match self.load_latest_config(/*fallback_cwd*/ None).await {
             Ok(config) => config,
             Err(error) => {
                 self.outgoing.send_error(request_id, error).await;
@@ -4513,7 +4526,7 @@ impl CodexMessageProcessor {
     }
 
     async fn mcp_server_refresh(&self, request_id: ConnectionRequestId, _params: Option<()>) {
-        let config = match self.load_latest_config(None).await {
+        let config = match self.load_latest_config(/*fallback_cwd*/ None).await {
             Ok(config) => config,
             Err(error) => {
                 self.outgoing.send_error(request_id, error).await;
@@ -4572,7 +4585,7 @@ impl CodexMessageProcessor {
         request_id: ConnectionRequestId,
         params: McpServerOauthLoginParams,
     ) {
-        let config = match self.load_latest_config(None).await {
+        let config = match self.load_latest_config(/*fallback_cwd*/ None).await {
             Ok(config) => config,
             Err(error) => {
                 self.outgoing.send_error(request_id, error).await;
@@ -4684,7 +4697,7 @@ impl CodexMessageProcessor {
         let request = request_id.clone();
 
         let outgoing = Arc::clone(&self.outgoing);
-        let config = match self.load_latest_config(None).await {
+        let config = match self.load_latest_config(/*fallback_cwd*/ None).await {
             Ok(config) => config,
             Err(error) => {
                 self.outgoing.send_error(request, error).await;
@@ -4856,7 +4869,7 @@ impl CodexMessageProcessor {
     async fn finalize_thread_teardown(&mut self, thread_id: ThreadId) {
         self.pending_thread_unloads.lock().await.remove(&thread_id);
         self.outgoing
-            .cancel_requests_for_thread(thread_id, None)
+            .cancel_requests_for_thread(thread_id, /*error*/ None)
             .await;
         self.thread_state_manager
             .remove_thread_state(thread_id)
@@ -4919,7 +4932,7 @@ impl CodexMessageProcessor {
             // Any pending app-server -> client requests for this thread can no longer be
             // answered; cancel their callbacks before shutdown/unload.
             self.outgoing
-                .cancel_requests_for_thread(thread_id, None)
+                .cancel_requests_for_thread(thread_id, /*error*/ None)
                 .await;
             self.thread_state_manager
                 .remove_thread_state(thread_id)
@@ -5092,7 +5105,7 @@ impl CodexMessageProcessor {
     }
 
     async fn apps_list(&self, request_id: ConnectionRequestId, params: AppsListParams) {
-        let mut config = match self.load_latest_config(None).await {
+        let mut config = match self.load_latest_config(/*fallback_cwd*/ None).await {
             Ok(config) => config,
             Err(error) => {
                 self.outgoing.send_error(request_id, error).await;
@@ -5389,7 +5402,7 @@ impl CodexMessageProcessor {
         } = params;
         let roots = cwds.unwrap_or_default();
 
-        let mut config = match self.load_latest_config(None).await {
+        let mut config = match self.load_latest_config(/*fallback_cwd*/ None).await {
             Ok(config) => config,
             Err(err) => {
                 self.outgoing.send_error(request_id, err).await;
@@ -5422,7 +5435,7 @@ impl CodexMessageProcessor {
                 }
             }
 
-            config = match self.load_latest_config(None).await {
+            config = match self.load_latest_config(/*fallback_cwd*/ None).await {
                 Ok(config) => config,
                 Err(err) => {
                     self.outgoing.send_error(request_id, err).await;
@@ -5692,9 +5705,9 @@ impl CodexMessageProcessor {
                     Vec::new()
                 } else {
                     let (all_connectors_result, accessible_connectors_result) = tokio::join!(
-                        connectors::list_all_connectors_with_options(&config, true),
+                        connectors::list_all_connectors_with_options(&config, /*force_refetch*/ true),
                         connectors::list_accessible_connectors_from_mcp_tools_with_options_and_status(
-                            &config, true
+                            &config, /*force_refetch*/ true
                         ),
                     );
 
@@ -6046,7 +6059,7 @@ impl CodexMessageProcessor {
             .ensure_conversation_listener(
                 thread_id,
                 request_id.connection_id,
-                false,
+                /*raw_events_enabled*/ false,
                 ApiVersion::V2,
             )
             .await
@@ -6327,7 +6340,7 @@ impl CodexMessageProcessor {
                 usize::MAX,
                 config,
                 rollout_path,
-                false,
+                /*persist_extended_history*/ false,
                 self.request_trace_context(request_id).await,
             )
             .await
@@ -6341,7 +6354,7 @@ impl CodexMessageProcessor {
             self.ensure_conversation_listener(
                 thread_id,
                 request_id.connection_id,
-                false,
+                /*raw_events_enabled*/ false,
                 ApiVersion::V2,
             )
             .await,
@@ -6362,7 +6375,7 @@ impl CodexMessageProcessor {
                         self.thread_watch_manager
                             .loaded_status_for_thread(&thread.id)
                             .await,
-                        false,
+                        /*has_in_progress_turn*/ false,
                     );
                     let notif = ThreadStartedNotification { thread };
                     self.outgoing
@@ -7050,7 +7063,7 @@ impl CodexMessageProcessor {
         tokio::spawn(async move {
             let derived_config = derive_config_for_cwd(
                 &cli_overrides,
-                None,
+                /*request_overrides*/ None,
                 ConfigOverrides {
                     cwd: Some(command_cwd.clone()),
                     ..Default::default()

--- a/codex-rs/app-server/src/codex_message_processor/plugin_app_helpers.rs
+++ b/codex-rs/app-server/src/codex_message_processor/plugin_app_helpers.rs
@@ -15,15 +15,16 @@ pub(super) async fn load_plugin_app_summaries(
         return Vec::new();
     }
 
-    let connectors = match connectors::list_all_connectors_with_options(config, false).await {
-        Ok(connectors) => connectors,
-        Err(err) => {
-            warn!("failed to load app metadata for plugin/read: {err:#}");
-            connectors::list_cached_all_connectors(config)
-                .await
-                .unwrap_or_default()
-        }
-    };
+    let connectors =
+        match connectors::list_all_connectors_with_options(config, /*force_refetch*/ false).await {
+            Ok(connectors) => connectors,
+            Err(err) => {
+                warn!("failed to load app metadata for plugin/read: {err:#}");
+                connectors::list_cached_all_connectors(config)
+                    .await
+                    .unwrap_or_default()
+            }
+        };
 
     connectors::connectors_for_plugin_apps(connectors, plugin_apps)
         .into_iter()

--- a/codex-rs/app-server/src/command_exec.rs
+++ b/codex-rs/app-server/src/command_exec.rs
@@ -201,7 +201,9 @@ impl CommandExecManager {
             let sessions = Arc::clone(&self.sessions);
             tokio::spawn(async move {
                 let _started_network_proxy = started_network_proxy;
-                match codex_core::sandboxing::execute_env(exec_request, None).await {
+                match codex_core::sandboxing::execute_env(exec_request, /*stdout_stream*/ None)
+                    .await
+                {
                     Ok(output) => {
                         outgoing
                             .send_response(

--- a/codex-rs/app-server/src/in_process.rs
+++ b/codex-rs/app-server/src/in_process.rs
@@ -390,8 +390,8 @@ fn start_uninitialized(args: InProcessStartArgs) -> InProcessClientHandle {
                 Arc::clone(&outbound_initialized),
                 Arc::clone(&outbound_experimental_api_enabled),
                 Arc::clone(&outbound_opted_out_notification_methods),
-                true,
-                None,
+                /*allow_legacy_notifications*/ true,
+                /*disconnect_sender*/ None,
             ),
         );
         let mut outbound_handle = tokio::spawn(async move {

--- a/codex-rs/app-server/src/lib.rs
+++ b/codex-rs/app-server/src/lib.rs
@@ -266,10 +266,10 @@ fn app_text_range(range: &CoreTextRange) -> AppTextRange {
 fn project_config_warning(config: &Config) -> Option<ConfigWarningNotification> {
     let mut disabled_folders = Vec::new();
 
-    for layer in config
-        .config_layer_stack
-        .get_layers(ConfigLayerStackOrdering::LowestPrecedenceFirst, true)
-    {
+    for layer in config.config_layer_stack.get_layers(
+        ConfigLayerStackOrdering::LowestPrecedenceFirst,
+        /*include_disabled*/ true,
+    ) {
         if !matches!(layer.name, ConfigLayerSource::Project { .. })
             || layer.disabled_reason.is_none()
         {
@@ -418,7 +418,7 @@ pub async fn run_main_with_transport(
 
             let auth_manager = AuthManager::shared(
                 config.codex_home.clone(),
-                false,
+                /*enable_codex_api_key_env*/ false,
                 config.cli_auth_credentials_store_mode,
             );
             cloud_requirements_loader(

--- a/codex-rs/app-server/src/main.rs
+++ b/codex-rs/app-server/src/main.rs
@@ -37,7 +37,7 @@ fn main() -> anyhow::Result<()> {
             arg0_paths,
             CliConfigOverrides::default(),
             loader_overrides,
-            false,
+            /*default_analytics_enabled*/ false,
             transport,
         )
         .await?;

--- a/codex-rs/app-server/src/message_processor.rs
+++ b/codex-rs/app-server/src/message_processor.rs
@@ -332,7 +332,7 @@ impl MessageProcessor {
                     request_id.clone(),
                     codex_request,
                     session,
-                    None,
+                    /*outbound_initialized*/ None,
                     request_context.clone(),
                 )
                 .await;
@@ -358,7 +358,8 @@ impl MessageProcessor {
         };
         let request_span =
             crate::app_server_tracing::typed_request_span(&request, connection_id, session);
-        let request_context = RequestContext::new(request_id.clone(), request_span, None);
+        let request_context =
+            RequestContext::new(request_id.clone(), request_span, /*parent_trace*/ None);
         tracing::trace!(
             ?connection_id,
             request_id = ?request_id.request_id,

--- a/codex-rs/app-server/src/outgoing_message.rs
+++ b/codex-rs/app-server/src/outgoing_message.rs
@@ -234,7 +234,10 @@ impl OutgoingMessageSender {
         &self,
         request: ServerRequestPayload,
     ) -> (RequestId, oneshot::Receiver<ClientRequestResult>) {
-        self.send_request_to_connections(None, request, None).await
+        self.send_request_to_connections(
+            /*connection_ids*/ None, request, /*thread_id*/ None,
+        )
+        .await
     }
 
     fn next_request_id(&self) -> RequestId {

--- a/codex-rs/app-server/src/thread_state.rs
+++ b/codex-rs/app-server/src/thread_state.rs
@@ -284,7 +284,7 @@ impl ThreadStateManager {
         {
             let mut thread_state_guard = thread_state.lock().await;
             if experimental_raw_events {
-                thread_state_guard.set_experimental_raw_events(true);
+                thread_state_guard.set_experimental_raw_events(/*enabled*/ true);
             }
         }
         Some(thread_state)

--- a/codex-rs/app-server/src/thread_status.rs
+++ b/codex-rs/app-server/src/thread_status.rs
@@ -91,13 +91,17 @@ impl ThreadWatchManager {
     }
 
     pub(crate) async fn upsert_thread(&self, thread: Thread) {
-        self.mutate_and_publish(move |state| state.upsert_thread(thread.id, true))
-            .await;
+        self.mutate_and_publish(move |state| {
+            state.upsert_thread(thread.id, /*emit_notification*/ true)
+        })
+        .await;
     }
 
     pub(crate) async fn upsert_thread_silently(&self, thread: Thread) {
-        self.mutate_and_publish(move |state| state.upsert_thread(thread.id, false))
-            .await;
+        self.mutate_and_publish(move |state| {
+            state.upsert_thread(thread.id, /*emit_notification*/ false)
+        })
+        .await;
     }
 
     pub(crate) async fn remove_thread(&self, thread_id: &str) {

--- a/codex-rs/app-server/tests/common/mcp_process.rs
+++ b/codex-rs/app-server/tests/common/mcp_process.rs
@@ -267,7 +267,8 @@ impl McpProcess {
 
     /// Send an `account/rateLimits/read` JSON-RPC request.
     pub async fn send_get_account_rate_limits_request(&mut self) -> anyhow::Result<i64> {
-        self.send_request("account/rateLimits/read", None).await
+        self.send_request("account/rateLimits/read", /*params*/ None)
+            .await
     }
 
     /// Send an `account/read` JSON-RPC request.
@@ -768,7 +769,7 @@ impl McpProcess {
 
     /// Send an `account/logout` JSON-RPC request.
     pub async fn send_logout_account_request(&mut self) -> anyhow::Result<i64> {
-        self.send_request("account/logout", None).await
+        self.send_request("account/logout", /*params*/ None).await
     }
 
     /// Send an `account/login/start` JSON-RPC request for API key login.

--- a/codex-rs/app-server/tests/common/models_cache.rs
+++ b/codex-rs/app-server/tests/common/models_cache.rs
@@ -37,7 +37,7 @@ fn preset_to_info(preset: &ModelPreset, priority: i32) -> ModelInfo {
         availability_nux: None,
         apply_patch_tool_type: None,
         web_search_tool_type: Default::default(),
-        truncation_policy: TruncationPolicyConfig::bytes(10_000),
+        truncation_policy: TruncationPolicyConfig::bytes(/*limit*/ 10_000),
         supports_parallel_tool_calls: false,
         supports_image_detail_original: false,
         context_window: Some(272_000),

--- a/codex-rs/apply-patch/src/lib.rs
+++ b/codex-rs/apply-patch/src/lib.rs
@@ -399,7 +399,7 @@ fn compute_replacements(
                 original_lines,
                 std::slice::from_ref(ctx_line),
                 line_index,
-                false,
+                /*eof*/ false,
             ) {
                 line_index = idx + 1;
             } else {
@@ -512,7 +512,7 @@ pub fn unified_diff_from_chunks(
     path: &Path,
     chunks: &[UpdateFileChunk],
 ) -> std::result::Result<ApplyPatchFileUpdate, ApplyPatchError> {
-    unified_diff_from_chunks_with_context(path, chunks, 1)
+    unified_diff_from_chunks_with_context(path, chunks, /*context*/ 1)
 }
 
 pub fn unified_diff_from_chunks_with_context(

--- a/codex-rs/artifacts/src/runtime/js_runtime.rs
+++ b/codex-rs/artifacts/src/runtime/js_runtime.rs
@@ -74,7 +74,7 @@ pub fn can_manage_artifact_runtime() -> bool {
 
 pub(crate) fn resolve_machine_js_runtime() -> Option<JsRuntime> {
     resolve_js_runtime_from_candidates(
-        None,
+        /*preferred_node_path*/ None,
         system_node_runtime(),
         system_electron_runtime(),
         codex_app_runtime_candidates(),

--- a/codex-rs/backend-client/src/client.rs
+++ b/codex-rs/backend-client/src/client.rs
@@ -399,7 +399,7 @@ impl Client {
         let plan_type = Some(Self::map_plan_type(payload.plan_type));
         let mut snapshots = vec![Self::make_rate_limit_snapshot(
             Some("codex".to_string()),
-            None,
+            /*limit_name*/ None,
             payload.rate_limit.flatten().map(|details| *details),
             payload.credits.flatten().map(|details| *details),
             plan_type,
@@ -410,7 +410,7 @@ impl Client {
                     Some(details.metered_feature),
                     Some(details.limit_name),
                     details.rate_limit.flatten().map(|rate_limit| *rate_limit),
-                    None,
+                    /*credits*/ None,
                     plan_type,
                 )
             }));

--- a/codex-rs/chatgpt/src/chatgpt_client.rs
+++ b/codex-rs/chatgpt/src/chatgpt_client.rs
@@ -13,7 +13,7 @@ pub(crate) async fn chatgpt_get_request<T: DeserializeOwned>(
     config: &Config,
     path: String,
 ) -> anyhow::Result<T> {
-    chatgpt_get_request_with_timeout(config, path, None).await
+    chatgpt_get_request_with_timeout(config, path, /*timeout*/ None).await
 }
 
 pub(crate) async fn chatgpt_get_request_with_timeout<T: DeserializeOwned>(

--- a/codex-rs/chatgpt/src/chatgpt_token.rs
+++ b/codex-rs/chatgpt/src/chatgpt_token.rs
@@ -23,8 +23,11 @@ pub async fn init_chatgpt_token_from_auth(
     codex_home: &Path,
     auth_credentials_store_mode: AuthCredentialsStoreMode,
 ) -> std::io::Result<()> {
-    let auth_manager =
-        AuthManager::new(codex_home.to_path_buf(), false, auth_credentials_store_mode);
+    let auth_manager = AuthManager::new(
+        codex_home.to_path_buf(),
+        /*enable_codex_api_key_env*/ false,
+        auth_credentials_store_mode,
+    );
     if let Some(auth) = auth_manager.auth().await {
         let token_data = auth.get_token_data()?;
         set_chatgpt_token_data(token_data);

--- a/codex-rs/chatgpt/src/connectors.rs
+++ b/codex-rs/chatgpt/src/connectors.rs
@@ -29,7 +29,7 @@ const DIRECTORY_CONNECTORS_TIMEOUT: Duration = Duration::from_secs(60);
 async fn apps_enabled(config: &Config) -> bool {
     let auth_manager = AuthManager::shared(
         config.codex_home.clone(),
-        false,
+        /*enable_codex_api_key_env*/ false,
         config.cli_auth_credentials_store_mode,
     );
     config.features.apps_enabled(Some(&auth_manager)).await
@@ -45,13 +45,15 @@ pub async fn list_connectors(config: &Config) -> anyhow::Result<Vec<AppInfo>> {
     let connectors = connectors_result?;
     let accessible = accessible_result?;
     Ok(with_app_enabled_state(
-        merge_connectors_with_accessible(connectors, accessible, true),
+        merge_connectors_with_accessible(
+            connectors, accessible, /*all_connectors_loaded*/ true,
+        ),
         config,
     ))
 }
 
 pub async fn list_all_connectors(config: &Config) -> anyhow::Result<Vec<AppInfo>> {
-    list_all_connectors_with_options(config, false).await
+    list_all_connectors_with_options(config, /*force_refetch*/ false).await
 }
 
 pub async fn list_cached_all_connectors(config: &Config) -> Option<Vec<AppInfo>> {

--- a/codex-rs/cli/src/debug_sandbox.rs
+++ b/codex-rs/cli/src/debug_sandbox.rs
@@ -69,7 +69,7 @@ pub async fn run_command_under_landlock(
         config_overrides,
         codex_linux_sandbox_exe,
         SandboxType::Landlock,
-        false,
+        /*log_denials*/ false,
     )
     .await
 }
@@ -89,7 +89,7 @@ pub async fn run_command_under_windows(
         config_overrides,
         codex_linux_sandbox_exe,
         SandboxType::Windows,
-        false,
+        /*log_denials*/ false,
     )
     .await
 }
@@ -131,7 +131,10 @@ async fn run_command_under_sandbox(
     let sandbox_policy_cwd = cwd.clone();
 
     let stdio_policy = StdioPolicy::Inherit;
-    let env = create_env(&config.permissions.shell_environment_policy, None);
+    let env = create_env(
+        &config.permissions.shell_environment_policy,
+        /*thread_id*/ None,
+    );
 
     // Special-case Windows sandbox: execute and exit the process to emulate inherited stdio.
     if let SandboxType::Windows = sandbox_type {
@@ -223,8 +226,8 @@ async fn run_command_under_sandbox(
         Some(spec) => Some(
             spec.start_proxy(
                 config.permissions.sandbox_policy.get(),
-                None,
-                None,
+                /*policy_decider*/ None,
+                /*blocked_request_observer*/ None,
                 managed_network_requirements_enabled,
                 NetworkProxyAuditMetadata::default(),
             )

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -830,7 +830,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
                 &mut apply_cli.config_overrides,
                 root_config_overrides.clone(),
             );
-            run_apply_command(apply_cli, None).await?;
+            run_apply_command(apply_cli, /*cwd*/ None).await?;
         }
         Some(Subcommand::ResponsesApiProxy(args)) => {
             reject_remote_mode_for_subcommand(root_remote.as_deref(), "responses-api-proxy")?;
@@ -906,7 +906,7 @@ async fn enable_feature_in_config(interactive: &TuiCli, feature: &str) -> anyhow
     let codex_home = find_codex_home()?;
     ConfigEditsBuilder::new(&codex_home)
         .with_profile(interactive.config_profile.as_deref())
-        .set_feature_enabled(feature, true)
+        .set_feature_enabled(feature, /*enabled*/ true)
         .apply()
         .await?;
     println!("Enabled feature `{feature}` in config.toml.");
@@ -919,7 +919,7 @@ async fn disable_feature_in_config(interactive: &TuiCli, feature: &str) -> anyho
     let codex_home = find_codex_home()?;
     ConfigEditsBuilder::new(&codex_home)
         .with_profile(interactive.config_profile.as_deref())
-        .set_feature_enabled(feature, false)
+        .set_feature_enabled(feature, /*enabled*/ false)
         .apply()
         .await?;
     println!("Disabled feature `{feature}` in config.toml.");

--- a/codex-rs/cli/src/mcp_cmd.rs
+++ b/codex-rs/cli/src/mcp_cmd.rs
@@ -321,8 +321,11 @@ async fn run_add(config_overrides: &CliConfigOverrides, add_args: AddArgs) -> Re
     match oauth_login_support(&transport).await {
         McpOAuthLoginSupport::Supported(oauth_config) => {
             println!("Detected OAuth support. Starting OAuth flow…");
-            let resolved_scopes =
-                resolve_oauth_scopes(None, None, oauth_config.discovered_scopes.clone());
+            let resolved_scopes = resolve_oauth_scopes(
+                /*explicit_scopes*/ None,
+                /*configured_scopes*/ None,
+                oauth_config.discovered_scopes.clone(),
+            );
             perform_oauth_login_retry_without_scopes(
                 &name,
                 &oauth_config.url,
@@ -330,7 +333,7 @@ async fn run_add(config_overrides: &CliConfigOverrides, add_args: AddArgs) -> Re
                 oauth_config.http_headers,
                 oauth_config.env_http_headers,
                 &resolved_scopes,
-                None,
+                /*oauth_resource*/ None,
                 config.mcp_oauth_callback_port,
                 config.mcp_oauth_callback_url.as_deref(),
             )
@@ -387,7 +390,7 @@ async fn run_login(config_overrides: &CliConfigOverrides, login_args: LoginArgs)
         .await
         .context("failed to load configuration")?;
     let mcp_manager = McpManager::new(Arc::new(PluginsManager::new(config.codex_home.clone())));
-    let mcp_servers = mcp_manager.effective_servers(&config, None);
+    let mcp_servers = mcp_manager.effective_servers(&config, /*auth*/ None);
 
     let LoginArgs { name, scopes } = login_args;
 
@@ -438,7 +441,7 @@ async fn run_logout(config_overrides: &CliConfigOverrides, logout_args: LogoutAr
         .await
         .context("failed to load configuration")?;
     let mcp_manager = McpManager::new(Arc::new(PluginsManager::new(config.codex_home.clone())));
-    let mcp_servers = mcp_manager.effective_servers(&config, None);
+    let mcp_servers = mcp_manager.effective_servers(&config, /*auth*/ None);
 
     let LogoutArgs { name } = logout_args;
 
@@ -468,7 +471,7 @@ async fn run_list(config_overrides: &CliConfigOverrides, list_args: ListArgs) ->
         .await
         .context("failed to load configuration")?;
     let mcp_manager = McpManager::new(Arc::new(PluginsManager::new(config.codex_home.clone())));
-    let mcp_servers = mcp_manager.effective_servers(&config, None);
+    let mcp_servers = mcp_manager.effective_servers(&config, /*auth*/ None);
 
     let mut entries: Vec<_> = mcp_servers.iter().collect();
     entries.sort_by(|(a, _), (b, _)| a.cmp(b));
@@ -717,7 +720,7 @@ async fn run_get(config_overrides: &CliConfigOverrides, get_args: GetArgs) -> Re
         .await
         .context("failed to load configuration")?;
     let mcp_manager = McpManager::new(Arc::new(PluginsManager::new(config.codex_home.clone())));
-    let mcp_servers = mcp_manager.effective_servers(&config, None);
+    let mcp_servers = mcp_manager.effective_servers(&config, /*auth*/ None);
 
     let Some(server) = mcp_servers.get(&get_args.name) else {
         bail!("No MCP server named '{name}' found.", name = get_args.name);

--- a/codex-rs/cloud-requirements/src/lib.rs
+++ b/codex-rs/cloud-requirements/src/lib.rs
@@ -286,7 +286,7 @@ impl CloudRequirementsService {
             .map_err(|_| {
                 CloudRequirementsLoadError::new(
                     CloudRequirementsLoadErrorCode::Timeout,
-                    None,
+                    /*status_code*/ None,
                     format!(
                         "timed out waiting for cloud requirements after {}s",
                         self.timeout.as_secs()
@@ -368,7 +368,9 @@ impl CloudRequirementsService {
         while attempt <= CLOUD_REQUIREMENTS_MAX_ATTEMPTS {
             let contents = match self.fetcher.fetch_requirements(&auth).await {
                 Ok(contents) => {
-                    emit_fetch_attempt_metric(trigger, attempt, "success", None);
+                    emit_fetch_attempt_metric(
+                        trigger, attempt, "success", /*status_code*/ None,
+                    );
                     contents
                 }
                 Err(FetchAttemptError::Retryable(status)) => {
@@ -488,7 +490,7 @@ impl CloudRequirementsService {
                         );
                         return Err(CloudRequirementsLoadError::new(
                             CloudRequirementsLoadErrorCode::Parse,
-                            None,
+                            /*status_code*/ None,
                             CLOUD_REQUIREMENTS_LOAD_FAILED_MESSAGE,
                         ));
                     }
@@ -501,7 +503,9 @@ impl CloudRequirementsService {
                 tracing::warn!(error = %err, "Failed to write cloud requirements cache");
             }
 
-            emit_fetch_final_metric(trigger, "success", "none", attempt, None);
+            emit_fetch_final_metric(
+                trigger, "success", "none", attempt, /*status_code*/ None,
+            );
             return Ok(requirements);
         }
 
@@ -709,7 +713,7 @@ pub fn cloud_requirements_loader(
             tracing::error!(error = %err, "Cloud requirements task failed");
             CloudRequirementsLoadError::new(
                 CloudRequirementsLoadErrorCode::Internal,
-                None,
+                /*status_code*/ None,
                 format!("cloud requirements load failed: {err}"),
             )
         })?
@@ -807,7 +811,7 @@ fn emit_metric(metric_name: &str, tags: Vec<(&str, String)>) {
             .iter()
             .map(|(key, value)| (*key, value.as_str()))
             .collect::<Vec<_>>();
-        let _ = metrics.counter(metric_name, 1, &tag_refs);
+        let _ = metrics.counter(metric_name, /*inc*/ 1, &tag_refs);
     }
 }
 

--- a/codex-rs/cloud-tasks-client/src/http.rs
+++ b/codex-rs/cloud-tasks-client/src/http.rs
@@ -94,7 +94,9 @@ impl CloudBackend for HttpClient {
     }
 
     async fn apply_task(&self, id: TaskId, diff_override: Option<String>) -> Result<ApplyOutcome> {
-        self.apply_api().run(id, diff_override, false).await
+        self.apply_api()
+            .run(id, diff_override, /*preflight*/ false)
+            .await
     }
 
     async fn apply_task_preflight(
@@ -102,7 +104,9 @@ impl CloudBackend for HttpClient {
         id: TaskId,
         diff_override: Option<String>,
     ) -> Result<ApplyOutcome> {
-        self.apply_api().run(id, diff_override, true).await
+        self.apply_api()
+            .run(id, diff_override, /*preflight*/ true)
+            .await
     }
 
     async fn create_task(
@@ -533,8 +537,8 @@ mod api {
                 let _ = writeln!(
                     &mut log,
                     "stdout_tail=\n{}\nstderr_tail=\n{}",
-                    tail(&r.stdout, 2000),
-                    tail(&r.stderr, 2000)
+                    tail(&r.stdout, /*max*/ 2000),
+                    tail(&r.stderr, /*max*/ 2000)
                 );
                 let _ = writeln!(&mut log, "{summary}");
                 let _ = writeln!(

--- a/codex-rs/cloud-tasks-client/src/mock.rs
+++ b/codex-rs/cloud-tasks-client/src/mock.rs
@@ -70,7 +70,10 @@ impl CloudBackend for MockClient {
     }
 
     async fn get_task_summary(&self, id: TaskId) -> Result<TaskSummary> {
-        let tasks = self.list_tasks(None, None, None).await?.tasks;
+        let tasks = self
+            .list_tasks(/*env*/ None, /*limit*/ None, /*cursor*/ None)
+            .await?
+            .tasks;
         tasks
             .into_iter()
             .find(|t| t.id == id)

--- a/codex-rs/cloud-tasks/src/app.rs
+++ b/codex-rs/cloud-tasks/src/app.rs
@@ -125,7 +125,7 @@ pub async fn load_tasks(
     // In later milestones, add a small debounce, spinner, and error display.
     let tasks = tokio::time::timeout(
         Duration::from_secs(5),
-        backend.list_tasks(env, Some(20), None),
+        backend.list_tasks(env, Some(20), /*cursor*/ None),
     )
     .await??;
     // Hide review-only tasks from the main list.

--- a/codex-rs/cloud-tasks/src/lib.rs
+++ b/codex-rs/cloud-tasks/src/lib.rs
@@ -171,7 +171,7 @@ async fn run_exec_command(args: crate::cli::ExecCommand) -> anyhow::Result<()> {
         &env_id,
         &prompt,
         &git_ref,
-        false,
+        /*qa_mode*/ false,
         attempts,
     )
     .await?;
@@ -827,7 +827,7 @@ pub async fn run_main(cli: Cli, _codex_linux_sandbox_exe: Option<PathBuf>) -> an
         let backend = Arc::clone(&backend);
         let tx = tx.clone();
         tokio::spawn(async move {
-            let res = app::load_tasks(&*backend, None).await;
+            let res = app::load_tasks(&*backend, /*env*/ None).await;
             let _ = tx.send(app::AppEvent::TasksLoaded {
                 env: None,
                 result: res,
@@ -861,7 +861,10 @@ pub async fn run_main(cli: Cli, _codex_linux_sandbox_exe: Option<PathBuf>) -> an
             let headers = util::build_chatgpt_headers().await;
 
             // Run autodetect. If it fails, we keep using "All".
-            let res = crate::env_detect::autodetect_environment_id(&base_url, &headers, None).await;
+            let res = crate::env_detect::autodetect_environment_id(
+                &base_url, &headers, /*desired_label*/ None,
+            )
+            .await;
             let _ = tx.send(app::AppEvent::EnvironmentAutodetected(res));
         });
     }
@@ -1105,7 +1108,7 @@ pub async fn run_main(cli: Cli, _codex_linux_sandbox_exe: Option<PathBuf>) -> an
                                 ov.base_can_apply = true;
                                 ov.apply_selection_to_fields();
                             } else {
-                                let mut overlay = app::DiffOverlay::new(id.clone(), title, None);
+                                let mut overlay = app::DiffOverlay::new(id.clone(), title, /*attempt_total_hint*/ None);
                                 {
                                     let base = overlay.base_attempt_mut();
                                     base.diff_lines = diff_lines.clone();
@@ -1178,7 +1181,7 @@ pub async fn run_main(cli: Cli, _codex_linux_sandbox_exe: Option<PathBuf>) -> an
                                         });
                                     }
                             } else {
-                                let mut overlay = app::DiffOverlay::new(id.clone(), title, None);
+                                let mut overlay = app::DiffOverlay::new(id.clone(), title, /*attempt_total_hint*/ None);
                                 {
                                     let base = overlay.base_attempt_mut();
                                     base.text_lines = conv.clone();
@@ -1216,7 +1219,7 @@ pub async fn run_main(cli: Cli, _codex_linux_sandbox_exe: Option<PathBuf>) -> an
                                         .as_ref()
                                         .map(|d| d.lines().map(str::to_string).collect())
                                         .unwrap_or_default();
-                                    let text_lines = conversation_lines(None, &attempt.messages);
+                                    let text_lines = conversation_lines(/*prompt*/ None, &attempt.messages);
                                     ov.attempts.push(app::AttemptView {
                                         turn_id: Some(attempt.turn_id.clone()),
                                         status: attempt.status,
@@ -1263,7 +1266,7 @@ pub async fn run_main(cli: Cli, _codex_linux_sandbox_exe: Option<PathBuf>) -> an
                                 ov.current_view = app::DetailView::Prompt;
                                 ov.apply_selection_to_fields();
                             } else {
-                                let mut overlay = app::DiffOverlay::new(id.clone(), title, None);
+                                let mut overlay = app::DiffOverlay::new(id.clone(), title, /*attempt_total_hint*/ None);
                                 {
                                     let base = overlay.base_attempt_mut();
                                     base.text_lines = pretty;
@@ -1500,9 +1503,9 @@ pub async fn run_main(cli: Cli, _codex_linux_sandbox_exe: Option<PathBuf>) -> an
                                                 let backend = Arc::clone(&backend);
                                                 let best_of_n = page.best_of_n;
                                                 tokio::spawn(async move {
-                                                    let git_ref = resolve_git_ref(None).await;
+                                                    let git_ref = resolve_git_ref(/*branch_override*/ None).await;
 
-                                                    let result = codex_cloud_tasks_client::CloudBackend::create_task(&*backend, &env, &text, &git_ref, false, best_of_n).await;
+                                                    let result = codex_cloud_tasks_client::CloudBackend::create_task(&*backend, &env, &text, &git_ref, /*qa_mode*/ false, best_of_n).await;
                                                     let evt = match result {
                                                         Ok(ok) => app::AppEvent::NewTaskSubmitted(Ok(ok)),
                                                         Err(e) => app::AppEvent::NewTaskSubmitted(Err(format!("{e}"))),
@@ -1685,11 +1688,11 @@ pub async fn run_main(cli: Cli, _codex_linux_sandbox_exe: Option<PathBuf>) -> an
                                     needs_redraw = true;
                                 }
                                 KeyCode::Down | KeyCode::Char('j') => {
-                                    if let Some(ov) = &mut app.diff_overlay { ov.sd.scroll_by(1); }
+                                    if let Some(ov) = &mut app.diff_overlay { ov.sd.scroll_by(/*delta*/ 1); }
                                     needs_redraw = true;
                                 }
                                 KeyCode::Up | KeyCode::Char('k') => {
-                                    if let Some(ov) = &mut app.diff_overlay { ov.sd.scroll_by(-1); }
+                                    if let Some(ov) = &mut app.diff_overlay { ov.sd.scroll_by(/*delta*/ -1); }
                                     needs_redraw = true;
                                 }
                                 KeyCode::PageDown | KeyCode::Char(' ') => {
@@ -1721,7 +1724,7 @@ pub async fn run_main(cli: Cli, _codex_linux_sandbox_exe: Option<PathBuf>) -> an
                                 KeyCode::PageUp => { if let Some(m) = app.env_modal.as_mut() { let step = 10usize; m.selected = m.selected.saturating_sub(step); } needs_redraw = true; }
                                 KeyCode::Char('n') => {
                                     if app.env_filter.is_none() {
-                                        app.new_task = Some(crate::new_task::NewTaskPage::new(None, app.best_of_n));
+                                        app.new_task = Some(crate::new_task::NewTaskPage::new(/*env_id*/ None, app.best_of_n));
                                     } else {
                                         app.new_task = Some(crate::new_task::NewTaskPage::new(app.env_filter.clone(), app.best_of_n));
                                     }

--- a/codex-rs/cloud-tasks/src/new_task.rs
+++ b/codex-rs/cloud-tasks/src/new_task.rs
@@ -30,6 +30,6 @@ impl NewTaskPage {
 
 impl Default for NewTaskPage {
     fn default() -> Self {
-        Self::new(None, 1)
+        Self::new(/*env_id*/ None, /*best_of_n*/ 1)
     }
 }

--- a/codex-rs/cloud-tasks/src/ui.rs
+++ b/codex-rs/cloud-tasks/src/ui.rs
@@ -582,7 +582,10 @@ fn style_conversation_lines(
             speaker = Some(ConversationSpeaker::User);
             in_code = false;
             bullet_indent = None;
-            styled.push(conversation_header_line(ConversationSpeaker::User, None));
+            styled.push(conversation_header_line(
+                ConversationSpeaker::User,
+                /*attempt*/ None,
+            ));
             last_src = Some(src_idx);
             continue;
         }

--- a/codex-rs/cloud-tasks/src/util.rs
+++ b/codex-rs/cloud-tasks/src/util.rs
@@ -64,7 +64,7 @@ pub async fn load_auth_manager() -> Option<AuthManager> {
     let config = Config::load_with_cli_overrides(Vec::new()).await.ok()?;
     Some(AuthManager::new(
         config.codex_home,
-        false,
+        /*enable_codex_api_key_env*/ false,
         config.cli_auth_credentials_store_mode,
     ))
 }

--- a/codex-rs/codex-api/src/endpoint/models.rs
+++ b/codex-rs/codex-api/src/endpoint/models.rs
@@ -44,9 +44,15 @@ impl<T: HttpTransport, A: AuthProvider> ModelsClient<T, A> {
     ) -> Result<(Vec<ModelInfo>, Option<String>), ApiError> {
         let resp = self
             .session
-            .execute_with(Method::GET, Self::path(), extra_headers, None, |req| {
-                Self::append_client_version_query(req, client_version);
-            })
+            .execute_with(
+                Method::GET,
+                Self::path(),
+                extra_headers,
+                /*body*/ None,
+                |req| {
+                    Self::append_client_version_query(req, client_version);
+                },
+            )
             .await?;
 
         let header_etag = resp

--- a/codex-rs/codex-api/src/rate_limits.rs
+++ b/codex-rs/codex-api/src/rate_limits.rs
@@ -20,7 +20,7 @@ impl Display for RateLimitError {
 
 /// Parses the default Codex rate-limit header family into a `RateLimitSnapshot`.
 pub fn parse_default_rate_limit(headers: &HeaderMap) -> Option<RateLimitSnapshot> {
-    parse_rate_limit_for_limit(headers, None)
+    parse_rate_limit_for_limit(headers, /*limit_id*/ None)
 }
 
 /// Parses all known rate-limit header families into update records keyed by limit id.

--- a/codex-rs/codex-api/src/sse/responses.rs
+++ b/codex-rs/codex-api/src/sse/responses.rs
@@ -45,7 +45,12 @@ pub fn stream_from_fixture(
     let reader = std::io::Cursor::new(content);
     let stream = ReaderStream::new(reader).map_err(|err| TransportError::Network(err.to_string()));
     let (tx_event, rx_event) = mpsc::channel::<Result<ResponseEvent, ApiError>>(1600);
-    tokio::spawn(process_sse(Box::pin(stream), tx_event, idle_timeout, None));
+    tokio::spawn(process_sse(
+        Box::pin(stream),
+        tx_event,
+        idle_timeout,
+        /*telemetry*/ None,
+    ));
     Ok(ResponseStream { rx_event })
 }
 

--- a/codex-rs/codex-experimental-api-macros/src/lib.rs
+++ b/codex-rs/codex-experimental-api-macros/src/lib.rs
@@ -38,7 +38,7 @@ fn derive_for_struct(input: &DeriveInput, data: &DataStruct) -> TokenStream {
             let mut registrations = Vec::new();
             for field in &named.named {
                 if let Some(reason) = experimental_reason(&field.attrs) {
-                    let expr = experimental_presence_expr(field, false);
+                    let expr = experimental_presence_expr(field, /*tuple_struct*/ false);
                     checks.push(quote! {
                         if #expr {
                             return Some(#reason);

--- a/codex-rs/config/src/config_requirements.rs
+++ b/codex-rs/config/src/config_requirements.rs
@@ -92,20 +92,23 @@ impl Default for ConfigRequirements {
         Self {
             approval_policy: ConstrainedWithSource::new(
                 Constrained::allow_any_from_default(),
-                None,
+                /*source*/ None,
             ),
             sandbox_policy: ConstrainedWithSource::new(
                 Constrained::allow_any(SandboxPolicy::new_read_only_policy()),
-                None,
+                /*source*/ None,
             ),
             web_search_mode: ConstrainedWithSource::new(
                 Constrained::allow_any(WebSearchMode::Cached),
-                None,
+                /*source*/ None,
             ),
             feature_requirements: None,
             mcp_servers: None,
             exec_policy: None,
-            enforce_residency: ConstrainedWithSource::new(Constrained::allow_any(None), None),
+            enforce_residency: ConstrainedWithSource::new(
+                Constrained::allow_any(/*initial_value*/ None),
+                /*source*/ None,
+            ),
             network: None,
         }
     }
@@ -508,7 +511,10 @@ impl TryFrom<ConfigRequirementsWithSources> for ConfigRequirements {
                 })?;
                 ConstrainedWithSource::new(constrained, Some(requirement_source))
             }
-            None => ConstrainedWithSource::new(Constrained::allow_any_from_default(), None),
+            None => ConstrainedWithSource::new(
+                Constrained::allow_any_from_default(),
+                /*source*/ None,
+            ),
         };
 
         // TODO(gt): `ConfigRequirementsToml` should let the author specify the
@@ -559,7 +565,10 @@ impl TryFrom<ConfigRequirementsWithSources> for ConfigRequirements {
                 ConstrainedWithSource::new(constrained, Some(requirement_source))
             }
             None => {
-                ConstrainedWithSource::new(Constrained::allow_any(default_sandbox_policy), None)
+                ConstrainedWithSource::new(
+                    Constrained::allow_any(default_sandbox_policy),
+                    /*source*/ None,
+                )
             }
         };
         let exec_policy = match rules {
@@ -612,7 +621,10 @@ impl TryFrom<ConfigRequirementsWithSources> for ConfigRequirements {
                 })?;
                 ConstrainedWithSource::new(constrained, Some(requirement_source))
             }
-            None => ConstrainedWithSource::new(Constrained::allow_any(WebSearchMode::Cached), None),
+            None => ConstrainedWithSource::new(
+                Constrained::allow_any(WebSearchMode::Cached),
+                /*source*/ None,
+            ),
         };
         let feature_requirements =
             feature_requirements.filter(|requirements| !requirements.value.is_empty());
@@ -638,7 +650,10 @@ impl TryFrom<ConfigRequirementsWithSources> for ConfigRequirements {
                 })?;
                 ConstrainedWithSource::new(constrained, Some(requirement_source))
             }
-            None => ConstrainedWithSource::new(Constrained::allow_any(None), None),
+            None => ConstrainedWithSource::new(
+                Constrained::allow_any(/*initial_value*/ None),
+                /*source*/ None,
+            ),
         };
         let network = network.map(|sourced_network| {
             let Sourced { value, source } = sourced_network;

--- a/codex-rs/config/src/diagnostics.rs
+++ b/codex-rs/config/src/diagnostics.rs
@@ -142,7 +142,10 @@ pub async fn first_layer_config_error<T: DeserializeOwned>(
     // per-file error to point users at a specific file and range rather than an
     // opaque merged-layer failure.
     first_layer_config_error_for_entries::<T, _>(
-        layers.get_layers(ConfigLayerStackOrdering::LowestPrecedenceFirst, false),
+        layers.get_layers(
+            ConfigLayerStackOrdering::LowestPrecedenceFirst,
+            /*include_disabled*/ false,
+        ),
         config_toml_file,
     )
     .await

--- a/codex-rs/config/src/state.rs
+++ b/codex-rs/config/src/state.rs
@@ -211,7 +211,10 @@ impl ConfigLayerStack {
 
     pub fn effective_config(&self) -> TomlValue {
         let mut merged = TomlValue::Table(toml::map::Map::new());
-        for layer in self.get_layers(ConfigLayerStackOrdering::LowestPrecedenceFirst, false) {
+        for layer in self.get_layers(
+            ConfigLayerStackOrdering::LowestPrecedenceFirst,
+            /*include_disabled*/ false,
+        ) {
             merge_toml_values(&mut merged, &layer.config);
         }
         merged
@@ -221,7 +224,10 @@ impl ConfigLayerStack {
         let mut origins = HashMap::new();
         let mut path = Vec::new();
 
-        for layer in self.get_layers(ConfigLayerStackOrdering::LowestPrecedenceFirst, false) {
+        for layer in self.get_layers(
+            ConfigLayerStackOrdering::LowestPrecedenceFirst,
+            /*include_disabled*/ false,
+        ) {
             record_origins(&layer.config, &layer.metadata(), &mut path, &mut origins);
         }
 
@@ -231,7 +237,10 @@ impl ConfigLayerStack {
     /// Returns the highest-precedence to lowest-precedence layers, so
     /// `ConfigLayerSource::SessionFlags` would be first, if present.
     pub fn layers_high_to_low(&self) -> Vec<&ConfigLayerEntry> {
-        self.get_layers(ConfigLayerStackOrdering::HighestPrecedenceFirst, false)
+        self.get_layers(
+            ConfigLayerStackOrdering::HighestPrecedenceFirst,
+            /*include_disabled*/ false,
+        )
     }
 
     /// Returns the highest-precedence to lowest-precedence layers, so

--- a/codex-rs/core/src/agent/control.rs
+++ b/codex-rs/core/src/agent/control.rs
@@ -186,7 +186,7 @@ impl AgentControl {
                             initial_history,
                             self.clone(),
                             session_source,
-                            false,
+                            /*persist_extended_history*/ false,
                             inherited_shell_snapshot,
                         )
                         .await?
@@ -196,8 +196,8 @@ impl AgentControl {
                             config,
                             self.clone(),
                             session_source,
-                            false,
-                            None,
+                            /*persist_extended_history*/ false,
+                            /*metrics_service_name*/ None,
                             inherited_shell_snapshot,
                         )
                         .await?

--- a/codex-rs/core/src/agent/guards.rs
+++ b/codex-rs/core/src/agent/guards.rs
@@ -138,7 +138,11 @@ impl Guards {
                 active_agents.used_agent_nicknames.clear();
                 active_agents.nickname_reset_count += 1;
                 if let Some(metrics) = codex_otel::metrics::global() {
-                    let _ = metrics.counter("codex.multi_agent.nickname_pool_reset", 1, &[]);
+                    let _ = metrics.counter(
+                        "codex.multi_agent.nickname_pool_reset",
+                        /*inc*/ 1,
+                        &[],
+                    );
                 }
                 format_agent_nickname(
                     names.choose(&mut rand::rng())?,
@@ -179,7 +183,7 @@ pub(crate) struct SpawnReservation {
 
 impl SpawnReservation {
     pub(crate) fn reserve_agent_nickname(&mut self, names: &[&str]) -> Result<String> {
-        self.reserve_agent_nickname_with_preference(names, None)
+        self.reserve_agent_nickname_with_preference(names, /*preferred*/ None)
     }
 
     pub(crate) fn reserve_agent_nickname_with_preference(
@@ -198,7 +202,7 @@ impl SpawnReservation {
     }
 
     pub(crate) fn commit(self, thread_id: ThreadId) {
-        self.commit_with_agent_nickname(thread_id, None);
+        self.commit_with_agent_nickname(thread_id, /*agent_nickname*/ None);
     }
 
     pub(crate) fn commit_with_agent_nickname(

--- a/codex-rs/core/src/agent/role.rs
+++ b/codex-rs/core/src/agent/role.rs
@@ -231,7 +231,10 @@ mod reload {
     fn existing_layers(config: &Config) -> Vec<ConfigLayerEntry> {
         config
             .config_layer_stack
-            .get_layers(ConfigLayerStackOrdering::LowestPrecedenceFirst, true)
+            .get_layers(
+                ConfigLayerStackOrdering::LowestPrecedenceFirst,
+                /*include_disabled*/ true,
+            )
             .into_iter()
             .cloned()
             .collect()

--- a/codex-rs/core/src/auth.rs
+++ b/codex-rs/core/src/auth.rs
@@ -194,7 +194,11 @@ impl CodexAuth {
         codex_home: &Path,
         auth_credentials_store_mode: AuthCredentialsStoreMode,
     ) -> std::io::Result<Option<Self>> {
-        load_auth(codex_home, false, auth_credentials_store_mode)
+        load_auth(
+            codex_home,
+            /*enable_codex_api_key_env*/ false,
+            auth_credentials_store_mode,
+        )
     }
 
     pub fn auth_mode(&self) -> AuthMode {
@@ -457,7 +461,7 @@ pub fn load_auth_dot_json(
 pub fn enforce_login_restrictions(config: &Config) -> std::io::Result<()> {
     let Some(auth) = load_auth(
         &config.codex_home,
-        true,
+        /*enable_codex_api_key_env*/ true,
         config.cli_auth_credentials_store_mode,
     )?
     else {

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -564,7 +564,7 @@ impl ModelClient {
             auth_context.recovery_mode,
             auth_context.recovery_phase,
             request_route_telemetry.endpoint,
-            false,
+            /*connection_reused*/ false,
             response_debug.request_id.as_deref(),
             response_debug.cf_ray.as_deref(),
             response_debug.auth_error.as_deref(),
@@ -796,9 +796,11 @@ impl ModelClientSession {
         let Some(last_response) = self.get_last_response() else {
             return ResponsesWsRequest::ResponseCreate(payload);
         };
-        let Some(incremental_items) =
-            self.get_incremental_items(request, Some(&last_response), true)
-        else {
+        let Some(incremental_items) = self.get_incremental_items(
+            request,
+            Some(&last_response),
+            /*allow_empty_delta*/ true,
+        ) else {
             return ResponsesWsRequest::ResponseCreate(payload);
         };
 
@@ -846,13 +848,14 @@ impl ModelClientSession {
                 client_setup.api_provider,
                 client_setup.api_auth,
                 Some(Arc::clone(&self.turn_state)),
-                None,
+                /*turn_metadata_header*/ None,
                 auth_context,
                 RequestRouteTelemetry::for_endpoint(RESPONSES_ENDPOINT),
             )
             .await?;
         self.websocket_session.connection = Some(connection);
-        self.websocket_session.set_connection_reused(false);
+        self.websocket_session
+            .set_connection_reused(/*connection_reused*/ false);
         Ok(())
     }
     /// Returns a websocket connection for this turn.
@@ -906,9 +909,11 @@ impl ModelClientSession {
                 )
                 .await?;
             self.websocket_session.connection = Some(new_conn);
-            self.websocket_session.set_connection_reused(false);
+            self.websocket_session
+                .set_connection_reused(/*connection_reused*/ false);
         } else {
-            self.websocket_session.set_connection_reused(true);
+            self.websocket_session
+                .set_connection_reused(/*connection_reused*/ true);
         }
 
         self.websocket_session
@@ -1202,7 +1207,7 @@ impl ModelClientSession {
                 summary,
                 service_tier,
                 turn_metadata_header,
-                true,
+                /*warmup*/ true,
             )
             .await
         {
@@ -1255,7 +1260,7 @@ impl ModelClientSession {
                             summary,
                             service_tier,
                             turn_metadata_header,
-                            false,
+                            /*warmup*/ false,
                         )
                         .await?
                     {
@@ -1297,14 +1302,15 @@ impl ModelClientSession {
             warn!("falling back to HTTP");
             session_telemetry.counter(
                 "codex.transport.fallback_to_http",
-                1,
+                /*inc*/ 1,
                 &[("from_wire_api", "responses_websocket")],
             );
 
             self.websocket_session.connection = None;
             self.websocket_session.last_request = None;
             self.websocket_session.last_response_rx = None;
-            self.websocket_session.set_connection_reused(false);
+            self.websocket_session
+                .set_connection_reused(/*connection_reused*/ false);
         }
         activated
     }
@@ -1527,7 +1533,7 @@ async fn handle_unauthorized(
                     debug.cf_ray.as_deref(),
                     debug.auth_error.as_deref(),
                     debug.auth_error_code.as_deref(),
-                    None,
+                    /*recovery_reason*/ None,
                     step_result.auth_state_changed(),
                 );
                 emit_feedback_auth_recovery_tags(
@@ -1550,8 +1556,8 @@ async fn handle_unauthorized(
                     debug.cf_ray.as_deref(),
                     debug.auth_error.as_deref(),
                     debug.auth_error_code.as_deref(),
-                    None,
-                    None,
+                    /*recovery_reason*/ None,
+                    /*auth_state_changed*/ None,
                 );
                 emit_feedback_auth_recovery_tags(
                     mode,
@@ -1573,8 +1579,8 @@ async fn handle_unauthorized(
                     debug.cf_ray.as_deref(),
                     debug.auth_error.as_deref(),
                     debug.auth_error_code.as_deref(),
-                    None,
-                    None,
+                    /*recovery_reason*/ None,
+                    /*auth_state_changed*/ None,
                 );
                 emit_feedback_auth_recovery_tags(
                     mode,
@@ -1607,7 +1613,7 @@ async fn handle_unauthorized(
         debug.auth_error.as_deref(),
         debug.auth_error_code.as_deref(),
         recovery_reason,
-        None,
+        /*auth_state_changed*/ None,
     );
     emit_feedback_auth_recovery_tags(
         mode,

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -630,7 +630,7 @@ impl Codex {
 
     /// Submit the `op` wrapped in a `Submission` with a unique ID.
     pub async fn submit(&self, op: Op) -> CodexResult<String> {
-        self.submit_with_trace(op, None).await
+        self.submit_with_trace(op, /*trace*/ None).await
     }
 
     pub async fn submit_with_trace(
@@ -855,9 +855,11 @@ impl TurnContext {
         };
         config.model_reasoning_effort = reasoning_effort;
 
-        let collaboration_mode =
-            self.collaboration_mode
-                .with_updates(Some(model.clone()), Some(reasoning_effort), None);
+        let collaboration_mode = self.collaboration_mode.with_updates(
+            Some(model.clone()),
+            Some(reasoning_effort),
+            /*developer_instructions*/ None,
+        );
         let features = self.features.clone();
         let tools_config = ToolsConfig::new(&ToolsConfigParams {
             model_info: &model_info,
@@ -1590,7 +1592,7 @@ impl Session {
         config.features.emit_metrics(&session_telemetry);
         session_telemetry.counter(
             THREAD_STARTED_METRIC,
-            1,
+            /*inc*/ 1,
             &[(
                 "is_git",
                 if get_git_repo_root(&session_configuration.cwd).is_some() {
@@ -1722,7 +1724,8 @@ impl Session {
                 (None, None)
             };
 
-        let mut hook_shell_argv = default_shell.derive_exec_args("", false);
+        let mut hook_shell_argv =
+            default_shell.derive_exec_args("", /*use_login_shell*/ false);
         let hook_shell_program = hook_shell_argv.remove(0);
         let _ = hook_shell_argv.pop();
         let hooks = Hooks::new(HooksConfig {
@@ -2072,7 +2075,8 @@ impl Session {
             InitialHistory::New => {
                 // Defer initial context insertion until the first real turn starts so
                 // turn/start overrides can be merged before we write model-visible context.
-                self.set_previous_turn_settings(None).await;
+                self.set_previous_turn_settings(/*previous_turn_settings*/ None)
+                    .await;
             }
             InitialHistory::Resumed(resumed_history) => {
                 let rollout_items = resumed_history.history;
@@ -2449,7 +2453,7 @@ impl Session {
             startup_turn_context.as_ref(),
             &[],
             &HashSet::new(),
-            None,
+            /*skills_outcome*/ None,
             &startup_cancellation_token,
         )
         .await?;
@@ -2535,8 +2539,13 @@ impl Session {
             let state = self.state.lock().await;
             state.session_configuration.clone()
         };
-        self.new_turn_from_configuration(sub_id, session_configuration, None, false)
-            .await
+        self.new_turn_from_configuration(
+            sub_id,
+            session_configuration,
+            /*final_output_json_schema*/ None,
+            /*sandbox_policy_changed*/ false,
+        )
+        .await
     }
 
     async fn build_settings_update_items(
@@ -3284,7 +3293,7 @@ impl Session {
     pub(crate) async fn record_model_warning(&self, message: impl Into<String>, ctx: &TurnContext) {
         self.services
             .session_telemetry
-            .counter("codex.model_warning", 1, &[]);
+            .counter("codex.model_warning", /*inc*/ 1, &[]);
         let item = ResponseItem::Message {
             id: None,
             role: "user".to_string(),
@@ -4186,7 +4195,7 @@ async fn submission_loop(sess: Arc<Session>, config: Arc<Config>, rx_sub: Receiv
                         state.session_configuration.collaboration_mode.with_updates(
                             model.clone(),
                             effort,
-                            None,
+                            /*developer_instructions*/ None,
                         )
                     };
                     handlers::override_turn_context(
@@ -4536,7 +4545,9 @@ mod handlers {
         current_context.session_telemetry.user_prompt(&items);
 
         // Attempt to inject input into current task.
-        if let Err(SteerInputError::NoActiveTurn(items)) = sess.steer_input(items, None).await {
+        if let Err(SteerInputError::NoActiveTurn(items)) =
+            sess.steer_input(items, /*expected_turn_id*/ None).await
+        {
             sess.refresh_mcp_servers_if_requested(&current_context)
                 .await;
             let regular_task = sess.take_startup_regular_task().await.unwrap_or_default();
@@ -5281,7 +5292,7 @@ async fn spawn_review_thread(
         sess.services.shell_zsh_path.as_ref(),
         sess.services.main_execve_wrapper_exe.as_ref(),
     )
-    .with_web_search_config(None)
+    .with_web_search_config(/*web_search_config*/ None)
     .with_allow_login_shell(config.permissions.allow_login_shell)
     .with_agent_roles(config.agent_roles.clone());
 
@@ -5964,7 +5975,7 @@ pub(crate) async fn run_turn(
             }
             Err(e) => {
                 info!("Turn error: {e:#}");
-                let event = EventMsg::Error(e.to_error_event(None));
+                let event = EventMsg::Error(e.to_error_event(/*message_prefix*/ None));
                 sess.send_event(&turn_context, event).await;
                 // let the user continue the conversation
                 break;
@@ -7031,7 +7042,8 @@ async fn handle_assistant_item_done_in_plan_mode(
     {
         maybe_complete_plan_item_from_message(sess, turn_context, state, item).await;
 
-        if let Some(turn_item) = handle_non_tool_response_item(sess, turn_context, item, true).await
+        if let Some(turn_item) =
+            handle_non_tool_response_item(sess, turn_context, item, /*plan_mode*/ true).await
         {
             emit_turn_item_in_plan_mode(
                 sess,
@@ -7044,7 +7056,7 @@ async fn handle_assistant_item_done_in_plan_mode(
         }
 
         record_completed_response_item(sess, turn_context, item).await;
-        if let Some(agent_message) = last_assistant_message_from_item(item, true) {
+        if let Some(agent_message) = last_assistant_message_from_item(item, /*plan_mode*/ true) {
             *last_agent_message = Some(agent_message);
         }
         return true;
@@ -7415,7 +7427,7 @@ async fn try_run_sampling_request(
 
 pub(super) fn get_last_assistant_message_from_turn(responses: &[ResponseItem]) -> Option<String> {
     for item in responses.iter().rev() {
-        if let Some(message) = last_assistant_message_from_item(item, false) {
+        if let Some(message) = last_assistant_message_from_item(item, /*plan_mode*/ false) {
             return Some(message);
         }
     }

--- a/codex-rs/core/src/codex_delegate.rs
+++ b/codex-rs/core/src/codex_delegate.rs
@@ -481,7 +481,7 @@ async fn handle_exec_approval(
             parent_session,
             &approval_id_for_op,
             cancel_token,
-            None,
+            /*review_cancel_token*/ None,
         )
         .await
     };
@@ -587,7 +587,7 @@ async fn handle_patch_approval(
             parent_session,
             &approval_id,
             cancel_token,
-            None,
+            /*review_cancel_token*/ None,
         )
         .await
     };
@@ -675,7 +675,7 @@ async fn maybe_auto_review_mcp_request_user_input(
         Arc::clone(parent_session),
         Arc::clone(parent_ctx),
         build_guardian_mcp_tool_review_request(&event.call_id, &invocation, metadata.as_ref()),
-        None,
+        /*retry_reason*/ None,
         review_cancel.clone(),
     );
     let decision = await_approval_with_cancel(

--- a/codex-rs/core/src/codex_thread.rs
+++ b/codex-rs/core/src/codex_thread.rs
@@ -173,7 +173,7 @@ impl CodexThread {
         if was_zero {
             self.codex
                 .session
-                .set_out_of_band_elicitation_pause_state(true);
+                .set_out_of_band_elicitation_pause_state(/*paused*/ true);
         }
 
         Ok(*guard)
@@ -192,7 +192,7 @@ impl CodexThread {
         if now_zero {
             self.codex
                 .session
-                .set_out_of_band_elicitation_pause_state(false);
+                .set_out_of_band_elicitation_pause_state(/*paused*/ false);
         }
 
         Ok(*guard)

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -163,7 +163,7 @@ async fn run_compact_task_inner(
                     continue;
                 }
                 sess.set_total_tokens_full(turn_context.as_ref()).await;
-                let event = EventMsg::Error(e.to_error_event(None));
+                let event = EventMsg::Error(e.to_error_event(/*message_prefix*/ None));
                 sess.send_event(&turn_context, event).await;
                 return Err(e);
             }
@@ -180,7 +180,7 @@ async fn run_compact_task_inner(
                     tokio::time::sleep(delay).await;
                     continue;
                 } else {
-                    let event = EventMsg::Error(e.to_error_event(None));
+                    let event = EventMsg::Error(e.to_error_event(/*message_prefix*/ None));
                     sess.send_event(&turn_context, event).await;
                     return Err(e);
                 }

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -101,7 +101,7 @@ async fn run_remote_compact_task_inner_impl(
         turn_context.as_ref(),
         &prompt_input,
         &HashSet::new(),
-        None,
+        /*skills_outcome*/ None,
         &CancellationToken::new(),
     )
     .await?;

--- a/codex-rs/core/src/config/agent_roles.rs
+++ b/codex-rs/core/src/config/agent_roles.rs
@@ -19,8 +19,10 @@ pub(crate) fn load_agent_roles(
     config_layer_stack: &ConfigLayerStack,
     startup_warnings: &mut Vec<String>,
 ) -> std::io::Result<BTreeMap<String, AgentRoleConfig>> {
-    let layers =
-        config_layer_stack.get_layers(ConfigLayerStackOrdering::LowestPrecedenceFirst, false);
+    let layers = config_layer_stack.get_layers(
+        ConfigLayerStackOrdering::LowestPrecedenceFirst,
+        /*include_disabled*/ false,
+    );
     if layers.is_empty() {
         return load_agent_roles_without_layers(cfg);
     }
@@ -450,13 +452,14 @@ fn discover_agent_roles_in_dir(
         if declared_role_files.contains(&agent_file) {
             continue;
         }
-        let parsed_file = match read_resolved_agent_role_file(&agent_file, None) {
-            Ok(parsed_file) => parsed_file,
-            Err(err) => {
-                push_agent_role_warning(startup_warnings, err);
-                continue;
-            }
-        };
+        let parsed_file =
+            match read_resolved_agent_role_file(&agent_file, /*role_name_hint*/ None) {
+                Ok(parsed_file) => parsed_file,
+                Err(err) => {
+                    push_agent_role_warning(startup_warnings, err);
+                    continue;
+                }
+            };
         let role_name = parsed_file.role_name;
         if roles.contains_key(&role_name) {
             push_agent_role_warning(

--- a/codex-rs/core/src/config/managed_features.rs
+++ b/codex-rs/core/src/config/managed_features.rs
@@ -81,11 +81,11 @@ impl ManagedFeatures {
     }
 
     pub fn enable(&mut self, feature: Feature) -> ConstraintResult<()> {
-        self.set_enabled(feature, true)
+        self.set_enabled(feature, /*enabled*/ true)
     }
 
     pub fn disable(&mut self, feature: Feature) -> ConstraintResult<()> {
-        self.set_enabled(feature, false)
+        self.set_enabled(feature, /*enabled*/ false)
     }
 }
 
@@ -321,7 +321,12 @@ pub(crate) fn validate_feature_requirements_in_config_toml(
             })
     }
 
-    validate_profile(cfg, None, &ConfigProfile::default(), feature_requirements)?;
+    validate_profile(
+        cfg,
+        /*profile_name*/ None,
+        &ConfigProfile::default(),
+        feature_requirements,
+    )?;
     for (profile_name, profile) in &cfg.profiles {
         validate_profile(cfg, Some(profile_name), profile, feature_requirements)?;
     }

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -1831,9 +1831,10 @@ fn resolve_permission_config_syntax(
     }
 
     let mut selection = None;
-    for layer in
-        config_layer_stack.get_layers(ConfigLayerStackOrdering::LowestPrecedenceFirst, false)
-    {
+    for layer in config_layer_stack.get_layers(
+        ConfigLayerStackOrdering::LowestPrecedenceFirst,
+        /*include_disabled*/ false,
+    ) {
         let Ok(layer_selection) = layer.config.clone().try_into::<PermissionSelectionToml>() else {
             continue;
         };

--- a/codex-rs/core/src/config/network_proxy_spec.rs
+++ b/codex-rs/core/src/config/network_proxy_spec.rs
@@ -77,7 +77,7 @@ impl NetworkProxySpec {
     }
 
     pub fn proxy_host_and_port(&self) -> String {
-        host_and_port_from_network_addr(&self.config.network.proxy_url, 3128)
+        host_and_port_from_network_addr(&self.config.network.proxy_url, /*default_port*/ 3128)
     }
 
     pub fn socks_enabled(&self) -> bool {

--- a/codex-rs/core/src/config/permissions.rs
+++ b/codex-rs/core/src/config/permissions.rs
@@ -281,9 +281,11 @@ fn parse_special_path(path: &str) -> Option<FileSystemSpecialPath> {
     match path {
         ":root" => Some(FileSystemSpecialPath::Root),
         ":minimal" => Some(FileSystemSpecialPath::Minimal),
-        ":project_roots" => Some(FileSystemSpecialPath::project_roots(None)),
+        ":project_roots" => Some(FileSystemSpecialPath::project_roots(/*subpath*/ None)),
         ":tmpdir" => Some(FileSystemSpecialPath::Tmpdir),
-        _ if path.starts_with(':') => Some(FileSystemSpecialPath::unknown(path, None)),
+        _ if path.starts_with(':') => {
+            Some(FileSystemSpecialPath::unknown(path, /*subpath*/ None))
+        }
         _ => None,
     }
 }

--- a/codex-rs/core/src/config/service.rs
+++ b/codex-rs/core/src/config/service.rs
@@ -183,7 +183,10 @@ impl ConfigService {
             origins: layers.origins(),
             layers: params.include_layers.then(|| {
                 layers
-                    .get_layers(ConfigLayerStackOrdering::HighestPrecedenceFirst, true)
+                    .get_layers(
+                        ConfigLayerStackOrdering::HighestPrecedenceFirst,
+                        /*include_disabled*/ true,
+                    )
                     .iter()
                     .map(|layer| layer.as_layer())
                     .collect()

--- a/codex-rs/core/src/config_loader/layer_io.rs
+++ b/codex-rs/core/src/config_loader/layer_io.rs
@@ -56,12 +56,13 @@ pub(super) async fn load_config_layers_internal(
         managed_config_path.unwrap_or_else(|| managed_config_default_path(codex_home)),
     )?;
 
-    let managed_config = read_config_from_path(&managed_config_path, false)
-        .await?
-        .map(|managed_config| MangedConfigFromFile {
-            managed_config,
-            file: managed_config_path.clone(),
-        });
+    let managed_config =
+        read_config_from_path(&managed_config_path, /*log_missing_as_info*/ false)
+            .await?
+            .map(|managed_config| MangedConfigFromFile {
+                managed_config,
+                file: managed_config_path.clone(),
+            });
 
     #[cfg(target_os = "macos")]
     let managed_preferences =

--- a/codex-rs/core/src/config_loader/mod.rs
+++ b/codex-rs/core/src/config_loader/mod.rs
@@ -209,7 +209,7 @@ pub async fn load_config_layers_state(
                     return Err(io_error_from_config_error(
                         io::ErrorKind::InvalidData,
                         config_error,
-                        None,
+                        /*source*/ None,
                     ));
                 }
                 return Err(err);
@@ -853,15 +853,20 @@ async fn load_project_layers(
                             &dot_codex_abs,
                             &layer_dir,
                             TomlValue::Table(toml::map::Map::new()),
-                            true,
+                            /*config_toml_exists*/ true,
                         ));
                         continue;
                     }
                 };
                 let config =
                     resolve_relative_paths_in_config_toml(config, dot_codex_abs.as_path())?;
-                let entry =
-                    project_layer_entry(trust_context, &dot_codex_abs, &layer_dir, config, true);
+                let entry = project_layer_entry(
+                    trust_context,
+                    &dot_codex_abs,
+                    &layer_dir,
+                    config,
+                    /*config_toml_exists*/ true,
+                );
                 layers.push(entry);
             }
             Err(err) => {
@@ -874,7 +879,7 @@ async fn load_project_layers(
                         &dot_codex_abs,
                         &layer_dir,
                         TomlValue::Table(toml::map::Map::new()),
-                        false,
+                        /*config_toml_exists*/ false,
                     ));
                 } else {
                     let config_file_display = config_file.as_path().display();

--- a/codex-rs/core/src/connectors.rs
+++ b/codex-rs/core/src/connectors.rs
@@ -104,9 +104,11 @@ pub async fn list_accessible_connectors_from_mcp_tools(
     config: &Config,
 ) -> anyhow::Result<Vec<AppInfo>> {
     Ok(
-        list_accessible_connectors_from_mcp_tools_with_options_and_status(config, false)
-            .await?
-            .connectors,
+        list_accessible_connectors_from_mcp_tools_with_options_and_status(
+            config, /*force_refetch*/ false,
+        )
+        .await?
+        .connectors,
     )
 }
 
@@ -186,7 +188,12 @@ pub async fn list_accessible_connectors_from_mcp_tools_with_options_and_status(
         });
     }
 
-    let mcp_servers = with_codex_apps_mcp(HashMap::new(), true, auth.as_ref(), config);
+    let mcp_servers = with_codex_apps_mcp(
+        HashMap::new(),
+        /*connectors_enabled*/ true,
+        auth.as_ref(),
+        config,
+    );
     if mcp_servers.is_empty() {
         return Ok(AccessibleConnectorsStatus {
             connectors: Vec::new(),
@@ -408,7 +415,7 @@ async fn list_directory_connectors_for_tool_suggest_with_auth(
     codex_connectors::list_all_connectors_with_options(
         cache_key,
         is_workspace_account,
-        false,
+        /*force_refetch*/ false,
         |path| {
             let access_token = access_token.clone();
             let account_id = account_id.clone();
@@ -459,7 +466,7 @@ async fn chatgpt_get_request_with_token<T: DeserializeOwned>(
 fn auth_manager_from_config(config: &Config) -> std::sync::Arc<AuthManager> {
     AuthManager::shared(
         config.codex_home.clone(),
-        false,
+        /*enable_codex_api_key_env*/ false,
         config.cli_auth_credentials_store_mode,
     )
 }

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -55,7 +55,9 @@ impl ContextManager {
     pub(crate) fn new() -> Self {
         Self {
             items: Vec::new(),
-            token_info: TokenUsageInfo::new_or_append(&None, &None, None),
+            token_info: TokenUsageInfo::new_or_append(
+                &None, &None, /*model_context_window*/ None,
+            ),
             reference_context_item: None,
         }
     }

--- a/codex-rs/core/src/default_client.rs
+++ b/codex-rs/core/src/default_client.rs
@@ -97,7 +97,7 @@ pub fn originator() -> Originator {
     }
 
     if std::env::var(CODEX_INTERNAL_ORIGINATOR_OVERRIDE_ENV_VAR).is_ok() {
-        let originator = get_originator_value(None);
+        let originator = get_originator_value(/*provided*/ None);
         if let Ok(mut guard) = ORIGINATOR.write() {
             match guard.as_ref() {
                 Some(originator) => return originator.clone(),
@@ -107,7 +107,7 @@ pub fn originator() -> Originator {
         return originator;
     }
 
-    get_originator_value(None)
+    get_originator_value(/*provided*/ None)
 }
 
 pub fn is_first_party_originator(originator_value: &str) -> bool {

--- a/codex-rs/core/src/environment_context.rs
+++ b/codex-rs/core/src/environment_context.rs
@@ -82,7 +82,14 @@ impl EnvironmentContext {
         } else {
             before_network
         };
-        EnvironmentContext::new(cwd, shell.clone(), current_date, timezone, network, None)
+        EnvironmentContext::new(
+            cwd,
+            shell.clone(),
+            current_date,
+            timezone,
+            network,
+            /*subagents*/ None,
+        )
     }
 
     pub fn from_turn_context(turn_context: &TurnContext, shell: &Shell) -> Self {
@@ -92,7 +99,7 @@ impl EnvironmentContext {
             turn_context.current_date.clone(),
             turn_context.timezone.clone(),
             Self::network_from_turn_context(turn_context),
-            None,
+            /*subagents*/ None,
         )
     }
 
@@ -103,7 +110,7 @@ impl EnvironmentContext {
             turn_context_item.current_date.clone(),
             turn_context_item.timezone.clone(),
             Self::network_from_turn_context_item(turn_context_item),
-            None,
+            /*subagents*/ None,
         )
     }
 

--- a/codex-rs/core/src/exec.rs
+++ b/codex-rs/core/src/exec.rs
@@ -877,12 +877,12 @@ async fn consume_truncated_output(
     let stdout_handle = tokio::spawn(read_capped(
         BufReader::new(stdout_reader),
         stdout_stream.clone(),
-        false,
+        /*is_stderr*/ false,
     ));
     let stderr_handle = tokio::spawn(read_capped(
         BufReader::new(stderr_reader),
         stdout_stream.clone(),
-        true,
+        /*is_stderr*/ true,
     ));
 
     let (exit_status, timed_out) = tokio::select! {

--- a/codex-rs/core/src/exec_policy.rs
+++ b/codex-rs/core/src/exec_policy.rs
@@ -449,7 +449,10 @@ pub async fn load_exec_policy(config_stack: &ConfigLayerStack) -> Result<Policy,
     // from each layer, so that higher-precedence layers can override
     // rules defined in lower-precedence ones.
     let mut policy_paths = Vec::new();
-    for layer in config_stack.get_layers(ConfigLayerStackOrdering::LowestPrecedenceFirst, false) {
+    for layer in config_stack.get_layers(
+        ConfigLayerStackOrdering::LowestPrecedenceFirst,
+        /*include_disabled*/ false,
+    ) {
         if let Some(config_folder) = layer.config_folder() {
             #[expect(clippy::expect_used)]
             let policy_dir = config_folder.join(RULES_DIR_NAME).expect("safe join");

--- a/codex-rs/core/src/external_agent_config.rs
+++ b/codex-rs/core/src/external_agent_config.rs
@@ -60,7 +60,7 @@ impl ExternalAgentConfigService {
     ) -> io::Result<Vec<ExternalAgentConfigMigrationItem>> {
         let mut items = Vec::new();
         if params.include_home {
-            self.detect_migrations(None, &mut items)?;
+            self.detect_migrations(/*repo_root*/ None, &mut items)?;
         }
 
         for cwd in params.cwds.as_deref().unwrap_or(&[]) {
@@ -81,7 +81,7 @@ impl ExternalAgentConfigService {
                     emit_migration_metric(
                         EXTERNAL_AGENT_CONFIG_IMPORT_METRIC,
                         ExternalAgentConfigMigrationItemType::Config,
-                        None,
+                        /*skills_count*/ None,
                     );
                 }
                 ExternalAgentConfigMigrationItemType::Skills => {
@@ -97,7 +97,7 @@ impl ExternalAgentConfigService {
                     emit_migration_metric(
                         EXTERNAL_AGENT_CONFIG_IMPORT_METRIC,
                         ExternalAgentConfigMigrationItemType::AgentsMd,
-                        None,
+                        /*skills_count*/ None,
                     );
                 }
                 ExternalAgentConfigMigrationItemType::McpServerConfig => {}
@@ -153,7 +153,7 @@ impl ExternalAgentConfigService {
                     emit_migration_metric(
                         EXTERNAL_AGENT_CONFIG_DETECT_METRIC,
                         ExternalAgentConfigMigrationItemType::Config,
-                        None,
+                        /*skills_count*/ None,
                     );
                 }
             }
@@ -210,7 +210,7 @@ impl ExternalAgentConfigService {
             emit_migration_metric(
                 EXTERNAL_AGENT_CONFIG_DETECT_METRIC,
                 ExternalAgentConfigMigrationItemType::AgentsMd,
-                None,
+                /*skills_count*/ None,
             );
         }
 
@@ -684,7 +684,7 @@ fn emit_migration_metric(
         .iter()
         .map(|(key, value)| (*key, value.as_str()))
         .collect::<Vec<_>>();
-    let _ = metrics.counter(metric_name, 1, &tag_refs);
+    let _ = metrics.counter(metric_name, /*inc*/ 1, &tag_refs);
 }
 
 #[cfg(test)]

--- a/codex-rs/core/src/features.rs
+++ b/codex-rs/core/src/features.rs
@@ -341,7 +341,7 @@ impl Features {
             if self.enabled(feature.id) != feature.default_enabled {
                 otel.counter(
                     "codex.feature.state",
-                    1,
+                    /*inc*/ 1,
                     &[
                         ("feature", feature.key),
                         ("value", &self.enabled(feature.id).to_string()),

--- a/codex-rs/core/src/guardian/approval_request.rs
+++ b/codex-rs/core/src/guardian/approval_request.rs
@@ -198,7 +198,7 @@ pub(crate) fn guardian_approval_request_to_json(
             *sandbox_permissions,
             additional_permissions.as_ref(),
             justification.as_ref(),
-            None,
+            /*tty*/ None,
         ),
         GuardianApprovalRequest::ExecCommand {
             id: _,

--- a/codex-rs/core/src/guardian/review.rs
+++ b/codex-rs/core/src/guardian/review.rs
@@ -221,7 +221,7 @@ pub(crate) async fn review_approval_request(
         Arc::clone(turn),
         request,
         retry_reason,
-        None,
+        /*external_cancel*/ None,
     )
     .await
 }

--- a/codex-rs/core/src/guardian/review_session.rs
+++ b/codex-rs/core/src/guardian/review_session.rs
@@ -266,7 +266,7 @@ impl GuardianReviewSessionManager {
                             params.spawn_config.clone(),
                             next_reuse_key.clone(),
                             spawn_cancel_token.clone(),
-                            None,
+                            /*initial_history*/ None,
                         )),
                     )
                     .await
@@ -297,7 +297,12 @@ impl GuardianReviewSessionManager {
 
         if trunk.reuse_key != next_reuse_key {
             return self
-                .run_ephemeral_review(params, next_reuse_key, deadline, None)
+                .run_ephemeral_review(
+                    params,
+                    next_reuse_key,
+                    deadline,
+                    /*initial_history*/ None,
+                )
                 .await;
         }
 

--- a/codex-rs/core/src/landlock.rs
+++ b/codex-rs/core/src/landlock.rs
@@ -43,7 +43,7 @@ where
         network_sandbox_policy,
         sandbox_policy_cwd,
         use_legacy_landlock,
-        allow_network_for_proxy(false),
+        allow_network_for_proxy(/*enforce_managed_network*/ false),
     );
     let arg0 = Some("codex-linux-sandbox");
     spawn_child_async(SpawnChildRequest {

--- a/codex-rs/core/src/mcp/mod.rs
+++ b/codex-rs/core/src/mcp/mod.rs
@@ -252,7 +252,7 @@ fn effective_mcp_servers(
 pub async fn collect_mcp_snapshot(config: &Config) -> McpListToolsResponseEvent {
     let auth_manager = AuthManager::shared(
         config.codex_home.clone(),
-        false,
+        /*enable_codex_api_key_env*/ false,
         config.cli_auth_credentials_store_mode,
     );
     let auth = auth_manager.auth().await;

--- a/codex-rs/core/src/mcp/skill_dependencies.rs
+++ b/codex-rs/core/src/mcp/skill_dependencies.rs
@@ -239,7 +239,7 @@ pub(crate) async fn maybe_install_mcp_dependencies(
         .await;
 
         let resolved_scopes = resolve_oauth_scopes(
-            None,
+            /*explicit_scopes*/ None,
             server_config.scopes.clone(),
             oauth_config.discovered_scopes.clone(),
         );

--- a/codex-rs/core/src/mcp_connection_manager.rs
+++ b/codex-rs/core/src/mcp_connection_manager.rs
@@ -1585,7 +1585,9 @@ async fn list_tools_for_client_uncached(
     client: &Arc<RmcpClient>,
     timeout: Option<Duration>,
 ) -> Result<Vec<ToolInfo>> {
-    let resp = client.list_tools_with_connector_ids(None, timeout).await?;
+    let resp = client
+        .list_tools_with_connector_ids(/*params*/ None, timeout)
+        .await?;
     let tools = resp
         .tools
         .into_iter()

--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -108,13 +108,15 @@ pub(crate) async fn handle_mcp_tool_call(
             &call_id,
             invocation,
             "MCP tool call blocked by app configuration".to_string(),
-            false,
+            /*already_started*/ false,
         )
         .await;
         let status = if result.is_ok() { "ok" } else { "error" };
-        turn_context
-            .session_telemetry
-            .counter("codex.mcp.call", 1, &[("status", status)]);
+        turn_context.session_telemetry.counter(
+            "codex.mcp.call",
+            /*inc*/ 1,
+            &[("status", status)],
+        );
         return CallToolResult::from_result(result);
     }
     let request_meta = build_mcp_tool_call_request_meta(&server, metadata.as_ref());
@@ -190,7 +192,7 @@ pub(crate) async fn handle_mcp_tool_call(
                     &call_id,
                     invocation,
                     message,
-                    true,
+                    /*already_started*/ true,
                 )
                 .await
             }
@@ -202,7 +204,7 @@ pub(crate) async fn handle_mcp_tool_call(
                     &call_id,
                     invocation,
                     message,
-                    true,
+                    /*already_started*/ true,
                 )
                 .await
             }
@@ -213,16 +215,18 @@ pub(crate) async fn handle_mcp_tool_call(
                     &call_id,
                     invocation,
                     message,
-                    true,
+                    /*already_started*/ true,
                 )
                 .await
             }
         };
 
         let status = if result.is_ok() { "ok" } else { "error" };
-        turn_context
-            .session_telemetry
-            .counter("codex.mcp.call", 1, &[("status", status)]);
+        turn_context.session_telemetry.counter(
+            "codex.mcp.call",
+            /*inc*/ 1,
+            &[("status", status)],
+        );
 
         return CallToolResult::from_result(result);
     }
@@ -263,7 +267,7 @@ pub(crate) async fn handle_mcp_tool_call(
     let status = if result.is_ok() { "ok" } else { "error" };
     turn_context
         .session_telemetry
-        .counter("codex.mcp.call", 1, &[("status", status)]);
+        .counter("codex.mcp.call", /*inc*/ 1, &[("status", status)]);
 
     CallToolResult::from_result(result)
 }

--- a/codex-rs/core/src/memories/phase1.rs
+++ b/codex-rs/core/src/memories/phase1.rs
@@ -97,7 +97,7 @@ pub(in crate::memories) async fn run(session: &Arc<Session>, config: &Config) {
     if claimed_candidates.is_empty() {
         session.services.session_telemetry.counter(
             metrics::MEMORY_PHASE_ONE_JOBS,
-            1,
+            /*inc*/ 1,
             &[("status", "skipped_no_candidates")],
         );
         return;
@@ -211,7 +211,7 @@ async fn claim_startup_jobs(
             warn!("state db claim_stage1_jobs_for_startup failed during memories startup: {err}");
             session.services.session_telemetry.counter(
                 metrics::MEMORY_PHASE_ONE_JOBS,
-                1,
+                /*inc*/ 1,
                 &[("status", "failed_claim")],
             );
             None

--- a/codex-rs/core/src/memories/phase2.rs
+++ b/codex-rs/core/src/memories/phase2.rs
@@ -61,7 +61,7 @@ pub(super) async fn run(session: &Arc<Session>, config: Arc<Config>) {
         Err(e) => {
             session.services.session_telemetry.counter(
                 metrics::MEMORY_PHASE_TWO_JOBS,
-                1,
+                /*inc*/ 1,
                 &[("status", e)],
             );
             return;
@@ -198,7 +198,7 @@ mod job {
             } => {
                 session_telemetry.counter(
                     metrics::MEMORY_PHASE_TWO_JOBS,
-                    1,
+                    /*inc*/ 1,
                     &[("status", "claimed")],
                 );
                 (ownership_token, input_watermark)
@@ -218,7 +218,7 @@ mod job {
     ) {
         session.services.session_telemetry.counter(
             metrics::MEMORY_PHASE_TWO_JOBS,
-            1,
+            /*inc*/ 1,
             &[("status", reason)],
         );
         if matches!(
@@ -250,7 +250,7 @@ mod job {
     ) {
         session.services.session_telemetry.counter(
             metrics::MEMORY_PHASE_TWO_JOBS,
-            1,
+            /*inc*/ 1,
             &[("status", reason)],
         );
         let _ = db
@@ -462,7 +462,7 @@ fn emit_metrics(session: &Arc<Session>, counters: Counters) {
 
     otel.counter(
         metrics::MEMORY_PHASE_TWO_JOBS,
-        1,
+        /*inc*/ 1,
         &[("status", "agent_spawned")],
     );
 }

--- a/codex-rs/core/src/memories/usage.rs
+++ b/codex-rs/core/src/memories/usage.rs
@@ -41,7 +41,7 @@ pub(crate) async fn emit_metric_for_tool_read(invocation: &ToolInvocation, succe
     for kind in kinds {
         invocation.turn.session_telemetry.counter(
             MEMORIES_USAGE_METRIC,
-            1,
+            /*inc*/ 1,
             &[
                 ("kind", kind.as_tag()),
                 ("tool", invocation.tool_name.as_str()),

--- a/codex-rs/core/src/models_manager/manager.rs
+++ b/codex-rs/core/src/models_manager/manager.rs
@@ -182,7 +182,7 @@ impl ModelsManager {
             auth_manager,
             model_catalog,
             collaboration_modes_config,
-            ModelProviderInfo::create_openai_provider(/* base_url */ None),
+            ModelProviderInfo::create_openai_provider(/*base_url*/ None),
         )
     }
 
@@ -523,7 +523,7 @@ impl ModelsManager {
         Self::new_with_provider(
             codex_home,
             auth_manager,
-            None,
+            /*model_catalog*/ None,
             CollaborationModesConfig::default(),
             provider,
         )

--- a/codex-rs/core/src/models_manager/model_info.rs
+++ b/codex-rs/core/src/models_manager/model_info.rs
@@ -80,7 +80,7 @@ pub(crate) fn model_info_from_slug(slug: &str) -> ModelInfo {
         default_verbosity: None,
         apply_patch_tool_type: None,
         web_search_tool_type: WebSearchToolType::Text,
-        truncation_policy: TruncationPolicyConfig::bytes(10_000),
+        truncation_policy: TruncationPolicyConfig::bytes(/*limit*/ 10_000),
         supports_parallel_tool_calls: false,
         supports_image_detail_original: false,
         context_window: Some(272_000),

--- a/codex-rs/core/src/network_proxy_loader.rs
+++ b/codex-rs/core/src/network_proxy_loader.rs
@@ -46,7 +46,7 @@ async fn build_config_state_with_mtimes() -> Result<(ConfigState, Vec<LayerMtime
     let overrides = LoaderOverrides::default();
     let config_layer_stack = load_config_layers_state(
         &codex_home,
-        None,
+        /*cwd*/ None,
         &cli_overrides,
         overrides,
         CloudRequirementsLoader::default(),
@@ -78,7 +78,10 @@ async fn build_config_state_with_mtimes() -> Result<(ConfigState, Vec<LayerMtime
 
 fn collect_layer_mtimes(stack: &ConfigLayerStack) -> Vec<LayerMtime> {
     stack
-        .get_layers(ConfigLayerStackOrdering::LowestPrecedenceFirst, false)
+        .get_layers(
+            ConfigLayerStackOrdering::LowestPrecedenceFirst,
+            /*include_disabled*/ false,
+        )
         .iter()
         .filter_map(|layer| {
             let path = match &layer.name {
@@ -113,7 +116,10 @@ fn network_constraints_from_trusted_layers(
     layers: &ConfigLayerStack,
 ) -> Result<NetworkProxyConstraints> {
     let mut constraints = NetworkProxyConstraints::default();
-    for layer in layers.get_layers(ConfigLayerStackOrdering::LowestPrecedenceFirst, false) {
+    for layer in layers.get_layers(
+        ConfigLayerStackOrdering::LowestPrecedenceFirst,
+        /*include_disabled*/ false,
+    ) {
         if is_user_controlled_layer(&layer.name) {
             continue;
         }
@@ -196,7 +202,10 @@ fn config_from_layers(
     exec_policy: &codex_execpolicy::Policy,
 ) -> Result<NetworkProxyConfig> {
     let mut config = NetworkProxyConfig::default();
-    for layer in layers.get_layers(ConfigLayerStackOrdering::LowestPrecedenceFirst, false) {
+    for layer in layers.get_layers(
+        ConfigLayerStackOrdering::LowestPrecedenceFirst,
+        /*include_disabled*/ false,
+    ) {
         let parsed = network_tables_from_toml(&layer.config)?;
         apply_network_tables(&mut config, parsed)?;
     }

--- a/codex-rs/core/src/personality_migration.rs
+++ b/codex-rs/core/src/personality_migration.rs
@@ -34,7 +34,7 @@ pub async fn maybe_migrate_personality(
     }
 
     let config_profile = config_toml
-        .get_config_profile(None)
+        .get_config_profile(/*override_profile*/ None)
         .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
     if config_toml.personality.is_some() || config_profile.personality.is_some() {
         create_marker(&marker_path).await?;
@@ -70,12 +70,12 @@ async fn has_recorded_sessions(codex_home: &Path, default_provider: &str) -> io:
         && let Some(ids) = state_db::list_thread_ids_db(
             Some(state_db_ctx.as_ref()),
             codex_home,
-            1,
-            None,
+            /*page_size*/ 1,
+            /*cursor*/ None,
             ThreadSortKey::CreatedAt,
             allowed_sources,
-            None,
-            false,
+            /*model_providers*/ None,
+            /*archived_only*/ false,
             "personality_migration",
         )
         .await
@@ -86,8 +86,8 @@ async fn has_recorded_sessions(codex_home: &Path, default_provider: &str) -> io:
 
     let sessions = get_threads_in_root(
         codex_home.join(SESSIONS_SUBDIR),
-        1,
-        None,
+        /*page_size*/ 1,
+        /*cursor*/ None,
         ThreadSortKey::CreatedAt,
         ThreadListConfig {
             allowed_sources,
@@ -103,8 +103,8 @@ async fn has_recorded_sessions(codex_home: &Path, default_provider: &str) -> io:
 
     let archived_sessions = get_threads_in_root(
         codex_home.join(ARCHIVED_SESSIONS_SUBDIR),
-        1,
-        None,
+        /*page_size*/ 1,
+        /*cursor*/ None,
         ThreadSortKey::CreatedAt,
         ThreadListConfig {
             allowed_sources,

--- a/codex-rs/core/src/plugins/manager.rs
+++ b/codex-rs/core/src/plugins/manager.rs
@@ -434,7 +434,11 @@ impl PluginsManager {
     }
 
     pub fn plugins_for_config(&self, config: &Config) -> PluginLoadOutcome {
-        self.plugins_for_layer_stack(&config.cwd, &config.config_layer_stack, false)
+        self.plugins_for_layer_stack(
+            &config.cwd,
+            &config.config_layer_stack,
+            /*force_reload*/ false,
+        )
     }
 
     pub fn plugins_for_layer_stack(

--- a/codex-rs/core/src/project_doc.rs
+++ b/codex-rs/core/src/project_doc.rs
@@ -190,10 +190,10 @@ pub fn discover_project_doc_paths(config: &Config) -> std::io::Result<Vec<PathBu
     }
 
     let mut merged = TomlValue::Table(toml::map::Map::new());
-    for layer in config
-        .config_layer_stack
-        .get_layers(ConfigLayerStackOrdering::LowestPrecedenceFirst, false)
-    {
+    for layer in config.config_layer_stack.get_layers(
+        ConfigLayerStackOrdering::LowestPrecedenceFirst,
+        /*include_disabled*/ false,
+    ) {
         if matches!(layer.name, ConfigLayerSource::Project { .. }) {
             continue;
         }

--- a/codex-rs/core/src/realtime_context.rs
+++ b/codex-rs/core/src/realtime_context.rs
@@ -105,12 +105,12 @@ async fn load_recent_threads(sess: &Session) -> Vec<ThreadMetadata> {
     match state_db
         .list_threads(
             MAX_RECENT_THREADS,
-            None,
+            /*anchor*/ None,
             SortKey::UpdatedAt,
             &[],
-            None,
-            false,
-            None,
+            /*model_providers*/ None,
+            /*archived_only*/ false,
+            /*search_term*/ None,
         )
         .await
     {
@@ -235,7 +235,7 @@ fn render_tree(root: &Path) -> Option<Vec<String>> {
     }
 
     let mut lines = Vec::new();
-    collect_tree_lines(root, 0, &mut lines);
+    collect_tree_lines(root, /*depth*/ 0, &mut lines);
     (!lines.is_empty()).then_some(lines)
 }
 

--- a/codex-rs/core/src/review_format.rs
+++ b/codex-rs/core/src/review_format.rs
@@ -68,7 +68,7 @@ pub fn render_review_output_text(output: &ReviewOutputEvent) -> String {
         sections.push(explanation.to_string());
     }
     if !output.findings.is_empty() {
-        let findings = format_review_findings_block(&output.findings, None);
+        let findings = format_review_findings_block(&output.findings, /*selection*/ None);
         let trimmed = findings.trim();
         if !trimmed.is_empty() {
             sections.push(trimmed.to_string());

--- a/codex-rs/core/src/rollout/list.rs
+++ b/codex-rs/core/src/rollout/list.rs
@@ -1223,7 +1223,7 @@ async fn find_thread_path_by_id_str_in_subdir(
         ..Default::default()
     };
 
-    let results = file_search::run(id_str, vec![root], options, None)
+    let results = file_search::run(id_str, vec![root], options, /*cancel_flag*/ None)
         .map_err(|e| io::Error::other(format!("file search failed: {e}")))?;
 
     let found = results.matches.into_iter().next().map(|m| m.full_path());

--- a/codex-rs/core/src/rollout/recorder.rs
+++ b/codex-rs/core/src/rollout/recorder.rs
@@ -180,7 +180,7 @@ impl RolloutRecorder {
             allowed_sources,
             model_providers,
             default_provider,
-            false,
+            /*archived*/ false,
             search_term,
         )
         .await
@@ -206,7 +206,7 @@ impl RolloutRecorder {
             allowed_sources,
             model_providers,
             default_provider,
-            true,
+            /*archived*/ true,
             search_term,
         )
         .await
@@ -320,8 +320,8 @@ impl RolloutRecorder {
                     sort_key,
                     allowed_sources,
                     model_providers,
-                    false,
-                    None,
+                    /*archived*/ false,
+                    /*search_term*/ None,
                 )
                 .await
                 else {
@@ -889,7 +889,7 @@ async fn write_and_reconcile_items(
         state_builder,
         items,
         default_provider,
-        None,
+        /*new_thread_memory_mode*/ None,
     )
     .await;
     Ok(())

--- a/codex-rs/core/src/sandboxing/mod.rs
+++ b/codex-rs/core/src/sandboxing/mod.rs
@@ -728,7 +728,13 @@ pub async fn execute_env(
     stdout_stream: Option<StdoutStream>,
 ) -> crate::error::Result<ExecToolCallOutput> {
     let effective_policy = exec_request.sandbox_policy.clone();
-    execute_exec_request(exec_request, &effective_policy, stdout_stream, None).await
+    execute_exec_request(
+        exec_request,
+        &effective_policy,
+        stdout_stream,
+        /*after_spawn*/ None,
+    )
+    .await
 }
 
 pub async fn execute_exec_request_with_after_spawn(

--- a/codex-rs/core/src/seatbelt.rs
+++ b/codex-rs/core/src/seatbelt.rs
@@ -45,8 +45,13 @@ pub async fn spawn_command_under_seatbelt(
     network: Option<&NetworkProxy>,
     mut env: HashMap<String, String>,
 ) -> std::io::Result<Child> {
-    let args =
-        create_seatbelt_command_args(command, sandbox_policy, sandbox_policy_cwd, false, network);
+    let args = create_seatbelt_command_args(
+        command,
+        sandbox_policy,
+        sandbox_policy_cwd,
+        /*enforce_managed_network*/ false,
+        network,
+    );
     let arg0 = None;
     env.insert(CODEX_SANDBOX_ENV_VAR.to_string(), "seatbelt".to_string());
     spawn_child_async(SpawnChildRequest {
@@ -338,7 +343,7 @@ pub(crate) fn create_seatbelt_command_args(
         sandbox_policy_cwd,
         enforce_managed_network,
         network,
-        None,
+        /*extensions*/ None,
     )
 }
 

--- a/codex-rs/core/src/shell.rs
+++ b/codex-rs/core/src/shell.rs
@@ -291,20 +291,20 @@ pub fn default_user_shell() -> Shell {
 
 fn default_user_shell_from_path(user_shell_path: Option<PathBuf>) -> Shell {
     if cfg!(windows) {
-        get_shell(ShellType::PowerShell, None).unwrap_or(ultimate_fallback_shell())
+        get_shell(ShellType::PowerShell, /*path*/ None).unwrap_or(ultimate_fallback_shell())
     } else {
         let user_default_shell = user_shell_path
             .and_then(|shell| detect_shell_type(&shell))
-            .and_then(|shell_type| get_shell(shell_type, None));
+            .and_then(|shell_type| get_shell(shell_type, /*path*/ None));
 
         let shell_with_fallback = if cfg!(target_os = "macos") {
             user_default_shell
-                .or_else(|| get_shell(ShellType::Zsh, None))
-                .or_else(|| get_shell(ShellType::Bash, None))
+                .or_else(|| get_shell(ShellType::Zsh, /*path*/ None))
+                .or_else(|| get_shell(ShellType::Bash, /*path*/ None))
         } else {
             user_default_shell
-                .or_else(|| get_shell(ShellType::Bash, None))
-                .or_else(|| get_shell(ShellType::Zsh, None))
+                .or_else(|| get_shell(ShellType::Bash, /*path*/ None))
+                .or_else(|| get_shell(ShellType::Zsh, /*path*/ None))
         };
 
         shell_with_fallback.unwrap_or(ultimate_fallback_shell())

--- a/codex-rs/core/src/shell_snapshot.rs
+++ b/codex-rs/core/src/shell_snapshot.rs
@@ -102,7 +102,7 @@ impl ShellSnapshot {
                 if let Some(failure_reason) = snapshot.as_ref().err() {
                     counter_tags.push(("failure_reason", *failure_reason));
                 }
-                session_telemetry.counter("codex.shell_snapshot", 1, &counter_tags);
+                session_telemetry.counter("codex.shell_snapshot", /*inc*/ 1, &counter_tags);
                 let _ = shell_snapshot_tx.send(snapshot.ok());
             }
             .instrument(snapshot_span),
@@ -199,7 +199,7 @@ async fn write_shell_snapshot(
     if shell_type == ShellType::PowerShell || shell_type == ShellType::Cmd {
         bail!("Shell snapshot not supported yet for {shell_type:?}");
     }
-    let shell = get_shell(shell_type.clone(), None)
+    let shell = get_shell(shell_type.clone(), /*path*/ None)
         .with_context(|| format!("No available shell for {shell_type:?}"))?;
 
     let raw_snapshot = capture_snapshot(&shell, cwd).await?;
@@ -243,13 +243,26 @@ fn strip_snapshot_preamble(snapshot: &str) -> Result<String> {
 async fn validate_snapshot(shell: &Shell, snapshot_path: &Path, cwd: &Path) -> Result<()> {
     let snapshot_path_display = snapshot_path.display();
     let script = format!("set -e; . \"{snapshot_path_display}\"");
-    run_script_with_timeout(shell, &script, SNAPSHOT_TIMEOUT, false, cwd)
-        .await
-        .map(|_| ())
+    run_script_with_timeout(
+        shell,
+        &script,
+        SNAPSHOT_TIMEOUT,
+        /*use_login_shell*/ false,
+        cwd,
+    )
+    .await
+    .map(|_| ())
 }
 
 async fn run_shell_script(shell: &Shell, script: &str, cwd: &Path) -> Result<String> {
-    run_script_with_timeout(shell, script, SNAPSHOT_TIMEOUT, true, cwd).await
+    run_script_with_timeout(
+        shell,
+        script,
+        SNAPSHOT_TIMEOUT,
+        /*use_login_shell*/ true,
+        cwd,
+    )
+    .await
 }
 
 async fn run_script_with_timeout(

--- a/codex-rs/core/src/skills/injection.rs
+++ b/codex-rs/core/src/skills/injection.rs
@@ -81,7 +81,7 @@ fn emit_skill_injected_metric(
 
     otel.counter(
         "codex.skill.injected",
-        1,
+        /*inc*/ 1,
         &[("status", status), ("skill", skill.name.as_str())],
     );
 }

--- a/codex-rs/core/src/skills/invocation_utils.rs
+++ b/codex-rs/core/src/skills/invocation_utils.rs
@@ -96,7 +96,7 @@ pub(crate) async fn maybe_emit_implicit_skill_invocation(
 
     turn_context.session_telemetry.counter(
         "codex.skill.injected",
-        1,
+        /*inc*/ 1,
         &[
             ("status", "ok"),
             ("skill", skill_name.as_str()),

--- a/codex-rs/core/src/skills/loader.rs
+++ b/codex-rs/core/src/skills/loader.rs
@@ -247,9 +247,10 @@ fn skill_roots_from_layer_stack_inner(
 ) -> Vec<SkillRoot> {
     let mut roots = Vec::new();
 
-    for layer in
-        config_layer_stack.get_layers(ConfigLayerStackOrdering::HighestPrecedenceFirst, true)
-    {
+    for layer in config_layer_stack.get_layers(
+        ConfigLayerStackOrdering::HighestPrecedenceFirst,
+        /*include_disabled*/ true,
+    ) {
         let Some(config_folder) = layer.config_folder() else {
             continue;
         };
@@ -321,9 +322,10 @@ fn repo_agents_skill_roots(config_layer_stack: &ConfigLayerStack, cwd: &Path) ->
 
 fn project_root_markers_from_stack(config_layer_stack: &ConfigLayerStack) -> Vec<String> {
     let mut merged = TomlValue::Table(toml::map::Map::new());
-    for layer in
-        config_layer_stack.get_layers(ConfigLayerStackOrdering::LowestPrecedenceFirst, false)
-    {
+    for layer in config_layer_stack.get_layers(
+        ConfigLayerStackOrdering::LowestPrecedenceFirst,
+        /*include_disabled*/ false,
+    ) {
         if matches!(layer.name, ConfigLayerSource::Project { .. }) {
             continue;
         }

--- a/codex-rs/core/src/skills/manager.rs
+++ b/codex-rs/core/src/skills/manager.rs
@@ -250,9 +250,10 @@ fn disabled_paths_from_stack(
     config_layer_stack: &crate::config_loader::ConfigLayerStack,
 ) -> HashSet<PathBuf> {
     let mut configs = HashMap::new();
-    for layer in
-        config_layer_stack.get_layers(ConfigLayerStackOrdering::LowestPrecedenceFirst, true)
-    {
+    for layer in config_layer_stack.get_layers(
+        ConfigLayerStackOrdering::LowestPrecedenceFirst,
+        /*include_disabled*/ true,
+    ) {
         if !matches!(
             layer.name,
             ConfigLayerSource::User { .. } | ConfigLayerSource::SessionFlags

--- a/codex-rs/core/src/state_db.rs
+++ b/codex-rs/core/src/state_db.rs
@@ -350,7 +350,7 @@ pub async fn reconcile_rollout(
             items,
             "reconcile_rollout",
             new_thread_memory_mode,
-            None,
+            /*updated_at_override*/ None,
         )
         .await;
         return;
@@ -472,10 +472,10 @@ pub async fn read_repair_rollout_path(
         Some(ctx),
         rollout_path,
         default_provider.as_str(),
-        None,
+        /*builder*/ None,
         &[],
         archived_only,
-        None,
+        /*new_thread_memory_mode*/ None,
     )
     .await;
 }

--- a/codex-rs/core/src/tasks/compact.rs
+++ b/codex-rs/core/src/tasks/compact.rs
@@ -32,14 +32,14 @@ impl SessionTask for CompactTask {
         let _ = if crate::compact::should_use_remote_compact_task(&ctx.provider) {
             let _ = session.services.session_telemetry.counter(
                 "codex.task.compact",
-                1,
+                /*inc*/ 1,
                 &[("type", "remote")],
             );
             crate::compact_remote::run_remote_compact_task(session.clone(), ctx).await
         } else {
             let _ = session.services.session_telemetry.counter(
                 "codex.task.compact",
-                1,
+                /*inc*/ 1,
                 &[("type", "local")],
             );
             crate::compact::run_compact_task(session.clone(), ctx, input).await

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -68,7 +68,11 @@ fn emit_turn_network_proxy_metric(
     } else {
         "false"
     };
-    session_telemetry.counter(TURN_NETWORK_PROXY_METRIC, 1, &[("active", active), tmp_mem]);
+    session_telemetry.counter(
+        TURN_NETWORK_PROXY_METRIC,
+        /*inc*/ 1,
+        &[("active", active), tmp_mem],
+    );
 }
 
 /// Thin wrapper that exposes the parts of [`Session`] task runners need.

--- a/codex-rs/core/src/tasks/regular.rs
+++ b/codex-rs/core/src/tasks/regular.rs
@@ -81,7 +81,7 @@ impl SessionTask for RegularTask {
     ) -> Option<String> {
         let sess = session.clone_session();
         let run_turn_span = trace_span!("run_turn");
-        sess.set_server_reasoning_included(false).await;
+        sess.set_server_reasoning_included(/*included*/ false).await;
         let prewarmed_client_session = self.take_prewarmed_session().await;
         run_turn(
             sess,

--- a/codex-rs/core/src/tasks/review.rs
+++ b/codex-rs/core/src/tasks/review.rs
@@ -55,11 +55,11 @@ impl SessionTask for ReviewTask {
         input: Vec<UserInput>,
         cancellation_token: CancellationToken,
     ) -> Option<String> {
-        let _ = session
-            .session
-            .services
-            .session_telemetry
-            .counter("codex.task.review", 1, &[]);
+        let _ = session.session.services.session_telemetry.counter(
+            "codex.task.review",
+            /*inc*/ 1,
+            &[],
+        );
 
         // Start sub-codex conversation and get the receiver for events.
         let output = match start_review_conversation(
@@ -80,7 +80,7 @@ impl SessionTask for ReviewTask {
     }
 
     async fn abort(&self, session: Arc<SessionTaskContext>, ctx: Arc<TurnContext>) {
-        exit_review_mode(session.clone_session(), None, ctx).await;
+        exit_review_mode(session.clone_session(), /*review_output*/ None, ctx).await;
     }
 }
 
@@ -121,8 +121,8 @@ async fn start_review_conversation(
         ctx.clone(),
         cancellation_token,
         SubAgentSource::Review,
-        None,
-        None,
+        /*final_output_json_schema*/ None,
+        /*initial_history*/ None,
     )
     .await)
         .ok()
@@ -217,7 +217,7 @@ pub(crate) async fn exit_review_mode(
             findings_str.push_str(text);
         }
         if !out.findings.is_empty() {
-            let block = format_review_findings_block(&out.findings, None);
+            let block = format_review_findings_block(&out.findings, /*selection*/ None);
             findings_str.push_str(&format!("\n{block}"));
         }
         let rendered =

--- a/codex-rs/core/src/tasks/undo.rs
+++ b/codex-rs/core/src/tasks/undo.rs
@@ -42,11 +42,11 @@ impl SessionTask for UndoTask {
         _input: Vec<UserInput>,
         cancellation_token: CancellationToken,
     ) -> Option<String> {
-        let _ = session
-            .session
-            .services
-            .session_telemetry
-            .counter("codex.task.undo", 1, &[]);
+        let _ = session.session.services.session_telemetry.counter(
+            "codex.task.undo",
+            /*inc*/ 1,
+            &[],
+        );
         let sess = session.clone_session();
         sess.send_event(
             ctx.as_ref(),

--- a/codex-rs/core/src/tasks/user_shell.rs
+++ b/codex-rs/core/src/tasks/user_shell.rs
@@ -101,7 +101,7 @@ pub(crate) async fn execute_user_shell_command(
     session
         .services
         .session_telemetry
-        .counter("codex.task.user_shell", 1, &[]);
+        .counter("codex.task.user_shell", /*inc*/ 1, &[]);
 
     if mode == UserShellCommandMode::StandaloneTurn {
         // Auxiliary mode runs within an existing active turn. That turn already
@@ -185,9 +185,14 @@ pub(crate) async fn execute_user_shell_command(
         tx_event: session.get_tx_event(),
     });
 
-    let exec_result = execute_exec_request(exec_env, &sandbox_policy, stdout_stream, None)
-        .or_cancel(&cancellation_token)
-        .await;
+    let exec_result = execute_exec_request(
+        exec_env,
+        &sandbox_policy,
+        stdout_stream,
+        /*after_spawn*/ None,
+    )
+    .or_cancel(&cancellation_token)
+    .await;
 
     match exec_result {
         Err(CancelErr::Cancelled) => {

--- a/codex-rs/core/src/terminal.rs
+++ b/codex-rs/core/src/terminal.rs
@@ -108,7 +108,13 @@ impl TerminalInfo {
         version: Option<String>,
         multiplexer: Option<Multiplexer>,
     ) -> Self {
-        Self::new(name, Some(term_program), version, None, multiplexer)
+        Self::new(
+            name,
+            Some(term_program),
+            version,
+            /*term*/ None,
+            multiplexer,
+        )
     }
 
     /// Creates terminal metadata from a `TERM_PROGRAM` match plus a `TERM` value.
@@ -128,7 +134,13 @@ impl TerminalInfo {
         version: Option<String>,
         multiplexer: Option<Multiplexer>,
     ) -> Self {
-        Self::new(name, None, version, None, multiplexer)
+        Self::new(
+            name,
+            /*term_program*/ None,
+            version,
+            /*term*/ None,
+            multiplexer,
+        )
     }
 
     /// Creates terminal metadata from a `TERM` capability value.
@@ -138,12 +150,24 @@ impl TerminalInfo {
         } else {
             TerminalName::Unknown
         };
-        Self::new(name, None, None, Some(term), multiplexer)
+        Self::new(
+            name,
+            /*term_program*/ None,
+            /*version*/ None,
+            Some(term),
+            multiplexer,
+        )
     }
 
     /// Creates terminal metadata for unknown terminals.
     fn unknown(multiplexer: Option<Multiplexer>) -> Self {
-        Self::new(TerminalName::Unknown, None, None, None, multiplexer)
+        Self::new(
+            TerminalName::Unknown,
+            /*term_program*/ None,
+            /*version*/ None,
+            /*term*/ None,
+            multiplexer,
+        )
     }
 
     /// Formats the terminal info as a User-Agent token.
@@ -279,11 +303,15 @@ fn detect_terminal_info_from_env(env: &dyn Environment) -> TerminalInfo {
     }
 
     if env.has("ITERM_SESSION_ID") || env.has("ITERM_PROFILE") || env.has("ITERM_PROFILE_NAME") {
-        return TerminalInfo::from_name(TerminalName::Iterm2, None, multiplexer);
+        return TerminalInfo::from_name(TerminalName::Iterm2, /*version*/ None, multiplexer);
     }
 
     if env.has("TERM_SESSION_ID") {
-        return TerminalInfo::from_name(TerminalName::AppleTerminal, None, multiplexer);
+        return TerminalInfo::from_name(
+            TerminalName::AppleTerminal,
+            /*version*/ None,
+            multiplexer,
+        );
     }
 
     if env.has("KITTY_WINDOW_ID")
@@ -292,7 +320,7 @@ fn detect_terminal_info_from_env(env: &dyn Environment) -> TerminalInfo {
             .map(|term| term.contains("kitty"))
             .unwrap_or(false)
     {
-        return TerminalInfo::from_name(TerminalName::Kitty, None, multiplexer);
+        return TerminalInfo::from_name(TerminalName::Kitty, /*version*/ None, multiplexer);
     }
 
     if env.has("ALACRITTY_SOCKET")
@@ -301,7 +329,11 @@ fn detect_terminal_info_from_env(env: &dyn Environment) -> TerminalInfo {
             .map(|term| term == "alacritty")
             .unwrap_or(false)
     {
-        return TerminalInfo::from_name(TerminalName::Alacritty, None, multiplexer);
+        return TerminalInfo::from_name(
+            TerminalName::Alacritty,
+            /*version*/ None,
+            multiplexer,
+        );
     }
 
     if env.has("KONSOLE_VERSION") {
@@ -310,7 +342,11 @@ fn detect_terminal_info_from_env(env: &dyn Environment) -> TerminalInfo {
     }
 
     if env.has("GNOME_TERMINAL_SCREEN") {
-        return TerminalInfo::from_name(TerminalName::GnomeTerminal, None, multiplexer);
+        return TerminalInfo::from_name(
+            TerminalName::GnomeTerminal,
+            /*version*/ None,
+            multiplexer,
+        );
     }
 
     if env.has("VTE_VERSION") {
@@ -319,7 +355,11 @@ fn detect_terminal_info_from_env(env: &dyn Environment) -> TerminalInfo {
     }
 
     if env.has("WT_SESSION") {
-        return TerminalInfo::from_name(TerminalName::WindowsTerminal, None, multiplexer);
+        return TerminalInfo::from_name(
+            TerminalName::WindowsTerminal,
+            /*version*/ None,
+            multiplexer,
+        );
     }
 
     if let Some(term) = env.var_non_empty("TERM") {

--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -173,7 +173,7 @@ impl ThreadManager {
             .model_providers
             .get(OPENAI_PROVIDER_ID)
             .cloned()
-            .unwrap_or_else(|| ModelProviderInfo::create_openai_provider(/* base_url */ None));
+            .unwrap_or_else(|| ModelProviderInfo::create_openai_provider(/*base_url*/ None));
         let (thread_created_tx, _) = broadcast::channel(THREAD_CREATED_CHANNEL_CAPACITY);
         let plugins_manager = Arc::new(PluginsManager::new(codex_home.clone()));
         let mcp_manager = Arc::new(McpManager::new(Arc::clone(&plugins_manager)));
@@ -213,7 +213,7 @@ impl ThreadManager {
         auth: CodexAuth,
         provider: ModelProviderInfo,
     ) -> Self {
-        set_thread_manager_test_mode_for_tests(true);
+        set_thread_manager_test_mode_for_tests(/*enabled*/ true);
         let codex_home = std::env::temp_dir().join(format!(
             "codex-thread-manager-test-{}",
             uuid::Uuid::new_v4()
@@ -233,7 +233,7 @@ impl ThreadManager {
         provider: ModelProviderInfo,
         codex_home: PathBuf,
     ) -> Self {
-        set_thread_manager_test_mode_for_tests(true);
+        set_thread_manager_test_mode_for_tests(/*enabled*/ true);
         let auth_manager = AuthManager::from_auth_for_testing(auth);
         let (thread_created_tx, _) = broadcast::channel(THREAD_CREATED_CHANNEL_CAPACITY);
         let plugins_manager = Arc::new(PluginsManager::new(codex_home.clone()));
@@ -241,7 +241,7 @@ impl ThreadManager {
         let skills_manager = Arc::new(SkillsManager::new(
             codex_home.clone(),
             Arc::clone(&plugins_manager),
-            true,
+            /*bundled_skills_enabled*/ true,
         ));
         let file_watcher = build_file_watcher(codex_home.clone(), Arc::clone(&skills_manager));
         Self {
@@ -340,7 +340,12 @@ impl ThreadManager {
     pub async fn start_thread(&self, config: Config) -> CodexResult<NewThread> {
         // Box delegated thread-spawn futures so these convenience wrappers do
         // not inline the full spawn path into every caller's async state.
-        Box::pin(self.start_thread_with_tools(config, Vec::new(), false)).await
+        Box::pin(self.start_thread_with_tools(
+            config,
+            Vec::new(),
+            /*persist_extended_history*/ false,
+        ))
+        .await
     }
 
     pub async fn start_thread_with_tools(
@@ -353,8 +358,8 @@ impl ThreadManager {
             config,
             dynamic_tools,
             persist_extended_history,
-            None,
-            None,
+            /*metrics_service_name*/ None,
+            /*parent_trace*/ None,
         ))
         .await
     }
@@ -392,7 +397,7 @@ impl ThreadManager {
             config,
             initial_history,
             auth_manager,
-            false,
+            /*persist_extended_history*/ false,
             parent_trace,
         ))
         .await
@@ -413,7 +418,7 @@ impl ThreadManager {
             self.agent_control(),
             Vec::new(),
             persist_extended_history,
-            None,
+            /*metrics_service_name*/ None,
             parent_trace,
         ))
         .await
@@ -498,7 +503,7 @@ impl ThreadManager {
             self.agent_control(),
             Vec::new(),
             persist_extended_history,
-            None,
+            /*metrics_service_name*/ None,
             parent_trace,
         ))
         .await
@@ -558,9 +563,9 @@ impl ThreadManagerState {
             config,
             agent_control,
             self.session_source.clone(),
-            false,
-            None,
-            None,
+            /*persist_extended_history*/ false,
+            /*metrics_service_name*/ None,
+            /*inherited_shell_snapshot*/ None,
         ))
         .await
     }
@@ -584,7 +589,7 @@ impl ThreadManagerState {
             persist_extended_history,
             metrics_service_name,
             inherited_shell_snapshot,
-            None,
+            /*parent_trace*/ None,
         ))
         .await
     }
@@ -605,10 +610,10 @@ impl ThreadManagerState {
             agent_control,
             session_source,
             Vec::new(),
-            false,
-            None,
+            /*persist_extended_history*/ false,
+            /*metrics_service_name*/ None,
             inherited_shell_snapshot,
-            None,
+            /*parent_trace*/ None,
         ))
         .await
     }
@@ -630,9 +635,9 @@ impl ThreadManagerState {
             session_source,
             Vec::new(),
             persist_extended_history,
-            None,
+            /*metrics_service_name*/ None,
             inherited_shell_snapshot,
-            None,
+            /*parent_trace*/ None,
         ))
         .await
     }
@@ -659,7 +664,7 @@ impl ThreadManagerState {
             dynamic_tools,
             persist_extended_history,
             metrics_service_name,
-            None,
+            /*inherited_shell_snapshot*/ None,
             parent_trace,
         ))
         .await

--- a/codex-rs/core/src/tools/code_mode/execute_handler.rs
+++ b/codex-rs/core/src/tools/code_mode/execute_handler.rs
@@ -84,7 +84,10 @@ impl CodeModeExecuteHandler {
                 Ok(message) => message,
                 Err(error) => return Err(FunctionCallError::RespondToModel(error)),
             };
-            handle_node_message(&exec, cell_id, message, None, started_at).await
+            handle_node_message(
+                &exec, cell_id, message, /*poll_max_output_tokens*/ None, started_at,
+            )
+            .await
         };
         match result {
             Ok(CodeModeSessionProgress::Finished(output))

--- a/codex-rs/core/src/tools/code_mode/mod.rs
+++ b/codex-rs/core/src/tools/code_mode/mod.rs
@@ -230,7 +230,7 @@ async fn build_enabled_tools(exec: &ExecContext) -> Vec<protocol::EnabledTool> {
     let mut out = router
         .specs()
         .into_iter()
-        .map(|spec| augment_tool_spec_for_code_mode(spec, true))
+        .map(|spec| augment_tool_spec_for_code_mode(spec, /*code_mode_enabled*/ true))
         .filter_map(enabled_tool_from_spec)
         .collect::<Vec<_>>();
     out.sort_by(|left, right| left.tool_name.cmp(&right.tool_name));

--- a/codex-rs/core/src/tools/context.rs
+++ b/codex-rs/core/src/tools/context.rs
@@ -230,7 +230,7 @@ impl ToolOutput for AbortedToolOutput {
                 vec![FunctionCallOutputContentItem::InputText {
                     text: self.message.clone(),
                 }],
-                None,
+                /*success*/ None,
             ),
         }
     }

--- a/codex-rs/core/src/tools/events.rs
+++ b/codex-rs/core/src/tools/events.rs
@@ -162,7 +162,14 @@ impl ToolEmitter {
             ) => {
                 emit_exec_stage(
                     ctx,
-                    ExecCommandInput::new(command, cwd.as_path(), parsed_cmd, *source, None, None),
+                    ExecCommandInput::new(
+                        command,
+                        cwd.as_path(),
+                        parsed_cmd,
+                        *source,
+                        /*interaction_input*/ None,
+                        /*process_id*/ None,
+                    ),
                     stage,
                 )
                 .await;
@@ -233,7 +240,7 @@ impl ToolEmitter {
                     changes.clone(),
                     String::new(),
                     (*message).to_string(),
-                    false,
+                    /*success*/ false,
                     PatchApplyStatus::Failed,
                 )
                 .await;
@@ -247,7 +254,7 @@ impl ToolEmitter {
                     changes.clone(),
                     String::new(),
                     (*message).to_string(),
-                    false,
+                    /*success*/ false,
                     PatchApplyStatus::Declined,
                 )
                 .await;
@@ -269,7 +276,7 @@ impl ToolEmitter {
                         cwd.as_path(),
                         parsed_cmd,
                         *source,
-                        None,
+                        /*interaction_input*/ None,
                         process_id.as_deref(),
                     ),
                     stage,

--- a/codex-rs/core/src/tools/handlers/agent_jobs.rs
+++ b/codex-rs/core/src/tools/handlers/agent_jobs.rs
@@ -584,7 +584,13 @@ async fn run_agent_job_loop(
     .await?;
     let initial_progress = db.get_agent_job_progress(job_id.as_str()).await?;
     progress_emitter
-        .maybe_emit(&session, &turn, job_id.as_str(), &initial_progress, true)
+        .maybe_emit(
+            &session,
+            &turn,
+            job_id.as_str(),
+            &initial_progress,
+            /*force*/ true,
+        )
         .await?;
 
     let mut cancel_requested = db.is_agent_job_cancelled(job_id.as_str()).await?;
@@ -633,7 +639,7 @@ async fn run_agent_job_loop(
                         db.mark_agent_job_item_pending(
                             job_id.as_str(),
                             item.item_id.as_str(),
-                            None,
+                            /*error_message*/ None,
                         )
                         .await?;
                         break;
@@ -719,7 +725,13 @@ async fn run_agent_job_loop(
             active_items.remove(&thread_id);
             let progress = db.get_agent_job_progress(job_id.as_str()).await?;
             progress_emitter
-                .maybe_emit(&session, &turn, job_id.as_str(), &progress, false)
+                .maybe_emit(
+                    &session,
+                    &turn,
+                    job_id.as_str(),
+                    &progress,
+                    /*force*/ false,
+                )
                 .await?;
         }
     }
@@ -738,7 +750,13 @@ async fn run_agent_job_loop(
             format!("agent job {job_id} cancelled with {pending_items} unprocessed items");
         let _ = session.notify_background_event(&turn, message).await;
         progress_emitter
-            .maybe_emit(&session, &turn, job_id.as_str(), &progress, true)
+            .maybe_emit(
+                &session,
+                &turn,
+                job_id.as_str(),
+                &progress,
+                /*force*/ true,
+            )
             .await?;
         return Ok(());
     }
@@ -750,7 +768,13 @@ async fn run_agent_job_loop(
     db.mark_agent_job_completed(job_id.as_str()).await?;
     let progress = db.get_agent_job_progress(job_id.as_str()).await?;
     progress_emitter
-        .maybe_emit(&session, &turn, job_id.as_str(), &progress, true)
+        .maybe_emit(
+            &session,
+            &turn,
+            job_id.as_str(),
+            &progress,
+            /*force*/ true,
+        )
         .await?;
     Ok(())
 }
@@ -759,7 +783,9 @@ async fn export_job_csv_snapshot(
     db: Arc<codex_state::StateRuntime>,
     job: &codex_state::AgentJob,
 ) -> anyhow::Result<()> {
-    let items = db.list_agent_job_items(job.id.as_str(), None, None).await?;
+    let items = db
+        .list_agent_job_items(job.id.as_str(), /*status*/ None, /*limit*/ None)
+        .await?;
     let csv_content = render_job_csv(job.input_headers.as_slice(), items.as_slice())
         .map_err(|err| anyhow::anyhow!("failed to render job csv for auto-export: {err}"))?;
     let output_path = PathBuf::from(job.output_csv_path.clone());
@@ -778,7 +804,11 @@ async fn recover_running_items(
     runtime_timeout: Duration,
 ) -> anyhow::Result<()> {
     let running_items = db
-        .list_agent_job_items(job_id, Some(codex_state::AgentJobItemStatus::Running), None)
+        .list_agent_job_items(
+            job_id,
+            Some(codex_state::AgentJobItemStatus::Running),
+            /*limit*/ None,
+        )
         .await?;
     for item in running_items {
         if is_item_stale(&item, runtime_timeout) {

--- a/codex-rs/core/src/tools/handlers/artifacts.rs
+++ b/codex-rs/core/src/tools/handlers/artifacts.rs
@@ -225,9 +225,9 @@ async fn emit_exec_begin(session: &Session, turn: &TurnContext, call_id: &str) {
         vec![ARTIFACTS_TOOL_NAME.to_string()],
         turn.cwd.clone(),
         ExecCommandSource::Agent,
-        true,
+        /*freeform*/ true,
     );
-    let ctx = ToolEventCtx::new(session, turn, call_id, None);
+    let ctx = ToolEventCtx::new(session, turn, call_id, /*turn_diff_tracker*/ None);
     emitter.emit(ctx, ToolEventStage::Begin).await;
 }
 
@@ -251,9 +251,9 @@ async fn emit_exec_end(
         vec![ARTIFACTS_TOOL_NAME.to_string()],
         turn.cwd.clone(),
         ExecCommandSource::Agent,
-        true,
+        /*freeform*/ true,
     );
-    let ctx = ToolEventCtx::new(session, turn, call_id, None);
+    let ctx = ToolEventCtx::new(session, turn, call_id, /*turn_diff_tracker*/ None);
     let stage = if success {
         ToolEventStage::Success(exec_output)
     } else {

--- a/codex-rs/core/src/tools/handlers/js_repl.rs
+++ b/codex-rs/core/src/tools/handlers/js_repl.rs
@@ -63,9 +63,9 @@ async fn emit_js_repl_exec_begin(
         vec!["js_repl".to_string()],
         turn.cwd.clone(),
         ExecCommandSource::Agent,
-        false,
+        /*freeform*/ false,
     );
-    let ctx = ToolEventCtx::new(session, turn, call_id, None);
+    let ctx = ToolEventCtx::new(session, turn, call_id, /*turn_diff_tracker*/ None);
     emitter.emit(ctx, ToolEventStage::Begin).await;
 }
 
@@ -82,9 +82,9 @@ async fn emit_js_repl_exec_end(
         vec!["js_repl".to_string()],
         turn.cwd.clone(),
         ExecCommandSource::Agent,
-        false,
+        /*freeform*/ false,
     );
-    let ctx = ToolEventCtx::new(session, turn, call_id, None);
+    let ctx = ToolEventCtx::new(session, turn, call_id, /*turn_diff_tracker*/ None);
     let stage = if error.is_some() {
         ToolEventStage::Failure(ToolEventFailure::Output(exec_output))
     } else {
@@ -169,7 +169,7 @@ impl ToolHandler for JsReplHandler {
             turn.as_ref(),
             &call_id,
             &content,
-            None,
+            /*error*/ None,
             started_at.elapsed(),
         )
         .await;

--- a/codex-rs/core/src/tools/handlers/multi_agents/resume_agent.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents/resume_agent.rs
@@ -103,7 +103,7 @@ impl ToolHandler for Handler {
             return Err(err);
         }
         turn.session_telemetry
-            .counter("codex.multi_agent.resume", 1, &[]);
+            .counter("codex.multi_agent.resume", /*inc*/ 1, &[]);
 
         Ok(ResumeAgentResult { status })
     }
@@ -150,7 +150,11 @@ async fn try_resume_closed_agent(
         .resume_agent_from_rollout(
             config,
             receiver_thread_id,
-            thread_spawn_source(session.conversation_id, child_depth, None),
+            thread_spawn_source(
+                session.conversation_id,
+                child_depth,
+                /*agent_role*/ None,
+            ),
         )
         .await
         .map_err(|err| collab_agent_error(receiver_thread_id, err))?;

--- a/codex-rs/core/src/tools/handlers/multi_agents/spawn.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents/spawn.rs
@@ -127,8 +127,11 @@ impl ToolHandler for Handler {
             .await;
         let new_thread_id = result?;
         let role_tag = role_name.unwrap_or(DEFAULT_ROLE_NAME);
-        turn.session_telemetry
-            .counter("codex.multi_agent.spawn", 1, &[("role", role_tag)]);
+        turn.session_telemetry.counter(
+            "codex.multi_agent.spawn",
+            /*inc*/ 1,
+            &[("role", role_tag)],
+        );
 
         Ok(SpawnAgentResult {
             agent_id: new_thread_id.to_string(),

--- a/codex-rs/core/src/tools/handlers/multi_agents/wait.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents/wait.rs
@@ -197,7 +197,7 @@ impl ToolOutput for WaitAgentResult {
     }
 
     fn to_response_item(&self, call_id: &str, payload: &ToolPayload) -> ResponseInputItem {
-        tool_output_response_item(call_id, payload, self, None, "wait_agent")
+        tool_output_response_item(call_id, payload, self, /*success*/ None, "wait_agent")
     }
 
     fn code_mode_result(&self, _payload: &ToolPayload) -> JsonValue {

--- a/codex-rs/core/src/tools/handlers/shell.rs
+++ b/codex-rs/core/src/tools/handlers/shell.rs
@@ -417,7 +417,12 @@ impl ShellHandler {
             source,
             freeform,
         );
-        let event_ctx = ToolEventCtx::new(session.as_ref(), turn.as_ref(), &call_id, None);
+        let event_ctx = ToolEventCtx::new(
+            session.as_ref(),
+            turn.as_ref(),
+            &call_id,
+            /*turn_diff_tracker*/ None,
+        );
         emitter.begin(event_ctx).await;
 
         let exec_approval_requirement = session
@@ -478,7 +483,12 @@ impl ShellHandler {
             )
             .await
             .map(|result| result.output);
-        let event_ctx = ToolEventCtx::new(session.as_ref(), turn.as_ref(), &call_id, None);
+        let event_ctx = ToolEventCtx::new(
+            session.as_ref(),
+            turn.as_ref(),
+            &call_id,
+            /*turn_diff_tracker*/ None,
+        );
         let content = emitter.finish(event_ctx, out).await?;
         Ok(FunctionToolOutput::from_text(content, Some(true)))
     }

--- a/codex-rs/core/src/tools/handlers/view_image.rs
+++ b/codex-rs/core/src/tools/handlers/view_image.rs
@@ -115,23 +115,19 @@ impl ToolHandler for ViewImageHandler {
         };
         let image_detail = use_original_detail.then_some(ImageDetail::Original);
 
-        let content = local_image_content_items_with_label_number(&abs_path, None, image_mode)
-            .into_iter()
-            .map(|item| match item {
-                ContentItem::InputText { text } => {
-                    FunctionCallOutputContentItem::InputText { text }
-                }
-                ContentItem::InputImage { image_url } => {
-                    FunctionCallOutputContentItem::InputImage {
-                        image_url,
-                        detail: image_detail,
-                    }
-                }
-                ContentItem::OutputText { text } => {
-                    FunctionCallOutputContentItem::InputText { text }
-                }
-            })
-            .collect();
+        let content = local_image_content_items_with_label_number(
+            &abs_path, /*label_number*/ None, image_mode,
+        )
+        .into_iter()
+        .map(|item| match item {
+            ContentItem::InputText { text } => FunctionCallOutputContentItem::InputText { text },
+            ContentItem::InputImage { image_url } => FunctionCallOutputContentItem::InputImage {
+                image_url,
+                detail: image_detail,
+            },
+            ContentItem::OutputText { text } => FunctionCallOutputContentItem::InputText { text },
+        })
+        .collect();
 
         session
             .send_event(

--- a/codex-rs/core/src/tools/js_repl/mod.rs
+++ b/codex-rs/core/src/tools/js_repl/mod.rs
@@ -792,7 +792,11 @@ impl JsReplManager {
     }
 
     fn summarize_tool_call_error(error: &str) -> JsReplToolCallResponseSummary {
-        Self::summarize_text_payload(None, JsReplToolCallPayloadKind::Error, error)
+        Self::summarize_text_payload(
+            /*response_type*/ None,
+            JsReplToolCallPayloadKind::Error,
+            error,
+        )
     }
 
     pub async fn reset(&self) -> Result<(), FunctionCallError> {
@@ -962,7 +966,7 @@ impl JsReplManager {
                     with_model_kernel_failure_message(
                         "js_repl kernel closed unexpectedly",
                         "response_channel_closed",
-                        None,
+                        /*stream_error*/ None,
                         &snapshot,
                     )
                 } else {
@@ -1531,7 +1535,13 @@ impl JsReplManager {
         if is_js_repl_internal_tool(&req.tool_name) {
             let error = "js_repl cannot invoke itself".to_string();
             let summary = Self::summarize_tool_call_error(&error);
-            Self::log_tool_call_response(&req, false, &summary, None, Some(&error));
+            Self::log_tool_call_response(
+                &req,
+                /*ok*/ false,
+                &summary,
+                /*response*/ None,
+                Some(&error),
+            );
             return RunToolResult {
                 id: req.id,
                 ok: false,
@@ -1610,7 +1620,13 @@ impl JsReplManager {
                 let summary = Self::summarize_tool_call_response(&response);
                 match serde_json::to_value(response) {
                     Ok(value) => {
-                        Self::log_tool_call_response(&req, true, &summary, Some(&value), None);
+                        Self::log_tool_call_response(
+                            &req,
+                            /*ok*/ true,
+                            &summary,
+                            Some(&value),
+                            /*error*/ None,
+                        );
                         RunToolResult {
                             id: req.id,
                             ok: true,
@@ -1621,7 +1637,13 @@ impl JsReplManager {
                     Err(err) => {
                         let error = format!("failed to serialize tool output: {err}");
                         let summary = Self::summarize_tool_call_error(&error);
-                        Self::log_tool_call_response(&req, false, &summary, None, Some(&error));
+                        Self::log_tool_call_response(
+                            &req,
+                            /*ok*/ false,
+                            &summary,
+                            /*response*/ None,
+                            Some(&error),
+                        );
                         RunToolResult {
                             id: req.id,
                             ok: false,
@@ -1634,7 +1656,13 @@ impl JsReplManager {
             Err(err) => {
                 let error = err.to_string();
                 let summary = Self::summarize_tool_call_error(&error);
-                Self::log_tool_call_response(&req, false, &summary, None, Some(&error));
+                Self::log_tool_call_response(
+                    &req,
+                    /*ok*/ false,
+                    &summary,
+                    /*response*/ None,
+                    Some(&error),
+                );
                 RunToolResult {
                     id: req.id,
                     ok: false,

--- a/codex-rs/core/src/tools/network_approval.rs
+++ b/codex-rs/core/src/tools/network_approval.rs
@@ -377,14 +377,14 @@ impl NetworkApprovalService {
                 .request_command_approval(
                     turn_context.as_ref(),
                     approval_id,
-                    None,
+                    /*approval_id*/ None,
                     prompt_command,
                     turn_context.cwd.clone(),
                     Some(prompt_reason),
                     Some(network_approval_context.clone()),
-                    None,
-                    None,
-                    None,
+                    /*proposed_execpolicy_amendment*/ None,
+                    /*additional_permissions*/ None,
+                    /*skill_metadata*/ None,
                     available_decisions,
                 )
                 .await

--- a/codex-rs/core/src/tools/registry.rs
+++ b/codex-rs/core/src/tools/registry.rs
@@ -217,7 +217,7 @@ impl ToolRegistry {
                     &call_id_owned,
                     log_payload.as_ref(),
                     Duration::ZERO,
-                    false,
+                    /*success*/ false,
                     &message,
                     &metric_tags,
                     mcp_server_ref,
@@ -234,7 +234,7 @@ impl ToolRegistry {
                 &call_id_owned,
                 log_payload.as_ref(),
                 Duration::ZERO,
-                false,
+                /*success*/ false,
                 &message,
                 &metric_tags,
                 mcp_server_ref,
@@ -341,7 +341,7 @@ impl ToolRegistryBuilder {
     }
 
     pub fn push_spec(&mut self, spec: ToolSpec) {
-        self.push_spec_with_parallel_support(spec, false);
+        self.push_spec_with_parallel_support(spec, /*supports_parallel_tool_calls*/ false);
     }
 
     pub fn push_spec_with_parallel_support(

--- a/codex-rs/core/src/tools/runtimes/apply_patch.rs
+++ b/codex-rs/core/src/tools/runtimes/apply_patch.rs
@@ -147,7 +147,13 @@ impl Approvable<ApplyPatchRequest> for ApplyPatchRuntime {
             }
             if let Some(reason) = retry_reason {
                 let rx_approve = session
-                    .request_patch_approval(turn, call_id, changes.clone(), Some(reason), None)
+                    .request_patch_approval(
+                        turn,
+                        call_id,
+                        changes.clone(),
+                        Some(reason),
+                        /*grant_root*/ None,
+                    )
                     .await;
                 return rx_approve.await.unwrap_or_default();
             }
@@ -158,7 +164,9 @@ impl Approvable<ApplyPatchRequest> for ApplyPatchRuntime {
                 approval_keys,
                 || async move {
                     let rx_approve = session
-                        .request_patch_approval(turn, call_id, changes, None, None)
+                        .request_patch_approval(
+                            turn, call_id, changes, /*reason*/ None, /*grant_root*/ None,
+                        )
                         .await;
                     rx_approve.await.unwrap_or_default()
                 },
@@ -198,7 +206,7 @@ impl ToolRuntime<ApplyPatchRequest, ExecToolCallOutput> for ApplyPatchRuntime {
     ) -> Result<ExecToolCallOutput, ToolError> {
         let spec = Self::build_command_spec(req, &ctx.turn.config.codex_home)?;
         let env = attempt
-            .env_for(spec, None)
+            .env_for(spec, /*network*/ None)
             .map_err(|err| ToolError::Codex(err.into()))?;
         let out = execute_env(env, Self::stdout_stream(ctx))
             .await

--- a/codex-rs/core/src/tools/runtimes/shell.rs
+++ b/codex-rs/core/src/tools/runtimes/shell.rs
@@ -174,7 +174,7 @@ impl Approvable<ShellRequest> for ShellRuntime {
                     .request_command_approval(
                         turn,
                         call_id,
-                        None,
+                        /*approval_id*/ None,
                         command,
                         cwd,
                         reason,
@@ -183,7 +183,7 @@ impl Approvable<ShellRequest> for ShellRuntime {
                             .proposed_execpolicy_amendment()
                             .cloned(),
                         req.additional_permissions.clone(),
-                        None,
+                        /*skill_metadata*/ None,
                         available_decisions,
                     )
                     .await

--- a/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
+++ b/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
@@ -435,7 +435,7 @@ impl CoreShellActionProvider {
                             cwd: workdir,
                             additional_permissions,
                         },
-                        None,
+                        /*retry_reason*/ None,
                     )
                     .await;
                 }
@@ -468,9 +468,9 @@ impl CoreShellActionProvider {
                         approval_id,
                         command,
                         workdir,
-                        None,
-                        None,
-                        None,
+                        /*reason*/ None,
+                        /*network_approval_context*/ None,
+                        /*proposed_execpolicy_amendment*/ None,
                         additional_permissions,
                         skill_metadata,
                         Some(available_decisions),
@@ -913,7 +913,7 @@ impl ShellCommandExecutor for CoreShellCommandExecutor {
                 justification: self.justification.clone(),
                 arg0: self.arg0.clone(),
             },
-            None,
+            /*stdout_stream*/ None,
             after_spawn,
         )
         .await?;

--- a/codex-rs/core/src/tools/runtimes/unified_exec.rs
+++ b/codex-rs/core/src/tools/runtimes/unified_exec.rs
@@ -143,7 +143,7 @@ impl Approvable<UnifiedExecRequest> for UnifiedExecRuntime<'_> {
                     .request_command_approval(
                         turn,
                         call_id,
-                        None,
+                        /*approval_id*/ None,
                         command,
                         cwd,
                         reason,
@@ -152,7 +152,7 @@ impl Approvable<UnifiedExecRequest> for UnifiedExecRuntime<'_> {
                             .proposed_execpolicy_amendment()
                             .cloned(),
                         req.additional_permissions.clone(),
-                        None,
+                        /*skill_metadata*/ None,
                         available_decisions,
                     )
                     .await

--- a/codex-rs/core/src/tools/sandboxing.rs
+++ b/codex-rs/core/src/tools/sandboxing.rs
@@ -94,7 +94,7 @@ where
 
     services.session_telemetry.counter(
         "codex.approval.requested",
-        1,
+        /*inc*/ 1,
         &[
             ("tool", tool_name),
             ("approved", decision.to_opaque_string()),

--- a/codex-rs/core/src/tools/spec.rs
+++ b/codex-rs/core/src/tools/spec.rs
@@ -2258,7 +2258,7 @@ fn push_tool_spec(
 ) {
     let spec = augment_tool_spec_for_code_mode(spec, code_mode_enabled);
     if supports_parallel_tool_calls {
-        builder.push_spec_with_parallel_support(spec, true);
+        builder.push_spec_with_parallel_support(spec, /*supports_parallel_tool_calls*/ true);
     } else {
         builder.push_spec(spec);
     }
@@ -2566,14 +2566,16 @@ pub(crate) fn build_specs_with_discoverable_tools(
             &nested_config,
             mcp_tools.clone(),
             app_tools.clone(),
-            None,
+            /*discoverable_tools*/ None,
             dynamic_tools,
         )
         .build();
         let mut enabled_tools = nested_specs
             .into_iter()
             .filter_map(|spec| {
-                let (name, description) = match augment_tool_spec_for_code_mode(spec.spec, true) {
+                let (name, description) = match augment_tool_spec_for_code_mode(
+                    spec.spec, /*code_mode_enabled*/ true,
+                ) {
                     ToolSpec::Function(tool) => (tool.name, tool.description),
                     ToolSpec::Freeform(tool) => (tool.name, tool.description),
                     _ => return None,
@@ -2586,14 +2588,14 @@ pub(crate) fn build_specs_with_discoverable_tools(
         push_tool_spec(
             &mut builder,
             create_code_mode_tool(&enabled_tools, config.code_mode_only_enabled),
-            false,
+            /*supports_parallel_tool_calls*/ false,
             config.code_mode_enabled,
         );
         builder.register_handler(PUBLIC_TOOL_NAME, code_mode_handler);
         push_tool_spec(
             &mut builder,
             create_exec_wait_tool(),
-            false,
+            /*supports_parallel_tool_calls*/ false,
             config.code_mode_enabled,
         );
         builder.register_handler(WAIT_TOOL_NAME, code_mode_wait_handler);
@@ -2604,7 +2606,7 @@ pub(crate) fn build_specs_with_discoverable_tools(
             push_tool_spec(
                 &mut builder,
                 create_shell_tool(exec_permission_approvals_enabled),
-                true,
+                /*supports_parallel_tool_calls*/ true,
                 config.code_mode_enabled,
             );
         }
@@ -2612,7 +2614,7 @@ pub(crate) fn build_specs_with_discoverable_tools(
             push_tool_spec(
                 &mut builder,
                 ToolSpec::LocalShell {},
-                true,
+                /*supports_parallel_tool_calls*/ true,
                 config.code_mode_enabled,
             );
         }
@@ -2623,13 +2625,13 @@ pub(crate) fn build_specs_with_discoverable_tools(
                     config.allow_login_shell,
                     exec_permission_approvals_enabled,
                 ),
-                true,
+                /*supports_parallel_tool_calls*/ true,
                 config.code_mode_enabled,
             );
             push_tool_spec(
                 &mut builder,
                 create_write_stdin_tool(),
-                false,
+                /*supports_parallel_tool_calls*/ false,
                 config.code_mode_enabled,
             );
             builder.register_handler("exec_command", unified_exec_handler.clone());
@@ -2645,7 +2647,7 @@ pub(crate) fn build_specs_with_discoverable_tools(
                     config.allow_login_shell,
                     exec_permission_approvals_enabled,
                 ),
-                true,
+                /*supports_parallel_tool_calls*/ true,
                 config.code_mode_enabled,
             );
         }
@@ -2663,19 +2665,19 @@ pub(crate) fn build_specs_with_discoverable_tools(
         push_tool_spec(
             &mut builder,
             create_list_mcp_resources_tool(),
-            true,
+            /*supports_parallel_tool_calls*/ true,
             config.code_mode_enabled,
         );
         push_tool_spec(
             &mut builder,
             create_list_mcp_resource_templates_tool(),
-            true,
+            /*supports_parallel_tool_calls*/ true,
             config.code_mode_enabled,
         );
         push_tool_spec(
             &mut builder,
             create_read_mcp_resource_tool(),
-            true,
+            /*supports_parallel_tool_calls*/ true,
             config.code_mode_enabled,
         );
         builder.register_handler("list_mcp_resources", mcp_resource_handler.clone());
@@ -2686,7 +2688,7 @@ pub(crate) fn build_specs_with_discoverable_tools(
     push_tool_spec(
         &mut builder,
         PLAN_TOOL.clone(),
-        false,
+        /*supports_parallel_tool_calls*/ false,
         config.code_mode_enabled,
     );
     builder.register_handler("update_plan", plan_handler);
@@ -2695,13 +2697,13 @@ pub(crate) fn build_specs_with_discoverable_tools(
         push_tool_spec(
             &mut builder,
             create_js_repl_tool(),
-            false,
+            /*supports_parallel_tool_calls*/ false,
             config.code_mode_enabled,
         );
         push_tool_spec(
             &mut builder,
             create_js_repl_reset_tool(),
-            false,
+            /*supports_parallel_tool_calls*/ false,
             config.code_mode_enabled,
         );
         builder.register_handler("js_repl", js_repl_handler);
@@ -2714,7 +2716,7 @@ pub(crate) fn build_specs_with_discoverable_tools(
             create_request_user_input_tool(CollaborationModesConfig {
                 default_mode_request_user_input: config.default_mode_request_user_input,
             }),
-            false,
+            /*supports_parallel_tool_calls*/ false,
             config.code_mode_enabled,
         );
         builder.register_handler("request_user_input", request_user_input_handler);
@@ -2724,7 +2726,7 @@ pub(crate) fn build_specs_with_discoverable_tools(
         push_tool_spec(
             &mut builder,
             create_request_permissions_tool(),
-            false,
+            /*supports_parallel_tool_calls*/ false,
             config.code_mode_enabled,
         );
         builder.register_handler("request_permissions", request_permissions_handler);
@@ -2737,7 +2739,7 @@ pub(crate) fn build_specs_with_discoverable_tools(
         push_tool_spec(
             &mut builder,
             create_tool_search_tool(&app_tools),
-            true,
+            /*supports_parallel_tool_calls*/ true,
             config.code_mode_enabled,
         );
         builder.register_handler(TOOL_SEARCH_TOOL_NAME, search_tool_handler);
@@ -2755,7 +2757,10 @@ pub(crate) fn build_specs_with_discoverable_tools(
             .as_ref()
             .filter(|tools| !tools.is_empty())
     {
-        builder.push_spec_with_parallel_support(create_tool_suggest_tool(discoverable_tools), true);
+        builder.push_spec_with_parallel_support(
+            create_tool_suggest_tool(discoverable_tools),
+            /*supports_parallel_tool_calls*/ true,
+        );
         builder.register_handler(TOOL_SUGGEST_TOOL_NAME, tool_suggest_handler);
     }
 
@@ -2765,7 +2770,7 @@ pub(crate) fn build_specs_with_discoverable_tools(
                 push_tool_spec(
                     &mut builder,
                     create_apply_patch_freeform_tool(),
-                    false,
+                    /*supports_parallel_tool_calls*/ false,
                     config.code_mode_enabled,
                 );
             }
@@ -2773,7 +2778,7 @@ pub(crate) fn build_specs_with_discoverable_tools(
                 push_tool_spec(
                     &mut builder,
                     create_apply_patch_json_tool(),
-                    false,
+                    /*supports_parallel_tool_calls*/ false,
                     config.code_mode_enabled,
                 );
             }
@@ -2789,7 +2794,7 @@ pub(crate) fn build_specs_with_discoverable_tools(
         push_tool_spec(
             &mut builder,
             create_grep_files_tool(),
-            true,
+            /*supports_parallel_tool_calls*/ true,
             config.code_mode_enabled,
         );
         builder.register_handler("grep_files", grep_files_handler);
@@ -2803,7 +2808,7 @@ pub(crate) fn build_specs_with_discoverable_tools(
         push_tool_spec(
             &mut builder,
             create_read_file_tool(),
-            true,
+            /*supports_parallel_tool_calls*/ true,
             config.code_mode_enabled,
         );
         builder.register_handler("read_file", read_file_handler);
@@ -2818,7 +2823,7 @@ pub(crate) fn build_specs_with_discoverable_tools(
         push_tool_spec(
             &mut builder,
             create_list_dir_tool(),
-            true,
+            /*supports_parallel_tool_calls*/ true,
             config.code_mode_enabled,
         );
         builder.register_handler("list_dir", list_dir_handler);
@@ -2832,7 +2837,7 @@ pub(crate) fn build_specs_with_discoverable_tools(
         push_tool_spec(
             &mut builder,
             create_test_sync_tool(),
-            true,
+            /*supports_parallel_tool_calls*/ true,
             config.code_mode_enabled,
         );
         builder.register_handler("test_sync_tool", test_sync_handler);
@@ -2873,7 +2878,7 @@ pub(crate) fn build_specs_with_discoverable_tools(
                     .and_then(|cfg| cfg.search_context_size),
                 search_content_types,
             },
-            false,
+            /*supports_parallel_tool_calls*/ false,
             config.code_mode_enabled,
         );
     }
@@ -2884,7 +2889,7 @@ pub(crate) fn build_specs_with_discoverable_tools(
             ToolSpec::ImageGeneration {
                 output_format: "png".to_string(),
             },
-            false,
+            /*supports_parallel_tool_calls*/ false,
             config.code_mode_enabled,
         );
     }
@@ -2892,7 +2897,7 @@ pub(crate) fn build_specs_with_discoverable_tools(
     push_tool_spec(
         &mut builder,
         create_view_image_tool(config.can_request_original_image_detail),
-        true,
+        /*supports_parallel_tool_calls*/ true,
         config.code_mode_enabled,
     );
     builder.register_handler("view_image", view_image_handler);
@@ -2901,7 +2906,7 @@ pub(crate) fn build_specs_with_discoverable_tools(
         push_tool_spec(
             &mut builder,
             create_artifacts_tool(),
-            false,
+            /*supports_parallel_tool_calls*/ false,
             config.code_mode_enabled,
         );
         builder.register_handler("artifacts", artifacts_handler);
@@ -2911,31 +2916,31 @@ pub(crate) fn build_specs_with_discoverable_tools(
         push_tool_spec(
             &mut builder,
             create_spawn_agent_tool(config),
-            false,
+            /*supports_parallel_tool_calls*/ false,
             config.code_mode_enabled,
         );
         push_tool_spec(
             &mut builder,
             create_send_input_tool(),
-            false,
+            /*supports_parallel_tool_calls*/ false,
             config.code_mode_enabled,
         );
         push_tool_spec(
             &mut builder,
             create_resume_agent_tool(),
-            false,
+            /*supports_parallel_tool_calls*/ false,
             config.code_mode_enabled,
         );
         push_tool_spec(
             &mut builder,
             create_wait_agent_tool(),
-            false,
+            /*supports_parallel_tool_calls*/ false,
             config.code_mode_enabled,
         );
         push_tool_spec(
             &mut builder,
             create_close_agent_tool(),
-            false,
+            /*supports_parallel_tool_calls*/ false,
             config.code_mode_enabled,
         );
         builder.register_handler("spawn_agent", Arc::new(SpawnAgentHandler));
@@ -2950,7 +2955,7 @@ pub(crate) fn build_specs_with_discoverable_tools(
         push_tool_spec(
             &mut builder,
             create_spawn_agents_on_csv_tool(),
-            false,
+            /*supports_parallel_tool_calls*/ false,
             config.code_mode_enabled,
         );
         builder.register_handler("spawn_agents_on_csv", agent_jobs_handler.clone());
@@ -2958,7 +2963,7 @@ pub(crate) fn build_specs_with_discoverable_tools(
             push_tool_spec(
                 &mut builder,
                 create_report_agent_job_result_tool(),
-                false,
+                /*supports_parallel_tool_calls*/ false,
                 config.code_mode_enabled,
             );
             builder.register_handler("report_agent_job_result", agent_jobs_handler);
@@ -2975,7 +2980,7 @@ pub(crate) fn build_specs_with_discoverable_tools(
                     push_tool_spec(
                         &mut builder,
                         ToolSpec::Function(converted_tool),
-                        false,
+                        /*supports_parallel_tool_calls*/ false,
                         config.code_mode_enabled,
                     );
                     builder.register_handler(name, mcp_handler.clone());
@@ -2994,7 +2999,7 @@ pub(crate) fn build_specs_with_discoverable_tools(
                     push_tool_spec(
                         &mut builder,
                         ToolSpec::Function(converted_tool),
-                        false,
+                        /*supports_parallel_tool_calls*/ false,
                         config.code_mode_enabled,
                     );
                     builder.register_handler(tool.name.clone(), dynamic_tool_handler.clone());

--- a/codex-rs/core/src/turn_metadata.rs
+++ b/codex-rs/core/src/turn_metadata.rs
@@ -104,7 +104,7 @@ pub async fn build_turn_metadata_header(cwd: &Path, sandbox: Option<&str>) -> Op
     }
 
     build_turn_metadata_bag(
-        None,
+        /*turn_id*/ None,
         sandbox.map(ToString::to_string),
         repo_root,
         Some(WorkspaceGitMetadata {
@@ -135,7 +135,12 @@ impl TurnMetadataState {
     ) -> Self {
         let repo_root = get_git_repo_root(&cwd).map(|root| root.to_string_lossy().into_owned());
         let sandbox = Some(sandbox_tag(sandbox_policy, windows_sandbox_level).to_string());
-        let base_metadata = build_turn_metadata_bag(Some(turn_id), sandbox, None, None);
+        let base_metadata = build_turn_metadata_bag(
+            Some(turn_id),
+            sandbox,
+            /*repo_root*/ None,
+            /*workspace_git_metadata*/ None,
+        );
         let base_header = base_metadata
             .to_header_value()
             .unwrap_or_else(|| "{}".to_string());

--- a/codex-rs/core/src/unified_exec/async_watcher.rs
+++ b/codex-rs/core/src/unified_exec/async_watcher.rs
@@ -196,7 +196,12 @@ pub(crate) async fn emit_exec_end_for_unified_exec(
         duration,
         timed_out: false,
     };
-    let event_ctx = ToolEventCtx::new(session_ref.as_ref(), turn_ref.as_ref(), &call_id, None);
+    let event_ctx = ToolEventCtx::new(
+        session_ref.as_ref(),
+        turn_ref.as_ref(),
+        &call_id,
+        /*turn_diff_tracker*/ None,
+    );
     let emitter = ToolEmitter::unified_exec(
         &command,
         cwd,

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -180,7 +180,7 @@ impl UnifiedExecProcessManager {
             context.session.as_ref(),
             context.turn.as_ref(),
             &context.call_id,
-            None,
+            /*turn_diff_tracker*/ None,
         );
         let emitter = ToolEmitter::unified_exec(
             &request.command,

--- a/codex-rs/core/src/windows_sandbox.rs
+++ b/codex-rs/core/src/windows_sandbox.rs
@@ -375,7 +375,7 @@ fn emit_windows_sandbox_setup_success_metrics(
     );
     let _ = metrics.counter(
         "codex.windows_sandbox.setup_success",
-        1,
+        /*inc*/ 1,
         &[("originator", originator_tag), ("mode", mode_tag)],
     );
 }
@@ -401,7 +401,7 @@ fn emit_windows_sandbox_setup_failure_metrics(
     );
     let _ = metrics.counter(
         "codex.windows_sandbox.setup_failure",
-        1,
+        /*inc*/ 1,
         &[("originator", originator_tag), ("mode", mode_tag)],
     );
 
@@ -426,7 +426,7 @@ fn emit_windows_sandbox_setup_failure_metrics(
     } else {
         let _ = metrics.counter(
             "codex.windows_sandbox.legacy_setup_preflight_failed",
-            1,
+            /*inc*/ 1,
             &[("originator", originator_tag)],
         );
     }

--- a/codex-rs/core/tests/common/lib.rs
+++ b/codex-rs/core/tests/common/lib.rs
@@ -25,8 +25,8 @@ pub mod zsh_fork;
 
 #[ctor]
 fn enable_deterministic_unified_exec_process_ids_for_tests() {
-    codex_core::test_support::set_thread_manager_test_mode(true);
-    codex_core::test_support::set_deterministic_process_ids(true);
+    codex_core::test_support::set_thread_manager_test_mode(/*enabled*/ true);
+    codex_core::test_support::set_deterministic_process_ids(/*enabled*/ true);
 }
 
 #[ctor]
@@ -79,7 +79,7 @@ pub fn test_path_buf_with_windows(unix_path: &str, windows_path: Option<&str>) -
 }
 
 pub fn test_path_buf(unix_path: &str) -> PathBuf {
-    test_path_buf_with_windows(unix_path, None)
+    test_path_buf_with_windows(unix_path, /*windows_path*/ None)
 }
 
 pub fn test_absolute_path_with_windows(
@@ -91,7 +91,7 @@ pub fn test_absolute_path_with_windows(
 }
 
 pub fn test_absolute_path(unix_path: &str) -> AbsolutePathBuf {
-    test_absolute_path_with_windows(unix_path, None)
+    test_absolute_path_with_windows(unix_path, /*windows_path*/ None)
 }
 
 pub fn test_tmp_path() -> AbsolutePathBuf {
@@ -264,7 +264,7 @@ pub fn sandbox_network_env_var() -> &'static str {
 }
 
 pub fn format_with_current_shell(command: &str) -> Vec<String> {
-    codex_core::shell::default_user_shell().derive_exec_args(command, true)
+    codex_core::shell::default_user_shell().derive_exec_args(command, /*use_login_shell*/ true)
 }
 
 pub fn format_with_current_shell_display(command: &str) -> String {
@@ -273,7 +273,8 @@ pub fn format_with_current_shell_display(command: &str) -> String {
 }
 
 pub fn format_with_current_shell_non_login(command: &str) -> Vec<String> {
-    codex_core::shell::default_user_shell().derive_exec_args(command, false)
+    codex_core::shell::default_user_shell()
+        .derive_exec_args(command, /*use_login_shell*/ false)
 }
 
 pub fn format_with_current_shell_display_non_login(command: &str) -> String {

--- a/codex-rs/core/tests/common/streaming_sse.rs
+++ b/codex-rs/core/tests/common/streaming_sse.rs
@@ -81,7 +81,7 @@ pub async fn start_streaming_sse_server(
                     tokio::spawn(async move {
                         let (request, body_prefix) = read_http_request(&mut stream).await;
                         let Some((method, path)) = parse_request_line(&request) else {
-                            let _ = write_http_response(&mut stream, 400, "bad request", "text/plain").await;
+                            let _ = write_http_response(&mut stream, /*status*/ 400, "bad request", "text/plain").await;
                             return;
                         };
 
@@ -90,7 +90,7 @@ pub async fn start_streaming_sse_server(
                                 .await
                                 .is_err()
                             {
-                                let _ = write_http_response(&mut stream, 400, "bad request", "text/plain").await;
+                                let _ = write_http_response(&mut stream, /*status*/ 400, "bad request", "text/plain").await;
                                 return;
                             }
                             let body = serde_json::json!({
@@ -98,7 +98,7 @@ pub async fn start_streaming_sse_server(
                                 "object": "list"
                             })
                             .to_string();
-                            let _ = write_http_response(&mut stream, 200, &body, "application/json").await;
+                            let _ = write_http_response(&mut stream, /*status*/ 200, &body, "application/json").await;
                             return;
                         }
 
@@ -108,13 +108,13 @@ pub async fn start_streaming_sse_server(
                             {
                                 Ok(body) => body,
                                 Err(_) => {
-                                    let _ = write_http_response(&mut stream, 400, "bad request", "text/plain").await;
+                                    let _ = write_http_response(&mut stream, /*status*/ 400, "bad request", "text/plain").await;
                                     return;
                                 }
                             };
                             requests.lock().await.push(body);
                             let Some((chunks, completion)) = take_next_stream(&state).await else {
-                                let _ = write_http_response(&mut stream, 500, "no responses queued", "text/plain").await;
+                                let _ = write_http_response(&mut stream, /*status*/ 500, "no responses queued", "text/plain").await;
                                 return;
                             };
 
@@ -138,7 +138,7 @@ pub async fn start_streaming_sse_server(
                             return;
                         }
 
-                        let _ = write_http_response(&mut stream, 404, "not found", "text/plain").await;
+                        let _ = write_http_response(&mut stream, /*status*/ 404, "not found", "text/plain").await;
                     });
                 }
             }

--- a/codex-rs/core/tests/common/test_codex.rs
+++ b/codex-rs/core/tests/common/test_codex.rs
@@ -105,7 +105,7 @@ impl TestCodexBuilder {
             Some(home) => home,
             None => Arc::new(TempDir::new()?),
         };
-        Box::pin(self.build_with_home(server, home, None)).await
+        Box::pin(self.build_with_home(server, home, /*resume_from*/ None)).await
     }
 
     pub async fn build_with_streaming_server(
@@ -117,7 +117,12 @@ impl TestCodexBuilder {
             Some(home) => home,
             None => Arc::new(TempDir::new()?),
         };
-        Box::pin(self.build_with_home_and_base_url(format!("{base_url}/v1"), home, None)).await
+        Box::pin(self.build_with_home_and_base_url(
+            format!("{base_url}/v1"),
+            home,
+            /*resume_from*/ None,
+        ))
+        .await
     }
 
     pub async fn build_with_websocket_server(
@@ -138,7 +143,7 @@ impl TestCodexBuilder {
                 .enable(Feature::ResponsesWebsockets)
                 .expect("test config should allow feature update");
         }));
-        Box::pin(self.build_with_home_and_base_url(base_url, home, None)).await
+        Box::pin(self.build_with_home_and_base_url(base_url, home, /*resume_from*/ None)).await
     }
 
     pub async fn resume(
@@ -202,7 +207,7 @@ impl TestCodexBuilder {
                     config.clone(),
                     path,
                     auth_manager,
-                    None,
+                    /*parent_trace*/ None,
                 ))
                 .await?
             }
@@ -226,7 +231,7 @@ impl TestCodexBuilder {
     ) -> anyhow::Result<(Config, Arc<TempDir>)> {
         let model_provider = ModelProviderInfo {
             base_url: Some(base_url),
-            ..built_in_model_providers(/* openai_base_url */ None)["openai"].clone()
+            ..built_in_model_providers(/*openai_base_url*/ None)["openai"].clone()
         };
         let cwd = Arc::new(TempDir::new()?);
         let mut config = load_default_config_for_test(home).await;
@@ -362,8 +367,13 @@ impl TestCodex {
         approval_policy: AskForApproval,
         sandbox_policy: SandboxPolicy,
     ) -> Result<()> {
-        self.submit_turn_with_context(prompt, approval_policy, sandbox_policy, None)
-            .await
+        self.submit_turn_with_context(
+            prompt,
+            approval_policy,
+            sandbox_policy,
+            /*service_tier*/ None,
+        )
+        .await
     }
 
     async fn submit_turn_with_context(

--- a/codex-rs/core/tests/common/zsh_fork.rs
+++ b/codex-rs/core/tests/common/zsh_fork.rs
@@ -102,7 +102,7 @@ fn find_test_zsh_path() -> Result<Option<PathBuf>> {
         return Ok(None);
     }
 
-    match crate::fetch_dotslash_file(&dotslash_zsh, None) {
+    match crate::fetch_dotslash_file(&dotslash_zsh, /*dotslash_cache*/ None) {
         Ok(path) => Ok(Some(path)),
         Err(error) => {
             eprintln!("skipping zsh-fork test: failed to fetch zsh via dotslash: {error:#}");

--- a/codex-rs/debug-client/src/main.rs
+++ b/codex-rs/debug-client/src/main.rs
@@ -219,7 +219,7 @@ fn handle_command(
             true
         }
         UserCommand::RefreshThread => {
-            match client.request_thread_list(None) {
+            match client.request_thread_list(/*cursor*/ None) {
                 Ok(request_id) => {
                     output
                         .client_line(&format!("requested thread list ({request_id:?})"))

--- a/codex-rs/exec/src/event_processor_with_human_output.rs
+++ b/codex-rs/exec/src/event_processor_with_human_output.rs
@@ -778,7 +778,7 @@ impl EventProcessor for EventProcessorWithHumanOutput {
                     self,
                     "{} {}",
                     "collab".style(self.magenta),
-                    format_collab_invocation("wait", &call_id, None).style(self.bold)
+                    format_collab_invocation("wait", &call_id, /*prompt*/ None).style(self.bold)
                 );
                 eprintln!(
                     "  receivers: {}",
@@ -795,7 +795,7 @@ impl EventProcessor for EventProcessorWithHumanOutput {
                     ts_msg!(
                         self,
                         "{} {}:",
-                        format_collab_invocation("wait", &call_id, None),
+                        format_collab_invocation("wait", &call_id, /*prompt*/ None),
                         "timed out".style(self.yellow)
                     );
                     return CodexStatus::Running;
@@ -804,7 +804,7 @@ impl EventProcessor for EventProcessorWithHumanOutput {
                 let title_style = if success { self.green } else { self.red };
                 let title = format!(
                     "{} {} agents complete:",
-                    format_collab_invocation("wait", &call_id, None),
+                    format_collab_invocation("wait", &call_id, /*prompt*/ None),
                     statuses.len()
                 );
                 ts_msg!(self, "{}", title.style(title_style));
@@ -830,7 +830,8 @@ impl EventProcessor for EventProcessorWithHumanOutput {
                     self,
                     "{} {}",
                     "collab".style(self.magenta),
-                    format_collab_invocation("close_agent", &call_id, None).style(self.bold)
+                    format_collab_invocation("close_agent", &call_id, /*prompt*/ None)
+                        .style(self.bold)
                 );
                 eprintln!(
                     "  receiver: {}",
@@ -848,7 +849,7 @@ impl EventProcessor for EventProcessorWithHumanOutput {
                 let title_style = if success { self.green } else { self.red };
                 let title = format!(
                     "{} {}:",
-                    format_collab_invocation("close_agent", &call_id, None),
+                    format_collab_invocation("close_agent", &call_id, /*prompt*/ None),
                     format_collab_status(&status)
                 );
                 ts_msg!(self, "{}", title.style(title_style));
@@ -1249,7 +1250,7 @@ fn format_collab_invocation(tool: &str, call_id: &str, prompt: Option<&str>) -> 
     let prompt = prompt
         .map(str::trim)
         .filter(|prompt| !prompt.is_empty())
-        .map(|prompt| truncate_preview(prompt, 120));
+        .map(|prompt| truncate_preview(prompt, /*max_chars*/ 120));
     match prompt {
         Some(prompt) => format!("{tool}({call_id}, prompt=\"{prompt}\")"),
         None => format!("{tool}({call_id})"),
@@ -1262,7 +1263,7 @@ fn format_collab_status(status: &AgentStatus) -> String {
         AgentStatus::Running => "running".to_string(),
         AgentStatus::Interrupted => "interrupted".to_string(),
         AgentStatus::Completed(Some(message)) => {
-            let preview = truncate_preview(message.trim(), 120);
+            let preview = truncate_preview(message.trim(), /*max_chars*/ 120);
             if preview.is_empty() {
                 "completed".to_string()
             } else {
@@ -1271,7 +1272,7 @@ fn format_collab_status(status: &AgentStatus) -> String {
         }
         AgentStatus::Completed(None) => "completed".to_string(),
         AgentStatus::Errored(message) => {
-            let preview = truncate_preview(message.trim(), 120);
+            let preview = truncate_preview(message.trim(), /*max_chars*/ 120);
             if preview.is_empty() {
                 "errored".to_string()
             } else {

--- a/codex-rs/exec/src/event_processor_with_jsonl_output.rs
+++ b/codex-rs/exec/src/event_processor_with_jsonl_output.rs
@@ -495,7 +495,7 @@ impl EventProcessorWithJsonOutput {
                 .iter()
                 .map(ToString::to_string)
                 .collect(),
-            None,
+            /*prompt*/ None,
         )
     }
 
@@ -526,7 +526,7 @@ impl EventProcessorWithJsonOutput {
             CollabTool::Wait,
             ev.sender_thread_id.to_string(),
             receiver_thread_ids,
-            None,
+            /*prompt*/ None,
             agents_states,
             status,
         )
@@ -538,7 +538,7 @@ impl EventProcessorWithJsonOutput {
             CollabTool::CloseAgent,
             ev.sender_thread_id.to_string(),
             vec![ev.receiver_thread_id.to_string()],
-            None,
+            /*prompt*/ None,
         )
     }
 
@@ -555,7 +555,7 @@ impl EventProcessorWithJsonOutput {
             CollabTool::CloseAgent,
             ev.sender_thread_id.to_string(),
             vec![receiver_id.clone()],
-            None,
+            /*prompt*/ None,
             [(receiver_id, agent_state)].into_iter().collect(),
             status,
         )

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -288,7 +288,7 @@ pub async fn run_main(cli: Cli, arg0_paths: Arg0DispatchPaths) -> anyhow::Result
 
     let cloud_auth_manager = AuthManager::shared(
         codex_home.clone(),
-        false,
+        /*enable_codex_api_key_env*/ false,
         config_toml.cli_auth_credentials_store.unwrap_or_default(),
     );
     let chatgpt_base_url = config_toml
@@ -390,7 +390,7 @@ pub async fn run_main(cli: Cli, arg0_paths: Arg0DispatchPaths) -> anyhow::Result
         codex_core::otel_init::build_provider(
             &config,
             env!("CARGO_PKG_VERSION"),
-            None,
+            /*service_name_override*/ None,
             DEFAULT_ANALYTICS_ENABLED,
         )
     })) {
@@ -1357,7 +1357,7 @@ fn local_external_chatgpt_tokens(
 ) -> Result<ChatgptAuthTokensRefreshResponse, String> {
     let auth_manager = AuthManager::shared(
         config.codex_home.clone(),
-        false,
+        /*enable_codex_api_key_env*/ false,
         config.cli_auth_credentials_store_mode,
     );
     auth_manager.set_forced_chatgpt_workspace_id(config.forced_chatgpt_workspace_id.clone());
@@ -1408,8 +1408,8 @@ async fn resolve_resume_path(
         };
         match codex_core::RolloutRecorder::find_latest_thread_path(
             config,
-            1,
-            None,
+            /*page_size*/ 1,
+            /*cursor*/ None,
             codex_core::ThreadSortKey::UpdatedAt,
             &[],
             Some(default_provider_filter.as_slice()),

--- a/codex-rs/execpolicy-legacy/src/policy_parser.rs
+++ b/codex-rs/execpolicy-legacy/src/policy_parser.rs
@@ -221,6 +221,6 @@ fn policy_builtins(builder: &mut GlobalsBuilder) {
     }
 
     fn flag(name: String) -> anyhow::Result<Opt> {
-        Ok(Opt::new(name, OptMeta::Flag, false))
+        Ok(Opt::new(name, OptMeta::Flag, /*required*/ false))
     }
 }

--- a/codex-rs/execpolicy/src/execpolicycheck.rs
+++ b/codex-rs/execpolicy/src/execpolicycheck.rs
@@ -44,7 +44,7 @@ impl ExecPolicyCheckCommand {
         let policy = load_policies(&self.rules)?;
         let matched_rules = policy.matches_for_command_with_options(
             &self.command,
-            None,
+            /*heuristics_fallback*/ None,
             &MatchOptions {
                 resolve_host_executables: self.resolve_host_executables,
             },

--- a/codex-rs/execpolicy/src/rule.rs
+++ b/codex-rs/execpolicy/src/rule.rs
@@ -255,7 +255,7 @@ pub(crate) fn validate_match_examples(
 
     for example in matches {
         if !policy
-            .matches_for_command_with_options(example, None, &options)
+            .matches_for_command_with_options(example, /*heuristics_fallback*/ None, &options)
             .is_empty()
         {
             continue;
@@ -290,7 +290,7 @@ pub(crate) fn validate_not_match_examples(
 
     for example in not_matches {
         if let Some(rule) = policy
-            .matches_for_command_with_options(example, None, &options)
+            .matches_for_command_with_options(example, /*heuristics_fallback*/ None, &options)
             .first()
         {
             return Err(Error::ExampleDidMatch {

--- a/codex-rs/file-search/src/lib.rs
+++ b/codex-rs/file-search/src/lib.rs
@@ -261,7 +261,7 @@ pub async fn run_main<T: Reporter>(
             compute_indices,
             respect_gitignore: true,
         },
-        None,
+        /*cancel_flag*/ None,
     )?;
     let match_count = matches.len();
     let matches_truncated = total_match_count > match_count;

--- a/codex-rs/hooks/src/engine/discovery.rs
+++ b/codex-rs/hooks/src/engine/discovery.rs
@@ -26,9 +26,10 @@ pub(crate) fn discover_handlers(config_layer_stack: Option<&ConfigLayerStack>) -
     let mut warnings = Vec::new();
     let mut display_order = 0_i64;
 
-    for layer in
-        config_layer_stack.get_layers(ConfigLayerStackOrdering::LowestPrecedenceFirst, false)
-    {
+    for layer in config_layer_stack.get_layers(
+        ConfigLayerStackOrdering::LowestPrecedenceFirst,
+        /*include_disabled*/ false,
+    ) {
         let Some(folder) = layer.config_folder() else {
             continue;
         };
@@ -87,7 +88,7 @@ pub(crate) fn discover_handlers(config_layer_stack: Option<&ConfigLayerStack>) -
                 &mut display_order,
                 source_path.as_path(),
                 codex_protocol::protocol::HookEventName::Stop,
-                None,
+                /*matcher*/ None,
                 group.hooks,
             );
         }

--- a/codex-rs/hooks/src/events/stop.rs
+++ b/codex-rs/hooks/src/events/stop.rs
@@ -50,10 +50,14 @@ pub(crate) fn preview(
     handlers: &[ConfiguredHandler],
     _request: &StopRequest,
 ) -> Vec<HookRunSummary> {
-    dispatcher::select_handlers(handlers, HookEventName::Stop, None)
-        .into_iter()
-        .map(|handler| dispatcher::running_summary(&handler))
-        .collect()
+    dispatcher::select_handlers(
+        handlers,
+        HookEventName::Stop,
+        /*session_start_source*/ None,
+    )
+    .into_iter()
+    .map(|handler| dispatcher::running_summary(&handler))
+    .collect()
 }
 
 pub(crate) async fn run(
@@ -61,7 +65,11 @@ pub(crate) async fn run(
     shell: &CommandShell,
     request: StopRequest,
 ) -> StopOutcome {
-    let matched = dispatcher::select_handlers(handlers, HookEventName::Stop, None);
+    let matched = dispatcher::select_handlers(
+        handlers,
+        HookEventName::Stop,
+        /*session_start_source*/ None,
+    );
     if matched.is_empty() {
         return StopOutcome {
             hook_events: Vec::new(),

--- a/codex-rs/linux-sandbox/src/linux_run_main.rs
+++ b/codex-rs/linux-sandbox/src/linux_run_main.rs
@@ -140,7 +140,7 @@ pub fn run_main() -> ! {
             &sandbox_policy,
             network_sandbox_policy,
             &sandbox_policy_cwd,
-            false,
+            /*apply_landlock_fs*/ false,
             allow_network_for_proxy,
             proxy_routing_active,
         ) {
@@ -154,9 +154,9 @@ pub fn run_main() -> ! {
             &sandbox_policy,
             network_sandbox_policy,
             &sandbox_policy_cwd,
-            false,
+            /*apply_landlock_fs*/ false,
             allow_network_for_proxy,
-            false,
+            /*proxy_routed_network*/ false,
         ) {
             panic!("error applying Linux sandbox restrictions: {e:?}");
         }
@@ -199,9 +199,9 @@ pub fn run_main() -> ! {
         &sandbox_policy,
         network_sandbox_policy,
         &sandbox_policy_cwd,
-        true,
+        /*apply_landlock_fs*/ true,
         allow_network_for_proxy,
-        false,
+        /*proxy_routed_network*/ false,
     ) {
         panic!("error applying legacy Linux sandbox restrictions: {e:?}");
     }

--- a/codex-rs/lmstudio/src/client.rs
+++ b/codex-rs/lmstudio/src/client.rs
@@ -125,7 +125,7 @@ impl LMStudioClient {
 
     // Find lms, checking fallback paths if not in PATH
     fn find_lms() -> std::io::Result<String> {
-        Self::find_lms_with_home_dir(None)
+        Self::find_lms_with_home_dir(/*home_dir*/ None)
     }
 
     fn find_lms_with_home_dir(home_dir: Option<&str>) -> std::io::Result<String> {

--- a/codex-rs/login/src/device_code_auth.rs
+++ b/codex-rs/login/src/device_code_auth.rs
@@ -212,7 +212,7 @@ pub async fn complete_device_code_login(
 
     crate::server::persist_tokens_async(
         &opts.codex_home,
-        None,
+        /*api_key*/ None,
         tokens.id_token,
         tokens.access_token,
         tokens.refresh_token,

--- a/codex-rs/login/src/server.rs
+++ b/codex-rs/login/src/server.rs
@@ -317,7 +317,7 @@ async fn process_request(
                         "Missing authorization code. Sign-in could not be completed.",
                         io::ErrorKind::InvalidData,
                         Some("missing_authorization_code"),
-                        None,
+                        /*error_description*/ None,
                     );
                 }
             };
@@ -335,7 +335,7 @@ async fn process_request(
                             &message,
                             io::ErrorKind::PermissionDenied,
                             Some("workspace_restriction"),
-                            None,
+                            /*error_description*/ None,
                         );
                     }
                     // Obtain API key via token-exchange and persist
@@ -373,7 +373,7 @@ async fn process_request(
                             "Sign-in completed but redirecting back to Codex failed.",
                             io::ErrorKind::Other,
                             Some("redirect_failed"),
-                            None,
+                            /*error_description*/ None,
                         ),
                     }
                 }
@@ -384,7 +384,7 @@ async fn process_request(
                         &format!("Token exchange failed: {err}"),
                         io::ErrorKind::Other,
                         Some("token_exchange_failed"),
-                        None,
+                        /*error_description*/ None,
                     )
                 }
             }

--- a/codex-rs/mcp-server/src/codex_tool_runner.rs
+++ b/codex-rs/mcp-server/src/codex_tool_runner.rs
@@ -299,7 +299,9 @@ async fn run_codex_tool_session_inner(
                             Some(msg) => msg,
                             None => "".to_string(),
                         };
-                        let result = create_call_tool_result_with_thread_id(thread_id, text, None);
+                        let result = create_call_tool_result_with_thread_id(
+                            thread_id, text, /*is_error*/ None,
+                        );
                         outgoing.send_response(request_id.clone(), result).await;
                         // unregister the id so we don't keep it in the map
                         running_requests_id_to_codex_uuid

--- a/codex-rs/mcp-server/src/message_processor.rs
+++ b/codex-rs/mcp-server/src/message_processor.rs
@@ -55,7 +55,7 @@ impl MessageProcessor {
         let outgoing = Arc::new(outgoing);
         let auth_manager = AuthManager::shared(
             config.codex_home.clone(),
-            false,
+            /*enable_codex_api_key_env*/ false,
             config.cli_auth_credentials_store_mode,
         );
         let thread_manager = Arc::new(ThreadManager::new(

--- a/codex-rs/network-proxy/src/certs.rs
+++ b/codex-rs/network-proxy/src/certs.rs
@@ -140,9 +140,9 @@ fn load_or_create_ca() -> Result<(String, String)> {
     //
     // We intentionally use create-new semantics: if a key already exists, we should not overwrite
     // it silently (that would invalidate previously-trusted cert chains).
-    write_atomic_create_new(&key_path, key_pem.as_bytes(), 0o600)
+    write_atomic_create_new(&key_path, key_pem.as_bytes(), /*mode*/ 0o600)
         .with_context(|| format!("failed to persist CA key {}", key_path.display()))?;
-    if let Err(err) = write_atomic_create_new(&cert_path, cert_pem.as_bytes(), 0o644)
+    if let Err(err) = write_atomic_create_new(&cert_path, cert_pem.as_bytes(), /*mode*/ 0o644)
         .with_context(|| format!("failed to persist CA cert {}", cert_path.display()))
     {
         // Avoid leaving a partially-created CA around (cert missing) if the second write fails.

--- a/codex-rs/network-proxy/src/config.rs
+++ b/codex-rs/network-proxy/src/config.rs
@@ -208,9 +208,9 @@ pub(crate) fn validate_unix_socket_allowlist_paths(cfg: &NetworkProxyConfig) -> 
 pub fn resolve_runtime(cfg: &NetworkProxyConfig) -> Result<RuntimeConfig> {
     validate_unix_socket_allowlist_paths(cfg)?;
 
-    let http_addr = resolve_addr(&cfg.network.proxy_url, 3128)
+    let http_addr = resolve_addr(&cfg.network.proxy_url, /*default_port*/ 3128)
         .with_context(|| format!("invalid network.proxy_url: {}", cfg.network.proxy_url))?;
-    let socks_addr = resolve_addr(&cfg.network.socks_url, 8081)
+    let socks_addr = resolve_addr(&cfg.network.socks_url, /*default_port*/ 8081)
         .with_context(|| format!("invalid network.socks_url: {}", cfg.network.socks_url))?;
     let (http_addr, socks_addr) = clamp_bind_addrs(http_addr, socks_addr, &cfg.network);
 

--- a/codex-rs/network-proxy/src/http_proxy.rs
+++ b/codex-rs/network-proxy/src/http_proxy.rs
@@ -187,7 +187,7 @@ async fn http_connect_accept(
             client_addr(&req),
             Some("CONNECT".to_string()),
             NetworkProtocol::HttpsConnect,
-            None,
+            /*audit_endpoint_override*/ None,
         )
         .await);
     }
@@ -469,7 +469,7 @@ async fn http_plain_proxy(
             return Ok(proxy_disabled_response(
                 &app_state,
                 socket_path,
-                0,
+                /*port*/ 0,
                 client_addr(&req),
                 Some(req.method().as_str().to_string()),
                 NetworkProtocol::Http,
@@ -495,7 +495,11 @@ async fn http_plain_proxy(
             warn!(
                 "unix socket blocked by method policy (client={client}, method={method}, mode=limited, allowed_methods=GET, HEAD, OPTIONS)"
             );
-            return Ok(json_blocked("unix-socket", REASON_METHOD_NOT_ALLOWED, None));
+            return Ok(json_blocked(
+                "unix-socket",
+                REASON_METHOD_NOT_ALLOWED,
+                /*details*/ None,
+            ));
         }
 
         if !unix_socket_permissions_supported() {
@@ -560,7 +564,11 @@ async fn http_plain_proxy(
                 );
                 let client = client.as_deref().unwrap_or_default();
                 warn!("unix socket blocked (client={client}, path={socket_path})");
-                Ok(json_blocked("unix-socket", REASON_NOT_ALLOWED, None))
+                Ok(json_blocked(
+                    "unix-socket",
+                    REASON_NOT_ALLOWED,
+                    /*details*/ None,
+                ))
             }
             Err(err) => {
                 warn!("unix socket check failed: {err}");
@@ -610,7 +618,7 @@ async fn http_plain_proxy(
             client_addr(&req),
             Some(req.method().as_str().to_string()),
             NetworkProtocol::Http,
-            None,
+            /*audit_endpoint_override*/ None,
         )
         .await);
     }

--- a/codex-rs/network-proxy/src/policy.rs
+++ b/codex-rs/network-proxy/src/policy.rs
@@ -58,14 +58,14 @@ fn is_non_public_ipv4(ip: Ipv4Addr) -> bool {
         || ip.is_unspecified()
         || ip.is_multicast()
         || ip.is_broadcast()
-        || ipv4_in_cidr(ip, [0, 0, 0, 0], 8) // "this network" (RFC 1122)
-        || ipv4_in_cidr(ip, [100, 64, 0, 0], 10) // CGNAT (RFC 6598)
-        || ipv4_in_cidr(ip, [192, 0, 0, 0], 24) // IETF Protocol Assignments (RFC 6890)
-        || ipv4_in_cidr(ip, [192, 0, 2, 0], 24) // TEST-NET-1 (RFC 5737)
-        || ipv4_in_cidr(ip, [198, 18, 0, 0], 15) // Benchmarking (RFC 2544)
-        || ipv4_in_cidr(ip, [198, 51, 100, 0], 24) // TEST-NET-2 (RFC 5737)
-        || ipv4_in_cidr(ip, [203, 0, 113, 0], 24) // TEST-NET-3 (RFC 5737)
-        || ipv4_in_cidr(ip, [240, 0, 0, 0], 4) // Reserved (RFC 6890)
+        || ipv4_in_cidr(ip, [0, 0, 0, 0], /*prefix*/ 8) // "this network" (RFC 1122)
+        || ipv4_in_cidr(ip, [100, 64, 0, 0], /*prefix*/ 10) // CGNAT (RFC 6598)
+        || ipv4_in_cidr(ip, [192, 0, 0, 0], /*prefix*/ 24) // IETF Protocol Assignments (RFC 6890)
+        || ipv4_in_cidr(ip, [192, 0, 2, 0], /*prefix*/ 24) // TEST-NET-1 (RFC 5737)
+        || ipv4_in_cidr(ip, [198, 18, 0, 0], /*prefix*/ 15) // Benchmarking (RFC 2544)
+        || ipv4_in_cidr(ip, [198, 51, 100, 0], /*prefix*/ 24) // TEST-NET-2 (RFC 5737)
+        || ipv4_in_cidr(ip, [203, 0, 113, 0], /*prefix*/ 24) // TEST-NET-3 (RFC 5737)
+        || ipv4_in_cidr(ip, [240, 0, 0, 0], /*prefix*/ 4) // Reserved (RFC 6890)
 }
 
 fn ipv4_in_cidr(ip: Ipv4Addr, base: [u8; 4], prefix: u8) -> bool {

--- a/codex-rs/network-proxy/src/runtime.rs
+++ b/codex-rs/network-proxy/src/runtime.rs
@@ -253,7 +253,7 @@ impl NetworkProxyState {
             state,
             reloader,
             audit_metadata,
-            None,
+            /*blocked_request_observer*/ None,
         )
     }
 

--- a/codex-rs/network-proxy/src/upstream.rs
+++ b/codex-rs/network-proxy/src/upstream.rs
@@ -88,7 +88,7 @@ fn read_proxy_env(keys: &[&str]) -> Option<ProxyAddress> {
 }
 
 pub(crate) fn proxy_for_connect() -> Option<ProxyAddress> {
-    ProxyConfig::from_env().proxy_for_protocol(true)
+    ProxyConfig::from_env().proxy_for_protocol(/*is_secure*/ true)
 }
 
 #[derive(Clone)]

--- a/codex-rs/otel/src/events/session_telemetry.rs
+++ b/codex-rs/otel/src/events/session_telemetry.rs
@@ -345,16 +345,16 @@ impl SessionTelemetry {
             status,
             error.as_deref(),
             duration,
-            false,
-            None,
-            false,
-            None,
-            None,
+            /*auth_header_attached*/ false,
+            /*auth_header_name*/ None,
+            /*retry_after_unauthorized*/ false,
+            /*recovery_mode*/ None,
+            /*recovery_phase*/ None,
             "unknown",
-            None,
-            None,
-            None,
-            None,
+            /*request_id*/ None,
+            /*cf_ray*/ None,
+            /*auth_error*/ None,
+            /*auth_error_code*/ None,
         );
 
         response
@@ -385,7 +385,7 @@ impl SessionTelemetry {
             .unwrap_or_else(|| "none".to_string());
         self.counter(
             API_CALL_COUNT_METRIC,
-            1,
+            /*inc*/ 1,
             &[("status", status_str.as_str()), ("success", success_str)],
         );
         self.record_duration(
@@ -474,7 +474,7 @@ impl SessionTelemetry {
         let success_str = if error.is_none() { "true" } else { "false" };
         self.counter(
             WEBSOCKET_REQUEST_COUNT_METRIC,
-            1,
+            /*inc*/ 1,
             &[("success", success_str)],
         );
         self.record_duration(
@@ -608,7 +608,7 @@ impl SessionTelemetry {
         let kind_str = kind.as_deref().unwrap_or(WEBSOCKET_UNKNOWN_KIND);
         let success_str = if success { "true" } else { "false" };
         let tags = [("kind", kind_str), ("success", success_str)];
-        self.counter(WEBSOCKET_EVENT_COUNT_METRIC, 1, &tags);
+        self.counter(WEBSOCKET_EVENT_COUNT_METRIC, /*inc*/ 1, &tags);
         self.record_duration(WEBSOCKET_EVENT_DURATION_METRIC, duration, &tags);
         log_and_trace_event!(
             self,
@@ -662,11 +662,15 @@ impl SessionTelemetry {
                 }
             }
             Ok(Some(Err(error))) => {
-                self.sse_event_failed(None, duration, error);
+                self.sse_event_failed(/*kind*/ None, duration, error);
             }
             Ok(None) => {}
             Err(_) => {
-                self.sse_event_failed(None, duration, &"idle timeout waiting for SSE");
+                self.sse_event_failed(
+                    /*kind*/ None,
+                    duration,
+                    &"idle timeout waiting for SSE",
+                );
             }
         }
     }
@@ -674,7 +678,7 @@ impl SessionTelemetry {
     fn sse_event(&self, kind: &str, duration: Duration) {
         self.counter(
             SSE_EVENT_COUNT_METRIC,
-            1,
+            /*inc*/ 1,
             &[("kind", kind), ("success", "true")],
         );
         self.record_duration(
@@ -697,7 +701,7 @@ impl SessionTelemetry {
         let kind_str = kind.map_or(SSE_UNKNOWN_KIND, String::as_str);
         self.counter(
             SSE_EVENT_COUNT_METRIC,
-            1,
+            /*inc*/ 1,
             &[("kind", kind_str), ("success", "false")],
         );
         self.record_duration(
@@ -911,7 +915,7 @@ impl SessionTelemetry {
         tags.push(("tool", tool_name));
         tags.push(("success", success_str));
         tags.extend_from_slice(extra_tags);
-        self.counter(TOOL_CALL_COUNT_METRIC, 1, &tags);
+        self.counter(TOOL_CALL_COUNT_METRIC, /*inc*/ 1, &tags);
         self.record_duration(TOOL_CALL_DURATION_METRIC, duration, &tags);
         let mcp_server = mcp_server.unwrap_or("");
         let mcp_server_origin = mcp_server_origin.unwrap_or("");

--- a/codex-rs/rmcp-client/src/auth_status.rs
+++ b/codex-rs/rmcp-client/src/auth_status.rs
@@ -62,9 +62,11 @@ pub async fn determine_streamable_http_auth_status(
 
 /// Attempt to determine whether a streamable HTTP MCP server advertises OAuth login.
 pub async fn supports_oauth_login(url: &str) -> Result<bool> {
-    Ok(discover_streamable_http_oauth(url, None, None)
-        .await?
-        .is_some())
+    Ok(discover_streamable_http_oauth(
+        url, /*http_headers*/ None, /*env_http_headers*/ None,
+    )
+    .await?
+    .is_some())
 }
 
 pub async fn discover_streamable_http_oauth(

--- a/codex-rs/rmcp-client/src/perform_oauth_login.rs
+++ b/codex-rs/rmcp-client/src/perform_oauth_login.rs
@@ -92,10 +92,10 @@ pub async fn perform_oauth_login(
         headers,
         scopes,
         oauth_resource,
-        true,
+        /*launch_browser*/ true,
         callback_port,
         callback_url,
-        None,
+        /*timeout_secs*/ None,
     )
     .await?
     .finish()
@@ -126,7 +126,7 @@ pub async fn perform_oauth_login_return_url(
         headers,
         scopes,
         oauth_resource,
-        false,
+        /*launch_browser*/ false,
         callback_port,
         callback_url,
         timeout_secs,

--- a/codex-rs/rmcp-client/src/rmcp_client.rs
+++ b/codex-rs/rmcp-client/src/rmcp_client.rs
@@ -744,19 +744,25 @@ impl RmcpClient {
         params: Option<serde_json::Value>,
     ) -> Result<()> {
         self.refresh_oauth_if_needed().await;
-        self.run_service_operation("notifications/custom", None, move |service| {
-            let params = params.clone();
-            async move {
-                service
-                    .send_notification(ClientNotification::CustomNotification(CustomNotification {
-                        method: method.to_string(),
-                        params,
-                        extensions: Extensions::new(),
-                    }))
-                    .await
-            }
-            .boxed()
-        })
+        self.run_service_operation(
+            "notifications/custom",
+            /*timeout*/ None,
+            move |service| {
+                let params = params.clone();
+                async move {
+                    service
+                        .send_notification(ClientNotification::CustomNotification(
+                            CustomNotification {
+                                method: method.to_string(),
+                                params,
+                                extensions: Extensions::new(),
+                            },
+                        ))
+                        .await
+                }
+                .boxed()
+            },
+        )
         .await?;
         self.persist_oauth_tokens().await;
         Ok(())
@@ -769,7 +775,7 @@ impl RmcpClient {
     ) -> Result<ServerResult> {
         self.refresh_oauth_if_needed().await;
         let response = self
-            .run_service_operation("requests/custom", None, move |service| {
+            .run_service_operation("requests/custom", /*timeout*/ None, move |service| {
                 let params = params.clone();
                 async move {
                     service

--- a/codex-rs/state/src/bin/logs_client.rs
+++ b/codex-rs/state/src/bin/logs_client.rs
@@ -205,7 +205,12 @@ async fn fetch_backfill(
     filter: &LogFilter,
     backfill: usize,
 ) -> anyhow::Result<Vec<LogRow>> {
-    let query = to_log_query(filter, Some(backfill), None, true);
+    let query = to_log_query(
+        filter,
+        Some(backfill),
+        /*after_id*/ None,
+        /*descending*/ true,
+    );
     runtime
         .query_logs(&query)
         .await
@@ -217,7 +222,12 @@ async fn fetch_new_rows(
     filter: &LogFilter,
     last_id: i64,
 ) -> anyhow::Result<Vec<LogRow>> {
-    let query = to_log_query(filter, None, Some(last_id), false);
+    let query = to_log_query(
+        filter,
+        /*limit*/ None,
+        Some(last_id),
+        /*descending*/ false,
+    );
     runtime
         .query_logs(&query)
         .await
@@ -225,7 +235,9 @@ async fn fetch_new_rows(
 }
 
 async fn fetch_max_id(runtime: &StateRuntime, filter: &LogFilter) -> anyhow::Result<i64> {
-    let query = to_log_query(filter, None, None, false);
+    let query = to_log_query(
+        filter, /*limit*/ None, /*after_id*/ None, /*descending*/ false,
+    );
     runtime
         .max_log_id(&query)
         .await

--- a/codex-rs/state/src/runtime/memories.rs
+++ b/codex-rs/state/src/runtime/memories.rs
@@ -30,7 +30,8 @@ impl StateRuntime {
     /// stage-1 (`memory_stage1`) and phase-2 (`memory_consolidate_global`)
     /// memory pipelines.
     pub async fn clear_memory_data(&self) -> anyhow::Result<()> {
-        self.clear_memory_data_inner(false).await
+        self.clear_memory_data_inner(/*disable_existing_threads*/ false)
+            .await
     }
 
     /// Resets persisted memory state for a clean-slate local start.
@@ -39,7 +40,8 @@ impl StateRuntime {
     /// jobs, this disables memory generation for all existing threads so
     /// historical rollouts are not immediately picked up again.
     pub async fn reset_memory_data_for_fresh_start(&self) -> anyhow::Result<()> {
-        self.clear_memory_data_inner(true).await
+        self.clear_memory_data_inner(/*disable_existing_threads*/ true)
+            .await
     }
 
     async fn clear_memory_data_inner(&self, disable_existing_threads: bool) -> anyhow::Result<()> {
@@ -193,12 +195,12 @@ LEFT JOIN jobs
         );
         push_thread_filters(
             &mut builder,
-            false,
+            /*archived_only*/ false,
             allowed_sources,
-            None,
-            None,
+            /*model_providers*/ None,
+            /*anchor*/ None,
             SortKey::UpdatedAt,
-            None,
+            /*search_term*/ None,
         );
         builder.push(" AND threads.memory_mode = 'enabled'");
         builder

--- a/codex-rs/state/src/runtime/threads.rs
+++ b/codex-rs/state/src/runtime/threads.rs
@@ -189,7 +189,7 @@ FROM threads
             model_providers,
             anchor,
             sort_key,
-            None,
+            /*search_term*/ None,
         );
         push_thread_order_and_limit(&mut builder, sort_key, limit);
 
@@ -204,7 +204,7 @@ FROM threads
 
     /// Insert or replace thread metadata directly.
     pub async fn upsert_thread(&self, metadata: &crate::ThreadMetadata) -> anyhow::Result<()> {
-        self.upsert_thread_with_creation_memory_mode(metadata, None)
+        self.upsert_thread_with_creation_memory_mode(metadata, /*creation_memory_mode*/ None)
             .await
     }
 

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -236,10 +236,10 @@ fn emit_skill_load_warnings(app_event_tx: &AppEventSender, errors: &[SkillErrorI
 fn emit_project_config_warnings(app_event_tx: &AppEventSender, config: &Config) {
     let mut disabled_folders = Vec::new();
 
-    for layer in config
-        .config_layer_stack
-        .get_layers(ConfigLayerStackOrdering::LowestPrecedenceFirst, true)
-    {
+    for layer in config.config_layer_stack.get_layers(
+        ConfigLayerStackOrdering::LowestPrecedenceFirst,
+        /*include_disabled*/ true,
+    ) {
         let ConfigLayerSource::Project { dot_codex_folder } = &layer.name else {
             continue;
         };
@@ -1127,8 +1127,10 @@ impl App {
         }
 
         if let Some(label) = permissions_history_label {
-            self.chat_widget
-                .add_info_message(format!("Permissions updated to {label}"), None);
+            self.chat_widget.add_info_message(
+                format!("Permissions updated to {label}"),
+                /*hint*/ None,
+            );
         }
     }
 
@@ -1140,7 +1142,7 @@ impl App {
         }
 
         self.chat_widget
-            .add_info_message(format!("Opened {url} in your browser."), None);
+            .add_info_message(format!("Opened {url} in your browser."), /*hint*/ None);
     }
 
     fn clear_ui_header_lines_with_version(
@@ -1256,7 +1258,7 @@ impl App {
         if self.active_thread_id.is_some() {
             return;
         }
-        self.set_thread_active(thread_id, true).await;
+        self.set_thread_active(thread_id, /*active*/ true).await;
         let receiver = if let Some(channel) = self.thread_event_channels.get_mut(&thread_id) {
             channel.receiver.take()
         } else {
@@ -1297,7 +1299,7 @@ impl App {
 
     async fn clear_active_thread(&mut self) {
         if let Some(active_id) = self.active_thread_id.take() {
-            self.set_thread_active(active_id, false).await;
+            self.set_thread_active(active_id, /*active*/ false).await;
         }
         self.active_thread_rx = None;
         self.refresh_pending_thread_approvals().await;
@@ -1578,7 +1580,10 @@ impl App {
             let thread_id = session.session_id;
             self.primary_thread_id = Some(thread_id);
             self.primary_session_configured = Some(session.clone());
-            self.upsert_agent_picker_thread(thread_id, None, None, false);
+            self.upsert_agent_picker_thread(
+                thread_id, /*agent_nickname*/ None, /*agent_role*/ None,
+                /*is_closed*/ false,
+            );
             self.ensure_thread_channel(thread_id);
             self.activate_thread_channel(thread_id).await;
             self.enqueue_thread_event(thread_id, event).await?;
@@ -1609,7 +1614,7 @@ impl App {
                         thread_id,
                         session_source.get_nickname(),
                         session_source.get_agent_role(),
-                        false,
+                        /*is_closed*/ false,
                     );
                 }
                 Err(_) => {
@@ -1628,7 +1633,7 @@ impl App {
 
         if self.agent_navigation.is_empty() {
             self.chat_widget
-                .add_info_message("No agents available yet.".to_string(), None);
+                .add_info_message("No agents available yet.".to_string(), /*hint*/ None);
             return;
         }
 
@@ -1751,7 +1756,7 @@ impl App {
         if is_replay_only {
             self.chat_widget.add_info_message(
                 format!("Agent thread {thread_id} is closed. Replaying saved transcript."),
-                None,
+                /*hint*/ None,
             );
         }
         self.drain_active_thread_events(tui).await?;
@@ -1904,13 +1909,15 @@ impl App {
         if let Some(event) = snapshot.session_configured {
             self.handle_codex_event_replay(event);
         }
-        self.chat_widget.set_queue_autosend_suppressed(true);
+        self.chat_widget
+            .set_queue_autosend_suppressed(/*suppressed*/ true);
         self.chat_widget
             .restore_thread_input_state(snapshot.input_state);
         for event in snapshot.events {
             self.handle_codex_event_replay(event);
         }
-        self.chat_widget.set_queue_autosend_suppressed(false);
+        self.chat_widget
+            .set_queue_autosend_suppressed(/*suppressed*/ false);
         if resume_restored_queue {
             self.chat_widget.maybe_send_next_queued_input();
         }
@@ -2025,7 +2032,7 @@ impl App {
             .as_ref()
             .is_some_and(|cmd| !cmd.is_empty())
         {
-            session_telemetry.counter("codex.status_line", 1, &[]);
+            session_telemetry.counter("codex.status_line", /*inc*/ 1, &[]);
         }
 
         let status_line_invalid_items_warned = Arc::new(AtomicBool::new(false));
@@ -2067,7 +2074,7 @@ impl App {
                         config.clone(),
                         target_session.path.clone(),
                         auth_manager.clone(),
-                        None,
+                        /*parent_trace*/ None,
                     )
                     .await
                     .wrap_err_with(|| {
@@ -2098,14 +2105,18 @@ impl App {
                 ChatWidget::new_from_existing(init, resumed.thread, resumed.session_configured)
             }
             SessionSelection::Fork(target_session) => {
-                session_telemetry.counter("codex.thread.fork", 1, &[("source", "cli_subcommand")]);
+                session_telemetry.counter(
+                    "codex.thread.fork",
+                    /*inc*/ 1,
+                    &[("source", "cli_subcommand")],
+                );
                 let forked = thread_manager
                     .fork_thread(
                         usize::MAX,
                         config.clone(),
                         target_session.path.clone(),
-                        false,
-                        None,
+                        /*persist_extended_history*/ false,
+                        /*parent_trace*/ None,
                     )
                     .await
                     .wrap_err_with(|| {
@@ -2406,13 +2417,19 @@ impl App {
                 self.start_fresh_session_with_summary_hint(tui).await;
             }
             AppEvent::ClearUi => {
-                self.clear_terminal_ui(tui, false)?;
+                self.clear_terminal_ui(tui, /*redraw_header*/ false)?;
                 self.reset_app_ui_state_after_clear();
 
                 self.start_fresh_session_with_summary_hint(tui).await;
             }
             AppEvent::OpenResumePicker => {
-                match crate::resume_picker::run_resume_picker(tui, &self.config, false).await? {
+                match crate::resume_picker::run_resume_picker(
+                    tui,
+                    &self.config,
+                    /*show_all*/ false,
+                )
+                .await?
+                {
                     SessionSelection::Resume(target_session) => {
                         let current_cwd = self.config.cwd.clone();
                         let resume_cwd = match crate::resolve_cwd_for_resume_or_fork(
@@ -2422,7 +2439,7 @@ impl App {
                             target_session.thread_id,
                             &target_session.path,
                             CwdPromptAction::Resume,
-                            true,
+                            /*allow_prompt*/ true,
                         )
                         .await?
                         {
@@ -2456,7 +2473,7 @@ impl App {
                                 resume_config.clone(),
                                 target_session.path.clone(),
                                 self.auth_manager.clone(),
-                                None,
+                                /*parent_trace*/ None,
                             )
                             .await
                         {
@@ -2507,7 +2524,7 @@ impl App {
             AppEvent::ForkCurrentSession => {
                 self.session_telemetry.counter(
                     "codex.thread.fork",
-                    1,
+                    /*inc*/ 1,
                     &[("source", "slash_command")],
                 );
                 let summary = session_summary(
@@ -2525,7 +2542,13 @@ impl App {
                     if path.exists() {
                         match self
                             .server
-                            .fork_thread(usize::MAX, self.config.clone(), path.clone(), false, None)
+                            .fork_thread(
+                                usize::MAX,
+                                self.config.clone(),
+                                path.clone(),
+                                /*persist_extended_history*/ false,
+                                /*parent_trace*/ None,
+                            )
                             .await
                         {
                             Ok(forked) => {
@@ -2777,7 +2800,7 @@ impl App {
             AppEvent::OpenWindowsSandboxFallbackPrompt { preset } => {
                 self.session_telemetry.counter(
                     "codex.windows_sandbox.fallback_prompt_shown",
-                    1,
+                    /*inc*/ 1,
                     &[],
                 );
                 self.chat_widget.clear_windows_sandbox_setup_status();
@@ -2971,7 +2994,7 @@ impl App {
                     self.chat_widget
                         .add_to_history(history_cell::new_info_event(
                             format!("Sandbox read access granted for {}", path.display()),
-                            None,
+                            /*hint*/ None,
                         ));
                 }
             },
@@ -3106,7 +3129,7 @@ impl App {
                             message.push_str(profile);
                             message.push_str(" profile");
                         }
-                        self.chat_widget.add_info_message(message, None);
+                        self.chat_widget.add_info_message(message, /*hint*/ None);
                     }
                     Err(err) => {
                         tracing::error!(
@@ -3140,7 +3163,7 @@ impl App {
                             message.push_str(profile);
                             message.push_str(" profile");
                         }
-                        self.chat_widget.add_info_message(message, None);
+                        self.chat_widget.add_info_message(message, /*hint*/ None);
                     }
                     Err(err) => {
                         tracing::error!(
@@ -3176,7 +3199,7 @@ impl App {
                             message.push_str(profile);
                             message.push_str(" profile");
                         }
-                        self.chat_widget.add_info_message(message, None);
+                        self.chat_widget.add_info_message(message, /*hint*/ None);
                     }
                     Err(err) => {
                         tracing::error!(error = %err, "failed to persist fast mode selection");
@@ -3223,7 +3246,7 @@ impl App {
                             let selection = name.unwrap_or_else(|| "System default".to_string());
                             self.chat_widget.add_info_message(
                                 format!("Realtime {} set to {selection}", kind.noun()),
-                                None,
+                                /*hint*/ None,
                             );
                         }
                     }
@@ -3369,7 +3392,7 @@ impl App {
             }
             AppEvent::PersistFullAccessWarningAcknowledged => {
                 if let Err(err) = ConfigEditsBuilder::new(&self.config.codex_home)
-                    .set_hide_full_access_warning(true)
+                    .set_hide_full_access_warning(/*acknowledged*/ true)
                     .apply()
                     .await
                 {
@@ -3384,7 +3407,7 @@ impl App {
             }
             AppEvent::PersistWorldWritableWarningAcknowledged => {
                 if let Err(err) = ConfigEditsBuilder::new(&self.config.codex_home)
-                    .set_hide_world_writable_warning(true)
+                    .set_hide_world_writable_warning(/*acknowledged*/ true)
                     .apply()
                     .await
                 {
@@ -3399,7 +3422,7 @@ impl App {
             }
             AppEvent::PersistRateLimitSwitchPromptHidden => {
                 if let Err(err) = ConfigEditsBuilder::new(&self.config.codex_home)
-                    .set_hide_rate_limit_model_nudge(true)
+                    .set_hide_rate_limit_model_nudge(/*acknowledged*/ true)
                     .apply()
                     .await
                 {
@@ -3795,7 +3818,7 @@ impl App {
                     format!(
                         "Agent thread {closed_thread_id} closed. Switched back to main thread."
                     ),
-                    None,
+                    /*hint*/ None,
                 );
             } else {
                 self.clear_active_thread().await;
@@ -3834,7 +3857,7 @@ impl App {
             thread_id,
             config_snapshot.session_source.get_nickname(),
             config_snapshot.session_source.get_agent_role(),
-            false,
+            /*is_closed*/ false,
         );
         let event = Event {
             id: String::new(),
@@ -4002,7 +4025,7 @@ impl App {
     fn reset_external_editor_state(&mut self, tui: &mut tui::Tui) {
         self.chat_widget
             .set_external_editor_state(ExternalEditorState::Closed);
-        self.chat_widget.set_footer_hint_override(None);
+        self.chat_widget.set_footer_hint_override(/*items*/ None);
         tui.frame_requester().schedule_frame();
     }
 
@@ -4066,7 +4089,7 @@ impl App {
                 if !self.chat_widget.can_run_ctrl_l_clear_now() {
                     return;
                 }
-                if let Err(err) = self.clear_terminal_ui(tui, false) {
+                if let Err(err) = self.clear_terminal_ui(tui, /*redraw_header*/ false) {
                     tracing::warn!(error = %err, "failed to clear terminal UI");
                     self.chat_widget
                         .add_error_message(format!("Failed to clear terminal UI: {err}"));

--- a/codex-rs/tui/src/app/agent_navigation.rs
+++ b/codex-rs/tui/src/app/agent_navigation.rs
@@ -106,7 +106,10 @@ impl AgentNavigationState {
         if let Some(entry) = self.threads.get_mut(&thread_id) {
             entry.is_closed = true;
         } else {
-            self.upsert(thread_id, None, None, true);
+            self.upsert(
+                thread_id, /*agent_nickname*/ None, /*agent_role*/ None,
+                /*is_closed*/ true,
+            );
         }
     }
 
@@ -202,7 +205,11 @@ impl AgentNavigationState {
                         is_primary,
                     )
                 })
-                .unwrap_or_else(|| format_agent_picker_item_name(None, None, is_primary)),
+                .unwrap_or_else(|| {
+                    format_agent_picker_item_name(
+                        /*agent_nickname*/ None, /*agent_role*/ None, is_primary,
+                    )
+                }),
         )
     }
 

--- a/codex-rs/tui/src/app_backtrack.rs
+++ b/codex-rs/tui/src/app_backtrack.rs
@@ -344,7 +344,7 @@ impl App {
         } else {
             self.backtrack.nth_user_message = usize::MAX;
             if let Some(Overlay::Transcript(t)) = &mut self.overlay {
-                t.set_highlight_cell(None);
+                t.set_highlight_cell(/*cell*/ None);
             }
         }
     }

--- a/codex-rs/tui/src/ascii_animation.rs
+++ b/codex-rs/tui/src/ascii_animation.rs
@@ -19,7 +19,7 @@ pub(crate) struct AsciiAnimation {
 
 impl AsciiAnimation {
     pub(crate) fn new(request_frame: FrameRequester) -> Self {
-        Self::with_variants(request_frame, ALL_VARIANTS, 0)
+        Self::with_variants(request_frame, ALL_VARIANTS, /*variant_idx*/ 0)
     }
 
     pub(crate) fn with_variants(

--- a/codex-rs/tui/src/bottom_pane/app_link_view.rs
+++ b/codex-rs/tui/src/bottom_pane/app_link_view.rs
@@ -506,7 +506,7 @@ impl crate::render::renderable::Renderable for AppLinkView {
         ])
         .areas(area);
 
-        let inner = content_area.inset(Insets::vh(1, 2));
+        let inner = content_area.inset(Insets::vh(/*v*/ 1, /*h*/ 2));
         let content_width = inner.width.max(1);
         let lines = self.content_lines(content_width);
         Paragraph::new(lines)

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -674,7 +674,12 @@ impl ChatComposer {
         };
         let [composer_rect, popup_rect] =
             Layout::vertical([Constraint::Min(3), popup_constraint]).areas(area);
-        let mut textarea_rect = composer_rect.inset(Insets::tlbr(1, LIVE_PREFIX_COLS, 1, 1));
+        let mut textarea_rect = composer_rect.inset(Insets::tlbr(
+            /*top*/ 1,
+            LIVE_PREFIX_COLS,
+            /*bottom*/ 1,
+            /*right*/ 1,
+        ));
         let remote_images_height = self
             .remote_images_lines(textarea_rect.width)
             .len()
@@ -1037,7 +1042,7 @@ impl ChatComposer {
         self.bind_mentions_from_snapshot(mention_bindings);
         self.relabel_attached_images_and_update_placeholders();
         self.selected_remote_image_index = None;
-        self.textarea.set_cursor(0);
+        self.textarea.set_cursor(/*pos*/ 0);
         self.sync_popups();
     }
 
@@ -2092,14 +2097,14 @@ impl ChatComposer {
     ///
     /// The returned string **does not** include the leading `@`.
     fn current_at_token(textarea: &TextArea) -> Option<String> {
-        Self::current_prefixed_token(textarea, '@', false)
+        Self::current_prefixed_token(textarea, '@', /*allow_empty*/ false)
     }
 
     fn current_mention_token(&self) -> Option<String> {
         if !self.mentions_enabled() {
             return None;
         }
-        Self::current_prefixed_token(&self.textarea, '$', true)
+        Self::current_prefixed_token(&self.textarea, '$', /*allow_empty*/ true)
     }
 
     /// Replace the active `@token` (the one under the cursor) with `path`.
@@ -2329,7 +2334,7 @@ impl ChatComposer {
                         r#"Unrecognized command '/{name}'. Type "/" for a list of supported commands."#
                     );
                     self.app_event_tx.send(AppEvent::InsertHistoryCell(Box::new(
-                        history_cell::new_info_event(message, None),
+                        history_cell::new_info_event(message, /*hint*/ None),
                     )));
                     self.set_text_content_with_mention_bindings(
                         original_input.clone(),
@@ -2481,7 +2486,9 @@ impl ChatComposer {
             return (result, true);
         }
 
-        if let Some((text, text_elements)) = self.prepare_submission_text(true) {
+        if let Some((text, text_elements)) =
+            self.prepare_submission_text(/*record_history*/ true)
+        {
             if should_queue {
                 (
                     InputResult::Queued {
@@ -2788,7 +2795,7 @@ impl ChatComposer {
                 code: KeyCode::Enter,
                 modifiers: KeyModifiers::NONE,
                 ..
-            } => self.handle_submission(false),
+            } => self.handle_submission(/*should_queue*/ false),
             input => self.handle_input_basic(input),
         }
     }
@@ -4160,7 +4167,7 @@ impl Renderable for ChatComposer {
     }
 
     fn render(&self, area: Rect, buf: &mut Buffer) {
-        self.render_with_mask(area, buf, None);
+        self.render_with_mask(area, buf, /*mask_char*/ None);
     }
 }
 
@@ -4254,7 +4261,10 @@ impl ChatComposer {
                 let right_line = if status_line_active {
                     let full =
                         mode_indicator_line(self.collaboration_mode_indicator, show_cycle_hint);
-                    let compact = mode_indicator_line(self.collaboration_mode_indicator, false);
+                    let compact = mode_indicator_line(
+                        self.collaboration_mode_indicator,
+                        /*show_cycle_hint*/ false,
+                    );
                     let full_width = full.as_ref().map(|l| l.width() as u16).unwrap_or(0);
                     if can_show_left_with_context(hint_rect, left_width, full_width) {
                         full

--- a/codex-rs/tui/src/bottom_pane/command_popup.rs
+++ b/codex-rs/tui/src/bottom_pane/command_popup.rs
@@ -274,7 +274,9 @@ impl WidgetRef for CommandPopup {
     fn render_ref(&self, area: Rect, buf: &mut Buffer) {
         let rows = self.rows_from_matches(self.filtered());
         render_rows(
-            area.inset(Insets::tlbr(0, 2, 0, 0)),
+            area.inset(Insets::tlbr(
+                /*top*/ 0, /*left*/ 2, /*bottom*/ 0, /*right*/ 0,
+            )),
             buf,
             &rows,
             &self.state,

--- a/codex-rs/tui/src/bottom_pane/experimental_features_view.rs
+++ b/codex-rs/tui/src/bottom_pane/experimental_features_view.rs
@@ -243,7 +243,7 @@ impl Renderable for ExperimentalFeaturesView {
             Constraint::Max(1),
             Constraint::Length(rows_height),
         ])
-        .areas(content_area.inset(Insets::vh(1, 2)));
+        .areas(content_area.inset(Insets::vh(/*v*/ 1, /*h*/ 2)));
 
         self.header.render(header_area, buf);
 

--- a/codex-rs/tui/src/bottom_pane/feedback_view.rs
+++ b/codex-rs/tui/src/bottom_pane/feedback_view.rs
@@ -104,7 +104,7 @@ impl FeedbackNoteView {
             self.include_logs,
             &attachment_paths,
             Some(SessionSource::Cli),
-            None,
+            /*logs_override*/ None,
         );
 
         match result {

--- a/codex-rs/tui/src/bottom_pane/file_search_popup.rs
+++ b/codex-rs/tui/src/bottom_pane/file_search_popup.rs
@@ -141,7 +141,9 @@ impl WidgetRef for &FileSearchPopup {
         };
 
         render_rows(
-            area.inset(Insets::tlbr(0, 2, 0, 0)),
+            area.inset(Insets::tlbr(
+                /*top*/ 0, /*left*/ 2, /*bottom*/ 0, /*right*/ 0,
+            )),
             buf,
             &rows_all,
             &self.state,

--- a/codex-rs/tui/src/bottom_pane/footer.rs
+++ b/codex-rs/tui/src/bottom_pane/footer.rs
@@ -199,7 +199,14 @@ pub(crate) fn footer_height(props: &FooterProps) -> u16 {
         | FooterMode::ShortcutOverlay
         | FooterMode::EscHint => false,
     };
-    footer_from_props_lines(props, None, false, show_shortcuts_hint, show_queue_hint).len() as u16
+    footer_from_props_lines(
+        props,
+        /*collaboration_mode_indicator*/ None,
+        /*show_cycle_hint*/ false,
+        show_shortcuts_hint,
+        show_queue_hint,
+    )
+    .len() as u16
 }
 
 /// Render a single precomputed footer line.

--- a/codex-rs/tui/src/bottom_pane/mcp_server_elicitation.rs
+++ b/codex-rs/tui/src/bottom_pane/mcp_server_elicitation.rs
@@ -1104,24 +1104,25 @@ impl McpServerElicitationOverlay {
         }
         self.validation_error = None;
         if self.request.response_mode == McpServerElicitationResponseMode::ApprovalAction {
-            let (decision, meta) = match self.field_value(0).as_ref().and_then(Value::as_str) {
-                Some(APPROVAL_ACCEPT_ONCE_VALUE) => (ElicitationAction::Accept, None),
-                Some(APPROVAL_ACCEPT_SESSION_VALUE) => (
-                    ElicitationAction::Accept,
-                    Some(serde_json::json!({
-                        APPROVAL_PERSIST_KEY: APPROVAL_PERSIST_SESSION_VALUE,
-                    })),
-                ),
-                Some(APPROVAL_ACCEPT_ALWAYS_VALUE) => (
-                    ElicitationAction::Accept,
-                    Some(serde_json::json!({
-                        APPROVAL_PERSIST_KEY: APPROVAL_PERSIST_ALWAYS_VALUE,
-                    })),
-                ),
-                Some(APPROVAL_DECLINE_VALUE) => (ElicitationAction::Decline, None),
-                Some(APPROVAL_CANCEL_VALUE) => (ElicitationAction::Cancel, None),
-                _ => (ElicitationAction::Cancel, None),
-            };
+            let (decision, meta) =
+                match self.field_value(/*idx*/ 0).as_ref().and_then(Value::as_str) {
+                    Some(APPROVAL_ACCEPT_ONCE_VALUE) => (ElicitationAction::Accept, None),
+                    Some(APPROVAL_ACCEPT_SESSION_VALUE) => (
+                        ElicitationAction::Accept,
+                        Some(serde_json::json!({
+                            APPROVAL_PERSIST_KEY: APPROVAL_PERSIST_SESSION_VALUE,
+                        })),
+                    ),
+                    Some(APPROVAL_ACCEPT_ALWAYS_VALUE) => (
+                        ElicitationAction::Accept,
+                        Some(serde_json::json!({
+                            APPROVAL_PERSIST_KEY: APPROVAL_PERSIST_ALWAYS_VALUE,
+                        })),
+                    ),
+                    Some(APPROVAL_DECLINE_VALUE) => (ElicitationAction::Decline, None),
+                    Some(APPROVAL_CANCEL_VALUE) => (ElicitationAction::Cancel, None),
+                    _ => (ElicitationAction::Cancel, None),
+                };
             self.app_event_tx.send(AppEvent::SubmitThreadOp {
                 thread_id: self.request.thread_id,
                 op: Op::ResolveElicitation {
@@ -1171,7 +1172,7 @@ impl McpServerElicitationOverlay {
         if self.current_index() + 1 >= self.field_count() {
             self.submit_answers();
         } else {
-            self.move_field(true);
+            self.move_field(/*next*/ true);
         }
     }
 
@@ -1466,7 +1467,7 @@ impl BottomPaneView for McpServerElicitationOverlay {
                 modifiers: KeyModifiers::NONE,
                 ..
             } => {
-                self.move_field(false);
+                self.move_field(/*next*/ false);
                 return;
             }
             KeyEvent {
@@ -1479,7 +1480,7 @@ impl BottomPaneView for McpServerElicitationOverlay {
                 modifiers: KeyModifiers::NONE,
                 ..
             } => {
-                self.move_field(true);
+                self.move_field(/*next*/ true);
                 return;
             }
             KeyEvent {
@@ -1487,7 +1488,7 @@ impl BottomPaneView for McpServerElicitationOverlay {
                 modifiers: KeyModifiers::NONE,
                 ..
             } if self.current_field_is_select() => {
-                self.move_field(false);
+                self.move_field(/*next*/ false);
                 return;
             }
             KeyEvent {
@@ -1495,7 +1496,7 @@ impl BottomPaneView for McpServerElicitationOverlay {
                 modifiers: KeyModifiers::NONE,
                 ..
             } if self.current_field_is_select() => {
-                self.move_field(true);
+                self.move_field(/*next*/ true);
                 return;
             }
             _ => {}
@@ -1518,10 +1519,10 @@ impl BottomPaneView for McpServerElicitationOverlay {
                     }
                 }
                 KeyCode::Backspace | KeyCode::Delete => self.clear_selection(),
-                KeyCode::Char(' ') => self.select_current_option(true),
+                KeyCode::Char(' ') => self.select_current_option(/*committed*/ true),
                 KeyCode::Enter => {
                     if self.selected_option_index().is_some() {
-                        self.select_current_option(true);
+                        self.select_current_option(/*committed*/ true);
                     }
                     self.go_next_or_submit();
                 }
@@ -1530,7 +1531,7 @@ impl BottomPaneView for McpServerElicitationOverlay {
                         if let Some(answer) = self.current_answer_mut() {
                             answer.selection.selected_idx = Some(option_idx);
                         }
-                        self.select_current_option(true);
+                        self.select_current_option(/*committed*/ true);
                         self.go_next_or_submit();
                     }
                 }

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -700,14 +700,14 @@ impl BottomPane {
 
     pub(crate) fn show_esc_backtrack_hint(&mut self) {
         self.esc_backtrack_hint = true;
-        self.composer.set_esc_backtrack_hint(true);
+        self.composer.set_esc_backtrack_hint(/*show*/ true);
         self.request_redraw();
     }
 
     pub(crate) fn clear_esc_backtrack_hint(&mut self) {
         if self.esc_backtrack_hint {
             self.esc_backtrack_hint = false;
-            self.composer.set_esc_backtrack_hint(false);
+            self.composer.set_esc_backtrack_hint(/*show*/ false);
             self.request_redraw();
         }
     }
@@ -729,7 +729,7 @@ impl BottomPane {
                     ));
                 }
                 if let Some(status) = self.status.as_mut() {
-                    status.set_interrupt_hint_visible(true);
+                    status.set_interrupt_hint_visible(/*visible*/ true);
                 }
                 self.sync_status_inline_message();
                 self.request_redraw();
@@ -943,7 +943,7 @@ impl BottomPane {
         );
         self.pause_status_timer_for_modal();
         self.set_composer_input_enabled(
-            false,
+            /*enabled*/ false,
             Some("Answer the questions to continue.".to_string()),
         );
         self.push_view(Box::new(modal));
@@ -1004,7 +1004,7 @@ impl BottomPane {
             );
             self.pause_status_timer_for_modal();
             self.set_composer_input_enabled(
-                false,
+                /*enabled*/ false,
                 Some("Respond to the tool suggestion to continue.".to_string()),
             );
             self.push_view(Box::new(view));
@@ -1020,7 +1020,7 @@ impl BottomPane {
         );
         self.pause_status_timer_for_modal();
         self.set_composer_input_enabled(
-            false,
+            /*enabled*/ false,
             Some("Respond to the MCP server request to continue.".to_string()),
         );
         self.push_view(Box::new(modal));
@@ -1028,7 +1028,7 @@ impl BottomPane {
 
     fn on_active_view_complete(&mut self) {
         self.resume_status_timer_after_modal();
-        self.set_composer_input_enabled(true, None);
+        self.set_composer_input_enabled(/*enabled*/ true, /*placeholder*/ None);
     }
 
     fn pause_status_timer_for_modal(&mut self) {
@@ -1131,12 +1131,15 @@ impl BottomPane {
         } else {
             let mut flex = FlexRenderable::new();
             if let Some(status) = &self.status {
-                flex.push(0, RenderableItem::Borrowed(status));
+                flex.push(/*flex*/ 0, RenderableItem::Borrowed(status));
             }
             // Avoid double-surfacing the same summary and avoid adding an extra
             // row while the status line is already visible.
             if self.status.is_none() && !self.unified_exec_footer.is_empty() {
-                flex.push(0, RenderableItem::Borrowed(&self.unified_exec_footer));
+                flex.push(
+                    /*flex*/ 0,
+                    RenderableItem::Borrowed(&self.unified_exec_footer),
+                );
             }
             let has_pending_thread_approvals = !self.pending_thread_approvals.is_empty();
             let has_pending_input = !self.pending_input_preview.queued_messages.is_empty()
@@ -1145,19 +1148,25 @@ impl BottomPane {
                 self.status.is_some() || !self.unified_exec_footer.is_empty();
             let has_inline_previews = has_pending_thread_approvals || has_pending_input;
             if has_inline_previews && has_status_or_footer {
-                flex.push(0, RenderableItem::Owned("".into()));
+                flex.push(/*flex*/ 0, RenderableItem::Owned("".into()));
             }
-            flex.push(1, RenderableItem::Borrowed(&self.pending_thread_approvals));
+            flex.push(
+                /*flex*/ 1,
+                RenderableItem::Borrowed(&self.pending_thread_approvals),
+            );
             if has_pending_thread_approvals && has_pending_input {
-                flex.push(0, RenderableItem::Owned("".into()));
+                flex.push(/*flex*/ 0, RenderableItem::Owned("".into()));
             }
-            flex.push(1, RenderableItem::Borrowed(&self.pending_input_preview));
+            flex.push(
+                /*flex*/ 1,
+                RenderableItem::Borrowed(&self.pending_input_preview),
+            );
             if !has_inline_previews && has_status_or_footer {
-                flex.push(0, RenderableItem::Owned("".into()));
+                flex.push(/*flex*/ 0, RenderableItem::Owned("".into()));
             }
             let mut flex2 = FlexRenderable::new();
-            flex2.push(1, RenderableItem::Owned(flex.into()));
-            flex2.push(0, RenderableItem::Borrowed(&self.composer));
+            flex2.push(/*flex*/ 1, RenderableItem::Owned(flex.into()));
+            flex2.push(/*flex*/ 0, RenderableItem::Borrowed(&self.composer));
             RenderableItem::Owned(Box::new(flex2))
         }
     }

--- a/codex-rs/tui/src/bottom_pane/multi_select_picker.rs
+++ b/codex-rs/tui/src/bottom_pane/multi_select_picker.rs
@@ -533,7 +533,7 @@ impl Renderable for MultiSelectPicker {
             Constraint::Length(2),
             Constraint::Length(rows_height),
         ])
-        .areas(content_area.inset(Insets::vh(1, 2)));
+        .areas(content_area.inset(Insets::vh(/*v*/ 1, /*h*/ 2)));
 
         self.header.render(header_area, buf);
 

--- a/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
@@ -706,7 +706,7 @@ impl RequestUserInputOverlay {
                 self.submit_answers();
             }
         } else {
-            self.move_question(true);
+            self.move_question(/*next*/ true);
         }
     }
 
@@ -958,10 +958,10 @@ impl RequestUserInputOverlay {
                 }
             }
             KeyCode::Up | KeyCode::Char('k') => {
-                state.move_up_wrap(2);
+                state.move_up_wrap(/*len*/ 2);
             }
             KeyCode::Down | KeyCode::Char('j') => {
-                state.move_down_wrap(2);
+                state.move_down_wrap(/*len*/ 2);
             }
             KeyCode::Enter => {
                 let selected = state.selected_idx.unwrap_or(0);
@@ -1024,7 +1024,7 @@ impl BottomPaneView for RequestUserInputOverlay {
                 modifiers: KeyModifiers::NONE,
                 ..
             } => {
-                self.move_question(false);
+                self.move_question(/*next*/ false);
                 return;
             }
             KeyEvent {
@@ -1037,7 +1037,7 @@ impl BottomPaneView for RequestUserInputOverlay {
                 modifiers: KeyModifiers::CONTROL,
                 ..
             } => {
-                self.move_question(true);
+                self.move_question(/*next*/ true);
                 return;
             }
             KeyEvent {
@@ -1045,7 +1045,7 @@ impl BottomPaneView for RequestUserInputOverlay {
                 modifiers: KeyModifiers::NONE,
                 ..
             } if self.has_options() && matches!(self.focus, Focus::Options) => {
-                self.move_question(false);
+                self.move_question(/*next*/ false);
                 return;
             }
             KeyEvent {
@@ -1053,7 +1053,7 @@ impl BottomPaneView for RequestUserInputOverlay {
                 modifiers: KeyModifiers::NONE,
                 ..
             } if self.has_options() && matches!(self.focus, Focus::Options) => {
-                self.move_question(false);
+                self.move_question(/*next*/ false);
                 return;
             }
             KeyEvent {
@@ -1061,7 +1061,7 @@ impl BottomPaneView for RequestUserInputOverlay {
                 modifiers: KeyModifiers::NONE,
                 ..
             } if self.has_options() && matches!(self.focus, Focus::Options) => {
-                self.move_question(true);
+                self.move_question(/*next*/ true);
                 return;
             }
             KeyEvent {
@@ -1069,7 +1069,7 @@ impl BottomPaneView for RequestUserInputOverlay {
                 modifiers: KeyModifiers::NONE,
                 ..
             } if self.has_options() && matches!(self.focus, Focus::Options) => {
-                self.move_question(true);
+                self.move_question(/*next*/ true);
                 return;
             }
             _ => {}
@@ -1105,7 +1105,7 @@ impl BottomPaneView for RequestUserInputOverlay {
                         }
                     }
                     KeyCode::Char(' ') => {
-                        self.select_current_option(true);
+                        self.select_current_option(/*committed*/ true);
                     }
                     KeyCode::Backspace | KeyCode::Delete => {
                         self.clear_selection();
@@ -1119,7 +1119,7 @@ impl BottomPaneView for RequestUserInputOverlay {
                     KeyCode::Enter => {
                         let has_selection = self.selected_option_index().is_some();
                         if has_selection {
-                            self.select_current_option(true);
+                            self.select_current_option(/*committed*/ true);
                         }
                         self.go_next_or_submit();
                     }
@@ -1128,7 +1128,7 @@ impl BottomPaneView for RequestUserInputOverlay {
                             if let Some(answer) = self.current_answer_mut() {
                                 answer.options_state.selected_idx = Some(option_idx);
                             }
-                            self.select_current_option(true);
+                            self.select_current_option(/*committed*/ true);
                             self.go_next_or_submit();
                         }
                     }
@@ -1158,7 +1158,7 @@ impl BottomPaneView for RequestUserInputOverlay {
                     if !self.handle_composer_input_result(result) {
                         self.pending_submission_draft = None;
                         if self.has_options() {
-                            self.select_current_option(true);
+                            self.select_current_option(/*committed*/ true);
                         }
                         self.go_next_or_submit();
                     }

--- a/codex-rs/tui/src/bottom_pane/skill_popup.rs
+++ b/codex-rs/tui/src/bottom_pane/skill_popup.rs
@@ -199,7 +199,9 @@ impl WidgetRef for SkillPopup {
         };
         let rows = self.rows_from_matches(self.filtered());
         render_rows_single_line(
-            list_area.inset(Insets::tlbr(0, 2, 0, 0)),
+            list_area.inset(Insets::tlbr(
+                /*top*/ 0, /*left*/ 2, /*bottom*/ 0, /*right*/ 0,
+            )),
             buf,
             &rows,
             &self.state,

--- a/codex-rs/tui/src/bottom_pane/skills_toggle_view.rs
+++ b/codex-rs/tui/src/bottom_pane/skills_toggle_view.rs
@@ -314,7 +314,7 @@ impl Renderable for SkillsToggleView {
             Constraint::Length(2),
             Constraint::Length(rows_height),
         ])
-        .areas(content_area.inset(Insets::vh(1, 2)));
+        .areas(content_area.inset(Insets::vh(/*v*/ 1, /*h*/ 2)));
 
         self.header.render(header_area, buf);
 

--- a/codex-rs/tui/src/bottom_pane/status_line_setup.rs
+++ b/codex-rs/tui/src/bottom_pane/status_line_setup.rs
@@ -205,7 +205,7 @@ impl StatusLineSetupView {
                 if !used_ids.insert(item_id.clone()) {
                     continue;
                 }
-                items.push(Self::status_line_select_item(item, true));
+                items.push(Self::status_line_select_item(item, /*enabled*/ true));
             }
         }
 
@@ -214,7 +214,7 @@ impl StatusLineSetupView {
             if used_ids.contains(&item_id) {
                 continue;
             }
-            items.push(Self::status_line_select_item(item, false));
+            items.push(Self::status_line_select_item(item, /*enabled*/ false));
         }
 
         Self {

--- a/codex-rs/tui/src/bottom_pane/textarea.rs
+++ b/codex-rs/tui/src/bottom_pane/textarea.rs
@@ -101,7 +101,7 @@ impl TextArea {
     /// as submit or slash-command dispatch clear the draft through this method and still want
     /// `Ctrl+Y` to recover the user's most recent kill.
     pub fn set_text_clearing_elements(&mut self, text: &str) {
-        self.set_text_inner(text, None);
+        self.set_text_inner(text, /*elements*/ None);
     }
 
     /// Replace the visible textarea text and rebuild the provided text elements.
@@ -160,7 +160,7 @@ impl TextArea {
         if pos <= self.cursor_pos {
             self.cursor_pos += text.len();
         }
-        self.shift_elements(pos, 0, text.len());
+        self.shift_elements(pos, /*removed*/ 0, text.len());
         self.preferred_col = None;
     }
 
@@ -355,7 +355,7 @@ impl TextArea {
                 code: KeyCode::Char('h'),
                 modifiers: KeyModifiers::CONTROL,
                 ..
-            } => self.delete_backward(1),
+            } => self.delete_backward(/*n*/ 1),
             KeyEvent {
                 code: KeyCode::Delete,
                 modifiers: KeyModifiers::ALT,
@@ -374,7 +374,7 @@ impl TextArea {
                 code: KeyCode::Char('d'),
                 modifiers: KeyModifiers::CONTROL,
                 ..
-            } => self.delete_forward(1),
+            } => self.delete_forward(/*n*/ 1),
 
             KeyEvent {
                 code: KeyCode::Char('w'),
@@ -507,27 +507,27 @@ impl TextArea {
                 code: KeyCode::Home,
                 ..
             } => {
-                self.move_cursor_to_beginning_of_line(false);
+                self.move_cursor_to_beginning_of_line(/*move_up_at_bol*/ false);
             }
             KeyEvent {
                 code: KeyCode::Char('a'),
                 modifiers: KeyModifiers::CONTROL,
                 ..
             } => {
-                self.move_cursor_to_beginning_of_line(true);
+                self.move_cursor_to_beginning_of_line(/*move_up_at_bol*/ true);
             }
 
             KeyEvent {
                 code: KeyCode::End, ..
             } => {
-                self.move_cursor_to_end_of_line(false);
+                self.move_cursor_to_end_of_line(/*move_down_at_eol*/ false);
             }
             KeyEvent {
                 code: KeyCode::Char('e'),
                 modifiers: KeyModifiers::CONTROL,
                 ..
             } => {
-                self.move_cursor_to_end_of_line(true);
+                self.move_cursor_to_end_of_line(/*move_down_at_eol*/ true);
             }
             _o => {
                 #[cfg(feature = "debug-logs")]
@@ -999,7 +999,7 @@ impl TextArea {
     }
 
     fn add_element(&mut self, range: Range<usize>) -> u64 {
-        self.add_element_with_id(range, None)
+        self.add_element_with_id(range, /*name*/ None)
     }
 
     /// Mark an existing text range as an atomic element without changing the text.
@@ -1228,7 +1228,7 @@ impl TextArea {
             }
             start = idx;
         }
-        self.adjust_pos_out_of_elements(start, true)
+        self.adjust_pos_out_of_elements(start, /*prefer_start*/ true)
     }
 
     pub(crate) fn end_of_next_word(&self) -> usize {
@@ -1249,7 +1249,7 @@ impl TextArea {
                 break;
             }
         }
-        self.adjust_pos_out_of_elements(end, false)
+        self.adjust_pos_out_of_elements(end, /*prefer_start*/ false)
     }
 
     fn adjust_pos_out_of_elements(&self, pos: usize, prefer_start: bool) -> usize {

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1194,7 +1194,7 @@ impl ChatWidget {
     fn set_status_header(&mut self, header: String) {
         self.set_status(
             header,
-            None,
+            /*details*/ None,
             StatusDetailsCapitalization::CapitalizeFirst,
             STATUS_DETAILS_DEFAULT_MAX_LINES,
         );
@@ -1251,7 +1251,7 @@ impl ChatWidget {
         let enabled = !items.is_empty();
         self.bottom_pane.set_status_line_enabled(enabled);
         if !enabled {
-            self.set_status_line(None);
+            self.set_status_line(/*status_line*/ None);
             return;
         }
 
@@ -1356,7 +1356,7 @@ impl ChatWidget {
     fn on_session_configured(&mut self, event: codex_protocol::protocol::SessionConfiguredEvent) {
         self.bottom_pane
             .set_history_metadata(event.history_log_id, event.history_entry_count);
-        self.set_skills(None);
+        self.set_skills(/*skills*/ None);
         self.session_network_proxy = event.network_proxy.clone();
         self.thread_id = Some(event.session_id);
         self.thread_name = event.thread_name.clone();
@@ -1393,7 +1393,7 @@ impl ChatWidget {
         self.current_collaboration_mode = self.current_collaboration_mode.with_updates(
             Some(model_for_header.clone()),
             Some(event.reasoning_effort),
-            None,
+            /*developer_instructions*/ None,
         );
         if let Some(mask) = self.active_collaboration_mask.as_mut() {
             mask.model = Some(model_for_header.clone());
@@ -1692,7 +1692,8 @@ impl ChatWidget {
 
     fn on_task_started(&mut self) {
         self.agent_turn_running = true;
-        self.turn_sleep_inhibitor.set_turn_running(true);
+        self.turn_sleep_inhibitor
+            .set_turn_running(/*turn_running*/ true);
         self.saw_plan_update_this_turn = false;
         self.saw_plan_item_this_turn = false;
         self.plan_delta_buffer.clear();
@@ -1707,7 +1708,8 @@ impl ChatWidget {
         self.update_task_running_state();
         self.retry_status_header = None;
         self.pending_status_indicator_restore = false;
-        self.bottom_pane.set_interrupt_hint_visible(true);
+        self.bottom_pane
+            .set_interrupt_hint_visible(/*visible*/ true);
         self.set_status_header(String::from("Working"));
         self.full_reasoning_buffer.clear();
         self.reasoning_buffer.clear();
@@ -1756,7 +1758,8 @@ impl ChatWidget {
         // Mark task stopped and request redraw now that all content is in history.
         self.pending_status_indicator_restore = false;
         self.agent_turn_running = false;
-        self.turn_sleep_inhibitor.set_turn_running(false);
+        self.turn_sleep_inhibitor
+            .set_turn_running(/*turn_running*/ false);
         self.update_task_running_state();
         self.running_commands.clear();
         self.suppressed_exec_calls.clear();
@@ -1900,7 +1903,8 @@ impl ChatWidget {
         match info {
             Some(info) => self.apply_token_info(info),
             None => {
-                self.bottom_pane.set_context_window(None, None);
+                self.bottom_pane
+                    .set_context_window(/*percent*/ None, /*used_tokens*/ None);
                 self.token_info = None;
             }
         }
@@ -1954,7 +1958,8 @@ impl ChatWidget {
             match saved {
                 Some(info) => self.apply_token_info(info),
                 None => {
-                    self.bottom_pane.set_context_window(None, None);
+                    self.bottom_pane
+                        .set_context_window(/*percent*/ None, /*used_tokens*/ None);
                     self.token_info = None;
                 }
             }
@@ -2054,7 +2059,8 @@ impl ChatWidget {
         self.finalize_active_cell_as_failed();
         // Reset running state and clear streaming buffers.
         self.agent_turn_running = false;
-        self.turn_sleep_inhibitor.set_turn_running(false);
+        self.turn_sleep_inhibitor
+            .set_turn_running(/*turn_running*/ false);
         self.update_task_running_state();
         self.running_commands.clear();
         self.suppressed_exec_calls.clear();
@@ -2178,7 +2184,7 @@ impl ChatWidget {
             if send_pending_steers_immediately {
                 self.add_to_history(history_cell::new_info_event(
                     "Model interrupted to submit steer instructions.".to_owned(),
-                    None,
+                    /*hint*/ None,
                 ));
             } else {
                 self.add_to_history(history_cell::new_error_event(
@@ -2458,7 +2464,8 @@ impl ChatWidget {
             // review is pending. Parallel reviews are aggregated into one
             // footer summary by `PendingGuardianReviewStatus`.
             self.bottom_pane.ensure_status_indicator();
-            self.bottom_pane.set_interrupt_hint_visible(true);
+            self.bottom_pane
+                .set_interrupt_hint_visible(/*visible*/ true);
             self.pending_guardian_review_status
                 .start_or_update(ev.id.clone(), detail);
             if let Some(status) = self.pending_guardian_review_status.status_indicator_state() {
@@ -2662,12 +2669,13 @@ impl ChatWidget {
             // Surface this in the status indicator (single "waiting" surface) instead of
             // the transcript. Keep the header short so the interrupt hint remains visible.
             self.bottom_pane.ensure_status_indicator();
-            self.bottom_pane.set_interrupt_hint_visible(true);
+            self.bottom_pane
+                .set_interrupt_hint_visible(/*visible*/ true);
             self.set_status(
                 "Waiting for background terminal".to_string(),
                 command_display.clone(),
                 StatusDetailsCapitalization::Preserve,
-                1,
+                /*details_max_lines*/ 1,
             );
             match &mut self.unified_exec_wait_streak {
                 Some(wait) if wait.process_id == ev.process_id => {
@@ -2917,7 +2925,8 @@ impl ChatWidget {
     fn on_background_event(&mut self, message: String) {
         debug!("BackgroundEvent: {message}");
         self.bottom_pane.ensure_status_indicator();
-        self.bottom_pane.set_interrupt_hint_visible(true);
+        self.bottom_pane
+            .set_interrupt_hint_visible(/*visible*/ true);
         self.set_status_header(message);
     }
 
@@ -2930,7 +2939,7 @@ impl ChatWidget {
             message.push_str(": ");
             message.push_str(&status_message);
         }
-        self.add_to_history(history_cell::new_info_event(message, None));
+        self.add_to_history(history_cell::new_info_event(message, /*hint*/ None));
         self.request_redraw();
     }
 
@@ -2954,7 +2963,8 @@ impl ChatWidget {
 
     fn on_undo_started(&mut self, event: UndoStartedEvent) {
         self.bottom_pane.ensure_status_indicator();
-        self.bottom_pane.set_interrupt_hint_visible(false);
+        self.bottom_pane
+            .set_interrupt_hint_visible(/*visible*/ false);
         let message = event
             .message
             .unwrap_or_else(|| "Undo in progress...".to_string());
@@ -2972,7 +2982,7 @@ impl ChatWidget {
             }
         });
         if success {
-            self.add_info_message(message, None);
+            self.add_info_message(message, /*hint*/ None);
         } else {
             self.add_error_message(message);
         }
@@ -3112,7 +3122,7 @@ impl ChatWidget {
                     .map(|current| self.worked_elapsed_from(current));
                 self.add_to_history(history_cell::FinalMessageSeparator::new(
                     elapsed_seconds,
-                    None,
+                    /*runtime_metrics*/ None,
                 ));
                 self.needs_final_message_separator = false;
                 self.had_work_activity = false;
@@ -3661,7 +3671,9 @@ impl ChatWidget {
         widget
             .bottom_pane
             .set_status_line_enabled(!widget.configured_status_line_items().is_empty());
-        widget.bottom_pane.set_collaboration_modes_enabled(true);
+        widget
+            .bottom_pane
+            .set_collaboration_modes_enabled(/*enabled*/ true);
         widget.sync_fast_command_enabled();
         widget.sync_personality_command_enabled();
         widget
@@ -3847,7 +3859,9 @@ impl ChatWidget {
         widget
             .bottom_pane
             .set_status_line_enabled(!widget.configured_status_line_items().is_empty());
-        widget.bottom_pane.set_collaboration_modes_enabled(true);
+        widget
+            .bottom_pane
+            .set_collaboration_modes_enabled(/*enabled*/ true);
         widget.sync_fast_command_enabled();
         widget.sync_personality_command_enabled();
         widget
@@ -4025,7 +4039,9 @@ impl ChatWidget {
         widget
             .bottom_pane
             .set_status_line_enabled(!widget.configured_status_line_items().is_empty());
-        widget.bottom_pane.set_collaboration_modes_enabled(true);
+        widget
+            .bottom_pane
+            .set_collaboration_modes_enabled(/*enabled*/ true);
         widget.sync_fast_command_enabled();
         widget.sync_personality_command_enabled();
         widget
@@ -4326,7 +4342,7 @@ impl ChatWidget {
                     let message = format!(
                         "{DEFAULT_PROJECT_DOC_FILENAME} already exists here. Skipping /init to avoid overwriting it."
                     );
-                    self.add_info_message(message, None);
+                    self.add_info_message(message, /*hint*/ None);
                     return;
                 }
                 const INIT_PROMPT: &str = include_str!("../prompt_for_init_command.md");
@@ -4341,7 +4357,7 @@ impl ChatWidget {
             }
             SlashCommand::Rename => {
                 self.session_telemetry
-                    .counter("codex.thread.rename", 1, &[]);
+                    .counter("codex.thread.rename", /*inc*/ 1, &[]);
                 self.show_rename_prompt();
             }
             SlashCommand::Model => {
@@ -4360,7 +4376,7 @@ impl ChatWidget {
                     return;
                 }
                 if self.realtime_conversation.is_live() {
-                    self.request_realtime_conversation_close(None);
+                    self.request_realtime_conversation_close(/*info_message*/ None);
                 } else {
                     self.start_realtime_conversation();
                 }
@@ -4385,7 +4401,10 @@ impl ChatWidget {
                 if let Some(mask) = collaboration_modes::plan_mask(self.models_manager.as_ref()) {
                     self.set_collaboration_mask(mask);
                 } else {
-                    self.add_info_message("Plan mode unavailable right now.".to_string(), None);
+                    self.add_info_message(
+                        "Plan mode unavailable right now.".to_string(),
+                        /*hint*/ None,
+                    );
                 }
             }
             SlashCommand::Collab => {
@@ -4502,7 +4521,7 @@ impl ChatWidget {
                     self.add_info_message(
                         "`/copy` is unavailable before the first Codex output or right after a rollback."
                             .to_string(),
-                        None,
+                        /*hint*/ None,
                     );
                     return;
                 };
@@ -4565,10 +4584,13 @@ impl ChatWidget {
                 if let Some(path) = self.rollout_path() {
                     self.add_info_message(
                         format!("Current rollout path: {}", path.display()),
-                        None,
+                        /*hint*/ None,
                     );
                 } else {
-                    self.add_info_message("Rollout path is not available yet.".to_string(), None);
+                    self.add_info_message(
+                        "Rollout path is not available yet.".to_string(),
+                        /*hint*/ None,
+                    );
                 }
             }
             SlashCommand::TestApproval => {
@@ -4641,7 +4663,7 @@ impl ChatWidget {
                 }
                 match trimmed.to_ascii_lowercase().as_str() {
                     "on" => self.set_service_tier_selection(Some(ServiceTier::Fast)),
-                    "off" => self.set_service_tier_selection(None),
+                    "off" => self.set_service_tier_selection(/*service_tier*/ None),
                     "status" => {
                         let status = if matches!(self.config.service_tier, Some(ServiceTier::Fast))
                         {
@@ -4649,7 +4671,10 @@ impl ChatWidget {
                         } else {
                             "off"
                         };
-                        self.add_info_message(format!("Fast mode is {status}."), None);
+                        self.add_info_message(
+                            format!("Fast mode is {status}."),
+                            /*hint*/ None,
+                        );
                     }
                     _ => {
                         self.add_error_message("Usage: /fast [on|off|status]".to_string());
@@ -4658,9 +4683,10 @@ impl ChatWidget {
             }
             SlashCommand::Rename if !trimmed.is_empty() => {
                 self.session_telemetry
-                    .counter("codex.thread.rename", 1, &[]);
-                let Some((prepared_args, _prepared_elements)) =
-                    self.bottom_pane.prepare_inline_args_submission(false)
+                    .counter("codex.thread.rename", /*inc*/ 1, &[]);
+                let Some((prepared_args, _prepared_elements)) = self
+                    .bottom_pane
+                    .prepare_inline_args_submission(/*record_history*/ false)
                 else {
                     return;
                 };
@@ -4680,8 +4706,9 @@ impl ChatWidget {
                 if self.active_mode_kind() != ModeKind::Plan {
                     return;
                 }
-                let Some((prepared_args, prepared_elements)) =
-                    self.bottom_pane.prepare_inline_args_submission(true)
+                let Some((prepared_args, prepared_elements)) = self
+                    .bottom_pane
+                    .prepare_inline_args_submission(/*record_history*/ true)
                 else {
                     return;
                 };
@@ -4706,8 +4733,9 @@ impl ChatWidget {
                 }
             }
             SlashCommand::Review if !trimmed.is_empty() => {
-                let Some((prepared_args, _prepared_elements)) =
-                    self.bottom_pane.prepare_inline_args_submission(false)
+                let Some((prepared_args, _prepared_elements)) = self
+                    .bottom_pane
+                    .prepare_inline_args_submission(/*record_history*/ false)
                 else {
                     return;
                 };
@@ -4722,8 +4750,9 @@ impl ChatWidget {
                 self.bottom_pane.drain_pending_submission_state();
             }
             SlashCommand::SandboxReadRoot if !trimmed.is_empty() => {
-                let Some((prepared_args, _prepared_elements)) =
-                    self.bottom_pane.prepare_inline_args_submission(false)
+                let Some((prepared_args, _prepared_elements)) = self
+                    .bottom_pane
+                    .prepare_inline_args_submission(/*record_history*/ false)
                 else {
                     return;
                 };
@@ -4752,7 +4781,7 @@ impl ChatWidget {
         let view = CustomPromptView::new(
             title.to_string(),
             "Type a name and press Enter".to_string(),
-            None,
+            /*context_label*/ None,
             Box::new(move |name: String| {
                 let Some(name) = codex_core::util::normalize_thread_name(&name) else {
                     tx.send(AppEvent::InsertHistoryCell(Box::new(
@@ -5160,13 +5189,17 @@ impl ChatWidget {
                 continue;
             }
             // `id: None` indicates a synthetic/fake id coming from replay.
-            self.dispatch_event_msg(None, msg, Some(ReplayKind::ResumeInitialMessages));
+            self.dispatch_event_msg(
+                /*id*/ None,
+                msg,
+                Some(ReplayKind::ResumeInitialMessages),
+            );
         }
     }
 
     pub(crate) fn handle_codex_event(&mut self, event: Event) {
         let Event { id, msg } = event;
-        self.dispatch_event_msg(Some(id), msg, None);
+        self.dispatch_event_msg(Some(id), msg, /*replay_kind*/ None);
     }
 
     pub(crate) fn handle_codex_event_replay(&mut self, event: Event) {
@@ -5174,7 +5207,7 @@ impl ChatWidget {
         if matches!(msg, EventMsg::ShutdownComplete) {
             return;
         }
-        self.dispatch_event_msg(None, msg, Some(ReplayKind::ThreadSnapshot));
+        self.dispatch_event_msg(/*id*/ None, msg, Some(ReplayKind::ThreadSnapshot));
     }
 
     /// Dispatch a protocol `EventMsg` to the appropriate handler.
@@ -5479,7 +5512,7 @@ impl ChatWidget {
         }
         // Avoid toggling running state for replayed history events on resume.
         if !from_replay && !self.bottom_pane.is_task_running() {
-            self.bottom_pane.set_task_running(true);
+            self.bottom_pane.set_task_running(/*running*/ true);
         }
         self.is_review_mode = true;
         let hint = review
@@ -5509,11 +5542,11 @@ impl ChatWidget {
                     let mut rendered: Vec<ratatui::text::Line<'static>> = vec!["".into()];
                     append_markdown(
                         &explanation,
-                        None,
+                        /*width*/ None,
                         Some(self.config.cwd.as_path()),
                         &mut rendered,
                     );
-                    let body_cell = AgentMessageCell::new(rendered, false);
+                    let body_cell = AgentMessageCell::new(rendered, /*is_first_line*/ false);
                     self.app_event_tx
                         .send(AppEvent::InsertHistoryCell(Box::new(body_cell)));
                 }
@@ -5757,7 +5790,10 @@ impl ChatWidget {
 
         self.config
             .config_layer_stack
-            .get_layers(ConfigLayerStackOrdering::LowestPrecedenceFirst, true)
+            .get_layers(
+                ConfigLayerStackOrdering::LowestPrecedenceFirst,
+                /*include_disabled*/ true,
+            )
             .iter()
             .find_map(|layer| match &layer.name {
                 ConfigLayerSource::Project { dot_codex_folder } => {
@@ -5771,7 +5807,7 @@ impl ChatWidget {
         self.status_line_project_root().map(|root| {
             root.file_name()
                 .map(|name| name.to_string_lossy().to_string())
-                .unwrap_or_else(|| format_directory_display(&root, None))
+                .unwrap_or_else(|| format_directory_display(&root, /*max_width*/ None))
         })
     }
 
@@ -5830,7 +5866,10 @@ impl ChatWidget {
                 Some(format!("{} {label}{fast_label}", self.model_display_name()))
             }
             StatusLineItem::CurrentDir => {
-                Some(format_directory_display(self.status_line_cwd(), None))
+                Some(format_directory_display(
+                    self.status_line_cwd(),
+                    /*max_width*/ None,
+                ))
             }
             StatusLineItem::ProjectRoot => self.status_line_project_root_name(),
             StatusLineItem::GitBranch => self.status_line_branch.clone(),
@@ -5965,7 +6004,10 @@ impl ChatWidget {
 
     fn clean_background_terminals(&mut self) {
         self.submit_op(Op::CleanBackgroundTerminals);
-        self.add_info_message("Stopping all background terminals.".to_string(), None);
+        self.add_info_message(
+            "Stopping all background terminals.".to_string(),
+            /*hint*/ None,
+        );
     }
 
     fn stop_rate_limit_poller(&mut self) {
@@ -5979,7 +6021,7 @@ impl ChatWidget {
     }
 
     fn prefetch_connectors(&mut self) {
-        self.prefetch_connectors_with_options(false);
+        self.prefetch_connectors_with_options(/*force_refetch*/ false);
     }
 
     fn prefetch_connectors_with_options(&mut self, force_refetch: bool) {
@@ -6034,7 +6076,7 @@ impl ChatWidget {
                 let connectors = connectors::merge_connectors_with_accessible(
                     all_connectors,
                     accessible_connectors,
-                    true,
+                    /*all_connectors_loaded*/ true,
                 );
                 Ok(ConnectorsSnapshot { connectors })
             }
@@ -6209,7 +6251,7 @@ impl ChatWidget {
         if !self.is_session_configured() {
             self.add_info_message(
                 "Model selection is disabled until startup completes.".to_string(),
-                None,
+                /*hint*/ None,
             );
             return;
         }
@@ -6219,7 +6261,7 @@ impl ChatWidget {
             Err(_) => {
                 self.add_info_message(
                     "Models are being updated; please try /model again in a moment.".to_string(),
-                    None,
+                    /*hint*/ None,
                 );
                 return;
             }
@@ -6231,7 +6273,7 @@ impl ChatWidget {
         if !self.is_session_configured() {
             self.add_info_message(
                 "Personality selection is disabled until startup completes.".to_string(),
-                None,
+                /*hint*/ None,
             );
             return;
         }
@@ -6592,7 +6634,7 @@ impl ChatWidget {
         if presets.is_empty() {
             self.add_info_message(
                 "No additional models are available right now.".to_string(),
-                None,
+                /*hint*/ None,
             );
             return;
         }
@@ -6638,7 +6680,7 @@ impl ChatWidget {
         if presets.is_empty() {
             self.add_info_message(
                 "No collaboration modes are available right now.".to_string(),
-                None,
+                /*hint*/ None,
             );
             return;
         }
@@ -7255,7 +7297,10 @@ impl ChatWidget {
             tx.send(AppEvent::UpdateSandboxPolicy(sandbox_clone));
             tx.send(AppEvent::UpdateApprovalsReviewer(approvals_reviewer));
             tx.send(AppEvent::InsertHistoryCell(Box::new(
-                history_cell::new_info_event(format!("Permissions updated to {label}"), None),
+                history_cell::new_info_event(
+                    format!("Permissions updated to {label}"),
+                    /*hint*/ None,
+                ),
             )));
         })]
     }
@@ -7899,9 +7944,11 @@ impl ChatWidget {
 
     /// Set the reasoning effort in the stored collaboration mode.
     pub(crate) fn set_reasoning_effort(&mut self, effort: Option<ReasoningEffortConfig>) {
-        self.current_collaboration_mode =
-            self.current_collaboration_mode
-                .with_updates(None, Some(effort), None);
+        self.current_collaboration_mode = self.current_collaboration_mode.with_updates(
+            /*model*/ None,
+            Some(effort),
+            /*developer_instructions*/ None,
+        );
         if self.collaboration_modes_enabled()
             && let Some(mask) = self.active_collaboration_mask.as_mut()
             && mask.mode != Some(ModeKind::Plan)
@@ -7962,9 +8009,11 @@ impl ChatWidget {
 
     /// Set the model in the widget's config copy and stored collaboration mode.
     pub(crate) fn set_model(&mut self, model: &str) {
-        self.current_collaboration_mode =
-            self.current_collaboration_mode
-                .with_updates(Some(model.to_string()), None, None);
+        self.current_collaboration_mode = self.current_collaboration_mode.with_updates(
+            Some(model.to_string()),
+            /*effort*/ None,
+            /*developer_instructions*/ None,
+        );
         if self.collaboration_modes_enabled()
             && let Some(mask) = self.active_collaboration_mask.as_mut()
         {
@@ -8248,7 +8297,7 @@ impl ChatWidget {
             message.push_str(" for ");
             message.push_str(next_mode.display_name());
             message.push_str(" mode.");
-            self.add_info_message(message, None);
+            self.add_info_message(message, /*hint*/ None);
         }
         self.request_redraw();
     }
@@ -8288,8 +8337,8 @@ impl ChatWidget {
         Box::new(history_cell::SessionHeaderHistoryCell::new_with_style(
             DEFAULT_MODEL_DISPLAY_NAME.to_string(),
             placeholder_style,
-            None,
-            false,
+            /*reasoning_effort*/ None,
+            /*show_fast_status*/ false,
             config.cwd.clone(),
             CODEX_CLI_VERSION,
         ))
@@ -8356,7 +8405,10 @@ impl ChatWidget {
         let mcp_manager = McpManager::new(Arc::new(PluginsManager::new(
             self.config.codex_home.clone(),
         )));
-        if mcp_manager.effective_servers(&self.config, None).is_empty() {
+        if mcp_manager
+            .effective_servers(&self.config, /*auth*/ None)
+            .is_empty()
+        {
             self.add_to_history(history_cell::empty_mcp_output());
         } else {
             self.submit_op(Op::ListMcpTools);
@@ -8380,7 +8432,7 @@ impl ChatWidget {
         match connectors_cache {
             ConnectorsCacheState::Ready(snapshot) => {
                 if snapshot.connectors.is_empty() {
-                    self.add_info_message("No apps available.".to_string(), None);
+                    self.add_info_message("No apps available.".to_string(), /*hint*/ None);
                 } else {
                     self.open_connectors_popup(&snapshot.connectors);
                 }
@@ -8406,8 +8458,9 @@ impl ChatWidget {
     }
 
     fn open_connectors_popup(&mut self, connectors: &[connectors::AppInfo]) {
-        self.bottom_pane
-            .show_selection_view(self.connectors_popup_params(connectors, None));
+        self.bottom_pane.show_selection_view(
+            self.connectors_popup_params(connectors, /*selected_connector_id*/ None),
+        );
     }
 
     fn connectors_loading_popup_params(&self) -> SelectionViewParams {
@@ -8502,7 +8555,10 @@ impl ChatWidget {
                 let missing_label_for_action = missing_label.clone();
                 item.actions = vec![Box::new(move |tx| {
                     tx.send(AppEvent::InsertHistoryCell(Box::new(
-                        history_cell::new_info_event(missing_label_for_action.clone(), None),
+                        history_cell::new_info_event(
+                            missing_label_for_action.clone(),
+                            /*hint*/ None,
+                        ),
                     )));
                 })];
                 item.dismiss_on_select = true;
@@ -8797,7 +8853,7 @@ impl ChatWidget {
         // Record outbound operation for session replay fidelity.
         crate::session_log::log_outbound_op(&op);
         if matches!(&op, Op::Review { .. }) && !self.bottom_pane.is_task_running() {
-            self.bottom_pane.set_task_running(true);
+            self.bottom_pane.set_task_running(/*running*/ true);
         }
         if let Err(e) = self.codex_op_tx.send(op) {
             tracing::error!("failed to submit op: {e}");
@@ -8848,7 +8904,7 @@ impl ChatWidget {
                     snapshot.connectors = connectors::merge_connectors_with_accessible(
                         Vec::new(),
                         snapshot.connectors,
-                        false,
+                        /*all_connectors_loaded*/ false,
                     );
                 }
                 snapshot.connectors =
@@ -8889,13 +8945,13 @@ impl ChatWidget {
                     self.bottom_pane.set_connectors_snapshot(Some(snapshot));
                 } else {
                     self.connectors_cache = ConnectorsCacheState::Failed(err);
-                    self.bottom_pane.set_connectors_snapshot(None);
+                    self.bottom_pane.set_connectors_snapshot(/*snapshot*/ None);
                 }
             }
         }
 
         if trigger_pending_force_refetch {
-            self.prefetch_connectors_with_options(true);
+            self.prefetch_connectors_with_options(/*force_refetch*/ true);
         }
     }
 
@@ -8924,7 +8980,7 @@ impl ChatWidget {
 
     fn refresh_plugin_mentions(&mut self) {
         if !self.config.features.enabled(Feature::Plugins) {
-            self.bottom_pane.set_plugin_mentions(None);
+            self.bottom_pane.set_plugin_mentions(/*plugins*/ None);
             return;
         }
 
@@ -9033,7 +9089,7 @@ impl ChatWidget {
     }
 
     pub(crate) async fn show_review_commit_picker(&mut self, cwd: &Path) {
-        let commits = codex_core::git_info::recent_commits(cwd, 100).await;
+        let commits = codex_core::git_info::recent_commits(cwd, /*limit*/ 100).await;
 
         let mut items: Vec<SelectionItem> = Vec::with_capacity(commits.len());
         for entry in commits {
@@ -9075,7 +9131,7 @@ impl ChatWidget {
         let view = CustomPromptView::new(
             "Custom review instructions".to_string(),
             "Type instructions and press Enter".to_string(),
-            None,
+            /*context_label*/ None,
             Box::new(move |prompt: String| {
                 let trimmed = prompt.trim().to_string();
                 if trimmed.is_empty() {
@@ -9166,14 +9222,18 @@ impl ChatWidget {
 
     fn as_renderable(&self) -> RenderableItem<'_> {
         let active_cell_renderable = match &self.active_cell {
-            Some(cell) => RenderableItem::Borrowed(cell).inset(Insets::tlbr(1, 0, 0, 0)),
+            Some(cell) => RenderableItem::Borrowed(cell).inset(Insets::tlbr(
+                /*top*/ 1, /*left*/ 0, /*bottom*/ 0, /*right*/ 0,
+            )),
             None => RenderableItem::Owned(Box::new(())),
         };
         let mut flex = FlexRenderable::new();
-        flex.push(1, active_cell_renderable);
+        flex.push(/*flex*/ 1, active_cell_renderable);
         flex.push(
-            0,
-            RenderableItem::Borrowed(&self.bottom_pane).inset(Insets::tlbr(1, 0, 0, 0)),
+            /*flex*/ 0,
+            RenderableItem::Borrowed(&self.bottom_pane).inset(Insets::tlbr(
+                /*top*/ 1, /*left*/ 0, /*bottom*/ 0, /*right*/ 0,
+            )),
         );
         RenderableItem::Owned(Box::new(flex))
     }
@@ -9265,7 +9325,10 @@ impl Notification {
                     .unwrap_or_else(|| "Agent turn complete".to_string())
             }
             Notification::ExecApprovalRequested { command } => {
-                format!("Approval requested: {}", truncate_text(command, 30))
+                format!(
+                    "Approval requested: {}",
+                    truncate_text(command, /*max_graphemes*/ 30)
+                )
             }
             Notification::EditApprovalRequested { cwd, changes } => {
                 format!(
@@ -9352,7 +9415,7 @@ impl Notification {
         if summary.is_empty() {
             None
         } else {
-            Some(truncate_text(summary, 30))
+            Some(truncate_text(summary, /*max_graphemes*/ 30))
         }
     }
 }

--- a/codex-rs/tui/src/chatwidget/agent.rs
+++ b/codex-rs/tui/src/chatwidget/agent.rs
@@ -46,7 +46,7 @@ pub(crate) fn spawn_agent(
                 tracing::error!("{message}");
                 app_event_tx_clone.send(AppEvent::CodexEvent(Event {
                     id: "".to_string(),
-                    msg: EventMsg::Error(err.to_error_event(None)),
+                    msg: EventMsg::Error(err.to_error_event(/*message_prefix*/ None)),
                 }));
                 app_event_tx_clone.send(AppEvent::FatalExitRequest(message));
                 tracing::error!("failed to initialize codex: {err}");

--- a/codex-rs/tui/src/chatwidget/realtime.rs
+++ b/codex-rs/tui/src/chatwidget/realtime.rs
@@ -183,7 +183,7 @@ impl ChatWidget {
             self.realtime_conversation.warned_audio_only_submission = true;
             self.add_info_message(
                 "Realtime voice mode is audio-only. Use /realtime to stop.".to_string(),
-                None,
+                /*hint*/ None,
             );
         } else {
             self.request_redraw();
@@ -212,7 +212,7 @@ impl ChatWidget {
     pub(super) fn request_realtime_conversation_close(&mut self, info_message: Option<String>) {
         if !self.realtime_conversation.is_live() {
             if let Some(message) = info_message {
-                self.add_info_message(message, None);
+                self.add_info_message(message, /*hint*/ None);
             }
             return;
         }
@@ -221,10 +221,10 @@ impl ChatWidget {
         self.realtime_conversation.phase = RealtimeConversationPhase::Stopping;
         self.submit_op(Op::RealtimeConversationClose);
         self.stop_realtime_local_audio();
-        self.set_footer_hint_override(None);
+        self.set_footer_hint_override(/*items*/ None);
 
         if let Some(message) = info_message {
-            self.add_info_message(message, None);
+            self.add_info_message(message, /*hint*/ None);
         } else {
             self.request_redraw();
         }
@@ -232,7 +232,7 @@ impl ChatWidget {
 
     pub(super) fn reset_realtime_conversation_state(&mut self) {
         self.stop_realtime_local_audio();
-        self.set_footer_hint_override(None);
+        self.set_footer_hint_override(/*items*/ None);
         self.realtime_conversation.phase = RealtimeConversationPhase::Inactive;
         self.realtime_conversation.requested_close = false;
         self.realtime_conversation.session_id = None;
@@ -282,7 +282,10 @@ impl ChatWidget {
         let reason = ev.reason;
         self.reset_realtime_conversation_state();
         if !requested && let Some(reason) = reason {
-            self.add_info_message(format!("Realtime voice mode closed: {reason}"), None);
+            self.add_info_message(
+                format!("Realtime voice mode closed: {reason}"),
+                /*hint*/ None,
+            );
         }
         self.request_redraw();
     }

--- a/codex-rs/tui/src/chatwidget/skills.rs
+++ b/codex-rs/tui/src/chatwidget/skills.rs
@@ -61,7 +61,7 @@ impl ChatWidget {
 
     pub(crate) fn open_manage_skills_popup(&mut self) {
         if self.skills_all.is_empty() {
-            self.add_info_message("No skills available.".to_string(), None);
+            self.add_info_message("No skills available.".to_string(), /*hint*/ None);
             return;
         }
 
@@ -133,7 +133,7 @@ impl ChatWidget {
         }
         self.add_info_message(
             format!("{enabled_count} skills enabled, {disabled_count} skills disabled"),
-            None,
+            /*hint*/ None,
         );
     }
 

--- a/codex-rs/tui/src/cwd_prompt.rs
+++ b/codex-rs/tui/src/cwd_prompt.rs
@@ -212,20 +212,23 @@ impl WidgetRef for &CwdPromptScreen {
                 "Session = latest cwd recorded in the {action_past} session"
             ))
             .dim()
-            .inset(Insets::tlbr(0, 2, 0, 0)),
+            .inset(Insets::tlbr(
+                /*top*/ 0, /*left*/ 2, /*bottom*/ 0, /*right*/ 0,
+            )),
         );
         column.push(
-            Line::from("Current = your current working directory".dim())
-                .inset(Insets::tlbr(0, 2, 0, 0)),
+            Line::from("Current = your current working directory".dim()).inset(Insets::tlbr(
+                /*top*/ 0, /*left*/ 2, /*bottom*/ 0, /*right*/ 0,
+            )),
         );
         column.push("");
         column.push(selection_option_row(
-            0,
+            /*index*/ 0,
             format!("Use session directory ({session_cwd})"),
             self.highlighted == CwdSelection::Session,
         ));
         column.push(selection_option_row(
-            1,
+            /*index*/ 1,
             format!("Use current directory ({current_cwd})"),
             self.highlighted == CwdSelection::Current,
         ));
@@ -236,7 +239,9 @@ impl WidgetRef for &CwdPromptScreen {
                 key_hint::plain(KeyCode::Enter).into(),
                 " to continue".dim(),
             ])
-            .inset(Insets::tlbr(0, 2, 0, 0)),
+            .inset(Insets::tlbr(
+                /*top*/ 0, /*left*/ 2, /*bottom*/ 0, /*right*/ 0,
+            )),
         );
         column.render(area, buf);
     }

--- a/codex-rs/tui/src/debug_config.rs
+++ b/codex-rs/tui/src/debug_config.rs
@@ -60,7 +60,10 @@ fn render_debug_config_lines(stack: &ConfigLayerStack) -> Vec<Line<'static>> {
             .bold()
             .into(),
     );
-    let layers = stack.get_layers(ConfigLayerStackOrdering::LowestPrecedenceFirst, true);
+    let layers = stack.get_layers(
+        ConfigLayerStackOrdering::LowestPrecedenceFirst,
+        /*include_disabled*/ true,
+    );
     if layers.is_empty() {
         lines.push("  <none>".dim().into());
     } else {
@@ -186,7 +189,7 @@ fn render_non_file_layer_details(layer: &ConfigLayerEntry) -> Vec<Line<'static>>
 
 fn render_session_flag_details(config: &TomlValue) -> Vec<Line<'static>> {
     let mut pairs = Vec::new();
-    flatten_toml_key_values(config, None, &mut pairs);
+    flatten_toml_key_values(config, /*prefix*/ None, &mut pairs);
 
     if pairs.is_empty() {
         return vec!["     - <none>".dim().into()];

--- a/codex-rs/tui/src/diff_render.rs
+++ b/codex-rs/tui/src/diff_render.rs
@@ -306,13 +306,13 @@ impl DiffSummary {
 impl Renderable for FileChange {
     fn render(&self, area: Rect, buf: &mut Buffer) {
         let mut lines = vec![];
-        render_change(self, &mut lines, area.width as usize, None);
+        render_change(self, &mut lines, area.width as usize, /*lang*/ None);
         Paragraph::new(lines).render(area, buf);
     }
 
     fn desired_height(&self, width: u16) -> u16 {
         let mut lines = vec![];
-        render_change(self, &mut lines, width as usize, None);
+        render_change(self, &mut lines, width as usize, /*lang*/ None);
         lines.len() as u16
     }
 }
@@ -332,7 +332,9 @@ impl From<DiffSummary> for Box<dyn Renderable> {
             rows.push(Box::new(RtLine::from("")));
             rows.push(Box::new(InsetRenderable::new(
                 Box::new(row.change) as Box<dyn Renderable>,
-                Insets::tlbr(0, 2, 0, 0),
+                Insets::tlbr(
+                    /*top*/ 0, /*left*/ 2, /*bottom*/ 0, /*right*/ 0,
+                ),
             )));
         }
 
@@ -502,7 +504,7 @@ fn render_change(
                         raw,
                         width,
                         line_number_width,
-                        None,
+                        /*syntax_spans*/ None,
                         style_context.theme,
                         style_context.color_level,
                         style_context.diff_backgrounds,
@@ -534,7 +536,7 @@ fn render_change(
                         raw,
                         width,
                         line_number_width,
-                        None,
+                        /*syntax_spans*/ None,
                         style_context.theme,
                         style_context.color_level,
                         style_context.diff_backgrounds,
@@ -649,7 +651,7 @@ fn render_change(
                                             s,
                                             width,
                                             line_number_width,
-                                            None,
+                                            /*syntax_spans*/ None,
                                             style_context.theme,
                                             style_context.color_level,
                                             style_context.diff_backgrounds,
@@ -682,7 +684,7 @@ fn render_change(
                                             s,
                                             width,
                                             line_number_width,
-                                            None,
+                                            /*syntax_spans*/ None,
                                             style_context.theme,
                                             style_context.color_level,
                                             style_context.diff_backgrounds,
@@ -715,7 +717,7 @@ fn render_change(
                                             s,
                                             width,
                                             line_number_width,
-                                            None,
+                                            /*syntax_spans*/ None,
                                             style_context.theme,
                                             style_context.color_level,
                                             style_context.diff_backgrounds,
@@ -796,7 +798,7 @@ pub(crate) fn push_wrapped_diff_line_with_style_context(
         text,
         width,
         line_number_width,
-        None,
+        /*syntax_spans*/ None,
         style_context.theme,
         style_context.color_level,
         style_context.diff_backgrounds,

--- a/codex-rs/tui/src/exec_cell/render.rs
+++ b/codex-rs/tui/src/exec_cell/render.rs
@@ -681,9 +681,9 @@ impl ExecDisplayLayout {
 
 const EXEC_DISPLAY_LAYOUT: ExecDisplayLayout = ExecDisplayLayout::new(
     PrefixedBlock::new("  │ ", "  │ "),
-    2,
+    /*command_continuation_max_lines*/ 2,
     PrefixedBlock::new("  └ ", "    "),
-    5,
+    /*output_max_lines*/ 5,
 );
 
 #[cfg(test)]

--- a/codex-rs/tui/src/file_search.rs
+++ b/codex-rs/tui/src/file_search.rs
@@ -87,7 +87,7 @@ impl FileSearchManager {
                 ..Default::default()
             },
             reporter,
-            None,
+            /*cancel_flag*/ None,
         );
         match session {
             Ok(session) => st.session = Some(session),

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -782,7 +782,7 @@ fn truncate_exec_snippet(full_cmd: &str) -> String {
         Some((first, _)) => format!("{first} ..."),
         None => full_cmd.to_string(),
     };
-    snippet = truncate_text(&snippet, 80);
+    snippet = truncate_text(&snippet, /*max_graphemes*/ 80);
     snippet
 }
 
@@ -1003,7 +1003,7 @@ pub(crate) fn card_inner_width(width: u16, max_inner_width: usize) -> Option<usi
 
 /// Render `lines` inside a border sized to the widest span in the content.
 pub(crate) fn with_border(lines: Vec<Line<'static>>) -> Vec<Line<'static>> {
-    with_border_internal(lines, None)
+    with_border_internal(lines, /*forced_inner_width*/ None)
 }
 
 /// Render `lines` inside a border whose inner width is at least `inner_width`.
@@ -1660,7 +1660,7 @@ pub(crate) fn new_active_web_search_call(
     query: String,
     animations_enabled: bool,
 ) -> WebSearchCell {
-    WebSearchCell::new(call_id, query, None, animations_enabled)
+    WebSearchCell::new(call_id, query, /*action*/ None, animations_enabled)
 }
 
 pub(crate) fn new_web_search_call(
@@ -1668,7 +1668,12 @@ pub(crate) fn new_web_search_call(
     query: String,
     action: WebSearchAction,
 ) -> WebSearchCell {
-    let mut cell = WebSearchCell::new(call_id, query, Some(action), false);
+    let mut cell = WebSearchCell::new(
+        call_id,
+        query,
+        Some(action),
+        /*animations_enabled*/ false,
+    );
     cell.complete();
     cell
 }
@@ -1812,7 +1817,7 @@ pub(crate) fn new_mcp_tools_output(
     }
 
     let mcp_manager = McpManager::new(Arc::new(PluginsManager::new(config.codex_home.clone())));
-    let effective_servers = mcp_manager.effective_servers(config, None);
+    let effective_servers = mcp_manager.effective_servers(config, /*auth*/ None);
     let mut servers: Vec<_> = effective_servers.iter().collect();
     servers.sort_by(|(a, _), (b, _)| a.cmp(b));
 
@@ -2345,7 +2350,7 @@ pub(crate) fn new_reasoning_summary_block(
                     header_buffer,
                     summary_buffer,
                     &cwd,
-                    false,
+                    /*transcript_only*/ false,
                 ));
             }
         }
@@ -2354,7 +2359,7 @@ pub(crate) fn new_reasoning_summary_block(
         "".to_string(),
         full_reasoning_buffer.to_string(),
         &cwd,
-        true,
+        /*transcript_only*/ true,
     ))
 }
 

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -397,7 +397,7 @@ pub async fn run_main(
 
     let cloud_auth_manager = AuthManager::shared(
         codex_home.to_path_buf(),
-        false,
+        /*enable_codex_api_key_env*/ false,
         config_toml.cli_auth_credentials_store.unwrap_or_default(),
     );
     let chatgpt_base_url = config_toml
@@ -560,7 +560,12 @@ pub async fn run_main(
     }
 
     let otel = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        codex_core::otel_init::build_provider(&config, env!("CARGO_PKG_VERSION"), None, true)
+        codex_core::otel_init::build_provider(
+            &config,
+            env!("CARGO_PKG_VERSION"),
+            /*service_name_override*/ None,
+            /*default_analytics_enabled*/ true,
+        )
     })) {
         Ok(Ok(otel)) => otel,
         Ok(Err(e)) => {
@@ -666,7 +671,7 @@ async fn run_ratatui_app(
 
     let auth_manager = AuthManager::shared(
         initial_config.codex_home.clone(),
-        false,
+        /*enable_codex_api_key_env*/ false,
         initial_config.cli_auth_credentials_store_mode,
     );
     let login_status = get_login_status(&initial_config);
@@ -773,19 +778,24 @@ async fn run_ratatui_app(
             let provider_filter = vec![config.model_provider_id.clone()];
             match RolloutRecorder::list_threads(
                 &config,
-                1,
-                None,
+                /*page_size*/ 1,
+                /*cursor*/ None,
                 ThreadSortKey::UpdatedAt,
                 INTERACTIVE_SESSION_SOURCES,
                 Some(provider_filter.as_slice()),
                 &config.model_provider_id,
-                None,
+                /*search_term*/ None,
             )
             .await
             {
                 Ok(page) => match page.items.first() {
                     Some(item) => {
-                        match resolve_session_thread_id(item.path.as_path(), None).await {
+                        match resolve_session_thread_id(
+                            item.path.as_path(),
+                            /*id_str_if_uuid*/ None,
+                        )
+                        .await
+                        {
                             Some(thread_id) => resume_picker::SessionSelection::Fork(
                                 resume_picker::SessionTarget {
                                     path: item.path.clone(),
@@ -868,8 +878,8 @@ async fn run_ratatui_app(
         };
         match RolloutRecorder::find_latest_thread_path(
             &config,
-            1,
-            None,
+            /*page_size*/ 1,
+            /*cursor*/ None,
             ThreadSortKey::UpdatedAt,
             INTERACTIVE_SESSION_SOURCES,
             Some(provider_filter.as_slice()),
@@ -878,30 +888,34 @@ async fn run_ratatui_app(
         )
         .await
         {
-            Ok(Some(path)) => match resolve_session_thread_id(path.as_path(), None).await {
-                Some(thread_id) => {
-                    resume_picker::SessionSelection::Resume(resume_picker::SessionTarget {
-                        path,
-                        thread_id,
-                    })
+            Ok(Some(path)) => {
+                match resolve_session_thread_id(path.as_path(), /*id_str_if_uuid*/ None).await {
+                    Some(thread_id) => {
+                        resume_picker::SessionSelection::Resume(resume_picker::SessionTarget {
+                            path,
+                            thread_id,
+                        })
+                    }
+                    None => {
+                        let rollout_path = path.display();
+                        error!(
+                            "Error reading session metadata from latest rollout: {rollout_path}"
+                        );
+                        restore();
+                        session_log::log_session_end();
+                        let _ = tui.terminal.clear();
+                        return Ok(AppExitInfo {
+                            token_usage: codex_protocol::protocol::TokenUsage::default(),
+                            thread_id: None,
+                            thread_name: None,
+                            update_action: None,
+                            exit_reason: ExitReason::Fatal(format!(
+                                "Found latest saved session at {rollout_path}, but failed to read its metadata. Run `codex resume` to choose from existing sessions."
+                            )),
+                        });
+                    }
                 }
-                None => {
-                    let rollout_path = path.display();
-                    error!("Error reading session metadata from latest rollout: {rollout_path}");
-                    restore();
-                    session_log::log_session_end();
-                    let _ = tui.terminal.clear();
-                    return Ok(AppExitInfo {
-                        token_usage: codex_protocol::protocol::TokenUsage::default(),
-                        thread_id: None,
-                        thread_name: None,
-                        update_action: None,
-                        exit_reason: ExitReason::Fatal(format!(
-                            "Found latest saved session at {rollout_path}, but failed to read its metadata. Run `codex resume` to choose from existing sessions."
-                        )),
-                    });
-                }
-            },
+            }
             _ => resume_picker::SessionSelection::StartFresh,
         }
     } else if cli.resume_picker {
@@ -1222,8 +1236,13 @@ async fn load_config_or_exit(
     overrides: ConfigOverrides,
     cloud_requirements: CloudRequirementsLoader,
 ) -> Config {
-    load_config_or_exit_with_fallback_cwd(cli_kv_overrides, overrides, cloud_requirements, None)
-        .await
+    load_config_or_exit_with_fallback_cwd(
+        cli_kv_overrides,
+        overrides,
+        cloud_requirements,
+        /*fallback_cwd*/ None,
+    )
+    .await
 }
 
 async fn load_config_or_exit_with_fallback_cwd(

--- a/codex-rs/tui/src/live_wrap.rs
+++ b/codex-rs/tui/src/live_wrap.rs
@@ -66,7 +66,7 @@ impl RowBuilder {
                 if start < i {
                     self.current_line.push_str(&fragment[start..i]);
                 }
-                self.flush_current_line(true);
+                self.flush_current_line(/*explicit_break*/ true);
                 start = i + ch.len_utf8();
             }
         }
@@ -78,7 +78,7 @@ impl RowBuilder {
 
     /// Mark the end of the current logical line (equivalent to pushing a '\n').
     pub fn end_line(&mut self) {
-        self.flush_current_line(true);
+        self.flush_current_line(/*explicit_break*/ true);
     }
 
     /// Drain and return all produced rows.

--- a/codex-rs/tui/src/main.rs
+++ b/codex-rs/tui/src/main.rs
@@ -91,7 +91,7 @@ fn main() -> anyhow::Result<()> {
                     into_app_server_cli(inner),
                     arg0_paths,
                     codex_core::config_loader::LoaderOverrides::default(),
-                    None,
+                    /*remote*/ None,
                 )
                 .await?,
             )

--- a/codex-rs/tui/src/markdown_render.rs
+++ b/codex-rs/tui/src/markdown_render.rs
@@ -87,7 +87,7 @@ impl IndentContext {
 }
 
 pub fn render_markdown_text(input: &str) -> Text<'static> {
-    render_markdown_text_with_width(input, None)
+    render_markdown_text_with_width(input, /*width*/ None)
 }
 
 /// Render markdown using the current process working directory for local file-link display.
@@ -227,8 +227,8 @@ where
                 self.push_line(Line::from("———"));
                 self.needs_newline = true;
             }
-            Event::Html(html) => self.html(html, false),
-            Event::InlineHtml(html) => self.html(html, true),
+            Event::Html(html) => self.html(html, /*inline*/ false),
+            Event::InlineHtml(html) => self.html(html, /*inline*/ true),
             Event::FootnoteReference(_) => {}
             Event::TaskListMarker(_) => {}
         }
@@ -352,8 +352,11 @@ where
             self.push_blank_line();
             self.needs_newline = false;
         }
-        self.indent_stack
-            .push(IndentContext::new(vec![Span::from("> ")], None, false));
+        self.indent_stack.push(IndentContext::new(
+            vec![Span::from("> ")],
+            /*marker*/ None,
+            /*is_list*/ false,
+        ));
     }
 
     fn end_blockquote(&mut self) {
@@ -512,8 +515,11 @@ where
             let indent_len = if is_ordered { width + 2 } else { width + 1 };
             vec![Span::from(" ".repeat(indent_len))]
         };
-        self.indent_stack
-            .push(IndentContext::new(indent_prefix, marker, true));
+        self.indent_stack.push(IndentContext::new(
+            indent_prefix,
+            marker,
+            /*is_list*/ true,
+        ));
         self.needs_newline = false;
     }
 
@@ -538,8 +544,8 @@ where
 
         self.indent_stack.push(IndentContext::new(
             vec![indent.unwrap_or_default()],
-            None,
-            false,
+            /*marker*/ None,
+            /*is_list*/ false,
         ));
         self.needs_newline = true;
     }
@@ -659,7 +665,7 @@ where
         let was_pending = self.pending_marker_line;
 
         self.current_initial_indent = self.prefix_spans(was_pending);
-        self.current_subsequent_indent = self.prefix_spans(false);
+        self.current_subsequent_indent = self.prefix_spans(/*pending_marker_line*/ false);
         self.current_line_style = style;
         self.current_line_content = Some(line);
         self.current_line_in_code_block = self.in_code_block;

--- a/codex-rs/tui/src/model_migration.rs
+++ b/codex-rs/tui/src/model_migration.rs
@@ -307,7 +307,9 @@ impl ModelMigrationScreen {
             column.push(
                 Paragraph::new(line.clone())
                     .wrap(Wrap { trim: false })
-                    .inset(Insets::tlbr(0, 2, 0, 0)),
+                    .inset(Insets::tlbr(
+                        /*top*/ 0, /*left*/ 2, /*bottom*/ 0, /*right*/ 0,
+                    )),
             );
         }
     }
@@ -326,7 +328,12 @@ impl ModelMigrationScreen {
             column.push(
                 Paragraph::new(line)
                     .wrap(Wrap { trim: false })
-                    .inset(Insets::tlbr(0, horizontal_inset, 0, 0)),
+                    .inset(Insets::tlbr(
+                        /*top*/ 0,
+                        horizontal_inset,
+                        /*bottom*/ 0,
+                        /*right*/ 0,
+                    )),
             );
         }
     }
@@ -336,7 +343,9 @@ impl ModelMigrationScreen {
         column.push(
             Paragraph::new("Choose how you'd like Codex to proceed.")
                 .wrap(Wrap { trim: false })
-                .inset(Insets::tlbr(0, 2, 0, 0)),
+                .inset(Insets::tlbr(
+                    /*top*/ 0, /*left*/ 2, /*bottom*/ 0, /*right*/ 0,
+                )),
         );
         column.push(Line::from(""));
 
@@ -359,7 +368,9 @@ impl ModelMigrationScreen {
                 key_hint::plain(KeyCode::Enter).into(),
                 " to confirm".dim(),
             ])
-            .inset(Insets::tlbr(0, 2, 0, 0)),
+            .inset(Insets::tlbr(
+                /*top*/ 0, /*left*/ 2, /*bottom*/ 0, /*right*/ 0,
+            )),
         );
     }
 }

--- a/codex-rs/tui/src/multi_agents.rs
+++ b/codex-rs/tui/src/multi_agents.rs
@@ -224,7 +224,7 @@ pub(crate) fn interaction_end(ev: CollabAgentInteractionEndEvent) -> PlainHistor
             nickname: receiver_agent_nickname.as_deref(),
             role: receiver_agent_role.as_deref(),
         },
-        None,
+        /*spawn_request*/ None,
     );
 
     let mut details = Vec::new();
@@ -244,7 +244,11 @@ pub(crate) fn waiting_begin(ev: CollabWaitingBeginEvent) -> PlainHistoryCell {
     let receiver_agents = merge_wait_receivers(&receiver_thread_ids, receiver_agents);
 
     let title = match receiver_agents.as_slice() {
-        [receiver] => title_with_agent("Waiting for", agent_label_from_ref(receiver), None),
+        [receiver] => title_with_agent(
+            "Waiting for",
+            agent_label_from_ref(receiver),
+            /*spawn_request*/ None,
+        ),
         [] => title_text("Waiting for agents"),
         _ => title_text(format!("Waiting for {} agents", receiver_agents.len())),
     };
@@ -290,7 +294,7 @@ pub(crate) fn close_end(ev: CollabCloseEndEvent) -> PlainHistoryCell {
                 nickname: receiver_agent_nickname.as_deref(),
                 role: receiver_agent_role.as_deref(),
             },
-            None,
+            /*spawn_request*/ None,
         ),
         Vec::new(),
     )
@@ -313,7 +317,7 @@ pub(crate) fn resume_begin(ev: CollabResumeBeginEvent) -> PlainHistoryCell {
                 nickname: receiver_agent_nickname.as_deref(),
                 role: receiver_agent_role.as_deref(),
             },
-            None,
+            /*spawn_request*/ None,
         ),
         Vec::new(),
     )
@@ -337,7 +341,7 @@ pub(crate) fn resume_end(ev: CollabResumeEndEvent) -> PlainHistoryCell {
                 nickname: receiver_agent_nickname.as_deref(),
                 role: receiver_agent_role.as_deref(),
             },
-            None,
+            /*spawn_request*/ None,
         ),
         vec![status_summary_line(&status)],
     )

--- a/codex-rs/tui/src/onboarding/auth.rs
+++ b/codex-rs/tui/src/onboarding/auth.rs
@@ -137,19 +137,19 @@ impl KeyboardHandler for AuthModeWidget {
 
         match key_event.code {
             KeyCode::Up | KeyCode::Char('k') => {
-                self.move_highlight(-1);
+                self.move_highlight(/*delta*/ -1);
             }
             KeyCode::Down | KeyCode::Char('j') => {
-                self.move_highlight(1);
+                self.move_highlight(/*delta*/ 1);
             }
             KeyCode::Char('1') => {
-                self.select_option_by_index(0);
+                self.select_option_by_index(/*index*/ 0);
             }
             KeyCode::Char('2') => {
-                self.select_option_by_index(1);
+                self.select_option_by_index(/*index*/ 1);
             }
             KeyCode::Char('3') => {
-                self.select_option_by_index(2);
+                self.select_option_by_index(/*index*/ 2);
             }
             KeyCode::Enter => {
                 let sign_in_state = { (*self.sign_in_state.read().unwrap()).clone() };

--- a/codex-rs/tui/src/onboarding/trust_directory.rs
+++ b/codex-rs/tui/src/onboarding/trust_directory.rs
@@ -56,7 +56,7 @@ impl WidgetRef for &TrustDirectoryWidget {
                 "Do you trust the contents of this directory? Working with untrusted contents comes with higher risk of prompt injection.".to_string(),
             )
                 .wrap(Wrap { trim: true })
-                .inset(Insets::tlbr(0, 2, 0, 0)),
+                .inset(Insets::tlbr(/*top*/ 0, /*left*/ 2, /*bottom*/ 0, /*right*/ 0)),
         );
         column.push("");
 
@@ -80,7 +80,9 @@ impl WidgetRef for &TrustDirectoryWidget {
                 Paragraph::new(error.to_string())
                     .red()
                     .wrap(Wrap { trim: true })
-                    .inset(Insets::tlbr(0, 2, 0, 0)),
+                    .inset(Insets::tlbr(
+                        /*top*/ 0, /*left*/ 2, /*bottom*/ 0, /*right*/ 0,
+                    )),
             );
             column.push("");
         }
@@ -95,7 +97,9 @@ impl WidgetRef for &TrustDirectoryWidget {
                     " to continue".dim()
                 },
             ])
-            .inset(Insets::tlbr(0, 2, 0, 0)),
+            .inset(Insets::tlbr(
+                /*top*/ 0, /*left*/ 2, /*bottom*/ 0, /*right*/ 0,
+            )),
         );
 
         column.render(area, buf);

--- a/codex-rs/tui/src/pager_overlay.rs
+++ b/codex-rs/tui/src/pager_overlay.rs
@@ -457,7 +457,7 @@ impl TranscriptOverlay {
     pub(crate) fn new(transcript_cells: Vec<Arc<dyn HistoryCell>>) -> Self {
         Self {
             view: PagerView::new(
-                Self::render_cells(&transcript_cells, None),
+                Self::render_cells(&transcript_cells, /*highlight_cell*/ None),
                 "T R A N S C R I P T".to_string(),
                 usize::MAX,
             ),
@@ -495,7 +495,9 @@ impl TranscriptOverlay {
                 if !c.is_stream_continuation() && i > 0 {
                     cell_renderable = Box::new(InsetRenderable::new(
                         cell_renderable,
-                        Insets::tlbr(1, 0, 0, 0),
+                        Insets::tlbr(
+                            /*top*/ 1, /*left*/ 0, /*bottom*/ 0, /*right*/ 0,
+                        ),
                     ));
                 }
                 v.push(cell_renderable);
@@ -528,8 +530,12 @@ impl TranscriptOverlay {
             {
                 // The tail was rendered as the only entry, so it lacks a top
                 // inset; add one now that it follows a committed cell.
-                Box::new(InsetRenderable::new(tail, Insets::tlbr(1, 0, 0, 0)))
-                    as Box<dyn Renderable>
+                Box::new(InsetRenderable::new(
+                    tail,
+                    Insets::tlbr(
+                        /*top*/ 1, /*left*/ 0, /*bottom*/ 0, /*right*/ 0,
+                    ),
+                )) as Box<dyn Renderable>
             } else {
                 tail
             };
@@ -649,7 +655,12 @@ impl TranscriptOverlay {
         let paragraph = Paragraph::new(Text::from(lines)).wrap(Wrap { trim: false });
         let mut renderable: Box<dyn Renderable> = Box::new(CachedRenderable::new(paragraph));
         if has_prior_cells && !is_stream_continuation {
-            renderable = Box::new(InsetRenderable::new(renderable, Insets::tlbr(1, 0, 0, 0)));
+            renderable = Box::new(InsetRenderable::new(
+                renderable,
+                Insets::tlbr(
+                    /*top*/ 1, /*left*/ 0, /*bottom*/ 0, /*right*/ 0,
+                ),
+            ));
         }
         renderable
     }
@@ -721,7 +732,7 @@ impl StaticOverlay {
 
     pub(crate) fn with_renderables(renderables: Vec<Box<dyn Renderable>>, title: String) -> Self {
         Self {
-            view: PagerView::new(renderables, title, 0),
+            view: PagerView::new(renderables, title, /*scroll_offset*/ 0),
             is_done: false,
         }
     }

--- a/codex-rs/tui/src/public_widgets/composer_input.rs
+++ b/codex-rs/tui/src/public_widgets/composer_input.rs
@@ -37,7 +37,13 @@ impl ComposerInput {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         let sender = AppEventSender::new(tx.clone());
         // `enhanced_keys_supported=true` enables Shift+Enter newline hint/behavior.
-        let inner = ChatComposer::new(true, sender, true, "Compose new task".to_string(), false);
+        let inner = ChatComposer::new(
+            /*has_input_focus*/ true,
+            sender,
+            /*enhanced_keys_supported*/ true,
+            "Compose new task".to_string(),
+            /*disable_paste_burst*/ false,
+        );
         Self { inner, _tx: tx, rx }
     }
 
@@ -80,7 +86,7 @@ impl ComposerInput {
 
     /// Clear any previously set custom hint items and restore the default hints.
     pub fn clear_hint_items(&mut self) {
-        self.inner.set_footer_hint_override(None);
+        self.inner.set_footer_hint_override(/*items*/ None);
     }
 
     /// Desired height (in rows) for a given width.

--- a/codex-rs/tui/src/resume_picker.rs
+++ b/codex-rs/tui/src/resume_picker.rs
@@ -167,7 +167,7 @@ async fn run_session_picker(
                 INTERACTIVE_SESSION_SOURCES,
                 Some(provider_filter.as_slice()),
                 request.default_provider.as_str(),
-                None,
+                /*search_term*/ None,
             )
             .await;
             let _ = tx.send(BackgroundEvent::PageLoaded {
@@ -416,7 +416,13 @@ impl PickerState {
                     let path = row.path.clone();
                     let thread_id = match row.thread_id {
                         Some(thread_id) => Some(thread_id),
-                        None => crate::resolve_session_thread_id(path.as_path(), None).await,
+                        None => {
+                            crate::resolve_session_thread_id(
+                                path.as_path(),
+                                /*id_str_if_uuid*/ None,
+                            )
+                            .await
+                        }
                     };
                     if let Some(thread_id) = thread_id {
                         return Ok(Some(self.action.selection(path, thread_id)));
@@ -1255,14 +1261,14 @@ fn calculate_column_metrics(rows: &[Row], include_cwd: bool) -> ColumnMetrics {
         let created = format_created_label(row);
         let updated = format_updated_label(row);
         let branch_raw = row.git_branch.clone().unwrap_or_default();
-        let branch = right_elide(&branch_raw, 24);
+        let branch = right_elide(&branch_raw, /*max*/ 24);
         let cwd = if include_cwd {
             let cwd_raw = row
                 .cwd
                 .as_ref()
                 .map(|p| display_path_for(p, std::path::Path::new("/")))
                 .unwrap_or_default();
-            right_elide(&cwd_raw, 24)
+            right_elide(&cwd_raw, /*max*/ 24)
         } else {
             String::new()
         };

--- a/codex-rs/tui/src/selection_list.rs
+++ b/codex-rs/tui/src/selection_list.rs
@@ -12,7 +12,7 @@ pub(crate) fn selection_option_row(
     label: String,
     is_selected: bool,
 ) -> Box<dyn Renderable> {
-    selection_option_row_with_dim(index, label, is_selected, false)
+    selection_option_row_with_dim(index, label, is_selected, /*dim*/ false)
 }
 
 pub(crate) fn selection_option_row_with_dim(

--- a/codex-rs/tui/src/status_indicator_widget.rs
+++ b/codex-rs/tui/src/status_indicator_widget.rs
@@ -209,7 +209,7 @@ impl StatusIndicatorWidget {
         let opts = RtOptions::new(usize::from(width))
             .initial_indent(Line::from(DETAILS_PREFIX.dim()))
             .subsequent_indent(Line::from(Span::from(" ".repeat(prefix_width)).dim()))
-            .break_words(true);
+            .break_words(/*break_words*/ true);
 
         let mut out = word_wrap_lines(details.lines().map(|line| vec![line.dim()]), opts);
 

--- a/codex-rs/tui/src/streaming/controller.rs
+++ b/codex-rs/tui/src/streaming/controller.rs
@@ -167,13 +167,16 @@ impl PlanStreamController {
         }
 
         self.state.clear();
-        self.emit(out_lines, true)
+        self.emit(out_lines, /*include_bottom_padding*/ true)
     }
 
     /// Step animation: commit at most one queued line and handle end-of-drain cleanup.
     pub(crate) fn on_commit_tick(&mut self) -> (Option<Box<dyn HistoryCell>>, bool) {
         let step = self.state.step();
-        (self.emit(step, false), self.state.is_idle())
+        (
+            self.emit(step, /*include_bottom_padding*/ false),
+            self.state.is_idle(),
+        )
     }
 
     /// Step animation: commit at most `max_lines` queued lines.
@@ -185,7 +188,10 @@ impl PlanStreamController {
         max_lines: usize,
     ) -> (Option<Box<dyn HistoryCell>>, bool) {
         let step = self.state.drain_n(max_lines.max(1));
-        (self.emit(step, false), self.state.is_idle())
+        (
+            self.emit(step, /*include_bottom_padding*/ false),
+            self.state.is_idle(),
+        )
     }
 
     /// Returns the current number of queued plan lines waiting to be displayed.

--- a/codex-rs/tui/src/theme_picker.rs
+++ b/codex-rs/tui/src/theme_picker.rs
@@ -242,7 +242,13 @@ impl Renderable for ThemePreviewWideRenderable {
     }
 
     fn render(&self, area: Rect, buf: &mut Buffer) {
-        render_preview(area, buf, &WIDE_PREVIEW_ROWS, true, WIDE_PREVIEW_LEFT_INSET);
+        render_preview(
+            area,
+            buf,
+            &WIDE_PREVIEW_ROWS,
+            /*center_vertically*/ true,
+            WIDE_PREVIEW_LEFT_INSET,
+        );
     }
 }
 
@@ -252,7 +258,13 @@ impl Renderable for ThemePreviewNarrowRenderable {
     }
 
     fn render(&self, area: Rect, buf: &mut Buffer) {
-        render_preview(area, buf, &NARROW_PREVIEW_ROWS, false, 0);
+        render_preview(
+            area,
+            buf,
+            &NARROW_PREVIEW_ROWS,
+            /*center_vertically*/ false,
+            /*left_inset*/ 0,
+        );
     }
 }
 
@@ -274,7 +286,7 @@ fn theme_picker_subtitle(codex_home: Option<&Path>, terminal_width: Option<u16>)
     let themes_dir = codex_home.map(|home| home.join("themes"));
     let themes_dir_display = themes_dir
         .as_deref()
-        .map(|path| format_directory_display(path, None));
+        .map(|path| format_directory_display(path, /*max_width*/ None));
     let available_width = subtitle_available_width(terminal_width);
 
     if let Some(path) = themes_dir_display

--- a/codex-rs/tui/src/wrapping.rs
+++ b/codex-rs/tui/src/wrapping.rs
@@ -464,7 +464,7 @@ fn is_domain_label(label: &str) -> bool {
 pub(crate) fn url_preserving_wrap_options<'a>(opts: RtOptions<'a>) -> RtOptions<'a> {
     opts.word_separator(textwrap::WordSeparator::AsciiSpace)
         .word_splitter(textwrap::WordSplitter::Custom(split_non_url_word))
-        .break_words(false)
+        .break_words(/*break_words*/ false)
 }
 
 /// Custom `textwrap::WordSplitter` callback. Returns empty (no split

--- a/codex-rs/tui_app_server/src/app.rs
+++ b/codex-rs/tui_app_server/src/app.rs
@@ -236,10 +236,10 @@ fn emit_skill_load_warnings(app_event_tx: &AppEventSender, errors: &[SkillErrorI
 fn emit_project_config_warnings(app_event_tx: &AppEventSender, config: &Config) {
     let mut disabled_folders = Vec::new();
 
-    for layer in config
-        .config_layer_stack
-        .get_layers(ConfigLayerStackOrdering::LowestPrecedenceFirst, true)
-    {
+    for layer in config.config_layer_stack.get_layers(
+        ConfigLayerStackOrdering::LowestPrecedenceFirst,
+        /*include_disabled*/ true,
+    ) {
         let ConfigLayerSource::Project { dot_codex_folder } = &layer.name else {
             continue;
         };
@@ -1117,17 +1117,17 @@ impl App {
             // this runtime patch, the config edit would only affect future
             // sessions or turns recreated from disk.
             let op = AppCommand::override_turn_context(
-                None,
+                /*cwd*/ None,
                 approval_policy_override,
                 approvals_reviewer_override,
                 sandbox_policy_override,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
+                /*windows_sandbox_level*/ None,
+                /*model*/ None,
+                /*effort*/ None,
+                /*summary*/ None,
+                /*service_tier*/ None,
+                /*collaboration_mode*/ None,
+                /*personality*/ None,
             );
             let replay_state_op =
                 ThreadEventStore::op_can_change_pending_replay_state(&op).then(|| op.clone());
@@ -1163,8 +1163,10 @@ impl App {
         }
 
         if let Some(label) = permissions_history_label {
-            self.chat_widget
-                .add_info_message(format!("Permissions updated to {label}"), None);
+            self.chat_widget.add_info_message(
+                format!("Permissions updated to {label}"),
+                /*hint*/ None,
+            );
         }
     }
 
@@ -1176,7 +1178,7 @@ impl App {
         }
 
         self.chat_widget
-            .add_info_message(format!("Opened {url} in your browser."), None);
+            .add_info_message(format!("Opened {url} in your browser."), /*hint*/ None);
     }
 
     fn clear_ui_header_lines_with_version(
@@ -1292,7 +1294,7 @@ impl App {
         if self.active_thread_id.is_some() {
             return;
         }
-        self.set_thread_active(thread_id, true).await;
+        self.set_thread_active(thread_id, /*active*/ true).await;
         let receiver = if let Some(channel) = self.thread_event_channels.get_mut(&thread_id) {
             channel.receiver.take()
         } else {
@@ -1333,7 +1335,7 @@ impl App {
 
     async fn clear_active_thread(&mut self) {
         if let Some(active_id) = self.active_thread_id.take() {
-            self.set_thread_active(active_id, false).await;
+            self.set_thread_active(active_id, /*active*/ false).await;
         }
         self.active_thread_rx = None;
         self.refresh_pending_thread_approvals().await;
@@ -1860,7 +1862,10 @@ impl App {
             let thread_id = session.session_id;
             self.primary_thread_id = Some(thread_id);
             self.primary_session_configured = Some(session.clone());
-            self.upsert_agent_picker_thread(thread_id, None, None, false);
+            self.upsert_agent_picker_thread(
+                thread_id, /*agent_nickname*/ None, /*agent_role*/ None,
+                /*is_closed*/ false,
+            );
             self.ensure_thread_channel(thread_id);
             self.activate_thread_channel(thread_id).await;
             self.enqueue_thread_event(thread_id, event).await?;
@@ -1886,7 +1891,10 @@ impl App {
         for thread_id in thread_ids {
             if self.thread_event_listener_tasks.contains_key(&thread_id) {
                 if self.agent_navigation.get(&thread_id).is_none() {
-                    self.upsert_agent_picker_thread(thread_id, None, None, false);
+                    self.upsert_agent_picker_thread(
+                        thread_id, /*agent_nickname*/ None, /*agent_role*/ None,
+                        /*is_closed*/ false,
+                    );
                 }
             } else {
                 self.mark_agent_picker_thread_closed(thread_id);
@@ -1903,7 +1911,7 @@ impl App {
 
         if self.agent_navigation.is_empty() {
             self.chat_widget
-                .add_info_message("No agents available yet.".to_string(), None);
+                .add_info_message("No agents available yet.".to_string(), /*hint*/ None);
             return;
         }
 
@@ -2014,7 +2022,7 @@ impl App {
         if is_replay_only {
             self.chat_widget.add_info_message(
                 format!("Agent thread {thread_id} is closed. Replaying saved transcript."),
-                None,
+                /*hint*/ None,
             );
         }
         self.drain_active_thread_events(tui).await?;
@@ -2182,13 +2190,15 @@ impl App {
         if let Some(event) = snapshot.session_configured {
             self.handle_codex_event_replay(event);
         }
-        self.chat_widget.set_queue_autosend_suppressed(true);
+        self.chat_widget
+            .set_queue_autosend_suppressed(/*suppressed*/ true);
         self.chat_widget
             .restore_thread_input_state(snapshot.input_state);
         for event in snapshot.events {
             self.handle_codex_event_replay(event);
         }
-        self.chat_widget.set_queue_autosend_suppressed(false);
+        self.chat_widget
+            .set_queue_autosend_suppressed(/*suppressed*/ false);
         if resume_restored_queue {
             self.chat_widget.maybe_send_next_queued_input();
         }
@@ -2282,7 +2292,7 @@ impl App {
             ThreadId::new(),
             model.as_str(),
             model.as_str(),
-            None,
+            /*account_id*/ None,
             bootstrap.account_email.clone(),
             auth_mode,
             codex_core::default_client::originator().value,
@@ -2295,7 +2305,7 @@ impl App {
             .as_ref()
             .is_some_and(|cmd| !cmd.is_empty())
         {
-            session_telemetry.counter("codex.status_line", 1, &[]);
+            session_telemetry.counter("codex.status_line", /*inc*/ 1, &[]);
         }
 
         let status_line_invalid_items_warned = Arc::new(AtomicBool::new(false));
@@ -2374,7 +2384,11 @@ impl App {
                 )
             }
             SessionSelection::Fork(target_session) => {
-                session_telemetry.counter("codex.thread.fork", 1, &[("source", "cli_subcommand")]);
+                session_telemetry.counter(
+                    "codex.thread.fork",
+                    /*inc*/ 1,
+                    &[("source", "cli_subcommand")],
+                );
                 let forked = app_server
                     .fork_thread(config.clone(), target_session.thread_id)
                     .await
@@ -2680,7 +2694,7 @@ impl App {
                     .await;
             }
             AppEvent::ClearUi => {
-                self.clear_terminal_ui(tui, false)?;
+                self.clear_terminal_ui(tui, /*redraw_header*/ false)?;
                 self.reset_app_ui_state_after_clear();
 
                 self.start_fresh_session_with_summary_hint(tui, app_server)
@@ -2707,7 +2721,7 @@ impl App {
                 match crate::resume_picker::run_resume_picker_with_app_server(
                     tui,
                     &self.config,
-                    false,
+                    /*show_all*/ false,
                     picker_app_server,
                 )
                 .await?
@@ -2724,7 +2738,7 @@ impl App {
                                 target_session.thread_id,
                                 target_session.path.as_deref(),
                                 CwdPromptAction::Resume,
-                                true,
+                                /*allow_prompt*/ true,
                             )
                             .await?
                             {
@@ -2806,7 +2820,7 @@ impl App {
             AppEvent::ForkCurrentSession => {
                 self.session_telemetry.counter(
                     "codex.thread.fork",
-                    1,
+                    /*inc*/ 1,
                     &[("source", "slash_command")],
                 );
                 let summary = session_summary(
@@ -3065,7 +3079,7 @@ impl App {
             AppEvent::OpenWindowsSandboxFallbackPrompt { preset } => {
                 self.session_telemetry.counter(
                     "codex.windows_sandbox.fallback_prompt_shown",
-                    1,
+                    /*inc*/ 1,
                     &[],
                 );
                 self.chat_widget.clear_windows_sandbox_setup_status();
@@ -3259,7 +3273,7 @@ impl App {
                     self.chat_widget
                         .add_to_history(history_cell::new_info_event(
                             format!("Sandbox read access granted for {}", path.display()),
-                            None,
+                            /*hint*/ None,
                         ));
                 }
             },
@@ -3398,7 +3412,7 @@ impl App {
                             message.push_str(profile);
                             message.push_str(" profile");
                         }
-                        self.chat_widget.add_info_message(message, None);
+                        self.chat_widget.add_info_message(message, /*hint*/ None);
                     }
                     Err(err) => {
                         tracing::error!(
@@ -3432,7 +3446,7 @@ impl App {
                             message.push_str(profile);
                             message.push_str(" profile");
                         }
-                        self.chat_widget.add_info_message(message, None);
+                        self.chat_widget.add_info_message(message, /*hint*/ None);
                     }
                     Err(err) => {
                         tracing::error!(
@@ -3468,7 +3482,7 @@ impl App {
                             message.push_str(profile);
                             message.push_str(" profile");
                         }
-                        self.chat_widget.add_info_message(message, None);
+                        self.chat_widget.add_info_message(message, /*hint*/ None);
                     }
                     Err(err) => {
                         tracing::error!(error = %err, "failed to persist fast mode selection");
@@ -3515,7 +3529,7 @@ impl App {
                             let selection = name.unwrap_or_else(|| "System default".to_string());
                             self.chat_widget.add_info_message(
                                 format!("Realtime {} set to {selection}", kind.noun()),
-                                None,
+                                /*hint*/ None,
                             );
                         }
                     }
@@ -3661,7 +3675,7 @@ impl App {
             }
             AppEvent::PersistFullAccessWarningAcknowledged => {
                 if let Err(err) = ConfigEditsBuilder::new(&self.config.codex_home)
-                    .set_hide_full_access_warning(true)
+                    .set_hide_full_access_warning(/*acknowledged*/ true)
                     .apply()
                     .await
                 {
@@ -3676,7 +3690,7 @@ impl App {
             }
             AppEvent::PersistWorldWritableWarningAcknowledged => {
                 if let Err(err) = ConfigEditsBuilder::new(&self.config.codex_home)
-                    .set_hide_world_writable_warning(true)
+                    .set_hide_world_writable_warning(/*acknowledged*/ true)
                     .apply()
                     .await
                 {
@@ -3691,7 +3705,7 @@ impl App {
             }
             AppEvent::PersistRateLimitSwitchPromptHidden => {
                 if let Err(err) = ConfigEditsBuilder::new(&self.config.codex_home)
-                    .set_hide_rate_limit_model_nudge(true)
+                    .set_hide_rate_limit_model_nudge(/*acknowledged*/ true)
                     .apply()
                     .await
                 {
@@ -4090,7 +4104,7 @@ impl App {
                     format!(
                         "Agent thread {closed_thread_id} closed. Switched back to main thread."
                     ),
-                    None,
+                    /*hint*/ None,
                 );
             } else {
                 self.clear_active_thread().await;
@@ -4237,7 +4251,7 @@ impl App {
     fn reset_external_editor_state(&mut self, tui: &mut tui::Tui) {
         self.chat_widget
             .set_external_editor_state(ExternalEditorState::Closed);
-        self.chat_widget.set_footer_hint_override(None);
+        self.chat_widget.set_footer_hint_override(/*items*/ None);
         tui.frame_requester().schedule_frame();
     }
 
@@ -4301,7 +4315,7 @@ impl App {
                 if !self.chat_widget.can_run_ctrl_l_clear_now() {
                     return;
                 }
-                if let Err(err) = self.clear_terminal_ui(tui, false) {
+                if let Err(err) = self.clear_terminal_ui(tui, /*redraw_header*/ false) {
                     tracing::warn!(error = %err, "failed to clear terminal UI");
                     self.chat_widget
                         .add_error_message(format!("Failed to clear terminal UI: {err}"));

--- a/codex-rs/tui_app_server/src/app/agent_navigation.rs
+++ b/codex-rs/tui_app_server/src/app/agent_navigation.rs
@@ -106,7 +106,10 @@ impl AgentNavigationState {
         if let Some(entry) = self.threads.get_mut(&thread_id) {
             entry.is_closed = true;
         } else {
-            self.upsert(thread_id, None, None, true);
+            self.upsert(
+                thread_id, /*agent_nickname*/ None, /*agent_role*/ None,
+                /*is_closed*/ true,
+            );
         }
     }
 
@@ -202,7 +205,11 @@ impl AgentNavigationState {
                         is_primary,
                     )
                 })
-                .unwrap_or_else(|| format_agent_picker_item_name(None, None, is_primary)),
+                .unwrap_or_else(|| {
+                    format_agent_picker_item_name(
+                        /*agent_nickname*/ None, /*agent_role*/ None, is_primary,
+                    )
+                }),
         )
     }
 

--- a/codex-rs/tui_app_server/src/app_backtrack.rs
+++ b/codex-rs/tui_app_server/src/app_backtrack.rs
@@ -345,7 +345,7 @@ impl App {
         } else {
             self.backtrack.nth_user_message = usize::MAX;
             if let Some(Overlay::Transcript(t)) = &mut self.overlay {
-                t.set_highlight_cell(None);
+                t.set_highlight_cell(/*cell*/ None);
             }
         }
     }

--- a/codex-rs/tui_app_server/src/app_event_sender.rs
+++ b/codex-rs/tui_app_server/src/app_event_sender.rs
@@ -82,7 +82,7 @@ impl AppEventSender {
     pub(crate) fn exec_approval(&self, thread_id: ThreadId, id: String, decision: ReviewDecision) {
         self.send(AppEvent::SubmitThreadOp {
             thread_id,
-            op: AppCommand::exec_approval(id, None, decision).into_core(),
+            op: AppCommand::exec_approval(id, /*turn_id*/ None, decision).into_core(),
         });
     }
 

--- a/codex-rs/tui_app_server/src/ascii_animation.rs
+++ b/codex-rs/tui_app_server/src/ascii_animation.rs
@@ -19,7 +19,7 @@ pub(crate) struct AsciiAnimation {
 
 impl AsciiAnimation {
     pub(crate) fn new(request_frame: FrameRequester) -> Self {
-        Self::with_variants(request_frame, ALL_VARIANTS, 0)
+        Self::with_variants(request_frame, ALL_VARIANTS, /*variant_idx*/ 0)
     }
 
     pub(crate) fn with_variants(

--- a/codex-rs/tui_app_server/src/bottom_pane/app_link_view.rs
+++ b/codex-rs/tui_app_server/src/bottom_pane/app_link_view.rs
@@ -156,8 +156,8 @@ impl AppLinkView {
             target.server_name.clone(),
             target.request_id.clone(),
             decision,
-            None,
-            None,
+            /*content*/ None,
+            /*meta*/ None,
         );
     }
 
@@ -505,7 +505,7 @@ impl crate::render::renderable::Renderable for AppLinkView {
         ])
         .areas(area);
 
-        let inner = content_area.inset(Insets::vh(1, 2));
+        let inner = content_area.inset(Insets::vh(/*v*/ 1, /*h*/ 2));
         let content_width = inner.width.max(1);
         let lines = self.content_lines(content_width);
         Paragraph::new(lines)

--- a/codex-rs/tui_app_server/src/bottom_pane/approval_overlay.rs
+++ b/codex-rs/tui_app_server/src/bottom_pane/approval_overlay.rs
@@ -342,8 +342,8 @@ impl ApprovalOverlay {
             server_name.to_string(),
             request_id.clone(),
             decision,
-            None,
-            None,
+            /*content*/ None,
+            /*meta*/ None,
         );
     }
 

--- a/codex-rs/tui_app_server/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui_app_server/src/bottom_pane/chat_composer.rs
@@ -674,7 +674,12 @@ impl ChatComposer {
         };
         let [composer_rect, popup_rect] =
             Layout::vertical([Constraint::Min(3), popup_constraint]).areas(area);
-        let mut textarea_rect = composer_rect.inset(Insets::tlbr(1, LIVE_PREFIX_COLS, 1, 1));
+        let mut textarea_rect = composer_rect.inset(Insets::tlbr(
+            /*top*/ 1,
+            LIVE_PREFIX_COLS,
+            /*bottom*/ 1,
+            /*right*/ 1,
+        ));
         let remote_images_height = self
             .remote_images_lines(textarea_rect.width)
             .len()
@@ -1037,7 +1042,7 @@ impl ChatComposer {
         self.bind_mentions_from_snapshot(mention_bindings);
         self.relabel_attached_images_and_update_placeholders();
         self.selected_remote_image_index = None;
-        self.textarea.set_cursor(0);
+        self.textarea.set_cursor(/*pos*/ 0);
         self.sync_popups();
     }
 
@@ -2092,14 +2097,14 @@ impl ChatComposer {
     ///
     /// The returned string **does not** include the leading `@`.
     fn current_at_token(textarea: &TextArea) -> Option<String> {
-        Self::current_prefixed_token(textarea, '@', false)
+        Self::current_prefixed_token(textarea, '@', /*allow_empty*/ false)
     }
 
     fn current_mention_token(&self) -> Option<String> {
         if !self.mentions_enabled() {
             return None;
         }
-        Self::current_prefixed_token(&self.textarea, '$', true)
+        Self::current_prefixed_token(&self.textarea, '$', /*allow_empty*/ true)
     }
 
     /// Replace the active `@token` (the one under the cursor) with `path`.
@@ -2342,7 +2347,7 @@ impl ChatComposer {
                         )));
                     } else {
                         self.app_event_tx.send(AppEvent::InsertHistoryCell(Box::new(
-                            history_cell::new_info_event(message, None),
+                            history_cell::new_info_event(message, /*hint*/ None),
                         )));
                     }
                     self.set_text_content_with_mention_bindings(
@@ -2495,7 +2500,9 @@ impl ChatComposer {
             return (result, true);
         }
 
-        if let Some((text, text_elements)) = self.prepare_submission_text(true) {
+        if let Some((text, text_elements)) =
+            self.prepare_submission_text(/*record_history*/ true)
+        {
             if should_queue {
                 (
                     InputResult::Queued {
@@ -2802,7 +2809,7 @@ impl ChatComposer {
                 code: KeyCode::Enter,
                 modifiers: KeyModifiers::NONE,
                 ..
-            } => self.handle_submission(false),
+            } => self.handle_submission(/*should_queue*/ false),
             input => self.handle_input_basic(input),
         }
     }
@@ -4175,7 +4182,7 @@ impl Renderable for ChatComposer {
     }
 
     fn render(&self, area: Rect, buf: &mut Buffer) {
-        self.render_with_mask(area, buf, None);
+        self.render_with_mask(area, buf, /*mask_char*/ None);
     }
 }
 
@@ -4269,7 +4276,10 @@ impl ChatComposer {
                 let right_line = if status_line_active {
                     let full =
                         mode_indicator_line(self.collaboration_mode_indicator, show_cycle_hint);
-                    let compact = mode_indicator_line(self.collaboration_mode_indicator, false);
+                    let compact = mode_indicator_line(
+                        self.collaboration_mode_indicator,
+                        /*show_cycle_hint*/ false,
+                    );
                     let full_width = full.as_ref().map(|l| l.width() as u16).unwrap_or(0);
                     if can_show_left_with_context(hint_rect, left_width, full_width) {
                         full

--- a/codex-rs/tui_app_server/src/bottom_pane/command_popup.rs
+++ b/codex-rs/tui_app_server/src/bottom_pane/command_popup.rs
@@ -275,7 +275,9 @@ impl WidgetRef for CommandPopup {
     fn render_ref(&self, area: Rect, buf: &mut Buffer) {
         let rows = self.rows_from_matches(self.filtered());
         render_rows(
-            area.inset(Insets::tlbr(0, 2, 0, 0)),
+            area.inset(Insets::tlbr(
+                /*top*/ 0, /*left*/ 2, /*bottom*/ 0, /*right*/ 0,
+            )),
             buf,
             &rows,
             &self.state,

--- a/codex-rs/tui_app_server/src/bottom_pane/experimental_features_view.rs
+++ b/codex-rs/tui_app_server/src/bottom_pane/experimental_features_view.rs
@@ -243,7 +243,7 @@ impl Renderable for ExperimentalFeaturesView {
             Constraint::Max(1),
             Constraint::Length(rows_height),
         ])
-        .areas(content_area.inset(Insets::vh(1, 2)));
+        .areas(content_area.inset(Insets::vh(/*v*/ 1, /*h*/ 2)));
 
         self.header.render(header_area, buf);
 

--- a/codex-rs/tui_app_server/src/bottom_pane/feedback_view.rs
+++ b/codex-rs/tui_app_server/src/bottom_pane/feedback_view.rs
@@ -104,7 +104,7 @@ impl FeedbackNoteView {
             self.include_logs,
             &attachment_paths,
             Some(SessionSource::Cli),
-            None,
+            /*logs_override*/ None,
         );
 
         match result {

--- a/codex-rs/tui_app_server/src/bottom_pane/file_search_popup.rs
+++ b/codex-rs/tui_app_server/src/bottom_pane/file_search_popup.rs
@@ -141,7 +141,9 @@ impl WidgetRef for &FileSearchPopup {
         };
 
         render_rows(
-            area.inset(Insets::tlbr(0, 2, 0, 0)),
+            area.inset(Insets::tlbr(
+                /*top*/ 0, /*left*/ 2, /*bottom*/ 0, /*right*/ 0,
+            )),
             buf,
             &rows_all,
             &self.state,

--- a/codex-rs/tui_app_server/src/bottom_pane/footer.rs
+++ b/codex-rs/tui_app_server/src/bottom_pane/footer.rs
@@ -199,7 +199,14 @@ pub(crate) fn footer_height(props: &FooterProps) -> u16 {
         | FooterMode::ShortcutOverlay
         | FooterMode::EscHint => false,
     };
-    footer_from_props_lines(props, None, false, show_shortcuts_hint, show_queue_hint).len() as u16
+    footer_from_props_lines(
+        props,
+        /*collaboration_mode_indicator*/ None,
+        /*show_cycle_hint*/ false,
+        show_shortcuts_hint,
+        show_queue_hint,
+    )
+    .len() as u16
 }
 
 /// Render a single precomputed footer line.

--- a/codex-rs/tui_app_server/src/bottom_pane/mcp_server_elicitation.rs
+++ b/codex-rs/tui_app_server/src/bottom_pane/mcp_server_elicitation.rs
@@ -1088,8 +1088,8 @@ impl McpServerElicitationOverlay {
             self.request.server_name.clone(),
             self.request.request_id.clone(),
             ElicitationAction::Cancel,
-            None,
-            None,
+            /*content*/ None,
+            /*meta*/ None,
         );
     }
 
@@ -1102,30 +1102,31 @@ impl McpServerElicitationOverlay {
         }
         self.validation_error = None;
         if self.request.response_mode == McpServerElicitationResponseMode::ApprovalAction {
-            let (decision, meta) = match self.field_value(0).as_ref().and_then(Value::as_str) {
-                Some(APPROVAL_ACCEPT_ONCE_VALUE) => (ElicitationAction::Accept, None),
-                Some(APPROVAL_ACCEPT_SESSION_VALUE) => (
-                    ElicitationAction::Accept,
-                    Some(serde_json::json!({
-                        APPROVAL_PERSIST_KEY: APPROVAL_PERSIST_SESSION_VALUE,
-                    })),
-                ),
-                Some(APPROVAL_ACCEPT_ALWAYS_VALUE) => (
-                    ElicitationAction::Accept,
-                    Some(serde_json::json!({
-                        APPROVAL_PERSIST_KEY: APPROVAL_PERSIST_ALWAYS_VALUE,
-                    })),
-                ),
-                Some(APPROVAL_DECLINE_VALUE) => (ElicitationAction::Decline, None),
-                Some(APPROVAL_CANCEL_VALUE) => (ElicitationAction::Cancel, None),
-                _ => (ElicitationAction::Cancel, None),
-            };
+            let (decision, meta) =
+                match self.field_value(/*idx*/ 0).as_ref().and_then(Value::as_str) {
+                    Some(APPROVAL_ACCEPT_ONCE_VALUE) => (ElicitationAction::Accept, None),
+                    Some(APPROVAL_ACCEPT_SESSION_VALUE) => (
+                        ElicitationAction::Accept,
+                        Some(serde_json::json!({
+                            APPROVAL_PERSIST_KEY: APPROVAL_PERSIST_SESSION_VALUE,
+                        })),
+                    ),
+                    Some(APPROVAL_ACCEPT_ALWAYS_VALUE) => (
+                        ElicitationAction::Accept,
+                        Some(serde_json::json!({
+                            APPROVAL_PERSIST_KEY: APPROVAL_PERSIST_ALWAYS_VALUE,
+                        })),
+                    ),
+                    Some(APPROVAL_DECLINE_VALUE) => (ElicitationAction::Decline, None),
+                    Some(APPROVAL_CANCEL_VALUE) => (ElicitationAction::Cancel, None),
+                    _ => (ElicitationAction::Cancel, None),
+                };
             self.app_event_tx.resolve_elicitation(
                 self.request.thread_id,
                 self.request.server_name.clone(),
                 self.request.request_id.clone(),
                 decision,
-                None,
+                /*content*/ None,
                 meta,
             );
             if let Some(next) = self.queue.pop_front() {
@@ -1150,7 +1151,7 @@ impl McpServerElicitationOverlay {
             self.request.request_id.clone(),
             ElicitationAction::Accept,
             Some(Value::Object(content)),
-            None,
+            /*meta*/ None,
         );
         if let Some(next) = self.queue.pop_front() {
             self.request = next;
@@ -1165,7 +1166,7 @@ impl McpServerElicitationOverlay {
         if self.current_index() + 1 >= self.field_count() {
             self.submit_answers();
         } else {
-            self.move_field(true);
+            self.move_field(/*next*/ true);
         }
     }
 
@@ -1460,7 +1461,7 @@ impl BottomPaneView for McpServerElicitationOverlay {
                 modifiers: KeyModifiers::NONE,
                 ..
             } => {
-                self.move_field(false);
+                self.move_field(/*next*/ false);
                 return;
             }
             KeyEvent {
@@ -1473,7 +1474,7 @@ impl BottomPaneView for McpServerElicitationOverlay {
                 modifiers: KeyModifiers::NONE,
                 ..
             } => {
-                self.move_field(true);
+                self.move_field(/*next*/ true);
                 return;
             }
             KeyEvent {
@@ -1481,7 +1482,7 @@ impl BottomPaneView for McpServerElicitationOverlay {
                 modifiers: KeyModifiers::NONE,
                 ..
             } if self.current_field_is_select() => {
-                self.move_field(false);
+                self.move_field(/*next*/ false);
                 return;
             }
             KeyEvent {
@@ -1489,7 +1490,7 @@ impl BottomPaneView for McpServerElicitationOverlay {
                 modifiers: KeyModifiers::NONE,
                 ..
             } if self.current_field_is_select() => {
-                self.move_field(true);
+                self.move_field(/*next*/ true);
                 return;
             }
             _ => {}
@@ -1512,10 +1513,10 @@ impl BottomPaneView for McpServerElicitationOverlay {
                     }
                 }
                 KeyCode::Backspace | KeyCode::Delete => self.clear_selection(),
-                KeyCode::Char(' ') => self.select_current_option(true),
+                KeyCode::Char(' ') => self.select_current_option(/*committed*/ true),
                 KeyCode::Enter => {
                     if self.selected_option_index().is_some() {
-                        self.select_current_option(true);
+                        self.select_current_option(/*committed*/ true);
                     }
                     self.go_next_or_submit();
                 }
@@ -1524,7 +1525,7 @@ impl BottomPaneView for McpServerElicitationOverlay {
                         if let Some(answer) = self.current_answer_mut() {
                             answer.selection.selected_idx = Some(option_idx);
                         }
-                        self.select_current_option(true);
+                        self.select_current_option(/*committed*/ true);
                         self.go_next_or_submit();
                     }
                 }

--- a/codex-rs/tui_app_server/src/bottom_pane/mod.rs
+++ b/codex-rs/tui_app_server/src/bottom_pane/mod.rs
@@ -699,14 +699,14 @@ impl BottomPane {
 
     pub(crate) fn show_esc_backtrack_hint(&mut self) {
         self.esc_backtrack_hint = true;
-        self.composer.set_esc_backtrack_hint(true);
+        self.composer.set_esc_backtrack_hint(/*show*/ true);
         self.request_redraw();
     }
 
     pub(crate) fn clear_esc_backtrack_hint(&mut self) {
         if self.esc_backtrack_hint {
             self.esc_backtrack_hint = false;
-            self.composer.set_esc_backtrack_hint(false);
+            self.composer.set_esc_backtrack_hint(/*show*/ false);
             self.request_redraw();
         }
     }
@@ -728,7 +728,7 @@ impl BottomPane {
                     ));
                 }
                 if let Some(status) = self.status.as_mut() {
-                    status.set_interrupt_hint_visible(true);
+                    status.set_interrupt_hint_visible(/*visible*/ true);
                 }
                 self.sync_status_inline_message();
                 self.request_redraw();
@@ -936,7 +936,7 @@ impl BottomPane {
         );
         self.pause_status_timer_for_modal();
         self.set_composer_input_enabled(
-            false,
+            /*enabled*/ false,
             Some("Answer the questions to continue.".to_string()),
         );
         self.push_view(Box::new(modal));
@@ -997,7 +997,7 @@ impl BottomPane {
             );
             self.pause_status_timer_for_modal();
             self.set_composer_input_enabled(
-                false,
+                /*enabled*/ false,
                 Some("Respond to the tool suggestion to continue.".to_string()),
             );
             self.push_view(Box::new(view));
@@ -1013,7 +1013,7 @@ impl BottomPane {
         );
         self.pause_status_timer_for_modal();
         self.set_composer_input_enabled(
-            false,
+            /*enabled*/ false,
             Some("Respond to the MCP server request to continue.".to_string()),
         );
         self.push_view(Box::new(modal));
@@ -1021,7 +1021,7 @@ impl BottomPane {
 
     fn on_active_view_complete(&mut self) {
         self.resume_status_timer_after_modal();
-        self.set_composer_input_enabled(true, None);
+        self.set_composer_input_enabled(/*enabled*/ true, /*placeholder*/ None);
     }
 
     fn pause_status_timer_for_modal(&mut self) {
@@ -1124,12 +1124,15 @@ impl BottomPane {
         } else {
             let mut flex = FlexRenderable::new();
             if let Some(status) = &self.status {
-                flex.push(0, RenderableItem::Borrowed(status));
+                flex.push(/*flex*/ 0, RenderableItem::Borrowed(status));
             }
             // Avoid double-surfacing the same summary and avoid adding an extra
             // row while the status line is already visible.
             if self.status.is_none() && !self.unified_exec_footer.is_empty() {
-                flex.push(0, RenderableItem::Borrowed(&self.unified_exec_footer));
+                flex.push(
+                    /*flex*/ 0,
+                    RenderableItem::Borrowed(&self.unified_exec_footer),
+                );
             }
             let has_pending_thread_approvals = !self.pending_thread_approvals.is_empty();
             let has_pending_input = !self.pending_input_preview.queued_messages.is_empty()
@@ -1138,19 +1141,25 @@ impl BottomPane {
                 self.status.is_some() || !self.unified_exec_footer.is_empty();
             let has_inline_previews = has_pending_thread_approvals || has_pending_input;
             if has_inline_previews && has_status_or_footer {
-                flex.push(0, RenderableItem::Owned("".into()));
+                flex.push(/*flex*/ 0, RenderableItem::Owned("".into()));
             }
-            flex.push(1, RenderableItem::Borrowed(&self.pending_thread_approvals));
+            flex.push(
+                /*flex*/ 1,
+                RenderableItem::Borrowed(&self.pending_thread_approvals),
+            );
             if has_pending_thread_approvals && has_pending_input {
-                flex.push(0, RenderableItem::Owned("".into()));
+                flex.push(/*flex*/ 0, RenderableItem::Owned("".into()));
             }
-            flex.push(1, RenderableItem::Borrowed(&self.pending_input_preview));
+            flex.push(
+                /*flex*/ 1,
+                RenderableItem::Borrowed(&self.pending_input_preview),
+            );
             if !has_inline_previews && has_status_or_footer {
-                flex.push(0, RenderableItem::Owned("".into()));
+                flex.push(/*flex*/ 0, RenderableItem::Owned("".into()));
             }
             let mut flex2 = FlexRenderable::new();
-            flex2.push(1, RenderableItem::Owned(flex.into()));
-            flex2.push(0, RenderableItem::Borrowed(&self.composer));
+            flex2.push(/*flex*/ 1, RenderableItem::Owned(flex.into()));
+            flex2.push(/*flex*/ 0, RenderableItem::Borrowed(&self.composer));
             RenderableItem::Owned(Box::new(flex2))
         }
     }

--- a/codex-rs/tui_app_server/src/bottom_pane/multi_select_picker.rs
+++ b/codex-rs/tui_app_server/src/bottom_pane/multi_select_picker.rs
@@ -533,7 +533,7 @@ impl Renderable for MultiSelectPicker {
             Constraint::Length(2),
             Constraint::Length(rows_height),
         ])
-        .areas(content_area.inset(Insets::vh(1, 2)));
+        .areas(content_area.inset(Insets::vh(/*v*/ 1, /*h*/ 2)));
 
         self.header.render(header_area, buf);
 

--- a/codex-rs/tui_app_server/src/bottom_pane/request_user_input/mod.rs
+++ b/codex-rs/tui_app_server/src/bottom_pane/request_user_input/mod.rs
@@ -707,7 +707,7 @@ impl RequestUserInputOverlay {
                 self.submit_answers();
             }
         } else {
-            self.move_question(true);
+            self.move_question(/*next*/ true);
         }
     }
 
@@ -958,10 +958,10 @@ impl RequestUserInputOverlay {
                 }
             }
             KeyCode::Up | KeyCode::Char('k') => {
-                state.move_up_wrap(2);
+                state.move_up_wrap(/*len*/ 2);
             }
             KeyCode::Down | KeyCode::Char('j') => {
-                state.move_down_wrap(2);
+                state.move_down_wrap(/*len*/ 2);
             }
             KeyCode::Enter => {
                 let selected = state.selected_idx.unwrap_or(0);
@@ -1024,7 +1024,7 @@ impl BottomPaneView for RequestUserInputOverlay {
                 modifiers: KeyModifiers::NONE,
                 ..
             } => {
-                self.move_question(false);
+                self.move_question(/*next*/ false);
                 return;
             }
             KeyEvent {
@@ -1037,7 +1037,7 @@ impl BottomPaneView for RequestUserInputOverlay {
                 modifiers: KeyModifiers::CONTROL,
                 ..
             } => {
-                self.move_question(true);
+                self.move_question(/*next*/ true);
                 return;
             }
             KeyEvent {
@@ -1045,7 +1045,7 @@ impl BottomPaneView for RequestUserInputOverlay {
                 modifiers: KeyModifiers::NONE,
                 ..
             } if self.has_options() && matches!(self.focus, Focus::Options) => {
-                self.move_question(false);
+                self.move_question(/*next*/ false);
                 return;
             }
             KeyEvent {
@@ -1053,7 +1053,7 @@ impl BottomPaneView for RequestUserInputOverlay {
                 modifiers: KeyModifiers::NONE,
                 ..
             } if self.has_options() && matches!(self.focus, Focus::Options) => {
-                self.move_question(false);
+                self.move_question(/*next*/ false);
                 return;
             }
             KeyEvent {
@@ -1061,7 +1061,7 @@ impl BottomPaneView for RequestUserInputOverlay {
                 modifiers: KeyModifiers::NONE,
                 ..
             } if self.has_options() && matches!(self.focus, Focus::Options) => {
-                self.move_question(true);
+                self.move_question(/*next*/ true);
                 return;
             }
             KeyEvent {
@@ -1069,7 +1069,7 @@ impl BottomPaneView for RequestUserInputOverlay {
                 modifiers: KeyModifiers::NONE,
                 ..
             } if self.has_options() && matches!(self.focus, Focus::Options) => {
-                self.move_question(true);
+                self.move_question(/*next*/ true);
                 return;
             }
             _ => {}
@@ -1105,7 +1105,7 @@ impl BottomPaneView for RequestUserInputOverlay {
                         }
                     }
                     KeyCode::Char(' ') => {
-                        self.select_current_option(true);
+                        self.select_current_option(/*committed*/ true);
                     }
                     KeyCode::Backspace | KeyCode::Delete => {
                         self.clear_selection();
@@ -1119,7 +1119,7 @@ impl BottomPaneView for RequestUserInputOverlay {
                     KeyCode::Enter => {
                         let has_selection = self.selected_option_index().is_some();
                         if has_selection {
-                            self.select_current_option(true);
+                            self.select_current_option(/*committed*/ true);
                         }
                         self.go_next_or_submit();
                     }
@@ -1128,7 +1128,7 @@ impl BottomPaneView for RequestUserInputOverlay {
                             if let Some(answer) = self.current_answer_mut() {
                                 answer.options_state.selected_idx = Some(option_idx);
                             }
-                            self.select_current_option(true);
+                            self.select_current_option(/*committed*/ true);
                             self.go_next_or_submit();
                         }
                     }
@@ -1158,7 +1158,7 @@ impl BottomPaneView for RequestUserInputOverlay {
                     if !self.handle_composer_input_result(result) {
                         self.pending_submission_draft = None;
                         if self.has_options() {
-                            self.select_current_option(true);
+                            self.select_current_option(/*committed*/ true);
                         }
                         self.go_next_or_submit();
                     }

--- a/codex-rs/tui_app_server/src/bottom_pane/skill_popup.rs
+++ b/codex-rs/tui_app_server/src/bottom_pane/skill_popup.rs
@@ -199,7 +199,9 @@ impl WidgetRef for SkillPopup {
         };
         let rows = self.rows_from_matches(self.filtered());
         render_rows_single_line(
-            list_area.inset(Insets::tlbr(0, 2, 0, 0)),
+            list_area.inset(Insets::tlbr(
+                /*top*/ 0, /*left*/ 2, /*bottom*/ 0, /*right*/ 0,
+            )),
             buf,
             &rows,
             &self.state,

--- a/codex-rs/tui_app_server/src/bottom_pane/skills_toggle_view.rs
+++ b/codex-rs/tui_app_server/src/bottom_pane/skills_toggle_view.rs
@@ -186,7 +186,8 @@ impl SkillsToggleView {
         }
         self.complete = true;
         self.app_event_tx.send(AppEvent::ManageSkillsClosed);
-        self.app_event_tx.list_skills(Vec::new(), true);
+        self.app_event_tx
+            .list_skills(Vec::new(), /*force_reload*/ true);
     }
 
     fn rows_width(total_width: u16) -> u16 {
@@ -310,7 +311,7 @@ impl Renderable for SkillsToggleView {
             Constraint::Length(2),
             Constraint::Length(rows_height),
         ])
-        .areas(content_area.inset(Insets::vh(1, 2)));
+        .areas(content_area.inset(Insets::vh(/*v*/ 1, /*h*/ 2)));
 
         self.header.render(header_area, buf);
 

--- a/codex-rs/tui_app_server/src/bottom_pane/status_line_setup.rs
+++ b/codex-rs/tui_app_server/src/bottom_pane/status_line_setup.rs
@@ -205,7 +205,7 @@ impl StatusLineSetupView {
                 if !used_ids.insert(item_id.clone()) {
                     continue;
                 }
-                items.push(Self::status_line_select_item(item, true));
+                items.push(Self::status_line_select_item(item, /*enabled*/ true));
             }
         }
 
@@ -214,7 +214,7 @@ impl StatusLineSetupView {
             if used_ids.contains(&item_id) {
                 continue;
             }
-            items.push(Self::status_line_select_item(item, false));
+            items.push(Self::status_line_select_item(item, /*enabled*/ false));
         }
 
         Self {

--- a/codex-rs/tui_app_server/src/bottom_pane/textarea.rs
+++ b/codex-rs/tui_app_server/src/bottom_pane/textarea.rs
@@ -101,7 +101,7 @@ impl TextArea {
     /// as submit or slash-command dispatch clear the draft through this method and still want
     /// `Ctrl+Y` to recover the user's most recent kill.
     pub fn set_text_clearing_elements(&mut self, text: &str) {
-        self.set_text_inner(text, None);
+        self.set_text_inner(text, /*elements*/ None);
     }
 
     /// Replace the visible textarea text and rebuild the provided text elements.
@@ -160,7 +160,7 @@ impl TextArea {
         if pos <= self.cursor_pos {
             self.cursor_pos += text.len();
         }
-        self.shift_elements(pos, 0, text.len());
+        self.shift_elements(pos, /*removed*/ 0, text.len());
         self.preferred_col = None;
     }
 
@@ -355,7 +355,7 @@ impl TextArea {
                 code: KeyCode::Char('h'),
                 modifiers: KeyModifiers::CONTROL,
                 ..
-            } => self.delete_backward(1),
+            } => self.delete_backward(/*n*/ 1),
             KeyEvent {
                 code: KeyCode::Delete,
                 modifiers: KeyModifiers::ALT,
@@ -374,7 +374,7 @@ impl TextArea {
                 code: KeyCode::Char('d'),
                 modifiers: KeyModifiers::CONTROL,
                 ..
-            } => self.delete_forward(1),
+            } => self.delete_forward(/*n*/ 1),
 
             KeyEvent {
                 code: KeyCode::Char('w'),
@@ -507,27 +507,27 @@ impl TextArea {
                 code: KeyCode::Home,
                 ..
             } => {
-                self.move_cursor_to_beginning_of_line(false);
+                self.move_cursor_to_beginning_of_line(/*move_up_at_bol*/ false);
             }
             KeyEvent {
                 code: KeyCode::Char('a'),
                 modifiers: KeyModifiers::CONTROL,
                 ..
             } => {
-                self.move_cursor_to_beginning_of_line(true);
+                self.move_cursor_to_beginning_of_line(/*move_up_at_bol*/ true);
             }
 
             KeyEvent {
                 code: KeyCode::End, ..
             } => {
-                self.move_cursor_to_end_of_line(false);
+                self.move_cursor_to_end_of_line(/*move_down_at_eol*/ false);
             }
             KeyEvent {
                 code: KeyCode::Char('e'),
                 modifiers: KeyModifiers::CONTROL,
                 ..
             } => {
-                self.move_cursor_to_end_of_line(true);
+                self.move_cursor_to_end_of_line(/*move_down_at_eol*/ true);
             }
             _o => {
                 #[cfg(feature = "debug-logs")]
@@ -999,7 +999,7 @@ impl TextArea {
     }
 
     fn add_element(&mut self, range: Range<usize>) -> u64 {
-        self.add_element_with_id(range, None)
+        self.add_element_with_id(range, /*name*/ None)
     }
 
     /// Mark an existing text range as an atomic element without changing the text.
@@ -1228,7 +1228,7 @@ impl TextArea {
             }
             start = idx;
         }
-        self.adjust_pos_out_of_elements(start, true)
+        self.adjust_pos_out_of_elements(start, /*prefer_start*/ true)
     }
 
     pub(crate) fn end_of_next_word(&self) -> usize {
@@ -1249,7 +1249,7 @@ impl TextArea {
                 break;
             }
         }
-        self.adjust_pos_out_of_elements(end, false)
+        self.adjust_pos_out_of_elements(end, /*prefer_start*/ false)
     }
 
     fn adjust_pos_out_of_elements(&self, pos: usize, prefer_start: bool) -> usize {

--- a/codex-rs/tui_app_server/src/chatwidget.rs
+++ b/codex-rs/tui_app_server/src/chatwidget.rs
@@ -1194,7 +1194,7 @@ impl ChatWidget {
     fn set_status_header(&mut self, header: String) {
         self.set_status(
             header,
-            None,
+            /*details*/ None,
             StatusDetailsCapitalization::CapitalizeFirst,
             STATUS_DETAILS_DEFAULT_MAX_LINES,
         );
@@ -1251,7 +1251,7 @@ impl ChatWidget {
         let enabled = !items.is_empty();
         self.bottom_pane.set_status_line_enabled(enabled);
         if !enabled {
-            self.set_status_line(None);
+            self.set_status_line(/*status_line*/ None);
             return;
         }
 
@@ -1356,7 +1356,7 @@ impl ChatWidget {
     fn on_session_configured(&mut self, event: codex_protocol::protocol::SessionConfiguredEvent) {
         self.bottom_pane
             .set_history_metadata(event.history_log_id, event.history_entry_count);
-        self.set_skills(None);
+        self.set_skills(/*skills*/ None);
         self.session_network_proxy = event.network_proxy.clone();
         self.thread_id = Some(event.session_id);
         self.thread_name = event.thread_name.clone();
@@ -1393,7 +1393,7 @@ impl ChatWidget {
         self.current_collaboration_mode = self.current_collaboration_mode.with_updates(
             Some(model_for_header.clone()),
             Some(event.reasoning_effort),
-            None,
+            /*developer_instructions*/ None,
         );
         if let Some(mask) = self.active_collaboration_mask.as_mut() {
             mask.model = Some(model_for_header.clone());
@@ -1419,7 +1419,10 @@ impl ChatWidget {
         if let Some(messages) = initial_messages {
             self.replay_initial_messages(messages);
         }
-        self.submit_op(AppCommand::list_skills(Vec::new(), true));
+        self.submit_op(AppCommand::list_skills(
+            Vec::new(),
+            /*force_reload*/ true,
+        ));
         if self.connectors_enabled() {
             self.prefetch_connectors();
         }
@@ -1671,7 +1674,8 @@ impl ChatWidget {
 
     fn on_task_started(&mut self) {
         self.agent_turn_running = true;
-        self.turn_sleep_inhibitor.set_turn_running(true);
+        self.turn_sleep_inhibitor
+            .set_turn_running(/*turn_running*/ true);
         self.saw_plan_update_this_turn = false;
         self.saw_plan_item_this_turn = false;
         self.plan_delta_buffer.clear();
@@ -1686,7 +1690,8 @@ impl ChatWidget {
         self.update_task_running_state();
         self.retry_status_header = None;
         self.pending_status_indicator_restore = false;
-        self.bottom_pane.set_interrupt_hint_visible(true);
+        self.bottom_pane
+            .set_interrupt_hint_visible(/*visible*/ true);
         self.set_status_header(String::from("Working"));
         self.full_reasoning_buffer.clear();
         self.reasoning_buffer.clear();
@@ -1735,7 +1740,8 @@ impl ChatWidget {
         // Mark task stopped and request redraw now that all content is in history.
         self.pending_status_indicator_restore = false;
         self.agent_turn_running = false;
-        self.turn_sleep_inhibitor.set_turn_running(false);
+        self.turn_sleep_inhibitor
+            .set_turn_running(/*turn_running*/ false);
         self.update_task_running_state();
         self.running_commands.clear();
         self.suppressed_exec_calls.clear();
@@ -1879,7 +1885,8 @@ impl ChatWidget {
         match info {
             Some(info) => self.apply_token_info(info),
             None => {
-                self.bottom_pane.set_context_window(None, None);
+                self.bottom_pane
+                    .set_context_window(/*percent*/ None, /*used_tokens*/ None);
                 self.token_info = None;
             }
         }
@@ -1933,7 +1940,8 @@ impl ChatWidget {
             match saved {
                 Some(info) => self.apply_token_info(info),
                 None => {
-                    self.bottom_pane.set_context_window(None, None);
+                    self.bottom_pane
+                        .set_context_window(/*percent*/ None, /*used_tokens*/ None);
                     self.token_info = None;
                 }
             }
@@ -2033,7 +2041,8 @@ impl ChatWidget {
         self.finalize_active_cell_as_failed();
         // Reset running state and clear streaming buffers.
         self.agent_turn_running = false;
-        self.turn_sleep_inhibitor.set_turn_running(false);
+        self.turn_sleep_inhibitor
+            .set_turn_running(/*turn_running*/ false);
         self.update_task_running_state();
         self.running_commands.clear();
         self.suppressed_exec_calls.clear();
@@ -2157,7 +2166,7 @@ impl ChatWidget {
             if send_pending_steers_immediately {
                 self.add_to_history(history_cell::new_info_event(
                     "Model interrupted to submit steer instructions.".to_owned(),
-                    None,
+                    /*hint*/ None,
                 ));
             } else {
                 self.add_to_history(history_cell::new_error_event(
@@ -2437,7 +2446,8 @@ impl ChatWidget {
             // review is pending. Parallel reviews are aggregated into one
             // footer summary by `PendingGuardianReviewStatus`.
             self.bottom_pane.ensure_status_indicator();
-            self.bottom_pane.set_interrupt_hint_visible(true);
+            self.bottom_pane
+                .set_interrupt_hint_visible(/*visible*/ true);
             self.pending_guardian_review_status
                 .start_or_update(ev.id.clone(), detail);
             if let Some(status) = self.pending_guardian_review_status.status_indicator_state() {
@@ -2641,12 +2651,13 @@ impl ChatWidget {
             // Surface this in the status indicator (single "waiting" surface) instead of
             // the transcript. Keep the header short so the interrupt hint remains visible.
             self.bottom_pane.ensure_status_indicator();
-            self.bottom_pane.set_interrupt_hint_visible(true);
+            self.bottom_pane
+                .set_interrupt_hint_visible(/*visible*/ true);
             self.set_status(
                 "Waiting for background terminal".to_string(),
                 command_display.clone(),
                 StatusDetailsCapitalization::Preserve,
-                1,
+                /*details_max_lines*/ 1,
             );
             match &mut self.unified_exec_wait_streak {
                 Some(wait) if wait.process_id == ev.process_id => {
@@ -2896,7 +2907,8 @@ impl ChatWidget {
     fn on_background_event(&mut self, message: String) {
         debug!("BackgroundEvent: {message}");
         self.bottom_pane.ensure_status_indicator();
-        self.bottom_pane.set_interrupt_hint_visible(true);
+        self.bottom_pane
+            .set_interrupt_hint_visible(/*visible*/ true);
         self.set_status_header(message);
     }
 
@@ -2909,7 +2921,7 @@ impl ChatWidget {
             message.push_str(": ");
             message.push_str(&status_message);
         }
-        self.add_to_history(history_cell::new_info_event(message, None));
+        self.add_to_history(history_cell::new_info_event(message, /*hint*/ None));
         self.request_redraw();
     }
 
@@ -2933,7 +2945,8 @@ impl ChatWidget {
 
     fn on_undo_started(&mut self, event: UndoStartedEvent) {
         self.bottom_pane.ensure_status_indicator();
-        self.bottom_pane.set_interrupt_hint_visible(false);
+        self.bottom_pane
+            .set_interrupt_hint_visible(/*visible*/ false);
         let message = event
             .message
             .unwrap_or_else(|| "Undo in progress...".to_string());
@@ -2951,7 +2964,7 @@ impl ChatWidget {
             }
         });
         if success {
-            self.add_info_message(message, None);
+            self.add_info_message(message, /*hint*/ None);
         } else {
             self.add_error_message(message);
         }
@@ -3091,7 +3104,7 @@ impl ChatWidget {
                     .map(|current| self.worked_elapsed_from(current));
                 self.add_to_history(history_cell::FinalMessageSeparator::new(
                     elapsed_seconds,
-                    None,
+                    /*runtime_metrics*/ None,
                 ));
                 self.needs_final_message_separator = false;
                 self.had_work_activity = false;
@@ -3652,7 +3665,9 @@ impl ChatWidget {
         widget
             .bottom_pane
             .set_status_line_enabled(!widget.configured_status_line_items().is_empty());
-        widget.bottom_pane.set_collaboration_modes_enabled(true);
+        widget
+            .bottom_pane
+            .set_collaboration_modes_enabled(/*enabled*/ true);
         widget.sync_fast_command_enabled();
         widget.sync_personality_command_enabled();
         widget
@@ -3842,7 +3857,9 @@ impl ChatWidget {
         widget
             .bottom_pane
             .set_status_line_enabled(!widget.configured_status_line_items().is_empty());
-        widget.bottom_pane.set_collaboration_modes_enabled(true);
+        widget
+            .bottom_pane
+            .set_collaboration_modes_enabled(/*enabled*/ true);
         widget.sync_fast_command_enabled();
         widget.sync_personality_command_enabled();
         widget
@@ -4143,7 +4160,7 @@ impl ChatWidget {
                     let message = format!(
                         "{DEFAULT_PROJECT_DOC_FILENAME} already exists here. Skipping /init to avoid overwriting it."
                     );
-                    self.add_info_message(message, None);
+                    self.add_info_message(message, /*hint*/ None);
                     return;
                 }
                 const INIT_PROMPT: &str = include_str!("../prompt_for_init_command.md");
@@ -4158,7 +4175,7 @@ impl ChatWidget {
             }
             SlashCommand::Rename => {
                 self.session_telemetry
-                    .counter("codex.thread.rename", 1, &[]);
+                    .counter("codex.thread.rename", /*inc*/ 1, &[]);
                 self.show_rename_prompt();
             }
             SlashCommand::Model => {
@@ -4177,7 +4194,7 @@ impl ChatWidget {
                     return;
                 }
                 if self.realtime_conversation.is_live() {
-                    self.request_realtime_conversation_close(None);
+                    self.request_realtime_conversation_close(/*info_message*/ None);
                 } else {
                     self.start_realtime_conversation();
                 }
@@ -4202,7 +4219,10 @@ impl ChatWidget {
                 if let Some(mask) = collaboration_modes::plan_mask(self.model_catalog.as_ref()) {
                     self.set_collaboration_mask(mask);
                 } else {
-                    self.add_info_message("Plan mode unavailable right now.".to_string(), None);
+                    self.add_info_message(
+                        "Plan mode unavailable right now.".to_string(),
+                        /*hint*/ None,
+                    );
                 }
             }
             SlashCommand::Collab => {
@@ -4319,7 +4339,7 @@ impl ChatWidget {
                     self.add_info_message(
                         "`/copy` is unavailable before the first Codex output or right after a rollback."
                             .to_string(),
-                        None,
+                        /*hint*/ None,
                     );
                     return;
                 };
@@ -4382,10 +4402,13 @@ impl ChatWidget {
                 if let Some(path) = self.rollout_path() {
                     self.add_info_message(
                         format!("Current rollout path: {}", path.display()),
-                        None,
+                        /*hint*/ None,
                     );
                 } else {
-                    self.add_info_message("Rollout path is not available yet.".to_string(), None);
+                    self.add_info_message(
+                        "Rollout path is not available yet.".to_string(),
+                        /*hint*/ None,
+                    );
                 }
             }
             SlashCommand::TestApproval => {
@@ -4458,7 +4481,7 @@ impl ChatWidget {
                 }
                 match trimmed.to_ascii_lowercase().as_str() {
                     "on" => self.set_service_tier_selection(Some(ServiceTier::Fast)),
-                    "off" => self.set_service_tier_selection(None),
+                    "off" => self.set_service_tier_selection(/*service_tier*/ None),
                     "status" => {
                         let status = if matches!(self.config.service_tier, Some(ServiceTier::Fast))
                         {
@@ -4466,7 +4489,10 @@ impl ChatWidget {
                         } else {
                             "off"
                         };
-                        self.add_info_message(format!("Fast mode is {status}."), None);
+                        self.add_info_message(
+                            format!("Fast mode is {status}."),
+                            /*hint*/ None,
+                        );
                     }
                     _ => {
                         self.add_error_message("Usage: /fast [on|off|status]".to_string());
@@ -4475,9 +4501,10 @@ impl ChatWidget {
             }
             SlashCommand::Rename if !trimmed.is_empty() => {
                 self.session_telemetry
-                    .counter("codex.thread.rename", 1, &[]);
-                let Some((prepared_args, _prepared_elements)) =
-                    self.bottom_pane.prepare_inline_args_submission(false)
+                    .counter("codex.thread.rename", /*inc*/ 1, &[]);
+                let Some((prepared_args, _prepared_elements)) = self
+                    .bottom_pane
+                    .prepare_inline_args_submission(/*record_history*/ false)
                 else {
                     return;
                 };
@@ -4496,8 +4523,9 @@ impl ChatWidget {
                 if self.active_mode_kind() != ModeKind::Plan {
                     return;
                 }
-                let Some((prepared_args, prepared_elements)) =
-                    self.bottom_pane.prepare_inline_args_submission(true)
+                let Some((prepared_args, prepared_elements)) = self
+                    .bottom_pane
+                    .prepare_inline_args_submission(/*record_history*/ true)
                 else {
                     return;
                 };
@@ -4522,8 +4550,9 @@ impl ChatWidget {
                 }
             }
             SlashCommand::Review if !trimmed.is_empty() => {
-                let Some((prepared_args, _prepared_elements)) =
-                    self.bottom_pane.prepare_inline_args_submission(false)
+                let Some((prepared_args, _prepared_elements)) = self
+                    .bottom_pane
+                    .prepare_inline_args_submission(/*record_history*/ false)
                 else {
                     return;
                 };
@@ -4536,8 +4565,9 @@ impl ChatWidget {
                 self.bottom_pane.drain_pending_submission_state();
             }
             SlashCommand::SandboxReadRoot if !trimmed.is_empty() => {
-                let Some((prepared_args, _prepared_elements)) =
-                    self.bottom_pane.prepare_inline_args_submission(false)
+                let Some((prepared_args, _prepared_elements)) = self
+                    .bottom_pane
+                    .prepare_inline_args_submission(/*record_history*/ false)
                 else {
                     return;
                 };
@@ -4566,7 +4596,7 @@ impl ChatWidget {
         let view = CustomPromptView::new(
             title.to_string(),
             "Type a name and press Enter".to_string(),
-            None,
+            /*context_label*/ None,
             Box::new(move |name: String| {
                 let Some(name) = codex_core::util::normalize_thread_name(&name) else {
                     tx.send(AppEvent::InsertHistoryCell(Box::new(
@@ -4862,9 +4892,9 @@ impl ChatWidget {
             self.config.permissions.sandbox_policy.get().clone(),
             effective_mode.model().to_string(),
             effective_mode.reasoning_effort(),
-            None,
+            /*summary*/ None,
             service_tier,
-            None,
+            /*final_output_json_schema*/ None,
             collaboration_mode,
             personality,
         );
@@ -4966,13 +4996,17 @@ impl ChatWidget {
                 continue;
             }
             // `id: None` indicates a synthetic/fake id coming from replay.
-            self.dispatch_event_msg(None, msg, Some(ReplayKind::ResumeInitialMessages));
+            self.dispatch_event_msg(
+                /*id*/ None,
+                msg,
+                Some(ReplayKind::ResumeInitialMessages),
+            );
         }
     }
 
     pub(crate) fn handle_codex_event(&mut self, event: Event) {
         let Event { id, msg } = event;
-        self.dispatch_event_msg(Some(id), msg, None);
+        self.dispatch_event_msg(Some(id), msg, /*replay_kind*/ None);
     }
 
     pub(crate) fn handle_codex_event_replay(&mut self, event: Event) {
@@ -4980,7 +5014,7 @@ impl ChatWidget {
         if matches!(msg, EventMsg::ShutdownComplete) {
             return;
         }
-        self.dispatch_event_msg(None, msg, Some(ReplayKind::ThreadSnapshot));
+        self.dispatch_event_msg(/*id*/ None, msg, Some(ReplayKind::ThreadSnapshot));
     }
 
     /// Dispatch a protocol `EventMsg` to the appropriate handler.
@@ -5133,7 +5167,10 @@ impl ChatWidget {
             EventMsg::ListSkillsResponse(ev) => self.on_list_skills(ev),
             EventMsg::ListRemoteSkillsResponse(_) | EventMsg::RemoteSkillDownloaded(_) => {}
             EventMsg::SkillsUpdateAvailable => {
-                self.submit_op(AppCommand::list_skills(Vec::new(), true));
+                self.submit_op(AppCommand::list_skills(
+                    Vec::new(),
+                    /*force_reload*/ true,
+                ));
             }
             EventMsg::ShutdownComplete => self.on_shutdown_complete(),
             EventMsg::TurnDiff(TurnDiffEvent { unified_diff }) => self.on_turn_diff(unified_diff),
@@ -5286,7 +5323,7 @@ impl ChatWidget {
         }
         // Avoid toggling running state for replayed history events on resume.
         if !from_replay && !self.bottom_pane.is_task_running() {
-            self.bottom_pane.set_task_running(true);
+            self.bottom_pane.set_task_running(/*running*/ true);
         }
         self.is_review_mode = true;
         let hint = review
@@ -5316,11 +5353,11 @@ impl ChatWidget {
                     let mut rendered: Vec<ratatui::text::Line<'static>> = vec!["".into()];
                     append_markdown(
                         &explanation,
-                        None,
+                        /*width*/ None,
                         Some(self.config.cwd.as_path()),
                         &mut rendered,
                     );
-                    let body_cell = AgentMessageCell::new(rendered, false);
+                    let body_cell = AgentMessageCell::new(rendered, /*is_first_line*/ false);
                     self.app_event_tx
                         .send(AppEvent::InsertHistoryCell(Box::new(body_cell)));
                 }
@@ -5564,7 +5601,10 @@ impl ChatWidget {
 
         self.config
             .config_layer_stack
-            .get_layers(ConfigLayerStackOrdering::LowestPrecedenceFirst, true)
+            .get_layers(
+                ConfigLayerStackOrdering::LowestPrecedenceFirst,
+                /*include_disabled*/ true,
+            )
             .iter()
             .find_map(|layer| match &layer.name {
                 ConfigLayerSource::Project { dot_codex_folder } => {
@@ -5578,7 +5618,7 @@ impl ChatWidget {
         self.status_line_project_root().map(|root| {
             root.file_name()
                 .map(|name| name.to_string_lossy().to_string())
-                .unwrap_or_else(|| format_directory_display(&root, None))
+                .unwrap_or_else(|| format_directory_display(&root, /*max_width*/ None))
         })
     }
 
@@ -5637,7 +5677,10 @@ impl ChatWidget {
                 Some(format!("{} {label}{fast_label}", self.model_display_name()))
             }
             StatusLineItem::CurrentDir => {
-                Some(format_directory_display(self.status_line_cwd(), None))
+                Some(format_directory_display(
+                    self.status_line_cwd(),
+                    /*max_width*/ None,
+                ))
             }
             StatusLineItem::ProjectRoot => self.status_line_project_root_name(),
             StatusLineItem::GitBranch => self.status_line_branch.clone(),
@@ -5772,7 +5815,10 @@ impl ChatWidget {
 
     fn clean_background_terminals(&mut self) {
         self.submit_op(AppCommand::clean_background_terminals());
-        self.add_info_message("Stopping all background terminals.".to_string(), None);
+        self.add_info_message(
+            "Stopping all background terminals.".to_string(),
+            /*hint*/ None,
+        );
     }
 
     fn stop_rate_limit_poller(&mut self) {}
@@ -5782,7 +5828,7 @@ impl ChatWidget {
     }
 
     fn prefetch_connectors(&mut self) {
-        self.prefetch_connectors_with_options(false);
+        self.prefetch_connectors_with_options(/*force_refetch*/ false);
     }
 
     fn prefetch_connectors_with_options(&mut self, force_refetch: bool) {
@@ -5837,7 +5883,7 @@ impl ChatWidget {
                 let connectors = connectors::merge_connectors_with_accessible(
                     all_connectors,
                     accessible_connectors,
-                    true,
+                    /*all_connectors_loaded*/ true,
                 );
                 Ok(ConnectorsSnapshot { connectors })
             }
@@ -5909,17 +5955,17 @@ impl ChatWidget {
         let switch_actions: Vec<SelectionAction> = vec![Box::new(move |tx| {
             tx.send(AppEvent::CodexOp(
                 AppCommand::override_turn_context(
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
+                    /*cwd*/ None,
+                    /*approval_policy*/ None,
+                    /*approvals_reviewer*/ None,
+                    /*sandbox_policy*/ None,
+                    /*windows_sandbox_level*/ None,
                     Some(switch_model_for_events.clone()),
                     Some(Some(default_effort)),
-                    None,
-                    None,
-                    None,
-                    None,
+                    /*summary*/ None,
+                    /*service_tier*/ None,
+                    /*collaboration_mode*/ None,
+                    /*personality*/ None,
                 )
                 .into_core(),
             ));
@@ -5985,7 +6031,7 @@ impl ChatWidget {
         if !self.is_session_configured() {
             self.add_info_message(
                 "Model selection is disabled until startup completes.".to_string(),
-                None,
+                /*hint*/ None,
             );
             return;
         }
@@ -5995,7 +6041,7 @@ impl ChatWidget {
             Err(_) => {
                 self.add_info_message(
                     "Models are being updated; please try /model again in a moment.".to_string(),
-                    None,
+                    /*hint*/ None,
                 );
                 return;
             }
@@ -6007,7 +6053,7 @@ impl ChatWidget {
         if !self.is_session_configured() {
             self.add_info_message(
                 "Personality selection is disabled until startup completes.".to_string(),
-                None,
+                /*hint*/ None,
             );
             return;
         }
@@ -6034,16 +6080,16 @@ impl ChatWidget {
                 let actions: Vec<SelectionAction> = vec![Box::new(move |tx| {
                     tx.send(AppEvent::CodexOp(
                         AppCommand::override_turn_context(
-                            None,
-                            None,
-                            None,
-                            None,
-                            None,
-                            None,
-                            None,
-                            None,
-                            None,
-                            None,
+                            /*cwd*/ None,
+                            /*approval_policy*/ None,
+                            /*approvals_reviewer*/ None,
+                            /*sandbox_policy*/ None,
+                            /*windows_sandbox_level*/ None,
+                            /*model*/ None,
+                            /*effort*/ None,
+                            /*summary*/ None,
+                            /*service_tier*/ None,
+                            /*collaboration_mode*/ None,
                             Some(personality),
                         )
                         .into_core(),
@@ -6371,7 +6417,7 @@ impl ChatWidget {
         if presets.is_empty() {
             self.add_info_message(
                 "No additional models are available right now.".to_string(),
-                None,
+                /*hint*/ None,
             );
             return;
         }
@@ -6417,7 +6463,7 @@ impl ChatWidget {
         if presets.is_empty() {
             self.add_info_message(
                 "No collaboration modes are available right now.".to_string(),
-                None,
+                /*hint*/ None,
             );
             return;
         }
@@ -7019,17 +7065,17 @@ impl ChatWidget {
             let sandbox_clone = sandbox.clone();
             tx.send(AppEvent::CodexOp(
                 AppCommand::override_turn_context(
-                    None,
+                    /*cwd*/ None,
                     Some(approval),
                     Some(approvals_reviewer),
                     Some(sandbox_clone.clone()),
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
+                    /*windows_sandbox_level*/ None,
+                    /*model*/ None,
+                    /*effort*/ None,
+                    /*summary*/ None,
+                    /*service_tier*/ None,
+                    /*collaboration_mode*/ None,
+                    /*personality*/ None,
                 )
                 .into_core(),
             ));
@@ -7037,7 +7083,10 @@ impl ChatWidget {
             tx.send(AppEvent::UpdateSandboxPolicy(sandbox_clone));
             tx.send(AppEvent::UpdateApprovalsReviewer(approvals_reviewer));
             tx.send(AppEvent::InsertHistoryCell(Box::new(
-                history_cell::new_info_event(format!("Permissions updated to {label}"), None),
+                history_cell::new_info_event(
+                    format!("Permissions updated to {label}"),
+                    /*hint*/ None,
+                ),
             )));
         })]
     }
@@ -7681,9 +7730,11 @@ impl ChatWidget {
 
     /// Set the reasoning effort in the stored collaboration mode.
     pub(crate) fn set_reasoning_effort(&mut self, effort: Option<ReasoningEffortConfig>) {
-        self.current_collaboration_mode =
-            self.current_collaboration_mode
-                .with_updates(None, Some(effort), None);
+        self.current_collaboration_mode = self.current_collaboration_mode.with_updates(
+            /*model*/ None,
+            Some(effort),
+            /*developer_instructions*/ None,
+        );
         if self.collaboration_modes_enabled()
             && let Some(mask) = self.active_collaboration_mask.as_mut()
             && mask.mode != Some(ModeKind::Plan)
@@ -7770,9 +7821,11 @@ impl ChatWidget {
 
     /// Set the model in the widget's config copy and stored collaboration mode.
     pub(crate) fn set_model(&mut self, model: &str) {
-        self.current_collaboration_mode =
-            self.current_collaboration_mode
-                .with_updates(Some(model.to_string()), None, None);
+        self.current_collaboration_mode = self.current_collaboration_mode.with_updates(
+            Some(model.to_string()),
+            /*effort*/ None,
+            /*developer_instructions*/ None,
+        );
         if self.collaboration_modes_enabled()
             && let Some(mask) = self.active_collaboration_mask.as_mut()
         {
@@ -7785,17 +7838,17 @@ impl ChatWidget {
         self.set_service_tier(service_tier);
         self.app_event_tx.send(AppEvent::CodexOp(
             AppCommand::override_turn_context(
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
+                /*cwd*/ None,
+                /*approval_policy*/ None,
+                /*approvals_reviewer*/ None,
+                /*sandbox_policy*/ None,
+                /*windows_sandbox_level*/ None,
+                /*model*/ None,
+                /*effort*/ None,
+                /*summary*/ None,
                 Some(service_tier),
-                None,
-                None,
+                /*collaboration_mode*/ None,
+                /*personality*/ None,
             )
             .into_core(),
         ));
@@ -8058,7 +8111,7 @@ impl ChatWidget {
             message.push_str(" for ");
             message.push_str(next_mode.display_name());
             message.push_str(" mode.");
-            self.add_info_message(message, None);
+            self.add_info_message(message, /*hint*/ None);
         }
         self.request_redraw();
     }
@@ -8096,8 +8149,8 @@ impl ChatWidget {
         Box::new(history_cell::SessionHeaderHistoryCell::new_with_style(
             DEFAULT_MODEL_DISPLAY_NAME.to_string(),
             placeholder_style,
-            None,
-            false,
+            /*reasoning_effort*/ None,
+            /*show_fast_status*/ false,
             config.cwd.clone(),
             CODEX_CLI_VERSION,
         ))
@@ -8169,7 +8222,10 @@ impl ChatWidget {
         let mcp_manager = McpManager::new(Arc::new(PluginsManager::new(
             self.config.codex_home.clone(),
         )));
-        if mcp_manager.effective_servers(&self.config, None).is_empty() {
+        if mcp_manager
+            .effective_servers(&self.config, /*auth*/ None)
+            .is_empty()
+        {
             self.add_to_history(history_cell::empty_mcp_output());
         } else {
             self.add_app_server_stub_message("MCP tool inventory");
@@ -8193,7 +8249,7 @@ impl ChatWidget {
         match connectors_cache {
             ConnectorsCacheState::Ready(snapshot) => {
                 if snapshot.connectors.is_empty() {
-                    self.add_info_message("No apps available.".to_string(), None);
+                    self.add_info_message("No apps available.".to_string(), /*hint*/ None);
                 } else {
                     self.open_connectors_popup(&snapshot.connectors);
                 }
@@ -8219,8 +8275,9 @@ impl ChatWidget {
     }
 
     fn open_connectors_popup(&mut self, connectors: &[connectors::AppInfo]) {
-        self.bottom_pane
-            .show_selection_view(self.connectors_popup_params(connectors, None));
+        self.bottom_pane.show_selection_view(
+            self.connectors_popup_params(connectors, /*selected_connector_id*/ None),
+        );
     }
 
     fn connectors_loading_popup_params(&self) -> SelectionViewParams {
@@ -8315,7 +8372,10 @@ impl ChatWidget {
                 let missing_label_for_action = missing_label.clone();
                 item.actions = vec![Box::new(move |tx| {
                     tx.send(AppEvent::InsertHistoryCell(Box::new(
-                        history_cell::new_info_event(missing_label_for_action.clone(), None),
+                        history_cell::new_info_event(
+                            missing_label_for_action.clone(),
+                            /*hint*/ None,
+                        ),
                     )));
                 })];
                 item.dismiss_on_select = true;
@@ -8612,7 +8672,7 @@ impl ChatWidget {
     {
         let op: AppCommand = op.into();
         if op.is_review() && !self.bottom_pane.is_task_running() {
-            self.bottom_pane.set_task_running(true);
+            self.bottom_pane.set_task_running(/*running*/ true);
         }
         match &self.codex_op_target {
             CodexOpTarget::Direct(codex_op_tx) => {
@@ -8664,7 +8724,7 @@ impl ChatWidget {
                     snapshot.connectors = connectors::merge_connectors_with_accessible(
                         Vec::new(),
                         snapshot.connectors,
-                        false,
+                        /*all_connectors_loaded*/ false,
                     );
                 }
                 snapshot.connectors =
@@ -8705,13 +8765,13 @@ impl ChatWidget {
                     self.bottom_pane.set_connectors_snapshot(Some(snapshot));
                 } else {
                     self.connectors_cache = ConnectorsCacheState::Failed(err);
-                    self.bottom_pane.set_connectors_snapshot(None);
+                    self.bottom_pane.set_connectors_snapshot(/*snapshot*/ None);
                 }
             }
         }
 
         if trigger_pending_force_refetch {
-            self.prefetch_connectors_with_options(true);
+            self.prefetch_connectors_with_options(/*force_refetch*/ true);
         }
     }
 
@@ -8740,7 +8800,7 @@ impl ChatWidget {
 
     fn refresh_plugin_mentions(&mut self) {
         if !self.config.features.enabled(Feature::Plugins) {
-            self.bottom_pane.set_plugin_mentions(None);
+            self.bottom_pane.set_plugin_mentions(/*plugins*/ None);
             return;
         }
 
@@ -8845,7 +8905,7 @@ impl ChatWidget {
     }
 
     pub(crate) async fn show_review_commit_picker(&mut self, cwd: &Path) {
-        let commits = codex_core::git_info::recent_commits(cwd, 100).await;
+        let commits = codex_core::git_info::recent_commits(cwd, /*limit*/ 100).await;
 
         let mut items: Vec<SelectionItem> = Vec::with_capacity(commits.len());
         for entry in commits {
@@ -8885,7 +8945,7 @@ impl ChatWidget {
         let view = CustomPromptView::new(
             "Custom review instructions".to_string(),
             "Type instructions and press Enter".to_string(),
-            None,
+            /*context_label*/ None,
             Box::new(move |prompt: String| {
                 let trimmed = prompt.trim().to_string();
                 if trimmed.is_empty() {
@@ -8974,14 +9034,18 @@ impl ChatWidget {
 
     fn as_renderable(&self) -> RenderableItem<'_> {
         let active_cell_renderable = match &self.active_cell {
-            Some(cell) => RenderableItem::Borrowed(cell).inset(Insets::tlbr(1, 0, 0, 0)),
+            Some(cell) => RenderableItem::Borrowed(cell).inset(Insets::tlbr(
+                /*top*/ 1, /*left*/ 0, /*bottom*/ 0, /*right*/ 0,
+            )),
             None => RenderableItem::Owned(Box::new(())),
         };
         let mut flex = FlexRenderable::new();
-        flex.push(1, active_cell_renderable);
+        flex.push(/*flex*/ 1, active_cell_renderable);
         flex.push(
-            0,
-            RenderableItem::Borrowed(&self.bottom_pane).inset(Insets::tlbr(1, 0, 0, 0)),
+            /*flex*/ 0,
+            RenderableItem::Borrowed(&self.bottom_pane).inset(Insets::tlbr(
+                /*top*/ 1, /*left*/ 0, /*bottom*/ 0, /*right*/ 0,
+            )),
         );
         RenderableItem::Owned(Box::new(flex))
     }
@@ -9073,7 +9137,10 @@ impl Notification {
                     .unwrap_or_else(|| "Agent turn complete".to_string())
             }
             Notification::ExecApprovalRequested { command } => {
-                format!("Approval requested: {}", truncate_text(command, 30))
+                format!(
+                    "Approval requested: {}",
+                    truncate_text(command, /*max_graphemes*/ 30)
+                )
             }
             Notification::EditApprovalRequested { cwd, changes } => {
                 format!(
@@ -9160,7 +9227,7 @@ impl Notification {
         if summary.is_empty() {
             None
         } else {
-            Some(truncate_text(summary, 30))
+            Some(truncate_text(summary, /*max_graphemes*/ 30))
         }
     }
 }

--- a/codex-rs/tui_app_server/src/chatwidget/realtime.rs
+++ b/codex-rs/tui_app_server/src/chatwidget/realtime.rs
@@ -185,7 +185,7 @@ impl ChatWidget {
             self.realtime_conversation.warned_audio_only_submission = true;
             self.add_info_message(
                 "Realtime voice mode is audio-only. Use /realtime to stop.".to_string(),
-                None,
+                /*hint*/ None,
             );
         } else {
             self.request_redraw();
@@ -216,7 +216,7 @@ impl ChatWidget {
     pub(super) fn request_realtime_conversation_close(&mut self, info_message: Option<String>) {
         if !self.realtime_conversation.is_live() {
             if let Some(message) = info_message {
-                self.add_info_message(message, None);
+                self.add_info_message(message, /*hint*/ None);
             }
             return;
         }
@@ -225,10 +225,10 @@ impl ChatWidget {
         self.realtime_conversation.phase = RealtimeConversationPhase::Stopping;
         self.submit_op(AppCommand::realtime_conversation_close());
         self.stop_realtime_local_audio();
-        self.set_footer_hint_override(None);
+        self.set_footer_hint_override(/*items*/ None);
 
         if let Some(message) = info_message {
-            self.add_info_message(message, None);
+            self.add_info_message(message, /*hint*/ None);
         } else {
             self.request_redraw();
         }
@@ -236,7 +236,7 @@ impl ChatWidget {
 
     pub(super) fn reset_realtime_conversation_state(&mut self) {
         self.stop_realtime_local_audio();
-        self.set_footer_hint_override(None);
+        self.set_footer_hint_override(/*items*/ None);
         self.realtime_conversation.phase = RealtimeConversationPhase::Inactive;
         self.realtime_conversation.requested_close = false;
         self.realtime_conversation.session_id = None;
@@ -286,7 +286,10 @@ impl ChatWidget {
         let reason = ev.reason;
         self.reset_realtime_conversation_state();
         if !requested && let Some(reason) = reason {
-            self.add_info_message(format!("Realtime voice mode closed: {reason}"), None);
+            self.add_info_message(
+                format!("Realtime voice mode closed: {reason}"),
+                /*hint*/ None,
+            );
         }
         self.request_redraw();
     }

--- a/codex-rs/tui_app_server/src/chatwidget/skills.rs
+++ b/codex-rs/tui_app_server/src/chatwidget/skills.rs
@@ -61,7 +61,7 @@ impl ChatWidget {
 
     pub(crate) fn open_manage_skills_popup(&mut self) {
         if self.skills_all.is_empty() {
-            self.add_info_message("No skills available.".to_string(), None);
+            self.add_info_message("No skills available.".to_string(), /*hint*/ None);
             return;
         }
 
@@ -133,7 +133,7 @@ impl ChatWidget {
         }
         self.add_info_message(
             format!("{enabled_count} skills enabled, {disabled_count} skills disabled"),
-            None,
+            /*hint*/ None,
         );
     }
 

--- a/codex-rs/tui_app_server/src/cwd_prompt.rs
+++ b/codex-rs/tui_app_server/src/cwd_prompt.rs
@@ -212,20 +212,23 @@ impl WidgetRef for &CwdPromptScreen {
                 "Session = latest cwd recorded in the {action_past} session"
             ))
             .dim()
-            .inset(Insets::tlbr(0, 2, 0, 0)),
+            .inset(Insets::tlbr(
+                /*top*/ 0, /*left*/ 2, /*bottom*/ 0, /*right*/ 0,
+            )),
         );
         column.push(
-            Line::from("Current = your current working directory".dim())
-                .inset(Insets::tlbr(0, 2, 0, 0)),
+            Line::from("Current = your current working directory".dim()).inset(Insets::tlbr(
+                /*top*/ 0, /*left*/ 2, /*bottom*/ 0, /*right*/ 0,
+            )),
         );
         column.push("");
         column.push(selection_option_row(
-            0,
+            /*index*/ 0,
             format!("Use session directory ({session_cwd})"),
             self.highlighted == CwdSelection::Session,
         ));
         column.push(selection_option_row(
-            1,
+            /*index*/ 1,
             format!("Use current directory ({current_cwd})"),
             self.highlighted == CwdSelection::Current,
         ));
@@ -236,7 +239,9 @@ impl WidgetRef for &CwdPromptScreen {
                 key_hint::plain(KeyCode::Enter).into(),
                 " to continue".dim(),
             ])
-            .inset(Insets::tlbr(0, 2, 0, 0)),
+            .inset(Insets::tlbr(
+                /*top*/ 0, /*left*/ 2, /*bottom*/ 0, /*right*/ 0,
+            )),
         );
         column.render(area, buf);
     }

--- a/codex-rs/tui_app_server/src/debug_config.rs
+++ b/codex-rs/tui_app_server/src/debug_config.rs
@@ -60,7 +60,10 @@ fn render_debug_config_lines(stack: &ConfigLayerStack) -> Vec<Line<'static>> {
             .bold()
             .into(),
     );
-    let layers = stack.get_layers(ConfigLayerStackOrdering::LowestPrecedenceFirst, true);
+    let layers = stack.get_layers(
+        ConfigLayerStackOrdering::LowestPrecedenceFirst,
+        /*include_disabled*/ true,
+    );
     if layers.is_empty() {
         lines.push("  <none>".dim().into());
     } else {
@@ -186,7 +189,7 @@ fn render_non_file_layer_details(layer: &ConfigLayerEntry) -> Vec<Line<'static>>
 
 fn render_session_flag_details(config: &TomlValue) -> Vec<Line<'static>> {
     let mut pairs = Vec::new();
-    flatten_toml_key_values(config, None, &mut pairs);
+    flatten_toml_key_values(config, /*prefix*/ None, &mut pairs);
 
     if pairs.is_empty() {
         return vec!["     - <none>".dim().into()];

--- a/codex-rs/tui_app_server/src/diff_render.rs
+++ b/codex-rs/tui_app_server/src/diff_render.rs
@@ -306,13 +306,13 @@ impl DiffSummary {
 impl Renderable for FileChange {
     fn render(&self, area: Rect, buf: &mut Buffer) {
         let mut lines = vec![];
-        render_change(self, &mut lines, area.width as usize, None);
+        render_change(self, &mut lines, area.width as usize, /*lang*/ None);
         Paragraph::new(lines).render(area, buf);
     }
 
     fn desired_height(&self, width: u16) -> u16 {
         let mut lines = vec![];
-        render_change(self, &mut lines, width as usize, None);
+        render_change(self, &mut lines, width as usize, /*lang*/ None);
         lines.len() as u16
     }
 }
@@ -332,7 +332,9 @@ impl From<DiffSummary> for Box<dyn Renderable> {
             rows.push(Box::new(RtLine::from("")));
             rows.push(Box::new(InsetRenderable::new(
                 Box::new(row.change) as Box<dyn Renderable>,
-                Insets::tlbr(0, 2, 0, 0),
+                Insets::tlbr(
+                    /*top*/ 0, /*left*/ 2, /*bottom*/ 0, /*right*/ 0,
+                ),
             )));
         }
 
@@ -502,7 +504,7 @@ fn render_change(
                         raw,
                         width,
                         line_number_width,
-                        None,
+                        /*syntax_spans*/ None,
                         style_context.theme,
                         style_context.color_level,
                         style_context.diff_backgrounds,
@@ -534,7 +536,7 @@ fn render_change(
                         raw,
                         width,
                         line_number_width,
-                        None,
+                        /*syntax_spans*/ None,
                         style_context.theme,
                         style_context.color_level,
                         style_context.diff_backgrounds,
@@ -649,7 +651,7 @@ fn render_change(
                                             s,
                                             width,
                                             line_number_width,
-                                            None,
+                                            /*syntax_spans*/ None,
                                             style_context.theme,
                                             style_context.color_level,
                                             style_context.diff_backgrounds,
@@ -682,7 +684,7 @@ fn render_change(
                                             s,
                                             width,
                                             line_number_width,
-                                            None,
+                                            /*syntax_spans*/ None,
                                             style_context.theme,
                                             style_context.color_level,
                                             style_context.diff_backgrounds,
@@ -715,7 +717,7 @@ fn render_change(
                                             s,
                                             width,
                                             line_number_width,
-                                            None,
+                                            /*syntax_spans*/ None,
                                             style_context.theme,
                                             style_context.color_level,
                                             style_context.diff_backgrounds,
@@ -796,7 +798,7 @@ pub(crate) fn push_wrapped_diff_line_with_style_context(
         text,
         width,
         line_number_width,
-        None,
+        /*syntax_spans*/ None,
         style_context.theme,
         style_context.color_level,
         style_context.diff_backgrounds,

--- a/codex-rs/tui_app_server/src/exec_cell/render.rs
+++ b/codex-rs/tui_app_server/src/exec_cell/render.rs
@@ -681,9 +681,9 @@ impl ExecDisplayLayout {
 
 const EXEC_DISPLAY_LAYOUT: ExecDisplayLayout = ExecDisplayLayout::new(
     PrefixedBlock::new("  │ ", "  │ "),
-    2,
+    /*command_continuation_max_lines*/ 2,
     PrefixedBlock::new("  └ ", "    "),
-    5,
+    /*output_max_lines*/ 5,
 );
 
 #[cfg(test)]

--- a/codex-rs/tui_app_server/src/file_search.rs
+++ b/codex-rs/tui_app_server/src/file_search.rs
@@ -87,7 +87,7 @@ impl FileSearchManager {
                 ..Default::default()
             },
             reporter,
-            None,
+            /*cancel_flag*/ None,
         );
         match session {
             Ok(session) => st.session = Some(session),

--- a/codex-rs/tui_app_server/src/history_cell.rs
+++ b/codex-rs/tui_app_server/src/history_cell.rs
@@ -782,7 +782,7 @@ fn truncate_exec_snippet(full_cmd: &str) -> String {
         Some((first, _)) => format!("{first} ..."),
         None => full_cmd.to_string(),
     };
-    snippet = truncate_text(&snippet, 80);
+    snippet = truncate_text(&snippet, /*max_graphemes*/ 80);
     snippet
 }
 
@@ -1003,7 +1003,7 @@ pub(crate) fn card_inner_width(width: u16, max_inner_width: usize) -> Option<usi
 
 /// Render `lines` inside a border sized to the widest span in the content.
 pub(crate) fn with_border(lines: Vec<Line<'static>>) -> Vec<Line<'static>> {
-    with_border_internal(lines, None)
+    with_border_internal(lines, /*forced_inner_width*/ None)
 }
 
 /// Render `lines` inside a border whose inner width is at least `inner_width`.
@@ -1660,7 +1660,7 @@ pub(crate) fn new_active_web_search_call(
     query: String,
     animations_enabled: bool,
 ) -> WebSearchCell {
-    WebSearchCell::new(call_id, query, None, animations_enabled)
+    WebSearchCell::new(call_id, query, /*action*/ None, animations_enabled)
 }
 
 pub(crate) fn new_web_search_call(
@@ -1668,7 +1668,12 @@ pub(crate) fn new_web_search_call(
     query: String,
     action: WebSearchAction,
 ) -> WebSearchCell {
-    let mut cell = WebSearchCell::new(call_id, query, Some(action), false);
+    let mut cell = WebSearchCell::new(
+        call_id,
+        query,
+        Some(action),
+        /*animations_enabled*/ false,
+    );
     cell.complete();
     cell
 }
@@ -1812,7 +1817,7 @@ pub(crate) fn new_mcp_tools_output(
     }
 
     let mcp_manager = McpManager::new(Arc::new(PluginsManager::new(config.codex_home.clone())));
-    let effective_servers = mcp_manager.effective_servers(config, None);
+    let effective_servers = mcp_manager.effective_servers(config, /*auth*/ None);
     let mut servers: Vec<_> = effective_servers.iter().collect();
     servers.sort_by(|(a, _), (b, _)| a.cmp(b));
 
@@ -2345,7 +2350,7 @@ pub(crate) fn new_reasoning_summary_block(
                     header_buffer,
                     summary_buffer,
                     &cwd,
-                    false,
+                    /*transcript_only*/ false,
                 ));
             }
         }
@@ -2354,7 +2359,7 @@ pub(crate) fn new_reasoning_summary_block(
         "".to_string(),
         full_reasoning_buffer.to_string(),
         &cwd,
-        true,
+        /*transcript_only*/ true,
     ))
 }
 

--- a/codex-rs/tui_app_server/src/lib.rs
+++ b/codex-rs/tui_app_server/src/lib.rs
@@ -504,7 +504,10 @@ async fn lookup_session_target_with_app_server(
                 return Ok(None);
             }
         };
-        return match app_server.thread_read(thread_id, false).await {
+        return match app_server
+            .thread_read(thread_id, /*include_turns*/ false)
+            .await
+        {
             Ok(thread) => Ok(session_target_from_app_server_thread(thread)),
             Err(err) => {
                 warn!(
@@ -668,7 +671,7 @@ pub async fn run_main(
         .unwrap_or_else(|| "https://chatgpt.com/backend-api/".to_string());
     let cloud_requirements = cloud_requirements_loader_for_storage(
         codex_home.to_path_buf(),
-        false,
+        /*enable_codex_api_key_env*/ false,
         config_toml.cli_auth_credentials_store.unwrap_or_default(),
         chatgpt_base_url,
     );
@@ -825,7 +828,12 @@ pub async fn run_main(
     }
 
     let otel = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        codex_core::otel_init::build_provider(&config, env!("CARGO_PKG_VERSION"), None, true)
+        codex_core::otel_init::build_provider(
+            &config,
+            env!("CARGO_PKG_VERSION"),
+            /*service_name_override*/ None,
+            /*default_analytics_enabled*/ true,
+        )
     })) {
         Ok(Ok(otel)) => otel,
         Ok(Err(e)) => {
@@ -1004,7 +1012,7 @@ async fn run_ratatui_app(
         if show_login_screen && !remote_mode {
             cloud_requirements = cloud_requirements_loader_for_storage(
                 initial_config.codex_home.clone(),
-                false,
+                /*enable_codex_api_key_env*/ false,
                 initial_config.cli_auth_credentials_store_mode,
                 initial_config.chatgpt_base_url.clone(),
             );
@@ -1086,7 +1094,11 @@ async fn run_ratatui_app(
             let Some(app_server) = session_lookup_app_server.as_mut() else {
                 unreachable!("session lookup app server should be initialized for --fork --last");
             };
-            match lookup_latest_session_target_with_app_server(app_server, &config, None).await? {
+            match lookup_latest_session_target_with_app_server(
+                app_server, &config, /*cwd_filter*/ None,
+            )
+            .await?
+            {
                 Some(target_session) => resume_picker::SessionSelection::Fork(target_session),
                 None => resume_picker::SessionSelection::StartFresh,
             }
@@ -1475,8 +1487,13 @@ async fn load_config_or_exit(
     overrides: ConfigOverrides,
     cloud_requirements: CloudRequirementsLoader,
 ) -> Config {
-    load_config_or_exit_with_fallback_cwd(cli_kv_overrides, overrides, cloud_requirements, None)
-        .await
+    load_config_or_exit_with_fallback_cwd(
+        cli_kv_overrides,
+        overrides,
+        cloud_requirements,
+        /*fallback_cwd*/ None,
+    )
+    .await
 }
 
 async fn load_config_or_exit_with_fallback_cwd(

--- a/codex-rs/tui_app_server/src/live_wrap.rs
+++ b/codex-rs/tui_app_server/src/live_wrap.rs
@@ -66,7 +66,7 @@ impl RowBuilder {
                 if start < i {
                     self.current_line.push_str(&fragment[start..i]);
                 }
-                self.flush_current_line(true);
+                self.flush_current_line(/*explicit_break*/ true);
                 start = i + ch.len_utf8();
             }
         }
@@ -78,7 +78,7 @@ impl RowBuilder {
 
     /// Mark the end of the current logical line (equivalent to pushing a '\n').
     pub fn end_line(&mut self) {
-        self.flush_current_line(true);
+        self.flush_current_line(/*explicit_break*/ true);
     }
 
     /// Drain and return all produced rows.

--- a/codex-rs/tui_app_server/src/main.rs
+++ b/codex-rs/tui_app_server/src/main.rs
@@ -26,7 +26,7 @@ fn main() -> anyhow::Result<()> {
             inner,
             arg0_paths,
             codex_core::config_loader::LoaderOverrides::default(),
-            None,
+            /*remote*/ None,
         )
         .await?;
         let token_usage = exit_info.token_usage;

--- a/codex-rs/tui_app_server/src/markdown_render.rs
+++ b/codex-rs/tui_app_server/src/markdown_render.rs
@@ -87,7 +87,7 @@ impl IndentContext {
 }
 
 pub fn render_markdown_text(input: &str) -> Text<'static> {
-    render_markdown_text_with_width(input, None)
+    render_markdown_text_with_width(input, /*width*/ None)
 }
 
 /// Render markdown using the current process working directory for local file-link display.
@@ -227,8 +227,8 @@ where
                 self.push_line(Line::from("———"));
                 self.needs_newline = true;
             }
-            Event::Html(html) => self.html(html, false),
-            Event::InlineHtml(html) => self.html(html, true),
+            Event::Html(html) => self.html(html, /*inline*/ false),
+            Event::InlineHtml(html) => self.html(html, /*inline*/ true),
             Event::FootnoteReference(_) => {}
             Event::TaskListMarker(_) => {}
         }
@@ -352,8 +352,11 @@ where
             self.push_blank_line();
             self.needs_newline = false;
         }
-        self.indent_stack
-            .push(IndentContext::new(vec![Span::from("> ")], None, false));
+        self.indent_stack.push(IndentContext::new(
+            vec![Span::from("> ")],
+            /*marker*/ None,
+            /*is_list*/ false,
+        ));
     }
 
     fn end_blockquote(&mut self) {
@@ -512,8 +515,11 @@ where
             let indent_len = if is_ordered { width + 2 } else { width + 1 };
             vec![Span::from(" ".repeat(indent_len))]
         };
-        self.indent_stack
-            .push(IndentContext::new(indent_prefix, marker, true));
+        self.indent_stack.push(IndentContext::new(
+            indent_prefix,
+            marker,
+            /*is_list*/ true,
+        ));
         self.needs_newline = false;
     }
 
@@ -538,8 +544,8 @@ where
 
         self.indent_stack.push(IndentContext::new(
             vec![indent.unwrap_or_default()],
-            None,
-            false,
+            /*marker*/ None,
+            /*is_list*/ false,
         ));
         self.needs_newline = true;
     }
@@ -659,7 +665,7 @@ where
         let was_pending = self.pending_marker_line;
 
         self.current_initial_indent = self.prefix_spans(was_pending);
-        self.current_subsequent_indent = self.prefix_spans(false);
+        self.current_subsequent_indent = self.prefix_spans(/*pending_marker_line*/ false);
         self.current_line_style = style;
         self.current_line_content = Some(line);
         self.current_line_in_code_block = self.in_code_block;

--- a/codex-rs/tui_app_server/src/model_migration.rs
+++ b/codex-rs/tui_app_server/src/model_migration.rs
@@ -307,7 +307,9 @@ impl ModelMigrationScreen {
             column.push(
                 Paragraph::new(line.clone())
                     .wrap(Wrap { trim: false })
-                    .inset(Insets::tlbr(0, 2, 0, 0)),
+                    .inset(Insets::tlbr(
+                        /*top*/ 0, /*left*/ 2, /*bottom*/ 0, /*right*/ 0,
+                    )),
             );
         }
     }
@@ -326,7 +328,12 @@ impl ModelMigrationScreen {
             column.push(
                 Paragraph::new(line)
                     .wrap(Wrap { trim: false })
-                    .inset(Insets::tlbr(0, horizontal_inset, 0, 0)),
+                    .inset(Insets::tlbr(
+                        /*top*/ 0,
+                        horizontal_inset,
+                        /*bottom*/ 0,
+                        /*right*/ 0,
+                    )),
             );
         }
     }
@@ -336,7 +343,9 @@ impl ModelMigrationScreen {
         column.push(
             Paragraph::new("Choose how you'd like Codex to proceed.")
                 .wrap(Wrap { trim: false })
-                .inset(Insets::tlbr(0, 2, 0, 0)),
+                .inset(Insets::tlbr(
+                    /*top*/ 0, /*left*/ 2, /*bottom*/ 0, /*right*/ 0,
+                )),
         );
         column.push(Line::from(""));
 
@@ -359,7 +368,9 @@ impl ModelMigrationScreen {
                 key_hint::plain(KeyCode::Enter).into(),
                 " to confirm".dim(),
             ])
-            .inset(Insets::tlbr(0, 2, 0, 0)),
+            .inset(Insets::tlbr(
+                /*top*/ 0, /*left*/ 2, /*bottom*/ 0, /*right*/ 0,
+            )),
         );
     }
 }

--- a/codex-rs/tui_app_server/src/multi_agents.rs
+++ b/codex-rs/tui_app_server/src/multi_agents.rs
@@ -224,7 +224,7 @@ pub(crate) fn interaction_end(ev: CollabAgentInteractionEndEvent) -> PlainHistor
             nickname: receiver_agent_nickname.as_deref(),
             role: receiver_agent_role.as_deref(),
         },
-        None,
+        /*spawn_request*/ None,
     );
 
     let mut details = Vec::new();
@@ -244,7 +244,11 @@ pub(crate) fn waiting_begin(ev: CollabWaitingBeginEvent) -> PlainHistoryCell {
     let receiver_agents = merge_wait_receivers(&receiver_thread_ids, receiver_agents);
 
     let title = match receiver_agents.as_slice() {
-        [receiver] => title_with_agent("Waiting for", agent_label_from_ref(receiver), None),
+        [receiver] => title_with_agent(
+            "Waiting for",
+            agent_label_from_ref(receiver),
+            /*spawn_request*/ None,
+        ),
         [] => title_text("Waiting for agents"),
         _ => title_text(format!("Waiting for {} agents", receiver_agents.len())),
     };
@@ -290,7 +294,7 @@ pub(crate) fn close_end(ev: CollabCloseEndEvent) -> PlainHistoryCell {
                 nickname: receiver_agent_nickname.as_deref(),
                 role: receiver_agent_role.as_deref(),
             },
-            None,
+            /*spawn_request*/ None,
         ),
         Vec::new(),
     )
@@ -313,7 +317,7 @@ pub(crate) fn resume_begin(ev: CollabResumeBeginEvent) -> PlainHistoryCell {
                 nickname: receiver_agent_nickname.as_deref(),
                 role: receiver_agent_role.as_deref(),
             },
-            None,
+            /*spawn_request*/ None,
         ),
         Vec::new(),
     )
@@ -337,7 +341,7 @@ pub(crate) fn resume_end(ev: CollabResumeEndEvent) -> PlainHistoryCell {
                 nickname: receiver_agent_nickname.as_deref(),
                 role: receiver_agent_role.as_deref(),
             },
-            None,
+            /*spawn_request*/ None,
         ),
         vec![status_summary_line(&status)],
     )

--- a/codex-rs/tui_app_server/src/onboarding/auth.rs
+++ b/codex-rs/tui_app_server/src/onboarding/auth.rs
@@ -137,19 +137,19 @@ impl KeyboardHandler for AuthModeWidget {
 
         match key_event.code {
             KeyCode::Up | KeyCode::Char('k') => {
-                self.move_highlight(-1);
+                self.move_highlight(/*delta*/ -1);
             }
             KeyCode::Down | KeyCode::Char('j') => {
-                self.move_highlight(1);
+                self.move_highlight(/*delta*/ 1);
             }
             KeyCode::Char('1') => {
-                self.select_option_by_index(0);
+                self.select_option_by_index(/*index*/ 0);
             }
             KeyCode::Char('2') => {
-                self.select_option_by_index(1);
+                self.select_option_by_index(/*index*/ 1);
             }
             KeyCode::Char('3') => {
-                self.select_option_by_index(2);
+                self.select_option_by_index(/*index*/ 2);
             }
             KeyCode::Enter => {
                 let sign_in_state = { (*self.sign_in_state.read().unwrap()).clone() };
@@ -182,7 +182,7 @@ impl KeyboardHandler for AuthModeWidget {
                         });
                         *sign_in_state = SignInState::PickMode;
                         drop(sign_in_state);
-                        self.set_error(None);
+                        self.set_error(/*message*/ None);
                         self.request_frame.schedule_frame();
                     }
                     SignInState::ChatGptDeviceCode(state) => {
@@ -191,7 +191,7 @@ impl KeyboardHandler for AuthModeWidget {
                         }
                         *sign_in_state = SignInState::PickMode;
                         drop(sign_in_state);
-                        self.set_error(None);
+                        self.set_error(/*message*/ None);
                         self.request_frame.schedule_frame();
                     }
                     _ => {}
@@ -585,7 +585,7 @@ impl AuthModeWidget {
                 match key_event.code {
                     KeyCode::Esc => {
                         *guard = SignInState::PickMode;
-                        self.set_error(None);
+                        self.set_error(/*message*/ None);
                         should_request_frame = true;
                     }
                     KeyCode::Enter => {
@@ -604,7 +604,7 @@ impl AuthModeWidget {
                         } else {
                             state.value.pop();
                         }
-                        self.set_error(None);
+                        self.set_error(/*message*/ None);
                         should_request_frame = true;
                     }
                     KeyCode::Char(c)
@@ -618,7 +618,7 @@ impl AuthModeWidget {
                             state.prepopulated_from_env = false;
                         }
                         state.value.push(c);
-                        self.set_error(None);
+                        self.set_error(/*message*/ None);
                         should_request_frame = true;
                     }
                     _ => {}
@@ -651,7 +651,7 @@ impl AuthModeWidget {
             } else {
                 state.value.push_str(trimmed);
             }
-            self.set_error(None);
+            self.set_error(/*message*/ None);
         } else {
             return false;
         }
@@ -666,7 +666,7 @@ impl AuthModeWidget {
             self.disallow_api_login();
             return;
         }
-        self.set_error(None);
+        self.set_error(/*message*/ None);
         let prefill_from_env = read_openai_api_key_from_env();
         let mut guard = self.sign_in_state.write().unwrap();
         match &mut *guard {
@@ -696,7 +696,7 @@ impl AuthModeWidget {
             self.disallow_api_login();
             return;
         }
-        self.set_error(None);
+        self.set_error(/*message*/ None);
         let request_handle = self.app_server_request_handle.clone();
         let sign_in_state = self.sign_in_state.clone();
         let error = self.error.clone();
@@ -758,7 +758,7 @@ impl AuthModeWidget {
             return;
         }
 
-        self.set_error(None);
+        self.set_error(/*message*/ None);
         let request_handle = self.app_server_request_handle.clone();
         let sign_in_state = self.sign_in_state.clone();
         let error = self.error.clone();
@@ -822,7 +822,7 @@ impl AuthModeWidget {
         }
 
         if notification.success {
-            self.set_error(None);
+            self.set_error(/*message*/ None);
             *self.sign_in_state.write().unwrap() = SignInState::ChatGptSuccessMessage;
         } else {
             self.set_error(notification.error);

--- a/codex-rs/tui_app_server/src/onboarding/trust_directory.rs
+++ b/codex-rs/tui_app_server/src/onboarding/trust_directory.rs
@@ -56,7 +56,7 @@ impl WidgetRef for &TrustDirectoryWidget {
                 "Do you trust the contents of this directory? Working with untrusted contents comes with higher risk of prompt injection.".to_string(),
             )
                 .wrap(Wrap { trim: true })
-                .inset(Insets::tlbr(0, 2, 0, 0)),
+                .inset(Insets::tlbr(/*top*/ 0, /*left*/ 2, /*bottom*/ 0, /*right*/ 0)),
         );
         column.push("");
 
@@ -80,7 +80,9 @@ impl WidgetRef for &TrustDirectoryWidget {
                 Paragraph::new(error.to_string())
                     .red()
                     .wrap(Wrap { trim: true })
-                    .inset(Insets::tlbr(0, 2, 0, 0)),
+                    .inset(Insets::tlbr(
+                        /*top*/ 0, /*left*/ 2, /*bottom*/ 0, /*right*/ 0,
+                    )),
             );
             column.push("");
         }
@@ -95,7 +97,9 @@ impl WidgetRef for &TrustDirectoryWidget {
                     " to continue".dim()
                 },
             ])
-            .inset(Insets::tlbr(0, 2, 0, 0)),
+            .inset(Insets::tlbr(
+                /*top*/ 0, /*left*/ 2, /*bottom*/ 0, /*right*/ 0,
+            )),
         );
 
         column.render(area, buf);

--- a/codex-rs/tui_app_server/src/pager_overlay.rs
+++ b/codex-rs/tui_app_server/src/pager_overlay.rs
@@ -457,7 +457,7 @@ impl TranscriptOverlay {
     pub(crate) fn new(transcript_cells: Vec<Arc<dyn HistoryCell>>) -> Self {
         Self {
             view: PagerView::new(
-                Self::render_cells(&transcript_cells, None),
+                Self::render_cells(&transcript_cells, /*highlight_cell*/ None),
                 "T R A N S C R I P T".to_string(),
                 usize::MAX,
             ),
@@ -495,7 +495,9 @@ impl TranscriptOverlay {
                 if !c.is_stream_continuation() && i > 0 {
                     cell_renderable = Box::new(InsetRenderable::new(
                         cell_renderable,
-                        Insets::tlbr(1, 0, 0, 0),
+                        Insets::tlbr(
+                            /*top*/ 1, /*left*/ 0, /*bottom*/ 0, /*right*/ 0,
+                        ),
                     ));
                 }
                 v.push(cell_renderable);
@@ -528,8 +530,12 @@ impl TranscriptOverlay {
             {
                 // The tail was rendered as the only entry, so it lacks a top
                 // inset; add one now that it follows a committed cell.
-                Box::new(InsetRenderable::new(tail, Insets::tlbr(1, 0, 0, 0)))
-                    as Box<dyn Renderable>
+                Box::new(InsetRenderable::new(
+                    tail,
+                    Insets::tlbr(
+                        /*top*/ 1, /*left*/ 0, /*bottom*/ 0, /*right*/ 0,
+                    ),
+                )) as Box<dyn Renderable>
             } else {
                 tail
             };
@@ -649,7 +655,12 @@ impl TranscriptOverlay {
         let paragraph = Paragraph::new(Text::from(lines)).wrap(Wrap { trim: false });
         let mut renderable: Box<dyn Renderable> = Box::new(CachedRenderable::new(paragraph));
         if has_prior_cells && !is_stream_continuation {
-            renderable = Box::new(InsetRenderable::new(renderable, Insets::tlbr(1, 0, 0, 0)));
+            renderable = Box::new(InsetRenderable::new(
+                renderable,
+                Insets::tlbr(
+                    /*top*/ 1, /*left*/ 0, /*bottom*/ 0, /*right*/ 0,
+                ),
+            ));
         }
         renderable
     }
@@ -721,7 +732,7 @@ impl StaticOverlay {
 
     pub(crate) fn with_renderables(renderables: Vec<Box<dyn Renderable>>, title: String) -> Self {
         Self {
-            view: PagerView::new(renderables, title, 0),
+            view: PagerView::new(renderables, title, /*scroll_offset*/ 0),
             is_done: false,
         }
     }

--- a/codex-rs/tui_app_server/src/public_widgets/composer_input.rs
+++ b/codex-rs/tui_app_server/src/public_widgets/composer_input.rs
@@ -37,7 +37,13 @@ impl ComposerInput {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         let sender = AppEventSender::new(tx.clone());
         // `enhanced_keys_supported=true` enables Shift+Enter newline hint/behavior.
-        let inner = ChatComposer::new(true, sender, true, "Compose new task".to_string(), false);
+        let inner = ChatComposer::new(
+            /*has_input_focus*/ true,
+            sender,
+            /*enhanced_keys_supported*/ true,
+            "Compose new task".to_string(),
+            /*disable_paste_burst*/ false,
+        );
         Self { inner, _tx: tx, rx }
     }
 
@@ -80,7 +86,7 @@ impl ComposerInput {
 
     /// Clear any previously set custom hint items and restore the default hints.
     pub fn clear_hint_items(&mut self) {
-        self.inner.set_footer_hint_override(None);
+        self.inner.set_footer_hint_override(/*items*/ None);
     }
 
     /// Desired height (in rows) for a given width.

--- a/codex-rs/tui_app_server/src/resume_picker.rs
+++ b/codex-rs/tui_app_server/src/resume_picker.rs
@@ -325,7 +325,7 @@ fn spawn_rollout_page_loader(
                 INTERACTIVE_SESSION_SOURCES,
                 default_provider.as_ref().map(std::slice::from_ref),
                 default_provider.as_deref().unwrap_or_default(),
-                None,
+                /*search_term*/ None,
             )
             .await
             .map(picker_page_from_rollout_page);
@@ -603,7 +603,11 @@ impl PickerState {
                         Some(thread_id) => Some(thread_id),
                         None => match path.as_ref() {
                             Some(path) => {
-                                crate::resolve_session_thread_id(path.as_path(), None).await
+                                crate::resolve_session_thread_id(
+                                    path.as_path(),
+                                    /*id_str_if_uuid*/ None,
+                                )
+                                .await
                             }
                             None => None,
                         },
@@ -1518,14 +1522,14 @@ fn calculate_column_metrics(rows: &[Row], include_cwd: bool) -> ColumnMetrics {
         let created = format_created_label(row);
         let updated = format_updated_label(row);
         let branch_raw = row.git_branch.clone().unwrap_or_default();
-        let branch = right_elide(&branch_raw, 24);
+        let branch = right_elide(&branch_raw, /*max*/ 24);
         let cwd = if include_cwd {
             let cwd_raw = row
                 .cwd
                 .as_ref()
                 .map(|p| display_path_for(p, std::path::Path::new("/")))
                 .unwrap_or_default();
-            right_elide(&cwd_raw, 24)
+            right_elide(&cwd_raw, /*max*/ 24)
         } else {
             String::new()
         };

--- a/codex-rs/tui_app_server/src/selection_list.rs
+++ b/codex-rs/tui_app_server/src/selection_list.rs
@@ -12,7 +12,7 @@ pub(crate) fn selection_option_row(
     label: String,
     is_selected: bool,
 ) -> Box<dyn Renderable> {
-    selection_option_row_with_dim(index, label, is_selected, false)
+    selection_option_row_with_dim(index, label, is_selected, /*dim*/ false)
 }
 
 pub(crate) fn selection_option_row_with_dim(

--- a/codex-rs/tui_app_server/src/status_indicator_widget.rs
+++ b/codex-rs/tui_app_server/src/status_indicator_widget.rs
@@ -207,7 +207,7 @@ impl StatusIndicatorWidget {
         let opts = RtOptions::new(usize::from(width))
             .initial_indent(Line::from(DETAILS_PREFIX.dim()))
             .subsequent_indent(Line::from(Span::from(" ".repeat(prefix_width)).dim()))
-            .break_words(true);
+            .break_words(/*break_words*/ true);
 
         let mut out = word_wrap_lines(details.lines().map(|line| vec![line.dim()]), opts);
 

--- a/codex-rs/tui_app_server/src/streaming/controller.rs
+++ b/codex-rs/tui_app_server/src/streaming/controller.rs
@@ -167,13 +167,16 @@ impl PlanStreamController {
         }
 
         self.state.clear();
-        self.emit(out_lines, true)
+        self.emit(out_lines, /*include_bottom_padding*/ true)
     }
 
     /// Step animation: commit at most one queued line and handle end-of-drain cleanup.
     pub(crate) fn on_commit_tick(&mut self) -> (Option<Box<dyn HistoryCell>>, bool) {
         let step = self.state.step();
-        (self.emit(step, false), self.state.is_idle())
+        (
+            self.emit(step, /*include_bottom_padding*/ false),
+            self.state.is_idle(),
+        )
     }
 
     /// Step animation: commit at most `max_lines` queued lines.
@@ -185,7 +188,10 @@ impl PlanStreamController {
         max_lines: usize,
     ) -> (Option<Box<dyn HistoryCell>>, bool) {
         let step = self.state.drain_n(max_lines.max(1));
-        (self.emit(step, false), self.state.is_idle())
+        (
+            self.emit(step, /*include_bottom_padding*/ false),
+            self.state.is_idle(),
+        )
     }
 
     /// Returns the current number of queued plan lines waiting to be displayed.

--- a/codex-rs/tui_app_server/src/theme_picker.rs
+++ b/codex-rs/tui_app_server/src/theme_picker.rs
@@ -242,7 +242,13 @@ impl Renderable for ThemePreviewWideRenderable {
     }
 
     fn render(&self, area: Rect, buf: &mut Buffer) {
-        render_preview(area, buf, &WIDE_PREVIEW_ROWS, true, WIDE_PREVIEW_LEFT_INSET);
+        render_preview(
+            area,
+            buf,
+            &WIDE_PREVIEW_ROWS,
+            /*center_vertically*/ true,
+            WIDE_PREVIEW_LEFT_INSET,
+        );
     }
 }
 
@@ -252,7 +258,13 @@ impl Renderable for ThemePreviewNarrowRenderable {
     }
 
     fn render(&self, area: Rect, buf: &mut Buffer) {
-        render_preview(area, buf, &NARROW_PREVIEW_ROWS, false, 0);
+        render_preview(
+            area,
+            buf,
+            &NARROW_PREVIEW_ROWS,
+            /*center_vertically*/ false,
+            /*left_inset*/ 0,
+        );
     }
 }
 
@@ -274,7 +286,7 @@ fn theme_picker_subtitle(codex_home: Option<&Path>, terminal_width: Option<u16>)
     let themes_dir = codex_home.map(|home| home.join("themes"));
     let themes_dir_display = themes_dir
         .as_deref()
-        .map(|path| format_directory_display(path, None));
+        .map(|path| format_directory_display(path, /*max_width*/ None));
     let available_width = subtitle_available_width(terminal_width);
 
     if let Some(path) = themes_dir_display

--- a/codex-rs/tui_app_server/src/wrapping.rs
+++ b/codex-rs/tui_app_server/src/wrapping.rs
@@ -464,7 +464,7 @@ fn is_domain_label(label: &str) -> bool {
 pub(crate) fn url_preserving_wrap_options<'a>(opts: RtOptions<'a>) -> RtOptions<'a> {
     opts.word_separator(textwrap::WordSeparator::AsciiSpace)
         .word_splitter(textwrap::WordSplitter::Custom(split_non_url_word))
-        .break_words(false)
+        .break_words(/*break_words*/ false)
 }
 
 /// Custom `textwrap::WordSplitter` callback. Returns empty (no split

--- a/codex-rs/utils/git/src/branch.rs
+++ b/codex-rs/utils/git/src/branch.rs
@@ -41,7 +41,7 @@ pub fn merge_base_with_head(
             OsString::from(head),
             OsString::from(preferred_ref),
         ],
-        None,
+        /*env*/ None,
     )?;
 
     Ok(Some(merge_base))
@@ -55,7 +55,7 @@ fn resolve_branch_ref(repo_root: &Path, branch: &str) -> Result<Option<String>, 
             OsString::from("--verify"),
             OsString::from(branch),
         ],
-        None,
+        /*env*/ None,
     );
 
     match rev {
@@ -77,7 +77,7 @@ fn resolve_upstream_if_remote_ahead(
             OsString::from("--symbolic-full-name"),
             OsString::from(format!("{branch}@{{upstream}}")),
         ],
-        None,
+        /*env*/ None,
     ) {
         Ok(name) => {
             let trimmed = name.trim();
@@ -98,7 +98,7 @@ fn resolve_upstream_if_remote_ahead(
             OsString::from("--count"),
             OsString::from(format!("{branch}...{upstream}")),
         ],
-        None,
+        /*env*/ None,
     ) {
         Ok(counts) => counts,
         Err(GitToolingError::GitCommand { .. }) => return Ok(None),

--- a/codex-rs/utils/git/src/ghost_commits.rs
+++ b/codex-rs/utils/git/src/ghost_commits.rs
@@ -489,7 +489,7 @@ fn restore_to_commit_inner(
         restore_args.push(OsString::from("."));
     }
 
-    run_git_for_status(repo_root, restore_args, None)?;
+    run_git_for_status(repo_root, restore_args, /*env*/ None)?;
     Ok(())
 }
 
@@ -532,7 +532,7 @@ fn capture_status_snapshot(
         args.push(prefix.as_os_str().to_os_string());
     }
 
-    let output = run_git_for_stdout_all(repo_root, args, None)?;
+    let output = run_git_for_stdout_all(repo_root, args, /*env*/ None)?;
     if output.is_empty() {
         return Ok(StatusSnapshot::default());
     }
@@ -599,20 +599,26 @@ fn capture_status_snapshot(
                 }
             }
             b'1' => {
-                if let Some(path) = extract_status_path_after_fields(entry, 8) {
+                if let Some(path) =
+                    extract_status_path_after_fields(entry, /*fields_before_path*/ 8)
+                {
                     let normalized = normalize_relative_path(Path::new(path))?;
                     snapshot.tracked_paths.push(normalized);
                 }
             }
             b'2' => {
-                if let Some(path) = extract_status_path_after_fields(entry, 9) {
+                if let Some(path) =
+                    extract_status_path_after_fields(entry, /*fields_before_path*/ 9)
+                {
                     let normalized = normalize_relative_path(Path::new(path))?;
                     snapshot.tracked_paths.push(normalized);
                 }
                 expect_rename_source = true;
             }
             b'u' => {
-                if let Some(path) = extract_status_path_after_fields(entry, 10) {
+                if let Some(path) =
+                    extract_status_path_after_fields(entry, /*fields_before_path*/ 10)
+                {
                     let normalized = normalize_relative_path(Path::new(path))?;
                     snapshot.tracked_paths.push(normalized);
                 }

--- a/codex-rs/utils/git/src/operations.rs
+++ b/codex-rs/utils/git/src/operations.rs
@@ -14,7 +14,7 @@ pub(crate) fn ensure_git_repository(path: &Path) -> Result<(), GitToolingError> 
             OsString::from("rev-parse"),
             OsString::from("--is-inside-work-tree"),
         ],
-        None,
+        /*env*/ None,
     ) {
         Ok(output) if output.trim() == "true" => Ok(()),
         Ok(_) => Err(GitToolingError::NotAGitRepository {
@@ -37,7 +37,7 @@ pub(crate) fn resolve_head(path: &Path) -> Result<Option<String>, GitToolingErro
             OsString::from("--verify"),
             OsString::from("HEAD"),
         ],
-        None,
+        /*env*/ None,
     ) {
         Ok(sha) => Ok(Some(sha)),
         Err(GitToolingError::GitCommand { status, .. }) if status.code() == Some(128) => Ok(None),
@@ -84,7 +84,7 @@ pub(crate) fn resolve_repository_root(path: &Path) -> Result<PathBuf, GitTooling
             OsString::from("rev-parse"),
             OsString::from("--show-toplevel"),
         ],
-        None,
+        /*env*/ None,
     )?;
     Ok(PathBuf::from(root))
 }

--- a/codex-rs/utils/pty/src/pipe.rs
+++ b/codex-rs/utils/pty/src/pipe.rs
@@ -238,7 +238,7 @@ async fn spawn_process_with_stdin_mode(
         wait_handle,
         exit_status,
         exit_code,
-        None,
+        /*pty_handles*/ None,
     );
 
     Ok(SpawnedProcess {

--- a/tools/argument-comment-lint/README.md
+++ b/tools/argument-comment-lint/README.md
@@ -92,7 +92,7 @@ rustc incremental compilation ICE locally. To override that behavior for an ad
 hoc run:
 
 ```bash
-DYLINT_RUSTFLAGS="-A uncommented_anonymous_literal_argument" \
+DYLINT_RUSTFLAGS="-A uncommented-anonymous-literal-argument" \
 CARGO_INCREMENTAL=1 \
   ./tools/argument-comment-lint/run.sh -p codex-core
 ```

--- a/tools/argument-comment-lint/run.sh
+++ b/tools/argument-comment-lint/run.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 lint_path="$repo_root/tools/argument-comment-lint"
 manifest_path="$repo_root/codex-rs/Cargo.toml"
-strict_lint="uncommented_anonymous_literal_argument"
+strict_lint="uncommented-anonymous-literal-argument"
 noise_lint="unknown_lints"
 
 has_manifest_path=false


### PR DESCRIPTION
## Why

Once the repo-local lint exists, `codex-rs` needs to follow the checked-in convention and CI needs to keep it from drifting. This commit applies the fallback `/*param*/` style consistently across existing positional literal call sites without changing those APIs.

The longer-term preference is still to avoid APIs that require comments by choosing clearer parameter types and call shapes. This PR is intentionally the mechanical follow-through for the places where the existing signatures stay in place.

After rebasing onto newer `main`, the rollout also had to cover newly introduced `tui_app_server` call sites. That made it clear the first cut of the CI job was too expensive for the common path: it was spending almost as much time installing `cargo-dylint` and re-testing the lint crate as a representative test job spends running product tests. The CI update keeps the full workspace enforcement but trims that extra overhead from ordinary `codex-rs` PRs.

## What changed

- keep a dedicated `argument_comment_lint` job in `rust-ci`
- mechanically annotate remaining opaque positional literals across `codex-rs` with exact `/*param*/` comments, including the rebased `tui_app_server` call sites that now fall under the lint
- keep the checked-in style aligned with the lint policy by using `/*param*/` and leaving string and char literals uncommented
- cache `cargo-dylint`, `dylint-link`, and the relevant Cargo registry/git metadata in the lint job
- split changed-path detection so the lint crate's own `cargo test` step runs only when `tools/argument-comment-lint/*` or `rust-ci.yml` changes
- continue to run the repo wrapper over the `codex-rs` workspace, so product-code enforcement is unchanged

Most of the code changes in this commit are intentionally mechanical comment rewrites or insertions driven by the lint itself.

## Verification

- `./tools/argument-comment-lint/run.sh --workspace`
- `cargo test -p codex-tui-app-server -p codex-tui`
- parsed `.github/workflows/rust-ci.yml` locally with PyYAML

---

* -> #14652
* #14651
