### PR TITLE
[plugins] Polish tool suggest prompts.

### DIFF
--- a/codex-rs/core/src/tools/spec_tests.rs
+++ b/codex-rs/core/src/tools/spec_tests.rs
@@ -2090,11 +2090,9 @@ fn tool_suggest_can_be_registered_without_search_tool() {
     let ToolSpec::Function(ResponsesApiTool { description, .. }) = &tool_suggest.spec else {
         panic!("expected function tool");
     };
-    assert!(
-        description.contains(
-            "Suggests a missing connector in an installed plugin, or in narrower cases a discoverable plugin"
-        )
-    );
+    assert!(description.contains(
+        "Suggests a missing connector in an installed plugin, or in narrower cases a not installed but discoverable plugin"
+    ));
     assert!(description.contains(
         "You've already tried to find a matching available tool for the user's request but couldn't find a good match. This includes `tool_search` (if available) and other means."
     ));
@@ -2345,11 +2343,9 @@ fn tool_suggest_description_lists_discoverable_tools() {
     else {
         panic!("expected function tool");
     };
-    assert!(
-        description.contains(
-            "Suggests a missing connector in an installed plugin, or in narrower cases a discoverable plugin"
-        )
-    );
+    assert!(description.contains(
+        "Suggests a missing connector in an installed plugin, or in narrower cases a not installed but discoverable plugin"
+    ));
     assert!(description.contains("Google Calendar"));
     assert!(description.contains("Gmail"));
     assert!(description.contains("Sample Plugin"));

--- a/codex-rs/core/src/tools/spec_tests.rs
+++ b/codex-rs/core/src/tools/spec_tests.rs
@@ -2092,10 +2092,12 @@ fn tool_suggest_can_be_registered_without_search_tool() {
     };
     assert!(
         description.contains(
-            "You've already tried to find a matching available tool for the user's request"
+            "Suggests a discoverable connector, or in narrower cases a discoverable plugin"
         )
     );
-    assert!(description.contains("This includes `tool_search` (if available) and other means."));
+    assert!(description.contains(
+        "You've already tried to find a matching available tool for the user's request but couldn't find a good match. This includes `tool_search` (if available) and other means."
+    ));
 }
 
 #[test]
@@ -2343,6 +2345,11 @@ fn tool_suggest_description_lists_discoverable_tools() {
     else {
         panic!("expected function tool");
     };
+    assert!(
+        description.contains(
+            "Suggests a discoverable connector, or in narrower cases a discoverable plugin"
+        )
+    );
     assert!(description.contains("Google Calendar"));
     assert!(description.contains("Gmail"));
     assert!(description.contains("Sample Plugin"));
@@ -2355,10 +2362,19 @@ fn tool_suggest_description_lists_discoverable_tools() {
     );
     assert!(
         description.contains(
-            "You've already tried to find a matching available tool for the user's request"
+            "You've already tried to find a matching available tool for the user's request but couldn't find a good match. This includes `tool_search` (if available) and other means."
         )
     );
-    assert!(description.contains("This includes `tool_search` (if available) and other means."));
+    assert!(description.contains(
+        "only suggest discoverable and installable plugins when the user's intent very explicitly and unambiguously matches that plugin itself"
+    ));
+    assert!(description.contains(
+        "Do not suggest a plugin just because one of its connectors or capabilities seems relevant."
+    ));
+    assert!(description.contains("This stricter rule does not apply to connector suggestions."));
+    assert!(description.contains(
+        "Apply the stricter explicit-and-unambiguous rule only for `plugin` suggestions"
+    ));
     assert!(description.contains("DO NOT explore or recommend tools that are not on this list."));
     assert!(!description.contains("tool_search fails to find a good match"));
     let JsonSchema::Object { required, .. } = parameters else {

--- a/codex-rs/core/src/tools/spec_tests.rs
+++ b/codex-rs/core/src/tools/spec_tests.rs
@@ -2092,7 +2092,7 @@ fn tool_suggest_can_be_registered_without_search_tool() {
     };
     assert!(
         description.contains(
-            "Suggests a discoverable connector, or in narrower cases a discoverable plugin"
+            "Suggests a missing connector in an installed plugin, or in narrower cases a discoverable plugin"
         )
     );
     assert!(description.contains(
@@ -2347,7 +2347,7 @@ fn tool_suggest_description_lists_discoverable_tools() {
     };
     assert!(
         description.contains(
-            "Suggests a discoverable connector, or in narrower cases a discoverable plugin"
+            "Suggests a missing connector in an installed plugin, or in narrower cases a discoverable plugin"
         )
     );
     assert!(description.contains("Google Calendar"));
@@ -2366,14 +2366,16 @@ fn tool_suggest_description_lists_discoverable_tools() {
         )
     );
     assert!(description.contains(
-        "only suggest discoverable and installable plugins when the user's intent very explicitly and unambiguously matches that plugin itself"
+        "For connectors/apps that are not installed but needed for an installed plugin, suggest to install them if the task requirements match precisely."
+    ));
+    assert!(description.contains(
+        "For plugins that are not installed but discoverable, only suggest discoverable and installable plugins when the user's intent very explicitly and unambiguously matches that plugin itself."
     ));
     assert!(description.contains(
         "Do not suggest a plugin just because one of its connectors or capabilities seems relevant."
     ));
-    assert!(description.contains("This stricter rule does not apply to connector suggestions."));
     assert!(description.contains(
-        "Apply the stricter explicit-and-unambiguous rule only for `plugin` suggestions"
+        "Apply the stricter explicit-and-unambiguous rule for *discoverable tools* like plugin install suggestions; *missing tools* like connector install suggestions continue to use the normal clear-fit standard."
     ));
     assert!(description.contains("DO NOT explore or recommend tools that are not on this list."));
     assert!(!description.contains("tool_search fails to find a good match"));

--- a/codex-rs/core/templates/search_tool/tool_suggest_description.md
+++ b/codex-rs/core/templates/search_tool/tool_suggest_description.md
@@ -1,6 +1,6 @@
 # Tool suggestion discovery
 
-Suggests a missing connector in a plugin, or in narrower cases a discoverable plugin, when the user clearly wants a capability that is not currently available in the active `tools` list.
+Suggests a missing connector in an installed plugin, or in narrower cases a not installed but discoverable plugin, when the user clearly wants a capability that is not currently available in the active `tools` list.
 
 Use this ONLY when:
 - You've already tried to find a matching available tool for the user's request but couldn't find a good match. This includes `tool_search` (if available) and other means.

--- a/codex-rs/core/templates/search_tool/tool_suggest_description.md
+++ b/codex-rs/core/templates/search_tool/tool_suggest_description.md
@@ -1,10 +1,11 @@
 # Tool suggestion discovery
 
-Suggests a discoverable connector or plugin when the user clearly wants a capability that is not currently available in the active `tools` list.
+Suggests a missing connector from an installed plugin, or in narrower cases a discoverable plugin, when the user clearly wants a capability that is not currently available in the active `tools` list.
 
 Use this ONLY when:
 - You've already tried to find a matching available tool for the user's request but couldn't find a good match. This includes `tool_search` (if available) and other means.
 - AND the user's request strongly matches one of the discoverable tools listed below.
+- For `plugin` suggestions, only suggest discoverable and installable plugins when the user's intent very explicitly and unambiguously matches that plugin itself. Do not suggest a plugin just because one of its connectors or capabilities seems relevant. This stricter rule does not apply to connector suggestions.
 
 Tool suggestions should only use the discoverable tools listed here. DO NOT explore or recommend tools that are not on this list.
 
@@ -14,7 +15,7 @@ Discoverable tools:
 Workflow:
 
 1. Ensure all possible means have been exhausted to find an existing available tool but none of them matches the request intent.
-2. Match the user's request against the discoverable tools list above.
+2. Match the user's request against the discoverable tools list above. Apply the stricter explicit-and-unambiguous rule only for `plugin` suggestions; connector suggestions continue to use the normal clear-fit standard.
 3. If one tool clearly fits, call `tool_suggest` with:
    - `tool_type`: `connector` or `plugin`
    - `action_type`: `install` or `enable`

--- a/codex-rs/core/templates/search_tool/tool_suggest_description.md
+++ b/codex-rs/core/templates/search_tool/tool_suggest_description.md
@@ -1,11 +1,11 @@
 # Tool suggestion discovery
 
-Suggests a missing connector from an installed plugin, or in narrower cases a discoverable plugin, when the user clearly wants a capability that is not currently available in the active `tools` list.
+Suggests a missing connector in a plugin, or in narrower cases a discoverable plugin, when the user clearly wants a capability that is not currently available in the active `tools` list.
 
 Use this ONLY when:
 - You've already tried to find a matching available tool for the user's request but couldn't find a good match. This includes `tool_search` (if available) and other means.
-- AND the user's request strongly matches one of the discoverable tools listed below.
-- For `plugin` suggestions, only suggest discoverable and installable plugins when the user's intent very explicitly and unambiguously matches that plugin itself. Do not suggest a plugin just because one of its connectors or capabilities seems relevant. This stricter rule does not apply to connector suggestions.
+- For connectors/apps that are not installed but needed for an installed plugin, suggest to install them if the task requirements match precisely.
+- For plugins that are not installed but discoverable, only suggest discoverable and installable plugins when the user's intent very explicitly and unambiguously matches that plugin itself. Do not suggest a plugin just because one of its connectors or capabilities seems relevant.
 
 Tool suggestions should only use the discoverable tools listed here. DO NOT explore or recommend tools that are not on this list.
 
@@ -15,7 +15,7 @@ Discoverable tools:
 Workflow:
 
 1. Ensure all possible means have been exhausted to find an existing available tool but none of them matches the request intent.
-2. Match the user's request against the discoverable tools list above. Apply the stricter explicit-and-unambiguous rule only for `plugin` suggestions; connector suggestions continue to use the normal clear-fit standard.
+2. Match the user's request against the discoverable tools list above. Apply the stricter explicit-and-unambiguous rule for *discoverable tools* like plugin install suggestions; *missing tools* like connector install suggestions continue to use the normal clear-fit standard.
 3. If one tool clearly fits, call `tool_suggest` with:
    - `tool_type`: `connector` or `plugin`
    - `action_type`: `install` or `enable`


### PR DESCRIPTION
- [x] Polish tool suggest prompts to distinguish between missing connectors and discoverable plugins, and be very precise about the triggering conditions.