### PR TITLE
Test --add-dir workspace-write shell writes

### DIFF
--- a/codex-rs/exec/tests/suite/add_dir.rs
+++ b/codex-rs/exec/tests/suite/add_dir.rs
@@ -2,7 +2,14 @@
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use core_test_support::responses;
+use core_test_support::responses::ev_completed;
+use core_test_support::responses::ev_function_call;
+use core_test_support::responses::ev_response_created;
+use core_test_support::responses::mount_sse_sequence;
+use core_test_support::responses::sse;
 use core_test_support::test_codex_exec::test_codex_exec;
+use pretty_assertions::assert_eq;
+use std::fs;
 
 /// Verify that the --add-dir flag is accepted and the command runs successfully.
 /// This test confirms the CLI argument is properly wired up.
@@ -67,6 +74,60 @@ async fn accepts_multiple_add_dir_flags() -> anyhow::Result<()> {
         .arg("test with three directories")
         .assert()
         .code(0);
+
+    Ok(())
+}
+
+/// Verify that --add-dir grants write access to the specified directory when
+/// workspace-write sandboxing is active.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn add_dir_allows_writes_under_workspace_write() -> anyhow::Result<()> {
+    let test = test_codex_exec();
+    let server = responses::start_mock_server().await;
+    let writable_dir = tempfile::tempdir()?;
+    let target_file = writable_dir.path().join("created-by-codex.txt");
+    let args = serde_json::json!({
+        "command": [
+            "bash",
+            "-lc",
+            "printf add-dir-ok > \"$1\"",
+            "bash",
+            target_file.to_string_lossy(),
+        ],
+    });
+
+    mount_sse_sequence(
+        &server,
+        vec![
+            sse(vec![
+                ev_response_created("response_1"),
+                ev_function_call(
+                    "shell_add_dir_write",
+                    "shell",
+                    &serde_json::to_string(&args)?,
+                ),
+                ev_completed("response_1"),
+            ]),
+            sse(vec![
+                ev_response_created("response_2"),
+                responses::ev_assistant_message("response_2", "Done"),
+                ev_completed("response_2"),
+            ]),
+        ],
+    )
+    .await;
+
+    test.cmd_with_server(&server)
+        .arg("--skip-git-repo-check")
+        .arg("--sandbox")
+        .arg("workspace-write")
+        .arg("--add-dir")
+        .arg(writable_dir.path())
+        .arg("create a file in the added directory")
+        .assert()
+        .code(0);
+
+    assert_eq!(fs::read_to_string(target_file)?, "add-dir-ok");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Refs #18448.

`--add-dir` is intended to behave like `sandbox_workspace_write.writable_roots`, but the existing `codex-exec` coverage only checked that the flag was accepted. That left the reported failure mode uncovered: a model-issued shell command could still be unable to write into the added directory while `workspace-write` sandboxing was active.

This PR adds an end-to-end `codex-exec` regression test that starts a mocked model turn, has the shell tool write into a temporary directory supplied via `--add-dir`, and verifies the file is created.
