### PR TITLE
tui: remove debug/test-only crate features

### DIFF
--- a/.github/scripts/verify_cargo_workspace_manifests.py
+++ b/.github/scripts/verify_cargo_workspace_manifests.py
@@ -32,8 +32,6 @@ MANIFEST_FEATURE_EXCEPTIONS = {
     },
     "codex-rs/tui/Cargo.toml": {
         "default": ("voice-input",),
-        "vt100-tests": (),
-        "debug-logs": (),
         "voice-input": ("dep:cpal",),
     },
 }

--- a/codex-rs/tui/Cargo.toml
+++ b/codex-rs/tui/Cargo.toml
@@ -19,10 +19,6 @@ path = "src/lib.rs"
 
 [features]
 default = ["voice-input"]
-# Enable vt100-based tests (emulator) when running with `--features vt100-tests`.
-vt100-tests = []
-# Gate verbose debug logging inside the TUI implementation.
-debug-logs = []
 voice-input = ["dep:cpal"]
 
 [lints]

--- a/codex-rs/tui/src/bottom_pane/textarea.rs
+++ b/codex-rs/tui/src/bottom_pane/textarea.rs
@@ -529,10 +529,7 @@ impl TextArea {
             } => {
                 self.move_cursor_to_end_of_line(/*move_down_at_eol*/ true);
             }
-            _o => {
-                #[cfg(feature = "debug-logs")]
-                tracing::debug!("Unhandled key event in TextArea: {:?}", _o);
-            }
+            _ => {}
         }
     }
 

--- a/codex-rs/tui/tests/all.rs
+++ b/codex-rs/tui/tests/all.rs
@@ -1,6 +1,5 @@
 // Single integration test binary that aggregates all test modules.
 // The submodules live in `tests/suite/`.
-#[cfg(feature = "vt100-tests")]
 mod test_backend;
 
 #[allow(unused_imports)]

--- a/codex-rs/tui/tests/suite/vt100_history.rs
+++ b/codex-rs/tui/tests/suite/vt100_history.rs
@@ -1,4 +1,3 @@
-#![cfg(feature = "vt100-tests")]
 #![expect(clippy::expect_used)]
 
 use crate::test_backend::VT100Backend;
@@ -44,8 +43,10 @@ impl TestScenario {
 #[test]
 fn basic_insertion_no_wrap() {
     // Screen of 20x6; viewport is the last row (height=1 at y=5)
-    let area = Rect::new(0, 5, 20, 1);
-    let mut scenario = TestScenario::new(20, 6, area);
+    let area = Rect::new(
+        /*x*/ 0, /*y*/ 5, /*width*/ 20, /*height*/ 1,
+    );
+    let mut scenario = TestScenario::new(/*width*/ 20, /*height*/ 6, area);
 
     let lines = vec!["first".into(), "second".into()];
     scenario.run_insert(lines);
@@ -56,8 +57,10 @@ fn basic_insertion_no_wrap() {
 
 #[test]
 fn long_token_wraps() {
-    let area = Rect::new(0, 5, 20, 1);
-    let mut scenario = TestScenario::new(20, 6, area);
+    let area = Rect::new(
+        /*x*/ 0, /*y*/ 5, /*width*/ 20, /*height*/ 1,
+    );
+    let mut scenario = TestScenario::new(/*width*/ 20, /*height*/ 6, area);
 
     let long = "A".repeat(45); // > 2 lines at width 20
     let lines = vec![long.clone().into()];
@@ -86,8 +89,10 @@ fn long_token_wraps() {
 
 #[test]
 fn emoji_and_cjk() {
-    let area = Rect::new(0, 5, 20, 1);
-    let mut scenario = TestScenario::new(20, 6, area);
+    let area = Rect::new(
+        /*x*/ 0, /*y*/ 5, /*width*/ 20, /*height*/ 1,
+    );
+    let mut scenario = TestScenario::new(/*width*/ 20, /*height*/ 6, area);
 
     let text = String::from("😀😀😀😀😀 你好世界");
     let lines = vec![text.clone().into()];
@@ -103,8 +108,10 @@ fn emoji_and_cjk() {
 
 #[test]
 fn mixed_ansi_spans() {
-    let area = Rect::new(0, 5, 20, 1);
-    let mut scenario = TestScenario::new(20, 6, area);
+    let area = Rect::new(
+        /*x*/ 0, /*y*/ 5, /*width*/ 20, /*height*/ 1,
+    );
+    let mut scenario = TestScenario::new(/*width*/ 20, /*height*/ 6, area);
 
     let line = vec!["red".red(), "+plain".into()].into();
     scenario.run_insert(vec![line]);
@@ -114,8 +121,10 @@ fn mixed_ansi_spans() {
 
 #[test]
 fn cursor_restoration() {
-    let area = Rect::new(0, 5, 20, 1);
-    let mut scenario = TestScenario::new(20, 6, area);
+    let area = Rect::new(
+        /*x*/ 0, /*y*/ 5, /*width*/ 20, /*height*/ 1,
+    );
+    let mut scenario = TestScenario::new(/*width*/ 20, /*height*/ 6, area);
 
     let lines = vec!["x".into()];
     scenario.run_insert(lines);
@@ -125,8 +134,10 @@ fn cursor_restoration() {
 #[test]
 fn word_wrap_no_mid_word_split() {
     // Screen of 40x10; viewport is the last row
-    let area = Rect::new(0, 9, 40, 1);
-    let mut scenario = TestScenario::new(40, 10, area);
+    let area = Rect::new(
+        /*x*/ 0, /*y*/ 9, /*width*/ 40, /*height*/ 1,
+    );
+    let mut scenario = TestScenario::new(/*width*/ 40, /*height*/ 10, area);
 
     let sample = "Years passed, and Willowmere thrived in peace and friendship. Mira’s herb garden flourished with both ordinary and enchanted plants, and travelers spoke of the kindness of the woman who tended them.";
     scenario.run_insert(vec![sample.into()]);
@@ -140,8 +151,10 @@ fn word_wrap_no_mid_word_split() {
 #[test]
 fn em_dash_and_space_word_wrap() {
     // Repro from report: ensure we break before "inside", not mid-word.
-    let area = Rect::new(0, 9, 40, 1);
-    let mut scenario = TestScenario::new(40, 10, area);
+    let area = Rect::new(
+        /*x*/ 0, /*y*/ 9, /*width*/ 40, /*height*/ 1,
+    );
+    let mut scenario = TestScenario::new(/*width*/ 40, /*height*/ 10, area);
 
     let sample = "Mara found an old key on the shore. Curious, she opened a tarnished box half-buried in sand—and inside lay a single, glowing seed.";
     scenario.run_insert(vec![sample.into()]);

--- a/codex-rs/tui/tests/suite/vt100_live_commit.rs
+++ b/codex-rs/tui/tests/suite/vt100_live_commit.rs
@@ -1,21 +1,21 @@
-#![cfg(feature = "vt100-tests")]
-
 use crate::test_backend::VT100Backend;
 use ratatui::layout::Rect;
 use ratatui::text::Line;
 
 #[test]
 fn live_001_commit_on_overflow() {
-    let backend = VT100Backend::new(20, 6);
+    let backend = VT100Backend::new(/*width*/ 20, /*height*/ 6);
     let mut term = match codex_tui::custom_terminal::Terminal::with_options(backend) {
         Ok(t) => t,
         Err(e) => panic!("failed to construct terminal: {e}"),
     };
-    let area = Rect::new(0, 5, 20, 1);
+    let area = Rect::new(
+        /*x*/ 0, /*y*/ 5, /*width*/ 20, /*height*/ 1,
+    );
     term.set_viewport_area(area);
 
     // Build 5 explicit rows at width 20.
-    let mut rb = codex_tui::live_wrap::RowBuilder::new(20);
+    let mut rb = codex_tui::live_wrap::RowBuilder::new(/*target_width*/ 20);
     rb.push_fragment("one\n");
     rb.push_fragment("two\n");
     rb.push_fragment("three\n");
@@ -23,7 +23,7 @@ fn live_001_commit_on_overflow() {
     rb.push_fragment("five\n");
 
     // Keep the last 3 in the live ring; commit the first 2.
-    let commit_rows = rb.drain_commit_ready(3);
+    let commit_rows = rb.drain_commit_ready(/*max_keep*/ 3);
     let lines: Vec<Line<'static>> = commit_rows.into_iter().map(|r| r.text.into()).collect();
 
     codex_tui::insert_history::insert_history_lines(&mut term, lines)


### PR DESCRIPTION
## Why

The remaining `vt100-tests` and `debug-logs` features in `codex-tui` were only gating test-only and debug-only behavior. Those feature toggles add Cargo and Bazel permutations without buying anything, and they make it easier for more crate features to linger in the workspace.

## What changed

- delete `vt100-tests` and `debug-logs` from `codex-tui`
- always compile the VT100 integration tests in the TUI test target instead of hiding them behind a Cargo feature
- remove the unused textarea debug logging branch instead of replacing it with another gate
- add the required argument-comment annotations in the VT100 tests now that Bazel sees those callsites during linting
- shrink the manifest verifier allowlist again so only the remaining real feature exceptions stay permitted

## How tested

- `cargo test -p codex-tui`
- `just argument-comment-lint -p codex-tui`
