### PR TITLE
Remove the codex-tui app-server originator workaround

### DIFF
--- a/codex-rs/app-server/src/message_processor.rs
+++ b/codex-rs/app-server/src/message_processor.rs
@@ -61,7 +61,6 @@ use codex_core::ThreadManager;
 use codex_core::config::Config;
 use codex_core::config_loader::CloudRequirementsLoader;
 use codex_core::config_loader::LoaderOverrides;
-use codex_core::default_client::DEFAULT_ORIGINATOR;
 use codex_core::default_client::SetOriginatorError;
 use codex_core::default_client::USER_AGENT_SUFFIX;
 use codex_core::default_client::get_codex_user_agent;
@@ -88,7 +87,6 @@ use toml::Value as TomlValue;
 use tracing::Instrument;
 
 const EXTERNAL_AUTH_REFRESH_TIMEOUT: Duration = Duration::from_secs(10);
-const TUI_CLIENT_NAME: &str = "codex-tui";
 
 #[derive(Clone)]
 struct ExternalAuthRefreshBridge {
@@ -569,13 +567,7 @@ impl MessageProcessor {
                 } = params.client_info;
                 session.app_server_client_name = Some(name.clone());
                 session.client_version = Some(version.clone());
-                let originator = if name == TUI_CLIENT_NAME {
-                    // TODO: Remove this temporary workaround once the TUI no longer
-                    // needs to retain the `codex_cli_rs` originator behavior.
-                    DEFAULT_ORIGINATOR.to_string()
-                } else {
-                    name.clone()
-                };
+                let originator = name.clone();
                 if let Err(error) = set_default_originator(originator) {
                     match error {
                         SetOriginatorError::InvalidHeaderValue => {

--- a/codex-rs/login/src/auth/default_client.rs
+++ b/codex-rs/login/src/auth/default_client.rs
@@ -119,6 +119,7 @@ pub fn originator() -> Originator {
 
 pub fn is_first_party_originator(originator_value: &str) -> bool {
     originator_value == DEFAULT_ORIGINATOR
+        || originator_value == "codex-tui"
         || originator_value == "codex_vscode"
         || originator_value.starts_with("Codex ")
 }

--- a/codex-rs/login/src/auth/default_client_tests.rs
+++ b/codex-rs/login/src/auth/default_client_tests.rs
@@ -14,6 +14,7 @@ fn test_get_codex_user_agent() {
 #[test]
 fn is_first_party_originator_matches_known_values() {
     assert_eq!(is_first_party_originator(DEFAULT_ORIGINATOR), true);
+    assert_eq!(is_first_party_originator("codex-tui"), true);
     assert_eq!(is_first_party_originator("codex_vscode"), true);
     assert_eq!(is_first_party_originator("Codex Something Else"), true);
     assert_eq!(is_first_party_originator("codex_cli"), false);


### PR DESCRIPTION
## Summary
- remove the temporary `codex-tui` special-case when setting the default originator during app-server initialization
