### PR TITLE
fix: build PATH env var using OsString instead of String

### DIFF
--- a/codex-rs/arg0/src/lib.rs
+++ b/codex-rs/arg0/src/lib.rs
@@ -309,14 +309,16 @@ pub fn prepend_path_entry_for_codex_aliases() -> std::io::Result<Arg0PathEntryGu
     #[cfg(windows)]
     const PATH_SEPARATOR: &str = ";";
 
-    let path_element = path.display();
-    let updated_path_env_var = match std::env::var("PATH") {
-        Ok(existing_path) => {
-            format!("{path_element}{PATH_SEPARATOR}{existing_path}")
+    let updated_path_env_var = match std::env::var_os("PATH") {
+        Some(existing_path) => {
+            let mut path_env_var =
+                std::ffi::OsString::with_capacity(path.as_os_str().len() + 1 + existing_path.len());
+            path_env_var.push(path);
+            path_env_var.push(PATH_SEPARATOR);
+            path_env_var.push(existing_path);
+            path_env_var
         }
-        Err(_) => {
-            format!("{path_element}")
-        }
+        None => path.as_os_str().to_owned(),
     };
 
     unsafe {


### PR DESCRIPTION
## Why

`prepend_path_entry_for_codex_aliases()` was rebuilding `PATH` through `std::env::var("PATH")` and `String` formatting. That assumes the inherited `PATH` is valid UTF-8, which is not guaranteed on supported platforms. When `PATH` contains non-UTF-8 bytes, Codex can fail to prepend the per-session helper directory even though the existing environment is otherwise usable.

## What changed

- read `PATH` with `std::env::var_os()` instead of `std::env::var()`
- construct the updated value as an `OsString` instead of a formatted `String`
- preserve the existing `PATH` contents while still prepending the arg0 helper directory

## How to verify

- Not run locally; change is limited to how `PATH` is reconstructed before `std::env::set_var()`.


---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/15360).
* #15363
* __->__ #15360