### PR TITLE
ci: restore Linux remote-env PR tests

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -11,6 +11,7 @@ The workflows in this directory are split so that pull requests get fast, review
 - `rust-ci.yml` keeps the Cargo-native PR checks intentionally small:
   - `cargo fmt --check`
   - `cargo shear`
+  - Linux remote-env tests
   - `argument-comment-lint` on Linux, macOS, and Windows
   - `tools/argument-comment-lint` package tests when the lint or its workflow wiring changes
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,10 +8,10 @@ The workflows in this directory are split so that pull requests get fast, review
   It runs Bazel `test` and Bazel `clippy` on the supported Bazel targets,
   including the generated Rust test binaries needed to lint inline `#[cfg(test)]`
   code.
-- `rust-ci.yml` keeps the Cargo-native PR checks intentionally small:
+- `rust-ci.yml` keeps a small set of supplemental PR checks intentionally small:
   - `cargo fmt --check`
   - `cargo shear`
-  - Linux remote-env tests
+  - Linux remote-env smoke tests
   - `argument-comment-lint` on Linux, macOS, and Windows
   - `tools/argument-comment-lint` package tests when the lint or its workflow wiring changes
 
@@ -25,7 +25,7 @@ The workflows in this directory are split so that pull requests get fast, review
   - the full Cargo `nextest` matrix
   - release-profile Cargo builds
   - cross-platform `argument-comment-lint`
-  - Linux remote-env tests
+  - the broader Linux remote-env coverage
 
 ## Rule Of Thumb
 

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -39,7 +39,7 @@ jobs:
           argument_comment_lint_package=false
           workflows=false
           for f in "${files[@]}"; do
-            [[ $f == codex-rs/* ]] && codex=true
+            [[ $f == codex-rs/* || $f == defs.bzl || $f == scripts/test-remote-env.sh ]] && codex=true
             [[ $f == codex-rs/* || $f == tools/argument-comment-lint/* || $f == justfile ]] && argument_comment_lint=true
             [[ $f == tools/argument-comment-lint/* || $f == .github/workflows/rust-ci.yml || $f == .github/workflows/rust-ci-full.yml ]] && argument_comment_lint_package=true
             [[ $f == .github/* ]] && workflows=true

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -50,7 +50,7 @@ jobs:
           echo "codex=$codex" >> "$GITHUB_OUTPUT"
           echo "workflows=$workflows" >> "$GITHUB_OUTPUT"
 
-  # --- Fast Cargo-native PR checks -------------------------------------------
+  # --- Fast PR checks --------------------------------------------------------
   general:
     name: Format / etc
     runs-on: ubuntu-24.04
@@ -97,16 +97,13 @@ jobs:
       run:
         working-directory: codex-rs
     env:
-      USE_SCCACHE: "true"
-      CARGO_INCREMENTAL: "0"
-      SCCACHE_CACHE_SIZE: 10G
-      CODEX_TEST_REMOTE_ENV_TARGET: x86_64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Set up Node.js for js_repl tests
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      - name: Set up Bazel CI
+        uses: ./.github/actions/setup-bazel-ci
         with:
-          node-version-file: codex-rs/node-version.txt
+          target: x86_64-unknown-linux-gnu
+          install-test-prereqs: "true"
       - name: Install Linux build dependencies
         shell: bash
         run: |
@@ -115,60 +112,6 @@ jobs:
             sudo apt-get update -y
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends pkg-config libcap-dev
           fi
-      - name: Install DotSlash
-        uses: facebook/install-dotslash@1e4e7b3e07eaca387acb98f1d4720e0bee8dbb6a # v2
-      - uses: dtolnay/rust-toolchain@a0b273b48ed29de4470960879e8381ff45632f26 # 1.93.0
-        with:
-          targets: ${{ env.CODEX_TEST_REMOTE_ENV_TARGET }}
-      - name: Compute lockfile hash
-        id: lockhash
-        shell: bash
-        run: |
-          set -euo pipefail
-          echo "hash=$(sha256sum Cargo.lock | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
-          echo "toolchain_hash=$(sha256sum rust-toolchain.toml | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
-      - name: Restore cargo home cache
-        id: cache_cargo_home_restore
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: cargo-home-${{ runner.os }}-${{ env.CODEX_TEST_REMOTE_ENV_TARGET }}-remote-tests-${{ steps.lockhash.outputs.hash }}-${{ steps.lockhash.outputs.toolchain_hash }}
-          restore-keys: |
-            cargo-home-${{ runner.os }}-${{ env.CODEX_TEST_REMOTE_ENV_TARGET }}-remote-tests-
-      - name: Install sccache
-        uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532 # v2
-        with:
-          tool: sccache
-          version: 0.7.5
-      - name: Configure sccache backend
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -n "${ACTIONS_CACHE_URL:-}" && -n "${ACTIONS_RUNTIME_TOKEN:-}" ]]; then
-            echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
-            echo "Using sccache GitHub backend"
-          else
-            echo "SCCACHE_GHA_ENABLED=false" >> "$GITHUB_ENV"
-            echo "SCCACHE_DIR=${{ github.workspace }}/.sccache" >> "$GITHUB_ENV"
-            echo "Using sccache local disk + actions/cache fallback"
-          fi
-      - name: Enable sccache wrapper
-        shell: bash
-        run: echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-      - name: Restore sccache cache (fallback)
-        if: ${{ env.SCCACHE_GHA_ENABLED != 'true' }}
-        id: cache_sccache_restore
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: ${{ github.workspace }}/.sccache/
-          key: sccache-${{ runner.os }}-${{ env.CODEX_TEST_REMOTE_ENV_TARGET }}-remote-tests-${{ steps.lockhash.outputs.hash }}-${{ github.run_id }}
-          restore-keys: |
-            sccache-${{ runner.os }}-${{ env.CODEX_TEST_REMOTE_ENV_TARGET }}-remote-tests-${{ steps.lockhash.outputs.hash }}-
-            sccache-${{ runner.os }}-${{ env.CODEX_TEST_REMOTE_ENV_TARGET }}-remote-tests-
       - name: Enable unprivileged user namespaces
         run: |
           sudo sysctl -w kernel.unprivileged_userns_clone=1
@@ -180,43 +123,39 @@ jobs:
         run: |
           set -euo pipefail
           export CODEX_TEST_REMOTE_ENV_CONTAINER_NAME=codex-remote-test-env
+          export CODEX_TEST_REMOTE_ENV_SKIP_EXEC_SERVER_BUILD=1
           source "${GITHUB_WORKSPACE}/scripts/test-remote-env.sh"
           echo "CODEX_TEST_REMOTE_ENV=${CODEX_TEST_REMOTE_ENV}" >> "$GITHUB_ENV"
-      - name: Build remote exec-server binary
-        shell: bash
-        run: |
-          set -euo pipefail
-          cargo build -p codex-exec-server --bin codex-exec-server --target ${{ env.CODEX_TEST_REMOTE_ENV_TARGET }}
-          binary_path="${GITHUB_WORKSPACE}/codex-rs/target/${{ env.CODEX_TEST_REMOTE_ENV_TARGET }}/debug/codex-exec-server"
-          echo "CARGO_BIN_EXE_codex_exec_server=${binary_path}" >> "$GITHUB_ENV"
-      - name: Remote tests
+      - name: Remote tests via Bazel
         id: remote_tests
         shell: bash
         run: |
           set -euo pipefail
-          cargo test -p codex-core --target ${{ env.CODEX_TEST_REMOTE_ENV_TARGET }} --lib unified_exec::tests::unified_exec_uses_remote_exec_server_when_configured -- --exact
-          cargo test -p codex-core --target ${{ env.CODEX_TEST_REMOTE_ENV_TARGET }} --lib unified_exec::tests::remote_exec_server_rejects_inherited_fd_launches -- --exact
-          cargo test -p codex-core --target ${{ env.CODEX_TEST_REMOTE_ENV_TARGET }} --test all suite::remote_env::remote_test_env_can_connect_and_use_filesystem -- --exact
+          cd "${GITHUB_WORKSPACE}"
+
+          run_remote_test() {
+            local target="$1"
+            local test_name="$2"
+
+            "${GITHUB_WORKSPACE}/.github/scripts/run-bazel-ci.sh" \
+              --print-failed-test-logs \
+              --use-node-test-env \
+              -- \
+              test \
+              --test_env=CODEX_TEST_REMOTE_ENV="${CODEX_TEST_REMOTE_ENV}" \
+              --test_arg="${test_name}" \
+              --test_arg=--exact \
+              --test_verbose_timeout_warnings \
+              --build_metadata=COMMIT_SHA="${GITHUB_SHA}" \
+              -- \
+              "${target}"
+          }
+
+          run_remote_test "//codex-rs/core:core-unit-tests" "unified_exec::tests::unified_exec_uses_remote_exec_server_when_configured"
+          run_remote_test "//codex-rs/core:core-unit-tests" "unified_exec::tests::remote_exec_server_rejects_inherited_fd_launches"
+          run_remote_test "//codex-rs/core:core-all-test" "suite::remote_env::remote_test_env_can_connect_and_use_filesystem"
         env:
           RUST_BACKTRACE: 1
-      - name: Save cargo home cache
-        if: always() && !cancelled() && steps.cache_cargo_home_restore.outputs.cache-hit != 'true'
-        continue-on-error: true
-        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: cargo-home-${{ runner.os }}-${{ env.CODEX_TEST_REMOTE_ENV_TARGET }}-remote-tests-${{ steps.lockhash.outputs.hash }}-${{ steps.lockhash.outputs.toolchain_hash }}
-      - name: Save sccache cache (fallback)
-        if: always() && !cancelled() && env.SCCACHE_GHA_ENABLED != 'true'
-        continue-on-error: true
-        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: ${{ github.workspace }}/.sccache/
-          key: sccache-${{ runner.os }}-${{ env.CODEX_TEST_REMOTE_ENV_TARGET }}-remote-tests-${{ steps.lockhash.outputs.hash }}-${{ github.run_id }}
       - name: Tear down remote test env
         if: always()
         shell: bash

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -85,6 +85,148 @@ jobs:
       - name: cargo shear
         run: cargo shear
 
+  remote_tests_linux:
+    name: Remote tests - Linux
+    runs-on:
+      group: codex-runners
+      labels: codex-linux-x64
+    timeout-minutes: 45
+    needs: changed
+    if: ${{ needs.changed.outputs.codex == 'true' || needs.changed.outputs.workflows == 'true' }}
+    defaults:
+      run:
+        working-directory: codex-rs
+    env:
+      USE_SCCACHE: "true"
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_CACHE_SIZE: 10G
+      CODEX_TEST_REMOTE_ENV_TARGET: x86_64-unknown-linux-gnu
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Set up Node.js for js_repl tests
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version-file: codex-rs/node-version.txt
+      - name: Install Linux build dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          if command -v apt-get >/dev/null 2>&1; then
+            sudo apt-get update -y
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends pkg-config libcap-dev
+          fi
+      - name: Install DotSlash
+        uses: facebook/install-dotslash@1e4e7b3e07eaca387acb98f1d4720e0bee8dbb6a # v2
+      - uses: dtolnay/rust-toolchain@a0b273b48ed29de4470960879e8381ff45632f26 # 1.93.0
+        with:
+          targets: ${{ env.CODEX_TEST_REMOTE_ENV_TARGET }}
+      - name: Compute lockfile hash
+        id: lockhash
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "hash=$(sha256sum Cargo.lock | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+          echo "toolchain_hash=$(sha256sum rust-toolchain.toml | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+      - name: Restore cargo home cache
+        id: cache_cargo_home_restore
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: cargo-home-${{ runner.os }}-${{ env.CODEX_TEST_REMOTE_ENV_TARGET }}-remote-tests-${{ steps.lockhash.outputs.hash }}-${{ steps.lockhash.outputs.toolchain_hash }}
+          restore-keys: |
+            cargo-home-${{ runner.os }}-${{ env.CODEX_TEST_REMOTE_ENV_TARGET }}-remote-tests-
+      - name: Install sccache
+        uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532 # v2
+        with:
+          tool: sccache
+          version: 0.7.5
+      - name: Configure sccache backend
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -n "${ACTIONS_CACHE_URL:-}" && -n "${ACTIONS_RUNTIME_TOKEN:-}" ]]; then
+            echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+            echo "Using sccache GitHub backend"
+          else
+            echo "SCCACHE_GHA_ENABLED=false" >> "$GITHUB_ENV"
+            echo "SCCACHE_DIR=${{ github.workspace }}/.sccache" >> "$GITHUB_ENV"
+            echo "Using sccache local disk + actions/cache fallback"
+          fi
+      - name: Enable sccache wrapper
+        shell: bash
+        run: echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+      - name: Restore sccache cache (fallback)
+        if: ${{ env.SCCACHE_GHA_ENABLED != 'true' }}
+        id: cache_sccache_restore
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: ${{ github.workspace }}/.sccache/
+          key: sccache-${{ runner.os }}-${{ env.CODEX_TEST_REMOTE_ENV_TARGET }}-remote-tests-${{ steps.lockhash.outputs.hash }}-${{ github.run_id }}
+          restore-keys: |
+            sccache-${{ runner.os }}-${{ env.CODEX_TEST_REMOTE_ENV_TARGET }}-remote-tests-${{ steps.lockhash.outputs.hash }}-
+            sccache-${{ runner.os }}-${{ env.CODEX_TEST_REMOTE_ENV_TARGET }}-remote-tests-
+      - name: Enable unprivileged user namespaces
+        run: |
+          sudo sysctl -w kernel.unprivileged_userns_clone=1
+          if sudo sysctl -a 2>/dev/null | grep -q '^kernel.apparmor_restrict_unprivileged_userns'; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
+      - name: Set up remote test env (Docker)
+        shell: bash
+        run: |
+          set -euo pipefail
+          export CODEX_TEST_REMOTE_ENV_CONTAINER_NAME=codex-remote-test-env
+          source "${GITHUB_WORKSPACE}/scripts/test-remote-env.sh"
+          echo "CODEX_TEST_REMOTE_ENV=${CODEX_TEST_REMOTE_ENV}" >> "$GITHUB_ENV"
+      - name: Build remote exec-server binary
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo build -p codex-exec-server --bin codex-exec-server --target ${{ env.CODEX_TEST_REMOTE_ENV_TARGET }}
+          binary_path="${GITHUB_WORKSPACE}/codex-rs/target/${{ env.CODEX_TEST_REMOTE_ENV_TARGET }}/debug/codex-exec-server"
+          echo "CARGO_BIN_EXE_codex_exec_server=${binary_path}" >> "$GITHUB_ENV"
+      - name: Remote tests
+        id: remote_tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo test -p codex-core --target ${{ env.CODEX_TEST_REMOTE_ENV_TARGET }} --lib unified_exec::tests::unified_exec_uses_remote_exec_server_when_configured -- --exact
+          cargo test -p codex-core --target ${{ env.CODEX_TEST_REMOTE_ENV_TARGET }} --lib unified_exec::tests::remote_exec_server_rejects_inherited_fd_launches -- --exact
+          cargo test -p codex-core --target ${{ env.CODEX_TEST_REMOTE_ENV_TARGET }} --test all suite::remote_env::remote_test_env_can_connect_and_use_filesystem -- --exact
+        env:
+          RUST_BACKTRACE: 1
+      - name: Save cargo home cache
+        if: always() && !cancelled() && steps.cache_cargo_home_restore.outputs.cache-hit != 'true'
+        continue-on-error: true
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: cargo-home-${{ runner.os }}-${{ env.CODEX_TEST_REMOTE_ENV_TARGET }}-remote-tests-${{ steps.lockhash.outputs.hash }}-${{ steps.lockhash.outputs.toolchain_hash }}
+      - name: Save sccache cache (fallback)
+        if: always() && !cancelled() && env.SCCACHE_GHA_ENABLED != 'true'
+        continue-on-error: true
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: ${{ github.workspace }}/.sccache/
+          key: sccache-${{ runner.os }}-${{ env.CODEX_TEST_REMOTE_ENV_TARGET }}-remote-tests-${{ steps.lockhash.outputs.hash }}-${{ github.run_id }}
+      - name: Tear down remote test env
+        if: always()
+        shell: bash
+        run: |
+          set +e
+          if [[ "${{ steps.remote_tests.outcome }}" != "success" ]]; then
+            docker logs codex-remote-test-env || true
+          fi
+          docker rm -f codex-remote-test-env >/dev/null 2>&1 || true
+
   argument_comment_lint_package:
     name: Argument comment lint package
     runs-on: ubuntu-24.04
@@ -194,6 +336,7 @@ jobs:
         changed,
         general,
         cargo_shear,
+        remote_tests_linux,
         argument_comment_lint_package,
         argument_comment_lint_prebuilt,
       ]
@@ -206,6 +349,7 @@ jobs:
           echo "argpkg : ${{ needs.argument_comment_lint_package.result }}"
           echo "arglint: ${{ needs.argument_comment_lint_prebuilt.result }}"
           echo "general: ${{ needs.general.result }}"
+          echo "remote : ${{ needs.remote_tests_linux.result }}"
           echo "shear  : ${{ needs.cargo_shear.result }}"
 
           # If nothing relevant changed (PR touching only root README, etc.),
@@ -226,4 +370,5 @@ jobs:
           if [[ '${{ needs.changed.outputs.codex }}' == 'true' || '${{ needs.changed.outputs.workflows }}' == 'true' ]]; then
             [[ '${{ needs.general.result }}' == 'success' ]] || { echo 'general failed'; exit 1; }
             [[ '${{ needs.cargo_shear.result }}' == 'success' ]] || { echo 'cargo_shear failed'; exit 1; }
+            [[ '${{ needs.remote_tests_linux.result }}' == 'success' ]] || { echo 'remote_tests_linux failed'; exit 1; }
           fi

--- a/codex-rs/core/BUILD.bazel
+++ b/codex-rs/core/BUILD.bazel
@@ -52,6 +52,7 @@ codex_rust_crate(
         "//codex-rs/linux-sandbox:codex-linux-sandbox",
         "//codex-rs/rmcp-client:test_stdio_server",
         "//codex-rs/rmcp-client:test_streamable_http_server",
+        "//codex-rs/exec-server:codex-exec-server",
         "//codex-rs/cli:codex",
     ],
 )

--- a/defs.bzl
+++ b/defs.bzl
@@ -218,6 +218,17 @@ def codex_rust_crate(
 
         maybe_deps += [name + "-build-script"]
 
+    sanitized_binaries = []
+    cargo_env = {}
+    for binary in binaries.keys():
+        #binary = binary.replace("-", "_")
+        sanitized_binaries.append(binary)
+        cargo_env["CARGO_BIN_EXE_" + binary] = "$(rlocationpath :%s)" % binary
+    for binary_label in extra_binaries:
+        sanitized_binaries.append(binary_label)
+        binary = Label(binary_label).name
+        cargo_env["CARGO_BIN_EXE_" + binary] = "$(rlocationpath %s)" % binary_label
+
     if lib_srcs:
         lib_rule = rust_proc_macro if proc_macro else rust_library
         lib_rule(
@@ -251,7 +262,7 @@ def codex_rust_crate(
                 "--remap-path-prefix=codex-rs=",
             ],
             rustc_env = rustc_env,
-            data = test_data_extra,
+            data = test_data_extra + sanitized_binaries,
             tags = test_tags + ["manual"],
         )
 
@@ -261,7 +272,7 @@ def codex_rust_crate(
 
         workspace_root_test(
             name = name + "-unit-tests",
-            env = test_env,
+            env = test_env | cargo_env,
             test_bin = ":" + unit_test_binary,
             workspace_root_marker = "//codex-rs/utils/cargo-bin:repo_root.marker",
             tags = test_tags,
@@ -270,13 +281,7 @@ def codex_rust_crate(
 
         maybe_deps += [name]
 
-    sanitized_binaries = []
-    cargo_env = {}
     for binary, main in binaries.items():
-        #binary = binary.replace("-", "_")
-        sanitized_binaries.append(binary)
-        cargo_env["CARGO_BIN_EXE_" + binary] = "$(rlocationpath :%s)" % binary
-
         rust_binary(
             name = binary,
             crate_name = binary.replace("-", "_"),
@@ -287,11 +292,6 @@ def codex_rust_crate(
             srcs = native.glob(["src/**/*.rs"]),
             visibility = ["//visibility:public"],
         )
-
-    for binary_label in extra_binaries:
-        sanitized_binaries.append(binary_label)
-        binary = Label(binary_label).name
-        cargo_env["CARGO_BIN_EXE_" + binary] = "$(rlocationpath %s)" % binary_label
 
     integration_test_kwargs = {}
     if integration_test_args:

--- a/scripts/test-remote-env.sh
+++ b/scripts/test-remote-env.sh
@@ -32,19 +32,21 @@ setup_remote_env() {
     return 1
   fi
 
-  if ! command -v cargo >/dev/null 2>&1; then
-    echo "cargo is required to build codex-exec-server" >&2
-    return 1
-  fi
+  if [[ "${CODEX_TEST_REMOTE_ENV_SKIP_EXEC_SERVER_BUILD:-0}" != "1" ]]; then
+    if ! command -v cargo >/dev/null 2>&1; then
+      echo "cargo is required to build codex-exec-server" >&2
+      return 1
+    fi
 
-  (
-    cd "${REPO_ROOT}/codex-rs"
-    cargo build -p codex-exec-server --bin codex-exec-server
-  )
+    (
+      cd "${REPO_ROOT}/codex-rs"
+      cargo build -p codex-exec-server --bin codex-exec-server
+    )
 
-  if [[ ! -f "${codex_exec_server_binary_path}" ]]; then
-    echo "codex-exec-server binary not found at ${codex_exec_server_binary_path}" >&2
-    return 1
+    if [[ ! -f "${codex_exec_server_binary_path}" ]]; then
+      echo "codex-exec-server binary not found at ${codex_exec_server_binary_path}" >&2
+      return 1
+    fi
   fi
 
   docker rm -f "${container_name}" >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary
- restore a Linux PR-time remote-env lane in `rust-ci.yml`
- run a small `codex-core` remote-env smoke set after booting the Docker-backed test environment
- update workflow docs so the PR-time versus post-merge split remains accurate

## Validation
- parsed `.github/workflows/rust-ci.yml` as YAML locally
- reviewed the restored lane against the existing `rust-ci-full.yml` remote-env setup
- relying on PR CI for runner-backed execution