### PR TITLE
Harden local file link target rendering

### DIFF
--- a/codex-rs/tui/src/markdown_render.rs
+++ b/codex-rs/tui/src/markdown_render.rs
@@ -581,15 +581,16 @@ where
     }
 
     fn push_link(&mut self, dest_url: String) {
-        let show_destination = should_render_link_destination(&dest_url);
+        let destination = normalize_local_link_destination(&dest_url);
+        let show_destination = should_render_link_destination(&destination);
         self.link = Some(LinkState {
             show_destination,
-            local_target_display: if is_local_path_like_link(&dest_url) {
-                render_local_link_target(&dest_url, self.cwd.as_deref())
+            local_target_display: if is_local_path_like_link(&destination) {
+                render_local_link_target(&destination, self.cwd.as_deref())
             } else {
                 None
             },
-            destination: dest_url,
+            destination,
         });
     }
 
@@ -738,6 +739,27 @@ fn is_local_path_like_link(dest_url: &str) -> bool {
             [drive, b':', separator, ..]
                 if drive.is_ascii_alphabetic() && matches!(separator, b'/' | b'\\')
         )
+}
+
+fn normalize_local_link_destination(dest_url: &str) -> String {
+    let mut candidate = dest_url.trim();
+    if let Some(inner) = strip_balanced_wrapper(candidate, '`', '`') {
+        candidate = inner.trim();
+    }
+    if let Some(inner) = strip_balanced_wrapper(candidate, '<', '>') {
+        candidate = inner.trim();
+    }
+    if is_local_path_like_link(candidate) {
+        candidate.to_string()
+    } else {
+        dest_url.to_string()
+    }
+}
+
+fn strip_balanced_wrapper(value: &str, start: char, end: char) -> Option<&str> {
+    value
+        .strip_prefix(start)
+        .and_then(|inner| inner.strip_suffix(end))
 }
 
 /// Parse a local link target into normalized path text plus an optional location suffix.

--- a/codex-rs/tui/src/markdown_render_tests.rs
+++ b/codex-rs/tui/src/markdown_render_tests.rs
@@ -701,6 +701,40 @@ fn file_link_appends_line_number_when_label_lacks_it() {
 }
 
 #[test]
+fn file_link_uses_target_when_label_is_code() {
+    let text = render_markdown_text_for_cwd(
+        "[`markdown_render.rs`](/Users/example/code/codex/codex-rs/tui/src/markdown_render.rs:74)",
+        Path::new("/Users/example/code/codex"),
+    );
+    let expected = Text::from(Line::from_iter([
+        "codex-rs/tui/src/markdown_render.rs:74".cyan(),
+    ]));
+    assert_eq!(text, expected);
+}
+
+#[test]
+fn file_link_uses_target_wrapped_in_backticks() {
+    let text = render_markdown_text_for_cwd(
+        "[markdown_render.rs](`/Users/example/code/codex/codex-rs/tui/src/markdown_render.rs:74`)",
+        Path::new("/Users/example/code/codex"),
+    );
+    let expected = Text::from(Line::from_iter([
+        "codex-rs/tui/src/markdown_render.rs:74".cyan(),
+    ]));
+    assert_eq!(text, expected);
+}
+
+#[test]
+fn file_link_uses_angle_wrapped_target_with_spaces() {
+    let text = render_markdown_text_for_cwd(
+        "[My Report.md](</Users/example/code/codex/docs/My Report.md:12>)",
+        Path::new("/Users/example/code/codex"),
+    );
+    let expected = Text::from(Line::from_iter(["docs/My Report.md:12".cyan()]));
+    assert_eq!(text, expected);
+}
+
+#[test]
 fn file_link_keeps_absolute_paths_outside_cwd() {
     let text = render_markdown_text_for_cwd(
         "[README.md:74](/Users/example/code/codex/README.md:74)",


### PR DESCRIPTION
Local file links in the TUI render from the markdown target so the transcript shows the real path rather than whatever label was written.

This tightens that path by accepting a small recoverable wrapper around local targets before deciding whether they are filesystem links. A target wrapped in a balanced pair of backticks now renders like the same plain target, and angle-bracket targets with spaces continue to render as local paths. Malformed markdown is intentionally left alone instead of guessing at intent.