### PR TITLE
fix(bazel): fix simdutf

### DIFF
--- a/patches/v8_bazel_rules.patch
+++ b/patches/v8_bazel_rules.patch
@@ -191,7 +191,6 @@ index 85f31b7..7314584 100644
 +    actual = "@simdutf//:simdutf",
  )
  
- v8_library(
 @@ -4593,7 +4598,7 @@ v8_library(
      copts = ["-Wno-implicit-fallthrough"],
      icu_deps = [

--- a/patches/v8_module_deps.patch
+++ b/patches/v8_module_deps.patch
@@ -6,7 +6,7 @@
 diff --git a/orig/v8-14.6.202.11/MODULE.bazel b/mod/v8-14.6.202.11/MODULE.bazel
 --- a/orig/v8-14.6.202.11/MODULE.bazel
 +++ b/mod/v8-14.6.202.11/MODULE.bazel
-@@ -8,7 +8,57 @@
+@@ -8,7 +8,65 @@
  bazel_dep(name = "rules_python", version = "1.0.0")
  bazel_dep(name = "platforms", version = "1.0.0")
  bazel_dep(name = "abseil-cpp", version = "20250814.0")
@@ -42,11 +42,12 @@ diff --git a/orig/v8-14.6.202.11/MODULE.bazel b/mod/v8-14.6.202.11/MODULE.bazel
 +    urls = ["https://github.com/fastfloat/fast_float/archive/refs/tags/v8.0.2.tar.gz"],
 +)
 +
-+git_repository(
++http_archive(
 +    name = "simdutf",
-+    build_file_content = 'load("@rules_cc//cc:defs.bzl", "cc_library")\n\ncc_library(\n    name = "simdutf",\n    srcs = ["simdutf.cpp"],\n    hdrs = ["simdutf.h"],\n    copts = ["-std=c++20"],\n    include_prefix = "third_party/simdutf",\n    visibility = ["//visibility:public"],\n)\n',
-+    commit = "93b35aec29256f705c97f675fe4623578bd7a395",
-+    remote = "https://chromium.googlesource.com/chromium/src/third_party/simdutf",
++    build_file_content = 'load("@rules_cc//cc:defs.bzl", "cc_library")\n\ncc_library(\n    name = "simdutf",\n    srcs = ["src/simdutf.cpp"],\n    hdrs = glob(["include/**/*.h"]),\n    textual_hdrs = glob(["src/**/*.h", "src/**/*.cpp"], exclude = ["src/simdutf.cpp"]),\n    copts = ["-std=c++20"],\n    include_prefix = "third_party/simdutf",\n    includes = ["include", "src"],\n    strip_include_prefix = "include",\n    visibility = ["//visibility:public"],\n)\n',
++    sha256 = "0180de81a1dd48a87b8c0442ffa81734f3db91a7350914107a449935124e3c6f",
++    strip_prefix = "simdutf-7.7.0",
++    urls = ["https://github.com/simdutf/simdutf/archive/refs/tags/v7.7.0.tar.gz"],
 +)
 +
 +git_repository(
@@ -65,7 +66,7 @@ diff --git a/orig/v8-14.6.202.11/MODULE.bazel b/mod/v8-14.6.202.11/MODULE.bazel
  
  pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
  pip.parse(
-@@ -22,171 +72,3 @@
+@@ -22,171 +80,3 @@
  )
  use_repo(pip, "v8_python_deps")
  


### PR DESCRIPTION
## Summary

This changes our V8 Bazel wiring so `simdutf` no longer comes from a live `git_repository` fetch against Chromium's Googlesource host.

Instead, we pull `simdutf` from a pinned GitHub release archive and keep the V8 `simdutf` target wired through the external repo. The archive-backed target is set up to match the way V8 consumes `simdutf` today, including the amalgamated `src/simdutf.cpp` entrypoint and the internal files it includes.

## Why

CI was intermittently failing while Bazel tried to fetch:

`https://chromium.googlesource.com/chromium/src/third_party/simdutf/`

That fetch was returning HTTP 429s, which then fan out into failures in the Bazel jobs, the SDK job, and the argument-comment lint jobs since they all go through the same dependency resolution path.

## What changed

- replaced the `simdutf` `git_repository` in the patched V8 module deps with a pinned `http_archive`
- pointed that archive at `simdutf` `v7.7.0` on GitHub
- added the archive hash so the fetch is deterministic
- kept the V8 BUILD patch pointing `:simdutf` at the external `@simdutf//:simdutf` target
- configured the Bazel `cc_library` for the archive to use the amalgamated `src/simdutf.cpp` source plus the internal headers / textual includes it depends on

## Validation

- ran `bazel build @v8//:simdutf`
- confirmed the target builds successfully with the new archive-backed wiring
