### PR TITLE
mcp: include permission profiles in sandbox state

### DIFF
--- a/codex-rs/codex-mcp/src/mcp_connection_manager.rs
+++ b/codex-rs/codex-mcp/src/mcp_connection_manager.rs
@@ -42,6 +42,7 @@ use codex_protocol::approvals::ElicitationRequest;
 use codex_protocol::approvals::ElicitationRequestEvent;
 use codex_protocol::mcp::CallToolResult;
 use codex_protocol::mcp::RequestId as ProtocolRequestId;
+use codex_protocol::models::PermissionProfile;
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::Event;
 use codex_protocol::protocol::EventMsg;
@@ -646,6 +647,8 @@ pub const MCP_SANDBOX_STATE_META_CAPABILITY: &str = "codex/sandbox-state-meta";
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SandboxState {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permission_profile: Option<PermissionProfile>,
     pub sandbox_policy: SandboxPolicy,
     pub codex_linux_sandbox_exe: Option<PathBuf>,
     pub sandbox_cwd: PathBuf,

--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -519,6 +519,7 @@ async fn augment_mcp_tool_request_meta_with_sandbox_state(
     }
 
     let sandbox_state = serde_json::to_value(SandboxState {
+        permission_profile: Some(turn_context.permission_profile()),
         sandbox_policy: turn_context.sandbox_policy.get().clone(),
         codex_linux_sandbox_exe: turn_context.codex_linux_sandbox_exe.clone(),
         sandbox_cwd: turn_context.cwd.to_path_buf(),


### PR DESCRIPTION
## Why

MCP tool calls can receive a serialized `SandboxState` when a server declares the sandbox-state capability. That state is one of the places MCP runtimes learn what permissions Codex is operating under. As the permissions migration makes `PermissionProfile` the canonical representation, MCP consumers should be able to read that profile directly instead of reconstructing permissions from the legacy `SandboxPolicy`.

## What changed

- Adds optional `permissionProfile` to `codex_mcp::SandboxState`, while keeping `sandboxPolicy` for existing MCP consumers.
- Populates `permissionProfile` from the current `TurnContext` when serializing sandbox state for MCP tool calls.

## Verification

- Current GitHub Actions for this PR are passing.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/18286).
* #18288
* #18287
* __->__ #18286
