### PR TITLE
Emit live hook prompts before raw-event filtering

### DIFF
--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -2059,7 +2059,7 @@ async fn maybe_emit_raw_response_item_completed(
         .await;
 }
 
-async fn maybe_emit_hook_prompt_item_completed(
+pub(crate) async fn maybe_emit_hook_prompt_item_completed(
     api_version: ApiVersion,
     conversation_id: ThreadId,
     turn_id: &str,

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -1,4 +1,5 @@
 use crate::bespoke_event_handling::apply_bespoke_event_handling;
+use crate::bespoke_event_handling::maybe_emit_hook_prompt_item_completed;
 use crate::command_exec::CommandExecManager;
 use crate::command_exec::StartCommandExecParams;
 use crate::config_api::apply_runtime_feature_enablement;
@@ -7435,15 +7436,26 @@ impl CodexMessageProcessor {
                         let subscribed_connection_ids = thread_state_manager
                             .subscribed_connection_ids(conversation_id)
                             .await;
-                        if let EventMsg::RawResponseItem(_) = &event.msg && !raw_events_enabled {
-                            continue;
-                        }
-
                         let thread_outgoing = ThreadScopedOutgoingMessageSender::new(
                             outgoing_for_task.clone(),
                             subscribed_connection_ids,
                             conversation_id,
                         );
+
+                        if let EventMsg::RawResponseItem(raw_response_item_event) = &event.msg
+                            && !raw_events_enabled
+                        {
+                            maybe_emit_hook_prompt_item_completed(
+                                api_version,
+                                conversation_id,
+                                &event.id,
+                                &raw_response_item_event.item,
+                                &thread_outgoing,
+                            )
+                            .await;
+                            continue;
+                        }
+
                         apply_bespoke_event_handling(
                             event.clone(),
                             conversation_id,


### PR DESCRIPTION
# What
Project raw Stop-hook prompt response items into typed v2 hookPrompt item-completed notifications before applying the raw-response-event filter. Keep ordinary raw response items filtered for normal subscribers; only the existing hookPrompt bridge runs on the filtered raw-item path.

# Why
Blocked Stop hooks record their continuation instruction as a raw model-history user item. Normal v2 desktop subscribers do not opt into raw response events, so the app-server listener filtered that raw item before the existing hookPrompt translator could emit the typed live item/completed notification. As a result, the hook-prompt bubble only appeared after thread history was reloaded.