### PR TITLE
Fix Windows exec-server output test flake

### DIFF
--- a/codex-rs/exec-server/src/server/handler/tests.rs
+++ b/codex-rs/exec-server/src/server/handler/tests.rs
@@ -275,7 +275,7 @@ async fn output_and_exit_are_retained_after_notification_receiver_closes() {
             process_id.as_str(),
             shell_argv(
                 "sleep 0.05; printf 'first\\n'; sleep 0.05; printf 'second\\n'",
-                "echo first && ping -n 2 127.0.0.1 >NUL && echo second",
+                "echo first&& ping -n 2 127.0.0.1 >NUL&& echo second",
             ),
         ))
         .await


### PR DESCRIPTION
Problem: The Windows exec-server test command could let separator whitespace become part of `echo` output, making the exact retained-output assertion flaky.

Solution: Tighten the Windows `cmd.exe` command by placing command separators directly after the echoed tokens so stdout remains deterministic while preserving the exact assertion.