### PR TITLE
fix(permissions):  preserve explicit empty legacy network lists

### DIFF
--- a/codex-rs/app-server/src/config_api.rs
+++ b/codex-rs/app-server/src/config_api.rs
@@ -590,6 +590,7 @@ mod tests {
                     )]),
                 }),
                 allow_local_binding: Some(true),
+                ..Default::default()
             }),
         };
 
@@ -675,6 +676,7 @@ mod tests {
                     )]),
                 }),
                 allow_local_binding: None,
+                ..Default::default()
             }),
         };
 

--- a/codex-rs/config/src/config_requirements.rs
+++ b/codex-rs/config/src/config_requirements.rs
@@ -233,6 +233,12 @@ pub struct NetworkRequirementsToml {
     pub managed_allowed_domains_only: Option<bool>,
     pub unix_sockets: Option<NetworkUnixSocketPermissionsToml>,
     pub allow_local_binding: Option<bool>,
+    #[serde(skip)]
+    #[doc(hidden)]
+    pub explicit_legacy_allowed_domains: bool,
+    #[serde(skip)]
+    #[doc(hidden)]
+    pub explicit_legacy_denied_domains: bool,
 }
 
 #[derive(Deserialize)]
@@ -278,6 +284,8 @@ impl<'de> Deserialize<'de> for NetworkRequirementsToml {
             allow_unix_sockets,
             allow_local_binding,
         } = raw;
+        let explicit_legacy_allowed_domains = allowed_domains.is_some();
+        let explicit_legacy_denied_domains = denied_domains.is_some();
 
         if domains.is_some() && (allowed_domains.is_some() || denied_domains.is_some()) {
             return Err(D::Error::custom(
@@ -304,6 +312,8 @@ impl<'de> Deserialize<'de> for NetworkRequirementsToml {
             unix_sockets: unix_sockets
                 .or_else(|| legacy_unix_socket_permissions_from_list(allow_unix_sockets)),
             allow_local_binding,
+            explicit_legacy_allowed_domains,
+            explicit_legacy_denied_domains,
         })
     }
 }
@@ -315,6 +325,7 @@ fn legacy_domain_permissions_from_lists(
     allowed_domains: Option<Vec<String>>,
     denied_domains: Option<Vec<String>>,
 ) -> Option<NetworkDomainPermissionsToml> {
+    let has_legacy_domain_config = allowed_domains.is_some() || denied_domains.is_some();
     let mut entries = BTreeMap::new();
 
     for pattern in allowed_domains.unwrap_or_default() {
@@ -325,19 +336,20 @@ fn legacy_domain_permissions_from_lists(
         entries.insert(pattern, NetworkDomainPermissionToml::Deny);
     }
 
-    (!entries.is_empty()).then_some(NetworkDomainPermissionsToml { entries })
+    has_legacy_domain_config.then_some(NetworkDomainPermissionsToml { entries })
 }
 
 fn legacy_unix_socket_permissions_from_list(
     allow_unix_sockets: Option<Vec<String>>,
 ) -> Option<NetworkUnixSocketPermissionsToml> {
+    let has_legacy_unix_socket_config = allow_unix_sockets.is_some();
     let entries = allow_unix_sockets
         .unwrap_or_default()
         .into_iter()
         .map(|path| (path, NetworkUnixSocketPermissionToml::Allow))
         .collect::<BTreeMap<_, _>>();
 
-    (!entries.is_empty()).then_some(NetworkUnixSocketPermissionsToml { entries })
+    has_legacy_unix_socket_config.then_some(NetworkUnixSocketPermissionsToml { entries })
 }
 
 /// Normalized network constraints derived from requirements TOML.
@@ -355,6 +367,12 @@ pub struct NetworkConstraints {
     pub managed_allowed_domains_only: Option<bool>,
     pub unix_sockets: Option<NetworkUnixSocketPermissionsToml>,
     pub allow_local_binding: Option<bool>,
+    #[serde(skip)]
+    #[doc(hidden)]
+    pub explicit_legacy_allowed_domains: bool,
+    #[serde(skip)]
+    #[doc(hidden)]
+    pub explicit_legacy_denied_domains: bool,
 }
 
 impl<'de> Deserialize<'de> for NetworkConstraints {
@@ -364,6 +382,16 @@ impl<'de> Deserialize<'de> for NetworkConstraints {
     {
         let requirements = NetworkRequirementsToml::deserialize(deserializer)?;
         Ok(requirements.into())
+    }
+}
+
+impl NetworkConstraints {
+    pub fn explicit_legacy_allowed_domains(&self) -> bool {
+        self.explicit_legacy_allowed_domains
+    }
+
+    pub fn explicit_legacy_denied_domains(&self) -> bool {
+        self.explicit_legacy_denied_domains
     }
 }
 
@@ -380,6 +408,8 @@ impl From<NetworkRequirementsToml> for NetworkConstraints {
             managed_allowed_domains_only,
             unix_sockets,
             allow_local_binding,
+            explicit_legacy_allowed_domains,
+            explicit_legacy_denied_domains,
         } = value;
         Self {
             enabled,
@@ -392,6 +422,8 @@ impl From<NetworkRequirementsToml> for NetworkConstraints {
             managed_allowed_domains_only,
             unix_sockets,
             allow_local_binding,
+            explicit_legacy_allowed_domains,
+            explicit_legacy_denied_domains,
         }
     }
 }
@@ -1840,6 +1872,41 @@ guardian_developer_instructions = """
                 .contains("`experimental_network.unix_sockets` cannot be combined"),
             "unexpected error: {err:#}"
         );
+    }
+
+    #[test]
+    fn empty_legacy_network_lists_are_preserved_in_canonical_constraints() -> Result<()> {
+        let toml_str = r#"
+            [experimental_network]
+            allowed_domains = []
+            denied_domains = []
+            allow_unix_sockets = []
+        "#;
+
+        let source = RequirementSource::CloudRequirements;
+        let mut requirements_with_sources = ConfigRequirementsWithSources::default();
+        requirements_with_sources.merge_unset_fields(source.clone(), from_str(toml_str)?);
+
+        let requirements = ConfigRequirements::try_from(requirements_with_sources)?;
+        let sourced_network = requirements
+            .network
+            .expect("network requirements should be preserved as constraints");
+
+        assert_eq!(sourced_network.source, source);
+        assert_eq!(
+            sourced_network.value.domains,
+            Some(NetworkDomainPermissionsToml {
+                entries: BTreeMap::new(),
+            })
+        );
+        assert_eq!(
+            sourced_network.value.unix_sockets,
+            Some(NetworkUnixSocketPermissionsToml {
+                entries: BTreeMap::new(),
+            })
+        );
+
+        Ok(())
     }
 
     #[test]

--- a/codex-rs/core/src/config/network_proxy_spec.rs
+++ b/codex-rs/core/src/config/network_proxy_spec.rs
@@ -225,20 +225,21 @@ impl NetworkProxySpec {
             constraints.dangerously_allow_all_unix_sockets =
                 Some(dangerously_allow_all_unix_sockets);
         }
-        let managed_allowed_domains = if hard_deny_allowlist_misses {
-            Some(
+        let managed_allowed_domains =
+            if hard_deny_allowlist_misses || requirements.explicit_legacy_allowed_domains() {
+                Some(
+                    requirements
+                        .domains
+                        .as_ref()
+                        .and_then(codex_config::NetworkDomainPermissionsToml::allowed_domains)
+                        .unwrap_or_default(),
+                )
+            } else {
                 requirements
                     .domains
                     .as_ref()
                     .and_then(codex_config::NetworkDomainPermissionsToml::allowed_domains)
-                    .unwrap_or_default(),
-            )
-        } else {
-            requirements
-                .domains
-                .as_ref()
-                .and_then(codex_config::NetworkDomainPermissionsToml::allowed_domains)
-        };
+            };
         if let Some(managed_allowed_domains) = managed_allowed_domains {
             // Managed requirements seed the baseline allowlist. User additions
             // can extend that baseline unless managed-only mode pins the
@@ -257,10 +258,20 @@ impl NetworkProxySpec {
             constraints.allowed_domains = Some(managed_allowed_domains);
             constraints.allowlist_expansion_enabled = Some(allowlist_expansion_enabled);
         }
-        let managed_denied_domains = requirements
-            .domains
-            .as_ref()
-            .and_then(codex_config::NetworkDomainPermissionsToml::denied_domains);
+        let managed_denied_domains = if requirements.explicit_legacy_denied_domains() {
+            Some(
+                requirements
+                    .domains
+                    .as_ref()
+                    .and_then(codex_config::NetworkDomainPermissionsToml::denied_domains)
+                    .unwrap_or_default(),
+            )
+        } else {
+            requirements
+                .domains
+                .as_ref()
+                .and_then(codex_config::NetworkDomainPermissionsToml::denied_domains)
+        };
         if let Some(managed_denied_domains) = managed_denied_domains {
             let effective_denied_domains = if denylist_expansion_enabled {
                 Self::merge_domain_lists(

--- a/codex-rs/core/src/config/network_proxy_spec_tests.rs
+++ b/codex-rs/core/src/config/network_proxy_spec_tests.rs
@@ -179,6 +179,69 @@ fn danger_full_access_keeps_managed_allowlist_and_denylist_fixed() {
 }
 
 #[test]
+fn explicit_empty_legacy_allowed_domains_pin_full_access_allowlist_empty() {
+    let mut config = NetworkProxyConfig::default();
+    config
+        .network
+        .set_allowed_domains(vec!["api.example.com".to_string()]);
+    let requirements: NetworkConstraints =
+        toml::from_str("allowed_domains = []").expect("legacy allowlist should parse");
+
+    let spec = NetworkProxySpec::from_config_and_constraints(
+        config,
+        Some(requirements),
+        &SandboxPolicy::DangerFullAccess,
+    )
+    .expect("explicit empty legacy allowlist should remain constraining");
+
+    assert_eq!(spec.config.network.allowed_domains(), None);
+    assert_eq!(spec.constraints.allowed_domains, Some(Vec::new()));
+    assert_eq!(spec.constraints.allowlist_expansion_enabled, Some(false));
+}
+
+#[test]
+fn explicit_empty_legacy_denied_domains_pin_full_access_denylist_empty() {
+    let mut config = NetworkProxyConfig::default();
+    config
+        .network
+        .set_denied_domains(vec!["blocked.example.com".to_string()]);
+    let requirements: NetworkConstraints =
+        toml::from_str("denied_domains = []").expect("legacy denylist should parse");
+
+    let spec = NetworkProxySpec::from_config_and_constraints(
+        config,
+        Some(requirements),
+        &SandboxPolicy::DangerFullAccess,
+    )
+    .expect("explicit empty legacy denylist should remain constraining");
+
+    assert_eq!(spec.config.network.denied_domains(), None);
+    assert_eq!(spec.constraints.denied_domains, Some(Vec::new()));
+    assert_eq!(spec.constraints.denylist_expansion_enabled, Some(false));
+}
+
+#[test]
+fn explicit_empty_legacy_allow_unix_sockets_disables_allow_all_unix_sockets() {
+    let mut config = NetworkProxyConfig::default();
+    config.network.dangerously_allow_all_unix_sockets = true;
+    let requirements: NetworkConstraints =
+        toml::from_str("allow_unix_sockets = []").expect("legacy unix socket list should parse");
+
+    let err = NetworkProxySpec::from_config_and_constraints(
+        config,
+        Some(requirements),
+        &SandboxPolicy::DangerFullAccess,
+    )
+    .expect_err("explicit empty legacy unix socket allowlist should remain constraining");
+
+    assert!(
+        err.to_string()
+            .contains("network proxy constraints are invalid: invalid value for network.dangerously_allow_all_unix_sockets"),
+        "unexpected error: {err:#}"
+    );
+}
+
+#[test]
 fn managed_allowed_domains_only_disables_default_mode_allowlist_expansion() {
     let mut config = NetworkProxyConfig::default();
     config

--- a/codex-rs/tui/src/debug_config.rs
+++ b/codex-rs/tui/src/debug_config.rs
@@ -339,6 +339,7 @@ fn format_network_constraints(network: &NetworkConstraints) -> String {
         managed_allowed_domains_only,
         unix_sockets,
         allow_local_binding,
+        ..
     } = network;
 
     if let Some(enabled) = enabled {

--- a/codex-rs/tui_app_server/src/debug_config.rs
+++ b/codex-rs/tui_app_server/src/debug_config.rs
@@ -339,6 +339,7 @@ fn format_network_constraints(network: &NetworkConstraints) -> String {
         managed_allowed_domains_only,
         unix_sockets,
         allow_local_binding,
+        ..
     } = network;
 
     if let Some(enabled) = enabled {


### PR DESCRIPTION
## What changed
Preserve explicit empty legacy network lists when migrating to the canonical network permission maps.

This keeps `allowed_domains = []`, `denied_domains = []`, and `allow_unix_sockets = []` semantically meaningful instead of collapsing them to an absent value during normalization.

## Why this changed
The merged schema migration was lossy for explicit empty legacy lists.

That changed loaded policy in danger-full-access mode:
- `allowed_domains = []` used to pin the effective allowlist empty, but after migration it was treated as absent.
- `allow_unix_sockets = []` used to keep `dangerously_allow_all_unix_sockets` constrained off, but after migration that constraint disappeared.

## Impact
Managed configs that still use legacy network fields keep their old restrictive behavior even when the configured list is intentionally empty.

## Root cause
The migration helpers returned `None` when the canonical map ended up empty, which erased the distinction between:
- a legacy field being omitted
- a legacy field being explicitly present with an empty list

The follow-up fix preserves that distinction by carrying explicit legacy side-presence through normalization and runtime constraint construction.

## Validation
- `cargo test -p codex-config`
- `cargo test -p codex-core network_proxy_spec`
- `cargo clippy -p codex-config -p codex-core --tests -- -D warnings`
- `just fmt`
- `just argument-comment-lint`
