### PR TITLE
Suppress bwrap warning when sandboxing is bypassed

### DIFF
--- a/codex-rs/app-server/src/lib.rs
+++ b/codex-rs/app-server/src/lib.rs
@@ -457,7 +457,9 @@ pub async fn run_main_with_transport(
             range: None,
         });
     }
-    if let Some(warning) = codex_core::config::system_bwrap_warning() {
+    if let Some(warning) =
+        codex_core::config::system_bwrap_warning(config.permissions.sandbox_policy.get())
+    {
         config_warnings.push(ConfigWarningNotification {
             summary: warning,
             details: None,

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -652,9 +652,8 @@ async fn run_exec_session(args: ExecRunArgs) -> anyhow::Result<()> {
     // is using.
     event_processor.print_config_summary(&config, &prompt_summary, &session_configured);
     if !json_mode
-        && let Some(message) = codex_core::config::system_bwrap_warning(
-            config.permissions.sandbox_policy.get(),
-        )
+        && let Some(message) =
+            codex_core::config::system_bwrap_warning(config.permissions.sandbox_policy.get())
     {
         event_processor.process_warning(message);
     }

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -651,7 +651,11 @@ async fn run_exec_session(args: ExecRunArgs) -> anyhow::Result<()> {
     // Print the effective configuration and initial request so users can see what Codex
     // is using.
     event_processor.print_config_summary(&config, &prompt_summary, &session_configured);
-    if !json_mode && let Some(message) = codex_core::config::system_bwrap_warning() {
+    if !json_mode
+        && let Some(message) = codex_core::config::system_bwrap_warning(
+            config.permissions.sandbox_policy.get(),
+        )
+    {
         event_processor.process_warning(message);
     }
 

--- a/codex-rs/sandboxing/src/bwrap.rs
+++ b/codex-rs/sandboxing/src/bwrap.rs
@@ -1,10 +1,22 @@
+use codex_protocol::protocol::SandboxPolicy;
 use std::path::Path;
 use std::path::PathBuf;
 
 const SYSTEM_BWRAP_PROGRAM: &str = "bwrap";
 
-pub fn system_bwrap_warning() -> Option<String> {
+pub fn system_bwrap_warning(sandbox_policy: &SandboxPolicy) -> Option<String> {
+    if !should_warn_about_system_bwrap(sandbox_policy) {
+        return None;
+    }
+
     system_bwrap_warning_for_lookup(find_system_bwrap_in_path())
+}
+
+fn should_warn_about_system_bwrap(sandbox_policy: &SandboxPolicy) -> bool {
+    !matches!(
+        sandbox_policy,
+        SandboxPolicy::DangerFullAccess | SandboxPolicy::ExternalSandbox { .. }
+    )
 }
 
 fn system_bwrap_warning_for_lookup(system_bwrap_path: Option<PathBuf>) -> Option<String> {

--- a/codex-rs/sandboxing/src/lib.rs
+++ b/codex-rs/sandboxing/src/lib.rs
@@ -20,6 +20,8 @@ pub use manager::SandboxablePreference;
 pub use manager::get_platform_sandbox;
 
 #[cfg(not(target_os = "linux"))]
-pub fn system_bwrap_warning() -> Option<String> {
+pub fn system_bwrap_warning(
+    _sandbox_policy: &codex_protocol::protocol::SandboxPolicy,
+) -> Option<String> {
     None
 }

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -470,8 +470,10 @@ fn emit_project_config_warnings(app_event_tx: &AppEventSender, config: &Config) 
     )));
 }
 
-fn emit_system_bwrap_warning(app_event_tx: &AppEventSender) {
-    let Some(message) = codex_core::config::system_bwrap_warning() else {
+fn emit_system_bwrap_warning(app_event_tx: &AppEventSender, config: &Config) {
+    let Some(message) =
+        codex_core::config::system_bwrap_warning(config.permissions.sandbox_policy.get())
+    else {
         return;
     };
 
@@ -3564,7 +3566,7 @@ impl App {
         let (app_event_tx, mut app_event_rx) = unbounded_channel();
         let app_event_tx = AppEventSender::new(app_event_tx);
         emit_project_config_warnings(&app_event_tx, &config);
-        emit_system_bwrap_warning(&app_event_tx);
+        emit_system_bwrap_warning(&app_event_tx, &config);
         tui.set_notification_method(config.tui_notification_method);
 
         let harness_overrides =


### PR DESCRIPTION
Addresses #15282

Problem: Codex warned about missing system bubblewrap even when sandboxing was disabled.

Solution: Gate the bwrap warning on the active sandbox policy and skip it for danger-full-access and external-sandbox modes.
