### PR TITLE
[codex] Lint Cargo examples

### DIFF
--- a/.github/workflows/rust-ci-full.yml
+++ b/.github/workflows/rust-ci-full.yml
@@ -443,7 +443,7 @@ jobs:
           cargo chef cook --recipe-path "$RECIPE" --target ${{ matrix.target }} --release
 
       - name: cargo clippy
-        run: cargo clippy --target ${{ matrix.target }} --tests --profile ${{ matrix.profile }} --timings -- -D warnings
+        run: cargo clippy --target ${{ matrix.target }} --all-targets --profile ${{ matrix.profile }} --timings -- -D warnings
 
       - name: Upload Cargo timings (clippy)
         if: always()

--- a/defs.bzl
+++ b/defs.bzl
@@ -143,7 +143,7 @@ def codex_rust_crate(
         test_tags = [],
         unit_test_timeout = None,
         extra_binaries = []):
-    """Defines a Rust crate with library, binaries, and tests wired for Bazel + Cargo parity.
+    """Defines a Rust crate with library, binaries, examples, and tests wired for Bazel + Cargo parity.
 
     The macro mirrors Cargo conventions: it builds a library when `src/` exists,
     wires build scripts, exports `CARGO_BIN_EXE_*` for integration tests, and
@@ -297,6 +297,24 @@ def codex_rust_crate(
             edition = crate_edition,
             rustc_flags = rustc_flags_extra + WINDOWS_RUSTC_LINK_FLAGS,
             srcs = native.glob(["src/**/*.rs"]),
+            visibility = ["//visibility:public"],
+        )
+
+    for example in native.glob(["examples/*.rs", "examples/*/main.rs"], allow_empty = True):
+        if example.endswith("/main.rs"):
+            example_file_stem = example.removeprefix("examples/").removesuffix("/main.rs")
+        else:
+            example_file_stem = example.removeprefix("examples/").removesuffix(".rs")
+        example_name = "example-" + example_file_stem.replace("/", "-")
+
+        rust_binary(
+            name = example_name,
+            crate_name = example_file_stem.replace("-", "_"),
+            crate_root = example,
+            deps = all_crate_deps(normal = True, normal_dev = True) + maybe_deps + deps_extra,
+            edition = crate_edition,
+            rustc_flags = rustc_flags_extra + WINDOWS_RUSTC_LINK_FLAGS,
+            srcs = native.glob(["examples/**"], allow_empty = True),
             visibility = ["//visibility:public"],
         )
 

--- a/justfile
+++ b/justfile
@@ -33,10 +33,10 @@ fmt:
     cargo fmt -- --config imports_granularity=Item 2>/dev/null
 
 fix *args:
-    cargo clippy --fix --tests --allow-dirty "$@"
+    cargo clippy --fix --all-targets --allow-dirty "$@"
 
 clippy *args:
-    cargo clippy --tests "$@"
+    cargo clippy --all-targets "$@"
 
 install:
     rustup show active-toolchain


### PR DESCRIPTION
- Add "examples" to the default build targets bazel generates
- Lint all targets with `just clippy` not only --tests