### PR TITLE
Skip local shell snapshots for remote unified exec

### DIFF
--- a/codex-rs/core/src/tools/runtimes/unified_exec.rs
+++ b/codex-rs/core/src/tools/runtimes/unified_exec.rs
@@ -202,13 +202,22 @@ impl<'a> ToolRuntime<UnifiedExecRequest, UnifiedExecProcess> for UnifiedExecRunt
     ) -> Result<UnifiedExecProcess, ToolError> {
         let base_command = &req.command;
         let session_shell = ctx.session.user_shell();
-        let command = maybe_wrap_shell_lc_with_snapshot(
-            base_command,
-            session_shell.as_ref(),
-            &req.cwd,
-            &req.explicit_env_overrides,
-            &req.env,
-        );
+        let environment_is_remote = ctx
+            .turn
+            .environment
+            .as_ref()
+            .is_some_and(|environment| environment.is_remote());
+        let command = if environment_is_remote {
+            base_command.to_vec()
+        } else {
+            maybe_wrap_shell_lc_with_snapshot(
+                base_command,
+                session_shell.as_ref(),
+                &req.cwd,
+                &req.explicit_env_overrides,
+                &req.env,
+            )
+        };
         let command = if matches!(session_shell.shell_type, ShellType::PowerShell) {
             prefix_powershell_script_with_utf8(&command)
         } else {


### PR DESCRIPTION
## Summary
- detect remote exec-server sessions in the unified-exec runtime
- bypass the local shell-snapshot bootstrap only for those remote sessions
- preserve existing local snapshot wrapping, PowerShell UTF-8 prefixing, sandbox orchestration, and zsh-fork handling

## Why
The shell snapshot file is currently captured and stored next to Core. If Core wraps a remote command with `. /path/to/local/snapshot`, the process starts on the executor and tries to source a path from the orchestrator filesystem. This keeps remote commands from receiving that known-local path until shell snapshots are captured/restored on the executor side.

## Validation
- `just fmt`
- `git diff --check`
- `cargo test -p codex-core --lib tools::runtimes::tests`