### PR TITLE
Avoid fatal TUI errors on skills list failure

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -2486,14 +2486,16 @@ impl App {
                 Ok(true)
             }
             AppCommandView::ListSkills { cwds, force_reload } => {
-                let response = app_server
-                    .skills_list(codex_app_server_protocol::SkillsListParams {
-                        cwds: cwds.to_vec(),
-                        force_reload,
-                        per_cwd_extra_user_roots: None,
-                    })
-                    .await?;
-                self.handle_skills_list_response(response);
+                self.handle_skills_list_result(
+                    app_server
+                        .skills_list(codex_app_server_protocol::SkillsListParams {
+                            cwds: cwds.to_vec(),
+                            force_reload,
+                            per_cwd_extra_user_roots: None,
+                        })
+                        .await,
+                    "failed to refresh skills",
+                );
                 Ok(true)
             }
             AppCommandView::Compact => {
@@ -2564,6 +2566,23 @@ impl App {
             }
             AppCommandView::OverrideTurnContext { .. } => Ok(true),
             _ => Ok(false),
+        }
+    }
+
+    fn handle_skills_list_result(
+        &mut self,
+        result: Result<SkillsListResponse>,
+        failure_message: &str,
+    ) -> bool {
+        match result {
+            Ok(response) => {
+                self.handle_skills_list_response(response);
+                true
+            }
+            Err(err) => {
+                tracing::warn!("{failure_message}: {err:#}");
+                false
+            }
         }
     }
 
@@ -3973,17 +3992,16 @@ impl App {
             app.enqueue_primary_thread_session(started.session, started.turns)
                 .await?;
         }
-        match app_server
-            .skills_list(codex_app_server_protocol::SkillsListParams {
-                cwds: vec![app.config.cwd.to_path_buf()],
-                force_reload: true,
-                per_cwd_extra_user_roots: None,
-            })
-            .await
-        {
-            Ok(response) => app.handle_skills_list_response(response),
-            Err(err) => tracing::warn!("failed to load skills on startup: {err:#}"),
-        }
+        app.handle_skills_list_result(
+            app_server
+                .skills_list(codex_app_server_protocol::SkillsListParams {
+                    cwds: vec![app.config.cwd.to_path_buf()],
+                    force_reload: true,
+                    per_cwd_extra_user_roots: None,
+                })
+                .await,
+            "failed to load skills on startup",
+        );
 
         // On startup, if Agent mode (workspace-write) or ReadOnly is active, warn about world-writable dirs on Windows.
         #[cfg(target_os = "windows")]

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -2573,15 +2573,11 @@ impl App {
         &mut self,
         result: Result<SkillsListResponse>,
         failure_message: &str,
-    ) -> bool {
+    ) {
         match result {
-            Ok(response) => {
-                self.handle_skills_list_response(response);
-                true
-            }
+            Ok(response) => self.handle_skills_list_response(response),
             Err(err) => {
                 tracing::warn!("{failure_message}: {err:#}");
-                false
             }
         }
     }


### PR DESCRIPTION
Addresses #17951

Problem: The TUI treated skills/list failures as fatal during refresh, so proxy/firewall responses that break plugin discovery could crash the session.

Solution: Route startup and refresh skills/list responses through shared graceful handling that logs a warning and keeps the TUI running.