### PR TITLE
fix(core) disable command_might_be_dangerous when unsandboxed

### DIFF
--- a/codex-rs/core/src/exec_policy.rs
+++ b/codex-rs/core/src/exec_policy.rs
@@ -553,8 +553,8 @@ pub fn render_decision_for_unmatched_command(
         cfg!(windows) && matches!(sandbox_policy, SandboxPolicy::ReadOnly { .. });
 
     let sandbox_is_explicitly_disabled = matches!(
-        file_system_sandbox_policy.kind,
-        FileSystemSandboxKind::Unrestricted | FileSystemSandboxKind::ExternalSandbox
+        sandbox_policy,
+        SandboxPolicy::DangerFullAccess | SandboxPolicy::ExternalSandbox { .. }
     );
 
     // If the command is flagged as dangerous or we have no sandbox protection,

--- a/codex-rs/core/src/exec_policy.rs
+++ b/codex-rs/core/src/exec_policy.rs
@@ -549,8 +549,13 @@ pub fn render_decision_for_unmatched_command(
 
     // On Windows, ReadOnly sandbox is not a real sandbox, so special-case it
     // here.
-    let runtime_sandbox_provides_safety =
+    let relying_on_runtime_sandbox_for_safety =
         cfg!(windows) && matches!(sandbox_policy, SandboxPolicy::ReadOnly { .. });
+
+    let sandbox_is_explicitly_disabled = matches!(
+        file_system_sandbox_policy.kind,
+        FileSystemSandboxKind::Unrestricted | FileSystemSandboxKind::ExternalSandbox
+    );
 
     // If the command is flagged as dangerous or we have no sandbox protection,
     // we should never allow it to run without approval.
@@ -558,9 +563,16 @@ pub fn render_decision_for_unmatched_command(
     // We prefer to prompt the user rather than outright forbid the command,
     // but if the user has explicitly disabled prompts, we must
     // forbid the command.
-    if command_might_be_dangerous(command) || runtime_sandbox_provides_safety {
+    if command_might_be_dangerous(command) || relying_on_runtime_sandbox_for_safety {
         return match approval_policy {
-            AskForApproval::Never => Decision::Forbidden,
+            AskForApproval::Never => {
+                if sandbox_is_explicitly_disabled {
+                    // If the sandbox is explicitly disabled, we should allow the command to run
+                    Decision::Allow
+                } else {
+                    Decision::Forbidden
+                }
+            }
             AskForApproval::OnFailure
             | AskForApproval::OnRequest
             | AskForApproval::UnlessTrusted

--- a/codex-rs/core/src/exec_policy.rs
+++ b/codex-rs/core/src/exec_policy.rs
@@ -549,13 +549,8 @@ pub fn render_decision_for_unmatched_command(
 
     // On Windows, ReadOnly sandbox is not a real sandbox, so special-case it
     // here.
-    let relying_on_runtime_sandbox_for_safety =
+    let environment_lacks_sandbox_protections =
         cfg!(windows) && matches!(sandbox_policy, SandboxPolicy::ReadOnly { .. });
-
-    let sandbox_is_explicitly_disabled = matches!(
-        sandbox_policy,
-        SandboxPolicy::DangerFullAccess | SandboxPolicy::ExternalSandbox { .. }
-    );
 
     // If the command is flagged as dangerous or we have no sandbox protection,
     // we should never allow it to run without approval.
@@ -563,9 +558,13 @@ pub fn render_decision_for_unmatched_command(
     // We prefer to prompt the user rather than outright forbid the command,
     // but if the user has explicitly disabled prompts, we must
     // forbid the command.
-    if command_might_be_dangerous(command) || relying_on_runtime_sandbox_for_safety {
+    if command_might_be_dangerous(command) || environment_lacks_sandbox_protections {
         return match approval_policy {
             AskForApproval::Never => {
+                let sandbox_is_explicitly_disabled = matches!(
+                    sandbox_policy,
+                    SandboxPolicy::DangerFullAccess | SandboxPolicy::ExternalSandbox { .. }
+                );
                 if sandbox_is_explicitly_disabled {
                     // If the sandbox is explicitly disabled, we should allow the command to run
                     Decision::Allow

--- a/codex-rs/core/src/exec_policy_tests.rs
+++ b/codex-rs/core/src/exec_policy_tests.rs
@@ -1585,32 +1585,6 @@ async fn dangerous_rm_rf_requires_approval_in_danger_full_access() {
     );
 }
 
-#[tokio::test]
-async fn dangerous_rm_rf_is_allowed_without_approval_in_external_sandbox_when_prompts_disabled() {
-    let command = vec_str(&["rm", "-rf", "/tmp/nonexistent"]);
-    let manager = ExecPolicyManager::default();
-    let requirement = manager
-        .create_exec_approval_requirement_for_command(ExecApprovalRequest {
-            command: &command,
-            approval_policy: AskForApproval::Never,
-            sandbox_policy: &SandboxPolicy::ExternalSandbox {
-                network_access: Default::default(),
-            },
-            file_system_sandbox_policy: &external_file_system_sandbox_policy(),
-            sandbox_permissions: SandboxPermissions::UseDefault,
-            prefix_rule: None,
-        })
-        .await;
-
-    assert_eq!(
-        requirement,
-        ExecApprovalRequirement::Skip {
-            bypass_sandbox: false,
-            proposed_execpolicy_amendment: Some(ExecPolicyAmendment::new(command)),
-        }
-    );
-}
-
 fn vec_str(items: &[&str]) -> Vec<String> {
     items.iter().map(std::string::ToString::to_string).collect()
 }
@@ -1715,4 +1689,97 @@ async fn verify_approval_requirement_for_unsafe_powershell_command() {
         r#"On all platforms, a forbidden command should require approval
             (unless AskForApproval::Never is specified)."#
     );
+}
+
+struct ExecApprovalRequirementScenario {
+    policy_src: Option<String>,
+
+    command: Vec<String>,
+    approval_policy: AskForApproval,
+    sandbox_policy: SandboxPolicy,
+    file_system_sandbox_policy: FileSystemSandboxPolicy,
+    sandbox_permissions: SandboxPermissions,
+    prefix_rule: Option<Vec<String>>,
+
+    expected_requirement: ExecApprovalRequirement,
+}
+
+async fn assert_exec_approval_requirement_for_command(test: ExecApprovalRequirementScenario) {
+    let ExecApprovalRequirementScenario {
+        policy_src,
+        command,
+        approval_policy,
+        sandbox_policy,
+        file_system_sandbox_policy,
+        sandbox_permissions,
+        prefix_rule,
+        expected_requirement,
+    } = test;
+
+    let policy = match policy_src {
+        Some(src) => {
+            let mut parser = PolicyParser::new();
+            parser
+                .parse("test.rules", src.as_str())
+                .expect("parse policy");
+            Arc::new(parser.build())
+        }
+        None => Arc::new(Policy::empty()),
+    };
+
+    let requirement = ExecPolicyManager::new(policy)
+        .create_exec_approval_requirement_for_command(ExecApprovalRequest {
+            command: &command,
+            approval_policy,
+            sandbox_policy: &sandbox_policy,
+            file_system_sandbox_policy: &file_system_sandbox_policy,
+            sandbox_permissions,
+            prefix_rule,
+        })
+        .await;
+
+    assert_eq!(requirement, expected_requirement);
+}
+
+#[tokio::test]
+async fn dangerous_command_allowed_when_sandbox_is_explicitly_disabled() {
+    let command = vec_str(&["rm", "-rf", "/tmp/nonexistent"]);
+    assert_exec_approval_requirement_for_command(ExecApprovalRequirementScenario {
+        policy_src: None,
+        command,
+        approval_policy: AskForApproval::Never,
+        sandbox_policy: SandboxPolicy::ExternalSandbox {
+            network_access: Default::default(),
+        },
+        file_system_sandbox_policy: external_file_system_sandbox_policy(),
+        sandbox_permissions: SandboxPermissions::UseDefault,
+        prefix_rule: None,
+        expected_requirement: ExecApprovalRequirement::Skip {
+            bypass_sandbox: false,
+            proposed_execpolicy_amendment: Some(ExecPolicyAmendment {
+                command: vec_str(["rm", "-rf", "/tmp/nonexistent"]),
+            }),
+        },
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn dangerous_command_forbidden_in_external_sandbox_when_policy_matches() {
+    let command = vec_str(&["rm", "-rf", "/tmp/nonexistent"]);
+    assert_exec_approval_requirement_for_command(ExecApprovalRequirementScenario {
+        policy_src: Some("prefix_rule(pattern=['rm'], decision='prompt')".to_string()),
+        command,
+        approval_policy: AskForApproval::Never,
+        sandbox_policy: SandboxPolicy::ExternalSandbox {
+            network_access: Default::default(),
+        },
+        file_system_sandbox_policy: external_file_system_sandbox_policy(),
+        sandbox_permissions: SandboxPermissions::UseDefault,
+        prefix_rule: None,
+        expected_requirement: ExecApprovalRequirement::Forbidden {
+            reason: "approval required by policy, but AskForApproval is set to Never".to_string(),
+        },
+    })
+    .await;
 }

--- a/codex-rs/core/src/exec_policy_tests.rs
+++ b/codex-rs/core/src/exec_policy_tests.rs
@@ -81,6 +81,10 @@ fn unrestricted_file_system_sandbox_policy() -> FileSystemSandboxPolicy {
     FileSystemSandboxPolicy::unrestricted()
 }
 
+fn external_file_system_sandbox_policy() -> FileSystemSandboxPolicy {
+    FileSystemSandboxPolicy::external_sandbox()
+}
+
 async fn test_config() -> (TempDir, Config) {
     let home = TempDir::new().expect("create temp dir");
     let config = ConfigBuilder::default()
@@ -1576,6 +1580,32 @@ async fn dangerous_rm_rf_requires_approval_in_danger_full_access() {
         requirement,
         ExecApprovalRequirement::NeedsApproval {
             reason: None,
+            proposed_execpolicy_amendment: Some(ExecPolicyAmendment::new(command)),
+        }
+    );
+}
+
+#[tokio::test]
+async fn dangerous_rm_rf_is_allowed_without_approval_in_external_sandbox_when_prompts_disabled() {
+    let command = vec_str(&["rm", "-rf", "/tmp/nonexistent"]);
+    let manager = ExecPolicyManager::default();
+    let requirement = manager
+        .create_exec_approval_requirement_for_command(ExecApprovalRequest {
+            command: &command,
+            approval_policy: AskForApproval::Never,
+            sandbox_policy: &SandboxPolicy::ExternalSandbox {
+                network_access: Default::default(),
+            },
+            file_system_sandbox_policy: &external_file_system_sandbox_policy(),
+            sandbox_permissions: SandboxPermissions::UseDefault,
+            prefix_rule: None,
+        })
+        .await;
+
+    assert_eq!(
+        requirement,
+        ExecApprovalRequirement::Skip {
+            bypass_sandbox: false,
             proposed_execpolicy_amendment: Some(ExecPolicyAmendment::new(command)),
         }
     );

--- a/codex-rs/core/src/exec_policy_tests.rs
+++ b/codex-rs/core/src/exec_policy_tests.rs
@@ -1691,20 +1691,68 @@ async fn verify_approval_requirement_for_unsafe_powershell_command() {
     );
 }
 
-struct ExecApprovalRequirementScenario {
-    policy_src: Option<String>,
+#[tokio::test]
+async fn dangerous_command_allowed_when_sandbox_is_explicitly_disabled() {
+    let command = vec_str(&["rm", "-rf", "/tmp/nonexistent"]);
+    assert_exec_approval_requirement_for_command(
+        ExecApprovalRequirementScenario {
+            policy_src: None,
+            command,
+            approval_policy: AskForApproval::Never,
+            sandbox_policy: SandboxPolicy::ExternalSandbox {
+                network_access: Default::default(),
+            },
+            file_system_sandbox_policy: external_file_system_sandbox_policy(),
+            sandbox_permissions: SandboxPermissions::UseDefault,
+            prefix_rule: None,
+        },
+        ExecApprovalRequirement::Skip {
+            bypass_sandbox: false,
+            proposed_execpolicy_amendment: Some(ExecPolicyAmendment {
+                command: vec_str(&["rm", "-rf", "/tmp/nonexistent"]),
+            }),
+        },
+    )
+    .await;
+}
 
+#[tokio::test]
+async fn dangerous_command_forbidden_in_external_sandbox_when_policy_matches() {
+    let command = vec_str(&["rm", "-rf", "/tmp/nonexistent"]);
+    assert_exec_approval_requirement_for_command(
+        ExecApprovalRequirementScenario {
+            policy_src: Some("prefix_rule(pattern=['rm'], decision='prompt')".to_string()),
+            command,
+            approval_policy: AskForApproval::Never,
+            sandbox_policy: SandboxPolicy::ExternalSandbox {
+                network_access: Default::default(),
+            },
+            file_system_sandbox_policy: external_file_system_sandbox_policy(),
+            sandbox_permissions: SandboxPermissions::UseDefault,
+            prefix_rule: None,
+        },
+        ExecApprovalRequirement::Forbidden {
+            reason: "approval required by policy, but AskForApproval is set to Never".to_string(),
+        },
+    )
+    .await;
+}
+
+struct ExecApprovalRequirementScenario {
+    /// Source for the Starlark `.rules` file.
+    policy_src: Option<String>,
     command: Vec<String>,
     approval_policy: AskForApproval,
     sandbox_policy: SandboxPolicy,
     file_system_sandbox_policy: FileSystemSandboxPolicy,
     sandbox_permissions: SandboxPermissions,
     prefix_rule: Option<Vec<String>>,
-
-    expected_requirement: ExecApprovalRequirement,
 }
 
-async fn assert_exec_approval_requirement_for_command(test: ExecApprovalRequirementScenario) {
+async fn assert_exec_approval_requirement_for_command(
+    test: ExecApprovalRequirementScenario,
+    expected_requirement: ExecApprovalRequirement,
+) {
     let ExecApprovalRequirementScenario {
         policy_src,
         command,
@@ -1713,7 +1761,6 @@ async fn assert_exec_approval_requirement_for_command(test: ExecApprovalRequirem
         file_system_sandbox_policy,
         sandbox_permissions,
         prefix_rule,
-        expected_requirement,
     } = test;
 
     let policy = match policy_src {
@@ -1739,47 +1786,4 @@ async fn assert_exec_approval_requirement_for_command(test: ExecApprovalRequirem
         .await;
 
     assert_eq!(requirement, expected_requirement);
-}
-
-#[tokio::test]
-async fn dangerous_command_allowed_when_sandbox_is_explicitly_disabled() {
-    let command = vec_str(&["rm", "-rf", "/tmp/nonexistent"]);
-    assert_exec_approval_requirement_for_command(ExecApprovalRequirementScenario {
-        policy_src: None,
-        command,
-        approval_policy: AskForApproval::Never,
-        sandbox_policy: SandboxPolicy::ExternalSandbox {
-            network_access: Default::default(),
-        },
-        file_system_sandbox_policy: external_file_system_sandbox_policy(),
-        sandbox_permissions: SandboxPermissions::UseDefault,
-        prefix_rule: None,
-        expected_requirement: ExecApprovalRequirement::Skip {
-            bypass_sandbox: false,
-            proposed_execpolicy_amendment: Some(ExecPolicyAmendment {
-                command: vec_str(["rm", "-rf", "/tmp/nonexistent"]),
-            }),
-        },
-    })
-    .await;
-}
-
-#[tokio::test]
-async fn dangerous_command_forbidden_in_external_sandbox_when_policy_matches() {
-    let command = vec_str(&["rm", "-rf", "/tmp/nonexistent"]);
-    assert_exec_approval_requirement_for_command(ExecApprovalRequirementScenario {
-        policy_src: Some("prefix_rule(pattern=['rm'], decision='prompt')".to_string()),
-        command,
-        approval_policy: AskForApproval::Never,
-        sandbox_policy: SandboxPolicy::ExternalSandbox {
-            network_access: Default::default(),
-        },
-        file_system_sandbox_policy: external_file_system_sandbox_policy(),
-        sandbox_permissions: SandboxPermissions::UseDefault,
-        prefix_rule: None,
-        expected_requirement: ExecApprovalRequirement::Forbidden {
-            reason: "approval required by policy, but AskForApproval is set to Never".to_string(),
-        },
-    })
-    .await;
 }


### PR DESCRIPTION
## Summary
If we are in a mode that is already explicitly un-sandboxed, then `ApprovalPolicy::Never` should not block dangerous commands.

## Testing
- [x] Existing unit test covers old behavior
- [x] Added a unit test for this new case