### PR TITLE
fix: rename is_azure_responses_wire_base_url to is_azure_responses_provider

### DIFF
--- a/codex-rs/codex-api/src/lib.rs
+++ b/codex-rs/codex-api/src/lib.rs
@@ -57,7 +57,7 @@ pub use crate::error::ApiError;
 pub use crate::files::upload_local_file;
 pub use crate::provider::Provider;
 pub use crate::provider::RetryConfig;
-pub use crate::provider::is_azure_responses_wire_base_url;
+pub use crate::provider::is_azure_responses_provider;
 pub use crate::requests::Compression;
 pub use crate::sse::stream_from_fixture;
 pub use crate::telemetry::SseTelemetry;

--- a/codex-rs/codex-api/src/provider.rs
+++ b/codex-rs/codex-api/src/provider.rs
@@ -86,7 +86,7 @@ impl Provider {
     }
 
     pub fn is_azure_responses_endpoint(&self) -> bool {
-        is_azure_responses_wire_base_url(&self.name, Some(&self.base_url))
+        is_azure_responses_provider(&self.name, Some(&self.base_url))
     }
 
     pub fn websocket_url_for_path(&self, path: &str) -> Result<Url, url::ParseError> {
@@ -103,21 +103,20 @@ impl Provider {
     }
 }
 
-pub fn is_azure_responses_wire_base_url(name: &str, base_url: Option<&str>) -> bool {
+pub fn is_azure_responses_provider(name: &str, base_url: Option<&str>) -> bool {
     if name.eq_ignore_ascii_case("azure") {
-        return true;
+        true
+    } else if let Some(base_url) = base_url {
+        matches_azure_responses_base_url(base_url)
+    } else {
+        false
     }
-
-    let Some(base_url) = base_url else {
-        return false;
-    };
-
-    let base = base_url.to_ascii_lowercase();
-    base.contains("openai.azure.") || matches_azure_responses_base_url(&base)
 }
 
 fn matches_azure_responses_base_url(base_url: &str) -> bool {
-    const AZURE_MARKERS: [&str; 5] = [
+    let base_url = base_url.to_ascii_lowercase();
+    const AZURE_MARKERS: [&str; 6] = [
+        "openai.azure.",
         "cognitiveservices.azure.",
         "aoai.azure.",
         "azure-api.",
@@ -144,12 +143,12 @@ mod tests {
 
         for base_url in positive_cases {
             assert!(
-                is_azure_responses_wire_base_url("test", Some(base_url)),
+                is_azure_responses_provider("test", Some(base_url)),
                 "expected {base_url} to be detected as Azure"
             );
         }
 
-        assert!(is_azure_responses_wire_base_url(
+        assert!(is_azure_responses_provider(
             "Azure",
             Some("https://example.com")
         ));
@@ -162,7 +161,7 @@ mod tests {
 
         for base_url in negative_cases {
             assert!(
-                !is_azure_responses_wire_base_url("test", Some(base_url)),
+                !is_azure_responses_provider("test", Some(base_url)),
                 "expected {base_url} not to be detected as Azure"
             );
         }


### PR DESCRIPTION
## Why

While reviewing https://github.com/openai/codex/pull/17958, the helper name `is_azure_responses_wire_base_url` looked misleading because the helper returns true for either the `azure` provider name or an Azure Responses `base_url`. The new name makes both inputs part of the contract.

## What

- Rename `is_azure_responses_wire_base_url` to `is_azure_responses_provider`.
- Move the `openai.azure.` marker into `matches_azure_responses_base_url` so all base URL marker matching is centralized.
- Keep `Provider::is_azure_responses_endpoint()` behavior unchanged.

## Verification

- Compared the parent and current implementations. `name.eq_ignore_ascii_case("azure")` still returns true before consulting `base_url`, `None` still returns false, base URLs are still lowercased before marker matching, and the same Azure marker set is checked.
- Ran `cargo test -p codex-api`.
