### PR TITLE
defer all tools behind feature flag

### DIFF
--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -497,7 +497,7 @@
             "tool_search": {
               "type": "boolean"
             },
-            "tool_search_token_budget_deferral": {
+            "tool_search_always_defer_mcp_tools": {
               "type": "boolean"
             },
             "tool_suggest": {
@@ -2393,7 +2393,7 @@
         "tool_search": {
           "type": "boolean"
         },
-        "tool_search_token_budget_deferral": {
+        "tool_search_always_defer_mcp_tools": {
           "type": "boolean"
         },
         "tool_suggest": {

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -497,6 +497,9 @@
             "tool_search": {
               "type": "boolean"
             },
+            "tool_search_token_budget_deferral": {
+              "type": "boolean"
+            },
             "tool_suggest": {
               "type": "boolean"
             },
@@ -2388,6 +2391,9 @@
           "type": "boolean"
         },
         "tool_search": {
+          "type": "boolean"
+        },
+        "tool_search_token_budget_deferral": {
           "type": "boolean"
         },
         "tool_suggest": {

--- a/codex-rs/core/src/codex_tests.rs
+++ b/codex-rs/core/src/codex_tests.rs
@@ -10,15 +10,12 @@ use crate::config_loader::RequirementSource;
 use crate::config_loader::Sourced;
 use crate::exec::ExecCapturePolicy;
 use crate::function_tool::FunctionCallError;
-use crate::mcp_tool_exposure::DIRECT_MCP_TOOL_EXPOSURE_THRESHOLD;
-use crate::mcp_tool_exposure::build_mcp_tool_exposure;
 use crate::shell::default_user_shell;
 use crate::tools::format_exec_output_str;
 
+use codex_features::Feature;
 use codex_features::Features;
 use codex_login::CodexAuth;
-use codex_mcp::CODEX_APPS_MCP_SERVER_NAME;
-use codex_mcp::ToolInfo;
 use codex_model_provider_info::ModelProviderInfo;
 use codex_models_manager::bundled_models_response;
 use codex_models_manager::model_info;
@@ -117,8 +114,6 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use codex_protocol::mcp::CallToolResult as McpCallToolResult;
 use pretty_assertions::assert_eq;
-use rmcp::model::JsonObject;
-use rmcp::model::Tool;
 use serde::Deserialize;
 use serde_json::json;
 use std::path::PathBuf;
@@ -403,80 +398,6 @@ fn assistant_message_stream_parsers_seed_plan_parser_across_added_and_delta_boun
     );
     assert_eq!(tail.visible_text, "");
     assert!(tail.plan_segments.is_empty());
-}
-
-fn make_mcp_tool(
-    server_name: &str,
-    tool_name: &str,
-    connector_id: Option<&str>,
-    connector_name: Option<&str>,
-) -> ToolInfo {
-    let tool_namespace = if server_name == CODEX_APPS_MCP_SERVER_NAME {
-        connector_name
-            .map(codex_connectors::metadata::sanitize_name)
-            .map(|connector_name| format!("mcp__{server_name}__{connector_name}"))
-            .unwrap_or_else(|| server_name.to_string())
-    } else {
-        format!("mcp__{server_name}__")
-    };
-
-    ToolInfo {
-        server_name: server_name.to_string(),
-        callable_name: tool_name.to_string(),
-        callable_namespace: tool_namespace,
-        server_instructions: None,
-        tool: Tool {
-            name: tool_name.to_string().into(),
-            title: None,
-            description: Some(format!("Test tool: {tool_name}").into()),
-            input_schema: Arc::new(JsonObject::default()),
-            output_schema: None,
-            annotations: None,
-            execution: None,
-            icons: None,
-            meta: None,
-        },
-        connector_id: connector_id.map(str::to_string),
-        connector_name: connector_name.map(str::to_string),
-        plugin_display_names: Vec::new(),
-        connector_description: None,
-    }
-}
-
-fn numbered_mcp_tools(count: usize) -> HashMap<String, ToolInfo> {
-    (0..count)
-        .map(|index| {
-            let tool_name = format!("tool_{index}");
-            (
-                format!("mcp__rmcp__{tool_name}"),
-                make_mcp_tool(
-                    "rmcp", &tool_name, /*connector_id*/ None, /*connector_name*/ None,
-                ),
-            )
-        })
-        .collect()
-}
-
-async fn tools_config_for_mcp_tool_exposure(search_tool: bool) -> ToolsConfig {
-    let config = test_config().await;
-    let model_info = ModelsManager::construct_model_info_offline_for_tests(
-        "gpt-5-codex",
-        &config.to_models_manager_config(),
-    );
-    let features = Features::with_defaults();
-    let available_models = Vec::new();
-    let mut tools_config = ToolsConfig::new(&ToolsConfigParams {
-        model_info: &model_info,
-        available_models: &available_models,
-        features: &features,
-        image_generation_tool_auth_allowed: true,
-        web_search_mode: Some(WebSearchMode::Cached),
-        session_source: SessionSource::Cli,
-        sandbox_policy: &SandboxPolicy::DangerFullAccess,
-        windows_sandbox_level: WindowsSandboxLevel::Disabled,
-    });
-    tools_config.search_tool = search_tool;
-    tools_config
 }
 
 #[test]
@@ -1144,102 +1065,6 @@ fn collect_explicit_app_ids_from_skill_items_skips_plain_mentions_with_skill_con
     );
 
     assert_eq!(connector_ids, HashSet::<String>::new());
-}
-
-#[tokio::test]
-async fn mcp_tool_exposure_directly_exposes_small_effective_tool_sets() {
-    let config = test_config().await;
-    let tools_config = tools_config_for_mcp_tool_exposure(/*search_tool*/ true).await;
-    let mcp_tools = numbered_mcp_tools(DIRECT_MCP_TOOL_EXPOSURE_THRESHOLD - 1);
-
-    let exposure = build_mcp_tool_exposure(
-        &mcp_tools,
-        /*connectors*/ None,
-        &[],
-        &config,
-        &tools_config,
-    );
-
-    let mut direct_tool_names: Vec<_> = exposure.direct_tools.keys().cloned().collect();
-    direct_tool_names.sort();
-    let mut expected_tool_names: Vec<_> = mcp_tools.keys().cloned().collect();
-    expected_tool_names.sort();
-    assert_eq!(direct_tool_names, expected_tool_names);
-    assert!(exposure.deferred_tools.is_none());
-}
-
-#[tokio::test]
-async fn mcp_tool_exposure_searches_large_effective_tool_sets() {
-    let config = test_config().await;
-    let tools_config = tools_config_for_mcp_tool_exposure(/*search_tool*/ true).await;
-    let mcp_tools = numbered_mcp_tools(DIRECT_MCP_TOOL_EXPOSURE_THRESHOLD);
-
-    let exposure = build_mcp_tool_exposure(
-        &mcp_tools,
-        /*connectors*/ None,
-        &[],
-        &config,
-        &tools_config,
-    );
-
-    assert!(exposure.direct_tools.is_empty());
-    let deferred_tools = exposure
-        .deferred_tools
-        .as_ref()
-        .expect("large tool sets should be discoverable through tool_search");
-    let mut deferred_tool_names: Vec<_> = deferred_tools.keys().cloned().collect();
-    deferred_tool_names.sort();
-    let mut expected_tool_names: Vec<_> = mcp_tools.keys().cloned().collect();
-    expected_tool_names.sort();
-    assert_eq!(deferred_tool_names, expected_tool_names);
-}
-
-#[tokio::test]
-async fn mcp_tool_exposure_directly_exposes_explicit_apps_without_deferred_overlap() {
-    let config = test_config().await;
-    let tools_config = tools_config_for_mcp_tool_exposure(/*search_tool*/ true).await;
-    let mut mcp_tools = numbered_mcp_tools(DIRECT_MCP_TOOL_EXPOSURE_THRESHOLD - 1);
-    mcp_tools.extend([(
-        "mcp__codex_apps__calendar_create_event".to_string(),
-        make_mcp_tool(
-            CODEX_APPS_MCP_SERVER_NAME,
-            "calendar_create_event",
-            Some("calendar"),
-            Some("Calendar"),
-        ),
-    )]);
-    let connectors = vec![make_connector("calendar", "Calendar")];
-
-    let exposure = build_mcp_tool_exposure(
-        &mcp_tools,
-        Some(connectors.as_slice()),
-        connectors.as_slice(),
-        &config,
-        &tools_config,
-    );
-
-    let mut tool_names: Vec<String> = exposure.direct_tools.into_keys().collect();
-    tool_names.sort();
-    assert_eq!(
-        tool_names,
-        vec!["mcp__codex_apps__calendar_create_event".to_string()]
-    );
-    assert_eq!(
-        exposure.deferred_tools.as_ref().map(HashMap::len),
-        Some(DIRECT_MCP_TOOL_EXPOSURE_THRESHOLD - 1)
-    );
-    let deferred_tools = exposure
-        .deferred_tools
-        .as_ref()
-        .expect("large tool sets should be discoverable through tool_search");
-    assert!(
-        tool_names
-            .iter()
-            .all(|direct_tool_name| !deferred_tools.contains_key(direct_tool_name)),
-        "direct tools should not also be deferred: {tool_names:?}"
-    );
-    assert!(!deferred_tools.contains_key("mcp__codex_apps__calendar_create_event"));
-    assert!(deferred_tools.contains_key("mcp__rmcp__tool_0"));
 }
 
 #[tokio::test]

--- a/codex-rs/core/src/mcp_tool_exposure.rs
+++ b/codex-rs/core/src/mcp_tool_exposure.rs
@@ -33,21 +33,11 @@ pub(crate) fn build_mcp_tool_exposure(
         ));
     }
 
-    if !tools_config.search_tool {
-        return McpToolExposure {
-            direct_tools: deferred_tools,
-            deferred_tools: None,
-        };
-    }
-
-    let should_defer = if config
-        .features
-        .enabled(Feature::ToolSearchAlwaysDeferMcpTools)
-    {
-        true
-    } else {
-        deferred_tools.len() >= DIRECT_MCP_TOOL_EXPOSURE_THRESHOLD
-    };
+    let should_defer = tools_config.search_tool
+        && (config
+            .features
+            .enabled(Feature::ToolSearchAlwaysDeferMcpTools)
+            || deferred_tools.len() >= DIRECT_MCP_TOOL_EXPOSURE_THRESHOLD);
 
     if !should_defer {
         return McpToolExposure {

--- a/codex-rs/core/src/mcp_tool_exposure.rs
+++ b/codex-rs/core/src/mcp_tool_exposure.rs
@@ -5,15 +5,12 @@ use codex_features::Feature;
 use codex_mcp::CODEX_APPS_MCP_SERVER_NAME;
 use codex_mcp::ToolInfo as McpToolInfo;
 use codex_mcp::filter_non_codex_apps_mcp_tools_only;
-use codex_tools::ResponsesApiNamespaceTool;
 use codex_tools::ToolsConfig;
-use codex_utils_string::approx_bytes_for_tokens;
 
 use crate::config::Config;
 use crate::connectors;
 
 pub(crate) const DIRECT_MCP_TOOL_EXPOSURE_THRESHOLD: usize = 100;
-const DIRECT_MCP_TOOL_EXPOSURE_TOKEN_THRESHOLD: usize = 2_000;
 
 pub(crate) struct McpToolExposure {
     pub(crate) direct_tools: HashMap<String, McpToolInfo>,
@@ -45,10 +42,9 @@ pub(crate) fn build_mcp_tool_exposure(
 
     let should_defer = if config
         .features
-        .enabled(Feature::ToolSearchTokenBudgetDeferral)
+        .enabled(Feature::ToolSearchAlwaysDeferMcpTools)
     {
-        estimate_direct_mcp_tool_schema_bytes(&deferred_tools)
-            >= approx_bytes_for_tokens(DIRECT_MCP_TOOL_EXPOSURE_TOKEN_THRESHOLD)
+        true
     } else {
         deferred_tools.len() >= DIRECT_MCP_TOOL_EXPOSURE_THRESHOLD
     };
@@ -95,22 +91,6 @@ fn filter_codex_apps_mcp_tools(
         })
         .map(|(name, tool)| (name.clone(), tool.clone()))
         .collect()
-}
-
-fn estimate_direct_mcp_tool_schema_bytes(mcp_tools: &HashMap<String, McpToolInfo>) -> usize {
-    mcp_tools
-        .values()
-        .filter_map(|tool| {
-            let responses_tool = codex_tools::mcp_tool_to_responses_api_tool(
-                &tool.canonical_tool_name(),
-                &tool.tool,
-            )
-            .ok()?;
-            serde_json::to_vec(&ResponsesApiNamespaceTool::Function(responses_tool))
-                .ok()
-                .map(|bytes| bytes.len())
-        })
-        .sum()
 }
 
 #[cfg(test)]

--- a/codex-rs/core/src/mcp_tool_exposure.rs
+++ b/codex-rs/core/src/mcp_tool_exposure.rs
@@ -1,15 +1,19 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
 
+use codex_features::Feature;
 use codex_mcp::CODEX_APPS_MCP_SERVER_NAME;
 use codex_mcp::ToolInfo as McpToolInfo;
 use codex_mcp::filter_non_codex_apps_mcp_tools_only;
+use codex_tools::ResponsesApiNamespaceTool;
 use codex_tools::ToolsConfig;
+use codex_utils_string::approx_bytes_for_tokens;
 
 use crate::config::Config;
 use crate::connectors;
 
 pub(crate) const DIRECT_MCP_TOOL_EXPOSURE_THRESHOLD: usize = 100;
+const DIRECT_MCP_TOOL_EXPOSURE_TOKEN_THRESHOLD: usize = 2_000;
 
 pub(crate) struct McpToolExposure {
     pub(crate) direct_tools: HashMap<String, McpToolInfo>,
@@ -32,7 +36,24 @@ pub(crate) fn build_mcp_tool_exposure(
         ));
     }
 
-    if !tools_config.search_tool || deferred_tools.len() < DIRECT_MCP_TOOL_EXPOSURE_THRESHOLD {
+    if !tools_config.search_tool {
+        return McpToolExposure {
+            direct_tools: deferred_tools,
+            deferred_tools: None,
+        };
+    }
+
+    let should_defer = if config
+        .features
+        .enabled(Feature::ToolSearchTokenBudgetDeferral)
+    {
+        estimate_direct_mcp_tool_schema_bytes(&deferred_tools)
+            >= approx_bytes_for_tokens(DIRECT_MCP_TOOL_EXPOSURE_TOKEN_THRESHOLD)
+    } else {
+        deferred_tools.len() >= DIRECT_MCP_TOOL_EXPOSURE_THRESHOLD
+    };
+
+    if !should_defer {
         return McpToolExposure {
             direct_tools: deferred_tools,
             deferred_tools: None,
@@ -75,3 +96,23 @@ fn filter_codex_apps_mcp_tools(
         .map(|(name, tool)| (name.clone(), tool.clone()))
         .collect()
 }
+
+fn estimate_direct_mcp_tool_schema_bytes(mcp_tools: &HashMap<String, McpToolInfo>) -> usize {
+    mcp_tools
+        .values()
+        .filter_map(|tool| {
+            let responses_tool = codex_tools::mcp_tool_to_responses_api_tool(
+                &tool.canonical_tool_name(),
+                &tool.tool,
+            )
+            .ok()?;
+            serde_json::to_vec(&ResponsesApiNamespaceTool::Function(responses_tool))
+                .ok()
+                .map(|bytes| bytes.len())
+        })
+        .sum()
+}
+
+#[cfg(test)]
+#[path = "mcp_tool_exposure_test.rs"]
+mod tests;

--- a/codex-rs/core/src/mcp_tool_exposure_test.rs
+++ b/codex-rs/core/src/mcp_tool_exposure_test.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use codex_connectors::metadata::sanitize_name;
 use codex_features::Feature;
 use codex_features::Features;
 use codex_mcp::CODEX_APPS_MCP_SERVER_NAME;
@@ -44,25 +45,9 @@ fn make_mcp_tool(
     connector_id: Option<&str>,
     connector_name: Option<&str>,
 ) -> ToolInfo {
-    make_mcp_tool_with_description(
-        server_name,
-        tool_name,
-        connector_id,
-        connector_name,
-        format!("Test tool: {tool_name}"),
-    )
-}
-
-fn make_mcp_tool_with_description(
-    server_name: &str,
-    tool_name: &str,
-    connector_id: Option<&str>,
-    connector_name: Option<&str>,
-    description: String,
-) -> ToolInfo {
     let tool_namespace = if server_name == CODEX_APPS_MCP_SERVER_NAME {
         connector_name
-            .map(crate::connectors::sanitize_name)
+            .map(sanitize_name)
             .map(|connector_name| format!("mcp__{server_name}__{connector_name}"))
             .unwrap_or_else(|| server_name.to_string())
     } else {
@@ -77,7 +62,7 @@ fn make_mcp_tool_with_description(
         tool: Tool {
             name: tool_name.to_string().into(),
             title: None,
-            description: Some(description.into()),
+            description: Some(format!("Test tool: {tool_name}").into()),
             input_schema: Arc::new(JsonObject::default()),
             output_schema: None,
             annotations: None,
@@ -225,22 +210,18 @@ async fn directly_exposes_explicit_apps_without_deferred_overlap() {
 }
 
 #[tokio::test]
-async fn token_budget_feature_preserves_explicit_apps() {
+async fn always_defer_feature_preserves_explicit_apps() {
     let mut config = test_config().await;
     config
         .features
-        .enable(Feature::ToolSearchTokenBudgetDeferral)
+        .enable(Feature::ToolSearchAlwaysDeferMcpTools)
         .expect("test config should allow feature update");
     let tools_config = tools_config_for_mcp_tool_exposure(/*search_tool*/ true).await;
     let mcp_tools = HashMap::from([
         (
-            "mcp__rmcp__expensive_tool".to_string(),
-            make_mcp_tool_with_description(
-                "rmcp",
-                "expensive_tool",
-                /*connector_id*/ None,
-                /*connector_name*/ None,
-                "x".repeat(9_000),
+            "mcp__rmcp__tool".to_string(),
+            make_mcp_tool(
+                "rmcp", "tool", /*connector_id*/ None, /*connector_name*/ None,
             ),
         ),
         (
@@ -272,7 +253,7 @@ async fn token_budget_feature_preserves_explicit_apps() {
     let deferred_tools = exposure
         .deferred_tools
         .as_ref()
-        .expect("expensive tool sets should be discoverable through tool_search");
-    assert!(deferred_tools.contains_key("mcp__rmcp__expensive_tool"));
+        .expect("MCP tools should be discoverable through tool_search");
+    assert!(deferred_tools.contains_key("mcp__rmcp__tool"));
     assert!(!deferred_tools.contains_key("mcp__codex_apps__calendar_create_event"));
 }

--- a/codex-rs/core/src/mcp_tool_exposure_test.rs
+++ b/codex-rs/core/src/mcp_tool_exposure_test.rs
@@ -1,0 +1,278 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use codex_features::Feature;
+use codex_features::Features;
+use codex_mcp::CODEX_APPS_MCP_SERVER_NAME;
+use codex_mcp::ToolInfo;
+use codex_models_manager::manager::ModelsManager;
+use codex_protocol::config_types::WebSearchMode;
+use codex_protocol::config_types::WindowsSandboxLevel;
+use codex_protocol::protocol::SandboxPolicy;
+use codex_protocol::protocol::SessionSource;
+use codex_tools::ToolsConfig;
+use codex_tools::ToolsConfigParams;
+use pretty_assertions::assert_eq;
+use rmcp::model::JsonObject;
+use rmcp::model::Tool;
+
+use super::*;
+use crate::config::test_config;
+use crate::connectors::AppInfo;
+
+fn make_connector(id: &str, name: &str) -> AppInfo {
+    AppInfo {
+        id: id.to_string(),
+        name: name.to_string(),
+        description: None,
+        logo_url: None,
+        logo_url_dark: None,
+        distribution_channel: None,
+        branding: None,
+        app_metadata: None,
+        labels: None,
+        install_url: None,
+        is_accessible: true,
+        is_enabled: true,
+        plugin_display_names: Vec::new(),
+    }
+}
+
+fn make_mcp_tool(
+    server_name: &str,
+    tool_name: &str,
+    connector_id: Option<&str>,
+    connector_name: Option<&str>,
+) -> ToolInfo {
+    make_mcp_tool_with_description(
+        server_name,
+        tool_name,
+        connector_id,
+        connector_name,
+        format!("Test tool: {tool_name}"),
+    )
+}
+
+fn make_mcp_tool_with_description(
+    server_name: &str,
+    tool_name: &str,
+    connector_id: Option<&str>,
+    connector_name: Option<&str>,
+    description: String,
+) -> ToolInfo {
+    let tool_namespace = if server_name == CODEX_APPS_MCP_SERVER_NAME {
+        connector_name
+            .map(crate::connectors::sanitize_name)
+            .map(|connector_name| format!("mcp__{server_name}__{connector_name}"))
+            .unwrap_or_else(|| server_name.to_string())
+    } else {
+        format!("mcp__{server_name}__")
+    };
+
+    ToolInfo {
+        server_name: server_name.to_string(),
+        callable_name: tool_name.to_string(),
+        callable_namespace: tool_namespace,
+        server_instructions: None,
+        tool: Tool {
+            name: tool_name.to_string().into(),
+            title: None,
+            description: Some(description.into()),
+            input_schema: Arc::new(JsonObject::default()),
+            output_schema: None,
+            annotations: None,
+            execution: None,
+            icons: None,
+            meta: None,
+        },
+        connector_id: connector_id.map(str::to_string),
+        connector_name: connector_name.map(str::to_string),
+        plugin_display_names: Vec::new(),
+        connector_description: None,
+    }
+}
+
+fn numbered_mcp_tools(count: usize) -> HashMap<String, ToolInfo> {
+    (0..count)
+        .map(|index| {
+            let tool_name = format!("tool_{index}");
+            (
+                format!("mcp__rmcp__{tool_name}"),
+                make_mcp_tool(
+                    "rmcp", &tool_name, /*connector_id*/ None, /*connector_name*/ None,
+                ),
+            )
+        })
+        .collect()
+}
+
+async fn tools_config_for_mcp_tool_exposure(search_tool: bool) -> ToolsConfig {
+    let config = test_config().await;
+    let model_info = ModelsManager::construct_model_info_offline_for_tests(
+        "gpt-5-codex",
+        &config.to_models_manager_config(),
+    );
+    let features = Features::with_defaults();
+    let available_models = Vec::new();
+    let mut tools_config = ToolsConfig::new(&ToolsConfigParams {
+        model_info: &model_info,
+        available_models: &available_models,
+        features: &features,
+        image_generation_tool_auth_allowed: true,
+        web_search_mode: Some(WebSearchMode::Cached),
+        session_source: SessionSource::Cli,
+        sandbox_policy: &SandboxPolicy::DangerFullAccess,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
+    });
+    tools_config.search_tool = search_tool;
+    tools_config
+}
+
+#[tokio::test]
+async fn directly_exposes_small_effective_tool_sets() {
+    let config = test_config().await;
+    let tools_config = tools_config_for_mcp_tool_exposure(/*search_tool*/ true).await;
+    let mcp_tools = numbered_mcp_tools(DIRECT_MCP_TOOL_EXPOSURE_THRESHOLD - 1);
+
+    let exposure = build_mcp_tool_exposure(
+        &mcp_tools,
+        /*connectors*/ None,
+        &[],
+        &config,
+        &tools_config,
+    );
+
+    let mut direct_tool_names: Vec<_> = exposure.direct_tools.keys().cloned().collect();
+    direct_tool_names.sort();
+    let mut expected_tool_names: Vec<_> = mcp_tools.keys().cloned().collect();
+    expected_tool_names.sort();
+    assert_eq!(direct_tool_names, expected_tool_names);
+    assert!(exposure.deferred_tools.is_none());
+}
+
+#[tokio::test]
+async fn searches_large_effective_tool_sets() {
+    let config = test_config().await;
+    let tools_config = tools_config_for_mcp_tool_exposure(/*search_tool*/ true).await;
+    let mcp_tools = numbered_mcp_tools(DIRECT_MCP_TOOL_EXPOSURE_THRESHOLD);
+
+    let exposure = build_mcp_tool_exposure(
+        &mcp_tools,
+        /*connectors*/ None,
+        &[],
+        &config,
+        &tools_config,
+    );
+
+    assert!(exposure.direct_tools.is_empty());
+    let deferred_tools = exposure
+        .deferred_tools
+        .as_ref()
+        .expect("large tool sets should be discoverable through tool_search");
+    let mut deferred_tool_names: Vec<_> = deferred_tools.keys().cloned().collect();
+    deferred_tool_names.sort();
+    let mut expected_tool_names: Vec<_> = mcp_tools.keys().cloned().collect();
+    expected_tool_names.sort();
+    assert_eq!(deferred_tool_names, expected_tool_names);
+}
+
+#[tokio::test]
+async fn directly_exposes_explicit_apps_without_deferred_overlap() {
+    let config = test_config().await;
+    let tools_config = tools_config_for_mcp_tool_exposure(/*search_tool*/ true).await;
+    let mut mcp_tools = numbered_mcp_tools(DIRECT_MCP_TOOL_EXPOSURE_THRESHOLD - 1);
+    mcp_tools.extend([(
+        "mcp__codex_apps__calendar_create_event".to_string(),
+        make_mcp_tool(
+            CODEX_APPS_MCP_SERVER_NAME,
+            "calendar_create_event",
+            Some("calendar"),
+            Some("Calendar"),
+        ),
+    )]);
+    let connectors = vec![make_connector("calendar", "Calendar")];
+
+    let exposure = build_mcp_tool_exposure(
+        &mcp_tools,
+        Some(connectors.as_slice()),
+        connectors.as_slice(),
+        &config,
+        &tools_config,
+    );
+
+    let mut tool_names: Vec<String> = exposure.direct_tools.into_keys().collect();
+    tool_names.sort();
+    assert_eq!(
+        tool_names,
+        vec!["mcp__codex_apps__calendar_create_event".to_string()]
+    );
+    assert_eq!(
+        exposure.deferred_tools.as_ref().map(HashMap::len),
+        Some(DIRECT_MCP_TOOL_EXPOSURE_THRESHOLD - 1)
+    );
+    let deferred_tools = exposure
+        .deferred_tools
+        .as_ref()
+        .expect("large tool sets should be discoverable through tool_search");
+    assert!(
+        tool_names
+            .iter()
+            .all(|direct_tool_name| !deferred_tools.contains_key(direct_tool_name)),
+        "direct tools should not also be deferred: {tool_names:?}"
+    );
+    assert!(!deferred_tools.contains_key("mcp__codex_apps__calendar_create_event"));
+    assert!(deferred_tools.contains_key("mcp__rmcp__tool_0"));
+}
+
+#[tokio::test]
+async fn token_budget_feature_preserves_explicit_apps() {
+    let mut config = test_config().await;
+    config
+        .features
+        .enable(Feature::ToolSearchTokenBudgetDeferral)
+        .expect("test config should allow feature update");
+    let tools_config = tools_config_for_mcp_tool_exposure(/*search_tool*/ true).await;
+    let mcp_tools = HashMap::from([
+        (
+            "mcp__rmcp__expensive_tool".to_string(),
+            make_mcp_tool_with_description(
+                "rmcp",
+                "expensive_tool",
+                /*connector_id*/ None,
+                /*connector_name*/ None,
+                "x".repeat(9_000),
+            ),
+        ),
+        (
+            "mcp__codex_apps__calendar_create_event".to_string(),
+            make_mcp_tool(
+                CODEX_APPS_MCP_SERVER_NAME,
+                "calendar_create_event",
+                Some("calendar"),
+                Some("Calendar"),
+            ),
+        ),
+    ]);
+    let connectors = vec![make_connector("calendar", "Calendar")];
+
+    let exposure = build_mcp_tool_exposure(
+        &mcp_tools,
+        Some(connectors.as_slice()),
+        connectors.as_slice(),
+        &config,
+        &tools_config,
+    );
+
+    let mut direct_tool_names: Vec<String> = exposure.direct_tools.into_keys().collect();
+    direct_tool_names.sort();
+    assert_eq!(
+        direct_tool_names,
+        vec!["mcp__codex_apps__calendar_create_event".to_string()]
+    );
+    let deferred_tools = exposure
+        .deferred_tools
+        .as_ref()
+        .expect("expensive tool sets should be discoverable through tool_search");
+    assert!(deferred_tools.contains_key("mcp__rmcp__expensive_tool"));
+    assert!(!deferred_tools.contains_key("mcp__codex_apps__calendar_create_event"));
+}

--- a/codex-rs/core/tests/common/apps_test_server.rs
+++ b/codex-rs/core/tests/common/apps_test_server.rs
@@ -38,13 +38,32 @@ impl AppsTestServer {
     }
 
     pub async fn mount_searchable(server: &MockServer) -> Result<Self> {
+        Self::mount_with_options(
+            server, /*searchable*/ true, /*expensive_tool*/ false,
+        )
+        .await
+    }
+
+    pub async fn mount_with_expensive_tool(server: &MockServer) -> Result<Self> {
+        Self::mount_with_options(
+            server, /*searchable*/ false, /*expensive_tool*/ true,
+        )
+        .await
+    }
+
+    async fn mount_with_options(
+        server: &MockServer,
+        searchable: bool,
+        expensive_tool: bool,
+    ) -> Result<Self> {
         mount_oauth_metadata(server).await;
         mount_connectors_directory(server).await;
         mount_streamable_http_json_rpc(
             server,
             CONNECTOR_NAME.to_string(),
             CONNECTOR_DESCRIPTION.to_string(),
-            /*searchable*/ true,
+            searchable,
+            expensive_tool,
         )
         .await;
         Ok(Self {
@@ -63,6 +82,7 @@ impl AppsTestServer {
             connector_name.to_string(),
             CONNECTOR_DESCRIPTION.to_string(),
             /*searchable*/ false,
+            /*expensive_tool*/ false,
         )
         .await;
         Ok(Self {
@@ -119,6 +139,7 @@ async fn mount_streamable_http_json_rpc(
     connector_name: String,
     connector_description: String,
     searchable: bool,
+    expensive_tool: bool,
 ) {
     Mock::given(method("POST"))
         .and(path_regex("^/api/codex/apps/?$"))
@@ -126,6 +147,7 @@ async fn mount_streamable_http_json_rpc(
             connector_name,
             connector_description,
             searchable,
+            expensive_tool,
         })
         .mount(server)
         .await;
@@ -135,6 +157,7 @@ struct CodexAppsJsonRpcResponder {
     connector_name: String,
     connector_description: String,
     searchable: bool,
+    expensive_tool: bool,
 }
 
 impl Respond for CodexAppsJsonRpcResponder {
@@ -181,6 +204,11 @@ impl Respond for CodexAppsJsonRpcResponder {
             "notifications/initialized" => ResponseTemplate::new(202),
             "tools/list" => {
                 let id = body.get("id").cloned().unwrap_or(Value::Null);
+                let create_event_description = if self.expensive_tool {
+                    "x".repeat(9_000)
+                } else {
+                    "Create a calendar event.".to_string()
+                };
                 let mut response = json!({
                     "jsonrpc": "2.0",
                     "id": id,
@@ -188,7 +216,7 @@ impl Respond for CodexAppsJsonRpcResponder {
                         "tools": [
                             {
                                 "name": "calendar_create_event",
-                                "description": "Create a calendar event.",
+                                "description": create_event_description,
                                 "annotations": {
                                     "readOnlyHint": false,
                                     "destructiveHint": false,

--- a/codex-rs/core/tests/common/apps_test_server.rs
+++ b/codex-rs/core/tests/common/apps_test_server.rs
@@ -38,32 +38,13 @@ impl AppsTestServer {
     }
 
     pub async fn mount_searchable(server: &MockServer) -> Result<Self> {
-        Self::mount_with_options(
-            server, /*searchable*/ true, /*expensive_tool*/ false,
-        )
-        .await
-    }
-
-    pub async fn mount_with_expensive_tool(server: &MockServer) -> Result<Self> {
-        Self::mount_with_options(
-            server, /*searchable*/ false, /*expensive_tool*/ true,
-        )
-        .await
-    }
-
-    async fn mount_with_options(
-        server: &MockServer,
-        searchable: bool,
-        expensive_tool: bool,
-    ) -> Result<Self> {
         mount_oauth_metadata(server).await;
         mount_connectors_directory(server).await;
         mount_streamable_http_json_rpc(
             server,
             CONNECTOR_NAME.to_string(),
             CONNECTOR_DESCRIPTION.to_string(),
-            searchable,
-            expensive_tool,
+            /*searchable*/ true,
         )
         .await;
         Ok(Self {
@@ -82,7 +63,6 @@ impl AppsTestServer {
             connector_name.to_string(),
             CONNECTOR_DESCRIPTION.to_string(),
             /*searchable*/ false,
-            /*expensive_tool*/ false,
         )
         .await;
         Ok(Self {
@@ -139,7 +119,6 @@ async fn mount_streamable_http_json_rpc(
     connector_name: String,
     connector_description: String,
     searchable: bool,
-    expensive_tool: bool,
 ) {
     Mock::given(method("POST"))
         .and(path_regex("^/api/codex/apps/?$"))
@@ -147,7 +126,6 @@ async fn mount_streamable_http_json_rpc(
             connector_name,
             connector_description,
             searchable,
-            expensive_tool,
         })
         .mount(server)
         .await;
@@ -157,7 +135,6 @@ struct CodexAppsJsonRpcResponder {
     connector_name: String,
     connector_description: String,
     searchable: bool,
-    expensive_tool: bool,
 }
 
 impl Respond for CodexAppsJsonRpcResponder {
@@ -204,11 +181,6 @@ impl Respond for CodexAppsJsonRpcResponder {
             "notifications/initialized" => ResponseTemplate::new(202),
             "tools/list" => {
                 let id = body.get("id").cloned().unwrap_or(Value::Null);
-                let create_event_description = if self.expensive_tool {
-                    "x".repeat(9_000)
-                } else {
-                    "Create a calendar event.".to_string()
-                };
                 let mut response = json!({
                     "jsonrpc": "2.0",
                     "id": id,
@@ -216,7 +188,7 @@ impl Respond for CodexAppsJsonRpcResponder {
                         "tools": [
                             {
                                 "name": "calendar_create_event",
-                                "description": create_event_description,
+                                "description": "Create a calendar event.",
                                 "annotations": {
                                     "readOnlyHint": false,
                                     "destructiveHint": false,

--- a/codex-rs/core/tests/suite/search_tool.rs
+++ b/codex-rs/core/tests/suite/search_tool.rs
@@ -228,12 +228,8 @@ async fn always_defer_feature_hides_small_app_tool_sets() -> Result<()> {
         "small app tool sets should be deferred behind tool_search: {tools:?}"
     );
     assert!(
-        !tools.iter().any(|name| name == CALENDAR_CREATE_TOOL),
-        "app tool should not be directly exposed: {tools:?}"
-    );
-    assert!(
-        !tools.iter().any(|name| name == SEARCH_CALENDAR_NAMESPACE),
-        "app namespace should not be directly exposed: {tools:?}"
+        tools.iter().all(|name| !name.starts_with("mcp__")),
+        "MCP tools should not be directly exposed: {tools:?}"
     );
 
     Ok(())

--- a/codex-rs/core/tests/suite/search_tool.rs
+++ b/codex-rs/core/tests/suite/search_tool.rs
@@ -190,6 +190,56 @@ async fn search_tool_enabled_by_default_adds_tool_search() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn token_budget_deferral_hides_expensive_app_tools() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let apps_server = AppsTestServer::mount_with_expensive_tool(&server).await?;
+    let mock = mount_sse_once(
+        &server,
+        sse(vec![
+            ev_response_created("resp-1"),
+            ev_assistant_message("msg-1", "done"),
+            ev_completed("resp-1"),
+        ]),
+    )
+    .await;
+
+    let mut builder =
+        configured_builder(apps_server.chatgpt_base_url.clone()).with_config(|config| {
+            config
+                .features
+                .enable(Feature::ToolSearchTokenBudgetDeferral)
+                .expect("test config should allow feature update");
+        });
+    let test = builder.build(&server).await?;
+
+    test.submit_turn_with_policies(
+        "list tools",
+        AskForApproval::Never,
+        SandboxPolicy::DangerFullAccess,
+    )
+    .await?;
+
+    let body = mock.single_request().body_json();
+    let tools = tool_names(&body);
+    assert!(
+        tools.iter().any(|name| name == TOOL_SEARCH_TOOL_NAME),
+        "expensive app tools should be deferred behind tool_search: {tools:?}"
+    );
+    assert!(
+        !tools.iter().any(|name| name == CALENDAR_CREATE_TOOL),
+        "expensive app tool should not be directly exposed: {tools:?}"
+    );
+    assert!(
+        !tools.iter().any(|name| name == SEARCH_CALENDAR_NAMESPACE),
+        "expensive app namespace should not be directly exposed: {tools:?}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn tool_search_disabled_exposes_apps_tools_directly() -> Result<()> {
     skip_if_no_network!(Ok(()));
 

--- a/codex-rs/core/tests/suite/search_tool.rs
+++ b/codex-rs/core/tests/suite/search_tool.rs
@@ -190,11 +190,11 @@ async fn search_tool_enabled_by_default_adds_tool_search() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn token_budget_deferral_hides_expensive_app_tools() -> Result<()> {
+async fn always_defer_feature_hides_small_app_tool_sets() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
     let server = start_mock_server().await;
-    let apps_server = AppsTestServer::mount_with_expensive_tool(&server).await?;
+    let apps_server = AppsTestServer::mount(&server).await?;
     let mock = mount_sse_once(
         &server,
         sse(vec![
@@ -209,7 +209,7 @@ async fn token_budget_deferral_hides_expensive_app_tools() -> Result<()> {
         configured_builder(apps_server.chatgpt_base_url.clone()).with_config(|config| {
             config
                 .features
-                .enable(Feature::ToolSearchTokenBudgetDeferral)
+                .enable(Feature::ToolSearchAlwaysDeferMcpTools)
                 .expect("test config should allow feature update");
         });
     let test = builder.build(&server).await?;
@@ -225,15 +225,15 @@ async fn token_budget_deferral_hides_expensive_app_tools() -> Result<()> {
     let tools = tool_names(&body);
     assert!(
         tools.iter().any(|name| name == TOOL_SEARCH_TOOL_NAME),
-        "expensive app tools should be deferred behind tool_search: {tools:?}"
+        "small app tool sets should be deferred behind tool_search: {tools:?}"
     );
     assert!(
         !tools.iter().any(|name| name == CALENDAR_CREATE_TOOL),
-        "expensive app tool should not be directly exposed: {tools:?}"
+        "app tool should not be directly exposed: {tools:?}"
     );
     assert!(
         !tools.iter().any(|name| name == SEARCH_CALENDAR_NAMESPACE),
-        "expensive app namespace should not be directly exposed: {tools:?}"
+        "app namespace should not be directly exposed: {tools:?}"
     );
 
     Ok(())

--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -148,8 +148,8 @@ pub enum Feature {
     Apps,
     /// Enable the tool_search tool for apps.
     ToolSearch,
-    /// Use estimated tool-schema tokens instead of tool count for tool_search deferral.
-    ToolSearchTokenBudgetDeferral,
+    /// Always defer MCP tools behind tool_search instead of exposing small sets directly.
+    ToolSearchAlwaysDeferMcpTools,
     /// Expose placeholder tools for unavailable historical tool calls.
     UnavailableDummyTools,
     /// Enable discoverable tool suggestions for apps.
@@ -821,8 +821,8 @@ pub const FEATURES: &[FeatureSpec] = &[
         default_enabled: true,
     },
     FeatureSpec {
-        id: Feature::ToolSearchTokenBudgetDeferral,
-        key: "tool_search_token_budget_deferral",
+        id: Feature::ToolSearchAlwaysDeferMcpTools,
+        key: "tool_search_always_defer_mcp_tools",
         stage: Stage::UnderDevelopment,
         default_enabled: false,
     },

--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -148,6 +148,8 @@ pub enum Feature {
     Apps,
     /// Enable the tool_search tool for apps.
     ToolSearch,
+    /// Use estimated tool-schema tokens instead of tool count for tool_search deferral.
+    ToolSearchTokenBudgetDeferral,
     /// Expose placeholder tools for unavailable historical tool calls.
     UnavailableDummyTools,
     /// Enable discoverable tool suggestions for apps.
@@ -817,6 +819,12 @@ pub const FEATURES: &[FeatureSpec] = &[
         key: "tool_search",
         stage: Stage::Stable,
         default_enabled: true,
+    },
+    FeatureSpec {
+        id: Feature::ToolSearchTokenBudgetDeferral,
+        key: "tool_search_token_budget_deferral",
+        stage: Stage::UnderDevelopment,
+        default_enabled: false,
     },
     FeatureSpec {
         id: Feature::UnavailableDummyTools,


### PR DESCRIPTION
add new `tool_search_always_defer_mcp_tools` feature flag that always defers all mcp tools rather than deferring once > 100 deferrable tools.

add new tests, also move `mcp_exposure` tests into dedicated file rather than polluting `codex_tests`.