### PR TITLE
[oe 1/2] exec-server: derive remote exec env on the server

### DIFF
--- a/codex-rs/core/tests/suite/remote_env.rs
+++ b/codex-rs/core/tests/suite/remote_env.rs
@@ -1,12 +1,21 @@
 use anyhow::Result;
+use codex_exec_server::ExecBackend;
+use codex_exec_server::ExecParams;
+use codex_exec_server::ExecProcess;
+use codex_exec_server::ProcessId;
 use codex_exec_server::RemoveOptions;
+use codex_sandboxing::SandboxLaunchConfig;
 use core_test_support::PathBufExt;
 use core_test_support::get_remote_test_env;
 use core_test_support::test_codex::test_env;
 use pretty_assertions::assert_eq;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
+use tokio::sync::watch;
+use tokio::time::Duration;
+use tokio::time::timeout;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn remote_test_env_can_connect_and_use_filesystem() -> Result<()> {
@@ -38,6 +47,98 @@ async fn remote_test_env_can_connect_and_use_filesystem() -> Result<()> {
 
     Ok(())
 }
+
+async fn read_remote_process_until_change(
+    process: Arc<dyn ExecProcess>,
+    wake_rx: &mut watch::Receiver<u64>,
+    after_seq: Option<u64>,
+) -> Result<codex_exec_server::ReadResponse> {
+    let response = process
+        .read(after_seq, /*max_bytes*/ None, /*wait_ms*/ Some(0))
+        .await?;
+    if !response.chunks.is_empty() || response.closed || response.failure.is_some() {
+        return Ok(response);
+    }
+
+    timeout(Duration::from_secs(2), wake_rx.changed()).await??;
+    process
+        .read(after_seq, /*max_bytes*/ None, /*wait_ms*/ Some(0))
+        .await
+        .map_err(Into::into)
+}
+
+async fn collect_remote_process_output(
+    process: Arc<dyn ExecProcess>,
+    mut wake_rx: watch::Receiver<u64>,
+) -> Result<(String, Option<i32>)> {
+    let mut output = String::new();
+    let mut exit_code = None;
+    let mut after_seq = None;
+
+    loop {
+        let response =
+            read_remote_process_until_change(Arc::clone(&process), &mut wake_rx, after_seq).await?;
+        if let Some(message) = response.failure {
+            anyhow::bail!("process failed before closed state: {message}");
+        }
+        for chunk in response.chunks {
+            output.push_str(&String::from_utf8_lossy(&chunk.chunk.into_inner()));
+            after_seq = Some(chunk.seq);
+        }
+        if response.exited {
+            exit_code = response.exit_code;
+        }
+        if response.closed {
+            break;
+        }
+        after_seq = response.next_seq.checked_sub(1).or(after_seq);
+    }
+
+    Ok((output, exit_code))
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn remote_test_env_can_start_process_with_remote_cwd_env_and_arg0() -> Result<()> {
+    let Some(_remote_env) = get_remote_test_env() else {
+        return Ok(());
+    };
+
+    let test_env = test_env().await?;
+    let remote_cwd = test_env.cwd().clone().into_path_buf();
+    let command =
+        "printf 'PATH=%s\\n' \"$PATH\"; printf 'PWD=%s\\n' \"$PWD\"; printf 'ZERO=%s\\n' \"$0\""
+            .to_string();
+    let started = test_env
+        .environment()
+        .get_exec_backend()
+        .start(ExecParams {
+            process_id: ProcessId::from("remote-test-env-proc"),
+            argv: vec!["/bin/sh".to_string(), "-lc".to_string(), command],
+            cwd: remote_cwd.clone(),
+            env: Default::default(),
+            tty: false,
+            arg0: Some("sandbox-wrapper".to_string()),
+            sandbox: SandboxLaunchConfig::no_sandbox(remote_cwd.clone()),
+            managed_network: None,
+        })
+        .await?;
+
+    let wake_rx = started.process.subscribe_wake();
+    let (output, exit_code) = collect_remote_process_output(started.process, wake_rx).await?;
+    assert_eq!(exit_code, Some(0));
+
+    let lines = output.lines().collect::<Vec<_>>();
+    assert_eq!(lines.len(), 3, "unexpected remote output: {output:?}");
+    assert!(
+        lines[0].starts_with("PATH=") && lines[0].len() > "PATH=".len(),
+        "PATH should come from the remote exec-server"
+    );
+    assert_eq!(lines[1], format!("PWD={}", remote_cwd.display()));
+    assert_eq!(lines[2], "ZERO=sandbox-wrapper");
+
+    Ok(())
+}
+
 fn remote_test_file_path() -> PathBuf {
     let nanos = match SystemTime::now().duration_since(UNIX_EPOCH) {
         Ok(duration) => duration.as_nanos(),

--- a/codex-rs/exec-server/src/remote_process.rs
+++ b/codex-rs/exec-server/src/remote_process.rs
@@ -32,10 +32,14 @@ impl RemoteProcess {
 
 #[async_trait]
 impl ExecBackend for RemoteProcess {
-    async fn start(&self, params: ExecParams) -> Result<StartedExecProcess, ExecServerError> {
+    async fn start(&self, mut params: ExecParams) -> Result<StartedExecProcess, ExecServerError> {
         let process_id = params.process_id.clone();
         let sandbox_type = params.sandbox.sandbox;
         let session = self.client.register_session(&process_id).await?;
+        // TODO(exec-server): replace request env with an executor-evaluated env
+        // policy plus explicit per-request overrides. Do not send the
+        // orchestrator process environment across this boundary.
+        params.env.clear();
         match self.client.exec(params).await {
             Ok(_) => {}
             Err(err) => {

--- a/codex-rs/exec-server/src/server/process_handler.rs
+++ b/codex-rs/exec-server/src/server/process_handler.rs
@@ -43,7 +43,13 @@ impl ProcessHandler {
         self.process.require_initialized_for(method_family)
     }
 
-    pub(crate) async fn exec(&self, params: ExecParams) -> Result<ExecResponse, JSONRPCErrorError> {
+    pub(crate) async fn exec(
+        &self,
+        mut params: ExecParams,
+    ) -> Result<ExecResponse, JSONRPCErrorError> {
+        // TODO(exec-server): replace this process-wide inherit with an
+        // exec-server-side environment policy and explicit request overrides.
+        params.env = std::env::vars().collect();
         self.process.exec(params).await
     }
 

--- a/codex-rs/exec-server/tests/common/exec_server.rs
+++ b/codex-rs/exec-server/tests/common/exec_server.rs
@@ -41,9 +41,16 @@ impl Drop for ExecServerHarness {
 }
 
 pub(crate) async fn exec_server() -> anyhow::Result<ExecServerHarness> {
+    exec_server_with_env(&[]).await
+}
+
+pub(crate) async fn exec_server_with_env(
+    env: &[(&str, &str)],
+) -> anyhow::Result<ExecServerHarness> {
     let binary = cargo_bin("codex-exec-server")?;
     let mut child = Command::new(binary);
     child.args(["--listen", "ws://127.0.0.1:0"]);
+    child.envs(env.iter().copied());
     child.stdin(Stdio::null());
     child.stdout(Stdio::piped());
     child.stderr(Stdio::inherit());

--- a/codex-rs/exec-server/tests/exec_process.rs
+++ b/codex-rs/exec-server/tests/exec_process.rs
@@ -2,6 +2,7 @@
 
 mod common;
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -30,7 +31,9 @@ use tokio::time::Duration;
 use tokio::time::timeout;
 
 use common::exec_server::ExecServerHarness;
-use common::exec_server::exec_server;
+use common::exec_server::exec_server_with_env;
+
+const TEST_ENV_KEY: &str = "CODEX_EXEC_SERVER_TEST_ENV_SOURCE";
 
 struct ProcessContext {
     backend: Arc<dyn ExecBackend>,
@@ -38,8 +41,15 @@ struct ProcessContext {
 }
 
 async fn create_process_context(use_remote: bool) -> Result<ProcessContext> {
+    create_process_context_with_server_env(use_remote, &[]).await
+}
+
+async fn create_process_context_with_server_env(
+    use_remote: bool,
+    server_env: &[(&str, &str)],
+) -> Result<ProcessContext> {
     if use_remote {
-        let server = exec_server().await?;
+        let server = exec_server_with_env(server_env).await?;
         let environment = Environment::create(Some(server.websocket_url().to_string())).await?;
         Ok(ProcessContext {
             backend: environment.get_exec_backend(),
@@ -157,6 +167,86 @@ async fn assert_exec_process_streams_output(use_remote: bool) -> Result<()> {
     assert_eq!(output, "session output\n");
     assert_eq!(exit_code, Some(0));
     assert!(closed);
+    Ok(())
+}
+
+fn parse_env_output(output: &str) -> HashMap<String, String> {
+    output
+        .lines()
+        .filter_map(|line| {
+            let (key, value) = line.split_once('=')?;
+            Some((key.to_string(), value.to_string()))
+        })
+        .collect()
+}
+
+async fn collect_env_from_process(
+    use_remote: bool,
+    request_env: HashMap<String, String>,
+    server_env: &[(&str, &str)],
+) -> Result<HashMap<String, String>> {
+    let context = create_process_context_with_server_env(use_remote, server_env).await?;
+    let cwd = std::env::current_dir()?;
+    let session = context
+        .backend
+        .start(ExecParams {
+            process_id: ProcessId::from("proc-env-inherit"),
+            argv: vec!["/usr/bin/env".to_string()],
+            cwd: cwd.clone(),
+            env: request_env,
+            tty: false,
+            arg0: None,
+            sandbox: SandboxLaunchConfig::no_sandbox(cwd),
+            managed_network: None,
+        })
+        .await?;
+
+    let StartedExecProcess { process, .. } = session;
+    let wake_rx = process.subscribe_wake();
+    let (output, exit_code, closed) = collect_process_output_from_reads(process, wake_rx).await?;
+    assert_eq!(exit_code, Some(0));
+    assert!(closed);
+    Ok(parse_env_output(&output))
+}
+
+async fn assert_exec_process_selects_env_from_spawn_site(
+    use_remote: bool,
+    request_value: Option<&str>,
+    server_value: Option<&str>,
+    expected_value: Option<&str>,
+) -> Result<()> {
+    let request_path = "/orchestrator/path/that/must/not/win";
+    let server_path = "/exec/server/path/that/should/win/remotely";
+    let mut request_env = HashMap::new();
+    if let Some(value) = request_value {
+        request_env.insert(TEST_ENV_KEY.to_string(), value.to_string());
+        request_env.insert("PATH".to_string(), request_path.to_string());
+    }
+    let mut server_env = Vec::new();
+    if let Some(value) = server_value {
+        server_env.push((TEST_ENV_KEY, value));
+        server_env.push(("PATH", server_path));
+    }
+
+    let env = collect_env_from_process(use_remote, request_env, &server_env).await?;
+    assert_eq!(
+        env.get(TEST_ENV_KEY).map(String::as_str),
+        expected_value,
+        "child env should come from the expected process boundary"
+    );
+
+    let expected_path = if use_remote {
+        Some(server_path)
+    } else if request_value.is_some() {
+        Some(request_path)
+    } else {
+        None
+    };
+    assert_eq!(
+        env.get("PATH").map(String::as_str),
+        expected_path,
+        "PATH should follow the same spawn-site env selection"
+    );
     Ok(())
 }
 
@@ -428,6 +518,30 @@ async fn exec_process_starts_and_exits(use_remote: bool) -> Result<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn exec_process_streams_output(use_remote: bool) -> Result<()> {
     assert_exec_process_streams_output(use_remote).await
+}
+
+#[test_case(false, Some("client-request"), None, Some("client-request")
+    ; "local uses request env")]
+#[test_case(false, None, None, None
+    ; "local uses empty request env")]
+#[test_case(true, Some("client-request"), Some("exec-server"), Some("exec-server")
+    ; "remote uses server env instead of request env")]
+#[test_case(true, None, Some("exec-server"), Some("exec-server")
+    ; "remote uses server env without request env")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn exec_process_selects_env_from_spawn_site(
+    use_remote: bool,
+    request_value: Option<&str>,
+    server_value: Option<&str>,
+    expected_value: Option<&str>,
+) -> Result<()> {
+    assert_exec_process_selects_env_from_spawn_site(
+        use_remote,
+        request_value,
+        server_value,
+        expected_value,
+    )
+    .await
 }
 
 #[test_case(false ; "local")]


### PR DESCRIPTION
## Summary
- clear `ExecParams.env` in the remote exec-server client before sending `process/start`
- populate `ExecParams.env` inside the exec-server process handler from the exec-server host process
- add env matrix coverage showing local exec still uses request env, while remote exec uses server-side env and does not receive client secrets

## Stack / Land Order
1. This PR: remote exec-server host env
2. #17180: exec-server cwd / Environment cwd routing

Stacked on #17030 (`exec-server-managed-network-followup`).

## Behavior
- Local exec path is unchanged: it continues to execute with the caller-provided `params.env`
- Remote exec path intentionally drops orchestrator-provided env before RPC
- Remote exec path currently inherits `std::env::vars()` from the running exec-server process
- Future work can replace the process-wide inherit with an exec-server-side environment policy plus explicit override surface

## Validation
Remote on `dev` via the `codex-applied-devbox` mirror `/tmp/codex-worktrees/oe-p20-exec-server-smoke-flow-20260408`:

```sh
cargo check -p codex-exec-server -p codex-core
```

Also validated as part of the full #17181 -> #17180 stack:

```sh
cargo test -p codex-exec-server --test exec_process exec_process_uses_requested_cwd -- --nocapture
CODEX_TEST_REMOTE_ENV=codex-remote-test-env-privileged cargo test -p codex-core --lib environment_cwd -- --nocapture
```

All passed.

Co-authored-by: Codex <noreply@openai.com>