### PR TITLE
Fix deferred MCP fallback handler registration

### DIFF
--- a/codex-rs/core/src/tools/spec.rs
+++ b/codex-rs/core/src/tools/spec.rs
@@ -169,6 +169,21 @@ pub(crate) fn build_specs_with_discoverable_tools(
         .iter()
         .map(|configured_tool| configured_tool.name().to_string())
         .collect::<HashSet<_>>();
+    let direct_mcp_tool_names = mcp_tools
+        .as_ref()
+        .map(|tools| {
+            tools
+                .values()
+                .map(ToolInfo::canonical_tool_name)
+                .collect::<HashSet<_>>()
+        })
+        .unwrap_or_default();
+    let planned_mcp_handler_names = plan
+        .handlers
+        .iter()
+        .filter(|handler| handler.kind == ToolHandlerKind::Mcp)
+        .map(|handler| handler.name.clone())
+        .collect::<HashSet<_>>();
 
     for spec in plan.specs {
         if spec.supports_parallel_tool_calls {
@@ -285,12 +300,14 @@ pub(crate) fn build_specs_with_discoverable_tools(
         }
     }
     if let Some(deferred_mcp_tools) = deferred_mcp_tools.as_ref() {
-        for (name, _) in deferred_mcp_tools.iter().filter(|(name, _)| {
-            !mcp_tools
-                .as_ref()
-                .is_some_and(|tools| tools.contains_key(*name))
-        }) {
-            builder.register_handler(name.clone(), mcp_handler.clone());
+        for tool in deferred_mcp_tools.values() {
+            let tool_name = tool.canonical_tool_name();
+            if direct_mcp_tool_names.contains(&tool_name)
+                || planned_mcp_handler_names.contains(&tool_name)
+            {
+                continue;
+            }
+            builder.register_handler(tool_name, mcp_handler.clone());
         }
     }
 

--- a/codex-rs/core/src/tools/spec_tests.rs
+++ b/codex-rs/core/src/tools/spec_tests.rs
@@ -993,6 +993,8 @@ async fn search_tool_registers_namespaced_mcp_tool_aliases() {
     assert!(registry.has_handler(&ToolName::plain(TOOL_SEARCH_TOOL_NAME)));
     assert!(registry.has_handler(&app_alias));
     assert!(registry.has_handler(&mcp_alias));
+    assert!(!registry.has_handler(&ToolName::plain("mcp__codex_apps__calendar_create_event")));
+    assert!(!registry.has_handler(&ToolName::plain("mcp__rmcp__echo")));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Follow-up fix for #17404's MCP `ToolName`/namespaced handler registration work.

While working on draft PR #17849 (`tool-search-for-dynamic-tools`), we hit adjacent fallout from the MCP registration refactor: most MCP handler registration now uses `ToolInfo::canonical_tool_name()`, but the fallback registration loop for deferred MCP tools in `core/src/tools/spec.rs` still used the deferred tools map key directly.

That map key is a `String`, so passing it to `register_handler` creates a plain `ToolName`. For deferred MCP tools this can register flattened aliases such as `mcp__codex_apps__calendar_create_event` instead of the canonical namespaced identity `ToolName::namespaced("mcp__codex_apps__calendar", "_create_event")`. That diverges from the new router/invocation standard and can leave stale plain aliases in the runtime registry.

## Changes

- Track canonical direct MCP tool names instead of comparing deferred/direct map keys.
- Track MCP handlers already emitted by the registry plan, so the fallback does not duplicate registrations that were already planned with canonical `ToolName`s.
- Register fallback deferred MCP handlers from `ToolInfo::canonical_tool_name()`.
- Extend the existing namespaced MCP handler test to assert the old flattened plain aliases are not registered.

## Testing

- `cargo test -p codex-core search_tool_registers_namespaced_mcp_tool_aliases`
- `cargo test -p codex-core search_tool`
- `just fix -p codex-core`