### PR TITLE
Add CLI update announcement

### DIFF
--- a/announcement_tip.toml
+++ b/announcement_tip.toml
@@ -11,6 +11,7 @@ version_regex = "^0\\.0\\.0$"
 to_date = "2027-05-10"
 
 [[announcements]]
-content = "**Time to Update** - Please install the latest version of the CLI, this version won't be supported starting next month"
+content = "Update Required - This version will no longer be supported starting May 8th. Please upgrade to the latest version (https://github.com/openai/codex/releases/latest) using your preferred package manager."
+# Matches 0.x.y versions from 0.0.y through 0.119.y; excludes 0.120.0 and newer.
 version_regex = "^0\\.(?:[0-9]|[1-9][0-9]|1[01][0-9])\\."
 to_date = "2026-05-08"

--- a/announcement_tip.toml
+++ b/announcement_tip.toml
@@ -4,20 +4,13 @@
 # version_regex matches against the CLI version (env!("CARGO_PKG_VERSION")); omit to apply to all versions.
 # target_app specify which app should display the announcement (cli, vsce, ...).
 
-[[announcements]]
-content = "Welcome to Codex! Check out the new onboarding flow."
-from_date = "2024-10-01"
-to_date = "2024-10-15"
-target_app = "cli"
-
-# Test announcement only for local build version until 2026-01-10 excluded (past)
+# Test announcement only for local build version until 2027-05-10 excluded
 [[announcements]]
 content = "This is a test announcement"
 version_regex = "^0\\.0\\.0$"
-to_date = "2026-05-10"
+to_date = "2027-05-10"
 
 [[announcements]]
-content = "**BREAKING NEWS**: `gpt-5.3-codex` is out! Upgrade to `0.98.0` for a faster, smarter, more steerable agent."
-from_date = "2026-02-01"
-to_date = "2026-02-16"
-version_regex = "^0\\.(?:[0-9]|[1-8][0-9]|9[0-7])\\."
+content = "**Time to Update** - Please install the latest version of the CLI, this version won't be supported starting next month"
+version_regex = "^0\\.(?:[0-9]|[1-9][0-9]|1[01][0-9])\\."
+to_date = "2026-05-08"


### PR DESCRIPTION
## Summary
- Keep the existing local-build test announcement as the first announcement entry
- Add the CLI update reminder for versions below `0.120.0`
- Remove expired onboarding and gpt-5.3-codex announcement entries
<img width="1576" height="276" alt="Screenshot 2026-04-15 at 1 32 53 PM" src="https://github.com/user-attachments/assets/10b55d0b-09cd-4de0-ab51-4293d811b80c" />
