### PR TITLE
feat(tui): gate narrow permission requests by capability

### DIFF
--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -168,6 +168,7 @@ pub(crate) async fn apply_bespoke_event_handling(
     conversation: Arc<CodexThread>,
     thread_manager: Arc<ThreadManager>,
     outgoing: ThreadScopedOutgoingMessageSender,
+    request_permissions_outgoing: ThreadScopedOutgoingMessageSender,
     thread_state: Arc<tokio::sync::Mutex<ThreadState>>,
     thread_watch_manager: ThreadWatchManager,
     api_version: ApiVersion,
@@ -854,7 +855,7 @@ pub(crate) async fn apply_bespoke_event_handling(
             }
         }
         EventMsg::RequestPermissions(request) => {
-            if matches!(api_version, ApiVersion::V2) {
+            if matches!(api_version, ApiVersion::V2) && !request_permissions_outgoing.is_empty() {
                 let permission_guard = thread_watch_manager
                     .note_permission_requested(&conversation_id.to_string())
                     .await;
@@ -866,7 +867,7 @@ pub(crate) async fn apply_bespoke_event_handling(
                     reason: request.reason,
                     permissions: request.permissions.into(),
                 };
-                let (pending_request_id, rx) = outgoing
+                let (pending_request_id, rx) = request_permissions_outgoing
                     .send_request(ServerRequestPayload::PermissionsRequestApproval(params))
                     .await;
                 tokio::spawn(async move {
@@ -882,8 +883,11 @@ pub(crate) async fn apply_bespoke_event_handling(
                     .await;
                 });
             } else {
-                error!(
-                    "request_permissions is only supported on api v2 (call_id: {})",
+                // App-server clients must advertise support before receiving
+                // permission confirmation requests. Fail closed instead of
+                // emitting a request that existing clients cannot answer.
+                warn!(
+                    "request_permissions is not supported by this app-server client (call_id: {})",
                     request.call_id
                 );
                 let empty = CoreRequestPermissionsResponse {
@@ -3057,6 +3061,7 @@ mod tests {
                 self.conversation_id,
                 self.conversation.clone(),
                 self.thread_manager.clone(),
+                self.outgoing.clone(),
                 self.outgoing.clone(),
                 self.thread_state.clone(),
                 self.thread_watch_manager.clone(),

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -2331,6 +2331,13 @@ impl CodexMessageProcessor {
             };
         }
 
+        apply_surface_capability_feature_gates(
+            &mut config,
+            &listener_task_context.thread_state_manager,
+            &request_id,
+        )
+        .await;
+
         let instruction_sources = Self::instruction_sources_from_config(&config).await;
         let dynamic_tools = dynamic_tools.unwrap_or_default();
         let core_dynamic_tools = if dynamic_tools.is_empty() {
@@ -3886,7 +3893,7 @@ impl CodexMessageProcessor {
         let cloud_requirements = self.current_cloud_requirements();
         let cli_overrides = self.current_cli_overrides();
         let runtime_feature_enablement = self.current_runtime_feature_enablement();
-        let config = match derive_config_for_cwd(
+        let mut config = match derive_config_for_cwd(
             &cli_overrides,
             request_overrides,
             typesafe_overrides,
@@ -3904,6 +3911,12 @@ impl CodexMessageProcessor {
                 return;
             }
         };
+        apply_surface_capability_feature_gates(
+            &mut config,
+            &self.thread_state_manager,
+            &request_id,
+        )
+        .await;
 
         let fallback_model_provider = config.model_provider_id.clone();
         let instruction_sources = Self::instruction_sources_from_config(&config).await;
@@ -4444,7 +4457,7 @@ impl CodexMessageProcessor {
         let cloud_requirements = self.current_cloud_requirements();
         let cli_overrides = self.current_cli_overrides();
         let runtime_feature_enablement = self.current_runtime_feature_enablement();
-        let config = match derive_config_for_cwd(
+        let mut config = match derive_config_for_cwd(
             &cli_overrides,
             request_overrides,
             typesafe_overrides,
@@ -4463,6 +4476,12 @@ impl CodexMessageProcessor {
                 return;
             }
         };
+        apply_surface_capability_feature_gates(
+            &mut config,
+            &self.thread_state_manager,
+            &request_id,
+        )
+        .await;
 
         let fallback_model_provider = config.model_provider_id.clone();
         let instruction_sources = Self::instruction_sources_from_config(&config).await;
@@ -7539,11 +7558,19 @@ impl CodexMessageProcessor {
                         let subscribed_connection_ids = thread_state_manager
                             .subscribed_connection_ids(conversation_id)
                             .await;
+                        let request_permissions_connection_ids = thread_state_manager
+                            .subscribed_connection_ids_supporting(
+                                conversation_id,
+                                SupportedServerRequestMethod::PermissionsRequestApproval,
+                            )
+                            .await;
                         let thread_outgoing = ThreadScopedOutgoingMessageSender::new(
                             outgoing_for_task.clone(),
                             subscribed_connection_ids,
                             conversation_id,
                         );
+                        let request_permissions_outgoing = thread_outgoing
+                            .with_connection_ids(request_permissions_connection_ids);
 
                         if let EventMsg::RawResponseItem(raw_response_item_event) = &event.msg
                             && !raw_events_enabled
@@ -7565,6 +7592,7 @@ impl CodexMessageProcessor {
                             conversation.clone(),
                             thread_manager.clone(),
                             thread_outgoing,
+                            request_permissions_outgoing,
                             thread_state.clone(),
                             thread_watch_manager.clone(),
                             api_version,
@@ -8684,6 +8712,45 @@ async fn derive_config_from_params(
         .await?;
     apply_runtime_feature_enablement(&mut config, runtime_feature_enablement);
     Ok(config)
+}
+
+async fn apply_surface_capability_feature_gates(
+    config: &mut Config,
+    thread_state_manager: &ThreadStateManager,
+    request_id: &ConnectionRequestId,
+) {
+    let supported_server_requests = thread_state_manager
+        .supported_server_requests_for_connection(request_id.connection_id)
+        .await;
+    gate_permission_tool_feature(
+        config,
+        Feature::RequestPermissionsTool,
+        supported_server_requests
+            .contains(&SupportedServerRequestMethod::PermissionsRequestApproval),
+    );
+    gate_permission_tool_feature(
+        config,
+        Feature::RequestPermissionPresetTool,
+        /*surface_supports_tool*/ false,
+    );
+}
+
+fn gate_permission_tool_feature(
+    config: &mut Config,
+    feature: Feature,
+    surface_supports_tool: bool,
+) {
+    if surface_supports_tool || !config.features.get().enabled(feature) {
+        return;
+    }
+
+    if let Err(err) = config.features.disable(feature) {
+        warn!(
+            ?feature,
+            error = %err,
+            "failed to gate permission tool feature for unsupported app-server surface"
+        );
+    }
 }
 
 async fn derive_config_for_cwd(

--- a/codex-rs/app-server/src/outgoing_message.rs
+++ b/codex-rs/app-server/src/outgoing_message.rs
@@ -145,6 +145,18 @@ impl ThreadScopedOutgoingMessageSender {
         }
     }
 
+    pub(crate) fn with_connection_ids(&self, connection_ids: Vec<ConnectionId>) -> Self {
+        Self {
+            outgoing: Arc::clone(&self.outgoing),
+            connection_ids: Arc::new(connection_ids),
+            thread_id: self.thread_id,
+        }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.connection_ids.is_empty()
+    }
+
     pub(crate) async fn send_request(
         &self,
         payload: ServerRequestPayload,

--- a/codex-rs/app-server/src/thread_state.rs
+++ b/codex-rs/app-server/src/thread_state.rs
@@ -202,13 +202,57 @@ impl ThreadStateManager {
             .insert(connection_id, supported_server_requests);
     }
 
-    pub(crate) async fn subscribed_connection_ids(&self, thread_id: ThreadId) -> Vec<ConnectionId> {
+    pub(crate) async fn supported_server_requests_for_connection(
+        &self,
+        connection_id: ConnectionId,
+    ) -> HashSet<SupportedServerRequestMethod> {
         let state = self.state.lock().await;
         state
+            .supported_server_requests_by_connection
+            .get(&connection_id)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    pub(crate) async fn subscribed_connection_ids(&self, thread_id: ThreadId) -> Vec<ConnectionId> {
+        let state = self.state.lock().await;
+        let mut connection_ids = state
             .threads
             .get(&thread_id)
-            .map(|thread_entry| thread_entry.connection_ids.iter().copied().collect())
-            .unwrap_or_default()
+            .map(|thread_entry| {
+                thread_entry
+                    .connection_ids
+                    .iter()
+                    .copied()
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        sort_connection_ids(&mut connection_ids);
+        connection_ids
+    }
+
+    pub(crate) async fn subscribed_connection_ids_supporting(
+        &self,
+        thread_id: ThreadId,
+        method: SupportedServerRequestMethod,
+    ) -> Vec<ConnectionId> {
+        let state = self.state.lock().await;
+        let Some(thread_entry) = state.threads.get(&thread_id) else {
+            return Vec::new();
+        };
+        let mut connection_ids = thread_entry
+            .connection_ids
+            .iter()
+            .filter(|connection_id| {
+                state
+                    .supported_server_requests_by_connection
+                    .get(connection_id)
+                    .is_some_and(|supported| supported.contains(&method))
+            })
+            .copied()
+            .collect::<Vec<_>>();
+        sort_connection_ids(&mut connection_ids);
+        connection_ids
     }
 
     pub(crate) async fn thread_state(&self, thread_id: ThreadId) -> Arc<Mutex<ThreadState>> {
@@ -387,4 +431,8 @@ impl ThreadStateManager {
                 .collect::<Vec<_>>()
         }
     }
+}
+
+fn sort_connection_ids(connection_ids: &mut [ConnectionId]) {
+    connection_ids.sort_by_key(|connection_id| connection_id.0);
 }

--- a/codex-rs/app-server/tests/suite/v2/request_permissions.rs
+++ b/codex-rs/app-server/tests/suite/v2/request_permissions.rs
@@ -1,27 +1,124 @@
 use anyhow::Result;
+use anyhow::bail;
 use app_test_support::McpProcess;
 use app_test_support::create_final_assistant_message_sse_response;
 use app_test_support::create_mock_responses_server_sequence;
 use app_test_support::create_request_permissions_sse_response;
 use app_test_support::to_response;
+use codex_app_server_protocol::ClientInfo;
+use codex_app_server_protocol::InitializeCapabilities;
 use codex_app_server_protocol::JSONRPCMessage;
 use codex_app_server_protocol::JSONRPCResponse;
-use codex_app_server_protocol::PermissionGrantScope;
-use codex_app_server_protocol::PermissionsRequestApprovalResponse;
 use codex_app_server_protocol::RequestId;
 use codex_app_server_protocol::ServerRequest;
 use codex_app_server_protocol::ServerRequestResolvedNotification;
+use codex_app_server_protocol::SupportedServerRequestMethod;
 use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
 use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnStartResponse;
 use codex_app_server_protocol::UserInput as V2UserInput;
+use serde_json::Value;
+use serde_json::json;
 use tokio::time::timeout;
+use wiremock::MockServer;
 
 const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn request_permissions_round_trip() -> Result<()> {
+async fn permission_tools_are_hidden_without_supported_server_requests() -> Result<()> {
+    let body = first_responses_request_body_for_supported_server_requests(Vec::new()).await?;
+    assert_permission_tool_exposure(
+        &body, /*expect_permissions*/ false, /*expect_preset*/ false,
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn permission_tools_expose_only_narrow_permission_capability() -> Result<()> {
+    let body = first_responses_request_body_for_supported_server_requests(vec![
+        SupportedServerRequestMethod::PermissionsRequestApproval,
+    ])
+    .await?;
+    assert_permission_tool_exposure(
+        &body, /*expect_permissions*/ true, /*expect_preset*/ false,
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn permission_tools_keep_preset_hidden_without_delivery_support() -> Result<()> {
+    let body = first_responses_request_body_for_supported_server_requests(vec![
+        SupportedServerRequestMethod::PermissionPresetRequestApproval,
+    ])
+    .await?;
+    assert_permission_tool_exposure(
+        &body, /*expect_permissions*/ false, /*expect_preset*/ false,
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn permission_tools_expose_only_the_narrow_flow_for_now() -> Result<()> {
+    let body = first_responses_request_body_for_supported_server_requests(vec![
+        SupportedServerRequestMethod::PermissionsRequestApproval,
+        SupportedServerRequestMethod::PermissionPresetRequestApproval,
+    ])
+    .await?;
+    assert_permission_tool_exposure(
+        &body, /*expect_permissions*/ true, /*expect_preset*/ false,
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn request_permissions_round_trips_when_client_supports_app_request() -> Result<()> {
+    let codex_home = tempfile::TempDir::new()?;
+    let responses = vec![
+        create_request_permissions_sse_response("call1")?,
+        create_final_assistant_message_sse_response("done")?,
+    ];
+    let server = create_mock_responses_server_sequence(responses).await;
+    create_config_toml(codex_home.path(), &server.uri())?;
+
+    let mut mcp = McpProcess::new(codex_home.path()).await?;
+    initialize_with_supported_server_requests(
+        &mut mcp,
+        vec![SupportedServerRequestMethod::PermissionsRequestApproval],
+    )
+    .await?;
+
+    let thread_id = start_thread_and_turn(&mut mcp, "pick a directory").await?;
+
+    let server_request = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_request_message(),
+    )
+    .await??;
+    let ServerRequest::PermissionsRequestApproval { request_id, params } = server_request else {
+        bail!("expected PermissionsRequestApproval request");
+    };
+    assert_eq!(params.thread_id, thread_id);
+    assert_eq!(params.item_id, "call1");
+    assert_eq!(params.reason.as_deref(), Some("Select a workspace root"));
+    let resolved_request_id = request_id.clone();
+
+    mcp.send_response(
+        request_id,
+        json!({
+            "permissions": {},
+            "scope": "turn",
+        }),
+    )
+    .await?;
+
+    wait_for_server_request_resolved_then_turn_completed(&mut mcp, &thread_id, resolved_request_id)
+        .await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn request_permissions_auto_declines_without_app_request() -> Result<()> {
     let codex_home = tempfile::TempDir::new()?;
     let responses = vec![
         create_request_permissions_sse_response("call1")?,
@@ -62,44 +159,173 @@ async fn request_permissions_round_trip() -> Result<()> {
         mcp.read_stream_until_response_message(RequestId::Integer(turn_start_id)),
     )
     .await??;
-    let TurnStartResponse { turn, .. } = to_response(turn_start_resp)?;
+    let TurnStartResponse { .. } = to_response(turn_start_resp)?;
 
-    let server_req = timeout(
+    loop {
+        let message = timeout(DEFAULT_READ_TIMEOUT, mcp.read_next_message()).await??;
+        match message {
+            JSONRPCMessage::Request(request) => {
+                let server_request: ServerRequest = request.try_into()?;
+                bail!("unexpected app-server request: {server_request:?}");
+            }
+            JSONRPCMessage::Notification(notification)
+                if notification.method == "turn/completed" =>
+            {
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    Ok(())
+}
+
+async fn initialize_with_supported_server_requests(
+    mcp: &mut McpProcess,
+    supported_server_requests: Vec<SupportedServerRequestMethod>,
+) -> Result<()> {
+    let initialized = timeout(
         DEFAULT_READ_TIMEOUT,
-        mcp.read_stream_until_request_message(),
+        mcp.initialize_with_capabilities(
+            ClientInfo {
+                name: "codex_vscode".to_string(),
+                title: Some("Codex VS Code Extension".to_string()),
+                version: "0.1.0".to_string(),
+            },
+            Some(InitializeCapabilities {
+                experimental_api: true,
+                supported_server_requests: Some(supported_server_requests),
+                opt_out_notification_methods: None,
+            }),
+        ),
     )
     .await??;
-    let ServerRequest::PermissionsRequestApproval { request_id, params } = server_req else {
-        panic!("expected PermissionsRequestApproval request, got: {server_req:?}");
+    let JSONRPCMessage::Response(_) = initialized else {
+        bail!("expected initialize response, got {initialized:?}");
     };
+    Ok(())
+}
 
-    assert_eq!(params.thread_id, thread.id);
-    assert_eq!(params.turn_id, turn.id);
-    assert_eq!(params.item_id, "call1");
-    assert_eq!(params.reason, Some("Select a workspace root".to_string()));
-    let requested_writes = params
-        .permissions
-        .file_system
-        .and_then(|file_system| file_system.write)
-        .expect("request should include write permissions");
-    assert_eq!(requested_writes.len(), 2);
-    let resolved_request_id = request_id.clone();
+async fn first_responses_request_body_for_supported_server_requests(
+    supported_server_requests: Vec<SupportedServerRequestMethod>,
+) -> Result<Value> {
+    let codex_home = tempfile::TempDir::new()?;
+    let responses = vec![create_final_assistant_message_sse_response("done")?];
+    let server = create_mock_responses_server_sequence(responses).await;
+    create_config_toml(codex_home.path(), &server.uri())?;
 
-    mcp.send_response(
-        request_id,
-        serde_json::to_value(PermissionsRequestApprovalResponse {
-            permissions: codex_app_server_protocol::GrantedPermissionProfile {
-                network: None,
-                file_system: Some(codex_app_server_protocol::AdditionalFileSystemPermissions {
-                    read: None,
-                    write: Some(vec![requested_writes[0].clone()]),
-                }),
-            },
-            scope: PermissionGrantScope::Turn,
-        })?,
+    let mut mcp = McpProcess::new(codex_home.path()).await?;
+    if supported_server_requests.is_empty() {
+        timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+    } else {
+        initialize_with_supported_server_requests(&mut mcp, supported_server_requests).await?;
+    }
+
+    start_thread_and_turn(&mut mcp, "Hello").await?;
+    wait_for_turn_completed_without_server_request(&mut mcp).await?;
+
+    first_responses_request_body(&server).await
+}
+
+async fn first_responses_request_body(server: &MockServer) -> Result<Value> {
+    let requests = server
+        .received_requests()
+        .await
+        .ok_or_else(|| anyhow::format_err!("failed to fetch received requests"))?;
+    requests
+        .into_iter()
+        .find(|request| request.url.path().ends_with("/responses"))
+        .ok_or_else(|| anyhow::format_err!("expected a /responses request"))?
+        .body_json()
+        .map_err(Into::into)
+}
+
+fn assert_permission_tool_exposure(body: &Value, expect_permissions: bool, expect_preset: bool) {
+    let tool_names = body
+        .get("tools")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|tool| tool.get("name").and_then(Value::as_str))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        tool_names.contains(&"request_permissions"),
+        expect_permissions
+    );
+    assert_eq!(
+        tool_names.contains(&"request_permission_preset"),
+        expect_preset
+    );
+
+    let body_text = body.to_string();
+    assert_eq!(
+        body_text.contains("# request_permissions Tool"),
+        expect_permissions
+    );
+    assert_eq!(
+        body_text.contains("# request_permission_preset Tool"),
+        expect_preset
+    );
+}
+
+async fn start_thread_and_turn(mcp: &mut McpProcess, input: &str) -> Result<String> {
+    let thread_start_id = mcp
+        .send_thread_start_request(ThreadStartParams {
+            model: Some("mock-model".to_string()),
+            ..Default::default()
+        })
+        .await?;
+    let thread_start_resp: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(thread_start_id)),
     )
-    .await?;
+    .await??;
+    let ThreadStartResponse { thread, .. } = to_response(thread_start_resp)?;
 
+    let turn_start_id = mcp
+        .send_turn_start_request(TurnStartParams {
+            thread_id: thread.id.clone(),
+            input: vec![V2UserInput::Text {
+                text: input.to_string(),
+                text_elements: Vec::new(),
+            }],
+            model: Some("mock-model".to_string()),
+            ..Default::default()
+        })
+        .await?;
+    let turn_start_resp: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(turn_start_id)),
+    )
+    .await??;
+    let TurnStartResponse { .. } = to_response(turn_start_resp)?;
+    Ok(thread.id)
+}
+
+async fn wait_for_turn_completed_without_server_request(mcp: &mut McpProcess) -> Result<()> {
+    loop {
+        let message = timeout(DEFAULT_READ_TIMEOUT, mcp.read_next_message()).await??;
+        match message {
+            JSONRPCMessage::Request(request) => {
+                let server_request: ServerRequest = request.try_into()?;
+                bail!("unexpected app-server request: {server_request:?}");
+            }
+            JSONRPCMessage::Notification(notification)
+                if notification.method == "turn/completed" =>
+            {
+                break;
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+async fn wait_for_server_request_resolved_then_turn_completed(
+    mcp: &mut McpProcess,
+    thread_id: &str,
+    request_id: RequestId,
+) -> Result<()> {
     let mut saw_resolved = false;
     loop {
         let message = timeout(DEFAULT_READ_TIMEOUT, mcp.read_next_message()).await??;
@@ -108,14 +334,12 @@ async fn request_permissions_round_trip() -> Result<()> {
         };
         match notification.method.as_str() {
             "serverRequest/resolved" => {
-                let resolved: ServerRequestResolvedNotification = serde_json::from_value(
-                    notification
-                        .params
-                        .clone()
-                        .expect("serverRequest/resolved params"),
-                )?;
-                assert_eq!(resolved.thread_id, thread.id);
-                assert_eq!(resolved.request_id, resolved_request_id);
+                let Some(params) = notification.params.clone() else {
+                    bail!("serverRequest/resolved notification missing params");
+                };
+                let resolved: ServerRequestResolvedNotification = serde_json::from_value(params)?;
+                assert_eq!(resolved.thread_id, thread_id);
+                assert_eq!(resolved.request_id, request_id);
                 saw_resolved = true;
             }
             "turn/completed" => {
@@ -125,7 +349,6 @@ async fn request_permissions_round_trip() -> Result<()> {
             _ => {}
         }
     }
-
     Ok(())
 }
 
@@ -150,6 +373,7 @@ stream_max_retries = 0
 
 [features]
 request_permissions_tool = true
+request_permission_preset_tool = true
 "#
         ),
     )


### PR DESCRIPTION
## Summary
This PR gates the narrow `request_permissions` flow on the app-server capability handshake and only delivers approval requests to subscribed connections that explicitly advertise support for `item/permissions/requestApproval`.

It also narrows the tool surface to match that transport path: app-server sessions now expose `request_permissions` only when the client opted in, and they continue to hide `request_permission_preset` until the preset delivery/UI branches land.

## Stack
- Builds on #17586
- Followed by #17658

## Why
The previous layer established the capability contract, but the server still needed to honor it in two places:

1. tool exposure, so unsupported clients do not advertise a request flow they cannot answer
2. request delivery, so only opted-in listeners receive server approval requests

Keeping this branch limited to the narrow permission flow makes the behavior change reviewable without mixing in the preset picker work.

## Impact
Clients that do not advertise `item/permissions/requestApproval` keep the old behavior: the tool stays hidden and permission requests fail closed. Clients that do advertise it get the tool plus the round-trip server request path.

`request_permission_preset` remains hidden in app-server mode for now, even if a future-facing client advertises that capability, so the stack stays opt-in and truthful at each layer.

## Validation
- `cargo test -p codex-app-server permission_tools_`
- `cargo test -p codex-app-server request_permissions_`
- `just fmt`
- `just fix -p codex-app-server`
