### PR TITLE
Add mixed ASCII and OSC-8 span coverage

### DIFF
--- a/codex-rs/tui/src/line_truncation.rs
+++ b/codex-rs/tui/src/line_truncation.rs
@@ -154,6 +154,28 @@ mod tests {
     }
 
     #[test]
+    fn truncate_line_to_width_preserves_osc8_between_ascii_spans() {
+        let line = Line::from(vec![
+            "A".into(),
+            Span::from(osc8_hyperlink("https://example.com/docs", "BC"))
+                .cyan()
+                .underlined(),
+            "DE".into(),
+        ]);
+
+        let truncated = truncate_line_to_width(line, 4);
+
+        let expected = Line::from(vec![
+            "A".into(),
+            Span::from(osc8_hyperlink("https://example.com/docs", "BC"))
+                .cyan()
+                .underlined(),
+            "D".into(),
+        ]);
+        assert_eq!(truncated, expected);
+    }
+
+    #[test]
     fn truncate_line_with_ellipsis_if_overflow_preserves_osc8_wrapped_prefix() {
         let line = Line::from(vec![
             "See ".into(),

--- a/codex-rs/tui/src/markdown_render_tests.rs
+++ b/codex-rs/tui/src/markdown_render_tests.rs
@@ -9,7 +9,9 @@ use crate::markdown_render::COLON_LOCATION_SUFFIX_RE;
 use crate::markdown_render::HASH_LOCATION_SUFFIX_RE;
 use crate::markdown_render::render_markdown_text;
 use crate::markdown_render::render_markdown_text_with_width_and_cwd;
+use crate::osc8::ParsedOsc8;
 use crate::osc8::osc8_hyperlink;
+use crate::osc8::parse_osc8_hyperlink;
 use crate::osc8::strip_osc8_hyperlinks;
 use insta::assert_snapshot;
 
@@ -828,6 +830,36 @@ fn nested_styled_url_link_preserves_destination_outer_style() {
         ")".into(),
     ]));
     assert_eq!(text, expected);
+}
+
+#[test]
+fn wrapped_url_link_label_stays_clickable_across_lines() {
+    let text = render_markdown_text_with_width_and_cwd(
+        "[abcdefgh](https://example.com/docs)",
+        Some(4),
+        None,
+    );
+
+    let wrapped_label_lines = text.lines.iter().take(3).cloned().collect::<Vec<_>>();
+    let expected = vec![
+        Line::from(osc8_hyperlink("https://example.com/docs", "abc").underlined()),
+        Line::from(osc8_hyperlink("https://example.com/docs", "def").underlined()),
+        Line::from(osc8_hyperlink("https://example.com/docs", "gh").underlined()),
+    ];
+    assert_eq!(wrapped_label_lines, expected);
+
+    let first = text.lines[0]
+        .spans
+        .iter()
+        .map(|span| span.content.as_ref())
+        .collect::<String>();
+    assert_eq!(
+        parse_osc8_hyperlink(&first),
+        Some(ParsedOsc8 {
+            destination: "https://example.com/docs",
+            text: "abc",
+        })
+    );
 }
 
 #[test]

--- a/codex-rs/tui/src/wrapping.rs
+++ b/codex-rs/tui/src/wrapping.rs
@@ -1035,6 +1035,30 @@ mod tests {
     }
 
     #[test]
+    fn mixed_ascii_and_osc8_wrapped_spans_preserve_ratatui_spans_across_wraps() {
+        let url = "https://example.com/docs";
+        let line = Line::from(vec![
+            "ab".into(),
+            osc8_hyperlink(url, "cdef").cyan().underlined(),
+            "gh".into(),
+        ]);
+
+        let out = word_wrap_line(&line, 4);
+
+        let expected = vec![
+            Line::from(vec![
+                "ab".into(),
+                osc8_hyperlink(url, "cd").cyan().underlined(),
+            ]),
+            Line::from(vec![
+                osc8_hyperlink(url, "ef").cyan().underlined(),
+                "gh".into(),
+            ]),
+        ];
+        assert_eq!(out, expected);
+    }
+
+    #[test]
     fn leading_spaces_preserved_on_first_line() {
         let line = Line::from("   hello");
         let out = word_wrap_line(&line, 8);

--- a/codex-rs/tui_app_server/src/line_truncation.rs
+++ b/codex-rs/tui_app_server/src/line_truncation.rs
@@ -154,6 +154,28 @@ mod tests {
     }
 
     #[test]
+    fn truncate_line_to_width_preserves_osc8_between_ascii_spans() {
+        let line = Line::from(vec![
+            "A".into(),
+            Span::from(osc8_hyperlink("https://example.com/docs", "BC"))
+                .cyan()
+                .underlined(),
+            "DE".into(),
+        ]);
+
+        let truncated = truncate_line_to_width(line, 4);
+
+        let expected = Line::from(vec![
+            "A".into(),
+            Span::from(osc8_hyperlink("https://example.com/docs", "BC"))
+                .cyan()
+                .underlined(),
+            "D".into(),
+        ]);
+        assert_eq!(truncated, expected);
+    }
+
+    #[test]
     fn truncate_line_with_ellipsis_if_overflow_preserves_osc8_wrapped_prefix() {
         let line = Line::from(vec![
             "See ".into(),

--- a/codex-rs/tui_app_server/src/markdown_render_tests.rs
+++ b/codex-rs/tui_app_server/src/markdown_render_tests.rs
@@ -9,7 +9,9 @@ use crate::markdown_render::COLON_LOCATION_SUFFIX_RE;
 use crate::markdown_render::HASH_LOCATION_SUFFIX_RE;
 use crate::markdown_render::render_markdown_text;
 use crate::markdown_render::render_markdown_text_with_width_and_cwd;
+use crate::osc8::ParsedOsc8;
 use crate::osc8::osc8_hyperlink;
+use crate::osc8::parse_osc8_hyperlink;
 use crate::osc8::strip_osc8_hyperlinks;
 use insta::assert_snapshot;
 
@@ -828,6 +830,36 @@ fn nested_styled_url_link_preserves_destination_outer_style() {
         ")".into(),
     ]));
     assert_eq!(text, expected);
+}
+
+#[test]
+fn wrapped_url_link_label_stays_clickable_across_lines() {
+    let text = render_markdown_text_with_width_and_cwd(
+        "[abcdefgh](https://example.com/docs)",
+        Some(4),
+        None,
+    );
+
+    let wrapped_label_lines = text.lines.iter().take(3).cloned().collect::<Vec<_>>();
+    let expected = vec![
+        Line::from(osc8_hyperlink("https://example.com/docs", "abc").underlined()),
+        Line::from(osc8_hyperlink("https://example.com/docs", "def").underlined()),
+        Line::from(osc8_hyperlink("https://example.com/docs", "gh").underlined()),
+    ];
+    assert_eq!(wrapped_label_lines, expected);
+
+    let first = text.lines[0]
+        .spans
+        .iter()
+        .map(|span| span.content.as_ref())
+        .collect::<String>();
+    assert_eq!(
+        parse_osc8_hyperlink(&first),
+        Some(ParsedOsc8 {
+            destination: "https://example.com/docs",
+            text: "abc",
+        })
+    );
 }
 
 #[test]

--- a/codex-rs/tui_app_server/src/wrapping.rs
+++ b/codex-rs/tui_app_server/src/wrapping.rs
@@ -1035,6 +1035,30 @@ mod tests {
     }
 
     #[test]
+    fn mixed_ascii_and_osc8_wrapped_spans_preserve_ratatui_spans_across_wraps() {
+        let url = "https://example.com/docs";
+        let line = Line::from(vec![
+            "ab".into(),
+            osc8_hyperlink(url, "cdef").cyan().underlined(),
+            "gh".into(),
+        ]);
+
+        let out = word_wrap_line(&line, 4);
+
+        let expected = vec![
+            Line::from(vec![
+                "ab".into(),
+                osc8_hyperlink(url, "cd").cyan().underlined(),
+            ]),
+            Line::from(vec![
+                osc8_hyperlink(url, "ef").cyan().underlined(),
+                "gh".into(),
+            ]),
+        ];
+        assert_eq!(out, expected);
+    }
+
+    #[test]
     fn leading_spaces_preserved_on_first_line() {
         let line = Line::from("   hello");
         let out = word_wrap_line(&line, 8);


### PR DESCRIPTION
## Summary
- add exact mixed ASCII + OSC-8 truncation coverage in both TUI crates
- add exact mixed ASCII + OSC-8 wrapping coverage in both TUI crates

## Validation
- `just fmt`
- `cargo test -p codex-tui line_truncation::tests::truncate_line_to_width_preserves_osc8_between_ascii_spans -- --exact`
- `cargo test -p codex-tui wrapping::tests::mixed_ascii_and_osc8_wrapped_spans_preserve_ratatui_spans_across_wraps -- --exact`
- `cargo test -p codex-tui-app-server line_truncation::tests::truncate_line_to_width_preserves_osc8_between_ascii_spans -- --exact`
- `cargo test -p codex-tui-app-server wrapping::tests::mixed_ascii_and_osc8_wrapped_spans_preserve_ratatui_spans_across_wraps -- --exact`
- `cargo test -p codex-tui`
- `cargo test -p codex-tui-app-server`

Stacked on the destination-style PR.