### PR TITLE
Snapshot MCP tools for forked agents

### DIFF
--- a/codex-rs/core/src/agent/control.rs
+++ b/codex-rs/core/src/agent/control.rs
@@ -13,6 +13,7 @@ use crate::rollout::RolloutRecorder;
 use crate::session_prefix::format_subagent_context_line;
 use crate::session_prefix::format_subagent_notification_message;
 use crate::shell_snapshot::ShellSnapshot;
+use crate::state::McpToolSnapshot;
 use crate::thread_manager::ThreadManagerState;
 use crate::thread_rollout_truncation::truncate_rollout_to_last_n_fork_turns;
 use codex_features::Feature;
@@ -222,6 +223,9 @@ impl AgentControl {
                 let inherited_thread_state = InheritedThreadState::builder()
                     .prompt_cache_key(
                         parent_prompt_cache_key_for_source(&state, Some(&session_source)).await,
+                    )
+                    .mcp_tool_snapshot(
+                        parent_mcp_tool_snapshot_for_source(&state, Some(&session_source)).await,
                     )
                     .build();
                 self.spawn_forked_thread(
@@ -1188,6 +1192,30 @@ async fn parent_prompt_cache_key_for_source(
         .await
         .ok()
         .map(|parent_thread| parent_thread.codex.session.prompt_cache_key())
+}
+
+async fn parent_mcp_tool_snapshot_for_source(
+    state: &Arc<ThreadManagerState>,
+    session_source: Option<&SessionSource>,
+) -> Option<McpToolSnapshot> {
+    let Some(SessionSource::SubAgent(SubAgentSource::ThreadSpawn {
+        parent_thread_id, ..
+    })) = session_source
+    else {
+        return None;
+    };
+
+    let parent_thread = state.get_thread(*parent_thread_id).await.ok()?;
+    let tools = parent_thread
+        .codex
+        .session
+        .services
+        .mcp_connection_manager
+        .read()
+        .await
+        .list_all_tools()
+        .await;
+    Some(McpToolSnapshot { tools })
 }
 
 fn thread_spawn_parent_thread_id(session_source: &SessionSource) -> Option<ThreadId> {

--- a/codex-rs/core/src/agent/control_tests.rs
+++ b/codex-rs/core/src/agent/control_tests.rs
@@ -667,6 +667,33 @@ async fn spawn_agent_can_fork_parent_thread_history_with_sanitized_items() {
         child_thread.codex.session.prompt_cache_key(),
         parent_thread.codex.session.prompt_cache_key(),
     );
+    assert!(!Arc::ptr_eq(
+        &child_thread.codex.session.services.mcp_connection_manager,
+        &parent_thread.codex.session.services.mcp_connection_manager,
+    ));
+    let mcp_tool_snapshot = child_thread
+        .codex
+        .session
+        .services
+        .mcp_tool_snapshot
+        .lock()
+        .await
+        .clone()
+        .expect("forked child should inherit an MCP tool snapshot");
+    let parent_mcp_tools = parent_thread
+        .codex
+        .session
+        .services
+        .mcp_connection_manager
+        .read()
+        .await
+        .list_all_tools()
+        .await;
+    let mut snapshot_tool_names = mcp_tool_snapshot.tools.keys().cloned().collect::<Vec<_>>();
+    snapshot_tool_names.sort();
+    let mut parent_tool_names = parent_mcp_tools.keys().cloned().collect::<Vec<_>>();
+    parent_tool_names.sort();
+    assert_eq!(snapshot_tool_names, parent_tool_names);
     let history = child_thread.codex.session.clone_history().await;
     let expected_history = [
         ResponseItem::Message {

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1675,6 +1675,7 @@ impl Session {
             ),
         };
         let prompt_cache_key_override = inherited_thread_state.prompt_cache_key();
+        let mcp_tool_snapshot = inherited_thread_state.mcp_tool_snapshot();
         let window_generation = match &initial_history {
             InitialHistory::Resumed(resumed_history) => u64::try_from(
                 resumed_history
@@ -2033,6 +2034,7 @@ impl Session {
                 &config.permissions.approval_policy,
                 &config.permissions.sandbox_policy,
             ))),
+            mcp_tool_snapshot: Mutex::new(mcp_tool_snapshot),
             mcp_startup_cancellation_token: Mutex::new(CancellationToken::new()),
             unified_exec_manager: UnifiedExecProcessManager::new(
                 config.background_terminal_max_timeout,
@@ -4540,8 +4542,12 @@ impl Session {
             *guard = cancel_token;
         }
 
-        let mut manager = self.services.mcp_connection_manager.write().await;
-        *manager = refreshed_manager;
+        {
+            let mut manager = self.services.mcp_connection_manager.write().await;
+            *manager = refreshed_manager;
+        }
+        let mut snapshot = self.services.mcp_tool_snapshot.lock().await;
+        *snapshot = None;
     }
 
     async fn refresh_mcp_servers_if_requested(&self, turn_context: &TurnContext) {
@@ -6976,13 +6982,18 @@ pub(crate) async fn built_tools(
     skills_outcome: Option<&SkillLoadOutcome>,
     cancellation_token: &CancellationToken,
 ) -> CodexResult<Arc<ToolRouter>> {
-    let mcp_connection_manager = sess.services.mcp_connection_manager.read().await;
-    let has_mcp_servers = mcp_connection_manager.has_servers();
-    let all_mcp_tools = mcp_connection_manager
-        .list_all_tools()
-        .or_cancel(cancellation_token)
-        .await?;
-    drop(mcp_connection_manager);
+    let inherited_mcp_tools = sess.services.mcp_tool_snapshot.lock().await.clone();
+    let (has_mcp_servers, all_mcp_tools) = if let Some(snapshot) = inherited_mcp_tools {
+        (!snapshot.tools.is_empty(), snapshot.tools)
+    } else {
+        let mcp_connection_manager = sess.services.mcp_connection_manager.read().await;
+        let has_mcp_servers = mcp_connection_manager.has_servers();
+        let all_mcp_tools = mcp_connection_manager
+            .list_all_tools()
+            .or_cancel(cancellation_token)
+            .await?;
+        (has_mcp_servers, all_mcp_tools)
+    };
     let loaded_plugins = sess
         .services
         .plugins_manager

--- a/codex-rs/core/src/codex_tests.rs
+++ b/codex-rs/core/src/codex_tests.rs
@@ -2852,6 +2852,7 @@ pub(crate) async fn make_session_and_context() -> (Session, TurnContext) {
             &config.permissions.approval_policy,
             &config.permissions.sandbox_policy,
         ))),
+        mcp_tool_snapshot: Mutex::new(None),
         mcp_startup_cancellation_token: Mutex::new(CancellationToken::new()),
         unified_exec_manager: UnifiedExecProcessManager::new(
             config.background_terminal_max_timeout,
@@ -3698,6 +3699,7 @@ pub(crate) async fn make_session_and_context_with_dynamic_tools_and_rx(
             &config.permissions.approval_policy,
             &config.permissions.sandbox_policy,
         ))),
+        mcp_tool_snapshot: Mutex::new(None),
         mcp_startup_cancellation_token: Mutex::new(CancellationToken::new()),
         unified_exec_manager: UnifiedExecProcessManager::new(
             config.background_terminal_max_timeout,

--- a/codex-rs/core/src/inherited_thread_state.rs
+++ b/codex-rs/core/src/inherited_thread_state.rs
@@ -1,8 +1,11 @@
 use codex_protocol::ThreadId;
 
-#[derive(Clone, Copy, Debug, Default)]
+use crate::state::McpToolSnapshot;
+
+#[derive(Clone, Default)]
 pub(crate) struct InheritedThreadState {
     prompt_cache_key: Option<ThreadId>,
+    mcp_tool_snapshot: Option<McpToolSnapshot>,
 }
 
 impl InheritedThreadState {
@@ -13,11 +16,16 @@ impl InheritedThreadState {
     pub(crate) fn prompt_cache_key(&self) -> Option<ThreadId> {
         self.prompt_cache_key
     }
+
+    pub(crate) fn mcp_tool_snapshot(&self) -> Option<McpToolSnapshot> {
+        self.mcp_tool_snapshot.clone()
+    }
 }
 
 #[derive(Default)]
 pub(crate) struct InheritedThreadStateBuilder {
     prompt_cache_key: Option<ThreadId>,
+    mcp_tool_snapshot: Option<McpToolSnapshot>,
 }
 
 impl InheritedThreadStateBuilder {
@@ -26,9 +34,15 @@ impl InheritedThreadStateBuilder {
         self
     }
 
+    pub(crate) fn mcp_tool_snapshot(mut self, mcp_tool_snapshot: Option<McpToolSnapshot>) -> Self {
+        self.mcp_tool_snapshot = mcp_tool_snapshot;
+        self
+    }
+
     pub(crate) fn build(self) -> InheritedThreadState {
         InheritedThreadState {
             prompt_cache_key: self.prompt_cache_key,
+            mcp_tool_snapshot: self.mcp_tool_snapshot,
         }
     }
 }

--- a/codex-rs/core/src/state/mod.rs
+++ b/codex-rs/core/src/state/mod.rs
@@ -2,6 +2,7 @@ mod service;
 mod session;
 mod turn;
 
+pub(crate) use service::McpToolSnapshot;
 pub(crate) use service::SessionServices;
 pub(crate) use session::SessionState;
 pub(crate) use turn::ActiveTurn;

--- a/codex-rs/core/src/state/service.rs
+++ b/codex-rs/core/src/state/service.rs
@@ -20,6 +20,7 @@ use codex_exec_server::Environment;
 use codex_hooks::Hooks;
 use codex_login::AuthManager;
 use codex_mcp::McpConnectionManager;
+use codex_mcp::ToolInfo as McpToolInfo;
 use codex_models_manager::manager::ModelsManager;
 use codex_otel::SessionTelemetry;
 use codex_rollout::state_db::StateDbHandle;
@@ -29,8 +30,14 @@ use tokio::sync::RwLock;
 use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 
+#[derive(Clone, Default)]
+pub(crate) struct McpToolSnapshot {
+    pub(crate) tools: HashMap<String, McpToolInfo>,
+}
+
 pub(crate) struct SessionServices {
     pub(crate) mcp_connection_manager: Arc<RwLock<McpConnectionManager>>,
+    pub(crate) mcp_tool_snapshot: Mutex<Option<McpToolSnapshot>>,
     pub(crate) mcp_startup_cancellation_token: Mutex<CancellationToken>,
     pub(crate) unified_exec_manager: UnifiedExecProcessManager,
     #[cfg_attr(not(unix), allow(dead_code))]


### PR DESCRIPTION
## Summary

Stacked on #17248.

When a forked agent is created from a live parent thread, snapshot the parent's MCP tool listing and use that snapshot for the child thread's model-visible MCP tool surface.

This avoids sharing the mutable `McpConnectionManager` while keeping forked-agent tool specs stable across the fork.

## Design

- Extend inherited thread state with an optional MCP tool snapshot.
- Populate the snapshot only during actual fork creation from a live parent thread.
- Store the snapshot on the child session and have `built_tools` read it before falling back to the child session's MCP manager listing.
- Keep MCP tool execution and MCP lifecycle owned by the child session's own MCP manager.
- Clear the snapshot if the child explicitly refreshes MCP servers.

## Tests

- `cargo +1.93.1 test -p codex-core spawn_agent_can_fork_parent_thread_history_with_sanitized_items --lib`
