### PR TITLE
fix(tui): support legacy app-server approvals

### DIFF
--- a/codex-rs/tui_app_server/src/app.rs
+++ b/codex-rs/tui_app_server/src/app.rs
@@ -9,7 +9,6 @@ use crate::app_event::WindowsSandboxEnableMode;
 use crate::app_event_sender::AppEventSender;
 use crate::app_server_session::AppServerSession;
 use crate::app_server_session::AppServerStartedThread;
-use crate::app_server_session::ThreadSessionState;
 use crate::bottom_pane::ApprovalRequest;
 use crate::bottom_pane::FeedbackAudience;
 use crate::bottom_pane::McpServerElicitationFormRequest;
@@ -18,7 +17,6 @@ use crate::bottom_pane::SelectionViewParams;
 use crate::bottom_pane::popup_consts::standard_popup_hint_line;
 use crate::chatwidget::ChatWidget;
 use crate::chatwidget::ExternalEditorState;
-use crate::chatwidget::ReplayKind;
 use crate::chatwidget::ThreadInputState;
 use crate::cwd_prompt::CwdPromptAction;
 use crate::diff_render::DiffSummary;
@@ -38,7 +36,6 @@ use crate::multi_agents::format_agent_picker_item_name;
 use crate::multi_agents::next_agent_shortcut_matches;
 use crate::multi_agents::previous_agent_shortcut_matches;
 use crate::pager_overlay::Overlay;
-use crate::read_session_model;
 use crate::render::highlight::highlight_bash_to_lines;
 use crate::render::renderable::Renderable;
 use crate::resume_picker::SessionSelection;
@@ -47,19 +44,7 @@ use crate::tui::TuiEvent;
 use crate::update_action::UpdateAction;
 use crate::version::CODEX_CLI_VERSION;
 use codex_ansi_escape::ansi_escape_line;
-use codex_app_server_client::AppServerRequestHandle;
-use codex_app_server_protocol::ClientRequest;
 use codex_app_server_protocol::ConfigLayerSource;
-use codex_app_server_protocol::ListMcpServerStatusParams;
-use codex_app_server_protocol::ListMcpServerStatusResponse;
-use codex_app_server_protocol::McpServerStatus;
-use codex_app_server_protocol::RequestId;
-use codex_app_server_protocol::ServerNotification;
-use codex_app_server_protocol::ServerRequest;
-use codex_app_server_protocol::SkillsListResponse;
-use codex_app_server_protocol::ThreadRollbackResponse;
-use codex_app_server_protocol::Turn;
-use codex_app_server_protocol::TurnStatus;
 use codex_core::config::Config;
 use codex_core::config::ConfigBuilder;
 use codex_core::config::ConfigOverrides;
@@ -77,15 +62,17 @@ use codex_core::models_manager::model_presets::HIDE_GPT5_1_MIGRATION_PROMPT_CONF
 use codex_core::windows_sandbox::WindowsSandboxLevelExt;
 use codex_otel::SessionTelemetry;
 use codex_protocol::ThreadId;
-use codex_protocol::approvals::ExecApprovalRequestEvent;
 use codex_protocol::config_types::Personality;
 #[cfg(target_os = "windows")]
 use codex_protocol::config_types::WindowsSandboxLevel;
+use codex_protocol::items::TurnItem;
 use codex_protocol::openai_models::ModelAvailabilityNux;
 use codex_protocol::openai_models::ModelPreset;
 use codex_protocol::openai_models::ModelUpgrade;
 use codex_protocol::openai_models::ReasoningEffort as ReasoningEffortConfig;
 use codex_protocol::protocol::AskForApproval;
+use codex_protocol::protocol::Event;
+use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::FinalOutput;
 use codex_protocol::protocol::GetHistoryEntryResponseEvent;
 use codex_protocol::protocol::ListSkillsResponseEvent;
@@ -93,6 +80,7 @@ use codex_protocol::protocol::ListSkillsResponseEvent;
 use codex_protocol::protocol::McpAuthStatus;
 use codex_protocol::protocol::Op;
 use codex_protocol::protocol::SandboxPolicy;
+use codex_protocol::protocol::SessionConfiguredEvent;
 use codex_protocol::protocol::SessionSource;
 use codex_protocol::protocol::SkillErrorInfo;
 use codex_protocol::protocol::TokenUsage;
@@ -108,6 +96,7 @@ use ratatui::widgets::Paragraph;
 use ratatui::widgets::Wrap;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::collections::VecDeque;
 use std::path::Path;
 use std::path::PathBuf;
@@ -125,7 +114,6 @@ use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::mpsc::unbounded_channel;
 use tokio::task::JoinHandle;
 use toml::Value as TomlValue;
-use uuid::Uuid;
 mod agent_navigation;
 mod app_server_adapter;
 mod app_server_requests;
@@ -133,6 +121,7 @@ mod pending_interactive_replay;
 
 use self::agent_navigation::AgentNavigationDirection;
 use self::agent_navigation::AgentNavigationState;
+use self::app_server_adapter::thread_snapshot_events;
 use self::app_server_requests::PendingAppServerRequests;
 use self::app_server_requests::ResolvedAppServerRequest;
 use self::pending_interactive_replay::PendingInteractiveReplayState;
@@ -143,74 +132,6 @@ const THREAD_EVENT_CHANNEL_CAPACITY: usize = 32768;
 enum ThreadInteractiveRequest {
     Approval(ApprovalRequest),
     McpServerElicitation(McpServerElicitationFormRequest),
-}
-
-fn app_server_request_id_to_mcp_request_id(
-    request_id: &codex_app_server_protocol::RequestId,
-) -> codex_protocol::mcp::RequestId {
-    match request_id {
-        codex_app_server_protocol::RequestId::String(value) => {
-            codex_protocol::mcp::RequestId::String(value.clone())
-        }
-        codex_app_server_protocol::RequestId::Integer(value) => {
-            codex_protocol::mcp::RequestId::Integer(*value)
-        }
-    }
-}
-
-fn command_execution_decision_to_review_decision(
-    decision: codex_app_server_protocol::CommandExecutionApprovalDecision,
-) -> codex_protocol::protocol::ReviewDecision {
-    match decision {
-        codex_app_server_protocol::CommandExecutionApprovalDecision::Accept => {
-            codex_protocol::protocol::ReviewDecision::Approved
-        }
-        codex_app_server_protocol::CommandExecutionApprovalDecision::AcceptForSession => {
-            codex_protocol::protocol::ReviewDecision::ApprovedForSession
-        }
-        codex_app_server_protocol::CommandExecutionApprovalDecision::AcceptWithExecpolicyAmendment {
-            execpolicy_amendment,
-        } => codex_protocol::protocol::ReviewDecision::ApprovedExecpolicyAmendment {
-            proposed_execpolicy_amendment: execpolicy_amendment.into_core(),
-        },
-        codex_app_server_protocol::CommandExecutionApprovalDecision::ApplyNetworkPolicyAmendment {
-            network_policy_amendment,
-        } => codex_protocol::protocol::ReviewDecision::NetworkPolicyAmendment {
-            network_policy_amendment: network_policy_amendment.into_core(),
-        },
-        codex_app_server_protocol::CommandExecutionApprovalDecision::Decline => {
-            codex_protocol::protocol::ReviewDecision::Denied
-        }
-        codex_app_server_protocol::CommandExecutionApprovalDecision::Cancel => {
-            codex_protocol::protocol::ReviewDecision::Abort
-        }
-    }
-}
-
-fn convert_via_json<T, U>(value: T) -> Option<U>
-where
-    T: serde::Serialize,
-    U: serde::de::DeserializeOwned,
-{
-    serde_json::to_value(value)
-        .ok()
-        .and_then(|value| serde_json::from_value(value).ok())
-}
-
-fn default_exec_approval_decisions(
-    network_approval_context: Option<&codex_protocol::protocol::NetworkApprovalContext>,
-    proposed_execpolicy_amendment: Option<&codex_protocol::approvals::ExecPolicyAmendment>,
-    proposed_network_policy_amendments: Option<
-        &[codex_protocol::approvals::NetworkPolicyAmendment],
-    >,
-    additional_permissions: Option<&codex_protocol::models::PermissionProfile>,
-) -> Vec<codex_protocol::protocol::ReviewDecision> {
-    ExecApprovalRequestEvent::default_available_decisions(
-        network_approval_context,
-        proposed_execpolicy_amendment,
-        proposed_network_policy_amendments,
-        additional_permissions,
-    )
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -296,77 +217,6 @@ fn errors_for_cwd(cwd: &Path, response: &ListSkillsResponseEvent) -> Vec<SkillEr
         .unwrap_or_default()
 }
 
-fn list_skills_response_to_core(response: SkillsListResponse) -> ListSkillsResponseEvent {
-    ListSkillsResponseEvent {
-        skills: response
-            .data
-            .into_iter()
-            .map(|entry| codex_protocol::protocol::SkillsListEntry {
-                cwd: entry.cwd,
-                skills: entry
-                    .skills
-                    .into_iter()
-                    .map(|skill| codex_protocol::protocol::SkillMetadata {
-                        name: skill.name,
-                        description: skill.description,
-                        short_description: skill.short_description,
-                        interface: skill.interface.map(|interface| {
-                            codex_protocol::protocol::SkillInterface {
-                                display_name: interface.display_name,
-                                short_description: interface.short_description,
-                                icon_small: interface.icon_small,
-                                icon_large: interface.icon_large,
-                                brand_color: interface.brand_color,
-                                default_prompt: interface.default_prompt,
-                            }
-                        }),
-                        dependencies: skill.dependencies.map(|dependencies| {
-                            codex_protocol::protocol::SkillDependencies {
-                                tools: dependencies
-                                    .tools
-                                    .into_iter()
-                                    .map(|tool| codex_protocol::protocol::SkillToolDependency {
-                                        r#type: tool.r#type,
-                                        value: tool.value,
-                                        description: tool.description,
-                                        transport: tool.transport,
-                                        command: tool.command,
-                                        url: tool.url,
-                                    })
-                                    .collect(),
-                            }
-                        }),
-                        path: skill.path,
-                        scope: match skill.scope {
-                            codex_app_server_protocol::SkillScope::User => {
-                                codex_protocol::protocol::SkillScope::User
-                            }
-                            codex_app_server_protocol::SkillScope::Repo => {
-                                codex_protocol::protocol::SkillScope::Repo
-                            }
-                            codex_app_server_protocol::SkillScope::System => {
-                                codex_protocol::protocol::SkillScope::System
-                            }
-                            codex_app_server_protocol::SkillScope::Admin => {
-                                codex_protocol::protocol::SkillScope::Admin
-                            }
-                        },
-                        enabled: skill.enabled,
-                    })
-                    .collect(),
-                errors: entry
-                    .errors
-                    .into_iter()
-                    .map(|error| codex_protocol::protocol::SkillErrorInfo {
-                        path: error.path,
-                        message: error.message,
-                    })
-                    .collect(),
-            })
-            .collect(),
-    }
-}
-
 fn emit_skill_load_warnings(app_event_tx: &AppEventSender, errors: &[SkillErrorInfo]) {
     if errors.is_empty() {
         return;
@@ -431,16 +281,6 @@ fn emit_project_config_warnings(app_event_tx: &AppEventSender, config: &Config) 
     )));
 }
 
-fn emit_missing_system_bwrap_warning(app_event_tx: &AppEventSender) {
-    let Some(message) = codex_core::config::missing_system_bwrap_warning() else {
-        return;
-    };
-
-    app_event_tx.send(AppEvent::InsertHistoryCell(Box::new(
-        history_cell::new_warning_event(message),
-    )));
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct SessionSummary {
     usage_line: String,
@@ -449,9 +289,8 @@ struct SessionSummary {
 
 #[derive(Debug, Clone)]
 struct ThreadEventSnapshot {
-    session: Option<ThreadSessionState>,
-    turns: Vec<Turn>,
-    events: Vec<ThreadBufferedEvent>,
+    session_configured: Option<Event>,
+    events: Vec<Event>,
     input_state: Option<ThreadInputState>,
 }
 
@@ -463,14 +302,12 @@ enum ThreadBufferedEvent {
     LegacyWarning(String),
     LegacyRollback { num_turns: u32 },
 }
-
 #[derive(Debug)]
 struct ThreadEventStore {
-    session: Option<ThreadSessionState>,
-    turns: Vec<Turn>,
-    buffer: VecDeque<ThreadBufferedEvent>,
+    session_configured: Option<Event>,
+    buffer: VecDeque<Event>,
+    user_message_ids: HashSet<String>,
     pending_interactive_replay: PendingInteractiveReplayState,
-    pending_local_legacy_rollbacks: VecDeque<u32>,
     active_turn_id: Option<String>,
     input_state: Option<ThreadInputState>,
     capacity: usize,
@@ -478,20 +315,12 @@ struct ThreadEventStore {
 }
 
 impl ThreadEventStore {
-    fn event_survives_session_refresh(event: &ThreadBufferedEvent) -> bool {
-        matches!(
-            event,
-            ThreadBufferedEvent::Request(_) | ThreadBufferedEvent::LegacyWarning(_)
-        )
-    }
-
     fn new(capacity: usize) -> Self {
         Self {
-            session: None,
-            turns: Vec::new(),
+            session_configured: None,
             buffer: VecDeque::new(),
+            user_message_ids: HashSet::new(),
             pending_interactive_replay: PendingInteractiveReplayState::default(),
-            pending_local_legacy_rollbacks: VecDeque::new(),
             active_turn_id: None,
             input_state: None,
             capacity,
@@ -500,128 +329,83 @@ impl ThreadEventStore {
     }
 
     #[cfg_attr(not(test), allow(dead_code))]
-    fn new_with_session(capacity: usize, session: ThreadSessionState, turns: Vec<Turn>) -> Self {
+    fn new_with_session_configured(capacity: usize, event: Event) -> Self {
         let mut store = Self::new(capacity);
-        store.session = Some(session);
-        store.set_turns(turns);
+        store.session_configured = Some(event);
         store
     }
 
-    fn set_session(&mut self, session: ThreadSessionState, turns: Vec<Turn>) {
-        self.session = Some(session);
-        self.set_turns(turns);
-    }
-
-    fn rebase_buffer_after_session_refresh(&mut self) {
-        self.buffer.retain(Self::event_survives_session_refresh);
-    }
-
-    fn set_turns(&mut self, turns: Vec<Turn>) {
-        self.pending_local_legacy_rollbacks.clear();
-        self.active_turn_id = turns
-            .iter()
-            .rev()
-            .find(|turn| matches!(turn.status, TurnStatus::InProgress))
-            .map(|turn| turn.id.clone());
-        self.turns = turns;
-    }
-
-    fn push_notification(&mut self, notification: ServerNotification) {
-        self.pending_interactive_replay
-            .note_server_notification(&notification);
-        match &notification {
-            ServerNotification::TurnStarted(turn) => {
-                self.active_turn_id = Some(turn.turn.id.clone());
+    fn push_event(&mut self, event: Event) {
+        self.pending_interactive_replay.note_event(&event);
+        match &event.msg {
+            EventMsg::SessionConfigured(_) => {
+                self.session_configured = Some(event);
+                return;
             }
-            ServerNotification::TurnCompleted(turn) => {
-                if self.active_turn_id.as_deref() == Some(turn.turn.id.as_str()) {
+            EventMsg::TurnStarted(turn) => {
+                self.active_turn_id = Some(turn.turn_id.clone());
+            }
+            EventMsg::TurnComplete(turn) => {
+                if self.active_turn_id.as_deref() == Some(turn.turn_id.as_str()) {
                     self.active_turn_id = None;
                 }
             }
-            ServerNotification::ThreadClosed(_) => {
+            EventMsg::TurnAborted(turn) => {
+                if self.active_turn_id.as_deref() == turn.turn_id.as_deref() {
+                    self.active_turn_id = None;
+                }
+            }
+            EventMsg::ShutdownComplete => {
                 self.active_turn_id = None;
+            }
+            EventMsg::ItemCompleted(completed) => {
+                if let TurnItem::UserMessage(item) = &completed.item {
+                    if !event.id.is_empty() && self.user_message_ids.contains(&event.id) {
+                        return;
+                    }
+                    let legacy = Event {
+                        id: event.id,
+                        msg: item.as_legacy_event(),
+                    };
+                    self.push_legacy_event(legacy);
+                    return;
+                }
             }
             _ => {}
         }
-        self.buffer
-            .push_back(ThreadBufferedEvent::Notification(notification));
+
+        self.push_legacy_event(event);
+    }
+
+    fn push_legacy_event(&mut self, event: Event) {
+        if let EventMsg::UserMessage(_) = &event.msg
+            && !event.id.is_empty()
+            && !self.user_message_ids.insert(event.id.clone())
+        {
+            return;
+        }
+        self.buffer.push_back(event);
         if self.buffer.len() > self.capacity
             && let Some(removed) = self.buffer.pop_front()
-            && let ThreadBufferedEvent::Request(request) = &removed
         {
-            self.pending_interactive_replay
-                .note_evicted_server_request(request);
-        }
-    }
-
-    fn push_request(&mut self, request: ServerRequest) {
-        self.pending_interactive_replay
-            .note_server_request(&request);
-        self.buffer.push_back(ThreadBufferedEvent::Request(request));
-        if self.buffer.len() > self.capacity
-            && let Some(removed) = self.buffer.pop_front()
-            && let ThreadBufferedEvent::Request(request) = &removed
-        {
-            self.pending_interactive_replay
-                .note_evicted_server_request(request);
-        }
-    }
-
-    fn apply_thread_rollback(&mut self, response: &ThreadRollbackResponse) {
-        self.turns = response.thread.turns.clone();
-        self.buffer.clear();
-        self.pending_interactive_replay = PendingInteractiveReplayState::default();
-        self.active_turn_id = None;
-    }
-
-    fn note_local_thread_rollback(&mut self, num_turns: u32) {
-        self.pending_local_legacy_rollbacks.push_back(num_turns);
-        while self.pending_local_legacy_rollbacks.len() > self.capacity {
-            self.pending_local_legacy_rollbacks.pop_front();
-        }
-    }
-
-    fn consume_pending_local_legacy_rollback(&mut self, num_turns: u32) -> bool {
-        match self.pending_local_legacy_rollbacks.front() {
-            Some(pending_num_turns) if *pending_num_turns == num_turns => {
-                self.pending_local_legacy_rollbacks.pop_front();
-                true
+            self.pending_interactive_replay.note_evicted_event(&removed);
+            if matches!(removed.msg, EventMsg::UserMessage(_)) && !removed.id.is_empty() {
+                self.user_message_ids.remove(&removed.id);
             }
-            _ => false,
         }
-    }
-
-    fn apply_legacy_thread_rollback(&mut self, num_turns: u32) {
-        let num_turns = usize::try_from(num_turns).unwrap_or(usize::MAX);
-        if num_turns >= self.turns.len() {
-            self.turns.clear();
-        } else {
-            self.turns
-                .truncate(self.turns.len().saturating_sub(num_turns));
-        }
-        self.buffer.clear();
-        self.pending_interactive_replay = PendingInteractiveReplayState::default();
-        self.pending_local_legacy_rollbacks.clear();
-        self.active_turn_id = None;
     }
 
     fn snapshot(&self) -> ThreadEventSnapshot {
         ThreadEventSnapshot {
-            session: self.session.clone(),
-            turns: self.turns.clone(),
+            session_configured: self.session_configured.clone(),
             // Thread switches replay buffered events into a rebuilt ChatWidget. Only replay
             // interactive prompts that are still pending, or answered approvals/input will reappear.
             events: self
                 .buffer
                 .iter()
-                .filter(|event| match event {
-                    ThreadBufferedEvent::Request(request) => self
-                        .pending_interactive_replay
-                        .should_replay_snapshot_request(request),
-                    ThreadBufferedEvent::Notification(_)
-                    | ThreadBufferedEvent::HistoryEntryResponse(_)
-                    | ThreadBufferedEvent::LegacyWarning(_)
-                    | ThreadBufferedEvent::LegacyRollback { .. } => true,
+                .filter(|event| {
+                    self.pending_interactive_replay
+                        .should_replay_snapshot_event(event)
                 })
                 .cloned()
                 .collect(),
@@ -648,6 +432,10 @@ impl ThreadEventStore {
         PendingInteractiveReplayState::op_can_change_state(op)
     }
 
+    fn event_can_change_pending_thread_approvals(event: &Event) -> bool {
+        PendingInteractiveReplayState::event_can_change_pending_thread_approvals(event)
+    }
+
     fn has_pending_thread_approvals(&self) -> bool {
         self.pending_interactive_replay
             .has_pending_thread_approvals()
@@ -660,8 +448,8 @@ impl ThreadEventStore {
 
 #[derive(Debug)]
 struct ThreadEventChannel {
-    sender: mpsc::Sender<ThreadBufferedEvent>,
-    receiver: Option<mpsc::Receiver<ThreadBufferedEvent>>,
+    sender: mpsc::Sender<Event>,
+    receiver: Option<mpsc::Receiver<Event>>,
     store: Arc<Mutex<ThreadEventStore>>,
 }
 
@@ -676,13 +464,13 @@ impl ThreadEventChannel {
     }
 
     #[cfg_attr(not(test), allow(dead_code))]
-    fn new_with_session(capacity: usize, session: ThreadSessionState, turns: Vec<Turn>) -> Self {
+    fn new_with_session_configured(capacity: usize, event: Event) -> Self {
         let (sender, receiver) = mpsc::channel(capacity);
         Self {
             sender,
             receiver: Some(receiver),
-            store: Arc::new(Mutex::new(ThreadEventStore::new_with_session(
-                capacity, session, turns,
+            store: Arc::new(Mutex::new(ThreadEventStore::new_with_session_configured(
+                capacity, event,
             ))),
         }
     }
@@ -962,6 +750,12 @@ pub(crate) struct App {
     /// Set when the user confirms an update; propagated on exit.
     pub(crate) pending_update_action: Option<UpdateAction>,
 
+    /// One-shot guard used while switching threads.
+    ///
+    /// We set this when intentionally stopping the current thread before moving
+    /// to another one, then ignore exactly one `ShutdownComplete` so it is not
+    /// misclassified as an unexpected sub-agent death.
+    suppress_shutdown_complete: bool,
     /// Tracks the thread we intentionally shut down while exiting the app.
     ///
     /// When this matches the active thread, its `ShutdownComplete` should lead to
@@ -978,10 +772,10 @@ pub(crate) struct App {
     thread_event_listener_tasks: HashMap<ThreadId, JoinHandle<()>>,
     agent_navigation: AgentNavigationState,
     active_thread_id: Option<ThreadId>,
-    active_thread_rx: Option<mpsc::Receiver<ThreadBufferedEvent>>,
+    active_thread_rx: Option<mpsc::Receiver<Event>>,
     primary_thread_id: Option<ThreadId>,
-    primary_session_configured: Option<ThreadSessionState>,
-    pending_primary_events: VecDeque<ThreadBufferedEvent>,
+    primary_session_configured: Option<SessionConfiguredEvent>,
+    pending_primary_events: VecDeque<Event>,
     pending_app_server_requests: PendingAppServerRequests,
 }
 
@@ -1548,7 +1342,7 @@ impl App {
     async fn activate_thread_for_replay(
         &mut self,
         thread_id: ThreadId,
-    ) -> Option<(mpsc::Receiver<ThreadBufferedEvent>, ThreadEventSnapshot)> {
+    ) -> Option<(mpsc::Receiver<Event>, ThreadEventSnapshot)> {
         let channel = self.thread_event_channels.get_mut(&thread_id)?;
         let receiver = channel.receiver.take()?;
         let mut store = channel.store.lock().await;
@@ -1587,6 +1381,15 @@ impl App {
         if resolved.exec_approval_ids.is_empty() {
             return;
         }
+
+        self.pending_primary_events.retain(|event| {
+            let EventMsg::ExecApprovalRequest(approval) = &event.msg else {
+                return true;
+            };
+            !resolved
+                .exec_approval_ids
+                .contains(&approval.effective_approval_id())
+        });
 
         for channel in self.thread_event_channels.values() {
             let mut store = channel.store.lock().await;
@@ -1657,122 +1460,85 @@ impl App {
     async fn thread_cwd(&self, thread_id: ThreadId) -> Option<PathBuf> {
         let channel = self.thread_event_channels.get(&thread_id)?;
         let store = channel.store.lock().await;
-        store.session.as_ref().map(|session| session.cwd.clone())
+        match store.session_configured.as_ref().map(|event| &event.msg) {
+            Some(EventMsg::SessionConfigured(session)) => Some(session.cwd.clone()),
+            _ => None,
+        }
     }
 
-    async fn interactive_request_for_thread_request(
+    async fn interactive_request_for_thread_event(
         &self,
         thread_id: ThreadId,
-        request: &ServerRequest,
+        event: &Event,
     ) -> Option<ThreadInteractiveRequest> {
         let thread_label = Some(self.thread_label(thread_id));
-        match request {
-            ServerRequest::CommandExecutionRequestApproval { params, .. } => {
-                let network_approval_context = params
-                    .network_approval_context
-                    .clone()
-                    .and_then(convert_via_json);
-                let additional_permissions = params
-                    .additional_permissions
-                    .clone()
-                    .and_then(convert_via_json);
-                let proposed_execpolicy_amendment = params
-                    .proposed_execpolicy_amendment
-                    .clone()
-                    .map(codex_app_server_protocol::ExecPolicyAmendment::into_core);
-                let proposed_network_policy_amendments = params
-                    .proposed_network_policy_amendments
-                    .clone()
-                    .map(|amendments| {
-                        amendments
-                            .into_iter()
-                            .map(codex_app_server_protocol::NetworkPolicyAmendment::into_core)
-                            .collect::<Vec<_>>()
-                    });
+        match &event.msg {
+            EventMsg::ExecApprovalRequest(ev) => {
                 Some(ThreadInteractiveRequest::Approval(ApprovalRequest::Exec {
                     thread_id,
                     thread_label,
-                    id: params
-                        .approval_id
-                        .clone()
-                        .unwrap_or_else(|| params.item_id.clone()),
-                    command: params.command.clone().into_iter().collect(),
-                    reason: params.reason.clone(),
-                    available_decisions: params
-                        .available_decisions
-                        .clone()
-                        .map(|decisions| {
-                            decisions
-                                .into_iter()
-                                .map(command_execution_decision_to_review_decision)
-                                .collect()
-                        })
-                        .unwrap_or_else(|| {
-                            default_exec_approval_decisions(
-                                network_approval_context.as_ref(),
-                                proposed_execpolicy_amendment.as_ref(),
-                                proposed_network_policy_amendments.as_deref(),
-                                additional_permissions.as_ref(),
-                            )
-                        }),
-                    network_approval_context,
-                    additional_permissions,
+                    id: ev.effective_approval_id(),
+                    command: ev.command.clone(),
+                    reason: ev.reason.clone(),
+                    available_decisions: ev.effective_available_decisions(),
+                    network_approval_context: ev.network_approval_context.clone(),
+                    additional_permissions: ev.additional_permissions.clone(),
                 }))
             }
-            ServerRequest::FileChangeRequestApproval { params, .. } => Some(
-                ThreadInteractiveRequest::Approval(ApprovalRequest::ApplyPatch {
+            EventMsg::ApplyPatchApprovalRequest(ev) => Some(ThreadInteractiveRequest::Approval(
+                ApprovalRequest::ApplyPatch {
                     thread_id,
                     thread_label,
-                    id: params.item_id.clone(),
-                    reason: params.reason.clone(),
+                    id: ev.call_id.clone(),
+                    reason: ev.reason.clone(),
                     cwd: self
                         .thread_cwd(thread_id)
                         .await
                         .unwrap_or_else(|| self.config.cwd.clone()),
-                    changes: HashMap::new(),
-                }),
-            ),
-            ServerRequest::McpServerElicitationRequest { request_id, params } => {
-                if let Some(request) = McpServerElicitationFormRequest::from_app_server_request(
-                    thread_id,
-                    app_server_request_id_to_mcp_request_id(request_id),
-                    params.clone(),
-                ) {
+                    changes: ev.changes.clone(),
+                },
+            )),
+            EventMsg::ElicitationRequest(ev) => {
+                if let Some(request) =
+                    McpServerElicitationFormRequest::from_event(thread_id, ev.clone())
+                {
                     Some(ThreadInteractiveRequest::McpServerElicitation(request))
                 } else {
                     Some(ThreadInteractiveRequest::Approval(
                         ApprovalRequest::McpElicitation {
                             thread_id,
                             thread_label,
-                            server_name: params.server_name.clone(),
-                            request_id: app_server_request_id_to_mcp_request_id(request_id),
-                            message: match &params.request {
-                                codex_app_server_protocol::McpServerElicitationRequest::Form {
-                                    message,
-                                    ..
-                                }
-                                | codex_app_server_protocol::McpServerElicitationRequest::Url {
-                                    message,
-                                    ..
-                                } => message.clone(),
-                            },
+                            server_name: ev.server_name.clone(),
+                            request_id: ev.id.clone(),
+                            message: ev.request.message().to_string(),
                         },
                     ))
                 }
             }
-            ServerRequest::PermissionsRequestApproval { params, .. } => Some(
-                ThreadInteractiveRequest::Approval(ApprovalRequest::Permissions {
+            EventMsg::RequestPermissions(ev) => Some(ThreadInteractiveRequest::Approval(
+                ApprovalRequest::Permissions {
                     thread_id,
                     thread_label,
-                    call_id: params.item_id.clone(),
-                    reason: params.reason.clone(),
-                    permissions: serde_json::from_value(
-                        serde_json::to_value(&params.permissions).ok()?,
-                    )
-                    .ok()?,
-                }),
-            ),
+                    call_id: ev.call_id.clone(),
+                    reason: ev.reason.clone(),
+                    permissions: ev.permissions.clone(),
+                },
+            )),
             _ => None,
+        }
+    }
+
+    async fn submit_op_to_thread(&mut self, thread_id: ThreadId, op: AppCommand) {
+        let replay_state_op =
+            ThreadEventStore::op_can_change_pending_replay_state(&op).then(|| op.clone());
+        crate::session_log::log_outbound_op(&op);
+        let submitted = false;
+        self.chat_widget.add_error_message(format!(
+            "Not available in app-server TUI yet for thread {thread_id}."
+        ));
+        if submitted && let Some(op) = replay_state_op.as_ref() {
+            self.note_thread_outbound_op(thread_id, op).await;
+            self.refresh_pending_thread_approvals().await;
         }
     }
 
@@ -1820,9 +1586,7 @@ impl App {
             return Ok(());
         }
 
-        self.chat_widget.add_error_message(format!(
-            "Not available in app-server TUI yet for thread {thread_id}."
-        ));
+        self.submit_op_to_thread(thread_id, op).await;
         Ok(())
     }
 
@@ -1951,7 +1715,6 @@ impl App {
             _ => Ok(false),
         }
     }
-
     async fn try_submit_active_thread_op_via_app_server(
         &mut self,
         app_server: &mut AppServerSession,
@@ -2012,7 +1775,79 @@ impl App {
                         per_cwd_extra_user_roots: None,
                     })
                     .await?;
-                self.handle_skills_list_response(response);
+                self.handle_codex_event_now(Event {
+                    id: String::new(),
+                    msg: EventMsg::ListSkillsResponse(ListSkillsResponseEvent {
+                        skills: response
+                            .data
+                            .into_iter()
+                            .map(|entry| codex_protocol::protocol::SkillsListEntry {
+                                cwd: entry.cwd,
+                                skills: entry
+                                    .skills
+                                    .into_iter()
+                                    .map(|skill| codex_protocol::protocol::SkillMetadata {
+                                        name: skill.name,
+                                        description: skill.description,
+                                        short_description: skill.short_description,
+                                        interface: skill.interface.map(|interface| {
+                                            codex_protocol::protocol::SkillInterface {
+                                                display_name: interface.display_name,
+                                                short_description: interface.short_description,
+                                                icon_small: interface.icon_small,
+                                                icon_large: interface.icon_large,
+                                                brand_color: interface.brand_color,
+                                                default_prompt: interface.default_prompt,
+                                            }
+                                        }),
+                                        dependencies: skill.dependencies.map(|dependencies| {
+                                            codex_protocol::protocol::SkillDependencies {
+                                                tools: dependencies
+                                                    .tools
+                                                    .into_iter()
+                                                    .map(|tool| {
+                                                        codex_protocol::protocol::SkillToolDependency {
+                                                            r#type: tool.r#type,
+                                                            value: tool.value,
+                                                            description: tool.description,
+                                                            transport: tool.transport,
+                                                            command: tool.command,
+                                                            url: tool.url,
+                                                        }
+                                                    })
+                                                    .collect(),
+                                            }
+                                        }),
+                                        path: skill.path,
+                                        scope: match skill.scope {
+                                            codex_app_server_protocol::SkillScope::User => {
+                                                codex_protocol::protocol::SkillScope::User
+                                            }
+                                            codex_app_server_protocol::SkillScope::Repo => {
+                                                codex_protocol::protocol::SkillScope::Repo
+                                            }
+                                            codex_app_server_protocol::SkillScope::System => {
+                                                codex_protocol::protocol::SkillScope::System
+                                            }
+                                            codex_app_server_protocol::SkillScope::Admin => {
+                                                codex_protocol::protocol::SkillScope::Admin
+                                            }
+                                        },
+                                        enabled: skill.enabled,
+                                    })
+                                    .collect(),
+                                errors: entry
+                                    .errors
+                                    .into_iter()
+                                    .map(|error| codex_protocol::protocol::SkillErrorInfo {
+                                        path: error.path,
+                                        message: error.message,
+                                    })
+                                    .collect(),
+                            })
+                            .collect(),
+                    }),
+                });
                 Ok(true)
             }
             AppCommandView::Compact => {
@@ -2026,15 +1861,7 @@ impl App {
                 Ok(true)
             }
             AppCommandView::ThreadRollback { num_turns } => {
-                let response = match app_server.thread_rollback(thread_id, num_turns).await {
-                    Ok(response) => response,
-                    Err(err) => {
-                        self.handle_backtrack_rollback_failed();
-                        return Err(err);
-                    }
-                };
-                self.handle_thread_rollback_response(thread_id, num_turns, &response)
-                    .await;
+                app_server.thread_rollback(thread_id, num_turns).await?;
                 Ok(true)
             }
             AppCommandView::Review { review_request } => {
@@ -2145,89 +1972,11 @@ impl App {
         self.chat_widget.set_pending_thread_approvals(threads);
     }
 
-    async fn enqueue_thread_notification(
-        &mut self,
-        thread_id: ThreadId,
-        notification: ServerNotification,
-    ) -> Result<()> {
-        let inferred_session = self
-            .infer_session_for_thread_notification(thread_id, &notification)
-            .await;
-        let (sender, store) = {
-            let channel = self.ensure_thread_channel(thread_id);
-            (channel.sender.clone(), Arc::clone(&channel.store))
-        };
-
-        let should_send = {
-            let mut guard = store.lock().await;
-            if guard.session.is_none()
-                && let Some(session) = inferred_session
-            {
-                guard.session = Some(session);
-            }
-            guard.push_notification(notification.clone());
-            guard.active
-        };
-
-        if should_send {
-            match sender.try_send(ThreadBufferedEvent::Notification(notification)) {
-                Ok(()) => {}
-                Err(TrySendError::Full(event)) => {
-                    tokio::spawn(async move {
-                        if let Err(err) = sender.send(event).await {
-                            tracing::warn!("thread {thread_id} event channel closed: {err}");
-                        }
-                    });
-                }
-                Err(TrySendError::Closed(_)) => {
-                    tracing::warn!("thread {thread_id} event channel closed");
-                }
-            }
-        }
-        self.refresh_pending_thread_approvals().await;
-        Ok(())
-    }
-
-    async fn infer_session_for_thread_notification(
-        &mut self,
-        thread_id: ThreadId,
-        notification: &ServerNotification,
-    ) -> Option<ThreadSessionState> {
-        let ServerNotification::ThreadStarted(notification) = notification else {
-            return None;
-        };
-        let mut session = self.primary_session_configured.clone()?;
-        session.thread_id = thread_id;
-        session.thread_name = notification.thread.name.clone();
-        session.model_provider_id = notification.thread.model_provider.clone();
-        session.cwd = notification.thread.cwd.clone();
-        let rollout_path = notification.thread.path.clone();
-        if let Some(model) =
-            read_session_model(&self.config, thread_id, rollout_path.as_deref()).await
-        {
-            session.model = model;
-        } else if rollout_path.is_some() {
-            session.model.clear();
-        }
-        session.history_log_id = 0;
-        session.history_entry_count = 0;
-        session.rollout_path = rollout_path;
-        self.upsert_agent_picker_thread(
-            thread_id,
-            notification.thread.agent_nickname.clone(),
-            notification.thread.agent_role.clone(),
-            /*is_closed*/ false,
-        );
-        Some(session)
-    }
-
-    async fn enqueue_thread_request(
-        &mut self,
-        thread_id: ThreadId,
-        request: ServerRequest,
-    ) -> Result<()> {
+    async fn enqueue_thread_event(&mut self, thread_id: ThreadId, event: Event) -> Result<()> {
+        let refresh_pending_thread_approvals =
+            ThreadEventStore::event_can_change_pending_thread_approvals(&event);
         let inactive_interactive_request = if self.active_thread_id != Some(thread_id) {
-            self.interactive_request_for_thread_request(thread_id, &request)
+            self.interactive_request_for_thread_event(thread_id, &event)
                 .await
         } else {
             None
@@ -2239,12 +1988,15 @@ impl App {
 
         let should_send = {
             let mut guard = store.lock().await;
-            guard.push_request(request.clone());
+            guard.push_event(event.clone());
             guard.active
         };
 
         if should_send {
-            match sender.try_send(ThreadBufferedEvent::Request(request)) {
+            // Never await a bounded channel send on the main TUI loop: if the receiver falls behind,
+            // `send().await` can block and the UI stops drawing. If the channel is full, wait in a
+            // spawned task instead.
+            match sender.try_send(event) {
                 Ok(()) => {}
                 Err(TrySendError::Full(event)) => {
                     tokio::spawn(async move {
@@ -2268,52 +2020,23 @@ impl App {
                 }
             }
         }
-        self.refresh_pending_thread_approvals().await;
+        if refresh_pending_thread_approvals {
+            self.refresh_pending_thread_approvals().await;
+        }
         Ok(())
     }
 
-    async fn enqueue_thread_legacy_warning(
+    async fn handle_routed_thread_event(
         &mut self,
         thread_id: ThreadId,
-        message: String,
+        event: Event,
     ) -> Result<()> {
-        let (sender, store) = {
-            let channel = self.ensure_thread_channel(thread_id);
-            (channel.sender.clone(), Arc::clone(&channel.store))
-        };
-
-        let should_send = {
-            let mut guard = store.lock().await;
-            guard
-                .buffer
-                .push_back(ThreadBufferedEvent::LegacyWarning(message.clone()));
-            if guard.buffer.len() > guard.capacity
-                && let Some(removed) = guard.buffer.pop_front()
-                && let ThreadBufferedEvent::Request(request) = &removed
-            {
-                guard
-                    .pending_interactive_replay
-                    .note_evicted_server_request(request);
-            }
-            guard.active
-        };
-
-        if should_send {
-            match sender.try_send(ThreadBufferedEvent::LegacyWarning(message)) {
-                Ok(()) => {}
-                Err(TrySendError::Full(event)) => {
-                    tokio::spawn(async move {
-                        if let Err(err) = sender.send(event).await {
-                            tracing::warn!("thread {thread_id} event channel closed: {err}");
-                        }
-                    });
-                }
-                Err(TrySendError::Closed(_)) => {
-                    tracing::warn!("thread {thread_id} event channel closed");
-                }
-            }
+        if !self.thread_event_channels.contains_key(&thread_id) {
+            tracing::debug!("dropping stale event for untracked thread {thread_id}");
+            return Ok(());
         }
-        Ok(())
+
+        self.enqueue_thread_event(thread_id, event).await
     }
 
     async fn enqueue_thread_history_entry_response(
@@ -2400,24 +2123,20 @@ impl App {
 
     async fn enqueue_primary_thread_legacy_warning(&mut self, message: String) -> Result<()> {
         if let Some(thread_id) = self.primary_thread_id {
-            return self.enqueue_thread_legacy_warning(thread_id, message).await;
+            return self.enqueue_thread_event(thread_id, event).await;
         }
-        self.pending_primary_events
-            .push_back(ThreadBufferedEvent::LegacyWarning(message));
-        Ok(())
-    }
 
-    async fn enqueue_primary_thread_legacy_rollback(&mut self, num_turns: u32) -> Result<()> {
-        if let Some(thread_id) = self.primary_thread_id {
-            return self
-                .enqueue_thread_legacy_rollback(thread_id, num_turns)
-                .await;
-        }
-        self.pending_primary_events
-            .push_back(ThreadBufferedEvent::LegacyRollback { num_turns });
-        Ok(())
-    }
-
+        if let EventMsg::SessionConfigured(session) = &event.msg {
+            let thread_id = session.session_id;
+            self.primary_thread_id = Some(thread_id);
+            self.primary_session_configured = Some(session.clone());
+            self.upsert_agent_picker_thread(
+                thread_id, /*agent_nickname*/ None, /*agent_role*/ None,
+                /*is_closed*/ false,
+            );
+            self.ensure_thread_channel(thread_id);
+            self.activate_thread_channel(thread_id).await;
+            self.enqueue_thread_event(thread_id, event).await?;
     async fn enqueue_primary_thread_session(
         &mut self,
         session: ThreadSessionState,
@@ -2464,86 +2183,10 @@ impl App {
                         .await?;
                 }
             }
+        } else {
+            self.pending_primary_events.push_back(event);
         }
-        self.chat_widget
-            .set_initial_user_message_submit_suppressed(/*suppressed*/ false);
-        self.chat_widget.submit_initial_user_message_if_pending();
         Ok(())
-    }
-
-    async fn enqueue_primary_thread_notification(
-        &mut self,
-        notification: ServerNotification,
-    ) -> Result<()> {
-        if let Some(thread_id) = self.primary_thread_id {
-            return self
-                .enqueue_thread_notification(thread_id, notification)
-                .await;
-        }
-        self.pending_primary_events
-            .push_back(ThreadBufferedEvent::Notification(notification));
-        Ok(())
-    }
-
-    async fn enqueue_primary_thread_request(&mut self, request: ServerRequest) -> Result<()> {
-        if let Some(thread_id) = self.primary_thread_id {
-            return self.enqueue_thread_request(thread_id, request).await;
-        }
-        self.pending_primary_events
-            .push_back(ThreadBufferedEvent::Request(request));
-        Ok(())
-    }
-
-    async fn refresh_snapshot_session_if_needed(
-        &mut self,
-        app_server: &mut AppServerSession,
-        thread_id: ThreadId,
-        is_replay_only: bool,
-        snapshot: &mut ThreadEventSnapshot,
-    ) {
-        let should_refresh = !is_replay_only
-            && snapshot.session.as_ref().is_none_or(|session| {
-                session.model.trim().is_empty() || session.rollout_path.is_none()
-            });
-        if !should_refresh {
-            return;
-        }
-
-        match app_server
-            .resume_thread(self.config.clone(), thread_id)
-            .await
-        {
-            Ok(started) => {
-                self.apply_refreshed_snapshot_thread(thread_id, started, snapshot)
-                    .await
-            }
-            Err(err) => {
-                tracing::warn!(
-                    thread_id = %thread_id,
-                    error = %err,
-                    "failed to refresh inferred thread session before replay"
-                );
-            }
-        }
-    }
-
-    async fn apply_refreshed_snapshot_thread(
-        &mut self,
-        thread_id: ThreadId,
-        started: AppServerStartedThread,
-        snapshot: &mut ThreadEventSnapshot,
-    ) {
-        let AppServerStartedThread { session, turns } = started;
-        if let Some(channel) = self.thread_event_channels.get(&thread_id) {
-            let mut store = channel.store.lock().await;
-            store.set_session(session.clone(), turns.clone());
-            store.rebase_buffer_after_session_refresh();
-        }
-        snapshot.session = Some(session);
-        snapshot.turns = turns;
-        snapshot
-            .events
-            .retain(ThreadEventStore::event_survives_session_refresh);
     }
 
     /// Opens the `/agent` picker after refreshing cached labels for known threads.
@@ -2649,12 +2292,7 @@ impl App {
         self.sync_active_agent_label();
     }
 
-    async fn select_agent_thread(
-        &mut self,
-        tui: &mut tui::Tui,
-        app_server: &mut AppServerSession,
-        thread_id: ThreadId,
-    ) -> Result<()> {
+    async fn select_agent_thread(&mut self, tui: &mut tui::Tui, thread_id: ThreadId) -> Result<()> {
         if self.active_thread_id == Some(thread_id) {
             return Ok(());
         }
@@ -2672,8 +2310,7 @@ impl App {
         let previous_thread_id = self.active_thread_id;
         self.store_active_thread_receiver().await;
         self.active_thread_id = None;
-        let Some((receiver, mut snapshot)) = self.activate_thread_for_replay(thread_id).await
-        else {
+        let Some((receiver, snapshot)) = self.activate_thread_for_replay(thread_id).await else {
             self.chat_widget
                 .add_error_message(format!("Agent thread {thread_id} is already active."));
             if let Some(previous_thread_id) = previous_thread_id {
@@ -2681,14 +2318,6 @@ impl App {
             }
             return Ok(());
         };
-
-        self.refresh_snapshot_session_if_needed(
-            app_server,
-            thread_id,
-            is_replay_only,
-            &mut snapshot,
-        )
-        .await;
 
         self.active_thread_id = Some(thread_id);
         self.active_thread_rx = Some(receiver);
@@ -2798,8 +2427,66 @@ impl App {
         let init = self.chatwidget_init_for_forked_or_resumed_thread(tui, self.config.clone());
         self.chat_widget = ChatWidget::new_with_app_event(init);
         self.reset_thread_event_state();
-        self.enqueue_primary_thread_session(started.session, started.turns)
-            .await
+        self.restore_started_app_server_thread(started).await
+    }
+
+    /// Hydrate thread state from an `AppServerStartedThread` returned by the
+    /// app-server start/resume/fork handshake.
+    ///
+    /// This is the single path that every session-start variant funnels
+    /// through. It performs four things in order:
+    ///
+    /// 1. Converts the `Thread` snapshot into protocol-level `Event`s.
+    /// 2. Builds a **lossless** replay snapshot from a temporary store so that
+    ///    the initial render sees all history even when the thread has more
+    ///    turns than the bounded channel capacity.
+    /// 3. Pushes the same events into the real channel store for backtrack and
+    ///    navigation.
+    /// 4. Activates the thread channel and replays the snapshot into the chat
+    ///    widget.
+    async fn restore_started_app_server_thread(
+        &mut self,
+        started: AppServerStartedThread,
+    ) -> Result<()> {
+        let session_configured = started.session_configured;
+        let thread_id = session_configured.session_id;
+        let session_event = Event {
+            id: String::new(),
+            msg: EventMsg::SessionConfigured(session_configured.clone()),
+        };
+        let history_events =
+            thread_snapshot_events(&started.thread, started.show_raw_agent_reasoning);
+        let replay_snapshot = {
+            let mut replay_store = ThreadEventStore::new(history_events.len().saturating_add(1));
+            replay_store.push_event(session_event.clone());
+            for event in &history_events {
+                replay_store.push_event(event.clone());
+            }
+            replay_store.snapshot()
+        };
+
+        self.primary_thread_id = Some(thread_id);
+        self.primary_session_configured = Some(session_configured);
+        self.upsert_agent_picker_thread(
+            thread_id, /*agent_nickname*/ None, /*agent_role*/ None,
+            /*is_closed*/ false,
+        );
+
+        let store = {
+            let channel = self.ensure_thread_channel(thread_id);
+            Arc::clone(&channel.store)
+        };
+        {
+            let mut store = store.lock().await;
+            store.push_event(session_event);
+            for event in history_events {
+                store.push_event(event);
+            }
+        }
+
+        self.activate_thread_channel(thread_id).await;
+        self.replay_thread_snapshot(replay_snapshot, /*resume_restored_queue*/ false);
+        Ok(())
     }
 
     fn fresh_session_config(&self) -> Config {
@@ -2816,7 +2503,7 @@ impl App {
         let mut disconnected = false;
         loop {
             match rx.try_recv() {
-                Ok(event) => self.handle_thread_event_now(event),
+                Ok(event) => self.handle_codex_event_now(event),
                 Err(TryRecvError::Empty) => break,
                 Err(TryRecvError::Disconnected) => {
                     disconnected = true;
@@ -2845,14 +2532,11 @@ impl App {
     /// here so Ctrl+C-like exits don't accidentally resurrect the main thread.
     ///
     /// Failover is only eligible when all of these are true:
-    /// 1. the event is `thread/closed`;
+    /// 1. the event is `ShutdownComplete`;
     /// 2. the active thread differs from the primary thread;
     /// 3. the active thread is not the pending shutdown-exit thread.
-    fn active_non_primary_shutdown_target(
-        &self,
-        notification: &ServerNotification,
-    ) -> Option<(ThreadId, ThreadId)> {
-        if !matches!(notification, ServerNotification::ThreadClosed(_)) {
+    fn active_non_primary_shutdown_target(&self, msg: &EventMsg) -> Option<(ThreadId, ThreadId)> {
+        if !matches!(msg, EventMsg::ShutdownComplete) {
             return None;
         }
         let active_thread_id = self.active_thread_id?;
@@ -2868,19 +2552,17 @@ impl App {
         snapshot: ThreadEventSnapshot,
         resume_restored_queue: bool,
     ) {
-        if let Some(session) = snapshot.session {
-            self.chat_widget.handle_thread_session(session);
+        self.chat_widget
+            .set_initial_user_message_submit_suppressed(/*suppressed*/ true);
+        if let Some(event) = snapshot.session_configured {
+            self.handle_codex_event_replay(event);
         }
         self.chat_widget
             .set_queue_autosend_suppressed(/*suppressed*/ true);
         self.chat_widget
             .restore_thread_input_state(snapshot.input_state);
-        if !snapshot.turns.is_empty() {
-            self.chat_widget
-                .replay_thread_turns(snapshot.turns, ReplayKind::ThreadSnapshot);
-        }
         for event in snapshot.events {
-            self.handle_thread_event_replay(event);
+            self.handle_codex_event_replay(event);
         }
         self.chat_widget
             .set_queue_autosend_suppressed(/*suppressed*/ false);
@@ -2934,7 +2616,6 @@ impl App {
         let (app_event_tx, mut app_event_rx) = unbounded_channel();
         let app_event_tx = AppEventSender::new(app_event_tx);
         emit_project_config_warnings(&app_event_tx, &config);
-        emit_missing_system_bwrap_warning(&app_event_tx);
         tui.set_notification_method(config.tui_notification_method);
 
         let harness_overrides =
@@ -3031,7 +2712,7 @@ impl App {
                     status_line_invalid_items_warned: status_line_invalid_items_warned.clone(),
                     session_telemetry: session_telemetry.clone(),
                 };
-                (ChatWidget::new_with_app_event(init), Some(started))
+                (ChatWidget::new_with_app_event(init), started)
             }
             SessionSelection::Resume(target_session) => {
                 let resumed = app_server
@@ -3064,7 +2745,7 @@ impl App {
                     status_line_invalid_items_warned: status_line_invalid_items_warned.clone(),
                     session_telemetry: session_telemetry.clone(),
                 };
-                (ChatWidget::new_with_app_event(init), Some(resumed))
+                (ChatWidget::new_with_app_event(init), resumed)
             }
             SessionSelection::Fork(target_session) => {
                 session_telemetry.counter(
@@ -3102,7 +2783,7 @@ impl App {
                     status_line_invalid_items_warned: status_line_invalid_items_warned.clone(),
                     session_telemetry: session_telemetry.clone(),
                 };
-                (ChatWidget::new_with_app_event(init), Some(forked))
+                (ChatWidget::new_with_app_event(init), forked)
             }
         };
 
@@ -3141,6 +2822,7 @@ impl App {
             feedback_audience,
             remote_app_server_url,
             pending_update_action: None,
+            suppress_shutdown_complete: false,
             pending_shutdown_exit_thread_id: None,
             windows_sandbox: WindowsSandboxState::default(),
             thread_event_channels: HashMap::new(),
@@ -3153,10 +2835,8 @@ impl App {
             pending_primary_events: VecDeque::new(),
             pending_app_server_requests: PendingAppServerRequests::default(),
         };
-        if let Some(started) = initial_started_thread {
-            app.enqueue_primary_thread_session(started.session, started.turns)
-                .await?;
-        }
+        app.restore_started_app_server_thread(initial_started_thread)
+            .await?;
 
         // On startup, if Agent mode (workspace-write) or ReadOnly is active, warn about world-writable dirs on Windows.
         #[cfg(target_os = "windows")]
@@ -3235,7 +2915,7 @@ impl App {
                         app.active_thread_rx.is_some()
                     ) => {
                         if let Some(event) = active {
-                            if let Err(err) = app.handle_active_thread_event(tui, &mut app_server, event).await {
+                            if let Err(err) = app.handle_active_thread_event(tui, event).await {
                                 break Err(err);
                             }
                         } else {
@@ -3244,7 +2924,7 @@ impl App {
                         AppRunControl::Continue
                     }
                     Some(event) = tui_events.next() => {
-                        match app.handle_tui_event(tui, &mut app_server, event).await {
+                        match app.handle_tui_event(tui, event).await {
                             Ok(control) => control,
                             Err(err) => break Err(err),
                         }
@@ -3300,7 +2980,6 @@ impl App {
     pub(crate) async fn handle_tui_event(
         &mut self,
         tui: &mut tui::Tui,
-        app_server: &mut AppServerSession,
         event: TuiEvent,
     ) -> Result<AppRunControl> {
         if matches!(event, TuiEvent::Draw) {
@@ -3315,7 +2994,7 @@ impl App {
         } else {
             match event {
                 TuiEvent::Key(key_event) => {
-                    self.handle_key_event(tui, app_server, key_event).await;
+                    self.handle_key_event(tui, key_event).await;
                 }
                 TuiEvent::Paste(pasted) => {
                     // Many terminals convert newlines to \r when pasting (e.g., iTerm2),
@@ -3606,6 +3285,12 @@ impl App {
             AppEvent::CommitTick => {
                 self.chat_widget.on_commit_tick();
             }
+            AppEvent::CodexEvent(event) => {
+                self.enqueue_primary_event(event).await?;
+            }
+            AppEvent::ThreadEvent { thread_id, event } => {
+                self.handle_routed_thread_event(thread_id, event).await?;
+            }
             AppEvent::Exit(mode) => {
                 return Ok(self.handle_exit_mode(app_server, mode).await);
             }
@@ -3667,12 +3352,6 @@ impl App {
             }
             AppEvent::RefreshConnectors { force_refetch } => {
                 self.chat_widget.refresh_connectors(force_refetch);
-            }
-            AppEvent::FetchMcpInventory => {
-                self.fetch_mcp_inventory(app_server);
-            }
-            AppEvent::McpInventoryLoaded { result } => {
-                self.handle_mcp_inventory_result(result);
             }
             AppEvent::StartFileSearch(query) => {
                 self.file_search.on_user_query(query);
@@ -4457,7 +4136,7 @@ impl App {
                 self.open_agent_picker().await;
             }
             AppEvent::SelectAgentThread(thread_id) => {
-                self.select_agent_thread(tui, app_server, thread_id).await?;
+                self.select_agent_thread(tui, thread_id).await?;
             }
             AppEvent::OpenSkillsList => {
                 self.chat_widget.open_skills_list();
@@ -4721,100 +4400,33 @@ impl App {
         }
     }
 
-    fn handle_skills_list_response(&mut self, response: SkillsListResponse) {
-        let response = list_skills_response_to_core(response);
-        let cwd = self.chat_widget.config_ref().cwd.clone();
-        let errors = errors_for_cwd(&cwd, &response);
-        emit_skill_load_warnings(&self.app_event_tx, &errors);
-        self.chat_widget.handle_skills_list_response(response);
-    }
-
-    async fn handle_thread_rollback_response(
-        &mut self,
-        thread_id: ThreadId,
-        num_turns: u32,
-        response: &ThreadRollbackResponse,
-    ) {
-        if let Some(channel) = self.thread_event_channels.get(&thread_id) {
-            let mut store = channel.store.lock().await;
-            store.apply_thread_rollback(response);
-            store.note_local_thread_rollback(num_turns);
-        }
-        if self.active_thread_id == Some(thread_id)
-            && let Some(mut rx) = self.active_thread_rx.take()
-        {
-            let mut disconnected = false;
-            loop {
-                match rx.try_recv() {
-                    Ok(_) => {}
-                    Err(TryRecvError::Empty) => break,
-                    Err(TryRecvError::Disconnected) => {
-                        disconnected = true;
-                        break;
-                    }
-                }
-            }
-
-            if !disconnected {
-                self.active_thread_rx = Some(rx);
-            } else {
-                self.clear_active_thread().await;
-            }
-        }
-        self.handle_backtrack_rollback_succeeded(num_turns);
-        self.chat_widget.handle_thread_rolled_back();
-    }
-
-    fn handle_thread_event_now(&mut self, event: ThreadBufferedEvent) {
+    fn handle_codex_event_now(&mut self, event: Event) {
         let needs_refresh = matches!(
-            &event,
-            ThreadBufferedEvent::Notification(ServerNotification::TurnStarted(_))
-                | ThreadBufferedEvent::Notification(ServerNotification::ThreadTokenUsageUpdated(_))
+            event.msg,
+            EventMsg::SessionConfigured(_) | EventMsg::TurnStarted(_) | EventMsg::TokenCount(_)
         );
-        match event {
-            ThreadBufferedEvent::Notification(notification) => {
-                self.chat_widget
-                    .handle_server_notification(notification, /*replay_kind*/ None);
-            }
-            ThreadBufferedEvent::Request(request) => {
-                self.chat_widget
-                    .handle_server_request(request, /*replay_kind*/ None);
-            }
-            ThreadBufferedEvent::HistoryEntryResponse(event) => {
-                self.chat_widget.handle_history_entry_response(event);
-            }
-            ThreadBufferedEvent::LegacyWarning(message) => {
-                self.chat_widget.add_warning_message(message);
-            }
-            ThreadBufferedEvent::LegacyRollback { num_turns } => {
-                self.handle_backtrack_rollback_succeeded(num_turns);
-                self.chat_widget.handle_thread_rolled_back();
-            }
+        // This guard is only for intentional thread-switch shutdowns.
+        // App-exit shutdowns are tracked by `pending_shutdown_exit_thread_id`
+        // and resolved in `handle_active_thread_event`.
+        if self.suppress_shutdown_complete && matches!(event.msg, EventMsg::ShutdownComplete) {
+            self.suppress_shutdown_complete = false;
+            return;
         }
+        if let EventMsg::ListSkillsResponse(response) = &event.msg {
+            let cwd = self.chat_widget.config_ref().cwd.clone();
+            let errors = errors_for_cwd(&cwd, response);
+            emit_skill_load_warnings(&self.app_event_tx, &errors);
+        }
+        self.handle_backtrack_event(&event.msg);
+        self.chat_widget.handle_codex_event(event);
+
         if needs_refresh {
             self.refresh_status_line();
         }
     }
 
-    fn handle_thread_event_replay(&mut self, event: ThreadBufferedEvent) {
-        match event {
-            ThreadBufferedEvent::Notification(notification) => self
-                .chat_widget
-                .handle_server_notification(notification, Some(ReplayKind::ThreadSnapshot)),
-            ThreadBufferedEvent::Request(request) => self
-                .chat_widget
-                .handle_server_request(request, Some(ReplayKind::ThreadSnapshot)),
-            ThreadBufferedEvent::HistoryEntryResponse(event) => {
-                self.chat_widget.handle_history_entry_response(event)
-            }
-            ThreadBufferedEvent::LegacyWarning(message) => {
-                self.chat_widget.add_warning_message(message);
-            }
-            ThreadBufferedEvent::LegacyRollback { num_turns } => {
-                self.handle_backtrack_rollback_succeeded(num_turns);
-                self.chat_widget.handle_thread_rolled_back();
-            }
-        }
+    fn handle_codex_event_replay(&mut self, event: Event) {
+        self.chat_widget.handle_codex_event_replay(event);
     }
 
     /// Handles an event emitted by the currently active thread.
@@ -4822,19 +4434,11 @@ impl App {
     /// This function enforces shutdown intent routing: unexpected non-primary
     /// thread shutdowns fail over to the primary thread, while user-requested
     /// app exits consume only the tracked shutdown completion and then proceed.
-    async fn handle_active_thread_event(
-        &mut self,
-        tui: &mut tui::Tui,
-        app_server: &mut AppServerSession,
-        event: ThreadBufferedEvent,
-    ) -> Result<()> {
+    async fn handle_active_thread_event(&mut self, tui: &mut tui::Tui, event: Event) -> Result<()> {
         // Capture this before any potential thread switch: we only want to clear
         // the exit marker when the currently active thread acknowledges shutdown.
-        let pending_shutdown_exit_completed = matches!(
-            &event,
-            ThreadBufferedEvent::Notification(ServerNotification::ThreadClosed(_))
-        ) && self.pending_shutdown_exit_thread_id
-            == self.active_thread_id;
+        let pending_shutdown_exit_completed = matches!(&event.msg, EventMsg::ShutdownComplete)
+            && self.pending_shutdown_exit_thread_id == self.active_thread_id;
 
         // Processing order matters:
         //
@@ -4844,13 +4448,11 @@ impl App {
         //
         // This preserves the mental model that user-requested exits do not trigger
         // failover, while true sub-agent deaths still do.
-        if let ThreadBufferedEvent::Notification(notification) = &event
-            && let Some((closed_thread_id, primary_thread_id)) =
-                self.active_non_primary_shutdown_target(notification)
+        if let Some((closed_thread_id, primary_thread_id)) =
+            self.active_non_primary_shutdown_target(&event.msg)
         {
             self.mark_agent_picker_thread_closed(closed_thread_id);
-            self.select_agent_thread(tui, app_server, primary_thread_id)
-                .await?;
+            self.select_agent_thread(tui, primary_thread_id).await?;
             if self.active_thread_id == Some(primary_thread_id) {
                 self.chat_widget.add_info_message(
                     format!(
@@ -4872,7 +4474,7 @@ impl App {
             // thread, so unrelated shutdowns cannot consume this marker.
             self.pending_shutdown_exit_thread_id = None;
         }
-        self.handle_thread_event_now(event);
+        self.handle_codex_event_now(event);
         if self.backtrack_render_pending {
             tui.frame_requester().schedule_frame();
         }
@@ -5007,12 +4609,7 @@ impl App {
         tui.frame_requester().schedule_frame();
     }
 
-    async fn handle_key_event(
-        &mut self,
-        tui: &mut tui::Tui,
-        app_server: &mut AppServerSession,
-        key_event: KeyEvent,
-    ) {
+    async fn handle_key_event(&mut self, tui: &mut tui::Tui, key_event: KeyEvent) {
         // Some terminals, especially on macOS, encode Option+Left/Right as Option+b/f unless
         // enhanced keyboard reporting is available. We only treat those word-motion fallbacks as
         // agent-switch shortcuts when the composer is empty so we never steal the expected
@@ -5031,7 +4628,7 @@ impl App {
                 self.current_displayed_thread_id(),
                 AgentNavigationDirection::Previous,
             ) {
-                let _ = self.select_agent_thread(tui, app_server, thread_id).await;
+                let _ = self.select_agent_thread(tui, thread_id).await;
             }
             return;
         }
@@ -5046,7 +4643,7 @@ impl App {
                 self.current_displayed_thread_id(),
                 AgentNavigationDirection::Next,
             ) {
-                let _ = self.select_agent_thread(tui, app_server, thread_id).await;
+                let _ = self.select_agent_thread(tui, thread_id).await;
             }
             return;
         }
@@ -5178,89 +4775,13 @@ impl App {
     }
 }
 
-/// Collect every MCP server status from the app-server by walking the paginated
-/// `mcpServerStatus/list` RPC until no `next_cursor` is returned.
-///
-/// All pages are eagerly gathered into a single `Vec` so the caller can render
-/// the inventory atomically. Each page requests up to 100 entries.
-async fn fetch_all_mcp_server_statuses(
-    request_handle: AppServerRequestHandle,
-) -> Result<Vec<McpServerStatus>> {
-    let mut cursor = None;
-    let mut statuses = Vec::new();
-
-    loop {
-        let request_id = RequestId::String(format!("mcp-inventory-{}", Uuid::new_v4()));
-        let response: ListMcpServerStatusResponse = request_handle
-            .request_typed(ClientRequest::McpServerStatusList {
-                request_id,
-                params: ListMcpServerStatusParams {
-                    cursor: cursor.clone(),
-                    limit: Some(100),
-                },
-            })
-            .await
-            .wrap_err("mcpServerStatus/list failed in app-server TUI")?;
-        statuses.extend(response.data);
-        if let Some(next_cursor) = response.next_cursor {
-            cursor = Some(next_cursor);
-        } else {
-            break;
-        }
-    }
-
-    Ok(statuses)
-}
-
-/// Convert flat `McpServerStatus` responses into the per-server maps used by the
-/// in-process MCP subsystem (tools keyed as `mcp__{server}__{tool}`, plus
-/// per-server resource/template/auth maps). Test-only because the app-server TUI
-/// renders directly from `McpServerStatus` rather than these maps.
-#[cfg(test)]
-type McpInventoryMaps = (
-    HashMap<String, codex_protocol::mcp::Tool>,
-    HashMap<String, Vec<codex_protocol::mcp::Resource>>,
-    HashMap<String, Vec<codex_protocol::mcp::ResourceTemplate>>,
-    HashMap<String, McpAuthStatus>,
-);
-
-#[cfg(test)]
-fn mcp_inventory_maps_from_statuses(statuses: Vec<McpServerStatus>) -> McpInventoryMaps {
-    let mut tools = HashMap::new();
-    let mut resources = HashMap::new();
-    let mut resource_templates = HashMap::new();
-    let mut auth_statuses = HashMap::new();
-
-    for status in statuses {
-        let server_name = status.name;
-        auth_statuses.insert(
-            server_name.clone(),
-            match status.auth_status {
-                codex_app_server_protocol::McpAuthStatus::Unsupported => McpAuthStatus::Unsupported,
-                codex_app_server_protocol::McpAuthStatus::NotLoggedIn => McpAuthStatus::NotLoggedIn,
-                codex_app_server_protocol::McpAuthStatus::BearerToken => McpAuthStatus::BearerToken,
-                codex_app_server_protocol::McpAuthStatus::OAuth => McpAuthStatus::OAuth,
-            },
-        );
-        resources.insert(server_name.clone(), status.resources);
-        resource_templates.insert(server_name.clone(), status.resource_templates);
-        for (tool_name, tool) in status.tools {
-            tools.insert(format!("mcp__{server_name}__{tool_name}"), tool);
-        }
-    }
-
-    (tools, resources, resource_templates, auth_statuses)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::app_backtrack::BacktrackSelection;
     use crate::app_backtrack::BacktrackState;
     use crate::app_backtrack::user_count;
-
-    use crate::chatwidget::ChatWidgetInit;
-    use crate::chatwidget::create_initial_user_message;
+    use crate::app_server_session::AppServerStartedThread;
     use crate::chatwidget::tests::make_chatwidget_manual_with_sender;
     use crate::chatwidget::tests::set_chatgpt_auth;
     use crate::file_search::FileSearchManager;
@@ -5271,29 +4792,11 @@ mod tests {
     use crate::multi_agents::AgentPickerThreadEntry;
     use assert_matches::assert_matches;
 
-    use codex_app_server_protocol::AdditionalNetworkPermissions;
-    use codex_app_server_protocol::AdditionalPermissionProfile;
-    use codex_app_server_protocol::AgentMessageDeltaNotification;
-    use codex_app_server_protocol::CommandExecutionRequestApprovalParams;
-    use codex_app_server_protocol::NetworkApprovalContext as AppServerNetworkApprovalContext;
-    use codex_app_server_protocol::NetworkApprovalProtocol as AppServerNetworkApprovalProtocol;
-    use codex_app_server_protocol::NetworkPolicyAmendment as AppServerNetworkPolicyAmendment;
-    use codex_app_server_protocol::NetworkPolicyRuleAction as AppServerNetworkPolicyRuleAction;
-    use codex_app_server_protocol::RequestId as AppServerRequestId;
-    use codex_app_server_protocol::ServerNotification;
-    use codex_app_server_protocol::ServerRequest;
     use codex_app_server_protocol::Thread;
-    use codex_app_server_protocol::ThreadClosedNotification;
     use codex_app_server_protocol::ThreadItem;
-    use codex_app_server_protocol::ThreadStartedNotification;
-    use codex_app_server_protocol::ThreadTokenUsage;
-    use codex_app_server_protocol::ThreadTokenUsageUpdatedNotification;
-    use codex_app_server_protocol::TokenUsageBreakdown;
+    use codex_app_server_protocol::ThreadStatus;
     use codex_app_server_protocol::Turn;
-    use codex_app_server_protocol::TurnCompletedNotification;
-    use codex_app_server_protocol::TurnStartedNotification;
     use codex_app_server_protocol::TurnStatus;
-    use codex_app_server_protocol::UserInput as AppServerUserInput;
     use codex_core::config::ConfigBuilder;
     use codex_core::config::ConfigOverrides;
     use codex_core::config::types::ModelAvailabilityNuxConfig;
@@ -5303,22 +4806,20 @@ mod tests {
     use codex_protocol::config_types::CollaborationModeMask;
     use codex_protocol::config_types::ModeKind;
     use codex_protocol::config_types::Settings;
-    use codex_protocol::mcp::Tool;
-    use codex_protocol::models::NetworkPermissions;
-    use codex_protocol::models::PermissionProfile;
     use codex_protocol::openai_models::ModelAvailabilityNux;
+    use codex_protocol::protocol::AgentMessageDeltaEvent;
     use codex_protocol::protocol::AskForApproval;
     use codex_protocol::protocol::Event;
     use codex_protocol::protocol::EventMsg;
-    use codex_protocol::protocol::McpAuthStatus;
-    use codex_protocol::protocol::NetworkApprovalContext;
-    use codex_protocol::protocol::NetworkApprovalProtocol;
-    use codex_protocol::protocol::RolloutItem;
-    use codex_protocol::protocol::RolloutLine;
     use codex_protocol::protocol::SandboxPolicy;
     use codex_protocol::protocol::SessionConfiguredEvent;
     use codex_protocol::protocol::SessionSource;
-    use codex_protocol::protocol::TurnContextItem;
+    use codex_protocol::protocol::ThreadRolledBackEvent;
+    use codex_protocol::protocol::TurnAbortReason;
+    use codex_protocol::protocol::TurnAbortedEvent;
+    use codex_protocol::protocol::TurnCompleteEvent;
+    use codex_protocol::protocol::TurnStartedEvent;
+    use codex_protocol::protocol::UserMessageEvent;
     use codex_protocol::user_input::TextElement;
     use codex_protocol::user_input::UserInput;
     use crossterm::event::KeyModifiers;
@@ -5348,75 +4849,6 @@ mod tests {
             vec![base_cwd.join("rel")]
         );
         Ok(())
-    }
-
-    #[test]
-    fn mcp_inventory_maps_prefix_tool_names_by_server() {
-        let statuses = vec![
-            McpServerStatus {
-                name: "docs".to_string(),
-                tools: HashMap::from([(
-                    "list".to_string(),
-                    Tool {
-                        description: None,
-                        name: "list".to_string(),
-                        title: None,
-                        input_schema: serde_json::json!({"type": "object"}),
-                        output_schema: None,
-                        annotations: None,
-                        icons: None,
-                        meta: None,
-                    },
-                )]),
-                resources: Vec::new(),
-                resource_templates: Vec::new(),
-                auth_status: codex_app_server_protocol::McpAuthStatus::Unsupported,
-            },
-            McpServerStatus {
-                name: "disabled".to_string(),
-                tools: HashMap::new(),
-                resources: Vec::new(),
-                resource_templates: Vec::new(),
-                auth_status: codex_app_server_protocol::McpAuthStatus::Unsupported,
-            },
-        ];
-
-        let (tools, resources, resource_templates, auth_statuses) =
-            mcp_inventory_maps_from_statuses(statuses);
-        let mut resource_names = resources.keys().cloned().collect::<Vec<_>>();
-        resource_names.sort();
-        let mut template_names = resource_templates.keys().cloned().collect::<Vec<_>>();
-        template_names.sort();
-
-        assert_eq!(
-            tools.keys().cloned().collect::<Vec<_>>(),
-            vec!["mcp__docs__list".to_string()]
-        );
-        assert_eq!(resource_names, vec!["disabled", "docs"]);
-        assert_eq!(template_names, vec!["disabled", "docs"]);
-        assert_eq!(
-            auth_statuses.get("disabled"),
-            Some(&McpAuthStatus::Unsupported)
-        );
-    }
-
-    #[tokio::test]
-    async fn handle_mcp_inventory_result_clears_committed_loading_cell() {
-        let mut app = make_test_app().await;
-        app.transcript_cells
-            .push(Arc::new(history_cell::new_mcp_inventory_loading(
-                /*animations_enabled*/ false,
-            )));
-
-        app.handle_mcp_inventory_result(Ok(vec![McpServerStatus {
-            name: "docs".to_string(),
-            tools: HashMap::new(),
-            resources: Vec::new(),
-            resource_templates: Vec::new(),
-            auth_status: codex_app_server_protocol::McpAuthStatus::Unsupported,
-        }]));
-
-        assert_eq!(app.transcript_cells.len(), 0);
     }
 
     #[test]
@@ -5502,36 +4934,74 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn enqueue_primary_thread_session_replays_buffered_approval_after_attach() -> Result<()> {
+    async fn enqueue_primary_event_delivers_session_configured_before_buffered_approval()
+    -> Result<()> {
         let (mut app, mut app_event_rx, _op_rx) = make_test_app_with_channels().await;
         let thread_id = ThreadId::new();
-        let approval_request = exec_approval_request(thread_id, "turn-1", "call-1", None);
+        let approval_event = Event {
+            id: "approval-event".to_string(),
+            msg: EventMsg::ExecApprovalRequest(
+                codex_protocol::protocol::ExecApprovalRequestEvent {
+                    call_id: "call-1".to_string(),
+                    approval_id: None,
+                    turn_id: "turn-1".to_string(),
+                    command: vec!["echo".to_string(), "hello".to_string()],
+                    cwd: PathBuf::from("/tmp/project"),
+                    reason: Some("needs approval".to_string()),
+                    network_approval_context: None,
+                    proposed_execpolicy_amendment: None,
+                    proposed_network_policy_amendments: None,
+                    additional_permissions: None,
+                    skill_metadata: None,
+                    available_decisions: None,
+                    parsed_cmd: Vec::new(),
+                },
+            ),
+        };
+        let session_configured_event = Event {
+            id: "session-configured".to_string(),
+            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
+                session_id: thread_id,
+                forked_from_id: None,
+                thread_name: None,
+                model: "gpt-test".to_string(),
+                model_provider_id: "test-provider".to_string(),
+                service_tier: None,
+                approval_policy: AskForApproval::Never,
+                approvals_reviewer: ApprovalsReviewer::User,
+                sandbox_policy: SandboxPolicy::new_read_only_policy(),
+                cwd: PathBuf::from("/tmp/project"),
+                reasoning_effort: None,
+                history_log_id: 0,
+                history_entry_count: 0,
+                initial_messages: None,
+                network_proxy: None,
+                rollout_path: Some(PathBuf::new()),
+            }),
+        };
 
-        app.enqueue_primary_thread_request(approval_request).await?;
-        app.enqueue_primary_thread_session(
-            test_thread_session(thread_id, PathBuf::from("/tmp/project")),
-            Vec::new(),
-        )
-        .await?;
+        app.enqueue_primary_event(approval_event.clone()).await?;
+        app.enqueue_primary_event(session_configured_event.clone())
+            .await?;
 
         let rx = app
             .active_thread_rx
             .as_mut()
             .expect("primary thread receiver should be active");
-        let event = time::timeout(Duration::from_millis(50), rx.recv())
+        let first_event = time::timeout(Duration::from_millis(50), rx.recv())
+            .await
+            .expect("timed out waiting for session configured event")
+            .expect("channel closed unexpectedly");
+        let second_event = time::timeout(Duration::from_millis(50), rx.recv())
             .await
             .expect("timed out waiting for buffered approval event")
             .expect("channel closed unexpectedly");
 
-        assert!(matches!(
-            &event,
-            ThreadBufferedEvent::Request(ServerRequest::CommandExecutionRequestApproval {
-                params,
-                ..
-            }) if params.turn_id == "turn-1"
-        ));
+        assert!(matches!(first_event.msg, EventMsg::SessionConfigured(_)));
+        assert!(matches!(second_event.msg, EventMsg::ExecApprovalRequest(_)));
 
-        app.handle_thread_event_now(event);
+        app.handle_codex_event_now(first_event);
+        app.handle_codex_event_now(second_event);
         app.chat_widget
             .handle_key_event(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
 
@@ -5550,85 +5020,104 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn enqueue_primary_thread_session_replays_turns_before_initial_prompt_submit()
+    async fn resolved_buffered_primary_exec_approval_does_not_replay_after_session_configured()
     -> Result<()> {
-        let (mut app, mut app_event_rx, _op_rx) = make_test_app_with_channels().await;
+        let mut app = make_test_app().await;
         let thread_id = ThreadId::new();
-        let initial_prompt = "follow-up after replay".to_string();
-        let config = app.config.clone();
-        let model = codex_core::test_support::get_model_offline(config.model.as_deref());
-        app.chat_widget = ChatWidget::new_with_app_event(ChatWidgetInit {
-            config,
-            frame_requester: crate::tui::FrameRequester::test_dummy(),
-            app_event_tx: app.app_event_tx.clone(),
-            initial_user_message: create_initial_user_message(
-                Some(initial_prompt.clone()),
-                Vec::new(),
-                Vec::new(),
+        let approval_event = Event {
+            id: "approval-event".to_string(),
+            msg: EventMsg::ExecApprovalRequest(
+                codex_protocol::protocol::ExecApprovalRequestEvent {
+                    call_id: "call-1".to_string(),
+                    approval_id: Some("approval-1".to_string()),
+                    turn_id: String::new(),
+                    command: vec!["echo".to_string(), "hello".to_string()],
+                    cwd: PathBuf::from("/tmp/project"),
+                    reason: Some("needs approval".to_string()),
+                    network_approval_context: None,
+                    proposed_execpolicy_amendment: None,
+                    proposed_network_policy_amendments: None,
+                    additional_permissions: None,
+                    skill_metadata: None,
+                    available_decisions: None,
+                    parsed_cmd: Vec::new(),
+                },
             ),
-            enhanced_keys_supported: false,
-            has_chatgpt_account: false,
-            model_catalog: app.model_catalog.clone(),
-            feedback: codex_feedback::CodexFeedback::new(),
-            is_first_run: false,
-            feedback_audience: app.feedback_audience,
-            status_account_display: None,
-            initial_plan_type: None,
-            model: Some(model),
-            startup_tooltip_override: None,
-            status_line_invalid_items_warned: app.status_line_invalid_items_warned.clone(),
-            session_telemetry: app.session_telemetry.clone(),
-        });
+        };
+        let session_configured_event = Event {
+            id: "session-configured".to_string(),
+            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
+                session_id: thread_id,
+                forked_from_id: None,
+                thread_name: None,
+                model: "gpt-test".to_string(),
+                model_provider_id: "test-provider".to_string(),
+                service_tier: None,
+                approval_policy: AskForApproval::Never,
+                approvals_reviewer: ApprovalsReviewer::User,
+                sandbox_policy: SandboxPolicy::new_read_only_policy(),
+                cwd: PathBuf::from("/tmp/project"),
+                reasoning_effort: None,
+                history_log_id: 0,
+                history_entry_count: 0,
+                initial_messages: None,
+                network_proxy: None,
+                rollout_path: Some(PathBuf::new()),
+            }),
+        };
 
-        app.enqueue_primary_thread_session(
-            test_thread_session(thread_id, PathBuf::from("/tmp/project")),
-            vec![test_turn(
-                "turn-1",
-                TurnStatus::Completed,
-                vec![ThreadItem::UserMessage {
-                    id: "user-1".to_string(),
-                    content: vec![AppServerUserInput::Text {
-                        text: "earlier prompt".to_string(),
-                        text_elements: Vec::new(),
-                    }],
-                }],
-            )],
+        app.enqueue_primary_event(approval_event).await?;
+        app.note_app_server_request_resolved(ResolvedAppServerRequest {
+            exec_approval_ids: vec!["approval-1".to_string()],
+        })
+        .await;
+        app.enqueue_primary_event(session_configured_event).await?;
+
+        let rx = app
+            .active_thread_rx
+            .as_mut()
+            .expect("primary thread receiver should be active");
+        let first_event = time::timeout(Duration::from_millis(50), rx.recv())
+            .await
+            .expect("timed out waiting for session configured event")
+            .expect("channel closed unexpectedly");
+
+        assert!(matches!(first_event.msg, EventMsg::SessionConfigured(_)));
+        assert!(
+            time::timeout(Duration::from_millis(50), rx.recv())
+                .await
+                .is_err(),
+            "resolved buffered approval should not replay after session configured"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn routed_thread_event_does_not_recreate_channel_after_reset() -> Result<()> {
+        let mut app = make_test_app().await;
+        let thread_id = ThreadId::new();
+        app.thread_event_channels.insert(
+            thread_id,
+            ThreadEventChannel::new(THREAD_EVENT_CHANNEL_CAPACITY),
+        );
+
+        app.reset_thread_event_state();
+        app.handle_routed_thread_event(
+            thread_id,
+            Event {
+                id: "stale-event".to_string(),
+                msg: EventMsg::ShutdownComplete,
+            },
         )
         .await?;
 
-        let mut saw_replayed_answer = false;
-        let mut submitted_items = None;
-        while let Ok(event) = app_event_rx.try_recv() {
-            match event {
-                AppEvent::InsertHistoryCell(cell) => {
-                    let transcript = lines_to_single_string(&cell.transcript_lines(80));
-                    saw_replayed_answer |= transcript.contains("earlier prompt");
-                }
-                AppEvent::SubmitThreadOp {
-                    thread_id: op_thread_id,
-                    op: Op::UserTurn { items, .. },
-                } => {
-                    assert_eq!(op_thread_id, thread_id);
-                    submitted_items = Some(items);
-                }
-                AppEvent::CodexOp(Op::UserTurn { items, .. }) => {
-                    submitted_items = Some(items);
-                }
-                _ => {}
-            }
-        }
         assert!(
-            saw_replayed_answer,
-            "expected replayed history before initial prompt submit"
+            !app.thread_event_channels.contains_key(&thread_id),
+            "stale routed events should not recreate cleared thread channels"
         );
-        assert_eq!(
-            submitted_items,
-            Some(vec![UserInput::Text {
-                text: initial_prompt,
-                text_elements: Vec::new(),
-            }])
-        );
-
+        assert_eq!(app.active_thread_id, None);
+        assert_eq!(app.primary_thread_id, None);
         Ok(())
     }
 
@@ -5713,16 +5202,18 @@ mod tests {
             .insert(thread_id, ThreadEventChannel::new(1));
         app.set_thread_active(thread_id, true).await;
 
-        let event = thread_closed_notification(thread_id);
+        let event = Event {
+            id: String::new(),
+            msg: EventMsg::ShutdownComplete,
+        };
 
-        app.enqueue_thread_notification(thread_id, event.clone())
-            .await?;
+        app.enqueue_thread_event(thread_id, event.clone()).await?;
         time::timeout(
             Duration::from_millis(50),
-            app.enqueue_thread_notification(thread_id, event),
+            app.enqueue_thread_event(thread_id, event),
         )
         .await
-        .expect("enqueue_thread_notification blocked on a full channel")?;
+        .expect("enqueue_thread_event blocked on a full channel")?;
 
         let mut rx = app
             .thread_event_channels
@@ -5748,17 +5239,34 @@ mod tests {
     async fn replay_thread_snapshot_restores_draft_and_queued_input() {
         let mut app = make_test_app().await;
         let thread_id = ThreadId::new();
-        let session = test_thread_session(thread_id, PathBuf::from("/tmp/project"));
         app.thread_event_channels.insert(
             thread_id,
-            ThreadEventChannel::new_with_session(
+            ThreadEventChannel::new_with_session_configured(
                 THREAD_EVENT_CHANNEL_CAPACITY,
-                session.clone(),
-                Vec::new(),
+                Event {
+                    id: "session-configured".to_string(),
+                    msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
+                        session_id: thread_id,
+                        forked_from_id: None,
+                        thread_name: None,
+                        model: "gpt-test".to_string(),
+                        model_provider_id: "test-provider".to_string(),
+                        service_tier: None,
+                        approval_policy: AskForApproval::Never,
+                        approvals_reviewer: ApprovalsReviewer::User,
+                        sandbox_policy: SandboxPolicy::new_read_only_policy(),
+                        cwd: PathBuf::from("/tmp/project"),
+                        reasoning_effort: None,
+                        history_log_id: 0,
+                        history_entry_count: 0,
+                        initial_messages: None,
+                        network_proxy: None,
+                        rollout_path: Some(PathBuf::new()),
+                    }),
+                },
             ),
         );
         app.activate_thread_channel(thread_id).await;
-        app.chat_widget.handle_thread_session(session.clone());
 
         app.chat_widget
             .apply_external_edit("draft prompt".to_string());
@@ -5797,46 +5305,59 @@ mod tests {
 
         assert_eq!(app.chat_widget.composer_text_with_pending(), "draft prompt");
         assert!(app.chat_widget.queued_user_message_texts().is_empty());
-        while let Ok(op) = new_op_rx.try_recv() {
-            assert!(
-                !matches!(op, Op::UserTurn { .. }),
-                "draft-only replay should not auto-submit queued input"
-            );
-        }
-    }
-
-    #[tokio::test]
-    async fn active_turn_id_for_thread_uses_snapshot_turns() {
-        let mut app = make_test_app().await;
-        let thread_id = ThreadId::new();
-        let session = test_thread_session(thread_id, PathBuf::from("/tmp/project"));
-        app.thread_event_channels.insert(
-            thread_id,
-            ThreadEventChannel::new_with_session(
-                THREAD_EVENT_CHANNEL_CAPACITY,
-                session,
-                vec![test_turn("turn-1", TurnStatus::InProgress, Vec::new())],
+        match next_user_turn_op(&mut new_op_rx) {
+            Op::UserTurn { items, .. } => assert_eq!(
+                items,
+                vec![UserInput::Text {
+                    text: "queued follow-up".to_string(),
+                    text_elements: Vec::new(),
+                }]
             ),
-        );
-
-        assert_eq!(
-            app.active_turn_id_for_thread(thread_id).await,
-            Some("turn-1".to_string())
-        );
+            other => panic!("expected queued follow-up submission, got {other:?}"),
+        }
     }
 
     #[tokio::test]
     async fn replayed_turn_complete_submits_restored_queued_follow_up() {
         let (mut app, _app_event_rx, _op_rx) = make_test_app_with_channels().await;
         let thread_id = ThreadId::new();
-        let session = test_thread_session(thread_id, PathBuf::from("/tmp/project"));
-        app.chat_widget.handle_thread_session(session.clone());
+        let session_configured = Event {
+            id: "session-configured".to_string(),
+            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
+                session_id: thread_id,
+                forked_from_id: None,
+                thread_name: None,
+                model: "gpt-test".to_string(),
+                model_provider_id: "test-provider".to_string(),
+                service_tier: None,
+                approval_policy: AskForApproval::Never,
+                approvals_reviewer: ApprovalsReviewer::User,
+                sandbox_policy: SandboxPolicy::new_read_only_policy(),
+                cwd: PathBuf::from("/tmp/project"),
+                reasoning_effort: None,
+                history_log_id: 0,
+                history_entry_count: 0,
+                initial_messages: None,
+                network_proxy: None,
+                rollout_path: Some(PathBuf::new()),
+            }),
+        };
         app.chat_widget
-            .handle_server_notification(turn_started_notification(thread_id, "turn-1"), None);
-        app.chat_widget.handle_server_notification(
-            agent_message_delta_notification(thread_id, "turn-1", "agent-1", "streaming"),
-            None,
-        );
+            .handle_codex_event(session_configured.clone());
+        app.chat_widget.handle_codex_event(Event {
+            id: "turn-started".to_string(),
+            msg: EventMsg::TurnStarted(TurnStartedEvent {
+                turn_id: "turn-1".to_string(),
+                model_context_window: None,
+                collaboration_mode_kind: Default::default(),
+            }),
+        });
+        app.chat_widget.handle_codex_event(Event {
+            id: "agent-delta".to_string(),
+            msg: EventMsg::AgentMessageDelta(AgentMessageDeltaEvent {
+                delta: "streaming".to_string(),
+            }),
+        });
         app.chat_widget
             .apply_external_edit("queued follow-up".to_string());
         app.chat_widget
@@ -5849,15 +5370,18 @@ mod tests {
         let (chat_widget, _app_event_tx, _rx, mut new_op_rx) =
             make_chatwidget_manual_with_sender().await;
         app.chat_widget = chat_widget;
-        app.chat_widget.handle_thread_session(session.clone());
+        app.chat_widget.handle_codex_event(session_configured);
         while new_op_rx.try_recv().is_ok() {}
         app.replay_thread_snapshot(
             ThreadEventSnapshot {
-                session: None,
-                turns: Vec::new(),
-                events: vec![ThreadBufferedEvent::Notification(
-                    turn_completed_notification(thread_id, "turn-1", TurnStatus::Completed),
-                )],
+                session_configured: None,
+                events: vec![Event {
+                    id: "turn-complete".to_string(),
+                    msg: EventMsg::TurnComplete(TurnCompleteEvent {
+                        turn_id: "turn-1".to_string(),
+                        last_agent_message: None,
+                    }),
+                }],
                 input_state: Some(input_state),
             },
             true,
@@ -5876,44 +5400,46 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn replay_thread_snapshot_replays_legacy_warning_history() {
-        let (mut app, mut app_event_rx, _op_rx) = make_test_app_with_channels().await;
-
-        app.replay_thread_snapshot(
-            ThreadEventSnapshot {
-                session: None,
-                turns: Vec::new(),
-                events: vec![ThreadBufferedEvent::LegacyWarning(
-                    "legacy warning message".to_string(),
-                )],
-                input_state: None,
-            },
-            false,
-        );
-
-        let mut saw_warning = false;
-        while let Ok(event) = app_event_rx.try_recv() {
-            if let AppEvent::InsertHistoryCell(cell) = event {
-                let transcript = lines_to_single_string(&cell.transcript_lines(80));
-                saw_warning |= transcript.contains("legacy warning message");
-            }
-        }
-
-        assert!(saw_warning, "expected replayed legacy warning history cell");
-    }
-
-    #[tokio::test]
     async fn replay_only_thread_keeps_restored_queue_visible() {
         let (mut app, _app_event_rx, _op_rx) = make_test_app_with_channels().await;
         let thread_id = ThreadId::new();
-        let session = test_thread_session(thread_id, PathBuf::from("/tmp/project"));
-        app.chat_widget.handle_thread_session(session.clone());
+        let session_configured = Event {
+            id: "session-configured".to_string(),
+            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
+                session_id: thread_id,
+                forked_from_id: None,
+                thread_name: None,
+                model: "gpt-test".to_string(),
+                model_provider_id: "test-provider".to_string(),
+                service_tier: None,
+                approval_policy: AskForApproval::Never,
+                approvals_reviewer: ApprovalsReviewer::User,
+                sandbox_policy: SandboxPolicy::new_read_only_policy(),
+                cwd: PathBuf::from("/tmp/project"),
+                reasoning_effort: None,
+                history_log_id: 0,
+                history_entry_count: 0,
+                initial_messages: None,
+                network_proxy: None,
+                rollout_path: Some(PathBuf::new()),
+            }),
+        };
         app.chat_widget
-            .handle_server_notification(turn_started_notification(thread_id, "turn-1"), None);
-        app.chat_widget.handle_server_notification(
-            agent_message_delta_notification(thread_id, "turn-1", "agent-1", "streaming"),
-            None,
-        );
+            .handle_codex_event(session_configured.clone());
+        app.chat_widget.handle_codex_event(Event {
+            id: "turn-started".to_string(),
+            msg: EventMsg::TurnStarted(TurnStartedEvent {
+                turn_id: "turn-1".to_string(),
+                model_context_window: None,
+                collaboration_mode_kind: Default::default(),
+            }),
+        });
+        app.chat_widget.handle_codex_event(Event {
+            id: "agent-delta".to_string(),
+            msg: EventMsg::AgentMessageDelta(AgentMessageDeltaEvent {
+                delta: "streaming".to_string(),
+            }),
+        });
         app.chat_widget
             .apply_external_edit("queued follow-up".to_string());
         app.chat_widget
@@ -5926,16 +5452,19 @@ mod tests {
         let (chat_widget, _app_event_tx, _rx, mut new_op_rx) =
             make_chatwidget_manual_with_sender().await;
         app.chat_widget = chat_widget;
-        app.chat_widget.handle_thread_session(session.clone());
+        app.chat_widget.handle_codex_event(session_configured);
         while new_op_rx.try_recv().is_ok() {}
 
         app.replay_thread_snapshot(
             ThreadEventSnapshot {
-                session: None,
-                turns: Vec::new(),
-                events: vec![ThreadBufferedEvent::Notification(
-                    turn_completed_notification(thread_id, "turn-1", TurnStatus::Completed),
-                )],
+                session_configured: None,
+                events: vec![Event {
+                    id: "turn-complete".to_string(),
+                    msg: EventMsg::TurnComplete(TurnCompleteEvent {
+                        turn_id: "turn-1".to_string(),
+                        last_agent_message: None,
+                    }),
+                }],
                 input_state: Some(input_state),
             },
             false,
@@ -5955,14 +5484,43 @@ mod tests {
     async fn replay_thread_snapshot_keeps_queue_when_running_state_only_comes_from_snapshot() {
         let (mut app, _app_event_rx, _op_rx) = make_test_app_with_channels().await;
         let thread_id = ThreadId::new();
-        let session = test_thread_session(thread_id, PathBuf::from("/tmp/project"));
-        app.chat_widget.handle_thread_session(session.clone());
+        let session_configured = Event {
+            id: "session-configured".to_string(),
+            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
+                session_id: thread_id,
+                forked_from_id: None,
+                thread_name: None,
+                model: "gpt-test".to_string(),
+                model_provider_id: "test-provider".to_string(),
+                service_tier: None,
+                approval_policy: AskForApproval::Never,
+                approvals_reviewer: ApprovalsReviewer::User,
+                sandbox_policy: SandboxPolicy::new_read_only_policy(),
+                cwd: PathBuf::from("/tmp/project"),
+                reasoning_effort: None,
+                history_log_id: 0,
+                history_entry_count: 0,
+                initial_messages: None,
+                network_proxy: None,
+                rollout_path: Some(PathBuf::new()),
+            }),
+        };
         app.chat_widget
-            .handle_server_notification(turn_started_notification(thread_id, "turn-1"), None);
-        app.chat_widget.handle_server_notification(
-            agent_message_delta_notification(thread_id, "turn-1", "agent-1", "streaming"),
-            None,
-        );
+            .handle_codex_event(session_configured.clone());
+        app.chat_widget.handle_codex_event(Event {
+            id: "turn-started".to_string(),
+            msg: EventMsg::TurnStarted(TurnStartedEvent {
+                turn_id: "turn-1".to_string(),
+                model_context_window: None,
+                collaboration_mode_kind: Default::default(),
+            }),
+        });
+        app.chat_widget.handle_codex_event(Event {
+            id: "agent-delta".to_string(),
+            msg: EventMsg::AgentMessageDelta(AgentMessageDeltaEvent {
+                delta: "streaming".to_string(),
+            }),
+        });
         app.chat_widget
             .apply_external_edit("queued follow-up".to_string());
         app.chat_widget
@@ -5975,13 +5533,12 @@ mod tests {
         let (chat_widget, _app_event_tx, _rx, mut new_op_rx) =
             make_chatwidget_manual_with_sender().await;
         app.chat_widget = chat_widget;
-        app.chat_widget.handle_thread_session(session.clone());
+        app.chat_widget.handle_codex_event(session_configured);
         while new_op_rx.try_recv().is_ok() {}
 
         app.replay_thread_snapshot(
             ThreadEventSnapshot {
-                session: None,
-                turns: Vec::new(),
+                session_configured: None,
                 events: vec![],
                 input_state: Some(input_state),
             },
@@ -5999,87 +5556,46 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn replay_thread_snapshot_in_progress_turn_restores_running_queue_state() {
-        let (mut app, _app_event_rx, _op_rx) = make_test_app_with_channels().await;
-        let thread_id = ThreadId::new();
-        let session = test_thread_session(thread_id, PathBuf::from("/tmp/project"));
-        app.chat_widget.handle_thread_session(session.clone());
-        app.chat_widget
-            .handle_server_notification(turn_started_notification(thread_id, "turn-1"), None);
-        app.chat_widget.handle_server_notification(
-            agent_message_delta_notification(thread_id, "turn-1", "agent-1", "streaming"),
-            None,
-        );
-        app.chat_widget
-            .apply_external_edit("queued follow-up".to_string());
-        app.chat_widget
-            .handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
-        let input_state = app
-            .chat_widget
-            .capture_thread_input_state()
-            .expect("expected queued follow-up state");
-
-        let (chat_widget, _app_event_tx, _rx, mut new_op_rx) =
-            make_chatwidget_manual_with_sender().await;
-        app.chat_widget = chat_widget;
-        app.chat_widget.handle_thread_session(session.clone());
-        while new_op_rx.try_recv().is_ok() {}
-
-        app.replay_thread_snapshot(
-            ThreadEventSnapshot {
-                session: None,
-                turns: vec![test_turn("turn-1", TurnStatus::InProgress, Vec::new())],
-                events: Vec::new(),
-                input_state: Some(input_state),
-            },
-            true,
-        );
-
-        assert_eq!(
-            app.chat_widget.queued_user_message_texts(),
-            vec!["queued follow-up".to_string()]
-        );
-        assert!(
-            new_op_rx.try_recv().is_err(),
-            "restored queue should stay queued while replayed turn is still running"
-        );
-    }
-
-    #[tokio::test]
-    async fn replay_thread_snapshot_in_progress_turn_restores_running_state_without_input_state() {
-        let (mut app, _app_event_rx, _op_rx) = make_test_app_with_channels().await;
-        let thread_id = ThreadId::new();
-        let session = test_thread_session(thread_id, PathBuf::from("/tmp/project"));
-        let (chat_widget, _app_event_tx, _rx, _new_op_rx) =
-            make_chatwidget_manual_with_sender().await;
-        app.chat_widget = chat_widget;
-        app.chat_widget.handle_thread_session(session);
-
-        app.replay_thread_snapshot(
-            ThreadEventSnapshot {
-                session: None,
-                turns: vec![test_turn("turn-1", TurnStatus::InProgress, Vec::new())],
-                events: Vec::new(),
-                input_state: None,
-            },
-            false,
-        );
-
-        assert!(app.chat_widget.is_task_running_for_test());
-    }
-
-    #[tokio::test]
     async fn replay_thread_snapshot_does_not_submit_queue_before_replay_catches_up() {
         let (mut app, _app_event_rx, _op_rx) = make_test_app_with_channels().await;
         let thread_id = ThreadId::new();
-        let session = test_thread_session(thread_id, PathBuf::from("/tmp/project"));
-        app.chat_widget.handle_thread_session(session.clone());
+        let session_configured = Event {
+            id: "session-configured".to_string(),
+            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
+                session_id: thread_id,
+                forked_from_id: None,
+                thread_name: None,
+                model: "gpt-test".to_string(),
+                model_provider_id: "test-provider".to_string(),
+                service_tier: None,
+                approval_policy: AskForApproval::Never,
+                approvals_reviewer: ApprovalsReviewer::User,
+                sandbox_policy: SandboxPolicy::new_read_only_policy(),
+                cwd: PathBuf::from("/tmp/project"),
+                reasoning_effort: None,
+                history_log_id: 0,
+                history_entry_count: 0,
+                initial_messages: None,
+                network_proxy: None,
+                rollout_path: Some(PathBuf::new()),
+            }),
+        };
         app.chat_widget
-            .handle_server_notification(turn_started_notification(thread_id, "turn-1"), None);
-        app.chat_widget.handle_server_notification(
-            agent_message_delta_notification(thread_id, "turn-1", "agent-1", "streaming"),
-            None,
-        );
+            .handle_codex_event(session_configured.clone());
+        app.chat_widget.handle_codex_event(Event {
+            id: "turn-started".to_string(),
+            msg: EventMsg::TurnStarted(TurnStartedEvent {
+                turn_id: "turn-1".to_string(),
+                model_context_window: None,
+                collaboration_mode_kind: Default::default(),
+            }),
+        });
+        app.chat_widget.handle_codex_event(Event {
+            id: "agent-delta".to_string(),
+            msg: EventMsg::AgentMessageDelta(AgentMessageDeltaEvent {
+                delta: "streaming".to_string(),
+            }),
+        });
         app.chat_widget
             .apply_external_edit("queued follow-up".to_string());
         app.chat_widget
@@ -6092,22 +5608,28 @@ mod tests {
         let (chat_widget, _app_event_tx, _rx, mut new_op_rx) =
             make_chatwidget_manual_with_sender().await;
         app.chat_widget = chat_widget;
-        app.chat_widget.handle_thread_session(session.clone());
+        app.chat_widget.handle_codex_event(session_configured);
         while new_op_rx.try_recv().is_ok() {}
 
         app.replay_thread_snapshot(
             ThreadEventSnapshot {
-                session: None,
-                turns: Vec::new(),
+                session_configured: None,
                 events: vec![
-                    ThreadBufferedEvent::Notification(turn_completed_notification(
-                        thread_id,
-                        "turn-0",
-                        TurnStatus::Completed,
-                    )),
-                    ThreadBufferedEvent::Notification(turn_started_notification(
-                        thread_id, "turn-1",
-                    )),
+                    Event {
+                        id: "older-turn-complete".to_string(),
+                        msg: EventMsg::TurnComplete(TurnCompleteEvent {
+                            turn_id: "turn-0".to_string(),
+                            last_agent_message: None,
+                        }),
+                    },
+                    Event {
+                        id: "latest-turn-started".to_string(),
+                        msg: EventMsg::TurnStarted(TurnStartedEvent {
+                            turn_id: "turn-1".to_string(),
+                            model_context_window: None,
+                            collaboration_mode_kind: Default::default(),
+                        }),
+                    },
                 ],
                 input_state: Some(input_state),
             },
@@ -6123,10 +5645,13 @@ mod tests {
             vec!["queued follow-up".to_string()]
         );
 
-        app.chat_widget.handle_server_notification(
-            turn_completed_notification(thread_id, "turn-1", TurnStatus::Completed),
-            None,
-        );
+        app.chat_widget.handle_codex_event(Event {
+            id: "latest-turn-complete".to_string(),
+            msg: EventMsg::TurnComplete(TurnCompleteEvent {
+                turn_id: "turn-1".to_string(),
+                last_agent_message: None,
+            }),
+        });
 
         match next_user_turn_op(&mut new_op_rx) {
             Op::UserTurn { items, .. } => assert_eq!(
@@ -6144,17 +5669,34 @@ mod tests {
     async fn replay_thread_snapshot_restores_pending_pastes_for_submit() {
         let (mut app, _app_event_rx, _op_rx) = make_test_app_with_channels().await;
         let thread_id = ThreadId::new();
-        let session = test_thread_session(thread_id, PathBuf::from("/tmp/project"));
         app.thread_event_channels.insert(
             thread_id,
-            ThreadEventChannel::new_with_session(
+            ThreadEventChannel::new_with_session_configured(
                 THREAD_EVENT_CHANNEL_CAPACITY,
-                session.clone(),
-                Vec::new(),
+                Event {
+                    id: "session-configured".to_string(),
+                    msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
+                        session_id: thread_id,
+                        forked_from_id: None,
+                        thread_name: None,
+                        model: "gpt-test".to_string(),
+                        model_provider_id: "test-provider".to_string(),
+                        service_tier: None,
+                        approval_policy: AskForApproval::Never,
+                        approvals_reviewer: ApprovalsReviewer::User,
+                        sandbox_policy: SandboxPolicy::new_read_only_policy(),
+                        cwd: PathBuf::from("/tmp/project"),
+                        reasoning_effort: None,
+                        history_log_id: 0,
+                        history_entry_count: 0,
+                        initial_messages: None,
+                        network_proxy: None,
+                        rollout_path: Some(PathBuf::new()),
+                    }),
+                },
             ),
         );
         app.activate_thread_channel(thread_id).await;
-        app.chat_widget.handle_thread_session(session);
 
         let large = "x".repeat(1005);
         app.chat_widget.handle_paste(large.clone());
@@ -6201,8 +5743,29 @@ mod tests {
     async fn replay_thread_snapshot_restores_collaboration_mode_for_draft_submit() {
         let (mut app, _app_event_rx, _op_rx) = make_test_app_with_channels().await;
         let thread_id = ThreadId::new();
-        let session = test_thread_session(thread_id, PathBuf::from("/tmp/project"));
-        app.chat_widget.handle_thread_session(session.clone());
+        let session_configured = Event {
+            id: "session-configured".to_string(),
+            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
+                session_id: thread_id,
+                forked_from_id: None,
+                thread_name: None,
+                model: "gpt-test".to_string(),
+                model_provider_id: "test-provider".to_string(),
+                service_tier: None,
+                approval_policy: AskForApproval::Never,
+                approvals_reviewer: ApprovalsReviewer::User,
+                sandbox_policy: SandboxPolicy::new_read_only_policy(),
+                cwd: PathBuf::from("/tmp/project"),
+                reasoning_effort: None,
+                history_log_id: 0,
+                history_entry_count: 0,
+                initial_messages: None,
+                network_proxy: None,
+                rollout_path: Some(PathBuf::new()),
+            }),
+        };
+        app.chat_widget
+            .handle_codex_event(session_configured.clone());
         app.chat_widget
             .set_reasoning_effort(Some(ReasoningEffortConfig::High));
         app.chat_widget
@@ -6223,7 +5786,7 @@ mod tests {
         let (chat_widget, _app_event_tx, _rx, mut new_op_rx) =
             make_chatwidget_manual_with_sender().await;
         app.chat_widget = chat_widget;
-        app.chat_widget.handle_thread_session(session.clone());
+        app.chat_widget.handle_codex_event(session_configured);
         app.chat_widget
             .set_reasoning_effort(Some(ReasoningEffortConfig::Low));
         app.chat_widget
@@ -6238,8 +5801,7 @@ mod tests {
 
         app.replay_thread_snapshot(
             ThreadEventSnapshot {
-                session: None,
-                turns: Vec::new(),
+                session_configured: None,
                 events: vec![],
                 input_state: Some(input_state),
             },
@@ -6285,8 +5847,29 @@ mod tests {
     async fn replay_thread_snapshot_restores_collaboration_mode_without_input() {
         let (mut app, _app_event_rx, _op_rx) = make_test_app_with_channels().await;
         let thread_id = ThreadId::new();
-        let session = test_thread_session(thread_id, PathBuf::from("/tmp/project"));
-        app.chat_widget.handle_thread_session(session.clone());
+        let session_configured = Event {
+            id: "session-configured".to_string(),
+            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
+                session_id: thread_id,
+                forked_from_id: None,
+                thread_name: None,
+                model: "gpt-test".to_string(),
+                model_provider_id: "test-provider".to_string(),
+                service_tier: None,
+                approval_policy: AskForApproval::Never,
+                approvals_reviewer: ApprovalsReviewer::User,
+                sandbox_policy: SandboxPolicy::new_read_only_policy(),
+                cwd: PathBuf::from("/tmp/project"),
+                reasoning_effort: None,
+                history_log_id: 0,
+                history_entry_count: 0,
+                initial_messages: None,
+                network_proxy: None,
+                rollout_path: Some(PathBuf::new()),
+            }),
+        };
+        app.chat_widget
+            .handle_codex_event(session_configured.clone());
         app.chat_widget
             .set_reasoning_effort(Some(ReasoningEffortConfig::High));
         app.chat_widget
@@ -6305,7 +5888,7 @@ mod tests {
         let (chat_widget, _app_event_tx, _rx, _new_op_rx) =
             make_chatwidget_manual_with_sender().await;
         app.chat_widget = chat_widget;
-        app.chat_widget.handle_thread_session(session.clone());
+        app.chat_widget.handle_codex_event(session_configured);
         app.chat_widget
             .set_reasoning_effort(Some(ReasoningEffortConfig::Low));
         app.chat_widget
@@ -6319,8 +5902,7 @@ mod tests {
 
         app.replay_thread_snapshot(
             ThreadEventSnapshot {
-                session: None,
-                turns: Vec::new(),
+                session_configured: None,
                 events: vec![],
                 input_state: Some(input_state),
             },
@@ -6342,14 +5924,43 @@ mod tests {
     async fn replayed_interrupted_turn_restores_queued_input_to_composer() {
         let (mut app, _app_event_rx, _op_rx) = make_test_app_with_channels().await;
         let thread_id = ThreadId::new();
-        let session = test_thread_session(thread_id, PathBuf::from("/tmp/project"));
-        app.chat_widget.handle_thread_session(session.clone());
+        let session_configured = Event {
+            id: "session-configured".to_string(),
+            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
+                session_id: thread_id,
+                forked_from_id: None,
+                thread_name: None,
+                model: "gpt-test".to_string(),
+                model_provider_id: "test-provider".to_string(),
+                service_tier: None,
+                approval_policy: AskForApproval::Never,
+                approvals_reviewer: ApprovalsReviewer::User,
+                sandbox_policy: SandboxPolicy::new_read_only_policy(),
+                cwd: PathBuf::from("/tmp/project"),
+                reasoning_effort: None,
+                history_log_id: 0,
+                history_entry_count: 0,
+                initial_messages: None,
+                network_proxy: None,
+                rollout_path: Some(PathBuf::new()),
+            }),
+        };
         app.chat_widget
-            .handle_server_notification(turn_started_notification(thread_id, "turn-1"), None);
-        app.chat_widget.handle_server_notification(
-            agent_message_delta_notification(thread_id, "turn-1", "agent-1", "streaming"),
-            None,
-        );
+            .handle_codex_event(session_configured.clone());
+        app.chat_widget.handle_codex_event(Event {
+            id: "turn-started".to_string(),
+            msg: EventMsg::TurnStarted(TurnStartedEvent {
+                turn_id: "turn-1".to_string(),
+                model_context_window: None,
+                collaboration_mode_kind: Default::default(),
+            }),
+        });
+        app.chat_widget.handle_codex_event(Event {
+            id: "agent-delta".to_string(),
+            msg: EventMsg::AgentMessageDelta(AgentMessageDeltaEvent {
+                delta: "streaming".to_string(),
+            }),
+        });
         app.chat_widget
             .apply_external_edit("queued follow-up".to_string());
         app.chat_widget
@@ -6362,16 +5973,19 @@ mod tests {
         let (chat_widget, _app_event_tx, _rx, mut new_op_rx) =
             make_chatwidget_manual_with_sender().await;
         app.chat_widget = chat_widget;
-        app.chat_widget.handle_thread_session(session.clone());
+        app.chat_widget.handle_codex_event(session_configured);
         while new_op_rx.try_recv().is_ok() {}
 
         app.replay_thread_snapshot(
             ThreadEventSnapshot {
-                session: None,
-                turns: Vec::new(),
-                events: vec![ThreadBufferedEvent::Notification(
-                    turn_completed_notification(thread_id, "turn-1", TurnStatus::Interrupted),
-                )],
+                session_configured: None,
+                events: vec![Event {
+                    id: "turn-aborted".to_string(),
+                    msg: EventMsg::TurnAborted(TurnAbortedEvent {
+                        turn_id: Some("turn-1".to_string()),
+                        reason: TurnAbortReason::ReviewEnded,
+                    }),
+                }],
                 input_state: Some(input_state),
             },
             true,
@@ -6389,18 +6003,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn token_usage_update_refreshes_status_line_with_runtime_context_window() {
+    async fn live_turn_started_refreshes_status_line_with_runtime_context_window() {
         let mut app = make_test_app().await;
         app.chat_widget
             .setup_status_line(vec![crate::bottom_pane::StatusLineItem::ContextWindowSize]);
 
         assert_eq!(app.chat_widget.status_line_text(), None);
 
-        app.handle_thread_event_now(ThreadBufferedEvent::Notification(token_usage_notification(
-            ThreadId::new(),
-            "turn-1",
-            Some(950_000),
-        )));
+        app.handle_codex_event_now(Event {
+            id: "turn-started".to_string(),
+            msg: EventMsg::TurnStarted(TurnStartedEvent {
+                turn_id: "turn-1".to_string(),
+                model_context_window: Some(950_000),
+                collaboration_mode_kind: Default::default(),
+            }),
+        });
 
         assert_eq!(
             app.chat_widget.status_line_text(),
@@ -7048,12 +6665,26 @@ guardian_approval = true
         let agent_channel = ThreadEventChannel::new(1);
         {
             let mut store = agent_channel.store.lock().await;
-            store.push_request(exec_approval_request(
-                agent_thread_id,
-                "turn-1",
-                "call-1",
-                None,
-            ));
+            store.push_event(Event {
+                id: "ev-1".to_string(),
+                msg: EventMsg::ExecApprovalRequest(
+                    codex_protocol::protocol::ExecApprovalRequestEvent {
+                        call_id: "call-1".to_string(),
+                        approval_id: None,
+                        turn_id: "turn-1".to_string(),
+                        command: vec!["echo".to_string(), "hi".to_string()],
+                        cwd: PathBuf::from("/tmp"),
+                        reason: None,
+                        network_approval_context: None,
+                        proposed_execpolicy_amendment: None,
+                        proposed_network_policy_amendments: None,
+                        additional_permissions: None,
+                        skill_metadata: None,
+                        available_decisions: None,
+                        parsed_cmd: Vec::new(),
+                    },
+                ),
+            });
         }
         app.thread_event_channels
             .insert(agent_thread_id, agent_channel);
@@ -7089,15 +6720,29 @@ guardian_approval = true
             .insert(main_thread_id, ThreadEventChannel::new(1));
         app.thread_event_channels.insert(
             agent_thread_id,
-            ThreadEventChannel::new_with_session(
+            ThreadEventChannel::new_with_session_configured(
                 1,
-                ThreadSessionState {
-                    approval_policy: AskForApproval::OnRequest,
-                    sandbox_policy: SandboxPolicy::new_workspace_write_policy(),
-                    rollout_path: Some(PathBuf::from("/tmp/agent-rollout.jsonl")),
-                    ..test_thread_session(agent_thread_id, PathBuf::from("/tmp/agent"))
+                Event {
+                    id: String::new(),
+                    msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
+                        session_id: agent_thread_id,
+                        forked_from_id: None,
+                        thread_name: None,
+                        model: "gpt-5".to_string(),
+                        model_provider_id: "test-provider".to_string(),
+                        service_tier: None,
+                        approval_policy: AskForApproval::OnRequest,
+                        approvals_reviewer: ApprovalsReviewer::User,
+                        sandbox_policy: SandboxPolicy::new_workspace_write_policy(),
+                        cwd: PathBuf::from("/tmp/agent"),
+                        reasoning_effort: None,
+                        history_log_id: 0,
+                        history_entry_count: 0,
+                        initial_messages: None,
+                        network_proxy: None,
+                        rollout_path: Some(PathBuf::from("/tmp/agent-rollout.jsonl")),
+                    }),
                 },
-                Vec::new(),
             ),
         );
         app.agent_navigation.upsert(
@@ -7107,9 +6752,28 @@ guardian_approval = true
             false,
         );
 
-        app.enqueue_thread_request(
+        app.enqueue_thread_event(
             agent_thread_id,
-            exec_approval_request(agent_thread_id, "turn-approval", "call-approval", None),
+            Event {
+                id: "ev-approval".to_string(),
+                msg: EventMsg::ExecApprovalRequest(
+                    codex_protocol::protocol::ExecApprovalRequestEvent {
+                        call_id: "call-approval".to_string(),
+                        approval_id: None,
+                        turn_id: "turn-approval".to_string(),
+                        command: vec!["echo".to_string(), "hi".to_string()],
+                        cwd: PathBuf::from("/tmp/agent"),
+                        reason: Some("need approval".to_string()),
+                        network_approval_context: None,
+                        proposed_execpolicy_amendment: None,
+                        proposed_network_policy_amendments: None,
+                        additional_permissions: None,
+                        skill_metadata: None,
+                        available_decisions: None,
+                        parsed_cmd: Vec::new(),
+                    },
+                ),
+            },
         )
         .await?;
 
@@ -7118,379 +6782,6 @@ guardian_approval = true
             app.chat_widget.pending_thread_approvals(),
             &["Robie [explorer]".to_string()]
         );
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn inactive_thread_exec_approval_preserves_context() {
-        let app = make_test_app().await;
-        let thread_id = ThreadId::new();
-        let mut request = exec_approval_request(thread_id, "turn-approval", "call-approval", None);
-        let ServerRequest::CommandExecutionRequestApproval { params, .. } = &mut request else {
-            panic!("expected exec approval request");
-        };
-        params.network_approval_context = Some(AppServerNetworkApprovalContext {
-            host: "example.com".to_string(),
-            protocol: AppServerNetworkApprovalProtocol::Https,
-        });
-        params.additional_permissions = Some(AdditionalPermissionProfile {
-            network: Some(AdditionalNetworkPermissions {
-                enabled: Some(true),
-            }),
-            file_system: None,
-            macos: None,
-        });
-        params.proposed_network_policy_amendments = Some(vec![AppServerNetworkPolicyAmendment {
-            host: "example.com".to_string(),
-            action: AppServerNetworkPolicyRuleAction::Allow,
-        }]);
-
-        let Some(ThreadInteractiveRequest::Approval(ApprovalRequest::Exec {
-            available_decisions,
-            network_approval_context,
-            additional_permissions,
-            ..
-        })) = app
-            .interactive_request_for_thread_request(thread_id, &request)
-            .await
-        else {
-            panic!("expected exec approval request");
-        };
-
-        assert_eq!(
-            network_approval_context,
-            Some(NetworkApprovalContext {
-                host: "example.com".to_string(),
-                protocol: NetworkApprovalProtocol::Https,
-            })
-        );
-        assert_eq!(
-            additional_permissions,
-            Some(PermissionProfile {
-                network: Some(NetworkPermissions {
-                    enabled: Some(true),
-                }),
-                file_system: None,
-                macos: None,
-            })
-        );
-        assert_eq!(
-            available_decisions,
-            vec![
-                codex_protocol::protocol::ReviewDecision::Approved,
-                codex_protocol::protocol::ReviewDecision::ApprovedForSession,
-                codex_protocol::protocol::ReviewDecision::NetworkPolicyAmendment {
-                    network_policy_amendment: codex_protocol::approvals::NetworkPolicyAmendment {
-                        host: "example.com".to_string(),
-                        action: codex_protocol::approvals::NetworkPolicyRuleAction::Allow,
-                    },
-                },
-                codex_protocol::protocol::ReviewDecision::Abort,
-            ]
-        );
-    }
-
-    #[tokio::test]
-    async fn inactive_thread_approval_badge_clears_after_turn_completion_notification() -> Result<()>
-    {
-        let mut app = make_test_app().await;
-        let main_thread_id =
-            ThreadId::from_string("00000000-0000-0000-0000-000000000101").expect("valid thread");
-        let agent_thread_id =
-            ThreadId::from_string("00000000-0000-0000-0000-000000000202").expect("valid thread");
-
-        app.primary_thread_id = Some(main_thread_id);
-        app.active_thread_id = Some(main_thread_id);
-        app.thread_event_channels
-            .insert(main_thread_id, ThreadEventChannel::new(1));
-        app.thread_event_channels.insert(
-            agent_thread_id,
-            ThreadEventChannel::new_with_session(
-                4,
-                ThreadSessionState {
-                    approval_policy: AskForApproval::OnRequest,
-                    sandbox_policy: SandboxPolicy::new_workspace_write_policy(),
-                    rollout_path: Some(PathBuf::from("/tmp/agent-rollout.jsonl")),
-                    ..test_thread_session(agent_thread_id, PathBuf::from("/tmp/agent"))
-                },
-                Vec::new(),
-            ),
-        );
-        app.agent_navigation.upsert(
-            agent_thread_id,
-            Some("Robie".to_string()),
-            Some("explorer".to_string()),
-            false,
-        );
-
-        app.enqueue_thread_request(
-            agent_thread_id,
-            exec_approval_request(agent_thread_id, "turn-approval", "call-approval", None),
-        )
-        .await?;
-        assert_eq!(
-            app.chat_widget.pending_thread_approvals(),
-            &["Robie [explorer]".to_string()]
-        );
-
-        app.enqueue_thread_notification(
-            agent_thread_id,
-            turn_completed_notification(agent_thread_id, "turn-approval", TurnStatus::Completed),
-        )
-        .await?;
-
-        assert!(
-            app.chat_widget.pending_thread_approvals().is_empty(),
-            "turn completion should clear inactive-thread approval badge immediately"
-        );
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn legacy_warning_eviction_clears_pending_interactive_replay_state() -> Result<()> {
-        let mut app = make_test_app().await;
-        let thread_id = ThreadId::new();
-        let channel = ThreadEventChannel::new(1);
-        {
-            let mut store = channel.store.lock().await;
-            store.push_request(exec_approval_request(
-                thread_id,
-                "turn-approval",
-                "call-approval",
-                None,
-            ));
-            assert_eq!(store.has_pending_thread_approvals(), true);
-        }
-        app.thread_event_channels.insert(thread_id, channel);
-
-        app.enqueue_thread_legacy_warning(thread_id, "legacy warning".to_string())
-            .await?;
-
-        let store = app
-            .thread_event_channels
-            .get(&thread_id)
-            .expect("thread store should exist")
-            .store
-            .lock()
-            .await;
-        assert_eq!(store.has_pending_thread_approvals(), false);
-        let snapshot = store.snapshot();
-        assert_eq!(snapshot.events.len(), 1);
-        assert!(matches!(
-            snapshot.events.first(),
-            Some(ThreadBufferedEvent::LegacyWarning(message)) if message == "legacy warning"
-        ));
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn legacy_thread_rollback_trims_inactive_thread_snapshot_state() -> Result<()> {
-        let mut app = make_test_app().await;
-        let thread_id = ThreadId::new();
-        let session = test_thread_session(thread_id, PathBuf::from("/tmp/project"));
-        let turns = vec![
-            test_turn("turn-1", TurnStatus::Completed, Vec::new()),
-            test_turn("turn-2", TurnStatus::Completed, Vec::new()),
-        ];
-        let channel = ThreadEventChannel::new_with_session(4, session, turns);
-        {
-            let mut store = channel.store.lock().await;
-            store.push_request(exec_approval_request(
-                thread_id,
-                "turn-approval",
-                "call-approval",
-                None,
-            ));
-            assert_eq!(store.has_pending_thread_approvals(), true);
-        }
-        app.thread_event_channels.insert(thread_id, channel);
-
-        app.enqueue_thread_legacy_rollback(thread_id, 1).await?;
-
-        let store = app
-            .thread_event_channels
-            .get(&thread_id)
-            .expect("thread store should exist")
-            .store
-            .lock()
-            .await;
-        assert_eq!(
-            store.turns,
-            vec![test_turn("turn-1", TurnStatus::Completed, Vec::new())]
-        );
-        assert_eq!(store.has_pending_thread_approvals(), false);
-        let snapshot = store.snapshot();
-        assert_eq!(snapshot.turns, store.turns);
-        assert!(snapshot.events.is_empty());
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn inactive_thread_started_notification_initializes_replay_session() -> Result<()> {
-        let mut app = make_test_app().await;
-        let temp_dir = tempdir()?;
-        let main_thread_id =
-            ThreadId::from_string("00000000-0000-0000-0000-000000000101").expect("valid thread");
-        let agent_thread_id =
-            ThreadId::from_string("00000000-0000-0000-0000-000000000202").expect("valid thread");
-        let primary_session = ThreadSessionState {
-            approval_policy: AskForApproval::OnRequest,
-            sandbox_policy: SandboxPolicy::new_workspace_write_policy(),
-            ..test_thread_session(main_thread_id, PathBuf::from("/tmp/main"))
-        };
-
-        app.primary_thread_id = Some(main_thread_id);
-        app.active_thread_id = Some(main_thread_id);
-        app.primary_session_configured = Some(primary_session.clone());
-        app.thread_event_channels.insert(
-            main_thread_id,
-            ThreadEventChannel::new_with_session(4, primary_session.clone(), Vec::new()),
-        );
-
-        let rollout_path = temp_dir.path().join("agent-rollout.jsonl");
-        let turn_context = TurnContextItem {
-            turn_id: None,
-            trace_id: None,
-            cwd: PathBuf::from("/tmp/agent"),
-            current_date: None,
-            timezone: None,
-            approval_policy: primary_session.approval_policy,
-            sandbox_policy: primary_session.sandbox_policy.clone(),
-            network: None,
-            model: "gpt-agent".to_string(),
-            personality: None,
-            collaboration_mode: None,
-            realtime_active: Some(false),
-            effort: primary_session.reasoning_effort,
-            summary: app.config.model_reasoning_summary.unwrap_or_default(),
-            user_instructions: None,
-            developer_instructions: None,
-            final_output_json_schema: None,
-            truncation_policy: None,
-        };
-        let rollout = RolloutLine {
-            timestamp: "t0".to_string(),
-            item: RolloutItem::TurnContext(turn_context),
-        };
-        std::fs::write(
-            &rollout_path,
-            format!("{}\n", serde_json::to_string(&rollout)?),
-        )?;
-        app.enqueue_thread_notification(
-            agent_thread_id,
-            ServerNotification::ThreadStarted(ThreadStartedNotification {
-                thread: Thread {
-                    id: agent_thread_id.to_string(),
-                    preview: "agent thread".to_string(),
-                    ephemeral: false,
-                    model_provider: "agent-provider".to_string(),
-                    created_at: 1,
-                    updated_at: 2,
-                    status: codex_app_server_protocol::ThreadStatus::Idle,
-                    path: Some(rollout_path.clone()),
-                    cwd: PathBuf::from("/tmp/agent"),
-                    cli_version: "0.0.0".to_string(),
-                    source: codex_app_server_protocol::SessionSource::Unknown,
-                    agent_nickname: Some("Robie".to_string()),
-                    agent_role: Some("explorer".to_string()),
-                    git_info: None,
-                    name: Some("agent thread".to_string()),
-                    turns: Vec::new(),
-                },
-            }),
-        )
-        .await?;
-
-        let store = app
-            .thread_event_channels
-            .get(&agent_thread_id)
-            .expect("agent thread channel")
-            .store
-            .lock()
-            .await;
-        let session = store.session.clone().expect("inferred session");
-        drop(store);
-
-        assert_eq!(session.thread_id, agent_thread_id);
-        assert_eq!(session.thread_name, Some("agent thread".to_string()));
-        assert_eq!(session.model, "gpt-agent");
-        assert_eq!(session.model_provider_id, "agent-provider");
-        assert_eq!(session.approval_policy, primary_session.approval_policy);
-        assert_eq!(session.cwd, PathBuf::from("/tmp/agent"));
-        assert_eq!(session.rollout_path, Some(rollout_path));
-        assert_eq!(
-            app.agent_navigation.get(&agent_thread_id),
-            Some(&AgentPickerThreadEntry {
-                agent_nickname: Some("Robie".to_string()),
-                agent_role: Some("explorer".to_string()),
-                is_closed: false,
-            })
-        );
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn inactive_thread_started_notification_preserves_primary_model_when_path_missing()
-    -> Result<()> {
-        let mut app = make_test_app().await;
-        let main_thread_id =
-            ThreadId::from_string("00000000-0000-0000-0000-000000000301").expect("valid thread");
-        let agent_thread_id =
-            ThreadId::from_string("00000000-0000-0000-0000-000000000302").expect("valid thread");
-        let primary_session = ThreadSessionState {
-            approval_policy: AskForApproval::OnRequest,
-            sandbox_policy: SandboxPolicy::new_workspace_write_policy(),
-            ..test_thread_session(main_thread_id, PathBuf::from("/tmp/main"))
-        };
-
-        app.primary_thread_id = Some(main_thread_id);
-        app.active_thread_id = Some(main_thread_id);
-        app.primary_session_configured = Some(primary_session.clone());
-        app.thread_event_channels.insert(
-            main_thread_id,
-            ThreadEventChannel::new_with_session(4, primary_session.clone(), Vec::new()),
-        );
-
-        app.enqueue_thread_notification(
-            agent_thread_id,
-            ServerNotification::ThreadStarted(ThreadStartedNotification {
-                thread: Thread {
-                    id: agent_thread_id.to_string(),
-                    preview: "agent thread".to_string(),
-                    ephemeral: false,
-                    model_provider: "agent-provider".to_string(),
-                    created_at: 1,
-                    updated_at: 2,
-                    status: codex_app_server_protocol::ThreadStatus::Idle,
-                    path: None,
-                    cwd: PathBuf::from("/tmp/agent"),
-                    cli_version: "0.0.0".to_string(),
-                    source: codex_app_server_protocol::SessionSource::Unknown,
-                    agent_nickname: Some("Robie".to_string()),
-                    agent_role: Some("explorer".to_string()),
-                    git_info: None,
-                    name: Some("agent thread".to_string()),
-                    turns: Vec::new(),
-                },
-            }),
-        )
-        .await?;
-
-        let store = app
-            .thread_event_channels
-            .get(&agent_thread_id)
-            .expect("agent thread channel")
-            .store
-            .lock()
-            .await;
-        let session = store.session.clone().expect("inferred session");
-
-        assert_eq!(session.model, primary_session.model);
 
         Ok(())
     }
@@ -7538,9 +6829,7 @@ guardian_approval = true
         app.primary_thread_id = Some(ThreadId::new());
 
         assert_eq!(
-            app.active_non_primary_shutdown_target(&ServerNotification::SkillsChanged(
-                codex_app_server_protocol::SkillsChangedNotification {},
-            )),
+            app.active_non_primary_shutdown_target(&EventMsg::SkillsUpdateAvailable),
             None
         );
         Ok(())
@@ -7555,7 +6844,7 @@ guardian_approval = true
         app.primary_thread_id = Some(thread_id);
 
         assert_eq!(
-            app.active_non_primary_shutdown_target(&thread_closed_notification(thread_id)),
+            app.active_non_primary_shutdown_target(&EventMsg::ShutdownComplete),
             None
         );
         Ok(())
@@ -7571,7 +6860,7 @@ guardian_approval = true
         app.primary_thread_id = Some(primary_thread_id);
 
         assert_eq!(
-            app.active_non_primary_shutdown_target(&thread_closed_notification(active_thread_id)),
+            app.active_non_primary_shutdown_target(&EventMsg::ShutdownComplete),
             Some((active_thread_id, primary_thread_id))
         );
         Ok(())
@@ -7588,7 +6877,7 @@ guardian_approval = true
         app.pending_shutdown_exit_thread_id = Some(active_thread_id);
 
         assert_eq!(
-            app.active_non_primary_shutdown_target(&thread_closed_notification(active_thread_id)),
+            app.active_non_primary_shutdown_target(&EventMsg::ShutdownComplete),
             None
         );
         Ok(())
@@ -7605,7 +6894,7 @@ guardian_approval = true
         app.pending_shutdown_exit_thread_id = Some(ThreadId::new());
 
         assert_eq!(
-            app.active_non_primary_shutdown_target(&thread_closed_notification(active_thread_id)),
+            app.active_non_primary_shutdown_target(&EventMsg::ShutdownComplete),
             Some((active_thread_id, primary_thread_id))
         );
         Ok(())
@@ -7793,6 +7082,7 @@ guardian_approval = true
             feedback_audience: FeedbackAudience::External,
             remote_app_server_url: None,
             pending_update_action: None,
+            suppress_shutdown_complete: false,
             pending_shutdown_exit_thread_id: None,
             windows_sandbox: WindowsSandboxState::default(),
             thread_event_channels: HashMap::new(),
@@ -7844,6 +7134,7 @@ guardian_approval = true
                 feedback_audience: FeedbackAudience::External,
                 remote_app_server_url: None,
                 pending_update_action: None,
+                suppress_shutdown_complete: false,
                 pending_shutdown_exit_thread_id: None,
                 windows_sandbox: WindowsSandboxState::default(),
                 thread_event_channels: HashMap::new(),
@@ -7861,126 +7152,390 @@ guardian_approval = true
         )
     }
 
-    fn test_thread_session(thread_id: ThreadId, cwd: PathBuf) -> ThreadSessionState {
-        ThreadSessionState {
-            thread_id,
-            forked_from_id: None,
-            thread_name: None,
-            model: "gpt-test".to_string(),
-            model_provider_id: "test-provider".to_string(),
-            service_tier: None,
-            approval_policy: AskForApproval::Never,
-            approvals_reviewer: ApprovalsReviewer::User,
-            sandbox_policy: SandboxPolicy::new_read_only_policy(),
-            cwd,
-            reasoning_effort: None,
-            history_log_id: 0,
-            history_entry_count: 0,
-            network_proxy: None,
-            rollout_path: Some(PathBuf::new()),
-        }
-    }
+    #[tokio::test]
+    async fn restore_started_app_server_thread_replays_remote_history() -> Result<()> {
+        let (mut app, mut app_event_rx, _op_rx) = make_test_app_with_channels().await;
+        let thread_id = ThreadId::new();
 
-    fn test_turn(turn_id: &str, status: TurnStatus, items: Vec<ThreadItem>) -> Turn {
-        Turn {
-            id: turn_id.to_string(),
-            items,
-            status,
-            error: None,
-        }
-    }
-
-    fn turn_started_notification(thread_id: ThreadId, turn_id: &str) -> ServerNotification {
-        ServerNotification::TurnStarted(TurnStartedNotification {
-            thread_id: thread_id.to_string(),
-            turn: test_turn(turn_id, TurnStatus::InProgress, Vec::new()),
-        })
-    }
-
-    fn turn_completed_notification(
-        thread_id: ThreadId,
-        turn_id: &str,
-        status: TurnStatus,
-    ) -> ServerNotification {
-        ServerNotification::TurnCompleted(TurnCompletedNotification {
-            thread_id: thread_id.to_string(),
-            turn: test_turn(turn_id, status, Vec::new()),
-        })
-    }
-
-    fn thread_closed_notification(thread_id: ThreadId) -> ServerNotification {
-        ServerNotification::ThreadClosed(ThreadClosedNotification {
-            thread_id: thread_id.to_string(),
-        })
-    }
-
-    fn token_usage_notification(
-        thread_id: ThreadId,
-        turn_id: &str,
-        model_context_window: Option<i64>,
-    ) -> ServerNotification {
-        ServerNotification::ThreadTokenUsageUpdated(ThreadTokenUsageUpdatedNotification {
-            thread_id: thread_id.to_string(),
-            turn_id: turn_id.to_string(),
-            token_usage: ThreadTokenUsage {
-                total: TokenUsageBreakdown {
-                    total_tokens: 10,
-                    input_tokens: 4,
-                    cached_input_tokens: 1,
-                    output_tokens: 5,
-                    reasoning_output_tokens: 0,
-                },
-                last: TokenUsageBreakdown {
-                    total_tokens: 10,
-                    input_tokens: 4,
-                    cached_input_tokens: 1,
-                    output_tokens: 5,
-                    reasoning_output_tokens: 0,
-                },
-                model_context_window,
+        app.restore_started_app_server_thread(AppServerStartedThread {
+            thread: Thread {
+                id: thread_id.to_string(),
+                preview: "hello".to_string(),
+                ephemeral: false,
+                model_provider: "test-provider".to_string(),
+                created_at: 0,
+                updated_at: 0,
+                status: ThreadStatus::Idle,
+                path: None,
+                cwd: PathBuf::from("/tmp/project"),
+                cli_version: "test".to_string(),
+                source: SessionSource::Cli.into(),
+                agent_nickname: None,
+                agent_role: None,
+                git_info: None,
+                name: Some("restored".to_string()),
+                turns: vec![Turn {
+                    id: "turn-1".to_string(),
+                    items: vec![
+                        ThreadItem::UserMessage {
+                            id: "user-1".to_string(),
+                            content: vec![codex_app_server_protocol::UserInput::Text {
+                                text: "hello from remote".to_string(),
+                                text_elements: Vec::new(),
+                            }],
+                        },
+                        ThreadItem::AgentMessage {
+                            id: "assistant-1".to_string(),
+                            text: "restored response".to_string(),
+                            phase: None,
+                        },
+                    ],
+                    status: TurnStatus::Completed,
+                    error: None,
+                }],
             },
-        })
-    }
-
-    fn agent_message_delta_notification(
-        thread_id: ThreadId,
-        turn_id: &str,
-        item_id: &str,
-        delta: &str,
-    ) -> ServerNotification {
-        ServerNotification::AgentMessageDelta(AgentMessageDeltaNotification {
-            thread_id: thread_id.to_string(),
-            turn_id: turn_id.to_string(),
-            item_id: item_id.to_string(),
-            delta: delta.to_string(),
-        })
-    }
-
-    fn exec_approval_request(
-        thread_id: ThreadId,
-        turn_id: &str,
-        item_id: &str,
-        approval_id: Option<&str>,
-    ) -> ServerRequest {
-        ServerRequest::CommandExecutionRequestApproval {
-            request_id: AppServerRequestId::Integer(1),
-            params: CommandExecutionRequestApprovalParams {
-                thread_id: thread_id.to_string(),
-                turn_id: turn_id.to_string(),
-                item_id: item_id.to_string(),
-                approval_id: approval_id.map(str::to_string),
-                reason: Some("needs approval".to_string()),
-                network_approval_context: None,
-                command: Some("echo hello".to_string()),
-                cwd: Some(PathBuf::from("/tmp/project")),
-                command_actions: None,
-                additional_permissions: None,
-                skill_metadata: None,
-                proposed_execpolicy_amendment: None,
-                proposed_network_policy_amendments: None,
-                available_decisions: None,
+            session_configured: SessionConfiguredEvent {
+                session_id: thread_id,
+                forked_from_id: None,
+                thread_name: Some("restored".to_string()),
+                model: "gpt-test".to_string(),
+                model_provider_id: "test-provider".to_string(),
+                service_tier: None,
+                approval_policy: AskForApproval::Never,
+                approvals_reviewer: ApprovalsReviewer::User,
+                sandbox_policy: SandboxPolicy::new_read_only_policy(),
+                cwd: PathBuf::from("/tmp/project"),
+                reasoning_effort: None,
+                history_log_id: 0,
+                history_entry_count: 0,
+                initial_messages: None,
+                network_proxy: None,
+                rollout_path: Some(PathBuf::new()),
             },
+            show_raw_agent_reasoning: false,
+        })
+        .await?;
+
+        while let Ok(event) = app_event_rx.try_recv() {
+            if let AppEvent::InsertHistoryCell(cell) = event {
+                let cell: Arc<dyn HistoryCell> = cell.into();
+                app.transcript_cells.push(cell);
+            }
         }
+
+        assert_eq!(app.primary_thread_id, Some(thread_id));
+        assert_eq!(app.active_thread_id, Some(thread_id));
+
+        let user_messages: Vec<String> = app
+            .transcript_cells
+            .iter()
+            .filter_map(|cell| {
+                cell.as_any()
+                    .downcast_ref::<UserHistoryCell>()
+                    .map(|cell| cell.message.clone())
+            })
+            .collect();
+        let agent_messages: Vec<String> = app
+            .transcript_cells
+            .iter()
+            .filter_map(|cell| {
+                cell.as_any()
+                    .downcast_ref::<AgentMessageCell>()
+                    .map(|cell| {
+                        cell.display_lines(80)
+                            .into_iter()
+                            .map(|line| line.to_string())
+                            .collect::<Vec<_>>()
+                            .join("\n")
+                    })
+            })
+            .collect();
+
+        assert_eq!(user_messages, vec!["hello from remote".to_string()]);
+        assert_eq!(agent_messages, vec!["• restored response".to_string()]);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn restore_started_app_server_thread_submits_initial_prompt_after_history_replay()
+    -> Result<()> {
+        let (mut app, mut app_event_rx, mut op_rx) = make_test_app_with_channels().await;
+        let thread_id = ThreadId::new();
+        app.chat_widget.set_initial_user_message_for_test(
+            crate::chatwidget::create_initial_user_message(
+                Some("resume prompt".to_string()),
+                Vec::new(),
+                Vec::new(),
+            ),
+        );
+
+        app.restore_started_app_server_thread(AppServerStartedThread {
+            thread: Thread {
+                id: thread_id.to_string(),
+                preview: "hello".to_string(),
+                ephemeral: false,
+                model_provider: "test-provider".to_string(),
+                created_at: 0,
+                updated_at: 0,
+                status: ThreadStatus::Idle,
+                path: None,
+                cwd: PathBuf::from("/tmp/project"),
+                cli_version: "test".to_string(),
+                source: SessionSource::Cli.into(),
+                agent_nickname: None,
+                agent_role: None,
+                git_info: None,
+                name: Some("restored".to_string()),
+                turns: vec![Turn {
+                    id: "turn-1".to_string(),
+                    items: vec![
+                        ThreadItem::UserMessage {
+                            id: "user-1".to_string(),
+                            content: vec![codex_app_server_protocol::UserInput::Text {
+                                text: "hello from remote".to_string(),
+                                text_elements: Vec::new(),
+                            }],
+                        },
+                        ThreadItem::AgentMessage {
+                            id: "assistant-1".to_string(),
+                            text: "restored response".to_string(),
+                            phase: None,
+                        },
+                    ],
+                    status: TurnStatus::Completed,
+                    error: None,
+                }],
+            },
+            session_configured: SessionConfiguredEvent {
+                session_id: thread_id,
+                forked_from_id: None,
+                thread_name: Some("restored".to_string()),
+                model: "gpt-test".to_string(),
+                model_provider_id: "test-provider".to_string(),
+                service_tier: None,
+                approval_policy: AskForApproval::Never,
+                approvals_reviewer: ApprovalsReviewer::User,
+                sandbox_policy: SandboxPolicy::new_read_only_policy(),
+                cwd: PathBuf::from("/tmp/project"),
+                reasoning_effort: None,
+                history_log_id: 0,
+                history_entry_count: 0,
+                initial_messages: None,
+                network_proxy: None,
+                rollout_path: Some(PathBuf::new()),
+            },
+            show_raw_agent_reasoning: false,
+        })
+        .await?;
+
+        while let Ok(event) = app_event_rx.try_recv() {
+            if let AppEvent::InsertHistoryCell(cell) = event {
+                let cell: Arc<dyn HistoryCell> = cell.into();
+                app.transcript_cells.push(cell);
+            }
+        }
+
+        let user_messages: Vec<String> = app
+            .transcript_cells
+            .iter()
+            .filter_map(|cell| {
+                cell.as_any()
+                    .downcast_ref::<UserHistoryCell>()
+                    .map(|cell| cell.message.clone())
+            })
+            .collect();
+
+        assert_eq!(
+            user_messages,
+            vec!["hello from remote".to_string(), "resume prompt".to_string()]
+        );
+        match next_user_turn_op(&mut op_rx) {
+            Op::UserTurn { items, .. } => assert_eq!(
+                items,
+                vec![UserInput::Text {
+                    text: "resume prompt".to_string(),
+                    text_elements: Vec::new(),
+                }]
+            ),
+            other => panic!("expected resume prompt submission, got {other:?}"),
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn restore_started_app_server_thread_replays_history_beyond_store_capacity() -> Result<()>
+    {
+        let (mut app, mut app_event_rx, _op_rx) = make_test_app_with_channels().await;
+        let thread_id = ThreadId::new();
+        let turn_count = THREAD_EVENT_CHANNEL_CAPACITY + 5;
+
+        let turns = (0..turn_count)
+            .map(|index| Turn {
+                id: format!("turn-{index}"),
+                items: vec![ThreadItem::UserMessage {
+                    id: format!("user-{index}"),
+                    content: vec![codex_app_server_protocol::UserInput::Text {
+                        text: format!("message {index}"),
+                        text_elements: Vec::new(),
+                    }],
+                }],
+                status: TurnStatus::Completed,
+                error: None,
+            })
+            .collect();
+
+        app.restore_started_app_server_thread(AppServerStartedThread {
+            thread: Thread {
+                id: thread_id.to_string(),
+                preview: "hello".to_string(),
+                ephemeral: false,
+                model_provider: "test-provider".to_string(),
+                created_at: 0,
+                updated_at: 0,
+                status: ThreadStatus::Idle,
+                path: None,
+                cwd: PathBuf::from("/tmp/project"),
+                cli_version: "test".to_string(),
+                source: SessionSource::Cli.into(),
+                agent_nickname: None,
+                agent_role: None,
+                git_info: None,
+                name: Some("restored".to_string()),
+                turns,
+            },
+            session_configured: SessionConfiguredEvent {
+                session_id: thread_id,
+                forked_from_id: None,
+                thread_name: Some("restored".to_string()),
+                model: "gpt-test".to_string(),
+                model_provider_id: "test-provider".to_string(),
+                service_tier: None,
+                approval_policy: AskForApproval::Never,
+                approvals_reviewer: ApprovalsReviewer::User,
+                sandbox_policy: SandboxPolicy::new_read_only_policy(),
+                cwd: PathBuf::from("/tmp/project"),
+                reasoning_effort: None,
+                history_log_id: 0,
+                history_entry_count: 0,
+                initial_messages: None,
+                network_proxy: None,
+                rollout_path: Some(PathBuf::new()),
+            },
+            show_raw_agent_reasoning: false,
+        })
+        .await?;
+
+        while let Ok(event) = app_event_rx.try_recv() {
+            if let AppEvent::InsertHistoryCell(cell) = event {
+                let cell: Arc<dyn HistoryCell> = cell.into();
+                app.transcript_cells.push(cell);
+            }
+        }
+
+        let user_messages: Vec<String> = app
+            .transcript_cells
+            .iter()
+            .filter_map(|cell| {
+                cell.as_any()
+                    .downcast_ref::<UserHistoryCell>()
+                    .map(|cell| cell.message.clone())
+            })
+            .collect();
+
+        assert_eq!(user_messages.len(), turn_count);
+        assert_eq!(user_messages.first().map(String::as_str), Some("message 0"));
+        let last_message = format!("message {}", turn_count - 1);
+        assert_eq!(
+            user_messages.last().map(String::as_str),
+            Some(last_message.as_str())
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn restore_started_app_server_thread_replays_raw_reasoning_when_enabled() -> Result<()> {
+        let (mut app, mut app_event_rx, _op_rx) = make_test_app_with_channels().await;
+        let thread_id = ThreadId::new();
+
+        app.restore_started_app_server_thread(AppServerStartedThread {
+            thread: Thread {
+                id: thread_id.to_string(),
+                preview: "hello".to_string(),
+                ephemeral: false,
+                model_provider: "test-provider".to_string(),
+                created_at: 0,
+                updated_at: 0,
+                status: ThreadStatus::Idle,
+                path: None,
+                cwd: PathBuf::from("/tmp/project"),
+                cli_version: "test".to_string(),
+                source: SessionSource::Cli.into(),
+                agent_nickname: None,
+                agent_role: None,
+                git_info: None,
+                name: Some("restored".to_string()),
+                turns: vec![Turn {
+                    id: "turn-1".to_string(),
+                    items: vec![ThreadItem::Reasoning {
+                        id: "reasoning-1".to_string(),
+                        summary: vec!["summary reasoning".to_string()],
+                        content: vec!["raw reasoning".to_string()],
+                    }],
+                    status: TurnStatus::Completed,
+                    error: None,
+                }],
+            },
+            session_configured: SessionConfiguredEvent {
+                session_id: thread_id,
+                forked_from_id: None,
+                thread_name: Some("restored".to_string()),
+                model: "gpt-test".to_string(),
+                model_provider_id: "test-provider".to_string(),
+                service_tier: None,
+                approval_policy: AskForApproval::Never,
+                approvals_reviewer: ApprovalsReviewer::User,
+                sandbox_policy: SandboxPolicy::new_read_only_policy(),
+                cwd: PathBuf::from("/tmp/project"),
+                reasoning_effort: None,
+                history_log_id: 0,
+                history_entry_count: 0,
+                initial_messages: None,
+                network_proxy: None,
+                rollout_path: Some(PathBuf::new()),
+            },
+            show_raw_agent_reasoning: true,
+        })
+        .await?;
+
+        while let Ok(event) = app_event_rx.try_recv() {
+            if let AppEvent::InsertHistoryCell(cell) = event {
+                let cell: Arc<dyn HistoryCell> = cell.into();
+                app.transcript_cells.push(cell);
+            }
+        }
+
+        let channel = app
+            .thread_event_channels
+            .get(&thread_id)
+            .expect("restored thread channel should exist");
+        let snapshot = channel.store.lock().await.snapshot();
+        let replayed_raw_reasoning = snapshot.events.iter().any(|event| {
+            matches!(
+                &event.msg,
+                EventMsg::AgentReasoningRawContent(raw) if raw.text == "raw reasoning"
+            )
+        });
+
+        assert!(
+            replayed_raw_reasoning,
+            "expected restored snapshot to keep raw reasoning event: {:?}",
+            snapshot.events
+        );
+
+        Ok(())
     }
 
     #[test]
@@ -7988,74 +7543,33 @@ guardian_approval = true
         let mut store = ThreadEventStore::new(8);
         assert_eq!(store.active_turn_id(), None);
 
-        let thread_id = ThreadId::new();
-        store.push_notification(turn_started_notification(thread_id, "turn-1"));
+        store.push_event(Event {
+            id: "turn-started".to_string(),
+            msg: EventMsg::TurnStarted(TurnStartedEvent {
+                turn_id: "turn-1".to_string(),
+                model_context_window: Some(128_000),
+                collaboration_mode_kind: ModeKind::Default,
+            }),
+        });
         assert_eq!(store.active_turn_id(), Some("turn-1"));
 
-        store.push_notification(turn_completed_notification(
-            thread_id,
-            "turn-2",
-            TurnStatus::Completed,
-        ));
+        store.push_event(Event {
+            id: "other-turn-complete".to_string(),
+            msg: EventMsg::TurnComplete(TurnCompleteEvent {
+                turn_id: "turn-2".to_string(),
+                last_agent_message: None,
+            }),
+        });
         assert_eq!(store.active_turn_id(), Some("turn-1"));
 
-        store.push_notification(turn_completed_notification(
-            thread_id,
-            "turn-1",
-            TurnStatus::Interrupted,
-        ));
+        store.push_event(Event {
+            id: "turn-aborted".to_string(),
+            msg: EventMsg::TurnAborted(TurnAbortedEvent {
+                turn_id: Some("turn-1".to_string()),
+                reason: TurnAbortReason::Interrupted,
+            }),
+        });
         assert_eq!(store.active_turn_id(), None);
-    }
-
-    #[test]
-    fn thread_event_store_restores_active_turn_from_snapshot_turns() {
-        let thread_id = ThreadId::new();
-        let session = test_thread_session(thread_id, PathBuf::from("/tmp/project"));
-        let turns = vec![
-            test_turn("turn-1", TurnStatus::Completed, Vec::new()),
-            test_turn("turn-2", TurnStatus::InProgress, Vec::new()),
-        ];
-
-        let store = ThreadEventStore::new_with_session(8, session.clone(), turns.clone());
-        assert_eq!(store.active_turn_id(), Some("turn-2"));
-
-        let mut refreshed_store = ThreadEventStore::new(8);
-        refreshed_store.set_session(session, turns);
-        assert_eq!(refreshed_store.active_turn_id(), Some("turn-2"));
-    }
-
-    #[test]
-    fn thread_event_store_rebase_preserves_resolved_request_state() {
-        let thread_id = ThreadId::new();
-        let mut store = ThreadEventStore::new(8);
-        store.push_request(exec_approval_request(
-            thread_id,
-            "turn-approval",
-            "call-approval",
-            None,
-        ));
-        store.push_notification(ServerNotification::ServerRequestResolved(
-            codex_app_server_protocol::ServerRequestResolvedNotification {
-                request_id: AppServerRequestId::Integer(1),
-                thread_id: thread_id.to_string(),
-            },
-        ));
-
-        store.rebase_buffer_after_session_refresh();
-
-        let snapshot = store.snapshot();
-        assert!(snapshot.events.is_empty());
-        assert_eq!(store.has_pending_thread_approvals(), false);
-    }
-
-    #[test]
-    fn thread_event_store_consumes_matching_local_legacy_rollback_once() {
-        let mut store = ThreadEventStore::new(8);
-        store.note_local_thread_rollback(2);
-
-        assert!(store.consume_pending_local_legacy_rollback(2));
-        assert!(!store.consume_pending_local_legacy_rollback(2));
-        assert!(!store.consume_pending_local_legacy_rollback(1));
     }
 
     fn next_user_turn_op(op_rx: &mut tokio::sync::mpsc::UnboundedReceiver<Op>) -> Op {
@@ -8067,19 +7581,6 @@ guardian_approval = true
             seen.push(format!("{op:?}"));
         }
         panic!("expected UserTurn op, saw: {seen:?}");
-    }
-
-    fn lines_to_single_string(lines: &[Line<'_>]) -> String {
-        lines
-            .iter()
-            .map(|line| {
-                line.spans
-                    .iter()
-                    .map(|span| span.content.as_ref())
-                    .collect::<String>()
-            })
-            .collect::<Vec<_>>()
-            .join("\n")
     }
 
     fn test_session_telemetry(config: &Config, model: &str) -> SessionTelemetry {
@@ -8828,62 +8329,71 @@ guardian_approval = true
     }
 
     #[tokio::test]
-    async fn replay_thread_snapshot_replays_turn_history_in_order() {
+    async fn replayed_initial_messages_apply_rollback_in_queue_order() {
         let (mut app, mut app_event_rx, _op_rx) = make_test_app_with_channels().await;
-        let thread_id = ThreadId::new();
-        app.replay_thread_snapshot(
-            ThreadEventSnapshot {
-                session: Some(test_thread_session(
-                    thread_id,
-                    PathBuf::from("/home/user/project"),
-                )),
-                turns: vec![
-                    Turn {
-                        id: "turn-1".to_string(),
-                        items: vec![ThreadItem::UserMessage {
-                            id: "user-1".to_string(),
-                            content: vec![AppServerUserInput::Text {
-                                text: "first prompt".to_string(),
-                                text_elements: Vec::new(),
-                            }],
-                        }],
-                        status: TurnStatus::Completed,
-                        error: None,
-                    },
-                    Turn {
-                        id: "turn-2".to_string(),
-                        items: vec![
-                            ThreadItem::UserMessage {
-                                id: "user-2".to_string(),
-                                content: vec![AppServerUserInput::Text {
-                                    text: "third prompt".to_string(),
-                                    text_elements: Vec::new(),
-                                }],
-                            },
-                            ThreadItem::AgentMessage {
-                                id: "assistant-2".to_string(),
-                                text: "done".to_string(),
-                                phase: None,
-                                memory_citation: None,
-                            },
-                        ],
-                        status: TurnStatus::Completed,
-                        error: None,
-                    },
-                ],
-                events: Vec::new(),
-                input_state: None,
-            },
-            false,
-        );
 
+        let session_id = ThreadId::new();
+        app.handle_codex_event_replay(Event {
+            id: String::new(),
+            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
+                session_id,
+                forked_from_id: None,
+                thread_name: None,
+                model: "gpt-test".to_string(),
+                model_provider_id: "test-provider".to_string(),
+                service_tier: None,
+                approval_policy: AskForApproval::Never,
+                approvals_reviewer: ApprovalsReviewer::User,
+                sandbox_policy: SandboxPolicy::new_read_only_policy(),
+                cwd: PathBuf::from("/home/user/project"),
+                reasoning_effort: None,
+                history_log_id: 0,
+                history_entry_count: 0,
+                initial_messages: Some(vec![
+                    EventMsg::UserMessage(UserMessageEvent {
+                        message: "first prompt".to_string(),
+                        images: None,
+                        local_images: Vec::new(),
+                        text_elements: Vec::new(),
+                    }),
+                    EventMsg::UserMessage(UserMessageEvent {
+                        message: "second prompt".to_string(),
+                        images: None,
+                        local_images: Vec::new(),
+                        text_elements: Vec::new(),
+                    }),
+                    EventMsg::ThreadRolledBack(ThreadRolledBackEvent { num_turns: 1 }),
+                    EventMsg::UserMessage(UserMessageEvent {
+                        message: "third prompt".to_string(),
+                        images: None,
+                        local_images: Vec::new(),
+                        text_elements: Vec::new(),
+                    }),
+                ]),
+                network_proxy: None,
+                rollout_path: Some(PathBuf::new()),
+            }),
+        });
+
+        let mut saw_rollback = false;
         while let Ok(event) = app_event_rx.try_recv() {
-            if let AppEvent::InsertHistoryCell(cell) = event {
-                let cell: Arc<dyn HistoryCell> = cell.into();
-                app.transcript_cells.push(cell);
+            match event {
+                AppEvent::InsertHistoryCell(cell) => {
+                    let cell: Arc<dyn HistoryCell> = cell.into();
+                    app.transcript_cells.push(cell);
+                }
+                AppEvent::ApplyThreadRollback { num_turns } => {
+                    saw_rollback = true;
+                    crate::app_backtrack::trim_transcript_cells_drop_last_n_user_turns(
+                        &mut app.transcript_cells,
+                        num_turns,
+                    );
+                }
+                _ => {}
             }
         }
 
+        assert!(saw_rollback);
         let user_messages: Vec<String> = app
             .transcript_cells
             .iter()
@@ -8900,60 +8410,80 @@ guardian_approval = true
     }
 
     #[tokio::test]
-    async fn refreshed_snapshot_session_persists_resumed_turns() {
-        let mut app = make_test_app().await;
-        let thread_id = ThreadId::new();
-        let initial_session = test_thread_session(thread_id, PathBuf::from("/tmp/original"));
-        app.thread_event_channels.insert(
-            thread_id,
-            ThreadEventChannel::new_with_session(4, initial_session.clone(), Vec::new()),
-        );
+    async fn live_rollback_during_replay_is_applied_in_app_event_order() {
+        let (mut app, mut app_event_rx, _op_rx) = make_test_app_with_channels().await;
 
-        let resumed_turns = vec![test_turn(
-            "turn-1",
-            TurnStatus::Completed,
-            vec![ThreadItem::UserMessage {
-                id: "user-1".to_string(),
-                content: vec![AppServerUserInput::Text {
-                    text: "restored prompt".to_string(),
-                    text_elements: Vec::new(),
-                }],
-            }],
-        )];
-        let resumed_session = ThreadSessionState {
-            cwd: PathBuf::from("/tmp/refreshed"),
-            ..initial_session.clone()
-        };
-        let mut snapshot = ThreadEventSnapshot {
-            session: Some(initial_session),
-            turns: Vec::new(),
-            events: Vec::new(),
-            input_state: None,
-        };
+        let session_id = ThreadId::new();
+        app.handle_codex_event_replay(Event {
+            id: String::new(),
+            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
+                session_id,
+                forked_from_id: None,
+                thread_name: None,
+                model: "gpt-test".to_string(),
+                model_provider_id: "test-provider".to_string(),
+                service_tier: None,
+                approval_policy: AskForApproval::Never,
+                approvals_reviewer: ApprovalsReviewer::User,
+                sandbox_policy: SandboxPolicy::new_read_only_policy(),
+                cwd: PathBuf::from("/home/user/project"),
+                reasoning_effort: None,
+                history_log_id: 0,
+                history_entry_count: 0,
+                initial_messages: Some(vec![
+                    EventMsg::UserMessage(UserMessageEvent {
+                        message: "first prompt".to_string(),
+                        images: None,
+                        local_images: Vec::new(),
+                        text_elements: Vec::new(),
+                    }),
+                    EventMsg::UserMessage(UserMessageEvent {
+                        message: "second prompt".to_string(),
+                        images: None,
+                        local_images: Vec::new(),
+                        text_elements: Vec::new(),
+                    }),
+                ]),
+                network_proxy: None,
+                rollout_path: Some(PathBuf::new()),
+            }),
+        });
 
-        app.apply_refreshed_snapshot_thread(
-            thread_id,
-            AppServerStartedThread {
-                session: resumed_session.clone(),
-                turns: resumed_turns.clone(),
-            },
-            &mut snapshot,
-        )
-        .await;
+        // Simulate a live rollback arriving before queued replay inserts are drained.
+        app.handle_codex_event_now(Event {
+            id: "live-rollback".to_string(),
+            msg: EventMsg::ThreadRolledBack(ThreadRolledBackEvent { num_turns: 1 }),
+        });
 
-        assert_eq!(snapshot.session, Some(resumed_session.clone()));
-        assert_eq!(snapshot.turns, resumed_turns);
+        let mut saw_rollback = false;
+        while let Ok(event) = app_event_rx.try_recv() {
+            match event {
+                AppEvent::InsertHistoryCell(cell) => {
+                    let cell: Arc<dyn HistoryCell> = cell.into();
+                    app.transcript_cells.push(cell);
+                }
+                AppEvent::ApplyThreadRollback { num_turns } => {
+                    saw_rollback = true;
+                    crate::app_backtrack::trim_transcript_cells_drop_last_n_user_turns(
+                        &mut app.transcript_cells,
+                        num_turns,
+                    );
+                }
+                _ => {}
+            }
+        }
 
-        let store = app
-            .thread_event_channels
-            .get(&thread_id)
-            .expect("thread channel")
-            .store
-            .lock()
-            .await;
-        let store_snapshot = store.snapshot();
-        assert_eq!(store_snapshot.session, Some(resumed_session));
-        assert_eq!(store_snapshot.turns, snapshot.turns);
+        assert!(saw_rollback);
+        let user_messages: Vec<String> = app
+            .transcript_cells
+            .iter()
+            .filter_map(|cell| {
+                cell.as_any()
+                    .downcast_ref::<UserHistoryCell>()
+                    .map(|cell| cell.message.clone())
+            })
+            .collect();
+        assert_eq!(user_messages, vec!["first prompt".to_string()]);
     }
 
     #[tokio::test]
@@ -9007,108 +8537,6 @@ guardian_approval = true
             _ => panic!("expected transcript overlay"),
         };
         assert_eq!(overlay_cell_count, app.transcript_cells.len());
-    }
-
-    #[tokio::test]
-    async fn thread_rollback_response_discards_queued_active_thread_events() {
-        let mut app = make_test_app().await;
-        let thread_id = ThreadId::new();
-        let (tx, rx) = mpsc::channel(8);
-        app.active_thread_id = Some(thread_id);
-        app.active_thread_rx = Some(rx);
-        tx.send(ThreadBufferedEvent::LegacyWarning(
-            "stale warning".to_string(),
-        ))
-        .await
-        .expect("event should queue");
-
-        app.handle_thread_rollback_response(
-            thread_id,
-            1,
-            &ThreadRollbackResponse {
-                thread: Thread {
-                    id: thread_id.to_string(),
-                    preview: String::new(),
-                    ephemeral: false,
-                    model_provider: "openai".to_string(),
-                    created_at: 0,
-                    updated_at: 0,
-                    status: codex_app_server_protocol::ThreadStatus::Idle,
-                    path: None,
-                    cwd: PathBuf::from("/tmp/project"),
-                    cli_version: "0.0.0".to_string(),
-                    source: SessionSource::Cli.into(),
-                    agent_nickname: None,
-                    agent_role: None,
-                    git_info: None,
-                    name: None,
-                    turns: Vec::new(),
-                },
-            },
-        )
-        .await;
-
-        let rx = app
-            .active_thread_rx
-            .as_mut()
-            .expect("active receiver should remain attached");
-        assert!(matches!(rx.try_recv(), Err(TryRecvError::Empty)));
-    }
-
-    #[tokio::test]
-    async fn local_rollback_response_suppresses_matching_legacy_rollback() {
-        let mut app = make_test_app().await;
-        let thread_id = ThreadId::new();
-        let session = test_thread_session(thread_id, PathBuf::from("/tmp/project"));
-        let initial_turns = vec![
-            test_turn("turn-1", TurnStatus::Completed, Vec::new()),
-            test_turn("turn-2", TurnStatus::Completed, Vec::new()),
-        ];
-        app.thread_event_channels.insert(
-            thread_id,
-            ThreadEventChannel::new_with_session(8, session, initial_turns),
-        );
-
-        app.handle_thread_rollback_response(
-            thread_id,
-            1,
-            &ThreadRollbackResponse {
-                thread: Thread {
-                    id: thread_id.to_string(),
-                    preview: String::new(),
-                    ephemeral: false,
-                    model_provider: "openai".to_string(),
-                    created_at: 0,
-                    updated_at: 0,
-                    status: codex_app_server_protocol::ThreadStatus::Idle,
-                    path: None,
-                    cwd: PathBuf::from("/tmp/project"),
-                    cli_version: "0.0.0".to_string(),
-                    source: SessionSource::Cli.into(),
-                    agent_nickname: None,
-                    agent_role: None,
-                    git_info: None,
-                    name: None,
-                    turns: vec![test_turn("turn-1", TurnStatus::Completed, Vec::new())],
-                },
-            },
-        )
-        .await;
-
-        app.enqueue_thread_legacy_rollback(thread_id, 1)
-            .await
-            .expect("legacy rollback should not fail");
-
-        let store = app
-            .thread_event_channels
-            .get(&thread_id)
-            .expect("thread channel")
-            .store
-            .lock()
-            .await;
-        let snapshot = store.snapshot();
-        assert_eq!(snapshot.turns.len(), 1);
-        assert!(snapshot.events.is_empty());
     }
 
     #[tokio::test]

--- a/codex-rs/tui_app_server/src/app.rs
+++ b/codex-rs/tui_app_server/src/app.rs
@@ -134,6 +134,7 @@ mod pending_interactive_replay;
 use self::agent_navigation::AgentNavigationDirection;
 use self::agent_navigation::AgentNavigationState;
 use self::app_server_requests::PendingAppServerRequests;
+use self::app_server_requests::ResolvedAppServerRequest;
 use self::pending_interactive_replay::PendingInteractiveReplayState;
 
 const EXTERNAL_EDITOR_HINT: &str = "Save and close external editor to continue.";
@@ -633,6 +634,11 @@ impl ThreadEventStore {
         T: Into<AppCommand>,
     {
         self.pending_interactive_replay.note_outbound_op(op);
+    }
+
+    fn note_exec_approval_resolved(&mut self, approval_id: &str) {
+        self.pending_interactive_replay
+            .note_exec_approval_resolved(approval_id);
     }
 
     fn op_can_change_pending_replay_state<T>(op: T) -> bool
@@ -1575,6 +1581,21 @@ impl App {
             return;
         };
         self.note_thread_outbound_op(thread_id, op).await;
+    }
+
+    async fn note_app_server_request_resolved(&mut self, resolved: ResolvedAppServerRequest) {
+        if resolved.exec_approval_ids.is_empty() {
+            return;
+        }
+
+        for channel in self.thread_event_channels.values() {
+            let mut store = channel.store.lock().await;
+            for approval_id in &resolved.exec_approval_ids {
+                store.note_exec_approval_resolved(approval_id);
+            }
+        }
+
+        self.refresh_pending_thread_approvals().await;
     }
 
     async fn active_turn_id_for_thread(&self, thread_id: ThreadId) -> Option<String> {

--- a/codex-rs/tui_app_server/src/app.rs
+++ b/codex-rs/tui_app_server/src/app.rs
@@ -618,6 +618,7 @@ impl ThreadEventStore {
                         .pending_interactive_replay
                         .should_replay_snapshot_request(request),
                     ThreadBufferedEvent::Notification(_)
+                    | ThreadBufferedEvent::HistoryEntryResponse(_)
                     | ThreadBufferedEvent::LegacyWarning(_)
                     | ThreadBufferedEvent::LegacyRollback { .. } => true,
                 })
@@ -2385,6 +2386,50 @@ impl App {
         Ok(())
     }
 
+    async fn enqueue_thread_history_entry_response(
+        &mut self,
+        thread_id: ThreadId,
+        event: GetHistoryEntryResponseEvent,
+    ) -> Result<()> {
+        let (sender, store) = {
+            let channel = self.ensure_thread_channel(thread_id);
+            (channel.sender.clone(), Arc::clone(&channel.store))
+        };
+
+        let should_send = {
+            let mut guard = store.lock().await;
+            guard
+                .buffer
+                .push_back(ThreadBufferedEvent::HistoryEntryResponse(event.clone()));
+            if guard.buffer.len() > guard.capacity
+                && let Some(removed) = guard.buffer.pop_front()
+                && let ThreadBufferedEvent::Request(request) = &removed
+            {
+                guard
+                    .pending_interactive_replay
+                    .note_evicted_server_request(request);
+            }
+            guard.active
+        };
+
+        if should_send {
+            match sender.try_send(ThreadBufferedEvent::HistoryEntryResponse(event)) {
+                Ok(()) => {}
+                Err(TrySendError::Full(event)) => {
+                    tokio::spawn(async move {
+                        if let Err(err) = sender.send(event).await {
+                            tracing::warn!("thread {thread_id} event channel closed: {err}");
+                        }
+                    });
+                }
+                Err(TrySendError::Closed(_)) => {
+                    tracing::warn!("thread {thread_id} event channel closed");
+                }
+            }
+        }
+        Ok(())
+    }
+
     async fn enqueue_thread_legacy_rollback(
         &mut self,
         thread_id: ThreadId,
@@ -2475,6 +2520,10 @@ impl App {
                 }
                 ThreadBufferedEvent::Request(request) => {
                     self.enqueue_thread_request(thread_id, request).await?;
+                }
+                ThreadBufferedEvent::HistoryEntryResponse(event) => {
+                    self.enqueue_thread_history_entry_response(thread_id, event)
+                        .await?;
                 }
                 ThreadBufferedEvent::LegacyWarning(message) => {
                     self.enqueue_thread_legacy_warning(thread_id, message)
@@ -4801,6 +4850,9 @@ impl App {
                 self.chat_widget
                     .handle_server_request(request, /*replay_kind*/ None);
             }
+            ThreadBufferedEvent::HistoryEntryResponse(event) => {
+                self.chat_widget.handle_history_entry_response(event);
+            }
             ThreadBufferedEvent::LegacyWarning(message) => {
                 self.chat_widget.add_warning_message(message);
             }
@@ -4822,6 +4874,9 @@ impl App {
             ThreadBufferedEvent::Request(request) => self
                 .chat_widget
                 .handle_server_request(request, Some(ReplayKind::ThreadSnapshot)),
+            ThreadBufferedEvent::HistoryEntryResponse(event) => {
+                self.chat_widget.handle_history_entry_response(event)
+            }
             ThreadBufferedEvent::LegacyWarning(message) => {
                 self.chat_widget.add_warning_message(message);
             }

--- a/codex-rs/tui_app_server/src/app.rs
+++ b/codex-rs/tui_app_server/src/app.rs
@@ -4917,6 +4917,9 @@ impl App {
                     .handle_server_notification(notification, /*replay_kind*/ None);
             }
             ThreadBufferedEvent::Request(request) => {
+                if self.should_drop_stale_exec_approval_request(&request) {
+                    return;
+                }
                 self.chat_widget
                     .handle_server_request(request, /*replay_kind*/ None);
             }
@@ -4941,9 +4944,13 @@ impl App {
             ThreadBufferedEvent::Notification(notification) => self
                 .chat_widget
                 .handle_server_notification(notification, Some(ReplayKind::ThreadSnapshot)),
-            ThreadBufferedEvent::Request(request) => self
-                .chat_widget
-                .handle_server_request(request, Some(ReplayKind::ThreadSnapshot)),
+            ThreadBufferedEvent::Request(request) => {
+                if self.should_drop_stale_exec_approval_request(&request) {
+                    return;
+                }
+                self.chat_widget
+                    .handle_server_request(request, Some(ReplayKind::ThreadSnapshot));
+            }
             ThreadBufferedEvent::HistoryEntryResponse(event) => {
                 self.chat_widget.handle_history_entry_response(event)
             }
@@ -4955,6 +4962,19 @@ impl App {
                 self.chat_widget.handle_thread_rolled_back();
             }
         }
+    }
+
+    fn should_drop_stale_exec_approval_request(&self, request: &ServerRequest) -> bool {
+        let ServerRequest::CommandExecutionRequestApproval { params, .. } = request else {
+            return false;
+        };
+        let approval_id = params
+            .approval_id
+            .clone()
+            .unwrap_or_else(|| params.item_id.clone());
+        !self
+            .pending_app_server_requests
+            .has_pending_exec_approval(&approval_id)
     }
 
     /// Handles an event emitted by the currently active thread.
@@ -5647,6 +5667,11 @@ mod tests {
         let thread_id = ThreadId::new();
         let approval_request = exec_approval_request(thread_id, "turn-1", "call-1", None);
 
+        assert_eq!(
+            app.pending_app_server_requests
+                .note_server_request(&approval_request),
+            None
+        );
         app.enqueue_primary_thread_request(approval_request).await?;
         app.enqueue_primary_thread_session(
             test_thread_session(thread_id, PathBuf::from("/tmp/project")),
@@ -5755,6 +5780,20 @@ mod tests {
             "resolved active approval should be removed from the live queue"
         );
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stale_exec_approval_request_is_dropped_at_consume_time() -> Result<()> {
+        let mut app = make_test_app().await;
+        let thread_id = ThreadId::new();
+        let request = exec_approval_request(thread_id, "", "call-1", Some("approval-1"));
+
+        assert_eq!(app.chat_widget.has_active_view(), false);
+
+        app.handle_thread_event_now(ThreadBufferedEvent::Request(request));
+
+        assert_eq!(app.chat_widget.has_active_view(), false);
         Ok(())
     }
 

--- a/codex-rs/tui_app_server/src/app.rs
+++ b/codex-rs/tui_app_server/src/app.rs
@@ -1712,25 +1712,21 @@ impl App {
             };
 
             let mut retained_events = Vec::new();
-            loop {
-                match rx.try_recv() {
-                    Ok(event) => {
-                        let ThreadBufferedEvent::Request(
-                            ServerRequest::CommandExecutionRequestApproval { params, .. },
-                        ) = &event
-                        else {
-                            retained_events.push(event);
-                            continue;
-                        };
-                        let approval_id = params
-                            .approval_id
-                            .clone()
-                            .unwrap_or_else(|| params.item_id.clone());
-                        if !approval_ids.contains(&approval_id) {
-                            retained_events.push(event);
-                        }
-                    }
-                    Err(TryRecvError::Empty) | Err(TryRecvError::Disconnected) => break,
+            while let Ok(event) = rx.try_recv() {
+                let ThreadBufferedEvent::Request(ServerRequest::CommandExecutionRequestApproval {
+                    params,
+                    ..
+                }) = &event
+                else {
+                    retained_events.push(event);
+                    continue;
+                };
+                let approval_id = params
+                    .approval_id
+                    .clone()
+                    .unwrap_or_else(|| params.item_id.clone());
+                if !approval_ids.contains(&approval_id) {
+                    retained_events.push(event);
                 }
             }
 

--- a/codex-rs/tui_app_server/src/app.rs
+++ b/codex-rs/tui_app_server/src/app.rs
@@ -1390,6 +1390,8 @@ impl App {
                 .exec_approval_ids
                 .contains(&approval.effective_approval_id())
         });
+        self.chat_widget
+            .remove_resolved_exec_approvals(&resolved.exec_approval_ids);
 
         for channel in self.thread_event_channels.values() {
             let mut store = channel.store.lock().await;

--- a/codex-rs/tui_app_server/src/app.rs
+++ b/codex-rs/tui_app_server/src/app.rs
@@ -1595,6 +1595,8 @@ impl App {
                 .unwrap_or_else(|| params.item_id.clone());
             !resolved.exec_approval_ids.contains(&approval_id)
         });
+        self.remove_resolved_exec_approvals_from_active_queue(&resolved.exec_approval_ids)
+            .await;
         self.chat_widget
             .remove_resolved_exec_approvals(&resolved.exec_approval_ids);
 
@@ -1608,6 +1610,62 @@ impl App {
         }
 
         self.refresh_pending_thread_approvals().await;
+    }
+
+    async fn remove_resolved_exec_approvals_from_active_queue(&mut self, approval_ids: &[String]) {
+        let Some(thread_id) = self.active_thread_id else {
+            return;
+        };
+        let Some(mut rx) = self.active_thread_rx.take() else {
+            return;
+        };
+        let Some(channel) = self.thread_event_channels.get(&thread_id) else {
+            self.active_thread_rx = Some(rx);
+            return;
+        };
+
+        let sender = channel.sender.clone();
+        let mut disconnected = false;
+        let mut retained_events = Vec::new();
+
+        loop {
+            match rx.try_recv() {
+                Ok(event) => {
+                    let ThreadBufferedEvent::Request(
+                        ServerRequest::CommandExecutionRequestApproval { params, .. },
+                    ) = &event
+                    else {
+                        retained_events.push(event);
+                        continue;
+                    };
+                    let approval_id = params
+                        .approval_id
+                        .clone()
+                        .unwrap_or_else(|| params.item_id.clone());
+                    if !approval_ids.contains(&approval_id) {
+                        retained_events.push(event);
+                    }
+                }
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Disconnected) => {
+                    disconnected = true;
+                    break;
+                }
+            }
+        }
+
+        if disconnected {
+            self.clear_active_thread().await;
+            return;
+        }
+
+        for event in retained_events {
+            if sender.send(event).await.is_err() {
+                self.clear_active_thread().await;
+                return;
+            }
+        }
+        self.active_thread_rx = Some(rx);
     }
 
     async fn active_turn_id_for_thread(&self, thread_id: ThreadId) -> Option<String> {
@@ -5533,6 +5591,43 @@ mod tests {
                 .await
                 .is_err(),
             "resolved buffered approval should not replay after session configured"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn resolved_active_exec_approval_is_removed_from_active_thread_queue() -> Result<()> {
+        let mut app = make_test_app().await;
+        let thread_id = ThreadId::new();
+
+        app.enqueue_primary_thread_session(
+            test_thread_session(thread_id, PathBuf::from("/tmp/project")),
+            Vec::new(),
+        )
+        .await?;
+        app.enqueue_primary_thread_request(exec_approval_request(
+            thread_id,
+            "",
+            "call-1",
+            Some("approval-1"),
+        ))
+        .await?;
+
+        app.note_app_server_request_resolved(ResolvedAppServerRequest {
+            exec_approval_ids: vec!["approval-1".to_string()],
+        })
+        .await;
+
+        let rx = app
+            .active_thread_rx
+            .as_mut()
+            .expect("primary thread receiver should be active");
+        assert!(
+            time::timeout(Duration::from_millis(50), rx.recv())
+                .await
+                .is_err(),
+            "resolved active approval should be removed from the live queue"
         );
 
         Ok(())

--- a/codex-rs/tui_app_server/src/app.rs
+++ b/codex-rs/tui_app_server/src/app.rs
@@ -1660,13 +1660,35 @@ impl App {
             return;
         }
 
-        for event in retained_events {
-            if sender.send(event).await.is_err() {
-                self.clear_active_thread().await;
-                return;
+        self.active_thread_rx = Some(rx);
+
+        if retained_events.is_empty() {
+            return;
+        }
+
+        let mut pending_events = retained_events.into_iter();
+        while let Some(event) = pending_events.next() {
+            match sender.try_send(event) {
+                Ok(()) => {}
+                Err(TrySendError::Full(event)) => {
+                    let remaining_events: Vec<_> =
+                        std::iter::once(event).chain(pending_events).collect();
+                    tokio::spawn(async move {
+                        for event in remaining_events {
+                            if let Err(err) = sender.send(event).await {
+                                tracing::warn!("thread {thread_id} event channel closed: {err}");
+                                break;
+                            }
+                        }
+                    });
+                    return;
+                }
+                Err(TrySendError::Closed(_)) => {
+                    self.clear_active_thread().await;
+                    return;
+                }
             }
         }
-        self.active_thread_rx = Some(rx);
     }
 
     async fn active_turn_id_for_thread(&self, thread_id: ThreadId) -> Option<String> {

--- a/codex-rs/tui_app_server/src/app.rs
+++ b/codex-rs/tui_app_server/src/app.rs
@@ -2230,7 +2230,7 @@ impl App {
     ) -> Result<bool> {
         let Some(resolution) = self
             .pending_app_server_requests
-            .take_resolution(op)
+            .prepare_resolution(op)
             .map_err(|err| color_eyre::eyre::eyre!(err))?
         else {
             return Ok(false);
@@ -2241,6 +2241,7 @@ impl App {
             .await
         {
             Ok(()) => {
+                self.pending_app_server_requests.commit_resolution(op);
                 if ThreadEventStore::op_can_change_pending_replay_state(op) {
                     self.note_thread_outbound_op(thread_id, op).await;
                     self.refresh_pending_thread_approvals().await;

--- a/codex-rs/tui_app_server/src/app.rs
+++ b/codex-rs/tui_app_server/src/app.rs
@@ -682,6 +682,34 @@ impl ThreadEventChannel {
     }
 }
 
+fn requeue_retained_thread_events(
+    thread_id: ThreadId,
+    sender: mpsc::Sender<ThreadBufferedEvent>,
+    retained_events: Vec<ThreadBufferedEvent>,
+) -> bool {
+    let mut pending_events = retained_events.into_iter();
+    while let Some(event) = pending_events.next() {
+        match sender.try_send(event) {
+            Ok(()) => {}
+            Err(TrySendError::Full(event)) => {
+                let remaining_events: Vec<_> =
+                    std::iter::once(event).chain(pending_events).collect();
+                tokio::spawn(async move {
+                    for event in remaining_events {
+                        if let Err(err) = sender.send(event).await {
+                            tracing::warn!("thread {thread_id} event channel closed: {err}");
+                            break;
+                        }
+                    }
+                });
+                return true;
+            }
+            Err(TrySendError::Closed(_)) => return false,
+        }
+    }
+    true
+}
+
 fn should_show_model_migration_prompt(
     current_model: &str,
     target_model: &str,
@@ -1598,6 +1626,7 @@ impl App {
         });
         self.remove_resolved_exec_approvals_from_active_queue(&resolved.exec_approval_ids)
             .await;
+        self.remove_resolved_exec_approvals_from_inactive_queues(&resolved.exec_approval_ids);
         self.chat_widget
             .remove_resolved_exec_approvals(&resolved.exec_approval_ids);
 
@@ -1666,28 +1695,51 @@ impl App {
             return;
         }
 
-        let mut pending_events = retained_events.into_iter();
-        while let Some(event) = pending_events.next() {
-            match sender.try_send(event) {
-                Ok(()) => {}
-                Err(TrySendError::Full(event)) => {
-                    let remaining_events: Vec<_> =
-                        std::iter::once(event).chain(pending_events).collect();
-                    tokio::spawn(async move {
-                        for event in remaining_events {
-                            if let Err(err) = sender.send(event).await {
-                                tracing::warn!("thread {thread_id} event channel closed: {err}");
-                                break;
-                            }
+        if !requeue_retained_thread_events(thread_id, sender, retained_events) {
+            self.clear_active_thread().await;
+        }
+    }
+
+    fn remove_resolved_exec_approvals_from_inactive_queues(&mut self, approval_ids: &[String]) {
+        let active_thread_id = self.active_thread_id;
+
+        for (&thread_id, channel) in &mut self.thread_event_channels {
+            if Some(thread_id) == active_thread_id {
+                continue;
+            }
+            let Some(mut rx) = channel.receiver.take() else {
+                continue;
+            };
+
+            let mut retained_events = Vec::new();
+            loop {
+                match rx.try_recv() {
+                    Ok(event) => {
+                        let ThreadBufferedEvent::Request(
+                            ServerRequest::CommandExecutionRequestApproval { params, .. },
+                        ) = &event
+                        else {
+                            retained_events.push(event);
+                            continue;
+                        };
+                        let approval_id = params
+                            .approval_id
+                            .clone()
+                            .unwrap_or_else(|| params.item_id.clone());
+                        if !approval_ids.contains(&approval_id) {
+                            retained_events.push(event);
                         }
-                    });
-                    return;
-                }
-                Err(TrySendError::Closed(_)) => {
-                    self.clear_active_thread().await;
-                    return;
+                    }
+                    Err(TryRecvError::Empty) | Err(TryRecvError::Disconnected) => break,
                 }
             }
+
+            channel.receiver = Some(rx);
+            if retained_events.is_empty() {
+                continue;
+            }
+            let sender = channel.sender.clone();
+            let _ = requeue_retained_thread_events(thread_id, sender, retained_events);
         }
     }
 
@@ -5706,6 +5758,44 @@ mod tests {
                 .is_err(),
             "resolved active approval should be removed from the live queue"
         );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn resolved_exec_approval_is_removed_from_inactive_thread_queue() -> Result<()> {
+        let mut app = make_test_app().await;
+        let thread_id = ThreadId::new();
+
+        app.enqueue_primary_thread_session(
+            test_thread_session(thread_id, PathBuf::from("/tmp/project")),
+            Vec::new(),
+        )
+        .await?;
+        app.enqueue_primary_thread_request(exec_approval_request(
+            thread_id,
+            "",
+            "call-1",
+            Some("approval-1"),
+        ))
+        .await?;
+
+        app.store_active_thread_receiver().await;
+        app.active_thread_id = None;
+
+        app.note_app_server_request_resolved(ResolvedAppServerRequest {
+            exec_approval_ids: vec!["approval-1".to_string()],
+        })
+        .await;
+
+        let rx = app
+            .thread_event_channels
+            .get_mut(&thread_id)
+            .expect("thread channel should exist")
+            .receiver
+            .as_mut()
+            .expect("inactive receiver should be stored");
+        assert!(matches!(rx.try_recv(), Err(TryRecvError::Empty)));
 
         Ok(())
     }

--- a/codex-rs/tui_app_server/src/app.rs
+++ b/codex-rs/tui_app_server/src/app.rs
@@ -9,6 +9,7 @@ use crate::app_event::WindowsSandboxEnableMode;
 use crate::app_event_sender::AppEventSender;
 use crate::app_server_session::AppServerSession;
 use crate::app_server_session::AppServerStartedThread;
+use crate::app_server_session::ThreadSessionState;
 use crate::bottom_pane::ApprovalRequest;
 use crate::bottom_pane::FeedbackAudience;
 use crate::bottom_pane::McpServerElicitationFormRequest;
@@ -17,6 +18,7 @@ use crate::bottom_pane::SelectionViewParams;
 use crate::bottom_pane::popup_consts::standard_popup_hint_line;
 use crate::chatwidget::ChatWidget;
 use crate::chatwidget::ExternalEditorState;
+use crate::chatwidget::ReplayKind;
 use crate::chatwidget::ThreadInputState;
 use crate::cwd_prompt::CwdPromptAction;
 use crate::diff_render::DiffSummary;
@@ -36,6 +38,7 @@ use crate::multi_agents::format_agent_picker_item_name;
 use crate::multi_agents::next_agent_shortcut_matches;
 use crate::multi_agents::previous_agent_shortcut_matches;
 use crate::pager_overlay::Overlay;
+use crate::read_session_model;
 use crate::render::highlight::highlight_bash_to_lines;
 use crate::render::renderable::Renderable;
 use crate::resume_picker::SessionSelection;
@@ -44,7 +47,19 @@ use crate::tui::TuiEvent;
 use crate::update_action::UpdateAction;
 use crate::version::CODEX_CLI_VERSION;
 use codex_ansi_escape::ansi_escape_line;
+use codex_app_server_client::AppServerRequestHandle;
+use codex_app_server_protocol::ClientRequest;
 use codex_app_server_protocol::ConfigLayerSource;
+use codex_app_server_protocol::ListMcpServerStatusParams;
+use codex_app_server_protocol::ListMcpServerStatusResponse;
+use codex_app_server_protocol::McpServerStatus;
+use codex_app_server_protocol::RequestId;
+use codex_app_server_protocol::ServerNotification;
+use codex_app_server_protocol::ServerRequest;
+use codex_app_server_protocol::SkillsListResponse;
+use codex_app_server_protocol::ThreadRollbackResponse;
+use codex_app_server_protocol::Turn;
+use codex_app_server_protocol::TurnStatus;
 use codex_core::config::Config;
 use codex_core::config::ConfigBuilder;
 use codex_core::config::ConfigOverrides;
@@ -62,17 +77,15 @@ use codex_core::models_manager::model_presets::HIDE_GPT5_1_MIGRATION_PROMPT_CONF
 use codex_core::windows_sandbox::WindowsSandboxLevelExt;
 use codex_otel::SessionTelemetry;
 use codex_protocol::ThreadId;
+use codex_protocol::approvals::ExecApprovalRequestEvent;
 use codex_protocol::config_types::Personality;
 #[cfg(target_os = "windows")]
 use codex_protocol::config_types::WindowsSandboxLevel;
-use codex_protocol::items::TurnItem;
 use codex_protocol::openai_models::ModelAvailabilityNux;
 use codex_protocol::openai_models::ModelPreset;
 use codex_protocol::openai_models::ModelUpgrade;
 use codex_protocol::openai_models::ReasoningEffort as ReasoningEffortConfig;
 use codex_protocol::protocol::AskForApproval;
-use codex_protocol::protocol::Event;
-use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::FinalOutput;
 use codex_protocol::protocol::GetHistoryEntryResponseEvent;
 use codex_protocol::protocol::ListSkillsResponseEvent;
@@ -80,7 +93,6 @@ use codex_protocol::protocol::ListSkillsResponseEvent;
 use codex_protocol::protocol::McpAuthStatus;
 use codex_protocol::protocol::Op;
 use codex_protocol::protocol::SandboxPolicy;
-use codex_protocol::protocol::SessionConfiguredEvent;
 use codex_protocol::protocol::SessionSource;
 use codex_protocol::protocol::SkillErrorInfo;
 use codex_protocol::protocol::TokenUsage;
@@ -96,7 +108,6 @@ use ratatui::widgets::Paragraph;
 use ratatui::widgets::Wrap;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
-use std::collections::HashSet;
 use std::collections::VecDeque;
 use std::path::Path;
 use std::path::PathBuf;
@@ -114,6 +125,7 @@ use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::mpsc::unbounded_channel;
 use tokio::task::JoinHandle;
 use toml::Value as TomlValue;
+use uuid::Uuid;
 mod agent_navigation;
 mod app_server_adapter;
 mod app_server_requests;
@@ -121,7 +133,6 @@ mod pending_interactive_replay;
 
 use self::agent_navigation::AgentNavigationDirection;
 use self::agent_navigation::AgentNavigationState;
-use self::app_server_adapter::thread_snapshot_events;
 use self::app_server_requests::PendingAppServerRequests;
 use self::app_server_requests::ResolvedAppServerRequest;
 use self::pending_interactive_replay::PendingInteractiveReplayState;
@@ -132,6 +143,74 @@ const THREAD_EVENT_CHANNEL_CAPACITY: usize = 32768;
 enum ThreadInteractiveRequest {
     Approval(ApprovalRequest),
     McpServerElicitation(McpServerElicitationFormRequest),
+}
+
+fn app_server_request_id_to_mcp_request_id(
+    request_id: &codex_app_server_protocol::RequestId,
+) -> codex_protocol::mcp::RequestId {
+    match request_id {
+        codex_app_server_protocol::RequestId::String(value) => {
+            codex_protocol::mcp::RequestId::String(value.clone())
+        }
+        codex_app_server_protocol::RequestId::Integer(value) => {
+            codex_protocol::mcp::RequestId::Integer(*value)
+        }
+    }
+}
+
+fn command_execution_decision_to_review_decision(
+    decision: codex_app_server_protocol::CommandExecutionApprovalDecision,
+) -> codex_protocol::protocol::ReviewDecision {
+    match decision {
+        codex_app_server_protocol::CommandExecutionApprovalDecision::Accept => {
+            codex_protocol::protocol::ReviewDecision::Approved
+        }
+        codex_app_server_protocol::CommandExecutionApprovalDecision::AcceptForSession => {
+            codex_protocol::protocol::ReviewDecision::ApprovedForSession
+        }
+        codex_app_server_protocol::CommandExecutionApprovalDecision::AcceptWithExecpolicyAmendment {
+            execpolicy_amendment,
+        } => codex_protocol::protocol::ReviewDecision::ApprovedExecpolicyAmendment {
+            proposed_execpolicy_amendment: execpolicy_amendment.into_core(),
+        },
+        codex_app_server_protocol::CommandExecutionApprovalDecision::ApplyNetworkPolicyAmendment {
+            network_policy_amendment,
+        } => codex_protocol::protocol::ReviewDecision::NetworkPolicyAmendment {
+            network_policy_amendment: network_policy_amendment.into_core(),
+        },
+        codex_app_server_protocol::CommandExecutionApprovalDecision::Decline => {
+            codex_protocol::protocol::ReviewDecision::Denied
+        }
+        codex_app_server_protocol::CommandExecutionApprovalDecision::Cancel => {
+            codex_protocol::protocol::ReviewDecision::Abort
+        }
+    }
+}
+
+fn convert_via_json<T, U>(value: T) -> Option<U>
+where
+    T: serde::Serialize,
+    U: serde::de::DeserializeOwned,
+{
+    serde_json::to_value(value)
+        .ok()
+        .and_then(|value| serde_json::from_value(value).ok())
+}
+
+fn default_exec_approval_decisions(
+    network_approval_context: Option<&codex_protocol::protocol::NetworkApprovalContext>,
+    proposed_execpolicy_amendment: Option<&codex_protocol::approvals::ExecPolicyAmendment>,
+    proposed_network_policy_amendments: Option<
+        &[codex_protocol::approvals::NetworkPolicyAmendment],
+    >,
+    additional_permissions: Option<&codex_protocol::models::PermissionProfile>,
+) -> Vec<codex_protocol::protocol::ReviewDecision> {
+    ExecApprovalRequestEvent::default_available_decisions(
+        network_approval_context,
+        proposed_execpolicy_amendment,
+        proposed_network_policy_amendments,
+        additional_permissions,
+    )
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -217,6 +296,77 @@ fn errors_for_cwd(cwd: &Path, response: &ListSkillsResponseEvent) -> Vec<SkillEr
         .unwrap_or_default()
 }
 
+fn list_skills_response_to_core(response: SkillsListResponse) -> ListSkillsResponseEvent {
+    ListSkillsResponseEvent {
+        skills: response
+            .data
+            .into_iter()
+            .map(|entry| codex_protocol::protocol::SkillsListEntry {
+                cwd: entry.cwd,
+                skills: entry
+                    .skills
+                    .into_iter()
+                    .map(|skill| codex_protocol::protocol::SkillMetadata {
+                        name: skill.name,
+                        description: skill.description,
+                        short_description: skill.short_description,
+                        interface: skill.interface.map(|interface| {
+                            codex_protocol::protocol::SkillInterface {
+                                display_name: interface.display_name,
+                                short_description: interface.short_description,
+                                icon_small: interface.icon_small,
+                                icon_large: interface.icon_large,
+                                brand_color: interface.brand_color,
+                                default_prompt: interface.default_prompt,
+                            }
+                        }),
+                        dependencies: skill.dependencies.map(|dependencies| {
+                            codex_protocol::protocol::SkillDependencies {
+                                tools: dependencies
+                                    .tools
+                                    .into_iter()
+                                    .map(|tool| codex_protocol::protocol::SkillToolDependency {
+                                        r#type: tool.r#type,
+                                        value: tool.value,
+                                        description: tool.description,
+                                        transport: tool.transport,
+                                        command: tool.command,
+                                        url: tool.url,
+                                    })
+                                    .collect(),
+                            }
+                        }),
+                        path: skill.path,
+                        scope: match skill.scope {
+                            codex_app_server_protocol::SkillScope::User => {
+                                codex_protocol::protocol::SkillScope::User
+                            }
+                            codex_app_server_protocol::SkillScope::Repo => {
+                                codex_protocol::protocol::SkillScope::Repo
+                            }
+                            codex_app_server_protocol::SkillScope::System => {
+                                codex_protocol::protocol::SkillScope::System
+                            }
+                            codex_app_server_protocol::SkillScope::Admin => {
+                                codex_protocol::protocol::SkillScope::Admin
+                            }
+                        },
+                        enabled: skill.enabled,
+                    })
+                    .collect(),
+                errors: entry
+                    .errors
+                    .into_iter()
+                    .map(|error| codex_protocol::protocol::SkillErrorInfo {
+                        path: error.path,
+                        message: error.message,
+                    })
+                    .collect(),
+            })
+            .collect(),
+    }
+}
+
 fn emit_skill_load_warnings(app_event_tx: &AppEventSender, errors: &[SkillErrorInfo]) {
     if errors.is_empty() {
         return;
@@ -281,6 +431,16 @@ fn emit_project_config_warnings(app_event_tx: &AppEventSender, config: &Config) 
     )));
 }
 
+fn emit_missing_system_bwrap_warning(app_event_tx: &AppEventSender) {
+    let Some(message) = codex_core::config::missing_system_bwrap_warning() else {
+        return;
+    };
+
+    app_event_tx.send(AppEvent::InsertHistoryCell(Box::new(
+        history_cell::new_warning_event(message),
+    )));
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct SessionSummary {
     usage_line: String,
@@ -289,8 +449,9 @@ struct SessionSummary {
 
 #[derive(Debug, Clone)]
 struct ThreadEventSnapshot {
-    session_configured: Option<Event>,
-    events: Vec<Event>,
+    session: Option<ThreadSessionState>,
+    turns: Vec<Turn>,
+    events: Vec<ThreadBufferedEvent>,
     input_state: Option<ThreadInputState>,
 }
 
@@ -304,10 +465,11 @@ enum ThreadBufferedEvent {
 }
 #[derive(Debug)]
 struct ThreadEventStore {
-    session_configured: Option<Event>,
-    buffer: VecDeque<Event>,
-    user_message_ids: HashSet<String>,
+    session: Option<ThreadSessionState>,
+    turns: Vec<Turn>,
+    buffer: VecDeque<ThreadBufferedEvent>,
     pending_interactive_replay: PendingInteractiveReplayState,
+    pending_local_legacy_rollbacks: VecDeque<u32>,
     active_turn_id: Option<String>,
     input_state: Option<ThreadInputState>,
     capacity: usize,
@@ -315,12 +477,20 @@ struct ThreadEventStore {
 }
 
 impl ThreadEventStore {
+    fn event_survives_session_refresh(event: &ThreadBufferedEvent) -> bool {
+        matches!(
+            event,
+            ThreadBufferedEvent::Request(_) | ThreadBufferedEvent::LegacyWarning(_)
+        )
+    }
+
     fn new(capacity: usize) -> Self {
         Self {
-            session_configured: None,
+            session: None,
+            turns: Vec::new(),
             buffer: VecDeque::new(),
-            user_message_ids: HashSet::new(),
             pending_interactive_replay: PendingInteractiveReplayState::default(),
+            pending_local_legacy_rollbacks: VecDeque::new(),
             active_turn_id: None,
             input_state: None,
             capacity,
@@ -329,83 +499,127 @@ impl ThreadEventStore {
     }
 
     #[cfg_attr(not(test), allow(dead_code))]
-    fn new_with_session_configured(capacity: usize, event: Event) -> Self {
+    fn new_with_session(capacity: usize, session: ThreadSessionState, turns: Vec<Turn>) -> Self {
         let mut store = Self::new(capacity);
-        store.session_configured = Some(event);
+        store.session = Some(session);
+        store.set_turns(turns);
         store
     }
 
-    fn push_event(&mut self, event: Event) {
-        self.pending_interactive_replay.note_event(&event);
-        match &event.msg {
-            EventMsg::SessionConfigured(_) => {
-                self.session_configured = Some(event);
-                return;
+    fn set_session(&mut self, session: ThreadSessionState, turns: Vec<Turn>) {
+        self.session = Some(session);
+        self.set_turns(turns);
+    }
+
+    fn rebase_buffer_after_session_refresh(&mut self) {
+        self.buffer.retain(Self::event_survives_session_refresh);
+    }
+
+    fn set_turns(&mut self, turns: Vec<Turn>) {
+        self.pending_local_legacy_rollbacks.clear();
+        self.active_turn_id = turns
+            .iter()
+            .rev()
+            .find(|turn| matches!(turn.status, TurnStatus::InProgress))
+            .map(|turn| turn.id.clone());
+        self.turns = turns;
+    }
+
+    fn push_notification(&mut self, notification: ServerNotification) {
+        self.pending_interactive_replay
+            .note_server_notification(&notification);
+        match &notification {
+            ServerNotification::TurnStarted(turn) => {
+                self.active_turn_id = Some(turn.turn.id.clone());
             }
-            EventMsg::TurnStarted(turn) => {
-                self.active_turn_id = Some(turn.turn_id.clone());
-            }
-            EventMsg::TurnComplete(turn) => {
-                if self.active_turn_id.as_deref() == Some(turn.turn_id.as_str()) {
+            ServerNotification::TurnCompleted(turn) => {
+                if self.active_turn_id.as_deref() == Some(turn.turn.id.as_str()) {
                     self.active_turn_id = None;
                 }
             }
-            EventMsg::TurnAborted(turn) => {
-                if self.active_turn_id.as_deref() == turn.turn_id.as_deref() {
-                    self.active_turn_id = None;
-                }
-            }
-            EventMsg::ShutdownComplete => {
+            ServerNotification::ThreadClosed(_) => {
                 self.active_turn_id = None;
-            }
-            EventMsg::ItemCompleted(completed) => {
-                if let TurnItem::UserMessage(item) = &completed.item {
-                    if !event.id.is_empty() && self.user_message_ids.contains(&event.id) {
-                        return;
-                    }
-                    let legacy = Event {
-                        id: event.id,
-                        msg: item.as_legacy_event(),
-                    };
-                    self.push_legacy_event(legacy);
-                    return;
-                }
             }
             _ => {}
         }
-
-        self.push_legacy_event(event);
-    }
-
-    fn push_legacy_event(&mut self, event: Event) {
-        if let EventMsg::UserMessage(_) = &event.msg
-            && !event.id.is_empty()
-            && !self.user_message_ids.insert(event.id.clone())
-        {
-            return;
-        }
-        self.buffer.push_back(event);
+        self.buffer
+            .push_back(ThreadBufferedEvent::Notification(notification));
         if self.buffer.len() > self.capacity
             && let Some(removed) = self.buffer.pop_front()
+            && let ThreadBufferedEvent::Request(request) = &removed
         {
-            self.pending_interactive_replay.note_evicted_event(&removed);
-            if matches!(removed.msg, EventMsg::UserMessage(_)) && !removed.id.is_empty() {
-                self.user_message_ids.remove(&removed.id);
-            }
+            self.pending_interactive_replay
+                .note_evicted_server_request(request);
         }
+    }
+
+    fn push_request(&mut self, request: ServerRequest) {
+        self.pending_interactive_replay
+            .note_server_request(&request);
+        self.buffer.push_back(ThreadBufferedEvent::Request(request));
+        if self.buffer.len() > self.capacity
+            && let Some(removed) = self.buffer.pop_front()
+            && let ThreadBufferedEvent::Request(request) = &removed
+        {
+            self.pending_interactive_replay
+                .note_evicted_server_request(request);
+        }
+    }
+
+    fn apply_thread_rollback(&mut self, response: &ThreadRollbackResponse) {
+        self.turns = response.thread.turns.clone();
+        self.buffer.clear();
+        self.pending_interactive_replay = PendingInteractiveReplayState::default();
+        self.active_turn_id = None;
+    }
+
+    fn note_local_thread_rollback(&mut self, num_turns: u32) {
+        self.pending_local_legacy_rollbacks.push_back(num_turns);
+        while self.pending_local_legacy_rollbacks.len() > self.capacity {
+            self.pending_local_legacy_rollbacks.pop_front();
+        }
+    }
+
+    fn consume_pending_local_legacy_rollback(&mut self, num_turns: u32) -> bool {
+        match self.pending_local_legacy_rollbacks.front() {
+            Some(pending_num_turns) if *pending_num_turns == num_turns => {
+                self.pending_local_legacy_rollbacks.pop_front();
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn apply_legacy_thread_rollback(&mut self, num_turns: u32) {
+        let num_turns = usize::try_from(num_turns).unwrap_or(usize::MAX);
+        if num_turns >= self.turns.len() {
+            self.turns.clear();
+        } else {
+            self.turns
+                .truncate(self.turns.len().saturating_sub(num_turns));
+        }
+        self.buffer.clear();
+        self.pending_interactive_replay = PendingInteractiveReplayState::default();
+        self.pending_local_legacy_rollbacks.clear();
+        self.active_turn_id = None;
     }
 
     fn snapshot(&self) -> ThreadEventSnapshot {
         ThreadEventSnapshot {
-            session_configured: self.session_configured.clone(),
+            session: self.session.clone(),
+            turns: self.turns.clone(),
             // Thread switches replay buffered events into a rebuilt ChatWidget. Only replay
             // interactive prompts that are still pending, or answered approvals/input will reappear.
             events: self
                 .buffer
                 .iter()
-                .filter(|event| {
-                    self.pending_interactive_replay
-                        .should_replay_snapshot_event(event)
+                .filter(|event| match event {
+                    ThreadBufferedEvent::Request(request) => self
+                        .pending_interactive_replay
+                        .should_replay_snapshot_request(request),
+                    ThreadBufferedEvent::Notification(_)
+                    | ThreadBufferedEvent::LegacyWarning(_)
+                    | ThreadBufferedEvent::LegacyRollback { .. } => true,
                 })
                 .cloned()
                 .collect(),
@@ -420,20 +634,11 @@ impl ThreadEventStore {
         self.pending_interactive_replay.note_outbound_op(op);
     }
 
-    fn note_exec_approval_resolved(&mut self, approval_id: &str) {
-        self.pending_interactive_replay
-            .note_exec_approval_resolved(approval_id);
-    }
-
     fn op_can_change_pending_replay_state<T>(op: T) -> bool
     where
         T: Into<AppCommand>,
     {
         PendingInteractiveReplayState::op_can_change_state(op)
-    }
-
-    fn event_can_change_pending_thread_approvals(event: &Event) -> bool {
-        PendingInteractiveReplayState::event_can_change_pending_thread_approvals(event)
     }
 
     fn has_pending_thread_approvals(&self) -> bool {
@@ -448,8 +653,8 @@ impl ThreadEventStore {
 
 #[derive(Debug)]
 struct ThreadEventChannel {
-    sender: mpsc::Sender<Event>,
-    receiver: Option<mpsc::Receiver<Event>>,
+    sender: mpsc::Sender<ThreadBufferedEvent>,
+    receiver: Option<mpsc::Receiver<ThreadBufferedEvent>>,
     store: Arc<Mutex<ThreadEventStore>>,
 }
 
@@ -464,13 +669,13 @@ impl ThreadEventChannel {
     }
 
     #[cfg_attr(not(test), allow(dead_code))]
-    fn new_with_session_configured(capacity: usize, event: Event) -> Self {
+    fn new_with_session(capacity: usize, session: ThreadSessionState, turns: Vec<Turn>) -> Self {
         let (sender, receiver) = mpsc::channel(capacity);
         Self {
             sender,
             receiver: Some(receiver),
-            store: Arc::new(Mutex::new(ThreadEventStore::new_with_session_configured(
-                capacity, event,
+            store: Arc::new(Mutex::new(ThreadEventStore::new_with_session(
+                capacity, session, turns,
             ))),
         }
     }
@@ -750,12 +955,6 @@ pub(crate) struct App {
     /// Set when the user confirms an update; propagated on exit.
     pub(crate) pending_update_action: Option<UpdateAction>,
 
-    /// One-shot guard used while switching threads.
-    ///
-    /// We set this when intentionally stopping the current thread before moving
-    /// to another one, then ignore exactly one `ShutdownComplete` so it is not
-    /// misclassified as an unexpected sub-agent death.
-    suppress_shutdown_complete: bool,
     /// Tracks the thread we intentionally shut down while exiting the app.
     ///
     /// When this matches the active thread, its `ShutdownComplete` should lead to
@@ -772,10 +971,10 @@ pub(crate) struct App {
     thread_event_listener_tasks: HashMap<ThreadId, JoinHandle<()>>,
     agent_navigation: AgentNavigationState,
     active_thread_id: Option<ThreadId>,
-    active_thread_rx: Option<mpsc::Receiver<Event>>,
+    active_thread_rx: Option<mpsc::Receiver<ThreadBufferedEvent>>,
     primary_thread_id: Option<ThreadId>,
-    primary_session_configured: Option<SessionConfiguredEvent>,
-    pending_primary_events: VecDeque<Event>,
+    primary_session_configured: Option<ThreadSessionState>,
+    pending_primary_events: VecDeque<ThreadBufferedEvent>,
     pending_app_server_requests: PendingAppServerRequests,
 }
 
@@ -1342,7 +1541,7 @@ impl App {
     async fn activate_thread_for_replay(
         &mut self,
         thread_id: ThreadId,
-    ) -> Option<(mpsc::Receiver<Event>, ThreadEventSnapshot)> {
+    ) -> Option<(mpsc::Receiver<ThreadBufferedEvent>, ThreadEventSnapshot)> {
         let channel = self.thread_event_channels.get_mut(&thread_id)?;
         let receiver = channel.receiver.take()?;
         let mut store = channel.store.lock().await;
@@ -1383,12 +1582,18 @@ impl App {
         }
 
         self.pending_primary_events.retain(|event| {
-            let EventMsg::ExecApprovalRequest(approval) = &event.msg else {
+            let ThreadBufferedEvent::Request(ServerRequest::CommandExecutionRequestApproval {
+                params,
+                ..
+            }) = event
+            else {
                 return true;
             };
-            !resolved
-                .exec_approval_ids
-                .contains(&approval.effective_approval_id())
+            let approval_id = params
+                .approval_id
+                .clone()
+                .unwrap_or_else(|| params.item_id.clone());
+            !resolved.exec_approval_ids.contains(&approval_id)
         });
         self.chat_widget
             .remove_resolved_exec_approvals(&resolved.exec_approval_ids);
@@ -1396,7 +1601,9 @@ impl App {
         for channel in self.thread_event_channels.values() {
             let mut store = channel.store.lock().await;
             for approval_id in &resolved.exec_approval_ids {
-                store.note_exec_approval_resolved(approval_id);
+                store
+                    .pending_interactive_replay
+                    .note_exec_approval_resolved(approval_id);
             }
         }
 
@@ -1462,85 +1669,122 @@ impl App {
     async fn thread_cwd(&self, thread_id: ThreadId) -> Option<PathBuf> {
         let channel = self.thread_event_channels.get(&thread_id)?;
         let store = channel.store.lock().await;
-        match store.session_configured.as_ref().map(|event| &event.msg) {
-            Some(EventMsg::SessionConfigured(session)) => Some(session.cwd.clone()),
-            _ => None,
-        }
+        store.session.as_ref().map(|session| session.cwd.clone())
     }
 
-    async fn interactive_request_for_thread_event(
+    async fn interactive_request_for_thread_request(
         &self,
         thread_id: ThreadId,
-        event: &Event,
+        request: &ServerRequest,
     ) -> Option<ThreadInteractiveRequest> {
         let thread_label = Some(self.thread_label(thread_id));
-        match &event.msg {
-            EventMsg::ExecApprovalRequest(ev) => {
+        match request {
+            ServerRequest::CommandExecutionRequestApproval { params, .. } => {
+                let network_approval_context = params
+                    .network_approval_context
+                    .clone()
+                    .and_then(convert_via_json);
+                let additional_permissions = params
+                    .additional_permissions
+                    .clone()
+                    .and_then(convert_via_json);
+                let proposed_execpolicy_amendment = params
+                    .proposed_execpolicy_amendment
+                    .clone()
+                    .map(codex_app_server_protocol::ExecPolicyAmendment::into_core);
+                let proposed_network_policy_amendments = params
+                    .proposed_network_policy_amendments
+                    .clone()
+                    .map(|amendments| {
+                        amendments
+                            .into_iter()
+                            .map(codex_app_server_protocol::NetworkPolicyAmendment::into_core)
+                            .collect::<Vec<_>>()
+                    });
                 Some(ThreadInteractiveRequest::Approval(ApprovalRequest::Exec {
                     thread_id,
                     thread_label,
-                    id: ev.effective_approval_id(),
-                    command: ev.command.clone(),
-                    reason: ev.reason.clone(),
-                    available_decisions: ev.effective_available_decisions(),
-                    network_approval_context: ev.network_approval_context.clone(),
-                    additional_permissions: ev.additional_permissions.clone(),
+                    id: params
+                        .approval_id
+                        .clone()
+                        .unwrap_or_else(|| params.item_id.clone()),
+                    command: params.command.clone().into_iter().collect(),
+                    reason: params.reason.clone(),
+                    available_decisions: params
+                        .available_decisions
+                        .clone()
+                        .map(|decisions| {
+                            decisions
+                                .into_iter()
+                                .map(command_execution_decision_to_review_decision)
+                                .collect()
+                        })
+                        .unwrap_or_else(|| {
+                            default_exec_approval_decisions(
+                                network_approval_context.as_ref(),
+                                proposed_execpolicy_amendment.as_ref(),
+                                proposed_network_policy_amendments.as_deref(),
+                                additional_permissions.as_ref(),
+                            )
+                        }),
+                    network_approval_context,
+                    additional_permissions,
                 }))
             }
-            EventMsg::ApplyPatchApprovalRequest(ev) => Some(ThreadInteractiveRequest::Approval(
-                ApprovalRequest::ApplyPatch {
+            ServerRequest::FileChangeRequestApproval { params, .. } => Some(
+                ThreadInteractiveRequest::Approval(ApprovalRequest::ApplyPatch {
                     thread_id,
                     thread_label,
-                    id: ev.call_id.clone(),
-                    reason: ev.reason.clone(),
+                    id: params.item_id.clone(),
+                    reason: params.reason.clone(),
                     cwd: self
                         .thread_cwd(thread_id)
                         .await
                         .unwrap_or_else(|| self.config.cwd.clone()),
-                    changes: ev.changes.clone(),
-                },
-            )),
-            EventMsg::ElicitationRequest(ev) => {
-                if let Some(request) =
-                    McpServerElicitationFormRequest::from_event(thread_id, ev.clone())
-                {
+                    changes: HashMap::new(),
+                }),
+            ),
+            ServerRequest::McpServerElicitationRequest { request_id, params } => {
+                if let Some(request) = McpServerElicitationFormRequest::from_app_server_request(
+                    thread_id,
+                    app_server_request_id_to_mcp_request_id(request_id),
+                    params.clone(),
+                ) {
                     Some(ThreadInteractiveRequest::McpServerElicitation(request))
                 } else {
                     Some(ThreadInteractiveRequest::Approval(
                         ApprovalRequest::McpElicitation {
                             thread_id,
                             thread_label,
-                            server_name: ev.server_name.clone(),
-                            request_id: ev.id.clone(),
-                            message: ev.request.message().to_string(),
+                            server_name: params.server_name.clone(),
+                            request_id: app_server_request_id_to_mcp_request_id(request_id),
+                            message: match &params.request {
+                                codex_app_server_protocol::McpServerElicitationRequest::Form {
+                                    message,
+                                    ..
+                                }
+                                | codex_app_server_protocol::McpServerElicitationRequest::Url {
+                                    message,
+                                    ..
+                                } => message.clone(),
+                            },
                         },
                     ))
                 }
             }
-            EventMsg::RequestPermissions(ev) => Some(ThreadInteractiveRequest::Approval(
-                ApprovalRequest::Permissions {
+            ServerRequest::PermissionsRequestApproval { params, .. } => Some(
+                ThreadInteractiveRequest::Approval(ApprovalRequest::Permissions {
                     thread_id,
                     thread_label,
-                    call_id: ev.call_id.clone(),
-                    reason: ev.reason.clone(),
-                    permissions: ev.permissions.clone(),
-                },
-            )),
+                    call_id: params.item_id.clone(),
+                    reason: params.reason.clone(),
+                    permissions: serde_json::from_value(
+                        serde_json::to_value(&params.permissions).ok()?,
+                    )
+                    .ok()?,
+                }),
+            ),
             _ => None,
-        }
-    }
-
-    async fn submit_op_to_thread(&mut self, thread_id: ThreadId, op: AppCommand) {
-        let replay_state_op =
-            ThreadEventStore::op_can_change_pending_replay_state(&op).then(|| op.clone());
-        crate::session_log::log_outbound_op(&op);
-        let submitted = false;
-        self.chat_widget.add_error_message(format!(
-            "Not available in app-server TUI yet for thread {thread_id}."
-        ));
-        if submitted && let Some(op) = replay_state_op.as_ref() {
-            self.note_thread_outbound_op(thread_id, op).await;
-            self.refresh_pending_thread_approvals().await;
         }
     }
 
@@ -1588,7 +1832,9 @@ impl App {
             return Ok(());
         }
 
-        self.submit_op_to_thread(thread_id, op).await;
+        self.chat_widget.add_error_message(format!(
+            "Not available in app-server TUI yet for thread {thread_id}."
+        ));
         Ok(())
     }
 
@@ -1777,79 +2023,7 @@ impl App {
                         per_cwd_extra_user_roots: None,
                     })
                     .await?;
-                self.handle_codex_event_now(Event {
-                    id: String::new(),
-                    msg: EventMsg::ListSkillsResponse(ListSkillsResponseEvent {
-                        skills: response
-                            .data
-                            .into_iter()
-                            .map(|entry| codex_protocol::protocol::SkillsListEntry {
-                                cwd: entry.cwd,
-                                skills: entry
-                                    .skills
-                                    .into_iter()
-                                    .map(|skill| codex_protocol::protocol::SkillMetadata {
-                                        name: skill.name,
-                                        description: skill.description,
-                                        short_description: skill.short_description,
-                                        interface: skill.interface.map(|interface| {
-                                            codex_protocol::protocol::SkillInterface {
-                                                display_name: interface.display_name,
-                                                short_description: interface.short_description,
-                                                icon_small: interface.icon_small,
-                                                icon_large: interface.icon_large,
-                                                brand_color: interface.brand_color,
-                                                default_prompt: interface.default_prompt,
-                                            }
-                                        }),
-                                        dependencies: skill.dependencies.map(|dependencies| {
-                                            codex_protocol::protocol::SkillDependencies {
-                                                tools: dependencies
-                                                    .tools
-                                                    .into_iter()
-                                                    .map(|tool| {
-                                                        codex_protocol::protocol::SkillToolDependency {
-                                                            r#type: tool.r#type,
-                                                            value: tool.value,
-                                                            description: tool.description,
-                                                            transport: tool.transport,
-                                                            command: tool.command,
-                                                            url: tool.url,
-                                                        }
-                                                    })
-                                                    .collect(),
-                                            }
-                                        }),
-                                        path: skill.path,
-                                        scope: match skill.scope {
-                                            codex_app_server_protocol::SkillScope::User => {
-                                                codex_protocol::protocol::SkillScope::User
-                                            }
-                                            codex_app_server_protocol::SkillScope::Repo => {
-                                                codex_protocol::protocol::SkillScope::Repo
-                                            }
-                                            codex_app_server_protocol::SkillScope::System => {
-                                                codex_protocol::protocol::SkillScope::System
-                                            }
-                                            codex_app_server_protocol::SkillScope::Admin => {
-                                                codex_protocol::protocol::SkillScope::Admin
-                                            }
-                                        },
-                                        enabled: skill.enabled,
-                                    })
-                                    .collect(),
-                                errors: entry
-                                    .errors
-                                    .into_iter()
-                                    .map(|error| codex_protocol::protocol::SkillErrorInfo {
-                                        path: error.path,
-                                        message: error.message,
-                                    })
-                                    .collect(),
-                            })
-                            .collect(),
-                    }),
-                });
+                self.handle_skills_list_response(response);
                 Ok(true)
             }
             AppCommandView::Compact => {
@@ -1863,7 +2037,15 @@ impl App {
                 Ok(true)
             }
             AppCommandView::ThreadRollback { num_turns } => {
-                app_server.thread_rollback(thread_id, num_turns).await?;
+                let response = match app_server.thread_rollback(thread_id, num_turns).await {
+                    Ok(response) => response,
+                    Err(err) => {
+                        self.handle_backtrack_rollback_failed();
+                        return Err(err);
+                    }
+                };
+                self.handle_thread_rollback_response(thread_id, num_turns, &response)
+                    .await;
                 Ok(true)
             }
             AppCommandView::Review { review_request } => {
@@ -1974,11 +2156,89 @@ impl App {
         self.chat_widget.set_pending_thread_approvals(threads);
     }
 
-    async fn enqueue_thread_event(&mut self, thread_id: ThreadId, event: Event) -> Result<()> {
-        let refresh_pending_thread_approvals =
-            ThreadEventStore::event_can_change_pending_thread_approvals(&event);
+    async fn enqueue_thread_notification(
+        &mut self,
+        thread_id: ThreadId,
+        notification: ServerNotification,
+    ) -> Result<()> {
+        let inferred_session = self
+            .infer_session_for_thread_notification(thread_id, &notification)
+            .await;
+        let (sender, store) = {
+            let channel = self.ensure_thread_channel(thread_id);
+            (channel.sender.clone(), Arc::clone(&channel.store))
+        };
+
+        let should_send = {
+            let mut guard = store.lock().await;
+            if guard.session.is_none()
+                && let Some(session) = inferred_session
+            {
+                guard.session = Some(session);
+            }
+            guard.push_notification(notification.clone());
+            guard.active
+        };
+
+        if should_send {
+            match sender.try_send(ThreadBufferedEvent::Notification(notification)) {
+                Ok(()) => {}
+                Err(TrySendError::Full(event)) => {
+                    tokio::spawn(async move {
+                        if let Err(err) = sender.send(event).await {
+                            tracing::warn!("thread {thread_id} event channel closed: {err}");
+                        }
+                    });
+                }
+                Err(TrySendError::Closed(_)) => {
+                    tracing::warn!("thread {thread_id} event channel closed");
+                }
+            }
+        }
+        self.refresh_pending_thread_approvals().await;
+        Ok(())
+    }
+
+    async fn infer_session_for_thread_notification(
+        &mut self,
+        thread_id: ThreadId,
+        notification: &ServerNotification,
+    ) -> Option<ThreadSessionState> {
+        let ServerNotification::ThreadStarted(notification) = notification else {
+            return None;
+        };
+        let mut session = self.primary_session_configured.clone()?;
+        session.thread_id = thread_id;
+        session.thread_name = notification.thread.name.clone();
+        session.model_provider_id = notification.thread.model_provider.clone();
+        session.cwd = notification.thread.cwd.clone();
+        let rollout_path = notification.thread.path.clone();
+        if let Some(model) =
+            read_session_model(&self.config, thread_id, rollout_path.as_deref()).await
+        {
+            session.model = model;
+        } else if rollout_path.is_some() {
+            session.model.clear();
+        }
+        session.history_log_id = 0;
+        session.history_entry_count = 0;
+        session.rollout_path = rollout_path;
+        self.upsert_agent_picker_thread(
+            thread_id,
+            notification.thread.agent_nickname.clone(),
+            notification.thread.agent_role.clone(),
+            /*is_closed*/ false,
+        );
+        Some(session)
+    }
+
+    async fn enqueue_thread_request(
+        &mut self,
+        thread_id: ThreadId,
+        request: ServerRequest,
+    ) -> Result<()> {
         let inactive_interactive_request = if self.active_thread_id != Some(thread_id) {
-            self.interactive_request_for_thread_event(thread_id, &event)
+            self.interactive_request_for_thread_request(thread_id, &request)
                 .await
         } else {
             None
@@ -1990,15 +2250,12 @@ impl App {
 
         let should_send = {
             let mut guard = store.lock().await;
-            guard.push_event(event.clone());
+            guard.push_request(request.clone());
             guard.active
         };
 
         if should_send {
-            // Never await a bounded channel send on the main TUI loop: if the receiver falls behind,
-            // `send().await` can block and the UI stops drawing. If the channel is full, wait in a
-            // spawned task instead.
-            match sender.try_send(event) {
+            match sender.try_send(ThreadBufferedEvent::Request(request)) {
                 Ok(()) => {}
                 Err(TrySendError::Full(event)) => {
                     tokio::spawn(async move {
@@ -2022,29 +2279,14 @@ impl App {
                 }
             }
         }
-        if refresh_pending_thread_approvals {
-            self.refresh_pending_thread_approvals().await;
-        }
+        self.refresh_pending_thread_approvals().await;
         Ok(())
     }
 
-    async fn handle_routed_thread_event(
+    async fn enqueue_thread_legacy_warning(
         &mut self,
         thread_id: ThreadId,
-        event: Event,
-    ) -> Result<()> {
-        if !self.thread_event_channels.contains_key(&thread_id) {
-            tracing::debug!("dropping stale event for untracked thread {thread_id}");
-            return Ok(());
-        }
-
-        self.enqueue_thread_event(thread_id, event).await
-    }
-
-    async fn enqueue_thread_history_entry_response(
-        &mut self,
-        thread_id: ThreadId,
-        event: GetHistoryEntryResponseEvent,
+        message: String,
     ) -> Result<()> {
         let (sender, store) = {
             let channel = self.ensure_thread_channel(thread_id);
@@ -2055,7 +2297,7 @@ impl App {
             let mut guard = store.lock().await;
             guard
                 .buffer
-                .push_back(ThreadBufferedEvent::HistoryEntryResponse(event.clone()));
+                .push_back(ThreadBufferedEvent::LegacyWarning(message.clone()));
             if guard.buffer.len() > guard.capacity
                 && let Some(removed) = guard.buffer.pop_front()
                 && let ThreadBufferedEvent::Request(request) = &removed
@@ -2068,7 +2310,7 @@ impl App {
         };
 
         if should_send {
-            match sender.try_send(ThreadBufferedEvent::HistoryEntryResponse(event)) {
+            match sender.try_send(ThreadBufferedEvent::LegacyWarning(message)) {
                 Ok(()) => {}
                 Err(TrySendError::Full(event)) => {
                     tokio::spawn(async move {
@@ -2125,20 +2367,24 @@ impl App {
 
     async fn enqueue_primary_thread_legacy_warning(&mut self, message: String) -> Result<()> {
         if let Some(thread_id) = self.primary_thread_id {
-            return self.enqueue_thread_event(thread_id, event).await;
+            return self.enqueue_thread_legacy_warning(thread_id, message).await;
         }
+        self.pending_primary_events
+            .push_back(ThreadBufferedEvent::LegacyWarning(message));
+        Ok(())
+    }
 
-        if let EventMsg::SessionConfigured(session) = &event.msg {
-            let thread_id = session.session_id;
-            self.primary_thread_id = Some(thread_id);
-            self.primary_session_configured = Some(session.clone());
-            self.upsert_agent_picker_thread(
-                thread_id, /*agent_nickname*/ None, /*agent_role*/ None,
-                /*is_closed*/ false,
-            );
-            self.ensure_thread_channel(thread_id);
-            self.activate_thread_channel(thread_id).await;
-            self.enqueue_thread_event(thread_id, event).await?;
+    async fn enqueue_primary_thread_legacy_rollback(&mut self, num_turns: u32) -> Result<()> {
+        if let Some(thread_id) = self.primary_thread_id {
+            return self
+                .enqueue_thread_legacy_rollback(thread_id, num_turns)
+                .await;
+        }
+        self.pending_primary_events
+            .push_back(ThreadBufferedEvent::LegacyRollback { num_turns });
+        Ok(())
+    }
+
     async fn enqueue_primary_thread_session(
         &mut self,
         session: ThreadSessionState,
@@ -2172,10 +2418,6 @@ impl App {
                 ThreadBufferedEvent::Request(request) => {
                     self.enqueue_thread_request(thread_id, request).await?;
                 }
-                ThreadBufferedEvent::HistoryEntryResponse(event) => {
-                    self.enqueue_thread_history_entry_response(thread_id, event)
-                        .await?;
-                }
                 ThreadBufferedEvent::LegacyWarning(message) => {
                     self.enqueue_thread_legacy_warning(thread_id, message)
                         .await?;
@@ -2185,10 +2427,86 @@ impl App {
                         .await?;
                 }
             }
-        } else {
-            self.pending_primary_events.push_back(event);
         }
+        self.chat_widget
+            .set_initial_user_message_submit_suppressed(/*suppressed*/ false);
+        self.chat_widget.submit_initial_user_message_if_pending();
         Ok(())
+    }
+
+    async fn enqueue_primary_thread_notification(
+        &mut self,
+        notification: ServerNotification,
+    ) -> Result<()> {
+        if let Some(thread_id) = self.primary_thread_id {
+            return self
+                .enqueue_thread_notification(thread_id, notification)
+                .await;
+        }
+        self.pending_primary_events
+            .push_back(ThreadBufferedEvent::Notification(notification));
+        Ok(())
+    }
+
+    async fn enqueue_primary_thread_request(&mut self, request: ServerRequest) -> Result<()> {
+        if let Some(thread_id) = self.primary_thread_id {
+            return self.enqueue_thread_request(thread_id, request).await;
+        }
+        self.pending_primary_events
+            .push_back(ThreadBufferedEvent::Request(request));
+        Ok(())
+    }
+
+    async fn refresh_snapshot_session_if_needed(
+        &mut self,
+        app_server: &mut AppServerSession,
+        thread_id: ThreadId,
+        is_replay_only: bool,
+        snapshot: &mut ThreadEventSnapshot,
+    ) {
+        let should_refresh = !is_replay_only
+            && snapshot.session.as_ref().is_none_or(|session| {
+                session.model.trim().is_empty() || session.rollout_path.is_none()
+            });
+        if !should_refresh {
+            return;
+        }
+
+        match app_server
+            .resume_thread(self.config.clone(), thread_id)
+            .await
+        {
+            Ok(started) => {
+                self.apply_refreshed_snapshot_thread(thread_id, started, snapshot)
+                    .await
+            }
+            Err(err) => {
+                tracing::warn!(
+                    thread_id = %thread_id,
+                    error = %err,
+                    "failed to refresh inferred thread session before replay"
+                );
+            }
+        }
+    }
+
+    async fn apply_refreshed_snapshot_thread(
+        &mut self,
+        thread_id: ThreadId,
+        started: AppServerStartedThread,
+        snapshot: &mut ThreadEventSnapshot,
+    ) {
+        let AppServerStartedThread { session, turns } = started;
+        if let Some(channel) = self.thread_event_channels.get(&thread_id) {
+            let mut store = channel.store.lock().await;
+            store.set_session(session.clone(), turns.clone());
+            store.rebase_buffer_after_session_refresh();
+        }
+        snapshot.session = Some(session);
+        snapshot.turns = turns;
+        snapshot
+            .events
+            .retain(ThreadEventStore::event_survives_session_refresh);
     }
 
     /// Opens the `/agent` picker after refreshing cached labels for known threads.
@@ -2294,7 +2612,12 @@ impl App {
         self.sync_active_agent_label();
     }
 
-    async fn select_agent_thread(&mut self, tui: &mut tui::Tui, thread_id: ThreadId) -> Result<()> {
+    async fn select_agent_thread(
+        &mut self,
+        tui: &mut tui::Tui,
+        app_server: &mut AppServerSession,
+        thread_id: ThreadId,
+    ) -> Result<()> {
         if self.active_thread_id == Some(thread_id) {
             return Ok(());
         }
@@ -2312,7 +2635,8 @@ impl App {
         let previous_thread_id = self.active_thread_id;
         self.store_active_thread_receiver().await;
         self.active_thread_id = None;
-        let Some((receiver, snapshot)) = self.activate_thread_for_replay(thread_id).await else {
+        let Some((receiver, mut snapshot)) = self.activate_thread_for_replay(thread_id).await
+        else {
             self.chat_widget
                 .add_error_message(format!("Agent thread {thread_id} is already active."));
             if let Some(previous_thread_id) = previous_thread_id {
@@ -2320,6 +2644,14 @@ impl App {
             }
             return Ok(());
         };
+
+        self.refresh_snapshot_session_if_needed(
+            app_server,
+            thread_id,
+            is_replay_only,
+            &mut snapshot,
+        )
+        .await;
 
         self.active_thread_id = Some(thread_id);
         self.active_thread_rx = Some(receiver);
@@ -2429,66 +2761,8 @@ impl App {
         let init = self.chatwidget_init_for_forked_or_resumed_thread(tui, self.config.clone());
         self.chat_widget = ChatWidget::new_with_app_event(init);
         self.reset_thread_event_state();
-        self.restore_started_app_server_thread(started).await
-    }
-
-    /// Hydrate thread state from an `AppServerStartedThread` returned by the
-    /// app-server start/resume/fork handshake.
-    ///
-    /// This is the single path that every session-start variant funnels
-    /// through. It performs four things in order:
-    ///
-    /// 1. Converts the `Thread` snapshot into protocol-level `Event`s.
-    /// 2. Builds a **lossless** replay snapshot from a temporary store so that
-    ///    the initial render sees all history even when the thread has more
-    ///    turns than the bounded channel capacity.
-    /// 3. Pushes the same events into the real channel store for backtrack and
-    ///    navigation.
-    /// 4. Activates the thread channel and replays the snapshot into the chat
-    ///    widget.
-    async fn restore_started_app_server_thread(
-        &mut self,
-        started: AppServerStartedThread,
-    ) -> Result<()> {
-        let session_configured = started.session_configured;
-        let thread_id = session_configured.session_id;
-        let session_event = Event {
-            id: String::new(),
-            msg: EventMsg::SessionConfigured(session_configured.clone()),
-        };
-        let history_events =
-            thread_snapshot_events(&started.thread, started.show_raw_agent_reasoning);
-        let replay_snapshot = {
-            let mut replay_store = ThreadEventStore::new(history_events.len().saturating_add(1));
-            replay_store.push_event(session_event.clone());
-            for event in &history_events {
-                replay_store.push_event(event.clone());
-            }
-            replay_store.snapshot()
-        };
-
-        self.primary_thread_id = Some(thread_id);
-        self.primary_session_configured = Some(session_configured);
-        self.upsert_agent_picker_thread(
-            thread_id, /*agent_nickname*/ None, /*agent_role*/ None,
-            /*is_closed*/ false,
-        );
-
-        let store = {
-            let channel = self.ensure_thread_channel(thread_id);
-            Arc::clone(&channel.store)
-        };
-        {
-            let mut store = store.lock().await;
-            store.push_event(session_event);
-            for event in history_events {
-                store.push_event(event);
-            }
-        }
-
-        self.activate_thread_channel(thread_id).await;
-        self.replay_thread_snapshot(replay_snapshot, /*resume_restored_queue*/ false);
-        Ok(())
+        self.enqueue_primary_thread_session(started.session, started.turns)
+            .await
     }
 
     fn fresh_session_config(&self) -> Config {
@@ -2505,7 +2779,7 @@ impl App {
         let mut disconnected = false;
         loop {
             match rx.try_recv() {
-                Ok(event) => self.handle_codex_event_now(event),
+                Ok(event) => self.handle_thread_event_now(event),
                 Err(TryRecvError::Empty) => break,
                 Err(TryRecvError::Disconnected) => {
                     disconnected = true;
@@ -2534,11 +2808,14 @@ impl App {
     /// here so Ctrl+C-like exits don't accidentally resurrect the main thread.
     ///
     /// Failover is only eligible when all of these are true:
-    /// 1. the event is `ShutdownComplete`;
+    /// 1. the event is `thread/closed`;
     /// 2. the active thread differs from the primary thread;
     /// 3. the active thread is not the pending shutdown-exit thread.
-    fn active_non_primary_shutdown_target(&self, msg: &EventMsg) -> Option<(ThreadId, ThreadId)> {
-        if !matches!(msg, EventMsg::ShutdownComplete) {
+    fn active_non_primary_shutdown_target(
+        &self,
+        notification: &ServerNotification,
+    ) -> Option<(ThreadId, ThreadId)> {
+        if !matches!(notification, ServerNotification::ThreadClosed(_)) {
             return None;
         }
         let active_thread_id = self.active_thread_id?;
@@ -2554,17 +2831,19 @@ impl App {
         snapshot: ThreadEventSnapshot,
         resume_restored_queue: bool,
     ) {
-        self.chat_widget
-            .set_initial_user_message_submit_suppressed(/*suppressed*/ true);
-        if let Some(event) = snapshot.session_configured {
-            self.handle_codex_event_replay(event);
+        if let Some(session) = snapshot.session {
+            self.chat_widget.handle_thread_session(session);
         }
         self.chat_widget
             .set_queue_autosend_suppressed(/*suppressed*/ true);
         self.chat_widget
             .restore_thread_input_state(snapshot.input_state);
+        if !snapshot.turns.is_empty() {
+            self.chat_widget
+                .replay_thread_turns(snapshot.turns, ReplayKind::ThreadSnapshot);
+        }
         for event in snapshot.events {
-            self.handle_codex_event_replay(event);
+            self.handle_thread_event_replay(event);
         }
         self.chat_widget
             .set_queue_autosend_suppressed(/*suppressed*/ false);
@@ -2618,6 +2897,7 @@ impl App {
         let (app_event_tx, mut app_event_rx) = unbounded_channel();
         let app_event_tx = AppEventSender::new(app_event_tx);
         emit_project_config_warnings(&app_event_tx, &config);
+        emit_missing_system_bwrap_warning(&app_event_tx);
         tui.set_notification_method(config.tui_notification_method);
 
         let harness_overrides =
@@ -2714,7 +2994,7 @@ impl App {
                     status_line_invalid_items_warned: status_line_invalid_items_warned.clone(),
                     session_telemetry: session_telemetry.clone(),
                 };
-                (ChatWidget::new_with_app_event(init), started)
+                (ChatWidget::new_with_app_event(init), Some(started))
             }
             SessionSelection::Resume(target_session) => {
                 let resumed = app_server
@@ -2747,7 +3027,7 @@ impl App {
                     status_line_invalid_items_warned: status_line_invalid_items_warned.clone(),
                     session_telemetry: session_telemetry.clone(),
                 };
-                (ChatWidget::new_with_app_event(init), resumed)
+                (ChatWidget::new_with_app_event(init), Some(resumed))
             }
             SessionSelection::Fork(target_session) => {
                 session_telemetry.counter(
@@ -2785,7 +3065,7 @@ impl App {
                     status_line_invalid_items_warned: status_line_invalid_items_warned.clone(),
                     session_telemetry: session_telemetry.clone(),
                 };
-                (ChatWidget::new_with_app_event(init), forked)
+                (ChatWidget::new_with_app_event(init), Some(forked))
             }
         };
 
@@ -2824,7 +3104,6 @@ impl App {
             feedback_audience,
             remote_app_server_url,
             pending_update_action: None,
-            suppress_shutdown_complete: false,
             pending_shutdown_exit_thread_id: None,
             windows_sandbox: WindowsSandboxState::default(),
             thread_event_channels: HashMap::new(),
@@ -2837,8 +3116,10 @@ impl App {
             pending_primary_events: VecDeque::new(),
             pending_app_server_requests: PendingAppServerRequests::default(),
         };
-        app.restore_started_app_server_thread(initial_started_thread)
-            .await?;
+        if let Some(started) = initial_started_thread {
+            app.enqueue_primary_thread_session(started.session, started.turns)
+                .await?;
+        }
 
         // On startup, if Agent mode (workspace-write) or ReadOnly is active, warn about world-writable dirs on Windows.
         #[cfg(target_os = "windows")]
@@ -2917,7 +3198,7 @@ impl App {
                         app.active_thread_rx.is_some()
                     ) => {
                         if let Some(event) = active {
-                            if let Err(err) = app.handle_active_thread_event(tui, event).await {
+                            if let Err(err) = app.handle_active_thread_event(tui, &mut app_server, event).await {
                                 break Err(err);
                             }
                         } else {
@@ -2926,7 +3207,7 @@ impl App {
                         AppRunControl::Continue
                     }
                     Some(event) = tui_events.next() => {
-                        match app.handle_tui_event(tui, event).await {
+                        match app.handle_tui_event(tui, &mut app_server, event).await {
                             Ok(control) => control,
                             Err(err) => break Err(err),
                         }
@@ -2982,6 +3263,7 @@ impl App {
     pub(crate) async fn handle_tui_event(
         &mut self,
         tui: &mut tui::Tui,
+        app_server: &mut AppServerSession,
         event: TuiEvent,
     ) -> Result<AppRunControl> {
         if matches!(event, TuiEvent::Draw) {
@@ -2996,7 +3278,7 @@ impl App {
         } else {
             match event {
                 TuiEvent::Key(key_event) => {
-                    self.handle_key_event(tui, key_event).await;
+                    self.handle_key_event(tui, app_server, key_event).await;
                 }
                 TuiEvent::Paste(pasted) => {
                     // Many terminals convert newlines to \r when pasting (e.g., iTerm2),
@@ -3287,12 +3569,6 @@ impl App {
             AppEvent::CommitTick => {
                 self.chat_widget.on_commit_tick();
             }
-            AppEvent::CodexEvent(event) => {
-                self.enqueue_primary_event(event).await?;
-            }
-            AppEvent::ThreadEvent { thread_id, event } => {
-                self.handle_routed_thread_event(thread_id, event).await?;
-            }
             AppEvent::Exit(mode) => {
                 return Ok(self.handle_exit_mode(app_server, mode).await);
             }
@@ -3354,6 +3630,12 @@ impl App {
             }
             AppEvent::RefreshConnectors { force_refetch } => {
                 self.chat_widget.refresh_connectors(force_refetch);
+            }
+            AppEvent::FetchMcpInventory => {
+                self.fetch_mcp_inventory(app_server);
+            }
+            AppEvent::McpInventoryLoaded { result } => {
+                self.handle_mcp_inventory_result(result);
             }
             AppEvent::StartFileSearch(query) => {
                 self.file_search.on_user_query(query);
@@ -4138,7 +4420,7 @@ impl App {
                 self.open_agent_picker().await;
             }
             AppEvent::SelectAgentThread(thread_id) => {
-                self.select_agent_thread(tui, thread_id).await?;
+                self.select_agent_thread(tui, app_server, thread_id).await?;
             }
             AppEvent::OpenSkillsList => {
                 self.chat_widget.open_skills_list();
@@ -4402,33 +4684,94 @@ impl App {
         }
     }
 
-    fn handle_codex_event_now(&mut self, event: Event) {
-        let needs_refresh = matches!(
-            event.msg,
-            EventMsg::SessionConfigured(_) | EventMsg::TurnStarted(_) | EventMsg::TokenCount(_)
-        );
-        // This guard is only for intentional thread-switch shutdowns.
-        // App-exit shutdowns are tracked by `pending_shutdown_exit_thread_id`
-        // and resolved in `handle_active_thread_event`.
-        if self.suppress_shutdown_complete && matches!(event.msg, EventMsg::ShutdownComplete) {
-            self.suppress_shutdown_complete = false;
-            return;
-        }
-        if let EventMsg::ListSkillsResponse(response) = &event.msg {
-            let cwd = self.chat_widget.config_ref().cwd.clone();
-            let errors = errors_for_cwd(&cwd, response);
-            emit_skill_load_warnings(&self.app_event_tx, &errors);
-        }
-        self.handle_backtrack_event(&event.msg);
-        self.chat_widget.handle_codex_event(event);
+    fn handle_skills_list_response(&mut self, response: SkillsListResponse) {
+        let response = list_skills_response_to_core(response);
+        let cwd = self.chat_widget.config_ref().cwd.clone();
+        let errors = errors_for_cwd(&cwd, &response);
+        emit_skill_load_warnings(&self.app_event_tx, &errors);
+        self.chat_widget.handle_skills_list_response(response);
+    }
 
+    async fn handle_thread_rollback_response(
+        &mut self,
+        thread_id: ThreadId,
+        num_turns: u32,
+        response: &ThreadRollbackResponse,
+    ) {
+        if let Some(channel) = self.thread_event_channels.get(&thread_id) {
+            let mut store = channel.store.lock().await;
+            store.apply_thread_rollback(response);
+            store.note_local_thread_rollback(num_turns);
+        }
+        if self.active_thread_id == Some(thread_id)
+            && let Some(mut rx) = self.active_thread_rx.take()
+        {
+            let mut disconnected = false;
+            loop {
+                match rx.try_recv() {
+                    Ok(_) => {}
+                    Err(TryRecvError::Empty) => break,
+                    Err(TryRecvError::Disconnected) => {
+                        disconnected = true;
+                        break;
+                    }
+                }
+            }
+
+            if !disconnected {
+                self.active_thread_rx = Some(rx);
+            } else {
+                self.clear_active_thread().await;
+            }
+        }
+        self.handle_backtrack_rollback_succeeded(num_turns);
+        self.chat_widget.handle_thread_rolled_back();
+    }
+
+    fn handle_thread_event_now(&mut self, event: ThreadBufferedEvent) {
+        let needs_refresh = matches!(
+            &event,
+            ThreadBufferedEvent::Notification(ServerNotification::TurnStarted(_))
+                | ThreadBufferedEvent::Notification(ServerNotification::ThreadTokenUsageUpdated(_))
+        );
+        match event {
+            ThreadBufferedEvent::Notification(notification) => {
+                self.chat_widget
+                    .handle_server_notification(notification, /*replay_kind*/ None);
+            }
+            ThreadBufferedEvent::Request(request) => {
+                self.chat_widget
+                    .handle_server_request(request, /*replay_kind*/ None);
+            }
+            ThreadBufferedEvent::LegacyWarning(message) => {
+                self.chat_widget.add_warning_message(message);
+            }
+            ThreadBufferedEvent::LegacyRollback { num_turns } => {
+                self.handle_backtrack_rollback_succeeded(num_turns);
+                self.chat_widget.handle_thread_rolled_back();
+            }
+        }
         if needs_refresh {
             self.refresh_status_line();
         }
     }
 
-    fn handle_codex_event_replay(&mut self, event: Event) {
-        self.chat_widget.handle_codex_event_replay(event);
+    fn handle_thread_event_replay(&mut self, event: ThreadBufferedEvent) {
+        match event {
+            ThreadBufferedEvent::Notification(notification) => self
+                .chat_widget
+                .handle_server_notification(notification, Some(ReplayKind::ThreadSnapshot)),
+            ThreadBufferedEvent::Request(request) => self
+                .chat_widget
+                .handle_server_request(request, Some(ReplayKind::ThreadSnapshot)),
+            ThreadBufferedEvent::LegacyWarning(message) => {
+                self.chat_widget.add_warning_message(message);
+            }
+            ThreadBufferedEvent::LegacyRollback { num_turns } => {
+                self.handle_backtrack_rollback_succeeded(num_turns);
+                self.chat_widget.handle_thread_rolled_back();
+            }
+        }
     }
 
     /// Handles an event emitted by the currently active thread.
@@ -4436,11 +4779,19 @@ impl App {
     /// This function enforces shutdown intent routing: unexpected non-primary
     /// thread shutdowns fail over to the primary thread, while user-requested
     /// app exits consume only the tracked shutdown completion and then proceed.
-    async fn handle_active_thread_event(&mut self, tui: &mut tui::Tui, event: Event) -> Result<()> {
+    async fn handle_active_thread_event(
+        &mut self,
+        tui: &mut tui::Tui,
+        app_server: &mut AppServerSession,
+        event: ThreadBufferedEvent,
+    ) -> Result<()> {
         // Capture this before any potential thread switch: we only want to clear
         // the exit marker when the currently active thread acknowledges shutdown.
-        let pending_shutdown_exit_completed = matches!(&event.msg, EventMsg::ShutdownComplete)
-            && self.pending_shutdown_exit_thread_id == self.active_thread_id;
+        let pending_shutdown_exit_completed = matches!(
+            &event,
+            ThreadBufferedEvent::Notification(ServerNotification::ThreadClosed(_))
+        ) && self.pending_shutdown_exit_thread_id
+            == self.active_thread_id;
 
         // Processing order matters:
         //
@@ -4450,11 +4801,13 @@ impl App {
         //
         // This preserves the mental model that user-requested exits do not trigger
         // failover, while true sub-agent deaths still do.
-        if let Some((closed_thread_id, primary_thread_id)) =
-            self.active_non_primary_shutdown_target(&event.msg)
+        if let ThreadBufferedEvent::Notification(notification) = &event
+            && let Some((closed_thread_id, primary_thread_id)) =
+                self.active_non_primary_shutdown_target(notification)
         {
             self.mark_agent_picker_thread_closed(closed_thread_id);
-            self.select_agent_thread(tui, primary_thread_id).await?;
+            self.select_agent_thread(tui, app_server, primary_thread_id)
+                .await?;
             if self.active_thread_id == Some(primary_thread_id) {
                 self.chat_widget.add_info_message(
                     format!(
@@ -4476,7 +4829,7 @@ impl App {
             // thread, so unrelated shutdowns cannot consume this marker.
             self.pending_shutdown_exit_thread_id = None;
         }
-        self.handle_codex_event_now(event);
+        self.handle_thread_event_now(event);
         if self.backtrack_render_pending {
             tui.frame_requester().schedule_frame();
         }
@@ -4611,7 +4964,12 @@ impl App {
         tui.frame_requester().schedule_frame();
     }
 
-    async fn handle_key_event(&mut self, tui: &mut tui::Tui, key_event: KeyEvent) {
+    async fn handle_key_event(
+        &mut self,
+        tui: &mut tui::Tui,
+        app_server: &mut AppServerSession,
+        key_event: KeyEvent,
+    ) {
         // Some terminals, especially on macOS, encode Option+Left/Right as Option+b/f unless
         // enhanced keyboard reporting is available. We only treat those word-motion fallbacks as
         // agent-switch shortcuts when the composer is empty so we never steal the expected
@@ -4630,7 +4988,7 @@ impl App {
                 self.current_displayed_thread_id(),
                 AgentNavigationDirection::Previous,
             ) {
-                let _ = self.select_agent_thread(tui, thread_id).await;
+                let _ = self.select_agent_thread(tui, app_server, thread_id).await;
             }
             return;
         }
@@ -4645,7 +5003,7 @@ impl App {
                 self.current_displayed_thread_id(),
                 AgentNavigationDirection::Next,
             ) {
-                let _ = self.select_agent_thread(tui, thread_id).await;
+                let _ = self.select_agent_thread(tui, app_server, thread_id).await;
             }
             return;
         }
@@ -4777,13 +5135,89 @@ impl App {
     }
 }
 
+/// Collect every MCP server status from the app-server by walking the paginated
+/// `mcpServerStatus/list` RPC until no `next_cursor` is returned.
+///
+/// All pages are eagerly gathered into a single `Vec` so the caller can render
+/// the inventory atomically. Each page requests up to 100 entries.
+async fn fetch_all_mcp_server_statuses(
+    request_handle: AppServerRequestHandle,
+) -> Result<Vec<McpServerStatus>> {
+    let mut cursor = None;
+    let mut statuses = Vec::new();
+
+    loop {
+        let request_id = RequestId::String(format!("mcp-inventory-{}", Uuid::new_v4()));
+        let response: ListMcpServerStatusResponse = request_handle
+            .request_typed(ClientRequest::McpServerStatusList {
+                request_id,
+                params: ListMcpServerStatusParams {
+                    cursor: cursor.clone(),
+                    limit: Some(100),
+                },
+            })
+            .await
+            .wrap_err("mcpServerStatus/list failed in app-server TUI")?;
+        statuses.extend(response.data);
+        if let Some(next_cursor) = response.next_cursor {
+            cursor = Some(next_cursor);
+        } else {
+            break;
+        }
+    }
+
+    Ok(statuses)
+}
+
+/// Convert flat `McpServerStatus` responses into the per-server maps used by the
+/// in-process MCP subsystem (tools keyed as `mcp__{server}__{tool}`, plus
+/// per-server resource/template/auth maps). Test-only because the app-server TUI
+/// renders directly from `McpServerStatus` rather than these maps.
+#[cfg(test)]
+type McpInventoryMaps = (
+    HashMap<String, codex_protocol::mcp::Tool>,
+    HashMap<String, Vec<codex_protocol::mcp::Resource>>,
+    HashMap<String, Vec<codex_protocol::mcp::ResourceTemplate>>,
+    HashMap<String, McpAuthStatus>,
+);
+
+#[cfg(test)]
+fn mcp_inventory_maps_from_statuses(statuses: Vec<McpServerStatus>) -> McpInventoryMaps {
+    let mut tools = HashMap::new();
+    let mut resources = HashMap::new();
+    let mut resource_templates = HashMap::new();
+    let mut auth_statuses = HashMap::new();
+
+    for status in statuses {
+        let server_name = status.name;
+        auth_statuses.insert(
+            server_name.clone(),
+            match status.auth_status {
+                codex_app_server_protocol::McpAuthStatus::Unsupported => McpAuthStatus::Unsupported,
+                codex_app_server_protocol::McpAuthStatus::NotLoggedIn => McpAuthStatus::NotLoggedIn,
+                codex_app_server_protocol::McpAuthStatus::BearerToken => McpAuthStatus::BearerToken,
+                codex_app_server_protocol::McpAuthStatus::OAuth => McpAuthStatus::OAuth,
+            },
+        );
+        resources.insert(server_name.clone(), status.resources);
+        resource_templates.insert(server_name.clone(), status.resource_templates);
+        for (tool_name, tool) in status.tools {
+            tools.insert(format!("mcp__{server_name}__{tool_name}"), tool);
+        }
+    }
+
+    (tools, resources, resource_templates, auth_statuses)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::app_backtrack::BacktrackSelection;
     use crate::app_backtrack::BacktrackState;
     use crate::app_backtrack::user_count;
-    use crate::app_server_session::AppServerStartedThread;
+
+    use crate::chatwidget::ChatWidgetInit;
+    use crate::chatwidget::create_initial_user_message;
     use crate::chatwidget::tests::make_chatwidget_manual_with_sender;
     use crate::chatwidget::tests::set_chatgpt_auth;
     use crate::file_search::FileSearchManager;
@@ -4794,11 +5228,29 @@ mod tests {
     use crate::multi_agents::AgentPickerThreadEntry;
     use assert_matches::assert_matches;
 
+    use codex_app_server_protocol::AdditionalNetworkPermissions;
+    use codex_app_server_protocol::AdditionalPermissionProfile;
+    use codex_app_server_protocol::AgentMessageDeltaNotification;
+    use codex_app_server_protocol::CommandExecutionRequestApprovalParams;
+    use codex_app_server_protocol::NetworkApprovalContext as AppServerNetworkApprovalContext;
+    use codex_app_server_protocol::NetworkApprovalProtocol as AppServerNetworkApprovalProtocol;
+    use codex_app_server_protocol::NetworkPolicyAmendment as AppServerNetworkPolicyAmendment;
+    use codex_app_server_protocol::NetworkPolicyRuleAction as AppServerNetworkPolicyRuleAction;
+    use codex_app_server_protocol::RequestId as AppServerRequestId;
+    use codex_app_server_protocol::ServerNotification;
+    use codex_app_server_protocol::ServerRequest;
     use codex_app_server_protocol::Thread;
+    use codex_app_server_protocol::ThreadClosedNotification;
     use codex_app_server_protocol::ThreadItem;
-    use codex_app_server_protocol::ThreadStatus;
+    use codex_app_server_protocol::ThreadStartedNotification;
+    use codex_app_server_protocol::ThreadTokenUsage;
+    use codex_app_server_protocol::ThreadTokenUsageUpdatedNotification;
+    use codex_app_server_protocol::TokenUsageBreakdown;
     use codex_app_server_protocol::Turn;
+    use codex_app_server_protocol::TurnCompletedNotification;
+    use codex_app_server_protocol::TurnStartedNotification;
     use codex_app_server_protocol::TurnStatus;
+    use codex_app_server_protocol::UserInput as AppServerUserInput;
     use codex_core::config::ConfigBuilder;
     use codex_core::config::ConfigOverrides;
     use codex_core::config::types::ModelAvailabilityNuxConfig;
@@ -4808,20 +5260,22 @@ mod tests {
     use codex_protocol::config_types::CollaborationModeMask;
     use codex_protocol::config_types::ModeKind;
     use codex_protocol::config_types::Settings;
+    use codex_protocol::mcp::Tool;
+    use codex_protocol::models::NetworkPermissions;
+    use codex_protocol::models::PermissionProfile;
     use codex_protocol::openai_models::ModelAvailabilityNux;
-    use codex_protocol::protocol::AgentMessageDeltaEvent;
     use codex_protocol::protocol::AskForApproval;
     use codex_protocol::protocol::Event;
     use codex_protocol::protocol::EventMsg;
+    use codex_protocol::protocol::McpAuthStatus;
+    use codex_protocol::protocol::NetworkApprovalContext;
+    use codex_protocol::protocol::NetworkApprovalProtocol;
+    use codex_protocol::protocol::RolloutItem;
+    use codex_protocol::protocol::RolloutLine;
     use codex_protocol::protocol::SandboxPolicy;
     use codex_protocol::protocol::SessionConfiguredEvent;
     use codex_protocol::protocol::SessionSource;
-    use codex_protocol::protocol::ThreadRolledBackEvent;
-    use codex_protocol::protocol::TurnAbortReason;
-    use codex_protocol::protocol::TurnAbortedEvent;
-    use codex_protocol::protocol::TurnCompleteEvent;
-    use codex_protocol::protocol::TurnStartedEvent;
-    use codex_protocol::protocol::UserMessageEvent;
+    use codex_protocol::protocol::TurnContextItem;
     use codex_protocol::user_input::TextElement;
     use codex_protocol::user_input::UserInput;
     use crossterm::event::KeyModifiers;
@@ -4851,6 +5305,75 @@ mod tests {
             vec![base_cwd.join("rel")]
         );
         Ok(())
+    }
+
+    #[test]
+    fn mcp_inventory_maps_prefix_tool_names_by_server() {
+        let statuses = vec![
+            McpServerStatus {
+                name: "docs".to_string(),
+                tools: HashMap::from([(
+                    "list".to_string(),
+                    Tool {
+                        description: None,
+                        name: "list".to_string(),
+                        title: None,
+                        input_schema: serde_json::json!({"type": "object"}),
+                        output_schema: None,
+                        annotations: None,
+                        icons: None,
+                        meta: None,
+                    },
+                )]),
+                resources: Vec::new(),
+                resource_templates: Vec::new(),
+                auth_status: codex_app_server_protocol::McpAuthStatus::Unsupported,
+            },
+            McpServerStatus {
+                name: "disabled".to_string(),
+                tools: HashMap::new(),
+                resources: Vec::new(),
+                resource_templates: Vec::new(),
+                auth_status: codex_app_server_protocol::McpAuthStatus::Unsupported,
+            },
+        ];
+
+        let (tools, resources, resource_templates, auth_statuses) =
+            mcp_inventory_maps_from_statuses(statuses);
+        let mut resource_names = resources.keys().cloned().collect::<Vec<_>>();
+        resource_names.sort();
+        let mut template_names = resource_templates.keys().cloned().collect::<Vec<_>>();
+        template_names.sort();
+
+        assert_eq!(
+            tools.keys().cloned().collect::<Vec<_>>(),
+            vec!["mcp__docs__list".to_string()]
+        );
+        assert_eq!(resource_names, vec!["disabled", "docs"]);
+        assert_eq!(template_names, vec!["disabled", "docs"]);
+        assert_eq!(
+            auth_statuses.get("disabled"),
+            Some(&McpAuthStatus::Unsupported)
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_mcp_inventory_result_clears_committed_loading_cell() {
+        let mut app = make_test_app().await;
+        app.transcript_cells
+            .push(Arc::new(history_cell::new_mcp_inventory_loading(
+                /*animations_enabled*/ false,
+            )));
+
+        app.handle_mcp_inventory_result(Ok(vec![McpServerStatus {
+            name: "docs".to_string(),
+            tools: HashMap::new(),
+            resources: Vec::new(),
+            resource_templates: Vec::new(),
+            auth_status: codex_app_server_protocol::McpAuthStatus::Unsupported,
+        }]));
+
+        assert_eq!(app.transcript_cells.len(), 0);
     }
 
     #[test]
@@ -4936,74 +5459,36 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn enqueue_primary_event_delivers_session_configured_before_buffered_approval()
-    -> Result<()> {
+    async fn enqueue_primary_thread_session_replays_buffered_approval_after_attach() -> Result<()> {
         let (mut app, mut app_event_rx, _op_rx) = make_test_app_with_channels().await;
         let thread_id = ThreadId::new();
-        let approval_event = Event {
-            id: "approval-event".to_string(),
-            msg: EventMsg::ExecApprovalRequest(
-                codex_protocol::protocol::ExecApprovalRequestEvent {
-                    call_id: "call-1".to_string(),
-                    approval_id: None,
-                    turn_id: "turn-1".to_string(),
-                    command: vec!["echo".to_string(), "hello".to_string()],
-                    cwd: PathBuf::from("/tmp/project"),
-                    reason: Some("needs approval".to_string()),
-                    network_approval_context: None,
-                    proposed_execpolicy_amendment: None,
-                    proposed_network_policy_amendments: None,
-                    additional_permissions: None,
-                    skill_metadata: None,
-                    available_decisions: None,
-                    parsed_cmd: Vec::new(),
-                },
-            ),
-        };
-        let session_configured_event = Event {
-            id: "session-configured".to_string(),
-            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
-                session_id: thread_id,
-                forked_from_id: None,
-                thread_name: None,
-                model: "gpt-test".to_string(),
-                model_provider_id: "test-provider".to_string(),
-                service_tier: None,
-                approval_policy: AskForApproval::Never,
-                approvals_reviewer: ApprovalsReviewer::User,
-                sandbox_policy: SandboxPolicy::new_read_only_policy(),
-                cwd: PathBuf::from("/tmp/project"),
-                reasoning_effort: None,
-                history_log_id: 0,
-                history_entry_count: 0,
-                initial_messages: None,
-                network_proxy: None,
-                rollout_path: Some(PathBuf::new()),
-            }),
-        };
+        let approval_request = exec_approval_request(thread_id, "turn-1", "call-1", None);
 
-        app.enqueue_primary_event(approval_event.clone()).await?;
-        app.enqueue_primary_event(session_configured_event.clone())
-            .await?;
+        app.enqueue_primary_thread_request(approval_request).await?;
+        app.enqueue_primary_thread_session(
+            test_thread_session(thread_id, PathBuf::from("/tmp/project")),
+            Vec::new(),
+        )
+        .await?;
 
         let rx = app
             .active_thread_rx
             .as_mut()
             .expect("primary thread receiver should be active");
-        let first_event = time::timeout(Duration::from_millis(50), rx.recv())
-            .await
-            .expect("timed out waiting for session configured event")
-            .expect("channel closed unexpectedly");
-        let second_event = time::timeout(Duration::from_millis(50), rx.recv())
+        let event = time::timeout(Duration::from_millis(50), rx.recv())
             .await
             .expect("timed out waiting for buffered approval event")
             .expect("channel closed unexpectedly");
 
-        assert!(matches!(first_event.msg, EventMsg::SessionConfigured(_)));
-        assert!(matches!(second_event.msg, EventMsg::ExecApprovalRequest(_)));
+        assert!(matches!(
+            &event,
+            ThreadBufferedEvent::Request(ServerRequest::CommandExecutionRequestApproval {
+                params,
+                ..
+            }) if params.turn_id == "turn-1"
+        ));
 
-        app.handle_codex_event_now(first_event);
-        app.handle_codex_event_now(second_event);
+        app.handle_thread_event_now(event);
         app.chat_widget
             .handle_key_event(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
 
@@ -5026,65 +5511,23 @@ mod tests {
     -> Result<()> {
         let mut app = make_test_app().await;
         let thread_id = ThreadId::new();
-        let approval_event = Event {
-            id: "approval-event".to_string(),
-            msg: EventMsg::ExecApprovalRequest(
-                codex_protocol::protocol::ExecApprovalRequestEvent {
-                    call_id: "call-1".to_string(),
-                    approval_id: Some("approval-1".to_string()),
-                    turn_id: String::new(),
-                    command: vec!["echo".to_string(), "hello".to_string()],
-                    cwd: PathBuf::from("/tmp/project"),
-                    reason: Some("needs approval".to_string()),
-                    network_approval_context: None,
-                    proposed_execpolicy_amendment: None,
-                    proposed_network_policy_amendments: None,
-                    additional_permissions: None,
-                    skill_metadata: None,
-                    available_decisions: None,
-                    parsed_cmd: Vec::new(),
-                },
-            ),
-        };
-        let session_configured_event = Event {
-            id: "session-configured".to_string(),
-            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
-                session_id: thread_id,
-                forked_from_id: None,
-                thread_name: None,
-                model: "gpt-test".to_string(),
-                model_provider_id: "test-provider".to_string(),
-                service_tier: None,
-                approval_policy: AskForApproval::Never,
-                approvals_reviewer: ApprovalsReviewer::User,
-                sandbox_policy: SandboxPolicy::new_read_only_policy(),
-                cwd: PathBuf::from("/tmp/project"),
-                reasoning_effort: None,
-                history_log_id: 0,
-                history_entry_count: 0,
-                initial_messages: None,
-                network_proxy: None,
-                rollout_path: Some(PathBuf::new()),
-            }),
-        };
+        let approval_request = exec_approval_request(thread_id, "", "call-1", Some("approval-1"));
 
-        app.enqueue_primary_event(approval_event).await?;
+        app.enqueue_primary_thread_request(approval_request).await?;
         app.note_app_server_request_resolved(ResolvedAppServerRequest {
             exec_approval_ids: vec!["approval-1".to_string()],
         })
         .await;
-        app.enqueue_primary_event(session_configured_event).await?;
+        app.enqueue_primary_thread_session(
+            test_thread_session(thread_id, PathBuf::from("/tmp/project")),
+            Vec::new(),
+        )
+        .await?;
 
         let rx = app
             .active_thread_rx
             .as_mut()
             .expect("primary thread receiver should be active");
-        let first_event = time::timeout(Duration::from_millis(50), rx.recv())
-            .await
-            .expect("timed out waiting for session configured event")
-            .expect("channel closed unexpectedly");
-
-        assert!(matches!(first_event.msg, EventMsg::SessionConfigured(_)));
         assert!(
             time::timeout(Duration::from_millis(50), rx.recv())
                 .await
@@ -5096,30 +5539,85 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn routed_thread_event_does_not_recreate_channel_after_reset() -> Result<()> {
-        let mut app = make_test_app().await;
+    async fn enqueue_primary_thread_session_replays_turns_before_initial_prompt_submit()
+    -> Result<()> {
+        let (mut app, mut app_event_rx, _op_rx) = make_test_app_with_channels().await;
         let thread_id = ThreadId::new();
-        app.thread_event_channels.insert(
-            thread_id,
-            ThreadEventChannel::new(THREAD_EVENT_CHANNEL_CAPACITY),
-        );
+        let initial_prompt = "follow-up after replay".to_string();
+        let config = app.config.clone();
+        let model = codex_core::test_support::get_model_offline(config.model.as_deref());
+        app.chat_widget = ChatWidget::new_with_app_event(ChatWidgetInit {
+            config,
+            frame_requester: crate::tui::FrameRequester::test_dummy(),
+            app_event_tx: app.app_event_tx.clone(),
+            initial_user_message: create_initial_user_message(
+                Some(initial_prompt.clone()),
+                Vec::new(),
+                Vec::new(),
+            ),
+            enhanced_keys_supported: false,
+            has_chatgpt_account: false,
+            model_catalog: app.model_catalog.clone(),
+            feedback: codex_feedback::CodexFeedback::new(),
+            is_first_run: false,
+            feedback_audience: app.feedback_audience,
+            status_account_display: None,
+            initial_plan_type: None,
+            model: Some(model),
+            startup_tooltip_override: None,
+            status_line_invalid_items_warned: app.status_line_invalid_items_warned.clone(),
+            session_telemetry: app.session_telemetry.clone(),
+        });
 
-        app.reset_thread_event_state();
-        app.handle_routed_thread_event(
-            thread_id,
-            Event {
-                id: "stale-event".to_string(),
-                msg: EventMsg::ShutdownComplete,
-            },
+        app.enqueue_primary_thread_session(
+            test_thread_session(thread_id, PathBuf::from("/tmp/project")),
+            vec![test_turn(
+                "turn-1",
+                TurnStatus::Completed,
+                vec![ThreadItem::UserMessage {
+                    id: "user-1".to_string(),
+                    content: vec![AppServerUserInput::Text {
+                        text: "earlier prompt".to_string(),
+                        text_elements: Vec::new(),
+                    }],
+                }],
+            )],
         )
         .await?;
 
+        let mut saw_replayed_answer = false;
+        let mut submitted_items = None;
+        while let Ok(event) = app_event_rx.try_recv() {
+            match event {
+                AppEvent::InsertHistoryCell(cell) => {
+                    let transcript = lines_to_single_string(&cell.transcript_lines(80));
+                    saw_replayed_answer |= transcript.contains("earlier prompt");
+                }
+                AppEvent::SubmitThreadOp {
+                    thread_id: op_thread_id,
+                    op: Op::UserTurn { items, .. },
+                } => {
+                    assert_eq!(op_thread_id, thread_id);
+                    submitted_items = Some(items);
+                }
+                AppEvent::CodexOp(Op::UserTurn { items, .. }) => {
+                    submitted_items = Some(items);
+                }
+                _ => {}
+            }
+        }
         assert!(
-            !app.thread_event_channels.contains_key(&thread_id),
-            "stale routed events should not recreate cleared thread channels"
+            saw_replayed_answer,
+            "expected replayed history before initial prompt submit"
         );
-        assert_eq!(app.active_thread_id, None);
-        assert_eq!(app.primary_thread_id, None);
+        assert_eq!(
+            submitted_items,
+            Some(vec![UserInput::Text {
+                text: initial_prompt,
+                text_elements: Vec::new(),
+            }])
+        );
+
         Ok(())
     }
 
@@ -5204,18 +5702,16 @@ mod tests {
             .insert(thread_id, ThreadEventChannel::new(1));
         app.set_thread_active(thread_id, true).await;
 
-        let event = Event {
-            id: String::new(),
-            msg: EventMsg::ShutdownComplete,
-        };
+        let event = thread_closed_notification(thread_id);
 
-        app.enqueue_thread_event(thread_id, event.clone()).await?;
+        app.enqueue_thread_notification(thread_id, event.clone())
+            .await?;
         time::timeout(
             Duration::from_millis(50),
-            app.enqueue_thread_event(thread_id, event),
+            app.enqueue_thread_notification(thread_id, event),
         )
         .await
-        .expect("enqueue_thread_event blocked on a full channel")?;
+        .expect("enqueue_thread_notification blocked on a full channel")?;
 
         let mut rx = app
             .thread_event_channels
@@ -5241,34 +5737,17 @@ mod tests {
     async fn replay_thread_snapshot_restores_draft_and_queued_input() {
         let mut app = make_test_app().await;
         let thread_id = ThreadId::new();
+        let session = test_thread_session(thread_id, PathBuf::from("/tmp/project"));
         app.thread_event_channels.insert(
             thread_id,
-            ThreadEventChannel::new_with_session_configured(
+            ThreadEventChannel::new_with_session(
                 THREAD_EVENT_CHANNEL_CAPACITY,
-                Event {
-                    id: "session-configured".to_string(),
-                    msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
-                        session_id: thread_id,
-                        forked_from_id: None,
-                        thread_name: None,
-                        model: "gpt-test".to_string(),
-                        model_provider_id: "test-provider".to_string(),
-                        service_tier: None,
-                        approval_policy: AskForApproval::Never,
-                        approvals_reviewer: ApprovalsReviewer::User,
-                        sandbox_policy: SandboxPolicy::new_read_only_policy(),
-                        cwd: PathBuf::from("/tmp/project"),
-                        reasoning_effort: None,
-                        history_log_id: 0,
-                        history_entry_count: 0,
-                        initial_messages: None,
-                        network_proxy: None,
-                        rollout_path: Some(PathBuf::new()),
-                    }),
-                },
+                session.clone(),
+                Vec::new(),
             ),
         );
         app.activate_thread_channel(thread_id).await;
+        app.chat_widget.handle_thread_session(session.clone());
 
         app.chat_widget
             .apply_external_edit("draft prompt".to_string());
@@ -5307,59 +5786,46 @@ mod tests {
 
         assert_eq!(app.chat_widget.composer_text_with_pending(), "draft prompt");
         assert!(app.chat_widget.queued_user_message_texts().is_empty());
-        match next_user_turn_op(&mut new_op_rx) {
-            Op::UserTurn { items, .. } => assert_eq!(
-                items,
-                vec![UserInput::Text {
-                    text: "queued follow-up".to_string(),
-                    text_elements: Vec::new(),
-                }]
-            ),
-            other => panic!("expected queued follow-up submission, got {other:?}"),
+        while let Ok(op) = new_op_rx.try_recv() {
+            assert!(
+                !matches!(op, Op::UserTurn { .. }),
+                "draft-only replay should not auto-submit queued input"
+            );
         }
+    }
+
+    #[tokio::test]
+    async fn active_turn_id_for_thread_uses_snapshot_turns() {
+        let mut app = make_test_app().await;
+        let thread_id = ThreadId::new();
+        let session = test_thread_session(thread_id, PathBuf::from("/tmp/project"));
+        app.thread_event_channels.insert(
+            thread_id,
+            ThreadEventChannel::new_with_session(
+                THREAD_EVENT_CHANNEL_CAPACITY,
+                session,
+                vec![test_turn("turn-1", TurnStatus::InProgress, Vec::new())],
+            ),
+        );
+
+        assert_eq!(
+            app.active_turn_id_for_thread(thread_id).await,
+            Some("turn-1".to_string())
+        );
     }
 
     #[tokio::test]
     async fn replayed_turn_complete_submits_restored_queued_follow_up() {
         let (mut app, _app_event_rx, _op_rx) = make_test_app_with_channels().await;
         let thread_id = ThreadId::new();
-        let session_configured = Event {
-            id: "session-configured".to_string(),
-            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
-                session_id: thread_id,
-                forked_from_id: None,
-                thread_name: None,
-                model: "gpt-test".to_string(),
-                model_provider_id: "test-provider".to_string(),
-                service_tier: None,
-                approval_policy: AskForApproval::Never,
-                approvals_reviewer: ApprovalsReviewer::User,
-                sandbox_policy: SandboxPolicy::new_read_only_policy(),
-                cwd: PathBuf::from("/tmp/project"),
-                reasoning_effort: None,
-                history_log_id: 0,
-                history_entry_count: 0,
-                initial_messages: None,
-                network_proxy: None,
-                rollout_path: Some(PathBuf::new()),
-            }),
-        };
+        let session = test_thread_session(thread_id, PathBuf::from("/tmp/project"));
+        app.chat_widget.handle_thread_session(session.clone());
         app.chat_widget
-            .handle_codex_event(session_configured.clone());
-        app.chat_widget.handle_codex_event(Event {
-            id: "turn-started".to_string(),
-            msg: EventMsg::TurnStarted(TurnStartedEvent {
-                turn_id: "turn-1".to_string(),
-                model_context_window: None,
-                collaboration_mode_kind: Default::default(),
-            }),
-        });
-        app.chat_widget.handle_codex_event(Event {
-            id: "agent-delta".to_string(),
-            msg: EventMsg::AgentMessageDelta(AgentMessageDeltaEvent {
-                delta: "streaming".to_string(),
-            }),
-        });
+            .handle_server_notification(turn_started_notification(thread_id, "turn-1"), None);
+        app.chat_widget.handle_server_notification(
+            agent_message_delta_notification(thread_id, "turn-1", "agent-1", "streaming"),
+            None,
+        );
         app.chat_widget
             .apply_external_edit("queued follow-up".to_string());
         app.chat_widget
@@ -5372,18 +5838,15 @@ mod tests {
         let (chat_widget, _app_event_tx, _rx, mut new_op_rx) =
             make_chatwidget_manual_with_sender().await;
         app.chat_widget = chat_widget;
-        app.chat_widget.handle_codex_event(session_configured);
+        app.chat_widget.handle_thread_session(session.clone());
         while new_op_rx.try_recv().is_ok() {}
         app.replay_thread_snapshot(
             ThreadEventSnapshot {
-                session_configured: None,
-                events: vec![Event {
-                    id: "turn-complete".to_string(),
-                    msg: EventMsg::TurnComplete(TurnCompleteEvent {
-                        turn_id: "turn-1".to_string(),
-                        last_agent_message: None,
-                    }),
-                }],
+                session: None,
+                turns: Vec::new(),
+                events: vec![ThreadBufferedEvent::Notification(
+                    turn_completed_notification(thread_id, "turn-1", TurnStatus::Completed),
+                )],
                 input_state: Some(input_state),
             },
             true,
@@ -5402,46 +5865,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn replay_thread_snapshot_replays_legacy_warning_history() {
+        let (mut app, mut app_event_rx, _op_rx) = make_test_app_with_channels().await;
+
+        app.replay_thread_snapshot(
+            ThreadEventSnapshot {
+                session: None,
+                turns: Vec::new(),
+                events: vec![ThreadBufferedEvent::LegacyWarning(
+                    "legacy warning message".to_string(),
+                )],
+                input_state: None,
+            },
+            false,
+        );
+
+        let mut saw_warning = false;
+        while let Ok(event) = app_event_rx.try_recv() {
+            if let AppEvent::InsertHistoryCell(cell) = event {
+                let transcript = lines_to_single_string(&cell.transcript_lines(80));
+                saw_warning |= transcript.contains("legacy warning message");
+            }
+        }
+
+        assert!(saw_warning, "expected replayed legacy warning history cell");
+    }
+
+    #[tokio::test]
     async fn replay_only_thread_keeps_restored_queue_visible() {
         let (mut app, _app_event_rx, _op_rx) = make_test_app_with_channels().await;
         let thread_id = ThreadId::new();
-        let session_configured = Event {
-            id: "session-configured".to_string(),
-            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
-                session_id: thread_id,
-                forked_from_id: None,
-                thread_name: None,
-                model: "gpt-test".to_string(),
-                model_provider_id: "test-provider".to_string(),
-                service_tier: None,
-                approval_policy: AskForApproval::Never,
-                approvals_reviewer: ApprovalsReviewer::User,
-                sandbox_policy: SandboxPolicy::new_read_only_policy(),
-                cwd: PathBuf::from("/tmp/project"),
-                reasoning_effort: None,
-                history_log_id: 0,
-                history_entry_count: 0,
-                initial_messages: None,
-                network_proxy: None,
-                rollout_path: Some(PathBuf::new()),
-            }),
-        };
+        let session = test_thread_session(thread_id, PathBuf::from("/tmp/project"));
+        app.chat_widget.handle_thread_session(session.clone());
         app.chat_widget
-            .handle_codex_event(session_configured.clone());
-        app.chat_widget.handle_codex_event(Event {
-            id: "turn-started".to_string(),
-            msg: EventMsg::TurnStarted(TurnStartedEvent {
-                turn_id: "turn-1".to_string(),
-                model_context_window: None,
-                collaboration_mode_kind: Default::default(),
-            }),
-        });
-        app.chat_widget.handle_codex_event(Event {
-            id: "agent-delta".to_string(),
-            msg: EventMsg::AgentMessageDelta(AgentMessageDeltaEvent {
-                delta: "streaming".to_string(),
-            }),
-        });
+            .handle_server_notification(turn_started_notification(thread_id, "turn-1"), None);
+        app.chat_widget.handle_server_notification(
+            agent_message_delta_notification(thread_id, "turn-1", "agent-1", "streaming"),
+            None,
+        );
         app.chat_widget
             .apply_external_edit("queued follow-up".to_string());
         app.chat_widget
@@ -5454,19 +5915,16 @@ mod tests {
         let (chat_widget, _app_event_tx, _rx, mut new_op_rx) =
             make_chatwidget_manual_with_sender().await;
         app.chat_widget = chat_widget;
-        app.chat_widget.handle_codex_event(session_configured);
+        app.chat_widget.handle_thread_session(session.clone());
         while new_op_rx.try_recv().is_ok() {}
 
         app.replay_thread_snapshot(
             ThreadEventSnapshot {
-                session_configured: None,
-                events: vec![Event {
-                    id: "turn-complete".to_string(),
-                    msg: EventMsg::TurnComplete(TurnCompleteEvent {
-                        turn_id: "turn-1".to_string(),
-                        last_agent_message: None,
-                    }),
-                }],
+                session: None,
+                turns: Vec::new(),
+                events: vec![ThreadBufferedEvent::Notification(
+                    turn_completed_notification(thread_id, "turn-1", TurnStatus::Completed),
+                )],
                 input_state: Some(input_state),
             },
             false,
@@ -5486,43 +5944,14 @@ mod tests {
     async fn replay_thread_snapshot_keeps_queue_when_running_state_only_comes_from_snapshot() {
         let (mut app, _app_event_rx, _op_rx) = make_test_app_with_channels().await;
         let thread_id = ThreadId::new();
-        let session_configured = Event {
-            id: "session-configured".to_string(),
-            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
-                session_id: thread_id,
-                forked_from_id: None,
-                thread_name: None,
-                model: "gpt-test".to_string(),
-                model_provider_id: "test-provider".to_string(),
-                service_tier: None,
-                approval_policy: AskForApproval::Never,
-                approvals_reviewer: ApprovalsReviewer::User,
-                sandbox_policy: SandboxPolicy::new_read_only_policy(),
-                cwd: PathBuf::from("/tmp/project"),
-                reasoning_effort: None,
-                history_log_id: 0,
-                history_entry_count: 0,
-                initial_messages: None,
-                network_proxy: None,
-                rollout_path: Some(PathBuf::new()),
-            }),
-        };
+        let session = test_thread_session(thread_id, PathBuf::from("/tmp/project"));
+        app.chat_widget.handle_thread_session(session.clone());
         app.chat_widget
-            .handle_codex_event(session_configured.clone());
-        app.chat_widget.handle_codex_event(Event {
-            id: "turn-started".to_string(),
-            msg: EventMsg::TurnStarted(TurnStartedEvent {
-                turn_id: "turn-1".to_string(),
-                model_context_window: None,
-                collaboration_mode_kind: Default::default(),
-            }),
-        });
-        app.chat_widget.handle_codex_event(Event {
-            id: "agent-delta".to_string(),
-            msg: EventMsg::AgentMessageDelta(AgentMessageDeltaEvent {
-                delta: "streaming".to_string(),
-            }),
-        });
+            .handle_server_notification(turn_started_notification(thread_id, "turn-1"), None);
+        app.chat_widget.handle_server_notification(
+            agent_message_delta_notification(thread_id, "turn-1", "agent-1", "streaming"),
+            None,
+        );
         app.chat_widget
             .apply_external_edit("queued follow-up".to_string());
         app.chat_widget
@@ -5535,12 +5964,13 @@ mod tests {
         let (chat_widget, _app_event_tx, _rx, mut new_op_rx) =
             make_chatwidget_manual_with_sender().await;
         app.chat_widget = chat_widget;
-        app.chat_widget.handle_codex_event(session_configured);
+        app.chat_widget.handle_thread_session(session.clone());
         while new_op_rx.try_recv().is_ok() {}
 
         app.replay_thread_snapshot(
             ThreadEventSnapshot {
-                session_configured: None,
+                session: None,
+                turns: Vec::new(),
                 events: vec![],
                 input_state: Some(input_state),
             },
@@ -5558,46 +5988,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn replay_thread_snapshot_does_not_submit_queue_before_replay_catches_up() {
+    async fn replay_thread_snapshot_in_progress_turn_restores_running_queue_state() {
         let (mut app, _app_event_rx, _op_rx) = make_test_app_with_channels().await;
         let thread_id = ThreadId::new();
-        let session_configured = Event {
-            id: "session-configured".to_string(),
-            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
-                session_id: thread_id,
-                forked_from_id: None,
-                thread_name: None,
-                model: "gpt-test".to_string(),
-                model_provider_id: "test-provider".to_string(),
-                service_tier: None,
-                approval_policy: AskForApproval::Never,
-                approvals_reviewer: ApprovalsReviewer::User,
-                sandbox_policy: SandboxPolicy::new_read_only_policy(),
-                cwd: PathBuf::from("/tmp/project"),
-                reasoning_effort: None,
-                history_log_id: 0,
-                history_entry_count: 0,
-                initial_messages: None,
-                network_proxy: None,
-                rollout_path: Some(PathBuf::new()),
-            }),
-        };
+        let session = test_thread_session(thread_id, PathBuf::from("/tmp/project"));
+        app.chat_widget.handle_thread_session(session.clone());
         app.chat_widget
-            .handle_codex_event(session_configured.clone());
-        app.chat_widget.handle_codex_event(Event {
-            id: "turn-started".to_string(),
-            msg: EventMsg::TurnStarted(TurnStartedEvent {
-                turn_id: "turn-1".to_string(),
-                model_context_window: None,
-                collaboration_mode_kind: Default::default(),
-            }),
-        });
-        app.chat_widget.handle_codex_event(Event {
-            id: "agent-delta".to_string(),
-            msg: EventMsg::AgentMessageDelta(AgentMessageDeltaEvent {
-                delta: "streaming".to_string(),
-            }),
-        });
+            .handle_server_notification(turn_started_notification(thread_id, "turn-1"), None);
+        app.chat_widget.handle_server_notification(
+            agent_message_delta_notification(thread_id, "turn-1", "agent-1", "streaming"),
+            None,
+        );
         app.chat_widget
             .apply_external_edit("queued follow-up".to_string());
         app.chat_widget
@@ -5610,28 +6011,92 @@ mod tests {
         let (chat_widget, _app_event_tx, _rx, mut new_op_rx) =
             make_chatwidget_manual_with_sender().await;
         app.chat_widget = chat_widget;
-        app.chat_widget.handle_codex_event(session_configured);
+        app.chat_widget.handle_thread_session(session.clone());
         while new_op_rx.try_recv().is_ok() {}
 
         app.replay_thread_snapshot(
             ThreadEventSnapshot {
-                session_configured: None,
+                session: None,
+                turns: vec![test_turn("turn-1", TurnStatus::InProgress, Vec::new())],
+                events: Vec::new(),
+                input_state: Some(input_state),
+            },
+            true,
+        );
+
+        assert_eq!(
+            app.chat_widget.queued_user_message_texts(),
+            vec!["queued follow-up".to_string()]
+        );
+        assert!(
+            new_op_rx.try_recv().is_err(),
+            "restored queue should stay queued while replayed turn is still running"
+        );
+    }
+
+    #[tokio::test]
+    async fn replay_thread_snapshot_in_progress_turn_restores_running_state_without_input_state() {
+        let (mut app, _app_event_rx, _op_rx) = make_test_app_with_channels().await;
+        let thread_id = ThreadId::new();
+        let session = test_thread_session(thread_id, PathBuf::from("/tmp/project"));
+        let (chat_widget, _app_event_tx, _rx, _new_op_rx) =
+            make_chatwidget_manual_with_sender().await;
+        app.chat_widget = chat_widget;
+        app.chat_widget.handle_thread_session(session);
+
+        app.replay_thread_snapshot(
+            ThreadEventSnapshot {
+                session: None,
+                turns: vec![test_turn("turn-1", TurnStatus::InProgress, Vec::new())],
+                events: Vec::new(),
+                input_state: None,
+            },
+            false,
+        );
+
+        assert!(app.chat_widget.is_task_running_for_test());
+    }
+
+    #[tokio::test]
+    async fn replay_thread_snapshot_does_not_submit_queue_before_replay_catches_up() {
+        let (mut app, _app_event_rx, _op_rx) = make_test_app_with_channels().await;
+        let thread_id = ThreadId::new();
+        let session = test_thread_session(thread_id, PathBuf::from("/tmp/project"));
+        app.chat_widget.handle_thread_session(session.clone());
+        app.chat_widget
+            .handle_server_notification(turn_started_notification(thread_id, "turn-1"), None);
+        app.chat_widget.handle_server_notification(
+            agent_message_delta_notification(thread_id, "turn-1", "agent-1", "streaming"),
+            None,
+        );
+        app.chat_widget
+            .apply_external_edit("queued follow-up".to_string());
+        app.chat_widget
+            .handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        let input_state = app
+            .chat_widget
+            .capture_thread_input_state()
+            .expect("expected queued follow-up state");
+
+        let (chat_widget, _app_event_tx, _rx, mut new_op_rx) =
+            make_chatwidget_manual_with_sender().await;
+        app.chat_widget = chat_widget;
+        app.chat_widget.handle_thread_session(session.clone());
+        while new_op_rx.try_recv().is_ok() {}
+
+        app.replay_thread_snapshot(
+            ThreadEventSnapshot {
+                session: None,
+                turns: Vec::new(),
                 events: vec![
-                    Event {
-                        id: "older-turn-complete".to_string(),
-                        msg: EventMsg::TurnComplete(TurnCompleteEvent {
-                            turn_id: "turn-0".to_string(),
-                            last_agent_message: None,
-                        }),
-                    },
-                    Event {
-                        id: "latest-turn-started".to_string(),
-                        msg: EventMsg::TurnStarted(TurnStartedEvent {
-                            turn_id: "turn-1".to_string(),
-                            model_context_window: None,
-                            collaboration_mode_kind: Default::default(),
-                        }),
-                    },
+                    ThreadBufferedEvent::Notification(turn_completed_notification(
+                        thread_id,
+                        "turn-0",
+                        TurnStatus::Completed,
+                    )),
+                    ThreadBufferedEvent::Notification(turn_started_notification(
+                        thread_id, "turn-1",
+                    )),
                 ],
                 input_state: Some(input_state),
             },
@@ -5647,13 +6112,10 @@ mod tests {
             vec!["queued follow-up".to_string()]
         );
 
-        app.chat_widget.handle_codex_event(Event {
-            id: "latest-turn-complete".to_string(),
-            msg: EventMsg::TurnComplete(TurnCompleteEvent {
-                turn_id: "turn-1".to_string(),
-                last_agent_message: None,
-            }),
-        });
+        app.chat_widget.handle_server_notification(
+            turn_completed_notification(thread_id, "turn-1", TurnStatus::Completed),
+            None,
+        );
 
         match next_user_turn_op(&mut new_op_rx) {
             Op::UserTurn { items, .. } => assert_eq!(
@@ -5671,34 +6133,17 @@ mod tests {
     async fn replay_thread_snapshot_restores_pending_pastes_for_submit() {
         let (mut app, _app_event_rx, _op_rx) = make_test_app_with_channels().await;
         let thread_id = ThreadId::new();
+        let session = test_thread_session(thread_id, PathBuf::from("/tmp/project"));
         app.thread_event_channels.insert(
             thread_id,
-            ThreadEventChannel::new_with_session_configured(
+            ThreadEventChannel::new_with_session(
                 THREAD_EVENT_CHANNEL_CAPACITY,
-                Event {
-                    id: "session-configured".to_string(),
-                    msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
-                        session_id: thread_id,
-                        forked_from_id: None,
-                        thread_name: None,
-                        model: "gpt-test".to_string(),
-                        model_provider_id: "test-provider".to_string(),
-                        service_tier: None,
-                        approval_policy: AskForApproval::Never,
-                        approvals_reviewer: ApprovalsReviewer::User,
-                        sandbox_policy: SandboxPolicy::new_read_only_policy(),
-                        cwd: PathBuf::from("/tmp/project"),
-                        reasoning_effort: None,
-                        history_log_id: 0,
-                        history_entry_count: 0,
-                        initial_messages: None,
-                        network_proxy: None,
-                        rollout_path: Some(PathBuf::new()),
-                    }),
-                },
+                session.clone(),
+                Vec::new(),
             ),
         );
         app.activate_thread_channel(thread_id).await;
+        app.chat_widget.handle_thread_session(session);
 
         let large = "x".repeat(1005);
         app.chat_widget.handle_paste(large.clone());
@@ -5745,29 +6190,8 @@ mod tests {
     async fn replay_thread_snapshot_restores_collaboration_mode_for_draft_submit() {
         let (mut app, _app_event_rx, _op_rx) = make_test_app_with_channels().await;
         let thread_id = ThreadId::new();
-        let session_configured = Event {
-            id: "session-configured".to_string(),
-            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
-                session_id: thread_id,
-                forked_from_id: None,
-                thread_name: None,
-                model: "gpt-test".to_string(),
-                model_provider_id: "test-provider".to_string(),
-                service_tier: None,
-                approval_policy: AskForApproval::Never,
-                approvals_reviewer: ApprovalsReviewer::User,
-                sandbox_policy: SandboxPolicy::new_read_only_policy(),
-                cwd: PathBuf::from("/tmp/project"),
-                reasoning_effort: None,
-                history_log_id: 0,
-                history_entry_count: 0,
-                initial_messages: None,
-                network_proxy: None,
-                rollout_path: Some(PathBuf::new()),
-            }),
-        };
-        app.chat_widget
-            .handle_codex_event(session_configured.clone());
+        let session = test_thread_session(thread_id, PathBuf::from("/tmp/project"));
+        app.chat_widget.handle_thread_session(session.clone());
         app.chat_widget
             .set_reasoning_effort(Some(ReasoningEffortConfig::High));
         app.chat_widget
@@ -5788,7 +6212,7 @@ mod tests {
         let (chat_widget, _app_event_tx, _rx, mut new_op_rx) =
             make_chatwidget_manual_with_sender().await;
         app.chat_widget = chat_widget;
-        app.chat_widget.handle_codex_event(session_configured);
+        app.chat_widget.handle_thread_session(session.clone());
         app.chat_widget
             .set_reasoning_effort(Some(ReasoningEffortConfig::Low));
         app.chat_widget
@@ -5803,7 +6227,8 @@ mod tests {
 
         app.replay_thread_snapshot(
             ThreadEventSnapshot {
-                session_configured: None,
+                session: None,
+                turns: Vec::new(),
                 events: vec![],
                 input_state: Some(input_state),
             },
@@ -5849,29 +6274,8 @@ mod tests {
     async fn replay_thread_snapshot_restores_collaboration_mode_without_input() {
         let (mut app, _app_event_rx, _op_rx) = make_test_app_with_channels().await;
         let thread_id = ThreadId::new();
-        let session_configured = Event {
-            id: "session-configured".to_string(),
-            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
-                session_id: thread_id,
-                forked_from_id: None,
-                thread_name: None,
-                model: "gpt-test".to_string(),
-                model_provider_id: "test-provider".to_string(),
-                service_tier: None,
-                approval_policy: AskForApproval::Never,
-                approvals_reviewer: ApprovalsReviewer::User,
-                sandbox_policy: SandboxPolicy::new_read_only_policy(),
-                cwd: PathBuf::from("/tmp/project"),
-                reasoning_effort: None,
-                history_log_id: 0,
-                history_entry_count: 0,
-                initial_messages: None,
-                network_proxy: None,
-                rollout_path: Some(PathBuf::new()),
-            }),
-        };
-        app.chat_widget
-            .handle_codex_event(session_configured.clone());
+        let session = test_thread_session(thread_id, PathBuf::from("/tmp/project"));
+        app.chat_widget.handle_thread_session(session.clone());
         app.chat_widget
             .set_reasoning_effort(Some(ReasoningEffortConfig::High));
         app.chat_widget
@@ -5890,7 +6294,7 @@ mod tests {
         let (chat_widget, _app_event_tx, _rx, _new_op_rx) =
             make_chatwidget_manual_with_sender().await;
         app.chat_widget = chat_widget;
-        app.chat_widget.handle_codex_event(session_configured);
+        app.chat_widget.handle_thread_session(session.clone());
         app.chat_widget
             .set_reasoning_effort(Some(ReasoningEffortConfig::Low));
         app.chat_widget
@@ -5904,7 +6308,8 @@ mod tests {
 
         app.replay_thread_snapshot(
             ThreadEventSnapshot {
-                session_configured: None,
+                session: None,
+                turns: Vec::new(),
                 events: vec![],
                 input_state: Some(input_state),
             },
@@ -5926,43 +6331,14 @@ mod tests {
     async fn replayed_interrupted_turn_restores_queued_input_to_composer() {
         let (mut app, _app_event_rx, _op_rx) = make_test_app_with_channels().await;
         let thread_id = ThreadId::new();
-        let session_configured = Event {
-            id: "session-configured".to_string(),
-            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
-                session_id: thread_id,
-                forked_from_id: None,
-                thread_name: None,
-                model: "gpt-test".to_string(),
-                model_provider_id: "test-provider".to_string(),
-                service_tier: None,
-                approval_policy: AskForApproval::Never,
-                approvals_reviewer: ApprovalsReviewer::User,
-                sandbox_policy: SandboxPolicy::new_read_only_policy(),
-                cwd: PathBuf::from("/tmp/project"),
-                reasoning_effort: None,
-                history_log_id: 0,
-                history_entry_count: 0,
-                initial_messages: None,
-                network_proxy: None,
-                rollout_path: Some(PathBuf::new()),
-            }),
-        };
+        let session = test_thread_session(thread_id, PathBuf::from("/tmp/project"));
+        app.chat_widget.handle_thread_session(session.clone());
         app.chat_widget
-            .handle_codex_event(session_configured.clone());
-        app.chat_widget.handle_codex_event(Event {
-            id: "turn-started".to_string(),
-            msg: EventMsg::TurnStarted(TurnStartedEvent {
-                turn_id: "turn-1".to_string(),
-                model_context_window: None,
-                collaboration_mode_kind: Default::default(),
-            }),
-        });
-        app.chat_widget.handle_codex_event(Event {
-            id: "agent-delta".to_string(),
-            msg: EventMsg::AgentMessageDelta(AgentMessageDeltaEvent {
-                delta: "streaming".to_string(),
-            }),
-        });
+            .handle_server_notification(turn_started_notification(thread_id, "turn-1"), None);
+        app.chat_widget.handle_server_notification(
+            agent_message_delta_notification(thread_id, "turn-1", "agent-1", "streaming"),
+            None,
+        );
         app.chat_widget
             .apply_external_edit("queued follow-up".to_string());
         app.chat_widget
@@ -5975,19 +6351,16 @@ mod tests {
         let (chat_widget, _app_event_tx, _rx, mut new_op_rx) =
             make_chatwidget_manual_with_sender().await;
         app.chat_widget = chat_widget;
-        app.chat_widget.handle_codex_event(session_configured);
+        app.chat_widget.handle_thread_session(session.clone());
         while new_op_rx.try_recv().is_ok() {}
 
         app.replay_thread_snapshot(
             ThreadEventSnapshot {
-                session_configured: None,
-                events: vec![Event {
-                    id: "turn-aborted".to_string(),
-                    msg: EventMsg::TurnAborted(TurnAbortedEvent {
-                        turn_id: Some("turn-1".to_string()),
-                        reason: TurnAbortReason::ReviewEnded,
-                    }),
-                }],
+                session: None,
+                turns: Vec::new(),
+                events: vec![ThreadBufferedEvent::Notification(
+                    turn_completed_notification(thread_id, "turn-1", TurnStatus::Interrupted),
+                )],
                 input_state: Some(input_state),
             },
             true,
@@ -6005,21 +6378,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn live_turn_started_refreshes_status_line_with_runtime_context_window() {
+    async fn token_usage_update_refreshes_status_line_with_runtime_context_window() {
         let mut app = make_test_app().await;
         app.chat_widget
             .setup_status_line(vec![crate::bottom_pane::StatusLineItem::ContextWindowSize]);
 
         assert_eq!(app.chat_widget.status_line_text(), None);
 
-        app.handle_codex_event_now(Event {
-            id: "turn-started".to_string(),
-            msg: EventMsg::TurnStarted(TurnStartedEvent {
-                turn_id: "turn-1".to_string(),
-                model_context_window: Some(950_000),
-                collaboration_mode_kind: Default::default(),
-            }),
-        });
+        app.handle_thread_event_now(ThreadBufferedEvent::Notification(token_usage_notification(
+            ThreadId::new(),
+            "turn-1",
+            Some(950_000),
+        )));
 
         assert_eq!(
             app.chat_widget.status_line_text(),
@@ -6667,26 +7037,12 @@ guardian_approval = true
         let agent_channel = ThreadEventChannel::new(1);
         {
             let mut store = agent_channel.store.lock().await;
-            store.push_event(Event {
-                id: "ev-1".to_string(),
-                msg: EventMsg::ExecApprovalRequest(
-                    codex_protocol::protocol::ExecApprovalRequestEvent {
-                        call_id: "call-1".to_string(),
-                        approval_id: None,
-                        turn_id: "turn-1".to_string(),
-                        command: vec!["echo".to_string(), "hi".to_string()],
-                        cwd: PathBuf::from("/tmp"),
-                        reason: None,
-                        network_approval_context: None,
-                        proposed_execpolicy_amendment: None,
-                        proposed_network_policy_amendments: None,
-                        additional_permissions: None,
-                        skill_metadata: None,
-                        available_decisions: None,
-                        parsed_cmd: Vec::new(),
-                    },
-                ),
-            });
+            store.push_request(exec_approval_request(
+                agent_thread_id,
+                "turn-1",
+                "call-1",
+                None,
+            ));
         }
         app.thread_event_channels
             .insert(agent_thread_id, agent_channel);
@@ -6722,29 +7078,15 @@ guardian_approval = true
             .insert(main_thread_id, ThreadEventChannel::new(1));
         app.thread_event_channels.insert(
             agent_thread_id,
-            ThreadEventChannel::new_with_session_configured(
+            ThreadEventChannel::new_with_session(
                 1,
-                Event {
-                    id: String::new(),
-                    msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
-                        session_id: agent_thread_id,
-                        forked_from_id: None,
-                        thread_name: None,
-                        model: "gpt-5".to_string(),
-                        model_provider_id: "test-provider".to_string(),
-                        service_tier: None,
-                        approval_policy: AskForApproval::OnRequest,
-                        approvals_reviewer: ApprovalsReviewer::User,
-                        sandbox_policy: SandboxPolicy::new_workspace_write_policy(),
-                        cwd: PathBuf::from("/tmp/agent"),
-                        reasoning_effort: None,
-                        history_log_id: 0,
-                        history_entry_count: 0,
-                        initial_messages: None,
-                        network_proxy: None,
-                        rollout_path: Some(PathBuf::from("/tmp/agent-rollout.jsonl")),
-                    }),
+                ThreadSessionState {
+                    approval_policy: AskForApproval::OnRequest,
+                    sandbox_policy: SandboxPolicy::new_workspace_write_policy(),
+                    rollout_path: Some(PathBuf::from("/tmp/agent-rollout.jsonl")),
+                    ..test_thread_session(agent_thread_id, PathBuf::from("/tmp/agent"))
                 },
+                Vec::new(),
             ),
         );
         app.agent_navigation.upsert(
@@ -6754,28 +7096,9 @@ guardian_approval = true
             false,
         );
 
-        app.enqueue_thread_event(
+        app.enqueue_thread_request(
             agent_thread_id,
-            Event {
-                id: "ev-approval".to_string(),
-                msg: EventMsg::ExecApprovalRequest(
-                    codex_protocol::protocol::ExecApprovalRequestEvent {
-                        call_id: "call-approval".to_string(),
-                        approval_id: None,
-                        turn_id: "turn-approval".to_string(),
-                        command: vec!["echo".to_string(), "hi".to_string()],
-                        cwd: PathBuf::from("/tmp/agent"),
-                        reason: Some("need approval".to_string()),
-                        network_approval_context: None,
-                        proposed_execpolicy_amendment: None,
-                        proposed_network_policy_amendments: None,
-                        additional_permissions: None,
-                        skill_metadata: None,
-                        available_decisions: None,
-                        parsed_cmd: Vec::new(),
-                    },
-                ),
-            },
+            exec_approval_request(agent_thread_id, "turn-approval", "call-approval", None),
         )
         .await?;
 
@@ -6784,6 +7107,379 @@ guardian_approval = true
             app.chat_widget.pending_thread_approvals(),
             &["Robie [explorer]".to_string()]
         );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn inactive_thread_exec_approval_preserves_context() {
+        let app = make_test_app().await;
+        let thread_id = ThreadId::new();
+        let mut request = exec_approval_request(thread_id, "turn-approval", "call-approval", None);
+        let ServerRequest::CommandExecutionRequestApproval { params, .. } = &mut request else {
+            panic!("expected exec approval request");
+        };
+        params.network_approval_context = Some(AppServerNetworkApprovalContext {
+            host: "example.com".to_string(),
+            protocol: AppServerNetworkApprovalProtocol::Https,
+        });
+        params.additional_permissions = Some(AdditionalPermissionProfile {
+            network: Some(AdditionalNetworkPermissions {
+                enabled: Some(true),
+            }),
+            file_system: None,
+            macos: None,
+        });
+        params.proposed_network_policy_amendments = Some(vec![AppServerNetworkPolicyAmendment {
+            host: "example.com".to_string(),
+            action: AppServerNetworkPolicyRuleAction::Allow,
+        }]);
+
+        let Some(ThreadInteractiveRequest::Approval(ApprovalRequest::Exec {
+            available_decisions,
+            network_approval_context,
+            additional_permissions,
+            ..
+        })) = app
+            .interactive_request_for_thread_request(thread_id, &request)
+            .await
+        else {
+            panic!("expected exec approval request");
+        };
+
+        assert_eq!(
+            network_approval_context,
+            Some(NetworkApprovalContext {
+                host: "example.com".to_string(),
+                protocol: NetworkApprovalProtocol::Https,
+            })
+        );
+        assert_eq!(
+            additional_permissions,
+            Some(PermissionProfile {
+                network: Some(NetworkPermissions {
+                    enabled: Some(true),
+                }),
+                file_system: None,
+                macos: None,
+            })
+        );
+        assert_eq!(
+            available_decisions,
+            vec![
+                codex_protocol::protocol::ReviewDecision::Approved,
+                codex_protocol::protocol::ReviewDecision::ApprovedForSession,
+                codex_protocol::protocol::ReviewDecision::NetworkPolicyAmendment {
+                    network_policy_amendment: codex_protocol::approvals::NetworkPolicyAmendment {
+                        host: "example.com".to_string(),
+                        action: codex_protocol::approvals::NetworkPolicyRuleAction::Allow,
+                    },
+                },
+                codex_protocol::protocol::ReviewDecision::Abort,
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn inactive_thread_approval_badge_clears_after_turn_completion_notification() -> Result<()>
+    {
+        let mut app = make_test_app().await;
+        let main_thread_id =
+            ThreadId::from_string("00000000-0000-0000-0000-000000000101").expect("valid thread");
+        let agent_thread_id =
+            ThreadId::from_string("00000000-0000-0000-0000-000000000202").expect("valid thread");
+
+        app.primary_thread_id = Some(main_thread_id);
+        app.active_thread_id = Some(main_thread_id);
+        app.thread_event_channels
+            .insert(main_thread_id, ThreadEventChannel::new(1));
+        app.thread_event_channels.insert(
+            agent_thread_id,
+            ThreadEventChannel::new_with_session(
+                4,
+                ThreadSessionState {
+                    approval_policy: AskForApproval::OnRequest,
+                    sandbox_policy: SandboxPolicy::new_workspace_write_policy(),
+                    rollout_path: Some(PathBuf::from("/tmp/agent-rollout.jsonl")),
+                    ..test_thread_session(agent_thread_id, PathBuf::from("/tmp/agent"))
+                },
+                Vec::new(),
+            ),
+        );
+        app.agent_navigation.upsert(
+            agent_thread_id,
+            Some("Robie".to_string()),
+            Some("explorer".to_string()),
+            false,
+        );
+
+        app.enqueue_thread_request(
+            agent_thread_id,
+            exec_approval_request(agent_thread_id, "turn-approval", "call-approval", None),
+        )
+        .await?;
+        assert_eq!(
+            app.chat_widget.pending_thread_approvals(),
+            &["Robie [explorer]".to_string()]
+        );
+
+        app.enqueue_thread_notification(
+            agent_thread_id,
+            turn_completed_notification(agent_thread_id, "turn-approval", TurnStatus::Completed),
+        )
+        .await?;
+
+        assert!(
+            app.chat_widget.pending_thread_approvals().is_empty(),
+            "turn completion should clear inactive-thread approval badge immediately"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn legacy_warning_eviction_clears_pending_interactive_replay_state() -> Result<()> {
+        let mut app = make_test_app().await;
+        let thread_id = ThreadId::new();
+        let channel = ThreadEventChannel::new(1);
+        {
+            let mut store = channel.store.lock().await;
+            store.push_request(exec_approval_request(
+                thread_id,
+                "turn-approval",
+                "call-approval",
+                None,
+            ));
+            assert_eq!(store.has_pending_thread_approvals(), true);
+        }
+        app.thread_event_channels.insert(thread_id, channel);
+
+        app.enqueue_thread_legacy_warning(thread_id, "legacy warning".to_string())
+            .await?;
+
+        let store = app
+            .thread_event_channels
+            .get(&thread_id)
+            .expect("thread store should exist")
+            .store
+            .lock()
+            .await;
+        assert_eq!(store.has_pending_thread_approvals(), false);
+        let snapshot = store.snapshot();
+        assert_eq!(snapshot.events.len(), 1);
+        assert!(matches!(
+            snapshot.events.first(),
+            Some(ThreadBufferedEvent::LegacyWarning(message)) if message == "legacy warning"
+        ));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn legacy_thread_rollback_trims_inactive_thread_snapshot_state() -> Result<()> {
+        let mut app = make_test_app().await;
+        let thread_id = ThreadId::new();
+        let session = test_thread_session(thread_id, PathBuf::from("/tmp/project"));
+        let turns = vec![
+            test_turn("turn-1", TurnStatus::Completed, Vec::new()),
+            test_turn("turn-2", TurnStatus::Completed, Vec::new()),
+        ];
+        let channel = ThreadEventChannel::new_with_session(4, session, turns);
+        {
+            let mut store = channel.store.lock().await;
+            store.push_request(exec_approval_request(
+                thread_id,
+                "turn-approval",
+                "call-approval",
+                None,
+            ));
+            assert_eq!(store.has_pending_thread_approvals(), true);
+        }
+        app.thread_event_channels.insert(thread_id, channel);
+
+        app.enqueue_thread_legacy_rollback(thread_id, 1).await?;
+
+        let store = app
+            .thread_event_channels
+            .get(&thread_id)
+            .expect("thread store should exist")
+            .store
+            .lock()
+            .await;
+        assert_eq!(
+            store.turns,
+            vec![test_turn("turn-1", TurnStatus::Completed, Vec::new())]
+        );
+        assert_eq!(store.has_pending_thread_approvals(), false);
+        let snapshot = store.snapshot();
+        assert_eq!(snapshot.turns, store.turns);
+        assert!(snapshot.events.is_empty());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn inactive_thread_started_notification_initializes_replay_session() -> Result<()> {
+        let mut app = make_test_app().await;
+        let temp_dir = tempdir()?;
+        let main_thread_id =
+            ThreadId::from_string("00000000-0000-0000-0000-000000000101").expect("valid thread");
+        let agent_thread_id =
+            ThreadId::from_string("00000000-0000-0000-0000-000000000202").expect("valid thread");
+        let primary_session = ThreadSessionState {
+            approval_policy: AskForApproval::OnRequest,
+            sandbox_policy: SandboxPolicy::new_workspace_write_policy(),
+            ..test_thread_session(main_thread_id, PathBuf::from("/tmp/main"))
+        };
+
+        app.primary_thread_id = Some(main_thread_id);
+        app.active_thread_id = Some(main_thread_id);
+        app.primary_session_configured = Some(primary_session.clone());
+        app.thread_event_channels.insert(
+            main_thread_id,
+            ThreadEventChannel::new_with_session(4, primary_session.clone(), Vec::new()),
+        );
+
+        let rollout_path = temp_dir.path().join("agent-rollout.jsonl");
+        let turn_context = TurnContextItem {
+            turn_id: None,
+            trace_id: None,
+            cwd: PathBuf::from("/tmp/agent"),
+            current_date: None,
+            timezone: None,
+            approval_policy: primary_session.approval_policy,
+            sandbox_policy: primary_session.sandbox_policy.clone(),
+            network: None,
+            model: "gpt-agent".to_string(),
+            personality: None,
+            collaboration_mode: None,
+            realtime_active: Some(false),
+            effort: primary_session.reasoning_effort,
+            summary: app.config.model_reasoning_summary.unwrap_or_default(),
+            user_instructions: None,
+            developer_instructions: None,
+            final_output_json_schema: None,
+            truncation_policy: None,
+        };
+        let rollout = RolloutLine {
+            timestamp: "t0".to_string(),
+            item: RolloutItem::TurnContext(turn_context),
+        };
+        std::fs::write(
+            &rollout_path,
+            format!("{}\n", serde_json::to_string(&rollout)?),
+        )?;
+        app.enqueue_thread_notification(
+            agent_thread_id,
+            ServerNotification::ThreadStarted(ThreadStartedNotification {
+                thread: Thread {
+                    id: agent_thread_id.to_string(),
+                    preview: "agent thread".to_string(),
+                    ephemeral: false,
+                    model_provider: "agent-provider".to_string(),
+                    created_at: 1,
+                    updated_at: 2,
+                    status: codex_app_server_protocol::ThreadStatus::Idle,
+                    path: Some(rollout_path.clone()),
+                    cwd: PathBuf::from("/tmp/agent"),
+                    cli_version: "0.0.0".to_string(),
+                    source: codex_app_server_protocol::SessionSource::Unknown,
+                    agent_nickname: Some("Robie".to_string()),
+                    agent_role: Some("explorer".to_string()),
+                    git_info: None,
+                    name: Some("agent thread".to_string()),
+                    turns: Vec::new(),
+                },
+            }),
+        )
+        .await?;
+
+        let store = app
+            .thread_event_channels
+            .get(&agent_thread_id)
+            .expect("agent thread channel")
+            .store
+            .lock()
+            .await;
+        let session = store.session.clone().expect("inferred session");
+        drop(store);
+
+        assert_eq!(session.thread_id, agent_thread_id);
+        assert_eq!(session.thread_name, Some("agent thread".to_string()));
+        assert_eq!(session.model, "gpt-agent");
+        assert_eq!(session.model_provider_id, "agent-provider");
+        assert_eq!(session.approval_policy, primary_session.approval_policy);
+        assert_eq!(session.cwd, PathBuf::from("/tmp/agent"));
+        assert_eq!(session.rollout_path, Some(rollout_path));
+        assert_eq!(
+            app.agent_navigation.get(&agent_thread_id),
+            Some(&AgentPickerThreadEntry {
+                agent_nickname: Some("Robie".to_string()),
+                agent_role: Some("explorer".to_string()),
+                is_closed: false,
+            })
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn inactive_thread_started_notification_preserves_primary_model_when_path_missing()
+    -> Result<()> {
+        let mut app = make_test_app().await;
+        let main_thread_id =
+            ThreadId::from_string("00000000-0000-0000-0000-000000000301").expect("valid thread");
+        let agent_thread_id =
+            ThreadId::from_string("00000000-0000-0000-0000-000000000302").expect("valid thread");
+        let primary_session = ThreadSessionState {
+            approval_policy: AskForApproval::OnRequest,
+            sandbox_policy: SandboxPolicy::new_workspace_write_policy(),
+            ..test_thread_session(main_thread_id, PathBuf::from("/tmp/main"))
+        };
+
+        app.primary_thread_id = Some(main_thread_id);
+        app.active_thread_id = Some(main_thread_id);
+        app.primary_session_configured = Some(primary_session.clone());
+        app.thread_event_channels.insert(
+            main_thread_id,
+            ThreadEventChannel::new_with_session(4, primary_session.clone(), Vec::new()),
+        );
+
+        app.enqueue_thread_notification(
+            agent_thread_id,
+            ServerNotification::ThreadStarted(ThreadStartedNotification {
+                thread: Thread {
+                    id: agent_thread_id.to_string(),
+                    preview: "agent thread".to_string(),
+                    ephemeral: false,
+                    model_provider: "agent-provider".to_string(),
+                    created_at: 1,
+                    updated_at: 2,
+                    status: codex_app_server_protocol::ThreadStatus::Idle,
+                    path: None,
+                    cwd: PathBuf::from("/tmp/agent"),
+                    cli_version: "0.0.0".to_string(),
+                    source: codex_app_server_protocol::SessionSource::Unknown,
+                    agent_nickname: Some("Robie".to_string()),
+                    agent_role: Some("explorer".to_string()),
+                    git_info: None,
+                    name: Some("agent thread".to_string()),
+                    turns: Vec::new(),
+                },
+            }),
+        )
+        .await?;
+
+        let store = app
+            .thread_event_channels
+            .get(&agent_thread_id)
+            .expect("agent thread channel")
+            .store
+            .lock()
+            .await;
+        let session = store.session.clone().expect("inferred session");
+
+        assert_eq!(session.model, primary_session.model);
 
         Ok(())
     }
@@ -6831,7 +7527,9 @@ guardian_approval = true
         app.primary_thread_id = Some(ThreadId::new());
 
         assert_eq!(
-            app.active_non_primary_shutdown_target(&EventMsg::SkillsUpdateAvailable),
+            app.active_non_primary_shutdown_target(&ServerNotification::SkillsChanged(
+                codex_app_server_protocol::SkillsChangedNotification {},
+            )),
             None
         );
         Ok(())
@@ -6846,7 +7544,7 @@ guardian_approval = true
         app.primary_thread_id = Some(thread_id);
 
         assert_eq!(
-            app.active_non_primary_shutdown_target(&EventMsg::ShutdownComplete),
+            app.active_non_primary_shutdown_target(&thread_closed_notification(thread_id)),
             None
         );
         Ok(())
@@ -6862,7 +7560,7 @@ guardian_approval = true
         app.primary_thread_id = Some(primary_thread_id);
 
         assert_eq!(
-            app.active_non_primary_shutdown_target(&EventMsg::ShutdownComplete),
+            app.active_non_primary_shutdown_target(&thread_closed_notification(active_thread_id)),
             Some((active_thread_id, primary_thread_id))
         );
         Ok(())
@@ -6879,7 +7577,7 @@ guardian_approval = true
         app.pending_shutdown_exit_thread_id = Some(active_thread_id);
 
         assert_eq!(
-            app.active_non_primary_shutdown_target(&EventMsg::ShutdownComplete),
+            app.active_non_primary_shutdown_target(&thread_closed_notification(active_thread_id)),
             None
         );
         Ok(())
@@ -6896,7 +7594,7 @@ guardian_approval = true
         app.pending_shutdown_exit_thread_id = Some(ThreadId::new());
 
         assert_eq!(
-            app.active_non_primary_shutdown_target(&EventMsg::ShutdownComplete),
+            app.active_non_primary_shutdown_target(&thread_closed_notification(active_thread_id)),
             Some((active_thread_id, primary_thread_id))
         );
         Ok(())
@@ -7084,7 +7782,6 @@ guardian_approval = true
             feedback_audience: FeedbackAudience::External,
             remote_app_server_url: None,
             pending_update_action: None,
-            suppress_shutdown_complete: false,
             pending_shutdown_exit_thread_id: None,
             windows_sandbox: WindowsSandboxState::default(),
             thread_event_channels: HashMap::new(),
@@ -7136,7 +7833,6 @@ guardian_approval = true
                 feedback_audience: FeedbackAudience::External,
                 remote_app_server_url: None,
                 pending_update_action: None,
-                suppress_shutdown_complete: false,
                 pending_shutdown_exit_thread_id: None,
                 windows_sandbox: WindowsSandboxState::default(),
                 thread_event_channels: HashMap::new(),
@@ -7154,390 +7850,126 @@ guardian_approval = true
         )
     }
 
-    #[tokio::test]
-    async fn restore_started_app_server_thread_replays_remote_history() -> Result<()> {
-        let (mut app, mut app_event_rx, _op_rx) = make_test_app_with_channels().await;
-        let thread_id = ThreadId::new();
-
-        app.restore_started_app_server_thread(AppServerStartedThread {
-            thread: Thread {
-                id: thread_id.to_string(),
-                preview: "hello".to_string(),
-                ephemeral: false,
-                model_provider: "test-provider".to_string(),
-                created_at: 0,
-                updated_at: 0,
-                status: ThreadStatus::Idle,
-                path: None,
-                cwd: PathBuf::from("/tmp/project"),
-                cli_version: "test".to_string(),
-                source: SessionSource::Cli.into(),
-                agent_nickname: None,
-                agent_role: None,
-                git_info: None,
-                name: Some("restored".to_string()),
-                turns: vec![Turn {
-                    id: "turn-1".to_string(),
-                    items: vec![
-                        ThreadItem::UserMessage {
-                            id: "user-1".to_string(),
-                            content: vec![codex_app_server_protocol::UserInput::Text {
-                                text: "hello from remote".to_string(),
-                                text_elements: Vec::new(),
-                            }],
-                        },
-                        ThreadItem::AgentMessage {
-                            id: "assistant-1".to_string(),
-                            text: "restored response".to_string(),
-                            phase: None,
-                        },
-                    ],
-                    status: TurnStatus::Completed,
-                    error: None,
-                }],
-            },
-            session_configured: SessionConfiguredEvent {
-                session_id: thread_id,
-                forked_from_id: None,
-                thread_name: Some("restored".to_string()),
-                model: "gpt-test".to_string(),
-                model_provider_id: "test-provider".to_string(),
-                service_tier: None,
-                approval_policy: AskForApproval::Never,
-                approvals_reviewer: ApprovalsReviewer::User,
-                sandbox_policy: SandboxPolicy::new_read_only_policy(),
-                cwd: PathBuf::from("/tmp/project"),
-                reasoning_effort: None,
-                history_log_id: 0,
-                history_entry_count: 0,
-                initial_messages: None,
-                network_proxy: None,
-                rollout_path: Some(PathBuf::new()),
-            },
-            show_raw_agent_reasoning: false,
-        })
-        .await?;
-
-        while let Ok(event) = app_event_rx.try_recv() {
-            if let AppEvent::InsertHistoryCell(cell) = event {
-                let cell: Arc<dyn HistoryCell> = cell.into();
-                app.transcript_cells.push(cell);
-            }
+    fn test_thread_session(thread_id: ThreadId, cwd: PathBuf) -> ThreadSessionState {
+        ThreadSessionState {
+            thread_id,
+            forked_from_id: None,
+            thread_name: None,
+            model: "gpt-test".to_string(),
+            model_provider_id: "test-provider".to_string(),
+            service_tier: None,
+            approval_policy: AskForApproval::Never,
+            approvals_reviewer: ApprovalsReviewer::User,
+            sandbox_policy: SandboxPolicy::new_read_only_policy(),
+            cwd,
+            reasoning_effort: None,
+            history_log_id: 0,
+            history_entry_count: 0,
+            network_proxy: None,
+            rollout_path: Some(PathBuf::new()),
         }
-
-        assert_eq!(app.primary_thread_id, Some(thread_id));
-        assert_eq!(app.active_thread_id, Some(thread_id));
-
-        let user_messages: Vec<String> = app
-            .transcript_cells
-            .iter()
-            .filter_map(|cell| {
-                cell.as_any()
-                    .downcast_ref::<UserHistoryCell>()
-                    .map(|cell| cell.message.clone())
-            })
-            .collect();
-        let agent_messages: Vec<String> = app
-            .transcript_cells
-            .iter()
-            .filter_map(|cell| {
-                cell.as_any()
-                    .downcast_ref::<AgentMessageCell>()
-                    .map(|cell| {
-                        cell.display_lines(80)
-                            .into_iter()
-                            .map(|line| line.to_string())
-                            .collect::<Vec<_>>()
-                            .join("\n")
-                    })
-            })
-            .collect();
-
-        assert_eq!(user_messages, vec!["hello from remote".to_string()]);
-        assert_eq!(agent_messages, vec!["• restored response".to_string()]);
-
-        Ok(())
     }
 
-    #[tokio::test]
-    async fn restore_started_app_server_thread_submits_initial_prompt_after_history_replay()
-    -> Result<()> {
-        let (mut app, mut app_event_rx, mut op_rx) = make_test_app_with_channels().await;
-        let thread_id = ThreadId::new();
-        app.chat_widget.set_initial_user_message_for_test(
-            crate::chatwidget::create_initial_user_message(
-                Some("resume prompt".to_string()),
-                Vec::new(),
-                Vec::new(),
-            ),
-        );
-
-        app.restore_started_app_server_thread(AppServerStartedThread {
-            thread: Thread {
-                id: thread_id.to_string(),
-                preview: "hello".to_string(),
-                ephemeral: false,
-                model_provider: "test-provider".to_string(),
-                created_at: 0,
-                updated_at: 0,
-                status: ThreadStatus::Idle,
-                path: None,
-                cwd: PathBuf::from("/tmp/project"),
-                cli_version: "test".to_string(),
-                source: SessionSource::Cli.into(),
-                agent_nickname: None,
-                agent_role: None,
-                git_info: None,
-                name: Some("restored".to_string()),
-                turns: vec![Turn {
-                    id: "turn-1".to_string(),
-                    items: vec![
-                        ThreadItem::UserMessage {
-                            id: "user-1".to_string(),
-                            content: vec![codex_app_server_protocol::UserInput::Text {
-                                text: "hello from remote".to_string(),
-                                text_elements: Vec::new(),
-                            }],
-                        },
-                        ThreadItem::AgentMessage {
-                            id: "assistant-1".to_string(),
-                            text: "restored response".to_string(),
-                            phase: None,
-                        },
-                    ],
-                    status: TurnStatus::Completed,
-                    error: None,
-                }],
-            },
-            session_configured: SessionConfiguredEvent {
-                session_id: thread_id,
-                forked_from_id: None,
-                thread_name: Some("restored".to_string()),
-                model: "gpt-test".to_string(),
-                model_provider_id: "test-provider".to_string(),
-                service_tier: None,
-                approval_policy: AskForApproval::Never,
-                approvals_reviewer: ApprovalsReviewer::User,
-                sandbox_policy: SandboxPolicy::new_read_only_policy(),
-                cwd: PathBuf::from("/tmp/project"),
-                reasoning_effort: None,
-                history_log_id: 0,
-                history_entry_count: 0,
-                initial_messages: None,
-                network_proxy: None,
-                rollout_path: Some(PathBuf::new()),
-            },
-            show_raw_agent_reasoning: false,
-        })
-        .await?;
-
-        while let Ok(event) = app_event_rx.try_recv() {
-            if let AppEvent::InsertHistoryCell(cell) = event {
-                let cell: Arc<dyn HistoryCell> = cell.into();
-                app.transcript_cells.push(cell);
-            }
+    fn test_turn(turn_id: &str, status: TurnStatus, items: Vec<ThreadItem>) -> Turn {
+        Turn {
+            id: turn_id.to_string(),
+            items,
+            status,
+            error: None,
         }
-
-        let user_messages: Vec<String> = app
-            .transcript_cells
-            .iter()
-            .filter_map(|cell| {
-                cell.as_any()
-                    .downcast_ref::<UserHistoryCell>()
-                    .map(|cell| cell.message.clone())
-            })
-            .collect();
-
-        assert_eq!(
-            user_messages,
-            vec!["hello from remote".to_string(), "resume prompt".to_string()]
-        );
-        match next_user_turn_op(&mut op_rx) {
-            Op::UserTurn { items, .. } => assert_eq!(
-                items,
-                vec![UserInput::Text {
-                    text: "resume prompt".to_string(),
-                    text_elements: Vec::new(),
-                }]
-            ),
-            other => panic!("expected resume prompt submission, got {other:?}"),
-        }
-
-        Ok(())
     }
 
-    #[tokio::test]
-    async fn restore_started_app_server_thread_replays_history_beyond_store_capacity() -> Result<()>
-    {
-        let (mut app, mut app_event_rx, _op_rx) = make_test_app_with_channels().await;
-        let thread_id = ThreadId::new();
-        let turn_count = THREAD_EVENT_CHANNEL_CAPACITY + 5;
-
-        let turns = (0..turn_count)
-            .map(|index| Turn {
-                id: format!("turn-{index}"),
-                items: vec![ThreadItem::UserMessage {
-                    id: format!("user-{index}"),
-                    content: vec![codex_app_server_protocol::UserInput::Text {
-                        text: format!("message {index}"),
-                        text_elements: Vec::new(),
-                    }],
-                }],
-                status: TurnStatus::Completed,
-                error: None,
-            })
-            .collect();
-
-        app.restore_started_app_server_thread(AppServerStartedThread {
-            thread: Thread {
-                id: thread_id.to_string(),
-                preview: "hello".to_string(),
-                ephemeral: false,
-                model_provider: "test-provider".to_string(),
-                created_at: 0,
-                updated_at: 0,
-                status: ThreadStatus::Idle,
-                path: None,
-                cwd: PathBuf::from("/tmp/project"),
-                cli_version: "test".to_string(),
-                source: SessionSource::Cli.into(),
-                agent_nickname: None,
-                agent_role: None,
-                git_info: None,
-                name: Some("restored".to_string()),
-                turns,
-            },
-            session_configured: SessionConfiguredEvent {
-                session_id: thread_id,
-                forked_from_id: None,
-                thread_name: Some("restored".to_string()),
-                model: "gpt-test".to_string(),
-                model_provider_id: "test-provider".to_string(),
-                service_tier: None,
-                approval_policy: AskForApproval::Never,
-                approvals_reviewer: ApprovalsReviewer::User,
-                sandbox_policy: SandboxPolicy::new_read_only_policy(),
-                cwd: PathBuf::from("/tmp/project"),
-                reasoning_effort: None,
-                history_log_id: 0,
-                history_entry_count: 0,
-                initial_messages: None,
-                network_proxy: None,
-                rollout_path: Some(PathBuf::new()),
-            },
-            show_raw_agent_reasoning: false,
+    fn turn_started_notification(thread_id: ThreadId, turn_id: &str) -> ServerNotification {
+        ServerNotification::TurnStarted(TurnStartedNotification {
+            thread_id: thread_id.to_string(),
+            turn: test_turn(turn_id, TurnStatus::InProgress, Vec::new()),
         })
-        .await?;
-
-        while let Ok(event) = app_event_rx.try_recv() {
-            if let AppEvent::InsertHistoryCell(cell) = event {
-                let cell: Arc<dyn HistoryCell> = cell.into();
-                app.transcript_cells.push(cell);
-            }
-        }
-
-        let user_messages: Vec<String> = app
-            .transcript_cells
-            .iter()
-            .filter_map(|cell| {
-                cell.as_any()
-                    .downcast_ref::<UserHistoryCell>()
-                    .map(|cell| cell.message.clone())
-            })
-            .collect();
-
-        assert_eq!(user_messages.len(), turn_count);
-        assert_eq!(user_messages.first().map(String::as_str), Some("message 0"));
-        let last_message = format!("message {}", turn_count - 1);
-        assert_eq!(
-            user_messages.last().map(String::as_str),
-            Some(last_message.as_str())
-        );
-
-        Ok(())
     }
 
-    #[tokio::test]
-    async fn restore_started_app_server_thread_replays_raw_reasoning_when_enabled() -> Result<()> {
-        let (mut app, mut app_event_rx, _op_rx) = make_test_app_with_channels().await;
-        let thread_id = ThreadId::new();
-
-        app.restore_started_app_server_thread(AppServerStartedThread {
-            thread: Thread {
-                id: thread_id.to_string(),
-                preview: "hello".to_string(),
-                ephemeral: false,
-                model_provider: "test-provider".to_string(),
-                created_at: 0,
-                updated_at: 0,
-                status: ThreadStatus::Idle,
-                path: None,
-                cwd: PathBuf::from("/tmp/project"),
-                cli_version: "test".to_string(),
-                source: SessionSource::Cli.into(),
-                agent_nickname: None,
-                agent_role: None,
-                git_info: None,
-                name: Some("restored".to_string()),
-                turns: vec![Turn {
-                    id: "turn-1".to_string(),
-                    items: vec![ThreadItem::Reasoning {
-                        id: "reasoning-1".to_string(),
-                        summary: vec!["summary reasoning".to_string()],
-                        content: vec!["raw reasoning".to_string()],
-                    }],
-                    status: TurnStatus::Completed,
-                    error: None,
-                }],
-            },
-            session_configured: SessionConfiguredEvent {
-                session_id: thread_id,
-                forked_from_id: None,
-                thread_name: Some("restored".to_string()),
-                model: "gpt-test".to_string(),
-                model_provider_id: "test-provider".to_string(),
-                service_tier: None,
-                approval_policy: AskForApproval::Never,
-                approvals_reviewer: ApprovalsReviewer::User,
-                sandbox_policy: SandboxPolicy::new_read_only_policy(),
-                cwd: PathBuf::from("/tmp/project"),
-                reasoning_effort: None,
-                history_log_id: 0,
-                history_entry_count: 0,
-                initial_messages: None,
-                network_proxy: None,
-                rollout_path: Some(PathBuf::new()),
-            },
-            show_raw_agent_reasoning: true,
+    fn turn_completed_notification(
+        thread_id: ThreadId,
+        turn_id: &str,
+        status: TurnStatus,
+    ) -> ServerNotification {
+        ServerNotification::TurnCompleted(TurnCompletedNotification {
+            thread_id: thread_id.to_string(),
+            turn: test_turn(turn_id, status, Vec::new()),
         })
-        .await?;
+    }
 
-        while let Ok(event) = app_event_rx.try_recv() {
-            if let AppEvent::InsertHistoryCell(cell) = event {
-                let cell: Arc<dyn HistoryCell> = cell.into();
-                app.transcript_cells.push(cell);
-            }
+    fn thread_closed_notification(thread_id: ThreadId) -> ServerNotification {
+        ServerNotification::ThreadClosed(ThreadClosedNotification {
+            thread_id: thread_id.to_string(),
+        })
+    }
+
+    fn token_usage_notification(
+        thread_id: ThreadId,
+        turn_id: &str,
+        model_context_window: Option<i64>,
+    ) -> ServerNotification {
+        ServerNotification::ThreadTokenUsageUpdated(ThreadTokenUsageUpdatedNotification {
+            thread_id: thread_id.to_string(),
+            turn_id: turn_id.to_string(),
+            token_usage: ThreadTokenUsage {
+                total: TokenUsageBreakdown {
+                    total_tokens: 10,
+                    input_tokens: 4,
+                    cached_input_tokens: 1,
+                    output_tokens: 5,
+                    reasoning_output_tokens: 0,
+                },
+                last: TokenUsageBreakdown {
+                    total_tokens: 10,
+                    input_tokens: 4,
+                    cached_input_tokens: 1,
+                    output_tokens: 5,
+                    reasoning_output_tokens: 0,
+                },
+                model_context_window,
+            },
+        })
+    }
+
+    fn agent_message_delta_notification(
+        thread_id: ThreadId,
+        turn_id: &str,
+        item_id: &str,
+        delta: &str,
+    ) -> ServerNotification {
+        ServerNotification::AgentMessageDelta(AgentMessageDeltaNotification {
+            thread_id: thread_id.to_string(),
+            turn_id: turn_id.to_string(),
+            item_id: item_id.to_string(),
+            delta: delta.to_string(),
+        })
+    }
+
+    fn exec_approval_request(
+        thread_id: ThreadId,
+        turn_id: &str,
+        item_id: &str,
+        approval_id: Option<&str>,
+    ) -> ServerRequest {
+        ServerRequest::CommandExecutionRequestApproval {
+            request_id: AppServerRequestId::Integer(1),
+            params: CommandExecutionRequestApprovalParams {
+                thread_id: thread_id.to_string(),
+                turn_id: turn_id.to_string(),
+                item_id: item_id.to_string(),
+                approval_id: approval_id.map(str::to_string),
+                reason: Some("needs approval".to_string()),
+                network_approval_context: None,
+                command: Some("echo hello".to_string()),
+                cwd: Some(PathBuf::from("/tmp/project")),
+                command_actions: None,
+                additional_permissions: None,
+                skill_metadata: None,
+                proposed_execpolicy_amendment: None,
+                proposed_network_policy_amendments: None,
+                available_decisions: None,
+            },
         }
-
-        let channel = app
-            .thread_event_channels
-            .get(&thread_id)
-            .expect("restored thread channel should exist");
-        let snapshot = channel.store.lock().await.snapshot();
-        let replayed_raw_reasoning = snapshot.events.iter().any(|event| {
-            matches!(
-                &event.msg,
-                EventMsg::AgentReasoningRawContent(raw) if raw.text == "raw reasoning"
-            )
-        });
-
-        assert!(
-            replayed_raw_reasoning,
-            "expected restored snapshot to keep raw reasoning event: {:?}",
-            snapshot.events
-        );
-
-        Ok(())
     }
 
     #[test]
@@ -7545,33 +7977,74 @@ guardian_approval = true
         let mut store = ThreadEventStore::new(8);
         assert_eq!(store.active_turn_id(), None);
 
-        store.push_event(Event {
-            id: "turn-started".to_string(),
-            msg: EventMsg::TurnStarted(TurnStartedEvent {
-                turn_id: "turn-1".to_string(),
-                model_context_window: Some(128_000),
-                collaboration_mode_kind: ModeKind::Default,
-            }),
-        });
+        let thread_id = ThreadId::new();
+        store.push_notification(turn_started_notification(thread_id, "turn-1"));
         assert_eq!(store.active_turn_id(), Some("turn-1"));
 
-        store.push_event(Event {
-            id: "other-turn-complete".to_string(),
-            msg: EventMsg::TurnComplete(TurnCompleteEvent {
-                turn_id: "turn-2".to_string(),
-                last_agent_message: None,
-            }),
-        });
+        store.push_notification(turn_completed_notification(
+            thread_id,
+            "turn-2",
+            TurnStatus::Completed,
+        ));
         assert_eq!(store.active_turn_id(), Some("turn-1"));
 
-        store.push_event(Event {
-            id: "turn-aborted".to_string(),
-            msg: EventMsg::TurnAborted(TurnAbortedEvent {
-                turn_id: Some("turn-1".to_string()),
-                reason: TurnAbortReason::Interrupted,
-            }),
-        });
+        store.push_notification(turn_completed_notification(
+            thread_id,
+            "turn-1",
+            TurnStatus::Interrupted,
+        ));
         assert_eq!(store.active_turn_id(), None);
+    }
+
+    #[test]
+    fn thread_event_store_restores_active_turn_from_snapshot_turns() {
+        let thread_id = ThreadId::new();
+        let session = test_thread_session(thread_id, PathBuf::from("/tmp/project"));
+        let turns = vec![
+            test_turn("turn-1", TurnStatus::Completed, Vec::new()),
+            test_turn("turn-2", TurnStatus::InProgress, Vec::new()),
+        ];
+
+        let store = ThreadEventStore::new_with_session(8, session.clone(), turns.clone());
+        assert_eq!(store.active_turn_id(), Some("turn-2"));
+
+        let mut refreshed_store = ThreadEventStore::new(8);
+        refreshed_store.set_session(session, turns);
+        assert_eq!(refreshed_store.active_turn_id(), Some("turn-2"));
+    }
+
+    #[test]
+    fn thread_event_store_rebase_preserves_resolved_request_state() {
+        let thread_id = ThreadId::new();
+        let mut store = ThreadEventStore::new(8);
+        store.push_request(exec_approval_request(
+            thread_id,
+            "turn-approval",
+            "call-approval",
+            None,
+        ));
+        store.push_notification(ServerNotification::ServerRequestResolved(
+            codex_app_server_protocol::ServerRequestResolvedNotification {
+                request_id: AppServerRequestId::Integer(1),
+                thread_id: thread_id.to_string(),
+            },
+        ));
+
+        store.rebase_buffer_after_session_refresh();
+
+        let snapshot = store.snapshot();
+        assert!(snapshot.events.is_empty());
+        assert_eq!(store.has_pending_thread_approvals(), false);
+    }
+
+    #[test]
+    fn thread_event_store_consumes_matching_local_legacy_rollback_once() {
+        let mut store = ThreadEventStore::new(8);
+        store.note_local_thread_rollback(2);
+
+        assert!(store.consume_pending_local_legacy_rollback(2));
+        assert!(!store.consume_pending_local_legacy_rollback(2));
+        assert!(!store.consume_pending_local_legacy_rollback(1));
     }
 
     fn next_user_turn_op(op_rx: &mut tokio::sync::mpsc::UnboundedReceiver<Op>) -> Op {
@@ -7583,6 +8056,19 @@ guardian_approval = true
             seen.push(format!("{op:?}"));
         }
         panic!("expected UserTurn op, saw: {seen:?}");
+    }
+
+    fn lines_to_single_string(lines: &[Line<'_>]) -> String {
+        lines
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|span| span.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 
     fn test_session_telemetry(config: &Config, model: &str) -> SessionTelemetry {
@@ -8331,71 +8817,62 @@ guardian_approval = true
     }
 
     #[tokio::test]
-    async fn replayed_initial_messages_apply_rollback_in_queue_order() {
+    async fn replay_thread_snapshot_replays_turn_history_in_order() {
         let (mut app, mut app_event_rx, _op_rx) = make_test_app_with_channels().await;
+        let thread_id = ThreadId::new();
+        app.replay_thread_snapshot(
+            ThreadEventSnapshot {
+                session: Some(test_thread_session(
+                    thread_id,
+                    PathBuf::from("/home/user/project"),
+                )),
+                turns: vec![
+                    Turn {
+                        id: "turn-1".to_string(),
+                        items: vec![ThreadItem::UserMessage {
+                            id: "user-1".to_string(),
+                            content: vec![AppServerUserInput::Text {
+                                text: "first prompt".to_string(),
+                                text_elements: Vec::new(),
+                            }],
+                        }],
+                        status: TurnStatus::Completed,
+                        error: None,
+                    },
+                    Turn {
+                        id: "turn-2".to_string(),
+                        items: vec![
+                            ThreadItem::UserMessage {
+                                id: "user-2".to_string(),
+                                content: vec![AppServerUserInput::Text {
+                                    text: "third prompt".to_string(),
+                                    text_elements: Vec::new(),
+                                }],
+                            },
+                            ThreadItem::AgentMessage {
+                                id: "assistant-2".to_string(),
+                                text: "done".to_string(),
+                                phase: None,
+                                memory_citation: None,
+                            },
+                        ],
+                        status: TurnStatus::Completed,
+                        error: None,
+                    },
+                ],
+                events: Vec::new(),
+                input_state: None,
+            },
+            false,
+        );
 
-        let session_id = ThreadId::new();
-        app.handle_codex_event_replay(Event {
-            id: String::new(),
-            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
-                session_id,
-                forked_from_id: None,
-                thread_name: None,
-                model: "gpt-test".to_string(),
-                model_provider_id: "test-provider".to_string(),
-                service_tier: None,
-                approval_policy: AskForApproval::Never,
-                approvals_reviewer: ApprovalsReviewer::User,
-                sandbox_policy: SandboxPolicy::new_read_only_policy(),
-                cwd: PathBuf::from("/home/user/project"),
-                reasoning_effort: None,
-                history_log_id: 0,
-                history_entry_count: 0,
-                initial_messages: Some(vec![
-                    EventMsg::UserMessage(UserMessageEvent {
-                        message: "first prompt".to_string(),
-                        images: None,
-                        local_images: Vec::new(),
-                        text_elements: Vec::new(),
-                    }),
-                    EventMsg::UserMessage(UserMessageEvent {
-                        message: "second prompt".to_string(),
-                        images: None,
-                        local_images: Vec::new(),
-                        text_elements: Vec::new(),
-                    }),
-                    EventMsg::ThreadRolledBack(ThreadRolledBackEvent { num_turns: 1 }),
-                    EventMsg::UserMessage(UserMessageEvent {
-                        message: "third prompt".to_string(),
-                        images: None,
-                        local_images: Vec::new(),
-                        text_elements: Vec::new(),
-                    }),
-                ]),
-                network_proxy: None,
-                rollout_path: Some(PathBuf::new()),
-            }),
-        });
-
-        let mut saw_rollback = false;
         while let Ok(event) = app_event_rx.try_recv() {
-            match event {
-                AppEvent::InsertHistoryCell(cell) => {
-                    let cell: Arc<dyn HistoryCell> = cell.into();
-                    app.transcript_cells.push(cell);
-                }
-                AppEvent::ApplyThreadRollback { num_turns } => {
-                    saw_rollback = true;
-                    crate::app_backtrack::trim_transcript_cells_drop_last_n_user_turns(
-                        &mut app.transcript_cells,
-                        num_turns,
-                    );
-                }
-                _ => {}
+            if let AppEvent::InsertHistoryCell(cell) = event {
+                let cell: Arc<dyn HistoryCell> = cell.into();
+                app.transcript_cells.push(cell);
             }
         }
 
-        assert!(saw_rollback);
         let user_messages: Vec<String> = app
             .transcript_cells
             .iter()
@@ -8412,80 +8889,60 @@ guardian_approval = true
     }
 
     #[tokio::test]
-    async fn live_rollback_during_replay_is_applied_in_app_event_order() {
-        let (mut app, mut app_event_rx, _op_rx) = make_test_app_with_channels().await;
+    async fn refreshed_snapshot_session_persists_resumed_turns() {
+        let mut app = make_test_app().await;
+        let thread_id = ThreadId::new();
+        let initial_session = test_thread_session(thread_id, PathBuf::from("/tmp/original"));
+        app.thread_event_channels.insert(
+            thread_id,
+            ThreadEventChannel::new_with_session(4, initial_session.clone(), Vec::new()),
+        );
 
-        let session_id = ThreadId::new();
-        app.handle_codex_event_replay(Event {
-            id: String::new(),
-            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
-                session_id,
-                forked_from_id: None,
-                thread_name: None,
-                model: "gpt-test".to_string(),
-                model_provider_id: "test-provider".to_string(),
-                service_tier: None,
-                approval_policy: AskForApproval::Never,
-                approvals_reviewer: ApprovalsReviewer::User,
-                sandbox_policy: SandboxPolicy::new_read_only_policy(),
-                cwd: PathBuf::from("/home/user/project"),
-                reasoning_effort: None,
-                history_log_id: 0,
-                history_entry_count: 0,
-                initial_messages: Some(vec![
-                    EventMsg::UserMessage(UserMessageEvent {
-                        message: "first prompt".to_string(),
-                        images: None,
-                        local_images: Vec::new(),
-                        text_elements: Vec::new(),
-                    }),
-                    EventMsg::UserMessage(UserMessageEvent {
-                        message: "second prompt".to_string(),
-                        images: None,
-                        local_images: Vec::new(),
-                        text_elements: Vec::new(),
-                    }),
-                ]),
-                network_proxy: None,
-                rollout_path: Some(PathBuf::new()),
-            }),
-        });
+        let resumed_turns = vec![test_turn(
+            "turn-1",
+            TurnStatus::Completed,
+            vec![ThreadItem::UserMessage {
+                id: "user-1".to_string(),
+                content: vec![AppServerUserInput::Text {
+                    text: "restored prompt".to_string(),
+                    text_elements: Vec::new(),
+                }],
+            }],
+        )];
+        let resumed_session = ThreadSessionState {
+            cwd: PathBuf::from("/tmp/refreshed"),
+            ..initial_session.clone()
+        };
+        let mut snapshot = ThreadEventSnapshot {
+            session: Some(initial_session),
+            turns: Vec::new(),
+            events: Vec::new(),
+            input_state: None,
+        };
 
-        // Simulate a live rollback arriving before queued replay inserts are drained.
-        app.handle_codex_event_now(Event {
-            id: "live-rollback".to_string(),
-            msg: EventMsg::ThreadRolledBack(ThreadRolledBackEvent { num_turns: 1 }),
-        });
+        app.apply_refreshed_snapshot_thread(
+            thread_id,
+            AppServerStartedThread {
+                session: resumed_session.clone(),
+                turns: resumed_turns.clone(),
+            },
+            &mut snapshot,
+        )
+        .await;
 
-        let mut saw_rollback = false;
-        while let Ok(event) = app_event_rx.try_recv() {
-            match event {
-                AppEvent::InsertHistoryCell(cell) => {
-                    let cell: Arc<dyn HistoryCell> = cell.into();
-                    app.transcript_cells.push(cell);
-                }
-                AppEvent::ApplyThreadRollback { num_turns } => {
-                    saw_rollback = true;
-                    crate::app_backtrack::trim_transcript_cells_drop_last_n_user_turns(
-                        &mut app.transcript_cells,
-                        num_turns,
-                    );
-                }
-                _ => {}
-            }
-        }
+        assert_eq!(snapshot.session, Some(resumed_session.clone()));
+        assert_eq!(snapshot.turns, resumed_turns);
 
-        assert!(saw_rollback);
-        let user_messages: Vec<String> = app
-            .transcript_cells
-            .iter()
-            .filter_map(|cell| {
-                cell.as_any()
-                    .downcast_ref::<UserHistoryCell>()
-                    .map(|cell| cell.message.clone())
-            })
-            .collect();
-        assert_eq!(user_messages, vec!["first prompt".to_string()]);
+        let store = app
+            .thread_event_channels
+            .get(&thread_id)
+            .expect("thread channel")
+            .store
+            .lock()
+            .await;
+        let store_snapshot = store.snapshot();
+        assert_eq!(store_snapshot.session, Some(resumed_session));
+        assert_eq!(store_snapshot.turns, snapshot.turns);
     }
 
     #[tokio::test]
@@ -8539,6 +8996,108 @@ guardian_approval = true
             _ => panic!("expected transcript overlay"),
         };
         assert_eq!(overlay_cell_count, app.transcript_cells.len());
+    }
+
+    #[tokio::test]
+    async fn thread_rollback_response_discards_queued_active_thread_events() {
+        let mut app = make_test_app().await;
+        let thread_id = ThreadId::new();
+        let (tx, rx) = mpsc::channel(8);
+        app.active_thread_id = Some(thread_id);
+        app.active_thread_rx = Some(rx);
+        tx.send(ThreadBufferedEvent::LegacyWarning(
+            "stale warning".to_string(),
+        ))
+        .await
+        .expect("event should queue");
+
+        app.handle_thread_rollback_response(
+            thread_id,
+            1,
+            &ThreadRollbackResponse {
+                thread: Thread {
+                    id: thread_id.to_string(),
+                    preview: String::new(),
+                    ephemeral: false,
+                    model_provider: "openai".to_string(),
+                    created_at: 0,
+                    updated_at: 0,
+                    status: codex_app_server_protocol::ThreadStatus::Idle,
+                    path: None,
+                    cwd: PathBuf::from("/tmp/project"),
+                    cli_version: "0.0.0".to_string(),
+                    source: SessionSource::Cli.into(),
+                    agent_nickname: None,
+                    agent_role: None,
+                    git_info: None,
+                    name: None,
+                    turns: Vec::new(),
+                },
+            },
+        )
+        .await;
+
+        let rx = app
+            .active_thread_rx
+            .as_mut()
+            .expect("active receiver should remain attached");
+        assert!(matches!(rx.try_recv(), Err(TryRecvError::Empty)));
+    }
+
+    #[tokio::test]
+    async fn local_rollback_response_suppresses_matching_legacy_rollback() {
+        let mut app = make_test_app().await;
+        let thread_id = ThreadId::new();
+        let session = test_thread_session(thread_id, PathBuf::from("/tmp/project"));
+        let initial_turns = vec![
+            test_turn("turn-1", TurnStatus::Completed, Vec::new()),
+            test_turn("turn-2", TurnStatus::Completed, Vec::new()),
+        ];
+        app.thread_event_channels.insert(
+            thread_id,
+            ThreadEventChannel::new_with_session(8, session, initial_turns),
+        );
+
+        app.handle_thread_rollback_response(
+            thread_id,
+            1,
+            &ThreadRollbackResponse {
+                thread: Thread {
+                    id: thread_id.to_string(),
+                    preview: String::new(),
+                    ephemeral: false,
+                    model_provider: "openai".to_string(),
+                    created_at: 0,
+                    updated_at: 0,
+                    status: codex_app_server_protocol::ThreadStatus::Idle,
+                    path: None,
+                    cwd: PathBuf::from("/tmp/project"),
+                    cli_version: "0.0.0".to_string(),
+                    source: SessionSource::Cli.into(),
+                    agent_nickname: None,
+                    agent_role: None,
+                    git_info: None,
+                    name: None,
+                    turns: vec![test_turn("turn-1", TurnStatus::Completed, Vec::new())],
+                },
+            },
+        )
+        .await;
+
+        app.enqueue_thread_legacy_rollback(thread_id, 1)
+            .await
+            .expect("legacy rollback should not fail");
+
+        let store = app
+            .thread_event_channels
+            .get(&thread_id)
+            .expect("thread channel")
+            .store
+            .lock()
+            .await;
+        let snapshot = store.snapshot();
+        assert_eq!(snapshot.turns.len(), 1);
+        assert!(snapshot.events.is_empty());
     }
 
     #[tokio::test]

--- a/codex-rs/tui_app_server/src/app.rs
+++ b/codex-rs/tui_app_server/src/app.rs
@@ -1605,6 +1605,13 @@ impl App {
         self.note_thread_outbound_op(thread_id, op).await;
     }
 
+    /// Clears any queued or visible exec approval that is no longer backed by
+    /// a live app-server request.
+    ///
+    /// Legacy approvals can be buffered in several places at once: the primary
+    /// pre-session queue, the active/inactive per-thread receivers, replay
+    /// state, and the live modal stack. Cleanup has to touch all of them so a
+    /// resolved approval cannot reappear after a thread switch or replay.
     async fn note_app_server_request_resolved(&mut self, resolved: ResolvedAppServerRequest) {
         if resolved.exec_approval_ids.is_empty() {
             return;
@@ -1642,6 +1649,8 @@ impl App {
         self.refresh_pending_thread_approvals().await;
     }
 
+    /// Drains the active receiver, filters resolved exec approvals, then
+    /// restores unrelated events in their existing queue order.
     async fn remove_resolved_exec_approvals_from_active_queue(&mut self, approval_ids: &[String]) {
         let Some(thread_id) = self.active_thread_id else {
             return;
@@ -1700,6 +1709,8 @@ impl App {
         }
     }
 
+    /// Applies the same resolved-approval filtering to stored receivers for
+    /// inactive threads so stale prompts do not resurface after reactivation.
     fn remove_resolved_exec_approvals_from_inactive_queues(&mut self, approval_ids: &[String]) {
         let active_thread_id = self.active_thread_id;
 

--- a/codex-rs/tui_app_server/src/app/app_server_adapter.rs
+++ b/codex-rs/tui_app_server/src/app/app_server_adapter.rs
@@ -1,114 +1,23 @@
-/*
-This module holds the temporary adapter layer between the TUI and the app
-server during the hybrid migration period.
-
-For now, the TUI still owns its existing direct-core behavior, but startup
-allocates a local in-process app server and drains its event stream. Keeping
-the app-server-specific wiring here keeps that transitional logic out of the
-main `app.rs` orchestration path.
-
-As more TUI flows move onto the app-server surface directly, this adapter
-should shrink and eventually disappear.
-*/
-
 use super::App;
 use crate::app_event::AppEvent;
 use crate::app_server_session::AppServerSession;
 use crate::app_server_session::app_server_rate_limit_snapshot_to_core;
 use crate::app_server_session::status_account_display_from_auth_mode;
+use crate::exec_command::escape_command;
 use crate::local_chatgpt_auth::load_local_chatgpt_auth;
 use codex_app_server_client::AppServerEvent;
 use codex_app_server_protocol::AuthMode;
 use codex_app_server_protocol::ChatgptAuthTokensRefreshParams;
+use codex_app_server_protocol::CommandAction;
+use codex_app_server_protocol::CommandExecutionRequestApprovalParams;
+use codex_app_server_protocol::FileChangeRequestApprovalParams;
 use codex_app_server_protocol::JSONRPCErrorError;
 use codex_app_server_protocol::JSONRPCNotification;
 use codex_app_server_protocol::RequestId;
 use codex_app_server_protocol::ServerNotification;
 use codex_app_server_protocol::ServerRequest;
-#[cfg(test)]
-use codex_app_server_protocol::Thread;
-#[cfg(test)]
-use codex_app_server_protocol::ThreadItem;
-#[cfg(test)]
-use codex_app_server_protocol::Turn;
-#[cfg(test)]
-use codex_app_server_protocol::TurnStatus;
 use codex_protocol::ThreadId;
-#[cfg(test)]
-use codex_protocol::config_types::ModeKind;
-#[cfg(test)]
-use codex_protocol::items::AgentMessageContent;
-#[cfg(test)]
-use codex_protocol::items::AgentMessageItem;
-#[cfg(test)]
-use codex_protocol::items::ContextCompactionItem;
-#[cfg(test)]
-use codex_protocol::items::ImageGenerationItem;
-#[cfg(test)]
-use codex_protocol::items::PlanItem;
-#[cfg(test)]
-use codex_protocol::items::ReasoningItem;
-#[cfg(test)]
-use codex_protocol::items::TurnItem;
-#[cfg(test)]
-use codex_protocol::items::UserMessageItem;
-#[cfg(test)]
-use codex_protocol::items::WebSearchItem;
-#[cfg(test)]
-use codex_protocol::protocol::AgentMessageDeltaEvent;
-#[cfg(test)]
-use codex_protocol::protocol::AgentReasoningDeltaEvent;
-#[cfg(test)]
-use codex_protocol::protocol::AgentReasoningRawContentDeltaEvent;
-#[cfg(test)]
-use codex_protocol::protocol::ErrorEvent;
-#[cfg(test)]
-use codex_protocol::protocol::Event;
-#[cfg(test)]
-use codex_protocol::protocol::EventMsg;
-#[cfg(test)]
-use codex_protocol::protocol::ExecCommandBeginEvent;
-#[cfg(test)]
-use codex_protocol::protocol::ExecCommandEndEvent;
-#[cfg(test)]
-use codex_protocol::protocol::ExecCommandOutputDeltaEvent;
-#[cfg(test)]
-use codex_protocol::protocol::ExecCommandStatus;
-#[cfg(test)]
-use codex_protocol::protocol::ExecOutputStream;
-#[cfg(test)]
-use codex_protocol::protocol::ItemCompletedEvent;
-#[cfg(test)]
-use codex_protocol::protocol::ItemStartedEvent;
-#[cfg(test)]
-use codex_protocol::protocol::PlanDeltaEvent;
-#[cfg(test)]
-use codex_protocol::protocol::RealtimeConversationClosedEvent;
-#[cfg(test)]
-use codex_protocol::protocol::RealtimeConversationRealtimeEvent;
-#[cfg(test)]
-use codex_protocol::protocol::RealtimeConversationStartedEvent;
-#[cfg(test)]
-use codex_protocol::protocol::RealtimeEvent;
-#[cfg(test)]
-use codex_protocol::protocol::ThreadNameUpdatedEvent;
-#[cfg(test)]
-use codex_protocol::protocol::TokenCountEvent;
-#[cfg(test)]
-use codex_protocol::protocol::TokenUsage;
-#[cfg(test)]
-use codex_protocol::protocol::TokenUsageInfo;
-#[cfg(test)]
-use codex_protocol::protocol::TurnAbortReason;
-#[cfg(test)]
-use codex_protocol::protocol::TurnAbortedEvent;
-#[cfg(test)]
-use codex_protocol::protocol::TurnCompleteEvent;
-#[cfg(test)]
-use codex_protocol::protocol::TurnStartedEvent;
 use serde_json::Value;
-#[cfg(test)]
-use std::time::Duration;
 
 #[derive(Debug, PartialEq, Eq)]
 enum LegacyThreadNotification {
@@ -193,8 +102,10 @@ impl App {
     ) {
         match &notification {
             ServerNotification::ServerRequestResolved(notification) => {
-                self.pending_app_server_requests
+                let resolved = self
+                    .pending_app_server_requests
                     .resolve_notification(&notification.request_id);
+                self.note_app_server_request_resolved(resolved).await;
             }
             ServerNotification::AccountRateLimitsUpdated(notification) => {
                 self.chat_widget.on_rate_limit_snapshot(Some(
@@ -254,6 +165,13 @@ impl App {
         app_server_client: &AppServerSession,
         request: ServerRequest,
     ) {
+        if self
+            .try_handle_legacy_approval_request(app_server_client, &request)
+            .await
+        {
+            return;
+        }
+
         if let Some(unsupported) = self
             .pending_app_server_requests
             .note_server_request(&request)
@@ -291,6 +209,102 @@ impl App {
             };
         if let Err(err) = result {
             tracing::warn!("failed to enqueue app-server request: {err}");
+        }
+    }
+
+    /// Bridges deprecated v1 approval requests into the v2 approval UI path.
+    ///
+    /// The TUI only has one live approval surface. Legacy exec/patch requests
+    /// therefore need to be tracked under their original request IDs for
+    /// response serialization, while the visible request is rewritten into the
+    /// current thread-scoped v2 shape for routing and rendering.
+    async fn try_handle_legacy_approval_request(
+        &mut self,
+        app_server_client: &AppServerSession,
+        request: &ServerRequest,
+    ) -> bool {
+        if !matches!(
+            request,
+            ServerRequest::ExecCommandApproval { .. } | ServerRequest::ApplyPatchApproval { .. }
+        ) {
+            return false;
+        }
+
+        match bridge_legacy_approval_request(request) {
+            Ok((thread_id, bridged_request)) => {
+                if let Some(unsupported) = self
+                    .pending_app_server_requests
+                    .note_server_request(request)
+                {
+                    tracing::warn!(
+                        request_id = ?unsupported.request_id,
+                        message = unsupported.message,
+                        "rejecting unsupported app-server request"
+                    );
+                    self.chat_widget
+                        .add_error_message(unsupported.message.clone());
+                    if let Err(err) = self
+                        .reject_app_server_request(
+                            app_server_client,
+                            unsupported.request_id,
+                            unsupported.message,
+                        )
+                        .await
+                    {
+                        tracing::warn!("{err}");
+                    }
+                    return true;
+                }
+
+                let result = if self.primary_thread_id == Some(thread_id)
+                    || self.primary_thread_id.is_none()
+                {
+                    self.enqueue_primary_thread_request(bridged_request).await
+                } else {
+                    self.enqueue_thread_request(thread_id, bridged_request)
+                        .await
+                };
+                if let Err(err) = result {
+                    self.reject_failed_legacy_approval_enqueue(
+                        app_server_client,
+                        request,
+                        err.to_string(),
+                    )
+                    .await;
+                }
+            }
+            Err(message) => {
+                tracing::warn!(request_id = ?request.id(), "{message}");
+                self.chat_widget.add_error_message(message.clone());
+                if let Err(err) = self
+                    .reject_app_server_request(app_server_client, request.id().clone(), message)
+                    .await
+                {
+                    tracing::warn!("{err}");
+                }
+            }
+        }
+
+        true
+    }
+
+    async fn reject_failed_legacy_approval_enqueue(
+        &mut self,
+        app_server_client: &AppServerSession,
+        request: &ServerRequest,
+        err: String,
+    ) {
+        let message = format!("failed to surface legacy exec approval: {err}");
+        let resolved = self
+            .pending_app_server_requests
+            .resolve_notification(request.id());
+        self.note_app_server_request_resolved(resolved).await;
+        self.chat_widget.add_error_message(message.clone());
+        if let Err(reject_err) = self
+            .reject_app_server_request(app_server_client, request.id().clone(), message)
+            .await
+        {
+            tracing::warn!("{reject_err}");
         }
     }
 
@@ -361,7 +375,7 @@ impl App {
     async fn reject_app_server_request(
         &self,
         app_server_client: &AppServerSession,
-        request_id: codex_app_server_protocol::RequestId,
+        request_id: RequestId,
         reason: String,
     ) -> std::result::Result<(), String> {
         app_server_client
@@ -376,6 +390,84 @@ impl App {
             .await
             .map_err(|err| format!("failed to reject app-server request: {err}"))
     }
+}
+
+/// Re-expresses legacy approval payloads as the v2 request variants the UI
+/// already knows how to render.
+///
+/// The bridged request keeps the original `request_id`, so later approval
+/// responses can still resolve the server request using the matching v1 or v2
+/// wire format recorded in `PendingAppServerRequests`.
+fn bridge_legacy_approval_request(
+    request: &ServerRequest,
+) -> Result<(ThreadId, ServerRequest), String> {
+    match request {
+        ServerRequest::ExecCommandApproval { request_id, params } => Ok((
+            params.conversation_id,
+            ServerRequest::CommandExecutionRequestApproval {
+                request_id: request_id.clone(),
+                params: CommandExecutionRequestApprovalParams {
+                    thread_id: params.conversation_id.to_string(),
+                    turn_id: String::new(),
+                    item_id: params.call_id.clone(),
+                    approval_id: params.approval_id.clone(),
+                    reason: params.reason.clone(),
+                    network_approval_context: None,
+                    command: Some(escape_command(&params.command)),
+                    cwd: Some(params.cwd.clone()),
+                    command_actions: Some(
+                        params
+                            .parsed_cmd
+                            .clone()
+                            .into_iter()
+                            .map(CommandAction::from)
+                            .collect(),
+                    ),
+                    additional_permissions: None,
+                    skill_metadata: None,
+                    proposed_execpolicy_amendment: None,
+                    proposed_network_policy_amendments: None,
+                    available_decisions: None,
+                },
+            },
+        )),
+        ServerRequest::ApplyPatchApproval { request_id, params } => Ok((
+            params.conversation_id,
+            ServerRequest::FileChangeRequestApproval {
+                request_id: request_id.clone(),
+                params: FileChangeRequestApprovalParams {
+                    thread_id: params.conversation_id.to_string(),
+                    turn_id: String::new(),
+                    item_id: params.call_id.clone(),
+                    reason: params.reason.clone(),
+                    grant_root: params.grant_root.clone(),
+                },
+            },
+        )),
+        _ => Err("expected legacy approval request".to_string()),
+    }
+}
+
+fn resolve_chatgpt_auth_tokens_refresh_response(
+    codex_home: &std::path::Path,
+    auth_credentials_store_mode: codex_core::auth::AuthCredentialsStoreMode,
+    forced_chatgpt_workspace_id: Option<&str>,
+    params: &ChatgptAuthTokensRefreshParams,
+) -> Result<codex_app_server_protocol::ChatgptAuthTokensRefreshResponse, String> {
+    let auth = load_local_chatgpt_auth(
+        codex_home,
+        auth_credentials_store_mode,
+        forced_chatgpt_workspace_id,
+    )?;
+    if let Some(previous_account_id) = params.previous_account_id.as_deref()
+        && previous_account_id != auth.chatgpt_account_id
+    {
+        return Err(format!(
+            "local ChatGPT auth refresh account mismatch: expected `{previous_account_id}`, got `{}`",
+            auth.chatgpt_account_id
+        ));
+    }
+    Ok(auth.to_refresh_response())
 }
 
 fn server_request_thread_id(request: &ServerRequest) -> Option<ThreadId> {
@@ -515,54 +607,6 @@ fn server_notification_thread_target(
     }
 }
 
-fn resolve_chatgpt_auth_tokens_refresh_response(
-    codex_home: &std::path::Path,
-    auth_credentials_store_mode: codex_core::auth::AuthCredentialsStoreMode,
-    forced_chatgpt_workspace_id: Option<&str>,
-    params: &ChatgptAuthTokensRefreshParams,
-) -> Result<codex_app_server_protocol::ChatgptAuthTokensRefreshResponse, String> {
-    let auth = load_local_chatgpt_auth(
-        codex_home,
-        auth_credentials_store_mode,
-        forced_chatgpt_workspace_id,
-    )?;
-    if let Some(previous_account_id) = params.previous_account_id.as_deref()
-        && previous_account_id != auth.chatgpt_account_id
-    {
-        return Err(format!(
-            "local ChatGPT auth refresh account mismatch: expected `{previous_account_id}`, got `{}`",
-            auth.chatgpt_account_id
-        ));
-    }
-    Ok(auth.to_refresh_response())
-}
-
-#[cfg(test)]
-/// Convert a `Thread` snapshot into a flat sequence of protocol `Event`s
-/// suitable for replaying into the TUI event store.
-///
-/// Each turn is expanded into `TurnStarted`, zero or more `ItemCompleted`,
-/// and a terminal event that matches the turn's `TurnStatus`. Returns an
-/// empty vec (with a warning log) if the thread ID is not a valid UUID.
-pub(super) fn thread_snapshot_events(
-    thread: &Thread,
-    show_raw_agent_reasoning: bool,
-) -> Vec<Event> {
-    let Ok(thread_id) = ThreadId::from_string(&thread.id) else {
-        tracing::warn!(
-            thread_id = %thread.id,
-            "ignoring app-server thread snapshot with invalid thread id"
-        );
-        return Vec::new();
-    };
-
-    thread
-        .turns
-        .iter()
-        .flat_map(|turn| turn_snapshot_events(thread_id, turn, show_raw_agent_reasoning))
-        .collect()
-}
-
 fn legacy_thread_notification(
     notification: JSONRPCNotification,
 ) -> Option<(ThreadId, LegacyThreadNotification)> {
@@ -606,719 +650,26 @@ fn legacy_thread_notification(
 }
 
 #[cfg(test)]
-fn server_notification_thread_events(
-    notification: ServerNotification,
-) -> Option<(ThreadId, Vec<Event>)> {
-    match notification {
-        ServerNotification::ThreadTokenUsageUpdated(notification) => Some((
-            ThreadId::from_string(&notification.thread_id).ok()?,
-            vec![Event {
-                id: String::new(),
-                msg: EventMsg::TokenCount(TokenCountEvent {
-                    info: Some(TokenUsageInfo {
-                        total_token_usage: token_usage_from_app_server(
-                            notification.token_usage.total,
-                        ),
-                        last_token_usage: token_usage_from_app_server(
-                            notification.token_usage.last,
-                        ),
-                        model_context_window: notification.token_usage.model_context_window,
-                    }),
-                    rate_limits: None,
-                }),
-            }],
-        )),
-        ServerNotification::Error(notification) => Some((
-            ThreadId::from_string(&notification.thread_id).ok()?,
-            vec![Event {
-                id: String::new(),
-                msg: EventMsg::Error(ErrorEvent {
-                    message: notification.error.message,
-                    codex_error_info: notification
-                        .error
-                        .codex_error_info
-                        .and_then(app_server_codex_error_info_to_core),
-                }),
-            }],
-        )),
-        ServerNotification::ThreadNameUpdated(notification) => Some((
-            ThreadId::from_string(&notification.thread_id).ok()?,
-            vec![Event {
-                id: String::new(),
-                msg: EventMsg::ThreadNameUpdated(ThreadNameUpdatedEvent {
-                    thread_id: ThreadId::from_string(&notification.thread_id).ok()?,
-                    thread_name: notification.thread_name,
-                }),
-            }],
-        )),
-        ServerNotification::TurnStarted(notification) => Some((
-            ThreadId::from_string(&notification.thread_id).ok()?,
-            vec![Event {
-                id: String::new(),
-                msg: EventMsg::TurnStarted(TurnStartedEvent {
-                    turn_id: notification.turn.id,
-                    model_context_window: None,
-                    collaboration_mode_kind: ModeKind::default(),
-                }),
-            }],
-        )),
-        ServerNotification::TurnCompleted(notification) => {
-            let thread_id = ThreadId::from_string(&notification.thread_id).ok()?;
-            let mut events = Vec::new();
-            append_terminal_turn_events(
-                &mut events,
-                &notification.turn,
-                /*include_failed_error*/ false,
-            );
-            Some((thread_id, events))
-        }
-        ServerNotification::ItemStarted(notification) => Some((
-            ThreadId::from_string(&notification.thread_id).ok()?,
-            command_execution_started_event(&notification.turn_id, &notification.item).or_else(
-                || {
-                    Some(vec![Event {
-                        id: String::new(),
-                        msg: EventMsg::ItemStarted(ItemStartedEvent {
-                            thread_id: ThreadId::from_string(&notification.thread_id).ok()?,
-                            turn_id: notification.turn_id.clone(),
-                            item: thread_item_to_core(&notification.item)?,
-                        }),
-                    }])
-                },
-            )?,
-        )),
-        ServerNotification::ItemCompleted(notification) => Some((
-            ThreadId::from_string(&notification.thread_id).ok()?,
-            command_execution_completed_event(&notification.turn_id, &notification.item).or_else(
-                || {
-                    Some(vec![Event {
-                        id: String::new(),
-                        msg: EventMsg::ItemCompleted(ItemCompletedEvent {
-                            thread_id: ThreadId::from_string(&notification.thread_id).ok()?,
-                            turn_id: notification.turn_id.clone(),
-                            item: thread_item_to_core(&notification.item)?,
-                        }),
-                    }])
-                },
-            )?,
-        )),
-        ServerNotification::CommandExecutionOutputDelta(notification) => Some((
-            ThreadId::from_string(&notification.thread_id).ok()?,
-            vec![Event {
-                id: String::new(),
-                msg: EventMsg::ExecCommandOutputDelta(ExecCommandOutputDeltaEvent {
-                    call_id: notification.item_id,
-                    stream: ExecOutputStream::Stdout,
-                    chunk: notification.delta.into_bytes(),
-                }),
-            }],
-        )),
-        ServerNotification::AgentMessageDelta(notification) => Some((
-            ThreadId::from_string(&notification.thread_id).ok()?,
-            vec![Event {
-                id: String::new(),
-                msg: EventMsg::AgentMessageDelta(AgentMessageDeltaEvent {
-                    delta: notification.delta,
-                }),
-            }],
-        )),
-        ServerNotification::PlanDelta(notification) => Some((
-            ThreadId::from_string(&notification.thread_id).ok()?,
-            vec![Event {
-                id: String::new(),
-                msg: EventMsg::PlanDelta(PlanDeltaEvent {
-                    thread_id: notification.thread_id,
-                    turn_id: notification.turn_id,
-                    item_id: notification.item_id,
-                    delta: notification.delta,
-                }),
-            }],
-        )),
-        ServerNotification::ReasoningSummaryTextDelta(notification) => Some((
-            ThreadId::from_string(&notification.thread_id).ok()?,
-            vec![Event {
-                id: String::new(),
-                msg: EventMsg::AgentReasoningDelta(AgentReasoningDeltaEvent {
-                    delta: notification.delta,
-                }),
-            }],
-        )),
-        ServerNotification::ReasoningTextDelta(notification) => Some((
-            ThreadId::from_string(&notification.thread_id).ok()?,
-            vec![Event {
-                id: String::new(),
-                msg: EventMsg::AgentReasoningRawContentDelta(AgentReasoningRawContentDeltaEvent {
-                    delta: notification.delta,
-                }),
-            }],
-        )),
-        ServerNotification::ThreadRealtimeStarted(notification) => Some((
-            ThreadId::from_string(&notification.thread_id).ok()?,
-            vec![Event {
-                id: String::new(),
-                msg: EventMsg::RealtimeConversationStarted(RealtimeConversationStartedEvent {
-                    session_id: notification.session_id,
-                    version: notification.version,
-                }),
-            }],
-        )),
-        ServerNotification::ThreadRealtimeItemAdded(notification) => Some((
-            ThreadId::from_string(&notification.thread_id).ok()?,
-            vec![Event {
-                id: String::new(),
-                msg: EventMsg::RealtimeConversationRealtime(RealtimeConversationRealtimeEvent {
-                    payload: RealtimeEvent::ConversationItemAdded(notification.item),
-                }),
-            }],
-        )),
-        ServerNotification::ThreadRealtimeOutputAudioDelta(notification) => Some((
-            ThreadId::from_string(&notification.thread_id).ok()?,
-            vec![Event {
-                id: String::new(),
-                msg: EventMsg::RealtimeConversationRealtime(RealtimeConversationRealtimeEvent {
-                    payload: RealtimeEvent::AudioOut(notification.audio.into()),
-                }),
-            }],
-        )),
-        ServerNotification::ThreadRealtimeError(notification) => Some((
-            ThreadId::from_string(&notification.thread_id).ok()?,
-            vec![Event {
-                id: String::new(),
-                msg: EventMsg::RealtimeConversationRealtime(RealtimeConversationRealtimeEvent {
-                    payload: RealtimeEvent::Error(notification.message),
-                }),
-            }],
-        )),
-        ServerNotification::ThreadRealtimeClosed(notification) => Some((
-            ThreadId::from_string(&notification.thread_id).ok()?,
-            vec![Event {
-                id: String::new(),
-                msg: EventMsg::RealtimeConversationClosed(RealtimeConversationClosedEvent {
-                    reason: notification.reason,
-                }),
-            }],
-        )),
-        _ => None,
-    }
-}
-
-#[cfg(test)]
-fn token_usage_from_app_server(
-    value: codex_app_server_protocol::TokenUsageBreakdown,
-) -> TokenUsage {
-    TokenUsage {
-        input_tokens: value.input_tokens,
-        cached_input_tokens: value.cached_input_tokens,
-        output_tokens: value.output_tokens,
-        reasoning_output_tokens: value.reasoning_output_tokens,
-        total_tokens: value.total_tokens,
-    }
-}
-
-/// Expand a single `Turn` into the event sequence the TUI would have
-/// observed if it had been connected for the turn's entire lifetime.
-///
-/// Snapshot replay keeps committed-item semantics for user / plan /
-/// agent-message items, while replaying the legacy events that still
-/// drive rendering for reasoning, web-search, image-generation, and
-/// context-compaction history cells.
-#[cfg(test)]
-fn turn_snapshot_events(
-    thread_id: ThreadId,
-    turn: &Turn,
-    show_raw_agent_reasoning: bool,
-) -> Vec<Event> {
-    let mut events = vec![Event {
-        id: String::new(),
-        msg: EventMsg::TurnStarted(TurnStartedEvent {
-            turn_id: turn.id.clone(),
-            model_context_window: None,
-            collaboration_mode_kind: ModeKind::default(),
-        }),
-    }];
-
-    for item in &turn.items {
-        if let Some(command_events) = command_execution_snapshot_events(&turn.id, item) {
-            events.extend(command_events);
-            continue;
-        }
-
-        let Some(item) = thread_item_to_core(item) else {
-            continue;
-        };
-        match item {
-            TurnItem::UserMessage(_) | TurnItem::Plan(_) | TurnItem::AgentMessage(_) => {
-                events.push(Event {
-                    id: String::new(),
-                    msg: EventMsg::ItemCompleted(ItemCompletedEvent {
-                        thread_id,
-                        turn_id: turn.id.clone(),
-                        item,
-                    }),
-                });
-            }
-            TurnItem::Reasoning(_)
-            | TurnItem::WebSearch(_)
-            | TurnItem::ImageGeneration(_)
-            | TurnItem::ContextCompaction(_) => {
-                events.extend(
-                    item.as_legacy_events(show_raw_agent_reasoning)
-                        .into_iter()
-                        .map(|msg| Event {
-                            id: String::new(),
-                            msg,
-                        }),
-                );
-            }
-        }
-    }
-
-    append_terminal_turn_events(&mut events, turn, /*include_failed_error*/ true);
-
-    events
-}
-
-/// Append the terminal event(s) for a turn based on its `TurnStatus`.
-///
-/// This function is shared between the live notification bridge
-/// (`TurnCompleted` handling) and the snapshot replay path so that both
-/// produce identical `EventMsg` sequences for the same turn status.
-///
-/// - `Completed` → `TurnComplete`
-/// - `Interrupted` → `TurnAborted { reason: Interrupted }`
-/// - `Failed` → `Error` (if present) then `TurnComplete`
-/// - `InProgress` → no events (the turn is still running)
-#[cfg(test)]
-fn append_terminal_turn_events(events: &mut Vec<Event>, turn: &Turn, include_failed_error: bool) {
-    match turn.status {
-        TurnStatus::Completed => events.push(Event {
-            id: String::new(),
-            msg: EventMsg::TurnComplete(TurnCompleteEvent {
-                turn_id: turn.id.clone(),
-                last_agent_message: None,
-            }),
-        }),
-        TurnStatus::Interrupted => events.push(Event {
-            id: String::new(),
-            msg: EventMsg::TurnAborted(TurnAbortedEvent {
-                turn_id: Some(turn.id.clone()),
-                reason: TurnAbortReason::Interrupted,
-            }),
-        }),
-        TurnStatus::Failed => {
-            if include_failed_error && let Some(error) = &turn.error {
-                events.push(Event {
-                    id: String::new(),
-                    msg: EventMsg::Error(ErrorEvent {
-                        message: error.message.clone(),
-                        codex_error_info: error
-                            .codex_error_info
-                            .clone()
-                            .and_then(app_server_codex_error_info_to_core),
-                    }),
-                });
-            }
-            events.push(Event {
-                id: String::new(),
-                msg: EventMsg::TurnComplete(TurnCompleteEvent {
-                    turn_id: turn.id.clone(),
-                    last_agent_message: None,
-                }),
-            });
-        }
-        TurnStatus::InProgress => {
-            // Preserve unfinished turns during snapshot replay without emitting completion events.
-        }
-    }
-}
-
-#[cfg(test)]
-fn thread_item_to_core(item: &ThreadItem) -> Option<TurnItem> {
-    match item {
-        ThreadItem::UserMessage { id, content } => Some(TurnItem::UserMessage(UserMessageItem {
-            id: id.clone(),
-            content: content
-                .iter()
-                .cloned()
-                .map(codex_app_server_protocol::UserInput::into_core)
-                .collect(),
-        })),
-        ThreadItem::AgentMessage {
-            id,
-            text,
-            phase,
-            memory_citation,
-        } => Some(TurnItem::AgentMessage(AgentMessageItem {
-            id: id.clone(),
-            content: vec![AgentMessageContent::Text { text: text.clone() }],
-            phase: phase.clone(),
-            memory_citation: memory_citation.clone().map(|citation| {
-                codex_protocol::memory_citation::MemoryCitation {
-                    entries: citation
-                        .entries
-                        .into_iter()
-                        .map(
-                            |entry| codex_protocol::memory_citation::MemoryCitationEntry {
-                                path: entry.path,
-                                line_start: entry.line_start,
-                                line_end: entry.line_end,
-                                note: entry.note,
-                            },
-                        )
-                        .collect(),
-                    rollout_ids: citation.thread_ids,
-                }
-            }),
-        })),
-        ThreadItem::Plan { id, text } => Some(TurnItem::Plan(PlanItem {
-            id: id.clone(),
-            text: text.clone(),
-        })),
-        ThreadItem::Reasoning {
-            id,
-            summary,
-            content,
-        } => Some(TurnItem::Reasoning(ReasoningItem {
-            id: id.clone(),
-            summary_text: summary.clone(),
-            raw_content: content.clone(),
-        })),
-        ThreadItem::WebSearch { id, query, action } => Some(TurnItem::WebSearch(WebSearchItem {
-            id: id.clone(),
-            query: query.clone(),
-            action: app_server_web_search_action_to_core(action.clone()?)?,
-        })),
-        ThreadItem::ImageGeneration {
-            id,
-            status,
-            revised_prompt,
-            result,
-        } => Some(TurnItem::ImageGeneration(ImageGenerationItem {
-            id: id.clone(),
-            status: status.clone(),
-            revised_prompt: revised_prompt.clone(),
-            result: result.clone(),
-            saved_path: None,
-        })),
-        ThreadItem::ContextCompaction { id } => {
-            Some(TurnItem::ContextCompaction(ContextCompactionItem {
-                id: id.clone(),
-            }))
-        }
-        ThreadItem::CommandExecution { .. }
-        | ThreadItem::FileChange { .. }
-        | ThreadItem::McpToolCall { .. }
-        | ThreadItem::DynamicToolCall { .. }
-        | ThreadItem::CollabAgentToolCall { .. }
-        | ThreadItem::ImageView { .. }
-        | ThreadItem::EnteredReviewMode { .. }
-        | ThreadItem::ExitedReviewMode { .. } => {
-            tracing::debug!("ignoring unsupported app-server thread item in TUI adapter");
-            None
-        }
-    }
-}
-
-#[cfg(test)]
-fn command_execution_started_event(turn_id: &str, item: &ThreadItem) -> Option<Vec<Event>> {
-    let ThreadItem::CommandExecution {
-        id,
-        command,
-        cwd,
-        process_id,
-        source,
-        command_actions,
-        ..
-    } = item
-    else {
-        return None;
-    };
-
-    Some(vec![Event {
-        id: String::new(),
-        msg: EventMsg::ExecCommandBegin(ExecCommandBeginEvent {
-            call_id: id.clone(),
-            process_id: process_id.clone(),
-            turn_id: turn_id.to_string(),
-            command: split_command_string(command),
-            cwd: cwd.clone(),
-            parsed_cmd: command_actions
-                .iter()
-                .cloned()
-                .map(codex_app_server_protocol::CommandAction::into_core)
-                .collect(),
-            source: source.to_core(),
-            interaction_input: None,
-        }),
-    }])
-}
-
-#[cfg(test)]
-fn command_execution_completed_event(turn_id: &str, item: &ThreadItem) -> Option<Vec<Event>> {
-    let ThreadItem::CommandExecution {
-        id,
-        command,
-        cwd,
-        process_id,
-        source,
-        status,
-        command_actions,
-        aggregated_output,
-        exit_code,
-        duration_ms,
-    } = item
-    else {
-        return None;
-    };
-
-    if matches!(
-        status,
-        codex_app_server_protocol::CommandExecutionStatus::InProgress
-    ) {
-        return Some(Vec::new());
-    }
-
-    let status = match status {
-        codex_app_server_protocol::CommandExecutionStatus::InProgress => return Some(Vec::new()),
-        codex_app_server_protocol::CommandExecutionStatus::Completed => {
-            ExecCommandStatus::Completed
-        }
-        codex_app_server_protocol::CommandExecutionStatus::Failed => ExecCommandStatus::Failed,
-        codex_app_server_protocol::CommandExecutionStatus::Declined => ExecCommandStatus::Declined,
-    };
-
-    let duration = Duration::from_millis(
-        duration_ms
-            .and_then(|value| u64::try_from(value).ok())
-            .unwrap_or_default(),
-    );
-    let aggregated_output = aggregated_output.clone().unwrap_or_default();
-
-    Some(vec![Event {
-        id: String::new(),
-        msg: EventMsg::ExecCommandEnd(ExecCommandEndEvent {
-            call_id: id.clone(),
-            process_id: process_id.clone(),
-            turn_id: turn_id.to_string(),
-            command: split_command_string(command),
-            cwd: cwd.clone(),
-            parsed_cmd: command_actions
-                .iter()
-                .cloned()
-                .map(codex_app_server_protocol::CommandAction::into_core)
-                .collect(),
-            source: source.to_core(),
-            interaction_input: None,
-            stdout: String::new(),
-            stderr: String::new(),
-            aggregated_output: aggregated_output.clone(),
-            exit_code: exit_code.unwrap_or(-1),
-            duration,
-            formatted_output: aggregated_output,
-            status,
-        }),
-    }])
-}
-
-#[cfg(test)]
-fn command_execution_snapshot_events(turn_id: &str, item: &ThreadItem) -> Option<Vec<Event>> {
-    let mut events = command_execution_started_event(turn_id, item)?;
-    if let Some(end_events) = command_execution_completed_event(turn_id, item) {
-        events.extend(end_events);
-    }
-    Some(events)
-}
-
-#[cfg(test)]
-fn split_command_string(command: &str) -> Vec<String> {
-    let Some(parts) = shlex::split(command) else {
-        return vec![command.to_string()];
-    };
-    match shlex::try_join(parts.iter().map(String::as_str)) {
-        Ok(round_trip)
-            if round_trip == command
-                || (!command.contains(":\\")
-                    && shlex::split(&round_trip).as_ref() == Some(&parts)) =>
-        {
-            parts
-        }
-        _ => vec![command.to_string()],
-    }
-}
-
-#[cfg(test)]
-mod refresh_tests {
-    use super::*;
-
-    use base64::Engine;
-    use chrono::Utc;
-    use codex_app_server_protocol::AuthMode;
-    use codex_core::auth::AuthCredentialsStoreMode;
-    use codex_core::auth::AuthDotJson;
-    use codex_core::auth::save_auth;
-    use codex_core::token_data::TokenData;
-    use pretty_assertions::assert_eq;
-    use serde::Serialize;
-    use serde_json::json;
-    use tempfile::TempDir;
-
-    fn fake_jwt(account_id: &str, plan_type: &str) -> String {
-        #[derive(Serialize)]
-        struct Header {
-            alg: &'static str,
-            typ: &'static str,
-        }
-
-        let header = Header {
-            alg: "none",
-            typ: "JWT",
-        };
-        let payload = json!({
-            "email": "user@example.com",
-            "https://api.openai.com/auth": {
-                "chatgpt_account_id": account_id,
-                "chatgpt_plan_type": plan_type,
-            },
-        });
-        let encode = |bytes: &[u8]| base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes);
-        let header_b64 = encode(&serde_json::to_vec(&header).expect("serialize header"));
-        let payload_b64 = encode(&serde_json::to_vec(&payload).expect("serialize payload"));
-        let signature_b64 = encode(b"sig");
-        format!("{header_b64}.{payload_b64}.{signature_b64}")
-    }
-
-    fn write_chatgpt_auth(codex_home: &std::path::Path) {
-        let id_token = fake_jwt("workspace-1", "business");
-        let access_token = fake_jwt("workspace-1", "business");
-        save_auth(
-            codex_home,
-            &AuthDotJson {
-                auth_mode: Some(AuthMode::Chatgpt),
-                openai_api_key: None,
-                tokens: Some(TokenData {
-                    id_token: codex_core::token_data::parse_chatgpt_jwt_claims(&id_token)
-                        .expect("id token should parse"),
-                    access_token,
-                    refresh_token: "refresh-token".to_string(),
-                    account_id: Some("workspace-1".to_string()),
-                }),
-                last_refresh: Some(Utc::now()),
-            },
-            AuthCredentialsStoreMode::File,
-        )
-        .expect("chatgpt auth should save");
-    }
-
-    #[test]
-    fn refresh_request_uses_local_chatgpt_auth() {
-        let codex_home = TempDir::new().expect("tempdir");
-        write_chatgpt_auth(codex_home.path());
-
-        let response = resolve_chatgpt_auth_tokens_refresh_response(
-            codex_home.path(),
-            AuthCredentialsStoreMode::File,
-            Some("workspace-1"),
-            &ChatgptAuthTokensRefreshParams {
-                reason: codex_app_server_protocol::ChatgptAuthTokensRefreshReason::Unauthorized,
-                previous_account_id: Some("workspace-1".to_string()),
-            },
-        )
-        .expect("refresh response should resolve");
-
-        assert_eq!(response.chatgpt_account_id, "workspace-1");
-        assert_eq!(response.chatgpt_plan_type.as_deref(), Some("business"));
-        assert!(!response.access_token.is_empty());
-    }
-
-    #[test]
-    fn refresh_request_rejects_account_mismatch() {
-        let codex_home = TempDir::new().expect("tempdir");
-        write_chatgpt_auth(codex_home.path());
-
-        let err = resolve_chatgpt_auth_tokens_refresh_response(
-            codex_home.path(),
-            AuthCredentialsStoreMode::File,
-            Some("workspace-1"),
-            &ChatgptAuthTokensRefreshParams {
-                reason: codex_app_server_protocol::ChatgptAuthTokensRefreshReason::Unauthorized,
-                previous_account_id: Some("workspace-2".to_string()),
-            },
-        )
-        .expect_err("mismatched account should fail");
-
-        assert_eq!(
-            err,
-            "local ChatGPT auth refresh account mismatch: expected `workspace-2`, got `workspace-1`"
-        );
-    }
-}
-
-#[cfg(test)]
-fn app_server_web_search_action_to_core(
-    action: codex_app_server_protocol::WebSearchAction,
-) -> Option<codex_protocol::models::WebSearchAction> {
-    match action {
-        codex_app_server_protocol::WebSearchAction::Search { query, queries } => {
-            Some(codex_protocol::models::WebSearchAction::Search { query, queries })
-        }
-        codex_app_server_protocol::WebSearchAction::OpenPage { url } => {
-            Some(codex_protocol::models::WebSearchAction::OpenPage { url })
-        }
-        codex_app_server_protocol::WebSearchAction::FindInPage { url, pattern } => {
-            Some(codex_protocol::models::WebSearchAction::FindInPage { url, pattern })
-        }
-        codex_app_server_protocol::WebSearchAction::Other => {
-            Some(codex_protocol::models::WebSearchAction::Other)
-        }
-    }
-}
-
-#[cfg(test)]
-fn app_server_codex_error_info_to_core(
-    value: codex_app_server_protocol::CodexErrorInfo,
-) -> Option<codex_protocol::protocol::CodexErrorInfo> {
-    serde_json::from_value(serde_json::to_value(value).ok()?).ok()
-}
-
-#[cfg(test)]
 mod tests {
     use super::LegacyThreadNotification;
-    use super::command_execution_started_event;
+    use super::ServerNotificationThreadTarget;
+    use super::bridge_legacy_approval_request;
     use super::legacy_thread_notification;
-    use super::server_notification_thread_events;
-    use super::thread_snapshot_events;
-    use super::turn_snapshot_events;
-    use codex_app_server_protocol::AgentMessageDeltaNotification;
-    use codex_app_server_protocol::CodexErrorInfo;
-    use codex_app_server_protocol::CommandAction;
-    use codex_app_server_protocol::CommandExecutionOutputDeltaNotification;
-    use codex_app_server_protocol::CommandExecutionSource;
-    use codex_app_server_protocol::CommandExecutionStatus;
-    use codex_app_server_protocol::ItemCompletedNotification;
-    use codex_app_server_protocol::ItemStartedNotification;
+    use super::server_notification_thread_target;
+    use codex_app_server_protocol::CommandExecutionRequestApprovalParams;
+    use codex_app_server_protocol::ExecCommandApprovalParams;
+    use codex_app_server_protocol::FileChangeRequestApprovalParams;
     use codex_app_server_protocol::JSONRPCNotification;
-    use codex_app_server_protocol::ReasoningSummaryTextDeltaNotification;
+    use codex_app_server_protocol::RequestId as AppServerRequestId;
     use codex_app_server_protocol::ServerNotification;
-    use codex_app_server_protocol::Thread;
-    use codex_app_server_protocol::ThreadItem;
-    use codex_app_server_protocol::ThreadStatus;
+    use codex_app_server_protocol::ServerRequest;
     use codex_app_server_protocol::Turn;
-    use codex_app_server_protocol::TurnCompletedNotification;
-    use codex_app_server_protocol::TurnError;
+    use codex_app_server_protocol::TurnStartedNotification;
     use codex_app_server_protocol::TurnStatus;
     use codex_protocol::ThreadId;
-    use codex_protocol::items::AgentMessageContent;
-    use codex_protocol::items::AgentMessageItem;
-    use codex_protocol::items::TurnItem;
-    use codex_protocol::models::MessagePhase;
-    use codex_protocol::protocol::EventMsg;
-    use codex_protocol::protocol::ExecCommandSource;
-    use codex_protocol::protocol::SessionSource;
-    use codex_protocol::protocol::TurnAbortReason;
-    use codex_protocol::protocol::TurnAbortedEvent;
     use pretty_assertions::assert_eq;
     use serde_json::json;
-    use std::path::PathBuf;
+    use std::collections::HashMap;
 
     #[test]
     fn legacy_warning_notification_extracts_thread_id_and_message() {
@@ -1342,6 +693,22 @@ mod tests {
                 LegacyThreadNotification::Warning("legacy warning message".to_string())
             ))
         );
+    }
+
+    #[test]
+    fn legacy_warning_notification_ignores_non_warning_legacy_events() {
+        let notification = legacy_thread_notification(JSONRPCNotification {
+            method: "codex/event/task_started".to_string(),
+            params: Some(json!({
+                "conversationId": ThreadId::new().to_string(),
+                "id": "event-1",
+                "msg": {
+                    "type": "task_started",
+                },
+            })),
+        });
+
+        assert_eq!(notification, None);
     }
 
     #[test]
@@ -1369,548 +736,97 @@ mod tests {
     }
 
     #[test]
-    fn bridges_completed_agent_messages_from_server_notifications() {
-        let thread_id = "019cee8c-b993-7e33-88c0-014d4e62612d".to_string();
-        let turn_id = "019cee8c-b9b4-7f10-a1b0-38caa876a012".to_string();
-        let item_id = "msg_123".to_string();
-
-        let (actual_thread_id, events) = server_notification_thread_events(
-            ServerNotification::ItemCompleted(ItemCompletedNotification {
-                item: ThreadItem::AgentMessage {
-                    id: item_id,
-                    text: "Hello from your coding assistant.".to_string(),
-                    phase: Some(MessagePhase::FinalAnswer),
-                    memory_citation: None,
-                },
-                thread_id: thread_id.clone(),
-                turn_id: turn_id.clone(),
-            }),
-        )
-        .expect("notification should bridge");
-
-        assert_eq!(
-            actual_thread_id,
-            ThreadId::from_string(&thread_id).expect("valid thread id")
-        );
-        let [event] = events.as_slice() else {
-            panic!("expected one bridged event");
-        };
-        assert_eq!(event.id, String::new());
-        let EventMsg::ItemCompleted(completed) = &event.msg else {
-            panic!("expected item completed event");
-        };
-        assert_eq!(
-            completed.thread_id,
-            ThreadId::from_string(&thread_id).expect("valid thread id")
-        );
-        assert_eq!(completed.turn_id, turn_id);
-        match &completed.item {
-            TurnItem::AgentMessage(AgentMessageItem {
-                id, content, phase, ..
-            }) => {
-                assert_eq!(id, "msg_123");
-                let [AgentMessageContent::Text { text }] = content.as_slice() else {
-                    panic!("expected a single text content item");
-                };
-                assert_eq!(text, "Hello from your coding assistant.");
-                assert_eq!(*phase, Some(MessagePhase::FinalAnswer));
-            }
-            _ => panic!("expected bridged agent message item"),
-        }
-    }
-
-    #[test]
-    fn bridges_turn_completion_from_server_notifications() {
-        let thread_id = "019cee8c-b993-7e33-88c0-014d4e62612d".to_string();
-        let turn_id = "019cee8c-b9b4-7f10-a1b0-38caa876a012".to_string();
-
-        let (actual_thread_id, events) = server_notification_thread_events(
-            ServerNotification::TurnCompleted(TurnCompletedNotification {
-                thread_id: thread_id.clone(),
-                turn: Turn {
-                    id: turn_id.clone(),
-                    items: Vec::new(),
-                    status: TurnStatus::Completed,
-                    error: None,
-                },
-            }),
-        )
-        .expect("notification should bridge");
-
-        assert_eq!(
-            actual_thread_id,
-            ThreadId::from_string(&thread_id).expect("valid thread id")
-        );
-        let [event] = events.as_slice() else {
-            panic!("expected one bridged event");
-        };
-        assert_eq!(event.id, String::new());
-        let EventMsg::TurnComplete(completed) = &event.msg else {
-            panic!("expected turn complete event");
-        };
-        assert_eq!(completed.turn_id, turn_id);
-        assert_eq!(completed.last_agent_message, None);
-    }
-
-    #[test]
-    fn bridges_command_execution_notifications_into_legacy_exec_events() {
-        let thread_id = "019cee8c-b993-7e33-88c0-014d4e62612d".to_string();
-        let turn_id = "019cee8c-b9b4-7f10-a1b0-38caa876a012".to_string();
-        let item = ThreadItem::CommandExecution {
-            id: "cmd-1".to_string(),
-            command: "printf 'hello world\\n'".to_string(),
-            cwd: PathBuf::from("/tmp"),
-            process_id: None,
-            source: CommandExecutionSource::UserShell,
-            status: CommandExecutionStatus::InProgress,
-            command_actions: vec![CommandAction::Unknown {
-                command: "printf hello world".to_string(),
-            }],
-            aggregated_output: None,
-            exit_code: None,
-            duration_ms: None,
-        };
-
-        let (_, started_events) = server_notification_thread_events(
-            ServerNotification::ItemStarted(ItemStartedNotification {
-                item,
-                thread_id: thread_id.clone(),
-                turn_id: turn_id.clone(),
-            }),
-        )
-        .expect("command execution start should bridge");
-        let [started] = started_events.as_slice() else {
-            panic!("expected one started event");
-        };
-        let EventMsg::ExecCommandBegin(begin) = &started.msg else {
-            panic!("expected exec begin event");
-        };
-        assert_eq!(begin.call_id, "cmd-1");
-        assert_eq!(
-            begin.command,
-            vec!["printf".to_string(), "hello world\\n".to_string()]
-        );
-        assert_eq!(begin.cwd, PathBuf::from("/tmp"));
-        assert_eq!(begin.source, ExecCommandSource::UserShell);
-
-        let (_, delta_events) =
-            server_notification_thread_events(ServerNotification::CommandExecutionOutputDelta(
-                CommandExecutionOutputDeltaNotification {
-                    thread_id: thread_id.clone(),
-                    turn_id: turn_id.clone(),
-                    item_id: "cmd-1".to_string(),
-                    delta: "hello world\n".to_string(),
-                },
-            ))
-            .expect("command execution delta should bridge");
-        let [delta] = delta_events.as_slice() else {
-            panic!("expected one delta event");
-        };
-        let EventMsg::ExecCommandOutputDelta(delta) = &delta.msg else {
-            panic!("expected exec output delta event");
-        };
-        assert_eq!(delta.call_id, "cmd-1");
-        assert_eq!(delta.chunk, b"hello world\n");
-
-        let completed_item = ThreadItem::CommandExecution {
-            id: "cmd-1".to_string(),
-            command: "printf 'hello world\\n'".to_string(),
-            cwd: PathBuf::from("/tmp"),
-            process_id: None,
-            source: CommandExecutionSource::UserShell,
-            status: CommandExecutionStatus::Completed,
-            command_actions: vec![CommandAction::Unknown {
-                command: "printf hello world".to_string(),
-            }],
-            aggregated_output: Some("hello world\n".to_string()),
-            exit_code: Some(0),
-            duration_ms: Some(5),
-        };
-        let (_, completed_events) = server_notification_thread_events(
-            ServerNotification::ItemCompleted(ItemCompletedNotification {
-                item: completed_item,
-                thread_id,
-                turn_id,
-            }),
-        )
-        .expect("command execution completion should bridge");
-        let [completed] = completed_events.as_slice() else {
-            panic!("expected one completed event");
-        };
-        let EventMsg::ExecCommandEnd(end) = &completed.msg else {
-            panic!("expected exec end event");
-        };
-        assert_eq!(end.call_id, "cmd-1");
-        assert_eq!(end.exit_code, 0);
-        assert_eq!(end.formatted_output, "hello world\n");
-        assert_eq!(end.aggregated_output, "hello world\n");
-        assert_eq!(end.source, ExecCommandSource::UserShell);
-    }
-
-    #[test]
-    fn command_execution_snapshot_preserves_non_roundtrippable_command_strings() {
-        let item = ThreadItem::CommandExecution {
-            id: "cmd-1".to_string(),
-            command: r#"C:\Program Files\Git\bin\bash.exe -lc "echo hi""#.to_string(),
-            cwd: PathBuf::from("C:\\repo"),
-            process_id: None,
-            source: CommandExecutionSource::UserShell,
-            status: CommandExecutionStatus::InProgress,
-            command_actions: vec![],
-            aggregated_output: None,
-            exit_code: None,
-            duration_ms: None,
-        };
-
-        let events =
-            command_execution_started_event("turn-1", &item).expect("command execution start");
-        let [started] = events.as_slice() else {
-            panic!("expected one started event");
-        };
-        let EventMsg::ExecCommandBegin(begin) = &started.msg else {
-            panic!("expected exec begin event");
-        };
-        assert_eq!(
-            begin.command,
-            vec![r#"C:\Program Files\Git\bin\bash.exe -lc "echo hi""#.to_string()]
-        );
-    }
-
-    #[test]
-    fn replays_command_execution_items_from_thread_snapshots() {
-        let thread = Thread {
-            id: "019cee8c-b993-7e33-88c0-014d4e62612d".to_string(),
-            preview: String::new(),
-            ephemeral: false,
-            model_provider: "openai".to_string(),
-            created_at: 1,
-            updated_at: 1,
-            status: ThreadStatus::Idle,
-            path: None,
-            cwd: PathBuf::from("/tmp"),
-            cli_version: "test".to_string(),
-            source: SessionSource::Cli.into(),
-            agent_nickname: None,
-            agent_role: None,
-            git_info: None,
-            name: None,
-            turns: vec![Turn {
+    fn thread_scoped_notification_with_invalid_thread_id_is_not_treated_as_global() {
+        let notification = ServerNotification::TurnStarted(TurnStartedNotification {
+            thread_id: "not-a-thread-id".to_string(),
+            turn: Turn {
                 id: "turn-1".to_string(),
-                items: vec![ThreadItem::CommandExecution {
-                    id: "cmd-1".to_string(),
-                    command: "printf 'hello world\\n'".to_string(),
-                    cwd: PathBuf::from("/tmp"),
-                    process_id: None,
-                    source: CommandExecutionSource::UserShell,
-                    status: CommandExecutionStatus::Completed,
-                    command_actions: vec![CommandAction::Unknown {
-                        command: "printf hello world".to_string(),
-                    }],
-                    aggregated_output: Some("hello world\n".to_string()),
-                    exit_code: Some(0),
-                    duration_ms: Some(5),
-                }],
-                status: TurnStatus::Completed,
+                items: Vec::new(),
+                status: TurnStatus::InProgress,
                 error: None,
-            }],
-        };
+            },
+        });
 
-        let events = thread_snapshot_events(&thread, /*show_raw_agent_reasoning*/ false);
-        assert!(matches!(events[0].msg, EventMsg::TurnStarted(_)));
-        let EventMsg::ExecCommandBegin(begin) = &events[1].msg else {
-            panic!("expected exec begin event");
-        };
-        assert_eq!(begin.call_id, "cmd-1");
-        assert_eq!(begin.source, ExecCommandSource::UserShell);
-        let EventMsg::ExecCommandEnd(end) = &events[2].msg else {
-            panic!("expected exec end event");
-        };
-        assert_eq!(end.call_id, "cmd-1");
-        assert_eq!(end.formatted_output, "hello world\n");
-        assert!(matches!(events[3].msg, EventMsg::TurnComplete(_)));
+        assert_eq!(
+            server_notification_thread_target(&notification),
+            ServerNotificationThreadTarget::InvalidThreadId("not-a-thread-id".to_string())
+        );
     }
 
     #[test]
-    fn bridges_interrupted_turn_completion_from_server_notifications() {
-        let thread_id = "019cee8c-b993-7e33-88c0-014d4e62612d".to_string();
-        let turn_id = "019cee8c-b9b4-7f10-a1b0-38caa876a012".to_string();
+    fn bridges_legacy_remote_exec_approval_requests() {
+        let params = ExecCommandApprovalParams {
+            conversation_id: ThreadId::new(),
+            call_id: "call-2".to_string(),
+            approval_id: Some("approval-2".to_string()),
+            command: vec!["printf".to_string(), "hello world".to_string()],
+            cwd: "/tmp/project".into(),
+            reason: Some("Need shell".to_string()),
+            parsed_cmd: Vec::new(),
+        };
+        let request = ServerRequest::ExecCommandApproval {
+            request_id: AppServerRequestId::Integer(8),
+            params: params.clone(),
+        };
 
-        let (actual_thread_id, events) = server_notification_thread_events(
-            ServerNotification::TurnCompleted(TurnCompletedNotification {
-                thread_id: thread_id.clone(),
-                turn: Turn {
-                    id: turn_id.clone(),
-                    items: Vec::new(),
-                    status: TurnStatus::Interrupted,
-                    error: None,
+        let (thread_id, bridged_request) =
+            bridge_legacy_approval_request(&request).expect("request should bridge");
+
+        assert_eq!(thread_id, params.conversation_id);
+        assert_eq!(
+            bridged_request,
+            ServerRequest::CommandExecutionRequestApproval {
+                request_id: AppServerRequestId::Integer(8),
+                params: CommandExecutionRequestApprovalParams {
+                    thread_id: params.conversation_id.to_string(),
+                    turn_id: String::new(),
+                    item_id: "call-2".to_string(),
+                    approval_id: Some("approval-2".to_string()),
+                    reason: Some("Need shell".to_string()),
+                    network_approval_context: None,
+                    command: Some("printf 'hello world'".to_string()),
+                    cwd: Some("/tmp/project".into()),
+                    command_actions: Some(Vec::new()),
+                    additional_permissions: None,
+                    skill_metadata: None,
+                    proposed_execpolicy_amendment: None,
+                    proposed_network_policy_amendments: None,
+                    available_decisions: None,
                 },
-            }),
-        )
-        .expect("notification should bridge");
-
-        assert_eq!(
-            actual_thread_id,
-            ThreadId::from_string(&thread_id).expect("valid thread id")
+            }
         );
-        let [event] = events.as_slice() else {
-            panic!("expected one bridged event");
-        };
-        let EventMsg::TurnAborted(aborted) = &event.msg else {
-            panic!("expected turn aborted event");
-        };
-        assert_eq!(aborted.turn_id.as_deref(), Some(turn_id.as_str()));
-        assert_eq!(aborted.reason, TurnAbortReason::Interrupted);
     }
 
     #[test]
-    fn bridges_failed_turn_completion_from_server_notifications() {
-        let thread_id = "019cee8c-b993-7e33-88c0-014d4e62612d".to_string();
-        let turn_id = "019cee8c-b9b4-7f10-a1b0-38caa876a012".to_string();
+    fn bridges_legacy_patch_approval_requests() {
+        let params = codex_app_server_protocol::ApplyPatchApprovalParams {
+            conversation_id: ThreadId::new(),
+            call_id: "patch-1".to_string(),
+            file_changes: HashMap::new(),
+            reason: Some("Need write access".to_string()),
+            grant_root: Some("/tmp/project".into()),
+        };
+        let request = ServerRequest::ApplyPatchApproval {
+            request_id: AppServerRequestId::Integer(9),
+            params: params.clone(),
+        };
 
-        let (actual_thread_id, events) = server_notification_thread_events(
-            ServerNotification::TurnCompleted(TurnCompletedNotification {
-                thread_id: thread_id.clone(),
-                turn: Turn {
-                    id: turn_id.clone(),
-                    items: Vec::new(),
-                    status: TurnStatus::Failed,
-                    error: Some(TurnError {
-                        message: "request failed".to_string(),
-                        codex_error_info: Some(CodexErrorInfo::Other),
-                        additional_details: None,
-                    }),
+        let (thread_id, bridged_request) =
+            bridge_legacy_approval_request(&request).expect("request should bridge");
+
+        assert_eq!(thread_id, params.conversation_id);
+        assert_eq!(
+            bridged_request,
+            ServerRequest::FileChangeRequestApproval {
+                request_id: AppServerRequestId::Integer(9),
+                params: FileChangeRequestApprovalParams {
+                    thread_id: params.conversation_id.to_string(),
+                    turn_id: String::new(),
+                    item_id: "patch-1".to_string(),
+                    reason: Some("Need write access".to_string()),
+                    grant_root: Some("/tmp/project".into()),
                 },
-            }),
-        )
-        .expect("notification should bridge");
-
-        assert_eq!(
-            actual_thread_id,
-            ThreadId::from_string(&thread_id).expect("valid thread id")
+            }
         );
-        let [complete_event] = events.as_slice() else {
-            panic!("expected turn completion only");
-        };
-        let EventMsg::TurnComplete(completed) = &complete_event.msg else {
-            panic!("expected turn complete event");
-        };
-        assert_eq!(completed.turn_id, turn_id);
-        assert_eq!(completed.last_agent_message, None);
-    }
-
-    #[test]
-    fn bridges_text_deltas_from_server_notifications() {
-        let thread_id = "019cee8c-b993-7e33-88c0-014d4e62612d".to_string();
-
-        let (_, agent_events) = server_notification_thread_events(
-            ServerNotification::AgentMessageDelta(AgentMessageDeltaNotification {
-                thread_id: thread_id.clone(),
-                turn_id: "turn".to_string(),
-                item_id: "item".to_string(),
-                delta: "Hello".to_string(),
-            }),
-        )
-        .expect("notification should bridge");
-        let [agent_event] = agent_events.as_slice() else {
-            panic!("expected one bridged agent delta event");
-        };
-        assert_eq!(agent_event.id, String::new());
-        let EventMsg::AgentMessageDelta(delta) = &agent_event.msg else {
-            panic!("expected bridged agent message delta");
-        };
-        assert_eq!(delta.delta, "Hello");
-
-        let (_, reasoning_events) = server_notification_thread_events(
-            ServerNotification::ReasoningSummaryTextDelta(ReasoningSummaryTextDeltaNotification {
-                thread_id,
-                turn_id: "turn".to_string(),
-                item_id: "item".to_string(),
-                delta: "Thinking".to_string(),
-                summary_index: 0,
-            }),
-        )
-        .expect("notification should bridge");
-        let [reasoning_event] = reasoning_events.as_slice() else {
-            panic!("expected one bridged reasoning delta event");
-        };
-        assert_eq!(reasoning_event.id, String::new());
-        let EventMsg::AgentReasoningDelta(delta) = &reasoning_event.msg else {
-            panic!("expected bridged reasoning delta");
-        };
-        assert_eq!(delta.delta, "Thinking");
-    }
-
-    #[test]
-    fn bridges_thread_snapshot_turns_for_resume_restore() {
-        let thread_id = ThreadId::new();
-        let events = thread_snapshot_events(
-            &Thread {
-                id: thread_id.to_string(),
-                preview: "hello".to_string(),
-                ephemeral: false,
-                model_provider: "openai".to_string(),
-                created_at: 0,
-                updated_at: 0,
-                status: ThreadStatus::Idle,
-                path: None,
-                cwd: PathBuf::from("/tmp/project"),
-                cli_version: "test".to_string(),
-                source: SessionSource::Cli.into(),
-                agent_nickname: None,
-                agent_role: None,
-                git_info: None,
-                name: Some("restore".to_string()),
-                turns: vec![
-                    Turn {
-                        id: "turn-complete".to_string(),
-                        items: vec![
-                            ThreadItem::UserMessage {
-                                id: "user-1".to_string(),
-                                content: vec![codex_app_server_protocol::UserInput::Text {
-                                    text: "hello".to_string(),
-                                    text_elements: Vec::new(),
-                                }],
-                            },
-                            ThreadItem::AgentMessage {
-                                id: "assistant-1".to_string(),
-                                text: "hi".to_string(),
-                                phase: Some(MessagePhase::FinalAnswer),
-                                memory_citation: None,
-                            },
-                        ],
-                        status: TurnStatus::Completed,
-                        error: None,
-                    },
-                    Turn {
-                        id: "turn-interrupted".to_string(),
-                        items: Vec::new(),
-                        status: TurnStatus::Interrupted,
-                        error: None,
-                    },
-                    Turn {
-                        id: "turn-failed".to_string(),
-                        items: Vec::new(),
-                        status: TurnStatus::Failed,
-                        error: Some(TurnError {
-                            message: "request failed".to_string(),
-                            codex_error_info: Some(CodexErrorInfo::Other),
-                            additional_details: None,
-                        }),
-                    },
-                ],
-            },
-            /*show_raw_agent_reasoning*/ false,
-        );
-
-        assert_eq!(events.len(), 9);
-        assert!(matches!(events[0].msg, EventMsg::TurnStarted(_)));
-        assert!(matches!(events[1].msg, EventMsg::ItemCompleted(_)));
-        assert!(matches!(events[2].msg, EventMsg::ItemCompleted(_)));
-        assert!(matches!(events[3].msg, EventMsg::TurnComplete(_)));
-        assert!(matches!(events[4].msg, EventMsg::TurnStarted(_)));
-        let EventMsg::TurnAborted(TurnAbortedEvent { turn_id, reason }) = &events[5].msg else {
-            panic!("expected interrupted turn replay");
-        };
-        assert_eq!(turn_id.as_deref(), Some("turn-interrupted"));
-        assert_eq!(*reason, TurnAbortReason::Interrupted);
-        assert!(matches!(events[6].msg, EventMsg::TurnStarted(_)));
-        let EventMsg::Error(error) = &events[7].msg else {
-            panic!("expected failed turn error replay");
-        };
-        assert_eq!(error.message, "request failed");
-        assert_eq!(
-            error.codex_error_info,
-            Some(codex_protocol::protocol::CodexErrorInfo::Other)
-        );
-        assert!(matches!(events[8].msg, EventMsg::TurnComplete(_)));
-    }
-
-    #[test]
-    fn bridges_non_message_snapshot_items_via_legacy_events() {
-        let events = turn_snapshot_events(
-            ThreadId::new(),
-            &Turn {
-                id: "turn-complete".to_string(),
-                items: vec![
-                    ThreadItem::Reasoning {
-                        id: "reasoning-1".to_string(),
-                        summary: vec!["Need to inspect config".to_string()],
-                        content: vec!["hidden chain".to_string()],
-                    },
-                    ThreadItem::WebSearch {
-                        id: "search-1".to_string(),
-                        query: "ratatui stylize".to_string(),
-                        action: Some(codex_app_server_protocol::WebSearchAction::Other),
-                    },
-                    ThreadItem::ImageGeneration {
-                        id: "image-1".to_string(),
-                        status: "completed".to_string(),
-                        revised_prompt: Some("diagram".to_string()),
-                        result: "image.png".to_string(),
-                    },
-                    ThreadItem::ContextCompaction {
-                        id: "compact-1".to_string(),
-                    },
-                ],
-                status: TurnStatus::Completed,
-                error: None,
-            },
-            /*show_raw_agent_reasoning*/ false,
-        );
-
-        assert_eq!(events.len(), 6);
-        assert!(matches!(events[0].msg, EventMsg::TurnStarted(_)));
-        let EventMsg::AgentReasoning(reasoning) = &events[1].msg else {
-            panic!("expected reasoning replay");
-        };
-        assert_eq!(reasoning.text, "Need to inspect config");
-        let EventMsg::WebSearchEnd(web_search) = &events[2].msg else {
-            panic!("expected web search replay");
-        };
-        assert_eq!(web_search.call_id, "search-1");
-        assert_eq!(web_search.query, "ratatui stylize");
-        assert_eq!(
-            web_search.action,
-            codex_protocol::models::WebSearchAction::Other
-        );
-        let EventMsg::ImageGenerationEnd(image_generation) = &events[3].msg else {
-            panic!("expected image generation replay");
-        };
-        assert_eq!(image_generation.call_id, "image-1");
-        assert_eq!(image_generation.status, "completed");
-        assert_eq!(image_generation.revised_prompt.as_deref(), Some("diagram"));
-        assert_eq!(image_generation.result, "image.png");
-        assert!(matches!(events[4].msg, EventMsg::ContextCompacted(_)));
-        assert!(matches!(events[5].msg, EventMsg::TurnComplete(_)));
-    }
-
-    #[test]
-    fn bridges_raw_reasoning_snapshot_items_when_enabled() {
-        let events = turn_snapshot_events(
-            ThreadId::new(),
-            &Turn {
-                id: "turn-complete".to_string(),
-                items: vec![ThreadItem::Reasoning {
-                    id: "reasoning-1".to_string(),
-                    summary: vec!["Need to inspect config".to_string()],
-                    content: vec!["hidden chain".to_string()],
-                }],
-                status: TurnStatus::Completed,
-                error: None,
-            },
-            /*show_raw_agent_reasoning*/ true,
-        );
-
-        assert_eq!(events.len(), 4);
-        assert!(matches!(events[0].msg, EventMsg::TurnStarted(_)));
-        let EventMsg::AgentReasoning(reasoning) = &events[1].msg else {
-            panic!("expected reasoning replay");
-        };
-        assert_eq!(reasoning.text, "Need to inspect config");
-        let EventMsg::AgentReasoningRawContent(raw_reasoning) = &events[2].msg else {
-            panic!("expected raw reasoning replay");
-        };
-        assert_eq!(raw_reasoning.text, "hidden chain");
-        assert!(matches!(events[3].msg, EventMsg::TurnComplete(_)));
     }
 }

--- a/codex-rs/tui_app_server/src/app/app_server_adapter.rs
+++ b/codex-rs/tui_app_server/src/app/app_server_adapter.rs
@@ -1,3 +1,16 @@
+/*
+This module holds the temporary adapter layer between the TUI and the app
+server during the hybrid migration period.
+
+For now, the TUI still owns its existing direct-core behavior, but startup
+allocates a local in-process app server and drains its event stream. Keeping
+the app-server-specific wiring here keeps that transitional logic out of the
+main `app.rs` orchestration path.
+
+As more TUI flows move onto the app-server surface directly, this adapter
+should shrink and eventually disappear.
+*/
+
 use super::App;
 use crate::app_event::AppEvent;
 use crate::app_server_session::AppServerSession;
@@ -16,8 +29,90 @@ use codex_app_server_protocol::JSONRPCNotification;
 use codex_app_server_protocol::RequestId;
 use codex_app_server_protocol::ServerNotification;
 use codex_app_server_protocol::ServerRequest;
+#[cfg(test)]
+use codex_app_server_protocol::Thread;
+#[cfg(test)]
+use codex_app_server_protocol::ThreadItem;
+#[cfg(test)]
+use codex_app_server_protocol::Turn;
+#[cfg(test)]
+use codex_app_server_protocol::TurnStatus;
 use codex_protocol::ThreadId;
+#[cfg(test)]
+use codex_protocol::config_types::ModeKind;
+#[cfg(test)]
+use codex_protocol::items::AgentMessageContent;
+#[cfg(test)]
+use codex_protocol::items::AgentMessageItem;
+#[cfg(test)]
+use codex_protocol::items::ContextCompactionItem;
+#[cfg(test)]
+use codex_protocol::items::ImageGenerationItem;
+#[cfg(test)]
+use codex_protocol::items::PlanItem;
+#[cfg(test)]
+use codex_protocol::items::ReasoningItem;
+#[cfg(test)]
+use codex_protocol::items::TurnItem;
+#[cfg(test)]
+use codex_protocol::items::UserMessageItem;
+#[cfg(test)]
+use codex_protocol::items::WebSearchItem;
+#[cfg(test)]
+use codex_protocol::protocol::AgentMessageDeltaEvent;
+#[cfg(test)]
+use codex_protocol::protocol::AgentReasoningDeltaEvent;
+#[cfg(test)]
+use codex_protocol::protocol::AgentReasoningRawContentDeltaEvent;
+#[cfg(test)]
+use codex_protocol::protocol::ErrorEvent;
+#[cfg(test)]
+use codex_protocol::protocol::Event;
+#[cfg(test)]
+use codex_protocol::protocol::EventMsg;
+#[cfg(test)]
+use codex_protocol::protocol::ExecCommandBeginEvent;
+#[cfg(test)]
+use codex_protocol::protocol::ExecCommandEndEvent;
+#[cfg(test)]
+use codex_protocol::protocol::ExecCommandOutputDeltaEvent;
+#[cfg(test)]
+use codex_protocol::protocol::ExecCommandStatus;
+#[cfg(test)]
+use codex_protocol::protocol::ExecOutputStream;
+#[cfg(test)]
+use codex_protocol::protocol::ItemCompletedEvent;
+#[cfg(test)]
+use codex_protocol::protocol::ItemStartedEvent;
+#[cfg(test)]
+use codex_protocol::protocol::PlanDeltaEvent;
+#[cfg(test)]
+use codex_protocol::protocol::RealtimeConversationClosedEvent;
+#[cfg(test)]
+use codex_protocol::protocol::RealtimeConversationRealtimeEvent;
+#[cfg(test)]
+use codex_protocol::protocol::RealtimeConversationStartedEvent;
+#[cfg(test)]
+use codex_protocol::protocol::RealtimeEvent;
+#[cfg(test)]
+use codex_protocol::protocol::ThreadNameUpdatedEvent;
+#[cfg(test)]
+use codex_protocol::protocol::TokenCountEvent;
+#[cfg(test)]
+use codex_protocol::protocol::TokenUsage;
+#[cfg(test)]
+use codex_protocol::protocol::TokenUsageInfo;
+#[cfg(test)]
+use codex_protocol::protocol::TurnAbortReason;
+#[cfg(test)]
+use codex_protocol::protocol::TurnAbortedEvent;
+#[cfg(test)]
+use codex_protocol::protocol::TurnCompleteEvent;
+#[cfg(test)]
+use codex_protocol::protocol::TurnStartedEvent;
 use serde_json::Value;
+#[cfg(test)]
+use std::time::Duration;
 
 #[derive(Debug, PartialEq, Eq)]
 enum LegacyThreadNotification {
@@ -448,28 +543,6 @@ fn bridge_legacy_approval_request(
     }
 }
 
-fn resolve_chatgpt_auth_tokens_refresh_response(
-    codex_home: &std::path::Path,
-    auth_credentials_store_mode: codex_core::auth::AuthCredentialsStoreMode,
-    forced_chatgpt_workspace_id: Option<&str>,
-    params: &ChatgptAuthTokensRefreshParams,
-) -> Result<codex_app_server_protocol::ChatgptAuthTokensRefreshResponse, String> {
-    let auth = load_local_chatgpt_auth(
-        codex_home,
-        auth_credentials_store_mode,
-        forced_chatgpt_workspace_id,
-    )?;
-    if let Some(previous_account_id) = params.previous_account_id.as_deref()
-        && previous_account_id != auth.chatgpt_account_id
-    {
-        return Err(format!(
-            "local ChatGPT auth refresh account mismatch: expected `{previous_account_id}`, got `{}`",
-            auth.chatgpt_account_id
-        ));
-    }
-    Ok(auth.to_refresh_response())
-}
-
 fn server_request_thread_id(request: &ServerRequest) -> Option<ThreadId> {
     match request {
         ServerRequest::CommandExecutionRequestApproval { params, .. } => {
@@ -607,6 +680,54 @@ fn server_notification_thread_target(
     }
 }
 
+fn resolve_chatgpt_auth_tokens_refresh_response(
+    codex_home: &std::path::Path,
+    auth_credentials_store_mode: codex_core::auth::AuthCredentialsStoreMode,
+    forced_chatgpt_workspace_id: Option<&str>,
+    params: &ChatgptAuthTokensRefreshParams,
+) -> Result<codex_app_server_protocol::ChatgptAuthTokensRefreshResponse, String> {
+    let auth = load_local_chatgpt_auth(
+        codex_home,
+        auth_credentials_store_mode,
+        forced_chatgpt_workspace_id,
+    )?;
+    if let Some(previous_account_id) = params.previous_account_id.as_deref()
+        && previous_account_id != auth.chatgpt_account_id
+    {
+        return Err(format!(
+            "local ChatGPT auth refresh account mismatch: expected `{previous_account_id}`, got `{}`",
+            auth.chatgpt_account_id
+        ));
+    }
+    Ok(auth.to_refresh_response())
+}
+
+#[cfg(test)]
+/// Convert a `Thread` snapshot into a flat sequence of protocol `Event`s
+/// suitable for replaying into the TUI event store.
+///
+/// Each turn is expanded into `TurnStarted`, zero or more `ItemCompleted`,
+/// and a terminal event that matches the turn's `TurnStatus`. Returns an
+/// empty vec (with a warning log) if the thread ID is not a valid UUID.
+pub(super) fn thread_snapshot_events(
+    thread: &Thread,
+    show_raw_agent_reasoning: bool,
+) -> Vec<Event> {
+    let Ok(thread_id) = ThreadId::from_string(&thread.id) else {
+        tracing::warn!(
+            thread_id = %thread.id,
+            "ignoring app-server thread snapshot with invalid thread id"
+        );
+        return Vec::new();
+    };
+
+    thread
+        .turns
+        .iter()
+        .flat_map(|turn| turn_snapshot_events(thread_id, turn, show_raw_agent_reasoning))
+        .collect()
+}
+
 fn legacy_thread_notification(
     notification: JSONRPCNotification,
 ) -> Option<(ThreadId, LegacyThreadNotification)> {
@@ -650,26 +771,730 @@ fn legacy_thread_notification(
 }
 
 #[cfg(test)]
+fn server_notification_thread_events(
+    notification: ServerNotification,
+) -> Option<(ThreadId, Vec<Event>)> {
+    match notification {
+        ServerNotification::ThreadTokenUsageUpdated(notification) => Some((
+            ThreadId::from_string(&notification.thread_id).ok()?,
+            vec![Event {
+                id: String::new(),
+                msg: EventMsg::TokenCount(TokenCountEvent {
+                    info: Some(TokenUsageInfo {
+                        total_token_usage: token_usage_from_app_server(
+                            notification.token_usage.total,
+                        ),
+                        last_token_usage: token_usage_from_app_server(
+                            notification.token_usage.last,
+                        ),
+                        model_context_window: notification.token_usage.model_context_window,
+                    }),
+                    rate_limits: None,
+                }),
+            }],
+        )),
+        ServerNotification::Error(notification) => Some((
+            ThreadId::from_string(&notification.thread_id).ok()?,
+            vec![Event {
+                id: String::new(),
+                msg: EventMsg::Error(ErrorEvent {
+                    message: notification.error.message,
+                    codex_error_info: notification
+                        .error
+                        .codex_error_info
+                        .and_then(app_server_codex_error_info_to_core),
+                }),
+            }],
+        )),
+        ServerNotification::ThreadNameUpdated(notification) => Some((
+            ThreadId::from_string(&notification.thread_id).ok()?,
+            vec![Event {
+                id: String::new(),
+                msg: EventMsg::ThreadNameUpdated(ThreadNameUpdatedEvent {
+                    thread_id: ThreadId::from_string(&notification.thread_id).ok()?,
+                    thread_name: notification.thread_name,
+                }),
+            }],
+        )),
+        ServerNotification::TurnStarted(notification) => Some((
+            ThreadId::from_string(&notification.thread_id).ok()?,
+            vec![Event {
+                id: String::new(),
+                msg: EventMsg::TurnStarted(TurnStartedEvent {
+                    turn_id: notification.turn.id,
+                    model_context_window: None,
+                    collaboration_mode_kind: ModeKind::default(),
+                }),
+            }],
+        )),
+        ServerNotification::TurnCompleted(notification) => {
+            let thread_id = ThreadId::from_string(&notification.thread_id).ok()?;
+            let mut events = Vec::new();
+            append_terminal_turn_events(
+                &mut events,
+                &notification.turn,
+                /*include_failed_error*/ false,
+            );
+            Some((thread_id, events))
+        }
+        ServerNotification::ItemStarted(notification) => Some((
+            ThreadId::from_string(&notification.thread_id).ok()?,
+            command_execution_started_event(&notification.turn_id, &notification.item).or_else(
+                || {
+                    Some(vec![Event {
+                        id: String::new(),
+                        msg: EventMsg::ItemStarted(ItemStartedEvent {
+                            thread_id: ThreadId::from_string(&notification.thread_id).ok()?,
+                            turn_id: notification.turn_id.clone(),
+                            item: thread_item_to_core(&notification.item)?,
+                        }),
+                    }])
+                },
+            )?,
+        )),
+        ServerNotification::ItemCompleted(notification) => Some((
+            ThreadId::from_string(&notification.thread_id).ok()?,
+            command_execution_completed_event(&notification.turn_id, &notification.item).or_else(
+                || {
+                    Some(vec![Event {
+                        id: String::new(),
+                        msg: EventMsg::ItemCompleted(ItemCompletedEvent {
+                            thread_id: ThreadId::from_string(&notification.thread_id).ok()?,
+                            turn_id: notification.turn_id.clone(),
+                            item: thread_item_to_core(&notification.item)?,
+                        }),
+                    }])
+                },
+            )?,
+        )),
+        ServerNotification::CommandExecutionOutputDelta(notification) => Some((
+            ThreadId::from_string(&notification.thread_id).ok()?,
+            vec![Event {
+                id: String::new(),
+                msg: EventMsg::ExecCommandOutputDelta(ExecCommandOutputDeltaEvent {
+                    call_id: notification.item_id,
+                    stream: ExecOutputStream::Stdout,
+                    chunk: notification.delta.into_bytes(),
+                }),
+            }],
+        )),
+        ServerNotification::AgentMessageDelta(notification) => Some((
+            ThreadId::from_string(&notification.thread_id).ok()?,
+            vec![Event {
+                id: String::new(),
+                msg: EventMsg::AgentMessageDelta(AgentMessageDeltaEvent {
+                    delta: notification.delta,
+                }),
+            }],
+        )),
+        ServerNotification::PlanDelta(notification) => Some((
+            ThreadId::from_string(&notification.thread_id).ok()?,
+            vec![Event {
+                id: String::new(),
+                msg: EventMsg::PlanDelta(PlanDeltaEvent {
+                    thread_id: notification.thread_id,
+                    turn_id: notification.turn_id,
+                    item_id: notification.item_id,
+                    delta: notification.delta,
+                }),
+            }],
+        )),
+        ServerNotification::ReasoningSummaryTextDelta(notification) => Some((
+            ThreadId::from_string(&notification.thread_id).ok()?,
+            vec![Event {
+                id: String::new(),
+                msg: EventMsg::AgentReasoningDelta(AgentReasoningDeltaEvent {
+                    delta: notification.delta,
+                }),
+            }],
+        )),
+        ServerNotification::ReasoningTextDelta(notification) => Some((
+            ThreadId::from_string(&notification.thread_id).ok()?,
+            vec![Event {
+                id: String::new(),
+                msg: EventMsg::AgentReasoningRawContentDelta(AgentReasoningRawContentDeltaEvent {
+                    delta: notification.delta,
+                }),
+            }],
+        )),
+        ServerNotification::ThreadRealtimeStarted(notification) => Some((
+            ThreadId::from_string(&notification.thread_id).ok()?,
+            vec![Event {
+                id: String::new(),
+                msg: EventMsg::RealtimeConversationStarted(RealtimeConversationStartedEvent {
+                    session_id: notification.session_id,
+                    version: notification.version,
+                }),
+            }],
+        )),
+        ServerNotification::ThreadRealtimeItemAdded(notification) => Some((
+            ThreadId::from_string(&notification.thread_id).ok()?,
+            vec![Event {
+                id: String::new(),
+                msg: EventMsg::RealtimeConversationRealtime(RealtimeConversationRealtimeEvent {
+                    payload: RealtimeEvent::ConversationItemAdded(notification.item),
+                }),
+            }],
+        )),
+        ServerNotification::ThreadRealtimeOutputAudioDelta(notification) => Some((
+            ThreadId::from_string(&notification.thread_id).ok()?,
+            vec![Event {
+                id: String::new(),
+                msg: EventMsg::RealtimeConversationRealtime(RealtimeConversationRealtimeEvent {
+                    payload: RealtimeEvent::AudioOut(notification.audio.into()),
+                }),
+            }],
+        )),
+        ServerNotification::ThreadRealtimeError(notification) => Some((
+            ThreadId::from_string(&notification.thread_id).ok()?,
+            vec![Event {
+                id: String::new(),
+                msg: EventMsg::RealtimeConversationRealtime(RealtimeConversationRealtimeEvent {
+                    payload: RealtimeEvent::Error(notification.message),
+                }),
+            }],
+        )),
+        ServerNotification::ThreadRealtimeClosed(notification) => Some((
+            ThreadId::from_string(&notification.thread_id).ok()?,
+            vec![Event {
+                id: String::new(),
+                msg: EventMsg::RealtimeConversationClosed(RealtimeConversationClosedEvent {
+                    reason: notification.reason,
+                }),
+            }],
+        )),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+fn token_usage_from_app_server(
+    value: codex_app_server_protocol::TokenUsageBreakdown,
+) -> TokenUsage {
+    TokenUsage {
+        input_tokens: value.input_tokens,
+        cached_input_tokens: value.cached_input_tokens,
+        output_tokens: value.output_tokens,
+        reasoning_output_tokens: value.reasoning_output_tokens,
+        total_tokens: value.total_tokens,
+    }
+}
+
+/// Expand a single `Turn` into the event sequence the TUI would have
+/// observed if it had been connected for the turn's entire lifetime.
+///
+/// Snapshot replay keeps committed-item semantics for user / plan /
+/// agent-message items, while replaying the legacy events that still
+/// drive rendering for reasoning, web-search, image-generation, and
+/// context-compaction history cells.
+#[cfg(test)]
+fn turn_snapshot_events(
+    thread_id: ThreadId,
+    turn: &Turn,
+    show_raw_agent_reasoning: bool,
+) -> Vec<Event> {
+    let mut events = vec![Event {
+        id: String::new(),
+        msg: EventMsg::TurnStarted(TurnStartedEvent {
+            turn_id: turn.id.clone(),
+            model_context_window: None,
+            collaboration_mode_kind: ModeKind::default(),
+        }),
+    }];
+
+    for item in &turn.items {
+        if let Some(command_events) = command_execution_snapshot_events(&turn.id, item) {
+            events.extend(command_events);
+            continue;
+        }
+
+        let Some(item) = thread_item_to_core(item) else {
+            continue;
+        };
+        match item {
+            TurnItem::UserMessage(_) | TurnItem::Plan(_) | TurnItem::AgentMessage(_) => {
+                events.push(Event {
+                    id: String::new(),
+                    msg: EventMsg::ItemCompleted(ItemCompletedEvent {
+                        thread_id,
+                        turn_id: turn.id.clone(),
+                        item,
+                    }),
+                });
+            }
+            TurnItem::Reasoning(_)
+            | TurnItem::WebSearch(_)
+            | TurnItem::ImageGeneration(_)
+            | TurnItem::ContextCompaction(_) => {
+                events.extend(
+                    item.as_legacy_events(show_raw_agent_reasoning)
+                        .into_iter()
+                        .map(|msg| Event {
+                            id: String::new(),
+                            msg,
+                        }),
+                );
+            }
+        }
+    }
+
+    append_terminal_turn_events(&mut events, turn, /*include_failed_error*/ true);
+
+    events
+}
+
+/// Append the terminal event(s) for a turn based on its `TurnStatus`.
+///
+/// This function is shared between the live notification bridge
+/// (`TurnCompleted` handling) and the snapshot replay path so that both
+/// produce identical `EventMsg` sequences for the same turn status.
+///
+/// - `Completed` → `TurnComplete`
+/// - `Interrupted` → `TurnAborted { reason: Interrupted }`
+/// - `Failed` → `Error` (if present) then `TurnComplete`
+/// - `InProgress` → no events (the turn is still running)
+#[cfg(test)]
+fn append_terminal_turn_events(events: &mut Vec<Event>, turn: &Turn, include_failed_error: bool) {
+    match turn.status {
+        TurnStatus::Completed => events.push(Event {
+            id: String::new(),
+            msg: EventMsg::TurnComplete(TurnCompleteEvent {
+                turn_id: turn.id.clone(),
+                last_agent_message: None,
+            }),
+        }),
+        TurnStatus::Interrupted => events.push(Event {
+            id: String::new(),
+            msg: EventMsg::TurnAborted(TurnAbortedEvent {
+                turn_id: Some(turn.id.clone()),
+                reason: TurnAbortReason::Interrupted,
+            }),
+        }),
+        TurnStatus::Failed => {
+            if include_failed_error && let Some(error) = &turn.error {
+                events.push(Event {
+                    id: String::new(),
+                    msg: EventMsg::Error(ErrorEvent {
+                        message: error.message.clone(),
+                        codex_error_info: error
+                            .codex_error_info
+                            .clone()
+                            .and_then(app_server_codex_error_info_to_core),
+                    }),
+                });
+            }
+            events.push(Event {
+                id: String::new(),
+                msg: EventMsg::TurnComplete(TurnCompleteEvent {
+                    turn_id: turn.id.clone(),
+                    last_agent_message: None,
+                }),
+            });
+        }
+        TurnStatus::InProgress => {
+            // Preserve unfinished turns during snapshot replay without emitting completion events.
+        }
+    }
+}
+
+#[cfg(test)]
+fn thread_item_to_core(item: &ThreadItem) -> Option<TurnItem> {
+    match item {
+        ThreadItem::UserMessage { id, content } => Some(TurnItem::UserMessage(UserMessageItem {
+            id: id.clone(),
+            content: content
+                .iter()
+                .cloned()
+                .map(codex_app_server_protocol::UserInput::into_core)
+                .collect(),
+        })),
+        ThreadItem::AgentMessage {
+            id,
+            text,
+            phase,
+            memory_citation,
+        } => Some(TurnItem::AgentMessage(AgentMessageItem {
+            id: id.clone(),
+            content: vec![AgentMessageContent::Text { text: text.clone() }],
+            phase: phase.clone(),
+            memory_citation: memory_citation.clone().map(|citation| {
+                codex_protocol::memory_citation::MemoryCitation {
+                    entries: citation
+                        .entries
+                        .into_iter()
+                        .map(
+                            |entry| codex_protocol::memory_citation::MemoryCitationEntry {
+                                path: entry.path,
+                                line_start: entry.line_start,
+                                line_end: entry.line_end,
+                                note: entry.note,
+                            },
+                        )
+                        .collect(),
+                    rollout_ids: citation.thread_ids,
+                }
+            }),
+        })),
+        ThreadItem::Plan { id, text } => Some(TurnItem::Plan(PlanItem {
+            id: id.clone(),
+            text: text.clone(),
+        })),
+        ThreadItem::Reasoning {
+            id,
+            summary,
+            content,
+        } => Some(TurnItem::Reasoning(ReasoningItem {
+            id: id.clone(),
+            summary_text: summary.clone(),
+            raw_content: content.clone(),
+        })),
+        ThreadItem::WebSearch { id, query, action } => Some(TurnItem::WebSearch(WebSearchItem {
+            id: id.clone(),
+            query: query.clone(),
+            action: app_server_web_search_action_to_core(action.clone()?)?,
+        })),
+        ThreadItem::ImageGeneration {
+            id,
+            status,
+            revised_prompt,
+            result,
+        } => Some(TurnItem::ImageGeneration(ImageGenerationItem {
+            id: id.clone(),
+            status: status.clone(),
+            revised_prompt: revised_prompt.clone(),
+            result: result.clone(),
+            saved_path: None,
+        })),
+        ThreadItem::ContextCompaction { id } => {
+            Some(TurnItem::ContextCompaction(ContextCompactionItem {
+                id: id.clone(),
+            }))
+        }
+        ThreadItem::CommandExecution { .. }
+        | ThreadItem::FileChange { .. }
+        | ThreadItem::McpToolCall { .. }
+        | ThreadItem::DynamicToolCall { .. }
+        | ThreadItem::CollabAgentToolCall { .. }
+        | ThreadItem::ImageView { .. }
+        | ThreadItem::EnteredReviewMode { .. }
+        | ThreadItem::ExitedReviewMode { .. } => {
+            tracing::debug!("ignoring unsupported app-server thread item in TUI adapter");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+fn command_execution_started_event(turn_id: &str, item: &ThreadItem) -> Option<Vec<Event>> {
+    let ThreadItem::CommandExecution {
+        id,
+        command,
+        cwd,
+        process_id,
+        source,
+        command_actions,
+        ..
+    } = item
+    else {
+        return None;
+    };
+
+    Some(vec![Event {
+        id: String::new(),
+        msg: EventMsg::ExecCommandBegin(ExecCommandBeginEvent {
+            call_id: id.clone(),
+            process_id: process_id.clone(),
+            turn_id: turn_id.to_string(),
+            command: split_command_string(command),
+            cwd: cwd.clone(),
+            parsed_cmd: command_actions
+                .iter()
+                .cloned()
+                .map(codex_app_server_protocol::CommandAction::into_core)
+                .collect(),
+            source: source.to_core(),
+            interaction_input: None,
+        }),
+    }])
+}
+
+#[cfg(test)]
+fn command_execution_completed_event(turn_id: &str, item: &ThreadItem) -> Option<Vec<Event>> {
+    let ThreadItem::CommandExecution {
+        id,
+        command,
+        cwd,
+        process_id,
+        source,
+        status,
+        command_actions,
+        aggregated_output,
+        exit_code,
+        duration_ms,
+    } = item
+    else {
+        return None;
+    };
+
+    if matches!(
+        status,
+        codex_app_server_protocol::CommandExecutionStatus::InProgress
+    ) {
+        return Some(Vec::new());
+    }
+
+    let status = match status {
+        codex_app_server_protocol::CommandExecutionStatus::InProgress => return Some(Vec::new()),
+        codex_app_server_protocol::CommandExecutionStatus::Completed => {
+            ExecCommandStatus::Completed
+        }
+        codex_app_server_protocol::CommandExecutionStatus::Failed => ExecCommandStatus::Failed,
+        codex_app_server_protocol::CommandExecutionStatus::Declined => ExecCommandStatus::Declined,
+    };
+
+    let duration = Duration::from_millis(
+        duration_ms
+            .and_then(|value| u64::try_from(value).ok())
+            .unwrap_or_default(),
+    );
+    let aggregated_output = aggregated_output.clone().unwrap_or_default();
+
+    Some(vec![Event {
+        id: String::new(),
+        msg: EventMsg::ExecCommandEnd(ExecCommandEndEvent {
+            call_id: id.clone(),
+            process_id: process_id.clone(),
+            turn_id: turn_id.to_string(),
+            command: split_command_string(command),
+            cwd: cwd.clone(),
+            parsed_cmd: command_actions
+                .iter()
+                .cloned()
+                .map(codex_app_server_protocol::CommandAction::into_core)
+                .collect(),
+            source: source.to_core(),
+            interaction_input: None,
+            stdout: String::new(),
+            stderr: String::new(),
+            aggregated_output: aggregated_output.clone(),
+            exit_code: exit_code.unwrap_or(-1),
+            duration,
+            formatted_output: aggregated_output,
+            status,
+        }),
+    }])
+}
+
+#[cfg(test)]
+fn command_execution_snapshot_events(turn_id: &str, item: &ThreadItem) -> Option<Vec<Event>> {
+    let mut events = command_execution_started_event(turn_id, item)?;
+    if let Some(end_events) = command_execution_completed_event(turn_id, item) {
+        events.extend(end_events);
+    }
+    Some(events)
+}
+
+#[cfg(test)]
+fn split_command_string(command: &str) -> Vec<String> {
+    let Some(parts) = shlex::split(command) else {
+        return vec![command.to_string()];
+    };
+    match shlex::try_join(parts.iter().map(String::as_str)) {
+        Ok(round_trip)
+            if round_trip == command
+                || (!command.contains(":\\")
+                    && shlex::split(&round_trip).as_ref() == Some(&parts)) =>
+        {
+            parts
+        }
+        _ => vec![command.to_string()],
+    }
+}
+
+#[cfg(test)]
+mod refresh_tests {
+    use super::*;
+
+    use base64::Engine;
+    use chrono::Utc;
+    use codex_app_server_protocol::AuthMode;
+    use codex_core::auth::AuthCredentialsStoreMode;
+    use codex_core::auth::AuthDotJson;
+    use codex_core::auth::save_auth;
+    use codex_core::token_data::TokenData;
+    use pretty_assertions::assert_eq;
+    use serde::Serialize;
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    fn fake_jwt(account_id: &str, plan_type: &str) -> String {
+        #[derive(Serialize)]
+        struct Header {
+            alg: &'static str,
+            typ: &'static str,
+        }
+
+        let header = Header {
+            alg: "none",
+            typ: "JWT",
+        };
+        let payload = json!({
+            "email": "user@example.com",
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": account_id,
+                "chatgpt_plan_type": plan_type,
+            },
+        });
+        let encode = |bytes: &[u8]| base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes);
+        let header_b64 = encode(&serde_json::to_vec(&header).expect("serialize header"));
+        let payload_b64 = encode(&serde_json::to_vec(&payload).expect("serialize payload"));
+        let signature_b64 = encode(b"sig");
+        format!("{header_b64}.{payload_b64}.{signature_b64}")
+    }
+
+    fn write_chatgpt_auth(codex_home: &std::path::Path) {
+        let id_token = fake_jwt("workspace-1", "business");
+        let access_token = fake_jwt("workspace-1", "business");
+        save_auth(
+            codex_home,
+            &AuthDotJson {
+                auth_mode: Some(AuthMode::Chatgpt),
+                openai_api_key: None,
+                tokens: Some(TokenData {
+                    id_token: codex_core::token_data::parse_chatgpt_jwt_claims(&id_token)
+                        .expect("id token should parse"),
+                    access_token,
+                    refresh_token: "refresh-token".to_string(),
+                    account_id: Some("workspace-1".to_string()),
+                }),
+                last_refresh: Some(Utc::now()),
+            },
+            AuthCredentialsStoreMode::File,
+        )
+        .expect("chatgpt auth should save");
+    }
+
+    #[test]
+    fn refresh_request_uses_local_chatgpt_auth() {
+        let codex_home = TempDir::new().expect("tempdir");
+        write_chatgpt_auth(codex_home.path());
+
+        let response = resolve_chatgpt_auth_tokens_refresh_response(
+            codex_home.path(),
+            AuthCredentialsStoreMode::File,
+            Some("workspace-1"),
+            &ChatgptAuthTokensRefreshParams {
+                reason: codex_app_server_protocol::ChatgptAuthTokensRefreshReason::Unauthorized,
+                previous_account_id: Some("workspace-1".to_string()),
+            },
+        )
+        .expect("refresh response should resolve");
+
+        assert_eq!(response.chatgpt_account_id, "workspace-1");
+        assert_eq!(response.chatgpt_plan_type.as_deref(), Some("business"));
+        assert!(!response.access_token.is_empty());
+    }
+
+    #[test]
+    fn refresh_request_rejects_account_mismatch() {
+        let codex_home = TempDir::new().expect("tempdir");
+        write_chatgpt_auth(codex_home.path());
+
+        let err = resolve_chatgpt_auth_tokens_refresh_response(
+            codex_home.path(),
+            AuthCredentialsStoreMode::File,
+            Some("workspace-1"),
+            &ChatgptAuthTokensRefreshParams {
+                reason: codex_app_server_protocol::ChatgptAuthTokensRefreshReason::Unauthorized,
+                previous_account_id: Some("workspace-2".to_string()),
+            },
+        )
+        .expect_err("mismatched account should fail");
+
+        assert_eq!(
+            err,
+            "local ChatGPT auth refresh account mismatch: expected `workspace-2`, got `workspace-1`"
+        );
+    }
+}
+
+#[cfg(test)]
+fn app_server_web_search_action_to_core(
+    action: codex_app_server_protocol::WebSearchAction,
+) -> Option<codex_protocol::models::WebSearchAction> {
+    match action {
+        codex_app_server_protocol::WebSearchAction::Search { query, queries } => {
+            Some(codex_protocol::models::WebSearchAction::Search { query, queries })
+        }
+        codex_app_server_protocol::WebSearchAction::OpenPage { url } => {
+            Some(codex_protocol::models::WebSearchAction::OpenPage { url })
+        }
+        codex_app_server_protocol::WebSearchAction::FindInPage { url, pattern } => {
+            Some(codex_protocol::models::WebSearchAction::FindInPage { url, pattern })
+        }
+        codex_app_server_protocol::WebSearchAction::Other => {
+            Some(codex_protocol::models::WebSearchAction::Other)
+        }
+    }
+}
+
+#[cfg(test)]
+fn app_server_codex_error_info_to_core(
+    value: codex_app_server_protocol::CodexErrorInfo,
+) -> Option<codex_protocol::protocol::CodexErrorInfo> {
+    serde_json::from_value(serde_json::to_value(value).ok()?).ok()
+}
+
+#[cfg(test)]
 mod tests {
     use super::LegacyThreadNotification;
     use super::ServerNotificationThreadTarget;
     use super::bridge_legacy_approval_request;
+    use super::command_execution_started_event;
     use super::legacy_thread_notification;
+    use super::server_notification_thread_events;
     use super::server_notification_thread_target;
+    use super::thread_snapshot_events;
+    use super::turn_snapshot_events;
+    use codex_app_server_protocol::AgentMessageDeltaNotification;
+    use codex_app_server_protocol::ApplyPatchApprovalParams;
+    use codex_app_server_protocol::CodexErrorInfo;
+    use codex_app_server_protocol::CommandAction;
+    use codex_app_server_protocol::CommandExecutionOutputDeltaNotification;
     use codex_app_server_protocol::CommandExecutionRequestApprovalParams;
+    use codex_app_server_protocol::CommandExecutionSource;
+    use codex_app_server_protocol::CommandExecutionStatus;
     use codex_app_server_protocol::ExecCommandApprovalParams;
     use codex_app_server_protocol::FileChangeRequestApprovalParams;
+    use codex_app_server_protocol::ItemCompletedNotification;
+    use codex_app_server_protocol::ItemStartedNotification;
     use codex_app_server_protocol::JSONRPCNotification;
+    use codex_app_server_protocol::ReasoningSummaryTextDeltaNotification;
     use codex_app_server_protocol::RequestId as AppServerRequestId;
     use codex_app_server_protocol::ServerNotification;
     use codex_app_server_protocol::ServerRequest;
+    use codex_app_server_protocol::Thread;
+    use codex_app_server_protocol::ThreadItem;
+    use codex_app_server_protocol::ThreadStatus;
     use codex_app_server_protocol::Turn;
+    use codex_app_server_protocol::TurnCompletedNotification;
+    use codex_app_server_protocol::TurnError;
     use codex_app_server_protocol::TurnStartedNotification;
     use codex_app_server_protocol::TurnStatus;
     use codex_protocol::ThreadId;
+    use codex_protocol::items::AgentMessageContent;
+    use codex_protocol::items::AgentMessageItem;
+    use codex_protocol::items::TurnItem;
+    use codex_protocol::models::MessagePhase;
+    use codex_protocol::protocol::EventMsg;
+    use codex_protocol::protocol::ExecCommandSource;
+    use codex_protocol::protocol::SessionSource;
+    use codex_protocol::protocol::TurnAbortReason;
+    use codex_protocol::protocol::TurnAbortedEvent;
     use pretty_assertions::assert_eq;
     use serde_json::json;
     use std::collections::HashMap;
+    use std::path::PathBuf;
 
     #[test]
     fn legacy_warning_notification_extracts_thread_id_and_message() {
@@ -693,22 +1518,6 @@ mod tests {
                 LegacyThreadNotification::Warning("legacy warning message".to_string())
             ))
         );
-    }
-
-    #[test]
-    fn legacy_warning_notification_ignores_non_warning_legacy_events() {
-        let notification = legacy_thread_notification(JSONRPCNotification {
-            method: "codex/event/task_started".to_string(),
-            params: Some(json!({
-                "conversationId": ThreadId::new().to_string(),
-                "id": "event-1",
-                "msg": {
-                    "type": "task_started",
-                },
-            })),
-        });
-
-        assert_eq!(notification, None);
     }
 
     #[test]
@@ -799,7 +1608,7 @@ mod tests {
 
     #[test]
     fn bridges_legacy_patch_approval_requests() {
-        let params = codex_app_server_protocol::ApplyPatchApprovalParams {
+        let params = ApplyPatchApprovalParams {
             conversation_id: ThreadId::new(),
             call_id: "patch-1".to_string(),
             file_changes: HashMap::new(),
@@ -828,5 +1637,551 @@ mod tests {
                 },
             }
         );
+    }
+
+    #[test]
+    fn bridges_completed_agent_messages_from_server_notifications() {
+        let thread_id = "019cee8c-b993-7e33-88c0-014d4e62612d".to_string();
+        let turn_id = "019cee8c-b9b4-7f10-a1b0-38caa876a012".to_string();
+        let item_id = "msg_123".to_string();
+
+        let (actual_thread_id, events) = server_notification_thread_events(
+            ServerNotification::ItemCompleted(ItemCompletedNotification {
+                item: ThreadItem::AgentMessage {
+                    id: item_id,
+                    text: "Hello from your coding assistant.".to_string(),
+                    phase: Some(MessagePhase::FinalAnswer),
+                    memory_citation: None,
+                },
+                thread_id: thread_id.clone(),
+                turn_id: turn_id.clone(),
+            }),
+        )
+        .expect("notification should bridge");
+
+        assert_eq!(
+            actual_thread_id,
+            ThreadId::from_string(&thread_id).expect("valid thread id")
+        );
+        let [event] = events.as_slice() else {
+            panic!("expected one bridged event");
+        };
+        assert_eq!(event.id, String::new());
+        let EventMsg::ItemCompleted(completed) = &event.msg else {
+            panic!("expected item completed event");
+        };
+        assert_eq!(
+            completed.thread_id,
+            ThreadId::from_string(&thread_id).expect("valid thread id")
+        );
+        assert_eq!(completed.turn_id, turn_id);
+        match &completed.item {
+            TurnItem::AgentMessage(AgentMessageItem {
+                id, content, phase, ..
+            }) => {
+                assert_eq!(id, "msg_123");
+                let [AgentMessageContent::Text { text }] = content.as_slice() else {
+                    panic!("expected a single text content item");
+                };
+                assert_eq!(text, "Hello from your coding assistant.");
+                assert_eq!(*phase, Some(MessagePhase::FinalAnswer));
+            }
+            _ => panic!("expected bridged agent message item"),
+        }
+    }
+
+    #[test]
+    fn bridges_turn_completion_from_server_notifications() {
+        let thread_id = "019cee8c-b993-7e33-88c0-014d4e62612d".to_string();
+        let turn_id = "019cee8c-b9b4-7f10-a1b0-38caa876a012".to_string();
+
+        let (actual_thread_id, events) = server_notification_thread_events(
+            ServerNotification::TurnCompleted(TurnCompletedNotification {
+                thread_id: thread_id.clone(),
+                turn: Turn {
+                    id: turn_id.clone(),
+                    items: Vec::new(),
+                    status: TurnStatus::Completed,
+                    error: None,
+                },
+            }),
+        )
+        .expect("notification should bridge");
+
+        assert_eq!(
+            actual_thread_id,
+            ThreadId::from_string(&thread_id).expect("valid thread id")
+        );
+        let [event] = events.as_slice() else {
+            panic!("expected one bridged event");
+        };
+        assert_eq!(event.id, String::new());
+        let EventMsg::TurnComplete(completed) = &event.msg else {
+            panic!("expected turn complete event");
+        };
+        assert_eq!(completed.turn_id, turn_id);
+        assert_eq!(completed.last_agent_message, None);
+    }
+
+    #[test]
+    fn bridges_command_execution_notifications_into_legacy_exec_events() {
+        let thread_id = "019cee8c-b993-7e33-88c0-014d4e62612d".to_string();
+        let turn_id = "019cee8c-b9b4-7f10-a1b0-38caa876a012".to_string();
+        let item = ThreadItem::CommandExecution {
+            id: "cmd-1".to_string(),
+            command: "printf 'hello world\\n'".to_string(),
+            cwd: PathBuf::from("/tmp"),
+            process_id: None,
+            source: CommandExecutionSource::UserShell,
+            status: CommandExecutionStatus::InProgress,
+            command_actions: vec![CommandAction::Unknown {
+                command: "printf hello world".to_string(),
+            }],
+            aggregated_output: None,
+            exit_code: None,
+            duration_ms: None,
+        };
+
+        let (_, started_events) = server_notification_thread_events(
+            ServerNotification::ItemStarted(ItemStartedNotification {
+                item,
+                thread_id: thread_id.clone(),
+                turn_id: turn_id.clone(),
+            }),
+        )
+        .expect("command execution start should bridge");
+        let [started] = started_events.as_slice() else {
+            panic!("expected one started event");
+        };
+        let EventMsg::ExecCommandBegin(begin) = &started.msg else {
+            panic!("expected exec begin event");
+        };
+        assert_eq!(begin.call_id, "cmd-1");
+        assert_eq!(
+            begin.command,
+            vec!["printf".to_string(), "hello world\\n".to_string()]
+        );
+        assert_eq!(begin.cwd, PathBuf::from("/tmp"));
+        assert_eq!(begin.source, ExecCommandSource::UserShell);
+
+        let (_, delta_events) =
+            server_notification_thread_events(ServerNotification::CommandExecutionOutputDelta(
+                CommandExecutionOutputDeltaNotification {
+                    thread_id: thread_id.clone(),
+                    turn_id: turn_id.clone(),
+                    item_id: "cmd-1".to_string(),
+                    delta: "hello world\n".to_string(),
+                },
+            ))
+            .expect("command execution delta should bridge");
+        let [delta] = delta_events.as_slice() else {
+            panic!("expected one delta event");
+        };
+        let EventMsg::ExecCommandOutputDelta(delta) = &delta.msg else {
+            panic!("expected exec output delta event");
+        };
+        assert_eq!(delta.call_id, "cmd-1");
+        assert_eq!(delta.chunk, b"hello world\n");
+
+        let completed_item = ThreadItem::CommandExecution {
+            id: "cmd-1".to_string(),
+            command: "printf 'hello world\\n'".to_string(),
+            cwd: PathBuf::from("/tmp"),
+            process_id: None,
+            source: CommandExecutionSource::UserShell,
+            status: CommandExecutionStatus::Completed,
+            command_actions: vec![CommandAction::Unknown {
+                command: "printf hello world".to_string(),
+            }],
+            aggregated_output: Some("hello world\n".to_string()),
+            exit_code: Some(0),
+            duration_ms: Some(5),
+        };
+        let (_, completed_events) = server_notification_thread_events(
+            ServerNotification::ItemCompleted(ItemCompletedNotification {
+                item: completed_item,
+                thread_id,
+                turn_id,
+            }),
+        )
+        .expect("command execution completion should bridge");
+        let [completed] = completed_events.as_slice() else {
+            panic!("expected one completed event");
+        };
+        let EventMsg::ExecCommandEnd(end) = &completed.msg else {
+            panic!("expected exec end event");
+        };
+        assert_eq!(end.call_id, "cmd-1");
+        assert_eq!(end.exit_code, 0);
+        assert_eq!(end.formatted_output, "hello world\n");
+        assert_eq!(end.aggregated_output, "hello world\n");
+        assert_eq!(end.source, ExecCommandSource::UserShell);
+    }
+
+    #[test]
+    fn command_execution_snapshot_preserves_non_roundtrippable_command_strings() {
+        let item = ThreadItem::CommandExecution {
+            id: "cmd-1".to_string(),
+            command: r#"C:\Program Files\Git\bin\bash.exe -lc "echo hi""#.to_string(),
+            cwd: PathBuf::from("C:\\repo"),
+            process_id: None,
+            source: CommandExecutionSource::UserShell,
+            status: CommandExecutionStatus::InProgress,
+            command_actions: vec![],
+            aggregated_output: None,
+            exit_code: None,
+            duration_ms: None,
+        };
+
+        let events =
+            command_execution_started_event("turn-1", &item).expect("command execution start");
+        let [started] = events.as_slice() else {
+            panic!("expected one started event");
+        };
+        let EventMsg::ExecCommandBegin(begin) = &started.msg else {
+            panic!("expected exec begin event");
+        };
+        assert_eq!(
+            begin.command,
+            vec![r#"C:\Program Files\Git\bin\bash.exe -lc "echo hi""#.to_string()]
+        );
+    }
+
+    #[test]
+    fn replays_command_execution_items_from_thread_snapshots() {
+        let thread = Thread {
+            id: "019cee8c-b993-7e33-88c0-014d4e62612d".to_string(),
+            preview: String::new(),
+            ephemeral: false,
+            model_provider: "openai".to_string(),
+            created_at: 1,
+            updated_at: 1,
+            status: ThreadStatus::Idle,
+            path: None,
+            cwd: PathBuf::from("/tmp"),
+            cli_version: "test".to_string(),
+            source: SessionSource::Cli.into(),
+            agent_nickname: None,
+            agent_role: None,
+            git_info: None,
+            name: None,
+            turns: vec![Turn {
+                id: "turn-1".to_string(),
+                items: vec![ThreadItem::CommandExecution {
+                    id: "cmd-1".to_string(),
+                    command: "printf 'hello world\\n'".to_string(),
+                    cwd: PathBuf::from("/tmp"),
+                    process_id: None,
+                    source: CommandExecutionSource::UserShell,
+                    status: CommandExecutionStatus::Completed,
+                    command_actions: vec![CommandAction::Unknown {
+                        command: "printf hello world".to_string(),
+                    }],
+                    aggregated_output: Some("hello world\n".to_string()),
+                    exit_code: Some(0),
+                    duration_ms: Some(5),
+                }],
+                status: TurnStatus::Completed,
+                error: None,
+            }],
+        };
+
+        let events = thread_snapshot_events(&thread, /*show_raw_agent_reasoning*/ false);
+        assert!(matches!(events[0].msg, EventMsg::TurnStarted(_)));
+        let EventMsg::ExecCommandBegin(begin) = &events[1].msg else {
+            panic!("expected exec begin event");
+        };
+        assert_eq!(begin.call_id, "cmd-1");
+        assert_eq!(begin.source, ExecCommandSource::UserShell);
+        let EventMsg::ExecCommandEnd(end) = &events[2].msg else {
+            panic!("expected exec end event");
+        };
+        assert_eq!(end.call_id, "cmd-1");
+        assert_eq!(end.formatted_output, "hello world\n");
+        assert!(matches!(events[3].msg, EventMsg::TurnComplete(_)));
+    }
+
+    #[test]
+    fn bridges_interrupted_turn_completion_from_server_notifications() {
+        let thread_id = "019cee8c-b993-7e33-88c0-014d4e62612d".to_string();
+        let turn_id = "019cee8c-b9b4-7f10-a1b0-38caa876a012".to_string();
+
+        let (actual_thread_id, events) = server_notification_thread_events(
+            ServerNotification::TurnCompleted(TurnCompletedNotification {
+                thread_id: thread_id.clone(),
+                turn: Turn {
+                    id: turn_id.clone(),
+                    items: Vec::new(),
+                    status: TurnStatus::Interrupted,
+                    error: None,
+                },
+            }),
+        )
+        .expect("notification should bridge");
+
+        assert_eq!(
+            actual_thread_id,
+            ThreadId::from_string(&thread_id).expect("valid thread id")
+        );
+        let [event] = events.as_slice() else {
+            panic!("expected one bridged event");
+        };
+        let EventMsg::TurnAborted(aborted) = &event.msg else {
+            panic!("expected turn aborted event");
+        };
+        assert_eq!(aborted.turn_id.as_deref(), Some(turn_id.as_str()));
+        assert_eq!(aborted.reason, TurnAbortReason::Interrupted);
+    }
+
+    #[test]
+    fn bridges_failed_turn_completion_from_server_notifications() {
+        let thread_id = "019cee8c-b993-7e33-88c0-014d4e62612d".to_string();
+        let turn_id = "019cee8c-b9b4-7f10-a1b0-38caa876a012".to_string();
+
+        let (actual_thread_id, events) = server_notification_thread_events(
+            ServerNotification::TurnCompleted(TurnCompletedNotification {
+                thread_id: thread_id.clone(),
+                turn: Turn {
+                    id: turn_id.clone(),
+                    items: Vec::new(),
+                    status: TurnStatus::Failed,
+                    error: Some(TurnError {
+                        message: "request failed".to_string(),
+                        codex_error_info: Some(CodexErrorInfo::Other),
+                        additional_details: None,
+                    }),
+                },
+            }),
+        )
+        .expect("notification should bridge");
+
+        assert_eq!(
+            actual_thread_id,
+            ThreadId::from_string(&thread_id).expect("valid thread id")
+        );
+        let [complete_event] = events.as_slice() else {
+            panic!("expected turn completion only");
+        };
+        let EventMsg::TurnComplete(completed) = &complete_event.msg else {
+            panic!("expected turn complete event");
+        };
+        assert_eq!(completed.turn_id, turn_id);
+        assert_eq!(completed.last_agent_message, None);
+    }
+
+    #[test]
+    fn bridges_text_deltas_from_server_notifications() {
+        let thread_id = "019cee8c-b993-7e33-88c0-014d4e62612d".to_string();
+
+        let (_, agent_events) = server_notification_thread_events(
+            ServerNotification::AgentMessageDelta(AgentMessageDeltaNotification {
+                thread_id: thread_id.clone(),
+                turn_id: "turn".to_string(),
+                item_id: "item".to_string(),
+                delta: "Hello".to_string(),
+            }),
+        )
+        .expect("notification should bridge");
+        let [agent_event] = agent_events.as_slice() else {
+            panic!("expected one bridged agent delta event");
+        };
+        assert_eq!(agent_event.id, String::new());
+        let EventMsg::AgentMessageDelta(delta) = &agent_event.msg else {
+            panic!("expected bridged agent message delta");
+        };
+        assert_eq!(delta.delta, "Hello");
+
+        let (_, reasoning_events) = server_notification_thread_events(
+            ServerNotification::ReasoningSummaryTextDelta(ReasoningSummaryTextDeltaNotification {
+                thread_id,
+                turn_id: "turn".to_string(),
+                item_id: "item".to_string(),
+                delta: "Thinking".to_string(),
+                summary_index: 0,
+            }),
+        )
+        .expect("notification should bridge");
+        let [reasoning_event] = reasoning_events.as_slice() else {
+            panic!("expected one bridged reasoning delta event");
+        };
+        assert_eq!(reasoning_event.id, String::new());
+        let EventMsg::AgentReasoningDelta(delta) = &reasoning_event.msg else {
+            panic!("expected bridged reasoning delta");
+        };
+        assert_eq!(delta.delta, "Thinking");
+    }
+
+    #[test]
+    fn bridges_thread_snapshot_turns_for_resume_restore() {
+        let thread_id = ThreadId::new();
+        let events = thread_snapshot_events(
+            &Thread {
+                id: thread_id.to_string(),
+                preview: "hello".to_string(),
+                ephemeral: false,
+                model_provider: "openai".to_string(),
+                created_at: 0,
+                updated_at: 0,
+                status: ThreadStatus::Idle,
+                path: None,
+                cwd: PathBuf::from("/tmp/project"),
+                cli_version: "test".to_string(),
+                source: SessionSource::Cli.into(),
+                agent_nickname: None,
+                agent_role: None,
+                git_info: None,
+                name: Some("restore".to_string()),
+                turns: vec![
+                    Turn {
+                        id: "turn-complete".to_string(),
+                        items: vec![
+                            ThreadItem::UserMessage {
+                                id: "user-1".to_string(),
+                                content: vec![codex_app_server_protocol::UserInput::Text {
+                                    text: "hello".to_string(),
+                                    text_elements: Vec::new(),
+                                }],
+                            },
+                            ThreadItem::AgentMessage {
+                                id: "assistant-1".to_string(),
+                                text: "hi".to_string(),
+                                phase: Some(MessagePhase::FinalAnswer),
+                                memory_citation: None,
+                            },
+                        ],
+                        status: TurnStatus::Completed,
+                        error: None,
+                    },
+                    Turn {
+                        id: "turn-interrupted".to_string(),
+                        items: Vec::new(),
+                        status: TurnStatus::Interrupted,
+                        error: None,
+                    },
+                    Turn {
+                        id: "turn-failed".to_string(),
+                        items: Vec::new(),
+                        status: TurnStatus::Failed,
+                        error: Some(TurnError {
+                            message: "request failed".to_string(),
+                            codex_error_info: Some(CodexErrorInfo::Other),
+                            additional_details: None,
+                        }),
+                    },
+                ],
+            },
+            /*show_raw_agent_reasoning*/ false,
+        );
+
+        assert_eq!(events.len(), 9);
+        assert!(matches!(events[0].msg, EventMsg::TurnStarted(_)));
+        assert!(matches!(events[1].msg, EventMsg::ItemCompleted(_)));
+        assert!(matches!(events[2].msg, EventMsg::ItemCompleted(_)));
+        assert!(matches!(events[3].msg, EventMsg::TurnComplete(_)));
+        assert!(matches!(events[4].msg, EventMsg::TurnStarted(_)));
+        let EventMsg::TurnAborted(TurnAbortedEvent { turn_id, reason }) = &events[5].msg else {
+            panic!("expected interrupted turn replay");
+        };
+        assert_eq!(turn_id.as_deref(), Some("turn-interrupted"));
+        assert_eq!(*reason, TurnAbortReason::Interrupted);
+        assert!(matches!(events[6].msg, EventMsg::TurnStarted(_)));
+        let EventMsg::Error(error) = &events[7].msg else {
+            panic!("expected failed turn error replay");
+        };
+        assert_eq!(error.message, "request failed");
+        assert_eq!(
+            error.codex_error_info,
+            Some(codex_protocol::protocol::CodexErrorInfo::Other)
+        );
+        assert!(matches!(events[8].msg, EventMsg::TurnComplete(_)));
+    }
+
+    #[test]
+    fn bridges_non_message_snapshot_items_via_legacy_events() {
+        let events = turn_snapshot_events(
+            ThreadId::new(),
+            &Turn {
+                id: "turn-complete".to_string(),
+                items: vec![
+                    ThreadItem::Reasoning {
+                        id: "reasoning-1".to_string(),
+                        summary: vec!["Need to inspect config".to_string()],
+                        content: vec!["hidden chain".to_string()],
+                    },
+                    ThreadItem::WebSearch {
+                        id: "search-1".to_string(),
+                        query: "ratatui stylize".to_string(),
+                        action: Some(codex_app_server_protocol::WebSearchAction::Other),
+                    },
+                    ThreadItem::ImageGeneration {
+                        id: "image-1".to_string(),
+                        status: "completed".to_string(),
+                        revised_prompt: Some("diagram".to_string()),
+                        result: "image.png".to_string(),
+                    },
+                    ThreadItem::ContextCompaction {
+                        id: "compact-1".to_string(),
+                    },
+                ],
+                status: TurnStatus::Completed,
+                error: None,
+            },
+            /*show_raw_agent_reasoning*/ false,
+        );
+
+        assert_eq!(events.len(), 6);
+        assert!(matches!(events[0].msg, EventMsg::TurnStarted(_)));
+        let EventMsg::AgentReasoning(reasoning) = &events[1].msg else {
+            panic!("expected reasoning replay");
+        };
+        assert_eq!(reasoning.text, "Need to inspect config");
+        let EventMsg::WebSearchEnd(web_search) = &events[2].msg else {
+            panic!("expected web search replay");
+        };
+        assert_eq!(web_search.call_id, "search-1");
+        assert_eq!(web_search.query, "ratatui stylize");
+        assert_eq!(
+            web_search.action,
+            codex_protocol::models::WebSearchAction::Other
+        );
+        let EventMsg::ImageGenerationEnd(image_generation) = &events[3].msg else {
+            panic!("expected image generation replay");
+        };
+        assert_eq!(image_generation.call_id, "image-1");
+        assert_eq!(image_generation.status, "completed");
+        assert_eq!(image_generation.revised_prompt.as_deref(), Some("diagram"));
+        assert_eq!(image_generation.result, "image.png");
+        assert!(matches!(events[4].msg, EventMsg::ContextCompacted(_)));
+        assert!(matches!(events[5].msg, EventMsg::TurnComplete(_)));
+    }
+
+    #[test]
+    fn bridges_raw_reasoning_snapshot_items_when_enabled() {
+        let events = turn_snapshot_events(
+            ThreadId::new(),
+            &Turn {
+                id: "turn-complete".to_string(),
+                items: vec![ThreadItem::Reasoning {
+                    id: "reasoning-1".to_string(),
+                    summary: vec!["Need to inspect config".to_string()],
+                    content: vec!["hidden chain".to_string()],
+                }],
+                status: TurnStatus::Completed,
+                error: None,
+            },
+            /*show_raw_agent_reasoning*/ true,
+        );
+
+        assert_eq!(events.len(), 4);
+        assert!(matches!(events[0].msg, EventMsg::TurnStarted(_)));
+        let EventMsg::AgentReasoning(reasoning) = &events[1].msg else {
+            panic!("expected reasoning replay");
+        };
+        assert_eq!(reasoning.text, "Need to inspect config");
+        let EventMsg::AgentReasoningRawContent(raw_reasoning) = &events[2].msg else {
+            panic!("expected raw reasoning replay");
+        };
+        assert_eq!(raw_reasoning.text, "hidden chain");
+        assert!(matches!(events[3].msg, EventMsg::TurnComplete(_)));
     }
 }

--- a/codex-rs/tui_app_server/src/app/app_server_requests.rs
+++ b/codex-rs/tui_app_server/src/app/app_server_requests.rs
@@ -309,6 +309,10 @@ impl PendingAppServerRequests {
         self.mcp_requests.retain(|_, value| value != request_id);
         ResolvedAppServerRequest { exec_approval_ids }
     }
+
+    pub(super) fn has_pending_exec_approval(&self, approval_id: &str) -> bool {
+        self.exec_approvals.contains_key(approval_id)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/codex-rs/tui_app_server/src/app/app_server_requests.rs
+++ b/codex-rs/tui_app_server/src/app/app_server_requests.rs
@@ -2,7 +2,9 @@ use std::collections::HashMap;
 
 use crate::app_command::AppCommand;
 use crate::app_command::AppCommandView;
+use codex_app_server_protocol::CommandExecutionApprovalDecision;
 use codex_app_server_protocol::CommandExecutionRequestApprovalResponse;
+use codex_app_server_protocol::ExecCommandApprovalResponse;
 use codex_app_server_protocol::FileChangeApprovalDecision;
 use codex_app_server_protocol::FileChangeRequestApprovalResponse;
 use codex_app_server_protocol::GrantedPermissionProfile;
@@ -29,11 +31,23 @@ pub(super) struct UnsupportedAppServerRequest {
 
 #[derive(Debug, Default)]
 pub(super) struct PendingAppServerRequests {
-    exec_approvals: HashMap<String, AppServerRequestId>,
+    exec_approvals: HashMap<String, PendingExecApproval>,
     file_change_approvals: HashMap<String, AppServerRequestId>,
     permissions_approvals: HashMap<String, AppServerRequestId>,
     user_inputs: HashMap<String, AppServerRequestId>,
     mcp_requests: HashMap<McpLegacyRequestKey, AppServerRequestId>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ExecApprovalResponseKind {
+    LegacyV1,
+    V2,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PendingExecApproval {
+    request_id: AppServerRequestId,
+    response_kind: ExecApprovalResponseKind,
 }
 
 impl PendingAppServerRequests {
@@ -55,7 +69,13 @@ impl PendingAppServerRequests {
                     .approval_id
                     .clone()
                     .unwrap_or_else(|| params.item_id.clone());
-                self.exec_approvals.insert(approval_id, request_id.clone());
+                self.exec_approvals.insert(
+                    approval_id,
+                    PendingExecApproval {
+                        request_id: request_id.clone(),
+                        response_kind: ExecApprovalResponseKind::V2,
+                    },
+                );
                 None
             }
             ServerRequest::FileChangeRequestApproval { request_id, params } => {
@@ -99,13 +119,19 @@ impl PendingAppServerRequests {
                             .to_string(),
                 })
             }
-            ServerRequest::ExecCommandApproval { request_id, .. } => {
-                Some(UnsupportedAppServerRequest {
-                    request_id: request_id.clone(),
-                    message:
-                        "Legacy command approval requests are not available in app-server TUI yet."
-                            .to_string(),
-                })
+            ServerRequest::ExecCommandApproval { request_id, params } => {
+                let approval_id = params
+                    .approval_id
+                    .clone()
+                    .unwrap_or_else(|| params.call_id.clone());
+                self.exec_approvals.insert(
+                    approval_id,
+                    PendingExecApproval {
+                        request_id: request_id.clone(),
+                        response_kind: ExecApprovalResponseKind::LegacyV1,
+                    },
+                );
+                None
             }
         }
     }
@@ -122,15 +148,33 @@ impl PendingAppServerRequests {
             AppCommandView::ExecApproval { id, decision, .. } => self
                 .exec_approvals
                 .remove(id)
-                .map(|request_id| {
+                .map(|pending| {
                     Ok::<AppServerRequestResolution, String>(AppServerRequestResolution {
-                        request_id,
-                        result: serde_json::to_value(CommandExecutionRequestApprovalResponse {
-                            decision: decision.clone().into(),
-                        })
-                        .map_err(|err| {
-                            format!("failed to serialize command execution approval response: {err}")
-                        })?,
+                        request_id: pending.request_id,
+                        result: match pending.response_kind {
+                            ExecApprovalResponseKind::LegacyV1 => {
+                                serde_json::to_value(ExecCommandApprovalResponse {
+                                    decision: decision.clone(),
+                                })
+                                .map_err(|err| {
+                                    format!(
+                                        "failed to serialize legacy command approval response: {err}"
+                                    )
+                                })?
+                            }
+                            ExecApprovalResponseKind::V2 => {
+                                serde_json::to_value(CommandExecutionRequestApprovalResponse {
+                                    decision: CommandExecutionApprovalDecision::from(
+                                        decision.clone(),
+                                    ),
+                                })
+                                .map_err(|err| {
+                                    format!(
+                                        "failed to serialize command execution approval response: {err}"
+                                    )
+                                })?
+                            }
+                        },
                     })
                 })
                 .transpose()?,
@@ -238,7 +282,8 @@ impl PendingAppServerRequests {
     }
 
     pub(super) fn resolve_notification(&mut self, request_id: &AppServerRequestId) {
-        self.exec_approvals.retain(|_, value| value != request_id);
+        self.exec_approvals
+            .retain(|_, value| &value.request_id != request_id);
         self.file_change_approvals
             .retain(|_, value| value != request_id);
         self.permissions_approvals
@@ -280,6 +325,7 @@ fn file_change_decision(decision: &ReviewDecision) -> Result<FileChangeApprovalD
 mod tests {
     use super::PendingAppServerRequests;
     use codex_app_server_protocol::CommandExecutionRequestApprovalParams;
+    use codex_app_server_protocol::ExecCommandApprovalParams;
     use codex_app_server_protocol::FileChangeRequestApprovalParams;
     use codex_app_server_protocol::McpElicitationObjectType;
     use codex_app_server_protocol::McpElicitationSchema;
@@ -338,6 +384,37 @@ mod tests {
 
         assert_eq!(resolution.request_id, AppServerRequestId::Integer(41));
         assert_eq!(resolution.result, json!({ "decision": "accept" }));
+    }
+
+    #[test]
+    fn resolves_legacy_exec_approval_through_app_server_request_id() {
+        let mut pending = PendingAppServerRequests::default();
+        let request = ServerRequest::ExecCommandApproval {
+            request_id: AppServerRequestId::Integer(42),
+            params: ExecCommandApprovalParams {
+                conversation_id: codex_protocol::ThreadId::new(),
+                call_id: "call-2".to_string(),
+                approval_id: Some("approval-2".to_string()),
+                command: vec!["pwd".to_string()],
+                cwd: "/tmp/project".into(),
+                reason: Some("Need shell access".to_string()),
+                parsed_cmd: Vec::new(),
+            },
+        };
+
+        assert_eq!(pending.note_server_request(&request), None);
+
+        let resolution = pending
+            .take_resolution(&Op::ExecApproval {
+                id: "approval-2".to_string(),
+                turn_id: None,
+                decision: ReviewDecision::Approved,
+            })
+            .expect("resolution should serialize")
+            .expect("request should be pending");
+
+        assert_eq!(resolution.request_id, AppServerRequestId::Integer(42));
+        assert_eq!(resolution.result, json!({ "decision": "approved" }));
     }
 
     #[test]

--- a/codex-rs/tui_app_server/src/app/app_server_requests.rs
+++ b/codex-rs/tui_app_server/src/app/app_server_requests.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use crate::app_command::AppCommand;
 use crate::app_command::AppCommandView;
+use codex_app_server_protocol::ApplyPatchApprovalResponse;
 use codex_app_server_protocol::CommandExecutionApprovalDecision;
 use codex_app_server_protocol::CommandExecutionRequestApprovalResponse;
 use codex_app_server_protocol::ExecCommandApprovalResponse;
@@ -37,7 +38,7 @@ pub(super) struct ResolvedAppServerRequest {
 #[derive(Debug, Default)]
 pub(super) struct PendingAppServerRequests {
     exec_approvals: HashMap<String, PendingExecApproval>,
-    file_change_approvals: HashMap<String, AppServerRequestId>,
+    file_change_approvals: HashMap<String, PendingFileChangeApproval>,
     permissions_approvals: HashMap<String, AppServerRequestId>,
     user_inputs: HashMap<String, AppServerRequestId>,
     mcp_requests: HashMap<McpLegacyRequestKey, AppServerRequestId>,
@@ -50,10 +51,23 @@ enum ExecApprovalResponseKind {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+enum FileChangeApprovalResponseKind {
+    LegacyV1,
+    V2,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct PendingExecApproval {
     approval_id: String,
     request_id: AppServerRequestId,
     response_kind: ExecApprovalResponseKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PendingFileChangeApproval {
+    item_id: String,
+    request_id: AppServerRequestId,
+    response_kind: FileChangeApprovalResponseKind,
 }
 
 impl PendingAppServerRequests {
@@ -86,8 +100,14 @@ impl PendingAppServerRequests {
                 None
             }
             ServerRequest::FileChangeRequestApproval { request_id, params } => {
-                self.file_change_approvals
-                    .insert(params.item_id.clone(), request_id.clone());
+                self.file_change_approvals.insert(
+                    params.item_id.clone(),
+                    PendingFileChangeApproval {
+                        item_id: params.item_id.clone(),
+                        request_id: request_id.clone(),
+                        response_kind: FileChangeApprovalResponseKind::V2,
+                    },
+                );
                 None
             }
             ServerRequest::PermissionsRequestApproval { request_id, params } => {
@@ -118,13 +138,16 @@ impl PendingAppServerRequests {
                 })
             }
             ServerRequest::ChatgptAuthTokensRefresh { .. } => None,
-            ServerRequest::ApplyPatchApproval { request_id, .. } => {
-                Some(UnsupportedAppServerRequest {
-                    request_id: request_id.clone(),
-                    message:
-                        "Legacy patch approval requests are not available in app-server TUI yet."
-                            .to_string(),
-                })
+            ServerRequest::ApplyPatchApproval { request_id, params } => {
+                self.file_change_approvals.insert(
+                    params.call_id.clone(),
+                    PendingFileChangeApproval {
+                        item_id: params.call_id.clone(),
+                        request_id: request_id.clone(),
+                        response_kind: FileChangeApprovalResponseKind::LegacyV1,
+                    },
+                );
+                None
             }
             ServerRequest::ExecCommandApproval { request_id, params } => {
                 let approval_id = params
@@ -189,15 +212,31 @@ impl PendingAppServerRequests {
             AppCommandView::PatchApproval { id, decision } => self
                 .file_change_approvals
                 .get(id)
-                .map(|request_id| {
+                .map(|pending| {
                     Ok::<AppServerRequestResolution, String>(AppServerRequestResolution {
-                        request_id: request_id.clone(),
-                        result: serde_json::to_value(FileChangeRequestApprovalResponse {
-                            decision: file_change_decision(decision)?,
-                        })
-                        .map_err(|err| {
-                            format!("failed to serialize file change approval response: {err}")
-                        })?,
+                        request_id: pending.request_id.clone(),
+                        result: match pending.response_kind {
+                            FileChangeApprovalResponseKind::LegacyV1 => {
+                                serde_json::to_value(ApplyPatchApprovalResponse {
+                                    decision: decision.clone(),
+                                })
+                                .map_err(|err| {
+                                    format!(
+                                        "failed to serialize legacy patch approval response: {err}"
+                                    )
+                                })?
+                            }
+                            FileChangeApprovalResponseKind::V2 => {
+                                serde_json::to_value(FileChangeRequestApprovalResponse {
+                                    decision: file_change_decision(decision)?,
+                                })
+                                .map_err(|err| {
+                                    format!(
+                                        "failed to serialize file change approval response: {err}"
+                                    )
+                                })?
+                            }
+                        },
                     })
                 })
                 .transpose()?,
@@ -334,7 +373,7 @@ impl PendingAppServerRequests {
         self.exec_approvals
             .retain(|_, value| &value.request_id != request_id);
         self.file_change_approvals
-            .retain(|_, value| value != request_id);
+            .retain(|_, value| &value.request_id != request_id);
         self.permissions_approvals
             .retain(|_, value| value != request_id);
         self.user_inputs.retain(|_, value| value != request_id);
@@ -379,6 +418,7 @@ fn file_change_decision(decision: &ReviewDecision) -> Result<FileChangeApprovalD
 mod tests {
     use super::AppServerRequestResolution;
     use super::PendingAppServerRequests;
+    use codex_app_server_protocol::ApplyPatchApprovalParams;
     use codex_app_server_protocol::CommandExecutionRequestApprovalParams;
     use codex_app_server_protocol::ExecCommandApprovalParams;
     use codex_app_server_protocol::FileChangeRequestApprovalParams;
@@ -402,6 +442,7 @@ mod tests {
     use pretty_assertions::assert_eq;
     use serde_json::json;
     use std::collections::BTreeMap;
+    use std::collections::HashMap;
 
     #[test]
     fn resolves_exec_approval_through_app_server_request_id() {
@@ -469,6 +510,34 @@ mod tests {
             .expect("request should be pending");
 
         assert_eq!(resolution.request_id, AppServerRequestId::Integer(42));
+        assert_eq!(resolution.result, json!({ "decision": "approved" }));
+    }
+
+    #[test]
+    fn resolves_legacy_patch_approval_through_app_server_request_id() {
+        let mut pending = PendingAppServerRequests::default();
+        let request = ServerRequest::ApplyPatchApproval {
+            request_id: AppServerRequestId::Integer(43),
+            params: ApplyPatchApprovalParams {
+                conversation_id: codex_protocol::ThreadId::new(),
+                call_id: "patch-1".to_string(),
+                file_changes: HashMap::new(),
+                reason: Some("Need write access".to_string()),
+                grant_root: None,
+            },
+        };
+
+        assert_eq!(pending.note_server_request(&request), None);
+
+        let resolution = pending
+            .prepare_resolution(&Op::PatchApproval {
+                id: "patch-1".to_string(),
+                decision: ReviewDecision::Approved,
+            })
+            .expect("resolution should serialize")
+            .expect("request should be pending");
+
+        assert_eq!(resolution.request_id, AppServerRequestId::Integer(43));
         assert_eq!(resolution.result, json!({ "decision": "approved" }));
     }
 

--- a/codex-rs/tui_app_server/src/app/app_server_requests.rs
+++ b/codex-rs/tui_app_server/src/app/app_server_requests.rs
@@ -144,8 +144,8 @@ impl PendingAppServerRequests {
         }
     }
 
-    pub(super) fn take_resolution<T>(
-        &mut self,
+    pub(super) fn prepare_resolution<T>(
+        &self,
         op: T,
     ) -> Result<Option<AppServerRequestResolution>, String>
     where
@@ -155,10 +155,10 @@ impl PendingAppServerRequests {
         let resolution = match op.view() {
             AppCommandView::ExecApproval { id, decision, .. } => self
                 .exec_approvals
-                .remove(id)
+                .get(id)
                 .map(|pending| {
                     Ok::<AppServerRequestResolution, String>(AppServerRequestResolution {
-                        request_id: pending.request_id,
+                        request_id: pending.request_id.clone(),
                         result: match pending.response_kind {
                             ExecApprovalResponseKind::LegacyV1 => {
                                 serde_json::to_value(ExecCommandApprovalResponse {
@@ -188,10 +188,10 @@ impl PendingAppServerRequests {
                 .transpose()?,
             AppCommandView::PatchApproval { id, decision } => self
                 .file_change_approvals
-                .remove(id)
+                .get(id)
                 .map(|request_id| {
                     Ok::<AppServerRequestResolution, String>(AppServerRequestResolution {
-                        request_id,
+                        request_id: request_id.clone(),
                         result: serde_json::to_value(FileChangeRequestApprovalResponse {
                             decision: file_change_decision(decision)?,
                         })
@@ -203,10 +203,10 @@ impl PendingAppServerRequests {
                 .transpose()?,
             AppCommandView::RequestPermissionsResponse { id, response } => self
                 .permissions_approvals
-                .remove(id)
+                .get(id)
                 .map(|request_id| {
                     Ok::<AppServerRequestResolution, String>(AppServerRequestResolution {
-                        request_id,
+                        request_id: request_id.clone(),
                         result: serde_json::to_value(PermissionsRequestApprovalResponse {
                             permissions: serde_json::from_value::<GrantedPermissionProfile>(
                                 serde_json::to_value(&response.permissions).map_err(|err| {
@@ -226,10 +226,10 @@ impl PendingAppServerRequests {
                 .transpose()?,
             AppCommandView::UserInputAnswer { id, response } => self
                 .user_inputs
-                .remove(id)
+                .get(id)
                 .map(|request_id| {
                     Ok::<AppServerRequestResolution, String>(AppServerRequestResolution {
-                        request_id,
+                        request_id: request_id.clone(),
                         result: serde_json::to_value(
                             serde_json::from_value::<ToolRequestUserInputResponse>(
                                 serde_json::to_value(response).map_err(|err| {
@@ -256,13 +256,13 @@ impl PendingAppServerRequests {
                 meta,
             } => self
                 .mcp_requests
-                .remove(&McpLegacyRequestKey {
+                .get(&McpLegacyRequestKey {
                     server_name: server_name.to_string(),
                     request_id: request_id.clone(),
                 })
                 .map(|request_id| {
                     Ok::<AppServerRequestResolution, String>(AppServerRequestResolution {
-                        request_id,
+                        request_id: request_id.clone(),
                         result: serde_json::to_value(McpServerElicitationRequestResponse {
                             action: match decision {
                                 codex_protocol::approvals::ElicitationAction::Accept => {
@@ -287,6 +287,38 @@ impl PendingAppServerRequests {
             _ => None,
         };
         Ok(resolution)
+    }
+
+    pub(super) fn commit_resolution<T>(&mut self, op: T)
+    where
+        T: Into<AppCommand>,
+    {
+        let op: AppCommand = op.into();
+        match op.view() {
+            AppCommandView::ExecApproval { id, .. } => {
+                self.exec_approvals.remove(id);
+            }
+            AppCommandView::PatchApproval { id, .. } => {
+                self.file_change_approvals.remove(id);
+            }
+            AppCommandView::RequestPermissionsResponse { id, .. } => {
+                self.permissions_approvals.remove(id);
+            }
+            AppCommandView::UserInputAnswer { id, .. } => {
+                self.user_inputs.remove(id);
+            }
+            AppCommandView::ResolveElicitation {
+                server_name,
+                request_id,
+                ..
+            } => {
+                self.mcp_requests.remove(&McpLegacyRequestKey {
+                    server_name: server_name.to_string(),
+                    request_id: request_id.clone(),
+                });
+            }
+            _ => {}
+        }
     }
 
     pub(super) fn resolve_notification(
@@ -345,6 +377,7 @@ fn file_change_decision(decision: &ReviewDecision) -> Result<FileChangeApprovalD
 
 #[cfg(test)]
 mod tests {
+    use super::AppServerRequestResolution;
     use super::PendingAppServerRequests;
     use codex_app_server_protocol::CommandExecutionRequestApprovalParams;
     use codex_app_server_protocol::ExecCommandApprovalParams;
@@ -396,7 +429,7 @@ mod tests {
         assert_eq!(pending.note_server_request(&request), None);
 
         let resolution = pending
-            .take_resolution(&Op::ExecApproval {
+            .prepare_resolution(&Op::ExecApproval {
                 id: "approval-1".to_string(),
                 turn_id: None,
                 decision: ReviewDecision::Approved,
@@ -427,7 +460,7 @@ mod tests {
         assert_eq!(pending.note_server_request(&request), None);
 
         let resolution = pending
-            .take_resolution(&Op::ExecApproval {
+            .prepare_resolution(&Op::ExecApproval {
                 id: "approval-2".to_string(),
                 turn_id: None,
                 decision: ReviewDecision::Approved,
@@ -473,7 +506,7 @@ mod tests {
         );
 
         let permissions = pending
-            .take_resolution(&Op::RequestPermissionsResponse {
+            .prepare_resolution(&Op::RequestPermissionsResponse {
                 id: "perm-1".to_string(),
                 response: codex_protocol::request_permissions::RequestPermissionsResponse {
                     permissions: serde_json::from_value(json!({
@@ -499,7 +532,7 @@ mod tests {
         );
 
         let user_input = pending
-            .take_resolution(&Op::UserInputAnswer {
+            .prepare_resolution(&Op::UserInputAnswer {
                 id: "turn-2".to_string(),
                 response: codex_protocol::request_user_input::RequestUserInputResponse {
                     answers: std::iter::once((
@@ -556,7 +589,7 @@ mod tests {
         );
 
         let resolution = pending
-            .take_resolution(&Op::ResolveElicitation {
+            .prepare_resolution(&Op::ResolveElicitation {
                 server_name: "example".to_string(),
                 request_id: McpRequestId::Integer(12),
                 decision: ElicitationAction::Accept,
@@ -634,7 +667,7 @@ mod tests {
         );
 
         let error = pending
-            .take_resolution(&Op::PatchApproval {
+            .prepare_resolution(&Op::PatchApproval {
                 id: "patch-1".to_string(),
                 decision: ReviewDecision::ApprovedExecpolicyAmendment {
                     proposed_execpolicy_amendment: ExecPolicyAmendment::new(vec![
@@ -648,6 +681,65 @@ mod tests {
         assert_eq!(
             error,
             "execpolicy amendment is not a valid file change approval decision"
+        );
+    }
+
+    #[test]
+    fn exec_approval_stays_pending_until_resolution_is_committed() {
+        let mut pending = PendingAppServerRequests::default();
+        let request = ServerRequest::CommandExecutionRequestApproval {
+            request_id: AppServerRequestId::Integer(41),
+            params: CommandExecutionRequestApprovalParams {
+                thread_id: "thread-1".to_string(),
+                turn_id: "turn-1".to_string(),
+                item_id: "call-1".to_string(),
+                approval_id: Some("approval-1".to_string()),
+                reason: None,
+                network_approval_context: None,
+                command: Some("ls".to_string()),
+                cwd: None,
+                command_actions: None,
+                additional_permissions: None,
+                skill_metadata: None,
+                proposed_execpolicy_amendment: None,
+                proposed_network_policy_amendments: None,
+                available_decisions: None,
+            },
+        };
+        let op = Op::ExecApproval {
+            id: "approval-1".to_string(),
+            turn_id: None,
+            decision: ReviewDecision::Approved,
+        };
+
+        assert_eq!(pending.note_server_request(&request), None);
+
+        assert_eq!(
+            pending
+                .prepare_resolution(&op)
+                .expect("resolution should serialize"),
+            Some(AppServerRequestResolution {
+                request_id: AppServerRequestId::Integer(41),
+                result: json!({ "decision": "accept" }),
+            })
+        );
+        assert_eq!(
+            pending
+                .prepare_resolution(&op)
+                .expect("pending resolution should remain available"),
+            Some(AppServerRequestResolution {
+                request_id: AppServerRequestId::Integer(41),
+                result: json!({ "decision": "accept" }),
+            })
+        );
+
+        pending.commit_resolution(&op);
+
+        assert_eq!(
+            pending
+                .prepare_resolution(&op)
+                .expect("resolved approval should no longer be pending"),
+            None
         );
     }
 }

--- a/codex-rs/tui_app_server/src/app/app_server_requests.rs
+++ b/codex-rs/tui_app_server/src/app/app_server_requests.rs
@@ -29,6 +29,11 @@ pub(super) struct UnsupportedAppServerRequest {
     pub(super) message: String,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(super) struct ResolvedAppServerRequest {
+    pub(super) exec_approval_ids: Vec<String>,
+}
+
 #[derive(Debug, Default)]
 pub(super) struct PendingAppServerRequests {
     exec_approvals: HashMap<String, PendingExecApproval>,
@@ -46,6 +51,7 @@ enum ExecApprovalResponseKind {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct PendingExecApproval {
+    approval_id: String,
     request_id: AppServerRequestId,
     response_kind: ExecApprovalResponseKind,
 }
@@ -70,8 +76,9 @@ impl PendingAppServerRequests {
                     .clone()
                     .unwrap_or_else(|| params.item_id.clone());
                 self.exec_approvals.insert(
-                    approval_id,
+                    approval_id.clone(),
                     PendingExecApproval {
+                        approval_id,
                         request_id: request_id.clone(),
                         response_kind: ExecApprovalResponseKind::V2,
                     },
@@ -125,8 +132,9 @@ impl PendingAppServerRequests {
                     .clone()
                     .unwrap_or_else(|| params.call_id.clone());
                 self.exec_approvals.insert(
-                    approval_id,
+                    approval_id.clone(),
                     PendingExecApproval {
+                        approval_id,
                         request_id: request_id.clone(),
                         response_kind: ExecApprovalResponseKind::LegacyV1,
                     },
@@ -281,7 +289,16 @@ impl PendingAppServerRequests {
         Ok(resolution)
     }
 
-    pub(super) fn resolve_notification(&mut self, request_id: &AppServerRequestId) {
+    pub(super) fn resolve_notification(
+        &mut self,
+        request_id: &AppServerRequestId,
+    ) -> ResolvedAppServerRequest {
+        let exec_approval_ids = self
+            .exec_approvals
+            .values()
+            .filter(|pending| &pending.request_id == request_id)
+            .map(|pending| pending.approval_id.clone())
+            .collect();
         self.exec_approvals
             .retain(|_, value| &value.request_id != request_id);
         self.file_change_approvals
@@ -290,6 +307,7 @@ impl PendingAppServerRequests {
             .retain(|_, value| value != request_id);
         self.user_inputs.retain(|_, value| value != request_id);
         self.mcp_requests.retain(|_, value| value != request_id);
+        ResolvedAppServerRequest { exec_approval_ids }
     }
 }
 

--- a/codex-rs/tui_app_server/src/app/app_server_requests.rs
+++ b/codex-rs/tui_app_server/src/app/app_server_requests.rs
@@ -167,6 +167,13 @@ impl PendingAppServerRequests {
         }
     }
 
+    /// Builds the JSON-RPC result for an outbound approval/input response
+    /// without consuming the pending entry yet.
+    ///
+    /// Resolution is a two-step prepare/commit flow so transient
+    /// `resolve_server_request(...)` failures do not make replayable approval
+    /// prompts disappear. The stored response kind also preserves whether the
+    /// server expects the legacy v1 payload or the current v2 payload.
     pub(super) fn prepare_resolution<T>(
         &self,
         op: T,

--- a/codex-rs/tui_app_server/src/app/pending_interactive_replay.rs
+++ b/codex-rs/tui_app_server/src/app/pending_interactive_replay.rs
@@ -252,6 +252,19 @@ impl PendingInteractiveReplayState {
         }
     }
 
+    pub(super) fn note_exec_approval_resolved(&mut self, approval_id: &str) {
+        self.exec_approval_call_ids.remove(approval_id);
+        Self::remove_call_id_from_turn_map(
+            &mut self.exec_approval_call_ids_by_turn_id,
+            approval_id,
+        );
+        self.pending_requests_by_request_id.retain(
+            |_, pending| {
+                !matches!(pending, PendingInteractiveRequest::ExecApproval { approval_id: pending_id, .. } if pending_id == approval_id)
+            },
+        );
+    }
+
     pub(super) fn note_server_notification(&mut self, notification: &ServerNotification) {
         match notification {
             ServerNotification::ItemStarted(notification) => match &notification.item {

--- a/codex-rs/tui_app_server/src/bottom_pane/approval_overlay.rs
+++ b/codex-rs/tui_app_server/src/bottom_pane/approval_overlay.rs
@@ -99,6 +99,10 @@ impl ApprovalRequest {
             | ApprovalRequest::McpElicitation { thread_label, .. } => thread_label.as_deref(),
         }
     }
+
+    fn is_resolved_exec_approval(&self, approval_ids: &[String]) -> bool {
+        matches!(self, ApprovalRequest::Exec { id, .. } if approval_ids.contains(id))
+    }
 }
 
 /// Modal overlay asking the user to approve or deny one or more requests.
@@ -131,6 +135,28 @@ impl ApprovalOverlay {
 
     pub fn enqueue_request(&mut self, req: ApprovalRequest) {
         self.queue.push(req);
+    }
+
+    fn remove_resolved_exec_approvals(&mut self, approval_ids: &[String]) -> bool {
+        let mut changed = false;
+
+        self.queue.retain(|request| {
+            let keep = !request.is_resolved_exec_approval(approval_ids);
+            changed |= !keep;
+            keep
+        });
+
+        if self
+            .current_request
+            .as_ref()
+            .is_some_and(|request| request.is_resolved_exec_approval(approval_ids))
+        {
+            changed = true;
+            self.current_request = None;
+            self.advance_queue();
+        }
+
+        changed
     }
 
     fn set_current(&mut self, request: ApprovalRequest) {
@@ -464,6 +490,10 @@ impl BottomPaneView for ApprovalOverlay {
     ) -> Option<ApprovalRequest> {
         self.enqueue_request(request);
         None
+    }
+
+    fn remove_resolved_exec_approvals(&mut self, approval_ids: &[String]) -> bool {
+        self.remove_resolved_exec_approvals(approval_ids)
     }
 }
 

--- a/codex-rs/tui_app_server/src/bottom_pane/approval_overlay.rs
+++ b/codex-rs/tui_app_server/src/bottom_pane/approval_overlay.rs
@@ -137,7 +137,7 @@ impl ApprovalOverlay {
         self.queue.push(req);
     }
 
-    fn remove_resolved_exec_approvals(&mut self, approval_ids: &[String]) -> bool {
+    fn remove_resolved_exec_approvals_inner(&mut self, approval_ids: &[String]) -> bool {
         let mut changed = false;
 
         self.queue.retain(|request| {
@@ -493,7 +493,7 @@ impl BottomPaneView for ApprovalOverlay {
     }
 
     fn remove_resolved_exec_approvals(&mut self, approval_ids: &[String]) -> bool {
-        self.remove_resolved_exec_approvals(approval_ids)
+        self.remove_resolved_exec_approvals_inner(approval_ids)
     }
 }
 

--- a/codex-rs/tui_app_server/src/bottom_pane/bottom_pane_view.rs
+++ b/codex-rs/tui_app_server/src/bottom_pane/bottom_pane_view.rs
@@ -70,6 +70,12 @@ pub(crate) trait BottomPaneView: Renderable {
         Some(request)
     }
 
+    /// Remove any live exec approval prompts that have already been resolved
+    /// by the server. Returns true when the view changed.
+    fn remove_resolved_exec_approvals(&mut self, _approval_ids: &[String]) -> bool {
+        false
+    }
+
     /// Try to handle request_user_input; return the original value if not
     /// consumed.
     fn try_consume_user_input_request(

--- a/codex-rs/tui_app_server/src/bottom_pane/mod.rs
+++ b/codex-rs/tui_app_server/src/bottom_pane/mod.rs
@@ -924,6 +924,9 @@ impl BottomPane {
             !view.is_complete()
         });
         if changed {
+            // Resolved approvals can be hiding in a non-top overlay. We prune
+            // the full stack, then only resume the paused status/composer state
+            // if that removal actually dismisses the active modal layer.
             let active_view_removed = active_view_ptr.is_some_and(|active_view_ptr| {
                 !self.view_stack.iter().any(|view| {
                     std::ptr::eq(

--- a/codex-rs/tui_app_server/src/bottom_pane/mod.rs
+++ b/codex-rs/tui_app_server/src/bottom_pane/mod.rs
@@ -914,12 +914,27 @@ impl BottomPane {
     }
 
     pub(crate) fn remove_resolved_exec_approvals(&mut self, approval_ids: &[String]) {
+        let active_view_ptr = self
+            .view_stack
+            .last()
+            .map(|view| (&**view) as *const dyn BottomPaneView as *const ());
         let mut changed = false;
         self.view_stack.retain_mut(|view| {
             changed |= view.remove_resolved_exec_approvals(approval_ids);
             !view.is_complete()
         });
         if changed {
+            let active_view_removed = active_view_ptr.is_some_and(|active_view_ptr| {
+                !self.view_stack.iter().any(|view| {
+                    std::ptr::eq(
+                        (&**view) as *const dyn BottomPaneView as *const (),
+                        active_view_ptr,
+                    )
+                })
+            });
+            if active_view_removed && self.view_stack.is_empty() {
+                self.on_active_view_complete();
+            }
             self.request_redraw();
         }
     }
@@ -1510,6 +1525,40 @@ mod tests {
         assert!(
             pane.view_stack.is_empty(),
             "the hidden approval overlay should no longer resurface after the top modal closes"
+        );
+    }
+
+    #[test]
+    fn removing_active_resolved_exec_approval_resumes_status_timer() {
+        let (tx_raw, _rx) = unbounded_channel::<AppEvent>();
+        let tx = AppEventSender::new(tx_raw);
+        let features = Features::with_defaults();
+        let mut pane = BottomPane::new(BottomPaneParams {
+            app_event_tx: tx,
+            frame_requester: FrameRequester::test_dummy(),
+            has_input_focus: true,
+            enhanced_keys_supported: false,
+            placeholder_text: "Ask Codex to do anything".to_string(),
+            disable_paste_burst: false,
+            animations_enabled: true,
+            skills: Some(Vec::new()),
+        });
+
+        pane.set_task_running(true);
+        pane.push_approval_request(exec_request(), &features);
+        assert!(
+            pane.status
+                .as_ref()
+                .is_some_and(StatusIndicatorWidget::is_paused),
+            "approval modal should pause the running-task timer"
+        );
+
+        pane.remove_resolved_exec_approvals(&["1".to_string()]);
+        assert!(
+            pane.status
+                .as_ref()
+                .is_some_and(|status| !status.is_paused()),
+            "removing the active resolved approval should resume the running-task timer"
         );
     }
 

--- a/codex-rs/tui_app_server/src/bottom_pane/mod.rs
+++ b/codex-rs/tui_app_server/src/bottom_pane/mod.rs
@@ -913,6 +913,17 @@ impl BottomPane {
         self.push_view(Box::new(modal));
     }
 
+    pub(crate) fn remove_resolved_exec_approvals(&mut self, approval_ids: &[String]) {
+        if let Some(view) = self.view_stack.last_mut()
+            && view.remove_resolved_exec_approvals(approval_ids)
+        {
+            if view.is_complete() {
+                self.view_stack.pop();
+            }
+            self.request_redraw();
+        }
+    }
+
     /// Called when the agent requests user input.
     pub fn push_user_input_request(&mut self, request: RequestUserInputEvent) {
         let request = if let Some(view) = self.view_stack.last_mut() {
@@ -1406,6 +1417,53 @@ mod tests {
         assert!(
             found_composer,
             "expected composer visible under status line"
+        );
+    }
+
+    #[test]
+    fn resolved_exec_approval_is_removed_from_live_modal_and_queue() {
+        let (tx_raw, _rx) = unbounded_channel::<AppEvent>();
+        let tx = AppEventSender::new(tx_raw);
+        let features = Features::with_defaults();
+        let mut pane = BottomPane::new(BottomPaneParams {
+            app_event_tx: tx,
+            frame_requester: FrameRequester::test_dummy(),
+            has_input_focus: true,
+            enhanced_keys_supported: false,
+            placeholder_text: "Ask Codex to do anything".to_string(),
+            disable_paste_burst: false,
+            animations_enabled: true,
+            skills: Some(Vec::new()),
+        });
+
+        pane.push_approval_request(exec_request(), &features);
+        pane.push_approval_request(
+            ApprovalRequest::Exec {
+                thread_id: codex_protocol::ThreadId::new(),
+                thread_label: None,
+                id: "2".to_string(),
+                command: vec!["echo".into(), "ok".into()],
+                reason: None,
+                available_decisions: vec![
+                    codex_protocol::protocol::ReviewDecision::Approved,
+                    codex_protocol::protocol::ReviewDecision::Abort,
+                ],
+                network_approval_context: None,
+                additional_permissions: None,
+            },
+            &features,
+        );
+
+        pane.remove_resolved_exec_approvals(&["1".to_string()]);
+        assert!(
+            !pane.view_stack.is_empty(),
+            "next queued approval should become active"
+        );
+
+        pane.remove_resolved_exec_approvals(&["2".to_string()]);
+        assert!(
+            pane.view_stack.is_empty(),
+            "resolved exec approvals should be removed from the live modal queue"
         );
     }
 

--- a/codex-rs/tui_app_server/src/bottom_pane/mod.rs
+++ b/codex-rs/tui_app_server/src/bottom_pane/mod.rs
@@ -914,12 +914,12 @@ impl BottomPane {
     }
 
     pub(crate) fn remove_resolved_exec_approvals(&mut self, approval_ids: &[String]) {
-        if let Some(view) = self.view_stack.last_mut()
-            && view.remove_resolved_exec_approvals(approval_ids)
-        {
-            if view.is_complete() {
-                self.view_stack.pop();
-            }
+        let mut changed = false;
+        self.view_stack.retain_mut(|view| {
+            changed |= view.remove_resolved_exec_approvals(approval_ids);
+            !view.is_complete()
+        });
+        if changed {
             self.request_redraw();
         }
     }
@@ -1464,6 +1464,52 @@ mod tests {
         assert!(
             pane.view_stack.is_empty(),
             "resolved exec approvals should be removed from the live modal queue"
+        );
+    }
+
+    #[test]
+    fn resolved_exec_approval_is_removed_from_hidden_overlay_queue() {
+        let (tx_raw, _rx) = unbounded_channel::<AppEvent>();
+        let tx = AppEventSender::new(tx_raw);
+        let features = Features::with_defaults();
+        let mut pane = BottomPane::new(BottomPaneParams {
+            app_event_tx: tx,
+            frame_requester: FrameRequester::test_dummy(),
+            has_input_focus: true,
+            enhanced_keys_supported: false,
+            placeholder_text: "Ask Codex to do anything".to_string(),
+            disable_paste_burst: false,
+            animations_enabled: true,
+            skills: Some(Vec::new()),
+        });
+
+        pane.push_approval_request(exec_request(), &features);
+        pane.push_user_input_request(codex_protocol::request_user_input::RequestUserInputEvent {
+            call_id: "input-1".to_string(),
+            turn_id: "turn-1".to_string(),
+            questions: vec![
+                codex_protocol::request_user_input::RequestUserInputQuestion {
+                    id: "question-1".to_string(),
+                    header: "Header".to_string(),
+                    question: "Question?".to_string(),
+                    is_other: false,
+                    is_secret: false,
+                    options: None,
+                },
+            ],
+        });
+
+        pane.remove_resolved_exec_approvals(&["1".to_string()]);
+        assert_eq!(
+            pane.view_stack.len(),
+            1,
+            "resolved approval should be removed from hidden overlays without touching the top modal"
+        );
+
+        pane.view_stack.pop();
+        assert!(
+            pane.view_stack.is_empty(),
+            "the hidden approval overlay should no longer resurface after the top modal closes"
         );
     }
 

--- a/codex-rs/tui_app_server/src/chatwidget.rs
+++ b/codex-rs/tui_app_server/src/chatwidget.rs
@@ -3950,6 +3950,12 @@ impl ChatWidget {
         self.request_redraw();
     }
 
+    pub(crate) fn remove_resolved_exec_approvals(&mut self, approval_ids: &[String]) {
+        self.bottom_pane
+            .remove_resolved_exec_approvals(approval_ids);
+        self.request_redraw();
+    }
+
     pub(crate) fn push_mcp_server_elicitation_request(
         &mut self,
         request: McpServerElicitationFormRequest,

--- a/codex-rs/tui_app_server/src/chatwidget.rs
+++ b/codex-rs/tui_app_server/src/chatwidget.rs
@@ -1207,9 +1207,12 @@ fn app_server_request_id_to_mcp_request_id(
 fn exec_approval_request_from_params(
     params: CommandExecutionRequestApprovalParams,
 ) -> ExecApprovalRequestEvent {
+    let command = params.command.map_or_else(Vec::new, |command| {
+        shlex::split(&command).unwrap_or_else(|| vec![command])
+    });
     ExecApprovalRequestEvent {
         call_id: params.item_id,
-        command: params.command.into_iter().collect(),
+        command,
         cwd: params.cwd.unwrap_or_default(),
         reason: params.reason,
         network_approval_context: params

--- a/codex-rs/tui_app_server/src/chatwidget/tests.rs
+++ b/codex-rs/tui_app_server/src/chatwidget/tests.rs
@@ -23,6 +23,7 @@ use codex_app_server_protocol::CollabAgentState as AppServerCollabAgentState;
 use codex_app_server_protocol::CollabAgentStatus as AppServerCollabAgentStatus;
 use codex_app_server_protocol::CollabAgentTool as AppServerCollabAgentTool;
 use codex_app_server_protocol::CollabAgentToolCallStatus as AppServerCollabAgentToolCallStatus;
+use codex_app_server_protocol::CommandExecutionRequestApprovalParams;
 use codex_app_server_protocol::ErrorNotification;
 use codex_app_server_protocol::FileUpdateChange;
 use codex_app_server_protocol::GuardianApprovalReview;
@@ -10086,6 +10087,39 @@ async fn status_widget_and_approval_modal_snapshot() {
         .draw(|f| chat.render(f.area(), f.buffer_mut()))
         .expect("draw status + approval modal");
     assert_snapshot!("status_widget_and_approval_modal", terminal.backend());
+}
+
+#[test]
+fn exec_approval_request_from_params_splits_shell_command_string() {
+    let event = exec_approval_request_from_params(CommandExecutionRequestApprovalParams {
+        thread_id: "thread-1".to_string(),
+        turn_id: "turn-1".to_string(),
+        item_id: "call-1".to_string(),
+        approval_id: Some("approval-1".to_string()),
+        reason: Some("Need shell".to_string()),
+        network_approval_context: None,
+        command: Some("printf 'hello world'".to_string()),
+        cwd: Some(PathBuf::from("/tmp/project")),
+        command_actions: None,
+        additional_permissions: None,
+        skill_metadata: None,
+        proposed_execpolicy_amendment: None,
+        proposed_network_policy_amendments: None,
+        available_decisions: None,
+    });
+
+    assert_eq!(
+        serde_json::to_value(event).expect("event should serialize"),
+        serde_json::json!({
+            "call_id": "call-1",
+            "approval_id": "approval-1",
+            "turn_id": "turn-1",
+            "command": ["printf", "hello world"],
+            "cwd": "/tmp/project",
+            "reason": "Need shell",
+            "parsed_cmd": [],
+        })
+    );
 }
 
 #[tokio::test]

--- a/codex-rs/tui_app_server/src/status_indicator_widget.rs
+++ b/codex-rs/tui_app_server/src/status_indicator_widget.rs
@@ -153,6 +153,11 @@ impl StatusIndicatorWidget {
         self.show_interrupt_hint
     }
 
+    #[cfg(test)]
+    pub(crate) fn is_paused(&self) -> bool {
+        self.is_paused
+    }
+
     pub(crate) fn pause_timer(&mut self) {
         self.pause_timer_at(Instant::now());
     }


### PR DESCRIPTION
## Summary

Add compatibility for older app-server approval request shapes.

## Problem

Some app-server sessions still use legacy approval requests instead of the current v2 request types. The TUI already had the right approval UI, but it rejected these legacy requests as unsupported, leaving the agent blocked.

## What this change does

- accepts legacy `ExecCommandApproval` requests
- bridges them into the existing exec approval UI
- preserves shell-escaped command display when bridging legacy argv
- accepts legacy `ApplyPatchApproval` requests
- bridges them into the existing file-change approval UI
- tracks whether pending approvals came from legacy or current request shapes
- serializes approval responses back using the matching v1 or v2 wire format
- keeps pending approvals retryable until resolution RPCs succeed
- removes resolved bridged approvals from buffered, queued, replay, and modal state

## Result

Sessions using older app-server approval protocols can interoperate correctly with the TUI's existing approval flows for both command execution and patch application, including display, resolution, retry, and cleanup behavior.
