### PR TITLE
Fix fs/readDirectory to skip broken symlinks

### DIFF
--- a/codex-rs/exec-server/src/local_file_system.rs
+++ b/codex-rs/exec-server/src/local_file_system.rs
@@ -305,7 +305,9 @@ impl ExecutorFileSystem for DirectFileSystem {
         let mut entries = Vec::new();
         let mut read_dir = tokio::fs::read_dir(path.as_path()).await?;
         while let Some(entry) = read_dir.next_entry().await? {
-            let metadata = tokio::fs::metadata(entry.path()).await?;
+            let Ok(metadata) = tokio::fs::metadata(entry.path()).await else {
+                continue;
+            };
             entries.push(ReadDirectoryEntry {
                 file_name: entry.file_name().to_string_lossy().into_owned(),
                 is_directory: metadata.is_dir(),

--- a/codex-rs/exec-server/tests/file_system.rs
+++ b/codex-rs/exec-server/tests/file_system.rs
@@ -253,6 +253,11 @@ async fn file_system_methods_cover_surface_area(use_remote: bool) -> Result<()> 
         "hello from trait"
     );
 
+    symlink(
+        source_dir.join("missing-target"),
+        source_dir.join("broken-link"),
+    )?;
+
     let mut entries = file_system
         .read_directory(&absolute_path(source_dir), /*sandbox*/ None)
         .await


### PR DESCRIPTION
## Summary
- Skip directory entries whose metadata lookup fails during `fs/readDirectory`
- Add an exec-server regression test covering a broken symlink beside valid entries

## Testing
- `just fmt`
- `cargo test -p codex-exec-server` (started, but dependency/network updates stalled before completion in this environment)