### PR TITLE
Fix resume picker initial loading state

### DIFF
--- a/codex-rs/tui/src/resume_picker.rs
+++ b/codex-rs/tui/src/resume_picker.rs
@@ -1360,11 +1360,10 @@ fn render_empty_state_line(state: &PickerState) -> Line<'static> {
         return vec!["No results for your search".italic().dim()].into();
     }
 
-    if state.all_rows.is_empty() && state.pagination.num_scanned_files == 0 {
-        return vec!["No sessions yet".italic().dim()].into();
-    }
-
     if state.pagination.loading.is_pending() {
+        if state.all_rows.is_empty() && state.pagination.num_scanned_files == 0 {
+            return vec!["Loading sessions…".italic().dim()].into();
+        }
         return vec!["Loading older sessions…".italic().dim()].into();
     }
 


### PR DESCRIPTION
Addresses #16514

Problem: Resume picker could show “No sessions yet” before the initial session fetch finished.

Solution: Render a loading message while the first page is pending, and keep the empty state for truly empty results.