### PR TITLE
Treat ChatGPT `hc` plan as Enterprise

### DIFF
--- a/codex-rs/cloud-requirements/src/lib.rs
+++ b/codex-rs/cloud-requirements/src/lib.rs
@@ -1154,6 +1154,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn fetch_cloud_requirements_allows_hc_plan_as_enterprise() {
+        let codex_home = tempdir().expect("tempdir");
+        let service = CloudRequirementsService::new(
+            auth_manager_with_plan("hc"),
+            Arc::new(StaticFetcher {
+                contents: Some("allowed_approval_policies = [\"never\"]".to_string()),
+            }),
+            codex_home.path().to_path_buf(),
+            CLOUD_REQUIREMENTS_TIMEOUT,
+        );
+        assert_eq!(
+            service.fetch().await,
+            Ok(Some(ConfigRequirementsToml {
+                allowed_approval_policies: Some(vec![AskForApproval::Never]),
+                allowed_sandbox_modes: None,
+                allowed_web_search_modes: None,
+                guardian_developer_instructions: None,
+                feature_requirements: None,
+                mcp_servers: None,
+                apps: None,
+                rules: None,
+                enforce_residency: None,
+                network: None,
+            }))
+        );
+    }
+
+    #[tokio::test]
     async fn fetch_cloud_requirements_handles_missing_contents() {
         let result = parse_for_fetch(None);
         assert!(result.is_none());

--- a/codex-rs/login/src/token_data.rs
+++ b/codex-rs/login/src/token_data.rs
@@ -88,6 +88,7 @@ pub enum KnownPlan {
     Pro,
     Team,
     Business,
+    #[serde(alias = "hc")]
     Enterprise,
     Edu,
 }

--- a/codex-rs/login/src/token_data.rs
+++ b/codex-rs/login/src/token_data.rs
@@ -88,7 +88,6 @@ pub enum KnownPlan {
     Pro,
     Team,
     Business,
-    #[serde(alias = "hc")]
     Enterprise,
     Edu,
 }

--- a/codex-rs/login/src/token_data.rs
+++ b/codex-rs/login/src/token_data.rs
@@ -72,7 +72,7 @@ impl PlanType {
             "pro" => Self::Known(KnownPlan::Pro),
             "team" => Self::Known(KnownPlan::Team),
             "business" => Self::Known(KnownPlan::Business),
-            "enterprise" => Self::Known(KnownPlan::Enterprise),
+            "enterprise" | "hc" => Self::Known(KnownPlan::Enterprise),
             "education" | "edu" => Self::Known(KnownPlan::Edu),
             _ => Self::Unknown(raw.to_string()),
         }
@@ -88,6 +88,7 @@ pub enum KnownPlan {
     Pro,
     Team,
     Business,
+    #[serde(alias = "hc")]
     Enterprise,
     Edu,
 }

--- a/codex-rs/login/src/token_data_tests.rs
+++ b/codex-rs/login/src/token_data_tests.rs
@@ -54,6 +54,21 @@ fn id_token_info_parses_go_plan() {
 }
 
 #[test]
+fn id_token_info_parses_hc_plan_as_enterprise() {
+    let fake_jwt = fake_jwt(serde_json::json!({
+        "email": "user@example.com",
+        "https://api.openai.com/auth": {
+            "chatgpt_plan_type": "hc"
+        }
+    }));
+
+    let info = parse_chatgpt_jwt_claims(&fake_jwt).expect("should parse");
+    assert_eq!(info.email.as_deref(), Some("user@example.com"));
+    assert_eq!(info.get_chatgpt_plan_type().as_deref(), Some("Enterprise"));
+    assert_eq!(info.is_workspace_account(), true);
+}
+
+#[test]
 fn id_token_info_handles_missing_fields() {
     let fake_jwt = fake_jwt(serde_json::json!({ "sub": "123" }));
 


### PR DESCRIPTION
### Motivation

- Cloud requirements fetching only ran for `Business` or `Enterprise` accounts, but some ID tokens report `chatgpt_plan_type: "hc"`, which should be treated as an enterprise-equivalent plan.  

### Description

- Map raw plan string `"hc"` to `KnownPlan::Enterprise` in `PlanType::from_raw_value` by treating `"enterprise" | "hc"` as `Enterprise` in `login/src/token_data.rs`.  
- Add a unit test in `login/src/token_data_tests.rs` asserting a JWT with `chatgpt_plan_type: "hc"` parses as `Enterprise` and is considered a workspace account.  
- Add a unit test in `cloud-requirements/src/lib.rs` verifying `hc` accounts are eligible to fetch cloud requirements (treated like `Enterprise`).  
- Run formatting (`just fmt`) after changes.

### Testing

- Ran `just fmt` (succeeded).  
- Ran `cargo test -p codex-login --lib id_token_info_parses_hc_plan_as_enterprise` (passed).  
- Ran `cargo test -p codex-cloud-requirements --lib fetch_cloud_requirements_allows_hc_plan_as_enterprise` (passed) and `cargo test -p codex-cloud-requirements` (all tests passed).  
- Ran `just argument-comment-lint-from-source` (required installing `cargo-dylint`/`dylint-link` and the nightly toolchain as part of the run).  
- Note: a full `cargo test -p codex-login` run showed one unrelated, environment-dependent test failure (`auth::default_client::tests::test_create_client_sets_default_headers`) that is not caused by these changes; the targeted `login` unit added here passes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_69c349e31ae0832ca315ecc8ac718d4e)