### PR TITLE
fix: fix Windows CI regression introduced in #15999

### DIFF
--- a/codex-rs/core/src/tasks/review.rs
+++ b/codex-rs/core/src/tasks/review.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -32,7 +33,9 @@ use super::SessionTask;
 use super::SessionTaskContext;
 
 static REVIEW_EXIT_SUCCESS_TEMPLATE: LazyLock<Template> = LazyLock::new(|| {
-    Template::parse(crate::client_common::REVIEW_EXIT_SUCCESS_TMPL)
+    let normalized =
+        normalize_review_template_line_endings(crate::client_common::REVIEW_EXIT_SUCCESS_TMPL);
+    Template::parse(normalized.as_ref())
         .unwrap_or_else(|err| panic!("review exit success template must parse: {err}"))
 });
 
@@ -231,7 +234,10 @@ pub(crate) async fn exit_review_mode(
         let assistant_message = render_review_output_text(&out);
         (rendered, assistant_message)
     } else {
-        let rendered = crate::client_common::REVIEW_EXIT_INTERRUPTED_TMPL.to_string();
+        let rendered = normalize_review_template_line_endings(
+            crate::client_common::REVIEW_EXIT_INTERRUPTED_TMPL,
+        )
+        .into_owned();
         let assistant_message =
             "Review was interrupted. Please re-run /review and wait for it to complete."
                 .to_string();
@@ -284,8 +290,17 @@ fn render_review_exit_success(results: &str) -> String {
         .unwrap_or_else(|err| panic!("review exit success template must render: {err}"))
 }
 
+fn normalize_review_template_line_endings(template: &str) -> Cow<'_, str> {
+    if template.contains('\r') {
+        Cow::Owned(template.replace("\r\n", "\n").replace('\r', "\n"))
+    } else {
+        Cow::Borrowed(template)
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::normalize_review_template_line_endings;
     use super::render_review_exit_success;
     use pretty_assertions::assert_eq;
 
@@ -294,6 +309,14 @@ mod tests {
         assert_eq!(
             render_review_exit_success("Finding A\nFinding B"),
             "<user_action>\n  <context>User initiated a review task. Here's the full review output from reviewer model. User may select one or more comments to resolve.</context>\n  <action>review</action>\n  <results>\n  Finding A\nFinding B\n  </results>\n  </user_action>\n"
+        );
+    }
+
+    #[test]
+    fn normalize_review_template_line_endings_rewrites_crlf() {
+        assert_eq!(
+            normalize_review_template_line_endings("<user_action>\r\n  <results>\r\n  None.\r\n"),
+            "<user_action>\n  <results>\n  None.\n"
         );
     }
 }


### PR DESCRIPTION
#15999 introduced a Windows-only `\r\n` mismatch in review-exit template handling. This PR normalizes those template newlines and separates that fix from [#16014](https://github.com/openai/codex/pull/16014) so it can be reviewed independently.