### PR TITLE
ci: tune just bazel helpers for remote iteration

### DIFF
--- a/.github/scripts/run-bazel-ci.sh
+++ b/.github/scripts/run-bazel-ci.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 print_failed_bazel_test_logs=0
 use_node_test_env=0
 remote_download_toplevel=0
+use_ci_config=0
+ci_config_override=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -20,6 +22,24 @@ while [[ $# -gt 0 ]]; do
       remote_download_toplevel=1
       shift
       ;;
+    --use-ci-config)
+      use_ci_config=1
+      shift
+      ;;
+    --ci-config=*)
+      use_ci_config=1
+      ci_config_override="${1#*=}"
+      shift
+      ;;
+    --ci-config)
+      if [[ $# -lt 2 ]]; then
+        echo "Expected a value after --ci-config" >&2
+        exit 1
+      fi
+      use_ci_config=1
+      ci_config_override="$2"
+      shift 2
+      ;;
     --)
       shift
       break
@@ -32,7 +52,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ $# -eq 0 ]]; then
-  echo "Usage: $0 [--print-failed-test-logs] [--use-node-test-env] [--remote-download-toplevel] -- <bazel args> -- <targets>" >&2
+  echo "Usage: $0 [--print-failed-test-logs] [--use-node-test-env] [--remote-download-toplevel] [--use-ci-config] [--ci-config=<config>] -- <bazel args> -- <targets>" >&2
   exit 1
 fi
 
@@ -41,8 +61,23 @@ if [[ -n "${BAZEL_OUTPUT_USER_ROOT:-}" ]]; then
   bazel_startup_args+=("--output_user_root=${BAZEL_OUTPUT_USER_ROOT}")
 fi
 
+runner_os="${RUNNER_OS:-}"
+if [[ -z "${runner_os}" ]]; then
+  case "$(uname -s)" in
+    Darwin)
+      runner_os=macOS
+      ;;
+    Linux)
+      runner_os=Linux
+      ;;
+    MINGW*|MSYS*|CYGWIN*)
+      runner_os=Windows
+      ;;
+  esac
+fi
+
 ci_config=ci-linux
-case "${RUNNER_OS:-}" in
+case "${runner_os}" in
   macOS)
     ci_config=ci-macos
     ;;
@@ -50,6 +85,10 @@ case "${RUNNER_OS:-}" in
     ci_config=ci-windows
     ;;
 esac
+
+if [[ -n "${ci_config_override}" ]]; then
+  ci_config="${ci_config_override}"
+fi
 
 print_bazel_test_log_tails() {
   local console_log="$1"
@@ -112,7 +151,7 @@ if [[ ${#bazel_args[@]} -eq 0 || ${#bazel_targets[@]} -eq 0 ]]; then
   exit 1
 fi
 
-if [[ $use_node_test_env -eq 1 && "${RUNNER_OS:-}" != "Windows" ]]; then
+if [[ $use_node_test_env -eq 1 && "${runner_os}" != "Windows" ]]; then
   # Bazel test sandboxes on macOS may resolve an older Homebrew `node`
   # before the `actions/setup-node` runtime on PATH.
   node_bin="$(which node)"
@@ -134,6 +173,11 @@ if (( ${#bazel_startup_args[@]} > 0 )); then
   bazel_cmd+=("${bazel_startup_args[@]}")
 fi
 
+ci_config_args=()
+if [[ -n "${BUILDBUDDY_API_KEY:-}" || $use_ci_config -eq 1 ]]; then
+  ci_config_args+=("--config=${ci_config}")
+fi
+
 if [[ -n "${BUILDBUDDY_API_KEY:-}" ]]; then
   echo "BuildBuddy API key is available; using remote Bazel configuration."
   # Work around Bazel 9 remote repo contents cache / overlay materialization failures
@@ -142,7 +186,7 @@ if [[ -n "${BUILDBUDDY_API_KEY:-}" ]]; then
   # remote execution/cache; this only disables the startup-level repo contents cache.
   bazel_run_args=(
     "${bazel_args[@]}"
-    "--config=${ci_config}"
+    "${ci_config_args[@]}"
     "--remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}"
   )
   if (( ${#post_config_bazel_args[@]} > 0 )); then
@@ -158,28 +202,36 @@ if [[ -n "${BUILDBUDDY_API_KEY:-}" ]]; then
   bazel_status=${PIPESTATUS[0]}
   set -e
 else
-  echo "BuildBuddy API key is not available; using local Bazel configuration."
-  # Keep fork/community PRs on Bazel but disable remote services that are
-  # configured in .bazelrc and require auth.
-  #
-  # Flag docs:
-  # - Command-line reference: https://bazel.build/reference/command-line-reference
-  # - Remote caching overview: https://bazel.build/remote/caching
-  # - Remote execution overview: https://bazel.build/remote/rbe
-  # - Build Event Protocol overview: https://bazel.build/remote/bep
-  #
-  # --noexperimental_remote_repo_contents_cache:
-  #   disable remote repo contents cache enabled in .bazelrc startup options.
-  #   https://bazel.build/reference/command-line-reference#startup_options-flag--experimental_remote_repo_contents_cache
-  # --remote_cache= and --remote_executor=:
-  #   clear remote cache/execution endpoints configured in .bazelrc.
-  #   https://bazel.build/reference/command-line-reference#common_options-flag--remote_cache
-  #   https://bazel.build/reference/command-line-reference#common_options-flag--remote_executor
-  bazel_run_args=(
-    "${bazel_args[@]}"
-    --remote_cache=
-    --remote_executor=
-  )
+  bazel_run_args=("${bazel_args[@]}" "${ci_config_args[@]}")
+
+  if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+    echo "BuildBuddy API key is not available in GitHub Actions; disabling remote Bazel services."
+    # Keep fork/community PRs on Bazel but disable remote services that are
+    # configured in .bazelrc and require auth.
+    #
+    # Flag docs:
+    # - Command-line reference: https://bazel.build/reference/command-line-reference
+    # - Remote caching overview: https://bazel.build/remote/caching
+    # - Remote execution overview: https://bazel.build/remote/rbe
+    # - Build Event Protocol overview: https://bazel.build/remote/bep
+    #
+    # --noexperimental_remote_repo_contents_cache:
+    #   disable remote repo contents cache enabled in .bazelrc startup options.
+    #   https://bazel.build/reference/command-line-reference#startup_options-flag--experimental_remote_repo_contents_cache
+    # --remote_cache= and --remote_executor=:
+    #   clear remote cache/execution endpoints configured in .bazelrc.
+    #   https://bazel.build/reference/command-line-reference#common_options-flag--remote_cache
+    #   https://bazel.build/reference/command-line-reference#common_options-flag--remote_executor
+    bazel_run_args+=(
+      --remote_cache=
+      --remote_executor=
+    )
+  elif [[ $use_ci_config -eq 1 ]]; then
+    echo "BuildBuddy API key env var is not available; using ${ci_config} with remote settings from local Bazel config."
+  else
+    echo "BuildBuddy API key env var is not available; preserving Bazel remote settings from local Bazel config."
+  fi
+
   if (( ${#post_config_bazel_args[@]} > 0 )); then
     bazel_run_args+=("${post_config_bazel_args[@]}")
   fi

--- a/justfile
+++ b/justfile
@@ -67,17 +67,21 @@ bazel-lock-check:
     ./scripts/check-module-bazel-lock.sh
 
 bazel-test:
-    bazel test --test_tag_filters=-argument-comment-lint //... --keep_going
+    bazel test --test_tag_filters=-argument-comment-lint --keep_going -- //... -//third_party/v8:all
 
 bazel-clippy:
     bazel build --config=clippy -- //codex-rs/... -//codex-rs/v8-poc:all
 
 [no-cd]
 bazel-argument-comment-lint:
-    bazel build --config=argument-comment-lint -- //codex-rs/...
+    ./.github/scripts/run-bazel-ci.sh -- build --config=argument-comment-lint --keep_going -- //codex-rs/...
 
+# Fast local iteration helper: prefer the fully remote Linux path, even on
+# macOS, to keep local CPU/RAM use down. For best same-clone reruns, keep
+# BuildBuddy auth plus `build/test --watchfs` in `~/.bazelrc`.
+[no-cd]
 bazel-remote-test:
-    bazel test --test_tag_filters=-argument-comment-lint //... --config=remote --platforms=//:rbe --keep_going
+    ./.github/scripts/run-bazel-ci.sh --print-failed-test-logs --use-node-test-env --ci-config=ci-linux -- test --test_tag_filters=-argument-comment-lint --test_verbose_timeout_warnings -- //... -//third_party/v8:all
 
 build-for-release:
     bazel build //codex-rs/cli:release_binaries --config=remote
@@ -102,7 +106,7 @@ write-hooks-schema:
 [no-cd]
 argument-comment-lint *args:
     if [ "$#" -eq 0 ]; then \
-      bazel build --config=argument-comment-lint -- //codex-rs/...; \
+      ./.github/scripts/run-bazel-ci.sh -- build --config=argument-comment-lint --keep_going -- //codex-rs/...; \
     else \
       ./tools/argument-comment-lint/run-prebuilt-linter.py "$@"; \
     fi


### PR DESCRIPTION
## Why

The `just` Bazel helpers serve two related but slightly different purposes:

- `bazel-test` should stay close to the ordinary Bazel CI target set so local failures are easier to compare with CI
- `bazel-remote-test` should optimize for a very fast local incremental cycle by offloading as much work as possible remotely, even when the developer is on macOS

Before this change, the local helpers diverged in a few ways:

- `bazel-test` and `bazel-remote-test` still pulled in `third_party/v8` even though routine Bazel CI excludes those standalone targets while still testing `codex-rs/v8-poc`
- `bazel-remote-test` hard-coded `--config=remote --platforms=//:rbe`, which was too implicit and had no clear connection to the shared wrapper or CI configs
- the Bazel-backed argument-comment lint helpers in `justfile` bypassed `.github/scripts/run-bazel-ci.sh`, so they missed the shared wrapper behavior used in CI
- even after routing `bazel-remote-test` through the wrapper, local runs still defaulted to the host-specific CI config, which keeps test actions local on macOS and therefore did not maximize remote execution for the command whose whole purpose is fast remote iteration

## What Changed

- add the missing `--` separator before negative target patterns in `bazel-test`
- keep `third_party/v8` excluded from `bazel-test` and `bazel-remote-test`, matching the ordinary `//...` Bazel CI target set while still leaving `codex-rs/v8-poc` in scope
- route `bazel-remote-test`, `bazel-argument-comment-lint`, and the no-arg Bazel path in `argument-comment-lint` through `.github/scripts/run-bazel-ci.sh`
- teach `run-bazel-ci.sh` to infer the host OS when `RUNNER_OS` is unset, preserve local remote settings from Bazel config when `BUILDBUDDY_API_KEY` is not exported, and accept an explicit `--ci-config=<config>` override
- make `bazel-remote-test` pass `--ci-config=ci-linux`, intentionally preferring the Linux remote path for fast local iteration instead of the host-specific `ci-macos` split that keeps tests local
- add a `justfile` comment documenting the intended local workflow: keep BuildBuddy auth plus `build/test --watchfs` in `~/.bazelrc`, then use `just bazel-remote-test` for repeated runs in the same clone
- leave the explicit-argument `argument-comment-lint` path on the packaged wrapper so targeted local invocations still work as before

On Apple Silicon, that remote Linux path still means Linux arm64 rather than x86_64 because the repository's `//:rbe` platform follows the host architecture.

## Recommended Local Use

For developers who want low local CPU and RAM usage plus fast same-clone reruns:

- put BuildBuddy auth in `~/.bazelrc`
- enable `build --watchfs` and `test --watchfs` in `~/.bazelrc`
- use `just bazel-remote-test` for the repeated local iteration loop
- keep using `just bazel-test` when the goal is a more ordinary local `//...` run rather than the aggressively remote Linux path

## Testing

- `bash -n .github/scripts/run-bazel-ci.sh`
- `just --dry-run bazel-test bazel-remote-test bazel-argument-comment-lint argument-comment-lint`
- `BAZEL_OUTPUT_USER_ROOT=/tmp/codex3-bazel-ci-linux-validate-$$ ./.github/scripts/run-bazel-ci.sh --ci-config=ci-linux -- build --nobuild -- //codex-rs/network-proxy:network-proxy-unit-tests`
- `./.github/scripts/run-bazel-ci.sh -- build --config=argument-comment-lint --keep_going --nobuild -- //codex-rs/...`
