### PR TITLE
bazel: Enable `--experimental_remote_downloader`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -44,6 +44,7 @@ common --remote_timeout=3600
 common --noexperimental_throttle_remote_action_building
 common --experimental_remote_execution_keepalive
 common --grpc_keepalive_time=30s
+common --experimental_remote_downloader
 
 # This limits both in-flight executions and concurrent downloads. Even with high number
 # of jobs execution will still be limited by CPU cores, so this just pays a bit of

--- a/.bazelrc
+++ b/.bazelrc
@@ -44,7 +44,7 @@ common --remote_timeout=3600
 common --noexperimental_throttle_remote_action_building
 common --experimental_remote_execution_keepalive
 common --grpc_keepalive_time=30s
-common --experimental_remote_downloader
+common --experimental_remote_downloader=grpcs://remote.buildbuddy.io
 
 # This limits both in-flight executions and concurrent downloads. Even with high number
 # of jobs execution will still be limited by CPU cores, so this just pays a bit of


### PR DESCRIPTION
This should allow bazel to properly cache external deps.
