### PR TITLE
docs: update AGENTS.md to discourage adding code to codex-core

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,19 @@ Before finalizing a large change to `codex-rs`, run `just fix -p <project>` (in 
 
 Also run `just argument-comment-lint` to ensure the codebase is clean of comment lint errors.
 
+## The `codex-core` crate
+
+Over time, the `codex-core` crate (defined in `codex-rs/core/`) has become bloated because it is the largest crate, so it is often easier to add something new to `codex-core` rather than refactor out the library code you need so your new code neither takes a dependency on, nor contributes to the size of, `codex-core`.
+
+To that end: **resist adding code to codex-core**!
+
+Particularly when introducing a new concept/feature/API, before adding to `codex-core`, consider whether:
+
+- There is an existing crate other than `codex-core` that is an appropriate place for your new code to live.
+- It is time to introduce a new crate to the Cargo workspace for your new functionality. Refactor existing code as necessary to make this happen.
+
+Likewise, when reviewing code, do not hesitate to push back on PRs that would unnecessarily add code to `codex-core`.
+
 ## TUI style conventions
 
 See `codex-rs/tui/styles.md`.


### PR DESCRIPTION
## Why

`codex-core` is already the largest crate in `codex-rs`, so defaulting to it for new functionality makes it harder to keep the workspace modular. The repo guidance should make it explicit that contributors are expected to look for an existing non-`codex-core` crate, or introduce a new crate, before growing `codex-core` further.

## What Changed

- Added a dedicated `The \`codex-core\` crate` section to `AGENTS.md`.
- Documented why `codex-core` should be treated as a last resort for new functionality.
- Added concrete guidance for both implementation and review: prefer an existing non-`codex-core` crate when possible, introduce a new workspace crate when that is the cleaner boundary, and push back on PRs that grow `codex-core` unnecessarily.
