### PR TITLE
app-server: Only unload threads which were unused for some time

### DIFF
--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -142,7 +142,7 @@ Example with notification opt-out:
 - `thread/metadata/update` — patch stored thread metadata in sqlite; currently supports updating persisted `gitInfo` fields and returns the refreshed `thread`.
 - `thread/status/changed` — notification emitted when a loaded thread’s status changes (`threadId` + new `status`).
 - `thread/archive` — move a thread’s rollout file into the archived directory; returns `{}` on success and emits `thread/archived`.
-- `thread/unsubscribe` — unsubscribe this connection from thread turn/item events. If this was the last subscriber, the server shuts down and unloads the thread, then emits `thread/closed`.
+- `thread/unsubscribe` — unsubscribe this connection from thread turn/item events. If this was the last subscriber, the server keeps the thread loaded and unloads it only after it has had no subscribers and no thread activity for 30 minutes, then emits `thread/closed`.
 - `thread/name/set` — set or update a thread’s user-facing name for either a loaded thread or a persisted rollout; returns `{}` on success and emits `thread/name/updated` to initialized, opted-in clients. Thread names are not required to be unique; name lookups resolve to the most recently updated thread.
 - `thread/unarchive` — move an archived rollout file back into the sessions directory; returns the restored `thread` on success and emits `thread/unarchived`.
 - `thread/compact/start` — trigger conversation history compaction for a thread; returns `{}` immediately while progress streams through standard turn/item notifications.
@@ -336,11 +336,16 @@ When `nextCursor` is `null`, you’ve reached the final page.
 - `notSubscribed` when the connection was not subscribed to that thread.
 - `notLoaded` when the thread is not loaded.
 
-If this was the last subscriber, the server unloads the thread and emits `thread/closed` and a `thread/status/changed` transition to `notLoaded`.
+If this was the last subscriber, the server does not unload the thread immediately. It unloads the thread after the thread has had no subscribers and no thread activity for 30 minutes, then emits `thread/closed` and a `thread/status/changed` transition to `notLoaded`.
 
 ```json
 { "method": "thread/unsubscribe", "id": 22, "params": { "threadId": "thr_123" } }
 { "id": 22, "result": { "status": "unsubscribed" } }
+```
+
+Later, after the idle unload timeout:
+
+```json
 { "method": "thread/status/changed", "params": {
     "threadId": "thr_123",
     "status": { "type": "notLoaded" }

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -3828,9 +3828,18 @@ impl CodexMessageProcessor {
         self.command_exec_manager
             .connection_closed(connection_id)
             .await;
-        self.thread_state_manager
+        let thread_ids = self
+            .thread_state_manager
             .remove_connection(connection_id)
             .await;
+
+        for thread_id in thread_ids {
+            if self.thread_manager.get_thread(thread_id).await.is_err() {
+                // Reconcile stale app-server bookkeeping when the thread has already been
+                // removed from the core manager.
+                self.finalize_thread_teardown(thread_id).await;
+            }
+        }
     }
 
     pub(crate) fn subscribe_running_assistant_turn_count(&self) -> watch::Receiver<usize> {
@@ -4193,13 +4202,18 @@ impl CodexMessageProcessor {
                 .thread_state_manager
                 .thread_state(existing_thread_id)
                 .await;
-            self.ensure_listener_task_running(
-                existing_thread_id,
-                existing_thread.clone(),
-                thread_state.clone(),
-                ApiVersion::V2,
-            )
-            .await;
+            if let Err(error) = self
+                .ensure_listener_task_running(
+                    existing_thread_id,
+                    existing_thread.clone(),
+                    thread_state.clone(),
+                    ApiVersion::V2,
+                )
+                .await
+            {
+                self.outgoing.send_error(request_id, error).await;
+                return true;
+            }
 
             let config_snapshot = existing_thread.config_snapshot().await;
             let mismatch_details = collect_resume_override_mismatches(params, &config_snapshot);
@@ -7434,14 +7448,21 @@ impl CodexMessageProcessor {
             };
             thread_state
         };
-        Self::ensure_listener_task_running_task(
-            listener_task_context,
+        if let Err(error) = Self::ensure_listener_task_running_task(
+            listener_task_context.clone(),
             conversation_id,
             conversation,
             thread_state,
             api_version,
         )
-        .await;
+        .await
+        {
+            let _ = listener_task_context
+                .thread_state_manager
+                .unsubscribe_connection_from_thread(conversation_id, connection_id)
+                .await;
+            return Err(error);
+        }
         Ok(EnsureConversationListenerResult::Attached)
     }
 
@@ -7475,7 +7496,7 @@ impl CodexMessageProcessor {
         conversation: Arc<CodexThread>,
         thread_state: Arc<Mutex<ThreadState>>,
         api_version: ApiVersion,
-    ) {
+    ) -> Result<(), JSONRPCErrorError> {
         Self::ensure_listener_task_running_task(
             ListenerTaskContext {
                 thread_manager: Arc::clone(&self.thread_manager),
@@ -7493,7 +7514,7 @@ impl CodexMessageProcessor {
             thread_state,
             api_version,
         )
-        .await;
+        .await
     }
 
     async fn ensure_listener_task_running_task(
@@ -7502,7 +7523,7 @@ impl CodexMessageProcessor {
         conversation: Arc<CodexThread>,
         thread_state: Arc<Mutex<ThreadState>>,
         api_version: ApiVersion,
-    ) {
+    ) -> Result<(), JSONRPCErrorError> {
         let (cancel_tx, mut cancel_rx) = oneshot::channel();
         let Some(mut unloading_state) = UnloadingState::new(
             &listener_task_context,
@@ -7511,12 +7532,18 @@ impl CodexMessageProcessor {
         )
         .await
         else {
-            return;
+            return Err(JSONRPCErrorError {
+                code: INVALID_REQUEST_ERROR_CODE,
+                message: format!(
+                    "thread {conversation_id} is closing; retry after the thread is closed"
+                ),
+                data: None,
+            });
         };
         let (mut listener_command_rx, listener_generation) = {
             let mut thread_state = thread_state.lock().await;
             if thread_state.listener_matches(&conversation) {
-                return;
+                return Ok(());
             }
             thread_state.set_listener(cancel_tx, &conversation)
         };
@@ -7652,6 +7679,7 @@ impl CodexMessageProcessor {
                 thread_state.clear_listener();
             }
         });
+        Ok(())
     }
     async fn git_diff_to_origin(&self, request_id: ConnectionRequestId, cwd: PathBuf) {
         let diff = git_diff_to_remote(&cwd).await;

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -344,9 +344,11 @@ mod plugin_mcp_oauth;
 
 use crate::filters::compute_source_filters;
 use crate::filters::source_kind_matches;
+use crate::thread_state::ThreadIdleUnloadWait;
 use crate::thread_state::ThreadListenerCommand;
 use crate::thread_state::ThreadState;
 use crate::thread_state::ThreadStateManager;
+use crate::thread_state::ThreadSubscriptionRemoval;
 
 const THREAD_LIST_DEFAULT_LIMIT: usize = 25;
 const THREAD_LIST_MAX_LIMIT: usize = 100;
@@ -363,6 +365,7 @@ struct ThreadListFilters {
 const LOGIN_CHATGPT_TIMEOUT: Duration = Duration::from_secs(10 * 60);
 const LOGIN_ISSUER_OVERRIDE_ENV_VAR: &str = "CODEX_APP_SERVER_LOGIN_ISSUER";
 const APP_LIST_LOAD_TIMEOUT: Duration = Duration::from_secs(90);
+const THREAD_IDLE_UNLOAD_TIMEOUT: Duration = Duration::from_secs(30 * 60);
 
 enum ActiveLogin {
     Browser {
@@ -410,6 +413,12 @@ enum ThreadShutdownResult {
     TimedOut,
 }
 
+enum IdleThreadUnloadCheck {
+    Started,
+    Deferred,
+    NotEligible,
+}
+
 impl Drop for ActiveLogin {
     fn drop(&mut self) {
         self.cancel();
@@ -429,6 +438,7 @@ pub(crate) struct CodexMessageProcessor {
     cloud_requirements: Arc<RwLock<CloudRequirementsLoader>>,
     active_login: Arc<Mutex<Option<ActiveLogin>>>,
     pending_thread_unloads: Arc<Mutex<HashSet<ThreadId>>>,
+    pending_idle_thread_unloads: Arc<Mutex<HashSet<ThreadId>>>,
     thread_state_manager: ThreadStateManager,
     thread_watch_manager: ThreadWatchManager,
     command_exec_manager: CommandExecManager,
@@ -457,6 +467,18 @@ struct ListenerTaskContext {
     thread_watch_manager: ThreadWatchManager,
     fallback_model_provider: String,
     codex_home: PathBuf,
+    thread_unload_context: ThreadUnloadContext,
+}
+
+#[derive(Clone)]
+struct ThreadUnloadContext {
+    thread_manager: Arc<ThreadManager>,
+    outgoing: Arc<OutgoingMessageSender>,
+    pending_thread_unloads: Arc<Mutex<HashSet<ThreadId>>>,
+    pending_idle_thread_unloads: Arc<Mutex<HashSet<ThreadId>>>,
+    thread_state_manager: ThreadStateManager,
+    thread_watch_manager: ThreadWatchManager,
+    idle_timeout: Duration,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -491,6 +513,32 @@ impl CodexMessageProcessor {
         self.clear_plugin_related_caches();
     }
 
+    fn thread_unload_context(&self) -> ThreadUnloadContext {
+        ThreadUnloadContext {
+            thread_manager: Arc::clone(&self.thread_manager),
+            outgoing: Arc::clone(&self.outgoing),
+            pending_thread_unloads: Arc::clone(&self.pending_thread_unloads),
+            pending_idle_thread_unloads: Arc::clone(&self.pending_idle_thread_unloads),
+            thread_state_manager: self.thread_state_manager.clone(),
+            thread_watch_manager: self.thread_watch_manager.clone(),
+            idle_timeout: THREAD_IDLE_UNLOAD_TIMEOUT,
+        }
+    }
+
+    fn listener_task_context(&self) -> ListenerTaskContext {
+        ListenerTaskContext {
+            thread_manager: Arc::clone(&self.thread_manager),
+            thread_state_manager: self.thread_state_manager.clone(),
+            outgoing: Arc::clone(&self.outgoing),
+            analytics_events_client: self.analytics_events_client.clone(),
+            general_analytics_enabled: self.config.features.enabled(Feature::GeneralAnalytics),
+            thread_watch_manager: self.thread_watch_manager.clone(),
+            fallback_model_provider: self.config.model_provider_id.clone(),
+            codex_home: self.config.codex_home.clone(),
+            thread_unload_context: self.thread_unload_context(),
+        }
+    }
+
     fn clear_plugin_related_caches(&self) {
         self.thread_manager.plugins_manager().clear_cache();
         self.thread_manager.skills_manager().clear_cache();
@@ -515,6 +563,14 @@ impl CodexMessageProcessor {
             data: None,
         })?;
 
+        let pending_thread_unloads = self.pending_thread_unloads.lock().await;
+        if pending_thread_unloads.contains(&thread_id) {
+            return Err(JSONRPCErrorError {
+                code: INVALID_REQUEST_ERROR_CODE,
+                message: format!("thread {thread_id} is closing; retry after the thread is closed"),
+                data: None,
+            });
+        }
         let thread = self
             .thread_manager
             .get_thread(thread_id)
@@ -524,6 +580,10 @@ impl CodexMessageProcessor {
                 message: format!("thread not found: {thread_id}"),
                 data: None,
             })?;
+        self.thread_state_manager
+            .note_thread_activity(thread_id)
+            .await;
+        drop(pending_thread_unloads);
 
         Ok((thread_id, thread))
     }
@@ -553,6 +613,7 @@ impl CodexMessageProcessor {
             cloud_requirements,
             active_login: Arc::new(Mutex::new(None)),
             pending_thread_unloads: Arc::new(Mutex::new(HashSet::new())),
+            pending_idle_thread_unloads: Arc::new(Mutex::new(HashSet::new())),
             thread_state_manager: ThreadStateManager::new(),
             thread_watch_manager: ThreadWatchManager::new_with_outgoing(outgoing),
             command_exec_manager: CommandExecManager::default(),
@@ -2112,16 +2173,7 @@ impl CodexMessageProcessor {
         typesafe_overrides.ephemeral = ephemeral;
         let cloud_requirements = self.current_cloud_requirements();
         let cli_overrides = self.current_cli_overrides();
-        let listener_task_context = ListenerTaskContext {
-            thread_manager: Arc::clone(&self.thread_manager),
-            thread_state_manager: self.thread_state_manager.clone(),
-            outgoing: Arc::clone(&self.outgoing),
-            analytics_events_client: self.analytics_events_client.clone(),
-            general_analytics_enabled: self.config.features.enabled(Feature::GeneralAnalytics),
-            thread_watch_manager: self.thread_watch_manager.clone(),
-            fallback_model_provider: self.config.model_provider_id.clone(),
-            codex_home: self.config.codex_home.clone(),
-        };
+        let listener_task_context = self.listener_task_context();
         let request_trace = request_context.request_trace();
         let runtime_feature_enablement = self.current_runtime_feature_enablement();
         let thread_start_task = async move {
@@ -3725,12 +3777,11 @@ impl CodexMessageProcessor {
             .remove_connection(connection_id)
             .await;
         for thread_id in thread_ids_with_no_subscribers {
-            let Ok(thread) = self.thread_manager.get_thread(thread_id).await else {
+            if self.thread_manager.get_thread(thread_id).await.is_err() {
                 self.finalize_thread_teardown(thread_id).await;
                 continue;
-            };
-            self.unload_thread_without_subscribers(thread_id, thread)
-                .await;
+            }
+            self.schedule_thread_idle_unload_check(thread_id).await;
         }
     }
 
@@ -3768,21 +3819,22 @@ impl CodexMessageProcessor {
     }
 
     async fn thread_resume(&self, request_id: ConnectionRequestId, params: ThreadResumeParams) {
-        if let Ok(thread_id) = ThreadId::from_string(&params.thread_id)
-            && self
-                .pending_thread_unloads
-                .lock()
-                .await
-                .contains(&thread_id)
-        {
-            self.send_invalid_request_error(
-                request_id,
-                format!(
-                    "thread {thread_id} is closing; retry thread/resume after the thread is closed"
-                ),
-            )
-            .await;
-            return;
+        if let Ok(thread_id) = ThreadId::from_string(&params.thread_id) {
+            let pending_thread_unloads = self.pending_thread_unloads.lock().await;
+            if pending_thread_unloads.contains(&thread_id) {
+                drop(pending_thread_unloads);
+                self.send_invalid_request_error(
+                    request_id,
+                    format!(
+                        "thread {thread_id} is closing; retry thread/resume after the thread is closed"
+                    ),
+                )
+                .await;
+                return;
+            }
+            self.thread_state_manager
+                .note_thread_activity(thread_id)
+                .await;
         }
 
         if self
@@ -5426,6 +5478,10 @@ impl CodexMessageProcessor {
 
     async fn finalize_thread_teardown(&self, thread_id: ThreadId) {
         self.pending_thread_unloads.lock().await.remove(&thread_id);
+        self.pending_idle_thread_unloads
+            .lock()
+            .await
+            .remove(&thread_id);
         self.outgoing
             .cancel_requests_for_thread(thread_id, /*error*/ None)
             .await;
@@ -5437,60 +5493,251 @@ impl CodexMessageProcessor {
             .await;
     }
 
-    async fn unload_thread_without_subscribers(
-        &self,
+    async fn schedule_thread_idle_unload_check(&self, thread_id: ThreadId) {
+        Self::schedule_thread_idle_unload_check_task(self.thread_unload_context(), thread_id).await;
+    }
+
+    async fn schedule_thread_idle_unload_check_task(
+        context: ThreadUnloadContext,
         thread_id: ThreadId,
-        thread: Arc<CodexThread>,
     ) {
-        // This connection was the last subscriber. Only now do we unload the thread.
-        info!("thread {thread_id} has no subscribers; shutting down");
-        let should_start_unload_task = self.pending_thread_unloads.lock().await.insert(thread_id);
+        {
+            let mut pending_idle_thread_unloads = context.pending_idle_thread_unloads.lock().await;
+            if !pending_idle_thread_unloads.insert(thread_id) {
+                return;
+            }
+        }
+
+        tokio::spawn(async move {
+            Self::thread_idle_unload_check_task(context, thread_id).await;
+        });
+    }
+
+    async fn thread_idle_unload_check_task(context: ThreadUnloadContext, thread_id: ThreadId) {
+        loop {
+            match context
+                .thread_state_manager
+                .thread_idle_unload_wait(thread_id, context.idle_timeout)
+                .await
+            {
+                ThreadIdleUnloadWait::Ready => {
+                    context
+                        .pending_idle_thread_unloads
+                        .lock()
+                        .await
+                        .remove(&thread_id);
+
+                    if let Some(listener_command_tx) = context
+                        .thread_state_manager
+                        .listener_command_tx(thread_id)
+                        .await
+                        && listener_command_tx
+                            .send(ThreadListenerCommand::CheckIdleUnload {
+                                idle_timeout: context.idle_timeout,
+                            })
+                            .is_ok()
+                    {
+                        return;
+                    }
+
+                    let Ok(thread) = context.thread_manager.get_thread(thread_id).await else {
+                        context
+                            .thread_state_manager
+                            .remove_thread_state(thread_id)
+                            .await;
+                        context
+                            .thread_watch_manager
+                            .remove_thread(&thread_id.to_string())
+                            .await;
+                        return;
+                    };
+                    let active_turn_snapshot = context
+                        .thread_state_manager
+                        .has_active_turn_snapshot(thread_id)
+                        .await;
+                    if matches!(
+                        Self::check_idle_unload(
+                            &context,
+                            thread_id,
+                            &thread,
+                            active_turn_snapshot,
+                            context.idle_timeout,
+                        )
+                        .await,
+                        IdleThreadUnloadCheck::Deferred
+                    ) {
+                        context
+                            .pending_idle_thread_unloads
+                            .lock()
+                            .await
+                            .insert(thread_id);
+                        tokio::time::sleep(context.idle_timeout).await;
+                        continue;
+                    }
+                    return;
+                }
+                ThreadIdleUnloadWait::Wait(wait_duration) => {
+                    tokio::time::sleep(wait_duration).await;
+                }
+                ThreadIdleUnloadWait::HasSubscribers | ThreadIdleUnloadWait::Missing => {
+                    context
+                        .pending_idle_thread_unloads
+                        .lock()
+                        .await
+                        .remove(&thread_id);
+                    return;
+                }
+            }
+        }
+    }
+
+    async fn check_idle_unload_from_listener(
+        context: &ThreadUnloadContext,
+        thread_id: ThreadId,
+        thread: &Arc<CodexThread>,
+        thread_state: &Arc<Mutex<ThreadState>>,
+        idle_timeout: Duration,
+    ) -> IdleThreadUnloadCheck {
+        let active_turn_snapshot = thread_state.lock().await.active_turn_snapshot().is_some();
+        Self::check_idle_unload(
+            context,
+            thread_id,
+            thread,
+            active_turn_snapshot,
+            idle_timeout,
+        )
+        .await
+    }
+
+    async fn check_idle_unload(
+        context: &ThreadUnloadContext,
+        thread_id: ThreadId,
+        thread: &Arc<CodexThread>,
+        active_turn_snapshot: bool,
+        idle_timeout: Duration,
+    ) -> IdleThreadUnloadCheck {
+        let mut pending_thread_unloads = context.pending_thread_unloads.lock().await;
+        if pending_thread_unloads.contains(&thread_id) {
+            return IdleThreadUnloadCheck::Started;
+        }
+        match context
+            .thread_state_manager
+            .thread_idle_unload_wait(thread_id, idle_timeout)
+            .await
+        {
+            ThreadIdleUnloadWait::Ready => {}
+            ThreadIdleUnloadWait::Wait(_) => return IdleThreadUnloadCheck::Deferred,
+            ThreadIdleUnloadWait::HasSubscribers | ThreadIdleUnloadWait::Missing => {
+                return IdleThreadUnloadCheck::NotEligible;
+            }
+        }
+        if Self::thread_has_active_work(context, thread_id, thread, active_turn_snapshot).await {
+            context
+                .thread_state_manager
+                .note_thread_activity(thread_id)
+                .await;
+            return IdleThreadUnloadCheck::Deferred;
+        }
+        pending_thread_unloads.insert(thread_id);
+        drop(pending_thread_unloads);
+
+        info!("thread {thread_id} has no subscribers and is idle; shutting down");
+        context
+            .pending_idle_thread_unloads
+            .lock()
+            .await
+            .remove(&thread_id);
 
         // Any pending app-server -> client requests for this thread can no longer be
         // answered; cancel their callbacks before shutdown/unload.
-        self.outgoing
+        context
+            .outgoing
             .cancel_requests_for_thread(thread_id, /*error*/ None)
             .await;
-        self.thread_state_manager
+        context
+            .thread_state_manager
             .remove_thread_state(thread_id)
             .await;
 
-        if !should_start_unload_task {
-            return;
-        }
+        Self::spawn_thread_shutdown_task(context.clone(), thread_id, thread.clone());
+        IdleThreadUnloadCheck::Started
+    }
 
-        let outgoing = self.outgoing.clone();
-        let pending_thread_unloads = self.pending_thread_unloads.clone();
-        let thread_manager = self.thread_manager.clone();
-        let thread_watch_manager = self.thread_watch_manager.clone();
+    async fn thread_has_active_work(
+        context: &ThreadUnloadContext,
+        thread_id: ThreadId,
+        thread: &Arc<CodexThread>,
+        active_turn_snapshot: bool,
+    ) -> bool {
+        if matches!(thread.agent_status().await, AgentStatus::Running) || active_turn_snapshot {
+            return true;
+        }
+        matches!(
+            context
+                .thread_watch_manager
+                .loaded_status_for_thread(&thread_id.to_string())
+                .await,
+            ThreadStatus::Active { .. }
+        )
+    }
+
+    fn spawn_thread_shutdown_task(
+        context: ThreadUnloadContext,
+        thread_id: ThreadId,
+        thread: Arc<CodexThread>,
+    ) {
         tokio::spawn(async move {
             match Self::wait_for_thread_shutdown(&thread).await {
                 ThreadShutdownResult::Complete => {
-                    if thread_manager.remove_thread(&thread_id).await.is_none() {
+                    if context
+                        .thread_manager
+                        .remove_thread(&thread_id)
+                        .await
+                        .is_none()
+                    {
                         info!("thread {thread_id} was already removed before teardown finalized");
-                        thread_watch_manager
+                        context
+                            .thread_watch_manager
                             .remove_thread(&thread_id.to_string())
                             .await;
-                        pending_thread_unloads.lock().await.remove(&thread_id);
+                        context
+                            .pending_thread_unloads
+                            .lock()
+                            .await
+                            .remove(&thread_id);
                         return;
                     }
-                    thread_watch_manager
+                    context
+                        .thread_watch_manager
                         .remove_thread(&thread_id.to_string())
                         .await;
                     let notification = ThreadClosedNotification {
                         thread_id: thread_id.to_string(),
                     };
-                    outgoing
+                    context
+                        .outgoing
                         .send_server_notification(ServerNotification::ThreadClosed(notification))
                         .await;
-                    pending_thread_unloads.lock().await.remove(&thread_id);
+                    context
+                        .pending_thread_unloads
+                        .lock()
+                        .await
+                        .remove(&thread_id);
                 }
                 ThreadShutdownResult::SubmitFailed => {
-                    pending_thread_unloads.lock().await.remove(&thread_id);
+                    context
+                        .pending_thread_unloads
+                        .lock()
+                        .await
+                        .remove(&thread_id);
                     warn!("failed to submit Shutdown to thread {thread_id}");
                 }
                 ThreadShutdownResult::TimedOut => {
-                    pending_thread_unloads.lock().await.remove(&thread_id);
+                    context
+                        .pending_thread_unloads
+                        .lock()
+                        .await
+                        .remove(&thread_id);
                     warn!("thread {thread_id} shutdown timed out; leaving thread loaded");
                 }
             }
@@ -5511,7 +5758,7 @@ impl CodexMessageProcessor {
             }
         };
 
-        let Ok(thread) = self.thread_manager.get_thread(thread_id).await else {
+        let Ok(_thread) = self.thread_manager.get_thread(thread_id).await else {
             // Reconcile stale app-server bookkeeping when the thread has already been
             // removed from the core manager. This keeps loaded-status/subscription state
             // consistent with the source of truth before reporting NotLoaded.
@@ -5527,25 +5774,26 @@ impl CodexMessageProcessor {
             return;
         };
 
-        let was_subscribed = self
+        let removal = self
             .thread_state_manager
             .unsubscribe_connection_from_thread(thread_id, request_id.connection_id)
             .await;
-        if !was_subscribed {
-            self.outgoing
-                .send_response(
-                    request_id,
-                    ThreadUnsubscribeResponse {
-                        status: ThreadUnsubscribeStatus::NotSubscribed,
-                    },
-                )
-                .await;
-            return;
-        }
-
-        if !self.thread_state_manager.has_subscribers(thread_id).await {
-            self.unload_thread_without_subscribers(thread_id, thread)
-                .await;
+        match removal {
+            ThreadSubscriptionRemoval::NotSubscribed => {
+                self.outgoing
+                    .send_response(
+                        request_id,
+                        ThreadUnsubscribeResponse {
+                            status: ThreadUnsubscribeStatus::NotSubscribed,
+                        },
+                    )
+                    .await;
+                return;
+            }
+            ThreadSubscriptionRemoval::RemovedStillHasSubscribers => {}
+            ThreadSubscriptionRemoval::RemovedLastSubscriber => {
+                self.schedule_thread_idle_unload_check(thread_id).await;
+            }
         }
 
         self.outgoing
@@ -7295,16 +7543,7 @@ impl CodexMessageProcessor {
         api_version: ApiVersion,
     ) -> Result<EnsureConversationListenerResult, JSONRPCErrorError> {
         Self::ensure_conversation_listener_task(
-            ListenerTaskContext {
-                thread_manager: Arc::clone(&self.thread_manager),
-                thread_state_manager: self.thread_state_manager.clone(),
-                outgoing: Arc::clone(&self.outgoing),
-                analytics_events_client: self.analytics_events_client.clone(),
-                general_analytics_enabled: self.config.features.enabled(Feature::GeneralAnalytics),
-                thread_watch_manager: self.thread_watch_manager.clone(),
-                fallback_model_provider: self.config.model_provider_id.clone(),
-                codex_home: self.config.codex_home.clone(),
-            },
+            self.listener_task_context(),
             conversation_id,
             connection_id,
             raw_events_enabled,
@@ -7334,12 +7573,33 @@ impl CodexMessageProcessor {
                 });
             }
         };
-        let Some(thread_state) = listener_task_context
-            .thread_state_manager
-            .try_ensure_connection_subscribed(conversation_id, connection_id, raw_events_enabled)
-            .await
-        else {
-            return Ok(EnsureConversationListenerResult::ConnectionClosed);
+        let thread_state = {
+            let pending_thread_unloads = listener_task_context
+                .thread_unload_context
+                .pending_thread_unloads
+                .lock()
+                .await;
+            if pending_thread_unloads.contains(&conversation_id) {
+                return Err(JSONRPCErrorError {
+                    code: INVALID_REQUEST_ERROR_CODE,
+                    message: format!(
+                        "thread {conversation_id} is closing; retry after the thread is closed"
+                    ),
+                    data: None,
+                });
+            }
+            let Some(thread_state) = listener_task_context
+                .thread_state_manager
+                .try_ensure_connection_subscribed(
+                    conversation_id,
+                    connection_id,
+                    raw_events_enabled,
+                )
+                .await
+            else {
+                return Ok(EnsureConversationListenerResult::ConnectionClosed);
+            };
+            thread_state
         };
         Self::ensure_listener_task_running_task(
             listener_task_context,
@@ -7384,16 +7644,7 @@ impl CodexMessageProcessor {
         api_version: ApiVersion,
     ) {
         Self::ensure_listener_task_running_task(
-            ListenerTaskContext {
-                thread_manager: Arc::clone(&self.thread_manager),
-                thread_state_manager: self.thread_state_manager.clone(),
-                outgoing: Arc::clone(&self.outgoing),
-                analytics_events_client: self.analytics_events_client.clone(),
-                general_analytics_enabled: self.config.features.enabled(Feature::GeneralAnalytics),
-                thread_watch_manager: self.thread_watch_manager.clone(),
-                fallback_model_provider: self.config.model_provider_id.clone(),
-                codex_home: self.config.codex_home.clone(),
-            },
+            self.listener_task_context(),
             conversation_id,
             conversation,
             thread_state,
@@ -7426,6 +7677,7 @@ impl CodexMessageProcessor {
             thread_watch_manager,
             fallback_model_provider,
             codex_home,
+            thread_unload_context,
         } = listener_task_context;
         let outgoing_for_task = Arc::clone(&outgoing);
         tokio::spawn(async move {
@@ -7447,6 +7699,15 @@ impl CodexMessageProcessor {
                         // Track the event before emitting any typed
                         // translations so thread-local state such as raw event
                         // opt-in stays synchronized with the conversation.
+                        {
+                            let pending_thread_unloads = thread_unload_context
+                                .pending_thread_unloads
+                                .lock()
+                                .await;
+                            if !pending_thread_unloads.contains(&conversation_id) {
+                                thread_state_manager.note_thread_activity(conversation_id).await;
+                            }
+                        }
                         let raw_events_enabled = {
                             let mut thread_state = thread_state.lock().await;
                             thread_state.track_current_turn_event(&event.msg);
@@ -7501,6 +7762,7 @@ impl CodexMessageProcessor {
                             &thread_state,
                             &thread_watch_manager,
                             &outgoing_for_task,
+                            &thread_unload_context,
                             listener_command,
                         )
                         .await;
@@ -8001,6 +8263,7 @@ async fn handle_thread_listener_command(
     thread_state: &Arc<Mutex<ThreadState>>,
     thread_watch_manager: &ThreadWatchManager,
     outgoing: &Arc<OutgoingMessageSender>,
+    thread_unload_context: &ThreadUnloadContext,
     listener_command: ThreadListenerCommand,
 ) {
     match listener_command {
@@ -8013,9 +8276,27 @@ async fn handle_thread_listener_command(
                 thread_state,
                 thread_watch_manager,
                 outgoing,
+                thread_unload_context,
                 *resume_request,
             )
             .await;
+        }
+        ThreadListenerCommand::CheckIdleUnload { idle_timeout } => {
+            let result = CodexMessageProcessor::check_idle_unload_from_listener(
+                thread_unload_context,
+                conversation_id,
+                conversation,
+                thread_state,
+                idle_timeout,
+            )
+            .await;
+            if matches!(result, IdleThreadUnloadCheck::Deferred) {
+                CodexMessageProcessor::schedule_thread_idle_unload_check_task(
+                    thread_unload_context.clone(),
+                    conversation_id,
+                )
+                .await;
+            }
         }
         ThreadListenerCommand::ResolveServerRequest {
             request_id,
@@ -8042,6 +8323,7 @@ async fn handle_pending_thread_resume_request(
     thread_state: &Arc<Mutex<ThreadState>>,
     thread_watch_manager: &ThreadWatchManager,
     outgoing: &Arc<OutgoingMessageSender>,
+    thread_unload_context: &ThreadUnloadContext,
     pending: crate::thread_state::PendingThreadResumeRequest,
 ) {
     let active_turn = {
@@ -8095,6 +8377,37 @@ async fn handle_pending_thread_resume_request(
         has_live_in_progress_turn,
     );
 
+    {
+        let pending_thread_unloads = thread_unload_context.pending_thread_unloads.lock().await;
+        if pending_thread_unloads.contains(&conversation_id) {
+            drop(pending_thread_unloads);
+            outgoing
+                .send_error(
+                    request_id,
+                    JSONRPCErrorError {
+                        code: INVALID_REQUEST_ERROR_CODE,
+                        message: format!(
+                            "thread {conversation_id} is closing; retry thread/resume after the thread is closed"
+                        ),
+                        data: None,
+                    },
+                )
+                .await;
+            return;
+        }
+        if !thread_state_manager
+            .try_add_connection_to_thread(conversation_id, connection_id)
+            .await
+        {
+            tracing::debug!(
+                thread_id = %conversation_id,
+                connection_id = ?connection_id,
+                "skipping running thread resume for closed connection"
+            );
+            return;
+        }
+    }
+
     let ThreadConfigSnapshot {
         model,
         model_provider_id,
@@ -8120,9 +8433,6 @@ async fn handle_pending_thread_resume_request(
     outgoing.send_response(request_id, response).await;
     outgoing
         .replay_requests_to_connection_for_thread(connection_id, conversation_id)
-        .await;
-    let _attached = thread_state_manager
-        .try_add_connection_to_thread(conversation_id, connection_id)
         .await;
 }
 
@@ -9915,6 +10225,126 @@ mod tests {
             manager.subscribed_connection_ids(thread_id).await,
             vec![connection_b]
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn last_subscriber_removal_starts_idle_unload_wait() -> Result<()> {
+        let manager = ThreadStateManager::new();
+        let thread_id = ThreadId::from_string("ad7f0408-99b8-4f6e-a46f-bd0eec433370")?;
+        let connection = ConnectionId(1);
+        let idle_timeout = Duration::from_millis(30);
+
+        manager.connection_initialized(connection).await;
+        manager
+            .try_ensure_connection_subscribed(
+                thread_id, connection, /*experimental_raw_events*/ false,
+            )
+            .await
+            .expect("connection should be live");
+
+        assert!(matches!(
+            manager
+                .unsubscribe_connection_from_thread(thread_id, connection)
+                .await,
+            ThreadSubscriptionRemoval::RemovedLastSubscriber
+        ));
+        assert!(matches!(
+            manager
+                .thread_idle_unload_wait(thread_id, idle_timeout)
+                .await,
+            ThreadIdleUnloadWait::Wait(_)
+        ));
+
+        tokio::time::sleep(Duration::from_millis(40)).await;
+        assert!(matches!(
+            manager
+                .thread_idle_unload_wait(thread_id, idle_timeout)
+                .await,
+            ThreadIdleUnloadWait::Ready
+        ));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn thread_activity_resets_idle_unload_wait() -> Result<()> {
+        let manager = ThreadStateManager::new();
+        let thread_id = ThreadId::from_string("ad7f0408-99b8-4f6e-a46f-bd0eec433370")?;
+        let connection = ConnectionId(1);
+        let idle_timeout = Duration::from_millis(50);
+
+        manager.connection_initialized(connection).await;
+        manager
+            .try_ensure_connection_subscribed(
+                thread_id, connection, /*experimental_raw_events*/ false,
+            )
+            .await
+            .expect("connection should be live");
+        assert!(matches!(
+            manager
+                .unsubscribe_connection_from_thread(thread_id, connection)
+                .await,
+            ThreadSubscriptionRemoval::RemovedLastSubscriber
+        ));
+
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        manager.note_thread_activity(thread_id).await;
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        assert!(matches!(
+            manager
+                .thread_idle_unload_wait(thread_id, idle_timeout)
+                .await,
+            ThreadIdleUnloadWait::Wait(_)
+        ));
+
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        assert!(matches!(
+            manager
+                .thread_idle_unload_wait(thread_id, idle_timeout)
+                .await,
+            ThreadIdleUnloadWait::Ready
+        ));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn resubscribe_cancels_idle_unload_eligibility() -> Result<()> {
+        let manager = ThreadStateManager::new();
+        let thread_id = ThreadId::from_string("ad7f0408-99b8-4f6e-a46f-bd0eec433370")?;
+        let connection_a = ConnectionId(1);
+        let connection_b = ConnectionId(2);
+
+        manager.connection_initialized(connection_a).await;
+        manager.connection_initialized(connection_b).await;
+        manager
+            .try_ensure_connection_subscribed(
+                thread_id,
+                connection_a,
+                /*experimental_raw_events*/ false,
+            )
+            .await
+            .expect("connection_a should be live");
+        assert!(matches!(
+            manager
+                .unsubscribe_connection_from_thread(thread_id, connection_a)
+                .await,
+            ThreadSubscriptionRemoval::RemovedLastSubscriber
+        ));
+
+        manager
+            .try_ensure_connection_subscribed(
+                thread_id,
+                connection_b,
+                /*experimental_raw_events*/ false,
+            )
+            .await
+            .expect("connection_b should be live");
+        assert!(matches!(
+            manager
+                .thread_idle_unload_wait(thread_id, Duration::from_millis(1))
+                .await,
+            ThreadIdleUnloadWait::HasSubscribers
+        ));
         Ok(())
     }
 

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -321,6 +321,7 @@ use std::sync::RwLock;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
+use std::time::Instant;
 use std::time::SystemTime;
 use tokio::sync::Mutex;
 use tokio::sync::broadcast;
@@ -344,11 +345,9 @@ mod plugin_mcp_oauth;
 
 use crate::filters::compute_source_filters;
 use crate::filters::source_kind_matches;
-use crate::thread_state::ThreadIdleUnloadWait;
 use crate::thread_state::ThreadListenerCommand;
 use crate::thread_state::ThreadState;
 use crate::thread_state::ThreadStateManager;
-use crate::thread_state::ThreadSubscriptionRemoval;
 
 const THREAD_LIST_DEFAULT_LIMIT: usize = 25;
 const THREAD_LIST_MAX_LIMIT: usize = 100;
@@ -365,7 +364,7 @@ struct ThreadListFilters {
 const LOGIN_CHATGPT_TIMEOUT: Duration = Duration::from_secs(10 * 60);
 const LOGIN_ISSUER_OVERRIDE_ENV_VAR: &str = "CODEX_APP_SERVER_LOGIN_ISSUER";
 const APP_LIST_LOAD_TIMEOUT: Duration = Duration::from_secs(90);
-const THREAD_IDLE_UNLOAD_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+const THREAD_UNLOADING_DELAY: Duration = Duration::from_secs(30 * 60);
 
 enum ActiveLogin {
     Browser {
@@ -413,12 +412,6 @@ enum ThreadShutdownResult {
     TimedOut,
 }
 
-enum IdleThreadUnloadCheck {
-    Started,
-    Deferred,
-    NotEligible,
-}
-
 impl Drop for ActiveLogin {
     fn drop(&mut self) {
         self.cancel();
@@ -438,7 +431,6 @@ pub(crate) struct CodexMessageProcessor {
     cloud_requirements: Arc<RwLock<CloudRequirementsLoader>>,
     active_login: Arc<Mutex<Option<ActiveLogin>>>,
     pending_thread_unloads: Arc<Mutex<HashSet<ThreadId>>>,
-    pending_idle_thread_unloads: Arc<Mutex<HashSet<ThreadId>>>,
     thread_state_manager: ThreadStateManager,
     thread_watch_manager: ThreadWatchManager,
     command_exec_manager: CommandExecManager,
@@ -462,23 +454,12 @@ struct ListenerTaskContext {
     thread_manager: Arc<ThreadManager>,
     thread_state_manager: ThreadStateManager,
     outgoing: Arc<OutgoingMessageSender>,
+    pending_thread_unloads: Arc<Mutex<HashSet<ThreadId>>>,
     analytics_events_client: AnalyticsEventsClient,
     general_analytics_enabled: bool,
     thread_watch_manager: ThreadWatchManager,
     fallback_model_provider: String,
     codex_home: PathBuf,
-    thread_unload_context: ThreadUnloadContext,
-}
-
-#[derive(Clone)]
-struct ThreadUnloadContext {
-    thread_manager: Arc<ThreadManager>,
-    outgoing: Arc<OutgoingMessageSender>,
-    pending_thread_unloads: Arc<Mutex<HashSet<ThreadId>>>,
-    pending_idle_thread_unloads: Arc<Mutex<HashSet<ThreadId>>>,
-    thread_state_manager: ThreadStateManager,
-    thread_watch_manager: ThreadWatchManager,
-    idle_timeout: Duration,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -492,6 +473,110 @@ enum RefreshTokenRequestOutcome {
     NotAttemptedOrSucceeded,
     FailedTransiently,
     FailedPermanently,
+}
+
+struct UnloadingState {
+    delay: Duration,
+    has_subscribers_rx: watch::Receiver<bool>,
+    has_subscribers: (bool, Instant),
+    thread_status_rx: watch::Receiver<ThreadStatus>,
+    is_active: (bool, Instant),
+}
+
+impl UnloadingState {
+    async fn new(
+        listener_task_context: &ListenerTaskContext,
+        thread_id: ThreadId,
+        delay: Duration,
+    ) -> Option<Self> {
+        let has_subscribers_rx = listener_task_context
+            .thread_state_manager
+            .subscribe_to_has_connections(thread_id)
+            .await?;
+        let thread_status_rx = listener_task_context
+            .thread_watch_manager
+            .subscribe(thread_id)
+            .await?;
+        let has_subscribers = (*has_subscribers_rx.borrow(), Instant::now());
+        let is_active = (
+            matches!(*thread_status_rx.borrow(), ThreadStatus::Active { .. }),
+            Instant::now(),
+        );
+        Some(Self {
+            delay,
+            has_subscribers_rx,
+            thread_status_rx,
+            has_subscribers,
+            is_active,
+        })
+    }
+
+    fn unloading_target(&self) -> Option<Instant> {
+        match (self.has_subscribers, self.is_active) {
+            ((false, has_no_subscribers_since), (false, is_inactive_since)) => {
+                Some(std::cmp::max(has_no_subscribers_since, is_inactive_since) + self.delay)
+            }
+            _ => None,
+        }
+    }
+
+    fn sync_receiver_values(&mut self) {
+        let has_subscribers = *self.has_subscribers_rx.borrow();
+        if self.has_subscribers.0 != has_subscribers {
+            self.has_subscribers = (has_subscribers, Instant::now());
+        }
+
+        let is_active = matches!(*self.thread_status_rx.borrow(), ThreadStatus::Active { .. });
+        if self.is_active.0 != is_active {
+            self.is_active = (is_active, Instant::now());
+        }
+    }
+
+    fn should_unload_now(&mut self) -> bool {
+        self.sync_receiver_values();
+        self.unloading_target()
+            .is_some_and(|target| target <= Instant::now())
+    }
+
+    fn note_thread_activity_observed(&mut self) {
+        if !self.is_active.0 {
+            self.is_active = (false, Instant::now());
+        }
+    }
+
+    async fn wait_for_unloading_trigger(&mut self) -> bool {
+        loop {
+            self.sync_receiver_values();
+            let unloading_target = self.unloading_target();
+            if let Some(target) = unloading_target
+                && target <= Instant::now()
+            {
+                return true;
+            }
+            let unloading_sleep = async {
+                if let Some(target) = unloading_target {
+                    tokio::time::sleep_until(target.into()).await;
+                } else {
+                    futures::future::pending::<()>().await;
+                }
+            };
+            tokio::select! {
+                _ = unloading_sleep => return true,
+                changed = self.has_subscribers_rx.changed() => {
+                    if changed.is_err() {
+                        return false;
+                    }
+                    self.sync_receiver_values();
+                },
+                changed = self.thread_status_rx.changed() => {
+                    if changed.is_err() {
+                        return false;
+                    }
+                    self.sync_receiver_values();
+                },
+            }
+        }
+    }
 }
 
 pub(crate) struct CodexMessageProcessorArgs {
@@ -511,32 +596,6 @@ pub(crate) struct CodexMessageProcessorArgs {
 impl CodexMessageProcessor {
     pub(crate) fn handle_config_mutation(&self) {
         self.clear_plugin_related_caches();
-    }
-
-    fn thread_unload_context(&self) -> ThreadUnloadContext {
-        ThreadUnloadContext {
-            thread_manager: Arc::clone(&self.thread_manager),
-            outgoing: Arc::clone(&self.outgoing),
-            pending_thread_unloads: Arc::clone(&self.pending_thread_unloads),
-            pending_idle_thread_unloads: Arc::clone(&self.pending_idle_thread_unloads),
-            thread_state_manager: self.thread_state_manager.clone(),
-            thread_watch_manager: self.thread_watch_manager.clone(),
-            idle_timeout: THREAD_IDLE_UNLOAD_TIMEOUT,
-        }
-    }
-
-    fn listener_task_context(&self) -> ListenerTaskContext {
-        ListenerTaskContext {
-            thread_manager: Arc::clone(&self.thread_manager),
-            thread_state_manager: self.thread_state_manager.clone(),
-            outgoing: Arc::clone(&self.outgoing),
-            analytics_events_client: self.analytics_events_client.clone(),
-            general_analytics_enabled: self.config.features.enabled(Feature::GeneralAnalytics),
-            thread_watch_manager: self.thread_watch_manager.clone(),
-            fallback_model_provider: self.config.model_provider_id.clone(),
-            codex_home: self.config.codex_home.clone(),
-            thread_unload_context: self.thread_unload_context(),
-        }
     }
 
     fn clear_plugin_related_caches(&self) {
@@ -563,14 +622,6 @@ impl CodexMessageProcessor {
             data: None,
         })?;
 
-        let pending_thread_unloads = self.pending_thread_unloads.lock().await;
-        if pending_thread_unloads.contains(&thread_id) {
-            return Err(JSONRPCErrorError {
-                code: INVALID_REQUEST_ERROR_CODE,
-                message: format!("thread {thread_id} is closing; retry after the thread is closed"),
-                data: None,
-            });
-        }
         let thread = self
             .thread_manager
             .get_thread(thread_id)
@@ -580,10 +631,6 @@ impl CodexMessageProcessor {
                 message: format!("thread not found: {thread_id}"),
                 data: None,
             })?;
-        self.thread_state_manager
-            .note_thread_activity(thread_id)
-            .await;
-        drop(pending_thread_unloads);
 
         Ok((thread_id, thread))
     }
@@ -613,7 +660,6 @@ impl CodexMessageProcessor {
             cloud_requirements,
             active_login: Arc::new(Mutex::new(None)),
             pending_thread_unloads: Arc::new(Mutex::new(HashSet::new())),
-            pending_idle_thread_unloads: Arc::new(Mutex::new(HashSet::new())),
             thread_state_manager: ThreadStateManager::new(),
             thread_watch_manager: ThreadWatchManager::new_with_outgoing(outgoing),
             command_exec_manager: CommandExecManager::default(),
@@ -2173,7 +2219,17 @@ impl CodexMessageProcessor {
         typesafe_overrides.ephemeral = ephemeral;
         let cloud_requirements = self.current_cloud_requirements();
         let cli_overrides = self.current_cli_overrides();
-        let listener_task_context = self.listener_task_context();
+        let listener_task_context = ListenerTaskContext {
+            thread_manager: Arc::clone(&self.thread_manager),
+            thread_state_manager: self.thread_state_manager.clone(),
+            outgoing: Arc::clone(&self.outgoing),
+            pending_thread_unloads: Arc::clone(&self.pending_thread_unloads),
+            analytics_events_client: self.analytics_events_client.clone(),
+            general_analytics_enabled: self.config.features.enabled(Feature::GeneralAnalytics),
+            thread_watch_manager: self.thread_watch_manager.clone(),
+            fallback_model_provider: self.config.model_provider_id.clone(),
+            codex_home: self.config.codex_home.clone(),
+        };
         let request_trace = request_context.request_trace();
         let runtime_feature_enablement = self.current_runtime_feature_enablement();
         let thread_start_task = async move {
@@ -3772,17 +3828,9 @@ impl CodexMessageProcessor {
         self.command_exec_manager
             .connection_closed(connection_id)
             .await;
-        let thread_ids_with_no_subscribers = self
-            .thread_state_manager
+        self.thread_state_manager
             .remove_connection(connection_id)
             .await;
-        for thread_id in thread_ids_with_no_subscribers {
-            if self.thread_manager.get_thread(thread_id).await.is_err() {
-                self.finalize_thread_teardown(thread_id).await;
-                continue;
-            }
-            self.schedule_thread_idle_unload_check(thread_id).await;
-        }
     }
 
     pub(crate) fn subscribe_running_assistant_turn_count(&self) -> watch::Receiver<usize> {
@@ -3819,22 +3867,21 @@ impl CodexMessageProcessor {
     }
 
     async fn thread_resume(&self, request_id: ConnectionRequestId, params: ThreadResumeParams) {
-        if let Ok(thread_id) = ThreadId::from_string(&params.thread_id) {
-            let pending_thread_unloads = self.pending_thread_unloads.lock().await;
-            if pending_thread_unloads.contains(&thread_id) {
-                drop(pending_thread_unloads);
-                self.send_invalid_request_error(
-                    request_id,
-                    format!(
-                        "thread {thread_id} is closing; retry thread/resume after the thread is closed"
-                    ),
-                )
-                .await;
-                return;
-            }
-            self.thread_state_manager
-                .note_thread_activity(thread_id)
-                .await;
+        if let Ok(thread_id) = ThreadId::from_string(&params.thread_id)
+            && self
+                .pending_thread_unloads
+                .lock()
+                .await
+                .contains(&thread_id)
+        {
+            self.send_invalid_request_error(
+                request_id,
+                format!(
+                    "thread {thread_id} is closing; retry thread/resume after the thread is closed"
+                ),
+            )
+            .await;
+            return;
         }
 
         if self
@@ -5478,10 +5525,6 @@ impl CodexMessageProcessor {
 
     async fn finalize_thread_teardown(&self, thread_id: ThreadId) {
         self.pending_thread_unloads.lock().await.remove(&thread_id);
-        self.pending_idle_thread_unloads
-            .lock()
-            .await
-            .remove(&thread_id);
         self.outgoing
             .cancel_requests_for_thread(thread_id, /*error*/ None)
             .await;
@@ -5493,251 +5536,52 @@ impl CodexMessageProcessor {
             .await;
     }
 
-    async fn schedule_thread_idle_unload_check(&self, thread_id: ThreadId) {
-        Self::schedule_thread_idle_unload_check_task(self.thread_unload_context(), thread_id).await;
-    }
-
-    async fn schedule_thread_idle_unload_check_task(
-        context: ThreadUnloadContext,
-        thread_id: ThreadId,
-    ) {
-        {
-            let mut pending_idle_thread_unloads = context.pending_idle_thread_unloads.lock().await;
-            if !pending_idle_thread_unloads.insert(thread_id) {
-                return;
-            }
-        }
-
-        tokio::spawn(async move {
-            Self::thread_idle_unload_check_task(context, thread_id).await;
-        });
-    }
-
-    async fn thread_idle_unload_check_task(context: ThreadUnloadContext, thread_id: ThreadId) {
-        loop {
-            match context
-                .thread_state_manager
-                .thread_idle_unload_wait(thread_id, context.idle_timeout)
-                .await
-            {
-                ThreadIdleUnloadWait::Ready => {
-                    context
-                        .pending_idle_thread_unloads
-                        .lock()
-                        .await
-                        .remove(&thread_id);
-
-                    if let Some(listener_command_tx) = context
-                        .thread_state_manager
-                        .listener_command_tx(thread_id)
-                        .await
-                        && listener_command_tx
-                            .send(ThreadListenerCommand::CheckIdleUnload {
-                                idle_timeout: context.idle_timeout,
-                            })
-                            .is_ok()
-                    {
-                        return;
-                    }
-
-                    let Ok(thread) = context.thread_manager.get_thread(thread_id).await else {
-                        context
-                            .thread_state_manager
-                            .remove_thread_state(thread_id)
-                            .await;
-                        context
-                            .thread_watch_manager
-                            .remove_thread(&thread_id.to_string())
-                            .await;
-                        return;
-                    };
-                    let active_turn_snapshot = context
-                        .thread_state_manager
-                        .has_active_turn_snapshot(thread_id)
-                        .await;
-                    if matches!(
-                        Self::check_idle_unload(
-                            &context,
-                            thread_id,
-                            &thread,
-                            active_turn_snapshot,
-                            context.idle_timeout,
-                        )
-                        .await,
-                        IdleThreadUnloadCheck::Deferred
-                    ) {
-                        context
-                            .pending_idle_thread_unloads
-                            .lock()
-                            .await
-                            .insert(thread_id);
-                        tokio::time::sleep(context.idle_timeout).await;
-                        continue;
-                    }
-                    return;
-                }
-                ThreadIdleUnloadWait::Wait(wait_duration) => {
-                    tokio::time::sleep(wait_duration).await;
-                }
-                ThreadIdleUnloadWait::HasSubscribers | ThreadIdleUnloadWait::Missing => {
-                    context
-                        .pending_idle_thread_unloads
-                        .lock()
-                        .await
-                        .remove(&thread_id);
-                    return;
-                }
-            }
-        }
-    }
-
-    async fn check_idle_unload_from_listener(
-        context: &ThreadUnloadContext,
-        thread_id: ThreadId,
-        thread: &Arc<CodexThread>,
-        thread_state: &Arc<Mutex<ThreadState>>,
-        idle_timeout: Duration,
-    ) -> IdleThreadUnloadCheck {
-        let active_turn_snapshot = thread_state.lock().await.active_turn_snapshot().is_some();
-        Self::check_idle_unload(
-            context,
-            thread_id,
-            thread,
-            active_turn_snapshot,
-            idle_timeout,
-        )
-        .await
-    }
-
-    async fn check_idle_unload(
-        context: &ThreadUnloadContext,
-        thread_id: ThreadId,
-        thread: &Arc<CodexThread>,
-        active_turn_snapshot: bool,
-        idle_timeout: Duration,
-    ) -> IdleThreadUnloadCheck {
-        let mut pending_thread_unloads = context.pending_thread_unloads.lock().await;
-        if pending_thread_unloads.contains(&thread_id) {
-            return IdleThreadUnloadCheck::Started;
-        }
-        match context
-            .thread_state_manager
-            .thread_idle_unload_wait(thread_id, idle_timeout)
-            .await
-        {
-            ThreadIdleUnloadWait::Ready => {}
-            ThreadIdleUnloadWait::Wait(_) => return IdleThreadUnloadCheck::Deferred,
-            ThreadIdleUnloadWait::HasSubscribers | ThreadIdleUnloadWait::Missing => {
-                return IdleThreadUnloadCheck::NotEligible;
-            }
-        }
-        if Self::thread_has_active_work(context, thread_id, thread, active_turn_snapshot).await {
-            context
-                .thread_state_manager
-                .note_thread_activity(thread_id)
-                .await;
-            return IdleThreadUnloadCheck::Deferred;
-        }
-        pending_thread_unloads.insert(thread_id);
-        drop(pending_thread_unloads);
-
-        info!("thread {thread_id} has no subscribers and is idle; shutting down");
-        context
-            .pending_idle_thread_unloads
-            .lock()
-            .await
-            .remove(&thread_id);
-
-        // Any pending app-server -> client requests for this thread can no longer be
-        // answered; cancel their callbacks before shutdown/unload.
-        context
-            .outgoing
-            .cancel_requests_for_thread(thread_id, /*error*/ None)
-            .await;
-        context
-            .thread_state_manager
-            .remove_thread_state(thread_id)
-            .await;
-
-        Self::spawn_thread_shutdown_task(context.clone(), thread_id, thread.clone());
-        IdleThreadUnloadCheck::Started
-    }
-
-    async fn thread_has_active_work(
-        context: &ThreadUnloadContext,
-        thread_id: ThreadId,
-        thread: &Arc<CodexThread>,
-        active_turn_snapshot: bool,
-    ) -> bool {
-        if matches!(thread.agent_status().await, AgentStatus::Running) || active_turn_snapshot {
-            return true;
-        }
-        matches!(
-            context
-                .thread_watch_manager
-                .loaded_status_for_thread(&thread_id.to_string())
-                .await,
-            ThreadStatus::Active { .. }
-        )
-    }
-
-    fn spawn_thread_shutdown_task(
-        context: ThreadUnloadContext,
+    async fn unload_thread_without_subscribers(
+        thread_manager: Arc<ThreadManager>,
+        outgoing: Arc<OutgoingMessageSender>,
+        pending_thread_unloads: Arc<Mutex<HashSet<ThreadId>>>,
+        thread_state_manager: ThreadStateManager,
+        thread_watch_manager: ThreadWatchManager,
         thread_id: ThreadId,
         thread: Arc<CodexThread>,
     ) {
+        info!("thread {thread_id} has no subscribers and is idle; shutting down");
+
+        // Any pending app-server -> client requests for this thread can no longer be
+        // answered; cancel their callbacks before shutdown/unload.
+        outgoing
+            .cancel_requests_for_thread(thread_id, /*error*/ None)
+            .await;
+        thread_state_manager.remove_thread_state(thread_id).await;
+
         tokio::spawn(async move {
             match Self::wait_for_thread_shutdown(&thread).await {
                 ThreadShutdownResult::Complete => {
-                    if context
-                        .thread_manager
-                        .remove_thread(&thread_id)
-                        .await
-                        .is_none()
-                    {
+                    if thread_manager.remove_thread(&thread_id).await.is_none() {
                         info!("thread {thread_id} was already removed before teardown finalized");
-                        context
-                            .thread_watch_manager
+                        thread_watch_manager
                             .remove_thread(&thread_id.to_string())
                             .await;
-                        context
-                            .pending_thread_unloads
-                            .lock()
-                            .await
-                            .remove(&thread_id);
+                        pending_thread_unloads.lock().await.remove(&thread_id);
                         return;
                     }
-                    context
-                        .thread_watch_manager
+                    thread_watch_manager
                         .remove_thread(&thread_id.to_string())
                         .await;
                     let notification = ThreadClosedNotification {
                         thread_id: thread_id.to_string(),
                     };
-                    context
-                        .outgoing
+                    outgoing
                         .send_server_notification(ServerNotification::ThreadClosed(notification))
                         .await;
-                    context
-                        .pending_thread_unloads
-                        .lock()
-                        .await
-                        .remove(&thread_id);
+                    pending_thread_unloads.lock().await.remove(&thread_id);
                 }
                 ThreadShutdownResult::SubmitFailed => {
-                    context
-                        .pending_thread_unloads
-                        .lock()
-                        .await
-                        .remove(&thread_id);
+                    pending_thread_unloads.lock().await.remove(&thread_id);
                     warn!("failed to submit Shutdown to thread {thread_id}");
                 }
                 ThreadShutdownResult::TimedOut => {
-                    context
-                        .pending_thread_unloads
-                        .lock()
-                        .await
-                        .remove(&thread_id);
+                    pending_thread_unloads.lock().await.remove(&thread_id);
                     warn!("thread {thread_id} shutdown timed out; leaving thread loaded");
                 }
             }
@@ -5758,7 +5602,7 @@ impl CodexMessageProcessor {
             }
         };
 
-        let Ok(_thread) = self.thread_manager.get_thread(thread_id).await else {
+        if self.thread_manager.get_thread(thread_id).await.is_err() {
             // Reconcile stale app-server bookkeeping when the thread has already been
             // removed from the core manager. This keeps loaded-status/subscription state
             // consistent with the source of truth before reporting NotLoaded.
@@ -5774,35 +5618,18 @@ impl CodexMessageProcessor {
             return;
         };
 
-        let removal = self
+        let was_subscribed = self
             .thread_state_manager
             .unsubscribe_connection_from_thread(thread_id, request_id.connection_id)
             .await;
-        match removal {
-            ThreadSubscriptionRemoval::NotSubscribed => {
-                self.outgoing
-                    .send_response(
-                        request_id,
-                        ThreadUnsubscribeResponse {
-                            status: ThreadUnsubscribeStatus::NotSubscribed,
-                        },
-                    )
-                    .await;
-                return;
-            }
-            ThreadSubscriptionRemoval::RemovedStillHasSubscribers => {}
-            ThreadSubscriptionRemoval::RemovedLastSubscriber => {
-                self.schedule_thread_idle_unload_check(thread_id).await;
-            }
-        }
 
+        let status = if was_subscribed {
+            ThreadUnsubscribeStatus::Unsubscribed
+        } else {
+            ThreadUnsubscribeStatus::NotSubscribed
+        };
         self.outgoing
-            .send_response(
-                request_id,
-                ThreadUnsubscribeResponse {
-                    status: ThreadUnsubscribeStatus::Unsubscribed,
-                },
-            )
+            .send_response(request_id, ThreadUnsubscribeResponse { status })
             .await;
     }
 
@@ -7543,7 +7370,17 @@ impl CodexMessageProcessor {
         api_version: ApiVersion,
     ) -> Result<EnsureConversationListenerResult, JSONRPCErrorError> {
         Self::ensure_conversation_listener_task(
-            self.listener_task_context(),
+            ListenerTaskContext {
+                thread_manager: Arc::clone(&self.thread_manager),
+                thread_state_manager: self.thread_state_manager.clone(),
+                outgoing: Arc::clone(&self.outgoing),
+                pending_thread_unloads: Arc::clone(&self.pending_thread_unloads),
+                analytics_events_client: self.analytics_events_client.clone(),
+                general_analytics_enabled: self.config.features.enabled(Feature::GeneralAnalytics),
+                thread_watch_manager: self.thread_watch_manager.clone(),
+                fallback_model_provider: self.config.model_provider_id.clone(),
+                codex_home: self.config.codex_home.clone(),
+            },
             conversation_id,
             connection_id,
             raw_events_enabled,
@@ -7574,11 +7411,7 @@ impl CodexMessageProcessor {
             }
         };
         let thread_state = {
-            let pending_thread_unloads = listener_task_context
-                .thread_unload_context
-                .pending_thread_unloads
-                .lock()
-                .await;
+            let pending_thread_unloads = listener_task_context.pending_thread_unloads.lock().await;
             if pending_thread_unloads.contains(&conversation_id) {
                 return Err(JSONRPCErrorError {
                     code: INVALID_REQUEST_ERROR_CODE,
@@ -7644,7 +7477,17 @@ impl CodexMessageProcessor {
         api_version: ApiVersion,
     ) {
         Self::ensure_listener_task_running_task(
-            self.listener_task_context(),
+            ListenerTaskContext {
+                thread_manager: Arc::clone(&self.thread_manager),
+                thread_state_manager: self.thread_state_manager.clone(),
+                outgoing: Arc::clone(&self.outgoing),
+                pending_thread_unloads: Arc::clone(&self.pending_thread_unloads),
+                analytics_events_client: self.analytics_events_client.clone(),
+                general_analytics_enabled: self.config.features.enabled(Feature::GeneralAnalytics),
+                thread_watch_manager: self.thread_watch_manager.clone(),
+                fallback_model_provider: self.config.model_provider_id.clone(),
+                codex_home: self.config.codex_home.clone(),
+            },
             conversation_id,
             conversation,
             thread_state,
@@ -7661,6 +7504,15 @@ impl CodexMessageProcessor {
         api_version: ApiVersion,
     ) {
         let (cancel_tx, mut cancel_rx) = oneshot::channel();
+        let Some(mut unloading_state) = UnloadingState::new(
+            &listener_task_context,
+            conversation_id,
+            THREAD_UNLOADING_DELAY,
+        )
+        .await
+        else {
+            return;
+        };
         let (mut listener_command_rx, listener_generation) = {
             let mut thread_state = thread_state.lock().await;
             if thread_state.listener_matches(&conversation) {
@@ -7672,20 +7524,38 @@ impl CodexMessageProcessor {
             outgoing,
             thread_manager,
             thread_state_manager,
+            pending_thread_unloads,
             analytics_events_client: _,
             general_analytics_enabled: _,
             thread_watch_manager,
             fallback_model_provider,
             codex_home,
-            thread_unload_context,
         } = listener_task_context;
         let outgoing_for_task = Arc::clone(&outgoing);
         tokio::spawn(async move {
             loop {
                 tokio::select! {
+                    biased;
                     _ = &mut cancel_rx => {
                         // Listener was superseded or the thread is being torn down.
                         break;
+                    }
+                    listener_command = listener_command_rx.recv() => {
+                        let Some(listener_command) = listener_command else {
+                            break;
+                        };
+                        handle_thread_listener_command(
+                            conversation_id,
+                            &conversation,
+                            codex_home.as_path(),
+                            &thread_state_manager,
+                            &thread_state,
+                            &thread_watch_manager,
+                            &outgoing_for_task,
+                            &pending_thread_unloads,
+                            listener_command,
+                        )
+                        .await;
                     }
                     event = conversation.next_event() => {
                         let event = match event {
@@ -7699,15 +7569,6 @@ impl CodexMessageProcessor {
                         // Track the event before emitting any typed
                         // translations so thread-local state such as raw event
                         // opt-in stays synchronized with the conversation.
-                        {
-                            let pending_thread_unloads = thread_unload_context
-                                .pending_thread_unloads
-                                .lock()
-                                .await;
-                            if !pending_thread_unloads.contains(&conversation_id) {
-                                thread_state_manager.note_thread_activity(conversation_id).await;
-                            }
-                        }
                         let raw_events_enabled = {
                             let mut thread_state = thread_state.lock().await;
                             thread_state.track_current_turn_event(&event.msg);
@@ -7750,22 +7611,38 @@ impl CodexMessageProcessor {
                         )
                         .await;
                     }
-                    listener_command = listener_command_rx.recv() => {
-                        let Some(listener_command) = listener_command else {
+                    unloading_watchers_open = unloading_state.wait_for_unloading_trigger() => {
+                        if !unloading_watchers_open {
                             break;
-                        };
-                        handle_thread_listener_command(
+                        }
+                        if !unloading_state.should_unload_now() {
+                            continue;
+                        }
+                        if matches!(conversation.agent_status().await, AgentStatus::Running) {
+                            unloading_state.note_thread_activity_observed();
+                            continue;
+                        }
+                        {
+                            let mut pending_thread_unloads = pending_thread_unloads.lock().await;
+                            if pending_thread_unloads.contains(&conversation_id) {
+                                continue;
+                            }
+                            if !unloading_state.should_unload_now() {
+                                continue;
+                            }
+                            pending_thread_unloads.insert(conversation_id);
+                        }
+                        Self::unload_thread_without_subscribers(
+                            thread_manager.clone(),
+                            outgoing_for_task.clone(),
+                            pending_thread_unloads.clone(),
+                            thread_state_manager.clone(),
+                            thread_watch_manager.clone(),
                             conversation_id,
-                            &conversation,
-                            codex_home.as_path(),
-                            &thread_state_manager,
-                            &thread_state,
-                            &thread_watch_manager,
-                            &outgoing_for_task,
-                            &thread_unload_context,
-                            listener_command,
+                            conversation.clone(),
                         )
                         .await;
+                        break;
                     }
                 }
             }
@@ -8263,7 +8140,7 @@ async fn handle_thread_listener_command(
     thread_state: &Arc<Mutex<ThreadState>>,
     thread_watch_manager: &ThreadWatchManager,
     outgoing: &Arc<OutgoingMessageSender>,
-    thread_unload_context: &ThreadUnloadContext,
+    pending_thread_unloads: &Arc<Mutex<HashSet<ThreadId>>>,
     listener_command: ThreadListenerCommand,
 ) {
     match listener_command {
@@ -8276,27 +8153,10 @@ async fn handle_thread_listener_command(
                 thread_state,
                 thread_watch_manager,
                 outgoing,
-                thread_unload_context,
+                pending_thread_unloads,
                 *resume_request,
             )
             .await;
-        }
-        ThreadListenerCommand::CheckIdleUnload { idle_timeout } => {
-            let result = CodexMessageProcessor::check_idle_unload_from_listener(
-                thread_unload_context,
-                conversation_id,
-                conversation,
-                thread_state,
-                idle_timeout,
-            )
-            .await;
-            if matches!(result, IdleThreadUnloadCheck::Deferred) {
-                CodexMessageProcessor::schedule_thread_idle_unload_check_task(
-                    thread_unload_context.clone(),
-                    conversation_id,
-                )
-                .await;
-            }
         }
         ThreadListenerCommand::ResolveServerRequest {
             request_id,
@@ -8323,7 +8183,7 @@ async fn handle_pending_thread_resume_request(
     thread_state: &Arc<Mutex<ThreadState>>,
     thread_watch_manager: &ThreadWatchManager,
     outgoing: &Arc<OutgoingMessageSender>,
-    thread_unload_context: &ThreadUnloadContext,
+    pending_thread_unloads: &Arc<Mutex<HashSet<ThreadId>>>,
     pending: crate::thread_state::PendingThreadResumeRequest,
 ) {
     let active_turn = {
@@ -8378,7 +8238,7 @@ async fn handle_pending_thread_resume_request(
     );
 
     {
-        let pending_thread_unloads = thread_unload_context.pending_thread_unloads.lock().await;
+        let pending_thread_unloads = pending_thread_unloads.lock().await;
         if pending_thread_unloads.contains(&conversation_id) {
             drop(pending_thread_unloads);
             outgoing
@@ -10229,86 +10089,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn last_subscriber_removal_starts_idle_unload_wait() -> Result<()> {
-        let manager = ThreadStateManager::new();
-        let thread_id = ThreadId::from_string("ad7f0408-99b8-4f6e-a46f-bd0eec433370")?;
-        let connection = ConnectionId(1);
-        let idle_timeout = Duration::from_millis(30);
-
-        manager.connection_initialized(connection).await;
-        manager
-            .try_ensure_connection_subscribed(
-                thread_id, connection, /*experimental_raw_events*/ false,
-            )
-            .await
-            .expect("connection should be live");
-
-        assert!(matches!(
-            manager
-                .unsubscribe_connection_from_thread(thread_id, connection)
-                .await,
-            ThreadSubscriptionRemoval::RemovedLastSubscriber
-        ));
-        assert!(matches!(
-            manager
-                .thread_idle_unload_wait(thread_id, idle_timeout)
-                .await,
-            ThreadIdleUnloadWait::Wait(_)
-        ));
-
-        tokio::time::sleep(Duration::from_millis(40)).await;
-        assert!(matches!(
-            manager
-                .thread_idle_unload_wait(thread_id, idle_timeout)
-                .await,
-            ThreadIdleUnloadWait::Ready
-        ));
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn thread_activity_resets_idle_unload_wait() -> Result<()> {
-        let manager = ThreadStateManager::new();
-        let thread_id = ThreadId::from_string("ad7f0408-99b8-4f6e-a46f-bd0eec433370")?;
-        let connection = ConnectionId(1);
-        let idle_timeout = Duration::from_millis(50);
-
-        manager.connection_initialized(connection).await;
-        manager
-            .try_ensure_connection_subscribed(
-                thread_id, connection, /*experimental_raw_events*/ false,
-            )
-            .await
-            .expect("connection should be live");
-        assert!(matches!(
-            manager
-                .unsubscribe_connection_from_thread(thread_id, connection)
-                .await,
-            ThreadSubscriptionRemoval::RemovedLastSubscriber
-        ));
-
-        tokio::time::sleep(Duration::from_millis(30)).await;
-        manager.note_thread_activity(thread_id).await;
-        tokio::time::sleep(Duration::from_millis(30)).await;
-        assert!(matches!(
-            manager
-                .thread_idle_unload_wait(thread_id, idle_timeout)
-                .await,
-            ThreadIdleUnloadWait::Wait(_)
-        ));
-
-        tokio::time::sleep(Duration::from_millis(30)).await;
-        assert!(matches!(
-            manager
-                .thread_idle_unload_wait(thread_id, idle_timeout)
-                .await,
-            ThreadIdleUnloadWait::Ready
-        ));
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn resubscribe_cancels_idle_unload_eligibility() -> Result<()> {
+    async fn adding_connection_to_thread_updates_has_connections_watcher() -> Result<()> {
         let manager = ThreadStateManager::new();
         let thread_id = ThreadId::from_string("ad7f0408-99b8-4f6e-a46f-bd0eec433370")?;
         let connection_a = ConnectionId(1);
@@ -10324,27 +10105,33 @@ mod tests {
             )
             .await
             .expect("connection_a should be live");
-        assert!(matches!(
+        let mut has_connections = manager
+            .subscribe_to_has_connections(thread_id)
+            .await
+            .expect("thread should have a has-connections watcher");
+        assert!(*has_connections.borrow());
+
+        assert!(
             manager
                 .unsubscribe_connection_from_thread(thread_id, connection_a)
-                .await,
-            ThreadSubscriptionRemoval::RemovedLastSubscriber
-        ));
-
-        manager
-            .try_ensure_connection_subscribed(
-                thread_id,
-                connection_b,
-                /*experimental_raw_events*/ false,
-            )
+                .await
+        );
+        tokio::time::timeout(Duration::from_secs(1), has_connections.changed())
             .await
-            .expect("connection_b should be live");
-        assert!(matches!(
+            .expect("timed out waiting for no-subscriber update")
+            .expect("has-connections watcher should remain open");
+        assert!(!*has_connections.borrow());
+
+        assert!(
             manager
-                .thread_idle_unload_wait(thread_id, Duration::from_millis(1))
-                .await,
-            ThreadIdleUnloadWait::HasSubscribers
-        ));
+                .try_add_connection_to_thread(thread_id, connection_b)
+                .await
+        );
+        tokio::time::timeout(Duration::from_secs(1), has_connections.changed())
+            .await
+            .expect("timed out waiting for subscriber update")
+            .expect("has-connections watcher should remain open");
+        assert!(*has_connections.borrow());
         Ok(())
     }
 

--- a/codex-rs/app-server/src/thread_state.rs
+++ b/codex-rs/app-server/src/thread_state.rs
@@ -13,11 +13,10 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Weak;
-use std::time::Duration;
 use tokio::sync::Mutex;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
-use tokio::time::Instant;
+use tokio::sync::watch;
 use tracing::error;
 
 type PendingInterruptQueue = Vec<(
@@ -36,11 +35,6 @@ pub(crate) struct PendingThreadResumeRequest {
 pub(crate) enum ThreadListenerCommand {
     // SendThreadResumeResponse is used to resume an already running thread by sending the thread's history to the client and atomically subscribing for new updates.
     SendThreadResumeResponse(Box<PendingThreadResumeRequest>),
-    // CheckIdleUnload is used to serialize delayed idle-unload checks with
-    // thread event handling.
-    CheckIdleUnload {
-        idle_timeout: Duration,
-    },
     // ResolveServerRequest is used to notify the client that the request has been resolved.
     // It is executed in the thread listener's context to ensure that the resolved notification is ordered with regard to the request itself.
     ResolveServerRequest {
@@ -165,33 +159,27 @@ pub(crate) async fn resolve_server_request_on_thread_listener(
 struct ThreadEntry {
     state: Arc<Mutex<ThreadState>>,
     connection_ids: HashSet<ConnectionId>,
-    last_activity_at: Instant,
-    no_subscribers_since: Option<Instant>,
+    has_connections_watcher: watch::Sender<bool>,
 }
 
 impl Default for ThreadEntry {
     fn default() -> Self {
-        let now = Instant::now();
         Self {
             state: Arc::new(Mutex::new(ThreadState::default())),
             connection_ids: HashSet::new(),
-            last_activity_at: now,
-            no_subscribers_since: Some(now),
+            has_connections_watcher: watch::channel(false).0,
         }
     }
 }
 
-pub(crate) enum ThreadSubscriptionRemoval {
-    NotSubscribed,
-    RemovedStillHasSubscribers,
-    RemovedLastSubscriber,
-}
-
-pub(crate) enum ThreadIdleUnloadWait {
-    Ready,
-    Wait(Duration),
-    HasSubscribers,
-    Missing,
+impl ThreadEntry {
+    fn update_has_connections(&self) {
+        let _ = self.has_connections_watcher.send_if_modified(|current| {
+            let prev = *current;
+            *current = !self.connection_ids.is_empty();
+            prev != *current
+        });
+    }
 }
 
 #[derive(Default)]
@@ -231,43 +219,6 @@ impl ThreadStateManager {
     pub(crate) async fn thread_state(&self, thread_id: ThreadId) -> Arc<Mutex<ThreadState>> {
         let mut state = self.state.lock().await;
         state.threads.entry(thread_id).or_default().state.clone()
-    }
-
-    pub(crate) async fn listener_command_tx(
-        &self,
-        thread_id: ThreadId,
-    ) -> Option<mpsc::UnboundedSender<ThreadListenerCommand>> {
-        let thread_state = {
-            let state = self.state.lock().await;
-            state
-                .threads
-                .get(&thread_id)
-                .map(|thread_entry| thread_entry.state.clone())
-        }?;
-        let thread_state = thread_state.lock().await;
-        thread_state.listener_command_tx()
-    }
-
-    pub(crate) async fn note_thread_activity(&self, thread_id: ThreadId) {
-        let mut state = self.state.lock().await;
-        if let Some(thread_entry) = state.threads.get_mut(&thread_id) {
-            thread_entry.last_activity_at = Instant::now();
-        }
-    }
-
-    pub(crate) async fn has_active_turn_snapshot(&self, thread_id: ThreadId) -> bool {
-        let thread_state = {
-            let state = self.state.lock().await;
-            state
-                .threads
-                .get(&thread_id)
-                .map(|thread_entry| thread_entry.state.clone())
-        };
-        let Some(thread_state) = thread_state else {
-            return false;
-        };
-        let thread_state = thread_state.lock().await;
-        thread_state.active_turn_snapshot().is_some()
     }
 
     pub(crate) async fn remove_thread_state(&self, thread_id: ThreadId) {
@@ -324,11 +275,11 @@ impl ThreadStateManager {
         &self,
         thread_id: ThreadId,
         connection_id: ConnectionId,
-    ) -> ThreadSubscriptionRemoval {
+    ) -> bool {
         {
             let mut state = self.state.lock().await;
             if !state.threads.contains_key(&thread_id) {
-                return ThreadSubscriptionRemoval::NotSubscribed;
+                return false;
             }
 
             if !state
@@ -336,7 +287,7 @@ impl ThreadStateManager {
                 .get(&connection_id)
                 .is_some_and(|thread_ids| thread_ids.contains(&thread_id))
             {
-                return ThreadSubscriptionRemoval::NotSubscribed;
+                return false;
             }
 
             if let Some(thread_ids) = state.thread_ids_by_connection.get_mut(&connection_id) {
@@ -347,16 +298,11 @@ impl ThreadStateManager {
             }
             if let Some(thread_entry) = state.threads.get_mut(&thread_id) {
                 thread_entry.connection_ids.remove(&connection_id);
-                if thread_entry.connection_ids.is_empty() {
-                    thread_entry
-                        .no_subscribers_since
-                        .get_or_insert_with(Instant::now);
-                    return ThreadSubscriptionRemoval::RemovedLastSubscriber;
-                }
+                thread_entry.update_has_connections();
             }
         };
 
-        ThreadSubscriptionRemoval::RemovedStillHasSubscribers
+        true
     }
 
     #[cfg(test)]
@@ -387,7 +333,7 @@ impl ThreadStateManager {
                 .insert(thread_id);
             let thread_entry = state.threads.entry(thread_id).or_default();
             thread_entry.connection_ids.insert(connection_id);
-            thread_entry.no_subscribers_since = None;
+            thread_entry.update_has_connections();
             thread_entry.state.clone()
         };
         {
@@ -415,7 +361,7 @@ impl ThreadStateManager {
             .insert(thread_id);
         let thread_entry = state.threads.entry(thread_id).or_default();
         thread_entry.connection_ids.insert(connection_id);
-        thread_entry.no_subscribers_since = None;
+        thread_entry.update_has_connections();
         true
     }
 
@@ -430,11 +376,7 @@ impl ThreadStateManager {
             for thread_id in &thread_ids {
                 if let Some(thread_entry) = state.threads.get_mut(thread_id) {
                     thread_entry.connection_ids.remove(&connection_id);
-                    if thread_entry.connection_ids.is_empty() {
-                        thread_entry
-                            .no_subscribers_since
-                            .get_or_insert_with(Instant::now);
-                    }
+                    thread_entry.update_has_connections();
                 }
             }
             thread_ids
@@ -449,31 +391,14 @@ impl ThreadStateManager {
         }
     }
 
-    pub(crate) async fn thread_idle_unload_wait(
+    pub(crate) async fn subscribe_to_has_connections(
         &self,
         thread_id: ThreadId,
-        idle_timeout: Duration,
-    ) -> ThreadIdleUnloadWait {
+    ) -> Option<watch::Receiver<bool>> {
         let state = self.state.lock().await;
-        let Some(thread_entry) = state.threads.get(&thread_id) else {
-            return ThreadIdleUnloadWait::Missing;
-        };
-        if !thread_entry.connection_ids.is_empty() {
-            return ThreadIdleUnloadWait::HasSubscribers;
-        }
-        let Some(no_subscribers_since) = thread_entry.no_subscribers_since else {
-            return ThreadIdleUnloadWait::HasSubscribers;
-        };
-        let idle_since = if thread_entry.last_activity_at > no_subscribers_since {
-            thread_entry.last_activity_at
-        } else {
-            no_subscribers_since
-        };
-        let idle_duration = idle_since.elapsed();
-        if idle_duration >= idle_timeout {
-            ThreadIdleUnloadWait::Ready
-        } else {
-            ThreadIdleUnloadWait::Wait(idle_timeout.saturating_sub(idle_duration))
-        }
+        state
+            .threads
+            .get(&thread_id)
+            .map(|thread_entry| thread_entry.has_connections_watcher.subscribe())
     }
 }

--- a/codex-rs/app-server/src/thread_state.rs
+++ b/codex-rs/app-server/src/thread_state.rs
@@ -13,9 +13,11 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Weak;
+use std::time::Duration;
 use tokio::sync::Mutex;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
+use tokio::time::Instant;
 use tracing::error;
 
 type PendingInterruptQueue = Vec<(
@@ -34,6 +36,11 @@ pub(crate) struct PendingThreadResumeRequest {
 pub(crate) enum ThreadListenerCommand {
     // SendThreadResumeResponse is used to resume an already running thread by sending the thread's history to the client and atomically subscribing for new updates.
     SendThreadResumeResponse(Box<PendingThreadResumeRequest>),
+    // CheckIdleUnload is used to serialize delayed idle-unload checks with
+    // thread event handling.
+    CheckIdleUnload {
+        idle_timeout: Duration,
+    },
     // ResolveServerRequest is used to notify the client that the request has been resolved.
     // It is executed in the thread listener's context to ensure that the resolved notification is ordered with regard to the request itself.
     ResolveServerRequest {
@@ -158,15 +165,33 @@ pub(crate) async fn resolve_server_request_on_thread_listener(
 struct ThreadEntry {
     state: Arc<Mutex<ThreadState>>,
     connection_ids: HashSet<ConnectionId>,
+    last_activity_at: Instant,
+    no_subscribers_since: Option<Instant>,
 }
 
 impl Default for ThreadEntry {
     fn default() -> Self {
+        let now = Instant::now();
         Self {
             state: Arc::new(Mutex::new(ThreadState::default())),
             connection_ids: HashSet::new(),
+            last_activity_at: now,
+            no_subscribers_since: Some(now),
         }
     }
+}
+
+pub(crate) enum ThreadSubscriptionRemoval {
+    NotSubscribed,
+    RemovedStillHasSubscribers,
+    RemovedLastSubscriber,
+}
+
+pub(crate) enum ThreadIdleUnloadWait {
+    Ready,
+    Wait(Duration),
+    HasSubscribers,
+    Missing,
 }
 
 #[derive(Default)]
@@ -206,6 +231,43 @@ impl ThreadStateManager {
     pub(crate) async fn thread_state(&self, thread_id: ThreadId) -> Arc<Mutex<ThreadState>> {
         let mut state = self.state.lock().await;
         state.threads.entry(thread_id).or_default().state.clone()
+    }
+
+    pub(crate) async fn listener_command_tx(
+        &self,
+        thread_id: ThreadId,
+    ) -> Option<mpsc::UnboundedSender<ThreadListenerCommand>> {
+        let thread_state = {
+            let state = self.state.lock().await;
+            state
+                .threads
+                .get(&thread_id)
+                .map(|thread_entry| thread_entry.state.clone())
+        }?;
+        let thread_state = thread_state.lock().await;
+        thread_state.listener_command_tx()
+    }
+
+    pub(crate) async fn note_thread_activity(&self, thread_id: ThreadId) {
+        let mut state = self.state.lock().await;
+        if let Some(thread_entry) = state.threads.get_mut(&thread_id) {
+            thread_entry.last_activity_at = Instant::now();
+        }
+    }
+
+    pub(crate) async fn has_active_turn_snapshot(&self, thread_id: ThreadId) -> bool {
+        let thread_state = {
+            let state = self.state.lock().await;
+            state
+                .threads
+                .get(&thread_id)
+                .map(|thread_entry| thread_entry.state.clone())
+        };
+        let Some(thread_state) = thread_state else {
+            return false;
+        };
+        let thread_state = thread_state.lock().await;
+        thread_state.active_turn_snapshot().is_some()
     }
 
     pub(crate) async fn remove_thread_state(&self, thread_id: ThreadId) {
@@ -262,11 +324,11 @@ impl ThreadStateManager {
         &self,
         thread_id: ThreadId,
         connection_id: ConnectionId,
-    ) -> bool {
+    ) -> ThreadSubscriptionRemoval {
         {
             let mut state = self.state.lock().await;
             if !state.threads.contains_key(&thread_id) {
-                return false;
+                return ThreadSubscriptionRemoval::NotSubscribed;
             }
 
             if !state
@@ -274,7 +336,7 @@ impl ThreadStateManager {
                 .get(&connection_id)
                 .is_some_and(|thread_ids| thread_ids.contains(&thread_id))
             {
-                return false;
+                return ThreadSubscriptionRemoval::NotSubscribed;
             }
 
             if let Some(thread_ids) = state.thread_ids_by_connection.get_mut(&connection_id) {
@@ -285,12 +347,19 @@ impl ThreadStateManager {
             }
             if let Some(thread_entry) = state.threads.get_mut(&thread_id) {
                 thread_entry.connection_ids.remove(&connection_id);
+                if thread_entry.connection_ids.is_empty() {
+                    thread_entry
+                        .no_subscribers_since
+                        .get_or_insert_with(Instant::now);
+                    return ThreadSubscriptionRemoval::RemovedLastSubscriber;
+                }
             }
         };
 
-        true
+        ThreadSubscriptionRemoval::RemovedStillHasSubscribers
     }
 
+    #[cfg(test)]
     pub(crate) async fn has_subscribers(&self, thread_id: ThreadId) -> bool {
         self.state
             .lock()
@@ -318,6 +387,7 @@ impl ThreadStateManager {
                 .insert(thread_id);
             let thread_entry = state.threads.entry(thread_id).or_default();
             thread_entry.connection_ids.insert(connection_id);
+            thread_entry.no_subscribers_since = None;
             thread_entry.state.clone()
         };
         {
@@ -343,12 +413,9 @@ impl ThreadStateManager {
             .entry(connection_id)
             .or_default()
             .insert(thread_id);
-        state
-            .threads
-            .entry(thread_id)
-            .or_default()
-            .connection_ids
-            .insert(connection_id);
+        let thread_entry = state.threads.entry(thread_id).or_default();
+        thread_entry.connection_ids.insert(connection_id);
+        thread_entry.no_subscribers_since = None;
         true
     }
 
@@ -363,6 +430,11 @@ impl ThreadStateManager {
             for thread_id in &thread_ids {
                 if let Some(thread_entry) = state.threads.get_mut(thread_id) {
                     thread_entry.connection_ids.remove(&connection_id);
+                    if thread_entry.connection_ids.is_empty() {
+                        thread_entry
+                            .no_subscribers_since
+                            .get_or_insert_with(Instant::now);
+                    }
                 }
             }
             thread_ids
@@ -374,6 +446,34 @@ impl ThreadStateManager {
                         .is_some_and(|thread_entry| thread_entry.connection_ids.is_empty())
                 })
                 .collect::<Vec<_>>()
+        }
+    }
+
+    pub(crate) async fn thread_idle_unload_wait(
+        &self,
+        thread_id: ThreadId,
+        idle_timeout: Duration,
+    ) -> ThreadIdleUnloadWait {
+        let state = self.state.lock().await;
+        let Some(thread_entry) = state.threads.get(&thread_id) else {
+            return ThreadIdleUnloadWait::Missing;
+        };
+        if !thread_entry.connection_ids.is_empty() {
+            return ThreadIdleUnloadWait::HasSubscribers;
+        }
+        let Some(no_subscribers_since) = thread_entry.no_subscribers_since else {
+            return ThreadIdleUnloadWait::HasSubscribers;
+        };
+        let idle_since = if thread_entry.last_activity_at > no_subscribers_since {
+            thread_entry.last_activity_at
+        } else {
+            no_subscribers_since
+        };
+        let idle_duration = idle_since.elapsed();
+        if idle_duration >= idle_timeout {
+            ThreadIdleUnloadWait::Ready
+        } else {
+            ThreadIdleUnloadWait::Wait(idle_timeout.saturating_sub(idle_duration))
         }
     }
 }

--- a/codex-rs/app-server/src/thread_status.rs
+++ b/codex-rs/app-server/src/thread_status.rs
@@ -8,6 +8,7 @@ use codex_app_server_protocol::Thread;
 use codex_app_server_protocol::ThreadActiveFlag;
 use codex_app_server_protocol::ThreadStatus;
 use codex_app_server_protocol::ThreadStatusChangedNotification;
+use codex_protocol::ThreadId;
 use std::collections::HashMap;
 #[cfg(test)]
 use std::path::PathBuf;
@@ -244,6 +245,13 @@ impl ThreadWatchManager {
         }
     }
 
+    pub(crate) async fn subscribe(
+        &self,
+        thread_id: ThreadId,
+    ) -> Option<watch::Receiver<ThreadStatus>> {
+        Some(self.state.lock().await.subscribe(thread_id.to_string()))
+    }
+
     async fn note_active_guard_released(
         &self,
         thread_id: String,
@@ -295,6 +303,7 @@ pub(crate) fn resolve_thread_status(
 #[derive(Default)]
 struct ThreadWatchState {
     runtime_by_thread_id: HashMap<String, RuntimeFacts>,
+    status_watcher_by_thread_id: HashMap<String, watch::Sender<ThreadStatus>>,
 }
 
 impl ThreadWatchState {
@@ -309,6 +318,7 @@ impl ThreadWatchState {
             .entry(thread_id.clone())
             .or_default();
         runtime.is_loaded = true;
+        self.update_status_watcher_for_thread(&thread_id);
         if emit_notification {
             self.status_changed_notification(thread_id, previous_status)
         } else {
@@ -319,6 +329,7 @@ impl ThreadWatchState {
     fn remove_thread(&mut self, thread_id: &str) -> Option<ThreadStatusChangedNotification> {
         let previous_status = self.status_for(thread_id);
         self.runtime_by_thread_id.remove(thread_id);
+        self.update_status_watcher(thread_id, &ThreadStatus::NotLoaded);
         if previous_status.is_some() && previous_status != Some(ThreadStatus::NotLoaded) {
             Some(ThreadStatusChangedNotification {
                 thread_id: thread_id.to_string(),
@@ -344,6 +355,7 @@ impl ThreadWatchState {
             .or_default();
         runtime.is_loaded = true;
         mutate(runtime);
+        self.update_status_watcher_for_thread(thread_id);
         self.status_changed_notification(thread_id.to_string(), previous_status)
     }
 
@@ -356,6 +368,40 @@ impl ThreadWatchState {
     fn loaded_status_for_thread(&self, thread_id: &str) -> ThreadStatus {
         self.status_for(thread_id)
             .unwrap_or(ThreadStatus::NotLoaded)
+    }
+
+    fn subscribe(&mut self, thread_id: String) -> watch::Receiver<ThreadStatus> {
+        let status = self.loaded_status_for_thread(&thread_id);
+        let sender = self
+            .status_watcher_by_thread_id
+            .entry(thread_id)
+            .or_insert_with(|| watch::channel(status.clone()).0);
+        sender.subscribe()
+    }
+
+    fn update_status_watcher_for_thread(&mut self, thread_id: &str) {
+        let status = self.loaded_status_for_thread(thread_id);
+        self.update_status_watcher(thread_id, &status);
+    }
+
+    fn update_status_watcher(&mut self, thread_id: &str, status: &ThreadStatus) {
+        let remove_watcher = if let Some(sender) = self.status_watcher_by_thread_id.get(thread_id) {
+            let status = status.clone();
+            let _ = sender.send_if_modified(|current| {
+                if *current == status {
+                    false
+                } else {
+                    *current = status;
+                    true
+                }
+            });
+            sender.receiver_count() == 0
+        } else {
+            false
+        };
+        if remove_watcher {
+            self.status_watcher_by_thread_id.remove(thread_id);
+        }
     }
 
     fn status_changed_notification(
@@ -750,6 +796,55 @@ mod tests {
                 },
             },
         );
+    }
+
+    #[tokio::test]
+    async fn status_watchers_receive_only_their_thread_updates() {
+        let manager = ThreadWatchManager::new();
+        manager
+            .upsert_thread(test_thread(
+                INTERACTIVE_THREAD_ID,
+                codex_app_server_protocol::SessionSource::Cli,
+            ))
+            .await;
+        manager
+            .upsert_thread(test_thread(
+                NON_INTERACTIVE_THREAD_ID,
+                codex_app_server_protocol::SessionSource::AppServer,
+            ))
+            .await;
+        let interactive_thread_id = ThreadId::from_string(INTERACTIVE_THREAD_ID)
+            .expect("interactive thread id should parse");
+        let non_interactive_thread_id = ThreadId::from_string(NON_INTERACTIVE_THREAD_ID)
+            .expect("non-interactive thread id should parse");
+        let mut interactive_rx = manager
+            .subscribe(interactive_thread_id)
+            .await
+            .expect("interactive status watcher should subscribe");
+        let mut non_interactive_rx = manager
+            .subscribe(non_interactive_thread_id)
+            .await
+            .expect("non-interactive status watcher should subscribe");
+
+        manager.note_turn_started(INTERACTIVE_THREAD_ID).await;
+
+        timeout(Duration::from_secs(1), interactive_rx.changed())
+            .await
+            .expect("timed out waiting for interactive status update")
+            .expect("interactive status watcher should remain open");
+        assert_eq!(
+            *interactive_rx.borrow(),
+            ThreadStatus::Active {
+                active_flags: vec![],
+            },
+        );
+        assert!(
+            timeout(Duration::from_millis(100), non_interactive_rx.changed())
+                .await
+                .is_err(),
+            "unrelated thread watcher should not receive an update"
+        );
+        assert_eq!(*non_interactive_rx.borrow(), ThreadStatus::Idle);
     }
 
     async fn wait_for_status(

--- a/codex-rs/app-server/tests/suite/v2/connection_handling_websocket.rs
+++ b/codex-rs/app-server/tests/suite/v2/connection_handling_websocket.rs
@@ -338,7 +338,8 @@ async fn websocket_transport_allows_unauthenticated_non_loopback_startup_by_defa
 }
 
 #[tokio::test]
-async fn websocket_disconnect_unloads_last_subscribed_thread() -> Result<()> {
+async fn websocket_disconnect_keeps_last_subscribed_thread_loaded_until_idle_timeout() -> Result<()>
+{
     let server = create_mock_responses_server_sequence_unchecked(Vec::new()).await;
     let codex_home = TempDir::new()?;
     create_config_toml(codex_home.path(), &server.uri(), "never")?;
@@ -359,7 +360,7 @@ async fn websocket_disconnect_unloads_last_subscribed_thread() -> Result<()> {
     send_initialize_request(&mut ws2, /*id*/ 4, "ws_reconnect_client").await?;
     read_response_for_id(&mut ws2, /*id*/ 4).await?;
 
-    wait_for_loaded_threads(&mut ws2, /*first_id*/ 5, &[]).await?;
+    wait_for_loaded_threads(&mut ws2, /*first_id*/ 5, &[thread_id.as_str()]).await?;
 
     process
         .kill()

--- a/codex-rs/app-server/tests/suite/v2/thread_unsubscribe.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_unsubscribe.rs
@@ -7,10 +7,8 @@ use app_test_support::create_mock_responses_server_sequence_unchecked;
 use app_test_support::create_shell_command_sse_response;
 use app_test_support::to_response;
 use codex_app_server_protocol::ItemStartedNotification;
-use codex_app_server_protocol::JSONRPCNotification;
 use codex_app_server_protocol::JSONRPCResponse;
 use codex_app_server_protocol::RequestId;
-use codex_app_server_protocol::ServerNotification;
 use codex_app_server_protocol::ThreadItem;
 use codex_app_server_protocol::ThreadLoadedListParams;
 use codex_app_server_protocol::ThreadLoadedListResponse;
@@ -21,7 +19,6 @@ use codex_app_server_protocol::ThreadResumeResponse;
 use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
 use codex_app_server_protocol::ThreadStatus;
-use codex_app_server_protocol::ThreadStatusChangedNotification;
 use codex_app_server_protocol::ThreadUnsubscribeParams;
 use codex_app_server_protocol::ThreadUnsubscribeResponse;
 use codex_app_server_protocol::ThreadUnsubscribeStatus;
@@ -81,7 +78,7 @@ async fn wait_for_responses_request_count_to_stabilize(
 }
 
 #[tokio::test]
-async fn thread_unsubscribe_unloads_thread_and_emits_thread_closed_notification() -> Result<()> {
+async fn thread_unsubscribe_keeps_thread_loaded_until_idle_timeout() -> Result<()> {
     let server = create_mock_responses_server_repeating_assistant("Done").await;
     let codex_home = TempDir::new()?;
     create_config_toml(codex_home.path(), &server.uri())?;
@@ -104,20 +101,14 @@ async fn thread_unsubscribe_unloads_thread_and_emits_thread_closed_notification(
     let unsubscribe = to_response::<ThreadUnsubscribeResponse>(unsubscribe_resp)?;
     assert_eq!(unsubscribe.status, ThreadUnsubscribeStatus::Unsubscribed);
 
-    let closed_notif: JSONRPCNotification = timeout(
-        DEFAULT_READ_TIMEOUT,
-        mcp.read_stream_until_notification_message("thread/closed"),
-    )
-    .await??;
-    let parsed: ServerNotification = closed_notif.try_into()?;
-    let ServerNotification::ThreadClosed(payload) = parsed else {
-        anyhow::bail!("expected thread/closed notification");
-    };
-    assert_eq!(payload.thread_id, thread_id);
-
-    let status_changed = wait_for_thread_status_not_loaded(&mut mcp, &payload.thread_id).await?;
-    assert_eq!(status_changed.thread_id, payload.thread_id);
-    assert_eq!(status_changed.status, ThreadStatus::NotLoaded);
+    assert!(
+        timeout(
+            std::time::Duration::from_millis(250),
+            mcp.read_stream_until_notification_message("thread/closed"),
+        )
+        .await
+        .is_err()
+    );
 
     let list_id = mcp
         .send_thread_loaded_list_request(ThreadLoadedListParams::default())
@@ -129,22 +120,22 @@ async fn thread_unsubscribe_unloads_thread_and_emits_thread_closed_notification(
     .await??;
     let ThreadLoadedListResponse { data, next_cursor } =
         to_response::<ThreadLoadedListResponse>(list_resp)?;
-    assert_eq!(data, Vec::<String>::new());
+    assert_eq!(data, vec![thread_id]);
     assert_eq!(next_cursor, None);
 
     Ok(())
 }
 
 #[tokio::test]
-async fn thread_unsubscribe_during_turn_interrupts_turn_and_emits_thread_closed() -> Result<()> {
+async fn thread_unsubscribe_during_turn_keeps_turn_running() -> Result<()> {
     #[cfg(target_os = "windows")]
     let shell_command = vec![
         "powershell".to_string(),
         "-Command".to_string(),
-        "Start-Sleep -Seconds 10".to_string(),
+        "Start-Sleep -Seconds 1".to_string(),
     ];
     #[cfg(not(target_os = "windows"))]
-    let shell_command = vec!["sleep".to_string(), "10".to_string()];
+    let shell_command = vec!["sleep".to_string(), "1".to_string()];
 
     let tmp = TempDir::new()?;
     let codex_home = tmp.path().join("codex_home");
@@ -206,20 +197,18 @@ async fn thread_unsubscribe_during_turn_interrupts_turn_and_emits_thread_closed(
     let unsubscribe = to_response::<ThreadUnsubscribeResponse>(unsubscribe_resp)?;
     assert_eq!(unsubscribe.status, ThreadUnsubscribeStatus::Unsubscribed);
 
-    let closed_notif: JSONRPCNotification = timeout(
-        DEFAULT_READ_TIMEOUT,
-        mcp.read_stream_until_notification_message("thread/closed"),
-    )
-    .await??;
-    let parsed: ServerNotification = closed_notif.try_into()?;
-    let ServerNotification::ThreadClosed(payload) = parsed else {
-        anyhow::bail!("expected thread/closed notification");
-    };
-    assert_eq!(payload.thread_id, thread_id);
+    assert!(
+        timeout(
+            std::time::Duration::from_millis(250),
+            mcp.read_stream_until_notification_message("thread/closed"),
+        )
+        .await
+        .is_err()
+    );
 
     wait_for_responses_request_count_to_stabilize(
         &server,
-        /*expected_count*/ 1,
+        /*expected_count*/ 2,
         std::time::Duration::from_millis(200),
     )
     .await?;
@@ -228,7 +217,7 @@ async fn thread_unsubscribe_during_turn_interrupts_turn_and_emits_thread_closed(
 }
 
 #[tokio::test]
-async fn thread_unsubscribe_clears_cached_status_before_resume() -> Result<()> {
+async fn thread_unsubscribe_preserves_cached_status_before_idle_unload() -> Result<()> {
     let server = responses::start_mock_server().await;
     let _response_mock = responses::mount_sse_once(
         &server,
@@ -291,11 +280,14 @@ async fn thread_unsubscribe_clears_cached_status_before_resume() -> Result<()> {
     .await??;
     let unsubscribe = to_response::<ThreadUnsubscribeResponse>(unsubscribe_resp)?;
     assert_eq!(unsubscribe.status, ThreadUnsubscribeStatus::Unsubscribed);
-    timeout(
-        DEFAULT_READ_TIMEOUT,
-        mcp.read_stream_until_notification_message("thread/closed"),
-    )
-    .await??;
+    assert!(
+        timeout(
+            std::time::Duration::from_millis(250),
+            mcp.read_stream_until_notification_message("thread/closed"),
+        )
+        .await
+        .is_err()
+    );
 
     let resume_id = mcp
         .send_thread_resume_request(ThreadResumeParams {
@@ -309,13 +301,13 @@ async fn thread_unsubscribe_clears_cached_status_before_resume() -> Result<()> {
     )
     .await??;
     let resume: ThreadResumeResponse = to_response::<ThreadResumeResponse>(resume_resp)?;
-    assert_eq!(resume.thread.status, ThreadStatus::Idle);
+    assert_eq!(resume.thread.status, ThreadStatus::SystemError);
 
     Ok(())
 }
 
 #[tokio::test]
-async fn thread_unsubscribe_reports_not_loaded_after_thread_is_unloaded() -> Result<()> {
+async fn thread_unsubscribe_reports_not_subscribed_before_idle_unload() -> Result<()> {
     let server = create_mock_responses_server_repeating_assistant("Done").await;
     let codex_home = TempDir::new()?;
     create_config_toml(codex_home.path(), &server.uri())?;
@@ -341,12 +333,6 @@ async fn thread_unsubscribe_reports_not_loaded_after_thread_is_unloaded() -> Res
         ThreadUnsubscribeStatus::Unsubscribed
     );
 
-    timeout(
-        DEFAULT_READ_TIMEOUT,
-        mcp.read_stream_until_notification_message("thread/closed"),
-    )
-    .await??;
-
     let second_unsubscribe_id = mcp
         .send_thread_unsubscribe_request(ThreadUnsubscribeParams { thread_id })
         .await?;
@@ -358,7 +344,7 @@ async fn thread_unsubscribe_reports_not_loaded_after_thread_is_unloaded() -> Res
     let second_unsubscribe = to_response::<ThreadUnsubscribeResponse>(second_unsubscribe_resp)?;
     assert_eq!(
         second_unsubscribe.status,
-        ThreadUnsubscribeStatus::NotLoaded
+        ThreadUnsubscribeStatus::NotSubscribed
     );
 
     Ok(())
@@ -373,28 +359,6 @@ async fn wait_for_command_execution_item_started(mcp: &mut McpProcess) -> Result
         let started: ItemStartedNotification = serde_json::from_value(started_params)?;
         if let ThreadItem::CommandExecution { .. } = started.item {
             return Ok(());
-        }
-    }
-}
-
-async fn wait_for_thread_status_not_loaded(
-    mcp: &mut McpProcess,
-    thread_id: &str,
-) -> Result<ThreadStatusChangedNotification> {
-    loop {
-        let status_changed_notif: JSONRPCNotification = timeout(
-            DEFAULT_READ_TIMEOUT,
-            mcp.read_stream_until_notification_message("thread/status/changed"),
-        )
-        .await??;
-        let status_changed_params = status_changed_notif
-            .params
-            .context("thread/status/changed params must be present")?;
-        let status_changed: ThreadStatusChangedNotification =
-            serde_json::from_value(status_changed_params)?;
-        if status_changed.thread_id == thread_id && status_changed.status == ThreadStatus::NotLoaded
-        {
-            return Ok(status_changed);
         }
     }
 }


### PR DESCRIPTION
Currently app-server may unload actively running threads once the last connection disconnects, which is not expected.
Instead track when was the last active turn & when there were any subscribers the last time, also add 30 minute idleness/no subscribers timer to reduce the churn.