### PR TITLE
test: deflake external bearer auth token tests on Windows

### DIFF
--- a/codex-rs/login/src/auth/auth_tests.rs
+++ b/codex-rs/login/src/auth/auth_tests.rs
@@ -395,7 +395,7 @@ $lines | Select-Object -Skip 1 | Set-Content -Path tokens.txt
 "#,
             )?;
             (
-                "powershell".to_string(),
+                "powershell.exe".to_string(),
                 vec![
                     "-NoProfile".to_string(),
                     "-ExecutionPolicy".to_string(),
@@ -436,7 +436,7 @@ exit 1
 
         #[cfg(windows)]
         let (command, args) = (
-            "powershell".to_string(),
+            "powershell.exe".to_string(),
             vec![
                 "-NoProfile".to_string(),
                 "-ExecutionPolicy".to_string(),
@@ -457,7 +457,9 @@ exit 1
         serde_json::from_value(json!({
             "command": self.command,
             "args": self.args,
-            "timeout_ms": 1000,
+            // `powershell.exe` startup can be slow on loaded Windows CI workers, so leave enough
+            // slack to avoid turning these auth-cache assertions into a process-launch timing test.
+            "timeout_ms": 10_000,
             "refresh_interval_ms": 60000,
             "cwd": self.tempdir.path(),
         }))


### PR DESCRIPTION
## Why

`external_bearer_only_auth_manager_uses_cached_provider_token` can fail on Windows when cold `powershell.exe` startup exceeds the provider-auth helper's 1s timeout. When that happens, `AuthManager::resolve_external_api_key_auth()` [logs the resolver error and returns `None`](https://github.com/openai/codex/blob/024b08b411fe/codex-rs/login/src/auth/manager.rs#L1449-L1455), which is exactly the assertion failure from the flake.

## What

- Invoke `powershell.exe` explicitly in the Windows provider-auth test helpers in `login/src/auth/auth_tests.rs`.
- Increase the helper timeout to `10_000` ms and document why that slack exists.

## Verification

- `cargo test -p codex-login`
