### PR TITLE
[codex] Implement turn-scoped hook interrupts

### DIFF
--- a/codex-rs/core/src/function_tool.rs
+++ b/codex-rs/core/src/function_tool.rs
@@ -2,6 +2,8 @@ use thiserror::Error;
 
 #[derive(Debug, Error, PartialEq)]
 pub enum FunctionCallError {
+    #[error("turn interrupted")]
+    Interrupted,
     #[error("{0}")]
     RespondToModel(String),
     #[error("LocalShellCall without call_id or id")]

--- a/codex-rs/core/src/state/mod.rs
+++ b/codex-rs/core/src/state/mod.rs
@@ -7,5 +7,6 @@ pub(crate) use session::SessionState;
 pub(crate) use turn::ActiveTurn;
 pub(crate) use turn::MailboxDeliveryPhase;
 pub(crate) use turn::RunningTask;
+pub(crate) use turn::TaskAbortState;
 pub(crate) use turn::TaskKind;
 pub(crate) use turn::TurnState;

--- a/codex-rs/core/src/state/turn.rs
+++ b/codex-rs/core/src/state/turn.rs
@@ -22,6 +22,7 @@ use crate::tasks::AnySessionTask;
 use codex_protocol::models::PermissionProfile;
 use codex_protocol::protocol::ReviewDecision;
 use codex_protocol::protocol::TokenUsage;
+use codex_protocol::protocol::TurnAbortReason;
 
 /// Metadata about the currently running turn.
 pub(crate) struct ActiveTurn {
@@ -67,6 +68,7 @@ pub(crate) enum TaskKind {
 }
 
 pub(crate) struct RunningTask {
+    pub(crate) abort_state: Arc<Mutex<TaskAbortState>>,
     pub(crate) done: Arc<Notify>,
     pub(crate) kind: TaskKind,
     pub(crate) task: Arc<dyn AnySessionTask>,
@@ -75,6 +77,30 @@ pub(crate) struct RunningTask {
     pub(crate) turn_context: Arc<TurnContext>,
     // Timer recorded when the task drops to capture the full turn duration.
     pub(crate) _timer: Option<codex_otel::Timer>,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct TaskAbortState {
+    reason: Option<TurnAbortReason>,
+    finalized: bool,
+}
+
+impl TaskAbortState {
+    pub(crate) fn request_abort(&mut self, reason: TurnAbortReason) {
+        if self.reason.is_none() {
+            self.reason = Some(reason);
+        }
+    }
+
+    pub(crate) fn take_for_finalization(&mut self) -> Option<TurnAbortReason> {
+        if self.finalized {
+            None
+        } else {
+            let reason = self.reason.clone()?;
+            self.finalized = true;
+            Some(reason)
+        }
+    }
 }
 
 impl ActiveTurn {

--- a/codex-rs/core/src/stream_events_utils.rs
+++ b/codex-rs/core/src/stream_events_utils.rs
@@ -321,6 +321,9 @@ pub(crate) async fn handle_output_item_done(
 
             output.needs_follow_up = true;
         }
+        Err(FunctionCallError::Interrupted) => {
+            return Err(CodexErr::TurnAborted);
+        }
         // A fatal error occurred; surface it back into history.
         Err(FunctionCallError::Fatal(message)) => {
             return Err(CodexErr::Fatal(message));

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -11,6 +11,7 @@ use std::time::Instant;
 
 use futures::future::BoxFuture;
 use tokio::select;
+use tokio::sync::Mutex;
 use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
@@ -29,6 +30,7 @@ use crate::hook_runtime::record_additional_contexts;
 use crate::hook_runtime::record_pending_input;
 use crate::state::ActiveTurn;
 use crate::state::RunningTask;
+use crate::state::TaskAbortState;
 use crate::state::TaskKind;
 use codex_login::AuthManager;
 use codex_models_manager::manager::ModelsManager;
@@ -281,7 +283,10 @@ impl Session {
         let session_ctx = Arc::new(SessionTaskContext::new(Arc::clone(self)));
         let ctx = Arc::clone(&turn_context);
         let task_for_run = Arc::clone(&task);
+        let task_for_abort = Arc::clone(&task);
         let task_cancellation_token = cancellation_token.child_token();
+        let abort_state = Arc::new(Mutex::new(TaskAbortState::default()));
+        let abort_state_for_run = Arc::clone(&abort_state);
         // Task-owned turn spans keep a core-owned span open for the
         // full task lifecycle after the submission dispatch span ends.
         let task_span = info_span!(
@@ -315,7 +320,17 @@ impl Session {
                     )
                     .await;
                 }
-                if !task_cancellation_token.is_cancelled() {
+                let abort_reason = {
+                    let mut abort_state = abort_state_for_run.lock().await;
+                    abort_state.take_for_finalization()
+                };
+                if let Some(reason) = abort_reason {
+                    task_for_abort
+                        .abort(Arc::clone(&session_ctx), Arc::clone(&ctx_for_finish))
+                        .await;
+                    sess.on_self_aborted_task_finished(Arc::clone(&ctx_for_finish), reason)
+                        .await;
+                } else if !task_cancellation_token.is_cancelled() {
                     // Emit completion uniformly from spawn site so all tasks share the same lifecycle.
                     sess.on_task_finished(Arc::clone(&ctx_for_finish), last_agent_message)
                         .await;
@@ -329,6 +344,7 @@ impl Session {
             .start_timer(TURN_E2E_DURATION_METRIC, &[])
             .ok();
         let running_task = RunningTask {
+            abort_state,
             done,
             handle: Arc::new(AbortOnDropHandle::new(handle)),
             kind: task_kind,
@@ -394,6 +410,33 @@ impl Session {
         if reason == TurnAbortReason::Interrupted {
             self.maybe_start_turn_for_pending_work().await;
         }
+    }
+
+    pub(crate) async fn request_turn_abort(&self, sub_id: &str, reason: TurnAbortReason) {
+        let Some((abort_state, cancellation_token, turn_context)) = ({
+            let active = self.active_turn.lock().await;
+            active
+                .as_ref()
+                .and_then(|turn| turn.tasks.get(sub_id))
+                .map(|task| {
+                    (
+                        Arc::clone(&task.abort_state),
+                        task.cancellation_token.clone(),
+                        Arc::clone(&task.turn_context),
+                    )
+                })
+        }) else {
+            return;
+        };
+
+        {
+            let mut abort_state = abort_state.lock().await;
+            abort_state.request_abort(reason);
+        }
+        cancellation_token.cancel();
+        turn_context
+            .turn_metadata_state
+            .cancel_git_enrichment_task();
     }
 
     pub async fn on_task_finished(
@@ -545,6 +588,43 @@ impl Session {
         }
     }
 
+    async fn on_self_aborted_task_finished(
+        self: &Arc<Self>,
+        turn_context: Arc<TurnContext>,
+        reason: TurnAbortReason,
+    ) {
+        let turn_state = {
+            let mut active = self.active_turn.lock().await;
+            if let Some(at) = active.as_mut()
+                && at.remove_task(&turn_context.sub_id)
+            {
+                let turn_state = Arc::clone(&at.turn_state);
+                *active = None;
+                Some(turn_state)
+            } else {
+                None
+            }
+        };
+        let should_start_turn = turn_state.is_some();
+
+        if let Some(turn_state) = turn_state {
+            let mut turn_state = turn_state.lock().await;
+            turn_state.clear_pending();
+        }
+
+        self.emit_turn_aborted(turn_context.as_ref(), reason.clone())
+            .await;
+
+        if should_start_turn && reason == TurnAbortReason::Interrupted {
+            let session = Arc::clone(self);
+            let _scheduler = tokio::task::spawn_blocking(move || {
+                tokio::runtime::Handle::current().block_on(async move {
+                    session.maybe_start_turn_for_pending_work().await;
+                });
+            });
+        }
+    }
+
     async fn take_active_turn(&self) -> Option<ActiveTurn> {
         let mut active = self.active_turn.lock().await;
         active.take()
@@ -557,7 +637,7 @@ impl Session {
             .await;
     }
 
-    pub(crate) async fn cleanup_after_interrupt(&self, turn_context: &Arc<TurnContext>) {
+    pub(crate) async fn cleanup_after_interrupt(&self, turn_context: &TurnContext) {
         if let Some(manager) = turn_context.js_repl.manager_if_initialized()
             && let Err(err) = manager.interrupt_turn_exec(&turn_context.sub_id).await
         {
@@ -565,11 +645,49 @@ impl Session {
         }
     }
 
+    async fn emit_turn_aborted(
+        self: &Arc<Self>,
+        turn_context: &TurnContext,
+        reason: TurnAbortReason,
+    ) {
+        if reason == TurnAbortReason::Interrupted {
+            self.cleanup_after_interrupt(turn_context).await;
+
+            let marker = interrupted_turn_history_marker();
+            self.record_into_history(std::slice::from_ref(&marker), turn_context)
+                .await;
+            self.persist_rollout_items(&[RolloutItem::ResponseItem(marker)])
+                .await;
+            // Ensure the marker is durably visible before emitting TurnAborted: some clients
+            // synchronously re-read the rollout on receipt of the abort event.
+            if let Err(err) = self.flush_rollout().await {
+                warn!("failed to flush interrupted-turn marker before emitting TurnAborted: {err}");
+            }
+        }
+
+        let (completed_at, duration_ms) = turn_context
+            .turn_timing_state
+            .completed_at_and_duration_ms()
+            .await;
+        let event = EventMsg::TurnAborted(TurnAbortedEvent {
+            turn_id: Some(turn_context.sub_id.clone()),
+            reason,
+            completed_at,
+            duration_ms,
+        });
+        self.send_event(turn_context, event).await;
+    }
+
     async fn handle_task_abort(self: &Arc<Self>, task: RunningTask, reason: TurnAbortReason) {
         let sub_id = task.turn_context.sub_id.clone();
-        if task.cancellation_token.is_cancelled() {
-            return;
-        }
+        let reason = {
+            let mut abort_state = task.abort_state.lock().await;
+            abort_state.request_abort(reason);
+            let Some(reason) = abort_state.take_for_finalization() else {
+                return;
+            };
+            reason
+        };
 
         trace!(task_kind = ?task.kind, sub_id, "aborting running task");
         task.cancellation_token.cancel();
@@ -592,34 +710,8 @@ impl Session {
         session_task
             .abort(session_ctx, Arc::clone(&task.turn_context))
             .await;
-
-        if reason == TurnAbortReason::Interrupted {
-            self.cleanup_after_interrupt(&task.turn_context).await;
-
-            let marker = interrupted_turn_history_marker();
-            self.record_into_history(std::slice::from_ref(&marker), task.turn_context.as_ref())
-                .await;
-            self.persist_rollout_items(&[RolloutItem::ResponseItem(marker)])
-                .await;
-            // Ensure the marker is durably visible before emitting TurnAborted: some clients
-            // synchronously re-read the rollout on receipt of the abort event.
-            if let Err(err) = self.flush_rollout().await {
-                warn!("failed to flush interrupted-turn marker before emitting TurnAborted: {err}");
-            }
-        }
-
-        let (completed_at, duration_ms) = task
-            .turn_context
-            .turn_timing_state
-            .completed_at_and_duration_ms()
+        self.emit_turn_aborted(task.turn_context.as_ref(), reason)
             .await;
-        let event = EventMsg::TurnAborted(TurnAbortedEvent {
-            turn_id: Some(task.turn_context.sub_id.clone()),
-            reason,
-            completed_at,
-            duration_ms,
-        });
-        self.send_event(task.turn_context.as_ref(), event).await;
     }
 }
 

--- a/codex-rs/core/src/tools/events.rs
+++ b/codex-rs/core/src/tools/events.rs
@@ -357,6 +357,9 @@ impl ToolEmitter {
                 let result = Err(FunctionCallError::RespondToModel(normalized));
                 (event, result)
             }
+            Err(ToolError::Interrupted) => {
+                return Err(FunctionCallError::Interrupted);
+            }
         };
         self.emit(ctx, event).await;
         result

--- a/codex-rs/core/src/tools/network_approval.rs
+++ b/codex-rs/core/src/tools/network_approval.rs
@@ -118,6 +118,7 @@ enum PendingApprovalDecision {
 enum NetworkApprovalOutcome {
     DeniedByUser,
     DeniedByPolicy(String),
+    InterruptedByPolicy(String),
 }
 
 /// Whether an allowlist miss may be reviewed instead of hard-denied.
@@ -402,13 +403,25 @@ impl NetworkApprovalService {
                     pending_approvals.remove(&key);
                     return NetworkDecision::Allow;
                 }
-                PermissionRequestDecision::Deny { message } => {
+                PermissionRequestDecision::Deny { message, interrupt } => {
                     if let Some(owner_call) = owner_call.as_ref() {
                         self.record_call_outcome(
                             &owner_call.registration_id,
-                            NetworkApprovalOutcome::DeniedByPolicy(message),
+                            if interrupt {
+                                NetworkApprovalOutcome::InterruptedByPolicy(message)
+                            } else {
+                                NetworkApprovalOutcome::DeniedByPolicy(message)
+                            },
                         )
                         .await;
+                    }
+                    if interrupt {
+                        session
+                            .request_turn_abort(
+                                &turn_context.sub_id,
+                                codex_protocol::protocol::TurnAbortReason::Interrupted,
+                            )
+                            .await;
                     }
                     pending.set_decision(PendingApprovalDecision::Deny).await;
                     let mut pending_approvals = self.pending_host_approvals.lock().await;
@@ -668,6 +681,7 @@ pub(crate) async fn finish_immediate_network_approval(
             Err(ToolError::Rejected("rejected by user".to_string()))
         }
         Some(NetworkApprovalOutcome::DeniedByPolicy(message)) => Err(ToolError::Rejected(message)),
+        Some(NetworkApprovalOutcome::InterruptedByPolicy(_message)) => Err(ToolError::Interrupted),
         None => Ok(()),
     }
 }

--- a/codex-rs/core/src/tools/orchestrator.rs
+++ b/codex-rs/core/src/tools/orchestrator.rs
@@ -386,13 +386,23 @@ impl ToolOrchestrator {
                     );
                     return Ok(ReviewDecision::Approved);
                 }
-                Some(PermissionRequestDecision::Deny { message }) => {
+                Some(PermissionRequestDecision::Deny { message, interrupt }) => {
                     telemetry.otel.tool_decision(
                         telemetry.tool_name,
                         telemetry.call_id,
                         &ReviewDecision::Denied,
                         ToolDecisionSource::Config,
                     );
+                    if interrupt {
+                        approval_ctx
+                            .session
+                            .request_turn_abort(
+                                &approval_ctx.turn.sub_id,
+                                codex_protocol::protocol::TurnAbortReason::Interrupted,
+                            )
+                            .await;
+                        return Err(ToolError::Interrupted);
+                    }
                     return Err(ToolError::Rejected(message));
                 }
                 None => {}

--- a/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
+++ b/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
@@ -396,7 +396,7 @@ impl CoreShellActionProvider {
         let approval_id = Some(Uuid::new_v4().to_string());
         let source = self.tool_name;
         let guardian_review_id = routes_approval_to_guardian(&turn).then(new_guardian_review_id);
-        Ok(stopwatch
+        stopwatch
             .pause_for(async move {
                 // 1) Run PermissionRequest hooks
                 let permission_request = PermissionRequestPayload {
@@ -414,18 +414,27 @@ impl CoreShellActionProvider {
                 .await
                 {
                     Some(PermissionRequestDecision::Allow) => {
-                        return PromptDecision {
+                        return Ok(PromptDecision {
                             decision: ReviewDecision::Approved,
                             guardian_review_id: None,
                             rejection_message: None,
-                        };
+                        });
                     }
-                    Some(PermissionRequestDecision::Deny { message }) => {
-                        return PromptDecision {
+                    Some(PermissionRequestDecision::Deny { message, interrupt }) => {
+                        if interrupt {
+                            session
+                                .request_turn_abort(
+                                    &turn.sub_id,
+                                    codex_protocol::protocol::TurnAbortReason::Interrupted,
+                                )
+                                .await;
+                            return Err(anyhow::Error::new(ToolError::Interrupted));
+                        }
+                        return Ok(PromptDecision {
                             decision: ReviewDecision::Denied,
                             guardian_review_id: None,
                             rejection_message: Some(message),
-                        };
+                        });
                     }
                     None => {}
                 }
@@ -447,11 +456,11 @@ impl CoreShellActionProvider {
                         /*retry_reason*/ None,
                     )
                     .await;
-                    return PromptDecision {
+                    return Ok(PromptDecision {
                         decision,
                         guardian_review_id,
                         rejection_message: None,
-                    };
+                    });
                 }
 
                 // 3) Fall back to regular user prompt
@@ -469,13 +478,13 @@ impl CoreShellActionProvider {
                         Some(vec![ReviewDecision::Approved, ReviewDecision::Abort]),
                     )
                     .await;
-                PromptDecision {
+                Ok(PromptDecision {
                     decision,
                     guardian_review_id: None,
                     rejection_message: None,
-                }
+                })
             })
-            .await)
+            .await
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/codex-rs/core/src/tools/sandboxing.rs
+++ b/codex-rs/core/src/tools/sandboxing.rs
@@ -35,6 +35,7 @@ use std::fmt::Debug;
 use std::hash::Hash;
 use std::path::Path;
 use std::sync::Arc;
+use thiserror::Error;
 
 #[derive(Clone, Default, Debug)]
 pub(crate) struct ApprovalStore {
@@ -318,9 +319,13 @@ pub(crate) struct ToolCtx {
     pub tool_name: String,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub(crate) enum ToolError {
+    #[error("turn interrupted")]
+    Interrupted,
+    #[error("{0}")]
     Rejected(String),
+    #[error(transparent)]
     Codex(CodexErr),
 }
 

--- a/codex-rs/hooks/schema/generated/permission-request.command.output.schema.json
+++ b/codex-rs/hooks/schema/generated/permission-request.command.output.schema.json
@@ -28,7 +28,7 @@
         },
         "interrupt": {
           "default": false,
-          "description": "Reserved for future short-circuiting semantics.\n\nPermissionRequest hooks currently fail closed if this field is `true`.",
+          "description": "When `true` on a deny decision, interrupt the current turn instead of treating the denial as a normal rejection.",
           "type": "boolean"
         },
         "message": {

--- a/codex-rs/hooks/src/engine/output_parser.rs
+++ b/codex-rs/hooks/src/engine/output_parser.rs
@@ -22,7 +22,7 @@ pub(crate) struct PreToolUseOutput {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum PermissionRequestDecision {
     Allow,
-    Deny { message: String },
+    Deny { message: String, interrupt: bool },
 }
 
 #[derive(Debug, Clone)]
@@ -302,8 +302,6 @@ fn unsupported_permission_request_hook_specific_output(
         Some("PermissionRequest hook returned unsupported updatedInput".to_string())
     } else if decision.updated_permissions.is_some() {
         Some("PermissionRequest hook returned unsupported updatedPermissions".to_string())
-    } else if decision.interrupt {
-        Some("PermissionRequest hook returned unsupported interrupt:true".to_string())
     } else {
         None
     }
@@ -320,6 +318,7 @@ fn permission_request_decision(
                 .as_deref()
                 .and_then(trimmed_reason)
                 .unwrap_or_else(|| "PermissionRequest hook denied approval".to_string()),
+            interrupt: decision.interrupt,
         },
     }
 }
@@ -421,6 +420,7 @@ mod tests {
     use pretty_assertions::assert_eq;
     use serde_json::json;
 
+    use super::PermissionRequestDecision;
     use super::parse_permission_request;
 
     #[test]
@@ -470,14 +470,15 @@ mod tests {
     }
 
     #[test]
-    fn permission_request_rejects_reserved_interrupt_field() {
+    fn permission_request_accepts_interrupt_field() {
         let parsed = parse_permission_request(
             &json!({
                 "continue": true,
                 "hookSpecificOutput": {
                     "hookEventName": "PermissionRequest",
                     "decision": {
-                        "behavior": "allow",
+                        "behavior": "deny",
+                        "message": "stop now",
                         "interrupt": true
                     }
                 }
@@ -486,9 +487,13 @@ mod tests {
         )
         .expect("permission request hook output should parse");
 
+        assert_eq!(parsed.invalid_reason, None);
         assert_eq!(
-            parsed.invalid_reason,
-            Some("PermissionRequest hook returned unsupported interrupt:true".to_string())
+            parsed.decision,
+            Some(PermissionRequestDecision::Deny {
+                message: "stop now".to_string(),
+                interrupt: true,
+            })
         );
     }
 }

--- a/codex-rs/hooks/src/events/permission_request.rs
+++ b/codex-rs/hooks/src/events/permission_request.rs
@@ -48,7 +48,7 @@ pub struct PermissionRequestRequest {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PermissionRequestDecision {
     Allow,
-    Deny { message: String },
+    Deny { message: String, interrupt: bool },
 }
 
 #[derive(Debug)]
@@ -155,9 +155,10 @@ fn resolve_permission_request_decision<'a>(
             PermissionRequestDecision::Allow => {
                 resolved_allow = Some(PermissionRequestDecision::Allow);
             }
-            PermissionRequestDecision::Deny { message } => {
+            PermissionRequestDecision::Deny { message, interrupt } => {
                 return Some(PermissionRequestDecision::Deny {
                     message: message.clone(),
+                    interrupt: *interrupt,
                 });
             }
         }
@@ -223,13 +224,17 @@ fn parse_completed(
                             output_parser::PermissionRequestDecision::Allow => {
                                 decision = Some(PermissionRequestDecision::Allow);
                             }
-                            output_parser::PermissionRequestDecision::Deny { message } => {
+                            output_parser::PermissionRequestDecision::Deny {
+                                message,
+                                interrupt,
+                            } => {
                                 status = HookRunStatus::Blocked;
                                 entries.push(HookOutputEntry {
                                     kind: HookOutputEntryKind::Feedback,
                                     text: message.clone(),
                                 });
-                                decision = Some(PermissionRequestDecision::Deny { message });
+                                decision =
+                                    Some(PermissionRequestDecision::Deny { message, interrupt });
                             }
                         }
                     }
@@ -248,7 +253,10 @@ fn parse_completed(
                         kind: HookOutputEntryKind::Feedback,
                         text: message.clone(),
                     });
-                    decision = Some(PermissionRequestDecision::Deny { message });
+                    decision = Some(PermissionRequestDecision::Deny {
+                        message,
+                        interrupt: false,
+                    });
                 } else {
                     status = HookRunStatus::Failed;
                     entries.push(HookOutputEntry {
@@ -298,6 +306,7 @@ mod tests {
             PermissionRequestDecision::Allow,
             PermissionRequestDecision::Deny {
                 message: "repo deny".to_string(),
+                interrupt: false,
             },
         ];
 
@@ -305,6 +314,7 @@ mod tests {
             resolve_permission_request_decision(decisions.iter()),
             Some(PermissionRequestDecision::Deny {
                 message: "repo deny".to_string(),
+                interrupt: false,
             })
         );
     }

--- a/codex-rs/hooks/src/schema.rs
+++ b/codex-rs/hooks/src/schema.rs
@@ -150,9 +150,8 @@ pub(crate) struct PermissionRequestDecisionWire {
     pub updated_permissions: Option<Value>,
     #[serde(default)]
     pub message: Option<String>,
-    /// Reserved for future short-circuiting semantics.
-    ///
-    /// PermissionRequest hooks currently fail closed if this field is `true`.
+    /// When `true` on a deny decision, interrupt the current turn instead of
+    /// treating the denial as a normal rejection.
     #[serde(default)]
     pub interrupt: bool,
 }


### PR DESCRIPTION
## Summary
- treat `PermissionRequest` `deny { interrupt: true }` as a turn-scoped abort request instead of a detached session interrupt
- let the running task own `TurnAborted` finalization after its future unwinds, while keeping external aborts synchronous and deterministic
- thread the new interrupt-capable deny shape through hook parsing, schema, and the shell/tool/network approval paths

## Why
The first implementation detached abort work from the hook path. That created two races: the interrupted turn could still emit `TurnComplete`, and the delayed abort could later cancel a different active turn. A follow-up refactor that called `abort_turn()` from inside the running task fixed the first race but could still start replacement work before the interrupted task had actually exited.

This version keeps the interrupt request scoped to the current turn and moves self-abort finalization into the task runner, so successor work only starts after the interrupted task has really unwound.

## Validation
- `cargo test -p codex-hooks`
- `cargo test -p codex-core tools::handlers::multi_agents::tests::multi_agent_v2_followup_task_interrupts_busy_child_without_losing_message -- --exact --nocapture`
- `cargo test -p codex-core` *(still shows two unrelated existing failures: `plugins::manager::tests::list_marketplaces_ignores_installed_roots_missing_from_config` and `tools::js_repl::tests::js_repl_imported_local_files_can_access_repl_globals` in the sandboxed environment)*
- `just fmt`
- `just fix -p codex-hooks`
- `just fix -p codex-core`