### PR TITLE
Enable sccache on Windows ARM64 CI

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -169,10 +169,11 @@ jobs:
       run:
         working-directory: codex-rs
     env:
-      # Speed up repeated builds across CI runs by caching compiled objects, except on
-      # arm64 macOS runners cross-targeting x86_64 where ring/cc-rs can produce
-      # mixed-architecture archives under sccache.
-      USE_SCCACHE: ${{ (startsWith(matrix.runner, 'windows') || (matrix.runner == 'macos-15-xlarge' && matrix.target == 'x86_64-apple-darwin')) && 'false' || 'true' }}
+      # Speed up repeated builds across CI runs by caching compiled objects.
+      # Keep sccache disabled for Windows x64 and arm64 macOS cross-targeting
+      # x86_64, where ring/cc-rs can produce mixed-architecture archives under
+      # sccache. Windows arm64 keeps sccache enabled to reduce aarch64 build time.
+      USE_SCCACHE: ${{ ((matrix.runner == 'windows-x64') || (matrix.runner == 'macos-15-xlarge' && matrix.target == 'x86_64-apple-darwin')) && 'false' || 'true' }}
       CARGO_INCREMENTAL: "0"
       SCCACHE_CACHE_SIZE: 10G
       # In rust-ci, representative release-profile checks use thin LTO for faster feedback.
@@ -554,10 +555,11 @@ jobs:
       run:
         working-directory: codex-rs
     env:
-      # Speed up repeated builds across CI runs by caching compiled objects, except on
-      # arm64 macOS runners cross-targeting x86_64 where ring/cc-rs can produce
-      # mixed-architecture archives under sccache.
-      USE_SCCACHE: ${{ (startsWith(matrix.runner, 'windows') || (matrix.runner == 'macos-15-xlarge' && matrix.target == 'x86_64-apple-darwin')) && 'false' || 'true' }}
+      # Speed up repeated builds across CI runs by caching compiled objects.
+      # Keep sccache disabled for Windows x64 and arm64 macOS cross-targeting
+      # x86_64, where ring/cc-rs can produce mixed-architecture archives under
+      # sccache. Windows arm64 keeps sccache enabled to reduce aarch64 build time.
+      USE_SCCACHE: ${{ ((matrix.runner == 'windows-x64') || (matrix.runner == 'macos-15-xlarge' && matrix.target == 'x86_64-apple-darwin')) && 'false' || 'true' }}
       CARGO_INCREMENTAL: "0"
       SCCACHE_CACHE_SIZE: 10G
 


### PR DESCRIPTION
## Problem
Windows ARM64 CI builds are slow enough to risk timeouts.

## Approach
Enable the existing sccache path for `windows-arm64` in `.github/workflows/rust-ci.yml` while keeping `windows-x64` disabled and preserving the macOS cross-target exception. This is intended as a narrow experiment to measure whether object cache reuse improves aarch64 CI runtime.