### PR TITLE
fix: remove unused import

### DIFF
--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -2880,7 +2880,6 @@ mod tests {
     use pretty_assertions::assert_eq;
     use rmcp::model::Content;
     use serde_json::Value as JsonValue;
-    use serde_json::json;
     use std::time::Duration;
     use tokio::sync::Mutex;
     use tokio::sync::mpsc;


### PR DESCRIPTION
This lint violation slipped through because our Bazel CI setup currently doesn't cover `--tests` when doing `cargo clippy`. I am working on fixing this via:

- https://github.com/openai/codex/pull/16450
- https://github.com/openai/codex/pull/16460