### PR TITLE
Use shared access group for macOS keychain secrets

### DIFF
--- a/.github/actions/macos-code-sign/README.md
+++ b/.github/actions/macos-code-sign/README.md
@@ -1,0 +1,24 @@
+# macos-code-sign
+
+This action can sign the default Rust release binaries or an explicit list of macOS code paths.
+
+By default, alpha and beta tag builds automatically receive the shared keychain entitlement plist.
+Set `shared-keychain-entitlement: false` to opt out, or `true` to force it on for other builds.
+
+To sign a `Codex.app` bundle with the shared keychain entitlement, pass the app path plus the
+checked-in entitlements plist:
+
+```yaml
+- uses: ./.github/actions/macos-code-sign
+  with:
+    target: aarch64-apple-darwin
+    sign-binaries: "true"
+    sign-dmg: "false"
+    sign-paths: |
+      path/to/Codex.app
+    shared-keychain-entitlement: true
+```
+
+If only some signed paths should receive the entitlements plist, set `entitlements-paths` to the
+subset of paths that should be signed with `--entitlements`. You can still provide
+`entitlements-file` directly if a workflow needs a different plist.

--- a/.github/actions/macos-code-sign/README.md
+++ b/.github/actions/macos-code-sign/README.md
@@ -1,24 +1,4 @@
 # macos-code-sign
 
-This action can sign the default Rust release binaries or an explicit list of macOS code paths.
-
-By default, alpha and beta tag builds automatically receive the shared keychain entitlement plist.
-Set `shared-keychain-entitlement: false` to opt out, or `true` to force it on for other builds.
-
-To sign a `Codex.app` bundle with the shared keychain entitlement, pass the app path plus the
-checked-in entitlements plist:
-
-```yaml
-- uses: ./.github/actions/macos-code-sign
-  with:
-    target: aarch64-apple-darwin
-    sign-binaries: "true"
-    sign-dmg: "false"
-    sign-paths: |
-      path/to/Codex.app
-    shared-keychain-entitlement: true
-```
-
-If only some signed paths should receive the entitlements plist, set `entitlements-paths` to the
-subset of paths that should be signed with `--entitlements`. You can still provide
-`entitlements-file` directly if a workflow needs a different plist.
+This action signs the default Rust macOS release binaries and applies the shared keychain
+entitlement plist to those binaries during codesign.

--- a/.github/actions/macos-code-sign/action.yml
+++ b/.github/actions/macos-code-sign/action.yml
@@ -12,6 +12,22 @@ inputs:
     description: Whether to sign and notarize the macOS dmg.
     required: false
     default: "true"
+  sign-paths:
+    description: Optional newline-separated list of paths to sign when signing macOS binaries. Defaults to the release codex binaries.
+    required: false
+    default: ""
+  entitlements-file:
+    description: Optional path to an entitlements plist to apply while signing selected macOS code paths.
+    required: false
+    default: ""
+  entitlements-paths:
+    description: Optional newline-separated list of signed paths that should receive entitlements. Defaults to all sign-paths when entitlements-file is set.
+    required: false
+    default: ""
+  shared-keychain-entitlement:
+    description: Whether to apply the shared keychain entitlement plist. `auto` enables it for alpha and beta tag builds.
+    required: false
+    default: "auto"
   apple-certificate:
     description: Base64-encoded Apple signing certificate (P12).
     required: true
@@ -117,8 +133,6 @@ runs:
     - name: Sign macOS binaries
       if: ${{ inputs.sign-binaries == 'true' }}
       shell: bash
-      env:
-        TARGET: ${{ inputs.target }}
       run: |
         set -euo pipefail
 
@@ -132,16 +146,92 @@ runs:
           keychain_args+=(--keychain "${APPLE_CODESIGN_KEYCHAIN}")
         fi
 
-        for binary in codex codex-responses-api-proxy; do
-          path="codex-rs/target/${TARGET}/release/${binary}"
-          codesign --force --options runtime --timestamp --sign "$APPLE_CODESIGN_IDENTITY" "${keychain_args[@]}" "$path"
+        normalize_sign_path() {
+          local path="$1"
+          if [[ "$path" != /* ]]; then
+            path="${GITHUB_WORKSPACE}/${path}"
+          fi
+          printf '%s\n' "$path"
+        }
+
+        sign_paths=()
+        while IFS= read -r path; do
+          [[ -n "$path" ]] && sign_paths+=("$(normalize_sign_path "$path")")
+        done < <(printf '%s\n' '${{ inputs.sign-paths }}')
+
+        if ((${#sign_paths[@]} == 0)); then
+          for binary in codex codex-responses-api-proxy; do
+            sign_paths+=("$(normalize_sign_path "codex-rs/target/${{ inputs.target }}/release/${binary}")")
+          done
+        fi
+
+        entitlements_file="${{ inputs.entitlements-file }}"
+        shared_keychain_entitlement="${{ inputs.shared-keychain-entitlement }}"
+        if [[ -z "$entitlements_file" ]]; then
+          case "$shared_keychain_entitlement" in
+            true)
+              entitlements_file=".github/macos/codex-shared-keychain.entitlements"
+              ;;
+            auto)
+              if [[ "${GITHUB_REF_TYPE:-}" == "tag" ]] && [[ "${GITHUB_REF_NAME:-}" =~ -(alpha|beta)(\.[0-9]+)?$ ]]; then
+                entitlements_file=".github/macos/codex-shared-keychain.entitlements"
+              fi
+              ;;
+            false)
+              ;;
+            *)
+              echo "shared-keychain-entitlement must be one of: auto, true, false"
+              exit 1
+              ;;
+          esac
+        fi
+
+        if [[ -n "$entitlements_file" ]]; then
+          entitlements_file="$(normalize_sign_path "$entitlements_file")"
+          if [[ ! -f "$entitlements_file" ]]; then
+            echo "Entitlements file $entitlements_file not found"
+            exit 1
+          fi
+        fi
+
+        entitlements_paths=()
+        while IFS= read -r path; do
+          [[ -n "$path" ]] && entitlements_paths+=("$(normalize_sign_path "$path")")
+        done < <(printf '%s\n' '${{ inputs.entitlements-paths }}')
+
+        for path in "${sign_paths[@]}"; do
+          if [[ ! -e "$path" ]]; then
+            echo "Sign path $path not found"
+            exit 1
+          fi
+
+          codesign_args=(--force --options runtime --timestamp --sign "$APPLE_CODESIGN_IDENTITY")
+          codesign_args+=("${keychain_args[@]}")
+
+          if [[ -n "$entitlements_file" ]]; then
+            apply_entitlements=true
+            if ((${#entitlements_paths[@]} > 0)); then
+              apply_entitlements=false
+              for entitlements_path in "${entitlements_paths[@]}"; do
+                if [[ "$path" == "$entitlements_path" ]]; then
+                  apply_entitlements=true
+                  break
+                fi
+              done
+            fi
+
+            if [[ "$apply_entitlements" == "true" ]]; then
+              codesign_args+=(--entitlements "$entitlements_file")
+            fi
+          fi
+
+          codesign "${codesign_args[@]}" "$path"
         done
 
     - name: Notarize macOS binaries
       if: ${{ inputs.sign-binaries == 'true' }}
       shell: bash
       env:
-        TARGET: ${{ inputs.target }}
         APPLE_NOTARIZATION_KEY_P8: ${{ inputs.apple-notarization-key-p8 }}
         APPLE_NOTARIZATION_KEY_ID: ${{ inputs.apple-notarization-key-id }}
         APPLE_NOTARIZATION_ISSUER_ID: ${{ inputs.apple-notarization-issuer-id }}
@@ -166,7 +256,7 @@ runs:
 
         notarize_binary() {
           local binary="$1"
-          local source_path="codex-rs/target/${TARGET}/release/${binary}"
+          local source_path="codex-rs/target/${{ inputs.target }}/release/${binary}"
           local archive_path="${RUNNER_TEMP}/${binary}.zip"
 
           if [[ ! -f "$source_path" ]]; then
@@ -187,7 +277,6 @@ runs:
       if: ${{ inputs.sign-dmg == 'true' }}
       shell: bash
       env:
-        TARGET: ${{ inputs.target }}
         APPLE_NOTARIZATION_KEY_P8: ${{ inputs.apple-notarization-key-p8 }}
         APPLE_NOTARIZATION_KEY_ID: ${{ inputs.apple-notarization-key-id }}
         APPLE_NOTARIZATION_ISSUER_ID: ${{ inputs.apple-notarization-issuer-id }}
@@ -210,8 +299,7 @@ runs:
 
         source "$GITHUB_ACTION_PATH/notary_helpers.sh"
 
-        dmg_name="codex-${TARGET}.dmg"
-        dmg_path="codex-rs/target/${TARGET}/release/${dmg_name}"
+        dmg_path="codex-rs/target/${{ inputs.target }}/release/codex-${{ inputs.target }}.dmg"
 
         if [[ ! -f "$dmg_path" ]]; then
           echo "dmg $dmg_path not found"
@@ -224,7 +312,7 @@ runs:
         fi
 
         codesign --force --timestamp --sign "$APPLE_CODESIGN_IDENTITY" "${keychain_args[@]}" "$dmg_path"
-        notarize_submission "$dmg_name" "$dmg_path" "$notary_key_path"
+        notarize_submission "codex-${{ inputs.target }}.dmg" "$dmg_path" "$notary_key_path"
         xcrun stapler staple "$dmg_path"
 
     - name: Remove signing keychain

--- a/.github/actions/macos-code-sign/action.yml
+++ b/.github/actions/macos-code-sign/action.yml
@@ -12,22 +12,6 @@ inputs:
     description: Whether to sign and notarize the macOS dmg.
     required: false
     default: "true"
-  sign-paths:
-    description: Optional newline-separated list of paths to sign when signing macOS binaries. Defaults to the release codex binaries.
-    required: false
-    default: ""
-  entitlements-file:
-    description: Optional path to an entitlements plist to apply while signing selected macOS code paths.
-    required: false
-    default: ""
-  entitlements-paths:
-    description: Optional newline-separated list of signed paths that should receive entitlements. Defaults to all sign-paths when entitlements-file is set.
-    required: false
-    default: ""
-  shared-keychain-entitlement:
-    description: Whether to apply the shared keychain entitlement plist. `auto` enables it for alpha and beta tag builds.
-    required: false
-    default: "auto"
   apple-certificate:
     description: Base64-encoded Apple signing certificate (P12).
     required: true
@@ -146,84 +130,27 @@ runs:
           keychain_args+=(--keychain "${APPLE_CODESIGN_KEYCHAIN}")
         fi
 
-        normalize_sign_path() {
-          local path="$1"
-          if [[ "$path" != /* ]]; then
-            path="${GITHUB_WORKSPACE}/${path}"
-          fi
-          printf '%s\n' "$path"
-        }
-
-        sign_paths=()
-        while IFS= read -r path; do
-          [[ -n "$path" ]] && sign_paths+=("$(normalize_sign_path "$path")")
-        done < <(printf '%s\n' '${{ inputs.sign-paths }}')
-
-        if ((${#sign_paths[@]} == 0)); then
-          for binary in codex codex-responses-api-proxy; do
-            sign_paths+=("$(normalize_sign_path "codex-rs/target/${{ inputs.target }}/release/${binary}")")
-          done
+        entitlements_file="${GITHUB_WORKSPACE}/.github/macos/codex-shared-keychain.entitlements"
+        if [[ ! -f "$entitlements_file" ]]; then
+          echo "Entitlements file $entitlements_file not found"
+          exit 1
         fi
 
-        entitlements_file="${{ inputs.entitlements-file }}"
-        shared_keychain_entitlement="${{ inputs.shared-keychain-entitlement }}"
-        if [[ -z "$entitlements_file" ]]; then
-          case "$shared_keychain_entitlement" in
-            true)
-              entitlements_file=".github/macos/codex-shared-keychain.entitlements"
-              ;;
-            auto)
-              if [[ "${GITHUB_REF_TYPE:-}" == "tag" ]] && [[ "${GITHUB_REF_NAME:-}" =~ -(alpha|beta)(\.[0-9]+)?$ ]]; then
-                entitlements_file=".github/macos/codex-shared-keychain.entitlements"
-              fi
-              ;;
-            false)
-              ;;
-            *)
-              echo "shared-keychain-entitlement must be one of: auto, true, false"
-              exit 1
-              ;;
-          esac
-        fi
-
-        if [[ -n "$entitlements_file" ]]; then
-          entitlements_file="$(normalize_sign_path "$entitlements_file")"
-          if [[ ! -f "$entitlements_file" ]]; then
-            echo "Entitlements file $entitlements_file not found"
-            exit 1
-          fi
-        fi
-
-        entitlements_paths=()
-        while IFS= read -r path; do
-          [[ -n "$path" ]] && entitlements_paths+=("$(normalize_sign_path "$path")")
-        done < <(printf '%s\n' '${{ inputs.entitlements-paths }}')
-
-        for path in "${sign_paths[@]}"; do
+        for binary in codex codex-responses-api-proxy; do
+          path="codex-rs/target/${{ inputs.target }}/release/${binary}"
           if [[ ! -e "$path" ]]; then
             echo "Sign path $path not found"
             exit 1
           fi
 
-          codesign_args=(--force --options runtime --timestamp --sign "$APPLE_CODESIGN_IDENTITY")
+          codesign_args=(
+            --force
+            --options runtime
+            --timestamp
+            --sign "$APPLE_CODESIGN_IDENTITY"
+            --entitlements "$entitlements_file"
+          )
           codesign_args+=("${keychain_args[@]}")
-
-          if [[ -n "$entitlements_file" ]]; then
-            apply_entitlements=true
-            if ((${#entitlements_paths[@]} > 0)); then
-              apply_entitlements=false
-              for entitlements_path in "${entitlements_paths[@]}"; do
-                if [[ "$path" == "$entitlements_path" ]]; then
-                  apply_entitlements=true
-                  break
-                fi
-              done
-            fi
-
-            if [[ "$apply_entitlements" == "true" ]]; then
-              codesign_args+=(--entitlements "$entitlements_file")
-            fi
-          fi
 
           codesign "${codesign_args[@]}" "$path"
         done

--- a/.github/macos/codex-shared-keychain.entitlements
+++ b/.github/macos/codex-shared-keychain.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>keychain-access-groups</key>
+  <array>
+    <string>2DC432GLL2.com.openai.shared</string>
+  </array>
+</dict>
+</plist>

--- a/.github/macos/codex-shared-keychain.entitlements
+++ b/.github/macos/codex-shared-keychain.entitlements
@@ -4,7 +4,7 @@
 <dict>
   <key>keychain-access-groups</key>
   <array>
-    <string>2DC432GLL2.com.openai.shared</string>
+    <string>2DC432GLL2.com.openai.codex.shared</string>
   </array>
 </dict>
 </plist>

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1655,6 +1655,7 @@ dependencies = [
  "codex-core",
  "codex-exec",
  "codex-execpolicy",
+ "codex-keyring-store",
  "codex-login",
  "codex-mcp-server",
  "codex-protocol",
@@ -2101,7 +2102,10 @@ dependencies = [
 name = "codex-keyring-store"
 version = "0.0.0"
 dependencies = [
+ "core-foundation 0.10.1",
  "keyring",
+ "security-framework 3.5.1",
+ "security-framework-sys",
  "tracing",
 ]
 

--- a/codex-rs/cli/Cargo.toml
+++ b/codex-rs/cli/Cargo.toml
@@ -30,6 +30,7 @@ codex-config = { workspace = true }
 codex-core = { workspace = true }
 codex-exec = { workspace = true }
 codex-execpolicy = { workspace = true }
+codex-keyring-store = { workspace = true }
 codex-login = { workspace = true }
 codex-mcp-server = { workspace = true }
 codex-protocol = { workspace = true }

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -21,6 +21,7 @@ use codex_exec::Cli as ExecCli;
 use codex_exec::Command as ExecCommand;
 use codex_exec::ReviewArgs;
 use codex_execpolicy::ExecPolicyCheckCommand;
+use codex_keyring_store::migrate_existing_codex_items_to_access_group;
 use codex_responses_api_proxy::Args as ResponsesApiProxyArgs;
 use codex_state::StateRuntime;
 use codex_state::state_db_path;
@@ -600,6 +601,14 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
     let toggle_overrides = feature_toggles.to_overrides()?;
     root_config_overrides.raw_overrides.extend(toggle_overrides);
     let root_remote = remote.remote;
+
+    #[cfg(target_os = "macos")]
+    if let Err(error) = migrate_existing_codex_items_to_access_group() {
+        tracing::warn!(
+            error = %error,
+            "failed to migrate existing Codex keychain items into the shared macOS access group"
+        );
+    }
 
     match subcommand {
         None => {

--- a/codex-rs/keyring-store/Cargo.toml
+++ b/codex-rs/keyring-store/Cargo.toml
@@ -15,7 +15,10 @@ tracing = { workspace = true }
 keyring = { workspace = true, features = ["linux-native-async-persistent"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
+core-foundation = "0.10"
 keyring = { workspace = true, features = ["apple-native"] }
+security-framework = { version = "3", features = ["OSX_10_15"] }
+security-framework-sys = "2.15"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 keyring = { workspace = true, features = ["windows-native"] }

--- a/codex-rs/keyring-store/src/lib.rs
+++ b/codex-rs/keyring-store/src/lib.rs
@@ -47,6 +47,89 @@ impl fmt::Display for CredentialStoreError {
 
 impl Error for CredentialStoreError {}
 
+#[cfg(target_os = "macos")]
+fn load_password(service: &str, account: &str) -> Result<Option<String>, CredentialStoreError> {
+    macos::load_password(service, account).map_err(|error| {
+        trace!(
+            "keyring.load macos native error, service={service}, account={account}, error={error}"
+        );
+        CredentialStoreError::new(KeyringError::PlatformFailure(Box::new(error)))
+    })
+}
+
+#[cfg(not(target_os = "macos"))]
+fn load_password(service: &str, account: &str) -> Result<Option<String>, CredentialStoreError> {
+    let entry = Entry::new(service, account).map_err(CredentialStoreError::new)?;
+    match entry.get_password() {
+        Ok(password) => {
+            trace!("keyring.load success, service={service}, account={account}");
+            Ok(Some(password))
+        }
+        Err(keyring::Error::NoEntry) => {
+            trace!("keyring.load no entry, service={service}, account={account}");
+            Ok(None)
+        }
+        Err(error) => {
+            trace!("keyring.load error, service={service}, account={account}, error={error}");
+            Err(CredentialStoreError::new(error))
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn save_password(service: &str, account: &str, value: &str) -> Result<(), CredentialStoreError> {
+    macos::save_password(service, account, value).map_err(|error| {
+        trace!(
+            "keyring.save macos native error, service={service}, account={account}, error={error}"
+        );
+        CredentialStoreError::new(KeyringError::PlatformFailure(Box::new(error)))
+    })
+}
+
+#[cfg(not(target_os = "macos"))]
+fn save_password(service: &str, account: &str, value: &str) -> Result<(), CredentialStoreError> {
+    let entry = Entry::new(service, account).map_err(CredentialStoreError::new)?;
+    match entry.set_password(value) {
+        Ok(()) => {
+            trace!("keyring.save success, service={service}, account={account}");
+            Ok(())
+        }
+        Err(error) => {
+            trace!("keyring.save error, service={service}, account={account}, error={error}");
+            Err(CredentialStoreError::new(error))
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn delete_password(service: &str, account: &str) -> Result<bool, CredentialStoreError> {
+    macos::delete_password(service, account).map_err(|error| {
+        trace!(
+            "keyring.delete macos native error, service={service}, account={account}, error={error}"
+        );
+        CredentialStoreError::new(KeyringError::PlatformFailure(Box::new(error)))
+    })
+}
+
+#[cfg(not(target_os = "macos"))]
+fn delete_password(service: &str, account: &str) -> Result<bool, CredentialStoreError> {
+    let entry = Entry::new(service, account).map_err(CredentialStoreError::new)?;
+    match entry.delete_credential() {
+        Ok(()) => {
+            trace!("keyring.delete success, service={service}, account={account}");
+            Ok(true)
+        }
+        Err(keyring::Error::NoEntry) => {
+            trace!("keyring.delete no entry, service={service}, account={account}");
+            Ok(false)
+        }
+        Err(error) => {
+            trace!("keyring.delete error, service={service}, account={account}, error={error}");
+            Err(CredentialStoreError::new(error))
+        }
+    }
+}
+
 /// Shared credential store abstraction for keyring-backed implementations.
 pub trait KeyringStore: Debug + Send + Sync {
     fn load(&self, service: &str, account: &str) -> Result<Option<String>, CredentialStoreError>;
@@ -60,33 +143,7 @@ pub struct DefaultKeyringStore;
 impl KeyringStore for DefaultKeyringStore {
     fn load(&self, service: &str, account: &str) -> Result<Option<String>, CredentialStoreError> {
         trace!("keyring.load start, service={service}, account={account}");
-        #[cfg(target_os = "macos")]
-        {
-            macos::load_password(service, account).map_err(|error| {
-                trace!(
-                    "keyring.load macos native error, service={service}, account={account}, error={error}"
-                );
-                CredentialStoreError::new(KeyringError::PlatformFailure(Box::new(error)))
-            })
-        }
-
-        #[cfg(not(target_os = "macos"))]
-        let entry = Entry::new(service, account).map_err(CredentialStoreError::new)?;
-        #[cfg(not(target_os = "macos"))]
-        match entry.get_password() {
-            Ok(password) => {
-                trace!("keyring.load success, service={service}, account={account}");
-                Ok(Some(password))
-            }
-            Err(keyring::Error::NoEntry) => {
-                trace!("keyring.load no entry, service={service}, account={account}");
-                Ok(None)
-            }
-            Err(error) => {
-                trace!("keyring.load error, service={service}, account={account}, error={error}");
-                Err(CredentialStoreError::new(error))
-            }
-        }
+        load_password(service, account)
     }
 
     fn save(&self, service: &str, account: &str, value: &str) -> Result<(), CredentialStoreError> {
@@ -94,60 +151,12 @@ impl KeyringStore for DefaultKeyringStore {
             "keyring.save start, service={service}, account={account}, value_len={}",
             value.len()
         );
-        #[cfg(target_os = "macos")]
-        {
-            macos::save_password(service, account, value).map_err(|error| {
-                trace!(
-                    "keyring.save macos native error, service={service}, account={account}, error={error}"
-                );
-                CredentialStoreError::new(KeyringError::PlatformFailure(Box::new(error)))
-            })
-        }
-
-        #[cfg(not(target_os = "macos"))]
-        let entry = Entry::new(service, account).map_err(CredentialStoreError::new)?;
-        #[cfg(not(target_os = "macos"))]
-        match entry.set_password(value) {
-            Ok(()) => {
-                trace!("keyring.save success, service={service}, account={account}");
-                Ok(())
-            }
-            Err(error) => {
-                trace!("keyring.save error, service={service}, account={account}, error={error}");
-                Err(CredentialStoreError::new(error))
-            }
-        }
+        save_password(service, account, value)
     }
 
     fn delete(&self, service: &str, account: &str) -> Result<bool, CredentialStoreError> {
         trace!("keyring.delete start, service={service}, account={account}");
-        #[cfg(target_os = "macos")]
-        {
-            macos::delete_password(service, account).map_err(|error| {
-                trace!(
-                    "keyring.delete macos native error, service={service}, account={account}, error={error}"
-                );
-                CredentialStoreError::new(KeyringError::PlatformFailure(Box::new(error)))
-            })
-        }
-
-        #[cfg(not(target_os = "macos"))]
-        let entry = Entry::new(service, account).map_err(CredentialStoreError::new)?;
-        #[cfg(not(target_os = "macos"))]
-        match entry.delete_credential() {
-            Ok(()) => {
-                trace!("keyring.delete success, service={service}, account={account}");
-                Ok(true)
-            }
-            Err(keyring::Error::NoEntry) => {
-                trace!("keyring.delete no entry, service={service}, account={account}");
-                Ok(false)
-            }
-            Err(error) => {
-                trace!("keyring.delete error, service={service}, account={account}, error={error}");
-                Err(CredentialStoreError::new(error))
-            }
-        }
+        delete_password(service, account)
     }
 }
 

--- a/codex-rs/keyring-store/src/lib.rs
+++ b/codex-rs/keyring-store/src/lib.rs
@@ -1,9 +1,25 @@
-use keyring::Entry;
 use keyring::Error as KeyringError;
 use std::error::Error;
 use std::fmt;
 use std::fmt::Debug;
 use tracing::trace;
+
+#[cfg(target_os = "macos")]
+mod macos;
+
+#[cfg(not(target_os = "macos"))]
+use keyring::Entry;
+
+#[cfg(not(target_os = "macos"))]
+pub fn migrate_existing_codex_items_to_access_group() -> Result<(), CredentialStoreError> {
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+pub fn migrate_existing_codex_items_to_access_group() -> Result<(), CredentialStoreError> {
+    macos::migrate_existing_codex_items_to_access_group()
+        .map_err(|error| CredentialStoreError::new(KeyringError::PlatformFailure(Box::new(error))))
+}
 
 #[derive(Debug)]
 pub enum CredentialStoreError {
@@ -51,7 +67,19 @@ pub struct DefaultKeyringStore;
 impl KeyringStore for DefaultKeyringStore {
     fn load(&self, service: &str, account: &str) -> Result<Option<String>, CredentialStoreError> {
         trace!("keyring.load start, service={service}, account={account}");
+        #[cfg(target_os = "macos")]
+        {
+            macos::load_password(service, account).map_err(|error| {
+                trace!(
+                    "keyring.load macos native error, service={service}, account={account}, error={error}"
+                );
+                CredentialStoreError::new(KeyringError::PlatformFailure(Box::new(error)))
+            })
+        }
+
+        #[cfg(not(target_os = "macos"))]
         let entry = Entry::new(service, account).map_err(CredentialStoreError::new)?;
+        #[cfg(not(target_os = "macos"))]
         match entry.get_password() {
             Ok(password) => {
                 trace!("keyring.load success, service={service}, account={account}");
@@ -73,7 +101,19 @@ impl KeyringStore for DefaultKeyringStore {
             "keyring.save start, service={service}, account={account}, value_len={}",
             value.len()
         );
+        #[cfg(target_os = "macos")]
+        {
+            macos::save_password(service, account, value).map_err(|error| {
+                trace!(
+                    "keyring.save macos native error, service={service}, account={account}, error={error}"
+                );
+                CredentialStoreError::new(KeyringError::PlatformFailure(Box::new(error)))
+            })
+        }
+
+        #[cfg(not(target_os = "macos"))]
         let entry = Entry::new(service, account).map_err(CredentialStoreError::new)?;
+        #[cfg(not(target_os = "macos"))]
         match entry.set_password(value) {
             Ok(()) => {
                 trace!("keyring.save success, service={service}, account={account}");
@@ -88,7 +128,19 @@ impl KeyringStore for DefaultKeyringStore {
 
     fn delete(&self, service: &str, account: &str) -> Result<bool, CredentialStoreError> {
         trace!("keyring.delete start, service={service}, account={account}");
+        #[cfg(target_os = "macos")]
+        {
+            macos::delete_password(service, account).map_err(|error| {
+                trace!(
+                    "keyring.delete macos native error, service={service}, account={account}, error={error}"
+                );
+                CredentialStoreError::new(KeyringError::PlatformFailure(Box::new(error)))
+            })
+        }
+
+        #[cfg(not(target_os = "macos"))]
         let entry = Entry::new(service, account).map_err(CredentialStoreError::new)?;
+        #[cfg(not(target_os = "macos"))]
         match entry.delete_credential() {
             Ok(()) => {
                 trace!("keyring.delete success, service={service}, account={account}");

--- a/codex-rs/keyring-store/src/lib.rs
+++ b/codex-rs/keyring-store/src/lib.rs
@@ -10,15 +10,8 @@ mod macos;
 #[cfg(not(target_os = "macos"))]
 use keyring::Entry;
 
-#[cfg(not(target_os = "macos"))]
 pub fn migrate_existing_codex_items_to_access_group() -> Result<(), CredentialStoreError> {
     Ok(())
-}
-
-#[cfg(target_os = "macos")]
-pub fn migrate_existing_codex_items_to_access_group() -> Result<(), CredentialStoreError> {
-    macos::migrate_existing_codex_items_to_access_group()
-        .map_err(|error| CredentialStoreError::new(KeyringError::PlatformFailure(Box::new(error))))
 }
 
 #[derive(Debug)]

--- a/codex-rs/keyring-store/src/macos.rs
+++ b/codex-rs/keyring-store/src/macos.rs
@@ -42,7 +42,7 @@ impl fmt::Display for MacOsAccessGroupError {
 
 impl std::error::Error for MacOsAccessGroupError {}
 
-const SHARED_ACCESS_GROUP: &str = "2DC432GLL2.com.openai.shared";
+const SHARED_ACCESS_GROUP: &str = "2DC432GLL2.com.openai.codex.shared";
 const CODEX_KEYCHAIN_SERVICES: [&str; 3] = ["Codex Auth", "Codex MCP Credentials", "codex"];
 
 pub(crate) fn load_password(
@@ -266,6 +266,6 @@ mod tests {
 
     #[test]
     fn shared_access_group_matches_configured_team_prefix() {
-        assert_eq!(SHARED_ACCESS_GROUP, "2DC432GLL2.com.openai.shared");
+        assert_eq!(SHARED_ACCESS_GROUP, "2DC432GLL2.com.openai.codex.shared");
     }
 }

--- a/codex-rs/keyring-store/src/macos.rs
+++ b/codex-rs/keyring-store/src/macos.rs
@@ -1,0 +1,271 @@
+use core_foundation::base::TCFType;
+use core_foundation::dictionary::CFDictionary;
+use core_foundation::string::CFString;
+use security_framework::base::Error as SecurityError;
+use security_framework::item::ItemClass;
+use security_framework::item::ItemSearchOptions;
+use security_framework::item::ItemUpdateOptions;
+use security_framework::item::Limit;
+use security_framework::item::Location;
+use security_framework::item::SearchResult;
+use security_framework::item::update_item;
+use security_framework::passwords::PasswordOptions;
+use security_framework::passwords::delete_generic_password_options;
+use security_framework::passwords::generic_password;
+use security_framework::passwords::set_generic_password_options;
+use security_framework_sys::base::errSecItemNotFound;
+use security_framework_sys::item::kSecAttrAccount;
+use std::fmt;
+
+#[derive(Debug)]
+pub(crate) struct MacOsAccessGroupError {
+    details: String,
+}
+
+impl MacOsAccessGroupError {
+    fn new(details: impl Into<String>) -> Self {
+        Self {
+            details: details.into(),
+        }
+    }
+}
+
+impl fmt::Display for MacOsAccessGroupError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "failed to access macOS keychain item in shared access group: {}",
+            self.details
+        )
+    }
+}
+
+impl std::error::Error for MacOsAccessGroupError {}
+
+const SHARED_ACCESS_GROUP: &str = "2DC432GLL2.com.openai.shared";
+const CODEX_KEYCHAIN_SERVICES: [&str; 3] = ["Codex Auth", "Codex MCP Credentials", "codex"];
+
+pub(crate) fn load_password(
+    service: &str,
+    account: &str,
+) -> Result<Option<String>, MacOsAccessGroupError> {
+    if let Some(password) = load_shared_password_bytes(service, account)? {
+        return decode_password(password, service, account).map(Some);
+    }
+
+    if migrate_password_to_access_group(service, account)?
+        && let Some(password) = load_shared_password_bytes(service, account)?
+    {
+        return decode_password(password, service, account).map(Some);
+    }
+
+    load_legacy_password_bytes(service, account)?
+        .map(|password| decode_password(password, service, account))
+        .transpose()
+}
+
+pub(crate) fn save_password(
+    service: &str,
+    account: &str,
+    value: &str,
+) -> Result<(), MacOsAccessGroupError> {
+    if load_shared_password_bytes(service, account)?.is_none() {
+        let _ = migrate_password_to_access_group(service, account)?;
+    }
+
+    save_shared_password_bytes(service, account, value.as_bytes())
+}
+
+pub(crate) fn delete_password(service: &str, account: &str) -> Result<bool, MacOsAccessGroupError> {
+    let shared_removed = delete_shared_password(service, account)?;
+    let legacy_removed = delete_legacy_password(service, account)?;
+    Ok(shared_removed || legacy_removed)
+}
+
+pub(crate) fn migrate_existing_codex_items_to_access_group() -> Result<(), MacOsAccessGroupError> {
+    for service in CODEX_KEYCHAIN_SERVICES {
+        for account in legacy_accounts_for_service(service)? {
+            let _ = migrate_password_to_access_group(service, &account)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn migrate_password_to_access_group(
+    service: &str,
+    account: &str,
+) -> Result<bool, MacOsAccessGroupError> {
+    let mut search = ItemSearchOptions::new();
+    search
+        .class(ItemClass::generic_password())
+        .service(service)
+        .account(account);
+
+    let mut update = ItemUpdateOptions::new();
+    update
+        .set_access_group(SHARED_ACCESS_GROUP)
+        .set_location(Location::DataProtectionKeychain);
+
+    match update_item(&search, &update) {
+        Ok(()) => Ok(true),
+        Err(error) if error.code() == errSecItemNotFound => Ok(false),
+        Err(error) => Err(wrap_security_error(
+            "move existing generic password into the shared access group",
+            error,
+        )),
+    }
+}
+
+fn legacy_accounts_for_service(service: &str) -> Result<Vec<String>, MacOsAccessGroupError> {
+    let mut search = ItemSearchOptions::new();
+    search
+        .class(ItemClass::generic_password())
+        .service(service)
+        .load_attributes(true)
+        .limit(Limit::All);
+
+    let results = match search.search() {
+        Ok(results) => results,
+        Err(error) if error.code() == errSecItemNotFound => return Ok(Vec::new()),
+        Err(error) => {
+            return Err(wrap_security_error(
+                "search existing generic passwords for Codex service",
+                error,
+            ));
+        }
+    };
+
+    let mut accounts = Vec::with_capacity(results.len());
+    for result in results {
+        match result {
+            SearchResult::Dict(attributes) => accounts.push(account_from_attributes(&attributes)?),
+            SearchResult::Ref(_) | SearchResult::Data(_) | SearchResult::Other => {
+                return Err(MacOsAccessGroupError::new(
+                    "search existing generic passwords for Codex service returned an unexpected result",
+                ));
+            }
+        }
+    }
+
+    Ok(accounts)
+}
+
+fn account_from_attributes(attributes: &CFDictionary) -> Result<String, MacOsAccessGroupError> {
+    let Some(account_value) = attributes.find(unsafe { kSecAttrAccount }.cast()) else {
+        return Err(MacOsAccessGroupError::new(
+            "generic password attributes did not include an account name",
+        ));
+    };
+    Ok(unsafe { CFString::wrap_under_get_rule((*account_value).cast()) }.to_string())
+}
+
+fn decode_password(
+    password: Vec<u8>,
+    service: &str,
+    account: &str,
+) -> Result<String, MacOsAccessGroupError> {
+    String::from_utf8(password).map_err(|error| {
+        MacOsAccessGroupError::new(format!(
+            "decode password for service={service}, account={account}: {error}"
+        ))
+    })
+}
+
+fn load_shared_password_bytes(
+    service: &str,
+    account: &str,
+) -> Result<Option<Vec<u8>>, MacOsAccessGroupError> {
+    load_password_bytes(
+        shared_password_options(service, account),
+        "read shared generic password",
+    )
+}
+
+fn load_legacy_password_bytes(
+    service: &str,
+    account: &str,
+) -> Result<Option<Vec<u8>>, MacOsAccessGroupError> {
+    load_password_bytes(
+        legacy_password_options(service, account),
+        "read legacy generic password",
+    )
+}
+
+fn load_password_bytes(
+    options: PasswordOptions,
+    action: &str,
+) -> Result<Option<Vec<u8>>, MacOsAccessGroupError> {
+    match generic_password(options) {
+        Ok(password) => Ok(Some(password)),
+        Err(error) if error.code() == errSecItemNotFound => Ok(None),
+        Err(error) => Err(wrap_security_error(action, error)),
+    }
+}
+
+fn save_shared_password_bytes(
+    service: &str,
+    account: &str,
+    value: &[u8],
+) -> Result<(), MacOsAccessGroupError> {
+    set_generic_password_options(value, shared_password_options(service, account))
+        .map_err(|error| wrap_security_error("write shared generic password", error))
+}
+
+fn delete_shared_password(service: &str, account: &str) -> Result<bool, MacOsAccessGroupError> {
+    delete_password_options(
+        shared_password_options(service, account),
+        "delete shared generic password",
+    )
+}
+
+fn delete_legacy_password(service: &str, account: &str) -> Result<bool, MacOsAccessGroupError> {
+    delete_password_options(
+        legacy_password_options(service, account),
+        "delete legacy generic password",
+    )
+}
+
+fn delete_password_options(
+    options: PasswordOptions,
+    action: &str,
+) -> Result<bool, MacOsAccessGroupError> {
+    match delete_generic_password_options(options) {
+        Ok(()) => Ok(true),
+        Err(error) if error.code() == errSecItemNotFound => Ok(false),
+        Err(error) => Err(wrap_security_error(action, error)),
+    }
+}
+
+fn shared_password_options(service: &str, account: &str) -> PasswordOptions {
+    let mut options = PasswordOptions::new_generic_password(service, account);
+    options.use_protected_keychain();
+    options.set_access_group(SHARED_ACCESS_GROUP);
+    options
+}
+
+fn legacy_password_options(service: &str, account: &str) -> PasswordOptions {
+    PasswordOptions::new_generic_password(service, account)
+}
+
+fn wrap_security_error(action: &str, error: SecurityError) -> MacOsAccessGroupError {
+    MacOsAccessGroupError::new(format!("{action}: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codex_keychain_services_match_stored_secret_services() {
+        assert_eq!(
+            CODEX_KEYCHAIN_SERVICES,
+            ["Codex Auth", "Codex MCP Credentials", "codex"]
+        );
+    }
+
+    #[test]
+    fn shared_access_group_matches_configured_team_prefix() {
+        assert_eq!(SHARED_ACCESS_GROUP, "2DC432GLL2.com.openai.shared");
+    }
+}

--- a/codex-rs/keyring-store/src/macos.rs
+++ b/codex-rs/keyring-store/src/macos.rs
@@ -396,22 +396,4 @@ mod tests {
         );
         assert_eq!(store.shared_writes.get(), 1);
     }
-
-    #[test]
-    fn delete_removes_both_shared_and_legacy_passwords() {
-        let store = MockPasswordStore::default()
-            .with_shared_password("shared-value")
-            .with_legacy_password("legacy-value");
-
-        let deleted = delete_password_with_store(&store, "Codex Auth", "test-account").unwrap();
-
-        assert!(deleted);
-        assert_eq!(store.shared.borrow().clone(), None);
-        assert_eq!(store.legacy.borrow().clone(), None);
-    }
-
-    #[test]
-    fn shared_access_group_matches_configured_team_prefix() {
-        assert_eq!(SHARED_ACCESS_GROUP, "2DC432GLL2.com.openai.codex.shared");
-    }
 }

--- a/codex-rs/keyring-store/src/macos.rs
+++ b/codex-rs/keyring-store/src/macos.rs
@@ -1,23 +1,13 @@
-use core_foundation::base::TCFType;
-use core_foundation::dictionary::CFDictionary;
-use core_foundation::string::CFString;
 use security_framework::base::Error as SecurityError;
-use security_framework::item::ItemClass;
-use security_framework::item::ItemSearchOptions;
-use security_framework::item::ItemUpdateOptions;
-use security_framework::item::Limit;
-use security_framework::item::Location;
-use security_framework::item::SearchResult;
-use security_framework::item::update_item;
 use security_framework::passwords::PasswordOptions;
 use security_framework::passwords::delete_generic_password_options;
 use security_framework::passwords::generic_password;
 use security_framework::passwords::set_generic_password_options;
 use security_framework_sys::base::errSecItemNotFound;
-use security_framework_sys::item::kSecAttrAccount;
 use std::fmt;
+use tracing::warn;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct MacOsAccessGroupError {
     details: String,
 }
@@ -43,25 +33,12 @@ impl fmt::Display for MacOsAccessGroupError {
 impl std::error::Error for MacOsAccessGroupError {}
 
 const SHARED_ACCESS_GROUP: &str = "2DC432GLL2.com.openai.codex.shared";
-const CODEX_KEYCHAIN_SERVICES: [&str; 3] = ["Codex Auth", "Codex MCP Credentials", "codex"];
 
 pub(crate) fn load_password(
     service: &str,
     account: &str,
 ) -> Result<Option<String>, MacOsAccessGroupError> {
-    if let Some(password) = load_shared_password_bytes(service, account)? {
-        return decode_password(password, service, account).map(Some);
-    }
-
-    if migrate_password_to_access_group(service, account)?
-        && let Some(password) = load_shared_password_bytes(service, account)?
-    {
-        return decode_password(password, service, account).map(Some);
-    }
-
-    load_legacy_password_bytes(service, account)?
-        .map(|password| decode_password(password, service, account))
-        .transpose()
+    load_password_with_store(&NativePasswordStore, service, account)
 }
 
 pub(crate) fn save_password(
@@ -69,95 +46,147 @@ pub(crate) fn save_password(
     account: &str,
     value: &str,
 ) -> Result<(), MacOsAccessGroupError> {
-    if load_shared_password_bytes(service, account)?.is_none() {
-        let _ = migrate_password_to_access_group(service, account)?;
-    }
-
-    save_shared_password_bytes(service, account, value.as_bytes())
+    save_password_with_store(&NativePasswordStore, service, account, value)
 }
 
 pub(crate) fn delete_password(service: &str, account: &str) -> Result<bool, MacOsAccessGroupError> {
-    let shared_removed = delete_shared_password(service, account)?;
-    let legacy_removed = delete_legacy_password(service, account)?;
-    Ok(shared_removed || legacy_removed)
+    delete_password_with_store(&NativePasswordStore, service, account)
 }
 
-pub(crate) fn migrate_existing_codex_items_to_access_group() -> Result<(), MacOsAccessGroupError> {
-    for service in CODEX_KEYCHAIN_SERVICES {
-        for account in legacy_accounts_for_service(service)? {
-            let _ = migrate_password_to_access_group(service, &account)?;
-        }
+trait PasswordStore {
+    fn load_shared_password_bytes(
+        &self,
+        service: &str,
+        account: &str,
+    ) -> Result<Option<Vec<u8>>, MacOsAccessGroupError>;
+
+    fn load_legacy_password_bytes(
+        &self,
+        service: &str,
+        account: &str,
+    ) -> Result<Option<Vec<u8>>, MacOsAccessGroupError>;
+
+    fn save_shared_password_bytes(
+        &self,
+        service: &str,
+        account: &str,
+        value: &[u8],
+    ) -> Result<(), MacOsAccessGroupError>;
+
+    fn delete_shared_password(
+        &self,
+        service: &str,
+        account: &str,
+    ) -> Result<bool, MacOsAccessGroupError>;
+
+    fn delete_legacy_password(
+        &self,
+        service: &str,
+        account: &str,
+    ) -> Result<bool, MacOsAccessGroupError>;
+}
+
+#[derive(Debug)]
+struct NativePasswordStore;
+
+impl PasswordStore for NativePasswordStore {
+    fn load_shared_password_bytes(
+        &self,
+        service: &str,
+        account: &str,
+    ) -> Result<Option<Vec<u8>>, MacOsAccessGroupError> {
+        load_password_bytes(
+            shared_password_options(service, account),
+            "read shared generic password",
+        )
     }
 
-    Ok(())
+    fn load_legacy_password_bytes(
+        &self,
+        service: &str,
+        account: &str,
+    ) -> Result<Option<Vec<u8>>, MacOsAccessGroupError> {
+        load_password_bytes(
+            legacy_password_options(service, account),
+            "read legacy generic password",
+        )
+    }
+
+    fn save_shared_password_bytes(
+        &self,
+        service: &str,
+        account: &str,
+        value: &[u8],
+    ) -> Result<(), MacOsAccessGroupError> {
+        set_generic_password_options(value, shared_password_options(service, account))
+            .map_err(|error| wrap_security_error("write shared generic password", error))
+    }
+
+    fn delete_shared_password(
+        &self,
+        service: &str,
+        account: &str,
+    ) -> Result<bool, MacOsAccessGroupError> {
+        delete_password_options(
+            shared_password_options(service, account),
+            "delete shared generic password",
+        )
+    }
+
+    fn delete_legacy_password(
+        &self,
+        service: &str,
+        account: &str,
+    ) -> Result<bool, MacOsAccessGroupError> {
+        delete_password_options(
+            legacy_password_options(service, account),
+            "delete legacy generic password",
+        )
+    }
 }
 
-fn migrate_password_to_access_group(
+fn load_password_with_store(
+    store: &impl PasswordStore,
+    service: &str,
+    account: &str,
+) -> Result<Option<String>, MacOsAccessGroupError> {
+    if let Some(password) = store.load_shared_password_bytes(service, account)? {
+        return decode_password(password, service, account).map(Some);
+    }
+
+    let Some(password) = store.load_legacy_password_bytes(service, account)? else {
+        return Ok(None);
+    };
+
+    if let Err(error) = store.save_shared_password_bytes(service, account, &password) {
+        warn!(
+            error = %error,
+            service,
+            account,
+            "failed to backfill legacy macOS keychain item into the shared access group"
+        );
+    }
+
+    decode_password(password, service, account).map(Some)
+}
+
+fn save_password_with_store(
+    store: &impl PasswordStore,
+    service: &str,
+    account: &str,
+    value: &str,
+) -> Result<(), MacOsAccessGroupError> {
+    store.save_shared_password_bytes(service, account, value.as_bytes())
+}
+
+fn delete_password_with_store(
+    store: &impl PasswordStore,
     service: &str,
     account: &str,
 ) -> Result<bool, MacOsAccessGroupError> {
-    let mut search = ItemSearchOptions::new();
-    search
-        .class(ItemClass::generic_password())
-        .service(service)
-        .account(account);
-
-    let mut update = ItemUpdateOptions::new();
-    update
-        .set_access_group(SHARED_ACCESS_GROUP)
-        .set_location(Location::DataProtectionKeychain);
-
-    match update_item(&search, &update) {
-        Ok(()) => Ok(true),
-        Err(error) if error.code() == errSecItemNotFound => Ok(false),
-        Err(error) => Err(wrap_security_error(
-            "move existing generic password into the shared access group",
-            error,
-        )),
-    }
-}
-
-fn legacy_accounts_for_service(service: &str) -> Result<Vec<String>, MacOsAccessGroupError> {
-    let mut search = ItemSearchOptions::new();
-    search
-        .class(ItemClass::generic_password())
-        .service(service)
-        .load_attributes(true)
-        .limit(Limit::All);
-
-    let results = match search.search() {
-        Ok(results) => results,
-        Err(error) if error.code() == errSecItemNotFound => return Ok(Vec::new()),
-        Err(error) => {
-            return Err(wrap_security_error(
-                "search existing generic passwords for Codex service",
-                error,
-            ));
-        }
-    };
-
-    let mut accounts = Vec::with_capacity(results.len());
-    for result in results {
-        match result {
-            SearchResult::Dict(attributes) => accounts.push(account_from_attributes(&attributes)?),
-            SearchResult::Ref(_) | SearchResult::Data(_) | SearchResult::Other => {
-                return Err(MacOsAccessGroupError::new(
-                    "search existing generic passwords for Codex service returned an unexpected result",
-                ));
-            }
-        }
-    }
-
-    Ok(accounts)
-}
-
-fn account_from_attributes(attributes: &CFDictionary) -> Result<String, MacOsAccessGroupError> {
-    let Some(account_value) = attributes.find(unsafe { kSecAttrAccount }.cast()) else {
-        return Err(MacOsAccessGroupError::new(
-            "generic password attributes did not include an account name",
-        ));
-    };
-    Ok(unsafe { CFString::wrap_under_get_rule((*account_value).cast()) }.to_string())
+    let shared_removed = store.delete_shared_password(service, account)?;
+    let legacy_removed = store.delete_legacy_password(service, account)?;
+    Ok(shared_removed || legacy_removed)
 }
 
 fn decode_password(
@@ -172,26 +201,6 @@ fn decode_password(
     })
 }
 
-fn load_shared_password_bytes(
-    service: &str,
-    account: &str,
-) -> Result<Option<Vec<u8>>, MacOsAccessGroupError> {
-    load_password_bytes(
-        shared_password_options(service, account),
-        "read shared generic password",
-    )
-}
-
-fn load_legacy_password_bytes(
-    service: &str,
-    account: &str,
-) -> Result<Option<Vec<u8>>, MacOsAccessGroupError> {
-    load_password_bytes(
-        legacy_password_options(service, account),
-        "read legacy generic password",
-    )
-}
-
 fn load_password_bytes(
     options: PasswordOptions,
     action: &str,
@@ -201,29 +210,6 @@ fn load_password_bytes(
         Err(error) if error.code() == errSecItemNotFound => Ok(None),
         Err(error) => Err(wrap_security_error(action, error)),
     }
-}
-
-fn save_shared_password_bytes(
-    service: &str,
-    account: &str,
-    value: &[u8],
-) -> Result<(), MacOsAccessGroupError> {
-    set_generic_password_options(value, shared_password_options(service, account))
-        .map_err(|error| wrap_security_error("write shared generic password", error))
-}
-
-fn delete_shared_password(service: &str, account: &str) -> Result<bool, MacOsAccessGroupError> {
-    delete_password_options(
-        shared_password_options(service, account),
-        "delete shared generic password",
-    )
-}
-
-fn delete_legacy_password(service: &str, account: &str) -> Result<bool, MacOsAccessGroupError> {
-    delete_password_options(
-        legacy_password_options(service, account),
-        "delete legacy generic password",
-    )
 }
 
 fn delete_password_options(
@@ -255,13 +241,173 @@ fn wrap_security_error(action: &str, error: SecurityError) -> MacOsAccessGroupEr
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::Cell;
+    use std::cell::RefCell;
+
+    #[derive(Default)]
+    struct MockPasswordStore {
+        shared: RefCell<Option<Vec<u8>>>,
+        legacy: RefCell<Option<Vec<u8>>>,
+        save_shared_error: RefCell<Option<MacOsAccessGroupError>>,
+        shared_writes: Cell<usize>,
+    }
+
+    impl MockPasswordStore {
+        fn with_shared_password(self, value: &str) -> Self {
+            self.shared.replace(Some(value.as_bytes().to_vec()));
+            self
+        }
+
+        fn with_legacy_password(self, value: &str) -> Self {
+            self.legacy.replace(Some(value.as_bytes().to_vec()));
+            self
+        }
+
+        fn with_save_shared_error(self, details: &str) -> Self {
+            self.save_shared_error
+                .replace(Some(MacOsAccessGroupError::new(details)));
+            self
+        }
+    }
+
+    impl PasswordStore for MockPasswordStore {
+        fn load_shared_password_bytes(
+            &self,
+            _service: &str,
+            _account: &str,
+        ) -> Result<Option<Vec<u8>>, MacOsAccessGroupError> {
+            Ok(self.shared.borrow().clone())
+        }
+
+        fn load_legacy_password_bytes(
+            &self,
+            _service: &str,
+            _account: &str,
+        ) -> Result<Option<Vec<u8>>, MacOsAccessGroupError> {
+            Ok(self.legacy.borrow().clone())
+        }
+
+        fn save_shared_password_bytes(
+            &self,
+            _service: &str,
+            _account: &str,
+            value: &[u8],
+        ) -> Result<(), MacOsAccessGroupError> {
+            if let Some(error) = self.save_shared_error.borrow().clone() {
+                return Err(error);
+            }
+
+            self.shared.replace(Some(value.to_vec()));
+            self.shared_writes.set(self.shared_writes.get() + 1);
+            Ok(())
+        }
+
+        fn delete_shared_password(
+            &self,
+            _service: &str,
+            _account: &str,
+        ) -> Result<bool, MacOsAccessGroupError> {
+            Ok(self.shared.borrow_mut().take().is_some())
+        }
+
+        fn delete_legacy_password(
+            &self,
+            _service: &str,
+            _account: &str,
+        ) -> Result<bool, MacOsAccessGroupError> {
+            Ok(self.legacy.borrow_mut().take().is_some())
+        }
+    }
 
     #[test]
-    fn codex_keychain_services_match_stored_secret_services() {
+    fn load_prefers_shared_password_when_present() {
+        let store = MockPasswordStore::default()
+            .with_shared_password("shared-value")
+            .with_legacy_password("legacy-value");
+
+        let password = load_password_with_store(&store, "Codex Auth", "greg")
+            .unwrap()
+            .expect("expected password");
+
+        assert_eq!(password, "shared-value");
         assert_eq!(
-            CODEX_KEYCHAIN_SERVICES,
-            ["Codex Auth", "Codex MCP Credentials", "codex"]
+            store.shared.borrow().clone(),
+            Some(b"shared-value".to_vec())
         );
+        assert_eq!(
+            store.legacy.borrow().clone(),
+            Some(b"legacy-value".to_vec())
+        );
+        assert_eq!(store.shared_writes.get(), 0);
+    }
+
+    #[test]
+    fn load_backfills_shared_password_from_legacy_without_deleting_legacy() {
+        let store = MockPasswordStore::default().with_legacy_password("legacy-value");
+
+        let password = load_password_with_store(&store, "Codex Auth", "greg")
+            .unwrap()
+            .expect("expected password");
+
+        assert_eq!(password, "legacy-value");
+        assert_eq!(
+            store.shared.borrow().clone(),
+            Some(b"legacy-value".to_vec())
+        );
+        assert_eq!(
+            store.legacy.borrow().clone(),
+            Some(b"legacy-value".to_vec())
+        );
+        assert_eq!(store.shared_writes.get(), 1);
+    }
+
+    #[test]
+    fn load_returns_legacy_password_when_shared_backfill_fails() {
+        let store = MockPasswordStore::default()
+            .with_legacy_password("legacy-value")
+            .with_save_shared_error("shared write failed");
+
+        let password = load_password_with_store(&store, "Codex Auth", "greg")
+            .unwrap()
+            .expect("expected password");
+
+        assert_eq!(password, "legacy-value");
+        assert_eq!(store.shared.borrow().clone(), None);
+        assert_eq!(
+            store.legacy.borrow().clone(),
+            Some(b"legacy-value".to_vec())
+        );
+        assert_eq!(store.shared_writes.get(), 0);
+    }
+
+    #[test]
+    fn save_writes_only_to_shared_password() {
+        let store = MockPasswordStore::default().with_legacy_password("legacy-value");
+
+        save_password_with_store(&store, "Codex Auth", "greg", "shared-value").unwrap();
+
+        assert_eq!(
+            store.shared.borrow().clone(),
+            Some(b"shared-value".to_vec())
+        );
+        assert_eq!(
+            store.legacy.borrow().clone(),
+            Some(b"legacy-value".to_vec())
+        );
+        assert_eq!(store.shared_writes.get(), 1);
+    }
+
+    #[test]
+    fn delete_removes_both_shared_and_legacy_passwords() {
+        let store = MockPasswordStore::default()
+            .with_shared_password("shared-value")
+            .with_legacy_password("legacy-value");
+
+        let deleted = delete_password_with_store(&store, "Codex Auth", "greg").unwrap();
+
+        assert!(deleted);
+        assert_eq!(store.shared.borrow().clone(), None);
+        assert_eq!(store.legacy.borrow().clone(), None);
     }
 
     #[test]

--- a/codex-rs/keyring-store/src/macos.rs
+++ b/codex-rs/keyring-store/src/macos.rs
@@ -325,7 +325,7 @@ mod tests {
             .with_shared_password("shared-value")
             .with_legacy_password("legacy-value");
 
-        let password = load_password_with_store(&store, "Codex Auth", "greg")
+        let password = load_password_with_store(&store, "Codex Auth", "test-account")
             .unwrap()
             .expect("expected password");
 
@@ -345,7 +345,7 @@ mod tests {
     fn load_backfills_shared_password_from_legacy_without_deleting_legacy() {
         let store = MockPasswordStore::default().with_legacy_password("legacy-value");
 
-        let password = load_password_with_store(&store, "Codex Auth", "greg")
+        let password = load_password_with_store(&store, "Codex Auth", "test-account")
             .unwrap()
             .expect("expected password");
 
@@ -367,7 +367,7 @@ mod tests {
             .with_legacy_password("legacy-value")
             .with_save_shared_error("shared write failed");
 
-        let password = load_password_with_store(&store, "Codex Auth", "greg")
+        let password = load_password_with_store(&store, "Codex Auth", "test-account")
             .unwrap()
             .expect("expected password");
 
@@ -384,7 +384,7 @@ mod tests {
     fn save_writes_only_to_shared_password() {
         let store = MockPasswordStore::default().with_legacy_password("legacy-value");
 
-        save_password_with_store(&store, "Codex Auth", "greg", "shared-value").unwrap();
+        save_password_with_store(&store, "Codex Auth", "test-account", "shared-value").unwrap();
 
         assert_eq!(
             store.shared.borrow().clone(),
@@ -403,7 +403,7 @@ mod tests {
             .with_shared_password("shared-value")
             .with_legacy_password("legacy-value");
 
-        let deleted = delete_password_with_store(&store, "Codex Auth", "greg").unwrap();
+        let deleted = delete_password_with_store(&store, "Codex Auth", "test-account").unwrap();
 
         assert!(deleted);
         assert_eq!(store.shared.borrow().clone(), None);


### PR DESCRIPTION
## Problem
macOS keychain items are normally only accessible to the app that created them unless other builds are signed with a shared keychain access group. We want new Codex builds to converge on a shared secret container while older builds keep working with their legacy secrets during rollout.

## Summary
- use native Security.framework keychain access on macOS in `codex-keyring-store`
- add the shared access group `2DC432GLL2.com.openai.codex.shared`
- make newly signed macOS Codex builds carry that entitlement by default
- prefer the shared item whenever it already exists
- if the shared item is missing, read the legacy item and backfill a shared copy without deleting the legacy value
- if the shared backfill fails, continue using the legacy value for that read
- write new values only to the shared item
- delete both shared and legacy items on explicit delete
- keep the old startup migration helper as a no-op so migration is on-demand rather than eager

## Migration flow
```mermaid
flowchart TD
    A["New entitled Codex build reads secret"] --> B{"Shared item exists?"}
    B -->|Yes| C["Use shared item\n2DC432GLL2.com.openai.codex.shared"]
    B -->|No| D{"Legacy item exists?"}
    D -->|No| E["Return missing secret"]
    D -->|Yes| F["Read legacy item"]
    F --> G["Attempt to write shared copy"]
    G -->|Success| H["Return value and future reads prefer shared"]
    G -->|Failure| I["Return legacy value\nand keep legacy item unchanged"]

    J["New entitled Codex build writes secret"] --> K["Write shared item only"]
    K --> L["Legacy item is left untouched"]

    M["Older non-entitled build"] --> N["Continues reading legacy item"]
```

## Expected behavior
- all newly signed macOS Codex builds should carry the shared `keychain-access-groups` entitlement
- on first access to a legacy-only secret, a new build may prompt for keychain access so it can read the legacy value and create the shared copy
- older builds can continue using their legacy value because migration no longer moves or deletes legacy secrets during rollout
- once a new build writes a newer value, that new value lives only in the shared item; older builds continue seeing the older legacy value until they also move to the shared entitlement path

## Notes
- this is a coexistence-oriented migration path, not an in-place move with `SecItemUpdate`
- rollout is intentionally on-demand: we no longer sweep and migrate known services at startup
- because writes are shared-only, mixed-version coexistence preserves access but not value synchronization
- local testing showed that standalone binaries with `keychain-access-groups` are rejected by AMFI without the right provisioning context, so full end-to-end validation still has to happen in the signed `Codex.app` / shipping pipeline

## Testing
- `cargo test -p codex-keyring-store`
- `cargo test -p codex-cli`
- `just fix -p codex-keyring-store`
- `just fmt`
