### PR TITLE
Add turn environment list API surface

### DIFF
--- a/codex-rs/app-server-protocol/schema/json/ClientRequest.json
+++ b/codex-rs/app-server-protocol/schema/json/ClientRequest.json
@@ -3280,15 +3280,8 @@
             "null"
           ]
         },
-        "environmentId": {
-          "description": "Optional environment id to use for this thread. Supported values are `\"local\"` and `\"remote\"`. When omitted, the default environment is used.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "environmentIds": {
-          "description": "Optional ordered environment ids to use for this thread. For now only the first id is used. When omitted or empty, `environmentId` is used as a fallback for compatibility.",
+          "description": "Optional ordered environment ids to use for this thread. For now only the first id is used. When omitted or empty, the default environment is used.",
           "items": {
             "type": "string"
           },

--- a/codex-rs/app-server-protocol/schema/json/ClientRequest.json
+++ b/codex-rs/app-server-protocol/schema/json/ClientRequest.json
@@ -3287,6 +3287,16 @@
             "null"
           ]
         },
+        "environmentIds": {
+          "description": "Optional ordered environment ids to use for this thread. For now only the first id is used. When omitted or empty, `environmentId` is used as a fallback for compatibility.",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
         "ephemeral": {
           "type": [
             "boolean",

--- a/codex-rs/app-server-protocol/schema/json/ClientRequest.json
+++ b/codex-rs/app-server-protocol/schema/json/ClientRequest.json
@@ -3280,6 +3280,13 @@
             "null"
           ]
         },
+        "environmentId": {
+          "description": "Optional environment id to use for this thread. Supported values are `\"local\"` and `\"remote\"`. When omitted, the default environment is used.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "ephemeral": {
           "type": [
             "boolean",

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
@@ -14590,6 +14590,16 @@
               "null"
             ]
           },
+          "environmentIds": {
+            "description": "Optional ordered environment ids to use for this thread. For now only the first id is used. When omitted or empty, `environmentId` is used as a fallback for compatibility.",
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
           "ephemeral": {
             "type": [
               "boolean",

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
@@ -14583,15 +14583,8 @@
               "null"
             ]
           },
-          "environmentId": {
-            "description": "Optional environment id to use for this thread. Supported values are `\"local\"` and `\"remote\"`. When omitted, the default environment is used.",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
           "environmentIds": {
-            "description": "Optional ordered environment ids to use for this thread. For now only the first id is used. When omitted or empty, `environmentId` is used as a fallback for compatibility.",
+            "description": "Optional ordered environment ids to use for this thread. For now only the first id is used. When omitted or empty, the default environment is used.",
             "items": {
               "type": "string"
             },

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
@@ -14583,6 +14583,13 @@
               "null"
             ]
           },
+          "environmentId": {
+            "description": "Optional environment id to use for this thread. Supported values are `\"local\"` and `\"remote\"`. When omitted, the default environment is used.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "ephemeral": {
             "type": [
               "boolean",

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
@@ -12427,15 +12427,8 @@
             "null"
           ]
         },
-        "environmentId": {
-          "description": "Optional environment id to use for this thread. Supported values are `\"local\"` and `\"remote\"`. When omitted, the default environment is used.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "environmentIds": {
-          "description": "Optional ordered environment ids to use for this thread. For now only the first id is used. When omitted or empty, `environmentId` is used as a fallback for compatibility.",
+          "description": "Optional ordered environment ids to use for this thread. For now only the first id is used. When omitted or empty, the default environment is used.",
           "items": {
             "type": "string"
           },

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
@@ -12427,6 +12427,13 @@
             "null"
           ]
         },
+        "environmentId": {
+          "description": "Optional environment id to use for this thread. Supported values are `\"local\"` and `\"remote\"`. When omitted, the default environment is used.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "ephemeral": {
           "type": [
             "boolean",

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
@@ -12434,6 +12434,16 @@
             "null"
           ]
         },
+        "environmentIds": {
+          "description": "Optional ordered environment ids to use for this thread. For now only the first id is used. When omitted or empty, `environmentId` is used as a fallback for compatibility.",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
         "ephemeral": {
           "type": [
             "boolean",

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadStartParams.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadStartParams.json
@@ -157,15 +157,8 @@
         "null"
       ]
     },
-    "environmentId": {
-      "description": "Optional environment id to use for this thread. Supported values are `\"local\"` and `\"remote\"`. When omitted, the default environment is used.",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
     "environmentIds": {
-      "description": "Optional ordered environment ids to use for this thread. For now only the first id is used. When omitted or empty, `environmentId` is used as a fallback for compatibility.",
+      "description": "Optional ordered environment ids to use for this thread. For now only the first id is used. When omitted or empty, the default environment is used.",
       "items": {
         "type": "string"
       },

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadStartParams.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadStartParams.json
@@ -157,6 +157,13 @@
         "null"
       ]
     },
+    "environmentId": {
+      "description": "Optional environment id to use for this thread. Supported values are `\"local\"` and `\"remote\"`. When omitted, the default environment is used.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "ephemeral": {
       "type": [
         "boolean",

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadStartParams.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadStartParams.json
@@ -164,6 +164,16 @@
         "null"
       ]
     },
+    "environmentIds": {
+      "description": "Optional ordered environment ids to use for this thread. For now only the first id is used. When omitted or empty, `environmentId` is used as a fallback for compatibility.",
+      "items": {
+        "type": "string"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
+    },
     "ephemeral": {
       "type": [
         "boolean",

--- a/codex-rs/app-server-protocol/schema/typescript/v2/ThreadStartParams.ts
+++ b/codex-rs/app-server-protocol/schema/typescript/v2/ThreadStartParams.ts
@@ -14,14 +14,9 @@ export type ThreadStartParams = {model?: string | null, modelProvider?: string |
  * and subsequent turns.
  */
 approvalsReviewer?: ApprovalsReviewer | null, sandbox?: SandboxMode | null, config?: { [key in string]?: JsonValue } | null, serviceName?: string | null, baseInstructions?: string | null, developerInstructions?: string | null, personality?: Personality | null, ephemeral?: boolean | null, sessionStartSource?: ThreadStartSource | null, /**
- * Optional environment id to use for this thread. Supported values are
- * `"local"` and `"remote"`. When omitted, the default environment is
- * used.
- */
-environmentId?: string | null, /**
  * Optional ordered environment ids to use for this thread. For now only
- * the first id is used. When omitted or empty, `environmentId` is used as
- * a fallback for compatibility.
+ * the first id is used. When omitted or empty, the default environment is
+ * used.
  */
 environmentIds?: Array<string> | null, /**
  * If true, opt into emitting raw Responses API items on the event stream.

--- a/codex-rs/app-server-protocol/schema/typescript/v2/ThreadStartParams.ts
+++ b/codex-rs/app-server-protocol/schema/typescript/v2/ThreadStartParams.ts
@@ -14,6 +14,11 @@ export type ThreadStartParams = {model?: string | null, modelProvider?: string |
  * and subsequent turns.
  */
 approvalsReviewer?: ApprovalsReviewer | null, sandbox?: SandboxMode | null, config?: { [key in string]?: JsonValue } | null, serviceName?: string | null, baseInstructions?: string | null, developerInstructions?: string | null, personality?: Personality | null, ephemeral?: boolean | null, sessionStartSource?: ThreadStartSource | null, /**
+ * Optional environment id to use for this thread. Supported values are
+ * `"local"` and `"remote"`. When omitted, the default environment is
+ * used.
+ */
+environmentId?: string | null, /**
  * If true, opt into emitting raw Responses API items on the event stream.
  * This is for internal use only (e.g. Codex Cloud).
  */

--- a/codex-rs/app-server-protocol/schema/typescript/v2/ThreadStartParams.ts
+++ b/codex-rs/app-server-protocol/schema/typescript/v2/ThreadStartParams.ts
@@ -19,6 +19,11 @@ approvalsReviewer?: ApprovalsReviewer | null, sandbox?: SandboxMode | null, conf
  * used.
  */
 environmentId?: string | null, /**
+ * Optional ordered environment ids to use for this thread. For now only
+ * the first id is used. When omitted or empty, `environmentId` is used as
+ * a fallback for compatibility.
+ */
+environmentIds?: Array<string> | null, /**
  * If true, opt into emitting raw Responses API items on the event stream.
  * This is for internal use only (e.g. Codex Cloud).
  */

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -2722,6 +2722,11 @@ pub struct ThreadStartParams {
     pub ephemeral: Option<bool>,
     #[ts(optional = nullable)]
     pub session_start_source: Option<ThreadStartSource>,
+    /// Optional environment id to use for this thread. Supported values are
+    /// `"local"` and `"remote"`. When omitted, the default environment is
+    /// used.
+    #[ts(optional = nullable)]
+    pub environment_id: Option<String>,
     #[experimental("thread/start.dynamicTools")]
     #[ts(optional = nullable)]
     pub dynamic_tools: Option<Vec<DynamicToolSpec>>,

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -2727,6 +2727,11 @@ pub struct ThreadStartParams {
     /// used.
     #[ts(optional = nullable)]
     pub environment_id: Option<String>,
+    /// Optional ordered environment ids to use for this thread. For now only
+    /// the first id is used. When omitted or empty, `environmentId` is used as
+    /// a fallback for compatibility.
+    #[ts(optional = nullable)]
+    pub environment_ids: Option<Vec<String>>,
     #[experimental("thread/start.dynamicTools")]
     #[ts(optional = nullable)]
     pub dynamic_tools: Option<Vec<DynamicToolSpec>>,

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -2722,14 +2722,9 @@ pub struct ThreadStartParams {
     pub ephemeral: Option<bool>,
     #[ts(optional = nullable)]
     pub session_start_source: Option<ThreadStartSource>,
-    /// Optional environment id to use for this thread. Supported values are
-    /// `"local"` and `"remote"`. When omitted, the default environment is
-    /// used.
-    #[ts(optional = nullable)]
-    pub environment_id: Option<String>,
     /// Optional ordered environment ids to use for this thread. For now only
-    /// the first id is used. When omitted or empty, `environmentId` is used as
-    /// a fallback for compatibility.
+    /// the first id is used. When omitted or empty, the default environment is
+    /// used.
     #[ts(optional = nullable)]
     pub environment_ids: Option<Vec<String>>,
     #[experimental("thread/start.dynamicTools")]

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -2750,6 +2750,15 @@ pub struct ThreadStartParams {
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export_to = "v2/")]
+pub struct TurnEnvironmentParams {
+    pub environment_id: String,
+    #[ts(optional = nullable)]
+    pub cwd: Option<PathBuf>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub struct MockExperimentalMethodParams {
     /// Test-only payload field.
     #[ts(optional = nullable)]
@@ -4275,6 +4284,11 @@ pub struct TurnStartParams {
     #[experimental("turn/start.collaborationMode")]
     #[ts(optional = nullable)]
     pub collaboration_mode: Option<CollaborationMode>,
+
+    /// Optional ordered environment ids with per-environment cwd overrides for
+    /// this turn. For now only the first entry is used to drive execution.
+    #[ts(optional = nullable)]
+    pub environments: Option<Vec<TurnEnvironmentParams>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -2401,7 +2401,7 @@ impl CodexMessageProcessor {
         request_trace: Option<W3cTraceContext>,
         environment_id: Option<String>,
     ) {
-        let requested_cwd = typesafe_overrides.cwd.clone();
+        let explicit_cwd = typesafe_overrides.cwd.clone();
         let mut config = match derive_config_from_params(
             &cli_overrides,
             config_overrides.clone(),
@@ -2436,7 +2436,7 @@ impl CodexMessageProcessor {
             )
         );
 
-        if requested_cwd.is_some()
+        if explicit_cwd.is_some()
             && !config.active_project.is_trusted()
             && (requested_sandbox_trusts_project
                 || matches!(
@@ -2505,6 +2505,47 @@ impl CodexMessageProcessor {
             };
         }
 
+        if explicit_cwd.is_none() {
+            match listener_task_context
+                .thread_manager
+                .environment_manager()
+                .default_cwd(environment_id.as_deref())
+            {
+                Ok(Some(default_cwd)) => {
+                    config.cwd =
+                        match codex_utils_absolute_path::AbsolutePathBuf::from_absolute_path(
+                            default_cwd,
+                        ) {
+                            Ok(default_cwd) => default_cwd,
+                            Err(err) => {
+                                listener_task_context
+                                    .outgoing
+                                    .send_error(
+                                        request_id,
+                                        invalid_request(format!(
+                                            "failed to resolve environment default cwd {}: {err}",
+                                            default_cwd.display()
+                                        )),
+                                    )
+                                    .await;
+                                return;
+                            }
+                        };
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    listener_task_context
+                        .outgoing
+                        .send_error(
+                            request_id,
+                            invalid_request(format!("failed to resolve environment: {err}")),
+                        )
+                        .await;
+                    return;
+                }
+            }
+        }
+
         let instruction_sources = Self::instruction_sources_from_config(&config).await;
         let dynamic_tools = dynamic_tools.unwrap_or_default();
         let core_dynamic_tools = if dynamic_tools.is_empty() {
@@ -2549,7 +2590,6 @@ impl CodexMessageProcessor {
                 service_name,
                 request_trace,
                 environment_id,
-                requested_cwd,
             )
             .instrument(tracing::info_span!(
                 "app_server.thread_start.create_thread",

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -2267,15 +2267,16 @@ impl CodexMessageProcessor {
             personality,
             ephemeral,
             session_start_source,
-            environment_id,
             environment_ids,
             persist_extended_history,
         } = params;
+        // TODO(starr): Plumb environment ids as a list through core/session
+        // state instead of collapsing to the first id at the app-server
+        // boundary.
         let environment_id = environment_ids
             .as_ref()
             .and_then(|environment_ids| environment_ids.first())
-            .cloned()
-            .or(environment_id);
+            .cloned();
         let mut typesafe_overrides = self.build_thread_config_overrides(
             model,
             model_provider,

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -2542,6 +2542,7 @@ impl CodexMessageProcessor {
                 service_name,
                 request_trace,
                 environment_id,
+                requested_cwd,
             )
             .instrument(tracing::info_span!(
                 "app_server.thread_start.create_thread",

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -2505,47 +2505,6 @@ impl CodexMessageProcessor {
             };
         }
 
-        if requested_cwd.is_none() {
-            match listener_task_context
-                .thread_manager
-                .environment_manager()
-                .default_cwd(environment_id.as_deref())
-            {
-                Ok(Some(default_cwd)) => {
-                    config.cwd =
-                        match codex_utils_absolute_path::AbsolutePathBuf::from_absolute_path(
-                            default_cwd,
-                        ) {
-                            Ok(default_cwd) => default_cwd,
-                            Err(err) => {
-                                listener_task_context
-                                    .outgoing
-                                    .send_error(
-                                        request_id,
-                                        invalid_request(format!(
-                                            "failed to resolve environment default cwd {}: {err}",
-                                            default_cwd.display()
-                                        )),
-                                    )
-                                    .await;
-                                return;
-                            }
-                        };
-                }
-                Ok(None) => {}
-                Err(err) => {
-                    listener_task_context
-                        .outgoing
-                        .send_error(
-                            request_id,
-                            invalid_request(format!("failed to resolve environment: {err}")),
-                        )
-                        .await;
-                    return;
-                }
-            }
-        }
-
         let instruction_sources = Self::instruction_sources_from_config(&config).await;
         let dynamic_tools = dynamic_tools.unwrap_or_default();
         let core_dynamic_tools = if dynamic_tools.is_empty() {

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -2268,8 +2268,14 @@ impl CodexMessageProcessor {
             ephemeral,
             session_start_source,
             environment_id,
+            environment_ids,
             persist_extended_history,
         } = params;
+        let environment_id = environment_ids
+            .as_ref()
+            .and_then(|environment_ids| environment_ids.first())
+            .cloned()
+            .or(environment_id);
         let mut typesafe_overrides = self.build_thread_config_overrides(
             model,
             model_provider,

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -2267,6 +2267,7 @@ impl CodexMessageProcessor {
             personality,
             ephemeral,
             session_start_source,
+            environment_id,
             persist_extended_history,
         } = params;
         let mut typesafe_overrides = self.build_thread_config_overrides(
@@ -2314,6 +2315,7 @@ impl CodexMessageProcessor {
                 service_name,
                 experimental_raw_events,
                 request_trace,
+                environment_id,
             )
             .await;
         };
@@ -2390,6 +2392,7 @@ impl CodexMessageProcessor {
         service_name: Option<String>,
         experimental_raw_events: bool,
         request_trace: Option<W3cTraceContext>,
+        environment_id: Option<String>,
     ) {
         let requested_cwd = typesafe_overrides.cwd.clone();
         let mut config = match derive_config_from_params(
@@ -2538,6 +2541,7 @@ impl CodexMessageProcessor {
                 persist_extended_history,
                 service_name,
                 request_trace,
+                environment_id,
             )
             .instrument(tracing::info_span!(
                 "app_server.thread_start.create_thread",

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -2401,7 +2401,7 @@ impl CodexMessageProcessor {
         request_trace: Option<W3cTraceContext>,
         environment_id: Option<String>,
     ) {
-        let explicit_cwd = typesafe_overrides.cwd.clone();
+        let requested_cwd = typesafe_overrides.cwd.clone();
         let mut config = match derive_config_from_params(
             &cli_overrides,
             config_overrides.clone(),
@@ -2436,7 +2436,7 @@ impl CodexMessageProcessor {
             )
         );
 
-        if explicit_cwd.is_some()
+        if requested_cwd.is_some()
             && !config.active_project.is_trusted()
             && (requested_sandbox_trusts_project
                 || matches!(
@@ -2505,7 +2505,7 @@ impl CodexMessageProcessor {
             };
         }
 
-        if explicit_cwd.is_none() {
+        if requested_cwd.is_none() {
             match listener_task_context
                 .thread_manager
                 .environment_manager()

--- a/codex-rs/app-server/src/message_processor/tracing_tests.rs
+++ b/codex-rs/app-server/src/message_processor/tracing_tests.rs
@@ -618,6 +618,7 @@ async fn turn_start_jsonrpc_span_parents_core_turn_spans() -> Result<()> {
                     personality: None,
                     output_schema: None,
                     collaboration_mode: None,
+                    environments: None,
                 },
             },
             Some(remote_trace),

--- a/codex-rs/app-server/tests/suite/v2/skills_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/skills_list.rs
@@ -322,7 +322,7 @@ async fn skills_changed_notification_is_emitted_after_skill_change() -> Result<(
             personality: None,
             ephemeral: None,
             session_start_source: None,
-            environment_id: None,
+            environment_ids: None,
             dynamic_tools: None,
             mock_experimental_field: None,
             experimental_raw_events: false,

--- a/codex-rs/app-server/tests/suite/v2/skills_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/skills_list.rs
@@ -322,6 +322,7 @@ async fn skills_changed_notification_is_emitted_after_skill_change() -> Result<(
             personality: None,
             ephemeral: None,
             session_start_source: None,
+            environment_id: None,
             dynamic_tools: None,
             mock_experimental_field: None,
             experimental_raw_events: false,

--- a/codex-rs/app-server/tests/suite/v2/thread_start.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_start.rs
@@ -46,6 +46,7 @@ use super::analytics::wait_for_analytics_payload;
 
 const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 const CODEX_EXEC_SERVER_URL_ENV_VAR: &str = "CODEX_EXEC_SERVER_URL";
+const CODEX_EXEC_SERVER_CWD_ENV_VAR: &str = "CODEX_EXEC_SERVER_CWD";
 
 #[tokio::test]
 async fn thread_start_creates_thread_and_emits_started() -> Result<()> {
@@ -193,6 +194,87 @@ async fn thread_start_accepts_explicit_local_environment_when_default_is_remote(
     let ThreadStartResponse { thread, .. } = to_response::<ThreadStartResponse>(resp)?;
 
     assert!(!thread.id.is_empty(), "thread id should not be empty");
+    Ok(())
+}
+
+#[tokio::test]
+async fn thread_start_uses_remote_default_cwd_when_request_omits_cwd() -> Result<()> {
+    let server = create_mock_responses_server_repeating_assistant("Done").await;
+
+    let codex_home = TempDir::new()?;
+    create_config_toml_without_approval_policy(codex_home.path(), &server.uri())?;
+
+    let remote_default_cwd = TempDir::new()?;
+    let remote_default_cwd = remote_default_cwd.path().to_string_lossy().into_owned();
+
+    let mut mcp = McpProcess::new_with_env(
+        codex_home.path(),
+        &[
+            (CODEX_EXEC_SERVER_URL_ENV_VAR, Some("ws://127.0.0.1:1")),
+            (
+                CODEX_EXEC_SERVER_CWD_ENV_VAR,
+                Some(remote_default_cwd.as_str()),
+            ),
+        ],
+    )
+    .await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let req_id = mcp
+        .send_thread_start_request(ThreadStartParams::default())
+        .await?;
+
+    let resp: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(req_id)),
+    )
+    .await??;
+    let ThreadStartResponse { thread, .. } = to_response::<ThreadStartResponse>(resp)?;
+
+    assert_eq!(thread.cwd.as_path(), Path::new(&remote_default_cwd));
+    Ok(())
+}
+
+#[tokio::test]
+async fn thread_start_explicit_cwd_overrides_remote_default_cwd() -> Result<()> {
+    let server = create_mock_responses_server_repeating_assistant("Done").await;
+
+    let codex_home = TempDir::new()?;
+    create_config_toml_without_approval_policy(codex_home.path(), &server.uri())?;
+
+    let remote_default_cwd = TempDir::new()?;
+    let remote_default_cwd = remote_default_cwd.path().to_string_lossy().into_owned();
+    let requested_cwd = TempDir::new()?;
+    let requested_cwd = requested_cwd.path().to_string_lossy().into_owned();
+
+    let mut mcp = McpProcess::new_with_env(
+        codex_home.path(),
+        &[
+            (CODEX_EXEC_SERVER_URL_ENV_VAR, Some("ws://127.0.0.1:1")),
+            (
+                CODEX_EXEC_SERVER_CWD_ENV_VAR,
+                Some(remote_default_cwd.as_str()),
+            ),
+        ],
+    )
+    .await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let req_id = mcp
+        .send_thread_start_request(ThreadStartParams {
+            cwd: Some(requested_cwd.clone()),
+            ..Default::default()
+        })
+        .await?;
+
+    let resp: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(req_id)),
+    )
+    .await??;
+    let ThreadStartResponse { thread, .. } = to_response::<ThreadStartResponse>(resp)?;
+
+    assert_eq!(thread.cwd.as_path(), Path::new(&requested_cwd));
     Ok(())
 }
 

--- a/codex-rs/app-server/tests/suite/v2/thread_start.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_start.rs
@@ -188,7 +188,7 @@ async fn thread_start_accepts_explicit_local_environment_when_default_is_remote(
 
     let req_id = mcp
         .send_thread_start_request(ThreadStartParams {
-            environment_id: Some("local".to_string()),
+            environment_ids: Some(vec!["local".to_string()]),
             ..Default::default()
         })
         .await?;
@@ -305,7 +305,7 @@ async fn thread_start_rejects_explicit_remote_environment_when_not_configured() 
 
     let req_id = mcp
         .send_thread_start_request(ThreadStartParams {
-            environment_id: Some("remote".to_string()),
+            environment_ids: Some(vec!["remote".to_string()]),
             ..Default::default()
         })
         .await?;
@@ -342,7 +342,7 @@ async fn thread_start_rejects_explicit_environment_when_disabled() -> Result<()>
 
     let req_id = mcp
         .send_thread_start_request(ThreadStartParams {
-            environment_id: Some("local".to_string()),
+            environment_ids: Some(vec!["local".to_string()]),
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_start.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_start.rs
@@ -45,6 +45,7 @@ use super::analytics::thread_initialized_event;
 use super::analytics::wait_for_analytics_payload;
 
 const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+const CODEX_EXEC_SERVER_URL_ENV_VAR: &str = "CODEX_EXEC_SERVER_URL";
 
 #[tokio::test]
 async fn thread_start_creates_thread_and_emits_started() -> Result<()> {
@@ -160,6 +161,108 @@ async fn thread_start_creates_thread_and_emits_started() -> Result<()> {
         serde_json::from_value(notif.params.expect("params must be present"))?;
     assert_eq!(started.thread, thread);
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn thread_start_accepts_explicit_local_environment_when_default_is_remote() -> Result<()> {
+    let server = create_mock_responses_server_repeating_assistant("Done").await;
+
+    let codex_home = TempDir::new()?;
+    create_config_toml_without_approval_policy(codex_home.path(), &server.uri())?;
+
+    let mut mcp = McpProcess::new_with_env(
+        codex_home.path(),
+        &[(CODEX_EXEC_SERVER_URL_ENV_VAR, Some("ws://127.0.0.1:1"))],
+    )
+    .await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let req_id = mcp
+        .send_thread_start_request(ThreadStartParams {
+            environment_id: Some("local".to_string()),
+            ..Default::default()
+        })
+        .await?;
+
+    let resp: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(req_id)),
+    )
+    .await??;
+    let ThreadStartResponse { thread, .. } = to_response::<ThreadStartResponse>(resp)?;
+
+    assert!(!thread.id.is_empty(), "thread id should not be empty");
+    Ok(())
+}
+
+#[tokio::test]
+async fn thread_start_rejects_explicit_remote_environment_when_not_configured() -> Result<()> {
+    let server = create_mock_responses_server_repeating_assistant("Done").await;
+
+    let codex_home = TempDir::new()?;
+    create_config_toml_without_approval_policy(codex_home.path(), &server.uri())?;
+
+    let mut mcp = McpProcess::new(codex_home.path()).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let req_id = mcp
+        .send_thread_start_request(ThreadStartParams {
+            environment_id: Some("remote".to_string()),
+            ..Default::default()
+        })
+        .await?;
+
+    let err: JSONRPCError = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_error_message(RequestId::Integer(req_id)),
+    )
+    .await??;
+
+    assert!(
+        err.error
+            .message
+            .contains("remote environment is not configured"),
+        "unexpected error message: {}",
+        err.error.message
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn thread_start_rejects_explicit_environment_when_disabled() -> Result<()> {
+    let server = create_mock_responses_server_repeating_assistant("Done").await;
+
+    let codex_home = TempDir::new()?;
+    create_config_toml_without_approval_policy(codex_home.path(), &server.uri())?;
+
+    let mut mcp = McpProcess::new_with_env(
+        codex_home.path(),
+        &[(CODEX_EXEC_SERVER_URL_ENV_VAR, Some("none"))],
+    )
+    .await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let req_id = mcp
+        .send_thread_start_request(ThreadStartParams {
+            environment_id: Some("local".to_string()),
+            ..Default::default()
+        })
+        .await?;
+
+    let err: JSONRPCError = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_error_message(RequestId::Integer(req_id)),
+    )
+    .await??;
+
+    assert!(
+        err.error
+            .message
+            .contains("environments are disabled for this session"),
+        "unexpected error message: {}",
+        err.error.message
+    );
     Ok(())
 }
 

--- a/codex-rs/app-server/tests/suite/v2/thread_start.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_start.rs
@@ -20,7 +20,6 @@ use codex_app_server_protocol::ThreadStatus;
 use codex_app_server_protocol::ThreadStatusChangedNotification;
 use codex_config::types::AuthCredentialsStoreMode;
 use codex_core::config::set_project_trust_level;
-use codex_exec_server::ExecServerRuntimePaths;
 use codex_git_utils::resolve_root_git_project_for_trust;
 use codex_login::REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR;
 use codex_protocol::config_types::ServiceTier;
@@ -29,16 +28,10 @@ use codex_protocol::openai_models::ReasoningEffort;
 use pretty_assertions::assert_eq;
 use serde_json::Value;
 use serde_json::json;
-use std::net::TcpListener;
 use std::path::Path;
 use std::path::PathBuf;
-use std::time::Duration;
 use tempfile::TempDir;
-use tokio::task::JoinHandle;
-use tokio::time::Instant;
-use tokio::time::sleep;
 use tokio::time::timeout;
-use tokio_tungstenite::connect_async;
 use wiremock::Mock;
 use wiremock::MockServer;
 use wiremock::ResponseTemplate;
@@ -52,8 +45,6 @@ use super::analytics::wait_for_analytics_payload;
 
 const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 const CODEX_EXEC_SERVER_URL_ENV_VAR: &str = "CODEX_EXEC_SERVER_URL";
-const CODEX_EXEC_SERVER_CWD_ENV_VAR: &str = "CODEX_EXEC_SERVER_CWD";
-const EXEC_SERVER_CONNECT_RETRY_INTERVAL: Duration = Duration::from_millis(25);
 
 #[tokio::test]
 async fn thread_start_creates_thread_and_emits_started() -> Result<()> {
@@ -205,74 +196,14 @@ async fn thread_start_accepts_explicit_local_environment_when_default_is_remote(
 }
 
 #[tokio::test]
-async fn thread_start_uses_remote_default_cwd_when_request_omits_cwd() -> Result<()> {
-    let server = create_mock_responses_server_repeating_assistant("Done").await;
-
-    let codex_home = TempDir::new()?;
-    create_config_toml_without_approval_policy(codex_home.path(), &server.uri())?;
-    let exec_server = TestExecServer::spawn().await?;
-
-    let remote_default_cwd = TempDir::new()?;
-    let remote_default_cwd = remote_default_cwd.path().to_string_lossy().into_owned();
-
-    let mut mcp = McpProcess::new_with_env(
-        codex_home.path(),
-        &[
-            (
-                CODEX_EXEC_SERVER_URL_ENV_VAR,
-                Some(exec_server.websocket_url.as_str()),
-            ),
-            (
-                CODEX_EXEC_SERVER_CWD_ENV_VAR,
-                Some(remote_default_cwd.as_str()),
-            ),
-        ],
-    )
-    .await?;
-    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
-
-    let req_id = mcp
-        .send_thread_start_request(ThreadStartParams::default())
-        .await?;
-
-    let resp: JSONRPCResponse = timeout(
-        DEFAULT_READ_TIMEOUT,
-        mcp.read_stream_until_response_message(RequestId::Integer(req_id)),
-    )
-    .await??;
-    let ThreadStartResponse { thread, .. } = to_response::<ThreadStartResponse>(resp)?;
-
-    assert_eq!(thread.cwd.as_path(), Path::new(&remote_default_cwd));
-    Ok(())
-}
-
-#[tokio::test]
-async fn thread_start_explicit_cwd_overrides_remote_default_cwd() -> Result<()> {
-    let server = create_mock_responses_server_repeating_assistant("Done").await;
-
-    let codex_home = TempDir::new()?;
-    create_config_toml_without_approval_policy(codex_home.path(), &server.uri())?;
-    let exec_server = TestExecServer::spawn().await?;
-
-    let remote_default_cwd = TempDir::new()?;
-    let remote_default_cwd = remote_default_cwd.path().to_string_lossy().into_owned();
+async fn thread_start_uses_explicit_cwd() -> Result<()> {
     let requested_cwd = TempDir::new()?;
     let requested_cwd = requested_cwd.path().to_string_lossy().into_owned();
+    let server = create_mock_responses_server_repeating_assistant("Done").await;
+    let codex_home = TempDir::new()?;
+    create_config_toml_without_approval_policy(codex_home.path(), &server.uri())?;
 
-    let mut mcp = McpProcess::new_with_env(
-        codex_home.path(),
-        &[
-            (
-                CODEX_EXEC_SERVER_URL_ENV_VAR,
-                Some(exec_server.websocket_url.as_str()),
-            ),
-            (
-                CODEX_EXEC_SERVER_CWD_ENV_VAR,
-                Some(remote_default_cwd.as_str()),
-            ),
-        ],
-    )
-    .await?;
+    let mut mcp = McpProcess::new(codex_home.path()).await?;
     timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
 
     let req_id = mcp
@@ -420,64 +351,6 @@ fn normalize_path_for_comparison(path: impl AsRef<Path>) -> PathBuf {
 #[cfg(not(windows))]
 fn normalize_path_for_comparison(path: impl AsRef<Path>) -> PathBuf {
     path.as_ref().to_path_buf()
-}
-
-struct TestExecServer {
-    websocket_url: String,
-    task: JoinHandle<()>,
-}
-
-impl TestExecServer {
-    async fn spawn() -> Result<Self> {
-        let bind_addr = TcpListener::bind("127.0.0.1:0")?.local_addr()?;
-        let websocket_url = format!("ws://{bind_addr}");
-        let runtime_paths = ExecServerRuntimePaths::new(
-            std::env::current_exe()?,
-            /*codex_linux_sandbox_exe*/ None,
-        )?;
-        let listen_url = websocket_url.clone();
-        let task = tokio::spawn(async move {
-            codex_exec_server::run_main(&listen_url, runtime_paths)
-                .await
-                .expect("test exec-server should run");
-        });
-        wait_for_exec_server(websocket_url.as_str()).await?;
-        Ok(Self {
-            websocket_url,
-            task,
-        })
-    }
-}
-
-impl Drop for TestExecServer {
-    fn drop(&mut self) {
-        self.task.abort();
-    }
-}
-
-async fn wait_for_exec_server(websocket_url: &str) -> Result<()> {
-    let deadline = Instant::now() + DEFAULT_READ_TIMEOUT;
-    loop {
-        match connect_async(websocket_url).await {
-            Ok((mut websocket, _)) => {
-                websocket.close(None).await?;
-                return Ok(());
-            }
-            Err(err) if Instant::now() < deadline => {
-                let is_connection_refused = matches!(
-                    err,
-                    tokio_tungstenite::tungstenite::Error::Io(ref io_err)
-                        if io_err.kind() == std::io::ErrorKind::ConnectionRefused
-                );
-                if is_connection_refused {
-                    sleep(EXEC_SERVER_CONNECT_RETRY_INTERVAL).await;
-                    continue;
-                }
-                return Err(err.into());
-            }
-            Err(err) => return Err(err.into()),
-        }
-    }
 }
 
 #[tokio::test]

--- a/codex-rs/app-server/tests/suite/v2/thread_start.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_start.rs
@@ -20,6 +20,7 @@ use codex_app_server_protocol::ThreadStatus;
 use codex_app_server_protocol::ThreadStatusChangedNotification;
 use codex_config::types::AuthCredentialsStoreMode;
 use codex_core::config::set_project_trust_level;
+use codex_exec_server::ExecServerRuntimePaths;
 use codex_git_utils::resolve_root_git_project_for_trust;
 use codex_login::REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR;
 use codex_protocol::config_types::ServiceTier;
@@ -28,11 +29,16 @@ use codex_protocol::openai_models::ReasoningEffort;
 use pretty_assertions::assert_eq;
 use serde_json::Value;
 use serde_json::json;
+use std::net::TcpListener;
 use std::path::Path;
 use std::path::PathBuf;
 use std::time::Duration;
 use tempfile::TempDir;
+use tokio::task::JoinHandle;
+use tokio::time::Instant;
+use tokio::time::sleep;
 use tokio::time::timeout;
+use tokio_tungstenite::connect_async;
 use wiremock::Mock;
 use wiremock::MockServer;
 use wiremock::ResponseTemplate;
@@ -47,6 +53,7 @@ use super::analytics::wait_for_analytics_payload;
 const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 const CODEX_EXEC_SERVER_URL_ENV_VAR: &str = "CODEX_EXEC_SERVER_URL";
 const CODEX_EXEC_SERVER_CWD_ENV_VAR: &str = "CODEX_EXEC_SERVER_CWD";
+const EXEC_SERVER_CONNECT_RETRY_INTERVAL: Duration = Duration::from_millis(25);
 
 #[tokio::test]
 async fn thread_start_creates_thread_and_emits_started() -> Result<()> {
@@ -203,6 +210,7 @@ async fn thread_start_uses_remote_default_cwd_when_request_omits_cwd() -> Result
 
     let codex_home = TempDir::new()?;
     create_config_toml_without_approval_policy(codex_home.path(), &server.uri())?;
+    let exec_server = TestExecServer::spawn().await?;
 
     let remote_default_cwd = TempDir::new()?;
     let remote_default_cwd = remote_default_cwd.path().to_string_lossy().into_owned();
@@ -210,7 +218,10 @@ async fn thread_start_uses_remote_default_cwd_when_request_omits_cwd() -> Result
     let mut mcp = McpProcess::new_with_env(
         codex_home.path(),
         &[
-            (CODEX_EXEC_SERVER_URL_ENV_VAR, Some("ws://127.0.0.1:1")),
+            (
+                CODEX_EXEC_SERVER_URL_ENV_VAR,
+                Some(exec_server.websocket_url.as_str()),
+            ),
             (
                 CODEX_EXEC_SERVER_CWD_ENV_VAR,
                 Some(remote_default_cwd.as_str()),
@@ -241,6 +252,7 @@ async fn thread_start_explicit_cwd_overrides_remote_default_cwd() -> Result<()> 
 
     let codex_home = TempDir::new()?;
     create_config_toml_without_approval_policy(codex_home.path(), &server.uri())?;
+    let exec_server = TestExecServer::spawn().await?;
 
     let remote_default_cwd = TempDir::new()?;
     let remote_default_cwd = remote_default_cwd.path().to_string_lossy().into_owned();
@@ -250,7 +262,10 @@ async fn thread_start_explicit_cwd_overrides_remote_default_cwd() -> Result<()> 
     let mut mcp = McpProcess::new_with_env(
         codex_home.path(),
         &[
-            (CODEX_EXEC_SERVER_URL_ENV_VAR, Some("ws://127.0.0.1:1")),
+            (
+                CODEX_EXEC_SERVER_URL_ENV_VAR,
+                Some(exec_server.websocket_url.as_str()),
+            ),
             (
                 CODEX_EXEC_SERVER_CWD_ENV_VAR,
                 Some(remote_default_cwd.as_str()),
@@ -405,6 +420,64 @@ fn normalize_path_for_comparison(path: impl AsRef<Path>) -> PathBuf {
 #[cfg(not(windows))]
 fn normalize_path_for_comparison(path: impl AsRef<Path>) -> PathBuf {
     path.as_ref().to_path_buf()
+}
+
+struct TestExecServer {
+    websocket_url: String,
+    task: JoinHandle<()>,
+}
+
+impl TestExecServer {
+    async fn spawn() -> Result<Self> {
+        let bind_addr = TcpListener::bind("127.0.0.1:0")?.local_addr()?;
+        let websocket_url = format!("ws://{bind_addr}");
+        let runtime_paths = ExecServerRuntimePaths::new(
+            std::env::current_exe()?,
+            /*codex_linux_sandbox_exe*/ None,
+        )?;
+        let listen_url = websocket_url.clone();
+        let task = tokio::spawn(async move {
+            codex_exec_server::run_main(&listen_url, runtime_paths)
+                .await
+                .expect("test exec-server should run");
+        });
+        wait_for_exec_server(websocket_url.as_str()).await?;
+        Ok(Self {
+            websocket_url,
+            task,
+        })
+    }
+}
+
+impl Drop for TestExecServer {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+async fn wait_for_exec_server(websocket_url: &str) -> Result<()> {
+    let deadline = Instant::now() + DEFAULT_READ_TIMEOUT;
+    loop {
+        match connect_async(websocket_url).await {
+            Ok((mut websocket, _)) => {
+                websocket.close(None).await?;
+                return Ok(());
+            }
+            Err(err) if Instant::now() < deadline => {
+                let is_connection_refused = matches!(
+                    err,
+                    tokio_tungstenite::tungstenite::Error::Io(ref io_err)
+                        if io_err.kind() == std::io::ErrorKind::ConnectionRefused
+                );
+                if is_connection_refused {
+                    sleep(EXEC_SERVER_CONNECT_RETRY_INTERVAL).await;
+                    continue;
+                }
+                return Err(err.into());
+            }
+            Err(err) => return Err(err.into()),
+        }
+    }
 }
 
 #[tokio::test]

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -445,6 +445,7 @@ pub(crate) struct CodexSpawnArgs {
     pub(crate) user_shell_override: Option<shell::Shell>,
     pub(crate) parent_trace: Option<W3cTraceContext>,
     pub(crate) analytics_events_client: Option<AnalyticsEventsClient>,
+    pub(crate) environment_ids: Vec<String>,
 }
 
 pub(crate) const INITIAL_SUBMIT_ID: &str = "";
@@ -498,6 +499,7 @@ impl Codex {
             inherited_exec_policy,
             parent_trace: _,
             analytics_events_client,
+            environment_ids,
         } = args;
         let (tx_sub, rx_sub) = async_channel::bounded(SUBMISSION_CHANNEL_CAPACITY);
         let (tx_event, rx_event) = async_channel::unbounded();
@@ -660,6 +662,13 @@ impl Codex {
             network_sandbox_policy: config.permissions.network_sandbox_policy,
             windows_sandbox_level: WindowsSandboxLevel::from_config(&config),
             cwd: config.cwd.clone(),
+            environments: environment_ids
+                .into_iter()
+                .map(|environment_id| SessionEnvironment {
+                    environment_id,
+                    cwd: None,
+                })
+                .collect(),
             codex_home: config.codex_home.clone(),
             thread_name: None,
             original_config_do_not_use: Arc::clone(&config),
@@ -693,6 +702,7 @@ impl Codex {
             skills_watcher,
             agent_control,
             environment,
+            environment_manager,
             analytics_events_client,
         )
         .await
@@ -884,6 +894,12 @@ impl TurnSkillsContext {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct SessionEnvironment {
+    pub(crate) environment_id: String,
+    pub(crate) cwd: Option<AbsolutePathBuf>,
+}
+
 /// The context needed for a single turn of the thread.
 #[derive(Debug)]
 pub(crate) struct TurnContext {
@@ -898,6 +914,7 @@ pub(crate) struct TurnContext {
     pub(crate) reasoning_effort: Option<ReasoningEffortConfig>,
     pub(crate) reasoning_summary: ReasoningSummaryConfig,
     pub(crate) session_source: SessionSource,
+    pub(crate) environments: Vec<SessionEnvironment>,
     pub(crate) environment: Option<Arc<Environment>>,
     /// The session's absolute working directory. All relative paths provided
     /// by the model as well as sandbox policies are resolved against this path
@@ -1211,6 +1228,7 @@ pub(crate) struct SessionConfiguration {
     /// execution sandbox are resolved against this directory **instead** of
     /// the process-wide current working directory.
     cwd: AbsolutePathBuf,
+    environments: Vec<SessionEnvironment>,
     /// Directory containing all Codex state for this session.
     codex_home: AbsolutePathBuf,
     /// Optional user-facing name for the thread, updated during the session.
@@ -1251,6 +1269,18 @@ impl SessionConfiguration {
         }
     }
 
+    fn normalize_session_environment_cwd(
+        &self,
+        cwd: &PathBuf,
+        fallback_cwd: &AbsolutePathBuf,
+    ) -> AbsolutePathBuf {
+        AbsolutePathBuf::relative_to_current_dir(normalize_for_native_workdir(cwd.as_path()))
+            .unwrap_or_else(|e| {
+                warn!("failed to normalize update cwd: {cwd:?}: {e}");
+                fallback_cwd.clone()
+            })
+    }
+
     pub(crate) fn apply(&self, updates: &SessionSettingsUpdate) -> ConstraintResult<Self> {
         let mut next_configuration = self.clone();
         let file_system_policy_matches_legacy = self.file_system_sandbox_policy
@@ -1286,20 +1316,28 @@ impl SessionConfiguration {
         if let Some(windows_sandbox_level) = updates.windows_sandbox_level {
             next_configuration.windows_sandbox_level = windows_sandbox_level;
         }
-
-        let absolute_cwd = updates
-            .cwd
-            .as_ref()
-            .map(|cwd| {
-                AbsolutePathBuf::relative_to_current_dir(normalize_for_native_workdir(
-                    cwd.as_path(),
-                ))
-                .unwrap_or_else(|e| {
-                    warn!("failed to normalize update cwd: {cwd:?}: {e}");
-                    self.cwd.clone()
+        if let Some(environments) = updates.environments.as_ref() {
+            next_configuration.environments = environments
+                .iter()
+                .map(|environment| SessionEnvironment {
+                    environment_id: environment.environment_id.clone(),
+                    cwd: environment
+                        .cwd
+                        .as_ref()
+                        .map(|cwd| self.normalize_session_environment_cwd(cwd, &self.cwd)),
                 })
-            })
-            .unwrap_or_else(|| self.cwd.clone());
+                .collect();
+        }
+
+        let absolute_cwd = if let Some(cwd) = updates.cwd.as_ref() {
+            self.normalize_session_environment_cwd(cwd, &self.cwd)
+        } else {
+            next_configuration
+                .environments
+                .first()
+                .and_then(|environment| environment.cwd.clone())
+                .unwrap_or_else(|| self.cwd.clone())
+        };
 
         let cwd_changed = absolute_cwd.as_path() != self.cwd.as_path();
         next_configuration.cwd = absolute_cwd;
@@ -1331,6 +1369,7 @@ impl SessionConfiguration {
 
 #[derive(Default, Clone)]
 pub(crate) struct SessionSettingsUpdate {
+    pub(crate) environments: Option<Vec<codex_protocol::protocol::TurnEnvironment>>,
     pub(crate) cwd: Option<PathBuf>,
     pub(crate) approval_policy: Option<AskForApproval>,
     pub(crate) approvals_reviewer: Option<ApprovalsReviewer>,
@@ -1673,6 +1712,7 @@ impl Session {
             reasoning_effort,
             reasoning_summary,
             session_source,
+            environments: session_configuration.environments.clone(),
             environment,
             cwd,
             current_date: Some(current_date),
@@ -1724,6 +1764,7 @@ impl Session {
         skills_watcher: Arc<SkillsWatcher>,
         agent_control: AgentControl,
         environment: Option<Arc<Environment>>,
+        environment_manager: Arc<EnvironmentManager>,
         analytics_events_client: Option<AnalyticsEventsClient>,
     ) -> anyhow::Result<Arc<Self>> {
         debug!(
@@ -2178,6 +2219,7 @@ impl Session {
                 config.js_repl_node_path.clone(),
             ),
             environment,
+            environment_manager,
         };
         services
             .model_client
@@ -2618,6 +2660,8 @@ impl Session {
         &self,
         updates: SessionSettingsUpdate,
     ) -> ConstraintResult<()> {
+        self.validate_selected_environment_update(updates.environments.as_ref())
+            .await?;
         let mut state = self.state.lock().await;
 
         match state.session_configuration.apply(&updates) {
@@ -2656,6 +2700,20 @@ impl Session {
         sub_id: String,
         updates: SessionSettingsUpdate,
     ) -> ConstraintResult<Arc<TurnContext>> {
+        if let Err(err) = self
+            .validate_selected_environment_update(updates.environments.as_ref())
+            .await
+        {
+            self.send_event_raw(Event {
+                id: sub_id.clone(),
+                msg: EventMsg::Error(ErrorEvent {
+                    message: err.to_string(),
+                    codex_error_info: Some(CodexErrorInfo::BadRequest),
+                }),
+            })
+            .await;
+            return Err(err);
+        }
         let (
             session_configuration,
             sandbox_policy_changed,
@@ -2723,6 +2781,17 @@ impl Session {
         final_output_json_schema: Option<Option<Value>>,
     ) -> Arc<TurnContext> {
         let per_turn_config = Self::build_per_turn_config(&session_configuration);
+        let environment = self
+            .services
+            .environment_manager
+            .environment(Self::selected_environment_id(
+                &session_configuration.environments,
+            ))
+            .await
+            .unwrap_or_else(|err| {
+                error!("failed to create turn environment: {err}");
+                None
+            });
         {
             let mcp_connection_manager = self.services.mcp_connection_manager.read().await;
             mcp_connection_manager.set_approval_policy(&session_configuration.approval_policy);
@@ -2745,9 +2814,7 @@ impl Session {
             .await;
         let effective_skill_roots = plugin_outcome.effective_skill_roots();
         let skills_input = skills_load_input_from_config(&per_turn_config, effective_skill_roots);
-        let fs = self
-            .services
-            .environment
+        let fs = environment
             .as_ref()
             .map(|environment| environment.get_filesystem());
         let skills_outcome = Arc::new(
@@ -2777,7 +2844,7 @@ impl Session {
                     )
                     .then(|| started_proxy.proxy())
                 }),
-            self.services.environment.clone(),
+            environment,
             sub_id,
             Arc::clone(&self.js_repl),
             skills_outcome,
@@ -2805,6 +2872,30 @@ impl Session {
             )
             .await;
         }
+    }
+
+    fn selected_environment_id(environments: &[SessionEnvironment]) -> Option<&str> {
+        environments
+            .first()
+            .map(|environment| environment.environment_id.as_str())
+    }
+
+    async fn validate_selected_environment_update(
+        &self,
+        environments: Option<&Vec<codex_protocol::protocol::TurnEnvironment>>,
+    ) -> ConstraintResult<()> {
+        let Some(environment_id) = environments
+            .and_then(|environments| environments.first())
+            .map(|environment| environment.environment_id.as_str())
+        else {
+            return Ok(());
+        };
+        self.services
+            .environment_manager
+            .environment(Some(environment_id))
+            .await
+            .map(|_| ())
+            .map_err(|err| anyhow::anyhow!(err.to_string()))
     }
 
     pub(crate) async fn new_default_turn(&self) -> Arc<TurnContext> {
@@ -4769,6 +4860,7 @@ async fn submission_loop(sess: Arc<Session>, config: Arc<Config>, rx_sub: Receiv
                     false
                 }
                 Op::OverrideTurnContext {
+                    environments,
                     cwd,
                     approval_policy,
                     approvals_reviewer,
@@ -4795,6 +4887,7 @@ async fn submission_loop(sess: Arc<Session>, config: Arc<Config>, rx_sub: Receiv
                         &sess,
                         sub.id.clone(),
                         SessionSettingsUpdate {
+                            environments,
                             cwd,
                             approval_policy,
                             approvals_reviewer,
@@ -6094,6 +6187,7 @@ async fn spawn_review_thread(
         compact_prompt: parent_turn_context.compact_prompt.clone(),
         collaboration_mode: parent_turn_context.collaboration_mode.clone(),
         personality: parent_turn_context.personality,
+        environments: parent_turn_context.environments.clone(),
         approval_policy: parent_turn_context.approval_policy.clone(),
         sandbox_policy: parent_turn_context.sandbox_policy.clone(),
         file_system_sandbox_policy: parent_turn_context.file_system_sandbox_policy.clone(),

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -430,6 +430,7 @@ pub(crate) struct CodexSpawnArgs {
     pub(crate) auth_manager: Arc<AuthManager>,
     pub(crate) models_manager: Arc<ModelsManager>,
     pub(crate) environment_manager: Arc<EnvironmentManager>,
+    pub(crate) environment_id: Option<String>,
     pub(crate) skills_manager: Arc<SkillsManager>,
     pub(crate) plugins_manager: Arc<PluginsManager>,
     pub(crate) mcp_manager: Arc<McpManager>,
@@ -483,6 +484,7 @@ impl Codex {
             auth_manager,
             models_manager,
             environment_manager,
+            environment_id,
             skills_manager,
             plugins_manager,
             mcp_manager,
@@ -503,7 +505,7 @@ impl Codex {
         let (tx_event, rx_event) = async_channel::unbounded();
 
         let environment = environment_manager
-            .current()
+            .environment(environment_id.as_deref())
             .await
             .map_err(|err| CodexErr::Fatal(format!("failed to create environment: {err}")))?;
         let fs = environment

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -431,6 +431,7 @@ pub(crate) struct CodexSpawnArgs {
     pub(crate) models_manager: Arc<ModelsManager>,
     pub(crate) environment_manager: Arc<EnvironmentManager>,
     pub(crate) environment_id: Option<String>,
+    pub(crate) requested_cwd: Option<PathBuf>,
     pub(crate) skills_manager: Arc<SkillsManager>,
     pub(crate) plugins_manager: Arc<PluginsManager>,
     pub(crate) mcp_manager: Arc<McpManager>,
@@ -485,6 +486,7 @@ impl Codex {
             models_manager,
             environment_manager,
             environment_id,
+            requested_cwd,
             skills_manager,
             plugins_manager,
             mcp_manager,
@@ -508,6 +510,20 @@ impl Codex {
             .environment(environment_id.as_deref())
             .await
             .map_err(|err| CodexErr::Fatal(format!("failed to create environment: {err}")))?;
+        if requested_cwd.is_none()
+            && let Some(default_cwd) = environment
+                .as_ref()
+                .and_then(|environment| environment.default_cwd())
+        {
+            config.cwd =
+                codex_utils_absolute_path::AbsolutePathBuf::from_absolute_path(default_cwd)
+                    .map_err(|err| {
+                        CodexErr::Fatal(format!(
+                            "failed to resolve environment default cwd {}: {err}",
+                            default_cwd.display()
+                        ))
+                    })?;
+        }
         let fs = environment
             .as_ref()
             .map(|environment| environment.get_filesystem());

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -430,8 +430,6 @@ pub(crate) struct CodexSpawnArgs {
     pub(crate) auth_manager: Arc<AuthManager>,
     pub(crate) models_manager: Arc<ModelsManager>,
     pub(crate) environment_manager: Arc<EnvironmentManager>,
-    pub(crate) environment_id: Option<String>,
-    pub(crate) requested_cwd: Option<PathBuf>,
     pub(crate) skills_manager: Arc<SkillsManager>,
     pub(crate) plugins_manager: Arc<PluginsManager>,
     pub(crate) mcp_manager: Arc<McpManager>,
@@ -485,8 +483,6 @@ impl Codex {
             auth_manager,
             models_manager,
             environment_manager,
-            environment_id,
-            requested_cwd,
             skills_manager,
             plugins_manager,
             mcp_manager,
@@ -507,23 +503,9 @@ impl Codex {
         let (tx_event, rx_event) = async_channel::unbounded();
 
         let environment = environment_manager
-            .environment(environment_id.as_deref())
+            .current()
             .await
             .map_err(|err| CodexErr::Fatal(format!("failed to create environment: {err}")))?;
-        if requested_cwd.is_none()
-            && let Some(default_cwd) = environment
-                .as_ref()
-                .and_then(|environment| environment.default_cwd())
-        {
-            config.cwd =
-                codex_utils_absolute_path::AbsolutePathBuf::from_absolute_path(default_cwd)
-                    .map_err(|err| {
-                        CodexErr::Fatal(format!(
-                            "failed to resolve environment default cwd {}: {err}",
-                            default_cwd.display()
-                        ))
-                    })?;
-        }
         let fs = environment
             .as_ref()
             .map(|environment| environment.get_filesystem());

--- a/codex-rs/core/src/codex_delegate.rs
+++ b/codex-rs/core/src/codex_delegate.rs
@@ -83,6 +83,7 @@ pub(crate) async fn run_codex_thread_interactive(
             parent_ctx.environment.as_deref(),
         )),
         environment_id: None,
+        requested_cwd: None,
         skills_manager: Arc::clone(&parent_session.services.skills_manager),
         plugins_manager: Arc::clone(&parent_session.services.plugins_manager),
         mcp_manager: Arc::clone(&parent_session.services.mcp_manager),

--- a/codex-rs/core/src/codex_delegate.rs
+++ b/codex-rs/core/src/codex_delegate.rs
@@ -82,8 +82,6 @@ pub(crate) async fn run_codex_thread_interactive(
         environment_manager: Arc::new(EnvironmentManager::from_environment(
             parent_ctx.environment.as_deref(),
         )),
-        environment_id: None,
-        requested_cwd: None,
         skills_manager: Arc::clone(&parent_session.services.skills_manager),
         plugins_manager: Arc::clone(&parent_session.services.plugins_manager),
         mcp_manager: Arc::clone(&parent_session.services.mcp_manager),

--- a/codex-rs/core/src/codex_delegate.rs
+++ b/codex-rs/core/src/codex_delegate.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 use async_channel::Receiver;
 use async_channel::Sender;
 use codex_async_utils::OrCancelExt;
-use codex_exec_server::EnvironmentManager;
 use codex_protocol::protocol::ApplyPatchApprovalRequestEvent;
 use codex_protocol::protocol::Event;
 use codex_protocol::protocol::EventMsg;
@@ -79,9 +78,7 @@ pub(crate) async fn run_codex_thread_interactive(
         config,
         auth_manager,
         models_manager,
-        environment_manager: Arc::new(EnvironmentManager::from_environment(
-            parent_ctx.environment.as_deref(),
-        )),
+        environment_manager: Arc::clone(&parent_session.services.environment_manager),
         skills_manager: Arc::clone(&parent_session.services.skills_manager),
         plugins_manager: Arc::clone(&parent_session.services.plugins_manager),
         mcp_manager: Arc::clone(&parent_session.services.mcp_manager),
@@ -97,6 +94,11 @@ pub(crate) async fn run_codex_thread_interactive(
         inherited_exec_policy: Some(Arc::clone(&parent_session.services.exec_policy)),
         parent_trace: None,
         analytics_events_client: Some(parent_session.services.analytics_events_client.clone()),
+        environment_ids: parent_ctx
+            .environments
+            .iter()
+            .map(|environment| environment.environment_id.clone())
+            .collect(),
     }))
     .await?;
     if parent_session.enabled(codex_features::Feature::GeneralAnalytics) {

--- a/codex-rs/core/src/codex_delegate.rs
+++ b/codex-rs/core/src/codex_delegate.rs
@@ -82,6 +82,7 @@ pub(crate) async fn run_codex_thread_interactive(
         environment_manager: Arc::new(EnvironmentManager::from_environment(
             parent_ctx.environment.as_deref(),
         )),
+        environment_id: None,
         skills_manager: Arc::clone(&parent_session.services.skills_manager),
         plugins_manager: Arc::clone(&parent_session.services.plugins_manager),
         mcp_manager: Arc::clone(&parent_session.services.mcp_manager),

--- a/codex-rs/core/src/codex_tests.rs
+++ b/codex-rs/core/src/codex_tests.rs
@@ -1576,6 +1576,7 @@ async fn fork_startup_context_then_first_turn_diff_snapshot() -> anyhow::Result<
     forked
         .thread
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: Some(AskForApproval::Never),
             approvals_reviewer: None,
@@ -3603,6 +3604,7 @@ fn submission_dispatch_span_uses_debug_for_realtime_audio() {
 fn op_kind_distinguishes_turn_ops() {
     assert_eq!(
         Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,

--- a/codex-rs/core/src/codex_tests_guardian.rs
+++ b/codex-rs/core/src/codex_tests_guardian.rs
@@ -435,8 +435,6 @@ async fn guardian_subagent_does_not_inherit_parent_exec_policy_rules() {
         auth_manager,
         models_manager,
         environment_manager: Arc::new(EnvironmentManager::new(/*exec_server_url*/ None)),
-        environment_id: None,
-        requested_cwd: None,
         skills_manager,
         plugins_manager,
         mcp_manager,

--- a/codex-rs/core/src/codex_tests_guardian.rs
+++ b/codex-rs/core/src/codex_tests_guardian.rs
@@ -435,6 +435,7 @@ async fn guardian_subagent_does_not_inherit_parent_exec_policy_rules() {
         auth_manager,
         models_manager,
         environment_manager: Arc::new(EnvironmentManager::new(/*exec_server_url*/ None)),
+        environment_id: None,
         skills_manager,
         plugins_manager,
         mcp_manager,

--- a/codex-rs/core/src/codex_tests_guardian.rs
+++ b/codex-rs/core/src/codex_tests_guardian.rs
@@ -436,6 +436,7 @@ async fn guardian_subagent_does_not_inherit_parent_exec_policy_rules() {
         models_manager,
         environment_manager: Arc::new(EnvironmentManager::new(/*exec_server_url*/ None)),
         environment_id: None,
+        requested_cwd: None,
         skills_manager,
         plugins_manager,
         mcp_manager,

--- a/codex-rs/core/src/codex_tests_guardian.rs
+++ b/codex-rs/core/src/codex_tests_guardian.rs
@@ -452,6 +452,7 @@ async fn guardian_subagent_does_not_inherit_parent_exec_policy_rules() {
         user_shell_override: None,
         parent_trace: None,
         analytics_events_client: None,
+        environment_ids: vec!["local".to_string()],
     })
     .await
     .expect("spawn guardian subagent");

--- a/codex-rs/core/src/codex_thread.rs
+++ b/codex-rs/core/src/codex_thread.rs
@@ -4,6 +4,7 @@ use crate::codex::SteerInputError;
 use crate::config::ConstraintResult;
 use crate::file_watcher::WatchRegistration;
 use codex_exec_server::Environment;
+use codex_exec_server::EnvironmentManager;
 use codex_features::Feature;
 use codex_protocol::config_types::ApprovalsReviewer;
 use codex_protocol::config_types::Personality;
@@ -147,6 +148,10 @@ impl CodexThread {
 
     pub(crate) fn selected_environment(&self) -> Option<std::sync::Arc<Environment>> {
         self.codex.session.services.environment.clone()
+    }
+
+    pub(crate) fn environment_manager(&self) -> std::sync::Arc<EnvironmentManager> {
+        self.codex.session.services.environment_manager.clone()
     }
 
     /// Records a user-role session-prefix message without creating a new user turn boundary.

--- a/codex-rs/core/src/codex_thread.rs
+++ b/codex-rs/core/src/codex_thread.rs
@@ -3,6 +3,7 @@ use crate::codex::Codex;
 use crate::codex::SteerInputError;
 use crate::config::ConstraintResult;
 use crate::file_watcher::WatchRegistration;
+use codex_exec_server::Environment;
 use codex_features::Feature;
 use codex_protocol::config_types::ApprovalsReviewer;
 use codex_protocol::config_types::Personality;
@@ -142,6 +143,10 @@ impl CodexThread {
 
     pub(crate) async fn total_token_usage(&self) -> Option<TokenUsage> {
         self.codex.session.total_token_usage().await
+    }
+
+    pub(crate) fn selected_environment(&self) -> Option<std::sync::Arc<Environment>> {
+        self.codex.session.services.environment.clone()
     }
 
     /// Records a user-role session-prefix message without creating a new user turn boundary.

--- a/codex-rs/core/src/state/service.rs
+++ b/codex-rs/core/src/state/service.rs
@@ -18,6 +18,7 @@ use crate::tools::sandboxing::ApprovalStore;
 use crate::unified_exec::UnifiedExecProcessManager;
 use codex_analytics::AnalyticsEventsClient;
 use codex_exec_server::Environment;
+use codex_exec_server::EnvironmentManager;
 use codex_hooks::Hooks;
 use codex_login::AuthManager;
 use codex_mcp::McpConnectionManager;
@@ -65,4 +66,5 @@ pub(crate) struct SessionServices {
     pub(crate) model_client: ModelClient,
     pub(crate) code_mode_service: CodeModeService,
     pub(crate) environment: Option<Arc<Environment>>,
+    pub(crate) environment_manager: Arc<EnvironmentManager>,
 }

--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -488,6 +488,7 @@ impl ThreadManager {
             persist_extended_history,
             /*metrics_service_name*/ None,
             /*parent_trace*/ None,
+            /*environment_id*/ None,
         ))
         .await
     }
@@ -500,6 +501,7 @@ impl ThreadManager {
         persist_extended_history: bool,
         metrics_service_name: Option<String>,
         parent_trace: Option<W3cTraceContext>,
+        environment_id: Option<String>,
     ) -> CodexResult<NewThread> {
         Box::pin(self.state.spawn_thread(
             config,
@@ -511,6 +513,7 @@ impl ThreadManager {
             metrics_service_name,
             parent_trace,
             /*user_shell_override*/ None,
+            environment_id,
         ))
         .await
     }
@@ -551,6 +554,7 @@ impl ThreadManager {
             /*metrics_service_name*/ None,
             parent_trace,
             /*user_shell_override*/ None,
+            /*environment_id*/ None,
         ))
         .await
     }
@@ -570,6 +574,7 @@ impl ThreadManager {
             /*metrics_service_name*/ None,
             /*parent_trace*/ None,
             /*user_shell_override*/ Some(user_shell_override),
+            /*environment_id*/ None,
         ))
         .await
     }
@@ -592,6 +597,7 @@ impl ThreadManager {
             /*metrics_service_name*/ None,
             /*parent_trace*/ None,
             /*user_shell_override*/ Some(user_shell_override),
+            /*environment_id*/ None,
         ))
         .await
     }
@@ -700,6 +706,7 @@ impl ThreadManager {
             /*metrics_service_name*/ None,
             parent_trace,
             /*user_shell_override*/ None,
+            /*environment_id*/ None,
         ))
         .await
     }
@@ -801,6 +808,7 @@ impl ThreadManagerState {
             inherited_exec_policy,
             /*parent_trace*/ None,
             /*user_shell_override*/ None,
+            /*environment_id*/ None,
         ))
         .await
     }
@@ -828,6 +836,7 @@ impl ThreadManagerState {
             inherited_exec_policy,
             /*parent_trace*/ None,
             /*user_shell_override*/ None,
+            /*environment_id*/ None,
         ))
         .await
     }
@@ -856,6 +865,7 @@ impl ThreadManagerState {
             inherited_exec_policy,
             /*parent_trace*/ None,
             /*user_shell_override*/ None,
+            /*environment_id*/ None,
         ))
         .await
     }
@@ -873,6 +883,7 @@ impl ThreadManagerState {
         metrics_service_name: Option<String>,
         parent_trace: Option<W3cTraceContext>,
         user_shell_override: Option<crate::shell::Shell>,
+        environment_id: Option<String>,
     ) -> CodexResult<NewThread> {
         Box::pin(self.spawn_thread_with_source(
             config,
@@ -887,6 +898,7 @@ impl ThreadManagerState {
             /*inherited_exec_policy*/ None,
             parent_trace,
             user_shell_override,
+            environment_id,
         ))
         .await
     }
@@ -906,10 +918,11 @@ impl ThreadManagerState {
         inherited_exec_policy: Option<Arc<crate::exec_policy::ExecPolicyManager>>,
         parent_trace: Option<W3cTraceContext>,
         user_shell_override: Option<crate::shell::Shell>,
+        environment_id: Option<String>,
     ) -> CodexResult<NewThread> {
         let environment = self
             .environment_manager
-            .current()
+            .environment(environment_id.as_deref())
             .await
             .map_err(|err| CodexErr::Fatal(format!("failed to create environment: {err}")))?;
         let watch_registration = match environment.as_ref() {
@@ -932,6 +945,7 @@ impl ThreadManagerState {
             auth_manager,
             models_manager: Arc::clone(&self.models_manager),
             environment_manager: Arc::clone(&self.environment_manager),
+            environment_id,
             skills_manager: Arc::clone(&self.skills_manager),
             plugins_manager: Arc::clone(&self.plugins_manager),
             mcp_manager: Arc::clone(&self.mcp_manager),

--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -489,6 +489,7 @@ impl ThreadManager {
             /*metrics_service_name*/ None,
             /*parent_trace*/ None,
             /*environment_id*/ None,
+            /*requested_cwd*/ None,
         ))
         .await
     }
@@ -502,6 +503,7 @@ impl ThreadManager {
         metrics_service_name: Option<String>,
         parent_trace: Option<W3cTraceContext>,
         environment_id: Option<String>,
+        requested_cwd: Option<PathBuf>,
     ) -> CodexResult<NewThread> {
         Box::pin(self.state.spawn_thread(
             config,
@@ -514,6 +516,7 @@ impl ThreadManager {
             parent_trace,
             /*user_shell_override*/ None,
             environment_id,
+            requested_cwd,
         ))
         .await
     }
@@ -555,6 +558,7 @@ impl ThreadManager {
             parent_trace,
             /*user_shell_override*/ None,
             /*environment_id*/ None,
+            /*requested_cwd*/ None,
         ))
         .await
     }
@@ -575,6 +579,7 @@ impl ThreadManager {
             /*parent_trace*/ None,
             /*user_shell_override*/ Some(user_shell_override),
             /*environment_id*/ None,
+            /*requested_cwd*/ None,
         ))
         .await
     }
@@ -598,6 +603,7 @@ impl ThreadManager {
             /*parent_trace*/ None,
             /*user_shell_override*/ Some(user_shell_override),
             /*environment_id*/ None,
+            /*requested_cwd*/ None,
         ))
         .await
     }
@@ -707,6 +713,7 @@ impl ThreadManager {
             parent_trace,
             /*user_shell_override*/ None,
             /*environment_id*/ None,
+            /*requested_cwd*/ None,
         ))
         .await
     }
@@ -809,6 +816,7 @@ impl ThreadManagerState {
             /*parent_trace*/ None,
             /*user_shell_override*/ None,
             /*environment_id*/ None,
+            /*requested_cwd*/ None,
         ))
         .await
     }
@@ -837,6 +845,7 @@ impl ThreadManagerState {
             /*parent_trace*/ None,
             /*user_shell_override*/ None,
             /*environment_id*/ None,
+            /*requested_cwd*/ None,
         ))
         .await
     }
@@ -866,6 +875,7 @@ impl ThreadManagerState {
             /*parent_trace*/ None,
             /*user_shell_override*/ None,
             /*environment_id*/ None,
+            /*requested_cwd*/ None,
         ))
         .await
     }
@@ -884,6 +894,7 @@ impl ThreadManagerState {
         parent_trace: Option<W3cTraceContext>,
         user_shell_override: Option<crate::shell::Shell>,
         environment_id: Option<String>,
+        requested_cwd: Option<PathBuf>,
     ) -> CodexResult<NewThread> {
         Box::pin(self.spawn_thread_with_source(
             config,
@@ -899,6 +910,7 @@ impl ThreadManagerState {
             parent_trace,
             user_shell_override,
             environment_id,
+            requested_cwd,
         ))
         .await
     }
@@ -919,6 +931,7 @@ impl ThreadManagerState {
         parent_trace: Option<W3cTraceContext>,
         user_shell_override: Option<crate::shell::Shell>,
         environment_id: Option<String>,
+        requested_cwd: Option<PathBuf>,
     ) -> CodexResult<NewThread> {
         let environment = self
             .environment_manager
@@ -946,6 +959,7 @@ impl ThreadManagerState {
             models_manager: Arc::clone(&self.models_manager),
             environment_manager: Arc::clone(&self.environment_manager),
             environment_id,
+            requested_cwd,
             skills_manager: Arc::clone(&self.skills_manager),
             plugins_manager: Arc::clone(&self.plugins_manager),
             mcp_manager: Arc::clone(&self.mcp_manager),

--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -489,7 +489,7 @@ impl ThreadManager {
             persist_extended_history,
             /*metrics_service_name*/ None,
             /*parent_trace*/ None,
-            /*environment_id*/ None,
+            /*environment_ids*/ None,
         ))
         .await
     }
@@ -502,7 +502,7 @@ impl ThreadManager {
         persist_extended_history: bool,
         metrics_service_name: Option<String>,
         parent_trace: Option<W3cTraceContext>,
-        environment_id: Option<String>,
+        environment_ids: Option<Vec<String>>,
     ) -> CodexResult<NewThread> {
         Box::pin(self.state.spawn_thread(
             config,
@@ -514,7 +514,7 @@ impl ThreadManager {
             metrics_service_name,
             parent_trace,
             /*user_shell_override*/ None,
-            environment_id,
+            environment_ids,
         ))
         .await
     }
@@ -555,7 +555,7 @@ impl ThreadManager {
             /*metrics_service_name*/ None,
             parent_trace,
             /*user_shell_override*/ None,
-            /*environment_id*/ None,
+            /*environment_ids*/ None,
         ))
         .await
     }
@@ -575,7 +575,7 @@ impl ThreadManager {
             /*metrics_service_name*/ None,
             /*parent_trace*/ None,
             /*user_shell_override*/ Some(user_shell_override),
-            /*environment_id*/ None,
+            /*environment_ids*/ None,
         ))
         .await
     }
@@ -598,7 +598,7 @@ impl ThreadManager {
             /*metrics_service_name*/ None,
             /*parent_trace*/ None,
             /*user_shell_override*/ Some(user_shell_override),
-            /*environment_id*/ None,
+            /*environment_ids*/ None,
         ))
         .await
     }
@@ -707,7 +707,7 @@ impl ThreadManager {
             /*metrics_service_name*/ None,
             parent_trace,
             /*user_shell_override*/ None,
-            /*environment_id*/ None,
+            /*environment_ids*/ None,
         ))
         .await
     }
@@ -809,7 +809,7 @@ impl ThreadManagerState {
             inherited_exec_policy,
             /*parent_trace*/ None,
             /*user_shell_override*/ None,
-            /*environment_id*/ None,
+            /*environment_ids*/ None,
         ))
         .await
     }
@@ -837,7 +837,7 @@ impl ThreadManagerState {
             inherited_exec_policy,
             /*parent_trace*/ None,
             /*user_shell_override*/ None,
-            /*environment_id*/ None,
+            /*environment_ids*/ None,
         ))
         .await
     }
@@ -866,7 +866,7 @@ impl ThreadManagerState {
             inherited_exec_policy,
             /*parent_trace*/ None,
             /*user_shell_override*/ None,
-            /*environment_id*/ None,
+            /*environment_ids*/ None,
         ))
         .await
     }
@@ -884,7 +884,7 @@ impl ThreadManagerState {
         metrics_service_name: Option<String>,
         parent_trace: Option<W3cTraceContext>,
         user_shell_override: Option<crate::shell::Shell>,
-        environment_id: Option<String>,
+        environment_ids: Option<Vec<String>>,
     ) -> CodexResult<NewThread> {
         Box::pin(self.spawn_thread_with_source(
             config,
@@ -899,7 +899,7 @@ impl ThreadManagerState {
             /*inherited_exec_policy*/ None,
             parent_trace,
             user_shell_override,
-            environment_id,
+            environment_ids,
         ))
         .await
     }
@@ -917,9 +917,7 @@ impl ThreadManagerState {
         let Ok(parent_thread) = self.get_thread(*parent_thread_id).await else {
             return Arc::clone(&self.environment_manager);
         };
-        Arc::new(EnvironmentManager::from_environment(
-            parent_thread.selected_environment().as_deref(),
-        ))
+        parent_thread.environment_manager()
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -937,20 +935,33 @@ impl ThreadManagerState {
         inherited_exec_policy: Option<Arc<crate::exec_policy::ExecPolicyManager>>,
         parent_trace: Option<W3cTraceContext>,
         user_shell_override: Option<crate::shell::Shell>,
-        environment_id: Option<String>,
+        environment_ids: Option<Vec<String>>,
     ) -> CodexResult<NewThread> {
-        let environment_manager = if environment_id.is_some() {
+        let environment_manager = if environment_ids
+            .as_ref()
+            .is_some_and(|environment_ids| !environment_ids.is_empty())
+        {
             Arc::clone(&self.environment_manager)
         } else {
             self.inherited_environment_manager_for_source(&session_source)
                 .await
         };
+        let effective_environment_ids = environment_ids
+            .filter(|environment_ids| !environment_ids.is_empty())
+            .unwrap_or_else(|| {
+                environment_manager
+                    .default_environment_id()
+                    .map(|environment_id| vec![environment_id.to_string()])
+                    .unwrap_or_default()
+            });
+        let selected_environment_id = effective_environment_ids.first().cloned();
+        let selected_environment_manager = Arc::new(
+            environment_manager.with_default_environment_id(selected_environment_id.clone()),
+        );
         let environment = environment_manager
-            .environment(environment_id.as_deref())
+            .environment(selected_environment_id.as_deref())
             .await
             .map_err(|err| CodexErr::Fatal(format!("failed to create environment: {err}")))?;
-        let selected_environment_manager =
-            Arc::new(EnvironmentManager::from_environment(environment.as_deref()));
         let watch_registration = match environment.as_ref() {
             Some(environment) if !environment.is_remote() => {
                 self.skills_watcher
@@ -986,6 +997,7 @@ impl ThreadManagerState {
             user_shell_override,
             parent_trace,
             analytics_events_client: self.analytics_events_client.clone(),
+            environment_ids: effective_environment_ids,
         })
         .await?;
         self.finalize_thread_spawn(codex, thread_id, watch_registration)

--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -41,6 +41,7 @@ use codex_protocol::protocol::Op;
 use codex_protocol::protocol::RolloutItem;
 use codex_protocol::protocol::SessionConfiguredEvent;
 use codex_protocol::protocol::SessionSource;
+use codex_protocol::protocol::SubAgentSource;
 use codex_protocol::protocol::TurnAbortReason;
 use codex_protocol::protocol::TurnAbortedEvent;
 use codex_protocol::protocol::W3cTraceContext;
@@ -489,7 +490,6 @@ impl ThreadManager {
             /*metrics_service_name*/ None,
             /*parent_trace*/ None,
             /*environment_id*/ None,
-            /*requested_cwd*/ None,
         ))
         .await
     }
@@ -503,7 +503,6 @@ impl ThreadManager {
         metrics_service_name: Option<String>,
         parent_trace: Option<W3cTraceContext>,
         environment_id: Option<String>,
-        requested_cwd: Option<PathBuf>,
     ) -> CodexResult<NewThread> {
         Box::pin(self.state.spawn_thread(
             config,
@@ -516,7 +515,6 @@ impl ThreadManager {
             parent_trace,
             /*user_shell_override*/ None,
             environment_id,
-            requested_cwd,
         ))
         .await
     }
@@ -558,7 +556,6 @@ impl ThreadManager {
             parent_trace,
             /*user_shell_override*/ None,
             /*environment_id*/ None,
-            /*requested_cwd*/ None,
         ))
         .await
     }
@@ -579,7 +576,6 @@ impl ThreadManager {
             /*parent_trace*/ None,
             /*user_shell_override*/ Some(user_shell_override),
             /*environment_id*/ None,
-            /*requested_cwd*/ None,
         ))
         .await
     }
@@ -603,7 +599,6 @@ impl ThreadManager {
             /*parent_trace*/ None,
             /*user_shell_override*/ Some(user_shell_override),
             /*environment_id*/ None,
-            /*requested_cwd*/ None,
         ))
         .await
     }
@@ -713,7 +708,6 @@ impl ThreadManager {
             parent_trace,
             /*user_shell_override*/ None,
             /*environment_id*/ None,
-            /*requested_cwd*/ None,
         ))
         .await
     }
@@ -816,7 +810,6 @@ impl ThreadManagerState {
             /*parent_trace*/ None,
             /*user_shell_override*/ None,
             /*environment_id*/ None,
-            /*requested_cwd*/ None,
         ))
         .await
     }
@@ -845,7 +838,6 @@ impl ThreadManagerState {
             /*parent_trace*/ None,
             /*user_shell_override*/ None,
             /*environment_id*/ None,
-            /*requested_cwd*/ None,
         ))
         .await
     }
@@ -875,7 +867,6 @@ impl ThreadManagerState {
             /*parent_trace*/ None,
             /*user_shell_override*/ None,
             /*environment_id*/ None,
-            /*requested_cwd*/ None,
         ))
         .await
     }
@@ -894,7 +885,6 @@ impl ThreadManagerState {
         parent_trace: Option<W3cTraceContext>,
         user_shell_override: Option<crate::shell::Shell>,
         environment_id: Option<String>,
-        requested_cwd: Option<PathBuf>,
     ) -> CodexResult<NewThread> {
         Box::pin(self.spawn_thread_with_source(
             config,
@@ -910,9 +900,26 @@ impl ThreadManagerState {
             parent_trace,
             user_shell_override,
             environment_id,
-            requested_cwd,
         ))
         .await
+    }
+
+    async fn inherited_environment_manager_for_source(
+        &self,
+        session_source: &SessionSource,
+    ) -> Arc<EnvironmentManager> {
+        let SessionSource::SubAgent(SubAgentSource::ThreadSpawn {
+            parent_thread_id, ..
+        }) = session_source
+        else {
+            return Arc::clone(&self.environment_manager);
+        };
+        let Ok(parent_thread) = self.get_thread(*parent_thread_id).await else {
+            return Arc::clone(&self.environment_manager);
+        };
+        Arc::new(EnvironmentManager::from_environment(
+            parent_thread.selected_environment().as_deref(),
+        ))
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -931,13 +938,19 @@ impl ThreadManagerState {
         parent_trace: Option<W3cTraceContext>,
         user_shell_override: Option<crate::shell::Shell>,
         environment_id: Option<String>,
-        requested_cwd: Option<PathBuf>,
     ) -> CodexResult<NewThread> {
-        let environment = self
-            .environment_manager
+        let environment_manager = if environment_id.is_some() {
+            Arc::clone(&self.environment_manager)
+        } else {
+            self.inherited_environment_manager_for_source(&session_source)
+                .await
+        };
+        let environment = environment_manager
             .environment(environment_id.as_deref())
             .await
             .map_err(|err| CodexErr::Fatal(format!("failed to create environment: {err}")))?;
+        let selected_environment_manager =
+            Arc::new(EnvironmentManager::from_environment(environment.as_deref()));
         let watch_registration = match environment.as_ref() {
             Some(environment) if !environment.is_remote() => {
                 self.skills_watcher
@@ -957,9 +970,7 @@ impl ThreadManagerState {
             config,
             auth_manager,
             models_manager: Arc::clone(&self.models_manager),
-            environment_manager: Arc::clone(&self.environment_manager),
-            environment_id,
-            requested_cwd,
+            environment_manager: selected_environment_manager,
             skills_manager: Arc::clone(&self.skills_manager),
             plugins_manager: Arc::clone(&self.plugins_manager),
             mcp_manager: Arc::clone(&self.mcp_manager),
@@ -978,7 +989,6 @@ impl ThreadManagerState {
         })
         .await?;
         self.finalize_thread_spawn(codex, thread_id, watch_registration)
-            .await
     }
 
     async fn finalize_thread_spawn(

--- a/codex-rs/core/src/thread_manager_tests.rs
+++ b/codex-rs/core/src/thread_manager_tests.rs
@@ -10,6 +10,8 @@ use codex_protocol::models::ReasoningItemReasoningSummary;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::openai_models::ModelsResponse;
 use codex_protocol::protocol::AgentMessageEvent;
+use codex_protocol::protocol::SessionSource;
+use codex_protocol::protocol::SubAgentSource;
 use codex_protocol::protocol::TurnStartedEvent;
 use codex_protocol::protocol::UserMessageEvent;
 use core_test_support::PathBufExt;
@@ -271,6 +273,68 @@ async fn shutdown_all_threads_bounded_submits_shutdown_to_every_thread() {
     assert!(report.submit_failed.is_empty());
     assert!(report.timed_out.is_empty());
     assert!(manager.list_thread_ids().await.is_empty());
+}
+
+#[tokio::test]
+async fn spawned_subagent_thread_inherits_parent_environment_selection() {
+    let temp_dir = tempdir().expect("tempdir");
+    let mut config = test_config().await;
+    config.codex_home = temp_dir.path().join("codex-home").abs();
+    config.cwd = config.codex_home.abs();
+    std::fs::create_dir_all(&config.codex_home).expect("create codex home");
+
+    let manager = ThreadManager::with_models_provider_and_home_for_tests(
+        CodexAuth::from_api_key("dummy"),
+        config.model_provider.clone(),
+        config.codex_home.to_path_buf(),
+        Arc::new(codex_exec_server::EnvironmentManager::new(Some(
+            "ws://127.0.0.1:8765".to_string(),
+        ))),
+    );
+    let parent_thread = manager
+        .start_thread_with_tools_and_service_name(
+            config.clone(),
+            InitialHistory::New,
+            Vec::new(),
+            /*persist_extended_history*/ false,
+            /*metrics_service_name*/ None,
+            /*parent_trace*/ None,
+            Some("local".to_string()),
+        )
+        .await
+        .expect("start parent thread");
+
+    let child_thread = manager
+        .state
+        .spawn_new_thread_with_source(
+            config,
+            manager.agent_control(),
+            SessionSource::SubAgent(SubAgentSource::ThreadSpawn {
+                parent_thread_id: parent_thread.thread_id,
+                depth: 1,
+                agent_path: None,
+                agent_nickname: None,
+                agent_role: None,
+            }),
+            /*persist_extended_history*/ false,
+            /*metrics_service_name*/ None,
+            /*inherited_shell_snapshot*/ None,
+            /*inherited_exec_policy*/ None,
+        )
+        .await
+        .expect("start child thread");
+
+    let parent_environment = parent_thread
+        .thread
+        .selected_environment()
+        .expect("parent environment");
+    let child_environment = child_thread
+        .thread
+        .selected_environment()
+        .expect("child environment");
+
+    assert!(!parent_environment.is_remote());
+    assert!(!child_environment.is_remote());
 }
 
 #[tokio::test]

--- a/codex-rs/core/tests/suite/collaboration_instructions.rs
+++ b/codex-rs/core/tests/suite/collaboration_instructions.rs
@@ -123,6 +123,7 @@ async fn user_input_includes_collaboration_instructions_after_override() -> Resu
     let collaboration_mode = collab_mode_with_instructions(Some(collab_text));
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -222,6 +223,7 @@ async fn override_then_next_turn_uses_updated_collaboration_instructions() -> Re
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -275,6 +277,7 @@ async fn user_turn_overrides_collaboration_instructions_after_override() -> Resu
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -346,6 +349,7 @@ async fn collaboration_mode_update_emits_new_instruction_message() -> Result<()>
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -374,6 +378,7 @@ async fn collaboration_mode_update_emits_new_instruction_message() -> Result<()>
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -431,6 +436,7 @@ async fn collaboration_mode_update_noop_does_not_append() -> Result<()> {
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -459,6 +465,7 @@ async fn collaboration_mode_update_noop_does_not_append() -> Result<()> {
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -515,6 +522,7 @@ async fn collaboration_mode_update_emits_new_instruction_message_when_mode_chang
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -546,6 +554,7 @@ async fn collaboration_mode_update_emits_new_instruction_message_when_mode_chang
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -606,6 +615,7 @@ async fn collaboration_mode_update_noop_does_not_append_when_mode_is_unchanged()
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -637,6 +647,7 @@ async fn collaboration_mode_update_noop_does_not_append_when_mode_is_unchanged()
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -703,6 +714,7 @@ async fn resume_replays_collaboration_instructions() -> Result<()> {
     initial
         .codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -768,6 +780,7 @@ async fn empty_collaboration_instructions_are_ignored() -> Result<()> {
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,

--- a/codex-rs/core/tests/suite/compact.rs
+++ b/codex-rs/core/tests/suite/compact.rs
@@ -3049,6 +3049,7 @@ async fn snapshot_request_shape_pre_turn_compaction_including_incoming_user_mess
     }
     codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: Some(PathBuf::from(PRETURN_CONTEXT_DIFF_CWD)),
             approval_policy: None,
             approvals_reviewer: None,

--- a/codex-rs/core/tests/suite/compact_remote.rs
+++ b/codex-rs/core/tests/suite/compact_remote.rs
@@ -2063,6 +2063,7 @@ async fn snapshot_request_shape_remote_pre_turn_compaction_including_incoming_us
         if user == "USER_THREE" {
             codex
                 .submit(Op::OverrideTurnContext {
+                    environments: None,
                     cwd: Some(PathBuf::from(PRETURN_CONTEXT_DIFF_CWD)),
                     approval_policy: None,
                     approvals_reviewer: None,
@@ -2176,6 +2177,7 @@ async fn snapshot_request_shape_remote_pre_turn_compaction_strips_incoming_model
 
     codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,

--- a/codex-rs/core/tests/suite/compact_resume_fork.rs
+++ b/codex-rs/core/tests/suite/compact_resume_fork.rs
@@ -571,6 +571,7 @@ async fn snapshot_rollback_followup_turn_trims_context_updates() -> Result<()> {
     std::fs::create_dir_all(&override_cwd)?;
     conversation
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: Some(override_cwd.to_path_buf()),
             approval_policy: None,
             approvals_reviewer: None,

--- a/codex-rs/core/tests/suite/model_overrides.rs
+++ b/codex-rs/core/tests/suite/model_overrides.rs
@@ -26,6 +26,7 @@ async fn override_turn_context_does_not_persist_when_config_exists() {
 
     codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -64,6 +65,7 @@ async fn override_turn_context_does_not_create_config_file() {
 
     codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,

--- a/codex-rs/core/tests/suite/model_switching.rs
+++ b/codex-rs/core/tests/suite/model_switching.rs
@@ -141,6 +141,7 @@ async fn model_change_appends_model_instructions_developer_message() -> Result<(
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -238,6 +239,7 @@ async fn model_and_personality_change_only_appends_model_instructions() -> Resul
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -1019,6 +1021,7 @@ async fn model_switch_to_smaller_model_updates_token_context_window() -> Result<
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,

--- a/codex-rs/core/tests/suite/model_visible_layout.rs
+++ b/codex-rs/core/tests/suite/model_visible_layout.rs
@@ -447,6 +447,7 @@ async fn snapshot_model_visible_layout_resume_override_matches_rollout_model() -
     resumed
         .codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: Some(resume_override_cwd),
             approval_policy: None,
             approvals_reviewer: None,

--- a/codex-rs/core/tests/suite/override_updates.rs
+++ b/codex-rs/core/tests/suite/override_updates.rs
@@ -114,6 +114,7 @@ async fn override_turn_context_without_user_turn_does_not_record_permissions_upd
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: Some(AskForApproval::Never),
             approvals_reviewer: None,
@@ -156,6 +157,7 @@ async fn override_turn_context_without_user_turn_does_not_record_environment_upd
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: Some(new_cwd.path().to_path_buf()),
             approval_policy: None,
             approvals_reviewer: None,
@@ -195,6 +197,7 @@ async fn override_turn_context_without_user_turn_does_not_record_collaboration_u
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,

--- a/codex-rs/core/tests/suite/permissions_messages.rs
+++ b/codex-rs/core/tests/suite/permissions_messages.rs
@@ -98,6 +98,7 @@ async fn permissions_message_added_on_override_change() -> Result<()> {
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: Some(AskForApproval::Never),
             approvals_reviewer: None,
@@ -226,6 +227,7 @@ async fn permissions_message_omitted_when_disabled() -> Result<()> {
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: Some(AskForApproval::Never),
             approvals_reviewer: None,
@@ -312,6 +314,7 @@ async fn resume_replays_permissions_messages() -> Result<()> {
     initial
         .codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: Some(AskForApproval::Never),
             approvals_reviewer: None,
@@ -414,6 +417,7 @@ async fn resume_and_fork_append_permissions_messages() -> Result<()> {
     initial
         .codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: Some(AskForApproval::Never),
             approvals_reviewer: None,

--- a/codex-rs/core/tests/suite/personality.rs
+++ b/codex-rs/core/tests/suite/personality.rs
@@ -343,6 +343,7 @@ async fn user_turn_personality_some_adds_update_message() -> anyhow::Result<()> 
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -448,6 +449,7 @@ async fn user_turn_personality_same_value_does_not_add_update_message() -> anyho
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -566,6 +568,7 @@ async fn user_turn_personality_skips_if_feature_disabled() -> anyhow::Result<()>
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -842,6 +845,7 @@ async fn user_turn_personality_remote_model_template_includes_update_message() -
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,

--- a/codex-rs/core/tests/suite/prompt_caching.rs
+++ b/codex-rs/core/tests/suite/prompt_caching.rs
@@ -433,6 +433,7 @@ async fn overrides_turn_context_but_keeps_cached_prefix_and_key_constant() -> an
     };
     codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: Some(AskForApproval::Never),
             approvals_reviewer: None,
@@ -517,6 +518,7 @@ async fn override_before_first_turn_emits_environment_context() -> anyhow::Resul
 
     codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: Some(AskForApproval::Never),
             approvals_reviewer: None,

--- a/codex-rs/core/tests/suite/remote_models.rs
+++ b/codex-rs/core/tests/suite/remote_models.rs
@@ -358,6 +358,7 @@ async fn remote_models_remote_model_uses_unified_exec() -> Result<()> {
 
     codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -601,6 +602,7 @@ async fn remote_models_apply_remote_base_instructions() -> Result<()> {
 
     codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,

--- a/codex-rs/core/tests/suite/resume.rs
+++ b/codex-rs/core/tests/suite/resume.rs
@@ -418,6 +418,7 @@ async fn resume_model_switch_is_not_duplicated_after_pre_turn_override() -> Resu
     resumed
         .codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,

--- a/codex-rs/core/tests/suite/review.rs
+++ b/codex-rs/core/tests/suite/review.rs
@@ -834,6 +834,7 @@ async fn review_uses_overridden_cwd_for_base_branch_merge_base() {
 
     codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: Some(repo_path.to_path_buf()),
             approval_policy: None,
             approvals_reviewer: None,

--- a/codex-rs/exec-server/src/environment.rs
+++ b/codex-rs/exec-server/src/environment.rs
@@ -35,7 +35,7 @@ struct EnvironmentConfig {
 
 /// Resolves the current or explicitly selected execution environment for a
 /// session.
-pub trait EnvironmentResolver: Send + Sync + std::fmt::Debug {
+pub trait EnvironmentProvider: Send + Sync + std::fmt::Debug {
     async fn current(&self) -> Result<Option<Arc<Environment>>, ExecServerError>;
 
     async fn environment(
@@ -223,7 +223,7 @@ impl EnvironmentManager {
     }
 }
 
-impl EnvironmentResolver for EnvironmentManager {
+impl EnvironmentProvider for EnvironmentManager {
     /// Returns the cached environment, creating it on first access.
     async fn current(&self) -> Result<Option<Arc<Environment>>, ExecServerError> {
         self.current_environment
@@ -268,21 +268,21 @@ impl EnvironmentResolver for EnvironmentManager {
 
 impl EnvironmentManager {
     pub async fn current(&self) -> Result<Option<Arc<Environment>>, ExecServerError> {
-        <Self as EnvironmentResolver>::current(self).await
+        <Self as EnvironmentProvider>::current(self).await
     }
 
     pub async fn environment(
         &self,
         environment_id: Option<&str>,
     ) -> Result<Option<Arc<Environment>>, ExecServerError> {
-        <Self as EnvironmentResolver>::environment(self, environment_id).await
+        <Self as EnvironmentProvider>::environment(self, environment_id).await
     }
 
     pub fn default_cwd(
         &self,
         environment_id: Option<&str>,
     ) -> Result<Option<&Path>, ExecServerError> {
-        <Self as EnvironmentResolver>::default_cwd(self, environment_id)
+        <Self as EnvironmentProvider>::default_cwd(self, environment_id)
     }
 
     async fn local_environment(&self) -> Result<Arc<Environment>, ExecServerError> {

--- a/codex-rs/exec-server/src/environment.rs
+++ b/codex-rs/exec-server/src/environment.rs
@@ -33,6 +33,19 @@ struct EnvironmentConfig {
     default_cwd: Option<PathBuf>,
 }
 
+/// Resolves the current or explicitly selected execution environment for a
+/// session.
+pub trait EnvironmentResolver: Send + Sync + std::fmt::Debug {
+    async fn current(&self) -> Result<Option<Arc<Environment>>, ExecServerError>;
+
+    async fn environment(
+        &self,
+        environment_id: Option<&str>,
+    ) -> Result<Option<Arc<Environment>>, ExecServerError>;
+
+    fn default_cwd(&self, environment_id: Option<&str>) -> Result<Option<&Path>, ExecServerError>;
+}
+
 /// Lazily creates and caches the active environment for a session.
 ///
 /// The manager keeps the session's environment selection stable so subagents
@@ -172,8 +185,47 @@ impl EnvironmentManager {
         self.exec_server_url().is_some()
     }
 
+    fn environment_config(
+        &self,
+        environment_id: Option<&str>,
+    ) -> Result<Option<&EnvironmentConfig>, ExecServerError> {
+        match parse_environment_id(environment_id)? {
+            None => Ok(self.current_environment_config.as_ref()),
+            Some(ExplicitEnvironmentId::Local) => {
+                if self.disabled {
+                    return Err(ExecServerError::Protocol(
+                        "environments are disabled for this session".to_string(),
+                    ));
+                }
+                self.local_environment_config
+                    .as_ref()
+                    .ok_or_else(|| {
+                        ExecServerError::Protocol("local environment is not configured".to_string())
+                    })
+                    .map(Some)
+            }
+            Some(ExplicitEnvironmentId::Remote) => {
+                if self.disabled {
+                    return Err(ExecServerError::Protocol(
+                        "environments are disabled for this session".to_string(),
+                    ));
+                }
+                self.remote_environment_config
+                    .as_ref()
+                    .ok_or_else(|| {
+                        ExecServerError::Protocol(
+                            "remote environment is not configured".to_string(),
+                        )
+                    })
+                    .map(Some)
+            }
+        }
+    }
+}
+
+impl EnvironmentResolver for EnvironmentManager {
     /// Returns the cached environment, creating it on first access.
-    pub async fn current(&self) -> Result<Option<Arc<Environment>>, ExecServerError> {
+    async fn current(&self) -> Result<Option<Arc<Environment>>, ExecServerError> {
         self.current_environment
             .get_or_try_init(|| async {
                 if self.disabled {
@@ -196,7 +248,7 @@ impl EnvironmentManager {
             .map(std::option::Option::<&Arc<Environment>>::cloned)
     }
 
-    pub async fn environment(
+    async fn environment(
         &self,
         environment_id: Option<&str>,
     ) -> Result<Option<Arc<Environment>>, ExecServerError> {
@@ -205,6 +257,32 @@ impl EnvironmentManager {
             Some(ExplicitEnvironmentId::Local) => self.local_environment().await.map(Some),
             Some(ExplicitEnvironmentId::Remote) => self.remote_environment().await.map(Some),
         }
+    }
+
+    fn default_cwd(&self, environment_id: Option<&str>) -> Result<Option<&Path>, ExecServerError> {
+        Ok(self
+            .environment_config(environment_id)?
+            .and_then(|environment_config| environment_config.default_cwd.as_deref()))
+    }
+}
+
+impl EnvironmentManager {
+    pub async fn current(&self) -> Result<Option<Arc<Environment>>, ExecServerError> {
+        <Self as EnvironmentResolver>::current(self).await
+    }
+
+    pub async fn environment(
+        &self,
+        environment_id: Option<&str>,
+    ) -> Result<Option<Arc<Environment>>, ExecServerError> {
+        <Self as EnvironmentResolver>::environment(self, environment_id).await
+    }
+
+    pub fn default_cwd(
+        &self,
+        environment_id: Option<&str>,
+    ) -> Result<Option<&Path>, ExecServerError> {
+        <Self as EnvironmentResolver>::default_cwd(self, environment_id)
     }
 
     async fn local_environment(&self) -> Result<Arc<Environment>, ExecServerError> {
@@ -497,6 +575,7 @@ mod tests {
         .expect("runtime paths");
         let manager = EnvironmentManager::new_with_runtime_paths(
             /*exec_server_url*/ None,
+            /*exec_server_cwd*/ None,
             Some(runtime_paths.clone()),
         );
 
@@ -536,6 +615,25 @@ mod tests {
                 .default_cwd(),
             Some(Path::new("/tmp/session"))
         );
+    }
+
+    #[test]
+    fn environment_manager_reports_default_cwd_for_selected_environment() {
+        let manager = EnvironmentManager::new_with_runtime_paths(
+            Some("ws://127.0.0.1:8765".to_string()),
+            Some(PathBuf::from("/tmp/devbox")),
+            /*local_runtime_paths*/ None,
+        );
+
+        assert_eq!(
+            manager.default_cwd(/*environment_id*/ None),
+            Ok(Some(Path::new("/tmp/devbox")))
+        );
+        assert_eq!(
+            manager.default_cwd(Some("remote")),
+            Ok(Some(Path::new("/tmp/devbox")))
+        );
+        assert_eq!(manager.default_cwd(Some("local")), Ok(None));
     }
 
     #[tokio::test]

--- a/codex-rs/exec-server/src/environment.rs
+++ b/codex-rs/exec-server/src/environment.rs
@@ -1,5 +1,4 @@
-use std::path::Path;
-use std::path::PathBuf;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use tokio::sync::OnceCell;
@@ -16,21 +15,13 @@ use crate::remote_file_system::RemoteFileSystem;
 use crate::remote_process::RemoteProcess;
 
 pub const CODEX_EXEC_SERVER_URL_ENV_VAR: &str = "CODEX_EXEC_SERVER_URL";
-pub const CODEX_EXEC_SERVER_CWD_ENV_VAR: &str = "CODEX_EXEC_SERVER_CWD";
-
 const LOCAL_ENVIRONMENT_ID: &str = "local";
 const REMOTE_ENVIRONMENT_ID: &str = "remote";
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum ExplicitEnvironmentId {
-    Local,
-    Remote,
-}
+type EnvironmentId = String;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct EnvironmentConfig {
     exec_server_url: Option<String>,
-    default_cwd: Option<PathBuf>,
 }
 
 /// Lazily creates and caches the active environment for a session.
@@ -39,14 +30,10 @@ struct EnvironmentConfig {
 /// and follow-up turns preserve an explicit disabled state.
 #[derive(Debug)]
 pub struct EnvironmentManager {
-    current_environment_config: Option<EnvironmentConfig>,
-    local_environment_config: Option<EnvironmentConfig>,
-    remote_environment_config: Option<EnvironmentConfig>,
+    default_environment_id: Option<EnvironmentId>,
+    environment_configs: HashMap<EnvironmentId, EnvironmentConfig>,
+    environment_cache: HashMap<EnvironmentId, Arc<OnceCell<Arc<Environment>>>>,
     local_runtime_paths: Option<ExecServerRuntimePaths>,
-    disabled: bool,
-    current_environment: OnceCell<Option<Arc<Environment>>>,
-    local_environment: OnceCell<Arc<Environment>>,
-    remote_environment: OnceCell<Arc<Environment>>,
 }
 
 impl Default for EnvironmentManager {
@@ -58,48 +45,22 @@ impl Default for EnvironmentManager {
 impl EnvironmentManager {
     /// Builds a manager from the raw `CODEX_EXEC_SERVER_URL` value.
     pub fn new(exec_server_url: Option<String>) -> Self {
-        Self::new_with_runtime_paths(
-            exec_server_url,
-            /*exec_server_cwd*/ None,
-            /*local_runtime_paths*/ None,
-        )
+        Self::new_with_runtime_paths(exec_server_url, /*local_runtime_paths*/ None)
     }
 
     /// Builds a manager from the raw `CODEX_EXEC_SERVER_URL` value and local
     /// runtime paths used when creating local filesystem helpers.
     pub fn new_with_runtime_paths(
         exec_server_url: Option<String>,
-        exec_server_cwd: Option<PathBuf>,
         local_runtime_paths: Option<ExecServerRuntimePaths>,
     ) -> Self {
-        let (exec_server_url, disabled) = normalize_exec_server_url(exec_server_url);
-        let local_environment_config = (!disabled).then_some(EnvironmentConfig {
-            exec_server_url: None,
-            default_cwd: None,
-        });
-        let remote_environment_config =
-            exec_server_url
-                .clone()
-                .map(|exec_server_url| EnvironmentConfig {
-                    exec_server_url: Some(exec_server_url),
-                    default_cwd: exec_server_cwd,
-                });
-        let current_environment_config = if disabled {
-            None
-        } else if remote_environment_config.is_some() {
-            remote_environment_config.clone()
-        } else {
-            local_environment_config.clone()
-        };
+        let (default_environment_id, environment_configs) =
+            bootstrap_environment_set(exec_server_url);
         Self {
-            current_environment_config,
-            local_environment_config,
-            remote_environment_config,
+            default_environment_id,
+            environment_cache: build_environment_cache(&environment_configs),
+            environment_configs,
             local_runtime_paths,
-            disabled,
-            current_environment: OnceCell::new(),
-            local_environment: OnceCell::new(),
-            remote_environment: OnceCell::new(),
         }
     }
 
@@ -115,55 +76,30 @@ impl EnvironmentManager {
     ) -> Self {
         Self::new_with_runtime_paths(
             std::env::var(CODEX_EXEC_SERVER_URL_ENV_VAR).ok(),
-            std::env::var(CODEX_EXEC_SERVER_CWD_ENV_VAR)
-                .ok()
-                .map(PathBuf::from),
             local_runtime_paths,
         )
     }
 
-    /// Builds a manager from the currently selected environment, or from the
-    /// disabled mode when no environment is available.
-    pub fn from_environment(environment: Option<&Environment>) -> Self {
-        match environment {
-            Some(environment) => Self {
-                current_environment_config: Some(EnvironmentConfig {
-                    exec_server_url: environment.exec_server_url().map(str::to_owned),
-                    default_cwd: environment.default_cwd().map(PathBuf::from),
-                }),
-                local_environment_config: Some(EnvironmentConfig {
-                    exec_server_url: None,
-                    default_cwd: None,
-                }),
-                remote_environment_config: environment.exec_server_url().map(|exec_server_url| {
-                    EnvironmentConfig {
-                        exec_server_url: Some(exec_server_url.to_owned()),
-                        default_cwd: environment.default_cwd().map(PathBuf::from),
-                    }
-                }),
-                local_runtime_paths: environment.local_runtime_paths().cloned(),
-                disabled: false,
-                current_environment: OnceCell::new(),
-                local_environment: OnceCell::new(),
-                remote_environment: OnceCell::new(),
-            },
-            None => Self {
-                current_environment_config: None,
-                local_environment_config: None,
-                remote_environment_config: None,
-                local_runtime_paths: None,
-                disabled: true,
-                current_environment: OnceCell::new(),
-                local_environment: OnceCell::new(),
-                remote_environment: OnceCell::new(),
-            },
+    pub fn with_default_environment_id(&self, default_environment_id: Option<String>) -> Self {
+        let default_environment_id = default_environment_id
+            .filter(|environment_id| self.environment_configs.contains_key(environment_id));
+        Self {
+            default_environment_id,
+            environment_configs: self.environment_configs.clone(),
+            environment_cache: self.environment_cache.clone(),
+            local_runtime_paths: self.local_runtime_paths.clone(),
         }
+    }
+
+    pub fn default_environment_id(&self) -> Option<&str> {
+        self.default_environment_id.as_deref()
     }
 
     /// Returns the remote exec-server URL when one is configured.
     pub fn exec_server_url(&self) -> Option<&str> {
-        self.current_environment_config
+        self.default_environment_id
             .as_ref()
+            .and_then(|environment_id| self.environment_configs.get(environment_id))
             .and_then(|config| config.exec_server_url.as_deref())
     }
 
@@ -172,125 +108,49 @@ impl EnvironmentManager {
         self.exec_server_url().is_some()
     }
 
-    fn environment_config(
-        &self,
-        environment_id: Option<&str>,
-    ) -> Result<Option<&EnvironmentConfig>, ExecServerError> {
-        match parse_environment_id(environment_id)? {
-            None => Ok(self.current_environment_config.as_ref()),
-            Some(ExplicitEnvironmentId::Local) => {
-                if self.disabled {
-                    return Err(ExecServerError::Protocol(
-                        "environments are disabled for this session".to_string(),
-                    ));
-                }
-                self.local_environment_config
-                    .as_ref()
-                    .ok_or_else(|| {
-                        ExecServerError::Protocol("local environment is not configured".to_string())
-                    })
-                    .map(Some)
-            }
-            Some(ExplicitEnvironmentId::Remote) => {
-                if self.disabled {
-                    return Err(ExecServerError::Protocol(
-                        "environments are disabled for this session".to_string(),
-                    ));
-                }
-                self.remote_environment_config
-                    .as_ref()
-                    .ok_or_else(|| {
-                        ExecServerError::Protocol(
-                            "remote environment is not configured".to_string(),
-                        )
-                    })
-                    .map(Some)
-            }
-        }
+    fn is_disabled(&self) -> bool {
+        self.default_environment_id.is_none() && self.environment_configs.is_empty()
     }
 
     /// Returns the cached environment, creating it on first access.
     pub async fn current(&self) -> Result<Option<Arc<Environment>>, ExecServerError> {
-        self.current_environment
-            .get_or_try_init(|| async {
-                if self.disabled {
-                    Ok(None)
-                } else {
-                    let Some(environment_config) = self.current_environment_config.clone() else {
-                        return Ok(None);
-                    };
-                    Ok(Some(Arc::new(
-                        Environment::create_with_config(
-                            environment_config,
-                            self.local_runtime_paths.clone(),
-                        )
-                        .await?,
-                    )))
-                }
-            })
-            .await
-            .map(Option::as_ref)
-            .map(std::option::Option::<&Arc<Environment>>::cloned)
+        match self.default_environment_id.as_deref() {
+            Some(environment_id) => self.environment_by_id(environment_id).await.map(Some),
+            None => Ok(None),
+        }
     }
 
     pub async fn environment(
         &self,
         environment_id: Option<&str>,
     ) -> Result<Option<Arc<Environment>>, ExecServerError> {
-        match parse_environment_id(environment_id)? {
+        match normalize_environment_id(environment_id) {
             None => self.current().await,
-            Some(ExplicitEnvironmentId::Local) => self.local_environment().await.map(Some),
-            Some(ExplicitEnvironmentId::Remote) => self.remote_environment().await.map(Some),
+            Some(environment_id) => self.environment_by_id(&environment_id).await.map(Some),
         }
     }
 
-    pub fn default_cwd(
+    async fn environment_by_id(
         &self,
-        environment_id: Option<&str>,
-    ) -> Result<Option<&Path>, ExecServerError> {
-        Ok(self
-            .environment_config(environment_id)?
-            .and_then(|environment_config| environment_config.default_cwd.as_deref()))
-    }
-
-    async fn local_environment(&self) -> Result<Arc<Environment>, ExecServerError> {
-        if self.disabled {
+        environment_id: &str,
+    ) -> Result<Arc<Environment>, ExecServerError> {
+        if self.is_disabled() {
             return Err(ExecServerError::Protocol(
                 "environments are disabled for this session".to_string(),
             ));
         }
-        let Some(environment_config) = self.local_environment_config.clone() else {
-            return Err(ExecServerError::Protocol(
-                "local environment is not configured".to_string(),
-            ));
+        let Some(environment_config) = self.environment_configs.get(environment_id).cloned() else {
+            return Err(ExecServerError::Protocol(format!(
+                "unknown environment id: {environment_id}"
+            )));
+        };
+        let Some(environment_cell) = self.environment_cache.get(environment_id) else {
+            return Err(ExecServerError::Protocol(format!(
+                "unknown environment id: {environment_id}"
+            )));
         };
 
-        self.local_environment
-            .get_or_try_init(|| async {
-                Environment::create_with_config(
-                    environment_config,
-                    self.local_runtime_paths.clone(),
-                )
-                .await
-                .map(Arc::new)
-            })
-            .await
-            .map(Arc::clone)
-    }
-
-    async fn remote_environment(&self) -> Result<Arc<Environment>, ExecServerError> {
-        if self.disabled {
-            return Err(ExecServerError::Protocol(
-                "environments are disabled for this session".to_string(),
-            ));
-        }
-        let Some(environment_config) = self.remote_environment_config.clone() else {
-            return Err(ExecServerError::Protocol(
-                "remote environment is not configured".to_string(),
-            ));
-        };
-
-        self.remote_environment
+        environment_cell
             .get_or_try_init(|| async {
                 Environment::create_with_config(
                     environment_config,
@@ -311,7 +171,6 @@ impl EnvironmentManager {
 #[derive(Clone)]
 pub struct Environment {
     exec_server_url: Option<String>,
-    default_cwd: Option<PathBuf>,
     remote_exec_server_client: Option<ExecServerClient>,
     exec_backend: Arc<dyn ExecBackend>,
     local_runtime_paths: Option<ExecServerRuntimePaths>,
@@ -321,7 +180,6 @@ impl Default for Environment {
     fn default() -> Self {
         Self {
             exec_server_url: None,
-            default_cwd: None,
             remote_exec_server_client: None,
             exec_backend: Arc::new(LocalProcess::default()),
             local_runtime_paths: None,
@@ -349,14 +207,7 @@ impl Environment {
         exec_server_url: Option<String>,
         local_runtime_paths: Option<ExecServerRuntimePaths>,
     ) -> Result<Self, ExecServerError> {
-        Self::create_with_config(
-            EnvironmentConfig {
-                exec_server_url,
-                default_cwd: None,
-            },
-            local_runtime_paths,
-        )
-        .await
+        Self::create_with_config(EnvironmentConfig { exec_server_url }, local_runtime_paths).await
     }
 
     async fn create_with_config(
@@ -395,7 +246,6 @@ impl Environment {
 
         Ok(Self {
             exec_server_url,
-            default_cwd: environment_config.default_cwd,
             remote_exec_server_client,
             exec_backend,
             local_runtime_paths,
@@ -413,10 +263,6 @@ impl Environment {
 
     pub fn local_runtime_paths(&self) -> Option<&ExecServerRuntimePaths> {
         self.local_runtime_paths.as_ref()
-    }
-
-    pub fn default_cwd(&self) -> Option<&Path> {
-        self.default_cwd.as_deref()
     }
 
     pub fn get_exec_backend(&self) -> Arc<dyn ExecBackend> {
@@ -442,21 +288,53 @@ fn normalize_exec_server_url(exec_server_url: Option<String>) -> (Option<String>
     }
 }
 
-fn parse_environment_id(
-    environment_id: Option<&str>,
-) -> Result<Option<ExplicitEnvironmentId>, ExecServerError> {
+fn normalize_environment_id(environment_id: Option<&str>) -> Option<EnvironmentId> {
     match environment_id.map(str::trim) {
-        None | Some("") => Ok(None),
-        Some(environment_id) if environment_id.eq_ignore_ascii_case(LOCAL_ENVIRONMENT_ID) => {
-            Ok(Some(ExplicitEnvironmentId::Local))
-        }
-        Some(environment_id) if environment_id.eq_ignore_ascii_case(REMOTE_ENVIRONMENT_ID) => {
-            Ok(Some(ExplicitEnvironmentId::Remote))
-        }
-        Some(environment_id) => Err(ExecServerError::Protocol(format!(
-            "unknown environment id: {environment_id}"
-        ))),
+        None | Some("") => None,
+        Some(environment_id) => Some(environment_id.to_ascii_lowercase()),
     }
+}
+
+fn bootstrap_environment_set(
+    exec_server_url: Option<String>,
+) -> (
+    Option<EnvironmentId>,
+    HashMap<EnvironmentId, EnvironmentConfig>,
+) {
+    let (exec_server_url, disabled) = normalize_exec_server_url(exec_server_url);
+    if disabled {
+        return (None, HashMap::new());
+    }
+
+    let mut environment_configs = HashMap::from([(
+        LOCAL_ENVIRONMENT_ID.to_string(),
+        EnvironmentConfig {
+            exec_server_url: None,
+        },
+    )]);
+    let default_environment_id = if let Some(exec_server_url) = exec_server_url {
+        environment_configs.insert(
+            REMOTE_ENVIRONMENT_ID.to_string(),
+            EnvironmentConfig {
+                exec_server_url: Some(exec_server_url),
+            },
+        );
+        Some(REMOTE_ENVIRONMENT_ID.to_string())
+    } else {
+        Some(LOCAL_ENVIRONMENT_ID.to_string())
+    };
+
+    (default_environment_id, environment_configs)
+}
+
+fn build_environment_cache(
+    environment_configs: &HashMap<EnvironmentId, EnvironmentConfig>,
+) -> HashMap<EnvironmentId, Arc<OnceCell<Arc<Environment>>>> {
+    environment_configs
+        .keys()
+        .cloned()
+        .map(|environment_id| (environment_id, Arc::new(OnceCell::new())))
+        .collect()
 }
 #[cfg(test)]
 mod tests {
@@ -482,7 +360,7 @@ mod tests {
     fn environment_manager_normalizes_empty_url() {
         let manager = EnvironmentManager::new(Some(String::new()));
 
-        assert!(!manager.disabled);
+        assert_eq!(manager.default_environment_id(), Some("local"));
         assert_eq!(manager.exec_server_url(), None);
         assert!(!manager.is_remote());
     }
@@ -491,7 +369,7 @@ mod tests {
     fn environment_manager_treats_none_value_as_disabled() {
         let manager = EnvironmentManager::new(Some("none".to_string()));
 
-        assert!(manager.disabled);
+        assert_eq!(manager.default_environment_id(), None);
         assert_eq!(manager.exec_server_url(), None);
         assert!(!manager.is_remote());
     }
@@ -505,19 +383,22 @@ mod tests {
     }
 
     #[test]
-    fn environment_manager_carries_remote_default_cwd() {
-        let manager = EnvironmentManager::new_with_runtime_paths(
-            Some("ws://127.0.0.1:8765".to_string()),
-            Some(PathBuf::from("/tmp/devbox")),
-            /*local_runtime_paths*/ None,
-        );
+    fn environment_manager_bootstraps_local_and_remote_entries() {
+        let manager = EnvironmentManager::new(Some("ws://127.0.0.1:8765".to_string()));
 
+        assert_eq!(manager.default_environment_id(), Some("remote"));
+        assert_eq!(manager.environment_configs.len(), 2);
         assert_eq!(
-            manager
-                .remote_environment_config
-                .as_ref()
-                .and_then(|config| config.default_cwd.as_deref()),
-            Some(Path::new("/tmp/devbox"))
+            manager.environment_configs.get("local"),
+            Some(&EnvironmentConfig {
+                exec_server_url: None
+            })
+        );
+        assert_eq!(
+            manager.environment_configs.get("remote"),
+            Some(&EnvironmentConfig {
+                exec_server_url: Some("ws://127.0.0.1:8765".to_string()),
+            })
         );
     }
 
@@ -543,7 +424,6 @@ mod tests {
         .expect("runtime paths");
         let manager = EnvironmentManager::new_with_runtime_paths(
             /*exec_server_url*/ None,
-            /*exec_server_cwd*/ None,
             Some(runtime_paths.clone()),
         );
 
@@ -555,53 +435,11 @@ mod tests {
 
         assert_eq!(environment.local_runtime_paths(), Some(&runtime_paths));
         assert_eq!(
-            EnvironmentManager::from_environment(Some(&environment)).local_runtime_paths,
+            manager
+                .with_default_environment_id(Some("local".to_string()))
+                .local_runtime_paths,
             Some(runtime_paths)
         );
-    }
-
-    #[tokio::test]
-    async fn environment_manager_preserves_default_cwd_from_environment() {
-        let environment = Environment::create_with_config(
-            EnvironmentConfig {
-                exec_server_url: None,
-                default_cwd: Some(PathBuf::from("/tmp/session")),
-            },
-            /*local_runtime_paths*/ None,
-        )
-        .await
-        .expect("create environment");
-
-        let manager = EnvironmentManager::from_environment(Some(&environment));
-
-        assert_eq!(
-            manager
-                .current()
-                .await
-                .expect("get current environment")
-                .expect("local environment")
-                .default_cwd(),
-            Some(Path::new("/tmp/session"))
-        );
-    }
-
-    #[test]
-    fn environment_manager_reports_default_cwd_for_selected_environment() {
-        let manager = EnvironmentManager::new_with_runtime_paths(
-            Some("ws://127.0.0.1:8765".to_string()),
-            Some(PathBuf::from("/tmp/devbox")),
-            /*local_runtime_paths*/ None,
-        );
-
-        assert_eq!(
-            manager.default_cwd(/*environment_id*/ None),
-            Ok(Some(Path::new("/tmp/devbox")))
-        );
-        assert_eq!(
-            manager.default_cwd(Some("remote")),
-            Ok(Some(Path::new("/tmp/devbox")))
-        );
-        assert_eq!(manager.default_cwd(Some("local")), Ok(None));
     }
 
     #[tokio::test]
@@ -642,7 +480,7 @@ mod tests {
 
         assert_eq!(
             err.to_string(),
-            "exec-server protocol error: remote environment is not configured"
+            "exec-server protocol error: unknown environment id: remote"
         );
     }
 

--- a/codex-rs/exec-server/src/environment.rs
+++ b/codex-rs/exec-server/src/environment.rs
@@ -15,6 +15,15 @@ use crate::remote_process::RemoteProcess;
 
 pub const CODEX_EXEC_SERVER_URL_ENV_VAR: &str = "CODEX_EXEC_SERVER_URL";
 
+const LOCAL_ENVIRONMENT_ID: &str = "local";
+const REMOTE_ENVIRONMENT_ID: &str = "remote";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ExplicitEnvironmentId {
+    Local,
+    Remote,
+}
+
 /// Lazily creates and caches the active environment for a session.
 ///
 /// The manager keeps the session's environment selection stable so subagents
@@ -25,6 +34,8 @@ pub struct EnvironmentManager {
     local_runtime_paths: Option<ExecServerRuntimePaths>,
     disabled: bool,
     current_environment: OnceCell<Option<Arc<Environment>>>,
+    local_environment: OnceCell<Arc<Environment>>,
+    remote_environment: OnceCell<Arc<Environment>>,
 }
 
 impl Default for EnvironmentManager {
@@ -51,6 +62,8 @@ impl EnvironmentManager {
             local_runtime_paths,
             disabled,
             current_environment: OnceCell::new(),
+            local_environment: OnceCell::new(),
+            remote_environment: OnceCell::new(),
         }
     }
 
@@ -79,12 +92,16 @@ impl EnvironmentManager {
                 local_runtime_paths: environment.local_runtime_paths().cloned(),
                 disabled: false,
                 current_environment: OnceCell::new(),
+                local_environment: OnceCell::new(),
+                remote_environment: OnceCell::new(),
             },
             None => Self {
                 exec_server_url: None,
                 local_runtime_paths: None,
                 disabled: true,
                 current_environment: OnceCell::new(),
+                local_environment: OnceCell::new(),
+                remote_environment: OnceCell::new(),
             },
         }
     }
@@ -118,6 +135,62 @@ impl EnvironmentManager {
             .await
             .map(Option::as_ref)
             .map(std::option::Option::<&Arc<Environment>>::cloned)
+    }
+
+    pub async fn environment(
+        &self,
+        environment_id: Option<&str>,
+    ) -> Result<Option<Arc<Environment>>, ExecServerError> {
+        match parse_environment_id(environment_id)? {
+            None => self.current().await,
+            Some(ExplicitEnvironmentId::Local) => self.local_environment().await.map(Some),
+            Some(ExplicitEnvironmentId::Remote) => self.remote_environment().await.map(Some),
+        }
+    }
+
+    async fn local_environment(&self) -> Result<Arc<Environment>, ExecServerError> {
+        if self.disabled {
+            return Err(ExecServerError::Protocol(
+                "environments are disabled for this session".to_string(),
+            ));
+        }
+
+        self.local_environment
+            .get_or_try_init(|| async {
+                Environment::create_with_runtime_paths(
+                    /*exec_server_url*/ None,
+                    self.local_runtime_paths.clone(),
+                )
+                .await
+                .map(Arc::new)
+            })
+            .await
+            .map(Arc::clone)
+    }
+
+    async fn remote_environment(&self) -> Result<Arc<Environment>, ExecServerError> {
+        if self.disabled {
+            return Err(ExecServerError::Protocol(
+                "environments are disabled for this session".to_string(),
+            ));
+        }
+        let Some(exec_server_url) = &self.exec_server_url else {
+            return Err(ExecServerError::Protocol(
+                "remote environment is not configured".to_string(),
+            ));
+        };
+
+        self.remote_environment
+            .get_or_try_init(|| async {
+                Environment::create_with_runtime_paths(
+                    Some(exec_server_url.clone()),
+                    self.local_runtime_paths.clone(),
+                )
+                .await
+                .map(Arc::new)
+            })
+            .await
+            .map(Arc::clone)
     }
 }
 
@@ -236,6 +309,23 @@ fn normalize_exec_server_url(exec_server_url: Option<String>) -> (Option<String>
         Some(url) => (Some(url.to_string()), false),
     }
 }
+
+fn parse_environment_id(
+    environment_id: Option<&str>,
+) -> Result<Option<ExplicitEnvironmentId>, ExecServerError> {
+    match environment_id.map(str::trim) {
+        None | Some("") => Ok(None),
+        Some(environment_id) if environment_id.eq_ignore_ascii_case(LOCAL_ENVIRONMENT_ID) => {
+            Ok(Some(ExplicitEnvironmentId::Local))
+        }
+        Some(environment_id) if environment_id.eq_ignore_ascii_case(REMOTE_ENVIRONMENT_ID) => {
+            Ok(Some(ExplicitEnvironmentId::Remote))
+        }
+        Some(environment_id) => Err(ExecServerError::Protocol(format!(
+            "unknown environment id: {environment_id}"
+        ))),
+    }
+}
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -330,6 +420,65 @@ mod tests {
                 .await
                 .expect("get current environment")
                 .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn environment_manager_explicit_local_selection_bypasses_remote_default() {
+        let manager = EnvironmentManager::new(Some("ws://127.0.0.1:8765".to_string()));
+
+        let environment = manager
+            .environment(Some("local"))
+            .await
+            .expect("get explicit local environment")
+            .expect("local environment");
+
+        assert!(!environment.is_remote());
+        assert_eq!(environment.exec_server_url(), None);
+    }
+
+    #[tokio::test]
+    async fn environment_manager_rejects_remote_selection_when_not_configured() {
+        let manager = EnvironmentManager::new(/*exec_server_url*/ None);
+
+        let err = manager
+            .environment(Some("remote"))
+            .await
+            .expect_err("remote selection should fail");
+
+        assert_eq!(
+            err.to_string(),
+            "exec-server protocol error: remote environment is not configured"
+        );
+    }
+
+    #[tokio::test]
+    async fn environment_manager_rejects_explicit_selection_when_disabled() {
+        let manager = EnvironmentManager::new(Some("none".to_string()));
+
+        let err = manager
+            .environment(Some("local"))
+            .await
+            .expect_err("explicit local selection should fail");
+
+        assert_eq!(
+            err.to_string(),
+            "exec-server protocol error: environments are disabled for this session"
+        );
+    }
+
+    #[tokio::test]
+    async fn environment_manager_rejects_unknown_environment_id() {
+        let manager = EnvironmentManager::new(/*exec_server_url*/ None);
+
+        let err = manager
+            .environment(Some("mystery"))
+            .await
+            .expect_err("unknown environment should fail");
+
+        assert_eq!(
+            err.to_string(),
+            "exec-server protocol error: unknown environment id: mystery"
         );
     }
 

--- a/codex-rs/exec-server/src/environment.rs
+++ b/codex-rs/exec-server/src/environment.rs
@@ -33,19 +33,6 @@ struct EnvironmentConfig {
     default_cwd: Option<PathBuf>,
 }
 
-/// Resolves the current or explicitly selected execution environment for a
-/// session.
-pub trait EnvironmentProvider: Send + Sync + std::fmt::Debug {
-    async fn current(&self) -> Result<Option<Arc<Environment>>, ExecServerError>;
-
-    async fn environment(
-        &self,
-        environment_id: Option<&str>,
-    ) -> Result<Option<Arc<Environment>>, ExecServerError>;
-
-    fn default_cwd(&self, environment_id: Option<&str>) -> Result<Option<&Path>, ExecServerError>;
-}
-
 /// Lazily creates and caches the active environment for a session.
 ///
 /// The manager keeps the session's environment selection stable so subagents
@@ -221,11 +208,9 @@ impl EnvironmentManager {
             }
         }
     }
-}
 
-impl EnvironmentProvider for EnvironmentManager {
     /// Returns the cached environment, creating it on first access.
-    async fn current(&self) -> Result<Option<Arc<Environment>>, ExecServerError> {
+    pub async fn current(&self) -> Result<Option<Arc<Environment>>, ExecServerError> {
         self.current_environment
             .get_or_try_init(|| async {
                 if self.disabled {
@@ -248,7 +233,7 @@ impl EnvironmentProvider for EnvironmentManager {
             .map(std::option::Option::<&Arc<Environment>>::cloned)
     }
 
-    async fn environment(
+    pub async fn environment(
         &self,
         environment_id: Option<&str>,
     ) -> Result<Option<Arc<Environment>>, ExecServerError> {
@@ -259,30 +244,13 @@ impl EnvironmentProvider for EnvironmentManager {
         }
     }
 
-    fn default_cwd(&self, environment_id: Option<&str>) -> Result<Option<&Path>, ExecServerError> {
-        Ok(self
-            .environment_config(environment_id)?
-            .and_then(|environment_config| environment_config.default_cwd.as_deref()))
-    }
-}
-
-impl EnvironmentManager {
-    pub async fn current(&self) -> Result<Option<Arc<Environment>>, ExecServerError> {
-        <Self as EnvironmentProvider>::current(self).await
-    }
-
-    pub async fn environment(
-        &self,
-        environment_id: Option<&str>,
-    ) -> Result<Option<Arc<Environment>>, ExecServerError> {
-        <Self as EnvironmentProvider>::environment(self, environment_id).await
-    }
-
     pub fn default_cwd(
         &self,
         environment_id: Option<&str>,
     ) -> Result<Option<&Path>, ExecServerError> {
-        <Self as EnvironmentProvider>::default_cwd(self, environment_id)
+        Ok(self
+            .environment_config(environment_id)?
+            .and_then(|environment_config| environment_config.default_cwd.as_deref()))
     }
 
     async fn local_environment(&self) -> Result<Arc<Environment>, ExecServerError> {

--- a/codex-rs/exec-server/src/environment.rs
+++ b/codex-rs/exec-server/src/environment.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use tokio::sync::OnceCell;
@@ -14,6 +16,7 @@ use crate::remote_file_system::RemoteFileSystem;
 use crate::remote_process::RemoteProcess;
 
 pub const CODEX_EXEC_SERVER_URL_ENV_VAR: &str = "CODEX_EXEC_SERVER_URL";
+pub const CODEX_EXEC_SERVER_CWD_ENV_VAR: &str = "CODEX_EXEC_SERVER_CWD";
 
 const LOCAL_ENVIRONMENT_ID: &str = "local";
 const REMOTE_ENVIRONMENT_ID: &str = "remote";
@@ -24,13 +27,21 @@ enum ExplicitEnvironmentId {
     Remote,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct EnvironmentConfig {
+    exec_server_url: Option<String>,
+    default_cwd: Option<PathBuf>,
+}
+
 /// Lazily creates and caches the active environment for a session.
 ///
 /// The manager keeps the session's environment selection stable so subagents
 /// and follow-up turns preserve an explicit disabled state.
 #[derive(Debug)]
 pub struct EnvironmentManager {
-    exec_server_url: Option<String>,
+    current_environment_config: Option<EnvironmentConfig>,
+    local_environment_config: Option<EnvironmentConfig>,
+    remote_environment_config: Option<EnvironmentConfig>,
     local_runtime_paths: Option<ExecServerRuntimePaths>,
     disabled: bool,
     current_environment: OnceCell<Option<Arc<Environment>>>,
@@ -47,18 +58,43 @@ impl Default for EnvironmentManager {
 impl EnvironmentManager {
     /// Builds a manager from the raw `CODEX_EXEC_SERVER_URL` value.
     pub fn new(exec_server_url: Option<String>) -> Self {
-        Self::new_with_runtime_paths(exec_server_url, /*local_runtime_paths*/ None)
+        Self::new_with_runtime_paths(
+            exec_server_url,
+            /*exec_server_cwd*/ None,
+            /*local_runtime_paths*/ None,
+        )
     }
 
     /// Builds a manager from the raw `CODEX_EXEC_SERVER_URL` value and local
     /// runtime paths used when creating local filesystem helpers.
     pub fn new_with_runtime_paths(
         exec_server_url: Option<String>,
+        exec_server_cwd: Option<PathBuf>,
         local_runtime_paths: Option<ExecServerRuntimePaths>,
     ) -> Self {
         let (exec_server_url, disabled) = normalize_exec_server_url(exec_server_url);
+        let local_environment_config = (!disabled).then_some(EnvironmentConfig {
+            exec_server_url: None,
+            default_cwd: None,
+        });
+        let remote_environment_config =
+            exec_server_url
+                .clone()
+                .map(|exec_server_url| EnvironmentConfig {
+                    exec_server_url: Some(exec_server_url),
+                    default_cwd: exec_server_cwd,
+                });
+        let current_environment_config = if disabled {
+            None
+        } else if remote_environment_config.is_some() {
+            remote_environment_config.clone()
+        } else {
+            local_environment_config.clone()
+        };
         Self {
-            exec_server_url,
+            current_environment_config,
+            local_environment_config,
+            remote_environment_config,
             local_runtime_paths,
             disabled,
             current_environment: OnceCell::new(),
@@ -79,6 +115,9 @@ impl EnvironmentManager {
     ) -> Self {
         Self::new_with_runtime_paths(
             std::env::var(CODEX_EXEC_SERVER_URL_ENV_VAR).ok(),
+            std::env::var(CODEX_EXEC_SERVER_CWD_ENV_VAR)
+                .ok()
+                .map(PathBuf::from),
             local_runtime_paths,
         )
     }
@@ -88,7 +127,20 @@ impl EnvironmentManager {
     pub fn from_environment(environment: Option<&Environment>) -> Self {
         match environment {
             Some(environment) => Self {
-                exec_server_url: environment.exec_server_url().map(str::to_owned),
+                current_environment_config: Some(EnvironmentConfig {
+                    exec_server_url: environment.exec_server_url().map(str::to_owned),
+                    default_cwd: environment.default_cwd().map(PathBuf::from),
+                }),
+                local_environment_config: Some(EnvironmentConfig {
+                    exec_server_url: None,
+                    default_cwd: None,
+                }),
+                remote_environment_config: environment.exec_server_url().map(|exec_server_url| {
+                    EnvironmentConfig {
+                        exec_server_url: Some(exec_server_url.to_owned()),
+                        default_cwd: environment.default_cwd().map(PathBuf::from),
+                    }
+                }),
                 local_runtime_paths: environment.local_runtime_paths().cloned(),
                 disabled: false,
                 current_environment: OnceCell::new(),
@@ -96,7 +148,9 @@ impl EnvironmentManager {
                 remote_environment: OnceCell::new(),
             },
             None => Self {
-                exec_server_url: None,
+                current_environment_config: None,
+                local_environment_config: None,
+                remote_environment_config: None,
                 local_runtime_paths: None,
                 disabled: true,
                 current_environment: OnceCell::new(),
@@ -108,12 +162,14 @@ impl EnvironmentManager {
 
     /// Returns the remote exec-server URL when one is configured.
     pub fn exec_server_url(&self) -> Option<&str> {
-        self.exec_server_url.as_deref()
+        self.current_environment_config
+            .as_ref()
+            .and_then(|config| config.exec_server_url.as_deref())
     }
 
     /// Returns true when this manager is configured to use a remote exec server.
     pub fn is_remote(&self) -> bool {
-        self.exec_server_url.is_some()
+        self.exec_server_url().is_some()
     }
 
     /// Returns the cached environment, creating it on first access.
@@ -123,9 +179,12 @@ impl EnvironmentManager {
                 if self.disabled {
                     Ok(None)
                 } else {
+                    let Some(environment_config) = self.current_environment_config.clone() else {
+                        return Ok(None);
+                    };
                     Ok(Some(Arc::new(
-                        Environment::create_with_runtime_paths(
-                            self.exec_server_url.clone(),
+                        Environment::create_with_config(
+                            environment_config,
                             self.local_runtime_paths.clone(),
                         )
                         .await?,
@@ -154,11 +213,16 @@ impl EnvironmentManager {
                 "environments are disabled for this session".to_string(),
             ));
         }
+        let Some(environment_config) = self.local_environment_config.clone() else {
+            return Err(ExecServerError::Protocol(
+                "local environment is not configured".to_string(),
+            ));
+        };
 
         self.local_environment
             .get_or_try_init(|| async {
-                Environment::create_with_runtime_paths(
-                    /*exec_server_url*/ None,
+                Environment::create_with_config(
+                    environment_config,
                     self.local_runtime_paths.clone(),
                 )
                 .await
@@ -174,7 +238,7 @@ impl EnvironmentManager {
                 "environments are disabled for this session".to_string(),
             ));
         }
-        let Some(exec_server_url) = &self.exec_server_url else {
+        let Some(environment_config) = self.remote_environment_config.clone() else {
             return Err(ExecServerError::Protocol(
                 "remote environment is not configured".to_string(),
             ));
@@ -182,8 +246,8 @@ impl EnvironmentManager {
 
         self.remote_environment
             .get_or_try_init(|| async {
-                Environment::create_with_runtime_paths(
-                    Some(exec_server_url.clone()),
+                Environment::create_with_config(
+                    environment_config,
                     self.local_runtime_paths.clone(),
                 )
                 .await
@@ -201,6 +265,7 @@ impl EnvironmentManager {
 #[derive(Clone)]
 pub struct Environment {
     exec_server_url: Option<String>,
+    default_cwd: Option<PathBuf>,
     remote_exec_server_client: Option<ExecServerClient>,
     exec_backend: Arc<dyn ExecBackend>,
     local_runtime_paths: Option<ExecServerRuntimePaths>,
@@ -210,6 +275,7 @@ impl Default for Environment {
     fn default() -> Self {
         Self {
             exec_server_url: None,
+            default_cwd: None,
             remote_exec_server_client: None,
             exec_backend: Arc::new(LocalProcess::default()),
             local_runtime_paths: None,
@@ -237,7 +303,22 @@ impl Environment {
         exec_server_url: Option<String>,
         local_runtime_paths: Option<ExecServerRuntimePaths>,
     ) -> Result<Self, ExecServerError> {
-        let (exec_server_url, disabled) = normalize_exec_server_url(exec_server_url);
+        Self::create_with_config(
+            EnvironmentConfig {
+                exec_server_url,
+                default_cwd: None,
+            },
+            local_runtime_paths,
+        )
+        .await
+    }
+
+    async fn create_with_config(
+        environment_config: EnvironmentConfig,
+        local_runtime_paths: Option<ExecServerRuntimePaths>,
+    ) -> Result<Self, ExecServerError> {
+        let (exec_server_url, disabled) =
+            normalize_exec_server_url(environment_config.exec_server_url);
         if disabled {
             return Err(ExecServerError::Protocol(
                 "disabled mode does not create an Environment".to_string(),
@@ -268,6 +349,7 @@ impl Environment {
 
         Ok(Self {
             exec_server_url,
+            default_cwd: environment_config.default_cwd,
             remote_exec_server_client,
             exec_backend,
             local_runtime_paths,
@@ -285,6 +367,10 @@ impl Environment {
 
     pub fn local_runtime_paths(&self) -> Option<&ExecServerRuntimePaths> {
         self.local_runtime_paths.as_ref()
+    }
+
+    pub fn default_cwd(&self) -> Option<&Path> {
+        self.default_cwd.as_deref()
     }
 
     pub fn get_exec_backend(&self) -> Arc<dyn ExecBackend> {
@@ -372,6 +458,23 @@ mod tests {
         assert_eq!(manager.exec_server_url(), Some("ws://127.0.0.1:8765"));
     }
 
+    #[test]
+    fn environment_manager_carries_remote_default_cwd() {
+        let manager = EnvironmentManager::new_with_runtime_paths(
+            Some("ws://127.0.0.1:8765".to_string()),
+            Some(PathBuf::from("/tmp/devbox")),
+            /*local_runtime_paths*/ None,
+        );
+
+        assert_eq!(
+            manager
+                .remote_environment_config
+                .as_ref()
+                .and_then(|config| config.default_cwd.as_deref()),
+            Some(Path::new("/tmp/devbox"))
+        );
+    }
+
     #[tokio::test]
     async fn environment_manager_current_caches_environment() {
         let manager = EnvironmentManager::new(/*exec_server_url*/ None);
@@ -407,6 +510,31 @@ mod tests {
         assert_eq!(
             EnvironmentManager::from_environment(Some(&environment)).local_runtime_paths,
             Some(runtime_paths)
+        );
+    }
+
+    #[tokio::test]
+    async fn environment_manager_preserves_default_cwd_from_environment() {
+        let environment = Environment::create_with_config(
+            EnvironmentConfig {
+                exec_server_url: None,
+                default_cwd: Some(PathBuf::from("/tmp/session")),
+            },
+            /*local_runtime_paths*/ None,
+        )
+        .await
+        .expect("create environment");
+
+        let manager = EnvironmentManager::from_environment(Some(&environment));
+
+        assert_eq!(
+            manager
+                .current()
+                .await
+                .expect("get current environment")
+                .expect("local environment")
+                .default_cwd(),
+            Some(Path::new("/tmp/session"))
         );
     }
 

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -371,6 +371,13 @@ pub struct ConversationTextParams {
     pub text: String,
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, JsonSchema, TS)]
+pub struct TurnEnvironment {
+    pub environment_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<PathBuf>,
+}
+
 /// Submission operation
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, JsonSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -485,6 +492,11 @@ pub enum Op {
     /// turns that rely on persistent session-level context (for example,
     /// [`Op::UserInput`]).
     OverrideTurnContext {
+        /// Updated ordered environment selections for future turns. For now
+        /// only the first entry is used to drive execution.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        environments: Option<Vec<TurnEnvironment>>,
+
         /// Updated `cwd` for sandbox/tool calls.
         #[serde(skip_serializing_if = "Option::is_none")]
         cwd: Option<PathBuf>,

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -8384,6 +8384,7 @@ mod tests {
         assert_eq!(
             op_rx.try_recv(),
             Ok(Op::OverrideTurnContext {
+                environments: None,
                 cwd: None,
                 approval_policy: Some(guardian_approvals.approval_policy),
                 approvals_reviewer: Some(guardian_approvals.approvals_reviewer),
@@ -8475,6 +8476,7 @@ mod tests {
         assert_eq!(
             op_rx.try_recv(),
             Ok(Op::OverrideTurnContext {
+                environments: None,
                 cwd: None,
                 approval_policy: None,
                 approvals_reviewer: Some(ApprovalsReviewer::User),
@@ -8554,6 +8556,7 @@ mod tests {
         assert_eq!(
             op_rx.try_recv(),
             Ok(Op::OverrideTurnContext {
+                environments: None,
                 cwd: None,
                 approval_policy: Some(guardian_approvals.approval_policy),
                 approvals_reviewer: Some(guardian_approvals.approvals_reviewer),
@@ -8611,6 +8614,7 @@ mod tests {
         assert_eq!(
             op_rx.try_recv(),
             Ok(Op::OverrideTurnContext {
+                environments: None,
                 cwd: None,
                 approval_policy: None,
                 approvals_reviewer: Some(ApprovalsReviewer::User),
@@ -8670,6 +8674,7 @@ mod tests {
         assert_eq!(
             op_rx.try_recv(),
             Ok(Op::OverrideTurnContext {
+                environments: None,
                 cwd: None,
                 approval_policy: Some(guardian_approvals.approval_policy),
                 approvals_reviewer: Some(guardian_approvals.approvals_reviewer),
@@ -8757,6 +8762,7 @@ guardian_approval = true
         assert_eq!(
             op_rx.try_recv(),
             Ok(Op::OverrideTurnContext {
+                environments: None,
                 cwd: None,
                 approval_policy: None,
                 approvals_reviewer: Some(ApprovalsReviewer::User),

--- a/codex-rs/tui/src/chatwidget/tests/permissions.rs
+++ b/codex-rs/tui/src/chatwidget/tests/permissions.rs
@@ -628,6 +628,7 @@ async fn permissions_selection_sends_approvals_reviewer_in_override_turn_context
     assert_eq!(
         op,
         Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: Some(AskForApproval::OnRequest),
             approvals_reviewer: Some(ApprovalsReviewer::GuardianSubagent),


### PR DESCRIPTION
## Summary
- add the new turn environment list API surface
- extend the internal override op with the new optional field
- initialize the new field to `None` everywhere without wiring behavior yet

## Testing
- not run