### PR TITLE
tests: isolate approval fixtures from host rules

### DIFF
--- a/codex-rs/core/tests/suite/approvals.rs
+++ b/codex-rs/core/tests/suite/approvals.rs
@@ -593,7 +593,7 @@ async fn submit_turn(
             final_output_json_schema: None,
             cwd: test.cwd.path().to_path_buf(),
             approval_policy,
-            approvals_reviewer: None,
+            approvals_reviewer: Some(ApprovalsReviewer::User),
             sandbox_policy,
             permission_profile: None,
             model: session_model,

--- a/codex-rs/core/tests/suite/otel.rs
+++ b/codex-rs/core/tests/suite/otel.rs
@@ -1146,7 +1146,11 @@ async fn handle_container_exec_user_approved_records_tool_decision() {
     mount_sse_once(
         &server,
         sse(vec![
-            ev_local_shell_call("user_approved_call", "completed", vec!["/bin/date"]),
+            ev_local_shell_call(
+                "user_approved_call",
+                "completed",
+                vec!["/usr/bin/touch", "codex-otel-approval-test"],
+            ),
             ev_completed("done"),
         ]),
     )
@@ -1215,7 +1219,11 @@ async fn handle_container_exec_user_approved_for_session_records_tool_decision()
     mount_sse_once(
         &server,
         sse(vec![
-            ev_local_shell_call("user_approved_session_call", "completed", vec!["/bin/date"]),
+            ev_local_shell_call(
+                "user_approved_session_call",
+                "completed",
+                vec!["/usr/bin/touch", "codex-otel-approval-test"],
+            ),
             ev_completed("done"),
         ]),
     )
@@ -1283,7 +1291,11 @@ async fn handle_sandbox_error_user_approves_retry_records_tool_decision() {
     mount_sse_once(
         &server,
         sse(vec![
-            ev_local_shell_call("sandbox_retry_call", "completed", vec!["/bin/date"]),
+            ev_local_shell_call(
+                "sandbox_retry_call",
+                "completed",
+                vec!["/usr/bin/touch", "codex-otel-approval-test"],
+            ),
             ev_completed("done"),
         ]),
     )
@@ -1351,7 +1363,11 @@ async fn handle_container_exec_user_denies_records_tool_decision() {
     mount_sse_once(
         &server,
         sse(vec![
-            ev_local_shell_call("user_denied_call", "completed", vec!["/bin/date"]),
+            ev_local_shell_call(
+                "user_denied_call",
+                "completed",
+                vec!["/usr/bin/touch", "codex-otel-approval-test"],
+            ),
             ev_completed("done"),
         ]),
     )
@@ -1419,7 +1435,11 @@ async fn handle_sandbox_error_user_approves_for_session_records_tool_decision() 
     mount_sse_once(
         &server,
         sse(vec![
-            ev_local_shell_call("sandbox_session_call", "completed", vec!["/bin/date"]),
+            ev_local_shell_call(
+                "sandbox_session_call",
+                "completed",
+                vec!["/usr/bin/touch", "codex-otel-approval-test"],
+            ),
             ev_completed("done"),
         ]),
     )
@@ -1487,7 +1507,11 @@ async fn handle_sandbox_error_user_denies_records_tool_decision() {
     mount_sse_once(
         &server,
         sse(vec![
-            ev_local_shell_call("sandbox_deny_call", "completed", vec!["/bin/date"]),
+            ev_local_shell_call(
+                "sandbox_deny_call",
+                "completed",
+                vec!["/usr/bin/touch", "codex-otel-approval-test"],
+            ),
             ev_completed("done"),
         ]),
     )

--- a/codex-rs/core/tests/suite/permissions_messages.rs
+++ b/codex-rs/core/tests/suite/permissions_messages.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use codex_core::ForkSnapshot;
 use codex_core::config::Constrained;
+use codex_core::config_loader::ConfigLayerStack;
 use codex_core::context::ContextualUserFragment;
 use codex_core::context::PermissionsInstructions;
 use codex_core::load_exec_policy;
@@ -551,6 +552,7 @@ async fn permissions_message_includes_writable_roots() -> Result<()> {
     let mut builder = test_codex().with_config(move |config| {
         config.permissions.approval_policy = Constrained::allow_any(AskForApproval::OnRequest);
         config.permissions.sandbox_policy = Constrained::allow_any(sandbox_policy_for_config);
+        config.config_layer_stack = ConfigLayerStack::default();
     });
     let test = builder.build(&server).await?;
 


### PR DESCRIPTION
## Why

Several approval-focused tests were unintentionally sensitive to host-level rule files. On machines with broader allowed command prefixes, commonly allowed commands such as `/bin/date` could bypass the approval path these tests were meant to exercise, making the fixtures depend on the developer or CI host configuration.

## What changed

- Pins the approval matrix fixture to the explicit user reviewer so it does not inherit a host reviewer.
- Changes OTel approval fixtures to request `/usr/bin/touch codex-otel-approval-test`, avoiding a command that may be pre-approved by local rules.
- Clears the config layer stack for the permissions-message assertion that needs to compare only the permissions text under test.

## Verification

- `env -u CODEX_SANDBOX_NETWORK_DISABLED cargo test -p codex-core --test all approval_matrix_covers_all_modes -- --nocapture`
- `env -u CODEX_SANDBOX_NETWORK_DISABLED cargo test -p codex-core --test all permissions_messages -- --nocapture`
