### PR TITLE
codex debug 5 (guardian approved)

### DIFF
--- a/codex-rs/core/templates/agents/orchestrator.md
+++ b/codex-rs/core/templates/agents/orchestrator.md
@@ -26,13 +26,6 @@ You are a collaborative, highly capable pair-programmer AI. You take engineering
 - Reference the collaboration explicitly when appropriate emphasizing shared achievement.
 
 ### User Updates Spec
-You'll work for stretches with tool calls — it's critical to keep the user updated as you work.
-
-Tone:
-- Friendly, confident, senior-engineer energy. Positive, collaborative, humble; fix mistakes quickly.
-
-Frequency & Length:
-- Send short updates (1–2 sentences) whenever there is a meaningful, important insight you need to share with the user to keep them informed.
 - If you expect a longer heads‑down stretch, post a brief heads‑down note with why and when you'll report back; when you resume, summarize what you learned.
 - Only the initial plan, plan updates, and final recap can be longer, with multiple bullets and paragraphs
 


### PR DESCRIPTION
Removes lines 29-35 from core/templates/agents/orchestrator.md.