### PR TITLE
build: fix Bazel lzma-sys wiring

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -234,13 +234,17 @@ crate.annotation(
 
 inject_repo(crate, "zlib")
 
-# TODO(zbarsky): Enable annotation after fixing windows arm64 builds.
+bazel_dep(name = "xz", version = "5.4.5.bcr.8")
+
 crate.annotation(
     crate = "lzma-sys",
-    gen_build_script = "on",
+    gen_build_script = "off",
+    deps = ["@xz//:lzma"],
 )
 
 bazel_dep(name = "openssl", version = "3.5.4.bcr.0")
+
+inject_repo(crate, "xz")
 
 crate.annotation(
     build_script_data = [

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -228,6 +228,8 @@
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
     "https://bcr.bazel.build/modules/with_cfg.bzl/0.12.0/MODULE.bazel": "b573395fe63aef4299ba095173e2f62ccfee5ad9bbf7acaa95dba73af9fc2b38",
     "https://bcr.bazel.build/modules/with_cfg.bzl/0.12.0/source.json": "3f3fbaeafecaf629877ad152a2c9def21f8d330d91aa94c5dc75bbb98c10b8b8",
+    "https://bcr.bazel.build/modules/xz/5.4.5.bcr.8/MODULE.bazel": "e48a69bd54053c2ec5fffc2a29fb70122afd3e83ab6c07068f63bc6553fa57cc",
+    "https://bcr.bazel.build/modules/xz/5.4.5.bcr.8/source.json": "bd7e928ccd63505b44f4784f7bbf12cc11f9ff23bf3ca12ff2c91cd74846099e",
     "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/MODULE.bazel": "eec517b5bbe5492629466e11dae908d043364302283de25581e3eb944326c4ca",
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.8/MODULE.bazel": "772c674bb78a0342b8caf32ab5c25085c493ca4ff08398208dcbe4375fe9f776",


### PR DESCRIPTION
This seems to be required to fix bazel builds on an applied devbox

## Summary
- add the Bazel `xz` module
- wire `lzma-sys` directly to `@xz//:lzma` and disable its build script
- refresh `MODULE.bazel.lock`

## Validation
- `just bazel-lock-update`
- `just bazel-lock-check`
- `bazel run //codex-rs/cli:codex --run_under="cd $PWD &&" -- --version`
- `just bazel-codex --version`