### PR TITLE
Add recall slash command

### DIFF
--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -17,6 +17,7 @@ mod client_common;
 pub mod codex;
 mod realtime_context;
 mod realtime_conversation;
+pub mod recall;
 pub use codex::SteerInputError;
 mod codex_thread;
 mod compact_remote;

--- a/codex-rs/core/src/recall.rs
+++ b/codex-rs/core/src/recall.rs
@@ -1,0 +1,316 @@
+use std::collections::HashSet;
+use std::io;
+use std::path::PathBuf;
+
+use bm25::Document;
+use bm25::Language;
+use bm25::SearchEngineBuilder;
+use codex_protocol::ThreadId;
+use codex_protocol::items::TurnItem;
+use codex_protocol::protocol::InitialHistory;
+use codex_protocol::protocol::RolloutItem;
+
+use crate::INTERACTIVE_SESSION_SOURCES;
+use crate::RolloutRecorder;
+use crate::config::Config;
+use crate::content_items_to_text;
+use crate::find_thread_names_by_ids;
+use crate::parse_turn_item;
+use crate::rollout::list::Cursor;
+use crate::rollout::list::ThreadItem;
+use crate::rollout::list::ThreadSortKey;
+
+const RECALL_PAGE_SIZE: usize = 128;
+const RECALL_SNIPPET_MAX_CHARS: usize = 240;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SessionRecallHit {
+    pub thread_id: ThreadId,
+    pub score: f32,
+    pub thread_name: Option<String>,
+    pub path: PathBuf,
+    pub created_at: Option<String>,
+    pub updated_at: Option<String>,
+    pub cwd: Option<PathBuf>,
+    pub snippet: String,
+}
+
+pub async fn search_sessions(
+    config: &Config,
+    query: &str,
+    current_thread_id: Option<ThreadId>,
+    limit: usize,
+) -> io::Result<Vec<SessionRecallHit>> {
+    let query = query.trim();
+    if query.is_empty() || limit == 0 {
+        return Ok(Vec::new());
+    }
+
+    let mut items = list_all_threads(config, /*archived*/ false).await?;
+    items.extend(list_all_threads(config, /*archived*/ true).await?);
+
+    let thread_ids = items
+        .iter()
+        .filter_map(|item| item.thread_id)
+        .filter(|thread_id| Some(*thread_id) != current_thread_id)
+        .collect::<HashSet<_>>();
+    let thread_names = find_thread_names_by_ids(&config.codex_home, &thread_ids)
+        .await
+        .unwrap_or_default();
+
+    let mut entries = Vec::new();
+    for item in items {
+        let Some(thread_id) = item.thread_id else {
+            continue;
+        };
+        if Some(thread_id) == current_thread_id {
+            continue;
+        }
+        let Ok(history) = RolloutRecorder::get_rollout_history(item.path.as_path()).await else {
+            continue;
+        };
+
+        let transcript = transcript_text(&history);
+        let thread_name = thread_names.get(&thread_id).cloned();
+        let search_text = build_search_text(&item, thread_name.as_deref(), &transcript);
+        if search_text.trim().is_empty() {
+            continue;
+        }
+        let snippet = select_snippet(query, &transcript, &item, thread_name.as_deref());
+        entries.push((item, thread_id, thread_name, snippet, search_text));
+    }
+
+    if entries.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let documents = entries
+        .iter()
+        .enumerate()
+        .map(|(idx, (_, _, _, _, search_text))| Document::new(idx, search_text.clone()))
+        .collect::<Vec<_>>();
+    let search_engine =
+        SearchEngineBuilder::<usize>::with_documents(Language::English, documents).build();
+
+    Ok(search_engine
+        .search(query, limit)
+        .into_iter()
+        .filter_map(|result| {
+            entries
+                .get(result.document.id)
+                .map(
+                    |(item, thread_id, thread_name, snippet, _)| SessionRecallHit {
+                        thread_id: *thread_id,
+                        score: result.score,
+                        thread_name: thread_name.clone(),
+                        path: item.path.clone(),
+                        created_at: item.created_at.clone(),
+                        updated_at: item.updated_at.clone(),
+                        cwd: item.cwd.clone(),
+                        snippet: snippet.clone(),
+                    },
+                )
+        })
+        .collect())
+}
+
+pub fn format_recall_draft(query: &str, hits: &[SessionRecallHit]) -> String {
+    let mut draft = format!("Recalled context from previous Codex sessions for query: {query}\n\n");
+
+    for (index, hit) in hits.iter().enumerate() {
+        let title = hit
+            .thread_name
+            .as_deref()
+            .filter(|name| !name.trim().is_empty())
+            .unwrap_or(hit.snippet.as_str());
+        let updated_at = hit.updated_at.as_deref().or(hit.created_at.as_deref());
+        let cwd = hit
+            .cwd
+            .as_ref()
+            .map(|cwd| cwd.display().to_string())
+            .unwrap_or_else(|| "unknown cwd".to_string());
+        let updated_line = updated_at
+            .map(|updated_at| format!("Updated: {updated_at}\n"))
+            .unwrap_or_default();
+
+        draft.push_str(&format!(
+            "{}. {title}\nThread: {}\n{}Cwd: {cwd}\nRollout: {}\nExcerpt: {}\n\n",
+            index + 1,
+            hit.thread_id,
+            updated_line,
+            hit.path.display(),
+            hit.snippet
+        ));
+    }
+
+    draft.push_str("Use this recalled context if it is relevant to my next message.");
+    draft
+}
+
+async fn list_all_threads(config: &Config, archived: bool) -> io::Result<Vec<ThreadItem>> {
+    let mut items = Vec::new();
+    let mut cursor: Option<Cursor> = None;
+
+    loop {
+        let page = if archived {
+            RolloutRecorder::list_archived_threads(
+                config,
+                RECALL_PAGE_SIZE,
+                cursor.as_ref(),
+                ThreadSortKey::UpdatedAt,
+                INTERACTIVE_SESSION_SOURCES.as_slice(),
+                /*model_providers*/ None,
+                &config.model_provider_id,
+                /*search_term*/ None,
+            )
+            .await?
+        } else {
+            RolloutRecorder::list_threads(
+                config,
+                RECALL_PAGE_SIZE,
+                cursor.as_ref(),
+                ThreadSortKey::UpdatedAt,
+                INTERACTIVE_SESSION_SOURCES.as_slice(),
+                /*model_providers*/ None,
+                &config.model_provider_id,
+                /*search_term*/ None,
+            )
+            .await?
+        };
+
+        items.extend(page.items);
+        let Some(next_cursor) = page.next_cursor else {
+            break;
+        };
+        cursor = Some(next_cursor);
+    }
+
+    Ok(items)
+}
+
+fn transcript_text(history: &InitialHistory) -> String {
+    history
+        .get_rollout_items()
+        .into_iter()
+        .filter_map(|item| match item {
+            RolloutItem::ResponseItem(response_item) => match parse_turn_item(&response_item) {
+                Some(TurnItem::UserMessage(user)) => {
+                    let message = user.message();
+                    (!message.trim().is_empty()).then_some(message)
+                }
+                Some(TurnItem::AgentMessage(agent)) => {
+                    let text = agent
+                        .content
+                        .into_iter()
+                        .map(|content| match content {
+                            codex_protocol::items::AgentMessageContent::Text { text } => text,
+                        })
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    (!text.trim().is_empty()).then_some(text)
+                }
+                Some(TurnItem::Plan(plan)) => {
+                    let text = plan.text;
+                    (!text.trim().is_empty()).then_some(text)
+                }
+                _ => match response_item {
+                    codex_protocol::models::ResponseItem::Message { content, .. } => {
+                        content_items_to_text(&content).filter(|text| !text.trim().is_empty())
+                    }
+                    _ => None,
+                },
+            },
+            RolloutItem::EventMsg(ev) => match ev {
+                codex_protocol::protocol::EventMsg::UserMessage(user) => {
+                    let message = user.message;
+                    (!message.trim().is_empty()).then_some(message)
+                }
+                _ => None,
+            },
+            RolloutItem::SessionMeta(_)
+            | RolloutItem::TurnContext(_)
+            | RolloutItem::Compacted(_) => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+fn build_search_text(item: &ThreadItem, thread_name: Option<&str>, transcript: &str) -> String {
+    let mut parts = Vec::new();
+    if let Some(thread_name) = thread_name
+        && !thread_name.trim().is_empty()
+    {
+        parts.push(thread_name.to_string());
+    }
+    if let Some(message) = item.first_user_message.as_deref()
+        && !message.trim().is_empty()
+    {
+        parts.push(message.to_string());
+    }
+    if let Some(cwd) = item.cwd.as_ref() {
+        parts.push(cwd.display().to_string());
+    }
+    if let Some(branch) = item.git_branch.as_deref()
+        && !branch.trim().is_empty()
+    {
+        parts.push(branch.to_string());
+    }
+    if !transcript.trim().is_empty() {
+        parts.push(transcript.to_string());
+    }
+    parts.join("\n\n")
+}
+
+fn select_snippet(
+    query: &str,
+    transcript: &str,
+    item: &ThreadItem,
+    thread_name: Option<&str>,
+) -> String {
+    let terms = query_terms(query);
+    let candidate = transcript
+        .lines()
+        .map(str::trim)
+        .find(|line| {
+            !line.is_empty()
+                && terms
+                    .iter()
+                    .any(|term| line.to_ascii_lowercase().contains(term.as_str()))
+        })
+        .or_else(|| {
+            transcript
+                .lines()
+                .map(str::trim)
+                .find(|line| !line.is_empty())
+        })
+        .or(item.first_user_message.as_deref())
+        .or(thread_name)
+        .unwrap_or("No text excerpt available.");
+
+    truncate_snippet(candidate)
+}
+
+fn query_terms(query: &str) -> Vec<String> {
+    query
+        .to_ascii_lowercase()
+        .split(|ch: char| !ch.is_alphanumeric())
+        .filter(|term| !term.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn truncate_snippet(text: &str) -> String {
+    let mut out = String::new();
+    for (idx, ch) in text.chars().enumerate() {
+        if idx == RECALL_SNIPPET_MAX_CHARS {
+            out.push_str("...");
+            return out;
+        }
+        out.push(ch);
+    }
+    out
+}
+
+#[cfg(test)]
+#[path = "recall_tests.rs"]
+mod tests;

--- a/codex-rs/core/src/recall_tests.rs
+++ b/codex-rs/core/src/recall_tests.rs
@@ -1,0 +1,164 @@
+use std::fs::File;
+use std::io::Write;
+
+use codex_protocol::ThreadId;
+use codex_protocol::models::ContentItem;
+use codex_protocol::models::ResponseItem;
+use codex_protocol::protocol::EventMsg;
+use codex_protocol::protocol::RolloutItem;
+use codex_protocol::protocol::RolloutLine;
+use codex_protocol::protocol::SessionMeta;
+use codex_protocol::protocol::SessionMetaLine;
+use codex_protocol::protocol::SessionSource;
+use codex_protocol::protocol::UserMessageEvent;
+use pretty_assertions::assert_eq;
+use tempfile::tempdir;
+use uuid::Uuid;
+
+use crate::config::test_config;
+
+use super::*;
+
+#[tokio::test]
+async fn search_sessions_ranks_matching_rollout_first() {
+    let codex_home = tempdir().expect("tempdir");
+    let mut config = test_config();
+    config.codex_home = codex_home.path().to_path_buf();
+    config.model_provider_id = "openai".to_string();
+
+    let hit_id = Uuid::new_v4();
+    let miss_id = Uuid::new_v4();
+    write_rollout(
+        codex_home.path(),
+        hit_id,
+        "2026-03-19T10-00-00",
+        "we debugged bm25 recall over old sessions",
+        "The implementation used a sparse text index.",
+    );
+    write_rollout(
+        codex_home.path(),
+        miss_id,
+        "2026-03-19T09-00-00",
+        "we reviewed terminal colors",
+        "No search work happened in this session.",
+    );
+
+    let hits = search_sessions(&config, "bm25 recall", /*current_thread_id*/ None, 2)
+        .await
+        .expect("search sessions");
+
+    assert!(!hits.is_empty(), "expected at least one recall hit");
+    assert_eq!(hits[0].thread_id.to_string(), hit_id.to_string());
+    assert_eq!(
+        hits[0].snippet,
+        "we debugged bm25 recall over old sessions".to_string()
+    );
+}
+
+#[test]
+fn format_recall_draft_includes_source_metadata_and_excerpt() {
+    let thread_id = ThreadId::from_string(&Uuid::new_v4().to_string()).expect("thread id");
+    let hits = vec![SessionRecallHit {
+        thread_id,
+        score: 1.5,
+        thread_name: Some("Recall prototype".to_string()),
+        path: "/tmp/rollout.jsonl".into(),
+        created_at: Some("2026-03-19T10:00:00Z".to_string()),
+        updated_at: Some("2026-03-19T10:05:00Z".to_string()),
+        cwd: Some("/Users/starr/code/codex".into()),
+        snippet: "BM25 matched the old session.".to_string(),
+    }];
+
+    let draft = format_recall_draft("bm25", &hits);
+
+    assert_eq!(
+        draft,
+        format!(
+            "Recalled context from previous Codex sessions for query: bm25\n\n\
+             1. Recall prototype\n\
+             Thread: {thread_id}\n\
+             Updated: 2026-03-19T10:05:00Z\n\
+             Cwd: /Users/starr/code/codex\n\
+             Rollout: /tmp/rollout.jsonl\n\
+             Excerpt: BM25 matched the old session.\n\n\
+             Use this recalled context if it is relevant to my next message."
+        )
+    );
+}
+
+fn write_rollout(
+    codex_home: &std::path::Path,
+    uuid: Uuid,
+    ts: &str,
+    user_message: &str,
+    assistant_message: &str,
+) {
+    let day_dir = codex_home.join("sessions/2026/03/19");
+    std::fs::create_dir_all(&day_dir).expect("create day dir");
+    let path = day_dir.join(format!("rollout-{ts}-{uuid}.jsonl"));
+    let mut file = File::create(&path).expect("create rollout");
+    let thread_id = ThreadId::from_string(&uuid.to_string()).expect("thread id");
+
+    let session_meta = RolloutLine {
+        timestamp: format!("{ts}Z"),
+        item: RolloutItem::SessionMeta(SessionMetaLine {
+            meta: SessionMeta {
+                id: thread_id,
+                forked_from_id: None,
+                timestamp: format!("{ts}Z"),
+                cwd: codex_home.to_path_buf(),
+                originator: "cli".to_string(),
+                cli_version: "test".to_string(),
+                source: SessionSource::Cli,
+                agent_nickname: None,
+                agent_role: None,
+                model_provider: Some("openai".to_string()),
+                base_instructions: None,
+                dynamic_tools: None,
+                memory_mode: None,
+            },
+            git: None,
+        }),
+    };
+    writeln!(
+        file,
+        "{}",
+        serde_json::to_string(&session_meta).expect("serialize session meta")
+    )
+    .expect("write session meta");
+
+    let user = RolloutLine {
+        timestamp: format!("{ts}Z"),
+        item: RolloutItem::EventMsg(EventMsg::UserMessage(UserMessageEvent {
+            message: user_message.to_string(),
+            images: None,
+            text_elements: Vec::new(),
+            local_images: Vec::new(),
+        })),
+    };
+    writeln!(
+        file,
+        "{}",
+        serde_json::to_string(&user).expect("serialize user message")
+    )
+    .expect("write user message");
+
+    let assistant = RolloutLine {
+        timestamp: format!("{ts}Z"),
+        item: RolloutItem::ResponseItem(ResponseItem::Message {
+            id: None,
+            role: "assistant".to_string(),
+            content: vec![ContentItem::OutputText {
+                text: assistant_message.to_string(),
+            }],
+            end_turn: None,
+            phase: None,
+        }),
+    };
+    writeln!(
+        file,
+        "{}",
+        serde_json::to_string(&assistant).expect("serialize assistant message")
+    )
+    .expect("write assistant message");
+}

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -2674,6 +2674,10 @@ impl App {
                     }
                 }
             }
+            AppEvent::InsertComposerText(text) => {
+                self.chat_widget.insert_str(&text);
+                tui.frame_requester().schedule_frame();
+            }
             AppEvent::ApplyThreadRollback { num_turns } => {
                 if self.apply_non_pending_thread_rollback(num_turns) {
                     tui.frame_requester().schedule_frame();

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -164,6 +164,10 @@ pub(crate) enum AppEvent {
 
     InsertHistoryCell(Box<dyn HistoryCell>),
 
+    /// Insert text into the composer from an async UI workflow after the
+    /// original slash-command draft has already been consumed.
+    InsertComposerText(String),
+
     /// Apply rollback semantics to local transcript cells.
     ///
     /// This is emitted when rollback was not initiated by the current

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -4405,6 +4405,9 @@ impl ChatWidget {
             SlashCommand::Resume => {
                 self.app_event_tx.send(AppEvent::OpenResumePicker);
             }
+            SlashCommand::Recall => {
+                self.add_error_message("Usage: /recall <query>".to_string());
+            }
             SlashCommand::Fork => {
                 self.app_event_tx.send(AppEvent::ForkCurrentSession);
             }
@@ -4774,6 +4777,62 @@ impl ChatWidget {
                 self.request_redraw();
                 self.app_event_tx
                     .send(AppEvent::CodexOp(Op::SetThreadName { name }));
+                self.bottom_pane.drain_pending_submission_state();
+            }
+            SlashCommand::Recall if !trimmed.is_empty() => {
+                let Some((prepared_args, _prepared_elements)) = self
+                    .bottom_pane
+                    .prepare_inline_args_submission(/*record_history*/ false)
+                else {
+                    return;
+                };
+                let config = self.config.clone();
+                let current_thread_id = self.thread_id;
+                let query = prepared_args;
+                let tx = self.app_event_tx.clone();
+
+                self.add_info_message(
+                    format!("Searching past sessions for `{query}`..."),
+                    /*hint*/ None,
+                );
+                tokio::spawn(async move {
+                    match codex_core::recall::search_sessions(&config, &query, current_thread_id, 3)
+                        .await
+                    {
+                        Ok(hits) if hits.is_empty() => {
+                            tx.send(AppEvent::InsertHistoryCell(Box::new(
+                                history_cell::new_info_event(
+                                    format!("No past sessions matched `{query}`."),
+                                    /*hint*/ None,
+                                ),
+                            )));
+                        }
+                        Ok(hits) => {
+                            tx.send(AppEvent::InsertHistoryCell(Box::new(
+                                history_cell::new_info_event(
+                                    format!(
+                                        "Recalled {} past session(s) into the composer.",
+                                        hits.len()
+                                    ),
+                                    Some(
+                                        "Review/edit the recalled context, then press Enter to send."
+                                            .to_string(),
+                                    ),
+                                ),
+                            )));
+                            tx.send(AppEvent::InsertComposerText(
+                                codex_core::recall::format_recall_draft(&query, &hits),
+                            ));
+                        }
+                        Err(err) => {
+                            tx.send(AppEvent::InsertHistoryCell(Box::new(
+                                history_cell::new_error_event(format!(
+                                    "Failed to recall past sessions: {err}"
+                                )),
+                            )));
+                        }
+                    }
+                });
                 self.bottom_pane.drain_pending_submission_state();
             }
             SlashCommand::Plan if !trimmed.is_empty() => {

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -6197,6 +6197,21 @@ async fn slash_resume_opens_picker() {
 }
 
 #[tokio::test]
+async fn slash_recall_without_query_shows_usage() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(None).await;
+
+    chat.dispatch_command(SlashCommand::Recall);
+
+    let cells = drain_insert_history(&mut rx);
+    assert_eq!(cells.len(), 1, "expected usage error for bare /recall");
+    let rendered = lines_to_single_string(&cells[0]);
+    assert!(
+        rendered.contains("Usage: /recall <query>"),
+        "expected recall usage message: {rendered}"
+    );
+}
+
+#[tokio::test]
 async fn slash_fork_requests_current_fork() {
     let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(None).await;
 

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -26,6 +26,7 @@ pub enum SlashCommand {
     Rename,
     New,
     Resume,
+    Recall,
     Fork,
     Init,
     Compact,
@@ -76,6 +77,7 @@ impl SlashCommand {
             SlashCommand::Review => "review my current changes and find issues",
             SlashCommand::Rename => "rename the current thread",
             SlashCommand::Resume => "resume a saved chat",
+            SlashCommand::Recall => "recall context from older saved chats: /recall <query>",
             SlashCommand::Clear => "clear the terminal and start a new chat",
             SlashCommand::Fork => "fork the current chat",
             // SlashCommand::Undo => "ask Codex to undo a turn",
@@ -128,6 +130,7 @@ impl SlashCommand {
             self,
             SlashCommand::Review
                 | SlashCommand::Rename
+                | SlashCommand::Recall
                 | SlashCommand::Plan
                 | SlashCommand::Fast
                 | SlashCommand::SandboxReadRoot
@@ -139,6 +142,7 @@ impl SlashCommand {
         match self {
             SlashCommand::New
             | SlashCommand::Resume
+            | SlashCommand::Recall
             | SlashCommand::Fork
             | SlashCommand::Init
             | SlashCommand::Compact

--- a/codex-rs/tui_app_server/src/app.rs
+++ b/codex-rs/tui_app_server/src/app.rs
@@ -3559,6 +3559,10 @@ impl App {
                     }
                 }
             }
+            AppEvent::InsertComposerText(text) => {
+                self.chat_widget.insert_str(&text);
+                tui.frame_requester().schedule_frame();
+            }
             AppEvent::ApplyThreadRollback { num_turns } => {
                 if self.apply_non_pending_thread_rollback(num_turns) {
                     tui.frame_requester().schedule_frame();

--- a/codex-rs/tui_app_server/src/app_event.rs
+++ b/codex-rs/tui_app_server/src/app_event.rs
@@ -174,6 +174,10 @@ pub(crate) enum AppEvent {
 
     InsertHistoryCell(Box<dyn HistoryCell>),
 
+    /// Insert text into the composer from an async UI workflow after the
+    /// original slash-command draft has already been consumed.
+    InsertComposerText(String),
+
     /// Apply rollback semantics to local transcript cells.
     ///
     /// This is emitted when rollback was not initiated by the current

--- a/codex-rs/tui_app_server/src/chatwidget.rs
+++ b/codex-rs/tui_app_server/src/chatwidget.rs
@@ -4568,6 +4568,9 @@ impl ChatWidget {
             SlashCommand::Resume => {
                 self.app_event_tx.send(AppEvent::OpenResumePicker);
             }
+            SlashCommand::Recall => {
+                self.add_error_message("Usage: /recall <query>".to_string());
+            }
             SlashCommand::Fork => {
                 self.app_event_tx.send(AppEvent::ForkCurrentSession);
             }
@@ -4926,6 +4929,62 @@ impl ChatWidget {
                 self.add_boxed_history(Box::new(cell));
                 self.request_redraw();
                 self.app_event_tx.set_thread_name(name);
+                self.bottom_pane.drain_pending_submission_state();
+            }
+            SlashCommand::Recall if !trimmed.is_empty() => {
+                let Some((prepared_args, _prepared_elements)) = self
+                    .bottom_pane
+                    .prepare_inline_args_submission(/*record_history*/ false)
+                else {
+                    return;
+                };
+                let config = self.config.clone();
+                let current_thread_id = self.thread_id;
+                let query = prepared_args;
+                let tx = self.app_event_tx.clone();
+
+                self.add_info_message(
+                    format!("Searching past sessions for `{query}`..."),
+                    /*hint*/ None,
+                );
+                tokio::spawn(async move {
+                    match codex_core::recall::search_sessions(&config, &query, current_thread_id, 3)
+                        .await
+                    {
+                        Ok(hits) if hits.is_empty() => {
+                            tx.send(AppEvent::InsertHistoryCell(Box::new(
+                                history_cell::new_info_event(
+                                    format!("No past sessions matched `{query}`."),
+                                    /*hint*/ None,
+                                ),
+                            )));
+                        }
+                        Ok(hits) => {
+                            tx.send(AppEvent::InsertHistoryCell(Box::new(
+                                history_cell::new_info_event(
+                                    format!(
+                                        "Recalled {} past session(s) into the composer.",
+                                        hits.len()
+                                    ),
+                                    Some(
+                                        "Review/edit the recalled context, then press Enter to send."
+                                            .to_string(),
+                                    ),
+                                ),
+                            )));
+                            tx.send(AppEvent::InsertComposerText(
+                                codex_core::recall::format_recall_draft(&query, &hits),
+                            ));
+                        }
+                        Err(err) => {
+                            tx.send(AppEvent::InsertHistoryCell(Box::new(
+                                history_cell::new_error_event(format!(
+                                    "Failed to recall past sessions: {err}"
+                                )),
+                            )));
+                        }
+                    }
+                });
                 self.bottom_pane.drain_pending_submission_state();
             }
             SlashCommand::Plan if !trimmed.is_empty() => {

--- a/codex-rs/tui_app_server/src/chatwidget/tests.rs
+++ b/codex-rs/tui_app_server/src/chatwidget/tests.rs
@@ -6829,6 +6829,21 @@ async fn slash_resume_opens_picker() {
 }
 
 #[tokio::test]
+async fn slash_recall_without_query_shows_usage() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(None).await;
+
+    chat.dispatch_command(SlashCommand::Recall);
+
+    let cells = drain_insert_history(&mut rx);
+    assert_eq!(cells.len(), 1, "expected usage error for bare /recall");
+    let rendered = lines_to_single_string(&cells[0]);
+    assert!(
+        rendered.contains("Usage: /recall <query>"),
+        "expected recall usage message: {rendered}"
+    );
+}
+
+#[tokio::test]
 async fn slash_fork_requests_current_fork() {
     let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(None).await;
 

--- a/codex-rs/tui_app_server/src/slash_command.rs
+++ b/codex-rs/tui_app_server/src/slash_command.rs
@@ -26,6 +26,7 @@ pub enum SlashCommand {
     Rename,
     New,
     Resume,
+    Recall,
     Fork,
     Init,
     Compact,
@@ -75,6 +76,7 @@ impl SlashCommand {
             SlashCommand::Review => "review my current changes and find issues",
             SlashCommand::Rename => "rename the current thread",
             SlashCommand::Resume => "resume a saved chat",
+            SlashCommand::Recall => "recall context from older saved chats: /recall <query>",
             SlashCommand::Clear => "clear the terminal and start a new chat",
             SlashCommand::Fork => "fork the current chat",
             // SlashCommand::Undo => "ask Codex to undo a turn",
@@ -126,6 +128,7 @@ impl SlashCommand {
             self,
             SlashCommand::Review
                 | SlashCommand::Rename
+                | SlashCommand::Recall
                 | SlashCommand::Plan
                 | SlashCommand::Fast
                 | SlashCommand::SandboxReadRoot
@@ -137,6 +140,7 @@ impl SlashCommand {
         match self {
             SlashCommand::New
             | SlashCommand::Resume
+            | SlashCommand::Recall
             | SlashCommand::Fork
             | SlashCommand::Init
             | SlashCommand::Compact

--- a/docs/slash_commands.md
+++ b/docs/slash_commands.md
@@ -1,3 +1,9 @@
 # Slash commands
 
 For an overview of Codex CLI slash commands, see [this documentation](https://developers.openai.com/codex/cli/slash-commands).
+
+Local additions in this checkout:
+
+- `/recall <query>` builds an in-memory BM25 index over saved Codex session rollouts, ranks older
+  sessions against the query, and inserts the top recalled context into the composer for review
+  before sending.


### PR DESCRIPTION
## Summary
- add `/recall <query>` to BM25-search saved Codex session rollouts and insert the top recalled context into the composer
- include both TUI and tui_app_server wiring for the new slash command
- add focused recall ranking/formatting tests and bare-command usage coverage

## Validation
- `just fix -p codex-core -p codex-tui -p codex-tui-app-server`
- `cargo test -p codex-core recall`
- `cargo test -p codex-tui slash_recall_without_query_shows_usage`
- `cargo test -p codex-tui-app-server slash_recall_without_query_shows_usage`