### PR TITLE
Clarify guardian timeout guidance

### DIFF
--- a/codex-rs/core/src/guardian/review.rs
+++ b/codex-rs/core/src/guardian/review.rs
@@ -39,9 +39,9 @@ const GUARDIAN_REJECTION_INSTRUCTIONS: &str = concat!(
 );
 
 const GUARDIAN_TIMEOUT_INSTRUCTIONS: &str = concat!(
-    "The automatic approval review did not finish before its deadline. ",
+    "The automatic permission approval review did not finish before its deadline. ",
     "Do not assume the action is unsafe based on the timeout alone. ",
-    "You may retry once with a narrower or simpler request, or ask the user for guidance or explicit approval.",
+    "You may retry once, or ask the user for guidance or explicit approval.",
 );
 
 pub(crate) fn new_guardian_review_id() -> String {


### PR DESCRIPTION
## Summary
- update the guardian timeout guidance to say permission approval review timed out
- simplify the retry guidance to say retry once or ask the user for guidance or explicit approval

## Testing
- cargo test -p codex-core guardian_timeout_message_distinguishes_timeout_from_policy_denial
- cargo test -p codex-core guardian_review_decision_maps_to_mcp_tool_decision