### PR TITLE
refactor(proxy): clarify sandbox block messages

### DIFF
--- a/codex-rs/core/src/network_policy_decision.rs
+++ b/codex-rs/core/src/network_policy_decision.rs
@@ -60,9 +60,9 @@ pub(crate) fn denied_network_policy_message(blocked: &BlockedRequest) -> Option<
     let detail = match blocked.reason.as_str() {
         "denied" => "domain is explicitly denied by policy and cannot be approved from this prompt",
         "not_allowed" => "domain is not on the allowlist for the current sandbox mode",
-        "not_allowed_local" => "local/private network addresses are blocked by policy",
+        "not_allowed_local" => "local/private network addresses are blocked by the sandbox policy",
         "method_not_allowed" => "request method is blocked by the current network mode",
-        "proxy_disabled" => "managed network proxy is disabled",
+        "proxy_disabled" => "network proxy is disabled",
         _ => "request is blocked by network policy",
     };
 

--- a/codex-rs/network-proxy/src/responses.rs
+++ b/codex-rs/network-proxy/src/responses.rs
@@ -6,6 +6,7 @@ use crate::reasons::REASON_METHOD_NOT_ALLOWED;
 use crate::reasons::REASON_MITM_REQUIRED;
 use crate::reasons::REASON_NOT_ALLOWED;
 use crate::reasons::REASON_NOT_ALLOWED_LOCAL;
+use crate::reasons::REASON_PROXY_DISABLED;
 use rama_http::Body;
 use rama_http::Response;
 use rama_http::StatusCode;
@@ -59,18 +60,13 @@ pub fn blocked_header_value(reason: &str) -> &'static str {
 
 pub fn blocked_message(reason: &str) -> &'static str {
     match reason {
-        REASON_NOT_ALLOWED => {
-            "Codex blocked this request: domain not in allowlist (this is not a denylist block)."
-        }
-        REASON_NOT_ALLOWED_LOCAL => {
-            "Codex blocked this request: local/private addresses not allowed."
-        }
-        REASON_DENIED => "Codex blocked this request: domain denied by policy.",
-        REASON_METHOD_NOT_ALLOWED => {
-            "Codex blocked this request: method not allowed in limited mode."
-        }
-        REASON_MITM_REQUIRED => "Codex blocked this request: MITM required for limited HTTPS.",
-        _ => "Codex blocked this request by network policy.",
+        REASON_NOT_ALLOWED => "Domain not in allowlist.",
+        REASON_NOT_ALLOWED_LOCAL => "Sandbox policy blocks local/private network addresses.",
+        REASON_DENIED => "Domain denied by the sandbox policy.",
+        REASON_METHOD_NOT_ALLOWED => "Method not allowed in limited mode.",
+        REASON_MITM_REQUIRED => "MITM required for limited HTTPS.",
+        REASON_PROXY_DISABLED => "network proxy is disabled",
+        _ => "Request blocked by network policy.",
     }
 }
 
@@ -117,9 +113,6 @@ mod tests {
         };
 
         let message = blocked_message_with_policy(REASON_NOT_ALLOWED, &details);
-        assert_eq!(
-            message,
-            "Codex blocked this request: domain not in allowlist (this is not a denylist block)."
-        );
+        assert_eq!(message, "Domain not in allowlist.");
     }
 }


### PR DESCRIPTION
## Summary
- Replace Codex-branded network-proxy block responses with concise reason text
- Mention sandbox policy for local/private network and deny-policy wording
- Remove “managed” from the proxy-disabled denial detail