### PR TITLE
Stabilize status card width during rate-limit refresh

### DIFF
--- a/codex-rs/tui/src/status/card.rs
+++ b/codex-rs/tui/src/status/card.rs
@@ -106,6 +106,7 @@ struct StatusHistoryCell {
     forked_from: Option<String>,
     token_usage: StatusTokenUsageData,
     rate_limit_state: Arc<RwLock<StatusRateLimitState>>,
+    max_content_width: Arc<RwLock<usize>>,
 }
 
 #[cfg(test)]
@@ -336,6 +337,7 @@ impl StatusHistoryCell {
             refreshing_rate_limits,
         }));
         let agents_summary = Arc::new(RwLock::new(agents_summary));
+        let max_content_width = Arc::new(RwLock::new(0));
 
         (
             Self {
@@ -352,6 +354,7 @@ impl StatusHistoryCell {
                 token_usage,
                 agents_summary,
                 rate_limit_state: rate_limit_state.clone(),
+                max_content_width,
             },
             StatusHistoryHandle { rate_limit_state },
         )
@@ -687,7 +690,13 @@ impl HistoryCell for StatusHistoryCell {
         lines.extend(self.rate_limit_lines(&rate_limit_state, available_inner_width, &formatter));
 
         let content_width = lines.iter().map(line_display_width).max().unwrap_or(0);
-        let inner_width = content_width.min(available_inner_width);
+        #[expect(clippy::expect_used)]
+        let mut max_content_width = self
+            .max_content_width
+            .write()
+            .expect("status history max-content-width state poisoned");
+        *max_content_width = (*max_content_width).max(content_width);
+        let inner_width = (*max_content_width).min(available_inner_width);
         let truncated_lines: Vec<Line<'static>> = lines
             .into_iter()
             .map(|line| truncate_line_to_width(line, inner_width))

--- a/codex-rs/tui/src/status/tests.rs
+++ b/codex-rs/tui/src/status/tests.rs
@@ -1,5 +1,6 @@
 use super::new_status_output;
 use super::new_status_output_with_rate_limits;
+use super::new_status_output_with_rate_limits_handle;
 use super::rate_limit_snapshot_display;
 use crate::history_cell::HistoryCell;
 use crate::legacy_core::config::Config;
@@ -168,6 +169,82 @@ async fn status_snapshot_includes_reasoning_details() {
     }
     let sanitized = sanitize_directory(rendered_lines).join("\n");
     assert_snapshot!(sanitized);
+}
+
+#[tokio::test]
+async fn status_card_width_does_not_shrink_after_rate_limit_refresh() {
+    let temp_home = TempDir::new().expect("temp home");
+    let mut config = test_config(&temp_home).await;
+    config.model = Some("gpt-5.1-codex".to_string());
+    config.model_provider_id = "openai".to_string();
+    config.cwd = test_path_buf("/workspace/tests").abs();
+
+    let usage = TokenUsage::default();
+    let captured_at = chrono::Local
+        .with_ymd_and_hms(2024, 1, 2, 3, 4, 5)
+        .single()
+        .expect("timestamp");
+    let model_slug = crate::legacy_core::test_support::get_model_offline(config.model.as_deref());
+
+    let wide_snapshot = crate::status::RateLimitSnapshotDisplay {
+        limit_name: "a-very-long-non-codex-limit-name".to_string(),
+        captured_at,
+        primary: Some(crate::status::RateLimitWindowDisplay {
+            used_percent: 63.0,
+            resets_at: Some("10:30 on 20 Sep".to_string()),
+            window_minutes: Some(300),
+        }),
+        secondary: None,
+        credits: None,
+    };
+    let narrow_snapshot = crate::status::RateLimitSnapshotDisplay {
+        limit_name: "codex".to_string(),
+        captured_at,
+        primary: Some(crate::status::RateLimitWindowDisplay {
+            used_percent: 63.0,
+            resets_at: Some("10:30".to_string()),
+            window_minutes: Some(300),
+        }),
+        secondary: None,
+        credits: None,
+    };
+
+    let (composite, handle) = new_status_output_with_rate_limits_handle(
+        &config,
+        /*account_display*/ None,
+        /*token_info*/ None,
+        &usage,
+        &None,
+        /*thread_name*/ None,
+        /*forked_from*/ None,
+        &[wide_snapshot],
+        /*_plan_type*/ None,
+        captured_at,
+        &model_slug,
+        /*collaboration_mode*/ None,
+        /*reasoning_effort_override*/ None,
+        "<none>".to_string(),
+        /*refreshing_rate_limits*/ false,
+    );
+
+    let before = render_lines(&composite.display_lines(/*width*/ 120));
+    let before_width = before
+        .first()
+        .map(|line| line.chars().count())
+        .expect("status output should include a top border");
+
+    handle.finish_rate_limit_refresh(&[narrow_snapshot], captured_at);
+
+    let after = render_lines(&composite.display_lines(/*width*/ 120));
+    let after_width = after
+        .first()
+        .map(|line| line.chars().count())
+        .expect("status output should include a top border");
+
+    assert_eq!(
+        after_width, before_width,
+        "status card width should remain stable after rate-limit refresh"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
### Motivation

- Prevent visible layout jitter in the TUI `/status` card when asynchronous rate-limit updates shrink rendered rows, which caused the card width to reflow on refresh.

### Description

- Track the maximum observed content width per status card by adding a `max_content_width: Arc<RwLock<usize>>` field to `StatusHistoryCell` and initializing it during creation in `codex-rs/tui/src/status/card.rs`.
- When rendering, update `max_content_width` with the current content width and use the stored maximum (clamped to available space) as the inner width used for truncation so the card width stays monotonic across renders.
- Add a regression test `status_card_width_does_not_shrink_after_rate_limit_refresh` in `codex-rs/tui/src/status/tests.rs` that renders a wide rate-limit snapshot, refreshes to a narrower snapshot via `StatusHistoryHandle::finish_rate_limit_refresh`, and asserts the card width remains stable.

### Testing

- Ran `cargo test -p codex-tui` but the run failed in this environment because the `codex-linux-sandbox` build script requires `libcap` via `pkg-config` (build aborted with a missing `libcap.pc`/pkg-config error). (Test could not complete.)
- Ran `cargo fmt` successfully to format the workspace changes.
- Attempted `just fmt` as prescribed by repository guidelines but `just` is not installed and `cargo install just` failed due crates.io network restrictions in this environment, so `just fmt` could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_i_69de614f2c9c832e87a2616b0849305a)