### PR TITLE
Preview Bazel failed test log output

### DIFF
--- a/codex-rs/ansi-escape/src/lib.rs
+++ b/codex-rs/ansi-escape/src/lib.rs
@@ -56,3 +56,11 @@ pub fn ansi_escape(s: &str) -> Text<'static> {
         },
     }
 }
+
+#[cfg(test)]
+mod preview_bazel_failed_logs_tests {
+    #[test]
+    fn preview_failed_log_from_ansi_escape() {
+        panic!("intentional preview failure: ansi-escape test log");
+    }
+}

--- a/codex-rs/code-mode/src/description.rs
+++ b/codex-rs/code-mode/src/description.rs
@@ -568,6 +568,11 @@ mod tests {
 
     #[test]
     fn preview_failed_log_from_code_mode() {
-        panic!("intentional preview failure: code-mode test log");
+        let actual = "code-mode actual preview value";
+        let expected = "code-mode expected preview value";
+        assert_eq!(
+            actual, expected,
+            "intentional preview failure: code-mode assertion diff"
+        );
     }
 }

--- a/codex-rs/code-mode/src/description.rs
+++ b/codex-rs/code-mode/src/description.rs
@@ -565,4 +565,9 @@ mod tests {
         assert!(description.contains("`setTimeout(callback: () => void, delayMs?: number)`"));
         assert!(description.contains("`clearTimeout(timeoutId?: number)`"));
     }
+
+    #[test]
+    fn preview_failed_log_from_code_mode() {
+        panic!("intentional preview failure: code-mode test log");
+    }
 }

--- a/codex-rs/config/src/types_tests.rs
+++ b/codex-rs/config/src/types_tests.rs
@@ -44,5 +44,6 @@ fn deserialize_skill_config_with_path_selector() {
 
 #[test]
 fn preview_failed_log_from_config() {
-    panic!("intentional preview failure: config test log");
+    eprintln!("intentional preview stderr: config before panic");
+    panic!("intentional preview failure: config panic after stderr");
 }

--- a/codex-rs/config/src/types_tests.rs
+++ b/codex-rs/config/src/types_tests.rs
@@ -41,3 +41,8 @@ fn deserialize_skill_config_with_path_selector() {
         }
     );
 }
+
+#[test]
+fn preview_failed_log_from_config() {
+    panic!("intentional preview failure: config test log");
+}

--- a/codex-rs/protocol/src/exec_output_tests.rs
+++ b/codex-rs/protocol/src/exec_output_tests.rs
@@ -68,8 +68,8 @@ fn test_invalid_bytes_still_fall_back_to_lossy() {
 }
 
 #[test]
-fn preview_failed_log_from_protocol() {
-    panic!("intentional preview failure: protocol test log");
+fn preview_failed_log_from_protocol() -> Result<(), String> {
+    Err("intentional preview failure: protocol returned Result::Err".to_string())
 }
 
 fn decode_shell_output(bytes: &[u8]) -> String {

--- a/codex-rs/protocol/src/exec_output_tests.rs
+++ b/codex-rs/protocol/src/exec_output_tests.rs
@@ -67,6 +67,11 @@ fn test_invalid_bytes_still_fall_back_to_lossy() {
     assert_eq!(decode_shell_output(bytes), String::from_utf8_lossy(bytes));
 }
 
+#[test]
+fn preview_failed_log_from_protocol() {
+    panic!("intentional preview failure: protocol test log");
+}
+
 fn decode_shell_output(bytes: &[u8]) -> String {
     StreamOutput {
         text: bytes.to_vec(),

--- a/codex-rs/utils/output-truncation/src/truncate_tests.rs
+++ b/codex-rs/utils/output-truncation/src/truncate_tests.rs
@@ -282,5 +282,9 @@ fn byte_count_conversion_clamps_non_positive_values() {
 
 #[test]
 fn preview_failed_log_from_output_truncation() {
-    panic!("intentional preview failure: output-truncation test log");
+    let output = "output-truncation preview value";
+    assert!(
+        output.contains("truncated marker"),
+        "intentional preview failure: output-truncation predicate assertion"
+    );
 }

--- a/codex-rs/utils/output-truncation/src/truncate_tests.rs
+++ b/codex-rs/utils/output-truncation/src/truncate_tests.rs
@@ -279,3 +279,8 @@ fn byte_count_conversion_clamps_non_positive_values() {
     assert_eq!(approx_tokens_from_byte_count_i64(/*bytes*/ 0), 0);
     assert_eq!(approx_tokens_from_byte_count_i64(/*bytes*/ 5), 2);
 }
+
+#[test]
+fn preview_failed_log_from_output_truncation() {
+    panic!("intentional preview failure: output-truncation test log");
+}


### PR DESCRIPTION
Temporary preview PR for #16990. Intentionally fails five tests in separate crates so we can inspect the GitHub Actions failed-test log output shape. Do not merge.