### PR TITLE
fix: add update to Cargo.lock that was missed in #16512

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -6019,7 +6019,6 @@ name = "mcp_test_support"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "codex-core",
  "codex-login",
  "codex-mcp-server",
  "codex-terminal-detection",


### PR DESCRIPTION
This PR updates `Cargo.lock` to remove `codex-core` from `mcp_test_support`, which corresponds to `codex-rs/mcp-server/tests/common/Cargo.toml`. As noted in #16512, it updated that crate to drop its `codex-core` dependency.