### PR TITLE
fix: use cmd.exe in Windows unicode shell test

### DIFF
--- a/codex-rs/core/tests/suite/shell_command.rs
+++ b/codex-rs/core/tests/suite/shell_command.rs
@@ -268,7 +268,7 @@ async fn unicode_output(login: bool) -> anyhow::Result<()> {
     // config is actually being set correctly.
     let call_id = "unicode_output";
     let command = if cfg!(windows) {
-        "& $env:COMSPEC /c echo naïve_café"
+        "cmd.exe /c echo naïve_café"
     } else {
         "echo \"naïve_café\""
     };


### PR DESCRIPTION
## Why

This is a follow-up to #16665. The Windows `unicode_output` test should still exercise a child process so it verifies PowerShell's UTF-8 output configuration, but `$env:COMSPEC` depends on that environment variable surviving the curated Bazel test environment.

Using `cmd.exe` keeps the child-process coverage while avoiding both bare `cmd` + `PATHEXT` lookup and `$env:COMSPEC` env passthrough assumptions.

## What

- Run `cmd.exe /c echo naïve_café` in the Windows branch of `unicode_output`.

## Verification

- `cargo test -p codex-core unicode_output`
