### PR TITLE
[codex] Allow PyTorch libomp shm in Seatbelt

### DIFF
--- a/codex-rs/sandboxing/src/seatbelt_base_policy.sbpl
+++ b/codex-rs/sandboxing/src/seatbelt_base_policy.sbpl
@@ -92,6 +92,12 @@
 ; Needed for python multiprocessing on MacOS for the SemLock
 (allow ipc-posix-sem)
 
+; Needed for PyTorch/libomp on macOS to register OpenMP runtimes.
+(allow ipc-posix-shm-read-data
+  ipc-posix-shm-write-create
+  ipc-posix-shm-write-unlink
+  (ipc-posix-name-regex #"^/__KMP_REGISTERED_LIB_[0-9]+$"))
+
 (allow mach-lookup
   (global-name "com.apple.PowerManagement.control")
 )

--- a/codex-rs/sandboxing/src/seatbelt_tests.rs
+++ b/codex-rs/sandboxing/src/seatbelt_tests.rs
@@ -61,6 +61,19 @@ fn base_policy_allows_node_cpu_sysctls() {
 }
 
 #[test]
+fn base_policy_allows_kmp_registration_shm_read_create_and_unlink() {
+    let expected = r##"(allow ipc-posix-shm-read-data
+  ipc-posix-shm-write-create
+  ipc-posix-shm-write-unlink
+  (ipc-posix-name-regex #"^/__KMP_REGISTERED_LIB_[0-9]+$"))"##;
+
+    assert!(
+        MACOS_SEATBELT_BASE_POLICY.contains(expected),
+        "base policy must allow only KMP registration shm read/create/unlink:\n{MACOS_SEATBELT_BASE_POLICY}"
+    );
+}
+
+#[test]
 fn create_seatbelt_args_routes_network_through_proxy_ports() {
     let policy = dynamic_network_policy(
         &SandboxPolicy::new_read_only_policy(),


### PR DESCRIPTION
## Summary
- Add a targeted macOS Seatbelt allow rule for PyTorch/libomp KMP registration shared-memory objects.
- Scope the rule to read/create/unlink operations on names matching `^/__KMP_REGISTERED_LIB_[0-9]+$`.
- Add a base-policy regression assertion in `seatbelt_tests.rs`.

## Why
Importing PyTorch on macOS under the Codex sandbox can abort when libomp attempts to create the KMP registration POSIX shm object and Seatbelt denies `ipc-posix-shm-write-create`.

## Validation
- `just fmt`
- `cargo test -p codex-sandboxing`
- `cargo clippy -p codex-sandboxing --all-targets`
- `just argument-comment-lint`
- `git diff --check`
- End-to-end PyTorch import under `codex sandbox macos` exited `0` with no KMP shm denial
- `cargo clean`