### PR TITLE
ci: restore Linux remote-env PR tests

### DIFF
--- a/.github/scripts/run-bazel-ci.sh
+++ b/.github/scripts/run-bazel-ci.sh
@@ -251,10 +251,14 @@ else
   #   clear remote cache/execution endpoints configured in .bazelrc.
   #   https://bazel.build/reference/command-line-reference#common_options-flag--remote_cache
   #   https://bazel.build/reference/command-line-reference#common_options-flag--remote_executor
+  # --experimental_remote_downloader=:
+  #   clear the remote downloader endpoint because Bazel requires it to be used
+  #   with a gRPC remote cache.
   bazel_run_args=(
     "${bazel_args[@]}"
     --remote_cache=
     --remote_executor=
+    --experimental_remote_downloader=
   )
   if (( ${#post_config_bazel_args[@]} > 0 )); then
     bazel_run_args+=("${post_config_bazel_args[@]}")

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,9 +8,10 @@ The workflows in this directory are split so that pull requests get fast, review
   It runs Bazel `test` and Bazel `clippy` on the supported Bazel targets,
   including the generated Rust test binaries needed to lint inline `#[cfg(test)]`
   code.
-- `rust-ci.yml` keeps the Cargo-native PR checks intentionally small:
+- `rust-ci.yml` keeps a small set of supplemental PR checks intentionally small:
   - `cargo fmt --check`
   - `cargo shear`
+  - Linux remote-env smoke tests
   - `argument-comment-lint` on Linux, macOS, and Windows
   - `tools/argument-comment-lint` package tests when the lint or its workflow wiring changes
 
@@ -24,7 +25,7 @@ The workflows in this directory are split so that pull requests get fast, review
   - the full Cargo `nextest` matrix
   - release-profile Cargo builds
   - cross-platform `argument-comment-lint`
-  - Linux remote-env tests
+  - the broader Linux remote-env coverage
 
 ## Rule Of Thumb
 

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -155,6 +155,7 @@ jobs:
           run_remote_test "//codex-rs/core:core-all-test" "suite::remote_env::remote_test_env_can_connect_and_use_filesystem"
           run_remote_test "//codex-rs/core:core-all-test" "suite::apply_patch_cli::apply_patch_cli_uses_codex_self_exe_with_linux_sandbox_helper_alias"
         env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
           RUST_BACKTRACE: 1
       - name: Tear down remote test env
         if: always()

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -39,7 +39,7 @@ jobs:
           argument_comment_lint_package=false
           workflows=false
           for f in "${files[@]}"; do
-            [[ $f == codex-rs/* ]] && codex=true
+            [[ $f == codex-rs/* || $f == defs.bzl || $f == scripts/test-remote-env.sh ]] && codex=true
             [[ $f == codex-rs/* || $f == tools/argument-comment-lint/* || $f == justfile ]] && argument_comment_lint=true
             [[ $f == tools/argument-comment-lint/* || $f == .github/workflows/rust-ci.yml || $f == .github/workflows/rust-ci-full.yml ]] && argument_comment_lint_package=true
             [[ $f == .github/* ]] && workflows=true
@@ -50,7 +50,7 @@ jobs:
           echo "codex=$codex" >> "$GITHUB_OUTPUT"
           echo "workflows=$workflows" >> "$GITHUB_OUTPUT"
 
-  # --- Fast Cargo-native PR checks -------------------------------------------
+  # --- Fast PR checks --------------------------------------------------------
   general:
     name: Format / etc
     runs-on: ubuntu-24.04
@@ -84,6 +84,87 @@ jobs:
           version: 1.5.1
       - name: cargo shear
         run: cargo shear
+
+  remote_tests_linux:
+    name: Remote tests - Linux
+    runs-on:
+      group: codex-runners
+      labels: codex-linux-x64
+    timeout-minutes: 45
+    needs: changed
+    if: ${{ needs.changed.outputs.codex == 'true' || needs.changed.outputs.workflows == 'true' }}
+    defaults:
+      run:
+        working-directory: codex-rs
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Set up Bazel CI
+        uses: ./.github/actions/setup-bazel-ci
+        with:
+          target: x86_64-unknown-linux-gnu
+          install-test-prereqs: "true"
+      - name: Install Linux build dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          if command -v apt-get >/dev/null 2>&1; then
+            sudo apt-get update -y
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends pkg-config libcap-dev
+          fi
+      - name: Enable unprivileged user namespaces
+        run: |
+          sudo sysctl -w kernel.unprivileged_userns_clone=1
+          if sudo sysctl -a 2>/dev/null | grep -q '^kernel.apparmor_restrict_unprivileged_userns'; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
+      - name: Set up remote test env (Docker)
+        shell: bash
+        run: |
+          set -euo pipefail
+          export CODEX_TEST_REMOTE_ENV_CONTAINER_NAME=codex-remote-test-env
+          export CODEX_TEST_REMOTE_ENV_SKIP_CODEX_BUILD=1
+          source "${GITHUB_WORKSPACE}/scripts/test-remote-env.sh"
+          echo "CODEX_TEST_REMOTE_ENV=${CODEX_TEST_REMOTE_ENV}" >> "$GITHUB_ENV"
+      - name: Remote tests via Bazel
+        id: remote_tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd "${GITHUB_WORKSPACE}"
+
+          run_remote_test() {
+            local target="$1"
+            local test_name="$2"
+
+            "${GITHUB_WORKSPACE}/.github/scripts/run-bazel-ci.sh" \
+              --print-failed-test-logs \
+              --use-node-test-env \
+              -- \
+              test \
+              --test_env=CODEX_TEST_REMOTE_ENV="${CODEX_TEST_REMOTE_ENV}" \
+              --test_arg="${test_name}" \
+              --test_arg=--exact \
+              --test_verbose_timeout_warnings \
+              --build_metadata=COMMIT_SHA="${GITHUB_SHA}" \
+              -- \
+              "${target}"
+          }
+
+          run_remote_test "//codex-rs/core:core-unit-tests" "unified_exec::tests::unified_exec_uses_remote_exec_server_when_configured"
+          run_remote_test "//codex-rs/core:core-unit-tests" "unified_exec::tests::remote_exec_server_rejects_inherited_fd_launches"
+          run_remote_test "//codex-rs/core:core-all-test" "suite::remote_env::remote_test_env_can_connect_and_use_filesystem"
+          run_remote_test "//codex-rs/core:core-all-test" "suite::apply_patch_cli::apply_patch_cli_uses_codex_self_exe_with_linux_sandbox_helper_alias"
+        env:
+          RUST_BACKTRACE: 1
+      - name: Tear down remote test env
+        if: always()
+        shell: bash
+        run: |
+          set +e
+          if [[ "${{ steps.remote_tests.outcome }}" != "success" ]]; then
+            docker logs codex-remote-test-env || true
+          fi
+          docker rm -f codex-remote-test-env >/dev/null 2>&1 || true
 
   argument_comment_lint_package:
     name: Argument comment lint package
@@ -200,6 +281,7 @@ jobs:
         changed,
         general,
         cargo_shear,
+        remote_tests_linux,
         argument_comment_lint_package,
         argument_comment_lint_prebuilt,
       ]
@@ -212,6 +294,7 @@ jobs:
           echo "argpkg : ${{ needs.argument_comment_lint_package.result }}"
           echo "arglint: ${{ needs.argument_comment_lint_prebuilt.result }}"
           echo "general: ${{ needs.general.result }}"
+          echo "remote : ${{ needs.remote_tests_linux.result }}"
           echo "shear  : ${{ needs.cargo_shear.result }}"
 
           # If nothing relevant changed (PR touching only root README, etc.),
@@ -232,4 +315,5 @@ jobs:
           if [[ '${{ needs.changed.outputs.codex }}' == 'true' || '${{ needs.changed.outputs.workflows }}' == 'true' ]]; then
             [[ '${{ needs.general.result }}' == 'success' ]] || { echo 'general failed'; exit 1; }
             [[ '${{ needs.cargo_shear.result }}' == 'success' ]] || { echo 'cargo_shear failed'; exit 1; }
+            [[ '${{ needs.remote_tests_linux.result }}' == 'success' ]] || { echo 'remote_tests_linux failed'; exit 1; }
           fi

--- a/codex-rs/core/tests/common/test_codex.rs
+++ b/codex-rs/core/tests/common/test_codex.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
@@ -65,6 +66,8 @@ const TEST_MODEL_WITH_EXPERIMENTAL_TOOLS: &str = "test-gpt-5.1-codex";
 const REMOTE_EXEC_SERVER_START_TIMEOUT: Duration = Duration::from_secs(5);
 const REMOTE_EXEC_SERVER_POLL_INTERVAL: Duration = Duration::from_millis(25);
 static REMOTE_EXEC_SERVER_INSTANCE_COUNTER: AtomicU64 = AtomicU64::new(0);
+static SHARED_REMOTE_EXEC_SERVER: OnceLock<Result<Arc<SharedRemoteExecServer>, String>> =
+    OnceLock::new();
 
 #[derive(Debug)]
 struct RemoteExecServerProcess {
@@ -94,10 +97,11 @@ impl Drop for RemoteExecServerProcess {
     }
 }
 
-impl RemoteExecServerProcess {
-    fn register_cleanup_path(&mut self, path: &Path) {
-        self.cleanup_paths.push(path.display().to_string());
-    }
+#[derive(Debug)]
+struct SharedRemoteExecServer {
+    container_name: String,
+    listen_url: String,
+    _process: RemoteExecServerProcess,
 }
 
 #[derive(Debug)]
@@ -105,7 +109,7 @@ pub struct TestEnv {
     environment: codex_exec_server::Environment,
     cwd: AbsolutePathBuf,
     local_cwd_temp_dir: Option<Arc<TempDir>>,
-    _remote_exec_server_process: Option<RemoteExecServerProcess>,
+    shared_remote_exec_server: Option<Arc<SharedRemoteExecServer>>,
 }
 
 impl TestEnv {
@@ -117,7 +121,7 @@ impl TestEnv {
             environment,
             cwd,
             local_cwd_temp_dir: Some(local_cwd_temp_dir),
-            _remote_exec_server_process: None,
+            shared_remote_exec_server: None,
         })
     }
 
@@ -138,12 +142,27 @@ impl TestEnv {
     }
 }
 
+impl Drop for TestEnv {
+    fn drop(&mut self) {
+        if let Some(shared) = &self.shared_remote_exec_server {
+            let script = format!("rm -rf {}", self.cwd.as_path().display());
+            let _ = docker_command_capture_stdout([
+                "exec",
+                &shared.container_name,
+                "sh",
+                "-lc",
+                &script,
+            ]);
+        }
+    }
+}
+
 pub async fn test_env() -> Result<TestEnv> {
     match get_remote_test_env() {
         Some(remote_env) => {
-            let mut remote_process = start_remote_exec_server(&remote_env)?;
-            let remote_ip = remote_container_ip(&remote_env.container_name)?;
-            let websocket_url = rewrite_websocket_host(&remote_process.listen_url, &remote_ip)?;
+            let shared = shared_remote_exec_server(&remote_env)?;
+            let remote_ip = remote_container_ip(&shared.container_name)?;
+            let websocket_url = rewrite_websocket_host(&shared.listen_url, &remote_ip)?;
             let environment = codex_exec_server::Environment::create(Some(websocket_url)).await?;
             let cwd = remote_aware_cwd_path();
             environment
@@ -154,12 +173,11 @@ pub async fn test_env() -> Result<TestEnv> {
                     /*sandbox*/ None,
                 )
                 .await?;
-            remote_process.process.register_cleanup_path(cwd.as_path());
             Ok(TestEnv {
                 environment,
                 cwd,
                 local_cwd_temp_dir: None,
-                _remote_exec_server_process: Some(remote_process.process),
+                shared_remote_exec_server: Some(shared),
             })
         }
         None => TestEnv::local().await,
@@ -169,6 +187,29 @@ pub async fn test_env() -> Result<TestEnv> {
 struct RemoteExecServerStart {
     process: RemoteExecServerProcess,
     listen_url: String,
+}
+
+fn shared_remote_exec_server(remote_env: &RemoteEnvConfig) -> Result<Arc<SharedRemoteExecServer>> {
+    let result = SHARED_REMOTE_EXEC_SERVER.get_or_init(|| {
+        start_shared_remote_exec_server(remote_env)
+            .map(Arc::new)
+            .map_err(|err| format!("{err:#}"))
+    });
+
+    match result {
+        Ok(server) => Ok(Arc::clone(server)),
+        Err(err) => Err(anyhow!(err.clone())),
+    }
+}
+
+fn start_shared_remote_exec_server(remote_env: &RemoteEnvConfig) -> Result<SharedRemoteExecServer> {
+    let remote_start = start_remote_exec_server(remote_env)?;
+
+    Ok(SharedRemoteExecServer {
+        container_name: remote_env.container_name.clone(),
+        listen_url: remote_start.listen_url,
+        _process: remote_start.process,
+    })
 }
 
 fn start_remote_exec_server(remote_env: &RemoteEnvConfig) -> Result<RemoteExecServerStart> {

--- a/defs.bzl
+++ b/defs.bzl
@@ -230,6 +230,16 @@ def codex_rust_crate(
 
         maybe_deps += [name + "-build-script"]
 
+    sanitized_binaries = []
+    cargo_env = {}
+    for binary in binaries.keys():
+        sanitized_binaries.append(binary)
+        cargo_env["CARGO_BIN_EXE_" + binary] = "$(rlocationpath :%s)" % binary
+    for binary_label in extra_binaries:
+        sanitized_binaries.append(binary_label)
+        binary = Label(binary_label).name
+        cargo_env["CARGO_BIN_EXE_" + binary] = "$(rlocationpath %s)" % binary_label
+
     if lib_srcs:
         lib_rule = rust_proc_macro if proc_macro else rust_library
         lib_rule(
@@ -263,7 +273,7 @@ def codex_rust_crate(
                 "--remap-path-prefix=codex-rs=",
             ],
             rustc_env = rustc_env,
-            data = test_data_extra,
+            data = test_data_extra + sanitized_binaries,
             tags = test_tags + ["manual"],
         )
 
@@ -273,7 +283,7 @@ def codex_rust_crate(
 
         workspace_root_test(
             name = name + "-unit-tests",
-            env = test_env,
+            env = test_env | cargo_env,
             test_bin = ":" + unit_test_binary,
             workspace_root_marker = "//codex-rs/utils/cargo-bin:repo_root.marker",
             tags = test_tags,
@@ -282,13 +292,7 @@ def codex_rust_crate(
 
         maybe_deps += [name]
 
-    sanitized_binaries = []
-    cargo_env = {}
     for binary, main in binaries.items():
-        #binary = binary.replace("-", "_")
-        sanitized_binaries.append(binary)
-        cargo_env["CARGO_BIN_EXE_" + binary] = "$(rlocationpath :%s)" % binary
-
         rust_binary(
             name = binary,
             crate_name = binary.replace("-", "_"),
@@ -299,11 +303,6 @@ def codex_rust_crate(
             srcs = native.glob(["src/**/*.rs"]),
             visibility = ["//visibility:public"],
         )
-
-    for binary_label in extra_binaries:
-        sanitized_binaries.append(binary_label)
-        binary = Label(binary_label).name
-        cargo_env["CARGO_BIN_EXE_" + binary] = "$(rlocationpath %s)" % binary_label
 
     integration_test_kwargs = {}
     if integration_test_args:

--- a/scripts/test-remote-env.sh
+++ b/scripts/test-remote-env.sh
@@ -32,19 +32,21 @@ setup_remote_env() {
     return 1
   fi
 
-  if ! command -v cargo >/dev/null 2>&1; then
-    echo "cargo is required to build codex" >&2
-    return 1
-  fi
+  if [[ "${CODEX_TEST_REMOTE_ENV_SKIP_CODEX_BUILD:-0}" != "1" ]]; then
+    if ! command -v cargo >/dev/null 2>&1; then
+      echo "cargo is required to build codex" >&2
+      return 1
+    fi
 
-  (
-    cd "${REPO_ROOT}/codex-rs"
-    cargo build -p codex-cli --bin codex
-  )
+    (
+      cd "${REPO_ROOT}/codex-rs"
+      cargo build -p codex-cli --bin codex
+    )
 
-  if [[ ! -f "${codex_binary_path}" ]]; then
-    echo "codex binary not found at ${codex_binary_path}" >&2
-    return 1
+    if [[ ! -f "${codex_binary_path}" ]]; then
+      echo "codex binary not found at ${codex_binary_path}" >&2
+      return 1
+    fi
   fi
 
   docker rm -f "${container_name}" >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary
- restores a Linux remote-env smoke job to the PR `rust-ci` workflow, based on the shape from #16750
- runs targeted Bazel remote checks for unified exec, remote-env filesystem connectivity, and the existing apply_patch CLI helper-alias canary
- exposes crate `extra_binaries` to Bazel unit-test runfiles/env so unit tests can resolve the `codex` and `codex-linux-sandbox` helpers
- lets `scripts/test-remote-env.sh` skip its local Cargo build when CI is relying on Bazel-built helper binaries
- clears Bazel's remote downloader in no-BuildBuddy-key PR runs so local Bazel config does not fail before tests start

Stacked on #17837, which now reuses the remote exec-server within the codex-core test binary.

## Validation
- git diff --check
- CI is running on the updated branch
