### PR TITLE
Support PermissionRequest updatedPermissions (addRules type)

### DIFF
--- a/codex-rs/core/src/config_loader/mod.rs
+++ b/codex-rs/core/src/config_loader/mod.rs
@@ -741,7 +741,7 @@ fn copy_shape_from_original(original: &TomlValue, resolved: &TomlValue) -> TomlV
     }
 }
 
-async fn find_project_root(
+pub(crate) async fn find_project_root(
     cwd: &AbsolutePathBuf,
     project_root_markers: &[String],
 ) -> io::Result<AbsolutePathBuf> {

--- a/codex-rs/core/src/config_loader/mod.rs
+++ b/codex-rs/core/src/config_loader/mod.rs
@@ -25,6 +25,7 @@ use std::path::Path;
 #[cfg(windows)]
 use std::path::PathBuf;
 use toml::Value as TomlValue;
+use tracing::warn;
 
 pub use codex_config::AppRequirementToml;
 pub use codex_config::AppsRequirementsToml;
@@ -758,6 +759,31 @@ pub(crate) async fn find_project_root(
         }
     }
     Ok(cwd.clone())
+}
+
+pub(crate) async fn resolve_project_root(
+    config_layer_stack: &ConfigLayerStack,
+    cwd: &AbsolutePathBuf,
+) -> io::Result<AbsolutePathBuf> {
+    let mut merged = TomlValue::Table(toml::map::Map::new());
+    for layer in config_layer_stack.get_layers(
+        ConfigLayerStackOrdering::LowestPrecedenceFirst,
+        /*include_disabled*/ false,
+    ) {
+        if matches!(layer.name, ConfigLayerSource::Project { .. }) {
+            continue;
+        }
+        merge_toml_values(&mut merged, &layer.config);
+    }
+    let project_root_markers = match project_root_markers_from_config(&merged) {
+        Ok(Some(markers)) => markers,
+        Ok(None) => default_project_root_markers(),
+        Err(err) => {
+            warn!("invalid project_root_markers: {err}");
+            default_project_root_markers()
+        }
+    };
+    find_project_root(cwd, &project_root_markers).await
 }
 
 /// Return the appropriate list of layers (each with

--- a/codex-rs/core/src/config_loader/mod.rs
+++ b/codex-rs/core/src/config_loader/mod.rs
@@ -742,7 +742,7 @@ fn copy_shape_from_original(original: &TomlValue, resolved: &TomlValue) -> TomlV
     }
 }
 
-pub(crate) async fn find_project_root(
+async fn find_project_root(
     cwd: &AbsolutePathBuf,
     project_root_markers: &[String],
 ) -> io::Result<AbsolutePathBuf> {

--- a/codex-rs/core/src/exec_policy.rs
+++ b/codex-rs/core/src/exec_policy.rs
@@ -328,6 +328,21 @@ impl ExecPolicyManager {
             source,
         })?;
 
+        self.update_current_policy_if_needed(amendment)
+    }
+
+    pub(crate) async fn add_amendment_to_current_policy(
+        &self,
+        amendment: &ExecPolicyAmendment,
+    ) -> Result<(), ExecPolicyUpdateError> {
+        let _update_guard = self.update_lock.lock().await;
+        self.update_current_policy_if_needed(amendment)
+    }
+
+    fn update_current_policy_if_needed(
+        &self,
+        amendment: &ExecPolicyAmendment,
+    ) -> Result<(), ExecPolicyUpdateError> {
         let current_policy = self.current();
         let match_options = MatchOptions {
             resolve_host_executables: true,

--- a/codex-rs/core/src/hook_runtime.rs
+++ b/codex-rs/core/src/hook_runtime.rs
@@ -1,9 +1,14 @@
 use std::future::Future;
 use std::sync::Arc;
 
+use codex_app_server_protocol::ConfigLayerSource;
 use codex_hooks::PermissionRequestDecision;
 use codex_hooks::PermissionRequestOutcome;
 use codex_hooks::PermissionRequestRequest;
+use codex_hooks::PermissionSuggestion;
+use codex_hooks::PermissionSuggestionDestination;
+use codex_hooks::PermissionSuggestionRule;
+use codex_hooks::PermissionSuggestionType;
 use codex_hooks::PostToolUseOutcome;
 use codex_hooks::PostToolUseRequest;
 use codex_hooks::PreToolUseOutcome;
@@ -11,20 +16,31 @@ use codex_hooks::PreToolUseRequest;
 use codex_hooks::SessionStartOutcome;
 use codex_hooks::UserPromptSubmitOutcome;
 use codex_hooks::UserPromptSubmitRequest;
+use codex_protocol::approvals::ExecPolicyAmendment;
 use codex_protocol::items::TurnItem;
 use codex_protocol::models::DeveloperInstructions;
 use codex_protocol::models::ResponseInputItem;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::protocol::AskForApproval;
+use codex_protocol::protocol::Event;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::HookCompletedEvent;
 use codex_protocol::protocol::HookRunSummary;
 use codex_protocol::protocol::HookStartedEvent;
+use codex_protocol::protocol::WarningEvent;
 use codex_protocol::user_input::UserInput;
 use serde_json::Value;
+use toml::Value as TomlValue;
+use tracing::warn;
 
 use crate::codex::Session;
 use crate::codex::TurnContext;
+use crate::config::Config;
+use crate::config_loader::ConfigLayerStackOrdering;
+use crate::config_loader::default_project_root_markers;
+use crate::config_loader::find_project_root;
+use crate::config_loader::merge_toml_values;
+use crate::config_loader::project_root_markers_from_config;
 use crate::event_mapping::parse_turn_item;
 use crate::tools::sandboxing::PermissionRequestPayload;
 
@@ -180,7 +196,121 @@ pub(crate) async fn run_permission_request_hooks(
     } = sess.hooks().run_permission_request(request).await;
     emit_hook_completed_events(sess, turn_context, hook_events).await;
 
+    if let Some(PermissionRequestDecision::Allow {
+        updated_permissions,
+    }) = &decision
+    {
+        apply_permission_updates_from_hook(sess, turn_context, updated_permissions).await;
+    }
+
     decision
+}
+
+async fn apply_permission_updates_from_hook(
+    sess: &Arc<Session>,
+    turn_context: &Arc<TurnContext>,
+    updated_permissions: &[PermissionSuggestion],
+) {
+    for permission in updated_permissions {
+        if let Err(err) = apply_permission_update_from_hook(sess, turn_context, permission).await {
+            let message =
+                format!("PermissionRequest hook failed to apply updated permission: {err}");
+            warn!("{message}");
+            sess.send_event_raw(Event {
+                id: turn_context.sub_id.clone(),
+                msg: EventMsg::Warning(WarningEvent { message }),
+            })
+            .await;
+        }
+    }
+}
+
+async fn apply_permission_update_from_hook(
+    sess: &Arc<Session>,
+    turn_context: &Arc<TurnContext>,
+    permission: &PermissionSuggestion,
+) -> Result<(), String> {
+    match permission.suggestion_type {
+        PermissionSuggestionType::AddRules => {
+            for rule in &permission.rules {
+                match rule {
+                    PermissionSuggestionRule::PrefixRule { command } => {
+                        let amendment = ExecPolicyAmendment::new(command.clone());
+                        apply_execpolicy_amendment_destination(
+                            sess,
+                            turn_context,
+                            &permission.destination,
+                            &amendment,
+                        )
+                        .await?;
+                    }
+                }
+            }
+            Ok(())
+        }
+    }
+}
+
+async fn apply_execpolicy_amendment_destination(
+    sess: &Arc<Session>,
+    turn_context: &Arc<TurnContext>,
+    destination: &PermissionSuggestionDestination,
+    amendment: &ExecPolicyAmendment,
+) -> Result<(), String> {
+    match destination {
+        PermissionSuggestionDestination::Session => sess
+            .services
+            .exec_policy
+            .add_amendment_to_current_policy(amendment)
+            .await
+            .map_err(|err| format!("failed to cache session prefix rule: {err}")),
+        PermissionSuggestionDestination::UserSettings => {
+            let codex_home = sess.codex_home().await;
+            sess.services
+                .exec_policy
+                .append_amendment_and_update(&codex_home, amendment)
+                .await
+                .map_err(|err| format!("failed to persist user prefix rule: {err}"))
+        }
+        PermissionSuggestionDestination::ProjectSettings => {
+            let project_codex_home = project_codex_home(turn_context.config.as_ref())
+                .await
+                .map_err(|err| format!("failed to resolve project root for rules file: {err}"))?;
+            tokio::fs::create_dir_all(project_codex_home.join("rules"))
+                .await
+                .map_err(|err| format!("failed to create project rules directory: {err}"))?;
+            sess.services
+                .exec_policy
+                .append_amendment_and_update(&project_codex_home, amendment)
+                .await
+                .map_err(|err| format!("failed to persist project prefix rule: {err}"))
+        }
+    }
+}
+
+async fn project_codex_home(config: &Config) -> std::io::Result<std::path::PathBuf> {
+    let mut merged = TomlValue::Table(toml::map::Map::new());
+    for layer in config.config_layer_stack.get_layers(
+        ConfigLayerStackOrdering::LowestPrecedenceFirst,
+        /*include_disabled*/ false,
+    ) {
+        if matches!(layer.name, ConfigLayerSource::Project { .. }) {
+            continue;
+        }
+        merge_toml_values(&mut merged, &layer.config);
+    }
+    let project_root_markers = match project_root_markers_from_config(&merged) {
+        Ok(Some(markers)) => markers,
+        Ok(None) => default_project_root_markers(),
+        Err(err) => {
+            warn!("invalid project_root_markers: {err}");
+            default_project_root_markers()
+        }
+    };
+    Ok(find_project_root(&config.cwd, &project_root_markers)
+        .await?
+        .join(".codex")
+        .to_path_buf())
 }
 
 pub(crate) async fn run_post_tool_use_hooks(

--- a/codex-rs/core/src/hook_runtime.rs
+++ b/codex-rs/core/src/hook_runtime.rs
@@ -33,7 +33,6 @@ use tracing::warn;
 
 use crate::codex::Session;
 use crate::codex::TurnContext;
-use crate::config::Config;
 use crate::config_loader::resolve_project_root;
 use crate::event_mapping::parse_turn_item;
 use crate::tools::sandboxing::PermissionRequestPayload;
@@ -267,9 +266,12 @@ async fn apply_execpolicy_amendment_destination(
                 .map_err(|err| format!("failed to persist user prefix rule: {err}"))
         }
         PermissionSuggestionDestination::ProjectSettings => {
-            let project_codex_home = project_codex_home(turn_context.config.as_ref())
+            let config = turn_context.config.as_ref();
+            let project_codex_home = resolve_project_root(&config.config_layer_stack, &config.cwd)
                 .await
-                .map_err(|err| format!("failed to resolve project root for rules file: {err}"))?;
+                .map_err(|err| format!("failed to resolve project root for rules file: {err}"))?
+                .join(".codex")
+                .to_path_buf();
             tokio::fs::create_dir_all(project_codex_home.join("rules"))
                 .await
                 .map_err(|err| format!("failed to create project rules directory: {err}"))?;
@@ -280,15 +282,6 @@ async fn apply_execpolicy_amendment_destination(
                 .map_err(|err| format!("failed to persist project prefix rule: {err}"))
         }
     }
-}
-
-async fn project_codex_home(config: &Config) -> std::io::Result<std::path::PathBuf> {
-    Ok(
-        resolve_project_root(&config.config_layer_stack, &config.cwd)
-            .await?
-            .join(".codex")
-            .to_path_buf(),
-    )
 }
 
 pub(crate) async fn run_post_tool_use_hooks(

--- a/codex-rs/core/src/hook_runtime.rs
+++ b/codex-rs/core/src/hook_runtime.rs
@@ -1,7 +1,6 @@
 use std::future::Future;
 use std::sync::Arc;
 
-use codex_app_server_protocol::ConfigLayerSource;
 use codex_hooks::PermissionRequestDecision;
 use codex_hooks::PermissionRequestOutcome;
 use codex_hooks::PermissionRequestRequest;
@@ -30,17 +29,12 @@ use codex_protocol::protocol::HookStartedEvent;
 use codex_protocol::protocol::WarningEvent;
 use codex_protocol::user_input::UserInput;
 use serde_json::Value;
-use toml::Value as TomlValue;
 use tracing::warn;
 
 use crate::codex::Session;
 use crate::codex::TurnContext;
 use crate::config::Config;
-use crate::config_loader::ConfigLayerStackOrdering;
-use crate::config_loader::default_project_root_markers;
-use crate::config_loader::find_project_root;
-use crate::config_loader::merge_toml_values;
-use crate::config_loader::project_root_markers_from_config;
+use crate::config_loader::resolve_project_root;
 use crate::event_mapping::parse_turn_item;
 use crate::tools::sandboxing::PermissionRequestPayload;
 
@@ -289,28 +283,12 @@ async fn apply_execpolicy_amendment_destination(
 }
 
 async fn project_codex_home(config: &Config) -> std::io::Result<std::path::PathBuf> {
-    let mut merged = TomlValue::Table(toml::map::Map::new());
-    for layer in config.config_layer_stack.get_layers(
-        ConfigLayerStackOrdering::LowestPrecedenceFirst,
-        /*include_disabled*/ false,
-    ) {
-        if matches!(layer.name, ConfigLayerSource::Project { .. }) {
-            continue;
-        }
-        merge_toml_values(&mut merged, &layer.config);
-    }
-    let project_root_markers = match project_root_markers_from_config(&merged) {
-        Ok(Some(markers)) => markers,
-        Ok(None) => default_project_root_markers(),
-        Err(err) => {
-            warn!("invalid project_root_markers: {err}");
-            default_project_root_markers()
-        }
-    };
-    Ok(find_project_root(&config.cwd, &project_root_markers)
-        .await?
-        .join(".codex")
-        .to_path_buf())
+    Ok(
+        resolve_project_root(&config.config_layer_stack, &config.cwd)
+            .await?
+            .join(".codex")
+            .to_path_buf(),
+    )
 }
 
 pub(crate) async fn run_post_tool_use_hooks(

--- a/codex-rs/core/src/project_doc.rs
+++ b/codex-rs/core/src/project_doc.rs
@@ -16,18 +16,13 @@
 //! 3.  We do **not** walk past the project root.
 
 use crate::config::Config;
-use crate::config_loader::ConfigLayerStackOrdering;
-use crate::config_loader::default_project_root_markers;
-use crate::config_loader::merge_toml_values;
-use crate::config_loader::project_root_markers_from_config;
-use codex_app_server_protocol::ConfigLayerSource;
+use crate::config_loader::resolve_project_root;
 use codex_exec_server::Environment;
 use codex_exec_server::ExecutorFileSystem;
 use codex_features::Feature;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use dunce::canonicalize as normalize_path;
 use std::io;
-use toml::Value as TomlValue;
 use tracing::error;
 
 pub(crate) const HIERARCHICAL_AGENTS_MESSAGE: &str =
@@ -226,51 +221,14 @@ pub async fn discover_project_doc_paths(
         dir = AbsolutePathBuf::try_from(canon)?;
     }
 
-    let mut merged = TomlValue::Table(toml::map::Map::new());
-    for layer in config.config_layer_stack.get_layers(
-        ConfigLayerStackOrdering::LowestPrecedenceFirst,
-        /*include_disabled*/ false,
-    ) {
-        if matches!(layer.name, ConfigLayerSource::Project { .. }) {
-            continue;
-        }
-        merge_toml_values(&mut merged, &layer.config);
-    }
-    let project_root_markers = match project_root_markers_from_config(&merged) {
-        Ok(Some(markers)) => markers,
-        Ok(None) => default_project_root_markers(),
-        Err(err) => {
-            tracing::warn!("invalid project_root_markers: {err}");
-            default_project_root_markers()
-        }
-    };
-    let mut project_root = None;
-    if !project_root_markers.is_empty() {
-        for ancestor in dir.ancestors() {
-            for marker in &project_root_markers {
-                let marker_path = AbsolutePathBuf::try_from(ancestor.join(marker))?;
-                let marker_exists = match fs.get_metadata(&marker_path).await {
-                    Ok(_) => true,
-                    Err(err) if err.kind() == io::ErrorKind::NotFound => false,
-                    Err(err) => return Err(err),
-                };
-                if marker_exists {
-                    project_root = Some(AbsolutePathBuf::try_from(ancestor.to_path_buf())?);
-                    break;
-                }
-            }
-            if project_root.is_some() {
-                break;
-            }
-        }
-    }
+    let project_root = resolve_project_root(&config.config_layer_stack, &dir).await?;
 
-    let search_dirs: Vec<AbsolutePathBuf> = if let Some(root) = project_root {
+    let search_dirs: Vec<AbsolutePathBuf> = if project_root != dir {
         let mut dirs = Vec::new();
         let mut cursor = dir.clone();
         loop {
             dirs.push(cursor.clone());
-            if cursor == root {
+            if cursor == project_root {
                 break;
             }
             let Some(parent) = cursor.parent() else {

--- a/codex-rs/core/src/tools/network_approval.rs
+++ b/codex-rs/core/src/tools/network_approval.rs
@@ -395,7 +395,7 @@ impl NetworkApprovalService {
         .await
         {
             match permission_request_decision {
-                PermissionRequestDecision::Allow => {
+                PermissionRequestDecision::Allow { .. } => {
                     pending
                         .set_decision(PendingApprovalDecision::AllowOnce)
                         .await;

--- a/codex-rs/core/src/tools/orchestrator.rs
+++ b/codex-rs/core/src/tools/orchestrator.rs
@@ -377,7 +377,7 @@ impl ToolOrchestrator {
             )
             .await
             {
-                Some(PermissionRequestDecision::Allow) => {
+                Some(PermissionRequestDecision::Allow { .. }) => {
                     telemetry.otel.tool_decision(
                         telemetry.tool_name,
                         telemetry.call_id,

--- a/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
+++ b/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
@@ -414,7 +414,7 @@ impl CoreShellActionProvider {
                 )
                 .await
                 {
-                    Some(PermissionRequestDecision::Allow) => {
+                    Some(PermissionRequestDecision::Allow { .. }) => {
                         return PromptDecision {
                             decision: ReviewDecision::Approved,
                             guardian_review_id: None,

--- a/codex-rs/core/tests/suite/hooks.rs
+++ b/codex-rs/core/tests/suite/hooks.rs
@@ -284,6 +284,66 @@ if mode == "allow":
             "decision": {{"behavior": "allow"}}
         }}
     }}))
+elif mode == "allow_selected_session":
+    print(json.dumps({{
+        "hookSpecificOutput": {{
+            "hookEventName": "PermissionRequest",
+            "decision": {{
+                "behavior": "allow",
+                "updatedPermissions": [
+                    suggestion
+                    for suggestion in payload.get("permission_suggestions", [])
+                    if suggestion.get("destination") == "session"
+                ]
+            }}
+        }}
+    }}))
+elif mode == "allow_selected_project":
+    print(json.dumps({{
+        "hookSpecificOutput": {{
+            "hookEventName": "PermissionRequest",
+            "decision": {{
+                "behavior": "allow",
+                "updatedPermissions": [
+                    suggestion
+                    for suggestion in payload.get("permission_suggestions", [])
+                    if suggestion.get("destination") == "projectSettings"
+                ]
+            }}
+        }}
+    }}))
+elif mode == "allow_selected_user":
+    print(json.dumps({{
+        "hookSpecificOutput": {{
+            "hookEventName": "PermissionRequest",
+            "decision": {{
+                "behavior": "allow",
+                "updatedPermissions": [
+                    suggestion
+                    for suggestion in payload.get("permission_suggestions", [])
+                    if suggestion.get("destination") == "userSettings"
+                ]
+            }}
+        }}
+    }}))
+elif mode == "allow_unoffered_permission":
+    print(json.dumps({{
+        "hookSpecificOutput": {{
+            "hookEventName": "PermissionRequest",
+            "decision": {{
+                "behavior": "allow",
+                "updatedPermissions": [{{
+                    "type": "addRules",
+                    "rules": [{{
+                        "type": "prefixRule",
+                        "command": ["curl"]
+                    }}],
+                    "behavior": "allow",
+                    "destination": "userSettings"
+                }}]
+            }}
+        }}
+    }}))
 elif mode == "deny":
     print(json.dumps({{
         "hookSpecificOutput": {{
@@ -1335,6 +1395,136 @@ async fn permission_request_hook_sees_raw_exec_command_input() -> Result<()> {
                 "destination": "userSettings",
             }
         ]),
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn permission_request_hook_persists_selected_user_exec_rule() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let call_id_first = "permissionrequest-exec-rule-first";
+    let call_id_second = "permissionrequest-exec-rule-second";
+    let marker = std::env::temp_dir().join("permissionrequest-exec-rule-marker");
+    let command = format!("rm -f {}", marker.display());
+    let justification = "remove the temporary marker";
+    let args = serde_json::json!({
+        "cmd": command,
+        "login": true,
+        "sandbox_permissions": "require_escalated",
+        "justification": justification,
+    });
+    let responses = mount_sse_sequence(
+        &server,
+        vec![
+            sse(vec![
+                ev_response_created("resp-1"),
+                core_test_support::responses::ev_function_call(
+                    call_id_first,
+                    "exec_command",
+                    &serde_json::to_string(&args)?,
+                ),
+                ev_completed("resp-1"),
+            ]),
+            sse(vec![
+                ev_response_created("resp-2"),
+                ev_assistant_message("msg-1", "permission request hook persisted the exec rule"),
+                ev_completed("resp-2"),
+            ]),
+            sse(vec![
+                ev_response_created("resp-3"),
+                core_test_support::responses::ev_function_call(
+                    call_id_second,
+                    "exec_command",
+                    &serde_json::to_string(&args)?,
+                ),
+                ev_completed("resp-3"),
+            ]),
+            sse(vec![
+                ev_response_created("resp-4"),
+                ev_assistant_message("msg-2", "the persisted exec rule was reused"),
+                ev_completed("resp-4"),
+            ]),
+        ],
+    )
+    .await;
+
+    let mut builder = test_codex()
+        .with_pre_build_hook(|home| {
+            if let Err(error) = write_permission_request_hook(
+                home,
+                Some(PERMISSION_REQUEST_HOOK_MATCHER),
+                "allow_selected_user",
+                PERMISSION_REQUEST_ALLOW_REASON,
+            ) {
+                panic!("failed to write permission request hook test fixture: {error}");
+            }
+        })
+        .with_config(|config| {
+            config.use_experimental_unified_exec_tool = true;
+            config
+                .features
+                .enable(Feature::CodexHooks)
+                .expect("test config should allow feature update");
+            config
+                .features
+                .enable(Feature::UnifiedExec)
+                .expect("test config should allow feature update");
+        });
+    let test = builder.build(&server).await?;
+
+    fs::write(&marker, "seed").context("create exec command marker for first run")?;
+
+    test.submit_turn_with_policies(
+        "run the exec command and persist the suggested permission",
+        AskForApproval::OnRequest,
+        codex_protocol::protocol::SandboxPolicy::new_read_only_policy(),
+    )
+    .await?;
+
+    assert!(
+        !marker.exists(),
+        "first exec command should remove marker file"
+    );
+
+    fs::write(&marker, "seed").context("create exec command marker for second run")?;
+
+    test.submit_turn_with_policies(
+        "run the exec command again with the persisted permission",
+        AskForApproval::OnRequest,
+        codex_protocol::protocol::SandboxPolicy::new_read_only_policy(),
+    )
+    .await?;
+
+    assert!(
+        !marker.exists(),
+        "second exec command should remove marker file"
+    );
+
+    let requests = responses.requests();
+    assert_eq!(requests.len(), 4);
+    requests[1].function_call_output(call_id_first);
+    requests[3].function_call_output(call_id_second);
+
+    let hook_inputs = read_permission_request_hook_inputs(test.codex_home_path())?;
+    assert_eq!(
+        hook_inputs.len(),
+        1,
+        "persisted exec rule should bypass the second permission hook"
+    );
+
+    let rules_path = test.codex_home_path().join("rules").join("default.rules");
+    let rules_contents = fs::read_to_string(&rules_path)
+        .with_context(|| format!("read {}", rules_path.display()))?;
+    let marker_json =
+        serde_json::to_string(&marker.display().to_string()).context("serialize marker path")?;
+    let expected_rule =
+        format!(r#"prefix_rule(pattern=["rm", "-f", {marker_json}], decision="allow")"#);
+    assert!(
+        rules_contents.contains(&expected_rule),
+        "expected {rules_path:?} to contain {expected_rule}, got:\n{rules_contents}"
     );
 
     Ok(())

--- a/codex-rs/hooks/schema/generated/permission-request.command.output.schema.json
+++ b/codex-rs/hooks/schema/generated/permission-request.command.output.schema.json
@@ -41,7 +41,10 @@
         },
         "updatedPermissions": {
           "default": null,
-          "description": "Reserved for a future permission-rewrite capability.\n\nPermissionRequest hooks currently fail closed if this field is present."
+          "items": {
+            "$ref": "#/definitions/PermissionSuggestion"
+          },
+          "type": "array"
         }
       },
       "required": [
@@ -68,6 +71,79 @@
         "hookEventName"
       ],
       "type": "object"
+    },
+    "PermissionSuggestion": {
+      "properties": {
+        "behavior": {
+          "$ref": "#/definitions/PermissionSuggestionBehavior"
+        },
+        "destination": {
+          "$ref": "#/definitions/PermissionSuggestionDestination"
+        },
+        "rules": {
+          "items": {
+            "$ref": "#/definitions/PermissionSuggestionRule"
+          },
+          "type": "array"
+        },
+        "type": {
+          "$ref": "#/definitions/PermissionSuggestionType"
+        }
+      },
+      "required": [
+        "behavior",
+        "destination",
+        "rules",
+        "type"
+      ],
+      "type": "object"
+    },
+    "PermissionSuggestionBehavior": {
+      "enum": [
+        "allow",
+        "deny",
+        "ask"
+      ],
+      "type": "string"
+    },
+    "PermissionSuggestionDestination": {
+      "enum": [
+        "session",
+        "projectSettings",
+        "userSettings"
+      ],
+      "type": "string"
+    },
+    "PermissionSuggestionRule": {
+      "oneOf": [
+        {
+          "properties": {
+            "command": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": {
+              "enum": [
+                "prefixRule"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "command",
+            "type"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "PermissionSuggestionType": {
+      "enum": [
+        "addRules"
+      ],
+      "type": "string"
     }
   },
   "properties": {

--- a/codex-rs/hooks/src/engine/output_parser.rs
+++ b/codex-rs/hooks/src/engine/output_parser.rs
@@ -21,8 +21,12 @@ pub(crate) struct PreToolUseOutput {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum PermissionRequestDecision {
-    Allow,
-    Deny { message: String },
+    Allow {
+        updated_permissions: Vec<crate::events::permission_request::PermissionSuggestion>,
+    },
+    Deny {
+        message: String,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -300,8 +304,10 @@ fn unsupported_permission_request_hook_specific_output(
     let decision = decision?;
     if decision.updated_input.is_some() {
         Some("PermissionRequest hook returned unsupported updatedInput".to_string())
-    } else if decision.updated_permissions.is_some() {
-        Some("PermissionRequest hook returned unsupported updatedPermissions".to_string())
+    } else if matches!(decision.behavior, PermissionRequestBehaviorWire::Deny)
+        && decision.updated_permissions.is_some()
+    {
+        Some("PermissionRequest hook returned updatedPermissions for deny decision".to_string())
     } else if decision.interrupt {
         Some("PermissionRequest hook returned unsupported interrupt:true".to_string())
     } else {
@@ -313,7 +319,9 @@ fn permission_request_decision(
     decision: &PermissionRequestDecisionWire,
 ) -> PermissionRequestDecision {
     match decision.behavior {
-        PermissionRequestBehaviorWire::Allow => PermissionRequestDecision::Allow,
+        PermissionRequestBehaviorWire::Allow => PermissionRequestDecision::Allow {
+            updated_permissions: decision.updated_permissions.clone().unwrap_or_default(),
+        },
         PermissionRequestBehaviorWire::Deny => PermissionRequestDecision::Deny {
             message: decision
                 .message
@@ -421,6 +429,7 @@ mod tests {
     use pretty_assertions::assert_eq;
     use serde_json::json;
 
+    use super::PermissionRequestDecision;
     use super::parse_permission_request;
 
     #[test]
@@ -447,7 +456,7 @@ mod tests {
     }
 
     #[test]
-    fn permission_request_rejects_reserved_updated_permissions_field() {
+    fn permission_request_accepts_updated_permissions_for_allow_decision() {
         let parsed = parse_permission_request(
             &json!({
                 "continue": true,
@@ -455,7 +464,59 @@ mod tests {
                     "hookEventName": "PermissionRequest",
                     "decision": {
                         "behavior": "allow",
-                        "updatedPermissions": {}
+                        "updatedPermissions": [{
+                            "type": "addRules",
+                            "rules": [{
+                                "type": "prefixRule",
+                                "command": ["rm", "-f"]
+                            }],
+                            "behavior": "allow",
+                            "destination": "userSettings"
+                        }]
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .expect("permission request hook output should parse");
+
+        assert_eq!(
+            parsed.decision,
+            Some(PermissionRequestDecision::Allow {
+                updated_permissions: vec![crate::events::permission_request::PermissionSuggestion {
+                    suggestion_type:
+                        crate::events::permission_request::PermissionSuggestionType::AddRules,
+                    rules: vec![
+                        crate::events::permission_request::PermissionSuggestionRule::PrefixRule {
+                            command: vec!["rm".to_string(), "-f".to_string()],
+                        },
+                    ],
+                    behavior:
+                        crate::events::permission_request::PermissionSuggestionBehavior::Allow,
+                    destination: crate::events::permission_request::PermissionSuggestionDestination::UserSettings,
+                }],
+            })
+        );
+    }
+
+    #[test]
+    fn permission_request_rejects_updated_permissions_for_deny_decision() {
+        let parsed = parse_permission_request(
+            &json!({
+                "continue": true,
+                "hookSpecificOutput": {
+                    "hookEventName": "PermissionRequest",
+                    "decision": {
+                        "behavior": "deny",
+                        "updatedPermissions": [{
+                            "type": "addRules",
+                            "rules": [{
+                                "type": "prefixRule",
+                                "command": ["rm", "-f"]
+                            }],
+                            "behavior": "allow",
+                            "destination": "userSettings"
+                        }]
                     }
                 }
             })
@@ -465,7 +526,9 @@ mod tests {
 
         assert_eq!(
             parsed.invalid_reason,
-            Some("PermissionRequest hook returned unsupported updatedPermissions".to_string())
+            Some(
+                "PermissionRequest hook returned updatedPermissions for deny decision".to_string()
+            )
         );
     }
 

--- a/codex-rs/hooks/src/events/permission_request.rs
+++ b/codex-rs/hooks/src/events/permission_request.rs
@@ -11,8 +11,9 @@
 //! 2. Execute every matching handler in precedence order.
 //! 3. Parse each handler into transcript-visible output plus an optional
 //!    decision.
-//! 4. Fold the decisions conservatively: any deny wins, otherwise the last
-//!    allow wins, otherwise there is no hook verdict.
+//! 4. Fold the decisions conservatively: any deny wins, otherwise allow if at
+//!    least one handler allowed the request, and accumulate the selected
+//!    permission updates, otherwise there is no hook verdict.
 use std::path::PathBuf;
 
 use super::common;
@@ -31,9 +32,10 @@ use codex_protocol::protocol::HookOutputEntryKind;
 use codex_protocol::protocol::HookRunStatus;
 use codex_protocol::protocol::HookRunSummary;
 use schemars::JsonSchema;
+use serde::Deserialize;
 use serde::Serialize;
 
-#[derive(Debug, Clone, Serialize, JsonSchema, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct PermissionSuggestion {
     #[serde(rename = "type")]
@@ -43,13 +45,13 @@ pub struct PermissionSuggestion {
     pub destination: PermissionSuggestionDestination,
 }
 
-#[derive(Debug, Clone, Serialize, JsonSchema, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum PermissionSuggestionType {
     AddRules,
 }
 
-#[derive(Debug, Clone, Serialize, JsonSchema, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum PermissionSuggestionBehavior {
     Allow,
@@ -57,7 +59,7 @@ pub enum PermissionSuggestionBehavior {
     Ask,
 }
 
-#[derive(Debug, Clone, Serialize, JsonSchema, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub enum PermissionSuggestionDestination {
     #[serde(rename = "session")]
     Session,
@@ -67,7 +69,7 @@ pub enum PermissionSuggestionDestination {
     UserSettings,
 }
 
-#[derive(Debug, Clone, Serialize, JsonSchema, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum PermissionSuggestionRule {
     PrefixRule { command: Vec<String> },
@@ -90,8 +92,12 @@ pub struct PermissionRequestRequest {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PermissionRequestDecision {
-    Allow,
-    Deny { message: String },
+    Allow {
+        updated_permissions: Vec<PermissionSuggestion>,
+    },
+    Deny {
+        message: String,
+    },
 }
 
 #[derive(Debug)]
@@ -157,7 +163,7 @@ pub(crate) async fn run(
         }
     };
 
-    let results = dispatcher::execute_handlers(
+    let mut results = dispatcher::execute_handlers(
         shell,
         matched,
         input_json,
@@ -167,8 +173,22 @@ pub(crate) async fn run(
     )
     .await;
 
-    // Preserve the most specific matching allow, but treat any deny as final so
-    // broader policy layers cannot accidentally overrule a more specific block.
+    for result in &mut results {
+        if let Some(invalid_reason) = invalid_permission_updates(
+            result.data.decision.as_ref(),
+            &request.permission_suggestions,
+        ) {
+            result.completed.run.status = HookRunStatus::Failed;
+            result.completed.run.entries.push(HookOutputEntry {
+                kind: HookOutputEntryKind::Error,
+                text: invalid_reason,
+            });
+            result.data.decision = None;
+        }
+    }
+
+    // Any deny wins immediately. Otherwise, accumulate the selected permission
+    // updates from matching allow decisions in precedence order.
     let decision = resolve_permission_request_decision(
         results
             .iter()
@@ -187,16 +207,24 @@ pub(crate) async fn run(
 }
 
 /// Resolve matching hook decisions conservatively: any deny wins immediately;
-/// otherwise keep the highest-precedence allow so more specific handlers
-/// override broader ones.
+/// otherwise allow if any handler allowed the request and accumulate the
+/// distinct selected permission updates in precedence order.
 fn resolve_permission_request_decision<'a>(
     decisions: impl IntoIterator<Item = &'a PermissionRequestDecision>,
 ) -> Option<PermissionRequestDecision> {
-    let mut resolved_allow = None;
+    let mut saw_allow = false;
+    let mut updated_permissions = Vec::new();
     for decision in decisions {
         match decision {
-            PermissionRequestDecision::Allow => {
-                resolved_allow = Some(PermissionRequestDecision::Allow);
+            PermissionRequestDecision::Allow {
+                updated_permissions: selected_permissions,
+            } => {
+                saw_allow = true;
+                for permission in selected_permissions {
+                    if !updated_permissions.contains(permission) {
+                        updated_permissions.push(permission.clone());
+                    }
+                }
             }
             PermissionRequestDecision::Deny { message } => {
                 return Some(PermissionRequestDecision::Deny {
@@ -205,7 +233,29 @@ fn resolve_permission_request_decision<'a>(
             }
         }
     }
-    resolved_allow
+    saw_allow.then_some(PermissionRequestDecision::Allow {
+        updated_permissions,
+    })
+}
+
+fn invalid_permission_updates(
+    decision: Option<&PermissionRequestDecision>,
+    offered_permissions: &[PermissionSuggestion],
+) -> Option<String> {
+    let PermissionRequestDecision::Allow {
+        updated_permissions,
+    } = decision?
+    else {
+        return None;
+    };
+    if updated_permissions
+        .iter()
+        .any(|permission| !offered_permissions.contains(permission))
+    {
+        Some("PermissionRequest hook returned updatedPermissions that were not offered".to_string())
+    } else {
+        None
+    }
 }
 
 fn build_command_input(request: &PermissionRequestRequest) -> PermissionRequestCommandInput {
@@ -265,8 +315,12 @@ fn parse_completed(
                         });
                     } else if let Some(parsed_decision) = parsed.decision {
                         match parsed_decision {
-                            output_parser::PermissionRequestDecision::Allow => {
-                                decision = Some(PermissionRequestDecision::Allow);
+                            output_parser::PermissionRequestDecision::Allow {
+                                updated_permissions,
+                            } => {
+                                decision = Some(PermissionRequestDecision::Allow {
+                                    updated_permissions,
+                                });
                             }
                             output_parser::PermissionRequestDecision::Deny { message } => {
                                 status = HookRunStatus::Blocked;
@@ -335,12 +389,20 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use super::PermissionRequestDecision;
+    use super::PermissionSuggestion;
+    use super::PermissionSuggestionBehavior;
+    use super::PermissionSuggestionDestination;
+    use super::PermissionSuggestionRule;
+    use super::PermissionSuggestionType;
+    use super::invalid_permission_updates;
     use super::resolve_permission_request_decision;
 
     #[test]
     fn permission_request_deny_overrides_earlier_allow() {
         let decisions = [
-            PermissionRequestDecision::Allow,
+            PermissionRequestDecision::Allow {
+                updated_permissions: vec![],
+            },
             PermissionRequestDecision::Deny {
                 message: "repo deny".to_string(),
             },
@@ -357,13 +419,19 @@ mod tests {
     #[test]
     fn permission_request_returns_allow_when_no_handler_denies() {
         let decisions = [
-            PermissionRequestDecision::Allow,
-            PermissionRequestDecision::Allow,
+            PermissionRequestDecision::Allow {
+                updated_permissions: vec![],
+            },
+            PermissionRequestDecision::Allow {
+                updated_permissions: vec![],
+            },
         ];
 
         assert_eq!(
             resolve_permission_request_decision(decisions.iter()),
-            Some(PermissionRequestDecision::Allow)
+            Some(PermissionRequestDecision::Allow {
+                updated_permissions: vec![],
+            })
         );
     }
 
@@ -372,5 +440,62 @@ mod tests {
         let decisions = Vec::<PermissionRequestDecision>::new();
 
         assert_eq!(resolve_permission_request_decision(decisions.iter()), None);
+    }
+
+    #[test]
+    fn permission_request_accumulates_distinct_updated_permissions() {
+        let permission = PermissionSuggestion {
+            suggestion_type: PermissionSuggestionType::AddRules,
+            rules: vec![PermissionSuggestionRule::PrefixRule {
+                command: vec!["rm".to_string(), "-f".to_string()],
+            }],
+            behavior: PermissionSuggestionBehavior::Allow,
+            destination: PermissionSuggestionDestination::UserSettings,
+        };
+        let decisions = [
+            PermissionRequestDecision::Allow {
+                updated_permissions: vec![permission.clone()],
+            },
+            PermissionRequestDecision::Allow {
+                updated_permissions: vec![permission.clone()],
+            },
+        ];
+
+        assert_eq!(
+            resolve_permission_request_decision(decisions.iter()),
+            Some(PermissionRequestDecision::Allow {
+                updated_permissions: vec![permission],
+            })
+        );
+    }
+
+    #[test]
+    fn permission_request_rejects_unoffered_updated_permissions() {
+        let offered = vec![PermissionSuggestion {
+            suggestion_type: PermissionSuggestionType::AddRules,
+            rules: vec![PermissionSuggestionRule::PrefixRule {
+                command: vec!["rm".to_string()],
+            }],
+            behavior: PermissionSuggestionBehavior::Allow,
+            destination: PermissionSuggestionDestination::UserSettings,
+        }];
+        let selected = PermissionRequestDecision::Allow {
+            updated_permissions: vec![PermissionSuggestion {
+                suggestion_type: PermissionSuggestionType::AddRules,
+                rules: vec![PermissionSuggestionRule::PrefixRule {
+                    command: vec!["curl".to_string()],
+                }],
+                behavior: PermissionSuggestionBehavior::Allow,
+                destination: PermissionSuggestionDestination::UserSettings,
+            }],
+        };
+
+        assert_eq!(
+            invalid_permission_updates(Some(&selected), &offered),
+            Some(
+                "PermissionRequest hook returned updatedPermissions that were not offered"
+                    .to_string()
+            )
+        );
     }
 }

--- a/codex-rs/hooks/src/schema.rs
+++ b/codex-rs/hooks/src/schema.rs
@@ -145,11 +145,8 @@ pub(crate) struct PermissionRequestDecisionWire {
     /// PermissionRequest hooks currently fail closed if this field is present.
     #[serde(default)]
     pub updated_input: Option<Value>,
-    /// Reserved for a future permission-rewrite capability.
-    ///
-    /// PermissionRequest hooks currently fail closed if this field is present.
     #[serde(default)]
-    pub updated_permissions: Option<Value>,
+    pub updated_permissions: Option<Vec<PermissionSuggestion>>,
     #[serde(default)]
     pub message: Option<String>,
     /// Reserved for future short-circuiting semantics.


### PR DESCRIPTION
## What
- allow `PermissionRequest` hooks to return `decision.updatedPermissions` when `behavior` is `allow`
- validate that returned updates are an exact subset of the offered `permission_suggestions`
- apply selected `addRules` exec-policy suggestions to session memory or persisted rules state
- add schema/parser/runtime coverage and an end-to-end test for the persisted exec-rule path

## Why
- the previous PR only exposed permission suggestions to hooks
- this follow-up lets hooks actually accept and apply those suggestions so they can auto-approve exec requests by selecting the offered rule updates
- this keeps the first implementation narrow to `addRules`, which matches the current rules-file support

## Follow-up
- replaceRules and removeRules