### PR TITLE
bazel: lint rust_test targets in clippy workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -5,14 +5,14 @@ The workflows in this directory are split so that pull requests get fast, review
 ## Pull Requests
 
 - `bazel.yml` is the main pre-merge verification path for Rust code.
-  It runs Bazel `test` and Bazel `clippy` on the supported Bazel targets.
+  It runs Bazel `test` and Bazel `clippy` on the supported Bazel targets,
+  including the generated Rust test binaries needed to lint inline `#[cfg(test)]`
+  code.
 - `rust-ci.yml` keeps the Cargo-native PR checks intentionally small:
   - `cargo fmt --check`
   - `cargo shear`
   - `argument-comment-lint` on Linux, macOS, and Windows
   - `tools/argument-comment-lint` package tests when the lint or its workflow wiring changes
-
-The PR workflow still keeps the Linux lint lane on the default-targets-only invocation for now, but the released linter runs on Linux, macOS, and Windows before merge.
 
 ## Post-Merge On `main`
 

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -154,13 +154,17 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/bazel-execution-logs"
           echo "CODEX_BAZEL_EXECUTION_LOG_COMPACT_DIR=${RUNNER_TEMP}/bazel-execution-logs" >> "${GITHUB_ENV}"
 
-      - name: bazel build --config=clippy //codex-rs/...
+      - name: bazel build --config=clippy lint targets
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         shell: bash
         run: |
-          # Keep the initial Bazel clippy scope on codex-rs and out of the
-          # V8 proof-of-concept target for now.
+          bazel_target_lines="$(./scripts/list-bazel-clippy-targets.sh)"
+          bazel_targets=()
+          while IFS= read -r target; do
+            bazel_targets+=("${target}")
+          done <<< "${bazel_target_lines}"
+
           ./.github/scripts/run-bazel-ci.sh \
             -- \
             build \
@@ -168,8 +172,7 @@ jobs:
             --build_metadata=COMMIT_SHA=${GITHUB_SHA} \
             --build_metadata=TAG_job=clippy \
             -- \
-            //codex-rs/... \
-            -//codex-rs/v8-poc:all
+            "${bazel_targets[@]}"
 
       - name: Upload Bazel execution logs
         if: always() && !cancelled()

--- a/justfile
+++ b/justfile
@@ -69,8 +69,9 @@ bazel-lock-check:
 bazel-test:
     bazel test --test_tag_filters=-argument-comment-lint //... --keep_going
 
+[no-cd]
 bazel-clippy:
-    bazel build --config=clippy -- //codex-rs/... -//codex-rs/v8-poc:all
+    bazel_targets="$(./scripts/list-bazel-clippy-targets.sh)" && bazel build --config=clippy -- ${bazel_targets}
 
 [no-cd]
 bazel-argument-comment-lint:

--- a/scripts/list-bazel-clippy-targets.sh
+++ b/scripts/list-bazel-clippy-targets.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${repo_root}"
+
+# Resolve the dynamic targets before printing anything so callers do not
+# continue with a partial list if `bazel query` fails.
+manual_rust_test_targets="$(bazel query 'kind("rust_test rule", attr(tags, "manual", //codex-rs/... except //codex-rs/v8-poc/...))')"
+
+printf '%s\n' \
+  "//codex-rs/..." \
+  "-//codex-rs/v8-poc:all"
+
+# `--config=clippy` on the `workspace_root_test` wrappers does not lint the
+# underlying `rust_test` binaries. Add the internal manual `*-unit-tests-bin`
+# targets explicitly so inline `#[cfg(test)]` code is linted like
+# `cargo clippy --tests`.
+printf '%s\n' "${manual_rust_test_targets}"


### PR DESCRIPTION
## Why

`cargo clippy --tests` was catching warnings in inline `#[cfg(test)]` code that the Bazel PR Clippy lane missed. The existing Bazel invocation linted `//codex-rs/...`, but that did not apply Clippy to the generated manual `rust_test` binaries, so warnings in targets such as `//codex-rs/state:state-unit-tests-bin` only surfaced as plain compile warnings instead of failing the lint job.

## What Changed

- added `scripts/list-bazel-clippy-targets.sh` to expand the Bazel Clippy target set with the generated manual `rust_test` rules while still excluding `//codex-rs/v8-poc:all`
- updated `.github/workflows/bazel.yml` to use that expanded target list in the Bazel Clippy PR job
- updated `just bazel-clippy` to use the same target expansion locally
- updated `.github/workflows/README.md` to document that the Bazel PR lint lane now covers inline `#[cfg(test)]` code

## Verification

- `./scripts/list-bazel-clippy-targets.sh` includes `//codex-rs/state:state-unit-tests-bin`
- `bazel build --config=clippy -- //codex-rs/state:state-unit-tests-bin` now fails with the same unused import in `state/src/runtime/logs.rs` that `cargo clippy --tests` reports
