### PR TITLE
Add exec-server stub server and protocol docs

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -2004,6 +2004,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-exec-server"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "codex-app-server-protocol",
+ "codex-utils-cargo-bin",
+ "codex-utils-pty",
+ "pretty_assertions",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "codex-execpolicy"
 version = "0.0.0"
 dependencies = [

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "hooks",
     "secrets",
     "exec",
+    "exec-server",
     "execpolicy",
     "execpolicy-legacy",
     "keyring-store",

--- a/codex-rs/exec-server/BUILD.bazel
+++ b/codex-rs/exec-server/BUILD.bazel
@@ -1,0 +1,7 @@
+load("//:defs.bzl", "codex_rust_crate")
+
+codex_rust_crate(
+    name = "exec-server",
+    crate_name = "codex_exec_server",
+    test_tags = ["no-sandbox"],
+)

--- a/codex-rs/exec-server/Cargo.toml
+++ b/codex-rs/exec-server/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "codex-exec-server"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[[bin]]
+name = "codex-exec-server"
+path = "src/bin/codex-exec-server.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+base64 = { workspace = true }
+codex-app-server-protocol = { workspace = true }
+codex-utils-pty = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = [
+    "io-std",
+    "io-util",
+    "macros",
+    "process",
+    "rt-multi-thread",
+    "sync",
+    "time",
+] }
+tracing = { workspace = true }
+
+[dev-dependencies]
+anyhow = { workspace = true }
+codex-utils-cargo-bin = { workspace = true }
+pretty_assertions = { workspace = true }

--- a/codex-rs/exec-server/README.md
+++ b/codex-rs/exec-server/README.md
@@ -1,0 +1,285 @@
+# codex-exec-server
+
+`codex-exec-server` is a small standalone stdio JSON-RPC server for spawning
+and controlling subprocesses through `codex-utils-pty`.
+
+It currently provides:
+
+- a standalone binary: `codex-exec-server`
+- a Rust client: `ExecServerClient`
+- a small protocol module with shared request/response types
+
+This crate is intentionally narrow. It is not wired into the main Codex CLI or
+unified-exec in this PR; it is only the standalone transport layer.
+
+## Transport
+
+The server speaks newline-delimited JSON-RPC 2.0 over stdio.
+
+- `stdin`: one JSON-RPC message per line
+- `stdout`: one JSON-RPC message per line
+- `stderr`: reserved for logs / process errors
+
+Like the app-server transport, messages on the wire omit the `"jsonrpc":"2.0"`
+field and use the shared `codex-app-server-protocol` envelope types.
+
+The current protocol version is:
+
+```text
+exec-server.v0
+```
+
+## Lifecycle
+
+Each connection follows this sequence:
+
+1. Send `initialize`.
+2. Wait for the `initialize` response.
+3. Send `initialized`.
+4. Start and manage processes with `command/exec`, `command/exec/write`, and
+   `command/exec/terminate`.
+5. Read streaming notifications from `command/exec/outputDelta` and
+   `command/exec/exited`.
+
+If the server receives any notification other than `initialized`, it replies
+with an error using request id `-1`.
+
+If the stdio connection closes, the server terminates any remaining managed
+processes before exiting.
+
+## API
+
+### `initialize`
+
+Initial handshake request.
+
+Request params:
+
+```json
+{
+  "clientName": "my-client"
+}
+```
+
+Response:
+
+```json
+{
+  "protocolVersion": "exec-server.v0"
+}
+```
+
+### `initialized`
+
+Handshake acknowledgement notification sent by the client after a successful
+`initialize` response.
+
+Params are currently ignored. Sending any other notification method is treated
+as an invalid request.
+
+### `command/exec`
+
+Starts a new managed process.
+
+Request params:
+
+```json
+{
+  "processId": "proc-1",
+  "argv": ["bash", "-lc", "printf 'hello\\n'"],
+  "cwd": "/absolute/working/directory",
+  "env": {
+    "PATH": "/usr/bin:/bin"
+  },
+  "tty": true,
+  "outputBytesCap": 16384,
+  "arg0": null
+}
+```
+
+Field definitions:
+
+- `processId`: caller-chosen stable id for this process within the connection.
+- `argv`: command vector. It must be non-empty.
+- `cwd`: absolute working directory used for the child process.
+- `env`: environment variables passed to the child process.
+- `tty`: when `true`, spawn a PTY-backed interactive process; when `false`,
+  spawn a pipe-backed process with closed stdin.
+- `outputBytesCap`: maximum retained stdout/stderr bytes per stream for the
+  in-memory buffer. Defaults to `codex_utils_pty::DEFAULT_OUTPUT_BYTES_CAP`.
+- `arg0`: optional argv0 override forwarded to `codex-utils-pty`.
+
+Response:
+
+```json
+{
+  "processId": "proc-1",
+  "running": true,
+  "exitCode": null,
+  "stdout": null,
+  "stderr": null
+}
+```
+
+Behavior notes:
+
+- Reusing an existing `processId` is rejected.
+- PTY-backed processes accept later writes through `command/exec/write`.
+- Pipe-backed processes are launched with stdin closed and reject writes.
+- Output is streamed asynchronously via `command/exec/outputDelta`.
+- Exit is reported asynchronously via `command/exec/exited`.
+
+### `command/exec/write`
+
+Writes raw bytes to a running PTY-backed process stdin.
+
+Request params:
+
+```json
+{
+  "processId": "proc-1",
+  "chunk": "aGVsbG8K"
+}
+```
+
+`chunk` is base64-encoded raw bytes. In the example above it is `hello\n`.
+
+Response:
+
+```json
+{
+  "accepted": true
+}
+```
+
+Behavior notes:
+
+- Writes to an unknown `processId` are rejected.
+- Writes to a non-PTY process are rejected because stdin is already closed.
+
+### `command/exec/terminate`
+
+Terminates a running managed process.
+
+Request params:
+
+```json
+{
+  "processId": "proc-1"
+}
+```
+
+Response:
+
+```json
+{
+  "running": true
+}
+```
+
+If the process is already unknown or already removed, the server responds with:
+
+```json
+{
+  "running": false
+}
+```
+
+## Notifications
+
+### `command/exec/outputDelta`
+
+Streaming output chunk from a running process.
+
+Params:
+
+```json
+{
+  "processId": "proc-1",
+  "stream": "stdout",
+  "chunk": "aGVsbG8K"
+}
+```
+
+Fields:
+
+- `processId`: process identifier
+- `stream`: `"stdout"` or `"stderr"`
+- `chunk`: base64-encoded output bytes
+
+### `command/exec/exited`
+
+Final process exit notification.
+
+Params:
+
+```json
+{
+  "processId": "proc-1",
+  "exitCode": 0
+}
+```
+
+## Errors
+
+The server returns JSON-RPC errors with these codes:
+
+- `-32600`: invalid request
+- `-32602`: invalid params
+- `-32603`: internal error
+
+Typical error cases:
+
+- unknown method
+- malformed params
+- empty `argv`
+- duplicate `processId`
+- writes to unknown processes
+- writes to non-PTY processes
+
+## Rust surface
+
+The crate exports:
+
+- `ExecServerClient`
+- `ExecServerLaunchCommand`
+- `ExecServerProcess`
+- `ExecServerError`
+- protocol structs such as `ExecParams`, `ExecResponse`,
+  `WriteParams`, `TerminateParams`, `ExecOutputDeltaNotification`, and
+  `ExecExitedNotification`
+- `run_main()` for embedding the stdio server in a binary
+
+## Example session
+
+Initialize:
+
+```json
+{"id":1,"method":"initialize","params":{"clientName":"example-client"}}
+{"id":1,"result":{"protocolVersion":"exec-server.v0"}}
+{"method":"initialized","params":{}}
+```
+
+Start a process:
+
+```json
+{"id":2,"method":"command/exec","params":{"processId":"proc-1","argv":["bash","-lc","printf 'ready\\n'; while IFS= read -r line; do printf 'echo:%s\\n' \"$line\"; done"],"cwd":"/tmp","env":{"PATH":"/usr/bin:/bin"},"tty":true,"outputBytesCap":4096,"arg0":null}}
+{"id":2,"result":{"processId":"proc-1","running":true,"exitCode":null,"stdout":null,"stderr":null}}
+{"method":"command/exec/outputDelta","params":{"processId":"proc-1","stream":"stdout","chunk":"cmVhZHkK"}}
+```
+
+Write to the process:
+
+```json
+{"id":3,"method":"command/exec/write","params":{"processId":"proc-1","chunk":"aGVsbG8K"}}
+{"id":3,"result":{"accepted":true}}
+{"method":"command/exec/outputDelta","params":{"processId":"proc-1","stream":"stdout","chunk":"ZWNobzpoZWxsbwo="}}
+```
+
+Terminate it:
+
+```json
+{"id":4,"method":"command/exec/terminate","params":{"processId":"proc-1"}}
+{"id":4,"result":{"running":true}}
+{"method":"command/exec/exited","params":{"processId":"proc-1","exitCode":0}}
+```

--- a/codex-rs/exec-server/README.md
+++ b/codex-rs/exec-server/README.md
@@ -3,6 +3,10 @@
 `codex-exec-server` is a small standalone stdio JSON-RPC server for spawning
 and controlling subprocesses through `codex-utils-pty`.
 
+This PR intentionally lands only the standalone binary, client, wire protocol,
+and docs. Exec and filesystem methods are stubbed server-side here and are
+implemented in follow-up PRs.
+
 It currently provides:
 
 - a standalone binary: `codex-exec-server`
@@ -36,10 +40,7 @@ Each connection follows this sequence:
 1. Send `initialize`.
 2. Wait for the `initialize` response.
 3. Send `initialized`.
-4. Start and manage processes with `command/exec`, `command/exec/write`, and
-   `command/exec/terminate`.
-5. Read streaming notifications from `command/exec/outputDelta` and
-   `command/exec/exited`.
+4. Call exec or filesystem RPCs once the follow-up implementation PRs land.
 
 If the server receives any notification other than `initialized`, it replies
 with an error using request id `-1`.

--- a/codex-rs/exec-server/src/bin/codex-exec-server.rs
+++ b/codex-rs/exec-server/src/bin/codex-exec-server.rs
@@ -1,0 +1,7 @@
+#[tokio::main]
+async fn main() {
+    if let Err(err) = codex_exec_server::run_main().await {
+        eprintln!("{err}");
+        std::process::exit(1);
+    }
+}

--- a/codex-rs/exec-server/src/client.rs
+++ b/codex-rs/exec-server/src/client.rs
@@ -1,9 +1,6 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
-use std::process::Stdio;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
-use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicI64;
 use std::sync::atomic::Ordering;
 
@@ -21,132 +18,23 @@ use tokio::io::AsyncBufReadExt;
 use tokio::io::AsyncWriteExt;
 use tokio::io::BufReader;
 use tokio::process::Child;
-use tokio::process::Command;
 use tokio::sync::Mutex;
-use tokio::sync::broadcast;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
-use tracing::debug;
 use tracing::warn;
 
-use crate::protocol::EXEC_EXITED_METHOD;
-use crate::protocol::EXEC_METHOD;
-use crate::protocol::EXEC_OUTPUT_DELTA_METHOD;
-use crate::protocol::EXEC_TERMINATE_METHOD;
-use crate::protocol::EXEC_WRITE_METHOD;
-use crate::protocol::ExecExitedNotification;
-use crate::protocol::ExecOutputDeltaNotification;
-use crate::protocol::ExecParams;
-use crate::protocol::ExecResponse;
 use crate::protocol::INITIALIZE_METHOD;
 use crate::protocol::INITIALIZED_METHOD;
 use crate::protocol::InitializeParams;
 use crate::protocol::InitializeResponse;
-use crate::protocol::TerminateParams;
-use crate::protocol::TerminateResponse;
-use crate::protocol::WriteParams;
-use crate::protocol::WriteResponse;
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ExecServerLaunchCommand {
-    pub program: PathBuf,
-    pub args: Vec<String>,
-}
-
-pub struct ExecServerProcess {
-    process_id: String,
-    output_rx: broadcast::Receiver<Vec<u8>>,
-    writer_tx: mpsc::Sender<Vec<u8>>,
-    status: Arc<RemoteProcessStatus>,
-    client: ExecServerClient,
-}
-
-impl std::fmt::Debug for ExecServerProcess {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ExecServerProcess")
-            .field("process_id", &self.process_id)
-            .field("has_exited", &self.has_exited())
-            .field("exit_code", &self.exit_code())
-            .finish()
-    }
-}
-
-impl ExecServerProcess {
-    pub fn writer_sender(&self) -> mpsc::Sender<Vec<u8>> {
-        self.writer_tx.clone()
-    }
-
-    pub fn output_receiver(&self) -> broadcast::Receiver<Vec<u8>> {
-        self.output_rx.resubscribe()
-    }
-
-    pub fn has_exited(&self) -> bool {
-        self.status.has_exited()
-    }
-
-    pub fn exit_code(&self) -> Option<i32> {
-        self.status.exit_code()
-    }
-
-    pub fn terminate(&self) {
-        self.status.mark_exited(None);
-        let client = self.client.clone();
-        let process_id = self.process_id.clone();
-        tokio::spawn(async move {
-            let _ = client.terminate_process(&process_id).await;
-        });
-    }
-}
-
-impl std::fmt::Debug for RemoteProcessStatus {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RemoteProcessStatus")
-            .field("exited", &self.has_exited())
-            .field("exit_code", &self.exit_code())
-            .finish()
-    }
-}
-
-struct RemoteProcessStatus {
-    exited: AtomicBool,
-    exit_code: StdMutex<Option<i32>>,
-}
-
-impl RemoteProcessStatus {
-    fn new() -> Self {
-        Self {
-            exited: AtomicBool::new(false),
-            exit_code: StdMutex::new(None),
-        }
-    }
-
-    fn has_exited(&self) -> bool {
-        self.exited.load(Ordering::SeqCst)
-    }
-
-    fn exit_code(&self) -> Option<i32> {
-        self.exit_code.lock().ok().and_then(|guard| *guard)
-    }
-
-    fn mark_exited(&self, exit_code: Option<i32>) {
-        self.exited.store(true, Ordering::SeqCst);
-        if let Ok(mut guard) = self.exit_code.lock() {
-            *guard = exit_code;
-        }
-    }
-}
-
-struct RegisteredProcess {
-    output_tx: broadcast::Sender<Vec<u8>>,
-    status: Arc<RemoteProcessStatus>,
-}
+use crate::server_process::ExecServerLaunchCommand;
+use crate::server_process::spawn_stdio_exec_server;
 
 struct Inner {
     child: StdMutex<Option<Child>>,
     write_tx: mpsc::UnboundedSender<JSONRPCMessage>,
     pending: Mutex<HashMap<RequestId, oneshot::Sender<Result<Value, JSONRPCErrorError>>>>,
-    processes: Mutex<HashMap<String, RegisteredProcess>>,
     next_request_id: AtomicI64,
     reader_task: JoinHandle<()>,
     writer_task: JoinHandle<()>,
@@ -185,20 +73,11 @@ pub enum ExecServerError {
 
 impl ExecServerClient {
     pub async fn spawn(command: ExecServerLaunchCommand) -> Result<Self, ExecServerError> {
-        let mut child = Command::new(&command.program);
-        child.args(&command.args);
-        child.stdin(Stdio::piped());
-        child.stdout(Stdio::piped());
-        child.stderr(Stdio::inherit());
-        child.kill_on_drop(true);
-
-        let mut child = child.spawn().map_err(ExecServerError::Spawn)?;
-        let stdin = child.stdin.take().ok_or_else(|| {
-            ExecServerError::Protocol("exec-server stdin was not captured".to_string())
-        })?;
-        let stdout = child.stdout.take().ok_or_else(|| {
-            ExecServerError::Protocol("exec-server stdout was not captured".to_string())
-        })?;
+        let crate::server_process::SpawnedStdioExecServer {
+            child,
+            stdin,
+            stdout,
+        } = spawn_stdio_exec_server(command)?;
 
         let (write_tx, mut write_rx) = mpsc::unbounded_channel::<JSONRPCMessage>();
         let writer_task = tokio::spawn(async move {
@@ -227,7 +106,6 @@ impl ExecServerClient {
             RequestId,
             oneshot::Sender<Result<Value, JSONRPCErrorError>>,
         >::new());
-        let processes = Mutex::new(HashMap::<String, RegisteredProcess>::new());
         let inner = Arc::new_cyclic(move |weak| {
             let weak = weak.clone();
             let reader_task = tokio::spawn(async move {
@@ -236,12 +114,12 @@ impl ExecServerClient {
                     let Some(inner) = weak.upgrade() else {
                         break;
                     };
-                    let next_line = lines.next_line().await;
-                    match next_line {
+                    match lines.next_line().await {
                         Ok(Some(line)) => {
                             if line.trim().is_empty() {
                                 continue;
                             }
+
                             match serde_json::from_str::<JSONRPCMessage>(&line) {
                                 Ok(message) => {
                                     if let Err(err) = handle_server_message(&inner, message).await {
@@ -262,8 +140,9 @@ impl ExecServerClient {
                         }
                     }
                 }
+
                 if let Some(inner) = weak.upgrade() {
-                    handle_transport_shutdown(&inner).await;
+                    fail_pending_requests(&inner).await;
                 }
             });
 
@@ -271,7 +150,6 @@ impl ExecServerClient {
                 child: StdMutex::new(Some(child)),
                 write_tx,
                 pending,
-                processes,
                 next_request_id: AtomicI64::new(1),
                 reader_task,
                 writer_task,
@@ -279,92 +157,56 @@ impl ExecServerClient {
         });
 
         let client = Self { inner };
-        client.initialize().await?;
+        client
+            .initialize(InitializeParams {
+                client_name: "codex-core".to_string(),
+            })
+            .await?;
+        client.send_notification(INITIALIZED_METHOD, serde_json::json!({}))?;
         Ok(client)
     }
 
-    pub async fn start_process(
+    pub async fn initialize(
         &self,
-        params: ExecParams,
-    ) -> Result<ExecServerProcess, ExecServerError> {
-        let process_id = params.process_id.clone();
-        let status = Arc::new(RemoteProcessStatus::new());
-        let (output_tx, output_rx) = broadcast::channel(256);
-        self.inner.processes.lock().await.insert(
-            process_id.clone(),
-            RegisteredProcess {
-                output_tx,
-                status: Arc::clone(&status),
-            },
-        );
+        params: InitializeParams,
+    ) -> Result<InitializeResponse, ExecServerError> {
+        self.send_request(INITIALIZE_METHOD, params).await
+    }
 
-        let (writer_tx, mut writer_rx) = mpsc::channel::<Vec<u8>>(128);
-        let client = self.clone();
-        let write_process_id = process_id.clone();
-        tokio::spawn(async move {
-            while let Some(chunk) = writer_rx.recv().await {
-                let request = WriteParams {
-                    process_id: write_process_id.clone(),
-                    chunk: chunk.into(),
-                };
-                if client.write_process(request).await.is_err() {
-                    break;
-                }
-            }
-        });
+    async fn send_request<P, R>(&self, method: &str, params: P) -> Result<R, ExecServerError>
+    where
+        P: Serialize,
+        R: DeserializeOwned,
+    {
+        let id = RequestId::Integer(self.inner.next_request_id.fetch_add(1, Ordering::SeqCst));
+        let params = serde_json::to_value(params)?;
+        let (tx, rx) = oneshot::channel();
+        self.inner.pending.lock().await.insert(id.clone(), tx);
 
-        let response = match self.request::<_, ExecResponse>(EXEC_METHOD, &params).await {
-            Ok(response) => response,
-            Err(err) => {
-                self.inner.processes.lock().await.remove(&process_id);
-                return Err(err);
-            }
-        };
-
-        if let Some(exit_code) = response.exit_code {
-            status.mark_exited(Some(exit_code));
+        if let Err(err) = self
+            .inner
+            .write_tx
+            .send(JSONRPCMessage::Request(JSONRPCRequest {
+                id: id.clone(),
+                method: method.to_string(),
+                params: Some(params),
+                trace: None,
+            }))
+        {
+            let _ = self.inner.pending.lock().await.remove(&id);
+            return Err(ExecServerError::Protocol(format!(
+                "failed to queue exec-server request: {err}"
+            )));
         }
 
-        Ok(ExecServerProcess {
-            process_id,
-            output_rx,
-            writer_tx,
-            status,
-            client: self.clone(),
-        })
+        let result = rx.await.map_err(|_| ExecServerError::Closed)??;
+        Ok(serde_json::from_value(result)?)
     }
 
-    async fn initialize(&self) -> Result<(), ExecServerError> {
-        let _: InitializeResponse = self
-            .request(
-                INITIALIZE_METHOD,
-                &InitializeParams {
-                    client_name: "codex-core".to_string(),
-                },
-            )
-            .await?;
-        self.notify(INITIALIZED_METHOD, &serde_json::json!({}))
-            .await
-    }
-
-    async fn write_process(&self, params: WriteParams) -> Result<WriteResponse, ExecServerError> {
-        self.request(EXEC_WRITE_METHOD, &params).await
-    }
-
-    async fn terminate_process(
-        &self,
-        process_id: &str,
-    ) -> Result<TerminateResponse, ExecServerError> {
-        self.request(
-            EXEC_TERMINATE_METHOD,
-            &TerminateParams {
-                process_id: process_id.to_string(),
-            },
-        )
-        .await
-    }
-
-    async fn notify<P: Serialize>(&self, method: &str, params: &P) -> Result<(), ExecServerError> {
+    fn send_notification<P>(&self, method: &str, params: P) -> Result<(), ExecServerError>
+    where
+        P: Serialize,
+    {
         let params = serde_json::to_value(params)?;
         self.inner
             .write_tx
@@ -372,49 +214,25 @@ impl ExecServerClient {
                 method: method.to_string(),
                 params: Some(params),
             }))
-            .map_err(|_| ExecServerError::Closed)
+            .map_err(|err| {
+                ExecServerError::Protocol(format!(
+                    "failed to queue exec-server notification: {err}"
+                ))
+            })
     }
+}
 
-    async fn request<P, R>(&self, method: &str, params: &P) -> Result<R, ExecServerError>
-    where
-        P: Serialize,
-        R: DeserializeOwned,
-    {
-        let request_id =
-            RequestId::Integer(self.inner.next_request_id.fetch_add(1, Ordering::SeqCst));
-        let (response_tx, response_rx) = oneshot::channel();
-        self.inner
-            .pending
-            .lock()
-            .await
-            .insert(request_id.clone(), response_tx);
-
-        let params = serde_json::to_value(params)?;
-        let message = JSONRPCMessage::Request(JSONRPCRequest {
-            id: request_id.clone(),
-            method: method.to_string(),
-            params: Some(params),
-            trace: None,
-        });
-
-        if self.inner.write_tx.send(message).is_err() {
-            self.inner.pending.lock().await.remove(&request_id);
-            return Err(ExecServerError::Closed);
-        }
-
-        let result = response_rx.await.map_err(|_| ExecServerError::Closed)?;
-        match result {
-            Ok(value) => serde_json::from_value(value).map_err(ExecServerError::from),
-            Err(error) => Err(ExecServerError::Server {
-                code: error.code,
-                message: error.message,
-            }),
+impl From<JSONRPCErrorError> for ExecServerError {
+    fn from(error: JSONRPCErrorError) -> Self {
+        Self::Server {
+            code: error.code,
+            message: error.message,
         }
     }
 }
 
 async fn handle_server_message(
-    inner: &Arc<Inner>,
+    inner: &Inner,
     message: JSONRPCMessage,
 ) -> Result<(), ExecServerError> {
     match message {
@@ -422,76 +240,37 @@ async fn handle_server_message(
             if let Some(tx) = inner.pending.lock().await.remove(&id) {
                 let _ = tx.send(Ok(result));
             }
+            Ok(())
         }
         JSONRPCMessage::Error(JSONRPCError { id, error }) => {
             if let Some(tx) = inner.pending.lock().await.remove(&id) {
                 let _ = tx.send(Err(error));
+                Ok(())
+            } else {
+                Err(ExecServerError::Server {
+                    code: error.code,
+                    message: error.message,
+                })
             }
         }
-        JSONRPCMessage::Notification(notification) => {
-            handle_server_notification(inner, notification).await?;
-        }
-        JSONRPCMessage::Request(request) => {
-            return Err(ExecServerError::Protocol(format!(
-                "unexpected exec-server request from child: {}",
-                request.method
-            )));
-        }
+        JSONRPCMessage::Notification(notification) => Err(ExecServerError::Protocol(format!(
+            "unexpected exec-server notification: {}",
+            notification.method
+        ))),
+        JSONRPCMessage::Request(request) => Err(ExecServerError::Protocol(format!(
+            "unexpected exec-server request: {}",
+            request.method
+        ))),
     }
-
-    Ok(())
 }
 
-async fn handle_server_notification(
-    inner: &Arc<Inner>,
-    notification: JSONRPCNotification,
-) -> Result<(), ExecServerError> {
-    match notification.method.as_str() {
-        EXEC_OUTPUT_DELTA_METHOD => {
-            let params: ExecOutputDeltaNotification =
-                serde_json::from_value(notification.params.unwrap_or(Value::Null))?;
-            let chunk = params.chunk.into_inner();
-            let processes = inner.processes.lock().await;
-            if let Some(process) = processes.get(&params.process_id) {
-                let _ = process.output_tx.send(chunk);
-            }
-        }
-        EXEC_EXITED_METHOD => {
-            let params: ExecExitedNotification =
-                serde_json::from_value(notification.params.unwrap_or(Value::Null))?;
-            let mut processes = inner.processes.lock().await;
-            if let Some(process) = processes.remove(&params.process_id) {
-                process.status.mark_exited(Some(params.exit_code));
-            }
-        }
-        other => {
-            debug!("ignoring unknown exec-server notification: {other}");
-        }
-    }
-    Ok(())
-}
-
-async fn handle_transport_shutdown(inner: &Arc<Inner>) {
-    let pending = {
-        let mut pending = inner.pending.lock().await;
-        pending.drain().map(|(_, tx)| tx).collect::<Vec<_>>()
-    };
-    for tx in pending {
+async fn fail_pending_requests(inner: &Inner) {
+    let mut pending = inner.pending.lock().await;
+    for (_, tx) in pending.drain() {
         let _ = tx.send(Err(JSONRPCErrorError {
             code: -32000,
-            data: None,
             message: "exec-server transport closed".to_string(),
+            data: None,
         }));
-    }
-
-    let processes = {
-        let mut processes = inner.processes.lock().await;
-        processes
-            .drain()
-            .map(|(_, process)| process)
-            .collect::<Vec<_>>()
-    };
-    for process in processes {
-        process.status.mark_exited(None);
     }
 }

--- a/codex-rs/exec-server/src/client.rs
+++ b/codex-rs/exec-server/src/client.rs
@@ -1,0 +1,497 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicI64;
+use std::sync::atomic::Ordering;
+
+use codex_app_server_protocol::JSONRPCError;
+use codex_app_server_protocol::JSONRPCErrorError;
+use codex_app_server_protocol::JSONRPCMessage;
+use codex_app_server_protocol::JSONRPCNotification;
+use codex_app_server_protocol::JSONRPCRequest;
+use codex_app_server_protocol::JSONRPCResponse;
+use codex_app_server_protocol::RequestId;
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+use tokio::io::AsyncBufReadExt;
+use tokio::io::AsyncWriteExt;
+use tokio::io::BufReader;
+use tokio::process::Child;
+use tokio::process::Command;
+use tokio::sync::Mutex;
+use tokio::sync::broadcast;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+use tracing::debug;
+use tracing::warn;
+
+use crate::protocol::EXEC_EXITED_METHOD;
+use crate::protocol::EXEC_METHOD;
+use crate::protocol::EXEC_OUTPUT_DELTA_METHOD;
+use crate::protocol::EXEC_TERMINATE_METHOD;
+use crate::protocol::EXEC_WRITE_METHOD;
+use crate::protocol::ExecExitedNotification;
+use crate::protocol::ExecOutputDeltaNotification;
+use crate::protocol::ExecParams;
+use crate::protocol::ExecResponse;
+use crate::protocol::INITIALIZE_METHOD;
+use crate::protocol::INITIALIZED_METHOD;
+use crate::protocol::InitializeParams;
+use crate::protocol::InitializeResponse;
+use crate::protocol::TerminateParams;
+use crate::protocol::TerminateResponse;
+use crate::protocol::WriteParams;
+use crate::protocol::WriteResponse;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecServerLaunchCommand {
+    pub program: PathBuf,
+    pub args: Vec<String>,
+}
+
+pub struct ExecServerProcess {
+    process_id: String,
+    output_rx: broadcast::Receiver<Vec<u8>>,
+    writer_tx: mpsc::Sender<Vec<u8>>,
+    status: Arc<RemoteProcessStatus>,
+    client: ExecServerClient,
+}
+
+impl std::fmt::Debug for ExecServerProcess {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ExecServerProcess")
+            .field("process_id", &self.process_id)
+            .field("has_exited", &self.has_exited())
+            .field("exit_code", &self.exit_code())
+            .finish()
+    }
+}
+
+impl ExecServerProcess {
+    pub fn writer_sender(&self) -> mpsc::Sender<Vec<u8>> {
+        self.writer_tx.clone()
+    }
+
+    pub fn output_receiver(&self) -> broadcast::Receiver<Vec<u8>> {
+        self.output_rx.resubscribe()
+    }
+
+    pub fn has_exited(&self) -> bool {
+        self.status.has_exited()
+    }
+
+    pub fn exit_code(&self) -> Option<i32> {
+        self.status.exit_code()
+    }
+
+    pub fn terminate(&self) {
+        self.status.mark_exited(None);
+        let client = self.client.clone();
+        let process_id = self.process_id.clone();
+        tokio::spawn(async move {
+            let _ = client.terminate_process(&process_id).await;
+        });
+    }
+}
+
+impl std::fmt::Debug for RemoteProcessStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RemoteProcessStatus")
+            .field("exited", &self.has_exited())
+            .field("exit_code", &self.exit_code())
+            .finish()
+    }
+}
+
+struct RemoteProcessStatus {
+    exited: AtomicBool,
+    exit_code: StdMutex<Option<i32>>,
+}
+
+impl RemoteProcessStatus {
+    fn new() -> Self {
+        Self {
+            exited: AtomicBool::new(false),
+            exit_code: StdMutex::new(None),
+        }
+    }
+
+    fn has_exited(&self) -> bool {
+        self.exited.load(Ordering::SeqCst)
+    }
+
+    fn exit_code(&self) -> Option<i32> {
+        self.exit_code.lock().ok().and_then(|guard| *guard)
+    }
+
+    fn mark_exited(&self, exit_code: Option<i32>) {
+        self.exited.store(true, Ordering::SeqCst);
+        if let Ok(mut guard) = self.exit_code.lock() {
+            *guard = exit_code;
+        }
+    }
+}
+
+struct RegisteredProcess {
+    output_tx: broadcast::Sender<Vec<u8>>,
+    status: Arc<RemoteProcessStatus>,
+}
+
+struct Inner {
+    child: StdMutex<Option<Child>>,
+    write_tx: mpsc::UnboundedSender<JSONRPCMessage>,
+    pending: Mutex<HashMap<RequestId, oneshot::Sender<Result<Value, JSONRPCErrorError>>>>,
+    processes: Mutex<HashMap<String, RegisteredProcess>>,
+    next_request_id: AtomicI64,
+    reader_task: JoinHandle<()>,
+    writer_task: JoinHandle<()>,
+}
+
+impl Drop for Inner {
+    fn drop(&mut self) {
+        self.reader_task.abort();
+        self.writer_task.abort();
+        if let Ok(mut child_guard) = self.child.lock()
+            && let Some(child) = child_guard.as_mut()
+        {
+            let _ = child.start_kill();
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct ExecServerClient {
+    inner: Arc<Inner>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ExecServerError {
+    #[error("failed to spawn exec-server: {0}")]
+    Spawn(#[source] std::io::Error),
+    #[error("exec-server transport closed")]
+    Closed,
+    #[error("failed to serialize or deserialize exec-server JSON: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("exec-server protocol error: {0}")]
+    Protocol(String),
+    #[error("exec-server rejected request ({code}): {message}")]
+    Server { code: i64, message: String },
+}
+
+impl ExecServerClient {
+    pub async fn spawn(command: ExecServerLaunchCommand) -> Result<Self, ExecServerError> {
+        let mut child = Command::new(&command.program);
+        child.args(&command.args);
+        child.stdin(Stdio::piped());
+        child.stdout(Stdio::piped());
+        child.stderr(Stdio::inherit());
+        child.kill_on_drop(true);
+
+        let mut child = child.spawn().map_err(ExecServerError::Spawn)?;
+        let stdin = child.stdin.take().ok_or_else(|| {
+            ExecServerError::Protocol("exec-server stdin was not captured".to_string())
+        })?;
+        let stdout = child.stdout.take().ok_or_else(|| {
+            ExecServerError::Protocol("exec-server stdout was not captured".to_string())
+        })?;
+
+        let (write_tx, mut write_rx) = mpsc::unbounded_channel::<JSONRPCMessage>();
+        let writer_task = tokio::spawn(async move {
+            let mut stdin = stdin;
+            while let Some(message) = write_rx.recv().await {
+                let encoded = match serde_json::to_vec(&message) {
+                    Ok(encoded) => encoded,
+                    Err(err) => {
+                        warn!("failed to encode exec-server message: {err}");
+                        break;
+                    }
+                };
+                if stdin.write_all(&encoded).await.is_err() {
+                    break;
+                }
+                if stdin.write_all(b"\n").await.is_err() {
+                    break;
+                }
+                if stdin.flush().await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        let pending = Mutex::new(HashMap::<
+            RequestId,
+            oneshot::Sender<Result<Value, JSONRPCErrorError>>,
+        >::new());
+        let processes = Mutex::new(HashMap::<String, RegisteredProcess>::new());
+        let inner = Arc::new_cyclic(move |weak| {
+            let weak = weak.clone();
+            let reader_task = tokio::spawn(async move {
+                let mut lines = BufReader::new(stdout).lines();
+                loop {
+                    let Some(inner) = weak.upgrade() else {
+                        break;
+                    };
+                    let next_line = lines.next_line().await;
+                    match next_line {
+                        Ok(Some(line)) => {
+                            if line.trim().is_empty() {
+                                continue;
+                            }
+                            match serde_json::from_str::<JSONRPCMessage>(&line) {
+                                Ok(message) => {
+                                    if let Err(err) = handle_server_message(&inner, message).await {
+                                        warn!("failed to handle exec-server message: {err}");
+                                        break;
+                                    }
+                                }
+                                Err(err) => {
+                                    warn!("failed to parse exec-server message: {err}");
+                                    break;
+                                }
+                            }
+                        }
+                        Ok(None) => break,
+                        Err(err) => {
+                            warn!("failed to read exec-server stdout: {err}");
+                            break;
+                        }
+                    }
+                }
+                if let Some(inner) = weak.upgrade() {
+                    handle_transport_shutdown(&inner).await;
+                }
+            });
+
+            Inner {
+                child: StdMutex::new(Some(child)),
+                write_tx,
+                pending,
+                processes,
+                next_request_id: AtomicI64::new(1),
+                reader_task,
+                writer_task,
+            }
+        });
+
+        let client = Self { inner };
+        client.initialize().await?;
+        Ok(client)
+    }
+
+    pub async fn start_process(
+        &self,
+        params: ExecParams,
+    ) -> Result<ExecServerProcess, ExecServerError> {
+        let process_id = params.process_id.clone();
+        let status = Arc::new(RemoteProcessStatus::new());
+        let (output_tx, output_rx) = broadcast::channel(256);
+        self.inner.processes.lock().await.insert(
+            process_id.clone(),
+            RegisteredProcess {
+                output_tx,
+                status: Arc::clone(&status),
+            },
+        );
+
+        let (writer_tx, mut writer_rx) = mpsc::channel::<Vec<u8>>(128);
+        let client = self.clone();
+        let write_process_id = process_id.clone();
+        tokio::spawn(async move {
+            while let Some(chunk) = writer_rx.recv().await {
+                let request = WriteParams {
+                    process_id: write_process_id.clone(),
+                    chunk: chunk.into(),
+                };
+                if client.write_process(request).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        let response = match self.request::<_, ExecResponse>(EXEC_METHOD, &params).await {
+            Ok(response) => response,
+            Err(err) => {
+                self.inner.processes.lock().await.remove(&process_id);
+                return Err(err);
+            }
+        };
+
+        if let Some(exit_code) = response.exit_code {
+            status.mark_exited(Some(exit_code));
+        }
+
+        Ok(ExecServerProcess {
+            process_id,
+            output_rx,
+            writer_tx,
+            status,
+            client: self.clone(),
+        })
+    }
+
+    async fn initialize(&self) -> Result<(), ExecServerError> {
+        let _: InitializeResponse = self
+            .request(
+                INITIALIZE_METHOD,
+                &InitializeParams {
+                    client_name: "codex-core".to_string(),
+                },
+            )
+            .await?;
+        self.notify(INITIALIZED_METHOD, &serde_json::json!({}))
+            .await
+    }
+
+    async fn write_process(&self, params: WriteParams) -> Result<WriteResponse, ExecServerError> {
+        self.request(EXEC_WRITE_METHOD, &params).await
+    }
+
+    async fn terminate_process(
+        &self,
+        process_id: &str,
+    ) -> Result<TerminateResponse, ExecServerError> {
+        self.request(
+            EXEC_TERMINATE_METHOD,
+            &TerminateParams {
+                process_id: process_id.to_string(),
+            },
+        )
+        .await
+    }
+
+    async fn notify<P: Serialize>(&self, method: &str, params: &P) -> Result<(), ExecServerError> {
+        let params = serde_json::to_value(params)?;
+        self.inner
+            .write_tx
+            .send(JSONRPCMessage::Notification(JSONRPCNotification {
+                method: method.to_string(),
+                params: Some(params),
+            }))
+            .map_err(|_| ExecServerError::Closed)
+    }
+
+    async fn request<P, R>(&self, method: &str, params: &P) -> Result<R, ExecServerError>
+    where
+        P: Serialize,
+        R: DeserializeOwned,
+    {
+        let request_id =
+            RequestId::Integer(self.inner.next_request_id.fetch_add(1, Ordering::SeqCst));
+        let (response_tx, response_rx) = oneshot::channel();
+        self.inner
+            .pending
+            .lock()
+            .await
+            .insert(request_id.clone(), response_tx);
+
+        let params = serde_json::to_value(params)?;
+        let message = JSONRPCMessage::Request(JSONRPCRequest {
+            id: request_id.clone(),
+            method: method.to_string(),
+            params: Some(params),
+            trace: None,
+        });
+
+        if self.inner.write_tx.send(message).is_err() {
+            self.inner.pending.lock().await.remove(&request_id);
+            return Err(ExecServerError::Closed);
+        }
+
+        let result = response_rx.await.map_err(|_| ExecServerError::Closed)?;
+        match result {
+            Ok(value) => serde_json::from_value(value).map_err(ExecServerError::from),
+            Err(error) => Err(ExecServerError::Server {
+                code: error.code,
+                message: error.message,
+            }),
+        }
+    }
+}
+
+async fn handle_server_message(
+    inner: &Arc<Inner>,
+    message: JSONRPCMessage,
+) -> Result<(), ExecServerError> {
+    match message {
+        JSONRPCMessage::Response(JSONRPCResponse { id, result }) => {
+            if let Some(tx) = inner.pending.lock().await.remove(&id) {
+                let _ = tx.send(Ok(result));
+            }
+        }
+        JSONRPCMessage::Error(JSONRPCError { id, error }) => {
+            if let Some(tx) = inner.pending.lock().await.remove(&id) {
+                let _ = tx.send(Err(error));
+            }
+        }
+        JSONRPCMessage::Notification(notification) => {
+            handle_server_notification(inner, notification).await?;
+        }
+        JSONRPCMessage::Request(request) => {
+            return Err(ExecServerError::Protocol(format!(
+                "unexpected exec-server request from child: {}",
+                request.method
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+async fn handle_server_notification(
+    inner: &Arc<Inner>,
+    notification: JSONRPCNotification,
+) -> Result<(), ExecServerError> {
+    match notification.method.as_str() {
+        EXEC_OUTPUT_DELTA_METHOD => {
+            let params: ExecOutputDeltaNotification =
+                serde_json::from_value(notification.params.unwrap_or(Value::Null))?;
+            let chunk = params.chunk.into_inner();
+            let processes = inner.processes.lock().await;
+            if let Some(process) = processes.get(&params.process_id) {
+                let _ = process.output_tx.send(chunk);
+            }
+        }
+        EXEC_EXITED_METHOD => {
+            let params: ExecExitedNotification =
+                serde_json::from_value(notification.params.unwrap_or(Value::Null))?;
+            let mut processes = inner.processes.lock().await;
+            if let Some(process) = processes.remove(&params.process_id) {
+                process.status.mark_exited(Some(params.exit_code));
+            }
+        }
+        other => {
+            debug!("ignoring unknown exec-server notification: {other}");
+        }
+    }
+    Ok(())
+}
+
+async fn handle_transport_shutdown(inner: &Arc<Inner>) {
+    let pending = {
+        let mut pending = inner.pending.lock().await;
+        pending.drain().map(|(_, tx)| tx).collect::<Vec<_>>()
+    };
+    for tx in pending {
+        let _ = tx.send(Err(JSONRPCErrorError {
+            code: -32000,
+            data: None,
+            message: "exec-server transport closed".to_string(),
+        }));
+    }
+
+    let processes = {
+        let mut processes = inner.processes.lock().await;
+        processes
+            .drain()
+            .map(|(_, process)| process)
+            .collect::<Vec<_>>()
+    };
+    for process in processes {
+        process.status.mark_exited(None);
+    }
+}

--- a/codex-rs/exec-server/src/lib.rs
+++ b/codex-rs/exec-server/src/lib.rs
@@ -1,20 +1,11 @@
 mod client;
 mod protocol;
 mod server;
+mod server_process;
 
 pub use client::ExecServerClient;
 pub use client::ExecServerError;
-pub use client::ExecServerLaunchCommand;
-pub use client::ExecServerProcess;
-pub use protocol::ExecExitedNotification;
-pub use protocol::ExecOutputDeltaNotification;
-pub use protocol::ExecOutputStream;
-pub use protocol::ExecParams;
-pub use protocol::ExecResponse;
 pub use protocol::InitializeParams;
 pub use protocol::InitializeResponse;
-pub use protocol::TerminateParams;
-pub use protocol::TerminateResponse;
-pub use protocol::WriteParams;
-pub use protocol::WriteResponse;
 pub use server::run_main;
+pub use server_process::ExecServerLaunchCommand;

--- a/codex-rs/exec-server/src/lib.rs
+++ b/codex-rs/exec-server/src/lib.rs
@@ -1,0 +1,20 @@
+mod client;
+mod protocol;
+mod server;
+
+pub use client::ExecServerClient;
+pub use client::ExecServerError;
+pub use client::ExecServerLaunchCommand;
+pub use client::ExecServerProcess;
+pub use protocol::ExecExitedNotification;
+pub use protocol::ExecOutputDeltaNotification;
+pub use protocol::ExecOutputStream;
+pub use protocol::ExecParams;
+pub use protocol::ExecResponse;
+pub use protocol::InitializeParams;
+pub use protocol::InitializeResponse;
+pub use protocol::TerminateParams;
+pub use protocol::TerminateResponse;
+pub use protocol::WriteParams;
+pub use protocol::WriteResponse;
+pub use server::run_main;

--- a/codex-rs/exec-server/src/protocol.rs
+++ b/codex-rs/exec-server/src/protocol.rs
@@ -1,0 +1,143 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use codex_utils_pty::DEFAULT_OUTPUT_BYTES_CAP;
+use serde::Deserialize;
+use serde::Serialize;
+
+pub const INITIALIZE_METHOD: &str = "initialize";
+pub const INITIALIZED_METHOD: &str = "initialized";
+pub const EXEC_METHOD: &str = "command/exec";
+pub const EXEC_WRITE_METHOD: &str = "command/exec/write";
+pub const EXEC_TERMINATE_METHOD: &str = "command/exec/terminate";
+pub const EXEC_OUTPUT_DELTA_METHOD: &str = "command/exec/outputDelta";
+pub const EXEC_EXITED_METHOD: &str = "command/exec/exited";
+pub const PROTOCOL_VERSION: &str = "exec-server.v0";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ByteChunk(#[serde(with = "base64_bytes")] pub Vec<u8>);
+
+impl ByteChunk {
+    pub fn into_inner(self) -> Vec<u8> {
+        self.0
+    }
+}
+
+impl From<Vec<u8>> for ByteChunk {
+    fn from(value: Vec<u8>) -> Self {
+        Self(value)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InitializeParams {
+    pub client_name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InitializeResponse {
+    pub protocol_version: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExecParams {
+    pub process_id: String,
+    pub argv: Vec<String>,
+    pub cwd: PathBuf,
+    pub env: HashMap<String, String>,
+    pub tty: bool,
+    #[serde(default = "default_output_bytes_cap")]
+    pub output_bytes_cap: usize,
+    pub arg0: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExecResponse {
+    pub process_id: String,
+    pub running: bool,
+    pub exit_code: Option<i32>,
+    pub stdout: Option<ByteChunk>,
+    pub stderr: Option<ByteChunk>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WriteParams {
+    pub process_id: String,
+    pub chunk: ByteChunk,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WriteResponse {
+    pub accepted: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TerminateParams {
+    pub process_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TerminateResponse {
+    pub running: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ExecOutputStream {
+    Stdout,
+    Stderr,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExecOutputDeltaNotification {
+    pub process_id: String,
+    pub stream: ExecOutputStream,
+    pub chunk: ByteChunk,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExecExitedNotification {
+    pub process_id: String,
+    pub exit_code: i32,
+}
+
+fn default_output_bytes_cap() -> usize {
+    DEFAULT_OUTPUT_BYTES_CAP
+}
+
+mod base64_bytes {
+    use super::BASE64_STANDARD;
+    use base64::Engine as _;
+    use serde::Deserialize;
+    use serde::Deserializer;
+    use serde::Serializer;
+
+    pub fn serialize<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&BASE64_STANDARD.encode(bytes))
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let encoded = String::deserialize(deserializer)?;
+        BASE64_STANDARD
+            .decode(encoded)
+            .map_err(serde::de::Error::custom)
+    }
+}

--- a/codex-rs/exec-server/src/protocol.rs
+++ b/codex-rs/exec-server/src/protocol.rs
@@ -1,35 +1,9 @@
-use std::collections::HashMap;
-use std::path::PathBuf;
-
-use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
-use codex_utils_pty::DEFAULT_OUTPUT_BYTES_CAP;
 use serde::Deserialize;
 use serde::Serialize;
 
 pub const INITIALIZE_METHOD: &str = "initialize";
 pub const INITIALIZED_METHOD: &str = "initialized";
-pub const EXEC_METHOD: &str = "command/exec";
-pub const EXEC_WRITE_METHOD: &str = "command/exec/write";
-pub const EXEC_TERMINATE_METHOD: &str = "command/exec/terminate";
-pub const EXEC_OUTPUT_DELTA_METHOD: &str = "command/exec/outputDelta";
-pub const EXEC_EXITED_METHOD: &str = "command/exec/exited";
 pub const PROTOCOL_VERSION: &str = "exec-server.v0";
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct ByteChunk(#[serde(with = "base64_bytes")] pub Vec<u8>);
-
-impl ByteChunk {
-    pub fn into_inner(self) -> Vec<u8> {
-        self.0
-    }
-}
-
-impl From<Vec<u8>> for ByteChunk {
-    fn from(value: Vec<u8>) -> Self {
-        Self(value)
-    }
-}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -41,103 +15,4 @@ pub struct InitializeParams {
 #[serde(rename_all = "camelCase")]
 pub struct InitializeResponse {
     pub protocol_version: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ExecParams {
-    pub process_id: String,
-    pub argv: Vec<String>,
-    pub cwd: PathBuf,
-    pub env: HashMap<String, String>,
-    pub tty: bool,
-    #[serde(default = "default_output_bytes_cap")]
-    pub output_bytes_cap: usize,
-    pub arg0: Option<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ExecResponse {
-    pub process_id: String,
-    pub running: bool,
-    pub exit_code: Option<i32>,
-    pub stdout: Option<ByteChunk>,
-    pub stderr: Option<ByteChunk>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct WriteParams {
-    pub process_id: String,
-    pub chunk: ByteChunk,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct WriteResponse {
-    pub accepted: bool,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TerminateParams {
-    pub process_id: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TerminateResponse {
-    pub running: bool,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub enum ExecOutputStream {
-    Stdout,
-    Stderr,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ExecOutputDeltaNotification {
-    pub process_id: String,
-    pub stream: ExecOutputStream,
-    pub chunk: ByteChunk,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ExecExitedNotification {
-    pub process_id: String,
-    pub exit_code: i32,
-}
-
-fn default_output_bytes_cap() -> usize {
-    DEFAULT_OUTPUT_BYTES_CAP
-}
-
-mod base64_bytes {
-    use super::BASE64_STANDARD;
-    use base64::Engine as _;
-    use serde::Deserialize;
-    use serde::Deserializer;
-    use serde::Serializer;
-
-    pub fn serialize<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(&BASE64_STANDARD.encode(bytes))
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let encoded = String::deserialize(deserializer)?;
-        BASE64_STANDARD
-            .decode(encoded)
-            .map_err(serde::de::Error::custom)
-    }
 }

--- a/codex-rs/exec-server/src/server.rs
+++ b/codex-rs/exec-server/src/server.rs
@@ -1,122 +1,62 @@
-use std::collections::HashMap;
-use std::collections::VecDeque;
-use std::sync::Arc;
-use std::sync::Mutex as StdMutex;
-
 use codex_app_server_protocol::JSONRPCError;
 use codex_app_server_protocol::JSONRPCErrorError;
 use codex_app_server_protocol::JSONRPCMessage;
-use codex_app_server_protocol::JSONRPCNotification;
 use codex_app_server_protocol::JSONRPCRequest;
 use codex_app_server_protocol::JSONRPCResponse;
 use codex_app_server_protocol::RequestId;
-use codex_utils_pty::ExecCommandSession;
-use codex_utils_pty::TerminalSize;
-use serde::Serialize;
 use tokio::io::AsyncBufReadExt;
 use tokio::io::AsyncWriteExt;
 use tokio::io::BufReader;
-use tokio::io::BufWriter;
-use tokio::sync::Mutex;
 
-use crate::protocol::EXEC_EXITED_METHOD;
-use crate::protocol::EXEC_METHOD;
-use crate::protocol::EXEC_OUTPUT_DELTA_METHOD;
-use crate::protocol::EXEC_TERMINATE_METHOD;
-use crate::protocol::EXEC_WRITE_METHOD;
-use crate::protocol::ExecExitedNotification;
-use crate::protocol::ExecOutputDeltaNotification;
-use crate::protocol::ExecOutputStream;
-use crate::protocol::ExecParams;
-use crate::protocol::ExecResponse;
 use crate::protocol::INITIALIZE_METHOD;
 use crate::protocol::INITIALIZED_METHOD;
 use crate::protocol::InitializeResponse;
 use crate::protocol::PROTOCOL_VERSION;
-use crate::protocol::TerminateParams;
-use crate::protocol::TerminateResponse;
-use crate::protocol::WriteParams;
-use crate::protocol::WriteResponse;
-
-struct RunningProcess {
-    session: ExecCommandSession,
-    tty: bool,
-    stdout_buffer: Arc<StdMutex<BoundedBytesBuffer>>,
-    stderr_buffer: Arc<StdMutex<BoundedBytesBuffer>>,
-}
-
-#[derive(Debug)]
-struct BoundedBytesBuffer {
-    max_bytes: usize,
-    bytes: VecDeque<u8>,
-}
-
-impl BoundedBytesBuffer {
-    fn new(max_bytes: usize) -> Self {
-        Self {
-            max_bytes,
-            bytes: VecDeque::with_capacity(max_bytes.min(8192)),
-        }
-    }
-
-    fn push_chunk(&mut self, chunk: &[u8]) {
-        if self.max_bytes == 0 {
-            return;
-        }
-        for byte in chunk {
-            self.bytes.push_back(*byte);
-            if self.bytes.len() > self.max_bytes {
-                self.bytes.pop_front();
-            }
-        }
-    }
-
-    fn snapshot(&self) -> Vec<u8> {
-        self.bytes.iter().copied().collect()
-    }
-}
 
 pub async fn run_main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let writer = Arc::new(Mutex::new(BufWriter::new(tokio::io::stdout())));
-    let processes = Arc::new(Mutex::new(HashMap::<String, RunningProcess>::new()));
-    let mut lines = BufReader::new(tokio::io::stdin()).lines();
+    let mut stdin = BufReader::new(tokio::io::stdin()).lines();
+    let mut stdout = tokio::io::stdout();
 
-    while let Some(line) = lines.next_line().await? {
+    while let Some(line) = stdin.next_line().await? {
         if line.trim().is_empty() {
             continue;
         }
 
         let message = serde_json::from_str::<JSONRPCMessage>(&line)?;
-        if let JSONRPCMessage::Request(request) = message {
-            handle_request(request, &writer, &processes).await;
-            continue;
-        }
-
-        if let JSONRPCMessage::Notification(notification) = message {
-            if notification.method != INITIALIZED_METHOD {
-                send_error(
-                    &writer,
-                    RequestId::Integer(-1),
-                    invalid_request(format!(
-                        "unexpected notification method: {}",
-                        notification.method
-                    )),
-                )
-                .await;
+        match message {
+            JSONRPCMessage::Request(request) => {
+                handle_request(request, &mut stdout).await?;
             }
-            continue;
+            JSONRPCMessage::Notification(notification) => {
+                if notification.method != INITIALIZED_METHOD {
+                    send_error(
+                        &mut stdout,
+                        RequestId::Integer(-1),
+                        invalid_request(format!(
+                            "unexpected notification method: {}",
+                            notification.method
+                        )),
+                    )
+                    .await?;
+                }
+            }
+            JSONRPCMessage::Response(response) => {
+                send_error(
+                    &mut stdout,
+                    response.id,
+                    invalid_request("unexpected response from client".to_string()),
+                )
+                .await?;
+            }
+            JSONRPCMessage::Error(error) => {
+                send_error(
+                    &mut stdout,
+                    error.id,
+                    invalid_request("unexpected error from client".to_string()),
+                )
+                .await?;
+            }
         }
-    }
-
-    let remaining = {
-        let mut processes = processes.lock().await;
-        processes
-            .drain()
-            .map(|(_, process)| process)
-            .collect::<Vec<_>>()
-    };
-    for process in remaining {
-        process.session.terminate();
     }
 
     Ok(())
@@ -124,297 +64,74 @@ pub async fn run_main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> 
 
 async fn handle_request(
     request: JSONRPCRequest,
-    writer: &Arc<Mutex<BufWriter<tokio::io::Stdout>>>,
-    processes: &Arc<Mutex<HashMap<String, RunningProcess>>>,
-) {
-    let response = match request.method.as_str() {
-        INITIALIZE_METHOD => serde_json::to_value(InitializeResponse {
-            protocol_version: PROTOCOL_VERSION.to_string(),
-        })
-        .map_err(|err| internal_error(err.to_string())),
-        EXEC_METHOD => handle_exec_request(request.params, writer, processes).await,
-        EXEC_WRITE_METHOD => handle_write_request(request.params, processes).await,
-        EXEC_TERMINATE_METHOD => handle_terminate_request(request.params, processes).await,
-        other => Err(invalid_request(format!("unknown method: {other}"))),
-    };
+    stdout: &mut tokio::io::Stdout,
+) -> Result<(), std::io::Error> {
+    match request.method.as_str() {
+        INITIALIZE_METHOD => {
+            let result = serde_json::to_value(InitializeResponse {
+                protocol_version: PROTOCOL_VERSION.to_string(),
+            })
+            .map_err(std::io::Error::other)?;
 
-    match response {
-        Ok(result) => {
             send_response(
-                writer,
+                stdout,
                 JSONRPCResponse {
                     id: request.id,
                     result,
                 },
             )
-            .await;
-        }
-        Err(err) => {
-            send_error(writer, request.id, err).await;
-        }
-    }
-}
-
-async fn handle_exec_request(
-    params: Option<serde_json::Value>,
-    writer: &Arc<Mutex<BufWriter<tokio::io::Stdout>>>,
-    processes: &Arc<Mutex<HashMap<String, RunningProcess>>>,
-) -> Result<serde_json::Value, JSONRPCErrorError> {
-    let params: ExecParams = serde_json::from_value(params.unwrap_or(serde_json::Value::Null))
-        .map_err(|err| invalid_params(err.to_string()))?;
-
-    let (program, args) = params
-        .argv
-        .split_first()
-        .ok_or_else(|| invalid_params("argv must not be empty".to_string()))?;
-
-    let spawned = if params.tty {
-        codex_utils_pty::spawn_pty_process(
-            program,
-            args,
-            params.cwd.as_path(),
-            &params.env,
-            &params.arg0,
-            TerminalSize::default(),
-        )
-        .await
-    } else {
-        codex_utils_pty::spawn_pipe_process_no_stdin(
-            program,
-            args,
-            params.cwd.as_path(),
-            &params.env,
-            &params.arg0,
-        )
-        .await
-    }
-    .map_err(|err| internal_error(err.to_string()))?;
-
-    let stdout_buffer = Arc::new(StdMutex::new(BoundedBytesBuffer::new(
-        params.output_bytes_cap,
-    )));
-    let stderr_buffer = Arc::new(StdMutex::new(BoundedBytesBuffer::new(
-        params.output_bytes_cap,
-    )));
-
-    let process_id = params.process_id.clone();
-    {
-        let mut process_map = processes.lock().await;
-        if process_map.contains_key(&process_id) {
-            spawned.session.terminate();
-            return Err(invalid_request(format!(
-                "process {} already exists",
-                params.process_id
-            )));
-        }
-        process_map.insert(
-            process_id.clone(),
-            RunningProcess {
-                session: spawned.session,
-                tty: params.tty,
-                stdout_buffer: Arc::clone(&stdout_buffer),
-                stderr_buffer: Arc::clone(&stderr_buffer),
-            },
-        );
-    }
-
-    tokio::spawn(stream_output(
-        process_id.clone(),
-        ExecOutputStream::Stdout,
-        spawned.stdout_rx,
-        Arc::clone(writer),
-        Arc::clone(&stdout_buffer),
-    ));
-    tokio::spawn(stream_output(
-        process_id.clone(),
-        ExecOutputStream::Stderr,
-        spawned.stderr_rx,
-        Arc::clone(writer),
-        Arc::clone(&stderr_buffer),
-    ));
-    tokio::spawn(watch_exit(
-        process_id.clone(),
-        spawned.exit_rx,
-        Arc::clone(writer),
-        Arc::clone(processes),
-    ));
-
-    serde_json::to_value(ExecResponse {
-        process_id,
-        running: true,
-        exit_code: None,
-        stdout: None,
-        stderr: None,
-    })
-    .map_err(|err| internal_error(err.to_string()))
-}
-
-async fn handle_write_request(
-    params: Option<serde_json::Value>,
-    processes: &Arc<Mutex<HashMap<String, RunningProcess>>>,
-) -> Result<serde_json::Value, JSONRPCErrorError> {
-    let params: WriteParams = serde_json::from_value(params.unwrap_or(serde_json::Value::Null))
-        .map_err(|err| invalid_params(err.to_string()))?;
-
-    let writer_tx = {
-        let process_map = processes.lock().await;
-        let process = process_map
-            .get(&params.process_id)
-            .ok_or_else(|| invalid_request(format!("unknown process id {}", params.process_id)))?;
-        if !process.tty {
-            return Err(invalid_request(format!(
-                "stdin is closed for process {}",
-                params.process_id
-            )));
-        }
-        process.session.writer_sender()
-    };
-
-    writer_tx
-        .send(params.chunk.into_inner())
-        .await
-        .map_err(|_| internal_error("failed to write to process stdin".to_string()))?;
-
-    serde_json::to_value(WriteResponse { accepted: true })
-        .map_err(|err| internal_error(err.to_string()))
-}
-
-async fn handle_terminate_request(
-    params: Option<serde_json::Value>,
-    processes: &Arc<Mutex<HashMap<String, RunningProcess>>>,
-) -> Result<serde_json::Value, JSONRPCErrorError> {
-    let params: TerminateParams = serde_json::from_value(params.unwrap_or(serde_json::Value::Null))
-        .map_err(|err| invalid_params(err.to_string()))?;
-
-    let process = {
-        let mut process_map = processes.lock().await;
-        process_map.remove(&params.process_id)
-    };
-
-    if let Some(process) = process {
-        process.session.terminate();
-        serde_json::to_value(TerminateResponse { running: true })
-            .map_err(|err| internal_error(err.to_string()))
-    } else {
-        serde_json::to_value(TerminateResponse { running: false })
-            .map_err(|err| internal_error(err.to_string()))
-    }
-}
-
-async fn stream_output(
-    process_id: String,
-    stream: ExecOutputStream,
-    mut receiver: tokio::sync::mpsc::Receiver<Vec<u8>>,
-    writer: Arc<Mutex<BufWriter<tokio::io::Stdout>>>,
-    buffer: Arc<StdMutex<BoundedBytesBuffer>>,
-) {
-    while let Some(chunk) = receiver.recv().await {
-        if let Ok(mut guard) = buffer.lock() {
-            guard.push_chunk(&chunk);
-        }
-        let notification = ExecOutputDeltaNotification {
-            process_id: process_id.clone(),
-            stream,
-            chunk: chunk.into(),
-        };
-        if send_notification(&writer, EXEC_OUTPUT_DELTA_METHOD, &notification)
             .await
-            .is_err()
-        {
-            break;
+        }
+        method => {
+            send_error(
+                stdout,
+                request.id,
+                method_not_implemented(format!(
+                    "exec-server stub does not implement `{method}` yet"
+                )),
+            )
+            .await
         }
     }
-}
-
-async fn watch_exit(
-    process_id: String,
-    exit_rx: tokio::sync::oneshot::Receiver<i32>,
-    writer: Arc<Mutex<BufWriter<tokio::io::Stdout>>>,
-    processes: Arc<Mutex<HashMap<String, RunningProcess>>>,
-) {
-    let exit_code = exit_rx.await.unwrap_or(-1);
-    let removed = {
-        let mut processes = processes.lock().await;
-        processes.remove(&process_id)
-    };
-    if let Some(process) = removed {
-        let _ = process.stdout_buffer.lock().map(|buffer| buffer.snapshot());
-        let _ = process.stderr_buffer.lock().map(|buffer| buffer.snapshot());
-    }
-    let _ = send_notification(
-        &writer,
-        EXEC_EXITED_METHOD,
-        &ExecExitedNotification {
-            process_id,
-            exit_code,
-        },
-    )
-    .await;
 }
 
 async fn send_response(
-    writer: &Arc<Mutex<BufWriter<tokio::io::Stdout>>>,
+    stdout: &mut tokio::io::Stdout,
     response: JSONRPCResponse,
-) {
-    let _ = send_message(writer, JSONRPCMessage::Response(response)).await;
+) -> Result<(), std::io::Error> {
+    send_message(stdout, &JSONRPCMessage::Response(response)).await
 }
 
 async fn send_error(
-    writer: &Arc<Mutex<BufWriter<tokio::io::Stdout>>>,
+    stdout: &mut tokio::io::Stdout,
     id: RequestId,
     error: JSONRPCErrorError,
-) {
-    let _ = send_message(writer, JSONRPCMessage::Error(JSONRPCError { error, id })).await;
-}
-
-async fn send_notification<T: Serialize>(
-    writer: &Arc<Mutex<BufWriter<tokio::io::Stdout>>>,
-    method: &str,
-    params: &T,
-) -> Result<(), serde_json::Error> {
-    send_message(
-        writer,
-        JSONRPCMessage::Notification(JSONRPCNotification {
-            method: method.to_string(),
-            params: Some(serde_json::to_value(params)?),
-        }),
-    )
-    .await
-    .map_err(serde_json::Error::io)
+) -> Result<(), std::io::Error> {
+    send_message(stdout, &JSONRPCMessage::Error(JSONRPCError { id, error })).await
 }
 
 async fn send_message(
-    writer: &Arc<Mutex<BufWriter<tokio::io::Stdout>>>,
-    message: JSONRPCMessage,
-) -> std::io::Result<()> {
-    let encoded =
-        serde_json::to_vec(&message).map_err(|err| std::io::Error::other(err.to_string()))?;
-    let mut writer = writer.lock().await;
-    writer.write_all(&encoded).await?;
-    writer.write_all(b"\n").await?;
-    writer.flush().await
+    stdout: &mut tokio::io::Stdout,
+    message: &JSONRPCMessage,
+) -> Result<(), std::io::Error> {
+    let encoded = serde_json::to_vec(message).map_err(std::io::Error::other)?;
+    stdout.write_all(&encoded).await?;
+    stdout.write_all(b"\n").await?;
+    stdout.flush().await
 }
 
 fn invalid_request(message: String) -> JSONRPCErrorError {
     JSONRPCErrorError {
         code: -32600,
-        data: None,
         message,
+        data: None,
     }
 }
 
-fn invalid_params(message: String) -> JSONRPCErrorError {
+fn method_not_implemented(message: String) -> JSONRPCErrorError {
     JSONRPCErrorError {
-        code: -32602,
-        data: None,
+        code: -32601,
         message,
-    }
-}
-
-fn internal_error(message: String) -> JSONRPCErrorError {
-    JSONRPCErrorError {
-        code: -32603,
         data: None,
-        message,
     }
 }

--- a/codex-rs/exec-server/src/server.rs
+++ b/codex-rs/exec-server/src/server.rs
@@ -1,0 +1,420 @@
+use std::collections::HashMap;
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+
+use codex_app_server_protocol::JSONRPCError;
+use codex_app_server_protocol::JSONRPCErrorError;
+use codex_app_server_protocol::JSONRPCMessage;
+use codex_app_server_protocol::JSONRPCNotification;
+use codex_app_server_protocol::JSONRPCRequest;
+use codex_app_server_protocol::JSONRPCResponse;
+use codex_app_server_protocol::RequestId;
+use codex_utils_pty::ExecCommandSession;
+use codex_utils_pty::TerminalSize;
+use serde::Serialize;
+use tokio::io::AsyncBufReadExt;
+use tokio::io::AsyncWriteExt;
+use tokio::io::BufReader;
+use tokio::io::BufWriter;
+use tokio::sync::Mutex;
+
+use crate::protocol::EXEC_EXITED_METHOD;
+use crate::protocol::EXEC_METHOD;
+use crate::protocol::EXEC_OUTPUT_DELTA_METHOD;
+use crate::protocol::EXEC_TERMINATE_METHOD;
+use crate::protocol::EXEC_WRITE_METHOD;
+use crate::protocol::ExecExitedNotification;
+use crate::protocol::ExecOutputDeltaNotification;
+use crate::protocol::ExecOutputStream;
+use crate::protocol::ExecParams;
+use crate::protocol::ExecResponse;
+use crate::protocol::INITIALIZE_METHOD;
+use crate::protocol::INITIALIZED_METHOD;
+use crate::protocol::InitializeResponse;
+use crate::protocol::PROTOCOL_VERSION;
+use crate::protocol::TerminateParams;
+use crate::protocol::TerminateResponse;
+use crate::protocol::WriteParams;
+use crate::protocol::WriteResponse;
+
+struct RunningProcess {
+    session: ExecCommandSession,
+    tty: bool,
+    stdout_buffer: Arc<StdMutex<BoundedBytesBuffer>>,
+    stderr_buffer: Arc<StdMutex<BoundedBytesBuffer>>,
+}
+
+#[derive(Debug)]
+struct BoundedBytesBuffer {
+    max_bytes: usize,
+    bytes: VecDeque<u8>,
+}
+
+impl BoundedBytesBuffer {
+    fn new(max_bytes: usize) -> Self {
+        Self {
+            max_bytes,
+            bytes: VecDeque::with_capacity(max_bytes.min(8192)),
+        }
+    }
+
+    fn push_chunk(&mut self, chunk: &[u8]) {
+        if self.max_bytes == 0 {
+            return;
+        }
+        for byte in chunk {
+            self.bytes.push_back(*byte);
+            if self.bytes.len() > self.max_bytes {
+                self.bytes.pop_front();
+            }
+        }
+    }
+
+    fn snapshot(&self) -> Vec<u8> {
+        self.bytes.iter().copied().collect()
+    }
+}
+
+pub async fn run_main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let writer = Arc::new(Mutex::new(BufWriter::new(tokio::io::stdout())));
+    let processes = Arc::new(Mutex::new(HashMap::<String, RunningProcess>::new()));
+    let mut lines = BufReader::new(tokio::io::stdin()).lines();
+
+    while let Some(line) = lines.next_line().await? {
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let message = serde_json::from_str::<JSONRPCMessage>(&line)?;
+        if let JSONRPCMessage::Request(request) = message {
+            handle_request(request, &writer, &processes).await;
+            continue;
+        }
+
+        if let JSONRPCMessage::Notification(notification) = message {
+            if notification.method != INITIALIZED_METHOD {
+                send_error(
+                    &writer,
+                    RequestId::Integer(-1),
+                    invalid_request(format!(
+                        "unexpected notification method: {}",
+                        notification.method
+                    )),
+                )
+                .await;
+            }
+            continue;
+        }
+    }
+
+    let remaining = {
+        let mut processes = processes.lock().await;
+        processes
+            .drain()
+            .map(|(_, process)| process)
+            .collect::<Vec<_>>()
+    };
+    for process in remaining {
+        process.session.terminate();
+    }
+
+    Ok(())
+}
+
+async fn handle_request(
+    request: JSONRPCRequest,
+    writer: &Arc<Mutex<BufWriter<tokio::io::Stdout>>>,
+    processes: &Arc<Mutex<HashMap<String, RunningProcess>>>,
+) {
+    let response = match request.method.as_str() {
+        INITIALIZE_METHOD => serde_json::to_value(InitializeResponse {
+            protocol_version: PROTOCOL_VERSION.to_string(),
+        })
+        .map_err(|err| internal_error(err.to_string())),
+        EXEC_METHOD => handle_exec_request(request.params, writer, processes).await,
+        EXEC_WRITE_METHOD => handle_write_request(request.params, processes).await,
+        EXEC_TERMINATE_METHOD => handle_terminate_request(request.params, processes).await,
+        other => Err(invalid_request(format!("unknown method: {other}"))),
+    };
+
+    match response {
+        Ok(result) => {
+            send_response(
+                writer,
+                JSONRPCResponse {
+                    id: request.id,
+                    result,
+                },
+            )
+            .await;
+        }
+        Err(err) => {
+            send_error(writer, request.id, err).await;
+        }
+    }
+}
+
+async fn handle_exec_request(
+    params: Option<serde_json::Value>,
+    writer: &Arc<Mutex<BufWriter<tokio::io::Stdout>>>,
+    processes: &Arc<Mutex<HashMap<String, RunningProcess>>>,
+) -> Result<serde_json::Value, JSONRPCErrorError> {
+    let params: ExecParams = serde_json::from_value(params.unwrap_or(serde_json::Value::Null))
+        .map_err(|err| invalid_params(err.to_string()))?;
+
+    let (program, args) = params
+        .argv
+        .split_first()
+        .ok_or_else(|| invalid_params("argv must not be empty".to_string()))?;
+
+    let spawned = if params.tty {
+        codex_utils_pty::spawn_pty_process(
+            program,
+            args,
+            params.cwd.as_path(),
+            &params.env,
+            &params.arg0,
+            TerminalSize::default(),
+        )
+        .await
+    } else {
+        codex_utils_pty::spawn_pipe_process_no_stdin(
+            program,
+            args,
+            params.cwd.as_path(),
+            &params.env,
+            &params.arg0,
+        )
+        .await
+    }
+    .map_err(|err| internal_error(err.to_string()))?;
+
+    let stdout_buffer = Arc::new(StdMutex::new(BoundedBytesBuffer::new(
+        params.output_bytes_cap,
+    )));
+    let stderr_buffer = Arc::new(StdMutex::new(BoundedBytesBuffer::new(
+        params.output_bytes_cap,
+    )));
+
+    let process_id = params.process_id.clone();
+    {
+        let mut process_map = processes.lock().await;
+        if process_map.contains_key(&process_id) {
+            spawned.session.terminate();
+            return Err(invalid_request(format!(
+                "process {} already exists",
+                params.process_id
+            )));
+        }
+        process_map.insert(
+            process_id.clone(),
+            RunningProcess {
+                session: spawned.session,
+                tty: params.tty,
+                stdout_buffer: Arc::clone(&stdout_buffer),
+                stderr_buffer: Arc::clone(&stderr_buffer),
+            },
+        );
+    }
+
+    tokio::spawn(stream_output(
+        process_id.clone(),
+        ExecOutputStream::Stdout,
+        spawned.stdout_rx,
+        Arc::clone(writer),
+        Arc::clone(&stdout_buffer),
+    ));
+    tokio::spawn(stream_output(
+        process_id.clone(),
+        ExecOutputStream::Stderr,
+        spawned.stderr_rx,
+        Arc::clone(writer),
+        Arc::clone(&stderr_buffer),
+    ));
+    tokio::spawn(watch_exit(
+        process_id.clone(),
+        spawned.exit_rx,
+        Arc::clone(writer),
+        Arc::clone(processes),
+    ));
+
+    serde_json::to_value(ExecResponse {
+        process_id,
+        running: true,
+        exit_code: None,
+        stdout: None,
+        stderr: None,
+    })
+    .map_err(|err| internal_error(err.to_string()))
+}
+
+async fn handle_write_request(
+    params: Option<serde_json::Value>,
+    processes: &Arc<Mutex<HashMap<String, RunningProcess>>>,
+) -> Result<serde_json::Value, JSONRPCErrorError> {
+    let params: WriteParams = serde_json::from_value(params.unwrap_or(serde_json::Value::Null))
+        .map_err(|err| invalid_params(err.to_string()))?;
+
+    let writer_tx = {
+        let process_map = processes.lock().await;
+        let process = process_map
+            .get(&params.process_id)
+            .ok_or_else(|| invalid_request(format!("unknown process id {}", params.process_id)))?;
+        if !process.tty {
+            return Err(invalid_request(format!(
+                "stdin is closed for process {}",
+                params.process_id
+            )));
+        }
+        process.session.writer_sender()
+    };
+
+    writer_tx
+        .send(params.chunk.into_inner())
+        .await
+        .map_err(|_| internal_error("failed to write to process stdin".to_string()))?;
+
+    serde_json::to_value(WriteResponse { accepted: true })
+        .map_err(|err| internal_error(err.to_string()))
+}
+
+async fn handle_terminate_request(
+    params: Option<serde_json::Value>,
+    processes: &Arc<Mutex<HashMap<String, RunningProcess>>>,
+) -> Result<serde_json::Value, JSONRPCErrorError> {
+    let params: TerminateParams = serde_json::from_value(params.unwrap_or(serde_json::Value::Null))
+        .map_err(|err| invalid_params(err.to_string()))?;
+
+    let process = {
+        let mut process_map = processes.lock().await;
+        process_map.remove(&params.process_id)
+    };
+
+    if let Some(process) = process {
+        process.session.terminate();
+        serde_json::to_value(TerminateResponse { running: true })
+            .map_err(|err| internal_error(err.to_string()))
+    } else {
+        serde_json::to_value(TerminateResponse { running: false })
+            .map_err(|err| internal_error(err.to_string()))
+    }
+}
+
+async fn stream_output(
+    process_id: String,
+    stream: ExecOutputStream,
+    mut receiver: tokio::sync::mpsc::Receiver<Vec<u8>>,
+    writer: Arc<Mutex<BufWriter<tokio::io::Stdout>>>,
+    buffer: Arc<StdMutex<BoundedBytesBuffer>>,
+) {
+    while let Some(chunk) = receiver.recv().await {
+        if let Ok(mut guard) = buffer.lock() {
+            guard.push_chunk(&chunk);
+        }
+        let notification = ExecOutputDeltaNotification {
+            process_id: process_id.clone(),
+            stream,
+            chunk: chunk.into(),
+        };
+        if send_notification(&writer, EXEC_OUTPUT_DELTA_METHOD, &notification)
+            .await
+            .is_err()
+        {
+            break;
+        }
+    }
+}
+
+async fn watch_exit(
+    process_id: String,
+    exit_rx: tokio::sync::oneshot::Receiver<i32>,
+    writer: Arc<Mutex<BufWriter<tokio::io::Stdout>>>,
+    processes: Arc<Mutex<HashMap<String, RunningProcess>>>,
+) {
+    let exit_code = exit_rx.await.unwrap_or(-1);
+    let removed = {
+        let mut processes = processes.lock().await;
+        processes.remove(&process_id)
+    };
+    if let Some(process) = removed {
+        let _ = process.stdout_buffer.lock().map(|buffer| buffer.snapshot());
+        let _ = process.stderr_buffer.lock().map(|buffer| buffer.snapshot());
+    }
+    let _ = send_notification(
+        &writer,
+        EXEC_EXITED_METHOD,
+        &ExecExitedNotification {
+            process_id,
+            exit_code,
+        },
+    )
+    .await;
+}
+
+async fn send_response(
+    writer: &Arc<Mutex<BufWriter<tokio::io::Stdout>>>,
+    response: JSONRPCResponse,
+) {
+    let _ = send_message(writer, JSONRPCMessage::Response(response)).await;
+}
+
+async fn send_error(
+    writer: &Arc<Mutex<BufWriter<tokio::io::Stdout>>>,
+    id: RequestId,
+    error: JSONRPCErrorError,
+) {
+    let _ = send_message(writer, JSONRPCMessage::Error(JSONRPCError { error, id })).await;
+}
+
+async fn send_notification<T: Serialize>(
+    writer: &Arc<Mutex<BufWriter<tokio::io::Stdout>>>,
+    method: &str,
+    params: &T,
+) -> Result<(), serde_json::Error> {
+    send_message(
+        writer,
+        JSONRPCMessage::Notification(JSONRPCNotification {
+            method: method.to_string(),
+            params: Some(serde_json::to_value(params)?),
+        }),
+    )
+    .await
+    .map_err(serde_json::Error::io)
+}
+
+async fn send_message(
+    writer: &Arc<Mutex<BufWriter<tokio::io::Stdout>>>,
+    message: JSONRPCMessage,
+) -> std::io::Result<()> {
+    let encoded =
+        serde_json::to_vec(&message).map_err(|err| std::io::Error::other(err.to_string()))?;
+    let mut writer = writer.lock().await;
+    writer.write_all(&encoded).await?;
+    writer.write_all(b"\n").await?;
+    writer.flush().await
+}
+
+fn invalid_request(message: String) -> JSONRPCErrorError {
+    JSONRPCErrorError {
+        code: -32600,
+        data: None,
+        message,
+    }
+}
+
+fn invalid_params(message: String) -> JSONRPCErrorError {
+    JSONRPCErrorError {
+        code: -32602,
+        data: None,
+        message,
+    }
+}
+
+fn internal_error(message: String) -> JSONRPCErrorError {
+    JSONRPCErrorError {
+        code: -32603,
+        data: None,
+        message,
+    }
+}

--- a/codex-rs/exec-server/src/server_process.rs
+++ b/codex-rs/exec-server/src/server_process.rs
@@ -1,0 +1,46 @@
+use std::path::PathBuf;
+use std::process::Stdio;
+
+use tokio::process::Child;
+use tokio::process::ChildStdin;
+use tokio::process::ChildStdout;
+use tokio::process::Command;
+
+use crate::client::ExecServerError;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecServerLaunchCommand {
+    pub program: PathBuf,
+    pub args: Vec<String>,
+}
+
+pub(crate) struct SpawnedStdioExecServer {
+    pub(crate) child: Child,
+    pub(crate) stdin: ChildStdin,
+    pub(crate) stdout: ChildStdout,
+}
+
+pub(crate) fn spawn_stdio_exec_server(
+    command: ExecServerLaunchCommand,
+) -> Result<SpawnedStdioExecServer, ExecServerError> {
+    let mut child = Command::new(&command.program);
+    child.args(&command.args);
+    child.stdin(Stdio::piped());
+    child.stdout(Stdio::piped());
+    child.stderr(Stdio::inherit());
+    child.kill_on_drop(true);
+
+    let mut child = child.spawn().map_err(ExecServerError::Spawn)?;
+    let stdin = child.stdin.take().ok_or_else(|| {
+        ExecServerError::Protocol("exec-server stdin was not captured".to_string())
+    })?;
+    let stdout = child.stdout.take().ok_or_else(|| {
+        ExecServerError::Protocol("exec-server stdout was not captured".to_string())
+    })?;
+
+    Ok(SpawnedStdioExecServer {
+        child,
+        stdin,
+        stdout,
+    })
+}

--- a/codex-rs/exec-server/tests/stdio_smoke.rs
+++ b/codex-rs/exec-server/tests/stdio_smoke.rs
@@ -1,0 +1,141 @@
+#![cfg(unix)]
+
+use std::process::Stdio;
+use std::time::Duration;
+
+use codex_app_server_protocol::JSONRPCMessage;
+use codex_app_server_protocol::JSONRPCNotification;
+use codex_app_server_protocol::JSONRPCRequest;
+use codex_app_server_protocol::JSONRPCResponse;
+use codex_app_server_protocol::RequestId;
+use codex_exec_server::ExecParams;
+use codex_exec_server::ExecServerClient;
+use codex_exec_server::ExecServerLaunchCommand;
+use codex_exec_server::InitializeParams;
+use codex_exec_server::InitializeResponse;
+use codex_utils_cargo_bin::cargo_bin;
+use pretty_assertions::assert_eq;
+use tokio::io::AsyncBufReadExt;
+use tokio::io::AsyncWriteExt;
+use tokio::io::BufReader;
+use tokio::process::Command;
+use tokio::sync::broadcast;
+use tokio::time::timeout;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn exec_server_accepts_initialize_over_stdio() -> anyhow::Result<()> {
+    let binary = cargo_bin("codex-exec-server")?;
+    let mut child = Command::new(binary);
+    child.stdin(Stdio::piped());
+    child.stdout(Stdio::piped());
+    child.stderr(Stdio::inherit());
+    let mut child = child.spawn()?;
+
+    let mut stdin = child.stdin.take().expect("stdin");
+    let stdout = child.stdout.take().expect("stdout");
+    let mut stdout = BufReader::new(stdout).lines();
+
+    let initialize = JSONRPCMessage::Request(JSONRPCRequest {
+        id: RequestId::Integer(1),
+        method: "initialize".to_string(),
+        params: Some(serde_json::to_value(InitializeParams {
+            client_name: "exec-server-test".to_string(),
+        })?),
+        trace: None,
+    });
+    stdin
+        .write_all(format!("{}\n", serde_json::to_string(&initialize)?).as_bytes())
+        .await?;
+
+    let response_line = timeout(Duration::from_secs(5), stdout.next_line()).await??;
+    let response_line = response_line.expect("response line");
+    let response: JSONRPCMessage = serde_json::from_str(&response_line)?;
+    let JSONRPCMessage::Response(JSONRPCResponse { id, result }) = response else {
+        panic!("expected initialize response");
+    };
+    assert_eq!(id, RequestId::Integer(1));
+    let initialize_response: InitializeResponse = serde_json::from_value(result)?;
+    assert_eq!(initialize_response.protocol_version, "exec-server.v0");
+
+    let initialized = JSONRPCMessage::Notification(JSONRPCNotification {
+        method: "initialized".to_string(),
+        params: Some(serde_json::json!({})),
+    });
+    stdin
+        .write_all(format!("{}\n", serde_json::to_string(&initialized)?).as_bytes())
+        .await?;
+
+    child.start_kill()?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn exec_server_client_streams_output_and_accepts_writes() -> anyhow::Result<()> {
+    let mut env = std::collections::HashMap::new();
+    if let Some(path) = std::env::var_os("PATH") {
+        env.insert("PATH".to_string(), path.to_string_lossy().into_owned());
+    }
+
+    let client = ExecServerClient::spawn(ExecServerLaunchCommand {
+        program: cargo_bin("codex-exec-server")?,
+        args: Vec::new(),
+    })
+    .await?;
+
+    let process = client
+        .start_process(ExecParams {
+            process_id: "2001".to_string(),
+            argv: vec![
+                "bash".to_string(),
+                "-lc".to_string(),
+                "printf 'ready\\n'; while IFS= read -r line; do printf 'echo:%s\\n' \"$line\"; done"
+                    .to_string(),
+            ],
+            cwd: std::env::current_dir()?,
+            env,
+            tty: true,
+            output_bytes_cap: 4096,
+            arg0: None,
+        })
+        .await?;
+
+    let mut output = process.output_receiver();
+    assert!(
+        recv_until_contains(&mut output, "ready")
+            .await?
+            .contains("ready"),
+        "expected initial ready output"
+    );
+
+    process
+        .writer_sender()
+        .send(b"hello\n".to_vec())
+        .await
+        .expect("write should succeed");
+
+    assert!(
+        recv_until_contains(&mut output, "echo:hello")
+            .await?
+            .contains("echo:hello"),
+        "expected echoed output"
+    );
+
+    process.terminate();
+    Ok(())
+}
+
+async fn recv_until_contains(
+    output: &mut broadcast::Receiver<Vec<u8>>,
+    needle: &str,
+) -> anyhow::Result<String> {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let mut collected = String::new();
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        let chunk = timeout(remaining, output.recv()).await??;
+        collected.push_str(&String::from_utf8_lossy(&chunk));
+        if collected.contains(needle) {
+            return Ok(collected);
+        }
+    }
+}

--- a/codex-rs/exec-server/tests/stdio_smoke.rs
+++ b/codex-rs/exec-server/tests/stdio_smoke.rs
@@ -8,9 +8,6 @@ use codex_app_server_protocol::JSONRPCNotification;
 use codex_app_server_protocol::JSONRPCRequest;
 use codex_app_server_protocol::JSONRPCResponse;
 use codex_app_server_protocol::RequestId;
-use codex_exec_server::ExecParams;
-use codex_exec_server::ExecServerClient;
-use codex_exec_server::ExecServerLaunchCommand;
 use codex_exec_server::InitializeParams;
 use codex_exec_server::InitializeResponse;
 use codex_utils_cargo_bin::cargo_bin;
@@ -19,7 +16,6 @@ use tokio::io::AsyncBufReadExt;
 use tokio::io::AsyncWriteExt;
 use tokio::io::BufReader;
 use tokio::process::Command;
-use tokio::sync::broadcast;
 use tokio::time::timeout;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -70,72 +66,62 @@ async fn exec_server_accepts_initialize_over_stdio() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn exec_server_client_streams_output_and_accepts_writes() -> anyhow::Result<()> {
-    let mut env = std::collections::HashMap::new();
-    if let Some(path) = std::env::var_os("PATH") {
-        env.insert("PATH".to_string(), path.to_string_lossy().into_owned());
-    }
+async fn exec_server_stubs_command_exec_over_stdio() -> anyhow::Result<()> {
+    let binary = cargo_bin("codex-exec-server")?;
+    let mut child = Command::new(binary);
+    child.stdin(Stdio::piped());
+    child.stdout(Stdio::piped());
+    child.stderr(Stdio::inherit());
+    let mut child = child.spawn()?;
 
-    let client = ExecServerClient::spawn(ExecServerLaunchCommand {
-        program: cargo_bin("codex-exec-server")?,
-        args: Vec::new(),
-    })
-    .await?;
+    let mut stdin = child.stdin.take().expect("stdin");
+    let stdout = child.stdout.take().expect("stdout");
+    let mut stdout = BufReader::new(stdout).lines();
 
-    let process = client
-        .start_process(ExecParams {
-            process_id: "2001".to_string(),
-            argv: vec![
-                "bash".to_string(),
-                "-lc".to_string(),
-                "printf 'ready\\n'; while IFS= read -r line; do printf 'echo:%s\\n' \"$line\"; done"
-                    .to_string(),
-            ],
-            cwd: std::env::current_dir()?,
-            env,
-            tty: true,
-            output_bytes_cap: 4096,
-            arg0: None,
-        })
+    let initialize = JSONRPCMessage::Request(JSONRPCRequest {
+        id: RequestId::Integer(1),
+        method: "initialize".to_string(),
+        params: Some(serde_json::to_value(InitializeParams {
+            client_name: "exec-server-test".to_string(),
+        })?),
+        trace: None,
+    });
+    stdin
+        .write_all(format!("{}\n", serde_json::to_string(&initialize)?).as_bytes())
+        .await?;
+    let _ = timeout(Duration::from_secs(5), stdout.next_line()).await??;
+
+    let exec = JSONRPCMessage::Request(JSONRPCRequest {
+        id: RequestId::Integer(2),
+        method: "command/exec".to_string(),
+        params: Some(serde_json::json!({
+            "processId": "proc-1",
+            "argv": ["true"],
+            "cwd": std::env::current_dir()?,
+            "env": {},
+            "tty": false,
+            "arg0": null
+        })),
+        trace: None,
+    });
+    stdin
+        .write_all(format!("{}\n", serde_json::to_string(&exec)?).as_bytes())
         .await?;
 
-    let mut output = process.output_receiver();
-    assert!(
-        recv_until_contains(&mut output, "ready")
-            .await?
-            .contains("ready"),
-        "expected initial ready output"
+    let response_line = timeout(Duration::from_secs(5), stdout.next_line()).await??;
+    let response_line = response_line.expect("exec response line");
+    let response: JSONRPCMessage = serde_json::from_str(&response_line)?;
+    let JSONRPCMessage::Error(codex_app_server_protocol::JSONRPCError { id, error }) = response
+    else {
+        panic!("expected command/exec stub error");
+    };
+    assert_eq!(id, RequestId::Integer(2));
+    assert_eq!(error.code, -32601);
+    assert_eq!(
+        error.message,
+        "exec-server stub does not implement `command/exec` yet"
     );
 
-    process
-        .writer_sender()
-        .send(b"hello\n".to_vec())
-        .await
-        .expect("write should succeed");
-
-    assert!(
-        recv_until_contains(&mut output, "echo:hello")
-            .await?
-            .contains("echo:hello"),
-        "expected echoed output"
-    );
-
-    process.terminate();
+    child.start_kill()?;
     Ok(())
-}
-
-async fn recv_until_contains(
-    output: &mut broadcast::Receiver<Vec<u8>>,
-    needle: &str,
-) -> anyhow::Result<String> {
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
-    let mut collected = String::new();
-    loop {
-        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-        let chunk = timeout(remaining, output.recv()).await??;
-        collected.push_str(&String::from_utf8_lossy(&chunk));
-        if collected.contains(needle) {
-            return Ok(collected);
-        }
-    }
 }


### PR DESCRIPTION
## Summary

This PR adds the standalone `codex-exec-server` stdio JSON-RPC crate.

It includes:
- the `codex-exec-server` binary and Rust client
- smoke tests for stdio initialization, output streaming, and writes
- a crate-local README with the current transport, protocol, and API definition

It intentionally does not wire the crate into the CLI or unified-exec yet.

## Validation

- `cargo test -p codex-exec-server`
- `just bazel-lock-check`

## Notes

- The README documents the current wire protocol as implemented in this PR.
- The follow-up wiring into higher-level launch paths can land separately.
