### PR TITLE
Disable hooks on windows for now

### DIFF
--- a/codex-rs/hooks/src/engine/mod.rs
+++ b/codex-rs/hooks/src/engine/mod.rs
@@ -74,6 +74,17 @@ impl ClaudeHooksEngine {
             };
         }
 
+        if cfg!(windows) {
+            return Self {
+                handlers: Vec::new(),
+                warnings: vec![
+                    "Disabled `codex_hooks` for this session because `hooks.json` lifecycle hooks are not supported on Windows yet."
+                        .to_string(),
+                ],
+                shell,
+            };
+        }
+
         let _ = schema_loader::generated_hook_schemas();
         let discovered = discovery::discover_handlers(config_layer_stack);
         Self {


### PR DESCRIPTION
We'll verify a bit later that all of this works correctly and re-enable