### PR TITLE
Fix config-loader tests after filesystem abstraction race

### DIFF
--- a/codex-rs/core/src/config_loader/tests.rs
+++ b/codex-rs/core/src/config_loader/tests.rs
@@ -749,8 +749,14 @@ deny_read = ["./sensitive", "../shared/secret.txt"]
     )
     .await?;
 
+    let requirements_file = AbsolutePathBuf::try_from(requirements_file)?;
     let mut config_requirements_toml = ConfigRequirementsWithSources::default();
-    load_requirements_toml(&mut config_requirements_toml, &requirements_file).await?;
+    load_requirements_toml(
+        LOCAL_FS.as_ref(),
+        &mut config_requirements_toml,
+        &requirements_file,
+    )
+    .await?;
 
     let permissions = config_requirements_toml
         .permissions
@@ -775,7 +781,7 @@ deny_read = ["./sensitive", "../shared/secret.txt"]
     assert_eq!(
         permissions.source,
         RequirementSource::SystemRequirementsToml {
-            file: AbsolutePathBuf::try_from(requirements_file)?,
+            file: requirements_file,
         }
     );
 
@@ -797,8 +803,14 @@ deny_read = ["./sensitive/**/*.txt"]
     )
     .await?;
 
+    let requirements_file = AbsolutePathBuf::try_from(requirements_file)?;
     let mut config_requirements_toml = ConfigRequirementsWithSources::default();
-    load_requirements_toml(&mut config_requirements_toml, &requirements_file).await?;
+    load_requirements_toml(
+        LOCAL_FS.as_ref(),
+        &mut config_requirements_toml,
+        &requirements_file,
+    )
+    .await?;
 
     let permissions = config_requirements_toml
         .permissions
@@ -824,7 +836,7 @@ deny_read = ["./sensitive/**/*.txt"]
     assert_eq!(
         permissions.source,
         RequirementSource::SystemRequirementsToml {
-            file: AbsolutePathBuf::try_from(requirements_file)?,
+            file: requirements_file,
         }
     );
 


### PR DESCRIPTION
## Why

`origin/main` picked up two changes that crossed in flight:

- #18209 refactored config loading to read through `ExecutorFileSystem`, changing `load_requirements_toml` to take a filesystem handle and an `AbsolutePathBuf`.
- #17740 added managed `deny_read` requirements tests that still called `load_requirements_toml` with the previous two-argument signature.

Once both landed, `just clippy` failed because the new tests no longer matched the current helper API.

## What

- Updates the two managed `deny_read` requirements tests to convert the fixture path to `AbsolutePathBuf` before loading.
- Passes `LOCAL_FS.as_ref()` into `load_requirements_toml` so these tests follow the filesystem abstraction introduced by #18209.

## Verification

- `just clippy`
- `cargo test -p codex-core load_requirements_toml_resolves_deny_read`
- `cargo test -p codex-core --test all unified_exec_enforces_glob_deny_read_policy`
