### PR TITLE
Fix Windows provider auth test helpers

### DIFF
--- a/codex-rs/core/src/models_manager/manager_tests.rs
+++ b/codex-rs/core/src/models_manager/manager_tests.rs
@@ -145,7 +145,7 @@ mv tokens.next tokens.txt
             let script_path = tempdir.path().join("print-token.ps1");
             std::fs::write(
                 &script_path,
-                r#"$lines = Get-Content -Path tokens.txt
+                r#"$lines = @(Get-Content -Path tokens.txt)
 if ($lines.Count -eq 0) { exit 1 }
 Write-Output $lines[0]
 $lines | Select-Object -Skip 1 | Set-Content -Path tokens.txt

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -190,7 +190,7 @@ mv tokens.next tokens.txt
             let script_path = tempdir.path().join("print-token.ps1");
             std::fs::write(
                 &script_path,
-                r#"$lines = Get-Content -Path tokens.txt
+                r#"$lines = @(Get-Content -Path tokens.txt)
 if ($lines.Count -eq 0) { exit 1 }
 Write-Output $lines[0]
 $lines | Select-Object -Skip 1 | Set-Content -Path tokens.txt

--- a/codex-rs/login/src/auth/auth_tests.rs
+++ b/codex-rs/login/src/auth/auth_tests.rs
@@ -364,7 +364,7 @@ mv tokens.next tokens.txt
             let script_path = tempdir.path().join("print-token.ps1");
             std::fs::write(
                 &script_path,
-                r#"$lines = Get-Content -Path tokens.txt
+                r#"$lines = @(Get-Content -Path tokens.txt)
 if ($lines.Count -eq 0) { exit 1 }
 Write-Output $lines[0]
 $lines | Select-Object -Skip 1 | Set-Content -Path tokens.txt


### PR DESCRIPTION
## Summary
- make the Windows provider-auth test helper preserve token arrays correctly when only one line remains in the temp token file
- apply the same Windows-safe helper behavior across the affected `login` and `core` provider-auth tests
- keep the Cargo-only Windows test failure fixes separate from the Bazel Windows coverage work

## Verification
- `cargo test -p codex-login`
- targeted Cargo Windows coverage for the provider-auth tests in `codex-core`

## Notes
- this PR intentionally contains only the Cargo-powered Windows test fixes
- the Bazel Windows coverage follow-up is tracked separately in #16460