### PR TITLE
Inject executor-aware filesystem into app-server

### DIFF
--- a/codex-rs/app-server/src/fs_api.rs
+++ b/codex-rs/app-server/src/fs_api.rs
@@ -31,11 +31,15 @@ pub(crate) struct FsApi {
     file_system: Arc<dyn ExecutorFileSystem>,
 }
 
+impl FsApi {
+    pub(crate) fn new(file_system: Arc<dyn ExecutorFileSystem>) -> Self {
+        Self { file_system }
+    }
+}
+
 impl Default for FsApi {
     fn default() -> Self {
-        Self {
-            file_system: Environment::default().get_filesystem(),
-        }
+        Self::new(Environment::default().get_filesystem())
     }
 }
 

--- a/codex-rs/app-server/src/in_process.rs
+++ b/codex-rs/app-server/src/in_process.rs
@@ -403,7 +403,7 @@ fn start_uninitialized(args: InProcessStartArgs) -> InProcessClientHandle {
         let processor_outgoing = Arc::clone(&outgoing_message_sender);
         let (processor_tx, mut processor_rx) = mpsc::channel::<ProcessorCommand>(channel_capacity);
         let mut processor_handle = tokio::spawn(async move {
-            let mut processor = MessageProcessor::new(MessageProcessorArgs {
+            let mut processor = match MessageProcessor::new(MessageProcessorArgs {
                 outgoing: Arc::clone(&processor_outgoing),
                 arg0_paths: args.arg0_paths,
                 config: args.config,
@@ -417,7 +417,15 @@ fn start_uninitialized(args: InProcessStartArgs) -> InProcessClientHandle {
                 config_warnings: args.config_warnings,
                 session_source: args.session_source,
                 enable_codex_api_key_env: args.enable_codex_api_key_env,
-            });
+            })
+            .await
+            {
+                Ok(processor) => processor,
+                Err(err) => {
+                    warn!("failed to build in-process message processor: {err}");
+                    return;
+                }
+            };
             let mut thread_created_rx = processor.thread_created_receiver();
             let mut session = ConnectionSessionState::default();
             let mut listen_for_threads = true;

--- a/codex-rs/app-server/src/lib.rs
+++ b/codex-rs/app-server/src/lib.rs
@@ -623,7 +623,13 @@ pub async fn run_main_with_transport(
             config_warnings,
             session_source: SessionSource::VSCode,
             enable_codex_api_key_env: false,
-        });
+        })
+        .await
+        .map_err(|err| {
+            std::io::Error::other(format!(
+                "failed to build app-server message processor: {err}"
+            ))
+        })?;
         let mut thread_created_rx = processor.thread_created_receiver();
         let mut running_turn_count_rx = processor.subscribe_running_assistant_turn_count();
         let mut connections = HashMap::<ConnectionId, ConnectionState>::new();

--- a/codex-rs/app-server/src/message_processor.rs
+++ b/codex-rs/app-server/src/message_processor.rs
@@ -62,6 +62,7 @@ use codex_core::default_client::USER_AGENT_SUFFIX;
 use codex_core::default_client::get_codex_user_agent;
 use codex_core::default_client::set_default_client_residency_requirement;
 use codex_core::default_client::set_default_originator;
+use codex_core::executor_environment_for_config;
 use codex_core::models_manager::collaboration_mode_presets::CollaborationModesConfig;
 use codex_feedback::CodexFeedback;
 use codex_protocol::ThreadId;
@@ -181,7 +182,7 @@ pub(crate) struct MessageProcessorArgs {
 impl MessageProcessor {
     /// Create a new `MessageProcessor`, retaining a handle to the outgoing
     /// `Sender` so handlers can enqueue messages to be written to stdout.
-    pub(crate) fn new(args: MessageProcessorArgs) -> Self {
+    pub(crate) async fn new(args: MessageProcessorArgs) -> std::io::Result<Self> {
         let MessageProcessorArgs {
             outgoing,
             arg0_paths,
@@ -253,9 +254,10 @@ impl MessageProcessor {
             analytics_events_client,
         );
         let external_agent_config_api = ExternalAgentConfigApi::new(config.codex_home.clone());
-        let fs_api = FsApi::default();
+        let environment = executor_environment_for_config(config.as_ref(), None).await?;
+        let fs_api = FsApi::new(environment.get_filesystem());
 
-        Self {
+        Ok(Self {
             outgoing,
             codex_message_processor,
             config_api,
@@ -264,7 +266,7 @@ impl MessageProcessor {
             auth_manager,
             config,
             config_warnings: Arc::new(config_warnings),
-        }
+        })
     }
 
     pub(crate) fn clear_runtime_references(&self) {

--- a/codex-rs/app-server/src/message_processor/tracing_tests.rs
+++ b/codex-rs/app-server/src/message_processor/tracing_tests.rs
@@ -117,7 +117,7 @@ impl TracingHarness {
         let server = create_mock_responses_server_repeating_assistant("Done").await;
         let codex_home = TempDir::new()?;
         let config = Arc::new(build_test_config(codex_home.path(), &server.uri()).await?);
-        let (processor, outgoing_rx) = build_test_processor(config);
+        let (processor, outgoing_rx) = build_test_processor(config).await;
         let tracing = init_test_tracing();
         tracing.exporter.reset();
         tracing::callsite::rebuild_interest_cache();
@@ -224,7 +224,7 @@ async fn build_test_config(codex_home: &Path, server_uri: &str) -> Result<Config
         .await?)
 }
 
-fn build_test_processor(
+async fn build_test_processor(
     config: Arc<Config>,
 ) -> (
     MessageProcessor,
@@ -246,7 +246,9 @@ fn build_test_processor(
         config_warnings: Vec::new(),
         session_source: SessionSource::VSCode,
         enable_codex_api_key_env: false,
-    });
+    })
+    .await
+    .expect("test message processor should build");
     (processor, outgoing_rx)
 }
 

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -179,6 +179,7 @@ pub use file_watcher::FileWatcherEvent;
 pub use safety::get_platform_sandbox;
 pub use tools::spec::parse_tool_input_schema;
 pub use turn_metadata::build_turn_metadata_header;
+pub use unified_exec::executor_environment_for_config;
 pub mod compact;
 pub mod memory_trace;
 pub mod otel_init;

--- a/codex-rs/core/src/unified_exec/backend.rs
+++ b/codex-rs/core/src/unified_exec/backend.rs
@@ -1,3 +1,4 @@
+use std::io;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -179,15 +180,26 @@ pub(crate) async fn session_execution_backends_for_config(
             spawn_local_exec_server(command, ExecServerClientConnectOptions::default())
                 .await
                 .map_err(|err| UnifiedExecError::create_process(err.to_string()))?;
-        return Ok(exec_server_backends_from_spawned_server(Arc::new(
-            spawned_server,
-        ), path_mapper));
+        return Ok(exec_server_backends_from_spawned_server(
+            Arc::new(spawned_server),
+            path_mapper,
+        ));
     }
 
     let client = ExecServerClient::connect_in_process(ExecServerClientConnectOptions::default())
         .await
         .map_err(|err| UnifiedExecError::create_process(err.to_string()))?;
     Ok(exec_server_backends_from_client(client, path_mapper))
+}
+
+pub async fn executor_environment_for_config(
+    config: &Config,
+    local_exec_server_command: Option<ExecServerLaunchCommand>,
+) -> io::Result<Arc<Environment>> {
+    session_execution_backends_for_config(config, local_exec_server_command)
+        .await
+        .map(|backends| backends.environment)
+        .map_err(|err| io::Error::other(err.to_string()))
 }
 
 fn default_local_exec_server_command() -> ExecServerLaunchCommand {

--- a/codex-rs/core/src/unified_exec/mod.rs
+++ b/codex-rs/core/src/unified_exec/mod.rs
@@ -49,6 +49,7 @@ pub(crate) fn set_deterministic_process_ids_for_tests(enabled: bool) {
 }
 
 pub(crate) use backend::UnifiedExecSessionFactoryHandle;
+pub use backend::executor_environment_for_config;
 pub(crate) use backend::local_unified_exec_session_factory;
 pub(crate) use backend::session_execution_backends_for_config;
 pub(crate) use errors::UnifiedExecError;


### PR DESCRIPTION
## Summary
- expose a narrow core helper for selecting executor-aware environment from config
- make app-server MessageProcessor construction async so fs/* can use that environment
- inject app-server fs/* from the selected executor-aware filesystem instead of Environment::default()

## Validation
- in progress: focused codex-app-server fs test on isolated cargo target

## Stack
- base PR: #15033
