### PR TITLE
[Codex][Codex Auth] Handle stale managed auth refresh races before relogin

### DIFF
--- a/codex-rs/cloud-requirements/src/lib.rs
+++ b/codex-rs/cloud-requirements/src/lib.rs
@@ -975,6 +975,23 @@ mod tests {
         contents.and_then(|contents| parse_cloud_requirements(contents).ok().flatten())
     }
 
+    fn never_requirements() -> ConfigRequirementsToml {
+        ConfigRequirementsToml {
+            allowed_approval_policies: Some(vec![AskForApproval::Never]),
+            allowed_sandbox_modes: None,
+            allowed_web_search_modes: None,
+            guardian_developer_instructions: None,
+            feature_requirements: None,
+            mcp_servers: None,
+            apps: None,
+            rules: None,
+            enforce_residency: None,
+            network: None,
+        }
+    }
+
+    const AUTH_RECOVERY_MESSAGE: &str = "Your access token could not be refreshed because you have since logged out or signed in to another account. Please sign in again.";
+
     fn request_error() -> FetchAttemptError {
         FetchAttemptError::Retryable(RetryableFailureKind::Request { status_code: None })
     }
@@ -1161,21 +1178,7 @@ mod tests {
     async fn fetch_cloud_requirements_parses_valid_toml() {
         let result = parse_for_fetch(Some("allowed_approval_policies = [\"never\"]"));
 
-        assert_eq!(
-            result,
-            Some(ConfigRequirementsToml {
-                allowed_approval_policies: Some(vec![AskForApproval::Never]),
-                allowed_sandbox_modes: None,
-                allowed_web_search_modes: None,
-                guardian_developer_instructions: None,
-                feature_requirements: None,
-                mcp_servers: None,
-                apps: None,
-                rules: None,
-                enforce_residency: None,
-                network: None,
-            })
-        );
+        assert_eq!(result, Some(never_requirements()));
     }
 
     #[tokio::test]
@@ -1244,18 +1247,7 @@ enabled = false
 
         assert_eq!(
             handle.await.expect("cloud requirements task"),
-            Ok(Some(ConfigRequirementsToml {
-                allowed_approval_policies: Some(vec![AskForApproval::Never]),
-                allowed_sandbox_modes: None,
-                allowed_web_search_modes: None,
-                guardian_developer_instructions: None,
-                feature_requirements: None,
-                mcp_servers: None,
-                apps: None,
-                rules: None,
-                enforce_residency: None,
-                network: None,
-            }))
+            Ok(Some(never_requirements()))
         );
         assert_eq!(fetcher.request_count.load(Ordering::SeqCst), 2);
     }
@@ -1294,21 +1286,7 @@ enabled = false
             CLOUD_REQUIREMENTS_TIMEOUT,
         );
 
-        assert_eq!(
-            service.fetch().await,
-            Ok(Some(ConfigRequirementsToml {
-                allowed_approval_policies: Some(vec![AskForApproval::Never]),
-                allowed_sandbox_modes: None,
-                allowed_web_search_modes: None,
-                guardian_developer_instructions: None,
-                feature_requirements: None,
-                mcp_servers: None,
-                apps: None,
-                rules: None,
-                enforce_residency: None,
-                network: None,
-            }))
-        );
+        assert_eq!(service.fetch().await, Ok(Some(never_requirements())));
         assert_eq!(fetcher.request_count.load(Ordering::SeqCst), 1);
     }
 
@@ -1350,10 +1328,7 @@ enabled = false
             .fetch()
             .await
             .expect_err("same-account different-user auth should be rejected");
-        assert_eq!(
-            err.to_string(),
-            "Your access token could not be refreshed because you have since logged out or signed in to another account. Please sign in again."
-        );
+        assert_eq!(err.to_string(), AUTH_RECOVERY_MESSAGE);
         assert_eq!(fetcher.request_count.load(Ordering::SeqCst), 1);
     }
 
@@ -1394,10 +1369,7 @@ enabled = false
             .fetch()
             .await
             .expect_err("cloud requirements should surface auth recovery errors");
-        assert_eq!(
-            err.to_string(),
-            "Your access token could not be refreshed because you have since logged out or signed in to another account. Please sign in again."
-        );
+        assert_eq!(err.to_string(), AUTH_RECOVERY_MESSAGE);
         assert_eq!(fetcher.request_count.load(Ordering::SeqCst), 1);
     }
 

--- a/codex-rs/cloud-requirements/src/lib.rs
+++ b/codex-rs/cloud-requirements/src/lib.rs
@@ -1261,7 +1261,7 @@ enabled = false
     }
 
     #[tokio::test]
-    async fn fetch_cloud_requirements_recovers_after_unauthorized_reload() {
+    async fn fetch_cloud_requirements_uses_reloaded_auth_before_unauthorized_retry() {
         let auth = managed_auth_context(
             "business",
             Some("user-12345"),
@@ -1309,11 +1309,11 @@ enabled = false
                 network: None,
             }))
         );
-        assert_eq!(fetcher.request_count.load(Ordering::SeqCst), 2);
+        assert_eq!(fetcher.request_count.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]
-    async fn fetch_cloud_requirements_recovers_after_unauthorized_reload_updates_cache_identity() {
+    async fn fetch_cloud_requirements_rejects_different_user_in_same_account() {
         let auth = managed_auth_context(
             "business",
             Some("user-12345"),
@@ -1346,35 +1346,15 @@ enabled = false
             CLOUD_REQUIREMENTS_TIMEOUT,
         );
 
+        let err = service
+            .fetch()
+            .await
+            .expect_err("same-account different-user auth should be rejected");
         assert_eq!(
-            service.fetch().await,
-            Ok(Some(ConfigRequirementsToml {
-                allowed_approval_policies: Some(vec![AskForApproval::Never]),
-                allowed_sandbox_modes: None,
-                allowed_web_search_modes: None,
-                guardian_developer_instructions: None,
-                feature_requirements: None,
-                mcp_servers: None,
-                apps: None,
-                rules: None,
-                enforce_residency: None,
-                network: None,
-            }))
+            err.to_string(),
+            "Your access token could not be refreshed because you have since logged out or signed in to another account. Please sign in again."
         );
-
-        let path = codex_home.path().join(CLOUD_REQUIREMENTS_CACHE_FILENAME);
-        let cache_file: CloudRequirementsCacheFile =
-            serde_json::from_str(&std::fs::read_to_string(path).expect("read cache"))
-                .expect("parse cache");
-        assert_eq!(
-            cache_file.signed_payload.chatgpt_user_id,
-            Some("user-99999".to_string())
-        );
-        assert_eq!(
-            cache_file.signed_payload.account_id,
-            Some("account-12345".to_string())
-        );
-        assert_eq!(fetcher.request_count.load(Ordering::SeqCst), 2);
+        assert_eq!(fetcher.request_count.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/codex-rs/login/src/auth/auth_tests.rs
+++ b/codex-rs/login/src/auth/auth_tests.rs
@@ -4,15 +4,24 @@ use crate::auth::storage::get_auth_file;
 use crate::token_data::IdTokenInfo;
 use crate::token_data::KnownPlan as InternalKnownPlan;
 use crate::token_data::PlanType as InternalPlanType;
+use crate::token_data::TokenData;
 use codex_protocol::account::PlanType as AccountPlanType;
 
 use base64::Engine;
+use chrono::DateTime;
+use chrono::Duration;
 use codex_protocol::config_types::ForcedLoginMethod;
 use pretty_assertions::assert_eq;
 use serde::Serialize;
 use serde_json::json;
 use std::sync::Arc;
 use tempfile::tempdir;
+use wiremock::Mock;
+use wiremock::MockServer;
+use wiremock::Request;
+use wiremock::ResponseTemplate;
+use wiremock::matchers::method;
+use wiremock::matchers::path;
 
 #[tokio::test]
 async fn refresh_without_id_token() {
@@ -182,6 +191,7 @@ fn unauthorized_recovery_reports_mode_and_step_names() {
         manager: Arc::clone(&manager),
         step: UnauthorizedRecoveryStep::Reload,
         expected_account_id: None,
+        recovery_auth: None,
         mode: UnauthorizedRecoveryMode::Managed,
     };
     assert_eq!(managed.mode_name(), "managed");
@@ -191,10 +201,571 @@ fn unauthorized_recovery_reports_mode_and_step_names() {
         manager,
         step: UnauthorizedRecoveryStep::ExternalRefresh,
         expected_account_id: None,
+        recovery_auth: None,
         mode: UnauthorizedRecoveryMode::External,
     };
     assert_eq!(external.mode_name(), "external");
     assert_eq!(external.step_name(), "external_refresh");
+}
+
+#[tokio::test]
+#[serial(codex_api_key)]
+async fn stale_proactive_refresh_uses_newer_local_auth_before_spending_cached_refresh_token() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/oauth/token"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let ctx = RefreshTokenTestContext::new(&server);
+    let stale_auth = managed_auth_dot_json(
+        "stale-access",
+        "stale-refresh",
+        Some("account-id"),
+        "user-123",
+        "user@example.com",
+        refresh_time_days_ago(31),
+    );
+    ctx.write_auth(&stale_auth);
+
+    let newer_auth = managed_auth_dot_json(
+        "newer-access",
+        "newer-refresh",
+        Some("account-id"),
+        "user-123",
+        "user@example.com",
+        Utc::now(),
+    );
+    save_auth(
+        ctx.codex_home.path(),
+        &newer_auth,
+        AuthCredentialsStoreMode::File,
+    )
+    .expect("persist newer auth");
+
+    let refreshed = ctx.auth_manager.auth().await.expect("auth should exist");
+    assert_eq!(
+        refreshed.get_token_data().expect("token data").access_token,
+        "newer-access"
+    );
+
+    server.verify().await;
+}
+
+#[tokio::test]
+#[serial(codex_api_key)]
+async fn stale_proactive_refresh_uses_caller_snapshot_when_cache_already_changed() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/oauth/token"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let ctx = RefreshTokenTestContext::new(&server);
+    let stale_auth = managed_auth_dot_json(
+        "stale-access",
+        "stale-refresh",
+        Some("account-id"),
+        "user-123",
+        "user@example.com",
+        refresh_time_days_ago(31),
+    );
+    ctx.write_auth(&stale_auth);
+    let stale_cached_auth = ctx.auth_manager.auth_cached().expect("cached auth");
+
+    let newer_auth = managed_auth_dot_json(
+        "newer-access",
+        "newer-refresh",
+        Some("account-id"),
+        "user-123",
+        "user@example.com",
+        Utc::now(),
+    );
+    ctx.write_auth(&newer_auth);
+
+    assert_eq!(
+        ctx.auth_manager
+            .refresh_if_stale(&stale_cached_auth)
+            .await
+            .expect("refresh should succeed"),
+        true
+    );
+    assert_eq!(
+        ctx.auth_manager
+            .auth_cached()
+            .expect("cached auth")
+            .get_token_data()
+            .expect("token data")
+            .access_token,
+        "newer-access"
+    );
+
+    server.verify().await;
+}
+
+#[tokio::test]
+#[serial(codex_api_key)]
+async fn stale_proactive_refresh_without_account_id_still_recovers_newer_local_auth() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/oauth/token"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let ctx = RefreshTokenTestContext::new(&server);
+    let stale_auth = managed_auth_dot_json(
+        "stale-access",
+        "stale-refresh",
+        None,
+        "user-123",
+        "user@example.com",
+        refresh_time_days_ago(31),
+    );
+    ctx.write_auth(&stale_auth);
+
+    let newer_auth = managed_auth_dot_json(
+        "newer-access",
+        "newer-refresh",
+        None,
+        "user-123",
+        "user@example.com",
+        Utc::now(),
+    );
+    save_auth(
+        ctx.codex_home.path(),
+        &newer_auth,
+        AuthCredentialsStoreMode::File,
+    )
+    .expect("persist newer auth");
+
+    let refreshed = ctx.auth_manager.auth().await.expect("auth should exist");
+    assert_eq!(
+        refreshed.get_token_data().expect("token data").access_token,
+        "newer-access"
+    );
+
+    server.verify().await;
+}
+
+#[tokio::test]
+#[serial(codex_api_key)]
+async fn stale_proactive_refresh_does_not_overwrite_a_different_account_on_disk() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/oauth/token"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let ctx = RefreshTokenTestContext::new(&server);
+    let stale_auth = managed_auth_dot_json(
+        "stale-access",
+        "stale-refresh",
+        Some("account-a"),
+        "user-a",
+        "user-a@example.com",
+        refresh_time_days_ago(31),
+    );
+    ctx.write_auth(&stale_auth);
+
+    let other_auth = managed_auth_dot_json(
+        "other-access",
+        "other-refresh",
+        Some("account-b"),
+        "user-b",
+        "user-b@example.com",
+        Utc::now(),
+    );
+    save_auth(
+        ctx.codex_home.path(),
+        &other_auth,
+        AuthCredentialsStoreMode::File,
+    )
+    .expect("persist other-account auth");
+
+    let returned_auth = ctx.auth_manager.auth().await.expect("auth should exist");
+    assert_eq!(
+        returned_auth
+            .get_token_data()
+            .expect("token data")
+            .access_token,
+        "stale-access"
+    );
+    assert_eq!(
+        ctx.auth_manager
+            .auth_cached()
+            .expect("cached auth")
+            .get_token_data()
+            .expect("token data")
+            .access_token,
+        "stale-access"
+    );
+    assert_eq!(
+        CodexAuth::from_auth_storage(ctx.codex_home.path(), AuthCredentialsStoreMode::File)
+            .expect("load auth from disk")
+            .expect("persisted auth")
+            .get_token_data()
+            .expect("token data")
+            .access_token,
+        "other-access"
+    );
+
+    server.verify().await;
+}
+
+#[tokio::test]
+#[serial(codex_api_key)]
+async fn stale_proactive_refresh_does_not_adopt_a_different_user_in_same_account() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/oauth/token"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let ctx = RefreshTokenTestContext::new(&server);
+    let stale_auth = managed_auth_dot_json(
+        "stale-access",
+        "stale-refresh",
+        Some("account-a"),
+        "user-a",
+        "user-a@example.com",
+        refresh_time_days_ago(31),
+    );
+    ctx.write_auth(&stale_auth);
+
+    let other_user_auth = managed_auth_dot_json(
+        "other-access",
+        "other-refresh",
+        Some("account-a"),
+        "user-b",
+        "user-b@example.com",
+        Utc::now(),
+    );
+    save_auth(
+        ctx.codex_home.path(),
+        &other_user_auth,
+        AuthCredentialsStoreMode::File,
+    )
+    .expect("persist different-user auth in same account");
+
+    let returned_auth = ctx.auth_manager.auth().await.expect("auth should exist");
+    assert_eq!(
+        returned_auth
+            .get_token_data()
+            .expect("token data")
+            .access_token,
+        "stale-access"
+    );
+    assert_eq!(
+        ctx.auth_manager
+            .auth_cached()
+            .expect("cached auth")
+            .get_token_data()
+            .expect("token data")
+            .access_token,
+        "stale-access"
+    );
+
+    server.verify().await;
+}
+
+#[tokio::test]
+#[serial(codex_api_key)]
+async fn stale_proactive_refresh_without_account_id_adopts_auth_with_account_id() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/oauth/token"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let ctx = RefreshTokenTestContext::new(&server);
+    let stale_auth = managed_auth_dot_json(
+        "stale-access",
+        "stale-refresh",
+        None,
+        "user-a",
+        "user-a@example.com",
+        refresh_time_days_ago(31),
+    );
+    ctx.write_auth(&stale_auth);
+
+    let newer_auth = managed_auth_dot_json(
+        "newer-access",
+        "newer-refresh",
+        Some("account-id"),
+        "user-a",
+        "user-a@example.com",
+        Utc::now(),
+    );
+    save_auth(
+        ctx.codex_home.path(),
+        &newer_auth,
+        AuthCredentialsStoreMode::File,
+    )
+    .expect("persist same-user auth with account id");
+
+    let returned_auth = ctx.auth_manager.auth().await.expect("auth should exist");
+    assert_eq!(
+        returned_auth
+            .get_token_data()
+            .expect("token data")
+            .access_token,
+        "newer-access"
+    );
+    assert_eq!(
+        ctx.auth_manager
+            .auth_cached()
+            .expect("cached auth")
+            .get_token_data()
+            .expect("token data")
+            .access_token,
+        "newer-access"
+    );
+
+    server.verify().await;
+}
+
+#[tokio::test]
+#[serial(codex_api_key)]
+async fn stale_proactive_refresh_without_identity_claims_still_attempts_refresh() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/oauth/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "access_token": "refreshed-access",
+            "refresh_token": "refreshed-refresh",
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let ctx = RefreshTokenTestContext::new(&server);
+    let stale_auth = managed_auth_dot_json_without_user_id(
+        "stale-access",
+        "stale-refresh",
+        "user-a@example.com",
+        refresh_time_days_ago(31),
+    );
+    ctx.write_auth(&stale_auth);
+
+    let returned_auth = ctx.auth_manager.auth().await.expect("auth should exist");
+    assert_eq!(
+        returned_auth
+            .get_token_data()
+            .expect("token data")
+            .access_token,
+        "refreshed-access"
+    );
+
+    server.verify().await;
+}
+
+#[tokio::test]
+#[serial(codex_api_key)]
+async fn refresh_token_reused_without_account_id_adopts_auth_when_disk_auth_gains_account_id() {
+    let server = MockServer::start().await;
+    let ctx = Arc::new(RefreshTokenTestContext::new(&server));
+    let stale_auth = managed_auth_dot_json(
+        "stale-access",
+        "stale-refresh",
+        None,
+        "user-a",
+        "user-a@example.com",
+        refresh_time_days_ago(31),
+    );
+    ctx.write_auth(&stale_auth);
+
+    let newer_auth = managed_auth_dot_json(
+        "newer-access",
+        "newer-refresh",
+        Some("account-id"),
+        "user-a",
+        "user-a@example.com",
+        Utc::now(),
+    );
+    let ctx_for_response = Arc::clone(&ctx);
+    Mock::given(method("POST"))
+        .and(path("/oauth/token"))
+        .respond_with(move |_: &Request| {
+            save_auth(
+                ctx_for_response.codex_home.path(),
+                &newer_auth,
+                AuthCredentialsStoreMode::File,
+            )
+            .expect("persist same-user auth during reused-token response");
+            ResponseTemplate::new(401)
+                .set_body_json(json!({"error": {"code": "refresh_token_reused"}}))
+        })
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    ctx.auth_manager
+        .refresh_token_from_authority()
+        .await
+        .expect("same-user auth with a new account id should be adopted");
+    assert_eq!(
+        ctx.auth_manager
+            .auth_cached()
+            .expect("cached auth")
+            .get_token_data()
+            .expect("token data")
+            .access_token,
+        "newer-access"
+    );
+
+    server.verify().await;
+}
+
+#[tokio::test]
+#[serial(codex_api_key)]
+async fn unauthorized_recovery_reload_uses_original_auth_snapshot_for_same_account_user_guard() {
+    let server = MockServer::start().await;
+    let ctx = RefreshTokenTestContext::new(&server);
+    let original_auth = managed_auth_dot_json(
+        "original-access",
+        "original-refresh",
+        Some("account-id"),
+        "user-a",
+        "user-a@example.com",
+        refresh_time_days_ago(31),
+    );
+    ctx.write_auth(&original_auth);
+
+    let mut recovery = ctx.auth_manager.unauthorized_recovery();
+
+    let different_user_auth = managed_auth_dot_json(
+        "other-access",
+        "other-refresh",
+        Some("account-id"),
+        "user-b",
+        "user-b@example.com",
+        Utc::now(),
+    );
+    save_auth(
+        ctx.codex_home.path(),
+        &different_user_auth,
+        AuthCredentialsStoreMode::File,
+    )
+    .expect("persist different-user auth");
+    let different_user_cached_auth =
+        super::load_auth(ctx.codex_home.path(), false, AuthCredentialsStoreMode::File)
+            .expect("load auth should succeed")
+            .expect("auth should exist");
+    ctx.auth_manager
+        .set_cached_auth(Some(different_user_cached_auth));
+
+    let err = recovery
+        .next()
+        .await
+        .expect_err("recovery should reject a different user in the same account");
+    assert_eq!(
+        err.to_string(),
+        REFRESH_TOKEN_ACCOUNT_MISMATCH_MESSAGE.to_string()
+    );
+}
+
+#[tokio::test]
+#[serial(codex_api_key)]
+async fn refresh_token_reused_recovers_if_guarded_reload_finds_newer_auth() {
+    let server = MockServer::start().await;
+    let ctx = Arc::new(RefreshTokenTestContext::new(&server));
+    let stale_auth = managed_auth_dot_json(
+        "stale-access",
+        "stale-refresh",
+        Some("account-id"),
+        "user-123",
+        "user@example.com",
+        refresh_time_days_ago(31),
+    );
+    ctx.write_auth(&stale_auth);
+
+    let newer_auth = managed_auth_dot_json(
+        "newer-access",
+        "newer-refresh",
+        Some("account-id"),
+        "user-123",
+        "user@example.com",
+        Utc::now(),
+    );
+    let ctx_for_response = Arc::clone(&ctx);
+    Mock::given(method("POST"))
+        .and(path("/oauth/token"))
+        .respond_with(move |_: &Request| {
+            save_auth(
+                ctx_for_response.codex_home.path(),
+                &newer_auth,
+                AuthCredentialsStoreMode::File,
+            )
+            .expect("persist newer auth during reused-token response");
+            ResponseTemplate::new(401)
+                .set_body_json(json!({"error": {"code": "refresh_token_reused"}}))
+        })
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    ctx.auth_manager
+        .refresh_token()
+        .await
+        .expect("reload after reused token should recover");
+
+    let refreshed = ctx.auth_manager.auth_cached().expect("cached auth");
+    assert_eq!(
+        refreshed.get_token_data().expect("token data").access_token,
+        "newer-access"
+    );
+
+    server.verify().await;
+}
+
+#[tokio::test]
+#[serial(codex_api_key)]
+async fn refresh_token_reused_with_unchanged_local_auth_keeps_relogin_failure() {
+    let server = MockServer::start().await;
+    let ctx = RefreshTokenTestContext::new(&server);
+    let stale_auth = managed_auth_dot_json(
+        "stale-access",
+        "stale-refresh",
+        Some("account-id"),
+        "user-123",
+        "user@example.com",
+        refresh_time_days_ago(31),
+    );
+    ctx.write_auth(&stale_auth);
+
+    Mock::given(method("POST"))
+        .and(path("/oauth/token"))
+        .respond_with(
+            ResponseTemplate::new(401)
+                .set_body_json(json!({"error": {"code": "refresh_token_reused"}})),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let err = ctx
+        .auth_manager
+        .refresh_token()
+        .await
+        .expect_err("unchanged local auth should still surface relogin");
+    assert_eq!(
+        err.failed_reason(),
+        Some(RefreshTokenFailedReason::Exhausted)
+    );
+
+    server.verify().await;
 }
 
 struct AuthFileParams {
@@ -252,6 +823,142 @@ fn write_auth_file(params: AuthFileParams, codex_home: &Path) -> std::io::Result
     let auth_json = serde_json::to_string_pretty(&auth_json_data)?;
     std::fs::write(auth_file, auth_json)?;
     Ok(fake_jwt)
+}
+
+struct RefreshTokenTestContext {
+    codex_home: tempfile::TempDir,
+    auth_manager: Arc<AuthManager>,
+    _env_guard: EnvVarGuard,
+}
+
+impl RefreshTokenTestContext {
+    fn new(server: &MockServer) -> Self {
+        let codex_home = tempdir().expect("tempdir");
+        let endpoint = format!("{}/oauth/token", server.uri());
+        let env_guard = EnvVarGuard::set(REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR, &endpoint);
+        let auth_manager = AuthManager::shared(
+            codex_home.path().to_path_buf(),
+            false,
+            AuthCredentialsStoreMode::File,
+        );
+        Self {
+            codex_home,
+            auth_manager,
+            _env_guard: env_guard,
+        }
+    }
+
+    fn write_auth(&self, auth_dot_json: &AuthDotJson) {
+        save_auth(
+            self.codex_home.path(),
+            auth_dot_json,
+            AuthCredentialsStoreMode::File,
+        )
+        .expect("write auth");
+        self.auth_manager.reload();
+    }
+}
+
+fn managed_auth_dot_json(
+    access_token: &str,
+    refresh_token: &str,
+    account_id: Option<&str>,
+    chatgpt_user_id: &str,
+    email: &str,
+    last_refresh: DateTime<Utc>,
+) -> AuthDotJson {
+    AuthDotJson {
+        auth_mode: Some(ApiAuthMode::Chatgpt),
+        openai_api_key: None,
+        tokens: Some(TokenData {
+            id_token: IdTokenInfo {
+                email: Some(email.to_string()),
+                chatgpt_user_id: Some(chatgpt_user_id.to_string()),
+                raw_jwt: minimal_jwt(chatgpt_user_id, email),
+                ..IdTokenInfo::default()
+            },
+            access_token: access_token.to_string(),
+            refresh_token: refresh_token.to_string(),
+            account_id: account_id.map(str::to_owned),
+        }),
+        last_refresh: Some(last_refresh),
+    }
+}
+
+fn managed_auth_dot_json_without_user_id(
+    access_token: &str,
+    refresh_token: &str,
+    email: &str,
+    last_refresh: DateTime<Utc>,
+) -> AuthDotJson {
+    AuthDotJson {
+        auth_mode: Some(ApiAuthMode::Chatgpt),
+        openai_api_key: None,
+        tokens: Some(TokenData {
+            id_token: IdTokenInfo {
+                email: Some(email.to_string()),
+                raw_jwt: minimal_jwt_without_user_id(email),
+                ..IdTokenInfo::default()
+            },
+            access_token: access_token.to_string(),
+            refresh_token: refresh_token.to_string(),
+            account_id: None,
+        }),
+        last_refresh: Some(last_refresh),
+    }
+}
+
+fn refresh_time_days_ago(days: i64) -> DateTime<Utc> {
+    Utc::now() - Duration::days(days)
+}
+
+fn minimal_jwt(chatgpt_user_id: &str, email: &str) -> String {
+    #[derive(Serialize)]
+    struct Header {
+        alg: &'static str,
+        typ: &'static str,
+    }
+
+    let header = Header {
+        alg: "none",
+        typ: "JWT",
+    };
+    let payload = json!({
+        "sub": chatgpt_user_id,
+        "email": email,
+        "https://api.openai.com/auth": {
+            "chatgpt_user_id": chatgpt_user_id,
+        }
+    });
+
+    let b64 = |bytes: &[u8]| base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes);
+    let header_b64 = b64(&serde_json::to_vec(&header).expect("serialize header"));
+    let payload_b64 = b64(&serde_json::to_vec(&payload).expect("serialize payload"));
+    let signature_b64 = b64(b"sig");
+    format!("{header_b64}.{payload_b64}.{signature_b64}")
+}
+
+fn minimal_jwt_without_user_id(email: &str) -> String {
+    #[derive(Serialize)]
+    struct Header {
+        alg: &'static str,
+        typ: &'static str,
+    }
+
+    let header = Header {
+        alg: "none",
+        typ: "JWT",
+    };
+    let payload = json!({
+        "email": email,
+        "https://api.openai.com/auth": {}
+    });
+
+    let b64 = |bytes: &[u8]| base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes);
+    let header_b64 = b64(&serde_json::to_vec(&header).expect("serialize header"));
+    let payload_b64 = b64(&serde_json::to_vec(&payload).expect("serialize payload"));
+    let signature_b64 = b64(b"sig");
+    format!("{header_b64}.{payload_b64}.{signature_b64}")
 }
 
 async fn build_config(

--- a/codex-rs/login/src/auth/auth_tests.rs
+++ b/codex-rs/login/src/auth/auth_tests.rs
@@ -179,71 +179,31 @@ fn logout_removes_auth_file() -> Result<(), std::io::Error> {
     Ok(())
 }
 
-#[test]
-fn unauthorized_recovery_reports_mode_and_step_names() {
-    let dir = tempdir().unwrap();
-    let manager = AuthManager::shared(
-        dir.path().to_path_buf(),
-        false,
-        AuthCredentialsStoreMode::File,
-    );
-    let managed = UnauthorizedRecovery {
-        manager: Arc::clone(&manager),
-        step: UnauthorizedRecoveryStep::Reload,
-        expected_account_id: None,
-        recovery_auth: None,
-        mode: UnauthorizedRecoveryMode::Managed,
-    };
-    assert_eq!(managed.mode_name(), "managed");
-    assert_eq!(managed.step_name(), "reload");
-
-    let external = UnauthorizedRecovery {
-        manager,
-        step: UnauthorizedRecoveryStep::ExternalRefresh,
-        expected_account_id: None,
-        recovery_auth: None,
-        mode: UnauthorizedRecoveryMode::External,
-    };
-    assert_eq!(external.mode_name(), "external");
-    assert_eq!(external.step_name(), "external_refresh");
-}
-
 #[tokio::test]
 #[serial(codex_api_key)]
 async fn stale_proactive_refresh_uses_newer_local_auth_before_spending_cached_refresh_token() {
     let server = MockServer::start().await;
-    Mock::given(method("POST"))
-        .and(path("/oauth/token"))
-        .respond_with(ResponseTemplate::new(200))
-        .expect(0)
-        .mount(&server)
-        .await;
+    expect_refresh_unused(&server).await;
 
-    let ctx = RefreshTokenTestContext::new(&server);
-    let stale_auth = managed_auth_dot_json(
-        "stale-access",
-        "stale-refresh",
-        Some("account-id"),
-        "user-123",
-        "user@example.com",
-        refresh_time_days_ago(31),
+    let ctx = stale_managed_auth_context(
+        &server,
+        ManagedAuthFixture {
+            access_token: "stale-access",
+            refresh_token: "stale-refresh",
+            account_id: Some("account-id"),
+            chatgpt_user_id: "user-123",
+            email: "user@example.com",
+            last_refresh: refresh_time_days_ago(31),
+        },
+        ManagedAuthFixture {
+            access_token: "newer-access",
+            refresh_token: "newer-refresh",
+            account_id: Some("account-id"),
+            chatgpt_user_id: "user-123",
+            email: "user@example.com",
+            last_refresh: Utc::now(),
+        },
     );
-    ctx.write_auth(&stale_auth);
-
-    let newer_auth = managed_auth_dot_json(
-        "newer-access",
-        "newer-refresh",
-        Some("account-id"),
-        "user-123",
-        "user@example.com",
-        Utc::now(),
-    );
-    save_auth(
-        ctx.codex_home.path(),
-        &newer_auth,
-        AuthCredentialsStoreMode::File,
-    )
-    .expect("persist newer auth");
 
     let refreshed = ctx.auth_manager.auth().await.expect("auth should exist");
     assert_eq!(
@@ -275,64 +235,11 @@ async fn stale_proactive_refresh_uses_caller_snapshot_when_cache_already_changed
         refresh_time_days_ago(31),
     );
     ctx.write_auth(&stale_auth);
-    let stale_cached_auth = ctx.auth_manager.auth_cached().expect("cached auth");
 
     let newer_auth = managed_auth_dot_json(
         "newer-access",
         "newer-refresh",
         Some("account-id"),
-        "user-123",
-        "user@example.com",
-        Utc::now(),
-    );
-    ctx.write_auth(&newer_auth);
-
-    assert_eq!(
-        ctx.auth_manager
-            .refresh_if_stale(&stale_cached_auth)
-            .await
-            .expect("refresh should succeed"),
-        true
-    );
-    assert_eq!(
-        ctx.auth_manager
-            .auth_cached()
-            .expect("cached auth")
-            .get_token_data()
-            .expect("token data")
-            .access_token,
-        "newer-access"
-    );
-
-    server.verify().await;
-}
-
-#[tokio::test]
-#[serial(codex_api_key)]
-async fn stale_proactive_refresh_without_account_id_still_recovers_newer_local_auth() {
-    let server = MockServer::start().await;
-    Mock::given(method("POST"))
-        .and(path("/oauth/token"))
-        .respond_with(ResponseTemplate::new(200))
-        .expect(0)
-        .mount(&server)
-        .await;
-
-    let ctx = RefreshTokenTestContext::new(&server);
-    let stale_auth = managed_auth_dot_json(
-        "stale-access",
-        "stale-refresh",
-        None,
-        "user-123",
-        "user@example.com",
-        refresh_time_days_ago(31),
-    );
-    ctx.write_auth(&stale_auth);
-
-    let newer_auth = managed_auth_dot_json(
-        "newer-access",
-        "newer-refresh",
-        None,
         "user-123",
         "user@example.com",
         Utc::now(),
@@ -357,38 +264,27 @@ async fn stale_proactive_refresh_without_account_id_still_recovers_newer_local_a
 #[serial(codex_api_key)]
 async fn stale_proactive_refresh_does_not_overwrite_a_different_account_on_disk() {
     let server = MockServer::start().await;
-    Mock::given(method("POST"))
-        .and(path("/oauth/token"))
-        .respond_with(ResponseTemplate::new(200))
-        .expect(0)
-        .mount(&server)
-        .await;
+    expect_refresh_unused(&server).await;
 
-    let ctx = RefreshTokenTestContext::new(&server);
-    let stale_auth = managed_auth_dot_json(
-        "stale-access",
-        "stale-refresh",
-        Some("account-a"),
-        "user-a",
-        "user-a@example.com",
-        refresh_time_days_ago(31),
+    let ctx = stale_managed_auth_context(
+        &server,
+        ManagedAuthFixture {
+            access_token: "stale-access",
+            refresh_token: "stale-refresh",
+            account_id: Some("account-a"),
+            chatgpt_user_id: "user-a",
+            email: "user-a@example.com",
+            last_refresh: refresh_time_days_ago(31),
+        },
+        ManagedAuthFixture {
+            access_token: "other-access",
+            refresh_token: "other-refresh",
+            account_id: Some("account-b"),
+            chatgpt_user_id: "user-b",
+            email: "user-b@example.com",
+            last_refresh: Utc::now(),
+        },
     );
-    ctx.write_auth(&stale_auth);
-
-    let other_auth = managed_auth_dot_json(
-        "other-access",
-        "other-refresh",
-        Some("account-b"),
-        "user-b",
-        "user-b@example.com",
-        Utc::now(),
-    );
-    save_auth(
-        ctx.codex_home.path(),
-        &other_auth,
-        AuthCredentialsStoreMode::File,
-    )
-    .expect("persist other-account auth");
 
     let returned_auth = ctx.auth_manager.auth().await.expect("auth should exist");
     assert_eq!(
@@ -424,38 +320,27 @@ async fn stale_proactive_refresh_does_not_overwrite_a_different_account_on_disk(
 #[serial(codex_api_key)]
 async fn stale_proactive_refresh_does_not_adopt_a_different_user_in_same_account() {
     let server = MockServer::start().await;
-    Mock::given(method("POST"))
-        .and(path("/oauth/token"))
-        .respond_with(ResponseTemplate::new(200))
-        .expect(0)
-        .mount(&server)
-        .await;
+    expect_refresh_unused(&server).await;
 
-    let ctx = RefreshTokenTestContext::new(&server);
-    let stale_auth = managed_auth_dot_json(
-        "stale-access",
-        "stale-refresh",
-        Some("account-a"),
-        "user-a",
-        "user-a@example.com",
-        refresh_time_days_ago(31),
+    let ctx = stale_managed_auth_context(
+        &server,
+        ManagedAuthFixture {
+            access_token: "stale-access",
+            refresh_token: "stale-refresh",
+            account_id: Some("account-a"),
+            chatgpt_user_id: "user-a",
+            email: "user-a@example.com",
+            last_refresh: refresh_time_days_ago(31),
+        },
+        ManagedAuthFixture {
+            access_token: "other-access",
+            refresh_token: "other-refresh",
+            account_id: Some("account-a"),
+            chatgpt_user_id: "user-b",
+            email: "user-b@example.com",
+            last_refresh: Utc::now(),
+        },
     );
-    ctx.write_auth(&stale_auth);
-
-    let other_user_auth = managed_auth_dot_json(
-        "other-access",
-        "other-refresh",
-        Some("account-a"),
-        "user-b",
-        "user-b@example.com",
-        Utc::now(),
-    );
-    save_auth(
-        ctx.codex_home.path(),
-        &other_user_auth,
-        AuthCredentialsStoreMode::File,
-    )
-    .expect("persist different-user auth in same account");
 
     let returned_auth = ctx.auth_manager.auth().await.expect("auth should exist");
     assert_eq!(
@@ -482,38 +367,27 @@ async fn stale_proactive_refresh_does_not_adopt_a_different_user_in_same_account
 #[serial(codex_api_key)]
 async fn stale_proactive_refresh_without_account_id_adopts_auth_with_account_id() {
     let server = MockServer::start().await;
-    Mock::given(method("POST"))
-        .and(path("/oauth/token"))
-        .respond_with(ResponseTemplate::new(200))
-        .expect(0)
-        .mount(&server)
-        .await;
+    expect_refresh_unused(&server).await;
 
-    let ctx = RefreshTokenTestContext::new(&server);
-    let stale_auth = managed_auth_dot_json(
-        "stale-access",
-        "stale-refresh",
-        None,
-        "user-a",
-        "user-a@example.com",
-        refresh_time_days_ago(31),
+    let ctx = stale_managed_auth_context(
+        &server,
+        ManagedAuthFixture {
+            access_token: "stale-access",
+            refresh_token: "stale-refresh",
+            account_id: None,
+            chatgpt_user_id: "user-a",
+            email: "user-a@example.com",
+            last_refresh: refresh_time_days_ago(31),
+        },
+        ManagedAuthFixture {
+            access_token: "newer-access",
+            refresh_token: "newer-refresh",
+            account_id: Some("account-id"),
+            chatgpt_user_id: "user-a",
+            email: "user-a@example.com",
+            last_refresh: Utc::now(),
+        },
     );
-    ctx.write_auth(&stale_auth);
-
-    let newer_auth = managed_auth_dot_json(
-        "newer-access",
-        "newer-refresh",
-        Some("account-id"),
-        "user-a",
-        "user-a@example.com",
-        Utc::now(),
-    );
-    save_auth(
-        ctx.codex_home.path(),
-        &newer_auth,
-        AuthCredentialsStoreMode::File,
-    )
-    .expect("persist same-user auth with account id");
 
     let returned_auth = ctx.auth_manager.auth().await.expect("auth should exist");
     assert_eq!(
@@ -857,6 +731,54 @@ impl RefreshTokenTestContext {
         .expect("write auth");
         self.auth_manager.reload();
     }
+}
+
+struct ManagedAuthFixture<'a> {
+    access_token: &'a str,
+    refresh_token: &'a str,
+    account_id: Option<&'a str>,
+    chatgpt_user_id: &'a str,
+    email: &'a str,
+    last_refresh: DateTime<Utc>,
+}
+
+fn stale_managed_auth_context(
+    server: &MockServer,
+    stale: ManagedAuthFixture<'_>,
+    replacement: ManagedAuthFixture<'_>,
+) -> RefreshTokenTestContext {
+    let ctx = RefreshTokenTestContext::new(server);
+    ctx.write_auth(&managed_auth_dot_json(
+        stale.access_token,
+        stale.refresh_token,
+        stale.account_id,
+        stale.chatgpt_user_id,
+        stale.email,
+        stale.last_refresh,
+    ));
+    save_auth(
+        ctx.codex_home.path(),
+        &managed_auth_dot_json(
+            replacement.access_token,
+            replacement.refresh_token,
+            replacement.account_id,
+            replacement.chatgpt_user_id,
+            replacement.email,
+            replacement.last_refresh,
+        ),
+        AuthCredentialsStoreMode::File,
+    )
+    .expect("persist replacement auth");
+    ctx
+}
+
+async fn expect_refresh_unused(server: &MockServer) {
+    Mock::given(method("POST"))
+        .and(path("/oauth/token"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(0)
+        .mount(server)
+        .await;
 }
 
 fn managed_auth_dot_json(

--- a/codex-rs/login/src/auth/manager.rs
+++ b/codex-rs/login/src/auth/manager.rs
@@ -825,8 +825,10 @@ enum ReloadOutcome {
     ReloadedChanged,
     /// Reload was performed and the cached auth remained the same
     ReloadedNoChange,
-    /// Reload was skipped (missing or mismatched account id)
-    Skipped,
+    /// Reload was skipped because the on-disk auth is for a different account/workspace boundary.
+    SkippedDifferentIdentity,
+    /// Reload was skipped because the cached auth lacks enough identity to guard the reload.
+    SkippedUnknownIdentity,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -852,6 +854,7 @@ pub struct UnauthorizedRecovery {
     manager: Arc<AuthManager>,
     step: UnauthorizedRecoveryStep,
     expected_account_id: Option<String>,
+    recovery_auth: Option<CodexAuth>,
     mode: UnauthorizedRecoveryMode,
 }
 
@@ -886,6 +889,7 @@ impl UnauthorizedRecovery {
             manager,
             step,
             expected_account_id,
+            recovery_auth: cached_auth,
             mode,
         }
     }
@@ -958,10 +962,10 @@ impl UnauthorizedRecovery {
 
         match self.step {
             UnauthorizedRecoveryStep::Reload => {
-                match self
-                    .manager
-                    .reload_if_account_id_matches(self.expected_account_id.as_deref())
-                {
+                match self.manager.reload_if_account_id_matches(
+                    self.recovery_auth.as_ref(),
+                    self.expected_account_id.as_deref(),
+                ) {
                     ReloadOutcome::ReloadedChanged => {
                         self.step = UnauthorizedRecoveryStep::RefreshToken;
                         return Ok(UnauthorizedRecoveryStepResult {
@@ -974,7 +978,8 @@ impl UnauthorizedRecovery {
                             auth_state_changed: Some(false),
                         });
                     }
-                    ReloadOutcome::Skipped => {
+                    ReloadOutcome::SkippedDifferentIdentity
+                    | ReloadOutcome::SkippedUnknownIdentity => {
                         self.step = UnauthorizedRecoveryStep::Done;
                         return Err(RefreshTokenError::Permanent(RefreshTokenFailedError::new(
                             RefreshTokenFailedReason::Other,
@@ -1108,36 +1113,100 @@ impl AuthManager {
         self.set_cached_auth(new_auth)
     }
 
-    fn reload_if_account_id_matches(&self, expected_account_id: Option<&str>) -> ReloadOutcome {
+    fn reload_if_account_id_matches(
+        &self,
+        cached_auth: Option<&CodexAuth>,
+        expected_account_id: Option<&str>,
+    ) -> ReloadOutcome {
         let expected_account_id = match expected_account_id {
             Some(account_id) => account_id,
             None => {
                 tracing::info!("Skipping auth reload because no account id is available.");
-                return ReloadOutcome::Skipped;
+                return ReloadOutcome::SkippedUnknownIdentity;
             }
         };
 
         let new_auth = self.load_auth_from_storage();
         let new_account_id = new_auth.as_ref().and_then(CodexAuth::get_account_id);
 
+        if new_account_id.is_none() {
+            tracing::info!(
+                "Skipping auth reload because the on-disk auth does not contain account_id."
+            );
+            return ReloadOutcome::SkippedUnknownIdentity;
+        }
+
         if new_account_id.as_deref() != Some(expected_account_id) {
             let found_account_id = new_account_id.as_deref().unwrap_or("unknown");
             tracing::info!(
                 "Skipping auth reload due to account id mismatch (expected: {expected_account_id}, found: {found_account_id})"
             );
-            return ReloadOutcome::Skipped;
+            return ReloadOutcome::SkippedDifferentIdentity;
+        }
+
+        let cached_user_id = cached_auth.and_then(CodexAuth::get_chatgpt_user_id);
+        let new_user_id = new_auth.as_ref().and_then(CodexAuth::get_chatgpt_user_id);
+        if cached_user_id.is_some() && new_user_id.is_some() && cached_user_id != new_user_id {
+            tracing::info!("Skipping auth reload because chatgpt_user_id changed during refresh.");
+            return ReloadOutcome::SkippedDifferentIdentity;
         }
 
         tracing::info!("Reloading auth for account {expected_account_id}");
-        let cached_before_reload = self.auth_cached();
-        let auth_changed =
-            !Self::auths_equal_for_refresh(cached_before_reload.as_ref(), new_auth.as_ref());
+        let auth_changed = !Self::auths_equal_for_refresh(cached_auth, new_auth.as_ref());
         self.set_cached_auth(new_auth);
         if auth_changed {
             ReloadOutcome::ReloadedChanged
         } else {
             ReloadOutcome::ReloadedNoChange
         }
+    }
+
+    fn reload_for_refresh(&self, cached_auth: &CodexAuth) -> ReloadOutcome {
+        let new_auth = self.load_auth_from_storage();
+
+        if let Some(expected_account_id) = cached_auth.get_account_id() {
+            return self.reload_if_account_id_matches(
+                Some(cached_auth),
+                Some(expected_account_id.as_str()),
+            );
+        }
+
+        let Some(new_auth_ref) = new_auth.as_ref() else {
+            tracing::info!("Skipping auth reload because no auth is available on disk.");
+            return ReloadOutcome::SkippedUnknownIdentity;
+        };
+        if cached_auth.get_chatgpt_user_id().is_none() {
+            tracing::info!(
+                "Skipping guarded auth reload because the cached auth does not contain chatgpt_user_id."
+            );
+            return ReloadOutcome::SkippedUnknownIdentity;
+        }
+        if !Self::same_refresh_identity(cached_auth, new_auth_ref) {
+            tracing::info!(
+                "Skipping auth reload because chatgpt_user_id does not match during refresh."
+            );
+            return ReloadOutcome::SkippedDifferentIdentity;
+        }
+
+        if new_auth_ref.get_account_id().is_some() {
+            tracing::info!(
+                "Reloading auth for matching chatgpt_user_id after account_id appeared on disk."
+            );
+        }
+
+        let auth_changed = !Self::auths_equal_for_refresh(Some(cached_auth), new_auth.as_ref());
+        self.set_cached_auth(new_auth);
+        if auth_changed {
+            ReloadOutcome::ReloadedChanged
+        } else {
+            ReloadOutcome::ReloadedNoChange
+        }
+    }
+
+    fn same_refresh_identity(cached_auth: &CodexAuth, new_auth: &CodexAuth) -> bool {
+        let cached_user_id = cached_auth.get_chatgpt_user_id();
+        let new_user_id = new_auth.get_chatgpt_user_id();
+        cached_user_id.is_some() && cached_user_id == new_user_id
     }
 
     fn auths_equal_for_refresh(a: Option<&CodexAuth>, b: Option<&CodexAuth>) -> bool {
@@ -1256,13 +1325,16 @@ impl AuthManager {
             .as_ref()
             .and_then(CodexAuth::get_account_id);
 
-        match self.reload_if_account_id_matches(expected_account_id.as_deref()) {
+        match self.reload_if_account_id_matches(
+            auth_before_reload.as_ref(),
+            expected_account_id.as_deref(),
+        ) {
             ReloadOutcome::ReloadedChanged => {
                 tracing::info!("Skipping token refresh because auth changed after guarded reload.");
                 Ok(())
             }
             ReloadOutcome::ReloadedNoChange => self.refresh_token_from_authority().await,
-            ReloadOutcome::Skipped => {
+            ReloadOutcome::SkippedDifferentIdentity | ReloadOutcome::SkippedUnknownIdentity => {
                 Err(RefreshTokenError::Permanent(RefreshTokenFailedError::new(
                     RefreshTokenFailedReason::Other,
                     REFRESH_TOKEN_ACCOUNT_MISMATCH_MESSAGE.to_string(),
@@ -1275,6 +1347,9 @@ impl AuthManager {
     /// the token. On success, reloads the auth state from disk so other components
     /// observe refreshed token. If the token refresh fails, returns the error to
     /// the caller.
+    ///
+    /// If the authority reports `refresh_token_reused`, reload local auth once
+    /// more before surfacing relogin.
     pub async fn refresh_token_from_authority(&self) -> Result<(), RefreshTokenError> {
         tracing::info!("Refreshing token");
 
@@ -1287,15 +1362,30 @@ impl AuthManager {
                 self.refresh_external_auth(ExternalAuthRefreshReason::Unauthorized)
                     .await
             }
-            CodexAuth::Chatgpt(chatgpt_auth) => {
+            CodexAuth::Chatgpt(ref chatgpt_auth) => {
                 let token_data = chatgpt_auth.current_token_data().ok_or_else(|| {
                     RefreshTokenError::Transient(std::io::Error::other(
                         "Token data is not available.",
                     ))
                 })?;
-                self.refresh_and_persist_chatgpt_token(&chatgpt_auth, token_data.refresh_token)
-                    .await?;
-                Ok(())
+                match self
+                    .refresh_and_persist_chatgpt_token(chatgpt_auth, token_data.refresh_token)
+                    .await
+                {
+                    Err(RefreshTokenError::Permanent(error))
+                        if error.reason == RefreshTokenFailedReason::Exhausted =>
+                    {
+                        match self.reload_for_refresh(&auth) {
+                            ReloadOutcome::ReloadedChanged => Ok(()),
+                            ReloadOutcome::ReloadedNoChange
+                            | ReloadOutcome::SkippedDifferentIdentity
+                            | ReloadOutcome::SkippedUnknownIdentity => {
+                                Err(RefreshTokenError::Permanent(error))
+                            }
+                        }
+                    }
+                    other => other,
+                }
             }
             CodexAuth::ApiKey(_) => Ok(()),
         }
@@ -1341,8 +1431,27 @@ impl AuthManager {
         if last_refresh >= Utc::now() - chrono::Duration::days(TOKEN_REFRESH_INTERVAL) {
             return Ok(false);
         }
-        self.refresh_and_persist_chatgpt_token(chatgpt_auth, tokens.refresh_token)
-            .await?;
+        match self.reload_for_refresh(auth) {
+            ReloadOutcome::ReloadedChanged => {
+                tracing::info!(
+                    "Skipping token refresh because auth changed after proactive reload."
+                );
+            }
+            ReloadOutcome::ReloadedNoChange => {
+                self.refresh_and_persist_chatgpt_token(chatgpt_auth, tokens.refresh_token)
+                    .await?;
+            }
+            ReloadOutcome::SkippedDifferentIdentity => {
+                tracing::info!(
+                    "Skipping proactive token refresh because on-disk auth moved to another account."
+                );
+                return Ok(false);
+            }
+            ReloadOutcome::SkippedUnknownIdentity => {
+                self.refresh_and_persist_chatgpt_token(chatgpt_auth, tokens.refresh_token)
+                    .await?;
+            }
+        }
         Ok(true)
     }
 


### PR DESCRIPTION
CODEX-5156

###### Summary
- Managed ChatGPT auth now reloads compatible local auth before spending a stale cached refresh token on the normal `auth()` path.
- A `refresh_token_reused` failure now does one final guarded reload before forcing relogin.
- Guarded reload stays pinned to compatible `account_id` and `chatgpt_user_id` when an account boundary is known.
- Legacy auth without `account_id` keeps the old compatibility path instead of being stranded on stale credentials.

###### Rationale (from spec findings)
- The 401 incident spec captured a concrete stale-refresh split-brain cohort: one local client advanced auth while another local session failed with `refresh_token_reused`.
- The old proactive stale path went straight to the token authority and could spend an already-rotated refresh lineage.
- Same-store local auth advancement should not force relogin when newer compatible auth is already available on disk.
- Recovery still has to reject cross-user adoption when another local login changed the user identity inside the same workspace/account.

###### Scope
- Changes `codex-rs/login/src/auth/manager.rs`, `codex-rs/login/src/auth/auth_tests.rs`, and the two cloud-requirements expectations in `codex-rs/cloud-requirements/src/lib.rs`.
- Leaves storage/schema changes, cross-process locking, app-hosted `chatgptAuthTokens`, and cross-device auth divergence unchanged.

###### Trade-offs
- Recovery is limited to same-store local auth changes; it does not solve cases where the newer auth exists only on another machine or another store.
- When cached auth already has `account_id`, reload adoption now requires compatible `account_id` and `chatgpt_user_id` instead of accepting the account boundary alone.
- Unauthorized recovery now evaluates guarded reloads against the auth snapshot that triggered the 401, not mutable cache state.

###### Client follow-up
- Add observability for retained `refresh_token_reused` volume after the same-store race fix.
- Tackle login/bootstrap failures such as `token_exchange_failed` separately.
- Re-evaluate whether any later local refresh serialization is still needed after this resilience pass.

###### Testing
- `cargo test -p codex-login stale_proactive_refresh_uses_newer_local_auth_before_spending_cached_refresh_token -- --nocapture`
- `cargo test -p codex-login stale_proactive_refresh_does_not_adopt_a_different_user_in_same_account -- --nocapture`
- `cargo test -p codex-login stale_proactive_refresh_without_account_id_adopts_auth_with_account_id -- --nocapture`
- `cargo test -p codex-login stale_proactive_refresh_without_identity_claims_still_attempts_refresh -- --nocapture`
- `cargo test -p codex-login unauthorized_recovery_reload_uses_original_auth_snapshot_for_same_account_user_guard -- --nocapture`
- `cargo test -p codex-login refresh_token_reused_recovers_if_guarded_reload_finds_newer_auth -- --nocapture`
- `cargo test -p codex-login refresh_token_reused_without_account_id_adopts_auth_when_disk_auth_gains_account_id -- --nocapture`
- `cargo test -p codex-login --no-run --message-format short`
- `cargo test -p codex-cloud-requirements fetch_cloud_requirements_uses_reloaded_auth_before_unauthorized_retry -- --nocapture`
- `cargo test -p codex-cloud-requirements fetch_cloud_requirements_rejects_different_user_in_same_account -- --nocapture`
- `cargo test -p codex-cloud-requirements --no-run --message-format short`
- `just fmt`
- Manual built-CLI validation in isolated `CODEX_HOME=/tmp/codex-auth-resilience-smoke` using `/Users/ccy/code/codex/codex-rs/target/debug/codex`.
- Manual case 1: started a long-lived session, rewrote `auth.json` stale, restored newer same-user auth on disk, then prompted again in the same session; it succeeded without relogin.
- Manual case 2: repeated the flow with cached auth missing `tokens.account_id`, then restored current same-user auth on disk; the same session still succeeded without relogin.
