### PR TITLE
Bazel tests on darwin be strugglin

### DIFF
--- a/codex-rs/core/tests/suite/unified_exec.rs
+++ b/codex-rs/core/tests/suite/unified_exec.rs
@@ -159,7 +159,9 @@ async fn unified_exec_intercepts_apply_patch_exec_command() -> Result<()> {
     let call_id = "uexec-apply-patch";
     let args = json!({
         "cmd": command,
-        "yield_time_ms": 250,
+        // The intercepted apply_patch path spawns a helper process, which can
+        // take longer than a tiny unified-exec yield deadline on CI.
+        "yield_time_ms": 5_000,
     });
 
     let responses = vec![


### PR DESCRIPTION
This test suite has been struggling on the darwin bazel test runners.  

This fixes the CI flake in `suite::unified_exec::unified_exec_intercepts_apply_patch_exec_command` by relaxing the test’s `yield_time_ms` from 250ms to 5s.  The test exercises the intercepted `apply_patch` path, which spawns a helper process and can take longer than a very small unified-exec yield deadline on slower CI machines. No production timeout behavior changed.