### PR TITLE
[codex] add Ben as a predefined subagent name

### DIFF
--- a/codex-rs/core/src/agent/agent_names.txt
+++ b/codex-rs/core/src/agent/agent_names.txt
@@ -99,3 +99,4 @@ Banach
 Ramanujan
 Erdos
 Jason
+Ben


### PR DESCRIPTION
This change adds Ben to the codex-core built-in subagent nickname pool so spawned agents can pick it without any custom role configuration.

The previous lack of "Ben" in the sub-agent names was an unbearable mistake that this PR aims to fix