### PR TITLE
fix: fix clippy issue in examples/ folder

### DIFF
--- a/codex-rs/thread-store/examples/generate-proto.rs
+++ b/codex-rs/thread-store/examples/generate-proto.rs
@@ -1,7 +1,12 @@
 use std::path::PathBuf;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let proto_dir = PathBuf::from(std::env::args().nth(1).expect("proto dir"));
+    let Some(proto_dir_arg) = std::env::args().nth(1) else {
+        eprintln!("Usage: generate-proto <proto-dir>");
+        std::process::exit(1);
+    };
+
+    let proto_dir = PathBuf::from(proto_dir_arg);
     let proto_file = proto_dir.join("codex.thread_store.v1.proto");
 
     tonic_prost_build::configure()


### PR DESCRIPTION
I believe this use of `expect()` was introduced in https://github.com/openai/codex/pull/17826, but was not flagged by CI. Though I did see it in the diagnostics panel in VS Code, so it's worth cleaning up.

I guess our current CI does include `examples/` when running Clippy?