### PR TITLE
Test: re-enable Windows sccache in rust-ci

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -141,8 +141,8 @@ jobs:
       run:
         working-directory: codex-rs
     env:
-      # Speed up repeated builds across CI runs by caching compiled objects (non-Windows).
-      USE_SCCACHE: ${{ startsWith(matrix.runner, 'windows') && 'false' || 'true' }}
+      # Speed up repeated builds across CI runs by caching compiled objects.
+      USE_SCCACHE: "true"
       CARGO_INCREMENTAL: "0"
       SCCACHE_CACHE_SIZE: 10G
       # In rust-ci, representative release-profile checks use thin LTO for faster feedback.
@@ -506,8 +506,8 @@ jobs:
       run:
         working-directory: codex-rs
     env:
-      # Speed up repeated builds across CI runs by caching compiled objects (non-Windows).
-      USE_SCCACHE: ${{ startsWith(matrix.runner, 'windows') && 'false' || 'true' }}
+      # Speed up repeated builds across CI runs by caching compiled objects.
+      USE_SCCACHE: "true"
       CARGO_INCREMENTAL: "0"
       SCCACHE_CACHE_SIZE: 10G
 

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -497,7 +497,7 @@ jobs:
           key: apt-${{ matrix.runner }}-${{ matrix.target }}-v1
 
   tests:
-    name: Tests — ${{ matrix.runner }} - ${{ matrix.target }}
+    name: Tests — ${{ matrix.runner }} - ${{ matrix.target }}${{ matrix.shard && format(' ({0})', matrix.shard) || '' }}
     runs-on: ${{ matrix.runs_on || matrix.runner }}
     timeout-minutes: 30
     needs: changed
@@ -533,12 +533,32 @@ jobs:
           - runner: windows-x64
             target: x86_64-pc-windows-msvc
             profile: dev
+            partition: count:1/2
+            shard: shard-1-of-2
             runs_on:
               group: codex-runners
               labels: codex-windows-x64
           - runner: windows-arm64
             target: aarch64-pc-windows-msvc
             profile: dev
+            partition: count:1/2
+            shard: shard-1-of-2
+            runs_on:
+              group: codex-runners
+              labels: codex-windows-arm64
+          - runner: windows-x64
+            target: x86_64-pc-windows-msvc
+            profile: dev
+            partition: count:2/2
+            shard: shard-2-of-2
+            runs_on:
+              group: codex-runners
+              labels: codex-windows-x64
+          - runner: windows-arm64
+            target: aarch64-pc-windows-msvc
+            profile: dev
+            partition: count:2/2
+            shard: shard-2-of-2
             runs_on:
               group: codex-runners
               labels: codex-windows-arm64
@@ -644,7 +664,21 @@ jobs:
 
       - name: tests
         id: test
-        run: cargo nextest run --all-features --no-fail-fast --target ${{ matrix.target }} --cargo-profile ci-test --timings
+        shell: bash
+        run: |
+          set -euo pipefail
+          args=(
+            cargo nextest run
+            --all-features
+            --no-fail-fast
+            --target "${{ matrix.target }}"
+            --cargo-profile ci-test
+            --timings
+          )
+          if [[ -n "${{ matrix.partition || '' }}" ]]; then
+            args+=(--partition "${{ matrix.partition }}")
+          fi
+          "${args[@]}"
         env:
           RUST_BACKTRACE: 1
           NEXTEST_STATUS_LEVEL: leak
@@ -653,7 +687,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: cargo-timings-rust-ci-nextest-${{ matrix.target }}-${{ matrix.profile }}
+          name: cargo-timings-rust-ci-nextest-${{ matrix.target }}-${{ matrix.profile }}${{ matrix.shard && format('-{0}', matrix.shard) || '' }}
           path: codex-rs/target/**/cargo-timings/cargo-timing.html
           if-no-files-found: warn
 


### PR DESCRIPTION
Experimental CI-only change to re-enable sccache for Windows jobs in `rust-ci`.

Goal: compare Windows queue delay, execution time, and cache behavior against recent baseline runs.

Co-authored-by: Codex <noreply@openai.com>