### PR TITLE
Fix fuzzy search notification buffering in app-server tests

### DIFF
--- a/codex-rs/app-server/tests/common/mcp_process.rs
+++ b/codex-rs/app-server/tests/common/mcp_process.rs
@@ -1031,6 +1031,31 @@ impl McpProcess {
         Ok(notification)
     }
 
+    pub async fn read_stream_until_matching_notification<F>(
+        &mut self,
+        description: &str,
+        predicate: F,
+    ) -> anyhow::Result<JSONRPCNotification>
+    where
+        F: Fn(&JSONRPCNotification) -> bool,
+    {
+        eprintln!("in read_stream_until_matching_notification({description})");
+
+        let message = self
+            .read_stream_until_message(|message| {
+                matches!(
+                    message,
+                    JSONRPCMessage::Notification(notification) if predicate(notification)
+                )
+            })
+            .await?;
+
+        let JSONRPCMessage::Notification(notification) = message else {
+            unreachable!("expected JSONRPCMessage::Notification, got {message:?}");
+        };
+        Ok(notification)
+    }
+
     pub async fn read_next_message(&mut self) -> anyhow::Result<JSONRPCMessage> {
         self.read_stream_until_message(|_| true).await
     }
@@ -1041,6 +1066,16 @@ impl McpProcess {
     /// messages buffered from the prior turn.
     pub fn clear_message_buffer(&mut self) {
         self.pending_messages.clear();
+    }
+
+    pub fn pending_notification_methods(&self) -> Vec<String> {
+        self.pending_messages
+            .iter()
+            .filter_map(|message| match message {
+                JSONRPCMessage::Notification(notification) => Some(notification.method.clone()),
+                _ => None,
+            })
+            .collect()
     }
 
     /// Reads the stream until a message matches `predicate`, buffering any non-matching messages

--- a/codex-rs/app-server/tests/suite/fuzzy_file_search.rs
+++ b/codex-rs/app-server/tests/suite/fuzzy_file_search.rs
@@ -52,54 +52,86 @@ async fn wait_for_session_updated(
     query: &str,
     file_expectation: FileExpectation,
 ) -> Result<FuzzyFileSearchSessionUpdatedNotification> {
-    for _ in 0..20 {
-        let notification = timeout(
-            DEFAULT_READ_TIMEOUT,
-            mcp.read_stream_until_notification_message(SESSION_UPDATED_METHOD),
-        )
-        .await??;
-        let params = notification
-            .params
-            .ok_or_else(|| anyhow!("missing notification params"))?;
-        let payload = serde_json::from_value::<FuzzyFileSearchSessionUpdatedNotification>(params)?;
-        if payload.session_id != session_id || payload.query != query {
-            continue;
+    let description = format!("session update for sessionId={session_id}, query={query}");
+    let notification = match timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_matching_notification(&description, |notification| {
+            if notification.method != SESSION_UPDATED_METHOD {
+                return false;
+            }
+            let Some(params) = notification.params.as_ref() else {
+                return false;
+            };
+            let Ok(payload) =
+                serde_json::from_value::<FuzzyFileSearchSessionUpdatedNotification>(params.clone())
+            else {
+                return false;
+            };
+            let files_match = match file_expectation {
+                FileExpectation::Any => true,
+                FileExpectation::Empty => payload.files.is_empty(),
+                FileExpectation::NonEmpty => !payload.files.is_empty(),
+            };
+            payload.session_id == session_id && payload.query == query && files_match
+        }),
+    )
+    .await
+    {
+        Ok(result) => result?,
+        Err(_) => {
+            anyhow::bail!(
+                "timed out waiting for {description}; buffered notifications={:?}",
+                mcp.pending_notification_methods()
+            )
         }
-        let files_match = match file_expectation {
-            FileExpectation::Any => true,
-            FileExpectation::Empty => payload.files.is_empty(),
-            FileExpectation::NonEmpty => !payload.files.is_empty(),
-        };
-        if files_match {
-            return Ok(payload);
-        }
-    }
-    anyhow::bail!(
-        "did not receive expected session update for sessionId={session_id}, query={query}"
-    );
+    };
+    let params = notification
+        .params
+        .ok_or_else(|| anyhow!("missing notification params"))?;
+    Ok(serde_json::from_value::<
+        FuzzyFileSearchSessionUpdatedNotification,
+    >(params)?)
 }
 
 async fn wait_for_session_completed(
     mcp: &mut McpProcess,
     session_id: &str,
 ) -> Result<FuzzyFileSearchSessionCompletedNotification> {
-    for _ in 0..20 {
-        let notification = timeout(
-            DEFAULT_READ_TIMEOUT,
-            mcp.read_stream_until_notification_message(SESSION_COMPLETED_METHOD),
-        )
-        .await??;
-        let params = notification
-            .params
-            .ok_or_else(|| anyhow!("missing notification params"))?;
-        let payload =
-            serde_json::from_value::<FuzzyFileSearchSessionCompletedNotification>(params)?;
-        if payload.session_id == session_id {
-            return Ok(payload);
+    let description = format!("session completion for sessionId={session_id}");
+    let notification = match timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_matching_notification(&description, |notification| {
+            if notification.method != SESSION_COMPLETED_METHOD {
+                return false;
+            }
+            let Some(params) = notification.params.as_ref() else {
+                return false;
+            };
+            let Ok(payload) = serde_json::from_value::<FuzzyFileSearchSessionCompletedNotification>(
+                params.clone(),
+            ) else {
+                return false;
+            };
+            payload.session_id == session_id
+        }),
+    )
+    .await
+    {
+        Ok(result) => result?,
+        Err(_) => {
+            anyhow::bail!(
+                "timed out waiting for {description}; buffered notifications={:?}",
+                mcp.pending_notification_methods()
+            )
         }
-    }
+    };
 
-    anyhow::bail!("did not receive expected session completion for sessionId={session_id}");
+    let params = notification
+        .params
+        .ok_or_else(|| anyhow!("missing notification params"))?;
+    Ok(serde_json::from_value::<
+        FuzzyFileSearchSessionCompletedNotification,
+    >(params)?)
 }
 
 async fn assert_update_request_fails_for_missing_session(


### PR DESCRIPTION
## What is flaky
`codex-rs/app-server/tests/suite/fuzzy_file_search.rs` intermittently loses the expected `fuzzyFileSearch/sessionUpdated` and `fuzzyFileSearch/sessionCompleted` notifications when multiple fuzzy-search sessions are active and CI delivers notifications out of order.

## Why it was flaky
The wait helpers were keyed only by JSON-RPC method name.

- `wait_for_session_updated` consumed the next `fuzzyFileSearch/sessionUpdated` notification even when it belonged to a different search session.
- `wait_for_session_completed` did the same for `fuzzyFileSearch/sessionCompleted`.
- Once an unmatched notification was read, it was dropped permanently instead of buffered.
- That meant a valid completion for the target search could arrive slightly early, be consumed by the wrong waiter, and disappear before the test started waiting for it.

The result depended on notification ordering and runner scheduling instead of on the actual product behavior.

## How this PR fixes it
- Add a buffered notification reader in `codex-rs/app-server/tests/common/mcp_process.rs`.
- Match fuzzy-search notifications on the identifying payload fields instead of matching only on method name.
- Preserve unmatched notifications in the in-process queue so later waiters can still consume them.
- Include pending notification methods in timeout failures to make future diagnosis concrete.

## Why this fix fixes the flakiness
The test now behaves like a real consumer of an out-of-order event stream: notifications for other sessions stay buffered until the correct waiter asks for them. Reordering no longer loses the target event, so the test result is determined by whether the server emitted the right notifications, not by which one happened to be read first.
