### PR TITLE
fix: fix clippy issue caught by cargo but not bazel

### DIFF
--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -804,6 +804,7 @@ async fn provider_auth_command_refreshes_after_401() {
 ///
 /// The caller owns the server-side assertions, so this helper only validates that the request
 /// reaches `Completed` without surfacing an auth or transport error to the client.
+#[expect(clippy::expect_used, clippy::unwrap_used)]
 async fn send_provider_auth_request(server: &MockServer, auth: ModelProviderAuthInfo) {
     let provider = ModelProviderInfo {
         name: "corp".into(),


### PR DESCRIPTION
I noticed that https://github.com/openai/codex/actions/workflows/rust-ci-full.yml started failing on my own PR, https://github.com/openai/codex/pull/16288, even though CI was green when I merged it.

Apparently, it introduced a lint violation that was [correctly!] caught by our Cargo-based clippy runner, but not our Bazel-based one.

My next step is to figure out the reason for the delta between the two setups, but I wanted to get us green again quickly, first.