### PR TITLE
Fix misleading codex exec help usage

### DIFF
--- a/codex-rs/exec/src/cli.rs
+++ b/codex-rs/exec/src/cli.rs
@@ -6,7 +6,10 @@ use codex_utils_cli::CliConfigOverrides;
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
-#[command(version)]
+#[command(
+    version,
+    override_usage = "codex exec [OPTIONS] [PROMPT]\n       codex exec [OPTIONS] <COMMAND> [ARGS]"
+)]
 pub struct Cli {
     /// Action to perform. If omitted, runs a new non-interactive session.
     #[command(subcommand)]


### PR DESCRIPTION
Addresses #15535

Problem: `codex exec --help` advertised a second positional `[COMMAND]` even though `exec` only accepts a prompt or a subcommand.

Solution: Override the `exec` usage string so the help output shows the two supported invocation forms instead of the phantom positional.