### PR TITLE
fix windows-only clippy lint violation

### DIFF
--- a/codex-rs/core/src/exec_env.rs
+++ b/codex-rs/core/src/exec_env.rs
@@ -56,7 +56,7 @@ where
 const COMMON_CORE_VARS: &[&str] = &["PATH", "SHELL", "TMPDIR", "TEMP", "TMP"];
 
 #[cfg(target_os = "windows")]
-const PLATFORM_CORE_VARS: &[&str] = { &["PATHEXT", "USERNAME", "USERPROFILE"] };
+const PLATFORM_CORE_VARS: &[&str] = &["PATHEXT", "USERNAME", "USERPROFILE"];
 
 #[cfg(unix)]
 const PLATFORM_CORE_VARS: &[&str] = &["HOME", "LANG", "LC_ALL", "LC_CTYPE", "LOGNAME", "USER"];


### PR DESCRIPTION
I missed this in https://github.com/openai/codex/pull/16707.