### PR TITLE
Show install-required remote plugin details in TUI

### DIFF
--- a/codex-rs/tui/src/chatwidget/plugins.rs
+++ b/codex-rs/tui/src/chatwidget/plugins.rs
@@ -14,6 +14,7 @@ use crate::render::renderable::Renderable;
 use crate::shimmer::shimmer_spans;
 use crate::tui::FrameRequester;
 use codex_app_server_protocol::PluginDetail;
+use codex_app_server_protocol::PluginDetailsUnavailableReason;
 use codex_app_server_protocol::PluginInstallPolicy;
 use codex_app_server_protocol::PluginInstallResponse;
 use codex_app_server_protocol::PluginListResponse;
@@ -860,6 +861,9 @@ impl ChatWidget {
         if let Some(description) = plugin_detail_description(plugin) {
             header.push(Line::from(description.dim()));
         }
+        if let Some(message) = plugin_details_unavailable_message(plugin) {
+            header.push(Line::from(message.dim()));
+        }
 
         let cwd = self.config.cwd.to_path_buf();
         let plugins_response = plugins_response.clone();
@@ -1052,7 +1056,20 @@ fn plugin_detail_description(plugin: &PluginDetail) -> Option<String> {
         .map(str::to_string)
 }
 
+fn plugin_details_unavailable_message(plugin: &PluginDetail) -> Option<&'static str> {
+    match plugin.details_unavailable_reason {
+        Some(PluginDetailsUnavailableReason::InstallRequiredForRemoteSource) => Some(
+            "Remote Git plugin. Install it to download and view bundled skills, apps, and MCP servers.",
+        ),
+        None => None,
+    }
+}
+
 fn plugin_skill_summary(plugin: &PluginDetail) -> String {
+    if plugin.details_unavailable_reason.is_some() {
+        return "Install required to view bundled skills.".to_string();
+    }
+
     if plugin.skills.is_empty() {
         "No plugin skills.".to_string()
     } else {
@@ -1066,6 +1083,10 @@ fn plugin_skill_summary(plugin: &PluginDetail) -> String {
 }
 
 fn plugin_app_summary(plugin: &PluginDetail) -> String {
+    if plugin.details_unavailable_reason.is_some() {
+        return "Install required to view bundled apps.".to_string();
+    }
+
     if plugin.apps.is_empty() {
         "No plugin apps.".to_string()
     } else {
@@ -1079,6 +1100,10 @@ fn plugin_app_summary(plugin: &PluginDetail) -> String {
 }
 
 fn plugin_mcp_summary(plugin: &PluginDetail) -> String {
+    if plugin.details_unavailable_reason.is_some() {
+        return "Install required to view bundled MCP servers.".to_string();
+    }
+
     if plugin.mcp_servers.is_empty() {
         "No plugin MCP servers.".to_string()
     } else {

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plugin_detail_popup_remote_install_required.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plugin_detail_popup_remote_install_required.snap
@@ -1,0 +1,18 @@
+---
+source: tui/src/chatwidget/tests/popups_and_settings.rs
+expression: strip_osc8_for_snapshot(&popup)
+---
+  Plugins
+  Toolkit · Can be installed · ChatGPT Marketplace
+  Data shared with this app is subject to the app's terms of service and privacy policy. Learn
+  more.
+  Remote tools.
+  Remote Git plugin. Install it to download and view bundled skills, apps, and MCP servers.
+
+› 1. Back to plugins  Return to the plugin list.
+  2. Install plugin   Install this plugin now.
+     Skills           Install required to view bundled skills.
+     Apps             Install required to view bundled apps.
+     MCP Servers      Install required to view bundled MCP servers.
+
+  Press esc to close.

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -76,6 +76,7 @@ pub(super) use codex_app_server_protocol::PatchChangeKind;
 pub(super) use codex_app_server_protocol::PermissionsRequestApprovalParams as AppServerPermissionsRequestApprovalParams;
 pub(super) use codex_app_server_protocol::PluginAuthPolicy;
 pub(super) use codex_app_server_protocol::PluginDetail;
+pub(super) use codex_app_server_protocol::PluginDetailsUnavailableReason;
 pub(super) use codex_app_server_protocol::PluginInstallPolicy;
 pub(super) use codex_app_server_protocol::PluginInterface;
 pub(super) use codex_app_server_protocol::PluginListResponse;

--- a/codex-rs/tui/src/chatwidget/tests/helpers.rs
+++ b/codex-rs/tui/src/chatwidget/tests/helpers.rs
@@ -967,6 +967,7 @@ pub(super) fn plugins_test_detail(
             })
             .collect(),
         mcp_servers: mcp_servers.iter().map(|name| (*name).to_string()).collect(),
+        details_unavailable_reason: None,
     }
 }
 

--- a/codex-rs/tui/src/chatwidget/tests/popups_and_settings.rs
+++ b/codex-rs/tui/src/chatwidget/tests/popups_and_settings.rs
@@ -204,6 +204,44 @@ async fn plugin_detail_popup_snapshot_shows_install_actions_and_capability_summa
 }
 
 #[tokio::test]
+async fn plugin_detail_popup_snapshot_shows_remote_install_required_message() {
+    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    chat.set_feature_enabled(Feature::Plugins, /*enabled*/ true);
+
+    let mut summary = plugins_test_summary(
+        "plugin-toolkit",
+        "toolkit",
+        Some("Toolkit"),
+        Some("Remote tools."),
+        /*installed*/ false,
+        /*enabled*/ true,
+        PluginInstallPolicy::Available,
+    );
+    summary.source = PluginSource::Git {
+        url: "owner/repo".to_string(),
+        path: Some("plugins/toolkit".to_string()),
+        ref_name: None,
+        sha: None,
+    };
+    let response = plugins_test_response(vec![plugins_test_curated_marketplace(vec![
+        summary.clone(),
+    ])]);
+    let cwd = chat.config.cwd.clone();
+    chat.on_plugins_loaded(cwd.to_path_buf(), Ok(response));
+    chat.add_plugins_output();
+    let mut plugin = plugins_test_detail(summary, None, &[], &[], &[]);
+    plugin.details_unavailable_reason =
+        Some(PluginDetailsUnavailableReason::InstallRequiredForRemoteSource);
+    chat.on_plugin_detail_loaded(cwd.to_path_buf(), Ok(PluginReadResponse { plugin }));
+
+    let popup = render_bottom_popup(&chat, /*width*/ 100);
+    assert_chatwidget_snapshot!(
+        "plugin_detail_popup_remote_install_required",
+        strip_osc8_for_snapshot(&popup)
+    );
+}
+
+#[tokio::test]
 async fn plugin_detail_popup_hides_disclosure_for_installed_plugins() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
     chat.set_feature_enabled(Feature::Plugins, /*enabled*/ true);


### PR DESCRIPTION
## Summary
- Teach the TUI plugin detail popup to render the remote install-required state.
- Keep the Install action available for installable remote plugins.
- Add snapshot coverage for the new remote plugin detail screen.

## Context
This sits on `xli-codex/cross-repo-marketplace-read-api`, which adds `detailsUnavailableReason` to `PluginDetail`. When the reason is `installRequiredForRemoteSource`, bundled skills, apps, and MCP servers are intentionally unavailable until install.

## Validation
- `cargo test -p codex-tui plugin_detail_popup`
- `cargo test -p codex-tui`
- `just fix -p codex-tui`