### PR TITLE
Refactor Bazel CI job setup

### DIFF
--- a/.github/actions/prepare-bazel-ci/action.yml
+++ b/.github/actions/prepare-bazel-ci/action.yml
@@ -1,0 +1,47 @@
+name: prepare-bazel-ci
+description: Prepare a Bazel CI job with shared setup, repository cache restore, and execution logs.
+inputs:
+  target:
+    description: Target triple used for setup and cache namespacing.
+    required: true
+  install-test-prereqs:
+    description: Install Node.js and DotSlash for Bazel-backed test jobs.
+    required: false
+    default: "false"
+outputs:
+  repository-cache-hit:
+    description: Whether the Bazel repository cache restore hit.
+    value: ${{ steps.cache_bazel_repository_restore.outputs.cache-hit }}
+  repository-cache-path:
+    description: Filesystem path used for the Bazel repository cache.
+    value: ${{ steps.setup_bazel.outputs.repository-cache-path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Bazel CI
+      id: setup_bazel
+      uses: ./.github/actions/setup-bazel-ci
+      with:
+        target: ${{ inputs.target }}
+        install-test-prereqs: ${{ inputs.install-test-prereqs }}
+
+    # Restore the Bazel repository cache explicitly so external dependencies
+    # do not need to be re-downloaded on every CI run. Keep restore failures
+    # non-fatal so transient cache-service errors degrade to a cold build
+    # instead of failing the job.
+    - name: Restore bazel repository cache
+      id: cache_bazel_repository_restore
+      continue-on-error: true
+      uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+      with:
+        path: ${{ steps.setup_bazel.outputs.repository-cache-path }}
+        key: bazel-cache-${{ inputs.target }}-${{ hashFiles('MODULE.bazel', 'codex-rs/Cargo.lock', 'codex-rs/Cargo.toml') }}
+        restore-keys: |
+          bazel-cache-${{ inputs.target }}
+
+    - name: Set up Bazel execution logs
+      shell: bash
+      run: |
+        mkdir -p "${RUNNER_TEMP}/bazel-execution-logs"
+        echo "CODEX_BAZEL_EXECUTION_LOG_COMPACT_DIR=${RUNNER_TEMP}/bazel-execution-logs" >> "${GITHUB_ENV}"

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -58,37 +58,16 @@ jobs:
           python3 .github/scripts/rusty_v8_bazel.py check-module-bazel
           python3 -m unittest discover -s .github/scripts -p test_rusty_v8_bazel.py
 
-      - name: Set up Bazel CI
-        id: setup_bazel
-        uses: ./.github/actions/setup-bazel-ci
+      - name: Prepare Bazel CI
+        id: prepare_bazel
+        uses: ./.github/actions/prepare-bazel-ci
         with:
           target: ${{ matrix.target }}
           install-test-prereqs: "true"
-
-      # Restore the Bazel repository cache explicitly so external dependencies
-      # do not need to be re-downloaded on every CI run. Keep restore failures
-      # non-fatal so transient cache-service errors degrade to a cold build
-      # instead of failing the job.
-      - name: Restore bazel repository cache
-        id: cache_bazel_repository_restore
-        continue-on-error: true
-        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: ${{ steps.setup_bazel.outputs.repository-cache-path }}
-          key: bazel-cache-${{ matrix.target }}-${{ hashFiles('MODULE.bazel', 'codex-rs/Cargo.lock', 'codex-rs/Cargo.toml') }}
-          restore-keys: |
-            bazel-cache-${{ matrix.target }}
-
       - name: Check MODULE.bazel.lock is up to date
         if: matrix.os == 'ubuntu-24.04' && matrix.target == 'x86_64-unknown-linux-gnu'
         shell: bash
         run: ./scripts/check-module-bazel-lock.sh
-
-      - name: Set up Bazel execution logs
-        shell: bash
-        run: |
-          mkdir -p "${RUNNER_TEMP}/bazel-execution-logs"
-          echo "CODEX_BAZEL_EXECUTION_LOG_COMPACT_DIR=${RUNNER_TEMP}/bazel-execution-logs" >> "${GITHUB_ENV}"
 
       - name: bazel test //...
         env:
@@ -133,11 +112,11 @@ jobs:
       # Save bazel repository cache explicitly; make non-fatal so cache uploading
       # never fails the overall job. Only save when key wasn't hit.
       - name: Save bazel repository cache
-        if: always() && !cancelled() && steps.cache_bazel_repository_restore.outputs.cache-hit != 'true'
+        if: always() && !cancelled() && steps.prepare_bazel.outputs.repository-cache-hit != 'true'
         continue-on-error: true
         uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
-          path: ${{ steps.setup_bazel.outputs.repository-cache-path }}
+          path: ${{ steps.prepare_bazel.outputs.repository-cache-path }}
           key: bazel-cache-${{ matrix.target }}-${{ hashFiles('MODULE.bazel', 'codex-rs/Cargo.lock', 'codex-rs/Cargo.toml') }}
 
   clippy:
@@ -162,31 +141,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Set up Bazel CI
-        id: setup_bazel
-        uses: ./.github/actions/setup-bazel-ci
+      - name: Prepare Bazel CI
+        id: prepare_bazel
+        uses: ./.github/actions/prepare-bazel-ci
         with:
           target: ${{ matrix.target }}
-
-      # Restore the Bazel repository cache explicitly so external dependencies
-      # do not need to be re-downloaded on every CI run. Keep restore failures
-      # non-fatal so transient cache-service errors degrade to a cold build
-      # instead of failing the job.
-      - name: Restore bazel repository cache
-        id: cache_bazel_repository_restore
-        continue-on-error: true
-        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: ${{ steps.setup_bazel.outputs.repository-cache-path }}
-          key: bazel-cache-${{ matrix.target }}-${{ hashFiles('MODULE.bazel', 'codex-rs/Cargo.lock', 'codex-rs/Cargo.toml') }}
-          restore-keys: |
-            bazel-cache-${{ matrix.target }}
-
-      - name: Set up Bazel execution logs
-        shell: bash
-        run: |
-          mkdir -p "${RUNNER_TEMP}/bazel-execution-logs"
-          echo "CODEX_BAZEL_EXECUTION_LOG_COMPACT_DIR=${RUNNER_TEMP}/bazel-execution-logs" >> "${GITHUB_ENV}"
 
       - name: bazel build --config=clippy lint targets
         env:
@@ -230,9 +189,9 @@ jobs:
       # Save bazel repository cache explicitly; make non-fatal so cache uploading
       # never fails the overall job. Only save when key wasn't hit.
       - name: Save bazel repository cache
-        if: always() && !cancelled()
+        if: always() && !cancelled() && steps.prepare_bazel.outputs.repository-cache-hit != 'true'
         continue-on-error: true
         uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
-          path: ${{ steps.setup_bazel.outputs.repository-cache-path }}
+          path: ${{ steps.prepare_bazel.outputs.repository-cache-path }}
           key: bazel-cache-${{ matrix.target }}-${{ hashFiles('MODULE.bazel', 'codex-rs/Cargo.lock', 'codex-rs/Cargo.toml') }}


### PR DESCRIPTION
## Why

This stack adds a new Bazel CI lane that verifies Rust code behind `cfg(not(debug_assertions))`, but adding that job directly to `.github/workflows/bazel.yml` would duplicate the same setup in multiple places. Extracting the shared setup first keeps the follow-up change easier to review and reduces the chance that future Bazel workflow edits drift apart.

## What Changed

- Added `.github/actions/prepare-bazel-ci/action.yml` as a composite action for the Bazel job bootstrap shared by multiple workflow jobs.
- Moved the existing Bazel setup, repository-cache restore, and execution-log setup behind that action.
- Updated the `test` and `clippy` jobs in `.github/workflows/bazel.yml` to call `prepare-bazel-ci`.
- Exposed `repository-cache-hit` and `repository-cache-path` outputs so callers can keep the existing cache-save behavior without duplicating the restore step.

## Verification

- Parsed `.github/workflows/bazel.yml` as YAML locally after rebasing the stack.
- CI will exercise the refactored jobs end to end.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/17704).
* #17705
* __->__ #17704