### PR TITLE
Remove live PowerShell discovery from shell handler test

### DIFF
--- a/codex-rs/core/src/tools/handlers/shell_tests.rs
+++ b/codex-rs/core/src/tools/handlers/shell_tests.rs
@@ -7,8 +7,6 @@ use pretty_assertions::assert_eq;
 use crate::codex::make_session_and_context;
 use crate::exec_env::create_env;
 use crate::is_safe_command::is_known_safe_command;
-use crate::powershell::try_find_powershell_executable_blocking;
-use crate::powershell::try_find_pwsh_executable_blocking;
 use crate::sandboxing::SandboxPermissions;
 use crate::shell::Shell;
 use crate::shell::ShellType;
@@ -34,24 +32,8 @@ fn commands_generated_by_shell_command_handler_can_be_matched_by_is_known_safe_c
         shell_snapshot: crate::shell::empty_shell_snapshot_receiver(),
     };
     assert_safe(&zsh_shell, "ls -la");
-
-    if let Some(path) = try_find_powershell_executable_blocking() {
-        let powershell = Shell {
-            shell_type: ShellType::PowerShell,
-            shell_path: path.to_path_buf(),
-            shell_snapshot: crate::shell::empty_shell_snapshot_receiver(),
-        };
-        assert_safe(&powershell, "ls -Name");
-    }
-
-    if let Some(path) = try_find_pwsh_executable_blocking() {
-        let pwsh = Shell {
-            shell_type: ShellType::PowerShell,
-            shell_path: path.to_path_buf(),
-            shell_snapshot: crate::shell::empty_shell_snapshot_receiver(),
-        };
-        assert_safe(&pwsh, "ls -Name");
-    }
+    // PowerShell wrapper safety lives in codex-shell-command, which already
+    // covers real executable discovery and parser behavior directly.
 }
 
 fn assert_safe(shell: &Shell, command: &str) {


### PR DESCRIPTION
## What is flaky
`commands_generated_by_shell_command_handler_can_be_matched_by_is_known_safe_command` in `codex-rs/core/src/tools/handlers/shell_tests.rs` was intermittently environment-sensitive on Windows.

## Why it was flaky
This is a unit test for shell-command construction, but it was also probing the live environment for `powershell.exe` and `pwsh.exe`.

- The test changed behavior depending on which PowerShell executables happened to be installed on the runner.
- That made the result depend on machine setup instead of on the handler logic under test.
- The executable discovery and PowerShell wrapper parsing paths are already covered directly in `codex-shell-command`, so this unit test was duplicating the wrong layer of behavior.

In practice, the flakiness came from mixing an invariant unit test with host-specific shell discovery.

## How this PR fixes it
- Remove the live PowerShell executable discovery from this unit test.
- Keep the command-shape assertions that belong to the shell handler itself.
- Leave real PowerShell executable discovery and wrapper parsing coverage in the dedicated `codex-shell-command` tests.

## Why this fix fixes the flakiness
The test is now deterministic because it only checks the handler's own invariants. It no longer asks the host machine which PowerShell binary exists, so CI environment differences cannot flip the result while the product behavior remains separately covered where that behavior actually lives.
