### PR TITLE
increase unified_exec=>apply_patch test timeout

### DIFF
--- a/codex-rs/core/tests/suite/unified_exec.rs
+++ b/codex-rs/core/tests/suite/unified_exec.rs
@@ -161,7 +161,7 @@ async fn unified_exec_intercepts_apply_patch_exec_command() -> Result<()> {
         "cmd": command,
         // The intercepted apply_patch path spawns a helper process, which can
         // take longer than a tiny unified-exec yield deadline on CI.
-        "yield_time_ms": 5_000,
+        "yield_time_ms": 10_000,
     });
 
     let responses = vec![


### PR DESCRIPTION
suite::shell_snapshot::shell_command_snapshot_still_intercepts_apply_patch is hyper flaky still on darwin bazel builds.  Increasing this reduces that flake.  But its probably worth looking into more.