### PR TITLE
Skip update prompts for source builds

### DIFF
--- a/codex-rs/tui/src/updates.rs
+++ b/codex-rs/tui/src/updates.rs
@@ -15,7 +15,7 @@ use std::path::PathBuf;
 use crate::version::CODEX_CLI_VERSION;
 
 pub fn get_upgrade_version(config: &Config) -> Option<String> {
-    if !config.check_for_update_on_startup {
+    if !config.check_for_update_on_startup || is_source_build_version(CODEX_CLI_VERSION) {
         return None;
     }
 
@@ -137,7 +137,7 @@ fn extract_version_from_latest_tag(latest_tag_name: &str) -> anyhow::Result<Stri
 /// Returns the latest version to show in a popup, if it should be shown.
 /// This respects the user's dismissal choice for the current latest version.
 pub fn get_upgrade_version_for_popup(config: &Config) -> Option<String> {
-    if !config.check_for_update_on_startup {
+    if !config.check_for_update_on_startup || is_source_build_version(CODEX_CLI_VERSION) {
         return None;
     }
 
@@ -175,6 +175,10 @@ fn parse_version(v: &str) -> Option<(u64, u64, u64)> {
     let min = iter.next()?.parse::<u64>().ok()?;
     let pat = iter.next()?.parse::<u64>().ok()?;
     Some((maj, min, pat))
+}
+
+fn is_source_build_version(version: &str) -> bool {
+    parse_version(version) == Some((0, 0, 0))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Addresses #17166

Problem: Source builds report version 0.0.0, so the TUI update path can treat any released Codex version as upgradeable and show startup or popup prompts.

Solution: Skip both TUI update prompt entry points when the running CLI version is the source-build sentinel 0.0.0.