### PR TITLE
fix: guard guardian_command_source_tool_name with cfg(unix)

### DIFF
--- a/codex-rs/core/src/guardian/approval_request.rs
+++ b/codex-rs/core/src/guardian/approval_request.rs
@@ -160,6 +160,7 @@ fn command_assessment_action(
     }
 }
 
+#[cfg(unix)]
 fn guardian_command_source_tool_name(source: GuardianCommandSource) -> &'static str {
     match source {
         GuardianCommandSource::Shell => "shell",


### PR DESCRIPTION
This currently contributing to `rust-ci-full.yml` being red on `main` for windows lint builds due to the cargo/bazel coverage gap that I'm working on. Hopefully this gets us back on track.