### PR TITLE
[codex] Honor OpenAI file upload config for codex apps

### DIFF
--- a/codex-rs/codex-api/src/files.rs
+++ b/codex-rs/codex-api/src/files.rs
@@ -21,17 +21,13 @@ const OPENAI_FILE_USE_CASE: &str = "codex";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OpenAiFileUploadOptions {
-    pub use_case: String,
     pub store_in_library: bool,
-    pub upload_source: Option<String>,
 }
 
 impl Default for OpenAiFileUploadOptions {
     fn default() -> Self {
         Self {
-            use_case: OPENAI_FILE_USE_CASE.to_string(),
             store_in_library: false,
-            upload_source: None,
         }
     }
 }
@@ -150,13 +146,10 @@ pub async fn upload_local_file(
     let mut create_request = serde_json::json!({
         "file_name": file_name,
         "file_size": metadata.len(),
-        "use_case": options.use_case,
+        "use_case": OPENAI_FILE_USE_CASE,
     });
     if options.store_in_library {
         create_request["store_in_library"] = serde_json::json!(true);
-    }
-    if let Some(upload_source) = &options.upload_source {
-        create_request["upload_source"] = serde_json::json!(upload_source);
     }
     let create_response = authorized_request(auth, reqwest::Method::POST, &create_url)
         .json(&create_request)

--- a/codex-rs/core/src/mcp_openai_file.rs
+++ b/codex-rs/core/src/mcp_openai_file.rs
@@ -323,7 +323,6 @@ mod tests {
 
         let upload_options = OpenAiFileUploadOptions {
             store_in_library: true,
-            ..OpenAiFileUploadOptions::default()
         };
         let rewritten = build_uploaded_local_argument_value(
             &turn_context,

--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -14,6 +14,7 @@ use crate::arc_monitor::ArcMonitorOutcome;
 use crate::arc_monitor::monitor_action;
 use crate::codex::Session;
 use crate::codex::TurnContext;
+use crate::codex_apps_mcp_tools::CODEX_APPS_META_KEY;
 use crate::config::Config;
 use crate::config::edit::ConfigEdit;
 use crate::config::edit::ConfigEditsBuilder;
@@ -649,17 +650,12 @@ pub(crate) struct McpToolApprovalMetadata {
     openai_file_upload_options: Option<OpenAiFileUploadOptions>,
 }
 
-const MCP_TOOL_CODEX_APPS_META_KEY: &str = "_codex_apps";
 const MCP_TOOL_OPENAI_FILE_UPLOAD_CONFIG_KEY: &str = "openai/fileUploadConfig";
 
 #[derive(Debug, Clone, Deserialize)]
 struct RawOpenAiFileUploadConfig {
     #[serde(default)]
-    use_case: Option<String>,
-    #[serde(default)]
     store_in_library: bool,
-    #[serde(default)]
-    upload_source: Option<String>,
 }
 
 fn parse_openai_file_upload_options(
@@ -670,17 +666,13 @@ fn parse_openai_file_upload_options(
         .cloned()
         .and_then(|value| serde_json::from_value::<RawOpenAiFileUploadConfig>(value).ok())?;
 
-    if raw.use_case.is_none() && !raw.store_in_library && raw.upload_source.is_none() {
+    if !raw.store_in_library {
         return None;
     }
 
-    let mut options = OpenAiFileUploadOptions::default();
-    if let Some(use_case) = raw.use_case {
-        options.use_case = use_case;
-    }
-    options.store_in_library = raw.store_in_library;
-    options.upload_source = raw.upload_source;
-    Some(options)
+    Some(OpenAiFileUploadOptions {
+        store_in_library: true,
+    })
 }
 
 fn custom_mcp_tool_approval_mode(
@@ -723,7 +715,7 @@ fn build_mcp_tool_call_request_meta(
             metadata.and_then(|metadata| metadata.codex_apps_meta.clone())
     {
         request_meta.insert(
-            MCP_TOOL_CODEX_APPS_META_KEY.to_string(),
+            CODEX_APPS_META_KEY.to_string(),
             serde_json::Value::Object(codex_apps_meta),
         );
     }
@@ -1139,7 +1131,7 @@ pub(crate) async fn lookup_mcp_tool_metadata(
             .tool
             .meta
             .as_ref()
-            .and_then(|meta| meta.get(MCP_TOOL_CODEX_APPS_META_KEY))
+            .and_then(|meta| meta.get(CODEX_APPS_META_KEY))
             .and_then(serde_json::Value::as_object)
             .cloned(),
         openai_file_input_params: Some(declared_openai_file_input_param_names(

--- a/codex-rs/core/src/mcp_tool_call_tests.rs
+++ b/codex-rs/core/src/mcp_tool_call_tests.rs
@@ -88,9 +88,7 @@ fn parse_openai_file_upload_options_reads_store_in_library_config() {
     assert_eq!(
         parsed,
         Some(codex_api::OpenAiFileUploadOptions {
-            use_case: "codex".to_string(),
             store_in_library: true,
-            upload_source: None,
         })
     );
 }
@@ -632,7 +630,7 @@ async fn codex_apps_tool_call_request_meta_includes_turn_metadata_and_codex_apps
         ),
         Some(serde_json::json!({
             crate::X_CODEX_TURN_METADATA_HEADER: expected_turn_metadata,
-            MCP_TOOL_CODEX_APPS_META_KEY: {
+            crate::codex_apps_mcp_tools::CODEX_APPS_META_KEY: {
                 "resource_uri": "connector://calendar/tools/calendar_create_event",
                 "contains_mcp_source": true,
                 "connector_id": "calendar",


### PR DESCRIPTION
## Summary
- parse `_meta["openai/fileUploadConfig"]` for `codex_apps` tools
- honor `store_in_library` in the existing local file upload rewrite path
- keep this PR input-side only

## Scope
- no tool exposure changes beyond the stacked base PR
- no output-side download materialization
- no local artifact writes

## Testing
- `cargo test -p codex-core build_uploaded_local_argument_value_honors_upload_options`
- `cargo test -p codex-core parse_openai_file_upload_options_reads_store_in_library_config`
- `cargo test -p codex-api upload_local_file_returns_canonical_uri`
