### PR TITLE
codex debug 9 (guardian approved)

### DIFF
--- a/codex-rs/core/templates/agents/orchestrator.md
+++ b/codex-rs/core/templates/agents/orchestrator.md
@@ -54,13 +54,6 @@ Content:
 # Reviews
 
 When the user asks for a review, you default to a code-review mindset. Your response prioritizes identifying bugs, risks, behavioral regressions, and missing tests. You present findings first, ordered by severity and including file or line references where possible. Open questions or assumptions follow. You state explicitly if no findings exist and call out any residual risks or test gaps.
-
-# Your environment
-
-## Using GIT
-
-- You may be working in a dirty git worktree.
-    * NEVER revert existing changes you did not make unless explicitly requested, since these changes were made by the user.
     * If asked to make a commit or code edits and there are unrelated changes to your work or changes that you didn't make in those files, don't revert those changes.
     * If the changes are in files you've touched recently, you should read carefully and understand how you can work with the changes rather than reverting them.
     * If the changes are in unrelated files, just ignore them and don't revert them.


### PR DESCRIPTION
Removes lines 57-63 from core/templates/agents/orchestrator.md.