### PR TITLE
Reduce app-server test subprocess log noise

### DIFF
--- a/codex-rs/app-server/tests/common/mcp_process.rs
+++ b/codex-rs/app-server/tests/common/mcp_process.rs
@@ -143,7 +143,7 @@ impl McpProcess {
         cmd.stderr(Stdio::piped());
         cmd.current_dir(codex_home);
         cmd.env("CODEX_HOME", codex_home);
-        cmd.env("RUST_LOG", "info");
+        cmd.env("RUST_LOG", "warn");
         // Keep integration tests isolated from host managed configuration.
         cmd.env(
             "CODEX_APP_SERVER_MANAGED_CONFIG_PATH",


### PR DESCRIPTION
## Summary
- lower the default RUST_LOG for app-server integration subprocesses from info to warn
- keep individual tests able to opt back into info/debug logging through env overrides

## Flake target
- suite::v2::account::set_auth_token_updates_account_and_notifies
- suite::v2::account::set_auth_token_cancels_active_chatgpt_login

## Validation
- just fmt
- cargo test -p codex-app-server --test all suite::v2::account::set_auth_token_updates_account_and_notifies -- --exact
- cargo test -p codex-app-server --test all suite::v2::account::set_auth_token_cancels_active_chatgpt_login -- --exact
- just fix -p codex-app-server