### PR TITLE
feat(tui): support permission preset requests

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -125,6 +125,7 @@ use codex_protocol::protocol::SandboxPolicy;
 use codex_protocol::protocol::SessionSource;
 use codex_protocol::protocol::SkillErrorInfo;
 use codex_protocol::protocol::TokenUsage;
+use codex_protocol::request_permission_preset::RequestPermissionPresetEvent;
 use codex_terminal_detection::user_agent;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use color_eyre::eyre::Result;
@@ -174,6 +175,10 @@ const THREAD_EVENT_CHANNEL_CAPACITY: usize = 32768;
 enum ThreadInteractiveRequest {
     Approval(ApprovalRequest),
     McpServerElicitation(McpServerElicitationFormRequest),
+    PermissionPreset {
+        request: RequestPermissionPresetEvent,
+        response_context: crate::app_event::PermissionPresetSelectionContext,
+    },
 }
 
 fn app_server_request_id_to_mcp_request_id(
@@ -1843,6 +1848,25 @@ impl App {
                     suggested_scope: params.suggested_scope.to_core(),
                 }),
             ),
+            ServerRequest::PermissionPresetRequestApproval { params, .. } => {
+                Some(ThreadInteractiveRequest::PermissionPreset {
+                    request: RequestPermissionPresetEvent {
+                        turn_id: params.turn_id.clone(),
+                        call_id: params.item_id.clone(),
+                        reason: params.reason.clone(),
+                        preset: params.preset.to_core(),
+                        label: params.label.clone(),
+                        description: params.description.clone(),
+                        approval_policy: params.approval_policy.to_core(),
+                        approvals_reviewer: params.approvals_reviewer.to_core(),
+                        sandbox_policy: params.sandbox_policy.to_core(),
+                    },
+                    response_context: crate::app_event::PermissionPresetSelectionContext {
+                        thread_id,
+                        call_id: params.item_id.clone(),
+                    },
+                })
+            }
             _ => None,
         }
     }
@@ -2683,6 +2707,13 @@ impl App {
                 ThreadInteractiveRequest::McpServerElicitation(request) => {
                     self.chat_widget
                         .push_mcp_server_elicitation_request(request);
+                }
+                ThreadInteractiveRequest::PermissionPreset {
+                    request,
+                    response_context,
+                } => {
+                    self.chat_widget
+                        .handle_request_permission_preset_now(request, Some(response_context));
                 }
             }
         }
@@ -4611,9 +4642,13 @@ impl App {
             AppEvent::OpenFullAccessConfirmation {
                 preset,
                 return_to_permissions,
+                permission_preset_context,
             } => {
-                self.chat_widget
-                    .open_full_access_confirmation(preset, return_to_permissions);
+                self.chat_widget.open_full_access_confirmation(
+                    preset,
+                    return_to_permissions,
+                    permission_preset_context,
+                );
             }
             AppEvent::OpenWorldWritableWarningConfirmation {
                 preset,
@@ -5486,6 +5521,13 @@ impl App {
             }
             AppEvent::OpenPermissionsPopup => {
                 self.chat_widget.open_permissions_popup();
+            }
+            AppEvent::OpenPermissionsPopupForRequest {
+                preset,
+                response_context,
+            } => {
+                self.chat_widget
+                    .open_permissions_popup_for_request(preset, response_context);
             }
             AppEvent::OpenReviewBranchPicker(cwd) => {
                 self.chat_widget.show_review_branch_picker(&cwd).await;
@@ -6382,6 +6424,7 @@ mod tests {
     use codex_app_server_protocol::NetworkPolicyAmendment as AppServerNetworkPolicyAmendment;
     use codex_app_server_protocol::NetworkPolicyRuleAction as AppServerNetworkPolicyRuleAction;
     use codex_app_server_protocol::NonSteerableTurnKind as AppServerNonSteerableTurnKind;
+    use codex_app_server_protocol::PermissionPresetRequestApprovalParams;
     use codex_app_server_protocol::PermissionsRequestApprovalParams;
     use codex_app_server_protocol::RequestId as AppServerRequestId;
     use codex_app_server_protocol::ServerNotification;
@@ -8711,6 +8754,45 @@ guardian_approval = true
             }
         );
         assert_eq!(suggested_scope, PermissionGrantScope::Turn);
+    }
+
+    #[tokio::test]
+    async fn inactive_thread_permission_preset_request_preserves_response_context() {
+        let app = make_test_app().await;
+        let thread_id = ThreadId::new();
+        let request = ServerRequest::PermissionPresetRequestApproval {
+            request_id: AppServerRequestId::Integer(8),
+            params: PermissionPresetRequestApprovalParams {
+                thread_id: thread_id.to_string(),
+                turn_id: "turn-preset".to_string(),
+                item_id: "call-preset".to_string(),
+                preset: codex_app_server_protocol::PermissionPresetId::FullAccess,
+                label: "Full Access".to_string(),
+                description: "Run commands without filesystem sandboxing; network access enabled."
+                    .to_string(),
+                approval_policy: codex_app_server_protocol::AskForApproval::Never,
+                approvals_reviewer: codex_app_server_protocol::ApprovalsReviewer::User,
+                sandbox_policy: codex_app_server_protocol::SandboxPolicy::DangerFullAccess,
+                reason: Some("The user asked to switch into full access mode.".to_string()),
+            },
+        };
+
+        let Some(ThreadInteractiveRequest::PermissionPreset {
+            request,
+            response_context,
+        }) = app
+            .interactive_request_for_thread_request(thread_id, &request)
+            .await
+        else {
+            panic!("expected permission preset request");
+        };
+
+        assert_eq!(
+            request.preset,
+            codex_protocol::request_permission_preset::PermissionPresetId::FullAccess
+        );
+        assert_eq!(response_context.thread_id, thread_id);
+        assert_eq!(response_context.call_id, "call-preset");
     }
 
     #[tokio::test]

--- a/codex-rs/tui/src/app/app_server_adapter.rs
+++ b/codex-rs/tui/src/app/app_server_adapter.rs
@@ -298,6 +298,9 @@ fn server_request_thread_id(request: &ServerRequest) -> Option<ThreadId> {
         ServerRequest::PermissionsRequestApproval { params, .. } => {
             ThreadId::from_string(&params.thread_id).ok()
         }
+        ServerRequest::PermissionPresetRequestApproval { params, .. } => {
+            ThreadId::from_string(&params.thread_id).ok()
+        }
         ServerRequest::DynamicToolCall { params, .. } => {
             ThreadId::from_string(&params.thread_id).ok()
         }

--- a/codex-rs/tui/src/app/app_server_requests.rs
+++ b/codex-rs/tui/src/app/app_server_requests.rs
@@ -8,6 +8,7 @@ use codex_app_server_protocol::FileChangeApprovalDecision;
 use codex_app_server_protocol::FileChangeRequestApprovalResponse;
 use codex_app_server_protocol::McpServerElicitationAction;
 use codex_app_server_protocol::McpServerElicitationRequestResponse;
+use codex_app_server_protocol::PermissionPresetRequestApprovalResponse;
 use codex_app_server_protocol::PermissionsRequestApprovalResponse;
 use codex_app_server_protocol::RequestId as AppServerRequestId;
 use codex_app_server_protocol::ServerRequest;
@@ -32,6 +33,7 @@ pub(super) struct PendingAppServerRequests {
     exec_approvals: HashMap<String, AppServerRequestId>,
     file_change_approvals: HashMap<String, AppServerRequestId>,
     permissions_approvals: HashMap<String, AppServerRequestId>,
+    permission_preset_approvals: HashMap<String, AppServerRequestId>,
     user_inputs: HashMap<String, AppServerRequestId>,
     mcp_requests: HashMap<McpLegacyRequestKey, AppServerRequestId>,
 }
@@ -41,6 +43,7 @@ impl PendingAppServerRequests {
         self.exec_approvals.clear();
         self.file_change_approvals.clear();
         self.permissions_approvals.clear();
+        self.permission_preset_approvals.clear();
         self.user_inputs.clear();
         self.mcp_requests.clear();
     }
@@ -65,6 +68,11 @@ impl PendingAppServerRequests {
             }
             ServerRequest::PermissionsRequestApproval { request_id, params } => {
                 self.permissions_approvals
+                    .insert(params.item_id.clone(), request_id.clone());
+                None
+            }
+            ServerRequest::PermissionPresetRequestApproval { request_id, params } => {
+                self.permission_preset_approvals
                     .insert(params.item_id.clone(), request_id.clone());
                 None
             }
@@ -164,6 +172,24 @@ impl PendingAppServerRequests {
                     })
                 })
                 .transpose()?,
+            AppCommandView::RequestPermissionPresetResponse { id, response } => self
+                .permission_preset_approvals
+                .remove(id)
+                .map(|request_id| {
+                    Ok::<AppServerRequestResolution, String>(AppServerRequestResolution {
+                        request_id,
+                        result: serde_json::to_value(PermissionPresetRequestApprovalResponse {
+                            decision: response.decision.into(),
+                            preset: response.preset.into(),
+                        })
+                        .map_err(|err| {
+                            format!(
+                                "failed to serialize permission preset approval response: {err}"
+                            )
+                        })?,
+                    })
+                })
+                .transpose()?,
             AppCommandView::UserInputAnswer { id, response } => self
                 .user_inputs
                 .remove(id)
@@ -234,6 +260,8 @@ impl PendingAppServerRequests {
         self.file_change_approvals
             .retain(|_, value| value != request_id);
         self.permissions_approvals
+            .retain(|_, value| value != request_id);
+        self.permission_preset_approvals
             .retain(|_, value| value != request_id);
         self.user_inputs.retain(|_, value| value != request_id);
         self.mcp_requests.retain(|_, value| value != request_id);

--- a/codex-rs/tui/src/app/pending_interactive_replay.rs
+++ b/codex-rs/tui/src/app/pending_interactive_replay.rs
@@ -44,6 +44,8 @@ pub(super) struct PendingInteractiveReplayState {
     elicitation_requests: HashSet<ElicitationRequestKey>,
     request_permissions_call_ids: HashSet<String>,
     request_permissions_call_ids_by_turn_id: HashMap<String, Vec<String>>,
+    request_permission_preset_call_ids: HashSet<String>,
+    request_permission_preset_call_ids_by_turn_id: HashMap<String, Vec<String>>,
     request_user_input_call_ids: HashSet<String>,
     request_user_input_call_ids_by_turn_id: HashMap<String, Vec<String>>,
     pending_requests_by_request_id: HashMap<AppServerRequestId, PendingInteractiveRequest>,
@@ -61,6 +63,10 @@ enum PendingInteractiveRequest {
     },
     Elicitation(ElicitationRequestKey),
     RequestPermissions {
+        turn_id: String,
+        item_id: String,
+    },
+    RequestPermissionPreset {
         turn_id: String,
         item_id: String,
     },
@@ -82,6 +88,7 @@ impl PendingInteractiveReplayState {
                 | AppCommandView::PatchApproval { .. }
                 | AppCommandView::ResolveElicitation { .. }
                 | AppCommandView::RequestPermissionsResponse { .. }
+                | AppCommandView::RequestPermissionPresetResponse { .. }
                 | AppCommandView::UserInputAnswer { .. }
                 | AppCommandView::Shutdown
         )
@@ -139,6 +146,18 @@ impl PendingInteractiveReplayState {
                 self.pending_requests_by_request_id.retain(
                     |_, pending| {
                         !matches!(pending, PendingInteractiveRequest::RequestPermissions { item_id, .. } if item_id == id)
+                    },
+                );
+            }
+            AppCommandView::RequestPermissionPresetResponse { id, .. } => {
+                self.request_permission_preset_call_ids.remove(id);
+                Self::remove_call_id_from_turn_map(
+                    &mut self.request_permission_preset_call_ids_by_turn_id,
+                    id,
+                );
+                self.pending_requests_by_request_id.retain(
+                    |_, pending| {
+                        !matches!(pending, PendingInteractiveRequest::RequestPermissionPreset { item_id, .. } if item_id == id)
                     },
                 );
             }
@@ -248,6 +267,21 @@ impl PendingInteractiveReplayState {
                     },
                 );
             }
+            ServerRequest::PermissionPresetRequestApproval { request_id, params } => {
+                self.request_permission_preset_call_ids
+                    .insert(params.item_id.clone());
+                self.request_permission_preset_call_ids_by_turn_id
+                    .entry(params.turn_id.clone())
+                    .or_default()
+                    .push(params.item_id.clone());
+                self.pending_requests_by_request_id.insert(
+                    request_id.clone(),
+                    PendingInteractiveRequest::RequestPermissionPreset {
+                        turn_id: params.turn_id.clone(),
+                        item_id: params.item_id.clone(),
+                    },
+                );
+            }
             _ => {}
         }
     }
@@ -275,6 +309,7 @@ impl PendingInteractiveReplayState {
                 self.clear_exec_approval_turn(&notification.turn.id);
                 self.clear_patch_approval_turn(&notification.turn.id);
                 self.clear_request_permissions_turn(&notification.turn.id);
+                self.clear_request_permission_preset_turn(&notification.turn.id);
                 self.clear_request_user_input_turn(&notification.turn.id);
             }
             ServerNotification::ServerRequestResolved(notification) => {
@@ -348,6 +383,24 @@ impl PendingInteractiveReplayState {
                         .remove(&params.turn_id);
                 }
             }
+            ServerRequest::PermissionPresetRequestApproval { params, .. } => {
+                self.request_permission_preset_call_ids
+                    .remove(&params.item_id);
+                let mut remove_turn_entry = false;
+                if let Some(call_ids) = self
+                    .request_permission_preset_call_ids_by_turn_id
+                    .get_mut(&params.turn_id)
+                {
+                    call_ids.retain(|call_id| call_id != &params.item_id);
+                    if call_ids.is_empty() {
+                        remove_turn_entry = true;
+                    }
+                }
+                if remove_turn_entry {
+                    self.request_permission_preset_call_ids_by_turn_id
+                        .remove(&params.turn_id);
+                }
+            }
             _ => {}
         }
         self.pending_requests_by_request_id
@@ -374,6 +427,9 @@ impl PendingInteractiveReplayState {
             ServerRequest::PermissionsRequestApproval { params, .. } => {
                 self.request_permissions_call_ids.contains(&params.item_id)
             }
+            ServerRequest::PermissionPresetRequestApproval { params, .. } => self
+                .request_permission_preset_call_ids
+                .contains(&params.item_id),
             _ => true,
         }
     }
@@ -383,6 +439,7 @@ impl PendingInteractiveReplayState {
             || !self.patch_approval_call_ids.is_empty()
             || !self.elicitation_requests.is_empty()
             || !self.request_permissions_call_ids.is_empty()
+            || !self.request_permission_preset_call_ids.is_empty()
     }
 
     fn clear_request_user_input_turn(&mut self, turn_id: &str) {
@@ -407,6 +464,22 @@ impl PendingInteractiveReplayState {
         self.pending_requests_by_request_id.retain(
             |_, pending| {
                 !matches!(pending, PendingInteractiveRequest::RequestPermissions { turn_id: pending_turn_id, .. } if pending_turn_id == turn_id)
+            },
+        );
+    }
+
+    fn clear_request_permission_preset_turn(&mut self, turn_id: &str) {
+        if let Some(call_ids) = self
+            .request_permission_preset_call_ids_by_turn_id
+            .remove(turn_id)
+        {
+            for call_id in call_ids {
+                self.request_permission_preset_call_ids.remove(&call_id);
+            }
+        }
+        self.pending_requests_by_request_id.retain(
+            |_, pending| {
+                !matches!(pending, PendingInteractiveRequest::RequestPermissionPreset { turn_id: pending_turn_id, .. } if pending_turn_id == turn_id)
             },
         );
     }
@@ -472,6 +545,8 @@ impl PendingInteractiveReplayState {
         self.elicitation_requests.clear();
         self.request_permissions_call_ids.clear();
         self.request_permissions_call_ids_by_turn_id.clear();
+        self.request_permission_preset_call_ids.clear();
+        self.request_permission_preset_call_ids_by_turn_id.clear();
         self.request_user_input_call_ids.clear();
         self.request_user_input_call_ids_by_turn_id.clear();
         self.pending_requests_by_request_id.clear();
@@ -508,6 +583,14 @@ impl PendingInteractiveReplayState {
                 self.request_permissions_call_ids.remove(&item_id);
                 Self::remove_call_id_from_turn_map_entry(
                     &mut self.request_permissions_call_ids_by_turn_id,
+                    &turn_id,
+                    &item_id,
+                );
+            }
+            PendingInteractiveRequest::RequestPermissionPreset { turn_id, item_id } => {
+                self.request_permission_preset_call_ids.remove(&item_id);
+                Self::remove_call_id_from_turn_map_entry(
+                    &mut self.request_permission_preset_call_ids_by_turn_id,
                     &turn_id,
                     &item_id,
                 );
@@ -552,6 +635,10 @@ impl PendingInteractiveReplayState {
             (
                 PendingInteractiveRequest::RequestPermissions { turn_id, item_id },
                 ServerRequest::PermissionsRequestApproval { params, .. },
+            ) => turn_id == &params.turn_id && item_id == &params.item_id,
+            (
+                PendingInteractiveRequest::RequestPermissionPreset { turn_id, item_id },
+                ServerRequest::PermissionPresetRequestApproval { params, .. },
             ) => turn_id == &params.turn_id && item_id == &params.item_id,
             (
                 PendingInteractiveRequest::RequestUserInput { turn_id, item_id },

--- a/codex-rs/tui/src/app_command.rs
+++ b/codex-rs/tui/src/app_command.rs
@@ -17,6 +17,7 @@ use codex_protocol::protocol::Op;
 use codex_protocol::protocol::ReviewDecision;
 use codex_protocol::protocol::ReviewRequest;
 use codex_protocol::protocol::SandboxPolicy;
+use codex_protocol::request_permission_preset::RequestPermissionPresetResponse;
 use codex_protocol::request_permissions::RequestPermissionsResponse;
 use codex_protocol::request_user_input::RequestUserInputResponse;
 use codex_protocol::user_input::UserInput;
@@ -88,6 +89,10 @@ pub(crate) enum AppCommandView<'a> {
     RequestPermissionsResponse {
         id: &'a str,
         response: &'a RequestPermissionsResponse,
+    },
+    RequestPermissionPresetResponse {
+        id: &'a str,
+        response: &'a RequestPermissionPresetResponse,
     },
     ReloadUserConfig,
     ListSkills {
@@ -241,6 +246,13 @@ impl AppCommand {
         Self(Op::RequestPermissionsResponse { id, response })
     }
 
+    pub(crate) fn request_permission_preset_response(
+        id: String,
+        response: RequestPermissionPresetResponse,
+    ) -> Self {
+        Self(Op::RequestPermissionPresetResponse { id, response })
+    }
+
     pub(crate) fn reload_user_config() -> Self {
         Self(Op::ReloadUserConfig)
     }
@@ -378,6 +390,9 @@ impl AppCommand {
             }
             Op::RequestPermissionsResponse { id, response } => {
                 AppCommandView::RequestPermissionsResponse { id, response }
+            }
+            Op::RequestPermissionPresetResponse { id, response } => {
+                AppCommandView::RequestPermissionPresetResponse { id, response }
             }
             Op::ReloadUserConfig => AppCommandView::ReloadUserConfig,
             Op::ListSkills { cwds, force_reload } => AppCommandView::ListSkills {

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -39,6 +39,7 @@ use codex_protocol::config_types::ServiceTier;
 use codex_protocol::openai_models::ReasoningEffort;
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::SandboxPolicy;
+use codex_protocol::request_permission_preset::PermissionPresetId;
 use codex_realtime_webrtc::RealtimeWebrtcEvent;
 use codex_realtime_webrtc::RealtimeWebrtcSessionHandle;
 
@@ -69,6 +70,12 @@ impl RealtimeAudioDeviceKind {
 pub(crate) enum WindowsSandboxEnableMode {
     Elevated,
     Legacy,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PermissionPresetSelectionContext {
+    pub(crate) thread_id: ThreadId,
+    pub(crate) call_id: String,
 }
 
 #[derive(Debug, Clone)]
@@ -377,6 +384,7 @@ pub(crate) enum AppEvent {
     OpenFullAccessConfirmation {
         preset: ApprovalPreset,
         return_to_permissions: bool,
+        permission_preset_context: Option<PermissionPresetSelectionContext>,
     },
 
     /// Open the Windows world-writable directories warning.
@@ -517,6 +525,12 @@ pub(crate) enum AppEvent {
 
     /// Re-open the permissions presets popup.
     OpenPermissionsPopup,
+
+    /// Open the permissions presets popup for a model-requested change.
+    OpenPermissionsPopupForRequest {
+        preset: PermissionPresetId,
+        response_context: PermissionPresetSelectionContext,
+    },
 
     /// Live update for the in-progress voice recording placeholder. Carries
     /// the placeholder `id` and the text to display (e.g., an ASCII meter).

--- a/codex-rs/tui/src/app_event_sender.rs
+++ b/codex-rs/tui/src/app_event_sender.rs
@@ -7,6 +7,7 @@ use codex_protocol::mcp::RequestId as McpRequestId;
 use codex_protocol::protocol::ConversationAudioParams;
 use codex_protocol::protocol::ReviewDecision;
 use codex_protocol::protocol::ReviewRequest;
+use codex_protocol::request_permission_preset::RequestPermissionPresetResponse;
 use codex_protocol::request_permissions::RequestPermissionsResponse;
 use codex_protocol::request_user_input::RequestUserInputResponse;
 use tokio::sync::mpsc::UnboundedSender;
@@ -92,6 +93,18 @@ impl AppEventSender {
         self.send(AppEvent::SubmitThreadOp {
             thread_id,
             op: AppCommand::request_permissions_response(id, response).into_core(),
+        });
+    }
+
+    pub(crate) fn request_permission_preset_response(
+        &self,
+        thread_id: ThreadId,
+        id: String,
+        response: RequestPermissionPresetResponse,
+    ) {
+        self.send(AppEvent::SubmitThreadOp {
+            thread_id,
+            op: AppCommand::request_permission_preset_response(id, response).into_core(),
         });
     }
 

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -6755,7 +6755,7 @@ impl ChatWidget {
                 self.on_request_permissions(ev);
             }
             EventMsg::RequestPermissionPreset(ev) => {
-                self.on_request_permission_preset(ev, None);
+                self.on_request_permission_preset(ev, /*response_context*/ None);
             }
             EventMsg::ExecCommandBegin(ev) => self.on_exec_command_begin(ev),
             EventMsg::TerminalInteraction(delta) => self.on_terminal_interaction(delta),

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -216,6 +216,10 @@ use codex_protocol::protocol::ViewImageToolCallEvent;
 use codex_protocol::protocol::WarningEvent;
 use codex_protocol::protocol::WebSearchBeginEvent;
 use codex_protocol::protocol::WebSearchEndEvent;
+use codex_protocol::request_permission_preset::PermissionPresetId;
+use codex_protocol::request_permission_preset::RequestPermissionPresetDecision;
+use codex_protocol::request_permission_preset::RequestPermissionPresetEvent;
+use codex_protocol::request_permission_preset::RequestPermissionPresetResponse;
 use codex_protocol::request_permissions::RequestPermissionsEvent;
 use codex_protocol::request_user_input::RequestUserInputEvent;
 use codex_protocol::request_user_input::RequestUserInputQuestionOption;
@@ -298,6 +302,7 @@ fn queued_message_edit_binding_for_terminal(terminal_info: TerminalInfo) -> KeyB
 use crate::app_event::AppEvent;
 use crate::app_event::ConnectorsSnapshot;
 use crate::app_event::ExitMode;
+use crate::app_event::PermissionPresetSelectionContext;
 use crate::app_event::RateLimitRefreshOrigin;
 #[cfg(target_os = "windows")]
 use crate::app_event::WindowsSandboxEnableMode;
@@ -1573,6 +1578,22 @@ fn request_permissions_from_params(
         reason: params.reason,
         permissions: params.permissions.into(),
         suggested_scope: params.suggested_scope.to_core(),
+    }
+}
+
+fn request_permission_preset_from_params(
+    params: codex_app_server_protocol::PermissionPresetRequestApprovalParams,
+) -> RequestPermissionPresetEvent {
+    RequestPermissionPresetEvent {
+        turn_id: params.turn_id,
+        call_id: params.item_id,
+        reason: params.reason,
+        preset: params.preset.to_core(),
+        label: params.label,
+        description: params.description,
+        approval_policy: params.approval_policy.to_core(),
+        approvals_reviewer: params.approvals_reviewer.to_core(),
+        sandbox_policy: params.sandbox_policy.to_core(),
     }
 }
 
@@ -3494,6 +3515,19 @@ impl ChatWidget {
         );
     }
 
+    fn on_request_permission_preset(
+        &mut self,
+        ev: RequestPermissionPresetEvent,
+        response_context: Option<PermissionPresetSelectionContext>,
+    ) {
+        let ev2 = ev.clone();
+        let response_context2 = response_context.clone();
+        self.defer_or_handle(
+            |q| q.push_request_permission_preset(ev, response_context),
+            |s| s.handle_request_permission_preset_now(ev2, response_context2),
+        );
+    }
+
     fn on_exec_command_begin(&mut self, ev: ExecCommandBeginEvent) {
         self.flush_answer_stream_with_separator();
         if is_unified_exec_source(ev.source) {
@@ -4586,6 +4620,23 @@ impl ChatWidget {
         };
         self.bottom_pane
             .push_approval_request(request, &self.config.features);
+        self.request_redraw();
+    }
+
+    pub(crate) fn handle_request_permission_preset_now(
+        &mut self,
+        ev: RequestPermissionPresetEvent,
+        response_context: Option<PermissionPresetSelectionContext>,
+    ) {
+        self.flush_answer_stream_with_separator();
+        let preset = ev.preset;
+        let call_id = ev.call_id;
+        let response_context =
+            response_context.unwrap_or_else(|| PermissionPresetSelectionContext {
+                thread_id: self.thread_id.unwrap_or_default(),
+                call_id,
+            });
+        self.open_permissions_popup_for_request(preset, response_context);
         self.request_redraw();
     }
 
@@ -5989,6 +6040,16 @@ impl ChatWidget {
             ServerRequest::PermissionsRequestApproval { params, .. } => {
                 self.on_request_permissions(request_permissions_from_params(params));
             }
+            ServerRequest::PermissionPresetRequestApproval { params, .. } => {
+                let response_context = PermissionPresetSelectionContext {
+                    thread_id: self.thread_id.unwrap_or_default(),
+                    call_id: params.item_id.clone(),
+                };
+                self.on_request_permission_preset(
+                    request_permission_preset_from_params(params),
+                    Some(response_context),
+                );
+            }
             ServerRequest::ToolRequestUserInput { params, .. } => {
                 self.on_request_user_input(request_user_input_from_params(params));
             }
@@ -6693,7 +6754,9 @@ impl ChatWidget {
             EventMsg::RequestPermissions(ev) => {
                 self.on_request_permissions(ev);
             }
-            EventMsg::RequestPermissionPreset(_) => {}
+            EventMsg::RequestPermissionPreset(ev) => {
+                self.on_request_permission_preset(ev, None);
+            }
             EventMsg::ExecCommandBegin(ev) => self.on_exec_command_begin(ev),
             EventMsg::TerminalInteraction(delta) => self.on_terminal_interaction(delta),
             EventMsg::ExecCommandOutputDelta(delta) => self.on_exec_command_output_delta(delta),
@@ -8265,13 +8328,30 @@ impl ChatWidget {
 
     /// Open a popup to choose the permissions mode (approval policy + sandbox policy).
     pub(crate) fn open_permissions_popup(&mut self) {
+        self.open_permissions_popup_with_request(/*request*/ None);
+    }
+
+    pub(crate) fn open_permissions_popup_for_request(
+        &mut self,
+        preset: PermissionPresetId,
+        response_context: PermissionPresetSelectionContext,
+    ) {
+        self.open_permissions_popup_with_request(Some((preset, response_context)));
+    }
+
+    fn open_permissions_popup_with_request(
+        &mut self,
+        request: Option<(PermissionPresetId, PermissionPresetSelectionContext)>,
+    ) {
         let include_read_only = cfg!(target_os = "windows");
         let current_approval = self.config.permissions.approval_policy.value();
         let current_sandbox = self.config.permissions.sandbox_policy.get();
         let guardian_approval_enabled = self.config.features.enabled(Feature::GuardianApproval);
         let current_review_policy = self.config.approvals_reviewer;
         let mut items: Vec<SelectionItem> = Vec::new();
+        let mut initial_selected_idx = None;
         let presets: Vec<ApprovalPreset> = builtin_approval_presets();
+        let requested_preset = request.as_ref().map(|(preset, _)| *preset);
 
         #[cfg(target_os = "windows")]
         let windows_sandbox_level = WindowsSandboxLevel::from_config(&self.config);
@@ -8296,10 +8376,19 @@ impl ChatWidget {
                 .map(|err| err.to_string())
         };
 
+        let mut record_initial_selection = |item_id: PermissionPresetId, idx: usize| {
+            if requested_preset == Some(item_id) {
+                initial_selected_idx = Some(idx);
+            }
+        };
+
         for preset in presets.into_iter() {
             if !include_read_only && preset.id == "read-only" {
                 continue;
             }
+            let Some(preset_id) = PermissionPresetId::from_id(preset.id) else {
+                continue;
+            };
             let base_name = if preset.id == "auto" && windows_degraded_sandbox_enabled {
                 "Default (non-admin sandbox)".to_string()
             } else {
@@ -8325,12 +8414,15 @@ impl ChatWidget {
                     .notices
                     .hide_full_access_warning
                     .unwrap_or(false);
+            let response_context = request.as_ref().map(|(_, context)| context.clone());
             let default_actions: Vec<SelectionAction> = if requires_confirmation {
                 let preset_clone = preset.clone();
+                let permission_preset_context = response_context.clone();
                 vec![Box::new(move |tx| {
                     tx.send(AppEvent::OpenFullAccessConfirmation {
                         preset: preset_clone.clone(),
                         return_to_permissions: !include_read_only,
+                        permission_preset_context: permission_preset_context.clone(),
                     });
                 })]
             } else if preset.id == "auto" {
@@ -8371,32 +8463,37 @@ impl ChatWidget {
                             });
                         })]
                     } else {
-                        Self::approval_preset_actions(
+                        Self::permission_preset_actions(
                             preset.approval,
                             preset.sandbox.clone(),
                             base_name.clone(),
                             ApprovalsReviewer::User,
+                            response_context.clone().map(|context| (context, preset_id)),
                         )
                     }
                 }
                 #[cfg(not(target_os = "windows"))]
                 {
-                    Self::approval_preset_actions(
+                    Self::permission_preset_actions(
                         preset.approval,
                         preset.sandbox.clone(),
                         base_name.clone(),
                         ApprovalsReviewer::User,
+                        response_context.clone().map(|context| (context, preset_id)),
                     )
                 }
             } else {
-                Self::approval_preset_actions(
+                Self::permission_preset_actions(
                     preset.approval,
                     preset.sandbox.clone(),
                     base_name.clone(),
                     ApprovalsReviewer::User,
+                    response_context.clone().map(|context| (context, preset_id)),
                 )
             };
             if preset.id == "auto" {
+                let idx = items.len();
+                record_initial_selection(PermissionPresetId::Auto, idx);
                 items.push(SelectionItem {
                     name: base_name.clone(),
                     description: base_description.clone(),
@@ -8409,6 +8506,8 @@ impl ChatWidget {
                 });
 
                 if guardian_approval_enabled {
+                    let idx = items.len();
+                    record_initial_selection(PermissionPresetId::GuardianApprovals, idx);
                     items.push(SelectionItem {
                         name: "Guardian Approvals".to_string(),
                         description: Some(
@@ -8417,15 +8516,18 @@ impl ChatWidget {
                         ),
                         is_current: current_review_policy == ApprovalsReviewer::GuardianSubagent
                             && Self::preset_matches_current(
-                                current_approval,
-                                current_sandbox,
-                                &preset,
-                            ),
-                        actions: Self::approval_preset_actions(
+                            current_approval,
+                            current_sandbox,
+                            &preset,
+                        ),
+                        actions: Self::permission_preset_actions(
                             preset.approval,
                             preset.sandbox.clone(),
                             "Guardian Approvals".to_string(),
                             ApprovalsReviewer::GuardianSubagent,
+                            response_context
+                                .clone()
+                                .map(|context| (context, PermissionPresetId::GuardianApprovals)),
                         ),
                         dismiss_on_select: true,
                         disabled_reason: approval_disabled_reason
@@ -8434,6 +8536,8 @@ impl ChatWidget {
                     });
                 }
             } else {
+                let idx = items.len();
+                record_initial_selection(preset_id, idx);
                 items.push(SelectionItem {
                     name: base_name,
                     description: base_description,
@@ -8465,6 +8569,20 @@ impl ChatWidget {
             footer_hint: Some(standard_popup_hint_line()),
             items,
             header: Box::new(()),
+            initial_selected_idx,
+            on_cancel: request.map(|(preset, context)| {
+                Box::new(move |tx: &AppEventSender| {
+                    tx.request_permission_preset_response(
+                        context.thread_id,
+                        context.call_id.clone(),
+                        RequestPermissionPresetResponse {
+                            decision: RequestPermissionPresetDecision::Declined,
+                            preset,
+                            message: "permission preset picker was dismissed".to_string(),
+                        },
+                    );
+                }) as Box<dyn Fn(&AppEventSender) + Send + Sync>
+            }),
             ..Default::default()
         });
     }
@@ -8488,14 +8606,32 @@ impl ChatWidget {
         self.bottom_pane.show_view(Box::new(view));
     }
 
+    #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
     fn approval_preset_actions(
         approval: AskForApproval,
         sandbox: SandboxPolicy,
         label: String,
         approvals_reviewer: ApprovalsReviewer,
     ) -> Vec<SelectionAction> {
+        Self::permission_preset_actions(
+            approval,
+            sandbox,
+            label,
+            approvals_reviewer,
+            /*response*/ None,
+        )
+    }
+
+    fn permission_preset_actions(
+        approval: AskForApproval,
+        sandbox: SandboxPolicy,
+        label: String,
+        approvals_reviewer: ApprovalsReviewer,
+        response: Option<(PermissionPresetSelectionContext, PermissionPresetId)>,
+    ) -> Vec<SelectionAction> {
         vec![Box::new(move |tx| {
             let sandbox_clone = sandbox.clone();
+            let message = format!("Permissions updated to {label}");
             tx.send(AppEvent::CodexOp(
                 AppCommand::override_turn_context(
                     /*cwd*/ None,
@@ -8516,11 +8652,19 @@ impl ChatWidget {
             tx.send(AppEvent::UpdateSandboxPolicy(sandbox_clone));
             tx.send(AppEvent::UpdateApprovalsReviewer(approvals_reviewer));
             tx.send(AppEvent::InsertHistoryCell(Box::new(
-                history_cell::new_info_event(
-                    format!("Permissions updated to {label}"),
-                    /*hint*/ None,
-                ),
+                history_cell::new_info_event(message.clone(), /*hint*/ None),
             )));
+            if let Some((context, preset)) = &response {
+                tx.request_permission_preset_response(
+                    context.thread_id,
+                    context.call_id.clone(),
+                    RequestPermissionPresetResponse {
+                        decision: RequestPermissionPresetDecision::Accepted,
+                        preset: *preset,
+                        message,
+                    },
+                );
+            }
         })]
     }
 
@@ -8593,6 +8737,7 @@ impl ChatWidget {
         &mut self,
         preset: ApprovalPreset,
         return_to_permissions: bool,
+        permission_preset_context: Option<PermissionPresetSelectionContext>,
     ) {
         let selected_name = preset.label.to_string();
         let approval = preset.approval;
@@ -8611,21 +8756,26 @@ impl ChatWidget {
         ));
         let header = ColumnRenderable::with(header_children);
 
-        let mut accept_actions = Self::approval_preset_actions(
+        let response_context = permission_preset_context
+            .clone()
+            .map(|context| (context, PermissionPresetId::FullAccess));
+        let mut accept_actions = Self::permission_preset_actions(
             approval,
             sandbox.clone(),
             selected_name.clone(),
             ApprovalsReviewer::User,
+            response_context.clone(),
         );
         accept_actions.push(Box::new(|tx| {
             tx.send(AppEvent::UpdateFullAccessWarningAcknowledged(true));
         }));
 
-        let mut accept_and_remember_actions = Self::approval_preset_actions(
+        let mut accept_and_remember_actions = Self::permission_preset_actions(
             approval,
             sandbox,
             selected_name,
             ApprovalsReviewer::User,
+            response_context,
         );
         accept_and_remember_actions.push(Box::new(|tx| {
             tx.send(AppEvent::UpdateFullAccessWarningAcknowledged(true));
@@ -8634,8 +8784,26 @@ impl ChatWidget {
 
         let deny_actions: Vec<SelectionAction> = vec![Box::new(move |tx| {
             if return_to_permissions {
-                tx.send(AppEvent::OpenPermissionsPopup);
+                if let Some(context) = permission_preset_context.clone() {
+                    tx.send(AppEvent::OpenPermissionsPopupForRequest {
+                        preset: PermissionPresetId::FullAccess,
+                        response_context: context,
+                    });
+                } else {
+                    tx.send(AppEvent::OpenPermissionsPopup);
+                }
             } else {
+                if let Some(context) = permission_preset_context.clone() {
+                    tx.request_permission_preset_response(
+                        context.thread_id,
+                        context.call_id,
+                        RequestPermissionPresetResponse {
+                            decision: RequestPermissionPresetDecision::Declined,
+                            preset: PermissionPresetId::FullAccess,
+                            message: "permission preset picker was dismissed".to_string(),
+                        },
+                    );
+                }
                 tx.send(AppEvent::OpenApprovalsPopup);
             }
         })];

--- a/codex-rs/tui/src/chatwidget/interrupts.rs
+++ b/codex-rs/tui/src/chatwidget/interrupts.rs
@@ -8,10 +8,12 @@ use codex_protocol::protocol::ExecCommandEndEvent;
 use codex_protocol::protocol::McpToolCallBeginEvent;
 use codex_protocol::protocol::McpToolCallEndEvent;
 use codex_protocol::protocol::PatchApplyEndEvent;
+use codex_protocol::request_permission_preset::RequestPermissionPresetEvent;
 use codex_protocol::request_permissions::RequestPermissionsEvent;
 use codex_protocol::request_user_input::RequestUserInputEvent;
 
 use super::ChatWidget;
+use crate::app_event::PermissionPresetSelectionContext;
 
 #[derive(Debug)]
 pub(crate) enum QueuedInterrupt {
@@ -19,6 +21,10 @@ pub(crate) enum QueuedInterrupt {
     ApplyPatchApproval(ApplyPatchApprovalRequestEvent),
     Elicitation(ElicitationRequestEvent),
     RequestPermissions(RequestPermissionsEvent),
+    RequestPermissionPreset {
+        ev: RequestPermissionPresetEvent,
+        response_context: Option<PermissionPresetSelectionContext>,
+    },
     RequestUserInput(RequestUserInputEvent),
     ExecBegin(ExecCommandBeginEvent),
     ExecEnd(ExecCommandEndEvent),
@@ -62,6 +68,18 @@ impl InterruptManager {
             .push_back(QueuedInterrupt::RequestPermissions(ev));
     }
 
+    pub(crate) fn push_request_permission_preset(
+        &mut self,
+        ev: RequestPermissionPresetEvent,
+        response_context: Option<PermissionPresetSelectionContext>,
+    ) {
+        self.queue
+            .push_back(QueuedInterrupt::RequestPermissionPreset {
+                ev,
+                response_context,
+            });
+    }
+
     pub(crate) fn push_user_input(&mut self, ev: RequestUserInputEvent) {
         self.queue.push_back(QueuedInterrupt::RequestUserInput(ev));
     }
@@ -93,6 +111,10 @@ impl InterruptManager {
                 QueuedInterrupt::ApplyPatchApproval(ev) => chat.handle_apply_patch_approval_now(ev),
                 QueuedInterrupt::Elicitation(ev) => chat.handle_elicitation_request_now(ev),
                 QueuedInterrupt::RequestPermissions(ev) => chat.handle_request_permissions_now(ev),
+                QueuedInterrupt::RequestPermissionPreset {
+                    ev,
+                    response_context,
+                } => chat.handle_request_permission_preset_now(ev, response_context),
                 QueuedInterrupt::RequestUserInput(ev) => chat.handle_request_user_input_now(ev),
                 QueuedInterrupt::ExecBegin(ev) => chat.handle_exec_begin_now(ev),
                 QueuedInterrupt::ExecEnd(ev) => chat.handle_exec_end_now(ev),

--- a/codex-rs/tui/src/chatwidget/tests/approval_requests.rs
+++ b/codex-rs/tui/src/chatwidget/tests/approval_requests.rs
@@ -2,6 +2,10 @@
 //! to keep the primary module under blob-size policy limits.
 
 use super::*;
+use codex_protocol::protocol::AskForApproval;
+use codex_protocol::protocol::SandboxPolicy;
+use codex_protocol::request_permission_preset::PermissionPresetId;
+use codex_protocol::request_permission_preset::RequestPermissionPresetEvent;
 use pretty_assertions::assert_eq;
 
 #[tokio::test]
@@ -48,6 +52,72 @@ async fn exec_approval_emits_proposed_command_and_decision_history() {
     assert_snapshot!(
         "exec_approval_history_decision_approved_short",
         lines_to_single_string(&decision)
+    );
+}
+
+#[tokio::test]
+async fn permission_preset_request_opens_permissions_picker_with_requested_preset_selected() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    #[cfg(target_os = "windows")]
+    {
+        chat.config.notices.hide_world_writable_warning = Some(true);
+        chat.set_windows_sandbox_mode(Some(WindowsSandboxModeToml::Unelevated));
+    }
+    chat.set_feature_enabled(Feature::GuardianApproval, /*enabled*/ false);
+
+    let ev = RequestPermissionPresetEvent {
+        call_id: "preset-call".into(),
+        turn_id: "preset-turn".into(),
+        preset: PermissionPresetId::FullAccess,
+        label: "Full access".into(),
+        description: "Run commands without filesystem sandboxing; network access enabled.".into(),
+        approval_policy: AskForApproval::Never,
+        approvals_reviewer: ApprovalsReviewer::User,
+        sandbox_policy: SandboxPolicy::DangerFullAccess,
+        reason: Some("the user asked to switch into full access mode".into()),
+    };
+    chat.handle_codex_event(Event {
+        id: "sub-preset".into(),
+        msg: EventMsg::RequestPermissionPreset(ev),
+    });
+
+    let proposed_cells = drain_insert_history(&mut rx);
+    assert!(
+        proposed_cells.is_empty(),
+        "expected preset request to open the picker without emitting history cells"
+    );
+
+    let popup = render_bottom_popup(&chat, /*width*/ 100);
+    assert!(
+        popup
+            .lines()
+            .any(|line| line.contains('›') && line.contains("Full Access")),
+        "expected Full Access to be preselected in the permissions picker: {popup}"
+    );
+    assert_snapshot!("permission_preset_request_picker", popup);
+
+    chat.handle_key_event(KeyEvent::from(KeyCode::Enter));
+
+    let events = std::iter::from_fn(|| rx.try_recv().ok()).collect::<Vec<_>>();
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            AppEvent::OpenFullAccessConfirmation {
+                permission_preset_context: Some(_),
+                ..
+            }
+        )),
+        "expected selecting Full Access to invoke the existing confirmation flow: {events:?}"
+    );
+    assert!(
+        !events.iter().any(|event| matches!(
+            event,
+            AppEvent::SubmitThreadOp {
+                op: Op::RequestPermissionPresetResponse { .. },
+                ..
+            }
+        )),
+        "expected no permission preset response until the user confirms Full Access: {events:?}"
     );
 }
 

--- a/codex-rs/tui/src/chatwidget/tests/permissions.rs
+++ b/codex-rs/tui/src/chatwidget/tests/permissions.rs
@@ -77,7 +77,9 @@ async fn full_access_confirmation_popup_snapshot() {
         .into_iter()
         .find(|preset| preset.id == "full-access")
         .expect("full access preset");
-    chat.open_full_access_confirmation(preset, /*return_to_permissions*/ false);
+    chat.open_full_access_confirmation(
+        preset, /*return_to_permissions*/ false, /*permission_preset_context*/ None,
+    );
 
     let popup = render_bottom_popup(&chat, /*width*/ 80);
     assert_chatwidget_snapshot!("full_access_confirmation_popup", popup);
@@ -669,8 +671,10 @@ async fn permissions_full_access_history_cell_emitted_only_after_confirmation() 
             AppEvent::OpenFullAccessConfirmation {
                 preset,
                 return_to_permissions,
+                permission_preset_context,
             } => {
-                open_confirmation_event = Some((preset, return_to_permissions));
+                open_confirmation_event =
+                    Some((preset, return_to_permissions, permission_preset_context));
             }
             _ => {}
         }
@@ -681,9 +685,9 @@ async fn permissions_full_access_history_cell_emitted_only_after_confirmation() 
             "did not expect history cell before confirming full access"
         );
     }
-    let (preset, return_to_permissions) =
+    let (preset, return_to_permissions, permission_preset_context) =
         open_confirmation_event.expect("expected full access confirmation event");
-    chat.open_full_access_confirmation(preset, return_to_permissions);
+    chat.open_full_access_confirmation(preset, return_to_permissions, permission_preset_context);
 
     let popup = render_bottom_popup(&chat, /*width*/ 80);
     assert!(

--- a/codex-rs/tui/src/chatwidget/tests/snapshots/codex_tui__chatwidget__tests__approval_requests__permission_preset_request_picker.snap
+++ b/codex-rs/tui/src/chatwidget/tests/snapshots/codex_tui__chatwidget__tests__approval_requests__permission_preset_request_picker.snap
@@ -1,0 +1,13 @@
+---
+source: tui/src/chatwidget/tests/approval_requests.rs
+assertion_line: 97
+expression: popup
+---
+  Update Model Permissions
+
+  1. Default      Codex can read and edit files in the current workspace, and run commands.
+                  Approval is required to access the internet or edit other files.
+› 2. Full Access  Codex can edit files outside this workspace and access the internet without
+                  asking for approval. Exercise caution when using.
+
+  Press enter to confirm or esc to go back

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -471,7 +471,10 @@ where
 }
 
 fn tui_supported_server_requests() -> Vec<SupportedServerRequestMethod> {
-    vec![SupportedServerRequestMethod::PermissionsRequestApproval]
+    vec![
+        SupportedServerRequestMethod::PermissionsRequestApproval,
+        SupportedServerRequestMethod::PermissionPresetRequestApproval,
+    ]
 }
 
 async fn shutdown_app_server_if_present(app_server: Option<AppServerSession>) {
@@ -1826,7 +1829,10 @@ mod tests {
         let supported = tui_supported_server_requests();
         assert_eq!(
             supported,
-            vec![SupportedServerRequestMethod::PermissionsRequestApproval]
+            vec![
+                SupportedServerRequestMethod::PermissionsRequestApproval,
+                SupportedServerRequestMethod::PermissionPresetRequestApproval,
+            ]
         );
     }
 


### PR DESCRIPTION
## Summary
- advertise `permissionPreset/requestApproval` support from the TUI app-server client
- route permission preset requests through the existing permissions picker and full-access confirmation flows while preserving the original thread and call context
- replay and resolve preset requests for inactive threads, and cover the new picker state with targeted tests and a snapshot

## Stack
- Builds on #17664

## Testing
- `cargo test -p codex-tui`
- `just fix -p codex-tui`
- `just fmt`
