### PR TITLE
Add pattern matching for MITM hooks

### DIFF
--- a/codex-rs/network-proxy/README.md
+++ b/codex-rs/network-proxy/README.md
@@ -83,9 +83,10 @@ prefix = "Bearer "
 
 # `match.body` is reserved for a future release. Current hooks match only on
 # method/path/query/headers and can mutate outbound request headers.
-# `match.path_prefixes` accepts literal prefixes by default.
-# Prefix with `glob:` to opt into wildcard matching, for example
-# `glob:/repos/*/codex/issues*` or `glob:*preview*`.
+# `match.path_prefixes` accepts literal prefixes by default. Prefix path,
+# query, or header matchers with `glob:` to opt into wildcard matching.
+# Use `literal:` when a literal value must start with a reserved prefix.
+# In paths, `*` and `?` do not match `/`; use `**` when crossing segments is intended.
 ```
 
 ### 2) Run the proxy

--- a/codex-rs/network-proxy/README.md
+++ b/codex-rs/network-proxy/README.md
@@ -89,6 +89,23 @@ prefix = "Bearer "
 # In paths, `*` and `?` do not match `/`; use `**` when crossing segments is intended.
 ```
 
+Matcher syntax example:
+
+```toml
+[permissions.workspace.network.mitm_hooks.match]
+# Literal path prefixes are the default.
+path_prefixes = [
+  "/repos/openai/",
+  "glob:/repos/*/codex/issues*",
+]
+
+[permissions.workspace.network.mitm_hooks.match.query]
+state = ["open", "glob:triage*", "literal:glob:*"]
+
+[permissions.workspace.network.mitm_hooks.match.headers]
+"x-github-api-version" = ["2022-11-28", "glob:2022*preview"]
+```
+
 ### 2) Run the proxy
 
 ```bash

--- a/codex-rs/network-proxy/README.md
+++ b/codex-rs/network-proxy/README.md
@@ -84,7 +84,7 @@ prefix = "Bearer "
 # `match.body` is reserved for a future release. Current hooks match only on
 # method/path/query/headers and can mutate outbound request headers.
 # `match.path_prefixes` accepts literal prefixes by default. Prefix path,
-# query, or header matchers with `glob:` to opt into wildcard matching.
+# query, or header matchers with `pattern:` to opt into wildcard matching.
 # Use `literal:` when a literal value must start with a reserved prefix.
 # In paths, `*` and `?` do not match `/`; use `**` when crossing segments is intended.
 ```
@@ -96,14 +96,14 @@ Matcher syntax example:
 # Literal path prefixes are the default.
 path_prefixes = [
   "/repos/openai/",
-  "glob:/repos/*/codex/issues*",
+  "pattern:/repos/*/codex/issues*",
 ]
 
 [permissions.workspace.network.mitm_hooks.match.query]
-state = ["open", "glob:triage*", "literal:glob:*"]
+state = ["open", "pattern:triage*", "literal:pattern:*"]
 
 [permissions.workspace.network.mitm_hooks.match.headers]
-"x-github-api-version" = ["2022-11-28", "glob:2022*preview"]
+"x-github-api-version" = ["2022-11-28", "pattern:2022*preview"]
 ```
 
 ### 2) Run the proxy

--- a/codex-rs/network-proxy/README.md
+++ b/codex-rs/network-proxy/README.md
@@ -83,6 +83,9 @@ prefix = "Bearer "
 
 # `match.body` is reserved for a future release. Current hooks match only on
 # method/path/query/headers and can mutate outbound request headers.
+# `match.path_prefixes` accepts literal prefixes and glob patterns.
+# `match.query` / `match.headers` value lists accept exact values or glob patterns
+# such as `*preview*`.
 ```
 
 ### 2) Run the proxy

--- a/codex-rs/network-proxy/README.md
+++ b/codex-rs/network-proxy/README.md
@@ -83,9 +83,9 @@ prefix = "Bearer "
 
 # `match.body` is reserved for a future release. Current hooks match only on
 # method/path/query/headers and can mutate outbound request headers.
-# `match.path_prefixes` accepts literal prefixes and glob patterns.
-# `match.query` / `match.headers` value lists accept exact values or glob patterns
-# such as `*preview*`.
+# `match.path_prefixes` accepts literal prefixes by default.
+# Prefix with `glob:` to opt into wildcard matching, for example
+# `glob:/repos/*/codex/issues*` or `glob:*preview*`.
 ```
 
 ### 2) Run the proxy

--- a/codex-rs/network-proxy/src/http_proxy.rs
+++ b/codex-rs/network-proxy/src/http_proxy.rs
@@ -1093,7 +1093,9 @@ mod tests {
             .unwrap();
         req.extensions_mut().insert(state);
 
-        let response = http_connect_accept(None, req).await.unwrap_err();
+        let response = http_connect_accept(/*policy_decider*/ None, req)
+            .await
+            .unwrap_err();
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
         assert_eq!(
             response.headers().get("x-proxy-error").unwrap(),

--- a/codex-rs/network-proxy/src/mitm_hook.rs
+++ b/codex-rs/network-proxy/src/mitm_hook.rs
@@ -18,6 +18,7 @@ use std::path::Path;
 use url::form_urlencoded;
 
 const GLOB_PREFIX: &str = "glob:";
+const LITERAL_PREFIX: &str = "literal:";
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 #[serde(default)]
@@ -121,6 +122,11 @@ pub enum PathMatcher {
 pub enum ValueMatcher {
     Exact(String),
     Glob(CompiledGlobMatcher),
+}
+
+enum MatcherPattern<'a> {
+    Literal(&'a str),
+    Glob(&'a str),
 }
 
 #[derive(Clone)]
@@ -468,13 +474,17 @@ fn compile_path_matchers(path_prefixes: &[String]) -> Result<Vec<PathMatcher>> {
     path_prefixes
         .iter()
         .map(|prefix| {
-            if prefix.is_empty() {
-                return Err(anyhow!("path_prefixes must not contain empty entries"));
-            }
-
-            match parse_glob_pattern(prefix)? {
-                Some(glob_pattern) => Ok(PathMatcher::Glob(compile_glob_matcher(glob_pattern)?)),
-                None => Ok(PathMatcher::Prefix(prefix.clone())),
+            match parse_matcher_pattern(prefix)? {
+                MatcherPattern::Literal(prefix) => {
+                    if prefix.is_empty() {
+                        return Err(anyhow!("path_prefixes must not contain empty entries"));
+                    }
+                    Ok(PathMatcher::Prefix(prefix.to_string()))
+                }
+                MatcherPattern::Glob(glob_pattern) => Ok(PathMatcher::Glob(compile_glob_matcher(
+                    glob_pattern,
+                    /*literal_separator*/ true,
+                )?)),
             }
         })
         .collect()
@@ -483,25 +493,35 @@ fn compile_path_matchers(path_prefixes: &[String]) -> Result<Vec<PathMatcher>> {
 fn compile_value_matchers(values: &[String]) -> Result<Vec<ValueMatcher>> {
     values
         .iter()
-        .map(|value| match parse_glob_pattern(value)? {
-            Some(glob_pattern) => Ok(ValueMatcher::Glob(compile_glob_matcher(glob_pattern)?)),
-            None => Ok(ValueMatcher::Exact(value.clone())),
+        .map(|value| match parse_matcher_pattern(value)? {
+            MatcherPattern::Literal(value) => Ok(ValueMatcher::Exact(value.to_string())),
+            MatcherPattern::Glob(glob_pattern) => Ok(ValueMatcher::Glob(compile_glob_matcher(
+                glob_pattern,
+                /*literal_separator*/ false,
+            )?)),
         })
         .collect()
 }
 
-fn parse_glob_pattern(pattern: &str) -> Result<Option<&str>> {
+fn parse_matcher_pattern(pattern: &str) -> Result<MatcherPattern<'_>> {
+    if let Some(literal) = pattern.strip_prefix(LITERAL_PREFIX) {
+        return Ok(MatcherPattern::Literal(literal));
+    }
     let Some(glob_pattern) = pattern.strip_prefix(GLOB_PREFIX) else {
-        return Ok(None);
+        return Ok(MatcherPattern::Literal(pattern));
     };
     if glob_pattern.is_empty() {
         return Err(anyhow!("glob pattern must not be empty"));
     }
-    Ok(Some(glob_pattern))
+    Ok(MatcherPattern::Glob(glob_pattern))
 }
 
-fn compile_glob_matcher(pattern: &str) -> Result<CompiledGlobMatcher> {
-    GlobBuilder::new(pattern)
+fn compile_glob_matcher(pattern: &str, literal_separator: bool) -> Result<CompiledGlobMatcher> {
+    let mut builder = GlobBuilder::new(pattern);
+    builder
+        .backslash_escape(true)
+        .literal_separator(literal_separator);
+    builder
         .build()
         .map(|glob| CompiledGlobMatcher {
             pattern: pattern.to_string(),
@@ -873,6 +893,31 @@ mod tests {
     }
 
     #[test]
+    fn evaluate_path_wildcard_does_not_cross_segment_boundaries() {
+        let mut config = base_config();
+        let mut hook = github_hook();
+        hook.matcher.path_prefixes = vec!["glob:/repos/*/codex/issues*".to_string()];
+        config.network.mitm_hooks = vec![hook];
+
+        let hooks = compile_mitm_hooks_with_resolvers(
+            &config,
+            |_| Some("abc".to_string()),
+            |_| Err(anyhow!("unexpected file lookup")),
+        )
+        .unwrap();
+        let nested_req = Request::builder()
+            .method(Method::POST)
+            .uri("/repos/openai/private/codex/issues")
+            .body(Body::empty())
+            .unwrap();
+
+        assert_eq!(
+            evaluate_mitm_hooks(&hooks, "api.github.com", &nested_req),
+            HookEvaluation::HookedHostNoMatch
+        );
+    }
+
+    #[test]
     fn evaluate_treats_glob_metacharacters_as_literal_without_glob_prefix() {
         let mut config = base_config();
         let mut hook = github_hook();
@@ -900,6 +945,49 @@ mod tests {
             .method(Method::POST)
             .uri("/repos/draft/codex/issues?state=open")
             .header("x-github-api-version", "2022-11-28-preview")
+            .body(Body::empty())
+            .unwrap();
+
+        assert_eq!(
+            evaluate_mitm_hooks(&hooks, "api.github.com", &exact_req),
+            HookEvaluation::Matched {
+                actions: hooks.get("api.github.com").unwrap()[0].actions.clone(),
+            }
+        );
+        assert_eq!(
+            evaluate_mitm_hooks(&hooks, "api.github.com", &non_literal_req),
+            HookEvaluation::HookedHostNoMatch
+        );
+    }
+
+    #[test]
+    fn evaluate_allows_literal_values_with_reserved_prefixes() {
+        let mut config = base_config();
+        let mut hook = github_hook();
+        hook.matcher.query =
+            BTreeMap::from([("state".to_string(), vec!["literal:glob:*".to_string()])]);
+        hook.matcher.headers = BTreeMap::from([(
+            "x-github-api-version".to_string(),
+            vec!["literal:glob:*".to_string()],
+        )]);
+        config.network.mitm_hooks = vec![hook];
+
+        let hooks = compile_mitm_hooks_with_resolvers(
+            &config,
+            |_| Some("abc".to_string()),
+            |_| Err(anyhow!("unexpected file lookup")),
+        )
+        .unwrap();
+        let exact_req = Request::builder()
+            .method(Method::POST)
+            .uri("/repos/openai/codex/issues?state=glob%3A%2A")
+            .header("x-github-api-version", "glob:*")
+            .body(Body::empty())
+            .unwrap();
+        let non_literal_req = Request::builder()
+            .method(Method::POST)
+            .uri("/repos/openai/codex/issues?state=glob%3Aopen")
+            .header("x-github-api-version", "glob:preview")
             .body(Body::empty())
             .unwrap();
 

--- a/codex-rs/network-proxy/src/mitm_hook.rs
+++ b/codex-rs/network-proxy/src/mitm_hook.rs
@@ -17,7 +17,7 @@ use std::fs;
 use std::path::Path;
 use url::form_urlencoded;
 
-const GLOB_PREFIX: &str = "glob:";
+const PATTERN_PREFIX: &str = "pattern:";
 const LITERAL_PREFIX: &str = "literal:";
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
@@ -507,7 +507,7 @@ fn parse_matcher_pattern(pattern: &str) -> Result<MatcherPattern<'_>> {
     if let Some(literal) = pattern.strip_prefix(LITERAL_PREFIX) {
         return Ok(MatcherPattern::Literal(literal));
     }
-    let Some(glob_pattern) = pattern.strip_prefix(GLOB_PREFIX) else {
+    let Some(glob_pattern) = pattern.strip_prefix(PATTERN_PREFIX) else {
         return Ok(MatcherPattern::Literal(pattern));
     };
     if glob_pattern.is_empty() {
@@ -852,11 +852,12 @@ mod tests {
     fn evaluate_matches_wildcard_path_query_and_header_constraints() {
         let mut config = base_config();
         let mut hook = github_hook();
-        hook.matcher.path_prefixes = vec!["glob:/repos/*/codex/issues*".to_string()];
-        hook.matcher.query = BTreeMap::from([("state".to_string(), vec!["glob:op*".to_string()])]);
+        hook.matcher.path_prefixes = vec!["pattern:/repos/*/codex/issues*".to_string()];
+        hook.matcher.query =
+            BTreeMap::from([("state".to_string(), vec!["pattern:op*".to_string()])]);
         hook.matcher.headers = BTreeMap::from([(
             "x-github-api-version".to_string(),
-            vec!["glob:2022*preview".to_string()],
+            vec!["pattern:2022*preview".to_string()],
         )]);
         config.network.mitm_hooks = vec![hook];
 
@@ -885,7 +886,7 @@ mod tests {
     fn validate_rejects_invalid_wildcard_path_pattern() {
         let mut config = base_config();
         let mut hook = github_hook();
-        hook.matcher.path_prefixes = vec!["glob:/repos/[".to_string()];
+        hook.matcher.path_prefixes = vec!["pattern:/repos/[".to_string()];
         config.network.mitm_hooks = vec![hook];
 
         let err = validate_mitm_hook_config(&config).expect_err("invalid glob should fail");
@@ -896,7 +897,7 @@ mod tests {
     fn evaluate_path_wildcard_does_not_cross_segment_boundaries() {
         let mut config = base_config();
         let mut hook = github_hook();
-        hook.matcher.path_prefixes = vec!["glob:/repos/*/codex/issues*".to_string()];
+        hook.matcher.path_prefixes = vec!["pattern:/repos/*/codex/issues*".to_string()];
         config.network.mitm_hooks = vec![hook];
 
         let hooks = compile_mitm_hooks_with_resolvers(
@@ -965,10 +966,10 @@ mod tests {
         let mut config = base_config();
         let mut hook = github_hook();
         hook.matcher.query =
-            BTreeMap::from([("state".to_string(), vec!["literal:glob:*".to_string()])]);
+            BTreeMap::from([("state".to_string(), vec!["literal:pattern:*".to_string()])]);
         hook.matcher.headers = BTreeMap::from([(
             "x-github-api-version".to_string(),
-            vec!["literal:glob:*".to_string()],
+            vec!["literal:pattern:*".to_string()],
         )]);
         config.network.mitm_hooks = vec![hook];
 
@@ -980,14 +981,14 @@ mod tests {
         .unwrap();
         let exact_req = Request::builder()
             .method(Method::POST)
-            .uri("/repos/openai/codex/issues?state=glob%3A%2A")
-            .header("x-github-api-version", "glob:*")
+            .uri("/repos/openai/codex/issues?state=pattern%3A%2A")
+            .header("x-github-api-version", "pattern:*")
             .body(Body::empty())
             .unwrap();
         let non_literal_req = Request::builder()
             .method(Method::POST)
-            .uri("/repos/openai/codex/issues?state=glob%3Aopen")
-            .header("x-github-api-version", "glob:preview")
+            .uri("/repos/openai/codex/issues?state=pattern%3Aopen")
+            .header("x-github-api-version", "pattern:preview")
             .body(Body::empty())
             .unwrap();
 

--- a/codex-rs/network-proxy/src/mitm_hook.rs
+++ b/codex-rs/network-proxy/src/mitm_hook.rs
@@ -4,6 +4,7 @@ use anyhow::Context as _;
 use anyhow::Result;
 use anyhow::anyhow;
 use codex_utils_absolute_path::AbsolutePathBuf;
+use globset::GlobBuilder;
 use rama_http::HeaderValue;
 use rama_http::Request;
 use rama_http::header::HeaderName;
@@ -340,12 +341,7 @@ fn hook_matches(hook: &MitmHook, req: &Request) -> bool {
     }
 
     let path = req.uri().path();
-    if !hook
-        .matcher
-        .path_prefixes
-        .iter()
-        .any(|prefix| path.starts_with(prefix))
-    {
+    if !path_matches(&hook.matcher.path_prefixes, path) {
         return false;
     }
 
@@ -376,7 +372,7 @@ fn query_matches(query_constraints: &[QueryConstraint], req: &Request) -> bool {
                 constraint
                     .allowed_values
                     .iter()
-                    .any(|allowed| allowed == candidate)
+                    .any(|allowed| value_matches(allowed, candidate))
             })
         })
     })
@@ -397,10 +393,53 @@ fn headers_match(header_constraints: &[HeaderConstraint], req: &Request) -> bool
                 constraint
                     .allowed_values
                     .iter()
-                    .any(|allowed| allowed == candidate)
+                    .any(|allowed| value_matches(allowed, candidate))
             })
         })
     })
+}
+
+fn path_matches(path_prefixes: &[String], path: &str) -> bool {
+    path_prefixes.iter().any(|prefix| {
+        if has_glob_meta(prefix) {
+            glob_matches(prefix, path)
+        } else {
+            path.starts_with(prefix)
+        }
+    })
+}
+
+fn value_matches(pattern: &str, candidate: &str) -> bool {
+    if has_glob_meta(pattern) {
+        glob_matches(pattern, candidate)
+    } else {
+        pattern == candidate
+    }
+}
+
+fn glob_matches(pattern: &str, candidate: &str) -> bool {
+    compile_glob(pattern)
+        .map(|glob| glob.compile_matcher().is_match(candidate))
+        .unwrap_or(false)
+}
+
+fn has_glob_meta(pattern: &str) -> bool {
+    pattern.contains(['*', '?', '['])
+}
+
+fn validate_glob_pattern_if_needed(pattern: &str, context: &str) -> Result<()> {
+    if !has_glob_meta(pattern) {
+        return Ok(());
+    }
+
+    let _ = compile_glob(pattern).with_context(|| format!("invalid glob pattern in {context}"))?;
+    Ok(())
+}
+
+fn compile_glob(pattern: &str) -> Result<globset::Glob> {
+    GlobBuilder::new(pattern)
+        .build()
+        .map_err(|err| anyhow!("invalid glob pattern {pattern:?}: {err}"))
 }
 
 fn normalize_hook_host(host: &str) -> Result<String> {
@@ -436,6 +475,7 @@ fn normalize_path_prefixes(path_prefixes: &[String]) -> Result<Vec<String>> {
             if prefix.is_empty() {
                 return Err(anyhow!("path_prefixes must not contain empty entries"));
             }
+            validate_glob_pattern_if_needed(prefix, "path_prefixes")?;
             Ok(prefix.clone())
         })
         .collect()
@@ -452,6 +492,9 @@ fn validate_query_constraints(query: &BTreeMap<String, Vec<String>>) -> Result<(
                 "query key {name:?} must list at least one allowed value"
             ));
         }
+        for value in values {
+            validate_glob_pattern_if_needed(value, &format!("query key {name:?}"))?;
+        }
     }
     Ok(())
 }
@@ -464,8 +507,11 @@ fn normalize_query_name(name: &str) -> Result<String> {
 }
 
 fn validate_header_constraints(headers: &BTreeMap<String, Vec<String>>) -> Result<()> {
-    for name in headers.keys() {
+    for (name, values) in headers {
         let _ = parse_header_name(name)?;
+        for value in values {
+            validate_glob_pattern_if_needed(value, &format!("header {name:?}"))?;
+        }
     }
     Ok(())
 }
@@ -727,6 +773,50 @@ mod tests {
                 actions: hooks.get("api.github.com").unwrap()[0].actions.clone(),
             }
         );
+    }
+
+    #[test]
+    fn evaluate_matches_wildcard_path_query_and_header_constraints() {
+        let mut config = base_config();
+        let mut hook = github_hook();
+        hook.matcher.path_prefixes = vec!["/repos/*/codex/issues*".to_string()];
+        hook.matcher.query = BTreeMap::from([("state".to_string(), vec!["op*".to_string()])]);
+        hook.matcher.headers = BTreeMap::from([(
+            "x-github-api-version".to_string(),
+            vec!["2022*preview".to_string()],
+        )]);
+        config.network.mitm_hooks = vec![hook];
+
+        let hooks = compile_mitm_hooks_with_resolvers(
+            &config,
+            |_| Some("abc".to_string()),
+            |_| Err(anyhow!("unexpected file lookup")),
+        )
+        .unwrap();
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/repos/openai/codex/issues?state=open")
+            .header("x-github-api-version", "2022-11-28-preview")
+            .body(Body::empty())
+            .unwrap();
+
+        assert_eq!(
+            evaluate_mitm_hooks(&hooks, "api.github.com", &req),
+            HookEvaluation::Matched {
+                actions: hooks.get("api.github.com").unwrap()[0].actions.clone(),
+            }
+        );
+    }
+
+    #[test]
+    fn validate_rejects_invalid_wildcard_path_pattern() {
+        let mut config = base_config();
+        let mut hook = github_hook();
+        hook.matcher.path_prefixes = vec!["/repos/[".to_string()];
+        config.network.mitm_hooks = vec![hook];
+
+        let err = validate_mitm_hook_config(&config).expect_err("invalid glob should fail");
+        assert!(format!("{err:#}").contains("invalid glob pattern"));
     }
 
     #[test]

--- a/codex-rs/network-proxy/src/mitm_hook.rs
+++ b/codex-rs/network-proxy/src/mitm_hook.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 use anyhow::anyhow;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use globset::GlobBuilder;
+use globset::GlobMatcher;
 use rama_http::HeaderValue;
 use rama_http::Request;
 use rama_http::header::HeaderName;
@@ -15,6 +16,8 @@ use std::env;
 use std::fs;
 use std::path::Path;
 use url::form_urlencoded;
+
+const GLOB_PREFIX: &str = "glob:";
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 #[serde(default)]
@@ -66,7 +69,7 @@ pub struct MitmHook {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MitmHookMatcher {
     pub methods: Vec<String>,
-    pub path_prefixes: Vec<String>,
+    pub path_prefixes: Vec<PathMatcher>,
     pub query: Vec<QueryConstraint>,
     pub headers: Vec<HeaderConstraint>,
     pub body: Option<MitmHookBodyMatcher>,
@@ -75,13 +78,13 @@ pub struct MitmHookMatcher {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QueryConstraint {
     pub name: String,
-    pub allowed_values: Vec<String>,
+    pub allowed_values: Vec<ValueMatcher>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HeaderConstraint {
     pub name: HeaderName,
-    pub allowed_values: Vec<String>,
+    pub allowed_values: Vec<ValueMatcher>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -106,6 +109,46 @@ pub enum SecretSource {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MitmHookBodyMatcher {
     pub raw: serde_json::Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PathMatcher {
+    Prefix(String),
+    Glob(CompiledGlobMatcher),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ValueMatcher {
+    Exact(String),
+    Glob(CompiledGlobMatcher),
+}
+
+#[derive(Clone)]
+pub struct CompiledGlobMatcher {
+    pattern: String,
+    matcher: GlobMatcher,
+}
+
+impl std::fmt::Debug for CompiledGlobMatcher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CompiledGlobMatcher")
+            .field("pattern", &self.pattern)
+            .finish()
+    }
+}
+
+impl PartialEq for CompiledGlobMatcher {
+    fn eq(&self, other: &Self) -> bool {
+        self.pattern == other.pattern
+    }
+}
+
+impl Eq for CompiledGlobMatcher {}
+
+impl CompiledGlobMatcher {
+    fn is_match(&self, candidate: &str) -> bool {
+        self.matcher.is_match(candidate)
+    }
 }
 
 pub type MitmHooksByHost = BTreeMap<String, Vec<MitmHook>>;
@@ -140,7 +183,7 @@ pub(crate) fn validate_mitm_hook_config(config: &NetworkProxyConfig) -> Result<(
         }
 
         let path_prefixes =
-            normalize_path_prefixes(&hook.matcher.path_prefixes).with_context(|| {
+            compile_path_matchers(&hook.matcher.path_prefixes).with_context(|| {
                 format!("invalid network.mitm_hooks[{hook_index}].match.path_prefixes")
             })?;
         if path_prefixes.is_empty() {
@@ -226,7 +269,7 @@ where
     for hook in &config.network.mitm_hooks {
         let host = normalize_hook_host(&hook.host)?;
         let methods = normalize_methods(&hook.matcher.methods)?;
-        let path_prefixes = normalize_path_prefixes(&hook.matcher.path_prefixes)?;
+        let path_prefixes = compile_path_matchers(&hook.matcher.path_prefixes)?;
         let query = hook
             .matcher
             .query
@@ -234,7 +277,7 @@ where
             .map(|(name, values)| {
                 Ok(QueryConstraint {
                     name: normalize_query_name(name)?,
-                    allowed_values: values.clone(),
+                    allowed_values: compile_value_matchers(values)?,
                 })
             })
             .collect::<Result<Vec<_>>>()?;
@@ -245,7 +288,7 @@ where
             .map(|(name, values)| {
                 Ok(HeaderConstraint {
                     name: parse_header_name(name)?,
-                    allowed_values: values.clone(),
+                    allowed_values: compile_value_matchers(values)?,
                 })
             })
             .collect::<Result<Vec<_>>>()?;
@@ -372,7 +415,7 @@ fn query_matches(query_constraints: &[QueryConstraint], req: &Request) -> bool {
                 constraint
                     .allowed_values
                     .iter()
-                    .any(|allowed| value_matches(allowed, candidate))
+                    .any(|allowed| allowed.matches(candidate))
             })
         })
     })
@@ -393,52 +436,77 @@ fn headers_match(header_constraints: &[HeaderConstraint], req: &Request) -> bool
                 constraint
                     .allowed_values
                     .iter()
-                    .any(|allowed| value_matches(allowed, candidate))
+                    .any(|allowed| allowed.matches(candidate))
             })
         })
     })
 }
 
-fn path_matches(path_prefixes: &[String], path: &str) -> bool {
-    path_prefixes.iter().any(|prefix| {
-        if has_glob_meta(prefix) {
-            glob_matches(prefix, path)
-        } else {
-            path.starts_with(prefix)
+fn path_matches(path_prefixes: &[PathMatcher], path: &str) -> bool {
+    path_prefixes.iter().any(|matcher| matcher.matches(path))
+}
+
+impl PathMatcher {
+    fn matches(&self, candidate: &str) -> bool {
+        match self {
+            Self::Prefix(prefix) => candidate.starts_with(prefix),
+            Self::Glob(glob) => glob.is_match(candidate),
         }
-    })
-}
-
-fn value_matches(pattern: &str, candidate: &str) -> bool {
-    if has_glob_meta(pattern) {
-        glob_matches(pattern, candidate)
-    } else {
-        pattern == candidate
     }
 }
 
-fn glob_matches(pattern: &str, candidate: &str) -> bool {
-    compile_glob(pattern)
-        .map(|glob| glob.compile_matcher().is_match(candidate))
-        .unwrap_or(false)
-}
-
-fn has_glob_meta(pattern: &str) -> bool {
-    pattern.contains(['*', '?', '['])
-}
-
-fn validate_glob_pattern_if_needed(pattern: &str, context: &str) -> Result<()> {
-    if !has_glob_meta(pattern) {
-        return Ok(());
+impl ValueMatcher {
+    fn matches(&self, candidate: &str) -> bool {
+        match self {
+            Self::Exact(value) => value == candidate,
+            Self::Glob(glob) => glob.is_match(candidate),
+        }
     }
-
-    let _ = compile_glob(pattern).with_context(|| format!("invalid glob pattern in {context}"))?;
-    Ok(())
 }
 
-fn compile_glob(pattern: &str) -> Result<globset::Glob> {
+fn compile_path_matchers(path_prefixes: &[String]) -> Result<Vec<PathMatcher>> {
+    path_prefixes
+        .iter()
+        .map(|prefix| {
+            if prefix.is_empty() {
+                return Err(anyhow!("path_prefixes must not contain empty entries"));
+            }
+
+            match parse_glob_pattern(prefix)? {
+                Some(glob_pattern) => Ok(PathMatcher::Glob(compile_glob_matcher(glob_pattern)?)),
+                None => Ok(PathMatcher::Prefix(prefix.clone())),
+            }
+        })
+        .collect()
+}
+
+fn compile_value_matchers(values: &[String]) -> Result<Vec<ValueMatcher>> {
+    values
+        .iter()
+        .map(|value| match parse_glob_pattern(value)? {
+            Some(glob_pattern) => Ok(ValueMatcher::Glob(compile_glob_matcher(glob_pattern)?)),
+            None => Ok(ValueMatcher::Exact(value.clone())),
+        })
+        .collect()
+}
+
+fn parse_glob_pattern(pattern: &str) -> Result<Option<&str>> {
+    let Some(glob_pattern) = pattern.strip_prefix(GLOB_PREFIX) else {
+        return Ok(None);
+    };
+    if glob_pattern.is_empty() {
+        return Err(anyhow!("glob pattern must not be empty"));
+    }
+    Ok(Some(glob_pattern))
+}
+
+fn compile_glob_matcher(pattern: &str) -> Result<CompiledGlobMatcher> {
     GlobBuilder::new(pattern)
         .build()
+        .map(|glob| CompiledGlobMatcher {
+            pattern: pattern.to_string(),
+            matcher: glob.compile_matcher(),
+        })
         .map_err(|err| anyhow!("invalid glob pattern {pattern:?}: {err}"))
 }
 
@@ -468,19 +536,6 @@ fn normalize_methods(methods: &[String]) -> Result<Vec<String>> {
         .collect()
 }
 
-fn normalize_path_prefixes(path_prefixes: &[String]) -> Result<Vec<String>> {
-    path_prefixes
-        .iter()
-        .map(|prefix| {
-            if prefix.is_empty() {
-                return Err(anyhow!("path_prefixes must not contain empty entries"));
-            }
-            validate_glob_pattern_if_needed(prefix, "path_prefixes")?;
-            Ok(prefix.clone())
-        })
-        .collect()
-}
-
 fn validate_query_constraints(query: &BTreeMap<String, Vec<String>>) -> Result<()> {
     for (name, values) in query {
         let normalized = normalize_query_name(name)?;
@@ -492,9 +547,8 @@ fn validate_query_constraints(query: &BTreeMap<String, Vec<String>>) -> Result<(
                 "query key {name:?} must list at least one allowed value"
             ));
         }
-        for value in values {
-            validate_glob_pattern_if_needed(value, &format!("query key {name:?}"))?;
-        }
+        let _ = compile_value_matchers(values)
+            .with_context(|| format!("invalid matcher for query key {name:?}"))?;
     }
     Ok(())
 }
@@ -509,9 +563,8 @@ fn normalize_query_name(name: &str) -> Result<String> {
 fn validate_header_constraints(headers: &BTreeMap<String, Vec<String>>) -> Result<()> {
     for (name, values) in headers {
         let _ = parse_header_name(name)?;
-        for value in values {
-            validate_glob_pattern_if_needed(value, &format!("header {name:?}"))?;
-        }
+        let _ = compile_value_matchers(values)
+            .with_context(|| format!("invalid matcher for header {name:?}"))?;
     }
     Ok(())
 }
@@ -779,11 +832,11 @@ mod tests {
     fn evaluate_matches_wildcard_path_query_and_header_constraints() {
         let mut config = base_config();
         let mut hook = github_hook();
-        hook.matcher.path_prefixes = vec!["/repos/*/codex/issues*".to_string()];
-        hook.matcher.query = BTreeMap::from([("state".to_string(), vec!["op*".to_string()])]);
+        hook.matcher.path_prefixes = vec!["glob:/repos/*/codex/issues*".to_string()];
+        hook.matcher.query = BTreeMap::from([("state".to_string(), vec!["glob:op*".to_string()])]);
         hook.matcher.headers = BTreeMap::from([(
             "x-github-api-version".to_string(),
-            vec!["2022*preview".to_string()],
+            vec!["glob:2022*preview".to_string()],
         )]);
         config.network.mitm_hooks = vec![hook];
 
@@ -812,11 +865,54 @@ mod tests {
     fn validate_rejects_invalid_wildcard_path_pattern() {
         let mut config = base_config();
         let mut hook = github_hook();
-        hook.matcher.path_prefixes = vec!["/repos/[".to_string()];
+        hook.matcher.path_prefixes = vec!["glob:/repos/[".to_string()];
         config.network.mitm_hooks = vec![hook];
 
         let err = validate_mitm_hook_config(&config).expect_err("invalid glob should fail");
         assert!(format!("{err:#}").contains("invalid glob pattern"));
+    }
+
+    #[test]
+    fn evaluate_treats_glob_metacharacters_as_literal_without_glob_prefix() {
+        let mut config = base_config();
+        let mut hook = github_hook();
+        hook.matcher.path_prefixes = vec!["/repos/[draft]/".to_string()];
+        hook.matcher.query = BTreeMap::from([("state".to_string(), vec!["op*".to_string()])]);
+        hook.matcher.headers = BTreeMap::from([(
+            "x-github-api-version".to_string(),
+            vec!["2022-11-28[preview]".to_string()],
+        )]);
+        config.network.mitm_hooks = vec![hook];
+
+        let hooks = compile_mitm_hooks_with_resolvers(
+            &config,
+            |_| Some("abc".to_string()),
+            |_| Err(anyhow!("unexpected file lookup")),
+        )
+        .unwrap();
+        let exact_req = Request::builder()
+            .method(Method::POST)
+            .uri("/repos/[draft]/codex/issues?state=op*")
+            .header("x-github-api-version", "2022-11-28[preview]")
+            .body(Body::empty())
+            .unwrap();
+        let non_literal_req = Request::builder()
+            .method(Method::POST)
+            .uri("/repos/draft/codex/issues?state=open")
+            .header("x-github-api-version", "2022-11-28-preview")
+            .body(Body::empty())
+            .unwrap();
+
+        assert_eq!(
+            evaluate_mitm_hooks(&hooks, "api.github.com", &exact_req),
+            HookEvaluation::Matched {
+                actions: hooks.get("api.github.com").unwrap()[0].actions.clone(),
+            }
+        );
+        assert_eq!(
+            evaluate_mitm_hooks(&hooks, "api.github.com", &non_literal_req),
+            HookEvaluation::HookedHostNoMatch
+        );
     }
 
     #[test]

--- a/codex-rs/network-proxy/src/mitm_tests.rs
+++ b/codex-rs/network-proxy/src/mitm_tests.rs
@@ -169,7 +169,12 @@ async fn mitm_policy_allows_matching_hooked_write_in_full_mode() {
     };
     network.set_allowed_domains(vec!["api.github.com".to_string()]);
     let app_state = Arc::new(network_proxy_state_for_policy(network));
-    let ctx = policy_ctx(app_state.clone(), NetworkMode::Full, "api.github.com", 443);
+    let ctx = policy_ctx(
+        app_state.clone(),
+        NetworkMode::Full,
+        "api.github.com",
+        /*target_port*/ 443,
+    );
     let req = Request::builder()
         .method(Method::POST)
         .uri("/repos/openai/codex/issues")
@@ -202,7 +207,12 @@ async fn mitm_policy_blocks_hook_miss_for_hooked_host_and_records_telemetry_in_f
     };
     network.set_allowed_domains(vec!["api.github.com".to_string()]);
     let app_state = Arc::new(network_proxy_state_for_policy(network));
-    let ctx = policy_ctx(app_state.clone(), NetworkMode::Full, "api.github.com", 443);
+    let ctx = policy_ctx(
+        app_state.clone(),
+        NetworkMode::Full,
+        "api.github.com",
+        /*target_port*/ 443,
+    );
     let req = Request::builder()
         .method(Method::GET)
         .uri("/repos/openai/codex/issues?token=secret")


### PR DESCRIPTION
## Summary
1. Add explicit pattern matching for MITM hook path, query, and header constraints.
2. Keep literal matching as the default and require `pattern:` for wildcard style matching.
3. Keep `literal:` as the escape when a value starts with a reserved prefix.
4. Document the exact TOML shape and matcher semantics in the proxy README.

## Scope
1. This PR stays within MITM hook request matching on top of `codex/mitm-proxy-landing`.
2. It does not add secret sourcing, trust distribution, feature gating, or platform rollout work.
3. It also carries the minimal inherited test callsite comment fixes needed to unblock argument comment lint on this stacked branch.

## Safety
1. Path matching keeps segment boundaries, so `*` and `?` do not cross `/`.
2. Invalid pattern syntax fails during hook compilation before activation.
3. Literal values that start with `pattern:` can still be expressed with `literal:`.

## Validation
1. `cargo fmt --all`
2. `git diff --check`
3. `cargo test -p codex-network-proxy`
