### PR TITLE
Add JIT entitlement for macosx

### DIFF
--- a/.github/actions/macos-code-sign/action.yml
+++ b/.github/actions/macos-code-sign/action.yml
@@ -132,9 +132,11 @@ runs:
           keychain_args+=(--keychain "${APPLE_CODESIGN_KEYCHAIN}")
         fi
 
+        entitlements_path="$GITHUB_ACTION_PATH/codex.entitlements.plist"
+
         for binary in codex codex-responses-api-proxy; do
           path="codex-rs/target/${TARGET}/release/${binary}"
-          codesign --force --options runtime --timestamp --sign "$APPLE_CODESIGN_IDENTITY" "${keychain_args[@]}" "$path"
+          codesign --force --options runtime --timestamp --entitlements "$entitlements_path" --sign "$APPLE_CODESIGN_IDENTITY" "${keychain_args[@]}" "$path"
         done
 
     - name: Notarize macOS binaries

--- a/.github/actions/macos-code-sign/codex.entitlements.plist
+++ b/.github/actions/macos-code-sign/codex.entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
Without this entitlement, hardened mac os release binaries are unable to allocate the executable memory for the JIT compiled JS.

Tested with local signing.  Without entitlement I reproduce the error:
```
#
# Fatal process out of memory: Failed to reserve virtual memory for CodeRange
#
==== C stack trace ===============================

    0   codex                               0x00000001075d1acc codex + 85760716
    1   codex                               0x00000001075d6a64 codex + 85781092
    2   codex                               0x00000001075c7100 codex + 85717248
    3   codex                               0x0000000107637394 codex + 86176660
    4   codex                               0x0000000107823cfc codex + 88194300
    5   codex                               0x000000010777c438 codex + 87508024
    6   codex                               0x000000010777d130 codex + 87511344
    7   codex                               0x0000000107c87a54 codex + 92797524
    8   codex                               0x0000000107641188 codex + 86217096
    9   codex                               0x00000001076412d8 codex + 86217432
    10  codex                               0x0000000107553908 codex + 85244168
    11  codex                               0x000000010465f124 codex + 36008228
    12  codex                               0x000000010466a0d0 codex + 36053200
    13  codex                               0x000000010466ce78 codex + 36064888
    14  codex                               0x000000010734edb0 codex + 83127728
    15  libsystem_pthread.dylib             0x00000001810d3c08 _pthread_start + 136
    16  libsystem_pthread.dylib             0x00000001810ceba8 thread_start + 8
zsh: trace trap  target/release/codex exec --enable code_mode_only --enable code_mode --
```

With the entitlement the exec succeeds.