### PR TITLE
Upgrade workflows to larger runners

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -31,8 +31,14 @@ jobs:
           # Linux
           - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
+            runs_on:
+              group: codex-runners
+              labels: codex-linux-x64
           - os: ubuntu-24.04
             target: x86_64-unknown-linux-musl
+            runs_on:
+              group: codex-runners
+              labels: codex-linux-x64
           # 2026-02-27 Bazel tests have been flaky on arm in CI.
           # Disable until we can investigate and stabilize them.
           # - os: ubuntu-24.04-arm
@@ -41,9 +47,12 @@ jobs:
           #   target: aarch64-unknown-linux-gnu
 
           # Windows
-          - os: windows-latest
+          - os: windows-x64
             target: x86_64-pc-windows-gnullvm
-    runs-on: ${{ matrix.os }}
+            runs_on:
+              group: codex-runners
+              labels: codex-windows-x64
+    runs-on: ${{ matrix.runs_on || matrix.os }}
 
     # Configure a human readable name for each job
     name: Local Bazel build on ${{ matrix.os }} for ${{ matrix.target }}
@@ -131,11 +140,17 @@ jobs:
           # that the Bazel test job uses.
           - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
+            runs_on:
+              group: codex-runners
+              labels: codex-linux-x64
           - os: macos-15-xlarge
             target: aarch64-apple-darwin
-          - os: windows-latest
+          - os: windows-x64
             target: x86_64-pc-windows-gnullvm
-    runs-on: ${{ matrix.os }}
+            runs_on:
+              group: codex-runners
+              labels: codex-windows-x64
+    runs-on: ${{ matrix.runs_on || matrix.os }}
     name: Bazel clippy on ${{ matrix.os }} for ${{ matrix.target }}
 
     steps:
@@ -204,11 +219,17 @@ jobs:
         include:
           - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
+            runs_on:
+              group: codex-runners
+              labels: codex-linux-x64
           - os: macos-15-xlarge
             target: aarch64-apple-darwin
-          - os: windows-latest
+          - os: windows-x64
             target: x86_64-pc-windows-gnullvm
-    runs-on: ${{ matrix.os }}
+            runs_on:
+              group: codex-runners
+              labels: codex-windows-x64
+    runs-on: ${{ matrix.runs_on || matrix.os }}
     name: Verify release build on ${{ matrix.os }} for ${{ matrix.target }}
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,9 @@ on:
 
 jobs:
   build-test:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: codex-runners
+      labels: codex-linux-x64
     timeout-minutes: 10
     env:
       NODE_OPTIONS: --max-old-space-size=4096

--- a/.github/workflows/rust-ci-full.yml
+++ b/.github/workflows/rust-ci-full.yml
@@ -42,7 +42,9 @@ jobs:
 
   argument_comment_lint_package:
     name: Argument comment lint package
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: codex-runners
+      labels: codex-linux-x64
     env:
       CARGO_DYLINT_VERSION: 5.0.0
       DYLINT_LINK_VERSION: 5.0.0
@@ -87,6 +89,9 @@ jobs:
         include:
           - name: Linux
             runner: ubuntu-24.04
+            runs_on:
+              group: codex-runners
+              labels: codex-linux-x64
           - name: macOS
             runner: macos-15-xlarge
           - name: Windows

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -87,7 +87,9 @@ jobs:
 
   argument_comment_lint_package:
     name: Argument comment lint package
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: codex-runners
+      labels: codex-linux-x64
     needs: changed
     if: ${{ needs.changed.outputs.argument_comment_lint_package == 'true' }}
     env:
@@ -144,6 +146,9 @@ jobs:
           - name: Linux
             runner: ubuntu-24.04
             timeout_minutes: 30
+            runs_on:
+              group: codex-runners
+              labels: codex-linux-x64
           - name: macOS
             runner: macos-15-xlarge
             timeout_minutes: 30

--- a/.github/workflows/rust-release-argument-comment-lint.yml
+++ b/.github/workflows/rust-release-argument-comment-lint.yml
@@ -39,12 +39,18 @@ jobs:
             lib_name: libargument_comment_lint@nightly-2025-09-18-x86_64-unknown-linux-gnu.so
             runner_binary: argument-comment-lint
             cargo_dylint_binary: cargo-dylint
+            runs_on:
+              group: codex-runners
+              labels: codex-linux-x64
           - runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             archive_name: argument-comment-lint-aarch64-unknown-linux-gnu.tar.gz
             lib_name: libargument_comment_lint@nightly-2025-09-18-aarch64-unknown-linux-gnu.so
             runner_binary: argument-comment-lint
             cargo_dylint_binary: cargo-dylint
+            runs_on:
+              group: codex-runners
+              labels: codex-linux-arm64
           - runner: windows-x64
             target: x86_64-pc-windows-msvc
             archive_name: argument-comment-lint-x86_64-pc-windows-msvc.zip

--- a/.github/workflows/rust-release-zsh.yml
+++ b/.github/workflows/rust-release-zsh.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   linux:
     name: Build zsh (Linux) - ${{ matrix.variant }} - ${{ matrix.target }}
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ matrix.runs_on || matrix.runner }}
     timeout-minutes: 30
     container:
       image: ${{ matrix.image }}
@@ -24,11 +24,17 @@ jobs:
             variant: ubuntu-24.04
             image: ubuntu:24.04
             archive_name: codex-zsh-x86_64-unknown-linux-musl.tar.gz
+            runs_on:
+              group: codex-runners
+              labels: codex-linux-x64
           - runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
             variant: ubuntu-24.04
             image: arm64v8/ubuntu:24.04
             archive_name: codex-zsh-aarch64-unknown-linux-musl.tar.gz
+            runs_on:
+              group: codex-runners
+              labels: codex-linux-arm64
 
     steps:
       - name: Install build prerequisites
@@ -60,7 +66,7 @@ jobs:
 
   darwin:
     name: Build zsh (macOS) - ${{ matrix.variant }} - ${{ matrix.target }}
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ matrix.runs_on || matrix.runner }}
     timeout-minutes: 30
 
     strategy:

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -71,12 +71,24 @@ jobs:
             target: x86_64-apple-darwin
           - runner: ubuntu-24.04
             target: x86_64-unknown-linux-musl
+            runs_on:
+              group: codex-runners
+              labels: codex-linux-x64
           - runner: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
+            runs_on:
+              group: codex-runners
+              labels: codex-linux-x64
           - runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
+            runs_on:
+              group: codex-runners
+              labels: codex-linux-arm64
           - runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
+            runs_on:
+              group: codex-runners
+              labels: codex-linux-arm64
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/rusty-v8-release.yml
+++ b/.github/workflows/rusty-v8-release.yml
@@ -59,7 +59,7 @@ jobs:
   build:
     name: Build ${{ matrix.target }}
     needs: metadata
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ matrix.runs_on || matrix.runner }}
     permissions:
       contents: read
       actions: read
@@ -70,9 +70,15 @@ jobs:
           - runner: ubuntu-24.04
             platform: linux_amd64_musl
             target: x86_64-unknown-linux-musl
+            runs_on:
+              group: codex-runners
+              labels: codex-linux-x64
           - runner: ubuntu-24.04-arm
             platform: linux_arm64_musl
             target: aarch64-unknown-linux-musl
+            runs_on:
+              group: codex-runners
+              labels: codex-linux-arm64
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/v8-canary.yml
+++ b/.github/workflows/v8-canary.yml
@@ -56,7 +56,7 @@ jobs:
   build:
     name: Build ${{ matrix.target }}
     needs: metadata
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ matrix.runs_on || matrix.runner }}
     permissions:
       contents: read
       actions: read
@@ -67,9 +67,15 @@ jobs:
           - runner: ubuntu-24.04
             platform: linux_amd64_musl
             target: x86_64-unknown-linux-musl
+            runs_on:
+              group: codex-runners
+              labels: codex-linux-x64
           - runner: ubuntu-24.04-arm
             platform: linux_arm64_musl
             target: aarch64-unknown-linux-musl
+            runs_on:
+              group: codex-runners
+              labels: codex-linux-arm64
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
The large codex runners change was partially reverted and never fully rolled out, but there is no harm in applying it to all workflows that need to build stuff.

## Summary
- Keep build, test, lint, and packaging jobs on the larger `codex-runners` capacity where they benefit from it.
- Move administrative and metadata-only workflows back to standard hosted Linux runners.
- Preserve matrix-based runner selection in workflows that need cross-platform build coverage.

## Testing
- `yq e '.'` over all `.github/workflows/*.yml`
- `git diff --check`