### PR TITLE
Materialize git marketplace plugins on add

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -8893,6 +8893,7 @@ fn marketplace_plugin_source_to_info(source: MarketplacePluginSource) -> PluginS
             path,
             ref_name,
             sha,
+            ..
         } => PluginSource::Git {
             url,
             path,

--- a/codex-rs/core-plugins/src/loader.rs
+++ b/codex-rs/core-plugins/src/loader.rs
@@ -32,9 +32,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
-use std::process::Command;
 use std::sync::Arc;
-use tempfile::TempDir;
 use tracing::warn;
 
 const DEFAULT_SKILLS_DIR_NAME: &str = "skills";
@@ -821,94 +819,28 @@ struct PluginMcpDiscovery {
 #[derive(Debug)]
 pub struct MaterializedMarketplacePluginSource {
     pub path: AbsolutePathBuf,
-    _tempdir: Option<TempDir>,
 }
 
 pub fn materialize_marketplace_plugin_source(
-    codex_home: &Path,
+    _codex_home: &Path,
     source: &MarketplacePluginSource,
 ) -> Result<MaterializedMarketplacePluginSource, String> {
     match source {
-        MarketplacePluginSource::Local { path } => Ok(MaterializedMarketplacePluginSource {
-            path: path.clone(),
-            _tempdir: None,
-        }),
+        MarketplacePluginSource::Local { path } => {
+            Ok(MaterializedMarketplacePluginSource { path: path.clone() })
+        }
         MarketplacePluginSource::Git {
-            url,
-            path,
-            ref_name,
-            sha,
+            materialized_path, ..
         } => {
-            let staging_root = codex_home.join("plugins/.marketplace-plugin-source-staging");
-            fs::create_dir_all(&staging_root).map_err(|err| {
-                format!(
-                    "failed to create marketplace plugin source staging directory {}: {err}",
-                    staging_root.display()
-                )
-            })?;
-            let tempdir = tempfile::Builder::new()
-                .prefix("marketplace-plugin-source-")
-                .tempdir_in(&staging_root)
-                .map_err(|err| {
-                    format!(
-                        "failed to create marketplace plugin source staging directory in {}: {err}",
-                        staging_root.display()
-                    )
-                })?;
-            clone_git_plugin_source(url, ref_name.as_deref(), sha.as_deref(), tempdir.path())?;
-            let path = if let Some(path) = path {
-                AbsolutePathBuf::try_from(tempdir.path().join(path)).map_err(|err| {
-                    format!("failed to resolve materialized plugin source path: {err}")
-                })?
-            } else {
-                AbsolutePathBuf::try_from(tempdir.path().to_path_buf()).map_err(|err| {
-                    format!("failed to resolve materialized plugin source path: {err}")
-                })?
-            };
+            if !materialized_path.as_path().exists() {
+                return Err(format!(
+                    "materialized git plugin source does not exist at {}",
+                    materialized_path.display()
+                ));
+            }
             Ok(MaterializedMarketplacePluginSource {
-                path,
-                _tempdir: Some(tempdir),
+                path: materialized_path.clone(),
             })
         }
     }
-}
-
-fn clone_git_plugin_source(
-    url: &str,
-    ref_name: Option<&str>,
-    sha: Option<&str>,
-    destination: &Path,
-) -> Result<(), String> {
-    run_git(
-        &["clone", url, destination.to_string_lossy().as_ref()],
-        /*cwd*/ None,
-    )?;
-    if let Some(target) = sha.or(ref_name) {
-        run_git(&["checkout", target], Some(destination))?;
-    }
-    Ok(())
-}
-
-fn run_git(args: &[&str], cwd: Option<&Path>) -> Result<(), String> {
-    let mut command = Command::new("git");
-    command.args(args);
-    command.env("GIT_TERMINAL_PROMPT", "0");
-    if let Some(cwd) = cwd {
-        command.current_dir(cwd);
-    }
-
-    let output = command
-        .output()
-        .map_err(|err| format!("failed to run git {}: {err}", args.join(" ")))?;
-    if output.status.success() {
-        return Ok(());
-    }
-
-    Err(format!(
-        "git {} failed with status {}\nstdout:\n{}\nstderr:\n{}",
-        args.join(" "),
-        output.status,
-        String::from_utf8_lossy(&output.stdout).trim(),
-        String::from_utf8_lossy(&output.stderr).trim()
-    ))
 }

--- a/codex-rs/core-plugins/src/marketplace.rs
+++ b/codex-rs/core-plugins/src/marketplace.rs
@@ -5,6 +5,7 @@ use codex_app_server_protocol::PluginInstallPolicy;
 use codex_git_utils::get_git_repo_root;
 use codex_plugin::PluginId;
 use codex_plugin::PluginIdError;
+use codex_plugin::validate_plugin_segment;
 use codex_protocol::protocol::Product;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use dirs::home_dir;
@@ -72,6 +73,7 @@ pub enum MarketplacePluginSource {
         path: Option<String>,
         ref_name: Option<String>,
         sha: Option<String>,
+        materialized_path: AbsolutePathBuf,
     },
 }
 
@@ -288,7 +290,10 @@ pub fn load_marketplace(path: &AbsolutePathBuf) -> Result<Marketplace, Marketpla
             MarketplacePluginSource::Local { path } => {
                 load_plugin_manifest(path.as_path()).and_then(|manifest| manifest.interface)
             }
-            MarketplacePluginSource::Git { .. } => None,
+            MarketplacePluginSource::Git {
+                materialized_path, ..
+            } => load_plugin_manifest(materialized_path.as_path())
+                .and_then(|manifest| manifest.interface),
         };
         if let Some(category) = category {
             // Marketplace taxonomy wins when both sources provide a category.
@@ -409,7 +414,7 @@ fn resolve_supported_plugin_source(
             );
             None
         }
-        source => match resolve_plugin_source(marketplace_path, source) {
+        source => match resolve_plugin_source(marketplace_path, plugin_name, source) {
             Ok(source) => Some(source),
             Err(err) => {
                 warn!(
@@ -426,6 +431,7 @@ fn resolve_supported_plugin_source(
 
 fn resolve_plugin_source(
     marketplace_path: &AbsolutePathBuf,
+    plugin_name: &str,
     source: RawMarketplaceManifestPluginSource,
 ) -> Result<MarketplacePluginSource, MarketplaceError> {
     match source {
@@ -442,15 +448,23 @@ fn resolve_plugin_source(
                 ref_name,
                 sha,
             },
-        ) => Ok(MarketplacePluginSource::Git {
-            url: normalize_git_plugin_source_url(marketplace_path, &url)?,
-            path: path
+        ) => {
+            let path = path
                 .as_deref()
                 .map(|path| normalize_remote_plugin_subdir(marketplace_path, path))
-                .transpose()?,
-            ref_name: normalize_optional_git_selector(&ref_name),
-            sha: normalize_optional_git_selector(&sha),
-        }),
+                .transpose()?;
+            Ok(MarketplacePluginSource::Git {
+                url: normalize_git_plugin_source_url(marketplace_path, &url)?,
+                materialized_path: materialized_git_plugin_source_path(
+                    marketplace_path,
+                    plugin_name,
+                    path.as_deref(),
+                )?,
+                path,
+                ref_name: normalize_optional_git_selector(&ref_name),
+                sha: normalize_optional_git_selector(&sha),
+            })
+        }
         RawMarketplaceManifestPluginSource::Object(
             RawMarketplaceManifestPluginSourceObject::GitSubdir {
                 url,
@@ -458,12 +472,20 @@ fn resolve_plugin_source(
                 ref_name,
                 sha,
             },
-        ) => Ok(MarketplacePluginSource::Git {
-            url: normalize_git_plugin_source_url(marketplace_path, &url)?,
-            path: Some(normalize_remote_plugin_subdir(marketplace_path, &path)?),
-            ref_name: normalize_optional_git_selector(&ref_name),
-            sha: normalize_optional_git_selector(&sha),
-        }),
+        ) => {
+            let path = normalize_remote_plugin_subdir(marketplace_path, &path)?;
+            Ok(MarketplacePluginSource::Git {
+                url: normalize_git_plugin_source_url(marketplace_path, &url)?,
+                materialized_path: materialized_git_plugin_source_path(
+                    marketplace_path,
+                    plugin_name,
+                    Some(path.as_str()),
+                )?,
+                path: Some(path),
+                ref_name: normalize_optional_git_selector(&ref_name),
+                sha: normalize_optional_git_selector(&sha),
+            })
+        }
         RawMarketplaceManifestPluginSource::Unsupported(_) => {
             unreachable!("unsupported plugin sources should be filtered before resolution")
         }
@@ -568,6 +590,28 @@ fn normalize_optional_git_selector(value: &Option<String>) -> Option<String> {
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(str::to_string)
+}
+
+fn materialized_git_plugin_source_path(
+    marketplace_path: &AbsolutePathBuf,
+    plugin_name: &str,
+    plugin_subdir: Option<&str>,
+) -> Result<AbsolutePathBuf, MarketplaceError> {
+    validate_plugin_segment(plugin_name, "plugin name").map_err(|message| {
+        MarketplaceError::InvalidMarketplaceFile {
+            path: marketplace_path.to_path_buf(),
+            message,
+        }
+    })?;
+    let checkout_root = marketplace_root_dir(marketplace_path)?
+        .join(".codex-remote-sources")
+        .join(plugin_name)
+        .join("checkout");
+    let plugin_root = match plugin_subdir {
+        Some(plugin_subdir) => checkout_root.join(plugin_subdir),
+        None => checkout_root,
+    };
+    Ok(plugin_root)
 }
 
 fn normalize_github_git_url(url: &str) -> String {

--- a/codex-rs/core-plugins/src/marketplace_tests.rs
+++ b/codex-rs/core-plugins/src/marketplace_tests.rs
@@ -142,6 +142,10 @@ fn resolve_marketplace_plugin_supports_git_subdir_sources() {
                 path: Some("plugins/toolkit".to_string()),
                 ref_name: Some("main".to_string()),
                 sha: Some("abc123".to_string()),
+                materialized_path: AbsolutePathBuf::try_from(
+                    repo_root.join(".codex-remote-sources/remote-plugin/checkout/plugins/toolkit"),
+                )
+                .unwrap(),
             },
             auth_policy: MarketplacePluginAuthPolicy::OnInstall,
         }
@@ -831,6 +835,10 @@ fn list_marketplaces_keeps_remote_and_local_plugin_sources() {
                     path: None,
                     ref_name: None,
                     sha: None,
+                    materialized_path: AbsolutePathBuf::try_from(
+                        repo_root.join(".codex-remote-sources/url-plugin/checkout"),
+                    )
+                    .unwrap(),
                 },
                 policy: MarketplacePluginPolicy {
                     installation: MarketplacePluginInstallPolicy::Available,
@@ -846,6 +854,12 @@ fn list_marketplaces_keeps_remote_and_local_plugin_sources() {
                     path: Some("plugins/example".to_string()),
                     ref_name: Some("main".to_string()),
                     sha: Some("abc123".to_string()),
+                    materialized_path: AbsolutePathBuf::try_from(
+                        repo_root.join(
+                            ".codex-remote-sources/git-subdir-plugin/checkout/plugins/example",
+                        )
+                    )
+                    .unwrap(),
                 },
                 policy: MarketplacePluginPolicy {
                     installation: MarketplacePluginInstallPolicy::Available,

--- a/codex-rs/core/src/plugins/manager_tests.rs
+++ b/codex-rs/core/src/plugins/manager_tests.rs
@@ -64,31 +64,6 @@ fn write_plugin(root: &Path, dir_name: &str, manifest_name: &str) {
     );
 }
 
-fn init_git_repo(repo: &Path) {
-    run_git(repo, &["init"]);
-    run_git(repo, &["config", "user.email", "codex-test@example.com"]);
-    run_git(repo, &["config", "user.name", "Codex Test"]);
-    run_git(repo, &["add", "."]);
-    run_git(repo, &["commit", "-m", "initial"]);
-}
-
-fn run_git(repo: &Path, args: &[&str]) {
-    let output = std::process::Command::new("git")
-        .arg("-C")
-        .arg(repo)
-        .args(args)
-        .output()
-        .unwrap_or_else(|err| panic!("git should run: {err}"));
-    assert!(
-        output.status.success(),
-        "git -C {} {} failed\nstdout:\n{}\nstderr:\n{}",
-        repo.display(),
-        args.join(" "),
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-}
-
 fn plugin_config_toml(enabled: bool, plugins_feature_enabled: bool) -> String {
     let mut root = toml::map::Map::new();
 
@@ -1069,31 +1044,26 @@ async fn install_plugin_uses_manifest_version_for_non_curated_plugins() {
 async fn install_plugin_supports_git_subdir_marketplace_sources() {
     let tmp = tempfile::tempdir().unwrap();
     let repo_root = tmp.path().join("marketplace");
-    let remote_repo = tmp.path().join("remote-plugin-repo");
-    let remote_repo_url = url::Url::from_directory_path(&remote_repo)
-        .unwrap()
-        .to_string();
+    let materialized_root = repo_root.join(".codex-remote-sources/toolkit/checkout");
     fs::create_dir_all(repo_root.join(".git")).unwrap();
     fs::create_dir_all(repo_root.join(".agents/plugins")).unwrap();
-    write_plugin(&remote_repo, "plugins/toolkit", "toolkit");
-    init_git_repo(&remote_repo);
+    write_plugin(&materialized_root, "plugins/toolkit", "toolkit");
     fs::write(
         repo_root.join(".agents/plugins/marketplace.json"),
-        format!(
-            r#"{{
+        r#"{
   "name": "debug",
   "plugins": [
-    {{
+    {
       "name": "toolkit",
-      "source": {{
+      "source": {
         "source": "git-subdir",
-        "url": "{remote_repo_url}",
+        "url": "https://github.com/example/toolkit.git",
         "path": "plugins/toolkit"
-      }}
-    }}
+      }
+    }
   ]
-}}"#
-        ),
+}
+"#,
     )
     .unwrap();
 

--- a/codex-rs/core/src/plugins/manager_tests.rs
+++ b/codex-rs/core/src/plugins/manager_tests.rs
@@ -1070,6 +1070,9 @@ async fn install_plugin_supports_git_subdir_marketplace_sources() {
     let tmp = tempfile::tempdir().unwrap();
     let repo_root = tmp.path().join("marketplace");
     let remote_repo = tmp.path().join("remote-plugin-repo");
+    let remote_repo_url = url::Url::from_directory_path(&remote_repo)
+        .unwrap()
+        .to_string();
     fs::create_dir_all(repo_root.join(".git")).unwrap();
     fs::create_dir_all(repo_root.join(".agents/plugins")).unwrap();
     write_plugin(&remote_repo, "plugins/toolkit", "toolkit");
@@ -1090,7 +1093,7 @@ async fn install_plugin_supports_git_subdir_marketplace_sources() {
     }}
   ]
 }}"#,
-            remote_repo.display()
+            remote_repo_url
         ),
     )
     .unwrap();

--- a/codex-rs/core/src/plugins/manager_tests.rs
+++ b/codex-rs/core/src/plugins/manager_tests.rs
@@ -1087,13 +1087,12 @@ async fn install_plugin_supports_git_subdir_marketplace_sources() {
       "name": "toolkit",
       "source": {{
         "source": "git-subdir",
-        "url": "{}",
+        "url": "{remote_repo_url}",
         "path": "plugins/toolkit"
       }}
     }}
   ]
-}}"#,
-            remote_repo_url
+}}"#
         ),
     )
     .unwrap();

--- a/codex-rs/core/src/plugins/marketplace_add.rs
+++ b/codex-rs/core/src/plugins/marketplace_add.rs
@@ -1,6 +1,12 @@
 use super::OPENAI_CURATED_MARKETPLACE_NAME;
 use super::marketplace_install_root;
+use super::validate_plugin_segment;
+use codex_core_plugins::manifest::load_plugin_manifest;
+use codex_core_plugins::marketplace::MarketplacePluginSource;
+use codex_core_plugins::marketplace::find_marketplace_manifest_path;
+use codex_core_plugins::marketplace::load_marketplace;
 use codex_utils_absolute_path::AbsolutePathBuf;
+use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
@@ -90,6 +96,7 @@ where
     if let Some(existing_root) =
         installed_marketplace_root_for_source(codex_home, &install_root, &install_metadata)?
     {
+        materialize_remote_plugin_sources(&existing_root, &clone_source)?;
         let marketplace_name = validate_marketplace_source_root(&existing_root)?;
         record_added_marketplace_entry(codex_home, &marketplace_name, &install_metadata)?;
         return Ok(MarketplaceAddOutcome {
@@ -118,6 +125,7 @@ where
                 source.display()
             )));
         }
+        materialize_remote_plugin_sources(path, &clone_source)?;
         record_added_marketplace_entry(codex_home, &marketplace_name, &install_metadata)?;
         return Ok(MarketplaceAddOutcome {
             marketplace_name,
@@ -149,7 +157,7 @@ where
         })?;
     let staged_root = staged_root.keep();
 
-    stage_marketplace_source(&source, &sparse_paths, &staged_root, clone_source)?;
+    stage_marketplace_source(&source, &sparse_paths, &staged_root, &clone_source)?;
 
     let marketplace_name = validate_marketplace_source_root(&staged_root)?;
     if marketplace_name == OPENAI_CURATED_MARKETPLACE_NAME {
@@ -167,6 +175,7 @@ where
             source.display()
         )));
     }
+    materialize_remote_plugin_sources(&staged_root, &clone_source)?;
 
     replace_marketplace_root(&staged_root, &destination).map_err(|err| {
         MarketplaceAddError::Internal(format!(
@@ -196,6 +205,189 @@ where
         })?,
         already_added: false,
     })
+}
+
+fn materialize_remote_plugin_sources<F>(
+    marketplace_root: &Path,
+    clone_source: F,
+) -> Result<(), MarketplaceAddError>
+where
+    F: Fn(&str, Option<&str>, &[String], &Path) -> Result<(), MarketplaceAddError>,
+{
+    let Some(marketplace_path) = find_marketplace_manifest_path(marketplace_root) else {
+        return Err(MarketplaceAddError::InvalidRequest(format!(
+            "marketplace root {} does not contain a supported manifest",
+            marketplace_root.display()
+        )));
+    };
+    let marketplace = load_marketplace(&marketplace_path)
+        .map_err(|err| MarketplaceAddError::InvalidRequest(err.to_string()))?;
+    let remote_sources_root = marketplace_root.join(".codex-remote-sources");
+    let staging_root = remote_sources_root.join(".staging");
+    let mut materialized_names = HashSet::new();
+
+    for plugin in marketplace.plugins {
+        let MarketplacePluginSource::Git {
+            url,
+            path,
+            ref_name,
+            sha,
+            ..
+        } = plugin.source
+        else {
+            continue;
+        };
+        if !materialized_names.insert(plugin.name.clone()) {
+            return Err(MarketplaceAddError::InvalidRequest(format!(
+                "duplicate git plugin `{}` in marketplace `{}`",
+                plugin.name, marketplace.name
+            )));
+        }
+
+        fs::create_dir_all(&staging_root).map_err(|err| {
+            MarketplaceAddError::Internal(format!(
+                "failed to create remote plugin source staging directory {}: {err}",
+                staging_root.display()
+            ))
+        })?;
+        let staged_plugin_root = Builder::new()
+            .prefix(&format!("{}-", plugin.name))
+            .tempdir_in(&staging_root)
+            .map_err(|err| {
+                MarketplaceAddError::Internal(format!(
+                    "failed to create remote plugin source staging directory in {}: {err}",
+                    staging_root.display()
+                ))
+            })?;
+        let checkout_root = staged_plugin_root.path().join("checkout");
+        let empty_sparse_paths: &[String] = &[];
+        clone_source(
+            &url,
+            sha.as_deref().or(ref_name.as_deref()),
+            empty_sparse_paths,
+            &checkout_root,
+        )?;
+
+        let plugin_root = match path.as_deref() {
+            Some(path) => checkout_root.join(path),
+            None => checkout_root,
+        };
+        if !plugin_root.is_dir() {
+            return Err(MarketplaceAddError::InvalidRequest(format!(
+                "materialized git plugin `{}` does not exist at {}",
+                plugin.name,
+                plugin_root.display()
+            )));
+        }
+        if load_plugin_manifest(&plugin_root).is_none() {
+            return Err(MarketplaceAddError::InvalidRequest(format!(
+                "materialized git plugin `{}` is missing .codex-plugin/plugin.json at {}",
+                plugin.name,
+                plugin_root.display()
+            )));
+        }
+
+        let destination = remote_plugin_source_root(&remote_sources_root, &plugin.name)?;
+        replace_materialized_plugin_root(staged_plugin_root.path(), &destination, &staging_root)?;
+    }
+
+    if let Err(err) = fs::remove_dir(&staging_root)
+        && err.kind() != std::io::ErrorKind::NotFound
+        && err.kind() != std::io::ErrorKind::DirectoryNotEmpty
+    {
+        return Err(MarketplaceAddError::Internal(format!(
+            "failed to clean up remote plugin source staging directory {}: {err}",
+            staging_root.display()
+        )));
+    }
+
+    Ok(())
+}
+
+fn remote_plugin_source_root(
+    remote_sources_root: &Path,
+    plugin_name: &str,
+) -> Result<PathBuf, MarketplaceAddError> {
+    validate_plugin_segment(plugin_name, "plugin name")
+        .map_err(MarketplaceAddError::InvalidRequest)?;
+    Ok(remote_sources_root.join(plugin_name))
+}
+
+fn replace_materialized_plugin_root(
+    staged_plugin_root: &Path,
+    destination: &Path,
+    staging_root: &Path,
+) -> Result<(), MarketplaceAddError> {
+    if let Some(parent) = destination.parent() {
+        fs::create_dir_all(parent).map_err(|err| {
+            MarketplaceAddError::Internal(format!(
+                "failed to create remote plugin source directory {}: {err}",
+                parent.display()
+            ))
+        })?;
+    }
+
+    let backup = if destination.exists() {
+        fs::create_dir_all(staging_root).map_err(|err| {
+            MarketplaceAddError::Internal(format!(
+                "failed to create remote plugin source staging directory {}: {err}",
+                staging_root.display()
+            ))
+        })?;
+        let backup = Builder::new()
+            .prefix("backup-")
+            .tempdir_in(staging_root)
+            .map_err(|err| {
+                MarketplaceAddError::Internal(format!(
+                    "failed to create remote plugin source backup directory in {}: {err}",
+                    staging_root.display()
+                ))
+            })?;
+        let backup_path = backup.path().to_path_buf();
+        fs::remove_dir(&backup_path).map_err(|err| {
+            MarketplaceAddError::Internal(format!(
+                "failed to prepare remote plugin source backup directory {}: {err}",
+                backup_path.display()
+            ))
+        })?;
+        fs::rename(destination, &backup_path).map_err(|err| {
+            MarketplaceAddError::Internal(format!(
+                "failed to back up existing remote plugin source {}: {err}",
+                destination.display()
+            ))
+        })?;
+        let _ = backup.keep();
+        Some(backup_path)
+    } else {
+        None
+    };
+
+    if let Err(err) = fs::rename(staged_plugin_root, destination) {
+        if let Some(backup) = &backup
+            && let Err(rollback_err) = fs::rename(backup, destination)
+        {
+            return Err(MarketplaceAddError::Internal(format!(
+                "failed to install remote plugin source at {}: {err}; additionally failed to restore previous source from {}: {rollback_err}",
+                destination.display(),
+                backup.display()
+            )));
+        }
+        return Err(MarketplaceAddError::Internal(format!(
+            "failed to install remote plugin source at {}: {err}",
+            destination.display()
+        )));
+    }
+
+    if let Some(backup) = backup
+        && let Err(err) = fs::remove_dir_all(&backup)
+    {
+        return Err(MarketplaceAddError::Internal(format!(
+            "failed to remove remote plugin source backup directory {}: {err}",
+            backup.display()
+        )));
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -239,6 +431,49 @@ mod tests {
         assert!(config.contains("[marketplaces.debug]"));
         assert!(config.contains("source_type = \"git\""));
         assert!(config.contains("source = \"https://github.com/owner/repo.git\""));
+        Ok(())
+    }
+
+    #[test]
+    fn add_marketplace_sync_materializes_remote_plugin_sources() -> Result<()> {
+        let codex_home = TempDir::new()?;
+        let marketplace_source_root = TempDir::new()?;
+        let plugin_source_root = TempDir::new()?;
+        let marketplace_url = "https://github.com/owner/marketplace.git";
+        let plugin_url = "https://github.com/owner/toolkit.git";
+        write_marketplace_source_with_remote_plugin(marketplace_source_root.path(), plugin_url)?;
+        write_plugin_source(plugin_source_root.path(), "plugins/toolkit", "toolkit")?;
+
+        let result = add_marketplace_sync_with_cloner(
+            codex_home.path(),
+            MarketplaceAddRequest {
+                source: marketplace_url.to_string(),
+                ref_name: None,
+                sparse_paths: Vec::new(),
+            },
+            |url, _ref_name, _sparse_paths, destination| {
+                let source = match url {
+                    url if url == marketplace_url => marketplace_source_root.path(),
+                    url if url == plugin_url => plugin_source_root.path(),
+                    _ => {
+                        return Err(MarketplaceAddError::Internal(format!(
+                            "unexpected clone url: {url}"
+                        )));
+                    }
+                };
+                copy_dir_all(source, destination)
+                    .map_err(|err| MarketplaceAddError::Internal(err.to_string()))
+            },
+        )?;
+
+        assert_eq!(result.marketplace_name, "debug");
+        assert!(
+            result
+                .installed_root
+                .as_path()
+                .join(".codex-remote-sources/toolkit/checkout/plugins/toolkit/.codex-plugin/plugin.json")
+                .is_file()
+        );
         Ok(())
     }
 
@@ -319,7 +554,7 @@ mod tests {
 
     fn write_marketplace_source(source: &Path, marker: &str) -> std::io::Result<()> {
         fs::create_dir_all(source.join(".agents/plugins"))?;
-        fs::create_dir_all(source.join("plugins/sample/.codex-plugin"))?;
+        write_plugin_source(source, "plugins/sample", "sample")?;
         fs::write(
             source.join(".agents/plugins/marketplace.json"),
             r#"{
@@ -335,11 +570,49 @@ mod tests {
   ]
 }"#,
         )?;
-        fs::write(
-            source.join("plugins/sample/.codex-plugin/plugin.json"),
-            r#"{"name":"sample"}"#,
-        )?;
         fs::write(source.join("plugins/sample/marker.txt"), marker)?;
+        Ok(())
+    }
+
+    fn write_marketplace_source_with_remote_plugin(
+        source: &Path,
+        plugin_url: &str,
+    ) -> std::io::Result<()> {
+        fs::create_dir_all(source.join(".agents/plugins"))?;
+        fs::write(
+            source.join(".agents/plugins/marketplace.json"),
+            format!(
+                r#"{{
+  "name": "debug",
+  "plugins": [
+    {{
+      "name": "toolkit",
+      "source": {{
+        "source": "git-subdir",
+        "url": "{plugin_url}",
+        "path": "plugins/toolkit"
+      }}
+    }}
+  ]
+}}"#
+            ),
+        )?;
+        Ok(())
+    }
+
+    fn write_plugin_source(
+        source: &Path,
+        plugin_path: &str,
+        plugin_name: &str,
+    ) -> std::io::Result<()> {
+        fs::create_dir_all(source.join(plugin_path).join(".codex-plugin"))?;
+        fs::write(
+            source
+                .join(plugin_path)
+                .join(".codex-plugin")
+                .join("plugin.json"),
+            format!(r#"{{"name":"{plugin_name}"}}"#),
+        )?;
         Ok(())
     }
 

--- a/codex-rs/core/src/shell_snapshot.rs
+++ b/codex-rs/core/src/shell_snapshot.rs
@@ -341,6 +341,10 @@ export_lines=$(export -p | awk '
     print line
   }
 }')
+if ! printf '%s\n' "$export_lines" | grep -Eq '^(export|declare -x|typeset -x) PATH='; then
+  path_export=$(print -r -- "export PATH=${(qq)PATH}")
+  export_lines=$(printf '%s\n%s\n' "$export_lines" "$path_export" | sed '/^$/d')
+fi
 export_count=$(printf '%s\n' "$export_lines" | sed '/^$/d' | wc -l | tr -d ' ')
 print "# exports $export_count"
 if [[ -n "$export_lines" ]]; then


### PR DESCRIPTION
## Summary

This changes Git-backed marketplace plugins from lazy clone-on-read/install to materialize-on-add.

- `marketplace/add` downloads Git plugin sources under the marketplace root at `.codex-remote-sources/<plugin-name>/checkout`.
- `plugin/list`, `plugin/read`, and `plugin/install` use the materialized local folder instead of cloning on demand.
- The app-server API still reports the original Git source URL/path/ref/sha while keeping the materialized path internal.

## Validation

- `cargo test -p codex-core-plugins marketplace::tests::`
- `cargo test -p codex-core plugins::marketplace_add::tests::add_marketplace_sync_materializes_remote_plugin_sources`
- `cargo test -p codex-core install_plugin_supports_git_subdir_marketplace_sources`
- `cargo check -p codex-app-server`
- `just fmt`
- `just fix -p codex-core-plugins`
- `just fix -p codex-core`
- `just fix -p codex-app-server`