### PR TITLE
Add use_agent_identity feature flag

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/account.rs
+++ b/codex-rs/app-server/tests/suite/v2/account.rs
@@ -45,7 +45,9 @@ use wiremock::ResponseTemplate;
 use wiremock::matchers::method;
 use wiremock::matchers::path;
 
-const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+// Account tests spin up fresh app-server processes repeatedly, which can take
+// longer on slower Bazel macOS runners once the suite is already warm.
+const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
 const LOGIN_ISSUER_ENV_VAR: &str = "CODEX_APP_SERVER_LOGIN_ISSUER";
 
 // Helper to create a minimal config.toml for the app server

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -503,6 +503,9 @@
             "unified_exec": {
               "type": "boolean"
             },
+            "use_agent_identity": {
+              "type": "boolean"
+            },
             "use_legacy_landlock": {
               "type": "boolean"
             },
@@ -2347,6 +2350,9 @@
           "type": "boolean"
         },
         "unified_exec": {
+          "type": "boolean"
+        },
+        "use_agent_identity": {
           "type": "boolean"
         },
         "use_legacy_landlock": {

--- a/codex-rs/exec-server/src/server/handler/tests.rs
+++ b/codex-rs/exec-server/src/server/handler/tests.rs
@@ -275,7 +275,7 @@ async fn output_and_exit_are_retained_after_notification_receiver_closes() {
             process_id.as_str(),
             shell_argv(
                 "sleep 0.05; printf 'first\\n'; sleep 0.05; printf 'second\\n'",
-                "echo first&& ping -n 2 127.0.0.1 >NUL&& echo second",
+                "(echo first) && ping -n 2 127.0.0.1 >NUL && (echo second)",
             ),
         ))
         .await

--- a/codex-rs/exec-server/src/server/handler/tests.rs
+++ b/codex-rs/exec-server/src/server/handler/tests.rs
@@ -275,6 +275,7 @@ async fn output_and_exit_are_retained_after_notification_receiver_closes() {
             process_id.as_str(),
             shell_argv(
                 "sleep 0.05; printf 'first\\n'; sleep 0.05; printf 'second\\n'",
+                // `cmd.exe` retains the space before `&&` in `echo first && ...`.
                 "(echo first) && ping -n 2 127.0.0.1 >NUL && (echo second)",
             ),
         ))

--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -186,6 +186,8 @@ pub enum Feature {
     ResponsesWebsockets,
     /// Legacy rollout flag for Responses API WebSocket transport v2 experiments.
     ResponsesWebsocketsV2,
+    /// Use the agent identity registration flow for ChatGPT-authenticated sessions.
+    UseAgentIdentity,
 }
 
 impl Feature {
@@ -907,6 +909,12 @@ pub const FEATURES: &[FeatureSpec] = &[
         id: Feature::ResponsesWebsocketsV2,
         key: "responses_websockets_v2",
         stage: Stage::Removed,
+        default_enabled: false,
+    },
+    FeatureSpec {
+        id: Feature::UseAgentIdentity,
+        key: "use_agent_identity",
+        stage: Stage::UnderDevelopment,
         default_enabled: false,
     },
 ];

--- a/codex-rs/features/src/tests.rs
+++ b/codex-rs/features/src/tests.rs
@@ -170,10 +170,13 @@ fn use_agent_identity_is_under_development() {
 }
 
 #[test]
-fn image_detail_original_feature_is_under_development() {
+fn image_detail_original_feature_is_experimental_and_user_toggleable() {
+    let stage = Feature::ImageDetailOriginal.stage();
+
+    assert!(matches!(stage, Stage::Experimental { .. }));
     assert_eq!(
-        Feature::ImageDetailOriginal.stage(),
-        Stage::UnderDevelopment
+        stage.experimental_menu_name(),
+        Some("Original image detail")
     );
     assert_eq!(Feature::ImageDetailOriginal.default_enabled(), false);
 }

--- a/codex-rs/features/src/tests.rs
+++ b/codex-rs/features/src/tests.rs
@@ -164,6 +164,21 @@ fn remote_control_is_under_development() {
 }
 
 #[test]
+fn use_agent_identity_is_under_development() {
+    assert_eq!(Feature::UseAgentIdentity.stage(), Stage::UnderDevelopment);
+    assert_eq!(Feature::UseAgentIdentity.default_enabled(), false);
+}
+
+#[test]
+fn image_detail_original_feature_is_under_development() {
+    assert_eq!(
+        Feature::ImageDetailOriginal.stage(),
+        Stage::UnderDevelopment
+    );
+    assert_eq!(Feature::ImageDetailOriginal.default_enabled(), false);
+}
+
+#[test]
 fn collab_is_legacy_alias_for_multi_agent() {
     assert_eq!(feature_for_key("multi_agent"), Some(Feature::Collab));
     assert_eq!(feature_for_key("collab"), Some(Feature::Collab));


### PR DESCRIPTION
## Summary

Stack PR 1 of 4 for feature-gated agent identity support.

This PR adds the under-development `features.use_agent_identity` config flag and schema plumbing only. Runtime behavior remains unchanged with the flag off.

## Stack

- PR1: https://github.com/openai/codex/pull/17385 - this PR
- PR2: https://github.com/openai/codex/pull/17386 - register agent identities when enabled
- PR3: https://github.com/openai/codex/pull/17387 - register agent tasks when enabled
- PR4: https://github.com/openai/codex/pull/17388 - use `AgentAssertion` downstream when enabled

## Validation

Covered as part of the local stack validation pass:

- `just fmt`
- `cargo test -p codex-core --lib agent_identity`
- `cargo test -p codex-core --lib agent_assertion`
- `cargo test -p codex-core --lib websocket_agent_task`
- `cargo test -p codex-api api_bridge`
- `cargo build -p codex-cli --bin codex`

## Notes

The full local app-server E2E path is still being debugged after PR creation. The current branch stack is directionally ready for review while that follow-up continues.