### PR TITLE
debug: windows flake

### DIFF
--- a/.github/scripts/run-bazel-ci.sh
+++ b/.github/scripts/run-bazel-ci.sh
@@ -94,6 +94,11 @@ print_bazel_test_log_tails() {
     local rel_path="${target#//}"
     rel_path="${rel_path/://}"
     local test_log="${testlogs_dir}/${rel_path}/test.log"
+    local reported_test_log
+    reported_test_log="$(grep -F "FAIL: ${target} " "$console_log" | sed -nE 's#.* \(see ([^)]+/test\.log)\).*#\1#p' | head -n 1 || true)"
+    if [[ -n "$reported_test_log" ]]; then
+      test_log="$reported_test_log"
+    fi
 
     echo "::group::Bazel test log tail for ${target}"
     if [[ -f "$test_log" ]]; then

--- a/codex-rs/app-server/tests/suite/v2/thread_unsubscribe.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_unsubscribe.rs
@@ -130,9 +130,9 @@ async fn thread_unsubscribe_keeps_thread_loaded_until_idle_timeout() -> Result<(
 async fn thread_unsubscribe_during_turn_keeps_turn_running() -> Result<()> {
     #[cfg(target_os = "windows")]
     let shell_command = vec![
-        "powershell".to_string(),
-        "-Command".to_string(),
-        "Start-Sleep -Seconds 1".to_string(),
+        "Start-Sleep".to_string(),
+        "-Seconds".to_string(),
+        "1".to_string(),
     ];
     #[cfg(not(target_os = "windows"))]
     let shell_command = vec!["sleep".to_string(), "1".to_string()];


### PR DESCRIPTION
Make sure Bazel logs shows every errors so that we can debug flakes + fix a small flake on Windows by updating the sleep command to a `Start-Sleep` instead of a PowerShell nested command (otherwise we had double nesting which is absurdely slow) 