### PR TITLE
Use codex-auto-review for guardian reviews

### DIFF
--- a/codex-rs/core/src/guardian/mod.rs
+++ b/codex-rs/core/src/guardian/mod.rs
@@ -34,7 +34,7 @@ pub(crate) use review::review_approval_request_with_cancel;
 pub(crate) use review::routes_approval_to_guardian;
 pub(crate) use review_session::GuardianReviewSessionManager;
 
-const GUARDIAN_PREFERRED_MODEL: &str = "gpt-5.4";
+const GUARDIAN_PREFERRED_MODEL: &str = "codex-auto-review";
 pub(crate) const GUARDIAN_REVIEW_TIMEOUT: Duration = Duration::from_secs(90);
 pub(crate) const GUARDIAN_REVIEWER_NAME: &str = "guardian";
 const GUARDIAN_MAX_MESSAGE_TRANSCRIPT_TOKENS: usize = 10_000;


### PR DESCRIPTION
## Summary

This is the minimal client-side follow-up for the Codex Auto Review model slug rollout. It updates the guardian reviewer preferred model from `gpt-5.4` to `codex-auto-review`, so the client can rely on the backend catalog + Statsig mapping instead of hardcoding the GPT-5.4 slug.

Context: https://openai.slack.com/archives/C0AF9328RL0/p1775777479388369?thread_ts=1775773094.071629&cid=C0AF9328RL0

## Testing

- `cargo fmt --package codex-core --check`
- `cargo test -p codex-core guardian::`
- `bazel test --experimental_remote_downloader= --test_output=errors //codex-rs/core:core-unit-tests --test_arg=guardian`