### PR TITLE
[oe 2/2] exec-server: route remote tools from Environment cwd

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1032,6 +1032,20 @@ impl TurnContext {
             .map_or_else(|| self.cwd.to_path_buf(), |p| self.cwd.as_path().join(p))
     }
 
+    pub(crate) fn environment_cwd(&self) -> &Path {
+        self.environment
+            .as_ref()
+            .map_or(self.cwd.as_path(), |environment| environment.cwd())
+    }
+
+    pub(crate) fn resolve_environment_path(&self, path: Option<String>) -> PathBuf {
+        let base = self.environment_cwd();
+        path.as_ref().map(PathBuf::from).map_or_else(
+            || base.to_path_buf(),
+            |path| crate::util::resolve_path(base, &path),
+        )
+    }
+
     pub(crate) fn compact_prompt(&self) -> &str {
         self.compact_prompt
             .as_deref()

--- a/codex-rs/core/src/tools/handlers/apply_patch.rs
+++ b/codex-rs/core/src/tools/handlers/apply_patch.rs
@@ -113,7 +113,7 @@ async fn effective_patch_permissions(
     let effective_additional_permissions = apply_granted_turn_permissions(
         session,
         crate::sandboxing::SandboxPermissions::UseDefault,
-        write_permissions_for_paths(&file_paths, &file_system_sandbox_policy, &turn.cwd),
+        write_permissions_for_paths(&file_paths, &file_system_sandbox_policy, &action.cwd),
     )
     .await;
 
@@ -168,7 +168,13 @@ impl ToolHandler for ApplyPatchHandler {
 
         // Re-parse and verify the patch so we can compute changes and approval.
         // Avoid building temporary ExecParams/command vectors; derive directly from inputs.
-        let cwd = turn.cwd.clone();
+        let cwd = AbsolutePathBuf::try_from(turn.resolve_environment_path(/*path*/ None)).map_err(
+            |err| {
+                FunctionCallError::RespondToModel(format!(
+                    "apply_patch verification failed: failed to resolve cwd: {err}"
+                ))
+            },
+        )?;
         let command = vec!["apply_patch".to_string(), patch_input.clone()];
         let Some(environment) = turn.environment.as_ref() else {
             return Err(FunctionCallError::RespondToModel(

--- a/codex-rs/core/src/tools/handlers/unified_exec.rs
+++ b/codex-rs/core/src/tools/handlers/unified_exec.rs
@@ -189,10 +189,10 @@ impl ToolHandler for UnifiedExecHandler {
 
         let response = match tool_name.as_str() {
             "exec_command" => {
-                let cwd = resolve_workdir_base_path(&arguments, context.turn.cwd.as_path())?;
+                let cwd = resolve_workdir_base_path(&arguments, context.turn.environment_cwd())?;
                 let args: ExecCommandArgs =
                     parse_arguments_with_base_path(&arguments, cwd.as_path())?;
-                let workdir = context.turn.resolve_path(args.workdir.clone());
+                let workdir = context.turn.resolve_environment_path(args.workdir.clone());
                 maybe_emit_implicit_skill_invocation(
                     session.as_ref(),
                     context.turn.as_ref(),
@@ -255,7 +255,7 @@ impl ToolHandler for UnifiedExecHandler {
 
                 let workdir = workdir.filter(|value| !value.is_empty());
 
-                let workdir = workdir.map(|dir| context.turn.resolve_path(Some(dir)));
+                let workdir = workdir.map(|dir| context.turn.resolve_environment_path(Some(dir)));
                 let cwd = workdir.clone().unwrap_or(cwd);
                 let normalized_additional_permissions = match implicit_granted_permissions(
                     sandbox_permissions,

--- a/codex-rs/core/src/tools/handlers/view_image.rs
+++ b/codex-rs/core/src/tools/handlers/view_image.rs
@@ -87,8 +87,8 @@ impl ToolHandler for ViewImageHandler {
             }
         };
 
-        let abs_path =
-            AbsolutePathBuf::try_from(turn.resolve_path(Some(args.path))).map_err(|error| {
+        let abs_path = AbsolutePathBuf::try_from(turn.resolve_environment_path(Some(args.path)))
+            .map_err(|error| {
                 FunctionCallError::RespondToModel(format!("unable to resolve image path: {error}"))
             })?;
         let Some(environment) = turn.environment.as_ref() else {

--- a/codex-rs/core/src/tools/runtimes/unified_exec.rs
+++ b/codex-rs/core/src/tools/runtimes/unified_exec.rs
@@ -46,6 +46,7 @@ use codex_shell_command::powershell::prefix_powershell_script_with_utf8;
 use codex_tools::UnifiedExecShellMode;
 use futures::future::BoxFuture;
 use std::collections::HashMap;
+use std::path::Path;
 use std::path::PathBuf;
 
 /// Request payload used by the unified-exec runtime after approvals and
@@ -55,6 +56,7 @@ pub struct UnifiedExecRequest {
     pub command: Vec<String>,
     pub process_id: i32,
     pub cwd: PathBuf,
+    pub sandbox_cwd: PathBuf,
     pub env: HashMap<String, String>,
     pub explicit_env_overrides: HashMap<String, String>,
     pub network: Option<NetworkProxy>,
@@ -92,10 +94,11 @@ struct RemoteManagedNetworkLaunch {
 
 fn build_remote_exec_sandbox_config(
     attempt: &SandboxAttempt<'_>,
+    sandbox_cwd: &Path,
     additional_permissions: Option<PermissionProfile>,
 ) -> SandboxLaunchConfig {
     if matches!(attempt.sandbox, codex_sandboxing::SandboxType::None) {
-        return SandboxLaunchConfig::no_sandbox(attempt.sandbox_cwd.to_path_buf());
+        return SandboxLaunchConfig::no_sandbox(sandbox_cwd.to_path_buf());
     }
 
     SandboxLaunchConfig {
@@ -103,7 +106,7 @@ fn build_remote_exec_sandbox_config(
         policy: attempt.policy.clone(),
         file_system_policy: attempt.file_system_policy.clone(),
         network_policy: attempt.network_policy,
-        sandbox_policy_cwd: attempt.sandbox_cwd.to_path_buf(),
+        sandbox_policy_cwd: sandbox_cwd.to_path_buf(),
         additional_permissions,
         enforce_managed_network: attempt.enforce_managed_network,
         windows_sandbox_level: attempt.windows_sandbox_level,
@@ -316,6 +319,7 @@ impl<'a> ToolRuntime<UnifiedExecRequest, UnifiedExecProcess> for UnifiedExecRunt
                 arg0: None,
                 sandbox: build_remote_exec_sandbox_config(
                     attempt,
+                    req.sandbox_cwd.as_path(),
                     req.additional_permissions.clone(),
                 ),
                 managed_network,

--- a/codex-rs/core/src/unified_exec/mod_tests.rs
+++ b/codex-rs/core/src/unified_exec/mod_tests.rs
@@ -622,3 +622,84 @@ async fn remote_exec_server_rejects_inherited_fd_launches() -> anyhow::Result<()
     );
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn turn_context_resolves_environment_paths_from_remote_environment_cwd() -> anyhow::Result<()>
+{
+    skip_if_sandbox!(Ok(()));
+    let Some(_remote_env) = get_remote_test_env() else {
+        return Ok(());
+    };
+
+    let remote_test_env = remote_test_env().await?;
+    let (_, mut turn) = make_session_and_context().await;
+    let thread_cwd = turn.cwd.to_path_buf();
+    turn.environment = Some(Arc::new(remote_test_env.environment().clone()));
+
+    let environment_cwd = turn.environment_cwd().to_path_buf();
+    assert_ne!(
+        environment_cwd, thread_cwd,
+        "remote environment cwd should be a useful regression sentinel"
+    );
+    assert_eq!(environment_cwd, remote_test_env.environment().cwd());
+    assert_eq!(
+        turn.resolve_environment_path(Some("relative-workdir".to_string())),
+        environment_cwd.join("relative-workdir")
+    );
+    assert_eq!(
+        turn.resolve_path(Some("relative-workdir".to_string())),
+        thread_cwd.join("relative-workdir")
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unified_exec_exec_command_uses_remote_environment_cwd_by_default() -> anyhow::Result<()> {
+    skip_if_sandbox!(Ok(()));
+    let Some(_remote_env) = get_remote_test_env() else {
+        return Ok(());
+    };
+
+    let remote_test_env = remote_test_env().await?;
+    let (session, mut turn) = make_session_and_context().await;
+    turn.environment = Some(Arc::new(remote_test_env.environment().clone()));
+
+    let session = Arc::new(session);
+    let turn = Arc::new(turn);
+    let manager = &session.services.unified_exec_manager;
+    let context = UnifiedExecContext::new(Arc::clone(&session), Arc::clone(&turn), "call".into());
+    let process_id = manager.allocate_process_id().await;
+    let output = manager
+        .exec_command(
+            ExecCommandRequest {
+                command: vec![
+                    "bash".to_string(),
+                    "-lc".to_string(),
+                    "printf 'PWD=%s\\n' \"$PWD\"".to_string(),
+                ],
+                process_id,
+                yield_time_ms: 2_500,
+                max_output_tokens: None,
+                workdir: None,
+                network: None,
+                tty: false,
+                sandbox_permissions: SandboxPermissions::UseDefault,
+                additional_permissions: None,
+                additional_permissions_preapproved: false,
+                justification: None,
+                prefix_rule: None,
+            },
+            &context,
+        )
+        .await?;
+
+    assert_eq!(
+        output.truncated_output(),
+        format!("PWD={}\n", turn.environment_cwd().display())
+    );
+    assert_eq!(output.exit_code, Some(0));
+    assert_eq!(output.process_id, None);
+
+    Ok(())
+}

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -162,10 +162,11 @@ impl UnifiedExecProcessManager {
         request: ExecCommandRequest,
         context: &UnifiedExecContext,
     ) -> Result<ExecCommandToolOutput, UnifiedExecError> {
+        let sandbox_cwd = context.turn.environment_cwd().to_path_buf();
         let cwd = request
             .workdir
             .clone()
-            .unwrap_or_else(|| context.turn.cwd.to_path_buf());
+            .unwrap_or_else(|| sandbox_cwd.clone());
         let process = self
             .open_session_with_sandbox(&request, cwd.clone(), context)
             .await;
@@ -695,6 +696,7 @@ impl UnifiedExecProcessManager {
             command: request.command.clone(),
             process_id: request.process_id,
             cwd,
+            sandbox_cwd,
             env,
             explicit_env_overrides: context.turn.shell_environment_policy.r#set.clone(),
             network: request.network.clone(),

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -692,6 +692,7 @@ impl UnifiedExecProcessManager {
                 prefix_rule: request.prefix_rule.clone(),
             })
             .await;
+        let sandbox_cwd = context.turn.environment_cwd().to_path_buf();
         let req = UnifiedExecToolRequest {
             command: request.command.clone(),
             process_id: request.process_id,

--- a/codex-rs/exec-server/src/client.rs
+++ b/codex-rs/exec-server/src/client.rs
@@ -1,4 +1,6 @@
 use std::collections::HashMap;
+use std::path::Path;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -118,6 +120,7 @@ struct Inner {
     // need serialization so concurrent register/remove operations do not
     // overwrite each other's copy-on-write updates.
     sessions_write_lock: Mutex<()>,
+    cwd: PathBuf,
     reader_task: tokio::task::JoinHandle<()>,
 }
 
@@ -181,30 +184,6 @@ impl ExecServerClient {
             args.into(),
         )
         .await
-    }
-
-    pub async fn initialize(
-        &self,
-        options: ExecServerClientConnectOptions,
-    ) -> Result<InitializeResponse, ExecServerError> {
-        let ExecServerClientConnectOptions {
-            client_name,
-            initialize_timeout,
-        } = options;
-
-        timeout(initialize_timeout, async {
-            let response = self
-                .inner
-                .client
-                .call(INITIALIZE_METHOD, &InitializeParams { client_name })
-                .await?;
-            self.notify_initialized().await?;
-            Ok(response)
-        })
-        .await
-        .map_err(|_| ExecServerError::InitializeTimedOut {
-            timeout: initialize_timeout,
-        })?
     }
 
     pub async fn exec(&self, params: ExecParams) -> Result<ExecResponse, ExecServerError> {
@@ -350,11 +329,34 @@ impl ExecServerClient {
         self.inner.remove_session(process_id).await;
     }
 
+    pub fn cwd(&self) -> &Path {
+        self.inner.cwd.as_path()
+    }
+
     async fn connect(
         connection: JsonRpcConnection,
         options: ExecServerClientConnectOptions,
     ) -> Result<Self, ExecServerError> {
         let (rpc_client, mut events_rx) = RpcClient::new(connection);
+        let ExecServerClientConnectOptions {
+            client_name,
+            initialize_timeout,
+        } = options;
+        let initialize_response = timeout(initialize_timeout, async {
+            let response: InitializeResponse = rpc_client
+                .call(INITIALIZE_METHOD, &InitializeParams { client_name })
+                .await?;
+            rpc_client
+                .notify(INITIALIZED_METHOD, &serde_json::json!({}))
+                .await
+                .map_err(ExecServerError::Json)?;
+            Ok(response)
+        })
+        .await
+        .map_err(|_| ExecServerError::InitializeTimedOut {
+            timeout: initialize_timeout,
+        })??;
+
         let inner = Arc::new_cyclic(|weak| {
             let weak = weak.clone();
             let reader_task = tokio::spawn(async move {
@@ -388,21 +390,11 @@ impl ExecServerClient {
                 client: rpc_client,
                 sessions: ArcSwap::from_pointee(HashMap::new()),
                 sessions_write_lock: Mutex::new(()),
+                cwd: initialize_response.cwd,
                 reader_task,
             }
         });
-
-        let client = Self { inner };
-        client.initialize(options).await?;
-        Ok(client)
-    }
-
-    async fn notify_initialized(&self) -> Result<(), ExecServerError> {
-        self.inner
-            .client
-            .notify(INITIALIZED_METHOD, &serde_json::json!({}))
-            .await
-            .map_err(ExecServerError::Json)
+        Ok(Self { inner })
     }
 }
 
@@ -632,6 +624,7 @@ mod tests {
     use codex_app_server_protocol::JSONRPCNotification;
     use codex_app_server_protocol::JSONRPCResponse;
     use pretty_assertions::assert_eq;
+    use std::path::PathBuf;
     use tokio::io::AsyncBufReadExt;
     use tokio::io::AsyncWrite;
     use tokio::io::AsyncWriteExt;
@@ -693,8 +686,10 @@ mod tests {
                 &mut server_writer,
                 JSONRPCMessage::Response(JSONRPCResponse {
                     id: request.id,
-                    result: serde_json::to_value(InitializeResponse {})
-                        .expect("initialize response should serialize"),
+                    result: serde_json::to_value(InitializeResponse {
+                        cwd: PathBuf::from("/server/default"),
+                    })
+                    .expect("initialize response should serialize"),
                 }),
             )
             .await;
@@ -721,6 +716,7 @@ mod tests {
         )
         .await
         .expect("client should connect");
+        assert_eq!(client.cwd(), PathBuf::from("/server/default"));
 
         let noisy_process_id = ProcessId::from("noisy");
         let quiet_process_id = ProcessId::from("quiet");

--- a/codex-rs/exec-server/src/client.rs
+++ b/codex-rs/exec-server/src/client.rs
@@ -350,7 +350,7 @@ impl ExecServerClient {
                 .notify(INITIALIZED_METHOD, &serde_json::json!({}))
                 .await
                 .map_err(ExecServerError::Json)?;
-            Ok(response)
+            Ok::<InitializeResponse, ExecServerError>(response)
         })
         .await
         .map_err(|_| ExecServerError::InitializeTimedOut {

--- a/codex-rs/exec-server/src/environment.rs
+++ b/codex-rs/exec-server/src/environment.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use tokio::sync::OnceCell;
@@ -95,22 +97,25 @@ impl EnvironmentManager {
 pub struct Environment {
     exec_server_url: Option<String>,
     remote_exec_server_client: Option<ExecServerClient>,
+    cwd: PathBuf,
     exec_backend: Arc<dyn ExecBackend>,
 }
 
 impl Default for Environment {
     fn default() -> Self {
         let local_process = LocalProcess::default();
-        if let Err(err) = local_process.initialize() {
-            panic!("default local process initialization should succeed: {err:?}");
-        }
+        local_process
+            .initialize()
+            .expect("default local process initialization should succeed");
         if let Err(err) = local_process.initialized() {
             panic!("default local process should accept initialized notification: {err}");
         }
+        let cwd = std::env::current_dir().expect("default local cwd should be readable");
 
         Self {
             exec_server_url: None,
             remote_exec_server_client: None,
+            cwd,
             exec_backend: Arc::new(local_process),
         }
     }
@@ -148,8 +153,13 @@ impl Environment {
             None
         };
 
-        let exec_backend: Arc<dyn ExecBackend> = match remote_exec_server_client.clone() {
-            Some(client) => Arc::new(RemoteProcess::new(client)),
+        let (cwd, exec_backend): (PathBuf, Arc<dyn ExecBackend>) = match remote_exec_server_client
+            .clone()
+        {
+            Some(client) => (
+                client.cwd().to_path_buf(),
+                Arc::new(RemoteProcess::new(client)),
+            ),
             None if exec_server_url.is_some() => {
                 return Err(ExecServerError::Protocol(
                     "remote mode should have an exec-server client".to_string(),
@@ -163,13 +173,17 @@ impl Environment {
                 local_process
                     .initialized()
                     .map_err(ExecServerError::Protocol)?;
-                Arc::new(local_process)
+                let cwd = std::env::current_dir().map_err(|err| {
+                    ExecServerError::Protocol(format!("failed to read current directory: {err}"))
+                })?;
+                (cwd, Arc::new(local_process) as Arc<dyn ExecBackend>)
             }
         };
 
         Ok(Self {
             exec_server_url,
             remote_exec_server_client,
+            cwd,
             exec_backend,
         })
     }
@@ -185,6 +199,10 @@ impl Environment {
 
     pub fn get_exec_backend(&self) -> Arc<dyn ExecBackend> {
         Arc::clone(&self.exec_backend)
+    }
+
+    pub fn cwd(&self) -> &Path {
+        self.cwd.as_path()
     }
 
     pub fn get_filesystem(&self) -> Arc<dyn ExecutorFileSystem> {
@@ -220,6 +238,10 @@ mod tests {
 
         assert_eq!(environment.exec_server_url(), None);
         assert!(environment.remote_exec_server_client.is_none());
+        assert_eq!(
+            environment.cwd(),
+            std::env::current_dir().expect("read current dir").as_path()
+        );
     }
 
     #[test]

--- a/codex-rs/exec-server/src/local_process.rs
+++ b/codex-rs/exec-server/src/local_process.rs
@@ -38,7 +38,6 @@ use crate::protocol::ExecOutputDeltaNotification;
 use crate::protocol::ExecOutputStream;
 use crate::protocol::ExecParams;
 use crate::protocol::ExecResponse;
-use crate::protocol::InitializeResponse;
 use crate::protocol::ProcessOutputChunk;
 use crate::protocol::ReadParams;
 use crate::protocol::ReadResponse;
@@ -198,13 +197,13 @@ impl LocalProcess {
         }
     }
 
-    pub(crate) fn initialize(&self) -> Result<InitializeResponse, JSONRPCErrorError> {
+    pub(crate) fn initialize(&self) -> Result<(), JSONRPCErrorError> {
         if self.inner.initialize_requested.swap(true, Ordering::SeqCst) {
             return Err(invalid_request(
                 "initialize may only be sent once per connection".to_string(),
             ));
         }
-        Ok(InitializeResponse {})
+        Ok(())
     }
 
     pub(crate) fn initialized(&self) -> Result<(), String> {

--- a/codex-rs/exec-server/src/protocol.rs
+++ b/codex-rs/exec-server/src/protocol.rs
@@ -52,7 +52,9 @@ pub struct InitializeParams {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct InitializeResponse {}
+pub struct InitializeResponse {
+    pub cwd: PathBuf,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/codex-rs/exec-server/src/server/handler/tests.rs
+++ b/codex-rs/exec-server/src/server/handler/tests.rs
@@ -42,7 +42,9 @@ async fn initialized_handler() -> Arc<ExecServerHandler> {
     )));
     assert_eq!(
         handler.initialize().expect("initialize"),
-        InitializeResponse {}
+        InitializeResponse {
+            cwd: std::env::current_dir().expect("cwd")
+        }
     );
     handler.initialized().expect("initialized");
     handler

--- a/codex-rs/exec-server/src/server/process_handler.rs
+++ b/codex-rs/exec-server/src/server/process_handler.rs
@@ -11,6 +11,7 @@ use crate::protocol::TerminateResponse;
 use crate::protocol::WriteParams;
 use crate::protocol::WriteResponse;
 use crate::rpc::RpcNotificationSender;
+use crate::rpc::internal_error;
 
 #[derive(Clone)]
 pub(crate) struct ProcessHandler {
@@ -29,7 +30,13 @@ impl ProcessHandler {
     }
 
     pub(crate) fn initialize(&self) -> Result<InitializeResponse, JSONRPCErrorError> {
-        self.process.initialize()
+        self.process.initialize()?;
+        let cwd = std::env::current_dir().map_err(|err| {
+            internal_error(format!(
+                "failed to read exec-server current directory: {err}"
+            ))
+        })?;
+        Ok(InitializeResponse { cwd })
     }
 
     pub(crate) fn initialized(&self) -> Result<(), String> {

--- a/codex-rs/exec-server/tests/common/exec_server.rs
+++ b/codex-rs/exec-server/tests/common/exec_server.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+use std::path::Path;
 use std::process::Stdio;
 use std::time::Duration;
 
@@ -44,13 +45,27 @@ pub(crate) async fn exec_server() -> anyhow::Result<ExecServerHarness> {
     exec_server_with_env(&[]).await
 }
 
+pub(crate) async fn exec_server_in_cwd(cwd: &Path) -> anyhow::Result<ExecServerHarness> {
+    exec_server_with_env_and_cwd(&[], Some(cwd)).await
+}
+
 pub(crate) async fn exec_server_with_env(
     env: &[(&str, &str)],
+) -> anyhow::Result<ExecServerHarness> {
+    exec_server_with_env_and_cwd(env, None).await
+}
+
+pub(crate) async fn exec_server_with_env_and_cwd(
+    env: &[(&str, &str)],
+    cwd: Option<&Path>,
 ) -> anyhow::Result<ExecServerHarness> {
     let binary = cargo_bin("codex-exec-server")?;
     let mut child = Command::new(binary);
     child.args(["--listen", "ws://127.0.0.1:0"]);
     child.envs(env.iter().copied());
+    if let Some(cwd) = cwd {
+        child.current_dir(cwd);
+    }
     child.stdin(Stdio::null());
     child.stdout(Stdio::piped());
     child.stderr(Stdio::inherit());

--- a/codex-rs/exec-server/tests/exec_process.rs
+++ b/codex-rs/exec-server/tests/exec_process.rs
@@ -170,6 +170,37 @@ async fn assert_exec_process_streams_output(use_remote: bool) -> Result<()> {
     Ok(())
 }
 
+async fn assert_exec_process_uses_requested_cwd(use_remote: bool) -> Result<()> {
+    let context = create_process_context(use_remote).await?;
+    let requested_cwd = TempDir::new()?;
+    let requested_cwd = std::fs::canonicalize(requested_cwd.path())?;
+    let session = context
+        .backend
+        .start(ExecParams {
+            process_id: ProcessId::from("proc-cwd"),
+            argv: vec![
+                "/bin/sh".to_string(),
+                "-c".to_string(),
+                "printf 'PWD=%s\\n' \"$PWD\"".to_string(),
+            ],
+            cwd: requested_cwd.clone(),
+            env: Default::default(),
+            tty: false,
+            arg0: None,
+            sandbox: SandboxLaunchConfig::no_sandbox(requested_cwd.clone()),
+            managed_network: None,
+        })
+        .await?;
+
+    let StartedExecProcess { process, .. } = session;
+    let wake_rx = process.subscribe_wake();
+    let (output, exit_code, closed) = collect_process_output_from_reads(process, wake_rx).await?;
+    assert_eq!(output, format!("PWD={}\n", requested_cwd.display()));
+    assert_eq!(exit_code, Some(0));
+    assert!(closed);
+    Ok(())
+}
+
 fn parse_env_output(output: &str) -> HashMap<String, String> {
     output
         .lines()
@@ -518,6 +549,13 @@ async fn exec_process_starts_and_exits(use_remote: bool) -> Result<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn exec_process_streams_output(use_remote: bool) -> Result<()> {
     assert_exec_process_streams_output(use_remote).await
+}
+
+#[test_case(false ; "local")]
+#[test_case(true ; "remote")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn exec_process_uses_requested_cwd(use_remote: bool) -> Result<()> {
+    assert_exec_process_uses_requested_cwd(use_remote).await
 }
 
 #[test_case(false, Some("client-request"), None, Some("client-request")

--- a/codex-rs/exec-server/tests/initialize.rs
+++ b/codex-rs/exec-server/tests/initialize.rs
@@ -4,14 +4,18 @@ mod common;
 
 use codex_app_server_protocol::JSONRPCMessage;
 use codex_app_server_protocol::JSONRPCResponse;
+use codex_exec_server::Environment;
 use codex_exec_server::InitializeParams;
 use codex_exec_server::InitializeResponse;
-use common::exec_server::exec_server;
+use common::exec_server::exec_server_in_cwd;
 use pretty_assertions::assert_eq;
+use tempfile::TempDir;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn exec_server_accepts_initialize() -> anyhow::Result<()> {
-    let mut server = exec_server().await?;
+    let remote_cwd = TempDir::new()?;
+    let remote_cwd = remote_cwd.path().canonicalize()?;
+    let mut server = exec_server_in_cwd(&remote_cwd).await?;
     let initialize_id = server
         .send_request(
             "initialize",
@@ -27,7 +31,21 @@ async fn exec_server_accepts_initialize() -> anyhow::Result<()> {
     };
     assert_eq!(id, initialize_id);
     let initialize_response: InitializeResponse = serde_json::from_value(result)?;
-    assert_eq!(initialize_response, InitializeResponse {});
+    assert_eq!(initialize_response, InitializeResponse { cwd: remote_cwd });
+
+    server.shutdown().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn remote_environment_uses_exec_server_cwd() -> anyhow::Result<()> {
+    let remote_cwd = TempDir::new()?;
+    let remote_cwd = remote_cwd.path().canonicalize()?;
+    let mut server = exec_server_in_cwd(&remote_cwd).await?;
+
+    let environment = Environment::create(Some(server.websocket_url().to_string())).await?;
+
+    assert_eq!(environment.cwd(), remote_cwd.as_path());
 
     server.shutdown().await?;
     Ok(())

--- a/codex-rs/exec-server/tests/websocket.rs
+++ b/codex-rs/exec-server/tests/websocket.rs
@@ -53,7 +53,12 @@ async fn exec_server_reports_malformed_websocket_json_and_keeps_running() -> any
     };
     assert_eq!(id, initialize_id);
     let initialize_response: InitializeResponse = serde_json::from_value(result)?;
-    assert_eq!(initialize_response, InitializeResponse {});
+    assert_eq!(
+        initialize_response,
+        InitializeResponse {
+            cwd: std::env::current_dir()?
+        }
+    );
 
     server.shutdown().await?;
     Ok(())


### PR DESCRIPTION
## Summary
- return the exec-server current directory in the initialize response
- store that cwd on remote `Environment` without replacing the thread-level cwd
- add `TurnContext` helpers for choosing Environment cwd at tool/runtime boundaries
- route remote exec, persistent exec sessions, apply_patch, and view_image relative-path handling through the Environment cwd
- add cwd smoke coverage for exec-server process startup and unified exec remote Environment selection

## Stack / Land Order
1. #17181: remote exec-server host env
2. This PR: exec-server cwd / Environment cwd routing

Stacked on #17181 (`starr/oe-p20-exec-server-host-env-20260408`).

## Behavior
- Thread cwd remains the orchestrator/thread cwd
- `Environment::cwd()` is the execution host cwd
- Remote tool callsites now select `turn.environment_cwd()` for execution-relative defaults
- Explicit tool cwd/workdir requests still resolve relative to that environment cwd

## Validation
Remote on `dev` via the `codex-applied-devbox` mirror `/tmp/codex-worktrees/oe-p20-exec-server-smoke-flow-20260408`:

```sh
cargo check -p codex-exec-server -p codex-core
cargo test -p codex-exec-server --test exec_process exec_process_uses_requested_cwd -- --nocapture
CODEX_TEST_REMOTE_ENV=codex-remote-test-env-privileged cargo test -p codex-core --lib environment_cwd -- --nocapture
```

All passed.

Co-authored-by: Codex <noreply@openai.com>