### PR TITLE
3/4 Remove local realtime playback interruption

### DIFF
--- a/codex-rs/tui/src/chatwidget/realtime.rs
+++ b/codex-rs/tui/src/chatwidget/realtime.rs
@@ -302,11 +302,11 @@ impl ChatWidget {
             RealtimeEvent::SessionUpdated { session_id, .. } => {
                 self.realtime_conversation.session_id = Some(session_id);
             }
-            RealtimeEvent::InputAudioSpeechStarted(_) => self.interrupt_realtime_audio_playback(),
+            RealtimeEvent::InputAudioSpeechStarted(_) => {}
             RealtimeEvent::InputTranscriptDelta(_) => {}
             RealtimeEvent::OutputTranscriptDelta(_) => {}
             RealtimeEvent::AudioOut(frame) => self.enqueue_realtime_audio_out(&frame),
-            RealtimeEvent::ResponseCancelled(_) => self.interrupt_realtime_audio_playback(),
+            RealtimeEvent::ResponseCancelled(_) => {}
             RealtimeEvent::ConversationItemAdded(_item) => {}
             RealtimeEvent::ConversationItemDone { .. } => {}
             RealtimeEvent::HandoffRequested(_) => {}
@@ -367,16 +367,6 @@ impl ChatWidget {
             let _ = frame;
         }
     }
-
-    #[cfg(not(target_os = "linux"))]
-    fn interrupt_realtime_audio_playback(&mut self) {
-        if let Some(player) = &self.realtime_conversation.audio_player {
-            player.clear();
-        }
-    }
-
-    #[cfg(target_os = "linux")]
-    fn interrupt_realtime_audio_playback(&mut self) {}
 
     #[cfg(not(target_os = "linux"))]
     fn start_realtime_local_audio(&mut self) {


### PR DESCRIPTION
Stack position: 3/4

Stack:
- 1/4 #16805 Replace realtime websocket transport with WebRTC
- 2/4 #16806 Route TUI realtime audio through shared echo cancellation
- 3/4 #16807 Remove local realtime playback interruption (this PR)
- 4/4 #16769 Support ChatGPT realtime call auth and request shape

This PR:
- Stop locally clearing speaker playback on input speech-start events.
- Keep interruption behavior owned by the transport/session side instead of resetting the local queue in the TUI.