### PR TITLE
Use message string in v2 send_message

### DIFF
--- a/codex-rs/core/src/tools/handlers/multi_agents_tests.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_tests.rs
@@ -496,7 +496,7 @@ async fn multi_agent_v2_spawn_returns_path_and_send_message_accepts_relative_pat
             "send_message",
             function_payload(json!({
                 "target": "test_process",
-                "items": [{"type": "text", "text": "continue"}]
+                "message": "continue"
             })),
         ))
         .await
@@ -689,7 +689,7 @@ async fn multi_agent_v2_send_message_accepts_root_target_from_child() {
             "send_message",
             function_payload(json!({
                 "target": "/root",
-                "items": [{"type": "text", "text": "done"}]
+                "message": "done"
             })),
         ))
         .await
@@ -952,7 +952,7 @@ async fn multi_agent_v2_list_agents_omits_closed_agents() {
 }
 
 #[tokio::test]
-async fn multi_agent_v2_send_message_rejects_structured_items() {
+async fn multi_agent_v2_send_message_rejects_legacy_items_field() {
     let (mut session, mut turn) = make_session_and_context().await;
     let manager = thread_manager();
     let root = manager
@@ -999,14 +999,12 @@ async fn multi_agent_v2_send_message_rejects_structured_items() {
     );
 
     let Err(err) = SendMessageHandlerV2.handle(invocation).await else {
-        panic!("structured items should be rejected in v2");
+        panic!("legacy items field should be rejected in v2");
     };
-    assert_eq!(
-        err,
-        FunctionCallError::RespondToModel(
-            "send_message only supports text content in MultiAgentV2 for now".to_string()
-        )
-    );
+    let FunctionCallError::RespondToModel(message) = err else {
+        panic!("legacy items field should surface as a model-facing error");
+    };
+    assert!(message.contains("unknown field `items`"));
 }
 
 #[tokio::test]
@@ -1050,7 +1048,7 @@ async fn multi_agent_v2_send_message_rejects_interrupt_parameter() {
         "send_message",
         function_payload(json!({
             "target": agent_id.to_string(),
-            "items": [{"type": "text", "text": "continue"}],
+            "message": "continue",
             "interrupt": true
         })),
     );
@@ -1062,7 +1060,7 @@ async fn multi_agent_v2_send_message_rejects_interrupt_parameter() {
         panic!("expected model-facing parse error");
     };
     assert!(message.starts_with(
-        "failed to parse function arguments: unknown field `interrupt`, expected `target` or `items`"
+        "failed to parse function arguments: unknown field `interrupt`, expected `target` or `message`"
     ));
 
     let ops = manager.captured_ops();

--- a/codex-rs/core/src/tools/handlers/multi_agents_tests.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_tests.rs
@@ -347,7 +347,7 @@ async fn multi_agent_v2_spawn_requires_task_name() {
         Arc::new(turn),
         "spawn_agent",
         function_payload(json!({
-            "items": [{"type": "text", "text": "inspect this repo"}]
+            "message": "inspect this repo"
         })),
     );
     let Err(err) = SpawnAgentHandlerV2.handle(invocation).await else {
@@ -360,7 +360,7 @@ async fn multi_agent_v2_spawn_requires_task_name() {
 }
 
 #[tokio::test]
-async fn multi_agent_v2_spawn_rejects_legacy_message_field() {
+async fn multi_agent_v2_spawn_rejects_legacy_items_field() {
     let (mut session, mut turn) = make_session_and_context().await;
     let manager = thread_manager();
     let root = manager
@@ -387,12 +387,12 @@ async fn multi_agent_v2_spawn_rejects_legacy_message_field() {
         })),
     );
     let Err(err) = SpawnAgentHandlerV2.handle(invocation).await else {
-        panic!("legacy message field should be rejected");
+        panic!("legacy items field should be rejected");
     };
     let FunctionCallError::RespondToModel(message) = err else {
-        panic!("legacy message field should surface as a model-facing error");
+        panic!("legacy items field should surface as a model-facing error");
     };
-    assert!(message.contains("unknown field `message`"));
+    assert!(message.contains("unknown field `items`"));
 }
 
 #[tokio::test]
@@ -444,7 +444,7 @@ async fn multi_agent_v2_spawn_returns_path_and_send_message_accepts_relative_pat
             turn.clone(),
             "spawn_agent",
             function_payload(json!({
-                "items": [{"type": "text", "text": "inspect this repo"}],
+                "message": "inspect this repo",
                 "task_name": "test_process"
             })),
         ))
@@ -539,7 +539,7 @@ async fn multi_agent_v2_spawn_rejects_legacy_fork_context() {
             Arc::new(turn),
             "spawn_agent",
             function_payload(json!({
-                "items": [{"type": "text", "text": "inspect this repo"}],
+                "message": "inspect this repo",
                 "task_name": "worker",
                 "fork_context": true
             })),
@@ -578,7 +578,7 @@ async fn multi_agent_v2_spawn_rejects_invalid_fork_turns_string() {
             Arc::new(turn),
             "spawn_agent",
             function_payload(json!({
-                "items": [{"type": "text", "text": "inspect this repo"}],
+                "message": "inspect this repo",
                 "task_name": "worker",
                 "fork_turns": "banana"
             })),
@@ -617,7 +617,7 @@ async fn multi_agent_v2_spawn_rejects_zero_fork_turns() {
             Arc::new(turn),
             "spawn_agent",
             function_payload(json!({
-                "items": [{"type": "text", "text": "inspect this repo"}],
+                "message": "inspect this repo",
                 "task_name": "worker",
                 "fork_turns": "0"
             })),
@@ -731,7 +731,7 @@ async fn multi_agent_v2_list_agents_returns_completed_status_and_last_task_messa
             turn.clone(),
             "spawn_agent",
             function_payload(json!({
-                "items": [{"type": "text", "text": "inspect this repo"}],
+                "message": "inspect this repo",
                 "task_name": "worker"
             })),
         ))
@@ -909,7 +909,7 @@ async fn multi_agent_v2_list_agents_omits_closed_agents() {
             turn.clone(),
             "spawn_agent",
             function_payload(json!({
-                "items": [{"type": "text", "text": "inspect this repo"}],
+                "message": "inspect this repo",
                 "task_name": "worker"
             })),
         ))
@@ -973,7 +973,7 @@ async fn multi_agent_v2_send_message_rejects_structured_items() {
             turn.clone(),
             "spawn_agent",
             function_payload(json!({
-                "items": [{"type": "text", "text": "boot worker"}],
+                "message": "boot worker",
                 "task_name": "worker"
             })),
         ))
@@ -1031,7 +1031,7 @@ async fn multi_agent_v2_send_message_rejects_interrupt_parameter() {
             turn.clone(),
             "spawn_agent",
             function_payload(json!({
-                "items": [{"type": "text", "text": "boot worker"}],
+                "message": "boot worker",
                 "task_name": "worker"
             })),
         ))
@@ -1104,7 +1104,7 @@ async fn multi_agent_v2_assign_task_interrupts_busy_child_without_losing_message
             turn.clone(),
             "spawn_agent",
             function_payload(json!({
-                "items": [{"type": "text", "text": "boot worker"}],
+                "message": "boot worker",
                 "task_name": "worker"
             })),
         ))
@@ -1233,7 +1233,7 @@ async fn multi_agent_v2_assign_task_completion_notifies_parent_on_every_turn() {
             turn.clone(),
             "spawn_agent",
             function_payload(json!({
-                "items": [{"type": "text", "text": "boot worker"}],
+                "message": "boot worker",
                 "task_name": "worker"
             })),
         ))
@@ -1438,7 +1438,7 @@ async fn multi_agent_v2_spawn_includes_agent_id_key_when_named() {
             Arc::new(turn),
             "spawn_agent",
             function_payload(json!({
-                "items": [{"type": "text", "text": "inspect this repo"}],
+                "message": "inspect this repo",
                 "task_name": "test_process"
             })),
         ))
@@ -1476,7 +1476,7 @@ async fn multi_agent_v2_spawn_surfaces_task_name_validation_errors() {
         Arc::new(turn),
         "spawn_agent",
         function_payload(json!({
-            "items": [{"type": "text", "text": "inspect this repo"}],
+            "message": "inspect this repo",
             "task_name": "BadName"
         })),
     );
@@ -2103,7 +2103,7 @@ async fn multi_agent_v2_wait_agent_accepts_timeout_only_argument() {
             turn.clone(),
             "spawn_agent",
             function_payload(json!({
-                "items": [{"type": "text", "text": "boot worker"}],
+                "message": "boot worker",
                 "task_name": "worker"
             })),
         ))
@@ -2349,7 +2349,7 @@ async fn multi_agent_v2_wait_agent_returns_summary_for_mailbox_activity() {
             turn.clone(),
             "spawn_agent",
             function_payload(json!({
-                "items": [{"type": "text", "text": "inspect this repo"}],
+                "message": "inspect this repo",
                 "task_name": "test_process"
             })),
         ))
@@ -2440,7 +2440,7 @@ async fn multi_agent_v2_wait_agent_waits_for_new_mail_after_start() {
             turn.clone(),
             "spawn_agent",
             function_payload(json!({
-                "items": [{"type": "text", "text": "boot worker"}],
+                "message": "boot worker",
                 "task_name": "worker"
             })),
         ))
@@ -2540,7 +2540,7 @@ async fn multi_agent_v2_wait_agent_wakes_on_any_mailbox_notification() {
                 turn.clone(),
                 "spawn_agent",
                 function_payload(json!({
-                    "items": [{"type": "text", "text": format!("boot {task_name}")}],
+                    "message": format!("boot {task_name}"),
                     "task_name": task_name
                 })),
             ))
@@ -2627,7 +2627,7 @@ async fn multi_agent_v2_wait_agent_does_not_return_completed_content() {
             turn.clone(),
             "spawn_agent",
             function_payload(json!({
-                "items": [{"type": "text", "text": "boot worker"}],
+                "message": "boot worker",
                 "task_name": "worker"
             })),
         ))
@@ -2713,7 +2713,7 @@ async fn multi_agent_v2_close_agent_accepts_task_name_target() {
             turn.clone(),
             "spawn_agent",
             function_payload(json!({
-                "items": [{"type": "text", "text": "inspect this repo"}],
+                "message": "inspect this repo",
                 "task_name": "worker"
             })),
         ))

--- a/codex-rs/core/src/tools/handlers/multi_agents_v2/message_tool.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_v2/message_tool.rs
@@ -1,7 +1,7 @@
 //! Shared argument parsing and dispatch for the v2 text-only agent messaging tools.
 //!
-//! `send_message` and `assign_task` intentionally expose the same input shape and differ only in
-//! whether the resulting `InterAgentCommunication` should wake the target immediately.
+//! `send_message` and `assign_task` share the same submission path and differ only in whether the
+//! resulting `InterAgentCommunication` should wake the target immediately.
 
 use super::*;
 use crate::agent::control::render_input_preview;
@@ -42,7 +42,7 @@ impl MessageDeliveryMode {
 /// Input for the MultiAgentV2 `send_message` tool.
 pub(crate) struct SendMessageArgs {
     pub(crate) target: String,
-    pub(crate) items: Vec<UserInput>,
+    pub(crate) message: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -79,6 +79,15 @@ impl ToolOutput for MessageToolResult {
     }
 }
 
+fn message_content(message: String) -> Result<String, FunctionCallError> {
+    if message.trim().is_empty() {
+        return Err(FunctionCallError::RespondToModel(
+            "Empty message can't be sent to an agent".to_string(),
+        ));
+    }
+    Ok(message)
+}
+
 /// Validates that the tool input is non-empty text-only content and returns its preview string.
 fn text_content(
     items: &[UserInput],
@@ -101,11 +110,46 @@ fn text_content(
 }
 
 /// Handles the shared MultiAgentV2 text-message flow for both `send_message` and `assign_task`.
+pub(crate) async fn handle_message_string_tool(
+    invocation: ToolInvocation,
+    mode: MessageDeliveryMode,
+    target: String,
+    message: String,
+    interrupt: bool,
+) -> Result<MessageToolResult, FunctionCallError> {
+    handle_message_submission(
+        invocation,
+        mode,
+        target,
+        message_content(message)?,
+        interrupt,
+    )
+    .await
+}
+
+/// Handles the shared MultiAgentV2 text-message flow for both `send_message` and `assign_task`.
 pub(crate) async fn handle_message_tool(
     invocation: ToolInvocation,
     mode: MessageDeliveryMode,
     target: String,
     items: Vec<UserInput>,
+    interrupt: bool,
+) -> Result<MessageToolResult, FunctionCallError> {
+    handle_message_submission(
+        invocation,
+        mode,
+        target,
+        text_content(&items, mode)?,
+        interrupt,
+    )
+    .await
+}
+
+async fn handle_message_submission(
+    invocation: ToolInvocation,
+    mode: MessageDeliveryMode,
+    target: String,
+    prompt: String,
     interrupt: bool,
 ) -> Result<MessageToolResult, FunctionCallError> {
     let ToolInvocation {
@@ -117,7 +161,6 @@ pub(crate) async fn handle_message_tool(
     } = invocation;
     let _ = payload;
     let receiver_thread_id = resolve_agent_target(&session, &turn, &target).await?;
-    let prompt = text_content(&items, mode)?;
     let receiver_agent = session
         .services
         .agent_control

--- a/codex-rs/core/src/tools/handlers/multi_agents_v2/send_message.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_v2/send_message.rs
@@ -1,7 +1,7 @@
 use super::message_tool::MessageDeliveryMode;
 use super::message_tool::MessageToolResult;
 use super::message_tool::SendMessageArgs;
-use super::message_tool::handle_message_tool;
+use super::message_tool::handle_message_string_tool;
 use super::*;
 
 pub(crate) struct Handler;
@@ -21,11 +21,11 @@ impl ToolHandler for Handler {
     async fn handle(&self, invocation: ToolInvocation) -> Result<Self::Output, FunctionCallError> {
         let arguments = function_arguments(invocation.payload.clone())?;
         let args: SendMessageArgs = parse_arguments(&arguments)?;
-        handle_message_tool(
+        handle_message_string_tool(
             invocation,
             MessageDeliveryMode::QueueOnly,
             args.target,
-            args.items,
+            args.message,
             /*interrupt*/ false,
         )
         .await

--- a/codex-rs/core/src/tools/handlers/multi_agents_v2/spawn.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_v2/spawn.rs
@@ -40,7 +40,7 @@ impl ToolHandler for Handler {
             .map(str::trim)
             .filter(|role| !role.is_empty());
 
-        let initial_operation = parse_collab_input(/*message*/ None, Some(args.items))?;
+        let initial_operation = parse_collab_input(Some(args.message), /*items*/ None)?;
         let prompt = render_input_preview(&initial_operation);
 
         let session_source = turn.session_source.clone();
@@ -202,7 +202,7 @@ impl ToolHandler for Handler {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct SpawnAgentArgs {
-    items: Vec<UserInput>,
+    message: String,
     task_name: String,
     agent_type: Option<String>,
     model: Option<String>,

--- a/codex-rs/core/src/tools/spec_tests.rs
+++ b/codex-rs/core/src/tools/spec_tests.rs
@@ -527,10 +527,11 @@ fn test_build_specs_multi_agent_v2_uses_task_names_and_hides_resume() {
     };
     assert!(properties.contains_key("target"));
     assert!(!properties.contains_key("interrupt"));
-    assert!(!properties.contains_key("message"));
+    assert!(properties.contains_key("message"));
+    assert!(!properties.contains_key("items"));
     assert_eq!(
         required.as_ref(),
-        Some(&vec!["target".to_string(), "items".to_string()])
+        Some(&vec!["target".to_string(), "message".to_string()])
     );
 
     let assign_task = find_tool(&tools, "assign_task");

--- a/codex-rs/core/src/tools/spec_tests.rs
+++ b/codex-rs/core/src/tools/spec_tests.rs
@@ -497,13 +497,13 @@ fn test_build_specs_multi_agent_v2_uses_task_names_and_hides_resume() {
         panic!("spawn_agent should use object params");
     };
     assert!(properties.contains_key("task_name"));
-    assert!(properties.contains_key("items"));
+    assert!(properties.contains_key("message"));
     assert!(properties.contains_key("fork_turns"));
-    assert!(!properties.contains_key("message"));
+    assert!(!properties.contains_key("items"));
     assert!(!properties.contains_key("fork_context"));
     assert_eq!(
         required.as_ref(),
-        Some(&vec!["task_name".to_string(), "items".to_string()])
+        Some(&vec!["task_name".to_string(), "message".to_string()])
     );
     let output_schema = output_schema
         .as_ref()

--- a/codex-rs/tools/src/agent_tool.rs
+++ b/codex-rs/tools/src/agent_tool.rs
@@ -127,7 +127,12 @@ pub fn create_send_message_tool() -> ToolSpec {
                 ),
             },
         ),
-        ("items".to_string(), create_collab_input_items_schema()),
+        (
+            "message".to_string(),
+            JsonSchema::String {
+                description: Some("Message text to queue on the target agent.".to_string()),
+            },
+        ),
     ]);
 
     ToolSpec::Function(ResponsesApiTool {
@@ -138,7 +143,7 @@ pub fn create_send_message_tool() -> ToolSpec {
         defer_loading: None,
         parameters: JsonSchema::Object {
             properties,
-            required: Some(vec!["target".to_string(), "items".to_string()]),
+            required: Some(vec!["target".to_string(), "message".to_string()]),
             additional_properties: Some(false.into()),
         },
         output_schema: Some(send_input_output_schema()),

--- a/codex-rs/tools/src/agent_tool.rs
+++ b/codex-rs/tools/src/agent_tool.rs
@@ -66,7 +66,7 @@ pub fn create_spawn_agent_tool_v2(options: SpawnAgentToolOptions<'_>) -> ToolSpe
         defer_loading: None,
         parameters: JsonSchema::Object {
             properties,
-            required: Some(vec!["task_name".to_string(), "items".to_string()]),
+            required: Some(vec!["task_name".to_string(), "message".to_string()]),
             additional_properties: Some(false.into()),
         },
         output_schema: Some(spawn_agent_output_schema_v2()),
@@ -585,7 +585,12 @@ fn spawn_agent_common_properties_v1(agent_type_description: &str) -> BTreeMap<St
 
 fn spawn_agent_common_properties_v2(agent_type_description: &str) -> BTreeMap<String, JsonSchema> {
     BTreeMap::from([
-        ("items".to_string(), create_collab_input_items_schema()),
+        (
+            "message".to_string(),
+            JsonSchema::String {
+                description: Some("Initial plain-text task for the new agent.".to_string()),
+            },
+        ),
         (
             "agent_type".to_string(),
             JsonSchema::String {

--- a/codex-rs/tools/src/agent_tool_tests.rs
+++ b/codex-rs/tools/src/agent_tool_tests.rs
@@ -56,9 +56,9 @@ fn spawn_agent_tool_v2_requires_task_name_and_lists_visible_models() {
     assert!(description.contains("visible display (`visible-model`)"));
     assert!(!description.contains("hidden display (`hidden-model`)"));
     assert!(properties.contains_key("task_name"));
-    assert!(properties.contains_key("items"));
+    assert!(properties.contains_key("message"));
     assert!(properties.contains_key("fork_turns"));
-    assert!(!properties.contains_key("message"));
+    assert!(!properties.contains_key("items"));
     assert!(!properties.contains_key("fork_context"));
     assert_eq!(
         properties.get("agent_type"),
@@ -68,7 +68,7 @@ fn spawn_agent_tool_v2_requires_task_name_and_lists_visible_models() {
     );
     assert_eq!(
         required,
-        Some(vec!["task_name".to_string(), "items".to_string()])
+        Some(vec!["task_name".to_string(), "message".to_string()])
     );
     assert_eq!(
         output_schema.expect("spawn_agent output schema")["required"],

--- a/codex-rs/tools/src/agent_tool_tests.rs
+++ b/codex-rs/tools/src/agent_tool_tests.rs
@@ -95,7 +95,7 @@ fn spawn_agent_tool_v1_keeps_legacy_fork_context_field() {
 }
 
 #[test]
-fn send_message_tool_requires_items_and_uses_submission_output() {
+fn send_message_tool_requires_message_and_uses_submission_output() {
     let ToolSpec::Function(ResponsesApiTool {
         parameters,
         output_schema,
@@ -113,12 +113,12 @@ fn send_message_tool_requires_items_and_uses_submission_output() {
         panic!("send_message should use object params");
     };
     assert!(properties.contains_key("target"));
-    assert!(properties.contains_key("items"));
+    assert!(properties.contains_key("message"));
     assert!(!properties.contains_key("interrupt"));
-    assert!(!properties.contains_key("message"));
+    assert!(!properties.contains_key("items"));
     assert_eq!(
         required,
-        Some(vec!["target".to_string(), "items".to_string()])
+        Some(vec!["target".to_string(), "message".to_string()])
     );
     assert_eq!(
         output_schema.expect("send_message output schema")["required"],


### PR DESCRIPTION
## Summary
- switch MultiAgentV2 send_message to accept a single message string instead of items
- keep the old assign_task item parser in place for the next branch
- update send_message schema/spec and focused handler tests

## Verification
- cargo test -p codex-tools send_message_tool_requires_message_and_uses_submission_output
- cargo test -p codex-core multi_agent_v2_send_message
- just fix -p codex-tools
- just fix -p codex-core
- just argument-comment-lint