### PR TITLE
Clarify codex_home base for MDM path resolution

### DIFF
--- a/codex-rs/core/src/config_loader/mod.rs
+++ b/codex-rs/core/src/config_loader/mod.rs
@@ -285,6 +285,8 @@ pub async fn load_config_layers_state(
         ));
     }
     if let Some(config) = managed_config_from_mdm {
+        // Use codex_home as the synthetic base so AbsolutePathBufGuard expands
+        // both `~` and `./` here. In practice, MDM is expected to use `~`.
         let managed_config =
             resolve_relative_paths_in_config_toml(config.managed_config, codex_home)?;
         layers.push(ConfigLayerEntry::new_with_raw_toml(

--- a/codex-rs/core/src/config_loader/mod.rs
+++ b/codex-rs/core/src/config_loader/mod.rs
@@ -286,8 +286,9 @@ pub async fn load_config_layers_state(
     }
     if let Some(config) = managed_config_from_mdm {
         // Use codex_home as the synthetic base so AbsolutePathBufGuard expands
-        // both `~` and `./` here. In practice, MDM is expected to use `~`
-        // because MDM is set by a trusted person.
+        // both `~` and `./` here. MDM should prefer `~` or other absolute
+        // paths; we continue to resolve `./` for compatibility with existing
+        // managed configs.
         let managed_config =
             resolve_relative_paths_in_config_toml(config.managed_config, codex_home)?;
         layers.push(ConfigLayerEntry::new_with_raw_toml(

--- a/codex-rs/core/src/config_loader/mod.rs
+++ b/codex-rs/core/src/config_loader/mod.rs
@@ -286,7 +286,8 @@ pub async fn load_config_layers_state(
     }
     if let Some(config) = managed_config_from_mdm {
         // Use codex_home as the synthetic base so AbsolutePathBufGuard expands
-        // both `~` and `./` here. In practice, MDM is expected to use `~`.
+        // both `~` and `./` here. In practice, MDM is expected to use `~`
+        // because MDM is set by a trusted person.
         let managed_config =
             resolve_relative_paths_in_config_toml(config.managed_config, codex_home)?;
         layers.push(ConfigLayerEntry::new_with_raw_toml(

--- a/codex-rs/core/src/config_loader/mod.rs
+++ b/codex-rs/core/src/config_loader/mod.rs
@@ -285,10 +285,11 @@ pub async fn load_config_layers_state(
         ));
     }
     if let Some(config) = managed_config_from_mdm {
-        // Use codex_home as the synthetic base so AbsolutePathBufGuard expands
-        // both `~` and `./` here. MDM should prefer `~` or other absolute
-        // paths; we continue to resolve `./` for compatibility with existing
-        // managed configs.
+        // As a general rule, config from MDM should _not_ include relative
+        // paths, starting with `./`, but a path starting with `~/` _is_ a
+        // supported use case. Because resolve_relative_paths_in_config_toml()
+        // relies on AbsolutePathBufGuard to resolve `~/`, we must supply a
+        // value for base_dir, so codex_home is as good a value as any.
         let managed_config =
             resolve_relative_paths_in_config_toml(config.managed_config, codex_home)?;
         layers.push(ConfigLayerEntry::new_with_raw_toml(


### PR DESCRIPTION
## Summary

Add the follow up code comment Michael asked for at the MDM `managed_config_from_mdm` - a follow up from https://github.com/openai/codex/pull/15351.

## Validation

1. `cargo fmt --all --check`
2. `cargo test -p codex-core managed_preferences_expand_home_directory_in_workspace_write_roots -- --nocapture`
3. `cargo test -p codex-core write_value_succeeds_when_managed_preferences_expand_home_directory_paths -- --nocapture`
4. `./tools/argument-comment-lint/run-prebuilt-linter.sh -p codex-core`
