### PR TITLE
Clean up TUI /plugins row allignment

### DIFF
--- a/codex-rs/tui/src/chatwidget/plugins.rs
+++ b/codex-rs/tui/src/chatwidget/plugins.rs
@@ -687,7 +687,7 @@ impl ChatWidget {
                 plugin_brief_description(plugin, &marketplace_label, status_label_width);
             let selected_status_label = format!("{status_label:<status_label_width$}");
             let selected_description =
-                format!("{selected_status_label} · Press Enter to view plugin details.");
+                format!("{selected_status_label}   Press Enter to view plugin details.");
             let search_value = format!(
                 "{display_name} {} {} {}",
                 plugin.id, plugin.name, marketplace_label

--- a/codex-rs/tui/src/chatwidget/plugins.rs
+++ b/codex-rs/tui/src/chatwidget/plugins.rs
@@ -673,14 +673,21 @@ impl ChatWidget {
                 .then_with(|| left.1.name.cmp(&right.1.name))
                 .then_with(|| left.1.id.cmp(&right.1.id))
         });
+        let status_label_width = plugin_entries
+            .iter()
+            .map(|(_, plugin, _)| plugin_status_label(plugin).chars().count())
+            .max()
+            .unwrap_or(0);
 
         let mut items: Vec<SelectionItem> = Vec::new();
         for (marketplace, plugin, display_name) in plugin_entries {
             let marketplace_label = marketplace_display_name(marketplace);
             let status_label = plugin_status_label(plugin);
-            let description = plugin_brief_description(plugin, &marketplace_label);
+            let description =
+                plugin_brief_description(plugin, &marketplace_label, status_label_width);
+            let selected_status_label = format!("{status_label:<status_label_width$}");
             let selected_description =
-                format!("{status_label}. Press Enter to view plugin details.");
+                format!("{selected_status_label} · Press Enter to view plugin details.");
             let search_value = format!(
                 "{display_name} {} {} {}",
                 plugin.id, plugin.name, marketplace_label
@@ -691,7 +698,7 @@ impl ChatWidget {
             let plugin_name = plugin.name.clone();
 
             items.push(SelectionItem {
-                name: format!("{display_name} · {marketplace_label}"),
+                name: display_name,
                 description: Some(description),
                 selected_description: Some(selected_description),
                 search_value: Some(search_value),
@@ -876,8 +883,13 @@ fn plugin_display_name(plugin: &PluginSummary) -> String {
         .unwrap_or_else(|| plugin.name.clone())
 }
 
-fn plugin_brief_description(plugin: &PluginSummary, marketplace_label: &str) -> String {
+fn plugin_brief_description(
+    plugin: &PluginSummary,
+    marketplace_label: &str,
+    status_label_width: usize,
+) -> String {
     let status_label = plugin_status_label(plugin);
+    let status_label = format!("{status_label:<status_label_width$}");
     match plugin_description(plugin) {
         Some(description) => format!("{status_label} · {marketplace_label} · {description}"),
         None => format!("{status_label} · {marketplace_label}"),
@@ -894,7 +906,7 @@ fn plugin_status_label(plugin: &PluginSummary) -> &'static str {
     } else {
         match plugin.install_policy {
             PluginInstallPolicy::NotAvailable => "Not installable",
-            PluginInstallPolicy::Available => "Can be installed",
+            PluginInstallPolicy::Available => "Available",
             PluginInstallPolicy::InstalledByDefault => "Available by default",
         }
     }

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plugin_detail_popup_installable.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plugin_detail_popup_installable.snap
@@ -4,7 +4,7 @@ expression: popup
 ---
   Plugins
   Figma · ChatGPT Marketplace
-  Can be installed
+  Available
   Turn Figma files into implementation context.
 
 › 1. Back to plugins  Return to the plugin list.

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plugins_popup_curated_marketplace.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plugins_popup_curated_marketplace.snap
@@ -10,8 +10,8 @@ expression: popup
 
   Type to search plugins
 › Alpha Sync          Installed · Disabled · Press Enter to view plugin details.
-  Bravo Search        Available           · ChatGPT Marketplace · Search docs and tickets.
-  Hidden Repo Plugin  Available           · Repo Marketplace · Should not be shown in /plugins.
+  Bravo Search        Available            · ChatGPT Marketplace · Search docs and tickets.
+  Hidden Repo Plugin  Available            · Repo Marketplace · Should not be shown in /plugins.
   Starter             Available by default · ChatGPT Marketplace · Included by default.
 
   Press esc to close.

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plugins_popup_curated_marketplace.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plugins_popup_curated_marketplace.snap
@@ -9,12 +9,9 @@ expression: popup
   Using cached marketplace data: remote sync timed out
 
   Type to search plugins
-› Alpha Sync · ChatGPT Marketplace       Installed · Disabled. Press Enter to view plugin details.
-  Bravo Search · ChatGPT Marketplace     Can be installed · ChatGPT Marketplace · Search docs and
-                                         tickets.
-  Hidden Repo Plugin · Repo Marketplace  Can be installed · Repo Marketplace · Should not be shown
-                                         in /plugins.
-  Starter · ChatGPT Marketplace          Available by default · ChatGPT Marketplace · Included by
-                                         default.
+› Alpha Sync          Installed · Disabled · Press Enter to view plugin details.
+  Bravo Search        Available           · ChatGPT Marketplace · Search docs and tickets.
+  Hidden Repo Plugin  Available           · Repo Marketplace · Should not be shown in /plugins.
+  Starter             Available by default · ChatGPT Marketplace · Included by default.
 
   Press esc to close.

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plugins_popup_curated_marketplace.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plugins_popup_curated_marketplace.snap
@@ -9,7 +9,7 @@ expression: popup
   Using cached marketplace data: remote sync timed out
 
   Type to search plugins
-› Alpha Sync          Installed · Disabled · Press Enter to view plugin details.
+› Alpha Sync          Installed · Disabled   Press Enter to view plugin details.
   Bravo Search        Available            · ChatGPT Marketplace · Search docs and tickets.
   Hidden Repo Plugin  Available            · Repo Marketplace · Should not be shown in /plugins.
   Starter             Available by default · ChatGPT Marketplace · Included by default.

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plugins_popup_search_filtered.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plugins_popup_search_filtered.snap
@@ -8,6 +8,6 @@ expression: popup
   Installed 0 of 3 available plugins.
 
   sla
-› Slack · ChatGPT Marketplace  Can be installed. Press Enter to view plugin details.
+› Slack  Available · Press Enter to view plugin details.
 
   Press esc to close.

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plugins_popup_search_filtered.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plugins_popup_search_filtered.snap
@@ -8,6 +8,6 @@ expression: popup
   Installed 0 of 3 available plugins.
 
   sla
-› Slack  Available · Press Enter to view plugin details.
+› Slack  Available   Press Enter to view plugin details.
 
   Press esc to close.

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -7411,7 +7411,7 @@ async fn plugins_popup_refresh_replaces_selection_with_first_row() {
         "expected refresh to rebuild the popup from the new first row, got:\n{after}"
     );
     assert!(
-        after.contains("Slack · ChatGPT Marketplace"),
+        after.contains("Slack"),
         "expected refreshed popup to include the updated plugin list, got:\n{after}"
     );
 }
@@ -7447,7 +7447,7 @@ async fn plugins_popup_refreshes_installed_counts_after_install() {
         "expected initial installed count before refresh, got:\n{before}"
     );
     assert!(
-        before.contains("Can be installed"),
+        before.contains("Available"),
         "expected pre-install popup copy before refresh, got:\n{before}"
     );
 
@@ -7480,7 +7480,7 @@ async fn plugins_popup_refreshes_installed_counts_after_install() {
         "expected /plugins to refresh installed counts after install, got:\n{after}"
     );
     assert!(
-        after.contains("Installed. Press Enter to view plugin details."),
+        after.contains("Installed · Press Enter to view plugin details."),
         "expected refreshed selected row copy to reflect the installed plugin state, got:\n{after}"
     );
 }
@@ -7528,8 +7528,7 @@ async fn plugins_popup_search_filters_visible_rows_snapshot() {
     let popup = render_bottom_popup(&chat, 100);
     assert_snapshot!("plugins_popup_search_filtered", popup);
     assert!(
-        !popup.contains("Calendar · ChatGPT Marketplace")
-            && !popup.contains("Drive · ChatGPT Marketplace"),
+        !popup.contains("Calendar") && !popup.contains("Drive"),
         "expected search to leave only matching rows visible, got:\n{popup}"
     );
 }
@@ -7581,8 +7580,7 @@ async fn plugins_popup_search_no_matches_and_backspace_restores_results() {
 
     let restored = render_bottom_popup(&chat, 100);
     assert!(
-        restored.contains("Calendar · ChatGPT Marketplace")
-            && restored.contains("Slack · ChatGPT Marketplace"),
+        restored.contains("Calendar") && restored.contains("Slack"),
         "expected clearing the query to restore the plugin rows, got:\n{restored}"
     );
     assert!(

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -7480,7 +7480,7 @@ async fn plugins_popup_refreshes_installed_counts_after_install() {
         "expected /plugins to refresh installed counts after install, got:\n{after}"
     );
     assert!(
-        after.contains("Installed · Press Enter to view plugin details."),
+        after.contains("Installed   Press Enter to view plugin details."),
         "expected refreshed selected row copy to reflect the installed plugin state, got:\n{after}"
     );
 }

--- a/codex-rs/tui_app_server/src/chatwidget/plugins.rs
+++ b/codex-rs/tui_app_server/src/chatwidget/plugins.rs
@@ -687,7 +687,7 @@ impl ChatWidget {
                 plugin_brief_description(plugin, &marketplace_label, status_label_width);
             let selected_status_label = format!("{status_label:<status_label_width$}");
             let selected_description =
-                format!("{selected_status_label} · Press Enter to view plugin details.");
+                format!("{selected_status_label}   Press Enter to view plugin details.");
             let search_value = format!(
                 "{display_name} {} {} {}",
                 plugin.id, plugin.name, marketplace_label

--- a/codex-rs/tui_app_server/src/chatwidget/plugins.rs
+++ b/codex-rs/tui_app_server/src/chatwidget/plugins.rs
@@ -673,14 +673,21 @@ impl ChatWidget {
                 .then_with(|| left.1.name.cmp(&right.1.name))
                 .then_with(|| left.1.id.cmp(&right.1.id))
         });
+        let status_label_width = plugin_entries
+            .iter()
+            .map(|(_, plugin, _)| plugin_status_label(plugin).chars().count())
+            .max()
+            .unwrap_or(0);
 
         let mut items: Vec<SelectionItem> = Vec::new();
         for (marketplace, plugin, display_name) in plugin_entries {
             let marketplace_label = marketplace_display_name(marketplace);
             let status_label = plugin_status_label(plugin);
-            let description = plugin_brief_description(plugin, &marketplace_label);
+            let description =
+                plugin_brief_description(plugin, &marketplace_label, status_label_width);
+            let selected_status_label = format!("{status_label:<status_label_width$}");
             let selected_description =
-                format!("{status_label}. Press Enter to view plugin details.");
+                format!("{selected_status_label} · Press Enter to view plugin details.");
             let search_value = format!(
                 "{display_name} {} {} {}",
                 plugin.id, plugin.name, marketplace_label
@@ -691,7 +698,7 @@ impl ChatWidget {
             let plugin_name = plugin.name.clone();
 
             items.push(SelectionItem {
-                name: format!("{display_name} · {marketplace_label}"),
+                name: display_name,
                 description: Some(description),
                 selected_description: Some(selected_description),
                 search_value: Some(search_value),
@@ -876,8 +883,13 @@ fn plugin_display_name(plugin: &PluginSummary) -> String {
         .unwrap_or_else(|| plugin.name.clone())
 }
 
-fn plugin_brief_description(plugin: &PluginSummary, marketplace_label: &str) -> String {
+fn plugin_brief_description(
+    plugin: &PluginSummary,
+    marketplace_label: &str,
+    status_label_width: usize,
+) -> String {
     let status_label = plugin_status_label(plugin);
+    let status_label = format!("{status_label:<status_label_width$}");
     match plugin_description(plugin) {
         Some(description) => format!("{status_label} · {marketplace_label} · {description}"),
         None => format!("{status_label} · {marketplace_label}"),
@@ -894,7 +906,7 @@ fn plugin_status_label(plugin: &PluginSummary) -> &'static str {
     } else {
         match plugin.install_policy {
             PluginInstallPolicy::NotAvailable => "Not installable",
-            PluginInstallPolicy::Available => "Can be installed",
+            PluginInstallPolicy::Available => "Available",
             PluginInstallPolicy::InstalledByDefault => "Available by default",
         }
     }

--- a/codex-rs/tui_app_server/src/chatwidget/snapshots/codex_tui_app_server__chatwidget__tests__plugin_detail_popup_installable.snap
+++ b/codex-rs/tui_app_server/src/chatwidget/snapshots/codex_tui_app_server__chatwidget__tests__plugin_detail_popup_installable.snap
@@ -4,7 +4,7 @@ expression: popup
 ---
   Plugins
   Figma · ChatGPT Marketplace
-  Can be installed
+  Available
   Turn Figma files into implementation context.
 
 › 1. Back to plugins  Return to the plugin list.

--- a/codex-rs/tui_app_server/src/chatwidget/snapshots/codex_tui_app_server__chatwidget__tests__plugins_popup_curated_marketplace.snap
+++ b/codex-rs/tui_app_server/src/chatwidget/snapshots/codex_tui_app_server__chatwidget__tests__plugins_popup_curated_marketplace.snap
@@ -9,8 +9,8 @@ expression: popup
 
   Type to search plugins
 › Alpha Sync          Installed · Disabled · Press Enter to view plugin details.
-  Bravo Search        Available           · ChatGPT Marketplace · Search docs and tickets.
-  Hidden Repo Plugin  Available           · Repo Marketplace · Should not be shown in /plugins.
+  Bravo Search        Available            · ChatGPT Marketplace · Search docs and tickets.
+  Hidden Repo Plugin  Available            · Repo Marketplace · Should not be shown in /plugins.
   Starter             Available by default · ChatGPT Marketplace · Included by default.
 
   Press esc to close.

--- a/codex-rs/tui_app_server/src/chatwidget/snapshots/codex_tui_app_server__chatwidget__tests__plugins_popup_curated_marketplace.snap
+++ b/codex-rs/tui_app_server/src/chatwidget/snapshots/codex_tui_app_server__chatwidget__tests__plugins_popup_curated_marketplace.snap
@@ -8,7 +8,7 @@ expression: popup
   Using cached marketplace data: remote sync timed out
 
   Type to search plugins
-› Alpha Sync          Installed · Disabled · Press Enter to view plugin details.
+› Alpha Sync          Installed · Disabled   Press Enter to view plugin details.
   Bravo Search        Available            · ChatGPT Marketplace · Search docs and tickets.
   Hidden Repo Plugin  Available            · Repo Marketplace · Should not be shown in /plugins.
   Starter             Available by default · ChatGPT Marketplace · Included by default.

--- a/codex-rs/tui_app_server/src/chatwidget/snapshots/codex_tui_app_server__chatwidget__tests__plugins_popup_curated_marketplace.snap
+++ b/codex-rs/tui_app_server/src/chatwidget/snapshots/codex_tui_app_server__chatwidget__tests__plugins_popup_curated_marketplace.snap
@@ -8,12 +8,9 @@ expression: popup
   Using cached marketplace data: remote sync timed out
 
   Type to search plugins
-› Alpha Sync · ChatGPT Marketplace       Installed · Disabled. Press Enter to view plugin details.
-  Bravo Search · ChatGPT Marketplace     Can be installed · ChatGPT Marketplace · Search docs and
-                                         tickets.
-  Hidden Repo Plugin · Repo Marketplace  Can be installed · Repo Marketplace · Should not be shown
-                                         in /plugins.
-  Starter · ChatGPT Marketplace          Available by default · ChatGPT Marketplace · Included by
-                                         default.
+› Alpha Sync          Installed · Disabled · Press Enter to view plugin details.
+  Bravo Search        Available           · ChatGPT Marketplace · Search docs and tickets.
+  Hidden Repo Plugin  Available           · Repo Marketplace · Should not be shown in /plugins.
+  Starter             Available by default · ChatGPT Marketplace · Included by default.
 
   Press esc to close.

--- a/codex-rs/tui_app_server/src/chatwidget/snapshots/codex_tui_app_server__chatwidget__tests__plugins_popup_search_filtered.snap
+++ b/codex-rs/tui_app_server/src/chatwidget/snapshots/codex_tui_app_server__chatwidget__tests__plugins_popup_search_filtered.snap
@@ -7,6 +7,6 @@ expression: popup
   Installed 0 of 3 available plugins.
 
   sla
-› Slack  Available · Press Enter to view plugin details.
+› Slack  Available   Press Enter to view plugin details.
 
   Press esc to close.

--- a/codex-rs/tui_app_server/src/chatwidget/snapshots/codex_tui_app_server__chatwidget__tests__plugins_popup_search_filtered.snap
+++ b/codex-rs/tui_app_server/src/chatwidget/snapshots/codex_tui_app_server__chatwidget__tests__plugins_popup_search_filtered.snap
@@ -7,6 +7,6 @@ expression: popup
   Installed 0 of 3 available plugins.
 
   sla
-› Slack · ChatGPT Marketplace  Can be installed. Press Enter to view plugin details.
+› Slack  Available · Press Enter to view plugin details.
 
   Press esc to close.

--- a/codex-rs/tui_app_server/src/chatwidget/tests.rs
+++ b/codex-rs/tui_app_server/src/chatwidget/tests.rs
@@ -8008,7 +8008,7 @@ async fn plugins_popup_refresh_replaces_selection_with_first_row() {
         "expected refresh to rebuild the popup from the new first row, got:\n{after}"
     );
     assert!(
-        after.contains("Slack · ChatGPT Marketplace"),
+        after.contains("Slack"),
         "expected refreshed popup to include the updated plugin list, got:\n{after}"
     );
 }
@@ -8044,7 +8044,7 @@ async fn plugins_popup_refreshes_installed_counts_after_install() {
         "expected initial installed count before refresh, got:\n{before}"
     );
     assert!(
-        before.contains("Can be installed"),
+        before.contains("Available"),
         "expected pre-install popup copy before refresh, got:\n{before}"
     );
 
@@ -8077,7 +8077,7 @@ async fn plugins_popup_refreshes_installed_counts_after_install() {
         "expected /plugins to refresh installed counts after install, got:\n{after}"
     );
     assert!(
-        after.contains("Installed. Press Enter to view plugin details."),
+        after.contains("Installed · Press Enter to view plugin details."),
         "expected refreshed selected row copy to reflect the installed plugin state, got:\n{after}"
     );
 }
@@ -8125,8 +8125,7 @@ async fn plugins_popup_search_filters_visible_rows_snapshot() {
     let popup = render_bottom_popup(&chat, 100);
     assert_snapshot!("plugins_popup_search_filtered", popup);
     assert!(
-        !popup.contains("Calendar · ChatGPT Marketplace")
-            && !popup.contains("Drive · ChatGPT Marketplace"),
+        !popup.contains("Calendar") && !popup.contains("Drive"),
         "expected search to leave only matching rows visible, got:\n{popup}"
     );
 }
@@ -8178,8 +8177,7 @@ async fn plugins_popup_search_no_matches_and_backspace_restores_results() {
 
     let restored = render_bottom_popup(&chat, 100);
     assert!(
-        restored.contains("Calendar · ChatGPT Marketplace")
-            && restored.contains("Slack · ChatGPT Marketplace"),
+        restored.contains("Calendar") && restored.contains("Slack"),
         "expected clearing the query to restore the plugin rows, got:\n{restored}"
     );
     assert!(

--- a/codex-rs/tui_app_server/src/chatwidget/tests.rs
+++ b/codex-rs/tui_app_server/src/chatwidget/tests.rs
@@ -8077,7 +8077,7 @@ async fn plugins_popup_refreshes_installed_counts_after_install() {
         "expected /plugins to refresh installed counts after install, got:\n{after}"
     );
     assert!(
-        after.contains("Installed · Press Enter to view plugin details."),
+        after.contains("Installed   Press Enter to view plugin details."),
         "expected refreshed selected row copy to reflect the installed plugin state, got:\n{after}"
     );
 }


### PR DESCRIPTION
- Remove marketplace from left column.
- Change `Can be installed` to `Available`
- Align right-column marketplace + selected-row hint text across states.
- Changes applied to both `tui` and `tui_app_server`.
- Update related snapshots/tests.


<img width="2142" height="590" alt="image" src="https://github.com/user-attachments/assets/6e60b783-2bea-46d4-b353-f2fd328ac4d0" />
