### PR TITLE
Surface TUI skills refresh failures

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -2101,7 +2101,7 @@ impl App {
         tokio::spawn(async move {
             let result = fetch_skills_list(request_handle, cwd)
                 .await
-                .map_err(|err| err.to_string());
+                .map_err(|err| format!("{err:#}"));
             app_event_tx.send(AppEvent::SkillsListLoaded { result });
         });
     }
@@ -2682,6 +2682,8 @@ impl App {
             Ok(response) => self.handle_skills_list_response(response),
             Err(err) => {
                 tracing::warn!("{failure_message}: {err:#}");
+                self.chat_widget
+                    .add_error_message(format!("{failure_message}: {err:#}"));
             }
         }
     }


### PR DESCRIPTION
## Why

`skills/list` refreshes are best-effort metadata updates. If one fails during startup or thread switching, the TUI should keep running and show enough detail to diagnose the app-server failure instead of leaving the user with only a log entry.

This addresses the recoverability and observability issue reported in #16914.

## What Changed

- Preserve the full startup `skills/list` error chain before sending it back through the app event queue.
- Surface failed skills refreshes as recoverable TUI error messages while still logging the warning.

This is related to the recent bug fix from [PR #18370](https://github.com/openai/codex/pull/18370).