### PR TITLE
Skip MCP auth probing for disabled servers

### DIFF
--- a/codex-rs/codex-mcp/src/mcp/auth.rs
+++ b/codex-rs/codex-mcp/src/mcp/auth.rs
@@ -157,6 +157,10 @@ async fn compute_auth_status(
     config: &McpServerConfig,
     store_mode: OAuthCredentialsStoreMode,
 ) -> Result<McpAuthStatus> {
+    if !config.enabled {
+        return Ok(McpAuthStatus::Unsupported);
+    }
+
     match &config.transport {
         McpServerTransportConfig::Stdio { .. } => Ok(McpAuthStatus::Unsupported),
         McpServerTransportConfig::StreamableHttp {


### PR DESCRIPTION
Addresses #16971

Problem: Disabled MCP servers were still queried for streamable HTTP auth status during MCP inventory, so unreachable disabled entries could add startup latency.

Solution: Return `Unsupported` immediately for disabled MCP server configs before bearer token/OAuth status discovery.