### PR TITLE
Initialize environments field at callsites

### DIFF
--- a/codex-rs/app-server/src/message_processor/tracing_tests.rs
+++ b/codex-rs/app-server/src/message_processor/tracing_tests.rs
@@ -618,6 +618,7 @@ async fn turn_start_jsonrpc_span_parents_core_turn_spans() -> Result<()> {
                     personality: None,
                     output_schema: None,
                     collaboration_mode: None,
+                    environments: None,
                 },
             },
             Some(remote_trace),

--- a/codex-rs/core/src/codex_tests.rs
+++ b/codex-rs/core/src/codex_tests.rs
@@ -1576,6 +1576,7 @@ async fn fork_startup_context_then_first_turn_diff_snapshot() -> anyhow::Result<
     forked
         .thread
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: Some(AskForApproval::Never),
             approvals_reviewer: None,
@@ -3603,6 +3604,7 @@ fn submission_dispatch_span_uses_debug_for_realtime_audio() {
 fn op_kind_distinguishes_turn_ops() {
     assert_eq!(
         Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,

--- a/codex-rs/core/src/codex_tests_guardian.rs
+++ b/codex-rs/core/src/codex_tests_guardian.rs
@@ -452,6 +452,7 @@ async fn guardian_subagent_does_not_inherit_parent_exec_policy_rules() {
         user_shell_override: None,
         parent_trace: None,
         analytics_events_client: None,
+        environment_ids: vec!["local".to_string()],
     })
     .await
     .expect("spawn guardian subagent");

--- a/codex-rs/core/tests/suite/collaboration_instructions.rs
+++ b/codex-rs/core/tests/suite/collaboration_instructions.rs
@@ -123,6 +123,7 @@ async fn user_input_includes_collaboration_instructions_after_override() -> Resu
     let collaboration_mode = collab_mode_with_instructions(Some(collab_text));
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -222,6 +223,7 @@ async fn override_then_next_turn_uses_updated_collaboration_instructions() -> Re
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -275,6 +277,7 @@ async fn user_turn_overrides_collaboration_instructions_after_override() -> Resu
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -346,6 +349,7 @@ async fn collaboration_mode_update_emits_new_instruction_message() -> Result<()>
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -374,6 +378,7 @@ async fn collaboration_mode_update_emits_new_instruction_message() -> Result<()>
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -431,6 +436,7 @@ async fn collaboration_mode_update_noop_does_not_append() -> Result<()> {
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -459,6 +465,7 @@ async fn collaboration_mode_update_noop_does_not_append() -> Result<()> {
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -515,6 +522,7 @@ async fn collaboration_mode_update_emits_new_instruction_message_when_mode_chang
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -546,6 +554,7 @@ async fn collaboration_mode_update_emits_new_instruction_message_when_mode_chang
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -606,6 +615,7 @@ async fn collaboration_mode_update_noop_does_not_append_when_mode_is_unchanged()
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -637,6 +647,7 @@ async fn collaboration_mode_update_noop_does_not_append_when_mode_is_unchanged()
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -703,6 +714,7 @@ async fn resume_replays_collaboration_instructions() -> Result<()> {
     initial
         .codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -768,6 +780,7 @@ async fn empty_collaboration_instructions_are_ignored() -> Result<()> {
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,

--- a/codex-rs/core/tests/suite/compact.rs
+++ b/codex-rs/core/tests/suite/compact.rs
@@ -3049,6 +3049,7 @@ async fn snapshot_request_shape_pre_turn_compaction_including_incoming_user_mess
     }
     codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: Some(PathBuf::from(PRETURN_CONTEXT_DIFF_CWD)),
             approval_policy: None,
             approvals_reviewer: None,

--- a/codex-rs/core/tests/suite/compact_remote.rs
+++ b/codex-rs/core/tests/suite/compact_remote.rs
@@ -2063,6 +2063,7 @@ async fn snapshot_request_shape_remote_pre_turn_compaction_including_incoming_us
         if user == "USER_THREE" {
             codex
                 .submit(Op::OverrideTurnContext {
+                    environments: None,
                     cwd: Some(PathBuf::from(PRETURN_CONTEXT_DIFF_CWD)),
                     approval_policy: None,
                     approvals_reviewer: None,
@@ -2176,6 +2177,7 @@ async fn snapshot_request_shape_remote_pre_turn_compaction_strips_incoming_model
 
     codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,

--- a/codex-rs/core/tests/suite/compact_resume_fork.rs
+++ b/codex-rs/core/tests/suite/compact_resume_fork.rs
@@ -571,6 +571,7 @@ async fn snapshot_rollback_followup_turn_trims_context_updates() -> Result<()> {
     std::fs::create_dir_all(&override_cwd)?;
     conversation
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: Some(override_cwd.to_path_buf()),
             approval_policy: None,
             approvals_reviewer: None,

--- a/codex-rs/core/tests/suite/model_overrides.rs
+++ b/codex-rs/core/tests/suite/model_overrides.rs
@@ -26,6 +26,7 @@ async fn override_turn_context_does_not_persist_when_config_exists() {
 
     codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -64,6 +65,7 @@ async fn override_turn_context_does_not_create_config_file() {
 
     codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,

--- a/codex-rs/core/tests/suite/model_switching.rs
+++ b/codex-rs/core/tests/suite/model_switching.rs
@@ -141,6 +141,7 @@ async fn model_change_appends_model_instructions_developer_message() -> Result<(
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -238,6 +239,7 @@ async fn model_and_personality_change_only_appends_model_instructions() -> Resul
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -1019,6 +1021,7 @@ async fn model_switch_to_smaller_model_updates_token_context_window() -> Result<
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,

--- a/codex-rs/core/tests/suite/model_visible_layout.rs
+++ b/codex-rs/core/tests/suite/model_visible_layout.rs
@@ -447,6 +447,7 @@ async fn snapshot_model_visible_layout_resume_override_matches_rollout_model() -
     resumed
         .codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: Some(resume_override_cwd),
             approval_policy: None,
             approvals_reviewer: None,

--- a/codex-rs/core/tests/suite/override_updates.rs
+++ b/codex-rs/core/tests/suite/override_updates.rs
@@ -114,6 +114,7 @@ async fn override_turn_context_without_user_turn_does_not_record_permissions_upd
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: Some(AskForApproval::Never),
             approvals_reviewer: None,
@@ -156,6 +157,7 @@ async fn override_turn_context_without_user_turn_does_not_record_environment_upd
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: Some(new_cwd.path().to_path_buf()),
             approval_policy: None,
             approvals_reviewer: None,
@@ -195,6 +197,7 @@ async fn override_turn_context_without_user_turn_does_not_record_collaboration_u
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,

--- a/codex-rs/core/tests/suite/permissions_messages.rs
+++ b/codex-rs/core/tests/suite/permissions_messages.rs
@@ -98,6 +98,7 @@ async fn permissions_message_added_on_override_change() -> Result<()> {
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: Some(AskForApproval::Never),
             approvals_reviewer: None,
@@ -226,6 +227,7 @@ async fn permissions_message_omitted_when_disabled() -> Result<()> {
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: Some(AskForApproval::Never),
             approvals_reviewer: None,
@@ -312,6 +314,7 @@ async fn resume_replays_permissions_messages() -> Result<()> {
     initial
         .codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: Some(AskForApproval::Never),
             approvals_reviewer: None,
@@ -414,6 +417,7 @@ async fn resume_and_fork_append_permissions_messages() -> Result<()> {
     initial
         .codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: Some(AskForApproval::Never),
             approvals_reviewer: None,

--- a/codex-rs/core/tests/suite/personality.rs
+++ b/codex-rs/core/tests/suite/personality.rs
@@ -343,6 +343,7 @@ async fn user_turn_personality_some_adds_update_message() -> anyhow::Result<()> 
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -448,6 +449,7 @@ async fn user_turn_personality_same_value_does_not_add_update_message() -> anyho
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -566,6 +568,7 @@ async fn user_turn_personality_skips_if_feature_disabled() -> anyhow::Result<()>
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -842,6 +845,7 @@ async fn user_turn_personality_remote_model_template_includes_update_message() -
 
     test.codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,

--- a/codex-rs/core/tests/suite/prompt_caching.rs
+++ b/codex-rs/core/tests/suite/prompt_caching.rs
@@ -433,6 +433,7 @@ async fn overrides_turn_context_but_keeps_cached_prefix_and_key_constant() -> an
     };
     codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: Some(AskForApproval::Never),
             approvals_reviewer: None,
@@ -517,6 +518,7 @@ async fn override_before_first_turn_emits_environment_context() -> anyhow::Resul
 
     codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: Some(AskForApproval::Never),
             approvals_reviewer: None,

--- a/codex-rs/core/tests/suite/remote_models.rs
+++ b/codex-rs/core/tests/suite/remote_models.rs
@@ -358,6 +358,7 @@ async fn remote_models_remote_model_uses_unified_exec() -> Result<()> {
 
     codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,
@@ -601,6 +602,7 @@ async fn remote_models_apply_remote_base_instructions() -> Result<()> {
 
     codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,

--- a/codex-rs/core/tests/suite/resume.rs
+++ b/codex-rs/core/tests/suite/resume.rs
@@ -418,6 +418,7 @@ async fn resume_model_switch_is_not_duplicated_after_pre_turn_override() -> Resu
     resumed
         .codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: None,
             approvals_reviewer: None,

--- a/codex-rs/core/tests/suite/review.rs
+++ b/codex-rs/core/tests/suite/review.rs
@@ -834,6 +834,7 @@ async fn review_uses_overridden_cwd_for_base_branch_merge_base() {
 
     codex
         .submit(Op::OverrideTurnContext {
+            environments: None,
             cwd: Some(repo_path.to_path_buf()),
             approval_policy: None,
             approvals_reviewer: None,

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -8384,6 +8384,7 @@ mod tests {
         assert_eq!(
             op_rx.try_recv(),
             Ok(Op::OverrideTurnContext {
+                environments: None,
                 cwd: None,
                 approval_policy: Some(guardian_approvals.approval_policy),
                 approvals_reviewer: Some(guardian_approvals.approvals_reviewer),
@@ -8475,6 +8476,7 @@ mod tests {
         assert_eq!(
             op_rx.try_recv(),
             Ok(Op::OverrideTurnContext {
+                environments: None,
                 cwd: None,
                 approval_policy: None,
                 approvals_reviewer: Some(ApprovalsReviewer::User),
@@ -8554,6 +8556,7 @@ mod tests {
         assert_eq!(
             op_rx.try_recv(),
             Ok(Op::OverrideTurnContext {
+                environments: None,
                 cwd: None,
                 approval_policy: Some(guardian_approvals.approval_policy),
                 approvals_reviewer: Some(guardian_approvals.approvals_reviewer),
@@ -8611,6 +8614,7 @@ mod tests {
         assert_eq!(
             op_rx.try_recv(),
             Ok(Op::OverrideTurnContext {
+                environments: None,
                 cwd: None,
                 approval_policy: None,
                 approvals_reviewer: Some(ApprovalsReviewer::User),
@@ -8670,6 +8674,7 @@ mod tests {
         assert_eq!(
             op_rx.try_recv(),
             Ok(Op::OverrideTurnContext {
+                environments: None,
                 cwd: None,
                 approval_policy: Some(guardian_approvals.approval_policy),
                 approvals_reviewer: Some(guardian_approvals.approvals_reviewer),
@@ -8757,6 +8762,7 @@ guardian_approval = true
         assert_eq!(
             op_rx.try_recv(),
             Ok(Op::OverrideTurnContext {
+                environments: None,
                 cwd: None,
                 approval_policy: None,
                 approvals_reviewer: Some(ApprovalsReviewer::User),

--- a/codex-rs/tui/src/chatwidget/tests/permissions.rs
+++ b/codex-rs/tui/src/chatwidget/tests/permissions.rs
@@ -628,6 +628,7 @@ async fn permissions_selection_sends_approvals_reviewer_in_override_turn_context
     assert_eq!(
         op,
         Op::OverrideTurnContext {
+            environments: None,
             cwd: None,
             approval_policy: Some(AskForApproval::OnRequest),
             approvals_reviewer: Some(ApprovalsReviewer::GuardianSubagent),


### PR DESCRIPTION
## Summary
- initialize the new `environments` field to `None` at existing callsites
- keep this PR intentionally mechanical so the later wiring diff stays readable

## Testing
- not run