### PR TITLE
Fix flaky app list tests

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -6092,26 +6092,23 @@ impl CodexMessageProcessor {
         );
         let cached_all_connectors = all_connectors.clone();
 
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-
         let accessible_config = config.clone();
-        let accessible_tx = tx.clone();
-        tokio::spawn(async move {
+        let mut accessible_task = tokio::spawn(async move {
             let result = connectors::list_accessible_connectors_from_mcp_tools_with_options(
                 &accessible_config,
                 force_refetch,
             )
             .await
             .map_err(|err| format!("failed to load accessible apps: {err}"));
-            let _ = accessible_tx.send(AppListLoadResult::Accessible(result));
+            AppListLoadResult::Accessible(result)
         });
 
         let all_config = config.clone();
-        tokio::spawn(async move {
+        let mut directory_task = tokio::spawn(async move {
             let result = connectors::list_all_connectors_with_options(&all_config, force_refetch)
                 .await
                 .map_err(|err| format!("failed to list apps: {err}"));
-            let _ = tx.send(AppListLoadResult::Directory(result));
+            AppListLoadResult::Directory(result)
         });
 
         let app_list_deadline = tokio::time::Instant::now() + APP_LIST_LOAD_TIMEOUT;
@@ -6139,18 +6136,37 @@ impl CodexMessageProcessor {
         }
 
         loop {
-            let result = match tokio::time::timeout_at(app_list_deadline, rx.recv()).await {
-                Ok(Some(result)) => result,
-                Ok(None) => {
+            let result = match tokio::time::timeout_at(app_list_deadline, async {
+                tokio::select! {
+                    result = &mut accessible_task, if !accessible_loaded => result,
+                    result = &mut directory_task, if !all_loaded => result,
+                }
+            })
+            .await
+            {
+                Ok(Ok(result)) => result,
+                Ok(Err(err)) => {
+                    if !accessible_loaded {
+                        accessible_task.abort();
+                    }
+                    if !all_loaded {
+                        directory_task.abort();
+                    }
                     let error = JSONRPCErrorError {
                         code: INTERNAL_ERROR_CODE,
-                        message: "failed to load app lists".to_string(),
+                        message: format!("failed to load app lists: {err}"),
                         data: None,
                     };
                     outgoing.send_error(request_id, error).await;
                     return;
                 }
                 Err(_) => {
+                    if !accessible_loaded {
+                        accessible_task.abort();
+                    }
+                    if !all_loaded {
+                        directory_task.abort();
+                    }
                     let timeout_seconds = APP_LIST_LOAD_TIMEOUT.as_secs();
                     let error = JSONRPCErrorError {
                         code: INTERNAL_ERROR_CODE,
@@ -6170,6 +6186,9 @@ impl CodexMessageProcessor {
                     accessible_loaded = true;
                 }
                 AppListLoadResult::Accessible(Err(err)) => {
+                    if !all_loaded {
+                        directory_task.abort();
+                    }
                     let error = JSONRPCErrorError {
                         code: INTERNAL_ERROR_CODE,
                         message: err,
@@ -6183,6 +6202,9 @@ impl CodexMessageProcessor {
                     all_loaded = true;
                 }
                 AppListLoadResult::Directory(Err(err)) => {
+                    if !accessible_loaded {
+                        accessible_task.abort();
+                    }
                     let error = JSONRPCErrorError {
                         code: INTERNAL_ERROR_CODE,
                         message: err,

--- a/codex-rs/app-server/tests/suite/v2/app_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/app_list.rs
@@ -926,9 +926,12 @@ async fn list_apps_force_refetch_preserves_previous_cache_on_failure() -> Result
     assert!(initial_next_cursor.is_none());
     assert_eq!(initial_data.len(), 1);
     assert!(initial_data.iter().all(|app| app.is_accessible));
+    timeout(
+        DEFAULT_TIMEOUT,
+        server_control.wait_for_tools_list_finished(),
+    )
+    .await?;
 
-    let directory_gate = server_control.pause_next_directory_list();
-    let tool_list_gate = server_control.pause_next_tools_list();
     write_chatgpt_auth(
         codex_home.path(),
         ChatGptAuthFixture::new("chatgpt-token-invalid")
@@ -947,9 +950,6 @@ async fn list_apps_force_refetch_preserves_previous_cache_on_failure() -> Result
             force_refetch: true,
         })
         .await?;
-    timeout(DEFAULT_TIMEOUT, tool_list_gate.wait_started()).await?;
-    directory_gate.release();
-    timeout(DEFAULT_TIMEOUT, directory_gate.wait_finished()).await?;
     let refetch_error: JSONRPCError = timeout(
         DEFAULT_TIMEOUT,
         mcp.read_stream_until_error_message(RequestId::Integer(refetch_request)),
@@ -957,8 +957,11 @@ async fn list_apps_force_refetch_preserves_previous_cache_on_failure() -> Result
     .await??;
     assert!(refetch_error.error.message.contains("failed to"));
 
-    tool_list_gate.release();
-    timeout(DEFAULT_TIMEOUT, tool_list_gate.wait_finished()).await?;
+    timeout(
+        DEFAULT_TIMEOUT,
+        server_control.wait_for_tools_list_finished(),
+    )
+    .await?;
 
     let cached_request = mcp
         .send_apps_list_request(AppsListParams {
@@ -1347,27 +1350,26 @@ struct AppsServerState {
     expected_bearer: String,
     expected_account_id: String,
     response: Arc<StdMutex<serde_json::Value>>,
-    directory_gate: Arc<StdMutex<Option<RequestGate>>>,
     directory_delay: Duration,
 }
 
 #[derive(Clone)]
 struct AppListMcpServer {
     tools: Arc<StdMutex<Vec<Tool>>>,
-    tools_gate: Arc<StdMutex<Option<RequestGate>>>,
     tools_delay: Duration,
+    tools_list_finished: Arc<Notify>,
 }
 
 impl AppListMcpServer {
     fn new(
         tools: Arc<StdMutex<Vec<Tool>>>,
-        tools_gate: Arc<StdMutex<Option<RequestGate>>>,
         tools_delay: Duration,
+        tools_list_finished: Arc<Notify>,
     ) -> Self {
         Self {
             tools,
-            tools_gate,
             tools_delay,
+            tools_list_finished,
         }
     }
 }
@@ -1376,8 +1378,7 @@ impl AppListMcpServer {
 struct AppsServerControl {
     response: Arc<StdMutex<serde_json::Value>>,
     tools: Arc<StdMutex<Vec<Tool>>>,
-    directory_gate: Arc<StdMutex<Option<RequestGate>>>,
-    tools_gate: Arc<StdMutex<Option<RequestGate>>>,
+    tools_list_finished: Arc<Notify>,
 }
 
 impl AppsServerControl {
@@ -1397,80 +1398,16 @@ impl AppsServerControl {
         *tools_guard = tools;
     }
 
-    fn pause_next_directory_list(&self) -> RequestGate {
-        pause_next_request(&self.directory_gate)
-    }
-
-    fn pause_next_tools_list(&self) -> RequestGate {
-        pause_next_request(&self.tools_gate)
+    async fn wait_for_tools_list_finished(&self) {
+        self.tools_list_finished.notified().await;
     }
 }
 
-#[derive(Clone)]
-struct RequestGate {
-    started: Arc<Notify>,
-    release: Arc<Notify>,
-    finished: Arc<Notify>,
-}
+struct NotifyOnDrop(Arc<Notify>);
 
-impl RequestGate {
-    fn new() -> Self {
-        Self {
-            started: Arc::new(Notify::new()),
-            release: Arc::new(Notify::new()),
-            finished: Arc::new(Notify::new()),
-        }
-    }
-
-    async fn wait_started(&self) {
-        self.started.notified().await;
-    }
-
-    fn release(&self) {
-        self.release.notify_one();
-    }
-
-    async fn wait_finished(&self) {
-        self.finished.notified().await;
-    }
-
-    async fn wait_for_release(&self) {
-        self.started.notify_one();
-        self.release.notified().await;
-    }
-}
-
-fn pause_next_request(gate_slot: &Arc<StdMutex<Option<RequestGate>>>) -> RequestGate {
-    let gate = RequestGate::new();
-    let mut gate_slot = gate_slot
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    *gate_slot = Some(gate.clone());
-    gate
-}
-
-fn take_next_request_gate(gate_slot: &Arc<StdMutex<Option<RequestGate>>>) -> Option<RequestGate> {
-    gate_slot
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .take()
-}
-
-struct RequestGateFinish {
-    finished: Arc<Notify>,
-}
-
-impl RequestGateFinish {
-    fn new(gate: &RequestGate) -> Self {
-        Self {
-            finished: Arc::clone(&gate.finished),
-        }
-    }
-}
-
-impl Drop for RequestGateFinish {
+impl Drop for NotifyOnDrop {
     fn drop(&mut self) {
-        self.finished.notify_one();
+        self.0.notify_one();
     }
 }
 
@@ -1489,14 +1426,10 @@ impl ServerHandler for AppListMcpServer {
     ) -> impl std::future::Future<Output = Result<ListToolsResult, rmcp::ErrorData>> + Send + '_
     {
         let tools = self.tools.clone();
-        let tools_gate = self.tools_gate.clone();
         let tools_delay = self.tools_delay;
+        let tools_list_finished = self.tools_list_finished.clone();
         async move {
-            let gate = take_next_request_gate(&tools_gate);
-            let _finish = gate.as_ref().map(RequestGateFinish::new);
-            if let Some(gate) = &gate {
-                gate.wait_for_release().await;
-            }
+            let _notify_finished = NotifyOnDrop(tools_list_finished);
             if tools_delay > Duration::ZERO {
                 tokio::time::sleep(tools_delay).await;
             }
@@ -1535,21 +1468,18 @@ async fn start_apps_server_with_delays_and_control(
         json!({ "apps": connectors, "next_token": null }),
     ));
     let tools = Arc::new(StdMutex::new(tools));
-    let directory_gate = Arc::new(StdMutex::new(None));
-    let tools_gate = Arc::new(StdMutex::new(None));
+    let tools_list_finished = Arc::new(Notify::new());
     let state = AppsServerState {
         expected_bearer: "Bearer chatgpt-token".to_string(),
         expected_account_id: "account-123".to_string(),
         response: response.clone(),
-        directory_gate: directory_gate.clone(),
         directory_delay,
     };
     let state = Arc::new(state);
     let server_control = AppsServerControl {
         response,
         tools: tools.clone(),
-        directory_gate,
-        tools_gate: tools_gate.clone(),
+        tools_list_finished: tools_list_finished.clone(),
     };
 
     let listener = TcpListener::bind("127.0.0.1:0").await?;
@@ -1558,12 +1488,12 @@ async fn start_apps_server_with_delays_and_control(
     let mcp_service = StreamableHttpService::new(
         {
             let tools = tools.clone();
-            let tools_gate = tools_gate.clone();
+            let tools_list_finished = tools_list_finished.clone();
             move || {
                 Ok(AppListMcpServer::new(
                     tools.clone(),
-                    tools_gate.clone(),
                     tools_delay,
+                    tools_list_finished.clone(),
                 ))
             }
         },
@@ -1592,12 +1522,6 @@ async fn list_directory_connectors(
     headers: HeaderMap,
     uri: Uri,
 ) -> Result<impl axum::response::IntoResponse, StatusCode> {
-    let gate = take_next_request_gate(&state.directory_gate);
-    let _finish = gate.as_ref().map(RequestGateFinish::new);
-    if let Some(gate) = &gate {
-        gate.wait_for_release().await;
-    }
-
     if state.directory_delay > Duration::ZERO {
         tokio::time::sleep(state.directory_delay).await;
     }

--- a/codex-rs/app-server/tests/suite/v2/app_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/app_list.rs
@@ -53,6 +53,7 @@ use rmcp::transport::streamable_http_server::session::local::LocalSessionManager
 use serde_json::json;
 use tempfile::TempDir;
 use tokio::net::TcpListener;
+use tokio::sync::Notify;
 use tokio::task::JoinHandle;
 use tokio::time::timeout;
 
@@ -887,7 +888,7 @@ async fn list_apps_force_refetch_preserves_previous_cache_on_failure() -> Result
         connectors,
         tools,
         Duration::ZERO,
-        Duration::from_millis(150),
+        Duration::ZERO,
     )
     .await?;
 
@@ -926,6 +927,8 @@ async fn list_apps_force_refetch_preserves_previous_cache_on_failure() -> Result
     assert_eq!(initial_data.len(), 1);
     assert!(initial_data.iter().all(|app| app.is_accessible));
 
+    let directory_gate = server_control.pause_next_directory_list();
+    let tool_list_gate = server_control.pause_next_tools_list();
     write_chatgpt_auth(
         codex_home.path(),
         ChatGptAuthFixture::new("chatgpt-token-invalid")
@@ -944,6 +947,9 @@ async fn list_apps_force_refetch_preserves_previous_cache_on_failure() -> Result
             force_refetch: true,
         })
         .await?;
+    timeout(DEFAULT_TIMEOUT, tool_list_gate.wait_started()).await?;
+    directory_gate.release();
+    timeout(DEFAULT_TIMEOUT, directory_gate.wait_finished()).await?;
     let refetch_error: JSONRPCError = timeout(
         DEFAULT_TIMEOUT,
         mcp.read_stream_until_error_message(RequestId::Integer(refetch_request)),
@@ -951,7 +957,8 @@ async fn list_apps_force_refetch_preserves_previous_cache_on_failure() -> Result
     .await??;
     assert!(refetch_error.error.message.contains("failed to"));
 
-    tokio::time::sleep(Duration::from_millis(250)).await;
+    tool_list_gate.release();
+    timeout(DEFAULT_TIMEOUT, tool_list_gate.wait_finished()).await?;
 
     let cached_request = mcp
         .send_apps_list_request(AppsListParams {
@@ -1340,18 +1347,28 @@ struct AppsServerState {
     expected_bearer: String,
     expected_account_id: String,
     response: Arc<StdMutex<serde_json::Value>>,
+    directory_gate: Arc<StdMutex<Option<RequestGate>>>,
     directory_delay: Duration,
 }
 
 #[derive(Clone)]
 struct AppListMcpServer {
     tools: Arc<StdMutex<Vec<Tool>>>,
+    tools_gate: Arc<StdMutex<Option<RequestGate>>>,
     tools_delay: Duration,
 }
 
 impl AppListMcpServer {
-    fn new(tools: Arc<StdMutex<Vec<Tool>>>, tools_delay: Duration) -> Self {
-        Self { tools, tools_delay }
+    fn new(
+        tools: Arc<StdMutex<Vec<Tool>>>,
+        tools_gate: Arc<StdMutex<Option<RequestGate>>>,
+        tools_delay: Duration,
+    ) -> Self {
+        Self {
+            tools,
+            tools_gate,
+            tools_delay,
+        }
     }
 }
 
@@ -1359,6 +1376,8 @@ impl AppListMcpServer {
 struct AppsServerControl {
     response: Arc<StdMutex<serde_json::Value>>,
     tools: Arc<StdMutex<Vec<Tool>>>,
+    directory_gate: Arc<StdMutex<Option<RequestGate>>>,
+    tools_gate: Arc<StdMutex<Option<RequestGate>>>,
 }
 
 impl AppsServerControl {
@@ -1377,6 +1396,82 @@ impl AppsServerControl {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         *tools_guard = tools;
     }
+
+    fn pause_next_directory_list(&self) -> RequestGate {
+        pause_next_request(&self.directory_gate)
+    }
+
+    fn pause_next_tools_list(&self) -> RequestGate {
+        pause_next_request(&self.tools_gate)
+    }
+}
+
+#[derive(Clone)]
+struct RequestGate {
+    started: Arc<Notify>,
+    release: Arc<Notify>,
+    finished: Arc<Notify>,
+}
+
+impl RequestGate {
+    fn new() -> Self {
+        Self {
+            started: Arc::new(Notify::new()),
+            release: Arc::new(Notify::new()),
+            finished: Arc::new(Notify::new()),
+        }
+    }
+
+    async fn wait_started(&self) {
+        self.started.notified().await;
+    }
+
+    fn release(&self) {
+        self.release.notify_one();
+    }
+
+    async fn wait_finished(&self) {
+        self.finished.notified().await;
+    }
+
+    async fn wait_for_release(&self) {
+        self.started.notify_one();
+        self.release.notified().await;
+    }
+}
+
+fn pause_next_request(gate_slot: &Arc<StdMutex<Option<RequestGate>>>) -> RequestGate {
+    let gate = RequestGate::new();
+    let mut gate_slot = gate_slot
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    *gate_slot = Some(gate.clone());
+    gate
+}
+
+fn take_next_request_gate(gate_slot: &Arc<StdMutex<Option<RequestGate>>>) -> Option<RequestGate> {
+    gate_slot
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .take()
+}
+
+struct RequestGateFinish {
+    finished: Arc<Notify>,
+}
+
+impl RequestGateFinish {
+    fn new(gate: &RequestGate) -> Self {
+        Self {
+            finished: Arc::clone(&gate.finished),
+        }
+    }
+}
+
+impl Drop for RequestGateFinish {
+    fn drop(&mut self) {
+        self.finished.notify_one();
+    }
 }
 
 impl ServerHandler for AppListMcpServer {
@@ -1394,8 +1489,14 @@ impl ServerHandler for AppListMcpServer {
     ) -> impl std::future::Future<Output = Result<ListToolsResult, rmcp::ErrorData>> + Send + '_
     {
         let tools = self.tools.clone();
+        let tools_gate = self.tools_gate.clone();
         let tools_delay = self.tools_delay;
         async move {
+            let gate = take_next_request_gate(&tools_gate);
+            let _finish = gate.as_ref().map(RequestGateFinish::new);
+            if let Some(gate) = &gate {
+                gate.wait_for_release().await;
+            }
             if tools_delay > Duration::ZERO {
                 tokio::time::sleep(tools_delay).await;
             }
@@ -1434,16 +1535,21 @@ async fn start_apps_server_with_delays_and_control(
         json!({ "apps": connectors, "next_token": null }),
     ));
     let tools = Arc::new(StdMutex::new(tools));
+    let directory_gate = Arc::new(StdMutex::new(None));
+    let tools_gate = Arc::new(StdMutex::new(None));
     let state = AppsServerState {
         expected_bearer: "Bearer chatgpt-token".to_string(),
         expected_account_id: "account-123".to_string(),
         response: response.clone(),
+        directory_gate: directory_gate.clone(),
         directory_delay,
     };
     let state = Arc::new(state);
     let server_control = AppsServerControl {
         response,
         tools: tools.clone(),
+        directory_gate,
+        tools_gate: tools_gate.clone(),
     };
 
     let listener = TcpListener::bind("127.0.0.1:0").await?;
@@ -1452,7 +1558,14 @@ async fn start_apps_server_with_delays_and_control(
     let mcp_service = StreamableHttpService::new(
         {
             let tools = tools.clone();
-            move || Ok(AppListMcpServer::new(tools.clone(), tools_delay))
+            let tools_gate = tools_gate.clone();
+            move || {
+                Ok(AppListMcpServer::new(
+                    tools.clone(),
+                    tools_gate.clone(),
+                    tools_delay,
+                ))
+            }
         },
         Arc::new(LocalSessionManager::default()),
         StreamableHttpServerConfig::default(),
@@ -1479,6 +1592,12 @@ async fn list_directory_connectors(
     headers: HeaderMap,
     uri: Uri,
 ) -> Result<impl axum::response::IntoResponse, StatusCode> {
+    let gate = take_next_request_gate(&state.directory_gate);
+    let _finish = gate.as_ref().map(RequestGateFinish::new);
+    if let Some(gate) = &gate {
+        gate.wait_for_release().await;
+    }
+
     if state.directory_delay > Duration::ZERO {
         tokio::time::sleep(state.directory_delay).await;
     }

--- a/codex-rs/app-server/tests/suite/v2/app_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/app_list.rs
@@ -61,6 +61,13 @@ const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
 #[tokio::test]
 async fn list_apps_returns_empty_when_connectors_disabled() -> Result<()> {
     let codex_home = TempDir::new()?;
+    std::fs::write(
+        codex_home.path().join("config.toml"),
+        r#"
+[features]
+connectors = false
+"#,
+    )?;
     let mut mcp = McpProcess::new(codex_home.path()).await?;
 
     timeout(DEFAULT_TIMEOUT, mcp.initialize()).await??;
@@ -876,8 +883,13 @@ async fn list_apps_force_refetch_preserves_previous_cache_on_failure() -> Result
         plugin_display_names: Vec::new(),
     }];
     let tools = vec![connector_tool("beta", "Beta App")?];
-    let (server_url, server_handle) =
-        start_apps_server_with_delays(connectors, tools, Duration::ZERO, Duration::ZERO).await?;
+    let (server_url, server_handle, server_control) = start_apps_server_with_delays_and_control(
+        connectors,
+        tools,
+        Duration::ZERO,
+        Duration::from_millis(150),
+    )
+    .await?;
 
     let codex_home = TempDir::new()?;
     write_connectors_config(codex_home.path(), &server_url)?;
@@ -922,6 +934,7 @@ async fn list_apps_force_refetch_preserves_previous_cache_on_failure() -> Result
             .chatgpt_account_id("account-123"),
         AuthCredentialsStoreMode::File,
     )?;
+    server_control.set_tools(Vec::new());
 
     let refetch_request = mcp
         .send_apps_list_request(AppsListParams {
@@ -937,6 +950,8 @@ async fn list_apps_force_refetch_preserves_previous_cache_on_failure() -> Result
     )
     .await??;
     assert!(refetch_error.error.message.contains("failed to"));
+
+    tokio::time::sleep(Duration::from_millis(250)).await;
 
     let cached_request = mcp
         .send_apps_list_request(AppsListParams {


### PR DESCRIPTION
## Summary
- Abort unfinished app-list refresh tasks on error or timeout so a failed request cannot leave background work mutating caches later.
- Make the disabled-connectors test explicitly write `connectors = false` into the temp config.
- Strengthen the force-refetch cache test to exercise the race window that was causing intermittent failures.

## Testing
- `just fmt`
- `cargo test -p codex-app-server suite::v2::app_list`
- stress-tested `suite::v2::app_list::list_apps_force_refetch_preserves_previous_cache_on_failure` 30x
- `env CODEX_HOME=/tmp/codex-app-server-test-home cargo test -p codex-app-server`