### PR TITLE
Keep Local Bazel Cache Uploads Read Only By Default

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,5 @@
+try-import %workspace%/user.bazelrc
+
 common --repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 common --repo_env=BAZEL_NO_APPLE_CPP_TOOLCHAIN=1
 # Dummy xcode config so we don't need to build xcode_locator in repo rule.
@@ -38,6 +40,11 @@ common --test_output=errors
 common --bes_results_url=https://app.buildbuddy.io/invocation/
 common --bes_backend=grpcs://remote.buildbuddy.io
 common --remote_cache=grpcs://remote.buildbuddy.io
+# Per-user auth can be added in `user.bazelrc` without checking credentials
+# into the repo. For open-source-safe defaults, local builds stay read-only.
+# Keep local developers on shared cache reads, but avoid publishing
+# machine-specific local outputs into the shared cache by default.
+common --noremote_upload_local_results
 common --remote_download_toplevel
 common --nobuild_runfile_links
 common --remote_timeout=3600
@@ -53,6 +60,7 @@ common --jobs=30
 
 common:remote --extra_execution_platforms=//:rbe
 common:remote --remote_executor=grpcs://remote.buildbuddy.io
+common:remote --remote_upload_local_results
 common:remote --jobs=800
 # TODO(team): Evaluate if this actually helps, zbarsky is not sure, everything seems bottlenecked on `core` either way.
 # Enable pipelined compilation since we are not bound by local CPU count.

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ result
 CLAUDE.md
 .claude/
 AGENTS.override.md
+user.bazelrc
 
 # caches
 .cache/
@@ -91,4 +92,3 @@ CHANGELOG.ignore.md
 # Python bytecode files
 __pycache__/
 *.pyc
-


### PR DESCRIPTION
## Problem

We are debugging a cache correctness issue in Codex where a local Bazel run appears to have reused a machine specific artifact from another developer. The immediate concern is that local machines can populate the shared remote cache by default.

Example Buildbudy link - https://app.buildbuddy.io/invocation/3d930d29-16ad-4d05-8eee-4c8198fcb78a

Locally building codex failed with this error for another user other than neil@:

`bazel   run //codex-rs/cli:codex
cxxbridge error: Failed to create directory /Users/neil/Library/Caches/bazel/_bazel_neil/ab4e3ea67871de3405481bb5c0f62f4f/sandbox/darwin-sandbox/1921/execroot/_main/bazel-out/darwin_arm64-opt-exec/bin/external/rules_rs++crate+crates__scra`

## Root Cause

1. `.bazelrc` points local builds at the shared BuildBuddy cache.
2. Before this change, local builds also uploaded local action results by default.
3. BuildBuddy side permissions may still matter, but the checked in repo config currently permits the local write path.

## Fix

1. Add `try-import %workspace%/user.bazelrc` so per user auth can live outside the repo.
2. Disable local cache uploads by default in the checked in `.bazelrc`.
3. Re enable uploads only for the `remote` config so CI and remote exec remain cache writers.
4. Ignore `user.bazelrc` in git.

## Validation

1. Inspected Bazel flag behavior for `remote_upload_local_results`.
2. Verified the staged diff is scoped to `.bazelrc` and `.gitignore`.
3. No full Bazel build was run locally because this is a checked in config only change.

## Follow Up

1. BuildBuddy side enforcement should still restrict writer permissions by key, role, or partition across machines.
