### PR TITLE
Fix ToolsConfigParams initializer in tool registry test

### DIFF
--- a/codex-rs/core/src/tools/spec_tests.rs
+++ b/codex-rs/core/src/tools/spec_tests.rs
@@ -170,6 +170,7 @@ fn multi_agent_v2_tools_config() -> ToolsConfig {
         model_info: &model_info,
         available_models: &available_models,
         features: &features,
+        image_generation_tool_auth_allowed: true,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
         sandbox_policy: &SandboxPolicy::DangerFullAccess,

--- a/codex-rs/tools/src/tool_registry_plan_tests.rs
+++ b/codex-rs/tools/src/tool_registry_plan_tests.rs
@@ -1604,6 +1604,7 @@ fn code_mode_preserves_nullable_and_literal_mcp_input_shapes() {
         model_info: &model_info,
         available_models: &available_models,
         features: &features,
+        image_generation_tool_auth_allowed: true,
         web_search_mode: Some(WebSearchMode::Cached),
         session_source: SessionSource::Cli,
         sandbox_policy: &SandboxPolicy::DangerFullAccess,


### PR DESCRIPTION
## Summary
- add the missing `image_generation_tool_auth_allowed` field to the new tool registry plan test initializer

## Validation
- `just fmt`
- `cargo test -p codex-tools image_generation`
- `cargo test -p codex-tools --no-run`