### PR TITLE
fix: suppress status card expect_used warnings after #16351

### DIFF
--- a/codex-rs/tui/src/status/card.rs
+++ b/codex-rs/tui/src/status/card.rs
@@ -82,6 +82,7 @@ impl StatusHistoryHandle {
         } else {
             compose_rate_limit_data_many(rate_limits, now)
         };
+        #[expect(clippy::expect_used)]
         let mut state = self
             .rate_limit_state
             .write()
@@ -558,6 +559,7 @@ impl HistoryCell for StatusHistoryCell {
             .collect();
         let mut seen: BTreeSet<String> = labels.iter().cloned().collect();
         let thread_name = self.thread_name.as_deref().filter(|name| !name.is_empty());
+        #[expect(clippy::expect_used)]
         let rate_limit_state = self
             .rate_limit_state
             .read()


### PR DESCRIPTION
## Why

Follow-up to #16351.

That PR synchronized Bazel clippy lint levels with Cargo, but two intentional `expect()` calls in `codex-rs/tui/src/status/card.rs` still tripped `clippy::expect_used` (I believe #16201 raced with #16351, which is why it was missed).
