### PR TITLE
fix(core): skip default approval for custom MCP tools without usable annotations

### DIFF
--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -46,6 +46,7 @@ use codex_mcp::mcp_permission_prompt_is_auto_approved;
 use codex_otel::sanitize_metric_tag_value;
 use codex_protocol::mcp::CallToolResult;
 use codex_protocol::openai_models::InputModality;
+use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::McpInvocation;
 use codex_protocol::protocol::McpToolCallBeginEvent;
@@ -829,8 +830,9 @@ fn mcp_tool_approval_prompt_options(
 ///
 /// The function's early-exit order matters:
 /// 1. Full-access mode → skip everything.
-/// 2. Custom MCP in `Auto` mode without annotations → skip (user opted in by
-///    configuring the server; see `should_skip_default_custom_mcp_approval`).
+/// 2. Custom MCP in `Auto` mode without annotations (or with empty annotations
+///    where every hint is `None`) → skip (user opted in by configuring the
+///    server; see `should_skip_default_custom_mcp_approval`).
 /// 3. Annotation-based check → skip if annotations say the tool is safe and
 ///    the mode is not `Prompt`.
 /// 4. ARC safety monitor (for `Approve` mode) → may block or escalate.
@@ -892,7 +894,7 @@ async fn maybe_request_mcp_tool_approval(
     // safety-monitor block so that `Approve`-mode tools are still
     // safety-checked even when running non-interactively.
     if matches!(turn_context.approval_policy.value(), AskForApproval::Never) {
-        return Some(McpToolApprovalDecision::Decline);
+        return Some(McpToolApprovalDecision::Decline { message: None });
     }
     let session_approval_key = session_mcp_tool_approval_key(invocation, metadata, approval_mode);
     let persistent_approval_key =
@@ -1051,14 +1053,23 @@ async fn maybe_request_mcp_tool_approval(
 ///
 /// Codex Apps tools always carry `ToolAnnotations`, so the annotation-based logic in
 /// `requires_mcp_tool_approval` is authoritative for them. Custom MCP servers, however,
-/// may not provide annotations at all. When a custom tool is in the default `Auto`
-/// approval mode and no annotations are present, the user has already opted in by
-/// configuring the server — prompting them again would be a regression from the
-/// expected behavior (see #15824).
+/// may omit annotations entirely **or** supply a `ToolAnnotations` struct with every
+/// hint field set to `None` (the "empty annotations" case — common for stdio-based
+/// servers that echo the struct without populating it). Both cases signal the same
+/// thing: the server has no opinion on the tool's risk profile.
+///
+/// When a custom tool is in the default `Auto` approval mode and annotations are absent
+/// or empty, the user has already opted in by configuring the server — prompting them
+/// again would be a regression from the expected behavior (see #15824).
 ///
 /// This gate intentionally does **not** fire for `Prompt` or `Approve` modes: those
 /// represent an explicit per-tool override that should always take effect regardless
 /// of annotation presence.
+///
+/// Callers that set any concrete hint value (e.g. `destructive_hint: Some(true)`)
+/// will fall through to the normal `requires_mcp_tool_approval` path, ensuring
+/// annotation-based approval is still enforced whenever the server actually provides
+/// risk information.
 fn should_skip_default_custom_mcp_approval(
     invocation: &McpInvocation,
     approval_mode: AppToolApproval,
@@ -1066,7 +1077,11 @@ fn should_skip_default_custom_mcp_approval(
 ) -> bool {
     invocation.server != CODEX_APPS_MCP_SERVER_NAME
         && approval_mode == AppToolApproval::Auto
-        && annotations.is_none()
+        && annotations.is_none_or(|annotations| {
+            annotations.destructive_hint.is_none()
+                && annotations.read_only_hint.is_none()
+                && annotations.open_world_hint.is_none()
+        })
 }
 
 async fn maybe_monitor_auto_approved_mcp_tool_call(

--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -836,6 +836,9 @@ async fn maybe_request_mcp_tool_approval(
     }
 
     let annotations = metadata.and_then(|metadata| metadata.annotations.as_ref());
+    if should_skip_default_custom_mcp_approval(invocation, approval_mode, annotations) {
+        return None;
+    }
     let approval_required = requires_mcp_tool_approval(annotations);
     if !approval_required && approval_mode != AppToolApproval::Prompt {
         return None;
@@ -866,6 +869,9 @@ async fn maybe_request_mcp_tool_approval(
         }
     }
 
+    if matches!(turn_context.approval_policy.value(), AskForApproval::Never) {
+        return Some(McpToolApprovalDecision::Decline);
+    }
     let session_approval_key = session_mcp_tool_approval_key(invocation, metadata, approval_mode);
     let persistent_approval_key =
         persistent_mcp_tool_approval_key(invocation, metadata, approval_mode);
@@ -1016,6 +1022,16 @@ async fn maybe_request_mcp_tool_approval(
     )
     .await;
     Some(decision)
+}
+
+fn should_skip_default_custom_mcp_approval(
+    invocation: &McpInvocation,
+    approval_mode: AppToolApproval,
+    annotations: Option<&ToolAnnotations>,
+) -> bool {
+    invocation.server != CODEX_APPS_MCP_SERVER_NAME
+        && approval_mode == AppToolApproval::Auto
+        && annotations.is_none()
 }
 
 async fn maybe_monitor_auto_approved_mcp_tool_call(

--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -819,6 +819,23 @@ fn mcp_tool_approval_prompt_options(
     }
 }
 
+/// Determines whether an MCP tool call requires user approval and, if so,
+/// obtains a decision via the appropriate channel (interactive prompt, guardian,
+/// or ARC safety monitor).
+///
+/// Returns `None` when the call may proceed without any approval gate, or
+/// `Some(decision)` when an approval path was triggered. The caller must
+/// inspect the decision variant to decide whether to execute or skip the tool.
+///
+/// The function's early-exit order matters:
+/// 1. Full-access mode → skip everything.
+/// 2. Custom MCP in `Auto` mode without annotations → skip (user opted in by
+///    configuring the server; see `should_skip_default_custom_mcp_approval`).
+/// 3. Annotation-based check → skip if annotations say the tool is safe and
+///    the mode is not `Prompt`.
+/// 4. ARC safety monitor (for `Approve` mode) → may block or escalate.
+/// 5. Non-interactive guard → `Decline` rather than hang.
+/// 6. Guardian / interactive prompt → obtain a user or guardian decision.
 async fn maybe_request_mcp_tool_approval(
     sess: &Arc<Session>,
     turn_context: &Arc<TurnContext>,
@@ -869,6 +886,11 @@ async fn maybe_request_mcp_tool_approval(
         }
     }
 
+    // In runs with `--ask-for-approval never` (for example `codex exec`), no
+    // user is available to answer the approval prompt. Decline rather than
+    // hanging forever. This check is intentionally placed *after* the ARC
+    // safety-monitor block so that `Approve`-mode tools are still
+    // safety-checked even when running non-interactively.
     if matches!(turn_context.approval_policy.value(), AskForApproval::Never) {
         return Some(McpToolApprovalDecision::Decline);
     }
@@ -1024,6 +1046,19 @@ async fn maybe_request_mcp_tool_approval(
     Some(decision)
 }
 
+/// Returns `true` when a custom (non-Codex-Apps) MCP tool call should bypass the
+/// default annotation-driven approval path entirely.
+///
+/// Codex Apps tools always carry `ToolAnnotations`, so the annotation-based logic in
+/// `requires_mcp_tool_approval` is authoritative for them. Custom MCP servers, however,
+/// may not provide annotations at all. When a custom tool is in the default `Auto`
+/// approval mode and no annotations are present, the user has already opted in by
+/// configuring the server — prompting them again would be a regression from the
+/// expected behavior (see #15824).
+///
+/// This gate intentionally does **not** fire for `Prompt` or `Approve` modes: those
+/// represent an explicit per-tool override that should always take effect regardless
+/// of annotation presence.
 fn should_skip_default_custom_mcp_approval(
     invocation: &McpInvocation,
     approval_mode: AppToolApproval,

--- a/codex-rs/core/src/mcp_tool_call_tests.rs
+++ b/codex-rs/core/src/mcp_tool_call_tests.rs
@@ -210,6 +210,24 @@ fn custom_mcp_invocation_without_annotations() -> McpInvocation {
     }
 }
 
+/// Builds metadata whose `annotations` field is `Some(...)` but every hint inside
+/// is `None` — the "empty annotations" variant that stdio MCP servers commonly emit.
+fn custom_mcp_metadata_with_empty_annotations() -> McpToolApprovalMetadata {
+    McpToolApprovalMetadata {
+        annotations: Some(annotations(
+            /*read_only*/ None, /*destructive*/ None, /*open_world*/ None,
+        )),
+        connector_id: None,
+        connector_name: None,
+        connector_description: None,
+        tool_title: Some("Search".to_string()),
+        tool_description: Some("Search docs".to_string()),
+        mcp_app_resource_uri: None,
+        codex_apps_meta: None,
+        openai_file_input_params: None,
+    }
+}
+
 #[test]
 fn approval_required_when_read_only_false_and_destructive() {
     let annotations = annotations(Some(false), Some(true), /*open_world*/ None);
@@ -2099,6 +2117,7 @@ async fn custom_auto_mode_skips_approval_when_annotations_are_missing_in_never_m
         &turn_context,
         "call-custom-auto",
         &invocation,
+        "mcp__docs__search",
         /*metadata*/ None,
         AppToolApproval::Auto,
     )
@@ -2128,6 +2147,7 @@ async fn custom_auto_mode_skips_approval_when_annotations_are_missing_in_on_requ
                 &turn_context,
                 "call-custom-auto-on-request",
                 &invocation,
+                "mcp__docs__search",
                 /*metadata*/ None,
                 AppToolApproval::Auto,
             )
@@ -2138,6 +2158,44 @@ async fn custom_auto_mode_skips_approval_when_annotations_are_missing_in_on_requ
     let decision = tokio::time::timeout(std::time::Duration::from_millis(200), &mut approval_task)
         .await
         .expect("custom MCP tools should not wait for approval when annotations are missing")
+        .expect("approval task should complete successfully");
+
+    assert_eq!(decision, None);
+}
+
+#[tokio::test]
+async fn custom_auto_mode_skips_approval_when_annotations_have_no_hints_in_on_request_mode() {
+    let (session, turn_context, _rx_event) = make_session_and_context_with_rx().await;
+    {
+        let mut active_turn = session.active_turn.lock().await;
+        *active_turn = Some(ActiveTurn::default());
+    }
+
+    let session = Arc::new(session);
+    let turn_context = Arc::new(turn_context);
+    let invocation = custom_mcp_invocation_without_annotations();
+    let metadata = custom_mcp_metadata_with_empty_annotations();
+
+    let mut approval_task = {
+        let session = Arc::clone(&session);
+        let turn_context = Arc::clone(&turn_context);
+        tokio::spawn(async move {
+            maybe_request_mcp_tool_approval(
+                &session,
+                &turn_context,
+                "call-custom-auto-empty-annotations-on-request",
+                &invocation,
+                "mcp__docs__search",
+                Some(&metadata),
+                AppToolApproval::Auto,
+            )
+            .await
+        })
+    };
+
+    let decision = tokio::time::timeout(std::time::Duration::from_millis(200), &mut approval_task)
+        .await
+        .expect("custom MCP tools with empty annotations should not wait for approval")
         .expect("approval task should complete successfully");
 
     assert_eq!(decision, None);
@@ -2190,6 +2248,7 @@ async fn custom_approve_mode_without_metadata_still_uses_arc_monitor() {
         &turn_context,
         "call-custom-approve-no-metadata",
         &invocation,
+        "mcp__docs__search",
         /*metadata*/ None,
         AppToolApproval::Approve,
     )

--- a/codex-rs/core/src/mcp_tool_call_tests.rs
+++ b/codex-rs/core/src/mcp_tool_call_tests.rs
@@ -2097,7 +2097,7 @@ async fn custom_auto_mode_skips_approval_when_annotations_are_missing_in_never_m
         &turn_context,
         "call-custom-auto",
         &invocation,
-        None,
+        /*metadata*/ None,
         AppToolApproval::Auto,
     )
     .await;
@@ -2126,7 +2126,7 @@ async fn custom_auto_mode_skips_approval_when_annotations_are_missing_in_on_requ
                 &turn_context,
                 "call-custom-auto-on-request",
                 &invocation,
-                None,
+                /*metadata*/ None,
                 AppToolApproval::Auto,
             )
             .await
@@ -2188,7 +2188,7 @@ async fn custom_approve_mode_without_metadata_still_uses_arc_monitor() {
         &turn_context,
         "call-custom-approve-no-metadata",
         &invocation,
-        None,
+        /*metadata*/ None,
         AppToolApproval::Approve,
     )
     .await;

--- a/codex-rs/core/src/mcp_tool_call_tests.rs
+++ b/codex-rs/core/src/mcp_tool_call_tests.rs
@@ -200,6 +200,8 @@ fn openai_file_params_are_only_honored_for_codex_apps() {
     );
 }
 
+/// Builds an `McpInvocation` for a non-Codex-Apps server with no annotations,
+/// representing the scenario that triggered the regression in #15824.
 fn custom_mcp_invocation_without_annotations() -> McpInvocation {
     McpInvocation {
         server: "docs".to_string(),

--- a/codex-rs/core/src/mcp_tool_call_tests.rs
+++ b/codex-rs/core/src/mcp_tool_call_tests.rs
@@ -200,6 +200,14 @@ fn openai_file_params_are_only_honored_for_codex_apps() {
     );
 }
 
+fn custom_mcp_invocation_without_annotations() -> McpInvocation {
+    McpInvocation {
+        server: "docs".to_string(),
+        tool: "search".to_string(),
+        arguments: Some(serde_json::json!({ "query": "approval regression" })),
+    }
+}
+
 #[test]
 fn approval_required_when_read_only_false_and_destructive() {
     let annotations = annotations(Some(false), Some(true), /*open_world*/ None);
@@ -2061,6 +2069,126 @@ async fn custom_approve_mode_blocks_when_arc_returns_interrupt_for_model() {
         &invocation,
         "mcp__test__tool",
         Some(&metadata),
+        AppToolApproval::Approve,
+    )
+    .await;
+
+    assert_eq!(
+        decision,
+        Some(McpToolApprovalDecision::BlockedBySafetyMonitor(
+            "Tool call was cancelled because of safety risks: high-risk action".to_string(),
+        ))
+    );
+}
+
+#[tokio::test]
+async fn custom_auto_mode_skips_approval_when_annotations_are_missing_in_never_mode() {
+    let (session, mut turn_context) = make_session_and_context().await;
+    turn_context
+        .approval_policy
+        .set(AskForApproval::Never)
+        .expect("test setup should allow updating approval policy");
+    let session = Arc::new(session);
+    let turn_context = Arc::new(turn_context);
+    let invocation = custom_mcp_invocation_without_annotations();
+
+    let decision = maybe_request_mcp_tool_approval(
+        &session,
+        &turn_context,
+        "call-custom-auto",
+        &invocation,
+        None,
+        AppToolApproval::Auto,
+    )
+    .await;
+
+    assert_eq!(decision, None);
+}
+
+#[tokio::test]
+async fn custom_auto_mode_skips_approval_when_annotations_are_missing_in_on_request_mode() {
+    let (session, turn_context, _rx_event) = make_session_and_context_with_rx().await;
+    {
+        let mut active_turn = session.active_turn.lock().await;
+        *active_turn = Some(ActiveTurn::default());
+    }
+
+    let session = Arc::new(session);
+    let turn_context = Arc::new(turn_context);
+    let invocation = custom_mcp_invocation_without_annotations();
+
+    let mut approval_task = {
+        let session = Arc::clone(&session);
+        let turn_context = Arc::clone(&turn_context);
+        tokio::spawn(async move {
+            maybe_request_mcp_tool_approval(
+                &session,
+                &turn_context,
+                "call-custom-auto-on-request",
+                &invocation,
+                None,
+                AppToolApproval::Auto,
+            )
+            .await
+        })
+    };
+
+    let decision = tokio::time::timeout(std::time::Duration::from_millis(200), &mut approval_task)
+        .await
+        .expect("custom MCP tools should not wait for approval when annotations are missing")
+        .expect("approval task should complete successfully");
+
+    assert_eq!(decision, None);
+}
+
+#[tokio::test]
+async fn custom_approve_mode_without_metadata_still_uses_arc_monitor() {
+    use wiremock::Mock;
+    use wiremock::MockServer;
+    use wiremock::ResponseTemplate;
+    use wiremock::matchers::method;
+    use wiremock::matchers::path;
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/codex/safety/arc"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "outcome": "steer-model",
+            "short_reason": "needs approval",
+            "rationale": "high-risk action",
+            "risk_score": 96,
+            "risk_level": "critical",
+            "evidence": [{
+                "message": "search",
+                "why": "high-risk action",
+            }],
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let (session, mut turn_context) = make_session_and_context().await;
+    turn_context.auth_manager = Some(crate::test_support::auth_manager_from_auth(
+        codex_login::CodexAuth::create_dummy_chatgpt_auth_for_testing(),
+    ));
+    let mut config = (*turn_context.config).clone();
+    config.chatgpt_base_url = server.uri();
+    turn_context.config = Arc::new(config);
+
+    let session = Arc::new(session);
+    let turn_context = Arc::new(turn_context);
+    let invocation = McpInvocation {
+        server: "docs".to_string(),
+        tool: "search".to_string(),
+        arguments: Some(serde_json::json!({ "query": "approval regression" })),
+    };
+
+    let decision = maybe_request_mcp_tool_approval(
+        &session,
+        &turn_context,
+        "call-custom-approve-no-metadata",
+        &invocation,
+        None,
         AppToolApproval::Approve,
     )
     .await;


### PR DESCRIPTION
## Summary

This change restores the expected default behavior for non-`codex_apps` MCP tools in `auto` approval mode when the server does not provide usable risk annotations.

Custom MCP servers may omit `ToolAnnotations` entirely, or they may emit an "empty" `ToolAnnotations` object where every hint is `None`. Both cases should behave the same way: Codex should treat the tool as lacking annotation data, not route it into the app-tool approval path.

That regression was surfacing in headless `exec` flows as immediate MCP tool cancellation (`user cancelled MCP tool call`) for otherwise trivial custom stdio servers.

Addresses #15824
Addresses #16685

## Behavior

For non-`codex_apps` MCP tools in the default `auto` approval mode:

- Missing annotations skip the approval path.
- Empty annotations (all hints `None`) also skip the approval path.
- Explicit `prompt` mode still prompts.
- Explicit `approve` mode still uses the allow/ARC path.
- `codex_apps` behavior is unchanged.

## Validation

- `just fmt`
- `cargo test -p codex-core --lib mcp_tool_call::tests::custom_auto_mode_skips_approval_when_annotations_are_missing_in_on_request_mode -- --exact --nocapture`
- `cargo test -p codex-core --lib mcp_tool_call::tests::custom_auto_mode_skips_approval_when_annotations_have_no_hints_in_on_request_mode -- --exact --nocapture`

Manual validation with the patched debug binary:

- `./codex-rs/target/debug/codex exec --json "Use the minimal-regression-repro MCP server and call the ping tool exactly once."`
- `./codex-rs/target/debug/codex exec --json --full-auto "Use the minimal-regression-repro MCP server and call the count tool with to=3."`

Both manual repros completed successfully and returned normal MCP results instead of `user cancelled MCP tool call`.

## Notes

A broader `cargo test -p codex-core` run still hits unrelated existing config test failures around guardian approval defaults on this branch, but the focused MCP regression tests and the manual `exec` repro are green.
