### PR TITLE
[codex] Increase Bazel Rust test stack

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -187,6 +187,9 @@ def codex_rust_crate(
         # `codex-rs` checkout.
         "INSTA_WORKSPACE_ROOT": ".",
         "INSTA_SNAPSHOT_PATH": "src",
+        # Bazel's Rust test runner can use a smaller default thread stack than
+        # Cargo on macOS. Keep recursive async-heavy tests below the stack limit.
+        "RUST_MIN_STACK": "8388608",
     }
 
     native.filegroup(


### PR DESCRIPTION
## Summary

This separates the Bazel Rust test stack-size fix from the marketplace local-source branch.

Bazel's Rust unit-test launcher can run tests with a smaller default thread stack on macOS than the Cargo path, which caused async-heavy tests such as the guardian tests to overflow the stack in CI. Setting `RUST_MIN_STACK=8388608` for Bazel Rust unit tests gives the test harness enough stack headroom without changing production behavior.

## Validation

- `bazel test --config=ci --test_tag_filters=-argument-comment-lint --test_output=errors //codex-rs/core:core-unit-tests`
