### PR TITLE
Use in-process app-server for unknown-thread MCP read test

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/mcp_resource.rs
+++ b/codex-rs/app-server/tests/suite/v2/mcp_resource.rs
@@ -209,12 +209,9 @@ async fn mcp_resource_read_returns_error_for_unknown_thread() -> Result<()> {
         Ok(result) => anyhow::bail!("expected thread-not-found error, got response: {result:?}"),
         Err(error) => error,
     };
-    let error_debug = format!("{error:?}");
-    let message = error.message;
-
     assert!(
-        message.contains("thread not found"),
-        "expected thread-not-found error, got: {error_debug}"
+        error.message.contains("thread not found"),
+        "expected thread-not-found error, got: {error:?}"
     );
 
     Ok(())

--- a/codex-rs/app-server/tests/suite/v2/mcp_resource.rs
+++ b/codex-rs/app-server/tests/suite/v2/mcp_resource.rs
@@ -202,17 +202,15 @@ async fn mcp_resource_read_returns_error_for_unknown_thread() -> Result<()> {
                 uri: TEST_RESOURCE_URI.to_string(),
             },
         })
-        .await?;
-    let error = match response {
-        Ok(result) => {
-            client.shutdown().await?;
-            anyhow::bail!("expected thread-not-found error, got response: {result:?}");
-        }
+        .await;
+    client.shutdown().await?;
+
+    let error = match response? {
+        Ok(result) => anyhow::bail!("expected thread-not-found error, got response: {result:?}"),
         Err(error) => error,
     };
     let error_debug = format!("{error:?}");
     let message = error.message;
-    client.shutdown().await?;
 
     assert!(
         message.contains("thread not found"),

--- a/codex-rs/app-server/tests/suite/v2/mcp_resource.rs
+++ b/codex-rs/app-server/tests/suite/v2/mcp_resource.rs
@@ -7,7 +7,11 @@ use app_test_support::McpProcess;
 use app_test_support::to_response;
 use app_test_support::write_chatgpt_auth;
 use axum::Router;
-use codex_app_server_protocol::JSONRPCError;
+use codex_app_server::in_process;
+use codex_app_server::in_process::InProcessStartArgs;
+use codex_app_server_protocol::ClientInfo;
+use codex_app_server_protocol::ClientRequest;
+use codex_app_server_protocol::InitializeParams;
 use codex_app_server_protocol::JSONRPCResponse;
 use codex_app_server_protocol::McpResourceContent;
 use codex_app_server_protocol::McpResourceReadParams;
@@ -15,7 +19,14 @@ use codex_app_server_protocol::McpResourceReadResponse;
 use codex_app_server_protocol::RequestId;
 use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
+use codex_arg0::Arg0DispatchPaths;
 use codex_config::types::AuthCredentialsStoreMode;
+use codex_core::config::ConfigBuilder;
+use codex_core::config_loader::CloudRequirementsLoader;
+use codex_core::config_loader::LoaderOverrides;
+use codex_exec_server::EnvironmentManager;
+use codex_feedback::CodexFeedback;
+use codex_protocol::protocol::SessionSource;
 use core_test_support::responses;
 use pretty_assertions::assert_eq;
 use rmcp::handler::server::ServerHandler;
@@ -149,25 +160,63 @@ stream_max_retries = 0
 #[tokio::test]
 async fn mcp_resource_read_returns_error_for_unknown_thread() -> Result<()> {
     let codex_home = TempDir::new()?;
-    let mut mcp = McpProcess::new(codex_home.path()).await?;
-    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+    let loader_overrides = LoaderOverrides::without_managed_config_for_tests();
+    let config = ConfigBuilder::default()
+        .codex_home(codex_home.path().to_path_buf())
+        .fallback_cwd(Some(codex_home.path().to_path_buf()))
+        .loader_overrides(loader_overrides.clone())
+        .build()
+        .await?;
+    // This negative-path test does not need the stdio subprocess; keeping it
+    // in-process avoids child-process teardown timing in nextest leak detection.
+    let client = in_process::start(InProcessStartArgs {
+        arg0_paths: Arg0DispatchPaths::default(),
+        config: Arc::new(config),
+        cli_overrides: Vec::new(),
+        loader_overrides,
+        cloud_requirements: CloudRequirementsLoader::default(),
+        feedback: CodexFeedback::new(),
+        log_db: None,
+        environment_manager: Arc::new(EnvironmentManager::new(/*exec_server_url*/ None)),
+        config_warnings: Vec::new(),
+        session_source: SessionSource::Cli,
+        enable_codex_api_key_env: false,
+        initialize: InitializeParams {
+            client_info: ClientInfo {
+                name: "codex-app-server-tests".to_string(),
+                title: None,
+                version: "0.1.0".to_string(),
+            },
+            capabilities: None,
+        },
+        channel_capacity: in_process::DEFAULT_IN_PROCESS_CHANNEL_CAPACITY,
+    })
+    .await?;
 
-    let request_id = mcp
-        .send_mcp_resource_read_request(McpResourceReadParams {
-            thread_id: "00000000-0000-4000-8000-000000000000".to_string(),
-            server: "codex_apps".to_string(),
-            uri: TEST_RESOURCE_URI.to_string(),
+    let response = client
+        .request(ClientRequest::McpResourceRead {
+            request_id: RequestId::Integer(1),
+            params: McpResourceReadParams {
+                thread_id: "00000000-0000-4000-8000-000000000000".to_string(),
+                server: "codex_apps".to_string(),
+                uri: TEST_RESOURCE_URI.to_string(),
+            },
         })
         .await?;
-    let error: JSONRPCError = timeout(
-        DEFAULT_READ_TIMEOUT,
-        mcp.read_stream_until_error_message(RequestId::Integer(request_id)),
-    )
-    .await??;
+    let error = match response {
+        Ok(result) => {
+            client.shutdown().await?;
+            anyhow::bail!("expected thread-not-found error, got response: {result:?}");
+        }
+        Err(error) => error,
+    };
+    let error_debug = format!("{error:?}");
+    let message = error.message;
+    client.shutdown().await?;
 
     assert!(
-        error.error.message.contains("thread not found"),
-        "expected thread-not-found error, got: {error:?}"
+        message.contains("thread not found"),
+        "expected thread-not-found error, got: {error_debug}"
     );
 
     Ok(())


### PR DESCRIPTION
## Summary
- Switch the unknown-thread MCP resource read test from the stdio subprocess to the in-process app-server path.
- Keep the assertion focused on the returned error message while avoiding child-process teardown timing issues in nextest.

## Testing
- Not run (not requested)