### PR TITLE
[codex] Fix unified exec test build

### DIFF
--- a/codex-rs/core/tests/suite/unified_exec.rs
+++ b/codex-rs/core/tests/suite/unified_exec.rs
@@ -171,7 +171,7 @@ async fn create_workspace_directory(
     test: &TestCodex,
     rel_path: impl AsRef<std::path::Path>,
 ) -> Result<std::path::PathBuf> {
-    let abs_path = test.config.cwd.join(rel_path.as_ref())?;
+    let abs_path = test.config.cwd.join(rel_path.as_ref());
     test.fs()
         .create_directory(&abs_path, CreateDirectoryOptions { recursive: true })
         .await?;


### PR DESCRIPTION
## Summary
- Remove the stale `?` after `AbsolutePathBuf::join` in the unified exec integration test helper.

## Root Cause
- `AbsolutePathBuf::join` was made infallible, but `core/tests/suite/unified_exec.rs` still treated it as a `Result`, which broke the Windows test build for the `all` integration test target.

## Validation
- `just fmt`
- `cargo test -p codex-core --test all unified_exec_resolves_relative_workdir`