### PR TITLE
fix(core): default approval prompts for custom MCP tools

### DIFF
--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -699,12 +699,6 @@ async fn maybe_request_mcp_tool_approval(
     }
 
     let annotations = metadata.and_then(|metadata| metadata.annotations.as_ref());
-    if invocation.server != CODEX_APPS_MCP_SERVER_NAME
-        && approval_mode == AppToolApproval::Auto
-        && annotations.is_none()
-    {
-        return None;
-    }
     let approval_required = requires_mcp_tool_approval(annotations);
     if !approval_required && approval_mode != AppToolApproval::Prompt {
         return None;
@@ -735,6 +729,9 @@ async fn maybe_request_mcp_tool_approval(
         }
     }
 
+    if matches!(turn_context.approval_policy.value(), AskForApproval::Never) {
+        return Some(McpToolApprovalDecision::Decline);
+    }
     let session_approval_key = session_mcp_tool_approval_key(invocation, metadata, approval_mode);
     let persistent_approval_key =
         persistent_mcp_tool_approval_key(invocation, metadata, approval_mode);

--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -699,6 +699,12 @@ async fn maybe_request_mcp_tool_approval(
     }
 
     let annotations = metadata.and_then(|metadata| metadata.annotations.as_ref());
+    if invocation.server != CODEX_APPS_MCP_SERVER_NAME
+        && approval_mode == AppToolApproval::Auto
+        && annotations.is_none()
+    {
+        return None;
+    }
     let approval_required = requires_mcp_tool_approval(annotations);
     if !approval_required && approval_mode != AppToolApproval::Prompt {
         return None;

--- a/codex-rs/core/src/mcp_tool_call_tests.rs
+++ b/codex-rs/core/src/mcp_tool_call_tests.rs
@@ -1495,8 +1495,12 @@ async fn custom_approve_mode_blocks_when_arc_returns_interrupt_for_model() {
 }
 
 #[tokio::test]
-async fn custom_auto_mode_skips_when_annotations_are_missing() {
-    let (session, turn_context) = make_session_and_context().await;
+async fn custom_auto_mode_declines_when_annotations_are_missing_in_never_mode() {
+    let (session, mut turn_context) = make_session_and_context().await;
+    turn_context
+        .approval_policy
+        .set(AskForApproval::Never)
+        .expect("test setup should allow updating approval policy");
     let session = Arc::new(session);
     let turn_context = Arc::new(turn_context);
     let invocation = McpInvocation {
@@ -1515,7 +1519,7 @@ async fn custom_auto_mode_skips_when_annotations_are_missing() {
     )
     .await;
 
-    assert_eq!(decision, None);
+    assert_eq!(decision, Some(McpToolApprovalDecision::Decline));
 }
 
 #[tokio::test]
@@ -1546,7 +1550,7 @@ async fn custom_approve_mode_without_metadata_still_uses_arc_monitor() {
 
     let (session, mut turn_context) = make_session_and_context().await;
     turn_context.auth_manager = Some(crate::test_support::auth_manager_from_auth(
-        crate::CodexAuth::create_dummy_chatgpt_auth_for_testing(),
+        codex_login::CodexAuth::create_dummy_chatgpt_auth_for_testing(),
     ));
     let mut config = (*turn_context.config).clone();
     config.chatgpt_base_url = server.uri();

--- a/codex-rs/core/src/mcp_tool_call_tests.rs
+++ b/codex-rs/core/src/mcp_tool_call_tests.rs
@@ -1495,6 +1495,90 @@ async fn custom_approve_mode_blocks_when_arc_returns_interrupt_for_model() {
 }
 
 #[tokio::test]
+async fn custom_auto_mode_skips_when_annotations_are_missing() {
+    let (session, turn_context) = make_session_and_context().await;
+    let session = Arc::new(session);
+    let turn_context = Arc::new(turn_context);
+    let invocation = McpInvocation {
+        server: "docs".to_string(),
+        tool: "search".to_string(),
+        arguments: Some(serde_json::json!({ "query": "approval regression" })),
+    };
+
+    let decision = maybe_request_mcp_tool_approval(
+        &session,
+        &turn_context,
+        "call-custom-auto",
+        &invocation,
+        None,
+        AppToolApproval::Auto,
+    )
+    .await;
+
+    assert_eq!(decision, None);
+}
+
+#[tokio::test]
+async fn custom_approve_mode_without_metadata_still_uses_arc_monitor() {
+    use wiremock::Mock;
+    use wiremock::MockServer;
+    use wiremock::ResponseTemplate;
+    use wiremock::matchers::method;
+    use wiremock::matchers::path;
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/codex/safety/arc"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "outcome": "steer-model",
+            "short_reason": "needs approval",
+            "rationale": "high-risk action",
+            "risk_score": 96,
+            "risk_level": "critical",
+            "evidence": [{
+                "message": "search",
+                "why": "high-risk action",
+            }],
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let (session, mut turn_context) = make_session_and_context().await;
+    turn_context.auth_manager = Some(crate::test_support::auth_manager_from_auth(
+        crate::CodexAuth::create_dummy_chatgpt_auth_for_testing(),
+    ));
+    let mut config = (*turn_context.config).clone();
+    config.chatgpt_base_url = server.uri();
+    turn_context.config = Arc::new(config);
+
+    let session = Arc::new(session);
+    let turn_context = Arc::new(turn_context);
+    let invocation = McpInvocation {
+        server: "docs".to_string(),
+        tool: "search".to_string(),
+        arguments: Some(serde_json::json!({ "query": "approval regression" })),
+    };
+
+    let decision = maybe_request_mcp_tool_approval(
+        &session,
+        &turn_context,
+        "call-custom-approve-no-metadata",
+        &invocation,
+        None,
+        AppToolApproval::Approve,
+    )
+    .await;
+
+    assert_eq!(
+        decision,
+        Some(McpToolApprovalDecision::BlockedBySafetyMonitor(
+            "Tool call was cancelled because of safety risks: high-risk action".to_string(),
+        ))
+    );
+}
+
+#[tokio::test]
 async fn approve_mode_blocks_when_arc_returns_interrupt_without_annotations() {
     use wiremock::Mock;
     use wiremock::MockServer;


### PR DESCRIPTION
## Summary
Preserve `#15519`'s fail-closed behavior for MCP tools with missing annotations, while fixing the non-interactive regression it exposed for custom MCP servers.

This change keeps the default approval-required behavior for unannotated MCP tools, but prevents `AskForApproval::Never` from surfacing an interactive MCP approval prompt. Instead, approval-required custom MCP calls are declined deterministically in non-interactive mode.

That fixes the regression where non-`codex_apps` MCP calls could emit `RequestUserInput` and hang headless runs or tests, without reopening the safety hole that `#15519` intentionally closed.

#15824

## Behavior
For non-`codex_apps` MCP tools with missing annotations:

- In interactive approval modes, approval is still required.
- In `AskForApproval::Never`, Codex no longer prompts.
- In `AskForApproval::Never`, the tool call is declined instead.

This preserves the intent of `#15519`:
- missing annotations still do not silently bypass approval
- `codex_apps` behavior is unchanged
- explicitly approved custom MCP tools still keep their approval flow and ARC behavior

## Validation
- `just fmt`
- `cargo test -p codex-core --lib custom_auto_mode_declines_when_annotations_are_missing_in_never_mode -- --nocapture`
- `cargo test -p codex-core --lib custom_approve_mode_without_metadata_still_uses_arc_monitor -- --nocapture`
- `cargo test -p codex-core --lib approve_mode_blocks_when_arc_returns_interrupt_without_annotations -- --nocapture`
- `timeout 300 cargo test -p codex-core --test all -- --test-threads=1 suite::rmcp_client::stdio_image_responses_are_sanitized_for_text_only_model suite::rmcp_client::stdio_image_responses_round_trip suite::rmcp_client::stdio_server_propagates_whitelisted_env_vars suite::rmcp_client::stdio_server_round_trip suite::sqlite_state::mcp_call_marks_thread_memory_mode_polluted_when_configured suite::truncation::mcp_image_output_preserves_image_and_no_text_summary suite::truncation::mcp_tool_call_output_exceeds_limit_truncated_for_model suite::truncation::mcp_tool_call_output_not_truncated_with_custom_limit`

## Manual Repro
Validated with a custom stdio MCP server whose `echo` tool intentionally omits annotations.

Steps:
1. Register the custom MCP server as `noann`.
2. Run Codex with `--ask-for-approval never --sandbox read-only`.
3. Ask: `Call the noann echo tool with message ping.`

Behavior on `32c4993c8a17cb0608d747f268e3d543745de962`:
- Codex incorrectly prompts: `Allow the noann MCP server to run tool "echo"?`

Behavior on this branch:
- No approval prompt appears.
- The tool call is handled non-interactively instead of hanging behind `RequestUserInput`.

## Notes
- `just argument-comment-lint` is currently broken in this checkout because `tools/argument-comment-lint/run-prebuilt-linter.sh` is missing.
- A broader `cargo test -p codex-core` run previously surfaced an unrelated existing failure in `suite::apply_patch_cli::apply_patch_aggregates_diff_across_multiple_tool_calls`.
