### PR TITLE
fix: fix comment linter lint violations in Linux-only code

### DIFF
--- a/codex-rs/exec/tests/suite/sandbox.rs
+++ b/codex-rs/exec/tests/suite/sandbox.rs
@@ -51,9 +51,9 @@ async fn spawn_command_under_sandbox(
         command_cwd,
         sandbox_policy,
         sandbox_cwd,
-        false,
+        /*use_legacy_landlock*/ false,
         stdio_policy,
-        None,
+        /*network*/ None,
         env,
     )
     .await

--- a/codex-rs/linux-sandbox/tests/suite/landlock.rs
+++ b/codex-rs/linux-sandbox/tests/suite/landlock.rs
@@ -45,7 +45,7 @@ const BWRAP_UNAVAILABLE_ERR: &str = "build-time bubblewrap is not available in t
 
 fn create_env_from_core_vars() -> HashMap<String, String> {
     let policy = ShellEnvironmentPolicy::default();
-    create_env(&policy, None)
+    create_env(&policy, /*thread_id*/ None)
 }
 
 #[expect(clippy::print_stdout)]
@@ -64,9 +64,15 @@ async fn run_cmd_output(
     writable_roots: &[PathBuf],
     timeout_ms: u64,
 ) -> codex_core::exec::ExecToolCallOutput {
-    run_cmd_result_with_writable_roots(cmd, writable_roots, timeout_ms, false, false)
-        .await
-        .expect("sandboxed command should execute")
+    run_cmd_result_with_writable_roots(
+        cmd,
+        writable_roots,
+        timeout_ms,
+        /*use_legacy_landlock*/ false,
+        /*network_access*/ false,
+    )
+    .await
+    .expect("sandboxed command should execute")
 }
 
 async fn run_cmd_result_with_writable_roots(
@@ -137,7 +143,7 @@ async fn run_cmd_result_with_policies(
         sandbox_cwd.as_path(),
         &codex_linux_sandbox_exe,
         use_legacy_landlock,
-        None,
+        /*stdout_stream*/ None,
     )
     .await
 }
@@ -158,8 +164,8 @@ async fn should_skip_bwrap_tests() -> bool {
         &["bash", "-lc", "true"],
         &[],
         NETWORK_TIMEOUT_MS,
-        false,
-        true,
+        /*use_legacy_landlock*/ false,
+        /*network_access*/ true,
     )
     .await
     {
@@ -219,8 +225,8 @@ async fn test_dev_null_write() {
         // We have seen timeouts when running this test in CI on GitHub,
         // so we are using a generous timeout until we can diagnose further.
         LONG_TIMEOUT_MS,
-        false,
-        true,
+        /*use_legacy_landlock*/ false,
+        /*network_access*/ true,
     )
     .await
     .expect("sandboxed command should execute");
@@ -243,8 +249,8 @@ async fn bwrap_populates_minimal_dev_nodes() {
         ],
         &[],
         LONG_TIMEOUT_MS,
-        false,
-        true,
+        /*use_legacy_landlock*/ false,
+        /*network_access*/ true,
     )
     .await
     .expect("sandboxed command should execute");
@@ -281,8 +287,8 @@ async fn bwrap_preserves_writable_dev_shm_bind_mount() {
         ],
         &[PathBuf::from("/dev/shm")],
         LONG_TIMEOUT_MS,
-        false,
-        true,
+        /*use_legacy_landlock*/ false,
+        /*network_access*/ true,
     )
     .await
     .expect("sandboxed command should execute");
@@ -328,8 +334,8 @@ async fn sandbox_ignores_missing_writable_roots_under_bwrap() {
         &["bash", "-lc", "printf sandbox-ok"],
         &[existing_root, missing_root],
         LONG_TIMEOUT_MS,
-        false,
-        true,
+        /*use_legacy_landlock*/ false,
+        /*network_access*/ true,
     )
     .await
     .expect("sandboxed command should execute");
@@ -360,7 +366,7 @@ async fn test_no_new_privs_is_enabled() {
 #[tokio::test]
 #[should_panic(expected = "Sandbox(Timeout")]
 async fn test_timeout() {
-    run_cmd(&["sleep", "2"], &[], 50).await;
+    run_cmd(&["sleep", "2"], &[], /*timeout_ms*/ 50).await;
 }
 
 /// Helper that runs `cmd` under the Linux sandbox and asserts that the command
@@ -397,8 +403,8 @@ async fn assert_network_blocked(cmd: &[&str]) {
         NetworkSandboxPolicy::from(&sandbox_policy),
         sandbox_cwd.as_path(),
         &codex_linux_sandbox_exe,
-        false,
-        None,
+        /*use_legacy_landlock*/ false,
+        /*stdout_stream*/ None,
     )
     .await;
 
@@ -473,8 +479,8 @@ async fn sandbox_blocks_git_and_codex_writes_inside_writable_root() {
             ],
             &[tmpdir.path().to_path_buf()],
             LONG_TIMEOUT_MS,
-            false,
-            true,
+            /*use_legacy_landlock*/ false,
+            /*network_access*/ true,
         )
         .await,
         ".git write should be denied under bubblewrap",
@@ -489,8 +495,8 @@ async fn sandbox_blocks_git_and_codex_writes_inside_writable_root() {
             ],
             &[tmpdir.path().to_path_buf()],
             LONG_TIMEOUT_MS,
-            false,
-            true,
+            /*use_legacy_landlock*/ false,
+            /*network_access*/ true,
         )
         .await,
         ".codex write should be denied under bubblewrap",
@@ -526,8 +532,8 @@ async fn sandbox_blocks_codex_symlink_replacement_attack() {
             ],
             &[tmpdir.path().to_path_buf()],
             LONG_TIMEOUT_MS,
-            false,
-            true,
+            /*use_legacy_landlock*/ false,
+            /*network_access*/ true,
         )
         .await,
         ".codex symlink replacement should be denied",
@@ -598,7 +604,7 @@ async fn sandbox_blocks_explicit_split_policy_carveouts_under_bwrap() {
             file_system_sandbox_policy,
             NetworkSandboxPolicy::Enabled,
             LONG_TIMEOUT_MS,
-            false,
+            /*use_legacy_landlock*/ false,
         )
         .await,
         "explicit split-policy carveout should be denied under bubblewrap",
@@ -680,7 +686,7 @@ async fn sandbox_reenables_writable_subpaths_under_unreadable_parents() {
         file_system_sandbox_policy,
         NetworkSandboxPolicy::Enabled,
         LONG_TIMEOUT_MS,
-        false,
+        /*use_legacy_landlock*/ false,
     )
     .await
     .expect("nested writable carveout should execute under bubblewrap");
@@ -731,7 +737,7 @@ async fn sandbox_blocks_root_read_carveouts_under_bwrap() {
             file_system_sandbox_policy,
             NetworkSandboxPolicy::Enabled,
             LONG_TIMEOUT_MS,
-            false,
+            /*use_legacy_landlock*/ false,
         )
         .await,
         "root-read carveout should be denied under bubblewrap",

--- a/codex-rs/linux-sandbox/tests/suite/managed_proxy.rs
+++ b/codex-rs/linux-sandbox/tests/suite/managed_proxy.rs
@@ -44,7 +44,7 @@ const PROXY_ENV_KEYS: &[&str] = &[
 
 fn create_env_from_core_vars() -> HashMap<String, String> {
     let policy = ShellEnvironmentPolicy::default();
-    create_env(&policy, None)
+    create_env(&policy, /*thread_id*/ None)
 }
 
 fn strip_proxy_env(env: &mut HashMap<String, String>) {
@@ -66,7 +66,7 @@ async fn should_skip_bwrap_tests() -> bool {
     let output = run_linux_sandbox_direct(
         &["bash", "-c", "true"],
         &SandboxPolicy::new_read_only_policy(),
-        false,
+        /*allow_network_for_proxy*/ false,
         env,
         NETWORK_TIMEOUT_MS,
     )
@@ -92,7 +92,7 @@ async fn managed_proxy_skip_reason() -> Option<String> {
     let output = run_linux_sandbox_direct(
         &["bash", "-c", "true"],
         &SandboxPolicy::DangerFullAccess,
-        true,
+        /*allow_network_for_proxy*/ true,
         env,
         NETWORK_TIMEOUT_MS,
     )
@@ -171,7 +171,7 @@ async fn managed_proxy_mode_fails_closed_without_proxy_env() {
     let output = run_linux_sandbox_direct(
         &["bash", "-c", "true"],
         &SandboxPolicy::DangerFullAccess,
-        true,
+        /*allow_network_for_proxy*/ true,
         env,
         NETWORK_TIMEOUT_MS,
     )
@@ -226,7 +226,7 @@ async fn managed_proxy_mode_routes_through_bridge_and_blocks_direct_egress() {
             "proxy=\"${HTTP_PROXY#*://}\"; host=\"${proxy%%:*}\"; port=\"${proxy##*:}\"; exec 3<>/dev/tcp/${host}/${port}; printf 'GET http://example.com/ HTTP/1.1\\r\\nHost: example.com\\r\\n\\r\\n' >&3; IFS= read -r line <&3; printf '%s\\n' \"$line\"",
         ],
         &SandboxPolicy::DangerFullAccess,
-        true,
+        /*allow_network_for_proxy*/ true,
         env.clone(),
         NETWORK_TIMEOUT_MS,
     )
@@ -257,7 +257,7 @@ async fn managed_proxy_mode_routes_through_bridge_and_blocks_direct_egress() {
     let direct_egress_output = run_linux_sandbox_direct(
         &["bash", "-c", "echo hi > /dev/tcp/192.0.2.1/80"],
         &SandboxPolicy::DangerFullAccess,
-        true,
+        /*allow_network_for_proxy*/ true,
         env,
         NETWORK_TIMEOUT_MS,
     )
@@ -295,7 +295,7 @@ async fn managed_proxy_mode_denies_af_unix_creation_for_user_command() {
             "import socket,sys\ntry:\n    socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)\nexcept PermissionError:\n    sys.exit(0)\nexcept OSError:\n    sys.exit(2)\nsys.exit(1)\n",
         ],
         &SandboxPolicy::DangerFullAccess,
-        true,
+        /*allow_network_for_proxy*/ true,
         env,
         NETWORK_TIMEOUT_MS,
     )


### PR DESCRIPTION
https://github.com/openai/codex/pull/16071 took care of this for Windows, so this takes care of things for Linux.

We don't touch the CI jobs in this PR because https://github.com/openai/codex/pull/16106 is going to be the real fix there (including a major speedup!).