### PR TITLE
[codex] Clarify bubblewrap install warning

### DIFF
--- a/codex-rs/sandboxing/src/bwrap.rs
+++ b/codex-rs/sandboxing/src/bwrap.rs
@@ -23,7 +23,7 @@ fn system_bwrap_warning_for_lookup(system_bwrap_path: Option<PathBuf>) -> Option
     match system_bwrap_path {
         Some(_) => None,
         None => Some(
-            "Codex could not find system bubblewrap on PATH. Please install bubblewrap with your package manager. Codex will use the vendored bubblewrap in the meantime."
+            "Codex could not find system bubblewrap on PATH. Please install the Bubblewrap system package with your OS package manager (for example apt, dnf, or pacman), not npm. Upstream project: https://github.com/containers/bubblewrap. Codex will use the vendored bubblewrap in the meantime."
                 .to_string(),
         ),
     }

--- a/codex-rs/sandboxing/src/bwrap_tests.rs
+++ b/codex-rs/sandboxing/src/bwrap_tests.rs
@@ -10,6 +10,8 @@ fn system_bwrap_warning_reports_missing_system_bwrap() {
         .expect("missing system bwrap should emit a warning");
 
     assert!(warning.contains("could not find system bubblewrap"));
+    assert!(warning.contains("not npm"));
+    assert!(warning.contains("https://github.com/containers/bubblewrap"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- clarify the Linux bubblewrap startup warning to say the required package is the OS-level Bubblewrap package, not an npm package
- add the upstream Bubblewrap GitHub URL so users can verify they are installing the right project
- extend the sandboxing unit test to cover the new clarification text

## Why
Codex already falls back to vendored bubblewrap, but the existing warning did not explicitly disambiguate the system package from the unrelated npm package name.

## Validation
- cargo test -p codex-sandboxing