### PR TITLE
[codex] Update Codex app promo date

### DIFF
--- a/codex-rs/tui/src/tooltips.rs
+++ b/codex-rs/tui/src/tooltips.rs
@@ -9,9 +9,9 @@ const ANNOUNCEMENT_TIP_URL: &str =
 const IS_MACOS: bool = cfg!(target_os = "macos");
 const IS_WINDOWS: bool = cfg!(target_os = "windows");
 
-const PAID_TOOLTIP: &str = "*New* Try the **Codex App** with 2x rate limits until *April 2nd*. Run 'codex app' or visit https://chatgpt.com/codex?app-landing-page=true";
-const PAID_TOOLTIP_WINDOWS: &str = "*New* Try the **Codex App**, now available on **Windows**, with 2x rate limits until *April 2nd*. Run 'codex app' or visit https://chatgpt.com/codex?app-landing-page=true";
-const PAID_TOOLTIP_NON_MAC: &str = "*New* 2x rate limits until *April 2nd*.";
+const PAID_TOOLTIP: &str = "*New* Try the **Codex App** with 2x rate limits until *April 7th*. Run 'codex app' or visit https://chatgpt.com/codex?app-landing-page=true";
+const PAID_TOOLTIP_WINDOWS: &str = "*New* Try the **Codex App**, now available on **Windows**, with 2x rate limits until *April 7th*. Run 'codex app' or visit https://chatgpt.com/codex?app-landing-page=true";
+const PAID_TOOLTIP_NON_MAC: &str = "*New* 2x rate limits until *April 7th*.";
 const FAST_TOOLTIP: &str = "*New* Use **/fast** to enable our fastest inference at 2X plan usage.";
 const OTHER_TOOLTIP: &str = "*New* Build faster with the **Codex App**. Run 'codex app' or visit https://chatgpt.com/codex?app-landing-page=true";
 const OTHER_TOOLTIP_NON_MAC: &str = "*New* Build faster with Codex.";


### PR DESCRIPTION
## Summary
- Update paid Codex App promo tooltip dates from April 2nd to April 7th across platform variants.

## Validation
- `just fmt`
- `cargo test -p codex-tui`
- `git diff --check`