### PR TITLE
nit: get rid of an expect

### DIFF
--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -1223,11 +1223,15 @@ impl SandboxPolicy {
 
                 // Include /tmp on Unix unless explicitly excluded.
                 if cfg!(unix) && !exclude_slash_tmp {
-                    #[allow(clippy::expect_used)]
-                    let slash_tmp =
-                        AbsolutePathBuf::from_absolute_path("/tmp").expect("/tmp is absolute");
-                    if slash_tmp.as_path().is_dir() {
-                        roots.push(slash_tmp);
+                    match AbsolutePathBuf::from_absolute_path("/tmp") {
+                        Ok(slash_tmp) => {
+                            if slash_tmp.as_path().is_dir() {
+                                roots.push(slash_tmp);
+                            }
+                        }
+                        Err(e) => {
+                            error!("Ignoring invalid /tmp for sandbox writable root: {e}");
+                        }
                     }
                 }
 


### PR DESCRIPTION
Get rid of an `expect()` that caused a `panic` in the TUI

<img width="1320" height="415" alt="Screenshot 2026-04-16 at 15 30 20" src="https://github.com/user-attachments/assets/588aaf6f-b009-4b58-8daf-56c3a9d6fe3b" />


Basically in `from_absolute_path` there is a `absolutize::absolutize` that calls a `current_dir()` . But the dir in which Codex was running got re-generated (because of Codex I guess but I can't exactly see the source). So `current_dir()` returns an `ENOENT` and 💥 