### PR TITLE
feat: use scoped remote control server tokens

### DIFF
--- a/codex-rs/app-server/src/transport/remote_control/enroll.rs
+++ b/codex-rs/app-server/src/transport/remote_control/enroll.rs
@@ -214,6 +214,7 @@ pub(crate) fn format_headers(headers: &HeaderMap) -> String {
 pub(super) async fn enroll_remote_control_server(
     remote_control_target: &RemoteControlTarget,
     auth: &RemoteControlConnectionAuth,
+    existing_enrollment: Option<&RemoteControlEnrollment>,
 ) -> io::Result<RemoteControlEnrollmentResult> {
     let enroll_url = &remote_control_target.enroll_url;
     let server_name = gethostname().to_string_lossy().trim().to_string();
@@ -222,6 +223,8 @@ pub(super) async fn enroll_remote_control_server(
         os: std::env::consts::OS,
         arch: std::env::consts::ARCH,
         app_server_version: env!("CARGO_PKG_VERSION"),
+        server_id: existing_enrollment.map(|enrollment| enrollment.server_id.clone()),
+        environment_id: existing_enrollment.map(|enrollment| enrollment.environment_id.clone()),
     };
     let client = build_reqwest_client();
     let mut http_request = client
@@ -569,6 +572,7 @@ mod tests {
                 account_id: "account_id".to_string(),
                 is_fedramp_account: false,
             },
+            /*existing_enrollment*/ None,
         )
         .await
         .expect_err("invalid response should fail to parse");

--- a/codex-rs/app-server/src/transport/remote_control/enroll.rs
+++ b/codex-rs/app-server/src/transport/remote_control/enroll.rs
@@ -2,6 +2,9 @@ use super::protocol::EnrollRemoteServerRequest;
 use super::protocol::EnrollRemoteServerResponse;
 use super::protocol::RemoteControlTarget;
 use axum::http::HeaderMap;
+use chrono::DateTime;
+use chrono::Duration;
+use chrono::Utc;
 use codex_login::default_client::build_reqwest_client;
 use codex_state::RemoteControlEnrollmentRecord;
 use codex_state::StateRuntime;
@@ -13,6 +16,8 @@ use tracing::warn;
 
 const REMOTE_CONTROL_ENROLL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 const REMOTE_CONTROL_RESPONSE_BODY_MAX_BYTES: usize = 4096;
+const REMOTE_CONTROL_SERVER_WEBSOCKET_SCOPE: &str = "remote_control_server_websocket";
+const REMOTE_CONTROL_SERVER_TOKEN_REFRESH_SKEW_SECONDS: i64 = 60;
 
 const REQUEST_ID_HEADER: &str = "x-request-id";
 const OAI_REQUEST_ID_HEADER: &str = "x-oai-request-id";
@@ -26,6 +31,24 @@ pub(super) struct RemoteControlEnrollment {
     pub(super) environment_id: String,
     pub(super) server_id: String,
     pub(super) server_name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct RemoteControlServerToken {
+    pub(super) bearer_token: String,
+    pub(super) expires_at: DateTime<Utc>,
+}
+
+impl RemoteControlServerToken {
+    pub(super) fn expires_soon(&self, now: DateTime<Utc>) -> bool {
+        self.expires_at <= now + Duration::seconds(REMOTE_CONTROL_SERVER_TOKEN_REFRESH_SKEW_SECONDS)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct RemoteControlEnrollmentResult {
+    pub(super) enrollment: RemoteControlEnrollment,
+    pub(super) server_token: Option<RemoteControlServerToken>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -191,7 +214,7 @@ pub(crate) fn format_headers(headers: &HeaderMap) -> String {
 pub(super) async fn enroll_remote_control_server(
     remote_control_target: &RemoteControlTarget,
     auth: &RemoteControlConnectionAuth,
-) -> io::Result<RemoteControlEnrollment> {
+) -> io::Result<RemoteControlEnrollmentResult> {
     let enroll_url = &remote_control_target.enroll_url;
     let server_name = gethostname().to_string_lossy().trim().to_string();
     let request = EnrollRemoteServerRequest {
@@ -246,18 +269,66 @@ pub(super) async fn enroll_remote_control_server(
         ))
     })?;
 
-    Ok(RemoteControlEnrollment {
-        account_id: auth.account_id.clone(),
-        environment_id: enrollment.environment_id,
-        server_id: enrollment.server_id,
-        server_name,
+    let server_token = remote_control_server_token_from_response(&enrollment)?;
+    Ok(RemoteControlEnrollmentResult {
+        enrollment: RemoteControlEnrollment {
+            account_id: auth.account_id.clone(),
+            environment_id: enrollment.environment_id,
+            server_id: enrollment.server_id,
+            server_name,
+        },
+        server_token,
     })
+}
+
+fn remote_control_server_token_from_response(
+    enrollment: &EnrollRemoteServerResponse,
+) -> io::Result<Option<RemoteControlServerToken>> {
+    let Some(remote_control_token) = enrollment.remote_control_token.as_ref() else {
+        return Ok(None);
+    };
+    let expires_at = enrollment.expires_at.as_ref().ok_or_else(|| {
+        io::Error::new(
+            ErrorKind::InvalidData,
+            "remote control enrollment response included a token without expires_at",
+        )
+    })?;
+    let scopes = enrollment.scopes.as_ref().ok_or_else(|| {
+        io::Error::new(
+            ErrorKind::InvalidData,
+            "remote control enrollment response included a token without scopes",
+        )
+    })?;
+    if !scopes
+        .iter()
+        .any(|scope| scope == REMOTE_CONTROL_SERVER_WEBSOCKET_SCOPE)
+    {
+        return Err(io::Error::new(
+            ErrorKind::InvalidData,
+            "remote control enrollment response token is missing server websocket scope",
+        ));
+    }
+    let expires_at = DateTime::parse_from_rfc3339(expires_at)
+        .map_err(|err| {
+            io::Error::new(
+                ErrorKind::InvalidData,
+                format!("invalid remote control token expires_at: {err}"),
+            )
+        })?
+        .with_timezone(&Utc);
+
+    Ok(Some(RemoteControlServerToken {
+        bearer_token: remote_control_token.clone(),
+        expires_at,
+    }))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::transport::remote_control::protocol::normalize_remote_control_url;
+    use chrono::DateTime;
+    use chrono::Utc;
     use codex_state::StateRuntime;
     use pretty_assertions::assert_eq;
     use serde_json::json;
@@ -420,6 +491,50 @@ mod tests {
             )
             .await,
             Some(second_enrollment)
+        );
+    }
+
+    #[test]
+    fn remote_control_server_token_from_response_accepts_legacy_response_without_token() {
+        assert_eq!(
+            remote_control_server_token_from_response(&EnrollRemoteServerResponse {
+                server_id: "srv_e_test".to_string(),
+                environment_id: "env_test".to_string(),
+                remote_control_token: None,
+                expires_at: None,
+                scopes: None,
+            })
+            .expect("legacy response should parse"),
+            None
+        );
+    }
+
+    #[test]
+    fn remote_control_server_token_from_response_parses_scoped_token() {
+        let server_token = remote_control_server_token_from_response(&EnrollRemoteServerResponse {
+            server_id: "srv_e_test".to_string(),
+            environment_id: "env_test".to_string(),
+            remote_control_token: Some("remote-control-token".to_string()),
+            expires_at: Some("2026-04-09T12:00:00Z".to_string()),
+            scopes: Some(vec!["remote_control_server_websocket".to_string()]),
+        })
+        .expect("token response should parse")
+        .expect("token should be present");
+
+        assert_eq!(server_token.bearer_token, "remote-control-token");
+        assert!(
+            !server_token.expires_soon(
+                DateTime::parse_from_rfc3339("2026-04-09T11:58:30Z")
+                    .expect("timestamp should parse")
+                    .with_timezone(&Utc)
+            )
+        );
+        assert!(
+            server_token.expires_soon(
+                DateTime::parse_from_rfc3339("2026-04-09T11:59:30Z")
+                    .expect("timestamp should parse")
+                    .with_timezone(&Utc)
+            )
         );
     }
 

--- a/codex-rs/app-server/src/transport/remote_control/enroll.rs
+++ b/codex-rs/app-server/src/transport/remote_control/enroll.rs
@@ -48,7 +48,7 @@ impl RemoteControlServerToken {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct RemoteControlEnrollmentResult {
     pub(super) enrollment: RemoteControlEnrollment,
-    pub(super) server_token: Option<RemoteControlServerToken>,
+    pub(super) server_token: RemoteControlServerToken,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -286,23 +286,9 @@ pub(super) async fn enroll_remote_control_server(
 
 fn remote_control_server_token_from_response(
     enrollment: &EnrollRemoteServerResponse,
-) -> io::Result<Option<RemoteControlServerToken>> {
-    let Some(remote_control_token) = enrollment.remote_control_token.as_ref() else {
-        return Ok(None);
-    };
-    let expires_at = enrollment.expires_at.as_ref().ok_or_else(|| {
-        io::Error::new(
-            ErrorKind::InvalidData,
-            "remote control enrollment response included a token without expires_at",
-        )
-    })?;
-    let scopes = enrollment.scopes.as_ref().ok_or_else(|| {
-        io::Error::new(
-            ErrorKind::InvalidData,
-            "remote control enrollment response included a token without scopes",
-        )
-    })?;
-    if !scopes
+) -> io::Result<RemoteControlServerToken> {
+    if !enrollment
+        .scopes
         .iter()
         .any(|scope| scope == REMOTE_CONTROL_SERVER_WEBSOCKET_SCOPE)
     {
@@ -311,7 +297,7 @@ fn remote_control_server_token_from_response(
             "remote control enrollment response token is missing server websocket scope",
         ));
     }
-    let expires_at = DateTime::parse_from_rfc3339(expires_at)
+    let expires_at = DateTime::parse_from_rfc3339(&enrollment.expires_at)
         .map_err(|err| {
             io::Error::new(
                 ErrorKind::InvalidData,
@@ -320,10 +306,10 @@ fn remote_control_server_token_from_response(
         })?
         .with_timezone(&Utc);
 
-    Ok(Some(RemoteControlServerToken {
-        bearer_token: remote_control_token.clone(),
+    Ok(RemoteControlServerToken {
+        bearer_token: enrollment.remote_control_token.clone(),
         expires_at,
-    }))
+    })
 }
 
 #[cfg(test)]
@@ -498,31 +484,15 @@ mod tests {
     }
 
     #[test]
-    fn remote_control_server_token_from_response_accepts_legacy_response_without_token() {
-        assert_eq!(
-            remote_control_server_token_from_response(&EnrollRemoteServerResponse {
-                server_id: "srv_e_test".to_string(),
-                environment_id: "env_test".to_string(),
-                remote_control_token: None,
-                expires_at: None,
-                scopes: None,
-            })
-            .expect("legacy response should parse"),
-            None
-        );
-    }
-
-    #[test]
     fn remote_control_server_token_from_response_parses_scoped_token() {
         let server_token = remote_control_server_token_from_response(&EnrollRemoteServerResponse {
             server_id: "srv_e_test".to_string(),
             environment_id: "env_test".to_string(),
-            remote_control_token: Some("remote-control-token".to_string()),
-            expires_at: Some("2026-04-09T12:00:00Z".to_string()),
-            scopes: Some(vec!["remote_control_server_websocket".to_string()]),
+            remote_control_token: "remote-control-token".to_string(),
+            expires_at: "2026-04-09T12:00:00Z".to_string(),
+            scopes: vec!["remote_control_server_websocket".to_string()],
         })
-        .expect("token response should parse")
-        .expect("token should be present");
+        .expect("token response should parse");
 
         assert_eq!(server_token.bearer_token, "remote-control-token");
         assert!(

--- a/codex-rs/app-server/src/transport/remote_control/protocol.rs
+++ b/codex-rs/app-server/src/transport/remote_control/protocol.rs
@@ -19,6 +19,10 @@ pub(super) struct EnrollRemoteServerRequest {
     pub(super) os: &'static str,
     pub(super) arch: &'static str,
     pub(super) app_server_version: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) server_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) environment_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/codex-rs/app-server/src/transport/remote_control/protocol.rs
+++ b/codex-rs/app-server/src/transport/remote_control/protocol.rs
@@ -25,6 +25,12 @@ pub(super) struct EnrollRemoteServerRequest {
 pub(super) struct EnrollRemoteServerResponse {
     pub(super) server_id: String,
     pub(super) environment_id: String,
+    #[serde(default)]
+    pub(super) remote_control_token: Option<String>,
+    #[serde(default)]
+    pub(super) expires_at: Option<String>,
+    #[serde(default)]
+    pub(super) scopes: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/codex-rs/app-server/src/transport/remote_control/protocol.rs
+++ b/codex-rs/app-server/src/transport/remote_control/protocol.rs
@@ -29,12 +29,9 @@ pub(super) struct EnrollRemoteServerRequest {
 pub(super) struct EnrollRemoteServerResponse {
     pub(super) server_id: String,
     pub(super) environment_id: String,
-    #[serde(default)]
-    pub(super) remote_control_token: Option<String>,
-    #[serde(default)]
-    pub(super) expires_at: Option<String>,
-    #[serde(default)]
-    pub(super) scopes: Option<Vec<String>>,
+    pub(super) remote_control_token: String,
+    pub(super) expires_at: String,
+    pub(super) scopes: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/codex-rs/app-server/src/transport/remote_control/tests.rs
+++ b/codex-rs/app-server/src/transport/remote_control/tests.rs
@@ -938,6 +938,112 @@ async fn remote_control_http_mode_enrolls_before_connecting() {
 }
 
 #[tokio::test]
+async fn remote_control_renews_server_token_with_existing_enrollment_ids() {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("listener should bind");
+    let remote_control_url = remote_control_url_for_listener(&listener);
+    let codex_home = TempDir::new().expect("temp dir should create");
+    let (transport_event_tx, _transport_event_rx) =
+        mpsc::channel::<TransportEvent>(CHANNEL_CAPACITY);
+    let expected_server_name = gethostname().to_string_lossy().trim().to_string();
+    let shutdown_token = CancellationToken::new();
+    let (remote_task, _remote_handle) = start_remote_control(
+        remote_control_url,
+        Some(remote_control_state_runtime(&codex_home).await),
+        remote_control_auth_manager(),
+        transport_event_tx,
+        shutdown_token.clone(),
+        /*app_server_client_name_rx*/ None,
+        /*initial_enabled*/ true,
+    )
+    .await
+    .expect("remote control should start");
+
+    let enroll_request = accept_http_request(&listener).await;
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&enroll_request.body)
+            .expect("initial enroll body should deserialize"),
+        json!({
+            "name": expected_server_name,
+            "os": std::env::consts::OS,
+            "arch": std::env::consts::ARCH,
+            "app_server_version": env!("CARGO_PKG_VERSION"),
+        })
+    );
+    respond_with_json(
+        enroll_request.stream,
+        json!({
+            "server_id": "srv_e_test",
+            "environment_id": "env_test",
+            "remote_control_token": "remote-control-token-1",
+            "expires_at": (chrono::Utc::now() + chrono::Duration::seconds(30)).to_rfc3339(),
+            "scopes": ["remote_control_server_websocket"],
+        }),
+    )
+    .await;
+
+    let (first_handshake_request, mut first_websocket) =
+        accept_remote_control_backend_connection(&listener).await;
+    assert_eq!(
+        first_handshake_request.headers.get("authorization"),
+        Some(&"Bearer remote-control-token-1".to_string())
+    );
+    assert_eq!(
+        first_handshake_request.headers.get("x-codex-server-id"),
+        Some(&"srv_e_test".to_string())
+    );
+    first_websocket
+        .close(None)
+        .await
+        .expect("first websocket should close");
+    drop(first_websocket);
+
+    let renew_request = accept_http_request(&listener).await;
+    assert_eq!(
+        renew_request.request_line,
+        "POST /backend-api/wham/remote/control/server/enroll HTTP/1.1"
+    );
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&renew_request.body)
+            .expect("renew enroll body should deserialize"),
+        json!({
+            "name": expected_server_name,
+            "os": std::env::consts::OS,
+            "arch": std::env::consts::ARCH,
+            "app_server_version": env!("CARGO_PKG_VERSION"),
+            "server_id": "srv_e_test",
+            "environment_id": "env_test",
+        })
+    );
+    respond_with_json(
+        renew_request.stream,
+        json!({
+            "server_id": "srv_e_test",
+            "environment_id": "env_test",
+            "remote_control_token": "remote-control-token-2",
+            "expires_at": (chrono::Utc::now() + chrono::Duration::minutes(10)).to_rfc3339(),
+            "scopes": ["remote_control_server_websocket"],
+        }),
+    )
+    .await;
+
+    let (second_handshake_request, _second_websocket) =
+        accept_remote_control_backend_connection(&listener).await;
+    assert_eq!(
+        second_handshake_request.headers.get("authorization"),
+        Some(&"Bearer remote-control-token-2".to_string())
+    );
+    assert_eq!(
+        second_handshake_request.headers.get("x-codex-server-id"),
+        Some(&"srv_e_test".to_string())
+    );
+
+    shutdown_token.cancel();
+    let _ = remote_task.await;
+}
+
+#[tokio::test]
 async fn remote_control_http_mode_reuses_persisted_enrollment_before_reenrolling() {
     let listener = TcpListener::bind("127.0.0.1:0")
         .await

--- a/codex-rs/app-server/src/transport/remote_control/tests.rs
+++ b/codex-rs/app-server/src/transport/remote_control/tests.rs
@@ -114,6 +114,20 @@ fn remote_control_url_for_listener(listener: &TcpListener) -> String {
     format!("http://{addr}/backend-api/")
 }
 
+fn remote_control_enroll_response(
+    server_id: impl Into<String>,
+    environment_id: impl Into<String>,
+    remote_control_token: impl Into<String>,
+) -> serde_json::Value {
+    json!({
+        "server_id": server_id.into(),
+        "environment_id": environment_id.into(),
+        "remote_control_token": remote_control_token.into(),
+        "expires_at": (chrono::Utc::now() + chrono::Duration::minutes(10)).to_rfc3339(),
+        "scopes": ["remote_control_server_websocket"],
+    })
+}
+
 #[tokio::test]
 async fn remote_control_transport_manages_virtual_clients_and_routes_messages() {
     let listener = TcpListener::bind("127.0.0.1:0")
@@ -142,7 +156,7 @@ async fn remote_control_transport_manages_virtual_clients_and_routes_messages() 
     );
     respond_with_json(
         enroll_request.stream,
-        json!({ "server_id": "srv_e_test", "environment_id": "env_test" }),
+        remote_control_enroll_response("srv_e_test", "env_test", "remote-control-token"),
     )
     .await;
     let mut websocket = accept_remote_control_connection(&listener).await;
@@ -408,7 +422,7 @@ async fn remote_control_transport_reconnects_after_disconnect() {
     );
     respond_with_json(
         enroll_request.stream,
-        json!({ "server_id": "srv_e_test", "environment_id": "env_test" }),
+        remote_control_enroll_response("srv_e_test", "env_test", "remote-control-token"),
     )
     .await;
     let mut first_websocket = accept_remote_control_connection(&listener).await;
@@ -547,7 +561,7 @@ async fn remote_control_handle_set_enabled_stops_and_restarts_connections() {
     );
     respond_with_json(
         enroll_request.stream,
-        json!({ "server_id": "srv_e_test", "environment_id": "env_test" }),
+        remote_control_enroll_response("srv_e_test", "env_test", "remote-control-token"),
     )
     .await;
     let mut first_websocket = accept_remote_control_connection(&listener).await;
@@ -596,7 +610,7 @@ async fn remote_control_transport_clears_outgoing_buffer_when_backend_acks() {
     let enroll_request = accept_http_request(&listener).await;
     respond_with_json(
         enroll_request.stream,
-        json!({ "server_id": "srv_e_test", "environment_id": "env_test" }),
+        remote_control_enroll_response("srv_e_test", "env_test", "remote-control-token"),
     )
     .await;
     let mut first_websocket = accept_remote_control_connection(&listener).await;
@@ -786,7 +800,7 @@ async fn remote_control_http_mode_enrolls_before_connecting() {
     );
     respond_with_json(
         enroll_request.stream,
-        json!({ "server_id": "srv_e_test", "environment_id": "env_test" }),
+        remote_control_enroll_response("srv_e_test", "env_test", "remote-control-token"),
     )
     .await;
 
@@ -798,7 +812,7 @@ async fn remote_control_http_mode_enrolls_before_connecting() {
     );
     assert_eq!(
         handshake_request.headers.get("authorization"),
-        Some(&"Bearer Access Token".to_string())
+        Some(&"Bearer remote-control-token".to_string())
     );
     assert_eq!(
         handshake_request
@@ -1044,7 +1058,7 @@ async fn remote_control_renews_server_token_with_existing_enrollment_ids() {
 }
 
 #[tokio::test]
-async fn remote_control_http_mode_reuses_persisted_enrollment_before_reenrolling() {
+async fn remote_control_http_mode_renews_token_for_persisted_enrollment_before_connecting() {
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
         .expect("listener should bind");
@@ -1053,6 +1067,7 @@ async fn remote_control_http_mode_reuses_persisted_enrollment_before_reenrolling
     let state_db = remote_control_state_runtime(&codex_home).await;
     let remote_control_target =
         normalize_remote_control_url(&remote_control_url).expect("target should parse");
+    let expected_server_name = gethostname().to_string_lossy().trim().to_string();
     let persisted_enrollment = RemoteControlEnrollment {
         account_id: "account_id".to_string(),
         environment_id: "env_persisted".to_string(),
@@ -1084,6 +1099,33 @@ async fn remote_control_http_mode_reuses_persisted_enrollment_before_reenrolling
     .await
     .expect("remote control should start");
 
+    let renew_request = accept_http_request(&listener).await;
+    assert_eq!(
+        renew_request.request_line,
+        "POST /backend-api/wham/remote/control/server/enroll HTTP/1.1"
+    );
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&renew_request.body)
+            .expect("renew enroll body should deserialize"),
+        json!({
+            "name": expected_server_name,
+            "os": std::env::consts::OS,
+            "arch": std::env::consts::ARCH,
+            "app_server_version": env!("CARGO_PKG_VERSION"),
+            "server_id": persisted_enrollment.server_id.clone(),
+            "environment_id": persisted_enrollment.environment_id.clone(),
+        })
+    );
+    respond_with_json(
+        renew_request.stream,
+        remote_control_enroll_response(
+            persisted_enrollment.server_id.clone(),
+            persisted_enrollment.environment_id.clone(),
+            "remote-control-token",
+        ),
+    )
+    .await;
+
     let (handshake_request, _websocket) = accept_remote_control_backend_connection(&listener).await;
     assert_eq!(
         handshake_request.path,
@@ -1094,6 +1136,10 @@ async fn remote_control_http_mode_reuses_persisted_enrollment_before_reenrolling
         Some(&persisted_enrollment.server_id)
     );
     assert_eq!(
+        handshake_request.headers.get("authorization"),
+        Some(&"Bearer remote-control-token".to_string())
+    );
+    assert_eq!(
         load_persisted_remote_control_enrollment(
             Some(state_db.as_ref()),
             &remote_control_target,
@@ -1101,7 +1147,10 @@ async fn remote_control_http_mode_reuses_persisted_enrollment_before_reenrolling
             /*app_server_client_name*/ None,
         )
         .await,
-        Some(persisted_enrollment)
+        Some(RemoteControlEnrollment {
+            server_name: expected_server_name,
+            ..persisted_enrollment
+        })
     );
 
     shutdown_token.cancel();
@@ -1156,10 +1205,29 @@ async fn remote_control_stdio_mode_waits_for_client_name_before_connecting() {
         .expect_err("remote control should wait for the stdio client name");
 
     let _ = app_server_client_name_tx.send(app_server_client_name.to_string());
+    let renew_request = accept_http_request(&listener).await;
+    assert_eq!(
+        renew_request.request_line,
+        "POST /backend-api/wham/remote/control/server/enroll HTTP/1.1"
+    );
+    respond_with_json(
+        renew_request.stream,
+        remote_control_enroll_response(
+            persisted_enrollment.server_id.clone(),
+            persisted_enrollment.environment_id.clone(),
+            "remote-control-token",
+        ),
+    )
+    .await;
+
     let (handshake_request, _websocket) = accept_remote_control_backend_connection(&listener).await;
     assert_eq!(
         handshake_request.headers.get("x-codex-server-id"),
         Some(&persisted_enrollment.server_id)
+    );
+    assert_eq!(
+        handshake_request.headers.get("authorization"),
+        Some(&"Bearer remote-control-token".to_string())
     );
 
     shutdown_token.cancel();
@@ -1226,10 +1294,11 @@ async fn remote_control_waits_for_account_id_before_enrolling() {
     );
     respond_with_json(
         enroll_request.stream,
-        json!({
-            "server_id": expected_enrollment.server_id,
-            "environment_id": expected_enrollment.environment_id,
-        }),
+        remote_control_enroll_response(
+            expected_enrollment.server_id.clone(),
+            expected_enrollment.environment_id.clone(),
+            "remote-control-token",
+        ),
     )
     .await;
 
@@ -1264,7 +1333,7 @@ async fn remote_control_http_mode_clears_stale_persisted_enrollment_after_404() 
         account_id: "account_id".to_string(),
         environment_id: "env_refreshed".to_string(),
         server_id: "srv_e_refreshed".to_string(),
-        server_name: expected_server_name,
+        server_name: expected_server_name.clone(),
     };
     update_persisted_remote_control_enrollment(
         Some(state_db.as_ref()),
@@ -1291,6 +1360,33 @@ async fn remote_control_http_mode_clears_stale_persisted_enrollment_after_404() 
     .await
     .expect("remote control should start");
 
+    let stale_token_request = accept_http_request(&listener).await;
+    assert_eq!(
+        stale_token_request.request_line,
+        "POST /backend-api/wham/remote/control/server/enroll HTTP/1.1"
+    );
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&stale_token_request.body)
+            .expect("stale token enroll body should deserialize"),
+        json!({
+            "name": expected_server_name,
+            "os": std::env::consts::OS,
+            "arch": std::env::consts::ARCH,
+            "app_server_version": env!("CARGO_PKG_VERSION"),
+            "server_id": stale_enrollment.server_id.clone(),
+            "environment_id": stale_enrollment.environment_id.clone(),
+        })
+    );
+    respond_with_json(
+        stale_token_request.stream,
+        remote_control_enroll_response(
+            stale_enrollment.server_id.clone(),
+            stale_enrollment.environment_id.clone(),
+            "stale-remote-control-token",
+        ),
+    )
+    .await;
+
     let websocket_request = accept_http_request(&listener).await;
     assert_eq!(
         websocket_request.request_line,
@@ -1300,6 +1396,10 @@ async fn remote_control_http_mode_clears_stale_persisted_enrollment_after_404() 
         websocket_request.headers.get("x-codex-server-id"),
         Some(&stale_enrollment.server_id)
     );
+    assert_eq!(
+        websocket_request.headers.get("authorization"),
+        Some(&"Bearer stale-remote-control-token".to_string())
+    );
     respond_with_status(websocket_request.stream, "404 Not Found", "").await;
 
     let enroll_request = accept_http_request(&listener).await;
@@ -1307,12 +1407,23 @@ async fn remote_control_http_mode_clears_stale_persisted_enrollment_after_404() 
         enroll_request.request_line,
         "POST /backend-api/wham/remote/control/server/enroll HTTP/1.1"
     );
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&enroll_request.body)
+            .expect("refreshed enroll body should deserialize"),
+        json!({
+            "name": refreshed_enrollment.server_name.clone(),
+            "os": std::env::consts::OS,
+            "arch": std::env::consts::ARCH,
+            "app_server_version": env!("CARGO_PKG_VERSION"),
+        })
+    );
     respond_with_json(
         enroll_request.stream,
-        json!({
-            "server_id": refreshed_enrollment.server_id,
-            "environment_id": refreshed_enrollment.environment_id,
-        }),
+        remote_control_enroll_response(
+            refreshed_enrollment.server_id.clone(),
+            refreshed_enrollment.environment_id.clone(),
+            "refreshed-remote-control-token",
+        ),
     )
     .await;
 
@@ -1320,6 +1431,10 @@ async fn remote_control_http_mode_clears_stale_persisted_enrollment_after_404() 
     assert_eq!(
         handshake_request.headers.get("x-codex-server-id"),
         Some(&refreshed_enrollment.server_id)
+    );
+    assert_eq!(
+        handshake_request.headers.get("authorization"),
+        Some(&"Bearer refreshed-remote-control-token".to_string())
     );
     assert_eq!(
         load_persisted_remote_control_enrollment(

--- a/codex-rs/app-server/src/transport/remote_control/websocket.rs
+++ b/codex-rs/app-server/src/transport/remote_control/websocket.rs
@@ -119,6 +119,7 @@ struct WebsocketState {
 struct RemoteControlEnrollmentState {
     enrollment: Option<RemoteControlEnrollment>,
     server_token: Option<RemoteControlServerToken>,
+    server_token_refresh_required: bool,
 }
 
 pub(crate) struct RemoteControlWebsocket {
@@ -853,6 +854,7 @@ async fn connect_remote_control_websocket_with_options(
         );
         enrollment_state.enrollment = None;
         enrollment_state.server_token = None;
+        enrollment_state.server_token_refresh_required = false;
     }
 
     if enrollment_state.enrollment.is_none() {
@@ -865,26 +867,43 @@ async fn connect_remote_control_websocket_with_options(
         .await;
     }
 
-    if enrollment_state
-        .server_token
-        .as_ref()
-        .is_some_and(|server_token| server_token.expires_soon(Utc::now()))
-    {
+    let should_refresh_server_token = enrollment_state.server_token_refresh_required
+        || enrollment_state
+            .server_token
+            .as_ref()
+            .is_some_and(|server_token| server_token.expires_soon(Utc::now()));
+    if should_refresh_server_token {
         info!(
-            "remote control server token is near expiry; creating a new enrollment: websocket_url={}, account_id={}",
+            "remote control server token needs refresh; renewing enrollment token: websocket_url={}, account_id={}",
             remote_control_target.websocket_url, auth.account_id
         );
-        enrollment_state.enrollment = None;
         enrollment_state.server_token = None;
+        enrollment_state.server_token_refresh_required = true;
     }
 
-    if enrollment_state.enrollment.is_none() {
-        info!(
-            "creating new remote control enrollment: websocket_url={}, enroll_url={}, account_id={}",
-            remote_control_target.websocket_url, remote_control_target.enroll_url, auth.account_id
-        );
+    if enrollment_state.enrollment.is_none() || should_refresh_server_token {
+        let existing_enrollment = enrollment_state.enrollment.as_ref();
+        if let Some(existing_enrollment) = existing_enrollment {
+            info!(
+                "renewing remote control server token for existing enrollment: websocket_url={}, enroll_url={}, account_id={}, server_id={}, environment_id={}",
+                remote_control_target.websocket_url,
+                remote_control_target.enroll_url,
+                auth.account_id,
+                existing_enrollment.server_id,
+                existing_enrollment.environment_id
+            );
+        } else {
+            info!(
+                "creating new remote control enrollment: websocket_url={}, enroll_url={}, account_id={}",
+                remote_control_target.websocket_url,
+                remote_control_target.enroll_url,
+                auth.account_id
+            );
+        }
         let enrollment_result =
-            match enroll_remote_control_server(remote_control_target, &auth).await {
+            match enroll_remote_control_server(remote_control_target, &auth, existing_enrollment)
+                .await
+            {
                 Ok(enrollment_result) => enrollment_result,
                 Err(err)
                     if err.kind() == ErrorKind::PermissionDenied
@@ -917,6 +936,7 @@ async fn connect_remote_control_websocket_with_options(
         );
         enrollment_state.enrollment = Some(new_enrollment);
         enrollment_state.server_token = enrollment_result.server_token;
+        enrollment_state.server_token_refresh_required = false;
     }
 
     let enrollment_ref = enrollment_state.enrollment.as_ref().ok_or_else(|| {
@@ -957,30 +977,18 @@ async fn connect_remote_control_websocket_with_options(
                     }
                     enrollment_state.enrollment = None;
                     enrollment_state.server_token = None;
+                    enrollment_state.server_token_refresh_required = false;
                 }
                 tungstenite::Error::Http(response)
                     if matches!(response.status().as_u16(), 401 | 403) =>
                 {
                     if enrollment_state.server_token.is_some() {
                         info!(
-                            "remote control websocket token auth failed with HTTP {}; clearing enrollment before re-enrolling",
+                            "remote control websocket token auth failed with HTTP {}; renewing token before reconnecting",
                             response.status()
                         );
-                        if let Err(clear_err) = update_persisted_remote_control_enrollment(
-                            state_db,
-                            remote_control_target,
-                            &auth.account_id,
-                            app_server_client_name,
-                            /*enrollment*/ None,
-                        )
-                        .await
-                        {
-                            warn!(
-                                "failed to clear remote control enrollment after token auth failure: {clear_err}"
-                            );
-                        }
-                        enrollment_state.enrollment = None;
                         enrollment_state.server_token = None;
+                        enrollment_state.server_token_refresh_required = true;
                         return Err(io::Error::other(format!(
                             "remote control websocket token auth failed with HTTP {}; re-enrolling",
                             response.status()
@@ -1009,6 +1017,7 @@ async fn connect_remote_control_websocket_with_options(
                             );
                         }
                         enrollment_state.enrollment = None;
+                        enrollment_state.server_token_refresh_required = false;
                     }
                 }
                 _ => {}
@@ -1266,6 +1275,63 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn connect_remote_control_websocket_keeps_enrollment_after_server_token_auth_failure() {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("listener should bind");
+        let remote_control_url = remote_control_url_for_listener(&listener);
+        let remote_control_target =
+            normalize_remote_control_url(&remote_control_url).expect("target should parse");
+        let server_task = tokio::spawn(async move {
+            let (stream, request_line) = accept_http_request(&listener).await;
+            assert_eq!(
+                request_line,
+                "GET /backend-api/wham/remote/control/server HTTP/1.1"
+            );
+            respond_with_status_and_headers(stream, "401 Unauthorized", &[], "unauthorized").await;
+        });
+        let codex_home = TempDir::new().expect("temp dir should create");
+        let state_db = remote_control_state_runtime(&codex_home).await;
+        let auth_manager = remote_control_auth_manager();
+        let mut auth_recovery = auth_manager.unauthorized_recovery();
+        let enrollment = RemoteControlEnrollment {
+            account_id: "account_id".to_string(),
+            environment_id: "env_test".to_string(),
+            server_id: "srv_e_test".to_string(),
+            server_name: "test-server".to_string(),
+        };
+        let mut enrollment_state = RemoteControlEnrollmentState {
+            enrollment: Some(enrollment.clone()),
+            server_token: Some(RemoteControlServerToken {
+                bearer_token: "remote-control-token".to_string(),
+                expires_at: Utc::now() + chrono::Duration::minutes(10),
+            }),
+            ..Default::default()
+        };
+
+        let err = connect_remote_control_websocket(
+            &remote_control_target,
+            Some(state_db.as_ref()),
+            &auth_manager,
+            &mut auth_recovery,
+            &mut enrollment_state,
+            /*subscribe_cursor*/ None,
+            /*app_server_client_name*/ None,
+        )
+        .await
+        .expect_err("server token auth failure should fail this connect attempt");
+
+        server_task.await.expect("server task should succeed");
+        assert_eq!(
+            err.to_string(),
+            "remote control websocket token auth failed with HTTP 401 Unauthorized; re-enrolling"
+        );
+        assert_eq!(enrollment_state.enrollment, Some(enrollment));
+        assert_eq!(enrollment_state.server_token, None);
+        assert!(enrollment_state.server_token_refresh_required);
+    }
+
+    #[tokio::test]
     async fn connect_remote_control_websocket_includes_http_error_details() {
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
@@ -1303,6 +1369,7 @@ mod tests {
                 server_name: "test-server".to_string(),
             }),
             server_token: None,
+            ..Default::default()
         };
 
         let err = match connect_remote_control_websocket(
@@ -1354,6 +1421,7 @@ mod tests {
                 server_name: "test-server".to_string(),
             }),
             server_token: None,
+            ..Default::default()
         };
         save_auth(
             codex_home.path(),

--- a/codex-rs/app-server/src/transport/remote_control/websocket.rs
+++ b/codex-rs/app-server/src/transport/remote_control/websocket.rs
@@ -690,7 +690,7 @@ fn build_remote_control_websocket_request(
     websocket_url: &str,
     enrollment: &RemoteControlEnrollment,
     auth: &RemoteControlConnectionAuth,
-    server_token: Option<&RemoteControlServerToken>,
+    server_token: &RemoteControlServerToken,
     subscribe_cursor: Option<&str>,
 ) -> io::Result<tungstenite::http::Request<()>> {
     let mut request = websocket_url.into_client_request().map_err(|err| {
@@ -711,9 +711,7 @@ fn build_remote_control_websocket_request(
         "x-codex-protocol-version",
         REMOTE_CONTROL_PROTOCOL_VERSION,
     )?;
-    let authorization_header_value = server_token
-        .map(|server_token| format!("Bearer {}", server_token.bearer_token))
-        .unwrap_or_else(|| auth.authorization_header_value.clone());
+    let authorization_header_value = format!("Bearer {}", server_token.bearer_token);
     set_remote_control_header(headers, "authorization", &authorization_header_value)?;
     set_remote_control_header(headers, REMOTE_CONTROL_ACCOUNT_ID_HEADER, &auth.account_id)?;
     if auth.is_fedramp_account {
@@ -867,11 +865,12 @@ async fn connect_remote_control_websocket_with_options(
         .await;
     }
 
-    let should_refresh_server_token = enrollment_state.server_token_refresh_required
-        || enrollment_state
-            .server_token
-            .as_ref()
-            .is_some_and(|server_token| server_token.expires_soon(Utc::now()));
+    let should_refresh_server_token = enrollment_state.enrollment.is_some()
+        && (enrollment_state.server_token_refresh_required
+            || enrollment_state
+                .server_token
+                .as_ref()
+                .is_none_or(|server_token| server_token.expires_soon(Utc::now())));
     if should_refresh_server_token {
         info!(
             "remote control server token needs refresh; renewing enrollment token: websocket_url={}, account_id={}",
@@ -935,18 +934,21 @@ async fn connect_remote_control_websocket_with_options(
             new_enrollment.environment_id
         );
         enrollment_state.enrollment = Some(new_enrollment);
-        enrollment_state.server_token = enrollment_result.server_token;
+        enrollment_state.server_token = Some(enrollment_result.server_token);
         enrollment_state.server_token_refresh_required = false;
     }
 
     let enrollment_ref = enrollment_state.enrollment.as_ref().ok_or_else(|| {
         io::Error::other("missing remote control enrollment after enrollment step")
     })?;
+    let server_token = enrollment_state.server_token.as_ref().ok_or_else(|| {
+        io::Error::other("missing remote control server token after enrollment step")
+    })?;
     let request = build_remote_control_websocket_request(
         &remote_control_target.websocket_url,
         enrollment_ref,
         &auth,
-        enrollment_state.server_token.as_ref(),
+        server_token,
         subscribe_cursor,
     )?;
 
@@ -982,43 +984,16 @@ async fn connect_remote_control_websocket_with_options(
                 tungstenite::Error::Http(response)
                     if matches!(response.status().as_u16(), 401 | 403) =>
                 {
-                    if enrollment_state.server_token.is_some() {
-                        info!(
-                            "remote control websocket token auth failed with HTTP {}; renewing token before reconnecting",
-                            response.status()
-                        );
-                        enrollment_state.server_token = None;
-                        enrollment_state.server_token_refresh_required = true;
-                        return Err(io::Error::other(format!(
-                            "remote control websocket token auth failed with HTTP {}; re-enrolling",
-                            response.status()
-                        )));
-                    } else if recover_remote_control_auth(auth_recovery).await {
-                        return Err(io::Error::other(format!(
-                            "remote control websocket auth failed with HTTP {}; retrying after auth recovery",
-                            response.status()
-                        )));
-                    } else {
-                        info!(
-                            "remote control websocket rejected legacy account auth with HTTP {}; clearing enrollment before re-enrolling",
-                            response.status()
-                        );
-                        if let Err(clear_err) = update_persisted_remote_control_enrollment(
-                            state_db,
-                            remote_control_target,
-                            &auth.account_id,
-                            app_server_client_name,
-                            /*enrollment*/ None,
-                        )
-                        .await
-                        {
-                            warn!(
-                                "failed to clear legacy remote control enrollment after auth failure: {clear_err}"
-                            );
-                        }
-                        enrollment_state.enrollment = None;
-                        enrollment_state.server_token_refresh_required = false;
-                    }
+                    info!(
+                        "remote control websocket token auth failed with HTTP {}; renewing token before reconnecting",
+                        response.status()
+                    );
+                    enrollment_state.server_token = None;
+                    enrollment_state.server_token_refresh_required = true;
+                    return Err(io::Error::other(format!(
+                        "remote control websocket token auth failed with HTTP {}; re-enrolling",
+                        response.status()
+                    )));
                 }
                 _ => {}
             }
@@ -1170,8 +1145,15 @@ mod tests {
         }
     }
 
+    fn remote_control_server_token(bearer_token: &str) -> RemoteControlServerToken {
+        RemoteControlServerToken {
+            bearer_token: bearer_token.to_string(),
+            expires_at: Utc::now() + chrono::Duration::minutes(10),
+        }
+    }
+
     #[test]
-    fn build_remote_control_websocket_request_uses_server_token_when_available() {
+    fn build_remote_control_websocket_request_uses_server_token() {
         let enrollment = RemoteControlEnrollment {
             account_id: "account_id".to_string(),
             environment_id: "env_test".to_string(),
@@ -1183,16 +1165,13 @@ mod tests {
             account_id: "account_id".to_string(),
             is_fedramp_account: false,
         };
-        let server_token = RemoteControlServerToken {
-            bearer_token: "remote-control-token".to_string(),
-            expires_at: Utc::now() + chrono::Duration::minutes(10),
-        };
+        let server_token = remote_control_server_token("remote-control-token");
 
         let request = build_remote_control_websocket_request(
             "ws://localhost:8080/backend-api/wham/remote/control/server",
             &enrollment,
             &auth,
-            Some(&server_token),
+            &server_token,
             /*subscribe_cursor*/ None,
         )
         .expect("websocket request should build");
@@ -1214,39 +1193,8 @@ mod tests {
     }
 
     #[test]
-    fn build_remote_control_websocket_request_falls_back_to_account_token() {
-        let enrollment = RemoteControlEnrollment {
-            account_id: "account_id".to_string(),
-            environment_id: "env_test".to_string(),
-            server_id: "srv_e_test".to_string(),
-            server_name: "test-server".to_string(),
-        };
-        let auth = RemoteControlConnectionAuth {
-            authorization_header_value: "AgentAssertion assertion".to_string(),
-            account_id: "account_id".to_string(),
-            is_fedramp_account: false,
-        };
-
-        let request = build_remote_control_websocket_request(
-            "ws://localhost:8080/backend-api/wham/remote/control/server",
-            &enrollment,
-            &auth,
-            /*server_token*/ None,
-            /*subscribe_cursor*/ None,
-        )
-        .expect("websocket request should build");
-
-        assert_eq!(
-            request
-                .headers()
-                .get("authorization")
-                .expect("authorization header should exist"),
-            "AgentAssertion assertion"
-        );
-    }
-
-    #[test]
     fn build_remote_control_websocket_request_includes_fedramp_header() {
+        let server_token = remote_control_server_token("remote-control-token");
         let request = build_remote_control_websocket_request(
             "ws://127.0.0.1/backend-api/wham/remote/control/server",
             &RemoteControlEnrollment {
@@ -1260,7 +1208,7 @@ mod tests {
                 account_id: "account_id".to_string(),
                 is_fedramp_account: true,
             },
-            /*server_token*/ None,
+            &server_token,
             /*subscribe_cursor*/ None,
         )
         .expect("request should build");
@@ -1302,10 +1250,7 @@ mod tests {
         };
         let mut enrollment_state = RemoteControlEnrollmentState {
             enrollment: Some(enrollment.clone()),
-            server_token: Some(RemoteControlServerToken {
-                bearer_token: "remote-control-token".to_string(),
-                expires_at: Utc::now() + chrono::Duration::minutes(10),
-            }),
+            server_token: Some(remote_control_server_token("remote-control-token")),
             ..Default::default()
         };
 
@@ -1368,7 +1313,7 @@ mod tests {
                 server_id: "srv_e_test".to_string(),
                 server_name: "test-server".to_string(),
             }),
-            server_token: None,
+            server_token: Some(remote_control_server_token("remote-control-token")),
             ..Default::default()
         };
 
@@ -1389,82 +1334,6 @@ mod tests {
 
         server_task.await.expect("server task should succeed");
         assert_eq!(err.to_string(), expected_error);
-    }
-
-    #[tokio::test]
-    async fn connect_remote_control_websocket_recovers_after_unauthorized_reload() {
-        let listener = TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("listener should bind");
-        let remote_control_url = remote_control_url_for_listener(&listener);
-        let remote_control_target =
-            normalize_remote_control_url(&remote_control_url).expect("target should parse");
-        let codex_home = TempDir::new().expect("temp dir should create");
-        save_auth(
-            codex_home.path(),
-            &remote_control_auth_dot_json("stale-token"),
-            AuthCredentialsStoreMode::File,
-        )
-        .expect("stale auth should save");
-        let state_db = remote_control_state_runtime(&codex_home).await;
-        let auth_manager = AuthManager::shared(
-            codex_home.path().to_path_buf(),
-            /*enable_codex_api_key_env*/ false,
-            AuthCredentialsStoreMode::File,
-        );
-        let mut auth_recovery = auth_manager.unauthorized_recovery();
-        let mut enrollment_state = RemoteControlEnrollmentState {
-            enrollment: Some(RemoteControlEnrollment {
-                account_id: "account_id".to_string(),
-                environment_id: "env_test".to_string(),
-                server_id: "srv_e_test".to_string(),
-                server_name: "test-server".to_string(),
-            }),
-            server_token: None,
-            ..Default::default()
-        };
-        save_auth(
-            codex_home.path(),
-            &remote_control_auth_dot_json("fresh-token"),
-            AuthCredentialsStoreMode::File,
-        )
-        .expect("fresh auth should save");
-
-        let server_task = tokio::spawn(async move {
-            let (stream, request_line) = accept_http_request(&listener).await;
-            assert_eq!(
-                request_line,
-                "GET /backend-api/wham/remote/control/server HTTP/1.1"
-            );
-            respond_with_status_and_headers(stream, "401 Unauthorized", &[], "unauthorized").await;
-        });
-
-        let err = connect_remote_control_websocket(
-            &remote_control_target,
-            Some(state_db.as_ref()),
-            &auth_manager,
-            &mut auth_recovery,
-            &mut enrollment_state,
-            /*subscribe_cursor*/ None,
-            /*app_server_client_name*/ None,
-        )
-        .await
-        .expect_err("unauthorized response should fail the websocket connect");
-
-        server_task.await.expect("server task should succeed");
-        assert_eq!(
-            err.to_string(),
-            "remote control websocket auth failed with HTTP 401 Unauthorized; retrying after auth recovery"
-        );
-        assert_eq!(
-            auth_manager
-                .auth()
-                .await
-                .expect("auth should remain available")
-                .get_token()
-                .expect("token should be readable"),
-            "fresh-token"
-        );
     }
 
     #[tokio::test]

--- a/codex-rs/app-server/src/transport/remote_control/websocket.rs
+++ b/codex-rs/app-server/src/transport/remote_control/websocket.rs
@@ -3,6 +3,7 @@ use crate::transport::remote_control::client_tracker::ClientTracker;
 use crate::transport::remote_control::client_tracker::REMOTE_CONTROL_IDLE_SWEEP_INTERVAL;
 use crate::transport::remote_control::enroll::RemoteControlConnectionAuth;
 use crate::transport::remote_control::enroll::RemoteControlEnrollment;
+use crate::transport::remote_control::enroll::RemoteControlServerToken;
 use crate::transport::remote_control::enroll::enroll_remote_control_server;
 use crate::transport::remote_control::enroll::format_headers;
 use crate::transport::remote_control::enroll::load_persisted_remote_control_enrollment;
@@ -17,6 +18,7 @@ use super::protocol::ServerEnvelope;
 use super::protocol::StreamId;
 use axum::http::HeaderValue;
 use base64::Engine;
+use chrono::Utc;
 use codex_core::util::backoff;
 use codex_login::AuthManager;
 use codex_login::UnauthorizedRecovery;
@@ -113,6 +115,12 @@ struct WebsocketState {
     next_seq_id_by_stream: HashMap<(ClientId, StreamId), u64>,
 }
 
+#[derive(Default)]
+struct RemoteControlEnrollmentState {
+    enrollment: Option<RemoteControlEnrollment>,
+    server_token: Option<RemoteControlServerToken>,
+}
+
 pub(crate) struct RemoteControlWebsocket {
     remote_control_url: String,
     remote_control_target: Option<RemoteControlTarget>,
@@ -120,7 +128,7 @@ pub(crate) struct RemoteControlWebsocket {
     auth_manager: Arc<AuthManager>,
     shutdown_token: CancellationToken,
     reconnect_attempt: u64,
-    enrollment: Option<RemoteControlEnrollment>,
+    enrollment_state: RemoteControlEnrollmentState,
     auth_recovery: UnauthorizedRecovery,
     client_tracker: Arc<Mutex<ClientTracker>>,
     state: Arc<Mutex<WebsocketState>>,
@@ -191,7 +199,7 @@ impl RemoteControlWebsocket {
             auth_manager,
             shutdown_token,
             reconnect_attempt: 0,
-            enrollment: None,
+            enrollment_state: RemoteControlEnrollmentState::default(),
             auth_recovery,
             client_tracker: Arc::new(Mutex::new(client_tracker)),
             state: Arc::new(Mutex::new(WebsocketState {
@@ -304,16 +312,14 @@ impl RemoteControlWebsocket {
                     }
                     return ConnectOutcome::Disabled;
                 }
-                connect_result = connect_remote_control_websocket_with_options(
-                    ConnectRemoteControlWebsocketOptions {
-                        remote_control_target: &remote_control_target,
-                        state_db: self.state_db.as_deref(),
-                        auth_manager: &self.auth_manager,
-                        auth_recovery: &mut self.auth_recovery,
-                        enrollment: &mut self.enrollment,
-                        subscribe_cursor: subscribe_cursor.as_deref(),
-                        app_server_client_name,
-                    },
+                connect_result = connect_remote_control_websocket(
+                    &remote_control_target,
+                    self.state_db.as_deref(),
+                    &self.auth_manager,
+                    &mut self.auth_recovery,
+                    &mut self.enrollment_state,
+                    subscribe_cursor.as_deref(),
+                    app_server_client_name,
                 ) => connect_result,
             };
 
@@ -683,6 +689,7 @@ fn build_remote_control_websocket_request(
     websocket_url: &str,
     enrollment: &RemoteControlEnrollment,
     auth: &RemoteControlConnectionAuth,
+    server_token: Option<&RemoteControlServerToken>,
     subscribe_cursor: Option<&str>,
 ) -> io::Result<tungstenite::http::Request<()>> {
     let mut request = websocket_url.into_client_request().map_err(|err| {
@@ -703,7 +710,10 @@ fn build_remote_control_websocket_request(
         "x-codex-protocol-version",
         REMOTE_CONTROL_PROTOCOL_VERSION,
     )?;
-    set_remote_control_header(headers, "authorization", &auth.authorization_header_value)?;
+    let authorization_header_value = server_token
+        .map(|server_token| format!("Bearer {}", server_token.bearer_token))
+        .unwrap_or_else(|| auth.authorization_header_value.clone());
+    set_remote_control_header(headers, "authorization", &authorization_header_value)?;
     set_remote_control_header(headers, REMOTE_CONTROL_ACCOUNT_ID_HEADER, &auth.account_id)?;
     if auth.is_fedramp_account {
         set_remote_control_header(headers, REMOTE_CONTROL_FEDRAMP_HEADER, "true")?;
@@ -774,13 +784,12 @@ pub(crate) async fn load_remote_control_auth(
     })
 }
 
-#[cfg(test)]
-pub(super) async fn connect_remote_control_websocket(
+async fn connect_remote_control_websocket(
     remote_control_target: &RemoteControlTarget,
     state_db: Option<&StateRuntime>,
     auth_manager: &Arc<AuthManager>,
     auth_recovery: &mut UnauthorizedRecovery,
-    enrollment: &mut Option<RemoteControlEnrollment>,
+    enrollment_state: &mut RemoteControlEnrollmentState,
     subscribe_cursor: Option<&str>,
     app_server_client_name: Option<&str>,
 ) -> io::Result<(
@@ -792,7 +801,7 @@ pub(super) async fn connect_remote_control_websocket(
         state_db,
         auth_manager,
         auth_recovery,
-        enrollment,
+        enrollment_state,
         subscribe_cursor,
         app_server_client_name,
     })
@@ -804,7 +813,7 @@ struct ConnectRemoteControlWebsocketOptions<'a> {
     state_db: Option<&'a StateRuntime>,
     auth_manager: &'a Arc<AuthManager>,
     auth_recovery: &'a mut UnauthorizedRecovery,
-    enrollment: &'a mut Option<RemoteControlEnrollment>,
+    enrollment_state: &'a mut RemoteControlEnrollmentState,
     subscribe_cursor: Option<&'a str>,
     app_server_client_name: Option<&'a str>,
 }
@@ -820,7 +829,7 @@ async fn connect_remote_control_websocket_with_options(
         state_db,
         auth_manager,
         auth_recovery,
-        enrollment,
+        enrollment_state,
         subscribe_cursor,
         app_server_client_name,
     } = options;
@@ -828,21 +837,26 @@ async fn connect_remote_control_websocket_with_options(
     ensure_rustls_crypto_provider();
 
     let auth = load_remote_control_auth(auth_manager).await?;
-    let enrollment_account_id = enrollment.as_ref().map(|enrollment| &enrollment.account_id);
+    let enrollment_account_id = enrollment_state
+        .enrollment
+        .as_ref()
+        .map(|enrollment| &enrollment.account_id);
     if enrollment_account_id.is_some_and(|account_id| account_id != &auth.account_id) {
         info!(
             "clearing in-memory remote control enrollment because account id changed: websocket_url={}, previous_account_id={:?}, current_account_id={:?}",
             remote_control_target.websocket_url,
-            enrollment
+            enrollment_state
+                .enrollment
                 .as_ref()
                 .map(|enrollment| enrollment.account_id.as_str()),
             auth.account_id
         );
-        *enrollment = None;
+        enrollment_state.enrollment = None;
+        enrollment_state.server_token = None;
     }
 
-    if enrollment.is_none() {
-        *enrollment = load_persisted_remote_control_enrollment(
+    if enrollment_state.enrollment.is_none() {
+        enrollment_state.enrollment = load_persisted_remote_control_enrollment(
             state_db,
             remote_control_target,
             &auth.account_id,
@@ -851,24 +865,38 @@ async fn connect_remote_control_websocket_with_options(
         .await;
     }
 
-    if enrollment.is_none() {
+    if enrollment_state
+        .server_token
+        .as_ref()
+        .is_some_and(|server_token| server_token.expires_soon(Utc::now()))
+    {
+        info!(
+            "remote control server token is near expiry; creating a new enrollment: websocket_url={}, account_id={}",
+            remote_control_target.websocket_url, auth.account_id
+        );
+        enrollment_state.enrollment = None;
+        enrollment_state.server_token = None;
+    }
+
+    if enrollment_state.enrollment.is_none() {
         info!(
             "creating new remote control enrollment: websocket_url={}, enroll_url={}, account_id={}",
             remote_control_target.websocket_url, remote_control_target.enroll_url, auth.account_id
         );
-        let new_enrollment = match enroll_remote_control_server(remote_control_target, &auth).await
-        {
-            Ok(new_enrollment) => new_enrollment,
-            Err(err)
-                if err.kind() == ErrorKind::PermissionDenied
-                    && recover_remote_control_auth(auth_recovery).await =>
-            {
-                return Err(io::Error::other(format!(
-                    "{err}; retrying after auth recovery"
-                )));
-            }
-            Err(err) => return Err(err),
-        };
+        let enrollment_result =
+            match enroll_remote_control_server(remote_control_target, &auth).await {
+                Ok(enrollment_result) => enrollment_result,
+                Err(err)
+                    if err.kind() == ErrorKind::PermissionDenied
+                        && recover_remote_control_auth(auth_recovery).await =>
+                {
+                    return Err(io::Error::other(format!(
+                        "{err}; retrying after auth recovery"
+                    )));
+                }
+                Err(err) => return Err(err),
+            };
+        let new_enrollment = enrollment_result.enrollment;
         if let Err(err) = update_persisted_remote_control_enrollment(
             state_db,
             remote_control_target,
@@ -887,16 +915,18 @@ async fn connect_remote_control_websocket_with_options(
             new_enrollment.server_id,
             new_enrollment.environment_id
         );
-        *enrollment = Some(new_enrollment);
+        enrollment_state.enrollment = Some(new_enrollment);
+        enrollment_state.server_token = enrollment_result.server_token;
     }
 
-    let enrollment_ref = enrollment.as_ref().ok_or_else(|| {
+    let enrollment_ref = enrollment_state.enrollment.as_ref().ok_or_else(|| {
         io::Error::other("missing remote control enrollment after enrollment step")
     })?;
     let request = build_remote_control_websocket_request(
         &remote_control_target.websocket_url,
         enrollment_ref,
         &auth,
+        enrollment_state.server_token.as_ref(),
         subscribe_cursor,
     )?;
 
@@ -925,16 +955,60 @@ async fn connect_remote_control_websocket_with_options(
                             "failed to clear stale remote control enrollment in sqlite state db: {clear_err}"
                         );
                     }
-                    *enrollment = None;
+                    enrollment_state.enrollment = None;
+                    enrollment_state.server_token = None;
                 }
                 tungstenite::Error::Http(response)
                     if matches!(response.status().as_u16(), 401 | 403) =>
                 {
-                    if recover_remote_control_auth(auth_recovery).await {
+                    if enrollment_state.server_token.is_some() {
+                        info!(
+                            "remote control websocket token auth failed with HTTP {}; clearing enrollment before re-enrolling",
+                            response.status()
+                        );
+                        if let Err(clear_err) = update_persisted_remote_control_enrollment(
+                            state_db,
+                            remote_control_target,
+                            &auth.account_id,
+                            app_server_client_name,
+                            /*enrollment*/ None,
+                        )
+                        .await
+                        {
+                            warn!(
+                                "failed to clear remote control enrollment after token auth failure: {clear_err}"
+                            );
+                        }
+                        enrollment_state.enrollment = None;
+                        enrollment_state.server_token = None;
+                        return Err(io::Error::other(format!(
+                            "remote control websocket token auth failed with HTTP {}; re-enrolling",
+                            response.status()
+                        )));
+                    } else if recover_remote_control_auth(auth_recovery).await {
                         return Err(io::Error::other(format!(
                             "remote control websocket auth failed with HTTP {}; retrying after auth recovery",
                             response.status()
                         )));
+                    } else {
+                        info!(
+                            "remote control websocket rejected legacy account auth with HTTP {}; clearing enrollment before re-enrolling",
+                            response.status()
+                        );
+                        if let Err(clear_err) = update_persisted_remote_control_enrollment(
+                            state_db,
+                            remote_control_target,
+                            &auth.account_id,
+                            app_server_client_name,
+                            /*enrollment*/ None,
+                        )
+                        .await
+                        {
+                            warn!(
+                                "failed to clear legacy remote control enrollment after auth failure: {clear_err}"
+                            );
+                        }
+                        enrollment_state.enrollment = None;
                     }
                 }
                 _ => {}
@@ -1088,6 +1162,81 @@ mod tests {
     }
 
     #[test]
+    fn build_remote_control_websocket_request_uses_server_token_when_available() {
+        let enrollment = RemoteControlEnrollment {
+            account_id: "account_id".to_string(),
+            environment_id: "env_test".to_string(),
+            server_id: "srv_e_test".to_string(),
+            server_name: "test-server".to_string(),
+        };
+        let auth = RemoteControlConnectionAuth {
+            authorization_header_value: "AgentAssertion assertion".to_string(),
+            account_id: "account_id".to_string(),
+            is_fedramp_account: false,
+        };
+        let server_token = RemoteControlServerToken {
+            bearer_token: "remote-control-token".to_string(),
+            expires_at: Utc::now() + chrono::Duration::minutes(10),
+        };
+
+        let request = build_remote_control_websocket_request(
+            "ws://localhost:8080/backend-api/wham/remote/control/server",
+            &enrollment,
+            &auth,
+            Some(&server_token),
+            /*subscribe_cursor*/ None,
+        )
+        .expect("websocket request should build");
+
+        assert_eq!(
+            request
+                .headers()
+                .get("authorization")
+                .expect("authorization header should exist"),
+            "Bearer remote-control-token"
+        );
+        assert_eq!(
+            request
+                .headers()
+                .get(REMOTE_CONTROL_ACCOUNT_ID_HEADER)
+                .expect("account id header should exist"),
+            "account_id"
+        );
+    }
+
+    #[test]
+    fn build_remote_control_websocket_request_falls_back_to_account_token() {
+        let enrollment = RemoteControlEnrollment {
+            account_id: "account_id".to_string(),
+            environment_id: "env_test".to_string(),
+            server_id: "srv_e_test".to_string(),
+            server_name: "test-server".to_string(),
+        };
+        let auth = RemoteControlConnectionAuth {
+            authorization_header_value: "AgentAssertion assertion".to_string(),
+            account_id: "account_id".to_string(),
+            is_fedramp_account: false,
+        };
+
+        let request = build_remote_control_websocket_request(
+            "ws://localhost:8080/backend-api/wham/remote/control/server",
+            &enrollment,
+            &auth,
+            /*server_token*/ None,
+            /*subscribe_cursor*/ None,
+        )
+        .expect("websocket request should build");
+
+        assert_eq!(
+            request
+                .headers()
+                .get("authorization")
+                .expect("authorization header should exist"),
+            "AgentAssertion assertion"
+        );
+    }
+
+    #[test]
     fn build_remote_control_websocket_request_includes_fedramp_header() {
         let request = build_remote_control_websocket_request(
             "ws://127.0.0.1/backend-api/wham/remote/control/server",
@@ -1102,6 +1251,7 @@ mod tests {
                 account_id: "account_id".to_string(),
                 is_fedramp_account: true,
             },
+            /*server_token*/ None,
             /*subscribe_cursor*/ None,
         )
         .expect("request should build");
@@ -1145,19 +1295,22 @@ mod tests {
         let state_db = remote_control_state_runtime(&codex_home).await;
         let auth_manager = remote_control_auth_manager();
         let mut auth_recovery = auth_manager.unauthorized_recovery();
-        let mut enrollment = Some(RemoteControlEnrollment {
-            account_id: "account_id".to_string(),
-            environment_id: "env_test".to_string(),
-            server_id: "srv_e_test".to_string(),
-            server_name: "test-server".to_string(),
-        });
+        let mut enrollment_state = RemoteControlEnrollmentState {
+            enrollment: Some(RemoteControlEnrollment {
+                account_id: "account_id".to_string(),
+                environment_id: "env_test".to_string(),
+                server_id: "srv_e_test".to_string(),
+                server_name: "test-server".to_string(),
+            }),
+            server_token: None,
+        };
 
         let err = match connect_remote_control_websocket(
             &remote_control_target,
             Some(state_db.as_ref()),
             &auth_manager,
             &mut auth_recovery,
-            &mut enrollment,
+            &mut enrollment_state,
             /*subscribe_cursor*/ None,
             /*app_server_client_name*/ None,
         )
@@ -1193,12 +1346,15 @@ mod tests {
             AuthCredentialsStoreMode::File,
         );
         let mut auth_recovery = auth_manager.unauthorized_recovery();
-        let mut enrollment = Some(RemoteControlEnrollment {
-            account_id: "account_id".to_string(),
-            environment_id: "env_test".to_string(),
-            server_id: "srv_e_test".to_string(),
-            server_name: "test-server".to_string(),
-        });
+        let mut enrollment_state = RemoteControlEnrollmentState {
+            enrollment: Some(RemoteControlEnrollment {
+                account_id: "account_id".to_string(),
+                environment_id: "env_test".to_string(),
+                server_id: "srv_e_test".to_string(),
+                server_name: "test-server".to_string(),
+            }),
+            server_token: None,
+        };
         save_auth(
             codex_home.path(),
             &remote_control_auth_dot_json("fresh-token"),
@@ -1220,7 +1376,7 @@ mod tests {
             Some(state_db.as_ref()),
             &auth_manager,
             &mut auth_recovery,
-            &mut enrollment,
+            &mut enrollment_state,
             /*subscribe_cursor*/ None,
             /*app_server_client_name*/ None,
         )
@@ -1274,7 +1430,7 @@ mod tests {
             AuthCredentialsStoreMode::File,
         );
         let mut auth_recovery = auth_manager.unauthorized_recovery();
-        let mut enrollment = None;
+        let mut enrollment_state = RemoteControlEnrollmentState::default();
         save_auth(
             codex_home.path(),
             &remote_control_auth_dot_json("fresh-token"),
@@ -1287,7 +1443,7 @@ mod tests {
             Some(state_db.as_ref()),
             &auth_manager,
             &mut auth_recovery,
-            &mut enrollment,
+            &mut enrollment_state,
             /*subscribe_cursor*/ None,
             /*app_server_client_name*/ None,
         )


### PR DESCRIPTION
## Summary

Updates the app-server remote-control client to consume the new short-lived server-scoped token returned by backend enrollment.

- Parse optional `remote_control_token`, `expires_at`, and `scopes` from `/remote/control/server/enroll` for compatibility with old backends.
- Keep the server-scoped token in memory only; persisted enrollment metadata still contains only server/environment identity.
- Prefer `Authorization: Bearer <remote_control_token>` on the remote-control server websocket when the backend provides one.
- Fall back to the legacy account bearer token when talking to an older backend.
- Re-enroll near token expiry and after 401/403 failures when using the scoped token.
- Add remote-control transport tests for token parsing, expiry handling, and Authorization header selection.

## Scope

This is the client half of the server-authority token split. It prevents the app-server websocket from depending on a reusable account bearer token once the backend starts returning scoped server tokens.