### PR TITLE
bazel: add Windows gnullvm stack flags to unit test binaries

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -200,11 +200,14 @@ def codex_rust_crate(
             name = unit_test_binary,
             crate = name,
             deps = all_crate_deps(normal = True, normal_dev = True) + maybe_deps + deps_extra,
+            # Unit tests also compile to standalone Windows executables, so
+            # keep their stack reserve aligned with binaries and integration
+            # tests under gnullvm.
             # Bazel has emitted both `codex-rs/<crate>/...` and
             # `../codex-rs/<crate>/...` paths for `file!()`. Strip either
             # prefix so the workspace-root launcher sees Cargo-like metadata
             # such as `tui/src/...`.
-            rustc_flags = rustc_flags_extra + [
+            rustc_flags = rustc_flags_extra + WINDOWS_GNULLVM_RUSTC_STACK_FLAGS + [
                 "--remap-path-prefix=../codex-rs=",
                 "--remap-path-prefix=codex-rs=",
             ],


### PR DESCRIPTION
## Summary

Add the Windows gnullvm stack-reserve flags to the `*-unit-tests-bin` path in `codex_rust_crate()`.

## Why

This is the narrow code fix behind the earlier review comment on [#16067](https://github.com/openai/codex/pull/16067). That comment was stale relative to the workflow-only PR it landed on, but it pointed at a real gap in `defs.bzl`.

Today, `codex_rust_crate()` already appends `WINDOWS_GNULLVM_RUSTC_STACK_FLAGS` for:

- `rust_binary()` targets
- integration-test `rust_test()` targets

But the unit-test binary path still omitted those flags. That meant the generated `*-unit-tests-bin` executables were not built the same way as the rest of the Windows gnullvm executables in the macro.

## What Changed

- Added `WINDOWS_GNULLVM_RUSTC_STACK_FLAGS` to the `unit_test_binary` `rust_test()` rule in `defs.bzl`
- Added a short comment explaining why unit-test binaries need the same stack-reserve treatment as binaries and integration tests on Windows gnullvm

## Testing

- `bazel query '//codex-rs/core:*'`
- `bazel query '//codex-rs/shell-command:*'`

Those queries load packages that exercise `codex_rust_crate()`, including `*-unit-tests-bin` targets. The actual runtime effect is Windows-specific, so the real end-to-end confirmation still comes from Windows CI.
