### PR TITLE
expermimental build

### DIFF
--- a/codex-rs/app-server/src/fuzzy_file_search.rs
+++ b/codex-rs/app-server/src/fuzzy_file_search.rs
@@ -15,8 +15,8 @@ use tracing::warn;
 
 use crate::outgoing_message::OutgoingMessageSender;
 
-const MATCH_LIMIT: usize = 50;
-const MAX_THREADS: usize = 12;
+const MATCH_LIMIT: usize = 100;
+const MAX_THREADS: usize = 8;
 
 pub(crate) async fn run_fuzzy_file_search(
     query: String,

--- a/codex-rs/file-search/src/cli.rs
+++ b/codex-rs/file-search/src/cli.rs
@@ -13,7 +13,7 @@ pub struct Cli {
     pub json: bool,
 
     /// Maximum number of results to return.
-    #[clap(long, short = 'l', default_value = "64")]
+    #[clap(long, short = 'l', default_value = "100")]
     pub limit: NonZero<usize>,
 
     /// Directory to search.
@@ -25,12 +25,11 @@ pub struct Cli {
     pub compute_indices: bool,
 
     // While it is common to default to the number of logical CPUs when creating
-    // a thread pool, empirically, the I/O of the filetree traversal offers
-    // limited parallelism and is the bottleneck, so using a smaller number of
-    // threads is more efficient. (Empirically, using more than 2 threads doesn't seem to provide much benefit.)
+    // a thread pool, empirically, 8 worker threads was the fastest setting in
+    // local monorepo evals among the best-performing quality tiers.
     //
     /// Number of worker threads to use.
-    #[clap(long, default_value = "2")]
+    #[clap(long, default_value = "8")]
     pub threads: NonZero<usize>,
 
     /// Exclude patterns

--- a/codex-rs/file-search/src/lib.rs
+++ b/codex-rs/file-search/src/lib.rs
@@ -116,10 +116,10 @@ impl Default for FileSearchOptions {
     fn default() -> Self {
         Self {
             #[expect(clippy::unwrap_used)]
-            limit: NonZero::new(20).unwrap(),
+            limit: NonZero::new(100).unwrap(),
             exclude: Vec::new(),
             #[expect(clippy::unwrap_used)]
-            threads: NonZero::new(2).unwrap(),
+            threads: NonZero::new(8).unwrap(),
             compute_indices: false,
             respect_gitignore: true,
         }

--- a/codex-rs/tui/src/file_search.rs
+++ b/codex-rs/tui/src/file_search.rs
@@ -6,12 +6,15 @@
 //! on every keystroke, and drops the session when the query becomes empty.
 
 use codex_file_search as file_search;
+use std::num::NonZero;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex;
 
 use crate::app_event::AppEvent;
 use crate::app_event_sender::AppEventSender;
+
+const FILE_SEARCH_LIMIT: usize = 50;
 
 pub(crate) struct FileSearchManager {
     state: Arc<Mutex<SearchState>>,
@@ -83,6 +86,8 @@ impl FileSearchManager {
         let session = file_search::create_session(
             vec![self.search_dir.clone()],
             file_search::FileSearchOptions {
+                #[expect(clippy::unwrap_used)]
+                limit: NonZero::new(FILE_SEARCH_LIMIT).unwrap(),
                 compute_indices: true,
                 ..Default::default()
             },

--- a/codex-rs/tui/src/file_search.rs
+++ b/codex-rs/tui/src/file_search.rs
@@ -14,7 +14,7 @@ use std::sync::Mutex;
 use crate::app_event::AppEvent;
 use crate::app_event_sender::AppEventSender;
 
-const FILE_SEARCH_LIMIT: usize = 50;
+const FILE_SEARCH_LIMIT: usize = 100;
 
 pub(crate) struct FileSearchManager {
     state: Arc<Mutex<SearchState>>,

--- a/codex-rs/tui_app_server/src/file_search.rs
+++ b/codex-rs/tui_app_server/src/file_search.rs
@@ -6,12 +6,15 @@
 //! on every keystroke, and drops the session when the query becomes empty.
 
 use codex_file_search as file_search;
+use std::num::NonZero;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex;
 
 use crate::app_event::AppEvent;
 use crate::app_event_sender::AppEventSender;
+
+const FILE_SEARCH_LIMIT: usize = 50;
 
 pub(crate) struct FileSearchManager {
     state: Arc<Mutex<SearchState>>,
@@ -83,6 +86,8 @@ impl FileSearchManager {
         let session = file_search::create_session(
             vec![self.search_dir.clone()],
             file_search::FileSearchOptions {
+                #[expect(clippy::unwrap_used)]
+                limit: NonZero::new(FILE_SEARCH_LIMIT).unwrap(),
                 compute_indices: true,
                 ..Default::default()
             },

--- a/codex-rs/tui_app_server/src/file_search.rs
+++ b/codex-rs/tui_app_server/src/file_search.rs
@@ -14,7 +14,7 @@ use std::sync::Mutex;
 use crate::app_event::AppEvent;
 use crate::app_event_sender::AppEventSender;
 
-const FILE_SEARCH_LIMIT: usize = 50;
+const FILE_SEARCH_LIMIT: usize = 100;
 
 pub(crate) struct FileSearchManager {
     state: Arc<Mutex<SearchState>>,


### PR DESCRIPTION
## Summary
- tune Codex file-search defaults from a realistic quality/performance eval loop
- raise the default result budget to `100` across the shared file-search crate and the TUI/app-server entrypoints
- set the shared file-search default worker count to `8`

## Evaluation
- built a realistic search scenario set centered on Codex code navigation and MCP-heavy use cases
- corpus roots: `codex`, `openai`, and `docs`
- exact-target set: `44` search cases across MCP/tool lookup, approvals/sandbox prompts, protocol/schema lookup, OAuth/MCP client files, connector catalog/docs, and large-repo application files
- broad probes: `mcp`, `approval`, `sandbox`, `oauth`, `connector`, `github`, and `slack`
- tried engine-ranking changes and rerank formulas in parallel; they either regressed quality or failed to reproduce end-to-end, so they are not included in this PR
- ran a ten-way config sweep: `l50_t2`, `l50_t4`, `l50_t8`, `l75_t2`, `l75_t4`, `l75_t8`, `l100_t2`, `l100_t4`, `l100_t8`, `l150_t4`

Among the top-quality tier, `l100_t8` was the fastest setting:
- `MRR = 0.4445`
- `hit@1 = 0.3864`
- `hit@5 = 0.5000`
- `hit@10 = 0.5682`
- `mean latency = 3642.54 ms`
- `median latency = 745.91 ms`

Other tied top-quality configs were slower:
- `l75_t4` mean `3999.77 ms`
- `l100_t4` mean `4014.52 ms`
- `l50_t8` mean `4414.51 ms`
- `l100_t2` mean `4688.22 ms`

## Changes kept
- `codex-file-search` default `limit = 100`
- `codex-file-search` default `threads = 8`
- app-server fuzzy search `MATCH_LIMIT = 100`
- app-server fuzzy search `MAX_THREADS = 8`
- TUI and TUI app-server `FILE_SEARCH_LIMIT = 100`

## Verification
- `git diff --check`
- `cargo test -p codex-file-search` (`15 passed; 0 failed`)
- GitHub CI started successfully; early code-related checks are green and the remaining matrix is pending

## Notes
- this is performance-only work; no UX/search-presentation changes are included
- raw eval artifacts were saved locally under `~/repos/docs/codex`
