### PR TITLE
Fix non-determinism in rules_rs/crate_git_repository.bzl

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -71,6 +71,7 @@ single_version_override(
     patch_strip = 1,
     patches = [
         "//patches:rules_rs_windows_gnullvm_exec.patch",
+        "//patches:rules_rs_delete_git_worktree_pointer.patch",
     ],
     version = "0.0.43",
 )

--- a/patches/rules_rs_delete_git_worktree_pointer.patch
+++ b/patches/rules_rs_delete_git_worktree_pointer.patch
@@ -1,0 +1,20 @@
+diff --git a/rs/private/crate_git_repository.bzl b/rs/private/crate_git_repository.bzl
+--- a/rs/private/crate_git_repository.bzl
++++ b/rs/private/crate_git_repository.bzl
+@@ -35,6 +35,14 @@
+         "HEAD"
+     ])
+     if result.return_code != 0:
+         fail(result.stderr)
+
++    # Remove .git worktree pointer file. It contains an absolute path to
++    # the bazel output base which is machine-specific and non-deterministic.
++    # Leaving it in pollutes compile_data globs and causes AC misses.
++    #
++    # Note that bazelbuild/rules_rust ignores .git (among other paths) during splicing:
++    # https://github.com/bazelbuild/rules_rust/blob/ca4915c0210bcd240152a5333ecb24d266bda144/crate_universe/src/splicing/splicer.rs#L42
++    rctx.delete(root.get_child(".git"))
++
+     if strip_prefix:
+         dest_link = dest_dir.get_child(strip_prefix)
+         if not dest_link.exists:


### PR DESCRIPTION
Running multiple builds with no changes causes some differences, we see that https://app.buildbuddy.io/compare/a9719629-1660-4735-a477-d66357f234fb...df85310b-eb5c-4c10-8b79-4d0449ba6cdd#file shows the file-differences between two Bazel builds.

These differences are caused by a non-deterministic `.git` entry in the rules_rs crates that are created with `crate_git_repository`.

As a way to make these deterministic, we can remove this entry after we download the git source, so that the input to the compile action is deterministic.

### CLA

I have read the CLA Document and I hereby sign the CLA