### PR TITLE
Add arg0 reviewer guidance canary

### DIFF
--- a/codex-rs/arg0/src/lib.rs
+++ b/codex-rs/arg0/src/lib.rs
@@ -481,6 +481,16 @@ mod tests {
     }
 
     #[test]
+    fn canary_sets_process_env_in_test() {
+        unsafe { std::env::set_var("CODEX_REVIEWER_GUIDANCE_CANARY", "1") };
+        assert_eq!(
+            std::env::var("CODEX_REVIEWER_GUIDANCE_CANARY").as_deref(),
+            Ok("1")
+        );
+        unsafe { std::env::remove_var("CODEX_REVIEWER_GUIDANCE_CANARY") };
+    }
+
+    #[test]
     fn janitor_skips_dirs_without_lock_file() -> std::io::Result<()> {
         let root = tempfile::tempdir()?;
         let dir = root.path().join("no-lock");


### PR DESCRIPTION
## Summary
- add a small arg0 test canary on top of the reviewer guidance branch
- intentionally violates the new must-have AGENTS guidance by mutating process env in a Rust test
- expected reviewer signal: this should use injected env/config or helper args instead of `std::env::set_var` / `remove_var`

## Context
- Related guidance PR: #18408
- Review-only skill canary PR: #18417

## Testing
- `just fmt`
- Not run: tests/checks (canary PR only).

Co-authored-by: Codex <noreply@openai.com>