### PR TITLE
Support PermissionRequest hook deny interrupts

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -205,6 +205,7 @@ mod rollout_reconstruction_tests;
 #[derive(Debug, PartialEq)]
 pub enum SteerInputError {
     NoActiveTurn(Vec<UserInput>),
+    TurnAbortInProgress(Vec<UserInput>),
     ExpectedTurnMismatch { expected: String, actual: String },
     ActiveTurnNotSteerable { turn_kind: NonSteerableTurnKind },
     EmptyInput,
@@ -215,6 +216,10 @@ impl SteerInputError {
         match self {
             Self::NoActiveTurn(_) => ErrorEvent {
                 message: "no active turn to steer".to_string(),
+                codex_error_info: Some(CodexErrorInfo::BadRequest),
+            },
+            Self::TurnAbortInProgress(_) => ErrorEvent {
+                message: "turn abort is still in progress".to_string(),
                 codex_error_info: Some(CodexErrorInfo::BadRequest),
             },
             Self::ExpectedTurnMismatch { expected, actual } => ErrorEvent {
@@ -4159,6 +4164,9 @@ impl Session {
         let Some(active_turn) = active.as_mut() else {
             return Err(SteerInputError::NoActiveTurn(input));
         };
+        if active_turn.is_aborting() {
+            return Err(SteerInputError::TurnAbortInProgress(input));
+        }
 
         let Some((active_turn_id, _)) = active_turn.tasks.first() else {
             return Err(SteerInputError::NoActiveTurn(input));
@@ -5016,6 +5024,21 @@ mod handlers {
             ),
             _ => unreachable!(),
         };
+
+        let abort_in_progress = {
+            let active = sess.active_turn.lock().await;
+            active
+                .as_ref()
+                .is_some_and(crate::state::ActiveTurn::is_aborting)
+        };
+        if abort_in_progress {
+            sess.send_event_raw(Event {
+                id: sub_id,
+                msg: EventMsg::Error(SteerInputError::TurnAbortInProgress(items).to_error_event()),
+            })
+            .await;
+            return;
+        }
 
         let Ok(current_context) = sess.new_turn_with_sub_id(sub_id.clone(), updates).await else {
             // new_turn_with_sub_id already emits the error event.

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -4430,7 +4430,7 @@ impl Session {
         info!("interrupt received: abort current task, if any");
         let has_active_turn = { self.active_turn.lock().await.is_some() };
         if has_active_turn {
-            self.abort_all_tasks(TurnAbortReason::Interrupted).await;
+            self.request_task_abort(TurnAbortReason::Interrupted).await;
         } else {
             self.cancel_mcp_startup().await;
         }
@@ -7532,6 +7532,9 @@ async fn drain_in_flight(
             Ok(response_input) => {
                 sess.record_conversation_items(&turn_context, &[response_input.into()])
                     .await;
+            }
+            Err(CodexErr::TurnAborted) => {
+                return Err(CodexErr::TurnAborted);
             }
             Err(err) => {
                 error_or_panic(format!("in-flight tool future failed during drain: {err}"));

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -4164,6 +4164,8 @@ impl Session {
         let Some(active_turn) = active.as_mut() else {
             return Err(SteerInputError::NoActiveTurn(input));
         };
+        // An aborting turn still owns the session until cleanup finishes, but it can no longer
+        // accept same-turn input.
         if active_turn.is_aborting() {
             return Err(SteerInputError::TurnAbortInProgress(input));
         }

--- a/codex-rs/core/src/codex_tests.rs
+++ b/codex-rs/core/src/codex_tests.rs
@@ -42,6 +42,7 @@ use tracing::Span;
 use crate::RolloutRecorderParams;
 use crate::rollout::policy::EventPersistenceMode;
 use crate::rollout::recorder::RolloutRecorder;
+use crate::state::ActiveTurn;
 use crate::state::TaskKind;
 use crate::tasks::SessionTask;
 use crate::tasks::SessionTaskContext;
@@ -82,6 +83,7 @@ use codex_protocol::protocol::RealtimeConversationListVoicesResponseEvent;
 use codex_protocol::protocol::RealtimeVoice;
 use codex_protocol::protocol::RealtimeVoicesList;
 use codex_protocol::protocol::ResumedHistory;
+use codex_protocol::protocol::ReviewDecision;
 use codex_protocol::protocol::RolloutItem;
 use codex_protocol::protocol::Submission;
 use codex_protocol::protocol::ThreadRolledBackEvent;
@@ -4686,6 +4688,55 @@ impl SessionTask for SlowAbortTask {
     }
 }
 
+struct ApprovalWaitTask {
+    approval_id: String,
+    warning_message: String,
+}
+
+impl SessionTask for ApprovalWaitTask {
+    fn kind(&self) -> TaskKind {
+        TaskKind::Regular
+    }
+
+    fn span_name(&self) -> &'static str {
+        "session_task.approval_wait"
+    }
+
+    async fn run(
+        self: Arc<Self>,
+        session: Arc<SessionTaskContext>,
+        ctx: Arc<TurnContext>,
+        _input: Vec<UserInput>,
+        _cancellation_token: CancellationToken,
+    ) -> Option<String> {
+        let decision = session
+            .clone_session()
+            .request_command_approval(
+                ctx.as_ref(),
+                self.approval_id.clone(),
+                /*approval_id*/ None,
+                vec!["echo".to_string(), "hi".to_string()],
+                ctx.cwd.to_path_buf(),
+                /*reason*/ None,
+                /*network_approval_context*/ None,
+                /*proposed_execpolicy_amendment*/ None,
+                /*additional_permissions*/ None,
+                Some(vec![ReviewDecision::Approved, ReviewDecision::Abort]),
+            )
+            .await;
+        session
+            .clone_session()
+            .send_event(
+                ctx.as_ref(),
+                EventMsg::Warning(WarningEvent {
+                    message: format!("approval decision: {decision:?} {}", self.warning_message),
+                }),
+            )
+            .await;
+        None
+    }
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[test_log::test]
 async fn abort_regular_task_emits_turn_aborted_only() {
@@ -4809,6 +4860,65 @@ async fn interrupt_keeps_active_turn_installed_until_abort_cleanup_finishes() {
         EventMsg::TurnAborted(e) => assert_eq!(TurnAbortReason::Interrupted, e.reason),
         other => panic!("unexpected event: {other:?}"),
     }
+
+    let active_turn = sess.active_turn.lock().await;
+    assert!(active_turn.is_none());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn interrupt_waiting_approval_does_not_emit_abort_fallback_before_turn_aborted() {
+    let (sess, tc, rx) = make_session_and_context_with_rx().await;
+    let warning_message = "approval wait should not escape interrupt".to_string();
+    sess.spawn_task(
+        Arc::clone(&tc),
+        Vec::new(),
+        ApprovalWaitTask {
+            approval_id: "approval-wait".to_string(),
+            warning_message: warning_message.clone(),
+        },
+    )
+    .await;
+
+    loop {
+        let evt = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+            .await
+            .expect("timeout waiting for approval request event")
+            .expect("event");
+        if matches!(evt.msg, EventMsg::ExecApprovalRequest(_)) {
+            break;
+        }
+    }
+
+    sess.interrupt_task().await;
+
+    loop {
+        let evt = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+            .await
+            .expect("timeout waiting for abort event")
+            .expect("event");
+        match evt.msg {
+            EventMsg::Warning(WarningEvent { message }) => {
+                assert!(
+                    !message.contains(&warning_message),
+                    "approval wait surfaced fallback decision before interrupt completed"
+                );
+            }
+            EventMsg::TurnAborted(e) => {
+                assert_eq!(TurnAbortReason::Interrupted, e.reason);
+                break;
+            }
+            _ => {}
+        }
+    }
+}
+
+#[tokio::test]
+async fn interrupt_clears_empty_aborting_turn() {
+    let (sess, _tc, _rx) = make_session_and_context_with_rx().await;
+    *sess.active_turn.lock().await = Some(ActiveTurn::default());
+
+    sess.interrupt_task().await;
+    tokio::task::yield_now().await;
 
     let active_turn = sess.active_turn.lock().await;
     assert!(active_turn.is_none());

--- a/codex-rs/core/src/codex_tests.rs
+++ b/codex-rs/core/src/codex_tests.rs
@@ -4654,6 +4654,38 @@ impl SessionTask for NeverEndingTask {
     }
 }
 
+struct SlowAbortTask {
+    abort_started: Arc<tokio::sync::Notify>,
+    finish_abort: Arc<tokio::sync::Notify>,
+}
+
+impl SessionTask for SlowAbortTask {
+    fn kind(&self) -> TaskKind {
+        TaskKind::Regular
+    }
+
+    fn span_name(&self) -> &'static str {
+        "session_task.slow_abort"
+    }
+
+    async fn run(
+        self: Arc<Self>,
+        _session: Arc<SessionTaskContext>,
+        _ctx: Arc<TurnContext>,
+        _input: Vec<UserInput>,
+        _cancellation_token: CancellationToken,
+    ) -> Option<String> {
+        loop {
+            sleep(Duration::from_secs(60)).await;
+        }
+    }
+
+    async fn abort(&self, _session: Arc<SessionTaskContext>, _ctx: Arc<TurnContext>) {
+        self.abort_started.notify_waiters();
+        self.finish_abort.notified().await;
+    }
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[test_log::test]
 async fn abort_regular_task_emits_turn_aborted_only() {
@@ -4719,6 +4751,67 @@ async fn abort_gracefully_emits_turn_aborted_only() {
     }
     // No extra events should be emitted after an abort.
     assert!(rx.try_recv().is_err());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn interrupt_keeps_active_turn_installed_until_abort_cleanup_finishes() {
+    let (sess, tc, rx) = make_session_and_context_with_rx().await;
+    let abort_started = Arc::new(tokio::sync::Notify::new());
+    let finish_abort = Arc::new(tokio::sync::Notify::new());
+    let input = vec![UserInput::Text {
+        text: "hello".to_string(),
+        text_elements: Vec::new(),
+    }];
+    sess.spawn_task(
+        Arc::clone(&tc),
+        input,
+        SlowAbortTask {
+            abort_started: Arc::clone(&abort_started),
+            finish_abort: Arc::clone(&finish_abort),
+        },
+    )
+    .await;
+
+    sess.interrupt_task().await;
+    tokio::time::timeout(Duration::from_secs(2), abort_started.notified())
+        .await
+        .expect("timeout waiting for abort cleanup to start");
+
+    {
+        let active_turn = sess.active_turn.lock().await;
+        assert!(
+            active_turn
+                .as_ref()
+                .is_some_and(crate::state::ActiveTurn::is_aborting)
+        );
+    }
+
+    let err = sess
+        .steer_input(
+            vec![UserInput::Text {
+                text: "new prompt".to_string(),
+                text_elements: Vec::new(),
+            }],
+            /*expected_turn_id*/ None,
+            /*responsesapi_client_metadata*/ None,
+        )
+        .await
+        .expect_err("interrupting turn should not accept new steer input");
+    assert!(matches!(err, SteerInputError::TurnAbortInProgress(_)));
+
+    finish_abort.notify_waiters();
+
+    let evt = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .expect("timeout waiting for abort event")
+        .expect("event");
+    match evt.msg {
+        EventMsg::TurnAborted(e) => assert_eq!(TurnAbortReason::Interrupted, e.reason),
+        other => panic!("unexpected event: {other:?}"),
+    }
+
+    let active_turn = sess.active_turn.lock().await;
+    assert!(active_turn.is_none());
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/codex-rs/core/src/function_tool.rs
+++ b/codex-rs/core/src/function_tool.rs
@@ -4,6 +4,8 @@ use thiserror::Error;
 pub enum FunctionCallError {
     #[error("{0}")]
     RespondToModel(String),
+    #[error("tool interrupted")]
+    Interrupted,
     #[error("LocalShellCall without call_id or id")]
     MissingLocalShellCallId,
     #[error("Fatal error: {0}")]

--- a/codex-rs/core/src/state/turn.rs
+++ b/codex-rs/core/src/state/turn.rs
@@ -25,6 +25,7 @@ use codex_protocol::protocol::TokenUsage;
 
 /// Metadata about the currently running turn.
 pub(crate) struct ActiveTurn {
+    abort_in_progress: bool,
     pub(crate) tasks: IndexMap<String, RunningTask>,
     pub(crate) turn_state: Arc<Mutex<TurnState>>,
 }
@@ -53,6 +54,7 @@ pub(crate) enum MailboxDeliveryPhase {
 impl Default for ActiveTurn {
     fn default() -> Self {
         Self {
+            abort_in_progress: false,
             tasks: IndexMap::new(),
             turn_state: Arc::new(Mutex::new(TurnState::default())),
         }
@@ -83,9 +85,21 @@ impl ActiveTurn {
         self.tasks.insert(sub_id, task);
     }
 
+    pub(crate) fn is_aborting(&self) -> bool {
+        self.abort_in_progress
+    }
+
     pub(crate) fn remove_task(&mut self, sub_id: &str) -> bool {
         self.tasks.swap_remove(sub_id);
         self.tasks.is_empty()
+    }
+
+    pub(crate) fn begin_abort(&mut self) -> Option<Vec<RunningTask>> {
+        if self.abort_in_progress {
+            return None;
+        }
+        self.abort_in_progress = true;
+        Some(self.drain_tasks())
     }
 
     pub(crate) fn drain_tasks(&mut self) -> Vec<RunningTask> {
@@ -243,13 +257,5 @@ impl TurnState {
 
     pub(crate) fn granted_permissions(&self) -> Option<PermissionProfile> {
         self.granted_permissions.clone()
-    }
-}
-
-impl ActiveTurn {
-    /// Clear any pending approvals and input buffered for the current turn.
-    pub(crate) async fn clear_pending(&self) {
-        let mut ts = self.turn_state.lock().await;
-        ts.clear_pending();
     }
 }

--- a/codex-rs/core/src/stream_events_utils.rs
+++ b/codex-rs/core/src/stream_events_utils.rs
@@ -325,6 +325,9 @@ pub(crate) async fn handle_output_item_done(
         Err(FunctionCallError::Fatal(message)) => {
             return Err(CodexErr::Fatal(message));
         }
+        Err(FunctionCallError::Interrupted) => {
+            return Err(CodexErr::TurnAborted);
+        }
     }
 
     Ok(output)

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -409,6 +409,9 @@ impl Session {
             let Some(active_turn) = active.as_mut() else {
                 return;
             };
+            // Async abort keeps the turn installed until cleanup completes so the session does
+            // not look idle to other callers while the old turn is still unwinding. Mark it as
+            // aborting before we cancel tasks so the turn remains non-steerable during that gap.
             let Some(tasks) = active_turn.begin_abort() else {
                 return;
             };
@@ -662,6 +665,8 @@ impl Session {
         }
 
         if clear_active_turn_before_event {
+            // The final async-aborted task clears the installed aborting turn before emitting the
+            // client-visible abort event so immediate follow-up actions observe an idle session.
             let mut active = self.active_turn.lock().await;
             if active.as_ref().is_some_and(ActiveTurn::is_aborting) {
                 *active = None;

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -388,7 +388,7 @@ impl Session {
         if let Some(mut active_turn) = self.take_active_turn().await {
             let turn_state = Arc::clone(&active_turn.turn_state);
             let tasks = active_turn.drain_tasks();
-            self.prepare_tasks_for_abort(&tasks, &turn_state).await;
+            self.prepare_tasks_for_abort(&tasks).await;
             for task in tasks {
                 self.handle_task_abort(
                     task,
@@ -397,6 +397,8 @@ impl Session {
                 )
                 .await;
             }
+            let mut state = turn_state.lock().await;
+            state.clear_pending();
         }
         if reason == TurnAbortReason::Interrupted {
             self.maybe_start_turn_for_pending_work().await;
@@ -417,7 +419,7 @@ impl Session {
             };
             (tasks, Arc::clone(&active_turn.turn_state))
         };
-        self.prepare_tasks_for_abort(&tasks, &turn_state).await;
+        self.prepare_tasks_for_abort(&tasks).await;
         let session = Arc::clone(self);
         tokio::spawn(async move {
             let num_tasks = tasks.len();
@@ -426,6 +428,14 @@ impl Session {
                     .handle_task_abort(task, reason.clone(), index + 1 == num_tasks)
                     .await;
             }
+            let mut state = turn_state.lock().await;
+            state.clear_pending();
+            drop(state);
+            let mut active = session.active_turn.lock().await;
+            if active.as_ref().is_some_and(ActiveTurn::is_aborting) {
+                *active = None;
+            }
+            drop(active);
             if reason == TurnAbortReason::Interrupted {
                 session.maybe_start_turn_for_pending_work().await;
             }
@@ -586,21 +596,13 @@ impl Session {
         active.take()
     }
 
-    async fn prepare_tasks_for_abort(
-        &self,
-        tasks: &[RunningTask],
-        turn_state: &Arc<tokio::sync::Mutex<crate::state::TurnState>>,
-    ) {
+    async fn prepare_tasks_for_abort(&self, tasks: &[RunningTask]) {
         for task in tasks {
             task.cancellation_token.cancel();
             task.turn_context
                 .turn_metadata_state
                 .cancel_git_enrichment_task();
         }
-        // Let interrupted tasks observe cancellation before dropping pending approvals, or an
-        // in-flight approval wait can surface as a model-visible rejection before TurnAborted.
-        let mut state = turn_state.lock().await;
-        state.clear_pending();
     }
 
     pub(crate) async fn close_unified_exec_processes(&self) {

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -261,6 +261,7 @@ impl Session {
             let mut active = self.active_turn.lock().await;
             let turn = active.get_or_insert_with(ActiveTurn::default);
             debug_assert!(turn.tasks.is_empty());
+            debug_assert!(!turn.is_aborting());
             Arc::clone(&turn.turn_state)
         };
         {
@@ -277,6 +278,7 @@ impl Session {
         let mut active = self.active_turn.lock().await;
         let turn = active.get_or_insert_with(ActiveTurn::default);
         debug_assert!(turn.tasks.is_empty());
+        debug_assert!(!turn.is_aborting());
         let done_clone = Arc::clone(&done);
         let session_ctx = Arc::new(SessionTaskContext::new(Arc::clone(self)));
         let ctx = Arc::clone(&turn_context);
@@ -384,9 +386,16 @@ impl Session {
 
     pub async fn abort_all_tasks(self: &Arc<Self>, reason: TurnAbortReason) {
         if let Some(mut active_turn) = self.take_active_turn().await {
-            let tasks = self.prepare_tasks_for_abort(&mut active_turn).await;
+            let turn_state = Arc::clone(&active_turn.turn_state);
+            let tasks = active_turn.drain_tasks();
+            self.prepare_tasks_for_abort(&tasks, &turn_state).await;
             for task in tasks {
-                self.handle_task_abort(task, reason.clone()).await;
+                self.handle_task_abort(
+                    task,
+                    reason.clone(),
+                    /*clear_active_turn_before_event*/ false,
+                )
+                .await;
             }
         }
         if reason == TurnAbortReason::Interrupted {
@@ -395,14 +404,24 @@ impl Session {
     }
 
     pub(crate) async fn request_task_abort(self: &Arc<Self>, reason: TurnAbortReason) {
-        let Some(mut active_turn) = self.take_active_turn().await else {
-            return;
+        let (tasks, turn_state) = {
+            let mut active = self.active_turn.lock().await;
+            let Some(active_turn) = active.as_mut() else {
+                return;
+            };
+            let Some(tasks) = active_turn.begin_abort() else {
+                return;
+            };
+            (tasks, Arc::clone(&active_turn.turn_state))
         };
-        let tasks = self.prepare_tasks_for_abort(&mut active_turn).await;
+        self.prepare_tasks_for_abort(&tasks, &turn_state).await;
         let session = Arc::clone(self);
         tokio::spawn(async move {
-            for task in tasks {
-                session.handle_task_abort(task, reason.clone()).await;
+            let num_tasks = tasks.len();
+            for (index, task) in tasks.into_iter().enumerate() {
+                session
+                    .handle_task_abort(task, reason.clone(), index + 1 == num_tasks)
+                    .await;
             }
             if reason == TurnAbortReason::Interrupted {
                 session.maybe_start_turn_for_pending_work().await;
@@ -564,9 +583,12 @@ impl Session {
         active.take()
     }
 
-    async fn prepare_tasks_for_abort(&self, active_turn: &mut ActiveTurn) -> Vec<RunningTask> {
-        let tasks = active_turn.drain_tasks();
-        for task in &tasks {
+    async fn prepare_tasks_for_abort(
+        &self,
+        tasks: &[RunningTask],
+        turn_state: &Arc<tokio::sync::Mutex<crate::state::TurnState>>,
+    ) {
+        for task in tasks {
             task.cancellation_token.cancel();
             task.turn_context
                 .turn_metadata_state
@@ -574,8 +596,8 @@ impl Session {
         }
         // Let interrupted tasks observe cancellation before dropping pending approvals, or an
         // in-flight approval wait can surface as a model-visible rejection before TurnAborted.
-        active_turn.clear_pending().await;
-        tasks
+        let mut state = turn_state.lock().await;
+        state.clear_pending();
     }
 
     pub(crate) async fn close_unified_exec_processes(&self) {
@@ -593,7 +615,12 @@ impl Session {
         }
     }
 
-    async fn handle_task_abort(self: &Arc<Self>, task: RunningTask, reason: TurnAbortReason) {
+    async fn handle_task_abort(
+        self: &Arc<Self>,
+        task: RunningTask,
+        reason: TurnAbortReason,
+        clear_active_turn_before_event: bool,
+    ) {
         let sub_id = task.turn_context.sub_id.clone();
         if !task.cancellation_token.is_cancelled() {
             trace!(task_kind = ?task.kind, sub_id, "aborting running task");
@@ -631,6 +658,13 @@ impl Session {
             // synchronously re-read the rollout on receipt of the abort event.
             if let Err(err) = self.flush_rollout().await {
                 warn!("failed to flush interrupted-turn marker before emitting TurnAborted: {err}");
+            }
+        }
+
+        if clear_active_turn_before_event {
+            let mut active = self.active_turn.lock().await;
+            if active.as_ref().is_some_and(ActiveTurn::is_aborting) {
+                *active = None;
             }
         }
 

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -384,16 +384,30 @@ impl Session {
 
     pub async fn abort_all_tasks(self: &Arc<Self>, reason: TurnAbortReason) {
         if let Some(mut active_turn) = self.take_active_turn().await {
-            for task in active_turn.drain_tasks() {
+            let tasks = self.prepare_tasks_for_abort(&mut active_turn).await;
+            for task in tasks {
                 self.handle_task_abort(task, reason.clone()).await;
             }
-            // Let interrupted tasks observe cancellation before dropping pending approvals, or an
-            // in-flight approval wait can surface as a model-visible rejection before TurnAborted.
-            active_turn.clear_pending().await;
         }
         if reason == TurnAbortReason::Interrupted {
             self.maybe_start_turn_for_pending_work().await;
         }
+    }
+
+    pub(crate) async fn request_task_abort(self: &Arc<Self>, reason: TurnAbortReason) {
+        let Some(mut active_turn) = self.take_active_turn().await else {
+            return;
+        };
+        let tasks = self.prepare_tasks_for_abort(&mut active_turn).await;
+        let session = Arc::clone(self);
+        tokio::spawn(async move {
+            for task in tasks {
+                session.handle_task_abort(task, reason.clone()).await;
+            }
+            if reason == TurnAbortReason::Interrupted {
+                session.maybe_start_turn_for_pending_work().await;
+            }
+        });
     }
 
     pub async fn on_task_finished(
@@ -550,6 +564,20 @@ impl Session {
         active.take()
     }
 
+    async fn prepare_tasks_for_abort(&self, active_turn: &mut ActiveTurn) -> Vec<RunningTask> {
+        let tasks = active_turn.drain_tasks();
+        for task in &tasks {
+            task.cancellation_token.cancel();
+            task.turn_context
+                .turn_metadata_state
+                .cancel_git_enrichment_task();
+        }
+        // Let interrupted tasks observe cancellation before dropping pending approvals, or an
+        // in-flight approval wait can surface as a model-visible rejection before TurnAborted.
+        active_turn.clear_pending().await;
+        tasks
+    }
+
     pub(crate) async fn close_unified_exec_processes(&self) {
         self.services
             .unified_exec_manager
@@ -567,12 +595,10 @@ impl Session {
 
     async fn handle_task_abort(self: &Arc<Self>, task: RunningTask, reason: TurnAbortReason) {
         let sub_id = task.turn_context.sub_id.clone();
-        if task.cancellation_token.is_cancelled() {
-            return;
+        if !task.cancellation_token.is_cancelled() {
+            trace!(task_kind = ?task.kind, sub_id, "aborting running task");
+            task.cancellation_token.cancel();
         }
-
-        trace!(task_kind = ?task.kind, sub_id, "aborting running task");
-        task.cancellation_token.cancel();
         task.turn_context
             .turn_metadata_state
             .cancel_git_enrichment_task();

--- a/codex-rs/core/src/tools/events.rs
+++ b/codex-rs/core/src/tools/events.rs
@@ -357,6 +357,7 @@ impl ToolEmitter {
                 let result = Err(FunctionCallError::RespondToModel(normalized));
                 (event, result)
             }
+            Err(ToolError::Interrupted) => return Err(FunctionCallError::Interrupted),
         };
         self.emit(ctx, event).await;
         result

--- a/codex-rs/core/src/tools/network_approval.rs
+++ b/codex-rs/core/src/tools/network_approval.rs
@@ -118,6 +118,7 @@ enum PendingApprovalDecision {
 enum NetworkApprovalOutcome {
     DeniedByUser,
     DeniedByPolicy(String),
+    Interrupted,
 }
 
 /// Whether an allowlist miss may be reviewed instead of hard-denied.
@@ -269,7 +270,7 @@ impl NetworkApprovalService {
         let mut call_outcomes = self.call_outcomes.lock().await;
         if matches!(
             call_outcomes.get(registration_id),
-            Some(NetworkApprovalOutcome::DeniedByUser)
+            Some(NetworkApprovalOutcome::DeniedByUser | NetworkApprovalOutcome::Interrupted)
         ) {
             return;
         }
@@ -404,11 +405,13 @@ impl NetworkApprovalService {
                 }
                 PermissionRequestDecision::Deny { message, interrupt } => {
                     if let Some(owner_call) = owner_call.as_ref() {
-                        self.record_call_outcome(
-                            &owner_call.registration_id,
-                            NetworkApprovalOutcome::DeniedByPolicy(message.clone()),
-                        )
-                        .await;
+                        let outcome = if interrupt {
+                            NetworkApprovalOutcome::Interrupted
+                        } else {
+                            NetworkApprovalOutcome::DeniedByPolicy(message.clone())
+                        };
+                        self.record_call_outcome(&owner_call.registration_id, outcome)
+                            .await;
                     }
                     if interrupt {
                         session.interrupt_task().await;
@@ -671,6 +674,7 @@ pub(crate) async fn finish_immediate_network_approval(
             Err(ToolError::Rejected("rejected by user".to_string()))
         }
         Some(NetworkApprovalOutcome::DeniedByPolicy(message)) => Err(ToolError::Rejected(message)),
+        Some(NetworkApprovalOutcome::Interrupted) => Err(ToolError::Interrupted),
         None => Ok(()),
     }
 }

--- a/codex-rs/core/src/tools/network_approval.rs
+++ b/codex-rs/core/src/tools/network_approval.rs
@@ -402,13 +402,16 @@ impl NetworkApprovalService {
                     pending_approvals.remove(&key);
                     return NetworkDecision::Allow;
                 }
-                PermissionRequestDecision::Deny { message } => {
+                PermissionRequestDecision::Deny { message, interrupt } => {
                     if let Some(owner_call) = owner_call.as_ref() {
                         self.record_call_outcome(
                             &owner_call.registration_id,
-                            NetworkApprovalOutcome::DeniedByPolicy(message),
+                            NetworkApprovalOutcome::DeniedByPolicy(message.clone()),
                         )
                         .await;
+                    }
+                    if interrupt {
+                        session.interrupt_task().await;
                     }
                     pending.set_decision(PendingApprovalDecision::Deny).await;
                     let mut pending_approvals = self.pending_host_approvals.lock().await;

--- a/codex-rs/core/src/tools/network_approval_tests.rs
+++ b/codex-rs/core/src/tools/network_approval_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::codex::make_session_and_context_with_rx;
 use codex_network_proxy::BlockedRequestArgs;
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::SandboxPolicy;
@@ -252,6 +253,60 @@ async fn blocked_request_policy_does_not_override_user_denial_outcome() {
         service.take_call_outcome("registration-1").await,
         Some(NetworkApprovalOutcome::DeniedByUser)
     );
+}
+
+#[tokio::test]
+async fn blocked_request_policy_does_not_override_interrupted_outcome() {
+    let service = NetworkApprovalService::default();
+    service
+        .register_call(
+            "registration-1".to_string(),
+            "turn-1".to_string(),
+            "curl http://example.com".to_string(),
+        )
+        .await;
+
+    service
+        .record_call_outcome("registration-1", NetworkApprovalOutcome::Interrupted)
+        .await;
+    service
+        .record_blocked_request(denied_blocked_request("example.com"))
+        .await;
+
+    assert_eq!(
+        service.take_call_outcome("registration-1").await,
+        Some(NetworkApprovalOutcome::Interrupted)
+    );
+}
+
+#[tokio::test]
+async fn finish_immediate_network_approval_returns_interrupted() {
+    let (session, _turn_context, _rx) = make_session_and_context_with_rx().await;
+    session
+        .services
+        .network_approval
+        .register_call(
+            "registration-1".to_string(),
+            "turn-1".to_string(),
+            "curl http://example.com".to_string(),
+        )
+        .await;
+    session
+        .services
+        .network_approval
+        .record_call_outcome("registration-1", NetworkApprovalOutcome::Interrupted)
+        .await;
+
+    let result = finish_immediate_network_approval(
+        &session,
+        ActiveNetworkApproval {
+            registration_id: Some("registration-1".to_string()),
+            mode: NetworkApprovalMode::Immediate,
+        },
+    )
+    .await;
+
+    assert!(matches!(result, Err(ToolError::Interrupted)));
 }
 
 #[tokio::test]

--- a/codex-rs/core/src/tools/orchestrator.rs
+++ b/codex-rs/core/src/tools/orchestrator.rs
@@ -386,13 +386,17 @@ impl ToolOrchestrator {
                     );
                     return Ok(ReviewDecision::Approved);
                 }
-                Some(PermissionRequestDecision::Deny { message }) => {
+                Some(PermissionRequestDecision::Deny { message, interrupt }) => {
                     telemetry.otel.tool_decision(
                         telemetry.tool_name,
                         telemetry.call_id,
                         &ReviewDecision::Denied,
                         ToolDecisionSource::Config,
                     );
+                    if interrupt {
+                        approval_ctx.session.interrupt_task().await;
+                        return Err(ToolError::Interrupted);
+                    }
                     return Err(ToolError::Rejected(message));
                 }
                 None => {}

--- a/codex-rs/core/src/tools/parallel.rs
+++ b/codex-rs/core/src/tools/parallel.rs
@@ -64,6 +64,7 @@ impl ToolCallRuntime {
         async move {
             match future.await {
                 Ok(response) => Ok(response.into_response()),
+                Err(FunctionCallError::Interrupted) => Err(CodexErr::TurnAborted),
                 Err(FunctionCallError::Fatal(message)) => Err(CodexErr::Fatal(message)),
                 Err(other) => Ok(Self::failure_response(error_call, other)),
             }

--- a/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
+++ b/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
@@ -420,9 +420,15 @@ impl CoreShellActionProvider {
                             rejection_message: None,
                         };
                     }
-                    Some(PermissionRequestDecision::Deny { message }) => {
+                    Some(PermissionRequestDecision::Deny { message, interrupt }) => {
+                        let decision = if interrupt {
+                            session.interrupt_task().await;
+                            ReviewDecision::Abort
+                        } else {
+                            ReviewDecision::Denied
+                        };
                         return PromptDecision {
-                            decision: ReviewDecision::Denied,
+                            decision,
                             guardian_review_id: None,
                             rejection_message: Some(message),
                         };

--- a/codex-rs/core/src/tools/sandboxing.rs
+++ b/codex-rs/core/src/tools/sandboxing.rs
@@ -321,6 +321,7 @@ pub(crate) struct ToolCtx {
 #[derive(Debug)]
 pub(crate) enum ToolError {
     Rejected(String),
+    Interrupted,
     Codex(CodexErr),
 }
 

--- a/codex-rs/core/tests/suite/hooks.rs
+++ b/codex-rs/core/tests/suite/hooks.rs
@@ -294,6 +294,17 @@ elif mode == "deny":
             }}
         }}
     }}))
+elif mode == "deny_interrupt":
+    print(json.dumps({{
+        "hookSpecificOutput": {{
+            "hookEventName": "PermissionRequest",
+            "decision": {{
+                "behavior": "deny",
+                "message": reason,
+                "interrupt": True
+            }}
+        }}
+    }}))
 elif mode == "exit_2":
     sys.stderr.write(reason + "\n")
     raise SystemExit(2)
@@ -1217,6 +1228,112 @@ async fn permission_request_hook_allows_shell_command_without_user_approval() ->
             .as_str()
             .is_some_and(|turn_id| !turn_id.is_empty())
     );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn permission_request_hook_interrupts_shell_command_turn() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let call_id = "permissionrequest-shell-command-interrupt";
+    let marker = std::env::temp_dir().join("permissionrequest-shell-command-interrupt-marker");
+    let command = format!("rm -f {}", marker.display());
+    let args = serde_json::json!({ "command": command });
+    let responses = mount_sse_once(
+        &server,
+        sse(vec![
+            ev_response_created("resp-1"),
+            core_test_support::responses::ev_function_call(
+                call_id,
+                "shell_command",
+                &serde_json::to_string(&args)?,
+            ),
+            ev_completed("resp-1"),
+        ]),
+    )
+    .await;
+
+    let test = test_codex()
+        .with_pre_build_hook(|home| {
+            if let Err(error) = write_permission_request_hook(
+                home,
+                Some(PERMISSION_REQUEST_HOOK_MATCHER),
+                "deny_interrupt",
+                "blocked and interrupted by hook",
+            ) {
+                panic!("failed to write permission request hook test fixture: {error}");
+            }
+        })
+        .with_config(|config| {
+            config
+                .features
+                .enable(Feature::CodexHooks)
+                .expect("test config should allow feature update");
+        })
+        .build(&server)
+        .await?;
+
+    fs::write(&marker, "seed").context("create interrupt permission request marker")?;
+
+    test.codex
+        .submit(Op::UserTurn {
+            items: vec![UserInput::Text {
+                text: "run the shell command after hook approval".into(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+            cwd: test.config.cwd.to_path_buf(),
+            approval_policy: AskForApproval::OnRequest,
+            approvals_reviewer: None,
+            sandbox_policy: SandboxPolicy::DangerFullAccess,
+            model: test.session_configured.model.clone(),
+            effort: None,
+            summary: None,
+            service_tier: None,
+            collaboration_mode: None,
+            personality: None,
+        })
+        .await?;
+
+    let mut started_turn_id = None;
+    let mut aborted = None;
+    let mut seen_events = Vec::new();
+    while aborted.is_none() {
+        let event = timeout(Duration::from_secs(10), test.codex.next_event())
+            .await
+            .expect("timeout waiting for hook interrupt events")?;
+        seen_events.push(format!("{:?}", event.msg));
+        match event.msg {
+            EventMsg::TurnStarted(started) => {
+                started_turn_id = Some(started.turn_id);
+            }
+            EventMsg::TurnAborted(event) => {
+                aborted = Some(event);
+            }
+            EventMsg::TurnComplete(event) => {
+                panic!("expected interrupted turn, saw completion instead: {event:?}");
+            }
+            _ => {}
+        }
+    }
+    let aborted = aborted.expect("turn aborted event should be present");
+    assert_eq!(
+        aborted.reason,
+        codex_protocol::protocol::TurnAbortReason::Interrupted
+    );
+    assert_eq!(aborted.turn_id, started_turn_id);
+    assert_eq!(responses.requests().len(), 1);
+    assert!(
+        marker.exists(),
+        "interrupted command should not remove marker file"
+    );
+    assert_single_permission_request_hook_input(
+        test.codex_home_path(),
+        &command,
+        /*description*/ None,
+    )?;
 
     Ok(())
 }

--- a/codex-rs/hooks/schema/generated/permission-request.command.output.schema.json
+++ b/codex-rs/hooks/schema/generated/permission-request.command.output.schema.json
@@ -28,7 +28,7 @@
         },
         "interrupt": {
           "default": false,
-          "description": "Reserved for future short-circuiting semantics.\n\nPermissionRequest hooks currently fail closed if this field is `true`.",
+          "description": "When `true`, a deny decision interrupts the current turn after the hook feedback is recorded.",
           "type": "boolean"
         },
         "message": {

--- a/codex-rs/hooks/src/engine/output_parser.rs
+++ b/codex-rs/hooks/src/engine/output_parser.rs
@@ -22,7 +22,7 @@ pub(crate) struct PreToolUseOutput {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum PermissionRequestDecision {
     Allow,
-    Deny { message: String },
+    Deny { message: String, interrupt: bool },
 }
 
 #[derive(Debug, Clone)]
@@ -302,7 +302,9 @@ fn unsupported_permission_request_hook_specific_output(
         Some("PermissionRequest hook returned unsupported updatedInput".to_string())
     } else if decision.updated_permissions.is_some() {
         Some("PermissionRequest hook returned unsupported updatedPermissions".to_string())
-    } else if decision.interrupt {
+    } else if decision.interrupt
+        && matches!(decision.behavior, PermissionRequestBehaviorWire::Allow)
+    {
         Some("PermissionRequest hook returned unsupported interrupt:true".to_string())
     } else {
         None
@@ -320,6 +322,7 @@ fn permission_request_decision(
                 .as_deref()
                 .and_then(trimmed_reason)
                 .unwrap_or_else(|| "PermissionRequest hook denied approval".to_string()),
+            interrupt: decision.interrupt,
         },
     }
 }
@@ -421,6 +424,7 @@ mod tests {
     use pretty_assertions::assert_eq;
     use serde_json::json;
 
+    use super::PermissionRequestDecision;
     use super::parse_permission_request;
 
     #[test]
@@ -489,6 +493,34 @@ mod tests {
         assert_eq!(
             parsed.invalid_reason,
             Some("PermissionRequest hook returned unsupported interrupt:true".to_string())
+        );
+    }
+
+    #[test]
+    fn permission_request_accepts_interrupting_deny() {
+        let parsed = parse_permission_request(
+            &json!({
+                "continue": true,
+                "hookSpecificOutput": {
+                    "hookEventName": "PermissionRequest",
+                    "decision": {
+                        "behavior": "deny",
+                        "message": "blocked",
+                        "interrupt": true
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .expect("permission request hook output should parse");
+
+        assert_eq!(parsed.invalid_reason, None);
+        assert_eq!(
+            parsed.decision,
+            Some(PermissionRequestDecision::Deny {
+                message: "blocked".to_string(),
+                interrupt: true,
+            })
         );
     }
 }

--- a/codex-rs/hooks/src/events/permission_request.rs
+++ b/codex-rs/hooks/src/events/permission_request.rs
@@ -48,7 +48,7 @@ pub struct PermissionRequestRequest {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PermissionRequestDecision {
     Allow,
-    Deny { message: String },
+    Deny { message: String, interrupt: bool },
 }
 
 #[derive(Debug)]
@@ -155,9 +155,10 @@ fn resolve_permission_request_decision<'a>(
             PermissionRequestDecision::Allow => {
                 resolved_allow = Some(PermissionRequestDecision::Allow);
             }
-            PermissionRequestDecision::Deny { message } => {
+            PermissionRequestDecision::Deny { message, interrupt } => {
                 return Some(PermissionRequestDecision::Deny {
                     message: message.clone(),
+                    interrupt: *interrupt,
                 });
             }
         }
@@ -223,13 +224,17 @@ fn parse_completed(
                             output_parser::PermissionRequestDecision::Allow => {
                                 decision = Some(PermissionRequestDecision::Allow);
                             }
-                            output_parser::PermissionRequestDecision::Deny { message } => {
+                            output_parser::PermissionRequestDecision::Deny {
+                                message,
+                                interrupt,
+                            } => {
                                 status = HookRunStatus::Blocked;
                                 entries.push(HookOutputEntry {
                                     kind: HookOutputEntryKind::Feedback,
                                     text: message.clone(),
                                 });
-                                decision = Some(PermissionRequestDecision::Deny { message });
+                                decision =
+                                    Some(PermissionRequestDecision::Deny { message, interrupt });
                             }
                         }
                     }
@@ -248,7 +253,10 @@ fn parse_completed(
                         kind: HookOutputEntryKind::Feedback,
                         text: message.clone(),
                     });
-                    decision = Some(PermissionRequestDecision::Deny { message });
+                    decision = Some(PermissionRequestDecision::Deny {
+                        message,
+                        interrupt: false,
+                    });
                 } else {
                     status = HookRunStatus::Failed;
                     entries.push(HookOutputEntry {
@@ -298,6 +306,7 @@ mod tests {
             PermissionRequestDecision::Allow,
             PermissionRequestDecision::Deny {
                 message: "repo deny".to_string(),
+                interrupt: false,
             },
         ];
 
@@ -305,6 +314,7 @@ mod tests {
             resolve_permission_request_decision(decisions.iter()),
             Some(PermissionRequestDecision::Deny {
                 message: "repo deny".to_string(),
+                interrupt: false,
             })
         );
     }

--- a/codex-rs/hooks/src/schema.rs
+++ b/codex-rs/hooks/src/schema.rs
@@ -150,9 +150,8 @@ pub(crate) struct PermissionRequestDecisionWire {
     pub updated_permissions: Option<Value>,
     #[serde(default)]
     pub message: Option<String>,
-    /// Reserved for future short-circuiting semantics.
-    ///
-    /// PermissionRequest hooks currently fail closed if this field is `true`.
+    /// When `true`, a deny decision interrupts the current turn after the hook
+    /// feedback is recorded.
     #[serde(default)]
     pub interrupt: bool,
 }


### PR DESCRIPTION
## Summary
- allow `PermissionRequest` hook handlers to return `decision.interrupt: true` when denying a request
- route interrupting denies through the existing interrupted-turn lifecycle so the agent loop stops with `TurnAbortReason::Interrupted`
- add end-to-end coverage for an interrupting `shell_command` denial and update the generated hook schema fixture

## Why
This extends the permission-request hook contract so a deny can optionally behave like an Esc interrupt instead of only surfacing as a normal approval rejection.

## Implementation
- parse and carry `interrupt` only for deny decisions in the hooks crate
- map interrupting denies to `session.interrupt_task()` in the core approval paths
- treat interrupted in-flight tool futures as normal turn aborts during drain

## Validation
- `cargo test -p codex-hooks`
- `cargo test -p codex-core --test all permission_request_hook_interrupts_shell_command_turn`
- `cargo test -p codex-core`

## Notes
- This PR is stacked on `codex/permission-request-hooks-base` (#17563).
- The local `cargo test -p codex-core` run still reported two unrelated failures in this environment:
  - `plugins::manager::tests::list_marketplaces_ignores_installed_roots_missing_from_config`
  - `tools::js_repl::tests::js_repl_imported_local_files_can_access_repl_globals`
