### PR TITLE
fix: address unused variable on windows

### DIFF
--- a/codex-rs/tui/src/tui.rs
+++ b/codex-rs/tui/src/tui.rs
@@ -569,11 +569,10 @@ impl Tui {
                 terminal.invalidate_viewport();
             }
 
-            let area = terminal.viewport_area;
-
             // Update the y position for suspending so Ctrl-Z can place the cursor correctly.
             #[cfg(unix)]
             {
+                let area = terminal.viewport_area;
                 let inline_area_bottom = if self.alt_screen_active.load(Ordering::Relaxed) {
                     self.alt_saved_viewport
                         .map(|r| r.bottom().saturating_sub(1))


### PR DESCRIPTION
This slipped in during https://github.com/openai/codex/pull/16578. I am still working on getting Windows working properly with Bazel on PRs.