### PR TITLE
fix: remove unused import

### DIFF
--- a/codex-rs/state/src/runtime/logs.rs
+++ b/codex-rs/state/src/runtime/logs.rs
@@ -537,7 +537,6 @@ mod tests {
     use crate::LogQuery;
     use crate::logs_db_path;
     use crate::migrations::LOGS_MIGRATOR;
-    use crate::state_db_path;
     use chrono::Utc;
     use pretty_assertions::assert_eq;
     use sqlx::SqlitePool;


### PR DESCRIPTION
https://github.com/openai/codex/pull/16433 resulted in an unused import inside `mod tests`. This is flagged by `cargo clippy --tests`, which is run as part of https://github.com/openai/codex/actions/workflows/rust-ci-full.yml, but is not caught by our current Bazel setup for clippy.

Fixing this ASAP to get https://github.com/openai/codex/actions/workflows/rust-ci-full.yml green again, but am looking at fixing the Bazel workflow in parallel.