### PR TITLE
Reserve missing preserved paths in Linux sandbox policy

### DIFF
--- a/codex-rs/linux-sandbox/src/bwrap.rs
+++ b/codex-rs/linux-sandbox/src/bwrap.rs
@@ -15,15 +15,18 @@ use std::collections::HashSet;
 use std::ffi::OsString;
 use std::fs;
 use std::fs::File;
+use std::fs::Metadata;
 use std::io;
 use std::os::fd::AsRawFd;
 use std::os::unix::ffi::OsStringExt;
+use std::os::unix::fs::MetadataExt;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 
 use codex_protocol::error::CodexErr;
 use codex_protocol::error::Result;
+use codex_protocol::permissions::is_preserved_path_name;
 use codex_protocol::protocol::FileSystemSandboxPolicy;
 use codex_protocol::protocol::WritableRoot;
 use codex_utils_absolute_path::AbsolutePathBuf;
@@ -101,6 +104,121 @@ impl BwrapNetworkMode {
 pub(crate) struct BwrapArgs {
     pub args: Vec<String>,
     pub preserved_files: Vec<File>,
+    pub synthetic_mount_targets: Vec<SyntheticMountTarget>,
+    pub protected_create_targets: Vec<ProtectedCreateTarget>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct FileIdentity {
+    dev: u64,
+    ino: u64,
+}
+
+impl FileIdentity {
+    fn from_metadata(metadata: &Metadata) -> Self {
+        Self {
+            dev: metadata.dev(),
+            ino: metadata.ino(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SyntheticMountTargetKind {
+    EmptyFile,
+    EmptyDirectory,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct SyntheticMountTarget {
+    path: PathBuf,
+    kind: SyntheticMountTargetKind,
+    // If an empty preserved path was already present, remember its inode so
+    // cleanup does not delete a real pre-existing file or directory.
+    pre_existing_path: Option<FileIdentity>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ProtectedCreateTarget {
+    path: PathBuf,
+}
+
+impl ProtectedCreateTarget {
+    pub(crate) fn missing(path: &Path) -> Self {
+        Self {
+            path: path.to_path_buf(),
+        }
+    }
+
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl SyntheticMountTarget {
+    pub(crate) fn missing(path: &Path) -> Self {
+        Self {
+            path: path.to_path_buf(),
+            kind: SyntheticMountTargetKind::EmptyFile,
+            pre_existing_path: None,
+        }
+    }
+
+    pub(crate) fn missing_empty_directory(path: &Path) -> Self {
+        Self {
+            path: path.to_path_buf(),
+            kind: SyntheticMountTargetKind::EmptyDirectory,
+            pre_existing_path: None,
+        }
+    }
+
+    pub(crate) fn existing_empty_file(path: &Path, metadata: &Metadata) -> Self {
+        Self {
+            path: path.to_path_buf(),
+            kind: SyntheticMountTargetKind::EmptyFile,
+            pre_existing_path: Some(FileIdentity::from_metadata(metadata)),
+        }
+    }
+
+    fn existing_empty_directory(path: &Path, metadata: &Metadata) -> Self {
+        Self {
+            path: path.to_path_buf(),
+            kind: SyntheticMountTargetKind::EmptyDirectory,
+            pre_existing_path: Some(FileIdentity::from_metadata(metadata)),
+        }
+    }
+
+    pub(crate) fn preserves_pre_existing_path(&self) -> bool {
+        self.pre_existing_path.is_some()
+    }
+
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub(crate) fn kind(&self) -> SyntheticMountTargetKind {
+        self.kind
+    }
+
+    pub(crate) fn should_remove_after_bwrap(&self, metadata: &Metadata) -> bool {
+        match self.kind {
+            SyntheticMountTargetKind::EmptyFile => {
+                if !metadata.file_type().is_file() || metadata.len() != 0 {
+                    return false;
+                }
+            }
+            SyntheticMountTargetKind::EmptyDirectory => {
+                if !metadata.file_type().is_dir() {
+                    return false;
+                }
+            }
+        }
+
+        match self.pre_existing_path {
+            Some(pre_existing_path) => pre_existing_path != FileIdentity::from_metadata(metadata),
+            None => true,
+        }
+    }
 }
 
 /// Wrap a command with bubblewrap so the filesystem is read-only by default,
@@ -126,6 +244,8 @@ pub(crate) fn create_bwrap_command_args(
             Ok(BwrapArgs {
                 args: command,
                 preserved_files: Vec::new(),
+                synthetic_mount_targets: Vec::new(),
+                protected_create_targets: Vec::new(),
             })
         } else {
             Ok(create_bwrap_flags_full_filesystem(command, options))
@@ -165,6 +285,8 @@ fn create_bwrap_flags_full_filesystem(command: Vec<String>, options: BwrapOption
     BwrapArgs {
         args,
         preserved_files: Vec::new(),
+        synthetic_mount_targets: Vec::new(),
+        protected_create_targets: Vec::new(),
     }
 }
 
@@ -179,6 +301,8 @@ fn create_bwrap_flags(
     let BwrapArgs {
         args: filesystem_args,
         preserved_files,
+        synthetic_mount_targets,
+        protected_create_targets,
     } = create_filesystem_args(
         file_system_sandbox_policy,
         sandbox_policy_cwd,
@@ -216,6 +340,8 @@ fn create_bwrap_flags(
     Ok(BwrapArgs {
         args,
         preserved_files,
+        synthetic_mount_targets,
+        protected_create_targets,
     })
 }
 
@@ -275,7 +401,7 @@ fn create_filesystem_args(
     unreadable_roots.sort();
     unreadable_roots.dedup();
 
-    let mut args = if file_system_sandbox_policy.has_full_disk_read_access() {
+    let args = if file_system_sandbox_policy.has_full_disk_read_access() {
         // Read-only root, then mount a minimal device tree.
         // In bubblewrap (`bubblewrap.c`, `SETUP_MOUNT_DEV`), `--dev /dev`
         // creates the standard minimal nodes: null, zero, full, random,
@@ -348,7 +474,12 @@ fn create_filesystem_args(
 
         args
     };
-    let mut preserved_files = Vec::new();
+    let mut bwrap_args = BwrapArgs {
+        args,
+        preserved_files: Vec::new(),
+        synthetic_mount_targets: Vec::new(),
+        protected_create_targets: Vec::new(),
+    };
     let mut allowed_write_paths = Vec::with_capacity(writable_roots.len());
     for writable_root in &writable_roots {
         let root = writable_root.root.as_path();
@@ -379,12 +510,7 @@ fn create_filesystem_args(
     unreadable_ancestors_of_writable_roots.sort_by_key(|path| path_depth(path));
 
     for unreadable_root in &unreadable_ancestors_of_writable_roots {
-        append_unreadable_root_args(
-            &mut args,
-            &mut preserved_files,
-            unreadable_root,
-            &allowed_write_paths,
-        )?;
+        append_unreadable_root_args(&mut bwrap_args, unreadable_root, &allowed_write_paths)?;
     }
 
     for writable_root in &sorted_writable_roots {
@@ -398,13 +524,13 @@ fn create_filesystem_args(
             .filter(|unreadable_root| root.starts_with(unreadable_root))
             .max_by_key(|unreadable_root| path_depth(unreadable_root))
         {
-            append_mount_target_parent_dir_args(&mut args, root, masking_root);
+            append_mount_target_parent_dir_args(&mut bwrap_args.args, root, masking_root);
         }
 
         let mount_root = symlink_target.as_deref().unwrap_or(root);
-        args.push("--bind".to_string());
-        args.push(path_to_string(mount_root));
-        args.push(path_to_string(mount_root));
+        bwrap_args.args.push("--bind".to_string());
+        bwrap_args.args.push(path_to_string(mount_root));
+        bwrap_args.args.push(path_to_string(mount_root));
 
         let mut read_only_subpaths: Vec<PathBuf> = writable_root
             .read_only_subpaths
@@ -415,9 +541,16 @@ fn create_filesystem_args(
         if let Some(target) = &symlink_target {
             read_only_subpaths = remap_paths_for_symlink_target(read_only_subpaths, root, target);
         }
+        append_protected_create_targets_for_writable_root(
+            &mut bwrap_args,
+            writable_root,
+            root,
+            symlink_target.as_deref(),
+            &read_only_subpaths,
+        );
         read_only_subpaths.sort_by_key(|path| path_depth(path));
         for subpath in read_only_subpaths {
-            append_read_only_subpath_args(&mut args, &subpath, &allowed_write_paths)?;
+            append_read_only_subpath_args(&mut bwrap_args, &subpath, &allowed_write_paths)?;
         }
         let mut nested_unreadable_roots: Vec<PathBuf> = unreadable_roots
             .iter()
@@ -430,12 +563,7 @@ fn create_filesystem_args(
         }
         nested_unreadable_roots.sort_by_key(|path| path_depth(path));
         for unreadable_root in nested_unreadable_roots {
-            append_unreadable_root_args(
-                &mut args,
-                &mut preserved_files,
-                &unreadable_root,
-                &allowed_write_paths,
-            )?;
+            append_unreadable_root_args(&mut bwrap_args, &unreadable_root, &allowed_write_paths)?;
         }
     }
 
@@ -451,18 +579,33 @@ fn create_filesystem_args(
         .collect();
     rootless_unreadable_roots.sort_by_key(|path| path_depth(path));
     for unreadable_root in rootless_unreadable_roots {
-        append_unreadable_root_args(
-            &mut args,
-            &mut preserved_files,
-            &unreadable_root,
-            &allowed_write_paths,
-        )?;
+        append_unreadable_root_args(&mut bwrap_args, &unreadable_root, &allowed_write_paths)?;
     }
 
-    Ok(BwrapArgs {
-        args,
-        preserved_files,
-    })
+    Ok(bwrap_args)
+}
+
+fn append_protected_create_targets_for_writable_root(
+    bwrap_args: &mut BwrapArgs,
+    writable_root: &WritableRoot,
+    root: &Path,
+    symlink_target: Option<&Path>,
+    read_only_subpaths: &[PathBuf],
+) {
+    for name in &writable_root.preserved_path_names {
+        let mut path = root.join(name);
+        if let Some(target) = symlink_target
+            && let Ok(relative_path) = path.strip_prefix(root)
+        {
+            path = target.join(relative_path);
+        }
+        if read_only_subpaths.iter().any(|subpath| subpath == &path) || path.exists() {
+            continue;
+        }
+        bwrap_args
+            .protected_create_targets
+            .push(ProtectedCreateTarget::missing(&path));
+    }
 }
 
 fn expand_unreadable_globs_with_ripgrep(
@@ -787,7 +930,7 @@ fn append_mount_target_parent_dir_args(args: &mut Vec<String>, mount_target: &Pa
 }
 
 fn append_read_only_subpath_args(
-    args: &mut Vec<String>,
+    bwrap_args: &mut BwrapArgs,
     subpath: &Path,
     allowed_write_paths: &[PathBuf],
 ) -> Result<()> {
@@ -805,28 +948,107 @@ fn append_read_only_subpath_args(
         )));
     }
 
+    if let Some(metadata) = transient_empty_preserved_path_metadata(subpath)
+        && is_within_allowed_write_paths(subpath, allowed_write_paths)
+    {
+        // Another concurrent bwrap setup can leave an empty mount target at
+        // a missing preserved path. Treat it like the missing case instead of
+        // binding that transient host path as the stable source.
+        match metadata {
+            EmptyPreservedPathMetadata::File(metadata) => {
+                append_existing_empty_file_bind_data_args(bwrap_args, subpath, &metadata)?;
+            }
+            EmptyPreservedPathMetadata::Directory(metadata) => {
+                append_existing_empty_directory_args(bwrap_args, subpath, &metadata);
+            }
+        }
+        return Ok(());
+    }
+
     if !subpath.exists() {
         if let Some(first_missing_component) = find_first_non_existent_component(subpath)
             && is_within_allowed_write_paths(&first_missing_component, allowed_write_paths)
         {
-            args.push("--ro-bind".to_string());
-            args.push("/dev/null".to_string());
-            args.push(path_to_string(&first_missing_component));
+            append_missing_read_only_subpath_args(bwrap_args, &first_missing_component)?;
         }
         return Ok(());
     }
 
     if is_within_allowed_write_paths(subpath, allowed_write_paths) {
-        args.push("--ro-bind".to_string());
-        args.push(path_to_string(subpath));
-        args.push(path_to_string(subpath));
+        bwrap_args.args.push("--ro-bind".to_string());
+        bwrap_args.args.push(path_to_string(subpath));
+        bwrap_args.args.push(path_to_string(subpath));
     }
     Ok(())
 }
 
+fn append_empty_file_bind_data_args(bwrap_args: &mut BwrapArgs, path: &Path) -> Result<()> {
+    if bwrap_args.preserved_files.is_empty() {
+        bwrap_args.preserved_files.push(File::open("/dev/null")?);
+    }
+    let null_fd = bwrap_args.preserved_files[0].as_raw_fd().to_string();
+    bwrap_args.args.push("--ro-bind-data".to_string());
+    bwrap_args.args.push(null_fd);
+    bwrap_args.args.push(path_to_string(path));
+    Ok(())
+}
+
+fn append_empty_directory_args(bwrap_args: &mut BwrapArgs, path: &Path) {
+    bwrap_args.args.push("--perms".to_string());
+    bwrap_args.args.push("555".to_string());
+    bwrap_args.args.push("--tmpfs".to_string());
+    bwrap_args.args.push(path_to_string(path));
+    bwrap_args.args.push("--remount-ro".to_string());
+    bwrap_args.args.push(path_to_string(path));
+}
+
+fn append_missing_read_only_subpath_args(bwrap_args: &mut BwrapArgs, path: &Path) -> Result<()> {
+    if path.file_name().is_some_and(is_preserved_path_name) {
+        append_empty_directory_args(bwrap_args, path);
+        bwrap_args
+            .synthetic_mount_targets
+            .push(SyntheticMountTarget::missing_empty_directory(path));
+        return Ok(());
+    }
+
+    append_missing_empty_file_bind_data_args(bwrap_args, path)
+}
+
+fn append_missing_empty_file_bind_data_args(bwrap_args: &mut BwrapArgs, path: &Path) -> Result<()> {
+    append_empty_file_bind_data_args(bwrap_args, path)?;
+    bwrap_args
+        .synthetic_mount_targets
+        .push(SyntheticMountTarget::missing(path));
+    Ok(())
+}
+
+fn append_existing_empty_file_bind_data_args(
+    bwrap_args: &mut BwrapArgs,
+    path: &Path,
+    metadata: &Metadata,
+) -> Result<()> {
+    append_empty_file_bind_data_args(bwrap_args, path)?;
+    bwrap_args
+        .synthetic_mount_targets
+        .push(SyntheticMountTarget::existing_empty_file(path, metadata));
+    Ok(())
+}
+
+fn append_existing_empty_directory_args(
+    bwrap_args: &mut BwrapArgs,
+    path: &Path,
+    metadata: &Metadata,
+) {
+    append_empty_directory_args(bwrap_args, path);
+    bwrap_args
+        .synthetic_mount_targets
+        .push(SyntheticMountTarget::existing_empty_directory(
+            path, metadata,
+        ));
+}
+
 fn append_unreadable_root_args(
-    args: &mut Vec<String>,
-    preserved_files: &mut Vec<File>,
+    bwrap_args: &mut BwrapArgs,
     unreadable_root: &Path,
     allowed_write_paths: &[PathBuf],
 ) -> Result<()> {
@@ -851,24 +1073,16 @@ fn append_unreadable_root_args(
         if let Some(first_missing_component) = find_first_non_existent_component(unreadable_root)
             && is_within_allowed_write_paths(&first_missing_component, allowed_write_paths)
         {
-            args.push("--ro-bind".to_string());
-            args.push("/dev/null".to_string());
-            args.push(path_to_string(&first_missing_component));
+            append_missing_empty_file_bind_data_args(bwrap_args, &first_missing_component)?;
         }
         return Ok(());
     }
 
-    append_existing_unreadable_path_args(
-        args,
-        preserved_files,
-        unreadable_root,
-        allowed_write_paths,
-    )
+    append_existing_unreadable_path_args(bwrap_args, unreadable_root, allowed_write_paths)
 }
 
 fn append_existing_unreadable_path_args(
-    args: &mut Vec<String>,
-    preserved_files: &mut Vec<File>,
+    bwrap_args: &mut BwrapArgs,
     unreadable_root: &Path,
     allowed_write_paths: &[PathBuf],
 ) -> Result<()> {
@@ -878,40 +1092,37 @@ fn append_existing_unreadable_path_args(
             .map(PathBuf::as_path)
             .filter(|path| *path != unreadable_root && path.starts_with(unreadable_root))
             .collect();
-        args.push("--perms".to_string());
+        bwrap_args.args.push("--perms".to_string());
         // Execute-only perms let the process traverse into explicitly
         // re-opened writable descendants while still hiding the denied
         // directory contents. Plain denied directories with no writable child
         // mounts stay at `000`.
-        args.push(if writable_descendants.is_empty() {
+        bwrap_args.args.push(if writable_descendants.is_empty() {
             "000".to_string()
         } else {
             "111".to_string()
         });
-        args.push("--tmpfs".to_string());
-        args.push(path_to_string(unreadable_root));
+        bwrap_args.args.push("--tmpfs".to_string());
+        bwrap_args.args.push(path_to_string(unreadable_root));
         // Recreate any writable descendants inside the tmpfs before remounting
         // the denied parent read-only. Otherwise bubblewrap cannot mkdir the
         // nested mount targets after the parent has been frozen.
         writable_descendants.sort_by_key(|path| path_depth(path));
         for writable_descendant in writable_descendants {
-            append_mount_target_parent_dir_args(args, writable_descendant, unreadable_root);
+            append_mount_target_parent_dir_args(
+                &mut bwrap_args.args,
+                writable_descendant,
+                unreadable_root,
+            );
         }
-        args.push("--remount-ro".to_string());
-        args.push(path_to_string(unreadable_root));
+        bwrap_args.args.push("--remount-ro".to_string());
+        bwrap_args.args.push(path_to_string(unreadable_root));
         return Ok(());
     }
 
-    if preserved_files.is_empty() {
-        preserved_files.push(File::open("/dev/null")?);
-    }
-    let null_fd = preserved_files[0].as_raw_fd().to_string();
-    args.push("--perms".to_string());
-    args.push("000".to_string());
-    args.push("--ro-bind-data".to_string());
-    args.push(null_fd);
-    args.push(path_to_string(unreadable_root));
-    Ok(())
+    bwrap_args.args.push("--perms".to_string());
+    bwrap_args.args.push("000".to_string());
+    append_empty_file_bind_data_args(bwrap_args, unreadable_root)
 }
 
 /// Returns true when `path` is under any allowed writable root.
@@ -919,6 +1130,35 @@ fn is_within_allowed_write_paths(path: &Path, allowed_write_paths: &[PathBuf]) -
     allowed_write_paths
         .iter()
         .any(|root| path.starts_with(root))
+}
+
+enum EmptyPreservedPathMetadata {
+    File(Metadata),
+    Directory(Metadata),
+}
+
+fn transient_empty_preserved_path_metadata(path: &Path) -> Option<EmptyPreservedPathMetadata> {
+    if !path.file_name().is_some_and(is_preserved_path_name) {
+        return None;
+    }
+
+    let metadata = fs::symlink_metadata(path).ok()?;
+    if metadata.file_type().is_file() && metadata.len() == 0 {
+        return Some(EmptyPreservedPathMetadata::File(metadata));
+    }
+
+    if metadata.file_type().is_dir() && directory_is_empty(path) {
+        return Some(EmptyPreservedPathMetadata::Directory(metadata));
+    }
+
+    None
+}
+
+fn directory_is_empty(path: &Path) -> bool {
+    let Ok(mut entries) = fs::read_dir(path) else {
+        return false;
+    };
+    entries.next().is_none()
 }
 
 fn first_writable_symlink_component_in_path(
@@ -998,6 +1238,7 @@ fn find_first_non_existent_component(target_path: &Path) -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
     use codex_protocol::protocol::FileSystemAccessMode;
     use codex_protocol::protocol::FileSystemPath;
     use codex_protocol::protocol::FileSystemSandboxEntry;
@@ -1360,6 +1601,132 @@ mod tests {
     }
 
     #[test]
+    fn missing_read_only_subpath_uses_empty_file_bind_data() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let workspace = temp_dir.path().join("workspace");
+        let blocked = workspace.join("blocked");
+        std::fs::create_dir_all(&workspace).expect("create workspace");
+
+        let workspace_root =
+            AbsolutePathBuf::from_absolute_path(&workspace).expect("absolute workspace");
+        let blocked_root = AbsolutePathBuf::from_absolute_path(&blocked).expect("absolute blocked");
+        let policy = FileSystemSandboxPolicy::restricted(vec![
+            FileSystemSandboxEntry {
+                path: FileSystemPath::Path {
+                    path: workspace_root,
+                },
+                access: FileSystemAccessMode::Write,
+            },
+            FileSystemSandboxEntry {
+                path: FileSystemPath::Path { path: blocked_root },
+                access: FileSystemAccessMode::Read,
+            },
+        ]);
+
+        let args =
+            create_filesystem_args(&policy, temp_dir.path(), NO_UNREADABLE_GLOB_SCAN_MAX_DEPTH)
+                .expect("filesystem args");
+
+        assert_empty_file_bound_without_perms(&args.args, &blocked);
+        assert_empty_directory_mounted_read_only(&args.args, &workspace.join(".git"));
+        assert_empty_directory_mounted_read_only(&args.args, &workspace.join(".agents"));
+        assert_empty_directory_mounted_read_only(&args.args, &workspace.join(".codex"));
+        assert_eq!(args.preserved_files.len(), 1);
+        assert_eq!(
+            synthetic_mount_target_paths(&args),
+            vec![
+                workspace.join(".git"),
+                workspace.join(".agents"),
+                workspace.join(".codex"),
+                blocked.clone(),
+            ]
+        );
+        assert!(
+            !blocked.exists(),
+            "missing path mask should not materialize host-side preserved paths at arg construction time",
+        );
+    }
+
+    #[test]
+    fn transient_empty_preserved_file_uses_empty_file_bind_data() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let workspace = temp_dir.path().join("workspace");
+        let dot_git = workspace.join(".git");
+        std::fs::create_dir_all(&workspace).expect("create workspace");
+        File::create(&dot_git).expect("create empty .git file");
+
+        let workspace_root =
+            AbsolutePathBuf::from_absolute_path(&workspace).expect("absolute workspace");
+        let policy = FileSystemSandboxPolicy::restricted(vec![FileSystemSandboxEntry {
+            path: FileSystemPath::Path {
+                path: workspace_root,
+            },
+            access: FileSystemAccessMode::Write,
+        }]);
+
+        let args =
+            create_filesystem_args(&policy, temp_dir.path(), NO_UNREADABLE_GLOB_SCAN_MAX_DEPTH)
+                .expect("filesystem args");
+        let dot_git_str = path_to_string(&dot_git);
+
+        assert_empty_file_bound_without_perms(&args.args, &dot_git);
+        assert_empty_directory_mounted_read_only(&args.args, &workspace.join(".agents"));
+        assert_empty_directory_mounted_read_only(&args.args, &workspace.join(".codex"));
+        assert_eq!(
+            synthetic_mount_target_paths(&args),
+            vec![
+                dot_git.clone(),
+                workspace.join(".agents"),
+                workspace.join(".codex"),
+            ]
+        );
+        assert!(
+            !args
+                .args
+                .windows(3)
+                .any(|window| window == ["--ro-bind", dot_git_str.as_str(), dot_git_str.as_str()]),
+            "transient empty preserved file should not be treated as a stable bind source",
+        );
+        let metadata = std::fs::symlink_metadata(&dot_git).expect("stat .git");
+        assert!(
+            !args.synthetic_mount_targets[0].should_remove_after_bwrap(&metadata),
+            "pre-existing empty preserved files must not be cleaned up as synthetic targets",
+        );
+    }
+
+    #[test]
+    fn missing_child_git_under_parent_repo_uses_read_only_empty_directory() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let repo = temp_dir.path().join("repo");
+        let workspace = repo.join("workspace");
+        let dot_git = workspace.join(".git");
+        std::fs::create_dir_all(repo.join(".git")).expect("create parent .git");
+        std::fs::create_dir_all(&workspace).expect("create workspace");
+
+        let workspace_root =
+            AbsolutePathBuf::from_absolute_path(&workspace).expect("absolute workspace");
+        let policy = FileSystemSandboxPolicy::restricted(vec![FileSystemSandboxEntry {
+            path: FileSystemPath::Path {
+                path: workspace_root,
+            },
+            access: FileSystemAccessMode::Write,
+        }]);
+
+        let args = create_filesystem_args(&policy, &workspace, NO_UNREADABLE_GLOB_SCAN_MAX_DEPTH)
+            .expect("filesystem args");
+        assert_empty_directory_mounted_read_only(&args.args, &dot_git);
+        assert!(
+            synthetic_mount_target_paths(&args).contains(&dot_git),
+            "missing child .git should be a transient mount target",
+        );
+        assert_eq!(
+            protected_create_target_paths(&args),
+            Vec::<PathBuf>::new(),
+            "missing child .git should fail at creation time through the read-only mount",
+        );
+    }
+
+    #[test]
     fn ignores_missing_writable_roots() {
         let temp_dir = TempDir::new().expect("temp dir");
         let existing_root = temp_dir.path().join("existing");
@@ -1412,6 +1779,18 @@ mod tests {
             NO_UNREADABLE_GLOB_SCAN_MAX_DEPTH,
         )
         .expect("bwrap fs args");
+        assert!(args.preserved_files.is_empty());
+        assert_eq!(
+            synthetic_mount_target_paths(&args),
+            vec![
+                PathBuf::from("/.git"),
+                PathBuf::from("/.agents"),
+                PathBuf::from("/.codex"),
+                PathBuf::from("/dev/.git"),
+                PathBuf::from("/dev/.agents"),
+                PathBuf::from("/dev/.codex"),
+            ]
+        );
         assert_eq!(
             args.args,
             vec![
@@ -1426,17 +1805,50 @@ mod tests {
                 "--bind".to_string(),
                 "/".to_string(),
                 "/".to_string(),
-                // Mask the default protected .codex subpath under that writable
+                // Mask the default preserved paths under that writable
                 // root. Because the root is `/` in this test, the carveout path
-                // appears as `/.codex`.
-                "--ro-bind".to_string(),
-                "/dev/null".to_string(),
+                // appears as `/.codex`, `/.agents`, and `/.git`.
+                "--perms".to_string(),
+                "555".to_string(),
+                "--tmpfs".to_string(),
+                "/.git".to_string(),
+                "--remount-ro".to_string(),
+                "/.git".to_string(),
+                "--perms".to_string(),
+                "555".to_string(),
+                "--tmpfs".to_string(),
+                "/.agents".to_string(),
+                "--remount-ro".to_string(),
+                "/.agents".to_string(),
+                "--perms".to_string(),
+                "555".to_string(),
+                "--tmpfs".to_string(),
+                "/.codex".to_string(),
+                "--remount-ro".to_string(),
                 "/.codex".to_string(),
                 // Rebind /dev after the root bind so device nodes remain
                 // writable/usable inside the writable root.
                 "--bind".to_string(),
                 "/dev".to_string(),
                 "/dev".to_string(),
+                "--perms".to_string(),
+                "555".to_string(),
+                "--tmpfs".to_string(),
+                "/dev/.git".to_string(),
+                "--remount-ro".to_string(),
+                "/dev/.git".to_string(),
+                "--perms".to_string(),
+                "555".to_string(),
+                "--tmpfs".to_string(),
+                "/dev/.agents".to_string(),
+                "--remount-ro".to_string(),
+                "/dev/.agents".to_string(),
+                "--perms".to_string(),
+                "555".to_string(),
+                "--tmpfs".to_string(),
+                "/dev/.codex".to_string(),
+                "--remount-ro".to_string(),
+                "/dev/.codex".to_string(),
             ]
         );
     }
@@ -1900,6 +2312,7 @@ mod tests {
         let blocked_file_str = path_to_string(blocked_file.as_path());
 
         assert_eq!(args.preserved_files.len(), 1);
+        assert!(args.synthetic_mount_targets.is_empty());
         assert!(args.args.windows(5).any(|window| {
             window[0] == "--perms"
                 && window[1] == "000"
@@ -2002,5 +2415,53 @@ mod tests {
             }),
             "expected file mask for {path}: {args:#?}"
         );
+    }
+
+    /// Assert that `path` is backed by an fd-supplied empty file without
+    /// changing the next mount operation's permissions.
+    fn assert_empty_file_bound_without_perms(args: &[String], path: &Path) {
+        let path = path_to_string(path);
+        assert!(
+            args.windows(3)
+                .any(|window| { window[0] == "--ro-bind-data" && window[2] == path }),
+            "expected empty file bind for {path}: {args:#?}"
+        );
+        assert!(
+            !args.windows(5).any(|window| {
+                window[0] == "--perms"
+                    && window[1] == "000"
+                    && window[2] == "--ro-bind-data"
+                    && window[4] == path
+            }),
+            "missing path bind should not set explicit file perms for {path}: {args:#?}"
+        );
+    }
+
+    fn assert_empty_directory_mounted_read_only(args: &[String], path: &Path) {
+        let path = path_to_string(path);
+        assert!(
+            args.windows(4)
+                .any(|window| window == ["--perms", "555", "--tmpfs", path.as_str()]),
+            "expected empty directory mount for {path}: {args:#?}"
+        );
+        assert!(
+            args.windows(2)
+                .any(|window| window == ["--remount-ro", path.as_str()]),
+            "expected read-only remount for {path}: {args:#?}"
+        );
+    }
+
+    fn synthetic_mount_target_paths(args: &BwrapArgs) -> Vec<PathBuf> {
+        args.synthetic_mount_targets
+            .iter()
+            .map(|target| target.path().to_path_buf())
+            .collect()
+    }
+
+    fn protected_create_target_paths(args: &BwrapArgs) -> Vec<PathBuf> {
+        args.protected_create_targets
+            .iter()
+            .map(|target| target.path().to_path_buf())
+            .collect()
     }
 }

--- a/codex-rs/linux-sandbox/src/linux_run_main.rs
+++ b/codex-rs/linux-sandbox/src/linux_run_main.rs
@@ -1,11 +1,17 @@
 use clap::Parser;
 use std::ffi::CString;
 use std::fmt;
+use std::fs;
 use std::fs::File;
+use std::fs::OpenOptions;
 use std::io::Read;
+use std::os::fd::AsRawFd;
 use std::os::fd::FromRawFd;
+use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::atomic::AtomicI32;
+use std::sync::atomic::Ordering;
 
 use crate::bwrap::BwrapNetworkMode;
 use crate::bwrap::BwrapOptions;
@@ -19,6 +25,29 @@ use codex_protocol::protocol::FileSystemSandboxPolicy;
 use codex_protocol::protocol::NetworkSandboxPolicy;
 use codex_protocol::protocol::SandboxPolicy;
 use codex_sandboxing::landlock::CODEX_LINUX_SANDBOX_ARG0;
+
+static BWRAP_CHILD_PID: AtomicI32 = AtomicI32::new(0);
+static PENDING_FORWARDED_SIGNAL: AtomicI32 = AtomicI32::new(0);
+
+const FORWARDED_SIGNALS: &[libc::c_int] =
+    &[libc::SIGHUP, libc::SIGINT, libc::SIGQUIT, libc::SIGTERM];
+const SYNTHETIC_MOUNT_MARKER_SYNTHETIC: &[u8] = b"synthetic\n";
+const SYNTHETIC_MOUNT_MARKER_EXISTING: &[u8] = b"existing\n";
+const PROTECTED_CREATE_MARKER: &[u8] = b"protected-create\n";
+
+#[derive(Debug)]
+struct SyntheticMountTargetRegistration {
+    target: crate::bwrap::SyntheticMountTarget,
+    marker_file: PathBuf,
+    marker_dir: PathBuf,
+}
+
+#[derive(Debug)]
+struct ProtectedCreateTargetRegistration {
+    target: crate::bwrap::ProtectedCreateTarget,
+    marker_file: PathBuf,
+    marker_dir: PathBuf,
+}
 
 #[derive(Debug, Parser)]
 /// CLI surface for the Linux sandbox helper.
@@ -443,7 +472,7 @@ fn run_bwrap_with_proc_fallback(
         options,
     );
     apply_inner_command_argv0(&mut bwrap_args.args);
-    exec_bwrap(bwrap_args.args, bwrap_args.preserved_files);
+    run_or_exec_bwrap(bwrap_args);
 }
 
 fn bwrap_network_mode(
@@ -480,6 +509,8 @@ fn build_bwrap_argv(
     crate::bwrap::BwrapArgs {
         args: argv,
         preserved_files: bwrap_args.preserved_files,
+        synthetic_mount_targets: bwrap_args.synthetic_mount_targets,
+        protected_create_targets: bwrap_args.protected_create_targets,
     }
 }
 
@@ -568,6 +599,547 @@ fn resolve_true_command() -> String {
     "true".to_string()
 }
 
+fn run_or_exec_bwrap(bwrap_args: crate::bwrap::BwrapArgs) -> ! {
+    if bwrap_args.synthetic_mount_targets.is_empty()
+        && bwrap_args.protected_create_targets.is_empty()
+    {
+        exec_bwrap(bwrap_args.args, bwrap_args.preserved_files);
+    }
+    run_bwrap_in_child_with_synthetic_mount_cleanup(bwrap_args);
+}
+
+fn run_bwrap_in_child_with_synthetic_mount_cleanup(bwrap_args: crate::bwrap::BwrapArgs) -> ! {
+    let crate::bwrap::BwrapArgs {
+        args,
+        preserved_files,
+        synthetic_mount_targets,
+        protected_create_targets,
+    } = bwrap_args;
+    let setup_signal_mask = ForwardedSignalMask::block();
+    let synthetic_mount_registrations = register_synthetic_mount_targets(&synthetic_mount_targets);
+    let protected_create_registrations =
+        register_protected_create_targets(&protected_create_targets);
+    let parent_pid = unsafe { libc::getpid() };
+    let pid = unsafe { libc::fork() };
+    if pid < 0 {
+        let err = std::io::Error::last_os_error();
+        panic!("failed to fork for bubblewrap: {err}");
+    }
+
+    if pid == 0 {
+        reset_forwarded_signal_handlers_to_default();
+        setup_signal_mask.restore();
+        let setpgid_res = unsafe { libc::setpgid(0, 0) };
+        if setpgid_res < 0 {
+            let err = std::io::Error::last_os_error();
+            panic!("failed to place bubblewrap child in its own process group: {err}");
+        }
+        terminate_with_parent(parent_pid);
+        exec_bwrap(args, preserved_files);
+    }
+
+    install_bwrap_signal_forwarders(pid);
+    setup_signal_mask.restore();
+    let status = wait_for_bwrap_child(pid);
+    let cleanup_signal_mask = ForwardedSignalMask::block();
+    BWRAP_CHILD_PID.store(0, Ordering::SeqCst);
+    cleanup_synthetic_mount_targets(&synthetic_mount_registrations);
+    let protected_create_violation =
+        cleanup_protected_create_targets(&protected_create_registrations);
+    cleanup_signal_mask.restore();
+    exit_with_wait_status_or_policy_violation(status, protected_create_violation);
+}
+
+struct ForwardedSignalMask {
+    previous: libc::sigset_t,
+}
+
+impl ForwardedSignalMask {
+    fn block() -> Self {
+        let mut blocked: libc::sigset_t = unsafe { std::mem::zeroed() };
+        let mut previous: libc::sigset_t = unsafe { std::mem::zeroed() };
+        unsafe {
+            libc::sigemptyset(&mut blocked);
+            for signal in FORWARDED_SIGNALS {
+                libc::sigaddset(&mut blocked, *signal);
+            }
+            if libc::sigprocmask(libc::SIG_BLOCK, &blocked, &mut previous) < 0 {
+                let err = std::io::Error::last_os_error();
+                panic!("failed to block bubblewrap forwarded signals: {err}");
+            }
+        }
+        Self { previous }
+    }
+
+    fn restore(&self) {
+        let mut restored = self.previous;
+        unsafe {
+            for signal in FORWARDED_SIGNALS {
+                libc::sigdelset(&mut restored, *signal);
+            }
+            if libc::sigprocmask(libc::SIG_SETMASK, &restored, std::ptr::null_mut()) < 0 {
+                let err = std::io::Error::last_os_error();
+                panic!("failed to restore bubblewrap forwarded signals: {err}");
+            }
+        }
+    }
+}
+
+fn terminate_with_parent(parent_pid: libc::pid_t) {
+    let res = unsafe { libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM) };
+    if res < 0 {
+        let err = std::io::Error::last_os_error();
+        panic!("failed to set bubblewrap child parent-death signal: {err}");
+    }
+    if unsafe { libc::getppid() } != parent_pid {
+        unsafe {
+            libc::raise(libc::SIGTERM);
+        }
+    }
+}
+
+fn install_bwrap_signal_forwarders(pid: libc::pid_t) {
+    BWRAP_CHILD_PID.store(pid, Ordering::SeqCst);
+    for signal in FORWARDED_SIGNALS {
+        let mut action: libc::sigaction = unsafe { std::mem::zeroed() };
+        action.sa_sigaction = forward_signal_to_bwrap_child as *const () as libc::sighandler_t;
+        unsafe {
+            libc::sigemptyset(&mut action.sa_mask);
+            if libc::sigaction(*signal, &action, std::ptr::null_mut()) < 0 {
+                let err = std::io::Error::last_os_error();
+                panic!("failed to install bubblewrap signal forwarder for {signal}: {err}");
+            }
+        }
+    }
+    replay_pending_forwarded_signal(pid);
+}
+
+extern "C" fn forward_signal_to_bwrap_child(signal: libc::c_int) {
+    PENDING_FORWARDED_SIGNAL.store(signal, Ordering::SeqCst);
+    let pid = BWRAP_CHILD_PID.load(Ordering::SeqCst);
+    if pid > 0 {
+        send_signal_to_bwrap_child(pid, signal);
+    }
+}
+
+fn replay_pending_forwarded_signal(pid: libc::pid_t) {
+    let signal = PENDING_FORWARDED_SIGNAL.swap(0, Ordering::SeqCst);
+    if signal > 0 {
+        send_signal_to_bwrap_child(pid, signal);
+    }
+}
+
+fn send_signal_to_bwrap_child(pid: libc::pid_t, signal: libc::c_int) {
+    unsafe {
+        libc::kill(-pid, signal);
+        libc::kill(pid, signal);
+    }
+}
+
+fn reset_forwarded_signal_handlers_to_default() {
+    for signal in FORWARDED_SIGNALS {
+        unsafe {
+            if libc::signal(*signal, libc::SIG_DFL) == libc::SIG_ERR {
+                let err = std::io::Error::last_os_error();
+                panic!("failed to reset bubblewrap signal handler for {signal}: {err}");
+            }
+        }
+    }
+}
+
+fn wait_for_bwrap_child(pid: libc::pid_t) -> libc::c_int {
+    loop {
+        let mut status: libc::c_int = 0;
+        let wait_res = unsafe { libc::waitpid(pid, &mut status as *mut libc::c_int, 0) };
+        if wait_res >= 0 {
+            return status;
+        }
+        let err = std::io::Error::last_os_error();
+        if err.raw_os_error() == Some(libc::EINTR) {
+            continue;
+        }
+        panic!("waitpid failed for bubblewrap child: {err}");
+    }
+}
+
+fn register_synthetic_mount_targets(
+    targets: &[crate::bwrap::SyntheticMountTarget],
+) -> Vec<SyntheticMountTargetRegistration> {
+    with_synthetic_mount_registry_lock(|| {
+        targets
+            .iter()
+            .map(|target| {
+                let marker_dir = synthetic_mount_marker_dir(target.path());
+                fs::create_dir_all(&marker_dir).unwrap_or_else(|err| {
+                    panic!(
+                        "failed to create synthetic bubblewrap mount marker directory {}: {err}",
+                        marker_dir.display()
+                    )
+                });
+                let target = if target.preserves_pre_existing_path()
+                    && synthetic_mount_marker_dir_has_active_synthetic_owner(&marker_dir)
+                {
+                    match target.kind() {
+                        crate::bwrap::SyntheticMountTargetKind::EmptyFile => {
+                            crate::bwrap::SyntheticMountTarget::missing(target.path())
+                        }
+                        crate::bwrap::SyntheticMountTargetKind::EmptyDirectory => {
+                            crate::bwrap::SyntheticMountTarget::missing_empty_directory(
+                                target.path(),
+                            )
+                        }
+                    }
+                } else {
+                    target.clone()
+                };
+                let marker_file = marker_dir.join(std::process::id().to_string());
+                fs::write(&marker_file, synthetic_mount_marker_contents(&target)).unwrap_or_else(
+                    |err| {
+                        panic!(
+                            "failed to register synthetic bubblewrap mount target {}: {err}",
+                            target.path().display()
+                        )
+                    },
+                );
+                SyntheticMountTargetRegistration {
+                    target,
+                    marker_file,
+                    marker_dir,
+                }
+            })
+            .collect()
+    })
+}
+
+fn register_protected_create_targets(
+    targets: &[crate::bwrap::ProtectedCreateTarget],
+) -> Vec<ProtectedCreateTargetRegistration> {
+    with_synthetic_mount_registry_lock(|| {
+        targets
+            .iter()
+            .map(|target| {
+                let marker_dir = synthetic_mount_marker_dir(target.path());
+                fs::create_dir_all(&marker_dir).unwrap_or_else(|err| {
+                    panic!(
+                        "failed to create protected create marker directory {}: {err}",
+                        marker_dir.display()
+                    )
+                });
+                let marker_file = marker_dir.join(std::process::id().to_string());
+                fs::write(&marker_file, PROTECTED_CREATE_MARKER).unwrap_or_else(|err| {
+                    panic!(
+                        "failed to register protected create target {}: {err}",
+                        target.path().display()
+                    )
+                });
+                ProtectedCreateTargetRegistration {
+                    target: target.clone(),
+                    marker_file,
+                    marker_dir,
+                }
+            })
+            .collect()
+    })
+}
+
+fn synthetic_mount_marker_contents(target: &crate::bwrap::SyntheticMountTarget) -> &'static [u8] {
+    if target.preserves_pre_existing_path() {
+        SYNTHETIC_MOUNT_MARKER_EXISTING
+    } else {
+        SYNTHETIC_MOUNT_MARKER_SYNTHETIC
+    }
+}
+
+fn synthetic_mount_marker_dir_has_active_synthetic_owner(marker_dir: &Path) -> bool {
+    synthetic_mount_marker_dir_has_active_process_matching(marker_dir, |path| {
+        match fs::read(path) {
+            Ok(contents) => contents == SYNTHETIC_MOUNT_MARKER_SYNTHETIC,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => false,
+            Err(err) => panic!(
+                "failed to read synthetic bubblewrap mount marker {}: {err}",
+                path.display()
+            ),
+        }
+    })
+}
+
+fn synthetic_mount_marker_dir_has_active_process(marker_dir: &Path) -> bool {
+    synthetic_mount_marker_dir_has_active_process_matching(marker_dir, |_| true)
+}
+
+fn synthetic_mount_marker_dir_has_active_process_matching(
+    marker_dir: &Path,
+    matches_marker: impl Fn(&Path) -> bool,
+) -> bool {
+    let entries = match fs::read_dir(marker_dir) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return false,
+        Err(err) => panic!(
+            "failed to read synthetic bubblewrap mount marker directory {}: {err}",
+            marker_dir.display()
+        ),
+    };
+    for entry in entries {
+        let entry = entry.unwrap_or_else(|err| {
+            panic!(
+                "failed to read synthetic bubblewrap mount marker in {}: {err}",
+                marker_dir.display()
+            )
+        });
+        let path = entry.path();
+        let Some(pid) = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .and_then(|name| name.parse::<libc::pid_t>().ok())
+        else {
+            continue;
+        };
+        if !process_is_active(pid) {
+            match fs::remove_file(&path) {
+                Ok(()) => {}
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                Err(err) => panic!(
+                    "failed to remove stale synthetic bubblewrap mount marker {}: {err}",
+                    path.display()
+                ),
+            }
+            continue;
+        }
+        let matches_marker = matches_marker(&path);
+        if matches_marker {
+            return true;
+        }
+    }
+    false
+}
+
+fn cleanup_synthetic_mount_targets(targets: &[SyntheticMountTargetRegistration]) {
+    with_synthetic_mount_registry_lock(|| {
+        for target in targets.iter().rev() {
+            match fs::remove_file(&target.marker_file) {
+                Ok(()) => {}
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                Err(err) => panic!(
+                    "failed to unregister synthetic bubblewrap mount target {}: {err}",
+                    target.target.path().display()
+                ),
+            }
+        }
+
+        for target in targets.iter().rev() {
+            if synthetic_mount_marker_dir_has_active_process(&target.marker_dir) {
+                continue;
+            }
+            remove_synthetic_mount_target(&target.target);
+            match fs::remove_dir(&target.marker_dir) {
+                Ok(()) => {}
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                Err(err) if err.kind() == std::io::ErrorKind::DirectoryNotEmpty => {}
+                Err(err) => panic!(
+                    "failed to remove synthetic bubblewrap mount marker directory {}: {err}",
+                    target.marker_dir.display()
+                ),
+            }
+        }
+    });
+}
+
+fn cleanup_protected_create_targets(targets: &[ProtectedCreateTargetRegistration]) -> bool {
+    with_synthetic_mount_registry_lock(|| {
+        for target in targets.iter().rev() {
+            match fs::remove_file(&target.marker_file) {
+                Ok(()) => {}
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                Err(err) => panic!(
+                    "failed to unregister protected create target {}: {err}",
+                    target.target.path().display()
+                ),
+            }
+        }
+
+        let mut violation = false;
+        for target in targets.iter().rev() {
+            if synthetic_mount_marker_dir_has_active_process(&target.marker_dir) {
+                if target.target.path().exists() {
+                    violation = true;
+                }
+                continue;
+            }
+            violation |= remove_protected_create_target(&target.target);
+            match fs::remove_dir(&target.marker_dir) {
+                Ok(()) => {}
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                Err(err) if err.kind() == std::io::ErrorKind::DirectoryNotEmpty => {}
+                Err(err) => panic!(
+                    "failed to remove protected create marker directory {}: {err}",
+                    target.marker_dir.display()
+                ),
+            }
+        }
+        violation
+    })
+}
+
+fn remove_protected_create_target(target: &crate::bwrap::ProtectedCreateTarget) -> bool {
+    let path = target.path();
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return false,
+        Err(err) => panic!(
+            "failed to inspect protected create target {}: {err}",
+            path.display()
+        ),
+    };
+
+    if metadata.is_dir() {
+        fs::remove_dir_all(path).unwrap_or_else(|err| {
+            panic!(
+                "failed to remove protected create target directory {}: {err}",
+                path.display()
+            )
+        });
+    } else {
+        fs::remove_file(path).unwrap_or_else(|err| {
+            panic!(
+                "failed to remove protected create target file {}: {err}",
+                path.display()
+            )
+        });
+    }
+    eprintln!(
+        "sandbox blocked creation of preserved workspace metadata path {}",
+        path.display()
+    );
+    true
+}
+
+fn remove_synthetic_mount_target(target: &crate::bwrap::SyntheticMountTarget) {
+    let path = target.path();
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return,
+        Err(err) => panic!(
+            "failed to inspect synthetic bubblewrap mount target {}: {err}",
+            path.display()
+        ),
+    };
+    if !target.should_remove_after_bwrap(&metadata) {
+        return;
+    }
+    match target.kind() {
+        crate::bwrap::SyntheticMountTargetKind::EmptyFile => match fs::remove_file(path) {
+            Ok(()) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => panic!(
+                "failed to remove synthetic bubblewrap mount target {}: {err}",
+                path.display()
+            ),
+        },
+        crate::bwrap::SyntheticMountTargetKind::EmptyDirectory => match fs::remove_dir(path) {
+            Ok(()) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) if err.kind() == std::io::ErrorKind::DirectoryNotEmpty => {}
+            Err(err) => panic!(
+                "failed to remove synthetic bubblewrap mount target {}: {err}",
+                path.display()
+            ),
+        },
+    }
+}
+
+fn process_is_active(pid: libc::pid_t) -> bool {
+    let result = unsafe { libc::kill(pid, 0) };
+    if result == 0 {
+        return true;
+    }
+    let err = std::io::Error::last_os_error();
+    !matches!(err.raw_os_error(), Some(libc::ESRCH))
+}
+
+fn with_synthetic_mount_registry_lock<T>(f: impl FnOnce() -> T) -> T {
+    let registry_root = synthetic_mount_registry_root();
+    fs::create_dir_all(&registry_root).unwrap_or_else(|err| {
+        panic!(
+            "failed to create synthetic bubblewrap mount registry {}: {err}",
+            registry_root.display()
+        )
+    });
+    let lock_path = registry_root.join("lock");
+    let lock_file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+        .unwrap_or_else(|err| {
+            panic!(
+                "failed to open synthetic bubblewrap mount registry lock {}: {err}",
+                lock_path.display()
+            )
+        });
+    if unsafe { libc::flock(lock_file.as_raw_fd(), libc::LOCK_EX) } < 0 {
+        let err = std::io::Error::last_os_error();
+        panic!(
+            "failed to lock synthetic bubblewrap mount registry {}: {err}",
+            lock_path.display()
+        );
+    }
+    let result = f();
+    if unsafe { libc::flock(lock_file.as_raw_fd(), libc::LOCK_UN) } < 0 {
+        let err = std::io::Error::last_os_error();
+        panic!(
+            "failed to unlock synthetic bubblewrap mount registry {}: {err}",
+            lock_path.display()
+        );
+    }
+    result
+}
+
+fn synthetic_mount_marker_dir(path: &Path) -> PathBuf {
+    synthetic_mount_registry_root().join(format!("{:016x}", hash_path(path)))
+}
+
+fn synthetic_mount_registry_root() -> PathBuf {
+    std::env::temp_dir().join("codex-bwrap-synthetic-mount-targets")
+}
+
+fn hash_path(path: &Path) -> u64 {
+    let mut hash = 0xcbf29ce484222325u64;
+    for byte in path.as_os_str().as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
+}
+
+fn exit_with_wait_status(status: libc::c_int) -> ! {
+    if libc::WIFEXITED(status) {
+        std::process::exit(libc::WEXITSTATUS(status));
+    }
+
+    if libc::WIFSIGNALED(status) {
+        let signal = libc::WTERMSIG(status);
+        unsafe {
+            libc::signal(signal, libc::SIG_DFL);
+            libc::kill(libc::getpid(), signal);
+        }
+        std::process::exit(128 + signal);
+    }
+
+    std::process::exit(1);
+}
+
+fn exit_with_wait_status_or_policy_violation(
+    status: libc::c_int,
+    protected_create_violation: bool,
+) -> ! {
+    if protected_create_violation && libc::WIFEXITED(status) && libc::WEXITSTATUS(status) == 0 {
+        std::process::exit(1);
+    }
+
+    exit_with_wait_status(status);
+}
+
 /// Run a short-lived bubblewrap preflight in a child process and capture stderr.
 ///
 /// Strategy:
@@ -581,6 +1153,16 @@ fn resolve_true_command() -> String {
 ///   command, and reads are bounded to a fixed max size.
 fn run_bwrap_in_child_capture_stderr(bwrap_args: crate::bwrap::BwrapArgs) -> String {
     const MAX_PREFLIGHT_STDERR_BYTES: u64 = 64 * 1024;
+    let crate::bwrap::BwrapArgs {
+        args,
+        preserved_files,
+        synthetic_mount_targets,
+        protected_create_targets,
+    } = bwrap_args;
+    let setup_signal_mask = ForwardedSignalMask::block();
+    let synthetic_mount_registrations = register_synthetic_mount_targets(&synthetic_mount_targets);
+    let protected_create_registrations =
+        register_protected_create_targets(&protected_create_targets);
 
     let mut pipe_fds = [0; 2];
     let pipe_res = unsafe { libc::pipe2(pipe_fds.as_mut_ptr(), libc::O_CLOEXEC) };
@@ -598,6 +1180,8 @@ fn run_bwrap_in_child_capture_stderr(bwrap_args: crate::bwrap::BwrapArgs) -> Str
     }
 
     if pid == 0 {
+        reset_forwarded_signal_handlers_to_default();
+        setup_signal_mask.restore();
         // Child: redirect stderr to the pipe, then run bubblewrap.
         unsafe {
             close_fd_or_panic(read_fd, "close read end in bubblewrap child");
@@ -608,9 +1192,11 @@ fn run_bwrap_in_child_capture_stderr(bwrap_args: crate::bwrap::BwrapArgs) -> Str
             close_fd_or_panic(write_fd, "close write end in bubblewrap child");
         }
 
-        exec_bwrap(bwrap_args.args, bwrap_args.preserved_files);
+        exec_bwrap(args, preserved_files);
     }
 
+    install_bwrap_signal_forwarders(pid);
+    setup_signal_mask.restore();
     // Parent: close the write end and read stderr while the child runs.
     close_fd_or_panic(write_fd, "close write end in bubblewrap parent");
 
@@ -622,12 +1208,12 @@ fn run_bwrap_in_child_capture_stderr(bwrap_args: crate::bwrap::BwrapArgs) -> Str
         panic!("failed to read bubblewrap stderr: {err}");
     }
 
-    let mut status: libc::c_int = 0;
-    let wait_res = unsafe { libc::waitpid(pid, &mut status as *mut libc::c_int, 0) };
-    if wait_res < 0 {
-        let err = std::io::Error::last_os_error();
-        panic!("waitpid failed for bubblewrap child: {err}");
-    }
+    wait_for_bwrap_child(pid);
+    let cleanup_signal_mask = ForwardedSignalMask::block();
+    BWRAP_CHILD_PID.store(0, Ordering::SeqCst);
+    cleanup_synthetic_mount_targets(&synthetic_mount_registrations);
+    cleanup_protected_create_targets(&protected_create_registrations);
+    cleanup_signal_mask.restore();
 
     String::from_utf8_lossy(&stderr_bytes).into_owned()
 }

--- a/codex-rs/linux-sandbox/src/linux_run_main_tests.rs
+++ b/codex-rs/linux-sandbox/src/linux_run_main_tests.rs
@@ -1,6 +1,10 @@
 #[cfg(test)]
 use super::*;
 #[cfg(test)]
+use crate::linux_run_main::install_bwrap_signal_forwarders;
+#[cfg(test)]
+use crate::linux_run_main::wait_for_bwrap_child;
+#[cfg(test)]
 use codex_protocol::protocol::FileSystemSandboxPolicy;
 #[cfg(test)]
 use codex_protocol::protocol::NetworkSandboxPolicy;
@@ -253,6 +257,180 @@ fn managed_proxy_preflight_argv_is_wrapped_for_full_access_policy() {
     )
     .args;
     assert!(argv.iter().any(|arg| arg == "--"));
+}
+
+#[test]
+fn cleanup_synthetic_mount_targets_removes_only_empty_mount_targets() {
+    let temp_dir = tempfile::TempDir::new().expect("tempdir");
+    let empty_file = temp_dir.path().join(".git");
+    let empty_dir = temp_dir.path().join(".agents");
+    let non_empty_file = temp_dir.path().join("non-empty");
+    let missing_file = temp_dir.path().join(".missing");
+    std::fs::write(&empty_file, "").expect("write empty file");
+    std::fs::create_dir(&empty_dir).expect("create empty dir");
+    std::fs::write(&non_empty_file, "keep").expect("write nonempty file");
+
+    let registrations = register_synthetic_mount_targets(&[
+        crate::bwrap::SyntheticMountTarget::missing(&empty_file),
+        crate::bwrap::SyntheticMountTarget::missing_empty_directory(&empty_dir),
+        crate::bwrap::SyntheticMountTarget::missing(&non_empty_file),
+        crate::bwrap::SyntheticMountTarget::missing(&missing_file),
+    ]);
+    cleanup_synthetic_mount_targets(&registrations);
+
+    assert!(!empty_file.exists());
+    assert!(!empty_dir.exists());
+    assert_eq!(
+        std::fs::read_to_string(&non_empty_file).expect("read nonempty file"),
+        "keep"
+    );
+    assert!(!missing_file.exists());
+}
+
+#[test]
+fn cleanup_synthetic_mount_targets_waits_for_other_active_registrations() {
+    let temp_dir = tempfile::TempDir::new().expect("tempdir");
+    let empty_file = temp_dir.path().join(".git");
+    std::fs::write(&empty_file, "").expect("write empty file");
+    let target = crate::bwrap::SyntheticMountTarget::missing(&empty_file);
+
+    let registrations = register_synthetic_mount_targets(std::slice::from_ref(&target));
+    let active_marker = registrations[0].marker_dir.join("1");
+    std::fs::write(&active_marker, "").expect("write active marker");
+
+    cleanup_synthetic_mount_targets(&registrations);
+    assert!(empty_file.exists());
+
+    std::fs::remove_file(active_marker).expect("remove active marker");
+    let registrations = register_synthetic_mount_targets(std::slice::from_ref(&target));
+    cleanup_synthetic_mount_targets(&registrations);
+
+    assert!(!empty_file.exists());
+}
+
+#[test]
+fn cleanup_synthetic_mount_targets_removes_transient_file_after_concurrent_owner_exits() {
+    let temp_dir = tempfile::TempDir::new().expect("tempdir");
+    let empty_file = temp_dir.path().join(".git");
+    let first_target = crate::bwrap::SyntheticMountTarget::missing(&empty_file);
+
+    let first_registrations = register_synthetic_mount_targets(&[first_target]);
+    std::fs::write(&empty_file, "").expect("write transient empty file");
+    let active_marker = first_registrations[0].marker_dir.join("1");
+    std::fs::write(&active_marker, SYNTHETIC_MOUNT_MARKER_SYNTHETIC).expect("write active marker");
+    let metadata = std::fs::symlink_metadata(&empty_file).expect("stat empty file");
+    let second_target =
+        crate::bwrap::SyntheticMountTarget::existing_empty_file(&empty_file, &metadata);
+    let second_registrations = register_synthetic_mount_targets(&[second_target]);
+
+    cleanup_synthetic_mount_targets(&first_registrations);
+    assert!(empty_file.exists());
+
+    std::fs::remove_file(active_marker).expect("remove active marker");
+    cleanup_synthetic_mount_targets(&second_registrations);
+
+    assert!(!empty_file.exists());
+}
+
+#[test]
+fn cleanup_synthetic_mount_targets_preserves_real_pre_existing_empty_file() {
+    let temp_dir = tempfile::TempDir::new().expect("tempdir");
+    let empty_file = temp_dir.path().join(".git");
+    std::fs::write(&empty_file, "").expect("write pre-existing empty file");
+    let metadata = std::fs::symlink_metadata(&empty_file).expect("stat empty file");
+    let first_target =
+        crate::bwrap::SyntheticMountTarget::existing_empty_file(&empty_file, &metadata);
+    let second_target =
+        crate::bwrap::SyntheticMountTarget::existing_empty_file(&empty_file, &metadata);
+
+    let first_registrations = register_synthetic_mount_targets(&[first_target]);
+    let second_registrations = register_synthetic_mount_targets(&[second_target]);
+
+    cleanup_synthetic_mount_targets(&first_registrations);
+    cleanup_synthetic_mount_targets(&second_registrations);
+
+    assert!(empty_file.exists());
+}
+
+#[test]
+fn cleanup_protected_create_targets_removes_created_path_and_reports_violation() {
+    let temp_dir = tempfile::TempDir::new().expect("tempdir");
+    let dot_git = temp_dir.path().join(".git");
+    let target = crate::bwrap::ProtectedCreateTarget::missing(&dot_git);
+
+    let registrations = register_protected_create_targets(&[target]);
+    std::fs::create_dir(&dot_git).expect("create protected path");
+    let violation = cleanup_protected_create_targets(&registrations);
+
+    assert!(violation);
+    assert!(!dot_git.exists());
+}
+
+#[test]
+fn cleanup_protected_create_targets_waits_for_other_active_registrations() {
+    let temp_dir = tempfile::TempDir::new().expect("tempdir");
+    let dot_git = temp_dir.path().join(".git");
+    let target = crate::bwrap::ProtectedCreateTarget::missing(&dot_git);
+
+    let registrations = register_protected_create_targets(std::slice::from_ref(&target));
+    let active_marker = registrations[0].marker_dir.join("1");
+    std::fs::write(&active_marker, PROTECTED_CREATE_MARKER).expect("write active marker");
+    std::fs::write(&dot_git, "").expect("create protected path");
+
+    let violation = cleanup_protected_create_targets(&registrations);
+    assert!(violation);
+    assert!(dot_git.exists());
+
+    std::fs::remove_file(active_marker).expect("remove active marker");
+    let registrations = register_protected_create_targets(std::slice::from_ref(&target));
+    let violation = cleanup_protected_create_targets(&registrations);
+
+    assert!(violation);
+    assert!(!dot_git.exists());
+}
+
+#[test]
+fn bwrap_signal_forwarder_terminates_child_and_keeps_parent_alive() {
+    let supervisor_pid = unsafe { libc::fork() };
+    assert!(supervisor_pid >= 0, "failed to fork supervisor");
+
+    if supervisor_pid == 0 {
+        run_bwrap_signal_forwarder_test_supervisor();
+    }
+
+    let status = wait_for_bwrap_child(supervisor_pid);
+    assert!(libc::WIFEXITED(status), "supervisor status: {status}");
+    assert_eq!(libc::WEXITSTATUS(status), 0);
+}
+
+#[cfg(test)]
+fn run_bwrap_signal_forwarder_test_supervisor() -> ! {
+    let child_pid = unsafe { libc::fork() };
+    if child_pid < 0 {
+        unsafe {
+            libc::_exit(2);
+        }
+    }
+
+    if child_pid == 0 {
+        loop {
+            unsafe {
+                libc::pause();
+            }
+        }
+    }
+
+    install_bwrap_signal_forwarders(child_pid);
+    unsafe {
+        libc::raise(libc::SIGTERM);
+    }
+
+    let status = wait_for_bwrap_child(child_pid);
+    let child_terminated_by_sigterm =
+        libc::WIFSIGNALED(status) && libc::WTERMSIG(status) == libc::SIGTERM;
+    unsafe {
+        libc::_exit(if child_terminated_by_sigterm { 0 } else { 1 });
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This PR protects preserved workspace metadata paths under workspace write sandboxes without breaking normal Git discovery. The preserved names are `.git`, `.codex`, and `.agents`.

BUGB 15632 tracks the Bugcrowd submission.

## Root Cause

The previous policy only treated `.git` and `.agents` as protected after they already existed. That left a first run gap where sandboxed code in a new workspace could create `.git/config`.

The report used `git init` followed by a Git config value that could persist on the host. A later host side Git command could then load attacker controlled repo metadata.

The hard part is that missing `.git` cannot always be materialized as a read only placeholder. If Codex runs inside a subdirectory of an existing Git repo or worktree, materializing a child `.git` changes Git discovery and hides the valid parent repo. In that case the child `.git` must stay absent while creation is still denied.

## Design

1. The protocol layer now carries a real preserved path policy primitive on writable roots through `preserved_path_names`.
2. Writable root policy rejects writes whose path components include `.git`, `.codex`, or `.agents` unless an explicit user write policy covers that preserved path.
3. Existing `.git`, `.codex`, and `.agents` paths stay read only under default writable roots.
4. Missing `.codex` and `.agents` are reserved under writable roots so first creation is blocked.
5. Missing child `.git` under a valid parent repo or worktree stays absent so normal `git status` and `git rev parse` keep discovering the parent.
6. Seatbelt enforces preserved names directly in the generated sandbox profile for writable roots.
7. Linux bwrap setup masks representable missing preserved paths with `/dev/null`.
8. Linux tracks missing preserved targets that cannot be safely materialized as `protected_create_targets`, runs bwrap with a parent helper only when cleanup or protected target checks are needed, and removes any forbidden preserved target that a sandboxed process managed to create before returning failure.
9. The command preflight no longer contains a hard coded table for `touch`, `mkdir`, `rm`, `rmdir`, `ln`, `mv`, `cp`, `install`, or `git init`. It only catches literal shell redirection targets early for user feedback. The sandbox policy is the security boundary.
10. The Linux launcher forwards termination signals to the bwrap child process group, clears the child pid after wait, and then runs cleanup.

## Validation

Current PR head: `3ae2e24e72eb879d66de9e28b6f32226f52d5eae`.

Current base main: `bb83eec825b74aaf06f74650d2c004b0629dd19a`.

1. Local macOS build passed for the CLI crate and Linux sandbox crate.
2. Formatting passed with `just fmt`.
3. Diff whitespace check passed.
4. Conflict marker scan passed across the checkout outside vendored code.
5. GitHub Actions passed on the current head, including macOS, Ubuntu, Windows, Bazel local builds, Bazel clippy, release builds, argument comment lint, format, spellcheck, SDK checks, cargo shear, cargo deny, blob policy, CLA, and required CI results.
6. Linux devbox validation passed all 46 preserved path smoke cases on the current head using literal `just c` for each case.
7. The devbox smoke run reported all 46 cases passed on the current head.
8. Case 46 covered Viyat's parent repo subdirectory scenario: parent Git discovery still works, `git init` and `mkdir .codex` are denied, normal coding can create the requested JSONL viewer, and no child `.git`, `.codex`, or `.agents` directory is left behind.
9. The detailed devbox log is available in the validation workspace.
