### PR TITLE
Preserve outer styles on visible OSC-8 destinations

### DIFF
--- a/codex-rs/tui/src/markdown_render.rs
+++ b/codex-rs/tui/src/markdown_render.rs
@@ -611,10 +611,16 @@ where
         if let Some(link) = self.link.take() {
             if link.show_destination {
                 self.pop_inline_style();
+                let destination_style = self
+                    .inline_styles
+                    .last()
+                    .copied()
+                    .unwrap_or_default()
+                    .patch(self.styles.link_destination);
                 self.push_span(" (".into());
                 self.push_span(Span::styled(
                     osc8_hyperlink(&link.destination, &link.destination),
-                    self.styles.link_destination,
+                    destination_style,
                 ));
                 self.push_span(")".into());
             } else if let Some(local_target_display) = link.local_target_display {

--- a/codex-rs/tui/src/markdown_render_tests.rs
+++ b/codex-rs/tui/src/markdown_render_tests.rs
@@ -812,6 +812,25 @@ fn url_link_with_inline_code_is_clickable() {
 }
 
 #[test]
+fn nested_styled_url_link_preserves_destination_outer_style() {
+    let text = render_markdown_text("***[docs](https://example.com/docs)***");
+    let expected = Text::from(Line::from_iter([
+        osc8_hyperlink("https://example.com/docs", "docs")
+            .bold()
+            .italic()
+            .underlined(),
+        " (".into(),
+        osc8_hyperlink("https://example.com/docs", "https://example.com/docs")
+            .bold()
+            .italic()
+            .cyan()
+            .underlined(),
+        ")".into(),
+    ]));
+    assert_eq!(text, expected);
+}
+
+#[test]
 fn url_link_sanitizes_control_chars() {
     assert_eq!(
         osc8_hyperlink("https://example.com/\u{1b}]8;;\u{07}injected", "unsafe"),

--- a/codex-rs/tui_app_server/src/markdown_render.rs
+++ b/codex-rs/tui_app_server/src/markdown_render.rs
@@ -611,10 +611,16 @@ where
         if let Some(link) = self.link.take() {
             if link.show_destination {
                 self.pop_inline_style();
+                let destination_style = self
+                    .inline_styles
+                    .last()
+                    .copied()
+                    .unwrap_or_default()
+                    .patch(self.styles.link_destination);
                 self.push_span(" (".into());
                 self.push_span(Span::styled(
                     osc8_hyperlink(&link.destination, &link.destination),
-                    self.styles.link_destination,
+                    destination_style,
                 ));
                 self.push_span(")".into());
             } else if let Some(local_target_display) = link.local_target_display {

--- a/codex-rs/tui_app_server/src/markdown_render_tests.rs
+++ b/codex-rs/tui_app_server/src/markdown_render_tests.rs
@@ -812,6 +812,25 @@ fn url_link_with_inline_code_is_clickable() {
 }
 
 #[test]
+fn nested_styled_url_link_preserves_destination_outer_style() {
+    let text = render_markdown_text("***[docs](https://example.com/docs)***");
+    let expected = Text::from(Line::from_iter([
+        osc8_hyperlink("https://example.com/docs", "docs")
+            .bold()
+            .italic()
+            .underlined(),
+        " (".into(),
+        osc8_hyperlink("https://example.com/docs", "https://example.com/docs")
+            .bold()
+            .italic()
+            .cyan()
+            .underlined(),
+        ")".into(),
+    ]));
+    assert_eq!(text, expected);
+}
+
+#[test]
 fn url_link_sanitizes_control_chars() {
     assert_eq!(
         osc8_hyperlink("https://example.com/\u{1b}]8;;\u{07}injected", "unsafe"),


### PR DESCRIPTION
## Summary
- compose the appended visible URL style over the remaining inline style stack after popping the link-label style
- add a nested strong+emphasis markdown regression in both TUI renderers

## Validation
- `just fmt`
- `cargo test -p codex-tui markdown_render::markdown_render_tests::nested_styled_url_link_preserves_destination_outer_style -- --exact`
- `cargo test -p codex-tui-app-server markdown_render::markdown_render_tests::nested_styled_url_link_preserves_destination_outer_style -- --exact`

Stacked on #15200.