### PR TITLE
Tweak /plugin menu wording

### DIFF
--- a/codex-rs/tui/src/chatwidget/plugins.rs
+++ b/codex-rs/tui/src/chatwidget/plugins.rs
@@ -355,9 +355,7 @@ impl ChatWidget {
             };
             items.push(SelectionItem {
                 name: install_label.to_string(),
-                description: Some(
-                    "Open the ChatGPT app management page".to_string(),
-                ),
+                description: Some("Open the ChatGPT app management page".to_string()),
                 selected_description: Some("Open the app page in your browser.".to_string()),
                 actions: vec![Box::new(move |tx| {
                     tx.send(AppEvent::OpenUrlInBrowser {
@@ -508,9 +506,7 @@ impl ChatWidget {
             header: Box::new(header),
             items: vec![SelectionItem {
                 name: "Loading plugin details...".to_string(),
-                description: Some(
-                    "This updates when plugin details have been loaded.".to_string(),
-                ),
+                description: Some("This updates when plugin details load.".to_string()),
                 is_disabled: true,
                 ..Default::default()
             }],

--- a/codex-rs/tui/src/chatwidget/plugins.rs
+++ b/codex-rs/tui/src/chatwidget/plugins.rs
@@ -478,7 +478,7 @@ impl ChatWidget {
         header.push(Line::from("Plugins".bold()));
         header.push(Line::from("Loading available plugins...".dim()));
         header.push(Line::from(
-            "This first pass shows the ChatGPT marketplace only.".dim(),
+            "Available marketplaces will appear here when ready.".dim(),
         ));
 
         SelectionViewParams {

--- a/codex-rs/tui/src/chatwidget/plugins.rs
+++ b/codex-rs/tui/src/chatwidget/plugins.rs
@@ -356,7 +356,7 @@ impl ChatWidget {
             items.push(SelectionItem {
                 name: install_label.to_string(),
                 description: Some(
-                    "Open the same ChatGPT app management link used by /apps.".to_string(),
+                    "Open the ChatGPT app management page".to_string(),
                 ),
                 selected_description: Some("Open the app page in your browser.".to_string()),
                 actions: vec![Box::new(move |tx| {
@@ -368,7 +368,7 @@ impl ChatWidget {
             });
         } else {
             items.push(SelectionItem {
-                name: "ChatGPT link unavailable".to_string(),
+                name: "ChatGPT apps link unavailable".to_string(),
                 description: Some("This app did not provide an install/manage URL.".to_string()),
                 is_disabled: true,
                 ..Default::default()
@@ -509,7 +509,7 @@ impl ChatWidget {
             items: vec![SelectionItem {
                 name: "Loading plugin details...".to_string(),
                 description: Some(
-                    "This updates when the plugin detail request finishes.".to_string(),
+                    "This updates when plugin details have been loaded.".to_string(),
                 ),
                 is_disabled: true,
                 ..Default::default()
@@ -556,7 +556,7 @@ impl ChatWidget {
             header: Box::new(header),
             items: vec![SelectionItem {
                 name: "Uninstalling plugin...".to_string(),
-                description: Some("This updates when plugin removal completes.".to_string()),
+                description: Some("This updates when the plugin removal completes.".to_string()),
                 is_disabled: true,
                 ..Default::default()
             }],

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plugins_popup_loading_state.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plugins_popup_loading_state.snap
@@ -4,6 +4,6 @@ expression: popup
 ---
   Plugins
   Loading available plugins...
-  This first pass shows the ChatGPT marketplace only.
+  Available marketplaces will appear here when ready.
 
 › 1. Loading plugins...  This updates when the marketplace list is ready.

--- a/codex-rs/tui_app_server/src/chatwidget/plugins.rs
+++ b/codex-rs/tui_app_server/src/chatwidget/plugins.rs
@@ -355,9 +355,7 @@ impl ChatWidget {
             };
             items.push(SelectionItem {
                 name: install_label.to_string(),
-                description: Some(
-                    "Open the same ChatGPT app management link used by /apps.".to_string(),
-                ),
+                description: Some("Open the ChatGPT app management page".to_string()),
                 selected_description: Some("Open the app page in your browser.".to_string()),
                 actions: vec![Box::new(move |tx| {
                     tx.send(AppEvent::OpenUrlInBrowser {
@@ -368,7 +366,7 @@ impl ChatWidget {
             });
         } else {
             items.push(SelectionItem {
-                name: "ChatGPT link unavailable".to_string(),
+                name: "ChatGPT apps link unavailable".to_string(),
                 description: Some("This app did not provide an install/manage URL.".to_string()),
                 is_disabled: true,
                 ..Default::default()
@@ -508,9 +506,7 @@ impl ChatWidget {
             header: Box::new(header),
             items: vec![SelectionItem {
                 name: "Loading plugin details...".to_string(),
-                description: Some(
-                    "This updates when the plugin detail request finishes.".to_string(),
-                ),
+                description: Some("This updates when plugin details load.".to_string()),
                 is_disabled: true,
                 ..Default::default()
             }],
@@ -556,7 +552,7 @@ impl ChatWidget {
             header: Box::new(header),
             items: vec![SelectionItem {
                 name: "Uninstalling plugin...".to_string(),
-                description: Some("This updates when plugin removal completes.".to_string()),
+                description: Some("This updates when the plugin removal completes.".to_string()),
                 is_disabled: true,
                 ..Default::default()
             }],

--- a/codex-rs/tui_app_server/src/chatwidget/plugins.rs
+++ b/codex-rs/tui_app_server/src/chatwidget/plugins.rs
@@ -478,7 +478,7 @@ impl ChatWidget {
         header.push(Line::from("Plugins".bold()));
         header.push(Line::from("Loading available plugins...".dim()));
         header.push(Line::from(
-            "This first pass shows the ChatGPT marketplace only.".dim(),
+            "Available marketplaces will appear here when ready.".dim(),
         ));
 
         SelectionViewParams {

--- a/codex-rs/tui_app_server/src/chatwidget/snapshots/codex_tui_app_server__chatwidget__tests__plugins_popup_loading_state.snap
+++ b/codex-rs/tui_app_server/src/chatwidget/snapshots/codex_tui_app_server__chatwidget__tests__plugins_popup_loading_state.snap
@@ -4,6 +4,6 @@ expression: popup
 ---
   Plugins
   Loading available plugins...
-  This first pass shows the ChatGPT marketplace only.
+  Available marketplaces will appear here when ready.
 
 › 1. Loading plugins...  This updates when the marketplace list is ready.


### PR DESCRIPTION
- Updated `/plugin` UI messaging for clearer wording.
- Synced the same copy changes across `tui` and `tui_app_server`.