### PR TITLE
Fix tui_app_server login and terminal cleanup regressions

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -1911,6 +1911,13 @@ impl CodexMessageProcessor {
         }
     }
 
+    pub(crate) async fn cancel_active_login(&self) {
+        let mut guard = self.active_login.lock().await;
+        if let Some(active_login) = guard.take() {
+            drop(active_login);
+        }
+    }
+
     pub(crate) async fn clear_all_thread_listeners(&self) {
         self.thread_state_manager.clear_all_listeners().await;
     }

--- a/codex-rs/app-server/src/in_process.rs
+++ b/codex-rs/app-server/src/in_process.rs
@@ -457,6 +457,7 @@ fn start_uninitialized(args: InProcessStartArgs) -> InProcessClientHandle {
             }
 
             processor.clear_runtime_references();
+            processor.cancel_active_login().await;
             processor.connection_closed(IN_PROCESS_CONNECTION_ID).await;
             processor.clear_all_thread_listeners().await;
             processor.drain_background_tasks().await;

--- a/codex-rs/app-server/src/message_processor.rs
+++ b/codex-rs/app-server/src/message_processor.rs
@@ -451,6 +451,10 @@ impl MessageProcessor {
         self.codex_message_processor.drain_background_tasks().await;
     }
 
+    pub(crate) async fn cancel_active_login(&self) {
+        self.codex_message_processor.cancel_active_login().await;
+    }
+
     pub(crate) async fn clear_all_thread_listeners(&self) {
         self.codex_message_processor
             .clear_all_thread_listeners()

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -609,6 +609,7 @@ async fn run_ratatui_app(
     terminal.clear()?;
 
     let mut tui = Tui::new(terminal);
+    let mut terminal_restore_guard = TerminalRestoreGuard::new();
 
     #[cfg(not(debug_assertions))]
     {
@@ -619,7 +620,7 @@ async fn run_ratatui_app(
             match update_prompt::run_update_prompt_if_needed(&mut tui, &initial_config).await? {
                 UpdatePromptOutcome::Continue => {}
                 UpdatePromptOutcome::RunUpdate(action) => {
-                    crate::tui::restore()?;
+                    terminal_restore_guard.restore()?;
                     return Ok(AppExitInfo {
                         token_usage: codex_protocol::protocol::TokenUsage::default(),
                         thread_id: None,
@@ -660,7 +661,7 @@ async fn run_ratatui_app(
         )
         .await?;
         if onboarding_result.should_exit {
-            restore();
+            terminal_restore_guard.restore_silently();
             session_log::log_session_end();
             let _ = tui.terminal.clear();
             return Ok(AppExitInfo {
@@ -701,7 +702,7 @@ async fn run_ratatui_app(
 
     let mut missing_session_exit = |id_str: &str, action: &str| {
         error!("Error finding conversation path: {id_str}");
-        restore();
+        terminal_restore_guard.restore_silently();
         session_log::log_session_end();
         let _ = tui.terminal.clear();
         Ok(AppExitInfo {
@@ -773,7 +774,7 @@ async fn run_ratatui_app(
                                 error!(
                                     "Error reading session metadata from latest rollout: {rollout_path}"
                                 );
-                                restore();
+                                terminal_restore_guard.restore_silently();
                                 session_log::log_session_end();
                                 let _ = tui.terminal.clear();
                                 return Ok(AppExitInfo {
@@ -795,7 +796,7 @@ async fn run_ratatui_app(
         } else if cli.fork_picker {
             match resume_picker::run_fork_picker(&mut tui, &config, cli.fork_show_all).await? {
                 resume_picker::SessionSelection::Exit => {
-                    restore();
+                    terminal_restore_guard.restore_silently();
                     session_log::log_session_end();
                     return Ok(AppExitInfo {
                         token_usage: codex_protocol::protocol::TokenUsage::default(),
@@ -867,7 +868,7 @@ async fn run_ratatui_app(
                         error!(
                             "Error reading session metadata from latest rollout: {rollout_path}"
                         );
-                        restore();
+                        terminal_restore_guard.restore_silently();
                         session_log::log_session_end();
                         let _ = tui.terminal.clear();
                         return Ok(AppExitInfo {
@@ -887,7 +888,7 @@ async fn run_ratatui_app(
     } else if cli.resume_picker {
         match resume_picker::run_resume_picker(&mut tui, &config, cli.resume_show_all).await? {
             resume_picker::SessionSelection::Exit => {
-                restore();
+                terminal_restore_guard.restore_silently();
                 session_log::log_session_end();
                 return Ok(AppExitInfo {
                     token_usage: codex_protocol::protocol::TokenUsage::default(),
@@ -929,7 +930,7 @@ async fn run_ratatui_app(
             {
                 ResolveCwdOutcome::Continue(cwd) => cwd,
                 ResolveCwdOutcome::Exit => {
-                    restore();
+                    terminal_restore_guard.restore_silently();
                     session_log::log_session_end();
                     return Ok(AppExitInfo {
                         token_usage: codex_protocol::protocol::TokenUsage::default(),
@@ -1003,7 +1004,7 @@ async fn run_ratatui_app(
     )
     .await;
 
-    restore();
+    terminal_restore_guard.restore_silently();
     // Mark the end of the recorded session.
     session_log::log_session_end();
     // ignore error when collecting usage – report underlying error instead
@@ -1125,6 +1126,38 @@ fn restore() {
         eprintln!(
             "failed to restore terminal. Run `reset` or restart your terminal to recover: {err}"
         );
+    }
+}
+
+struct TerminalRestoreGuard {
+    active: bool,
+}
+
+impl TerminalRestoreGuard {
+    fn new() -> Self {
+        Self { active: true }
+    }
+
+    #[cfg_attr(debug_assertions, allow(dead_code))]
+    fn restore(&mut self) -> color_eyre::Result<()> {
+        if self.active {
+            crate::tui::restore()?;
+            self.active = false;
+        }
+        Ok(())
+    }
+
+    fn restore_silently(&mut self) {
+        if self.active {
+            restore();
+            self.active = false;
+        }
+    }
+}
+
+impl Drop for TerminalRestoreGuard {
+    fn drop(&mut self) {
+        self.restore_silently();
     }
 }
 

--- a/codex-rs/tui_app_server/src/app_server_session.rs
+++ b/codex-rs/tui_app_server/src/app_server_session.rs
@@ -80,6 +80,7 @@ use color_eyre::eyre::Result;
 use color_eyre::eyre::WrapErr;
 use std::collections::HashMap;
 use std::path::PathBuf;
+use tracing::debug;
 
 use crate::bottom_pane::FeedbackAudience;
 use crate::status::StatusAccountDisplay;
@@ -178,16 +179,6 @@ impl AppServerSession {
             })
             .await
             .wrap_err("model/list failed during TUI bootstrap")?;
-        let rate_limit_request_id = self.next_request_id();
-        let rate_limits: GetAccountRateLimitsResponse = self
-            .client
-            .request_typed(ClientRequest::GetAccountRateLimits {
-                request_id: rate_limit_request_id,
-                params: None,
-            })
-            .await
-            .wrap_err("account/rateLimits/read failed during TUI bootstrap")?;
-
         let available_models = models
             .data
             .into_iter()
@@ -252,6 +243,25 @@ impl AppServerSession {
                 false,
             ),
         };
+        let rate_limit_snapshots = if account.requires_openai_auth && has_chatgpt_account {
+            let rate_limit_request_id = self.next_request_id();
+            match self
+                .client
+                .request_typed(ClientRequest::GetAccountRateLimits {
+                    request_id: rate_limit_request_id,
+                    params: None,
+                })
+                .await
+            {
+                Ok(rate_limits) => app_server_rate_limit_snapshots_to_core(rate_limits),
+                Err(error) => {
+                    debug!(error = ?error, "failed to fetch rate limits during TUI bootstrap");
+                    Vec::new()
+                }
+            }
+        } else {
+            Vec::new()
+        };
 
         Ok(AppServerBootstrap {
             account_auth_mode,
@@ -263,7 +273,7 @@ impl AppServerSession {
             feedback_audience,
             has_chatgpt_account,
             available_models,
-            rate_limit_snapshots: app_server_rate_limit_snapshots_to_core(rate_limits),
+            rate_limit_snapshots,
         })
     }
 

--- a/codex-rs/tui_app_server/src/lib.rs
+++ b/codex-rs/tui_app_server/src/lib.rs
@@ -938,6 +938,7 @@ async fn run_ratatui_app(
     terminal.clear()?;
 
     let mut tui = Tui::new(terminal);
+    let mut terminal_restore_guard = TerminalRestoreGuard::new();
 
     #[cfg(not(debug_assertions))]
     {
@@ -948,7 +949,7 @@ async fn run_ratatui_app(
             match update_prompt::run_update_prompt_if_needed(&mut tui, &initial_config).await? {
                 UpdatePromptOutcome::Continue => {}
                 UpdatePromptOutcome::RunUpdate(action) => {
-                    crate::tui::restore()?;
+                    terminal_restore_guard.restore()?;
                     return Ok(AppExitInfo {
                         token_usage: codex_protocol::protocol::TokenUsage::default(),
                         thread_id: None,
@@ -1016,7 +1017,7 @@ async fn run_ratatui_app(
         )
         .await?;
         if onboarding_result.should_exit {
-            restore();
+            terminal_restore_guard.restore_silently();
             session_log::log_session_end();
             let _ = tui.terminal.clear();
             return Ok(AppExitInfo {
@@ -1062,7 +1063,7 @@ async fn run_ratatui_app(
 
     let mut missing_session_exit = |id_str: &str, action: &str| {
         error!("Error finding conversation path: {id_str}");
-        restore();
+        terminal_restore_guard.restore_silently();
         session_log::log_session_end();
         let _ = tui.terminal.clear();
         Ok(AppExitInfo {
@@ -1137,7 +1138,7 @@ async fn run_ratatui_app(
             .await?
             {
                 resume_picker::SessionSelection::Exit => {
-                    restore();
+                    terminal_restore_guard.restore_silently();
                     session_log::log_session_end();
                     return Ok(AppExitInfo {
                         token_usage: codex_protocol::protocol::TokenUsage::default(),
@@ -1189,7 +1190,7 @@ async fn run_ratatui_app(
         .await?
         {
             resume_picker::SessionSelection::Exit => {
-                restore();
+                terminal_restore_guard.restore_silently();
                 session_log::log_session_end();
                 return Ok(AppExitInfo {
                     token_usage: codex_protocol::protocol::TokenUsage::default(),
@@ -1235,7 +1236,7 @@ async fn run_ratatui_app(
                 {
                     ResolveCwdOutcome::Continue(cwd) => cwd,
                     ResolveCwdOutcome::Exit => {
-                        restore();
+                        terminal_restore_guard.restore_silently();
                         session_log::log_session_end();
                         return Ok(AppExitInfo {
                             token_usage: codex_protocol::protocol::TokenUsage::default(),
@@ -1303,7 +1304,7 @@ async fn run_ratatui_app(
     {
         Ok(app_server) => app_server,
         Err(err) => {
-            restore();
+            terminal_restore_guard.restore_silently();
             session_log::log_session_end();
             return Err(err);
         }
@@ -1326,7 +1327,7 @@ async fn run_ratatui_app(
     )
     .await;
 
-    restore();
+    terminal_restore_guard.restore_silently();
     // Mark the end of the recorded session.
     session_log::log_session_end();
     // ignore error when collecting usage – report underlying error instead
@@ -1465,6 +1466,38 @@ fn restore() {
         eprintln!(
             "failed to restore terminal. Run `reset` or restart your terminal to recover: {err}"
         );
+    }
+}
+
+struct TerminalRestoreGuard {
+    active: bool,
+}
+
+impl TerminalRestoreGuard {
+    fn new() -> Self {
+        Self { active: true }
+    }
+
+    #[cfg_attr(debug_assertions, allow(dead_code))]
+    fn restore(&mut self) -> color_eyre::Result<()> {
+        if self.active {
+            crate::tui::restore()?;
+            self.active = false;
+        }
+        Ok(())
+    }
+
+    fn restore_silently(&mut self) {
+        if self.active {
+            restore();
+            self.active = false;
+        }
+    }
+}
+
+impl Drop for TerminalRestoreGuard {
+    fn drop(&mut self) {
+        self.restore_silently();
     }
 }
 

--- a/codex-rs/tui_app_server/src/onboarding/auth.rs
+++ b/codex-rs/tui_app_server/src/onboarding/auth.rs
@@ -163,37 +163,7 @@ impl KeyboardHandler for AuthModeWidget {
             }
             KeyCode::Esc => {
                 tracing::info!("Esc pressed");
-                let mut sign_in_state = self.sign_in_state.write().unwrap();
-                match &*sign_in_state {
-                    SignInState::ChatGptContinueInBrowser(state) => {
-                        let request_handle = self.app_server_request_handle.clone();
-                        let login_id = state.login_id.clone();
-                        tokio::spawn(async move {
-                            let _ = request_handle
-                                .request_typed::<codex_app_server_protocol::CancelLoginAccountResponse>(
-                                    ClientRequest::CancelLoginAccount {
-                                        request_id: onboarding_request_id(),
-                                        params: CancelLoginAccountParams { login_id },
-                                    },
-                                )
-                                .await;
-                        });
-                        *sign_in_state = SignInState::PickMode;
-                        drop(sign_in_state);
-                        self.set_error(/*message*/ None);
-                        self.request_frame.schedule_frame();
-                    }
-                    SignInState::ChatGptDeviceCode(state) => {
-                        if let Some(cancel) = &state.cancel {
-                            cancel.notify_one();
-                        }
-                        *sign_in_state = SignInState::PickMode;
-                        drop(sign_in_state);
-                        self.set_error(/*message*/ None);
-                        self.request_frame.schedule_frame();
-                    }
-                    _ => {}
-                }
+                self.cancel_active_attempt();
             }
             _ => {}
         }
@@ -221,6 +191,36 @@ pub(crate) struct AuthModeWidget {
 }
 
 impl AuthModeWidget {
+    pub(crate) fn cancel_active_attempt(&self) {
+        let mut sign_in_state = self.sign_in_state.write().unwrap();
+        match &*sign_in_state {
+            SignInState::ChatGptContinueInBrowser(state) => {
+                let request_handle = self.app_server_request_handle.clone();
+                let login_id = state.login_id.clone();
+                tokio::spawn(async move {
+                    let _ = request_handle
+                        .request_typed::<codex_app_server_protocol::CancelLoginAccountResponse>(
+                            ClientRequest::CancelLoginAccount {
+                                request_id: onboarding_request_id(),
+                                params: CancelLoginAccountParams { login_id },
+                            },
+                        )
+                        .await;
+                });
+            }
+            SignInState::ChatGptDeviceCode(state) => {
+                if let Some(cancel) = &state.cancel {
+                    cancel.notify_one();
+                }
+            }
+            _ => return,
+        }
+        *sign_in_state = SignInState::PickMode;
+        drop(sign_in_state);
+        self.set_error(/*message*/ None);
+        self.request_frame.schedule_frame();
+    }
+
     fn set_error(&self, message: Option<String>) {
         *self.error.write().unwrap() = message;
     }
@@ -771,6 +771,7 @@ impl AuthModeWidget {
                 .await
             {
                 Ok(LoginAccountResponse::Chatgpt { login_id, auth_url }) => {
+                    maybe_open_auth_url_in_browser(&request_handle, &auth_url);
                     *error.write().unwrap() = None;
                     *sign_in_state.write().unwrap() =
                         SignInState::ChatGptContinueInBrowser(ContinueInBrowserState {
@@ -877,6 +878,16 @@ impl WidgetRef for AuthModeWidget {
                 self.render_api_key_configured(area, buf);
             }
         }
+    }
+}
+
+pub(super) fn maybe_open_auth_url_in_browser(request_handle: &AppServerRequestHandle, url: &str) {
+    if !matches!(request_handle, AppServerRequestHandle::InProcess(_)) {
+        return;
+    }
+
+    if let Err(err) = webbrowser::open(url) {
+        tracing::warn!("failed to open browser for login URL: {err}");
     }
 }
 
@@ -988,6 +999,50 @@ mod tests {
             &*widget.sign_in_state.read().unwrap(),
             SignInState::ChatGptSuccess
         ));
+    }
+
+    #[tokio::test]
+    async fn cancel_active_attempt_resets_browser_login_state() {
+        let (widget, _tmp) = widget_forced_chatgpt().await;
+        *widget.error.write().unwrap() = Some("still logging in".to_string());
+        *widget.sign_in_state.write().unwrap() =
+            SignInState::ChatGptContinueInBrowser(ContinueInBrowserState {
+                login_id: "login-1".to_string(),
+                auth_url: "https://auth.example.com".to_string(),
+            });
+
+        widget.cancel_active_attempt();
+
+        assert_eq!(widget.error_message(), None);
+        assert!(matches!(
+            &*widget.sign_in_state.read().unwrap(),
+            SignInState::PickMode
+        ));
+    }
+
+    #[tokio::test]
+    async fn cancel_active_attempt_notifies_device_code_login() {
+        let (widget, _tmp) = widget_forced_chatgpt().await;
+        let cancel = Arc::new(Notify::new());
+        *widget.error.write().unwrap() = Some("still logging in".to_string());
+        *widget.sign_in_state.write().unwrap() =
+            SignInState::ChatGptDeviceCode(ContinueWithDeviceCodeState {
+                device_code: None,
+                cancel: Some(cancel.clone()),
+            });
+
+        widget.cancel_active_attempt();
+
+        assert_eq!(widget.error_message(), None);
+        assert!(matches!(
+            &*widget.sign_in_state.read().unwrap(),
+            SignInState::PickMode
+        ));
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(50), cancel.notified())
+                .await
+                .is_ok()
+        );
     }
 
     /// Collects all buffer cell symbols that contain the OSC 8 open sequence

--- a/codex-rs/tui_app_server/src/onboarding/auth/headless_chatgpt_login.rs
+++ b/codex-rs/tui_app_server/src/onboarding/auth/headless_chatgpt_login.rs
@@ -29,6 +29,7 @@ use super::ContinueInBrowserState;
 use super::ContinueWithDeviceCodeState;
 use super::SignInState;
 use super::mark_url_hyperlink;
+use super::maybe_open_auth_url_in_browser;
 use super::onboarding_request_id;
 
 pub(super) fn start_headless_chatgpt_login(widget: &mut AuthModeWidget) {
@@ -289,6 +290,7 @@ async fn fallback_to_browser_login(
         .await
     {
         Ok(LoginAccountResponse::Chatgpt { login_id, auth_url }) => {
+            maybe_open_auth_url_in_browser(&request_handle, &auth_url);
             *error.write().unwrap() = None;
             let _updated = set_device_code_state_for_active_attempt(
                 &sign_in_state,

--- a/codex-rs/tui_app_server/src/onboarding/onboarding_screen.rs
+++ b/codex-rs/tui_app_server/src/onboarding/onboarding_screen.rs
@@ -206,6 +206,14 @@ impl OnboardingScreen {
         self.should_exit
     }
 
+    fn cancel_auth_if_active(&self) {
+        for step in &self.steps {
+            if let Step::Auth(widget) = step {
+                widget.cancel_active_attempt();
+            }
+        }
+    }
+
     fn auth_widget_mut(&mut self) -> Option<&mut AuthModeWidget> {
         self.steps.iter_mut().find_map(|step| match step {
             Step::Auth(widget) => Some(widget),
@@ -270,6 +278,7 @@ impl KeyboardHandler for OnboardingScreen {
         };
         if should_quit {
             if self.is_auth_in_progress() {
+                self.cancel_auth_if_active();
                 // If the user cancels the auth menu, exit the app rather than
                 // leave the user at a prompt in an unauthed state.
                 self.should_exit = true;


### PR DESCRIPTION
## Summary

This PR fixes a cluster of `tui_app_server` regressions in startup, login, and shutdown behavior:

- Fixes a fatal startup error when launching the CLI while logged out:
  `account/rateLimits/read failed during TUI bootstrap`
- Fixes terminal cleanup on early TUI exit paths, which could leave behind a stray `%` in `zsh`. This affects both tui and tui_app_server paths
- Fixes ChatGPT login browser launch so the local browser opens again for in-process `tui_app_server` login flows
- Fixes slow `Ctrl+C` exit from the “Finish signing in with your browser” screen by canceling the active login attempt before onboarding shutdown

## Root Causes

### Logged-out bootstrap failure
During TUI bootstrap, `tui_app_server` fetched account rate limits unconditionally and treated any failure as fatal. When the user was logged out, the account bootstrap response had no ChatGPT account, so the rate-limit RPC failed and aborted startup.

### Stray `%` after exit
Several app-server TUI paths could return after `tui::init()` without guaranteeing terminal restore. That left the shell inheriting a dirty terminal state, which showed up as a highlighted `%` prompt marker in `zsh`.

### ChatGPT browser not opening
In the app-server-backed login flow, the backend intentionally starts the ChatGPT login server with `open_browser: false`, but the TUI client never opened the returned `auth_url` itself. As a result, the browser never launched.

### Slow `Ctrl+C` on login screen
`Esc` canceled the active auth attempt, but onboarding-level `Ctrl+C` quit bypassed that cancellation path. The TUI exited while the login server was still running, and in-process app-server shutdown then waited on that stale login attempt.

## Fixes

- Rate-limit bootstrap is now gated so it only runs when OpenAI auth is required and a ChatGPT account is actually present; failures are treated as non-fatal and fall back to empty snapshots
- Added guaranteed terminal restore guards around TUI startup/exit paths so fatal and early-return flows restore the terminal cleanly
- The app-server TUI now opens ChatGPT `auth_url`s locally for in-process login flows, including the device-code fallback-to-browser path
- Auth cancellation is now centralized and reused by both `Esc` and onboarding `Ctrl+C`
- In-process app-server shutdown now explicitly drops any active ChatGPT login before draining background work
