### PR TITLE
fix: clean up remaining Windows argument-comment-lint violations

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -163,10 +163,10 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
         shell: bash
         run: python3 ./tools/argument-comment-lint/run-prebuilt-linter.py -- --lib --bins
-      - name: Run argument comment lint on codex-rs (default targets only)
+      - name: Run argument comment lint on codex-rs
         if: ${{ runner.os == 'Windows' }}
         shell: bash
-        run: python ./tools/argument-comment-lint/run-prebuilt-linter.py -- --lib --bins
+        run: python ./tools/argument-comment-lint/run-prebuilt-linter.py
 
   # --- CI to validate on different os/targets --------------------------------
   lint_build:

--- a/codex-rs/network-proxy/src/proxy.rs
+++ b/codex-rs/network-proxy/src/proxy.rs
@@ -780,7 +780,7 @@ mod tests {
         let reserved = reserve_windows_managed_listeners(
             SocketAddr::from(([127, 0, 0, 1], busy_port)),
             SocketAddr::from(([127, 0, 0, 1], 48081)),
-            false,
+            /*reserve_socks_listener*/ false,
         )
         .unwrap();
 

--- a/codex-rs/tui_app_server/src/multi_agents.rs
+++ b/codex-rs/tui_app_server/src/multi_agents.rs
@@ -717,19 +717,19 @@ mod tests {
     fn agent_shortcut_matches_option_arrows_only() {
         assert!(previous_agent_shortcut_matches(
             KeyEvent::new(KeyCode::Left, crossterm::event::KeyModifiers::ALT,),
-            false
+            /*allow_word_motion_fallback*/ false
         ));
         assert!(next_agent_shortcut_matches(
             KeyEvent::new(KeyCode::Right, crossterm::event::KeyModifiers::ALT,),
-            false
+            /*allow_word_motion_fallback*/ false
         ));
         assert!(!previous_agent_shortcut_matches(
             KeyEvent::new(KeyCode::Char('b'), crossterm::event::KeyModifiers::ALT,),
-            false
+            /*allow_word_motion_fallback*/ false
         ));
         assert!(!next_agent_shortcut_matches(
             KeyEvent::new(KeyCode::Char('f'), crossterm::event::KeyModifiers::ALT,),
-            false
+            /*allow_word_motion_fallback*/ false
         ));
     }
 

--- a/codex-rs/windows-sandbox-rs/src/elevated_impl.rs
+++ b/codex-rs/windows-sandbox-rs/src/elevated_impl.rs
@@ -490,12 +490,12 @@ mod windows_impl {
 
         #[test]
         fn applies_network_block_when_access_is_disabled() {
-            assert!(!workspace_policy(false).has_full_network_access());
+            assert!(!workspace_policy(/*network_access*/ false).has_full_network_access());
         }
 
         #[test]
         fn skips_network_block_when_access_is_allowed() {
-            assert!(workspace_policy(true).has_full_network_access());
+            assert!(workspace_policy(/*network_access*/ true).has_full_network_access());
         }
 
         #[test]

--- a/codex-rs/windows-sandbox-rs/src/lib.rs
+++ b/codex-rs/windows-sandbox-rs/src/lib.rs
@@ -617,12 +617,16 @@ mod windows_impl {
 
         #[test]
         fn applies_network_block_when_access_is_disabled() {
-            assert!(should_apply_network_block(&workspace_policy(false)));
+            assert!(should_apply_network_block(&workspace_policy(
+                /*network_access*/ false
+            )));
         }
 
         #[test]
         fn skips_network_block_when_access_is_allowed() {
-            assert!(!should_apply_network_block(&workspace_policy(true)));
+            assert!(!should_apply_network_block(&workspace_policy(
+                /*network_access*/ true
+            )));
         }
 
         #[test]


### PR DESCRIPTION
## Why

The initial `argument-comment-lint` rollout left Windows on default-target coverage because there were still Windows-only callsites failing under `--all-targets`. This follow-up cleans up those remaining Windows-specific violations so the Windows CI lane can enforce the same stricter coverage, leaving Linux as the remaining platform-specific follow-up.

## What changed

- switched the Windows `rust-ci` argument-comment-lint step back to the default wrapper invocation so it runs full-target coverage again
- added the required `/*param_name*/` annotations at Windows-gated literal callsites in:
  - `codex-rs/windows-sandbox-rs/src/lib.rs`
  - `codex-rs/windows-sandbox-rs/src/elevated_impl.rs`
  - `codex-rs/tui_app_server/src/multi_agents.rs`
  - `codex-rs/network-proxy/src/proxy.rs`

## Validation

- Windows `argument comment lint` CI on this PR
