### PR TITLE
test: use cmd.exe for ProviderAuthScript on Windows

### DIFF
--- a/codex-rs/core/src/models_manager/manager_tests.rs
+++ b/codex-rs/core/src/models_manager/manager_tests.rs
@@ -112,10 +112,12 @@ impl ProviderAuthScript {
     fn new(tokens: &[&str]) -> std::io::Result<Self> {
         let tempdir = tempfile::tempdir()?;
         let tokens_file = tempdir.path().join("tokens.txt");
+        // `cmd.exe`'s `set /p` treats LF-only input as one line, so use CRLF on Windows.
+        let token_line_ending = if cfg!(windows) { "\r\n" } else { "\n" };
         let mut token_file_contents = String::new();
         for token in tokens {
             token_file_contents.push_str(token);
-            token_file_contents.push('\n');
+            token_file_contents.push_str(token_line_ending);
         }
         std::fs::write(&tokens_file, token_file_contents)?;
 
@@ -153,7 +155,7 @@ if not defined first_line exit /b 1
 setlocal EnableDelayedExpansion
 echo(!first_line!
 endlocal
-more +2 tokens.txt > tokens.next
+more +1 tokens.txt > tokens.next
 move /y tokens.next tokens.txt >nul
 "#,
             )?;

--- a/codex-rs/core/src/models_manager/manager_tests.rs
+++ b/codex-rs/core/src/models_manager/manager_tests.rs
@@ -142,23 +142,28 @@ mv tokens.next tokens.txt
 
         #[cfg(windows)]
         let (command, args) = {
-            let script_path = tempdir.path().join("print-token.ps1");
+            let script_path = tempdir.path().join("print-token.cmd");
             std::fs::write(
                 &script_path,
-                r#"$lines = @(Get-Content -Path tokens.txt)
-if ($lines.Count -eq 0) { exit 1 }
-Write-Output $lines[0]
-$lines | Select-Object -Skip 1 | Set-Content -Path tokens.txt
+                r#"@echo off
+setlocal EnableExtensions DisableDelayedExpansion
+set "first_line="
+<tokens.txt set /p "first_line="
+if not defined first_line exit /b 1
+setlocal EnableDelayedExpansion
+echo(!first_line!
+endlocal
+more +2 tokens.txt > tokens.next
+move /y tokens.next tokens.txt >nul
 "#,
             )?;
             (
-                "powershell".to_string(),
+                "cmd.exe".to_string(),
                 vec![
-                    "-NoProfile".to_string(),
-                    "-ExecutionPolicy".to_string(),
-                    "Bypass".to_string(),
-                    "-File".to_string(),
-                    ".\\print-token.ps1".to_string(),
+                    "/d".to_string(),
+                    "/s".to_string(),
+                    "/c".to_string(),
+                    ".\\print-token.cmd".to_string(),
                 ],
             )
         };
@@ -172,7 +177,7 @@ $lines | Select-Object -Skip 1 | Set-Content -Path tokens.txt
 
     fn auth_config(&self) -> ModelProviderAuthInfo {
         let timeout_ms = if cfg!(windows) {
-            // `powershell.exe` startup can be slow on loaded Windows CI workers
+            // Process startup can be slow on loaded Windows CI workers.
             10_000
         } else {
             2_000

--- a/codex-rs/login/src/auth/auth_tests.rs
+++ b/codex-rs/login/src/auth/auth_tests.rs
@@ -355,10 +355,12 @@ impl ProviderAuthScript {
     fn new(tokens: &[&str]) -> std::io::Result<Self> {
         let tempdir = tempfile::tempdir()?;
         let token_file = tempdir.path().join("tokens.txt");
+        // `cmd.exe`'s `set /p` treats LF-only input as one line, so use CRLF on Windows.
+        let token_line_ending = if cfg!(windows) { "\r\n" } else { "\n" };
         let mut token_file_contents = String::new();
         for token in tokens {
             token_file_contents.push_str(token);
-            token_file_contents.push('\n');
+            token_file_contents.push_str(token_line_ending);
         }
         std::fs::write(&token_file, token_file_contents)?;
 
@@ -396,7 +398,7 @@ if not defined first_line exit /b 1
 setlocal EnableDelayedExpansion
 echo(!first_line!
 endlocal
-more +2 tokens.txt > tokens.next
+more +1 tokens.txt > tokens.next
 move /y tokens.next tokens.txt >nul
 "#,
             )?;

--- a/codex-rs/login/src/auth/auth_tests.rs
+++ b/codex-rs/login/src/auth/auth_tests.rs
@@ -385,23 +385,28 @@ mv tokens.next tokens.txt
 
         #[cfg(windows)]
         let (command, args) = {
-            let script_path = tempdir.path().join("print-token.ps1");
+            let script_path = tempdir.path().join("print-token.cmd");
             std::fs::write(
                 &script_path,
-                r#"$lines = @(Get-Content -Path tokens.txt)
-if ($lines.Count -eq 0) { exit 1 }
-Write-Output $lines[0]
-$lines | Select-Object -Skip 1 | Set-Content -Path tokens.txt
+                r#"@echo off
+setlocal EnableExtensions DisableDelayedExpansion
+set "first_line="
+<tokens.txt set /p "first_line="
+if not defined first_line exit /b 1
+setlocal EnableDelayedExpansion
+echo(!first_line!
+endlocal
+more +2 tokens.txt > tokens.next
+move /y tokens.next tokens.txt >nul
 "#,
             )?;
             (
-                "powershell.exe".to_string(),
+                "cmd.exe".to_string(),
                 vec![
-                    "-NoProfile".to_string(),
-                    "-ExecutionPolicy".to_string(),
-                    "Bypass".to_string(),
-                    "-File".to_string(),
-                    ".\\print-token.ps1".to_string(),
+                    "/d".to_string(),
+                    "/s".to_string(),
+                    "/c".to_string(),
+                    ".\\print-token.cmd".to_string(),
                 ],
             )
         };
@@ -436,13 +441,12 @@ exit 1
 
         #[cfg(windows)]
         let (command, args) = (
-            "powershell.exe".to_string(),
+            "cmd.exe".to_string(),
             vec![
-                "-NoProfile".to_string(),
-                "-ExecutionPolicy".to_string(),
-                "Bypass".to_string(),
-                "-Command".to_string(),
-                "exit 1".to_string(),
+                "/d".to_string(),
+                "/s".to_string(),
+                "/c".to_string(),
+                "exit /b 1".to_string(),
             ],
         );
 
@@ -457,8 +461,8 @@ exit 1
         serde_json::from_value(json!({
             "command": self.command,
             "args": self.args,
-            // `powershell.exe` startup can be slow on loaded Windows CI workers, so leave enough
-            // slack to avoid turning these auth-cache assertions into a process-launch timing test.
+            // Process startup can be slow on loaded Windows CI workers, so leave enough slack to
+            // avoid turning these auth-cache assertions into a process-launch timing test.
             "timeout_ms": 10_000,
             "refresh_interval_ms": 60000,
             "cwd": self.tempdir.path(),


### PR DESCRIPTION
## Why

The Windows `ProviderAuthScript` test helpers do not need PowerShell. Running them through `cmd.exe` is enough to emit the next fixture token and rotate `tokens.txt`, and it avoids a PowerShell-specific dependency in these tests.

## What changed

- Replaced the Windows `print-token.ps1` fixtures with `print-token.cmd` in `codex-rs/core/src/models_manager/manager_tests.rs` and `codex-rs/login/src/auth/auth_tests.rs`.
- Switched the failing external-auth helper in `codex-rs/login/src/auth/auth_tests.rs` from `powershell.exe -Command 'exit 1'` to `cmd.exe /d /s /c 'exit /b 1'`.
- Updated Windows timeout comments so they no longer call out PowerShell specifically.

## Verification

- `cargo test -p codex-login`
- `cargo test -p codex-core` (fails in unrelated `core/src/config/config_tests.rs` assertions in this checkout)
