### PR TITLE
Exclude manual targets from Bazel test CI

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -94,7 +94,7 @@ jobs:
             "${bazel_wrapper_args[@]}" \
             -- \
             test \
-            --test_tag_filters=-argument-comment-lint \
+            --test_tag_filters=-argument-comment-lint,-manual \
             --test_verbose_timeout_warnings \
             --build_metadata=COMMIT_SHA=${GITHUB_SHA} \
             -- \


### PR DESCRIPTION
## Summary

The Bazel workflow currently runs `bazel test //...` with `--test_tag_filters=-argument-comment-lint`. In practice, `tests(//...)` includes internal raw Rust `*-unit-tests-bin` targets generated by `codex_rust_crate`, even though those targets are tagged `manual` and have corresponding `workspace_root_test` wrapper targets.

Those raw binaries bypass the wrapper environment/runfiles setup. For example, `//codex-rs/core:core-unit-tests-bin` can fail `shell_snapshot::tests::macos_zsh_snapshot_includes_sections`, while the intended `//codex-rs/core:core-unit-tests` wrapper passes the same test.

This adds `-manual` to the Bazel test tag filter so CI exercises the intended wrapper/integration test targets and does not run internal manual test binaries directly.

## Validation

- `bazel test //codex-rs/core:core-unit-tests --test_arg=macos_zsh_snapshot_includes_sections --test_output=errors` passes locally.
- `bazel test //codex-rs/core:core-unit-tests-bin --test_arg=macos_zsh_snapshot_includes_sections --test_output=errors` reproduces the raw-bin failure locally.
- `bazel query 'attr(tags, manual, //codex-rs/core:*)'` shows `//codex-rs/core:core-unit-tests-bin` is tagged `manual`.
- `bazel test //codex-rs/core:core-unit-tests-bin --test_tag_filters=-manual --test_output=errors` reports the explicit target is excluded by filters, confirming the tag filter applies.