### PR TITLE
Drop sandbox_permissions from sandbox exec requests

### DIFF
--- a/codex-rs/app-server/src/command_exec.rs
+++ b/codex-rs/app-server/src/command_exec.rs
@@ -737,11 +737,9 @@ mod tests {
             sandbox: SandboxType::WindowsRestrictedToken,
             windows_sandbox_level: WindowsSandboxLevel::Disabled,
             windows_sandbox_private_desktop: false,
-            sandbox_permissions: codex_core::sandboxing::SandboxPermissions::UseDefault,
             sandbox_policy: sandbox_policy.clone(),
             file_system_sandbox_policy: FileSystemSandboxPolicy::from(&sandbox_policy),
             network_sandbox_policy: NetworkSandboxPolicy::from(&sandbox_policy),
-            justification: None,
             arg0: None,
         }
     }
@@ -850,11 +848,9 @@ mod tests {
                     sandbox: SandboxType::None,
                     windows_sandbox_level: WindowsSandboxLevel::Disabled,
                     windows_sandbox_private_desktop: false,
-                    sandbox_permissions: codex_core::sandboxing::SandboxPermissions::UseDefault,
                     sandbox_policy: sandbox_policy.clone(),
                     file_system_sandbox_policy: FileSystemSandboxPolicy::from(&sandbox_policy),
                     network_sandbox_policy: NetworkSandboxPolicy::from(&sandbox_policy),
-                    justification: None,
                     arg0: None,
                 },
                 started_network_proxy: None,

--- a/codex-rs/core/src/exec.rs
+++ b/codex-rs/core/src/exec.rs
@@ -241,10 +241,10 @@ pub fn build_exec_request(
         expiration,
         capture_policy,
         network,
-        sandbox_permissions,
+        sandbox_permissions: _,
         windows_sandbox_level,
         windows_sandbox_private_desktop,
-        justification,
+        justification: _,
         arg0: _,
     } = params;
     if let Some(network) = network.as_ref() {
@@ -268,8 +268,6 @@ pub fn build_exec_request(
     let options = ExecOptions {
         expiration,
         capture_policy,
-        sandbox_permissions,
-        justification,
     };
     let exec_req = manager
         .transform(SandboxTransformRequest {
@@ -309,11 +307,9 @@ pub(crate) async fn execute_exec_request(
         sandbox,
         windows_sandbox_level,
         windows_sandbox_private_desktop,
-        sandbox_permissions,
         sandbox_policy: _sandbox_policy_from_env,
         file_system_sandbox_policy,
         network_sandbox_policy,
-        justification,
         arg0,
     } = exec_request;
     let _ = _sandbox_policy_from_env;
@@ -325,10 +321,10 @@ pub(crate) async fn execute_exec_request(
         capture_policy,
         env,
         network: network.clone(),
-        sandbox_permissions,
+        sandbox_permissions: SandboxPermissions::UseDefault,
         windows_sandbox_level,
         windows_sandbox_private_desktop,
-        justification,
+        justification: None,
         arg0,
     };
 

--- a/codex-rs/core/src/sandboxing/mod.rs
+++ b/codex-rs/core/src/sandboxing/mod.rs
@@ -30,8 +30,6 @@ use std::path::PathBuf;
 pub(crate) struct ExecOptions {
     pub(crate) expiration: ExecExpiration,
     pub(crate) capture_policy: ExecCapturePolicy,
-    pub(crate) sandbox_permissions: SandboxPermissions,
-    pub(crate) justification: Option<String>,
 }
 
 #[derive(Debug)]
@@ -45,11 +43,9 @@ pub struct ExecRequest {
     pub sandbox: SandboxType,
     pub windows_sandbox_level: WindowsSandboxLevel,
     pub windows_sandbox_private_desktop: bool,
-    pub sandbox_permissions: SandboxPermissions,
     pub sandbox_policy: SandboxPolicy,
     pub file_system_sandbox_policy: FileSystemSandboxPolicy,
     pub network_sandbox_policy: NetworkSandboxPolicy,
-    pub justification: Option<String>,
     pub arg0: Option<String>,
 }
 
@@ -74,8 +70,6 @@ impl ExecRequest {
         let ExecOptions {
             expiration,
             capture_policy,
-            sandbox_permissions,
-            justification,
         } = options;
         if !network_sandbox_policy.is_enabled() {
             env.insert(
@@ -97,11 +91,9 @@ impl ExecRequest {
             sandbox,
             windows_sandbox_level,
             windows_sandbox_private_desktop,
-            sandbox_permissions,
             sandbox_policy,
             file_system_sandbox_policy,
             network_sandbox_policy,
-            justification,
             arg0,
         }
     }

--- a/codex-rs/core/src/tasks/user_shell.rs
+++ b/codex-rs/core/src/tasks/user_shell.rs
@@ -25,7 +25,6 @@ use crate::protocol::ExecCommandStatus;
 use crate::protocol::SandboxPolicy;
 use crate::protocol::TurnStartedEvent;
 use crate::sandboxing::ExecRequest;
-use crate::sandboxing::SandboxPermissions;
 use crate::state::TaskKind;
 use crate::tools::format_exec_output_str;
 use crate::tools::runtimes::maybe_wrap_shell_lc_with_snapshot;
@@ -173,11 +172,9 @@ pub(crate) async fn execute_user_shell_command(
             .config
             .permissions
             .windows_sandbox_private_desktop,
-        sandbox_permissions: SandboxPermissions::UseDefault,
         sandbox_policy: sandbox_policy.clone(),
         file_system_sandbox_policy: FileSystemSandboxPolicy::from(&sandbox_policy),
         network_sandbox_policy: NetworkSandboxPolicy::from(&sandbox_policy),
-        justification: None,
         arg0: None,
     };
 

--- a/codex-rs/core/src/tools/handlers/apply_patch.rs
+++ b/codex-rs/core/src/tools/handlers/apply_patch.rs
@@ -200,8 +200,6 @@ impl ToolHandler for ApplyPatchHandler {
                             file_paths,
                             changes,
                             exec_approval_requirement: apply.exec_approval_requirement,
-                            sandbox_permissions: effective_additional_permissions
-                                .sandbox_permissions,
                             additional_permissions: effective_additional_permissions
                                 .additional_permissions,
                             permissions_preapproved: effective_additional_permissions
@@ -305,7 +303,6 @@ pub(crate) async fn intercept_apply_patch(
                         file_paths: approval_keys,
                         changes,
                         exec_approval_requirement: apply.exec_approval_requirement,
-                        sandbox_permissions: effective_additional_permissions.sandbox_permissions,
                         additional_permissions: effective_additional_permissions
                             .additional_permissions,
                         permissions_preapproved: effective_additional_permissions

--- a/codex-rs/core/src/tools/js_repl/mod.rs
+++ b/codex-rs/core/src/tools/js_repl/mod.rs
@@ -40,7 +40,6 @@ use crate::exec_env::create_env;
 use crate::function_tool::FunctionCallError;
 use crate::original_image_detail::normalize_output_image_detail;
 use crate::sandboxing::ExecOptions;
-use crate::sandboxing::SandboxPermissions;
 use crate::tools::ToolRouter;
 use crate::tools::context::SharedTurnDiffTracker;
 use crate::truncate::TruncationPolicy;
@@ -1058,8 +1057,6 @@ impl JsReplManager {
         let options = ExecOptions {
             expiration: ExecExpiration::DefaultTimeout,
             capture_policy: ExecCapturePolicy::ShellTool,
-            sandbox_permissions: SandboxPermissions::UseDefault,
-            justification: None,
         };
         let exec_env = sandbox
             .transform(SandboxTransformRequest {

--- a/codex-rs/core/src/tools/runtimes/apply_patch.rs
+++ b/codex-rs/core/src/tools/runtimes/apply_patch.rs
@@ -10,7 +10,6 @@ use crate::guardian::GuardianApprovalRequest;
 use crate::guardian::review_approval_request;
 use crate::guardian::routes_approval_to_guardian;
 use crate::sandboxing::ExecOptions;
-use crate::sandboxing::SandboxPermissions;
 use crate::sandboxing::execute_env;
 use crate::tools::sandboxing::Approvable;
 use crate::tools::sandboxing::ApprovalCtx;
@@ -40,7 +39,6 @@ pub struct ApplyPatchRequest {
     pub file_paths: Vec<AbsolutePathBuf>,
     pub changes: std::collections::HashMap<PathBuf, FileChange>,
     pub exec_approval_requirement: ExecApprovalRequirement,
-    pub sandbox_permissions: SandboxPermissions,
     pub additional_permissions: Option<PermissionProfile>,
     pub permissions_preapproved: bool,
     pub timeout_ms: Option<u64>,
@@ -206,8 +204,6 @@ impl ToolRuntime<ApplyPatchRequest, ExecToolCallOutput> for ApplyPatchRuntime {
         let options = ExecOptions {
             expiration: req.timeout_ms.into(),
             capture_policy: ExecCapturePolicy::ShellTool,
-            sandbox_permissions: req.sandbox_permissions,
-            justification: None,
         };
         let env = attempt
             .env_for(command, options, /*network*/ None)

--- a/codex-rs/core/src/tools/runtimes/apply_patch_tests.rs
+++ b/codex-rs/core/src/tools/runtimes/apply_patch_tests.rs
@@ -48,7 +48,6 @@ fn guardian_review_request_includes_patch_context() {
             reason: None,
             proposed_execpolicy_amendment: None,
         },
-        sandbox_permissions: SandboxPermissions::UseDefault,
         additional_permissions: None,
         permissions_preapproved: false,
         timeout_ms: None,

--- a/codex-rs/core/src/tools/runtimes/shell.rs
+++ b/codex-rs/core/src/tools/runtimes/shell.rs
@@ -254,8 +254,6 @@ impl ToolRuntime<ShellRequest, ExecToolCallOutput> for ShellRuntime {
         let options = ExecOptions {
             expiration: req.timeout_ms.into(),
             capture_policy: ExecCapturePolicy::ShellTool,
-            sandbox_permissions: req.sandbox_permissions,
-            justification: req.justification.clone(),
         };
         let env = attempt
             .env_for(command, options, req.network.as_ref())

--- a/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
+++ b/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
@@ -120,8 +120,6 @@ pub(super) async fn try_run_zsh_fork(
     let options = ExecOptions {
         expiration: req.timeout_ms.into(),
         capture_policy: ExecCapturePolicy::ShellTool,
-        sandbox_permissions: req.sandbox_permissions,
-        justification: req.justification.clone(),
     };
     let sandbox_exec_request = attempt
         .env_for(command, options, req.network.as_ref())
@@ -136,11 +134,9 @@ pub(super) async fn try_run_zsh_fork(
         sandbox,
         windows_sandbox_level,
         windows_sandbox_private_desktop: _windows_sandbox_private_desktop,
-        sandbox_permissions,
         sandbox_policy,
         file_system_sandbox_policy,
         network_sandbox_policy,
-        justification,
         arg0,
     } = sandbox_exec_request;
     let ParsedShellCommand { script, login, .. } = extract_shell_script(&command)?;
@@ -161,8 +157,6 @@ pub(super) async fn try_run_zsh_fork(
         env: sandbox_env,
         network: sandbox_network,
         windows_sandbox_level,
-        sandbox_permissions,
-        justification,
         arg0,
         sandbox_policy_cwd: ctx.turn.cwd.clone(),
         macos_seatbelt_profile_extensions: ctx
@@ -267,8 +261,6 @@ pub(crate) async fn prepare_unified_exec_zsh_fork(
         env: exec_request.env.clone(),
         network: exec_request.network.clone(),
         windows_sandbox_level: exec_request.windows_sandbox_level,
-        sandbox_permissions: exec_request.sandbox_permissions,
-        justification: exec_request.justification.clone(),
         arg0: exec_request.arg0.clone(),
         sandbox_policy_cwd: ctx.turn.cwd.clone(),
         macos_seatbelt_profile_extensions: ctx
@@ -864,8 +856,6 @@ struct CoreShellCommandExecutor {
     env: HashMap<String, String>,
     network: Option<codex_network_proxy::NetworkProxy>,
     windows_sandbox_level: WindowsSandboxLevel,
-    sandbox_permissions: SandboxPermissions,
-    justification: Option<String>,
     arg0: Option<String>,
     sandbox_policy_cwd: PathBuf,
     #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
@@ -916,11 +906,9 @@ impl ShellCommandExecutor for CoreShellCommandExecutor {
                 sandbox: self.sandbox,
                 windows_sandbox_level: self.windows_sandbox_level,
                 windows_sandbox_private_desktop: false,
-                sandbox_permissions: self.sandbox_permissions,
                 sandbox_policy: self.sandbox_policy.clone(),
                 file_system_sandbox_policy: self.file_system_sandbox_policy.clone(),
                 network_sandbox_policy: self.network_sandbox_policy,
-                justification: self.justification.clone(),
                 arg0: self.arg0.clone(),
             },
             /*stdout_stream*/ None,
@@ -1044,11 +1032,6 @@ impl CoreShellCommandExecutor {
             self.windows_sandbox_level,
             self.network.is_some(),
         );
-        let sandbox_permissions = if additional_permissions.is_some() {
-            SandboxPermissions::WithAdditionalPermissions
-        } else {
-            SandboxPermissions::UseDefault
-        };
         let command = SandboxCommand {
             program: program.clone(),
             args: args.to_vec(),
@@ -1059,8 +1042,6 @@ impl CoreShellCommandExecutor {
         let options = ExecOptions {
             expiration: ExecExpiration::DefaultTimeout,
             capture_policy: ExecCapturePolicy::ShellTool,
-            sandbox_permissions,
-            justification: self.justification.clone(),
         };
         let exec_request = sandbox_manager.transform(SandboxTransformRequest {
             command,

--- a/codex-rs/core/src/tools/runtimes/shell/unix_escalation_tests.rs
+++ b/codex-rs/core/src/tools/runtimes/shell/unix_escalation_tests.rs
@@ -660,8 +660,6 @@ async fn prepare_escalated_exec_turn_default_preserves_macos_seatbelt_extensions
         file_system_sandbox_policy: read_only_file_system_sandbox_policy(),
         network_sandbox_policy: NetworkSandboxPolicy::Restricted,
         windows_sandbox_level: WindowsSandboxLevel::Disabled,
-        sandbox_permissions: SandboxPermissions::UseDefault,
-        justification: None,
         arg0: None,
         sandbox_policy_cwd: cwd.to_path_buf(),
         macos_seatbelt_profile_extensions: Some(MacOsSeatbeltProfileExtensions {
@@ -712,8 +710,6 @@ async fn prepare_escalated_exec_permissions_preserve_macos_seatbelt_extensions()
         file_system_sandbox_policy: unrestricted_file_system_sandbox_policy(),
         network_sandbox_policy: NetworkSandboxPolicy::Enabled,
         windows_sandbox_level: WindowsSandboxLevel::Disabled,
-        sandbox_permissions: SandboxPermissions::UseDefault,
-        justification: None,
         arg0: None,
         sandbox_policy_cwd: cwd.to_path_buf(),
         macos_seatbelt_profile_extensions: None,
@@ -787,8 +783,6 @@ async fn prepare_escalated_exec_permission_profile_unions_turn_and_requested_mac
         file_system_sandbox_policy: read_only_file_system_sandbox_policy(),
         network_sandbox_policy: NetworkSandboxPolicy::from(&sandbox_policy),
         windows_sandbox_level: WindowsSandboxLevel::Disabled,
-        sandbox_permissions: SandboxPermissions::UseDefault,
-        justification: None,
         arg0: None,
         sandbox_policy_cwd: cwd.to_path_buf(),
         macos_seatbelt_profile_extensions: Some(MacOsSeatbeltProfileExtensions {

--- a/codex-rs/core/src/tools/runtimes/unified_exec.rs
+++ b/codex-rs/core/src/tools/runtimes/unified_exec.rs
@@ -218,8 +218,6 @@ impl<'a> ToolRuntime<UnifiedExecRequest, UnifiedExecProcess> for UnifiedExecRunt
             let options = ExecOptions {
                 expiration: ExecExpiration::DefaultTimeout,
                 capture_policy: ExecCapturePolicy::ShellTool,
-                sandbox_permissions: req.sandbox_permissions,
-                justification: req.justification.clone(),
             };
             let exec_env = attempt
                 .env_for(command, options, req.network.as_ref())
@@ -265,8 +263,6 @@ impl<'a> ToolRuntime<UnifiedExecRequest, UnifiedExecProcess> for UnifiedExecRunt
         let options = ExecOptions {
             expiration: ExecExpiration::DefaultTimeout,
             capture_policy: ExecCapturePolicy::ShellTool,
-            sandbox_permissions: req.sandbox_permissions,
-            justification: req.justification.clone(),
         };
         let exec_env = attempt
             .env_for(command, options, req.network.as_ref())


### PR DESCRIPTION
## Summary
- drop `sandbox_permissions` from the sandboxing `ExecOptions` and `ExecRequest` adapter types
- remove the now-unused plumbing from shell, unified exec, JS REPL, and apply-patch runtime call sites
- default reconstructed `ExecParams` to `SandboxPermissions::UseDefault` where the lower-level API still requires the field

## Testing
- `just fmt`
- `just argument-comment-lint`
- `cargo test -p codex-core` (still running locally; first failures observed in `suite::cli_stream::responses_mode_stream_cli`, `suite::cli_stream::responses_mode_stream_cli_supports_openai_base_url_config_override`, and `suite::cli_stream::responses_mode_stream_cli_supports_openai_base_url_env_fallback`)
