### PR TITLE
Expose environment selection in app-server thread APIs

### DIFF
--- a/codex-rs/app-server-client/src/lib.rs
+++ b/codex-rs/app-server-client/src/lib.rs
@@ -1219,6 +1219,7 @@ mod tests {
                     request_id: RequestId::Integer(2),
                     params: ThreadStartParams {
                         ephemeral: Some(true),
+                        environment_id: None,
                         ..ThreadStartParams::default()
                     },
                 })
@@ -1238,6 +1239,7 @@ mod tests {
                 request_id: RequestId::Integer(3),
                 params: ThreadStartParams {
                     ephemeral: Some(true),
+                    environment_id: None,
                     ..ThreadStartParams::default()
                 },
             })

--- a/codex-rs/app-server-protocol/src/protocol/common.rs
+++ b/codex-rs/app-server-protocol/src/protocol/common.rs
@@ -352,6 +352,14 @@ client_request_definitions! {
         params: v2::AppsListParams,
         response: v2::AppsListResponse,
     },
+    EnvironmentRegister => "environment/register" {
+        params: v2::EnvironmentRegisterParams,
+        response: v2::EnvironmentRegisterResponse,
+    },
+    EnvironmentList => "environment/list" {
+        params: v2::EnvironmentListParams,
+        response: v2::EnvironmentListResponse,
+    },
     FsReadFile => "fs/readFile" {
         params: v2::FsReadFileParams,
         response: v2::FsReadFileResponse,

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -2279,6 +2279,53 @@ pub struct FeedbackUploadResponse {
     pub thread_id: String,
 }
 
+/// Register or replace a named execution environment.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
+pub struct EnvironmentRegisterParams {
+    /// Logical environment identifier used by thread and fs APIs.
+    pub environment_id: String,
+    /// Optional exec-server websocket URL; omit for local execution.
+    #[ts(optional = nullable)]
+    pub exec_server_url: Option<String>,
+}
+
+/// Successful response for `environment/register`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
+pub struct EnvironmentRegisterResponse {}
+
+/// List named execution environments registered with the app-server.
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
+pub struct EnvironmentListParams {
+    #[ts(optional = nullable)]
+    pub cursor: Option<String>,
+    #[ts(optional = nullable)]
+    pub limit: Option<u32>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
+pub struct EnvironmentListEntry {
+    pub environment_id: String,
+    #[ts(optional = nullable)]
+    pub exec_server_url: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
+pub struct EnvironmentListResponse {
+    pub data: Vec<EnvironmentListEntry>,
+    #[ts(optional = nullable)]
+    pub next_cursor: Option<String>,
+}
+
 /// Read a file from the host filesystem.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
@@ -2701,6 +2748,8 @@ pub struct ThreadStartParams {
     pub ephemeral: Option<bool>,
     #[ts(optional = nullable)]
     pub session_start_source: Option<ThreadStartSource>,
+    #[ts(optional = nullable)]
+    pub environment_id: Option<String>,
     #[experimental("thread/start.dynamicTools")]
     #[ts(optional = nullable)]
     pub dynamic_tools: Option<Vec<DynamicToolSpec>>,
@@ -7717,6 +7766,7 @@ mod tests {
                         request_permissions: true,
                         mcp_elicitations: false,
                     }),
+                    environment_id: None,
                     ..Default::default()
                 },
             },
@@ -8688,6 +8738,16 @@ mod tests {
         let serialized_without_override =
             serde_json::to_value(ThreadStartParams::default()).expect("params should serialize");
         assert_eq!(serialized_without_override.get("serviceTier"), None);
+    }
+
+    #[test]
+    fn thread_start_params_round_trip_environment_id() {
+        let params: ThreadStartParams =
+            serde_json::from_value(json!({ "environmentId": "dev" })).expect("deserialize params");
+        assert_eq!(params.environment_id.as_deref(), Some("dev"));
+
+        let serialized = serde_json::to_value(&params).expect("serialize params");
+        assert_eq!(serialized.get("environmentId"), Some(&json!("dev")));
     }
 
     #[test]

--- a/codex-rs/app-server-test-client/src/lib.rs
+++ b/codex-rs/app-server-test-client/src/lib.rs
@@ -720,7 +720,8 @@ async fn trigger_zsh_fork_multi_cmd_approval(
 
             let thread_response = client.thread_start(ThreadStartParams {
                 dynamic_tools: dynamic_tools.clone(),
-                ..Default::default()
+                environment_id: None,
+            ..Default::default()
             })?;
             println!("< thread/start response: {thread_response:?}");
 
@@ -958,6 +959,7 @@ async fn send_message_v2_with_policies(
 
             let thread_response = client.thread_start(ThreadStartParams {
                 dynamic_tools: policies.dynamic_tools.clone(),
+                environment_id: None,
                 ..Default::default()
             })?;
             println!("< thread/start response: {thread_response:?}");
@@ -997,6 +999,7 @@ async fn send_follow_up_v2(
 
         let thread_response = client.thread_start(ThreadStartParams {
             dynamic_tools: dynamic_tools.clone(),
+            environment_id: None,
             ..Default::default()
         })?;
         println!("< thread/start response: {thread_response:?}");
@@ -1238,6 +1241,7 @@ fn live_elicitation_timeout_pause(
 
     let thread_response = client.thread_start(ThreadStartParams {
         model: Some(model),
+        environment_id: None,
         ..Default::default()
     })?;
     println!("< thread/start response: {thread_response:?}");

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -865,6 +865,12 @@ impl CodexMessageProcessor {
             ClientRequest::Initialize { .. } => {
                 panic!("Initialize should be handled in MessageProcessor");
             }
+            ClientRequest::EnvironmentRegister { .. } => {
+                panic!("EnvironmentRegister should be handled in MessageProcessor");
+            }
+            ClientRequest::EnvironmentList { .. } => {
+                panic!("EnvironmentList should be handled in MessageProcessor");
+            }
             // === v2 Thread/Turn APIs ===
             ClientRequest::ThreadStart { request_id, params } => {
                 self.thread_start(
@@ -2274,6 +2280,7 @@ impl CodexMessageProcessor {
             ephemeral,
             session_start_source,
             persist_extended_history,
+            environment_id,
         } = params;
         let mut typesafe_overrides = self.build_thread_config_overrides(
             model,
@@ -2320,6 +2327,7 @@ impl CodexMessageProcessor {
                 service_name,
                 experimental_raw_events,
                 request_trace,
+                environment_id,
             )
             .await;
         };
@@ -2396,6 +2404,7 @@ impl CodexMessageProcessor {
         service_name: Option<String>,
         experimental_raw_events: bool,
         request_trace: Option<W3cTraceContext>,
+        environment_id: Option<String>,
     ) {
         let requested_cwd = typesafe_overrides.cwd.clone();
         let mut config = match derive_config_from_params(
@@ -2543,6 +2552,7 @@ impl CodexMessageProcessor {
                 persist_extended_history,
                 service_name,
                 request_trace,
+                environment_id,
             )
             .instrument(tracing::info_span!(
                 "app_server.thread_start.create_thread",
@@ -6339,7 +6349,12 @@ impl CodexMessageProcessor {
         };
         let skills_manager = self.thread_manager.skills_manager();
         let plugins_manager = self.thread_manager.plugins_manager();
-        let fs = match self.thread_manager.environment_manager().current().await {
+        let fs = match self
+            .thread_manager
+            .environment_manager()
+            .environment(None)
+            .await
+        {
             Ok(Some(environment)) => Some(environment.get_filesystem()),
             Ok(None) => None,
             Err(err) => {

--- a/codex-rs/app-server/src/in_process.rs
+++ b/codex-rs/app-server/src/in_process.rs
@@ -786,6 +786,7 @@ mod tests {
                     request_id: RequestId::Integer(2),
                     params: ThreadStartParams {
                         ephemeral: Some(true),
+                        environment_id: None,
                         ..ThreadStartParams::default()
                     },
                 })

--- a/codex-rs/app-server/src/message_processor.rs
+++ b/codex-rs/app-server/src/message_processor.rs
@@ -36,6 +36,10 @@ use codex_app_server_protocol::ConfigBatchWriteParams;
 use codex_app_server_protocol::ConfigReadParams;
 use codex_app_server_protocol::ConfigValueWriteParams;
 use codex_app_server_protocol::ConfigWarningNotification;
+use codex_app_server_protocol::EnvironmentListParams;
+use codex_app_server_protocol::EnvironmentListResponse;
+use codex_app_server_protocol::EnvironmentRegisterParams;
+use codex_app_server_protocol::EnvironmentRegisterResponse;
 use codex_app_server_protocol::ExperimentalApi;
 use codex_app_server_protocol::ExperimentalFeatureEnablementSetParams;
 use codex_app_server_protocol::ExternalAgentConfigDetectParams;
@@ -64,7 +68,9 @@ use codex_core::ThreadManager;
 use codex_core::config::Config;
 use codex_core::config_loader::CloudRequirementsLoader;
 use codex_core::config_loader::LoaderOverrides;
+use codex_exec_server::EnvironmentConfig;
 use codex_exec_server::EnvironmentManager;
+use codex_exec_server::RegisteredEnvironment;
 use codex_features::Feature;
 use codex_feedback::CodexFeedback;
 use codex_login::AuthManager;
@@ -166,6 +172,7 @@ pub(crate) struct MessageProcessor {
     config_api: ConfigApi,
     external_agent_config_api: ExternalAgentConfigApi,
     fs_api: FsApi,
+    environment_manager: Arc<EnvironmentManager>,
     auth_manager: Arc<AuthManager>,
     analytics_events_client: AnalyticsEventsClient,
     fs_watch_manager: FsWatchManager,
@@ -277,7 +284,7 @@ impl MessageProcessor {
                     .features
                     .enabled(Feature::DefaultModeRequestUserInput),
             },
-            environment_manager,
+            environment_manager.clone(),
             Some(analytics_events_client.clone()),
         ));
         thread_manager
@@ -325,6 +332,7 @@ impl MessageProcessor {
             config_api,
             external_agent_config_api,
             fs_api,
+            environment_manager,
             auth_manager,
             analytics_events_client,
             fs_watch_manager,
@@ -833,6 +841,26 @@ impl MessageProcessor {
                 )
                 .await;
             }
+            ClientRequest::EnvironmentRegister { request_id, params } => {
+                self.handle_environment_register(
+                    ConnectionRequestId {
+                        connection_id,
+                        request_id,
+                    },
+                    params,
+                )
+                .await;
+            }
+            ClientRequest::EnvironmentList { request_id, params } => {
+                self.handle_environment_list(
+                    ConnectionRequestId {
+                        connection_id,
+                        request_id,
+                    },
+                    params,
+                )
+                .await;
+            }
             ClientRequest::ExperimentalFeatureEnablementSet { request_id, params } => {
                 self.handle_experimental_feature_enablement_set(
                     ConnectionRequestId {
@@ -1136,6 +1164,70 @@ impl MessageProcessor {
             Ok(response) => self.outgoing.send_response(request_id, response).await,
             Err(error) => self.outgoing.send_error(request_id, error).await,
         }
+    }
+
+    async fn handle_environment_register(
+        &self,
+        request_id: ConnectionRequestId,
+        params: EnvironmentRegisterParams,
+    ) {
+        match self
+            .environment_manager
+            .register_environment(
+                params.environment_id,
+                EnvironmentConfig {
+                    exec_server_url: params.exec_server_url,
+                },
+            )
+            .await
+        {
+            Ok(()) => {
+                self.outgoing
+                    .send_response(request_id, EnvironmentRegisterResponse {})
+                    .await
+            }
+            Err(err) => {
+                self.outgoing
+                    .send_error(
+                        request_id,
+                        JSONRPCErrorError {
+                            code: INVALID_REQUEST_ERROR_CODE,
+                            message: err.to_string(),
+                            data: None,
+                        },
+                    )
+                    .await
+            }
+        }
+    }
+
+    async fn handle_environment_list(
+        &self,
+        request_id: ConnectionRequestId,
+        params: EnvironmentListParams,
+    ) {
+        let (data, next_cursor) = self
+            .environment_manager
+            .list_environments(params.cursor.as_deref(), params.limit)
+            .await;
+        let response = EnvironmentListResponse {
+            data: data
+                .into_iter()
+                .map(
+                    |RegisteredEnvironment {
+                         environment_id,
+                         config,
+                     }| {
+                        codex_app_server_protocol::EnvironmentListEntry {
+                            environment_id,
+                            exec_server_url: config.exec_server_url,
+                        }
+                    },
+                )
+                .collect(),
+            next_cursor,
+        };
+        self.outgoing.send_response(request_id, response).await;
     }
 
     async fn handle_fs_read_file(&self, request_id: ConnectionRequestId, params: FsReadFileParams) {

--- a/codex-rs/app-server/tests/common/mcp_process.rs
+++ b/codex-rs/app-server/tests/common/mcp_process.rs
@@ -23,6 +23,8 @@ use codex_app_server_protocol::CommandExecWriteParams;
 use codex_app_server_protocol::ConfigBatchWriteParams;
 use codex_app_server_protocol::ConfigReadParams;
 use codex_app_server_protocol::ConfigValueWriteParams;
+use codex_app_server_protocol::EnvironmentListParams;
+use codex_app_server_protocol::EnvironmentRegisterParams;
 use codex_app_server_protocol::ExperimentalFeatureListParams;
 use codex_app_server_protocol::FeedbackUploadParams;
 use codex_app_server_protocol::FsCopyParams;
@@ -603,6 +605,22 @@ impl McpProcess {
     ) -> anyhow::Result<i64> {
         let params = Some(serde_json::to_value(params)?);
         self.send_request("mock/experimentalMethod", params).await
+    }
+
+    pub async fn send_environment_register_request(
+        &mut self,
+        params: EnvironmentRegisterParams,
+    ) -> anyhow::Result<i64> {
+        let params = Some(serde_json::to_value(params)?);
+        self.send_request("environment/register", params).await
+    }
+
+    pub async fn send_environment_list_request(
+        &mut self,
+        params: EnvironmentListParams,
+    ) -> anyhow::Result<i64> {
+        let params = Some(serde_json::to_value(params)?);
+        self.send_request("environment/list", params).await
     }
 
     /// Send a `thread/memoryMode/set` JSON-RPC request (v2, experimental).

--- a/codex-rs/app-server/tests/suite/v2/account.rs
+++ b/codex-rs/app-server/tests/suite/v2/account.rs
@@ -460,6 +460,7 @@ async fn external_auth_refreshes_on_unauthorized() -> Result<()> {
     let thread_req = mcp
         .send_thread_start_request(codex_app_server_protocol::ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -566,6 +567,7 @@ async fn external_auth_refresh_error_fails_turn() -> Result<()> {
     let thread_req = mcp
         .send_thread_start_request(codex_app_server_protocol::ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -688,6 +690,7 @@ async fn external_auth_refresh_mismatched_workspace_fails_turn() -> Result<()> {
     let thread_req = mcp
         .send_thread_start_request(codex_app_server_protocol::ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -803,6 +806,7 @@ async fn external_auth_refresh_invalid_access_token_fails_turn() -> Result<()> {
     let thread_req = mcp
         .send_thread_start_request(codex_app_server_protocol::ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/compaction.rs
+++ b/codex-rs/app-server/tests/suite/v2/compaction.rs
@@ -322,6 +322,7 @@ async fn start_thread(mcp: &mut McpProcess) -> Result<String> {
     let thread_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/connection_handling_websocket.rs
+++ b/codex-rs/app-server/tests/suite/v2/connection_handling_websocket.rs
@@ -608,6 +608,7 @@ async fn start_thread(stream: &mut WsClient, id: i64) -> Result<String> {
         id,
         Some(serde_json::to_value(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })?),
     )

--- a/codex-rs/app-server/tests/suite/v2/connection_handling_websocket_unix.rs
+++ b/codex-rs/app-server/tests/suite/v2/connection_handling_websocket_unix.rs
@@ -185,6 +185,7 @@ async fn send_thread_start_request(stream: &mut WsClient, id: i64) -> Result<()>
         id,
         Some(serde_json::to_value(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })?),
     )

--- a/codex-rs/app-server/tests/suite/v2/dynamic_tools.rs
+++ b/codex-rs/app-server/tests/suite/v2/dynamic_tools.rs
@@ -68,6 +68,7 @@ async fn thread_start_injects_dynamic_tools_into_model_requests() -> Result<()> 
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             dynamic_tools: Some(vec![dynamic_tool.clone()]),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -147,6 +148,7 @@ async fn thread_start_keeps_hidden_dynamic_tools_out_of_model_requests() -> Resu
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             dynamic_tools: Some(vec![dynamic_tool.clone()]),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -233,6 +235,7 @@ async fn dynamic_tool_call_round_trip_sends_text_content_items_to_model() -> Res
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             dynamic_tools: Some(vec![dynamic_tool]),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -402,6 +405,7 @@ async fn dynamic_tool_call_round_trip_sends_content_items_to_model() -> Result<(
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             dynamic_tools: Some(vec![dynamic_tool]),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/experimental_api.rs
+++ b/codex-rs/app-server/tests/suite/v2/experimental_api.rs
@@ -188,6 +188,7 @@ async fn thread_start_mock_field_requires_experimental_api_capability() -> Resul
     let request_id = mcp
         .send_thread_start_request(ThreadStartParams {
             mock_experimental_field: Some("mock".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -225,6 +226,7 @@ async fn thread_start_without_dynamic_tools_allows_without_experimental_api_capa
     let request_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -267,6 +269,7 @@ async fn thread_start_granular_approval_policy_requires_experimental_api_capabil
                 request_permissions: true,
                 mcp_elicitations: false,
             }),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/mcp_resource.rs
+++ b/codex-rs/app-server/tests/suite/v2/mcp_resource.rs
@@ -98,6 +98,7 @@ stream_max_retries = 0
     let thread_start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/mcp_server_elicitation.rs
+++ b/codex-rs/app-server/tests/suite/v2/mcp_server_elicitation.rs
@@ -122,6 +122,7 @@ async fn mcp_server_elicitation_round_trip() -> Result<()> {
     let thread_start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/mcp_tool.rs
+++ b/codex-rs/app-server/tests/suite/v2/mcp_tool.rs
@@ -74,6 +74,7 @@ url = "{mcp_server_url}/mcp"
     let thread_start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/output_schema.rs
+++ b/codex-rs/app-server/tests/suite/v2/output_schema.rs
@@ -37,6 +37,7 @@ async fn turn_start_accepts_output_schema_v2() -> Result<()> {
 
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -119,6 +120,7 @@ async fn turn_start_output_schema_is_per_turn_v2() -> Result<()> {
 
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/plan_item.rs
+++ b/codex-rs/app-server/tests/suite/v2/plan_item.rs
@@ -131,6 +131,7 @@ async fn start_plan_mode_turn(mcp: &mut McpProcess) -> Result<codex_app_server_p
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/request_permissions.rs
+++ b/codex-rs/app-server/tests/suite/v2/request_permissions.rs
@@ -36,6 +36,7 @@ async fn request_permissions_round_trip() -> Result<()> {
     let thread_start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/request_user_input.rs
+++ b/codex-rs/app-server/tests/suite/v2/request_user_input.rs
@@ -38,6 +38,7 @@ async fn request_user_input_round_trip() -> Result<()> {
     let thread_start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/review.rs
+++ b/codex-rs/app-server/tests/suite/v2/review.rs
@@ -409,6 +409,7 @@ async fn start_default_thread(mcp: &mut McpProcess) -> Result<String> {
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/safety_check_downgrade.rs
+++ b/codex-rs/app-server/tests/suite/v2/safety_check_downgrade.rs
@@ -46,6 +46,7 @@ async fn openai_model_header_mismatch_emits_model_rerouted_notification_v2() -> 
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some(REQUESTED_MODEL.to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -119,6 +120,7 @@ async fn response_model_field_mismatch_emits_model_rerouted_notification_v2_when
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some(REQUESTED_MODEL.to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/skills_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/skills_list.rs
@@ -322,6 +322,7 @@ async fn skills_changed_notification_is_emitted_after_skill_change() -> Result<(
             personality: None,
             ephemeral: None,
             session_start_source: None,
+            environment_id: None,
             dynamic_tools: None,
             mock_experimental_field: None,
             experimental_raw_events: false,

--- a/codex-rs/app-server/tests/suite/v2/thread_archive.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_archive.rs
@@ -40,6 +40,7 @@ async fn thread_archive_requires_materialized_rollout() -> Result<()> {
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -172,6 +173,7 @@ async fn thread_archive_clears_stale_subscriptions_before_resume() -> Result<()>
     let start_id = primary
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_fork.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_fork.rs
@@ -239,6 +239,7 @@ async fn thread_fork_rejects_unmaterialized_thread() -> Result<()> {
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_inject_items.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_inject_items.rs
@@ -42,6 +42,7 @@ async fn thread_inject_items_adds_raw_response_items_to_thread_history() -> Resu
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -158,6 +159,7 @@ async fn thread_inject_items_adds_raw_response_items_after_a_turn() -> Result<()
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_list.rs
@@ -209,6 +209,7 @@ async fn thread_list_reports_system_error_idle_flag_after_failed_turn() -> Resul
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_loaded_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_loaded_list.rs
@@ -126,6 +126,7 @@ async fn start_thread(mcp: &mut McpProcess) -> Result<String> {
     let req_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("gpt-5.1".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_memory_mode_set.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_memory_mode_set.rs
@@ -33,6 +33,7 @@ async fn thread_memory_mode_set_updates_loaded_thread_state() -> Result<()> {
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_metadata_update.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_metadata_update.rs
@@ -46,6 +46,7 @@ async fn thread_metadata_update_patches_git_branch_and_returns_updated_thread() 
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -136,6 +137,7 @@ async fn thread_metadata_update_rejects_empty_git_info_patch() -> Result<()> {
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_read.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_read.rs
@@ -216,6 +216,7 @@ async fn thread_read_loaded_thread_returns_precomputed_path_before_materializati
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -420,6 +421,7 @@ async fn thread_read_include_turns_rejects_unmaterialized_loaded_thread() -> Res
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -476,6 +478,7 @@ async fn thread_read_reports_system_error_idle_flag_after_failed_turn() -> Resul
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_resume.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_resume.rs
@@ -122,6 +122,7 @@ async fn thread_resume_rejects_unmaterialized_thread() -> Result<()> {
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("gpt-5.1-codex-max".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -650,6 +651,7 @@ async fn thread_resume_keeps_in_flight_turn_streaming() -> Result<()> {
     let start_id = primary
         .send_thread_start_request(ThreadStartParams {
             model: Some("gpt-5.1-codex-max".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -757,6 +759,7 @@ async fn thread_resume_rejects_history_when_thread_is_running() -> Result<()> {
     let start_id = primary
         .send_thread_start_request(ThreadStartParams {
             model: Some("gpt-5.1-codex-max".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -873,6 +876,7 @@ async fn thread_resume_rejects_mismatched_path_when_thread_is_running() -> Resul
     let start_id = primary
         .send_thread_start_request(ThreadStartParams {
             model: Some("gpt-5.1-codex-max".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -979,6 +983,7 @@ async fn thread_resume_rejoins_running_thread_even_with_override_mismatch() -> R
     let start_id = primary
         .send_thread_start_request(ThreadStartParams {
             model: Some("gpt-5.1-codex-max".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -1092,6 +1097,7 @@ async fn thread_resume_replays_pending_command_execution_request_approval() -> R
     let start_id = primary
         .send_thread_start_request(ThreadStartParams {
             model: Some("gpt-5.1-codex-max".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -1230,6 +1236,7 @@ async fn thread_resume_replays_pending_file_change_request_approval() -> Result<
         .send_thread_start_request(ThreadStartParams {
             model: Some("gpt-5.1-codex-max".to_string()),
             cwd: Some(workspace.to_string_lossy().into_owned()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -1579,6 +1586,7 @@ async fn thread_resume_prefers_path_over_thread_id() -> Result<()> {
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("gpt-5.1-codex-max".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -1699,6 +1707,7 @@ async fn start_materialized_thread_and_restart(
     let start_id = first_mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("gpt-5.1-codex-max".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -1773,6 +1782,7 @@ async fn thread_resume_accepts_personality_override() -> Result<()> {
     let start_id = primary
         .send_thread_start_request(ThreadStartParams {
             model: Some("gpt-5.2-codex".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_rollback.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_rollback.rs
@@ -42,6 +42,7 @@ async fn thread_rollback_drops_last_turns_and_persists_to_rollout() -> Result<()
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_shell_command.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_shell_command.rs
@@ -59,6 +59,7 @@ async fn thread_shell_command_runs_as_standalone_turn_and_persists_history() -> 
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             persist_extended_history: true,
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -192,6 +193,7 @@ async fn thread_shell_command_uses_existing_active_turn() -> Result<()> {
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             persist_extended_history: true,
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_start.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_start.rs
@@ -5,6 +5,10 @@ use app_test_support::create_mock_responses_server_repeating_assistant;
 use app_test_support::to_response;
 use app_test_support::write_chatgpt_auth;
 use codex_app_server_protocol::AskForApproval;
+use codex_app_server_protocol::EnvironmentListEntry;
+use codex_app_server_protocol::EnvironmentListParams;
+use codex_app_server_protocol::EnvironmentListResponse;
+use codex_app_server_protocol::EnvironmentRegisterParams;
 use codex_app_server_protocol::JSONRPCError;
 use codex_app_server_protocol::JSONRPCMessage;
 use codex_app_server_protocol::JSONRPCResponse;
@@ -62,6 +66,7 @@ async fn thread_start_creates_thread_and_emits_started() -> Result<()> {
     let req_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("gpt-5.1".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -180,6 +185,7 @@ async fn thread_start_response_includes_loaded_instruction_sources() -> Result<(
     let request_id = mcp
         .send_thread_start_request(ThreadStartParams {
             cwd: Some(workspace.path().display().to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -327,6 +333,7 @@ model_reasoning_effort = "high"
     let req_id = mcp
         .send_thread_start_request(ThreadStartParams {
             cwd: Some(workspace.path().to_string_lossy().into_owned()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -357,6 +364,7 @@ async fn thread_start_accepts_flex_service_tier() -> Result<()> {
     let req_id = mcp
         .send_thread_start_request(ThreadStartParams {
             service_tier: Some(Some(ServiceTier::Flex)),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -385,6 +393,7 @@ async fn thread_start_accepts_metrics_service_name() -> Result<()> {
     let req_id = mcp
         .send_thread_start_request(ThreadStartParams {
             service_name: Some("my_app_server_client".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -396,6 +405,187 @@ async fn thread_start_accepts_metrics_service_name() -> Result<()> {
     .await??;
     let ThreadStartResponse { thread, .. } = to_response::<ThreadStartResponse>(resp)?;
     assert!(!thread.id.is_empty(), "thread id should not be empty");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn thread_start_accepts_named_local_environment_id() -> Result<()> {
+    let server = create_mock_responses_server_repeating_assistant("Done").await;
+
+    let codex_home = TempDir::new()?;
+    create_config_toml_without_approval_policy(codex_home.path(), &server.uri())?;
+
+    let mut mcp = McpProcess::new(codex_home.path()).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let register_request_id = mcp
+        .send_environment_register_request(EnvironmentRegisterParams {
+            environment_id: "local".to_string(),
+            exec_server_url: None,
+        })
+        .await?;
+    timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(register_request_id)),
+    )
+    .await??;
+
+    let req_id = mcp
+        .send_thread_start_request(ThreadStartParams {
+            environment_id: Some("local".to_string()),
+            ..Default::default()
+        })
+        .await?;
+    let resp: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(req_id)),
+    )
+    .await??;
+    let ThreadStartResponse { thread, .. } = to_response::<ThreadStartResponse>(resp)?;
+    assert!(!thread.id.is_empty(), "thread id should not be empty");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn thread_start_rejects_unknown_environment_id() -> Result<()> {
+    let server = create_mock_responses_server_repeating_assistant("Done").await;
+
+    let codex_home = TempDir::new()?;
+    create_config_toml_without_approval_policy(codex_home.path(), &server.uri())?;
+
+    let mut mcp = McpProcess::new(codex_home.path()).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let req_id = mcp
+        .send_thread_start_request(ThreadStartParams {
+            environment_id: Some("missing".to_string()),
+            ..Default::default()
+        })
+        .await?;
+
+    let err: JSONRPCError = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_error_message(RequestId::Integer(req_id)),
+    )
+    .await??;
+    assert!(
+        err.error
+            .message
+            .contains("unknown environment id: missing"),
+        "unexpected error message: {}",
+        err.error.message
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn thread_start_succeeds_when_default_environment_is_disabled() -> Result<()> {
+    let server = create_mock_responses_server_repeating_assistant("Done").await;
+
+    let codex_home = TempDir::new()?;
+    create_config_toml_without_approval_policy(codex_home.path(), &server.uri())?;
+
+    let mut mcp = McpProcess::new_with_env(
+        codex_home.path(),
+        &[("CODEX_EXEC_SERVER_URL", Some("none"))],
+    )
+    .await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let req_id = mcp
+        .send_thread_start_request(ThreadStartParams::default())
+        .await?;
+    let resp: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(req_id)),
+    )
+    .await??;
+    let ThreadStartResponse { thread, .. } = to_response::<ThreadStartResponse>(resp)?;
+    assert!(!thread.id.is_empty(), "thread id should not be empty");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn environment_list_returns_sorted_paginated_registered_environments() -> Result<()> {
+    let server = create_mock_responses_server_repeating_assistant("Done").await;
+
+    let codex_home = TempDir::new()?;
+    create_config_toml_without_approval_policy(codex_home.path(), &server.uri())?;
+
+    let mut mcp = McpProcess::new(codex_home.path()).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    for (environment_id, exec_server_url) in [
+        ("beta", Some("ws://127.0.0.1:8765".to_string())),
+        ("alpha", None),
+        ("gamma", None),
+    ] {
+        let request_id = mcp
+            .send_environment_register_request(EnvironmentRegisterParams {
+                environment_id: environment_id.to_string(),
+                exec_server_url,
+            })
+            .await?;
+        timeout(
+            DEFAULT_READ_TIMEOUT,
+            mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+        )
+        .await??;
+    }
+
+    let first_page_id = mcp
+        .send_environment_list_request(EnvironmentListParams {
+            cursor: None,
+            limit: Some(2),
+        })
+        .await?;
+    let first_page: EnvironmentListResponse = to_response(
+        timeout(
+            DEFAULT_READ_TIMEOUT,
+            mcp.read_stream_until_response_message(RequestId::Integer(first_page_id)),
+        )
+        .await??,
+    )?;
+    assert_eq!(
+        first_page.data,
+        vec![
+            EnvironmentListEntry {
+                environment_id: "alpha".to_string(),
+                exec_server_url: None,
+            },
+            EnvironmentListEntry {
+                environment_id: "beta".to_string(),
+                exec_server_url: Some("ws://127.0.0.1:8765".to_string()),
+            },
+        ]
+    );
+    assert_eq!(first_page.next_cursor.as_deref(), Some("beta"));
+
+    let second_page_id = mcp
+        .send_environment_list_request(EnvironmentListParams {
+            cursor: first_page.next_cursor,
+            limit: Some(2),
+        })
+        .await?;
+    let second_page: EnvironmentListResponse = to_response(
+        timeout(
+            DEFAULT_READ_TIMEOUT,
+            mcp.read_stream_until_response_message(RequestId::Integer(second_page_id)),
+        )
+        .await??,
+    )?;
+    assert_eq!(
+        second_page.data,
+        vec![EnvironmentListEntry {
+            environment_id: "gamma".to_string(),
+            exec_server_url: None,
+        }]
+    );
+    assert_eq!(second_page.next_cursor, None);
 
     Ok(())
 }
@@ -413,6 +603,7 @@ async fn thread_start_ephemeral_remains_pathless() -> Result<()> {
         .send_thread_start_request(ThreadStartParams {
             model: Some("gpt-5.1".to_string()),
             ephemeral: Some(true),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -686,6 +877,7 @@ model_reasoning_effort = "high"
         .send_thread_start_request(ThreadStartParams {
             cwd: Some(workspace.path().display().to_string()),
             sandbox: Some(SandboxMode::WorkspaceWrite),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -698,6 +890,7 @@ model_reasoning_effort = "high"
     let second_request = mcp
         .send_thread_start_request(ThreadStartParams {
             cwd: Some(workspace.path().display().to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -743,6 +936,7 @@ async fn thread_start_with_nested_git_cwd_trusts_repo_root() -> Result<()> {
         .send_thread_start_request(ThreadStartParams {
             cwd: Some(nested.display().to_string()),
             sandbox: Some(SandboxMode::WorkspaceWrite),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -776,6 +970,7 @@ async fn thread_start_with_read_only_sandbox_does_not_persist_project_trust() ->
     let request_id = mcp
         .send_thread_start_request(ThreadStartParams {
             cwd: Some(workspace.path().display().to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -818,6 +1013,7 @@ model_reasoning_effort = "high"
         .send_thread_start_request(ThreadStartParams {
             cwd: Some(workspace.path().display().to_string()),
             sandbox: Some(SandboxMode::WorkspaceWrite),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_status.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_status.rs
@@ -35,6 +35,7 @@ async fn thread_status_changed_emits_runtime_updates() -> Result<()> {
     let thread_start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -157,6 +158,7 @@ async fn thread_status_changed_can_be_opted_out() -> Result<()> {
     let thread_start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_unarchive.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_unarchive.rs
@@ -41,6 +41,7 @@ async fn thread_unarchive_moves_rollout_back_into_sessions_directory() -> Result
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_unsubscribe.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_unsubscribe.rs
@@ -390,6 +390,7 @@ async fn start_thread(mcp: &mut McpProcess) -> Result<String> {
     let req_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/turn_interrupt.rs
+++ b/codex-rs/app-server/tests/suite/v2/turn_interrupt.rs
@@ -61,6 +61,7 @@ async fn turn_interrupt_aborts_running_turn() -> Result<()> {
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -154,6 +155,7 @@ async fn turn_interrupt_resolves_pending_command_approval_request() -> Result<()
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/turn_start.rs
+++ b/codex-rs/app-server/tests/suite/v2/turn_start.rs
@@ -110,6 +110,7 @@ async fn turn_start_sends_originator_header() -> Result<()> {
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -177,6 +178,7 @@ async fn turn_start_emits_user_message_item_with_text_elements() -> Result<()> {
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -275,6 +277,7 @@ async fn thread_start_omits_empty_instruction_overrides_from_model_request() -> 
             )])),
             base_instructions: Some(String::new()),
             developer_instructions: Some(String::new()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -353,6 +356,7 @@ async fn turn_start_tracks_turn_event_analytics() -> Result<()> {
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -445,6 +449,7 @@ async fn turn_start_does_not_track_turn_event_analytics_without_feature() -> Res
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -510,6 +515,7 @@ async fn turn_start_accepts_text_at_limit_with_mention_item() -> Result<()> {
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -569,6 +575,7 @@ async fn turn_start_rejects_combined_oversized_text_input() -> Result<()> {
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -654,6 +661,7 @@ async fn turn_start_emits_notifications_and_accepts_model_override() -> Result<(
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -788,6 +796,7 @@ async fn turn_start_accepts_collaboration_mode_override_v2() -> Result<()> {
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("gpt-5.2-codex".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -875,6 +884,7 @@ async fn turn_start_uses_thread_feature_overrides_for_collaboration_mode_instruc
                 "features.default_mode_request_user_input".to_string(),
                 json!(true),
             )])),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -955,6 +965,7 @@ async fn turn_start_accepts_personality_override_v2() -> Result<()> {
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("exp-codex-personality".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -1036,6 +1047,7 @@ async fn turn_start_change_personality_mid_thread_v2() -> Result<()> {
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("exp-codex-personality".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -1162,6 +1174,7 @@ async fn turn_start_uses_migrated_pragmatic_personality_without_override_v2() ->
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("gpt-5.2-codex".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -1231,6 +1244,7 @@ async fn turn_start_accepts_local_image_input() -> Result<()> {
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -1317,6 +1331,7 @@ async fn turn_start_exec_approval_toggle_v2() -> Result<()> {
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -1459,6 +1474,7 @@ async fn turn_start_exec_approval_decline_v2() -> Result<()> {
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -1612,6 +1628,7 @@ async fn turn_start_updates_sandbox_and_cwd_between_turns_v2() -> Result<()> {
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -1764,6 +1781,7 @@ async fn turn_start_file_change_approval_v2() -> Result<()> {
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
             cwd: Some(workspace.to_string_lossy().into_owned()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -1982,6 +2000,7 @@ async fn turn_start_emits_spawn_agent_item_with_model_metadata_v2() -> Result<()
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("gpt-5.2-codex".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -2196,6 +2215,7 @@ config_file = "./custom-role.toml"
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("gpt-5.2-codex".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -2340,6 +2360,7 @@ async fn turn_start_file_change_approval_accept_for_session_persists_v2() -> Res
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
             cwd: Some(workspace.to_string_lossy().into_owned()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -2521,6 +2542,7 @@ async fn turn_start_file_change_approval_decline_v2() -> Result<()> {
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
             cwd: Some(workspace.to_string_lossy().into_owned()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -2666,6 +2688,7 @@ async fn command_execution_notifications_include_process_id() -> Result<()> {
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -2799,6 +2822,7 @@ async fn turn_start_with_elevated_override_does_not_persist_project_trust() -> R
     let thread_request = mcp
         .send_thread_start_request(ThreadStartParams {
             cwd: Some(workspace.path().display().to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/turn_start_zsh_fork.rs
+++ b/codex-rs/app-server/tests/suite/v2/turn_start_zsh_fork.rs
@@ -104,6 +104,7 @@ async fn turn_start_shell_zsh_fork_executes_command_v2() -> Result<()> {
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
             cwd: Some(workspace.to_string_lossy().into_owned()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -223,6 +224,7 @@ async fn turn_start_shell_zsh_fork_exec_approval_decline_v2() -> Result<()> {
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
             cwd: Some(workspace.to_string_lossy().into_owned()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -356,6 +358,7 @@ async fn turn_start_shell_zsh_fork_exec_approval_cancel_v2() -> Result<()> {
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
             cwd: Some(workspace.to_string_lossy().into_owned()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -515,6 +518,7 @@ async fn turn_start_shell_zsh_fork_subcommand_decline_marks_parent_declined_v2()
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
             cwd: Some(workspace.to_string_lossy().into_owned()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/turn_steer.rs
+++ b/codex-rs/app-server/tests/suite/v2/turn_steer.rs
@@ -49,6 +49,7 @@ async fn turn_steer_requires_active_turn() -> Result<()> {
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -133,6 +134,7 @@ async fn turn_steer_rejects_oversized_text_input() -> Result<()> {
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -242,6 +244,7 @@ async fn turn_steer_returns_active_turn_id() -> Result<()> {
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/debug-client/src/client.rs
+++ b/codex-rs/debug-client/src/client.rs
@@ -391,6 +391,7 @@ pub fn build_thread_start_params(
         cwd,
         approval_policy: Some(approval_policy),
         experimental_raw_events: false,
+        environment_id: None,
         ..Default::default()
     }
 }

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -915,6 +915,7 @@ fn thread_start_params_from_config(config: &Config) -> ThreadStartParams {
         sandbox: sandbox_mode_from_policy(config.permissions.sandbox_policy.get()),
         config: config_request_overrides_from_config(config),
         ephemeral: Some(config.ephemeral),
+        environment_id: None,
         ..ThreadStartParams::default()
     }
 }

--- a/codex-rs/tui/src/app_server_session.rs
+++ b/codex-rs/tui/src/app_server_session.rs
@@ -910,6 +910,7 @@ fn thread_start_params_from_config(
         ephemeral: Some(config.ephemeral),
         session_start_source,
         persist_extended_history: true,
+        environment_id: None,
         ..ThreadStartParams::default()
     }
 }

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -2043,6 +2043,7 @@ mod tests {
                 request_id: RequestId::Integer(1),
                 params: ThreadStartParams {
                     ephemeral: Some(true),
+                    environment_id: None,
                     ..ThreadStartParams::default()
                 },
             })


### PR DESCRIPTION
## Summary
- add `thread/start.environmentId` to the app-server API
- add `environment/register` and `environment/list` app-server APIs
- plumb thread environment selection through app-server request handling and client/test callsites

## Stack
- base: `starr/env-registry-2-core`
