### PR TITLE
chore: enable await-holding clippy lints

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -82,6 +82,8 @@ build:clippy --@rules_rust//rust/settings:clippy.toml=//codex-rs:clippy.toml
 # in their own `Cargo.toml`, but `rules_rust` Bazel clippy does not read Cargo lint levels.
 # `clippy.toml` can configure lint behavior, but it cannot set allow/warn/deny/forbid levels.
 build:clippy --@rules_rust//rust/settings:clippy_flag=-Dwarnings
+build:clippy --@rules_rust//rust/settings:clippy_flag=--deny=clippy::await_holding_invalid_type
+build:clippy --@rules_rust//rust/settings:clippy_flag=--deny=clippy::await_holding_lock
 build:clippy --@rules_rust//rust/settings:clippy_flag=--deny=clippy::expect_used
 build:clippy --@rules_rust//rust/settings:clippy_flag=--deny=clippy::identity_op
 build:clippy --@rules_rust//rust/settings:clippy_flag=--deny=clippy::manual_clamp

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -383,6 +383,8 @@ zeroize = "1.8.2"
 rust = {}
 
 [workspace.lints.clippy]
+await_holding_invalid_type = "deny"
+await_holding_lock = "deny"
 expect_used = "deny"
 identity_op = "deny"
 manual_clamp = "deny"


### PR DESCRIPTION

Follow-up to https://github.com/openai/codex/pull/18178, where we said the await-holding clippy rule would be enabled separately.

Enable `await_holding_lock` and `await_holding_invalid_type` after the preceding commits fixed or explicitly documented the current offenders.














