### PR TITLE
[codex] Add guardian context to PermissionRequest hooks

### DIFF
--- a/codex-rs/core/src/guardian/mod.rs
+++ b/codex-rs/core/src/guardian/mod.rs
@@ -25,12 +25,16 @@ use serde::Serialize;
 pub(crate) use approval_request::GuardianApprovalRequest;
 pub(crate) use approval_request::GuardianMcpAnnotations;
 pub(crate) use approval_request::guardian_approval_request_to_json;
+pub(crate) use review::GuardianApprovalReview;
+pub(crate) use review::GuardianApprovalReviewResult;
+pub(crate) use review::GuardianApprovalReviewStatus;
 pub(crate) use review::guardian_rejection_message;
 pub(crate) use review::guardian_timeout_message;
 pub(crate) use review::is_guardian_reviewer_source;
 pub(crate) use review::new_guardian_review_id;
 pub(crate) use review::review_approval_request;
 pub(crate) use review::review_approval_request_with_cancel;
+pub(crate) use review::review_approval_request_with_review;
 pub(crate) use review::routes_approval_to_guardian;
 pub(crate) use review_session::GuardianReviewSessionManager;
 

--- a/codex-rs/core/src/guardian/review.rs
+++ b/codex-rs/core/src/guardian/review.rs
@@ -80,6 +80,30 @@ pub(super) enum GuardianReviewOutcome {
     Aborted,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GuardianApprovalReviewResult {
+    pub(crate) decision: ReviewDecision,
+    pub(crate) review: GuardianApprovalReview,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GuardianApprovalReview {
+    pub(crate) status: GuardianApprovalReviewStatus,
+    pub(crate) decision: Option<GuardianAssessmentOutcome>,
+    pub(crate) risk_level: Option<GuardianRiskLevel>,
+    pub(crate) user_authorization: Option<GuardianUserAuthorization>,
+    pub(crate) rationale: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum GuardianApprovalReviewStatus {
+    Approved,
+    Denied,
+    Aborted,
+    Failed,
+    TimedOut,
+}
+
 fn guardian_risk_level_str(level: GuardianRiskLevel) -> &'static str {
     match level {
         GuardianRiskLevel::Low => "low",
@@ -117,7 +141,7 @@ async fn run_guardian_review(
     request: GuardianApprovalRequest,
     retry_reason: Option<String>,
     external_cancel: Option<CancellationToken>,
-) -> ReviewDecision {
+) -> GuardianApprovalReviewResult {
     let target_item_id = guardian_request_target_item_id(&request).map(str::to_string);
     let assessment_turn_id = guardian_request_turn_id(&request, &turn.sub_id).to_string();
     let action_summary = guardian_assessment_action(&request);
@@ -158,7 +182,16 @@ async fn run_guardian_review(
                 }),
             )
             .await;
-        return ReviewDecision::Abort;
+        return GuardianApprovalReviewResult {
+            decision: ReviewDecision::Abort,
+            review: GuardianApprovalReview {
+                status: GuardianApprovalReviewStatus::Aborted,
+                decision: None,
+                risk_level: None,
+                user_authorization: None,
+                rationale: None,
+            },
+        };
     }
 
     let schema = guardian_output_schema();
@@ -173,14 +206,17 @@ async fn run_guardian_review(
     )
     .await;
 
-    let assessment = match outcome {
-        GuardianReviewOutcome::Completed(Ok(assessment)) => assessment,
-        GuardianReviewOutcome::Completed(Err(err)) => GuardianAssessment {
-            risk_level: GuardianRiskLevel::High,
-            user_authorization: GuardianUserAuthorization::Unknown,
-            outcome: GuardianAssessmentOutcome::Deny,
-            rationale: format!("Automatic approval review failed: {err}"),
-        },
+    let (assessment, advisory_status) = match outcome {
+        GuardianReviewOutcome::Completed(Ok(assessment)) => (assessment, None),
+        GuardianReviewOutcome::Completed(Err(err)) => (
+            GuardianAssessment {
+                risk_level: GuardianRiskLevel::High,
+                user_authorization: GuardianUserAuthorization::Unknown,
+                outcome: GuardianAssessmentOutcome::Deny,
+                rationale: format!("Automatic approval review failed: {err}"),
+            },
+            Some(GuardianApprovalReviewStatus::Failed),
+        ),
         GuardianReviewOutcome::TimedOut => {
             let rationale =
                 "Automatic approval review timed out while evaluating the requested approval."
@@ -203,13 +239,22 @@ async fn run_guardian_review(
                         status: GuardianAssessmentStatus::TimedOut,
                         risk_level: None,
                         user_authorization: None,
-                        rationale: Some(rationale),
+                        rationale: Some(rationale.clone()),
                         decision_source: Some(GuardianAssessmentDecisionSource::Agent),
                         action: terminal_action,
                     }),
                 )
                 .await;
-            return ReviewDecision::TimedOut;
+            return GuardianApprovalReviewResult {
+                decision: ReviewDecision::TimedOut,
+                review: GuardianApprovalReview {
+                    status: GuardianApprovalReviewStatus::TimedOut,
+                    decision: None,
+                    risk_level: None,
+                    user_authorization: None,
+                    rationale: Some(rationale),
+                },
+            };
         }
         GuardianReviewOutcome::Aborted => {
             session
@@ -228,7 +273,16 @@ async fn run_guardian_review(
                     }),
                 )
                 .await;
-            return ReviewDecision::Abort;
+            return GuardianApprovalReviewResult {
+                decision: ReviewDecision::Abort,
+                review: GuardianApprovalReview {
+                    status: GuardianApprovalReviewStatus::Aborted,
+                    decision: None,
+                    risk_level: None,
+                    user_authorization: None,
+                    rationale: None,
+                },
+            };
         }
     };
 
@@ -259,6 +313,23 @@ async fn run_guardian_review(
     } else {
         GuardianAssessmentStatus::Denied
     };
+    let advisory_status = advisory_status.unwrap_or(if approved {
+        GuardianApprovalReviewStatus::Approved
+    } else {
+        GuardianApprovalReviewStatus::Denied
+    });
+    let decision = if approved {
+        ReviewDecision::Approved
+    } else {
+        ReviewDecision::Denied
+    };
+    let review = GuardianApprovalReview {
+        status: advisory_status,
+        decision: Some(assessment.outcome),
+        risk_level: Some(assessment.risk_level),
+        user_authorization: Some(assessment.user_authorization),
+        rationale: Some(assessment.rationale.clone()),
+    };
     {
         let mut rationales = session.services.guardian_rejections.lock().await;
         if approved {
@@ -288,11 +359,26 @@ async fn run_guardian_review(
         )
         .await;
 
-    if approved {
-        ReviewDecision::Approved
-    } else {
-        ReviewDecision::Denied
-    }
+    GuardianApprovalReviewResult { decision, review }
+}
+
+/// Runs guardian and returns both the approval decision and hook-visible review data.
+pub(crate) async fn review_approval_request_with_review(
+    session: &Arc<Session>,
+    turn: &Arc<TurnContext>,
+    review_id: String,
+    request: GuardianApprovalRequest,
+    retry_reason: Option<String>,
+) -> GuardianApprovalReviewResult {
+    run_guardian_review(
+        Arc::clone(session),
+        Arc::clone(turn),
+        review_id,
+        request,
+        retry_reason,
+        /*external_cancel*/ None,
+    )
+    .await
 }
 
 /// Public entrypoint for approval requests that should be reviewed by guardian.
@@ -303,15 +389,9 @@ pub(crate) async fn review_approval_request(
     request: GuardianApprovalRequest,
     retry_reason: Option<String>,
 ) -> ReviewDecision {
-    run_guardian_review(
-        Arc::clone(session),
-        Arc::clone(turn),
-        review_id,
-        request,
-        retry_reason,
-        /*external_cancel*/ None,
-    )
-    .await
+    review_approval_request_with_review(session, turn, review_id, request, retry_reason)
+        .await
+        .decision
 }
 
 pub(crate) async fn review_approval_request_with_cancel(
@@ -331,6 +411,7 @@ pub(crate) async fn review_approval_request_with_cancel(
         Some(cancel_token),
     )
     .await
+    .decision
 }
 
 /// Runs the guardian in a locked-down reusable review session.

--- a/codex-rs/core/src/hook_runtime.rs
+++ b/codex-rs/core/src/hook_runtime.rs
@@ -26,6 +26,7 @@ use serde_json::Value;
 use crate::codex::Session;
 use crate::codex::TurnContext;
 use crate::event_mapping::parse_turn_item;
+use crate::tools::sandboxing::PermissionRequestHookRequest;
 use crate::tools::sandboxing::PermissionRequestPayload;
 
 pub(crate) struct HookRuntimeOutcome {
@@ -152,9 +153,20 @@ pub(crate) async fn run_pre_tool_use_hooks(
 pub(crate) async fn run_permission_request_hooks(
     sess: &Arc<Session>,
     turn_context: &Arc<TurnContext>,
-    run_id_suffix: String,
-    payload: PermissionRequestPayload,
+    hook_request: PermissionRequestHookRequest,
 ) -> Option<PermissionRequestDecision> {
+    let PermissionRequestHookRequest {
+        run_id_suffix,
+        payload,
+        guardian_review,
+    } = hook_request;
+    let PermissionRequestPayload {
+        tool_name,
+        command,
+        sandbox_permissions,
+        additional_permissions,
+        justification,
+    } = payload;
     let request = PermissionRequestRequest {
         session_id: sess.conversation_id,
         turn_id: turn_context.sub_id.clone(),
@@ -162,12 +174,13 @@ pub(crate) async fn run_permission_request_hooks(
         transcript_path: sess.hook_transcript_path().await,
         model: turn_context.model_info.slug.clone(),
         permission_mode: hook_permission_mode(turn_context),
-        tool_name: payload.tool_name,
+        tool_name,
         run_id_suffix,
-        command: payload.command,
-        sandbox_permissions: payload.sandbox_permissions,
-        additional_permissions: payload.additional_permissions,
-        justification: payload.justification,
+        command,
+        sandbox_permissions,
+        additional_permissions,
+        justification,
+        guardian_review,
     };
     let preview_runs = sess.hooks().preview_permission_request(&request);
     emit_hook_started_events(sess, turn_context, preview_runs).await;

--- a/codex-rs/core/src/tools/orchestrator.rs
+++ b/codex-rs/core/src/tools/orchestrator.rs
@@ -6,9 +6,14 @@ simple sequence for any ToolRuntime: approval → select sandbox → attempt →
 retry with an escalated sandbox strategy on denial (no re‑approval thanks to
 caching).
 */
+use crate::guardian::GuardianApprovalReview;
+use crate::guardian::GuardianApprovalReviewResult;
+use crate::guardian::GuardianApprovalReviewStatus;
+use crate::guardian::GuardianAssessmentOutcome;
 use crate::guardian::guardian_rejection_message;
 use crate::guardian::guardian_timeout_message;
 use crate::guardian::new_guardian_review_id;
+use crate::guardian::review_approval_request_with_review;
 use crate::guardian::routes_approval_to_guardian;
 use crate::hook_runtime::run_permission_request_hooks;
 use crate::network_policy_decision::network_approval_context_from_payload;
@@ -19,6 +24,7 @@ use crate::tools::network_approval::finish_deferred_network_approval;
 use crate::tools::network_approval::finish_immediate_network_approval;
 use crate::tools::sandboxing::ApprovalCtx;
 use crate::tools::sandboxing::ExecApprovalRequirement;
+use crate::tools::sandboxing::PermissionRequestHookRequest;
 use crate::tools::sandboxing::SandboxAttempt;
 use crate::tools::sandboxing::SandboxOverride;
 use crate::tools::sandboxing::ToolCtx;
@@ -26,6 +32,9 @@ use crate::tools::sandboxing::ToolError;
 use crate::tools::sandboxing::ToolRuntime;
 use crate::tools::sandboxing::default_exec_approval_requirement;
 use codex_hooks::PermissionRequestDecision;
+use codex_hooks::PermissionRequestGuardianReview;
+use codex_hooks::PermissionRequestGuardianReviewDecision;
+use codex_hooks::PermissionRequestGuardianReviewStatus as HookGuardianReviewStatus;
 use codex_otel::SessionTelemetry;
 use codex_otel::ToolDecisionSource;
 use codex_protocol::error::CodexErr;
@@ -52,10 +61,17 @@ enum ApprovalAttempt {
     Retry,
 }
 
+#[derive(Clone, Copy)]
 struct ApprovalTelemetry<'a> {
     otel: &'a SessionTelemetry,
     tool_name: &'a str,
     call_id: &'a str,
+}
+
+struct ApprovalRequestCtx<'a> {
+    approval: ApprovalCtx<'a>,
+    routes_to_guardian: bool,
+    telemetry: ApprovalTelemetry<'a>,
 }
 
 impl ToolOrchestrator {
@@ -130,7 +146,6 @@ impl ToolOrchestrator {
         let otel_tn = &tool_ctx.tool_name;
         let otel_ci = &tool_ctx.call_id;
         let use_guardian = routes_approval_to_guardian(turn_ctx);
-
         // 1) Approval
         let mut already_approved = false;
 
@@ -163,12 +178,14 @@ impl ToolOrchestrator {
                     tool,
                     req,
                     ApprovalAttempt::Initial,
-                    approval_ctx,
-                    turn_ctx,
-                    ApprovalTelemetry {
-                        otel: &otel,
-                        tool_name: otel_tn,
-                        call_id: otel_ci,
+                    ApprovalRequestCtx {
+                        routes_to_guardian: use_guardian,
+                        approval: approval_ctx,
+                        telemetry: ApprovalTelemetry {
+                            otel: &otel,
+                            tool_name: otel_tn,
+                            call_id: otel_ci,
+                        },
                     },
                 )
                 .await?;
@@ -322,17 +339,18 @@ impl ToolOrchestrator {
                         retry_reason: Some(retry_reason),
                         network_approval_context: network_approval_context.clone(),
                     };
-
                     let decision = Self::request_approval(
                         tool,
                         req,
                         ApprovalAttempt::Retry,
-                        approval_ctx,
-                        turn_ctx,
-                        ApprovalTelemetry {
-                            otel: &otel,
-                            tool_name: otel_tn,
-                            call_id: otel_ci,
+                        ApprovalRequestCtx {
+                            routes_to_guardian: use_guardian,
+                            approval: approval_ctx,
+                            telemetry: ApprovalTelemetry {
+                                otel: &otel,
+                                tool_name: otel_tn,
+                                call_id: otel_ci,
+                            },
                         },
                     )
                     .await?;
@@ -399,21 +417,55 @@ impl ToolOrchestrator {
         }
     }
 
-    // PermissionRequest hooks get the first chance to answer approval prompts
-    // for tools that expose a hook payload. Today this is Bash-only; if no
-    // matching hook returns a decision, fall back to the normal user or guardian
-    // approval path.
+    // Centralize one approval prompt for three possible decision makers. If
+    // this prompt would normally route to guardian, run guardian first and pass
+    // its result to PermissionRequest hooks as advisory context. The hook can
+    // still answer the prompt; if it stays quiet, reuse the guardian decision
+    // instead of asking guardian again. Without a hook or reusable guardian
+    // result, fall back to the runtime's normal approval path.
     async fn request_approval<Rq, Out, T>(
         tool: &mut T,
         req: &Rq,
         approval_attempt: ApprovalAttempt,
-        approval_ctx: ApprovalCtx<'_>,
-        turn_ctx: &crate::codex::TurnContext,
-        telemetry: ApprovalTelemetry<'_>,
+        request_ctx: ApprovalRequestCtx<'_>,
     ) -> Result<ReviewDecision, ToolError>
     where
         T: ToolRuntime<Rq, Out>,
     {
+        let ApprovalRequestCtx {
+            approval: approval_ctx,
+            routes_to_guardian,
+            telemetry,
+        } = request_ctx;
+        let ApprovalTelemetry {
+            otel,
+            tool_name: otel_tn,
+            call_id: otel_ci,
+        } = telemetry;
+
+        let guardian_review = if routes_to_guardian {
+            if let Some(review_id) = approval_ctx.guardian_review_id.clone() {
+                if let Some(request) = tool.guardian_approval_request(req, &approval_ctx) {
+                    Some(
+                        review_approval_request_with_review(
+                            approval_ctx.session,
+                            approval_ctx.turn,
+                            review_id,
+                            request,
+                            approval_ctx.retry_reason.clone(),
+                        )
+                        .await,
+                    )
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
         if let Some(permission_request) = tool.permission_request_payload(req) {
             let run_id_suffix = match approval_attempt {
                 ApprovalAttempt::Initial => format!("{}:initial", approval_ctx.call_id),
@@ -422,24 +474,29 @@ impl ToolOrchestrator {
             match run_permission_request_hooks(
                 approval_ctx.session,
                 approval_ctx.turn,
-                run_id_suffix,
-                permission_request,
+                PermissionRequestHookRequest {
+                    run_id_suffix,
+                    payload: permission_request,
+                    guardian_review: guardian_review
+                        .as_ref()
+                        .map(|review| permission_request_guardian_review(review.review.clone())),
+                },
             )
             .await
             {
                 Some(PermissionRequestDecision::Allow) => {
-                    telemetry.otel.tool_decision(
-                        telemetry.tool_name,
-                        telemetry.call_id,
+                    otel.tool_decision(
+                        otel_tn,
+                        otel_ci,
                         &ReviewDecision::Approved,
                         ToolDecisionSource::Config,
                     );
                     return Ok(ReviewDecision::Approved);
                 }
                 Some(PermissionRequestDecision::Deny { message }) => {
-                    telemetry.otel.tool_decision(
-                        telemetry.tool_name,
-                        telemetry.call_id,
+                    otel.tool_decision(
+                        otel_tn,
+                        otel_ci,
                         &ReviewDecision::Denied,
                         ToolDecisionSource::Config,
                     );
@@ -449,18 +506,23 @@ impl ToolOrchestrator {
             }
         }
 
+        if let Some(GuardianApprovalReviewResult { decision, .. }) = guardian_review {
+            otel.tool_decision(
+                otel_tn,
+                otel_ci,
+                &decision,
+                ToolDecisionSource::AutomatedReviewer,
+            );
+            return Ok(decision);
+        }
+
         let decision = tool.start_approval_async(req, approval_ctx).await;
-        let otel_source = if routes_approval_to_guardian(turn_ctx) {
+        let otel_source = if routes_to_guardian {
             ToolDecisionSource::AutomatedReviewer
         } else {
             ToolDecisionSource::User
         };
-        telemetry.otel.tool_decision(
-            telemetry.tool_name,
-            telemetry.call_id,
-            &decision,
-            otel_source,
-        );
+        otel.tool_decision(otel_tn, otel_ci, &decision, otel_source);
         Ok(decision)
     }
 }
@@ -469,4 +531,25 @@ fn build_denial_reason_from_output(_output: &ExecToolCallOutput) -> String {
     // Keep approval reason terse and stable for UX/tests, but accept the
     // output so we can evolve heuristics later without touching call sites.
     "command failed; retry without sandbox?".to_string()
+}
+
+fn permission_request_guardian_review(
+    review: GuardianApprovalReview,
+) -> PermissionRequestGuardianReview {
+    PermissionRequestGuardianReview {
+        status: match review.status {
+            GuardianApprovalReviewStatus::Approved => HookGuardianReviewStatus::Approved,
+            GuardianApprovalReviewStatus::Denied => HookGuardianReviewStatus::Denied,
+            GuardianApprovalReviewStatus::Aborted => HookGuardianReviewStatus::Aborted,
+            GuardianApprovalReviewStatus::Failed => HookGuardianReviewStatus::Failed,
+            GuardianApprovalReviewStatus::TimedOut => HookGuardianReviewStatus::TimedOut,
+        },
+        decision: review.decision.map(|decision| match decision {
+            GuardianAssessmentOutcome::Allow => PermissionRequestGuardianReviewDecision::Allow,
+            GuardianAssessmentOutcome::Deny => PermissionRequestGuardianReviewDecision::Deny,
+        }),
+        risk_level: review.risk_level,
+        user_authorization: review.user_authorization,
+        rationale: review.rationale,
+    }
 }

--- a/codex-rs/core/src/tools/runtimes/shell.rs
+++ b/codex-rs/core/src/tools/runtimes/shell.rs
@@ -117,6 +117,17 @@ impl ShellRuntime {
             tx_event: ctx.session.get_tx_event(),
         })
     }
+
+    fn guardian_request(req: &ShellRequest, ctx: &ApprovalCtx<'_>) -> GuardianApprovalRequest {
+        GuardianApprovalRequest::Shell {
+            id: ctx.call_id.to_string(),
+            command: req.command.clone(),
+            cwd: req.cwd.to_path_buf(),
+            sandbox_permissions: req.sandbox_permissions,
+            additional_permissions: req.additional_permissions.clone(),
+            justification: req.justification.clone(),
+        }
+    }
 }
 
 impl Sandboxable for ShellRuntime {
@@ -160,14 +171,7 @@ impl Approvable<ShellRequest> for ShellRuntime {
                     session,
                     turn,
                     review_id,
-                    GuardianApprovalRequest::Shell {
-                        id: call_id,
-                        command,
-                        cwd,
-                        sandbox_permissions: req.sandbox_permissions,
-                        additional_permissions: req.additional_permissions.clone(),
-                        justification: req.justification.clone(),
-                    },
+                    Self::guardian_request(req, &ctx),
                     retry_reason,
                 )
                 .await;
@@ -206,6 +210,14 @@ impl Approvable<ShellRequest> for ShellRuntime {
             req.additional_permissions.clone(),
             req.justification.clone(),
         ))
+    }
+
+    fn guardian_approval_request(
+        &self,
+        req: &ShellRequest,
+        ctx: &ApprovalCtx<'_>,
+    ) -> Option<GuardianApprovalRequest> {
+        Some(Self::guardian_request(req, ctx))
     }
 
     fn sandbox_mode_for_first_attempt(&self, req: &ShellRequest) -> SandboxOverride {

--- a/codex-rs/core/src/tools/runtimes/unified_exec.rs
+++ b/codex-rs/core/src/tools/runtimes/unified_exec.rs
@@ -91,6 +91,21 @@ impl<'a> UnifiedExecRuntime<'a> {
             shell_mode,
         }
     }
+
+    fn guardian_request(
+        req: &UnifiedExecRequest,
+        ctx: &ApprovalCtx<'_>,
+    ) -> GuardianApprovalRequest {
+        GuardianApprovalRequest::ExecCommand {
+            id: ctx.call_id.to_string(),
+            command: req.command.clone(),
+            cwd: req.cwd.to_path_buf(),
+            sandbox_permissions: req.sandbox_permissions,
+            additional_permissions: req.additional_permissions.clone(),
+            justification: req.justification.clone(),
+            tty: req.tty,
+        }
+    }
 }
 
 impl Sandboxable for UnifiedExecRuntime<'_> {
@@ -136,15 +151,7 @@ impl Approvable<UnifiedExecRequest> for UnifiedExecRuntime<'_> {
                     session,
                     turn,
                     review_id,
-                    GuardianApprovalRequest::ExecCommand {
-                        id: call_id,
-                        command,
-                        cwd,
-                        sandbox_permissions: req.sandbox_permissions,
-                        additional_permissions: req.additional_permissions.clone(),
-                        justification: req.justification.clone(),
-                        tty: req.tty,
-                    },
+                    Self::guardian_request(req, &ctx),
                     retry_reason,
                 )
                 .await;
@@ -189,6 +196,14 @@ impl Approvable<UnifiedExecRequest> for UnifiedExecRuntime<'_> {
             req.additional_permissions.clone(),
             req.justification.clone(),
         ))
+    }
+
+    fn guardian_approval_request(
+        &self,
+        req: &UnifiedExecRequest,
+        ctx: &ApprovalCtx<'_>,
+    ) -> Option<GuardianApprovalRequest> {
+        Some(Self::guardian_request(req, ctx))
     }
 
     fn sandbox_mode_for_first_attempt(&self, req: &UnifiedExecRequest) -> SandboxOverride {

--- a/codex-rs/core/src/tools/sandboxing.rs
+++ b/codex-rs/core/src/tools/sandboxing.rs
@@ -6,10 +6,12 @@
 
 use crate::codex::Session;
 use crate::codex::TurnContext;
+use crate::guardian::GuardianApprovalRequest;
 use crate::sandboxing::ExecOptions;
 use crate::sandboxing::SandboxPermissions;
 use crate::state::SessionServices;
 use crate::tools::network_approval::NetworkApprovalSpec;
+use codex_hooks::PermissionRequestGuardianReview;
 use codex_network_proxy::NetworkProxy;
 use codex_protocol::approvals::ExecPolicyAmendment;
 use codex_protocol::approvals::NetworkApprovalContext;
@@ -158,6 +160,13 @@ impl PermissionRequestPayload {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PermissionRequestHookRequest {
+    pub run_id_suffix: String,
+    pub payload: PermissionRequestPayload,
+    pub guardian_review: Option<PermissionRequestGuardianReview>,
+}
+
 // Specifies what tool orchestrator should do with a given tool call.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum ExecApprovalRequirement {
@@ -301,6 +310,19 @@ pub(crate) trait Approvable<Req> {
     }
 
     fn permission_request_payload(&self, _req: &Req) -> Option<PermissionRequestPayload> {
+        None
+    }
+
+    /// Build the guardian request that corresponds to this approval prompt.
+    ///
+    /// Runtimes that can route approvals through guardian should return the
+    /// same request they would pass to `review_approval_request`, so shared
+    /// orchestration can run guardian once and reuse that decision as fallback.
+    fn guardian_approval_request(
+        &self,
+        _req: &Req,
+        _ctx: &ApprovalCtx<'_>,
+    ) -> Option<GuardianApprovalRequest> {
         None
     }
 

--- a/codex-rs/core/tests/suite/hooks.rs
+++ b/codex-rs/core/tests/suite/hooks.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 use anyhow::Context;
 use anyhow::Result;
+use codex_config::types::ApprovalsReviewer;
 use codex_features::Feature;
 use codex_protocol::items::parse_hook_prompt_fragment;
 use codex_protocol::models::ContentItem;
@@ -12,6 +13,7 @@ use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::Op;
 use codex_protocol::protocol::RolloutItem;
 use codex_protocol::protocol::RolloutLine;
+use codex_protocol::protocol::SandboxPolicy;
 use codex_protocol::user_input::UserInput;
 use core_test_support::responses::ev_assistant_message;
 use core_test_support::responses::ev_completed;
@@ -578,10 +580,9 @@ async fn stop_hook_can_block_multiple_times_in_same_turn() -> Result<()> {
             }
         })
         .with_config(|config| {
-            config
-                .features
-                .enable(Feature::CodexHooks)
-                .expect("test config should allow feature update");
+            if let Err(error) = config.features.enable(Feature::CodexHooks) {
+                panic!("test config should allow feature update: {error}");
+            }
         });
     let test = builder.build(&server).await?;
 
@@ -677,10 +678,9 @@ async fn session_start_hook_sees_materialized_transcript_path() -> Result<()> {
             }
         })
         .with_config(|config| {
-            config
-                .features
-                .enable(Feature::CodexHooks)
-                .expect("test config should allow feature update");
+            if let Err(error) = config.features.enable(Feature::CodexHooks) {
+                panic!("test config should allow feature update: {error}");
+            }
         });
     let test = builder.build(&server).await?;
 
@@ -1142,7 +1142,7 @@ async fn permission_request_hook_allows_shell_command_without_user_approval() ->
     test.submit_turn_with_policies(
         "run the shell command after hook approval",
         AskForApproval::OnRequest,
-        codex_protocol::protocol::SandboxPolicy::DangerFullAccess,
+        SandboxPolicy::DangerFullAccess,
     )
     .await?;
 
@@ -1167,6 +1167,7 @@ async fn permission_request_hook_allows_shell_command_without_user_approval() ->
             "justification": null,
         })
     );
+    assert_eq!(hook_inputs[0]["guardian_review"], Value::Null);
     assert!(
         hook_inputs[0].get("tool_use_id").is_none(),
         "PermissionRequest input should not include a tool_use_id",
@@ -1175,6 +1176,137 @@ async fn permission_request_hook_allows_shell_command_without_user_approval() ->
         hook_inputs[0]["turn_id"]
             .as_str()
             .is_some_and(|turn_id| !turn_id.is_empty())
+    );
+
+    Ok(())
+}
+
+#[test]
+fn permission_request_hook_receives_guardian_review_before_fallback() -> Result<()> {
+    std::thread::Builder::new()
+        .stack_size(32 * 1024 * 1024)
+        .spawn(|| {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build current-thread tokio runtime")
+                .block_on(permission_request_hook_receives_guardian_review_before_fallback_inner())
+        })
+        .expect("spawn guardian permission request hook test thread")
+        .join()
+        .expect("guardian permission request hook test thread panicked")
+}
+
+async fn permission_request_hook_receives_guardian_review_before_fallback_inner() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let call_id = "permissionrequest-guardian-review";
+    let marker = std::env::temp_dir().join("permissionrequest-guardian-review-marker");
+    let command = format!("rm -f {}", marker.display());
+    let args = serde_json::json!({ "command": command });
+    let guardian_assessment = serde_json::json!({
+        "risk_level": "medium",
+        "user_authorization": "high",
+        "outcome": "allow",
+        "rationale": "The user asked to delete this local marker file.",
+    })
+    .to_string();
+    let responses = mount_sse_sequence(
+        &server,
+        vec![
+            sse(vec![
+                ev_response_created("resp-1"),
+                core_test_support::responses::ev_function_call(
+                    call_id,
+                    "shell_command",
+                    &serde_json::to_string(&args)?,
+                ),
+                ev_completed("resp-1"),
+            ]),
+            sse(vec![
+                ev_response_created("resp-guardian"),
+                ev_assistant_message("msg-guardian", &guardian_assessment),
+                ev_completed("resp-guardian"),
+            ]),
+            sse(vec![
+                ev_response_created("resp-2"),
+                ev_assistant_message("msg-1", "guardian fallback allowed it"),
+                ev_completed("resp-2"),
+            ]),
+        ],
+    )
+    .await;
+
+    let mut builder = test_codex()
+        .with_pre_build_hook(|home| {
+            if let Err(error) =
+                write_permission_request_hook(home, Some("^Bash$"), "quiet", "unused")
+            {
+                panic!("failed to write permission request hook test fixture: {error}");
+            }
+        })
+        .with_config(|config| {
+            if let Err(error) = config.features.enable(Feature::CodexHooks) {
+                panic!("test config should allow feature update: {error}");
+            }
+            if let Err(error) = config.features.enable(Feature::ExecPermissionApprovals) {
+                panic!("test config should allow feature update: {error}");
+            }
+            if let Err(error) = config.features.enable(Feature::GuardianApproval) {
+                panic!("test config should allow feature update: {error}");
+            }
+            config.approvals_reviewer = ApprovalsReviewer::GuardianSubagent;
+        });
+    let test = builder.build(&server).await?;
+
+    fs::write(&marker, "seed").context("create guardian review marker")?;
+
+    test.submit_turn_with_policies(
+        "run the shell command after guardian review",
+        AskForApproval::OnRequest,
+        SandboxPolicy::DangerFullAccess,
+    )
+    .await?;
+
+    let requests = responses.requests();
+    assert_eq!(
+        requests.len(),
+        3,
+        "guardian decision should be reused instead of running a second review",
+    );
+    assert!(
+        requests[2]
+            .input()
+            .iter()
+            .any(|item| item.get("type").and_then(Value::as_str) == Some("function_call_output")),
+        "guardian-approved fallback should continue with tool output",
+    );
+    assert!(
+        !marker.exists(),
+        "guardian-approved fallback should remove marker file",
+    );
+
+    let hook_inputs = read_permission_request_hook_inputs(test.codex_home_path())?;
+    assert_eq!(hook_inputs.len(), 1);
+    assert_eq!(hook_inputs[0]["tool_input"]["command"], command);
+    assert_eq!(
+        hook_inputs[0]["approval_context"],
+        serde_json::json!({
+            "sandbox_permissions": "use_default",
+            "additional_permissions": null,
+            "justification": null,
+        })
+    );
+    assert_eq!(
+        hook_inputs[0]["guardian_review"],
+        serde_json::json!({
+            "status": "approved",
+            "decision": "allow",
+            "risk_level": "medium",
+            "user_authorization": "high",
+            "rationale": "The user asked to delete this local marker file.",
+        })
     );
 
     Ok(())

--- a/codex-rs/hooks/schema/generated/permission-request.command.input.schema.json
+++ b/codex-rs/hooks/schema/generated/permission-request.command.input.schema.json
@@ -23,6 +23,24 @@
       },
       "type": "object"
     },
+    "GuardianRiskLevel": {
+      "enum": [
+        "low",
+        "medium",
+        "high",
+        "critical"
+      ],
+      "type": "string"
+    },
+    "GuardianUserAuthorization": {
+      "enum": [
+        "unknown",
+        "low",
+        "medium",
+        "high"
+      ],
+      "type": "string"
+    },
     "NetworkPermissions": {
       "properties": {
         "enabled": {
@@ -65,6 +83,75 @@
         "sandbox_permissions"
       ],
       "type": "object"
+    },
+    "PermissionRequestGuardianReview": {
+      "additionalProperties": false,
+      "properties": {
+        "decision": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PermissionRequestGuardianReviewDecision"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "rationale": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "risk_level": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/GuardianRiskLevel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "status": {
+          "$ref": "#/definitions/PermissionRequestGuardianReviewStatus"
+        },
+        "user_authorization": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/GuardianUserAuthorization"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "decision",
+        "rationale",
+        "risk_level",
+        "status",
+        "user_authorization"
+      ],
+      "type": "object"
+    },
+    "PermissionRequestGuardianReviewDecision": {
+      "enum": [
+        "allow",
+        "deny"
+      ],
+      "type": "string"
+    },
+    "PermissionRequestGuardianReviewStatus": {
+      "enum": [
+        "approved",
+        "denied",
+        "aborted",
+        "failed",
+        "timed_out"
+      ],
+      "type": "string"
     },
     "PermissionRequestToolInput": {
       "additionalProperties": false,
@@ -112,6 +199,16 @@
     "cwd": {
       "type": "string"
     },
+    "guardian_review": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/PermissionRequestGuardianReview"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "hook_event_name": {
       "const": "PermissionRequest",
       "type": "string"
@@ -150,6 +247,7 @@
   "required": [
     "approval_context",
     "cwd",
+    "guardian_review",
     "hook_event_name",
     "model",
     "permission_mode",

--- a/codex-rs/hooks/src/events/permission_request.rs
+++ b/codex-rs/hooks/src/events/permission_request.rs
@@ -1,3 +1,10 @@
+//! PermissionRequest hook execution for approval prompts.
+//!
+//! This event is different from `PreToolUse`: it runs only when Codex is about
+//! to ask for permission, and its decision answers that approval prompt rather
+//! than blocking normal tool execution. A quiet hook is a no-op so callers can
+//! fall back to the existing approval path.
+
 use std::path::PathBuf;
 
 use codex_protocol::ThreadId;
@@ -16,6 +23,7 @@ use crate::engine::ConfiguredHandler;
 use crate::engine::command_runner::CommandRunResult;
 use crate::engine::dispatcher;
 use crate::engine::output_parser;
+use crate::permission_review::PermissionRequestGuardianReview;
 use crate::schema::PermissionRequestApprovalContext;
 use crate::schema::PermissionRequestCommandInput;
 use crate::schema::PermissionRequestToolInput;
@@ -29,11 +37,21 @@ pub struct PermissionRequestRequest {
     pub model: String,
     pub permission_mode: String,
     pub tool_name: String,
+    /// Suffix used only for hook run ids.
+    ///
+    /// Claude's PermissionRequest input does not include `tool_use_id`, but Codex
+    /// still needs stable begin/end ids for hook UI and transcript bookkeeping.
     pub run_id_suffix: String,
     pub command: String,
     pub sandbox_permissions: SandboxPermissions,
     pub additional_permissions: Option<PermissionProfile>,
     pub justification: Option<String>,
+    /// Advisory approval context from Codex's automated reviewer, when one ran.
+    ///
+    /// A hook can use this as another signal, but it is not bound by the
+    /// guardian's decision. The hook may allow, deny, or stay quiet; if it stays
+    /// quiet, the orchestrator falls back to the guardian's original decision.
+    pub guardian_review: Option<PermissionRequestGuardianReview>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -89,6 +107,10 @@ pub(crate) async fn run(
         };
     }
 
+    // This first pass is Bash-only. Keep the wire input fixed to Claude's
+    // `Bash` shape even though the request carries `tool_name`, so later
+    // tool support has to choose its own explicit schema instead of
+    // accidentally inheriting Bash fields.
     let input_json = match serde_json::to_string(&build_command_input(&request)) {
         Ok(input_json) => input_json,
         Err(error) => {
@@ -115,6 +137,9 @@ pub(crate) async fn run(
     )
     .await;
 
+    // Multiple hooks may match the same approval prompt. For now, use the first
+    // explicit decision in declaration order and leave richer precedence rules
+    // to the follow-up work.
     let decision = results
         .iter()
         .find_map(|result| result.data.decision.clone());
@@ -148,6 +173,7 @@ fn build_command_input(request: &PermissionRequestRequest) -> PermissionRequestC
             additional_permissions: request.additional_permissions.clone(),
             justification: request.justification.clone(),
         },
+        guardian_review: request.guardian_review.clone(),
     }
 }
 
@@ -203,6 +229,9 @@ fn parse_completed(
                         }
                     }
                 } else if trimmed_stdout.starts_with('{') || trimmed_stdout.starts_with('[') {
+                    // Invalid JSON-like output is treated as a hook failure, not an
+                    // approval decision. That keeps malformed hooks fail-open: the
+                    // orchestrator can still fall back to normal approval.
                     status = HookRunStatus::Failed;
                     entries.push(HookOutputEntry {
                         kind: HookOutputEntryKind::Error,
@@ -211,6 +240,8 @@ fn parse_completed(
                 }
             }
             Some(2) => {
+                // Match Claude's blocking-hook convention: exit code 2 denies
+                // the approval prompt, with stderr as the denial message.
                 if let Some(message) = common::trimmed_non_empty(&run_result.stderr) {
                     status = HookRunStatus::Blocked;
                     entries.push(HookOutputEntry {
@@ -251,5 +282,89 @@ fn parse_completed(
     dispatcher::ParsedHandler {
         completed,
         data: PermissionRequestHandlerData { decision },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use codex_protocol::ThreadId;
+    use codex_protocol::models::NetworkPermissions;
+    use codex_protocol::models::PermissionProfile;
+    use codex_protocol::models::SandboxPermissions;
+    use pretty_assertions::assert_eq;
+    use serde_json::json;
+
+    use super::PermissionRequestRequest;
+    use super::build_command_input;
+
+    #[test]
+    fn command_input_includes_approval_context_alongside_guardian_review() {
+        let request = PermissionRequestRequest {
+            session_id: ThreadId::new(),
+            turn_id: "turn-123".to_string(),
+            cwd: PathBuf::from("/repo"),
+            transcript_path: Some(PathBuf::from("/tmp/transcript.jsonl")),
+            model: "gpt-5".to_string(),
+            permission_mode: "on-request".to_string(),
+            tool_name: "Bash".to_string(),
+            run_id_suffix: "call-123".to_string(),
+            command: "cargo test -p codex-core".to_string(),
+            sandbox_permissions: SandboxPermissions::WithAdditionalPermissions,
+            additional_permissions: Some(PermissionProfile {
+                network: Some(NetworkPermissions {
+                    enabled: Some(true),
+                }),
+                file_system: None,
+            }),
+            justification: Some("Need network and target writes".to_string()),
+            guardian_review: Some(crate::permission_review::PermissionRequestGuardianReview {
+                status: crate::permission_review::PermissionRequestGuardianReviewStatus::Approved,
+                decision: Some(
+                    crate::permission_review::PermissionRequestGuardianReviewDecision::Allow,
+                ),
+                risk_level: None,
+                user_authorization: None,
+                rationale: Some("Scoped escalation looks reasonable".to_string()),
+            }),
+        };
+
+        let actual = serde_json::to_value(build_command_input(&request))
+            .expect("serialize permission request input");
+
+        assert_eq!(
+            actual,
+            json!({
+                "session_id": request.session_id.to_string(),
+                "turn_id": "turn-123",
+                "transcript_path": "/tmp/transcript.jsonl",
+                "cwd": "/repo",
+                "hook_event_name": "PermissionRequest",
+                "model": "gpt-5",
+                "permission_mode": "on-request",
+                "tool_name": "Bash",
+                "tool_input": {
+                    "command": "cargo test -p codex-core",
+                },
+                "approval_context": {
+                    "sandbox_permissions": "with_additional_permissions",
+                    "additional_permissions": {
+                        "file_system": null,
+                        "network": {
+                            "enabled": true,
+                        },
+                    },
+                    "justification": "Need network and target writes",
+                },
+                "guardian_review": {
+                    "status": "approved",
+                    "decision": "allow",
+                    "risk_level": null,
+                    "user_authorization": null,
+                    "rationale": "Scoped escalation looks reasonable",
+                },
+            })
+        );
     }
 }

--- a/codex-rs/hooks/src/lib.rs
+++ b/codex-rs/hooks/src/lib.rs
@@ -1,6 +1,7 @@
 mod engine;
 pub(crate) mod events;
 mod legacy_notify;
+mod permission_review;
 mod registry;
 mod schema;
 mod types;
@@ -21,6 +22,9 @@ pub use events::user_prompt_submit::UserPromptSubmitOutcome;
 pub use events::user_prompt_submit::UserPromptSubmitRequest;
 pub use legacy_notify::legacy_notify_json;
 pub use legacy_notify::notify_hook;
+pub use permission_review::PermissionRequestGuardianReview;
+pub use permission_review::PermissionRequestGuardianReviewDecision;
+pub use permission_review::PermissionRequestGuardianReviewStatus;
 pub use registry::Hooks;
 pub use registry::HooksConfig;
 pub use registry::command_from_argv;

--- a/codex-rs/hooks/src/permission_review.rs
+++ b/codex-rs/hooks/src/permission_review.rs
@@ -1,0 +1,83 @@
+use codex_protocol::protocol::GuardianRiskLevel;
+use codex_protocol::protocol::GuardianUserAuthorization;
+use schemars::JsonSchema;
+use schemars::r#gen::SchemaGenerator;
+use schemars::schema::InstanceType;
+use schemars::schema::Schema;
+use schemars::schema::SchemaObject;
+use schemars::schema::SubschemaValidation;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct PermissionRequestGuardianReview {
+    pub status: PermissionRequestGuardianReviewStatus,
+    #[schemars(schema_with = "nullable_permission_request_guardian_review_decision_schema")]
+    pub decision: Option<PermissionRequestGuardianReviewDecision>,
+    #[schemars(schema_with = "nullable_guardian_risk_level_schema")]
+    pub risk_level: Option<GuardianRiskLevel>,
+    #[schemars(schema_with = "nullable_guardian_user_authorization_schema")]
+    pub user_authorization: Option<GuardianUserAuthorization>,
+    #[schemars(schema_with = "nullable_string_schema")]
+    pub rationale: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PermissionRequestGuardianReviewStatus {
+    Approved,
+    Denied,
+    Aborted,
+    Failed,
+    TimedOut,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PermissionRequestGuardianReviewDecision {
+    Allow,
+    Deny,
+}
+
+pub(crate) fn nullable_permission_request_guardian_review_schema(
+    generator: &mut SchemaGenerator,
+) -> Schema {
+    nullable_schema(generator.subschema_for::<PermissionRequestGuardianReview>())
+}
+
+fn nullable_permission_request_guardian_review_decision_schema(
+    generator: &mut SchemaGenerator,
+) -> Schema {
+    nullable_schema(generator.subschema_for::<PermissionRequestGuardianReviewDecision>())
+}
+
+fn nullable_guardian_risk_level_schema(generator: &mut SchemaGenerator) -> Schema {
+    nullable_schema(generator.subschema_for::<GuardianRiskLevel>())
+}
+
+fn nullable_guardian_user_authorization_schema(generator: &mut SchemaGenerator) -> Schema {
+    nullable_schema(generator.subschema_for::<GuardianUserAuthorization>())
+}
+
+fn nullable_string_schema(_generator: &mut SchemaGenerator) -> Schema {
+    Schema::Object(SchemaObject {
+        instance_type: Some(vec![InstanceType::String, InstanceType::Null].into()),
+        ..Default::default()
+    })
+}
+
+fn nullable_schema(schema: Schema) -> Schema {
+    Schema::Object(SchemaObject {
+        subschemas: Some(Box::new(SubschemaValidation {
+            any_of: Some(vec![
+                schema,
+                Schema::Object(SchemaObject {
+                    instance_type: Some(InstanceType::Null.into()),
+                    ..Default::default()
+                }),
+            ]),
+            ..Default::default()
+        })),
+        ..Default::default()
+    })
+}

--- a/codex-rs/hooks/src/schema.rs
+++ b/codex-rs/hooks/src/schema.rs
@@ -15,6 +15,8 @@ use std::path::PathBuf;
 use codex_protocol::models::PermissionProfile;
 use codex_protocol::models::SandboxPermissions;
 
+use crate::permission_review::PermissionRequestGuardianReview;
+
 const GENERATED_DIR: &str = "generated";
 const POST_TOOL_USE_INPUT_FIXTURE: &str = "post-tool-use.command.input.schema.json";
 const POST_TOOL_USE_OUTPUT_FIXTURE: &str = "post-tool-use.command.output.schema.json";
@@ -264,6 +266,10 @@ pub(crate) struct PermissionRequestCommandInput {
     pub tool_name: String,
     pub tool_input: PermissionRequestToolInput,
     pub approval_context: PermissionRequestApprovalContext,
+    #[schemars(
+        schema_with = "crate::permission_review::nullable_permission_request_guardian_review_schema"
+    )]
+    pub guardian_review: Option<PermissionRequestGuardianReview>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]


### PR DESCRIPTION
## Summary

Stacks on #17563 and adds the guardian-specific PermissionRequest behavior.

When an approval would route through guardian, Codex now runs guardian first, passes the resulting review into the PermissionRequest hook input as advisory context, and reuses that guardian decision if matching hooks stay quiet. Hooks can still explicitly allow or deny the approval prompt.

## Validation

- `just write-hooks-schema`
- `just fmt`
- `cargo test -p codex-hooks`
- `cargo test -p codex-core permission_request_hook`
- `just fix -p codex-core`
- `just fix -p codex-hooks`