### PR TITLE
tui_app_server: tolerate missing rate limits while logged out

### DIFF
--- a/codex-rs/tui_app_server/src/app_server_session.rs
+++ b/codex-rs/tui_app_server/src/app_server_session.rs
@@ -80,6 +80,7 @@ use color_eyre::eyre::Result;
 use color_eyre::eyre::WrapErr;
 use std::collections::HashMap;
 use std::path::PathBuf;
+use tracing::debug;
 
 use crate::bottom_pane::FeedbackAudience;
 use crate::status::StatusAccountDisplay;
@@ -178,16 +179,6 @@ impl AppServerSession {
             })
             .await
             .wrap_err("model/list failed during TUI bootstrap")?;
-        let rate_limit_request_id = self.next_request_id();
-        let rate_limits: GetAccountRateLimitsResponse = self
-            .client
-            .request_typed(ClientRequest::GetAccountRateLimits {
-                request_id: rate_limit_request_id,
-                params: None,
-            })
-            .await
-            .wrap_err("account/rateLimits/read failed during TUI bootstrap")?;
-
         let available_models = models
             .data
             .into_iter()
@@ -252,6 +243,25 @@ impl AppServerSession {
                 false,
             ),
         };
+        let rate_limit_snapshots = if account.requires_openai_auth && has_chatgpt_account {
+            let rate_limit_request_id = self.next_request_id();
+            match self
+                .client
+                .request_typed(ClientRequest::GetAccountRateLimits {
+                    request_id: rate_limit_request_id,
+                    params: None,
+                })
+                .await
+            {
+                Ok(rate_limits) => app_server_rate_limit_snapshots_to_core(rate_limits),
+                Err(error) => {
+                    debug!(error = ?error, "failed to fetch rate limits during TUI bootstrap");
+                    Vec::new()
+                }
+            }
+        } else {
+            Vec::new()
+        };
 
         Ok(AppServerBootstrap {
             account_auth_mode,
@@ -263,7 +273,7 @@ impl AppServerSession {
             feedback_audience,
             has_chatgpt_account,
             available_models,
-            rate_limit_snapshots: app_server_rate_limit_snapshots_to_core(rate_limits),
+            rate_limit_snapshots,
         })
     }
 


### PR DESCRIPTION
## Summary

Fixes a `tui_app_server` bootstrap failure when launching the CLI while logged out.

## Root cause

During TUI bootstrap, `tui_app_server` fetched `account/rateLimits/read` unconditionally and treated failures as fatal. When the user was logged out, there was no ChatGPT account available, so that RPC failed and aborted startup with:

```
Error: account/rateLimits/read failed during TUI bootstrap
```

## Changes

- Only fetch bootstrap rate limits when OpenAI auth is required and a ChatGPT account is present
- Treat bootstrap rate-limit fetch failures as non-fatal and fall back to empty snapshots
- Log the fetch failure at debug level instead of aborting startup