### PR TITLE
Enable agent identity for tokenless startup auth

### DIFF
--- a/codex-rs/core/src/agent_identity.rs
+++ b/codex-rs/core/src/agent_identity.rs
@@ -91,7 +91,7 @@ struct AgentIdentityBinding {
     binding_id: String,
     chatgpt_account_id: String,
     chatgpt_user_id: Option<String>,
-    access_token: String,
+    access_token: Option<String>,
 }
 
 struct GeneratedAgentKeyMaterial {
@@ -116,10 +116,15 @@ impl AgentIdentityManager {
 
     pub(crate) fn is_enabled(&self) -> bool {
         self.feature_enabled
+            || self
+                .auth_manager
+                .auth_cached()
+                .as_ref()
+                .is_some_and(CodexAuth::is_agent_identity_only)
     }
 
     pub(crate) async fn ensure_registered_identity(&self) -> Result<Option<StoredAgentIdentity>> {
-        if !self.feature_enabled {
+        if !self.is_enabled() {
             return Ok(None);
         }
 
@@ -154,7 +159,7 @@ impl AgentIdentityManager {
     }
 
     pub(crate) async fn task_matches_current_identity(&self, task: &RegisteredAgentTask) -> bool {
-        if !self.feature_enabled {
+        if !self.is_enabled() {
             return false;
         }
 
@@ -244,11 +249,15 @@ impl AgentIdentityManager {
         target_url: &str,
     ) -> Result<String> {
         let url = agent_identity_biscuit_url(&self.chatgpt_base_url);
+        let access_token = binding
+            .access_token
+            .as_deref()
+            .context("ChatGPT access token is unavailable")?;
         let request_id = agent_identity_request_id()?;
         let client = create_client();
         let response = client
             .get(&url)
-            .bearer_auth(&binding.access_token)
+            .bearer_auth(access_token)
             .header("X-Request-Id", request_id.clone())
             .header("X-Original-Method", target_method)
             .header("X-Original-Url", target_url)
@@ -455,6 +464,16 @@ impl AgentIdentityBinding {
             return None;
         }
 
+        if auth.is_agent_identity_only() {
+            let record = auth.agent_identity_record()?;
+            return Some(Self {
+                binding_id: format!("chatgpt-account-{}", record.workspace_id),
+                chatgpt_account_id: record.workspace_id,
+                chatgpt_user_id: record.chatgpt_user_id,
+                access_token: None,
+            });
+        }
+
         let token_data = auth.get_token_data().ok()?;
         let resolved_account_id =
             forced_workspace_id
@@ -471,7 +490,7 @@ impl AgentIdentityBinding {
                 .id_token
                 .chatgpt_user_id
                 .filter(|value| !value.is_empty()),
-            access_token: token_data.access_token,
+            access_token: Some(token_data.access_token),
         })
     }
 }
@@ -580,6 +599,28 @@ mod tests {
         );
 
         assert_eq!(manager.ensure_registered_identity().await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn ensure_registered_identity_uses_agent_identity_only_auth_when_feature_is_disabled() {
+        let auth = make_agent_identity_only_auth("account-123", Some("user-123"), "agent-123");
+        let auth_manager = AuthManager::from_auth_for_testing(auth);
+        let manager = AgentIdentityManager::new_for_tests(
+            auth_manager,
+            /*feature_enabled*/ false,
+            "https://chatgpt.com/backend-api/".to_string(),
+            SessionSource::Cli,
+        );
+
+        let stored = manager
+            .ensure_registered_identity()
+            .await
+            .unwrap()
+            .expect("agent identity-only auth should load the stored identity");
+
+        assert_eq!(stored.agent_runtime_id, "agent-123");
+        assert_eq!(stored.chatgpt_account_id, "account-123");
+        assert_eq!(stored.chatgpt_user_id.as_deref(), Some("user-123"));
     }
 
     #[tokio::test]
@@ -823,6 +864,33 @@ mod tests {
             }),
             last_refresh: Some(Utc::now()),
             agent_identity: None,
+        };
+        save_auth(tempdir.path(), &auth_json, AuthCredentialsStoreMode::File).expect("save auth");
+        CodexAuth::from_auth_storage(tempdir.path(), AuthCredentialsStoreMode::File)
+            .expect("load auth")
+            .expect("auth")
+    }
+
+    fn make_agent_identity_only_auth(
+        account_id: &str,
+        user_id: Option<&str>,
+        agent_runtime_id: &str,
+    ) -> CodexAuth {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let key_material = generate_agent_key_material().expect("key material");
+        let auth_json = AuthDotJson {
+            auth_mode: Some(ApiAuthMode::Chatgpt),
+            openai_api_key: None,
+            tokens: None,
+            last_refresh: None,
+            agent_identity: Some(AgentIdentityAuthRecord {
+                workspace_id: account_id.to_string(),
+                chatgpt_user_id: user_id.map(ToOwned::to_owned),
+                agent_runtime_id: agent_runtime_id.to_string(),
+                agent_private_key: key_material.private_key_pkcs8_base64,
+                registered_at: Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
+                background_task_id: None,
+            }),
         };
         save_auth(tempdir.path(), &auth_json, AuthCredentialsStoreMode::File).expect("save auth");
         CodexAuth::from_auth_storage(tempdir.path(), AuthCredentialsStoreMode::File)

--- a/codex-rs/core/src/agent_identity/task_registration.rs
+++ b/codex-rs/core/src/agent_identity/task_registration.rs
@@ -36,7 +36,7 @@ struct RegisterTaskResponse {
 
 impl AgentIdentityManager {
     pub(crate) async fn register_task(&self) -> Result<Option<RegisteredAgentTask>> {
-        if !self.feature_enabled {
+        if !self.is_enabled() {
             return Ok(None);
         }
 
@@ -65,12 +65,15 @@ impl AgentIdentityManager {
         let client = create_client();
         let url =
             agent_task_registration_url(&self.chatgpt_base_url, &stored_identity.agent_runtime_id);
-        let human_biscuit = self.mint_human_biscuit(&binding, "POST", &url).await?;
-        let response = client
+        let mut request = client
             .post(&url)
-            .header("X-OpenAI-Authorization", human_biscuit)
             .json(&request_body)
-            .timeout(AGENT_TASK_REGISTRATION_TIMEOUT)
+            .timeout(AGENT_TASK_REGISTRATION_TIMEOUT);
+        if binding.access_token.is_some() {
+            let human_biscuit = self.mint_human_biscuit(&binding, "POST", &url).await?;
+            request = request.header("X-OpenAI-Authorization", human_biscuit);
+        }
+        let response = request
             .send()
             .await
             .with_context(|| format!("failed to send agent task registration request to {url}"))?;
@@ -196,6 +199,50 @@ mod tests {
         );
 
         assert_eq!(manager.register_task().await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn register_task_uses_agent_identity_only_auth_when_feature_is_disabled() {
+        let server = MockServer::start().await;
+        let chatgpt_base_url = server.uri();
+        let auth = make_agent_identity_only_auth("account-123", Some("user-123"), "agent-123");
+        let auth_manager = AuthManager::from_auth_for_testing(auth.clone());
+        let manager = AgentIdentityManager::new_for_tests(
+            auth_manager,
+            /*feature_enabled*/ false,
+            chatgpt_base_url,
+            SessionSource::Cli,
+        );
+        let stored_identity = manager
+            .current_stored_identity()
+            .await
+            .expect("stored identity");
+        let encrypted_task_id =
+            encrypt_task_id_for_identity(&stored_identity, "task_123").expect("task ciphertext");
+
+        Mock::given(method("POST"))
+            .and(path("/v1/agent/agent-123/task/register"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "encrypted_task_id": encrypted_task_id,
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let task = manager
+            .register_task()
+            .await
+            .unwrap()
+            .expect("task should be registered");
+
+        assert_eq!(
+            task,
+            RegisteredAgentTask {
+                agent_runtime_id: "agent-123".to_string(),
+                task_id: "task_123".to_string(),
+                registered_at: task.registered_at.clone(),
+            }
+        );
     }
 
     #[tokio::test]
@@ -445,6 +492,33 @@ mod tests {
             }),
             last_refresh: Some(Utc::now()),
             agent_identity: None,
+        };
+        save_auth(tempdir.path(), &auth_json, AuthCredentialsStoreMode::File).expect("save auth");
+        CodexAuth::from_auth_storage(tempdir.path(), AuthCredentialsStoreMode::File)
+            .expect("load auth")
+            .expect("auth")
+    }
+
+    fn make_agent_identity_only_auth(
+        account_id: &str,
+        user_id: Option<&str>,
+        agent_runtime_id: &str,
+    ) -> CodexAuth {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let key_material = generate_agent_key_material().expect("key material");
+        let auth_json = AuthDotJson {
+            auth_mode: Some(ApiAuthMode::Chatgpt),
+            openai_api_key: None,
+            tokens: None,
+            last_refresh: None,
+            agent_identity: Some(AgentIdentityAuthRecord {
+                workspace_id: account_id.to_string(),
+                chatgpt_user_id: user_id.map(ToOwned::to_owned),
+                agent_runtime_id: agent_runtime_id.to_string(),
+                agent_private_key: key_material.private_key_pkcs8_base64,
+                registered_at: Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
+                background_task_id: None,
+            }),
         };
         save_auth(tempdir.path(), &auth_json, AuthCredentialsStoreMode::File).expect("save auth");
         CodexAuth::from_auth_storage(tempdir.path(), AuthCredentialsStoreMode::File)

--- a/codex-rs/login/src/agent_identity.rs
+++ b/codex-rs/login/src/agent_identity.rs
@@ -74,6 +74,10 @@ impl BackgroundAgentTaskAuthMode {
     fn is_enabled(self) -> bool {
         matches!(self, Self::Enabled)
     }
+
+    fn is_enabled_for_auth(self, auth: &CodexAuth) -> bool {
+        self.is_enabled() || auth.is_agent_identity_only()
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -124,7 +128,7 @@ struct AgentIdentityBinding {
     binding_id: String,
     chatgpt_account_id: String,
     chatgpt_user_id: Option<String>,
-    access_token: String,
+    access_token: Option<String>,
 }
 
 struct GeneratedAgentKeyMaterial {
@@ -166,7 +170,7 @@ impl BackgroundAgentTaskManager {
         &self,
         auth: &CodexAuth,
     ) -> Result<Option<String>> {
-        if !self.auth_mode.is_enabled() {
+        if !self.auth_mode.is_enabled_for_auth(auth) {
             debug!("skipping background agent task auth because agent identity is disabled");
             return Ok(None);
         }
@@ -314,12 +318,15 @@ impl BackgroundAgentTaskManager {
         let client = create_client();
         let url =
             agent_task_registration_url(&self.chatgpt_base_url, &stored_identity.agent_runtime_id);
-        let human_biscuit = self.mint_human_biscuit(binding, "POST", &url).await?;
-        let response = client
+        let mut request = client
             .post(&url)
-            .header("X-OpenAI-Authorization", human_biscuit)
             .json(&request_body)
-            .timeout(AGENT_TASK_REGISTRATION_TIMEOUT)
+            .timeout(AGENT_TASK_REGISTRATION_TIMEOUT);
+        if binding.access_token.is_some() {
+            let human_biscuit = self.mint_human_biscuit(binding, "POST", &url).await?;
+            request = request.header("X-OpenAI-Authorization", human_biscuit);
+        }
+        let response = request
             .send()
             .await
             .with_context(|| format!("failed to send background agent task request to {url}"))?;
@@ -353,11 +360,15 @@ impl BackgroundAgentTaskManager {
         target_url: &str,
     ) -> Result<String> {
         let url = agent_identity_biscuit_url(&self.chatgpt_base_url);
+        let access_token = binding
+            .access_token
+            .as_deref()
+            .context("ChatGPT access token is unavailable")?;
         let request_id = agent_identity_request_id()?;
         let client = create_client();
         let response = client
             .get(&url)
-            .bearer_auth(&binding.access_token)
+            .bearer_auth(access_token)
             .header("X-Request-Id", request_id.clone())
             .header("X-Original-Method", target_method)
             .header("X-Original-Url", target_url)
@@ -448,7 +459,7 @@ pub fn cached_background_agent_task_authorization_header_value(
     auth: &CodexAuth,
     auth_mode: BackgroundAgentTaskAuthMode,
 ) -> Result<Option<String>> {
-    if !auth_mode.is_enabled() {
+    if !auth_mode.is_enabled_for_auth(auth) {
         return Ok(None);
     }
 
@@ -551,6 +562,16 @@ impl AgentIdentityBinding {
             return None;
         }
 
+        if auth.is_agent_identity_only() {
+            let record = auth.agent_identity_record()?;
+            return Some(Self {
+                binding_id: format!("chatgpt-account-{}", record.workspace_id),
+                chatgpt_account_id: record.workspace_id,
+                chatgpt_user_id: record.chatgpt_user_id,
+                access_token: None,
+            });
+        }
+
         let token_data = auth.get_token_data().ok()?;
         let resolved_account_id =
             forced_workspace_id
@@ -567,7 +588,7 @@ impl AgentIdentityBinding {
                 .id_token
                 .chatgpt_user_id
                 .filter(|value| !value.is_empty()),
-            access_token: token_data.access_token,
+            access_token: Some(token_data.access_token),
         })
     }
 }
@@ -797,6 +818,31 @@ mod tests {
         assert_eq!(None, authorization_header_value);
     }
 
+    #[tokio::test]
+    async fn disabled_background_agent_task_auth_uses_agent_identity_only_auth() {
+        let auth = make_agent_identity_only_auth(
+            "account_id",
+            /*user_id*/ None,
+            "agent_123",
+            Some("task_123"),
+        );
+        let auth_manager = AuthManager::from_auth_for_testing(auth.clone());
+        let manager = BackgroundAgentTaskManager::new_with_auth_mode(
+            auth_manager,
+            "https://chatgpt.com/backend-api".to_string(),
+            SessionSource::Cli,
+            BackgroundAgentTaskAuthMode::Disabled,
+        );
+
+        let authorization_header_value = manager
+            .authorization_header_value_for_auth(&auth)
+            .await
+            .expect("identity-only auth should not fail")
+            .expect("identity-only auth should return an agent assertion");
+
+        assert!(authorization_header_value.starts_with("AgentAssertion "));
+    }
+
     #[test]
     fn cached_background_agent_task_auth_honors_disabled_mode() {
         let auth = CodexAuth::create_dummy_chatgpt_auth_for_testing();
@@ -826,5 +872,37 @@ mod tests {
 
         assert_eq!(None, disabled_authorization_header_value);
         assert!(enabled_authorization_header_value.is_some());
+    }
+
+    fn make_agent_identity_only_auth(
+        account_id: &str,
+        user_id: Option<&str>,
+        agent_runtime_id: &str,
+        background_task_id: Option<&str>,
+    ) -> CodexAuth {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let key_material = generate_agent_key_material().expect("generate key material");
+        crate::save_auth(
+            tempdir.path(),
+            &crate::AuthDotJson {
+                auth_mode: Some(codex_app_server_protocol::AuthMode::Chatgpt),
+                openai_api_key: None,
+                tokens: None,
+                last_refresh: None,
+                agent_identity: Some(AgentIdentityAuthRecord {
+                    workspace_id: account_id.to_string(),
+                    chatgpt_user_id: user_id.map(ToOwned::to_owned),
+                    agent_runtime_id: agent_runtime_id.to_string(),
+                    agent_private_key: key_material.private_key_pkcs8_base64,
+                    registered_at: "2026-04-13T12:00:00Z".to_string(),
+                    background_task_id: background_task_id.map(ToOwned::to_owned),
+                }),
+            },
+            crate::AuthCredentialsStoreMode::File,
+        )
+        .expect("save auth");
+        CodexAuth::from_auth_storage(tempdir.path(), crate::AuthCredentialsStoreMode::File)
+            .expect("load auth")
+            .expect("auth")
     }
 }

--- a/codex-rs/login/src/auth/auth_tests.rs
+++ b/codex-rs/login/src/auth/auth_tests.rs
@@ -259,6 +259,74 @@ fn dummy_chatgpt_auth_does_not_create_cwd_auth_json_when_identity_is_set() {
 }
 
 #[test]
+fn chatgpt_auth_detects_agent_identity_only() {
+    let codex_home = tempdir().unwrap();
+    let record = AgentIdentityAuthRecord {
+        workspace_id: "account-123".to_string(),
+        chatgpt_user_id: Some("user-123".to_string()),
+        agent_runtime_id: "agent_123".to_string(),
+        agent_private_key: "pkcs8-base64".to_string(),
+        registered_at: "2026-04-13T12:00:00Z".to_string(),
+        background_task_id: None,
+    };
+    let auth_dot_json = AuthDotJson {
+        auth_mode: Some(ApiAuthMode::ChatgptAuthTokens),
+        openai_api_key: None,
+        tokens: None,
+        last_refresh: None,
+        agent_identity: Some(record.clone()),
+    };
+    super::save_auth(
+        codex_home.path(),
+        &auth_dot_json,
+        AuthCredentialsStoreMode::File,
+    )
+    .expect("save auth file");
+    let auth = super::load_auth(
+        codex_home.path(),
+        /*enable_codex_api_key_env*/ false,
+        AuthCredentialsStoreMode::File,
+    )
+    .expect("load auth")
+    .expect("auth available");
+
+    assert!(auth.is_agent_identity_only());
+    assert_eq!(auth.agent_identity_record(), Some(record));
+}
+
+#[test]
+fn chatgpt_auth_with_tokens_is_not_agent_identity_only() {
+    let codex_home = tempdir().unwrap();
+    write_auth_file(
+        AuthFileParams {
+            openai_api_key: None,
+            chatgpt_plan_type: Some("pro".to_string()),
+            chatgpt_account_id: Some("account-123".to_string()),
+        },
+        codex_home.path(),
+    )
+    .expect("failed to write auth file");
+    let auth = super::load_auth(
+        codex_home.path(),
+        /*enable_codex_api_key_env*/ false,
+        AuthCredentialsStoreMode::File,
+    )
+    .expect("load auth")
+    .expect("auth available");
+    auth.set_agent_identity(AgentIdentityAuthRecord {
+        workspace_id: "account-123".to_string(),
+        chatgpt_user_id: Some("user-123".to_string()),
+        agent_runtime_id: "agent_123".to_string(),
+        agent_private_key: "pkcs8-base64".to_string(),
+        registered_at: "2026-04-13T12:00:00Z".to_string(),
+        background_task_id: None,
+    })
+    .expect("set agent identity");
+
+    assert!(!auth.is_agent_identity_only());
+}
+
+#[test]
 fn unauthorized_recovery_reports_mode_and_step_names() {
     let dir = tempdir().unwrap();
     let manager = AuthManager::shared(
@@ -684,6 +752,30 @@ async fn build_config(
     }
 }
 
+fn write_agent_identity_only_auth_file(
+    codex_home: &Path,
+    workspace_id: &str,
+) -> std::io::Result<()> {
+    save_auth(
+        codex_home,
+        &AuthDotJson {
+            auth_mode: Some(AuthMode::Chatgpt),
+            openai_api_key: None,
+            tokens: None,
+            last_refresh: None,
+            agent_identity: Some(AgentIdentityAuthRecord {
+                workspace_id: workspace_id.to_string(),
+                chatgpt_user_id: None,
+                agent_runtime_id: "agent_123".to_string(),
+                agent_private_key: "private-key".to_string(),
+                registered_at: "2026-04-13T12:00:00Z".to_string(),
+                background_task_id: None,
+            }),
+        },
+        AuthCredentialsStoreMode::File,
+    )
+}
+
 /// Use sparingly.
 /// TODO (gpeal): replace this with an injectable env var provider.
 #[cfg(test)]
@@ -792,6 +884,50 @@ async fn enforce_login_restrictions_allows_matching_workspace() {
     assert!(
         codex_home.path().join("auth.json").exists(),
         "auth.json should remain when restrictions pass"
+    );
+}
+
+#[tokio::test]
+#[serial(codex_api_key)]
+async fn enforce_login_restrictions_allows_matching_agent_identity_only_workspace() {
+    let codex_home = tempdir().unwrap();
+    write_agent_identity_only_auth_file(codex_home.path(), "org_mine")
+        .expect("failed to write auth file");
+
+    let config = build_config(
+        codex_home.path(),
+        /*forced_login_method*/ None,
+        Some("org_mine".to_string()),
+    )
+    .await;
+
+    super::enforce_login_restrictions(&config).expect("matching workspace should succeed");
+    assert!(
+        codex_home.path().join("auth.json").exists(),
+        "auth.json should remain when restrictions pass"
+    );
+}
+
+#[tokio::test]
+#[serial(codex_api_key)]
+async fn enforce_login_restrictions_logs_out_for_agent_identity_only_workspace_mismatch() {
+    let codex_home = tempdir().unwrap();
+    write_agent_identity_only_auth_file(codex_home.path(), "org_another_org")
+        .expect("failed to write auth file");
+
+    let config = build_config(
+        codex_home.path(),
+        /*forced_login_method*/ None,
+        Some("org_mine".to_string()),
+    )
+    .await;
+
+    let err = super::enforce_login_restrictions(&config)
+        .expect_err("expected workspace mismatch to error");
+    assert!(err.to_string().contains("workspace org_mine"));
+    assert!(
+        !codex_home.path().join("auth.json").exists(),
+        "auth.json should be removed on mismatch"
     );
 }
 

--- a/codex-rs/login/src/auth/manager.rs
+++ b/codex-rs/login/src/auth/manager.rs
@@ -311,6 +311,17 @@ impl CodexAuth {
             .is_some_and(|t| t.id_token.is_fedramp_account())
     }
 
+    pub fn is_agent_identity_only(&self) -> bool {
+        self.get_current_auth_json().is_some_and(|auth| {
+            auth.tokens.is_none() && auth.agent_identity.is_some() && self.is_chatgpt_auth()
+        })
+    }
+
+    pub fn agent_identity_record(&self) -> Option<AgentIdentityAuthRecord> {
+        self.get_current_auth_json()
+            .and_then(|auth| auth.agent_identity)
+    }
+
     /// Returns `None` if `is_chatgpt_auth()` is false.
     pub fn get_account_email(&self) -> Option<String> {
         self.get_current_token_data().and_then(|t| t.id_token.email)
@@ -622,6 +633,23 @@ pub fn enforce_login_restrictions(config: &AuthConfig) -> std::io::Result<()> {
 
     if let Some(expected_account_id) = config.forced_chatgpt_workspace_id.as_deref() {
         if !auth.is_chatgpt_auth() {
+            return Ok(());
+        }
+
+        if auth.is_agent_identity_only() {
+            let actual_account_id = auth
+                .agent_identity_record()
+                .map(|identity| identity.workspace_id);
+            if actual_account_id.as_deref() != Some(expected_account_id) {
+                return logout_with_message(
+                    &config.codex_home,
+                    format!(
+                        "Login is restricted to workspace {expected_account_id}, but current agent identity belongs to {actual_account_id:?}. Logging out."
+                    ),
+                    config.auth_credentials_store_mode,
+                );
+            }
+
             return Ok(());
         }
 
@@ -1545,6 +1573,10 @@ impl AuthManager {
     ) -> anyhow::Result<Option<AgentIdentityAuthRecord>> {
         if !auth.is_chatgpt_auth() {
             return Ok(None);
+        }
+
+        if auth.is_agent_identity_only() {
+            return Ok(auth.agent_identity_record());
         }
 
         let token_data = auth

--- a/codex-rs/model-provider/src/auth.rs
+++ b/codex-rs/model-provider/src/auth.rs
@@ -41,6 +41,16 @@ fn bearer_auth_provider_from_auth(
     }
 
     if let Some(auth) = auth {
+        if auth.is_agent_identity_only() {
+            return Ok(BearerAuthProvider {
+                token: None,
+                account_id: auth
+                    .agent_identity_record()
+                    .map(|record| record.workspace_id),
+                is_fedramp_account: false,
+            });
+        }
+
         let token = auth.get_token()?;
         Ok(BearerAuthProvider {
             token: Some(token),


### PR DESCRIPTION
## Stack

1. #18176 - Accept JWT agent identity auth input
2. #18177 - Enable agent identity for tokenless startup auth
3. #18180 - Load agent identity from `CODEX_AGENT_IDENTITY`

## What changed

Codex now treats agent identity as enabled when ChatGPT auth has `agent_identity` and no user OAuth tokens.

The small shape change is that `AgentIdentityBinding` can carry `access_token: None`. Token-backed auth still mints the human biscuit before registration. Tokenless auth reuses the stored agent identity, signs the task registration payload with the agent private key, and then uses the task id to build `AgentAssertion` auth.

This also handles two startup checks for tokenless auth:

- request auth setup no longer fails while looking for a bearer token
- forced workspace checks compare against `agent_identity.workspace_id`

## Validation

- `cd codex-rs && just fmt`
- `cd codex-rs && cargo check -p codex-login -p codex-core`
- `cd codex-rs && cargo test -p codex-login agent_identity`
- `cd codex-rs && cargo test -p codex-core agent_identity`
- `cd codex-rs && cargo test -p codex-login enforce_login_restrictions`
- `cd codex-rs && just fix -p codex-login`
- `cd codex-rs && just fix -p codex-core`
