### PR TITLE
Improve Bazel failed test output in CI

### DIFF
--- a/.github/scripts/run-bazel-ci.sh
+++ b/.github/scripts/run-bazel-ci.sh
@@ -163,27 +163,13 @@ print_failed_bazel_test_logs() {
   done
 
   echo
-  echo "Bazel failed test targets:"
-  for target_log in "${failed_target_logs[@]}"; do
-    local target="${target_log%%$'\t'*}"
-    echo "  FAIL ${target}"
-  done
-
-  echo
   awk -F '\t' '
     BEGIN {
-      print "Rust test failures across failed Bazel targets:"
+      print "Rust test failures:"
     }
     $1 == "F" {
       saw_failure = 1
-      if ($2 != current_target) {
-        if (current_target != "") {
-          print ""
-        }
-        current_target = $2
-        print "  " current_target
-      }
-      print "    " $3
+      print "  FAIL " $2 " " $3
     }
     $1 == "T" {
       passed += $3

--- a/.github/scripts/run-bazel-ci.sh
+++ b/.github/scripts/run-bazel-ci.sh
@@ -2,15 +2,15 @@
 
 set -euo pipefail
 
-print_failed_bazel_test_logs=0
+summarize_failed_bazel_test_logs=0
 use_node_test_env=0
 remote_download_toplevel=0
 windows_msvc_host_platform=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --print-failed-test-logs)
-      print_failed_bazel_test_logs=1
+    --summarize-failed-test-logs)
+      summarize_failed_bazel_test_logs=1
       shift
       ;;
     --use-node-test-env)
@@ -37,7 +37,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ $# -eq 0 ]]; then
-  echo "Usage: $0 [--print-failed-test-logs] [--use-node-test-env] [--remote-download-toplevel] [--windows-msvc-host-platform] -- <bazel args> -- <targets>" >&2
+  echo "Usage: $0 [--summarize-failed-test-logs] [--use-node-test-env] [--remote-download-toplevel] [--windows-msvc-host-platform] -- <bazel args> -- <targets>" >&2
   exit 1
 fi
 
@@ -65,7 +65,7 @@ case "${RUNNER_OS:-}" in
     ;;
 esac
 
-print_failed_bazel_test_logs() {
+summarize_failed_bazel_test_logs() {
   local console_log="$1"
   local testlogs_dir=
   local -a bazel_info_cmd=(bazel)
@@ -101,13 +101,6 @@ print_failed_bazel_test_logs() {
     return
   fi
 
-  echo
-  echo "Bazel failed test targets:"
-  for target_log in "${failed_target_logs[@]}"; do
-    local target="${target_log%%$'\t'*}"
-    echo "  FAIL ${target}"
-  done
-
   for target_log in "${failed_target_logs[@]}"; do
     local target="${target_log%%$'\t'*}"
     local test_log="${target_log#*$'\t'}"
@@ -126,12 +119,7 @@ print_failed_bazel_test_logs() {
       test_log="${testlogs_dir}/${rel_path}/test.log"
     fi
 
-    echo
-    echo "FAIL ${target}"
-    echo "test log: ${test_log}"
-    echo
     if [[ -f "$test_log" ]]; then
-      cat "$test_log"
       awk -v target="$target" '
         /^failures:$/ {
           in_failures = 1
@@ -157,8 +145,6 @@ print_failed_bazel_test_logs() {
           print ""
         }
       ' "$test_log" >> "$rust_test_summary"
-    else
-      echo "Missing test log: $test_log"
     fi
   done
 
@@ -363,8 +349,8 @@ else
 fi
 
 if [[ ${bazel_status:-0} -ne 0 ]]; then
-  if [[ $print_failed_bazel_test_logs -eq 1 ]]; then
-    print_failed_bazel_test_logs "$bazel_console_log"
+  if [[ $summarize_failed_bazel_test_logs -eq 1 ]]; then
+    summarize_failed_bazel_test_logs "$bazel_console_log"
   fi
   exit "$bazel_status"
 fi

--- a/.github/scripts/run-bazel-ci.sh
+++ b/.github/scripts/run-bazel-ci.sh
@@ -133,6 +133,13 @@ print_failed_bazel_test_logs() {
       echo "Missing test log: $test_log"
     fi
   done
+
+  echo
+  echo "Bazel failed test targets:"
+  for target_log in "${failed_target_logs[@]}"; do
+    local target="${target_log%%$'\t'*}"
+    echo "  FAIL ${target}"
+  done
 }
 
 bazel_args=()

--- a/.github/scripts/run-bazel-ci.sh
+++ b/.github/scripts/run-bazel-ci.sh
@@ -69,6 +69,8 @@ print_failed_bazel_test_logs() {
   local console_log="$1"
   local testlogs_dir=
   local -a bazel_info_cmd=(bazel)
+  local rust_test_summary
+  rust_test_summary="$(mktemp)"
 
   local failed_target_logs=()
   while IFS= read -r target_log; do
@@ -95,6 +97,7 @@ print_failed_bazel_test_logs() {
 
   if [[ ${#failed_target_logs[@]} -eq 0 ]]; then
     echo "No failed Bazel test targets were found in console output."
+    rm -f "$rust_test_summary"
     return
   fi
 
@@ -129,6 +132,31 @@ print_failed_bazel_test_logs() {
     echo
     if [[ -f "$test_log" ]]; then
       cat "$test_log"
+      awk -v target="$target" '
+        /^failures:$/ {
+          in_failures = 1
+          next
+        }
+        in_failures && /^    / {
+          print "F\t" target "\t" substr($0, 5)
+          next
+        }
+        in_failures && $0 !~ /^$/ {
+          in_failures = 0
+        }
+        /^test result: FAILED\./ {
+          line = $0
+          sub(/^test result: FAILED\. /, "", line)
+          sub(/; finished.*$/, "", line)
+          field_count = split(line, fields, "; ")
+          printf "T\t%s", target
+          for (i = 1; i <= field_count; i++) {
+            split(fields[i], parts, " ")
+            printf "\t%d", parts[1]
+          }
+          print ""
+        }
+      ' "$test_log" >> "$rust_test_summary"
     else
       echo "Missing test log: $test_log"
     fi
@@ -140,6 +168,47 @@ print_failed_bazel_test_logs() {
     local target="${target_log%%$'\t'*}"
     echo "  FAIL ${target}"
   done
+
+  echo
+  awk -F '\t' '
+    BEGIN {
+      print "Rust test failures across failed Bazel targets:"
+    }
+    $1 == "F" {
+      saw_failure = 1
+      if ($2 != current_target) {
+        if (current_target != "") {
+          print ""
+        }
+        current_target = $2
+        print "  " current_target
+      }
+      print "    " $3
+    }
+    $1 == "T" {
+      passed += $3
+      failed += $4
+      ignored += $5
+      measured += $6
+      filtered += $7
+      result_count += 1
+    }
+    END {
+      if (!saw_failure) {
+        print "  No Rust test failure names found in test logs."
+      }
+
+      print ""
+      print "Rust test result totals across failed Bazel targets:"
+      if (result_count > 0) {
+        printf "  %d passed; %d failed; %d ignored; %d measured; %d filtered out\n",
+          passed, failed, ignored, measured, filtered
+      } else {
+        print "  No Rust test result totals found in test logs."
+      }
+    }
+  ' "$rust_test_summary"
+  rm -f "$rust_test_summary"
 }
 
 bazel_args=()

--- a/.github/scripts/run-bazel-ci.sh
+++ b/.github/scripts/run-bazel-ci.sh
@@ -65,43 +65,73 @@ case "${RUNNER_OS:-}" in
     ;;
 esac
 
-print_bazel_test_log_tails() {
+print_failed_bazel_test_logs() {
   local console_log="$1"
-  local testlogs_dir
+  local testlogs_dir=
   local -a bazel_info_cmd=(bazel)
 
-  if (( ${#bazel_startup_args[@]} > 0 )); then
-    bazel_info_cmd+=("${bazel_startup_args[@]}")
-  fi
-
-  testlogs_dir="$(run_bazel "${bazel_info_cmd[@]:1}" info bazel-testlogs 2>/dev/null || echo bazel-testlogs)"
-
-  local failed_targets=()
-  while IFS= read -r target; do
-    failed_targets+=("$target")
+  local failed_target_logs=()
+  while IFS= read -r target_log; do
+    failed_target_logs+=("$target_log")
   done < <(
     grep -E '^FAIL: //' "$console_log" \
-      | sed -E 's#^FAIL: (//[^ ]+).*#\1#' \
+      | awk '{
+          target = $2
+          test_log = ""
+          if (match($0, /\(see [^)]*test\.log\)/)) {
+            test_log = substr($0, RSTART + 5, RLENGTH - 6)
+          }
+          if (!(target in test_logs) || test_logs[target] == "") {
+            test_logs[target] = test_log
+          }
+        }
+        END {
+          for (target in test_logs) {
+            print target "\t" test_logs[target]
+          }
+        }' \
       | sort -u
   )
 
-  if [[ ${#failed_targets[@]} -eq 0 ]]; then
+  if [[ ${#failed_target_logs[@]} -eq 0 ]]; then
     echo "No failed Bazel test targets were found in console output."
     return
   fi
 
-  for target in "${failed_targets[@]}"; do
-    local rel_path="${target#//}"
-    rel_path="${rel_path/:/\/}"
-    local test_log="${testlogs_dir}/${rel_path}/test.log"
+  echo
+  echo "Bazel failed test targets:"
+  for target_log in "${failed_target_logs[@]}"; do
+    local target="${target_log%%$'\t'*}"
+    echo "  FAIL ${target}"
+  done
 
-    echo "::group::Bazel test log tail for ${target}"
+  for target_log in "${failed_target_logs[@]}"; do
+    local target="${target_log%%$'\t'*}"
+    local test_log="${target_log#*$'\t'}"
+
+    if [[ -z "$test_log" ]]; then
+      if [[ -z "$testlogs_dir" ]]; then
+        if (( ${#bazel_startup_args[@]} > 0 )); then
+          bazel_info_cmd+=("${bazel_startup_args[@]}")
+        fi
+
+        testlogs_dir="$(run_bazel "${bazel_info_cmd[@]:1}" info bazel-testlogs 2>/dev/null || echo bazel-testlogs)"
+      fi
+
+      local rel_path="${target#//}"
+      rel_path="${rel_path/:/\/}"
+      test_log="${testlogs_dir}/${rel_path}/test.log"
+    fi
+
+    echo
+    echo "FAIL ${target}"
+    echo "test log: ${test_log}"
+    echo
     if [[ -f "$test_log" ]]; then
-      tail -n 200 "$test_log"
+      cat "$test_log"
     else
       echo "Missing test log: $test_log"
     fi
-    echo "::endgroup::"
   done
 }
 
@@ -272,7 +302,7 @@ fi
 
 if [[ ${bazel_status:-0} -ne 0 ]]; then
   if [[ $print_failed_bazel_test_logs -eq 1 ]]; then
-    print_bazel_test_log_tails "$bazel_console_log"
+    print_failed_bazel_test_logs "$bazel_console_log"
   fi
   exit "$bazel_status"
 fi

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -108,6 +108,7 @@ jobs:
             "${bazel_wrapper_args[@]}" \
             -- \
             test \
+            --test_output=errors \
             --test_tag_filters=-argument-comment-lint \
             --test_verbose_timeout_warnings \
             --build_metadata=COMMIT_SHA=${GITHUB_SHA} \

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -97,7 +97,7 @@ jobs:
           )
 
           bazel_wrapper_args=(
-            --print-failed-test-logs
+            --summarize-failed-test-logs
             --use-node-test-env
           )
           if [[ "${RUNNER_OS}" == "Windows" ]]; then


### PR DESCRIPTION
Use Bazel's native --test_output=errors output in CI so failed test logs appear at the failing target. Keep the wrapper's end-of-job behavior compact: summarize Rust failure names with FAIL lines and aggregate the passed/failed/ignored/measured/filtered counts across failed Bazel targets.