### PR TITLE
Update issue labeler agent labels

### DIFF
--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -44,6 +44,7 @@ jobs:
             6. iOS — Issues with the Codex iOS app.
 
             - Additionally add zero or more of the following labels that are relevant to the issue content. Prefer a small set of precise labels over many broad ones.
+            - For agent-area issues, prefer the most specific applicable label. Use "agent" only as a fallback for agent-related issues that do not fit a more specific agent-area label. Prefer "app-server" over "session" or "config" when the issue is about app-server protocol, API, RPC, schema, launch, or bridge behavior.
             1. windows-os — Bugs or friction specific to Windows environments (always when PowerShell is mentioned, path handling, copy/paste, OS-specific auth or tooling failures).
             2. mcp — Topics involving Model Context Protocol servers/clients.
             3. mcp-server — Problems related to the codex mcp-server command, where codex runs as an MCP server.
@@ -61,6 +62,13 @@ jobs:
             15. sandbox - Issues related to local sandbox environments or tool call approvals to override sandbox restrictions.
             16. tool-calls - Problems related to specific tool call invocations including unexpected errors, failures, or hangs.
             17. TUI - Problems with the terminal user interface (TUI) including keyboard shortcuts, copy & pasting, menus, or screen update issues.
+            18. app-server - Issues involving the app-server protocol or interfaces, including SDK/API payloads, thread/* and turn/* RPCs, app-server launch behavior, external app/controller bridges, and app-server protocol/schema behavior.
+            19. connectivity - Network connectivity or endpoint issues, including reconnecting messages, stream dropped/disconnected errors, websocket/SSE/transport failures, timeout/network/VPN/proxy/API endpoint failures, and related retry behavior.
+            20. subagent - Issues involving subagents, sub-agents, or multi-agent behavior, including spawn_agent, wait_agent, close_agent, worker/explorer roles, delegation, agent teams, lifecycle, model/config inheritance, quotas, and orchestration.
+            21. session - Issues involving session or thread management, including resume, fork, archive, rename/title, thread history, rollout persistence, compaction, checkpoints, retention, and cross-session state.
+            22. config - Issues involving config.toml, config keys, config key merging, config updates, profiles, hooks config, project config, agent role TOMLs, instruction/personality config, and config schema behavior.
+            23. plan - Issues involving plan mode, planning workflows, or plan-specific tools/behavior.
+            24. agent - Fallback only for core agent loop or agent-related issues that do not fit app-server, connectivity, subagent, session, config, or plan.
 
             Issue number: ${{ github.event.issue.number }}
 


### PR DESCRIPTION
Problem: The automatic issue labeler still treated agent-related issues as one broad category, even though more specific agent-area labels now exist.

Solution: Update the issue labeler prompt to prefer the new agent-area labels and keep "agent" as the fallback for uncategorized core agent issues.