### PR TITLE
shell-command: speed up Windows PowerShell safety tests

### DIFF
--- a/codex-rs/shell-command/src/command_safety/windows_safe_commands.rs
+++ b/codex-rs/shell-command/src/command_safety/windows_safe_commands.rs
@@ -340,6 +340,13 @@ mod tests {
         args.iter().map(ToString::to_string).collect()
     }
 
+    fn assert_unsafe_parsed_command(words: &[&str]) {
+        assert!(
+            !is_safe_powershell_command(&vec_str(words)),
+            "expected parsed command {words:?} to require approval",
+        );
+    }
+
     #[test]
     fn recognizes_safe_powershell_wrappers() {
         assert!(is_safe_command_windows(&vec_str(&[
@@ -441,136 +448,69 @@ mod tests {
 
     #[test]
     fn rejects_git_global_override_options() {
-        let Some(pwsh) = try_find_pwsh_executable_blocking() else {
-            return;
-        };
-
-        let pwsh: String = pwsh.as_path().to_str().unwrap().into();
-        for script in [
-            "git -c core.pager=cat show HEAD:foo.rs",
-            "git --config-env core.pager=PAGER show HEAD:foo.rs",
-            "git --config-env=core.pager=PAGER show HEAD:foo.rs",
-            "git --git-dir .evil-git diff HEAD~1..HEAD",
-            "git --git-dir=.evil-git diff HEAD~1..HEAD",
-            "git --work-tree . status",
-            "git --work-tree=. status",
-            "git --exec-path .git/helpers show HEAD:foo.rs",
-            "git --exec-path=.git/helpers show HEAD:foo.rs",
-            "git --namespace attacker show HEAD:foo.rs",
-            "git --namespace=attacker show HEAD:foo.rs",
-            "git --super-prefix attacker/ show HEAD:foo.rs",
-            "git --super-prefix=attacker/ show HEAD:foo.rs",
+        for words in [
+            &["git", "-c", "core.pager=cat", "show", "HEAD:foo.rs"][..],
+            &[
+                "git",
+                "--config-env",
+                "core.pager=PAGER",
+                "show",
+                "HEAD:foo.rs",
+            ][..],
+            &[
+                "git",
+                "--config-env=core.pager=PAGER",
+                "show",
+                "HEAD:foo.rs",
+            ][..],
+            &["git", "--git-dir", ".evil-git", "diff", "HEAD~1..HEAD"][..],
+            &["git", "--git-dir=.evil-git", "diff", "HEAD~1..HEAD"][..],
+            &["git", "--work-tree", ".", "status"][..],
+            &["git", "--work-tree=.", "status"][..],
+            &["git", "--exec-path", ".git/helpers", "show", "HEAD:foo.rs"][..],
+            &["git", "--exec-path=.git/helpers", "show", "HEAD:foo.rs"][..],
+            &["git", "--namespace", "attacker", "show", "HEAD:foo.rs"][..],
+            &["git", "--namespace=attacker", "show", "HEAD:foo.rs"][..],
+            &["git", "--super-prefix", "attacker/", "show", "HEAD:foo.rs"][..],
+            &["git", "--super-prefix=attacker/", "show", "HEAD:foo.rs"][..],
         ] {
-            assert!(
-                !is_safe_command_windows(&[
-                    pwsh.clone(),
-                    "-NoLogo".to_string(),
-                    "-NoProfile".to_string(),
-                    "-Command".to_string(),
-                    script.to_string(),
-                ]),
-                "expected {script:?} to require approval due to unsafe git global option",
-            );
+            assert_unsafe_parsed_command(words);
         }
     }
 
     #[test]
-    fn rejects_powershell_commands_with_side_effects() {
-        assert!(!is_safe_command_windows(&vec_str(&[
-            "powershell.exe",
-            "-NoLogo",
-            "-Command",
-            "Remove-Item foo.txt",
-        ])));
+    fn rejects_parsed_powershell_commands_with_side_effects() {
+        for words in [
+            &["Remove-Item", "foo.txt"][..],
+            &["rg", "--pre", "cat"][..],
+            &["Set-Content", "foo.txt", "hello"][..],
+            &["Out-File", "y"][..],
+            &["Write-Output", "(Set-Content", "foo6.txt", "abc)"][..],
+            &["Write-Host", "(Remove-Item", "foo.txt)"][..],
+            &["Get-Content", "(New-Item", "bar.txt)"][..],
+        ] {
+            assert_unsafe_parsed_command(words);
+        }
+    }
 
-        assert!(!is_safe_command_windows(&vec_str(&[
-            "powershell.exe",
-            "-NoProfile",
-            "-Command",
-            "rg --pre cat",
-        ])));
-
-        assert!(!is_safe_command_windows(&vec_str(&[
-            "powershell.exe",
-            "-Command",
-            "Set-Content foo.txt 'hello'",
-        ])));
-
-        // Redirections are blocked
-        assert!(!is_safe_command_windows(&vec_str(&[
-            "powershell.exe",
-            "-Command",
+    #[test]
+    fn rejects_parser_only_powershell_side_effect_patterns() {
+        for script in [
             "echo hi > out.txt",
-        ])));
-        assert!(!is_safe_command_windows(&vec_str(&[
-            "powershell.exe",
-            "-Command",
             "Get-Content x | Out-File y",
-        ])));
-        assert!(!is_safe_command_windows(&vec_str(&[
-            "powershell.exe",
-            "-Command",
             "Write-Output foo 2> err.txt",
-        ])));
-
-        // Call operator is blocked
-        assert!(!is_safe_command_windows(&vec_str(&[
-            "powershell.exe",
-            "-Command",
             "& Remove-Item foo",
-        ])));
-
-        // Chained safe + unsafe must fail
-        assert!(!is_safe_command_windows(&vec_str(&[
-            "powershell.exe",
-            "-Command",
             "Get-ChildItem; Remove-Item foo",
-        ])));
-        // Nested unsafe cmdlet inside safe command must fail
-        assert!(!is_safe_command_windows(&vec_str(&[
-            "powershell.exe",
-            "-Command",
-            "Write-Output (Set-Content foo6.txt 'abc')",
-        ])));
-        // Additional nested unsafe cmdlet examples must fail
-        assert!(!is_safe_command_windows(&vec_str(&[
-            "powershell.exe",
-            "-Command",
-            "Write-Host (Remove-Item foo.txt)",
-        ])));
-        assert!(!is_safe_command_windows(&vec_str(&[
-            "powershell.exe",
-            "-Command",
-            "Get-Content (New-Item bar.txt)",
-        ])));
-
-        // Unsafe @ expansion.
-        assert!(!is_safe_command_windows(&vec_str(&[
-            "powershell.exe",
-            "-Command",
-            "ls @(calc.exe)"
-        ])));
-
-        // Unsupported constructs that the AST parser refuses (no fallback to manual splitting).
-        assert!(!is_safe_command_windows(&vec_str(&[
-            "powershell.exe",
-            "-Command",
-            "ls && pwd"
-        ])));
-
-        // Sub-expressions are rejected even if they contain otherwise safe commands.
-        assert!(!is_safe_command_windows(&vec_str(&[
-            "powershell.exe",
-            "-Command",
-            "Write-Output $(Get-Content foo)"
-        ])));
-
-        // Empty words from the parser (e.g. '') are rejected.
-        assert!(!is_safe_command_windows(&vec_str(&[
-            "powershell.exe",
-            "-Command",
-            "''"
-        ])));
+            "ls @(calc.exe)",
+            "ls && pwd",
+            "Write-Output $(Get-Content foo)",
+            "''",
+        ] {
+            assert!(
+                !is_safe_command_windows(&vec_str(&["powershell.exe", "-Command", script,])),
+                "expected {script:?} to require approval",
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Why

`//codex-rs/shell-command:shell-command-unit-tests` became a real bottleneck in the Windows Bazel lane because the `windows_safe_commands` tests were repeatedly calling `is_safe_command_windows()`, and that helper shells out to a real PowerShell parser process for every `powershell.exe -Command ...` assertion.

In the Windows Bazel run that motivated this extraction, the target hit Bazel's 300s timeout while several tests in this module were still reported as "running for over 60 seconds". That makes this a key performance improvement: it removes repeated PowerShell startup cost from a hot unit-test target without weakening the safety checks we actually care about, which should materially improve the Windows Bazel feedback loop.

This change was split out of #16053 so it can land immediately on its own.

## What

- add a small test helper that asserts `is_safe_powershell_command()` directly on already-parsed words
- move parser-independent negative cases, including the unsafe git global override checks and obvious side-effecting PowerShell commands, onto that direct helper path
- keep the true parser-integration coverage on `is_safe_command_windows()`, but limit it to cases that still need a real PowerShell AST parse

The net effect is that we still verify both layers:

- the parser-independent safelist logic
- the PowerShell parser integration points

but we stop paying interpreter startup cost for every single negative test case.

## Testing

- `cargo test -p codex-shell-command`
- `just argument-comment-lint`
- the changed test module is Windows-only, so the main end-to-end verification for the extracted improvement is this PR's Windows Bazel CI
