### PR TITLE
fix: increase timeout to account for slow PowerShell startup

### DIFF
--- a/codex-rs/mcp-server/tests/suite/codex_tool.rs
+++ b/codex-rs/mcp-server/tests/suite/codex_tool.rs
@@ -60,17 +60,24 @@ async fn shell_command_approval_triggers_elicitation() -> anyhow::Result<()> {
         .path()
         .join(created_filename);
 
-    let shell_command = if cfg!(windows) {
-        vec![
-            "New-Item".to_string(),
-            "-ItemType".to_string(),
-            "File".to_string(),
-            "-Path".to_string(),
-            created_filename.to_string(),
-            "-Force".to_string(),
-        ]
+    let (shell_command, timeout_ms) = if cfg!(windows) {
+        (
+            vec![
+                "New-Item".to_string(),
+                "-ItemType".to_string(),
+                "File".to_string(),
+                "-Path".to_string(),
+                created_filename.to_string(),
+                "-Force".to_string(),
+            ],
+            // `powershell.exe` startup can be slow on loaded Windows CI workers
+            10_000,
+        )
     } else {
-        vec!["touch".to_string(), created_filename.to_string()]
+        (
+            vec!["touch".to_string(), created_filename.to_string()],
+            5_000,
+        )
     };
     let expected_shell_command =
         format_with_current_shell(&shlex::try_join(shell_command.iter().map(String::as_str))?);
@@ -83,7 +90,7 @@ async fn shell_command_approval_triggers_elicitation() -> anyhow::Result<()> {
         create_shell_command_sse_response(
             shell_command.clone(),
             Some(workdir_for_shell_function_call.path()),
-            Some(5_000),
+            Some(timeout_ms),
             "call1234",
         )?,
         create_final_assistant_message_sse_response("File created!")?,


### PR DESCRIPTION
Similar to https://github.com/openai/codex/pull/16604, I am seeing failures on Windows Bazel that could be due to PowerShell startup timeouts, so try increasing.