### PR TITLE
Fix Windows marketplace add CI failure

### DIFF
--- a/.github/scripts/run-bazel-ci.sh
+++ b/.github/scripts/run-bazel-ci.sh
@@ -69,12 +69,33 @@ print_bazel_test_log_tails() {
   local console_log="$1"
   local testlogs_dir
   local -a bazel_info_cmd=(bazel)
+  local -a bazel_info_args=(info)
 
   if (( ${#bazel_startup_args[@]} > 0 )); then
     bazel_info_cmd+=("${bazel_startup_args[@]}")
   fi
 
-  testlogs_dir="$(run_bazel "${bazel_info_cmd[@]:1}" info bazel-testlogs 2>/dev/null || echo bazel-testlogs)"
+  for arg in "${bazel_args[@]:1}"; do
+    case "$arg" in
+      --config=*|--host_platform=*|--platforms=*|--cpu=*|--compilation_mode=*|-c)
+        bazel_info_args+=("$arg")
+        ;;
+    esac
+  done
+
+  if [[ -n "${BUILDBUDDY_API_KEY:-}" ]]; then
+    bazel_info_args+=("--config=${ci_config}")
+  fi
+
+  for arg in "${post_config_bazel_args[@]}"; do
+    case "$arg" in
+      --host_platform=*|--platforms=*|--cpu=*|--compilation_mode=*|-c)
+        bazel_info_args+=("$arg")
+        ;;
+    esac
+  done
+
+  testlogs_dir="$(run_bazel "${bazel_info_cmd[@]:1}" "${bazel_info_args[@]}" bazel-testlogs 2>/dev/null || echo bazel-testlogs)"
 
   local failed_targets=()
   while IFS= read -r target; do
@@ -93,7 +114,17 @@ print_bazel_test_log_tails() {
   for target in "${failed_targets[@]}"; do
     local rel_path="${target#//}"
     rel_path="${rel_path/:/\/}"
+    local reported_test_log
+    reported_test_log="$(
+      { grep -F "/${rel_path}/test.log" "$console_log" || true; } \
+        | tail -n 1 \
+        | tr -d '\r' \
+        | sed -n -E 's#^.*((/|[A-Za-z]:/)[^[:space:])]+/test\.log).*$#\1#p'
+    )"
     local test_log="${testlogs_dir}/${rel_path}/test.log"
+    if [[ -f "$reported_test_log" ]]; then
+      test_log="$reported_test_log"
+    fi
 
     echo "::group::Bazel test log tail for ${target}"
     if [[ -f "$test_log" ]]; then

--- a/codex-rs/cli/src/marketplace_cmd.rs
+++ b/codex-rs/cli/src/marketplace_cmd.rs
@@ -262,12 +262,15 @@ fn normalize_git_url(url: &str) -> String {
 }
 
 fn looks_like_local_path(source: &str) -> bool {
+    let bytes = source.as_bytes();
     source.starts_with("./")
         || source.starts_with("../")
         || source.starts_with('/')
+        || source.starts_with('\\')
         || source.starts_with("~/")
         || source == "."
         || source == ".."
+        || matches!(bytes, [drive, b':', b'/' | b'\\', ..] if drive.is_ascii_alphabetic())
 }
 
 fn is_ssh_git_url(source: &str) -> bool {
@@ -495,6 +498,21 @@ mod tests {
     #[test]
     fn local_path_source_is_rejected() {
         let err = parse_marketplace_source("./marketplace", /*explicit_ref*/ None).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("local marketplace sources are not supported yet"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn windows_absolute_path_source_is_rejected_as_local() {
+        let err = parse_marketplace_source(
+            r"C:\Users\runneradmin\AppData\Local\Temp\marketplace",
+            /*explicit_ref*/ None,
+        )
+        .unwrap_err();
 
         assert!(
             err.to_string()


### PR DESCRIPTION
Problem: Windows Bazel CI failed because `marketplace add` classified native `C:\...\` temp paths as invalid marketplace sources, and the CI wrapper tailed logs from the wrong configured output tree.

Solution: Recognize Windows absolute/local path forms as unsupported local marketplace sources and make the Bazel CI wrapper locate failed-test logs from the matching Bazel configuration or reported log path.