### PR TITLE
Fix deprecated login --api-key parsing

### DIFF
--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -287,6 +287,8 @@ struct LoginCommand {
 
     #[arg(
         long = "api-key",
+        num_args = 0..=1,
+        default_missing_value = "",
         value_name = "API_KEY",
         help = "(deprecated) Previously accepted the API key directly; now exits with guidance to use --with-api-key",
         hide = true


### PR DESCRIPTION
Addresses #16655

Problem: `codex login --api-key` failed in Clap before Codex could show the deprecation guidance.

Solution: Allow the hidden `--api-key` flag to parse with zero or one values so both forms reach the `--with-api-key` message.
