### PR TITLE
Install rustls provider for remote websocket client

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1509,6 +1509,7 @@ dependencies = [
  "codex-exec-server",
  "codex-feedback",
  "codex-protocol",
+ "codex-utils-rustls-provider",
  "futures",
  "pretty_assertions",
  "serde",

--- a/codex-rs/app-server-client/Cargo.toml
+++ b/codex-rs/app-server-client/Cargo.toml
@@ -19,6 +19,7 @@ codex-core = { workspace = true }
 codex-exec-server = { workspace = true }
 codex-feedback = { workspace = true }
 codex-protocol = { workspace = true }
+codex-utils-rustls-provider = { workspace = true }
 futures = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/codex-rs/app-server-client/src/remote.rs
+++ b/codex-rs/app-server-client/src/remote.rs
@@ -36,6 +36,7 @@ use codex_app_server_protocol::RequestId;
 use codex_app_server_protocol::Result as JsonRpcResult;
 use codex_app_server_protocol::ServerNotification;
 use codex_app_server_protocol::ServerRequest;
+use codex_utils_rustls_provider::ensure_rustls_crypto_provider;
 use futures::SinkExt;
 use futures::StreamExt;
 use serde::de::DeserializeOwned;
@@ -169,6 +170,7 @@ impl RemoteAppServerClient {
                 })?;
             request.headers_mut().insert(AUTHORIZATION, header_value);
         }
+        ensure_rustls_crypto_provider();
         let stream = timeout(CONNECT_TIMEOUT, connect_async(request))
             .await
             .map_err(|_| {


### PR DESCRIPTION
Addresses #17283

Problem: `codex --remote wss://...` could panic because app-server-client did not install rustls' process-level crypto provider before opening TLS websocket connections.

Solution: Add the existing rustls provider utility dependency and install it before the remote websocket connect.