### PR TITLE
fix: move some test utilities out of codex-rs/core/src/tools/spec.rs

### DIFF
--- a/codex-rs/core/src/tools/spec.rs
+++ b/codex-rs/core/src/tools/spec.rs
@@ -19,9 +19,6 @@ use codex_tools::build_tool_registry_plan;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-#[cfg(test)]
-pub(crate) use codex_tools::mcp_call_tool_result_output_schema;
-
 pub(crate) fn tool_user_shell_type(user_shell: &Shell) -> ToolUserShellType {
     match user_shell.shell_type {
         ShellType::Zsh => ToolUserShellType::Zsh,
@@ -30,23 +27,6 @@ pub(crate) fn tool_user_shell_type(user_shell: &Shell) -> ToolUserShellType {
         ShellType::Sh => ToolUserShellType::Sh,
         ShellType::Cmd => ToolUserShellType::Cmd,
     }
-}
-
-/// Builds the tool registry builder while collecting tool specs for later serialization.
-#[cfg(test)]
-pub(crate) fn build_specs(
-    config: &ToolsConfig,
-    mcp_tools: Option<HashMap<String, rmcp::model::Tool>>,
-    app_tools: Option<HashMap<String, ToolInfo>>,
-    dynamic_tools: &[DynamicToolSpec],
-) -> ToolRegistryBuilder {
-    build_specs_with_discoverable_tools(
-        config,
-        mcp_tools,
-        app_tools,
-        /*discoverable_tools*/ None,
-        dynamic_tools,
-    )
 }
 
 pub(crate) fn build_specs_with_discoverable_tools(

--- a/codex-rs/core/src/tools/spec_tests.rs
+++ b/codex-rs/core/src/tools/spec_tests.rs
@@ -29,6 +29,7 @@ use codex_tools::ToolsConfig;
 use codex_tools::ToolsConfigParams;
 use codex_tools::UnifiedExecShellMode;
 use codex_tools::ZshForkConfig;
+use codex_tools::mcp_call_tool_result_output_schema;
 use codex_tools::mcp_tool_to_deferred_responses_api_tool;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use pretty_assertions::assert_eq;
@@ -168,6 +169,22 @@ fn model_info_from_models_json(slug: &str) -> ModelInfo {
         .find(|candidate| candidate.slug == slug)
         .unwrap_or_else(|| panic!("model slug {slug} is missing from models.json"));
     with_config_overrides(model, &config)
+}
+
+/// Builds the tool registry builder while collecting tool specs for later serialization.
+fn build_specs(
+    config: &ToolsConfig,
+    mcp_tools: Option<HashMap<String, rmcp::model::Tool>>,
+    app_tools: Option<HashMap<String, ToolInfo>>,
+    dynamic_tools: &[DynamicToolSpec],
+) -> ToolRegistryBuilder {
+    build_specs_with_discoverable_tools(
+        config,
+        mcp_tools,
+        app_tools,
+        /*discoverable_tools*/ None,
+        dynamic_tools,
+    )
 }
 
 #[test]


### PR DESCRIPTION
The `#[cfg(test)]` in `codex-rs/core/src/tools/spec.rs` smelled funny to me and it turns out these members were straightforward to move.