### PR TITLE
fix(core) rm execute_exec_request sandbox_policy

### DIFF
--- a/codex-rs/core/src/exec.rs
+++ b/codex-rs/core/src/exec.rs
@@ -314,7 +314,6 @@ pub fn build_exec_request(
 
 pub(crate) async fn execute_exec_request(
     exec_request: ExecRequest,
-    sandbox_policy: &SandboxPolicy,
     stdout_stream: Option<StdoutStream>,
     after_spawn: Option<Box<dyn FnOnce() + Send>>,
 ) -> Result<ExecToolCallOutput> {
@@ -328,13 +327,12 @@ pub(crate) async fn execute_exec_request(
         sandbox,
         windows_sandbox_level,
         windows_sandbox_private_desktop,
-        sandbox_policy: _sandbox_policy_from_env,
+        sandbox_policy,
         file_system_sandbox_policy,
         network_sandbox_policy,
         windows_restricted_token_filesystem_overlay,
         arg0,
     } = exec_request;
-    let _ = _sandbox_policy_from_env;
 
     let params = ExecParams {
         command,
@@ -354,7 +352,7 @@ pub(crate) async fn execute_exec_request(
     let raw_output_result = exec(
         params,
         sandbox,
-        sandbox_policy,
+        &sandbox_policy,
         &file_system_sandbox_policy,
         windows_restricted_token_filesystem_overlay.as_ref(),
         network_sandbox_policy,

--- a/codex-rs/core/src/sandboxing/mod.rs
+++ b/codex-rs/core/src/sandboxing/mod.rs
@@ -141,14 +141,7 @@ pub async fn execute_env(
     exec_request: ExecRequest,
     stdout_stream: Option<StdoutStream>,
 ) -> crate::error::Result<ExecToolCallOutput> {
-    let effective_policy = exec_request.sandbox_policy.clone();
-    execute_exec_request(
-        exec_request,
-        &effective_policy,
-        stdout_stream,
-        /*after_spawn*/ None,
-    )
-    .await
+    execute_exec_request(exec_request, stdout_stream, /*after_spawn*/ None).await
 }
 
 pub async fn execute_exec_request_with_after_spawn(
@@ -156,6 +149,5 @@ pub async fn execute_exec_request_with_after_spawn(
     stdout_stream: Option<StdoutStream>,
     after_spawn: Option<Box<dyn FnOnce() + Send>>,
 ) -> crate::error::Result<ExecToolCallOutput> {
-    let effective_policy = exec_request.sandbox_policy.clone();
-    execute_exec_request(exec_request, &effective_policy, stdout_stream, after_spawn).await
+    execute_exec_request(exec_request, stdout_stream, after_spawn).await
 }

--- a/codex-rs/core/src/tasks/user_shell.rs
+++ b/codex-rs/core/src/tasks/user_shell.rs
@@ -185,14 +185,9 @@ pub(crate) async fn execute_user_shell_command(
         tx_event: session.get_tx_event(),
     });
 
-    let exec_result = execute_exec_request(
-        exec_env,
-        &sandbox_policy,
-        stdout_stream,
-        /*after_spawn*/ None,
-    )
-    .or_cancel(&cancellation_token)
-    .await;
+    let exec_result = execute_exec_request(exec_env, stdout_stream, /*after_spawn*/ None)
+        .or_cancel(&cancellation_token)
+        .await;
 
     match exec_result {
         Err(CancelErr::Cancelled) => {


### PR DESCRIPTION
## Summary
In #11871 we started consolidating on ExecRequest.sandbox_policy instead of passing in a separate policy object that theoretically could differ (but did not). This finishes the some parameter cleanup.

This should be a simple noop, since all 3 callsites of this function already used a cloned object from the ExecRequest value.

## Testing
- [x] Existing tests pass