### PR TITLE
fix: tighten up shell arg quoting in GitHub workflows

### DIFF
--- a/.github/actions/linux-code-sign/action.yml
+++ b/.github/actions/linux-code-sign/action.yml
@@ -17,6 +17,7 @@ runs:
     - name: Cosign Linux artifacts
       shell: bash
       env:
+        ARTIFACTS_DIR: ${{ inputs.artifacts-dir }}
         COSIGN_EXPERIMENTAL: "1"
         COSIGN_YES: "true"
         COSIGN_OIDC_CLIENT_ID: "sigstore"
@@ -24,7 +25,7 @@ runs:
       run: |
         set -euo pipefail
 
-        dest="${{ inputs.artifacts-dir }}"
+        dest="$ARTIFACTS_DIR"
         if [[ ! -d "$dest" ]]; then
           echo "Destination $dest does not exist"
           exit 1

--- a/.github/actions/macos-code-sign/action.yml
+++ b/.github/actions/macos-code-sign/action.yml
@@ -117,6 +117,8 @@ runs:
     - name: Sign macOS binaries
       if: ${{ inputs.sign-binaries == 'true' }}
       shell: bash
+      env:
+        TARGET: ${{ inputs.target }}
       run: |
         set -euo pipefail
 
@@ -131,7 +133,7 @@ runs:
         fi
 
         for binary in codex codex-responses-api-proxy; do
-          path="codex-rs/target/${{ inputs.target }}/release/${binary}"
+          path="codex-rs/target/${TARGET}/release/${binary}"
           codesign --force --options runtime --timestamp --sign "$APPLE_CODESIGN_IDENTITY" "${keychain_args[@]}" "$path"
         done
 
@@ -139,6 +141,7 @@ runs:
       if: ${{ inputs.sign-binaries == 'true' }}
       shell: bash
       env:
+        TARGET: ${{ inputs.target }}
         APPLE_NOTARIZATION_KEY_P8: ${{ inputs.apple-notarization-key-p8 }}
         APPLE_NOTARIZATION_KEY_ID: ${{ inputs.apple-notarization-key-id }}
         APPLE_NOTARIZATION_ISSUER_ID: ${{ inputs.apple-notarization-issuer-id }}
@@ -163,7 +166,7 @@ runs:
 
         notarize_binary() {
           local binary="$1"
-          local source_path="codex-rs/target/${{ inputs.target }}/release/${binary}"
+          local source_path="codex-rs/target/${TARGET}/release/${binary}"
           local archive_path="${RUNNER_TEMP}/${binary}.zip"
 
           if [[ ! -f "$source_path" ]]; then
@@ -184,6 +187,7 @@ runs:
       if: ${{ inputs.sign-dmg == 'true' }}
       shell: bash
       env:
+        TARGET: ${{ inputs.target }}
         APPLE_NOTARIZATION_KEY_P8: ${{ inputs.apple-notarization-key-p8 }}
         APPLE_NOTARIZATION_KEY_ID: ${{ inputs.apple-notarization-key-id }}
         APPLE_NOTARIZATION_ISSUER_ID: ${{ inputs.apple-notarization-issuer-id }}
@@ -206,7 +210,8 @@ runs:
 
         source "$GITHUB_ACTION_PATH/notary_helpers.sh"
 
-        dmg_path="codex-rs/target/${{ inputs.target }}/release/codex-${{ inputs.target }}.dmg"
+        dmg_name="codex-${TARGET}.dmg"
+        dmg_path="codex-rs/target/${TARGET}/release/${dmg_name}"
 
         if [[ ! -f "$dmg_path" ]]; then
           echo "dmg $dmg_path not found"
@@ -219,7 +224,7 @@ runs:
         fi
 
         codesign --force --timestamp --sign "$APPLE_CODESIGN_IDENTITY" "${keychain_args[@]}" "$dmg_path"
-        notarize_submission "codex-${{ inputs.target }}.dmg" "$dmg_path" "$notary_key_path"
+        notarize_submission "$dmg_name" "$dmg_path" "$notary_key_path"
         xcrun stapler staple "$dmg_path"
 
     - name: Remove signing keychain

--- a/.github/workflows/blob-size-policy.yml
+++ b/.github/workflows/blob-size-policy.yml
@@ -21,9 +21,12 @@ jobs:
           echo "head=$(git rev-parse HEAD^2)" >> "$GITHUB_OUTPUT"
 
       - name: Check changed blob sizes
+        env:
+          BASE_SHA: ${{ steps.range.outputs.base }}
+          HEAD_SHA: ${{ steps.range.outputs.head }}
         run: |
           python3 scripts/check_blob_size.py \
-            --base "${{ steps.range.outputs.base }}" \
-            --head "${{ steps.range.outputs.head }}" \
+            --base "$BASE_SHA" \
+            --head "$HEAD_SHA" \
             --max-bytes 512000 \
             --allowlist .github/blob-size-allowlist.txt

--- a/.github/workflows/issue-deduplicator.yml
+++ b/.github/workflows/issue-deduplicator.yml
@@ -396,6 +396,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
-          gh issue edit "${{ github.event.issue.number }}" --remove-label codex-deduplicate || true
+          gh issue edit "$ISSUE_NUMBER" --remove-label codex-deduplicate || true
           echo "Attempted to remove label: codex-deduplicate"

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -490,9 +490,10 @@ jobs:
       - name: Stage npm packages
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ steps.release_name.outputs.name }}
         run: |
           ./scripts/stage_npm_packages.py \
-            --release-version "${{ steps.release_name.outputs.name }}" \
+            --release-version "$RELEASE_VERSION" \
             --package codex \
             --package codex-responses-api-proxy \
             --package codex-sdk
@@ -561,10 +562,12 @@ jobs:
       - name: Download npm tarballs from release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.release.outputs.tag }}
+          RELEASE_VERSION: ${{ needs.release.outputs.version }}
         run: |
           set -euo pipefail
-          version="${{ needs.release.outputs.version }}"
-          tag="${{ needs.release.outputs.tag }}"
+          version="$RELEASE_VERSION"
+          tag="$RELEASE_TAG"
           mkdir -p dist/npm
           patterns=(
             "codex-npm-${version}.tgz"

--- a/.github/workflows/shell-tool-mcp.yml
+++ b/.github/workflows/shell-tool-mcp.yml
@@ -31,11 +31,14 @@ jobs:
     steps:
       - name: Compute version and tags
         id: compute
+        env:
+          RELEASE_TAG_INPUT: ${{ inputs.release-tag }}
+          RELEASE_VERSION_INPUT: ${{ inputs.release-version }}
         run: |
           set -euo pipefail
 
-          version="${{ inputs.release-version }}"
-          release_tag="${{ inputs.release-tag }}"
+          version="$RELEASE_VERSION_INPUT"
+          release_tag="$RELEASE_TAG_INPUT"
 
           if [[ -z "$version" ]]; then
             if [[ -n "$release_tag" && "$release_tag" =~ ^rust-v.+ ]]; then
@@ -483,20 +486,22 @@ jobs:
           STAGING_DIR: ${{ runner.temp }}/shell-tool-mcp
 
       - name: Ensure binaries are executable
+        env:
+          STAGING_DIR: ${{ steps.staging.outputs.dir }}
         run: |
           set -euo pipefail
-          staging="${{ steps.staging.outputs.dir }}"
           chmod +x \
-            "$staging"/vendor/*/bash/*/bash \
-            "$staging"/vendor/*/zsh/*/zsh
+            "$STAGING_DIR"/vendor/*/bash/*/bash \
+            "$STAGING_DIR"/vendor/*/zsh/*/zsh
 
       - name: Create npm tarball
         shell: bash
+        env:
+          STAGING_DIR: ${{ steps.staging.outputs.dir }}
         run: |
           set -euo pipefail
           mkdir -p dist/npm
-          staging="${{ steps.staging.outputs.dir }}"
-          pack_info=$(cd "$staging" && npm pack --ignore-scripts --json --pack-destination "${GITHUB_WORKSPACE}/dist/npm")
+          pack_info=$(cd "$STAGING_DIR" && npm pack --ignore-scripts --json --pack-destination "${GITHUB_WORKSPACE}/dist/npm")
           filename=$(PACK_INFO="$pack_info" node -e 'const data = JSON.parse(process.env.PACK_INFO); console.log(data[0].filename);')
           mv "dist/npm/${filename}" "dist/npm/codex-shell-tool-mcp-npm-${PACKAGE_VERSION}.tgz"
 


### PR DESCRIPTION
Inspired by the work done over in https://github.com/openai/codex-action/pull/74, this tightens up our use of GitHub expressions as shell/environment variables.