### PR TITLE
(tui): Decode percent-escaped bare local file links

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -2854,6 +2854,7 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width 0.2.1",
  "url",
+ "urlencoding",
  "uuid",
  "vt100",
  "webbrowser",

--- a/codex-rs/tui/Cargo.toml
+++ b/codex-rs/tui/Cargo.toml
@@ -105,6 +105,7 @@ two-face = { version = "0.5", default-features = false, features = ["syntect-def
 unicode-segmentation = { workspace = true }
 unicode-width = { workspace = true }
 url = { workspace = true }
+urlencoding = { workspace = true }
 webbrowser = { workspace = true }
 uuid = { workspace = true }
 

--- a/codex-rs/tui/src/markdown_render.rs
+++ b/codex-rs/tui/src/markdown_render.rs
@@ -789,7 +789,9 @@ fn parse_local_link_target(dest_url: &str) -> Option<(String, Option<String>)> {
         location_suffix = Some(suffix);
     }
 
-    Some((expand_local_link_path(path_text), location_suffix))
+    let decoded_path_text =
+        urlencoding::decode(path_text).unwrap_or(std::borrow::Cow::Borrowed(path_text));
+    Some((expand_local_link_path(&decoded_path_text), location_suffix))
 }
 
 /// Normalize a hash fragment like `L12` or `L12C3-L14C9` into the display suffix we render.

--- a/codex-rs/tui/src/markdown_render_tests.rs
+++ b/codex-rs/tui/src/markdown_render_tests.rs
@@ -679,11 +679,11 @@ fn file_link_hides_destination() {
 #[test]
 fn file_link_decodes_percent_encoded_bare_path_destination() {
     let text = render_markdown_text_for_cwd(
-        "[Kleidung](/Users/example/code/codex/Archiv%201/Pers%C3%B6nliches/Kleidung/)",
+        "[report](/Users/example/code/codex/Example%20Folder/R%C3%A9sum%C3%A9/report.md)",
         Path::new("/Users/example/code/codex"),
     );
     let expected = Text::from(Line::from_iter([
-        "Archiv 1/Persönliches/Kleidung".cyan(),
+        "Example Folder/Résumé/report.md".cyan(),
     ]));
     assert_eq!(text, expected);
 }

--- a/codex-rs/tui/src/markdown_render_tests.rs
+++ b/codex-rs/tui/src/markdown_render_tests.rs
@@ -677,6 +677,18 @@ fn file_link_hides_destination() {
 }
 
 #[test]
+fn file_link_decodes_percent_encoded_bare_path_destination() {
+    let text = render_markdown_text_for_cwd(
+        "[Kleidung](/Users/example/code/codex/Archiv%201/Pers%C3%B6nliches/Kleidung/)",
+        Path::new("/Users/example/code/codex"),
+    );
+    let expected = Text::from(Line::from_iter([
+        "Archiv 1/Persönliches/Kleidung".cyan(),
+    ]));
+    assert_eq!(text, expected);
+}
+
+#[test]
 fn file_link_appends_line_number_when_label_lacks_it() {
     let text = render_markdown_text_for_cwd(
         "[markdown_render.rs](/Users/example/code/codex/codex-rs/tui/src/markdown_render.rs:74)",


### PR DESCRIPTION
Addresses #16622

Problem: bare local file links in TUI markdown render percent-encoded path bytes literally, unlike file:// links.

Solution: decode bare path targets before local-path expansion and add regression coverage for spaces and Unicode.