### PR TITLE
Fix clippy warnings in external agent config migration

### DIFF
--- a/codex-rs/core/src/external_agent_config.rs
+++ b/codex-rs/core/src/external_agent_config.rs
@@ -3,7 +3,6 @@ use crate::plugins::PluginId;
 use crate::plugins::PluginInstallRequest;
 use crate::plugins::PluginsManager;
 use crate::plugins::add_marketplace;
-use codex_utils_absolute_path::AbsolutePathBuf;
 use serde_json::Value as JsonValue;
 use std::collections::BTreeMap;
 use std::collections::HashSet;

--- a/codex-rs/core/src/external_agent_config.rs
+++ b/codex-rs/core/src/external_agent_config.rs
@@ -185,7 +185,7 @@ impl ExternalAgentConfigService {
             |repo_root| repo_root.join(".codex").join("config.toml"),
         );
         if let Some(settings) = settings.as_ref() {
-            let migrated = build_config_from_external(&settings)?;
+            let migrated = build_config_from_external(settings)?;
             if !is_empty_toml_table(&migrated) {
                 let mut should_include = true;
                 if target_config.exists() {
@@ -352,23 +352,12 @@ impl ExternalAgentConfigService {
             let add_marketplace_outcome = add_marketplace(self.codex_home.clone(), request).await;
             let marketplace_path = match add_marketplace_outcome {
                 Ok(add_marketplace_outcome) => {
-                    match AbsolutePathBuf::try_from(
-                        add_marketplace_outcome
-                            .installed_root
-                            .join(INSTALLED_MARKETPLACE_MANIFEST_RELATIVE_PATH),
-                    ) {
-                        Ok(path) => {
-                            outcome
-                                .succeeded_marketplaces
-                                .push(marketplace_name.clone());
-                            path
-                        }
-                        Err(_) => {
-                            outcome.failed_marketplaces.push(marketplace_name);
-                            outcome.failed_plugin_ids.extend(plugin_ids);
-                            continue;
-                        }
-                    }
+                    outcome
+                        .succeeded_marketplaces
+                        .push(marketplace_name.clone());
+                    add_marketplace_outcome
+                        .installed_root
+                        .join(INSTALLED_MARKETPLACE_MANIFEST_RELATIVE_PATH)
                 }
                 Err(_) => {
                     outcome.failed_marketplaces.push(marketplace_name);


### PR DESCRIPTION
Fix clippy warnings in external agent config migration

```
error: this expression creates a reference which is immediately dereferenced by the compiler
   --> core/src/external_agent_config.rs:188:55
    |
188 |             let migrated = build_config_from_external(&settings)?;
    |                                                       ^^^^^^^^^ help: change this to: `settings`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#needless_borrow
    = note: requested on the command line with `-D clippy::needless-borrow`

error: useless conversion to the same type: `codex_utils_absolute_path::AbsolutePathBuf`
   --> core/src/external_agent_config.rs:355:27
    |
355 |                       match AbsolutePathBuf::try_from(
    |  ___________________________^
356 | |                         add_marketplace_outcome
357 | |                             .installed_root
358 | |                             .join(INSTALLED_MARKETPLACE_MANIFEST_RELATIVE_PATH),
359 | |                     ) {
    | |_____________________^
    |
    = help: consider removing `AbsolutePathBuf::try_from()`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#useless_conversion
    = note: `-D clippy::useless-conversion` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::useless_conversion)]`

error: aborting due to 2 previous errors
```