### PR TITLE
Fix Windows marketplace paths and shell command strings

### DIFF
--- a/codex-rs/app-server/tests/common/lib.rs
+++ b/codex-rs/app-server/tests/common/lib.rs
@@ -37,6 +37,7 @@ pub use responses::create_final_assistant_message_sse_response;
 pub use responses::create_request_permissions_sse_response;
 pub use responses::create_request_user_input_sse_response;
 pub use responses::create_shell_command_sse_response;
+pub use responses::create_shell_command_sse_response_from_command;
 pub use rollout::create_fake_rollout;
 pub use rollout::create_fake_rollout_with_source;
 pub use rollout::create_fake_rollout_with_text_elements;

--- a/codex-rs/app-server/tests/common/responses.rs
+++ b/codex-rs/app-server/tests/common/responses.rs
@@ -10,11 +10,37 @@ pub fn create_shell_command_sse_response(
 ) -> anyhow::Result<String> {
     // The `arguments` for the `shell_command` tool is a serialized JSON object.
     let command_str = shlex::try_join(command.iter().map(String::as_str))?;
-    let tool_call_arguments = serde_json::to_string(&json!({
-        "command": command_str,
+    create_shell_command_sse_response_from_command(
+        &command_str,
+        workdir,
+        timeout_ms,
+        call_id,
+        /*login*/ None,
+    )
+}
+
+pub fn create_shell_command_sse_response_from_command(
+    command: &str,
+    workdir: Option<&Path>,
+    timeout_ms: Option<u64>,
+    call_id: &str,
+    login: Option<bool>,
+) -> anyhow::Result<String> {
+    // Use this when a test already has a shell command string. It fixes string
+    // quoting for those callers by avoiding a rebuild from argv with POSIX
+    // rules, which can change how Windows PowerShell parses the command; for
+    // sleep-based tests, nested parsing can add another PowerShell startup
+    // before the requested sleep even begins.
+    let mut tool_call_arguments = json!({
+        "command": command,
         "workdir": workdir.map(|w| w.to_string_lossy()),
         "timeout_ms": timeout_ms
-    }))?;
+    });
+    if let Some(login) = login {
+        tool_call_arguments["login"] = json!(login);
+    }
+
+    let tool_call_arguments = serde_json::to_string(&tool_call_arguments)?;
     Ok(responses::sse(vec![
         responses::ev_response_created("resp-1"),
         responses::ev_function_call(call_id, "shell_command", &tool_call_arguments),

--- a/codex-rs/core/src/plugins/marketplace_add.rs
+++ b/codex-rs/core/src/plugins/marketplace_add.rs
@@ -276,12 +276,18 @@ mod tests {
 
         let config = fs::read_to_string(codex_home.path().join(codex_config::CONFIG_TOML_FILE))?;
         let config: toml::Value = toml::from_str(&config)?;
+        let marketplace = config
+            .get("marketplaces")
+            .and_then(toml::Value::as_table)
+            .and_then(|marketplaces| marketplaces.get("debug"))
+            .and_then(toml::Value::as_table)
+            .expect("debug marketplace should be present in config");
         assert_eq!(
-            config["marketplaces"]["debug"]["source_type"].as_str(),
+            marketplace.get("source_type").and_then(toml::Value::as_str),
             Some("local")
         );
         assert_eq!(
-            config["marketplaces"]["debug"]["source"].as_str(),
+            marketplace.get("source").and_then(toml::Value::as_str),
             Some(expected_source.as_str())
         );
         Ok(())

--- a/codex-rs/core/src/plugins/marketplace_add/source.rs
+++ b/codex-rs/core/src/plugins/marketplace_add/source.rs
@@ -133,6 +133,16 @@ fn looks_like_local_path(source: &str) -> bool {
         || source.starts_with("~/")
         || source == "."
         || source == ".."
+        || {
+            #[cfg(windows)]
+            {
+                source.starts_with(".\\") || source.starts_with("..\\") || source.starts_with('\\')
+            }
+            #[cfg(not(windows))]
+            {
+                false
+            }
+        }
 }
 
 fn looks_like_windows_absolute_path(source: &str) -> bool {
@@ -320,6 +330,14 @@ mod tests {
             panic!("expected local path source");
         };
         assert!(path.is_absolute());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_backslash_relative_path_looks_local() {
+        assert!(looks_like_local_path(r".\marketplace"));
+        assert!(looks_like_local_path(r"..\marketplace"));
+        assert!(looks_like_local_path(r"\marketplace"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This PR fixes some behaviors causing the Windows tests to be extra flaky.

- treat Windows backslash-relative/rooted marketplace sources as local paths
- keep the local marketplace config test on structured TOML access so Windows backslashes are not interpreted through indexing/string escapes
- add a test helper for shell_command responses that accepts an already-constructed raw command string, preserving Windows PowerShell quoting semantics

## Stack
- Stacked on #18000 / `starr/deterministic-thread-unsubscribe`
- Extracted from the closed broad CI-stabilization PR #17895
- Intentionally excludes the timeout/concurrency/test-sweep changes from #17895

## Validation
- `just fmt`
- `cargo test -p codex-core marketplace_add`
- `cargo test -p codex-cli marketplace_add`
- `cargo test -p codex-app-server suite::v2::thread_unsubscribe::thread_unsubscribe_during_turn_keeps_turn_running -- --exact`
- `git diff --check`

