### PR TITLE
Fix code mode yield startup race

### DIFF
--- a/codex-rs/core/src/tools/code_mode/runner.cjs
+++ b/codex-rs/core/src/tools/code_mode/runner.cjs
@@ -465,6 +465,7 @@ function codeModeWorkerMain() {
       writable: false,
     });
 
+    parentPort.postMessage({ type: 'started' });
     try {
       await runModule(context, start, callTool, helpers);
       parentPort.postMessage({
@@ -639,6 +640,10 @@ function startSession(protocol, sessions, start) {
     content_items: [],
     default_yield_time_ms: normalizeYieldTime(start.default_yield_time_ms),
     id: start.cell_id,
+    initial_yield_time_ms:
+      start.yield_time_ms == null
+        ? normalizeYieldTime(start.default_yield_time_ms)
+        : normalizeYieldTime(start.yield_time_ms),
     initial_yield_timer: null,
     initial_yield_triggered: false,
     max_output_tokens_per_exec_call: maxOutputTokensPerExecCall,
@@ -651,11 +656,6 @@ function startSession(protocol, sessions, start) {
     }),
   };
   sessions.set(session.id, session);
-  const initialYieldTime =
-    start.yield_time_ms == null
-      ? session.default_yield_time_ms
-      : normalizeYieldTime(start.yield_time_ms);
-  scheduleInitialYield(protocol, session, initialYieldTime);
 
   session.worker.on('message', (message) => {
     void handleWorkerMessage(protocol, sessions, session, message).catch((error) => {
@@ -691,6 +691,11 @@ async function handleWorkerMessage(protocol, sessions, session, message) {
 
   if (message.type === 'content_item') {
     session.content_items.push(cloneJsonValue(message.item));
+    return;
+  }
+
+  if (message.type === 'started') {
+    scheduleInitialYield(protocol, session, session.initial_yield_time_ms);
     return;
   }
 


### PR DESCRIPTION
## What is flaky
`code_mode_yield_timeout_works_for_busy_loop` in `codex-rs/core/tests/suite/code_mode.rs` intermittently failed on loaded CI runners.

## Why it was flaky
The initial `yield_time_ms` budget started when the worker was created, not when user code actually started running.

- Worker startup includes thread scheduling, context creation, and runtime setup.
- On a busy runner, that startup latency could consume most or all of the configured 100 ms yield budget.
- The test expected the busy loop to emit output before the initial yield, but the timer could already have expired before the first user statement executed.

That made the test sensitive to runner startup jitter rather than to the actual code-mode yield behavior.

## How this PR fixes it
- Have the worker send a `started` message once the runtime is initialized and execution is about to begin.
- Store the intended initial yield budget on the session.
- Schedule the initial yield timer only after the `started` message arrives.

## Why this fix fixes the flakiness
`yield_time_ms` now measures execution time instead of worker boot time. Startup jitter can no longer steal the timeout budget, so the test outcome depends on the code-mode runner semantics rather than on CI machine load at worker creation.
