### PR TITLE
More Bazel build timing mitigations

### DIFF
--- a/codex-rs/app-server/tests/suite/conversation_summary.rs
+++ b/codex-rs/app-server/tests/suite/conversation_summary.rs
@@ -15,6 +15,13 @@ use std::path::PathBuf;
 use tempfile::TempDir;
 use tokio::time::timeout;
 
+// macOS arm64 and Windows Bazel CI can spend tens of seconds in app-server
+// startup before the initialize response arrives, even for simple rollout
+// summary RPCs. Keep local/Linux coverage fast while giving slower runners
+// enough time to complete the MCP handshake.
+#[cfg(any(target_os = "macos", windows))]
+const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+#[cfg(not(any(target_os = "macos", windows)))]
 const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 const FILENAME_TS: &str = "2025-01-02T12-00-00";
 const META_RFC3339: &str = "2025-01-02T12:00:00Z";

--- a/codex-rs/app-server/tests/suite/v2/mcp_resource.rs
+++ b/codex-rs/app-server/tests/suite/v2/mcp_resource.rs
@@ -45,6 +45,9 @@ use tempfile::TempDir;
 use tokio::net::TcpListener;
 use tokio::time::timeout;
 
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(60);
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(10);
 const TEST_RESOURCE_URI: &str = "test://codex/resource";
 const TEST_BLOB_RESOURCE_URI: &str = "test://codex/resource.bin";

--- a/codex-rs/app-server/tests/suite/v2/mcp_server_elicitation.rs
+++ b/codex-rs/app-server/tests/suite/v2/mcp_server_elicitation.rs
@@ -63,6 +63,9 @@ use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
 use tokio::time::timeout;
 
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 const CONNECTOR_ID: &str = "calendar";
 const CONNECTOR_NAME: &str = "Calendar";

--- a/codex-rs/app-server/tests/suite/v2/mcp_server_status.rs
+++ b/codex-rs/app-server/tests/suite/v2/mcp_server_status.rs
@@ -35,6 +35,9 @@ use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
 use tokio::time::timeout;
 
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(60);
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[tokio::test]

--- a/codex-rs/app-server/tests/suite/v2/turn_start_zsh_fork.rs
+++ b/codex-rs/app-server/tests/suite/v2/turn_start_zsh_fork.rs
@@ -40,9 +40,15 @@ use std::path::Path;
 use tempfile::TempDir;
 use tokio::time::timeout;
 
+// The zsh-fork suite can take longer to surface follow-up approvals and
+// completion notifications on slower Windows and macOS x86 Bazel runners than
+// it does on local or Linux builds. Give those runners extra headroom without
+// slowing the rest of the suite.
+#[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
 #[cfg(windows)]
 const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
-#[cfg(not(windows))]
+#[cfg(not(any(windows, all(target_os = "macos", target_arch = "x86_64"))))]
 const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 #[tokio::test]

--- a/codex-rs/core/src/agent/control_tests.rs
+++ b/codex-rs/core/src/agent/control_tests.rs
@@ -1575,7 +1575,11 @@ async fn resume_thread_subagent_restores_stored_nickname_and_role() {
     let state_db = child_thread
         .state_db()
         .expect("sqlite state db should be available for nickname resume test");
-    timeout(Duration::from_secs(5), async {
+    // Linux Bazel runners can take noticeably longer to flush the freshly
+    // spawned child thread metadata into SQLite than local cargo test runs.
+    // Give the persistence poll enough headroom so this resume test validates
+    // the stored nickname/role behavior instead of racing the background write.
+    timeout(Duration::from_secs(20), async {
         loop {
             if let Ok(Some(metadata)) = state_db.get_thread(child_thread_id).await
                 && metadata.agent_nickname.is_some()

--- a/codex-rs/core/src/guardian/review_session.rs
+++ b/codex-rs/core/src/guardian/review_session.rs
@@ -874,16 +874,21 @@ mod tests {
         assert!(!guardian_config.features.enabled(Feature::CodexHooks));
     }
 
-    #[tokio::test(flavor = "current_thread")]
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn run_before_review_deadline_times_out_before_future_completes() {
-        let outcome = run_before_review_deadline(
-            tokio::time::Instant::now() + Duration::from_millis(10),
-            /*external_cancel*/ None,
-            async {
-                tokio::time::sleep(Duration::from_millis(50)).await;
-            },
-        )
-        .await;
+        let outcome = tokio::spawn(async {
+            run_before_review_deadline(
+                tokio::time::Instant::now() + Duration::from_millis(10),
+                /*external_cancel*/ None,
+                async {
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                },
+            )
+            .await
+        });
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_millis(11)).await;
+        let outcome = outcome.await.expect("timeout task should join");
 
         assert!(matches!(
             outcome,
@@ -913,19 +918,27 @@ mod tests {
         ));
     }
 
-    #[tokio::test(flavor = "current_thread")]
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn run_before_review_deadline_with_cancel_cancels_token_on_timeout() {
         let cancel_token = CancellationToken::new();
 
-        let outcome = run_before_review_deadline_with_cancel(
-            tokio::time::Instant::now() + Duration::from_millis(10),
-            /*external_cancel*/ None,
-            &cancel_token,
-            async {
-                tokio::time::sleep(Duration::from_millis(50)).await;
-            },
-        )
-        .await;
+        let outcome = tokio::spawn({
+            let cancel_token = cancel_token.clone();
+            async move {
+                run_before_review_deadline_with_cancel(
+                    tokio::time::Instant::now() + Duration::from_millis(10),
+                    /*external_cancel*/ None,
+                    &cancel_token,
+                    async {
+                        tokio::time::sleep(Duration::from_millis(50)).await;
+                    },
+                )
+                .await
+            }
+        });
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_millis(11)).await;
+        let outcome = outcome.await.expect("timeout task should join");
 
         assert!(matches!(
             outcome,

--- a/codex-rs/core/tests/suite/apply_patch_cli.rs
+++ b/codex-rs/core/tests/suite/apply_patch_cli.rs
@@ -35,6 +35,7 @@ use core_test_support::test_codex::TestCodexBuilder;
 use core_test_support::test_codex::TestCodexHarness;
 use core_test_support::test_codex::test_codex;
 use core_test_support::wait_for_event;
+use core_test_support::wait_for_event_match;
 use core_test_support::wait_for_event_with_timeout;
 use serde_json::json;
 use test_case::test_case;
@@ -748,7 +749,48 @@ async fn apply_patch_cli_verification_failure_has_no_side_effects(
 
     mount_apply_patch(&harness, call_id, patch, "failed", model_output).await;
 
-    harness.submit("attempt partial apply patch").await?;
+    let test = harness.test();
+    let turn_complete_timeout = if model_output == ApplyPatchModelOutput::ShellViaHeredoc {
+        // Heredoc shell execution can take noticeably longer on slower remote
+        // Linux Bazel workers before the failed apply_patch turn completes.
+        Duration::from_secs(60)
+    } else {
+        Duration::from_secs(30)
+    };
+    let model = test.session_configured.model.clone();
+    test.codex
+        .submit(Op::UserTurn {
+            items: vec![UserInput::Text {
+                text: "attempt partial apply patch".into(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+            cwd: harness.cwd().to_path_buf(),
+            approval_policy: AskForApproval::Never,
+            approvals_reviewer: None,
+            sandbox_policy: SandboxPolicy::DangerFullAccess,
+            model,
+            effort: None,
+            summary: None,
+            service_tier: None,
+            collaboration_mode: None,
+            personality: None,
+        })
+        .await?;
+    let turn_id = wait_for_event_match(&test.codex, |event| match event {
+        EventMsg::TurnStarted(event) => Some(event.turn_id.clone()),
+        _ => None,
+    })
+    .await;
+    wait_for_event_with_timeout(
+        &test.codex,
+        |event| match event {
+            EventMsg::TurnComplete(event) => event.turn_id == turn_id,
+            _ => false,
+        },
+        turn_complete_timeout,
+    )
+    .await;
 
     assert!(
         !harness.path_exists("created.txt").await?,

--- a/codex-rs/core/tests/suite/realtime_conversation.rs
+++ b/codex-rs/core/tests/suite/realtime_conversation.rs
@@ -301,9 +301,13 @@ async fn conversation_start_audio_text_close_round_trip() -> Result<()> {
 
     let mut builder = test_codex();
     let test = builder.build_with_websocket_server(&server).await?;
+    // Bazel CI can take a few seconds to bring up the subprocess and websocket
+    // client before the realtime handshake lands. Give this env-key fallback
+    // test enough headroom so it validates auth precedence instead of racing
+    // transport startup on slower runners.
     assert!(
         server
-            .wait_for_handshakes(/*expected*/ 1, Duration::from_secs(2))
+            .wait_for_handshakes(/*expected*/ 1, Duration::from_secs(10))
             .await
     );
 


### PR DESCRIPTION
Address test-side flakes caused by slower CI runners racing background persistence or app-server startup.
- Increase the SQLite persistence poll timeout in `resume_thread_subagent_restores_stored_nickname_and_role`
- Increase the app-server initialize/read timeout for the conversation summary test on slower macOS and Windows Bazel runners
- More and more similar timing fixes