### PR TITLE
[codex] Normalize Windows path in MCP startup snapshot test

### DIFF
--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -11760,7 +11760,7 @@ async fn app_server_mcp_startup_failure_renders_warning_history() {
 
     assert_snapshot!(
         "app_server_mcp_startup_failure_renders_warning_history",
-        term.backend().vt100().screen().contents()
+        normalize_snapshot_paths(term.backend().vt100().screen().contents())
     );
 }
 


### PR DESCRIPTION
## Summary
A Windows-only snapshot assertion in the app-server MCP startup warning test compared the raw rendered path, so CI saw `C:\tmp\project` instead of the normalized `/tmp/project` snapshot fixture.

## Fix
Route that snapshot assertion through the existing `normalize_snapshot_paths(...)` helper so the test remains platform-stable.