### PR TITLE
[codex] Bound optional fs watch test waits

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/fs.rs
+++ b/codex-rs/app-server/tests/suite/v2/fs.rs
@@ -33,6 +33,9 @@ use std::process::Command;
 const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(60);
 #[cfg(not(any(target_os = "macos", windows)))]
 const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(10);
+// Optional watch events should not inherit the slow process/RPC timeout: these
+// tests intentionally tolerate missing OS notifications in sandboxed CI.
+const OPTIONAL_FS_CHANGED_TIMEOUT: Duration = Duration::from_millis(1500);
 
 async fn initialized_mcp(codex_home: &TempDir) -> Result<McpProcess> {
     let mut mcp = McpProcess::new(codex_home.path()).await?;
@@ -832,7 +835,7 @@ async fn maybe_fs_changed_notification(
     mcp: &mut McpProcess,
 ) -> Result<Option<FsChangedNotification>> {
     match timeout(
-        DEFAULT_READ_TIMEOUT,
+        OPTIONAL_FS_CHANGED_TIMEOUT,
         mcp.read_stream_until_notification_message("fs/changed"),
     )
     .await


### PR DESCRIPTION
## Why

The app-server fs watch integration tests intentionally tolerate missing `notify` events in sandboxed CI, but the optional read path reused `DEFAULT_READ_TIMEOUT`. On macOS and Windows that timeout is 60 seconds, while nextest reports a timeout after 30 seconds for a test that makes no progress. As a result, simple fs watch tests can hit `TIMEOUT [  30.006s]` before the helper returns `None`.

## What changed

- Added a dedicated 1.5 second timeout for optional `fs/changed` notification reads in `codex-rs/app-server/tests/suite/v2/fs.rs`.
- Left the broader RPC/process timeout in place for actual app-server requests and initialization.

## Validation

- `just fmt`
- `git diff --check`
- Triggered `rust-ci-full` by pushing to the full-ci branch: https://github.com/openai/codex/actions/runs/24598372693

The new `rust-ci-full` run is queued for amended commit `0e31a0fc5667cbce39a0c8d10860a893a61c6093`. The pre-amend run was not green: Windows arm64 tests passed, but macOS, Windows x64, Linux x64 remote, and Linux arm64 test jobs failed again after rerunning failed jobs once. The visible GitHub annotations only reported broad `tests` step exit codes; this Codex environment could not download the Actions failed logs/artifacts because the GitHub Actions result storage endpoint returned SSL/EOF errors.

Local focused `cargo test -p codex-app-server fs_watch` did not reach compilation because the configured `packageproxy` registry cannot resolve the locked `rand 0.9.3` dependency for the current workspace.