### PR TITLE
Mirror user text into realtime

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/realtime_conversation.rs
+++ b/codex-rs/app-server/tests/suite/v2/realtime_conversation.rs
@@ -1148,7 +1148,6 @@ async fn webrtc_v2_forwards_audio_and_text_between_client_and_sideband() -> Resu
                     "samples_per_channel": 512
                 }),
             ],
-            vec![],
         ])]),
     )
     .await?;
@@ -1217,7 +1216,6 @@ async fn webrtc_v2_text_input_is_append_only_while_response_is_active() -> Resul
         no_main_loop_responses(),
         realtime_sideband(vec![realtime_sideband_connection(vec![
             vec![session_updated("sess_v2_response_queue")],
-            vec![],
             vec![
                 json!({
                     "type": "response.created",
@@ -1233,7 +1231,6 @@ async fn webrtc_v2_text_input_is_append_only_while_response_is_active() -> Resul
                 "type": "response.done",
                 "response": { "id": "resp_active" }
             })],
-            vec![],
         ])]),
     )
     .await?;
@@ -1293,7 +1290,6 @@ async fn webrtc_v2_text_input_is_append_only_when_response_is_cancelled() -> Res
         no_main_loop_responses(),
         realtime_sideband(vec![realtime_sideband_connection(vec![
             vec![session_updated("sess_v2_response_cancel_queue")],
-            vec![],
             vec![json!({
                 "type": "response.created",
                 "response": { "id": "resp_cancelled" }
@@ -1303,7 +1299,6 @@ async fn webrtc_v2_text_input_is_append_only_when_response_is_cancelled() -> Res
                 "type": "response.cancelled",
                 "response": { "id": "resp_cancelled" }
             })],
-            vec![],
         ])]),
     )
     .await?;

--- a/codex-rs/app-server/tests/suite/v2/realtime_conversation.rs
+++ b/codex-rs/app-server/tests/suite/v2/realtime_conversation.rs
@@ -661,7 +661,7 @@ async fn realtime_conversation_streams_v2_notifications() -> Result<()> {
     let connections = realtime_server.connections();
     assert_eq!(connections.len(), 1);
     let connection = &connections[0];
-    assert_eq!(connection.len(), 4);
+    assert_eq!(connection.len(), 3);
     assert_eq!(
         connection[0].body_json()["type"].as_str(),
         Some("session.update")
@@ -679,10 +679,6 @@ async fn realtime_conversation_streams_v2_notifications() -> Result<()> {
             .as_str()
             .context("expected websocket request type")?
             .to_string(),
-        connection[3].body_json()["type"]
-            .as_str()
-            .context("expected websocket request type")?
-            .to_string(),
     ];
     request_types.sort();
     assert_eq!(
@@ -690,7 +686,6 @@ async fn realtime_conversation_streams_v2_notifications() -> Result<()> {
         [
             "conversation.item.create".to_string(),
             "input_audio_buffer.append".to_string(),
-            "response.create".to_string(),
         ]
     );
 
@@ -1185,7 +1180,6 @@ async fn webrtc_v2_forwards_audio_and_text_between_client_and_sideband() -> Resu
     let requests = [
         harness.sideband_outbound_request(/*request_index*/ 1).await,
         harness.sideband_outbound_request(/*request_index*/ 2).await,
-        harness.sideband_outbound_request(/*request_index*/ 3).await,
     ];
     assert!(
         requests
@@ -1208,13 +1202,12 @@ async fn webrtc_v2_forwards_audio_and_text_between_client_and_sideband() -> Resu
     Ok(())
 }
 
-/// Regression coverage for Realtime V2's single-active-response rule.
+/// Regression coverage for Realtime V2 text input while a response is active.
 ///
-/// The Realtime API rejects a new `response.create` while a default response is
-/// still active, so the input task should queue the second create and flush it
-/// only after the server sends `response.done` for the active response.
+/// Text input is append-only, so app-server should send the user message without
+/// requesting a new realtime response.
 #[tokio::test]
-async fn webrtc_v2_queues_text_response_create_while_response_is_active() -> Result<()> {
+async fn webrtc_v2_text_input_is_append_only_while_response_is_active() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
     // Phase 1: script a server-side response that becomes active after the first
@@ -1253,15 +1246,14 @@ async fn webrtc_v2_queues_text_response_create_while_response_is_active() -> Res
     // notifications; they are the protocol frames app-server sends upstream.
     assert_v2_session_update(&harness.sideband_outbound_request(/*request_index*/ 0).await)?;
 
-    // Phase 2: send the first text turn. It is safe to emit `response.create`
-    // immediately because no default response is active yet.
+    // Phase 2: send the first text turn. Text input is append-only, so this
+    // sends only the user text item.
     let thread_id = started.started.thread_id.clone();
     harness.append_text(thread_id.clone(), "first").await?;
     assert_v2_user_text_item(
         &harness.sideband_outbound_request(/*request_index*/ 1).await,
         "first",
     );
-    assert_v2_response_create(&harness.sideband_outbound_request(/*request_index*/ 2).await);
     let transcript = harness
         .read_notification::<ThreadRealtimeTranscriptUpdatedNotification>(
             "thread/realtime/transcriptUpdated",
@@ -1270,39 +1262,28 @@ async fn webrtc_v2_queues_text_response_create_while_response_is_active() -> Res
     assert_eq!(transcript.text, "active response started");
 
     // Phase 3: send a second text turn while `resp_active` is still open. The
-    // user message must reach realtime, but `response.create` must not be sent
-    // yet or the Realtime API rejects it as an active-response conflict.
+    // user message must reach realtime without requesting another response.
     harness.append_text(thread_id.clone(), "second").await?;
     assert_v2_user_text_item(
-        &harness.sideband_outbound_request(/*request_index*/ 3).await,
+        &harness.sideband_outbound_request(/*request_index*/ 2).await,
         "second",
     );
 
-    // Phase 4: the audio input causes the scripted sideband stream to send
-    // `response.done`, which clears the active response and flushes the queued
-    // `response.create` for the second text turn.
+    // Phase 4: audio still forwards normally after text input.
     harness.append_audio(thread_id).await?;
 
-    // This is the negative check: if the second text turn had emitted
-    // `response.create` immediately, request 4 would be that create instead of
-    // the audio append.
-    let audio = harness.sideband_outbound_request(/*request_index*/ 4).await;
+    let audio = harness.sideband_outbound_request(/*request_index*/ 3).await;
     assert_eq!(audio["type"], "input_audio_buffer.append");
     assert_eq!(audio["audio"], "BQYH");
-    assert_v2_response_create(&harness.sideband_outbound_request(/*request_index*/ 5).await);
 
     harness.shutdown().await;
     Ok(())
 }
 
-/// Regression coverage for the same queued `response.create` path when the
-/// active Realtime V2 response is cancelled instead of completed.
-///
-/// `response.cancelled` should clear the active-response guard exactly like
-/// `response.done`, so a text turn queued during the active response still gets
-/// one deferred `response.create`.
+/// Regression coverage for append-only Realtime V2 text input when the active
+/// response is cancelled instead of completed.
 #[tokio::test]
-async fn webrtc_v2_flushes_queued_text_response_create_when_response_is_cancelled() -> Result<()> {
+async fn webrtc_v2_text_input_is_append_only_when_response_is_cancelled() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
     // Phase 1: script a server-side response that becomes active after the first
@@ -1331,36 +1312,29 @@ async fn webrtc_v2_flushes_queued_text_response_create_when_response_is_cancelle
     assert_eq!(started.started.version, RealtimeConversationVersion::V2);
     assert_v2_session_update(&harness.sideband_outbound_request(/*request_index*/ 0).await)?;
 
-    // Phase 2: send the first text turn. It is safe to emit `response.create`
-    // immediately because no default response is active yet.
+    // Phase 2: send the first text turn. Text input is append-only, so this
+    // sends only the user text item.
     let thread_id = started.started.thread_id.clone();
     harness.append_text(thread_id.clone(), "first").await?;
     assert_v2_user_text_item(
         &harness.sideband_outbound_request(/*request_index*/ 1).await,
         "first",
     );
-    assert_v2_response_create(&harness.sideband_outbound_request(/*request_index*/ 2).await);
 
     // Phase 3: send a second text turn while `resp_cancelled` is still open.
-    // The user message must reach realtime, but `response.create` stays queued.
+    // The user message must reach realtime without requesting another response.
     harness.append_text(thread_id.clone(), "second").await?;
     assert_v2_user_text_item(
-        &harness.sideband_outbound_request(/*request_index*/ 3).await,
+        &harness.sideband_outbound_request(/*request_index*/ 2).await,
         "second",
     );
 
-    // Phase 4: the audio input causes the scripted sideband stream to send
-    // `response.cancelled`, which clears the active response and flushes the
-    // queued `response.create` for the second text turn.
+    // Phase 4: audio still forwards normally after text input.
     harness.append_audio(thread_id).await?;
 
-    // This is the negative check: if the second text turn had emitted
-    // `response.create` immediately, request 4 would be that create instead of
-    // the audio append.
-    let audio = harness.sideband_outbound_request(/*request_index*/ 4).await;
+    let audio = harness.sideband_outbound_request(/*request_index*/ 3).await;
     assert_eq!(audio["type"], "input_audio_buffer.append");
     assert_eq!(audio["audio"], "BQYH");
-    assert_v2_response_create(&harness.sideband_outbound_request(/*request_index*/ 5).await);
 
     harness.shutdown().await;
     Ok(())

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -4916,7 +4916,6 @@ mod handlers {
     use codex_rmcp_client::ElicitationAction;
     use codex_rmcp_client::ElicitationResponse;
     use serde_json::Value;
-    use std::collections::HashMap;
     use std::path::PathBuf;
     use std::sync::Arc;
     use tracing::debug;
@@ -4960,29 +4959,23 @@ mod handlers {
         }
     }
 
-    struct PreparedUserInputOrTurn {
-        items: Vec<UserInput>,
-        updates: SessionSettingsUpdate,
-        responsesapi_client_metadata: Option<HashMap<String, String>>,
-    }
-
     pub async fn user_input_or_turn(sess: &Arc<Session>, sub_id: String, op: Op) {
-        let prepared = prepare_user_input_or_turn(op);
-        let text = UserMessageItem::new(&prepared.items).message();
+        let items = match &op {
+            Op::UserTurn { items, .. } | Op::UserInput { items, .. } => items,
+            _ => unreachable!(),
+        };
+        let text = UserMessageItem::new(items).message();
         let realtime_text = (!text.is_empty()).then_some(text);
-        run_user_input_or_turn(sess, sub_id, prepared, realtime_text).await;
+        if user_input_or_turn_without_realtime_text_mirror(sess, sub_id, op).await {
+            mirror_user_text_to_realtime(sess, realtime_text).await;
+        }
     }
 
     pub(super) async fn user_input_or_turn_without_realtime_text_mirror(
         sess: &Arc<Session>,
         sub_id: String,
         op: Op,
-    ) {
-        let prepared = prepare_user_input_or_turn(op);
-        run_user_input_or_turn(sess, sub_id, prepared, /*realtime_text*/ None).await;
-    }
-
-    fn prepare_user_input_or_turn(op: Op) -> PreparedUserInputOrTurn {
+    ) -> bool {
         let (items, updates, responsesapi_client_metadata) = match op {
             Op::UserTurn {
                 cwd,
@@ -5041,27 +5034,10 @@ mod handlers {
             ),
             _ => unreachable!(),
         };
-        PreparedUserInputOrTurn {
-            items,
-            updates,
-            responsesapi_client_metadata,
-        }
-    }
 
-    async fn run_user_input_or_turn(
-        sess: &Arc<Session>,
-        sub_id: String,
-        prepared: PreparedUserInputOrTurn,
-        realtime_text: Option<String>,
-    ) {
-        let PreparedUserInputOrTurn {
-            items,
-            updates,
-            responsesapi_client_metadata,
-        } = prepared;
         let Ok(current_context) = sess.new_turn_with_sub_id(sub_id.clone(), updates).await else {
             // new_turn_with_sub_id already emits the error event.
-            return;
+            return false;
         };
         sess.maybe_emit_unknown_model_warning_for_turn(current_context.as_ref())
             .await;
@@ -5075,7 +5051,7 @@ mod handlers {
         {
             Ok(_) => {
                 current_context.session_telemetry.user_prompt(&items);
-                mirror_user_text_to_realtime(sess, realtime_text).await;
+                true
             }
             Err(SteerInputError::NoActiveTurn(items)) => {
                 if let Some(responsesapi_client_metadata) = responsesapi_client_metadata {
@@ -5092,7 +5068,7 @@ mod handlers {
                     crate::tasks::RegularTask::new(),
                 )
                 .await;
-                mirror_user_text_to_realtime(sess, realtime_text).await;
+                true
             }
             Err(err) => {
                 sess.send_event_raw(Event {
@@ -5100,6 +5076,7 @@ mod handlers {
                     msg: EventMsg::Error(err.to_error_event()),
                 })
                 .await;
+                false
             }
         }
     }

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -4960,7 +4960,8 @@ mod handlers {
     }
 
     pub async fn user_input_or_turn(sess: &Arc<Session>, sub_id: String, op: Op) {
-        user_input_or_turn_inner(sess, sub_id, op, /*mirror_to_realtime*/ true).await;
+        let mirror_to_realtime = true;
+        user_input_or_turn_inner(sess, sub_id, op, mirror_to_realtime).await;
     }
 
     pub(super) async fn user_input_or_turn_without_realtime_text_mirror(
@@ -4968,7 +4969,8 @@ mod handlers {
         sub_id: String,
         op: Op,
     ) {
-        user_input_or_turn_inner(sess, sub_id, op, /*mirror_to_realtime*/ false).await;
+        let mirror_to_realtime = false;
+        user_input_or_turn_inner(sess, sub_id, op, mirror_to_realtime).await;
     }
 
     async fn user_input_or_turn_inner(

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -4960,8 +4960,10 @@ mod handlers {
     }
 
     pub async fn user_input_or_turn(sess: &Arc<Session>, sub_id: String, op: Op) {
-        let mirror_to_realtime = true;
-        user_input_or_turn_inner(sess, sub_id, op, mirror_to_realtime).await;
+        let accepted_items = user_input_or_turn_inner(sess, sub_id, op).await;
+        if let Some(items) = accepted_items {
+            mirror_user_text_to_realtime(sess, &items).await;
+        }
     }
 
     pub(super) async fn user_input_or_turn_without_realtime_text_mirror(
@@ -4969,16 +4971,14 @@ mod handlers {
         sub_id: String,
         op: Op,
     ) {
-        let mirror_to_realtime = false;
-        user_input_or_turn_inner(sess, sub_id, op, mirror_to_realtime).await;
+        let _ = user_input_or_turn_inner(sess, sub_id, op).await;
     }
 
     async fn user_input_or_turn_inner(
         sess: &Arc<Session>,
         sub_id: String,
         op: Op,
-        mirror_to_realtime: bool,
-    ) {
+    ) -> Option<Vec<UserInput>> {
         let (items, updates, responsesapi_client_metadata) = match op {
             Op::UserTurn {
                 cwd,
@@ -5040,7 +5040,7 @@ mod handlers {
 
         let Ok(current_context) = sess.new_turn_with_sub_id(sub_id.clone(), updates).await else {
             // new_turn_with_sub_id already emits the error event.
-            return;
+            return None;
         };
         sess.maybe_emit_unknown_model_warning_for_turn(current_context.as_ref())
             .await;
@@ -5054,9 +5054,7 @@ mod handlers {
         {
             Ok(_) => {
                 current_context.session_telemetry.user_prompt(&items);
-                if mirror_to_realtime {
-                    mirror_user_text_to_realtime(sess, &items).await;
-                }
+                Some(items)
             }
             Err(SteerInputError::NoActiveTurn(items)) => {
                 if let Some(responsesapi_client_metadata) = responsesapi_client_metadata {
@@ -5067,20 +5065,14 @@ mod handlers {
                 current_context.session_telemetry.user_prompt(&items);
                 sess.refresh_mcp_servers_if_requested(&current_context)
                     .await;
-                let realtime_items = if mirror_to_realtime {
-                    Some(items.clone())
-                } else {
-                    None
-                };
+                let accepted_items = items.clone();
                 sess.spawn_task(
                     Arc::clone(&current_context),
                     items,
                     crate::tasks::RegularTask::new(),
                 )
                 .await;
-                if let Some(items) = realtime_items {
-                    mirror_user_text_to_realtime(sess, &items).await;
-                }
+                Some(accepted_items)
             }
             Err(err) => {
                 sess.send_event_raw(Event {
@@ -5088,6 +5080,7 @@ mod handlers {
                     msg: EventMsg::Error(err.to_error_event()),
                 })
                 .await;
+                None
             }
         }
     }

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -2265,7 +2265,7 @@ impl Session {
     }
 
     pub(crate) async fn route_realtime_text_input(self: &Arc<Self>, text: String) {
-        handlers::user_input_or_turn_with_realtime_text_mirror(
+        handlers::user_input_or_turn_without_realtime_text_mirror(
             self,
             self.next_internal_sub_id(),
             Op::UserInput {
@@ -2276,7 +2276,6 @@ impl Session {
                 final_output_json_schema: None,
                 responsesapi_client_metadata: None,
             },
-            handlers::RealtimeTextMirror::Disabled,
         )
         .await;
     }
@@ -4917,6 +4916,7 @@ mod handlers {
     use codex_rmcp_client::ElicitationAction;
     use codex_rmcp_client::ElicitationResponse;
     use serde_json::Value;
+    use std::collections::HashMap;
     use std::path::PathBuf;
     use std::sync::Arc;
     use tracing::debug;
@@ -4960,22 +4960,29 @@ mod handlers {
         }
     }
 
-    pub(super) enum RealtimeTextMirror {
-        Enabled,
-        Disabled,
+    struct PreparedUserInputOrTurn {
+        items: Vec<UserInput>,
+        updates: SessionSettingsUpdate,
+        responsesapi_client_metadata: Option<HashMap<String, String>>,
     }
 
     pub async fn user_input_or_turn(sess: &Arc<Session>, sub_id: String, op: Op) {
-        user_input_or_turn_with_realtime_text_mirror(sess, sub_id, op, RealtimeTextMirror::Enabled)
-            .await;
+        let prepared = prepare_user_input_or_turn(op);
+        let text = UserMessageItem::new(&prepared.items).message();
+        let realtime_text = (!text.is_empty()).then_some(text);
+        run_user_input_or_turn(sess, sub_id, prepared, realtime_text).await;
     }
 
-    pub(super) async fn user_input_or_turn_with_realtime_text_mirror(
+    pub(super) async fn user_input_or_turn_without_realtime_text_mirror(
         sess: &Arc<Session>,
         sub_id: String,
         op: Op,
-        realtime_text_mirror: RealtimeTextMirror,
     ) {
+        let prepared = prepare_user_input_or_turn(op);
+        run_user_input_or_turn(sess, sub_id, prepared, /*realtime_text*/ None).await;
+    }
+
+    fn prepare_user_input_or_turn(op: Op) -> PreparedUserInputOrTurn {
         let (items, updates, responsesapi_client_metadata) = match op {
             Op::UserTurn {
                 cwd,
@@ -5034,14 +5041,24 @@ mod handlers {
             ),
             _ => unreachable!(),
         };
-        let realtime_text = match realtime_text_mirror {
-            RealtimeTextMirror::Enabled => {
-                let text = UserMessageItem::new(&items).message();
-                (!text.is_empty()).then_some(text)
-            }
-            RealtimeTextMirror::Disabled => None,
-        };
+        PreparedUserInputOrTurn {
+            items,
+            updates,
+            responsesapi_client_metadata,
+        }
+    }
 
+    async fn run_user_input_or_turn(
+        sess: &Arc<Session>,
+        sub_id: String,
+        prepared: PreparedUserInputOrTurn,
+        realtime_text: Option<String>,
+    ) {
+        let PreparedUserInputOrTurn {
+            items,
+            updates,
+            responsesapi_client_metadata,
+        } = prepared;
         let Ok(current_context) = sess.new_turn_with_sub_id(sub_id.clone(), updates).await else {
             // new_turn_with_sub_id already emits the error event.
             return;

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -2265,7 +2265,7 @@ impl Session {
     }
 
     pub(crate) async fn route_realtime_text_input(self: &Arc<Self>, text: String) {
-        handlers::user_input_or_turn_without_realtime_text_mirror(
+        let _ = handlers::user_input_or_turn_without_realtime_text_mirror(
             self,
             self.next_internal_sub_id(),
             Op::UserInput {
@@ -4960,21 +4960,14 @@ mod handlers {
     }
 
     pub async fn user_input_or_turn(sess: &Arc<Session>, sub_id: String, op: Op) {
-        let accepted_items = user_input_or_turn_inner(sess, sub_id, op).await;
+        let accepted_items =
+            user_input_or_turn_without_realtime_text_mirror(sess, sub_id, op).await;
         if let Some(items) = accepted_items {
             mirror_user_text_to_realtime(sess, &items).await;
         }
     }
 
     pub(super) async fn user_input_or_turn_without_realtime_text_mirror(
-        sess: &Arc<Session>,
-        sub_id: String,
-        op: Op,
-    ) {
-        let _ = user_input_or_turn_inner(sess, sub_id, op).await;
-    }
-
-    async fn user_input_or_turn_inner(
         sess: &Arc<Session>,
         sub_id: String,
         op: Op,

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -2265,7 +2265,7 @@ impl Session {
     }
 
     pub(crate) async fn route_realtime_text_input(self: &Arc<Self>, text: String) {
-        let _ = handlers::user_input_or_turn_without_realtime_text_mirror(
+        handlers::user_input_or_turn_inner(
             self,
             self.next_internal_sub_id(),
             Op::UserInput {
@@ -2276,6 +2276,7 @@ impl Session {
                 final_output_json_schema: None,
                 responsesapi_client_metadata: None,
             },
+            /*mirror_user_text_to_realtime*/ None,
         )
         .await;
     }
@@ -4960,18 +4961,21 @@ mod handlers {
     }
 
     pub async fn user_input_or_turn(sess: &Arc<Session>, sub_id: String, op: Op) {
-        let accepted_items =
-            user_input_or_turn_without_realtime_text_mirror(sess, sub_id, op).await;
-        if let Some(items) = accepted_items {
-            mirror_user_text_to_realtime(sess, &items).await;
-        }
+        user_input_or_turn_inner(
+            sess,
+            sub_id,
+            op,
+            /*mirror_user_text_to_realtime*/ Some(()),
+        )
+        .await;
     }
 
-    pub(super) async fn user_input_or_turn_without_realtime_text_mirror(
+    pub(super) async fn user_input_or_turn_inner(
         sess: &Arc<Session>,
         sub_id: String,
         op: Op,
-    ) -> Option<Vec<UserInput>> {
+        mirror_user_text_to_realtime: Option<()>,
+    ) {
         let (items, updates, responsesapi_client_metadata) = match op {
             Op::UserTurn {
                 cwd,
@@ -5033,11 +5037,11 @@ mod handlers {
 
         let Ok(current_context) = sess.new_turn_with_sub_id(sub_id.clone(), updates).await else {
             // new_turn_with_sub_id already emits the error event.
-            return None;
+            return;
         };
         sess.maybe_emit_unknown_model_warning_for_turn(current_context.as_ref())
             .await;
-        match sess
+        let accepted_items = match sess
             .steer_input(
                 items.clone(),
                 /*expected_turn_id*/ None,
@@ -5075,6 +5079,9 @@ mod handlers {
                 .await;
                 None
             }
+        };
+        if let (Some(items), Some(())) = (accepted_items, mirror_user_text_to_realtime) {
+            self::mirror_user_text_to_realtime(sess, &items).await;
         }
     }
 

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -4960,22 +4960,23 @@ mod handlers {
     }
 
     pub async fn user_input_or_turn(sess: &Arc<Session>, sub_id: String, op: Op) {
-        let items = match &op {
-            Op::UserTurn { items, .. } | Op::UserInput { items, .. } => items,
-            _ => unreachable!(),
-        };
-        let text = UserMessageItem::new(items).message();
-        let realtime_text = (!text.is_empty()).then_some(text);
-        if user_input_or_turn_without_realtime_text_mirror(sess, sub_id, op).await {
-            mirror_user_text_to_realtime(sess, realtime_text).await;
-        }
+        user_input_or_turn_inner(sess, sub_id, op, /*mirror_to_realtime*/ true).await;
     }
 
     pub(super) async fn user_input_or_turn_without_realtime_text_mirror(
         sess: &Arc<Session>,
         sub_id: String,
         op: Op,
-    ) -> bool {
+    ) {
+        user_input_or_turn_inner(sess, sub_id, op, /*mirror_to_realtime*/ false).await;
+    }
+
+    async fn user_input_or_turn_inner(
+        sess: &Arc<Session>,
+        sub_id: String,
+        op: Op,
+        mirror_to_realtime: bool,
+    ) {
         let (items, updates, responsesapi_client_metadata) = match op {
             Op::UserTurn {
                 cwd,
@@ -5037,7 +5038,7 @@ mod handlers {
 
         let Ok(current_context) = sess.new_turn_with_sub_id(sub_id.clone(), updates).await else {
             // new_turn_with_sub_id already emits the error event.
-            return false;
+            return;
         };
         sess.maybe_emit_unknown_model_warning_for_turn(current_context.as_ref())
             .await;
@@ -5051,7 +5052,9 @@ mod handlers {
         {
             Ok(_) => {
                 current_context.session_telemetry.user_prompt(&items);
-                true
+                if mirror_to_realtime {
+                    mirror_user_text_to_realtime(sess, &items).await;
+                }
             }
             Err(SteerInputError::NoActiveTurn(items)) => {
                 if let Some(responsesapi_client_metadata) = responsesapi_client_metadata {
@@ -5062,13 +5065,20 @@ mod handlers {
                 current_context.session_telemetry.user_prompt(&items);
                 sess.refresh_mcp_servers_if_requested(&current_context)
                     .await;
+                let realtime_items = if mirror_to_realtime {
+                    Some(items.clone())
+                } else {
+                    None
+                };
                 sess.spawn_task(
                     Arc::clone(&current_context),
                     items,
                     crate::tasks::RegularTask::new(),
                 )
                 .await;
-                true
+                if let Some(items) = realtime_items {
+                    mirror_user_text_to_realtime(sess, &items).await;
+                }
             }
             Err(err) => {
                 sess.send_event_raw(Event {
@@ -5076,15 +5086,15 @@ mod handlers {
                     msg: EventMsg::Error(err.to_error_event()),
                 })
                 .await;
-                false
             }
         }
     }
 
-    async fn mirror_user_text_to_realtime(sess: &Arc<Session>, realtime_text: Option<String>) {
-        let Some(text) = realtime_text else {
+    async fn mirror_user_text_to_realtime(sess: &Arc<Session>, items: &[UserInput]) {
+        let text = UserMessageItem::new(items).message();
+        if text.is_empty() {
             return;
-        };
+        }
         if sess.conversation.running_state().await.is_none() {
             return;
         }

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -5093,7 +5093,7 @@ mod handlers {
         if sess.conversation.running_state().await.is_none() {
             return;
         }
-        if let Err(err) = sess.conversation.append_user_text(text).await {
+        if let Err(err) = sess.conversation.text_in(text).await {
             debug!("failed to mirror user text to realtime conversation: {err}");
         }
     }

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -5094,7 +5094,7 @@ mod handlers {
         if sess.conversation.running_state().await.is_none() {
             return;
         }
-        if let Err(err) = sess.conversation.text_in(text).await {
+        if let Err(err) = sess.conversation.append_user_text(text).await {
             debug!("failed to mirror user text to realtime conversation: {err}");
         }
     }

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -2265,7 +2265,7 @@ impl Session {
     }
 
     pub(crate) async fn route_realtime_text_input(self: &Arc<Self>, text: String) {
-        handlers::user_input_or_turn(
+        handlers::user_input_or_turn_with_realtime_text_mirror(
             self,
             self.next_internal_sub_id(),
             Op::UserInput {
@@ -2276,6 +2276,7 @@ impl Session {
                 final_output_json_schema: None,
                 responsesapi_client_metadata: None,
             },
+            handlers::RealtimeTextMirror::Disabled,
         )
         .await;
     }
@@ -4910,6 +4911,7 @@ mod handlers {
     use codex_protocol::config_types::ModeKind;
     use codex_protocol::config_types::Settings;
     use codex_protocol::dynamic_tools::DynamicToolResponse;
+    use codex_protocol::items::UserMessageItem;
     use codex_protocol::mcp::RequestId as ProtocolRequestId;
     use codex_protocol::user_input::UserInput;
     use codex_rmcp_client::ElicitationAction;
@@ -4917,6 +4919,7 @@ mod handlers {
     use serde_json::Value;
     use std::path::PathBuf;
     use std::sync::Arc;
+    use tracing::debug;
     use tracing::info;
     use tracing::warn;
 
@@ -4957,7 +4960,22 @@ mod handlers {
         }
     }
 
+    pub(super) enum RealtimeTextMirror {
+        Enabled,
+        Disabled,
+    }
+
     pub async fn user_input_or_turn(sess: &Arc<Session>, sub_id: String, op: Op) {
+        user_input_or_turn_with_realtime_text_mirror(sess, sub_id, op, RealtimeTextMirror::Enabled)
+            .await;
+    }
+
+    pub(super) async fn user_input_or_turn_with_realtime_text_mirror(
+        sess: &Arc<Session>,
+        sub_id: String,
+        op: Op,
+        realtime_text_mirror: RealtimeTextMirror,
+    ) {
         let (items, updates, responsesapi_client_metadata) = match op {
             Op::UserTurn {
                 cwd,
@@ -5016,6 +5034,13 @@ mod handlers {
             ),
             _ => unreachable!(),
         };
+        let realtime_text = match realtime_text_mirror {
+            RealtimeTextMirror::Enabled => {
+                let text = UserMessageItem::new(&items).message();
+                (!text.is_empty()).then_some(text)
+            }
+            RealtimeTextMirror::Disabled => None,
+        };
 
         let Ok(current_context) = sess.new_turn_with_sub_id(sub_id.clone(), updates).await else {
             // new_turn_with_sub_id already emits the error event.
@@ -5031,7 +5056,10 @@ mod handlers {
             )
             .await
         {
-            Ok(_) => current_context.session_telemetry.user_prompt(&items),
+            Ok(_) => {
+                current_context.session_telemetry.user_prompt(&items);
+                mirror_user_text_to_realtime(sess, realtime_text).await;
+            }
             Err(SteerInputError::NoActiveTurn(items)) => {
                 if let Some(responsesapi_client_metadata) = responsesapi_client_metadata {
                     current_context
@@ -5047,6 +5075,7 @@ mod handlers {
                     crate::tasks::RegularTask::new(),
                 )
                 .await;
+                mirror_user_text_to_realtime(sess, realtime_text).await;
             }
             Err(err) => {
                 sess.send_event_raw(Event {
@@ -5055,6 +5084,18 @@ mod handlers {
                 })
                 .await;
             }
+        }
+    }
+
+    async fn mirror_user_text_to_realtime(sess: &Arc<Session>, realtime_text: Option<String>) {
+        let Some(text) = realtime_text else {
+            return;
+        };
+        if sess.conversation.running_state().await.is_none() {
+            return;
+        }
+        if let Err(err) = sess.conversation.text_in(text).await {
+            debug!("failed to mirror user text to realtime conversation: {err}");
         }
     }
 

--- a/codex-rs/core/src/realtime_conversation.rs
+++ b/codex-rs/core/src/realtime_conversation.rs
@@ -403,10 +403,6 @@ impl RealtimeConversationManager {
     }
 
     pub(crate) async fn text_in(&self, text: String) -> CodexResult<()> {
-        self.queue_text_input(text).await
-    }
-
-    async fn queue_text_input(&self, text: String) -> CodexResult<()> {
         let sender = {
             let guard = self.state.lock().await;
             guard.as_ref().map(|state| state.user_text_tx.clone())
@@ -908,7 +904,7 @@ pub(crate) async fn handle_text(
     sub_id: String,
     params: ConversationTextParams,
 ) {
-    debug!(text = %params.text, "[realtime-text] sending realtime conversation text input");
+    debug!(text = %params.text, "[realtime-text] appending realtime conversation text input");
     if let Err(err) = sess.conversation.text_in(params.text).await {
         error!("failed to append realtime text: {err}");
         if sess.conversation.running_state().await.is_some() {
@@ -943,9 +939,9 @@ fn spawn_realtime_input_task(input: RealtimeInputTask) -> JoinHandle<()> {
 
         loop {
             let result = tokio::select! {
-                // Text that should be sent into realtime.
+                // Text typed by the user that should be sent into realtime.
                 user_text = user_text_rx.recv() => {
-                    handle_realtime_text_input(
+                    handle_user_text_input(
                         user_text,
                         &writer,
                         &events_tx,
@@ -990,12 +986,12 @@ fn spawn_realtime_input_task(input: RealtimeInputTask) -> JoinHandle<()> {
     })
 }
 
-async fn handle_realtime_text_input(
-    input: Result<String, RecvError>,
+async fn handle_user_text_input(
+    text: Result<String, RecvError>,
     writer: &RealtimeWebsocketWriter,
     events_tx: &Sender<RealtimeEvent>,
 ) -> anyhow::Result<()> {
-    let text = input.context("text input channel closed")?;
+    let text = text.context("user text input channel closed")?;
 
     if let Err(err) = writer.send_conversation_item_create(text).await {
         let mapped_error = map_api_error(err);

--- a/codex-rs/core/src/realtime_conversation.rs
+++ b/codex-rs/core/src/realtime_conversation.rs
@@ -114,6 +114,18 @@ enum HandoffOutput {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+struct RealtimeTextInput {
+    text: String,
+    response_mode: RealtimeTextResponseMode,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum RealtimeTextResponseMode {
+    AppendOnly,
+    RequestResponse,
+}
+
+#[derive(Debug, PartialEq, Eq)]
 struct OutputAudioState {
     item_id: String,
     audio_end_ms: u32,
@@ -184,7 +196,7 @@ impl RealtimeResponseCreateQueue {
 struct RealtimeInputTask {
     writer: RealtimeWebsocketWriter,
     events: RealtimeWebsocketEvents,
-    user_text_rx: Receiver<String>,
+    user_text_rx: Receiver<RealtimeTextInput>,
     handoff_output_rx: Receiver<HandoffOutput>,
     audio_rx: Receiver<RealtimeAudioFrame>,
     events_tx: Sender<RealtimeEvent>,
@@ -207,7 +219,7 @@ impl RealtimeHandoffState {
 #[allow(dead_code)]
 struct ConversationState {
     audio_tx: Sender<RealtimeAudioFrame>,
-    user_text_tx: Sender<String>,
+    user_text_tx: Sender<RealtimeTextInput>,
     writer: RealtimeWebsocketWriter,
     handoff: RealtimeHandoffState,
     input_task: JoinHandle<()>,
@@ -306,7 +318,7 @@ impl RealtimeConversationManager {
         let (audio_tx, audio_rx) =
             async_channel::bounded::<RealtimeAudioFrame>(AUDIO_IN_QUEUE_CAPACITY);
         let (user_text_tx, user_text_rx) =
-            async_channel::bounded::<String>(USER_TEXT_IN_QUEUE_CAPACITY);
+            async_channel::bounded::<RealtimeTextInput>(USER_TEXT_IN_QUEUE_CAPACITY);
         let (handoff_output_tx, handoff_output_rx) =
             async_channel::bounded::<HandoffOutput>(HANDOFF_OUT_QUEUE_CAPACITY);
         let (events_tx, events_rx) =
@@ -403,6 +415,22 @@ impl RealtimeConversationManager {
     }
 
     pub(crate) async fn text_in(&self, text: String) -> CodexResult<()> {
+        self.queue_text_input(RealtimeTextInput {
+            text,
+            response_mode: RealtimeTextResponseMode::RequestResponse,
+        })
+        .await
+    }
+
+    pub(crate) async fn append_user_text(&self, text: String) -> CodexResult<()> {
+        self.queue_text_input(RealtimeTextInput {
+            text,
+            response_mode: RealtimeTextResponseMode::AppendOnly,
+        })
+        .await
+    }
+
+    async fn queue_text_input(&self, input: RealtimeTextInput) -> CodexResult<()> {
         let sender = {
             let guard = self.state.lock().await;
             guard.as_ref().map(|state| state.user_text_tx.clone())
@@ -415,7 +443,7 @@ impl RealtimeConversationManager {
         };
 
         sender
-            .send(text)
+            .send(input)
             .await
             .map_err(|_| CodexErr::InvalidRequest("conversation is not running".to_string()))?;
         Ok(())
@@ -904,7 +932,7 @@ pub(crate) async fn handle_text(
     sub_id: String,
     params: ConversationTextParams,
 ) {
-    debug!(text = %params.text, "[realtime-text] appending realtime conversation text input");
+    debug!(text = %params.text, "[realtime-text] sending realtime conversation text input");
     if let Err(err) = sess.conversation.text_in(params.text).await {
         error!("failed to append realtime text: {err}");
         if sess.conversation.running_state().await.is_some() {
@@ -939,9 +967,9 @@ fn spawn_realtime_input_task(input: RealtimeInputTask) -> JoinHandle<()> {
 
         loop {
             let result = tokio::select! {
-                // Text typed by the user that should be sent into realtime.
+                // Text that should be sent into realtime.
                 user_text = user_text_rx.recv() => {
-                    handle_user_text_input(
+                    handle_realtime_text_input(
                         user_text,
                         &writer,
                         &events_tx,
@@ -988,16 +1016,16 @@ fn spawn_realtime_input_task(input: RealtimeInputTask) -> JoinHandle<()> {
     })
 }
 
-async fn handle_user_text_input(
-    text: Result<String, RecvError>,
+async fn handle_realtime_text_input(
+    input: Result<RealtimeTextInput, RecvError>,
     writer: &RealtimeWebsocketWriter,
     events_tx: &Sender<RealtimeEvent>,
     session_kind: RealtimeSessionKind,
     response_create_queue: &mut RealtimeResponseCreateQueue,
 ) -> anyhow::Result<()> {
-    let text = text.context("user text input channel closed")?;
+    let input = input.context("text input channel closed")?;
 
-    if let Err(err) = writer.send_conversation_item_create(text).await {
+    if let Err(err) = writer.send_conversation_item_create(input.text).await {
         let mapped_error = map_api_error(err);
         warn!("failed to send input text: {mapped_error}");
         let _ = events_tx
@@ -1007,11 +1035,14 @@ async fn handle_user_text_input(
     }
     match session_kind {
         RealtimeSessionKind::V1 => {}
-        RealtimeSessionKind::V2 => {
-            response_create_queue
-                .request_create(writer, events_tx, "text")
-                .await?;
-        }
+        RealtimeSessionKind::V2 => match input.response_mode {
+            RealtimeTextResponseMode::AppendOnly => {}
+            RealtimeTextResponseMode::RequestResponse => {
+                response_create_queue
+                    .request_create(writer, events_tx, "text")
+                    .await?;
+            }
+        },
     }
     Ok(())
 }

--- a/codex-rs/core/src/realtime_conversation.rs
+++ b/codex-rs/core/src/realtime_conversation.rs
@@ -114,18 +114,6 @@ enum HandoffOutput {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-struct RealtimeTextInput {
-    text: String,
-    response_mode: RealtimeTextResponseMode,
-}
-
-#[derive(Debug, PartialEq, Eq)]
-enum RealtimeTextResponseMode {
-    AppendOnly,
-    RequestResponse,
-}
-
-#[derive(Debug, PartialEq, Eq)]
 struct OutputAudioState {
     item_id: String,
     audio_end_ms: u32,
@@ -196,7 +184,7 @@ impl RealtimeResponseCreateQueue {
 struct RealtimeInputTask {
     writer: RealtimeWebsocketWriter,
     events: RealtimeWebsocketEvents,
-    user_text_rx: Receiver<RealtimeTextInput>,
+    user_text_rx: Receiver<String>,
     handoff_output_rx: Receiver<HandoffOutput>,
     audio_rx: Receiver<RealtimeAudioFrame>,
     events_tx: Sender<RealtimeEvent>,
@@ -219,7 +207,7 @@ impl RealtimeHandoffState {
 #[allow(dead_code)]
 struct ConversationState {
     audio_tx: Sender<RealtimeAudioFrame>,
-    user_text_tx: Sender<RealtimeTextInput>,
+    user_text_tx: Sender<String>,
     writer: RealtimeWebsocketWriter,
     handoff: RealtimeHandoffState,
     input_task: JoinHandle<()>,
@@ -318,7 +306,7 @@ impl RealtimeConversationManager {
         let (audio_tx, audio_rx) =
             async_channel::bounded::<RealtimeAudioFrame>(AUDIO_IN_QUEUE_CAPACITY);
         let (user_text_tx, user_text_rx) =
-            async_channel::bounded::<RealtimeTextInput>(USER_TEXT_IN_QUEUE_CAPACITY);
+            async_channel::bounded::<String>(USER_TEXT_IN_QUEUE_CAPACITY);
         let (handoff_output_tx, handoff_output_rx) =
             async_channel::bounded::<HandoffOutput>(HANDOFF_OUT_QUEUE_CAPACITY);
         let (events_tx, events_rx) =
@@ -415,22 +403,10 @@ impl RealtimeConversationManager {
     }
 
     pub(crate) async fn text_in(&self, text: String) -> CodexResult<()> {
-        self.queue_text_input(RealtimeTextInput {
-            text,
-            response_mode: RealtimeTextResponseMode::RequestResponse,
-        })
-        .await
+        self.queue_text_input(text).await
     }
 
-    pub(crate) async fn append_user_text(&self, text: String) -> CodexResult<()> {
-        self.queue_text_input(RealtimeTextInput {
-            text,
-            response_mode: RealtimeTextResponseMode::AppendOnly,
-        })
-        .await
-    }
-
-    async fn queue_text_input(&self, input: RealtimeTextInput) -> CodexResult<()> {
+    async fn queue_text_input(&self, text: String) -> CodexResult<()> {
         let sender = {
             let guard = self.state.lock().await;
             guard.as_ref().map(|state| state.user_text_tx.clone())
@@ -443,7 +419,7 @@ impl RealtimeConversationManager {
         };
 
         sender
-            .send(input)
+            .send(text)
             .await
             .map_err(|_| CodexErr::InvalidRequest("conversation is not running".to_string()))?;
         Ok(())
@@ -973,8 +949,6 @@ fn spawn_realtime_input_task(input: RealtimeInputTask) -> JoinHandle<()> {
                         user_text,
                         &writer,
                         &events_tx,
-                        session_kind,
-                        &mut response_create_queue,
                     )
                         .await
                 }
@@ -1017,32 +991,19 @@ fn spawn_realtime_input_task(input: RealtimeInputTask) -> JoinHandle<()> {
 }
 
 async fn handle_realtime_text_input(
-    input: Result<RealtimeTextInput, RecvError>,
+    input: Result<String, RecvError>,
     writer: &RealtimeWebsocketWriter,
     events_tx: &Sender<RealtimeEvent>,
-    session_kind: RealtimeSessionKind,
-    response_create_queue: &mut RealtimeResponseCreateQueue,
 ) -> anyhow::Result<()> {
-    let input = input.context("text input channel closed")?;
+    let text = input.context("text input channel closed")?;
 
-    if let Err(err) = writer.send_conversation_item_create(input.text).await {
+    if let Err(err) = writer.send_conversation_item_create(text).await {
         let mapped_error = map_api_error(err);
         warn!("failed to send input text: {mapped_error}");
         let _ = events_tx
             .send(RealtimeEvent::Error(mapped_error.to_string()))
             .await;
         return Err(mapped_error.into());
-    }
-    match session_kind {
-        RealtimeSessionKind::V1 => {}
-        RealtimeSessionKind::V2 => match input.response_mode {
-            RealtimeTextResponseMode::AppendOnly => {}
-            RealtimeTextResponseMode::RequestResponse => {
-                response_create_queue
-                    .request_create(writer, events_tx, "text")
-                    .await?;
-            }
-        },
     }
     Ok(())
 }

--- a/codex-rs/core/tests/suite/realtime_conversation.rs
+++ b/codex-rs/core/tests/suite/realtime_conversation.rs
@@ -1729,7 +1729,6 @@ async fn conversation_user_text_turn_is_sent_to_realtime_when_active() -> Result
     );
 
     realtime_server.shutdown().await;
-    api_server.shutdown().await;
     Ok(())
 }
 

--- a/codex-rs/core/tests/suite/realtime_conversation.rs
+++ b/codex-rs/core/tests/suite/realtime_conversation.rs
@@ -1627,6 +1627,113 @@ async fn conversation_startup_context_is_truncated_and_sent_once_per_start() -> 
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn conversation_user_text_turn_is_sent_to_realtime_when_active() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let api_server = start_mock_server().await;
+    let response_mock = responses::mount_sse_once(
+        &api_server,
+        responses::sse(vec![
+            responses::ev_response_created("resp_user_text"),
+            responses::ev_assistant_message("msg_user_text", "ack"),
+            responses::ev_completed("resp_user_text"),
+        ]),
+    )
+    .await;
+
+    let realtime_server = start_websocket_server(vec![vec![
+        vec![json!({
+            "type": "session.updated",
+            "session": { "id": "sess_user_text", "instructions": "backend prompt" }
+        })],
+        vec![],
+    ]])
+    .await;
+
+    let mut builder = test_codex().with_config({
+        let realtime_base_url = realtime_server.uri().to_string();
+        move |config| {
+            config.experimental_realtime_ws_base_url = Some(realtime_base_url);
+            config.realtime.version = RealtimeWsVersion::V1;
+        }
+    });
+    let test = builder.build(&api_server).await?;
+
+    test.codex
+        .submit(Op::RealtimeConversationStart(ConversationStartParams {
+            prompt: Some(Some("backend prompt".to_string())),
+            session_id: None,
+            transport: None,
+            voice: None,
+        }))
+        .await?;
+
+    let session_updated = wait_for_event_match(&test.codex, |msg| match msg {
+        EventMsg::RealtimeConversationRealtime(RealtimeConversationRealtimeEvent {
+            payload: RealtimeEvent::SessionUpdated { session_id, .. },
+        }) => Some(session_id.clone()),
+        _ => None,
+    })
+    .await;
+    assert_eq!(session_updated, "sess_user_text");
+
+    let user_text = "typed follow-up for realtime";
+    test.codex
+        .submit(Op::UserInput {
+            items: vec![UserInput::Text {
+                text: user_text.to_string(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+            responsesapi_client_metadata: None,
+        })
+        .await?;
+
+    wait_for_event(&test.codex, |event| {
+        matches!(event, EventMsg::TurnComplete(_))
+    })
+    .await;
+
+    let realtime_text_request = wait_for_matching_websocket_request(
+        &realtime_server,
+        "normal user turn text mirrored to realtime",
+        |request| websocket_request_text(request).as_deref() == Some(user_text),
+    )
+    .await;
+    let model_user_texts = response_mock.single_request().message_input_texts("user");
+    assert_eq!(
+        (
+            model_user_texts.iter().any(|text| text == user_text),
+            websocket_request_text(&realtime_text_request),
+        ),
+        (true, Some(user_text.to_string())),
+    );
+
+    let realtime_request_body = realtime_text_request.body_json();
+    let content = &realtime_request_body["item"]["content"][0];
+    let snapshot = format!(
+        "type: {}\nitem.type: {}\nitem.role: {}\ncontent[0].type: {}\ncontent[0].text: {}",
+        realtime_request_body["type"].as_str().unwrap_or_default(),
+        realtime_request_body["item"]["type"]
+            .as_str()
+            .unwrap_or_default(),
+        realtime_request_body["item"]["role"]
+            .as_str()
+            .unwrap_or_default(),
+        content["type"].as_str().unwrap_or_default(),
+        content["text"].as_str().unwrap_or_default(),
+    );
+    insta::assert_snapshot!(
+        "conversation_user_text_turn_is_sent_to_realtime_when_active",
+        snapshot
+    );
+
+    realtime_server.shutdown().await;
+    api_server.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn conversation_mirrors_assistant_message_text_to_realtime_handoff() -> Result<()> {
     skip_if_no_network!(Ok(()));
 

--- a/codex-rs/core/tests/suite/realtime_conversation.rs
+++ b/codex-rs/core/tests/suite/realtime_conversation.rs
@@ -1654,7 +1654,7 @@ async fn conversation_user_text_turn_is_sent_to_realtime_when_active() -> Result
         let realtime_base_url = realtime_server.uri().to_string();
         move |config| {
             config.experimental_realtime_ws_base_url = Some(realtime_base_url);
-            config.realtime.version = RealtimeWsVersion::V1;
+            config.experimental_realtime_ws_startup_context = Some(String::new());
         }
     });
     let test = builder.build(&api_server).await?;
@@ -1708,11 +1708,24 @@ async fn conversation_user_text_turn_is_sent_to_realtime_when_active() -> Result
         ),
         (true, Some(user_text.to_string())),
     );
+    let realtime_response_create = timeout(Duration::from_millis(200), async {
+        wait_for_matching_websocket_request(
+            &realtime_server,
+            "unexpected realtime response request for mirrored user text",
+            |request| request.body_json()["type"].as_str() == Some("response.create"),
+        )
+        .await
+    })
+    .await;
+    assert!(
+        realtime_response_create.is_err(),
+        "mirrored user text should not request a realtime response"
+    );
 
     let realtime_request_body = realtime_text_request.body_json();
     let content = &realtime_request_body["item"]["content"][0];
     let snapshot = format!(
-        "type: {}\nitem.type: {}\nitem.role: {}\ncontent[0].type: {}\ncontent[0].text: {}",
+        "type: {}\nitem.type: {}\nitem.role: {}\ncontent[0].type: {}\ncontent[0].text: {}\nresponse.create: {}",
         realtime_request_body["type"].as_str().unwrap_or_default(),
         realtime_request_body["item"]["type"]
             .as_str()
@@ -1722,6 +1735,7 @@ async fn conversation_user_text_turn_is_sent_to_realtime_when_active() -> Result
             .unwrap_or_default(),
         content["type"].as_str().unwrap_or_default(),
         content["text"].as_str().unwrap_or_default(),
+        realtime_response_create.is_ok(),
     );
     insta::assert_snapshot!(
         "conversation_user_text_turn_is_sent_to_realtime_when_active",

--- a/codex-rs/core/tests/suite/realtime_conversation.rs
+++ b/codex-rs/core/tests/suite/realtime_conversation.rs
@@ -2709,6 +2709,7 @@ async fn inbound_handoff_request_steers_active_turn() -> Result<()> {
             "type": "session.updated",
             "session": { "id": "sess_steer", "instructions": "backend prompt" }
         })],
+        vec![],
         vec![
             json!({
                 "type": "conversation.input_transcript.delta",
@@ -2763,6 +2764,12 @@ async fn inbound_handoff_request_steers_active_turn() -> Result<()> {
     wait_for_event(&test.codex, |event| {
         matches!(event, EventMsg::AgentMessageContentDelta(_))
     })
+    .await;
+    let _ = wait_for_matching_websocket_request(
+        &realtime_server,
+        "first prompt mirrored to realtime",
+        |request| websocket_request_text(request).as_deref() == Some("first prompt"),
+    )
     .await;
 
     test.codex

--- a/codex-rs/core/tests/suite/snapshots/all__suite__realtime_conversation__conversation_user_text_turn_is_sent_to_realtime_when_active.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__realtime_conversation__conversation_user_text_turn_is_sent_to_realtime_when_active.snap
@@ -1,0 +1,9 @@
+---
+source: core/tests/suite/realtime_conversation.rs
+expression: snapshot
+---
+type: conversation.item.create
+item.type: message
+item.role: user
+content[0].type: text
+content[0].text: typed follow-up for realtime

--- a/codex-rs/core/tests/suite/snapshots/all__suite__realtime_conversation__conversation_user_text_turn_is_sent_to_realtime_when_active.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__realtime_conversation__conversation_user_text_turn_is_sent_to_realtime_when_active.snap
@@ -5,5 +5,6 @@ expression: snapshot
 type: conversation.item.create
 item.type: message
 item.role: user
-content[0].type: text
+content[0].type: input_text
 content[0].text: typed follow-up for realtime
+response.create: false

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -5050,11 +5050,6 @@ impl ChatWidget {
                     {
                         return;
                     }
-                    let Some(user_message) =
-                        self.maybe_defer_user_message_for_realtime(user_message)
-                    else {
-                        return;
-                    };
                     let should_submit_now =
                         self.is_session_configured() && !self.is_plan_streaming_in_tui();
                     if should_submit_now {
@@ -5084,11 +5079,6 @@ impl ChatWidget {
                         mention_bindings: self
                             .bottom_pane
                             .take_recent_submission_mention_bindings(),
-                    };
-                    let Some(user_message) =
-                        self.maybe_defer_user_message_for_realtime(user_message)
-                    else {
-                        return;
                     };
                     self.queue_user_message(user_message);
                 }

--- a/codex-rs/tui/src/chatwidget/realtime.rs
+++ b/codex-rs/tui/src/chatwidget/realtime.rs
@@ -29,7 +29,6 @@ pub(super) struct RealtimeConversationUiState {
     pub(super) phase: RealtimeConversationPhase,
     requested_close: bool,
     session_id: Option<String>,
-    warned_audio_only_submission: bool,
     transport: RealtimeConversationUiTransport,
     #[cfg(not(target_os = "linux"))]
     pub(super) meter_placeholder_id: Option<String>,
@@ -191,28 +190,6 @@ impl ChatWidget {
         self.last_rendered_user_message_event.as_ref() != Some(&key)
     }
 
-    pub(super) fn maybe_defer_user_message_for_realtime(
-        &mut self,
-        user_message: UserMessage,
-    ) -> Option<UserMessage> {
-        if !self.realtime_conversation.is_live() {
-            return Some(user_message);
-        }
-
-        self.restore_user_message_to_composer(user_message);
-        if !self.realtime_conversation.warned_audio_only_submission {
-            self.realtime_conversation.warned_audio_only_submission = true;
-            self.add_info_message(
-                "Realtime voice mode is audio-only. Use /realtime to stop.".to_string(),
-                /*hint*/ None,
-            );
-        } else {
-            self.request_redraw();
-        }
-
-        None
-    }
-
     fn realtime_footer_hint_items() -> Vec<(String, String)> {
         vec![("/realtime".to_string(), "stop live voice".to_string())]
     }
@@ -238,7 +215,6 @@ impl ChatWidget {
         self.realtime_conversation.phase = RealtimeConversationPhase::Starting;
         self.realtime_conversation.requested_close = false;
         self.realtime_conversation.session_id = None;
-        self.realtime_conversation.warned_audio_only_submission = false;
         self.set_footer_hint_override(Some(Self::realtime_footer_hint_items()));
         match self.config.realtime.transport {
             RealtimeTransport::Websocket => {
@@ -297,7 +273,6 @@ impl ChatWidget {
         self.realtime_conversation.phase = RealtimeConversationPhase::Inactive;
         self.realtime_conversation.requested_close = false;
         self.realtime_conversation.session_id = None;
-        self.realtime_conversation.warned_audio_only_submission = false;
         self.realtime_conversation.transport = RealtimeConversationUiTransport::Websocket;
     }
 
@@ -320,7 +295,6 @@ impl ChatWidget {
             return;
         }
         self.realtime_conversation.session_id = ev.session_id;
-        self.realtime_conversation.warned_audio_only_submission = false;
         self.set_footer_hint_override(Some(Self::realtime_footer_hint_items()));
         if self.realtime_conversation_uses_webrtc() {
             self.realtime_conversation.phase = RealtimeConversationPhase::Starting;


### PR DESCRIPTION
- Let typed user messages submit while realtime is active and mirror accepted text into the realtime text stream.\n- Add integration coverage and snapshot for outbound realtime text.