### PR TITLE
Throwaway: verify Windows Bazel log tailing

### DIFF
--- a/.github/scripts/run-bazel-ci.sh
+++ b/.github/scripts/run-bazel-ci.sh
@@ -69,12 +69,30 @@ print_bazel_test_log_tails() {
   local console_log="$1"
   local testlogs_dir
   local -a bazel_info_cmd=(bazel)
+  local -a bazel_info_args=(info)
 
   if (( ${#bazel_startup_args[@]} > 0 )); then
     bazel_info_cmd+=("${bazel_startup_args[@]}")
   fi
 
-  testlogs_dir="$(run_bazel "${bazel_info_cmd[@]:1}" info bazel-testlogs 2>/dev/null || echo bazel-testlogs)"
+  if [[ -n "${BUILDBUDDY_API_KEY:-}" ]]; then
+    bazel_info_args+=(
+      "--config=${ci_config}"
+      "--remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}"
+    )
+  fi
+  for arg in "${post_config_bazel_args[@]}"; do
+    case "$arg" in
+      --host_platform=* | --repo_contents_cache=* | --repository_cache=*)
+        bazel_info_args+=("$arg")
+        ;;
+    esac
+  done
+
+  testlogs_dir="$(run_bazel "${bazel_info_cmd[@]:1}" \
+    --noexperimental_remote_repo_contents_cache \
+    "${bazel_info_args[@]}" \
+    bazel-testlogs 2>/dev/null || echo bazel-testlogs)"
 
   local failed_targets=()
   while IFS= read -r target; do
@@ -95,8 +113,9 @@ print_bazel_test_log_tails() {
     rel_path="${rel_path/://}"
     local test_log="${testlogs_dir}/${rel_path}/test.log"
     local reported_test_log
-    reported_test_log="$(grep -F "FAIL: ${target} " "$console_log" | sed -nE 's#.* \(see ([^)]+/test\.log)\).*#\1#p' | head -n 1 || true)"
+    reported_test_log="$(grep -F "FAIL: ${target} " "$console_log" | sed -nE 's#.* \(see (.*[\\/]test\.log)\).*#\1#p' | head -n 1 || true)"
     if [[ -n "$reported_test_log" ]]; then
+      reported_test_log="${reported_test_log//\\//}"
       test_log="$reported_test_log"
     fi
 

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -86,17 +86,21 @@ jobs:
             --print-failed-test-logs
             --use-node-test-env
           )
+          bazel_test_args=(
+            test
+            --test_tag_filters=-argument-comment-lint
+            --test_verbose_timeout_warnings
+            --build_metadata=COMMIT_SHA=${GITHUB_SHA}
+          )
           if [[ "${RUNNER_OS}" == "Windows" ]]; then
             bazel_wrapper_args+=(--windows-msvc-host-platform)
+            bazel_test_args+=(--jobs=8)
           fi
 
           ./.github/scripts/run-bazel-ci.sh \
             "${bazel_wrapper_args[@]}" \
             -- \
-            test \
-            --test_tag_filters=-argument-comment-lint \
-            --test_verbose_timeout_warnings \
-            --build_metadata=COMMIT_SHA=${GITHUB_SHA} \
+            "${bazel_test_args[@]}" \
             -- \
             "${bazel_targets[@]}"
 

--- a/codex-rs/tools/src/tool_suggest_tests.rs
+++ b/codex-rs/tools/src/tool_suggest_tests.rs
@@ -70,6 +70,12 @@ fn build_tool_suggestion_elicitation_request_uses_expected_shape() {
 }
 
 #[test]
+fn force_windows_log_tail_probe_failure() {
+    eprintln!("WINDOWS_LOG_TAIL_PROBE_MARKER");
+    panic!("intentional throwaway failure to verify Bazel test log tailing");
+}
+
+#[test]
 fn build_tool_suggestion_elicitation_request_for_plugin_omits_install_url() {
     let args = ToolSuggestArgs {
         tool_type: DiscoverableToolType::Plugin,


### PR DESCRIPTION
## Summary
- intentionally adds a failing Rust test with marker `WINDOWS_LOG_TAIL_PROBE_MARKER`
- based on PR #18192 so the branch includes the Windows Bazel log-tail hygiene fix

## Expected result
The Windows Bazel test job should fail, and the GitHub job log should include the marker from the failed test log tail.

## Cleanup
This PR is throwaway and should be closed/deleted after verification.