### PR TITLE
Fix Windows exec policy test flake

### DIFF
--- a/codex-rs/core/src/exec_policy_tests.rs
+++ b/codex-rs/core/src/exec_policy_tests.rs
@@ -1343,7 +1343,7 @@ prefix_rule(pattern=["cat"], decision="allow")
                 policy_src: Some(policy_src.to_string()),
                 command: command.clone(),
                 approval_policy,
-                sandbox_policy: SandboxPolicy::new_read_only_policy(),
+                sandbox_policy: SandboxPolicy::new_workspace_write_policy(),
                 file_system_sandbox_policy: read_only_file_system_sandbox_policy(),
                 sandbox_permissions: SandboxPermissions::UseDefault,
                 prefix_rule: None,


### PR DESCRIPTION
## Summary

This fixes a Windows-only failure in the exec policy multi-segment shell test. The test was meant to verify that a compound shell command only bypasses sandboxing when every parsed segment has an explicit exec policy allow rule.

On Windows, the read-only sandbox setup is intentionally treated as lacking sandbox protection, so the old fixture could take the approval path before reaching the intended bypass assertion. The test now uses the workspace-write sandbox policy, keeping the focus on the per-segment bypass rule while preserving the expected bypass_sandbox false result when only cat is explicitly allowed.