### PR TITLE
Add core CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Core crate ownership.
+/codex-rs/core/ @openai/codex-core-agent-team
+
+# Keep ownership changes reviewed by the same team.
+/.github/CODEOWNERS @openai/codex-core-agent-team


### PR DESCRIPTION
Adds @openai/codex-core-agent-team as the owner for codex-rs/core/ and protects .github/CODEOWNERS with the same owner.