### PR TITLE
Hide numeric prefixes on disabled TUI list rows

### DIFF
--- a/codex-rs/tui/src/bottom_pane/list_selection_view.rs
+++ b/codex-rs/tui/src/bottom_pane/list_selection_view.rs
@@ -371,10 +371,13 @@ impl ListSelectionView {
                         ""
                     };
                     let name_with_marker = format!("{name}{marker}");
+                    let is_disabled = item.is_disabled || item.disabled_reason.is_some();
                     let n = visible_idx + 1;
                     let wrap_prefix = if self.is_searchable {
                         // The number keys don't work when search is enabled (since we let the
                         // numbers be used for the search query).
+                        format!("{prefix} ")
+                    } else if is_disabled {
                         format!("{prefix} ")
                     } else {
                         format!("{prefix} {n}. ")
@@ -388,7 +391,6 @@ impl ListSelectionView {
                         .flatten()
                         .or_else(|| item.description.clone());
                     let wrap_indent = description.is_none().then_some(wrap_prefix_width);
-                    let is_disabled = item.is_disabled || item.disabled_reason.is_some();
                     GenericDisplayRow {
                         name: name_with_marker,
                         name_prefix_spans,

--- a/codex-rs/tui/src/bottom_pane/list_selection_view.rs
+++ b/codex-rs/tui/src/bottom_pane/list_selection_view.rs
@@ -378,7 +378,7 @@ impl ListSelectionView {
                         // numbers be used for the search query).
                         format!("{prefix} ")
                     } else if is_disabled {
-                        format!("{prefix} ")
+                        format!("{prefix} {}", " ".repeat(n.to_string().len() + 2))
                     } else {
                         format!("{prefix} {n}. ")
                     };

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__apps_popup_loading_state.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__apps_popup_loading_state.snap
@@ -5,4 +5,4 @@ expression: before
   Apps
   Loading installed and available apps...
 
-› 1. Loading apps...  This updates when the full list is ready.
+› Loading apps...  This updates when the full list is ready.

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__apps_popup_loading_state.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__apps_popup_loading_state.snap
@@ -5,4 +5,4 @@ expression: before
   Apps
   Loading installed and available apps...
 
-› Loading apps...  This updates when the full list is ready.
+›    Loading apps...  This updates when the full list is ready.

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plugin_detail_popup_installable.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plugin_detail_popup_installable.snap
@@ -9,8 +9,8 @@ expression: popup
 
 › 1. Back to plugins  Return to the plugin list.
   2. Install plugin   Install this plugin now.
-  Skills              design-review, extract-copy
-  Apps                Figma, Slack
-  MCP Servers         figma-mcp, docs-mcp
+     Skills           design-review, extract-copy
+     Apps             Figma, Slack
+     MCP Servers      figma-mcp, docs-mcp
 
   Press esc to close.

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plugin_detail_popup_installable.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plugin_detail_popup_installable.snap
@@ -9,8 +9,8 @@ expression: popup
 
 › 1. Back to plugins  Return to the plugin list.
   2. Install plugin   Install this plugin now.
-  3. Skills           design-review, extract-copy
-  4. Apps             Figma, Slack
-  5. MCP Servers      figma-mcp, docs-mcp
+  Skills              design-review, extract-copy
+  Apps                Figma, Slack
+  MCP Servers         figma-mcp, docs-mcp
 
   Press esc to close.

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plugins_popup_loading_state.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plugins_popup_loading_state.snap
@@ -6,4 +6,4 @@ expression: popup
   Loading available plugins...
   This first pass shows the ChatGPT marketplace only.
 
-› Loading plugins...  This updates when the marketplace list is ready.
+›    Loading plugins...  This updates when the marketplace list is ready.

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plugins_popup_loading_state.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plugins_popup_loading_state.snap
@@ -6,4 +6,4 @@ expression: popup
   Loading available plugins...
   This first pass shows the ChatGPT marketplace only.
 
-› 1. Loading plugins...  This updates when the marketplace list is ready.
+› Loading plugins...  This updates when the marketplace list is ready.

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__realtime_microphone_picker_popup.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__realtime_microphone_picker_popup.snap
@@ -5,12 +5,13 @@ expression: popup
   Select Microphone
   Saved devices apply to realtime voice only.
 
-  1. System default                             Use your operating system
-                                                default device.
-› Unavailable: Studio Mic (current) (disabled)  Configured device is not
-                                                currently available.
-                                                (disabled: Reconnect the
-                                                device or choose another one.)
+  1. System default                                Use your operating system
+                                                   default device.
+›    Unavailable: Studio Mic (current) (disabled)  Configured device is not
+                                                   currently available.
+                                                   (disabled: Reconnect the
+                                                   device or choose another
+                                                   one.)
   3. Built-in Mic
   4. USB Mic
 

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__realtime_microphone_picker_popup.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__realtime_microphone_picker_popup.snap
@@ -5,13 +5,12 @@ expression: popup
   Select Microphone
   Saved devices apply to realtime voice only.
 
-  1. System default                                Use your operating system
-                                                   default device.
-› 2. Unavailable: Studio Mic (current) (disabled)  Configured device is not
-                                                   currently available.
-                                                   (disabled: Reconnect the
-                                                   device or choose another
-                                                   one.)
+  1. System default                             Use your operating system
+                                                default device.
+› Unavailable: Studio Mic (current) (disabled)  Configured device is not
+                                                currently available.
+                                                (disabled: Reconnect the
+                                                device or choose another one.)
   3. Built-in Mic
   4. USB Mic
 

--- a/codex-rs/tui_app_server/src/bottom_pane/list_selection_view.rs
+++ b/codex-rs/tui_app_server/src/bottom_pane/list_selection_view.rs
@@ -371,10 +371,13 @@ impl ListSelectionView {
                         ""
                     };
                     let name_with_marker = format!("{name}{marker}");
+                    let is_disabled = item.is_disabled || item.disabled_reason.is_some();
                     let n = visible_idx + 1;
                     let wrap_prefix = if self.is_searchable {
                         // The number keys don't work when search is enabled (since we let the
                         // numbers be used for the search query).
+                        format!("{prefix} ")
+                    } else if is_disabled {
                         format!("{prefix} ")
                     } else {
                         format!("{prefix} {n}. ")
@@ -388,7 +391,6 @@ impl ListSelectionView {
                         .flatten()
                         .or_else(|| item.description.clone());
                     let wrap_indent = description.is_none().then_some(wrap_prefix_width);
-                    let is_disabled = item.is_disabled || item.disabled_reason.is_some();
                     GenericDisplayRow {
                         name: name_with_marker,
                         name_prefix_spans,

--- a/codex-rs/tui_app_server/src/bottom_pane/list_selection_view.rs
+++ b/codex-rs/tui_app_server/src/bottom_pane/list_selection_view.rs
@@ -378,7 +378,7 @@ impl ListSelectionView {
                         // numbers be used for the search query).
                         format!("{prefix} ")
                     } else if is_disabled {
-                        format!("{prefix} ")
+                        format!("{prefix} {}", " ".repeat(n.to_string().len() + 2))
                     } else {
                         format!("{prefix} {n}. ")
                     };

--- a/codex-rs/tui_app_server/src/chatwidget/snapshots/codex_tui_app_server__chatwidget__tests__apps_popup_loading_state.snap
+++ b/codex-rs/tui_app_server/src/chatwidget/snapshots/codex_tui_app_server__chatwidget__tests__apps_popup_loading_state.snap
@@ -5,4 +5,4 @@ expression: before
   Apps
   Loading installed and available apps...
 
-› 1. Loading apps...  This updates when the full list is ready.
+› Loading apps...  This updates when the full list is ready.

--- a/codex-rs/tui_app_server/src/chatwidget/snapshots/codex_tui_app_server__chatwidget__tests__apps_popup_loading_state.snap
+++ b/codex-rs/tui_app_server/src/chatwidget/snapshots/codex_tui_app_server__chatwidget__tests__apps_popup_loading_state.snap
@@ -5,4 +5,4 @@ expression: before
   Apps
   Loading installed and available apps...
 
-› Loading apps...  This updates when the full list is ready.
+›    Loading apps...  This updates when the full list is ready.

--- a/codex-rs/tui_app_server/src/chatwidget/snapshots/codex_tui_app_server__chatwidget__tests__plugin_detail_popup_installable.snap
+++ b/codex-rs/tui_app_server/src/chatwidget/snapshots/codex_tui_app_server__chatwidget__tests__plugin_detail_popup_installable.snap
@@ -9,8 +9,8 @@ expression: popup
 
 › 1. Back to plugins  Return to the plugin list.
   2. Install plugin   Install this plugin now.
-  Skills              design-review, extract-copy
-  Apps                Figma, Slack
-  MCP Servers         figma-mcp, docs-mcp
+     Skills           design-review, extract-copy
+     Apps             Figma, Slack
+     MCP Servers      figma-mcp, docs-mcp
 
   Press esc to close.

--- a/codex-rs/tui_app_server/src/chatwidget/snapshots/codex_tui_app_server__chatwidget__tests__plugin_detail_popup_installable.snap
+++ b/codex-rs/tui_app_server/src/chatwidget/snapshots/codex_tui_app_server__chatwidget__tests__plugin_detail_popup_installable.snap
@@ -9,8 +9,8 @@ expression: popup
 
 › 1. Back to plugins  Return to the plugin list.
   2. Install plugin   Install this plugin now.
-  3. Skills           design-review, extract-copy
-  4. Apps             Figma, Slack
-  5. MCP Servers      figma-mcp, docs-mcp
+  Skills              design-review, extract-copy
+  Apps                Figma, Slack
+  MCP Servers         figma-mcp, docs-mcp
 
   Press esc to close.

--- a/codex-rs/tui_app_server/src/chatwidget/snapshots/codex_tui_app_server__chatwidget__tests__plugins_popup_loading_state.snap
+++ b/codex-rs/tui_app_server/src/chatwidget/snapshots/codex_tui_app_server__chatwidget__tests__plugins_popup_loading_state.snap
@@ -6,4 +6,4 @@ expression: popup
   Loading available plugins...
   This first pass shows the ChatGPT marketplace only.
 
-› Loading plugins...  This updates when the marketplace list is ready.
+›    Loading plugins...  This updates when the marketplace list is ready.

--- a/codex-rs/tui_app_server/src/chatwidget/snapshots/codex_tui_app_server__chatwidget__tests__plugins_popup_loading_state.snap
+++ b/codex-rs/tui_app_server/src/chatwidget/snapshots/codex_tui_app_server__chatwidget__tests__plugins_popup_loading_state.snap
@@ -6,4 +6,4 @@ expression: popup
   Loading available plugins...
   This first pass shows the ChatGPT marketplace only.
 
-› 1. Loading plugins...  This updates when the marketplace list is ready.
+› Loading plugins...  This updates when the marketplace list is ready.

--- a/codex-rs/tui_app_server/src/chatwidget/snapshots/codex_tui_app_server__chatwidget__tests__realtime_microphone_picker_popup.snap
+++ b/codex-rs/tui_app_server/src/chatwidget/snapshots/codex_tui_app_server__chatwidget__tests__realtime_microphone_picker_popup.snap
@@ -5,12 +5,13 @@ expression: popup
   Select Microphone
   Saved devices apply to realtime voice only.
 
-  1. System default                             Use your operating system
-                                                default device.
-› Unavailable: Studio Mic (current) (disabled)  Configured device is not
-                                                currently available.
-                                                (disabled: Reconnect the
-                                                device or choose another one.)
+  1. System default                                Use your operating system
+                                                   default device.
+›    Unavailable: Studio Mic (current) (disabled)  Configured device is not
+                                                   currently available.
+                                                   (disabled: Reconnect the
+                                                   device or choose another
+                                                   one.)
   3. Built-in Mic
   4. USB Mic
 

--- a/codex-rs/tui_app_server/src/chatwidget/snapshots/codex_tui_app_server__chatwidget__tests__realtime_microphone_picker_popup.snap
+++ b/codex-rs/tui_app_server/src/chatwidget/snapshots/codex_tui_app_server__chatwidget__tests__realtime_microphone_picker_popup.snap
@@ -5,13 +5,12 @@ expression: popup
   Select Microphone
   Saved devices apply to realtime voice only.
 
-  1. System default                                Use your operating system
-                                                   default device.
-› 2. Unavailable: Studio Mic (current) (disabled)  Configured device is not
-                                                   currently available.
-                                                   (disabled: Reconnect the
-                                                   device or choose another
-                                                   one.)
+  1. System default                             Use your operating system
+                                                default device.
+› Unavailable: Studio Mic (current) (disabled)  Configured device is not
+                                                currently available.
+                                                (disabled: Reconnect the
+                                                device or choose another one.)
   3. Built-in Mic
   4. USB Mic
 


### PR DESCRIPTION
- Remove numeric prefixes for disabled rows in shared list rendering. These numbers are shortcuts, Ex: Pressing "2" selects option `#2`. Disabled items can not be selected, so keeping numbers on these items is misleading.
- Apply the same behavior in both tui and tui_app_server.
- Update affected snapshots for apps/plugins loading and plugin detail rows.

_**This is a global change.**_

Before:
<img width="1680" height="488" alt="image" src="https://github.com/user-attachments/assets/4bcf94ad-285f-48d3-a235-a85b58ee58e2" />

After:
<img width="1706" height="484" alt="image" src="https://github.com/user-attachments/assets/76bb6107-a562-42fe-ae94-29440447ca77" />


