### PR TITLE
Disable image generation via header

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1158,7 +1158,7 @@ impl Session {
     /// we precompute the comma-separated list of enabled experimental feature keys at session
     /// creation time and thread it into the client.
     fn build_model_client_beta_features_header(config: &Config) -> Option<String> {
-        let beta_features_header = FEATURES
+        let mut beta_features = FEATURES
             .iter()
             .filter_map(|spec| {
                 if spec.stage.experimental_menu_description().is_some()
@@ -1169,8 +1169,13 @@ impl Session {
                     None
                 }
             })
-            .collect::<Vec<_>>()
-            .join(",");
+            .collect::<Vec<_>>();
+
+        if !config.features.enabled(Feature::ImageGeneration) {
+            beta_features.push("disable_img_gen");
+        }
+
+        let beta_features_header = beta_features.join(",");
 
         if beta_features_header.is_empty() {
             None

--- a/codex-rs/core/src/codex_tests.rs
+++ b/codex-rs/core/src/codex_tests.rs
@@ -15,6 +15,7 @@ use crate::models_manager::model_info;
 use crate::shell::default_user_shell;
 use crate::tools::format_exec_output_str;
 
+use codex_features::Feature;
 use codex_features::Features;
 use codex_protocol::ThreadId;
 use codex_protocol::models::FunctionCallOutputBody;
@@ -142,6 +143,28 @@ fn assistant_message(text: &str) -> ResponseItem {
         end_turn: None,
         phase: None,
     }
+}
+
+#[test]
+fn beta_features_header_disables_image_generation_when_feature_is_off() {
+    let config = ConfigBuilder::default().build();
+
+    assert_eq!(
+        Session::build_model_client_beta_features_header(&config),
+        Some("disable_img_gen".to_string())
+    );
+}
+
+#[test]
+fn beta_features_header_uses_image_generation_feature_key_when_enabled() {
+    let mut config = ConfigBuilder::default().build();
+    config.features.enable(Feature::ImageGeneration);
+
+    let header = Session::build_model_client_beta_features_header(&config)
+        .expect("image generation should produce a beta features header");
+
+    assert!(header.split(',').any(|value| value == "image_generation"));
+    assert!(!header.split(',').any(|value| value == "disable_img_gen"));
 }
 
 fn skill_message(text: &str) -> ResponseItem {

--- a/codex-rs/core/src/codex_tests.rs
+++ b/codex-rs/core/src/codex_tests.rs
@@ -147,7 +147,7 @@ fn assistant_message(text: &str) -> ResponseItem {
 
 #[test]
 fn beta_features_header_disables_image_generation_when_feature_is_off() {
-    let config = ConfigBuilder::default().build();
+    let config = test_config();
 
     assert_eq!(
         Session::build_model_client_beta_features_header(&config),
@@ -157,7 +157,7 @@ fn beta_features_header_disables_image_generation_when_feature_is_off() {
 
 #[test]
 fn beta_features_header_uses_image_generation_feature_key_when_enabled() {
-    let mut config = ConfigBuilder::default().build();
+    let mut config = test_config();
     config.features.enable(Feature::ImageGeneration);
 
     let header = Session::build_model_client_beta_features_header(&config)


### PR DESCRIPTION
- send `disable_img_gen` in the beta features header when image generation is disabled
- keep the tool out of the tool list and cover the header behavior in tests