### PR TITLE
Render markdown links as OSC-8 in TUI

### DIFF
--- a/codex-rs/tui/src/markdown_render.rs
+++ b/codex-rs/tui/src/markdown_render.rs
@@ -5,6 +5,7 @@
 //! transcripts show the real file target (including normalized location suffixes) and can shorten
 //! absolute paths relative to a known working directory.
 
+use crate::osc8::osc8_hyperlink;
 use crate::render::highlight::highlight_code_to_lines;
 use crate::render::line_utils::line_to_static;
 use crate::wrapping::RtOptions;
@@ -42,7 +43,8 @@ struct MarkdownStyles {
     strikethrough: Style,
     ordered_list_marker: Style,
     unordered_list_marker: Style,
-    link: Style,
+    link_label: Style,
+    link_destination: Style,
     blockquote: Style,
 }
 
@@ -63,7 +65,8 @@ impl Default for MarkdownStyles {
             strikethrough: Style::new().crossed_out(),
             ordered_list_marker: Style::new().light_blue(),
             unordered_list_marker: Style::new(),
-            link: Style::new().cyan().underlined(),
+            link_label: Style::new().underlined(),
+            link_destination: Style::new().cyan().underlined(),
             blockquote: Style::new().green(),
         }
     }
@@ -272,7 +275,12 @@ where
             Tag::Emphasis => self.push_inline_style(self.styles.emphasis),
             Tag::Strong => self.push_inline_style(self.styles.strong),
             Tag::Strikethrough => self.push_inline_style(self.styles.strikethrough),
-            Tag::Link { dest_url, .. } => self.push_link(dest_url.to_string()),
+            Tag::Link { dest_url, .. } => {
+                self.push_link(dest_url.to_string());
+                if self.remote_link_destination().is_some() {
+                    self.push_inline_style(self.styles.link_label);
+                }
+            }
             Tag::HtmlBlock
             | Tag::FootnoteDefinition(_)
             | Tag::Table(_)
@@ -407,7 +415,7 @@ where
             if i > 0 {
                 self.push_line(Line::default());
             }
-            let content = line.to_string();
+            let content = self.maybe_wrap_remote_link_text(line);
             let span = Span::styled(
                 content,
                 self.inline_styles.last().copied().unwrap_or_default(),
@@ -426,7 +434,13 @@ where
             self.push_line(Line::default());
             self.pending_marker_line = false;
         }
-        let span = Span::from(code.into_string()).style(self.styles.code);
+        let style = self
+            .inline_styles
+            .last()
+            .copied()
+            .unwrap_or_default()
+            .patch(self.styles.code);
+        let span = Span::from(self.maybe_wrap_remote_link_text(code.as_ref())).style(style);
         self.push_span(span);
     }
 
@@ -445,7 +459,7 @@ where
                 self.push_line(Line::default());
             }
             let style = self.inline_styles.last().copied().unwrap_or_default();
-            self.push_span(Span::styled(line.to_string(), style));
+            self.push_span(Span::styled(self.maybe_wrap_remote_link_text(line), style));
         }
         self.needs_newline = !inline;
     }
@@ -596,8 +610,18 @@ where
     fn pop_link(&mut self) {
         if let Some(link) = self.link.take() {
             if link.show_destination {
+                self.pop_inline_style();
+                let destination_style = self
+                    .inline_styles
+                    .last()
+                    .copied()
+                    .unwrap_or_default()
+                    .patch(self.styles.link_destination);
                 self.push_span(" (".into());
-                self.push_span(Span::styled(link.destination, self.styles.link));
+                self.push_span(Span::styled(
+                    osc8_hyperlink(&link.destination, &link.destination),
+                    destination_style,
+                ));
                 self.push_span(")".into());
             } else if let Some(local_target_display) = link.local_target_display {
                 if self.pending_marker_line {
@@ -615,6 +639,20 @@ where
                 self.line_ends_with_local_link_target = true;
             }
         }
+    }
+
+    fn remote_link_destination(&self) -> Option<&str> {
+        self.link
+            .as_ref()
+            .filter(|link| link.show_destination)
+            .map(|link| link.destination.as_str())
+    }
+
+    fn maybe_wrap_remote_link_text(&self, text: &str) -> String {
+        self.remote_link_destination().map_or_else(
+            || text.to_string(),
+            |destination| osc8_hyperlink(destination, text),
+        )
     }
 
     fn suppressing_local_link_label(&self) -> bool {

--- a/codex-rs/tui/src/markdown_render_tests.rs
+++ b/codex-rs/tui/src/markdown_render_tests.rs
@@ -9,6 +9,10 @@ use crate::markdown_render::COLON_LOCATION_SUFFIX_RE;
 use crate::markdown_render::HASH_LOCATION_SUFFIX_RE;
 use crate::markdown_render::render_markdown_text;
 use crate::markdown_render::render_markdown_text_with_width_and_cwd;
+use crate::osc8::ParsedOsc8;
+use crate::osc8::osc8_hyperlink;
+use crate::osc8::parse_osc8_hyperlink;
+use crate::osc8::strip_osc8_hyperlinks;
 use insta::assert_snapshot;
 
 fn render_markdown_text_for_cwd(input: &str, cwd: &Path) -> Text<'static> {
@@ -651,9 +655,12 @@ fn strong_emphasis() {
 fn link() {
     let text = render_markdown_text("[Link](https://example.com)");
     let expected = Text::from(Line::from_iter([
-        "Link".into(),
+        osc8_hyperlink("https://example.com", "Link")
+            .underlined(),
         " (".into(),
-        "https://example.com".cyan().underlined(),
+        osc8_hyperlink("https://example.com", "https://example.com")
+            .cyan()
+            .underlined(),
         ")".into(),
     ]));
     assert_eq!(text, expected);
@@ -776,15 +783,91 @@ fn file_link_uses_target_path_for_hash_range() {
 }
 
 #[test]
-fn url_link_shows_destination() {
+fn url_link_renders_clickable_label_with_destination() {
     let text = render_markdown_text("[docs](https://example.com/docs)");
     let expected = Text::from(Line::from_iter([
-        "docs".into(),
+        osc8_hyperlink("https://example.com/docs", "docs")
+            .underlined(),
         " (".into(),
-        "https://example.com/docs".cyan().underlined(),
+        osc8_hyperlink("https://example.com/docs", "https://example.com/docs")
+            .cyan()
+            .underlined(),
         ")".into(),
     ]));
     assert_eq!(text, expected);
+}
+
+#[test]
+fn url_link_with_inline_code_is_clickable() {
+    let text = render_markdown_text("[`docs`](https://example.com/docs)");
+    let expected = Text::from(Line::from_iter([
+        osc8_hyperlink("https://example.com/docs", "docs")
+            .cyan()
+            .underlined(),
+        " (".into(),
+        osc8_hyperlink("https://example.com/docs", "https://example.com/docs")
+            .cyan()
+            .underlined(),
+        ")".into(),
+    ]));
+    assert_eq!(text, expected);
+}
+
+#[test]
+fn nested_styled_url_link_preserves_destination_outer_style() {
+    let text = render_markdown_text("***[docs](https://example.com/docs)***");
+    let expected = Text::from(Line::from_iter([
+        osc8_hyperlink("https://example.com/docs", "docs")
+            .bold()
+            .italic()
+            .underlined(),
+        " (".into(),
+        osc8_hyperlink("https://example.com/docs", "https://example.com/docs")
+            .bold()
+            .italic()
+            .cyan()
+            .underlined(),
+        ")".into(),
+    ]));
+    assert_eq!(text, expected);
+}
+
+#[test]
+fn wrapped_url_link_label_stays_clickable_across_lines() {
+    let text = render_markdown_text_with_width_and_cwd(
+        "[abcdefgh](https://example.com/docs)",
+        Some(4),
+        None,
+    );
+
+    let wrapped_label_lines = text.lines.iter().take(3).cloned().collect::<Vec<_>>();
+    let expected = vec![
+        Line::from(osc8_hyperlink("https://example.com/docs", "abc").underlined()),
+        Line::from(osc8_hyperlink("https://example.com/docs", "def").underlined()),
+        Line::from(osc8_hyperlink("https://example.com/docs", "gh").underlined()),
+    ];
+    assert_eq!(wrapped_label_lines, expected);
+
+    let first = text.lines[0]
+        .spans
+        .iter()
+        .map(|span| span.content.as_ref())
+        .collect::<String>();
+    assert_eq!(
+        parse_osc8_hyperlink(&first),
+        Some(ParsedOsc8 {
+            destination: "https://example.com/docs",
+            text: "abc",
+        })
+    );
+}
+
+#[test]
+fn url_link_sanitizes_control_chars() {
+    assert_eq!(
+        osc8_hyperlink("https://example.com/\u{1b}]8;;\u{07}injected", "unsafe"),
+        "\u{1b}]8;;https://example.com/]8;;injected\u{7}unsafe\u{1b}]8;;\u{7}"
+    );
 }
 
 #[test]
@@ -797,10 +880,12 @@ fn markdown_render_file_link_snapshot() {
         .lines
         .iter()
         .map(|l| {
-            l.spans
+            let line = l
+                .spans
                 .iter()
                 .map(|s| s.content.clone())
-                .collect::<String>()
+                .collect::<String>();
+            strip_osc8_hyperlinks(&line)
         })
         .collect::<Vec<_>>()
         .join("\n");
@@ -819,10 +904,12 @@ fn unordered_list_local_file_link_stays_inline_with_following_text() {
         .lines
         .iter()
         .map(|line| {
-            line.spans
+            let rendered = line
+                .spans
                 .iter()
                 .map(|span| span.content.as_ref())
-                .collect::<String>()
+                .collect::<String>();
+            strip_osc8_hyperlinks(&rendered)
         })
         .collect::<Vec<_>>();
     assert_eq!(
@@ -1161,10 +1248,12 @@ URL with parentheses: [link](https://example.com/path_(with)_parens).
         .lines
         .iter()
         .map(|l| {
-            l.spans
+            let line = l
+                .spans
                 .iter()
                 .map(|s| s.content.clone())
-                .collect::<String>()
+                .collect::<String>();
+            strip_osc8_hyperlinks(&line)
         })
         .collect::<Vec<_>>()
         .join("\n");

--- a/codex-rs/tui_app_server/src/markdown_render.rs
+++ b/codex-rs/tui_app_server/src/markdown_render.rs
@@ -5,6 +5,7 @@
 //! transcripts show the real file target (including normalized location suffixes) and can shorten
 //! absolute paths relative to a known working directory.
 
+use crate::osc8::osc8_hyperlink;
 use crate::render::highlight::highlight_code_to_lines;
 use crate::render::line_utils::line_to_static;
 use crate::wrapping::RtOptions;
@@ -42,7 +43,8 @@ struct MarkdownStyles {
     strikethrough: Style,
     ordered_list_marker: Style,
     unordered_list_marker: Style,
-    link: Style,
+    link_label: Style,
+    link_destination: Style,
     blockquote: Style,
 }
 
@@ -63,7 +65,8 @@ impl Default for MarkdownStyles {
             strikethrough: Style::new().crossed_out(),
             ordered_list_marker: Style::new().light_blue(),
             unordered_list_marker: Style::new(),
-            link: Style::new().cyan().underlined(),
+            link_label: Style::new().underlined(),
+            link_destination: Style::new().cyan().underlined(),
             blockquote: Style::new().green(),
         }
     }
@@ -272,7 +275,12 @@ where
             Tag::Emphasis => self.push_inline_style(self.styles.emphasis),
             Tag::Strong => self.push_inline_style(self.styles.strong),
             Tag::Strikethrough => self.push_inline_style(self.styles.strikethrough),
-            Tag::Link { dest_url, .. } => self.push_link(dest_url.to_string()),
+            Tag::Link { dest_url, .. } => {
+                self.push_link(dest_url.to_string());
+                if self.remote_link_destination().is_some() {
+                    self.push_inline_style(self.styles.link_label);
+                }
+            }
             Tag::HtmlBlock
             | Tag::FootnoteDefinition(_)
             | Tag::Table(_)
@@ -407,7 +415,7 @@ where
             if i > 0 {
                 self.push_line(Line::default());
             }
-            let content = line.to_string();
+            let content = self.maybe_wrap_remote_link_text(line);
             let span = Span::styled(
                 content,
                 self.inline_styles.last().copied().unwrap_or_default(),
@@ -426,7 +434,13 @@ where
             self.push_line(Line::default());
             self.pending_marker_line = false;
         }
-        let span = Span::from(code.into_string()).style(self.styles.code);
+        let style = self
+            .inline_styles
+            .last()
+            .copied()
+            .unwrap_or_default()
+            .patch(self.styles.code);
+        let span = Span::from(self.maybe_wrap_remote_link_text(code.as_ref())).style(style);
         self.push_span(span);
     }
 
@@ -445,7 +459,7 @@ where
                 self.push_line(Line::default());
             }
             let style = self.inline_styles.last().copied().unwrap_or_default();
-            self.push_span(Span::styled(line.to_string(), style));
+            self.push_span(Span::styled(self.maybe_wrap_remote_link_text(line), style));
         }
         self.needs_newline = !inline;
     }
@@ -596,8 +610,18 @@ where
     fn pop_link(&mut self) {
         if let Some(link) = self.link.take() {
             if link.show_destination {
+                self.pop_inline_style();
+                let destination_style = self
+                    .inline_styles
+                    .last()
+                    .copied()
+                    .unwrap_or_default()
+                    .patch(self.styles.link_destination);
                 self.push_span(" (".into());
-                self.push_span(Span::styled(link.destination, self.styles.link));
+                self.push_span(Span::styled(
+                    osc8_hyperlink(&link.destination, &link.destination),
+                    destination_style,
+                ));
                 self.push_span(")".into());
             } else if let Some(local_target_display) = link.local_target_display {
                 if self.pending_marker_line {
@@ -615,6 +639,20 @@ where
                 self.line_ends_with_local_link_target = true;
             }
         }
+    }
+
+    fn remote_link_destination(&self) -> Option<&str> {
+        self.link
+            .as_ref()
+            .filter(|link| link.show_destination)
+            .map(|link| link.destination.as_str())
+    }
+
+    fn maybe_wrap_remote_link_text(&self, text: &str) -> String {
+        self.remote_link_destination().map_or_else(
+            || text.to_string(),
+            |destination| osc8_hyperlink(destination, text),
+        )
     }
 
     fn suppressing_local_link_label(&self) -> bool {

--- a/codex-rs/tui_app_server/src/markdown_render_tests.rs
+++ b/codex-rs/tui_app_server/src/markdown_render_tests.rs
@@ -9,6 +9,10 @@ use crate::markdown_render::COLON_LOCATION_SUFFIX_RE;
 use crate::markdown_render::HASH_LOCATION_SUFFIX_RE;
 use crate::markdown_render::render_markdown_text;
 use crate::markdown_render::render_markdown_text_with_width_and_cwd;
+use crate::osc8::ParsedOsc8;
+use crate::osc8::osc8_hyperlink;
+use crate::osc8::parse_osc8_hyperlink;
+use crate::osc8::strip_osc8_hyperlinks;
 use insta::assert_snapshot;
 
 fn render_markdown_text_for_cwd(input: &str, cwd: &Path) -> Text<'static> {
@@ -651,9 +655,12 @@ fn strong_emphasis() {
 fn link() {
     let text = render_markdown_text("[Link](https://example.com)");
     let expected = Text::from(Line::from_iter([
-        "Link".into(),
+        osc8_hyperlink("https://example.com", "Link")
+            .underlined(),
         " (".into(),
-        "https://example.com".cyan().underlined(),
+        osc8_hyperlink("https://example.com", "https://example.com")
+            .cyan()
+            .underlined(),
         ")".into(),
     ]));
     assert_eq!(text, expected);
@@ -776,15 +783,91 @@ fn file_link_uses_target_path_for_hash_range() {
 }
 
 #[test]
-fn url_link_shows_destination() {
+fn url_link_renders_clickable_label_with_destination() {
     let text = render_markdown_text("[docs](https://example.com/docs)");
     let expected = Text::from(Line::from_iter([
-        "docs".into(),
+        osc8_hyperlink("https://example.com/docs", "docs")
+            .underlined(),
         " (".into(),
-        "https://example.com/docs".cyan().underlined(),
+        osc8_hyperlink("https://example.com/docs", "https://example.com/docs")
+            .cyan()
+            .underlined(),
         ")".into(),
     ]));
     assert_eq!(text, expected);
+}
+
+#[test]
+fn url_link_with_inline_code_is_clickable() {
+    let text = render_markdown_text("[`docs`](https://example.com/docs)");
+    let expected = Text::from(Line::from_iter([
+        osc8_hyperlink("https://example.com/docs", "docs")
+            .cyan()
+            .underlined(),
+        " (".into(),
+        osc8_hyperlink("https://example.com/docs", "https://example.com/docs")
+            .cyan()
+            .underlined(),
+        ")".into(),
+    ]));
+    assert_eq!(text, expected);
+}
+
+#[test]
+fn nested_styled_url_link_preserves_destination_outer_style() {
+    let text = render_markdown_text("***[docs](https://example.com/docs)***");
+    let expected = Text::from(Line::from_iter([
+        osc8_hyperlink("https://example.com/docs", "docs")
+            .bold()
+            .italic()
+            .underlined(),
+        " (".into(),
+        osc8_hyperlink("https://example.com/docs", "https://example.com/docs")
+            .bold()
+            .italic()
+            .cyan()
+            .underlined(),
+        ")".into(),
+    ]));
+    assert_eq!(text, expected);
+}
+
+#[test]
+fn wrapped_url_link_label_stays_clickable_across_lines() {
+    let text = render_markdown_text_with_width_and_cwd(
+        "[abcdefgh](https://example.com/docs)",
+        Some(4),
+        None,
+    );
+
+    let wrapped_label_lines = text.lines.iter().take(3).cloned().collect::<Vec<_>>();
+    let expected = vec![
+        Line::from(osc8_hyperlink("https://example.com/docs", "abc").underlined()),
+        Line::from(osc8_hyperlink("https://example.com/docs", "def").underlined()),
+        Line::from(osc8_hyperlink("https://example.com/docs", "gh").underlined()),
+    ];
+    assert_eq!(wrapped_label_lines, expected);
+
+    let first = text.lines[0]
+        .spans
+        .iter()
+        .map(|span| span.content.as_ref())
+        .collect::<String>();
+    assert_eq!(
+        parse_osc8_hyperlink(&first),
+        Some(ParsedOsc8 {
+            destination: "https://example.com/docs",
+            text: "abc",
+        })
+    );
+}
+
+#[test]
+fn url_link_sanitizes_control_chars() {
+    assert_eq!(
+        osc8_hyperlink("https://example.com/\u{1b}]8;;\u{07}injected", "unsafe"),
+        "\u{1b}]8;;https://example.com/]8;;injected\u{7}unsafe\u{1b}]8;;\u{7}"
+    );
 }
 
 #[test]
@@ -797,10 +880,12 @@ fn markdown_render_file_link_snapshot() {
         .lines
         .iter()
         .map(|l| {
-            l.spans
+            let line = l
+                .spans
                 .iter()
                 .map(|s| s.content.clone())
-                .collect::<String>()
+                .collect::<String>();
+            strip_osc8_hyperlinks(&line)
         })
         .collect::<Vec<_>>()
         .join("\n");
@@ -819,10 +904,12 @@ fn unordered_list_local_file_link_stays_inline_with_following_text() {
         .lines
         .iter()
         .map(|line| {
-            line.spans
+            let rendered = line
+                .spans
                 .iter()
                 .map(|span| span.content.as_ref())
-                .collect::<String>()
+                .collect::<String>();
+            strip_osc8_hyperlinks(&rendered)
         })
         .collect::<Vec<_>>();
     assert_eq!(
@@ -1161,10 +1248,12 @@ URL with parentheses: [link](https://example.com/path_(with)_parens).
         .lines
         .iter()
         .map(|l| {
-            l.spans
+            let line = l
+                .spans
                 .iter()
                 .map(|s| s.content.clone())
-                .collect::<String>()
+                .collect::<String>();
+            strip_osc8_hyperlinks(&line)
         })
         .collect::<Vec<_>>()
         .join("\n");


### PR DESCRIPTION
## Summary
- render remote markdown link labels as OSC-8 hyperlinks
- wrap the appended visible destination URL in OSC-8 too
- keep destination styling distinct from label styling and preserve outer inline styles on the visible URL
- add markdown renderer regressions, including wrapped label repro coverage

## Validation
- `just fmt`
- `CARGO_TARGET_DIR=/tmp/codex-target-osc8-clean cargo test -p codex-tui markdown_render::markdown_render_tests::wrapped_url_link_label_stays_clickable_across_lines -- --exact`

Stacked on the size-handling precursor.
