### PR TITLE
[sandboxing] Block Docker Desktop escape paths in macOS seatbelt

### DIFF
--- a/codex-rs/sandboxing/src/seatbelt_base_policy.sbpl
+++ b/codex-rs/sandboxing/src/seatbelt_base_policy.sbpl
@@ -7,6 +7,46 @@
 ; start with closed-by-default
 (deny default)
 
+; Block Docker Desktop control surfaces so the macOS sandbox cannot escape via
+; the host container runtime or its virtiofs bridge.
+(deny process-exec
+  (literal "/usr/bin/docker")
+  (literal "/usr/local/bin/docker")
+  (literal "/usr/local/bin/com.docker.cli")
+  (literal "/opt/homebrew/bin/docker")
+  (literal "/opt/homebrew/bin/com.docker.cli")
+  (subpath "/usr/local/Cellar/docker")
+  (subpath "/opt/homebrew/Cellar/docker")
+  (literal "/Applications/Docker.app/Contents/Resources/bin/docker")
+  (literal "/Applications/Docker.app/Contents/Resources/bin/com.docker.cli")
+  (subpath "/Applications/Docker.app/Contents/MacOS"))
+
+(deny file-read* file-write*
+  (literal "/var/run/docker.sock")
+  (literal "/var/run/docker.sock.raw")
+  (literal "/private/var/run/docker.sock")
+  (literal "/private/var/run/docker.sock.raw")
+  (subpath "/Users/Shared/.docker")
+  (regex #"^/Users/[^/]+/\.docker/run/")
+  (subpath "/var/run/docker")
+  (subpath "/private/var/run/docker"))
+
+(deny network-outbound
+  (remote unix-socket (literal "/var/run/docker.sock"))
+  (remote unix-socket (literal "/var/run/docker.sock.raw"))
+  (remote unix-socket (literal "/private/var/run/docker.sock"))
+  (remote unix-socket (literal "/private/var/run/docker.sock.raw"))
+  (remote unix-socket (subpath "/Users/Shared/.docker"))
+  (remote unix-socket (regex #"^/Users/[^/]+/\.docker/run/"))
+  (remote unix-socket (subpath "/var/run/docker"))
+  (remote unix-socket (subpath "/private/var/run/docker")))
+
+(deny mach-lookup
+  (xpc-service-name-prefix "com.docker."))
+
+(deny ipc-posix-shm-read* ipc-posix-shm-write*
+  (ipc-posix-name-prefix "docker"))
+
 ; child processes inherit the policy of their parent
 (allow process-exec)
 (allow process-fork)

--- a/codex-rs/sandboxing/src/seatbelt_tests.rs
+++ b/codex-rs/sandboxing/src/seatbelt_tests.rs
@@ -101,6 +101,75 @@ fn base_policy_allows_kmp_registration_shm_read_create_and_unlink() {
 }
 
 #[test]
+fn base_policy_denies_docker_desktop_escape_surfaces() {
+    let docker_exec_deny = r##"(deny process-exec
+  (literal "/usr/bin/docker")
+  (literal "/usr/local/bin/docker")
+  (literal "/usr/local/bin/com.docker.cli")
+  (literal "/opt/homebrew/bin/docker")
+  (literal "/opt/homebrew/bin/com.docker.cli")
+  (subpath "/usr/local/Cellar/docker")
+  (subpath "/opt/homebrew/Cellar/docker")
+  (literal "/Applications/Docker.app/Contents/Resources/bin/docker")
+  (literal "/Applications/Docker.app/Contents/Resources/bin/com.docker.cli")
+  (subpath "/Applications/Docker.app/Contents/MacOS"))"##;
+    let docker_socket_deny = r##"(deny file-read* file-write*
+  (literal "/var/run/docker.sock")
+  (literal "/var/run/docker.sock.raw")
+  (literal "/private/var/run/docker.sock")
+  (literal "/private/var/run/docker.sock.raw")
+  (subpath "/Users/Shared/.docker")
+  (regex #"^/Users/[^/]+/\.docker/run/")
+  (subpath "/var/run/docker")
+  (subpath "/private/var/run/docker"))"##;
+    let docker_unix_socket_deny = r##"(deny network-outbound
+  (remote unix-socket (literal "/var/run/docker.sock"))
+  (remote unix-socket (literal "/var/run/docker.sock.raw"))
+  (remote unix-socket (literal "/private/var/run/docker.sock"))
+  (remote unix-socket (literal "/private/var/run/docker.sock.raw"))
+  (remote unix-socket (subpath "/Users/Shared/.docker"))
+  (remote unix-socket (regex #"^/Users/[^/]+/\.docker/run/"))
+  (remote unix-socket (subpath "/var/run/docker"))
+  (remote unix-socket (subpath "/private/var/run/docker")))"##;
+    let docker_mach_deny = r##"(deny mach-lookup
+  (xpc-service-name-prefix "com.docker."))"##;
+    let docker_shm_deny = r##"(deny ipc-posix-shm-read* ipc-posix-shm-write*
+  (ipc-posix-name-prefix "docker"))"##;
+
+    assert!(
+        MACOS_SEATBELT_BASE_POLICY.contains(docker_exec_deny),
+        "base policy must deny Docker executables:\n{MACOS_SEATBELT_BASE_POLICY}"
+    );
+    assert!(
+        MACOS_SEATBELT_BASE_POLICY.contains(docker_socket_deny),
+        "base policy must deny Docker socket file access:\n{MACOS_SEATBELT_BASE_POLICY}"
+    );
+    assert!(
+        MACOS_SEATBELT_BASE_POLICY.contains(docker_unix_socket_deny),
+        "base policy must deny Docker unix socket outbound access:\n{MACOS_SEATBELT_BASE_POLICY}"
+    );
+    assert!(
+        MACOS_SEATBELT_BASE_POLICY.contains(docker_mach_deny),
+        "base policy must deny Docker mach services:\n{MACOS_SEATBELT_BASE_POLICY}"
+    );
+    assert!(
+        MACOS_SEATBELT_BASE_POLICY.contains(docker_shm_deny),
+        "base policy must deny Docker shared memory handles:\n{MACOS_SEATBELT_BASE_POLICY}"
+    );
+
+    let docker_exec_deny_position = MACOS_SEATBELT_BASE_POLICY
+        .find(docker_exec_deny)
+        .expect("Docker exec deny must exist");
+    let broad_exec_allow_position = MACOS_SEATBELT_BASE_POLICY
+        .find("(allow process-exec)")
+        .expect("broad process-exec allow must exist");
+    assert!(
+        docker_exec_deny_position < broad_exec_allow_position,
+        "Docker deny block must appear before broad process-exec allow:\n{MACOS_SEATBELT_BASE_POLICY}"
+    );
+}
+
+#[test]
 fn create_seatbelt_args_routes_network_through_proxy_ports() {
     let policy = dynamic_network_policy(
         &SandboxPolicy::new_read_only_policy(),


### PR DESCRIPTION
## Summary
CODEX's local code supports the core sandbox escape prerequisites, but the Docker Desktop and VirtioFS step still needs runtime confirmation before calling it fully validated. This PR will fix this Codex Sandbox Escape.

## Change Details
1. Add explicit Docker Desktop deny rules to the macOS seatbelt base policy so sandboxed commands cannot exec Docker, reach Docker socket paths, or talk to Docker XPC and shared memory surfaces.
2. Add a regression test that locks those deny rules into the policy template and checks that the Docker exec deny stays ahead of the broad `process exec` allow.

## Validation
1. `cargo test -p codex-sandboxing`
2. `cargo test -p codex-core --test all suite::seatbelt::`

## Tickets
1. `BUGB 15082` - https://linear.app/openai/issue/BUGB-15082/codex-sandbox-escape-via-docker-virtiofs-access-on-macos
