### PR TITLE
fix(tui): restore context usage when resuming sessions

### DIFF
--- a/codex-rs/analytics/src/analytics_client_tests.rs
+++ b/codex-rs/analytics/src/analytics_client_tests.rs
@@ -121,6 +121,7 @@ fn sample_thread_with_source(
         agent_role: None,
         git_info: None,
         name: None,
+        token_usage: None,
         turns: Vec::new(),
     }
 }

--- a/codex-rs/app-server-protocol/schema/json/ServerNotification.json
+++ b/codex-rs/app-server-protocol/schema/json/ServerNotification.json
@@ -2531,6 +2531,18 @@
           ],
           "description": "Current runtime status for the thread."
         },
+        "tokenUsage": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ThreadTokenUsage"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Latest known token usage for the thread, when available from runtime or rollout history."
+        },
         "turns": {
           "description": "Only populated on `thread/resume`, `thread/rollback`, `thread/fork`, and `thread/read` (when `includeTurns` is true) responses. For all other responses and notifications returning a Thread, the turns field will be an empty list.",
           "items": {

--- a/codex-rs/app-server-protocol/schema/json/ServerNotification.json
+++ b/codex-rs/app-server-protocol/schema/json/ServerNotification.json
@@ -2541,7 +2541,7 @@
             }
           ],
           "default": null,
-          "description": "Latest known token usage for the thread, when available from runtime or rollout history."
+          "description": "Latest token usage known when this thread snapshot was produced.\n\nApp-server emits live token usage updates separately, but resume and read responses must also carry the most recent persisted usage so clients can render context-window state before the next model turn produces a fresh update. A null value means no token-count event was available in runtime state or rollout history; clients should treat it as unknown rather than zero usage."
         },
         "turns": {
           "description": "Only populated on `thread/resume`, `thread/rollback`, `thread/fork`, and `thread/read` (when `includeTurns` is true) responses. For all other responses and notifications returning a Thread, the turns field will be an empty list.",

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
@@ -12772,6 +12772,18 @@
             ],
             "description": "Current runtime status for the thread."
           },
+          "tokenUsage": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/ThreadTokenUsage"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Latest known token usage for the thread, when available from runtime or rollout history."
+          },
           "turns": {
             "description": "Only populated on `thread/resume`, `thread/rollback`, `thread/fork`, and `thread/read` (when `includeTurns` is true) responses. For all other responses and notifications returning a Thread, the turns field will be an empty list.",
             "items": {

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
@@ -12782,7 +12782,7 @@
               }
             ],
             "default": null,
-            "description": "Latest known token usage for the thread, when available from runtime or rollout history."
+            "description": "Latest token usage known when this thread snapshot was produced.\n\nApp-server emits live token usage updates separately, but resume and read responses must also carry the most recent persisted usage so clients can render context-window state before the next model turn produces a fresh update. A null value means no token-count event was available in runtime state or rollout history; clients should treat it as unknown rather than zero usage."
           },
           "turns": {
             "description": "Only populated on `thread/resume`, `thread/rollback`, `thread/fork`, and `thread/read` (when `includeTurns` is true) responses. For all other responses and notifications returning a Thread, the turns field will be an empty list.",

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
@@ -10616,6 +10616,18 @@
           ],
           "description": "Current runtime status for the thread."
         },
+        "tokenUsage": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ThreadTokenUsage"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Latest known token usage for the thread, when available from runtime or rollout history."
+        },
         "turns": {
           "description": "Only populated on `thread/resume`, `thread/rollback`, `thread/fork`, and `thread/read` (when `includeTurns` is true) responses. For all other responses and notifications returning a Thread, the turns field will be an empty list.",
           "items": {

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
@@ -10626,7 +10626,7 @@
             }
           ],
           "default": null,
-          "description": "Latest known token usage for the thread, when available from runtime or rollout history."
+          "description": "Latest token usage known when this thread snapshot was produced.\n\nApp-server emits live token usage updates separately, but resume and read responses must also carry the most recent persisted usage so clients can render context-window state before the next model turn produces a fresh update. A null value means no token-count event was available in runtime state or rollout history; clients should treat it as unknown rather than zero usage."
         },
         "turns": {
           "description": "Only populated on `thread/resume`, `thread/rollback`, `thread/fork`, and `thread/read` (when `includeTurns` is true) responses. For all other responses and notifications returning a Thread, the turns field will be an empty list.",

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadForkResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadForkResponse.json
@@ -1116,7 +1116,7 @@
             }
           ],
           "default": null,
-          "description": "Latest known token usage for the thread, when available from runtime or rollout history."
+          "description": "Latest token usage known when this thread snapshot was produced.\n\nApp-server emits live token usage updates separately, but resume and read responses must also carry the most recent persisted usage so clients can render context-window state before the next model turn produces a fresh update. A null value means no token-count event was available in runtime state or rollout history; clients should treat it as unknown rather than zero usage."
         },
         "turns": {
           "description": "Only populated on `thread/resume`, `thread/rollback`, `thread/fork`, and `thread/read` (when `includeTurns` is true) responses. For all other responses and notifications returning a Thread, the turns field will be an empty list.",

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadForkResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadForkResponse.json
@@ -1106,6 +1106,18 @@
           ],
           "description": "Current runtime status for the thread."
         },
+        "tokenUsage": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ThreadTokenUsage"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Latest known token usage for the thread, when available from runtime or rollout history."
+        },
         "turns": {
           "description": "Only populated on `thread/resume`, `thread/rollback`, `thread/fork`, and `thread/read` (when `includeTurns` is true) responses. For all other responses and notifications returning a Thread, the turns field will be an empty list.",
           "items": {
@@ -1866,6 +1878,60 @@
           "type": "object"
         }
       ]
+    },
+    "ThreadTokenUsage": {
+      "properties": {
+        "last": {
+          "$ref": "#/definitions/TokenUsageBreakdown"
+        },
+        "modelContextWindow": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "total": {
+          "$ref": "#/definitions/TokenUsageBreakdown"
+        }
+      },
+      "required": [
+        "last",
+        "total"
+      ],
+      "type": "object"
+    },
+    "TokenUsageBreakdown": {
+      "properties": {
+        "cachedInputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "inputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "outputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "reasoningOutputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "totalTokens": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cachedInputTokens",
+        "inputTokens",
+        "outputTokens",
+        "reasoningOutputTokens",
+        "totalTokens"
+      ],
+      "type": "object"
     },
     "Turn": {
       "properties": {

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadListResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadListResponse.json
@@ -868,6 +868,18 @@
           ],
           "description": "Current runtime status for the thread."
         },
+        "tokenUsage": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ThreadTokenUsage"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Latest known token usage for the thread, when available from runtime or rollout history."
+        },
         "turns": {
           "description": "Only populated on `thread/resume`, `thread/rollback`, `thread/fork`, and `thread/read` (when `includeTurns` is true) responses. For all other responses and notifications returning a Thread, the turns field will be an empty list.",
           "items": {
@@ -1628,6 +1640,60 @@
           "type": "object"
         }
       ]
+    },
+    "ThreadTokenUsage": {
+      "properties": {
+        "last": {
+          "$ref": "#/definitions/TokenUsageBreakdown"
+        },
+        "modelContextWindow": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "total": {
+          "$ref": "#/definitions/TokenUsageBreakdown"
+        }
+      },
+      "required": [
+        "last",
+        "total"
+      ],
+      "type": "object"
+    },
+    "TokenUsageBreakdown": {
+      "properties": {
+        "cachedInputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "inputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "outputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "reasoningOutputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "totalTokens": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cachedInputTokens",
+        "inputTokens",
+        "outputTokens",
+        "reasoningOutputTokens",
+        "totalTokens"
+      ],
+      "type": "object"
     },
     "Turn": {
       "properties": {

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadListResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadListResponse.json
@@ -878,7 +878,7 @@
             }
           ],
           "default": null,
-          "description": "Latest known token usage for the thread, when available from runtime or rollout history."
+          "description": "Latest token usage known when this thread snapshot was produced.\n\nApp-server emits live token usage updates separately, but resume and read responses must also carry the most recent persisted usage so clients can render context-window state before the next model turn produces a fresh update. A null value means no token-count event was available in runtime state or rollout history; clients should treat it as unknown rather than zero usage."
         },
         "turns": {
           "description": "Only populated on `thread/resume`, `thread/rollback`, `thread/fork`, and `thread/read` (when `includeTurns` is true) responses. For all other responses and notifications returning a Thread, the turns field will be an empty list.",

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadMetadataUpdateResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadMetadataUpdateResponse.json
@@ -868,6 +868,18 @@
           ],
           "description": "Current runtime status for the thread."
         },
+        "tokenUsage": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ThreadTokenUsage"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Latest known token usage for the thread, when available from runtime or rollout history."
+        },
         "turns": {
           "description": "Only populated on `thread/resume`, `thread/rollback`, `thread/fork`, and `thread/read` (when `includeTurns` is true) responses. For all other responses and notifications returning a Thread, the turns field will be an empty list.",
           "items": {
@@ -1628,6 +1640,60 @@
           "type": "object"
         }
       ]
+    },
+    "ThreadTokenUsage": {
+      "properties": {
+        "last": {
+          "$ref": "#/definitions/TokenUsageBreakdown"
+        },
+        "modelContextWindow": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "total": {
+          "$ref": "#/definitions/TokenUsageBreakdown"
+        }
+      },
+      "required": [
+        "last",
+        "total"
+      ],
+      "type": "object"
+    },
+    "TokenUsageBreakdown": {
+      "properties": {
+        "cachedInputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "inputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "outputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "reasoningOutputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "totalTokens": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cachedInputTokens",
+        "inputTokens",
+        "outputTokens",
+        "reasoningOutputTokens",
+        "totalTokens"
+      ],
+      "type": "object"
     },
     "Turn": {
       "properties": {

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadMetadataUpdateResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadMetadataUpdateResponse.json
@@ -878,7 +878,7 @@
             }
           ],
           "default": null,
-          "description": "Latest known token usage for the thread, when available from runtime or rollout history."
+          "description": "Latest token usage known when this thread snapshot was produced.\n\nApp-server emits live token usage updates separately, but resume and read responses must also carry the most recent persisted usage so clients can render context-window state before the next model turn produces a fresh update. A null value means no token-count event was available in runtime state or rollout history; clients should treat it as unknown rather than zero usage."
         },
         "turns": {
           "description": "Only populated on `thread/resume`, `thread/rollback`, `thread/fork`, and `thread/read` (when `includeTurns` is true) responses. For all other responses and notifications returning a Thread, the turns field will be an empty list.",

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadReadResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadReadResponse.json
@@ -868,6 +868,18 @@
           ],
           "description": "Current runtime status for the thread."
         },
+        "tokenUsage": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ThreadTokenUsage"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Latest known token usage for the thread, when available from runtime or rollout history."
+        },
         "turns": {
           "description": "Only populated on `thread/resume`, `thread/rollback`, `thread/fork`, and `thread/read` (when `includeTurns` is true) responses. For all other responses and notifications returning a Thread, the turns field will be an empty list.",
           "items": {
@@ -1628,6 +1640,60 @@
           "type": "object"
         }
       ]
+    },
+    "ThreadTokenUsage": {
+      "properties": {
+        "last": {
+          "$ref": "#/definitions/TokenUsageBreakdown"
+        },
+        "modelContextWindow": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "total": {
+          "$ref": "#/definitions/TokenUsageBreakdown"
+        }
+      },
+      "required": [
+        "last",
+        "total"
+      ],
+      "type": "object"
+    },
+    "TokenUsageBreakdown": {
+      "properties": {
+        "cachedInputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "inputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "outputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "reasoningOutputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "totalTokens": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cachedInputTokens",
+        "inputTokens",
+        "outputTokens",
+        "reasoningOutputTokens",
+        "totalTokens"
+      ],
+      "type": "object"
     },
     "Turn": {
       "properties": {

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadReadResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadReadResponse.json
@@ -878,7 +878,7 @@
             }
           ],
           "default": null,
-          "description": "Latest known token usage for the thread, when available from runtime or rollout history."
+          "description": "Latest token usage known when this thread snapshot was produced.\n\nApp-server emits live token usage updates separately, but resume and read responses must also carry the most recent persisted usage so clients can render context-window state before the next model turn produces a fresh update. A null value means no token-count event was available in runtime state or rollout history; clients should treat it as unknown rather than zero usage."
         },
         "turns": {
           "description": "Only populated on `thread/resume`, `thread/rollback`, `thread/fork`, and `thread/read` (when `includeTurns` is true) responses. For all other responses and notifications returning a Thread, the turns field will be an empty list.",

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadResumeResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadResumeResponse.json
@@ -1116,7 +1116,7 @@
             }
           ],
           "default": null,
-          "description": "Latest known token usage for the thread, when available from runtime or rollout history."
+          "description": "Latest token usage known when this thread snapshot was produced.\n\nApp-server emits live token usage updates separately, but resume and read responses must also carry the most recent persisted usage so clients can render context-window state before the next model turn produces a fresh update. A null value means no token-count event was available in runtime state or rollout history; clients should treat it as unknown rather than zero usage."
         },
         "turns": {
           "description": "Only populated on `thread/resume`, `thread/rollback`, `thread/fork`, and `thread/read` (when `includeTurns` is true) responses. For all other responses and notifications returning a Thread, the turns field will be an empty list.",

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadResumeResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadResumeResponse.json
@@ -1106,6 +1106,18 @@
           ],
           "description": "Current runtime status for the thread."
         },
+        "tokenUsage": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ThreadTokenUsage"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Latest known token usage for the thread, when available from runtime or rollout history."
+        },
         "turns": {
           "description": "Only populated on `thread/resume`, `thread/rollback`, `thread/fork`, and `thread/read` (when `includeTurns` is true) responses. For all other responses and notifications returning a Thread, the turns field will be an empty list.",
           "items": {
@@ -1866,6 +1878,60 @@
           "type": "object"
         }
       ]
+    },
+    "ThreadTokenUsage": {
+      "properties": {
+        "last": {
+          "$ref": "#/definitions/TokenUsageBreakdown"
+        },
+        "modelContextWindow": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "total": {
+          "$ref": "#/definitions/TokenUsageBreakdown"
+        }
+      },
+      "required": [
+        "last",
+        "total"
+      ],
+      "type": "object"
+    },
+    "TokenUsageBreakdown": {
+      "properties": {
+        "cachedInputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "inputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "outputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "reasoningOutputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "totalTokens": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cachedInputTokens",
+        "inputTokens",
+        "outputTokens",
+        "reasoningOutputTokens",
+        "totalTokens"
+      ],
+      "type": "object"
     },
     "Turn": {
       "properties": {

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadRollbackResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadRollbackResponse.json
@@ -868,6 +868,18 @@
           ],
           "description": "Current runtime status for the thread."
         },
+        "tokenUsage": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ThreadTokenUsage"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Latest known token usage for the thread, when available from runtime or rollout history."
+        },
         "turns": {
           "description": "Only populated on `thread/resume`, `thread/rollback`, `thread/fork`, and `thread/read` (when `includeTurns` is true) responses. For all other responses and notifications returning a Thread, the turns field will be an empty list.",
           "items": {
@@ -1628,6 +1640,60 @@
           "type": "object"
         }
       ]
+    },
+    "ThreadTokenUsage": {
+      "properties": {
+        "last": {
+          "$ref": "#/definitions/TokenUsageBreakdown"
+        },
+        "modelContextWindow": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "total": {
+          "$ref": "#/definitions/TokenUsageBreakdown"
+        }
+      },
+      "required": [
+        "last",
+        "total"
+      ],
+      "type": "object"
+    },
+    "TokenUsageBreakdown": {
+      "properties": {
+        "cachedInputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "inputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "outputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "reasoningOutputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "totalTokens": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cachedInputTokens",
+        "inputTokens",
+        "outputTokens",
+        "reasoningOutputTokens",
+        "totalTokens"
+      ],
+      "type": "object"
     },
     "Turn": {
       "properties": {

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadRollbackResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadRollbackResponse.json
@@ -878,7 +878,7 @@
             }
           ],
           "default": null,
-          "description": "Latest known token usage for the thread, when available from runtime or rollout history."
+          "description": "Latest token usage known when this thread snapshot was produced.\n\nApp-server emits live token usage updates separately, but resume and read responses must also carry the most recent persisted usage so clients can render context-window state before the next model turn produces a fresh update. A null value means no token-count event was available in runtime state or rollout history; clients should treat it as unknown rather than zero usage."
         },
         "turns": {
           "description": "Only populated on `thread/resume`, `thread/rollback`, `thread/fork`, and `thread/read` (when `includeTurns` is true) responses. For all other responses and notifications returning a Thread, the turns field will be an empty list.",

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadStartResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadStartResponse.json
@@ -1116,7 +1116,7 @@
             }
           ],
           "default": null,
-          "description": "Latest known token usage for the thread, when available from runtime or rollout history."
+          "description": "Latest token usage known when this thread snapshot was produced.\n\nApp-server emits live token usage updates separately, but resume and read responses must also carry the most recent persisted usage so clients can render context-window state before the next model turn produces a fresh update. A null value means no token-count event was available in runtime state or rollout history; clients should treat it as unknown rather than zero usage."
         },
         "turns": {
           "description": "Only populated on `thread/resume`, `thread/rollback`, `thread/fork`, and `thread/read` (when `includeTurns` is true) responses. For all other responses and notifications returning a Thread, the turns field will be an empty list.",

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadStartResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadStartResponse.json
@@ -1106,6 +1106,18 @@
           ],
           "description": "Current runtime status for the thread."
         },
+        "tokenUsage": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ThreadTokenUsage"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Latest known token usage for the thread, when available from runtime or rollout history."
+        },
         "turns": {
           "description": "Only populated on `thread/resume`, `thread/rollback`, `thread/fork`, and `thread/read` (when `includeTurns` is true) responses. For all other responses and notifications returning a Thread, the turns field will be an empty list.",
           "items": {
@@ -1866,6 +1878,60 @@
           "type": "object"
         }
       ]
+    },
+    "ThreadTokenUsage": {
+      "properties": {
+        "last": {
+          "$ref": "#/definitions/TokenUsageBreakdown"
+        },
+        "modelContextWindow": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "total": {
+          "$ref": "#/definitions/TokenUsageBreakdown"
+        }
+      },
+      "required": [
+        "last",
+        "total"
+      ],
+      "type": "object"
+    },
+    "TokenUsageBreakdown": {
+      "properties": {
+        "cachedInputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "inputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "outputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "reasoningOutputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "totalTokens": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cachedInputTokens",
+        "inputTokens",
+        "outputTokens",
+        "reasoningOutputTokens",
+        "totalTokens"
+      ],
+      "type": "object"
     },
     "Turn": {
       "properties": {

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadStartedNotification.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadStartedNotification.json
@@ -868,6 +868,18 @@
           ],
           "description": "Current runtime status for the thread."
         },
+        "tokenUsage": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ThreadTokenUsage"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Latest known token usage for the thread, when available from runtime or rollout history."
+        },
         "turns": {
           "description": "Only populated on `thread/resume`, `thread/rollback`, `thread/fork`, and `thread/read` (when `includeTurns` is true) responses. For all other responses and notifications returning a Thread, the turns field will be an empty list.",
           "items": {
@@ -1628,6 +1640,60 @@
           "type": "object"
         }
       ]
+    },
+    "ThreadTokenUsage": {
+      "properties": {
+        "last": {
+          "$ref": "#/definitions/TokenUsageBreakdown"
+        },
+        "modelContextWindow": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "total": {
+          "$ref": "#/definitions/TokenUsageBreakdown"
+        }
+      },
+      "required": [
+        "last",
+        "total"
+      ],
+      "type": "object"
+    },
+    "TokenUsageBreakdown": {
+      "properties": {
+        "cachedInputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "inputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "outputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "reasoningOutputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "totalTokens": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cachedInputTokens",
+        "inputTokens",
+        "outputTokens",
+        "reasoningOutputTokens",
+        "totalTokens"
+      ],
+      "type": "object"
     },
     "Turn": {
       "properties": {

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadStartedNotification.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadStartedNotification.json
@@ -878,7 +878,7 @@
             }
           ],
           "default": null,
-          "description": "Latest known token usage for the thread, when available from runtime or rollout history."
+          "description": "Latest token usage known when this thread snapshot was produced.\n\nApp-server emits live token usage updates separately, but resume and read responses must also carry the most recent persisted usage so clients can render context-window state before the next model turn produces a fresh update. A null value means no token-count event was available in runtime state or rollout history; clients should treat it as unknown rather than zero usage."
         },
         "turns": {
           "description": "Only populated on `thread/resume`, `thread/rollback`, `thread/fork`, and `thread/read` (when `includeTurns` is true) responses. For all other responses and notifications returning a Thread, the turns field will be an empty list.",

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadUnarchiveResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadUnarchiveResponse.json
@@ -868,6 +868,18 @@
           ],
           "description": "Current runtime status for the thread."
         },
+        "tokenUsage": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ThreadTokenUsage"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Latest known token usage for the thread, when available from runtime or rollout history."
+        },
         "turns": {
           "description": "Only populated on `thread/resume`, `thread/rollback`, `thread/fork`, and `thread/read` (when `includeTurns` is true) responses. For all other responses and notifications returning a Thread, the turns field will be an empty list.",
           "items": {
@@ -1628,6 +1640,60 @@
           "type": "object"
         }
       ]
+    },
+    "ThreadTokenUsage": {
+      "properties": {
+        "last": {
+          "$ref": "#/definitions/TokenUsageBreakdown"
+        },
+        "modelContextWindow": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "total": {
+          "$ref": "#/definitions/TokenUsageBreakdown"
+        }
+      },
+      "required": [
+        "last",
+        "total"
+      ],
+      "type": "object"
+    },
+    "TokenUsageBreakdown": {
+      "properties": {
+        "cachedInputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "inputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "outputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "reasoningOutputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "totalTokens": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cachedInputTokens",
+        "inputTokens",
+        "outputTokens",
+        "reasoningOutputTokens",
+        "totalTokens"
+      ],
+      "type": "object"
     },
     "Turn": {
       "properties": {

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadUnarchiveResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadUnarchiveResponse.json
@@ -878,7 +878,7 @@
             }
           ],
           "default": null,
-          "description": "Latest known token usage for the thread, when available from runtime or rollout history."
+          "description": "Latest token usage known when this thread snapshot was produced.\n\nApp-server emits live token usage updates separately, but resume and read responses must also carry the most recent persisted usage so clients can render context-window state before the next model turn produces a fresh update. A null value means no token-count event was available in runtime state or rollout history; clients should treat it as unknown rather than zero usage."
         },
         "turns": {
           "description": "Only populated on `thread/resume`, `thread/rollback`, `thread/fork`, and `thread/read` (when `includeTurns` is true) responses. For all other responses and notifications returning a Thread, the turns field will be an empty list.",

--- a/codex-rs/app-server-protocol/schema/typescript/v2/Thread.ts
+++ b/codex-rs/app-server-protocol/schema/typescript/v2/Thread.ts
@@ -70,7 +70,9 @@ gitInfo: GitInfo | null,
  */
 name: string | null,
 /**
- * Latest known token usage for the thread, when available from runtime or rollout history.
+ * Latest token usage known when this thread snapshot was produced.
+ *
+ * App-server emits live token usage updates separately, but resume and read responses must also carry the most recent persisted usage so clients can render context-window state before the next model turn produces a fresh update. A null value means no token-count event was available in runtime state or rollout history; clients should treat it as unknown rather than zero usage.
  */
 tokenUsage: ThreadTokenUsage | null,
 /**

--- a/codex-rs/app-server-protocol/schema/typescript/v2/Thread.ts
+++ b/codex-rs/app-server-protocol/schema/typescript/v2/Thread.ts
@@ -5,6 +5,7 @@ import type { AbsolutePathBuf } from "../AbsolutePathBuf";
 import type { GitInfo } from "./GitInfo";
 import type { SessionSource } from "./SessionSource";
 import type { ThreadStatus } from "./ThreadStatus";
+import type { ThreadTokenUsage } from "./ThreadTokenUsage";
 import type { Turn } from "./Turn";
 
 export type Thread = { id: string,
@@ -68,6 +69,10 @@ gitInfo: GitInfo | null,
  * Optional user-facing thread title.
  */
 name: string | null,
+/**
+ * Latest known token usage for the thread, when available from runtime or rollout history.
+ */
+tokenUsage: ThreadTokenUsage | null,
 /**
  * Only populated on `thread/resume`, `thread/rollback`, `thread/fork`, and `thread/read`
  * (when `includeTurns` is true) responses.

--- a/codex-rs/app-server-protocol/src/protocol/common.rs
+++ b/codex-rs/app-server-protocol/src/protocol/common.rs
@@ -1421,6 +1421,7 @@ mod tests {
                     agent_role: None,
                     git_info: None,
                     name: None,
+                    token_usage: None,
                     turns: Vec::new(),
                 },
                 model: "gpt-5".to_string(),
@@ -1461,6 +1462,7 @@ mod tests {
                         "agentRole": null,
                         "gitInfo": null,
                         "name": null,
+                        "tokenUsage": null,
                         "turns": []
                     },
                     "model": "gpt-5",

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -3790,6 +3790,9 @@ pub struct Thread {
     pub git_info: Option<GitInfo>,
     /// Optional user-facing thread title.
     pub name: Option<String>,
+    /// Latest known token usage for the thread, when available from runtime or rollout history.
+    #[serde(default)]
+    pub token_usage: Option<ThreadTokenUsage>,
     /// Only populated on `thread/resume`, `thread/rollback`, `thread/fork`, and `thread/read`
     /// (when `includeTurns` is true) responses.
     /// For all other responses and notifications returning a Thread,
@@ -8710,6 +8713,7 @@ mod tests {
                 "agentRole": null,
                 "gitInfo": null,
                 "name": null,
+                "tokenUsage": null,
                 "turns": []
             },
             "model": "gpt-5",

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -3790,7 +3790,9 @@ pub struct Thread {
     pub git_info: Option<GitInfo>,
     /// Optional user-facing thread title.
     pub name: Option<String>,
-    /// Latest known token usage for the thread, when available from runtime or rollout history.
+    /// Latest token usage known when this thread snapshot was produced.
+    ///
+    /// App-server emits live token usage updates separately, but resume and read responses must also carry the most recent persisted usage so clients can render context-window state before the next model turn produces a fresh update. A null value means no token-count event was available in runtime state or rollout history; clients should treat it as unknown rather than zero usage.
     #[serde(default)]
     pub token_usage: Option<ThreadTokenUsage>,
     /// Only populated on `thread/resume`, `thread/rollback`, `thread/fork`, and `thread/read`

--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -129,6 +129,7 @@ use codex_protocol::protocol::Op;
 use codex_protocol::protocol::RealtimeEvent;
 use codex_protocol::protocol::ReviewDecision;
 use codex_protocol::protocol::ReviewOutputEvent;
+use codex_protocol::protocol::RolloutItem;
 use codex_protocol::protocol::TokenCountEvent;
 use codex_protocol::protocol::TurnAbortedEvent;
 use codex_protocol::protocol::TurnCompleteEvent;
@@ -1839,6 +1840,7 @@ pub(crate) async fn apply_bespoke_event_handling(
                         match read_rollout_items_from_rollout(rollout_path.as_path()).await {
                             Ok(items) => {
                                 thread.turns = build_turns_from_rollout_items(&items);
+                                thread.token_usage = last_token_usage_from_rollout_items(&items);
                                 thread.status = thread_watch_manager
                                     .loaded_status_for_thread(&thread.id)
                                     .await;
@@ -2296,6 +2298,15 @@ async fn handle_token_count_event(
             ))
             .await;
     }
+}
+
+fn last_token_usage_from_rollout_items(items: &[RolloutItem]) -> Option<ThreadTokenUsage> {
+    items.iter().rev().find_map(|item| match item {
+        RolloutItem::EventMsg(EventMsg::TokenCount(ev)) => {
+            ev.info.clone().map(ThreadTokenUsage::from)
+        }
+        _ => None,
+    })
 }
 
 async fn handle_error(

--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -2300,6 +2300,9 @@ async fn handle_token_count_event(
     }
 }
 
+/// Returns the newest persisted token usage in rollout order.
+///
+/// Rollback responses rebuild their thread snapshot from the same rollout file used by resume/read paths, so they need the same interpretation of token-count events. A missing value means the rollback target predates persisted token counts or never received one.
 fn last_token_usage_from_rollout_items(items: &[RolloutItem]) -> Option<ThreadTokenUsage> {
     items.iter().rev().find_map(|item| match item {
         RolloutItem::EventMsg(EventMsg::TokenCount(ev)) => {

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -8777,6 +8777,9 @@ enum ThreadTurnSource<'a> {
     HistoryItems(&'a [RolloutItem]),
 }
 
+/// Rehydrates the transcript-facing state that is derived from rollout history.
+///
+/// Thread snapshots store turns and token usage together because both are projections over the same ordered rollout stream. Keeping them in one helper prevents resume/read paths from restoring visible history while leaving the context-usage cache stale until a new turn emits `TokenCount`. When an active turn is supplied, it is merged only into the returned turn list; token usage still comes from persisted rollout items because in-flight usage is delivered through live token-usage notifications.
 async fn populate_thread_turns(
     thread: &mut Thread,
     turn_source: ThreadTurnSource<'_>,
@@ -8815,6 +8818,9 @@ fn apply_rollout_items_to_thread(
     thread.token_usage = last_token_usage_from_rollout_items(items);
 }
 
+/// Returns the newest persisted token usage in rollout order.
+///
+/// Rollouts may contain many token-count events across multiple turns, and only the latest one describes the status-line state the user saw before resume. Reading from the end also preserves compatibility with older rollouts that contain no token counts: callers receive `None` and can leave context usage unknown.
 fn last_token_usage_from_rollout_items(items: &[RolloutItem]) -> Option<ThreadTokenUsage> {
     items.iter().rev().find_map(|item| match item {
         RolloutItem::EventMsg(EventMsg::TokenCount(ev)) => {

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -9917,11 +9917,11 @@ mod tests {
     fn last_token_usage_from_rollout_items_uses_latest_token_count() {
         let items = vec![
             RolloutItem::EventMsg(EventMsg::TokenCount(TokenCountEvent {
-                info: Some(token_usage_info(100, Some(1_000))),
+                info: Some(token_usage_info(/*total_tokens*/ 100, Some(1_000))),
                 rate_limits: None,
             })),
             RolloutItem::EventMsg(EventMsg::TokenCount(TokenCountEvent {
-                info: Some(token_usage_info(250, Some(2_000))),
+                info: Some(token_usage_info(/*total_tokens*/ 250, Some(2_000))),
                 rate_limits: None,
             })),
         ];

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -177,6 +177,7 @@ use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
 use codex_app_server_protocol::ThreadStartedNotification;
 use codex_app_server_protocol::ThreadStatus;
+use codex_app_server_protocol::ThreadTokenUsage;
 use codex_app_server_protocol::ThreadUnarchiveParams;
 use codex_app_server_protocol::ThreadUnarchiveResponse;
 use codex_app_server_protocol::ThreadUnarchivedNotification;
@@ -4050,7 +4051,7 @@ impl CodexMessageProcessor {
         if include_turns && let Some(rollout_path) = rollout_path.as_ref() {
             match read_rollout_items_from_rollout(rollout_path).await {
                 Ok(items) => {
-                    thread.turns = build_turns_from_rollout_items(&items);
+                    apply_rollout_items_to_thread(&mut thread, &items, /*active_turn*/ None);
                 }
                 Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
                     self.send_invalid_request_error(
@@ -8781,26 +8782,46 @@ async fn populate_thread_turns(
     turn_source: ThreadTurnSource<'_>,
     active_turn: Option<&Turn>,
 ) -> std::result::Result<(), String> {
-    let mut turns = match turn_source {
+    match turn_source {
         ThreadTurnSource::RolloutPath(rollout_path) => {
-            read_rollout_items_from_rollout(rollout_path)
+            let items = read_rollout_items_from_rollout(rollout_path)
                 .await
-                .map(|items| build_turns_from_rollout_items(&items))
                 .map_err(|err| {
                     format!(
                         "failed to load rollout `{}` for thread {}: {err}",
                         rollout_path.display(),
                         thread.id
                     )
-                })?
+                })?;
+            apply_rollout_items_to_thread(thread, &items, active_turn);
         }
-        ThreadTurnSource::HistoryItems(items) => build_turns_from_rollout_items(items),
-    };
+        ThreadTurnSource::HistoryItems(items) => {
+            apply_rollout_items_to_thread(thread, items, active_turn);
+        }
+    }
+    Ok(())
+}
+
+fn apply_rollout_items_to_thread(
+    thread: &mut Thread,
+    items: &[RolloutItem],
+    active_turn: Option<&Turn>,
+) {
+    let mut turns = build_turns_from_rollout_items(items);
     if let Some(active_turn) = active_turn {
         merge_turn_history_with_active_turn(&mut turns, active_turn.clone());
     }
     thread.turns = turns;
-    Ok(())
+    thread.token_usage = last_token_usage_from_rollout_items(items);
+}
+
+fn last_token_usage_from_rollout_items(items: &[RolloutItem]) -> Option<ThreadTokenUsage> {
+    items.iter().rev().find_map(|item| match item {
+        RolloutItem::EventMsg(EventMsg::TokenCount(ev)) => {
+            ev.info.clone().map(ThreadTokenUsage::from)
+        }
+        _ => None,
+    })
 }
 
 async fn resolve_pending_server_request(
@@ -9783,6 +9804,7 @@ fn build_thread_from_snapshot(
         source: config_snapshot.session_source.clone().into(),
         git_info: None,
         name: None,
+        token_usage: None,
         turns: Vec::new(),
     }
 }
@@ -9838,6 +9860,7 @@ pub(crate) fn summary_to_thread(
         source: source.into(),
         git_info,
         name: None,
+        token_usage: None,
         turns: Vec::new(),
     }
 }
@@ -9849,16 +9872,77 @@ mod tests {
     use crate::outgoing_message::OutgoingMessage;
     use anyhow::Result;
     use codex_app_server_protocol::ServerRequestPayload;
+    use codex_app_server_protocol::TokenUsageBreakdown;
     use codex_app_server_protocol::ToolRequestUserInputParams;
     use codex_protocol::openai_models::ReasoningEffort;
     use codex_protocol::protocol::SessionSource;
     use codex_protocol::protocol::SubAgentSource;
+    use codex_protocol::protocol::TokenCountEvent;
+    use codex_protocol::protocol::TokenUsage;
+    use codex_protocol::protocol::TokenUsageInfo;
     use codex_utils_absolute_path::test_support::PathBufExt;
     use codex_utils_absolute_path::test_support::test_path_buf;
     use pretty_assertions::assert_eq;
     use serde_json::json;
     use std::path::PathBuf;
     use tempfile::TempDir;
+
+    fn token_usage_info(total_tokens: i64, model_context_window: Option<i64>) -> TokenUsageInfo {
+        TokenUsageInfo {
+            total_token_usage: TokenUsage {
+                input_tokens: total_tokens,
+                cached_input_tokens: 0,
+                output_tokens: 0,
+                reasoning_output_tokens: 0,
+                total_tokens,
+            },
+            last_token_usage: TokenUsage {
+                input_tokens: total_tokens,
+                cached_input_tokens: 0,
+                output_tokens: 0,
+                reasoning_output_tokens: 0,
+                total_tokens,
+            },
+            model_context_window,
+        }
+    }
+
+    #[test]
+    fn last_token_usage_from_rollout_items_uses_latest_token_count() {
+        let items = vec![
+            RolloutItem::EventMsg(EventMsg::TokenCount(TokenCountEvent {
+                info: Some(token_usage_info(100, Some(1_000))),
+                rate_limits: None,
+            })),
+            RolloutItem::EventMsg(EventMsg::TokenCount(TokenCountEvent {
+                info: Some(token_usage_info(250, Some(2_000))),
+                rate_limits: None,
+            })),
+        ];
+
+        let usage = last_token_usage_from_rollout_items(&items).expect("token usage");
+
+        assert_eq!(
+            usage,
+            ThreadTokenUsage {
+                total: TokenUsageBreakdown {
+                    total_tokens: 250,
+                    input_tokens: 250,
+                    cached_input_tokens: 0,
+                    output_tokens: 0,
+                    reasoning_output_tokens: 0,
+                },
+                last: TokenUsageBreakdown {
+                    total_tokens: 250,
+                    input_tokens: 250,
+                    cached_input_tokens: 0,
+                    output_tokens: 0,
+                    reasoning_output_tokens: 0,
+                },
+                model_context_window: Some(2_000),
+            }
+        );
+    }
 
     #[test]
     fn validate_dynamic_tools_rejects_unsupported_input_schema() {

--- a/codex-rs/app-server/src/thread_status.rs
+++ b/codex-rs/app-server/src/thread_status.rs
@@ -902,6 +902,7 @@ mod tests {
             source,
             git_info: None,
             name: None,
+            token_usage: None,
             turns: Vec::new(),
         }
     }

--- a/codex-rs/exec/src/lib_tests.rs
+++ b/codex-rs/exec/src/lib_tests.rs
@@ -259,6 +259,7 @@ fn turn_items_for_thread_returns_matching_turn_items() {
         agent_role: None,
         git_info: None,
         name: None,
+        token_usage: None,
         turns: vec![
             codex_app_server_protocol::Turn {
                 id: "turn-1".to_string(),
@@ -406,6 +407,7 @@ fn session_configured_from_thread_response_uses_review_policy_from_response() {
             agent_role: None,
             git_info: None,
             name: Some("thread".to_string()),
+            token_usage: None,
             turns: vec![],
         },
         model: "gpt-5.4".to_string(),

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -2756,6 +2756,7 @@ impl App {
         session.history_log_id = 0;
         session.history_entry_count = 0;
         session.rollout_path = rollout_path;
+        session.token_usage = notification.thread.token_usage.clone();
         self.upsert_agent_picker_thread(
             thread_id,
             notification.thread.agent_nickname.clone(),
@@ -9246,6 +9247,65 @@ guardian_approval = true
         Ok(())
     }
 
+    #[tokio::test]
+    async fn inactive_thread_started_notification_overwrites_primary_token_usage() -> Result<()> {
+        let mut app = make_test_app().await;
+        let main_thread_id =
+            ThreadId::from_string("00000000-0000-0000-0000-000000000401").expect("valid thread");
+        let agent_thread_id =
+            ThreadId::from_string("00000000-0000-0000-0000-000000000402").expect("valid thread");
+        let primary_token_usage = thread_token_usage(/*total_tokens*/ 90_000, Some(120_000));
+        let agent_token_usage = thread_token_usage(/*total_tokens*/ 30_000, Some(120_000));
+        let primary_session = ThreadSessionState {
+            token_usage: Some(primary_token_usage),
+            ..test_thread_session(main_thread_id, test_path_buf("/tmp/main"))
+        };
+
+        app.primary_thread_id = Some(main_thread_id);
+        app.active_thread_id = Some(main_thread_id);
+        app.primary_session_configured = Some(primary_session.clone());
+
+        app.enqueue_thread_notification(
+            agent_thread_id,
+            ServerNotification::ThreadStarted(ThreadStartedNotification {
+                thread: Thread {
+                    id: agent_thread_id.to_string(),
+                    forked_from_id: None,
+                    preview: "agent thread".to_string(),
+                    ephemeral: false,
+                    model_provider: "agent-provider".to_string(),
+                    created_at: 1,
+                    updated_at: 2,
+                    status: codex_app_server_protocol::ThreadStatus::Idle,
+                    path: None,
+                    cwd: test_path_buf("/tmp/agent").abs(),
+                    cli_version: "0.0.0".to_string(),
+                    source: codex_app_server_protocol::SessionSource::Unknown,
+                    agent_nickname: Some("Robie".to_string()),
+                    agent_role: Some("explorer".to_string()),
+                    git_info: None,
+                    name: Some("agent thread".to_string()),
+                    token_usage: Some(agent_token_usage.clone()),
+                    turns: Vec::new(),
+                },
+            }),
+        )
+        .await?;
+
+        let store = app
+            .thread_event_channels
+            .get(&agent_thread_id)
+            .expect("agent thread channel")
+            .store
+            .lock()
+            .await;
+        let session = store.session.clone().expect("inferred session");
+
+        assert_eq!(session.token_usage, Some(agent_token_usage));
+
+        Ok(())
+    }
+
     #[test]
     fn agent_picker_item_name_snapshot() {
         let thread_id =
@@ -9746,6 +9806,29 @@ guardian_approval = true
                 model_context_window,
             },
         })
+    }
+
+    fn thread_token_usage(
+        total_tokens: i64,
+        model_context_window: Option<i64>,
+    ) -> ThreadTokenUsage {
+        ThreadTokenUsage {
+            total: TokenUsageBreakdown {
+                total_tokens,
+                input_tokens: total_tokens,
+                cached_input_tokens: 0,
+                output_tokens: 0,
+                reasoning_output_tokens: 0,
+            },
+            last: TokenUsageBreakdown {
+                total_tokens,
+                input_tokens: total_tokens,
+                cached_input_tokens: 0,
+                output_tokens: 0,
+                reasoning_output_tokens: 0,
+            },
+            model_context_window,
+        }
     }
 
     fn hook_started_notification(thread_id: ThreadId, turn_id: &str) -> ServerNotification {

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -3195,6 +3195,7 @@ impl App {
                 history_entry_count: 0,
                 network_proxy: None,
                 rollout_path: thread.path.clone(),
+                token_usage: None,
             });
         session.thread_id = thread_id;
         session.thread_name = thread.name.clone();
@@ -3202,6 +3203,7 @@ impl App {
         session.cwd = thread.cwd.clone();
         session.instruction_source_paths = Vec::new();
         session.rollout_path = thread.path.clone();
+        session.token_usage = thread.token_usage.clone();
         if let Some(model) =
             read_session_model(&self.config, thread_id, thread.path.as_deref()).await
         {
@@ -7725,6 +7727,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn thread_session_token_usage_seeds_status_line_on_resume() {
+        let mut app = make_test_app().await;
+        app.chat_widget
+            .setup_status_line(vec![crate::bottom_pane::StatusLineItem::ContextUsed]);
+        let mut session = test_thread_session(ThreadId::new(), test_path_buf("/tmp/project"));
+        session.token_usage = Some(ThreadTokenUsage {
+            total: TokenUsageBreakdown {
+                total_tokens: 99_000,
+                input_tokens: 99_000,
+                cached_input_tokens: 0,
+                output_tokens: 0,
+                reasoning_output_tokens: 0,
+            },
+            last: TokenUsageBreakdown {
+                total_tokens: 99_000,
+                input_tokens: 99_000,
+                cached_input_tokens: 0,
+                output_tokens: 0,
+                reasoning_output_tokens: 0,
+            },
+            model_context_window: Some(112_000),
+        });
+
+        app.chat_widget.handle_thread_session(session);
+
+        assert_eq!(
+            app.chat_widget.status_line_text(),
+            Some("Context 87% used".into())
+        );
+    }
+
+    #[tokio::test]
     async fn open_agent_picker_keeps_missing_threads_for_replay() -> Result<()> {
         let mut app = make_test_app().await;
         let mut app_server =
@@ -9109,6 +9143,7 @@ guardian_approval = true
                     agent_role: Some("explorer".to_string()),
                     git_info: None,
                     name: Some("agent thread".to_string()),
+                    token_usage: None,
                     turns: Vec::new(),
                 },
             }),
@@ -9190,6 +9225,7 @@ guardian_approval = true
                     agent_role: Some("explorer".to_string()),
                     git_info: None,
                     name: Some("agent thread".to_string()),
+                    token_usage: None,
                     turns: Vec::new(),
                 },
             }),
@@ -9637,6 +9673,7 @@ guardian_approval = true
             history_entry_count: 0,
             network_proxy: None,
             rollout_path: Some(PathBuf::new()),
+            token_usage: None,
         }
     }
 
@@ -11187,6 +11224,7 @@ guardian_approval = true
                     agent_role: None,
                     git_info: None,
                     name: None,
+                    token_usage: None,
                     turns: Vec::new(),
                 },
             },

--- a/codex-rs/tui/src/app/app_server_adapter.rs
+++ b/codex-rs/tui/src/app/app_server_adapter.rs
@@ -1297,6 +1297,7 @@ mod tests {
             agent_role: None,
             git_info: None,
             name: None,
+            token_usage: None,
             turns: vec![Turn {
                 id: "turn-1".to_string(),
                 items: vec![ThreadItem::CommandExecution {
@@ -1473,6 +1474,7 @@ mod tests {
                 agent_role: None,
                 git_info: None,
                 name: Some("restore".to_string()),
+                token_usage: None,
                 turns: vec![
                     Turn {
                         id: "turn-complete".to_string(),

--- a/codex-rs/tui/src/app/loaded_threads.rs
+++ b/codex-rs/tui/src/app/loaded_threads.rs
@@ -127,6 +127,7 @@ mod tests {
             agent_role: None,
             git_info: None,
             name: None,
+            token_usage: None,
             turns: Vec::new(),
         }
     }

--- a/codex-rs/tui/src/app_server_session.rs
+++ b/codex-rs/tui/src/app_server_session.rs
@@ -126,6 +126,9 @@ pub(crate) struct AppServerSession {
     remote_cwd_override: Option<PathBuf>,
 }
 
+/// Session state normalized from app-server thread lifecycle responses.
+///
+/// This is the handoff object between the app-server protocol layer and `ChatWidget`. Values here should be ready to apply to the active UI without issuing another app-server read. In particular, `token_usage` mirrors the thread snapshot so a resumed session can paint context-window status immediately instead of waiting for a later live token update.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct ThreadSessionState {
     pub(crate) thread_id: ThreadId,
@@ -144,6 +147,9 @@ pub(crate) struct ThreadSessionState {
     pub(crate) history_entry_count: u64,
     pub(crate) network_proxy: Option<SessionNetworkProxyRuntime>,
     pub(crate) rollout_path: Option<PathBuf>,
+    /// Latest token usage restored from the app-server thread snapshot.
+    ///
+    /// `None` means app-server could not derive usage from runtime or rollout state; the TUI should keep existing unknown/empty context usage rather than inventing zero usage.
     pub(crate) token_usage: Option<ThreadTokenUsage>,
 }
 

--- a/codex-rs/tui/src/app_server_session.rs
+++ b/codex-rs/tui/src/app_server_session.rs
@@ -64,6 +64,7 @@ use codex_app_server_protocol::ThreadShellCommandResponse;
 use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
 use codex_app_server_protocol::ThreadStartSource;
+use codex_app_server_protocol::ThreadTokenUsage;
 use codex_app_server_protocol::ThreadUnsubscribeParams;
 use codex_app_server_protocol::ThreadUnsubscribeResponse;
 use codex_app_server_protocol::Turn;
@@ -143,6 +144,7 @@ pub(crate) struct ThreadSessionState {
     pub(crate) history_entry_count: u64,
     pub(crate) network_proxy: Option<SessionNetworkProxyRuntime>,
     pub(crate) rollout_path: Option<PathBuf>,
+    pub(crate) token_usage: Option<ThreadTokenUsage>,
 }
 
 #[derive(Clone, Copy)]
@@ -1016,6 +1018,7 @@ async fn thread_session_state_from_thread_start_response(
         response.thread.forked_from_id.clone(),
         response.thread.name.clone(),
         response.thread.path.clone(),
+        response.thread.token_usage.clone(),
         response.model.clone(),
         response.model_provider.clone(),
         response.service_tier,
@@ -1039,6 +1042,7 @@ async fn thread_session_state_from_thread_resume_response(
         response.thread.forked_from_id.clone(),
         response.thread.name.clone(),
         response.thread.path.clone(),
+        response.thread.token_usage.clone(),
         response.model.clone(),
         response.model_provider.clone(),
         response.service_tier,
@@ -1062,6 +1066,7 @@ async fn thread_session_state_from_thread_fork_response(
         response.thread.forked_from_id.clone(),
         response.thread.name.clone(),
         response.thread.path.clone(),
+        response.thread.token_usage.clone(),
         response.model.clone(),
         response.model_provider.clone(),
         response.service_tier,
@@ -1104,6 +1109,7 @@ async fn thread_session_state_from_thread_response(
     forked_from_id: Option<String>,
     thread_name: Option<String>,
     rollout_path: Option<PathBuf>,
+    token_usage: Option<ThreadTokenUsage>,
     model: String,
     model_provider_id: String,
     service_tier: Option<codex_protocol::config_types::ServiceTier>,
@@ -1142,6 +1148,7 @@ async fn thread_session_state_from_thread_response(
         history_entry_count,
         network_proxy: None,
         rollout_path,
+        token_usage,
     })
 }
 
@@ -1198,6 +1205,7 @@ mod tests {
     use super::*;
     use crate::legacy_core::config::ConfigBuilder;
     use codex_app_server_protocol::ThreadStatus;
+    use codex_app_server_protocol::TokenUsageBreakdown;
     use codex_app_server_protocol::Turn;
     use codex_app_server_protocol::TurnStatus;
     use codex_utils_absolute_path::test_support::PathBufExt;
@@ -1317,6 +1325,23 @@ mod tests {
         let config = build_config(&temp_dir).await;
         let thread_id = ThreadId::new();
         let forked_from_id = ThreadId::new();
+        let token_usage = ThreadTokenUsage {
+            total: TokenUsageBreakdown {
+                total_tokens: 870,
+                input_tokens: 870,
+                cached_input_tokens: 0,
+                output_tokens: 0,
+                reasoning_output_tokens: 0,
+            },
+            last: TokenUsageBreakdown {
+                total_tokens: 870,
+                input_tokens: 870,
+                cached_input_tokens: 0,
+                output_tokens: 0,
+                reasoning_output_tokens: 0,
+            },
+            model_context_window: Some(1_000),
+        };
         let response = ThreadResumeResponse {
             thread: codex_app_server_protocol::Thread {
                 id: thread_id.to_string(),
@@ -1335,6 +1360,7 @@ mod tests {
                 agent_role: None,
                 git_info: None,
                 name: None,
+                token_usage: Some(token_usage.clone()),
                 turns: vec![Turn {
                     id: "turn-1".to_string(),
                     items: vec![
@@ -1378,6 +1404,7 @@ mod tests {
             started.session.instruction_source_paths,
             response.instruction_sources
         );
+        assert_eq!(started.session.token_usage, Some(token_usage));
         assert_eq!(started.turns.len(), 1);
         assert_eq!(started.turns[0], response.thread.turns[0]);
     }
@@ -1400,6 +1427,7 @@ mod tests {
             /*forked_from_id*/ None,
             Some("restore".to_string()),
             /*rollout_path*/ None,
+            /*token_usage*/ None,
             "gpt-5.4".to_string(),
             "openai".to_string(),
             /*service_tier*/ None,
@@ -1430,6 +1458,7 @@ mod tests {
             Some(forked_from_id.to_string()),
             Some("restore".to_string()),
             /*rollout_path*/ None,
+            /*token_usage*/ None,
             "gpt-5.4".to_string(),
             "openai".to_string(),
             /*service_tier*/ None,

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -2068,6 +2068,9 @@ impl ChatWidget {
         }
     }
 
+    /// Applies a normalized app-server thread session to the chat UI.
+    ///
+    /// Session configuration still flows through the legacy `SessionConfigured` path so existing metadata, history, and footer setup stay centralized. Restored token usage is applied immediately afterward because it is not part of the legacy core event; skipping this step leaves the status line at its default value until a new turn emits a live token-count update.
     pub(crate) fn handle_thread_session(&mut self, session: ThreadSessionState) {
         let token_usage = session.token_usage.clone();
         self.instruction_source_paths = session.instruction_source_paths.clone();
@@ -2653,6 +2656,9 @@ impl ChatWidget {
         self.config.memories.generate_memories = generate_memories;
     }
 
+    /// Replaces the token-usage cache and refreshes all UI surfaces that derive from it.
+    ///
+    /// Runtime token-count events and resumed app-server sessions both use this entry point. Callers should pass `None` only when token usage is genuinely unknown; doing so clears the context-window display rather than showing zero usage.
     pub(crate) fn set_token_info(&mut self, info: Option<TokenUsageInfo>) {
         match info {
             Some(info) => self.apply_token_info(info),

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -2069,8 +2069,12 @@ impl ChatWidget {
     }
 
     pub(crate) fn handle_thread_session(&mut self, session: ThreadSessionState) {
+        let token_usage = session.token_usage.clone();
         self.instruction_source_paths = session.instruction_source_paths.clone();
         self.on_session_configured(thread_session_state_to_legacy_event(session));
+        if let Some(token_usage) = token_usage {
+            self.set_token_info(Some(token_usage_info_from_app_server(token_usage)));
+        }
     }
 
     fn emit_forked_thread_event(&self, forked_from_id: ThreadId) {
@@ -2658,6 +2662,8 @@ impl ChatWidget {
                 self.token_info = None;
             }
         }
+        self.refresh_status_surfaces();
+        self.request_redraw();
     }
 
     #[cfg(test)]

--- a/codex-rs/tui/src/resume_picker.rs
+++ b/codex-rs/tui/src/resume_picker.rs
@@ -2685,6 +2685,7 @@ mod tests {
             agent_role: None,
             git_info: None,
             name: Some(String::from("Named thread")),
+            token_usage: None,
             turns: Vec::new(),
         };
 


### PR DESCRIPTION
# Problem

Resumed TUI sessions could initially show `Context 0% used` even when the previous session had a much higher context usage value. The correct value appeared only after the user submitted another turn, because the live runtime token-count path refreshed the TUI state then. That made resume look like it had lost context accounting, even though the historical token-count events were already present in the rollout.


# Mental model

Thread history is reconstructed from the rollout stream. The visible transcript is one projection of that stream, and token usage is another projection. A resume/read response that restores turns but omits the latest token-count projection leaves the TUI with a partially restored session: history is current, but context-window state is still at the default.

The fix treats latest token usage as thread snapshot state. App-server reads the newest persisted `TokenCount` event while rebuilding turns and exposes it as `Thread.tokenUsage`. The TUI carries that value through `ThreadSessionState` and applies it during session bootstrap before any new live token-count update can arrive.

# Non-goals

This does not change the token-count calculation itself, the baseline adjustment used for context-window percentages, or the shape of live `thread/tokenUsage/updated` notifications. It also does not backfill token usage for rollouts that never persisted token-count events.

# Tradeoffs

Adding `tokenUsage` to `Thread` expands every response schema that embeds a thread. That is noisy in generated schema diffs, but it keeps resume/read/fork/rollback clients on a single snapshot object instead of requiring a second RPC or a parallel cache lookup. The field is nullable and defaults during deserialization so older persisted or test fixtures remain compatible.

The helper scans rollout items from the end to find the latest token-count event. This is simple and matches the desired semantics, but it means the response derives token usage only from events already persisted in the rollout. In-flight token usage remains the responsibility of live notifications.

# Architecture

`Thread.tokenUsage` is the app-server protocol boundary for latest known usage. When app-server builds a thread from a rollout-backed source, it now updates both `thread.turns` and `thread.token_usage` from the same ordered item list. The helper also preserves the existing active-turn merge behavior: active turns affect the rendered turns list, while token usage still comes from persisted rollout state.

On the TUI side, app-server lifecycle responses are normalized into `ThreadSessionState`. The normalized state includes the optional token usage from the thread snapshot. `ChatWidget::handle_thread_session` applies the legacy session configuration first, then applies restored token usage through `set_token_info`, which refreshes context-window status surfaces and requests a redraw.

# Observability

There are no new logs. The fastest debug path is to inspect a resumed thread/read response and check whether `thread.tokenUsage` is present. If the field is present but the TUI status line is wrong, the issue is likely in `ThreadSessionState` normalization or `ChatWidget::set_token_info`. If the field is absent, inspect the rollout for persisted `TokenCount` events and check app-server rollout reconstruction.

# Tests

Protocol serialization tests now include `tokenUsage`. App-server has coverage that the latest token-count event wins when deriving usage from rollout items. TUI session tests verify that resume responses preserve token usage and that applying a restored thread session seeds the status line before a new turn arrives.