### PR TITLE
#15565 Fix MCP tool display for hyphenated server names

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -217,7 +217,7 @@ use codex_core::find_thread_path_by_id_str;
 use codex_core::mcp::auth::discover_supported_scopes;
 use codex_core::mcp::auth::resolve_oauth_scopes;
 use codex_core::mcp::collect_mcp_snapshot;
-use codex_core::mcp::group_tools_by_server;
+use codex_core::mcp::group_tools_by_known_server_names;
 use codex_core::models_manager::collaboration_mode_presets::CollaborationModesConfig;
 use codex_core::parse_cursor;
 use codex_core::plugins::MarketplaceError;
@@ -264,6 +264,7 @@ use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::GitInfo as CoreGitInfo;
 use codex_protocol::protocol::InitialHistory;
 use codex_protocol::protocol::McpAuthStatus as CoreMcpAuthStatus;
+use codex_protocol::protocol::McpListToolsResponseEvent;
 use codex_protocol::protocol::McpServerRefreshConfig;
 use codex_protocol::protocol::Op;
 use codex_protocol::protocol::RateLimitSnapshot as CoreRateLimitSnapshot;
@@ -4845,80 +4846,14 @@ impl CodexMessageProcessor {
         config: Config,
     ) {
         let snapshot = collect_mcp_snapshot(&config).await;
-
-        let tools_by_server = group_tools_by_server(&snapshot.tools);
-
-        let mut server_names: Vec<String> = config
-            .mcp_servers
-            .keys()
-            .cloned()
-            .chain(snapshot.auth_statuses.keys().cloned())
-            .chain(snapshot.resources.keys().cloned())
-            .chain(snapshot.resource_templates.keys().cloned())
-            .collect();
-        server_names.sort();
-        server_names.dedup();
-
-        let total = server_names.len();
-        let limit = params.limit.unwrap_or(total as u32).max(1) as usize;
-        let effective_limit = limit.min(total);
-        let start = match params.cursor {
-            Some(cursor) => match cursor.parse::<usize>() {
-                Ok(idx) => idx,
-                Err(_) => {
-                    let error = JSONRPCErrorError {
-                        code: INVALID_REQUEST_ERROR_CODE,
-                        message: format!("invalid cursor: {cursor}"),
-                        data: None,
-                    };
-                    outgoing.send_error(request_id, error).await;
-                    return;
-                }
-            },
-            None => 0,
-        };
-
-        if start > total {
-            let error = JSONRPCErrorError {
-                code: INVALID_REQUEST_ERROR_CODE,
-                message: format!("cursor {start} exceeds total MCP servers {total}"),
-                data: None,
-            };
-            outgoing.send_error(request_id, error).await;
-            return;
+        match build_list_mcp_server_status_response(
+            &params,
+            config.mcp_servers.keys().cloned(),
+            &snapshot,
+        ) {
+            Ok(response) => outgoing.send_response(request_id, response).await,
+            Err(error) => outgoing.send_error(request_id, error).await,
         }
-
-        let end = start.saturating_add(effective_limit).min(total);
-
-        let data: Vec<McpServerStatus> = server_names[start..end]
-            .iter()
-            .map(|name| McpServerStatus {
-                name: name.clone(),
-                tools: tools_by_server.get(name).cloned().unwrap_or_default(),
-                resources: snapshot.resources.get(name).cloned().unwrap_or_default(),
-                resource_templates: snapshot
-                    .resource_templates
-                    .get(name)
-                    .cloned()
-                    .unwrap_or_default(),
-                auth_status: snapshot
-                    .auth_statuses
-                    .get(name)
-                    .cloned()
-                    .unwrap_or(CoreMcpAuthStatus::Unsupported)
-                    .into(),
-            })
-            .collect();
-
-        let next_cursor = if end < total {
-            Some(end.to_string())
-        } else {
-            None
-        };
-
-        let response = ListMcpServerStatusResponse { data, next_cursor };
-
-        outgoing.send_response(request_id, response).await;
     }
 
     async fn send_invalid_request_error(&self, request_id: ConnectionRequestId, message: String) {
@@ -7462,6 +7397,74 @@ enum ThreadTurnSource<'a> {
     HistoryItems(&'a [RolloutItem]),
 }
 
+fn build_list_mcp_server_status_response<I, S>(
+    params: &ListMcpServerStatusParams,
+    configured_server_names: I,
+    snapshot: &McpListToolsResponseEvent,
+) -> Result<ListMcpServerStatusResponse, JSONRPCErrorError>
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    let mut server_names: Vec<String> = configured_server_names
+        .into_iter()
+        .map(Into::into)
+        .chain(snapshot.auth_statuses.keys().cloned())
+        .chain(snapshot.resources.keys().cloned())
+        .chain(snapshot.resource_templates.keys().cloned())
+        .collect();
+    server_names.sort();
+    server_names.dedup();
+
+    let tools_by_server = group_tools_by_known_server_names(&snapshot.tools, server_names.iter());
+
+    let total = server_names.len();
+    let limit = params.limit.unwrap_or(total as u32).max(1) as usize;
+    let effective_limit = limit.min(total);
+    let start = match params.cursor.as_ref() {
+        Some(cursor) => cursor.parse::<usize>().map_err(|_| JSONRPCErrorError {
+            code: INVALID_REQUEST_ERROR_CODE,
+            message: format!("invalid cursor: {cursor}"),
+            data: None,
+        })?,
+        None => 0,
+    };
+
+    if start > total {
+        return Err(JSONRPCErrorError {
+            code: INVALID_REQUEST_ERROR_CODE,
+            message: format!("cursor {start} exceeds total MCP servers {total}"),
+            data: None,
+        });
+    }
+
+    let end = start.saturating_add(effective_limit).min(total);
+
+    let data: Vec<McpServerStatus> = server_names[start..end]
+        .iter()
+        .map(|name| McpServerStatus {
+            name: name.clone(),
+            tools: tools_by_server.get(name).cloned().unwrap_or_default(),
+            resources: snapshot.resources.get(name).cloned().unwrap_or_default(),
+            resource_templates: snapshot
+                .resource_templates
+                .get(name)
+                .cloned()
+                .unwrap_or_default(),
+            auth_status: snapshot
+                .auth_statuses
+                .get(name)
+                .cloned()
+                .unwrap_or(CoreMcpAuthStatus::Unsupported)
+                .into(),
+        })
+        .collect();
+
+    let next_cursor = (end < total).then(|| end.to_string());
+
+    Ok(ListMcpServerStatusResponse { data, next_cursor })
+}
+
 async fn populate_thread_turns(
     thread: &mut Thread,
     turn_source: ThreadTurnSource<'_>,
@@ -8979,6 +8982,46 @@ mod tests {
         );
         assert!(outgoing_rx.try_recv().is_err());
         Ok(())
+    }
+
+    #[test]
+    fn list_mcp_server_status_response_matches_hyphenated_server_names() {
+        let mut tools = HashMap::new();
+        tools.insert(
+            "mcp__autok_local__ping".to_string(),
+            codex_protocol::mcp::Tool {
+                description: None,
+                name: "ping".to_string(),
+                title: None,
+                input_schema: json!({"type": "object", "properties": {}}),
+                output_schema: None,
+                annotations: None,
+                icons: None,
+                meta: None,
+            },
+        );
+        let snapshot = McpListToolsResponseEvent {
+            tools,
+            resources: HashMap::new(),
+            resource_templates: HashMap::new(),
+            auth_statuses: HashMap::new(),
+        };
+
+        let response = build_list_mcp_server_status_response(
+            &ListMcpServerStatusParams {
+                cursor: None,
+                limit: None,
+            },
+            ["autok-local".to_string()],
+            &snapshot,
+        )
+        .expect("status response should build");
+
+        assert_eq!(response.next_cursor, None);
+        assert_eq!(response.data.len(), 1);
+        assert_eq!(response.data[0].name, "autok-local");
+        assert_eq!(response.data[0].tools.len(), 1);
+        assert!(response.data[0].tools.contains_key("ping"));
     }
 
     #[test]

--- a/codex-rs/core/src/mcp/mod.rs
+++ b/codex-rs/core/src/mcp/mod.rs
@@ -3,6 +3,7 @@ mod skill_dependencies;
 pub(crate) use skill_dependencies::maybe_prompt_and_install_mcp_dependencies;
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::env;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -15,6 +16,8 @@ use codex_protocol::mcp::Tool;
 use codex_protocol::protocol::McpListToolsResponseEvent;
 use codex_protocol::protocol::SandboxPolicy;
 use serde_json::Value;
+use sha1::Digest;
+use sha1::Sha1;
 
 use crate::AuthManager;
 use crate::CodexAuth;
@@ -30,6 +33,7 @@ use crate::plugins::PluginsManager;
 
 const MCP_TOOL_NAME_PREFIX: &str = "mcp";
 const MCP_TOOL_NAME_DELIMITER: &str = "__";
+const MAX_RESPONSES_API_TOOL_NAME_LENGTH: usize = 64;
 pub(crate) const CODEX_APPS_MCP_SERVER_NAME: &str = "codex_apps";
 const CODEX_CONNECTORS_TOKEN_ENV_VAR: &str = "CODEX_CONNECTORS_TOKEN";
 
@@ -303,6 +307,48 @@ pub async fn collect_mcp_snapshot(config: &Config) -> McpListToolsResponseEvent 
     snapshot
 }
 
+/// The Responses API requires tool names to match `^[a-zA-Z0-9_-]+$`.
+/// MCP server/tool names are user-controlled, so sanitize the fully-qualified
+/// name we expose to the model by replacing any disallowed character with `_`.
+pub(crate) fn sanitize_responses_api_tool_name(name: &str) -> String {
+    let mut sanitized = String::with_capacity(name.len());
+    for c in name.chars() {
+        if c.is_ascii_alphanumeric() || c == '_' {
+            sanitized.push(c);
+        } else {
+            sanitized.push('_');
+        }
+    }
+
+    if sanitized.is_empty() {
+        "_".to_string()
+    } else {
+        sanitized
+    }
+}
+
+pub(crate) fn qualify_responses_api_tool_name_from_raw(raw_name: &str) -> String {
+    let mut qualified_name = sanitize_responses_api_tool_name(raw_name);
+    if qualified_name.len() > MAX_RESPONSES_API_TOOL_NAME_LENGTH {
+        let mut hasher = Sha1::new();
+        hasher.update(raw_name.as_bytes());
+        let sha1_str = format!("{:x}", hasher.finalize());
+        let prefix_len = MAX_RESPONSES_API_TOOL_NAME_LENGTH - sha1_str.len();
+        qualified_name = format!("{}{}", &qualified_name[..prefix_len], sha1_str);
+    }
+    qualified_name
+}
+
+pub(crate) fn qualify_mcp_tool_name_for_responses_api(
+    server_name: &str,
+    tool_name: &str,
+) -> String {
+    let raw_name = format!(
+        "{MCP_TOOL_NAME_PREFIX}{MCP_TOOL_NAME_DELIMITER}{server_name}{MCP_TOOL_NAME_DELIMITER}{tool_name}"
+    );
+    qualify_responses_api_tool_name_from_raw(&raw_name)
+}
+
 pub fn split_qualified_tool_name(qualified_name: &str) -> Option<(String, String)> {
     let mut parts = qualified_name.split(MCP_TOOL_NAME_DELIMITER);
     let prefix = parts.next()?;
@@ -330,6 +376,61 @@ pub fn group_tools_by_server(
         }
     }
     grouped
+}
+
+/// Associate grouped MCP tools back to known raw server names.
+///
+/// Resolve tool buckets only when a qualified tool key maps back to a single
+/// known raw server name. This avoids guessing when names like `server-one`
+/// and `server_one` collapse to the same exposed key while still supporting
+/// raw server and tool names that contain the delimiter.
+pub fn group_tools_by_known_server_names<I, S>(
+    tools: &HashMap<String, Tool>,
+    server_names: I,
+) -> HashMap<String, HashMap<String, Tool>>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut seen = HashSet::new();
+    let server_names: Vec<String> = server_names
+        .into_iter()
+        .filter_map(|name| {
+            let name = name.as_ref().to_string();
+            if seen.insert(name.clone()) {
+                Some(name)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let mut resolved = HashMap::new();
+    for (qualified_name, tool) in tools {
+        let matching_servers: Vec<&String> = server_names
+            .iter()
+            .filter(|server_name| {
+                qualify_mcp_tool_name_for_responses_api(server_name, &tool.name) == *qualified_name
+            })
+            .collect();
+
+        if let [server_name] = matching_servers.as_slice() {
+            let prefix = format!(
+                "{MCP_TOOL_NAME_PREFIX}{MCP_TOOL_NAME_DELIMITER}{}{MCP_TOOL_NAME_DELIMITER}",
+                sanitize_responses_api_tool_name(server_name)
+            );
+            if let Some(tool_key) = qualified_name.strip_prefix(&prefix)
+                && !tool_key.is_empty()
+            {
+                resolved
+                    .entry((*server_name).clone())
+                    .or_insert_with(HashMap::new)
+                    .insert(tool_key.to_string(), tool.clone());
+            }
+        }
+    }
+
+    resolved
 }
 
 pub(crate) async fn collect_mcp_snapshot_from_manager(

--- a/codex-rs/core/src/mcp/mod_tests.rs
+++ b/codex-rs/core/src/mcp/mod_tests.rs
@@ -83,6 +83,75 @@ fn group_tools_by_server_strips_prefix_and_groups() {
 }
 
 #[test]
+fn group_tools_by_known_server_names_matches_unique_sanitized_alias() {
+    let mut tools = HashMap::new();
+    tools.insert("mcp__autok_local__ping".to_string(), make_tool("ping"));
+
+    let grouped = group_tools_by_known_server_names(&tools, ["autok-local"]);
+    let expected = HashMap::from([(
+        "autok-local".to_string(),
+        HashMap::from([("ping".to_string(), make_tool("ping"))]),
+    )]);
+
+    assert_eq!(grouped, expected);
+}
+
+#[test]
+fn group_tools_by_known_server_names_skips_ambiguous_aliases() {
+    let mut tools = HashMap::new();
+    tools.insert("mcp__server_one__ping".to_string(), make_tool("ping"));
+
+    let grouped = group_tools_by_known_server_names(&tools, ["server-one", "server_one"]);
+
+    assert!(grouped.is_empty());
+}
+
+#[test]
+fn group_tools_by_known_server_names_matches_server_names_with_delimiters() {
+    let mut tools = HashMap::new();
+    tools.insert("mcp__foo__bar__ping".to_string(), make_tool("ping"));
+
+    let grouped = group_tools_by_known_server_names(&tools, ["foo__bar"]);
+    let expected = HashMap::from([(
+        "foo__bar".to_string(),
+        HashMap::from([("ping".to_string(), make_tool("ping"))]),
+    )]);
+
+    assert_eq!(grouped, expected);
+}
+
+#[test]
+fn group_tools_by_known_server_names_does_not_match_shorter_delimited_prefixes() {
+    let mut tools = HashMap::new();
+    tools.insert("mcp__foo__bar__beta".to_string(), make_tool("beta"));
+
+    let grouped = group_tools_by_known_server_names(&tools, ["foo", "foo__bar"]);
+    let expected = HashMap::from([(
+        "foo__bar".to_string(),
+        HashMap::from([("beta".to_string(), make_tool("beta"))]),
+    )]);
+
+    assert_eq!(grouped, expected);
+}
+
+#[test]
+fn group_tools_by_known_server_names_preserves_exposed_tool_suffixes() {
+    let mut tools = HashMap::new();
+    tools.insert(
+        "mcp__server_one__tool_two_three".to_string(),
+        make_tool("tool.two-three"),
+    );
+
+    let grouped = group_tools_by_known_server_names(&tools, ["server-one"]);
+    let expected = HashMap::from([(
+        "server-one".to_string(),
+        HashMap::from([("tool_two_three".to_string(), make_tool("tool.two-three"))]),
+    )]);
+
+    assert_eq!(grouped, expected);
+}
+
+#[test]
 fn tool_plugin_provenance_collects_app_and_mcp_sources() {
     let provenance = ToolPluginProvenance::from_capability_summaries(&[
         PluginCapabilitySummary {

--- a/codex-rs/core/src/mcp_connection_manager.rs
+++ b/codex-rs/core/src/mcp_connection_manager.rs
@@ -22,6 +22,7 @@ use std::time::Instant;
 use crate::mcp::CODEX_APPS_MCP_SERVER_NAME;
 use crate::mcp::ToolPluginProvenance;
 use crate::mcp::auth::McpAuthStatusEntry;
+use crate::mcp::qualify_responses_api_tool_name_from_raw;
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
@@ -90,7 +91,6 @@ use crate::connectors::sanitize_name;
 /// OpenAI requires tool names to conform to `^[a-zA-Z0-9_-]+$`, so we must
 /// choose a delimiter from this character set.
 const MCP_TOOL_NAME_DELIMITER: &str = "__";
-const MAX_TOOL_NAME_LENGTH: usize = 64;
 
 /// Default timeout for initializing MCP server & initially listing tools.
 pub const DEFAULT_STARTUP_TIMEOUT: Duration = Duration::from_secs(10);
@@ -103,26 +103,6 @@ const CODEX_APPS_TOOLS_CACHE_DIR: &str = "cache/codex_apps_tools";
 const MCP_TOOLS_LIST_DURATION_METRIC: &str = "codex.mcp.tools.list.duration_ms";
 const MCP_TOOLS_FETCH_UNCACHED_DURATION_METRIC: &str = "codex.mcp.tools.fetch_uncached.duration_ms";
 const MCP_TOOLS_CACHE_WRITE_DURATION_METRIC: &str = "codex.mcp.tools.cache_write.duration_ms";
-
-/// The Responses API requires tool names to match `^[a-zA-Z0-9_-]+$`.
-/// MCP server/tool names are user-controlled, so sanitize the fully-qualified
-/// name we expose to the model by replacing any disallowed character with `_`.
-fn sanitize_responses_api_tool_name(name: &str) -> String {
-    let mut sanitized = String::with_capacity(name.len());
-    for c in name.chars() {
-        if c.is_ascii_alphanumeric() || c == '_' {
-            sanitized.push(c);
-        } else {
-            sanitized.push('_');
-        }
-    }
-
-    if sanitized.is_empty() {
-        "_".to_string()
-    } else {
-        sanitized
-    }
-}
 
 fn sha1_hex(s: &str) -> String {
     let mut hasher = Sha1::new();
@@ -176,15 +156,7 @@ where
         // Start from a "pretty" name (sanitized), then deterministically disambiguate on
         // collisions by appending a hash of the *raw* (unsanitized) qualified name. This
         // ensures tools like `foo.bar` and `foo_bar` don't collapse to the same key.
-        let mut qualified_name = sanitize_responses_api_tool_name(&qualified_name_raw);
-
-        // Enforce length constraints early; use the raw name for the hash input so the
-        // output remains stable even when sanitization changes.
-        if qualified_name.len() > MAX_TOOL_NAME_LENGTH {
-            let sha1_str = sha1_hex(&qualified_name_raw);
-            let prefix_len = MAX_TOOL_NAME_LENGTH - sha1_str.len();
-            qualified_name = format!("{}{}", &qualified_name[..prefix_len], sha1_str);
-        }
+        let qualified_name = qualify_responses_api_tool_name_from_raw(&qualified_name_raw);
 
         if used_names.contains(&qualified_name) {
             warn!("skipping duplicated tool {}", qualified_name);

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -42,6 +42,7 @@ use base64::Engine;
 use codex_core::config::Config;
 use codex_core::config::types::McpServerTransportConfig;
 use codex_core::mcp::McpManager;
+use codex_core::mcp::group_tools_by_known_server_names;
 use codex_core::plugins::PluginsManager;
 use codex_core::web_search::web_search_detail;
 use codex_otel::RuntimeMetricsSummary;
@@ -1822,13 +1823,16 @@ pub(crate) fn new_mcp_tools_output(
     let effective_servers = mcp_manager.effective_servers(config, /*auth*/ None);
     let mut servers: Vec<_> = effective_servers.iter().collect();
     servers.sort_by(|(a, _), (b, _)| a.cmp(b));
+    let tools_by_server = group_tools_by_known_server_names(
+        &tools,
+        servers.iter().map(|(server, _)| server.as_str()),
+    );
 
     for (server, cfg) in servers {
-        let prefix = format!("mcp__{server}__");
-        let mut names: Vec<String> = tools
-            .keys()
-            .filter(|k| k.starts_with(&prefix))
-            .map(|k| k[prefix.len()..].to_string())
+        let mut names: Vec<String> = tools_by_server
+            .get(server.as_str())
+            .into_iter()
+            .flat_map(|server_tools| server_tools.keys().cloned())
             .collect();
         names.sort();
 
@@ -2984,6 +2988,67 @@ mod tests {
         let rendered = render_lines(&cell.display_lines(120)).join("\n");
 
         insta::assert_snapshot!(rendered);
+    }
+
+    async fn config_with_mcp_server(server_name: &str) -> Config {
+        let mut config = test_config().await;
+        let mut servers = config.mcp_servers.get().clone();
+        servers.insert(
+            server_name.to_string(),
+            McpServerConfig {
+                enabled: true,
+                required: false,
+                disabled_reason: None,
+                startup_timeout_sec: None,
+                tool_timeout_sec: None,
+                enabled_tools: None,
+                disabled_tools: None,
+                scopes: None,
+                oauth_resource: None,
+                transport: McpServerTransportConfig::StreamableHttp {
+                    url: "https://example.com/mcp".to_string(),
+                    bearer_token_env_var: None,
+                    http_headers: None,
+                    env_http_headers: None,
+                },
+            },
+        );
+        config
+            .mcp_servers
+            .set(servers)
+            .expect("test mcp servers should accept any configuration");
+        config
+    }
+
+    #[tokio::test]
+    async fn mcp_tools_output_matches_hyphenated_server_names() {
+        let config = config_with_mcp_server("autok-local").await;
+        let mut tools = HashMap::new();
+        tools.insert(
+            "mcp__autok_local__ping".to_string(),
+            Tool {
+                description: None,
+                name: "ping".to_string(),
+                title: None,
+                input_schema: serde_json::json!({"type": "object", "properties": {}}),
+                output_schema: None,
+                annotations: None,
+                icons: None,
+                meta: None,
+            },
+        );
+
+        let cell = new_mcp_tools_output(
+            &config,
+            tools,
+            HashMap::new(),
+            HashMap::new(),
+            &HashMap::new(),
+        );
+        let rendered = render_lines(&cell.display_lines(120)).join("\n");
+
+        assert!(rendered.contains("autok-local"));
+        assert!(rendered.contains("Tools: ping"), "{rendered}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- fix MCP status/render grouping for configured server names that sanitize differently from their exposed tool IDs
- share raw-to-exposed MCP qualification logic in core and reuse it in app-server and TUI grouping
- add focused core, app-server, and TUI regressions for the hyphenated-server path and helper edge cases

## Verification
- `cargo test -p codex-core group_tools_by_known_server_names`
- `cargo test -p codex-tui mcp_tools_output_matches_hyphenated_server_names`
- `cargo test -p codex-app-server list_mcp_server_status_response_matches_hyphenated_server_names`
- `cargo check -p codex-app-server`

## Residual Risks / Follow-ups
- alias-colliding raw server names such as `server-one` and `server_one` still need a broader provenance or config-validation decision
- very long server names on the Responses tool-name truncation/hash path remain a separate follow-up outside this focused fix

Closes #15565
