### PR TITLE
tests: stabilize Windows apply_patch harness shell selection

### DIFF
--- a/codex-rs/core/tests/suite/apply_patch_cli.rs
+++ b/codex-rs/core/tests/suite/apply_patch_cli.rs
@@ -49,7 +49,10 @@ pub async fn apply_patch_harness() -> Result<TestCodexHarness> {
 async fn apply_patch_harness_with(
     configure: impl FnOnce(TestCodexBuilder) -> TestCodexBuilder,
 ) -> Result<TestCodexHarness> {
-    let builder = configure(test_codex()).with_config(|config| {
+    // Keep Windows shell-command apply_patch tests on a deterministic outer
+    // shell so heredoc interception does not depend on runner-local shell
+    // auto-detection.
+    let builder = configure(test_codex().with_windows_cmd_shell()).with_config(|config| {
         config.include_apply_patch_tool = true;
     });
     // Box harness construction so apply_patch_cli tests do not inline the


### PR DESCRIPTION
## Why

An unrelated Windows CI run exposed a flaky `apply_patch_cli` integration test:

- `suite::apply_patch_cli::apply_patch_cli_add_overwrites_existing_file::applypatchmodeloutput_shellcommandviaheredoc_expects`

The failure timed out waiting for turn completion in the `shell_command` heredoc path instead of failing the overwrite assertion itself.

This suite had already needed Windows-specific shell stabilization in [#14958](https://github.com/openai/codex/pull/14958), but the shared `apply_patch_harness()` path was still building the suite from the default shell-selection flow. That left the heredoc-based `apply_patch` tests sensitive to runner-local shell auto-detection again.

## What changed

- updated `core/tests/suite/apply_patch_cli.rs` so `apply_patch_harness_with(...)` starts from `test_codex().with_windows_cmd_shell()` before applying the suite-specific config
- kept the fix in the shared `apply_patch` harness instead of special-casing another single flaky test
- added a short comment explaining why the Windows override is intentional

## Test plan

- `cargo test -p codex-core --test all 'suite::apply_patch_cli::apply_patch_cli_add_overwrites_existing_file::applypatchmodeloutput_shellcommandviaheredoc_expects' -- --exact --nocapture`
- `cargo test -p codex-core --test all suite::apply_patch_cli -- --nocapture`
- `just argument-comment-lint`

## References

- #14958
