### PR TITLE
Add wildcard in the middle test coverage

### DIFF
--- a/codex-rs/network-proxy/src/policy.rs
+++ b/codex-rs/network-proxy/src/policy.rs
@@ -368,6 +368,16 @@ mod tests {
     }
 
     #[test]
+    fn compile_globset_supports_mid_label_wildcards() {
+        let set = compile_denylist_globset(&["region*.v2.argotunnel.com".to_string()]).unwrap();
+
+        assert_eq!(true, set.is_match("region1.v2.argotunnel.com"));
+        assert_eq!(true, set.is_match("region.v2.argotunnel.com"));
+        assert_eq!(false, set.is_match("xregion1.v2.argotunnel.com"));
+        assert_eq!(false, set.is_match("foo.region1.v2.argotunnel.com"));
+    }
+
+    #[test]
     fn compile_globset_normalizes_apex_and_subdomains() {
         let set = compile_denylist_globset(&["**.Example.COM.".to_string()]).unwrap();
 


### PR DESCRIPTION
## Summary
Add a focused codex network proxy unit test for the denylist pattern with wildcard in the middle `region*.some.malicious.tunnel.com`. This does not change how existing code works, just ensure that behavior stays the same and we got CI guards to guard existin behavior.

## Why
The managed Codex denylist update relies on this mid label glob form, and the existing tests only covered exact hosts, `*.` subdomains, and `**.` apex plus subdomains.

## Validation
`cargo test -p codex-network-proxy compile_globset_supports_mid_label_wildcards`
`cargo test -p codex-network-proxy`
`./tools/argument-comment-lint/run-prebuilt-linter.sh -p codex-network-proxy`