### PR TITLE
Preserve in-process request ordering for app-server clients

### DIFF
--- a/codex-rs/app-server-client/src/lib.rs
+++ b/codex-rs/app-server-client/src/lib.rs
@@ -352,14 +352,21 @@ impl InProcessAppServerClient {
                     command = command_rx.recv() => {
                         match command {
                             Some(ClientCommand::Request { request, response_tx }) => {
-                                let request_sender = request_sender.clone();
-                                // Request waits happen on a detached task so
-                                // this loop can keep draining runtime events
-                                // while the request is blocked on client input.
-                                tokio::spawn(async move {
-                                    let result = request_sender.request(*request).await;
-                                    let _ = response_tx.send(result);
-                                });
+                                // Enqueue synchronously so the embedded runtime
+                                // observes request order matching the caller's
+                                // command order, then detach only the response
+                                // wait so this loop can keep draining events.
+                                match request_sender.start_request(*request) {
+                                    Ok(pending_request) => {
+                                        tokio::spawn(async move {
+                                            let result = pending_request.recv().await;
+                                            let _ = response_tx.send(result);
+                                        });
+                                    }
+                                    Err(err) => {
+                                        let _ = response_tx.send(Err(err));
+                                    }
+                                }
                             }
                             Some(ClientCommand::Notify {
                                 notification,

--- a/codex-rs/app-server/src/in_process.rs
+++ b/codex-rs/app-server/src/in_process.rs
@@ -92,7 +92,24 @@ const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 /// Default bounded channel capacity for in-process runtime queues.
 pub const DEFAULT_IN_PROCESS_CHANNEL_CAPACITY: usize = CHANNEL_CAPACITY;
 
-type PendingClientRequestResponse = std::result::Result<Result, JSONRPCErrorError>;
+/// JSON-RPC application response returned by in-process client requests.
+pub type InProcessRequestResponse = std::result::Result<Result, JSONRPCErrorError>;
+
+/// Handle for a request that has been enqueued but whose response has not yet been awaited.
+pub struct PendingInProcessRequest {
+    response_rx: oneshot::Receiver<InProcessRequestResponse>,
+}
+
+impl PendingInProcessRequest {
+    pub async fn recv(self) -> IoResult<InProcessRequestResponse> {
+        self.response_rx.await.map_err(|err| {
+            IoError::new(
+                ErrorKind::BrokenPipe,
+                format!("in-process request response channel closed: {err}"),
+            )
+        })
+    }
+}
 
 fn server_notification_requires_delivery(notification: &ServerNotification) -> bool {
     matches!(notification, ServerNotification::TurnCompleted(_))
@@ -171,7 +188,7 @@ pub enum InProcessServerEvent {
 enum InProcessClientMessage {
     Request {
         request: Box<ClientRequest>,
-        response_tx: oneshot::Sender<PendingClientRequestResponse>,
+        response_tx: oneshot::Sender<InProcessRequestResponse>,
     },
     Notification {
         notification: ClientNotification,
@@ -200,18 +217,17 @@ pub struct InProcessClientSender {
 }
 
 impl InProcessClientSender {
-    pub async fn request(&self, request: ClientRequest) -> IoResult<PendingClientRequestResponse> {
+    pub fn start_request(&self, request: ClientRequest) -> IoResult<PendingInProcessRequest> {
         let (response_tx, response_rx) = oneshot::channel();
         self.try_send_client_message(InProcessClientMessage::Request {
             request: Box::new(request),
             response_tx,
         })?;
-        response_rx.await.map_err(|err| {
-            IoError::new(
-                ErrorKind::BrokenPipe,
-                format!("in-process request response channel closed: {err}"),
-            )
-        })
+        Ok(PendingInProcessRequest { response_rx })
+    }
+
+    pub async fn request(&self, request: ClientRequest) -> IoResult<InProcessRequestResponse> {
+        self.start_request(request)?.recv().await
     }
 
     pub fn notify(&self, notification: ClientNotification) -> IoResult<()> {
@@ -263,6 +279,11 @@ pub struct InProcessClientHandle {
 }
 
 impl InProcessClientHandle {
+    /// Enqueues a typed client request and returns a handle for awaiting the response later.
+    pub fn start_request(&self, request: ClientRequest) -> IoResult<PendingInProcessRequest> {
+        self.client.start_request(request)
+    }
+
     /// Sends a typed client request into the in-process runtime.
     ///
     /// The returned value is a transport-level `IoResult` containing either a
@@ -270,7 +291,7 @@ impl InProcessClientHandle {
     /// request IDs unique among concurrent requests; reusing an in-flight ID
     /// produces an `INVALID_REQUEST` response and can make request routing
     /// ambiguous in the caller.
-    pub async fn request(&self, request: ClientRequest) -> IoResult<PendingClientRequestResponse> {
+    pub async fn request(&self, request: ClientRequest) -> IoResult<InProcessRequestResponse> {
         self.client.request(request).await
     }
 
@@ -490,7 +511,7 @@ fn start_uninitialized(args: InProcessStartArgs) -> InProcessClientHandle {
             processor.shutdown_threads().await;
         });
         let mut pending_request_responses =
-            HashMap::<RequestId, oneshot::Sender<PendingClientRequestResponse>>::new();
+            HashMap::<RequestId, oneshot::Sender<InProcessRequestResponse>>::new();
         let mut shutdown_ack = None;
 
         loop {
@@ -732,6 +753,8 @@ mod tests {
     use super::*;
     use codex_app_server_protocol::ClientInfo;
     use codex_app_server_protocol::ConfigRequirementsReadResponse;
+    use codex_app_server_protocol::FuzzyFileSearchSessionStartParams;
+    use codex_app_server_protocol::FuzzyFileSearchSessionUpdateParams;
     use codex_app_server_protocol::SessionSource as ApiSessionSource;
     use codex_app_server_protocol::ThreadStartParams;
     use codex_app_server_protocol::ThreadStartResponse;
@@ -740,6 +763,7 @@ mod tests {
     use codex_app_server_protocol::TurnStatus;
     use codex_core::config::ConfigBuilder;
     use pretty_assertions::assert_eq;
+    use tempfile::TempDir;
 
     async fn build_test_config() -> Config {
         match ConfigBuilder::default().build().await {
@@ -851,6 +875,50 @@ mod tests {
         };
         let _parsed: ConfigRequirementsReadResponse =
             serde_json::from_value(response).expect("response should match v2 schema");
+        client
+            .shutdown()
+            .await
+            .expect("in-process runtime should shutdown cleanly");
+    }
+
+    #[tokio::test]
+    async fn start_request_preserves_enqueue_order_for_dependent_requests() {
+        let client = start_test_client(SessionSource::Cli).await;
+        let root = TempDir::new().expect("temp dir should be created");
+        std::fs::write(root.path().join("alpha.txt"), "contents")
+            .expect("fixture file should be written");
+        let root_path = root.path().to_string_lossy().to_string();
+
+        let start_request = client
+            .start_request(ClientRequest::FuzzyFileSearchSessionStart {
+                request_id: RequestId::Integer(10),
+                params: FuzzyFileSearchSessionStartParams {
+                    session_id: "session-1".to_string(),
+                    roots: vec![root_path],
+                },
+            })
+            .expect("session start should enqueue");
+        let update_request = client
+            .start_request(ClientRequest::FuzzyFileSearchSessionUpdate {
+                request_id: RequestId::Integer(11),
+                params: FuzzyFileSearchSessionUpdateParams {
+                    session_id: "session-1".to_string(),
+                    query: "alpha".to_string(),
+                },
+            })
+            .expect("session update should enqueue");
+
+        start_request
+            .recv()
+            .await
+            .expect("session start transport should succeed")
+            .expect("session start should succeed");
+        update_request
+            .recv()
+            .await
+            .expect("session update transport should succeed")
+            .expect("session update should succeed");
+
         client
             .shutdown()
             .await

--- a/codex-rs/app-server/src/in_process.rs
+++ b/codex-rs/app-server/src/in_process.rs
@@ -755,6 +755,8 @@ mod tests {
     use codex_app_server_protocol::ConfigRequirementsReadResponse;
     use codex_app_server_protocol::FuzzyFileSearchSessionStartParams;
     use codex_app_server_protocol::FuzzyFileSearchSessionUpdateParams;
+    use codex_app_server_protocol::InitializeCapabilities;
+    use codex_app_server_protocol::InitializeParams;
     use codex_app_server_protocol::SessionSource as ApiSessionSource;
     use codex_app_server_protocol::ThreadStartParams;
     use codex_app_server_protocol::ThreadStartResponse;
@@ -883,7 +885,33 @@ mod tests {
 
     #[tokio::test]
     async fn start_request_preserves_enqueue_order_for_dependent_requests() {
-        let client = start_test_client(SessionSource::Cli).await;
+        let client = start(InProcessStartArgs {
+            arg0_paths: Arg0DispatchPaths::default(),
+            config: Arc::new(build_test_config().await),
+            cli_overrides: Vec::new(),
+            loader_overrides: LoaderOverrides::default(),
+            cloud_requirements: CloudRequirementsLoader::default(),
+            auth_manager: None,
+            thread_manager: None,
+            feedback: CodexFeedback::new(),
+            config_warnings: Vec::new(),
+            session_source: SessionSource::Cli,
+            enable_codex_api_key_env: false,
+            initialize: InitializeParams {
+                client_info: ClientInfo {
+                    name: "codex-in-process-test".to_string(),
+                    title: None,
+                    version: "0.0.0".to_string(),
+                },
+                capabilities: Some(InitializeCapabilities {
+                    experimental_api: true,
+                    ..Default::default()
+                }),
+            },
+            channel_capacity: DEFAULT_IN_PROCESS_CHANNEL_CAPACITY,
+        })
+        .await
+        .expect("in-process runtime should start");
         let root = TempDir::new().expect("temp dir should be created");
         std::fs::write(root.path().join("alpha.txt"), "contents")
             .expect("fixture file should be written");


### PR DESCRIPTION
## What is flaky
Dependent in-process requests can arrive at the embedded app-server out of order. The concrete flaky case that exposed this was fuzzy file search session startup followed immediately by a session update: under CI load, `sessionUpdate` would sometimes reach the runtime before `sessionStart`, so the update failed even though the caller sent the commands in the correct order.

## Why it was flaky
`InProcessAppServerClient` drained its caller command queue in order, but it then detached each request with `tokio::spawn(async move { request_sender.request(...).await })`. The actual enqueue into the app-server runtime happened only when that spawned task first got scheduled. That means request ordering was no longer determined by the worker loop that received the commands; it was determined by Tokio task scheduling. A later dependent request could run first, especially on a loaded CI runner.

The lower-level in-process transport also only exposed an await-the-whole-request API, so callers had no way to enqueue requests synchronously and defer only the response wait.

## How this PR fixes it
This PR adds `PendingInProcessRequest` plus `start_request()` to the in-process transport, so a caller can enqueue a request immediately and await its response later. The app-server client worker now calls `start_request()` inside the serial worker loop, then detaches only `recv().await`. I also added a regression test that queues `fuzzyFileSearch/sessionStart` and `fuzzyFileSearch/sessionUpdate` back-to-back through the new API and verifies the dependent update succeeds.

## Why this fix fixes the flakiness
The request enters the runtime at the point the worker handles the command, not at some later scheduler-dependent point when a spawned task first runs. That restores the invariant the tests assumed: command order and runtime request order are the same. The response wait is still detached, so the worker can continue draining events without reintroducing the race.
