### PR TITLE
Bound Windows PowerShell parser hangs

### DIFF
--- a/codex-rs/shell-command/src/command_safety/windows_safe_commands.rs
+++ b/codex-rs/shell-command/src/command_safety/windows_safe_commands.rs
@@ -3,6 +3,7 @@ use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use serde::Deserialize;
 use std::io::Read;
 use std::path::Path;
+use std::process::Child;
 use std::process::Command;
 use std::process::Output;
 use std::process::Stdio;
@@ -155,46 +156,8 @@ fn parse_with_powershell_ast(executable: &str, script: &str) -> PowershellParseO
         Err(_) => return PowershellParseOutcome::Failed,
     };
 
-    let deadline = Instant::now() + POWERSHELL_PARSER_TIMEOUT;
-    let output = loop {
-        match child.try_wait() {
-            Ok(Some(status)) => {
-                let mut stdout = Vec::new();
-                let mut stderr = Vec::new();
-
-                if let Some(mut reader) = child.stdout.take()
-                    && reader.read_to_end(&mut stdout).is_err()
-                {
-                    return PowershellParseOutcome::Failed;
-                }
-
-                if let Some(mut reader) = child.stderr.take()
-                    && reader.read_to_end(&mut stderr).is_err()
-                {
-                    return PowershellParseOutcome::Failed;
-                }
-
-                break Output {
-                    status,
-                    stdout,
-                    stderr,
-                };
-            }
-            Ok(None) => {
-                if Instant::now() >= deadline {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    return PowershellParseOutcome::Failed;
-                }
-
-                thread::sleep(POWERSHELL_PARSER_POLL_INTERVAL);
-            }
-            Err(_) => {
-                let _ = child.kill();
-                let _ = child.wait();
-                return PowershellParseOutcome::Failed;
-            }
-        }
+    let Some(output) = wait_for_output_with_timeout(&mut child, POWERSHELL_PARSER_TIMEOUT) else {
+        return PowershellParseOutcome::Failed;
     };
 
     match output.status.success() {
@@ -206,6 +169,50 @@ fn parse_with_powershell_ast(executable: &str, script: &str) -> PowershellParseO
             }
         }
         false => PowershellParseOutcome::Failed,
+    }
+}
+
+fn wait_for_output_with_timeout(child: &mut Child, timeout: Duration) -> Option<Output> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let mut stdout = Vec::new();
+                let mut stderr = Vec::new();
+
+                if let Some(mut reader) = child.stdout.take()
+                    && reader.read_to_end(&mut stdout).is_err()
+                {
+                    return None;
+                }
+
+                if let Some(mut reader) = child.stderr.take()
+                    && reader.read_to_end(&mut stderr).is_err()
+                {
+                    return None;
+                }
+
+                return Some(Output {
+                    status,
+                    stdout,
+                    stderr,
+                });
+            }
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return None;
+                }
+
+                thread::sleep(POWERSHELL_PARSER_POLL_INTERVAL);
+            }
+            Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+        }
     }
 }
 
@@ -406,11 +413,9 @@ fn is_safe_git_command(words: &[String]) -> bool {
 mod tests {
     use super::*;
     use crate::powershell::try_find_pwsh_executable_blocking;
-    use std::fs;
     use std::string::ToString;
     use std::time::Duration;
     use std::time::Instant;
-    use std::time::SystemTime;
 
     /// Converts a slice of string literals into owned `String`s for the tests.
     fn vec_str(args: &[&str]) -> Vec<String> {
@@ -685,23 +690,17 @@ mod tests {
 
     #[test]
     fn powershell_ast_parser_times_out_for_stuck_child() {
-        let unique = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .expect("system time")
-            .as_nanos();
-        let script_path =
-            std::env::temp_dir().join(format!("codex-powershell-parser-timeout-{unique}.cmd"));
-        fs::write(&script_path, "@echo off\r\ntimeout /t 10 /nobreak >nul\r\n")
-            .expect("write fake powershell");
-
+        let mut child = Command::new("timeout.exe")
+            .args(["/t", "10", "/nobreak"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn timeout");
         let started = Instant::now();
-        let outcome = parse_with_powershell_ast(
-            script_path.to_str().expect("utf8 temp path"),
-            "Write-Output ok",
-        );
-        let _ = fs::remove_file(&script_path);
+        let output = wait_for_output_with_timeout(&mut child, POWERSHELL_PARSER_TIMEOUT);
 
-        assert!(matches!(outcome, PowershellParseOutcome::Failed));
+        assert!(output.is_none());
         assert!(started.elapsed() < POWERSHELL_PARSER_TIMEOUT + Duration::from_secs(1));
     }
 }

--- a/codex-rs/shell-command/src/command_safety/windows_safe_commands.rs
+++ b/codex-rs/shell-command/src/command_safety/windows_safe_commands.rs
@@ -1,11 +1,19 @@
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use serde::Deserialize;
+use std::io::Read;
 use std::path::Path;
 use std::process::Command;
+use std::process::Output;
+use std::process::Stdio;
 use std::sync::LazyLock;
+use std::thread;
+use std::time::Duration;
+use std::time::Instant;
 
 const POWERSHELL_PARSER_SCRIPT: &str = include_str!("powershell_parser.ps1");
+const POWERSHELL_PARSER_TIMEOUT: Duration = Duration::from_secs(5);
+const POWERSHELL_PARSER_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
 /// On Windows, we conservatively allow only clearly read-only PowerShell invocations
 /// that match a small safelist. Anything else (including direct CMD commands) is unsafe.
@@ -127,7 +135,7 @@ fn is_powershell_executable(exe: &str) -> bool {
 fn parse_with_powershell_ast(executable: &str, script: &str) -> PowershellParseOutcome {
     let encoded_script = encode_powershell_base64(script);
     let encoded_parser_script = encoded_parser_script();
-    match Command::new(executable)
+    let mut child = match Command::new(executable)
         .args([
             "-NoLogo",
             "-NoProfile",
@@ -136,18 +144,68 @@ fn parse_with_powershell_ast(executable: &str, script: &str) -> PowershellParseO
             encoded_parser_script,
         ])
         .env("CODEX_POWERSHELL_PAYLOAD", &encoded_script)
-        .output()
+        // Match `Command::output()` so PowerShell does not stay alive waiting on inherited stdin
+        // after the parser script has already finished.
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
     {
-        Ok(output) if output.status.success() => {
-            if let Ok(result) =
-                serde_json::from_slice::<PowershellParserOutput>(output.stdout.as_slice())
-            {
+        Ok(child) => child,
+        Err(_) => return PowershellParseOutcome::Failed,
+    };
+
+    let deadline = Instant::now() + POWERSHELL_PARSER_TIMEOUT;
+    let output = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let mut stdout = Vec::new();
+                let mut stderr = Vec::new();
+
+                if let Some(mut reader) = child.stdout.take()
+                    && reader.read_to_end(&mut stdout).is_err()
+                {
+                    return PowershellParseOutcome::Failed;
+                }
+
+                if let Some(mut reader) = child.stderr.take()
+                    && reader.read_to_end(&mut stderr).is_err()
+                {
+                    return PowershellParseOutcome::Failed;
+                }
+
+                break Output {
+                    status,
+                    stdout,
+                    stderr,
+                };
+            }
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return PowershellParseOutcome::Failed;
+                }
+
+                thread::sleep(POWERSHELL_PARSER_POLL_INTERVAL);
+            }
+            Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return PowershellParseOutcome::Failed;
+            }
+        }
+    };
+
+    match output.status.success() {
+        true => {
+            if let Ok(result) = serde_json::from_slice::<PowershellParserOutput>(&output.stdout) {
                 result.into_outcome()
             } else {
                 PowershellParseOutcome::Failed
             }
         }
-        _ => PowershellParseOutcome::Failed,
+        false => PowershellParseOutcome::Failed,
     }
 }
 
@@ -348,7 +406,11 @@ fn is_safe_git_command(words: &[String]) -> bool {
 mod tests {
     use super::*;
     use crate::powershell::try_find_pwsh_executable_blocking;
+    use std::fs;
     use std::string::ToString;
+    use std::time::Duration;
+    use std::time::Instant;
+    use std::time::SystemTime;
 
     /// Converts a slice of string literals into owned `String`s for the tests.
     fn vec_str(args: &[&str]) -> Vec<String> {
@@ -619,5 +681,27 @@ mod tests {
                 "`{chain}` should be considered safe to pwsh.exe"
             );
         }
+    }
+
+    #[test]
+    fn powershell_ast_parser_times_out_for_stuck_child() {
+        let unique = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        let script_path =
+            std::env::temp_dir().join(format!("codex-powershell-parser-timeout-{unique}.cmd"));
+        fs::write(&script_path, "@echo off\r\ntimeout /t 10 /nobreak >nul\r\n")
+            .expect("write fake powershell");
+
+        let started = Instant::now();
+        let outcome = parse_with_powershell_ast(
+            script_path.to_str().expect("utf8 temp path"),
+            "Write-Output ok",
+        );
+        let _ = fs::remove_file(&script_path);
+
+        assert!(matches!(outcome, PowershellParseOutcome::Failed));
+        assert!(started.elapsed() < POWERSHELL_PARSER_TIMEOUT + Duration::from_secs(1));
     }
 }


### PR DESCRIPTION
## What is flaky
`codex-rs/shell-command/src/command_safety/windows_safe_commands.rs` had intermittent Windows failures in `recognizes_safe_powershell_wrappers` and `accepts_full_path_powershell_invocations`.

## Why it was flaky
Those tests exercise the same PowerShell AST helper that `is_safe_command` uses to classify wrapper commands.

- The helper shells out to PowerShell and waits for it to parse the command AST.
- On some Windows CI runners, PowerShell startup can stall during process initialization.
- After the first timeout hardening, the helper no longer used `Command::output()`, which meant stdin was inherited unless it was set explicitly.
- An inherited stdin let the parser process sit around waiting for input until the timeout budget expired, even for commands that should have parsed immediately.

So the tests were not actually flaking on parsing logic. They were flaking because the helper process lifecycle depended on runner startup conditions and stdin wiring.

## How this PR fixes it
- Keep the parser bounded by a strict 5 second cap and fail closed if the child does not finish.
- Poll and terminate a stuck parser child instead of waiting indefinitely.
- Add a regression test for the stuck-child path.
- Set the parser subprocess stdin to `Stdio::null()` so it matches the old `Command::output()` behavior and never waits on inherited input.

## Why this fix fixes the flakiness
The safe-command classifier now has deterministic process semantics: the helper either exits quickly with parse output or it is treated as failed within the bounded window. There is no longer a path where a safe wrapper depends on ambient stdin state or on a half-started PowerShell process lingering until timeout.
