### PR TITLE
fix(tui): restore remote live app-server interactions

### DIFF
--- a/codex-rs/tui_app_server/src/app/app_server_adapter.rs
+++ b/codex-rs/tui_app_server/src/app/app_server_adapter.rs
@@ -1,14 +1,45 @@
 /*
-This module holds the temporary adapter layer between the TUI and the app
-server during the hybrid migration period.
+Temporary adapter layer between the TUI and the app server during the
+hybrid migration period.
 
-For now, the TUI still owns its existing direct-core behavior, but startup
-allocates a local in-process app server and drains its event stream. Keeping
-the app-server-specific wiring here keeps that transitional logic out of the
-main `app.rs` orchestration path.
+The TUI still owns its existing direct-core behavior, but startup
+allocates a local in-process app server and drains its event stream.
+Keeping the app-server-specific wiring here keeps that transitional logic
+out of the main `app.rs` orchestration path.
 
-As more TUI flows move onto the app-server surface directly, this adapter
-should shrink and eventually disappear.
+## Two protocol worlds
+
+The adapter translates between:
+
+- **Upstream** — the app-server protocol (`codex_app_server_protocol`):
+  `ServerNotification`, `ServerRequest`, and `LegacyNotification`.
+- **Downstream** — the TUI event store (`codex_protocol::protocol::Event`
+  / `EventMsg`).
+
+## Local vs remote
+
+When the app-server runs in-process (`is_remote == false`), most
+interactive flows — command execution, approvals, permissions — are
+handled through the legacy event path and do not need translation here.
+
+When connecting to a **remote** app-server (`is_remote == true`), this
+module provides the full translation surface:
+
+- `ServerNotification` → `Event` sequences via
+  `server_notification_thread_events`, including command-execution
+  lifecycle, output streaming, and terminal interaction.
+- `ServerRequest` → `Event` via `server_request_thread_event`, covering
+  command-execution approval, permissions, user-input, and MCP
+  elicitation.
+
+## Snapshot replay
+
+`thread_snapshot_events` / `turn_snapshot_events` expand a `Thread`
+snapshot into the event sequence the TUI would have observed live. This
+drives the resume and fork-history flows.
+
+As more TUI flows move onto the app-server surface directly, this
+adapter should shrink and eventually disappear.
 */
 
 use super::App;
@@ -416,6 +447,13 @@ pub(super) fn thread_snapshot_events(
         .collect()
 }
 
+/// Translate a remote `ServerRequest` (an interactive prompt from the
+/// app-server that expects a JSON-RPC response) into a TUI `Event` that
+/// will surface the appropriate approval / input dialog.
+///
+/// Returns `Err` with a human-readable message for request types that the
+/// TUI does not yet support; the caller is expected to reject the request
+/// back to the server with that message.
 fn server_request_thread_event(request: &ServerRequest) -> Result<(ThreadId, Event), String> {
     match request {
         ServerRequest::CommandExecutionRequestApproval { params, .. } => Ok((
@@ -574,10 +612,20 @@ fn thread_id_from_remote_request(context: &str, thread_id: &str) -> Result<Threa
         .map_err(|err| format!("failed to parse remote {context} thread id `{thread_id}`: {err}"))
 }
 
+/// Tokenize a remote command string into the `Vec<String>` argv the TUI
+/// approval dialog expects.
+///
+/// Falls back to a single-element vec when `shlex` cannot parse the input
+/// (e.g. unbalanced quotes). The fallback means the user sees one opaque
+/// string rather than a structured argv; this is intentional so that
+/// approvals are never silently blocked by a parse failure.
 fn split_remote_command_for_approval(command: &str) -> Vec<String> {
     shlex::split(command).unwrap_or_else(|| vec![command.to_string()])
 }
 
+/// Map an app-server `CommandExecutionApprovalDecision` to the TUI's
+/// `ReviewDecision` so the approval dialog can present the same options
+/// the remote server advertised.
 fn command_approval_decision_to_review_decision(
     decision: CommandExecutionApprovalDecision,
 ) -> ReviewDecision {
@@ -622,6 +670,9 @@ fn legacy_thread_event(params: Option<Value>) -> Option<(ThreadId, Event)> {
     Some((thread_id, event))
 }
 
+/// Returns `true` if the legacy event is also delivered via a
+/// `ServerNotification`, so the legacy copy should be dropped to avoid
+/// double-processing.
 fn legacy_event_is_shadowed_by_server_notification(msg: &EventMsg) -> bool {
     matches!(
         msg,
@@ -640,6 +691,13 @@ fn legacy_event_is_shadowed_by_server_notification(msg: &EventMsg) -> bool {
     )
 }
 
+/// Translate a `ServerNotification` into zero or more TUI `Event`s,
+/// returning the owning thread ID.
+///
+/// When `is_remote` is true, additional notification types are bridged:
+/// `CommandExecutionOutputDelta` and `TerminalInteraction`. These are
+/// only emitted by remote servers; the local app-server handles command
+/// I/O through the legacy event path.
 fn server_notification_thread_events(
     notification: ServerNotification,
     is_remote: bool,
@@ -971,6 +1029,12 @@ fn append_terminal_turn_events(events: &mut Vec<Event>, turn: &Turn, include_fai
     }
 }
 
+/// Remote-specific translation for `ItemStarted` notifications.
+///
+/// For `CommandExecution` items that are `InProgress`, this produces an
+/// `ExecCommandBegin` event instead of the generic `ItemStarted`, because
+/// the TUI renders command execution through the exec-command widget
+/// rather than the item-list widget.
 fn thread_item_started_events(
     thread_id: ThreadId,
     turn_id: String,
@@ -991,6 +1055,10 @@ fn thread_item_started_events(
     }])
 }
 
+/// Remote-specific translation for `ItemCompleted` notifications.
+///
+/// Mirrors `thread_item_started_events`: completed `CommandExecution`
+/// items produce `ExecCommandEnd` with aggregated output and exit code.
 fn thread_item_completed_events(
     thread_id: ThreadId,
     turn_id: String,
@@ -1011,6 +1079,9 @@ fn thread_item_completed_events(
     }])
 }
 
+/// If `item` is an in-progress `CommandExecution`, produce the
+/// `ExecCommandBegin` event the TUI uses to open a command-output panel.
+/// Returns `None` for non-command items or already-finished commands.
 fn command_execution_begin_event(turn_id: &str, item: &ThreadItem) -> Option<Event> {
     let ThreadItem::CommandExecution {
         id,
@@ -1048,6 +1119,9 @@ fn command_execution_begin_event(turn_id: &str, item: &ThreadItem) -> Option<Eve
     })
 }
 
+/// If `item` is a finished `CommandExecution`, produce the
+/// `ExecCommandEnd` event with aggregated output, exit code, and
+/// duration. Returns `None` for non-command items or still-running ones.
 fn command_execution_end_event(turn_id: &str, item: &ThreadItem) -> Option<Event> {
     let ThreadItem::CommandExecution {
         id,
@@ -1095,6 +1169,11 @@ fn command_execution_end_event(turn_id: &str, item: &ThreadItem) -> Option<Event
     })
 }
 
+/// Map the app-server's command-execution status to the TUI core enum.
+///
+/// `InProgress` is mapped to `Failed` defensively — a completed
+/// notification should never carry `InProgress`, so if it does the safest
+/// rendering is a failure indicator.
 fn command_execution_status_to_core(status: &CommandExecutionStatus) -> ExecCommandStatus {
     match status {
         CommandExecutionStatus::Completed => ExecCommandStatus::Completed,

--- a/codex-rs/tui_app_server/src/app/app_server_adapter.rs
+++ b/codex-rs/tui_app_server/src/app/app_server_adapter.rs
@@ -19,7 +19,10 @@ use crate::app_server_session::status_account_display_from_auth_mode;
 use crate::local_chatgpt_auth::load_local_chatgpt_auth;
 use codex_app_server_client::AppServerEvent;
 use codex_app_server_protocol::ChatgptAuthTokensRefreshParams;
+use codex_app_server_protocol::CommandExecutionApprovalDecision;
+use codex_app_server_protocol::CommandExecutionStatus;
 use codex_app_server_protocol::JSONRPCErrorError;
+use codex_app_server_protocol::RequestId as AppServerRequestId;
 use codex_app_server_protocol::ServerNotification;
 use codex_app_server_protocol::ServerRequest;
 use codex_app_server_protocol::Thread;
@@ -27,6 +30,8 @@ use codex_app_server_protocol::ThreadItem;
 use codex_app_server_protocol::Turn;
 use codex_app_server_protocol::TurnStatus;
 use codex_protocol::ThreadId;
+use codex_protocol::approvals::ElicitationRequestEvent;
+use codex_protocol::approvals::ExecApprovalRequestEvent;
 use codex_protocol::config_types::ModeKind;
 use codex_protocol::items::AgentMessageContent;
 use codex_protocol::items::AgentMessageItem;
@@ -37,12 +42,19 @@ use codex_protocol::items::ReasoningItem;
 use codex_protocol::items::TurnItem;
 use codex_protocol::items::UserMessageItem;
 use codex_protocol::items::WebSearchItem;
+use codex_protocol::mcp::RequestId as McpRequestId;
 use codex_protocol::protocol::AgentMessageDeltaEvent;
 use codex_protocol::protocol::AgentReasoningDeltaEvent;
 use codex_protocol::protocol::AgentReasoningRawContentDeltaEvent;
 use codex_protocol::protocol::ErrorEvent;
 use codex_protocol::protocol::Event;
 use codex_protocol::protocol::EventMsg;
+use codex_protocol::protocol::ExecCommandBeginEvent;
+use codex_protocol::protocol::ExecCommandEndEvent;
+use codex_protocol::protocol::ExecCommandOutputDeltaEvent;
+use codex_protocol::protocol::ExecCommandSource;
+use codex_protocol::protocol::ExecCommandStatus;
+use codex_protocol::protocol::ExecOutputStream;
 use codex_protocol::protocol::ItemCompletedEvent;
 use codex_protocol::protocol::ItemStartedEvent;
 use codex_protocol::protocol::PlanDeltaEvent;
@@ -50,6 +62,8 @@ use codex_protocol::protocol::RealtimeConversationClosedEvent;
 use codex_protocol::protocol::RealtimeConversationRealtimeEvent;
 use codex_protocol::protocol::RealtimeConversationStartedEvent;
 use codex_protocol::protocol::RealtimeEvent;
+use codex_protocol::protocol::ReviewDecision;
+use codex_protocol::protocol::TerminalInteractionEvent;
 use codex_protocol::protocol::ThreadNameUpdatedEvent;
 use codex_protocol::protocol::TokenCountEvent;
 use codex_protocol::protocol::TokenUsage;
@@ -58,7 +72,12 @@ use codex_protocol::protocol::TurnAbortReason;
 use codex_protocol::protocol::TurnAbortedEvent;
 use codex_protocol::protocol::TurnCompleteEvent;
 use codex_protocol::protocol::TurnStartedEvent;
+use codex_protocol::request_permissions::RequestPermissionsEvent;
+use codex_protocol::request_user_input::RequestUserInputEvent;
+use codex_protocol::request_user_input::RequestUserInputQuestion;
+use codex_protocol::request_user_input::RequestUserInputQuestionOption;
 use serde_json::Value;
+use std::time::Duration;
 
 impl App {
     pub(super) async fn handle_app_server_event(
@@ -109,26 +128,18 @@ impl App {
                     {
                         return;
                     }
-                    if let Some((thread_id, events)) =
-                        server_notification_thread_events(notification)
-                    {
+                    if let Some((thread_id, events)) = server_notification_thread_events(
+                        notification,
+                        app_server_client.is_remote(),
+                    ) {
                         for event in events {
-                            if self.primary_thread_id.is_none()
-                                || matches!(event.msg, EventMsg::SessionConfigured(_))
-                                    && self.primary_thread_id == Some(thread_id)
-                            {
-                                if let Err(err) = self.enqueue_primary_event(event).await {
-                                    tracing::warn!(
-                                        "failed to enqueue primary app-server server notification: {err}"
-                                    );
-                                }
-                            } else if let Err(err) =
-                                self.enqueue_thread_event(thread_id, event).await
-                            {
-                                tracing::warn!(
-                                    "failed to enqueue app-server server notification for {thread_id}: {err}"
-                                );
-                            }
+                            let _ = self
+                                .enqueue_app_server_thread_event(
+                                    thread_id,
+                                    event,
+                                    "app-server server notification",
+                                )
+                                .await;
                         }
                     }
                 }
@@ -163,9 +174,66 @@ impl App {
                     .await;
                     return;
                 }
-                if let Some(unsupported) = self
+                if app_server_client.is_remote() {
+                    match server_request_thread_event(&request) {
+                        Ok((thread_id, event)) => {
+                            if let Some(unsupported) =
+                                self.pending_app_server_requests.note_server_request(
+                                    &request, /*allow_legacy_exec_approvals*/ true,
+                                )
+                            {
+                                tracing::warn!(
+                                    request_id = ?unsupported.request_id,
+                                    message = unsupported.message,
+                                    "rejecting unsupported app-server request"
+                                );
+                                self.chat_widget
+                                    .add_error_message(unsupported.message.clone());
+                                if let Err(err) = self
+                                    .reject_app_server_request(
+                                        app_server_client,
+                                        unsupported.request_id,
+                                        unsupported.message,
+                                    )
+                                    .await
+                                {
+                                    tracing::warn!("{err}");
+                                }
+                                return;
+                            }
+                            let request_id = request.id().clone();
+                            let enqueue_result = self
+                                .enqueue_app_server_thread_event(
+                                    thread_id,
+                                    event,
+                                    "app-server remote server request",
+                                )
+                                .await;
+                            if enqueue_result.is_err() {
+                                self.pending_app_server_requests.clear_request(&request_id);
+                            }
+                        }
+                        Err(message) => {
+                            tracing::warn!(
+                                request_id = ?request.id(),
+                                "{message}"
+                            );
+                            self.chat_widget.add_error_message(message.clone());
+                            if let Err(err) = self
+                                .reject_app_server_request(
+                                    app_server_client,
+                                    request.id().clone(),
+                                    message,
+                                )
+                                .await
+                            {
+                                tracing::warn!("{err}");
+                            }
+                        }
+                    }
+                } else if let Some(unsupported) = self
                     .pending_app_server_requests
-                    .note_server_request(&request)
+                    .note_server_request(&request, /*allow_legacy_exec_approvals*/ false)
                 {
                     tracing::warn!(
                         request_id = ?unsupported.request_id,
@@ -276,6 +344,29 @@ impl App {
             .await
             .map_err(|err| format!("failed to reject app-server request: {err}"))
     }
+
+    async fn enqueue_app_server_thread_event(
+        &mut self,
+        thread_id: ThreadId,
+        event: Event,
+        context: &str,
+    ) -> Result<(), String> {
+        if self.primary_thread_id.is_none()
+            || matches!(event.msg, EventMsg::SessionConfigured(_))
+                && self.primary_thread_id == Some(thread_id)
+        {
+            if let Err(err) = self.enqueue_primary_event(event).await {
+                tracing::warn!("failed to enqueue primary {context}: {err}");
+                return Err(format!("failed to enqueue primary {context}: {err}"));
+            }
+        } else if let Err(err) = self.enqueue_thread_event(thread_id, event).await {
+            tracing::warn!("failed to enqueue {context} for {thread_id}: {err}");
+            return Err(format!(
+                "failed to enqueue {context} for {thread_id}: {err}"
+            ));
+        }
+        Ok(())
+    }
 }
 
 fn resolve_chatgpt_auth_tokens_refresh_response(
@@ -325,6 +416,196 @@ pub(super) fn thread_snapshot_events(
         .collect()
 }
 
+fn server_request_thread_event(request: &ServerRequest) -> Result<(ThreadId, Event), String> {
+    match request {
+        ServerRequest::CommandExecutionRequestApproval { params, .. } => Ok((
+            thread_id_from_remote_request("command execution approval", &params.thread_id)?,
+            Event {
+                id: String::new(),
+                msg: EventMsg::ExecApprovalRequest(ExecApprovalRequestEvent {
+                    call_id: params.item_id.clone(),
+                    approval_id: params.approval_id.clone(),
+                    turn_id: params.turn_id.clone(),
+                    command: params
+                        .command
+                        .as_deref()
+                        .map(split_remote_command_for_approval)
+                        .unwrap_or_default(),
+                    cwd: params.cwd.clone().unwrap_or_default(),
+                    reason: params.reason.clone(),
+                    network_approval_context: params.network_approval_context.clone().map(
+                        |context| codex_protocol::protocol::NetworkApprovalContext {
+                            host: context.host,
+                            protocol: context.protocol.to_core(),
+                        },
+                    ),
+                    proposed_execpolicy_amendment: params
+                        .proposed_execpolicy_amendment
+                        .clone()
+                        .map(codex_app_server_protocol::ExecPolicyAmendment::into_core),
+                    proposed_network_policy_amendments: params
+                        .proposed_network_policy_amendments
+                        .clone()
+                        .map(|amendments| {
+                            amendments
+                                .into_iter()
+                                .map(codex_app_server_protocol::NetworkPolicyAmendment::into_core)
+                                .collect()
+                        }),
+                    additional_permissions: params.additional_permissions.clone().map(Into::into),
+                    skill_metadata: None,
+                    available_decisions: params.available_decisions.clone().map(|decisions| {
+                        decisions
+                            .into_iter()
+                            .map(command_approval_decision_to_review_decision)
+                            .collect()
+                    }),
+                    parsed_cmd: params
+                        .command_actions
+                        .clone()
+                        .unwrap_or_default()
+                        .into_iter()
+                        .map(codex_app_server_protocol::CommandAction::into_core)
+                        .collect(),
+                }),
+            },
+        )),
+        ServerRequest::ExecCommandApproval { params, .. } => Ok((
+            params.conversation_id,
+            Event {
+                id: String::new(),
+                msg: EventMsg::ExecApprovalRequest(ExecApprovalRequestEvent {
+                    call_id: params.call_id.clone(),
+                    approval_id: params.approval_id.clone(),
+                    turn_id: String::new(),
+                    command: params.command.clone(),
+                    cwd: params.cwd.clone(),
+                    reason: params.reason.clone(),
+                    network_approval_context: None,
+                    proposed_execpolicy_amendment: None,
+                    proposed_network_policy_amendments: None,
+                    additional_permissions: None,
+                    skill_metadata: None,
+                    available_decisions: None,
+                    parsed_cmd: params.parsed_cmd.clone(),
+                }),
+            },
+        )),
+        ServerRequest::PermissionsRequestApproval { params, .. } => Ok((
+            thread_id_from_remote_request("permissions approval", &params.thread_id)?,
+            Event {
+                id: String::new(),
+                msg: EventMsg::RequestPermissions(RequestPermissionsEvent {
+                    call_id: params.item_id.clone(),
+                    turn_id: params.turn_id.clone(),
+                    reason: params.reason.clone(),
+                    permissions: params.permissions.clone().into(),
+                }),
+            },
+        )),
+        ServerRequest::ToolRequestUserInput { params, .. } => Ok((
+            thread_id_from_remote_request("request_user_input", &params.thread_id)?,
+            Event {
+                id: String::new(),
+                msg: EventMsg::RequestUserInput(RequestUserInputEvent {
+                    call_id: params.item_id.clone(),
+                    turn_id: params.turn_id.clone(),
+                    questions: params
+                        .questions
+                        .iter()
+                        .map(|question| RequestUserInputQuestion {
+                            id: question.id.clone(),
+                            header: question.header.clone(),
+                            question: question.question.clone(),
+                            is_other: question.is_other,
+                            is_secret: question.is_secret,
+                            options: question.options.as_ref().map(|options| {
+                                options
+                                    .iter()
+                                    .map(|option| RequestUserInputQuestionOption {
+                                        label: option.label.clone(),
+                                        description: option.description.clone(),
+                                    })
+                                    .collect()
+                            }),
+                        })
+                        .collect(),
+                }),
+            },
+        )),
+        ServerRequest::McpServerElicitationRequest { request_id, params } => Ok((
+            thread_id_from_remote_request("MCP elicitation request", &params.thread_id)?,
+            Event {
+                id: String::new(),
+                msg: EventMsg::ElicitationRequest(ElicitationRequestEvent {
+                    turn_id: params.turn_id.clone(),
+                    server_name: params.server_name.clone(),
+                    id: app_server_request_id_to_mcp_request_id(request_id),
+                    request: serde_json::from_value(
+                        serde_json::to_value(&params.request).map_err(|err| {
+                            format!(
+                                "failed to encode remote MCP elicitation request for `{}`: {err}",
+                                params.server_name
+                            )
+                        })?,
+                    )
+                    .map_err(|err| {
+                        format!(
+                            "failed to decode remote MCP elicitation request for `{}`: {err}",
+                            params.server_name
+                        )
+                    })?,
+                }),
+            },
+        )),
+        ServerRequest::FileChangeRequestApproval { .. } => {
+            Err("Remote file change approvals are not available in app-server TUI yet.".to_string())
+        }
+        ServerRequest::DynamicToolCall { .. }
+        | ServerRequest::ChatgptAuthTokensRefresh { .. }
+        | ServerRequest::ApplyPatchApproval { .. } => {
+            Err("This app-server request is not available in app-server TUI yet.".to_string())
+        }
+    }
+}
+
+fn thread_id_from_remote_request(context: &str, thread_id: &str) -> Result<ThreadId, String> {
+    ThreadId::from_string(thread_id)
+        .map_err(|err| format!("failed to parse remote {context} thread id `{thread_id}`: {err}"))
+}
+
+fn split_remote_command_for_approval(command: &str) -> Vec<String> {
+    shlex::split(command).unwrap_or_else(|| vec![command.to_string()])
+}
+
+fn command_approval_decision_to_review_decision(
+    decision: CommandExecutionApprovalDecision,
+) -> ReviewDecision {
+    match decision {
+        CommandExecutionApprovalDecision::Accept => ReviewDecision::Approved,
+        CommandExecutionApprovalDecision::AcceptForSession => ReviewDecision::ApprovedForSession,
+        CommandExecutionApprovalDecision::AcceptWithExecpolicyAmendment {
+            execpolicy_amendment,
+        } => ReviewDecision::ApprovedExecpolicyAmendment {
+            proposed_execpolicy_amendment: execpolicy_amendment.into_core(),
+        },
+        CommandExecutionApprovalDecision::ApplyNetworkPolicyAmendment {
+            network_policy_amendment,
+        } => ReviewDecision::NetworkPolicyAmendment {
+            network_policy_amendment: network_policy_amendment.into_core(),
+        },
+        CommandExecutionApprovalDecision::Decline => ReviewDecision::Denied,
+        CommandExecutionApprovalDecision::Cancel => ReviewDecision::Abort,
+    }
+}
+
+fn app_server_request_id_to_mcp_request_id(request_id: &AppServerRequestId) -> McpRequestId {
+    match request_id {
+        AppServerRequestId::String(value) => McpRequestId::String(value.clone()),
+        AppServerRequestId::Integer(value) => McpRequestId::Integer(*value),
+    }
+}
+
 fn legacy_thread_event(params: Option<Value>) -> Option<(ThreadId, Event)> {
     let Value::Object(mut params) = params? else {
         return None;
@@ -361,6 +642,7 @@ fn legacy_event_is_shadowed_by_server_notification(msg: &EventMsg) -> bool {
 
 fn server_notification_thread_events(
     notification: ServerNotification,
+    is_remote: bool,
 ) -> Option<(ThreadId, Vec<Event>)> {
     match notification {
         ServerNotification::ThreadTokenUsageUpdated(notification) => Some((
@@ -425,28 +707,38 @@ fn server_notification_thread_events(
             );
             Some((thread_id, events))
         }
-        ServerNotification::ItemStarted(notification) => Some((
-            ThreadId::from_string(&notification.thread_id).ok()?,
-            vec![Event {
-                id: String::new(),
-                msg: EventMsg::ItemStarted(ItemStartedEvent {
-                    thread_id: ThreadId::from_string(&notification.thread_id).ok()?,
-                    turn_id: notification.turn_id,
-                    item: thread_item_to_core(&notification.item)?,
-                }),
-            }],
-        )),
-        ServerNotification::ItemCompleted(notification) => Some((
-            ThreadId::from_string(&notification.thread_id).ok()?,
-            vec![Event {
-                id: String::new(),
-                msg: EventMsg::ItemCompleted(ItemCompletedEvent {
-                    thread_id: ThreadId::from_string(&notification.thread_id).ok()?,
-                    turn_id: notification.turn_id,
-                    item: thread_item_to_core(&notification.item)?,
-                }),
-            }],
-        )),
+        ServerNotification::ItemStarted(notification) => {
+            let thread_id = ThreadId::from_string(&notification.thread_id).ok()?;
+            let events = if is_remote {
+                thread_item_started_events(thread_id, notification.turn_id, notification.item)?
+            } else {
+                vec![Event {
+                    id: String::new(),
+                    msg: EventMsg::ItemStarted(ItemStartedEvent {
+                        thread_id,
+                        turn_id: notification.turn_id,
+                        item: thread_item_to_core(&notification.item)?,
+                    }),
+                }]
+            };
+            Some((thread_id, events))
+        }
+        ServerNotification::ItemCompleted(notification) => {
+            let thread_id = ThreadId::from_string(&notification.thread_id).ok()?;
+            let events = if is_remote {
+                thread_item_completed_events(thread_id, notification.turn_id, notification.item)?
+            } else {
+                vec![Event {
+                    id: String::new(),
+                    msg: EventMsg::ItemCompleted(ItemCompletedEvent {
+                        thread_id,
+                        turn_id: notification.turn_id,
+                        item: thread_item_to_core(&notification.item)?,
+                    }),
+                }]
+            };
+            Some((thread_id, events))
+        }
         ServerNotification::AgentMessageDelta(notification) => Some((
             ThreadId::from_string(&notification.thread_id).ok()?,
             vec![Event {
@@ -483,6 +775,28 @@ fn server_notification_thread_events(
                 id: String::new(),
                 msg: EventMsg::AgentReasoningRawContentDelta(AgentReasoningRawContentDeltaEvent {
                     delta: notification.delta,
+                }),
+            }],
+        )),
+        ServerNotification::CommandExecutionOutputDelta(notification) if is_remote => Some((
+            ThreadId::from_string(&notification.thread_id).ok()?,
+            vec![Event {
+                id: String::new(),
+                msg: EventMsg::ExecCommandOutputDelta(ExecCommandOutputDeltaEvent {
+                    call_id: notification.item_id,
+                    stream: ExecOutputStream::Stdout,
+                    chunk: notification.delta.into_bytes(),
+                }),
+            }],
+        )),
+        ServerNotification::TerminalInteraction(notification) if is_remote => Some((
+            ThreadId::from_string(&notification.thread_id).ok()?,
+            vec![Event {
+                id: String::new(),
+                msg: EventMsg::TerminalInteraction(TerminalInteractionEvent {
+                    call_id: notification.item_id,
+                    process_id: notification.process_id,
+                    stdin: notification.stdin,
                 }),
             }],
         )),
@@ -654,6 +968,139 @@ fn append_terminal_turn_events(events: &mut Vec<Event>, turn: &Turn, include_fai
         TurnStatus::InProgress => {
             // Preserve unfinished turns during snapshot replay without emitting completion events.
         }
+    }
+}
+
+fn thread_item_started_events(
+    thread_id: ThreadId,
+    turn_id: String,
+    item: ThreadItem,
+) -> Option<Vec<Event>> {
+    if let Some(event) = command_execution_begin_event(&turn_id, &item) {
+        return Some(vec![event]);
+    }
+
+    let item = thread_item_to_core(&item)?;
+    Some(vec![Event {
+        id: String::new(),
+        msg: EventMsg::ItemStarted(ItemStartedEvent {
+            thread_id,
+            turn_id,
+            item,
+        }),
+    }])
+}
+
+fn thread_item_completed_events(
+    thread_id: ThreadId,
+    turn_id: String,
+    item: ThreadItem,
+) -> Option<Vec<Event>> {
+    if let Some(event) = command_execution_end_event(&turn_id, &item) {
+        return Some(vec![event]);
+    }
+
+    let item = thread_item_to_core(&item)?;
+    Some(vec![Event {
+        id: String::new(),
+        msg: EventMsg::ItemCompleted(ItemCompletedEvent {
+            thread_id,
+            turn_id,
+            item,
+        }),
+    }])
+}
+
+fn command_execution_begin_event(turn_id: &str, item: &ThreadItem) -> Option<Event> {
+    let ThreadItem::CommandExecution {
+        id,
+        command,
+        cwd,
+        process_id,
+        status,
+        command_actions,
+        ..
+    } = item
+    else {
+        return None;
+    };
+
+    if *status != CommandExecutionStatus::InProgress {
+        return None;
+    }
+
+    Some(Event {
+        id: String::new(),
+        msg: EventMsg::ExecCommandBegin(ExecCommandBeginEvent {
+            call_id: id.clone(),
+            process_id: process_id.clone(),
+            turn_id: turn_id.to_string(),
+            command: split_remote_command_for_approval(command),
+            cwd: cwd.clone(),
+            parsed_cmd: command_actions
+                .clone()
+                .into_iter()
+                .map(codex_app_server_protocol::CommandAction::into_core)
+                .collect(),
+            source: ExecCommandSource::Agent,
+            interaction_input: None,
+        }),
+    })
+}
+
+fn command_execution_end_event(turn_id: &str, item: &ThreadItem) -> Option<Event> {
+    let ThreadItem::CommandExecution {
+        id,
+        command,
+        cwd,
+        process_id,
+        status,
+        command_actions,
+        aggregated_output,
+        exit_code,
+        duration_ms,
+    } = item
+    else {
+        return None;
+    };
+
+    if *status == CommandExecutionStatus::InProgress {
+        return None;
+    }
+
+    let aggregated_output = aggregated_output.clone().unwrap_or_default();
+    Some(Event {
+        id: String::new(),
+        msg: EventMsg::ExecCommandEnd(ExecCommandEndEvent {
+            call_id: id.clone(),
+            process_id: process_id.clone(),
+            turn_id: turn_id.to_string(),
+            command: split_remote_command_for_approval(command),
+            cwd: cwd.clone(),
+            parsed_cmd: command_actions
+                .clone()
+                .into_iter()
+                .map(codex_app_server_protocol::CommandAction::into_core)
+                .collect(),
+            source: ExecCommandSource::Agent,
+            interaction_input: None,
+            stdout: String::new(),
+            stderr: String::new(),
+            aggregated_output: aggregated_output.clone(),
+            exit_code: exit_code.unwrap_or(-1),
+            duration: Duration::from_millis(duration_ms.unwrap_or_default().max(0) as u64),
+            formatted_output: aggregated_output,
+            status: command_execution_status_to_core(status),
+        }),
+    })
+}
+
+fn command_execution_status_to_core(status: &CommandExecutionStatus) -> ExecCommandStatus {
+    match status {
+        CommandExecutionStatus::Completed => ExecCommandStatus::Completed,
+        CommandExecutionStatus::Failed => ExecCommandStatus::Failed,
+        CommandExecutionStatus::Declined => ExecCommandStatus::Declined,
+        CommandExecutionStatus::InProgress => ExecCommandStatus::Failed,
     }
 }
 
@@ -858,13 +1305,22 @@ fn app_server_codex_error_info_to_core(
 #[cfg(test)]
 mod tests {
     use super::server_notification_thread_events;
+    use super::server_request_thread_event;
     use super::thread_snapshot_events;
     use super::turn_snapshot_events;
     use codex_app_server_protocol::AgentMessageDeltaNotification;
     use codex_app_server_protocol::CodexErrorInfo;
+    use codex_app_server_protocol::CommandExecutionOutputDeltaNotification;
+    use codex_app_server_protocol::CommandExecutionRequestApprovalParams;
+    use codex_app_server_protocol::CommandExecutionStatus;
+    use codex_app_server_protocol::ExecCommandApprovalParams;
     use codex_app_server_protocol::ItemCompletedNotification;
+    use codex_app_server_protocol::ItemStartedNotification;
     use codex_app_server_protocol::ReasoningSummaryTextDeltaNotification;
+    use codex_app_server_protocol::RequestId as AppServerRequestId;
     use codex_app_server_protocol::ServerNotification;
+    use codex_app_server_protocol::ServerRequest;
+    use codex_app_server_protocol::TerminalInteractionNotification;
     use codex_app_server_protocol::Thread;
     use codex_app_server_protocol::ThreadItem;
     use codex_app_server_protocol::ThreadStatus;
@@ -900,6 +1356,7 @@ mod tests {
                 thread_id: thread_id.clone(),
                 turn_id: turn_id.clone(),
             }),
+            /*is_remote*/ false,
         )
         .expect("notification should bridge");
 
@@ -947,6 +1404,7 @@ mod tests {
                     error: None,
                 },
             }),
+            /*is_remote*/ false,
         )
         .expect("notification should bridge");
 
@@ -980,6 +1438,7 @@ mod tests {
                     error: None,
                 },
             }),
+            /*is_remote*/ false,
         )
         .expect("notification should bridge");
 
@@ -1016,6 +1475,7 @@ mod tests {
                     }),
                 },
             }),
+            /*is_remote*/ false,
         )
         .expect("notification should bridge");
 
@@ -1044,6 +1504,7 @@ mod tests {
                 item_id: "item".to_string(),
                 delta: "Hello".to_string(),
             }),
+            /*is_remote*/ false,
         )
         .expect("notification should bridge");
         let [agent_event] = agent_events.as_slice() else {
@@ -1063,6 +1524,7 @@ mod tests {
                 delta: "Thinking".to_string(),
                 summary_index: 0,
             }),
+            /*is_remote*/ false,
         )
         .expect("notification should bridge");
         let [reasoning_event] = reasoning_events.as_slice() else {
@@ -1246,5 +1708,137 @@ mod tests {
         };
         assert_eq!(raw_reasoning.text, "hidden chain");
         assert!(matches!(events[3].msg, EventMsg::TurnComplete(_)));
+    }
+
+    #[test]
+    fn bridges_remote_exec_command_items_and_output() {
+        let thread_id = "019cee8c-b993-7e33-88c0-014d4e62612d".to_string();
+        let turn_id = "019cee8c-b9b4-7f10-a1b0-38caa876a012".to_string();
+
+        let (_, started_events) = server_notification_thread_events(
+            ServerNotification::ItemStarted(ItemStartedNotification {
+                thread_id: thread_id.clone(),
+                turn_id: turn_id.clone(),
+                item: ThreadItem::CommandExecution {
+                    id: "call-1".to_string(),
+                    command: "pwd".to_string(),
+                    cwd: "/tmp/project".into(),
+                    process_id: Some("123".to_string()),
+                    status: CommandExecutionStatus::InProgress,
+                    command_actions: Vec::new(),
+                    aggregated_output: None,
+                    exit_code: None,
+                    duration_ms: None,
+                },
+            }),
+            /*is_remote*/ true,
+        )
+        .expect("notification should bridge");
+        assert!(matches!(
+            started_events[0].msg,
+            EventMsg::ExecCommandBegin(_)
+        ));
+
+        let (_, output_events) = server_notification_thread_events(
+            ServerNotification::CommandExecutionOutputDelta(
+                CommandExecutionOutputDeltaNotification {
+                    thread_id: thread_id.clone(),
+                    turn_id: turn_id.clone(),
+                    item_id: "call-1".to_string(),
+                    delta: "hello\n".to_string(),
+                },
+            ),
+            /*is_remote*/ true,
+        )
+        .expect("notification should bridge");
+        assert!(matches!(
+            output_events[0].msg,
+            EventMsg::ExecCommandOutputDelta(_)
+        ));
+
+        let (_, terminal_events) = server_notification_thread_events(
+            ServerNotification::TerminalInteraction(TerminalInteractionNotification {
+                thread_id,
+                turn_id: turn_id.clone(),
+                item_id: "call-1".to_string(),
+                process_id: "123".to_string(),
+                stdin: "y\n".to_string(),
+            }),
+            /*is_remote*/ true,
+        )
+        .expect("notification should bridge");
+        assert!(matches!(
+            terminal_events[0].msg,
+            EventMsg::TerminalInteraction(_)
+        ));
+
+        let (_, completed_events) = server_notification_thread_events(
+            ServerNotification::ItemCompleted(ItemCompletedNotification {
+                thread_id: "019cee8c-b993-7e33-88c0-014d4e62612d".to_string(),
+                turn_id,
+                item: ThreadItem::CommandExecution {
+                    id: "call-1".to_string(),
+                    command: "pwd".to_string(),
+                    cwd: "/tmp/project".into(),
+                    process_id: Some("123".to_string()),
+                    status: CommandExecutionStatus::Completed,
+                    command_actions: Vec::new(),
+                    aggregated_output: Some("hello\n".to_string()),
+                    exit_code: Some(0),
+                    duration_ms: Some(25),
+                },
+            }),
+            /*is_remote*/ true,
+        )
+        .expect("notification should bridge");
+        assert!(matches!(
+            completed_events[0].msg,
+            EventMsg::ExecCommandEnd(_)
+        ));
+    }
+
+    #[test]
+    fn bridges_remote_server_requests_into_core_events() {
+        let request = ServerRequest::CommandExecutionRequestApproval {
+            request_id: AppServerRequestId::Integer(7),
+            params: CommandExecutionRequestApprovalParams {
+                thread_id: ThreadId::new().to_string(),
+                turn_id: "turn-1".to_string(),
+                item_id: "call-1".to_string(),
+                approval_id: Some("approval-1".to_string()),
+                reason: Some("Need shell".to_string()),
+                network_approval_context: None,
+                command: Some("pwd".to_string()),
+                cwd: Some("/tmp/project".into()),
+                command_actions: None,
+                additional_permissions: None,
+                skill_metadata: None,
+                proposed_execpolicy_amendment: None,
+                proposed_network_policy_amendments: None,
+                available_decisions: None,
+            },
+        };
+
+        let (_, event) = server_request_thread_event(&request).expect("request should bridge");
+        assert!(matches!(event.msg, EventMsg::ExecApprovalRequest(_)));
+    }
+
+    #[test]
+    fn bridges_legacy_remote_exec_approval_requests() {
+        let request = ServerRequest::ExecCommandApproval {
+            request_id: AppServerRequestId::Integer(8),
+            params: ExecCommandApprovalParams {
+                conversation_id: ThreadId::new(),
+                call_id: "call-2".to_string(),
+                approval_id: Some("approval-2".to_string()),
+                command: vec!["pwd".to_string()],
+                cwd: "/tmp/project".into(),
+                reason: Some("Need shell".to_string()),
+                parsed_cmd: Vec::new(),
+            },
+        };
+
+        let (_, event) = server_request_thread_event(&request).expect("request should bridge");
+        assert!(matches!(event.msg, EventMsg::ExecApprovalRequest(_)));
     }
 }

--- a/codex-rs/tui_app_server/src/app/app_server_requests.rs
+++ b/codex-rs/tui_app_server/src/app/app_server_requests.rs
@@ -2,7 +2,9 @@ use std::collections::HashMap;
 
 use crate::app_command::AppCommand;
 use crate::app_command::AppCommandView;
+use codex_app_server_protocol::CommandExecutionApprovalDecision;
 use codex_app_server_protocol::CommandExecutionRequestApprovalResponse;
+use codex_app_server_protocol::ExecCommandApprovalResponse;
 use codex_app_server_protocol::FileChangeApprovalDecision;
 use codex_app_server_protocol::FileChangeRequestApprovalResponse;
 use codex_app_server_protocol::GrantedPermissionProfile;
@@ -31,9 +33,21 @@ pub(super) struct UnsupportedAppServerRequest {
     pub(super) message: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ExecApprovalResponseKind {
+    LegacyV1,
+    V2,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PendingExecApproval {
+    request_id: AppServerRequestId,
+    response_kind: ExecApprovalResponseKind,
+}
+
 #[derive(Debug, Default)]
 pub(super) struct PendingAppServerRequests {
-    exec_approvals: HashMap<String, AppServerRequestId>,
+    exec_approvals: HashMap<String, PendingExecApproval>,
     file_change_approvals: HashMap<String, AppServerRequestId>,
     permissions_approvals: HashMap<String, AppServerRequestId>,
     user_inputs: HashMap<String, AppServerRequestId>,
@@ -56,6 +70,7 @@ impl PendingAppServerRequests {
     pub(super) fn note_server_request(
         &mut self,
         request: &ServerRequest,
+        allow_legacy_exec_approvals: bool,
     ) -> Option<UnsupportedAppServerRequest> {
         match request {
             ServerRequest::CommandExecutionRequestApproval { request_id, params } => {
@@ -63,7 +78,13 @@ impl PendingAppServerRequests {
                     .approval_id
                     .clone()
                     .unwrap_or_else(|| params.item_id.clone());
-                self.exec_approvals.insert(approval_id, request_id.clone());
+                self.exec_approvals.insert(
+                    approval_id,
+                    PendingExecApproval {
+                        request_id: request_id.clone(),
+                        response_kind: ExecApprovalResponseKind::V2,
+                    },
+                );
                 None
             }
             ServerRequest::FileChangeRequestApproval { request_id, params } => {
@@ -108,15 +129,43 @@ impl PendingAppServerRequests {
                             .to_string(),
                 })
             }
-            ServerRequest::ExecCommandApproval { request_id, .. } => {
-                Some(UnsupportedAppServerRequest {
-                    request_id: request_id.clone(),
-                    message:
-                        "Legacy command approval requests are not available in app-server TUI yet."
+            ServerRequest::ExecCommandApproval { request_id, params } => {
+                if !allow_legacy_exec_approvals {
+                    Some(UnsupportedAppServerRequest {
+                        request_id: request_id.clone(),
+                        message: "Legacy command approval requests are not available in app-server TUI yet."
                             .to_string(),
-                })
+                    })
+                } else {
+                    let approval_id = params
+                        .approval_id
+                        .clone()
+                        .unwrap_or_else(|| params.call_id.clone());
+                    self.exec_approvals.insert(
+                        approval_id,
+                        PendingExecApproval {
+                            request_id: request_id.clone(),
+                            response_kind: ExecApprovalResponseKind::LegacyV1,
+                        },
+                    );
+                    None
+                }
             }
         }
+    }
+
+    pub(super) fn clear_request(&mut self, request_id: &AppServerRequestId) {
+        self.exec_approvals
+            .retain(|_, value| &value.request_id != request_id);
+        self.file_change_approvals
+            .retain(|_, value| value != request_id);
+        self.permissions_approvals
+            .retain(|_, value| value != request_id);
+        self.user_inputs.retain(|_, value| value != request_id);
+        self.mcp_pending_by_matcher
+            .retain(|_, value| value != request_id);
+        self.mcp_legacy_requests
+            .retain(|_, value| value != request_id);
     }
 
     pub(super) fn note_legacy_event(&mut self, event: &Event) {
@@ -152,15 +201,33 @@ impl PendingAppServerRequests {
             AppCommandView::ExecApproval { id, decision, .. } => self
                 .exec_approvals
                 .remove(id)
-                .map(|request_id| {
+                .map(|pending| {
                     Ok::<AppServerRequestResolution, String>(AppServerRequestResolution {
-                        request_id,
-                        result: serde_json::to_value(CommandExecutionRequestApprovalResponse {
-                            decision: decision.clone().into(),
-                        })
-                        .map_err(|err| {
-                            format!("failed to serialize command execution approval response: {err}")
-                        })?,
+                        request_id: pending.request_id,
+                        result: match pending.response_kind {
+                            ExecApprovalResponseKind::LegacyV1 => {
+                                serde_json::to_value(ExecCommandApprovalResponse {
+                                    decision: decision.clone(),
+                                })
+                                .map_err(|err| {
+                                    format!(
+                                        "failed to serialize legacy command approval response: {err}"
+                                    )
+                                })?
+                            }
+                            ExecApprovalResponseKind::V2 => {
+                                serde_json::to_value(CommandExecutionRequestApprovalResponse {
+                                    decision: CommandExecutionApprovalDecision::from(
+                                        decision.clone(),
+                                    ),
+                                })
+                                .map_err(|err| {
+                                    format!(
+                                        "failed to serialize command execution approval response: {err}"
+                                    )
+                                })?
+                            }
+                        },
                     })
                 })
                 .transpose()?,
@@ -268,7 +335,8 @@ impl PendingAppServerRequests {
     }
 
     pub(super) fn resolve_notification(&mut self, request_id: &AppServerRequestId) {
-        self.exec_approvals.retain(|_, value| value != request_id);
+        self.exec_approvals
+            .retain(|_, value| &value.request_id != request_id);
         self.file_change_approvals
             .retain(|_, value| value != request_id);
         self.permissions_approvals
@@ -360,6 +428,7 @@ fn file_change_decision(decision: &ReviewDecision) -> Result<FileChangeApprovalD
 mod tests {
     use super::PendingAppServerRequests;
     use codex_app_server_protocol::CommandExecutionRequestApprovalParams;
+    use codex_app_server_protocol::ExecCommandApprovalParams;
     use codex_app_server_protocol::FileChangeRequestApprovalParams;
     use codex_app_server_protocol::McpElicitationObjectType;
     use codex_app_server_protocol::McpElicitationSchema;
@@ -409,7 +478,10 @@ mod tests {
             },
         };
 
-        assert_eq!(pending.note_server_request(&request), None);
+        assert_eq!(
+            pending.note_server_request(&request, /*allow_legacy_exec_approvals*/ false),
+            None
+        );
 
         let resolution = pending
             .take_resolution(&Op::ExecApproval {
@@ -425,35 +497,75 @@ mod tests {
     }
 
     #[test]
+    fn resolves_legacy_exec_approval_through_app_server_request_id() {
+        let mut pending = PendingAppServerRequests::default();
+        let request = ServerRequest::ExecCommandApproval {
+            request_id: AppServerRequestId::Integer(42),
+            params: ExecCommandApprovalParams {
+                conversation_id: codex_protocol::ThreadId::new(),
+                call_id: "call-2".to_string(),
+                approval_id: Some("approval-2".to_string()),
+                command: vec!["pwd".to_string()],
+                cwd: "/tmp/project".into(),
+                reason: Some("Need shell access".to_string()),
+                parsed_cmd: Vec::new(),
+            },
+        };
+
+        assert_eq!(
+            pending.note_server_request(&request, /*allow_legacy_exec_approvals*/ true),
+            None
+        );
+
+        let resolution = pending
+            .take_resolution(&Op::ExecApproval {
+                id: "approval-2".to_string(),
+                turn_id: None,
+                decision: ReviewDecision::Approved,
+            })
+            .expect("resolution should serialize")
+            .expect("request should be pending");
+
+        assert_eq!(resolution.request_id, AppServerRequestId::Integer(42));
+        assert_eq!(resolution.result, json!({ "decision": "approved" }));
+    }
+
+    #[test]
     fn resolves_permissions_and_user_input_through_app_server_request_id() {
         let mut pending = PendingAppServerRequests::default();
 
         assert_eq!(
-            pending.note_server_request(&ServerRequest::PermissionsRequestApproval {
-                request_id: AppServerRequestId::Integer(7),
-                params: PermissionsRequestApprovalParams {
-                    thread_id: "thread-1".to_string(),
-                    turn_id: "turn-1".to_string(),
-                    item_id: "perm-1".to_string(),
-                    reason: None,
-                    permissions: serde_json::from_value(json!({
-                        "network": { "enabled": null }
-                    }))
-                    .expect("valid permissions"),
+            pending.note_server_request(
+                &ServerRequest::PermissionsRequestApproval {
+                    request_id: AppServerRequestId::Integer(7),
+                    params: PermissionsRequestApprovalParams {
+                        thread_id: "thread-1".to_string(),
+                        turn_id: "turn-1".to_string(),
+                        item_id: "perm-1".to_string(),
+                        reason: None,
+                        permissions: serde_json::from_value(json!({
+                            "network": { "enabled": null }
+                        }))
+                        .expect("valid permissions"),
+                    },
                 },
-            }),
+                /*allow_legacy_exec_approvals*/ false,
+            ),
             None
         );
         assert_eq!(
-            pending.note_server_request(&ServerRequest::ToolRequestUserInput {
-                request_id: AppServerRequestId::Integer(8),
-                params: ToolRequestUserInputParams {
-                    thread_id: "thread-1".to_string(),
-                    turn_id: "turn-2".to_string(),
-                    item_id: "tool-1".to_string(),
-                    questions: Vec::new(),
+            pending.note_server_request(
+                &ServerRequest::ToolRequestUserInput {
+                    request_id: AppServerRequestId::Integer(8),
+                    params: ToolRequestUserInputParams {
+                        thread_id: "thread-1".to_string(),
+                        turn_id: "turn-2".to_string(),
+                        item_id: "tool-1".to_string(),
+                        questions: Vec::new(),
+                    },
                 },
-            }),
+                /*allow_legacy_exec_approvals*/ false,
+            ),
             None
         );
 
@@ -536,24 +648,27 @@ mod tests {
         });
 
         assert_eq!(
-            pending.note_server_request(&ServerRequest::McpServerElicitationRequest {
-                request_id: AppServerRequestId::Integer(12),
-                params: McpServerElicitationRequestParams {
-                    thread_id: "thread-1".to_string(),
-                    turn_id: Some("turn-1".to_string()),
-                    server_name: "example".to_string(),
-                    request: McpServerElicitationRequest::Form {
-                        meta: None,
-                        message: "Need input".to_string(),
-                        requested_schema: McpElicitationSchema {
-                            schema_uri: None,
-                            type_: McpElicitationObjectType::Object,
-                            properties: BTreeMap::new(),
-                            required: None,
+            pending.note_server_request(
+                &ServerRequest::McpServerElicitationRequest {
+                    request_id: AppServerRequestId::Integer(12),
+                    params: McpServerElicitationRequestParams {
+                        thread_id: "thread-1".to_string(),
+                        turn_id: Some("turn-1".to_string()),
+                        server_name: "example".to_string(),
+                        request: McpServerElicitationRequest::Form {
+                            meta: None,
+                            message: "Need input".to_string(),
+                            requested_schema: McpElicitationSchema {
+                                schema_uri: None,
+                                type_: McpElicitationObjectType::Object,
+                                properties: BTreeMap::new(),
+                                required: None,
+                            },
                         },
                     },
                 },
-            }),
+                /*allow_legacy_exec_approvals*/ false,
+            ),
             None
         );
 
@@ -583,16 +698,19 @@ mod tests {
     fn rejects_dynamic_tool_calls_as_unsupported() {
         let mut pending = PendingAppServerRequests::default();
         let unsupported = pending
-            .note_server_request(&ServerRequest::DynamicToolCall {
-                request_id: AppServerRequestId::Integer(99),
-                params: codex_app_server_protocol::DynamicToolCallParams {
-                    thread_id: "thread-1".to_string(),
-                    turn_id: "turn-1".to_string(),
-                    call_id: "tool-1".to_string(),
-                    tool: "tool".to_string(),
-                    arguments: json!({}),
+            .note_server_request(
+                &ServerRequest::DynamicToolCall {
+                    request_id: AppServerRequestId::Integer(99),
+                    params: codex_app_server_protocol::DynamicToolCallParams {
+                        thread_id: "thread-1".to_string(),
+                        turn_id: "turn-1".to_string(),
+                        call_id: "tool-1".to_string(),
+                        tool: "tool".to_string(),
+                        arguments: json!({}),
+                    },
                 },
-            })
+                /*allow_legacy_exec_approvals*/ false,
+            )
             .expect("dynamic tool calls should be rejected");
 
         assert_eq!(unsupported.request_id, AppServerRequestId::Integer(99));
@@ -622,16 +740,19 @@ mod tests {
     fn rejects_invalid_patch_decisions_for_file_change_requests() {
         let mut pending = PendingAppServerRequests::default();
         assert_eq!(
-            pending.note_server_request(&ServerRequest::FileChangeRequestApproval {
-                request_id: AppServerRequestId::Integer(13),
-                params: FileChangeRequestApprovalParams {
-                    thread_id: "thread-1".to_string(),
-                    turn_id: "turn-1".to_string(),
-                    item_id: "patch-1".to_string(),
-                    reason: None,
-                    grant_root: None,
+            pending.note_server_request(
+                &ServerRequest::FileChangeRequestApproval {
+                    request_id: AppServerRequestId::Integer(13),
+                    params: FileChangeRequestApprovalParams {
+                        thread_id: "thread-1".to_string(),
+                        turn_id: "turn-1".to_string(),
+                        item_id: "patch-1".to_string(),
+                        reason: None,
+                        grant_root: None,
+                    },
                 },
-            }),
+                /*allow_legacy_exec_approvals*/ false,
+            ),
             None
         );
 

--- a/codex-rs/tui_app_server/src/app/app_server_requests.rs
+++ b/codex-rs/tui_app_server/src/app/app_server_requests.rs
@@ -1,3 +1,23 @@
+//! Tracks pending app-server requests and correlates them with user
+//! decisions to produce JSON-RPC response payloads.
+//!
+//! When the remote app-server needs interactive input (command approval,
+//! file-change approval, permission grant, user-input prompt, or MCP
+//! elicitation), it sends a `ServerRequest` with a `request_id`. This
+//! module records that request, waits for the TUI to produce an
+//! `AppCommand` with the user's decision, and then builds the
+//! `AppServerRequestResolution` that the caller sends back as a
+//! JSON-RPC response.
+//!
+//! ## MCP elicitation correlation
+//!
+//! MCP elicitation has a two-phase correlation problem: the legacy event
+//! path delivers an `ElicitationRequest` event (with a core
+//! `McpRequestId`), while the server-request path delivers a
+//! `McpServerElicitationRequest` (with an app-server `RequestId`).
+//! `McpServerMatcher` hashes on `(server_name, turn_id, request_body)`
+//! to pair these two regardless of arrival order.
+
 use std::collections::HashMap;
 
 use crate::app_command::AppCommand;
@@ -33,6 +53,13 @@ pub(super) struct UnsupportedAppServerRequest {
     pub(super) message: String,
 }
 
+/// Discriminates between the two wire formats for exec-approval responses.
+///
+/// - `LegacyV1` — older `ExecCommandApproval` path; serializes to
+///   `ExecCommandApprovalResponse` with `{ "decision": "approved" }`.
+/// - `V2` — current `CommandExecutionRequestApproval` path; serializes
+///   to `CommandExecutionRequestApprovalResponse` with
+///   `{ "decision": "accept" }`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum ExecApprovalResponseKind {
     LegacyV1,
@@ -45,14 +72,27 @@ struct PendingExecApproval {
     response_kind: ExecApprovalResponseKind,
 }
 
+/// In-memory registry of app-server requests awaiting user decisions.
+///
+/// Each request type has its own index keyed by the identifier the TUI
+/// will use to look it up when the user makes a choice (approval ID,
+/// item ID, turn ID, etc.). The maps are drained by `take_resolution`
+/// and bulk-cleared on turn boundaries or disconnects.
 #[derive(Debug, Default)]
 pub(super) struct PendingAppServerRequests {
+    /// Keyed by approval-ID (or item-ID fallback).
     exec_approvals: HashMap<String, PendingExecApproval>,
+    /// Keyed by item-ID.
     file_change_approvals: HashMap<String, AppServerRequestId>,
+    /// Keyed by item-ID.
     permissions_approvals: HashMap<String, AppServerRequestId>,
+    /// Keyed by turn-ID.
     user_inputs: HashMap<String, AppServerRequestId>,
+    /// V2 server-requests that arrived before the matching legacy event.
     mcp_pending_by_matcher: HashMap<McpServerMatcher, AppServerRequestId>,
+    /// Legacy events that arrived before the matching V2 server-request.
     mcp_legacy_by_matcher: HashMap<McpServerMatcher, McpLegacyRequestKey>,
+    /// Fully correlated MCP requests ready for resolution.
     mcp_legacy_requests: HashMap<McpLegacyRequestKey, AppServerRequestId>,
 }
 
@@ -168,6 +208,12 @@ impl PendingAppServerRequests {
             .retain(|_, value| value != request_id);
     }
 
+    /// Record a legacy event so it can be correlated with a future
+    /// `McpServerElicitationRequest` server-request.
+    ///
+    /// Only `ElicitationRequest` events need this treatment; all other
+    /// legacy event types are either fully handled by the legacy path or
+    /// have a 1:1 server-request equivalent that carries its own ID.
     pub(super) fn note_legacy_event(&mut self, event: &Event) {
         let EventMsg::ElicitationRequest(request) = &event.msg else {
             return;
@@ -349,10 +395,18 @@ impl PendingAppServerRequests {
     }
 }
 
+/// Content-based key for pairing a legacy `ElicitationRequest` event
+/// with its corresponding `McpServerElicitationRequest` server-request.
+///
+/// Both sides serialize the elicitation request body to a canonical JSON
+/// string so they produce the same matcher regardless of which arrives
+/// first. The `turn_id` further scopes the match to the correct turn.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct McpServerMatcher {
     server_name: String,
     turn_id: Option<String>,
+    /// Canonical JSON serialization of the elicitation request body,
+    /// used for equality comparison.
     request: String,
 }
 
@@ -403,6 +457,8 @@ impl McpServerMatcher {
     }
 }
 
+/// Identifies a legacy MCP elicitation by the values the TUI uses to
+/// resolve it: the server name and the core-protocol request ID.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct McpLegacyRequestKey {
     server_name: String,

--- a/codex-rs/tui_app_server/src/app/app_server_requests.rs
+++ b/codex-rs/tui_app_server/src/app/app_server_requests.rs
@@ -781,13 +781,17 @@ mod tests {
         let mut pending = PendingAppServerRequests::default();
 
         assert_eq!(
-            pending.note_server_request(&ServerRequest::ChatgptAuthTokensRefresh {
-                request_id: AppServerRequestId::Integer(100),
-                params: codex_app_server_protocol::ChatgptAuthTokensRefreshParams {
-                    reason: codex_app_server_protocol::ChatgptAuthTokensRefreshReason::Unauthorized,
-                    previous_account_id: Some("workspace-1".to_string()),
+            pending.note_server_request(
+                &ServerRequest::ChatgptAuthTokensRefresh {
+                    request_id: AppServerRequestId::Integer(100),
+                    params: codex_app_server_protocol::ChatgptAuthTokensRefreshParams {
+                        reason:
+                            codex_app_server_protocol::ChatgptAuthTokensRefreshReason::Unauthorized,
+                        previous_account_id: Some("workspace-1".to_string()),
+                    },
                 },
-            }),
+                /*allow_legacy_exec_approvals*/ false,
+            ),
             None
         );
     }


### PR DESCRIPTION
## Problem

When the TUI connects to a **remote** app-server (as opposed to a local in-process one), several interactive flows were silently broken:

1. **Command execution lifecycle** — `ItemStarted` / `ItemCompleted` notifications for `CommandExecution` items were passed through the generic `thread_item_to_core` path, which returns `None` for `CommandExecution` variants. The TUI never saw `ExecCommandBegin` / `ExecCommandEnd` events, so command output and status were invisible.

2. **Command execution output streaming** — `CommandExecutionOutputDelta` and `TerminalInteraction` notifications were unconditionally ignored (fell through to the `_ => None` arm in `server_notification_thread_events`).

3. **Server requests (approvals, permissions, user input, MCP elicitation)** — `AppServerEvent::ServerRequest` was only partially wired for remote sessions. The adapter did not translate `ServerRequest` variants into core `Event`/`EventMsg` values the TUI event store understands, so approval dialogs, permission prompts, and MCP elicitation forms never appeared.

4. **Legacy exec-command approvals** — The older `ExecCommandApproval` request variant was unconditionally rejected even when the server was remote and sent it as the only approval mechanism.

5. **ChatGPT auth token refresh** — `ChatgptAuthTokensRefresh` server requests were rejected as unsupported. The TUI now handles them by loading local ChatGPT credentials and responding with fresh tokens, including account-ID mismatch detection.

## Mental model

The app-server adapter sits between two protocol worlds:

- **Upstream**: the app-server protocol (`codex_app_server_protocol`) which uses `ServerNotification`, `ServerRequest`, and `LegacyNotification`.
- **Downstream**: the TUI event store which consumes `codex_protocol::protocol::Event` / `EventMsg`.

This PR closes the remaining translation gaps so that the remote app-server's full interactive surface — command execution, approval flows, permission grants, user-input prompts, MCP elicitation, and auth token refresh — is faithfully represented as TUI events.

The translation is split across two files:

| File | Responsibility |
|------|---------------|
| `app_server_adapter.rs` | Event *translation*: convert server notifications and requests into `Event` sequences. Also handles `ChatgptAuthTokensRefresh` requests by loading local credentials. |
| `app_server_requests.rs` | Request *lifecycle*: track pending server requests, correlate them with user decisions, and produce JSON-RPC response payloads. |

## Non-goals

- No changes to the local (in-process) app-server path; `is_remote` guards ensure existing behavior is untouched.
- No new TUI widgets or UI changes — this is purely plumbing.
- No changes to the app-server protocol definitions themselves.

## Tradeoffs

- **`split_remote_command_for_approval`** uses `shlex::split` to tokenize command strings arriving from the remote server. If the remote ever sends a command that `shlex` cannot parse (mismatched quotes), it falls back to a single-element vec. This is a pragmatic choice over rejecting the request.

- **Legacy V1 vs V2 approval responses** — rather than removing the legacy `ExecCommandApproval` path, the PR adds an `ExecApprovalResponseKind` discriminant so both response shapes can coexist. The legacy path is gated behind `allow_legacy_exec_approvals` so local sessions still reject it.

- **`serde_json` round-tripping** for MCP elicitation and permissions responses: both paths serialize to `Value` then deserialize into the app-server protocol type. This avoids adding direct `From`/`Into` impls across crate boundaries at the cost of runtime serialization overhead and opaque error messages.

## Architecture

```
Remote App-Server (WebSocket)
        │
        ▼
 AppServerEvent::ServerNotification ──► server_notification_thread_events()
                                            │  NEW: is_remote flag controls
                                            │  CommandExecution / OutputDelta /
                                            │  TerminalInteraction bridging
                                            ▼
                                     Vec<Event> ──► enqueue_app_server_thread_event()
                                                            │
 AppServerEvent::ServerRequest ──► server_request_thread_event()  ◄── NEW
        │                                   │
        ├── ChatgptAuthTokensRefresh ──► handle_chatgpt_auth_tokens_refresh_request()
        │                                   │  loads local credentials, responds or rejects
        │                                   │
        │                                   ▼
        │                            Event (approval / permission / etc.)
        │                                   │
        ▼                                   ▼
 PendingAppServerRequests::note_server_request()
        │    NEW: allow_legacy_exec_approvals
        │    NEW: ExecApprovalResponseKind enum
        ▼
 (user decision in TUI)
        │
        ▼
 PendingAppServerRequests::take_resolution()
        │    NEW: LegacyV1 vs V2 response serialization
        ▼
 AppServerRequestResolution ──► reject_app_server_request() or send response
```

## Observability

- `tracing::warn!` on every rejected or failed-to-enqueue server request, including the request ID.
- `tracing::debug!` for unsupported `ThreadItem` variants in `thread_item_to_core`.
- `tracing::warn!` when the event stream disconnects.
- `tracing::warn!` on ChatGPT auth refresh failures (serialization, account mismatch, task panic).

## Tests

All new translation paths are covered by unit tests in the same files:

| Test | What it validates |
|------|-------------------|
| `bridges_remote_exec_command_items_and_output` | Full command lifecycle: `ItemStarted` → `ExecCommandBegin`, `CommandExecutionOutputDelta` → `ExecCommandOutputDelta`, `TerminalInteraction` → `TerminalInteraction`, `ItemCompleted` → `ExecCommandEnd`. |
| `bridges_remote_server_requests_into_core_events` | `CommandExecutionRequestApproval` → `ExecApprovalRequest` with field mapping. |
| `bridges_legacy_remote_exec_approval_requests` | `ExecCommandApproval` (V1) → `ExecApprovalRequest`. |
| `resolves_legacy_exec_approval_through_app_server_request_id` | Round-trip: note legacy request → take resolution → verify V1 JSON shape. |
| `resolves_exec_approval_through_app_server_request_id` | Round-trip for V2 approval. |
| `correlates_mcp_elicitation_between_legacy_event_and_server_request` | MCP matcher correlation across legacy and server-request paths. |
| `does_not_mark_chatgpt_auth_refresh_as_unsupported` | `ChatgptAuthTokensRefresh` is no longer rejected. |
| `refresh_request_uses_local_chatgpt_auth` | End-to-end: writes local auth, resolves refresh, verifies response fields. |
| `refresh_request_rejects_account_mismatch` | Account-ID mismatch returns a descriptive error. |