### PR TITLE
[docs] Restore SECURITY.md update from PR 17848

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,3 +11,7 @@ Our security program is managed through Bugcrowd, and we ask that any validated 
 ## Vulnerability Disclosure Program
 
 Our Vulnerability Program Guidelines are defined on our [Bugcrowd program page](https://bugcrowd.com/engagements/openai).
+
+## How to operate CODEX safely
+
+For details on Codex security boundaries, including sandboxing, approvals, and network controls, see [Agent approvals & security](https://developers.openai.com/codex/agent-approvals-security).


### PR DESCRIPTION
Restore the `SECURITY.md` section from https://github.com/openai/codex/pull/17848. Note this was lost in the revert PR https://github.com/openai/codex/pull/18003.