### PR TITLE
Add thread title to configurable TUI status line

### DIFF
--- a/codex-rs/tui/src/bottom_pane/status_line_setup.rs
+++ b/codex-rs/tui/src/bottom_pane/status_line_setup.rs
@@ -14,7 +14,7 @@
 //! - Git information (branch name)
 //! - Context usage (meter, window size)
 //! - Usage limits (5-hour, weekly)
-//! - Session info (ID, tokens used)
+//! - Session info (thread title, ID, tokens used)
 //! - Application version
 
 use ratatui::buffer::Buffer;
@@ -98,6 +98,9 @@ pub(crate) enum StatusLineItem {
 
     /// Whether Fast mode is currently active.
     FastMode,
+
+    /// Current thread title (if set by user).
+    ThreadTitle,
 }
 
 impl StatusLineItem {
@@ -129,6 +132,7 @@ impl StatusLineItem {
                 "Current session identifier (omitted until session starts)"
             }
             StatusLineItem::FastMode => "Whether Fast mode is currently active",
+            StatusLineItem::ThreadTitle => "Current thread title (omitted unless changed by user)",
         }
     }
 }
@@ -149,6 +153,7 @@ const SELECTABLE_STATUS_LINE_ITEMS: &[StatusLineItem] = &[
     StatusLineItem::TotalOutputTokens,
     StatusLineItem::SessionId,
     StatusLineItem::FastMode,
+    StatusLineItem::ThreadTitle,
 ];
 
 /// Runtime values used to preview the current status-line selection.
@@ -377,6 +382,33 @@ mod tests {
         assert_eq!(
             preview_data.line_for_items(&items),
             Some(Line::from("gpt-5"))
+        );
+    }
+
+    #[test]
+    fn preview_includes_thread_title_in_left_sequence() {
+        let preview_data = StatusLinePreviewData::from_iter([
+            (StatusLineItem::ModelName, "gpt-5".to_string()),
+            (StatusLineItem::ThreadTitle, "Roadmap cleanup".to_string()),
+        ]);
+        let items = vec![
+            MultiSelectItem {
+                id: StatusLineItem::ModelName.to_string(),
+                name: String::new(),
+                description: None,
+                enabled: true,
+            },
+            MultiSelectItem {
+                id: StatusLineItem::ThreadTitle.to_string(),
+                name: String::new(),
+                description: None,
+                enabled: true,
+            },
+        ];
+
+        assert_eq!(
+            preview_data.line_for_items(&items),
+            Some(Line::from("gpt-5 · Roadmap cleanup"))
         );
     }
 

--- a/codex-rs/tui/src/bottom_pane/status_line_setup.rs
+++ b/codex-rs/tui/src/bottom_pane/status_line_setup.rs
@@ -386,7 +386,7 @@ mod tests {
     }
 
     #[test]
-    fn preview_includes_thread_title_in_left_sequence() {
+    fn preview_includes_thread_title() {
         let preview_data = StatusLinePreviewData::from_iter([
             (StatusLineItem::ModelName, "gpt-5".to_string()),
             (StatusLineItem::ThreadTitle, "Roadmap cleanup".to_string()),

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -2151,6 +2151,7 @@ impl ChatWidget {
             }
             self.thread_name = event.thread_name;
             self.refresh_terminal_title();
+            self.refresh_status_surfaces();
             self.request_redraw();
         }
     }

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__renamed_thread_footer_title.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__renamed_thread_footer_title.snap
@@ -1,0 +1,9 @@
+---
+source: tui/src/chatwidget/tests.rs
+expression: terminal.backend()
+---
+"                                                                                "
+"                                                                                "
+"› Ask Codex to do anything                                                      "
+"                                                                                "
+"  gpt-5.3-codex high · Roadmap cleanup                                          "

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__renamed_thread_footer_title_plan_mode_override.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__renamed_thread_footer_title_plan_mode_override.snap
@@ -1,0 +1,9 @@
+---
+source: tui/src/chatwidget/tests.rs
+expression: terminal.backend()
+---
+"                                                                                "
+"                                                                                "
+"› Ask Codex to do anything                                                      "
+"                                                                                "
+"  gpt-5.3-codex medium · Roadmap cleanup        Plan mode (shift+tab to cycle)  "

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__renamed_thread_footer_title_plan_mode_override.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__renamed_thread_footer_title_plan_mode_override.snap
@@ -1,9 +1,0 @@
----
-source: tui/src/chatwidget/tests.rs
-expression: terminal.backend()
----
-"                                                                                "
-"                                                                                "
-"› Ask Codex to do anything                                                      "
-"                                                                                "
-"  gpt-5.3-codex medium · Roadmap cleanup        Plan mode (shift+tab to cycle)  "

--- a/codex-rs/tui/src/chatwidget/status_surfaces.rs
+++ b/codex-rs/tui/src/chatwidget/status_surfaces.rs
@@ -495,6 +495,10 @@ impl ChatWidget {
                     "Fast off".to_string()
                 },
             ),
+            StatusLineItem::ThreadTitle => self.thread_name.as_ref().and_then(|name| {
+                let trimmed = name.trim();
+                (!trimmed.is_empty()).then(|| trimmed.to_string())
+            }),
         }
     }
 

--- a/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
+++ b/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
@@ -1199,6 +1199,102 @@ async fn status_line_model_with_reasoning_plan_mode_footer_snapshot() {
 }
 
 #[tokio::test]
+async fn renamed_thread_footer_title_snapshot() {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(Some("gpt-5.3-codex")).await;
+    chat.show_welcome_banner = false;
+    chat.config.tui_status_line = Some(vec![
+        "model-with-reasoning".to_string(),
+        "thread-title".to_string(),
+    ]);
+    chat.set_reasoning_effort(Some(ReasoningEffortConfig::High));
+    chat.refresh_status_line();
+
+    let thread_id = ThreadId::new();
+    chat.thread_id = Some(thread_id);
+    chat.handle_codex_event(Event {
+        id: "rename".to_string(),
+        msg: EventMsg::ThreadNameUpdated(codex_protocol::protocol::ThreadNameUpdatedEvent {
+            thread_id,
+            thread_name: Some("Roadmap cleanup".to_string()),
+        }),
+    });
+
+    let width = 80;
+    let height = chat.desired_height(width);
+    let mut terminal = Terminal::new(TestBackend::new(width, height)).expect("create terminal");
+    terminal
+        .draw(|f| chat.render(f.area(), f.buffer_mut()))
+        .expect("draw renamed-thread footer");
+    assert_chatwidget_snapshot!(
+        "renamed_thread_footer_title",
+        normalized_backend_snapshot(terminal.backend())
+    );
+}
+
+#[tokio::test]
+async fn thread_title_status_item_stays_in_left_status_line() {
+    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(Some("gpt-5.3-codex")).await;
+    chat.thread_name = Some("Roadmap cleanup".to_string());
+
+    let (left_line, right_line) = chat.status_line_lines_for_items(&[
+        crate::bottom_pane::StatusLineItem::ModelName,
+        crate::bottom_pane::StatusLineItem::ThreadTitle,
+    ]);
+
+    assert_eq!(
+        left_line,
+        Some(Line::from("gpt-5.3-codex · Roadmap cleanup"))
+    );
+    assert_eq!(right_line, None);
+}
+
+#[tokio::test]
+async fn renamed_thread_footer_title_plan_mode_override_snapshot() {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(Some("gpt-5.3-codex")).await;
+    chat.show_welcome_banner = false;
+    chat.set_feature_enabled(Feature::CollaborationModes, /*enabled*/ true);
+    chat.config.tui_status_line = Some(vec![
+        "model-with-reasoning".to_string(),
+        "thread-title".to_string(),
+    ]);
+    chat.set_reasoning_effort(Some(ReasoningEffortConfig::High));
+    chat.refresh_status_line();
+
+    let thread_id = ThreadId::new();
+    chat.thread_id = Some(thread_id);
+    chat.handle_server_notification(
+        ServerNotification::ThreadNameUpdated(
+            codex_app_server_protocol::ThreadNameUpdatedNotification {
+                thread_id: thread_id.to_string(),
+                thread_name: Some("Roadmap cleanup".to_string()),
+            },
+        ),
+        /*replay_kind*/ None,
+    );
+
+    let plan_mask = collaboration_modes::plan_mask(chat.model_catalog.as_ref())
+        .expect("expected plan collaboration mode");
+    chat.set_collaboration_mask(plan_mask);
+
+    let width = 80;
+    let height = chat.desired_height(width);
+    let mut terminal = Terminal::new(TestBackend::new(width, height)).expect("create terminal");
+    terminal
+        .draw(|f| chat.render(f.area(), f.buffer_mut()))
+        .expect("draw renamed-thread plan-mode footer");
+    assert_chatwidget_snapshot!(
+        "renamed_thread_footer_title_plan_mode_override",
+        normalized_backend_snapshot(terminal.backend())
+    );
+}
+
+#[tokio::test]
 async fn status_line_model_with_reasoning_fast_footer_snapshot() {
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;

--- a/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
+++ b/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
@@ -1235,63 +1235,6 @@ async fn renamed_thread_footer_title_snapshot() {
 }
 
 #[tokio::test]
-async fn thread_title_status_item_stays_in_left_status_line() {
-    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(Some("gpt-5.3-codex")).await;
-    chat.thread_name = Some("Roadmap cleanup".to_string());
-    chat.config.tui_status_line = Some(vec!["model-name".to_string(), "thread-title".to_string()]);
-
-    chat.refresh_status_line();
-
-    assert_eq!(
-        status_line_text(&chat),
-        Some("gpt-5.3-codex · Roadmap cleanup".to_string())
-    );
-}
-
-#[tokio::test]
-async fn renamed_thread_footer_title_plan_mode_override_snapshot() {
-    use ratatui::Terminal;
-    use ratatui::backend::TestBackend;
-
-    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(Some("gpt-5.3-codex")).await;
-    chat.show_welcome_banner = false;
-    chat.set_feature_enabled(Feature::CollaborationModes, /*enabled*/ true);
-    chat.config.tui_status_line = Some(vec![
-        "model-with-reasoning".to_string(),
-        "thread-title".to_string(),
-    ]);
-    chat.set_reasoning_effort(Some(ReasoningEffortConfig::High));
-    chat.refresh_status_line();
-
-    let thread_id = ThreadId::new();
-    chat.thread_id = Some(thread_id);
-    chat.handle_server_notification(
-        ServerNotification::ThreadNameUpdated(
-            codex_app_server_protocol::ThreadNameUpdatedNotification {
-                thread_id: thread_id.to_string(),
-                thread_name: Some("Roadmap cleanup".to_string()),
-            },
-        ),
-        /*replay_kind*/ None,
-    );
-
-    let plan_mask = collaboration_modes::plan_mask(chat.model_catalog.as_ref())
-        .expect("expected plan collaboration mode");
-    chat.set_collaboration_mask(plan_mask);
-
-    let width = 80;
-    let height = chat.desired_height(width);
-    let mut terminal = Terminal::new(TestBackend::new(width, height)).expect("create terminal");
-    terminal
-        .draw(|f| chat.render(f.area(), f.buffer_mut()))
-        .expect("draw renamed-thread plan-mode footer");
-    assert_chatwidget_snapshot!(
-        "renamed_thread_footer_title_plan_mode_override",
-        normalized_backend_snapshot(terminal.backend())
-    );
-}
-
-#[tokio::test]
 async fn status_line_model_with_reasoning_fast_footer_snapshot() {
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;

--- a/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
+++ b/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
@@ -1238,17 +1238,14 @@ async fn renamed_thread_footer_title_snapshot() {
 async fn thread_title_status_item_stays_in_left_status_line() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual(Some("gpt-5.3-codex")).await;
     chat.thread_name = Some("Roadmap cleanup".to_string());
+    chat.config.tui_status_line = Some(vec!["model-name".to_string(), "thread-title".to_string()]);
 
-    let (left_line, right_line) = chat.status_line_lines_for_items(&[
-        crate::bottom_pane::StatusLineItem::ModelName,
-        crate::bottom_pane::StatusLineItem::ThreadTitle,
-    ]);
+    chat.refresh_status_line();
 
     assert_eq!(
-        left_line,
-        Some(Line::from("gpt-5.3-codex · Roadmap cleanup"))
+        status_line_text(&chat),
+        Some("gpt-5.3-codex · Roadmap cleanup".to_string())
     );
-    assert_eq!(right_line, None);
 }
 
 #[tokio::test]


### PR DESCRIPTION
- Add thread-title as an optional TUI status line item, omitted unless the user has set a custom name (`ChatWidget.thread_name`).
- Refresh the status line when threads are renamded
- Add snapshot coverage for renamed-thread footer behavior.