### PR TITLE
Add realtime wire trace logs

### DIFF
--- a/codex-rs/codex-api/src/endpoint/mod.rs
+++ b/codex-rs/codex-api/src/endpoint/mod.rs
@@ -7,6 +7,8 @@ pub(crate) mod responses;
 pub(crate) mod responses_websocket;
 mod session;
 
+pub(crate) const REALTIME_WIRE_LOG_TARGET: &str = "codex_api::realtime::wire";
+
 pub use compact::CompactClient;
 pub use memories::MemoriesClient;
 pub use models::ModelsClient;

--- a/codex-rs/codex-api/src/endpoint/mod.rs
+++ b/codex-rs/codex-api/src/endpoint/mod.rs
@@ -7,8 +7,6 @@ pub(crate) mod responses;
 pub(crate) mod responses_websocket;
 mod session;
 
-pub(crate) const REALTIME_WIRE_LOG_TARGET: &str = "codex_api::realtime::wire";
-
 pub use compact::CompactClient;
 pub use memories::MemoriesClient;
 pub use models::ModelsClient;

--- a/codex-rs/codex-api/src/endpoint/realtime_call.rs
+++ b/codex-rs/codex-api/src/endpoint/realtime_call.rs
@@ -119,6 +119,7 @@ impl<T: HttpTransport, A: AuthProvider> RealtimeCallClient<T, A> {
         session_config: RealtimeSessionConfig,
         extra_headers: HeaderMap,
     ) -> Result<RealtimeCallResponse, ApiError> {
+        trace!(target: "codex_api::realtime_websocket::wire", "realtime call request SDP: {sdp}");
         // WebRTC can begin inference as soon as the peer connection comes up, so the initial
         // session payload is sent with call creation. The sideband WebSocket still sends its normal
         // session.update after it joins.

--- a/codex-rs/codex-api/src/endpoint/realtime_call.rs
+++ b/codex-rs/codex-api/src/endpoint/realtime_call.rs
@@ -1,5 +1,4 @@
 use crate::auth::AuthProvider;
-use crate::endpoint::REALTIME_WIRE_LOG_TARGET;
 use crate::endpoint::realtime_websocket::RealtimeSessionConfig;
 use crate::endpoint::realtime_websocket::session_update_session_json;
 use crate::endpoint::session::EndpointSession;
@@ -93,7 +92,6 @@ impl<T: HttpTransport, A: AuthProvider> RealtimeCallClient<T, A> {
         sdp: String,
         extra_headers: HeaderMap,
     ) -> Result<RealtimeCallResponse, ApiError> {
-        trace!(target: REALTIME_WIRE_LOG_TARGET, "realtime call request SDP: {sdp}");
         let resp = self
             .session
             .execute_with(
@@ -135,7 +133,6 @@ impl<T: HttpTransport, A: AuthProvider> RealtimeCallClient<T, A> {
                 session: &session,
             })
             .map_err(|err| ApiError::Stream(format!("failed to encode realtime call: {err}")))?;
-            trace!(target: REALTIME_WIRE_LOG_TARGET, "realtime call request: {body}");
             let resp = self
                 .session
                 .execute(Method::POST, Self::path(), extra_headers, Some(body))
@@ -160,11 +157,6 @@ impl<T: HttpTransport, A: AuthProvider> RealtimeCallClient<T, A> {
         body.extend_from_slice(session.as_bytes());
         body.extend_from_slice(b"\r\n");
         body.extend_from_slice(format!("--{MULTIPART_BOUNDARY}--\r\n").as_bytes());
-        trace!(
-            target: REALTIME_WIRE_LOG_TARGET,
-            "realtime call request multipart: {}",
-            String::from_utf8_lossy(&body)
-        );
 
         let resp = self
             .session
@@ -196,13 +188,11 @@ fn realtime_session_json(session_config: RealtimeSessionConfig) -> Result<Value,
 }
 
 fn decode_sdp_response(body: &[u8]) -> Result<String, ApiError> {
-    let sdp = String::from_utf8(body.to_vec()).map_err(|err| {
+    String::from_utf8(body.to_vec()).map_err(|err| {
         ApiError::Stream(format!(
             "failed to decode realtime call SDP response: {err}"
         ))
-    })?;
-    trace!(target: REALTIME_WIRE_LOG_TARGET, "realtime call response SDP: {sdp}");
-    Ok(sdp)
+    })
 }
 
 fn decode_call_id_from_location(headers: &HeaderMap) -> Result<String, ApiError> {
@@ -211,7 +201,7 @@ fn decode_call_id_from_location(headers: &HeaderMap) -> Result<String, ApiError>
         .ok_or_else(|| ApiError::Stream("realtime call response missing Location".to_string()))?
         .to_str()
         .map_err(|err| ApiError::Stream(format!("invalid realtime call Location: {err}")))?;
-    trace!(target: REALTIME_WIRE_LOG_TARGET, "realtime call response Location: {location}");
+    trace!("realtime call Location: {location}");
 
     location
         .split('?')

--- a/codex-rs/codex-api/src/endpoint/realtime_call.rs
+++ b/codex-rs/codex-api/src/endpoint/realtime_call.rs
@@ -1,4 +1,5 @@
 use crate::auth::AuthProvider;
+use crate::endpoint::REALTIME_WIRE_LOG_TARGET;
 use crate::endpoint::realtime_websocket::RealtimeSessionConfig;
 use crate::endpoint::realtime_websocket::session_update_session_json;
 use crate::endpoint::session::EndpointSession;
@@ -92,6 +93,7 @@ impl<T: HttpTransport, A: AuthProvider> RealtimeCallClient<T, A> {
         sdp: String,
         extra_headers: HeaderMap,
     ) -> Result<RealtimeCallResponse, ApiError> {
+        trace!(target: REALTIME_WIRE_LOG_TARGET, "realtime call request SDP: {sdp}");
         let resp = self
             .session
             .execute_with(
@@ -133,6 +135,7 @@ impl<T: HttpTransport, A: AuthProvider> RealtimeCallClient<T, A> {
                 session: &session,
             })
             .map_err(|err| ApiError::Stream(format!("failed to encode realtime call: {err}")))?;
+            trace!(target: REALTIME_WIRE_LOG_TARGET, "realtime call request: {body}");
             let resp = self
                 .session
                 .execute(Method::POST, Self::path(), extra_headers, Some(body))
@@ -157,6 +160,11 @@ impl<T: HttpTransport, A: AuthProvider> RealtimeCallClient<T, A> {
         body.extend_from_slice(session.as_bytes());
         body.extend_from_slice(b"\r\n");
         body.extend_from_slice(format!("--{MULTIPART_BOUNDARY}--\r\n").as_bytes());
+        trace!(
+            target: REALTIME_WIRE_LOG_TARGET,
+            "realtime call request multipart: {}",
+            String::from_utf8_lossy(&body)
+        );
 
         let resp = self
             .session
@@ -188,11 +196,13 @@ fn realtime_session_json(session_config: RealtimeSessionConfig) -> Result<Value,
 }
 
 fn decode_sdp_response(body: &[u8]) -> Result<String, ApiError> {
-    String::from_utf8(body.to_vec()).map_err(|err| {
+    let sdp = String::from_utf8(body.to_vec()).map_err(|err| {
         ApiError::Stream(format!(
             "failed to decode realtime call SDP response: {err}"
         ))
-    })
+    })?;
+    trace!(target: REALTIME_WIRE_LOG_TARGET, "realtime call response SDP: {sdp}");
+    Ok(sdp)
 }
 
 fn decode_call_id_from_location(headers: &HeaderMap) -> Result<String, ApiError> {
@@ -201,7 +211,7 @@ fn decode_call_id_from_location(headers: &HeaderMap) -> Result<String, ApiError>
         .ok_or_else(|| ApiError::Stream("realtime call response missing Location".to_string()))?
         .to_str()
         .map_err(|err| ApiError::Stream(format!("invalid realtime call Location: {err}")))?;
-    trace!("realtime call Location: {location}");
+    trace!(target: REALTIME_WIRE_LOG_TARGET, "realtime call response Location: {location}");
 
     location
         .split('?')

--- a/codex-rs/codex-api/src/endpoint/realtime_websocket/methods.rs
+++ b/codex-rs/codex-api/src/endpoint/realtime_websocket/methods.rs
@@ -78,6 +78,11 @@ impl WsStream {
                         };
                         match command {
                             WsCommand::Send { message, tx_result } => {
+                                trace!(
+                                    target: REALTIME_WIRE_LOG_TARGET,
+                                    message = ?message,
+                                    "realtime websocket request frame"
+                                );
                                 debug!("realtime websocket sending message");
                                 let result = inner.send(message).await;
                                 let should_break = result.is_err();
@@ -105,76 +110,58 @@ impl WsStream {
                         }
                     }
                     message = inner.next() => {
-                        let Some(message) = message else {
-                            break;
+                        let message = match message {
+                            Some(Ok(message)) => message,
+                            Some(Err(err)) => {
+                                error!("realtime websocket receive failed: {err}");
+                                let _ = tx_message.send(Err(err));
+                                break;
+                            }
+                            None => {
+                                break;
+                            }
                         };
+                        trace!(
+                            target: REALTIME_WIRE_LOG_TARGET,
+                            message = ?message,
+                            "realtime websocket event frame"
+                        );
                         match message {
-                            Ok(Message::Ping(payload)) => {
+                            Message::Ping(payload) => {
+                                let pong = Message::Pong(payload);
                                 trace!(
                                     target: REALTIME_WIRE_LOG_TARGET,
-                                    payload = ?payload,
-                                    payload_len = payload.len(),
-                                    "realtime websocket event ping frame"
+                                    message = ?pong,
+                                    "realtime websocket request frame"
                                 );
-                                trace!(
-                                    target: REALTIME_WIRE_LOG_TARGET,
-                                    payload = ?payload,
-                                    payload_len = payload.len(),
-                                    "realtime websocket request pong frame"
-                                );
-                                if let Err(err) = inner.send(Message::Pong(payload)).await {
+                                if let Err(err) = inner.send(pong).await {
                                     error!("realtime websocket failed to send pong: {err}");
                                     let _ = tx_message.send(Err(err));
                                     break;
                                 }
                             }
-                            Ok(Message::Pong(payload)) => {
-                                trace!(
-                                    target: REALTIME_WIRE_LOG_TARGET,
-                                    payload = ?payload,
-                                    payload_len = payload.len(),
-                                    "realtime websocket event pong frame"
-                                );
-                            }
-                            Ok(message @ (Message::Text(_)
+                            Message::Pong(_) => {}
+                            message @ (Message::Text(_)
                                 | Message::Binary(_)
                                 | Message::Close(_)
-                                | Message::Frame(_))) => {
+                                | Message::Frame(_)) => {
                                 let is_close = matches!(message, Message::Close(_));
                                 match &message {
-                                    Message::Text(_) => trace!("realtime websocket received text frame"),
+                                    Message::Text(_) => {}
                                     Message::Binary(binary) => {
-                                        trace!(
-                                            target: REALTIME_WIRE_LOG_TARGET,
-                                            payload = ?binary,
-                                            payload_len = binary.len(),
-                                            "realtime websocket event binary frame"
-                                        );
                                         error!(
                                             payload_len = binary.len(),
                                             "realtime websocket received unexpected binary frame"
                                         );
                                     }
                                     Message::Close(frame) => {
-                                        trace!(
-                                            target: REALTIME_WIRE_LOG_TARGET,
-                                            code = ?frame.as_ref().map(|frame| frame.code),
-                                            reason = ?frame.as_ref().map(|frame| frame.reason.as_str()),
-                                            "realtime websocket event close frame"
-                                        );
                                         info!(
                                             "realtime websocket received close frame: code={:?} reason={:?}",
                                             frame.as_ref().map(|frame| frame.code),
                                             frame.as_ref().map(|frame| frame.reason.as_str())
                                         );
                                     }
-                                    Message::Frame(frame) => {
-                                        trace!(
-                                            target: REALTIME_WIRE_LOG_TARGET,
-                                            frame = ?frame,
-                                            "realtime websocket event raw frame"
-                                        );
-                                    }
+                                    Message::Frame(_) => {}
                                     Message::Ping(_) | Message::Pong(_) => {}
                                 }
                                 if tx_message.send(Ok(message)).is_err() {
@@ -183,11 +170,6 @@ impl WsStream {
                                 if is_close {
                                     break;
                                 }
-                            }
-                            Err(err) => {
-                                error!("realtime websocket receive failed: {err}");
-                                let _ = tx_message.send(Err(err));
-                                break;
                             }
                         }
                     }
@@ -392,7 +374,6 @@ impl RealtimeWebsocketWriter {
             ));
         }
 
-        trace!(target: REALTIME_WIRE_LOG_TARGET, "realtime websocket request: {payload}");
         self.stream
             .send(Message::Text(payload.into()))
             .await
@@ -426,7 +407,6 @@ impl RealtimeWebsocketEvents {
 
             match msg {
                 Message::Text(text) => {
-                    trace!(target: REALTIME_WIRE_LOG_TARGET, "realtime websocket event: {text}");
                     if let Some(mut event) = parse_realtime_event(&text, self.event_parser) {
                         self.update_active_transcript(&mut event).await;
                         debug!(?event, "realtime websocket parsed event");

--- a/codex-rs/codex-api/src/endpoint/realtime_websocket/methods.rs
+++ b/codex-rs/codex-api/src/endpoint/realtime_websocket/methods.rs
@@ -1,3 +1,4 @@
+use crate::endpoint::REALTIME_WIRE_LOG_TARGET;
 use crate::endpoint::realtime_websocket::methods_common::conversation_handoff_append_message;
 use crate::endpoint::realtime_websocket::methods_common::conversation_item_create_message;
 use crate::endpoint::realtime_websocket::methods_common::normalized_session_mode;
@@ -45,8 +46,6 @@ use tracing::warn;
 use tungstenite::protocol::WebSocketConfig;
 use url::Url;
 
-const REALTIME_WIRE_LOG_TARGET: &str = "codex_api::realtime_websocket::wire";
-
 struct WsStream {
     tx_command: mpsc::Sender<WsCommand>,
     pump_task: tokio::task::JoinHandle<()>,
@@ -91,6 +90,10 @@ impl WsStream {
                                 }
                             }
                             WsCommand::Close { tx_result } => {
+                                trace!(
+                                    target: REALTIME_WIRE_LOG_TARGET,
+                                    "realtime websocket request close frame: code=None reason=None"
+                                );
                                 info!("realtime websocket sending close");
                                 let result = inner.close(None).await;
                                 if let Err(err) = &result {
@@ -107,14 +110,32 @@ impl WsStream {
                         };
                         match message {
                             Ok(Message::Ping(payload)) => {
-                                trace!(payload_len = payload.len(), "realtime websocket received ping");
+                                trace!(
+                                    target: REALTIME_WIRE_LOG_TARGET,
+                                    payload = ?payload,
+                                    payload_len = payload.len(),
+                                    "realtime websocket event ping frame"
+                                );
+                                trace!(
+                                    target: REALTIME_WIRE_LOG_TARGET,
+                                    payload = ?payload,
+                                    payload_len = payload.len(),
+                                    "realtime websocket request pong frame"
+                                );
                                 if let Err(err) = inner.send(Message::Pong(payload)).await {
                                     error!("realtime websocket failed to send pong: {err}");
                                     let _ = tx_message.send(Err(err));
                                     break;
                                 }
                             }
-                            Ok(Message::Pong(_)) => {}
+                            Ok(Message::Pong(payload)) => {
+                                trace!(
+                                    target: REALTIME_WIRE_LOG_TARGET,
+                                    payload = ?payload,
+                                    payload_len = payload.len(),
+                                    "realtime websocket event pong frame"
+                                );
+                            }
                             Ok(message @ (Message::Text(_)
                                 | Message::Binary(_)
                                 | Message::Close(_)
@@ -123,18 +144,36 @@ impl WsStream {
                                 match &message {
                                     Message::Text(_) => trace!("realtime websocket received text frame"),
                                     Message::Binary(binary) => {
+                                        trace!(
+                                            target: REALTIME_WIRE_LOG_TARGET,
+                                            payload = ?binary,
+                                            payload_len = binary.len(),
+                                            "realtime websocket event binary frame"
+                                        );
                                         error!(
                                             payload_len = binary.len(),
                                             "realtime websocket received unexpected binary frame"
                                         );
                                     }
-                                    Message::Close(frame) => info!(
-                                        "realtime websocket received close frame: code={:?} reason={:?}",
-                                        frame.as_ref().map(|frame| frame.code),
-                                        frame.as_ref().map(|frame| frame.reason.as_str())
-                                    ),
-                                    Message::Frame(_) => {
-                                        trace!("realtime websocket received raw frame");
+                                    Message::Close(frame) => {
+                                        trace!(
+                                            target: REALTIME_WIRE_LOG_TARGET,
+                                            code = ?frame.as_ref().map(|frame| frame.code),
+                                            reason = ?frame.as_ref().map(|frame| frame.reason.as_str()),
+                                            "realtime websocket event close frame"
+                                        );
+                                        info!(
+                                            "realtime websocket received close frame: code={:?} reason={:?}",
+                                            frame.as_ref().map(|frame| frame.code),
+                                            frame.as_ref().map(|frame| frame.reason.as_str())
+                                        );
+                                    }
+                                    Message::Frame(frame) => {
+                                        trace!(
+                                            target: REALTIME_WIRE_LOG_TARGET,
+                                            frame = ?frame,
+                                            "realtime websocket event raw frame"
+                                        );
                                     }
                                     Message::Ping(_) | Message::Pong(_) => {}
                                 }

--- a/codex-rs/codex-api/src/endpoint/realtime_websocket/methods.rs
+++ b/codex-rs/codex-api/src/endpoint/realtime_websocket/methods.rs
@@ -1,4 +1,3 @@
-use crate::endpoint::REALTIME_WIRE_LOG_TARGET;
 use crate::endpoint::realtime_websocket::methods_common::conversation_handoff_append_message;
 use crate::endpoint::realtime_websocket::methods_common::conversation_item_create_message;
 use crate::endpoint::realtime_websocket::methods_common::normalized_session_mode;
@@ -46,6 +45,8 @@ use tracing::warn;
 use tungstenite::protocol::WebSocketConfig;
 use url::Url;
 
+const REALTIME_WIRE_LOG_TARGET: &str = "codex_api::realtime_websocket::wire";
+
 struct WsStream {
     tx_command: mpsc::Sender<WsCommand>,
     pump_task: tokio::task::JoinHandle<()>,
@@ -61,19 +62,10 @@ enum WsCommand {
     },
 }
 
-type RealtimeWsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
-
-async fn send_ws_message(inner: &mut RealtimeWsStream, message: Message) -> Result<(), WsError> {
-    trace!(
-        target: REALTIME_WIRE_LOG_TARGET,
-        message = ?message,
-        "realtime websocket request frame"
-    );
-    inner.send(message).await
-}
-
 impl WsStream {
-    fn new(inner: RealtimeWsStream) -> (Self, mpsc::UnboundedReceiver<Result<Message, WsError>>) {
+    fn new(
+        inner: WebSocketStream<MaybeTlsStream<TcpStream>>,
+    ) -> (Self, mpsc::UnboundedReceiver<Result<Message, WsError>>) {
         let (tx_command, mut rx_command) = mpsc::channel::<WsCommand>(32);
         let (tx_message, rx_message) = mpsc::unbounded_channel::<Result<Message, WsError>>();
 
@@ -88,7 +80,7 @@ impl WsStream {
                         match command {
                             WsCommand::Send { message, tx_result } => {
                                 debug!("realtime websocket sending message");
-                                let result = send_ws_message(&mut inner, message).await;
+                                let result = inner.send(message).await;
                                 let should_break = result.is_err();
                                 if let Err(err) = &result {
                                     error!("realtime websocket send failed: {err}");
@@ -99,10 +91,6 @@ impl WsStream {
                                 }
                             }
                             WsCommand::Close { tx_result } => {
-                                trace!(
-                                    target: REALTIME_WIRE_LOG_TARGET,
-                                    "realtime websocket request close frame: code=None reason=None"
-                                );
                                 info!("realtime websocket sending close");
                                 let result = inner.close(None).await;
                                 if let Err(err) = &result {
@@ -114,54 +102,40 @@ impl WsStream {
                         }
                     }
                     message = inner.next() => {
-                        let message = match message {
-                            Some(Ok(message)) => message,
-                            Some(Err(err)) => {
-                                error!("realtime websocket receive failed: {err}");
-                                let _ = tx_message.send(Err(err));
-                                break;
-                            }
-                            None => {
-                                break;
-                            }
+                        let Some(message) = message else {
+                            break;
                         };
-                        trace!(
-                            target: REALTIME_WIRE_LOG_TARGET,
-                            message = ?message,
-                            "realtime websocket event frame"
-                        );
                         match message {
-                            Message::Ping(payload) => {
-                                if let Err(err) =
-                                    send_ws_message(&mut inner, Message::Pong(payload)).await
-                                {
+                            Ok(Message::Ping(payload)) => {
+                                trace!(payload_len = payload.len(), "realtime websocket received ping");
+                                if let Err(err) = inner.send(Message::Pong(payload)).await {
                                     error!("realtime websocket failed to send pong: {err}");
                                     let _ = tx_message.send(Err(err));
                                     break;
                                 }
                             }
-                            Message::Pong(_) => {}
-                            message @ (Message::Text(_)
+                            Ok(Message::Pong(_)) => {}
+                            Ok(message @ (Message::Text(_)
                                 | Message::Binary(_)
                                 | Message::Close(_)
-                                | Message::Frame(_)) => {
+                                | Message::Frame(_))) => {
                                 let is_close = matches!(message, Message::Close(_));
                                 match &message {
-                                    Message::Text(_) => {}
+                                    Message::Text(_) => trace!("realtime websocket received text frame"),
                                     Message::Binary(binary) => {
                                         error!(
                                             payload_len = binary.len(),
                                             "realtime websocket received unexpected binary frame"
                                         );
                                     }
-                                    Message::Close(frame) => {
-                                        info!(
-                                            "realtime websocket received close frame: code={:?} reason={:?}",
-                                            frame.as_ref().map(|frame| frame.code),
-                                            frame.as_ref().map(|frame| frame.reason.as_str())
-                                        );
+                                    Message::Close(frame) => info!(
+                                        "realtime websocket received close frame: code={:?} reason={:?}",
+                                        frame.as_ref().map(|frame| frame.code),
+                                        frame.as_ref().map(|frame| frame.reason.as_str())
+                                    ),
+                                    Message::Frame(_) => {
+                                        trace!("realtime websocket received raw frame");
                                     }
-                                    Message::Frame(_) => {}
                                     Message::Ping(_) | Message::Pong(_) => {}
                                 }
                                 if tx_message.send(Ok(message)).is_err() {
@@ -170,6 +144,11 @@ impl WsStream {
                                 if is_close {
                                     break;
                                 }
+                            }
+                            Err(err) => {
+                                error!("realtime websocket receive failed: {err}");
+                                let _ = tx_message.send(Err(err));
+                                break;
                             }
                         }
                     }
@@ -374,6 +353,7 @@ impl RealtimeWebsocketWriter {
             ));
         }
 
+        trace!(target: REALTIME_WIRE_LOG_TARGET, "realtime websocket request: {payload}");
         self.stream
             .send(Message::Text(payload.into()))
             .await
@@ -407,6 +387,7 @@ impl RealtimeWebsocketEvents {
 
             match msg {
                 Message::Text(text) => {
+                    trace!(target: REALTIME_WIRE_LOG_TARGET, "realtime websocket event: {text}");
                     if let Some(mut event) = parse_realtime_event(&text, self.event_parser) {
                         self.update_active_transcript(&mut event).await;
                         debug!(?event, "realtime websocket parsed event");

--- a/codex-rs/codex-api/src/endpoint/realtime_websocket/methods.rs
+++ b/codex-rs/codex-api/src/endpoint/realtime_websocket/methods.rs
@@ -45,6 +45,8 @@ use tracing::warn;
 use tungstenite::protocol::WebSocketConfig;
 use url::Url;
 
+const REALTIME_WIRE_LOG_TARGET: &str = "codex_api::realtime_websocket::wire";
+
 struct WsStream {
     tx_command: mpsc::Sender<WsCommand>,
     pump_task: tokio::task::JoinHandle<()>,
@@ -351,6 +353,7 @@ impl RealtimeWebsocketWriter {
             ));
         }
 
+        trace!(target: REALTIME_WIRE_LOG_TARGET, "realtime websocket request: {payload}");
         self.stream
             .send(Message::Text(payload.into()))
             .await
@@ -384,6 +387,7 @@ impl RealtimeWebsocketEvents {
 
             match msg {
                 Message::Text(text) => {
+                    trace!(target: REALTIME_WIRE_LOG_TARGET, "realtime websocket event: {text}");
                     if let Some(mut event) = parse_realtime_event(&text, self.event_parser) {
                         self.update_active_transcript(&mut event).await;
                         debug!(?event, "realtime websocket parsed event");

--- a/codex-rs/codex-api/src/endpoint/realtime_websocket/methods.rs
+++ b/codex-rs/codex-api/src/endpoint/realtime_websocket/methods.rs
@@ -61,10 +61,19 @@ enum WsCommand {
     },
 }
 
+type RealtimeWsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
+
+async fn send_ws_message(inner: &mut RealtimeWsStream, message: Message) -> Result<(), WsError> {
+    trace!(
+        target: REALTIME_WIRE_LOG_TARGET,
+        message = ?message,
+        "realtime websocket request frame"
+    );
+    inner.send(message).await
+}
+
 impl WsStream {
-    fn new(
-        inner: WebSocketStream<MaybeTlsStream<TcpStream>>,
-    ) -> (Self, mpsc::UnboundedReceiver<Result<Message, WsError>>) {
+    fn new(inner: RealtimeWsStream) -> (Self, mpsc::UnboundedReceiver<Result<Message, WsError>>) {
         let (tx_command, mut rx_command) = mpsc::channel::<WsCommand>(32);
         let (tx_message, rx_message) = mpsc::unbounded_channel::<Result<Message, WsError>>();
 
@@ -78,13 +87,8 @@ impl WsStream {
                         };
                         match command {
                             WsCommand::Send { message, tx_result } => {
-                                trace!(
-                                    target: REALTIME_WIRE_LOG_TARGET,
-                                    message = ?message,
-                                    "realtime websocket request frame"
-                                );
                                 debug!("realtime websocket sending message");
-                                let result = inner.send(message).await;
+                                let result = send_ws_message(&mut inner, message).await;
                                 let should_break = result.is_err();
                                 if let Err(err) = &result {
                                     error!("realtime websocket send failed: {err}");
@@ -128,13 +132,9 @@ impl WsStream {
                         );
                         match message {
                             Message::Ping(payload) => {
-                                let pong = Message::Pong(payload);
-                                trace!(
-                                    target: REALTIME_WIRE_LOG_TARGET,
-                                    message = ?pong,
-                                    "realtime websocket request frame"
-                                );
-                                if let Err(err) = inner.send(pong).await {
+                                if let Err(err) =
+                                    send_ws_message(&mut inner, Message::Pong(payload)).await
+                                {
                                     error!("realtime websocket failed to send pong: {err}");
                                     let _ = tx_message.send(Err(err));
                                     break;


### PR DESCRIPTION
- Add trace-only wire logging for realtime websocket request/event text payloads and the WebRTC call SDP request.
- Gate raw realtime logs behind `RUST_LOG=codex_api::realtime_websocket::wire=trace` so normal logs stay quiet.