### PR TITLE
[codex] Support local marketplace sources

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/marketplace_add.rs
+++ b/codex-rs/app-server/tests/suite/v2/marketplace_add.rs
@@ -13,7 +13,7 @@ use tokio::time::timeout;
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[tokio::test]
-async fn marketplace_add_supports_local_directory_source() -> Result<()> {
+async fn marketplace_add_local_directory_source() -> Result<()> {
     let codex_home = TempDir::new()?;
     let source = codex_home.path().join("marketplace");
     std::fs::create_dir_all(source.join(".agents/plugins"))?;

--- a/codex-rs/app-server/tests/suite/v2/marketplace_add.rs
+++ b/codex-rs/app-server/tests/suite/v2/marketplace_add.rs
@@ -5,7 +5,6 @@ use codex_app_server_protocol::JSONRPCResponse;
 use codex_app_server_protocol::MarketplaceAddParams;
 use codex_app_server_protocol::MarketplaceAddResponse;
 use codex_app_server_protocol::RequestId;
-use codex_core::plugins::marketplace_install_root;
 use pretty_assertions::assert_eq;
 use tempfile::TempDir;
 use tokio::time::Duration;
@@ -49,9 +48,7 @@ async fn marketplace_add_supports_local_directory_source() -> Result<()> {
         installed_root,
         already_added,
     } = to_response(response)?;
-    let expected_root = marketplace_install_root(codex_home.path())
-        .join("debug")
-        .canonicalize()?;
+    let expected_root = source.canonicalize()?;
 
     assert_eq!(marketplace_name, "debug");
     assert_eq!(installed_root.as_path(), expected_root.as_path());

--- a/codex-rs/app-server/tests/suite/v2/marketplace_add.rs
+++ b/codex-rs/app-server/tests/suite/v2/marketplace_add.rs
@@ -1,7 +1,12 @@
 use anyhow::Result;
 use app_test_support::McpProcess;
+use app_test_support::to_response;
+use codex_app_server_protocol::JSONRPCResponse;
 use codex_app_server_protocol::MarketplaceAddParams;
+use codex_app_server_protocol::MarketplaceAddResponse;
 use codex_app_server_protocol::RequestId;
+use codex_core::plugins::marketplace_install_root;
+use pretty_assertions::assert_eq;
 use tempfile::TempDir;
 use tokio::time::Duration;
 use tokio::time::timeout;
@@ -9,8 +14,20 @@ use tokio::time::timeout;
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[tokio::test]
-async fn marketplace_add_rejects_local_directory_source() -> Result<()> {
+async fn marketplace_add_supports_local_directory_source() -> Result<()> {
     let codex_home = TempDir::new()?;
+    let source = codex_home.path().join("marketplace");
+    std::fs::create_dir_all(source.join(".agents/plugins"))?;
+    std::fs::create_dir_all(source.join("plugins/sample/.codex-plugin"))?;
+    std::fs::write(
+        source.join(".agents/plugins/marketplace.json"),
+        r#"{"name":"debug","plugins":[]}"#,
+    )?;
+    std::fs::write(
+        source.join("plugins/sample/.codex-plugin/plugin.json"),
+        r#"{"name":"sample"}"#,
+    )?;
+    std::fs::write(source.join("plugins/sample/marker.txt"), "local ref")?;
     let mut mcp = McpProcess::new(codex_home.path()).await?;
     timeout(DEFAULT_TIMEOUT, mcp.initialize()).await??;
 
@@ -22,19 +39,26 @@ async fn marketplace_add_rejects_local_directory_source() -> Result<()> {
         })
         .await?;
 
-    let err = timeout(
+    let response: JSONRPCResponse = timeout(
         DEFAULT_TIMEOUT,
-        mcp.read_stream_until_error_message(RequestId::Integer(request_id)),
+        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
     )
     .await??;
+    let MarketplaceAddResponse {
+        marketplace_name,
+        installed_root,
+        already_added,
+    } = to_response(response)?;
+    let expected_root = marketplace_install_root(codex_home.path())
+        .join("debug")
+        .canonicalize()?;
 
-    assert_eq!(err.error.code, -32600);
-    assert!(
-        err.error.message.contains(
-            "local marketplace sources are not supported yet; use an HTTP(S) Git URL, SSH Git URL, or GitHub owner/repo"
-        ),
-        "unexpected error: {}",
-        err.error.message
+    assert_eq!(marketplace_name, "debug");
+    assert_eq!(installed_root.as_path(), expected_root.as_path());
+    assert!(!already_added);
+    assert_eq!(
+        std::fs::read_to_string(installed_root.as_path().join("plugins/sample/marker.txt"))?,
+        "local ref"
     );
     Ok(())
 }

--- a/codex-rs/cli/src/marketplace_cmd.rs
+++ b/codex-rs/cli/src/marketplace_cmd.rs
@@ -23,7 +23,8 @@ enum MarketplaceSubcommand {
 
 #[derive(Debug, Parser)]
 struct AddMarketplaceArgs {
-    /// Marketplace source. Supports owner/repo[@ref], HTTP(S) Git URLs, or SSH URLs.
+    /// Marketplace source. Supports owner/repo[@ref], HTTP(S) Git URLs, SSH URLs,
+    /// local filesystem paths, or direct marketplace.json URLs.
     source: String,
 
     /// Git ref to check out. Overrides any @ref or #ref suffix in SOURCE.

--- a/codex-rs/cli/src/marketplace_cmd.rs
+++ b/codex-rs/cli/src/marketplace_cmd.rs
@@ -24,7 +24,7 @@ enum MarketplaceSubcommand {
 #[derive(Debug, Parser)]
 struct AddMarketplaceArgs {
     /// Marketplace source. Supports owner/repo[@ref], HTTP(S) Git URLs, SSH URLs,
-    /// local filesystem paths, or direct marketplace.json URLs.
+    /// or local marketplace root directories.
     source: String,
 
     /// Git ref to check out. Overrides any @ref or #ref suffix in SOURCE.

--- a/codex-rs/cli/tests/marketplace_add.rs
+++ b/codex-rs/cli/tests/marketplace_add.rs
@@ -60,7 +60,7 @@ async fn marketplace_add_supports_local_directory_source() -> Result<()> {
     let expected_source = source.path().canonicalize()?.display().to_string();
     assert_eq!(
         config["marketplaces"]["debug"]["source_type"].as_str(),
-        Some("path")
+        Some("local")
     );
     assert_eq!(
         config["marketplaces"]["debug"]["source"].as_str(),

--- a/codex-rs/cli/tests/marketplace_add.rs
+++ b/codex-rs/cli/tests/marketplace_add.rs
@@ -39,7 +39,7 @@ fn write_marketplace_source(source: &Path, marker: &str) -> Result<()> {
 }
 
 #[tokio::test]
-async fn marketplace_add_supports_local_directory_source() -> Result<()> {
+async fn marketplace_add_local_directory_source() -> Result<()> {
     let codex_home = TempDir::new()?;
     let source = TempDir::new()?;
     write_marketplace_source(source.path(), "local ref")?;

--- a/codex-rs/cli/tests/marketplace_add.rs
+++ b/codex-rs/cli/tests/marketplace_add.rs
@@ -1,12 +1,9 @@
 use anyhow::Result;
 use codex_config::CONFIG_TOML_FILE;
 use codex_core::plugins::marketplace_install_root;
+use predicates::str::contains;
 use pretty_assertions::assert_eq;
-use std::io::Read;
-use std::io::Write;
-use std::net::TcpListener;
 use std::path::Path;
-use std::thread;
 use tempfile::TempDir;
 
 fn codex_command(codex_home: &Path) -> Result<assert_cmd::Command> {
@@ -76,61 +73,20 @@ async fn marketplace_add_supports_local_directory_source() -> Result<()> {
     Ok(())
 }
 
-fn spawn_manifest_server(body: String) -> Result<(u16, thread::JoinHandle<Result<()>>)> {
-    let listener = TcpListener::bind("127.0.0.1:0")?;
-    let port = listener.local_addr()?.port();
-    Ok((
-        port,
-        thread::spawn(move || {
-            let (mut stream, _addr) = listener.accept()?;
-            let mut request = [0_u8; 2048];
-            let _ = stream.read(&mut request)?;
-            let response = format!(
-                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-                body.len(),
-                body
-            );
-            stream.write_all(response.as_bytes())?;
-            Ok(())
-        }),
-    ))
-}
-
 #[tokio::test]
-async fn marketplace_add_supports_manifest_url_source() -> Result<()> {
+async fn marketplace_add_rejects_local_manifest_file_source() -> Result<()> {
     let codex_home = TempDir::new()?;
     let source = TempDir::new()?;
-    std::fs::create_dir_all(source.path().join(".agents/plugins"))?;
-    std::fs::write(
-        source.path().join(".agents/plugins/marketplace.json"),
-        r#"{"name":"debug-url","plugins":[]}"#,
-    )?;
-    let (port, server) = spawn_manifest_server(r#"{"name":"debug-url","plugins":[]}"#.to_string())?;
-    let url = format!("http://127.0.0.1:{port}/.agents/plugins/marketplace.json");
+    write_marketplace_source(source.path(), "local ref")?;
+    let manifest_path = source.path().join(".agents/plugins/marketplace.json");
 
     codex_command(codex_home.path())?
-        .args(["marketplace", "add", &url])
+        .args(["marketplace", "add", manifest_path.to_str().unwrap()])
         .assert()
-        .success();
-
-    let installed_root = marketplace_install_root(codex_home.path()).join("debug-url");
-    assert!(
-        installed_root
-            .join(".agents/plugins/marketplace.json")
-            .is_file()
-    );
-
-    let config = std::fs::read_to_string(codex_home.path().join(CONFIG_TOML_FILE))?;
-    let config: toml::Value = toml::from_str(&config)?;
-    assert_eq!(
-        config["marketplaces"]["debug-url"]["source_type"].as_str(),
-        Some("manifest_url")
-    );
-    assert_eq!(
-        config["marketplaces"]["debug-url"]["source"].as_str(),
-        Some(url.as_str())
-    );
-    server.join().unwrap()?;
+        .failure()
+        .stderr(contains(
+            "local marketplace source must be a directory, not a file",
+        ));
 
     Ok(())
 }

--- a/codex-rs/cli/tests/marketplace_add.rs
+++ b/codex-rs/cli/tests/marketplace_add.rs
@@ -1,7 +1,12 @@
 use anyhow::Result;
+use codex_config::CONFIG_TOML_FILE;
 use codex_core::plugins::marketplace_install_root;
-use predicates::str::contains;
+use pretty_assertions::assert_eq;
+use std::io::Read;
+use std::io::Write;
+use std::net::TcpListener;
 use std::path::Path;
+use std::thread;
 use tempfile::TempDir;
 
 fn codex_command(codex_home: &Path) -> Result<assert_cmd::Command> {
@@ -37,7 +42,7 @@ fn write_marketplace_source(source: &Path, marker: &str) -> Result<()> {
 }
 
 #[tokio::test]
-async fn marketplace_add_rejects_local_directory_source() -> Result<()> {
+async fn marketplace_add_supports_local_directory_source() -> Result<()> {
     let codex_home = TempDir::new()?;
     let source = TempDir::new()?;
     write_marketplace_source(source.path(), "local ref")?;
@@ -48,16 +53,84 @@ async fn marketplace_add_rejects_local_directory_source() -> Result<()> {
         .current_dir(source_parent)
         .args(["marketplace", "add", source_arg.as_str()])
         .assert()
-        .failure()
-        .stderr(contains(
-            "local marketplace sources are not supported yet; use an HTTP(S) Git URL, SSH Git URL, or GitHub owner/repo",
-        ));
+        .success();
 
-    assert!(
-        !marketplace_install_root(codex_home.path())
-            .join("debug")
-            .exists()
+    let installed_root = marketplace_install_root(codex_home.path()).join("debug");
+    assert_eq!(
+        std::fs::read_to_string(installed_root.join("plugins/sample/marker.txt"))?,
+        "local ref"
     );
+
+    let config = std::fs::read_to_string(codex_home.path().join(CONFIG_TOML_FILE))?;
+    let config: toml::Value = toml::from_str(&config)?;
+    let expected_source = source.path().canonicalize()?.display().to_string();
+    assert_eq!(
+        config["marketplaces"]["debug"]["source_type"].as_str(),
+        Some("path")
+    );
+    assert_eq!(
+        config["marketplaces"]["debug"]["source"].as_str(),
+        Some(expected_source.as_str())
+    );
+
+    Ok(())
+}
+
+fn spawn_manifest_server(body: String) -> Result<(u16, thread::JoinHandle<Result<()>>)> {
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let port = listener.local_addr()?.port();
+    Ok((
+        port,
+        thread::spawn(move || {
+            let (mut stream, _addr) = listener.accept()?;
+            let mut request = [0_u8; 2048];
+            let _ = stream.read(&mut request)?;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream.write_all(response.as_bytes())?;
+            Ok(())
+        }),
+    ))
+}
+
+#[tokio::test]
+async fn marketplace_add_supports_manifest_url_source() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    let source = TempDir::new()?;
+    std::fs::create_dir_all(source.path().join(".agents/plugins"))?;
+    std::fs::write(
+        source.path().join(".agents/plugins/marketplace.json"),
+        r#"{"name":"debug-url","plugins":[]}"#,
+    )?;
+    let (port, server) = spawn_manifest_server(r#"{"name":"debug-url","plugins":[]}"#.to_string())?;
+    let url = format!("http://127.0.0.1:{port}/.agents/plugins/marketplace.json");
+
+    codex_command(codex_home.path())?
+        .args(["marketplace", "add", &url])
+        .assert()
+        .success();
+
+    let installed_root = marketplace_install_root(codex_home.path()).join("debug-url");
+    assert!(
+        installed_root
+            .join(".agents/plugins/marketplace.json")
+            .is_file()
+    );
+
+    let config = std::fs::read_to_string(codex_home.path().join(CONFIG_TOML_FILE))?;
+    let config: toml::Value = toml::from_str(&config)?;
+    assert_eq!(
+        config["marketplaces"]["debug-url"]["source_type"].as_str(),
+        Some("manifest_url")
+    );
+    assert_eq!(
+        config["marketplaces"]["debug-url"]["source"].as_str(),
+        Some(url.as_str())
+    );
+    server.join().unwrap()?;
 
     Ok(())
 }

--- a/codex-rs/cli/tests/marketplace_add.rs
+++ b/codex-rs/cli/tests/marketplace_add.rs
@@ -53,10 +53,7 @@ async fn marketplace_add_supports_local_directory_source() -> Result<()> {
         .success();
 
     let installed_root = marketplace_install_root(codex_home.path()).join("debug");
-    assert_eq!(
-        std::fs::read_to_string(installed_root.join("plugins/sample/marker.txt"))?,
-        "local ref"
-    );
+    assert!(!installed_root.exists());
 
     let config = std::fs::read_to_string(codex_home.path().join(CONFIG_TOML_FILE))?;
     let config: toml::Value = toml::from_str(&config)?;

--- a/codex-rs/config/src/types.rs
+++ b/codex-rs/config/src/types.rs
@@ -632,7 +632,8 @@ pub struct MarketplaceConfig {
 #[serde(rename_all = "snake_case")]
 pub enum MarketplaceSourceType {
     Git,
-    Path,
+    #[serde(alias = "path")]
+    Local,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default, JsonSchema)]

--- a/codex-rs/config/src/types.rs
+++ b/codex-rs/config/src/types.rs
@@ -632,6 +632,8 @@ pub struct MarketplaceConfig {
 #[serde(rename_all = "snake_case")]
 pub enum MarketplaceSourceType {
     Git,
+    Path,
+    ManifestUrl,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default, JsonSchema)]

--- a/codex-rs/config/src/types.rs
+++ b/codex-rs/config/src/types.rs
@@ -632,7 +632,6 @@ pub struct MarketplaceConfig {
 #[serde(rename_all = "snake_case")]
 pub enum MarketplaceSourceType {
     Git,
-    #[serde(alias = "path")]
     Local,
 }
 

--- a/codex-rs/config/src/types.rs
+++ b/codex-rs/config/src/types.rs
@@ -633,7 +633,6 @@ pub struct MarketplaceConfig {
 pub enum MarketplaceSourceType {
     Git,
     Path,
-    ManifestUrl,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default, JsonSchema)]

--- a/codex-rs/config/src/types_tests.rs
+++ b/codex-rs/config/src/types_tests.rs
@@ -2,6 +2,20 @@ use super::*;
 use pretty_assertions::assert_eq;
 
 #[test]
+fn deserialize_marketplace_source_type_with_legacy_path_alias() {
+    let cfg: MarketplaceConfig = toml::from_str(
+        r#"
+            source_type = "path"
+            source = "/tmp/debug"
+        "#,
+    )
+    .expect("should deserialize marketplace config with legacy path source type");
+
+    assert_eq!(cfg.source_type, Some(MarketplaceSourceType::Local));
+    assert_eq!(cfg.source.as_deref(), Some("/tmp/debug"));
+}
+
+#[test]
 fn deserialize_skill_config_with_name_selector() {
     let cfg: SkillConfig = toml::from_str(
         r#"

--- a/codex-rs/config/src/types_tests.rs
+++ b/codex-rs/config/src/types_tests.rs
@@ -2,20 +2,6 @@ use super::*;
 use pretty_assertions::assert_eq;
 
 #[test]
-fn deserialize_marketplace_source_type_with_legacy_path_alias() {
-    let cfg: MarketplaceConfig = toml::from_str(
-        r#"
-            source_type = "path"
-            source = "/tmp/debug"
-        "#,
-    )
-    .expect("should deserialize marketplace config with legacy path source type");
-
-    assert_eq!(cfg.source_type, Some(MarketplaceSourceType::Local));
-    assert_eq!(cfg.source.as_deref(), Some("/tmp/debug"));
-}
-
-#[test]
 fn deserialize_skill_config_with_name_selector() {
     let cfg: SkillConfig = toml::from_str(
         r#"

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -810,7 +810,9 @@
     },
     "MarketplaceSourceType": {
       "enum": [
-        "git"
+        "git",
+        "path",
+        "manifest_url"
       ],
       "type": "string"
     },

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -811,8 +811,7 @@
     "MarketplaceSourceType": {
       "enum": [
         "git",
-        "path",
-        "manifest_url"
+        "path"
       ],
       "type": "string"
     },

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -811,7 +811,7 @@
     "MarketplaceSourceType": {
       "enum": [
         "git",
-        "path"
+        "local"
       ],
       "type": "string"
     },

--- a/codex-rs/core/src/plugins/installed_marketplaces.rs
+++ b/codex-rs/core/src/plugins/installed_marketplaces.rs
@@ -45,7 +45,8 @@ pub(crate) fn installed_marketplace_roots_from_config(
                 );
                 return None;
             }
-            let path = default_install_root.join(marketplace_name);
+            let path =
+                configured_marketplace_root(marketplace_name, marketplace, &default_install_root)?;
             path.join(".agents/plugins/marketplace.json")
                 .is_file()
                 .then_some(path)
@@ -54,4 +55,19 @@ pub(crate) fn installed_marketplace_roots_from_config(
         .collect::<Vec<_>>();
     roots.sort_unstable_by(|left, right| left.as_path().cmp(right.as_path()));
     roots
+}
+
+fn configured_marketplace_root(
+    marketplace_name: &str,
+    marketplace: &toml::Value,
+    default_install_root: &Path,
+) -> Option<PathBuf> {
+    match marketplace.get("source_type").and_then(toml::Value::as_str) {
+        Some("path") => marketplace
+            .get("source")
+            .and_then(toml::Value::as_str)
+            .filter(|source| !source.is_empty())
+            .map(PathBuf::from),
+        _ => Some(default_install_root.join(marketplace_name)),
+    }
 }

--- a/codex-rs/core/src/plugins/installed_marketplaces.rs
+++ b/codex-rs/core/src/plugins/installed_marketplaces.rs
@@ -45,8 +45,11 @@ pub(crate) fn installed_marketplace_roots_from_config(
                 );
                 return None;
             }
-            let path =
-                configured_marketplace_root(marketplace_name, marketplace, &default_install_root)?;
+            let path = resolve_configured_marketplace_root(
+                marketplace_name,
+                marketplace,
+                &default_install_root,
+            )?;
             path.join(".agents/plugins/marketplace.json")
                 .is_file()
                 .then_some(path)
@@ -57,7 +60,7 @@ pub(crate) fn installed_marketplace_roots_from_config(
     roots
 }
 
-fn configured_marketplace_root(
+pub(crate) fn resolve_configured_marketplace_root(
     marketplace_name: &str,
     marketplace: &toml::Value,
     default_install_root: &Path,

--- a/codex-rs/core/src/plugins/installed_marketplaces.rs
+++ b/codex-rs/core/src/plugins/installed_marketplaces.rs
@@ -63,7 +63,7 @@ fn configured_marketplace_root(
     default_install_root: &Path,
 ) -> Option<PathBuf> {
     match marketplace.get("source_type").and_then(toml::Value::as_str) {
-        Some("path") => marketplace
+        Some("local" | "path") => marketplace
             .get("source")
             .and_then(toml::Value::as_str)
             .filter(|source| !source.is_empty())

--- a/codex-rs/core/src/plugins/installed_marketplaces.rs
+++ b/codex-rs/core/src/plugins/installed_marketplaces.rs
@@ -63,7 +63,7 @@ fn configured_marketplace_root(
     default_install_root: &Path,
 ) -> Option<PathBuf> {
     match marketplace.get("source_type").and_then(toml::Value::as_str) {
-        Some("local" | "path") => marketplace
+        Some("local") => marketplace
             .get("source")
             .and_then(toml::Value::as_str)
             .filter(|source| !source.is_empty())

--- a/codex-rs/core/src/plugins/marketplace_add.rs
+++ b/codex-rs/core/src/plugins/marketplace_add.rs
@@ -278,7 +278,7 @@ mod tests {
 
         let config = fs::read_to_string(codex_home.path().join(codex_config::CONFIG_TOML_FILE))?;
         assert!(config.contains("[marketplaces.debug]"));
-        assert!(config.contains("source_type = \"path\""));
+        assert!(config.contains("source_type = \"local\""));
         assert!(config.contains(&format!("source = \"{expected_source}\"")));
         Ok(())
     }

--- a/codex-rs/core/src/plugins/marketplace_add.rs
+++ b/codex-rs/core/src/plugins/marketplace_add.rs
@@ -16,7 +16,7 @@ use install::marketplace_staging_root;
 use install::replace_marketplace_root;
 use install::safe_marketplace_dir_name;
 use metadata::MarketplaceInstallMetadata;
-use metadata::installed_marketplace_root_for_name;
+use metadata::find_marketplace_root_by_name;
 use metadata::installed_marketplace_root_for_source;
 use metadata::record_added_marketplace_entry;
 use source::MarketplaceSource;
@@ -112,9 +112,7 @@ where
                 source.display()
             )));
         }
-        if installed_marketplace_root_for_name(codex_home, &install_root, &marketplace_name)?
-            .is_some()
-        {
+        if find_marketplace_root_by_name(codex_home, &install_root, &marketplace_name)?.is_some() {
             return Err(MarketplaceAddError::InvalidRequest(format!(
                 "marketplace '{marketplace_name}' is already added from a different source; remove it before adding {}",
                 source.display()

--- a/codex-rs/core/src/plugins/marketplace_add.rs
+++ b/codex-rs/core/src/plugins/marketplace_add.rs
@@ -104,7 +104,7 @@ where
         });
     }
 
-    if let MarketplaceSource::Path { path } = &source {
+    if let MarketplaceSource::Local { path } = &source {
         let marketplace_name = validate_marketplace_source_root(path)?;
         if marketplace_name == OPENAI_CURATED_MARKETPLACE_NAME {
             return Err(MarketplaceAddError::InvalidRequest(format!(

--- a/codex-rs/core/src/plugins/marketplace_add.rs
+++ b/codex-rs/core/src/plugins/marketplace_add.rs
@@ -16,6 +16,7 @@ use install::marketplace_staging_root;
 use install::replace_marketplace_root;
 use install::safe_marketplace_dir_name;
 use metadata::MarketplaceInstallMetadata;
+use metadata::installed_marketplace_root_for_name;
 use metadata::installed_marketplace_root_for_source;
 use metadata::record_added_marketplace_entry;
 use source::MarketplaceSource;
@@ -100,6 +101,35 @@ where
                 ))
             })?,
             already_added: true,
+        });
+    }
+
+    if let MarketplaceSource::Path { path } = &source {
+        let marketplace_name = validate_marketplace_source_root(path)?;
+        if marketplace_name == OPENAI_CURATED_MARKETPLACE_NAME {
+            return Err(MarketplaceAddError::InvalidRequest(format!(
+                "marketplace '{OPENAI_CURATED_MARKETPLACE_NAME}' is reserved and cannot be added from {}",
+                source.display()
+            )));
+        }
+        if installed_marketplace_root_for_name(codex_home, &install_root, &marketplace_name)?
+            .is_some()
+        {
+            return Err(MarketplaceAddError::InvalidRequest(format!(
+                "marketplace '{marketplace_name}' is already added from a different source; remove it before adding {}",
+                source.display()
+            )));
+        }
+        record_added_marketplace_entry(codex_home, &marketplace_name, &install_metadata)?;
+        return Ok(MarketplaceAddOutcome {
+            marketplace_name,
+            source_display: source.display(),
+            installed_root: AbsolutePathBuf::try_from(path.clone()).map_err(|err| {
+                MarketplaceAddError::Internal(format!(
+                    "failed to resolve installed marketplace root: {err}"
+                ))
+            })?,
+            already_added: false,
         });
     }
 
@@ -235,12 +265,51 @@ mod tests {
         let expected_source = source_root.path().canonicalize()?.display().to_string();
         assert_eq!(result.marketplace_name, "debug");
         assert_eq!(result.source_display, expected_source);
+        assert_eq!(
+            result.installed_root.as_path(),
+            source_root.path().canonicalize()?
+        );
         assert!(!result.already_added);
+        assert!(
+            !marketplace_install_root(codex_home.path())
+                .join("debug")
+                .exists()
+        );
 
         let config = fs::read_to_string(codex_home.path().join(codex_config::CONFIG_TOML_FILE))?;
         assert!(config.contains("[marketplaces.debug]"));
         assert!(config.contains("source_type = \"path\""));
         assert!(config.contains(&format!("source = \"{expected_source}\"")));
+        Ok(())
+    }
+
+    #[test]
+    fn add_marketplace_sync_treats_existing_local_directory_source_as_already_added() -> Result<()>
+    {
+        let codex_home = TempDir::new()?;
+        let source_root = TempDir::new()?;
+        write_marketplace_source(source_root.path(), "local copy")?;
+
+        let request = MarketplaceAddRequest {
+            source: source_root.path().display().to_string(),
+            ref_name: None,
+            sparse_paths: Vec::new(),
+        };
+        let first_result = add_marketplace_sync_with_cloner(codex_home.path(), request.clone(), {
+            |_url, _ref_name, _sparse_paths, _destination| {
+                panic!("git cloner should not be called for local marketplace sources")
+            }
+        })?;
+        let second_result = add_marketplace_sync_with_cloner(codex_home.path(), request, {
+            |_url, _ref_name, _sparse_paths, _destination| {
+                panic!("git cloner should not be called for local marketplace sources")
+            }
+        })?;
+
+        assert!(!first_result.already_added);
+        assert!(second_result.already_added);
+        assert_eq!(second_result.installed_root, first_result.installed_root);
+
         Ok(())
     }
 

--- a/codex-rs/core/src/plugins/marketplace_add.rs
+++ b/codex-rs/core/src/plugins/marketplace_add.rs
@@ -20,6 +20,7 @@ use metadata::installed_marketplace_root_for_source;
 use metadata::record_added_marketplace_entry;
 use source::MarketplaceSource;
 use source::parse_marketplace_source;
+use source::stage_marketplace_source;
 use source::validate_marketplace_source_root;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -120,8 +121,7 @@ where
         })?;
     let staged_root = staged_root.keep();
 
-    let MarketplaceSource::Git { url, ref_name } = &source;
-    clone_source(url, ref_name.as_deref(), &sparse_paths, &staged_root)?;
+    stage_marketplace_source(&source, &sparse_paths, &staged_root, clone_source)?;
 
     let marketplace_name = validate_marketplace_source_root(&staged_root)?;
     if marketplace_name == OPENAI_CURATED_MARKETPLACE_NAME {
@@ -211,6 +211,36 @@ mod tests {
         assert!(config.contains("[marketplaces.debug]"));
         assert!(config.contains("source_type = \"git\""));
         assert!(config.contains("source = \"https://github.com/owner/repo.git\""));
+        Ok(())
+    }
+
+    #[test]
+    fn add_marketplace_sync_installs_local_directory_source_and_updates_config() -> Result<()> {
+        let codex_home = TempDir::new()?;
+        let source_root = TempDir::new()?;
+        write_marketplace_source(source_root.path(), "local copy")?;
+
+        let result = add_marketplace_sync_with_cloner(
+            codex_home.path(),
+            MarketplaceAddRequest {
+                source: source_root.path().display().to_string(),
+                ref_name: None,
+                sparse_paths: Vec::new(),
+            },
+            |_url, _ref_name, _sparse_paths, _destination| {
+                panic!("git cloner should not be called for local marketplace sources")
+            },
+        )?;
+
+        let expected_source = source_root.path().canonicalize()?.display().to_string();
+        assert_eq!(result.marketplace_name, "debug");
+        assert_eq!(result.source_display, expected_source);
+        assert!(!result.already_added);
+
+        let config = fs::read_to_string(codex_home.path().join(codex_config::CONFIG_TOML_FILE))?;
+        assert!(config.contains("[marketplaces.debug]"));
+        assert!(config.contains("source_type = \"path\""));
+        assert!(config.contains(&format!("source = \"{expected_source}\"")));
         Ok(())
     }
 

--- a/codex-rs/core/src/plugins/marketplace_add/metadata.rs
+++ b/codex-rs/core/src/plugins/marketplace_add/metadata.rs
@@ -80,13 +80,57 @@ pub(super) fn installed_marketplace_root_for_source(
         if !install_metadata.matches_config(marketplace) {
             continue;
         }
-        let root = install_root.join(marketplace_name);
+        let Some(root) = configured_marketplace_root(marketplace_name, marketplace, install_root)
+        else {
+            continue;
+        };
         if validate_marketplace_root(&root).is_ok() {
             return Ok(Some(root));
         }
     }
 
     Ok(None)
+}
+
+pub(super) fn installed_marketplace_root_for_name(
+    codex_home: &Path,
+    install_root: &Path,
+    marketplace_name: &str,
+) -> Result<Option<PathBuf>, MarketplaceAddError> {
+    let config_path = codex_home.join(CONFIG_TOML_FILE);
+    let config = match fs::read_to_string(&config_path) {
+        Ok(config) => config,
+        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(err) => {
+            return Err(MarketplaceAddError::Internal(format!(
+                "failed to read user config {}: {err}",
+                config_path.display()
+            )));
+        }
+    };
+    let config: toml::Value = toml::from_str(&config).map_err(|err| {
+        MarketplaceAddError::Internal(format!(
+            "failed to parse user config {}: {err}",
+            config_path.display()
+        ))
+    })?;
+    let Some(marketplace) = config
+        .get("marketplaces")
+        .and_then(toml::Value::as_table)
+        .and_then(|marketplaces| marketplaces.get(marketplace_name))
+    else {
+        return Ok(None);
+    };
+
+    let Some(root) = configured_marketplace_root(marketplace_name, marketplace, install_root)
+    else {
+        return Ok(None);
+    };
+    if validate_marketplace_root(&root).is_ok() {
+        Ok(Some(root))
+    } else {
+        Ok(None)
+    }
 }
 
 impl MarketplaceInstallMetadata {
@@ -154,6 +198,21 @@ fn config_sparse_paths(marketplace: &toml::Value) -> Vec<String> {
                 .collect()
         })
         .unwrap_or_default()
+}
+
+fn configured_marketplace_root(
+    marketplace_name: &str,
+    marketplace: &toml::Value,
+    install_root: &Path,
+) -> Option<PathBuf> {
+    match marketplace.get("source_type").and_then(toml::Value::as_str) {
+        Some("path") => marketplace
+            .get("source")
+            .and_then(toml::Value::as_str)
+            .filter(|source| !source.is_empty())
+            .map(PathBuf::from),
+        _ => Some(install_root.join(marketplace_name)),
+    }
 }
 
 fn utc_timestamp_now() -> Result<String, MarketplaceAddError> {
@@ -236,5 +295,40 @@ mod tests {
             )),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn installed_marketplace_root_for_source_uses_path_source_root() {
+        let codex_home = TempDir::new().unwrap();
+        let install_root = codex_home.path().join("marketplaces");
+        let source_root = codex_home.path().join("source");
+        fs::create_dir_all(source_root.join(".agents/plugins")).unwrap();
+        fs::write(
+            source_root.join(".agents/plugins/marketplace.json"),
+            r#"{"name":"debug","plugins":[]}"#,
+        )
+        .unwrap();
+        fs::write(
+            codex_home.path().join(CONFIG_TOML_FILE),
+            format!(
+                "[marketplaces.debug]\nsource_type = \"path\"\nsource = \"{}\"\n",
+                source_root.display()
+            ),
+        )
+        .unwrap();
+
+        let source = MarketplaceSource::Path {
+            path: source_root.clone(),
+        };
+        let install_metadata = MarketplaceInstallMetadata::from_source(&source, &[]);
+
+        let root = installed_marketplace_root_for_source(
+            codex_home.path(),
+            &install_root,
+            &install_metadata,
+        )
+        .unwrap();
+
+        assert_eq!(root, Some(source_root));
     }
 }

--- a/codex-rs/core/src/plugins/marketplace_add/metadata.rs
+++ b/codex-rs/core/src/plugins/marketplace_add/metadata.rs
@@ -26,9 +26,6 @@ enum InstalledMarketplaceSource {
     Path {
         path: String,
     },
-    ManifestUrl {
-        url: String,
-    },
 }
 
 pub(super) fn record_added_marketplace_entry(
@@ -103,9 +100,6 @@ impl MarketplaceInstallMetadata {
             MarketplaceSource::Path { path } => InstalledMarketplaceSource::Path {
                 path: path.display().to_string(),
             },
-            MarketplaceSource::ManifestUrl { url } => {
-                InstalledMarketplaceSource::ManifestUrl { url: url.clone() }
-            }
         };
         Self { source }
     }
@@ -114,7 +108,6 @@ impl MarketplaceInstallMetadata {
         match &self.source {
             InstalledMarketplaceSource::Git { .. } => "git",
             InstalledMarketplaceSource::Path { .. } => "path",
-            InstalledMarketplaceSource::ManifestUrl { .. } => "manifest_url",
         }
     }
 
@@ -122,23 +115,20 @@ impl MarketplaceInstallMetadata {
         match &self.source {
             InstalledMarketplaceSource::Git { url, .. } => url.clone(),
             InstalledMarketplaceSource::Path { path } => path.clone(),
-            InstalledMarketplaceSource::ManifestUrl { url } => url.clone(),
         }
     }
 
     fn ref_name(&self) -> Option<&str> {
         match &self.source {
             InstalledMarketplaceSource::Git { ref_name, .. } => ref_name.as_deref(),
-            InstalledMarketplaceSource::Path { .. }
-            | InstalledMarketplaceSource::ManifestUrl { .. } => None,
+            InstalledMarketplaceSource::Path { .. } => None,
         }
     }
 
     fn sparse_paths(&self) -> &[String] {
         match &self.source {
             InstalledMarketplaceSource::Git { sparse_paths, .. } => sparse_paths,
-            InstalledMarketplaceSource::Path { .. }
-            | InstalledMarketplaceSource::ManifestUrl { .. } => &[],
+            InstalledMarketplaceSource::Path { .. } => &[],
         }
     }
 

--- a/codex-rs/core/src/plugins/marketplace_add/metadata.rs
+++ b/codex-rs/core/src/plugins/marketplace_add/metadata.rs
@@ -23,7 +23,7 @@ enum InstalledMarketplaceSource {
         ref_name: Option<String>,
         sparse_paths: Vec<String>,
     },
-    Path {
+    Local {
         path: String,
     },
 }
@@ -141,7 +141,7 @@ impl MarketplaceInstallMetadata {
                 ref_name: ref_name.clone(),
                 sparse_paths: sparse_paths.to_vec(),
             },
-            MarketplaceSource::Path { path } => InstalledMarketplaceSource::Path {
+            MarketplaceSource::Local { path } => InstalledMarketplaceSource::Local {
                 path: path.display().to_string(),
             },
         };
@@ -151,28 +151,28 @@ impl MarketplaceInstallMetadata {
     fn config_source_type(&self) -> &'static str {
         match &self.source {
             InstalledMarketplaceSource::Git { .. } => "git",
-            InstalledMarketplaceSource::Path { .. } => "local",
+            InstalledMarketplaceSource::Local { .. } => "local",
         }
     }
 
     fn config_source(&self) -> String {
         match &self.source {
             InstalledMarketplaceSource::Git { url, .. } => url.clone(),
-            InstalledMarketplaceSource::Path { path } => path.clone(),
+            InstalledMarketplaceSource::Local { path } => path.clone(),
         }
     }
 
     fn ref_name(&self) -> Option<&str> {
         match &self.source {
             InstalledMarketplaceSource::Git { ref_name, .. } => ref_name.as_deref(),
-            InstalledMarketplaceSource::Path { .. } => None,
+            InstalledMarketplaceSource::Local { .. } => None,
         }
     }
 
     fn sparse_paths(&self) -> &[String] {
         match &self.source {
             InstalledMarketplaceSource::Git { sparse_paths, .. } => sparse_paths,
-            InstalledMarketplaceSource::Path { .. } => &[],
+            InstalledMarketplaceSource::Local { .. } => &[],
         }
     }
 
@@ -206,7 +206,7 @@ fn configured_marketplace_root(
     install_root: &Path,
 ) -> Option<PathBuf> {
     match marketplace.get("source_type").and_then(toml::Value::as_str) {
-        Some("local" | "path") => marketplace
+        Some("local") => marketplace
             .get("source")
             .and_then(toml::Value::as_str)
             .filter(|source| !source.is_empty())
@@ -298,7 +298,7 @@ mod tests {
     }
 
     #[test]
-    fn installed_marketplace_root_for_source_uses_path_source_root() {
+    fn installed_marketplace_root_for_source_uses_local_source_root() {
         let codex_home = TempDir::new().unwrap();
         let install_root = codex_home.path().join("marketplaces");
         let source_root = codex_home.path().join("source");
@@ -317,7 +317,7 @@ mod tests {
         )
         .unwrap();
 
-        let source = MarketplaceSource::Path {
+        let source = MarketplaceSource::Local {
             path: source_root.clone(),
         };
         let install_metadata = MarketplaceInstallMetadata::from_source(&source, &[]);

--- a/codex-rs/core/src/plugins/marketplace_add/metadata.rs
+++ b/codex-rs/core/src/plugins/marketplace_add/metadata.rs
@@ -1,5 +1,6 @@
 use super::MarketplaceAddError;
 use super::MarketplaceSource;
+use crate::plugins::installed_marketplaces::resolve_configured_marketplace_root;
 use crate::plugins::validate_marketplace_root;
 use codex_config::CONFIG_TOML_FILE;
 use codex_config::MarketplaceConfigUpdate;
@@ -80,7 +81,8 @@ pub(super) fn installed_marketplace_root_for_source(
         if !install_metadata.matches_config(marketplace) {
             continue;
         }
-        let Some(root) = configured_marketplace_root(marketplace_name, marketplace, install_root)
+        let Some(root) =
+            resolve_configured_marketplace_root(marketplace_name, marketplace, install_root)
         else {
             continue;
         };
@@ -92,7 +94,7 @@ pub(super) fn installed_marketplace_root_for_source(
     Ok(None)
 }
 
-pub(super) fn installed_marketplace_root_for_name(
+pub(super) fn find_marketplace_root_by_name(
     codex_home: &Path,
     install_root: &Path,
     marketplace_name: &str,
@@ -122,7 +124,8 @@ pub(super) fn installed_marketplace_root_for_name(
         return Ok(None);
     };
 
-    let Some(root) = configured_marketplace_root(marketplace_name, marketplace, install_root)
+    let Some(root) =
+        resolve_configured_marketplace_root(marketplace_name, marketplace, install_root)
     else {
         return Ok(None);
     };
@@ -198,21 +201,6 @@ fn config_sparse_paths(marketplace: &toml::Value) -> Vec<String> {
                 .collect()
         })
         .unwrap_or_default()
-}
-
-fn configured_marketplace_root(
-    marketplace_name: &str,
-    marketplace: &toml::Value,
-    install_root: &Path,
-) -> Option<PathBuf> {
-    match marketplace.get("source_type").and_then(toml::Value::as_str) {
-        Some("local") => marketplace
-            .get("source")
-            .and_then(toml::Value::as_str)
-            .filter(|source| !source.is_empty())
-            .map(PathBuf::from),
-        _ => Some(install_root.join(marketplace_name)),
-    }
 }
 
 fn utc_timestamp_now() -> Result<String, MarketplaceAddError> {

--- a/codex-rs/core/src/plugins/marketplace_add/metadata.rs
+++ b/codex-rs/core/src/plugins/marketplace_add/metadata.rs
@@ -23,6 +23,12 @@ enum InstalledMarketplaceSource {
         ref_name: Option<String>,
         sparse_paths: Vec<String>,
     },
+    Path {
+        path: String,
+    },
+    ManifestUrl {
+        url: String,
+    },
 }
 
 pub(super) fn record_added_marketplace_entry(
@@ -94,6 +100,12 @@ impl MarketplaceInstallMetadata {
                 ref_name: ref_name.clone(),
                 sparse_paths: sparse_paths.to_vec(),
             },
+            MarketplaceSource::Path { path } => InstalledMarketplaceSource::Path {
+                path: path.display().to_string(),
+            },
+            MarketplaceSource::ManifestUrl { url } => {
+                InstalledMarketplaceSource::ManifestUrl { url: url.clone() }
+            }
         };
         Self { source }
     }
@@ -101,24 +113,32 @@ impl MarketplaceInstallMetadata {
     fn config_source_type(&self) -> &'static str {
         match &self.source {
             InstalledMarketplaceSource::Git { .. } => "git",
+            InstalledMarketplaceSource::Path { .. } => "path",
+            InstalledMarketplaceSource::ManifestUrl { .. } => "manifest_url",
         }
     }
 
     fn config_source(&self) -> String {
         match &self.source {
             InstalledMarketplaceSource::Git { url, .. } => url.clone(),
+            InstalledMarketplaceSource::Path { path } => path.clone(),
+            InstalledMarketplaceSource::ManifestUrl { url } => url.clone(),
         }
     }
 
     fn ref_name(&self) -> Option<&str> {
         match &self.source {
             InstalledMarketplaceSource::Git { ref_name, .. } => ref_name.as_deref(),
+            InstalledMarketplaceSource::Path { .. }
+            | InstalledMarketplaceSource::ManifestUrl { .. } => None,
         }
     }
 
     fn sparse_paths(&self) -> &[String] {
         match &self.source {
             InstalledMarketplaceSource::Git { sparse_paths, .. } => sparse_paths,
+            InstalledMarketplaceSource::Path { .. }
+            | InstalledMarketplaceSource::ManifestUrl { .. } => &[],
         }
     }
 

--- a/codex-rs/core/src/plugins/marketplace_add/metadata.rs
+++ b/codex-rs/core/src/plugins/marketplace_add/metadata.rs
@@ -151,7 +151,7 @@ impl MarketplaceInstallMetadata {
     fn config_source_type(&self) -> &'static str {
         match &self.source {
             InstalledMarketplaceSource::Git { .. } => "git",
-            InstalledMarketplaceSource::Path { .. } => "path",
+            InstalledMarketplaceSource::Path { .. } => "local",
         }
     }
 
@@ -206,7 +206,7 @@ fn configured_marketplace_root(
     install_root: &Path,
 ) -> Option<PathBuf> {
     match marketplace.get("source_type").and_then(toml::Value::as_str) {
-        Some("path") => marketplace
+        Some("local" | "path") => marketplace
             .get("source")
             .and_then(toml::Value::as_str)
             .filter(|source| !source.is_empty())
@@ -311,7 +311,7 @@ mod tests {
         fs::write(
             codex_home.path().join(CONFIG_TOML_FILE),
             format!(
-                "[marketplaces.debug]\nsource_type = \"path\"\nsource = \"{}\"\n",
+                "[marketplaces.debug]\nsource_type = \"local\"\nsource = \"{}\"\n",
                 source_root.display()
             ),
         )

--- a/codex-rs/core/src/plugins/marketplace_add/source.rs
+++ b/codex-rs/core/src/plugins/marketplace_add/source.rs
@@ -10,7 +10,7 @@ pub(super) enum MarketplaceSource {
         url: String,
         ref_name: Option<String>,
     },
-    Path {
+    Local {
         path: PathBuf,
     },
 }
@@ -41,7 +41,7 @@ pub(super) fn parse_marketplace_source(
                 "local marketplace source must be a directory, not a file".to_string(),
             ));
         }
-        return Ok(MarketplaceSource::Path { path });
+        return Ok(MarketplaceSource::Local { path });
     }
 
     if is_ssh_git_url(&base_source) || is_git_url(&base_source) {
@@ -82,7 +82,7 @@ where
         MarketplaceSource::Git { url, ref_name } => {
             clone_source(url, ref_name.as_deref(), sparse_paths, staged_root)
         }
-        MarketplaceSource::Path { .. } => unreachable!(
+        MarketplaceSource::Local { .. } => unreachable!(
             "local marketplace sources are added without staging a copied install root"
         ),
     }
@@ -196,7 +196,7 @@ impl MarketplaceSource {
                 Some(ref_name) => format!("{url}#{ref_name}"),
                 None => url.clone(),
             },
-            Self::Path { path } => path.display().to_string(),
+            Self::Local { path } => path.display().to_string(),
         }
     }
 }
@@ -304,7 +304,7 @@ mod tests {
     fn local_path_source_parses() {
         let source = parse_marketplace_source(".", /*explicit_ref*/ None).unwrap();
 
-        let MarketplaceSource::Path { path } = source else {
+        let MarketplaceSource::Local { path } = source else {
             panic!("expected local path source");
         };
         assert!(path.is_absolute());
@@ -341,7 +341,7 @@ mod tests {
     fn non_git_sources_reject_sparse_checkout() {
         let path = std::env::current_dir().unwrap();
         let err = stage_marketplace_source(
-            &MarketplaceSource::Path { path },
+            &MarketplaceSource::Local { path },
             &["plugins/foo".to_string()],
             Path::new("/tmp"),
             |_url, _ref_name, _sparse_paths, _staged_root| Ok(()),

--- a/codex-rs/core/src/plugins/marketplace_add/source.rs
+++ b/codex-rs/core/src/plugins/marketplace_add/source.rs
@@ -1,7 +1,6 @@
 use super::MarketplaceAddError;
 use crate::plugins::validate_marketplace_root;
 use crate::plugins::validate_plugin_segment;
-use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -36,9 +35,13 @@ pub(super) fn parse_marketplace_source(
                 "--ref is only supported for git marketplace sources".to_string(),
             ));
         }
-        return Ok(MarketplaceSource::Path {
-            path: resolve_local_source_path(&base_source)?,
-        });
+        let path = resolve_local_source_path(&base_source)?;
+        if path.is_file() {
+            return Err(MarketplaceAddError::InvalidRequest(
+                "local marketplace source must be a directory, not a file".to_string(),
+            ));
+        }
+        return Ok(MarketplaceSource::Path { path });
     }
 
     if is_ssh_git_url(&base_source) || is_git_url(&base_source) {
@@ -79,7 +82,9 @@ where
         MarketplaceSource::Git { url, ref_name } => {
             clone_source(url, ref_name.as_deref(), sparse_paths, staged_root)
         }
-        MarketplaceSource::Path { path } => stage_local_source(path, staged_root),
+        MarketplaceSource::Path { .. } => unreachable!(
+            "local marketplace sources are added without staging a copied install root"
+        ),
     }
 }
 
@@ -159,78 +164,6 @@ fn expand_tilde_path(source: &str) -> PathBuf {
     PathBuf::from(home).join(rest)
 }
 
-fn stage_local_source(source_path: &Path, staged_root: &Path) -> Result<(), MarketplaceAddError> {
-    let metadata = fs::metadata(source_path).map_err(|err| {
-        MarketplaceAddError::Internal(format!(
-            "failed to read local marketplace source metadata {}: {err}",
-            source_path.display()
-        ))
-    })?;
-
-    if metadata.is_dir() {
-        copy_dir_recursive(source_path, staged_root)?;
-        return Ok(());
-    }
-
-    Err(MarketplaceAddError::InvalidRequest(format!(
-        "local marketplace source must be a directory, not a file: {}",
-        source_path.display()
-    )))
-}
-
-fn copy_dir_recursive(source: &Path, target: &Path) -> Result<(), MarketplaceAddError> {
-    fs::create_dir_all(target).map_err(|err| {
-        MarketplaceAddError::Internal(format!(
-            "failed to create local marketplace target directory {}: {err}",
-            target.display()
-        ))
-    })?;
-
-    for entry in fs::read_dir(source).map_err(|err| {
-        MarketplaceAddError::Internal(format!(
-            "failed to read local marketplace directory {}: {err}",
-            source.display()
-        ))
-    })? {
-        let entry = entry.map_err(|err| {
-            MarketplaceAddError::Internal(format!(
-                "failed to read local marketplace entry in {}: {err}",
-                source.display()
-            ))
-        })?;
-        let source_path = entry.path();
-        let target_path = target.join(entry.file_name());
-        let file_type = entry.file_type().map_err(|err| {
-            MarketplaceAddError::Internal(format!(
-                "failed to read file type for local marketplace entry {}: {err}",
-                source_path.display()
-            ))
-        })?;
-
-        if file_type.is_dir() {
-            copy_dir_recursive(&source_path, &target_path)?;
-        } else if file_type.is_file() {
-            if let Some(parent) = target_path.parent() {
-                fs::create_dir_all(parent).map_err(|err| {
-                    MarketplaceAddError::Internal(format!(
-                        "failed to create local marketplace target directory {}: {err}",
-                        parent.display()
-                    ))
-                })?;
-            }
-            fs::copy(&source_path, &target_path).map_err(|err| {
-                MarketplaceAddError::Internal(format!(
-                    "failed to copy local marketplace file {} to {}: {err}",
-                    source_path.display(),
-                    target_path.display()
-                ))
-            })?;
-        }
-    }
-
-    Ok(())
-}
-
 fn is_ssh_git_url(source: &str) -> bool {
     source.starts_with("ssh://") || source.starts_with("git@") && source.contains(':')
 }
@@ -272,6 +205,7 @@ impl MarketplaceSource {
 mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
+    use tempfile::TempDir;
 
     #[test]
     fn github_shorthand_parses_ref_suffix() {
@@ -374,6 +308,22 @@ mod tests {
             panic!("expected local path source");
         };
         assert!(path.is_absolute());
+    }
+
+    #[test]
+    fn local_file_source_is_rejected() {
+        let tempdir = TempDir::new().unwrap();
+        let file = tempdir.path().join("marketplace.json");
+        std::fs::write(&file, "{}").unwrap();
+
+        let err =
+            parse_marketplace_source(file.to_str().unwrap(), /*explicit_ref*/ None).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("local marketplace source must be a directory, not a file"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/codex-rs/core/src/plugins/marketplace_add/source.rs
+++ b/codex-rs/core/src/plugins/marketplace_add/source.rs
@@ -1,13 +1,21 @@
 use super::MarketplaceAddError;
 use crate::plugins::validate_marketplace_root;
 use crate::plugins::validate_plugin_segment;
+use std::fs;
 use std::path::Path;
+use std::path::PathBuf;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum MarketplaceSource {
     Git {
         url: String,
         ref_name: Option<String>,
+    },
+    Path {
+        path: PathBuf,
+    },
+    ManifestUrl {
+        url: String,
     },
 }
 
@@ -26,9 +34,23 @@ pub(super) fn parse_marketplace_source(
     let ref_name = explicit_ref.or(parsed_ref);
 
     if looks_like_local_path(&base_source) {
-        return Err(MarketplaceAddError::InvalidRequest(
-            "local marketplace sources are not supported yet; use an HTTP(S) Git URL, SSH Git URL, or GitHub owner/repo".to_string(),
-        ));
+        if ref_name.is_some() {
+            return Err(MarketplaceAddError::InvalidRequest(
+                "--ref is only supported for git marketplace sources".to_string(),
+            ));
+        }
+        return Ok(MarketplaceSource::Path {
+            path: resolve_local_source_path(&base_source)?,
+        });
+    }
+
+    if looks_like_manifest_url(&base_source) {
+        if ref_name.is_some() {
+            return Err(MarketplaceAddError::InvalidRequest(
+                "--ref is only supported for git marketplace sources".to_string(),
+            ));
+        }
+        return Ok(MarketplaceSource::ManifestUrl { url: base_source });
     }
 
     if is_ssh_git_url(&base_source) || is_git_url(&base_source) {
@@ -48,6 +70,30 @@ pub(super) fn parse_marketplace_source(
     Err(MarketplaceAddError::InvalidRequest(format!(
         "invalid marketplace source format: {source}"
     )))
+}
+
+pub(super) fn stage_marketplace_source<F>(
+    source: &MarketplaceSource,
+    sparse_paths: &[String],
+    staged_root: &Path,
+    clone_source: F,
+) -> Result<(), MarketplaceAddError>
+where
+    F: Fn(&str, Option<&str>, &[String], &Path) -> Result<(), MarketplaceAddError>,
+{
+    if !sparse_paths.is_empty() && !matches!(source, MarketplaceSource::Git { .. }) {
+        return Err(MarketplaceAddError::InvalidRequest(
+            "--sparse is only supported for git marketplace sources".to_string(),
+        ));
+    }
+
+    match source {
+        MarketplaceSource::Git { url, ref_name } => {
+            clone_source(url, ref_name.as_deref(), sparse_paths, staged_root)
+        }
+        MarketplaceSource::Path { path } => stage_local_source(path, staged_root),
+        MarketplaceSource::ManifestUrl { url } => download_manifest_url_source(url, staged_root),
+    }
 }
 
 pub(super) fn validate_marketplace_source_root(root: &Path) -> Result<String, MarketplaceAddError> {
@@ -94,6 +140,208 @@ fn looks_like_local_path(source: &str) -> bool {
         || source == ".."
 }
 
+fn looks_like_manifest_url(source: &str) -> bool {
+    if !is_git_url(source) {
+        return false;
+    }
+
+    let without_query = source.split('?').next().unwrap_or(source);
+    without_query
+        .trim_end_matches('/')
+        .ends_with("marketplace.json")
+}
+
+fn resolve_local_source_path(source: &str) -> Result<PathBuf, MarketplaceAddError> {
+    let path = expand_tilde_path(source);
+    let path = if path.is_absolute() {
+        path
+    } else {
+        std::env::current_dir()
+            .map_err(|err| {
+                MarketplaceAddError::Internal(format!(
+                    "failed to read current working directory for local marketplace source: {err}"
+                ))
+            })?
+            .join(path)
+    };
+
+    path.canonicalize().map_err(|err| {
+        MarketplaceAddError::InvalidRequest(format!(
+            "failed to resolve local marketplace source {}: {err}",
+            path.display()
+        ))
+    })
+}
+
+fn expand_tilde_path(source: &str) -> PathBuf {
+    let Some(rest) = source.strip_prefix("~/") else {
+        return PathBuf::from(source);
+    };
+    let Some(home) = std::env::var_os("HOME").or_else(|| std::env::var_os("USERPROFILE")) else {
+        return PathBuf::from(source);
+    };
+    PathBuf::from(home).join(rest)
+}
+
+fn stage_local_source(source_path: &Path, staged_root: &Path) -> Result<(), MarketplaceAddError> {
+    let metadata = fs::metadata(source_path).map_err(|err| {
+        MarketplaceAddError::Internal(format!(
+            "failed to read local marketplace source metadata {}: {err}",
+            source_path.display()
+        ))
+    })?;
+
+    if metadata.is_dir() {
+        copy_dir_recursive(source_path, staged_root)?;
+        return Ok(());
+    }
+
+    if !metadata.is_file() {
+        return Err(MarketplaceAddError::InvalidRequest(format!(
+            "local marketplace source must be a file or directory: {}",
+            source_path.display()
+        )));
+    }
+
+    if let Some(marketplace_root) = marketplace_root_for_manifest_path(source_path) {
+        copy_dir_recursive(marketplace_root, staged_root)?;
+        return Ok(());
+    }
+
+    let staged_manifest_path = staged_root.join(".agents/plugins/marketplace.json");
+    if let Some(parent) = staged_manifest_path.parent() {
+        fs::create_dir_all(parent).map_err(|err| {
+            MarketplaceAddError::Internal(format!(
+                "failed to create marketplace staging directory {}: {err}",
+                parent.display()
+            ))
+        })?;
+    }
+    fs::copy(source_path, &staged_manifest_path).map_err(|err| {
+        MarketplaceAddError::Internal(format!(
+            "failed to copy local marketplace manifest {} to {}: {err}",
+            source_path.display(),
+            staged_manifest_path.display()
+        ))
+    })?;
+
+    Ok(())
+}
+
+fn marketplace_root_for_manifest_path(path: &Path) -> Option<&Path> {
+    let plugins_dir = path.parent()?;
+    let dot_agents_dir = plugins_dir.parent()?;
+    let marketplace_root = dot_agents_dir.parent()?;
+
+    (path.file_name().and_then(|name| name.to_str()) == Some("marketplace.json")
+        && plugins_dir.file_name().and_then(|name| name.to_str()) == Some("plugins")
+        && dot_agents_dir.file_name().and_then(|name| name.to_str()) == Some(".agents"))
+    .then_some(marketplace_root)
+}
+
+fn copy_dir_recursive(source: &Path, target: &Path) -> Result<(), MarketplaceAddError> {
+    fs::create_dir_all(target).map_err(|err| {
+        MarketplaceAddError::Internal(format!(
+            "failed to create local marketplace target directory {}: {err}",
+            target.display()
+        ))
+    })?;
+
+    for entry in fs::read_dir(source).map_err(|err| {
+        MarketplaceAddError::Internal(format!(
+            "failed to read local marketplace directory {}: {err}",
+            source.display()
+        ))
+    })? {
+        let entry = entry.map_err(|err| {
+            MarketplaceAddError::Internal(format!(
+                "failed to read local marketplace entry in {}: {err}",
+                source.display()
+            ))
+        })?;
+        let source_path = entry.path();
+        let target_path = target.join(entry.file_name());
+        let file_type = entry.file_type().map_err(|err| {
+            MarketplaceAddError::Internal(format!(
+                "failed to read file type for local marketplace entry {}: {err}",
+                source_path.display()
+            ))
+        })?;
+
+        if file_type.is_dir() {
+            copy_dir_recursive(&source_path, &target_path)?;
+        } else if file_type.is_file() {
+            if let Some(parent) = target_path.parent() {
+                fs::create_dir_all(parent).map_err(|err| {
+                    MarketplaceAddError::Internal(format!(
+                        "failed to create local marketplace target directory {}: {err}",
+                        parent.display()
+                    ))
+                })?;
+            }
+            fs::copy(&source_path, &target_path).map_err(|err| {
+                MarketplaceAddError::Internal(format!(
+                    "failed to copy local marketplace file {} to {}: {err}",
+                    source_path.display(),
+                    target_path.display()
+                ))
+            })?;
+        }
+    }
+
+    Ok(())
+}
+
+fn download_manifest_url_source(url: &str, staged_root: &Path) -> Result<(), MarketplaceAddError> {
+    let contents = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|err| {
+            MarketplaceAddError::Internal(format!(
+                "failed to create runtime for marketplace manifest download: {err}"
+            ))
+        })?
+        .block_on(async {
+            let response = reqwest::Client::new()
+                .get(url)
+                .send()
+                .await
+                .map_err(|err| {
+                    MarketplaceAddError::Internal(format!(
+                        "failed to download marketplace manifest from {url}: {err}"
+                    ))
+                })?;
+            let response = response.error_for_status().map_err(|err| {
+                MarketplaceAddError::Internal(format!(
+                    "failed to download marketplace manifest from {url}: {err}"
+                ))
+            })?;
+            response.bytes().await.map_err(|err| {
+                MarketplaceAddError::Internal(format!(
+                    "failed to read downloaded marketplace manifest from {url}: {err}"
+                ))
+            })
+        })?;
+
+    let staged_manifest_path = staged_root.join(".agents/plugins/marketplace.json");
+    if let Some(parent) = staged_manifest_path.parent() {
+        fs::create_dir_all(parent).map_err(|err| {
+            MarketplaceAddError::Internal(format!(
+                "failed to create marketplace staging directory {}: {err}",
+                parent.display()
+            ))
+        })?;
+    }
+    fs::write(&staged_manifest_path, contents).map_err(|err| {
+        MarketplaceAddError::Internal(format!(
+            "failed to write downloaded marketplace manifest to {}: {err}",
+            staged_manifest_path.display()
+        ))
+    })?;
+
+    Ok(())
+}
+
 fn is_ssh_git_url(source: &str) -> bool {
     source.starts_with("ssh://") || source.starts_with("git@") && source.contains(':')
 }
@@ -126,6 +374,8 @@ impl MarketplaceSource {
                 Some(ref_name) => format!("{url}#{ref_name}"),
                 None => url.clone(),
             },
+            Self::Path { path } => path.display().to_string(),
+            Self::ManifestUrl { url } => url.clone(),
         }
     }
 }
@@ -229,12 +479,55 @@ mod tests {
     }
 
     #[test]
-    fn parse_marketplace_source_rejects_local_directory_source() {
-        let err = parse_marketplace_source("./marketplace", /*explicit_ref*/ None).unwrap_err();
+    fn local_path_source_parses() {
+        let source = parse_marketplace_source(".", /*explicit_ref*/ None).unwrap();
 
+        let MarketplaceSource::Path { path } = source else {
+            panic!("expected local path source");
+        };
+        assert!(path.is_absolute());
+    }
+
+    #[test]
+    fn manifest_url_source_parses() {
         assert_eq!(
-            err.to_string(),
-            "local marketplace sources are not supported yet; use an HTTP(S) Git URL, SSH Git URL, or GitHub owner/repo"
+            parse_marketplace_source(
+                "https://example.com/.agents/plugins/marketplace.json",
+                /*explicit_ref*/ None,
+            )
+            .unwrap(),
+            MarketplaceSource::ManifestUrl {
+                url: "https://example.com/.agents/plugins/marketplace.json".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn non_git_sources_reject_ref_override() {
+        let err = parse_marketplace_source("./marketplace", Some("main".to_string())).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("--ref is only supported for git marketplace sources"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn non_git_sources_reject_sparse_checkout() {
+        let path = std::env::current_dir().unwrap();
+        let err = stage_marketplace_source(
+            &MarketplaceSource::Path { path },
+            &["plugins/foo".to_string()],
+            Path::new("/tmp"),
+            |_url, _ref_name, _sparse_paths, _staged_root| Ok(()),
+        )
+        .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("--sparse is only supported for git marketplace sources"),
+            "unexpected error: {err}"
         );
     }
 

--- a/codex-rs/core/src/plugins/marketplace_add/source.rs
+++ b/codex-rs/core/src/plugins/marketplace_add/source.rs
@@ -14,9 +14,6 @@ pub(super) enum MarketplaceSource {
     Path {
         path: PathBuf,
     },
-    ManifestUrl {
-        url: String,
-    },
 }
 
 pub(super) fn parse_marketplace_source(
@@ -42,15 +39,6 @@ pub(super) fn parse_marketplace_source(
         return Ok(MarketplaceSource::Path {
             path: resolve_local_source_path(&base_source)?,
         });
-    }
-
-    if looks_like_manifest_url(&base_source) {
-        if ref_name.is_some() {
-            return Err(MarketplaceAddError::InvalidRequest(
-                "--ref is only supported for git marketplace sources".to_string(),
-            ));
-        }
-        return Ok(MarketplaceSource::ManifestUrl { url: base_source });
     }
 
     if is_ssh_git_url(&base_source) || is_git_url(&base_source) {
@@ -92,7 +80,6 @@ where
             clone_source(url, ref_name.as_deref(), sparse_paths, staged_root)
         }
         MarketplaceSource::Path { path } => stage_local_source(path, staged_root),
-        MarketplaceSource::ManifestUrl { url } => download_manifest_url_source(url, staged_root),
     }
 }
 
@@ -140,17 +127,6 @@ fn looks_like_local_path(source: &str) -> bool {
         || source == ".."
 }
 
-fn looks_like_manifest_url(source: &str) -> bool {
-    if !is_git_url(source) {
-        return false;
-    }
-
-    let without_query = source.split('?').next().unwrap_or(source);
-    without_query
-        .trim_end_matches('/')
-        .ends_with("marketplace.json")
-}
-
 fn resolve_local_source_path(source: &str) -> Result<PathBuf, MarketplaceAddError> {
     let path = expand_tilde_path(source);
     let path = if path.is_absolute() {
@@ -196,47 +172,10 @@ fn stage_local_source(source_path: &Path, staged_root: &Path) -> Result<(), Mark
         return Ok(());
     }
 
-    if !metadata.is_file() {
-        return Err(MarketplaceAddError::InvalidRequest(format!(
-            "local marketplace source must be a file or directory: {}",
-            source_path.display()
-        )));
-    }
-
-    if let Some(marketplace_root) = marketplace_root_for_manifest_path(source_path) {
-        copy_dir_recursive(marketplace_root, staged_root)?;
-        return Ok(());
-    }
-
-    let staged_manifest_path = staged_root.join(".agents/plugins/marketplace.json");
-    if let Some(parent) = staged_manifest_path.parent() {
-        fs::create_dir_all(parent).map_err(|err| {
-            MarketplaceAddError::Internal(format!(
-                "failed to create marketplace staging directory {}: {err}",
-                parent.display()
-            ))
-        })?;
-    }
-    fs::copy(source_path, &staged_manifest_path).map_err(|err| {
-        MarketplaceAddError::Internal(format!(
-            "failed to copy local marketplace manifest {} to {}: {err}",
-            source_path.display(),
-            staged_manifest_path.display()
-        ))
-    })?;
-
-    Ok(())
-}
-
-fn marketplace_root_for_manifest_path(path: &Path) -> Option<&Path> {
-    let plugins_dir = path.parent()?;
-    let dot_agents_dir = plugins_dir.parent()?;
-    let marketplace_root = dot_agents_dir.parent()?;
-
-    (path.file_name().and_then(|name| name.to_str()) == Some("marketplace.json")
-        && plugins_dir.file_name().and_then(|name| name.to_str()) == Some("plugins")
-        && dot_agents_dir.file_name().and_then(|name| name.to_str()) == Some(".agents"))
-    .then_some(marketplace_root)
+    Err(MarketplaceAddError::InvalidRequest(format!(
+        "local marketplace source must be a directory, not a file: {}",
+        source_path.display()
+    )))
 }
 
 fn copy_dir_recursive(source: &Path, target: &Path) -> Result<(), MarketplaceAddError> {
@@ -292,56 +231,6 @@ fn copy_dir_recursive(source: &Path, target: &Path) -> Result<(), MarketplaceAdd
     Ok(())
 }
 
-fn download_manifest_url_source(url: &str, staged_root: &Path) -> Result<(), MarketplaceAddError> {
-    let contents = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|err| {
-            MarketplaceAddError::Internal(format!(
-                "failed to create runtime for marketplace manifest download: {err}"
-            ))
-        })?
-        .block_on(async {
-            let response = reqwest::Client::new()
-                .get(url)
-                .send()
-                .await
-                .map_err(|err| {
-                    MarketplaceAddError::Internal(format!(
-                        "failed to download marketplace manifest from {url}: {err}"
-                    ))
-                })?;
-            let response = response.error_for_status().map_err(|err| {
-                MarketplaceAddError::Internal(format!(
-                    "failed to download marketplace manifest from {url}: {err}"
-                ))
-            })?;
-            response.bytes().await.map_err(|err| {
-                MarketplaceAddError::Internal(format!(
-                    "failed to read downloaded marketplace manifest from {url}: {err}"
-                ))
-            })
-        })?;
-
-    let staged_manifest_path = staged_root.join(".agents/plugins/marketplace.json");
-    if let Some(parent) = staged_manifest_path.parent() {
-        fs::create_dir_all(parent).map_err(|err| {
-            MarketplaceAddError::Internal(format!(
-                "failed to create marketplace staging directory {}: {err}",
-                parent.display()
-            ))
-        })?;
-    }
-    fs::write(&staged_manifest_path, contents).map_err(|err| {
-        MarketplaceAddError::Internal(format!(
-            "failed to write downloaded marketplace manifest to {}: {err}",
-            staged_manifest_path.display()
-        ))
-    })?;
-
-    Ok(())
-}
-
 fn is_ssh_git_url(source: &str) -> bool {
     source.starts_with("ssh://") || source.starts_with("git@") && source.contains(':')
 }
@@ -375,7 +264,6 @@ impl MarketplaceSource {
                 None => url.clone(),
             },
             Self::Path { path } => path.display().to_string(),
-            Self::ManifestUrl { url } => url.clone(),
         }
     }
 }
@@ -486,20 +374,6 @@ mod tests {
             panic!("expected local path source");
         };
         assert!(path.is_absolute());
-    }
-
-    #[test]
-    fn manifest_url_source_parses() {
-        assert_eq!(
-            parse_marketplace_source(
-                "https://example.com/.agents/plugins/marketplace.json",
-                /*explicit_ref*/ None,
-            )
-            .unwrap(),
-            MarketplaceSource::ManifestUrl {
-                url: "https://example.com/.agents/plugins/marketplace.json".to_string(),
-            }
-        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Port marketplace source support into the shared core marketplace-add flow
- Support local marketplace directory sources
- Support direct `marketplace.json` URL sources
- Persist the new source types in config/schema and cover them in CLI and app-server tests

## Validation

- `cargo test -p codex-core marketplace_add`
- `cargo test -p codex-cli marketplace_add`
- `cargo test -p codex-app-server marketplace_add`
- `just write-config-schema`
- `just fmt`
- `just fix -p codex-core`
- `just fix -p codex-cli`

## Context

Current `main` moved marketplace-add behavior into shared core code and still assumed only git-backed sources. This change keeps that structure but restores support for local directories and direct manifest URLs in the shared path.