### PR TITLE
ci: use BuildBuddy for rust-ci-full non-Windows argument-comment-lint

### DIFF
--- a/.github/workflows/rust-ci-full.yml
+++ b/.github/workflows/rust-ci-full.yml
@@ -112,6 +112,8 @@ jobs:
           rustup default nightly-2025-09-18
       - name: Run argument comment lint on codex-rs via Bazel
         if: ${{ runner.os != 'Windows' }}
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         shell: bash
         run: |
           ./.github/scripts/run-bazel-ci.sh \


### PR DESCRIPTION
## Why

PR #16130 fixed the Windows `argument-comment-lint` regression in `rust-ci-full`, but the next `main` runs still left the Linux and macOS lint legs timing out.

In [run 23695263729](https://github.com/openai/codex/actions/runs/23695263729), both non-Windows `argument-comment-lint` jobs were cancelled almost exactly 30 minutes after they started. The remaining workflow difference versus `rust-ci.yml` was that `rust-ci-full` did not pass `BUILDBUDDY_API_KEY` into the non-Windows Bazel lint step, so `run-bazel-ci.sh` fell back to local Bazel configuration instead of using the faster remote-backed path available on `main`.

## What changed

- passed `BUILDBUDDY_API_KEY` to the non-Windows `rust-ci-full` `argument-comment-lint` Bazel step
- left the Windows packaged-wrapper path from #16130 unchanged
- kept the change scoped to `rust-ci-full.yml`

## Test plan

- loaded `.github/workflows/rust-ci-full.yml` and `.github/workflows/rust-ci.yml` with `python3` + `yaml.safe_load(...)`
- inspected run `23695263729` and confirmed `Argument comment lint - Linux` and `Argument comment lint - macOS` were cancelled about 30 minutes after start
- verified the updated `rust-ci-full` step now matches the non-Windows secret wiring already present in `rust-ci.yml`

## References

- #16130
- #16106
