### PR TITLE
fix: deprecate use_legacy_landlock feature flag

### DIFF
--- a/codex-rs/core/tests/suite/deprecation_notice.rs
+++ b/codex-rs/core/tests/suite/deprecation_notice.rs
@@ -161,3 +161,45 @@ async fn emits_deprecation_notice_for_web_search_feature_flag_values() -> anyhow
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn emits_deprecation_notice_for_use_legacy_landlock() -> anyhow::Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+
+    let mut builder = test_codex().with_config(|config| {
+        let mut entries = BTreeMap::new();
+        entries.insert("use_legacy_landlock".to_string(), true);
+        let mut features = config.features.get().clone();
+        features.apply_map(&entries);
+        config
+            .features
+            .set(features)
+            .expect("test config should allow managed feature map updates");
+    });
+
+    let TestCodex { codex, .. } = builder.build(&server).await?;
+
+    let notice = wait_for_event_match(&codex, |event| match event {
+        EventMsg::DeprecationNotice(ev)
+            if ev.summary.contains("[features].use_legacy_landlock") =>
+        {
+            Some(ev.clone())
+        }
+        _ => None,
+    })
+    .await;
+
+    let DeprecationNoticeEvent { summary, details } = notice;
+    assert_eq!(
+        summary,
+        "`[features].use_legacy_landlock` is deprecated and will be removed soon.".to_string(),
+    );
+    assert_eq!(
+        details.as_deref(),
+        Some("Remove this setting to use the default Linux sandbox pipeline."),
+    );
+
+    Ok(())
+}

--- a/codex-rs/core/tests/suite/deprecation_notice.rs
+++ b/codex-rs/core/tests/suite/deprecation_notice.rs
@@ -198,7 +198,7 @@ async fn emits_deprecation_notice_for_use_legacy_landlock() -> anyhow::Result<()
     );
     assert_eq!(
         details.as_deref(),
-        Some("Remove this setting to use the default Linux sandbox pipeline."),
+        Some("Remove this setting to stop opting into the legacy Linux sandbox behavior."),
     );
 
     Ok(())

--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -471,7 +471,8 @@ fn legacy_usage_notice(alias: &str, feature: Feature) -> (String, Option<String>
             };
             let summary = format!("`{label}` is deprecated and will be removed soon.");
             let details =
-                "Remove this setting to use the default Linux sandbox pipeline.".to_string();
+                "Remove this setting to stop opting into the legacy Linux sandbox behavior."
+                    .to_string();
             (summary, Some(details))
         }
         _ => {

--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -371,6 +371,12 @@ impl Features {
                 "image_detail_original" => {
                     continue;
                 }
+                "use_legacy_landlock" => {
+                    self.record_legacy_usage_force(
+                        "features.use_legacy_landlock",
+                        Feature::UseLegacyLandlock,
+                    );
+                }
                 _ => {}
             }
             match feature_for_key(k) {
@@ -455,6 +461,18 @@ fn legacy_usage_notice(alias: &str, feature: Feature) -> (String, Option<String>
             let summary =
                 format!("`{label}` is deprecated because web search is enabled by default.");
             (summary, Some(web_search_details().to_string()))
+        }
+        Feature::UseLegacyLandlock => {
+            let label = match alias {
+                "features.use_legacy_landlock" | "use_legacy_landlock" => {
+                    "[features].use_legacy_landlock"
+                }
+                _ => alias,
+            };
+            let summary = format!("`{label}` is deprecated and will be removed soon.");
+            let details =
+                "Remove this setting to use the default Linux sandbox pipeline.".to_string();
+            (summary, Some(details))
         }
         _ => {
             let label = if alias.contains('.') || alias.starts_with('[') {
@@ -728,7 +746,7 @@ pub const FEATURES: &[FeatureSpec] = &[
     FeatureSpec {
         id: Feature::UseLegacyLandlock,
         key: "use_legacy_landlock",
-        stage: Stage::Stable,
+        stage: Stage::Deprecated,
         default_enabled: false,
     },
     FeatureSpec {

--- a/codex-rs/features/src/tests.rs
+++ b/codex-rs/features/src/tests.rs
@@ -42,8 +42,8 @@ fn default_enabled_features_are_stable() {
 }
 
 #[test]
-fn use_legacy_landlock_is_stable_and_disabled_by_default() {
-    assert_eq!(Feature::UseLegacyLandlock.stage(), Stage::Stable);
+fn use_legacy_landlock_is_deprecated_and_disabled_by_default() {
+    assert_eq!(Feature::UseLegacyLandlock.stage(), Stage::Deprecated);
     assert_eq!(Feature::UseLegacyLandlock.default_enabled(), false);
 }
 
@@ -164,6 +164,28 @@ fn use_linux_sandbox_bwrap_is_a_removed_feature_key() {
 fn image_generation_is_stable_and_enabled_by_default() {
     assert_eq!(Feature::ImageGeneration.stage(), Stage::Stable);
     assert_eq!(Feature::ImageGeneration.default_enabled(), true);
+}
+
+#[test]
+fn use_legacy_landlock_config_records_deprecation_notice() {
+    let mut entries = BTreeMap::new();
+    entries.insert("use_legacy_landlock".to_string(), true);
+
+    let mut features = Features::with_defaults();
+    features.apply_map(&entries);
+
+    let usages = features.legacy_feature_usages().collect::<Vec<_>>();
+    assert_eq!(usages.len(), 1);
+    assert_eq!(usages[0].alias, "features.use_legacy_landlock");
+    assert_eq!(usages[0].feature, Feature::UseLegacyLandlock);
+    assert_eq!(
+        usages[0].summary,
+        "`[features].use_legacy_landlock` is deprecated and will be removed soon."
+    );
+    assert_eq!(
+        usages[0].details.as_deref(),
+        Some("Remove this setting to use the default Linux sandbox pipeline.")
+    );
 }
 
 #[test]

--- a/codex-rs/features/src/tests.rs
+++ b/codex-rs/features/src/tests.rs
@@ -184,7 +184,7 @@ fn use_legacy_landlock_config_records_deprecation_notice() {
     );
     assert_eq!(
         usages[0].details.as_deref(),
-        Some("Remove this setting to use the default Linux sandbox pipeline.")
+        Some("Remove this setting to stop opting into the legacy Linux sandbox behavior.")
     );
 }
 


### PR DESCRIPTION
## Summary
- mark `features.use_legacy_landlock` as a deprecated feature flag
- emit a startup deprecation notice when the flag is configured
- add feature- and core-level regression coverage for the notice


<img width="1288" height="93" alt="Screenshot 2026-04-15 at 11 14 00 PM" src="https://github.com/user-attachments/assets/fffc628b-614c-4521-9374-64e50a269252" />