### PR TITLE
Refresh argument-comment-lint prebuilt wrapper

### DIFF
--- a/tools/argument-comment-lint/README.md
+++ b/tools/argument-comment-lint/README.md
@@ -110,12 +110,14 @@ host-qualified nightly filename to the plain `nightly-2025-09-18` channel when
 needed, and then invokes `cargo-dylint dylint --lib-path <that-library>` with
 the repo's default `DYLINT_RUSTFLAGS` and `CARGO_INCREMENTAL=0` settings.
 
-The checked-in `run-prebuilt-linter.sh` wrapper uses the fetched package
-contents directly so the current checked-in alpha artifact works the same way.
-It also makes sure the `rustup` shims stay ahead of any direct toolchain
-`cargo` binary on `PATH`, and sets `RUSTUP_HOME` from `rustup show home` when
-the environment does not already provide it. That extra `RUSTUP_HOME` export is
-required for the current Windows Dylint driver path.
+The checked-in `run-prebuilt-linter.sh` wrapper now invokes the package
+entrypoint directly and only layers on Codex-specific defaults like
+`--manifest-path`, `--workspace`, and `--no-deps` when the caller does not
+choose something narrower. The packaged runner now owns the bundled
+`cargo-dylint`, library discovery and filename normalization, default
+`DYLINT_RUSTFLAGS`, `CARGO_INCREMENTAL=0`, and `RUSTUP_HOME` inference. The
+shell wrapper still makes sure the `rustup` shims stay ahead of any direct
+toolchain `cargo` binary on `PATH`, because `cargo-dylint` still expects that.
 
 If you are changing the lint crate itself, use the source-build wrapper:
 
@@ -140,11 +142,11 @@ default:
 ./tools/argument-comment-lint/run-prebuilt-linter.sh -p codex-core
 ```
 
-The wrapper does that by setting `DYLINT_RUSTFLAGS`, and it leaves an explicit
-existing setting alone. It also defaults `CARGO_INCREMENTAL=0` unless you have
-already set it, because the current nightly Dylint flow can otherwise hit a
-rustc incremental compilation ICE locally. To override that behavior for an ad
-hoc run:
+The packaged runner does that by setting `DYLINT_RUSTFLAGS`, and it leaves an
+explicit existing setting alone. It also defaults `CARGO_INCREMENTAL=0` unless
+you have already set it, because the current nightly Dylint flow can otherwise
+hit a rustc incremental compilation ICE locally. To override that behavior for
+an ad hoc run:
 
 ```bash
 DYLINT_RUSTFLAGS="-A uncommented-anonymous-literal-argument" \

--- a/tools/argument-comment-lint/argument-comment-lint
+++ b/tools/argument-comment-lint/argument-comment-lint
@@ -4,73 +4,73 @@
   "name": "argument-comment-lint",
   "platforms": {
     "macos-aarch64": {
-      "size": 3402747,
+      "size": 3414909,
       "hash": "blake3",
-      "digest": "a11669d2f184a2c6f226cedce1bf10d1ec478d53413c42fe80d17dd873fdb2d7",
+      "digest": "2a455fa67fa862a36ac4b8b8d8cb57bb3397eafe0579a1fd1a98a96fe7238fc5",
       "format": "tar.gz",
       "path": "argument-comment-lint/bin/argument-comment-lint",
       "providers": [
         {
-          "url": "https://github.com/openai/codex/releases/download/rust-v0.117.0-alpha.2/argument-comment-lint-aarch64-apple-darwin.tar.gz"
+          "url": "https://github.com/openai/codex/releases/download/rust-v0.117.0-alpha.6/argument-comment-lint-aarch64-apple-darwin.tar.gz"
         },
         {
           "type": "github-release",
           "repo": "https://github.com/openai/codex",
-          "tag": "rust-v0.117.0-alpha.2",
+          "tag": "rust-v0.117.0-alpha.6",
           "name": "argument-comment-lint-aarch64-apple-darwin.tar.gz"
         }
       ]
     },
     "linux-x86_64": {
-      "size": 3869711,
+      "size": 3882120,
       "hash": "blake3",
-      "digest": "1015f4ba07d57edc5ec79c8f6709ddc1516f64c903e909820437a4b89d8d853a",
+      "digest": "8c50468cd97d70e029638a478bf977ff2fa150ba188e2597b615233376064c8a",
       "format": "tar.gz",
       "path": "argument-comment-lint/bin/argument-comment-lint",
       "providers": [
         {
-          "url": "https://github.com/openai/codex/releases/download/rust-v0.117.0-alpha.2/argument-comment-lint-x86_64-unknown-linux-gnu.tar.gz"
+          "url": "https://github.com/openai/codex/releases/download/rust-v0.117.0-alpha.6/argument-comment-lint-x86_64-unknown-linux-gnu.tar.gz"
         },
         {
           "type": "github-release",
           "repo": "https://github.com/openai/codex",
-          "tag": "rust-v0.117.0-alpha.2",
+          "tag": "rust-v0.117.0-alpha.6",
           "name": "argument-comment-lint-x86_64-unknown-linux-gnu.tar.gz"
         }
       ]
     },
     "linux-aarch64": {
-      "size": 3759446,
+      "size": 3772016,
       "hash": "blake3",
-      "digest": "91f2a31e6390ca728ad09ae1aa6b6f379c67d996efcc22956001df89f068af5b",
+      "digest": "390169281f19ffa0583bc52412040daea6791300f1d6278ad2c753e58b902554",
       "format": "tar.gz",
       "path": "argument-comment-lint/bin/argument-comment-lint",
       "providers": [
         {
-          "url": "https://github.com/openai/codex/releases/download/rust-v0.117.0-alpha.2/argument-comment-lint-aarch64-unknown-linux-gnu.tar.gz"
+          "url": "https://github.com/openai/codex/releases/download/rust-v0.117.0-alpha.6/argument-comment-lint-aarch64-unknown-linux-gnu.tar.gz"
         },
         {
           "type": "github-release",
           "repo": "https://github.com/openai/codex",
-          "tag": "rust-v0.117.0-alpha.2",
+          "tag": "rust-v0.117.0-alpha.6",
           "name": "argument-comment-lint-aarch64-unknown-linux-gnu.tar.gz"
         }
       ]
     },
     "windows-x86_64": {
-      "size": 3244599,
+      "size": 3255810,
       "hash": "blake3",
-      "digest": "dc711c6d85b1cabbe52447dda3872deb20c2e64b155da8be0ecb207c7c391683",
+      "digest": "dd2c9478d16ea8ed550438100e84b3c8caf496834004a90a291249f01b09c343",
       "format": "zip",
       "path": "argument-comment-lint/bin/argument-comment-lint.exe",
       "providers": [
         {
-          "url": "https://github.com/openai/codex/releases/download/rust-v0.117.0-alpha.2/argument-comment-lint-x86_64-pc-windows-msvc.zip"
+          "url": "https://github.com/openai/codex/releases/download/rust-v0.117.0-alpha.6/argument-comment-lint-x86_64-pc-windows-msvc.zip"
         },
         {
           "type": "github-release",
           "repo": "https://github.com/openai/codex",
-          "tag": "rust-v0.117.0-alpha.2",
+          "tag": "rust-v0.117.0-alpha.6",
           "name": "argument-comment-lint-x86_64-pc-windows-msvc.zip"
         }
       ]

--- a/tools/argument-comment-lint/run-prebuilt-linter.sh
+++ b/tools/argument-comment-lint/run-prebuilt-linter.sh
@@ -8,7 +8,6 @@ dotslash_manifest="$repo_root/tools/argument-comment-lint/argument-comment-lint"
 
 has_manifest_path=false
 has_package_selection=false
-has_library_selection=false
 has_no_deps=false
 expect_value=""
 
@@ -20,9 +19,6 @@ for arg in "$@"; do
                 ;;
             package_selection)
                 has_package_selection=true
-                ;;
-            library_selection)
-                has_library_selection=true
                 ;;
         esac
         expect_value=""
@@ -44,12 +40,6 @@ for arg in "$@"; do
             ;;
         --package=*)
             has_package_selection=true
-            ;;
-        --lib|--lib-path)
-            expect_value="library_selection"
-            ;;
-        --lib=*|--lib-path=*)
-            has_library_selection=true
             ;;
         --workspace)
             has_package_selection=true
@@ -82,6 +72,8 @@ EOF
 fi
 
 if command -v rustup >/dev/null 2>&1; then
+    # cargo-dylint still expects the rustup shims to win over direct toolchain
+    # cargo binaries on PATH.
     rustup_bin_dir="$(dirname "$(command -v rustup)")"
     path_entries=()
     while IFS= read -r entry; do
@@ -92,73 +84,6 @@ if command -v rustup >/dev/null 2>&1; then
         PATH+=":$(IFS=:; echo "${path_entries[*]}")"
     fi
     export PATH
-
-    if [[ -z "${RUSTUP_HOME:-}" ]]; then
-        rustup_home="$(rustup show home 2>/dev/null || true)"
-        if [[ -n "$rustup_home" ]]; then
-            export RUSTUP_HOME="$rustup_home"
-        fi
-    fi
 fi
 
-package_entrypoint="$(dotslash -- fetch "$dotslash_manifest")"
-bin_dir="$(cd "$(dirname "$package_entrypoint")" && pwd)"
-package_root="$(cd "$bin_dir/.." && pwd)"
-library_dir="$package_root/lib"
-
-cargo_dylint="$bin_dir/cargo-dylint"
-if [[ ! -x "$cargo_dylint" ]]; then
-    cargo_dylint="$bin_dir/cargo-dylint.exe"
-fi
-if [[ ! -x "$cargo_dylint" ]]; then
-    echo "bundled cargo-dylint executable not found under $bin_dir" >&2
-    exit 1
-fi
-
-shopt -s nullglob
-libraries=("$library_dir"/*@*)
-shopt -u nullglob
-if [[ ${#libraries[@]} -eq 0 ]]; then
-    echo "no packaged Dylint library found in $library_dir" >&2
-    exit 1
-fi
-if [[ ${#libraries[@]} -ne 1 ]]; then
-    echo "expected exactly one packaged Dylint library in $library_dir" >&2
-    exit 1
-fi
-
-library_path="${libraries[0]}"
-library_filename="$(basename "$library_path")"
-normalized_library_path="$library_path"
-library_ext=".${library_filename##*.}"
-library_stem="${library_filename%.*}"
-if [[ "$library_stem" =~ ^(.+@nightly-[0-9]{4}-[0-9]{2}-[0-9]{2})-.+$ ]]; then
-    normalized_library_filename="${BASH_REMATCH[1]}$library_ext"
-    temp_dir="$(mktemp -d "${TMPDIR:-/tmp}/argument-comment-lint.XXXXXX")"
-    normalized_library_path="$temp_dir/$normalized_library_filename"
-    cp "$library_path" "$normalized_library_path"
-fi
-
-if [[ -n "${DYLINT_RUSTFLAGS:-}" ]]; then
-    if [[ "$DYLINT_RUSTFLAGS" != *"-D uncommented-anonymous-literal-argument"* ]]; then
-        DYLINT_RUSTFLAGS+=" -D uncommented-anonymous-literal-argument"
-    fi
-    if [[ "$DYLINT_RUSTFLAGS" != *"-A unknown_lints"* ]]; then
-        DYLINT_RUSTFLAGS+=" -A unknown_lints"
-    fi
-else
-    DYLINT_RUSTFLAGS="-D uncommented-anonymous-literal-argument -A unknown_lints"
-fi
-export DYLINT_RUSTFLAGS
-
-if [[ -z "${CARGO_INCREMENTAL:-}" ]]; then
-    export CARGO_INCREMENTAL=0
-fi
-
-command=("$cargo_dylint" dylint --lib-path "$normalized_library_path")
-if [[ "$has_library_selection" == false ]]; then
-    command+=(--all)
-fi
-command+=("${lint_args[@]}")
-
-exec "${command[@]}"
+exec "$dotslash_manifest" "${lint_args[@]}"


### PR DESCRIPTION
## Summary
This refreshes the checked-in `argument-comment-lint` prebuilt wrapper now that the packaged runner owns the Dylint-specific setup work.

## Why
[#15198](https://github.com/openai/codex/pull/15198) moved the cross-platform package logic into the published `argument-comment-lint` entrypoint itself. The repo-side `tools/argument-comment-lint/run-prebuilt-linter.sh` was still carrying the old compatibility layer for unpacking the package, finding `cargo-dylint`, normalizing the bundled lint library filename, and filling in some Windows-specific environment setup.

Keeping that logic in both places makes the wrapper harder to review and easier to let drift from the packaged runner we are actually shipping.

## What Changed
- refresh `tools/argument-comment-lint/argument-comment-lint` to the newer released alpha artifact that includes the packaged-runner fixes
- simplify `tools/argument-comment-lint/run-prebuilt-linter.sh` so it keeps the repo defaults (`--manifest-path`, `--workspace`, `--no-deps`) and `rustup` shim ordering, then delegates directly to the packaged `argument-comment-lint` entrypoint
- update `tools/argument-comment-lint/README.md` so it describes the packaged runner as the owner of bundled `cargo-dylint`, library discovery and normalization, `DYLINT_RUSTFLAGS`, `CARGO_INCREMENTAL=0`, and `RUSTUP_HOME` inference

## Verification
- Existing PR CI exercises the refreshed prebuilt path via the `Argument comment lint` matrix jobs on Linux, macOS, and Windows.
