### PR TITLE
[codex] Unify approval request routing

### DIFF
--- a/codex-rs/core/src/codex_delegate.rs
+++ b/codex-rs/core/src/codex_delegate.rs
@@ -38,16 +38,19 @@ use crate::codex::Session;
 use crate::codex::TurnContext;
 use crate::codex::emit_subagent_session_started;
 use crate::config::Config;
-use crate::guardian::GuardianApprovalRequest;
 use crate::guardian::new_guardian_review_id;
 use crate::guardian::review_approval_request_with_cancel;
 use crate::guardian::routes_approval_to_guardian;
 use crate::mcp_tool_call::MCP_TOOL_APPROVAL_ACCEPT;
 use crate::mcp_tool_call::MCP_TOOL_APPROVAL_ACCEPT_FOR_SESSION;
 use crate::mcp_tool_call::MCP_TOOL_APPROVAL_DECLINE_SYNTHETIC;
-use crate::mcp_tool_call::build_guardian_mcp_tool_review_request;
+use crate::mcp_tool_call::build_mcp_tool_approval_request;
 use crate::mcp_tool_call::is_mcp_tool_approval_question_id;
 use crate::mcp_tool_call::lookup_mcp_tool_metadata;
+use crate::tools::approval::ApprovalRequest;
+use crate::tools::approval::ApprovalRequestKind;
+use crate::tools::approval::CommandApprovalRequest;
+use crate::tools::approval::PatchApprovalRequest;
 use codex_login::AuthManager;
 use codex_models_manager::manager::ModelsManager;
 use codex_protocol::error::CodexErr;
@@ -461,19 +464,28 @@ async fn handle_exec_approval(
             Arc::clone(parent_session),
             Arc::clone(parent_ctx),
             new_guardian_review_id(),
-            GuardianApprovalRequest::Shell {
-                id: call_id.clone(),
-                command,
-                cwd,
-                sandbox_permissions: if additional_permissions.is_some() {
-                    crate::sandboxing::SandboxPermissions::WithAdditionalPermissions
-                } else {
-                    crate::sandboxing::SandboxPermissions::UseDefault
-                },
-                additional_permissions,
-                justification: None,
-            },
-            reason,
+            ApprovalRequest::new(
+                /*prompt_reason*/ reason.clone(),
+                reason,
+                ApprovalRequestKind::Command(CommandApprovalRequest {
+                    id: call_id.clone(),
+                    approval_id: approval_id.clone(),
+                    source: codex_protocol::approvals::GuardianCommandSource::Shell,
+                    command,
+                    cwd,
+                    sandbox_permissions: if additional_permissions.is_some() {
+                        crate::sandboxing::SandboxPermissions::WithAdditionalPermissions
+                    } else {
+                        crate::sandboxing::SandboxPermissions::UseDefault
+                    },
+                    additional_permissions,
+                    justification: None,
+                    network_approval_context,
+                    proposed_execpolicy_amendment,
+                    available_decisions,
+                    tty: false,
+                }),
+            ),
             review_cancel.clone(),
         );
         await_approval_with_cancel(
@@ -569,13 +581,18 @@ async fn handle_patch_approval(
             Arc::clone(parent_session),
             Arc::clone(parent_ctx),
             new_guardian_review_id(),
-            GuardianApprovalRequest::ApplyPatch {
-                id: approval_id.clone(),
-                cwd: parent_ctx.cwd.clone(),
-                files,
-                patch,
-            },
-            reason.clone(),
+            ApprovalRequest::new(
+                reason.clone(),
+                reason.clone(),
+                ApprovalRequestKind::Patch(PatchApprovalRequest {
+                    id: approval_id.clone(),
+                    cwd: parent_ctx.cwd.clone(),
+                    files,
+                    patch,
+                    changes: changes.clone(),
+                    grant_root: grant_root.clone(),
+                }),
+            ),
             review_cancel.clone(),
         );
         Some(
@@ -690,8 +707,7 @@ async fn maybe_auto_review_mcp_request_user_input(
         Arc::clone(parent_session),
         Arc::clone(parent_ctx),
         new_guardian_review_id(),
-        build_guardian_mcp_tool_review_request(&event.call_id, &invocation, metadata.as_ref()),
-        /*retry_reason*/ None,
+        build_mcp_tool_approval_request(&event.call_id, &invocation, metadata.as_ref(), None),
         review_cancel.clone(),
     );
     let decision = await_approval_with_cancel(
@@ -734,8 +750,7 @@ fn spawn_guardian_review(
     session: Arc<Session>,
     turn: Arc<TurnContext>,
     review_id: String,
-    request: GuardianApprovalRequest,
-    retry_reason: Option<String>,
+    request: ApprovalRequest,
     cancel_token: CancellationToken,
 ) -> oneshot::Receiver<ReviewDecision> {
     let (tx, rx) = oneshot::channel();
@@ -752,7 +767,6 @@ fn spawn_guardian_review(
             &turn,
             review_id,
             request,
-            retry_reason,
             cancel_token,
         ));
         let _ = tx.send(decision);

--- a/codex-rs/core/src/codex_tests.rs
+++ b/codex-rs/core/src/codex_tests.rs
@@ -783,8 +783,13 @@ async fn danger_full_access_tool_attempts_do_not_enforce_managed_network() -> an
             &'a mut self,
             _req: &'a (),
             _ctx: crate::tools::sandboxing::ApprovalCtx<'a>,
-        ) -> futures::future::BoxFuture<'a, ReviewDecision> {
-            Box::pin(async { ReviewDecision::Approved })
+        ) -> futures::future::BoxFuture<'a, crate::tools::approval::ApprovalOutcome> {
+            Box::pin(async {
+                crate::tools::approval::ApprovalOutcome {
+                    decision: ReviewDecision::Approved,
+                    guardian_review_id: None,
+                }
+            })
         }
     }
 

--- a/codex-rs/core/src/guardian/approval_request.rs
+++ b/codex-rs/core/src/guardian/approval_request.rs
@@ -1,8 +1,6 @@
 use std::path::Path;
 
 use codex_protocol::approvals::GuardianAssessmentAction;
-use codex_protocol::approvals::GuardianCommandSource;
-use codex_protocol::approvals::NetworkApprovalProtocol;
 use codex_protocol::models::PermissionProfile;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use serde::Serialize;
@@ -10,72 +8,9 @@ use serde_json::Value;
 
 use super::GUARDIAN_MAX_ACTION_STRING_TOKENS;
 use super::prompt::guardian_truncate_text;
-
-#[derive(Debug, Clone, PartialEq)]
-pub(crate) enum GuardianApprovalRequest {
-    Shell {
-        id: String,
-        command: Vec<String>,
-        cwd: AbsolutePathBuf,
-        sandbox_permissions: crate::sandboxing::SandboxPermissions,
-        additional_permissions: Option<PermissionProfile>,
-        justification: Option<String>,
-    },
-    ExecCommand {
-        id: String,
-        command: Vec<String>,
-        cwd: AbsolutePathBuf,
-        sandbox_permissions: crate::sandboxing::SandboxPermissions,
-        additional_permissions: Option<PermissionProfile>,
-        justification: Option<String>,
-        tty: bool,
-    },
-    #[cfg(unix)]
-    Execve {
-        id: String,
-        source: GuardianCommandSource,
-        program: String,
-        argv: Vec<String>,
-        cwd: AbsolutePathBuf,
-        additional_permissions: Option<PermissionProfile>,
-    },
-    ApplyPatch {
-        id: String,
-        cwd: AbsolutePathBuf,
-        files: Vec<AbsolutePathBuf>,
-        patch: String,
-    },
-    NetworkAccess {
-        id: String,
-        turn_id: String,
-        target: String,
-        host: String,
-        protocol: NetworkApprovalProtocol,
-        port: u16,
-    },
-    McpToolCall {
-        id: String,
-        server: String,
-        tool_name: String,
-        arguments: Option<Value>,
-        connector_id: Option<String>,
-        connector_name: Option<String>,
-        connector_description: Option<String>,
-        tool_title: Option<String>,
-        tool_description: Option<String>,
-        annotations: Option<GuardianMcpAnnotations>,
-    },
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub(crate) struct GuardianMcpAnnotations {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) destructive_hint: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) open_world_hint: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) read_only_hint: Option<bool>,
-}
+use crate::tools::approval::ApprovalRequest;
+use crate::tools::approval::ApprovalRequestKind;
+use crate::tools::approval::McpToolApprovalAnnotations;
 
 #[derive(Serialize)]
 struct CommandApprovalAction<'a> {
@@ -120,7 +55,7 @@ struct McpToolCallApprovalAction<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     tool_description: Option<&'a String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    annotations: Option<&'a GuardianMcpAnnotations>,
+    annotations: Option<&'a McpToolApprovalAnnotations>,
 }
 
 fn serialize_guardian_action(value: impl Serialize) -> serde_json::Result<Value> {
@@ -148,7 +83,7 @@ fn serialize_command_guardian_action(
 }
 
 fn command_assessment_action(
-    source: GuardianCommandSource,
+    source: codex_protocol::approvals::GuardianCommandSource,
     command: &[String],
     cwd: &AbsolutePathBuf,
 ) -> GuardianAssessmentAction {
@@ -160,10 +95,12 @@ fn command_assessment_action(
 }
 
 #[cfg(unix)]
-fn guardian_command_source_tool_name(source: GuardianCommandSource) -> &'static str {
+fn guardian_command_source_tool_name(
+    source: codex_protocol::approvals::GuardianCommandSource,
+) -> &'static str {
     match source {
-        GuardianCommandSource::Shell => "shell",
-        GuardianCommandSource::UnifiedExec => "exec_command",
+        codex_protocol::approvals::GuardianCommandSource::Shell => "shell",
+        codex_protocol::approvals::GuardianCommandSource::UnifiedExec => "exec_command",
     }
 }
 
@@ -194,196 +131,136 @@ fn truncate_guardian_action_value(value: Value) -> Value {
 }
 
 pub(crate) fn guardian_approval_request_to_json(
-    action: &GuardianApprovalRequest,
+    action: &ApprovalRequest,
 ) -> serde_json::Result<Value> {
-    match action {
-        GuardianApprovalRequest::Shell {
-            id: _,
-            command,
-            cwd,
-            sandbox_permissions,
-            additional_permissions,
-            justification,
-        } => serialize_command_guardian_action(
-            "shell",
-            command,
-            cwd,
-            *sandbox_permissions,
-            additional_permissions.as_ref(),
-            justification.as_ref(),
-            /*tty*/ None,
-        ),
-        GuardianApprovalRequest::ExecCommand {
-            id: _,
-            command,
-            cwd,
-            sandbox_permissions,
-            additional_permissions,
-            justification,
-            tty,
-        } => serialize_command_guardian_action(
-            "exec_command",
-            command,
-            cwd,
-            *sandbox_permissions,
-            additional_permissions.as_ref(),
-            justification.as_ref(),
-            Some(*tty),
-        ),
+    match &action.kind {
+        ApprovalRequestKind::Command(request) => {
+            let tool = match request.source {
+                codex_protocol::approvals::GuardianCommandSource::Shell => "shell",
+                codex_protocol::approvals::GuardianCommandSource::UnifiedExec => "exec_command",
+            };
+            let tty = match request.source {
+                codex_protocol::approvals::GuardianCommandSource::Shell => None,
+                codex_protocol::approvals::GuardianCommandSource::UnifiedExec => Some(request.tty),
+            };
+            serialize_command_guardian_action(
+                tool,
+                &request.command,
+                &request.cwd,
+                request.sandbox_permissions,
+                request.additional_permissions.as_ref(),
+                request.justification.as_ref(),
+                tty,
+            )
+        }
         #[cfg(unix)]
-        GuardianApprovalRequest::Execve {
-            id: _,
-            source,
-            program,
-            argv,
-            cwd,
-            additional_permissions,
-        } => serialize_guardian_action(ExecveApprovalAction {
-            tool: guardian_command_source_tool_name(*source),
-            program,
-            argv,
-            cwd,
-            additional_permissions: additional_permissions.as_ref(),
+        ApprovalRequestKind::Execve(request) => serialize_guardian_action(ExecveApprovalAction {
+            tool: guardian_command_source_tool_name(request.source),
+            program: &request.program,
+            argv: &request.argv,
+            cwd: &request.cwd,
+            additional_permissions: request.additional_permissions.as_ref(),
         }),
-        GuardianApprovalRequest::ApplyPatch {
-            id: _,
-            cwd,
-            files,
-            patch,
-        } => Ok(serde_json::json!({
-            "tool": "apply_patch",
-            "cwd": cwd,
-            "files": files,
-            "patch": patch,
-        })),
-        GuardianApprovalRequest::NetworkAccess {
-            id: _,
-            turn_id: _,
-            target,
-            host,
-            protocol,
-            port,
-        } => Ok(serde_json::json!({
-            "tool": "network_access",
-            "target": target,
-            "host": host,
-            "protocol": protocol,
-            "port": port,
-        })),
-        GuardianApprovalRequest::McpToolCall {
-            id: _,
-            server,
-            tool_name,
-            arguments,
-            connector_id,
-            connector_name,
-            connector_description,
-            tool_title,
-            tool_description,
-            annotations,
-        } => serialize_guardian_action(McpToolCallApprovalAction {
-            tool: "mcp_tool_call",
-            server,
-            tool_name,
-            arguments: arguments.as_ref(),
-            connector_id: connector_id.as_ref(),
-            connector_name: connector_name.as_ref(),
-            connector_description: connector_description.as_ref(),
-            tool_title: tool_title.as_ref(),
-            tool_description: tool_description.as_ref(),
-            annotations: annotations.as_ref(),
-        }),
+        ApprovalRequestKind::Patch(request) => {
+            let cwd = &request.cwd;
+            let files = &request.files;
+            let patch = &request.patch;
+            Ok(serde_json::json!({
+                "tool": "apply_patch",
+                "cwd": cwd,
+                "files": files,
+                "patch": patch,
+            }))
+        }
+        ApprovalRequestKind::NetworkAccess(request) => {
+            let target = &request.target;
+            let host = &request.host;
+            let protocol = request.protocol;
+            let port = request.port;
+            Ok(serde_json::json!({
+                "tool": "network_access",
+                "target": target,
+                "host": host,
+                "protocol": protocol,
+                "port": port,
+            }))
+        }
+        ApprovalRequestKind::McpToolCall(request) => {
+            serialize_guardian_action(McpToolCallApprovalAction {
+                tool: "mcp_tool_call",
+                server: &request.server,
+                tool_name: &request.tool_name,
+                arguments: request.arguments.as_ref(),
+                connector_id: request.connector_id.as_ref(),
+                connector_name: request.connector_name.as_ref(),
+                connector_description: request.connector_description.as_ref(),
+                tool_title: request.tool_title.as_ref(),
+                tool_description: request.tool_description.as_ref(),
+                annotations: request.annotations.as_ref(),
+            })
+        }
     }
 }
 
-pub(crate) fn guardian_assessment_action(
-    action: &GuardianApprovalRequest,
-) -> GuardianAssessmentAction {
-    match action {
-        GuardianApprovalRequest::Shell { command, cwd, .. } => {
-            command_assessment_action(GuardianCommandSource::Shell, command, cwd)
-        }
-        GuardianApprovalRequest::ExecCommand { command, cwd, .. } => {
-            command_assessment_action(GuardianCommandSource::UnifiedExec, command, cwd)
+pub(crate) fn guardian_assessment_action(action: &ApprovalRequest) -> GuardianAssessmentAction {
+    match &action.kind {
+        ApprovalRequestKind::Command(request) => {
+            command_assessment_action(request.source, &request.command, &request.cwd)
         }
         #[cfg(unix)]
-        GuardianApprovalRequest::Execve {
-            source,
-            program,
-            argv,
-            cwd,
-            ..
-        } => GuardianAssessmentAction::Execve {
-            source: *source,
-            program: program.clone(),
-            argv: argv.clone(),
-            cwd: cwd.clone(),
+        ApprovalRequestKind::Execve(request) => GuardianAssessmentAction::Execve {
+            source: request.source,
+            program: request.program.clone(),
+            argv: request.argv.clone(),
+            cwd: request.cwd.clone(),
         },
-        GuardianApprovalRequest::ApplyPatch { cwd, files, .. } => {
-            GuardianAssessmentAction::ApplyPatch {
-                cwd: cwd.clone(),
-                files: files.clone(),
-            }
-        }
-        GuardianApprovalRequest::NetworkAccess {
-            id: _,
-            turn_id: _,
-            target,
-            host,
-            protocol,
-            port,
-        } => GuardianAssessmentAction::NetworkAccess {
-            target: target.clone(),
-            host: host.clone(),
-            protocol: *protocol,
-            port: *port,
+        ApprovalRequestKind::Patch(request) => GuardianAssessmentAction::ApplyPatch {
+            cwd: request.cwd.clone(),
+            files: request.files.clone(),
         },
-        GuardianApprovalRequest::McpToolCall {
-            server,
-            tool_name,
-            connector_id,
-            connector_name,
-            tool_title,
-            ..
-        } => GuardianAssessmentAction::McpToolCall {
-            server: server.clone(),
-            tool_name: tool_name.clone(),
-            connector_id: connector_id.clone(),
-            connector_name: connector_name.clone(),
-            tool_title: tool_title.clone(),
+        ApprovalRequestKind::NetworkAccess(request) => GuardianAssessmentAction::NetworkAccess {
+            target: request.target.clone(),
+            host: request.host.clone(),
+            protocol: request.protocol,
+            port: request.port,
+        },
+        ApprovalRequestKind::McpToolCall(request) => GuardianAssessmentAction::McpToolCall {
+            server: request.server.clone(),
+            tool_name: request.tool_name.clone(),
+            connector_id: request.connector_id.clone(),
+            connector_name: request.connector_name.clone(),
+            tool_title: request.tool_title.clone(),
         },
     }
 }
 
-pub(crate) fn guardian_request_target_item_id(request: &GuardianApprovalRequest) -> Option<&str> {
-    match request {
-        GuardianApprovalRequest::Shell { id, .. }
-        | GuardianApprovalRequest::ExecCommand { id, .. }
-        | GuardianApprovalRequest::ApplyPatch { id, .. }
-        | GuardianApprovalRequest::McpToolCall { id, .. } => Some(id),
-        GuardianApprovalRequest::NetworkAccess { .. } => None,
+pub(crate) fn guardian_request_target_item_id(request: &ApprovalRequest) -> Option<&str> {
+    match &request.kind {
+        ApprovalRequestKind::Command(request) => Some(&request.id),
+        ApprovalRequestKind::Patch(request) => Some(&request.id),
+        ApprovalRequestKind::McpToolCall(request) => Some(&request.id),
+        ApprovalRequestKind::NetworkAccess(_) => None,
         #[cfg(unix)]
-        GuardianApprovalRequest::Execve { id, .. } => Some(id),
+        ApprovalRequestKind::Execve(request) => Some(&request.id),
     }
 }
 
 pub(crate) fn guardian_request_turn_id<'a>(
-    request: &'a GuardianApprovalRequest,
+    request: &'a ApprovalRequest,
     default_turn_id: &'a str,
 ) -> &'a str {
-    match request {
-        GuardianApprovalRequest::NetworkAccess { turn_id, .. } => turn_id,
-        GuardianApprovalRequest::Shell { .. }
-        | GuardianApprovalRequest::ExecCommand { .. }
-        | GuardianApprovalRequest::ApplyPatch { .. }
-        | GuardianApprovalRequest::McpToolCall { .. } => default_turn_id,
+    match &request.kind {
+        ApprovalRequestKind::NetworkAccess(request) => &request.turn_id,
+        ApprovalRequestKind::Command(_)
+        | ApprovalRequestKind::Patch(_)
+        | ApprovalRequestKind::McpToolCall(_) => default_turn_id,
         #[cfg(unix)]
-        GuardianApprovalRequest::Execve { .. } => default_turn_id,
+        ApprovalRequestKind::Execve(_) => default_turn_id,
     }
 }
 
 pub(crate) fn format_guardian_action_pretty(
-    action: &GuardianApprovalRequest,
+    action: &ApprovalRequest,
 ) -> serde_json::Result<String> {
     let mut value = guardian_approval_request_to_json(action)?;
     value = truncate_guardian_action_value(value);

--- a/codex-rs/core/src/guardian/mod.rs
+++ b/codex-rs/core/src/guardian/mod.rs
@@ -22,8 +22,6 @@ use codex_protocol::protocol::GuardianAssessmentDecisionSource;
 use serde::Deserialize;
 use serde::Serialize;
 
-pub(crate) use approval_request::GuardianApprovalRequest;
-pub(crate) use approval_request::GuardianMcpAnnotations;
 pub(crate) use approval_request::guardian_approval_request_to_json;
 pub(crate) use review::guardian_rejection_message;
 pub(crate) use review::guardian_timeout_message;

--- a/codex-rs/core/src/guardian/prompt.rs
+++ b/codex-rs/core/src/guardian/prompt.rs
@@ -7,6 +7,7 @@ use serde_json::Value;
 use crate::codex::Session;
 use crate::compact::content_items_to_text;
 use crate::event_mapping::is_contextual_user_message_content;
+use crate::tools::approval::ApprovalRequest;
 use codex_utils_output_truncation::approx_bytes_for_tokens;
 use codex_utils_output_truncation::approx_token_count;
 use codex_utils_output_truncation::approx_tokens_from_byte_count;
@@ -16,7 +17,6 @@ use super::GUARDIAN_MAX_MESSAGE_TRANSCRIPT_TOKENS;
 use super::GUARDIAN_MAX_TOOL_ENTRY_TOKENS;
 use super::GUARDIAN_MAX_TOOL_TRANSCRIPT_TOKENS;
 use super::GUARDIAN_RECENT_ENTRY_LIMIT;
-use super::GuardianApprovalRequest;
 use super::GuardianAssessment;
 use super::TRUNCATION_TAG;
 use super::approval_request::format_guardian_action_pretty;
@@ -81,8 +81,7 @@ pub(crate) enum GuardianPromptMode {
 /// prompt text through trailing newlines.
 pub(crate) async fn build_guardian_prompt_items(
     session: &Session,
-    retry_reason: Option<String>,
-    request: GuardianApprovalRequest,
+    request: ApprovalRequest,
     mode: GuardianPromptMode,
 ) -> serde_json::Result<GuardianPromptItems> {
     let history = session.clone_history().await;
@@ -91,6 +90,7 @@ pub(crate) async fn build_guardian_prompt_items(
         parent_history_version: history.history_version(),
         transcript_entry_count: transcript_entries.len(),
     };
+    let retry_reason = request.review_reason.clone();
     let planned_action_json = format_guardian_action_pretty(&request)?;
 
     let prompt_shape = match mode {

--- a/codex-rs/core/src/guardian/review.rs
+++ b/codex-rs/core/src/guardian/review.rs
@@ -15,9 +15,9 @@ use tokio_util::sync::CancellationToken;
 
 use crate::codex::Session;
 use crate::codex::TurnContext;
+use crate::tools::approval::ApprovalRequest;
 
 use super::GUARDIAN_REVIEWER_NAME;
-use super::GuardianApprovalRequest;
 use super::GuardianAssessment;
 use super::GuardianAssessmentOutcome;
 use super::GuardianRejection;
@@ -114,8 +114,7 @@ async fn run_guardian_review(
     session: Arc<Session>,
     turn: Arc<TurnContext>,
     review_id: String,
-    request: GuardianApprovalRequest,
-    retry_reason: Option<String>,
+    request: ApprovalRequest,
     external_cancel: Option<CancellationToken>,
 ) -> ReviewDecision {
     let target_item_id = guardian_request_target_item_id(&request).map(str::to_string);
@@ -167,7 +166,6 @@ async fn run_guardian_review(
         session.clone(),
         turn.clone(),
         request,
-        retry_reason,
         schema,
         external_cancel,
     ))
@@ -300,8 +298,7 @@ pub(crate) async fn review_approval_request(
     session: &Arc<Session>,
     turn: &Arc<TurnContext>,
     review_id: String,
-    request: GuardianApprovalRequest,
-    retry_reason: Option<String>,
+    request: ApprovalRequest,
 ) -> ReviewDecision {
     // Box the delegated review future so callers do not inline the entire
     // guardian session state machine into their own async stack.
@@ -310,7 +307,6 @@ pub(crate) async fn review_approval_request(
         Arc::clone(turn),
         review_id,
         request,
-        retry_reason,
         /*external_cancel*/ None,
     ))
     .await
@@ -320,8 +316,7 @@ pub(crate) async fn review_approval_request_with_cancel(
     session: &Arc<Session>,
     turn: &Arc<TurnContext>,
     review_id: String,
-    request: GuardianApprovalRequest,
-    retry_reason: Option<String>,
+    request: ApprovalRequest,
     cancel_token: CancellationToken,
 ) -> ReviewDecision {
     Box::pin(run_guardian_review(
@@ -329,7 +324,6 @@ pub(crate) async fn review_approval_request_with_cancel(
         Arc::clone(turn),
         review_id,
         request,
-        retry_reason,
         Some(cancel_token),
     ))
     .await
@@ -352,8 +346,7 @@ pub(crate) async fn review_approval_request_with_cancel(
 pub(super) async fn run_guardian_review_session(
     session: Arc<Session>,
     turn: Arc<TurnContext>,
-    request: GuardianApprovalRequest,
-    retry_reason: Option<String>,
+    request: ApprovalRequest,
     schema: serde_json::Value,
     external_cancel: Option<CancellationToken>,
 ) -> GuardianReviewOutcome {
@@ -421,7 +414,6 @@ pub(super) async fn run_guardian_review_session(
                 parent_turn: turn.clone(),
                 spawn_config: guardian_config,
                 request,
-                retry_reason,
                 schema,
                 model: guardian_model,
                 reasoning_effort: guardian_reasoning_effort,

--- a/codex-rs/core/src/guardian/review_session.rs
+++ b/codex-rs/core/src/guardian/review_session.rs
@@ -39,12 +39,12 @@ use codex_utils_absolute_path::AbsolutePathBuf;
 
 use super::GUARDIAN_REVIEW_TIMEOUT;
 use super::GUARDIAN_REVIEWER_NAME;
-use super::GuardianApprovalRequest;
 use super::prompt::GuardianPromptMode;
 use super::prompt::GuardianTranscriptCursor;
 use super::prompt::build_guardian_prompt_items;
 use super::prompt::guardian_policy_prompt;
 use super::prompt::guardian_policy_prompt_with_config;
+use crate::tools::approval::ApprovalRequest;
 
 const GUARDIAN_INTERRUPT_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 const GUARDIAN_FOLLOWUP_REVIEW_REMINDER: &str = concat!(
@@ -66,8 +66,7 @@ pub(crate) struct GuardianReviewSessionParams {
     pub(crate) parent_session: Arc<Session>,
     pub(crate) parent_turn: Arc<TurnContext>,
     pub(crate) spawn_config: Config,
-    pub(crate) request: GuardianApprovalRequest,
-    pub(crate) retry_reason: Option<String>,
+    pub(crate) request: ApprovalRequest,
     pub(crate) schema: Value,
     pub(crate) model: String,
     pub(crate) reasoning_effort: Option<ReasoningEffortConfig>,
@@ -578,7 +577,6 @@ async fn run_review_on_session(
 
             let prompt_items = build_guardian_prompt_items(
                 params.parent_session.as_ref(),
-                params.retry_reason.clone(),
                 params.request.clone(),
                 prompt_mode,
             )

--- a/codex-rs/core/src/guardian/tests.rs
+++ b/codex-rs/core/src/guardian/tests.rs
@@ -15,9 +15,17 @@ use crate::config_loader::NetworkDomainPermissionsToml;
 use crate::config_loader::RequirementSource;
 use crate::config_loader::Sourced;
 use crate::test_support;
+use crate::tools::approval::ApprovalRequest;
+use crate::tools::approval::ApprovalRequestKind;
+use crate::tools::approval::CommandApprovalRequest;
+use crate::tools::approval::McpToolApprovalAnnotations;
+use crate::tools::approval::McpToolApprovalRequest;
+use crate::tools::approval::NetworkAccessApprovalRequest;
+use crate::tools::approval::PatchApprovalRequest;
 use codex_config::config_toml::ConfigToml;
 use codex_network_proxy::NetworkProxyConfig;
 use codex_protocol::ThreadId;
+use codex_protocol::approvals::GuardianCommandSource;
 use codex_protocol::approvals::NetworkApprovalProtocol;
 use codex_protocol::config_types::ApprovalsReviewer;
 use codex_protocol::models::ContentItem;
@@ -50,6 +58,7 @@ use insta::Settings;
 use insta::assert_snapshot;
 use pretty_assertions::assert_eq;
 use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use tempfile::TempDir;
@@ -58,6 +67,52 @@ use tokio_util::sync::CancellationToken;
 fn fixed_guardian_parent_session_id() -> ThreadId {
     ThreadId::from_string("11111111-1111-4111-8111-111111111111")
         .expect("fixed parent session id should be a valid UUID")
+}
+
+fn shell_approval_request(
+    id: &str,
+    command: Vec<String>,
+    cwd: codex_utils_absolute_path::AbsolutePathBuf,
+    justification: Option<String>,
+) -> ApprovalRequest {
+    ApprovalRequest::new(
+        /*prompt_reason*/ None,
+        /*review_reason*/ None,
+        ApprovalRequestKind::Command(CommandApprovalRequest {
+            id: id.to_string(),
+            approval_id: None,
+            source: GuardianCommandSource::Shell,
+            command,
+            cwd,
+            sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
+            additional_permissions: None,
+            justification,
+            network_approval_context: None,
+            proposed_execpolicy_amendment: None,
+            available_decisions: None,
+            tty: false,
+        }),
+    )
+}
+
+fn patch_approval_request(
+    id: &str,
+    cwd: codex_utils_absolute_path::AbsolutePathBuf,
+    files: Vec<codex_utils_absolute_path::AbsolutePathBuf>,
+    patch: String,
+) -> ApprovalRequest {
+    ApprovalRequest::new(
+        /*prompt_reason*/ None,
+        /*review_reason*/ None,
+        ApprovalRequestKind::Patch(PatchApprovalRequest {
+            id: id.to_string(),
+            cwd,
+            files,
+            patch,
+            changes: HashMap::new(),
+            grant_root: None,
+        }),
+    )
 }
 
 async fn guardian_test_session_and_turn(
@@ -227,20 +282,15 @@ async fn build_guardian_prompt_full_mode_preserves_initial_review_format() -> an
     let (session, turn) = guardian_test_session_and_turn_with_base_url("http://localhost").await;
     seed_guardian_parent_history(&session, &turn).await;
 
-    let prompt = build_guardian_prompt_items(
-        session.as_ref(),
-        Some("Sandbox denied outbound git push to github.com.".to_string()),
-        GuardianApprovalRequest::Shell {
-            id: "shell-1".to_string(),
-            command: vec!["git".to_string(), "push".to_string()],
-            cwd: test_path_buf("/repo/codex-rs/core").abs(),
-            sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
-            additional_permissions: None,
-            justification: Some("Need to push the reviewed docs fix.".to_string()),
-        },
-        GuardianPromptMode::Full,
-    )
-    .await?;
+    let mut request = shell_approval_request(
+        "shell-1",
+        vec!["git".to_string(), "push".to_string()],
+        test_path_buf("/repo/codex-rs/core").abs(),
+        Some("Need to push the reviewed docs fix.".to_string()),
+    );
+    request.review_reason = Some("Sandbox denied outbound git push to github.com.".to_string());
+    let prompt =
+        build_guardian_prompt_items(session.as_ref(), request, GuardianPromptMode::Full).await?;
 
     let text = guardian_prompt_text(&prompt.items);
     assert!(text.contains("whose request action you are assessing"));
@@ -285,15 +335,12 @@ async fn build_guardian_prompt_delta_mode_preserves_original_numbering() -> anyh
 
     let prompt = build_guardian_prompt_items(
         session.as_ref(),
-        /*retry_reason*/ None,
-        GuardianApprovalRequest::Shell {
-            id: "shell-2".to_string(),
-            command: vec!["git".to_string(), "push".to_string()],
-            cwd: test_path_buf("/repo/codex-rs/core").abs(),
-            sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
-            additional_permissions: None,
-            justification: Some("Need to push the second docs fix.".to_string()),
-        },
+        shell_approval_request(
+            "shell-2",
+            vec!["git".to_string(), "push".to_string()],
+            test_path_buf("/repo/codex-rs/core").abs(),
+            Some("Need to push the second docs fix.".to_string()),
+        ),
         GuardianPromptMode::Delta {
             cursor: GuardianTranscriptCursor {
                 parent_history_version: 0,
@@ -323,15 +370,12 @@ async fn build_guardian_prompt_delta_mode_handles_empty_delta() -> anyhow::Resul
 
     let prompt = build_guardian_prompt_items(
         session.as_ref(),
-        /*retry_reason*/ None,
-        GuardianApprovalRequest::Shell {
-            id: "shell-2".to_string(),
-            command: vec!["git".to_string(), "push".to_string()],
-            cwd: test_path_buf("/repo/codex-rs/core").abs(),
-            sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
-            additional_permissions: None,
-            justification: Some("Need to push the second docs fix.".to_string()),
-        },
+        shell_approval_request(
+            "shell-2",
+            vec!["git".to_string(), "push".to_string()],
+            test_path_buf("/repo/codex-rs/core").abs(),
+            Some("Need to push the second docs fix.".to_string()),
+        ),
         GuardianPromptMode::Delta {
             cursor: GuardianTranscriptCursor {
                 parent_history_version: 0,
@@ -358,15 +402,12 @@ async fn build_guardian_prompt_stale_delta_cursor_falls_back_to_full_prompt() ->
 
     let prompt = build_guardian_prompt_items(
         session.as_ref(),
-        /*retry_reason*/ None,
-        GuardianApprovalRequest::Shell {
-            id: "shell-3".to_string(),
-            command: vec!["git".to_string(), "push".to_string()],
-            cwd: test_path_buf("/repo/codex-rs/core").abs(),
-            sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
-            additional_permissions: None,
-            justification: Some("Need to push the docs fix.".to_string()),
-        },
+        shell_approval_request(
+            "shell-3",
+            vec!["git".to_string(), "push".to_string()],
+            test_path_buf("/repo/codex-rs/core").abs(),
+            Some("Need to push the docs fix.".to_string()),
+        ),
         GuardianPromptMode::Delta {
             cursor: GuardianTranscriptCursor {
                 parent_history_version: 0,
@@ -443,15 +484,12 @@ async fn build_guardian_prompt_stale_delta_version_falls_back_to_full_prompt() -
 
     let prompt = build_guardian_prompt_items(
         session.as_ref(),
-        /*retry_reason*/ None,
-        GuardianApprovalRequest::Shell {
-            id: "shell-4".to_string(),
-            command: vec!["git".to_string(), "push".to_string()],
-            cwd: test_path_buf("/repo/codex-rs/core").abs(),
-            sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
-            additional_permissions: None,
-            justification: Some("Need to push after the compaction.".to_string()),
-        },
+        shell_approval_request(
+            "shell-4",
+            vec!["git".to_string(), "push".to_string()],
+            test_path_buf("/repo/codex-rs/core").abs(),
+            Some("Need to push after the compaction.".to_string()),
+        ),
         GuardianPromptMode::Delta {
             cursor: GuardianTranscriptCursor {
                 parent_history_version: 0,
@@ -577,12 +615,12 @@ fn guardian_truncate_text_keeps_prefix_suffix_and_xml_marker() {
 #[test]
 fn format_guardian_action_pretty_truncates_large_string_fields() -> serde_json::Result<()> {
     let patch = "line\n".repeat(100_000);
-    let action = GuardianApprovalRequest::ApplyPatch {
-        id: "patch-1".to_string(),
-        cwd: test_path_buf("/tmp").abs(),
-        files: Vec::new(),
-        patch: patch.clone(),
-    };
+    let action = patch_approval_request(
+        "patch-1",
+        test_path_buf("/tmp").abs(),
+        Vec::new(),
+        patch.clone(),
+    );
 
     let rendered = format_guardian_action_pretty(&action)?;
 
@@ -594,24 +632,28 @@ fn format_guardian_action_pretty_truncates_large_string_fields() -> serde_json::
 
 #[test]
 fn guardian_approval_request_to_json_renders_mcp_tool_call_shape() -> serde_json::Result<()> {
-    let action = GuardianApprovalRequest::McpToolCall {
-        id: "call-1".to_string(),
-        server: "mcp_server".to_string(),
-        tool_name: "browser_navigate".to_string(),
-        arguments: Some(serde_json::json!({
-            "url": "https://example.com",
-        })),
-        connector_id: None,
-        connector_name: Some("Playwright".to_string()),
-        connector_description: None,
-        tool_title: Some("Navigate".to_string()),
-        tool_description: None,
-        annotations: Some(GuardianMcpAnnotations {
-            destructive_hint: Some(true),
-            open_world_hint: None,
-            read_only_hint: Some(false),
+    let action = ApprovalRequest::new(
+        /*prompt_reason*/ None,
+        /*review_reason*/ None,
+        ApprovalRequestKind::McpToolCall(McpToolApprovalRequest {
+            id: "call-1".to_string(),
+            server: "mcp_server".to_string(),
+            tool_name: "browser_navigate".to_string(),
+            arguments: Some(serde_json::json!({
+                "url": "https://example.com",
+            })),
+            connector_id: None,
+            connector_name: Some("Playwright".to_string()),
+            connector_description: None,
+            tool_title: Some("Navigate".to_string()),
+            tool_description: None,
+            annotations: Some(McpToolApprovalAnnotations {
+                destructive_hint: Some(true),
+                open_world_hint: None,
+                read_only_hint: Some(false),
+            }),
         }),
-    };
+    );
 
     assert_eq!(
         guardian_approval_request_to_json(&action)?,
@@ -637,13 +679,12 @@ fn guardian_approval_request_to_json_renders_mcp_tool_call_shape() -> serde_json
 fn guardian_assessment_action_redacts_apply_patch_patch_text() {
     let cwd = test_path_buf("/tmp").abs();
     let file = test_path_buf("/tmp/guardian.txt").abs();
-    let action = GuardianApprovalRequest::ApplyPatch {
-        id: "patch-1".to_string(),
-        cwd: cwd.clone(),
-        files: vec![file.clone()],
-        patch: "*** Begin Patch\n*** Update File: guardian.txt\n@@\n+secret\n*** End Patch"
-            .to_string(),
-    };
+    let action = patch_approval_request(
+        "patch-1",
+        cwd.clone(),
+        vec![file.clone()],
+        "*** Begin Patch\n*** Update File: guardian.txt\n@@\n+secret\n*** End Patch".to_string(),
+    );
 
     assert_eq!(
         serde_json::to_value(guardian_assessment_action(&action)).expect("serialize action"),
@@ -657,21 +698,25 @@ fn guardian_assessment_action_redacts_apply_patch_patch_text() {
 
 #[test]
 fn guardian_request_turn_id_prefers_network_access_owner_turn() {
-    let network_access = GuardianApprovalRequest::NetworkAccess {
-        id: "network-1".to_string(),
-        turn_id: "owner-turn".to_string(),
-        target: "https://example.com:443".to_string(),
-        host: "example.com".to_string(),
-        protocol: NetworkApprovalProtocol::Https,
-        port: 443,
-    };
-    let apply_patch = GuardianApprovalRequest::ApplyPatch {
-        id: "patch-1".to_string(),
-        cwd: test_path_buf("/tmp").abs(),
-        files: vec![test_path_buf("/tmp/guardian.txt").abs()],
-        patch: "*** Begin Patch\n*** Update File: guardian.txt\n@@\n+hello\n*** End Patch"
-            .to_string(),
-    };
+    let network_access = ApprovalRequest::new(
+        /*prompt_reason*/ None,
+        /*review_reason*/ None,
+        ApprovalRequestKind::NetworkAccess(NetworkAccessApprovalRequest {
+            id: "network-1".to_string(),
+            turn_id: "owner-turn".to_string(),
+            target: "https://example.com:443".to_string(),
+            host: "example.com".to_string(),
+            protocol: NetworkApprovalProtocol::Https,
+            port: 443,
+            cwd: test_path_buf("/tmp").abs(),
+        }),
+    );
+    let apply_patch = patch_approval_request(
+        "patch-1",
+        test_path_buf("/tmp").abs(),
+        vec![test_path_buf("/tmp/guardian.txt").abs()],
+        "*** Begin Patch\n*** Update File: guardian.txt\n@@\n+hello\n*** End Patch".to_string(),
+    );
 
     assert_eq!(
         guardian_request_turn_id(&network_access, "fallback-turn"),
@@ -693,14 +738,12 @@ async fn cancelled_guardian_review_emits_terminal_abort_without_warning() {
         &session,
         &turn,
         "review-cancelled-guardian".to_string(),
-        GuardianApprovalRequest::ApplyPatch {
-            id: "patch-1".to_string(),
-            cwd: test_path_buf("/tmp").abs(),
-            files: vec![test_path_buf("/tmp/guardian.txt").abs()],
-            patch: "*** Begin Patch\n*** Update File: guardian.txt\n@@\n+hello\n*** End Patch"
-                .to_string(),
-        },
-        /*retry_reason*/ None,
+        patch_approval_request(
+            "patch-1",
+            test_path_buf("/tmp").abs(),
+            vec![test_path_buf("/tmp/guardian.txt").abs()],
+            "*** Begin Patch\n*** Update File: guardian.txt\n@@\n+hello\n*** End Patch".to_string(),
+        ),
         cancel_token,
     )
     .await;
@@ -893,25 +936,23 @@ async fn guardian_review_request_layout_matches_model_visible_request_snapshot()
     let turn = Arc::new(turn);
     seed_guardian_parent_history(&session, &turn).await;
 
-    let request = GuardianApprovalRequest::Shell {
-        id: "shell-1".to_string(),
-        command: vec![
+    let mut request = shell_approval_request(
+        "shell-1",
+        vec![
             "git".to_string(),
             "push".to_string(),
             "origin".to_string(),
             "guardian-approval-mvp".to_string(),
         ],
-        cwd: test_path_buf("/repo/codex-rs/core").abs(),
-        sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
-        additional_permissions: None,
-        justification: Some("Need to push the reviewed docs fix to the repo remote.".to_string()),
-    };
+        test_path_buf("/repo/codex-rs/core").abs(),
+        Some("Need to push the reviewed docs fix to the repo remote.".to_string()),
+    );
+    request.review_reason = Some("Sandbox denied outbound git push to github.com.".to_string());
 
     let outcome = run_guardian_review_session_for_test(
         Arc::clone(&session),
         Arc::clone(&turn),
         request,
-        Some("Sandbox denied outbound git push to github.com.".to_string()),
         guardian_output_schema(),
         /*external_cancel*/ None,
     )
@@ -944,15 +985,12 @@ async fn build_guardian_prompt_items_includes_parent_session_id() -> anyhow::Res
     let (session, _) = crate::codex::make_session_and_context().await;
     let prompt = build_guardian_prompt_items(
         &session,
-        /*retry_reason*/ None,
-        GuardianApprovalRequest::Shell {
-            id: "shell-1".to_string(),
-            command: vec!["git".to_string(), "status".to_string()],
-            cwd: test_path_buf("/repo").abs(),
-            sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
-            additional_permissions: None,
-            justification: None,
-        },
+        shell_approval_request(
+            "shell-1",
+            vec!["git".to_string(), "status".to_string()],
+            test_path_buf("/repo").abs(),
+            None,
+        ),
         GuardianPromptMode::Full,
     )
     .await?;
@@ -1019,19 +1057,17 @@ async fn guardian_reuses_prompt_cache_key_and_appends_prior_reviews() -> anyhow:
     let (session, turn) = guardian_test_session_and_turn(&server).await;
     seed_guardian_parent_history(&session, &turn).await;
 
-    let first_request = GuardianApprovalRequest::Shell {
-        id: "shell-1".to_string(),
-        command: vec!["git".to_string(), "push".to_string()],
-        cwd: test_path_buf("/repo/codex-rs/core").abs(),
-        sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
-        additional_permissions: None,
-        justification: Some("Need to push the first docs fix.".to_string()),
-    };
+    let mut first_request = shell_approval_request(
+        "shell-1",
+        vec!["git".to_string(), "push".to_string()],
+        test_path_buf("/repo/codex-rs/core").abs(),
+        Some("Need to push the first docs fix.".to_string()),
+    );
+    first_request.review_reason = Some("First retry reason".to_string());
     let first_outcome = run_guardian_review_session_for_test(
         Arc::clone(&session),
         Arc::clone(&turn),
         first_request,
-        Some("First retry reason".to_string()),
         guardian_output_schema(),
         /*external_cancel*/ None,
     )
@@ -1061,23 +1097,21 @@ async fn guardian_reuses_prompt_cache_key_and_appends_prior_reviews() -> anyhow:
             turn.as_ref(),
         )
         .await;
-    let second_request = GuardianApprovalRequest::Shell {
-        id: "shell-2".to_string(),
-        command: vec![
+    let mut second_request = shell_approval_request(
+        "shell-2",
+        vec![
             "git".to_string(),
             "push".to_string(),
             "--force-with-lease".to_string(),
         ],
-        cwd: test_path_buf("/repo/codex-rs/core").abs(),
-        sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
-        additional_permissions: None,
-        justification: Some("Need to push the second docs fix.".to_string()),
-    };
+        test_path_buf("/repo/codex-rs/core").abs(),
+        Some("Need to push the second docs fix.".to_string()),
+    );
+    second_request.review_reason = Some("Second retry reason".to_string());
     let second_outcome = run_guardian_review_session_for_test(
         Arc::clone(&session),
         Arc::clone(&turn),
         second_request,
-        Some("Second retry reason".to_string()),
         guardian_output_schema(),
         /*external_cancel*/ None,
     )
@@ -1107,19 +1141,17 @@ async fn guardian_reuses_prompt_cache_key_and_appends_prior_reviews() -> anyhow:
             turn.as_ref(),
         )
         .await;
-    let third_request = GuardianApprovalRequest::Shell {
-        id: "shell-3".to_string(),
-        command: vec!["git".to_string(), "push".to_string()],
-        cwd: test_path_buf("/repo/codex-rs/core").abs(),
-        sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
-        additional_permissions: None,
-        justification: Some("Need to push the third docs fix.".to_string()),
-    };
+    let mut third_request = shell_approval_request(
+        "shell-3",
+        vec!["git".to_string(), "push".to_string()],
+        test_path_buf("/repo/codex-rs/core").abs(),
+        Some("Need to push the third docs fix.".to_string()),
+    );
+    third_request.review_reason = Some("Third retry reason".to_string());
     let third_outcome = run_guardian_review_session_for_test(
         Arc::clone(&session),
         Arc::clone(&turn),
         third_request,
-        Some("Third retry reason".to_string()),
         guardian_output_schema(),
         /*external_cancel*/ None,
     )
@@ -1269,15 +1301,12 @@ async fn guardian_review_surfaces_responses_api_errors_in_rejection_reason() -> 
         &session,
         &turn,
         "review-shell-guardian-error".to_string(),
-        GuardianApprovalRequest::Shell {
-            id: "shell-guardian-error".to_string(),
-            command: vec!["git".to_string(), "push".to_string()],
-            cwd: test_path_buf("/repo/codex-rs/core").abs(),
-            sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
-            additional_permissions: None,
-            justification: Some("Need to push the reviewed docs fix.".to_string()),
-        },
-        /*retry_reason*/ None,
+        shell_approval_request(
+            "shell-guardian-error",
+            vec!["git".to_string(), "push".to_string()],
+            test_path_buf("/repo/codex-rs/core").abs(),
+            Some("Need to push the reviewed docs fix.".to_string()),
+        ),
     )
     .await;
 
@@ -1403,21 +1432,18 @@ async fn guardian_parallel_reviews_fork_from_last_committed_trunk_history() -> a
         let (session, turn) = guardian_test_session_and_turn_with_base_url(server.uri()).await;
         seed_guardian_parent_history(&session, &turn).await;
 
-        let initial_request = GuardianApprovalRequest::Shell {
-            id: "shell-guardian-1".to_string(),
-            command: vec!["git".to_string(), "status".to_string()],
-            cwd: test_path_buf("/repo/codex-rs/core").abs(),
-            sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
-            additional_permissions: None,
-            justification: Some("Inspect repo state before proceeding.".to_string()),
-        };
+        let initial_request = shell_approval_request(
+            "shell-guardian-1",
+            vec!["git".to_string(), "status".to_string()],
+            test_path_buf("/repo/codex-rs/core").abs(),
+            Some("Inspect repo state before proceeding.".to_string()),
+        );
         assert_eq!(
             review_approval_request(
                 &session,
                 &turn,
                 "review-shell-guardian-1".to_string(),
                 initial_request,
-                /*retry_reason*/ None
             )
             .await,
             ReviewDecision::Approved
@@ -1448,22 +1474,20 @@ async fn guardian_parallel_reviews_fork_from_last_committed_trunk_history() -> a
             )
             .await;
 
-        let second_request = GuardianApprovalRequest::Shell {
-            id: "shell-guardian-2".to_string(),
-            command: vec!["git".to_string(), "diff".to_string()],
-            cwd: test_path_buf("/repo/codex-rs/core").abs(),
-            sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
-            additional_permissions: None,
-            justification: Some("Inspect pending changes before proceeding.".to_string()),
-        };
-        let third_request = GuardianApprovalRequest::Shell {
-            id: "shell-guardian-3".to_string(),
-            command: vec!["git".to_string(), "push".to_string()],
-            cwd: test_path_buf("/repo/codex-rs/core").abs(),
-            sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
-            additional_permissions: None,
-            justification: Some("Inspect whether pushing is safe before proceeding.".to_string()),
-        };
+        let mut second_request = shell_approval_request(
+            "shell-guardian-2",
+            vec!["git".to_string(), "diff".to_string()],
+            test_path_buf("/repo/codex-rs/core").abs(),
+            Some("Inspect pending changes before proceeding.".to_string()),
+        );
+        second_request.review_reason = Some("trunk follow-up".to_string());
+        let mut third_request = shell_approval_request(
+            "shell-guardian-3",
+            vec!["git".to_string(), "push".to_string()],
+            test_path_buf("/repo/codex-rs/core").abs(),
+            Some("Inspect whether pushing is safe before proceeding.".to_string()),
+        );
+        third_request.review_reason = Some("parallel follow-up".to_string());
 
         let session_for_second = Arc::clone(&session);
         let turn_for_second = Arc::clone(&turn);
@@ -1473,7 +1497,6 @@ async fn guardian_parallel_reviews_fork_from_last_committed_trunk_history() -> a
                 &turn_for_second,
                 "review-shell-guardian-2".to_string(),
                 second_request,
-                Some("trunk follow-up".to_string()),
             )
             .await
         });
@@ -1522,7 +1545,6 @@ async fn guardian_parallel_reviews_fork_from_last_committed_trunk_history() -> a
             &turn,
             "review-shell-guardian-3".to_string(),
             third_request,
-            Some("parallel follow-up".to_string()),
         )
         .await;
         assert_eq!(third_decision, ReviewDecision::Approved);

--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -19,8 +19,6 @@ use crate::config::edit::ConfigEdit;
 use crate::config::edit::ConfigEditsBuilder;
 use crate::config::load_global_mcp_servers;
 use crate::connectors;
-use crate::guardian::GuardianApprovalRequest;
-use crate::guardian::GuardianMcpAnnotations;
 use crate::guardian::guardian_approval_request_to_json;
 use crate::guardian::guardian_rejection_message;
 use crate::guardian::guardian_timeout_message;
@@ -30,6 +28,10 @@ use crate::guardian::routes_approval_to_guardian;
 use crate::mcp_openai_file::rewrite_mcp_tool_arguments_for_openai_files;
 use crate::mcp_tool_approval_templates::RenderedMcpToolApprovalParam;
 use crate::mcp_tool_approval_templates::render_mcp_tool_approval_template;
+use crate::tools::approval::ApprovalRequest;
+use crate::tools::approval::ApprovalRequestKind;
+use crate::tools::approval::McpToolApprovalAnnotations;
+use crate::tools::approval::McpToolApprovalRequest;
 use codex_analytics::AppInvocation;
 use codex_analytics::InvocationType;
 use codex_analytics::build_track_events_context;
@@ -847,8 +849,7 @@ async fn maybe_request_mcp_tool_approval(
             sess,
             turn_context,
             review_id.clone(),
-            build_guardian_mcp_tool_review_request(call_id, invocation, metadata),
-            monitor_reason.clone(),
+            build_mcp_tool_approval_request(call_id, invocation, metadata, monitor_reason.clone()),
         )
         .await;
         let decision = mcp_tool_approval_decision_from_guardian(sess, &review_id, decision).await;
@@ -975,7 +976,7 @@ fn prepare_arc_request_action(
     invocation: &McpInvocation,
     metadata: Option<&McpToolApprovalMetadata>,
 ) -> serde_json::Value {
-    let request = build_guardian_mcp_tool_review_request("arc-monitor", invocation, metadata);
+    let request = build_mcp_tool_approval_request("arc-monitor", invocation, metadata, None);
     match guardian_approval_request_to_json(&request) {
         Ok(action) => action,
         Err(error) => {
@@ -1014,29 +1015,35 @@ fn persistent_mcp_tool_approval_key(
     session_mcp_tool_approval_key(invocation, metadata, approval_mode)
 }
 
-pub(crate) fn build_guardian_mcp_tool_review_request(
+pub(crate) fn build_mcp_tool_approval_request(
     call_id: &str,
     invocation: &McpInvocation,
     metadata: Option<&McpToolApprovalMetadata>,
-) -> GuardianApprovalRequest {
-    GuardianApprovalRequest::McpToolCall {
-        id: call_id.to_string(),
-        server: invocation.server.clone(),
-        tool_name: invocation.tool.clone(),
-        arguments: invocation.arguments.clone(),
-        connector_id: metadata.and_then(|metadata| metadata.connector_id.clone()),
-        connector_name: metadata.and_then(|metadata| metadata.connector_name.clone()),
-        connector_description: metadata.and_then(|metadata| metadata.connector_description.clone()),
-        tool_title: metadata.and_then(|metadata| metadata.tool_title.clone()),
-        tool_description: metadata.and_then(|metadata| metadata.tool_description.clone()),
-        annotations: metadata
-            .and_then(|metadata| metadata.annotations.as_ref())
-            .map(|annotations| GuardianMcpAnnotations {
-                destructive_hint: annotations.destructive_hint,
-                open_world_hint: annotations.open_world_hint,
-                read_only_hint: annotations.read_only_hint,
-            }),
-    }
+    review_reason: Option<String>,
+) -> ApprovalRequest {
+    ApprovalRequest::new(
+        /*prompt_reason*/ None,
+        review_reason,
+        ApprovalRequestKind::McpToolCall(McpToolApprovalRequest {
+            id: call_id.to_string(),
+            server: invocation.server.clone(),
+            tool_name: invocation.tool.clone(),
+            arguments: invocation.arguments.clone(),
+            connector_id: metadata.and_then(|metadata| metadata.connector_id.clone()),
+            connector_name: metadata.and_then(|metadata| metadata.connector_name.clone()),
+            connector_description: metadata
+                .and_then(|metadata| metadata.connector_description.clone()),
+            tool_title: metadata.and_then(|metadata| metadata.tool_title.clone()),
+            tool_description: metadata.and_then(|metadata| metadata.tool_description.clone()),
+            annotations: metadata
+                .and_then(|metadata| metadata.annotations.as_ref())
+                .map(|annotations| McpToolApprovalAnnotations {
+                    destructive_hint: annotations.destructive_hint,
+                    open_world_hint: annotations.open_world_hint,
+                    read_only_hint: annotations.read_only_hint,
+                }),
+        }),
+    )
 }
 
 async fn mcp_tool_approval_decision_from_guardian(

--- a/codex-rs/core/src/mcp_tool_call_tests.rs
+++ b/codex-rs/core/src/mcp_tool_call_tests.rs
@@ -3,6 +3,10 @@ use crate::codex::make_session_and_context;
 use crate::codex::make_session_and_context_with_rx;
 use crate::config::ConfigBuilder;
 use crate::state::ActiveTurn;
+use crate::tools::approval::ApprovalRequest;
+use crate::tools::approval::ApprovalRequestKind;
+use crate::tools::approval::McpToolApprovalAnnotations;
+use crate::tools::approval::McpToolApprovalRequest;
 use codex_config::CONFIG_TOML_FILE;
 use codex_config::config_toml::ConfigToml;
 use codex_config::types::AppConfig;
@@ -732,7 +736,7 @@ fn guardian_mcp_review_request_includes_invocation_metadata() {
         })),
     };
 
-    let request = build_guardian_mcp_tool_review_request(
+    let request = build_mcp_tool_approval_request(
         "call-1",
         &invocation,
         Some(&approval_metadata(
@@ -742,24 +746,29 @@ fn guardian_mcp_review_request_includes_invocation_metadata() {
             Some("Navigate"),
             Some("Open a page"),
         )),
+        None,
     );
 
     assert_eq!(
         request,
-        GuardianApprovalRequest::McpToolCall {
-            id: "call-1".to_string(),
-            server: CODEX_APPS_MCP_SERVER_NAME.to_string(),
-            tool_name: "browser_navigate".to_string(),
-            arguments: Some(serde_json::json!({
-                "url": "https://example.com",
-            })),
-            connector_id: Some("playwright".to_string()),
-            connector_name: Some("Playwright".to_string()),
-            connector_description: Some("Browser automation".to_string()),
-            tool_title: Some("Navigate".to_string()),
-            tool_description: Some("Open a page".to_string()),
-            annotations: None,
-        }
+        ApprovalRequest::new(
+            /*prompt_reason*/ None,
+            /*review_reason*/ None,
+            ApprovalRequestKind::McpToolCall(McpToolApprovalRequest {
+                id: "call-1".to_string(),
+                server: CODEX_APPS_MCP_SERVER_NAME.to_string(),
+                tool_name: "browser_navigate".to_string(),
+                arguments: Some(serde_json::json!({
+                    "url": "https://example.com",
+                })),
+                connector_id: Some("playwright".to_string()),
+                connector_name: Some("Playwright".to_string()),
+                connector_description: Some("Browser automation".to_string()),
+                tool_title: Some("Navigate".to_string()),
+                tool_description: Some("Open a page".to_string()),
+                annotations: None,
+            }),
+        )
     );
 }
 
@@ -782,26 +791,30 @@ fn guardian_mcp_review_request_includes_annotations_when_present() {
         openai_file_input_params: None,
     };
 
-    let request = build_guardian_mcp_tool_review_request("call-1", &invocation, Some(&metadata));
+    let request = build_mcp_tool_approval_request("call-1", &invocation, Some(&metadata), None);
 
     assert_eq!(
         request,
-        GuardianApprovalRequest::McpToolCall {
-            id: "call-1".to_string(),
-            server: "custom_server".to_string(),
-            tool_name: "dangerous_tool".to_string(),
-            arguments: None,
-            connector_id: None,
-            connector_name: None,
-            connector_description: None,
-            tool_title: None,
-            tool_description: None,
-            annotations: Some(GuardianMcpAnnotations {
-                destructive_hint: Some(true),
-                open_world_hint: Some(true),
-                read_only_hint: Some(false),
+        ApprovalRequest::new(
+            /*prompt_reason*/ None,
+            /*review_reason*/ None,
+            ApprovalRequestKind::McpToolCall(McpToolApprovalRequest {
+                id: "call-1".to_string(),
+                server: "custom_server".to_string(),
+                tool_name: "dangerous_tool".to_string(),
+                arguments: None,
+                connector_id: None,
+                connector_name: None,
+                connector_description: None,
+                tool_title: None,
+                tool_description: None,
+                annotations: Some(McpToolApprovalAnnotations {
+                    destructive_hint: Some(true),
+                    open_world_hint: Some(true),
+                    read_only_hint: Some(false),
+                }),
             }),
-        }
+        )
     );
 }
 

--- a/codex-rs/core/src/tools/approval.rs
+++ b/codex-rs/core/src/tools/approval.rs
@@ -2,7 +2,6 @@
 
 use crate::codex::Session;
 use crate::codex::TurnContext;
-use crate::guardian::GuardianApprovalRequest;
 use crate::guardian::new_guardian_review_id;
 use crate::guardian::review_approval_request;
 use crate::guardian::routes_approval_to_guardian;
@@ -17,6 +16,7 @@ use codex_protocol::protocol::FileChange;
 use codex_protocol::protocol::ReviewDecision;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use serde::Serialize;
+use serde_json::Value;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -27,7 +27,7 @@ pub(crate) struct ApprovalCacheKey {
     value: String,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) struct ApprovalCacheKeys {
     pub tool_name: &'static str,
     pub keys: Vec<ApprovalCacheKey>,
@@ -39,23 +39,23 @@ pub(crate) struct ApprovalOutcome {
     pub guardian_review_id: Option<String>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) struct ApprovalRequest {
-    pub user_reason: Option<String>,
-    pub guardian_retry_reason: Option<String>,
+    pub prompt_reason: Option<String>,
+    pub review_reason: Option<String>,
     pub kind: ApprovalRequestKind,
     cache: Option<ApprovalCacheKeys>,
 }
 
 impl ApprovalRequest {
     pub(crate) fn new(
-        user_reason: Option<String>,
-        guardian_retry_reason: Option<String>,
+        prompt_reason: Option<String>,
+        review_reason: Option<String>,
         kind: ApprovalRequestKind,
     ) -> Self {
         Self {
-            user_reason,
-            guardian_retry_reason,
+            prompt_reason,
+            review_reason,
             kind,
             cache: None,
         }
@@ -81,65 +81,19 @@ impl ApprovalRequest {
             .map(|keys| ApprovalCacheKeys { tool_name, keys });
         self
     }
-
-    pub(crate) fn into_guardian_request(self) -> GuardianApprovalRequest {
-        match self.kind {
-            ApprovalRequestKind::Command(request) => match request.source {
-                GuardianCommandSource::Shell => GuardianApprovalRequest::Shell {
-                    id: request.id,
-                    command: request.command,
-                    cwd: request.cwd,
-                    sandbox_permissions: request.sandbox_permissions,
-                    additional_permissions: request.additional_permissions,
-                    justification: request.justification,
-                },
-                GuardianCommandSource::UnifiedExec => GuardianApprovalRequest::ExecCommand {
-                    id: request.id,
-                    command: request.command,
-                    cwd: request.cwd,
-                    sandbox_permissions: request.sandbox_permissions,
-                    additional_permissions: request.additional_permissions,
-                    justification: request.justification,
-                    tty: request.tty,
-                },
-            },
-            #[cfg(unix)]
-            ApprovalRequestKind::Execve(request) => GuardianApprovalRequest::Execve {
-                id: request.id,
-                source: request.source,
-                program: request.program,
-                argv: request.argv,
-                cwd: request.cwd,
-                additional_permissions: request.additional_permissions,
-            },
-            ApprovalRequestKind::Patch(request) => GuardianApprovalRequest::ApplyPatch {
-                id: request.id,
-                cwd: request.cwd,
-                files: request.files,
-                patch: request.patch,
-            },
-            ApprovalRequestKind::NetworkAccess(request) => GuardianApprovalRequest::NetworkAccess {
-                id: request.id,
-                turn_id: request.turn_id,
-                target: request.target,
-                host: request.host,
-                protocol: request.protocol,
-                port: request.port,
-            },
-        }
-    }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) enum ApprovalRequestKind {
     Command(CommandApprovalRequest),
     #[cfg(unix)]
     Execve(ExecveApprovalRequest),
     Patch(PatchApprovalRequest),
     NetworkAccess(NetworkAccessApprovalRequest),
+    McpToolCall(McpToolApprovalRequest),
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) struct CommandApprovalRequest {
     pub id: String,
     pub approval_id: Option<String>,
@@ -156,7 +110,7 @@ pub(crate) struct CommandApprovalRequest {
 }
 
 #[cfg(unix)]
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) struct ExecveApprovalRequest {
     pub id: String,
     pub approval_id: String,
@@ -168,7 +122,7 @@ pub(crate) struct ExecveApprovalRequest {
     pub additional_permissions: Option<PermissionProfile>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) struct PatchApprovalRequest {
     pub id: String,
     pub cwd: AbsolutePathBuf,
@@ -178,7 +132,7 @@ pub(crate) struct PatchApprovalRequest {
     pub grant_root: Option<PathBuf>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) struct NetworkAccessApprovalRequest {
     pub id: String,
     pub turn_id: String,
@@ -189,8 +143,28 @@ pub(crate) struct NetworkAccessApprovalRequest {
     pub cwd: AbsolutePathBuf,
 }
 
-pub(crate) fn guardian_review_id_for_turn(turn: &TurnContext) -> Option<String> {
-    routes_approval_to_guardian(turn).then(new_guardian_review_id)
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct McpToolApprovalRequest {
+    pub id: String,
+    pub server: String,
+    pub tool_name: String,
+    pub arguments: Option<Value>,
+    pub connector_id: Option<String>,
+    pub connector_name: Option<String>,
+    pub connector_description: Option<String>,
+    pub tool_title: Option<String>,
+    pub tool_description: Option<String>,
+    pub annotations: Option<McpToolApprovalAnnotations>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub(crate) struct McpToolApprovalAnnotations {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) destructive_hint: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) open_world_hint: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) read_only_hint: Option<bool>,
 }
 
 async fn dispatch_user_approval(
@@ -199,7 +173,9 @@ async fn dispatch_user_approval(
     request: ApprovalRequest,
 ) -> ReviewDecision {
     let ApprovalRequest {
-        user_reason, kind, ..
+        prompt_reason,
+        kind,
+        ..
     } = request;
     match kind {
         ApprovalRequestKind::Command(request) => {
@@ -210,7 +186,7 @@ async fn dispatch_user_approval(
                     request.approval_id,
                     request.command,
                     request.cwd,
-                    user_reason,
+                    prompt_reason,
                     request.network_approval_context,
                     request.proposed_execpolicy_amendment,
                     request.additional_permissions,
@@ -227,7 +203,7 @@ async fn dispatch_user_approval(
                     Some(request.approval_id),
                     request.command,
                     request.cwd,
-                    user_reason,
+                    prompt_reason,
                     /*network_approval_context*/ None,
                     /*proposed_execpolicy_amendment*/ None,
                     request.additional_permissions,
@@ -241,7 +217,7 @@ async fn dispatch_user_approval(
                     turn.as_ref(),
                     request.id,
                     request.changes,
-                    user_reason,
+                    prompt_reason,
                     request.grant_root,
                 )
                 .await;
@@ -255,7 +231,7 @@ async fn dispatch_user_approval(
                     /*approval_id*/ None,
                     vec!["network-access".to_string(), request.target],
                     request.cwd,
-                    user_reason,
+                    prompt_reason,
                     Some(NetworkApprovalContext {
                         host: request.host,
                         protocol: request.protocol,
@@ -266,6 +242,7 @@ async fn dispatch_user_approval(
                 )
                 .await
         }
+        ApprovalRequestKind::McpToolCall(_) => ReviewDecision::Abort,
     }
 }
 
@@ -287,21 +264,13 @@ async fn request_user_approval(
 pub(crate) async fn request_approval(
     session: &Arc<Session>,
     turn: &Arc<TurnContext>,
-    guardian_review_id: Option<String>,
     request: ApprovalRequest,
 ) -> ApprovalOutcome {
-    let guardian_retry_reason = request.guardian_retry_reason.clone();
-    if let Some(review_id) = guardian_review_id.clone() {
+    if routes_approval_to_guardian(turn) {
+        let review_id = new_guardian_review_id();
         return ApprovalOutcome {
-            decision: review_approval_request(
-                session,
-                turn,
-                review_id,
-                request.into_guardian_request(),
-                guardian_retry_reason,
-            )
-            .await,
-            guardian_review_id,
+            decision: review_approval_request(session, turn, review_id.clone(), request).await,
+            guardian_review_id: Some(review_id),
         };
     }
 
@@ -309,12 +278,4 @@ pub(crate) async fn request_approval(
         decision: request_user_approval(session, turn, request).await,
         guardian_review_id: None,
     }
-}
-
-pub(crate) async fn request_approval_for_turn(
-    session: &Arc<Session>,
-    turn: &Arc<TurnContext>,
-    request: ApprovalRequest,
-) -> ApprovalOutcome {
-    request_approval(session, turn, guardian_review_id_for_turn(turn), request).await
 }

--- a/codex-rs/core/src/tools/approval.rs
+++ b/codex-rs/core/src/tools/approval.rs
@@ -1,0 +1,320 @@
+//! Shared approval routing for user and guardian review prompts.
+
+use crate::codex::Session;
+use crate::codex::TurnContext;
+use crate::guardian::GuardianApprovalRequest;
+use crate::guardian::new_guardian_review_id;
+use crate::guardian::review_approval_request;
+use crate::guardian::routes_approval_to_guardian;
+use crate::sandboxing::SandboxPermissions;
+use crate::tools::sandboxing::with_cached_approval;
+use codex_protocol::approvals::ExecPolicyAmendment;
+use codex_protocol::approvals::GuardianCommandSource;
+use codex_protocol::approvals::NetworkApprovalContext;
+use codex_protocol::approvals::NetworkApprovalProtocol;
+use codex_protocol::models::PermissionProfile;
+use codex_protocol::protocol::FileChange;
+use codex_protocol::protocol::ReviewDecision;
+use codex_utils_absolute_path::AbsolutePathBuf;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize)]
+pub(crate) struct ApprovalCacheKey {
+    namespace: &'static str,
+    value: String,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ApprovalCacheKeys {
+    pub tool_name: &'static str,
+    pub keys: Vec<ApprovalCacheKey>,
+}
+
+#[derive(Debug)]
+pub(crate) struct ApprovalOutcome {
+    pub decision: ReviewDecision,
+    pub guardian_review_id: Option<String>,
+}
+
+#[derive(Debug)]
+pub(crate) struct ApprovalRequest {
+    pub user_reason: Option<String>,
+    pub guardian_retry_reason: Option<String>,
+    pub kind: ApprovalRequestKind,
+    cache: Option<ApprovalCacheKeys>,
+}
+
+impl ApprovalRequest {
+    pub(crate) fn new(
+        user_reason: Option<String>,
+        guardian_retry_reason: Option<String>,
+        kind: ApprovalRequestKind,
+    ) -> Self {
+        Self {
+            user_reason,
+            guardian_retry_reason,
+            kind,
+            cache: None,
+        }
+    }
+
+    pub(crate) fn with_session_cache<T>(mut self, tool_name: &'static str, keys: Vec<T>) -> Self
+    where
+        T: Serialize,
+    {
+        let keys = keys
+            .iter()
+            .map(|key| {
+                serde_json::to_string(key)
+                    .ok()
+                    .map(|value| ApprovalCacheKey {
+                        namespace: tool_name,
+                        value,
+                    })
+            })
+            .collect::<Option<Vec<_>>>();
+        self.cache = keys
+            .filter(|keys| !keys.is_empty())
+            .map(|keys| ApprovalCacheKeys { tool_name, keys });
+        self
+    }
+
+    pub(crate) fn into_guardian_request(self) -> GuardianApprovalRequest {
+        match self.kind {
+            ApprovalRequestKind::Command(request) => match request.source {
+                GuardianCommandSource::Shell => GuardianApprovalRequest::Shell {
+                    id: request.id,
+                    command: request.command,
+                    cwd: request.cwd,
+                    sandbox_permissions: request.sandbox_permissions,
+                    additional_permissions: request.additional_permissions,
+                    justification: request.justification,
+                },
+                GuardianCommandSource::UnifiedExec => GuardianApprovalRequest::ExecCommand {
+                    id: request.id,
+                    command: request.command,
+                    cwd: request.cwd,
+                    sandbox_permissions: request.sandbox_permissions,
+                    additional_permissions: request.additional_permissions,
+                    justification: request.justification,
+                    tty: request.tty,
+                },
+            },
+            #[cfg(unix)]
+            ApprovalRequestKind::Execve(request) => GuardianApprovalRequest::Execve {
+                id: request.id,
+                source: request.source,
+                program: request.program,
+                argv: request.argv,
+                cwd: request.cwd,
+                additional_permissions: request.additional_permissions,
+            },
+            ApprovalRequestKind::Patch(request) => GuardianApprovalRequest::ApplyPatch {
+                id: request.id,
+                cwd: request.cwd,
+                files: request.files,
+                patch: request.patch,
+            },
+            ApprovalRequestKind::NetworkAccess(request) => GuardianApprovalRequest::NetworkAccess {
+                id: request.id,
+                turn_id: request.turn_id,
+                target: request.target,
+                host: request.host,
+                protocol: request.protocol,
+                port: request.port,
+            },
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum ApprovalRequestKind {
+    Command(CommandApprovalRequest),
+    #[cfg(unix)]
+    Execve(ExecveApprovalRequest),
+    Patch(PatchApprovalRequest),
+    NetworkAccess(NetworkAccessApprovalRequest),
+}
+
+#[derive(Debug)]
+pub(crate) struct CommandApprovalRequest {
+    pub id: String,
+    pub approval_id: Option<String>,
+    pub source: GuardianCommandSource,
+    pub command: Vec<String>,
+    pub cwd: AbsolutePathBuf,
+    pub sandbox_permissions: SandboxPermissions,
+    pub additional_permissions: Option<PermissionProfile>,
+    pub justification: Option<String>,
+    pub network_approval_context: Option<NetworkApprovalContext>,
+    pub proposed_execpolicy_amendment: Option<ExecPolicyAmendment>,
+    pub available_decisions: Option<Vec<ReviewDecision>>,
+    pub tty: bool,
+}
+
+#[cfg(unix)]
+#[derive(Debug)]
+pub(crate) struct ExecveApprovalRequest {
+    pub id: String,
+    pub approval_id: String,
+    pub source: GuardianCommandSource,
+    pub program: String,
+    pub argv: Vec<String>,
+    pub command: Vec<String>,
+    pub cwd: AbsolutePathBuf,
+    pub additional_permissions: Option<PermissionProfile>,
+}
+
+#[derive(Debug)]
+pub(crate) struct PatchApprovalRequest {
+    pub id: String,
+    pub cwd: AbsolutePathBuf,
+    pub files: Vec<AbsolutePathBuf>,
+    pub patch: String,
+    pub changes: HashMap<PathBuf, FileChange>,
+    pub grant_root: Option<PathBuf>,
+}
+
+#[derive(Debug)]
+pub(crate) struct NetworkAccessApprovalRequest {
+    pub id: String,
+    pub turn_id: String,
+    pub target: String,
+    pub host: String,
+    pub protocol: NetworkApprovalProtocol,
+    pub port: u16,
+    pub cwd: AbsolutePathBuf,
+}
+
+pub(crate) fn guardian_review_id_for_turn(turn: &TurnContext) -> Option<String> {
+    routes_approval_to_guardian(turn).then(new_guardian_review_id)
+}
+
+async fn dispatch_user_approval(
+    session: &Arc<Session>,
+    turn: &Arc<TurnContext>,
+    request: ApprovalRequest,
+) -> ReviewDecision {
+    let ApprovalRequest {
+        user_reason, kind, ..
+    } = request;
+    match kind {
+        ApprovalRequestKind::Command(request) => {
+            session
+                .request_command_approval(
+                    turn.as_ref(),
+                    request.id,
+                    request.approval_id,
+                    request.command,
+                    request.cwd,
+                    user_reason,
+                    request.network_approval_context,
+                    request.proposed_execpolicy_amendment,
+                    request.additional_permissions,
+                    request.available_decisions,
+                )
+                .await
+        }
+        #[cfg(unix)]
+        ApprovalRequestKind::Execve(request) => {
+            session
+                .request_command_approval(
+                    turn.as_ref(),
+                    request.id,
+                    Some(request.approval_id),
+                    request.command,
+                    request.cwd,
+                    user_reason,
+                    /*network_approval_context*/ None,
+                    /*proposed_execpolicy_amendment*/ None,
+                    request.additional_permissions,
+                    Some(vec![ReviewDecision::Approved, ReviewDecision::Abort]),
+                )
+                .await
+        }
+        ApprovalRequestKind::Patch(request) => {
+            let rx_approve = session
+                .request_patch_approval(
+                    turn.as_ref(),
+                    request.id,
+                    request.changes,
+                    user_reason,
+                    request.grant_root,
+                )
+                .await;
+            rx_approve.await.unwrap_or_default()
+        }
+        ApprovalRequestKind::NetworkAccess(request) => {
+            session
+                .request_command_approval(
+                    turn.as_ref(),
+                    request.id,
+                    /*approval_id*/ None,
+                    vec!["network-access".to_string(), request.target],
+                    request.cwd,
+                    user_reason,
+                    Some(NetworkApprovalContext {
+                        host: request.host,
+                        protocol: request.protocol,
+                    }),
+                    /*proposed_execpolicy_amendment*/ None,
+                    /*additional_permissions*/ None,
+                    /*available_decisions*/ None,
+                )
+                .await
+        }
+    }
+}
+
+async fn request_user_approval(
+    session: &Arc<Session>,
+    turn: &Arc<TurnContext>,
+    request: ApprovalRequest,
+) -> ReviewDecision {
+    if let Some(cache) = request.cache.clone() {
+        with_cached_approval(&session.services, cache.tool_name, cache.keys, || {
+            dispatch_user_approval(session, turn, request)
+        })
+        .await
+    } else {
+        dispatch_user_approval(session, turn, request).await
+    }
+}
+
+pub(crate) async fn request_approval(
+    session: &Arc<Session>,
+    turn: &Arc<TurnContext>,
+    guardian_review_id: Option<String>,
+    request: ApprovalRequest,
+) -> ApprovalOutcome {
+    let guardian_retry_reason = request.guardian_retry_reason.clone();
+    if let Some(review_id) = guardian_review_id.clone() {
+        return ApprovalOutcome {
+            decision: review_approval_request(
+                session,
+                turn,
+                review_id,
+                request.into_guardian_request(),
+                guardian_retry_reason,
+            )
+            .await,
+            guardian_review_id,
+        };
+    }
+
+    ApprovalOutcome {
+        decision: request_user_approval(session, turn, request).await,
+        guardian_review_id: None,
+    }
+}
+
+pub(crate) async fn request_approval_for_turn(
+    session: &Arc<Session>,
+    turn: &Arc<TurnContext>,
+    request: ApprovalRequest,
+) -> ApprovalOutcome {
+    request_approval(session, turn, guardian_review_id_for_turn(turn), request).await
+}

--- a/codex-rs/core/src/tools/mod.rs
+++ b/codex-rs/core/src/tools/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod approval;
 pub(crate) mod code_mode;
 pub(crate) mod context;
 pub(crate) mod events;

--- a/codex-rs/core/src/tools/network_approval.rs
+++ b/codex-rs/core/src/tools/network_approval.rs
@@ -1,11 +1,11 @@
 use crate::codex::Session;
-use crate::guardian::GuardianApprovalRequest;
 use crate::guardian::guardian_rejection_message;
 use crate::guardian::guardian_timeout_message;
-use crate::guardian::new_guardian_review_id;
-use crate::guardian::review_approval_request;
-use crate::guardian::routes_approval_to_guardian;
 use crate::network_policy_decision::denied_network_policy_message;
+use crate::tools::approval::ApprovalRequest;
+use crate::tools::approval::ApprovalRequestKind;
+use crate::tools::approval::NetworkAccessApprovalRequest;
+use crate::tools::approval::request_approval_for_turn;
 use crate::tools::sandboxing::ToolError;
 use codex_network_proxy::BlockedRequest;
 use codex_network_proxy::BlockedRequestObserver;
@@ -370,46 +370,28 @@ impl NetworkApprovalService {
             protocol,
         };
         let owner_call = self.resolve_single_active_call().await;
-        let guardian_approval_id = Self::approval_id_for_key(&key);
-        let use_guardian = routes_approval_to_guardian(&turn_context);
-        let guardian_review_id = use_guardian.then(new_guardian_review_id);
-        let approval_decision = if let Some(review_id) = guardian_review_id.clone() {
-            review_approval_request(
-                &session,
-                &turn_context,
-                review_id,
-                GuardianApprovalRequest::NetworkAccess {
-                    id: guardian_approval_id.clone(),
+        let approval_outcome = request_approval_for_turn(
+            &session,
+            &turn_context,
+            ApprovalRequest::new(
+                Some(prompt_reason),
+                Some(policy_denial_message.clone()),
+                ApprovalRequestKind::NetworkAccess(NetworkAccessApprovalRequest {
+                    id: Self::approval_id_for_key(&key),
                     turn_id: owner_call
                         .as_ref()
                         .map_or_else(|| turn_context.sub_id.clone(), |call| call.turn_id.clone()),
                     target,
-                    host: request.host,
+                    host: request.host.clone(),
                     protocol,
                     port: key.port,
-                },
-                Some(policy_denial_message.clone()),
-            )
-            .await
-        } else {
-            let approval_id = Self::approval_id_for_key(&key);
-            let prompt_command = vec!["network-access".to_string(), target.clone()];
-            let available_decisions = None;
-            session
-                .request_command_approval(
-                    turn_context.as_ref(),
-                    approval_id,
-                    /*approval_id*/ None,
-                    prompt_command,
-                    turn_context.cwd.clone(),
-                    Some(prompt_reason),
-                    Some(network_approval_context.clone()),
-                    /*proposed_execpolicy_amendment*/ None,
-                    /*additional_permissions*/ None,
-                    available_decisions,
-                )
-                .await
-        };
+                    cwd: turn_context.cwd.clone(),
+                }),
+            ),
+        )
+        .await;
+        let guardian_review_id = approval_outcome.guardian_review_id;
+        let approval_decision = approval_outcome.decision;
 
         let mut cache_session_deny = false;
         let resolved = match approval_decision {

--- a/codex-rs/core/src/tools/network_approval.rs
+++ b/codex-rs/core/src/tools/network_approval.rs
@@ -5,7 +5,7 @@ use crate::network_policy_decision::denied_network_policy_message;
 use crate::tools::approval::ApprovalRequest;
 use crate::tools::approval::ApprovalRequestKind;
 use crate::tools::approval::NetworkAccessApprovalRequest;
-use crate::tools::approval::request_approval_for_turn;
+use crate::tools::approval::request_approval;
 use crate::tools::sandboxing::ToolError;
 use codex_network_proxy::BlockedRequest;
 use codex_network_proxy::BlockedRequestObserver;
@@ -370,7 +370,7 @@ impl NetworkApprovalService {
             protocol,
         };
         let owner_call = self.resolve_single_active_call().await;
-        let approval_outcome = request_approval_for_turn(
+        let approval_outcome = request_approval(
             &session,
             &turn_context,
             ApprovalRequest::new(

--- a/codex-rs/core/src/tools/orchestrator.rs
+++ b/codex-rs/core/src/tools/orchestrator.rs
@@ -8,7 +8,6 @@ caching).
 */
 use crate::guardian::guardian_rejection_message;
 use crate::guardian::guardian_timeout_message;
-use crate::guardian::new_guardian_review_id;
 use crate::guardian::routes_approval_to_guardian;
 use crate::network_policy_decision::network_approval_context_from_payload;
 use crate::tools::network_approval::DeferredNetworkApproval;
@@ -133,17 +132,17 @@ impl ToolOrchestrator {
                 return Err(ToolError::Rejected(reason));
             }
             ExecApprovalRequirement::NeedsApproval { reason, .. } => {
-                let guardian_review_id = use_guardian.then(new_guardian_review_id);
                 let approval_ctx = ApprovalCtx {
                     session: &tool_ctx.session,
                     turn: &tool_ctx.turn,
                     call_id: &tool_ctx.call_id,
-                    guardian_review_id: guardian_review_id.clone(),
                     retry_reason: reason,
                     network_approval_context: None,
                 };
-                let decision = tool.start_approval_async(req, approval_ctx).await;
-                let otel_source = if use_guardian {
+                let outcome = tool.start_approval_async(req, approval_ctx).await;
+                let decision = outcome.decision;
+                let guardian_review_id = outcome.guardian_review_id;
+                let otel_source = if guardian_review_id.is_some() || use_guardian {
                     otel_automated_reviewer.clone()
                 } else {
                     otel_user.clone()
@@ -286,18 +285,18 @@ impl ToolOrchestrator {
                     .should_bypass_approval(approval_policy, already_approved)
                     && network_approval_context.is_none();
                 if !bypass_retry_approval {
-                    let guardian_review_id = use_guardian.then(new_guardian_review_id);
                     let approval_ctx = ApprovalCtx {
                         session: &tool_ctx.session,
                         turn: &tool_ctx.turn,
                         call_id: &tool_ctx.call_id,
-                        guardian_review_id: guardian_review_id.clone(),
                         retry_reason: Some(retry_reason),
                         network_approval_context: network_approval_context.clone(),
                     };
 
-                    let decision = tool.start_approval_async(req, approval_ctx).await;
-                    let otel_source = if use_guardian {
+                    let outcome = tool.start_approval_async(req, approval_ctx).await;
+                    let decision = outcome.decision;
+                    let guardian_review_id = outcome.guardian_review_id;
+                    let otel_source = if guardian_review_id.is_some() || use_guardian {
                         otel_automated_reviewer
                     } else {
                         otel_user

--- a/codex-rs/core/src/tools/runtimes/apply_patch.rs
+++ b/codex-rs/core/src/tools/runtimes/apply_patch.rs
@@ -4,6 +4,7 @@
 //! selected turn environment filesystem for both local and remote turns, with
 //! sandboxing enforced by the explicit filesystem sandbox context.
 use crate::exec::is_likely_sandbox_denied;
+use crate::tools::approval::ApprovalOutcome;
 use crate::tools::approval::ApprovalRequest;
 use crate::tools::approval::ApprovalRequestKind;
 use crate::tools::approval::PatchApprovalRequest;
@@ -109,7 +110,7 @@ impl Approvable<ApplyPatchRequest> for ApplyPatchRuntime {
         &'a mut self,
         req: &'a ApplyPatchRequest,
         ctx: ApprovalCtx<'a>,
-    ) -> BoxFuture<'a, ReviewDecision> {
+    ) -> BoxFuture<'a, ApprovalOutcome> {
         let session = ctx.session;
         let turn = ctx.turn;
         let call_id = ctx.call_id.to_string();
@@ -121,7 +122,10 @@ impl Approvable<ApplyPatchRequest> for ApplyPatchRuntime {
         let patch = req.action.patch.clone();
         Box::pin(async move {
             if req.permissions_preapproved && retry_reason.is_none() {
-                return ReviewDecision::Approved;
+                return ApprovalOutcome {
+                    decision: ReviewDecision::Approved,
+                    guardian_review_id: None,
+                };
             }
 
             let request = ApprovalRequest::new(
@@ -142,9 +146,7 @@ impl Approvable<ApplyPatchRequest> for ApplyPatchRuntime {
                 request.with_session_cache("apply_patch", approval_keys)
             };
 
-            request_approval(session, turn, ctx.guardian_review_id.clone(), request)
-                .await
-                .decision
+            request_approval(session, turn, request).await
         })
     }
 

--- a/codex-rs/core/src/tools/runtimes/apply_patch.rs
+++ b/codex-rs/core/src/tools/runtimes/apply_patch.rs
@@ -4,8 +4,10 @@
 //! selected turn environment filesystem for both local and remote turns, with
 //! sandboxing enforced by the explicit filesystem sandbox context.
 use crate::exec::is_likely_sandbox_denied;
-use crate::guardian::GuardianApprovalRequest;
-use crate::guardian::review_approval_request;
+use crate::tools::approval::ApprovalRequest;
+use crate::tools::approval::ApprovalRequestKind;
+use crate::tools::approval::PatchApprovalRequest;
+use crate::tools::approval::request_approval;
 use crate::tools::sandboxing::Approvable;
 use crate::tools::sandboxing::ApprovalCtx;
 use crate::tools::sandboxing::ExecApprovalRequirement;
@@ -14,7 +16,6 @@ use crate::tools::sandboxing::Sandboxable;
 use crate::tools::sandboxing::ToolCtx;
 use crate::tools::sandboxing::ToolError;
 use crate::tools::sandboxing::ToolRuntime;
-use crate::tools::sandboxing::with_cached_approval;
 use codex_apply_patch::ApplyPatchAction;
 use codex_exec_server::FileSystemSandboxContext;
 use codex_protocol::error::CodexErr;
@@ -52,18 +53,6 @@ pub struct ApplyPatchRuntime;
 impl ApplyPatchRuntime {
     pub fn new() -> Self {
         Self
-    }
-
-    fn build_guardian_review_request(
-        req: &ApplyPatchRequest,
-        call_id: &str,
-    ) -> GuardianApprovalRequest {
-        GuardianApprovalRequest::ApplyPatch {
-            id: call_id.to_string(),
-            cwd: req.action.cwd.clone(),
-            files: req.file_paths.clone(),
-            patch: req.action.patch.clone(),
-        }
     }
 
     fn file_system_sandbox_context_for_attempt(
@@ -127,43 +116,35 @@ impl Approvable<ApplyPatchRequest> for ApplyPatchRuntime {
         let retry_reason = ctx.retry_reason.clone();
         let approval_keys = self.approval_keys(req);
         let changes = req.changes.clone();
-        let guardian_review_id = ctx.guardian_review_id.clone();
+        let cwd = req.action.cwd.clone();
+        let files = req.file_paths.clone();
+        let patch = req.action.patch.clone();
         Box::pin(async move {
             if req.permissions_preapproved && retry_reason.is_none() {
                 return ReviewDecision::Approved;
             }
-            if let Some(review_id) = guardian_review_id {
-                let action = ApplyPatchRuntime::build_guardian_review_request(req, ctx.call_id);
-                return review_approval_request(session, turn, review_id, action, retry_reason)
-                    .await;
-            }
-            if let Some(reason) = retry_reason {
-                let rx_approve = session
-                    .request_patch_approval(
-                        turn,
-                        call_id,
-                        changes.clone(),
-                        Some(reason),
-                        /*grant_root*/ None,
-                    )
-                    .await;
-                return rx_approve.await.unwrap_or_default();
-            }
 
-            with_cached_approval(
-                &session.services,
-                "apply_patch",
-                approval_keys,
-                || async move {
-                    let rx_approve = session
-                        .request_patch_approval(
-                            turn, call_id, changes, /*reason*/ None, /*grant_root*/ None,
-                        )
-                        .await;
-                    rx_approve.await.unwrap_or_default()
-                },
-            )
-            .await
+            let request = ApprovalRequest::new(
+                retry_reason.clone(),
+                retry_reason.clone(),
+                ApprovalRequestKind::Patch(PatchApprovalRequest {
+                    id: call_id,
+                    cwd,
+                    files,
+                    patch,
+                    changes,
+                    grant_root: None,
+                }),
+            );
+            let request = if retry_reason.is_some() {
+                request
+            } else {
+                request.with_session_cache("apply_patch", approval_keys)
+            };
+
+            request_approval(session, turn, ctx.guardian_review_id.clone(), request)
+                .await
+                .decision
         })
     }
 

--- a/codex-rs/core/src/tools/runtimes/apply_patch_tests.rs
+++ b/codex-rs/core/src/tools/runtimes/apply_patch_tests.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::guardian::GuardianApprovalRequest;
 use crate::tools::approval::ApprovalRequest;
 use crate::tools::approval::ApprovalRequestKind;
 use crate::tools::approval::PatchApprovalRequest;
@@ -66,9 +65,9 @@ fn guardian_review_request_includes_patch_context() {
         permissions_preapproved: false,
     };
 
-    let guardian_request = ApprovalRequest::new(
-        /*user_reason*/ None,
-        /*guardian_retry_reason*/ None,
+    let approval_request = ApprovalRequest::new(
+        /*prompt_reason*/ None,
+        /*review_reason*/ None,
         ApprovalRequestKind::Patch(PatchApprovalRequest {
             id: "call-1".to_string(),
             cwd: request.action.cwd.clone(),
@@ -77,17 +76,18 @@ fn guardian_review_request_includes_patch_context() {
             changes: request.changes.clone(),
             grant_root: None,
         }),
-    )
-    .into_guardian_request();
+    );
 
     assert_eq!(
-        guardian_request,
-        GuardianApprovalRequest::ApplyPatch {
+        approval_request.kind,
+        ApprovalRequestKind::Patch(PatchApprovalRequest {
             id: "call-1".to_string(),
             cwd: expected_cwd,
             files: request.file_paths,
             patch: expected_patch,
-        }
+            changes: request.changes,
+            grant_root: None,
+        })
     );
 }
 

--- a/codex-rs/core/src/tools/runtimes/apply_patch_tests.rs
+++ b/codex-rs/core/src/tools/runtimes/apply_patch_tests.rs
@@ -1,4 +1,8 @@
 use super::*;
+use crate::guardian::GuardianApprovalRequest;
+use crate::tools::approval::ApprovalRequest;
+use crate::tools::approval::ApprovalRequestKind;
+use crate::tools::approval::PatchApprovalRequest;
 use crate::tools::sandboxing::SandboxAttempt;
 use codex_protocol::config_types::WindowsSandboxLevel;
 use codex_protocol::models::FileSystemPermissions;
@@ -62,7 +66,19 @@ fn guardian_review_request_includes_patch_context() {
         permissions_preapproved: false,
     };
 
-    let guardian_request = ApplyPatchRuntime::build_guardian_review_request(&request, "call-1");
+    let guardian_request = ApprovalRequest::new(
+        /*user_reason*/ None,
+        /*guardian_retry_reason*/ None,
+        ApprovalRequestKind::Patch(PatchApprovalRequest {
+            id: "call-1".to_string(),
+            cwd: request.action.cwd.clone(),
+            files: request.file_paths.clone(),
+            patch: request.action.patch.clone(),
+            changes: request.changes.clone(),
+            grant_root: None,
+        }),
+    )
+    .into_guardian_request();
 
     assert_eq!(
         guardian_request,

--- a/codex-rs/core/src/tools/runtimes/shell.rs
+++ b/codex-rs/core/src/tools/runtimes/shell.rs
@@ -10,12 +10,14 @@ pub(crate) mod zsh_fork_backend;
 
 use crate::command_canonicalization::canonicalize_command_for_approval;
 use crate::exec::ExecCapturePolicy;
-use crate::guardian::GuardianApprovalRequest;
-use crate::guardian::review_approval_request;
 use crate::sandboxing::ExecOptions;
 use crate::sandboxing::SandboxPermissions;
 use crate::sandboxing::execute_env;
 use crate::shell::ShellType;
+use crate::tools::approval::ApprovalRequest;
+use crate::tools::approval::ApprovalRequestKind;
+use crate::tools::approval::CommandApprovalRequest;
+use crate::tools::approval::request_approval;
 use crate::tools::network_approval::NetworkApprovalMode;
 use crate::tools::network_approval::NetworkApprovalSpec;
 use crate::tools::runtimes::build_sandbox_command;
@@ -30,8 +32,8 @@ use crate::tools::sandboxing::ToolCtx;
 use crate::tools::sandboxing::ToolError;
 use crate::tools::sandboxing::ToolRuntime;
 use crate::tools::sandboxing::sandbox_override_for_first_attempt;
-use crate::tools::sandboxing::with_cached_approval;
 use codex_network_proxy::NetworkProxy;
+use codex_protocol::approvals::GuardianCommandSource;
 use codex_protocol::exec_output::ExecToolCallOutput;
 use codex_protocol::models::PermissionProfile;
 use codex_protocol::protocol::ReviewDecision;
@@ -151,45 +153,36 @@ impl Approvable<ShellRequest> for ShellRuntime {
         let session = ctx.session;
         let turn = ctx.turn;
         let call_id = ctx.call_id.to_string();
-        let guardian_review_id = ctx.guardian_review_id.clone();
         Box::pin(async move {
-            if let Some(review_id) = guardian_review_id {
-                return review_approval_request(
-                    session,
-                    turn,
-                    review_id,
-                    GuardianApprovalRequest::Shell {
+            request_approval(
+                session,
+                turn,
+                ctx.guardian_review_id.clone(),
+                ApprovalRequest::new(
+                    reason,
+                    retry_reason,
+                    ApprovalRequestKind::Command(CommandApprovalRequest {
                         id: call_id,
+                        approval_id: None,
+                        source: GuardianCommandSource::Shell,
                         command,
-                        cwd: cwd.clone(),
+                        cwd,
                         sandbox_permissions: req.sandbox_permissions,
                         additional_permissions: req.additional_permissions.clone(),
                         justification: req.justification.clone(),
-                    },
-                    retry_reason,
-                )
-                .await;
-            }
-            with_cached_approval(&session.services, "shell", keys, move || async move {
-                let available_decisions = None;
-                session
-                    .request_command_approval(
-                        turn,
-                        call_id,
-                        /*approval_id*/ None,
-                        command,
-                        cwd,
-                        reason,
-                        ctx.network_approval_context.clone(),
-                        req.exec_approval_requirement
+                        network_approval_context: ctx.network_approval_context.clone(),
+                        proposed_execpolicy_amendment: req
+                            .exec_approval_requirement
                             .proposed_execpolicy_amendment()
                             .cloned(),
-                        req.additional_permissions.clone(),
-                        available_decisions,
-                    )
-                    .await
-            })
+                        available_decisions: None,
+                        tty: false,
+                    }),
+                )
+                .with_session_cache("shell", keys),
+            )
             .await
+            .decision
         })
     }
 

--- a/codex-rs/core/src/tools/runtimes/shell.rs
+++ b/codex-rs/core/src/tools/runtimes/shell.rs
@@ -14,6 +14,7 @@ use crate::sandboxing::ExecOptions;
 use crate::sandboxing::SandboxPermissions;
 use crate::sandboxing::execute_env;
 use crate::shell::ShellType;
+use crate::tools::approval::ApprovalOutcome;
 use crate::tools::approval::ApprovalRequest;
 use crate::tools::approval::ApprovalRequestKind;
 use crate::tools::approval::CommandApprovalRequest;
@@ -36,7 +37,6 @@ use codex_network_proxy::NetworkProxy;
 use codex_protocol::approvals::GuardianCommandSource;
 use codex_protocol::exec_output::ExecToolCallOutput;
 use codex_protocol::models::PermissionProfile;
-use codex_protocol::protocol::ReviewDecision;
 use codex_sandboxing::SandboxablePreference;
 use codex_shell_command::powershell::prefix_powershell_script_with_utf8;
 use codex_utils_absolute_path::AbsolutePathBuf;
@@ -144,7 +144,7 @@ impl Approvable<ShellRequest> for ShellRuntime {
         &'a mut self,
         req: &'a ShellRequest,
         ctx: ApprovalCtx<'a>,
-    ) -> BoxFuture<'a, ReviewDecision> {
+    ) -> BoxFuture<'a, ApprovalOutcome> {
         let keys = self.approval_keys(req);
         let command = req.command.clone();
         let cwd = req.cwd.clone();
@@ -157,7 +157,6 @@ impl Approvable<ShellRequest> for ShellRuntime {
             request_approval(
                 session,
                 turn,
-                ctx.guardian_review_id.clone(),
                 ApprovalRequest::new(
                     reason,
                     retry_reason,
@@ -182,7 +181,6 @@ impl Approvable<ShellRequest> for ShellRuntime {
                 .with_session_cache("shell", keys),
             )
             .await
-            .decision
         })
     }
 

--- a/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
+++ b/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
@@ -2,16 +2,16 @@ use super::ShellRequest;
 use crate::exec::ExecCapturePolicy;
 use crate::exec::ExecExpiration;
 use crate::exec::is_likely_sandbox_denied;
-use crate::guardian::GuardianApprovalRequest;
 use crate::guardian::guardian_rejection_message;
 use crate::guardian::guardian_timeout_message;
-use crate::guardian::new_guardian_review_id;
-use crate::guardian::review_approval_request;
-use crate::guardian::routes_approval_to_guardian;
 use crate::sandboxing::ExecOptions;
 use crate::sandboxing::ExecRequest;
 use crate::sandboxing::SandboxPermissions;
 use crate::shell::ShellType;
+use crate::tools::approval::ApprovalRequest;
+use crate::tools::approval::ApprovalRequestKind;
+use crate::tools::approval::ExecveApprovalRequest;
+use crate::tools::approval::request_approval_for_turn;
 use crate::tools::runtimes::build_sandbox_command;
 use crate::tools::sandboxing::SandboxAttempt;
 use crate::tools::sandboxing::ToolCtx;
@@ -390,49 +390,32 @@ impl CoreShellActionProvider {
         let session = self.session.clone();
         let turn = self.turn.clone();
         let call_id = self.call_id.clone();
-        let approval_id = Some(Uuid::new_v4().to_string());
+        let approval_id = Uuid::new_v4().to_string();
         let source = self.tool_name;
-        let guardian_review_id = routes_approval_to_guardian(&turn).then(new_guardian_review_id);
         Ok(stopwatch
             .pause_for(async move {
-                if let Some(review_id) = guardian_review_id.clone() {
-                    let decision = review_approval_request(
-                        &session,
-                        &turn,
-                        review_id,
-                        GuardianApprovalRequest::Execve {
-                            id: call_id.clone(),
+                let outcome = request_approval_for_turn(
+                    &session,
+                    &turn,
+                    ApprovalRequest::new(
+                        /*user_reason*/ None,
+                        /*guardian_retry_reason*/ None,
+                        ApprovalRequestKind::Execve(ExecveApprovalRequest {
+                            id: call_id,
+                            approval_id,
                             source,
                             program: program.to_string_lossy().into_owned(),
                             argv: argv.to_vec(),
+                            command,
                             cwd: workdir.clone(),
                             additional_permissions,
-                        },
-                        /*retry_reason*/ None,
-                    )
-                    .await;
-                    return PromptDecision {
-                        decision,
-                        guardian_review_id,
-                    };
-                }
-                let decision = session
-                    .request_command_approval(
-                        &turn,
-                        call_id,
-                        approval_id,
-                        command,
-                        workdir.clone(),
-                        /*reason*/ None,
-                        /*network_approval_context*/ None,
-                        /*proposed_execpolicy_amendment*/ None,
-                        additional_permissions,
-                        Some(vec![ReviewDecision::Approved, ReviewDecision::Abort]),
-                    )
-                    .await;
+                        }),
+                    ),
+                )
+                .await;
                 PromptDecision {
-                    decision,
-                    guardian_review_id: None,
+                    decision: outcome.decision,
+                    guardian_review_id: outcome.guardian_review_id,
                 }
             })
             .await)

--- a/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
+++ b/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
@@ -11,7 +11,7 @@ use crate::shell::ShellType;
 use crate::tools::approval::ApprovalRequest;
 use crate::tools::approval::ApprovalRequestKind;
 use crate::tools::approval::ExecveApprovalRequest;
-use crate::tools::approval::request_approval_for_turn;
+use crate::tools::approval::request_approval;
 use crate::tools::runtimes::build_sandbox_command;
 use crate::tools::sandboxing::SandboxAttempt;
 use crate::tools::sandboxing::ToolCtx;
@@ -394,12 +394,12 @@ impl CoreShellActionProvider {
         let source = self.tool_name;
         Ok(stopwatch
             .pause_for(async move {
-                let outcome = request_approval_for_turn(
+                let outcome = request_approval(
                     &session,
                     &turn,
                     ApprovalRequest::new(
-                        /*user_reason*/ None,
-                        /*guardian_retry_reason*/ None,
+                        /*prompt_reason*/ None,
+                        /*review_reason*/ None,
                         ApprovalRequestKind::Execve(ExecveApprovalRequest {
                             id: call_id,
                             approval_id,

--- a/codex-rs/core/src/tools/runtimes/unified_exec.rs
+++ b/codex-rs/core/src/tools/runtimes/unified_exec.rs
@@ -11,6 +11,7 @@ use crate::sandboxing::ExecOptions;
 use crate::sandboxing::ExecServerEnvConfig;
 use crate::sandboxing::SandboxPermissions;
 use crate::shell::ShellType;
+use crate::tools::approval::ApprovalOutcome;
 use crate::tools::approval::ApprovalRequest;
 use crate::tools::approval::ApprovalRequestKind;
 use crate::tools::approval::CommandApprovalRequest;
@@ -39,7 +40,6 @@ use codex_protocol::approvals::GuardianCommandSource;
 use codex_protocol::error::CodexErr;
 use codex_protocol::error::SandboxErr;
 use codex_protocol::models::PermissionProfile;
-use codex_protocol::protocol::ReviewDecision;
 use codex_sandboxing::SandboxablePreference;
 use codex_shell_command::powershell::prefix_powershell_script_with_utf8;
 use codex_tools::UnifiedExecShellMode;
@@ -122,7 +122,7 @@ impl Approvable<UnifiedExecRequest> for UnifiedExecRuntime<'_> {
         &'b mut self,
         req: &'b UnifiedExecRequest,
         ctx: ApprovalCtx<'b>,
-    ) -> BoxFuture<'b, ReviewDecision> {
+    ) -> BoxFuture<'b, ApprovalOutcome> {
         let keys = self.approval_keys(req);
         let session = ctx.session;
         let turn = ctx.turn;
@@ -135,7 +135,6 @@ impl Approvable<UnifiedExecRequest> for UnifiedExecRuntime<'_> {
             request_approval(
                 session,
                 turn,
-                ctx.guardian_review_id.clone(),
                 ApprovalRequest::new(
                     reason,
                     retry_reason,
@@ -160,7 +159,6 @@ impl Approvable<UnifiedExecRequest> for UnifiedExecRuntime<'_> {
                 .with_session_cache("unified_exec", keys),
             )
             .await
-            .decision
         })
     }
 

--- a/codex-rs/core/src/tools/runtimes/unified_exec.rs
+++ b/codex-rs/core/src/tools/runtimes/unified_exec.rs
@@ -7,12 +7,14 @@ the process manager to spawn PTYs once an ExecRequest is prepared.
 use crate::command_canonicalization::canonicalize_command_for_approval;
 use crate::exec::ExecCapturePolicy;
 use crate::exec::ExecExpiration;
-use crate::guardian::GuardianApprovalRequest;
-use crate::guardian::review_approval_request;
 use crate::sandboxing::ExecOptions;
 use crate::sandboxing::ExecServerEnvConfig;
 use crate::sandboxing::SandboxPermissions;
 use crate::shell::ShellType;
+use crate::tools::approval::ApprovalRequest;
+use crate::tools::approval::ApprovalRequestKind;
+use crate::tools::approval::CommandApprovalRequest;
+use crate::tools::approval::request_approval;
 use crate::tools::network_approval::NetworkApprovalMode;
 use crate::tools::network_approval::NetworkApprovalSpec;
 use crate::tools::runtimes::build_sandbox_command;
@@ -28,12 +30,12 @@ use crate::tools::sandboxing::ToolCtx;
 use crate::tools::sandboxing::ToolError;
 use crate::tools::sandboxing::ToolRuntime;
 use crate::tools::sandboxing::sandbox_override_for_first_attempt;
-use crate::tools::sandboxing::with_cached_approval;
 use crate::unified_exec::NoopSpawnLifecycle;
 use crate::unified_exec::UnifiedExecError;
 use crate::unified_exec::UnifiedExecProcess;
 use crate::unified_exec::UnifiedExecProcessManager;
 use codex_network_proxy::NetworkProxy;
+use codex_protocol::approvals::GuardianCommandSource;
 use codex_protocol::error::CodexErr;
 use codex_protocol::error::SandboxErr;
 use codex_protocol::models::PermissionProfile;
@@ -129,46 +131,36 @@ impl Approvable<UnifiedExecRequest> for UnifiedExecRuntime<'_> {
         let cwd = req.cwd.clone();
         let retry_reason = ctx.retry_reason.clone();
         let reason = retry_reason.clone().or_else(|| req.justification.clone());
-        let guardian_review_id = ctx.guardian_review_id.clone();
         Box::pin(async move {
-            if let Some(review_id) = guardian_review_id {
-                return review_approval_request(
-                    session,
-                    turn,
-                    review_id,
-                    GuardianApprovalRequest::ExecCommand {
+            request_approval(
+                session,
+                turn,
+                ctx.guardian_review_id.clone(),
+                ApprovalRequest::new(
+                    reason,
+                    retry_reason,
+                    ApprovalRequestKind::Command(CommandApprovalRequest {
                         id: call_id,
+                        approval_id: None,
+                        source: GuardianCommandSource::UnifiedExec,
                         command,
-                        cwd: cwd.clone(),
+                        cwd,
                         sandbox_permissions: req.sandbox_permissions,
                         additional_permissions: req.additional_permissions.clone(),
                         justification: req.justification.clone(),
-                        tty: req.tty,
-                    },
-                    retry_reason,
-                )
-                .await;
-            }
-            with_cached_approval(&session.services, "unified_exec", keys, || async move {
-                let available_decisions = None;
-                session
-                    .request_command_approval(
-                        turn,
-                        call_id,
-                        /*approval_id*/ None,
-                        command,
-                        cwd.clone(),
-                        reason,
-                        ctx.network_approval_context.clone(),
-                        req.exec_approval_requirement
+                        network_approval_context: ctx.network_approval_context.clone(),
+                        proposed_execpolicy_amendment: req
+                            .exec_approval_requirement
                             .proposed_execpolicy_amendment()
                             .cloned(),
-                        req.additional_permissions.clone(),
-                        available_decisions,
-                    )
-                    .await
-            })
+                        available_decisions: None,
+                        tty: req.tty,
+                    }),
+                )
+                .with_session_cache("unified_exec", keys),
+            )
             .await
+            .decision
         })
     }
 

--- a/codex-rs/core/src/tools/sandboxing.rs
+++ b/codex-rs/core/src/tools/sandboxing.rs
@@ -9,6 +9,7 @@ use crate::codex::TurnContext;
 use crate::sandboxing::ExecOptions;
 use crate::sandboxing::SandboxPermissions;
 use crate::state::SessionServices;
+use crate::tools::approval::ApprovalOutcome;
 use crate::tools::network_approval::NetworkApprovalSpec;
 use codex_network_proxy::NetworkProxy;
 use codex_protocol::approvals::ExecPolicyAmendment;
@@ -120,13 +121,6 @@ pub(crate) struct ApprovalCtx<'a> {
     pub session: &'a Arc<Session>,
     pub turn: &'a Arc<TurnContext>,
     pub call_id: &'a str,
-    /// Guardian review lifecycle ID for this approval, when guardian is reviewing it.
-    ///
-    /// This is separate from `call_id`: `call_id` identifies the tool item under
-    /// review, while this ID identifies the review itself. Keeping both lets
-    /// denial handling, overrides, and app-server notifications refer to the
-    /// review without overloading the tool call ID as a review ID.
-    pub guardian_review_id: Option<String>,
     pub retry_reason: Option<String>,
     pub network_approval_context: Option<NetworkApprovalContext>,
 }
@@ -288,7 +282,7 @@ pub(crate) trait Approvable<Req> {
         &'a mut self,
         req: &'a Req,
         ctx: ApprovalCtx<'a>,
-    ) -> BoxFuture<'a, ReviewDecision>;
+    ) -> BoxFuture<'a, ApprovalOutcome>;
 }
 
 pub(crate) trait Sandboxable {


### PR DESCRIPTION
## Why

Approval routing was centralized, but callsites still had to build separate user and guardian approval request shapes. That left the same approval semantics duplicated across user prompt and guardian review construction.

## What

- Add a canonical ApprovalRequest/ApprovalRequestKind layer that routes to either user prompts or guardian review.
- Move user prompt dispatch, guardian projection, guardian routing, and session approval caching behind the shared approval module.
- Rewire shell, unified exec, apply_patch, network approval, and execve prompting to build one semantic approval request.
- Update apply_patch coverage to assert the new guardian projection path.

Validation:
- cargo check -p codex-core passed.
- just fix -p codex-core passed.
- just fmt passed.
- cargo test -p codex-core ran with 1576 passed, 1 failed, 3 ignored. The failing test is plugins::manager::tests::list_marketplaces_ignores_installed_roots_missing_from_config; rerunning that exact test fails the same way and it appears unrelated to this approval refactor.
