### PR TITLE
Refresh mentions list after plugin install/uninstall

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -1033,6 +1033,7 @@ impl App {
             .await?;
         self.apply_runtime_policy_overrides(&mut config);
         self.config = config;
+        self.chat_widget.sync_plugin_mentions_config(&self.config);
         Ok(())
     }
 
@@ -3181,6 +3182,7 @@ impl App {
                     if let Err(err) = self.refresh_in_memory_config_from_disk().await {
                         tracing::warn!(error = %err, "failed to refresh config after plugin install");
                     }
+                    self.chat_widget.refresh_plugin_mentions();
                     self.chat_widget.submit_op(Op::ReloadUserConfig);
                 }
                 let should_refresh_plugin_detail = self.chat_widget.on_plugin_install_loaded(
@@ -3634,6 +3636,7 @@ impl App {
                             "failed to refresh config after plugin uninstall"
                         );
                     }
+                    self.chat_widget.refresh_plugin_mentions();
                     self.chat_widget.submit_op(Op::ReloadUserConfig);
                 }
                 self.chat_widget.on_plugin_uninstall_loaded(

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -9117,7 +9117,7 @@ impl ChatWidget {
         self.bottom_pane.set_connectors_snapshot(Some(snapshot));
     }
 
-    fn refresh_plugin_mentions(&mut self) {
+    pub(crate) fn refresh_plugin_mentions(&mut self) {
         if !self.config.features.enabled(Feature::Plugins) {
             self.bottom_pane.set_plugin_mentions(/*plugins*/ None);
             return;
@@ -9128,6 +9128,11 @@ impl ChatWidget {
             .capability_summaries()
             .to_vec();
         self.bottom_pane.set_plugin_mentions(Some(plugins));
+    }
+
+    pub(crate) fn sync_plugin_mentions_config(&mut self, config: &Config) {
+        self.config.features = config.features.clone();
+        self.config.config_layer_stack = config.config_layer_stack.clone();
     }
 
     pub(crate) fn open_review_popup(&mut self) {

--- a/codex-rs/tui_app_server/src/app.rs
+++ b/codex-rs/tui_app_server/src/app.rs
@@ -1032,6 +1032,7 @@ impl App {
             .await?;
         self.apply_runtime_policy_overrides(&mut config);
         self.config = config;
+        self.chat_widget.sync_plugin_mentions_config(&self.config);
         Ok(())
     }
 
@@ -3684,6 +3685,7 @@ impl App {
                     if let Err(err) = self.refresh_in_memory_config_from_disk().await {
                         tracing::warn!(error = %err, "failed to refresh config after plugin install");
                     }
+                    self.chat_widget.refresh_plugin_mentions();
                     self.chat_widget.submit_op(AppCommand::reload_user_config());
                 }
                 let should_refresh_plugin_detail = self.chat_widget.on_plugin_install_loaded(
@@ -4160,6 +4162,7 @@ impl App {
                             "failed to refresh config after plugin uninstall"
                         );
                     }
+                    self.chat_widget.refresh_plugin_mentions();
                     self.chat_widget.submit_op(AppCommand::reload_user_config());
                 }
                 self.chat_widget.on_plugin_uninstall_loaded(

--- a/codex-rs/tui_app_server/src/chatwidget.rs
+++ b/codex-rs/tui_app_server/src/chatwidget.rs
@@ -10295,7 +10295,7 @@ impl ChatWidget {
         self.bottom_pane.set_connectors_snapshot(Some(snapshot));
     }
 
-    fn refresh_plugin_mentions(&mut self) {
+    pub(crate) fn refresh_plugin_mentions(&mut self) {
         if !self.config.features.enabled(Feature::Plugins) {
             self.bottom_pane.set_plugin_mentions(/*plugins*/ None);
             return;
@@ -10306,6 +10306,11 @@ impl ChatWidget {
             .capability_summaries()
             .to_vec();
         self.bottom_pane.set_plugin_mentions(Some(plugins));
+    }
+
+    pub(crate) fn sync_plugin_mentions_config(&mut self, config: &Config) {
+        self.config.features = config.features.clone();
+        self.config.config_layer_stack = config.config_layer_stack.clone();
     }
 
     pub(crate) fn open_review_popup(&mut self) {


### PR DESCRIPTION
Refresh mentions list after plugin install/uninstall to that $mentions are updated without requiring exiting/launching the client.
