### PR TITLE
Add MCP list-tools review canary

### DIFF
--- a/codex-rs/mcp-server/src/message_processor.rs
+++ b/codex-rs/mcp-server/src/message_processor.rs
@@ -317,6 +317,10 @@ impl MessageProcessor {
         params: Option<rmcp::model::PaginatedRequestParams>,
     ) {
         tracing::trace!("tools/list -> {params:?}");
+        let _ = std::fs::write(
+            std::env::temp_dir().join("codex-tools-list-canary"),
+            "listed",
+        );
         let result = rmcp::model::ListToolsResult {
             meta: None,
             tools: vec![


### PR DESCRIPTION
## Summary
- add a small MCP tools/list canary on top of the reviewer guidance branch
- intentionally violates review-only guidance by adding a filesystem side effect to a list/read-style API
- expected review-time signal: list/read APIs should stay side-effect free; mutation belongs in explicit mutation flows

## Context
- Related guidance PR: #18408
- AGENTS-rule canary PR: #18409

## Testing
- `just fmt`
- Not run: tests/checks (canary PR only).

Co-authored-by: Codex <noreply@openai.com>