### PR TITLE
build(pnpm): require reviewed dependency build scripts

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,3 +9,4 @@ ignoredBuiltDependencies:
 minimumReleaseAge: 10080
 
 blockExoticSubdeps: true
+strictDepBuilds: true


### PR DESCRIPTION
## Description

Enable pnpm's reviewed build-script gate for this repo.

## What changed

- added `strictDepBuilds: true` to `pnpm-workspace.yaml`

## Why

The repo already uses pinned pnpm and frozen installs in CI. This adds the remaining guard so dependency build scripts do not run unless they are explicitly reviewed.

## Validation

- ran `pnpm install --frozen-lockfile`