### PR TITLE
codex: add app-server ThreadStore adapter

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -327,10 +327,8 @@ use codex_thread_store::ListThreadsParams as StoreListThreadsParams;
 use codex_thread_store::LocalThreadStore;
 use codex_thread_store::ReadThreadParams as StoreReadThreadParams;
 use codex_thread_store::SortDirection as StoreSortDirection;
-use codex_thread_store::StoredThread;
 use codex_thread_store::ThreadMetadataPatch as StoreThreadMetadataPatch;
 use codex_thread_store::ThreadSortKey as StoreThreadSortKey;
-use codex_thread_store::ThreadStore;
 use codex_thread_store::ThreadStoreError;
 use codex_thread_store::UpdateThreadMetadataParams as StoreUpdateThreadMetadataParams;
 use codex_utils_absolute_path::AbsolutePathBuf;
@@ -367,6 +365,7 @@ use codex_app_server_protocol::ServerRequest;
 mod apps_list_helpers;
 mod plugin_app_helpers;
 mod plugin_mcp_oauth;
+mod thread_store_adapter;
 mod token_usage_replay;
 
 use crate::filters::compute_source_filters;
@@ -374,6 +373,7 @@ use crate::filters::source_kind_matches;
 use crate::thread_state::ThreadListenerCommand;
 use crate::thread_state::ThreadState;
 use crate::thread_state::ThreadStateManager;
+use thread_store_adapter::ThreadStoreAdapter;
 use token_usage_replay::latest_token_usage_turn_id_for_thread_path;
 use token_usage_replay::latest_token_usage_turn_id_from_rollout_items;
 use token_usage_replay::latest_token_usage_turn_id_from_rollout_path;
@@ -463,7 +463,7 @@ pub(crate) struct CodexMessageProcessor {
     analytics_events_client: AnalyticsEventsClient,
     arg0_paths: Arg0DispatchPaths,
     config: Arc<Config>,
-    thread_store: LocalThreadStore,
+    thread_store_adapter: ThreadStoreAdapter,
     cli_overrides: Arc<RwLock<Vec<(String, TomlValue)>>>,
     runtime_feature_enablement: Arc<RwLock<BTreeMap<String, bool>>>,
     cloud_requirements: Arc<RwLock<CloudRequirementsLoader>>,
@@ -714,7 +714,11 @@ impl CodexMessageProcessor {
             outgoing: outgoing.clone(),
             analytics_events_client,
             arg0_paths,
-            thread_store: LocalThreadStore::new(codex_rollout::RolloutConfig::from_view(&config)),
+            thread_store_adapter: ThreadStoreAdapter::new(
+                LocalThreadStore::new(codex_rollout::RolloutConfig::from_view(&config)),
+                config.model_provider_id.clone(),
+                config.cwd.clone(),
+            ),
             config,
             cli_overrides,
             runtime_feature_enablement,
@@ -2750,7 +2754,7 @@ impl CodexMessageProcessor {
 
         let thread_id_str = thread_id.to_string();
         if let Err(err) = self
-            .thread_store
+            .thread_store_adapter
             .read_thread(StoreReadThreadParams {
                 thread_id,
                 include_archived: false,
@@ -2766,7 +2770,7 @@ impl CodexMessageProcessor {
         self.prepare_thread_for_archive(thread_id).await;
 
         match self
-            .thread_store
+            .thread_store_adapter
             .archive_thread(StoreArchiveThreadParams { thread_id })
             .await
         {
@@ -2897,7 +2901,7 @@ impl CodexMessageProcessor {
         }
 
         if let Err(err) = self
-            .thread_store
+            .thread_store_adapter
             .update_thread_metadata(StoreUpdateThreadMetadataParams {
                 thread_id,
                 patch: StoreThreadMetadataPatch {
@@ -2967,7 +2971,7 @@ impl CodexMessageProcessor {
         }
 
         if let Err(err) = self
-            .thread_store
+            .thread_store_adapter
             .update_thread_metadata(StoreUpdateThreadMetadataParams {
                 thread_id,
                 patch: StoreThreadMetadataPatch {
@@ -3352,21 +3356,11 @@ impl CodexMessageProcessor {
             }
         };
 
-        let fallback_provider = self.config.model_provider_id.clone();
         let result = self
-            .thread_store
+            .thread_store_adapter
             .unarchive_thread(StoreArchiveThreadParams { thread_id })
             .await
-            .map_err(|err| thread_store_archive_error("unarchive", err))
-            .and_then(|stored_thread| {
-                summary_from_stored_thread(stored_thread, fallback_provider.as_str())
-                    .map(|summary| summary_to_thread(summary, &self.config.cwd))
-                    .ok_or_else(|| JSONRPCErrorError {
-                        code: INTERNAL_ERROR_CODE,
-                        message: format!("failed to read unarchived thread {thread_id}"),
-                        data: None,
-                    })
-            });
+            .map_err(|err| thread_store_archive_error("unarchive", err));
 
         match result {
             Ok(mut thread) => {
@@ -3803,9 +3797,8 @@ impl CodexMessageProcessor {
         thread_id: ThreadId,
         include_turns: bool,
     ) -> Result<Option<Thread>, ThreadReadViewError> {
-        let fallback_provider = self.config.model_provider_id.as_str();
         match self
-            .thread_store
+            .thread_store_adapter
             .read_thread(StoreReadThreadParams {
                 thread_id,
                 include_archived: true,
@@ -3813,14 +3806,7 @@ impl CodexMessageProcessor {
             })
             .await
         {
-            Ok(stored_thread) => {
-                let (mut thread, history) =
-                    thread_from_stored_thread(stored_thread, fallback_provider, &self.config.cwd);
-                if include_turns && let Some(history) = history {
-                    thread.turns = build_turns_from_rollout_items(&history.items);
-                }
-                Ok(Some(thread))
-            }
+            Ok(thread) => Ok(Some(thread)),
             Err(ThreadStoreError::InvalidRequest { message })
                 if message == format!("no rollout found for thread id {thread_id}") =>
             {
@@ -5100,7 +5086,6 @@ impl CodexMessageProcessor {
             }
             None => Some(vec![self.config.model_provider_id.clone()]),
         };
-        let fallback_provider = self.config.model_provider_id.clone();
         let (allowed_sources_vec, source_kind_filter) = compute_source_filters(source_kinds);
         let allowed_sources = allowed_sources_vec.as_slice();
         let store_sort_direction = match sort_direction {
@@ -5111,8 +5096,8 @@ impl CodexMessageProcessor {
         while remaining > 0 {
             let page_size = remaining.min(THREAD_LIST_MAX_LIMIT);
             let page = self
-                .thread_store
-                .list_threads(StoreListThreadsParams {
+                .thread_store_adapter
+                .list_thread_summaries(StoreListThreadsParams {
                     page_size,
                     cursor: cursor_obj.clone(),
                     sort_key,
@@ -5125,17 +5110,8 @@ impl CodexMessageProcessor {
                 .await
                 .map_err(thread_store_list_error)?;
 
-            let mut candidate_summaries = Vec::with_capacity(page.items.len());
-            for it in page.items {
-                let Some(summary) = summary_from_stored_thread(it, fallback_provider.as_str())
-                else {
-                    continue;
-                };
-                candidate_summaries.push(summary);
-            }
-
-            let mut filtered = Vec::with_capacity(candidate_summaries.len());
-            for summary in candidate_summaries {
+            let mut filtered = Vec::with_capacity(page.items.len());
+            for summary in page.items {
                 if source_kind_filter
                     .as_ref()
                     .is_none_or(|filter| source_kind_matches(&summary.source, filter))
@@ -9380,56 +9356,6 @@ fn thread_store_write_error(operation: &str, err: ThreadStoreError) -> JSONRPCEr
     }
 }
 
-fn thread_from_stored_thread(
-    thread: StoredThread,
-    fallback_provider: &str,
-    fallback_cwd: &AbsolutePathBuf,
-) -> (Thread, Option<codex_thread_store::StoredThreadHistory>) {
-    let path = thread.rollout_path;
-    let git_info = thread.git_info.map(|info| ApiGitInfo {
-        sha: info.commit_hash.map(|sha| sha.0),
-        branch: info.branch,
-        origin_url: info.repository_url,
-    });
-    let cwd = AbsolutePathBuf::relative_to_current_dir(path_utils::normalize_for_native_workdir(
-        thread.cwd,
-    ))
-    .unwrap_or_else(|err| {
-        warn!("failed to normalize thread cwd while reading stored thread: {err}");
-        fallback_cwd.clone()
-    });
-    let source = with_thread_spawn_agent_metadata(
-        thread.source,
-        thread.agent_nickname.clone(),
-        thread.agent_role.clone(),
-    );
-    let history = thread.history;
-    let thread = Thread {
-        id: thread.thread_id.to_string(),
-        forked_from_id: thread.forked_from_id.map(|id| id.to_string()),
-        preview: thread.first_user_message.unwrap_or(thread.preview),
-        ephemeral: false,
-        model_provider: if thread.model_provider.is_empty() {
-            fallback_provider.to_string()
-        } else {
-            thread.model_provider
-        },
-        created_at: thread.created_at.timestamp(),
-        updated_at: thread.updated_at.timestamp(),
-        status: ThreadStatus::NotLoaded,
-        path,
-        cwd,
-        cli_version: thread.cli_version,
-        agent_nickname: source.get_nickname(),
-        agent_role: source.get_agent_role(),
-        source: source.into(),
-        git_info,
-        name: thread.name,
-        turns: Vec::new(),
-    };
-    (thread, history)
-}
-
 fn thread_store_archive_error(operation: &str, err: ThreadStoreError) -> JSONRPCErrorError {
     match err {
         ThreadStoreError::InvalidRequest { message } => JSONRPCErrorError {
@@ -9443,49 +9369,6 @@ fn thread_store_archive_error(operation: &str, err: ThreadStoreError) -> JSONRPC
             data: None,
         },
     }
-}
-
-fn summary_from_stored_thread(
-    thread: StoredThread,
-    fallback_provider: &str,
-) -> Option<ConversationSummary> {
-    let path = thread.rollout_path?;
-    let source = with_thread_spawn_agent_metadata(
-        thread.source,
-        thread.agent_nickname.clone(),
-        thread.agent_role.clone(),
-    );
-    let git_info = thread.git_info.map(|git| ConversationGitInfo {
-        sha: git.commit_hash.map(|sha| sha.0),
-        branch: git.branch,
-        origin_url: git.repository_url,
-    });
-    Some(ConversationSummary {
-        conversation_id: thread.thread_id,
-        path,
-        preview: thread.first_user_message.unwrap_or(thread.preview),
-        // Preserve millisecond precision from the thread store so thread/list cursors
-        // round-trip the same ordering key used by pagination queries.
-        timestamp: Some(
-            thread
-                .created_at
-                .to_rfc3339_opts(SecondsFormat::Millis, true),
-        ),
-        updated_at: Some(
-            thread
-                .updated_at
-                .to_rfc3339_opts(SecondsFormat::Millis, true),
-        ),
-        model_provider: if thread.model_provider.is_empty() {
-            fallback_provider.to_string()
-        } else {
-            thread.model_provider
-        },
-        cwd: thread.cwd,
-        cli_version: thread.cli_version,
-        source,
-        git_info,
-    })
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -10076,11 +9959,8 @@ mod tests {
     use codex_app_server_protocol::ToolRequestUserInputParams;
     use codex_protocol::ThreadId;
     use codex_protocol::openai_models::ReasoningEffort;
-    use codex_protocol::protocol::AskForApproval;
-    use codex_protocol::protocol::SandboxPolicy;
     use codex_protocol::protocol::SessionSource;
     use codex_protocol::protocol::SubAgentSource;
-    use codex_thread_store::StoredThread;
     use codex_utils_absolute_path::test_support::PathBufExt;
     use codex_utils_absolute_path::test_support::test_path_buf;
     use pretty_assertions::assert_eq;
@@ -10128,53 +10008,6 @@ mod tests {
             defer_loading: false,
         }];
         validate_dynamic_tools(&tools).expect("valid schema");
-    }
-
-    #[test]
-    fn summary_from_stored_thread_preserves_millisecond_precision() {
-        let created_at =
-            DateTime::parse_from_rfc3339("2025-01-02T03:04:05.678Z").expect("valid timestamp");
-        let updated_at =
-            DateTime::parse_from_rfc3339("2025-01-02T03:04:06.789Z").expect("valid timestamp");
-        let thread_id =
-            ThreadId::from_string("00000000-0000-0000-0000-000000000123").expect("valid thread");
-        let stored_thread = StoredThread {
-            thread_id,
-            rollout_path: Some(PathBuf::from("/tmp/thread.jsonl")),
-            forked_from_id: None,
-            preview: "preview".to_string(),
-            name: None,
-            model_provider: "openai".to_string(),
-            model: None,
-            reasoning_effort: None,
-            created_at: created_at.with_timezone(&Utc),
-            updated_at: updated_at.with_timezone(&Utc),
-            archived_at: None,
-            cwd: PathBuf::from("/tmp"),
-            cli_version: "0.0.0".to_string(),
-            source: SessionSource::Cli,
-            agent_nickname: None,
-            agent_role: None,
-            agent_path: None,
-            git_info: None,
-            approval_mode: AskForApproval::OnRequest,
-            sandbox_policy: SandboxPolicy::new_read_only_policy(),
-            token_usage: None,
-            first_user_message: Some("first user message".to_string()),
-            history: None,
-        };
-
-        let summary =
-            summary_from_stored_thread(stored_thread, "fallback").expect("summary should exist");
-
-        assert_eq!(
-            summary.timestamp.as_deref(),
-            Some("2025-01-02T03:04:05.678Z")
-        );
-        assert_eq!(
-            summary.updated_at.as_deref(),
-            Some("2025-01-02T03:04:06.789Z")
-        );
     }
 
     #[test]

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -215,7 +215,6 @@ use codex_core::SessionMeta;
 use codex_core::SteerInputError;
 use codex_core::ThreadConfigSnapshot;
 use codex_core::ThreadManager;
-use codex_core::append_thread_name;
 use codex_core::clear_memory_roots_contents;
 use codex_core::config::Config;
 use codex_core::config::ConfigOverrides;
@@ -311,13 +310,11 @@ use codex_protocol::protocol::ReviewTarget as CoreReviewTarget;
 use codex_protocol::protocol::RolloutItem;
 use codex_protocol::protocol::SessionConfiguredEvent;
 use codex_protocol::protocol::SessionMetaLine;
-use codex_protocol::protocol::ThreadNameUpdatedEvent;
 use codex_protocol::protocol::USER_MESSAGE_BEGIN;
 use codex_protocol::protocol::W3cTraceContext;
 use codex_protocol::user_input::MAX_USER_INPUT_TEXT_CHARS;
 use codex_protocol::user_input::UserInput as CoreInputItem;
 use codex_rmcp_client::perform_oauth_login_return_url;
-use codex_rollout::append_rollout_item_to_path;
 use codex_rollout::state_db::StateDbHandle;
 use codex_rollout::state_db::get_state_db;
 use codex_rollout::state_db::reconcile_rollout;
@@ -331,9 +328,11 @@ use codex_thread_store::LocalThreadStore;
 use codex_thread_store::ReadThreadParams as StoreReadThreadParams;
 use codex_thread_store::SortDirection as StoreSortDirection;
 use codex_thread_store::StoredThread;
+use codex_thread_store::ThreadMetadataPatch as StoreThreadMetadataPatch;
 use codex_thread_store::ThreadSortKey as StoreThreadSortKey;
 use codex_thread_store::ThreadStore;
 use codex_thread_store::ThreadStoreError;
+use codex_thread_store::UpdateThreadMetadataParams as StoreUpdateThreadMetadataParams;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use codex_utils_json_to_toml::json_to_toml;
 use codex_utils_pty::DEFAULT_OUTPUT_BYTES_CAP;
@@ -2897,54 +2896,23 @@ impl CodexMessageProcessor {
             return;
         }
 
-        let rollout_path =
-            match find_thread_path_by_id_str(&self.config.codex_home, &thread_id.to_string()).await
-            {
-                Ok(Some(path)) => Some(path),
-                Ok(None) => None,
-                Err(err) => {
-                    self.send_invalid_request_error(
-                        request_id,
-                        format!("failed to locate thread id {thread_id}: {err}"),
-                    )
-                    .await;
-                    return;
-                }
-            };
-
-        let Some(rollout_path) = rollout_path else {
-            self.send_invalid_request_error(request_id, format!("thread not found: {thread_id}"))
-                .await;
-            return;
-        };
-
-        let msg = EventMsg::ThreadNameUpdated(ThreadNameUpdatedEvent {
-            thread_id,
-            thread_name: Some(name.clone()),
-        });
-        let item = RolloutItem::EventMsg(msg);
-        if let Err(err) = append_rollout_item_to_path(rollout_path.as_path(), &item).await {
-            self.send_internal_error(request_id, format!("failed to set thread name: {err}"))
+        if let Err(err) = self
+            .thread_store
+            .update_thread_metadata(StoreUpdateThreadMetadataParams {
+                thread_id,
+                patch: StoreThreadMetadataPatch {
+                    name: Some(name.clone()),
+                    ..Default::default()
+                },
+                include_archived: false,
+            })
+            .await
+        {
+            self.outgoing
+                .send_error(request_id, thread_store_write_error("set thread name", err))
                 .await;
             return;
         }
-        if let Err(err) = append_thread_name(&self.config.codex_home, thread_id, &name).await {
-            self.send_internal_error(request_id, format!("failed to index thread name: {err}"))
-                .await;
-            return;
-        }
-
-        let state_db_ctx = open_state_db_for_direct_thread_lookup(&self.config).await;
-        reconcile_rollout(
-            state_db_ctx.as_deref(),
-            rollout_path.as_path(),
-            self.config.model_provider_id.as_str(),
-            /*builder*/ None,
-            &[],
-            /*archived_only*/ None,
-            /*new_thread_memory_mode*/ None,
-        )
-        .await;
 
         self.outgoing
             .send_response(request_id, ThreadSetNameResponse {})
@@ -2998,72 +2966,26 @@ impl CodexMessageProcessor {
             return;
         }
 
-        let rollout_path =
-            match find_thread_path_by_id_str(&self.config.codex_home, &thread_id.to_string()).await
-            {
-                Ok(Some(path)) => Some(path),
-                Ok(None) => None,
-                Err(err) => {
-                    self.send_invalid_request_error(
-                        request_id,
-                        format!("failed to locate thread id {thread_id}: {err}"),
-                    )
-                    .await;
-                    return;
-                }
-            };
-
-        let Some(rollout_path) = rollout_path else {
-            self.send_invalid_request_error(request_id, format!("thread not found: {thread_id}"))
-                .await;
-            return;
-        };
-
-        let mut session_meta = match read_session_meta_line(rollout_path.as_path()).await {
-            Ok(session_meta) => session_meta,
-            Err(err) => {
-                self.send_internal_error(
+        if let Err(err) = self
+            .thread_store
+            .update_thread_metadata(StoreUpdateThreadMetadataParams {
+                thread_id,
+                patch: StoreThreadMetadataPatch {
+                    memory_mode: Some(mode.to_core()),
+                    ..Default::default()
+                },
+                include_archived: false,
+            })
+            .await
+        {
+            self.outgoing
+                .send_error(
                     request_id,
-                    format!("failed to set thread memory mode: {err}"),
+                    thread_store_write_error("set thread memory mode", err),
                 )
                 .await;
-                return;
-            }
-        };
-        if session_meta.meta.id != thread_id {
-            self.send_internal_error(
-                request_id,
-                format!(
-                    "failed to set thread memory mode: rollout session metadata id mismatch: expected {thread_id}, found {}",
-                    session_meta.meta.id
-                ),
-            )
-            .await;
             return;
         }
-        session_meta.meta.memory_mode = Some(mode.as_str().to_string());
-        let item = RolloutItem::SessionMeta(session_meta);
-
-        if let Err(err) = append_rollout_item_to_path(rollout_path.as_path(), &item).await {
-            self.send_internal_error(
-                request_id,
-                format!("failed to set thread memory mode: {err}"),
-            )
-            .await;
-            return;
-        }
-
-        let state_db_ctx = open_state_db_for_direct_thread_lookup(&self.config).await;
-        reconcile_rollout(
-            state_db_ctx.as_deref(),
-            rollout_path.as_path(),
-            self.config.model_provider_id.as_str(),
-            /*builder*/ None,
-            &[],
-            /*archived_only*/ None,
-            /*new_thread_memory_mode*/ None,
-        )
-        .await;
 
         self.outgoing
             .send_response(request_id, ThreadMemoryModeSetResponse {})
@@ -9433,6 +9355,26 @@ fn thread_store_list_error(err: ThreadStoreError) -> JSONRPCErrorError {
         err => JSONRPCErrorError {
             code: INTERNAL_ERROR_CODE,
             message: format!("failed to list threads: {err}"),
+            data: None,
+        },
+    }
+}
+
+fn thread_store_write_error(operation: &str, err: ThreadStoreError) -> JSONRPCErrorError {
+    match err {
+        ThreadStoreError::ThreadNotFound { thread_id } => JSONRPCErrorError {
+            code: INVALID_REQUEST_ERROR_CODE,
+            message: format!("thread not found: {thread_id}"),
+            data: None,
+        },
+        ThreadStoreError::InvalidRequest { message } => JSONRPCErrorError {
+            code: INVALID_REQUEST_ERROR_CODE,
+            message,
+            data: None,
+        },
+        err => JSONRPCErrorError {
+            code: INTERNAL_ERROR_CODE,
+            message: format!("failed to {operation}: {err}"),
             data: None,
         },
     }

--- a/codex-rs/app-server/src/codex_message_processor/thread_store_adapter.rs
+++ b/codex-rs/app-server/src/codex_message_processor/thread_store_adapter.rs
@@ -1,0 +1,308 @@
+use super::with_thread_spawn_agent_metadata;
+use chrono::SecondsFormat;
+use codex_app_server_protocol::ConversationGitInfo;
+use codex_app_server_protocol::ConversationSummary;
+use codex_app_server_protocol::GitInfo as ApiGitInfo;
+use codex_app_server_protocol::Thread;
+use codex_app_server_protocol::ThreadStatus;
+use codex_app_server_protocol::build_turns_from_rollout_items;
+use codex_core::path_utils;
+use codex_thread_store::ArchiveThreadParams as StoreArchiveThreadParams;
+use codex_thread_store::ListThreadsParams as StoreListThreadsParams;
+use codex_thread_store::LocalThreadStore;
+use codex_thread_store::ReadThreadParams as StoreReadThreadParams;
+use codex_thread_store::StoredThread;
+use codex_thread_store::ThreadPage;
+use codex_thread_store::ThreadStore;
+use codex_thread_store::ThreadStoreResult;
+use codex_thread_store::UpdateThreadMetadataParams as StoreUpdateThreadMetadataParams;
+use codex_utils_absolute_path::AbsolutePathBuf;
+use tracing::warn;
+
+/// App-server boundary around `ThreadStore`. Adapts `StoredThread` to `Thread`.
+pub(crate) struct ThreadStoreAdapter<S = LocalThreadStore> {
+    store: S,
+    fallback_provider: String,
+    fallback_cwd: AbsolutePathBuf,
+}
+
+pub(crate) struct ThreadSummaryPage {
+    pub(crate) items: Vec<ConversationSummary>,
+    pub(crate) next_cursor: Option<String>,
+}
+
+impl<S> ThreadStoreAdapter<S> {
+    pub(crate) fn new(store: S, fallback_provider: String, fallback_cwd: AbsolutePathBuf) -> Self {
+        Self {
+            store,
+            fallback_provider,
+            fallback_cwd,
+        }
+    }
+}
+
+impl<S> ThreadStoreAdapter<S>
+where
+    S: ThreadStore,
+{
+    pub(crate) async fn read_thread(
+        &self,
+        params: StoreReadThreadParams,
+    ) -> ThreadStoreResult<Thread> {
+        let include_turns = params.include_history;
+        let stored_thread = self.store.read_thread(params).await?;
+        Ok(self.thread_from_stored_thread(stored_thread, include_turns))
+    }
+
+    pub(crate) async fn list_thread_summaries(
+        &self,
+        params: StoreListThreadsParams,
+    ) -> ThreadStoreResult<ThreadSummaryPage> {
+        let page = self.store.list_threads(params).await?;
+        Ok(self.thread_summary_page_from_store(page))
+    }
+
+    pub(crate) async fn update_thread_metadata(
+        &self,
+        params: StoreUpdateThreadMetadataParams,
+    ) -> ThreadStoreResult<Thread> {
+        let stored_thread = self.store.update_thread_metadata(params).await?;
+        Ok(self.thread_from_stored_thread(stored_thread, /*include_turns*/ false))
+    }
+
+    pub(crate) async fn archive_thread(
+        &self,
+        params: StoreArchiveThreadParams,
+    ) -> ThreadStoreResult<()> {
+        self.store.archive_thread(params).await
+    }
+
+    pub(crate) async fn unarchive_thread(
+        &self,
+        params: StoreArchiveThreadParams,
+    ) -> ThreadStoreResult<Thread> {
+        let stored_thread = self.store.unarchive_thread(params).await?;
+        Ok(self.thread_from_stored_thread(stored_thread, /*include_turns*/ false))
+    }
+}
+
+impl<S> ThreadStoreAdapter<S> {
+    fn thread_from_stored_thread(
+        &self,
+        stored_thread: StoredThread,
+        include_turns: bool,
+    ) -> Thread {
+        let path = stored_thread.rollout_path;
+        let git_info = stored_thread.git_info.map(|info| ApiGitInfo {
+            sha: info.commit_hash.map(|sha| sha.0),
+            branch: info.branch,
+            origin_url: info.repository_url,
+        });
+        let cwd = AbsolutePathBuf::relative_to_current_dir(
+            path_utils::normalize_for_native_workdir(stored_thread.cwd),
+        )
+        .unwrap_or_else(|err| {
+            warn!("failed to normalize thread cwd while reading stored thread: {err}");
+            self.fallback_cwd.clone()
+        });
+        let source = with_thread_spawn_agent_metadata(
+            stored_thread.source,
+            stored_thread.agent_nickname.clone(),
+            stored_thread.agent_role.clone(),
+        );
+        let mut thread = Thread {
+            id: stored_thread.thread_id.to_string(),
+            forked_from_id: stored_thread.forked_from_id.map(|id| id.to_string()),
+            preview: stored_thread
+                .first_user_message
+                .unwrap_or(stored_thread.preview),
+            ephemeral: false,
+            model_provider: if stored_thread.model_provider.is_empty() {
+                self.fallback_provider.clone()
+            } else {
+                stored_thread.model_provider
+            },
+            created_at: stored_thread.created_at.timestamp(),
+            updated_at: stored_thread.updated_at.timestamp(),
+            status: ThreadStatus::NotLoaded,
+            path,
+            cwd,
+            cli_version: stored_thread.cli_version,
+            agent_nickname: source.get_nickname(),
+            agent_role: source.get_agent_role(),
+            source: source.into(),
+            git_info,
+            name: stored_thread.name,
+            turns: Vec::new(),
+        };
+        if include_turns && let Some(history) = stored_thread.history {
+            thread.turns = build_turns_from_rollout_items(&history.items);
+        }
+        thread
+    }
+
+    fn thread_summary_page_from_store(&self, page: ThreadPage) -> ThreadSummaryPage {
+        let items = page
+            .items
+            .into_iter()
+            .filter_map(|stored_thread| self.summary_from_stored_thread(stored_thread))
+            .collect();
+        ThreadSummaryPage {
+            items,
+            next_cursor: page.next_cursor,
+        }
+    }
+
+    fn summary_from_stored_thread(
+        &self,
+        stored_thread: StoredThread,
+    ) -> Option<ConversationSummary> {
+        let path = stored_thread.rollout_path?;
+        let source = with_thread_spawn_agent_metadata(
+            stored_thread.source,
+            stored_thread.agent_nickname.clone(),
+            stored_thread.agent_role.clone(),
+        );
+        let git_info = stored_thread.git_info.map(|git| ConversationGitInfo {
+            sha: git.commit_hash.map(|sha| sha.0),
+            branch: git.branch,
+            origin_url: git.repository_url,
+        });
+        Some(ConversationSummary {
+            conversation_id: stored_thread.thread_id,
+            path,
+            preview: stored_thread
+                .first_user_message
+                .unwrap_or(stored_thread.preview),
+            // Preserve millisecond precision from the thread store so thread/list cursors
+            // round-trip the same ordering key used by pagination queries.
+            timestamp: Some(
+                stored_thread
+                    .created_at
+                    .to_rfc3339_opts(SecondsFormat::Millis, true),
+            ),
+            updated_at: Some(
+                stored_thread
+                    .updated_at
+                    .to_rfc3339_opts(SecondsFormat::Millis, true),
+            ),
+            model_provider: if stored_thread.model_provider.is_empty() {
+                self.fallback_provider.clone()
+            } else {
+                stored_thread.model_provider
+            },
+            cwd: stored_thread.cwd,
+            cli_version: stored_thread.cli_version,
+            source,
+            git_info,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::DateTime;
+    use chrono::Utc;
+    use codex_protocol::ThreadId;
+    use codex_protocol::protocol::AskForApproval;
+    use codex_protocol::protocol::EventMsg;
+    use codex_protocol::protocol::RolloutItem;
+    use codex_protocol::protocol::SandboxPolicy;
+    use codex_protocol::protocol::SessionSource;
+    use codex_protocol::protocol::UserMessageEvent;
+    use codex_thread_store::StoredThreadHistory;
+    use pretty_assertions::assert_eq;
+    use std::path::PathBuf;
+
+    #[test]
+    fn summary_preserves_millisecond_precision() {
+        let created_at =
+            DateTime::parse_from_rfc3339("2025-01-02T03:04:05.678Z").expect("valid timestamp");
+        let updated_at =
+            DateTime::parse_from_rfc3339("2025-01-02T03:04:06.789Z").expect("valid timestamp");
+        let stored_thread = stored_thread(
+            created_at.with_timezone(&Utc),
+            updated_at.with_timezone(&Utc),
+        );
+
+        let adapter = ThreadStoreAdapter::new(
+            (),
+            "fallback".to_string(),
+            AbsolutePathBuf::from_absolute_path_checked("/fallback").expect("absolute path"),
+        );
+        let summary = adapter
+            .summary_from_stored_thread(stored_thread)
+            .expect("summary should exist");
+
+        assert_eq!(
+            summary.timestamp.as_deref(),
+            Some("2025-01-02T03:04:05.678Z")
+        );
+        assert_eq!(
+            summary.updated_at.as_deref(),
+            Some("2025-01-02T03:04:06.789Z")
+        );
+    }
+
+    #[test]
+    fn thread_conversion_includes_history_when_requested() {
+        let created_at =
+            DateTime::parse_from_rfc3339("2025-01-02T03:04:05.678Z").expect("valid timestamp");
+        let updated_at =
+            DateTime::parse_from_rfc3339("2025-01-02T03:04:06.789Z").expect("valid timestamp");
+        let mut stored_thread = stored_thread(
+            created_at.with_timezone(&Utc),
+            updated_at.with_timezone(&Utc),
+        );
+        stored_thread.history = Some(StoredThreadHistory {
+            thread_id: stored_thread.thread_id,
+            items: vec![RolloutItem::EventMsg(EventMsg::UserMessage(
+                UserMessageEvent {
+                    message: "hello".to_string(),
+                    images: None,
+                    local_images: Vec::new(),
+                    text_elements: Vec::new(),
+                },
+            ))],
+        });
+
+        let adapter = ThreadStoreAdapter::new(
+            (),
+            "fallback".to_string(),
+            AbsolutePathBuf::from_absolute_path_checked("/fallback").expect("absolute path"),
+        );
+        let thread = adapter.thread_from_stored_thread(stored_thread, /*include_turns*/ true);
+
+        assert_eq!(thread.turns.len(), 1);
+    }
+
+    fn stored_thread(created_at: DateTime<Utc>, updated_at: DateTime<Utc>) -> StoredThread {
+        StoredThread {
+            thread_id: ThreadId::from_string("00000000-0000-0000-0000-000000000123")
+                .expect("valid thread"),
+            rollout_path: Some(PathBuf::from("/tmp/thread.jsonl")),
+            forked_from_id: None,
+            preview: "preview".to_string(),
+            name: None,
+            model_provider: "openai".to_string(),
+            model: None,
+            reasoning_effort: None,
+            created_at,
+            updated_at,
+            archived_at: None,
+            cwd: PathBuf::from("/tmp"),
+            cli_version: "0.0.0".to_string(),
+            source: SessionSource::Cli,
+            agent_nickname: None,
+            agent_role: None,
+            agent_path: None,
+            git_info: None,
+            approval_mode: AskForApproval::OnRequest,
+            sandbox_policy: SandboxPolicy::new_read_only_policy(),
+            token_usage: None,
+            first_user_message: Some("first user message".to_string()),
+            history: None,
+        }
+    }
+}

--- a/codex-rs/thread-store/src/lib.rs
+++ b/codex-rs/thread-store/src/lib.rs
@@ -26,7 +26,6 @@ pub use types::LoadThreadHistoryParams;
 pub use types::OptionalStringPatch;
 pub use types::ReadThreadParams;
 pub use types::ResumeThreadRecorderParams;
-pub use types::SetThreadNameParams;
 pub use types::SortDirection;
 pub use types::StoredThread;
 pub use types::StoredThreadHistory;

--- a/codex-rs/thread-store/src/local/mod.rs
+++ b/codex-rs/thread-store/src/local/mod.rs
@@ -3,6 +3,7 @@ mod helpers;
 mod list_threads;
 mod read_thread;
 mod unarchive_thread;
+mod update_thread_metadata;
 
 #[cfg(test)]
 mod test_support;
@@ -17,7 +18,6 @@ use crate::ListThreadsParams;
 use crate::LoadThreadHistoryParams;
 use crate::ReadThreadParams;
 use crate::ResumeThreadRecorderParams;
-use crate::SetThreadNameParams;
 use crate::StoredThread;
 use crate::StoredThreadHistory;
 use crate::ThreadPage;
@@ -75,15 +75,11 @@ impl ThreadStore for LocalThreadStore {
         list_threads::list_threads(self, params).await
     }
 
-    async fn set_thread_name(&self, _params: SetThreadNameParams) -> ThreadStoreResult<()> {
-        unsupported("set_thread_name")
-    }
-
     async fn update_thread_metadata(
         &self,
-        _params: UpdateThreadMetadataParams,
+        params: UpdateThreadMetadataParams,
     ) -> ThreadStoreResult<StoredThread> {
-        unsupported("update_thread_metadata")
+        update_thread_metadata::update_thread_metadata(self, params).await
     }
 
     async fn archive_thread(&self, params: ArchiveThreadParams) -> ThreadStoreResult<()> {

--- a/codex-rs/thread-store/src/local/update_thread_metadata.rs
+++ b/codex-rs/thread-store/src/local/update_thread_metadata.rs
@@ -1,0 +1,397 @@
+use std::path::PathBuf;
+
+use codex_protocol::ThreadId;
+use codex_protocol::protocol::EventMsg;
+use codex_protocol::protocol::RolloutItem;
+use codex_protocol::protocol::ThreadMemoryMode;
+use codex_protocol::protocol::ThreadNameUpdatedEvent;
+use codex_rollout::StateDbHandle;
+use codex_rollout::append_rollout_item_to_path;
+use codex_rollout::append_thread_name;
+use codex_rollout::find_archived_thread_path_by_id_str;
+use codex_rollout::find_thread_path_by_id_str;
+use codex_rollout::read_session_meta_line;
+
+use super::LocalThreadStore;
+use crate::ReadThreadParams;
+use crate::StoredThread;
+use crate::ThreadStoreError;
+use crate::ThreadStoreResult;
+use crate::UpdateThreadMetadataParams;
+use crate::local::read_thread;
+
+struct ResolvedRolloutPath {
+    path: PathBuf,
+    archived: bool,
+}
+
+pub(super) async fn update_thread_metadata(
+    store: &LocalThreadStore,
+    params: UpdateThreadMetadataParams,
+) -> ThreadStoreResult<StoredThread> {
+    if params.patch.git_info.is_some() {
+        return Err(ThreadStoreError::Internal {
+            message: "local thread store does not implement git metadata updates in this slice"
+                .to_string(),
+        });
+    }
+    if params.patch.name.is_some() && params.patch.memory_mode.is_some() {
+        return Err(ThreadStoreError::InvalidRequest {
+            message: "local thread store applies one metadata field per patch in this slice"
+                .to_string(),
+        });
+    }
+
+    let thread_id = params.thread_id;
+    let resolved_rollout_path =
+        resolve_rollout_path(store, thread_id, params.include_archived).await?;
+    if let Some(name) = params.patch.name {
+        apply_thread_name(store, resolved_rollout_path.path.as_path(), thread_id, name).await?;
+    }
+    if let Some(memory_mode) = params.patch.memory_mode {
+        apply_thread_memory_mode(resolved_rollout_path.path.as_path(), thread_id, memory_mode)
+            .await?;
+    }
+
+    let state_db_ctx = open_state_db_for_direct_thread_lookup(store).await;
+    codex_rollout::state_db::reconcile_rollout(
+        state_db_ctx.as_deref(),
+        resolved_rollout_path.path.as_path(),
+        store.config.model_provider_id.as_str(),
+        /*builder*/ None,
+        &[],
+        /*archived_only*/ resolved_rollout_path.archived.then_some(true),
+        /*new_thread_memory_mode*/ None,
+    )
+    .await;
+
+    read_thread::read_thread(
+        store,
+        ReadThreadParams {
+            thread_id,
+            include_archived: params.include_archived,
+            include_history: false,
+        },
+    )
+    .await
+}
+
+async fn apply_thread_name(
+    store: &LocalThreadStore,
+    rollout_path: &std::path::Path,
+    thread_id: ThreadId,
+    name: String,
+) -> ThreadStoreResult<()> {
+    let item = RolloutItem::EventMsg(EventMsg::ThreadNameUpdated(ThreadNameUpdatedEvent {
+        thread_id,
+        thread_name: Some(name.clone()),
+    }));
+
+    append_rollout_item_to_path(rollout_path, &item)
+        .await
+        .map_err(|err| ThreadStoreError::Internal {
+            message: format!("failed to set thread name: {err}"),
+        })?;
+    append_thread_name(store.config.codex_home.as_path(), thread_id, &name)
+        .await
+        .map_err(|err| ThreadStoreError::Internal {
+            message: format!("failed to index thread name: {err}"),
+        })
+}
+
+async fn apply_thread_memory_mode(
+    rollout_path: &std::path::Path,
+    thread_id: ThreadId,
+    memory_mode: ThreadMemoryMode,
+) -> ThreadStoreResult<()> {
+    let mut session_meta =
+        read_session_meta_line(rollout_path)
+            .await
+            .map_err(|err| ThreadStoreError::Internal {
+                message: format!("failed to set thread memory mode: {err}"),
+            })?;
+    if session_meta.meta.id != thread_id {
+        return Err(ThreadStoreError::Internal {
+            message: format!(
+                "failed to set thread memory mode: rollout session metadata id mismatch: expected {thread_id}, found {}",
+                session_meta.meta.id
+            ),
+        });
+    }
+
+    session_meta.meta.memory_mode = Some(memory_mode_as_str(memory_mode).to_string());
+    append_rollout_item_to_path(rollout_path, &RolloutItem::SessionMeta(session_meta))
+        .await
+        .map_err(|err| ThreadStoreError::Internal {
+            message: format!("failed to set thread memory mode: {err}"),
+        })
+}
+
+async fn open_state_db_for_direct_thread_lookup(store: &LocalThreadStore) -> Option<StateDbHandle> {
+    codex_state::StateRuntime::init(
+        store.config.sqlite_home.clone(),
+        store.config.model_provider_id.clone(),
+    )
+    .await
+    .ok()
+}
+
+fn memory_mode_as_str(mode: ThreadMemoryMode) -> &'static str {
+    match mode {
+        ThreadMemoryMode::Enabled => "enabled",
+        ThreadMemoryMode::Disabled => "disabled",
+    }
+}
+
+async fn resolve_rollout_path(
+    store: &LocalThreadStore,
+    thread_id: ThreadId,
+    include_archived: bool,
+) -> ThreadStoreResult<ResolvedRolloutPath> {
+    let active_path =
+        find_thread_path_by_id_str(store.config.codex_home.as_path(), &thread_id.to_string())
+            .await
+            .map_err(|err| ThreadStoreError::InvalidRequest {
+                message: format!("failed to locate thread id {thread_id}: {err}"),
+            })?;
+    if let Some(path) = active_path {
+        return Ok(ResolvedRolloutPath {
+            path,
+            archived: false,
+        });
+    }
+    if !include_archived {
+        return Err(ThreadStoreError::InvalidRequest {
+            message: format!("thread not found: {thread_id}"),
+        });
+    }
+    find_archived_thread_path_by_id_str(store.config.codex_home.as_path(), &thread_id.to_string())
+        .await
+        .map_err(|err| ThreadStoreError::InvalidRequest {
+            message: format!("failed to locate archived thread id {thread_id}: {err}"),
+        })?
+        .map(|path| ResolvedRolloutPath {
+            path,
+            archived: true,
+        })
+        .ok_or_else(|| ThreadStoreError::InvalidRequest {
+            message: format!("thread not found: {thread_id}"),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+    use serde_json::Value;
+    use tempfile::TempDir;
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::ThreadMetadataPatch;
+    use crate::ThreadStore;
+    use crate::local::LocalThreadStore;
+    use crate::local::test_support::test_config;
+    use crate::local::test_support::write_archived_session_file;
+    use crate::local::test_support::write_session_file;
+
+    #[tokio::test]
+    async fn update_thread_metadata_sets_name_on_active_rollout_and_indexes_name() {
+        let home = TempDir::new().expect("temp dir");
+        let store = LocalThreadStore::new(test_config(home.path()));
+        let uuid = Uuid::from_u128(301);
+        let thread_id = ThreadId::from_string(&uuid.to_string()).expect("valid thread id");
+        let path =
+            write_session_file(home.path(), "2025-01-03T14-00-00", uuid).expect("session file");
+
+        let thread = store
+            .update_thread_metadata(UpdateThreadMetadataParams {
+                thread_id,
+                patch: ThreadMetadataPatch {
+                    name: Some("A sharper name".to_string()),
+                    ..Default::default()
+                },
+                include_archived: false,
+            })
+            .await
+            .expect("set thread name");
+
+        assert_eq!(thread.name.as_deref(), Some("A sharper name"));
+        let latest_name = codex_rollout::find_thread_name_by_id(home.path(), &thread_id)
+            .await
+            .expect("find thread name");
+        assert_eq!(latest_name.as_deref(), Some("A sharper name"));
+
+        let appended = last_rollout_item(path.as_path());
+        assert_eq!(appended["type"], "event_msg");
+        assert_eq!(appended["payload"]["type"], "thread_name_updated");
+        assert_eq!(appended["payload"]["thread_id"], thread_id.to_string());
+        assert_eq!(appended["payload"]["thread_name"], "A sharper name");
+    }
+
+    #[tokio::test]
+    async fn update_thread_metadata_sets_memory_mode_on_active_rollout() {
+        let home = TempDir::new().expect("temp dir");
+        let store = LocalThreadStore::new(test_config(home.path()));
+        let uuid = Uuid::from_u128(302);
+        let thread_id = ThreadId::from_string(&uuid.to_string()).expect("valid thread id");
+        let path =
+            write_session_file(home.path(), "2025-01-03T14-30-00", uuid).expect("session file");
+
+        let thread = store
+            .update_thread_metadata(UpdateThreadMetadataParams {
+                thread_id,
+                patch: ThreadMetadataPatch {
+                    memory_mode: Some(ThreadMemoryMode::Disabled),
+                    ..Default::default()
+                },
+                include_archived: false,
+            })
+            .await
+            .expect("set thread memory mode");
+
+        assert_eq!(thread.thread_id, thread_id);
+        let appended = last_rollout_item(path.as_path());
+        assert_eq!(appended["type"], "session_meta");
+        assert_eq!(appended["payload"]["id"], thread_id.to_string());
+        assert_eq!(appended["payload"]["memory_mode"], "disabled");
+    }
+
+    #[tokio::test]
+    async fn update_thread_metadata_rejects_mismatched_session_meta_id() {
+        let home = TempDir::new().expect("temp dir");
+        let store = LocalThreadStore::new(test_config(home.path()));
+        let filename_uuid = Uuid::from_u128(303);
+        let metadata_uuid = Uuid::from_u128(304);
+        let thread_id = ThreadId::from_string(&filename_uuid.to_string()).expect("valid thread id");
+        let path = write_session_file(home.path(), "2025-01-03T15-00-00", filename_uuid)
+            .expect("session file");
+        let content = std::fs::read_to_string(&path).expect("read rollout");
+        std::fs::write(
+            &path,
+            content.replace(&filename_uuid.to_string(), &metadata_uuid.to_string()),
+        )
+        .expect("rewrite rollout");
+
+        let err = store
+            .update_thread_metadata(UpdateThreadMetadataParams {
+                thread_id,
+                patch: ThreadMetadataPatch {
+                    memory_mode: Some(ThreadMemoryMode::Enabled),
+                    ..Default::default()
+                },
+                include_archived: false,
+            })
+            .await
+            .expect_err("mismatch should fail");
+
+        assert!(matches!(err, ThreadStoreError::Internal { .. }));
+        assert!(err.to_string().contains("metadata id mismatch"));
+    }
+
+    #[tokio::test]
+    async fn update_thread_metadata_rejects_multi_field_patch_without_partial_write() {
+        let home = TempDir::new().expect("temp dir");
+        let store = LocalThreadStore::new(test_config(home.path()));
+        let uuid = Uuid::from_u128(305);
+        let thread_id = ThreadId::from_string(&uuid.to_string()).expect("valid thread id");
+        let path =
+            write_session_file(home.path(), "2025-01-03T15-30-00", uuid).expect("session file");
+        let original = std::fs::read_to_string(&path).expect("read rollout");
+
+        let err = store
+            .update_thread_metadata(UpdateThreadMetadataParams {
+                thread_id,
+                patch: ThreadMetadataPatch {
+                    name: Some("Should not persist".to_string()),
+                    memory_mode: Some(ThreadMemoryMode::Disabled),
+                    ..Default::default()
+                },
+                include_archived: false,
+            })
+            .await
+            .expect_err("multi-field patch should fail");
+
+        assert!(matches!(err, ThreadStoreError::InvalidRequest { .. }));
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read rollout"),
+            original
+        );
+        let latest_name = codex_rollout::find_thread_name_by_id(home.path(), &thread_id)
+            .await
+            .expect("find thread name");
+        assert_eq!(latest_name, None);
+    }
+
+    #[tokio::test]
+    async fn update_thread_metadata_keeps_archived_thread_archived_in_sqlite() {
+        let home = TempDir::new().expect("temp dir");
+        let config = test_config(home.path());
+        let store = LocalThreadStore::new(config.clone());
+        let uuid = Uuid::from_u128(306);
+        let thread_id = ThreadId::from_string(&uuid.to_string()).expect("valid thread id");
+        let archived_path = write_archived_session_file(home.path(), "2025-01-03T16-00-00", uuid)
+            .expect("archived session file");
+        let runtime = codex_state::StateRuntime::init(
+            home.path().to_path_buf(),
+            config.model_provider_id.clone(),
+        )
+        .await
+        .expect("state db should initialize");
+        runtime
+            .mark_backfill_complete(/*last_watermark*/ None)
+            .await
+            .expect("backfill should be complete");
+        codex_rollout::state_db::reconcile_rollout(
+            Some(runtime.as_ref()),
+            archived_path.as_path(),
+            config.model_provider_id.as_str(),
+            /*builder*/ None,
+            &[],
+            /*archived_only*/ Some(true),
+            /*new_thread_memory_mode*/ None,
+        )
+        .await;
+        assert!(
+            runtime
+                .get_thread(thread_id)
+                .await
+                .expect("get metadata")
+                .expect("metadata")
+                .archived_at
+                .is_some()
+        );
+
+        let thread = store
+            .update_thread_metadata(UpdateThreadMetadataParams {
+                thread_id,
+                patch: ThreadMetadataPatch {
+                    name: Some("Archived title".to_string()),
+                    ..Default::default()
+                },
+                include_archived: true,
+            })
+            .await
+            .expect("set archived thread name");
+
+        assert!(thread.archived_at.is_some());
+        assert!(
+            runtime
+                .get_thread(thread_id)
+                .await
+                .expect("get metadata")
+                .expect("metadata")
+                .archived_at
+                .is_some()
+        );
+    }
+
+    fn last_rollout_item(path: &std::path::Path) -> Value {
+        let last_line = std::fs::read_to_string(path)
+            .expect("read rollout")
+            .lines()
+            .last()
+            .expect("last line")
+            .to_string();
+        serde_json::from_str(&last_line).expect("json line")
+    }
+}

--- a/codex-rs/thread-store/src/remote/mod.rs
+++ b/codex-rs/thread-store/src/remote/mod.rs
@@ -10,7 +10,6 @@ use crate::ListThreadsParams;
 use crate::LoadThreadHistoryParams;
 use crate::ReadThreadParams;
 use crate::ResumeThreadRecorderParams;
-use crate::SetThreadNameParams;
 use crate::StoredThread;
 use crate::StoredThreadHistory;
 use crate::ThreadPage;
@@ -80,10 +79,6 @@ impl ThreadStore for RemoteThreadStore {
 
     async fn list_threads(&self, params: ListThreadsParams) -> ThreadStoreResult<ThreadPage> {
         list_threads::list_threads(self, params).await
-    }
-
-    async fn set_thread_name(&self, _params: SetThreadNameParams) -> ThreadStoreResult<()> {
-        Err(not_implemented("set_thread_name"))
     }
 
     async fn update_thread_metadata(

--- a/codex-rs/thread-store/src/store.rs
+++ b/codex-rs/thread-store/src/store.rs
@@ -7,7 +7,6 @@ use crate::ListThreadsParams;
 use crate::LoadThreadHistoryParams;
 use crate::ReadThreadParams;
 use crate::ResumeThreadRecorderParams;
-use crate::SetThreadNameParams;
 use crate::StoredThread;
 use crate::StoredThreadHistory;
 use crate::ThreadPage;
@@ -44,9 +43,6 @@ pub trait ThreadStore: Send + Sync {
 
     /// Lists stored threads matching the supplied filters.
     async fn list_threads(&self, params: ListThreadsParams) -> ThreadStoreResult<ThreadPage>;
-
-    /// Sets a user-facing thread name.
-    async fn set_thread_name(&self, params: SetThreadNameParams) -> ThreadStoreResult<()>;
 
     /// Applies a mutable metadata patch and returns the updated thread.
     async fn update_thread_metadata(

--- a/codex-rs/thread-store/src/types.rs
+++ b/codex-rs/thread-store/src/types.rs
@@ -11,6 +11,7 @@ use codex_protocol::protocol::GitInfo;
 use codex_protocol::protocol::RolloutItem;
 use codex_protocol::protocol::SandboxPolicy;
 use codex_protocol::protocol::SessionSource;
+use codex_protocol::protocol::ThreadMemoryMode as MemoryMode;
 use codex_protocol::protocol::TokenUsage;
 use serde::Deserialize;
 use serde::Serialize;
@@ -193,15 +194,6 @@ pub struct StoredThread {
     pub history: Option<StoredThreadHistory>,
 }
 
-/// Parameters for setting a user-facing thread name.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct SetThreadNameParams {
-    /// Thread id to update.
-    pub thread_id: ThreadId,
-    /// Normalized thread name.
-    pub name: String,
-}
-
 /// Optional field patch where omission leaves a value unchanged and `Some(None)` clears it.
 pub type OptionalStringPatch = Option<Option<String>>;
 
@@ -219,6 +211,10 @@ pub struct GitInfoPatch {
 /// Patch for mutable thread metadata.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ThreadMetadataPatch {
+    /// Replacement user-facing thread name.
+    pub name: Option<String>,
+    /// Replacement thread memory behavior.
+    pub memory_mode: Option<MemoryMode>,
     /// Optional Git metadata patch.
     pub git_info: Option<GitInfoPatch>,
 }
@@ -230,6 +226,8 @@ pub struct UpdateThreadMetadataParams {
     pub thread_id: ThreadId,
     /// Patch to apply.
     pub patch: ThreadMetadataPatch,
+    /// Whether archived threads are eligible.
+    pub include_archived: bool,
 }
 
 /// Parameters for archiving or unarchiving a thread.


### PR DESCRIPTION
Builds on [#18361](https://github.com/openai/codex/pull/18361), which moves unloaded thread name and memory-mode writes behind ThreadStore.

- Adds an AppServer-local `ThreadStoreAdapter` around `ThreadStore` so the message processor can work with AppServer `Thread` and `ConversationSummary` views instead of persistence-facing `StoredThread` values.
- Moves the stored-thread-to-AppServer conversion logic into the adapter and routes migrated read/write paths through it, including persisted thread reads, list summaries, unarchive, archive checks, and unloaded metadata updates.
- Adds adapter-level unit coverage for stored-thread summary precision and history-to-turn conversion; validated with `cargo test -p codex-app-server`, `just fix -p codex-app-server`, `cargo check -p codex-app-server`, `just fmt`, and `git diff --check`.
