### PR TITLE
ci: run Bazel clippy on Windows gnullvm

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -103,11 +103,15 @@ jobs:
       matrix:
         include:
           # Keep Linux lint coverage on x64 and add the arm64 macOS path that
-          # the Bazel test job already exercises.
+          # the Bazel test job already exercises. Add Windows gnullvm as well
+          # so PRs get Bazel-native lint signal on the same Windows toolchain
+          # that the Bazel test job uses.
           - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
           - os: macos-15-xlarge
             target: aarch64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-gnullvm
     runs-on: ${{ matrix.os }}
     name: Bazel clippy on ${{ matrix.os }} for ${{ matrix.target }}
 


### PR DESCRIPTION
## Why

We want more of the pre-merge Rust signal to come from `bazel.yml`, especially on Windows. The Bazel test workflow already exercises `x86_64-pc-windows-gnullvm`, but the Bazel clippy job still only ran on Linux x64 and macOS arm64. That left a gap where Windows-only Bazel lint breakages could slip through until the Cargo-based workflow ran.

This change keeps the fix narrow. Rather than expanding the Bazel clippy target set or changing the shared setup logic, it extends the existing clippy matrix to the same Windows GNU toolchain that the Bazel test job already uses.

## What Changed

- add `windows-latest` / `x86_64-pc-windows-gnullvm` to the `clippy` job matrix in `.github/workflows/bazel.yml`
- update the nearby workflow comment to explain that the goal is to get Bazel-native Windows lint coverage on the same toolchain as the Bazel test lane
- leave the Bazel clippy scope unchanged at `//codex-rs/... -//codex-rs/v8-poc:all`

## Verification

- parsed `.github/workflows/bazel.yml` successfully with Ruby `YAML.load_file`
