### PR TITLE
fix: use COMSPEC in Windows unicode shell test

### DIFF
--- a/codex-rs/core/tests/suite/shell_command.rs
+++ b/codex-rs/core/tests/suite/shell_command.rs
@@ -268,7 +268,7 @@ async fn unicode_output(login: bool) -> anyhow::Result<()> {
     // config is actually being set correctly.
     let call_id = "unicode_output";
     let command = if cfg!(windows) {
-        "cmd /c echo naïve_café"
+        "& $env:COMSPEC /c echo naïve_café"
     } else {
         "echo \"naïve_café\""
     };


### PR DESCRIPTION
## Why

Windows Bazel shell tests launch PowerShell with a curated environment, so `PATHEXT` may be absent. The existing `unicode_output` test invokes bare `cmd`, which can fail before the test exercises UTF-8 child-process output.

## What

- Use `$env:COMSPEC /c echo naïve_café` in the Windows branch of `unicode_output`.
- Preserve the external child-process path instead of switching the test to a PowerShell builtin.

## Verification

- `cargo test -p codex-core unicode_output`
