### PR TITLE
test(tui): align memory settings test sqlite home

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -8328,6 +8328,7 @@ mod tests {
         let (mut app, _app_event_rx, _op_rx) = make_test_app_with_channels().await;
         let codex_home = tempdir()?;
         app.config.codex_home = codex_home.path().to_path_buf().abs();
+        app.config.sqlite_home = codex_home.path().to_path_buf();
         // Seed the previous setting so this test exercises the thread-mode update path.
         app.config.memories.generate_memories = true;
 


### PR DESCRIPTION
## Summary
- set `sqlite_home` in the memory settings test to match the temp Codex home
- keep the embedded app server and assertions pointed at the same state DB
- split this Linux Bazel test harness fix out from the tmux OSC 9 notification work

## Stack
- https://github.com/openai/codex/pull/18479
- #17836
