### PR TITLE
Display custom thread titles in TUI

### DIFF
--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -3536,10 +3536,13 @@ impl ChatComposer {
                 } else {
                     self.collaboration_mode_indicator
                 };
-                let thread_name_line = self
-                    .thread_name_label
-                    .as_ref()
-                    .map(|name| Line::from(vec![Span::from(name.clone()).dim()]));
+                let max_thread_name_width = available_width / 2;
+                let thread_name_line = self.thread_name_label.as_ref().map(|name| {
+                    truncate_line_with_ellipsis_if_overflow(
+                        Line::from(vec![Span::from(name.clone()).dim()]),
+                        max_thread_name_width,
+                    )
+                });
                 let mut left_width = if self.footer_flash_visible() {
                     self.footer_flash
                         .as_ref()

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -338,6 +338,8 @@ pub(crate) struct ChatComposer {
     status_line_enabled: bool,
     // Agent label injected into the footer's contextual row when multi-agent mode is active.
     active_agent_label: Option<String>,
+    // User-provided thread name shown in the footer's right-side context slot.
+    thread_name_label: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -459,6 +461,7 @@ impl ChatComposer {
             status_line_value: None,
             status_line_enabled: false,
             active_agent_label: None,
+            thread_name_label: None,
         };
         // Apply configuration via the setter to keep side-effects centralized.
         this.set_disable_paste_burst(disable_paste_burst);
@@ -3334,6 +3337,18 @@ impl ChatComposer {
         self.active_agent_label = active_agent_label;
         true
     }
+
+    pub(crate) fn set_thread_name_label(&mut self, thread_name_label: Option<String>) -> bool {
+        let thread_name_label = thread_name_label.and_then(|name| {
+            let trimmed = name.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_string())
+        });
+        if self.thread_name_label == thread_name_label {
+            return false;
+        }
+        self.thread_name_label = thread_name_label;
+        true
+    }
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -3521,6 +3536,10 @@ impl ChatComposer {
                 } else {
                     self.collaboration_mode_indicator
                 };
+                let thread_name_line = self
+                    .thread_name_label
+                    .as_ref()
+                    .map(|name| Line::from(vec![Span::from(name.clone()).dim()]));
                 let mut left_width = if self.footer_flash_visible() {
                     self.footer_flash
                         .as_ref()
@@ -3544,11 +3563,13 @@ impl ChatComposer {
                 };
                 let right_line = if status_line_active {
                     let full =
-                        mode_indicator_line(self.collaboration_mode_indicator, show_cycle_hint);
+                        mode_indicator_line(self.collaboration_mode_indicator, show_cycle_hint)
+                            .or_else(|| thread_name_line.clone());
                     let compact = mode_indicator_line(
                         self.collaboration_mode_indicator,
                         /*show_cycle_hint*/ false,
-                    );
+                    )
+                    .or_else(|| thread_name_line.clone());
                     let full_width = full.as_ref().map(|l| l.width() as u16).unwrap_or(0);
                     if can_show_left_with_context(hint_rect, left_width, full_width) {
                         full
@@ -3556,10 +3577,12 @@ impl ChatComposer {
                         compact
                     }
                 } else {
-                    Some(context_window_line(
-                        footer_props.context_window_percent,
-                        footer_props.context_window_used_tokens,
-                    ))
+                    thread_name_line.or_else(|| {
+                        Some(context_window_line(
+                            footer_props.context_window_percent,
+                            footer_props.context_window_used_tokens,
+                        ))
+                    })
                 };
                 let right_width = right_line.as_ref().map(|l| l.width() as u16).unwrap_or(0);
                 if status_line_active

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -1185,6 +1185,12 @@ impl BottomPane {
             self.request_redraw();
         }
     }
+
+    pub(crate) fn set_thread_name_label(&mut self, thread_name_label: Option<String>) {
+        if self.composer.set_thread_name_label(thread_name_label) {
+            self.request_redraw();
+        }
+    }
 }
 
 #[cfg(not(target_os = "linux"))]

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1938,6 +1938,8 @@ impl ChatWidget {
         self.session_network_proxy = event.network_proxy.clone();
         self.thread_id = Some(event.session_id);
         self.thread_name = event.thread_name.clone();
+        self.bottom_pane
+            .set_thread_name_label(event.thread_name.clone());
         self.forked_from = event.forked_from_id;
         self.current_rollout_path = event.rollout_path.clone();
         self.current_cwd = Some(event.cwd.clone());
@@ -2090,7 +2092,8 @@ impl ChatWidget {
 
     fn on_thread_name_updated(&mut self, event: codex_protocol::protocol::ThreadNameUpdatedEvent) {
         if self.thread_id == Some(event.thread_id) {
-            self.thread_name = event.thread_name;
+            self.thread_name = event.thread_name.clone();
+            self.bottom_pane.set_thread_name_label(event.thread_name);
             self.refresh_terminal_title();
             self.request_redraw();
         }

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__renamed_thread_footer_title.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__renamed_thread_footer_title.snap
@@ -1,0 +1,9 @@
+---
+source: tui/src/chatwidget/tests.rs
+expression: terminal.backend()
+---
+"                                                                                "
+"                                                                                "
+"› Ask Codex to do anything                                                      "
+"                                                                                "
+"  gpt-5.3-codex high                                           Roadmap cleanup  "

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__renamed_thread_footer_title_plan_mode_override.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__renamed_thread_footer_title_plan_mode_override.snap
@@ -1,0 +1,9 @@
+---
+source: tui/src/chatwidget/tests.rs
+expression: terminal.backend()
+---
+"                                                                                "
+"                                                                                "
+"› Ask Codex to do anything                                                      "
+"                                                                                "
+"  gpt-5.3-codex medium                          Plan mode (shift+tab to cycle)  "

--- a/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
+++ b/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
@@ -1038,6 +1038,79 @@ async fn status_line_model_with_reasoning_plan_mode_footer_snapshot() {
 }
 
 #[tokio::test]
+async fn renamed_thread_footer_title_snapshot() {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(Some("gpt-5.3-codex")).await;
+    chat.show_welcome_banner = false;
+    chat.config.tui_status_line = Some(vec!["model-with-reasoning".to_string()]);
+    chat.set_reasoning_effort(Some(ReasoningEffortConfig::High));
+    chat.refresh_status_line();
+
+    let thread_id = ThreadId::new();
+    chat.thread_id = Some(thread_id);
+    chat.handle_codex_event(Event {
+        id: "rename".to_string(),
+        msg: EventMsg::ThreadNameUpdated(codex_protocol::protocol::ThreadNameUpdatedEvent {
+            thread_id,
+            thread_name: Some("Roadmap cleanup".to_string()),
+        }),
+    });
+
+    let width = 80;
+    let height = chat.desired_height(width);
+    let mut terminal = Terminal::new(TestBackend::new(width, height)).expect("create terminal");
+    terminal
+        .draw(|f| chat.render(f.area(), f.buffer_mut()))
+        .expect("draw renamed-thread footer");
+    assert_chatwidget_snapshot!(
+        "renamed_thread_footer_title",
+        normalized_backend_snapshot(terminal.backend())
+    );
+}
+
+#[tokio::test]
+async fn renamed_thread_footer_title_plan_mode_override_snapshot() {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(Some("gpt-5.3-codex")).await;
+    chat.show_welcome_banner = false;
+    chat.set_feature_enabled(Feature::CollaborationModes, /*enabled*/ true);
+    chat.config.tui_status_line = Some(vec!["model-with-reasoning".to_string()]);
+    chat.set_reasoning_effort(Some(ReasoningEffortConfig::High));
+    chat.refresh_status_line();
+
+    let thread_id = ThreadId::new();
+    chat.thread_id = Some(thread_id);
+    chat.handle_server_notification(
+        ServerNotification::ThreadNameUpdated(
+            codex_app_server_protocol::ThreadNameUpdatedNotification {
+                thread_id: thread_id.to_string(),
+                thread_name: Some("Roadmap cleanup".to_string()),
+            },
+        ),
+        /*replay_kind*/ None,
+    );
+
+    let plan_mask = collaboration_modes::plan_mask(chat.model_catalog.as_ref())
+        .expect("expected plan collaboration mode");
+    chat.set_collaboration_mask(plan_mask);
+
+    let width = 80;
+    let height = chat.desired_height(width);
+    let mut terminal = Terminal::new(TestBackend::new(width, height)).expect("create terminal");
+    terminal
+        .draw(|f| chat.render(f.area(), f.buffer_mut()))
+        .expect("draw renamed-thread plan-mode footer");
+    assert_chatwidget_snapshot!(
+        "renamed_thread_footer_title_plan_mode_override",
+        normalized_backend_snapshot(terminal.backend())
+    );
+}
+
+#[tokio::test]
 async fn status_line_model_with_reasoning_fast_footer_snapshot() {
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;


### PR DESCRIPTION
- Show custom thread titles in the bottom-pane footer when available.
- Preserve plan mode information when plan mode is in use.
- Preserve existing footer priority rules and truncate long thread titles to half the usable footer width.
- Add snapshot coverage for renamed thread footer behavior.


https://github.com/user-attachments/assets/f42098cd-a72a-427f-95b0-a4b0675a9f32