### PR TITLE
Simplify exec-server runtime paths

### DIFF
--- a/codex-rs/app-server/src/lib.rs
+++ b/codex-rs/app-server/src/lib.rs
@@ -362,10 +362,7 @@ pub async fn run_main_with_transport(
     auth: AppServerWebsocketAuthSettings,
 ) -> IoResult<()> {
     let environment_manager = Arc::new(EnvironmentManager::from_env_with_runtime_paths(Some(
-        ExecServerRuntimePaths::from_optional_paths(
-            arg0_paths.codex_self_exe.clone(),
-            arg0_paths.codex_linux_sandbox_exe.clone(),
-        )?,
+        ExecServerRuntimePaths::from_optional_paths(arg0_paths.codex_self_exe.clone())?,
     )));
     let (transport_event_tx, mut transport_event_rx) =
         mpsc::channel::<TransportEvent>(CHANNEL_CAPACITY);

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -1126,10 +1126,7 @@ async fn run_exec_server_command(
         .codex_self_exe
         .clone()
         .ok_or_else(|| anyhow::anyhow!("Codex executable path is not configured"))?;
-    let runtime_paths = codex_exec_server::ExecServerRuntimePaths::new(
-        codex_self_exe,
-        arg0_paths.codex_linux_sandbox_exe.clone(),
-    )?;
+    let runtime_paths = codex_exec_server::ExecServerRuntimePaths::new(codex_self_exe)?;
     codex_exec_server::run_main(&cmd.listen, runtime_paths)
         .await
         .map_err(anyhow::Error::from_boxed)

--- a/codex-rs/exec-server/src/environment.rs
+++ b/codex-rs/exec-server/src/environment.rs
@@ -297,11 +297,9 @@ mod tests {
 
     #[tokio::test]
     async fn environment_manager_carries_local_runtime_paths() {
-        let runtime_paths = ExecServerRuntimePaths::new(
-            std::env::current_exe().expect("current exe"),
-            /*codex_linux_sandbox_exe*/ None,
-        )
-        .expect("runtime paths");
+        let runtime_paths =
+            ExecServerRuntimePaths::new(std::env::current_exe().expect("current exe"))
+                .expect("runtime paths");
         let manager = EnvironmentManager::new_with_runtime_paths(
             /*exec_server_url*/ None,
             Some(runtime_paths.clone()),

--- a/codex-rs/exec-server/src/fs_sandbox.rs
+++ b/codex-rs/exec-server/src/fs_sandbox.rs
@@ -100,7 +100,7 @@ impl FileSystemSandboxRunner {
                 enforce_managed_network: false,
                 network: None,
                 sandbox_policy_cwd: cwd.as_path(),
-                codex_linux_sandbox_exe: self.runtime_paths.codex_linux_sandbox_exe.as_deref(),
+                codex_linux_sandbox_exe: Some(self.runtime_paths.codex_self_exe.as_path()),
                 use_legacy_landlock: sandbox_context.use_legacy_landlock,
                 windows_sandbox_level: sandbox_context.windows_sandbox_level,
                 windows_sandbox_private_desktop: sandbox_context.windows_sandbox_private_desktop,
@@ -356,11 +356,8 @@ mod tests {
     #[test]
     fn helper_permissions_strip_network_grants() {
         let codex_self_exe = std::env::current_exe().expect("current exe");
-        let runtime_paths = ExecServerRuntimePaths::new(
-            codex_self_exe.clone(),
-            /*codex_linux_sandbox_exe*/ None,
-        )
-        .expect("runtime paths");
+        let runtime_paths =
+            ExecServerRuntimePaths::new(codex_self_exe.clone()).expect("runtime paths");
         let runner = FileSystemSandboxRunner::new(runtime_paths);
         let readable = AbsolutePathBuf::from_absolute_path(
             codex_self_exe.parent().expect("current exe parent"),
@@ -399,11 +396,8 @@ mod tests {
     #[test]
     fn helper_permissions_include_helper_read_root_without_additional_permissions() {
         let codex_self_exe = std::env::current_exe().expect("current exe");
-        let runtime_paths = ExecServerRuntimePaths::new(
-            codex_self_exe.clone(),
-            /*codex_linux_sandbox_exe*/ None,
-        )
-        .expect("runtime paths");
+        let runtime_paths =
+            ExecServerRuntimePaths::new(codex_self_exe.clone()).expect("runtime paths");
         let runner = FileSystemSandboxRunner::new(runtime_paths);
         let readable = AbsolutePathBuf::from_absolute_path(
             codex_self_exe.parent().expect("current exe parent"),

--- a/codex-rs/exec-server/src/runtime_paths.rs
+++ b/codex-rs/exec-server/src/runtime_paths.rs
@@ -7,32 +7,22 @@ use codex_utils_absolute_path::AbsolutePathBuf;
 pub struct ExecServerRuntimePaths {
     /// Stable path to the Codex executable used to launch hidden helper modes.
     pub codex_self_exe: AbsolutePathBuf,
-    /// Path to the Linux sandbox helper alias used when the platform sandbox
-    /// needs to re-enter Codex by argv0.
-    pub codex_linux_sandbox_exe: Option<AbsolutePathBuf>,
 }
 
 impl ExecServerRuntimePaths {
-    pub fn from_optional_paths(
-        codex_self_exe: Option<PathBuf>,
-        codex_linux_sandbox_exe: Option<PathBuf>,
-    ) -> std::io::Result<Self> {
+    pub fn from_optional_paths(codex_self_exe: Option<PathBuf>) -> std::io::Result<Self> {
         let codex_self_exe = codex_self_exe.ok_or_else(|| {
             std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
                 "Codex executable path is not configured",
             )
         })?;
-        Self::new(codex_self_exe, codex_linux_sandbox_exe)
+        Self::new(codex_self_exe)
     }
 
-    pub fn new(
-        codex_self_exe: PathBuf,
-        codex_linux_sandbox_exe: Option<PathBuf>,
-    ) -> std::io::Result<Self> {
+    pub fn new(codex_self_exe: PathBuf) -> std::io::Result<Self> {
         Ok(Self {
             codex_self_exe: absolute_path(codex_self_exe)?,
-            codex_linux_sandbox_exe: codex_linux_sandbox_exe.map(absolute_path).transpose()?,
         })
     }
 }

--- a/codex-rs/exec-server/src/server/file_system_handler.rs
+++ b/codex-rs/exec-server/src/server/file_system_handler.rs
@@ -186,11 +186,9 @@ mod tests {
     #[tokio::test]
     async fn no_platform_sandbox_policies_do_not_require_configured_sandbox_helper() {
         let temp_dir = tempfile::tempdir().expect("tempdir");
-        let runtime_paths = ExecServerRuntimePaths::new(
-            std::env::current_exe().expect("current exe"),
-            /*codex_linux_sandbox_exe*/ None,
-        )
-        .expect("runtime paths");
+        let runtime_paths =
+            ExecServerRuntimePaths::new(std::env::current_exe().expect("current exe"))
+                .expect("runtime paths");
         let handler = FileSystemHandler::new(runtime_paths);
 
         for (file_name, sandbox_policy) in [

--- a/codex-rs/exec-server/src/server/handler/tests.rs
+++ b/codex-rs/exec-server/src/server/handler/tests.rs
@@ -67,11 +67,8 @@ fn windows_command_processor() -> String {
 }
 
 fn test_runtime_paths() -> ExecServerRuntimePaths {
-    ExecServerRuntimePaths::new(
-        std::env::current_exe().expect("current exe"),
-        /*codex_linux_sandbox_exe*/ None,
-    )
-    .expect("runtime paths")
+    ExecServerRuntimePaths::new(std::env::current_exe().expect("current exe"))
+        .expect("runtime paths")
 }
 
 async fn initialized_handler() -> Arc<ExecServerHandler> {

--- a/codex-rs/exec-server/src/server/processor.rs
+++ b/codex-rs/exec-server/src/server/processor.rs
@@ -320,11 +320,8 @@ mod tests {
     }
 
     fn test_runtime_paths() -> ExecServerRuntimePaths {
-        ExecServerRuntimePaths::new(
-            std::env::current_exe().expect("current exe"),
-            /*codex_linux_sandbox_exe*/ None,
-        )
-        .expect("runtime paths")
+        ExecServerRuntimePaths::new(std::env::current_exe().expect("current exe"))
+            .expect("runtime paths")
     }
 
     async fn send_request<P: Serialize>(

--- a/codex-rs/exec-server/tests/common/exec_server.rs
+++ b/codex-rs/exec-server/tests/common/exec_server.rs
@@ -45,14 +45,12 @@ impl Drop for ExecServerHarness {
 
 pub(crate) struct TestCodexHelperPaths {
     pub(crate) codex_exe: PathBuf,
-    pub(crate) codex_linux_sandbox_exe: Option<PathBuf>,
 }
 
 pub(crate) fn test_codex_helper_paths() -> anyhow::Result<TestCodexHelperPaths> {
-    let (helper_binary, codex_linux_sandbox_exe) = super::current_test_binary_helper_paths()?;
+    let helper_binary = super::current_test_binary_helper_path()?;
     Ok(TestCodexHelperPaths {
         codex_exe: helper_binary,
-        codex_linux_sandbox_exe,
     })
 }
 

--- a/codex-rs/exec-server/tests/common/mod.rs
+++ b/codex-rs/exec-server/tests/common/mod.rs
@@ -22,24 +22,15 @@ pub static TEST_BINARY_DISPATCH_GUARD: Option<TestBinaryDispatchGuard> = {
         }
         TestBinaryDispatchMode::InstallAliases
     });
-    maybe_run_exec_server_from_test_binary(guard.as_ref());
+    maybe_run_exec_server_from_test_binary();
     guard
 };
 
-pub(crate) fn current_test_binary_helper_paths() -> anyhow::Result<(PathBuf, Option<PathBuf>)> {
-    let current_exe = env::current_exe()?;
-    let codex_linux_sandbox_exe = if cfg!(target_os = "linux") {
-        TEST_BINARY_DISPATCH_GUARD
-            .as_ref()
-            .and_then(|guard| guard.paths().codex_linux_sandbox_exe.clone())
-            .or_else(|| Some(current_exe.clone()))
-    } else {
-        None
-    };
-    Ok((current_exe, codex_linux_sandbox_exe))
+pub(crate) fn current_test_binary_helper_path() -> anyhow::Result<PathBuf> {
+    Ok(env::current_exe()?)
 }
 
-fn maybe_run_exec_server_from_test_binary(guard: Option<&TestBinaryDispatchGuard>) {
+fn maybe_run_exec_server_from_test_binary() {
     let mut args = env::args();
     let _program = args.next();
     let Some(command) = args.next() else {
@@ -73,10 +64,7 @@ fn maybe_run_exec_server_from_test_binary(guard: Option<&TestBinaryDispatchGuard
             std::process::exit(1);
         }
     };
-    let runtime_paths = match ExecServerRuntimePaths::new(
-        current_exe.clone(),
-        linux_sandbox_exe(guard, &current_exe),
-    ) {
+    let runtime_paths = match ExecServerRuntimePaths::new(current_exe.clone()) {
         Ok(runtime_paths) => runtime_paths,
         Err(error) => {
             eprintln!("failed to configure exec-server runtime paths: {error}");
@@ -102,22 +90,4 @@ fn maybe_run_exec_server_from_test_binary(guard: Option<&TestBinaryDispatchGuard
         }
     };
     std::process::exit(exit_code);
-}
-
-fn linux_sandbox_exe(
-    guard: Option<&TestBinaryDispatchGuard>,
-    current_exe: &std::path::Path,
-) -> Option<PathBuf> {
-    #[cfg(target_os = "linux")]
-    {
-        guard
-            .and_then(|guard| guard.paths().codex_linux_sandbox_exe.clone())
-            .or_else(|| Some(current_exe.to_path_buf()))
-    }
-    #[cfg(not(target_os = "linux"))]
-    {
-        let _ = guard;
-        let _ = current_exe;
-        None
-    }
 }

--- a/codex-rs/exec-server/tests/common/mod.rs
+++ b/codex-rs/exec-server/tests/common/mod.rs
@@ -64,7 +64,7 @@ fn maybe_run_exec_server_from_test_binary() {
             std::process::exit(1);
         }
     };
-    let runtime_paths = match ExecServerRuntimePaths::new(current_exe.clone()) {
+    let runtime_paths = match ExecServerRuntimePaths::new(current_exe) {
         Ok(runtime_paths) => runtime_paths,
         Err(error) => {
             eprintln!("failed to configure exec-server runtime paths: {error}");

--- a/codex-rs/exec-server/tests/file_system.rs
+++ b/codex-rs/exec-server/tests/file_system.rs
@@ -50,10 +50,7 @@ async fn create_file_system_context(use_remote: bool) -> Result<FileSystemContex
         })
     } else {
         let helper_paths = test_codex_helper_paths()?;
-        let runtime_paths = ExecServerRuntimePaths::new(
-            helper_paths.codex_exe.clone(),
-            helper_paths.codex_linux_sandbox_exe.clone(),
-        )?;
+        let runtime_paths = ExecServerRuntimePaths::new(helper_paths.codex_exe.clone())?;
         Ok(FileSystemContext {
             file_system: Arc::new(LocalFileSystem::with_runtime_paths(runtime_paths)),
             _helper_paths: Some(helper_paths),

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -470,10 +470,8 @@ pub async fn run_main(cli: Cli, arg0_paths: Arg0DispatchPaths) -> anyhow::Result
             range: None,
         })
         .collect();
-    let local_runtime_paths = ExecServerRuntimePaths::from_optional_paths(
-        arg0_paths.codex_self_exe.clone(),
-        arg0_paths.codex_linux_sandbox_exe.clone(),
-    )?;
+    let local_runtime_paths =
+        ExecServerRuntimePaths::from_optional_paths(arg0_paths.codex_self_exe.clone())?;
     let in_process_start_args = InProcessClientStartArgs {
         arg0_paths,
         config: std::sync::Arc::new(config.clone()),

--- a/codex-rs/mcp-server/src/lib.rs
+++ b/codex-rs/mcp-server/src/lib.rs
@@ -60,10 +60,7 @@ pub async fn run_main(
     cli_config_overrides: CliConfigOverrides,
 ) -> IoResult<()> {
     let environment_manager = Arc::new(EnvironmentManager::from_env_with_runtime_paths(Some(
-        ExecServerRuntimePaths::from_optional_paths(
-            arg0_paths.codex_self_exe.clone(),
-            arg0_paths.codex_linux_sandbox_exe.clone(),
-        )?,
+        ExecServerRuntimePaths::from_optional_paths(arg0_paths.codex_self_exe.clone())?,
     )));
     // Parse CLI overrides once and derive the base Config eagerly so later
     // components do not need to work with raw TOML values.

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -734,10 +734,7 @@ pub async fn run_main(
     };
 
     let environment_manager = Arc::new(EnvironmentManager::from_env_with_runtime_paths(Some(
-        ExecServerRuntimePaths::from_optional_paths(
-            arg0_paths.codex_self_exe.clone(),
-            arg0_paths.codex_linux_sandbox_exe.clone(),
-        )?,
+        ExecServerRuntimePaths::from_optional_paths(arg0_paths.codex_self_exe.clone())?,
     )));
     let cwd = cli.cwd.clone();
     let config_cwd =


### PR DESCRIPTION
## Summary
- remove the separate `codex_linux_sandbox_exe` field from `ExecServerRuntimePaths`
- route Linux filesystem sandboxing through the configured Codex executable via arg0 dispatch
- trim test helper plumbing that only existed to carry the separate sandbox alias

## Validation
- `cd /Users/starr/code/codex-worktrees/exec-runtime-paths-self-sandbox/codex-rs && just fmt`
- `cd /Users/starr/code/codex-worktrees/exec-runtime-paths-self-sandbox && bazel test //codex-rs/exec-server:exec-server-file_system-test //codex-rs/exec-server:exec-server-initialize-test //codex-rs/exec-server:exec-server-process-test //codex-rs/exec-server:exec-server-unit-tests //codex-rs/exec-server:exec-server-websocket-test //codex-rs/exec-server:exec-server-exec_process-test --test_arg=--test-threads=1 --test_output=errors`
- `cd /Users/starr/code/codex-worktrees/exec-runtime-paths-self-sandbox && bazel build //codex-rs/app-server:app-server //codex-rs/app-server:codex-app-server //codex-rs/mcp-server:mcp-server //codex-rs/mcp-server:codex-mcp-server //codex-rs/exec:exec //codex-rs/exec:codex-exec`
- `cd /tmp/codex-worktrees/exec-runtime-paths-self-sandbox && source scripts/test-remote-env.sh && cd codex-rs && cargo test -p codex-core --test all remote_test_env -- --test-threads=1 --nocapture` on devbox `dev`

Note: branch name includes `full-ci` so `.github/workflows/rust-ci-full.yml` runs on push.