### PR TITLE
Support PermissionRequest hook deny interrupts

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -4436,6 +4436,13 @@ impl Session {
         }
     }
 
+    pub(crate) fn interrupt_task_detached(self: &Arc<Self>) {
+        let session = Arc::clone(self);
+        tokio::spawn(async move {
+            session.interrupt_task().await;
+        });
+    }
+
     pub(crate) fn hooks(&self) -> &Hooks {
         &self.services.hooks
     }
@@ -7533,6 +7540,7 @@ async fn drain_in_flight(
                 sess.record_conversation_items(&turn_context, &[response_input.into()])
                     .await;
             }
+            Err(CodexErr::TurnAborted) => {}
             Err(err) => {
                 error_or_panic(format!("in-flight tool future failed during drain: {err}"));
             }

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -4436,13 +4436,6 @@ impl Session {
         }
     }
 
-    pub(crate) fn interrupt_task_detached(self: &Arc<Self>) {
-        let session = Arc::clone(self);
-        tokio::spawn(async move {
-            session.interrupt_task().await;
-        });
-    }
-
     pub(crate) fn hooks(&self) -> &Hooks {
         &self.services.hooks
     }

--- a/codex-rs/core/src/function_tool.rs
+++ b/codex-rs/core/src/function_tool.rs
@@ -2,6 +2,8 @@ use thiserror::Error;
 
 #[derive(Debug, Error, PartialEq)]
 pub enum FunctionCallError {
+    #[error("turn interrupted")]
+    Interrupted,
     #[error("{0}")]
     RespondToModel(String),
     #[error("LocalShellCall without call_id or id")]

--- a/codex-rs/core/src/state/turn.rs
+++ b/codex-rs/core/src/state/turn.rs
@@ -83,9 +83,8 @@ impl ActiveTurn {
         self.tasks.insert(sub_id, task);
     }
 
-    pub(crate) fn remove_task(&mut self, sub_id: &str) -> bool {
-        self.tasks.swap_remove(sub_id);
-        self.tasks.is_empty()
+    pub(crate) fn take_task(&mut self, sub_id: &str) -> Option<RunningTask> {
+        self.tasks.swap_remove(sub_id)
     }
 
     pub(crate) fn drain_tasks(&mut self) -> Vec<RunningTask> {

--- a/codex-rs/core/src/stream_events_utils.rs
+++ b/codex-rs/core/src/stream_events_utils.rs
@@ -321,6 +321,9 @@ pub(crate) async fn handle_output_item_done(
 
             output.needs_follow_up = true;
         }
+        Err(FunctionCallError::Interrupted) => {
+            return Err(CodexErr::TurnAborted);
+        }
         // A fatal error occurred; surface it back into history.
         Err(FunctionCallError::Fatal(message)) => {
             return Err(CodexErr::Fatal(message));

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -396,6 +396,30 @@ impl Session {
         }
     }
 
+    pub(crate) async fn abort_turn(self: &Arc<Self>, sub_id: &str, reason: TurnAbortReason) {
+        let (task, active_turn) = {
+            let mut active = self.active_turn.lock().await;
+            let Some(task) = active.as_mut().and_then(|turn| turn.take_task(sub_id)) else {
+                return;
+            };
+            let active_turn = if active.as_ref().is_some_and(|turn| turn.tasks.is_empty()) {
+                active.take()
+            } else {
+                None
+            };
+            (task, active_turn)
+        };
+
+        self.handle_task_abort(task, reason.clone()).await;
+
+        if let Some(active_turn) = active_turn {
+            active_turn.clear_pending().await;
+            if reason == TurnAbortReason::Interrupted {
+                self.maybe_start_turn_for_pending_work().await;
+            }
+        }
+    }
+
     pub async fn on_task_finished(
         self: &Arc<Self>,
         turn_context: Arc<TurnContext>,
@@ -411,15 +435,18 @@ impl Session {
         let mut turn_tool_calls = 0_u64;
         let turn_state = {
             let mut active = self.active_turn.lock().await;
-            if let Some(at) = active.as_mut()
-                && at.remove_task(&turn_context.sub_id)
-            {
-                should_clear_active_turn = true;
-                let turn_state = Arc::clone(&at.turn_state);
-                if should_clear_active_turn {
-                    *active = None;
+            if let Some(at) = active.as_mut() {
+                let removed = at.take_task(&turn_context.sub_id);
+                if removed.is_some() {
+                    should_clear_active_turn = at.tasks.is_empty();
+                    let turn_state = Arc::clone(&at.turn_state);
+                    if should_clear_active_turn {
+                        *active = None;
+                    }
+                    Some(turn_state)
+                } else {
+                    None
                 }
-                Some(turn_state)
             } else {
                 None
             }

--- a/codex-rs/core/src/tools/events.rs
+++ b/codex-rs/core/src/tools/events.rs
@@ -357,6 +357,9 @@ impl ToolEmitter {
                 let result = Err(FunctionCallError::RespondToModel(normalized));
                 (event, result)
             }
+            Err(ToolError::Interrupted) => {
+                return Err(FunctionCallError::Interrupted);
+            }
         };
         self.emit(ctx, event).await;
         result

--- a/codex-rs/core/src/tools/network_approval.rs
+++ b/codex-rs/core/src/tools/network_approval.rs
@@ -416,7 +416,12 @@ impl NetworkApprovalService {
                         .await;
                     }
                     if interrupt {
-                        session.interrupt_task_detached();
+                        session
+                            .abort_turn(
+                                &turn_context.sub_id,
+                                codex_protocol::protocol::TurnAbortReason::Interrupted,
+                            )
+                            .await;
                     }
                     pending.set_decision(PendingApprovalDecision::Deny).await;
                     let mut pending_approvals = self.pending_host_approvals.lock().await;

--- a/codex-rs/core/src/tools/network_approval.rs
+++ b/codex-rs/core/src/tools/network_approval.rs
@@ -118,6 +118,7 @@ enum PendingApprovalDecision {
 enum NetworkApprovalOutcome {
     DeniedByUser,
     DeniedByPolicy(String),
+    InterruptedByPolicy(String),
 }
 
 /// Whether an allowlist miss may be reviewed instead of hard-denied.
@@ -402,13 +403,20 @@ impl NetworkApprovalService {
                     pending_approvals.remove(&key);
                     return NetworkDecision::Allow;
                 }
-                PermissionRequestDecision::Deny { message } => {
+                PermissionRequestDecision::Deny { message, interrupt } => {
                     if let Some(owner_call) = owner_call.as_ref() {
                         self.record_call_outcome(
                             &owner_call.registration_id,
-                            NetworkApprovalOutcome::DeniedByPolicy(message),
+                            if interrupt {
+                                NetworkApprovalOutcome::InterruptedByPolicy(message)
+                            } else {
+                                NetworkApprovalOutcome::DeniedByPolicy(message)
+                            },
                         )
                         .await;
+                    }
+                    if interrupt {
+                        session.interrupt_task_detached();
                     }
                     pending.set_decision(PendingApprovalDecision::Deny).await;
                     let mut pending_approvals = self.pending_host_approvals.lock().await;
@@ -668,6 +676,7 @@ pub(crate) async fn finish_immediate_network_approval(
             Err(ToolError::Rejected("rejected by user".to_string()))
         }
         Some(NetworkApprovalOutcome::DeniedByPolicy(message)) => Err(ToolError::Rejected(message)),
+        Some(NetworkApprovalOutcome::InterruptedByPolicy(_message)) => Err(ToolError::Interrupted),
         None => Ok(()),
     }
 }

--- a/codex-rs/core/src/tools/orchestrator.rs
+++ b/codex-rs/core/src/tools/orchestrator.rs
@@ -394,7 +394,13 @@ impl ToolOrchestrator {
                         ToolDecisionSource::Config,
                     );
                     if interrupt {
-                        approval_ctx.session.interrupt_task_detached();
+                        approval_ctx
+                            .session
+                            .abort_turn(
+                                &approval_ctx.turn.sub_id,
+                                codex_protocol::protocol::TurnAbortReason::Interrupted,
+                            )
+                            .await;
                         return Err(ToolError::Interrupted);
                     }
                     return Err(ToolError::Rejected(message));

--- a/codex-rs/core/src/tools/orchestrator.rs
+++ b/codex-rs/core/src/tools/orchestrator.rs
@@ -386,13 +386,17 @@ impl ToolOrchestrator {
                     );
                     return Ok(ReviewDecision::Approved);
                 }
-                Some(PermissionRequestDecision::Deny { message }) => {
+                Some(PermissionRequestDecision::Deny { message, interrupt }) => {
                     telemetry.otel.tool_decision(
                         telemetry.tool_name,
                         telemetry.call_id,
                         &ReviewDecision::Denied,
                         ToolDecisionSource::Config,
                     );
+                    if interrupt {
+                        approval_ctx.session.interrupt_task_detached();
+                        return Err(ToolError::Interrupted);
+                    }
                     return Err(ToolError::Rejected(message));
                 }
                 None => {}

--- a/codex-rs/core/src/tools/parallel.rs
+++ b/codex-rs/core/src/tools/parallel.rs
@@ -64,6 +64,7 @@ impl ToolCallRuntime {
         async move {
             match future.await {
                 Ok(response) => Ok(response.into_response()),
+                Err(FunctionCallError::Interrupted) => Err(CodexErr::TurnAborted),
                 Err(FunctionCallError::Fatal(message)) => Err(CodexErr::Fatal(message)),
                 Err(other) => Ok(Self::failure_response(error_call, other)),
             }

--- a/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
+++ b/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
@@ -430,7 +430,12 @@ impl CoreShellActionProvider {
                     }
                     Some(PermissionRequestDecision::Deny { message, interrupt }) => {
                         if interrupt {
-                            session.interrupt_task_detached();
+                            session
+                                .abort_turn(
+                                    &turn.sub_id,
+                                    codex_protocol::protocol::TurnAbortReason::Interrupted,
+                                )
+                                .await;
                             return Err(anyhow::Error::new(ToolError::Interrupted));
                         }
                         return Ok(PromptDecision {

--- a/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
+++ b/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
@@ -77,6 +77,14 @@ const REJECT_SANDBOX_APPROVAL_REASON: &str =
     "approval required by policy, but AskForApproval::Granular.sandbox_approval is false";
 const REJECT_RULES_APPROVAL_REASON: &str =
     "approval required by policy rule, but AskForApproval::Granular.rules is false";
+
+fn preserve_interrupted_tool_error(err: anyhow::Error) -> ToolError {
+    match err.downcast::<ToolError>() {
+        Ok(tool_error) => tool_error,
+        Err(err) => ToolError::Rejected(err.to_string()),
+    }
+}
+
 fn approval_sandbox_permissions(
     sandbox_permissions: SandboxPermissions,
     additional_permissions_preapproved: bool,
@@ -215,7 +223,7 @@ pub(super) async fn try_run_zsh_fork(
     let exec_result = escalate_server
         .exec(exec_params, cancel_token, Arc::new(command_executor))
         .await
-        .map_err(|err| ToolError::Rejected(err.to_string()))?;
+        .map_err(preserve_interrupted_tool_error)?;
 
     map_exec_result(attempt.sandbox, exec_result).map(Some)
 }
@@ -288,7 +296,7 @@ pub(crate) async fn prepare_unified_exec_zsh_fork(
     );
     let escalation_session = escalate_server
         .start_session(CancellationToken::new(), Arc::new(command_executor))
-        .map_err(|err| ToolError::Rejected(err.to_string()))?;
+        .map_err(preserve_interrupted_tool_error)?;
     let mut exec_request = exec_request;
     exec_request.env.extend(escalation_session.env().clone());
     Ok(Some(PreparedUnifiedExecZshFork {
@@ -396,7 +404,7 @@ impl CoreShellActionProvider {
         let approval_id = Some(Uuid::new_v4().to_string());
         let source = self.tool_name;
         let guardian_review_id = routes_approval_to_guardian(&turn).then(new_guardian_review_id);
-        Ok(stopwatch
+        stopwatch
             .pause_for(async move {
                 // 1) Run PermissionRequest hooks
                 let permission_request = PermissionRequestPayload {
@@ -414,18 +422,22 @@ impl CoreShellActionProvider {
                 .await
                 {
                     Some(PermissionRequestDecision::Allow) => {
-                        return PromptDecision {
+                        return Ok(PromptDecision {
                             decision: ReviewDecision::Approved,
                             guardian_review_id: None,
                             rejection_message: None,
-                        };
+                        });
                     }
-                    Some(PermissionRequestDecision::Deny { message }) => {
-                        return PromptDecision {
+                    Some(PermissionRequestDecision::Deny { message, interrupt }) => {
+                        if interrupt {
+                            session.interrupt_task_detached();
+                            return Err(anyhow::Error::new(ToolError::Interrupted));
+                        }
+                        return Ok(PromptDecision {
                             decision: ReviewDecision::Denied,
                             guardian_review_id: None,
                             rejection_message: Some(message),
-                        };
+                        });
                     }
                     None => {}
                 }
@@ -447,11 +459,11 @@ impl CoreShellActionProvider {
                         /*retry_reason*/ None,
                     )
                     .await;
-                    return PromptDecision {
+                    return Ok(PromptDecision {
                         decision,
                         guardian_review_id,
                         rejection_message: None,
-                    };
+                    });
                 }
 
                 // 3) Fall back to regular user prompt
@@ -469,13 +481,13 @@ impl CoreShellActionProvider {
                         Some(vec![ReviewDecision::Approved, ReviewDecision::Abort]),
                     )
                     .await;
-                PromptDecision {
+                Ok(PromptDecision {
                     decision,
                     guardian_review_id: None,
                     rejection_message: None,
-                }
+                })
             })
-            .await)
+            .await
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/codex-rs/core/src/tools/sandboxing.rs
+++ b/codex-rs/core/src/tools/sandboxing.rs
@@ -35,6 +35,7 @@ use std::fmt::Debug;
 use std::hash::Hash;
 use std::path::Path;
 use std::sync::Arc;
+use thiserror::Error;
 
 #[derive(Clone, Default, Debug)]
 pub(crate) struct ApprovalStore {
@@ -318,9 +319,13 @@ pub(crate) struct ToolCtx {
     pub tool_name: String,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub(crate) enum ToolError {
+    #[error("turn interrupted")]
+    Interrupted,
+    #[error("{0}")]
     Rejected(String),
+    #[error(transparent)]
     Codex(CodexErr),
 }
 

--- a/codex-rs/core/tests/suite/hooks.rs
+++ b/codex-rs/core/tests/suite/hooks.rs
@@ -36,6 +36,7 @@ use core_test_support::streaming_sse::StreamingSseChunk;
 use core_test_support::streaming_sse::start_streaming_sse_server;
 use core_test_support::test_codex::test_codex;
 use core_test_support::wait_for_event;
+use core_test_support::wait_for_event_match;
 use pretty_assertions::assert_eq;
 use serde_json::Value;
 use std::sync::Arc;
@@ -294,6 +295,17 @@ elif mode == "deny":
             }}
         }}
     }}))
+elif mode == "deny_interrupt":
+    print(json.dumps({{
+        "hookSpecificOutput": {{
+            "hookEventName": "PermissionRequest",
+            "decision": {{
+                "behavior": "deny",
+                "message": reason,
+                "interrupt": True
+            }}
+        }}
+    }}))
 elif mode == "exit_2":
     sys.stderr.write(reason + "\n")
     raise SystemExit(2)
@@ -331,6 +343,15 @@ fn install_allow_permission_request_hook(home: &Path) -> Result<()> {
         Some(PERMISSION_REQUEST_HOOK_MATCHER),
         "allow",
         PERMISSION_REQUEST_ALLOW_REASON,
+    )
+}
+
+fn install_interrupting_permission_request_hook(home: &Path, reason: &str) -> Result<()> {
+    write_permission_request_hook(
+        home,
+        Some(PERMISSION_REQUEST_HOOK_MATCHER),
+        "deny_interrupt",
+        reason,
     )
 }
 
@@ -532,6 +553,70 @@ fn assert_single_permission_request_hook_input(
     assert_eq!(hook_inputs.len(), 1);
     assert_permission_request_hook_input(&hook_inputs[0], command, description);
     Ok(hook_inputs)
+}
+
+async fn submit_turn_and_wait_for_interrupt(
+    test: &core_test_support::test_codex::TestCodex,
+    prompt: &str,
+    approval_policy: AskForApproval,
+    sandbox_policy: SandboxPolicy,
+    expected_hook_message: &str,
+) -> Result<String> {
+    let session_model = test.session_configured.model.clone();
+    test.codex
+        .submit(Op::UserTurn {
+            items: vec![UserInput::Text {
+                text: prompt.to_string(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+            cwd: test.config.cwd.to_path_buf(),
+            approval_policy,
+            approvals_reviewer: None,
+            sandbox_policy,
+            model: session_model,
+            effort: None,
+            summary: None,
+            service_tier: None,
+            collaboration_mode: None,
+            personality: None,
+        })
+        .await?;
+
+    let turn_id = wait_for_event_match(&test.codex, |event| match event {
+        EventMsg::TurnStarted(event) => Some(event.turn_id.clone()),
+        _ => None,
+    })
+    .await;
+
+    let hook_event = wait_for_event_match(&test.codex, |event| match event {
+        EventMsg::HookCompleted(event) => Some(event.clone()),
+        _ => None,
+    })
+    .await;
+    assert_eq!(hook_event.turn_id.as_deref(), Some(turn_id.as_str()));
+    assert_eq!(
+        hook_event.run.status,
+        codex_protocol::protocol::HookRunStatus::Blocked
+    );
+    assert_eq!(
+        hook_event.run.entries,
+        vec![codex_protocol::protocol::HookOutputEntry {
+            kind: codex_protocol::protocol::HookOutputEntryKind::Feedback,
+            text: expected_hook_message.to_string(),
+        }]
+    );
+
+    wait_for_event(&test.codex, |event| match event {
+        EventMsg::TurnAborted(event) => {
+            event.turn_id.as_deref() == Some(turn_id.as_str())
+                && event.reason == codex_protocol::protocol::TurnAbortReason::Interrupted
+        }
+        _ => false,
+    })
+    .await;
+
+    Ok(turn_id)
 }
 
 fn read_post_tool_use_hook_inputs(home: &Path) -> Result<Vec<serde_json::Value>> {
@@ -1222,6 +1307,78 @@ async fn permission_request_hook_allows_shell_command_without_user_approval() ->
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn permission_request_hook_interrupts_shell_command_turn() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let call_id = "permissionrequest-shell-command-interrupt";
+    let marker = std::env::temp_dir().join("permissionrequest-shell-command-interrupt-marker");
+    let command = format!("rm -f {}", marker.display());
+    let reason = "interrupt shell approval";
+    let args = serde_json::json!({ "command": command });
+    let responses = mount_sse_once(
+        &server,
+        sse(vec![
+            ev_response_created("resp-1"),
+            ev_function_call(call_id, "shell_command", &serde_json::to_string(&args)?),
+            ev_completed("resp-1"),
+        ]),
+    )
+    .await;
+
+    let mut builder = test_codex()
+        .with_pre_build_hook(|home| {
+            if let Err(error) = install_interrupting_permission_request_hook(home, reason) {
+                panic!("failed to write interrupting permission request hook fixture: {error}");
+            }
+        })
+        .with_config(|config| {
+            config
+                .features
+                .enable(Feature::CodexHooks)
+                .expect("test config should allow feature update");
+        });
+    let test = builder.build(&server).await?;
+
+    fs::write(&marker, "seed").context("create permission request interrupt marker")?;
+
+    let _turn_id = submit_turn_and_wait_for_interrupt(
+        &test,
+        "interrupt the shell command after hook denial",
+        AskForApproval::OnRequest,
+        codex_protocol::protocol::SandboxPolicy::DangerFullAccess,
+        reason,
+    )
+    .await?;
+
+    assert_eq!(responses.requests().len(), 1);
+    assert!(
+        marker.exists(),
+        "interrupted command should not remove marker file"
+    );
+    assert!(
+        timeout(
+            Duration::from_secs(2),
+            wait_for_event(&test.codex, |event| matches!(
+                event,
+                EventMsg::ExecApprovalRequest(_)
+            ))
+        )
+        .await
+        .is_err(),
+        "expected the interrupting permission request hook to bypass the approval prompt"
+    );
+
+    assert_single_permission_request_hook_input(
+        test.codex_home_path(),
+        &command,
+        /*description*/ None,
+    )?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn permission_request_hook_sees_raw_exec_command_input() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
@@ -1291,6 +1448,89 @@ async fn permission_request_hook_sees_raw_exec_command_input() -> Result<()> {
     assert!(
         !marker.exists(),
         "approved exec command should remove marker file"
+    );
+
+    assert_single_permission_request_hook_input(
+        test.codex_home_path(),
+        &command,
+        Some(justification),
+    )?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn permission_request_hook_interrupts_exec_command_turn() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let call_id = "permissionrequest-exec-command-interrupt";
+    let marker = std::env::temp_dir().join("permissionrequest-exec-command-interrupt-marker");
+    let command = format!("rm -f {}", marker.display());
+    let justification = "interrupt the temporary marker removal";
+    let reason = "interrupt exec approval";
+    let args = serde_json::json!({
+        "cmd": command,
+        "login": true,
+        "sandbox_permissions": "require_escalated",
+        "justification": justification,
+    });
+    let responses = mount_sse_once(
+        &server,
+        sse(vec![
+            ev_response_created("resp-1"),
+            ev_function_call(call_id, "exec_command", &serde_json::to_string(&args)?),
+            ev_completed("resp-1"),
+        ]),
+    )
+    .await;
+
+    let mut builder = test_codex()
+        .with_pre_build_hook(|home| {
+            if let Err(error) = install_interrupting_permission_request_hook(home, reason) {
+                panic!("failed to write interrupting permission request hook fixture: {error}");
+            }
+        })
+        .with_config(|config| {
+            config.use_experimental_unified_exec_tool = true;
+            config
+                .features
+                .enable(Feature::CodexHooks)
+                .expect("test config should allow feature update");
+            config
+                .features
+                .enable(Feature::UnifiedExec)
+                .expect("test config should allow feature update");
+        });
+    let test = builder.build(&server).await?;
+
+    fs::write(&marker, "seed").context("create exec command interrupt marker")?;
+
+    let _turn_id = submit_turn_and_wait_for_interrupt(
+        &test,
+        "interrupt the exec command after hook denial",
+        AskForApproval::OnRequest,
+        codex_protocol::protocol::SandboxPolicy::new_read_only_policy(),
+        reason,
+    )
+    .await?;
+
+    assert_eq!(responses.requests().len(), 1);
+    assert!(
+        marker.exists(),
+        "interrupted exec command should not remove marker file"
+    );
+    assert!(
+        timeout(
+            Duration::from_secs(2),
+            wait_for_event(&test.codex, |event| matches!(
+                event,
+                EventMsg::ExecApprovalRequest(_)
+            ))
+        )
+        .await
+        .is_err(),
+        "expected the interrupting permission request hook to bypass the approval prompt"
     );
 
     assert_single_permission_request_hook_input(
@@ -1453,6 +1693,130 @@ allow_local_binding = true
         matches!(event, EventMsg::ShutdownComplete)
     })
     .await;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn permission_request_hook_interrupts_network_approval_turn() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let home = Arc::new(TempDir::new()?);
+    fs::write(
+        home.path().join("config.toml"),
+        r#"default_permissions = "workspace"
+
+[permissions.workspace.filesystem]
+":minimal" = "read"
+
+[permissions.workspace.network]
+enabled = true
+mode = "limited"
+allow_local_binding = true
+"#,
+    )?;
+    let call_id = "permissionrequest-network-approval-interrupt";
+    let command = r#"python3 -c "import urllib.request; opener = urllib.request.build_opener(urllib.request.ProxyHandler()); print('OK:' + opener.open('http://codex-network-test.invalid', timeout=2).read().decode(errors='replace'))""#;
+    let reason = "interrupt network approval";
+    let args = serde_json::json!({ "command": command });
+    let responses = mount_sse_once(
+        &server,
+        sse(vec![
+            ev_response_created("resp-1"),
+            ev_function_call(call_id, "shell_command", &serde_json::to_string(&args)?),
+            ev_completed("resp-1"),
+        ]),
+    )
+    .await;
+
+    let approval_policy = AskForApproval::OnFailure;
+    let sandbox_policy = SandboxPolicy::WorkspaceWrite {
+        writable_roots: vec![],
+        read_only_access: Default::default(),
+        network_access: true,
+        exclude_tmpdir_env_var: false,
+        exclude_slash_tmp: false,
+    };
+    let sandbox_policy_for_config = sandbox_policy.clone();
+    let test = test_codex()
+        .with_home(Arc::clone(&home))
+        .with_pre_build_hook(|home| {
+            if let Err(error) = install_interrupting_permission_request_hook(home, reason) {
+                panic!("failed to write interrupting permission request hook fixture: {error}");
+            }
+        })
+        .with_config(move |config| {
+            config
+                .features
+                .enable(Feature::CodexHooks)
+                .expect("test config should allow feature update");
+            config.permissions.approval_policy = Constrained::allow_any(approval_policy);
+            config.permissions.sandbox_policy = Constrained::allow_any(sandbox_policy_for_config);
+            let layers = config
+                .config_layer_stack
+                .get_layers(
+                    ConfigLayerStackOrdering::LowestPrecedenceFirst,
+                    /*include_disabled*/ true,
+                )
+                .into_iter()
+                .cloned()
+                .collect();
+            let mut requirements = config.config_layer_stack.requirements().clone();
+            requirements.network = Some(Sourced::new(
+                NetworkConstraints {
+                    enabled: Some(true),
+                    allow_local_binding: Some(true),
+                    ..Default::default()
+                },
+                RequirementSource::CloudRequirements,
+            ));
+            let mut requirements_toml = config.config_layer_stack.requirements_toml().clone();
+            requirements_toml.network = Some(NetworkRequirementsToml {
+                enabled: Some(true),
+                allow_local_binding: Some(true),
+                ..Default::default()
+            });
+            config.config_layer_stack =
+                ConfigLayerStack::new(layers, requirements, requirements_toml)
+                    .expect("rebuild config layer stack with network requirements");
+        })
+        .build(&server)
+        .await?;
+
+    assert!(
+        test.config.managed_network_requirements_enabled(),
+        "expected managed network requirements to be enabled"
+    );
+
+    let _turn_id = submit_turn_and_wait_for_interrupt(
+        &test,
+        "interrupt the network approval after hook denial",
+        approval_policy,
+        sandbox_policy,
+        reason,
+    )
+    .await?;
+
+    assert_eq!(responses.requests().len(), 1);
+    assert!(
+        timeout(
+            Duration::from_secs(2),
+            wait_for_event(&test.codex, |event| matches!(
+                event,
+                EventMsg::ExecApprovalRequest(_)
+            ))
+        )
+        .await
+        .is_err(),
+        "expected the interrupting permission request hook to bypass the approval prompt"
+    );
+
+    assert_single_permission_request_hook_input(
+        test.codex_home_path(),
+        command,
+        Some("network-access http://codex-network-test.invalid:80"),
+    )?;
 
     Ok(())
 }

--- a/codex-rs/hooks/schema/generated/permission-request.command.output.schema.json
+++ b/codex-rs/hooks/schema/generated/permission-request.command.output.schema.json
@@ -28,7 +28,7 @@
         },
         "interrupt": {
           "default": false,
-          "description": "Reserved for future short-circuiting semantics.\n\nPermissionRequest hooks currently fail closed if this field is `true`.",
+          "description": "When paired with `behavior: \"deny\"`, short-circuit the active turn with the same interrupt path used by Esc.",
           "type": "boolean"
         },
         "message": {

--- a/codex-rs/hooks/src/engine/output_parser.rs
+++ b/codex-rs/hooks/src/engine/output_parser.rs
@@ -22,7 +22,7 @@ pub(crate) struct PreToolUseOutput {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum PermissionRequestDecision {
     Allow,
-    Deny { message: String },
+    Deny { message: String, interrupt: bool },
 }
 
 #[derive(Debug, Clone)]
@@ -302,8 +302,10 @@ fn unsupported_permission_request_hook_specific_output(
         Some("PermissionRequest hook returned unsupported updatedInput".to_string())
     } else if decision.updated_permissions.is_some() {
         Some("PermissionRequest hook returned unsupported updatedPermissions".to_string())
-    } else if decision.interrupt {
-        Some("PermissionRequest hook returned unsupported interrupt:true".to_string())
+    } else if decision.interrupt
+        && !matches!(decision.behavior, PermissionRequestBehaviorWire::Deny)
+    {
+        Some("PermissionRequest hook returned interrupt:true without behavior:deny".to_string())
     } else {
         None
     }
@@ -320,6 +322,7 @@ fn permission_request_decision(
                 .as_deref()
                 .and_then(trimmed_reason)
                 .unwrap_or_else(|| "PermissionRequest hook denied approval".to_string()),
+            interrupt: decision.interrupt,
         },
     }
 }
@@ -470,7 +473,34 @@ mod tests {
     }
 
     #[test]
-    fn permission_request_rejects_reserved_interrupt_field() {
+    fn permission_request_accepts_interrupting_deny() {
+        let parsed = parse_permission_request(
+            &json!({
+                "continue": true,
+                "hookSpecificOutput": {
+                    "hookEventName": "PermissionRequest",
+                    "decision": {
+                        "behavior": "deny",
+                        "message": "stop now",
+                        "interrupt": true
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .expect("permission request hook output should parse");
+
+        assert_eq!(
+            parsed.decision,
+            Some(super::PermissionRequestDecision::Deny {
+                message: "stop now".to_string(),
+                interrupt: true,
+            })
+        );
+    }
+
+    #[test]
+    fn permission_request_rejects_interrupting_allow() {
         let parsed = parse_permission_request(
             &json!({
                 "continue": true,
@@ -488,7 +518,9 @@ mod tests {
 
         assert_eq!(
             parsed.invalid_reason,
-            Some("PermissionRequest hook returned unsupported interrupt:true".to_string())
+            Some(
+                "PermissionRequest hook returned interrupt:true without behavior:deny".to_string()
+            )
         );
     }
 }

--- a/codex-rs/hooks/src/events/permission_request.rs
+++ b/codex-rs/hooks/src/events/permission_request.rs
@@ -48,7 +48,7 @@ pub struct PermissionRequestRequest {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PermissionRequestDecision {
     Allow,
-    Deny { message: String },
+    Deny { message: String, interrupt: bool },
 }
 
 #[derive(Debug)]
@@ -155,9 +155,10 @@ fn resolve_permission_request_decision<'a>(
             PermissionRequestDecision::Allow => {
                 resolved_allow = Some(PermissionRequestDecision::Allow);
             }
-            PermissionRequestDecision::Deny { message } => {
+            PermissionRequestDecision::Deny { message, interrupt } => {
                 return Some(PermissionRequestDecision::Deny {
                     message: message.clone(),
+                    interrupt: *interrupt,
                 });
             }
         }
@@ -223,13 +224,17 @@ fn parse_completed(
                             output_parser::PermissionRequestDecision::Allow => {
                                 decision = Some(PermissionRequestDecision::Allow);
                             }
-                            output_parser::PermissionRequestDecision::Deny { message } => {
+                            output_parser::PermissionRequestDecision::Deny {
+                                message,
+                                interrupt,
+                            } => {
                                 status = HookRunStatus::Blocked;
                                 entries.push(HookOutputEntry {
                                     kind: HookOutputEntryKind::Feedback,
                                     text: message.clone(),
                                 });
-                                decision = Some(PermissionRequestDecision::Deny { message });
+                                decision =
+                                    Some(PermissionRequestDecision::Deny { message, interrupt });
                             }
                         }
                     }
@@ -248,7 +253,10 @@ fn parse_completed(
                         kind: HookOutputEntryKind::Feedback,
                         text: message.clone(),
                     });
-                    decision = Some(PermissionRequestDecision::Deny { message });
+                    decision = Some(PermissionRequestDecision::Deny {
+                        message,
+                        interrupt: false,
+                    });
                 } else {
                     status = HookRunStatus::Failed;
                     entries.push(HookOutputEntry {
@@ -298,6 +306,7 @@ mod tests {
             PermissionRequestDecision::Allow,
             PermissionRequestDecision::Deny {
                 message: "repo deny".to_string(),
+                interrupt: true,
             },
         ];
 
@@ -305,6 +314,7 @@ mod tests {
             resolve_permission_request_decision(decisions.iter()),
             Some(PermissionRequestDecision::Deny {
                 message: "repo deny".to_string(),
+                interrupt: true,
             })
         );
     }

--- a/codex-rs/hooks/src/schema.rs
+++ b/codex-rs/hooks/src/schema.rs
@@ -150,9 +150,8 @@ pub(crate) struct PermissionRequestDecisionWire {
     pub updated_permissions: Option<Value>,
     #[serde(default)]
     pub message: Option<String>,
-    /// Reserved for future short-circuiting semantics.
-    ///
-    /// PermissionRequest hooks currently fail closed if this field is `true`.
+    /// When paired with `behavior: "deny"`, short-circuit the active turn with
+    /// the same interrupt path used by Esc.
     #[serde(default)]
     pub interrupt: bool,
 }


### PR DESCRIPTION
## Summary

- allow PermissionRequest hooks to return `decision.interrupt: true` alongside `behavior: "deny"`
- route interrupting denies through the same turn-abort path used by an Esc interrupt
- add integration coverage for shell, exec_command, network approval, and a verified subagent smoke path

## Why

PermissionRequest hooks could deny a request, but they could not force the active agent loop to stop immediately. That made policy-driven hard stops behave differently from a user interrupt even when the hook author wanted the turn to terminate.

## Impact

- hook authors can now short-circuit a denied request cleanly by setting `interrupt: true`
- denied requests without `interrupt: true` keep the existing rejection behavior
- interrupt semantics are preserved across the command-execution and approval paths that can hit PermissionRequest hooks

## Validation

- `cargo test -p codex-hooks permission_request_`
- `cargo test -p codex-core permission_request_hook_`
- `cargo run -p codex-hooks --bin write_hooks_schema_fixtures`
- `just fix -p codex-hooks`
- `just fix -p codex-core`
- `just fmt`
- interactive TUI smoke test confirming an interrupting deny from a spawned subagent request

## Stack

- base branch: `codex/permission-request-hooks-base`
