### PR TITLE
[codex] Avoid parenthesized rendered markdown URLs

### DIFF
--- a/codex-rs/tui/src/markdown_render.rs
+++ b/codex-rs/tui/src/markdown_render.rs
@@ -596,9 +596,8 @@ where
     fn pop_link(&mut self) {
         if let Some(link) = self.link.take() {
             if link.show_destination {
-                self.push_span(" (".into());
+                self.push_span(" - ".into());
                 self.push_span(Span::styled(link.destination, self.styles.link));
-                self.push_span(")".into());
             } else if let Some(local_target_display) = link.local_target_display {
                 if self.pending_marker_line {
                     self.push_line(Line::default());

--- a/codex-rs/tui/src/markdown_render_tests.rs
+++ b/codex-rs/tui/src/markdown_render_tests.rs
@@ -652,9 +652,8 @@ fn link() {
     let text = render_markdown_text("[Link](https://example.com)");
     let expected = Text::from(Line::from_iter([
         "Link".into(),
-        " (".into(),
+        " - ".into(),
         "https://example.com".cyan().underlined(),
-        ")".into(),
     ]));
     assert_eq!(text, expected);
 }
@@ -807,9 +806,8 @@ fn url_link_shows_destination() {
     let text = render_markdown_text("[docs](https://example.com/docs)");
     let expected = Text::from(Line::from_iter([
         "docs".into(),
-        " (".into(),
+        " - ".into(),
         "https://example.com/docs".cyan().underlined(),
-        ")".into(),
     ]));
     assert_eq!(text, expected);
 }

--- a/codex-rs/tui/src/snapshots/codex_tui__markdown_render__markdown_render_tests__markdown_render_complex_snapshot.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__markdown_render__markdown_render_tests__markdown_render_complex_snapshot.snap
@@ -6,8 +6,8 @@ expression: rendered
 
 Intro paragraph with bold text, italic text, and inline code x=1.
 Combined bold-italic both and escaped asterisks *literal*.
-Auto-link: https://example.com (https://example.com) and reference link [ref][r1].
-Link with title: hover me (https://example.com) and mailto mailto:test@example.com (mailto:test@example.com).
+Auto-link: https://example.com - https://example.com and reference link [ref][r1].
+Link with title: hover me - https://example.com and mailto mailto:test@example.com - mailto:test@example.com.
 Image: alt text
 
 > Blockquote level 1
@@ -23,7 +23,7 @@ Image: alt text
     1. Alt-numbered subitem
 
 - [ ] Task: unchecked
-- [x] Task: checked with link home (https://example.org)
+- [x] Task: checked with link home - https://example.org
 
 ———
 


### PR DESCRIPTION
Fixes #17342.

This changes the TUI markdown renderer so remote links render as `label - url` instead of `label (url)`. That avoids placing a trailing `)` directly next to the rendered URL, which terminals like WezTerm and iTerm can treat as part of the clickable destination.

What changed:
- update remote markdown link rendering in the TUI transcript
- keep local file-link rendering unchanged
- update the existing markdown renderer assertions and snapshot output

Testing:
- build the patched binary with `CARGO_TARGET_DIR=target-17342 cargo build -p codex-cli --bin codex`
- ask Codex to print `[PR #496](https://github.com/org/repo/pull/496)` and confirm it renders as `PR #496 - https://github.com/org/repo/pull/496`
- click the rendered URL and confirm the browser opens the URL without a trailing `)`
