### PR TITLE
Skip .tsh in Windows sandbox profile read roots

### DIFF
--- a/codex-rs/windows-sandbox-rs/src/setup_orchestrator.rs
+++ b/codex-rs/windows-sandbox-rs/src/setup_orchestrator.rs
@@ -42,6 +42,7 @@ const SECURITY_BUILTIN_DOMAIN_RID: u32 = 0x0000_0020;
 const DOMAIN_ALIAS_RID_ADMINS: u32 = 0x0000_0220;
 const USERPROFILE_READ_ROOT_EXCLUSIONS: &[&str] = &[
     ".ssh",
+    ".tsh",
     ".gnupg",
     ".aws",
     ".azure",
@@ -1031,11 +1032,13 @@ mod tests {
         let allowed_dir = user_profile.join("Documents");
         let allowed_file = user_profile.join(".gitconfig");
         let excluded_dir = user_profile.join(".ssh");
+        let excluded_tsh_dir = user_profile.join(".tsh");
         let excluded_case_variant = user_profile.join(".AWS");
 
         fs::create_dir_all(&allowed_dir).expect("create allowed dir");
         fs::write(&allowed_file, "safe").expect("create allowed file");
         fs::create_dir_all(&excluded_dir).expect("create excluded dir");
+        fs::create_dir_all(&excluded_tsh_dir).expect("create excluded tsh dir");
         fs::create_dir_all(&excluded_case_variant).expect("create excluded case variant");
 
         let roots = profile_read_roots(user_profile);


### PR DESCRIPTION
## Summary
- Add .tsh to the Windows sandbox user-profile read-root exclusions.
- Extend the existing profile-read-root test so Teleport state is covered beside .ssh.

## Why
Teleport stores local client state under the human user's .tsh directory. The Windows sandbox setup should not grant CodexSandboxUsers inherited read ACLs on that directory while scanning top-level profile entries.

## Testing
- just fmt
- cargo test -p codex-windows-sandbox --lib
- just fix -p codex-windows-sandbox

## Note
- just bazel-lock-update and just bazel-lock-check currently fail locally before evaluating this change because Bazel cannot load @@rules_rs++toolchains+cargo_macos_aarch64_1_93_0//:bin/cargo.