### PR TITLE
fix: make MACOS_DEFAULT_PREFERENCES_POLICY part of MACOS_SEATBELT_BASE_POLICY

### DIFF
--- a/codex-rs/sandboxing/src/seatbelt.rs
+++ b/codex-rs/sandboxing/src/seatbelt.rs
@@ -19,14 +19,6 @@ const MACOS_SEATBELT_BASE_POLICY: &str = include_str!("seatbelt_base_policy.sbpl
 const MACOS_SEATBELT_NETWORK_POLICY: &str = include_str!("seatbelt_network_policy.sbpl");
 const MACOS_RESTRICTED_READ_ONLY_PLATFORM_DEFAULTS: &str =
     include_str!("restricted_read_only_platform_defaults.sbpl");
-const MACOS_DEFAULT_PREFERENCES_POLICY: &str = r#"; allow readonly user preferences
-(allow ipc-posix-shm-read* (ipc-posix-name-prefix "apple.cfprefs."))
-(allow mach-lookup
-    (global-name "com.apple.cfprefsd.daemon")
-    (global-name "com.apple.cfprefsd.agent")
-    (local-name "com.apple.cfprefsd.agent"))
-(allow user-preference-read)
-"#;
 
 /// When working with `sandbox-exec`, only consider `sandbox-exec` in `/usr/bin`
 /// to defend against an attacker trying to inject a malicious version on the
@@ -476,7 +468,6 @@ pub fn create_seatbelt_command_args_for_policies(
     let include_platform_defaults = file_system_sandbox_policy.include_platform_defaults();
     let mut policy_sections = vec![
         MACOS_SEATBELT_BASE_POLICY.to_string(),
-        MACOS_DEFAULT_PREFERENCES_POLICY.to_string(),
         file_read_policy,
         file_write_policy,
         network_policy,

--- a/codex-rs/sandboxing/src/seatbelt_base_policy.sbpl
+++ b/codex-rs/sandboxing/src/seatbelt_base_policy.sbpl
@@ -106,3 +106,11 @@
 ; PTYs created before entering seatbelt may lack the extension; allow ioctl
 ; on those slave ttys so interactive shells detect a TTY and remain functional.
 (allow file-ioctl (regex #"^/dev/ttys[0-9]+"))
+
+; allow readonly user preferences
+(allow ipc-posix-shm-read* (ipc-posix-name-prefix "apple.cfprefs."))
+(allow mach-lookup
+  (global-name "com.apple.cfprefsd.daemon")
+  (global-name "com.apple.cfprefsd.agent")
+  (local-name "com.apple.cfprefsd.agent"))
+(allow user-preference-read)

--- a/codex-rs/sandboxing/src/seatbelt_tests.rs
+++ b/codex-rs/sandboxing/src/seatbelt_tests.rs
@@ -953,14 +953,6 @@ fn create_seatbelt_args_for_cwd_as_git_repo() {
     // - write access to WRITABLE_ROOT_0 (but not its .git or .codex), WRITABLE_ROOT_1, and cwd as WRITABLE_ROOT_2.
     let expected_policy = format!(
         r#"{MACOS_SEATBELT_BASE_POLICY}
-; allow readonly user preferences
-(allow ipc-posix-shm-read* (ipc-posix-name-prefix "apple.cfprefs."))
-(allow mach-lookup
-    (global-name "com.apple.cfprefsd.daemon")
-    (global-name "com.apple.cfprefsd.agent")
-    (local-name "com.apple.cfprefsd.agent"))
-(allow user-preference-read)
-
 ; allow read-only file operations
 (allow file-read*)
 (allow file-write*


### PR DESCRIPTION
Follow-up from https://github.com/openai/codex/pull/15918 since these policies are always used together.