### PR TITLE
Throttle Windows Bazel test concurrency

### DIFF
--- a/.github/scripts/run-bazel-ci.sh
+++ b/.github/scripts/run-bazel-ci.sh
@@ -69,12 +69,30 @@ print_bazel_test_log_tails() {
   local console_log="$1"
   local testlogs_dir
   local -a bazel_info_cmd=(bazel)
+  local -a bazel_info_args=(info)
 
   if (( ${#bazel_startup_args[@]} > 0 )); then
     bazel_info_cmd+=("${bazel_startup_args[@]}")
   fi
 
-  testlogs_dir="$(run_bazel "${bazel_info_cmd[@]:1}" info bazel-testlogs 2>/dev/null || echo bazel-testlogs)"
+  if [[ -n "${BUILDBUDDY_API_KEY:-}" ]]; then
+    bazel_info_args+=(
+      "--config=${ci_config}"
+      "--remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}"
+    )
+  fi
+  for arg in "${post_config_bazel_args[@]}"; do
+    case "$arg" in
+      --host_platform=* | --repo_contents_cache=* | --repository_cache=*)
+        bazel_info_args+=("$arg")
+        ;;
+    esac
+  done
+
+  testlogs_dir="$(run_bazel "${bazel_info_cmd[@]:1}" \
+    --noexperimental_remote_repo_contents_cache \
+    "${bazel_info_args[@]}" \
+    bazel-testlogs 2>/dev/null || echo bazel-testlogs)"
 
   local failed_targets=()
   while IFS= read -r target; do
@@ -95,8 +113,9 @@ print_bazel_test_log_tails() {
     rel_path="${rel_path/://}"
     local test_log="${testlogs_dir}/${rel_path}/test.log"
     local reported_test_log
-    reported_test_log="$(grep -F "FAIL: ${target} " "$console_log" | sed -nE 's#.* \(see ([^)]+/test\.log)\).*#\1#p' | head -n 1 || true)"
+    reported_test_log="$(grep -F "FAIL: ${target} " "$console_log" | sed -nE 's#.* \(see (.*[\\/]test\.log)\).*#\1#p' | head -n 1 || true)"
     if [[ -n "$reported_test_log" ]]; then
+      reported_test_log="${reported_test_log//\\//}"
       test_log="$reported_test_log"
     fi
 

--- a/.github/scripts/run-bazel-ci.sh
+++ b/.github/scripts/run-bazel-ci.sh
@@ -75,12 +75,19 @@ print_bazel_test_log_tails() {
     bazel_info_cmd+=("${bazel_startup_args[@]}")
   fi
 
+  # `bazel info` needs the same CI config as the failed test invocation so
+  # platform-specific output roots match. On Windows, omitting `ci-windows`
+  # would point at `local_windows-fastbuild` even when the test ran with the
+  # MSVC host platform under `local_windows_msvc-fastbuild`.
   if [[ -n "${BUILDBUDDY_API_KEY:-}" ]]; then
     bazel_info_args+=(
       "--config=${ci_config}"
       "--remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}"
     )
   fi
+  # Only pass flags that affect Bazel's output-root selection or repository
+  # lookup. Test/build-only flags such as execution logs or remote download
+  # mode can make `bazel info` fail, which would hide the real test log path.
   for arg in "${post_config_bazel_args[@]}"; do
     case "$arg" in
       --host_platform=* | --repo_contents_cache=* | --repository_cache=*)

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -86,17 +86,21 @@ jobs:
             --print-failed-test-logs
             --use-node-test-env
           )
+          bazel_test_args=(
+            test
+            --test_tag_filters=-argument-comment-lint
+            --test_verbose_timeout_warnings
+            --build_metadata=COMMIT_SHA=${GITHUB_SHA}
+          )
           if [[ "${RUNNER_OS}" == "Windows" ]]; then
             bazel_wrapper_args+=(--windows-msvc-host-platform)
+            bazel_test_args+=(--jobs=8)
           fi
 
           ./.github/scripts/run-bazel-ci.sh \
             "${bazel_wrapper_args[@]}" \
             -- \
-            test \
-            --test_tag_filters=-argument-comment-lint \
-            --test_verbose_timeout_warnings \
-            --build_metadata=COMMIT_SHA=${GITHUB_SHA} \
+            "${bazel_test_args[@]}" \
             -- \
             "${bazel_targets[@]}"
 


### PR DESCRIPTION
## Summary
- cap the Windows Bazel test lane at `--jobs=8` to reduce local runner pressure
- keep Linux and macOS Bazel test concurrency unchanged
- make failed-test log tailing resolve `bazel-testlogs` with the same CI config and Windows host-platform context as the failed invocation
- prefer Bazel-reported `test.log` paths and normalize Windows path separators before tailing

## Context
The Windows Bazel workflow currently uses `ci-windows`, which does not inherit the remote executor config. This means the lane runs the `//...` test suite locally and otherwise falls back to the repo-wide `common --jobs=30`. The new Windows-only override is intended to reduce local executor pressure without changing coverage.

## Validation
Not run locally; this is a CI workflow change and the draft PR is intended to exercise the GitHub Actions lane directly.