### PR TITLE
feat: Handle alternate plugin manifest paths

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/plugin_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/plugin_list.rs
@@ -247,6 +247,111 @@ async fn plugin_list_keeps_valid_marketplaces_when_another_marketplace_fails_to_
 }
 
 #[tokio::test]
+async fn plugin_list_uses_alternate_discoverable_manifest_and_skips_undiscoverable_plugins()
+-> Result<()> {
+    let codex_home = TempDir::new()?;
+    let repo_root = TempDir::new()?;
+    let valid_plugin_root = repo_root.path().join("plugins/valid-plugin");
+    std::fs::create_dir_all(repo_root.path().join(".git"))?;
+    std::fs::create_dir_all(repo_root.path().join(".claude-plugin"))?;
+    std::fs::create_dir_all(valid_plugin_root.join(".claude-plugin"))?;
+    write_plugins_enabled_config(codex_home.path())?;
+
+    let marketplace_path =
+        AbsolutePathBuf::try_from(repo_root.path().join(".claude-plugin/marketplace.json"))?;
+    let valid_plugin_path = AbsolutePathBuf::try_from(valid_plugin_root.clone())?;
+
+    std::fs::write(
+        marketplace_path.as_path(),
+        r#"{
+  "name": "alternate-marketplace",
+  "plugins": [
+    {
+      "name": "valid-plugin",
+      "source": "./plugins/valid-plugin"
+    },
+    {
+      "name": "missing-plugin",
+      "source": "./plugins/missing-plugin"
+    }
+  ]
+}"#,
+    )?;
+    std::fs::write(
+        valid_plugin_root.join(".claude-plugin/plugin.json"),
+        r#"{
+  "name": "valid-plugin",
+  "interface": {
+    "displayName": "Valid Plugin"
+  }
+}"#,
+    )?;
+
+    let home = codex_home.path().to_string_lossy().into_owned();
+    let mut mcp = McpProcess::new_with_env(
+        codex_home.path(),
+        &[
+            ("HOME", Some(home.as_str())),
+            ("USERPROFILE", Some(home.as_str())),
+        ],
+    )
+    .await?;
+    timeout(DEFAULT_TIMEOUT, mcp.initialize()).await??;
+
+    let request_id = mcp
+        .send_plugin_list_request(PluginListParams {
+            cwds: Some(vec![AbsolutePathBuf::try_from(repo_root.path())?]),
+            force_remote_sync: false,
+        })
+        .await?;
+
+    let response: JSONRPCResponse = timeout(
+        DEFAULT_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+    let response: PluginListResponse = to_response(response)?;
+
+    assert_eq!(
+        response.marketplaces,
+        vec![PluginMarketplaceEntry {
+            name: "alternate-marketplace".to_string(),
+            path: marketplace_path,
+            interface: None,
+            plugins: vec![PluginSummary {
+                id: "valid-plugin@alternate-marketplace".to_string(),
+                name: "valid-plugin".to_string(),
+                source: PluginSource::Local {
+                    path: valid_plugin_path,
+                },
+                installed: false,
+                enabled: false,
+                install_policy: PluginInstallPolicy::Available,
+                auth_policy: PluginAuthPolicy::OnInstall,
+                interface: Some(codex_app_server_protocol::PluginInterface {
+                    display_name: Some("Valid Plugin".to_string()),
+                    short_description: None,
+                    long_description: None,
+                    developer_name: None,
+                    category: None,
+                    capabilities: Vec::new(),
+                    website_url: None,
+                    privacy_policy_url: None,
+                    terms_of_service_url: None,
+                    default_prompt: None,
+                    brand_color: None,
+                    composer_icon: None,
+                    logo: None,
+                    screenshots: Vec::new(),
+                }),
+            }],
+        }]
+    );
+    assert!(response.marketplace_load_errors.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
 async fn plugin_list_accepts_omitted_cwds() -> Result<()> {
     let codex_home = TempDir::new()?;
     std::fs::create_dir_all(codex_home.path().join(".agents/plugins"))?;

--- a/codex-rs/app-server/tests/suite/v2/plugin_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/plugin_list.rs
@@ -46,15 +46,6 @@ plugins = true
     )
 }
 
-fn write_primary_plugin_manifest(
-    plugin_root: &std::path::Path,
-    plugin_name: &str,
-) -> std::io::Result<()> {
-    let manifest_path = plugin_root.join(".codex-plugin/plugin.json");
-    std::fs::create_dir_all(manifest_path.parent().expect("manifest parent"))?;
-    std::fs::write(manifest_path, format!(r#"{{"name":"{plugin_name}"}}"#))
-}
-
 #[tokio::test]
 async fn plugin_list_skips_invalid_marketplace_file_and_reports_error() -> Result<()> {
     let codex_home = TempDir::new()?;
@@ -258,7 +249,7 @@ async fn plugin_list_keeps_valid_marketplaces_when_another_marketplace_fails_to_
 }
 
 #[tokio::test]
-async fn plugin_list_uses_alternate_discoverable_manifest_and_skips_undiscoverable_plugins()
+async fn plugin_list_uses_alternate_discoverable_manifest_and_keeps_undiscoverable_plugins()
 -> Result<()> {
     let codex_home = TempDir::new()?;
     let repo_root = TempDir::new()?;
@@ -340,33 +331,49 @@ async fn plugin_list_uses_alternate_discoverable_manifest_and_skips_undiscoverab
             name: "alternate-marketplace".to_string(),
             path: marketplace_path,
             interface: None,
-            plugins: vec![PluginSummary {
-                id: "valid-plugin@alternate-marketplace".to_string(),
-                name: "valid-plugin".to_string(),
-                source: PluginSource::Local {
-                    path: valid_plugin_path,
+            plugins: vec![
+                PluginSummary {
+                    id: "valid-plugin@alternate-marketplace".to_string(),
+                    name: "valid-plugin".to_string(),
+                    source: PluginSource::Local {
+                        path: valid_plugin_path,
+                    },
+                    installed: false,
+                    enabled: false,
+                    install_policy: PluginInstallPolicy::Available,
+                    auth_policy: PluginAuthPolicy::OnInstall,
+                    interface: Some(codex_app_server_protocol::PluginInterface {
+                        display_name: Some("Valid Plugin".to_string()),
+                        short_description: None,
+                        long_description: None,
+                        developer_name: None,
+                        category: None,
+                        capabilities: Vec::new(),
+                        website_url: None,
+                        privacy_policy_url: None,
+                        terms_of_service_url: None,
+                        default_prompt: None,
+                        brand_color: None,
+                        composer_icon: None,
+                        logo: None,
+                        screenshots: Vec::new(),
+                    }),
                 },
-                installed: false,
-                enabled: false,
-                install_policy: PluginInstallPolicy::Available,
-                auth_policy: PluginAuthPolicy::OnInstall,
-                interface: Some(codex_app_server_protocol::PluginInterface {
-                    display_name: Some("Valid Plugin".to_string()),
-                    short_description: None,
-                    long_description: None,
-                    developer_name: None,
-                    category: None,
-                    capabilities: Vec::new(),
-                    website_url: None,
-                    privacy_policy_url: None,
-                    terms_of_service_url: None,
-                    default_prompt: None,
-                    brand_color: None,
-                    composer_icon: None,
-                    logo: None,
-                    screenshots: Vec::new(),
-                }),
-            }],
+                PluginSummary {
+                    id: "missing-plugin@alternate-marketplace".to_string(),
+                    name: "missing-plugin".to_string(),
+                    source: PluginSource::Local {
+                        path: AbsolutePathBuf::try_from(
+                            repo_root.path().join("plugins/missing-plugin"),
+                        )?,
+                    },
+                    installed: false,
+                    enabled: false,
+                    install_policy: PluginInstallPolicy::Available,
+                    auth_policy: PluginAuthPolicy::OnInstall,
+                    interface: None,
+                },
+            ],
         }]
     );
     assert!(response.marketplace_load_errors.is_empty());
@@ -426,17 +433,8 @@ async fn plugin_list_includes_install_and_enabled_state_from_config() -> Result<
     let repo_root = TempDir::new()?;
     std::fs::create_dir_all(repo_root.path().join(".git"))?;
     std::fs::create_dir_all(repo_root.path().join(".agents/plugins"))?;
-    std::fs::create_dir_all(repo_root.path().join("enabled-plugin"))?;
-    std::fs::create_dir_all(repo_root.path().join("disabled-plugin"))?;
-    std::fs::create_dir_all(repo_root.path().join("uninstalled-plugin"))?;
     write_installed_plugin(&codex_home, "codex-curated", "enabled-plugin")?;
     write_installed_plugin(&codex_home, "codex-curated", "disabled-plugin")?;
-    write_primary_plugin_manifest(&repo_root.path().join("enabled-plugin"), "enabled-plugin")?;
-    write_primary_plugin_manifest(&repo_root.path().join("disabled-plugin"), "disabled-plugin")?;
-    write_primary_plugin_manifest(
-        &repo_root.path().join("uninstalled-plugin"),
-        "uninstalled-plugin",
-    )?;
     std::fs::write(
         repo_root.path().join(".agents/plugins/marketplace.json"),
         r#"{
@@ -566,9 +564,7 @@ enabled = false
 async fn plugin_list_uses_home_config_for_enabled_state() -> Result<()> {
     let codex_home = TempDir::new()?;
     std::fs::create_dir_all(codex_home.path().join(".agents/plugins"))?;
-    std::fs::create_dir_all(codex_home.path().join("shared-plugin"))?;
     write_installed_plugin(&codex_home, "codex-curated", "shared-plugin")?;
-    write_primary_plugin_manifest(&codex_home.path().join("shared-plugin"), "shared-plugin")?;
     std::fs::write(
         codex_home.path().join(".agents/plugins/marketplace.json"),
         r#"{
@@ -597,11 +593,6 @@ enabled = true
     let workspace_enabled = TempDir::new()?;
     std::fs::create_dir_all(workspace_enabled.path().join(".git"))?;
     std::fs::create_dir_all(workspace_enabled.path().join(".agents/plugins"))?;
-    std::fs::create_dir_all(workspace_enabled.path().join("shared-plugin"))?;
-    write_primary_plugin_manifest(
-        &workspace_enabled.path().join("shared-plugin"),
-        "shared-plugin",
-    )?;
     std::fs::write(
         workspace_enabled
             .path()

--- a/codex-rs/app-server/tests/suite/v2/plugin_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/plugin_list.rs
@@ -34,6 +34,8 @@ use wiremock::matchers::query_param;
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
 const TEST_CURATED_PLUGIN_SHA: &str = "0123456789abcdef0123456789abcdef01234567";
 const STARTUP_REMOTE_PLUGIN_SYNC_MARKER_FILE: &str = ".tmp/app-server-remote-plugin-sync-v1";
+const ALTERNATE_MARKETPLACE_RELATIVE_PATH: &str = ".claude-plugin/marketplace.json";
+const ALTERNATE_PLUGIN_MANIFEST_RELATIVE_PATH: &str = ".claude-plugin/plugin.json";
 
 fn write_plugins_enabled_config(codex_home: &std::path::Path) -> std::io::Result<()> {
     std::fs::write(
@@ -42,6 +44,15 @@ fn write_plugins_enabled_config(codex_home: &std::path::Path) -> std::io::Result
 plugins = true
 "#,
     )
+}
+
+fn write_primary_plugin_manifest(
+    plugin_root: &std::path::Path,
+    plugin_name: &str,
+) -> std::io::Result<()> {
+    let manifest_path = plugin_root.join(".codex-plugin/plugin.json");
+    std::fs::create_dir_all(manifest_path.parent().expect("manifest parent"))?;
+    std::fs::write(manifest_path, format!(r#"{{"name":"{plugin_name}"}}"#))
 }
 
 #[tokio::test]
@@ -253,12 +264,23 @@ async fn plugin_list_uses_alternate_discoverable_manifest_and_skips_undiscoverab
     let repo_root = TempDir::new()?;
     let valid_plugin_root = repo_root.path().join("plugins/valid-plugin");
     std::fs::create_dir_all(repo_root.path().join(".git"))?;
-    std::fs::create_dir_all(repo_root.path().join(".claude-plugin"))?;
-    std::fs::create_dir_all(valid_plugin_root.join(".claude-plugin"))?;
+    std::fs::create_dir_all(
+        repo_root
+            .path()
+            .join(ALTERNATE_MARKETPLACE_RELATIVE_PATH)
+            .parent()
+            .unwrap(),
+    )?;
+    std::fs::create_dir_all(
+        valid_plugin_root
+            .join(ALTERNATE_PLUGIN_MANIFEST_RELATIVE_PATH)
+            .parent()
+            .unwrap(),
+    )?;
     write_plugins_enabled_config(codex_home.path())?;
 
     let marketplace_path =
-        AbsolutePathBuf::try_from(repo_root.path().join(".claude-plugin/marketplace.json"))?;
+        AbsolutePathBuf::try_from(repo_root.path().join(ALTERNATE_MARKETPLACE_RELATIVE_PATH))?;
     let valid_plugin_path = AbsolutePathBuf::try_from(valid_plugin_root.clone())?;
 
     std::fs::write(
@@ -278,7 +300,7 @@ async fn plugin_list_uses_alternate_discoverable_manifest_and_skips_undiscoverab
 }"#,
     )?;
     std::fs::write(
-        valid_plugin_root.join(".claude-plugin/plugin.json"),
+        valid_plugin_root.join(ALTERNATE_PLUGIN_MANIFEST_RELATIVE_PATH),
         r#"{
   "name": "valid-plugin",
   "interface": {
@@ -404,8 +426,17 @@ async fn plugin_list_includes_install_and_enabled_state_from_config() -> Result<
     let repo_root = TempDir::new()?;
     std::fs::create_dir_all(repo_root.path().join(".git"))?;
     std::fs::create_dir_all(repo_root.path().join(".agents/plugins"))?;
+    std::fs::create_dir_all(repo_root.path().join("enabled-plugin"))?;
+    std::fs::create_dir_all(repo_root.path().join("disabled-plugin"))?;
+    std::fs::create_dir_all(repo_root.path().join("uninstalled-plugin"))?;
     write_installed_plugin(&codex_home, "codex-curated", "enabled-plugin")?;
     write_installed_plugin(&codex_home, "codex-curated", "disabled-plugin")?;
+    write_primary_plugin_manifest(&repo_root.path().join("enabled-plugin"), "enabled-plugin")?;
+    write_primary_plugin_manifest(&repo_root.path().join("disabled-plugin"), "disabled-plugin")?;
+    write_primary_plugin_manifest(
+        &repo_root.path().join("uninstalled-plugin"),
+        "uninstalled-plugin",
+    )?;
     std::fs::write(
         repo_root.path().join(".agents/plugins/marketplace.json"),
         r#"{
@@ -535,7 +566,9 @@ enabled = false
 async fn plugin_list_uses_home_config_for_enabled_state() -> Result<()> {
     let codex_home = TempDir::new()?;
     std::fs::create_dir_all(codex_home.path().join(".agents/plugins"))?;
+    std::fs::create_dir_all(codex_home.path().join("shared-plugin"))?;
     write_installed_plugin(&codex_home, "codex-curated", "shared-plugin")?;
+    write_primary_plugin_manifest(&codex_home.path().join("shared-plugin"), "shared-plugin")?;
     std::fs::write(
         codex_home.path().join(".agents/plugins/marketplace.json"),
         r#"{
@@ -564,6 +597,11 @@ enabled = true
     let workspace_enabled = TempDir::new()?;
     std::fs::create_dir_all(workspace_enabled.path().join(".git"))?;
     std::fs::create_dir_all(workspace_enabled.path().join(".agents/plugins"))?;
+    std::fs::create_dir_all(workspace_enabled.path().join("shared-plugin"))?;
+    write_primary_plugin_manifest(
+        &workspace_enabled.path().join("shared-plugin"),
+        "shared-plugin",
+    )?;
     std::fs::write(
         workspace_enabled
             .path()

--- a/codex-rs/app-server/tests/suite/v2/plugin_read.rs
+++ b/codex-rs/app-server/tests/suite/v2/plugin_read.rs
@@ -515,7 +515,7 @@ async fn plugin_read_returns_invalid_request_when_plugin_manifest_is_missing() -
     assert!(
         err.error
             .message
-            .contains("missing or invalid .codex-plugin/plugin.json")
+            .contains("missing or invalid plugin manifest")
     );
     Ok(())
 }

--- a/codex-rs/app-server/tests/suite/v2/plugin_read.rs
+++ b/codex-rs/app-server/tests/suite/v2/plugin_read.rs
@@ -512,11 +512,7 @@ async fn plugin_read_returns_invalid_request_when_plugin_manifest_is_missing() -
     .await??;
 
     assert_eq!(err.error.code, -32600);
-    assert!(
-        err.error
-            .message
-            .contains("missing or invalid plugin manifest")
-    );
+    assert!(err.error.message.contains("missing or invalid plugin.json"));
     Ok(())
 }
 

--- a/codex-rs/core-plugins/src/loader.rs
+++ b/codex-rs/core-plugins/src/loader.rs
@@ -462,7 +462,7 @@ async fn load_plugin(
     }
 
     let Some(manifest) = load_plugin_manifest(plugin_root.as_path()) else {
-        loaded_plugin.error = Some("missing or invalid plugin manifest".to_string());
+        loaded_plugin.error = Some("missing or invalid plugin.json".to_string());
         return loaded_plugin;
     };
 

--- a/codex-rs/core-plugins/src/loader.rs
+++ b/codex-rs/core-plugins/src/loader.rs
@@ -462,7 +462,7 @@ async fn load_plugin(
     }
 
     let Some(manifest) = load_plugin_manifest(plugin_root.as_path()) else {
-        loaded_plugin.error = Some("missing or invalid .codex-plugin/plugin.json".to_string());
+        loaded_plugin.error = Some("missing or invalid plugin manifest".to_string());
         return loaded_plugin;
     };
 

--- a/codex-rs/core-plugins/src/manifest.rs
+++ b/codex-rs/core-plugins/src/manifest.rs
@@ -1,5 +1,5 @@
 use codex_utils_absolute_path::AbsolutePathBuf;
-use codex_utils_plugins::PLUGIN_MANIFEST_PATH;
+use codex_utils_plugins::find_plugin_manifest_path;
 use serde::Deserialize;
 use serde_json::Value as JsonValue;
 use std::fs;
@@ -115,10 +115,7 @@ enum RawPluginManifestDefaultPromptEntry {
 }
 
 pub fn load_plugin_manifest(plugin_root: &Path) -> Option<PluginManifest> {
-    let manifest_path = plugin_root.join(PLUGIN_MANIFEST_PATH);
-    if !manifest_path.is_file() {
-        return None;
-    }
+    let manifest_path = find_plugin_manifest_path(plugin_root)?;
     let contents = fs::read_to_string(&manifest_path).ok()?;
     match serde_json::from_str::<RawPluginManifest>(&contents) {
         Ok(manifest) => {
@@ -319,11 +316,14 @@ fn resolve_default_prompt_str(plugin_root: &Path, field: &str, prompt: &str) -> 
 }
 
 fn warn_invalid_default_prompt(plugin_root: &Path, field: &str, message: &str) {
-    let manifest_path = plugin_root.join(PLUGIN_MANIFEST_PATH);
-    tracing::warn!(
-        path = %manifest_path.display(),
-        "ignoring {field}: {message}"
-    );
+    if let Some(manifest_path) = find_plugin_manifest_path(plugin_root) {
+        tracing::warn!(
+            path = %manifest_path.display(),
+            "ignoring {field}: {message}"
+        );
+    } else {
+        tracing::warn!("ignoring {field}: {message}");
+    }
 }
 
 fn json_value_type(value: &JsonValue) -> &'static str {
@@ -406,6 +406,12 @@ mod tests {
             ),
         )
         .expect("write manifest");
+    }
+
+    fn write_alternate_manifest(plugin_root: &Path, contents: &str) {
+        fs::create_dir_all(plugin_root.join(".claude-plugin")).expect("create manifest dir");
+        fs::write(plugin_root.join(".claude-plugin/plugin.json"), contents)
+            .expect("write manifest");
     }
 
     fn load_manifest(plugin_root: &Path) -> PluginManifest {
@@ -505,5 +511,32 @@ mod tests {
         let manifest = load_manifest(&plugin_root);
 
         assert_eq!(manifest.version, Some("1.2.3-beta+7".to_string()));
+    }
+
+    #[test]
+    fn plugin_manifest_uses_alternate_discoverable_path() {
+        let tmp = tempdir().expect("tempdir");
+        let plugin_root = tmp.path().join("demo-plugin");
+        write_alternate_manifest(
+            &plugin_root,
+            r#"{
+  "name": "demo-plugin",
+  "version": " 2.0.0 ",
+  "interface": {
+    "displayName": "Fallback Plugin"
+  }
+}"#,
+        );
+
+        let manifest = load_manifest(&plugin_root);
+
+        assert_eq!(manifest.version, Some("2.0.0".to_string()));
+        assert_eq!(
+            manifest
+                .interface
+                .as_ref()
+                .and_then(|interface| interface.display_name.as_deref()),
+            Some("Fallback Plugin")
+        );
     }
 }

--- a/codex-rs/core-plugins/src/manifest.rs
+++ b/codex-rs/core-plugins/src/manifest.rs
@@ -390,6 +390,8 @@ mod tests {
     use std::path::Path;
     use tempfile::tempdir;
 
+    const ALTERNATE_PLUGIN_MANIFEST_RELATIVE_PATH: &str = ".claude-plugin/plugin.json";
+
     fn write_manifest(plugin_root: &Path, version: Option<&str>, interface: &str) {
         fs::create_dir_all(plugin_root.join(".codex-plugin")).expect("create manifest dir");
         let version = version
@@ -408,10 +410,11 @@ mod tests {
         .expect("write manifest");
     }
 
-    fn write_alternate_manifest(plugin_root: &Path, contents: &str) {
-        fs::create_dir_all(plugin_root.join(".claude-plugin")).expect("create manifest dir");
-        fs::write(plugin_root.join(".claude-plugin/plugin.json"), contents)
-            .expect("write manifest");
+    fn write_alternate_plugin_manifest(plugin_root: &Path, contents: &str) {
+        let manifest_path = plugin_root.join(ALTERNATE_PLUGIN_MANIFEST_RELATIVE_PATH);
+        fs::create_dir_all(manifest_path.parent().expect("manifest parent"))
+            .expect("create manifest dir");
+        fs::write(manifest_path, contents).expect("write manifest");
     }
 
     fn load_manifest(plugin_root: &Path) -> PluginManifest {
@@ -517,7 +520,7 @@ mod tests {
     fn plugin_manifest_uses_alternate_discoverable_path() {
         let tmp = tempdir().expect("tempdir");
         let plugin_root = tmp.path().join("demo-plugin");
-        write_alternate_manifest(
+        write_alternate_plugin_manifest(
             &plugin_root,
             r#"{
   "name": "demo-plugin",

--- a/codex-rs/core-plugins/src/marketplace.rs
+++ b/codex-rs/core-plugins/src/marketplace.rs
@@ -160,7 +160,7 @@ impl MarketplaceError {
     }
 }
 
-pub fn resolve_marketplace_plugin(
+pub fn find_marketplace_plugin(
     marketplace_path: &AbsolutePathBuf,
     plugin_name: &str,
 ) -> Result<ResolvedMarketplacePlugin, MarketplaceError> {
@@ -185,12 +185,12 @@ pub fn resolve_marketplace_plugin(
     })
 }
 
-pub fn resolve_installable_marketplace_plugin(
+pub fn find_installable_marketplace_plugin(
     marketplace_path: &AbsolutePathBuf,
     plugin_name: &str,
     restriction_product: Option<Product>,
 ) -> Result<ResolvedMarketplacePlugin, MarketplaceError> {
-    let resolved = resolve_marketplace_plugin(marketplace_path, plugin_name)?;
+    let resolved = find_marketplace_plugin(marketplace_path, plugin_name)?;
     let product_allowed = match resolved.policy.products.as_deref() {
         None => true,
         Some([]) => false,
@@ -266,21 +266,20 @@ pub fn load_marketplace(path: &AbsolutePathBuf) -> Result<Marketplace, Marketpla
     let mut plugins = Vec::new();
 
     for plugin in marketplace.plugins {
-        let Some(plugin) = resolve_marketplace_plugin_entry(path, &marketplace.name, plugin)?
-        else {
-            continue;
+        let plugin = match resolve_marketplace_plugin_entry(path, &marketplace.name, plugin) {
+            Ok(Some(plugin)) => plugin,
+            Ok(None) => continue,
+            Err(MarketplaceError::InvalidPlugin(message)) => {
+                warn!(
+                    path = %path.display(),
+                    marketplace = %marketplace.name,
+                    error = %message,
+                    "skipping invalid marketplace plugin"
+                );
+                continue;
+            }
+            Err(err) => return Err(err),
         };
-        // Only list marketplace plugins that Codex can actually load.
-        if plugin.manifest.is_none() {
-            let MarketplacePluginSource::Local { path: source_path } = &plugin.source;
-            warn!(
-                path = %path.display(),
-                plugin = plugin.plugin_id.plugin_name,
-                source_path = %source_path.display(),
-                "skipping marketplace plugin that failed to load"
-            );
-            continue;
-        }
 
         plugins.push(MarketplacePlugin {
             name: plugin.plugin_id.plugin_name,

--- a/codex-rs/core-plugins/src/marketplace.rs
+++ b/codex-rs/core-plugins/src/marketplace.rs
@@ -26,8 +26,10 @@ const MARKETPLACE_MANIFEST_RELATIVE_PATHS: &[&str] = &[
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedMarketplacePlugin {
     pub plugin_id: PluginId,
-    pub source_path: AbsolutePathBuf,
-    pub auth_policy: MarketplacePluginAuthPolicy,
+    pub source: MarketplacePluginSource,
+    pub policy: MarketplacePluginPolicy,
+    pub interface: Option<PluginManifestInterface>,
+    pub manifest: Option<crate::manifest::PluginManifest>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -158,12 +160,9 @@ impl MarketplaceError {
     }
 }
 
-// Always read the specified marketplace file from disk so installs see the
-// latest marketplace.json contents without any in-memory cache invalidation.
 pub fn resolve_marketplace_plugin(
     marketplace_path: &AbsolutePathBuf,
     plugin_name: &str,
-    restriction_product: Option<Product>,
 ) -> Result<ResolvedMarketplacePlugin, MarketplaceError> {
     let marketplace = load_raw_marketplace_manifest(marketplace_path)?;
     let marketplace_name = marketplace.name;
@@ -173,45 +172,42 @@ pub fn resolve_marketplace_plugin(
             continue;
         }
 
-        let RawMarketplaceManifestPlugin {
-            name,
-            source,
-            policy,
-            ..
-        } = plugin;
-        let install_policy = policy.installation;
-        let product_allowed = match policy.products.as_deref() {
-            None => true,
-            Some([]) => false,
-            Some(products) => restriction_product
-                .is_some_and(|product| product.matches_product_restriction(products)),
-        };
-        if install_policy == MarketplacePluginInstallPolicy::NotAvailable || !product_allowed {
-            return Err(MarketplaceError::PluginNotAvailable {
-                plugin_name: name,
-                marketplace_name,
-            });
+        if let Some(plugin) =
+            resolve_marketplace_plugin_entry(marketplace_path, &marketplace_name, plugin)?
+        {
+            return Ok(plugin);
         }
-
-        let Some(source_path) =
-            resolve_supported_plugin_source_path(marketplace_path, &name, source)
-        else {
-            continue;
-        };
-
-        return Ok(ResolvedMarketplacePlugin {
-            plugin_id: PluginId::new(name, marketplace_name).map_err(|err| match err {
-                PluginIdError::Invalid(message) => MarketplaceError::InvalidPlugin(message),
-            })?,
-            source_path,
-            auth_policy: policy.authentication,
-        });
     }
 
     Err(MarketplaceError::PluginNotFound {
         plugin_name: plugin_name.to_string(),
         marketplace_name: marketplace_name_for_not_found,
     })
+}
+
+pub fn resolve_installable_marketplace_plugin(
+    marketplace_path: &AbsolutePathBuf,
+    plugin_name: &str,
+    restriction_product: Option<Product>,
+) -> Result<ResolvedMarketplacePlugin, MarketplaceError> {
+    let resolved = resolve_marketplace_plugin(marketplace_path, plugin_name)?;
+    let product_allowed = match resolved.policy.products.as_deref() {
+        None => true,
+        Some([]) => false,
+        Some(products) => {
+            restriction_product.is_some_and(|product| product.matches_product_restriction(products))
+        }
+    };
+    if resolved.policy.installation == MarketplacePluginInstallPolicy::NotAvailable
+        || !product_allowed
+    {
+        return Err(MarketplaceError::PluginNotAvailable {
+            plugin_name: resolved.plugin_id.plugin_name,
+            marketplace_name: resolved.plugin_id.marketplace_name,
+        });
+    }
+
+    Ok(resolved)
 }
 
 pub fn list_marketplaces(
@@ -270,45 +266,27 @@ pub fn load_marketplace(path: &AbsolutePathBuf) -> Result<Marketplace, Marketpla
     let mut plugins = Vec::new();
 
     for plugin in marketplace.plugins {
-        let RawMarketplaceManifestPlugin {
-            name,
-            source,
-            policy,
-            category,
-        } = plugin;
-        let Some(source_path) = resolve_supported_plugin_source_path(path, &name, source) else {
+        let Some(plugin) = resolve_marketplace_plugin_entry(path, &marketplace.name, plugin)?
+        else {
             continue;
         };
         // Only list marketplace plugins that Codex can actually load.
-        let Some(manifest) = load_plugin_manifest(source_path.as_path()) else {
+        if plugin.manifest.is_none() {
+            let MarketplacePluginSource::Local { path: source_path } = &plugin.source;
             warn!(
                 path = %path.display(),
-                plugin = name,
+                plugin = plugin.plugin_id.plugin_name,
                 source_path = %source_path.display(),
                 "skipping marketplace plugin that failed to load"
             );
             continue;
-        };
-        let source = MarketplacePluginSource::Local {
-            path: source_path.clone(),
-        };
-        let mut interface = manifest.interface;
-        if let Some(category) = category {
-            // Marketplace taxonomy wins when both sources provide a category.
-            interface
-                .get_or_insert_with(PluginManifestInterface::default)
-                .category = Some(category);
         }
 
         plugins.push(MarketplacePlugin {
-            name,
-            source,
-            policy: MarketplacePluginPolicy {
-                installation: policy.installation,
-                authentication: policy.authentication,
-                products: policy.products,
-            },
-            interface,
+            name: plugin.plugin_id.plugin_name,
+            source: plugin.source,
+            policy: plugin.policy,
+            interface: plugin.interface,
         });
     }
 
@@ -396,6 +374,48 @@ fn load_raw_marketplace_manifest(
         path: path.to_path_buf(),
         message: err.to_string(),
     })
+}
+
+fn resolve_marketplace_plugin_entry(
+    marketplace_path: &AbsolutePathBuf,
+    marketplace_name: &str,
+    plugin: RawMarketplaceManifestPlugin,
+) -> Result<Option<ResolvedMarketplacePlugin>, MarketplaceError> {
+    let RawMarketplaceManifestPlugin {
+        name,
+        source,
+        policy,
+        category,
+    } = plugin;
+    let Some(source_path) = resolve_supported_plugin_source_path(marketplace_path, &name, source)
+    else {
+        return Ok(None);
+    };
+
+    let manifest = load_plugin_manifest(source_path.as_path());
+    let mut interface = manifest
+        .as_ref()
+        .and_then(|manifest| manifest.interface.clone());
+    if let Some(category) = category {
+        // Marketplace taxonomy wins when both sources provide a category.
+        interface
+            .get_or_insert_with(PluginManifestInterface::default)
+            .category = Some(category);
+    }
+
+    Ok(Some(ResolvedMarketplacePlugin {
+        plugin_id: PluginId::new(name, marketplace_name.to_string()).map_err(|err| match err {
+            PluginIdError::Invalid(message) => MarketplaceError::InvalidPlugin(message),
+        })?,
+        source: MarketplacePluginSource::Local { path: source_path },
+        policy: MarketplacePluginPolicy {
+            installation: policy.installation,
+            authentication: policy.authentication,
+            products: policy.products,
+        },
+        interface,
+        manifest,
+    }))
 }
 
 fn resolve_supported_plugin_source_path(

--- a/codex-rs/core-plugins/src/marketplace.rs
+++ b/codex-rs/core-plugins/src/marketplace.rs
@@ -279,11 +279,20 @@ pub fn load_marketplace(path: &AbsolutePathBuf) -> Result<Marketplace, Marketpla
         let Some(source_path) = resolve_supported_plugin_source_path(path, &name, source) else {
             continue;
         };
+        // Only list marketplace plugins that Codex can actually load.
+        let Some(manifest) = load_plugin_manifest(source_path.as_path()) else {
+            warn!(
+                path = %path.display(),
+                plugin = name,
+                source_path = %source_path.display(),
+                "skipping marketplace plugin that failed to load"
+            );
+            continue;
+        };
         let source = MarketplacePluginSource::Local {
             path: source_path.clone(),
         };
-        let mut interface =
-            load_plugin_manifest(source_path.as_path()).and_then(|manifest| manifest.interface);
+        let mut interface = manifest.interface;
         if let Some(category) = category {
             // Marketplace taxonomy wins when both sources provide a category.
             interface

--- a/codex-rs/core-plugins/src/marketplace_tests.rs
+++ b/codex-rs/core-plugins/src/marketplace_tests.rs
@@ -53,7 +53,6 @@ fn resolve_marketplace_plugin_finds_repo_marketplace_plugin() {
     let resolved = resolve_marketplace_plugin(
         &AbsolutePathBuf::try_from(repo_root.join(".agents/plugins/marketplace.json")).unwrap(),
         "local-plugin",
-        Some(Product::Codex),
     )
     .unwrap();
 
@@ -62,8 +61,16 @@ fn resolve_marketplace_plugin_finds_repo_marketplace_plugin() {
         ResolvedMarketplacePlugin {
             plugin_id: PluginId::new("local-plugin".to_string(), "codex-curated".to_string())
                 .unwrap(),
-            source_path: AbsolutePathBuf::try_from(repo_root.join("plugin-1")).unwrap(),
-            auth_policy: MarketplacePluginAuthPolicy::OnInstall,
+            source: MarketplacePluginSource::Local {
+                path: AbsolutePathBuf::try_from(repo_root.join("plugin-1")).unwrap(),
+            },
+            policy: MarketplacePluginPolicy {
+                installation: MarketplacePluginInstallPolicy::Available,
+                authentication: MarketplacePluginAuthPolicy::OnInstall,
+                products: None,
+            },
+            interface: None,
+            manifest: None,
         }
     );
 }
@@ -86,12 +93,7 @@ fn resolve_marketplace_plugin_supports_alternate_layout_and_string_local_source(
 }"#,
     );
 
-    let resolved = resolve_marketplace_plugin(
-        &marketplace_path,
-        "string-source-plugin",
-        Some(Product::Codex),
-    )
-    .unwrap();
+    let resolved = resolve_marketplace_plugin(&marketplace_path, "string-source-plugin").unwrap();
 
     assert_eq!(
         resolved,
@@ -101,9 +103,17 @@ fn resolve_marketplace_plugin_supports_alternate_layout_and_string_local_source(
                 "alternate-marketplace".to_string()
             )
             .unwrap(),
-            source_path: AbsolutePathBuf::try_from(repo_root.join("plugins/string-source-plugin"))
-                .unwrap(),
-            auth_policy: MarketplacePluginAuthPolicy::OnInstall,
+            source: MarketplacePluginSource::Local {
+                path: AbsolutePathBuf::try_from(repo_root.join("plugins/string-source-plugin"))
+                    .unwrap(),
+            },
+            policy: MarketplacePluginPolicy {
+                installation: MarketplacePluginInstallPolicy::Available,
+                authentication: MarketplacePluginAuthPolicy::OnInstall,
+                products: None,
+            },
+            interface: None,
+            manifest: None,
         }
     );
 }
@@ -123,7 +133,6 @@ fn resolve_marketplace_plugin_reports_missing_plugin() {
     let err = resolve_marketplace_plugin(
         &AbsolutePathBuf::try_from(repo_root.join(".agents/plugins/marketplace.json")).unwrap(),
         "missing",
-        Some(Product::Codex),
     )
     .unwrap_err();
 
@@ -534,13 +543,14 @@ fn list_marketplaces_keeps_distinct_entries_for_same_name() {
     let resolved = resolve_marketplace_plugin(
         &AbsolutePathBuf::try_from(repo_marketplace).unwrap(),
         "local-plugin",
-        Some(Product::Codex),
     )
     .unwrap();
 
     assert_eq!(
-        resolved.source_path,
-        AbsolutePathBuf::try_from(repo_root.join("repo-plugin")).unwrap()
+        resolved.source,
+        MarketplacePluginSource::Local {
+            path: AbsolutePathBuf::try_from(repo_root.join("repo-plugin")).unwrap(),
+        }
     );
 }
 
@@ -1066,7 +1076,6 @@ fn resolve_marketplace_plugin_skips_invalid_local_paths() {
     let err = resolve_marketplace_plugin(
         &AbsolutePathBuf::try_from(repo_root.join(".agents/plugins/marketplace.json")).unwrap(),
         "local-plugin",
-        Some(Product::Codex),
     )
     .unwrap_err();
 
@@ -1097,8 +1106,7 @@ fn resolve_marketplace_plugin_skips_unsupported_sources() {
 }"#,
     );
 
-    let err = resolve_marketplace_plugin(&marketplace_path, "remote-plugin", Some(Product::Codex))
-        .unwrap_err();
+    let err = resolve_marketplace_plugin(&marketplace_path, "remote-plugin").unwrap_err();
 
     assert_eq!(
         err.to_string(),
@@ -1139,13 +1147,14 @@ fn resolve_marketplace_plugin_uses_first_duplicate_entry() {
     let resolved = resolve_marketplace_plugin(
         &AbsolutePathBuf::try_from(repo_root.join(".agents/plugins/marketplace.json")).unwrap(),
         "local-plugin",
-        Some(Product::Codex),
     )
     .unwrap();
 
     assert_eq!(
-        resolved.source_path,
-        AbsolutePathBuf::try_from(repo_root.join("first")).unwrap()
+        resolved.source,
+        MarketplacePluginSource::Local {
+            path: AbsolutePathBuf::try_from(repo_root.join("first")).unwrap(),
+        }
     );
 }
 
@@ -1175,7 +1184,7 @@ fn resolve_marketplace_plugin_rejects_disallowed_product() {
     )
     .unwrap();
 
-    let err = resolve_marketplace_plugin(
+    let err = resolve_installable_marketplace_plugin(
         &AbsolutePathBuf::try_from(repo_root.join(".agents/plugins/marketplace.json")).unwrap(),
         "chatgpt-plugin",
         Some(Product::Atlas),
@@ -1215,7 +1224,6 @@ fn resolve_marketplace_plugin_allows_missing_products_field() {
     let resolved = resolve_marketplace_plugin(
         &AbsolutePathBuf::try_from(repo_root.join(".agents/plugins/marketplace.json")).unwrap(),
         "default-plugin",
-        Some(Product::Codex),
     )
     .unwrap();
 
@@ -1248,7 +1256,7 @@ fn resolve_marketplace_plugin_rejects_explicit_empty_products() {
     )
     .unwrap();
 
-    let err = resolve_marketplace_plugin(
+    let err = resolve_installable_marketplace_plugin(
         &AbsolutePathBuf::try_from(repo_root.join(".agents/plugins/marketplace.json")).unwrap(),
         "disabled-plugin",
         Some(Product::Codex),

--- a/codex-rs/core-plugins/src/marketplace_tests.rs
+++ b/codex-rs/core-plugins/src/marketplace_tests.rs
@@ -5,12 +5,25 @@ use std::path::Path;
 use tempfile::tempdir;
 
 const ALTERNATE_MARKETPLACE_RELATIVE_PATH: &str = ".claude-plugin/marketplace.json";
+const ALTERNATE_PLUGIN_MANIFEST_RELATIVE_PATH: &str = ".claude-plugin/plugin.json";
 
 fn write_alternate_marketplace(repo_root: &Path, contents: &str) -> AbsolutePathBuf {
     let marketplace_path = repo_root.join(ALTERNATE_MARKETPLACE_RELATIVE_PATH);
     fs::create_dir_all(marketplace_path.parent().unwrap()).unwrap();
     fs::write(&marketplace_path, contents).unwrap();
     AbsolutePathBuf::try_from(marketplace_path).unwrap()
+}
+
+fn write_primary_plugin_manifest(plugin_root: &Path, contents: &str) {
+    let manifest_path = plugin_root.join(".codex-plugin/plugin.json");
+    fs::create_dir_all(manifest_path.parent().unwrap()).unwrap();
+    fs::write(manifest_path, contents).unwrap();
+}
+
+fn write_alternate_plugin_manifest(plugin_root: &Path, contents: &str) {
+    let manifest_path = plugin_root.join(ALTERNATE_PLUGIN_MANIFEST_RELATIVE_PATH);
+    fs::create_dir_all(manifest_path.parent().unwrap()).unwrap();
+    fs::write(manifest_path, contents).unwrap();
 }
 
 #[test]
@@ -124,8 +137,10 @@ fn resolve_marketplace_plugin_reports_missing_plugin() {
 fn list_marketplaces_supports_alternate_manifest_layout() {
     let tmp = tempdir().unwrap();
     let repo_root = tmp.path().join("repo");
+    let plugin_root = repo_root.join("plugins/string-source-plugin");
 
     fs::create_dir_all(repo_root.join(".git")).unwrap();
+    write_alternate_plugin_manifest(&plugin_root, r#"{"name":"string-source-plugin"}"#);
     let marketplace_path = write_alternate_marketplace(
         &repo_root,
         r#"{
@@ -170,12 +185,68 @@ fn list_marketplaces_supports_alternate_manifest_layout() {
 }
 
 #[test]
+fn list_marketplaces_skips_plugins_without_discoverable_manifest() {
+    let tmp = tempdir().unwrap();
+    let repo_root = tmp.path().join("repo");
+    let valid_plugin_root = repo_root.join("plugins/valid-plugin");
+
+    fs::create_dir_all(repo_root.join(".git")).unwrap();
+    write_primary_plugin_manifest(&valid_plugin_root, r#"{"name":"valid-plugin"}"#);
+    let marketplace_path = write_alternate_marketplace(
+        &repo_root,
+        r#"{
+  "name": "alternate-marketplace",
+  "plugins": [
+    {
+      "name": "valid-plugin",
+      "source": "./plugins/valid-plugin"
+    },
+    {
+      "name": "missing-plugin",
+      "source": "./plugins/missing-plugin"
+    }
+  ]
+}"#,
+    );
+
+    let marketplaces = list_marketplaces_with_home(
+        &[AbsolutePathBuf::try_from(repo_root.clone()).unwrap()],
+        /*home_dir*/ None,
+    )
+    .unwrap()
+    .marketplaces;
+
+    assert_eq!(
+        marketplaces,
+        vec![Marketplace {
+            name: "alternate-marketplace".to_string(),
+            path: marketplace_path,
+            interface: None,
+            plugins: vec![MarketplacePlugin {
+                name: "valid-plugin".to_string(),
+                source: MarketplacePluginSource::Local {
+                    path: AbsolutePathBuf::try_from(valid_plugin_root).unwrap(),
+                },
+                policy: MarketplacePluginPolicy {
+                    installation: MarketplacePluginInstallPolicy::Available,
+                    authentication: MarketplacePluginAuthPolicy::OnInstall,
+                    products: None,
+                },
+                interface: None,
+            }],
+        }]
+    );
+}
+
+#[test]
 fn list_marketplaces_prefers_first_supported_manifest_layout() {
     let tmp = tempdir().unwrap();
     let repo_root = tmp.path().join("repo");
+    let plugin_root = repo_root.join("plugins/agents-plugin");
 
     fs::create_dir_all(repo_root.join(".git")).unwrap();
     fs::create_dir_all(repo_root.join(".agents/plugins")).unwrap();
+    write_primary_plugin_manifest(&plugin_root, r#"{"name":"agents-plugin"}"#);
     fs::write(
         repo_root.join(".agents/plugins/marketplace.json"),
         r#"{
@@ -229,6 +300,16 @@ fn list_marketplaces_returns_home_and_repo_marketplaces() {
     fs::create_dir_all(repo_root.join(".git")).unwrap();
     fs::create_dir_all(home_root.join(".agents/plugins")).unwrap();
     fs::create_dir_all(repo_root.join(".agents/plugins")).unwrap();
+    write_primary_plugin_manifest(
+        &home_root.join("home-shared"),
+        r#"{"name":"shared-plugin"}"#,
+    );
+    write_primary_plugin_manifest(&home_root.join("home-only"), r#"{"name":"home-only"}"#);
+    write_primary_plugin_manifest(
+        &repo_root.join("repo-shared"),
+        r#"{"name":"shared-plugin"}"#,
+    );
+    write_primary_plugin_manifest(&repo_root.join("repo-only"), r#"{"name":"repo-only"}"#);
     fs::write(
         home_root.join(".agents/plugins/marketplace.json"),
         r#"{
@@ -367,6 +448,8 @@ fn list_marketplaces_keeps_distinct_entries_for_same_name() {
     fs::create_dir_all(repo_root.join(".git")).unwrap();
     fs::create_dir_all(home_root.join(".agents/plugins")).unwrap();
     fs::create_dir_all(repo_root.join(".agents/plugins")).unwrap();
+    write_primary_plugin_manifest(&home_root.join("home-plugin"), r#"{"name":"local-plugin"}"#);
+    write_primary_plugin_manifest(&repo_root.join("repo-plugin"), r#"{"name":"local-plugin"}"#);
 
     fs::write(
         home_marketplace.clone(),
@@ -470,6 +553,7 @@ fn list_marketplaces_dedupes_multiple_roots_in_same_repo() {
     fs::create_dir_all(repo_root.join(".git")).unwrap();
     fs::create_dir_all(repo_root.join(".agents/plugins")).unwrap();
     fs::create_dir_all(&nested_root).unwrap();
+    write_primary_plugin_manifest(&repo_root.join("plugin"), r#"{"name":"local-plugin"}"#);
     fs::write(
         repo_root.join(".agents/plugins/marketplace.json"),
         r#"{
@@ -527,6 +611,7 @@ fn list_marketplaces_reads_marketplace_display_name() {
 
     fs::create_dir_all(repo_root.join(".git")).unwrap();
     fs::create_dir_all(repo_root.join(".agents/plugins")).unwrap();
+    write_primary_plugin_manifest(&repo_root.join("plugin"), r#"{"name":"local-plugin"}"#);
     fs::write(
         repo_root.join(".agents/plugins/marketplace.json"),
         r#"{
@@ -572,6 +657,10 @@ fn list_marketplaces_skips_invalid_plugins_but_keeps_marketplace() {
     fs::create_dir_all(valid_repo_root.join(".agents/plugins")).unwrap();
     fs::create_dir_all(invalid_repo_root.join(".git")).unwrap();
     fs::create_dir_all(invalid_repo_root.join(".agents/plugins")).unwrap();
+    write_primary_plugin_manifest(
+        &valid_repo_root.join("plugin"),
+        r#"{"name":"valid-plugin"}"#,
+    );
     fs::write(
         valid_repo_root.join(".agents/plugins/marketplace.json"),
         r#"{
@@ -631,6 +720,10 @@ fn list_marketplaces_reports_marketplace_load_errors() {
     fs::create_dir_all(valid_repo_root.join(".agents/plugins")).unwrap();
     fs::create_dir_all(invalid_repo_root.join(".git")).unwrap();
     fs::create_dir_all(invalid_repo_root.join(".agents/plugins")).unwrap();
+    write_primary_plugin_manifest(
+        &valid_repo_root.join("plugin"),
+        r#"{"name":"valid-plugin"}"#,
+    );
     fs::write(
         valid_repo_root.join(".agents/plugins/marketplace.json"),
         r#"{
@@ -680,6 +773,10 @@ fn list_marketplaces_skips_unsupported_plugin_sources_but_keeps_local_plugins() 
     let repo_root = tmp.path().join("repo");
 
     fs::create_dir_all(repo_root.join(".git")).unwrap();
+    write_primary_plugin_manifest(
+        &repo_root.join("plugins/local-plugin"),
+        r#"{"name":"local-plugin"}"#,
+    );
     write_alternate_marketplace(
         &repo_root,
         r#"{
@@ -825,6 +922,10 @@ fn list_marketplaces_ignores_legacy_top_level_policy_fields() {
 
     fs::create_dir_all(repo_root.join(".git")).unwrap();
     fs::create_dir_all(repo_root.join(".agents/plugins")).unwrap();
+    write_primary_plugin_manifest(
+        &repo_root.join("plugins/demo-plugin"),
+        r#"{"name":"demo-plugin"}"#,
+    );
     fs::write(
         repo_root.join(".agents/plugins/marketplace.json"),
         r#"{

--- a/codex-rs/core-plugins/src/marketplace_tests.rs
+++ b/codex-rs/core-plugins/src/marketplace_tests.rs
@@ -14,12 +14,6 @@ fn write_alternate_marketplace(repo_root: &Path, contents: &str) -> AbsolutePath
     AbsolutePathBuf::try_from(marketplace_path).unwrap()
 }
 
-fn write_primary_plugin_manifest(plugin_root: &Path, contents: &str) {
-    let manifest_path = plugin_root.join(".codex-plugin/plugin.json");
-    fs::create_dir_all(manifest_path.parent().unwrap()).unwrap();
-    fs::write(manifest_path, contents).unwrap();
-}
-
 fn write_alternate_plugin_manifest(plugin_root: &Path, contents: &str) {
     let manifest_path = plugin_root.join(ALTERNATE_PLUGIN_MANIFEST_RELATIVE_PATH);
     fs::create_dir_all(manifest_path.parent().unwrap()).unwrap();
@@ -27,7 +21,7 @@ fn write_alternate_plugin_manifest(plugin_root: &Path, contents: &str) {
 }
 
 #[test]
-fn resolve_marketplace_plugin_finds_repo_marketplace_plugin() {
+fn find_marketplace_plugin_finds_repo_marketplace_plugin() {
     let tmp = tempdir().unwrap();
     let repo_root = tmp.path().join("repo");
     fs::create_dir_all(repo_root.join(".git")).unwrap();
@@ -50,7 +44,7 @@ fn resolve_marketplace_plugin_finds_repo_marketplace_plugin() {
     )
     .unwrap();
 
-    let resolved = resolve_marketplace_plugin(
+    let resolved = find_marketplace_plugin(
         &AbsolutePathBuf::try_from(repo_root.join(".agents/plugins/marketplace.json")).unwrap(),
         "local-plugin",
     )
@@ -76,7 +70,7 @@ fn resolve_marketplace_plugin_finds_repo_marketplace_plugin() {
 }
 
 #[test]
-fn resolve_marketplace_plugin_supports_alternate_layout_and_string_local_source() {
+fn find_marketplace_plugin_supports_alternate_layout_and_string_local_source() {
     let tmp = tempdir().unwrap();
     let repo_root = tmp.path().join("repo");
     fs::create_dir_all(repo_root.join(".git")).unwrap();
@@ -93,7 +87,7 @@ fn resolve_marketplace_plugin_supports_alternate_layout_and_string_local_source(
 }"#,
     );
 
-    let resolved = resolve_marketplace_plugin(&marketplace_path, "string-source-plugin").unwrap();
+    let resolved = find_marketplace_plugin(&marketplace_path, "string-source-plugin").unwrap();
 
     assert_eq!(
         resolved,
@@ -119,7 +113,7 @@ fn resolve_marketplace_plugin_supports_alternate_layout_and_string_local_source(
 }
 
 #[test]
-fn resolve_marketplace_plugin_reports_missing_plugin() {
+fn find_marketplace_plugin_reports_missing_plugin() {
     let tmp = tempdir().unwrap();
     let repo_root = tmp.path().join("repo");
     fs::create_dir_all(repo_root.join(".git")).unwrap();
@@ -130,7 +124,7 @@ fn resolve_marketplace_plugin_reports_missing_plugin() {
     )
     .unwrap();
 
-    let err = resolve_marketplace_plugin(
+    let err = find_marketplace_plugin(
         &AbsolutePathBuf::try_from(repo_root.join(".agents/plugins/marketplace.json")).unwrap(),
         "missing",
     )
@@ -149,7 +143,15 @@ fn list_marketplaces_supports_alternate_manifest_layout() {
     let plugin_root = repo_root.join("plugins/string-source-plugin");
 
     fs::create_dir_all(repo_root.join(".git")).unwrap();
-    write_alternate_plugin_manifest(&plugin_root, r#"{"name":"string-source-plugin"}"#);
+    write_alternate_plugin_manifest(
+        &plugin_root,
+        r#"{
+  "name":"string-source-plugin",
+  "interface": {
+    "displayName": "String Source Plugin"
+  }
+}"#,
+    );
     let marketplace_path = write_alternate_marketplace(
         &repo_root,
         r#"{
@@ -187,29 +189,38 @@ fn list_marketplaces_supports_alternate_manifest_layout() {
                     authentication: MarketplacePluginAuthPolicy::OnInstall,
                     products: None,
                 },
-                interface: None,
+                interface: Some(PluginManifestInterface {
+                    display_name: Some("String Source Plugin".to_string()),
+                    short_description: None,
+                    long_description: None,
+                    developer_name: None,
+                    category: None,
+                    capabilities: Vec::new(),
+                    website_url: None,
+                    privacy_policy_url: None,
+                    terms_of_service_url: None,
+                    default_prompt: None,
+                    brand_color: None,
+                    composer_icon: None,
+                    logo: None,
+                    screenshots: Vec::new(),
+                }),
             }],
         }]
     );
 }
 
 #[test]
-fn list_marketplaces_skips_plugins_without_discoverable_manifest() {
+fn list_marketplaces_includes_plugins_without_discoverable_manifest() {
     let tmp = tempdir().unwrap();
     let repo_root = tmp.path().join("repo");
-    let valid_plugin_root = repo_root.join("plugins/valid-plugin");
 
     fs::create_dir_all(repo_root.join(".git")).unwrap();
-    write_primary_plugin_manifest(&valid_plugin_root, r#"{"name":"valid-plugin"}"#);
     let marketplace_path = write_alternate_marketplace(
         &repo_root,
         r#"{
   "name": "alternate-marketplace",
   "plugins": [
-    {
-      "name": "valid-plugin",
-      "source": "./plugins/valid-plugin"
-    },
     {
       "name": "missing-plugin",
       "source": "./plugins/missing-plugin"
@@ -232,9 +243,10 @@ fn list_marketplaces_skips_plugins_without_discoverable_manifest() {
             path: marketplace_path,
             interface: None,
             plugins: vec![MarketplacePlugin {
-                name: "valid-plugin".to_string(),
+                name: "missing-plugin".to_string(),
                 source: MarketplacePluginSource::Local {
-                    path: AbsolutePathBuf::try_from(valid_plugin_root).unwrap(),
+                    path: AbsolutePathBuf::try_from(repo_root.join("plugins/missing-plugin"),)
+                        .unwrap(),
                 },
                 policy: MarketplacePluginPolicy {
                     installation: MarketplacePluginInstallPolicy::Available,
@@ -251,11 +263,9 @@ fn list_marketplaces_skips_plugins_without_discoverable_manifest() {
 fn list_marketplaces_prefers_first_supported_manifest_layout() {
     let tmp = tempdir().unwrap();
     let repo_root = tmp.path().join("repo");
-    let plugin_root = repo_root.join("plugins/agents-plugin");
 
     fs::create_dir_all(repo_root.join(".git")).unwrap();
     fs::create_dir_all(repo_root.join(".agents/plugins")).unwrap();
-    write_primary_plugin_manifest(&plugin_root, r#"{"name":"agents-plugin"}"#);
     fs::write(
         repo_root.join(".agents/plugins/marketplace.json"),
         r#"{
@@ -309,16 +319,6 @@ fn list_marketplaces_returns_home_and_repo_marketplaces() {
     fs::create_dir_all(repo_root.join(".git")).unwrap();
     fs::create_dir_all(home_root.join(".agents/plugins")).unwrap();
     fs::create_dir_all(repo_root.join(".agents/plugins")).unwrap();
-    write_primary_plugin_manifest(
-        &home_root.join("home-shared"),
-        r#"{"name":"shared-plugin"}"#,
-    );
-    write_primary_plugin_manifest(&home_root.join("home-only"), r#"{"name":"home-only"}"#);
-    write_primary_plugin_manifest(
-        &repo_root.join("repo-shared"),
-        r#"{"name":"shared-plugin"}"#,
-    );
-    write_primary_plugin_manifest(&repo_root.join("repo-only"), r#"{"name":"repo-only"}"#);
     fs::write(
         home_root.join(".agents/plugins/marketplace.json"),
         r#"{
@@ -457,8 +457,6 @@ fn list_marketplaces_keeps_distinct_entries_for_same_name() {
     fs::create_dir_all(repo_root.join(".git")).unwrap();
     fs::create_dir_all(home_root.join(".agents/plugins")).unwrap();
     fs::create_dir_all(repo_root.join(".agents/plugins")).unwrap();
-    write_primary_plugin_manifest(&home_root.join("home-plugin"), r#"{"name":"local-plugin"}"#);
-    write_primary_plugin_manifest(&repo_root.join("repo-plugin"), r#"{"name":"local-plugin"}"#);
 
     fs::write(
         home_marketplace.clone(),
@@ -540,7 +538,7 @@ fn list_marketplaces_keeps_distinct_entries_for_same_name() {
         ]
     );
 
-    let resolved = resolve_marketplace_plugin(
+    let resolved = find_marketplace_plugin(
         &AbsolutePathBuf::try_from(repo_marketplace).unwrap(),
         "local-plugin",
     )
@@ -563,7 +561,6 @@ fn list_marketplaces_dedupes_multiple_roots_in_same_repo() {
     fs::create_dir_all(repo_root.join(".git")).unwrap();
     fs::create_dir_all(repo_root.join(".agents/plugins")).unwrap();
     fs::create_dir_all(&nested_root).unwrap();
-    write_primary_plugin_manifest(&repo_root.join("plugin"), r#"{"name":"local-plugin"}"#);
     fs::write(
         repo_root.join(".agents/plugins/marketplace.json"),
         r#"{
@@ -621,7 +618,6 @@ fn list_marketplaces_reads_marketplace_display_name() {
 
     fs::create_dir_all(repo_root.join(".git")).unwrap();
     fs::create_dir_all(repo_root.join(".agents/plugins")).unwrap();
-    write_primary_plugin_manifest(&repo_root.join("plugin"), r#"{"name":"local-plugin"}"#);
     fs::write(
         repo_root.join(".agents/plugins/marketplace.json"),
         r#"{
@@ -667,10 +663,6 @@ fn list_marketplaces_skips_invalid_plugins_but_keeps_marketplace() {
     fs::create_dir_all(valid_repo_root.join(".agents/plugins")).unwrap();
     fs::create_dir_all(invalid_repo_root.join(".git")).unwrap();
     fs::create_dir_all(invalid_repo_root.join(".agents/plugins")).unwrap();
-    write_primary_plugin_manifest(
-        &valid_repo_root.join("plugin"),
-        r#"{"name":"valid-plugin"}"#,
-    );
     fs::write(
         valid_repo_root.join(".agents/plugins/marketplace.json"),
         r#"{
@@ -721,6 +713,67 @@ fn list_marketplaces_skips_invalid_plugins_but_keeps_marketplace() {
 }
 
 #[test]
+fn list_marketplaces_skips_plugins_with_invalid_names_but_keeps_marketplace() {
+    let tmp = tempdir().unwrap();
+    let repo_root = tmp.path().join("repo");
+
+    fs::create_dir_all(repo_root.join(".git")).unwrap();
+    fs::create_dir_all(repo_root.join(".agents/plugins")).unwrap();
+    fs::write(
+        repo_root.join(".agents/plugins/marketplace.json"),
+        r#"{
+  "name": "invalid-name-marketplace",
+  "plugins": [
+    {
+      "name": "valid-plugin",
+      "source": {
+        "source": "local",
+        "path": "./valid-plugin"
+      }
+    },
+    {
+      "name": "invalid.plugin",
+      "source": {
+        "source": "local",
+        "path": "./invalid-plugin"
+      }
+    }
+  ]
+}"#,
+    )
+    .unwrap();
+
+    let marketplaces = list_marketplaces_with_home(
+        &[AbsolutePathBuf::try_from(repo_root.clone()).unwrap()],
+        /*home_dir*/ None,
+    )
+    .unwrap()
+    .marketplaces;
+
+    assert_eq!(
+        marketplaces,
+        vec![Marketplace {
+            name: "invalid-name-marketplace".to_string(),
+            path: AbsolutePathBuf::try_from(repo_root.join(".agents/plugins/marketplace.json"))
+                .unwrap(),
+            interface: None,
+            plugins: vec![MarketplacePlugin {
+                name: "valid-plugin".to_string(),
+                source: MarketplacePluginSource::Local {
+                    path: AbsolutePathBuf::try_from(repo_root.join("valid-plugin")).unwrap(),
+                },
+                policy: MarketplacePluginPolicy {
+                    installation: MarketplacePluginInstallPolicy::Available,
+                    authentication: MarketplacePluginAuthPolicy::OnInstall,
+                    products: None,
+                },
+                interface: None,
+            }],
+        }]
+    );
+}
+
+#[test]
 fn list_marketplaces_reports_marketplace_load_errors() {
     let tmp = tempdir().unwrap();
     let valid_repo_root = tmp.path().join("valid-repo");
@@ -730,10 +783,6 @@ fn list_marketplaces_reports_marketplace_load_errors() {
     fs::create_dir_all(valid_repo_root.join(".agents/plugins")).unwrap();
     fs::create_dir_all(invalid_repo_root.join(".git")).unwrap();
     fs::create_dir_all(invalid_repo_root.join(".agents/plugins")).unwrap();
-    write_primary_plugin_manifest(
-        &valid_repo_root.join("plugin"),
-        r#"{"name":"valid-plugin"}"#,
-    );
     fs::write(
         valid_repo_root.join(".agents/plugins/marketplace.json"),
         r#"{
@@ -783,10 +832,6 @@ fn list_marketplaces_skips_unsupported_plugin_sources_but_keeps_local_plugins() 
     let repo_root = tmp.path().join("repo");
 
     fs::create_dir_all(repo_root.join(".git")).unwrap();
-    write_primary_plugin_manifest(
-        &repo_root.join("plugins/local-plugin"),
-        r#"{"name":"local-plugin"}"#,
-    );
     write_alternate_marketplace(
         &repo_root,
         r#"{
@@ -932,10 +977,6 @@ fn list_marketplaces_ignores_legacy_top_level_policy_fields() {
 
     fs::create_dir_all(repo_root.join(".git")).unwrap();
     fs::create_dir_all(repo_root.join(".agents/plugins")).unwrap();
-    write_primary_plugin_manifest(
-        &repo_root.join("plugins/demo-plugin"),
-        r#"{"name":"demo-plugin"}"#,
-    );
     fs::write(
         repo_root.join(".agents/plugins/marketplace.json"),
         r#"{
@@ -1051,7 +1092,7 @@ fn list_marketplaces_ignores_plugin_interface_assets_without_dot_slash() {
 }
 
 #[test]
-fn resolve_marketplace_plugin_skips_invalid_local_paths() {
+fn find_marketplace_plugin_skips_invalid_local_paths() {
     let tmp = tempdir().unwrap();
     let repo_root = tmp.path().join("repo");
     fs::create_dir_all(repo_root.join(".git")).unwrap();
@@ -1073,7 +1114,7 @@ fn resolve_marketplace_plugin_skips_invalid_local_paths() {
     )
     .unwrap();
 
-    let err = resolve_marketplace_plugin(
+    let err = find_marketplace_plugin(
         &AbsolutePathBuf::try_from(repo_root.join(".agents/plugins/marketplace.json")).unwrap(),
         "local-plugin",
     )
@@ -1086,7 +1127,7 @@ fn resolve_marketplace_plugin_skips_invalid_local_paths() {
 }
 
 #[test]
-fn resolve_marketplace_plugin_skips_unsupported_sources() {
+fn find_marketplace_plugin_skips_unsupported_sources() {
     let tmp = tempdir().unwrap();
     let repo_root = tmp.path().join("repo");
     fs::create_dir_all(repo_root.join(".git")).unwrap();
@@ -1106,7 +1147,7 @@ fn resolve_marketplace_plugin_skips_unsupported_sources() {
 }"#,
     );
 
-    let err = resolve_marketplace_plugin(&marketplace_path, "remote-plugin").unwrap_err();
+    let err = find_marketplace_plugin(&marketplace_path, "remote-plugin").unwrap_err();
 
     assert_eq!(
         err.to_string(),
@@ -1115,7 +1156,7 @@ fn resolve_marketplace_plugin_skips_unsupported_sources() {
 }
 
 #[test]
-fn resolve_marketplace_plugin_uses_first_duplicate_entry() {
+fn find_marketplace_plugin_uses_first_duplicate_entry() {
     let tmp = tempdir().unwrap();
     let repo_root = tmp.path().join("repo");
     fs::create_dir_all(repo_root.join(".git")).unwrap();
@@ -1144,7 +1185,7 @@ fn resolve_marketplace_plugin_uses_first_duplicate_entry() {
     )
     .unwrap();
 
-    let resolved = resolve_marketplace_plugin(
+    let resolved = find_marketplace_plugin(
         &AbsolutePathBuf::try_from(repo_root.join(".agents/plugins/marketplace.json")).unwrap(),
         "local-plugin",
     )
@@ -1159,7 +1200,7 @@ fn resolve_marketplace_plugin_uses_first_duplicate_entry() {
 }
 
 #[test]
-fn resolve_marketplace_plugin_rejects_disallowed_product() {
+fn find_installable_marketplace_plugin_rejects_disallowed_product() {
     let tmp = tempdir().unwrap();
     let repo_root = tmp.path().join("repo");
     fs::create_dir_all(repo_root.join(".git")).unwrap();
@@ -1184,7 +1225,7 @@ fn resolve_marketplace_plugin_rejects_disallowed_product() {
     )
     .unwrap();
 
-    let err = resolve_installable_marketplace_plugin(
+    let err = find_installable_marketplace_plugin(
         &AbsolutePathBuf::try_from(repo_root.join(".agents/plugins/marketplace.json")).unwrap(),
         "chatgpt-plugin",
         Some(Product::Atlas),
@@ -1198,7 +1239,7 @@ fn resolve_marketplace_plugin_rejects_disallowed_product() {
 }
 
 #[test]
-fn resolve_marketplace_plugin_allows_missing_products_field() {
+fn find_marketplace_plugin_allows_missing_products_field() {
     let tmp = tempdir().unwrap();
     let repo_root = tmp.path().join("repo");
     fs::create_dir_all(repo_root.join(".git")).unwrap();
@@ -1221,7 +1262,7 @@ fn resolve_marketplace_plugin_allows_missing_products_field() {
     )
     .unwrap();
 
-    let resolved = resolve_marketplace_plugin(
+    let resolved = find_marketplace_plugin(
         &AbsolutePathBuf::try_from(repo_root.join(".agents/plugins/marketplace.json")).unwrap(),
         "default-plugin",
     )
@@ -1231,7 +1272,7 @@ fn resolve_marketplace_plugin_allows_missing_products_field() {
 }
 
 #[test]
-fn resolve_marketplace_plugin_rejects_explicit_empty_products() {
+fn find_installable_marketplace_plugin_rejects_explicit_empty_products() {
     let tmp = tempdir().unwrap();
     let repo_root = tmp.path().join("repo");
     fs::create_dir_all(repo_root.join(".git")).unwrap();
@@ -1256,7 +1297,7 @@ fn resolve_marketplace_plugin_rejects_explicit_empty_products() {
     )
     .unwrap();
 
-    let err = resolve_installable_marketplace_plugin(
+    let err = find_installable_marketplace_plugin(
         &AbsolutePathBuf::try_from(repo_root.join(".agents/plugins/marketplace.json")).unwrap(),
         "disabled-plugin",
         Some(Product::Codex),

--- a/codex-rs/core-plugins/src/store.rs
+++ b/codex-rs/core-plugins/src/store.rs
@@ -114,7 +114,7 @@ impl PluginStore {
         let plugin_name = plugin_name_for_source(source_path.as_path())?;
         if plugin_name != plugin_id.plugin_name {
             return Err(PluginStoreError::Invalid(format!(
-                "plugin manifest name `{plugin_name}` does not match marketplace plugin name `{}`",
+                "plugin.json name `{plugin_name}` does not match marketplace plugin name `{}`",
                 plugin_id.plugin_name
             )));
         }
@@ -185,7 +185,7 @@ fn validate_plugin_version_segment(plugin_version: &str) -> Result<(), String> {
 
 fn plugin_manifest_for_source(source_path: &Path) -> Result<PluginManifest, PluginStoreError> {
     load_plugin_manifest(source_path)
-        .ok_or_else(|| PluginStoreError::Invalid("missing or invalid plugin manifest".to_string()))
+        .ok_or_else(|| PluginStoreError::Invalid("missing or invalid plugin.json".to_string()))
 }
 
 #[derive(Debug, Deserialize)]
@@ -199,25 +199,24 @@ fn plugin_manifest_version_for_source(
     source_path: &Path,
 ) -> Result<Option<String>, PluginStoreError> {
     let manifest_path = find_plugin_manifest_path(source_path)
-        .ok_or_else(|| PluginStoreError::Invalid("missing plugin manifest".to_string()))?;
+        .ok_or_else(|| PluginStoreError::Invalid("missing plugin.json".to_string()))?;
 
     let contents = fs::read_to_string(&manifest_path)
-        .map_err(|err| PluginStoreError::io("failed to read plugin manifest", err))?;
-    let manifest: RawPluginManifestVersion = serde_json::from_str(&contents).map_err(|err| {
-        PluginStoreError::Invalid(format!("failed to parse plugin manifest: {err}"))
-    })?;
+        .map_err(|err| PluginStoreError::io("failed to read plugin.json", err))?;
+    let manifest: RawPluginManifestVersion = serde_json::from_str(&contents)
+        .map_err(|err| PluginStoreError::Invalid(format!("failed to parse plugin.json: {err}")))?;
     let Some(version) = manifest.version else {
         return Ok(None);
     };
     let Some(version) = version.as_str() else {
         return Err(PluginStoreError::Invalid(
-            "invalid plugin version in plugin manifest: expected string".to_string(),
+            "invalid plugin version in plugin.json: expected string".to_string(),
         ));
     };
     let version = version.trim();
     if version.is_empty() {
         return Err(PluginStoreError::Invalid(
-            "invalid plugin version in plugin manifest: must not be blank".to_string(),
+            "invalid plugin version in plugin.json: must not be blank".to_string(),
         ));
     }
     Ok(Some(version.to_string()))

--- a/codex-rs/core-plugins/src/store.rs
+++ b/codex-rs/core-plugins/src/store.rs
@@ -3,7 +3,7 @@ use crate::manifest::load_plugin_manifest;
 use codex_plugin::PluginId;
 use codex_plugin::validate_plugin_segment;
 use codex_utils_absolute_path::AbsolutePathBuf;
-use codex_utils_plugins::PLUGIN_MANIFEST_PATH;
+use codex_utils_plugins::find_plugin_manifest_path;
 use serde::Deserialize;
 use serde_json::Value as JsonValue;
 use std::fs;
@@ -184,20 +184,8 @@ fn validate_plugin_version_segment(plugin_version: &str) -> Result<(), String> {
 }
 
 fn plugin_manifest_for_source(source_path: &Path) -> Result<PluginManifest, PluginStoreError> {
-    let manifest_path = source_path.join(PLUGIN_MANIFEST_PATH);
-    if !manifest_path.is_file() {
-        return Err(PluginStoreError::Invalid(format!(
-            "missing plugin manifest: {}",
-            manifest_path.display()
-        )));
-    }
-
-    load_plugin_manifest(source_path).ok_or_else(|| {
-        PluginStoreError::Invalid(format!(
-            "missing or invalid plugin manifest: {}",
-            manifest_path.display()
-        ))
-    })
+    load_plugin_manifest(source_path)
+        .ok_or_else(|| PluginStoreError::Invalid("missing or invalid plugin manifest".to_string()))
 }
 
 #[derive(Debug, Deserialize)]
@@ -210,37 +198,27 @@ struct RawPluginManifestVersion {
 fn plugin_manifest_version_for_source(
     source_path: &Path,
 ) -> Result<Option<String>, PluginStoreError> {
-    let manifest_path = source_path.join(PLUGIN_MANIFEST_PATH);
-    if !manifest_path.is_file() {
-        return Err(PluginStoreError::Invalid(format!(
-            "missing plugin manifest: {}",
-            manifest_path.display()
-        )));
-    }
+    let manifest_path = find_plugin_manifest_path(source_path)
+        .ok_or_else(|| PluginStoreError::Invalid("missing plugin manifest".to_string()))?;
 
     let contents = fs::read_to_string(&manifest_path)
         .map_err(|err| PluginStoreError::io("failed to read plugin manifest", err))?;
     let manifest: RawPluginManifestVersion = serde_json::from_str(&contents).map_err(|err| {
-        PluginStoreError::Invalid(format!(
-            "failed to parse plugin manifest {}: {err}",
-            manifest_path.display()
-        ))
+        PluginStoreError::Invalid(format!("failed to parse plugin manifest: {err}"))
     })?;
     let Some(version) = manifest.version else {
         return Ok(None);
     };
     let Some(version) = version.as_str() else {
-        return Err(PluginStoreError::Invalid(format!(
-            "invalid plugin version in manifest {}: expected string",
-            manifest_path.display()
-        )));
+        return Err(PluginStoreError::Invalid(
+            "invalid plugin version in plugin manifest: expected string".to_string(),
+        ));
     };
     let version = version.trim();
     if version.is_empty() {
-        return Err(PluginStoreError::Invalid(format!(
-            "invalid plugin version in manifest {}: must not be blank",
-            manifest_path.display()
-        )));
+        return Err(PluginStoreError::Invalid(
+            "invalid plugin version in plugin manifest: must not be blank".to_string(),
+        ));
     }
     Ok(Some(version.to_string()))
 }

--- a/codex-rs/core-plugins/src/store_tests.rs
+++ b/codex-rs/core-plugins/src/store_tests.rs
@@ -175,7 +175,7 @@ fn install_rejects_blank_manifest_version() {
 
     assert_eq!(
         err,
-        "invalid plugin version in plugin manifest: must not be blank"
+        "invalid plugin version in plugin.json: must not be blank"
     );
 }
 
@@ -301,6 +301,6 @@ fn install_rejects_manifest_names_that_do_not_match_marketplace_plugin_name() {
 
     assert_eq!(
         err.to_string(),
-        "plugin manifest name `manifest-name` does not match marketplace plugin name `different-name`"
+        "plugin.json name `manifest-name` does not match marketplace plugin name `different-name`"
     );
 }

--- a/codex-rs/core-plugins/src/store_tests.rs
+++ b/codex-rs/core-plugins/src/store_tests.rs
@@ -173,13 +173,9 @@ fn install_rejects_blank_manifest_version() {
         .expect_err("blank manifest version should be rejected");
     let err = err.to_string().replace('\\', "/");
 
-    assert!(
-        err.starts_with("invalid plugin version in manifest "),
-        "unexpected error: {err}"
-    );
-    assert!(
-        err.ends_with("sample-plugin/.codex-plugin/plugin.json: must not be blank"),
-        "unexpected error: {err}"
+    assert_eq!(
+        err,
+        "invalid plugin version in plugin manifest: must not be blank"
     );
 }
 

--- a/codex-rs/core/src/plugins/discoverable.rs
+++ b/codex-rs/core/src/plugins/discoverable.rs
@@ -4,6 +4,7 @@ use tracing::warn;
 
 use super::OPENAI_CURATED_MARKETPLACE_NAME;
 use super::PluginCapabilitySummary;
+use super::PluginReadRequest;
 use super::PluginsManager;
 use crate::config::Config;
 use codex_config::types::ToolSuggestDiscoverableType;
@@ -46,7 +47,7 @@ pub(crate) async fn list_tool_suggest_discoverable_plugins(
     else {
         return Ok(Vec::new());
     };
-    let curated_marketplace_name = curated_marketplace.name;
+    let curated_marketplace_path = curated_marketplace.path;
 
     let mut discoverable_plugins = Vec::<DiscoverablePluginInfo>::new();
     for plugin in curated_marketplace.plugins {
@@ -60,11 +61,17 @@ pub(crate) async fn list_tool_suggest_discoverable_plugins(
         let plugin_id = plugin.id.clone();
 
         match plugins_manager
-            .read_plugin_detail_for_marketplace_plugin(config, &curated_marketplace_name, plugin)
+            .read_plugin_for_config(
+                config,
+                &PluginReadRequest {
+                    plugin_name: plugin.name,
+                    marketplace_path: curated_marketplace_path.clone(),
+                },
+            )
             .await
         {
             Ok(plugin) => {
-                let plugin: PluginCapabilitySummary = plugin.into();
+                let plugin: PluginCapabilitySummary = plugin.plugin.into();
                 discoverable_plugins.push(DiscoverablePluginInfo {
                     id: plugin.config_name,
                     name: plugin.display_name,

--- a/codex-rs/core/src/plugins/discoverable.rs
+++ b/codex-rs/core/src/plugins/discoverable.rs
@@ -4,7 +4,6 @@ use tracing::warn;
 
 use super::OPENAI_CURATED_MARKETPLACE_NAME;
 use super::PluginCapabilitySummary;
-use super::PluginReadRequest;
 use super::PluginsManager;
 use crate::config::Config;
 use codex_config::types::ToolSuggestDiscoverableType;
@@ -47,7 +46,7 @@ pub(crate) async fn list_tool_suggest_discoverable_plugins(
     else {
         return Ok(Vec::new());
     };
-    let curated_marketplace_path = curated_marketplace.path;
+    let curated_marketplace_name = curated_marketplace.name;
 
     let mut discoverable_plugins = Vec::<DiscoverablePluginInfo>::new();
     for plugin in curated_marketplace.plugins {
@@ -61,17 +60,11 @@ pub(crate) async fn list_tool_suggest_discoverable_plugins(
         let plugin_id = plugin.id.clone();
 
         match plugins_manager
-            .read_plugin_for_config(
-                config,
-                &PluginReadRequest {
-                    plugin_name: plugin.name,
-                    marketplace_path: curated_marketplace_path.clone(),
-                },
-            )
+            .read_plugin_detail_for_marketplace_plugin(config, &curated_marketplace_name, plugin)
             .await
         {
             Ok(plugin) => {
-                let plugin: PluginCapabilitySummary = plugin.plugin.into();
+                let plugin: PluginCapabilitySummary = plugin.into();
                 discoverable_plugins.push(DiscoverablePluginInfo {
                     id: plugin.config_name,
                     name: plugin.display_name,

--- a/codex-rs/core/src/plugins/manager.rs
+++ b/codex-rs/core/src/plugins/manager.rs
@@ -1053,9 +1053,7 @@ impl PluginsManager {
             ));
         }
         let manifest = load_plugin_manifest(source_path.as_path()).ok_or_else(|| {
-            MarketplaceError::InvalidPlugin(
-                "missing or invalid .codex-plugin/plugin.json".to_string(),
-            )
+            MarketplaceError::InvalidPlugin("missing or invalid plugin manifest".to_string())
         })?;
         let description = manifest.description.clone();
         let manifest_paths = &manifest.paths;

--- a/codex-rs/core/src/plugins/manager.rs
+++ b/codex-rs/core/src/plugins/manager.rs
@@ -27,7 +27,6 @@ use codex_core_plugins::loader::refresh_curated_plugin_cache;
 use codex_core_plugins::loader::refresh_non_curated_plugin_cache;
 use codex_core_plugins::loader::refresh_non_curated_plugin_cache_force_reinstall;
 use codex_core_plugins::manifest::PluginManifestInterface;
-use codex_core_plugins::manifest::load_plugin_manifest;
 use codex_core_plugins::marketplace::MarketplaceError;
 use codex_core_plugins::marketplace::MarketplaceInterface;
 use codex_core_plugins::marketplace::MarketplaceListError;
@@ -37,6 +36,7 @@ use codex_core_plugins::marketplace::MarketplacePluginSource;
 use codex_core_plugins::marketplace::ResolvedMarketplacePlugin;
 use codex_core_plugins::marketplace::list_marketplaces;
 use codex_core_plugins::marketplace::load_marketplace;
+use codex_core_plugins::marketplace::resolve_installable_marketplace_plugin;
 use codex_core_plugins::marketplace::resolve_marketplace_plugin;
 use codex_core_plugins::marketplace_upgrade::ConfiguredMarketplaceUpgradeError;
 use codex_core_plugins::marketplace_upgrade::ConfiguredMarketplaceUpgradeOutcome;
@@ -535,7 +535,7 @@ impl PluginsManager {
         &self,
         request: PluginInstallRequest,
     ) -> Result<PluginInstallOutcome, PluginInstallError> {
-        let resolved = resolve_marketplace_plugin(
+        let resolved = resolve_installable_marketplace_plugin(
             &request.marketplace_path,
             &request.plugin_name,
             self.restriction_product,
@@ -549,7 +549,7 @@ impl PluginsManager {
         auth: Option<&CodexAuth>,
         request: PluginInstallRequest,
     ) -> Result<PluginInstallOutcome, PluginInstallError> {
-        let resolved = resolve_marketplace_plugin(
+        let resolved = resolve_installable_marketplace_plugin(
             &request.marketplace_path,
             &request.plugin_name,
             self.restriction_product,
@@ -572,7 +572,7 @@ impl PluginsManager {
         &self,
         resolved: ResolvedMarketplacePlugin,
     ) -> Result<PluginInstallOutcome, PluginInstallError> {
-        let auth_policy = resolved.auth_policy;
+        let auth_policy = resolved.policy.authentication;
         let plugin_version =
             if resolved.plugin_id.marketplace_name == OPENAI_CURATED_MARKETPLACE_NAME {
                 Some(
@@ -587,10 +587,11 @@ impl PluginsManager {
             };
         let store = self.store.clone();
         let result: StorePluginInstallResult = tokio::task::spawn_blocking(move || {
+            let MarketplacePluginSource::Local { path: source_path } = resolved.source;
             if let Some(plugin_version) = plugin_version {
-                store.install_with_version(resolved.source_path, resolved.plugin_id, plugin_version)
+                store.install_with_version(source_path, resolved.plugin_id, plugin_version)
             } else {
-                store.install(resolved.source_path, resolved.plugin_id)
+                store.install(source_path, resolved.plugin_id)
             }
         })
         .await
@@ -978,72 +979,17 @@ impl PluginsManager {
             return Err(MarketplaceError::PluginsDisabled);
         }
 
-        let marketplace = load_marketplace(&request.marketplace_path)?;
-        let marketplace_name = marketplace.name.clone();
-        let plugin = marketplace
-            .plugins
-            .into_iter()
-            .find(|plugin| plugin.name == request.plugin_name);
-        let Some(plugin) = plugin else {
-            return Err(MarketplaceError::PluginNotFound {
-                plugin_name: request.plugin_name.clone(),
-                marketplace_name,
-            });
-        };
-        let plugin_id = PluginId::new(plugin.name.clone(), marketplace.name.clone()).map_err(
-            |err| match err {
-                PluginIdError::Invalid(message) => MarketplaceError::InvalidPlugin(message),
-            },
-        )?;
-        let plugin_key = plugin_id.as_key();
-        let (installed_plugins, enabled_plugins) = self.configured_plugin_states(config);
-        let plugin = self
-            .read_plugin_detail_for_marketplace_plugin(
-                config,
-                &marketplace.name,
-                ConfiguredMarketplacePlugin {
-                    id: plugin_key.clone(),
-                    name: plugin.name,
-                    source: plugin.source,
-                    policy: plugin.policy,
-                    interface: plugin.interface,
-                    installed: installed_plugins.contains(&plugin_key),
-                    enabled: enabled_plugins.contains(&plugin_key),
-                },
-            )
-            .await?;
-
-        Ok(PluginReadOutcome {
-            marketplace_name: if marketplace.name == OPENAI_CURATED_MARKETPLACE_NAME {
-                OPENAI_CURATED_MARKETPLACE_DISPLAY_NAME.to_string()
-            } else {
-                marketplace.name
-            },
-            marketplace_path: marketplace.path,
-            plugin,
-        })
-    }
-
-    pub(crate) async fn read_plugin_detail_for_marketplace_plugin(
-        &self,
-        config: &Config,
-        marketplace_name: &str,
-        plugin: ConfiguredMarketplacePlugin,
-    ) -> Result<PluginDetail, MarketplaceError> {
+        let plugin = resolve_marketplace_plugin(&request.marketplace_path, &request.plugin_name)?;
         if !self.restriction_product_matches(plugin.policy.products.as_deref()) {
             return Err(MarketplaceError::PluginNotFound {
-                plugin_name: plugin.name,
-                marketplace_name: marketplace_name.to_string(),
+                plugin_name: plugin.plugin_id.plugin_name,
+                marketplace_name: plugin.plugin_id.marketplace_name,
             });
         }
 
-        let plugin_id =
-            PluginId::new(plugin.name.clone(), marketplace_name.to_string()).map_err(|err| {
-                match err {
-                    PluginIdError::Invalid(message) => MarketplaceError::InvalidPlugin(message),
-                }
-            })?;
-        let plugin_key = plugin_id.as_key();
+        let marketplace_name = plugin.plugin_id.marketplace_name.clone();
+        let plugin_key = plugin.plugin_id.as_key();
+        let (installed_plugins, enabled_plugins) = self.configured_plugin_states(config);
         let source_path = match &plugin.source {
             MarketplacePluginSource::Local { path } => path.clone(),
         };
@@ -1052,19 +998,17 @@ impl PluginsManager {
                 "path does not exist or is not a directory".to_string(),
             ));
         }
-        let manifest = load_plugin_manifest(source_path.as_path()).ok_or_else(|| {
+        let manifest = plugin.manifest.ok_or_else(|| {
             MarketplaceError::InvalidPlugin("missing or invalid plugin manifest".to_string())
         })?;
         let description = manifest.description.clone();
-        let manifest_paths = &manifest.paths;
-        let skill_config_rules = codex_core_skills::config_rules::skill_config_rules_from_stack(
-            &config.config_layer_stack,
-        );
         let resolved_skills = load_plugin_skills(
             &source_path,
-            manifest_paths,
+            &manifest.paths,
             self.restriction_product,
-            &skill_config_rules,
+            &codex_core_skills::config_rules::skill_config_rules_from_stack(
+                &config.config_layer_stack,
+            ),
         )
         .await;
         let apps = load_plugin_apps(source_path.as_path()).await;
@@ -1074,20 +1018,29 @@ impl PluginsManager {
             .collect::<Vec<_>>();
         mcp_server_names.sort_unstable();
         mcp_server_names.dedup();
-
-        Ok(PluginDetail {
-            id: plugin_key,
-            name: plugin.name,
+        let plugin = PluginDetail {
+            id: plugin_key.clone(),
+            name: plugin.plugin_id.plugin_name,
             description,
             source: plugin.source,
             policy: plugin.policy,
             interface: plugin.interface,
-            installed: plugin.installed,
-            enabled: plugin.enabled,
+            installed: installed_plugins.contains(&plugin_key),
+            enabled: enabled_plugins.contains(&plugin_key),
             skills: resolved_skills.skills,
             disabled_skill_paths: resolved_skills.disabled_skill_paths,
             apps,
             mcp_server_names,
+        };
+
+        Ok(PluginReadOutcome {
+            marketplace_name: if marketplace_name == OPENAI_CURATED_MARKETPLACE_NAME {
+                OPENAI_CURATED_MARKETPLACE_DISPLAY_NAME.to_string()
+            } else {
+                marketplace_name
+            },
+            marketplace_path: request.marketplace_path.clone(),
+            plugin,
         })
     }
 

--- a/codex-rs/core/src/plugins/manager.rs
+++ b/codex-rs/core/src/plugins/manager.rs
@@ -27,6 +27,7 @@ use codex_core_plugins::loader::refresh_curated_plugin_cache;
 use codex_core_plugins::loader::refresh_non_curated_plugin_cache;
 use codex_core_plugins::loader::refresh_non_curated_plugin_cache_force_reinstall;
 use codex_core_plugins::manifest::PluginManifestInterface;
+use codex_core_plugins::manifest::load_plugin_manifest;
 use codex_core_plugins::marketplace::MarketplaceError;
 use codex_core_plugins::marketplace::MarketplaceInterface;
 use codex_core_plugins::marketplace::MarketplaceListError;
@@ -34,10 +35,10 @@ use codex_core_plugins::marketplace::MarketplacePluginAuthPolicy;
 use codex_core_plugins::marketplace::MarketplacePluginPolicy;
 use codex_core_plugins::marketplace::MarketplacePluginSource;
 use codex_core_plugins::marketplace::ResolvedMarketplacePlugin;
+use codex_core_plugins::marketplace::find_installable_marketplace_plugin;
+use codex_core_plugins::marketplace::find_marketplace_plugin;
 use codex_core_plugins::marketplace::list_marketplaces;
 use codex_core_plugins::marketplace::load_marketplace;
-use codex_core_plugins::marketplace::resolve_installable_marketplace_plugin;
-use codex_core_plugins::marketplace::resolve_marketplace_plugin;
 use codex_core_plugins::marketplace_upgrade::ConfiguredMarketplaceUpgradeError;
 use codex_core_plugins::marketplace_upgrade::ConfiguredMarketplaceUpgradeOutcome;
 use codex_core_plugins::marketplace_upgrade::configured_git_marketplace_names;
@@ -535,7 +536,7 @@ impl PluginsManager {
         &self,
         request: PluginInstallRequest,
     ) -> Result<PluginInstallOutcome, PluginInstallError> {
-        let resolved = resolve_installable_marketplace_plugin(
+        let resolved = find_installable_marketplace_plugin(
             &request.marketplace_path,
             &request.plugin_name,
             self.restriction_product,
@@ -549,7 +550,7 @@ impl PluginsManager {
         auth: Option<&CodexAuth>,
         request: PluginInstallRequest,
     ) -> Result<PluginInstallOutcome, PluginInstallError> {
-        let resolved = resolve_installable_marketplace_plugin(
+        let resolved = find_installable_marketplace_plugin(
             &request.marketplace_path,
             &request.plugin_name,
             self.restriction_product,
@@ -979,7 +980,7 @@ impl PluginsManager {
             return Err(MarketplaceError::PluginsDisabled);
         }
 
-        let plugin = resolve_marketplace_plugin(&request.marketplace_path, &request.plugin_name)?;
+        let plugin = find_marketplace_plugin(&request.marketplace_path, &request.plugin_name)?;
         if !self.restriction_product_matches(plugin.policy.products.as_deref()) {
             return Err(MarketplaceError::PluginNotFound {
                 plugin_name: plugin.plugin_id.plugin_name,
@@ -990,6 +991,46 @@ impl PluginsManager {
         let marketplace_name = plugin.plugin_id.marketplace_name.clone();
         let plugin_key = plugin.plugin_id.as_key();
         let (installed_plugins, enabled_plugins) = self.configured_plugin_states(config);
+        let plugin = self
+            .read_plugin_detail_for_marketplace_plugin(
+                config,
+                &marketplace_name,
+                ConfiguredMarketplacePlugin {
+                    id: plugin_key.clone(),
+                    name: plugin.plugin_id.plugin_name,
+                    source: plugin.source,
+                    policy: plugin.policy,
+                    interface: plugin.interface,
+                    installed: installed_plugins.contains(&plugin_key),
+                    enabled: enabled_plugins.contains(&plugin_key),
+                },
+            )
+            .await?;
+
+        Ok(PluginReadOutcome {
+            marketplace_name: if marketplace_name == OPENAI_CURATED_MARKETPLACE_NAME {
+                OPENAI_CURATED_MARKETPLACE_DISPLAY_NAME.to_string()
+            } else {
+                marketplace_name
+            },
+            marketplace_path: request.marketplace_path.clone(),
+            plugin,
+        })
+    }
+
+    pub(crate) async fn read_plugin_detail_for_marketplace_plugin(
+        &self,
+        config: &Config,
+        marketplace_name: &str,
+        plugin: ConfiguredMarketplacePlugin,
+    ) -> Result<PluginDetail, MarketplaceError> {
+        if !self.restriction_product_matches(plugin.policy.products.as_deref()) {
+            return Err(MarketplaceError::PluginNotFound {
+                plugin_name: plugin.name,
+                marketplace_name: marketplace_name.to_string(),
+            });
+        }
+
         let source_path = match &plugin.source {
             MarketplacePluginSource::Local { path } => path.clone(),
         };
@@ -998,8 +1039,8 @@ impl PluginsManager {
                 "path does not exist or is not a directory".to_string(),
             ));
         }
-        let manifest = plugin.manifest.ok_or_else(|| {
-            MarketplaceError::InvalidPlugin("missing or invalid plugin manifest".to_string())
+        let manifest = load_plugin_manifest(source_path.as_path()).ok_or_else(|| {
+            MarketplaceError::InvalidPlugin("missing or invalid plugin.json".to_string())
         })?;
         let description = manifest.description.clone();
         let resolved_skills = load_plugin_skills(
@@ -1018,29 +1059,20 @@ impl PluginsManager {
             .collect::<Vec<_>>();
         mcp_server_names.sort_unstable();
         mcp_server_names.dedup();
-        let plugin = PluginDetail {
-            id: plugin_key.clone(),
-            name: plugin.plugin_id.plugin_name,
+
+        Ok(PluginDetail {
+            id: plugin.id,
+            name: plugin.name,
             description,
             source: plugin.source,
             policy: plugin.policy,
             interface: plugin.interface,
-            installed: installed_plugins.contains(&plugin_key),
-            enabled: enabled_plugins.contains(&plugin_key),
+            installed: plugin.installed,
+            enabled: plugin.enabled,
             skills: resolved_skills.skills,
             disabled_skill_paths: resolved_skills.disabled_skill_paths,
             apps,
             mcp_server_names,
-        };
-
-        Ok(PluginReadOutcome {
-            marketplace_name: if marketplace_name == OPENAI_CURATED_MARKETPLACE_NAME {
-                OPENAI_CURATED_MARKETPLACE_DISPLAY_NAME.to_string()
-            } else {
-                marketplace_name
-            },
-            marketplace_path: request.marketplace_path.clone(),
-            plugin,
         })
     }
 

--- a/codex-rs/core/src/plugins/manager_tests.rs
+++ b/codex-rs/core/src/plugins/manager_tests.rs
@@ -1578,7 +1578,13 @@ source = "/tmp/debug"
 
     let marketplace = marketplaces
         .into_iter()
-        .find(|marketplace| marketplace.name == "debug")
+        .find(|marketplace| {
+            marketplace.path
+                == AbsolutePathBuf::try_from(
+                    marketplace_root.join(".agents/plugins/marketplace.json"),
+                )
+                .unwrap()
+        })
         .expect("installed marketplace should be listed");
 
     assert_eq!(
@@ -1648,7 +1654,13 @@ source = "/tmp/debug"
 
     let marketplace = marketplaces
         .into_iter()
-        .find(|marketplace| marketplace.name == "debug")
+        .find(|marketplace| {
+            marketplace.path
+                == AbsolutePathBuf::try_from(
+                    marketplace_root.join(".agents/plugins/marketplace.json"),
+                )
+                .unwrap()
+        })
         .expect("configured marketplace should be discovered");
 
     assert_eq!(marketplace.plugins[0].id, "sample@debug");
@@ -1695,7 +1707,16 @@ plugins = true
         .unwrap()
         .marketplaces;
 
-    assert!(marketplaces.is_empty());
+    assert!(
+        marketplaces.iter().all(|marketplace| {
+            marketplace.path
+                != AbsolutePathBuf::try_from(
+                    marketplace_root.join(".agents/plugins/marketplace.json"),
+                )
+                .unwrap()
+        }),
+        "installed marketplace root missing from config should not be listed"
+    );
 }
 
 #[tokio::test]

--- a/codex-rs/plugin/src/lib.rs
+++ b/codex-rs/plugin/src/lib.rs
@@ -1,6 +1,5 @@
 //! Shared plugin identifiers and telemetry-facing summaries.
 
-pub use codex_utils_plugins::PLUGIN_MANIFEST_PATH;
 pub use codex_utils_plugins::mention_syntax;
 pub use codex_utils_plugins::plugin_namespace_for_skill_path;
 

--- a/codex-rs/utils/plugins/src/lib.rs
+++ b/codex-rs/utils/plugins/src/lib.rs
@@ -5,5 +5,5 @@ pub mod mcp_connector;
 pub mod mention_syntax;
 pub mod plugin_namespace;
 
-pub use plugin_namespace::PLUGIN_MANIFEST_PATH;
+pub use plugin_namespace::find_plugin_manifest_path;
 pub use plugin_namespace::plugin_namespace_for_skill_path;

--- a/codex-rs/utils/plugins/src/plugin_namespace.rs
+++ b/codex-rs/utils/plugins/src/plugin_namespace.rs
@@ -2,9 +2,18 @@
 
 use codex_exec_server::ExecutorFileSystem;
 use codex_utils_absolute_path::AbsolutePathBuf;
+use std::path::Path;
+use std::path::PathBuf;
 
-/// Relative path from a plugin root to its manifest file.
-pub const PLUGIN_MANIFEST_PATH: &str = ".codex-plugin/plugin.json";
+const DISCOVERABLE_PLUGIN_MANIFEST_PATHS: &[&str] =
+    &[".codex-plugin/plugin.json", ".claude-plugin/plugin.json"];
+
+pub fn find_plugin_manifest_path(plugin_root: &Path) -> Option<PathBuf> {
+    DISCOVERABLE_PLUGIN_MANIFEST_PATHS
+        .iter()
+        .map(|relative_path| plugin_root.join(relative_path))
+        .find(|manifest_path| manifest_path.is_file())
+}
 
 #[derive(serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -17,11 +26,18 @@ async fn plugin_manifest_name(
     fs: &dyn ExecutorFileSystem,
     plugin_root: &AbsolutePathBuf,
 ) -> Option<String> {
-    let manifest_path = plugin_root.join(PLUGIN_MANIFEST_PATH);
-    match fs.get_metadata(&manifest_path, /*sandbox*/ None).await {
-        Ok(metadata) if metadata.is_file => {}
-        Ok(_) | Err(_) => return None,
+    let mut manifest_path = None;
+    for relative_path in DISCOVERABLE_PLUGIN_MANIFEST_PATHS {
+        let candidate = plugin_root.join(relative_path);
+        match fs.get_metadata(&candidate, /*sandbox*/ None).await {
+            Ok(metadata) if metadata.is_file => {
+                manifest_path = Some(candidate);
+                break;
+            }
+            Ok(_) | Err(_) => {}
+        }
     }
+    let manifest_path = manifest_path?;
     let contents = fs
         .read_file_text(&manifest_path, /*sandbox*/ None)
         .await
@@ -53,6 +69,7 @@ pub async fn plugin_namespace_for_skill_path(
 
 #[cfg(test)]
 mod tests {
+    use super::find_plugin_manifest_path;
     use super::plugin_namespace_for_skill_path;
     use codex_exec_server::LOCAL_FS;
     use codex_utils_absolute_path::test_support::PathBufExt;
@@ -77,6 +94,31 @@ mod tests {
         assert_eq!(
             plugin_namespace_for_skill_path(LOCAL_FS.as_ref(), &skill_path.abs()).await,
             Some("sample".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn uses_name_from_alternate_discoverable_manifest_path() {
+        let tmp = tempdir().expect("tempdir");
+        let plugin_root = tmp.path().join("plugins/sample");
+        let skill_path = plugin_root.join("skills/search/SKILL.md");
+
+        fs::create_dir_all(skill_path.parent().expect("parent")).expect("mkdir");
+        fs::create_dir_all(plugin_root.join(".claude-plugin")).expect("mkdir manifest");
+        fs::write(
+            plugin_root.join(".claude-plugin/plugin.json"),
+            r#"{"name":"sample"}"#,
+        )
+        .expect("write manifest");
+        fs::write(&skill_path, "---\ndescription: search\n---\n").expect("write skill");
+
+        assert_eq!(
+            plugin_namespace_for_skill_path(LOCAL_FS.as_ref(), &skill_path.abs()).await,
+            Some("sample".to_string())
+        );
+        assert_eq!(
+            find_plugin_manifest_path(&plugin_root),
+            Some(plugin_root.join(".claude-plugin/plugin.json"))
         );
     }
 }

--- a/codex-rs/utils/plugins/src/plugin_namespace.rs
+++ b/codex-rs/utils/plugins/src/plugin_namespace.rs
@@ -76,6 +76,8 @@ mod tests {
     use std::fs;
     use tempfile::tempdir;
 
+    const ALTERNATE_PLUGIN_MANIFEST_RELATIVE_PATH: &str = ".claude-plugin/plugin.json";
+
     #[tokio::test]
     async fn uses_manifest_name() {
         let tmp = tempdir().expect("tempdir");
@@ -102,23 +104,18 @@ mod tests {
         let tmp = tempdir().expect("tempdir");
         let plugin_root = tmp.path().join("plugins/sample");
         let skill_path = plugin_root.join("skills/search/SKILL.md");
+        let manifest_path = plugin_root.join(ALTERNATE_PLUGIN_MANIFEST_RELATIVE_PATH);
 
         fs::create_dir_all(skill_path.parent().expect("parent")).expect("mkdir");
-        fs::create_dir_all(plugin_root.join(".claude-plugin")).expect("mkdir manifest");
-        fs::write(
-            plugin_root.join(".claude-plugin/plugin.json"),
-            r#"{"name":"sample"}"#,
-        )
-        .expect("write manifest");
+        fs::create_dir_all(manifest_path.parent().expect("manifest parent"))
+            .expect("mkdir manifest");
+        fs::write(&manifest_path, r#"{"name":"sample"}"#).expect("write manifest");
         fs::write(&skill_path, "---\ndescription: search\n---\n").expect("write skill");
 
         assert_eq!(
             plugin_namespace_for_skill_path(LOCAL_FS.as_ref(), &skill_path.abs()).await,
             Some("sample".to_string())
         );
-        assert_eq!(
-            find_plugin_manifest_path(&plugin_root),
-            Some(plugin_root.join(".claude-plugin/plugin.json"))
-        );
+        assert_eq!(find_plugin_manifest_path(&plugin_root), Some(manifest_path));
     }
 }


### PR DESCRIPTION
Load plugin manifests through a shared discoverable-path helper so manifest reads, installs, and skill names all see the same alternate manifest location.
