### PR TITLE
[codex] add Jason as a predefined subagent name

### DIFF
--- a/codex-rs/core/src/agent/agent_names.txt
+++ b/codex-rs/core/src/agent/agent_names.txt
@@ -98,3 +98,4 @@ Nash
 Banach
 Ramanujan
 Erdos
+Jason


### PR DESCRIPTION
This change adds Jason to codex-core's built-in subagent nickname pool so spawned agents can pick it without any custom role configuration. The default list was simply missing that predefined name (a grave mistake).
