### PR TITLE
Stabilize marketplace add local source test

### DIFF
--- a/codex-rs/cli/tests/marketplace_add.rs
+++ b/codex-rs/cli/tests/marketplace_add.rs
@@ -41,9 +41,12 @@ async fn marketplace_add_rejects_local_directory_source() -> Result<()> {
     let codex_home = TempDir::new()?;
     let source = TempDir::new()?;
     write_marketplace_source(source.path(), "local ref")?;
+    let source_parent = source.path().parent().unwrap();
+    let source_arg = format!("./{}", source.path().file_name().unwrap().to_string_lossy());
 
     codex_command(codex_home.path())?
-        .args(["marketplace", "add", source.path().to_str().unwrap()])
+        .current_dir(source_parent)
+        .args(["marketplace", "add", source_arg.as_str()])
         .assert()
         .failure()
         .stderr(contains(


### PR DESCRIPTION
## Summary
- Update the marketplace add local-source integration test to pass an explicit relative local path. Fix a failing test `marketplace_add_rejects_local_directory_source`
- Keep the change test-only; no CLI source parsing behavior changes.

## Tests
- cargo fmt -p codex-cli
- cargo test -p codex-cli --test marketplace_add

## Impact
- Production behavior is unchanged.
- No impact to feedback upload logic, DAGs, exports, or downstream pipelines.