### PR TITLE
chore: drop log DB

### DIFF
--- a/codex-rs/state/migrations/0023_drop_logs.sql
+++ b/codex-rs/state/migrations/0023_drop_logs.sql
@@ -1,0 +1,3 @@
+PRAGMA auto_vacuum = INCREMENTAL;
+
+DROP TABLE IF EXISTS logs;

--- a/codex-rs/state/src/runtime/logs.rs
+++ b/codex-rs/state/src/runtime/logs.rs
@@ -590,10 +590,8 @@ mod tests {
             .await
             .expect("insert test logs");
 
-        let state_count = log_row_count(state_db_path(codex_home.as_path()).as_path()).await;
         let logs_count = log_row_count(logs_db_path(codex_home.as_path()).as_path()).await;
 
-        assert_eq!(state_count, 0);
         assert_eq!(logs_count, 1);
 
         let _ = tokio::fs::remove_dir_all(codex_home).await;


### PR DESCRIPTION
Drop the log table from the state DB