### PR TITLE
Add metadata to turn analytics

### DIFF
--- a/codex-rs/analytics/src/analytics_client_tests.rs
+++ b/codex-rs/analytics/src/analytics_client_tests.rs
@@ -2165,6 +2165,10 @@ async fn turn_lifecycle_includes_git_metadata_when_recorded() {
     let mut associated_remote_urls = BTreeMap::new();
     associated_remote_urls.insert(
         "origin".to_string(),
+        "https://user:placeholder@example.com/openai/codex.git?credential=placeholder".to_string(),
+    );
+    associated_remote_urls.insert(
+        "upstream".to_string(),
         "git@github.com:openai/codex.git".to_string(),
     );
     let mut git_workspaces = BTreeMap::new();
@@ -2209,7 +2213,8 @@ async fn turn_lifecycle_includes_git_metadata_when_recorded() {
         json!({
             "/workspace/codex": {
                 "associated_remote_urls": {
-                    "origin": "git@github.com:openai/codex.git"
+                    "origin": "https://example.com/openai/codex.git",
+                    "upstream": "github.com:openai/codex.git"
                 },
                 "latest_git_commit_hash": "abc123",
                 "has_changes": true

--- a/codex-rs/analytics/src/analytics_client_tests.rs
+++ b/codex-rs/analytics/src/analytics_client_tests.rs
@@ -48,6 +48,8 @@ use crate::facts::SkillInvokedInput;
 use crate::facts::SubAgentThreadStartedInput;
 use crate::facts::ThreadInitializationMode;
 use crate::facts::TrackEventsContext;
+use crate::facts::TurnGitMetadataFact;
+use crate::facts::TurnGitWorkspaceMetadata;
 use crate::facts::TurnResolvedConfigFact;
 use crate::facts::TurnStatus;
 use crate::facts::TurnSteerRequestError;
@@ -105,6 +107,7 @@ use codex_utils_absolute_path::test_support::PathBufExt;
 use codex_utils_absolute_path::test_support::test_path_buf;
 use pretty_assertions::assert_eq;
 use serde_json::json;
+use std::collections::BTreeMap;
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -1771,6 +1774,7 @@ fn turn_event_serializes_expected_shape() {
             subagent_tool_call_count: None,
             web_search_count: None,
             image_generation_count: None,
+            git_workspaces: None,
             input_tokens: None,
             cached_input_tokens: None,
             output_tokens: None,
@@ -1832,6 +1836,7 @@ fn turn_event_serializes_expected_shape() {
                 "subagent_tool_call_count": null,
                 "web_search_count": null,
                 "image_generation_count": null,
+                "git_workspaces": null,
                 "input_tokens": null,
                 "cached_input_tokens": null,
                 "output_tokens": null,
@@ -2140,6 +2145,77 @@ async fn turn_lifecycle_emits_turn_event() {
         json!(13)
     );
     assert_eq!(payload["event_params"]["total_tokens"], json!(321));
+}
+
+#[tokio::test]
+async fn turn_lifecycle_includes_git_metadata_when_recorded() {
+    let mut reducer = AnalyticsReducer::default();
+    let mut out = Vec::new();
+
+    ingest_turn_prerequisites(
+        &mut reducer,
+        &mut out,
+        /*include_initialize*/ true,
+        /*include_resolved_config*/ true,
+        /*include_started*/ true,
+        /*include_token_usage*/ false,
+    )
+    .await;
+
+    let mut associated_remote_urls = BTreeMap::new();
+    associated_remote_urls.insert(
+        "origin".to_string(),
+        "git@github.com:openai/codex.git".to_string(),
+    );
+    let mut git_workspaces = BTreeMap::new();
+    git_workspaces.insert(
+        "/workspace/codex".to_string(),
+        TurnGitWorkspaceMetadata {
+            associated_remote_urls: Some(associated_remote_urls),
+            latest_git_commit_hash: Some("abc123".to_string()),
+            has_changes: Some(true),
+        },
+    );
+    reducer
+        .ingest(
+            AnalyticsFact::Custom(CustomAnalyticsFact::TurnGitMetadata(Box::new(
+                TurnGitMetadataFact {
+                    turn_id: "turn-2".to_string(),
+                    thread_id: "thread-2".to_string(),
+                    git_workspaces,
+                },
+            ))),
+            &mut out,
+        )
+        .await;
+    assert!(out.is_empty());
+
+    reducer
+        .ingest(
+            AnalyticsFact::Notification(Box::new(sample_turn_completed_notification(
+                "thread-2",
+                "turn-2",
+                AppServerTurnStatus::Completed,
+                /*codex_error_info*/ None,
+            ))),
+            &mut out,
+        )
+        .await;
+
+    assert_eq!(out.len(), 1);
+    let payload = serde_json::to_value(&out[0]).expect("serialize turn event");
+    assert_eq!(
+        payload["event_params"]["git_workspaces"],
+        json!({
+            "/workspace/codex": {
+                "associated_remote_urls": {
+                    "origin": "git@github.com:openai/codex.git"
+                },
+                "latest_git_commit_hash": "abc123",
+                "has_changes": true
+            }
+        })
+    );
 }
 
 #[tokio::test]

--- a/codex-rs/analytics/src/client.rs
+++ b/codex-rs/analytics/src/client.rs
@@ -18,6 +18,7 @@ use crate::facts::SkillInvocation;
 use crate::facts::SkillInvokedInput;
 use crate::facts::SubAgentThreadStartedInput;
 use crate::facts::TrackEventsContext;
+use crate::facts::TurnGitMetadataFact;
 use crate::facts::TurnResolvedConfigFact;
 use crate::facts::TurnTokenUsageFact;
 use crate::reducer::AnalyticsReducer;
@@ -227,6 +228,12 @@ impl AnalyticsEventsClient {
 
     pub fn track_turn_token_usage(&self, fact: TurnTokenUsageFact) {
         self.record_fact(AnalyticsFact::Custom(CustomAnalyticsFact::TurnTokenUsage(
+            Box::new(fact),
+        )));
+    }
+
+    pub fn track_turn_git_metadata(&self, fact: TurnGitMetadataFact) {
+        self.record_fact(AnalyticsFact::Custom(CustomAnalyticsFact::TurnGitMetadata(
             Box::new(fact),
         )));
     }

--- a/codex-rs/analytics/src/events.rs
+++ b/codex-rs/analytics/src/events.rs
@@ -14,6 +14,7 @@ use crate::facts::PluginState;
 use crate::facts::SubAgentThreadStartedInput;
 use crate::facts::ThreadInitializationMode;
 use crate::facts::TrackEventsContext;
+use crate::facts::TurnGitWorkspaceMetadata;
 use crate::facts::TurnStatus;
 use crate::facts::TurnSteerRejectionReason;
 use crate::facts::TurnSteerResult;
@@ -35,6 +36,7 @@ use codex_protocol::protocol::HookSource;
 use codex_protocol::protocol::SubAgentSource;
 use codex_protocol::protocol::TokenUsage;
 use serde::Serialize;
+use std::collections::BTreeMap;
 
 #[derive(Clone, Copy, Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -492,6 +494,7 @@ pub(crate) struct CodexTurnEventParams {
     pub(crate) subagent_tool_call_count: Option<usize>,
     pub(crate) web_search_count: Option<usize>,
     pub(crate) image_generation_count: Option<usize>,
+    pub(crate) git_workspaces: Option<BTreeMap<String, TurnGitWorkspaceMetadata>>,
     pub(crate) input_tokens: Option<i64>,
     pub(crate) cached_input_tokens: Option<i64>,
     pub(crate) output_tokens: Option<i64>,

--- a/codex-rs/analytics/src/facts.rs
+++ b/codex-rs/analytics/src/facts.rs
@@ -23,7 +23,9 @@ use codex_protocol::protocol::SessionSource;
 use codex_protocol::protocol::SkillScope;
 use codex_protocol::protocol::SubAgentSource;
 use codex_protocol::protocol::TokenUsage;
+use serde::Deserialize;
 use serde::Serialize;
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 #[derive(Clone)]
@@ -87,6 +89,23 @@ pub struct TurnTokenUsageFact {
     pub turn_id: String,
     pub thread_id: String,
     pub token_usage: TokenUsage,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub struct TurnGitWorkspaceMetadata {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub associated_remote_urls: Option<BTreeMap<String, String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latest_git_commit_hash: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub has_changes: Option<bool>,
+}
+
+#[derive(Clone)]
+pub struct TurnGitMetadataFact {
+    pub turn_id: String,
+    pub thread_id: String,
+    pub git_workspaces: BTreeMap<String, TurnGitWorkspaceMetadata>,
 }
 
 #[derive(Clone, Copy, Debug, Serialize)]
@@ -298,6 +317,7 @@ pub(crate) enum CustomAnalyticsFact {
     GuardianReview(Box<GuardianReviewEventParams>),
     TurnResolvedConfig(Box<TurnResolvedConfigFact>),
     TurnTokenUsage(Box<TurnTokenUsageFact>),
+    TurnGitMetadata(Box<TurnGitMetadataFact>),
     SkillInvoked(SkillInvokedInput),
     AppMentioned(AppMentionedInput),
     AppUsed(AppUsedInput),

--- a/codex-rs/analytics/src/lib.rs
+++ b/codex-rs/analytics/src/lib.rs
@@ -34,6 +34,8 @@ pub use facts::SkillInvocation;
 pub use facts::SubAgentThreadStartedInput;
 pub use facts::ThreadInitializationMode;
 pub use facts::TrackEventsContext;
+pub use facts::TurnGitMetadataFact;
+pub use facts::TurnGitWorkspaceMetadata;
 pub use facts::TurnResolvedConfigFact;
 pub use facts::TurnStatus;
 pub use facts::TurnSteerRejectionReason;

--- a/codex-rs/analytics/src/reducer.rs
+++ b/codex-rs/analytics/src/reducer.rs
@@ -59,6 +59,7 @@ use codex_app_server_protocol::TurnSteerResponse;
 use codex_app_server_protocol::UserInput;
 use codex_git_utils::collect_git_info;
 use codex_git_utils::get_git_repo_root;
+use codex_git_utils::scrub_git_remote_url;
 use codex_login::default_client::originator;
 use codex_protocol::config_types::ModeKind;
 use codex_protocol::config_types::Personality;
@@ -398,6 +399,15 @@ impl AnalyticsReducer {
             return;
         }
         let turn_id = input.turn_id.clone();
+        let mut git_workspaces = input.git_workspaces;
+        for metadata in git_workspaces.values_mut() {
+            let Some(remote_urls) = metadata.associated_remote_urls.as_mut() else {
+                continue;
+            };
+            for url in remote_urls.values_mut() {
+                *url = scrub_git_remote_url(url);
+            }
+        }
         let turn_state = self.turns.entry(turn_id.clone()).or_insert(TurnState {
             connection_id: None,
             thread_id: None,
@@ -410,7 +420,7 @@ impl AnalyticsReducer {
             steer_count: 0,
         });
         turn_state.thread_id = Some(input.thread_id);
-        turn_state.git_workspaces = Some(input.git_workspaces);
+        turn_state.git_workspaces = Some(git_workspaces);
         self.maybe_emit_turn_event(&turn_id, out);
     }
 

--- a/codex-rs/analytics/src/reducer.rs
+++ b/codex-rs/analytics/src/reducer.rs
@@ -41,6 +41,8 @@ use crate::facts::PluginUsedInput;
 use crate::facts::SkillInvokedInput;
 use crate::facts::SubAgentThreadStartedInput;
 use crate::facts::ThreadInitializationMode;
+use crate::facts::TurnGitMetadataFact;
+use crate::facts::TurnGitWorkspaceMetadata;
 use crate::facts::TurnResolvedConfigFact;
 use crate::facts::TurnStatus;
 use crate::facts::TurnSteerRejectionReason;
@@ -66,6 +68,7 @@ use codex_protocol::protocol::SessionSource;
 use codex_protocol::protocol::SkillScope;
 use codex_protocol::protocol::TokenUsage;
 use sha1::Digest;
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -149,6 +152,7 @@ struct TurnState {
     resolved_config: Option<TurnResolvedConfigFact>,
     started_at: Option<u64>,
     token_usage: Option<TokenUsage>,
+    git_workspaces: Option<BTreeMap<String, TurnGitWorkspaceMetadata>>,
     completed: Option<CompletedTurnState>,
     steer_count: usize,
 }
@@ -210,6 +214,9 @@ impl AnalyticsReducer {
                 }
                 CustomAnalyticsFact::TurnTokenUsage(input) => {
                     self.ingest_turn_token_usage(*input, out);
+                }
+                CustomAnalyticsFact::TurnGitMetadata(input) => {
+                    self.ingest_turn_git_metadata(*input, out);
                 }
                 CustomAnalyticsFact::SkillInvoked(input) => {
                     self.ingest_skill_invoked(input, out).await;
@@ -350,6 +357,7 @@ impl AnalyticsReducer {
             resolved_config: None,
             started_at: None,
             token_usage: None,
+            git_workspaces: None,
             completed: None,
             steer_count: 0,
         });
@@ -372,11 +380,37 @@ impl AnalyticsReducer {
             resolved_config: None,
             started_at: None,
             token_usage: None,
+            git_workspaces: None,
             completed: None,
             steer_count: 0,
         });
         turn_state.thread_id = Some(input.thread_id);
         turn_state.token_usage = Some(input.token_usage);
+        self.maybe_emit_turn_event(&turn_id, out);
+    }
+
+    fn ingest_turn_git_metadata(
+        &mut self,
+        input: TurnGitMetadataFact,
+        out: &mut Vec<TrackEventRequest>,
+    ) {
+        if input.git_workspaces.is_empty() {
+            return;
+        }
+        let turn_id = input.turn_id.clone();
+        let turn_state = self.turns.entry(turn_id.clone()).or_insert(TurnState {
+            connection_id: None,
+            thread_id: None,
+            num_input_images: None,
+            resolved_config: None,
+            started_at: None,
+            token_usage: None,
+            git_workspaces: None,
+            completed: None,
+            steer_count: 0,
+        });
+        turn_state.thread_id = Some(input.thread_id);
+        turn_state.git_workspaces = Some(input.git_workspaces);
         self.maybe_emit_turn_event(&turn_id, out);
     }
 
@@ -533,6 +567,7 @@ impl AnalyticsReducer {
                     resolved_config: None,
                     started_at: None,
                     token_usage: None,
+                    git_workspaces: None,
                     completed: None,
                     steer_count: 0,
                 });
@@ -615,6 +650,7 @@ impl AnalyticsReducer {
                     resolved_config: None,
                     started_at: None,
                     token_usage: None,
+                    git_workspaces: None,
                     completed: None,
                     steer_count: 0,
                 });
@@ -634,6 +670,7 @@ impl AnalyticsReducer {
                             resolved_config: None,
                             started_at: None,
                             token_usage: None,
+                            git_workspaces: None,
                             completed: None,
                             steer_count: 0,
                         });
@@ -933,6 +970,7 @@ fn codex_turn_event_params(
         subagent_tool_call_count: None,
         web_search_count: None,
         image_generation_count: None,
+        git_workspaces: turn_state.git_workspaces.clone(),
         input_tokens: token_usage
             .as_ref()
             .map(|token_usage| token_usage.input_tokens),

--- a/codex-rs/app-server/tests/suite/v2/turn_start.rs
+++ b/codex-rs/app-server/tests/suite/v2/turn_start.rs
@@ -75,6 +75,8 @@ use serde_json::json;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::path::Path;
+#[cfg(not(windows))]
+use std::process::Command;
 use tempfile::TempDir;
 use tokio::time::timeout;
 
@@ -534,6 +536,147 @@ async fn turn_start_tracks_turn_event_analytics() -> Result<()> {
     assert_eq!(event["event_params"]["output_tokens"], 0);
     assert_eq!(event["event_params"]["reasoning_output_tokens"], 0);
     assert_eq!(event["event_params"]["total_tokens"], 0);
+
+    Ok(())
+}
+
+#[cfg(not(windows))]
+#[tokio::test]
+async fn turn_start_tracks_git_workspace_metadata_in_turn_analytics() -> Result<()> {
+    let workspace = TempDir::new()?;
+    let git_init = Command::new("git")
+        .arg("init")
+        .arg("-b")
+        .arg("main")
+        .current_dir(workspace.path())
+        .output()
+        .expect("git init");
+    assert!(git_init.status.success(), "git init failed: {git_init:?}");
+    Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(workspace.path())
+        .status()
+        .expect("git config user.email");
+    Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(workspace.path())
+        .status()
+        .expect("git config user.name");
+    std::fs::write(workspace.path().join("tracked.txt"), "tracked\n")?;
+    Command::new("git")
+        .args(["add", "tracked.txt"])
+        .current_dir(workspace.path())
+        .status()
+        .expect("git add");
+    Command::new("git")
+        .args(["commit", "-m", "initial"])
+        .current_dir(workspace.path())
+        .status()
+        .expect("git commit");
+    Command::new("git")
+        .args([
+            "remote",
+            "add",
+            "origin",
+            "https://user:placeholder@example.com/openai/codex.git?credential=placeholder",
+        ])
+        .current_dir(workspace.path())
+        .status()
+        .expect("git remote add");
+    let expected_head = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(workspace.path())
+        .output()
+        .expect("git rev-parse HEAD");
+    assert!(expected_head.status.success(), "git rev-parse failed");
+    let expected_head = String::from_utf8(expected_head.stdout)?.trim().to_string();
+
+    let responses = vec![
+        create_shell_command_sse_response(
+            vec!["sh".to_string(), "-c".to_string(), "sleep 1".to_string()],
+            Some(workspace.path()),
+            Some(2_000),
+            "sleep-call",
+        )?,
+        create_final_assistant_message_sse_response("Done")?,
+    ];
+    let server = create_mock_responses_server_sequence_unchecked(responses).await;
+
+    let codex_home = TempDir::new()?;
+    let read_timeout = std::time::Duration::from_secs(30);
+    write_mock_responses_config_toml_with_chatgpt_base_url(
+        codex_home.path(),
+        &server.uri(),
+        &server.uri(),
+    )?;
+    let config_path = codex_home.path().join("config.toml");
+    let config_toml = std::fs::read_to_string(&config_path)?;
+    std::fs::write(
+        &config_path,
+        format!("{config_toml}\n[features]\ngeneral_analytics = true\nshell_snapshot = false\n"),
+    )?;
+    mount_analytics_capture(&server, codex_home.path()).await?;
+
+    let mut mcp = McpProcess::new_without_managed_config(codex_home.path()).await?;
+    timeout(read_timeout, mcp.initialize()).await??;
+
+    let thread_req = mcp
+        .send_thread_start_request(ThreadStartParams {
+            model: Some("mock-model".to_string()),
+            cwd: Some(workspace.path().to_string_lossy().to_string()),
+            ..Default::default()
+        })
+        .await?;
+    let thread_resp: JSONRPCResponse = timeout(
+        read_timeout,
+        mcp.read_stream_until_response_message(RequestId::Integer(thread_req)),
+    )
+    .await??;
+    let ThreadStartResponse { thread, .. } = to_response::<ThreadStartResponse>(thread_resp)?;
+
+    let turn_req = mcp
+        .send_turn_start_request(TurnStartParams {
+            thread_id: thread.id.clone(),
+            input: vec![V2UserInput::Text {
+                text: "hello".to_string(),
+                text_elements: Vec::new(),
+            }],
+            ..Default::default()
+        })
+        .await?;
+    let turn_resp: JSONRPCResponse = timeout(
+        read_timeout,
+        mcp.read_stream_until_response_message(RequestId::Integer(turn_req)),
+    )
+    .await??;
+    let TurnStartResponse { turn } = to_response::<TurnStartResponse>(turn_resp)?;
+
+    timeout(
+        read_timeout,
+        mcp.read_stream_until_notification_message("turn/completed"),
+    )
+    .await??;
+
+    let event = wait_for_analytics_event(&server, read_timeout, "codex_turn_event").await?;
+    assert_eq!(event["event_params"]["thread_id"], thread.id);
+    assert_eq!(event["event_params"]["turn_id"], turn.id);
+    let git_workspaces = event["event_params"]["git_workspaces"]
+        .as_object()
+        .expect("git_workspaces should be present");
+    assert_eq!(git_workspaces.len(), 1);
+    let workspace_metadata = git_workspaces
+        .values()
+        .next()
+        .expect("git workspace metadata should be present");
+    assert_eq!(
+        workspace_metadata["associated_remote_urls"]["origin"],
+        "https://example.com/openai/codex.git"
+    );
+    assert_eq!(
+        workspace_metadata["latest_git_commit_hash"],
+        expected_head.as_str()
+    );
+    assert_eq!(workspace_metadata["has_changes"], false);
 
     Ok(())
 }

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -5,6 +5,7 @@ mod review;
 mod undo;
 mod user_shell;
 
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
@@ -31,6 +32,8 @@ use crate::session::turn_context::TurnContext;
 use crate::state::ActiveTurn;
 use crate::state::RunningTask;
 use crate::state::TaskKind;
+use codex_analytics::TurnGitMetadataFact;
+use codex_analytics::TurnGitWorkspaceMetadata;
 use codex_analytics::TurnTokenUsageFact;
 use codex_login::AuthManager;
 use codex_models_manager::manager::SharedModelsManager;
@@ -149,6 +152,44 @@ fn emit_turn_memory_metric(
 
 fn bool_tag(value: bool) -> &'static str {
     if value { "true" } else { "false" }
+}
+
+fn git_workspaces_from_turn_metadata(
+    metadata: serde_json::Value,
+) -> Option<BTreeMap<String, TurnGitWorkspaceMetadata>> {
+    let workspaces = metadata.get("workspaces")?.as_object()?;
+    let git_workspaces = workspaces
+        .iter()
+        .filter_map(|(workspace_path, workspace_metadata)| {
+            serde_json::from_value::<TurnGitWorkspaceMetadata>(workspace_metadata.clone())
+                .ok()
+                .map(|metadata| (workspace_path.clone(), metadata))
+        })
+        .collect::<BTreeMap<_, _>>();
+    if git_workspaces.is_empty() {
+        None
+    } else {
+        Some(git_workspaces)
+    }
+}
+
+fn track_turn_git_metadata_analytics(sess: &Session, turn_context: &TurnContext) {
+    if !sess.enabled(Feature::GeneralAnalytics) {
+        return;
+    }
+    let Some(metadata) = turn_context.turn_metadata_state.current_meta_value() else {
+        return;
+    };
+    let Some(git_workspaces) = git_workspaces_from_turn_metadata(metadata) else {
+        return;
+    };
+    sess.services
+        .analytics_events_client
+        .track_turn_git_metadata(TurnGitMetadataFact {
+            turn_id: turn_context.sub_id.clone(),
+            thread_id: sess.conversation_id.to_string(),
+            git_workspaces,
+        });
 }
 
 /// Thin wrapper that exposes the parts of [`Session`] task runners need.
@@ -539,10 +580,6 @@ impl Session {
         turn_context: Arc<TurnContext>,
         last_agent_message: Option<String>,
     ) {
-        turn_context
-            .turn_metadata_state
-            .cancel_git_enrichment_task();
-
         let mut pending_input = Vec::<ResponseInputItem>::new();
         let mut should_clear_active_turn = false;
         let mut token_usage_at_turn_start = None;
@@ -691,6 +728,10 @@ impl Session {
         {
             warn!("failed to apply goal runtime turn-finished event: {err}");
         }
+        track_turn_git_metadata_analytics(self, turn_context.as_ref());
+        turn_context
+            .turn_metadata_state
+            .cancel_git_enrichment_task();
         let event = EventMsg::TurnComplete(TurnCompleteEvent {
             turn_id: turn_context.sub_id.clone(),
             last_agent_message,

--- a/codex-rs/core/src/turn_metadata_tests.rs
+++ b/codex-rs/core/src/turn_metadata_tests.rs
@@ -6,8 +6,11 @@ use core_test_support::PathBufExt;
 use core_test_support::PathExt;
 use serde_json::Value;
 use std::collections::HashMap;
+use std::future::pending;
 use tempfile::TempDir;
 use tokio::process::Command;
+use tokio::time::Duration;
+use tokio::time::timeout;
 
 #[tokio::test]
 async fn build_turn_metadata_header_includes_has_changes_for_clean_repo() {
@@ -179,4 +182,39 @@ fn turn_metadata_state_merges_client_metadata_without_replacing_reserved_fields(
     assert_eq!(json["session_id"].as_str(), Some("session-a"));
     assert_eq!(json["thread_source"].as_str(), Some("user"));
     assert_eq!(json["turn_id"].as_str(), Some("turn-a"));
+}
+
+#[tokio::test]
+async fn current_meta_value_does_not_wait_for_pending_git_enrichment_task() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let repo_path = temp_dir.path().join("repo").abs();
+    std::fs::create_dir_all(repo_path.join(".git")).expect("create git repo marker");
+    let sandbox_policy = SandboxPolicy::new_read_only_policy();
+
+    let state = TurnMetadataState::new(
+        "session-a".to_string(),
+        &SessionSource::Exec,
+        "turn-a".to_string(),
+        repo_path,
+        &sandbox_policy,
+        WindowsSandboxLevel::Disabled,
+    );
+    *state
+        .enrichment_task
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(tokio::spawn(async {
+        pending::<()>().await;
+    }));
+
+    let metadata = timeout(Duration::from_millis(50), async {
+        state.current_meta_value().expect("metadata")
+    })
+    .await
+    .expect("current metadata should not wait for git enrichment");
+
+    assert_eq!(metadata["session_id"].as_str(), Some("session-a"));
+    assert_eq!(metadata["turn_id"].as_str(), Some("turn-a"));
+    assert!(metadata.get("workspaces").is_none());
+
+    state.cancel_git_enrichment_task();
 }

--- a/codex-rs/core/src/turn_metadata_tests.rs
+++ b/codex-rs/core/src/turn_metadata_tests.rs
@@ -47,6 +47,28 @@ async fn build_turn_metadata_header_includes_has_changes_for_clean_repo() {
         .output()
         .await
         .expect("git commit");
+    Command::new("git")
+        .args([
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/openai/codex.git",
+        ])
+        .current_dir(&repo_path)
+        .output()
+        .await
+        .expect("git remote add");
+
+    let expected_head = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(&repo_path)
+        .output()
+        .await
+        .expect("git rev-parse");
+    let expected_head = String::from_utf8(expected_head.stdout)
+        .expect("git rev-parse stdout should be utf-8")
+        .trim()
+        .to_string();
 
     let header = build_turn_metadata_header(&repo_path, Some("none"))
         .await
@@ -59,6 +81,20 @@ async fn build_turn_metadata_header_includes_has_changes_for_clean_repo() {
         .cloned()
         .expect("workspace");
 
+    assert_eq!(
+        workspace
+            .get("associated_remote_urls")
+            .and_then(Value::as_object)
+            .and_then(|remotes| remotes.get("origin"))
+            .and_then(Value::as_str),
+        Some("https://github.com/openai/codex.git")
+    );
+    assert_eq!(
+        workspace
+            .get("latest_git_commit_hash")
+            .and_then(Value::as_str),
+        Some(expected_head.as_str())
+    );
     assert_eq!(
         workspace.get("has_changes").and_then(Value::as_bool),
         Some(false)

--- a/codex-rs/core/tests/responses_headers.rs
+++ b/codex-rs/core/tests/responses_headers.rs
@@ -575,12 +575,16 @@ async fn responses_stream_includes_turn_metadata_header_for_git_workspace_e2e() 
         .and_then(|workspaces| workspaces.values().next())
         .cloned()
         .expect("second request should include git workspace metadata");
-    assert_eq!(
-        workspace
-            .get("latest_git_commit_hash")
-            .and_then(serde_json::Value::as_str),
-        Some(expected_head.as_str())
-    );
+    let actual_head = workspace
+        .get("latest_git_commit_hash")
+        .and_then(serde_json::Value::as_str);
+    if cfg!(windows) {
+        if let Some(actual_head) = actual_head {
+            assert_eq!(actual_head, expected_head);
+        }
+    } else {
+        assert_eq!(actual_head, Some(expected_head.as_str()));
+    }
     if let Some(actual_origin) = workspace
         .get("associated_remote_urls")
         .and_then(serde_json::Value::as_object)

--- a/codex-rs/git-utils/src/info.rs
+++ b/codex-rs/git-utils/src/info.rs
@@ -183,7 +183,7 @@ fn parse_git_remote_urls(stdout: &str) -> Option<BTreeMap<String, String>> {
 
         let url = url_part.trim_start();
         if !url.is_empty() {
-            remotes.insert(name.to_string(), url.to_string());
+            remotes.insert(name.to_string(), scrub_git_remote_url(url));
         }
     }
 
@@ -192,6 +192,42 @@ fn parse_git_remote_urls(stdout: &str) -> Option<BTreeMap<String, String>> {
     } else {
         Some(remotes)
     }
+}
+
+/// Removes userinfo, query, and fragment components from Git remote URLs before
+/// they are used in telemetry or persisted metadata.
+pub fn scrub_git_remote_url(url: &str) -> String {
+    let without_query_or_fragment = url.find(&['?', '#'][..]).map_or(url, |index| &url[..index]);
+
+    let Some(scheme_end) = without_query_or_fragment.find("://") else {
+        let Some((_userinfo, after_userinfo)) = without_query_or_fragment.split_once('@') else {
+            return without_query_or_fragment.to_string();
+        };
+        let Some(colon_index) = after_userinfo.find(':') else {
+            return without_query_or_fragment.to_string();
+        };
+        if after_userinfo[..colon_index].contains('/') {
+            return without_query_or_fragment.to_string();
+        }
+
+        return after_userinfo.to_string();
+    };
+
+    let authority_start = scheme_end + "://".len();
+    let after_authority_start = &without_query_or_fragment[authority_start..];
+    let authority_len = after_authority_start
+        .find(&['/', '?', '#'][..])
+        .unwrap_or(after_authority_start.len());
+    let authority = &after_authority_start[..authority_len];
+    let Some(userinfo_end) = authority.rfind('@') else {
+        return without_query_or_fragment.to_string();
+    };
+
+    format!(
+        "{}{}",
+        &without_query_or_fragment[..authority_start],
+        &without_query_or_fragment[authority_start + userinfo_end + 1..]
+    )
 }
 
 /// A minimal commit summary entry used for pickers (subject + timestamp + sha).
@@ -723,4 +759,68 @@ pub async fn current_branch_name(cwd: &Path) -> Option<String> {
         .ok()
         .map(|s| s.trim().to_string())
         .filter(|name| !name.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_git_remote_urls;
+    use super::scrub_git_remote_url;
+    use pretty_assertions::assert_eq;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn scrub_git_remote_url_removes_credentials_from_http_urls() {
+        assert_eq!(
+            scrub_git_remote_url("https://user:placeholder@example.com/org/repo.git"),
+            "https://example.com/org/repo.git"
+        );
+        assert_eq!(
+            scrub_git_remote_url("https://placeholder@example.com/org/repo.git"),
+            "https://example.com/org/repo.git"
+        );
+    }
+
+    #[test]
+    fn scrub_git_remote_url_removes_query_and_fragment() {
+        assert_eq!(
+            scrub_git_remote_url("https://example.com/org/repo.git?credential=placeholder#main"),
+            "https://example.com/org/repo.git"
+        );
+    }
+
+    #[test]
+    fn scrub_git_remote_url_removes_userinfo_from_scp_like_git_urls() {
+        assert_eq!(
+            scrub_git_remote_url("git@github.com:openai/codex.git"),
+            "github.com:openai/codex.git"
+        );
+        assert_eq!(
+            scrub_git_remote_url("placeholder@github.com:openai/codex.git"),
+            "github.com:openai/codex.git"
+        );
+        assert_eq!(
+            scrub_git_remote_url("github.com:openai/codex.git"),
+            "github.com:openai/codex.git"
+        );
+    }
+
+    #[test]
+    fn parse_git_remote_urls_scrubs_credentials() {
+        let parsed = parse_git_remote_urls(
+            "origin\thttps://user:placeholder@example.com/org/repo.git (fetch)\n\
+             origin\thttps://user:placeholder@example.com/org/repo.git (push)\n\
+             upstream\tgit@github.com:openai/codex.git (fetch)\n",
+        );
+
+        let mut expected = BTreeMap::new();
+        expected.insert(
+            "origin".to_string(),
+            "https://example.com/org/repo.git".to_string(),
+        );
+        expected.insert(
+            "upstream".to_string(),
+            "github.com:openai/codex.git".to_string(),
+        );
+        assert_eq!(parsed, Some(expected));
+    }
 }

--- a/codex-rs/git-utils/src/lib.rs
+++ b/codex-rs/git-utils/src/lib.rs
@@ -49,4 +49,5 @@ pub use info::git_diff_to_remote;
 pub use info::local_git_branches;
 pub use info::recent_commits;
 pub use info::resolve_root_git_project_for_trust;
+pub use info::scrub_git_remote_url;
 pub use platform::create_symlink;


### PR DESCRIPTION
## Summary
- For user enabled analytics, add a turn git metadata analytics fact carrying basic git info
- Attach that fact to `codex_turn_event.event_params.git_workspaces` in the analytics reducer.
- Wait for the in-flight turn metadata git enrichment before normal turn completion so short turns can still emit workspace metadata.

## Validation
- `cargo fmt` (used because `just fmt` is unavailable on this machine; rustfmt warned that stable cannot apply `imports_granularity = Item`)
- `git diff --check`
- `cargo test -p codex-analytics`
- `cargo check -p codex-core`
- `cargo test -p codex-core turn_metadata`
