### PR TITLE
Plumb local and remote environment selection through threads and thread APIs

### DIFF
--- a/codex-rs/app-server-client/src/lib.rs
+++ b/codex-rs/app-server-client/src/lib.rs
@@ -1219,6 +1219,7 @@ mod tests {
                     request_id: RequestId::Integer(2),
                     params: ThreadStartParams {
                         ephemeral: Some(true),
+                        environment_id: None,
                         ..ThreadStartParams::default()
                     },
                 })
@@ -1238,6 +1239,7 @@ mod tests {
                 request_id: RequestId::Integer(3),
                 params: ThreadStartParams {
                     ephemeral: Some(true),
+                    environment_id: None,
                     ..ThreadStartParams::default()
                 },
             })

--- a/codex-rs/app-server-protocol/schema/json/ClientRequest.json
+++ b/codex-rs/app-server-protocol/schema/json/ClientRequest.json
@@ -3280,6 +3280,13 @@
             "null"
           ]
         },
+        "environmentId": {
+          "description": "Optional environment selection. Use `\"local\"` or `\"remote\"`, or omit the field to use the default environment.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "ephemeral": {
           "type": [
             "boolean",

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
@@ -14556,6 +14556,13 @@
               "null"
             ]
           },
+          "environmentId": {
+            "description": "Optional environment selection. Use `\"local\"` or `\"remote\"`, or omit the field to use the default environment.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "ephemeral": {
             "type": [
               "boolean",

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
@@ -12400,6 +12400,13 @@
             "null"
           ]
         },
+        "environmentId": {
+          "description": "Optional environment selection. Use `\"local\"` or `\"remote\"`, or omit the field to use the default environment.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "ephemeral": {
           "type": [
             "boolean",

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadStartParams.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadStartParams.json
@@ -157,6 +157,13 @@
         "null"
       ]
     },
+    "environmentId": {
+      "description": "Optional environment selection. Use `\"local\"` or `\"remote\"`, or omit the field to use the default environment.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "ephemeral": {
       "type": [
         "boolean",

--- a/codex-rs/app-server-protocol/schema/typescript/v2/ThreadStartParams.ts
+++ b/codex-rs/app-server-protocol/schema/typescript/v2/ThreadStartParams.ts
@@ -14,6 +14,10 @@ export type ThreadStartParams = {model?: string | null, modelProvider?: string |
  * and subsequent turns.
  */
 approvalsReviewer?: ApprovalsReviewer | null, sandbox?: SandboxMode | null, config?: { [key in string]?: JsonValue } | null, serviceName?: string | null, baseInstructions?: string | null, developerInstructions?: string | null, personality?: Personality | null, ephemeral?: boolean | null, sessionStartSource?: ThreadStartSource | null, /**
+ * Optional environment selection. Use `"local"` or `"remote"`, or omit
+ * the field to use the default environment.
+ */
+environmentId?: string | null, /**
  * If true, opt into emitting raw Responses API items on the event stream.
  * This is for internal use only (e.g. Codex Cloud).
  */

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -2701,6 +2701,10 @@ pub struct ThreadStartParams {
     pub ephemeral: Option<bool>,
     #[ts(optional = nullable)]
     pub session_start_source: Option<ThreadStartSource>,
+    /// Optional environment selection. Use `"local"` or `"remote"`, or omit
+    /// the field to use the default environment.
+    #[ts(optional = nullable)]
+    pub environment_id: Option<String>,
     #[experimental("thread/start.dynamicTools")]
     #[ts(optional = nullable)]
     pub dynamic_tools: Option<Vec<DynamicToolSpec>>,
@@ -7717,6 +7721,7 @@ mod tests {
                         request_permissions: true,
                         mcp_elicitations: false,
                     }),
+                    environment_id: None,
                     ..Default::default()
                 },
             },
@@ -8688,6 +8693,16 @@ mod tests {
         let serialized_without_override =
             serde_json::to_value(ThreadStartParams::default()).expect("params should serialize");
         assert_eq!(serialized_without_override.get("serviceTier"), None);
+    }
+
+    #[test]
+    fn thread_start_params_round_trip_environment_id() {
+        let params: ThreadStartParams =
+            serde_json::from_value(json!({ "environmentId": "dev" })).expect("deserialize params");
+        assert_eq!(params.environment_id.as_deref(), Some("dev"));
+
+        let serialized = serde_json::to_value(&params).expect("serialize params");
+        assert_eq!(serialized.get("environmentId"), Some(&json!("dev")));
     }
 
     #[test]

--- a/codex-rs/app-server-test-client/src/lib.rs
+++ b/codex-rs/app-server-test-client/src/lib.rs
@@ -720,7 +720,8 @@ async fn trigger_zsh_fork_multi_cmd_approval(
 
             let thread_response = client.thread_start(ThreadStartParams {
                 dynamic_tools: dynamic_tools.clone(),
-                ..Default::default()
+                environment_id: None,
+            ..Default::default()
             })?;
             println!("< thread/start response: {thread_response:?}");
 
@@ -958,6 +959,7 @@ async fn send_message_v2_with_policies(
 
             let thread_response = client.thread_start(ThreadStartParams {
                 dynamic_tools: policies.dynamic_tools.clone(),
+                environment_id: None,
                 ..Default::default()
             })?;
             println!("< thread/start response: {thread_response:?}");
@@ -997,6 +999,7 @@ async fn send_follow_up_v2(
 
         let thread_response = client.thread_start(ThreadStartParams {
             dynamic_tools: dynamic_tools.clone(),
+            environment_id: None,
             ..Default::default()
         })?;
         println!("< thread/start response: {thread_response:?}");
@@ -1238,6 +1241,7 @@ fn live_elicitation_timeout_pause(
 
     let thread_response = client.thread_start(ThreadStartParams {
         model: Some(model),
+        environment_id: None,
         ..Default::default()
     })?;
     println!("< thread/start response: {thread_response:?}");

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -2273,6 +2273,7 @@ impl CodexMessageProcessor {
             ephemeral,
             session_start_source,
             persist_extended_history,
+            environment_id,
         } = params;
         let mut typesafe_overrides = self.build_thread_config_overrides(
             model,
@@ -2319,6 +2320,7 @@ impl CodexMessageProcessor {
                 service_name,
                 experimental_raw_events,
                 request_trace,
+                environment_id,
             )
             .await;
         };
@@ -2395,6 +2397,7 @@ impl CodexMessageProcessor {
         service_name: Option<String>,
         experimental_raw_events: bool,
         request_trace: Option<W3cTraceContext>,
+        environment_id: Option<String>,
     ) {
         let requested_cwd = typesafe_overrides.cwd.clone();
         let mut config = match derive_config_from_params(
@@ -2542,6 +2545,7 @@ impl CodexMessageProcessor {
                 persist_extended_history,
                 service_name,
                 request_trace,
+                environment_id,
             )
             .instrument(tracing::info_span!(
                 "app_server.thread_start.create_thread",
@@ -6109,7 +6113,12 @@ impl CodexMessageProcessor {
         };
         let skills_manager = self.thread_manager.skills_manager();
         let plugins_manager = self.thread_manager.plugins_manager();
-        let fs = match self.thread_manager.environment_manager().current().await {
+        let fs = match self
+            .thread_manager
+            .environment_manager()
+            .environment(/*environment_id*/ None)
+            .await
+        {
             Ok(Some(environment)) => Some(environment.get_filesystem()),
             Ok(None) => None,
             Err(err) => {

--- a/codex-rs/app-server/src/in_process.rs
+++ b/codex-rs/app-server/src/in_process.rs
@@ -786,6 +786,7 @@ mod tests {
                     request_id: RequestId::Integer(2),
                     params: ThreadStartParams {
                         ephemeral: Some(true),
+                        environment_id: None,
                         ..ThreadStartParams::default()
                     },
                 })

--- a/codex-rs/app-server/tests/suite/v2/account.rs
+++ b/codex-rs/app-server/tests/suite/v2/account.rs
@@ -460,6 +460,7 @@ async fn external_auth_refreshes_on_unauthorized() -> Result<()> {
     let thread_req = mcp
         .send_thread_start_request(codex_app_server_protocol::ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -566,6 +567,7 @@ async fn external_auth_refresh_error_fails_turn() -> Result<()> {
     let thread_req = mcp
         .send_thread_start_request(codex_app_server_protocol::ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -688,6 +690,7 @@ async fn external_auth_refresh_mismatched_workspace_fails_turn() -> Result<()> {
     let thread_req = mcp
         .send_thread_start_request(codex_app_server_protocol::ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -803,6 +806,7 @@ async fn external_auth_refresh_invalid_access_token_fails_turn() -> Result<()> {
     let thread_req = mcp
         .send_thread_start_request(codex_app_server_protocol::ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/compaction.rs
+++ b/codex-rs/app-server/tests/suite/v2/compaction.rs
@@ -322,6 +322,7 @@ async fn start_thread(mcp: &mut McpProcess) -> Result<String> {
     let thread_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/connection_handling_websocket.rs
+++ b/codex-rs/app-server/tests/suite/v2/connection_handling_websocket.rs
@@ -608,6 +608,7 @@ async fn start_thread(stream: &mut WsClient, id: i64) -> Result<String> {
         id,
         Some(serde_json::to_value(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })?),
     )

--- a/codex-rs/app-server/tests/suite/v2/connection_handling_websocket_unix.rs
+++ b/codex-rs/app-server/tests/suite/v2/connection_handling_websocket_unix.rs
@@ -185,6 +185,7 @@ async fn send_thread_start_request(stream: &mut WsClient, id: i64) -> Result<()>
         id,
         Some(serde_json::to_value(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })?),
     )

--- a/codex-rs/app-server/tests/suite/v2/dynamic_tools.rs
+++ b/codex-rs/app-server/tests/suite/v2/dynamic_tools.rs
@@ -68,6 +68,7 @@ async fn thread_start_injects_dynamic_tools_into_model_requests() -> Result<()> 
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             dynamic_tools: Some(vec![dynamic_tool.clone()]),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -147,6 +148,7 @@ async fn thread_start_keeps_hidden_dynamic_tools_out_of_model_requests() -> Resu
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             dynamic_tools: Some(vec![dynamic_tool.clone()]),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -233,6 +235,7 @@ async fn dynamic_tool_call_round_trip_sends_text_content_items_to_model() -> Res
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             dynamic_tools: Some(vec![dynamic_tool]),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -402,6 +405,7 @@ async fn dynamic_tool_call_round_trip_sends_content_items_to_model() -> Result<(
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             dynamic_tools: Some(vec![dynamic_tool]),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/experimental_api.rs
+++ b/codex-rs/app-server/tests/suite/v2/experimental_api.rs
@@ -188,6 +188,7 @@ async fn thread_start_mock_field_requires_experimental_api_capability() -> Resul
     let request_id = mcp
         .send_thread_start_request(ThreadStartParams {
             mock_experimental_field: Some("mock".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -225,6 +226,7 @@ async fn thread_start_without_dynamic_tools_allows_without_experimental_api_capa
     let request_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -267,6 +269,7 @@ async fn thread_start_granular_approval_policy_requires_experimental_api_capabil
                 request_permissions: true,
                 mcp_elicitations: false,
             }),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/mcp_resource.rs
+++ b/codex-rs/app-server/tests/suite/v2/mcp_resource.rs
@@ -98,6 +98,7 @@ stream_max_retries = 0
     let thread_start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/mcp_server_elicitation.rs
+++ b/codex-rs/app-server/tests/suite/v2/mcp_server_elicitation.rs
@@ -122,6 +122,7 @@ async fn mcp_server_elicitation_round_trip() -> Result<()> {
     let thread_start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/mcp_tool.rs
+++ b/codex-rs/app-server/tests/suite/v2/mcp_tool.rs
@@ -74,6 +74,7 @@ url = "{mcp_server_url}/mcp"
     let thread_start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/output_schema.rs
+++ b/codex-rs/app-server/tests/suite/v2/output_schema.rs
@@ -37,6 +37,7 @@ async fn turn_start_accepts_output_schema_v2() -> Result<()> {
 
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -119,6 +120,7 @@ async fn turn_start_output_schema_is_per_turn_v2() -> Result<()> {
 
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/plan_item.rs
+++ b/codex-rs/app-server/tests/suite/v2/plan_item.rs
@@ -131,6 +131,7 @@ async fn start_plan_mode_turn(mcp: &mut McpProcess) -> Result<codex_app_server_p
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/request_permissions.rs
+++ b/codex-rs/app-server/tests/suite/v2/request_permissions.rs
@@ -36,6 +36,7 @@ async fn request_permissions_round_trip() -> Result<()> {
     let thread_start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/request_user_input.rs
+++ b/codex-rs/app-server/tests/suite/v2/request_user_input.rs
@@ -38,6 +38,7 @@ async fn request_user_input_round_trip() -> Result<()> {
     let thread_start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/review.rs
+++ b/codex-rs/app-server/tests/suite/v2/review.rs
@@ -409,6 +409,7 @@ async fn start_default_thread(mcp: &mut McpProcess) -> Result<String> {
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/safety_check_downgrade.rs
+++ b/codex-rs/app-server/tests/suite/v2/safety_check_downgrade.rs
@@ -46,6 +46,7 @@ async fn openai_model_header_mismatch_emits_model_rerouted_notification_v2() -> 
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some(REQUESTED_MODEL.to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -119,6 +120,7 @@ async fn response_model_field_mismatch_emits_model_rerouted_notification_v2_when
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some(REQUESTED_MODEL.to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/skills_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/skills_list.rs
@@ -322,6 +322,7 @@ async fn skills_changed_notification_is_emitted_after_skill_change() -> Result<(
             personality: None,
             ephemeral: None,
             session_start_source: None,
+            environment_id: None,
             dynamic_tools: None,
             mock_experimental_field: None,
             experimental_raw_events: false,

--- a/codex-rs/app-server/tests/suite/v2/thread_archive.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_archive.rs
@@ -40,6 +40,7 @@ async fn thread_archive_requires_materialized_rollout() -> Result<()> {
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -172,6 +173,7 @@ async fn thread_archive_clears_stale_subscriptions_before_resume() -> Result<()>
     let start_id = primary
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_fork.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_fork.rs
@@ -239,6 +239,7 @@ async fn thread_fork_rejects_unmaterialized_thread() -> Result<()> {
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_inject_items.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_inject_items.rs
@@ -42,6 +42,7 @@ async fn thread_inject_items_adds_raw_response_items_to_thread_history() -> Resu
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -158,6 +159,7 @@ async fn thread_inject_items_adds_raw_response_items_after_a_turn() -> Result<()
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_list.rs
@@ -209,6 +209,7 @@ async fn thread_list_reports_system_error_idle_flag_after_failed_turn() -> Resul
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_loaded_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_loaded_list.rs
@@ -126,6 +126,7 @@ async fn start_thread(mcp: &mut McpProcess) -> Result<String> {
     let req_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("gpt-5.1".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_memory_mode_set.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_memory_mode_set.rs
@@ -33,6 +33,7 @@ async fn thread_memory_mode_set_updates_loaded_thread_state() -> Result<()> {
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_metadata_update.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_metadata_update.rs
@@ -46,6 +46,7 @@ async fn thread_metadata_update_patches_git_branch_and_returns_updated_thread() 
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -136,6 +137,7 @@ async fn thread_metadata_update_rejects_empty_git_info_patch() -> Result<()> {
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_read.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_read.rs
@@ -216,6 +216,7 @@ async fn thread_read_loaded_thread_returns_precomputed_path_before_materializati
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -420,6 +421,7 @@ async fn thread_read_include_turns_rejects_unmaterialized_loaded_thread() -> Res
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -476,6 +478,7 @@ async fn thread_read_reports_system_error_idle_flag_after_failed_turn() -> Resul
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_resume.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_resume.rs
@@ -122,6 +122,7 @@ async fn thread_resume_rejects_unmaterialized_thread() -> Result<()> {
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("gpt-5.1-codex-max".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -650,6 +651,7 @@ async fn thread_resume_keeps_in_flight_turn_streaming() -> Result<()> {
     let start_id = primary
         .send_thread_start_request(ThreadStartParams {
             model: Some("gpt-5.1-codex-max".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -757,6 +759,7 @@ async fn thread_resume_rejects_history_when_thread_is_running() -> Result<()> {
     let start_id = primary
         .send_thread_start_request(ThreadStartParams {
             model: Some("gpt-5.1-codex-max".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -873,6 +876,7 @@ async fn thread_resume_rejects_mismatched_path_when_thread_is_running() -> Resul
     let start_id = primary
         .send_thread_start_request(ThreadStartParams {
             model: Some("gpt-5.1-codex-max".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -979,6 +983,7 @@ async fn thread_resume_rejoins_running_thread_even_with_override_mismatch() -> R
     let start_id = primary
         .send_thread_start_request(ThreadStartParams {
             model: Some("gpt-5.1-codex-max".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -1092,6 +1097,7 @@ async fn thread_resume_replays_pending_command_execution_request_approval() -> R
     let start_id = primary
         .send_thread_start_request(ThreadStartParams {
             model: Some("gpt-5.1-codex-max".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -1230,6 +1236,7 @@ async fn thread_resume_replays_pending_file_change_request_approval() -> Result<
         .send_thread_start_request(ThreadStartParams {
             model: Some("gpt-5.1-codex-max".to_string()),
             cwd: Some(workspace.to_string_lossy().into_owned()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -1579,6 +1586,7 @@ async fn thread_resume_prefers_path_over_thread_id() -> Result<()> {
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("gpt-5.1-codex-max".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -1699,6 +1707,7 @@ async fn start_materialized_thread_and_restart(
     let start_id = first_mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("gpt-5.1-codex-max".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -1773,6 +1782,7 @@ async fn thread_resume_accepts_personality_override() -> Result<()> {
     let start_id = primary
         .send_thread_start_request(ThreadStartParams {
             model: Some("gpt-5.2-codex".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_rollback.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_rollback.rs
@@ -42,6 +42,7 @@ async fn thread_rollback_drops_last_turns_and_persists_to_rollout() -> Result<()
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_shell_command.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_shell_command.rs
@@ -59,6 +59,7 @@ async fn thread_shell_command_runs_as_standalone_turn_and_persists_history() -> 
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             persist_extended_history: true,
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -192,6 +193,7 @@ async fn thread_shell_command_uses_existing_active_turn() -> Result<()> {
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             persist_extended_history: true,
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_start.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_start.rs
@@ -62,6 +62,7 @@ async fn thread_start_creates_thread_and_emits_started() -> Result<()> {
     let req_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("gpt-5.1".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -180,6 +181,7 @@ async fn thread_start_response_includes_loaded_instruction_sources() -> Result<(
     let request_id = mcp
         .send_thread_start_request(ThreadStartParams {
             cwd: Some(workspace.path().display().to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -327,6 +329,7 @@ model_reasoning_effort = "high"
     let req_id = mcp
         .send_thread_start_request(ThreadStartParams {
             cwd: Some(workspace.path().to_string_lossy().into_owned()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -357,6 +360,7 @@ async fn thread_start_accepts_flex_service_tier() -> Result<()> {
     let req_id = mcp
         .send_thread_start_request(ThreadStartParams {
             service_tier: Some(Some(ServiceTier::Flex)),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -385,6 +389,7 @@ async fn thread_start_accepts_metrics_service_name() -> Result<()> {
     let req_id = mcp
         .send_thread_start_request(ThreadStartParams {
             service_name: Some("my_app_server_client".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -401,6 +406,97 @@ async fn thread_start_accepts_metrics_service_name() -> Result<()> {
 }
 
 #[tokio::test]
+async fn thread_start_accepts_named_local_environment_id() -> Result<()> {
+    let server = create_mock_responses_server_repeating_assistant("Done").await;
+
+    let codex_home = TempDir::new()?;
+    create_config_toml_without_approval_policy(codex_home.path(), &server.uri())?;
+
+    let mut mcp = McpProcess::new_with_env(
+        codex_home.path(),
+        &[("CODEX_EXEC_SERVER_URL", Some("none"))],
+    )
+    .await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let req_id = mcp
+        .send_thread_start_request(ThreadStartParams {
+            environment_id: Some("local".to_string()),
+            ..Default::default()
+        })
+        .await?;
+    let resp: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(req_id)),
+    )
+    .await??;
+    let ThreadStartResponse { thread, .. } = to_response::<ThreadStartResponse>(resp)?;
+    assert!(!thread.id.is_empty(), "thread id should not be empty");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn thread_start_rejects_unknown_environment_id() -> Result<()> {
+    let server = create_mock_responses_server_repeating_assistant("Done").await;
+
+    let codex_home = TempDir::new()?;
+    create_config_toml_without_approval_policy(codex_home.path(), &server.uri())?;
+
+    let mut mcp = McpProcess::new(codex_home.path()).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let req_id = mcp
+        .send_thread_start_request(ThreadStartParams {
+            environment_id: Some("missing".to_string()),
+            ..Default::default()
+        })
+        .await?;
+
+    let err: JSONRPCError = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_error_message(RequestId::Integer(req_id)),
+    )
+    .await??;
+    assert!(
+        err.error
+            .message
+            .contains("unknown environment id: missing"),
+        "unexpected error message: {}",
+        err.error.message
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn thread_start_succeeds_when_default_environment_is_disabled() -> Result<()> {
+    let server = create_mock_responses_server_repeating_assistant("Done").await;
+
+    let codex_home = TempDir::new()?;
+    create_config_toml_without_approval_policy(codex_home.path(), &server.uri())?;
+
+    let mut mcp = McpProcess::new_with_env(
+        codex_home.path(),
+        &[("CODEX_EXEC_SERVER_URL", Some("none"))],
+    )
+    .await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let req_id = mcp
+        .send_thread_start_request(ThreadStartParams::default())
+        .await?;
+    let resp: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(req_id)),
+    )
+    .await??;
+    let ThreadStartResponse { thread, .. } = to_response::<ThreadStartResponse>(resp)?;
+    assert!(!thread.id.is_empty(), "thread id should not be empty");
+
+    Ok(())
+}
+#[tokio::test]
 async fn thread_start_ephemeral_remains_pathless() -> Result<()> {
     let server = create_mock_responses_server_repeating_assistant("Done").await;
     let codex_home = TempDir::new()?;
@@ -413,6 +509,7 @@ async fn thread_start_ephemeral_remains_pathless() -> Result<()> {
         .send_thread_start_request(ThreadStartParams {
             model: Some("gpt-5.1".to_string()),
             ephemeral: Some(true),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -686,6 +783,7 @@ model_reasoning_effort = "high"
         .send_thread_start_request(ThreadStartParams {
             cwd: Some(workspace.path().display().to_string()),
             sandbox: Some(SandboxMode::WorkspaceWrite),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -698,6 +796,7 @@ model_reasoning_effort = "high"
     let second_request = mcp
         .send_thread_start_request(ThreadStartParams {
             cwd: Some(workspace.path().display().to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -743,6 +842,7 @@ async fn thread_start_with_nested_git_cwd_trusts_repo_root() -> Result<()> {
         .send_thread_start_request(ThreadStartParams {
             cwd: Some(nested.display().to_string()),
             sandbox: Some(SandboxMode::WorkspaceWrite),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -776,6 +876,7 @@ async fn thread_start_with_read_only_sandbox_does_not_persist_project_trust() ->
     let request_id = mcp
         .send_thread_start_request(ThreadStartParams {
             cwd: Some(workspace.path().display().to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -818,6 +919,7 @@ model_reasoning_effort = "high"
         .send_thread_start_request(ThreadStartParams {
             cwd: Some(workspace.path().display().to_string()),
             sandbox: Some(SandboxMode::WorkspaceWrite),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_status.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_status.rs
@@ -35,6 +35,7 @@ async fn thread_status_changed_emits_runtime_updates() -> Result<()> {
     let thread_start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -157,6 +158,7 @@ async fn thread_status_changed_can_be_opted_out() -> Result<()> {
     let thread_start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_unarchive.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_unarchive.rs
@@ -41,6 +41,7 @@ async fn thread_unarchive_moves_rollout_back_into_sessions_directory() -> Result
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_unsubscribe.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_unsubscribe.rs
@@ -390,6 +390,7 @@ async fn start_thread(mcp: &mut McpProcess) -> Result<String> {
     let req_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/turn_interrupt.rs
+++ b/codex-rs/app-server/tests/suite/v2/turn_interrupt.rs
@@ -61,6 +61,7 @@ async fn turn_interrupt_aborts_running_turn() -> Result<()> {
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -161,6 +162,7 @@ async fn turn_interrupt_resolves_pending_command_approval_request() -> Result<()
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/turn_start.rs
+++ b/codex-rs/app-server/tests/suite/v2/turn_start.rs
@@ -110,6 +110,7 @@ async fn turn_start_sends_originator_header() -> Result<()> {
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -177,6 +178,7 @@ async fn turn_start_emits_user_message_item_with_text_elements() -> Result<()> {
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -275,6 +277,7 @@ async fn thread_start_omits_empty_instruction_overrides_from_model_request() -> 
             )])),
             base_instructions: Some(String::new()),
             developer_instructions: Some(String::new()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -353,6 +356,7 @@ async fn turn_start_tracks_turn_event_analytics() -> Result<()> {
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -445,6 +449,7 @@ async fn turn_start_does_not_track_turn_event_analytics_without_feature() -> Res
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -510,6 +515,7 @@ async fn turn_start_accepts_text_at_limit_with_mention_item() -> Result<()> {
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -569,6 +575,7 @@ async fn turn_start_rejects_combined_oversized_text_input() -> Result<()> {
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -654,6 +661,7 @@ async fn turn_start_emits_notifications_and_accepts_model_override() -> Result<(
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -788,6 +796,7 @@ async fn turn_start_accepts_collaboration_mode_override_v2() -> Result<()> {
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("gpt-5.2-codex".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -875,6 +884,7 @@ async fn turn_start_uses_thread_feature_overrides_for_collaboration_mode_instruc
                 "features.default_mode_request_user_input".to_string(),
                 json!(true),
             )])),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -955,6 +965,7 @@ async fn turn_start_accepts_personality_override_v2() -> Result<()> {
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("exp-codex-personality".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -1036,6 +1047,7 @@ async fn turn_start_change_personality_mid_thread_v2() -> Result<()> {
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("exp-codex-personality".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -1162,6 +1174,7 @@ async fn turn_start_uses_migrated_pragmatic_personality_without_override_v2() ->
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("gpt-5.2-codex".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -1231,6 +1244,7 @@ async fn turn_start_accepts_local_image_input() -> Result<()> {
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -1317,6 +1331,7 @@ async fn turn_start_exec_approval_toggle_v2() -> Result<()> {
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -1459,6 +1474,7 @@ async fn turn_start_exec_approval_decline_v2() -> Result<()> {
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -1612,6 +1628,7 @@ async fn turn_start_updates_sandbox_and_cwd_between_turns_v2() -> Result<()> {
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -1764,6 +1781,7 @@ async fn turn_start_file_change_approval_v2() -> Result<()> {
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
             cwd: Some(workspace.to_string_lossy().into_owned()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -1982,6 +2000,7 @@ async fn turn_start_emits_spawn_agent_item_with_model_metadata_v2() -> Result<()
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("gpt-5.2-codex".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -2196,6 +2215,7 @@ config_file = "./custom-role.toml"
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("gpt-5.2-codex".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -2340,6 +2360,7 @@ async fn turn_start_file_change_approval_accept_for_session_persists_v2() -> Res
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
             cwd: Some(workspace.to_string_lossy().into_owned()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -2521,6 +2542,7 @@ async fn turn_start_file_change_approval_decline_v2() -> Result<()> {
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
             cwd: Some(workspace.to_string_lossy().into_owned()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -2666,6 +2688,7 @@ async fn command_execution_notifications_include_process_id() -> Result<()> {
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -2799,6 +2822,7 @@ async fn turn_start_with_elevated_override_does_not_persist_project_trust() -> R
     let thread_request = mcp
         .send_thread_start_request(ThreadStartParams {
             cwd: Some(workspace.path().display().to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/turn_start_zsh_fork.rs
+++ b/codex-rs/app-server/tests/suite/v2/turn_start_zsh_fork.rs
@@ -104,6 +104,7 @@ async fn turn_start_shell_zsh_fork_executes_command_v2() -> Result<()> {
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
             cwd: Some(workspace.to_string_lossy().into_owned()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -223,6 +224,7 @@ async fn turn_start_shell_zsh_fork_exec_approval_decline_v2() -> Result<()> {
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
             cwd: Some(workspace.to_string_lossy().into_owned()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -356,6 +358,7 @@ async fn turn_start_shell_zsh_fork_exec_approval_cancel_v2() -> Result<()> {
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
             cwd: Some(workspace.to_string_lossy().into_owned()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -515,6 +518,7 @@ async fn turn_start_shell_zsh_fork_subcommand_decline_marks_parent_declined_v2()
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
             cwd: Some(workspace.to_string_lossy().into_owned()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/turn_steer.rs
+++ b/codex-rs/app-server/tests/suite/v2/turn_steer.rs
@@ -49,6 +49,7 @@ async fn turn_steer_requires_active_turn() -> Result<()> {
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -133,6 +134,7 @@ async fn turn_steer_rejects_oversized_text_input() -> Result<()> {
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;
@@ -242,6 +244,7 @@ async fn turn_steer_returns_active_turn_id() -> Result<()> {
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("mock-model".to_string()),
+            environment_id: None,
             ..Default::default()
         })
         .await?;

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -428,6 +428,7 @@ pub(crate) struct CodexSpawnArgs {
     pub(crate) auth_manager: Arc<AuthManager>,
     pub(crate) models_manager: Arc<ModelsManager>,
     pub(crate) environment_manager: Arc<EnvironmentManager>,
+    pub(crate) environment_id: Option<String>,
     pub(crate) skills_manager: Arc<SkillsManager>,
     pub(crate) plugins_manager: Arc<PluginsManager>,
     pub(crate) mcp_manager: Arc<McpManager>,
@@ -481,6 +482,7 @@ impl Codex {
             auth_manager,
             models_manager,
             environment_manager,
+            environment_id,
             skills_manager,
             plugins_manager,
             mcp_manager,
@@ -501,7 +503,7 @@ impl Codex {
         let (tx_event, rx_event) = async_channel::unbounded();
 
         let environment = environment_manager
-            .current()
+            .environment(environment_id.as_deref())
             .await
             .map_err(|err| CodexErr::Fatal(format!("failed to create environment: {err}")))?;
         let fs = environment

--- a/codex-rs/core/src/codex_delegate.rs
+++ b/codex-rs/core/src/codex_delegate.rs
@@ -82,6 +82,7 @@ pub(crate) async fn run_codex_thread_interactive(
         environment_manager: Arc::new(EnvironmentManager::from_environment(
             parent_ctx.environment.as_deref(),
         )),
+        environment_id: None,
         skills_manager: Arc::clone(&parent_session.services.skills_manager),
         plugins_manager: Arc::clone(&parent_session.services.plugins_manager),
         mcp_manager: Arc::clone(&parent_session.services.mcp_manager),

--- a/codex-rs/core/src/codex_tests_guardian.rs
+++ b/codex-rs/core/src/codex_tests_guardian.rs
@@ -435,6 +435,7 @@ async fn guardian_subagent_does_not_inherit_parent_exec_policy_rules() {
         auth_manager,
         models_manager,
         environment_manager: Arc::new(EnvironmentManager::new(/*exec_server_url*/ None)),
+        environment_id: None,
         skills_manager,
         plugins_manager,
         mcp_manager,

--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -471,6 +471,7 @@ impl ThreadManager {
             config,
             Vec::new(),
             /*persist_extended_history*/ false,
+            /*environment_id*/ None,
         ))
         .await
     }
@@ -480,6 +481,7 @@ impl ThreadManager {
         config: Config,
         dynamic_tools: Vec<codex_protocol::dynamic_tools::DynamicToolSpec>,
         persist_extended_history: bool,
+        environment_id: Option<String>,
     ) -> CodexResult<NewThread> {
         Box::pin(self.start_thread_with_tools_and_service_name(
             config,
@@ -488,6 +490,7 @@ impl ThreadManager {
             persist_extended_history,
             /*metrics_service_name*/ None,
             /*parent_trace*/ None,
+            environment_id,
         ))
         .await
     }
@@ -500,6 +503,7 @@ impl ThreadManager {
         persist_extended_history: bool,
         metrics_service_name: Option<String>,
         parent_trace: Option<W3cTraceContext>,
+        environment_id: Option<String>,
     ) -> CodexResult<NewThread> {
         Box::pin(self.state.spawn_thread(
             config,
@@ -511,6 +515,7 @@ impl ThreadManager {
             metrics_service_name,
             parent_trace,
             /*user_shell_override*/ None,
+            environment_id,
         ))
         .await
     }
@@ -551,6 +556,7 @@ impl ThreadManager {
             /*metrics_service_name*/ None,
             parent_trace,
             /*user_shell_override*/ None,
+            /*environment_id*/ None,
         ))
         .await
     }
@@ -570,6 +576,7 @@ impl ThreadManager {
             /*metrics_service_name*/ None,
             /*parent_trace*/ None,
             /*user_shell_override*/ Some(user_shell_override),
+            /*environment_id*/ None,
         ))
         .await
     }
@@ -592,6 +599,7 @@ impl ThreadManager {
             /*metrics_service_name*/ None,
             /*parent_trace*/ None,
             /*user_shell_override*/ Some(user_shell_override),
+            /*environment_id*/ None,
         ))
         .await
     }
@@ -700,6 +708,7 @@ impl ThreadManager {
             /*metrics_service_name*/ None,
             parent_trace,
             /*user_shell_override*/ None,
+            /*environment_id*/ None,
         ))
         .await
     }
@@ -801,6 +810,7 @@ impl ThreadManagerState {
             inherited_exec_policy,
             /*parent_trace*/ None,
             /*user_shell_override*/ None,
+            /*environment_id*/ None,
         ))
         .await
     }
@@ -828,6 +838,7 @@ impl ThreadManagerState {
             inherited_exec_policy,
             /*parent_trace*/ None,
             /*user_shell_override*/ None,
+            /*environment_id*/ None,
         ))
         .await
     }
@@ -856,6 +867,7 @@ impl ThreadManagerState {
             inherited_exec_policy,
             /*parent_trace*/ None,
             /*user_shell_override*/ None,
+            /*environment_id*/ None,
         ))
         .await
     }
@@ -873,6 +885,7 @@ impl ThreadManagerState {
         metrics_service_name: Option<String>,
         parent_trace: Option<W3cTraceContext>,
         user_shell_override: Option<crate::shell::Shell>,
+        environment_id: Option<String>,
     ) -> CodexResult<NewThread> {
         Box::pin(self.spawn_thread_with_source(
             config,
@@ -887,6 +900,7 @@ impl ThreadManagerState {
             /*inherited_exec_policy*/ None,
             parent_trace,
             user_shell_override,
+            environment_id,
         ))
         .await
     }
@@ -906,10 +920,11 @@ impl ThreadManagerState {
         inherited_exec_policy: Option<Arc<crate::exec_policy::ExecPolicyManager>>,
         parent_trace: Option<W3cTraceContext>,
         user_shell_override: Option<crate::shell::Shell>,
+        environment_id: Option<String>,
     ) -> CodexResult<NewThread> {
         let environment = self
             .environment_manager
-            .current()
+            .environment(environment_id.as_deref())
             .await
             .map_err(|err| CodexErr::Fatal(format!("failed to create environment: {err}")))?;
         let watch_registration = match environment.as_ref() {
@@ -932,6 +947,7 @@ impl ThreadManagerState {
             auth_manager,
             models_manager: Arc::clone(&self.models_manager),
             environment_manager: Arc::clone(&self.environment_manager),
+            environment_id,
             skills_manager: Arc::clone(&self.skills_manager),
             plugins_manager: Arc::clone(&self.plugins_manager),
             mcp_manager: Arc::clone(&self.mcp_manager),

--- a/codex-rs/core/tests/common/test_codex.rs
+++ b/codex-rs/core/tests/common/test_codex.rs
@@ -202,6 +202,8 @@ pub struct TestCodexBuilder {
     workspace_setups: Vec<Box<WorkspaceSetup>>,
     home: Option<Arc<TempDir>>,
     user_shell_override: Option<Shell>,
+    environment_manager_override: Option<Arc<codex_exec_server::EnvironmentManager>>,
+    thread_environment_id: Option<String>,
 }
 
 impl TestCodexBuilder {
@@ -250,6 +252,19 @@ impl TestCodexBuilder {
 
     pub fn with_user_shell(mut self, user_shell: Shell) -> Self {
         self.user_shell_override = Some(user_shell);
+        self
+    }
+
+    pub fn with_environment_manager(
+        mut self,
+        environment_manager: Arc<codex_exec_server::EnvironmentManager>,
+    ) -> Self {
+        self.environment_manager_override = Some(environment_manager);
+        self
+    }
+
+    pub fn with_thread_environment_id(mut self, environment_id: impl Into<String>) -> Self {
+        self.thread_environment_id = Some(environment_id.into());
         self
     }
 
@@ -348,9 +363,17 @@ impl TestCodexBuilder {
         let (config, fallback_cwd) = self
             .prepare_config(base_url, &home, test_env.cwd().clone())
             .await?;
-        let environment_manager = Arc::new(codex_exec_server::EnvironmentManager::new(
-            test_env.exec_server_url().map(str::to_owned),
-        ));
+        let environment_manager = self
+            .environment_manager_override
+            .clone()
+            .unwrap_or_else(|| {
+                Arc::new(codex_exec_server::EnvironmentManager::new(
+                    test_env.exec_server_url().map(str::to_owned),
+                ))
+            });
+        let selected_environment = environment_manager
+            .environment(self.thread_environment_id.as_deref())
+            .await?;
         let file_system = test_env.environment().get_filesystem();
         let mut workspace_setups = vec![];
         swap(&mut self.workspace_setups, &mut workspace_setups);
@@ -365,6 +388,7 @@ impl TestCodexBuilder {
             resume_from,
             test_env,
             environment_manager,
+            selected_environment,
         ))
         .await
     }
@@ -377,6 +401,7 @@ impl TestCodexBuilder {
         resume_from: Option<PathBuf>,
         test_env: TestEnv,
         environment_manager: Arc<codex_exec_server::EnvironmentManager>,
+        selected_environment: Option<Arc<codex_exec_server::Environment>>,
     ) -> anyhow::Result<TestCodex> {
         let auth = self.auth.clone();
         let thread_manager = if config.model_catalog.is_some() {
@@ -398,8 +423,15 @@ impl TestCodexBuilder {
         };
         let thread_manager = Arc::new(thread_manager);
         let user_shell_override = self.user_shell_override.clone();
+        let thread_environment_id = self.thread_environment_id.clone();
 
         let new_conversation = match (resume_from, user_shell_override) {
+            (Some(_), _) if thread_environment_id.is_some() => {
+                anyhow::bail!("test harness does not support resuming with thread_environment_id")
+            }
+            (_, Some(_)) if thread_environment_id.is_some() => anyhow::bail!(
+                "test harness does not support user_shell_override with thread_environment_id"
+            ),
             (Some(path), Some(user_shell_override)) => {
                 let auth_manager = codex_core::test_support::auth_manager_from_auth(auth);
                 Box::pin(
@@ -433,7 +465,15 @@ impl TestCodexBuilder {
                 )
                 .await?
             }
-            (None, None) => Box::pin(thread_manager.start_thread(config.clone())).await?,
+            (None, None) => {
+                Box::pin(thread_manager.start_thread_with_tools(
+                    config.clone(),
+                    Vec::new(),
+                    /*persist_extended_history*/ false,
+                    thread_environment_id,
+                ))
+                .await?
+            }
         };
 
         Ok(TestCodex {
@@ -443,6 +483,7 @@ impl TestCodexBuilder {
             codex: new_conversation.thread,
             session_configured: new_conversation.session_configured,
             thread_manager,
+            selected_environment,
             _test_env: test_env,
         })
     }
@@ -533,6 +574,7 @@ pub struct TestCodex {
     pub session_configured: SessionConfiguredEvent,
     pub config: Config,
     pub thread_manager: Arc<ThreadManager>,
+    selected_environment: Option<Arc<codex_exec_server::Environment>>,
     _test_env: TestEnv,
 }
 
@@ -551,6 +593,10 @@ impl TestCodex {
 
     pub fn executor_environment(&self) -> &TestEnv {
         &self._test_env
+    }
+
+    pub fn selected_environment(&self) -> Option<&codex_exec_server::Environment> {
+        self.selected_environment.as_deref()
     }
 
     pub fn fs(&self) -> Arc<dyn ExecutorFileSystem> {
@@ -879,6 +925,8 @@ pub fn test_codex() -> TestCodexBuilder {
         workspace_setups: vec![],
         home: None,
         user_shell_override: None,
+        environment_manager_override: None,
+        thread_environment_id: None,
     }
 }
 

--- a/codex-rs/core/tests/suite/code_mode.rs
+++ b/codex-rs/core/tests/suite/code_mode.rs
@@ -2438,6 +2438,7 @@ async fn code_mode_can_call_hidden_dynamic_tools() -> Result<()> {
                 defer_loading: true,
             }],
             /*persist_extended_history*/ false,
+            /*environment_id*/ None,
         )
         .await?;
     let mut test = base_test;

--- a/codex-rs/core/tests/suite/remote_env.rs
+++ b/codex-rs/core/tests/suite/remote_env.rs
@@ -2,6 +2,8 @@ use anyhow::Context;
 use anyhow::Result;
 use codex_exec_server::CopyOptions;
 use codex_exec_server::CreateDirectoryOptions;
+use codex_exec_server::Environment;
+use codex_exec_server::EnvironmentManager;
 use codex_exec_server::FileSystemSandboxContext;
 use codex_exec_server::RemoveOptions;
 use codex_protocol::protocol::ReadOnlyAccess;
@@ -9,13 +11,132 @@ use codex_protocol::protocol::SandboxPolicy;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use core_test_support::PathBufExt;
 use core_test_support::get_remote_test_env;
+use core_test_support::responses::ev_assistant_message;
+use core_test_support::responses::ev_completed;
+use core_test_support::responses::ev_response_created;
+use core_test_support::responses::mount_sse_once;
+use core_test_support::responses::sse;
+use core_test_support::responses::start_mock_server;
 use core_test_support::skip_if_no_network;
+use core_test_support::test_codex::test_codex;
 use core_test_support::test_codex::test_env;
 use pretty_assertions::assert_eq;
 use std::path::PathBuf;
 use std::process::Command;
+use std::sync::Arc;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
+
+const REMOTE_EXEC_SERVER_URL_ENV_VAR: &str = "CODEX_TEST_REMOTE_EXEC_SERVER_URL";
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn thread_can_start_and_complete_turn_with_disabled_default_environment() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let _mock = mount_sse_once(
+        &server,
+        sse(vec![
+            ev_response_created("resp-disabled"),
+            ev_assistant_message("msg-disabled", "done"),
+            ev_completed("resp-disabled"),
+        ]),
+    )
+    .await;
+
+    let environment_manager = Arc::new(EnvironmentManager::new(Some("none".to_string())));
+    let mut builder = test_codex().with_environment_manager(environment_manager);
+    let test = builder.build(&server).await?;
+    assert!(test.selected_environment().is_none());
+
+    test.submit_turn("hello from disabled env").await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn thread_can_start_and_complete_turn_with_named_local_environment() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let _mock = mount_sse_once(
+        &server,
+        sse(vec![
+            ev_response_created("resp-local"),
+            ev_assistant_message("msg-local", "done"),
+            ev_completed("resp-local"),
+        ]),
+    )
+    .await;
+
+    let environment_manager = Arc::new(EnvironmentManager::new(Some("none".to_string())));
+
+    let mut builder = test_codex()
+        .with_environment_manager(environment_manager)
+        .with_thread_environment_id("local");
+    let test = builder.build(&server).await?;
+    let selected_environment = test
+        .selected_environment()
+        .context("named local environment should resolve")?;
+    assert!(!selected_environment.is_remote());
+    assert_environment_file_round_trip(
+        &selected_environment,
+        local_test_file_path(),
+        b"named-local-environment",
+    )
+    .await?;
+
+    test.submit_turn("hello from named local env").await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn thread_can_start_and_complete_turn_with_named_remote_environment() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+    let Some(_remote_env) = get_remote_test_env() else {
+        return Ok(());
+    };
+
+    let remote_exec_server_url =
+        std::env::var(REMOTE_EXEC_SERVER_URL_ENV_VAR).with_context(|| {
+            format!(
+                "{REMOTE_EXEC_SERVER_URL_ENV_VAR} must be set for named remote environment tests"
+            )
+        })?;
+
+    let server = start_mock_server().await;
+    let _mock = mount_sse_once(
+        &server,
+        sse(vec![
+            ev_response_created("resp-remote"),
+            ev_assistant_message("msg-remote", "done"),
+            ev_completed("resp-remote"),
+        ]),
+    )
+    .await;
+
+    let environment_manager = Arc::new(EnvironmentManager::new(Some(remote_exec_server_url)));
+
+    let mut builder = test_codex()
+        .with_environment_manager(environment_manager)
+        .with_thread_environment_id("remote");
+    let test = builder.build_remote_aware(&server).await?;
+    let selected_environment = test
+        .selected_environment()
+        .context("named remote environment should resolve")?;
+    assert!(selected_environment.is_remote());
+    assert_environment_file_round_trip(
+        &selected_environment,
+        remote_test_file_path(),
+        b"named-remote-environment",
+    )
+    .await?;
+
+    test.submit_turn("hello from named remote env").await?;
+
+    Ok(())
+}
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn remote_test_env_can_connect_and_use_filesystem() -> Result<()> {
@@ -56,6 +177,36 @@ fn absolute_path(path: PathBuf) -> AbsolutePathBuf {
         Ok(path) => path,
         Err(error) => panic!("path should be absolute: {error}"),
     }
+}
+
+async fn assert_environment_file_round_trip(
+    environment: &Environment,
+    file_path: PathBuf,
+    payload: &[u8],
+) -> Result<()> {
+    let file_system = environment.get_filesystem();
+    file_system
+        .write_file(
+            &absolute_path(file_path.clone()),
+            payload.to_vec(),
+            /*sandbox*/ None,
+        )
+        .await?;
+    let actual = file_system
+        .read_file(&absolute_path(file_path.clone()), /*sandbox*/ None)
+        .await?;
+    assert_eq!(actual, payload);
+    file_system
+        .remove(
+            &absolute_path(file_path),
+            RemoveOptions {
+                recursive: false,
+                force: true,
+            },
+            /*sandbox*/ None,
+        )
+        .await?;
+    Ok(())
 }
 
 fn read_only_sandbox(readable_root: PathBuf) -> FileSystemSandboxContext {
@@ -342,6 +493,17 @@ fn remote_test_file_path() -> PathBuf {
     };
     PathBuf::from(format!(
         "/tmp/codex-remote-test-env-{}-{nanos}.txt",
+        std::process::id()
+    ))
+}
+
+fn local_test_file_path() -> PathBuf {
+    let nanos = match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(duration) => duration.as_nanos(),
+        Err(_) => 0,
+    };
+    std::env::temp_dir().join(format!(
+        "codex-local-test-env-{}-{nanos}.txt",
         std::process::id()
     ))
 }

--- a/codex-rs/debug-client/src/client.rs
+++ b/codex-rs/debug-client/src/client.rs
@@ -391,6 +391,7 @@ pub fn build_thread_start_params(
         cwd,
         approval_policy: Some(approval_policy),
         experimental_raw_events: false,
+        environment_id: None,
         ..Default::default()
     }
 }

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -915,6 +915,7 @@ fn thread_start_params_from_config(config: &Config) -> ThreadStartParams {
         sandbox: sandbox_mode_from_policy(config.permissions.sandbox_policy.get()),
         config: config_request_overrides_from_config(config),
         ephemeral: Some(config.ephemeral),
+        environment_id: None,
         ..ThreadStartParams::default()
     }
 }

--- a/codex-rs/tui/src/app_server_session.rs
+++ b/codex-rs/tui/src/app_server_session.rs
@@ -910,6 +910,7 @@ fn thread_start_params_from_config(
         ephemeral: Some(config.ephemeral),
         session_start_source,
         persist_extended_history: true,
+        environment_id: None,
         ..ThreadStartParams::default()
     }
 }

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -2043,6 +2043,7 @@ mod tests {
                 request_id: RequestId::Integer(1),
                 params: ThreadStartParams {
                     ephemeral: Some(true),
+                    environment_id: None,
                     ..ThreadStartParams::default()
                 },
             })


### PR DESCRIPTION
## Summary
- carry optional `environment_id` through `thread/start` and core thread spawn
- resolve the selected built-in local or remote environment once per thread
- add thread-facing coverage for default, local, and remote selection

## Validation
- not run