### PR TITLE
Sanitize forked child history

### DIFF
--- a/codex-rs/core/src/agent/control.rs
+++ b/codex-rs/core/src/agent/control.rs
@@ -94,17 +94,10 @@ fn agent_nickname_candidates(
 
 fn keep_forked_rollout_item(item: &RolloutItem) -> bool {
     match item {
-        RolloutItem::ResponseItem(ResponseItem::Message {
-            role,
-            content,
-            phase,
-            ..
-        }) => match role.as_str() {
+        RolloutItem::ResponseItem(ResponseItem::Message { role, phase, .. }) => match role.as_str()
+        {
             "system" | "developer" | "user" => true,
-            "assistant" => {
-                *phase == Some(MessagePhase::FinalAnswer)
-                    && !InterAgentCommunication::is_message_content(content)
-            }
+            "assistant" => *phase == Some(MessagePhase::FinalAnswer),
             _ => false,
         },
         RolloutItem::ResponseItem(_) => false,

--- a/codex-rs/core/src/agent/control.rs
+++ b/codex-rs/core/src/agent/control.rs
@@ -18,7 +18,7 @@ use codex_protocol::AgentPath;
 use codex_protocol::ThreadId;
 use codex_protocol::error::CodexErr;
 use codex_protocol::error::Result as CodexResult;
-use codex_protocol::models::FunctionCallOutputPayload;
+use codex_protocol::models::MessagePhase;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::protocol::InitialHistory;
 use codex_protocol::protocol::InterAgentCommunication;
@@ -39,7 +39,6 @@ use tokio::sync::watch;
 use tracing::warn;
 
 const AGENT_NAMES: &str = include_str!("agent_names.txt");
-const FORKED_SPAWN_AGENT_OUTPUT_MESSAGE: &str = "You are the newly spawned agent. The prior conversation history was forked from your parent agent. Treat the next user message as your new task, and use the forked history only as background context.";
 const ROOT_LAST_TASK_MESSAGE: &str = "Main thread";
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -91,6 +90,29 @@ fn agent_nickname_candidates(
         .into_iter()
         .map(ToOwned::to_owned)
         .collect()
+}
+
+fn keep_forked_rollout_item(item: &RolloutItem) -> bool {
+    match item {
+        RolloutItem::ResponseItem(ResponseItem::Message {
+            role,
+            content,
+            phase,
+            ..
+        }) => match role.as_str() {
+            "system" | "developer" | "user" => true,
+            "assistant" => {
+                *phase == Some(MessagePhase::FinalAnswer)
+                    && !InterAgentCommunication::is_message_content(content)
+            }
+            _ => false,
+        },
+        RolloutItem::ResponseItem(_) => false,
+        RolloutItem::Compacted(_)
+        | RolloutItem::EventMsg(_)
+        | RolloutItem::SessionMeta(_)
+        | RolloutItem::TurnContext(_) => true,
+    }
 }
 
 /// Control-plane handle for multi-agent operations.
@@ -260,11 +282,11 @@ impl AgentControl {
         inherited_shell_snapshot: Option<Arc<ShellSnapshot>>,
         inherited_exec_policy: Option<Arc<crate::exec_policy::ExecPolicyManager>>,
     ) -> CodexResult<crate::thread_manager::NewThread> {
-        let Some(call_id) = options.fork_parent_spawn_call_id.as_deref() else {
+        if options.fork_parent_spawn_call_id.is_none() {
             return Err(CodexErr::Fatal(
                 "spawn_agent fork requires a parent spawn call id".to_string(),
             ));
-        };
+        }
         let Some(fork_mode) = options.fork_mode.as_ref() else {
             return Err(CodexErr::Fatal(
                 "spawn_agent fork requires a fork mode".to_string(),
@@ -313,16 +335,7 @@ impl AgentControl {
             forked_rollout_items =
                 truncate_rollout_to_last_n_fork_turns(&forked_rollout_items, *last_n_turns);
         }
-
-        let mut output =
-            FunctionCallOutputPayload::from_text(FORKED_SPAWN_AGENT_OUTPUT_MESSAGE.to_string());
-        output.success = Some(true);
-        forked_rollout_items.push(RolloutItem::ResponseItem(
-            ResponseItem::FunctionCallOutput {
-                call_id: call_id.to_string(),
-                output,
-            },
-        ));
+        forked_rollout_items.retain(keep_forked_rollout_item);
 
         state
             .fork_thread_with_source(

--- a/codex-rs/core/src/agent/control.rs
+++ b/codex-rs/core/src/agent/control.rs
@@ -100,7 +100,21 @@ fn keep_forked_rollout_item(item: &RolloutItem) -> bool {
             "assistant" => *phase == Some(MessagePhase::FinalAnswer),
             _ => false,
         },
-        RolloutItem::ResponseItem(_) => false,
+        RolloutItem::ResponseItem(
+            ResponseItem::Reasoning { .. }
+            | ResponseItem::LocalShellCall { .. }
+            | ResponseItem::FunctionCall { .. }
+            | ResponseItem::ToolSearchCall { .. }
+            | ResponseItem::FunctionCallOutput { .. }
+            | ResponseItem::CustomToolCall { .. }
+            | ResponseItem::CustomToolCallOutput { .. }
+            | ResponseItem::ToolSearchOutput { .. }
+            | ResponseItem::WebSearchCall { .. }
+            | ResponseItem::ImageGenerationCall { .. }
+            | ResponseItem::GhostSnapshot { .. }
+            | ResponseItem::Compaction { .. }
+            | ResponseItem::Other,
+        ) => false,
         RolloutItem::Compacted(_)
         | RolloutItem::EventMsg(_)
         | RolloutItem::SessionMeta(_)

--- a/codex-rs/core/src/agent/control_tests.rs
+++ b/codex-rs/core/src/agent/control_tests.rs
@@ -14,6 +14,7 @@ use codex_login::CodexAuth;
 use codex_protocol::AgentPath;
 use codex_protocol::config_types::ModeKind;
 use codex_protocol::models::ContentItem;
+use codex_protocol::models::MessagePhase;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::protocol::ErrorEvent;
 use codex_protocol::protocol::EventMsg;
@@ -60,6 +61,37 @@ fn text_input(text: &str) -> Op {
         text_elements: Vec::new(),
     }]
     .into()
+}
+
+fn assistant_message(text: &str, phase: Option<MessagePhase>) -> ResponseItem {
+    ResponseItem::Message {
+        id: None,
+        role: "assistant".to_string(),
+        content: vec![ContentItem::OutputText {
+            text: text.to_string(),
+        }],
+        end_turn: None,
+        phase,
+    }
+}
+
+fn reasoning_item(id: &str) -> ResponseItem {
+    ResponseItem::Reasoning {
+        id: id.to_string(),
+        summary: Vec::new(),
+        content: None,
+        encrypted_content: None,
+    }
+}
+
+fn spawn_agent_call(call_id: &str) -> ResponseItem {
+    ResponseItem::FunctionCall {
+        id: None,
+        name: "spawn_agent".to_string(),
+        namespace: None,
+        arguments: "{}".to_string(),
+        call_id: call_id.to_string(),
+    }
 }
 
 struct AgentControlHarness {
@@ -151,6 +183,42 @@ fn history_contains_assistant_inter_agent_communication(
             }
             ContentItem::InputText { .. } | ContentItem::InputImage { .. } => false,
         })
+    })
+}
+
+fn history_contains_function_call(history_items: &[ResponseItem], call_id: &str) -> bool {
+    history_items.iter().any(|item| {
+        matches!(
+            item,
+            ResponseItem::FunctionCall {
+                call_id: item_call_id,
+                ..
+            } if item_call_id == call_id
+        )
+    })
+}
+
+fn history_contains_function_call_output(history_items: &[ResponseItem], call_id: &str) -> bool {
+    history_items.iter().any(|item| {
+        matches!(
+            item,
+            ResponseItem::FunctionCallOutput {
+                call_id: item_call_id,
+                ..
+            } if item_call_id == call_id
+        )
+    })
+}
+
+fn history_contains_reasoning_item(history_items: &[ResponseItem], id: &str) -> bool {
+    history_items.iter().any(|item| {
+        matches!(
+            item,
+            ResponseItem::Reasoning {
+                id: item_id,
+                ..
+            } if item_id == id
+        )
     })
 }
 
@@ -561,7 +629,7 @@ async fn spawn_agent_creates_thread_and_sends_prompt() {
 }
 
 #[tokio::test]
-async fn spawn_agent_can_fork_parent_thread_history() {
+async fn spawn_agent_can_fork_parent_thread_history_with_sanitized_items() {
     let harness = AgentControlHarness::new().await;
     let (parent_thread_id, parent_thread) = harness.start_thread().await;
     parent_thread
@@ -569,17 +637,27 @@ async fn spawn_agent_can_fork_parent_thread_history() {
         .await;
     let turn_context = parent_thread.codex.session.new_default_turn().await;
     let parent_spawn_call_id = "spawn-call-history".to_string();
-    let parent_spawn_call = ResponseItem::FunctionCall {
-        id: None,
-        name: "spawn_agent".to_string(),
-        namespace: None,
-        arguments: "{}".to_string(),
-        call_id: parent_spawn_call_id.clone(),
-    };
+    let trigger_message = InterAgentCommunication::new(
+        AgentPath::root(),
+        AgentPath::try_from("/root/worker").expect("agent path"),
+        Vec::new(),
+        "parent trigger message".to_string(),
+        /*trigger_turn*/ true,
+    );
     parent_thread
         .codex
         .session
-        .record_conversation_items(turn_context.as_ref(), &[parent_spawn_call])
+        .record_conversation_items(
+            turn_context.as_ref(),
+            &[
+                assistant_message("parent commentary", Some(MessagePhase::Commentary)),
+                assistant_message("parent final answer", Some(MessagePhase::FinalAnswer)),
+                assistant_message("parent unknown phase", /*phase*/ None),
+                reasoning_item("parent-reasoning"),
+                trigger_message.to_response_input_item().into(),
+                spawn_agent_call(&parent_spawn_call_id),
+            ],
+        )
         .await;
     parent_thread
         .codex
@@ -620,6 +698,34 @@ async fn spawn_agent_can_fork_parent_thread_history() {
         history.raw_items(),
         "parent seed context"
     ));
+    assert!(history_contains_text(
+        history.raw_items(),
+        "parent final answer"
+    ));
+    assert!(!history_contains_text(
+        history.raw_items(),
+        "parent commentary"
+    ));
+    assert!(!history_contains_text(
+        history.raw_items(),
+        "parent unknown phase"
+    ));
+    assert!(!history_contains_reasoning_item(
+        history.raw_items(),
+        "parent-reasoning"
+    ));
+    assert!(!history_contains_assistant_inter_agent_communication(
+        history.raw_items(),
+        &trigger_message
+    ));
+    assert!(!history_contains_function_call(
+        history.raw_items(),
+        &parent_spawn_call_id
+    ));
+    assert!(!history_contains_function_call_output(
+        history.raw_items(),
+        &parent_spawn_call_id
+    ));
 
     let expected = (
         child_thread_id,
@@ -650,22 +756,18 @@ async fn spawn_agent_can_fork_parent_thread_history() {
 }
 
 #[tokio::test]
-async fn spawn_agent_fork_injects_output_for_parent_spawn_call() {
+async fn spawn_agent_fork_strips_parent_spawn_call_without_injecting_output() {
     let harness = AgentControlHarness::new().await;
     let (parent_thread_id, parent_thread) = harness.start_thread().await;
     let turn_context = parent_thread.codex.session.new_default_turn().await;
     let parent_spawn_call_id = "spawn-call-1".to_string();
-    let parent_spawn_call = ResponseItem::FunctionCall {
-        id: None,
-        name: "spawn_agent".to_string(),
-        namespace: None,
-        arguments: "{}".to_string(),
-        call_id: parent_spawn_call_id.clone(),
-    };
     parent_thread
         .codex
         .session
-        .record_conversation_items(turn_context.as_ref(), &[parent_spawn_call])
+        .record_conversation_items(
+            turn_context.as_ref(),
+            &[spawn_agent_call(&parent_spawn_call_id)],
+        )
         .await;
     parent_thread
         .codex
@@ -701,21 +803,14 @@ async fn spawn_agent_fork_injects_output_for_parent_spawn_call() {
         .await
         .expect("child thread should be registered");
     let history = child_thread.codex.session.clone_history().await;
-    let injected_output = history.raw_items().iter().find_map(|item| match item {
-        ResponseItem::FunctionCallOutput { call_id, output }
-            if call_id == &parent_spawn_call_id =>
-        {
-            Some(output)
-        }
-        _ => None,
-    });
-    let injected_output =
-        injected_output.expect("forked child should contain synthetic tool output");
-    assert_eq!(
-        injected_output.text_content(),
-        Some(FORKED_SPAWN_AGENT_OUTPUT_MESSAGE)
-    );
-    assert_eq!(injected_output.success, Some(true));
+    assert!(!history_contains_function_call(
+        history.raw_items(),
+        &parent_spawn_call_id
+    ));
+    assert!(!history_contains_function_call_output(
+        history.raw_items(),
+        &parent_spawn_call_id
+    ));
 
     let _ = harness
         .control
@@ -734,17 +829,16 @@ async fn spawn_agent_fork_flushes_parent_rollout_before_loading_history() {
     let (parent_thread_id, parent_thread) = harness.start_thread().await;
     let turn_context = parent_thread.codex.session.new_default_turn().await;
     let parent_spawn_call_id = "spawn-call-unflushed".to_string();
-    let parent_spawn_call = ResponseItem::FunctionCall {
-        id: None,
-        name: "spawn_agent".to_string(),
-        namespace: None,
-        arguments: "{}".to_string(),
-        call_id: parent_spawn_call_id.clone(),
-    };
     parent_thread
         .codex
         .session
-        .record_conversation_items(turn_context.as_ref(), &[parent_spawn_call])
+        .record_conversation_items(
+            turn_context.as_ref(),
+            &[
+                assistant_message("unflushed final answer", Some(MessagePhase::FinalAnswer)),
+                spawn_agent_call(&parent_spawn_call_id),
+            ],
+        )
         .await;
 
     let child_thread_id = harness
@@ -775,27 +869,18 @@ async fn spawn_agent_fork_flushes_parent_rollout_before_loading_history() {
         .expect("child thread should be registered");
     let history = child_thread.codex.session.clone_history().await;
 
-    let mut parent_call_index = None;
-    let mut injected_output_index = None;
-    for (idx, item) in history.raw_items().iter().enumerate() {
-        match item {
-            ResponseItem::FunctionCall { call_id, .. } if call_id == &parent_spawn_call_id => {
-                parent_call_index = Some(idx);
-            }
-            ResponseItem::FunctionCallOutput { call_id, .. }
-                if call_id == &parent_spawn_call_id =>
-            {
-                injected_output_index = Some(idx);
-            }
-            _ => {}
-        }
-    }
-
-    let parent_call_index =
-        parent_call_index.expect("forked child should include the parent spawn_agent call");
-    let injected_output_index = injected_output_index
-        .expect("forked child should include synthetic output for the parent spawn_agent call");
-    assert!(parent_call_index < injected_output_index);
+    assert!(history_contains_text(
+        history.raw_items(),
+        "unflushed final answer"
+    ));
+    assert!(!history_contains_function_call(
+        history.raw_items(),
+        &parent_spawn_call_id
+    ));
+    assert!(!history_contains_function_call_output(
+        history.raw_items(),
+        &parent_spawn_call_id
+    ));
 
     let _ = harness
         .control
@@ -849,23 +934,32 @@ async fn spawn_agent_fork_last_n_turns_keeps_only_recent_turns() {
             &[triggered_communication.to_response_input_item().into()],
         )
         .await;
+    let commentary_turn_context = parent_thread.codex.session.new_default_turn().await;
+    parent_thread
+        .codex
+        .session
+        .record_conversation_items(
+            commentary_turn_context.as_ref(),
+            &[
+                assistant_message("recent commentary", Some(MessagePhase::Commentary)),
+                assistant_message("recent final answer", Some(MessagePhase::FinalAnswer)),
+                reasoning_item("recent-reasoning"),
+            ],
+        )
+        .await;
 
     parent_thread
         .inject_user_message_without_turn("current parent task".to_string())
         .await;
     let spawn_turn_context = parent_thread.codex.session.new_default_turn().await;
     let parent_spawn_call_id = "spawn-call-last-n".to_string();
-    let parent_spawn_call = ResponseItem::FunctionCall {
-        id: None,
-        name: "spawn_agent".to_string(),
-        namespace: None,
-        arguments: "{}".to_string(),
-        call_id: parent_spawn_call_id.clone(),
-    };
     parent_thread
         .codex
         .session
-        .record_conversation_items(spawn_turn_context.as_ref(), &[parent_spawn_call])
+        .record_conversation_items(
+            spawn_turn_context.as_ref(),
+            &[spawn_agent_call(&parent_spawn_call_id)],
+        )
         .await;
     parent_thread
         .codex
@@ -910,13 +1004,29 @@ async fn spawn_agent_fork_last_n_turns_keeps_only_recent_turns() {
         history.raw_items(),
         "queued message"
     ));
-    assert!(history_contains_text(
+    assert!(!history_contains_text(
         history.raw_items(),
         "triggered context"
     ));
     assert!(history_contains_text(
         history.raw_items(),
         "current parent task"
+    ));
+    assert!(history_contains_text(
+        history.raw_items(),
+        "recent final answer"
+    ));
+    assert!(!history_contains_text(
+        history.raw_items(),
+        "recent commentary"
+    ));
+    assert!(!history_contains_reasoning_item(
+        history.raw_items(),
+        "recent-reasoning"
+    ));
+    assert!(!history_contains_function_call(
+        history.raw_items(),
+        &parent_spawn_call_id
     ));
 
     let _ = harness

--- a/codex-rs/core/src/agent/control_tests.rs
+++ b/codex-rs/core/src/agent/control_tests.rs
@@ -75,6 +75,18 @@ fn assistant_message(text: &str, phase: Option<MessagePhase>) -> ResponseItem {
     }
 }
 
+fn user_message(text: &str) -> ResponseItem {
+    ResponseItem::Message {
+        id: None,
+        role: "user".to_string(),
+        content: vec![ContentItem::InputText {
+            text: text.to_string(),
+        }],
+        end_turn: None,
+        phase: None,
+    }
+}
+
 fn reasoning_item(id: &str) -> ResponseItem {
     ResponseItem::Reasoning {
         id: id.to_string(),
@@ -183,42 +195,6 @@ fn history_contains_assistant_inter_agent_communication(
             }
             ContentItem::InputText { .. } | ContentItem::InputImage { .. } => false,
         })
-    })
-}
-
-fn history_contains_function_call(history_items: &[ResponseItem], call_id: &str) -> bool {
-    history_items.iter().any(|item| {
-        matches!(
-            item,
-            ResponseItem::FunctionCall {
-                call_id: item_call_id,
-                ..
-            } if item_call_id == call_id
-        )
-    })
-}
-
-fn history_contains_function_call_output(history_items: &[ResponseItem], call_id: &str) -> bool {
-    history_items.iter().any(|item| {
-        matches!(
-            item,
-            ResponseItem::FunctionCallOutput {
-                call_id: item_call_id,
-                ..
-            } if item_call_id == call_id
-        )
-    })
-}
-
-fn history_contains_reasoning_item(history_items: &[ResponseItem], id: &str) -> bool {
-    history_items.iter().any(|item| {
-        matches!(
-            item,
-            ResponseItem::Reasoning {
-                id: item_id,
-                ..
-            } if item_id == id
-        )
     })
 }
 
@@ -694,38 +670,11 @@ async fn spawn_agent_can_fork_parent_thread_history_with_sanitized_items() {
         .expect("child thread should be registered");
     assert_ne!(child_thread_id, parent_thread_id);
     let history = child_thread.codex.session.clone_history().await;
-    assert!(history_contains_text(
-        history.raw_items(),
-        "parent seed context"
-    ));
-    assert!(history_contains_text(
-        history.raw_items(),
-        "parent final answer"
-    ));
-    assert!(!history_contains_text(
-        history.raw_items(),
-        "parent commentary"
-    ));
-    assert!(!history_contains_text(
-        history.raw_items(),
-        "parent unknown phase"
-    ));
-    assert!(!history_contains_reasoning_item(
-        history.raw_items(),
-        "parent-reasoning"
-    ));
-    assert!(!history_contains_assistant_inter_agent_communication(
-        history.raw_items(),
-        &trigger_message
-    ));
-    assert!(!history_contains_function_call(
-        history.raw_items(),
-        &parent_spawn_call_id
-    ));
-    assert!(!history_contains_function_call_output(
-        history.raw_items(),
-        &parent_spawn_call_id
-    ));
+    let expected_history = [
+        user_message("parent seed context"),
+        assistant_message("parent final answer", Some(MessagePhase::FinalAnswer)),
+    ];
+    assert_eq!(history.raw_items(), &expected_history);
 
     let expected = (
         child_thread_id,
@@ -803,14 +752,8 @@ async fn spawn_agent_fork_strips_parent_spawn_call_without_injecting_output() {
         .await
         .expect("child thread should be registered");
     let history = child_thread.codex.session.clone_history().await;
-    assert!(!history_contains_function_call(
-        history.raw_items(),
-        &parent_spawn_call_id
-    ));
-    assert!(!history_contains_function_call_output(
-        history.raw_items(),
-        &parent_spawn_call_id
-    ));
+    let expected_history: &[ResponseItem] = &[];
+    assert_eq!(history.raw_items(), expected_history);
 
     let _ = harness
         .control
@@ -868,19 +811,11 @@ async fn spawn_agent_fork_flushes_parent_rollout_before_loading_history() {
         .await
         .expect("child thread should be registered");
     let history = child_thread.codex.session.clone_history().await;
-
-    assert!(history_contains_text(
-        history.raw_items(),
-        "unflushed final answer"
-    ));
-    assert!(!history_contains_function_call(
-        history.raw_items(),
-        &parent_spawn_call_id
-    ));
-    assert!(!history_contains_function_call_output(
-        history.raw_items(),
-        &parent_spawn_call_id
-    ));
+    let expected_history = [assistant_message(
+        "unflushed final answer",
+        Some(MessagePhase::FinalAnswer),
+    )];
+    assert_eq!(history.raw_items(), &expected_history);
 
     let _ = harness
         .control
@@ -995,39 +930,11 @@ async fn spawn_agent_fork_last_n_turns_keeps_only_recent_turns() {
         .await
         .expect("child thread should be registered");
     let history = child_thread.codex.session.clone_history().await;
-
-    assert!(!history_contains_text(
-        history.raw_items(),
-        "old parent context"
-    ));
-    assert!(!history_contains_text(
-        history.raw_items(),
-        "queued message"
-    ));
-    assert!(!history_contains_text(
-        history.raw_items(),
-        "triggered context"
-    ));
-    assert!(history_contains_text(
-        history.raw_items(),
-        "current parent task"
-    ));
-    assert!(history_contains_text(
-        history.raw_items(),
-        "recent final answer"
-    ));
-    assert!(!history_contains_text(
-        history.raw_items(),
-        "recent commentary"
-    ));
-    assert!(!history_contains_reasoning_item(
-        history.raw_items(),
-        "recent-reasoning"
-    ));
-    assert!(!history_contains_function_call(
-        history.raw_items(),
-        &parent_spawn_call_id
-    ));
+    let expected_history = [
+        assistant_message("recent final answer", Some(MessagePhase::FinalAnswer)),
+        user_message("current parent task"),
+    ];
+    assert_eq!(history.raw_items(), &expected_history);
 
     let _ = harness
         .control

--- a/codex-rs/core/src/agent/control_tests.rs
+++ b/codex-rs/core/src/agent/control_tests.rs
@@ -679,7 +679,7 @@ async fn spawn_agent_can_fork_parent_thread_history_with_sanitized_items() {
                 agent_role: None,
             })),
             SpawnAgentOptions {
-                fork_parent_spawn_call_id: Some(parent_spawn_call_id),
+                fork_parent_spawn_call_id: Some(parent_spawn_call_id.clone()),
                 fork_mode: Some(SpawnAgentForkMode::FullHistory),
             },
         )
@@ -981,7 +981,7 @@ async fn spawn_agent_fork_last_n_turns_keeps_only_recent_turns() {
                 agent_role: None,
             })),
             SpawnAgentOptions {
-                fork_parent_spawn_call_id: Some(parent_spawn_call_id),
+                fork_parent_spawn_call_id: Some(parent_spawn_call_id.clone()),
                 fork_mode: Some(SpawnAgentForkMode::LastNTurns(2)),
             },
         )

--- a/codex-rs/core/src/agent/control_tests.rs
+++ b/codex-rs/core/src/agent/control_tests.rs
@@ -666,7 +666,11 @@ async fn spawn_agent_can_fork_parent_thread_history_with_sanitized_items() {
         },
         assistant_message("parent final answer", Some(MessagePhase::FinalAnswer)),
     ];
-    assert_eq!(history.raw_items(), &expected_history);
+    assert_eq!(
+        history.raw_items(),
+        &expected_history,
+        "forked child history should keep only parent user messages and assistant final answers"
+    );
 
     let expected = (
         child_thread_id,
@@ -741,10 +745,10 @@ async fn spawn_agent_fork_flushes_parent_rollout_before_loading_history() {
         .await
         .expect("child thread should be registered");
     let history = child_thread.codex.session.clone_history().await;
-    assert!(history_contains_text(
-        history.raw_items(),
-        "unflushed final answer"
-    ));
+    assert!(
+        history_contains_text(history.raw_items(), "unflushed final answer"),
+        "forked child history should include unflushed assistant final answers after flushing the parent rollout"
+    );
 
     let _ = harness
         .control
@@ -846,22 +850,22 @@ async fn spawn_agent_fork_last_n_turns_keeps_only_recent_turns() {
         .expect("child thread should be registered");
     let history = child_thread.codex.session.clone_history().await;
 
-    assert!(!history_contains_text(
-        history.raw_items(),
-        "old parent context"
-    ));
-    assert!(!history_contains_text(
-        history.raw_items(),
-        "queued message"
-    ));
-    assert!(!history_contains_text(
-        history.raw_items(),
-        "triggered context"
-    ));
-    assert!(history_contains_text(
-        history.raw_items(),
-        "current parent task"
-    ));
+    assert!(
+        !history_contains_text(history.raw_items(), "old parent context"),
+        "forked child history should drop parent context outside the requested last-N turn window"
+    );
+    assert!(
+        !history_contains_text(history.raw_items(), "queued message"),
+        "forked child history should drop queued inter-agent messages outside the requested last-N turn window"
+    );
+    assert!(
+        !history_contains_text(history.raw_items(), "triggered context"),
+        "forked child history should filter assistant inter-agent messages even when they fall inside the requested last-N turn window"
+    );
+    assert!(
+        history_contains_text(history.raw_items(), "current parent task"),
+        "forked child history should keep the parent user message from the requested last-N turn window"
+    );
 
     let _ = harness
         .control

--- a/codex-rs/core/src/agent/control_tests.rs
+++ b/codex-rs/core/src/agent/control_tests.rs
@@ -75,27 +75,6 @@ fn assistant_message(text: &str, phase: Option<MessagePhase>) -> ResponseItem {
     }
 }
 
-fn user_message(text: &str) -> ResponseItem {
-    ResponseItem::Message {
-        id: None,
-        role: "user".to_string(),
-        content: vec![ContentItem::InputText {
-            text: text.to_string(),
-        }],
-        end_turn: None,
-        phase: None,
-    }
-}
-
-fn reasoning_item(id: &str) -> ResponseItem {
-    ResponseItem::Reasoning {
-        id: id.to_string(),
-        summary: Vec::new(),
-        content: None,
-        encrypted_content: None,
-    }
-}
-
 fn spawn_agent_call(call_id: &str) -> ResponseItem {
     ResponseItem::FunctionCall {
         id: None,
@@ -629,7 +608,12 @@ async fn spawn_agent_can_fork_parent_thread_history_with_sanitized_items() {
                 assistant_message("parent commentary", Some(MessagePhase::Commentary)),
                 assistant_message("parent final answer", Some(MessagePhase::FinalAnswer)),
                 assistant_message("parent unknown phase", /*phase*/ None),
-                reasoning_item("parent-reasoning"),
+                ResponseItem::Reasoning {
+                    id: "parent-reasoning".to_string(),
+                    summary: Vec::new(),
+                    content: None,
+                    encrypted_content: None,
+                },
                 trigger_message.to_response_input_item().into(),
                 spawn_agent_call(&parent_spawn_call_id),
             ],
@@ -671,7 +655,15 @@ async fn spawn_agent_can_fork_parent_thread_history_with_sanitized_items() {
     assert_ne!(child_thread_id, parent_thread_id);
     let history = child_thread.codex.session.clone_history().await;
     let expected_history = [
-        user_message("parent seed context"),
+        ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![ContentItem::InputText {
+                text: "parent seed context".to_string(),
+            }],
+            end_turn: None,
+            phase: None,
+        },
         assistant_message("parent final answer", Some(MessagePhase::FinalAnswer)),
     ];
     assert_eq!(history.raw_items(), &expected_history);
@@ -692,68 +684,6 @@ async fn spawn_agent_can_fork_parent_thread_history_with_sanitized_items() {
         .into_iter()
         .find(|entry| *entry == expected);
     assert_eq!(captured, Some(expected));
-
-    let _ = harness
-        .control
-        .shutdown_live_agent(child_thread_id)
-        .await
-        .expect("child shutdown should submit");
-    let _ = parent_thread
-        .submit(Op::Shutdown {})
-        .await
-        .expect("parent shutdown should submit");
-}
-
-#[tokio::test]
-async fn spawn_agent_fork_strips_parent_spawn_call_without_injecting_output() {
-    let harness = AgentControlHarness::new().await;
-    let (parent_thread_id, parent_thread) = harness.start_thread().await;
-    let turn_context = parent_thread.codex.session.new_default_turn().await;
-    let parent_spawn_call_id = "spawn-call-1".to_string();
-    parent_thread
-        .codex
-        .session
-        .record_conversation_items(
-            turn_context.as_ref(),
-            &[spawn_agent_call(&parent_spawn_call_id)],
-        )
-        .await;
-    parent_thread
-        .codex
-        .session
-        .ensure_rollout_materialized()
-        .await;
-    parent_thread.codex.session.flush_rollout().await;
-
-    let child_thread_id = harness
-        .control
-        .spawn_agent_with_metadata(
-            harness.config.clone(),
-            text_input("child task"),
-            Some(SessionSource::SubAgent(SubAgentSource::ThreadSpawn {
-                parent_thread_id,
-                depth: 1,
-                agent_path: None,
-                agent_nickname: None,
-                agent_role: None,
-            })),
-            SpawnAgentOptions {
-                fork_parent_spawn_call_id: Some(parent_spawn_call_id.clone()),
-                fork_mode: Some(SpawnAgentForkMode::FullHistory),
-            },
-        )
-        .await
-        .expect("forked spawn should succeed")
-        .thread_id;
-
-    let child_thread = harness
-        .manager
-        .get_thread(child_thread_id)
-        .await
-        .expect("child thread should be registered");
-    let history = child_thread.codex.session.clone_history().await;
-    let expected_history: &[ResponseItem] = &[];
-    assert_eq!(history.raw_items(), expected_history);
 
     let _ = harness
         .control
@@ -811,11 +741,10 @@ async fn spawn_agent_fork_flushes_parent_rollout_before_loading_history() {
         .await
         .expect("child thread should be registered");
     let history = child_thread.codex.session.clone_history().await;
-    let expected_history = [assistant_message(
-        "unflushed final answer",
-        Some(MessagePhase::FinalAnswer),
-    )];
-    assert_eq!(history.raw_items(), &expected_history);
+    assert!(history_contains_text(
+        history.raw_items(),
+        "unflushed final answer"
+    ));
 
     let _ = harness
         .control
@@ -869,20 +798,6 @@ async fn spawn_agent_fork_last_n_turns_keeps_only_recent_turns() {
             &[triggered_communication.to_response_input_item().into()],
         )
         .await;
-    let commentary_turn_context = parent_thread.codex.session.new_default_turn().await;
-    parent_thread
-        .codex
-        .session
-        .record_conversation_items(
-            commentary_turn_context.as_ref(),
-            &[
-                assistant_message("recent commentary", Some(MessagePhase::Commentary)),
-                assistant_message("recent final answer", Some(MessagePhase::FinalAnswer)),
-                reasoning_item("recent-reasoning"),
-            ],
-        )
-        .await;
-
     parent_thread
         .inject_user_message_without_turn("current parent task".to_string())
         .await;
@@ -930,11 +845,23 @@ async fn spawn_agent_fork_last_n_turns_keeps_only_recent_turns() {
         .await
         .expect("child thread should be registered");
     let history = child_thread.codex.session.clone_history().await;
-    let expected_history = [
-        assistant_message("recent final answer", Some(MessagePhase::FinalAnswer)),
-        user_message("current parent task"),
-    ];
-    assert_eq!(history.raw_items(), &expected_history);
+
+    assert!(!history_contains_text(
+        history.raw_items(),
+        "old parent context"
+    ));
+    assert!(!history_contains_text(
+        history.raw_items(),
+        "queued message"
+    ));
+    assert!(!history_contains_text(
+        history.raw_items(),
+        "triggered context"
+    ));
+    assert!(history_contains_text(
+        history.raw_items(),
+        "current parent task"
+    ));
 
     let _ = harness
         .control

--- a/codex-rs/core/tests/suite/subagent_notifications.rs
+++ b/codex-rs/core/tests/suite/subagent_notifications.rs
@@ -382,7 +382,6 @@ async fn spawned_child_receives_forked_parent_context() -> Result<()> {
         sleep(Duration::from_millis(10)).await;
     };
     assert!(body_contains(&child_request, TURN_0_FORK_PROMPT));
-    assert!(body_contains(&child_request, "seeded"));
     assert!(!body_contains(&child_request, SPAWN_CALL_ID));
 
     Ok(())

--- a/codex-rs/core/tests/suite/subagent_notifications.rs
+++ b/codex-rs/core/tests/suite/subagent_notifications.rs
@@ -25,7 +25,6 @@ use tokio::time::sleep;
 use wiremock::MockServer;
 
 const SPAWN_CALL_ID: &str = "spawn-call-1";
-const FORKED_SPAWN_AGENT_OUTPUT_MESSAGE: &str = "You are the newly spawned agent. The prior conversation history was forked from your parent agent. Treat the next user message as your new task, and use the forked history only as background context.";
 const TURN_0_FORK_PROMPT: &str = "seed fork context";
 const TURN_1_PROMPT: &str = "spawn a child and continue";
 const TURN_2_NO_WAIT_PROMPT: &str = "follow up without wait";
@@ -372,8 +371,7 @@ async fn spawned_child_receives_forked_parent_context() -> Result<()> {
             .unwrap_or_default()
             .into_iter()
             .find(|request| {
-                body_contains(request, CHILD_PROMPT)
-                    && body_contains(request, FORKED_SPAWN_AGENT_OUTPUT_MESSAGE)
+                body_contains(request, CHILD_PROMPT) && !body_contains(request, SPAWN_CALL_ID)
             })
         {
             break request;
@@ -385,29 +383,7 @@ async fn spawned_child_receives_forked_parent_context() -> Result<()> {
     };
     assert!(body_contains(&child_request, TURN_0_FORK_PROMPT));
     assert!(body_contains(&child_request, "seeded"));
-
-    let child_body = child_request
-        .body_json::<serde_json::Value>()
-        .expect("forked child request body should be json");
-    let function_call_output = child_body["input"]
-        .as_array()
-        .and_then(|items| {
-            items.iter().find(|item| {
-                item["type"].as_str() == Some("function_call_output")
-                    && item["call_id"].as_str() == Some(SPAWN_CALL_ID)
-            })
-        })
-        .unwrap_or_else(|| panic!("expected forked child request to include spawn_agent output"));
-    let (content, success) = match &function_call_output["output"] {
-        serde_json::Value::String(text) => (Some(text.as_str()), None),
-        serde_json::Value::Object(output) => (
-            output.get("content").and_then(serde_json::Value::as_str),
-            output.get("success").and_then(serde_json::Value::as_bool),
-        ),
-        _ => (None, None),
-    };
-    assert_eq!(content, Some(FORKED_SPAWN_AGENT_OUTPUT_MESSAGE));
-    assert_ne!(success, Some(false));
+    assert!(!body_contains(&child_request, SPAWN_CALL_ID));
 
     Ok(())
 }


### PR DESCRIPTION
- Keep only parent system/developer/user messages plus assistant final-answer messages in forked child history.
- Strip parent tool/reasoning items and remove the unmatched synthetic spawn output.