### PR TITLE
Support Warp for OSC 9 notifications

### DIFF
--- a/codex-rs/tui/src/notifications/mod.rs
+++ b/codex-rs/tui/src/notifications/mod.rs
@@ -56,7 +56,7 @@ fn supports_osc9() -> bool {
     // that don't set it (e.g., tmux/ssh) to avoid regressing OSC 9 support.
     if matches!(
         env::var("TERM_PROGRAM").ok().as_deref(),
-        Some("WezTerm" | "ghostty")
+        Some("WezTerm" | "WarpTerminal" | "ghostty")
     ) {
         return true;
     }


### PR DESCRIPTION
Problem: Warp supports OSC 9 notifications, but the TUI's automatic notification backend selection did not recognize its `TERM_PROGRAM=WarpTerminal` environment value.

Solution: Treat `TERM_PROGRAM=WarpTerminal` as OSC 9-capable when choosing the TUI desktop notification backend.