### PR TITLE
[hooks] turn_id extension for Stop & UserPromptSubmit

### DIFF
--- a/codex-rs/core/tests/suite/hooks.rs
+++ b/codex-rs/core/tests/suite/hooks.rs
@@ -88,15 +88,20 @@ fn write_user_prompt_submit_hook(
     additional_context: &str,
 ) -> Result<()> {
     let script_path = home.join("user_prompt_submit_hook.py");
+    let log_path = home.join("user_prompt_submit_hook_log.jsonl");
+    let log_path = log_path.display();
     let blocked_prompt_json =
         serde_json::to_string(blocked_prompt).context("serialize blocked prompt for test")?;
     let additional_context_json = serde_json::to_string(additional_context)
         .context("serialize user prompt submit additional context for test")?;
     let script = format!(
         r#"import json
+from pathlib import Path
 import sys
 
 payload = json.load(sys.stdin)
+with Path(r"{log_path}").open("a", encoding="utf-8") as handle:
+    handle.write(json.dumps(payload) + "\n")
 
 if payload.get("prompt") == {blocked_prompt_json}:
     print(json.dumps({{
@@ -199,6 +204,15 @@ fn read_session_start_hook_inputs(home: &Path) -> Result<Vec<serde_json::Value>>
         .lines()
         .filter(|line| !line.trim().is_empty())
         .map(|line| serde_json::from_str(line).context("parse session start hook log line"))
+        .collect()
+}
+
+fn read_user_prompt_submit_hook_inputs(home: &Path) -> Result<Vec<serde_json::Value>> {
+    fs::read_to_string(home.join("user_prompt_submit_hook_log.jsonl"))
+        .context("read user prompt submit hook log")?
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str(line).context("parse user prompt submit hook log line"))
         .collect()
 }
 
@@ -305,6 +319,31 @@ async fn stop_hook_can_block_multiple_times_in_same_turn() -> Result<()> {
 
     let hook_inputs = read_stop_hook_inputs(test.codex_home_path())?;
     assert_eq!(hook_inputs.len(), 3);
+    let stop_turn_ids = hook_inputs
+        .iter()
+        .map(|input| {
+            input["turn_id"]
+                .as_str()
+                .expect("stop hook input turn_id")
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        stop_turn_ids.iter().all(|turn_id| !turn_id.is_empty()),
+        "stop hook turn ids should be non-empty",
+    );
+    let first_stop_turn_id = stop_turn_ids
+        .first()
+        .expect("stop hook inputs should include a first turn id")
+        .clone();
+    assert_eq!(
+        stop_turn_ids,
+        vec![
+            first_stop_turn_id.clone(),
+            first_stop_turn_id.clone(),
+            first_stop_turn_id,
+        ],
+    );
     assert_eq!(
         hook_inputs
             .iter()
@@ -508,6 +547,30 @@ async fn blocked_user_prompt_submit_persists_additional_context_for_next_turn() 
         "second request should include the accepted prompt",
     );
 
+    let hook_inputs = read_user_prompt_submit_hook_inputs(test.codex_home_path())?;
+    assert_eq!(hook_inputs.len(), 2);
+    assert_eq!(
+        hook_inputs
+            .iter()
+            .map(|input| {
+                input["prompt"]
+                    .as_str()
+                    .expect("user prompt submit hook prompt")
+                    .to_string()
+            })
+            .collect::<Vec<_>>(),
+        vec![
+            "blocked first prompt".to_string(),
+            "second prompt".to_string()
+        ],
+    );
+    assert!(
+        hook_inputs.iter().all(|input| input["turn_id"]
+            .as_str()
+            .is_some_and(|turn_id| !turn_id.is_empty())),
+        "blocked and accepted prompt hooks should both receive a non-empty turn_id",
+    );
+
     Ok(())
 }
 
@@ -622,6 +685,50 @@ async fn blocked_queued_prompt_does_not_strand_earlier_accepted_prompt() -> Resu
     assert!(
         !second_user_texts.contains(&"blocked queued prompt".to_string()),
         "second request should not include the blocked queued prompt",
+    );
+
+    let hook_inputs = read_user_prompt_submit_hook_inputs(test.codex_home_path())?;
+    assert_eq!(hook_inputs.len(), 3);
+    assert_eq!(
+        hook_inputs
+            .iter()
+            .map(|input| {
+                input["prompt"]
+                    .as_str()
+                    .expect("queued prompt hook prompt")
+                    .to_string()
+            })
+            .collect::<Vec<_>>(),
+        vec![
+            "initial prompt".to_string(),
+            "accepted queued prompt".to_string(),
+            "blocked queued prompt".to_string(),
+        ],
+    );
+    let queued_turn_ids = hook_inputs
+        .iter()
+        .map(|input| {
+            input["turn_id"]
+                .as_str()
+                .expect("queued prompt hook turn_id")
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        queued_turn_ids.iter().all(|turn_id| !turn_id.is_empty()),
+        "queued prompt hook turn ids should be non-empty",
+    );
+    let first_queued_turn_id = queued_turn_ids
+        .first()
+        .expect("queued prompt hook inputs should include a first turn id")
+        .clone();
+    assert_eq!(
+        queued_turn_ids,
+        vec![
+            first_queued_turn_id.clone(),
+            first_queued_turn_id.clone(),
+            first_queued_turn_id,
+        ],
     );
 
     server.shutdown().await;

--- a/codex-rs/hooks/schema/generated/stop.command.input.schema.json
+++ b/codex-rs/hooks/schema/generated/stop.command.input.schema.json
@@ -41,6 +41,10 @@
     },
     "transcript_path": {
       "$ref": "#/definitions/NullableString"
+    },
+    "turn_id": {
+      "description": "Codex extension: expose the active turn id to internal turn-scoped hooks.",
+      "type": "string"
     }
   },
   "required": [
@@ -51,7 +55,8 @@
     "permission_mode",
     "session_id",
     "stop_hook_active",
-    "transcript_path"
+    "transcript_path",
+    "turn_id"
   ],
   "title": "stop.command.input",
   "type": "object"

--- a/codex-rs/hooks/schema/generated/user-prompt-submit.command.input.schema.json
+++ b/codex-rs/hooks/schema/generated/user-prompt-submit.command.input.schema.json
@@ -38,6 +38,10 @@
     },
     "transcript_path": {
       "$ref": "#/definitions/NullableString"
+    },
+    "turn_id": {
+      "description": "Codex extension: expose the active turn id to internal turn-scoped hooks.",
+      "type": "string"
     }
   },
   "required": [
@@ -47,7 +51,8 @@
     "permission_mode",
     "prompt",
     "session_id",
-    "transcript_path"
+    "transcript_path",
+    "turn_id"
   ],
   "title": "user-prompt-submit.command.input",
   "type": "object"

--- a/codex-rs/hooks/src/events/stop.rs
+++ b/codex-rs/hooks/src/events/stop.rs
@@ -77,6 +77,7 @@ pub(crate) async fn run(
 
     let input_json = match serde_json::to_string(&StopCommandInput::new(
         request.session_id.to_string(),
+        request.turn_id.clone(),
         request.transcript_path.clone(),
         request.cwd.display().to_string(),
         request.model.clone(),

--- a/codex-rs/hooks/src/events/stop.rs
+++ b/codex-rs/hooks/src/events/stop.rs
@@ -14,6 +14,7 @@ use crate::engine::ConfiguredHandler;
 use crate::engine::command_runner::CommandRunResult;
 use crate::engine::dispatcher;
 use crate::engine::output_parser;
+use crate::schema::NullableString;
 use crate::schema::StopCommandInput;
 
 #[derive(Debug, Clone)]
@@ -75,16 +76,17 @@ pub(crate) async fn run(
         };
     }
 
-    let input_json = match serde_json::to_string(&StopCommandInput::new(
-        request.session_id.to_string(),
-        request.turn_id.clone(),
-        request.transcript_path.clone(),
-        request.cwd.display().to_string(),
-        request.model.clone(),
-        request.permission_mode.clone(),
-        request.stop_hook_active,
-        request.last_assistant_message.clone(),
-    )) {
+    let input_json = match serde_json::to_string(&StopCommandInput {
+        session_id: request.session_id.to_string(),
+        turn_id: request.turn_id.clone(),
+        transcript_path: NullableString::from_path(request.transcript_path.clone()),
+        cwd: request.cwd.display().to_string(),
+        hook_event_name: "Stop".to_string(),
+        model: request.model.clone(),
+        permission_mode: request.permission_mode.clone(),
+        stop_hook_active: request.stop_hook_active,
+        last_assistant_message: NullableString::from_string(request.last_assistant_message.clone()),
+    }) {
         Ok(input_json) => input_json,
         Err(error) => {
             return serialization_failure_outcome(common::serialization_failure_hook_events(

--- a/codex-rs/hooks/src/events/user_prompt_submit.rs
+++ b/codex-rs/hooks/src/events/user_prompt_submit.rs
@@ -77,6 +77,7 @@ pub(crate) async fn run(
 
     let input_json = match serde_json::to_string(&UserPromptSubmitCommandInput::new(
         request.session_id.to_string(),
+        request.turn_id.clone(),
         request.transcript_path.clone(),
         request.cwd.display().to_string(),
         request.model.clone(),

--- a/codex-rs/hooks/src/events/user_prompt_submit.rs
+++ b/codex-rs/hooks/src/events/user_prompt_submit.rs
@@ -14,6 +14,7 @@ use crate::engine::ConfiguredHandler;
 use crate::engine::command_runner::CommandRunResult;
 use crate::engine::dispatcher;
 use crate::engine::output_parser;
+use crate::schema::NullableString;
 use crate::schema::UserPromptSubmitCommandInput;
 
 #[derive(Debug, Clone)]
@@ -75,15 +76,16 @@ pub(crate) async fn run(
         };
     }
 
-    let input_json = match serde_json::to_string(&UserPromptSubmitCommandInput::new(
-        request.session_id.to_string(),
-        request.turn_id.clone(),
-        request.transcript_path.clone(),
-        request.cwd.display().to_string(),
-        request.model.clone(),
-        request.permission_mode.clone(),
-        request.prompt.clone(),
-    )) {
+    let input_json = match serde_json::to_string(&UserPromptSubmitCommandInput {
+        session_id: request.session_id.to_string(),
+        turn_id: request.turn_id.clone(),
+        transcript_path: NullableString::from_path(request.transcript_path.clone()),
+        cwd: request.cwd.display().to_string(),
+        hook_event_name: "UserPromptSubmit".to_string(),
+        model: request.model.clone(),
+        permission_mode: request.permission_mode.clone(),
+        prompt: request.prompt.clone(),
+    }) {
         Ok(input_json) => input_json,
         Err(error) => {
             return serialization_failure_outcome(common::serialization_failure_hook_events(

--- a/codex-rs/hooks/src/schema.rs
+++ b/codex-rs/hooks/src/schema.rs
@@ -178,6 +178,8 @@ impl SessionStartCommandInput {
 #[schemars(rename = "user-prompt-submit.command.input")]
 pub(crate) struct UserPromptSubmitCommandInput {
     pub session_id: String,
+    /// Codex extension: expose the active turn id to internal turn-scoped hooks.
+    pub turn_id: String,
     pub transcript_path: NullableString,
     pub cwd: String,
     #[schemars(schema_with = "user_prompt_submit_hook_event_name_schema")]
@@ -191,6 +193,7 @@ pub(crate) struct UserPromptSubmitCommandInput {
 impl UserPromptSubmitCommandInput {
     pub(crate) fn new(
         session_id: impl Into<String>,
+        turn_id: impl Into<String>,
         transcript_path: Option<PathBuf>,
         cwd: impl Into<String>,
         model: impl Into<String>,
@@ -199,6 +202,7 @@ impl UserPromptSubmitCommandInput {
     ) -> Self {
         Self {
             session_id: session_id.into(),
+            turn_id: turn_id.into(),
             transcript_path: NullableString::from_path(transcript_path),
             cwd: cwd.into(),
             hook_event_name: "UserPromptSubmit".to_string(),
@@ -214,6 +218,8 @@ impl UserPromptSubmitCommandInput {
 #[schemars(rename = "stop.command.input")]
 pub(crate) struct StopCommandInput {
     pub session_id: String,
+    /// Codex extension: expose the active turn id to internal turn-scoped hooks.
+    pub turn_id: String,
     pub transcript_path: NullableString,
     pub cwd: String,
     #[schemars(schema_with = "stop_hook_event_name_schema")]
@@ -228,6 +234,7 @@ pub(crate) struct StopCommandInput {
 impl StopCommandInput {
     pub(crate) fn new(
         session_id: impl Into<String>,
+        turn_id: impl Into<String>,
         transcript_path: Option<PathBuf>,
         cwd: impl Into<String>,
         model: impl Into<String>,
@@ -237,6 +244,7 @@ impl StopCommandInput {
     ) -> Self {
         Self {
             session_id: session_id.into(),
+            turn_id: turn_id.into(),
             transcript_path: NullableString::from_path(transcript_path),
             cwd: cwd.into(),
             hook_event_name: "Stop".to_string(),
@@ -390,10 +398,14 @@ mod tests {
     use super::SESSION_START_OUTPUT_FIXTURE;
     use super::STOP_INPUT_FIXTURE;
     use super::STOP_OUTPUT_FIXTURE;
+    use super::StopCommandInput;
     use super::USER_PROMPT_SUBMIT_INPUT_FIXTURE;
     use super::USER_PROMPT_SUBMIT_OUTPUT_FIXTURE;
+    use super::UserPromptSubmitCommandInput;
+    use super::schema_json;
     use super::write_schema_fixtures;
     use pretty_assertions::assert_eq;
+    use serde_json::Value;
     use tempfile::TempDir;
 
     fn expected_fixture(name: &str) -> &'static str {
@@ -443,6 +455,31 @@ mod tests {
                 .unwrap_or_else(|err| panic!("read generated schema {fixture}: {err}"));
             let actual = normalize_newlines(&actual);
             assert_eq!(expected, actual, "fixture should match generated schema");
+        }
+    }
+
+    #[test]
+    fn turn_scoped_hook_inputs_include_codex_turn_id_extension() {
+        // Codex intentionally diverges from Claude's public hook docs here so
+        // internal hook consumers can key off the active turn.
+        let user_prompt_submit: Value = serde_json::from_slice(
+            &schema_json::<UserPromptSubmitCommandInput>()
+                .expect("serialize user prompt submit input schema"),
+        )
+        .expect("parse user prompt submit input schema");
+        let stop: Value = serde_json::from_slice(
+            &schema_json::<StopCommandInput>().expect("serialize stop input schema"),
+        )
+        .expect("parse stop input schema");
+
+        for schema in [&user_prompt_submit, &stop] {
+            assert_eq!(schema["properties"]["turn_id"]["type"], "string");
+            assert!(
+                schema["required"]
+                    .as_array()
+                    .expect("schema required fields")
+                    .contains(&Value::String("turn_id".to_string()))
+            );
         }
     }
 }

--- a/codex-rs/hooks/src/schema.rs
+++ b/codex-rs/hooks/src/schema.rs
@@ -25,11 +25,11 @@ const STOP_OUTPUT_FIXTURE: &str = "stop.command.output.schema.json";
 pub(crate) struct NullableString(Option<String>);
 
 impl NullableString {
-    fn from_path(path: Option<PathBuf>) -> Self {
+    pub(crate) fn from_path(path: Option<PathBuf>) -> Self {
         Self(path.map(|path| path.display().to_string()))
     }
 
-    fn from_string(value: Option<String>) -> Self {
+    pub(crate) fn from_string(value: Option<String>) -> Self {
         Self(value)
     }
 }
@@ -190,29 +190,6 @@ pub(crate) struct UserPromptSubmitCommandInput {
     pub prompt: String,
 }
 
-impl UserPromptSubmitCommandInput {
-    pub(crate) fn new(
-        session_id: impl Into<String>,
-        turn_id: impl Into<String>,
-        transcript_path: Option<PathBuf>,
-        cwd: impl Into<String>,
-        model: impl Into<String>,
-        permission_mode: impl Into<String>,
-        prompt: impl Into<String>,
-    ) -> Self {
-        Self {
-            session_id: session_id.into(),
-            turn_id: turn_id.into(),
-            transcript_path: NullableString::from_path(transcript_path),
-            cwd: cwd.into(),
-            hook_event_name: "UserPromptSubmit".to_string(),
-            model: model.into(),
-            permission_mode: permission_mode.into(),
-            prompt: prompt.into(),
-        }
-    }
-}
-
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 #[schemars(rename = "stop.command.input")]
@@ -229,31 +206,6 @@ pub(crate) struct StopCommandInput {
     pub permission_mode: String,
     pub stop_hook_active: bool,
     pub last_assistant_message: NullableString,
-}
-
-impl StopCommandInput {
-    pub(crate) fn new(
-        session_id: impl Into<String>,
-        turn_id: impl Into<String>,
-        transcript_path: Option<PathBuf>,
-        cwd: impl Into<String>,
-        model: impl Into<String>,
-        permission_mode: impl Into<String>,
-        stop_hook_active: bool,
-        last_assistant_message: Option<String>,
-    ) -> Self {
-        Self {
-            session_id: session_id.into(),
-            turn_id: turn_id.into(),
-            transcript_path: NullableString::from_path(transcript_path),
-            cwd: cwd.into(),
-            hook_event_name: "Stop".to_string(),
-            model: model.into(),
-            permission_mode: permission_mode.into(),
-            stop_hook_active,
-            last_assistant_message: NullableString::from_string(last_assistant_message),
-        }
-    }
 }
 
 pub fn write_schema_fixtures(schema_root: &Path) -> anyhow::Result<()> {


### PR DESCRIPTION
## Description

Adding an extension to the spec that exposes the turn_id to hook scripts. This is a codex-specific mechanic that allows connecting the hook runs with particular turns

## Testing

hooks config / sample hooks to use. Extract this, rename codex -> .codex, and place this into a repo or your home folder. It includes: config.toml that enables hooks, hooks.json, and sample python hooks:

[codex.zip](https://github.com/user-attachments/files/26102671/codex.zip)

example run (note the turn_ids change between turns):

```
› hello


• Running SessionStart hook: lighting the observatory

SessionStart hook (completed)
  warning: Hi, I'm a session start hook for wizard-tower (startup).
  hook context: Startup context: A wimboltine stonpet is an exotic cuisine from hyperspace

• Running UserPromptSubmit hook: lighting the observatory lanterns

UserPromptSubmit hook (completed)
  warning: wizard-tower UserPromptSubmit demo inspected: hello for turn: 019d036d-c7fa-72d2-b6fd-
78878bfe34e4
  hook context: Wizard Tower UserPromptSubmit demo fired. For this reply only, include the exact
phrase 'observatory lanterns lit' near the end.

• Aloha! Grateful to be here and ready to build with you. Show me what you want to tackle in wizard-
  tower, and we’ll surf the next wave together. observatory lanterns lit

• Running Stop hook: back to shore

Stop hook (completed)
  warning: Wizard Tower Stop hook reviewed the completed reply (170 chars) for turn: 019d036d-c7fa-
72d2-b6fd-78878bfe34e4


› what's a stonpet?


• Running UserPromptSubmit hook: lighting the observatory lanterns

UserPromptSubmit hook (completed)
  warning: wizard-tower UserPromptSubmit demo inspected: what's a stonpet? for turn: 019d036e-3164-
72c3-a170-98925564c4fc
  hook context: Wizard Tower UserPromptSubmit demo fired. For this reply only, include the exact
phrase 'observatory lanterns lit' near the end.

• A stonpet isn’t a standard real-world word, brah. In our shared context here, a wimboltine stonpet
  is an exotic cuisine from hyperspace, so “stonpet” sounds like the dish or food itself.

  If you want, we can totally invent the lore for it next. observatory lanterns lit

• Running Stop hook: back to shore

Stop hook (completed)
  warning: Wizard Tower Stop hook reviewed the completed reply (271 chars) for turn: 019d036e-3164-
72c3-a170-98925564c4fc
```