### PR TITLE
[codex] Fix app-server initialized request analytics build

### DIFF
--- a/codex-rs/app-server/src/message_processor.rs
+++ b/codex-rs/app-server/src/message_processor.rs
@@ -725,6 +725,8 @@ impl MessageProcessor {
         session: Arc<ConnectionSessionState>,
         request_context: RequestContext,
     ) {
+        let connection_id = connection_request_id.connection_id;
+
         if !session.initialized() {
             let error = JSONRPCErrorError {
                 code: INVALID_REQUEST_ERROR_CODE,


### PR DESCRIPTION
Problem: PR #17372 moved initialized request handling into `dispatch_initialized_client_request`, leaving analytics code that uses `connection_id` without a local binding and breaking `codex-app-server` builds.

Solution: Restore the `connection_id` binding from `connection_request_id` before initialized request validation and analytics tracking.