### PR TITLE
[codex] Enable image generation feature by default

### DIFF
--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -752,8 +752,8 @@ pub const FEATURES: &[FeatureSpec] = &[
     FeatureSpec {
         id: Feature::ImageGeneration,
         key: "image_generation",
-        stage: Stage::UnderDevelopment,
-        default_enabled: false,
+        stage: Stage::Stable,
+        default_enabled: true,
     },
     FeatureSpec {
         id: Feature::SkillMcpDependencyInstall,

--- a/codex-rs/features/src/tests.rs
+++ b/codex-rs/features/src/tests.rs
@@ -145,9 +145,9 @@ fn use_linux_sandbox_bwrap_is_a_removed_feature_key() {
 }
 
 #[test]
-fn image_generation_is_under_development() {
-    assert_eq!(Feature::ImageGeneration.stage(), Stage::UnderDevelopment);
-    assert_eq!(Feature::ImageGeneration.default_enabled(), false);
+fn image_generation_is_stable_and_enabled_by_default() {
+    assert_eq!(Feature::ImageGeneration.stage(), Stage::Stable);
+    assert_eq!(Feature::ImageGeneration.default_enabled(), true);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Mark `image_generation` as a stable feature.
- Enable `image_generation` by default in the feature registry.
- Update the feature registry test expectation.

## Validation

- `just fmt`
- `cargo test -p codex-features image_generation`
- `git diff --check`