### PR TITLE
ci: upload compact Bazel execution logs for bazel.yml

### DIFF
--- a/.github/scripts/run-bazel-ci.sh
+++ b/.github/scripts/run-bazel-ci.sh
@@ -146,6 +146,12 @@ if [[ -n "${BAZEL_REPOSITORY_CACHE:-}" ]]; then
   post_config_bazel_args+=("--repository_cache=${BAZEL_REPOSITORY_CACHE}")
 fi
 
+if [[ -n "${CODEX_BAZEL_EXECUTION_LOG_COMPACT_DIR:-}" ]]; then
+  post_config_bazel_args+=(
+    "--execution_log_compact_file=${CODEX_BAZEL_EXECUTION_LOG_COMPACT_DIR}/execution-log-${bazel_args[0]}-${GITHUB_JOB:-local}-$$.zst"
+  )
+fi
+
 if [[ "${RUNNER_OS:-}" == "Windows" ]]; then
   windows_action_env_vars=(
     INCLUDE

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -63,6 +63,12 @@ jobs:
         shell: bash
         run: ./scripts/check-module-bazel-lock.sh
 
+      - name: Set up Bazel execution logs
+        shell: bash
+        run: |
+          mkdir -p "${RUNNER_TEMP}/bazel-execution-logs"
+          echo "CODEX_BAZEL_EXECUTION_LOG_COMPACT_DIR=${RUNNER_TEMP}/bazel-execution-logs" >> "${GITHUB_ENV}"
+
       - name: bazel test //...
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
@@ -86,6 +92,15 @@ jobs:
             --build_metadata=COMMIT_SHA=${GITHUB_SHA} \
             -- \
             "${bazel_targets[@]}"
+
+      - name: Upload Bazel execution logs
+        if: always() && !cancelled()
+        continue-on-error: true
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: bazel-execution-logs-test-${{ matrix.target }}
+          path: ${{ runner.temp }}/bazel-execution-logs
+          if-no-files-found: ignore
 
       # Save bazel repository cache explicitly; make non-fatal so cache uploading
       # never fails the overall job. Only save when key wasn't hit.
@@ -126,6 +141,12 @@ jobs:
         with:
           target: ${{ matrix.target }}
 
+      - name: Set up Bazel execution logs
+        shell: bash
+        run: |
+          mkdir -p "${RUNNER_TEMP}/bazel-execution-logs"
+          echo "CODEX_BAZEL_EXECUTION_LOG_COMPACT_DIR=${RUNNER_TEMP}/bazel-execution-logs" >> "${GITHUB_ENV}"
+
       - name: bazel build --config=clippy //codex-rs/...
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
@@ -142,6 +163,15 @@ jobs:
             -- \
             //codex-rs/... \
             -//codex-rs/v8-poc:all
+
+      - name: Upload Bazel execution logs
+        if: always() && !cancelled()
+        continue-on-error: true
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: bazel-execution-logs-clippy-${{ matrix.target }}
+          path: ${{ runner.temp }}/bazel-execution-logs
+          if-no-files-found: ignore
 
       # Save bazel repository cache explicitly; make non-fatal so cache uploading
       # never fails the overall job. Only save when key wasn't hit.


### PR DESCRIPTION
## Why

The main Bazel CI lanes need compact execution logs to investigate cache misses and unexpected rebuilds, but local users of the shared wrapper should not pay that log-generation cost by default.

## What Changed

- [`.github/scripts/run-bazel-ci.sh`](https://github.com/openai/codex/blob/a6ec239a24fd21507bb75a28f17277653f52e3a2/.github/scripts/run-bazel-ci.sh#L149-L153) now appends `--execution_log_compact_file=...` only when `CODEX_BAZEL_EXECUTION_LOG_COMPACT_DIR` is set; the caller owns creating that directory.
- [`.github/workflows/bazel.yml`](https://github.com/openai/codex/blob/a6ec239a24fd21507bb75a28f17277653f52e3a2/.github/workflows/bazel.yml#L66-L174) enables that env var only for the main `test` and `clippy` jobs, creates the temp log directory in each job, and uploads the resulting `*.zst` files from `runner.temp`.

## Verification

- `bash -n .github/scripts/run-bazel-ci.sh`
- Parsed `.github/workflows/bazel.yml` as YAML.
- Ran a local opt-in wrapper smoke test and confirmed it writes `execution-log-cquery-local-*.zst` when the caller pre-creates `CODEX_BAZEL_EXECUTION_LOG_COMPACT_DIR`.
