### PR TITLE
chore: unify memory drop endpoints

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -212,6 +212,7 @@ use codex_core::SteerInputError;
 use codex_core::ThreadConfigSnapshot;
 use codex_core::ThreadManager;
 use codex_core::append_thread_name;
+use codex_core::clear_memory_roots_contents;
 use codex_core::config::Config;
 use codex_core::config::ConfigOverrides;
 use codex_core::config::NetworkProxyAuditMetadata;
@@ -3080,48 +3081,12 @@ impl CodexMessageProcessor {
             return;
         }
 
-        let memory_root = self.config.codex_home.join("memories");
-        let memory_extensions_root = self.config.codex_home.join("memories_extensions");
-        let clear_memory_root_result: std::io::Result<()> = async {
-            for directory in [memory_root.as_path(), memory_extensions_root.as_path()] {
-                match tokio::fs::symlink_metadata(directory).await {
-                    Ok(metadata) if metadata.file_type().is_symlink() => {
-                        return Err(std::io::Error::new(
-                            std::io::ErrorKind::InvalidInput,
-                            format!(
-                                "refusing to clear symlinked memory root {}",
-                                directory.display()
-                            ),
-                        ));
-                    }
-                    Ok(_) => {}
-                    Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
-                    Err(err) => return Err(err),
-                }
-
-                tokio::fs::create_dir_all(directory).await?;
-                let mut entries = tokio::fs::read_dir(directory).await?;
-                while let Some(entry) = entries.next_entry().await? {
-                    let path = entry.path();
-                    let file_type = entry.file_type().await?;
-                    if file_type.is_dir() {
-                        tokio::fs::remove_dir_all(path).await?;
-                    } else {
-                        tokio::fs::remove_file(path).await?;
-                    }
-                }
-            }
-
-            Ok(())
-        }
-        .await;
-
-        if let Err(err) = clear_memory_root_result {
+        if let Err(err) = clear_memory_roots_contents(&self.config.codex_home).await {
             self.send_internal_error(
                 request_id,
                 format!(
-                    "failed to clear memory directory {}: {err}",
-                    memory_root.display()
+                    "failed to clear memory directories under {}: {err}",
+                    self.config.codex_home.display()
                 ),
             )
             .await;

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -49,6 +49,7 @@ use crate::mcp_cmd::McpCli;
 use crate::responses_cmd::ResponsesCommand;
 use crate::responses_cmd::run_responses_command;
 
+use codex_core::clear_memory_roots_contents;
 use codex_core::config::Config;
 use codex_core::config::ConfigOverrides;
 use codex_core::config::edit::ConfigEditsBuilder;
@@ -1282,27 +1283,17 @@ async fn run_debug_clear_memories_command(
         cleared_state_db = true;
     }
 
-    let memory_root = config.codex_home.join("memories");
-    let removed_memory_root = match tokio::fs::remove_dir_all(&memory_root).await {
-        Ok(()) => true,
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => false,
-        Err(err) => return Err(err.into()),
-    };
+    clear_memory_roots_contents(&config.codex_home).await?;
 
     let mut message = if cleared_state_db {
         format!("Cleared memory state from {}.", state_path.display())
     } else {
         format!("No state db found at {}.", state_path.display())
     };
-
-    if removed_memory_root {
-        message.push_str(&format!(" Removed {}.", memory_root.display()));
-    } else {
-        message.push_str(&format!(
-            " No memory directory found at {}.",
-            memory_root.display()
-        ));
-    }
+    message.push_str(&format!(
+        " Cleared memory directories under {}.",
+        config.codex_home.display()
+    ));
 
     println!("{message}");
 

--- a/codex-rs/cli/tests/debug_clear_memories.rs
+++ b/codex-rs/cli/tests/debug_clear_memories.rs
@@ -125,7 +125,8 @@ INSERT INTO jobs (
     .fetch_one(&pool)
     .await?;
     assert_eq!(memory_jobs_count, 0);
-    assert!(!memory_root.exists());
+    assert!(memory_root.exists());
+    assert_eq!(std::fs::read_dir(memory_root)?.count(), 0);
 
     Ok(())
 }

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -5567,15 +5567,15 @@ mod handlers {
             errors.push("state db unavailable; memory rows were not cleared".to_string());
         }
 
-        let memory_root = crate::memories::memory_root(&config.codex_home);
-        if let Err(err) = crate::memories::clear_memory_root_contents(&memory_root).await {
+        if let Err(err) = crate::memories::clear_memory_roots_contents(&config.codex_home).await {
             errors.push(format!(
-                "failed clearing memory directory {}: {err}",
-                memory_root.display()
+                "failed clearing memory directories under {}: {err}",
+                config.codex_home.display()
             ));
         }
 
         if errors.is_empty() {
+            let memory_root = crate::memories::memory_root(&config.codex_home);
             sess.send_event_raw(Event {
                 id: sub_id,
                 msg: EventMsg::Warning(WarningEvent {

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -59,6 +59,7 @@ pub use codex_mcp::SandboxState;
 mod mcp_openai_file;
 mod mcp_tool_call;
 mod memories;
+pub use memories::clear_memory_roots_contents;
 pub(crate) mod mention_syntax;
 pub(crate) mod message_history;
 pub(crate) mod utils;

--- a/codex-rs/core/src/memories/control.rs
+++ b/codex-rs/core/src/memories/control.rs
@@ -1,5 +1,16 @@
 use std::path::Path;
 
+pub async fn clear_memory_roots_contents(codex_home: &Path) -> std::io::Result<()> {
+    for memory_root in [
+        codex_home.join("memories"),
+        codex_home.join("memories_extensions"),
+    ] {
+        clear_memory_root_contents(memory_root.as_path()).await?;
+    }
+
+    Ok(())
+}
+
 pub(crate) async fn clear_memory_root_contents(memory_root: &Path) -> std::io::Result<()> {
     match tokio::fs::symlink_metadata(memory_root).await {
         Ok(metadata) if metadata.file_type().is_symlink() => {

--- a/codex-rs/core/src/memories/mod.rs
+++ b/codex-rs/core/src/memories/mod.rs
@@ -17,7 +17,7 @@ pub(crate) mod usage;
 
 use codex_protocol::openai_models::ReasoningEffort;
 
-pub(crate) use control::clear_memory_root_contents;
+pub use control::clear_memory_roots_contents;
 /// Starts the memory startup pipeline for eligible root sessions.
 /// This is the single entrypoint that `codex` uses to trigger memory startup.
 ///

--- a/codex-rs/core/src/memories/tests.rs
+++ b/codex-rs/core/src/memories/tests.rs
@@ -1,6 +1,6 @@
+use super::control::clear_memory_root_contents;
 use super::storage::rebuild_raw_memories_file_from_memories;
 use super::storage::sync_rollout_summaries_from_memories;
-use crate::memories::clear_memory_root_contents;
 use crate::memories::ensure_layout;
 use crate::memories::memory_root;
 use crate::memories::raw_memories_file;


### PR DESCRIPTION
Unify all the memories drop behind a single implementation that drops both the main memories and the extensions