### PR TITLE
Skip winres manifest under Bazel gnullvm

### DIFF
--- a/codex-rs/windows-sandbox-rs/build.rs
+++ b/codex-rs/windows-sandbox-rs/build.rs
@@ -1,4 +1,14 @@
 fn main() {
+    if std::env::var_os("RULES_RUST_BAZEL_BUILD_SCRIPT_RUNNER").is_some()
+        && matches!(std::env::var("CARGO_CFG_TARGET_ENV").as_deref(), Ok("gnu"))
+    {
+        // The Windows Bazel lint/test lane targets `windows-gnullvm`, where
+        // `winres` can emit a `resource` link directive without a usable
+        // archive in `OUT_DIR`. Skip embedding the manifest there; Cargo's
+        // normal MSVC builds still compile it.
+        return;
+    }
+
     let mut res = winres::WindowsResource::new();
     res.set_manifest_file("codex-windows-sandbox-setup.manifest");
     let _ = res.compile();


### PR DESCRIPTION
Fingers crossed this helps unblock getting the full windows comment lint working on Bazel.

If this doesn't pan out, we'll revert.

Though this references `RULES_RUST_BAZEL_BUILD_SCRIPT_RUNNER`, which doesn't exist until https://github.com/openai/codex/pull/16528, so maybe we'll just do it as part of that.