### PR TITLE
Label plugins as plugins, and hide skills/apps for given plugin

### DIFF
--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -3575,24 +3575,6 @@ impl ChatComposer {
 
     fn mention_items(&self) -> Vec<MentionItem> {
         let mut mentions = Vec::new();
-        let plugin_namespaces: HashSet<String> =
-            self.plugins.as_ref().map_or_else(HashSet::new, |plugins| {
-                plugins
-                    .iter()
-                    .filter_map(|plugin| {
-                        let (plugin_name, _) = plugin
-                            .config_name
-                            .split_once('@')
-                            .unwrap_or((plugin.config_name.as_str(), ""));
-                        let plugin_name = plugin_name.trim();
-                        if plugin_name.is_empty() {
-                            None
-                        } else {
-                            Some(plugin_name.to_ascii_lowercase())
-                        }
-                    })
-                    .collect()
-            });
         let plugin_display_names: HashSet<String> =
             self.plugins.as_ref().map_or_else(HashSet::new, |plugins| {
                 plugins
@@ -3603,13 +3585,6 @@ impl ChatComposer {
 
         if let Some(skills) = self.skills.as_ref() {
             for skill in skills {
-                let is_plugin_namespaced_skill =
-                    skill.name.split_once(':').is_some_and(|(namespace, _)| {
-                        plugin_namespaces.contains(&namespace.to_ascii_lowercase())
-                    });
-                if is_plugin_namespaced_skill {
-                    continue;
-                }
                 let display_name = skill_display_name(skill).to_string();
                 let description = skill_description(skill);
                 let skill_name = skill.name.clone();
@@ -5419,7 +5394,7 @@ mod tests {
     }
 
     #[test]
-    fn mention_items_hide_plugin_owned_skill_and_app_duplicates() {
+    fn mention_items_keep_plugin_owned_skills_but_hide_duplicate_apps() {
         let (tx, _rx) = unbounded_channel::<AppEvent>();
         let sender = AppEventSender::new(tx);
         let mut composer = ChatComposer::new(
@@ -5481,13 +5456,27 @@ mod tests {
             }],
         }));
 
-        let mentions = composer.mention_items();
-        assert_eq!(mentions.len(), 1);
-        assert_eq!(mentions[0].display_name, "Google Calendar".to_string());
-        assert_eq!(mentions[0].category_tag, Some("[Plugin]".to_string()));
+        let mut mention_summaries: Vec<_> = composer
+            .mention_items()
+            .into_iter()
+            .map(|mention| (mention.display_name, mention.category_tag, mention.path))
+            .collect();
+        mention_summaries.sort();
+
         assert_eq!(
-            mentions[0].path,
-            Some("plugin://google-calendar@debug".to_string())
+            mention_summaries,
+            vec![
+                (
+                    "Google Calendar".to_string(),
+                    Some("[Plugin]".to_string()),
+                    Some("plugin://google-calendar@debug".to_string()),
+                ),
+                (
+                    "Google Calendar".to_string(),
+                    Some("[Skill]".to_string()),
+                    Some("/tmp/repo/google-calendar/SKILL.md".to_string()),
+                ),
+            ]
         );
     }
 

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -3575,9 +3575,41 @@ impl ChatComposer {
 
     fn mention_items(&self) -> Vec<MentionItem> {
         let mut mentions = Vec::new();
+        let plugin_namespaces: HashSet<String> =
+            self.plugins.as_ref().map_or_else(HashSet::new, |plugins| {
+                plugins
+                    .iter()
+                    .filter_map(|plugin| {
+                        let (plugin_name, _) = plugin
+                            .config_name
+                            .split_once('@')
+                            .unwrap_or((plugin.config_name.as_str(), ""));
+                        let plugin_name = plugin_name.trim();
+                        if plugin_name.is_empty() {
+                            None
+                        } else {
+                            Some(plugin_name.to_ascii_lowercase())
+                        }
+                    })
+                    .collect()
+            });
+        let plugin_display_names: HashSet<String> =
+            self.plugins.as_ref().map_or_else(HashSet::new, |plugins| {
+                plugins
+                    .iter()
+                    .map(|plugin| plugin.display_name.to_ascii_lowercase())
+                    .collect()
+            });
 
         if let Some(skills) = self.skills.as_ref() {
             for skill in skills {
+                let is_plugin_namespaced_skill =
+                    skill.name.split_once(':').is_some_and(|(namespace, _)| {
+                        plugin_namespaces.contains(&namespace.to_ascii_lowercase())
+                    });
+                if is_plugin_namespaced_skill {
+                    continue;
+                }
                 let display_name = skill_display_name(skill).to_string();
                 let description = skill_description(skill);
                 let skill_name = skill.name.clone();
@@ -3657,18 +3689,30 @@ impl ChatComposer {
                 if !connector.is_accessible || !connector.is_enabled {
                     continue;
                 }
+                let plugin_backed_connector = connector
+                    .plugin_display_names
+                    .iter()
+                    .any(|name| plugin_display_names.contains(&name.to_ascii_lowercase()));
+                if plugin_backed_connector {
+                    continue;
+                }
                 let display_name = connectors::connector_display_label(connector);
                 let description = Some(Self::connector_brief_description(connector));
                 let slug = codex_core::connectors::connector_mention_slug(connector);
                 let search_terms = vec![display_name.clone(), connector.id.clone(), slug.clone()];
                 let connector_id = connector.id.as_str();
+                let category_tag = if connector.plugin_display_names.is_empty() {
+                    "[App]".to_string()
+                } else {
+                    "[Plugin]".to_string()
+                };
                 mentions.push(MentionItem {
                     display_name: display_name.clone(),
                     description,
                     insert_text: format!("${slug}"),
                     search_terms,
                     path: Some(format!("app://{connector_id}")),
-                    category_tag: Some("[App]".to_string()),
+                    category_tag: Some(category_tag),
                     sort_rank: 1,
                 });
             }
@@ -5372,6 +5416,79 @@ mod tests {
             .expect("expected plugin mention to be selected");
         assert_eq!(mention.insert_text, "$sample".to_string());
         assert_eq!(mention.path, Some("plugin://sample@test".to_string()));
+    }
+
+    #[test]
+    fn mention_items_hide_plugin_owned_skill_and_app_duplicates() {
+        let (tx, _rx) = unbounded_channel::<AppEvent>();
+        let sender = AppEventSender::new(tx);
+        let mut composer = ChatComposer::new(
+            true,
+            sender,
+            false,
+            "Ask Codex to do anything".to_string(),
+            false,
+        );
+        composer.set_connectors_enabled(true);
+        composer.set_text_content("$goog".to_string(), Vec::new(), Vec::new());
+        composer.set_skill_mentions(Some(vec![SkillMetadata {
+            name: "google-calendar:availability".to_string(),
+            description: "Find availability and plan event changes".to_string(),
+            short_description: None,
+            interface: Some(codex_core::skills::model::SkillInterface {
+                display_name: Some("Google Calendar".to_string()),
+                short_description: None,
+                icon_small: None,
+                icon_large: None,
+                brand_color: None,
+                default_prompt: None,
+            }),
+            dependencies: None,
+            policy: None,
+            permission_profile: None,
+            managed_network_override: None,
+            path_to_skills_md: PathBuf::from("/tmp/repo/google-calendar/SKILL.md"),
+            scope: codex_protocol::protocol::SkillScope::Repo,
+        }]));
+        composer.set_plugin_mentions(Some(vec![PluginCapabilitySummary {
+            config_name: "google-calendar@debug".to_string(),
+            display_name: "Google Calendar".to_string(),
+            description: Some(
+                "Connect Google Calendar for scheduling, availability, and event management."
+                    .to_string(),
+            ),
+            has_skills: true,
+            mcp_server_names: vec!["google-calendar".to_string()],
+            app_connector_ids: vec![codex_core::plugins::AppConnectorId(
+                "google_calendar".to_string(),
+            )],
+        }]));
+        composer.set_connector_mentions(Some(ConnectorsSnapshot {
+            connectors: vec![AppInfo {
+                id: "google_calendar".to_string(),
+                name: "Google Calendar".to_string(),
+                description: Some("Look up events and availability".to_string()),
+                logo_url: None,
+                logo_url_dark: None,
+                distribution_channel: None,
+                branding: None,
+                app_metadata: None,
+                labels: None,
+                install_url: Some("https://example.test/google-calendar".to_string()),
+                is_accessible: true,
+                is_enabled: true,
+                plugin_display_names: vec!["Google Calendar".to_string()],
+            }],
+        }));
+
+        let mentions = composer.mention_items();
+        assert_eq!(mentions.len(), 1);
+        assert_eq!(mentions[0].display_name, "Google Calendar".to_string());
+        assert_eq!(mentions[0].category_tag, Some("[Plugin]".to_string()));
+        assert_eq!(
+            mentions[0].path,
+            Some("plugin://google-calendar@debug".to_string())
+        );
     }
 
     #[test]

--- a/codex-rs/tui/src/bottom_pane/file_search_popup.rs
+++ b/codex-rs/tui/src/bottom_pane/file_search_popup.rs
@@ -70,7 +70,7 @@ impl FileSearchPopup {
         }
 
         self.display_query = query.to_string();
-        self.matches = matches;
+        self.matches = matches.into_iter().take(MAX_POPUP_ROWS).collect();
         self.waiting = false;
         let len = self.matches.len();
         self.state.clamp_selection(len);
@@ -150,5 +150,35 @@ impl WidgetRef for &FileSearchPopup {
             MAX_POPUP_ROWS,
             empty_message,
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codex_file_search::MatchType;
+    use pretty_assertions::assert_eq;
+
+    fn file_match(index: usize) -> FileMatch {
+        FileMatch {
+            score: index as u32,
+            path: PathBuf::from(format!("src/file_{index:02}.rs")),
+            match_type: MatchType::File,
+            root: PathBuf::from("/tmp/repo"),
+            indices: None,
+        }
+    }
+
+    #[test]
+    fn set_matches_keeps_only_the_first_page_of_results() {
+        let mut popup = FileSearchPopup::new();
+        popup.set_query("file");
+        popup.set_matches("file", (0..(MAX_POPUP_ROWS + 2)).map(file_match).collect());
+
+        assert_eq!(
+            popup.matches,
+            (0..MAX_POPUP_ROWS).map(file_match).collect::<Vec<_>>()
+        );
+        assert_eq!(popup.calculate_required_height(), MAX_POPUP_ROWS as u16);
     }
 }

--- a/codex-rs/tui/src/bottom_pane/skill_popup.rs
+++ b/codex-rs/tui/src/bottom_pane/skill_popup.rs
@@ -180,6 +180,7 @@ impl SkillPopup {
                 })
         });
 
+        out.truncate(MAX_POPUP_ROWS);
         out
     }
 }
@@ -228,4 +229,44 @@ fn skill_popup_hint_line() -> Line<'static> {
         key_hint::plain(KeyCode::Esc).into(),
         " to close".into(),
     ])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    fn mention_item(index: usize) -> MentionItem {
+        MentionItem {
+            display_name: format!("Mention {index:02}"),
+            description: Some(format!("Description {index:02}")),
+            insert_text: format!("$mention-{index:02}"),
+            search_terms: vec![format!("mention-{index:02}")],
+            path: Some(format!("skill://mention-{index:02}")),
+            category_tag: Some("[Skill]".to_string()),
+            sort_rank: 1,
+        }
+    }
+
+    #[test]
+    fn filtered_mentions_are_capped_to_max_popup_rows() {
+        let popup = SkillPopup::new((0..(MAX_POPUP_ROWS + 2)).map(mention_item).collect());
+
+        let filtered_names: Vec<String> = popup
+            .filtered_items()
+            .into_iter()
+            .map(|idx| popup.mentions[idx].display_name.clone())
+            .collect();
+
+        assert_eq!(
+            filtered_names,
+            (0..MAX_POPUP_ROWS)
+                .map(|idx| format!("Mention {idx:02}"))
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            popup.calculate_required_height(72),
+            (MAX_POPUP_ROWS as u16) + 2
+        );
+    }
 }

--- a/codex-rs/tui_app_server/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui_app_server/src/bottom_pane/chat_composer.rs
@@ -3590,24 +3590,6 @@ impl ChatComposer {
 
     fn mention_items(&self) -> Vec<MentionItem> {
         let mut mentions = Vec::new();
-        let plugin_namespaces: HashSet<String> =
-            self.plugins.as_ref().map_or_else(HashSet::new, |plugins| {
-                plugins
-                    .iter()
-                    .filter_map(|plugin| {
-                        let (plugin_name, _) = plugin
-                            .config_name
-                            .split_once('@')
-                            .unwrap_or((plugin.config_name.as_str(), ""));
-                        let plugin_name = plugin_name.trim();
-                        if plugin_name.is_empty() {
-                            None
-                        } else {
-                            Some(plugin_name.to_ascii_lowercase())
-                        }
-                    })
-                    .collect()
-            });
         let plugin_display_names: HashSet<String> =
             self.plugins.as_ref().map_or_else(HashSet::new, |plugins| {
                 plugins
@@ -3618,13 +3600,6 @@ impl ChatComposer {
 
         if let Some(skills) = self.skills.as_ref() {
             for skill in skills {
-                let is_plugin_namespaced_skill =
-                    skill.name.split_once(':').is_some_and(|(namespace, _)| {
-                        plugin_namespaces.contains(&namespace.to_ascii_lowercase())
-                    });
-                if is_plugin_namespaced_skill {
-                    continue;
-                }
                 let display_name = skill_display_name(skill).to_string();
                 let description = skill_description(skill);
                 let skill_name = skill.name.clone();
@@ -5431,6 +5406,93 @@ mod tests {
             .expect("expected plugin mention to be selected");
         assert_eq!(mention.insert_text, "$sample".to_string());
         assert_eq!(mention.path, Some("plugin://sample@test".to_string()));
+    }
+
+    #[test]
+    fn mention_items_keep_plugin_owned_skills_but_hide_duplicate_apps() {
+        let (tx, _rx) = unbounded_channel::<AppEvent>();
+        let sender = AppEventSender::new(tx);
+        let mut composer = ChatComposer::new(
+            true,
+            sender,
+            false,
+            "Ask Codex to do anything".to_string(),
+            false,
+        );
+        composer.set_connectors_enabled(true);
+        composer.set_text_content("$goog".to_string(), Vec::new(), Vec::new());
+        composer.set_skill_mentions(Some(vec![SkillMetadata {
+            name: "google-calendar:availability".to_string(),
+            description: "Find availability and plan event changes".to_string(),
+            short_description: None,
+            interface: Some(codex_core::skills::model::SkillInterface {
+                display_name: Some("Google Calendar".to_string()),
+                short_description: None,
+                icon_small: None,
+                icon_large: None,
+                brand_color: None,
+                default_prompt: None,
+            }),
+            dependencies: None,
+            policy: None,
+            permission_profile: None,
+            managed_network_override: None,
+            path_to_skills_md: PathBuf::from("/tmp/repo/google-calendar/SKILL.md"),
+            scope: codex_protocol::protocol::SkillScope::Repo,
+        }]));
+        composer.set_plugin_mentions(Some(vec![PluginCapabilitySummary {
+            config_name: "google-calendar@debug".to_string(),
+            display_name: "Google Calendar".to_string(),
+            description: Some(
+                "Connect Google Calendar for scheduling, availability, and event management."
+                    .to_string(),
+            ),
+            has_skills: true,
+            mcp_server_names: vec!["google-calendar".to_string()],
+            app_connector_ids: vec![codex_core::plugins::AppConnectorId(
+                "google_calendar".to_string(),
+            )],
+        }]));
+        composer.set_connector_mentions(Some(ConnectorsSnapshot {
+            connectors: vec![AppInfo {
+                id: "google_calendar".to_string(),
+                name: "Google Calendar".to_string(),
+                description: Some("Look up events and availability".to_string()),
+                logo_url: None,
+                logo_url_dark: None,
+                distribution_channel: None,
+                branding: None,
+                app_metadata: None,
+                labels: None,
+                install_url: Some("https://example.test/google-calendar".to_string()),
+                is_accessible: true,
+                is_enabled: true,
+                plugin_display_names: vec!["Google Calendar".to_string()],
+            }],
+        }));
+
+        let mut mention_summaries: Vec<_> = composer
+            .mention_items()
+            .into_iter()
+            .map(|mention| (mention.display_name, mention.category_tag, mention.path))
+            .collect();
+        mention_summaries.sort();
+
+        assert_eq!(
+            mention_summaries,
+            vec![
+                (
+                    "Google Calendar".to_string(),
+                    Some("[Plugin]".to_string()),
+                    Some("plugin://google-calendar@debug".to_string()),
+                ),
+                (
+                    "Google Calendar".to_string(),
+                    Some("[Skill]".to_string()),
+                    Some("/tmp/repo/google-calendar/SKILL.md".to_string()),
+                ),
+            ]
+        );
     }
 
     #[test]

--- a/codex-rs/tui_app_server/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui_app_server/src/bottom_pane/chat_composer.rs
@@ -3590,9 +3590,41 @@ impl ChatComposer {
 
     fn mention_items(&self) -> Vec<MentionItem> {
         let mut mentions = Vec::new();
+        let plugin_namespaces: HashSet<String> =
+            self.plugins.as_ref().map_or_else(HashSet::new, |plugins| {
+                plugins
+                    .iter()
+                    .filter_map(|plugin| {
+                        let (plugin_name, _) = plugin
+                            .config_name
+                            .split_once('@')
+                            .unwrap_or((plugin.config_name.as_str(), ""));
+                        let plugin_name = plugin_name.trim();
+                        if plugin_name.is_empty() {
+                            None
+                        } else {
+                            Some(plugin_name.to_ascii_lowercase())
+                        }
+                    })
+                    .collect()
+            });
+        let plugin_display_names: HashSet<String> =
+            self.plugins.as_ref().map_or_else(HashSet::new, |plugins| {
+                plugins
+                    .iter()
+                    .map(|plugin| plugin.display_name.to_ascii_lowercase())
+                    .collect()
+            });
 
         if let Some(skills) = self.skills.as_ref() {
             for skill in skills {
+                let is_plugin_namespaced_skill =
+                    skill.name.split_once(':').is_some_and(|(namespace, _)| {
+                        plugin_namespaces.contains(&namespace.to_ascii_lowercase())
+                    });
+                if is_plugin_namespaced_skill {
+                    continue;
+                }
                 let display_name = skill_display_name(skill).to_string();
                 let description = skill_description(skill);
                 let skill_name = skill.name.clone();
@@ -3672,18 +3704,30 @@ impl ChatComposer {
                 if !connector.is_accessible || !connector.is_enabled {
                     continue;
                 }
+                let plugin_backed_connector = connector
+                    .plugin_display_names
+                    .iter()
+                    .any(|name| plugin_display_names.contains(&name.to_ascii_lowercase()));
+                if plugin_backed_connector {
+                    continue;
+                }
                 let display_name = connectors::connector_display_label(connector);
                 let description = Some(Self::connector_brief_description(connector));
                 let slug = codex_core::connectors::connector_mention_slug(connector);
                 let search_terms = vec![display_name.clone(), connector.id.clone(), slug.clone()];
                 let connector_id = connector.id.as_str();
+                let category_tag = if connector.plugin_display_names.is_empty() {
+                    "[App]".to_string()
+                } else {
+                    "[Plugin]".to_string()
+                };
                 mentions.push(MentionItem {
                     display_name: display_name.clone(),
                     description,
                     insert_text: format!("${slug}"),
                     search_terms,
                     path: Some(format!("app://{connector_id}")),
-                    category_tag: Some("[App]".to_string()),
+                    category_tag: Some(category_tag),
                     sort_rank: 1,
                 });
             }

--- a/codex-rs/tui_app_server/src/bottom_pane/file_search_popup.rs
+++ b/codex-rs/tui_app_server/src/bottom_pane/file_search_popup.rs
@@ -70,7 +70,7 @@ impl FileSearchPopup {
         }
 
         self.display_query = query.to_string();
-        self.matches = matches;
+        self.matches = matches.into_iter().take(MAX_POPUP_ROWS).collect();
         self.waiting = false;
         let len = self.matches.len();
         self.state.clamp_selection(len);
@@ -150,5 +150,35 @@ impl WidgetRef for &FileSearchPopup {
             MAX_POPUP_ROWS,
             empty_message,
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codex_file_search::MatchType;
+    use pretty_assertions::assert_eq;
+
+    fn file_match(index: usize) -> FileMatch {
+        FileMatch {
+            score: index as u32,
+            path: PathBuf::from(format!("src/file_{index:02}.rs")),
+            match_type: MatchType::File,
+            root: PathBuf::from("/tmp/repo"),
+            indices: None,
+        }
+    }
+
+    #[test]
+    fn set_matches_keeps_only_the_first_page_of_results() {
+        let mut popup = FileSearchPopup::new();
+        popup.set_query("file");
+        popup.set_matches("file", (0..(MAX_POPUP_ROWS + 2)).map(file_match).collect());
+
+        assert_eq!(
+            popup.matches,
+            (0..MAX_POPUP_ROWS).map(file_match).collect::<Vec<_>>()
+        );
+        assert_eq!(popup.calculate_required_height(), MAX_POPUP_ROWS as u16);
     }
 }

--- a/codex-rs/tui_app_server/src/bottom_pane/skill_popup.rs
+++ b/codex-rs/tui_app_server/src/bottom_pane/skill_popup.rs
@@ -180,6 +180,7 @@ impl SkillPopup {
                 })
         });
 
+        out.truncate(MAX_POPUP_ROWS);
         out
     }
 }
@@ -228,4 +229,44 @@ fn skill_popup_hint_line() -> Line<'static> {
         key_hint::plain(KeyCode::Esc).into(),
         " to close".into(),
     ])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    fn mention_item(index: usize) -> MentionItem {
+        MentionItem {
+            display_name: format!("Mention {index:02}"),
+            description: Some(format!("Description {index:02}")),
+            insert_text: format!("$mention-{index:02}"),
+            search_terms: vec![format!("mention-{index:02}")],
+            path: Some(format!("skill://mention-{index:02}")),
+            category_tag: Some("[Skill]".to_string()),
+            sort_rank: 1,
+        }
+    }
+
+    #[test]
+    fn filtered_mentions_are_capped_to_max_popup_rows() {
+        let popup = SkillPopup::new((0..(MAX_POPUP_ROWS + 2)).map(mention_item).collect());
+
+        let filtered_names: Vec<String> = popup
+            .filtered_items()
+            .into_iter()
+            .map(|idx| popup.mentions[idx].display_name.clone())
+            .collect();
+
+        assert_eq!(
+            filtered_names,
+            (0..MAX_POPUP_ROWS)
+                .map(|idx| format!("Mention {idx:02}"))
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            popup.calculate_required_height(72),
+            (MAX_POPUP_ROWS as u16) + 2
+        );
+    }
 }


### PR DESCRIPTION
- Duplicate app mentions are now suppressed when they’re plugin-backed with the same display name.
- Remaining connector mentions now label category as [Plugin] when plugin metadata is present, otherwise [App].
- Mention result lists are now capped to 8 rows after filtering.
- Updates both tui and tui_app_server with the same changes.