### PR TITLE
Respect residency requirements in mcp-server

### DIFF
--- a/codex-rs/mcp-server/src/lib.rs
+++ b/codex-rs/mcp-server/src/lib.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use codex_arg0::Arg0DispatchPaths;
 use codex_core::config::Config;
 use codex_exec_server::EnvironmentManager;
+use codex_login::default_client::set_default_client_residency_requirement;
 use codex_utils_cli::CliConfigOverrides;
 
 use rmcp::model::ClientNotification;
@@ -71,6 +72,7 @@ pub async fn run_main(
         .map_err(|e| {
             std::io::Error::new(ErrorKind::InvalidData, format!("error loading config: {e}"))
         })?;
+    set_default_client_residency_requirement(config.enforce_residency.value());
 
     let otel = codex_core::otel_init::build_provider(
         &config,


### PR DESCRIPTION
Addresses #16951

Problem: codex mcp-server did not apply the configured residency requirement, so requests from non-US regions could miss the `residency` header and fail with a 401.

Solution: Set the default client residency requirement after loading config in the MCP server startup path, matching the existing exec and TUI behavior.