### PR TITLE
ci: keep rust-ci-full Windows argument-comment-lint on packaged wrapper

### DIFF
--- a/.github/workflows/rust-ci-full.yml
+++ b/.github/workflows/rust-ci-full.yml
@@ -99,7 +99,19 @@ jobs:
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt-get update
           sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends pkg-config libcap-dev
+      - name: Install nightly argument-comment-lint toolchain
+        if: ${{ runner.os == 'Windows' }}
+        shell: bash
+        run: |
+          rustup toolchain install nightly-2025-09-18 \
+            --profile minimal \
+            --component llvm-tools-preview \
+            --component rustc-dev \
+            --component rust-src \
+            --no-self-update
+          rustup default nightly-2025-09-18
       - name: Run argument comment lint on codex-rs via Bazel
+        if: ${{ runner.os != 'Windows' }}
         shell: bash
         run: |
           ./.github/scripts/run-bazel-ci.sh \
@@ -110,6 +122,10 @@ jobs:
             --build_metadata=COMMIT_SHA=${GITHUB_SHA} \
             -- \
             //codex-rs/...
+      - name: Run argument comment lint on codex-rs via packaged wrapper
+        if: ${{ runner.os == 'Windows' }}
+        shell: bash
+        run: python3 ./tools/argument-comment-lint/run-prebuilt-linter.py
 
   # --- CI to validate on different os/targets --------------------------------
   lint_build:


### PR DESCRIPTION
## Why

PR #16106 switched `rust-ci-full` over to the native Bazel-backed `argument-comment-lint` path on all three platforms.

That works on Linux and macOS, but the Windows leg in `rust-ci-full` now fails before linting starts: Bazel dies while building `rules_rust`'s `process_wrapper` tool, so `main` reports an `argument-comment-lint` failure even though no Rust lint finding was produced.

Until native Windows Bazel linting is repaired, `rust-ci-full` should keep the same Windows split that `rust-ci.yml` already uses.

## What changed

- restored the Windows-only nightly `argument-comment-lint` toolchain setup in `rust-ci-full`
- limited the Bazel-backed lint step in `rust-ci-full` to non-Windows runners
- routed the Windows runner back through `tools/argument-comment-lint/run-prebuilt-linter.py`
- left the Linux and macOS `rust-ci-full` behavior unchanged

## Test plan

- loaded `.github/workflows/rust-ci-full.yml` and `.github/workflows/rust-ci.yml` with `python3` + `yaml.safe_load(...)`
- inspected failing Actions run `23692864849`, especially job `69023229311`, to confirm the Windows failure occurs in Bazel `process_wrapper` setup before lint output is emitted

## References

- #16106
