### PR TITLE
[docs] Revert extra changes from PR 17848

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -94,7 +94,7 @@ jobs:
             "${bazel_wrapper_args[@]}" \
             -- \
             test \
-            --test_tag_filters=-argument-comment-lint,-flaky \
+            --test_tag_filters=-argument-comment-lint \
             --test_verbose_timeout_warnings \
             --build_metadata=COMMIT_SHA=${GITHUB_SHA} \
             -- \

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,3 @@ Our security program is managed through Bugcrowd, and we ask that any validated 
 ## Vulnerability Disclosure Program
 
 Our Vulnerability Program Guidelines are defined on our [Bugcrowd program page](https://bugcrowd.com/engagements/openai).
-
-## How to operate CODEX safely
-
-For details on Codex security boundaries, including sandboxing, approvals, and network controls, see [Agent approvals & security](https://developers.openai.com/codex/agent-approvals-security).

--- a/codex-rs/app-server/BUILD.bazel
+++ b/codex-rs/app-server/BUILD.bazel
@@ -3,9 +3,6 @@ load("//:defs.bzl", "codex_rust_crate")
 codex_rust_crate(
     name = "app-server",
     crate_name = "codex_app_server",
-    integration_test_tags_extra_by_stem = {
-        "all": ["flaky"],
-    },
     integration_test_timeout = "long",
     test_tags = ["no-sandbox"],
 )

--- a/codex-rs/core/BUILD.bazel
+++ b/codex-rs/core/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//:defs.bzl", "codex_rust_crate", "workspace_root_test")
+load("//:defs.bzl", "codex_rust_crate")
 
 filegroup(
     name = "model_availability_nux_fixtures",
@@ -31,15 +31,6 @@ codex_rust_crate(
         "//codex-rs/apply-patch:apply_patch_tool_instructions.md",
         "templates/realtime/backend_prompt.md",
     ],
-    integration_test_flaky_by_stem = {
-        "all": [
-            "suite::abort_tasks::interrupt_tool_records_history_entries",
-            "suite::apply_patch_cli::apply_patch_cli_rejects_invalid_hunk_header::applypatchmodeloutput_function_expects",
-        ],
-        "responses_headers": [
-            "responses_stream_includes_turn_metadata_header_for_git_workspace_e2e",
-        ],
-    },
     integration_test_timeout = "long",
     test_data_extra = [
         "config.schema.json",
@@ -57,12 +48,6 @@ codex_rust_crate(
         "//:AGENTS.md",
     ],
     test_tags = ["no-sandbox"],
-    unit_test_args = [
-        "--skip",
-        "guardian::tests::guardian_parallel_reviews_fork_from_last_committed_trunk_history",
-        "--skip",
-        "agent::control::tests::completion_watcher_notifies_parent_when_child_is_missing",
-    ],
     unit_test_timeout = "long",
     extra_binaries = [
         "//codex-rs/linux-sandbox:codex-linux-sandbox",
@@ -71,42 +56,4 @@ codex_rust_crate(
         "//codex-rs/responses-api-proxy:codex-responses-api-proxy",
         "//codex-rs/cli:codex",
     ],
-)
-
-workspace_root_test(
-    name = "core-guardian-parallel-reviews-flaky-test",
-    env = {
-        "INSTA_WORKSPACE_ROOT": ".",
-        "INSTA_SNAPSHOT_PATH": "src",
-    },
-    test_bin = ":core-unit-tests-bin",
-    workspace_root_marker = "//codex-rs/utils/cargo-bin:repo_root.marker",
-    args = [
-        "--exact",
-        "guardian::tests::guardian_parallel_reviews_fork_from_last_committed_trunk_history",
-    ],
-    tags = [
-        "flaky",
-        "no-sandbox",
-    ],
-    timeout = "long",
-)
-
-workspace_root_test(
-    name = "core-completion-watcher-missing-child-flaky-test",
-    env = {
-        "INSTA_WORKSPACE_ROOT": ".",
-        "INSTA_SNAPSHOT_PATH": "src",
-    },
-    test_bin = ":core-unit-tests-bin",
-    workspace_root_marker = "//codex-rs/utils/cargo-bin:repo_root.marker",
-    args = [
-        "--exact",
-        "agent::control::tests::completion_watcher_notifies_parent_when_child_is_missing",
-    ],
-    tags = [
-        "flaky",
-        "no-sandbox",
-    ],
-    timeout = "long",
 )

--- a/codex-rs/tui/BUILD.bazel
+++ b/codex-rs/tui/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//:defs.bzl", "MACOS_WEBRTC_RUSTC_LINK_FLAGS", "codex_rust_crate", "workspace_root_test")
+load("//:defs.bzl", "MACOS_WEBRTC_RUSTC_LINK_FLAGS", "codex_rust_crate")
 
 codex_rust_crate(
     name = "tui",
@@ -20,27 +20,8 @@ codex_rust_crate(
         "src/**/snapshots/**",
     ]) + ["//codex-rs/core:model_availability_nux_fixtures"],
     integration_compile_data_extra = ["src/test_backend.rs"],
-    unit_test_args = [
-        "--skip",
-        "app::tests::update_memory_settings_updates_current_thread_memory_mode",
-    ],
     extra_binaries = [
         "//codex-rs/cli:codex",
     ],
     rustc_flags_extra = MACOS_WEBRTC_RUSTC_LINK_FLAGS,
-)
-
-workspace_root_test(
-    name = "tui-update-memory-settings-flaky-test",
-    env = {
-        "INSTA_WORKSPACE_ROOT": ".",
-        "INSTA_SNAPSHOT_PATH": "src",
-    },
-    test_bin = ":tui-unit-tests-bin",
-    workspace_root_marker = "//codex-rs/utils/cargo-bin:repo_root.marker",
-    args = [
-        "--exact",
-        "app::tests::update_memory_settings_updates_current_thread_memory_mode",
-    ],
-    tags = ["flaky"],
 )

--- a/defs.bzl
+++ b/defs.bzl
@@ -137,13 +137,10 @@ def codex_rust_crate(
         rustc_env = {},
         deps_extra = [],
         integration_compile_data_extra = [],
-        integration_test_tags_extra_by_stem = {},
-        integration_test_flaky_by_stem = {},
         integration_test_args = [],
         integration_test_timeout = None,
         test_data_extra = [],
         test_tags = [],
-        unit_test_args = [],
         unit_test_timeout = None,
         extra_binaries = []):
     """Defines a Rust crate with library, binaries, and tests wired for Bazel + Cargo parity.
@@ -173,9 +170,6 @@ def codex_rust_crate(
         deps_extra: Extra normal deps beyond @crates resolution.
             Typically only needed when features add additional deps.
         integration_compile_data_extra: Extra compile_data for integration tests.
-        integration_test_flaky_by_stem: Mapping from `tests/*.rs` stem to exact
-            Rust test names that should be split into dedicated flaky targets
-            and skipped from the main integration test target.
         integration_test_args: Optional args for integration test binaries.
         integration_test_timeout: Optional Bazel timeout for integration test
             targets generated from `tests/*.rs`.
@@ -276,8 +270,6 @@ def codex_rust_crate(
         unit_test_kwargs = {}
         if unit_test_timeout:
             unit_test_kwargs["timeout"] = unit_test_timeout
-        if unit_test_args:
-            unit_test_kwargs["args"] = unit_test_args
 
         workspace_root_test(
             name = name + "-unit-tests",
@@ -313,9 +305,11 @@ def codex_rust_crate(
         binary = Label(binary_label).name
         cargo_env["CARGO_BIN_EXE_" + binary] = "$(rlocationpath %s)" % binary_label
 
-    integration_test_base_kwargs = {}
+    integration_test_kwargs = {}
+    if integration_test_args:
+        integration_test_kwargs["args"] = integration_test_args
     if integration_test_timeout:
-        integration_test_base_kwargs["timeout"] = integration_test_timeout
+        integration_test_kwargs["timeout"] = integration_test_timeout
 
     for test in native.glob(["tests/*.rs"], allow_empty = True):
         test_file_stem = test.removeprefix("tests/").removesuffix(".rs")
@@ -323,18 +317,6 @@ def codex_rust_crate(
         test_name = name + "-" + test_file_stem.replace("/", "-")
         if not test_name.endswith("-test"):
             test_name += "-test"
-        extra_test_tags = integration_test_tags_extra_by_stem.get(test_file_stem, [])
-        flaky_tests = integration_test_flaky_by_stem.get(test_file_stem, [])
-        stem_integration_test_args = [] + integration_test_args
-        for flaky_test in flaky_tests:
-            stem_integration_test_args += [
-                "--skip",
-                flaky_test,
-            ]
-
-        integration_test_kwargs = dict(integration_test_base_kwargs)
-        if stem_integration_test_args:
-            integration_test_kwargs["args"] = stem_integration_test_args
 
         rust_test(
             name = test_name,
@@ -356,32 +338,6 @@ def codex_rust_crate(
             # `INSTA_WORKSPACE_ROOT="codex-rs"` is tuned for unit tests that
             # execute from the repo root and can misplace integration snapshots.
             env = cargo_env,
-            tags = test_tags + extra_test_tags,
+            tags = test_tags,
             **integration_test_kwargs
         )
-
-        for flaky_test in flaky_tests:
-            flaky_test_suffix = flaky_test.replace("::", "-").replace("/", "-").replace("_", "-")
-            flaky_test_kwargs = dict(integration_test_base_kwargs)
-            flaky_test_kwargs["args"] = [
-                "--exact",
-                flaky_test,
-            ]
-
-            rust_test(
-                name = test_name.removesuffix("-test") + "-flaky-" + flaky_test_suffix + "-test",
-                crate_name = test_crate_name + "_flaky_" + flaky_test.replace("::", "_").replace("/", "_").replace("-", "_"),
-                crate_root = test,
-                srcs = [test],
-                data = native.glob(["tests/**"], allow_empty = True) + sanitized_binaries + test_data_extra,
-                compile_data = native.glob(["tests/**"], allow_empty = True) + integration_compile_data_extra,
-                deps = all_crate_deps(normal = True, normal_dev = True) + maybe_deps + deps_extra,
-                rustc_flags = rustc_flags_extra + WINDOWS_RUSTC_LINK_FLAGS + [
-                    "--remap-path-prefix=../codex-rs=",
-                    "--remap-path-prefix=codex-rs=",
-                ],
-                rustc_env = rustc_env,
-                env = cargo_env,
-                tags = test_tags + extra_test_tags + ["flaky"],
-                **flaky_test_kwargs
-            )


### PR DESCRIPTION
## Summary

1. Revert https://github.com/openai/codex/pull/17848 so the Bazel and `BUILD` file changes leave `main`.
2. Prepare for a narrower follow up that restores only `SECURITY.md`.

## Validation

1. Reviewed the revert diff against `main`.
2. Ran a clean diff check before push.
