### PR TITLE
chore: disable memory read path for morpheus

### DIFF
--- a/codex-rs/core/src/memories/phase2.rs
+++ b/codex-rs/core/src/memories/phase2.rs
@@ -272,6 +272,7 @@ mod agent {
         // Consolidation runs as an internal sub-agent and must not recursively delegate.
         let _ = agent_config.features.disable(Feature::SpawnCsv);
         let _ = agent_config.features.disable(Feature::Collab);
+        let _ = agent_config.features.disable(Feature::MemoryTool);
 
         // Sandbox policy
         let mut writable_roots = Vec::new();

--- a/codex-rs/core/src/memories/tests.rs
+++ b/codex-rs/core/src/memories/tests.rs
@@ -421,6 +421,7 @@ mod phase2 {
     use crate::codex::make_session_and_context;
     use crate::config::Config;
     use crate::config::test_config;
+    use crate::features::Feature;
     use crate::memories::memory_root;
     use crate::memories::phase2;
     use crate::memories::raw_memories_file;
@@ -585,6 +586,17 @@ mod phase2 {
 
         let completion = phase2::get_watermark(200, &[older, newer]);
         pretty_assertions::assert_eq!(completion, 456);
+    }
+
+    #[test]
+    fn phase2_subagent_config_disables_memory_tool() {
+        let mut config = test_config();
+        config.features.enable(Feature::MemoryTool);
+
+        let subagent_config =
+            phase2::agent::get_config(Arc::new(config)).expect("phase-2 subagent config");
+
+        assert!(!subagent_config.features.enabled(Feature::MemoryTool));
     }
 
     #[tokio::test]

--- a/codex-rs/core/src/memories/tests.rs
+++ b/codex-rs/core/src/memories/tests.rs
@@ -421,7 +421,6 @@ mod phase2 {
     use crate::codex::make_session_and_context;
     use crate::config::Config;
     use crate::config::test_config;
-    use crate::features::Feature;
     use crate::memories::memory_root;
     use crate::memories::phase2;
     use crate::memories::raw_memories_file;

--- a/codex-rs/core/src/memories/tests.rs
+++ b/codex-rs/core/src/memories/tests.rs
@@ -588,17 +588,6 @@ mod phase2 {
         pretty_assertions::assert_eq!(completion, 456);
     }
 
-    #[test]
-    fn phase2_subagent_config_disables_memory_tool() {
-        let mut config = test_config();
-        config.features.enable(Feature::MemoryTool);
-
-        let subagent_config =
-            phase2::agent::get_config(Arc::new(config)).expect("phase-2 subagent config");
-
-        assert!(!subagent_config.features.enabled(Feature::MemoryTool));
-    }
-
     #[tokio::test]
     async fn dispatch_skips_when_global_job_is_not_dirty() {
         let harness = DispatchHarness::new().await;


### PR DESCRIPTION
Because we don't want prompts collisions