### PR TITLE
[codex] Fix agent identity auth test fixture

### DIFF
--- a/codex-rs/login/src/auth/auth_tests.rs
+++ b/codex-rs/login/src/auth/auth_tests.rs
@@ -243,6 +243,7 @@ fn dummy_chatgpt_auth_does_not_create_cwd_auth_json_when_identity_is_set() {
         agent_runtime_id: "agent_123".to_string(),
         agent_private_key: "pkcs8-base64".to_string(),
         registered_at: "2026-04-13T12:00:00Z".to_string(),
+        background_task_id: None,
     };
 
     auth.set_agent_identity(record.clone())


### PR DESCRIPTION
## Summary
- Add the missing `background_task_id: None` field to the `AgentIdentityAuthRecord` fixture introduced in `auth_tests.rs`.

## Why
- Current `main` fails Bazel/rust-ci compile paths after the background-task auth field landed and a later auth test fixture constructed `AgentIdentityAuthRecord` without that new field.
- I intentionally removed the earlier broader CI-stability edits from this PR. The code-mode timeout, external-agent migration snapshot, and MCP resource timeout failures appear to be general/flaky or unrelated to the agent identity merge stack rather than cleanly caused by it.

## Validation
- `cargo test -p codex-login dummy_chatgpt_auth_does_not_create_cwd_auth_json_when_identity_is_set -- --nocapture`
- `just fmt`