### PR TITLE
fix: drop lock earlier; was held across send_event().await unnecessarily

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -6696,13 +6696,16 @@ pub(crate) async fn run_turn(
                 break;
             }
             Err(CodexErr::InvalidImageRequest()) => {
-                let mut state = sess.state.lock().await;
-                error_or_panic(
-                    "Invalid image detected; sanitizing tool output to prevent poisoning",
-                );
-                if state.history.replace_last_turn_images("Invalid image") {
-                    continue;
+                {
+                    let mut state = sess.state.lock().await;
+                    error_or_panic(
+                        "Invalid image detected; sanitizing tool output to prevent poisoning",
+                    );
+                    if state.history.replace_last_turn_images("Invalid image") {
+                        continue;
+                    }
                 }
+
                 let event = EventMsg::Error(ErrorEvent {
                     message: "Invalid image in your last message. Please remove it and try again."
                         .to_string(),


### PR DESCRIPTION
This was flagged by the Codex Security tool: the `state` lock was held longer than necessary, which included being held across an `async` call, increasing the potential for deadlock.

While this was flagged by the Codex Security tool, I will look into enabling https://rust-lang.github.io/rust-clippy/stable/index.html#await_holding_lock in a follow-up PR (though unfortunately, that Clippy rule claims it reports false positives when `drop()` is used to drop a guard instead of using the end of block scope to drop). Though I can't seem to find a Clippy rule that checks for opportunities to drop a guard as soon as it is no longer referenced, in general.