### PR TITLE
Harden exec-server follow-up and workspace remap

### DIFF
--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
@@ -7466,12 +7466,17 @@
           "isFile": {
             "description": "Whether this entry resolves to a regular file.",
             "type": "boolean"
+          },
+          "isSymlink": {
+            "description": "Whether this entry is a symlink.",
+            "type": "boolean"
           }
         },
         "required": [
           "fileName",
           "isDirectory",
-          "isFile"
+          "isFile",
+          "isSymlink"
         ],
         "type": "object"
       },

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
@@ -4110,12 +4110,17 @@
         "isFile": {
           "description": "Whether this entry resolves to a regular file.",
           "type": "boolean"
+        },
+        "isSymlink": {
+          "description": "Whether this entry is a symlink.",
+          "type": "boolean"
         }
       },
       "required": [
         "fileName",
         "isDirectory",
-        "isFile"
+        "isFile",
+        "isSymlink"
       ],
       "type": "object"
     },

--- a/codex-rs/app-server-protocol/schema/json/v2/FsReadDirectoryResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/FsReadDirectoryResponse.json
@@ -15,12 +15,17 @@
         "isFile": {
           "description": "Whether this entry resolves to a regular file.",
           "type": "boolean"
+        },
+        "isSymlink": {
+          "description": "Whether this entry is a symlink.",
+          "type": "boolean"
         }
       },
       "required": [
         "fileName",
         "isDirectory",
-        "isFile"
+        "isFile",
+        "isSymlink"
       ],
       "type": "object"
     }

--- a/codex-rs/app-server-protocol/schema/typescript/v2/FsReadDirectoryEntry.ts
+++ b/codex-rs/app-server-protocol/schema/typescript/v2/FsReadDirectoryEntry.ts
@@ -17,4 +17,8 @@ isDirectory: boolean,
 /**
  * Whether this entry resolves to a regular file.
  */
-isFile: boolean, };
+isFile: boolean, 
+/**
+ * Whether this entry is a symlink.
+ */
+isSymlink: boolean, };

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -2210,6 +2210,8 @@ pub struct FsReadDirectoryEntry {
     pub is_directory: bool,
     /// Whether this entry resolves to a regular file.
     pub is_file: bool,
+    /// Whether this entry is a symlink.
+    pub is_symlink: bool,
 }
 
 /// Directory entries returned by `fs/readDirectory`.

--- a/codex-rs/app-server/src/fs_api.rs
+++ b/codex-rs/app-server/src/fs_api.rs
@@ -119,6 +119,7 @@ impl FsApi {
                     file_name: entry.file_name,
                     is_directory: entry.is_directory,
                     is_file: entry.is_file,
+                    is_symlink: entry.is_symlink,
                 })
                 .collect(),
         })

--- a/codex-rs/app-server/tests/suite/v2/fs.rs
+++ b/codex-rs/app-server/tests/suite/v2/fs.rs
@@ -229,11 +229,13 @@ async fn fs_methods_cover_current_fs_utils_surface() -> Result<()> {
                 file_name: "nested".to_string(),
                 is_directory: true,
                 is_file: false,
+                is_symlink: false,
             },
             FsReadDirectoryEntry {
                 file_name: "root.txt".to_string(),
                 is_directory: false,
                 is_file: true,
+                is_symlink: false,
             },
         ]
     );

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -225,7 +225,7 @@ use crate::network_policy_decision::execpolicy_network_rule_amendment;
 use crate::plugins::PluginsManager;
 use crate::plugins::build_plugin_injections;
 use crate::plugins::render_plugins_section;
-use crate::project_doc::get_user_instructions;
+use crate::project_doc::get_user_instructions_with_environment;
 use crate::protocol::AgentMessageContentDeltaEvent;
 use crate::protocol::AgentReasoningSectionBreakEvent;
 use crate::protocol::ApplyPatchApprovalRequestEvent;
@@ -475,7 +475,7 @@ impl Codex {
             config.startup_warnings.push(message);
         }
 
-        let user_instructions = get_user_instructions(&config).await;
+        let user_instructions = config.user_instructions.clone();
 
         let exec_policy = if crate::guardian::is_guardian_reviewer_source(&session_source) {
             // Guardian review should rely on the built-in shell safety checks,
@@ -1764,6 +1764,9 @@ impl Session {
 
         let session_execution_backends =
             session_execution_backends_for_config(config.as_ref(), None).await?;
+        session_configuration.user_instructions =
+            get_user_instructions_with_environment(config.as_ref(), &session_execution_backends.environment)
+                .await;
         let services = SessionServices {
             // Initialize the MCP connection manager with an uninitialized
             // instance. It will be replaced with one created via

--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -1716,6 +1716,9 @@ fn unified_exec_exec_server_flags_load_from_config() -> std::io::Result<()> {
         experimental_unified_exec_exec_server_websocket_url: Some(
             "ws://127.0.0.1:8765".to_string(),
         ),
+        experimental_unified_exec_exec_server_workspace_root: Some(
+            AbsolutePathBuf::try_from("/home/dev-user/codex").unwrap(),
+        ),
         ..Default::default()
     };
 
@@ -1730,6 +1733,10 @@ fn unified_exec_exec_server_flags_load_from_config() -> std::io::Result<()> {
     assert_eq!(
         config.experimental_unified_exec_exec_server_websocket_url,
         Some("ws://127.0.0.1:8765".to_string())
+    );
+    assert_eq!(
+        config.experimental_unified_exec_exec_server_workspace_root,
+        Some(AbsolutePathBuf::try_from("/home/dev-user/codex").unwrap())
     );
 
     Ok(())

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -546,6 +546,10 @@ pub struct Config {
     /// spawned-local variants.
     pub experimental_unified_exec_exec_server_websocket_url: Option<String>,
 
+    /// When set, remap remote exec-server cwd and filesystem paths from the
+    /// local session cwd root into this executor-visible workspace root.
+    pub experimental_unified_exec_exec_server_workspace_root: Option<AbsolutePathBuf>,
+
     /// Additional experimental tools to expose regardless of the model catalog's
     /// advertised tool support.
     pub experimental_supported_tools: Vec<String>,
@@ -1343,6 +1347,10 @@ pub struct ConfigToml {
 
     /// Optional websocket URL for connecting to an existing `codex-exec-server`.
     pub experimental_unified_exec_exec_server_websocket_url: Option<String>,
+
+    /// Optional absolute path to the executor-visible workspace root that
+    /// corresponds to the local session cwd.
+    pub experimental_unified_exec_exec_server_workspace_root: Option<AbsolutePathBuf>,
 
     /// Additional experimental tools to expose regardless of the selected
     /// model's advertised tool support.
@@ -2493,6 +2501,10 @@ impl Config {
                     Some(trimmed.to_string())
                 }
             });
+        let experimental_unified_exec_exec_server_workspace_root = config_profile
+            .experimental_unified_exec_exec_server_workspace_root
+            .clone()
+            .or(cfg.experimental_unified_exec_exec_server_workspace_root.clone());
         let experimental_supported_tools = config_profile
             .experimental_supported_tools
             .clone()
@@ -2792,6 +2804,7 @@ impl Config {
             experimental_unified_exec_use_exec_server,
             experimental_unified_exec_spawn_local_exec_server,
             experimental_unified_exec_exec_server_websocket_url,
+            experimental_unified_exec_exec_server_workspace_root,
             experimental_supported_tools,
             background_terminal_max_timeout,
             ghost_snapshot,

--- a/codex-rs/core/src/config/profile.rs
+++ b/codex-rs/core/src/config/profile.rs
@@ -52,6 +52,7 @@ pub struct ConfigProfile {
     pub experimental_unified_exec_use_exec_server: Option<bool>,
     pub experimental_unified_exec_spawn_local_exec_server: Option<bool>,
     pub experimental_unified_exec_exec_server_websocket_url: Option<String>,
+    pub experimental_unified_exec_exec_server_workspace_root: Option<AbsolutePathBuf>,
     pub experimental_supported_tools: Option<Vec<String>>,
     pub experimental_use_freeform_apply_patch: Option<bool>,
     pub tools_view_image: Option<bool>,

--- a/codex-rs/core/src/exec_server_filesystem.rs
+++ b/codex-rs/core/src/exec_server_filesystem.rs
@@ -99,7 +99,7 @@ impl ExecutorFileSystem for ExecServerFileSystem {
                 file_name: entry.file_name,
                 is_directory: entry.is_directory,
                 is_file: entry.is_file,
-                is_symlink: false,
+                is_symlink: entry.is_symlink,
             })
             .collect())
     }

--- a/codex-rs/core/src/exec_server_filesystem.rs
+++ b/codex-rs/core/src/exec_server_filesystem.rs
@@ -19,20 +19,36 @@ use codex_exec_server::ExecServerClient;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use std::io;
 
+use crate::exec_server_path_mapper::RemoteWorkspacePathMapper;
+
 #[derive(Clone)]
 pub(crate) struct ExecServerFileSystem {
     client: ExecServerClient,
+    path_mapper: Option<RemoteWorkspacePathMapper>,
 }
 
 impl ExecServerFileSystem {
-    pub(crate) fn new(client: ExecServerClient) -> Self {
-        Self { client }
+    pub(crate) fn new(
+        client: ExecServerClient,
+        path_mapper: Option<RemoteWorkspacePathMapper>,
+    ) -> Self {
+        Self {
+            client,
+            path_mapper,
+        }
+    }
+
+    fn map_path(&self, path: &AbsolutePathBuf) -> AbsolutePathBuf {
+        self.path_mapper
+            .as_ref()
+            .map_or_else(|| path.clone(), |mapper| mapper.map_path(path))
     }
 }
 
 #[async_trait]
 impl ExecutorFileSystem for ExecServerFileSystem {
     async fn read_file(&self, path: &AbsolutePathBuf) -> FileSystemResult<Vec<u8>> {
+        let path = self.map_path(path);
         let response = self
             .client
             .fs_read_file(FsReadFileParams { path: path.clone() })
@@ -44,6 +60,7 @@ impl ExecutorFileSystem for ExecServerFileSystem {
     }
 
     async fn write_file(&self, path: &AbsolutePathBuf, contents: Vec<u8>) -> FileSystemResult<()> {
+        let path = self.map_path(path);
         self.client
             .fs_write_file(FsWriteFileParams {
                 path: path.clone(),
@@ -59,6 +76,7 @@ impl ExecutorFileSystem for ExecServerFileSystem {
         path: &AbsolutePathBuf,
         options: CreateDirectoryOptions,
     ) -> FileSystemResult<()> {
+        let path = self.map_path(path);
         self.client
             .fs_create_directory(FsCreateDirectoryParams {
                 path: path.clone(),
@@ -70,6 +88,7 @@ impl ExecutorFileSystem for ExecServerFileSystem {
     }
 
     async fn get_metadata(&self, path: &AbsolutePathBuf) -> FileSystemResult<FileMetadata> {
+        let path = self.map_path(path);
         let response = self
             .client
             .fs_get_metadata(FsGetMetadataParams { path: path.clone() })
@@ -87,6 +106,7 @@ impl ExecutorFileSystem for ExecServerFileSystem {
         &self,
         path: &AbsolutePathBuf,
     ) -> FileSystemResult<Vec<ReadDirectoryEntry>> {
+        let path = self.map_path(path);
         let response = self
             .client
             .fs_read_directory(FsReadDirectoryParams { path: path.clone() })
@@ -105,6 +125,7 @@ impl ExecutorFileSystem for ExecServerFileSystem {
     }
 
     async fn remove(&self, path: &AbsolutePathBuf, options: RemoveOptions) -> FileSystemResult<()> {
+        let path = self.map_path(path);
         self.client
             .fs_remove(FsRemoveParams {
                 path: path.clone(),
@@ -122,6 +143,8 @@ impl ExecutorFileSystem for ExecServerFileSystem {
         destination_path: &AbsolutePathBuf,
         options: CopyOptions,
     ) -> FileSystemResult<()> {
+        let source_path = self.map_path(source_path);
+        let destination_path = self.map_path(destination_path);
         self.client
             .fs_copy(FsCopyParams {
                 source_path: source_path.clone(),

--- a/codex-rs/core/src/exec_server_path_mapper.rs
+++ b/codex-rs/core/src/exec_server_path_mapper.rs
@@ -1,0 +1,54 @@
+use codex_utils_absolute_path::AbsolutePathBuf;
+
+#[derive(Clone, Debug)]
+pub(crate) struct RemoteWorkspacePathMapper {
+    local_root: AbsolutePathBuf,
+    remote_root: AbsolutePathBuf,
+}
+
+impl RemoteWorkspacePathMapper {
+    pub(crate) fn new(local_root: AbsolutePathBuf, remote_root: AbsolutePathBuf) -> Self {
+        Self {
+            local_root,
+            remote_root,
+        }
+    }
+
+    pub(crate) fn map_path(&self, path: &AbsolutePathBuf) -> AbsolutePathBuf {
+        let Ok(relative) = path.as_path().strip_prefix(self.local_root.as_path()) else {
+            return path.clone();
+        };
+        AbsolutePathBuf::try_from(self.remote_root.as_path().join(relative))
+            .expect("workspace remap should preserve an absolute path")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RemoteWorkspacePathMapper;
+    use codex_utils_absolute_path::AbsolutePathBuf;
+
+    #[test]
+    fn remaps_path_inside_workspace_root() {
+        let mapper = RemoteWorkspacePathMapper::new(
+            AbsolutePathBuf::try_from("/Users/starr/code/codex").unwrap(),
+            AbsolutePathBuf::try_from("/home/dev-user/codex").unwrap(),
+        );
+        let path = AbsolutePathBuf::try_from("/Users/starr/code/codex/codex-rs/core/src/lib.rs")
+            .unwrap();
+        assert_eq!(
+            mapper.map_path(&path),
+            AbsolutePathBuf::try_from("/home/dev-user/codex/codex-rs/core/src/lib.rs").unwrap()
+        );
+    }
+
+    #[test]
+    fn leaves_path_outside_workspace_root_unchanged() {
+        let mapper = RemoteWorkspacePathMapper::new(
+            AbsolutePathBuf::try_from("/Users/starr/code/codex").unwrap(),
+            AbsolutePathBuf::try_from("/home/dev-user/codex").unwrap(),
+        );
+        let path = AbsolutePathBuf::try_from("/tmp/outside.txt").unwrap();
+        assert_eq!(mapper.map_path(&path), path);
+    }
+}

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -39,6 +39,7 @@ pub mod exec;
 pub mod exec_env;
 mod exec_policy;
 mod exec_server_filesystem;
+mod exec_server_path_mapper;
 pub mod external_agent_config;
 pub mod features;
 mod file_watcher;

--- a/codex-rs/core/src/project_doc.rs
+++ b/codex-rs/core/src/project_doc.rs
@@ -22,6 +22,8 @@ use crate::config_loader::merge_toml_values;
 use crate::config_loader::project_root_markers_from_config;
 use crate::features::Feature;
 use codex_app_server_protocol::ConfigLayerSource;
+use codex_environment::Environment;
+use codex_utils_absolute_path::AbsolutePathBuf;
 use dunce::canonicalize as normalize_path;
 use std::path::PathBuf;
 use tokio::io::AsyncReadExt;
@@ -78,7 +80,21 @@ fn render_js_repl_instructions(config: &Config) -> Option<String> {
 /// string of instructions.
 pub(crate) async fn get_user_instructions(config: &Config) -> Option<String> {
     let project_docs = read_project_docs(config).await;
+    build_user_instructions(config, project_docs)
+}
 
+pub(crate) async fn get_user_instructions_with_environment(
+    config: &Config,
+    environment: &Environment,
+) -> Option<String> {
+    let project_docs = read_project_docs_with_environment(config, environment).await;
+    build_user_instructions(config, project_docs)
+}
+
+fn build_user_instructions(
+    config: &Config,
+    project_docs: std::io::Result<Option<String>>,
+) -> Option<String> {
     let mut output = String::new();
 
     if let Some(instructions) = config.user_instructions.clone() {
@@ -116,6 +132,69 @@ pub(crate) async fn get_user_instructions(config: &Config) -> Option<String> {
         Some(output)
     } else {
         None
+    }
+}
+
+pub async fn read_project_docs_with_environment(
+    config: &Config,
+    environment: &Environment,
+) -> std::io::Result<Option<String>> {
+    let max_total = config.project_doc_max_bytes;
+
+    if max_total == 0 {
+        return Ok(None);
+    }
+
+    let paths = discover_project_doc_paths_with_environment(config, environment).await?;
+    if paths.is_empty() {
+        return Ok(None);
+    }
+
+    let file_system = environment.get_filesystem();
+    let mut remaining: u64 = max_total as u64;
+    let mut parts: Vec<String> = Vec::new();
+
+    for p in paths {
+        if remaining == 0 {
+            break;
+        }
+
+        let metadata = match file_system.get_metadata(&p).await {
+            Ok(metadata) => metadata,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(e),
+        };
+
+        let data = match file_system.read_file(&p).await {
+            Ok(data) => data,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(e),
+        };
+
+        if (data.len() as u64) > remaining {
+            tracing::warn!(
+                "Project doc `{}` exceeds remaining budget ({} bytes) - truncating.",
+                p.display(),
+                remaining,
+            );
+        }
+
+        let allowed = remaining.min(data.len() as u64) as usize;
+        let data = &data[..allowed];
+
+        if metadata.is_file {
+            let text = String::from_utf8_lossy(data).to_string();
+            if !text.trim().is_empty() {
+                parts.push(text);
+                remaining = remaining.saturating_sub(data.len() as u64);
+            }
+        }
+    }
+
+    if parts.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(parts.join("\n\n")))
     }
 }
 
@@ -261,6 +340,119 @@ pub fn discover_project_doc_paths(config: &Config) -> std::io::Result<Vec<PathBu
                         break;
                     }
                 }
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    Ok(found)
+}
+
+pub async fn discover_project_doc_paths_with_environment(
+    config: &Config,
+    environment: &Environment,
+) -> std::io::Result<Vec<AbsolutePathBuf>> {
+    let dir = AbsolutePathBuf::try_from(config.cwd.clone()).map_err(|err| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("cwd must be absolute for project-doc discovery: {err}"),
+        )
+    })?;
+    let file_system = environment.get_filesystem();
+
+    let mut merged = TomlValue::Table(toml::map::Map::new());
+    for layer in config.config_layer_stack.get_layers(
+        ConfigLayerStackOrdering::LowestPrecedenceFirst,
+        /*include_disabled*/ false,
+    ) {
+        if matches!(layer.name, ConfigLayerSource::Project { .. }) {
+            continue;
+        }
+        merge_toml_values(&mut merged, &layer.config);
+    }
+    let project_root_markers = match project_root_markers_from_config(&merged) {
+        Ok(Some(markers)) => markers,
+        Ok(None) => default_project_root_markers(),
+        Err(err) => {
+            tracing::warn!("invalid project_root_markers: {err}");
+            default_project_root_markers()
+        }
+    };
+
+    let mut project_root = None;
+    if !project_root_markers.is_empty() {
+        for ancestor in dir.as_path().ancestors() {
+            let ancestor = AbsolutePathBuf::try_from(ancestor.to_path_buf()).map_err(|err| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("ancestor must stay absolute for project-doc discovery: {err}"),
+                )
+            })?;
+            for marker in &project_root_markers {
+                let marker_path = AbsolutePathBuf::try_from(ancestor.as_path().join(marker))
+                    .map_err(|err| {
+                        std::io::Error::new(
+                            std::io::ErrorKind::InvalidInput,
+                            format!("marker path must stay absolute for project-doc discovery: {err}"),
+                        )
+                    })?;
+                let marker_exists = match file_system.get_metadata(&marker_path).await {
+                    Ok(_) => true,
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
+                    Err(e) => return Err(e),
+                };
+                if marker_exists {
+                    project_root = Some(ancestor);
+                    break;
+                }
+            }
+            if project_root.is_some() {
+                break;
+            }
+        }
+    }
+
+    let search_dirs: Vec<AbsolutePathBuf> = if let Some(root) = project_root {
+        let mut dirs = Vec::new();
+        let mut cursor = dir.as_path();
+        loop {
+            dirs.push(AbsolutePathBuf::try_from(cursor.to_path_buf()).map_err(|err| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("search dir must stay absolute for project-doc discovery: {err}"),
+                )
+            })?);
+            if cursor == root.as_path() {
+                break;
+            }
+            let Some(parent) = cursor.parent() else {
+                break;
+            };
+            cursor = parent;
+        }
+        dirs.reverse();
+        dirs
+    } else {
+        vec![dir]
+    };
+
+    let mut found: Vec<AbsolutePathBuf> = Vec::new();
+    let candidate_filenames = candidate_filenames(config);
+    for d in search_dirs {
+        for name in &candidate_filenames {
+            let candidate = AbsolutePathBuf::try_from(d.as_path().join(name)).map_err(|err| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("candidate path must stay absolute for project-doc discovery: {err}"),
+                )
+            })?;
+            match file_system.get_metadata(&candidate).await {
+                Ok(metadata) if metadata.is_file => {
+                    found.push(candidate);
+                    break;
+                }
+                Ok(_) => continue,
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
                 Err(e) => return Err(e),
             }

--- a/codex-rs/core/src/project_doc_tests.rs
+++ b/codex-rs/core/src/project_doc_tests.rs
@@ -1,8 +1,19 @@
 use super::*;
 use crate::config::ConfigBuilder;
 use crate::features::Feature;
+use async_trait::async_trait;
+use codex_environment::CopyOptions;
+use codex_environment::CreateDirectoryOptions;
+use codex_environment::Environment;
+use codex_environment::ExecutorFileSystem;
+use codex_environment::FileMetadata;
+use codex_environment::FileSystemResult;
+use codex_environment::ReadDirectoryEntry;
+use codex_environment::RemoveOptions;
+use codex_utils_absolute_path::AbsolutePathBuf;
 use std::fs;
 use std::path::PathBuf;
+use std::sync::Arc;
 use tempfile::TempDir;
 
 /// Helper that returns a `Config` pointing at `root` and using `limit` as
@@ -66,6 +77,117 @@ async fn make_config_with_project_root_markers(
     config.project_doc_max_bytes = limit;
     config.user_instructions = instructions.map(ToOwned::to_owned);
     config
+}
+
+#[derive(Clone)]
+struct RemappedFileSystem {
+    local_root: AbsolutePathBuf,
+    remote_root: AbsolutePathBuf,
+}
+
+impl RemappedFileSystem {
+    fn new(local_root: &std::path::Path, remote_root: &std::path::Path) -> Self {
+        Self {
+            local_root: AbsolutePathBuf::try_from(local_root.to_path_buf()).unwrap(),
+            remote_root: AbsolutePathBuf::try_from(remote_root.to_path_buf()).unwrap(),
+        }
+    }
+
+    fn remap(&self, path: &AbsolutePathBuf) -> AbsolutePathBuf {
+        let relative = path
+            .as_path()
+            .strip_prefix(self.local_root.as_path())
+            .expect("path should remain within local root during test");
+        AbsolutePathBuf::try_from(self.remote_root.as_path().join(relative)).unwrap()
+    }
+}
+
+#[async_trait]
+impl ExecutorFileSystem for RemappedFileSystem {
+    async fn read_file(&self, path: &AbsolutePathBuf) -> FileSystemResult<Vec<u8>> {
+        tokio::fs::read(self.remap(path).as_path()).await
+    }
+
+    async fn write_file(&self, path: &AbsolutePathBuf, contents: Vec<u8>) -> FileSystemResult<()> {
+        tokio::fs::write(self.remap(path).as_path(), contents).await
+    }
+
+    async fn create_directory(
+        &self,
+        path: &AbsolutePathBuf,
+        options: CreateDirectoryOptions,
+    ) -> FileSystemResult<()> {
+        if options.recursive {
+            tokio::fs::create_dir_all(self.remap(path).as_path()).await
+        } else {
+            tokio::fs::create_dir(self.remap(path).as_path()).await
+        }
+    }
+
+    async fn get_metadata(&self, path: &AbsolutePathBuf) -> FileSystemResult<FileMetadata> {
+        let metadata = tokio::fs::metadata(self.remap(path).as_path()).await?;
+        Ok(FileMetadata {
+            is_directory: metadata.is_dir(),
+            is_file: metadata.is_file(),
+            created_at_ms: 0,
+            modified_at_ms: 0,
+        })
+    }
+
+    async fn read_directory(
+        &self,
+        path: &AbsolutePathBuf,
+    ) -> FileSystemResult<Vec<ReadDirectoryEntry>> {
+        let mut entries = Vec::new();
+        let mut read_dir = tokio::fs::read_dir(self.remap(path).as_path()).await?;
+        while let Some(entry) = read_dir.next_entry().await? {
+            let metadata = tokio::fs::symlink_metadata(entry.path()).await?;
+            entries.push(ReadDirectoryEntry {
+                file_name: entry.file_name().to_string_lossy().into_owned(),
+                is_directory: metadata.is_dir(),
+                is_file: metadata.is_file(),
+                is_symlink: metadata.file_type().is_symlink(),
+            });
+        }
+        Ok(entries)
+    }
+
+    async fn remove(
+        &self,
+        path: &AbsolutePathBuf,
+        options: RemoveOptions,
+    ) -> FileSystemResult<()> {
+        let remapped = self.remap(path);
+        match tokio::fs::symlink_metadata(remapped.as_path()).await {
+            Ok(metadata) => {
+                if metadata.is_dir() {
+                    if options.recursive {
+                        tokio::fs::remove_dir_all(remapped.as_path()).await
+                    } else {
+                        tokio::fs::remove_dir(remapped.as_path()).await
+                    }
+                } else {
+                    tokio::fs::remove_file(remapped.as_path()).await
+                }
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound && options.force => Ok(()),
+            Err(err) => Err(err),
+        }
+    }
+
+    async fn copy(
+        &self,
+        source_path: &AbsolutePathBuf,
+        destination_path: &AbsolutePathBuf,
+        _options: CopyOptions,
+    ) -> FileSystemResult<()> {
+        tokio::fs::copy(
+            self.remap(source_path).as_path(),
+            self.remap(destination_path).as_path(),
+        )
+        .await
+        .map(|_| ())
+    }
 }
 
 /// AGENTS.md missing – should yield `None`.
@@ -237,6 +359,55 @@ async fn keeps_existing_instructions_when_doc_missing() {
     let res = get_user_instructions(&make_config(&tmp, 4096, Some(INSTRUCTIONS)).await).await;
 
     assert_eq!(res, Some(INSTRUCTIONS.to_string()));
+}
+
+#[tokio::test]
+async fn environment_backed_project_doc_prefers_remote_workspace_contents() {
+    let local = tempfile::tempdir().expect("local tempdir");
+    let remote = tempfile::tempdir().expect("remote tempdir");
+    fs::write(local.path().join("AGENTS.md"), "local doc").unwrap();
+    fs::write(remote.path().join("AGENTS.md"), "remote doc").unwrap();
+
+    let cfg = make_config(&local, 4096, None).await;
+    let environment = Environment::new(Arc::new(RemappedFileSystem::new(
+        local.path(),
+        remote.path(),
+    )));
+
+    let res = get_user_instructions_with_environment(&cfg, &environment)
+        .await
+        .expect("remote doc expected");
+
+    assert_eq!(res, "remote doc");
+}
+
+#[tokio::test]
+async fn environment_backed_project_doc_discovers_remote_hierarchy() {
+    let local = tempfile::tempdir().expect("local tempdir");
+    let remote = tempfile::tempdir().expect("remote tempdir");
+    fs::write(local.path().join(".git"), "gitdir: /tmp/local\n").unwrap();
+    fs::create_dir_all(local.path().join("workspace/crate_a")).unwrap();
+    fs::write(remote.path().join(".git"), "gitdir: /tmp/remote\n").unwrap();
+    fs::write(remote.path().join("AGENTS.md"), "remote root").unwrap();
+    fs::create_dir_all(remote.path().join("workspace/crate_a")).unwrap();
+    fs::write(
+        remote.path().join("workspace/crate_a/AGENTS.md"),
+        "remote nested",
+    )
+    .unwrap();
+
+    let mut cfg = make_config(&local, 4096, None).await;
+    cfg.cwd = local.path().join("workspace/crate_a");
+    let environment = Environment::new(Arc::new(RemappedFileSystem::new(
+        local.path(),
+        remote.path(),
+    )));
+
+    let res = get_user_instructions_with_environment(&cfg, &environment)
+        .await
+        .expect("remote docs expected");
+
+    assert_eq!(res, "remote root\n\nremote nested");
 }
 
 /// When both the repository root and the working directory contain

--- a/codex-rs/core/src/unified_exec/backend.rs
+++ b/codex-rs/core/src/unified_exec/backend.rs
@@ -107,10 +107,11 @@ impl UnifiedExecSessionFactory for ExecServerUnifiedExecSessionFactory {
             return open_local_session(env, tty, spawn_lifecycle).await;
         }
 
-        if env.sandbox == SandboxType::WindowsRestrictedToken {
+        if env.sandbox != SandboxType::None {
             debug!(
                 process_id,
-                "falling back to local unified-exec backend because Windows restricted-token execution is not modeled by exec-server",
+                sandbox = ?env.sandbox,
+                "falling back to local unified-exec backend because sandboxed execution is not modeled by exec-server",
             );
             return open_local_session(env, tty, spawn_lifecycle).await;
         }

--- a/codex-rs/core/src/unified_exec/backend.rs
+++ b/codex-rs/core/src/unified_exec/backend.rs
@@ -14,6 +14,7 @@ use tracing::debug;
 use crate::config::Config;
 use crate::exec::SandboxType;
 use crate::exec_server_filesystem::ExecServerFileSystem;
+use crate::exec_server_path_mapper::RemoteWorkspacePathMapper;
 use crate::sandboxing::ExecRequest;
 use crate::unified_exec::SpawnLifecycleHandle;
 use crate::unified_exec::UnifiedExecError;
@@ -60,6 +61,7 @@ impl UnifiedExecSessionFactory for LocalUnifiedExecSessionFactory {
 pub(crate) struct ExecServerUnifiedExecSessionFactory {
     client: ExecServerClient,
     _spawned_server: Option<Arc<SpawnedExecServer>>,
+    path_mapper: Option<RemoteWorkspacePathMapper>,
 }
 
 impl std::fmt::Debug for ExecServerUnifiedExecSessionFactory {
@@ -71,19 +73,25 @@ impl std::fmt::Debug for ExecServerUnifiedExecSessionFactory {
 }
 
 impl ExecServerUnifiedExecSessionFactory {
-    pub(crate) fn from_client(client: ExecServerClient) -> UnifiedExecSessionFactoryHandle {
+    pub(crate) fn from_client(
+        client: ExecServerClient,
+        path_mapper: Option<RemoteWorkspacePathMapper>,
+    ) -> UnifiedExecSessionFactoryHandle {
         Arc::new(Self {
             client,
             _spawned_server: None,
+            path_mapper,
         })
     }
 
     pub(crate) fn from_spawned_server(
         spawned_server: Arc<SpawnedExecServer>,
+        path_mapper: Option<RemoteWorkspacePathMapper>,
     ) -> UnifiedExecSessionFactoryHandle {
         Arc::new(Self {
             client: spawned_server.client().clone(),
             _spawned_server: Some(spawned_server),
+            path_mapper,
         })
     }
 }
@@ -122,6 +130,7 @@ impl UnifiedExecSessionFactory for ExecServerUnifiedExecSessionFactory {
             env,
             tty,
             spawn_lifecycle,
+            self.path_mapper.as_ref(),
         )
         .await
     }
@@ -131,6 +140,19 @@ pub(crate) async fn session_execution_backends_for_config(
     config: &Config,
     local_exec_server_command: Option<ExecServerLaunchCommand>,
 ) -> Result<SessionExecutionBackends, UnifiedExecError> {
+    let path_mapper = config
+        .experimental_unified_exec_exec_server_workspace_root
+        .clone()
+        .map(|remote_root| {
+            RemoteWorkspacePathMapper::new(
+                config
+                    .cwd
+                    .clone()
+                    .try_into()
+                    .expect("config cwd should be absolute"),
+                remote_root,
+            )
+        });
     if !config.experimental_unified_exec_use_exec_server {
         return Ok(SessionExecutionBackends {
             unified_exec_session_factory: local_unified_exec_session_factory(),
@@ -148,7 +170,7 @@ pub(crate) async fn session_execution_backends_for_config(
         ))
         .await
         .map_err(|err| UnifiedExecError::create_process(err.to_string()))?;
-        return Ok(exec_server_backends_from_client(client));
+        return Ok(exec_server_backends_from_client(client, path_mapper));
     }
 
     if config.experimental_unified_exec_spawn_local_exec_server {
@@ -159,13 +181,13 @@ pub(crate) async fn session_execution_backends_for_config(
                 .map_err(|err| UnifiedExecError::create_process(err.to_string()))?;
         return Ok(exec_server_backends_from_spawned_server(Arc::new(
             spawned_server,
-        )));
+        ), path_mapper));
     }
 
     let client = ExecServerClient::connect_in_process(ExecServerClientConnectOptions::default())
         .await
         .map_err(|err| UnifiedExecError::create_process(err.to_string()))?;
-    Ok(exec_server_backends_from_client(client))
+    Ok(exec_server_backends_from_client(client, path_mapper))
 }
 
 fn default_local_exec_server_command() -> ExecServerLaunchCommand {
@@ -185,26 +207,34 @@ fn default_local_exec_server_command() -> ExecServerLaunchCommand {
     }
 }
 
-fn exec_server_backends_from_client(client: ExecServerClient) -> SessionExecutionBackends {
+fn exec_server_backends_from_client(
+    client: ExecServerClient,
+    path_mapper: Option<RemoteWorkspacePathMapper>,
+) -> SessionExecutionBackends {
     SessionExecutionBackends {
         unified_exec_session_factory: ExecServerUnifiedExecSessionFactory::from_client(
             client.clone(),
+            path_mapper.clone(),
         ),
         environment: Arc::new(Environment::new(Arc::new(ExecServerFileSystem::new(
             client,
+            path_mapper,
         )))),
     }
 }
 
 fn exec_server_backends_from_spawned_server(
     spawned_server: Arc<SpawnedExecServer>,
+    path_mapper: Option<RemoteWorkspacePathMapper>,
 ) -> SessionExecutionBackends {
     SessionExecutionBackends {
         unified_exec_session_factory: ExecServerUnifiedExecSessionFactory::from_spawned_server(
             Arc::clone(&spawned_server),
+            path_mapper.clone(),
         ),
         environment: Arc::new(Environment::new(Arc::new(ExecServerFileSystem::new(
             spawned_server.client().clone(),
+            path_mapper,
         )))),
     }
 }

--- a/codex-rs/core/src/unified_exec/process.rs
+++ b/codex-rs/core/src/unified_exec/process.rs
@@ -17,12 +17,14 @@ use crate::exec::ExecToolCallOutput;
 use crate::exec::SandboxType;
 use crate::exec::StreamOutput;
 use crate::exec::is_likely_sandbox_denied;
+use crate::exec_server_path_mapper::RemoteWorkspacePathMapper;
 use crate::sandboxing::ExecRequest;
 use crate::truncate::TruncationPolicy;
 use crate::truncate::formatted_truncate_text;
 use codex_exec_server::ExecParams;
 use codex_exec_server::ExecServerClient;
 use codex_exec_server::ExecServerEvent;
+use codex_utils_absolute_path::AbsolutePathBuf;
 use codex_utils_pty::ExecCommandSession;
 use codex_utils_pty::SpawnedPty;
 
@@ -338,14 +340,22 @@ impl UnifiedExecProcess {
         env: &ExecRequest,
         tty: bool,
         spawn_lifecycle: SpawnLifecycleHandle,
+        path_mapper: Option<&RemoteWorkspacePathMapper>,
     ) -> Result<Self, UnifiedExecError> {
         let process_key = process_id.to_string();
         let mut events_rx = client.event_receiver();
+        let cwd = path_mapper.map_or_else(
+            || env.cwd.clone(),
+            |mapper| match AbsolutePathBuf::try_from(env.cwd.clone()) {
+                Ok(cwd) => mapper.map_path(&cwd).into(),
+                Err(_) => env.cwd.clone(),
+            },
+        );
         let response = client
             .exec(ExecParams {
                 process_id: process_key.clone(),
                 argv: env.command.clone(),
-                cwd: env.cwd.clone(),
+                cwd,
                 env: env.env.clone(),
                 tty,
                 arg0: env.arg0.clone(),

--- a/codex-rs/core/src/unified_exec/process.rs
+++ b/codex-rs/core/src/unified_exec/process.rs
@@ -341,7 +341,7 @@ impl UnifiedExecProcess {
     ) -> Result<Self, UnifiedExecError> {
         let process_key = process_id.to_string();
         let mut events_rx = client.event_receiver();
-        client
+        let response = client
             .exec(ExecParams {
                 process_id: process_key.clone(),
                 argv: env.command.clone(),
@@ -353,6 +353,7 @@ impl UnifiedExecProcess {
             })
             .await
             .map_err(|err| UnifiedExecError::create_process(err.to_string()))?;
+        let process_key = response.process_id;
 
         let (output_tx, output_rx) = broadcast::channel(256);
         let (writer_tx, mut writer_rx) = mpsc::channel::<Vec<u8>>(256);
@@ -374,9 +375,10 @@ impl UnifiedExecProcess {
 
         {
             let client = client.clone();
+            let writer_process_key = process_key.clone();
             tokio::spawn(async move {
                 while let Some(chunk) = writer_rx.recv().await {
-                    if client.write(&process_key, chunk).await.is_err() {
+                    if client.write(&writer_process_key, chunk).await.is_err() {
                         break;
                     }
                 }
@@ -384,7 +386,7 @@ impl UnifiedExecProcess {
         }
 
         {
-            let process_key = process_id.to_string();
+            let process_key = process_key.clone();
             let exited = Arc::clone(&exited);
             let exit_code = Arc::clone(&exit_code);
             let cancellation_token = managed.cancellation_token();

--- a/codex-rs/exec-server/src/server/filesystem.rs
+++ b/codex-rs/exec-server/src/server/filesystem.rs
@@ -121,6 +121,7 @@ impl ExecServerFileSystem {
                     file_name: entry.file_name,
                     is_directory: entry.is_directory,
                     is_file: entry.is_file,
+                    is_symlink: entry.is_symlink,
                 })
                 .collect(),
         })

--- a/codex-rs/exec-server/src/server/handler.rs
+++ b/codex-rs/exec-server/src/server/handler.rs
@@ -43,6 +43,10 @@ use crate::server::routing::invalid_params;
 use crate::server::routing::invalid_request;
 
 const RETAINED_OUTPUT_BYTES_PER_PROCESS: usize = 1024 * 1024;
+#[cfg(test)]
+const EXITED_PROCESS_RETENTION: Duration = Duration::from_millis(25);
+#[cfg(not(test))]
+const EXITED_PROCESS_RETENTION: Duration = Duration::from_secs(30);
 
 #[derive(Clone)]
 struct RetainedOutputChunk {
@@ -613,11 +617,16 @@ async fn watch_exit(
     let _ = outbound_tx
         .send(ExecServerOutboundMessage::Notification(
             ExecServerServerNotification::Exited(ExecExitedNotification {
-                process_id,
+                process_id: process_id.clone(),
                 exit_code,
             }),
         ))
         .await;
+    tokio::spawn(async move {
+        tokio::time::sleep(EXITED_PROCESS_RETENTION).await;
+        let mut processes = processes.lock().await;
+        processes.remove(&process_id);
+    });
 }
 
 #[cfg(test)]

--- a/codex-rs/exec-server/src/server/handler/tests.rs
+++ b/codex-rs/exec-server/src/server/handler/tests.rs
@@ -590,35 +590,33 @@ async fn terminate_keeps_process_ids_reserved() {
         panic!("initialized should succeed: {err}");
     }
 
-    let spawned = codex_utils_pty::spawn_pipe_process_no_stdin(
-        "bash",
-        &["-lc".to_string(), "sleep 30".to_string()],
-        std::env::current_dir().expect("cwd").as_path(),
-        &HashMap::new(),
-        &None,
-    )
-    .await
-    .expect("spawn test process");
-    {
-        let mut process_map = handler.processes.lock().await;
-        process_map.insert(
-            "proc-1".to_string(),
-            super::RunningProcess {
-                session: spawned.session,
+    if let Err(err) = handler
+        .handle_message(ExecServerInboundMessage::Request(ExecServerRequest::Exec {
+            request_id: RequestId::Integer(2),
+            params: crate::protocol::ExecParams {
+                process_id: "proc-1".to_string(),
+                argv: vec![
+                    "bash".to_string(),
+                    "-lc".to_string(),
+                    "sleep 30".to_string(),
+                ],
+                cwd: std::env::current_dir().expect("cwd"),
+                env: HashMap::new(),
                 tty: false,
-                output: std::collections::VecDeque::new(),
-                retained_bytes: 0,
-                next_seq: 1,
-                exit_code: None,
-                output_notify: Arc::new(Notify::new()),
+                arg0: None,
+                sandbox: None,
             },
-        );
+        }))
+        .await
+    {
+        panic!("exec should not fail the handler: {err}");
     }
+    let _ = recv_outbound(&mut outgoing_rx).await;
 
     if let Err(err) = handler
         .handle_message(ExecServerInboundMessage::Request(
             ExecServerRequest::Terminate {
-                request_id: RequestId::Integer(2),
+                request_id: RequestId::Integer(3),
                 params: crate::protocol::TerminateParams {
                     process_id: "proc-1".to_string(),
                 },
@@ -632,7 +630,7 @@ async fn terminate_keeps_process_ids_reserved() {
     assert_eq!(
         recv_outbound(&mut outgoing_rx).await,
         ExecServerOutboundMessage::Response {
-            request_id: RequestId::Integer(2),
+            request_id: RequestId::Integer(3),
             response: ExecServerResponseMessage::Terminate(TerminateResponse { running: true }),
         }
     );
@@ -641,6 +639,18 @@ async fn terminate_keeps_process_ids_reserved() {
         handler.processes.lock().await.contains_key("proc-1"),
         "terminated ids should stay reserved until exit cleanup removes them"
     );
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(1);
+    loop {
+        if !handler.processes.lock().await.contains_key("proc-1") {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "terminated ids should be removed after the exit retention window"
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
 
     handler.shutdown().await;
 }

--- a/codex-rs/exec/tests/suite/remote_exec_server.rs
+++ b/codex-rs/exec/tests/suite/remote_exec_server.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use std::net::TcpListener;
+use std::path::PathBuf;
 use std::process::Stdio;
 use std::time::Duration;
 
@@ -30,6 +31,10 @@ async fn exec_cli_can_route_remote_exec_and_read_file_through_exec_server() -> a
     let external_websocket_url = std::env::var("CODEX_EXEC_SERVER_TEST_WS_URL")
         .ok()
         .filter(|value| !value.trim().is_empty());
+    let external_remote_root = std::env::var("CODEX_EXEC_SERVER_TEST_REMOTE_ROOT")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .map(PathBuf::from);
     let websocket_url = if let Some(websocket_url) = external_websocket_url {
         websocket_url
     } else {
@@ -53,8 +58,14 @@ async fn exec_cli_can_route_remote_exec_and_read_file_through_exec_server() -> a
         Some(child)
     };
 
-    let seed_path = test.cwd_path().join("remote_exec_seed.txt");
-    std::fs::write(&seed_path, "remote-fs-seed\n")?;
+    let local_workspace_root = test.cwd_path().to_path_buf();
+    let remote_workspace_root = external_remote_root
+        .clone()
+        .unwrap_or_else(|| local_workspace_root.clone());
+    let seed_path = local_workspace_root.join("remote_exec_seed.txt");
+    if external_remote_root.is_none() {
+        std::fs::write(&seed_path, "remote-fs-seed\n")?;
+    }
 
     let server = responses::start_mock_server().await;
     let response_mock = responses::mount_sse_sequence(
@@ -66,7 +77,11 @@ async fn exec_cli_can_route_remote_exec_and_read_file_through_exec_server() -> a
                     "call-exec",
                     "exec_command",
                     &serde_json::to_string(&json!({
-                        "cmd": "printf from-remote > remote_exec_generated.txt",
+                        "cmd": if external_remote_root.is_some() {
+                            "printf remote-fs-seed > remote_exec_seed.txt && printf from-remote > remote_exec_generated.txt"
+                        } else {
+                            "printf from-remote > remote_exec_generated.txt"
+                        },
                         "yield_time_ms": 500,
                     }))?,
                 ),
@@ -89,7 +104,7 @@ async fn exec_cli_can_route_remote_exec_and_read_file_through_exec_server() -> a
                     "call-list",
                     "list_dir",
                     &serde_json::to_string(&json!({
-                        "dir_path": test.cwd_path(),
+                        "dir_path": local_workspace_root,
                         "offset": 1,
                         "limit": 20,
                         "depth": 1,
@@ -122,17 +137,24 @@ async fn exec_cli_can_route_remote_exec_and_read_file_through_exec_server() -> a
             serde_json::to_string(&websocket_url)?
         ))
         .arg("-c")
+        .arg(format!(
+            "experimental_unified_exec_exec_server_workspace_root={}",
+            serde_json::to_string(&remote_workspace_root)?
+        ))
+        .arg("-c")
         .arg("experimental_supported_tools=[\"read_file\",\"list_dir\"]")
         .arg("run remote exec-server tools")
         .assert()
         .success();
 
-    let generated_path = test.cwd_path().join("remote_exec_generated.txt");
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
-    while tokio::time::Instant::now() < deadline && !generated_path.exists() {
-        tokio::time::sleep(Duration::from_millis(50)).await;
+    if external_remote_root.is_none() {
+        let generated_path = test.cwd_path().join("remote_exec_generated.txt");
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while tokio::time::Instant::now() < deadline && !generated_path.exists() {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        assert_eq!(std::fs::read_to_string(&generated_path)?, "from-remote");
     }
-    assert_eq!(std::fs::read_to_string(&generated_path)?, "from-remote");
 
     let requests = response_mock.requests();
     let read_output = extract_output_text(&requests[2].function_call_output("call-read"));

--- a/docs/config.md
+++ b/docs/config.md
@@ -89,6 +89,11 @@ connects to that existing websocket endpoint and uses it for both unified-exec
 processes and remote filesystem operations such as `read_file`, `list_dir`, and
 `view_image`.
 
+When `experimental_unified_exec_exec_server_workspace_root` is also set, Codex
+remaps remote exec `cwd` values and remote filesystem tool paths from the local
+session `cwd` root into that executor-visible workspace root. Use this when the
+executor is running on another host and cannot see the laptop's absolute paths.
+
 When `experimental_unified_exec_spawn_local_exec_server` is also enabled, Codex
 starts a session-scoped local `codex-exec-server` subprocess on startup and
 uses that connection for the same process and filesystem calls.


### PR DESCRIPTION
## Summary
- fall back to local unified-exec when sandboxed execution is requested and exec-server cannot model it
- use the server-issued `process_id` for remote continuation paths
- preserve `is_symlink` across `fs/readDirectory` protocol, server, core proxy, and app-server
- clean up exited exec-server processes after a retention window
- add an explicit exec-server workspace root and remap remote `cwd` plus executor-backed filesystem paths under that workspace
- adapt the remote exec-server integration path for true cross-host workspace testing

## Why
This is a stacked follow-up on top of #15015. It closes the highest-risk parity and correctness gaps in the new exec-server-backed process/filesystem path and starts the real remote-host remap work needed for local orchestrator plus remote executor.

## Validation
- `cargo test -p codex-exec-server`
- `cargo test -p codex-app-server-protocol`
- `just write-app-server-schema`
- live exec-server websocket boot in tmux
- focused `codex-core` remap validation is in progress on an isolated `/tmp` cargo target

## Notes
- This PR is still draft because remote project-docs, remote skills, app-server parity, and explicit sandbox behavior are still in flight.
- The local architecture diagram for this session is at `/tmp/019cfe71-pr15015-change-diagram.svg`.
- Ralph-loop state is tracked in `/tmp/codex_ralph_loop.md` and `/tmp/codex_remote_executor_handoff.log`.
