### PR TITLE
Remove unused json import in app-server tests

### DIFF
--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -2880,7 +2880,6 @@ mod tests {
     use pretty_assertions::assert_eq;
     use rmcp::model::Content;
     use serde_json::Value as JsonValue;
-    use serde_json::json;
     use std::time::Duration;
     use tokio::sync::Mutex;
     use tokio::sync::mpsc;


### PR DESCRIPTION
## Summary
- remove the unused serde_json::json import from bespoke_event_handling tests so codex-app-server compiles cleanly under -D warnings