### PR TITLE
Make memory model defaults and reasoning efforts configurable

### DIFF
--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -750,9 +750,25 @@
           "description": "Model used for memory consolidation.",
           "type": "string"
         },
+        "consolidation_reasoning_effort": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ReasoningEffort"
+            }
+          ],
+          "description": "Reasoning effort used for memory consolidation."
+        },
         "extract_model": {
           "description": "Model used for thread summarisation.",
           "type": "string"
+        },
+        "extract_reasoning_effort": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ReasoningEffort"
+            }
+          ],
+          "description": "Reasoning effort used for thread summarisation."
         },
         "generate_memories": {
           "description": "When `false`, newly created threads are stored with `memory_mode = \"disabled\"` in the state DB.",

--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -16,6 +16,7 @@ use crate::config_loader::RequirementSource;
 use crate::features::Feature;
 use assert_matches::assert_matches;
 use codex_config::CONFIG_TOML_FILE;
+use codex_protocol::openai_models::ReasoningEffort;
 use codex_protocol::permissions::FileSystemAccessMode;
 use codex_protocol::permissions::FileSystemPath;
 use codex_protocol::permissions::FileSystemSandboxEntry;
@@ -118,7 +119,9 @@ max_rollout_age_days = 42
 max_rollouts_per_startup = 9
 min_rollout_idle_hours = 24
 extract_model = "gpt-5-mini"
+extract_reasoning_effort = "low"
 consolidation_model = "gpt-5"
+consolidation_reasoning_effort = "medium"
 "#;
     let memories_cfg =
         toml::from_str::<ConfigToml>(memories).expect("TOML deserialization should succeed");
@@ -133,7 +136,9 @@ consolidation_model = "gpt-5"
             max_rollouts_per_startup: Some(9),
             min_rollout_idle_hours: Some(24),
             extract_model: Some("gpt-5-mini".to_string()),
+            extract_reasoning_effort: Some(ReasoningEffort::Low),
             consolidation_model: Some("gpt-5".to_string()),
+            consolidation_reasoning_effort: Some(ReasoningEffort::Medium),
         }),
         memories_cfg.memories
     );
@@ -156,7 +161,9 @@ consolidation_model = "gpt-5"
             max_rollouts_per_startup: 9,
             min_rollout_idle_hours: 24,
             extract_model: Some("gpt-5-mini".to_string()),
+            extract_reasoning_effort: Some(ReasoningEffort::Low),
             consolidation_model: Some("gpt-5".to_string()),
+            consolidation_reasoning_effort: Some(ReasoningEffort::Medium),
         }
     );
 }

--- a/codex-rs/core/src/config/types.rs
+++ b/codex-rs/core/src/config/types.rs
@@ -416,8 +416,12 @@ pub struct MemoriesToml {
     pub min_rollout_idle_hours: Option<i64>,
     /// Model used for thread summarisation.
     pub extract_model: Option<String>,
+    /// Reasoning effort used for thread summarisation.
+    pub extract_reasoning_effort: Option<codex_protocol::openai_models::ReasoningEffort>,
     /// Model used for memory consolidation.
     pub consolidation_model: Option<String>,
+    /// Reasoning effort used for memory consolidation.
+    pub consolidation_reasoning_effort: Option<codex_protocol::openai_models::ReasoningEffort>,
 }
 
 /// Effective memories settings after defaults are applied.
@@ -432,7 +436,9 @@ pub struct MemoriesConfig {
     pub max_rollouts_per_startup: usize,
     pub min_rollout_idle_hours: i64,
     pub extract_model: Option<String>,
+    pub extract_reasoning_effort: Option<codex_protocol::openai_models::ReasoningEffort>,
     pub consolidation_model: Option<String>,
+    pub consolidation_reasoning_effort: Option<codex_protocol::openai_models::ReasoningEffort>,
 }
 
 impl Default for MemoriesConfig {
@@ -447,7 +453,9 @@ impl Default for MemoriesConfig {
             max_rollouts_per_startup: DEFAULT_MEMORIES_MAX_ROLLOUTS_PER_STARTUP,
             min_rollout_idle_hours: DEFAULT_MEMORIES_MIN_ROLLOUT_IDLE_HOURS,
             extract_model: None,
+            extract_reasoning_effort: None,
             consolidation_model: None,
+            consolidation_reasoning_effort: None,
         }
     }
 }
@@ -482,7 +490,9 @@ impl From<MemoriesToml> for MemoriesConfig {
                 .unwrap_or(defaults.min_rollout_idle_hours)
                 .clamp(1, 48),
             extract_model: toml.extract_model,
+            extract_reasoning_effort: toml.extract_reasoning_effort,
             consolidation_model: toml.consolidation_model,
+            consolidation_reasoning_effort: toml.consolidation_reasoning_effort,
         }
     }
 }

--- a/codex-rs/core/src/memories/mod.rs
+++ b/codex-rs/core/src/memories/mod.rs
@@ -32,7 +32,7 @@ mod artifacts {
 /// Phase 1 (startup extraction).
 mod phase_one {
     /// Default model used for phase 1.
-    pub(super) const MODEL: &str = "gpt-5.1-codex-mini";
+    pub(super) const MODEL: &str = "gpt-5.4-mini";
     /// Default reasoning effort used for phase 1.
     pub(super) const REASONING_EFFORT: super::ReasoningEffort = super::ReasoningEffort::Low;
     /// Prompt used for phase 1.
@@ -64,7 +64,7 @@ mod phase_one {
 /// Phase 2 (aka `Consolidation`).
 mod phase_two {
     /// Default model used for phase 2.
-    pub(super) const MODEL: &str = "gpt-5.3-codex";
+    pub(super) const MODEL: &str = "gpt-5.4";
     /// Default reasoning effort used for phase 2.
     pub(super) const REASONING_EFFORT: super::ReasoningEffort = super::ReasoningEffort::Medium;
     /// Lease duration (seconds) for phase-2 consolidation job ownership.

--- a/codex-rs/core/src/memories/phase1.rs
+++ b/codex-rs/core/src/memories/phase1.rs
@@ -170,7 +170,11 @@ impl RequestContext {
             model_info,
             turn_metadata_header,
             session_telemetry: turn_context.session_telemetry.clone(),
-            reasoning_effort: Some(phase_one::REASONING_EFFORT),
+            reasoning_effort: turn_context
+                .config
+                .memories
+                .extract_reasoning_effort
+                .or(Some(phase_one::REASONING_EFFORT)),
             reasoning_summary: turn_context.reasoning_summary,
             service_tier: turn_context.config.service_tier,
         }

--- a/codex-rs/core/src/memories/phase2.rs
+++ b/codex-rs/core/src/memories/phase2.rs
@@ -306,7 +306,10 @@ mod agent {
                 .clone()
                 .unwrap_or(phase_two::MODEL.to_string()),
         );
-        agent_config.model_reasoning_effort = Some(phase_two::REASONING_EFFORT);
+        agent_config.model_reasoning_effort = config
+            .memories
+            .consolidation_reasoning_effort
+            .or(Some(phase_two::REASONING_EFFORT));
 
         Some(agent_config)
     }

--- a/codex-rs/exec-server/src/server/filesystem.rs
+++ b/codex-rs/exec-server/src/server/filesystem.rs
@@ -36,7 +36,7 @@ pub(crate) struct ExecServerFileSystem {
 impl Default for ExecServerFileSystem {
     fn default() -> Self {
         Self {
-            file_system: Arc::new(Environment.get_filesystem()),
+            file_system: Arc::new(Environment::default().get_filesystem()),
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `memories.extract_reasoning_effort` and `memories.consolidation_reasoning_effort`
- switch default memory models to `gpt-5.4-mini` for extraction and `gpt-5.4` for consolidation
- thread the new reasoning-effort config through memory phase 1 and phase 2
- update `config.schema.json`
- include the one-line `exec-server` fix needed to unblock schema generation

## Verification
- `just write-config-schema`
- `just fmt`
- `cargo test -p codex-core test_toml_parsing -- --nocapture`
- `cargo test -p codex-core` reached unrelated existing failures in `suite::cli_stream::*` and `suite::code_mode::*` after the memory/config path had already compiled and the unit suite had passed
