### PR TITLE
fix: increase timeout for rust-ci to 45 minutes for now

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -547,7 +547,10 @@ jobs:
   tests:
     name: Tests — ${{ matrix.runner }} - ${{ matrix.target }}${{ matrix.remote_env == 'true' && ' (remote)' || '' }}
     runs-on: ${{ matrix.runs_on || matrix.runner }}
-    timeout-minutes: ${{ matrix.runner == 'windows-arm64' && 35 || 30 }}
+    # Perhaps we can bring this back down to 30m once we finish the cutover
+    # from tui_app_server/ to tui/. Incidentally, windows-arm64 was the main
+    # offender for exceeding the timeout.
+    timeout-minutes: 45
     needs: changed
     if: ${{ needs.changed.outputs.codex == 'true' || needs.changed.outputs.workflows == 'true' || github.event_name == 'push' }}
     defaults:


### PR DESCRIPTION
https://github.com/openai/codex/pull/15478 raised the timeout to 35 minutes for `windows-arm64` only, though I just hit 35 minutes on https://github.com/openai/codex/actions/runs/23628986591/job/68826740108?pr=15944, so let's just increase it to 45 minutes. As noted, I'm hoping that we can bring it back down once we no longer have two copies of the `tui` crate.