### PR TITLE
[codex] route thread reads through thread store

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -3788,7 +3788,7 @@ impl CodexMessageProcessor {
         };
 
         let thread = match self
-            .read_thread_view(thread_uuid, include_turns, /*include_archived*/ false)
+            .read_thread_view(thread_uuid, include_turns, /*include_archived*/ true)
             .await
         {
             Ok(thread) => thread,
@@ -3916,15 +3916,26 @@ impl CodexMessageProcessor {
         // ThreadStore, but loaded threads that are not yet readable from the store may
         // still have local metadata. Keep this compatibility path centralized here so
         // future remote threadstore implementations have one app-server boundary to replace.
-        if let Some(summary) =
-            read_summary_from_state_db_by_thread_id(&self.config, thread_id).await
-        {
+        let loaded_state_db = loaded_thread.state_db();
+        let summary = match loaded_state_db.as_ref() {
+            Some(state_db) => {
+                read_summary_from_state_db_context_by_thread_id(Some(state_db), thread_id).await
+            }
+            None => read_summary_from_state_db_by_thread_id(&self.config, thread_id).await,
+        };
+        if let Some(summary) = summary {
             merge_mutable_thread_metadata(
                 &mut thread,
                 summary_to_thread(summary, &self.config.cwd),
             );
         }
         self.attach_thread_name(thread_id, &mut thread).await;
+        if thread.forked_from_id.is_none()
+            && let Some(path) = loaded_rollout_path.as_deref()
+            && path.exists()
+        {
+            thread.forked_from_id = forked_from_id_from_rollout(path).await;
+        }
 
         if include_turns {
             let path = loaded_materialized_rollout_path(

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -434,6 +434,11 @@ enum ThreadShutdownResult {
     TimedOut,
 }
 
+enum ThreadReadViewError {
+    InvalidRequest(String),
+    Internal(String),
+}
+
 impl Drop for ActiveLogin {
     fn drop(&mut self) {
         self.cancel();
@@ -3782,96 +3787,76 @@ impl CodexMessageProcessor {
             }
         };
 
-        let loaded_thread = self.thread_manager.get_thread(thread_uuid).await.ok();
-        let stored_thread = match self
+        let thread = match self
+            .read_thread_view(thread_uuid, include_turns, /*include_archived*/ false)
+            .await
+        {
+            Ok(thread) => thread,
+            Err(ThreadReadViewError::InvalidRequest(message)) => {
+                self.send_invalid_request_error(request_id, message).await;
+                return;
+            }
+            Err(ThreadReadViewError::Internal(message)) => {
+                self.send_internal_error(request_id, message).await;
+                return;
+            }
+        };
+        let response = ThreadReadResponse { thread };
+        self.outgoing.send_response(request_id, response).await;
+    }
+
+    /// Builds an API thread view by composing persisted store data with loaded live state.
+    async fn read_thread_view(
+        &self,
+        thread_id: ThreadId,
+        include_turns: bool,
+        include_archived: bool,
+    ) -> Result<Thread, ThreadReadViewError> {
+        let loaded_thread = self.thread_manager.get_thread(thread_id).await.ok();
+
+        // Thread API views prefer persisted store data because that is the stable
+        // cross-process/cross-host source of truth. A live thread is only used as a
+        // fallback when the store cannot resolve the id but this app-server already has
+        // the thread loaded in memory.
+        let mut thread = match self
             .thread_store
             .read_thread(StoreReadThreadParams {
-                thread_id: thread_uuid,
-                include_archived: false,
+                thread_id,
+                include_archived,
                 include_history: include_turns,
             })
             .await
         {
-            Ok(thread) => Some(thread),
-            Err(ThreadStoreError::InvalidRequest { message }) if loaded_thread.is_some() => {
-                debug!("falling back to loaded thread for {thread_uuid}: {message}");
-                None
+            Ok(stored_thread) => {
+                self.thread_view_from_stored_thread(stored_thread, include_turns)?
             }
-            Err(ThreadStoreError::ThreadNotFound { .. }) if loaded_thread.is_some() => {
-                debug!("falling back to loaded thread for {thread_uuid}: thread not found");
-                None
+            Err(ThreadStoreError::InvalidRequest { message }) => {
+                if let Some(loaded_thread) = loaded_thread.as_ref() {
+                    debug!("falling back to loaded thread for {thread_id}: {message}");
+                    self.thread_view_from_loaded_thread(thread_id, loaded_thread, include_turns)
+                        .await?
+                } else {
+                    return Err(ThreadReadViewError::InvalidRequest(message));
+                }
+            }
+            Err(ThreadStoreError::ThreadNotFound {
+                thread_id: missing_thread_id,
+            }) => {
+                if let Some(loaded_thread) = loaded_thread.as_ref() {
+                    debug!("falling back to loaded thread for {thread_id}: thread not found");
+                    self.thread_view_from_loaded_thread(thread_id, loaded_thread, include_turns)
+                        .await?
+                } else {
+                    return Err(ThreadReadViewError::InvalidRequest(format!(
+                        "thread not found: {missing_thread_id}"
+                    )));
+                }
             }
             Err(err) => {
-                self.outgoing
-                    .send_error(request_id, thread_store_read_error(err))
-                    .await;
-                return;
+                return Err(ThreadReadViewError::Internal(format!(
+                    "failed to read thread: {err}"
+                )));
             }
-        };
-
-        let mut thread = if let Some(stored_thread) = stored_thread {
-            let fallback_provider = self.config.model_provider_id.as_str();
-            let Some((mut thread, history)) =
-                thread_from_stored_thread(stored_thread, fallback_provider, &self.config.cwd)
-            else {
-                self.send_internal_error(
-                    request_id,
-                    format!("failed to read thread {thread_uuid}"),
-                )
-                .await;
-                return;
-            };
-            if include_turns {
-                let Some(history) = history else {
-                    self.send_internal_error(
-                        request_id,
-                        format!("failed to load rollout history for thread {thread_uuid}"),
-                    )
-                    .await;
-                    return;
-                };
-                thread.turns = build_turns_from_rollout_items(&history.items);
-            }
-            thread
-        } else {
-            // Only loaded live threads reach this branch. Stored threads should be read through the
-            // thread store above, while live threads may not have materialized a rollout yet.
-            let Some(thread) = loaded_thread.as_ref() else {
-                self.send_invalid_request_error(
-                    request_id,
-                    format!("thread not loaded: {thread_uuid}"),
-                )
-                .await;
-                return;
-            };
-            let config_snapshot = thread.config_snapshot().await;
-            let loaded_rollout_path = thread.rollout_path();
-            if include_turns {
-                let message = if config_snapshot.ephemeral && loaded_rollout_path.is_none() {
-                    "ephemeral threads do not support includeTurns".to_string()
-                } else {
-                    format!(
-                        "thread {thread_uuid} is not materialized yet; includeTurns is unavailable before first user message"
-                    )
-                };
-                self.send_invalid_request_error(request_id, message).await;
-                return;
-            }
-            let mut thread =
-                build_thread_from_snapshot(thread_uuid, &config_snapshot, loaded_rollout_path);
-            // Stored-thread metadata is applied inside LocalThreadStore. This is only for loaded
-            // live threads that are not yet readable from the store, such as a newly started thread
-            // with a precomputed rollout path but no materialized rollout file.
-            if let Some(summary) =
-                read_summary_from_state_db_by_thread_id(&self.config, thread_uuid).await
-            {
-                merge_mutable_thread_metadata(
-                    &mut thread,
-                    summary_to_thread(summary, &self.config.cwd),
-                );
-            }
-            self.attach_thread_name(thread_uuid, &mut thread).await;
-            thread
         };
 
         let has_live_in_progress_turn = if let Some(loaded_thread) = loaded_thread.as_ref() {
@@ -3879,19 +3864,83 @@ impl CodexMessageProcessor {
         } else {
             false
         };
-
         let thread_status = self
             .thread_watch_manager
             .loaded_status_for_thread(&thread.id)
             .await;
-
         set_thread_status_and_interrupt_stale_turns(
             &mut thread,
             thread_status,
             has_live_in_progress_turn,
         );
-        let response = ThreadReadResponse { thread };
-        self.outgoing.send_response(request_id, response).await;
+        Ok(thread)
+    }
+
+    fn thread_view_from_stored_thread(
+        &self,
+        stored_thread: StoredThread,
+        include_turns: bool,
+    ) -> Result<Thread, ThreadReadViewError> {
+        let thread_id = stored_thread.thread_id;
+        let fallback_provider = self.config.model_provider_id.as_str();
+        let (mut thread, history) =
+            thread_from_stored_thread(stored_thread, fallback_provider, &self.config.cwd);
+        if include_turns {
+            let Some(history) = history else {
+                return Err(ThreadReadViewError::Internal(format!(
+                    "failed to load rollout history for thread {thread_id}"
+                )));
+            };
+            thread.turns = build_turns_from_rollout_items(&history.items);
+        }
+        Ok(thread)
+    }
+
+    async fn thread_view_from_loaded_thread(
+        &self,
+        thread_id: ThreadId,
+        loaded_thread: &Arc<CodexThread>,
+        include_turns: bool,
+    ) -> Result<Thread, ThreadReadViewError> {
+        let config_snapshot = loaded_thread.config_snapshot().await;
+        let loaded_rollout_path = loaded_thread.rollout_path();
+        let mut thread =
+            build_thread_from_snapshot(thread_id, &config_snapshot, loaded_rollout_path.clone());
+
+        // Temporary live-thread metadata shim: stored-thread metadata is owned by
+        // ThreadStore, but loaded threads that are not yet readable from the store may
+        // still have local metadata. Keep this compatibility path centralized here so
+        // future remote threadstore implementations have one app-server boundary to replace.
+        if let Some(summary) =
+            read_summary_from_state_db_by_thread_id(&self.config, thread_id).await
+        {
+            merge_mutable_thread_metadata(
+                &mut thread,
+                summary_to_thread(summary, &self.config.cwd),
+            );
+        }
+        self.attach_thread_name(thread_id, &mut thread).await;
+
+        if include_turns {
+            let path = loaded_materialized_rollout_path(
+                thread_id,
+                &config_snapshot,
+                loaded_rollout_path.as_ref(),
+            )?;
+            // This path-based history load is a temporary local compatibility fallback for
+            // live threads resumed from explicit rollout paths outside codex_home. Stored
+            // thread reads should continue to go through ThreadStore; future pathless live
+            // history should come from ThreadManager/CodexThread instead of the filesystem.
+            let items = read_rollout_items_from_rollout(path).await.map_err(|err| {
+                ThreadReadViewError::Internal(format!(
+                    "failed to load rollout history {}: {err}",
+                    path.display()
+                ))
+            })?;
+            thread.turns = build_turns_from_rollout_items(&items);
+        }
+
+        Ok(thread)
     }
 
     pub(crate) fn thread_created_receiver(&self) -> broadcast::Receiver<ThreadId> {
@@ -4820,8 +4869,7 @@ impl CodexMessageProcessor {
         match params {
             GetConversationSummaryParams::RolloutPath { rollout_path } => {
                 // Legacy compatibility for clients that still hold local rollout paths. New
-                // callsites should prefer thread-id lookups through the thread store so hosted
-                // stores do not need to expose filesystem paths.
+                // callsites should prefer thread-id lookups through the thread store.
                 let path = if rollout_path.is_relative() {
                     self.config.codex_home.join(&rollout_path).to_path_buf()
                 } else {
@@ -9172,8 +9220,8 @@ fn thread_from_stored_thread(
     thread: StoredThread,
     fallback_provider: &str,
     fallback_cwd: &AbsolutePathBuf,
-) -> Option<(Thread, Option<codex_thread_store::StoredThreadHistory>)> {
-    let path = thread.rollout_path?;
+) -> (Thread, Option<codex_thread_store::StoredThreadHistory>) {
+    let path = thread.rollout_path;
     let git_info = thread.git_info.map(|info| ApiGitInfo {
         sha: info.commit_hash.map(|sha| sha.0),
         branch: info.branch,
@@ -9183,10 +9231,7 @@ fn thread_from_stored_thread(
         thread.cwd,
     ))
     .unwrap_or_else(|err| {
-        warn!(
-            path = %path.display(),
-            "failed to normalize thread cwd while reading stored thread: {err}"
-        );
+        warn!("failed to normalize thread cwd while reading stored thread: {err}");
         fallback_cwd.clone()
     });
     let source = with_thread_spawn_agent_metadata(
@@ -9208,7 +9253,7 @@ fn thread_from_stored_thread(
         created_at: thread.created_at.timestamp(),
         updated_at: thread.updated_at.timestamp(),
         status: ThreadStatus::NotLoaded,
-        path: Some(path),
+        path,
         cwd,
         cli_version: thread.cli_version,
         agent_nickname: source.get_nickname(),
@@ -9218,7 +9263,30 @@ fn thread_from_stored_thread(
         name: thread.name,
         turns: Vec::new(),
     };
-    Some((thread, history))
+    (thread, history)
+}
+
+fn loaded_materialized_rollout_path<'a>(
+    thread_id: ThreadId,
+    config_snapshot: &ThreadConfigSnapshot,
+    rollout_path: Option<&'a PathBuf>,
+) -> Result<&'a Path, ThreadReadViewError> {
+    let Some(path) = rollout_path else {
+        let message = if config_snapshot.ephemeral {
+            "ephemeral threads do not support includeTurns".to_string()
+        } else {
+            format!(
+                "thread {thread_id} is not materialized yet; includeTurns is unavailable before first user message"
+            )
+        };
+        return Err(ThreadReadViewError::InvalidRequest(message));
+    };
+    if !path.exists() {
+        return Err(ThreadReadViewError::InvalidRequest(format!(
+            "thread {thread_id} is not materialized yet; includeTurns is unavailable before first user message"
+        )));
+    }
+    Ok(path.as_path())
 }
 
 fn thread_store_archive_error(operation: &str, err: ThreadStoreError) -> JSONRPCErrorError {

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -3208,6 +3208,9 @@ impl CodexMessageProcessor {
             Some(None) => Some(None),
             None => None,
         };
+        let clears_git_info = matches!(git_sha, Some(None))
+            || matches!(git_branch, Some(None))
+            || matches!(git_origin_url, Some(None));
 
         let updated = match state_db_ctx
             .update_thread_git_info(
@@ -3232,6 +3235,18 @@ impl CodexMessageProcessor {
             self.send_internal_error(
                 request_id,
                 format!("thread metadata disappeared before update completed: {thread_uuid}"),
+            )
+            .await;
+            return;
+        }
+        if clears_git_info
+            && let Err(err) = state_db_ctx
+                .touch_thread_updated_at(thread_uuid, Utc::now())
+                .await
+        {
+            self.send_internal_error(
+                request_id,
+                format!("failed to touch thread metadata for {thread_uuid}: {err}"),
             )
             .await;
             return;

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -3927,10 +3927,9 @@ impl CodexMessageProcessor {
         let mut thread =
             build_thread_from_snapshot(thread_id, &config_snapshot, loaded_rollout_path.clone());
 
-        // Temporary live-thread metadata shim: stored-thread metadata is owned by
-        // ThreadStore, but loaded threads that are not yet readable from the store may
-        // still have local metadata. Keep this compatibility path centralized here so
-        // future remote threadstore implementations have one app-server boundary to replace.
+        // Temporary live-thread metadata shim: loaded threads that are not yet
+        // readable from the store may still have local metadata, so use it to fill
+        // summary fields for the live fallback view.
         let loaded_state_db = loaded_thread.state_db();
         let summary = match loaded_state_db.as_ref() {
             Some(state_db) => {

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -352,6 +352,7 @@ use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
 use toml::Value as TomlValue;
 use tracing::Instrument;
+use tracing::debug;
 use tracing::error;
 use tracing::info;
 use tracing::warn;
@@ -3782,65 +3783,59 @@ impl CodexMessageProcessor {
         };
 
         let loaded_thread = self.thread_manager.get_thread(thread_uuid).await.ok();
-        let loaded_thread_state_db = loaded_thread.as_ref().and_then(|thread| thread.state_db());
-        let db_summary = if let Some(state_db_ctx) = loaded_thread_state_db.as_ref() {
-            read_summary_from_state_db_context_by_thread_id(Some(state_db_ctx), thread_uuid).await
-        } else {
-            read_summary_from_state_db_by_thread_id(&self.config, thread_uuid).await
+        let stored_thread = match self
+            .thread_store
+            .read_thread(StoreReadThreadParams {
+                thread_id: thread_uuid,
+                include_archived: false,
+                include_history: include_turns,
+            })
+            .await
+        {
+            Ok(thread) => Some(thread),
+            Err(ThreadStoreError::InvalidRequest { message }) if loaded_thread.is_some() => {
+                debug!("falling back to loaded thread for {thread_uuid}: {message}");
+                None
+            }
+            Err(ThreadStoreError::ThreadNotFound { .. }) if loaded_thread.is_some() => {
+                debug!("falling back to loaded thread for {thread_uuid}: thread not found");
+                None
+            }
+            Err(err) => {
+                self.outgoing
+                    .send_error(request_id, thread_store_read_error(err))
+                    .await;
+                return;
+            }
         };
-        let mut rollout_path = db_summary.as_ref().map(|summary| summary.path.clone());
-        if rollout_path.is_none() || include_turns {
-            rollout_path =
-                match find_thread_path_by_id_str(&self.config.codex_home, &thread_uuid.to_string())
-                    .await
-                {
-                    Ok(Some(path)) => Some(path),
-                    Ok(None) => {
-                        if include_turns {
-                            None
-                        } else {
-                            rollout_path
-                        }
-                    }
-                    Err(err) => {
-                        self.send_invalid_request_error(
-                            request_id,
-                            format!("failed to locate thread id {thread_uuid}: {err}"),
-                        )
-                        .await;
-                        return;
-                    }
-                };
-        }
 
-        if include_turns && rollout_path.is_none() && db_summary.is_some() {
-            self.send_internal_error(
-                request_id,
-                format!("failed to locate rollout for thread {thread_uuid}"),
-            )
-            .await;
-            return;
-        }
-
-        let mut thread = if let Some(summary) = db_summary {
-            summary_to_thread(summary, &self.config.cwd)
-        } else if let Some(rollout_path) = rollout_path.as_ref() {
+        let mut thread = if let Some(stored_thread) = stored_thread {
             let fallback_provider = self.config.model_provider_id.as_str();
-            match read_summary_from_rollout(rollout_path, fallback_provider).await {
-                Ok(summary) => summary_to_thread(summary, &self.config.cwd),
-                Err(err) => {
+            let Some((mut thread, history)) =
+                thread_from_stored_thread(stored_thread, fallback_provider, &self.config.cwd)
+            else {
+                self.send_internal_error(
+                    request_id,
+                    format!("failed to read thread {thread_uuid}"),
+                )
+                .await;
+                return;
+            };
+            if include_turns {
+                let Some(history) = history else {
                     self.send_internal_error(
                         request_id,
-                        format!(
-                            "failed to load rollout `{}` for thread {thread_uuid}: {err}",
-                            rollout_path.display()
-                        ),
+                        format!("failed to load rollout history for thread {thread_uuid}"),
                     )
                     .await;
                     return;
-                }
+                };
+                thread.turns = build_turns_from_rollout_items(&history.items);
             }
+            thread
         } else {
+            // Only loaded live threads reach this branch. Stored threads should be read through the
+            // thread store above, while live threads may not have materialized a rollout yet.
             let Some(thread) = loaded_thread.as_ref() else {
                 self.send_invalid_request_error(
                     request_id,
@@ -3851,54 +3846,33 @@ impl CodexMessageProcessor {
             };
             let config_snapshot = thread.config_snapshot().await;
             let loaded_rollout_path = thread.rollout_path();
-            if include_turns && loaded_rollout_path.is_none() {
-                self.send_invalid_request_error(
-                    request_id,
-                    "ephemeral threads do not support includeTurns".to_string(),
-                )
-                .await;
+            if include_turns {
+                let message = if config_snapshot.ephemeral && loaded_rollout_path.is_none() {
+                    "ephemeral threads do not support includeTurns".to_string()
+                } else {
+                    format!(
+                        "thread {thread_uuid} is not materialized yet; includeTurns is unavailable before first user message"
+                    )
+                };
+                self.send_invalid_request_error(request_id, message).await;
                 return;
             }
-            if include_turns {
-                rollout_path = loaded_rollout_path.clone();
+            let mut thread =
+                build_thread_from_snapshot(thread_uuid, &config_snapshot, loaded_rollout_path);
+            // Stored-thread metadata is applied inside LocalThreadStore. This is only for loaded
+            // live threads that are not yet readable from the store, such as a newly started thread
+            // with a precomputed rollout path but no materialized rollout file.
+            if let Some(summary) =
+                read_summary_from_state_db_by_thread_id(&self.config, thread_uuid).await
+            {
+                merge_mutable_thread_metadata(
+                    &mut thread,
+                    summary_to_thread(summary, &self.config.cwd),
+                );
             }
-            build_thread_from_snapshot(thread_uuid, &config_snapshot, loaded_rollout_path)
+            self.attach_thread_name(thread_uuid, &mut thread).await;
+            thread
         };
-        if thread.forked_from_id.is_none()
-            && let Some(rollout_path) = rollout_path.as_ref()
-        {
-            thread.forked_from_id = forked_from_id_from_rollout(rollout_path).await;
-        }
-        self.attach_thread_name(thread_uuid, &mut thread).await;
-
-        if include_turns && let Some(rollout_path) = rollout_path.as_ref() {
-            match read_rollout_items_from_rollout(rollout_path).await {
-                Ok(items) => {
-                    thread.turns = build_turns_from_rollout_items(&items);
-                }
-                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                    self.send_invalid_request_error(
-                        request_id,
-                        format!(
-                            "thread {thread_uuid} is not materialized yet; includeTurns is unavailable before first user message"
-                        ),
-                    )
-                    .await;
-                    return;
-                }
-                Err(err) => {
-                    self.send_internal_error(
-                        request_id,
-                        format!(
-                            "failed to load rollout `{}` for thread {thread_uuid}: {err}",
-                            rollout_path.display()
-                        ),
-                    )
-                    .await;
-                    return;
-                }
-            }
-        }
 
         let has_live_in_progress_turn = if let Some(loaded_thread) = loaded_thread.as_ref() {
             matches!(loaded_thread.agent_status().await, AgentStatus::Running)
@@ -4842,54 +4816,67 @@ impl CodexMessageProcessor {
             return;
         }
 
-        let path = match params {
+        let fallback_provider = self.config.model_provider_id.as_str();
+        match params {
             GetConversationSummaryParams::RolloutPath { rollout_path } => {
-                if rollout_path.is_relative() {
+                // Legacy compatibility for clients that still hold local rollout paths. New
+                // callsites should prefer thread-id lookups through the thread store so hosted
+                // stores do not need to expose filesystem paths.
+                let path = if rollout_path.is_relative() {
                     self.config.codex_home.join(&rollout_path).to_path_buf()
                 } else {
                     rollout_path
-                }
-            }
-            GetConversationSummaryParams::ThreadId { conversation_id } => {
-                match codex_core::find_thread_path_by_id_str(
-                    &self.config.codex_home,
-                    &conversation_id.to_string(),
-                )
-                .await
-                {
-                    Ok(Some(p)) => p,
-                    _ => {
+                };
+                match read_summary_from_rollout(&path, fallback_provider).await {
+                    Ok(summary) => {
+                        let response = GetConversationSummaryResponse { summary };
+                        self.outgoing.send_response(request_id, response).await;
+                    }
+                    Err(err) => {
                         let error = JSONRPCErrorError {
-                            code: INVALID_REQUEST_ERROR_CODE,
+                            code: INTERNAL_ERROR_CODE,
                             message: format!(
-                                "no rollout found for conversation id {conversation_id}"
+                                "failed to load conversation summary from {}: {}",
+                                path.display(),
+                                err
                             ),
                             data: None,
                         };
                         self.outgoing.send_error(request_id, error).await;
+                    }
+                };
+            }
+            GetConversationSummaryParams::ThreadId { conversation_id } => {
+                let stored_thread = match self
+                    .thread_store
+                    .read_thread(StoreReadThreadParams {
+                        thread_id: conversation_id,
+                        include_archived: false,
+                        include_history: false,
+                    })
+                    .await
+                {
+                    Ok(thread) => thread,
+                    Err(err) => {
+                        self.outgoing
+                            .send_error(request_id, thread_store_read_error(err))
+                            .await;
                         return;
                     }
-                }
-            }
-        };
-
-        let fallback_provider = self.config.model_provider_id.as_str();
-        match read_summary_from_rollout(&path, fallback_provider).await {
-            Ok(summary) => {
-                let response = GetConversationSummaryResponse { summary };
-                self.outgoing.send_response(request_id, response).await;
-            }
-            Err(err) => {
-                let error = JSONRPCErrorError {
-                    code: INTERNAL_ERROR_CODE,
-                    message: format!(
-                        "failed to load conversation summary from {}: {}",
-                        path.display(),
-                        err
-                    ),
-                    data: None,
                 };
-                self.outgoing.send_error(request_id, error).await;
+                match summary_from_stored_thread(stored_thread, fallback_provider) {
+                    Some(summary) => {
+                        let response = GetConversationSummaryResponse { summary };
+                        self.outgoing.send_response(request_id, response).await;
+                    }
+                    None => {
+                        self.send_internal_error(
+                            request_id,
+                            format!("failed to read conversation summary for {conversation_id}"),
+                        )
+                        .await;
+                    }
+                }
             }
         }
     }
@@ -9143,6 +9130,11 @@ fn set_thread_name_from_title(thread: &mut Thread, title: String) {
 
 fn thread_store_list_error(err: ThreadStoreError) -> JSONRPCErrorError {
     match err {
+        ThreadStoreError::ThreadNotFound { thread_id } => JSONRPCErrorError {
+            code: INVALID_REQUEST_ERROR_CODE,
+            message: format!("thread not found: {thread_id}"),
+            data: None,
+        },
         ThreadStoreError::InvalidRequest { message } => JSONRPCErrorError {
             code: INVALID_REQUEST_ERROR_CODE,
             message,
@@ -9154,6 +9146,79 @@ fn thread_store_list_error(err: ThreadStoreError) -> JSONRPCErrorError {
             data: None,
         },
     }
+}
+
+fn thread_store_read_error(err: ThreadStoreError) -> JSONRPCErrorError {
+    match err {
+        ThreadStoreError::ThreadNotFound { thread_id } => JSONRPCErrorError {
+            code: INVALID_REQUEST_ERROR_CODE,
+            message: format!("thread not found: {thread_id}"),
+            data: None,
+        },
+        ThreadStoreError::InvalidRequest { message } => JSONRPCErrorError {
+            code: INVALID_REQUEST_ERROR_CODE,
+            message,
+            data: None,
+        },
+        err => JSONRPCErrorError {
+            code: INTERNAL_ERROR_CODE,
+            message: format!("failed to read thread: {err}"),
+            data: None,
+        },
+    }
+}
+
+fn thread_from_stored_thread(
+    thread: StoredThread,
+    fallback_provider: &str,
+    fallback_cwd: &AbsolutePathBuf,
+) -> Option<(Thread, Option<codex_thread_store::StoredThreadHistory>)> {
+    let path = thread.rollout_path?;
+    let git_info = thread.git_info.map(|info| ApiGitInfo {
+        sha: info.commit_hash.map(|sha| sha.0),
+        branch: info.branch,
+        origin_url: info.repository_url,
+    });
+    let cwd = AbsolutePathBuf::relative_to_current_dir(path_utils::normalize_for_native_workdir(
+        thread.cwd,
+    ))
+    .unwrap_or_else(|err| {
+        warn!(
+            path = %path.display(),
+            "failed to normalize thread cwd while reading stored thread: {err}"
+        );
+        fallback_cwd.clone()
+    });
+    let source = with_thread_spawn_agent_metadata(
+        thread.source,
+        thread.agent_nickname.clone(),
+        thread.agent_role.clone(),
+    );
+    let history = thread.history;
+    let thread = Thread {
+        id: thread.thread_id.to_string(),
+        forked_from_id: thread.forked_from_id.map(|id| id.to_string()),
+        preview: thread.first_user_message.unwrap_or(thread.preview),
+        ephemeral: false,
+        model_provider: if thread.model_provider.is_empty() {
+            fallback_provider.to_string()
+        } else {
+            thread.model_provider
+        },
+        created_at: thread.created_at.timestamp(),
+        updated_at: thread.updated_at.timestamp(),
+        status: ThreadStatus::NotLoaded,
+        path: Some(path),
+        cwd,
+        cli_version: thread.cli_version,
+        agent_nickname: source.get_nickname(),
+        agent_role: source.get_agent_role(),
+        source: source.into(),
+        git_info,
+        name: thread.name,
+        turns: Vec::new(),
+    };
+    Some((thread, history))
 }
 
 fn thread_store_archive_error(operation: &str, err: ThreadStoreError) -> JSONRPCErrorError {
@@ -9191,7 +9256,13 @@ fn summary_from_stored_thread(
         path,
         preview: thread.first_user_message.unwrap_or(thread.preview),
         timestamp: Some(thread.created_at.to_rfc3339_opts(SecondsFormat::Secs, true)),
-        updated_at: Some(thread.updated_at.to_rfc3339_opts(SecondsFormat::Secs, true)),
+        // Match the legacy rollout-backed summary path, which reports updated_at from the
+        // rollout file mtime with millisecond precision.
+        updated_at: Some(
+            thread
+                .updated_at
+                .to_rfc3339_opts(SecondsFormat::Millis, true),
+        ),
         model_provider: if thread.model_provider.is_empty() {
             fallback_provider.to_string()
         } else {

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -3836,6 +3836,11 @@ impl CodexMessageProcessor {
                     self.thread_view_from_loaded_thread(thread_id, loaded_thread, include_turns)
                         .await?
                 } else {
+                    if message == format!("no rollout found for thread id {thread_id}") {
+                        return Err(ThreadReadViewError::InvalidRequest(format!(
+                            "thread not loaded: {thread_id}"
+                        )));
+                    }
                     return Err(ThreadReadViewError::InvalidRequest(message));
                 }
             }
@@ -3848,7 +3853,7 @@ impl CodexMessageProcessor {
                         .await?
                 } else {
                     return Err(ThreadReadViewError::InvalidRequest(format!(
-                        "thread not found: {missing_thread_id}"
+                        "thread not loaded: {missing_thread_id}"
                     )));
                 }
             }

--- a/codex-rs/app-server/tests/suite/v2/thread_read.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_read.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use app_test_support::McpProcess;
 use app_test_support::create_fake_rollout_with_text_elements;
 use app_test_support::create_mock_responses_server_repeating_assistant;
+use app_test_support::rollout_path;
 use app_test_support::test_absolute_path;
 use app_test_support::to_response;
 use codex_app_server_protocol::JSONRPCError;
@@ -153,6 +154,90 @@ async fn thread_read_can_include_turns() -> Result<()> {
         other => panic!("expected user message item, got {other:?}"),
     }
     assert_eq!(thread.status, ThreadStatus::NotLoaded);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn thread_read_include_turns_supports_loaded_explicit_path_thread() -> Result<()> {
+    let server = create_mock_responses_server_repeating_assistant("Done").await;
+    let codex_home = TempDir::new()?;
+    let external_home = TempDir::new()?;
+    create_config_toml(codex_home.path(), &server.uri())?;
+
+    let filename_ts = "2025-01-05T12-00-00";
+    let preview = "External saved user message";
+    let text_elements = vec![TextElement::new(
+        ByteRange { start: 0, end: 8 },
+        Some("<external>".into()),
+    )];
+    let conversation_id = create_fake_rollout_with_text_elements(
+        external_home.path(),
+        filename_ts,
+        "2025-01-05T12:00:00Z",
+        preview,
+        text_elements
+            .iter()
+            .map(|elem| serde_json::to_value(elem).expect("serialize text element"))
+            .collect(),
+        Some("mock_provider"),
+        /*git_info*/ None,
+    )?;
+    let external_rollout_path = rollout_path(external_home.path(), filename_ts, &conversation_id);
+
+    let mut mcp = McpProcess::new(codex_home.path()).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let resume_id = mcp
+        .send_thread_resume_request(ThreadResumeParams {
+            thread_id: conversation_id.clone(),
+            path: Some(external_rollout_path),
+            ..Default::default()
+        })
+        .await?;
+    let resume_resp: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(resume_id)),
+    )
+    .await??;
+    let ThreadResumeResponse {
+        thread: resumed, ..
+    } = to_response::<ThreadResumeResponse>(resume_resp)?;
+    assert_eq!(resumed.id, conversation_id);
+
+    let read_id = mcp
+        .send_thread_read_request(ThreadReadParams {
+            thread_id: conversation_id,
+            include_turns: true,
+        })
+        .await?;
+    let read_resp: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(read_id)),
+    )
+    .await??;
+    let ThreadReadResponse { thread } = to_response::<ThreadReadResponse>(read_resp)?;
+
+    assert_eq!(
+        thread.turns.len(),
+        1,
+        "expected explicit-path rollout to provide one turn"
+    );
+    let turn = &thread.turns[0];
+    assert_eq!(turn.status, TurnStatus::Completed);
+    assert_eq!(turn.items.len(), 1, "expected user message item");
+    match &turn.items[0] {
+        ThreadItem::UserMessage { content, .. } => {
+            assert_eq!(
+                content,
+                &vec![UserInput::Text {
+                    text: preview.to_string(),
+                    text_elements: text_elements.into_iter().map(Into::into).collect(),
+                }]
+            );
+        }
+        other => panic!("expected user message item, got {other:?}"),
+    }
 
     Ok(())
 }

--- a/codex-rs/app-server/tests/suite/v2/thread_read.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_read.rs
@@ -28,6 +28,7 @@ use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnStartResponse;
 use codex_app_server_protocol::TurnStatus;
 use codex_app_server_protocol::UserInput;
+use codex_core::ARCHIVED_SESSIONS_SUBDIR;
 use codex_protocol::user_input::ByteRange;
 use codex_protocol::user_input::TextElement;
 use core_test_support::responses;
@@ -184,6 +185,13 @@ async fn thread_read_include_turns_supports_loaded_explicit_path_thread() -> Res
         /*git_info*/ None,
     )?;
     let external_rollout_path = rollout_path(external_home.path(), filename_ts, &conversation_id);
+    let parent_thread_id = "00000000-0000-0000-0000-000000000123";
+    let contents = std::fs::read_to_string(&external_rollout_path)?;
+    let mut lines = contents.lines().map(str::to_string).collect::<Vec<_>>();
+    let mut meta_line: Value = serde_json::from_str(&lines[0])?;
+    meta_line["payload"]["forked_from_id"] = Value::String(parent_thread_id.to_string());
+    lines[0] = meta_line.to_string();
+    std::fs::write(&external_rollout_path, format!("{}\n", lines.join("\n")))?;
 
     let mut mcp = McpProcess::new(codex_home.path()).await?;
     timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
@@ -218,6 +226,7 @@ async fn thread_read_include_turns_supports_loaded_explicit_path_thread() -> Res
     .await??;
     let ThreadReadResponse { thread } = to_response::<ThreadReadResponse>(read_resp)?;
 
+    assert_eq!(thread.forked_from_id.as_deref(), Some(parent_thread_id));
     assert_eq!(
         thread.turns.len(),
         1,
@@ -238,6 +247,54 @@ async fn thread_read_include_turns_supports_loaded_explicit_path_thread() -> Res
         }
         other => panic!("expected user message item, got {other:?}"),
     }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn thread_read_can_return_archived_threads_by_id() -> Result<()> {
+    let server = create_mock_responses_server_repeating_assistant("Done").await;
+    let codex_home = TempDir::new()?;
+    create_config_toml(codex_home.path(), &server.uri())?;
+
+    let filename_ts = "2025-01-05T12-00-00";
+    let preview = "Archived saved user message";
+    let conversation_id = create_fake_rollout_with_text_elements(
+        codex_home.path(),
+        filename_ts,
+        "2025-01-05T12:00:00Z",
+        preview,
+        vec![],
+        Some("mock_provider"),
+        /*git_info*/ None,
+    )?;
+    let active_rollout_path = rollout_path(codex_home.path(), filename_ts, &conversation_id);
+    let archived_dir = codex_home.path().join(ARCHIVED_SESSIONS_SUBDIR);
+    std::fs::create_dir_all(&archived_dir)?;
+    let archived_rollout_path =
+        archived_dir.join(active_rollout_path.file_name().expect("rollout file name"));
+    std::fs::rename(&active_rollout_path, &archived_rollout_path)?;
+
+    let mut mcp = McpProcess::new(codex_home.path()).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let read_id = mcp
+        .send_thread_read_request(ThreadReadParams {
+            thread_id: conversation_id.clone(),
+            include_turns: false,
+        })
+        .await?;
+    let read_resp: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(read_id)),
+    )
+    .await??;
+    let ThreadReadResponse { thread } = to_response::<ThreadReadResponse>(read_resp)?;
+
+    assert_eq!(thread.id, conversation_id);
+    assert_eq!(thread.preview, preview);
+    let path = thread.path.expect("thread path");
+    assert_eq!(path.canonicalize()?, archived_rollout_path.canonicalize()?);
 
     Ok(())
 }

--- a/codex-rs/thread-store/Cargo.toml
+++ b/codex-rs/thread-store/Cargo.toml
@@ -21,6 +21,7 @@ chrono = { workspace = true, features = ["serde"] }
 codex-git-utils = { workspace = true }
 codex-protocol = { workspace = true }
 codex-rollout = { workspace = true }
+codex-state = { workspace = true }
 prost = "0.14.3"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
@@ -29,7 +30,6 @@ tonic = { workspace = true }
 tonic-prost = { workspace = true }
 
 [dev-dependencies]
-codex-state = { workspace = true }
 pretty_assertions = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/codex-rs/thread-store/src/local/read_thread.rs
+++ b/codex-rs/thread-store/src/local/read_thread.rs
@@ -1,5 +1,7 @@
 use serde::de::DeserializeOwned;
 
+use chrono::DateTime;
+use chrono::Utc;
 use codex_rollout::RolloutRecorder;
 use codex_rollout::find_archived_thread_path_by_id_str;
 use codex_rollout::find_thread_name_by_id;
@@ -67,17 +69,22 @@ async fn read_thread_from_rollout_path(
     path: std::path::PathBuf,
 ) -> ThreadStoreResult<StoredThread> {
     let thread_id = params.thread_id;
+    let archived = path.starts_with(
+        store
+            .config
+            .codex_home
+            .join(codex_rollout::ARCHIVED_SESSIONS_SUBDIR),
+    );
     let Some(item) = read_thread_item_from_rollout(path.clone()).await else {
         // Some materialized sessions, such as standalone shell-command turns, have
         // valid persisted history and SQLite metadata before they have a user-message
         // preview that the rollout summary reader can use.
-        let Some(mut metadata) = read_sqlite_metadata(store, thread_id).await else {
-            return Err(ThreadStoreError::Internal {
-                message: format!("failed to read thread {}", path.display()),
-            });
+        let mut thread = if let Some(mut metadata) = read_sqlite_metadata(store, thread_id).await {
+            metadata.rollout_path = path.clone();
+            stored_thread_from_sqlite_metadata(store, metadata).await
+        } else {
+            stored_thread_from_session_meta(store, path.clone(), archived).await?
         };
-        metadata.rollout_path = path;
-        let mut thread = stored_thread_from_sqlite_metadata(store, metadata).await;
         if params.include_history {
             let Some(path) = thread.rollout_path.clone() else {
                 return Err(ThreadStoreError::Internal {
@@ -89,12 +96,6 @@ async fn read_thread_from_rollout_path(
         }
         return Ok(thread);
     };
-    let archived = item.path.starts_with(
-        store
-            .config
-            .codex_home
-            .join(codex_rollout::ARCHIVED_SESSIONS_SUBDIR),
-    );
     let mut thread =
         stored_thread_from_rollout_item(item, archived, store.config.model_provider_id.as_str())
             .ok_or_else(|| ThreadStoreError::Internal {
@@ -171,6 +172,54 @@ async fn read_sqlite_metadata(
         Ok(runtime) => runtime.get_thread(thread_id).await.ok().flatten(),
         Err(_) => None,
     }
+}
+
+async fn stored_thread_from_session_meta(
+    store: &LocalThreadStore,
+    path: std::path::PathBuf,
+    archived: bool,
+) -> ThreadStoreResult<StoredThread> {
+    let session_meta_line = read_session_meta_line(path.as_path())
+        .await
+        .map_err(|err| ThreadStoreError::Internal {
+            message: format!("failed to read thread {}: {err}", path.display()),
+        })?;
+    let created_at =
+        parse_rfc3339_datetime(session_meta_line.meta.timestamp.as_str()).unwrap_or_else(Utc::now);
+    let updated_at = read_rollout_updated_at(path.as_path()).unwrap_or(created_at);
+    let archived_at = archived.then_some(updated_at);
+    let model_provider = session_meta_line
+        .meta
+        .model_provider
+        .clone()
+        .filter(|provider| !provider.is_empty())
+        .unwrap_or_else(|| store.config.model_provider_id.clone());
+
+    Ok(StoredThread {
+        thread_id: session_meta_line.meta.id,
+        rollout_path: Some(path),
+        forked_from_id: session_meta_line.meta.forked_from_id,
+        preview: String::new(),
+        name: None,
+        model_provider,
+        model: None,
+        reasoning_effort: None,
+        created_at,
+        updated_at,
+        archived_at,
+        cwd: session_meta_line.meta.cwd,
+        cli_version: session_meta_line.meta.cli_version,
+        source: session_meta_line.meta.source,
+        agent_nickname: session_meta_line.meta.agent_nickname,
+        agent_role: session_meta_line.meta.agent_role,
+        agent_path: session_meta_line.meta.agent_path,
+        git_info: session_meta_line.git,
+        approval_mode: codex_protocol::protocol::AskForApproval::OnRequest,
+        sandbox_policy: codex_protocol::protocol::SandboxPolicy::new_read_only_policy(),
+        token_usage: None,
+        first_user_message: None,
+        history: None,
+    })
 }
 
 async fn stored_thread_from_sqlite_metadata(
@@ -275,6 +324,19 @@ fn parse_metadata_enum<T: DeserializeOwned>(value: &str) -> Option<T> {
     serde_json::from_str(value)
         .or_else(|_| serde_json::from_value(serde_json::Value::String(value.to_string())))
         .ok()
+}
+
+fn parse_rfc3339_datetime(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
+fn read_rollout_updated_at(path: &std::path::Path) -> Option<DateTime<Utc>> {
+    std::fs::metadata(path)
+        .ok()
+        .and_then(|meta| meta.modified().ok())
+        .map(DateTime::<Utc>::from)
 }
 
 fn parse_sandbox_policy(value: &str) -> codex_protocol::protocol::SandboxPolicy {
@@ -612,6 +674,74 @@ mod tests {
         assert_eq!(thread.model_provider, "sqlite-provider");
         assert_eq!(thread.cwd, home.path().join("workspace"));
         assert_eq!(thread.cli_version, "sqlite-cli");
+        let history = thread.history.expect("history should load");
+        assert_eq!(history.thread_id, thread_id);
+        assert_eq!(history.items.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn read_thread_uses_session_meta_for_rollout_without_user_preview_or_sqlite_metadata() {
+        let home = TempDir::new().expect("temp dir");
+        let store = LocalThreadStore::new(test_config(home.path()));
+        let uuid = Uuid::from_u128(218);
+        let thread_id = ThreadId::from_string(&uuid.to_string()).expect("valid thread id");
+        let day_dir = home.path().join("sessions/2025/01/03");
+        std::fs::create_dir_all(&day_dir).expect("sessions dir");
+        let rollout_path = day_dir.join(format!("rollout-2025-01-03T12-00-00-{uuid}.jsonl"));
+        let mut file = std::fs::File::create(&rollout_path).expect("session file");
+        let meta = serde_json::json!({
+            "timestamp": "2025-01-03T12:00:00Z",
+            "type": "session_meta",
+            "payload": {
+                "id": uuid,
+                "timestamp": "2025-01-03T12:00:00Z",
+                "cwd": home.path(),
+                "originator": "test_originator",
+                "cli_version": "test_version",
+                "source": "cli",
+                "model_provider": "rollout-provider",
+                "git": {
+                    "commit_hash": "abcdef",
+                    "branch": "main",
+                    "repository_url": "https://example.com/repo.git"
+                }
+            },
+        });
+        writeln!(file, "{meta}").expect("write session meta");
+
+        let thread = store
+            .read_thread(ReadThreadParams {
+                thread_id,
+                include_archived: false,
+                include_history: true,
+            })
+            .await
+            .expect("read thread");
+
+        assert_eq!(thread.thread_id, thread_id);
+        assert_eq!(thread.rollout_path, Some(rollout_path));
+        assert_eq!(thread.preview, "");
+        assert_eq!(thread.name, None);
+        assert_eq!(thread.model_provider, "rollout-provider");
+        assert_eq!(
+            thread.created_at,
+            parse_rfc3339_datetime("2025-01-03T12:00:00Z").unwrap()
+        );
+        assert!(thread.updated_at >= thread.created_at);
+        assert_eq!(thread.archived_at, None);
+        assert_eq!(thread.cwd, home.path());
+        assert_eq!(thread.cli_version, "test_version");
+        assert_eq!(thread.source, SessionSource::Cli);
+        let git_info = thread.git_info.expect("git info should be applied");
+        assert_eq!(
+            git_info.commit_hash.map(|sha| sha.0),
+            Some("abcdef".to_string())
+        );
+        assert_eq!(git_info.branch.as_deref(), Some("main"));
+        assert_eq!(
+            git_info.repository_url.as_deref(),
+            Some("https://example.com/repo.git")
+        );
         let history = thread.history.expect("history should load");
         assert_eq!(history.thread_id, thread_id);
         assert_eq!(history.items.len(), 1);

--- a/codex-rs/thread-store/src/local/read_thread.rs
+++ b/codex-rs/thread-store/src/local/read_thread.rs
@@ -1,6 +1,8 @@
 use codex_rollout::RolloutRecorder;
 use codex_rollout::find_archived_thread_path_by_id_str;
+use codex_rollout::find_thread_name_by_id;
 use codex_rollout::find_thread_path_by_id_str;
+use codex_rollout::read_session_meta_line;
 use codex_rollout::read_thread_item_from_rollout;
 
 use super::LocalThreadStore;
@@ -59,6 +61,44 @@ pub(super) async fn read_thread(
             .ok_or_else(|| ThreadStoreError::Internal {
                 message: format!("failed to read thread id from {}", path.display()),
             })?;
+    thread.forked_from_id = read_session_meta_line(path.as_path())
+        .await
+        .ok()
+        .and_then(|meta_line| meta_line.meta.forked_from_id);
+    let mut found_sqlite_title = false;
+    if let Ok(runtime) = codex_state::StateRuntime::init(
+        store.config.sqlite_home.clone(),
+        store.config.model_provider_id.clone(),
+    )
+    .await
+        && let Ok(Some(metadata)) = runtime.get_thread(thread.thread_id).await
+    {
+        if let Some(title) = distinct_title(&metadata) {
+            found_sqlite_title = true;
+            set_thread_name_from_title(&mut thread, title);
+        }
+        thread.git_info = if metadata.git_sha.is_none()
+            && metadata.git_branch.is_none()
+            && metadata.git_origin_url.is_none()
+        {
+            None
+        } else {
+            Some(codex_protocol::protocol::GitInfo {
+                commit_hash: metadata
+                    .git_sha
+                    .as_deref()
+                    .map(codex_git_utils::GitSha::new),
+                branch: metadata.git_branch,
+                repository_url: metadata.git_origin_url,
+            })
+        };
+    }
+    if !found_sqlite_title
+        && let Ok(Some(title)) =
+            find_thread_name_by_id(store.config.codex_home.as_path(), &thread_id).await
+    {
+        set_thread_name_from_title(&mut thread, title);
+    }
     if params.include_history {
         let (items, _, _) = RolloutRecorder::load_rollout_items(path.as_path())
             .await
@@ -70,9 +110,28 @@ pub(super) async fn read_thread(
     Ok(thread)
 }
 
+fn distinct_title(metadata: &codex_state::ThreadMetadata) -> Option<String> {
+    let title = metadata.title.trim();
+    if title.is_empty() || metadata.first_user_message.as_deref().map(str::trim) == Some(title) {
+        None
+    } else {
+        Some(title.to_string())
+    }
+}
+
+fn set_thread_name_from_title(thread: &mut StoredThread, title: String) {
+    if title.trim().is_empty() || thread.preview.trim() == title.trim() {
+        return;
+    }
+    thread.name = Some(title);
+}
+
 #[cfg(test)]
 mod tests {
+    use chrono::Utc;
     use codex_protocol::ThreadId;
+    use codex_protocol::protocol::SessionSource;
+    use codex_state::ThreadMetadataBuilder;
     use pretty_assertions::assert_eq;
     use tempfile::TempDir;
     use uuid::Uuid;
@@ -81,7 +140,9 @@ mod tests {
     use crate::ThreadStore;
     use crate::local::LocalThreadStore;
     use crate::local::test_support::test_config;
+    use crate::local::test_support::write_archived_session_file;
     use crate::local::test_support::write_session_file;
+    use crate::local::test_support::write_session_file_with_fork;
 
     #[tokio::test]
     async fn read_thread_returns_active_rollout_summary() {
@@ -105,10 +166,220 @@ mod tests {
         assert_eq!(thread.rollout_path, Some(active_path));
         assert_eq!(thread.archived_at, None);
         assert_eq!(thread.preview, "Hello from user");
+        let history = thread.history.expect("history should load");
+        assert_eq!(history.thread_id, thread_id);
+        assert_eq!(history.items.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn read_thread_returns_archived_rollout_when_requested() {
+        let home = TempDir::new().expect("temp dir");
+        let store = LocalThreadStore::new(test_config(home.path()));
+        let uuid = Uuid::from_u128(207);
+        let thread_id = ThreadId::from_string(&uuid.to_string()).expect("valid thread id");
+        let archived_path = write_archived_session_file(home.path(), "2025-01-03T12-00-00", uuid)
+            .expect("archived session file");
+
+        let active_only_err = store
+            .read_thread(ReadThreadParams {
+                thread_id,
+                include_archived: false,
+                include_history: false,
+            })
+            .await
+            .expect_err("active-only read should fail for archived rollout");
+        let ThreadStoreError::InvalidRequest { message } = active_only_err else {
+            panic!("expected invalid request error");
+        };
         assert_eq!(
-            thread.history.expect("history should load").thread_id,
-            thread_id
+            message,
+            format!("no rollout found for thread id {thread_id}")
         );
+
+        let thread = store
+            .read_thread(ReadThreadParams {
+                thread_id,
+                include_archived: true,
+                include_history: false,
+            })
+            .await
+            .expect("read archived thread");
+
+        assert_eq!(thread.thread_id, thread_id);
+        assert_eq!(thread.rollout_path, Some(archived_path));
+        assert!(thread.archived_at.is_some());
+        assert_eq!(thread.preview, "Archived user message");
+        assert!(thread.history.is_none());
+    }
+
+    #[tokio::test]
+    async fn read_thread_prefers_active_rollout_over_archived() {
+        let home = TempDir::new().expect("temp dir");
+        let store = LocalThreadStore::new(test_config(home.path()));
+        let uuid = Uuid::from_u128(208);
+        let thread_id = ThreadId::from_string(&uuid.to_string()).expect("valid thread id");
+        let active_path =
+            write_session_file(home.path(), "2025-01-03T12-00-00", uuid).expect("session file");
+        write_archived_session_file(home.path(), "2025-01-03T12-00-00", uuid)
+            .expect("archived session file");
+
+        let thread = store
+            .read_thread(ReadThreadParams {
+                thread_id,
+                include_archived: true,
+                include_history: false,
+            })
+            .await
+            .expect("read thread");
+
+        assert_eq!(thread.rollout_path, Some(active_path));
+        assert_eq!(thread.archived_at, None);
+        assert_eq!(thread.preview, "Hello from user");
+    }
+
+    #[tokio::test]
+    async fn read_thread_returns_forked_from_id() {
+        let home = TempDir::new().expect("temp dir");
+        let store = LocalThreadStore::new(test_config(home.path()));
+        let uuid = Uuid::from_u128(209);
+        let parent_uuid = Uuid::from_u128(210);
+        let thread_id = ThreadId::from_string(&uuid.to_string()).expect("valid thread id");
+        let parent_thread_id =
+            ThreadId::from_string(&parent_uuid.to_string()).expect("valid parent thread id");
+        write_session_file_with_fork(
+            home.path(),
+            home.path().join("sessions/2025/01/03"),
+            "2025-01-03T12-00-00",
+            uuid,
+            "Forked user message",
+            Some("test-provider"),
+            Some(parent_uuid),
+        )
+        .expect("forked session file");
+
+        let thread = store
+            .read_thread(ReadThreadParams {
+                thread_id,
+                include_archived: false,
+                include_history: false,
+            })
+            .await
+            .expect("read thread");
+
+        assert_eq!(thread.forked_from_id, Some(parent_thread_id));
+    }
+
+    #[tokio::test]
+    async fn read_thread_applies_sqlite_git_metadata() {
+        let home = TempDir::new().expect("temp dir");
+        let config = test_config(home.path());
+        let store = LocalThreadStore::new(config.clone());
+        let uuid = Uuid::from_u128(211);
+        let thread_id = ThreadId::from_string(&uuid.to_string()).expect("valid thread id");
+        let rollout_path =
+            write_session_file(home.path(), "2025-01-03T12-00-00", uuid).expect("session file");
+        let runtime = codex_state::StateRuntime::init(
+            config.sqlite_home.clone(),
+            config.model_provider_id.clone(),
+        )
+        .await
+        .expect("state db should initialize");
+        let mut builder =
+            ThreadMetadataBuilder::new(thread_id, rollout_path, Utc::now(), SessionSource::Cli);
+        builder.model_provider = Some(config.model_provider_id.clone());
+        builder.cwd = home.path().to_path_buf();
+        builder.cli_version = Some("test_version".to_string());
+        let mut metadata = builder.build(config.model_provider_id.as_str());
+        metadata.git_sha = Some("abc123".to_string());
+        metadata.git_branch = Some("feature/sqlite".to_string());
+        metadata.git_origin_url = Some("git@example.com:openai/codex.git".to_string());
+        runtime
+            .upsert_thread(&metadata)
+            .await
+            .expect("state db upsert should succeed");
+
+        let thread = store
+            .read_thread(ReadThreadParams {
+                thread_id,
+                include_archived: false,
+                include_history: false,
+            })
+            .await
+            .expect("read thread");
+
+        let git_info = thread.git_info.expect("git info should be applied");
+        assert_eq!(
+            git_info.commit_hash.map(|sha| sha.0),
+            Some("abc123".to_string())
+        );
+        assert_eq!(git_info.branch, Some("feature/sqlite".to_string()));
+        assert_eq!(
+            git_info.repository_url,
+            Some("git@example.com:openai/codex.git".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn read_thread_applies_sqlite_thread_name() {
+        let home = TempDir::new().expect("temp dir");
+        let config = test_config(home.path());
+        let store = LocalThreadStore::new(config.clone());
+        let uuid = Uuid::from_u128(212);
+        let thread_id = ThreadId::from_string(&uuid.to_string()).expect("valid thread id");
+        let rollout_path =
+            write_session_file(home.path(), "2025-01-03T12-00-00", uuid).expect("session file");
+        let runtime = codex_state::StateRuntime::init(
+            config.sqlite_home.clone(),
+            config.model_provider_id.clone(),
+        )
+        .await
+        .expect("state db should initialize");
+        let mut builder =
+            ThreadMetadataBuilder::new(thread_id, rollout_path, Utc::now(), SessionSource::Cli);
+        builder.model_provider = Some(config.model_provider_id.clone());
+        builder.cwd = home.path().to_path_buf();
+        builder.cli_version = Some("test_version".to_string());
+        let mut metadata = builder.build(config.model_provider_id.as_str());
+        metadata.title = "Saved title".to_string();
+        metadata.first_user_message = Some("Hello from user".to_string());
+        runtime
+            .upsert_thread(&metadata)
+            .await
+            .expect("state db upsert should succeed");
+
+        let thread = store
+            .read_thread(ReadThreadParams {
+                thread_id,
+                include_archived: false,
+                include_history: false,
+            })
+            .await
+            .expect("read thread");
+
+        assert_eq!(thread.name, Some("Saved title".to_string()));
+    }
+
+    #[tokio::test]
+    async fn read_thread_uses_legacy_thread_name_when_sqlite_title_is_missing() {
+        let home = TempDir::new().expect("temp dir");
+        let store = LocalThreadStore::new(test_config(home.path()));
+        let uuid = Uuid::from_u128(213);
+        let thread_id = ThreadId::from_string(&uuid.to_string()).expect("valid thread id");
+        write_session_file(home.path(), "2025-01-03T12-00-00", uuid).expect("session file");
+        codex_rollout::append_thread_name(home.path(), thread_id, "Legacy title")
+            .await
+            .expect("append legacy thread name");
+
+        let thread = store
+            .read_thread(ReadThreadParams {
+                thread_id,
+                include_archived: false,
+                include_history: false,
+            })
+            .await
+            .expect("read thread");
+
+        assert_eq!(thread.name, Some("Legacy title".to_string()));
     }
 
     #[tokio::test]

--- a/codex-rs/thread-store/src/local/read_thread.rs
+++ b/codex-rs/thread-store/src/local/read_thread.rs
@@ -79,12 +79,13 @@ async fn read_thread_from_rollout_path(
         // Some materialized sessions, such as standalone shell-command turns, have
         // valid persisted history and SQLite metadata before they have a user-message
         // preview that the rollout summary reader can use.
-        let mut thread = if let Some(mut metadata) = read_sqlite_metadata(store, thread_id).await {
-            metadata.rollout_path = path.clone();
-            stored_thread_from_sqlite_metadata(store, metadata).await
-        } else {
-            stored_thread_from_session_meta(store, path.clone(), archived).await?
-        };
+        let mut thread =
+            if let Ok(Some(mut metadata)) = read_sqlite_metadata(store, thread_id).await {
+                metadata.rollout_path = path.clone();
+                stored_thread_from_sqlite_metadata(store, metadata).await
+            } else {
+                stored_thread_from_session_meta(store, path.clone(), archived).await?
+            };
         if params.include_history {
             let Some(path) = thread.rollout_path.clone() else {
                 return Err(ThreadStoreError::Internal {
@@ -106,18 +107,14 @@ async fn read_thread_from_rollout_path(
         .ok()
         .and_then(|meta_line| meta_line.meta.forked_from_id);
     let mut found_sqlite_title = false;
-    if let Ok(runtime) = codex_state::StateRuntime::init(
-        store.config.sqlite_home.clone(),
-        store.config.model_provider_id.clone(),
-    )
-    .await
-        && let Ok(Some(metadata)) = runtime.get_thread(thread.thread_id).await
-    {
+    if let Ok(Some(metadata)) = read_sqlite_metadata(store, thread.thread_id).await {
         if let Some(title) = distinct_title(&metadata) {
             found_sqlite_title = true;
             set_thread_name_from_title(&mut thread, title);
         }
-        thread.git_info = git_info_from_metadata(&metadata);
+        if let Some(git_info) = git_info_from_metadata(&metadata) {
+            thread.git_info = Some(git_info);
+        }
     }
     if !found_sqlite_title
         && let Ok(Some(title)) =
@@ -137,9 +134,9 @@ async fn read_thread_from_sqlite_fallback(
     params: ReadThreadParams,
 ) -> ThreadStoreResult<StoredThread> {
     let thread_id = params.thread_id;
-    let metadata = read_sqlite_metadata(store, thread_id).await;
-    let Some(metadata) =
-        metadata.filter(|metadata| params.include_archived || metadata.archived_at.is_none())
+    let metadata = read_sqlite_metadata(store, thread_id).await?;
+    let Some(metadata) = metadata
+        .filter(|metadata| params.include_archived || !metadata_is_archived(store, metadata))
     else {
         return Err(ThreadStoreError::InvalidRequest {
             message: format!("no rollout found for thread id {thread_id}"),
@@ -162,16 +159,31 @@ async fn read_thread_from_sqlite_fallback(
 async fn read_sqlite_metadata(
     store: &LocalThreadStore,
     thread_id: codex_protocol::ThreadId,
-) -> Option<codex_state::ThreadMetadata> {
-    match codex_state::StateRuntime::init(
+) -> ThreadStoreResult<Option<codex_state::ThreadMetadata>> {
+    let runtime = codex_state::StateRuntime::init(
         store.config.sqlite_home.clone(),
         store.config.model_provider_id.clone(),
     )
     .await
-    {
-        Ok(runtime) => runtime.get_thread(thread_id).await.ok().flatten(),
-        Err(_) => None,
-    }
+    .map_err(|err| ThreadStoreError::Internal {
+        message: format!("failed to initialize SQLite state runtime: {err}"),
+    })?;
+    runtime
+        .get_thread(thread_id)
+        .await
+        .map_err(|err| ThreadStoreError::Internal {
+            message: format!("failed to read SQLite metadata for thread {thread_id}: {err}"),
+        })
+}
+
+fn metadata_is_archived(store: &LocalThreadStore, metadata: &codex_state::ThreadMetadata) -> bool {
+    metadata.archived_at.is_some()
+        || metadata.rollout_path.starts_with(
+            store
+                .config
+                .codex_home
+                .join(codex_rollout::ARCHIVED_SESSIONS_SUBDIR),
+        )
 }
 
 async fn stored_thread_from_session_meta(
@@ -544,6 +556,51 @@ mod tests {
         assert_eq!(
             git_info.repository_url,
             Some("git@example.com:openai/codex.git".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn read_thread_keeps_rollout_git_metadata_when_sqlite_git_metadata_is_empty() {
+        let home = TempDir::new().expect("temp dir");
+        let config = test_config(home.path());
+        let store = LocalThreadStore::new(config.clone());
+        let uuid = Uuid::from_u128(219);
+        let thread_id = ThreadId::from_string(&uuid.to_string()).expect("valid thread id");
+        let rollout_path =
+            write_session_file(home.path(), "2025-01-03T12-00-00", uuid).expect("session file");
+        let runtime = codex_state::StateRuntime::init(
+            config.sqlite_home.clone(),
+            config.model_provider_id.clone(),
+        )
+        .await
+        .expect("state db should initialize");
+        let mut builder =
+            ThreadMetadataBuilder::new(thread_id, rollout_path, Utc::now(), SessionSource::Cli);
+        builder.model_provider = Some(config.model_provider_id.clone());
+        let metadata = builder.build(config.model_provider_id.as_str());
+        runtime
+            .upsert_thread(&metadata)
+            .await
+            .expect("state db upsert should succeed");
+
+        let thread = store
+            .read_thread(ReadThreadParams {
+                thread_id,
+                include_archived: false,
+                include_history: false,
+            })
+            .await
+            .expect("read thread");
+
+        let git_info = thread.git_info.expect("rollout git info should be kept");
+        assert_eq!(
+            git_info.commit_hash.map(|sha| sha.0),
+            Some("abcdef".to_string())
+        );
+        assert_eq!(git_info.branch.as_deref(), Some("main"));
+        assert_eq!(
+            git_info.repository_url.as_deref(),
+            Some("https://example.com/repo.git")
         );
     }
 
@@ -922,6 +979,63 @@ mod tests {
         assert_eq!(thread.thread_id, thread_id);
         assert_eq!(thread.preview, "Archived SQLite preview");
         assert!(thread.archived_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn read_thread_sqlite_fallback_treats_archived_rollout_path_as_archived() {
+        let home = TempDir::new().expect("temp dir");
+        let config = test_config(home.path());
+        let store = LocalThreadStore::new(config.clone());
+        let uuid = Uuid::from_u128(220);
+        let thread_id = ThreadId::from_string(&uuid.to_string()).expect("valid thread id");
+        let rollout_path = home
+            .path()
+            .join(codex_rollout::ARCHIVED_SESSIONS_SUBDIR)
+            .join(format!("rollout-2025-01-03T12-00-00-{uuid}.jsonl"));
+        let runtime = codex_state::StateRuntime::init(
+            config.sqlite_home.clone(),
+            config.model_provider_id.clone(),
+        )
+        .await
+        .expect("state db should initialize");
+        let mut builder =
+            ThreadMetadataBuilder::new(thread_id, rollout_path, Utc::now(), SessionSource::Cli);
+        builder.model_provider = Some(config.model_provider_id.clone());
+        let mut metadata = builder.build(config.model_provider_id.as_str());
+        metadata.archived_at = None;
+        metadata.first_user_message = Some("Archived path SQLite preview".to_string());
+        runtime
+            .upsert_thread(&metadata)
+            .await
+            .expect("state db upsert should succeed");
+
+        let active_only_err = store
+            .read_thread(ReadThreadParams {
+                thread_id,
+                include_archived: false,
+                include_history: false,
+            })
+            .await
+            .expect_err("active-only read should fail for archived metadata path");
+        let ThreadStoreError::InvalidRequest { message } = active_only_err else {
+            panic!("expected invalid request error");
+        };
+        assert_eq!(
+            message,
+            format!("no rollout found for thread id {thread_id}")
+        );
+
+        let thread = store
+            .read_thread(ReadThreadParams {
+                thread_id,
+                include_archived: true,
+                include_history: false,
+            })
+            .await
+            .expect("read archived thread");
+
+        assert_eq!(thread.thread_id, thread_id);
+        assert_eq!(thread.preview, "Archived path SQLite preview");
     }
 
     #[tokio::test]

--- a/codex-rs/thread-store/src/local/read_thread.rs
+++ b/codex-rs/thread-store/src/local/read_thread.rs
@@ -114,6 +114,8 @@ async fn read_thread_from_rollout_path(
         }
         if let Some(git_info) = git_info_from_metadata(&metadata) {
             thread.git_info = Some(git_info);
+        } else if metadata.updated_at > thread.updated_at {
+            thread.git_info = None;
         }
     }
     if !found_sqlite_title

--- a/codex-rs/thread-store/src/local/read_thread.rs
+++ b/codex-rs/thread-store/src/local/read_thread.rs
@@ -17,6 +17,7 @@ use crate::StoredThreadHistory;
 use crate::ThreadStoreError;
 use crate::ThreadStoreResult;
 
+/// Reads a persisted thread by preferring discoverable rollout files, then SQLite metadata for external or legacy rows.
 pub(super) async fn read_thread(
     store: &LocalThreadStore,
     params: ReadThreadParams,
@@ -107,6 +108,9 @@ async fn read_thread_from_rollout_path(
         .ok()
         .and_then(|meta_line| meta_line.meta.forked_from_id);
     let mut found_sqlite_title = false;
+    // This overlay is different from the no-preview fallback above: the rollout
+    // summary was readable, so SQLite only supplies mutable metadata such as
+    // user-edited title, git fields, or explicit git-field clears.
     if let Ok(Some(metadata)) = read_sqlite_metadata(store, thread.thread_id).await {
         if let Some(title) = distinct_title(&metadata) {
             found_sqlite_title = true;

--- a/codex-rs/thread-store/src/local/read_thread.rs
+++ b/codex-rs/thread-store/src/local/read_thread.rs
@@ -67,11 +67,28 @@ async fn read_thread_from_rollout_path(
     path: std::path::PathBuf,
 ) -> ThreadStoreResult<StoredThread> {
     let thread_id = params.thread_id;
-    let item = read_thread_item_from_rollout(path.clone())
-        .await
-        .ok_or_else(|| ThreadStoreError::Internal {
-            message: format!("failed to read thread {}", path.display()),
-        })?;
+    let Some(item) = read_thread_item_from_rollout(path.clone()).await else {
+        // Some materialized sessions, such as standalone shell-command turns, have
+        // valid persisted history and SQLite metadata before they have a user-message
+        // preview that the rollout summary reader can use.
+        let Some(mut metadata) = read_sqlite_metadata(store, thread_id).await else {
+            return Err(ThreadStoreError::Internal {
+                message: format!("failed to read thread {}", path.display()),
+            });
+        };
+        metadata.rollout_path = path;
+        let mut thread = stored_thread_from_sqlite_metadata(store, metadata).await;
+        if params.include_history {
+            let Some(path) = thread.rollout_path.clone() else {
+                return Err(ThreadStoreError::Internal {
+                    message: format!("failed to load thread history for thread {thread_id}"),
+                });
+            };
+            let items = load_history_items(&path).await?;
+            thread.history = Some(StoredThreadHistory { thread_id, items });
+        }
+        return Ok(thread);
+    };
     let archived = item.path.starts_with(
         store
             .config
@@ -119,15 +136,7 @@ async fn read_thread_from_sqlite_fallback(
     params: ReadThreadParams,
 ) -> ThreadStoreResult<StoredThread> {
     let thread_id = params.thread_id;
-    let metadata = match codex_state::StateRuntime::init(
-        store.config.sqlite_home.clone(),
-        store.config.model_provider_id.clone(),
-    )
-    .await
-    {
-        Ok(runtime) => runtime.get_thread(thread_id).await.ok().flatten(),
-        Err(_) => None,
-    };
+    let metadata = read_sqlite_metadata(store, thread_id).await;
     let Some(metadata) =
         metadata.filter(|metadata| params.include_archived || metadata.archived_at.is_none())
     else {
@@ -147,6 +156,21 @@ async fn read_thread_from_sqlite_fallback(
         thread.history = Some(StoredThreadHistory { thread_id, items });
     }
     Ok(thread)
+}
+
+async fn read_sqlite_metadata(
+    store: &LocalThreadStore,
+    thread_id: codex_protocol::ThreadId,
+) -> Option<codex_state::ThreadMetadata> {
+    match codex_state::StateRuntime::init(
+        store.config.sqlite_home.clone(),
+        store.config.model_provider_id.clone(),
+    )
+    .await
+    {
+        Ok(runtime) => runtime.get_thread(thread_id).await.ok().flatten(),
+        Err(_) => None,
+    }
 }
 
 async fn stored_thread_from_sqlite_metadata(
@@ -268,6 +292,8 @@ fn parse_sandbox_policy(value: &str) -> codex_protocol::protocol::SandboxPolicy 
 
 #[cfg(test)]
 mod tests {
+    use std::io::Write;
+
     use chrono::Utc;
     use codex_protocol::ThreadId;
     use codex_protocol::protocol::SessionSource;
@@ -520,6 +546,75 @@ mod tests {
             .expect("read thread");
 
         assert_eq!(thread.name, Some("Legacy title".to_string()));
+    }
+
+    #[tokio::test]
+    async fn read_thread_uses_sqlite_metadata_for_rollout_without_user_preview() {
+        let home = TempDir::new().expect("temp dir");
+        let config = test_config(home.path());
+        let store = LocalThreadStore::new(config.clone());
+        let uuid = Uuid::from_u128(217);
+        let thread_id = ThreadId::from_string(&uuid.to_string()).expect("valid thread id");
+        let day_dir = home.path().join("sessions/2025/01/03");
+        std::fs::create_dir_all(&day_dir).expect("sessions dir");
+        let rollout_path = day_dir.join(format!("rollout-2025-01-03T12-00-00-{uuid}.jsonl"));
+        let mut file = std::fs::File::create(&rollout_path).expect("session file");
+        let meta = serde_json::json!({
+            "timestamp": "2025-01-03T12-00-00",
+            "type": "session_meta",
+            "payload": {
+                "id": uuid,
+                "timestamp": "2025-01-03T12-00-00",
+                "cwd": home.path(),
+                "originator": "test_originator",
+                "cli_version": "test_version",
+                "source": "cli",
+                "model_provider": "rollout-provider"
+            },
+        });
+        writeln!(file, "{meta}").expect("write session meta");
+
+        let runtime = codex_state::StateRuntime::init(
+            config.sqlite_home.clone(),
+            config.model_provider_id.clone(),
+        )
+        .await
+        .expect("state db should initialize");
+        let mut builder = ThreadMetadataBuilder::new(
+            thread_id,
+            rollout_path.clone(),
+            Utc::now(),
+            SessionSource::Cli,
+        );
+        builder.model_provider = Some("sqlite-provider".to_string());
+        builder.cwd = home.path().join("workspace");
+        builder.cli_version = Some("sqlite-cli".to_string());
+        let mut metadata = builder.build(config.model_provider_id.as_str());
+        metadata.title = "Command-only thread".to_string();
+        runtime
+            .upsert_thread(&metadata)
+            .await
+            .expect("state db upsert should succeed");
+
+        let thread = store
+            .read_thread(ReadThreadParams {
+                thread_id,
+                include_archived: false,
+                include_history: true,
+            })
+            .await
+            .expect("read thread");
+
+        assert_eq!(thread.thread_id, thread_id);
+        assert_eq!(thread.rollout_path, Some(rollout_path));
+        assert_eq!(thread.preview, "");
+        assert_eq!(thread.name.as_deref(), Some("Command-only thread"));
+        assert_eq!(thread.model_provider, "sqlite-provider");
+        assert_eq!(thread.cwd, home.path().join("workspace"));
+        assert_eq!(thread.cli_version, "sqlite-cli");
+        let history = thread.history.expect("history should load");
+        assert_eq!(history.thread_id, thread_id);
+        assert_eq!(history.items.len(), 1);
     }
 
     #[tokio::test]

--- a/codex-rs/thread-store/src/local/read_thread.rs
+++ b/codex-rs/thread-store/src/local/read_thread.rs
@@ -1,3 +1,5 @@
+use serde::de::DeserializeOwned;
+
 use codex_rollout::RolloutRecorder;
 use codex_rollout::find_archived_thread_path_by_id_str;
 use codex_rollout::find_thread_name_by_id;
@@ -17,6 +19,21 @@ pub(super) async fn read_thread(
     store: &LocalThreadStore,
     params: ReadThreadParams,
 ) -> ThreadStoreResult<StoredThread> {
+    // Local store resolution is rollout-first so summary extraction stays aligned
+    // with list/read behavior for normal persisted sessions. SQLite is a fallback
+    // for metadata rows that refer to rollouts not discoverable under codex_home,
+    // such as explicit-path resumes or legacy state.
+    let Some(path) = resolve_rollout_path(store, &params).await? else {
+        return read_thread_from_sqlite_fallback(store, params).await;
+    };
+
+    read_thread_from_rollout_path(store, params, path).await
+}
+
+async fn resolve_rollout_path(
+    store: &LocalThreadStore,
+    params: &ReadThreadParams,
+) -> ThreadStoreResult<Option<std::path::PathBuf>> {
     let thread_id = params.thread_id;
     let path = if params.include_archived {
         match find_thread_path_by_id_str(store.config.codex_home.as_path(), &thread_id.to_string())
@@ -40,11 +57,16 @@ pub(super) async fn read_thread(
             .map_err(|err| ThreadStoreError::InvalidRequest {
                 message: format!("failed to locate thread id {thread_id}: {err}"),
             })?
-    }
-    .ok_or_else(|| ThreadStoreError::InvalidRequest {
-        message: format!("no rollout found for thread id {thread_id}"),
-    })?;
+    };
+    Ok(path)
+}
 
+async fn read_thread_from_rollout_path(
+    store: &LocalThreadStore,
+    params: ReadThreadParams,
+    path: std::path::PathBuf,
+) -> ThreadStoreResult<StoredThread> {
+    let thread_id = params.thread_id;
     let item = read_thread_item_from_rollout(path.clone())
         .await
         .ok_or_else(|| ThreadStoreError::Internal {
@@ -77,21 +99,7 @@ pub(super) async fn read_thread(
             found_sqlite_title = true;
             set_thread_name_from_title(&mut thread, title);
         }
-        thread.git_info = if metadata.git_sha.is_none()
-            && metadata.git_branch.is_none()
-            && metadata.git_origin_url.is_none()
-        {
-            None
-        } else {
-            Some(codex_protocol::protocol::GitInfo {
-                commit_hash: metadata
-                    .git_sha
-                    .as_deref()
-                    .map(codex_git_utils::GitSha::new),
-                branch: metadata.git_branch,
-                repository_url: metadata.git_origin_url,
-            })
-        };
+        thread.git_info = git_info_from_metadata(&metadata);
     }
     if !found_sqlite_title
         && let Ok(Some(title)) =
@@ -100,14 +108,108 @@ pub(super) async fn read_thread(
         set_thread_name_from_title(&mut thread, title);
     }
     if params.include_history {
-        let (items, _, _) = RolloutRecorder::load_rollout_items(path.as_path())
-            .await
-            .map_err(|err| ThreadStoreError::Internal {
-                message: format!("failed to load thread history {}: {err}", path.display()),
-            })?;
+        let items = load_history_items(&path).await?;
         thread.history = Some(StoredThreadHistory { thread_id, items });
     }
     Ok(thread)
+}
+
+async fn read_thread_from_sqlite_fallback(
+    store: &LocalThreadStore,
+    params: ReadThreadParams,
+) -> ThreadStoreResult<StoredThread> {
+    let thread_id = params.thread_id;
+    let metadata = match codex_state::StateRuntime::init(
+        store.config.sqlite_home.clone(),
+        store.config.model_provider_id.clone(),
+    )
+    .await
+    {
+        Ok(runtime) => runtime.get_thread(thread_id).await.ok().flatten(),
+        Err(_) => None,
+    };
+    let Some(metadata) =
+        metadata.filter(|metadata| params.include_archived || metadata.archived_at.is_none())
+    else {
+        return Err(ThreadStoreError::InvalidRequest {
+            message: format!("no rollout found for thread id {thread_id}"),
+        });
+    };
+
+    let mut thread = stored_thread_from_sqlite_metadata(store, metadata).await;
+    if params.include_history {
+        let Some(path) = thread.rollout_path.clone() else {
+            return Err(ThreadStoreError::Internal {
+                message: format!("failed to load thread history for thread {thread_id}"),
+            });
+        };
+        let items = load_history_items(&path).await?;
+        thread.history = Some(StoredThreadHistory { thread_id, items });
+    }
+    Ok(thread)
+}
+
+async fn stored_thread_from_sqlite_metadata(
+    store: &LocalThreadStore,
+    metadata: codex_state::ThreadMetadata,
+) -> StoredThread {
+    let mut thread = StoredThread {
+        thread_id: metadata.id,
+        rollout_path: Some(metadata.rollout_path.clone()),
+        forked_from_id: read_session_meta_line(metadata.rollout_path.as_path())
+            .await
+            .ok()
+            .and_then(|meta_line| meta_line.meta.forked_from_id),
+        preview: metadata.first_user_message.clone().unwrap_or_default(),
+        name: None,
+        model_provider: if metadata.model_provider.is_empty() {
+            store.config.model_provider_id.clone()
+        } else {
+            metadata.model_provider.clone()
+        },
+        model: metadata.model.clone(),
+        reasoning_effort: metadata.reasoning_effort,
+        created_at: metadata.created_at,
+        updated_at: metadata.updated_at,
+        archived_at: metadata.archived_at,
+        cwd: metadata.cwd.clone(),
+        cli_version: metadata.cli_version.clone(),
+        source: parse_metadata_enum(&metadata.source)
+            .unwrap_or(codex_protocol::protocol::SessionSource::Unknown),
+        agent_nickname: metadata.agent_nickname.clone(),
+        agent_role: metadata.agent_role.clone(),
+        agent_path: metadata.agent_path.clone(),
+        git_info: git_info_from_metadata(&metadata),
+        approval_mode: parse_metadata_enum(&metadata.approval_mode)
+            .unwrap_or(codex_protocol::protocol::AskForApproval::OnRequest),
+        sandbox_policy: parse_sandbox_policy(metadata.sandbox_policy.as_str()),
+        token_usage: (metadata.tokens_used > 0).then(|| codex_protocol::protocol::TokenUsage {
+            total_tokens: metadata.tokens_used,
+            ..Default::default()
+        }),
+        first_user_message: metadata.first_user_message.clone(),
+        history: None,
+    };
+
+    if let Some(title) = distinct_title(&metadata) {
+        set_thread_name_from_title(&mut thread, title);
+    } else if let Ok(Some(title)) =
+        find_thread_name_by_id(store.config.codex_home.as_path(), &metadata.id).await
+    {
+        set_thread_name_from_title(&mut thread, title);
+    }
+    thread
+}
+
+async fn load_history_items(
+    path: &std::path::Path,
+) -> ThreadStoreResult<Vec<codex_protocol::protocol::RolloutItem>> {
+    let (items, _, _) = RolloutRecorder::load_rollout_items(path)
+        .await
+        .map_err(|err| ThreadStoreError::Internal {
+            message: format!("failed to load thread history {}: {err}", path.display()),
+        })?;
+    Ok(items)
 }
 
 fn distinct_title(metadata: &codex_state::ThreadMetadata) -> Option<String> {
@@ -124,6 +226,44 @@ fn set_thread_name_from_title(thread: &mut StoredThread, title: String) {
         return;
     }
     thread.name = Some(title);
+}
+
+fn git_info_from_metadata(
+    metadata: &codex_state::ThreadMetadata,
+) -> Option<codex_protocol::protocol::GitInfo> {
+    if metadata.git_sha.is_none()
+        && metadata.git_branch.is_none()
+        && metadata.git_origin_url.is_none()
+    {
+        return None;
+    }
+    Some(codex_protocol::protocol::GitInfo {
+        commit_hash: metadata
+            .git_sha
+            .as_deref()
+            .map(codex_git_utils::GitSha::new),
+        branch: metadata.git_branch.clone(),
+        repository_url: metadata.git_origin_url.clone(),
+    })
+}
+
+fn parse_metadata_enum<T: DeserializeOwned>(value: &str) -> Option<T> {
+    serde_json::from_str(value)
+        .or_else(|_| serde_json::from_value(serde_json::Value::String(value.to_string())))
+        .ok()
+}
+
+fn parse_sandbox_policy(value: &str) -> codex_protocol::protocol::SandboxPolicy {
+    parse_metadata_enum(value)
+        .or_else(|| match value.trim() {
+            "danger-full-access" => Some(codex_protocol::protocol::SandboxPolicy::DangerFullAccess),
+            "read-only" => Some(codex_protocol::protocol::SandboxPolicy::new_read_only_policy()),
+            "workspace-write" => {
+                Some(codex_protocol::protocol::SandboxPolicy::new_workspace_write_policy())
+            }
+            _ => None,
+        })
+        .unwrap_or_else(codex_protocol::protocol::SandboxPolicy::new_read_only_policy)
 }
 
 #[cfg(test)]
@@ -380,6 +520,183 @@ mod tests {
             .expect("read thread");
 
         assert_eq!(thread.name, Some("Legacy title".to_string()));
+    }
+
+    #[tokio::test]
+    async fn read_thread_falls_back_to_sqlite_summary() {
+        let home = TempDir::new().expect("temp dir");
+        let external = TempDir::new().expect("external temp dir");
+        let config = test_config(home.path());
+        let store = LocalThreadStore::new(config.clone());
+        let uuid = Uuid::from_u128(214);
+        let thread_id = ThreadId::from_string(&uuid.to_string()).expect("valid thread id");
+        let rollout_path = external
+            .path()
+            .join(format!("rollout-2025-01-03T12-00-00-{uuid}.jsonl"));
+        let runtime = codex_state::StateRuntime::init(
+            config.sqlite_home.clone(),
+            config.model_provider_id.clone(),
+        )
+        .await
+        .expect("state db should initialize");
+        let mut builder = ThreadMetadataBuilder::new(
+            thread_id,
+            rollout_path.clone(),
+            Utc::now(),
+            SessionSource::Exec,
+        );
+        builder.model_provider = Some("sqlite-provider".to_string());
+        builder.cwd = external.path().join("workspace");
+        builder.cli_version = Some("sqlite-cli".to_string());
+        let mut metadata = builder.build(config.model_provider_id.as_str());
+        metadata.title = "SQLite title".to_string();
+        metadata.first_user_message = Some("SQLite preview".to_string());
+        metadata.model = Some("sqlite-model".to_string());
+        metadata.git_sha = Some("abc123".to_string());
+        metadata.git_branch = Some("sqlite-branch".to_string());
+        metadata.git_origin_url = Some("https://example.com/sqlite.git".to_string());
+        runtime
+            .upsert_thread(&metadata)
+            .await
+            .expect("state db upsert should succeed");
+
+        let thread = store
+            .read_thread(ReadThreadParams {
+                thread_id,
+                include_archived: false,
+                include_history: false,
+            })
+            .await
+            .expect("read thread");
+
+        assert_eq!(thread.thread_id, thread_id);
+        assert_eq!(thread.rollout_path, Some(rollout_path));
+        assert_eq!(thread.preview, "SQLite preview");
+        assert_eq!(thread.first_user_message.as_deref(), Some("SQLite preview"));
+        assert_eq!(thread.name.as_deref(), Some("SQLite title"));
+        assert_eq!(thread.model_provider, "sqlite-provider");
+        assert_eq!(thread.model.as_deref(), Some("sqlite-model"));
+        assert_eq!(thread.cwd, external.path().join("workspace"));
+        assert_eq!(thread.cli_version, "sqlite-cli");
+        assert_eq!(thread.source, SessionSource::Exec);
+        assert_eq!(thread.archived_at, None);
+        let git_info = thread.git_info.expect("git info should be applied");
+        assert_eq!(
+            git_info.commit_hash.map(|sha| sha.0),
+            Some("abc123".to_string())
+        );
+        assert_eq!(git_info.branch.as_deref(), Some("sqlite-branch"));
+        assert_eq!(
+            git_info.repository_url.as_deref(),
+            Some("https://example.com/sqlite.git")
+        );
+        assert!(thread.history.is_none());
+    }
+
+    #[tokio::test]
+    async fn read_thread_sqlite_fallback_can_load_history() {
+        let home = TempDir::new().expect("temp dir");
+        let external = TempDir::new().expect("external temp dir");
+        let config = test_config(home.path());
+        let store = LocalThreadStore::new(config.clone());
+        let uuid = Uuid::from_u128(215);
+        let thread_id = ThreadId::from_string(&uuid.to_string()).expect("valid thread id");
+        let rollout_path = write_session_file_with_fork(
+            external.path(),
+            external.path().join("sessions/2025/01/03"),
+            "2025-01-03T12-00-00",
+            uuid,
+            "History user message",
+            Some("external-provider"),
+            /*forked_from_id*/ None,
+        )
+        .expect("external session file");
+        let runtime = codex_state::StateRuntime::init(
+            config.sqlite_home.clone(),
+            config.model_provider_id.clone(),
+        )
+        .await
+        .expect("state db should initialize");
+        let mut builder =
+            ThreadMetadataBuilder::new(thread_id, rollout_path, Utc::now(), SessionSource::Cli);
+        builder.model_provider = Some("sqlite-provider".to_string());
+        builder.cwd = external.path().to_path_buf();
+        let mut metadata = builder.build(config.model_provider_id.as_str());
+        metadata.first_user_message = Some("SQLite preview".to_string());
+        runtime
+            .upsert_thread(&metadata)
+            .await
+            .expect("state db upsert should succeed");
+
+        let thread = store
+            .read_thread(ReadThreadParams {
+                thread_id,
+                include_archived: false,
+                include_history: true,
+            })
+            .await
+            .expect("read thread");
+
+        let history = thread.history.expect("history should load");
+        assert_eq!(history.thread_id, thread_id);
+        assert_eq!(history.items.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn read_thread_sqlite_fallback_respects_include_archived() {
+        let home = TempDir::new().expect("temp dir");
+        let external = TempDir::new().expect("external temp dir");
+        let config = test_config(home.path());
+        let store = LocalThreadStore::new(config.clone());
+        let uuid = Uuid::from_u128(216);
+        let thread_id = ThreadId::from_string(&uuid.to_string()).expect("valid thread id");
+        let rollout_path = external
+            .path()
+            .join(format!("rollout-2025-01-03T12-00-00-{uuid}.jsonl"));
+        let runtime = codex_state::StateRuntime::init(
+            config.sqlite_home.clone(),
+            config.model_provider_id.clone(),
+        )
+        .await
+        .expect("state db should initialize");
+        let mut builder =
+            ThreadMetadataBuilder::new(thread_id, rollout_path, Utc::now(), SessionSource::Cli);
+        builder.archived_at = Some(Utc::now());
+        let mut metadata = builder.build(config.model_provider_id.as_str());
+        metadata.first_user_message = Some("Archived SQLite preview".to_string());
+        runtime
+            .upsert_thread(&metadata)
+            .await
+            .expect("state db upsert should succeed");
+
+        let active_only_err = store
+            .read_thread(ReadThreadParams {
+                thread_id,
+                include_archived: false,
+                include_history: false,
+            })
+            .await
+            .expect_err("active-only read should fail for archived metadata");
+        let ThreadStoreError::InvalidRequest { message } = active_only_err else {
+            panic!("expected invalid request error");
+        };
+        assert_eq!(
+            message,
+            format!("no rollout found for thread id {thread_id}")
+        );
+
+        let thread = store
+            .read_thread(ReadThreadParams {
+                thread_id,
+                include_archived: true,
+                include_history: false,
+            })
+            .await
+            .expect("read archived thread");
+
+        assert_eq!(thread.thread_id, thread_id);
+        assert_eq!(thread.preview, "Archived SQLite preview");
+        assert!(thread.archived_at.is_some());
     }
 
     #[tokio::test]

--- a/codex-rs/thread-store/src/local/test_support.rs
+++ b/codex-rs/thread-store/src/local/test_support.rs
@@ -18,13 +18,14 @@ pub(super) fn test_config(codex_home: &Path) -> RolloutConfig {
 }
 
 pub(super) fn write_session_file(root: &Path, ts: &str, uuid: Uuid) -> std::io::Result<PathBuf> {
-    write_session_file_with(
+    write_session_file_with_fork(
         root,
         root.join("sessions/2025/01/03"),
         ts,
         uuid,
         "Hello from user",
         Some("test-provider"),
+        /*forked_from_id*/ None,
     )
 }
 
@@ -33,13 +34,14 @@ pub(super) fn write_archived_session_file(
     ts: &str,
     uuid: Uuid,
 ) -> std::io::Result<PathBuf> {
-    write_session_file_with(
+    write_session_file_with_fork(
         root,
         root.join(ARCHIVED_SESSIONS_SUBDIR),
         ts,
         uuid,
         "Archived user message",
         Some("test-provider"),
+        /*forked_from_id*/ None,
     )
 }
 
@@ -50,6 +52,26 @@ pub(super) fn write_session_file_with(
     uuid: Uuid,
     first_user_message: &str,
     model_provider: Option<&str>,
+) -> std::io::Result<PathBuf> {
+    write_session_file_with_fork(
+        root,
+        day_dir,
+        ts,
+        uuid,
+        first_user_message,
+        model_provider,
+        /*forked_from_id*/ None,
+    )
+}
+
+pub(super) fn write_session_file_with_fork(
+    root: &Path,
+    day_dir: PathBuf,
+    ts: &str,
+    uuid: Uuid,
+    first_user_message: &str,
+    model_provider: Option<&str>,
+    forked_from_id: Option<Uuid>,
 ) -> std::io::Result<PathBuf> {
     fs::create_dir_all(&day_dir)?;
     let path = day_dir.join(format!("rollout-{ts}-{uuid}.jsonl"));
@@ -65,6 +87,7 @@ pub(super) fn write_session_file_with(
             "cli_version": "test_version",
             "source": "cli",
             "model_provider": model_provider,
+            "forked_from_id": forked_from_id,
             "git": {
                 "commit_hash": "abcdef",
                 "branch": "main",


### PR DESCRIPTION
High level: move app server's thread_read and get_thread_summary to use the ThreadStore interface

Specifically:
- make the implementation of thread reading in the local ThreadStore implementation more complete.
- introduce a "read_thread_view" in App Server that is responsible for merging "live" thread state with "persisted" thread state coming from the ThreadStore. Currently this merge is conceptually present in a number of places in the app server code but not clearly identified or centralized.

Caveats:
- in a couple places where the app server interface explicitly accepts a rollout path continue to operate directly on that path; focus on getting the read-by-thread-id case functional first
- does not yet attempt to migrate other call sites that read threads in app server methods that are about forking/resuming/creating threads -- these require more extensive cleanup to remove path assumptions first

Testing:
- add additional unit test coverage for the thread store local implementation of read_thread