### PR TITLE
[codex] Add tool interceptor support

### DIFF
--- a/codex-rs/config/src/config_toml.rs
+++ b/codex-rs/config/src/config_toml.rs
@@ -22,7 +22,6 @@ use crate::types::PluginConfig;
 use crate::types::SandboxWorkspaceWrite;
 use crate::types::ShellEnvironmentPolicyToml;
 use crate::types::SkillsConfig;
-use crate::types::ToolInterceptorsToml;
 use crate::types::ToolSuggestConfig;
 use crate::types::Tui;
 use crate::types::UriBasedFileOpener;
@@ -314,9 +313,9 @@ pub struct ConfigToml {
     /// Additional discoverable tools that can be suggested for installation.
     pub tool_suggest: Option<ToolSuggestConfig>,
 
-    /// Local subprocesses that can replace matching tool calls at execution time.
+    /// Local HTTP server that can replace tool call outputs before real dispatch.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub tool_interceptors: Option<ToolInterceptorsToml>,
+    pub tool_interceptor: Option<String>,
 
     /// Agent-related settings (thread limits, etc.).
     pub agents: Option<AgentsToml>,

--- a/codex-rs/config/src/config_toml.rs
+++ b/codex-rs/config/src/config_toml.rs
@@ -22,6 +22,7 @@ use crate::types::PluginConfig;
 use crate::types::SandboxWorkspaceWrite;
 use crate::types::ShellEnvironmentPolicyToml;
 use crate::types::SkillsConfig;
+use crate::types::ToolInterceptorsToml;
 use crate::types::ToolSuggestConfig;
 use crate::types::Tui;
 use crate::types::UriBasedFileOpener;
@@ -312,6 +313,10 @@ pub struct ConfigToml {
 
     /// Additional discoverable tools that can be suggested for installation.
     pub tool_suggest: Option<ToolSuggestConfig>,
+
+    /// Local subprocesses that can replace matching tool calls at execution time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_interceptors: Option<ToolInterceptorsToml>,
 
     /// Agent-related settings (thread limits, etc.).
     pub agents: Option<AgentsToml>,

--- a/codex-rs/config/src/types.rs
+++ b/codex-rs/config/src/types.rs
@@ -178,6 +178,41 @@ pub struct ToolSuggestConfig {
     pub discoverables: Vec<ToolSuggestDiscoverable>,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub struct ToolInterceptorsToml {
+    #[serde(default)]
+    pub handlers: HashMap<String, ToolInterceptorHandlerToml>,
+
+    #[serde(default)]
+    pub rules: Vec<ToolInterceptorRuleToml>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub struct ToolInterceptorHandlerToml {
+    pub command: String,
+
+    #[serde(default)]
+    pub args: Vec<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<AbsolutePathBuf>,
+
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub struct ToolInterceptorRuleToml {
+    pub tool: String,
+    pub handler: String,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub operation: Option<String>,
+}
+
 /// Memories settings loaded from config.toml.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default, JsonSchema)]
 #[schemars(deny_unknown_fields)]

--- a/codex-rs/config/src/types.rs
+++ b/codex-rs/config/src/types.rs
@@ -178,41 +178,6 @@ pub struct ToolSuggestConfig {
     pub discoverables: Vec<ToolSuggestDiscoverable>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default, JsonSchema)]
-#[schemars(deny_unknown_fields)]
-pub struct ToolInterceptorsToml {
-    #[serde(default)]
-    pub handlers: HashMap<String, ToolInterceptorHandlerToml>,
-
-    #[serde(default)]
-    pub rules: Vec<ToolInterceptorRuleToml>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, JsonSchema)]
-#[schemars(deny_unknown_fields)]
-pub struct ToolInterceptorHandlerToml {
-    pub command: String,
-
-    #[serde(default)]
-    pub args: Vec<String>,
-
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub cwd: Option<AbsolutePathBuf>,
-
-    #[serde(default)]
-    pub env: HashMap<String, String>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, JsonSchema)]
-#[schemars(deny_unknown_fields)]
-pub struct ToolInterceptorRuleToml {
-    pub tool: String,
-    pub handler: String,
-
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub operation: Option<String>,
-}
-
 /// Memories settings loaded from config.toml.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default, JsonSchema)]
 #[schemars(deny_unknown_fields)]

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -2857,6 +2857,10 @@
       "description": "Suppress warnings about unstable (under development) features.",
       "type": "boolean"
     },
+    "tool_interceptor": {
+      "description": "Local HTTP server that can replace tool call outputs before real dispatch.",
+      "type": "string"
+    },
     "tool_output_token_limit": {
       "description": "Token budget applied when storing tool/function outputs in the context manager.",
       "format": "uint",

--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -4857,6 +4857,7 @@ async fn test_precedence_fixture_with_o3_profile() -> std::io::Result<()> {
             model_availability_nux: ModelAvailabilityNuxConfig::default(),
             analytics_enabled: Some(true),
             feedback_enabled: true,
+            tool_interceptor: None,
             tool_suggest: ToolSuggestConfig::default(),
             tui_alternate_screen: AltScreenMode::Auto,
             tui_status_line: None,
@@ -5007,6 +5008,7 @@ async fn test_precedence_fixture_with_gpt3_profile() -> std::io::Result<()> {
         model_availability_nux: ModelAvailabilityNuxConfig::default(),
         analytics_enabled: Some(true),
         feedback_enabled: true,
+        tool_interceptor: None,
         tool_suggest: ToolSuggestConfig::default(),
         tui_alternate_screen: AltScreenMode::Auto,
         tui_status_line: None,
@@ -5155,6 +5157,7 @@ async fn test_precedence_fixture_with_zdr_profile() -> std::io::Result<()> {
         model_availability_nux: ModelAvailabilityNuxConfig::default(),
         analytics_enabled: Some(false),
         feedback_enabled: true,
+        tool_interceptor: None,
         tool_suggest: ToolSuggestConfig::default(),
         tui_alternate_screen: AltScreenMode::Auto,
         tui_status_line: None,
@@ -5288,6 +5291,7 @@ async fn test_precedence_fixture_with_gpt5_profile() -> std::io::Result<()> {
         model_availability_nux: ModelAvailabilityNuxConfig::default(),
         analytics_enabled: Some(true),
         feedback_enabled: true,
+        tool_interceptor: None,
         tool_suggest: ToolSuggestConfig::default(),
         tui_alternate_screen: AltScreenMode::Auto,
         tui_status_line: None,
@@ -6671,6 +6675,30 @@ discoverables = [
             ],
         }
     );
+    Ok(())
+}
+
+#[tokio::test]
+async fn tool_interceptor_loads_from_config_toml() -> std::io::Result<()> {
+    let cfg: ConfigToml = toml::from_str(
+        r#"
+tool_interceptor = "http://127.0.0.1:8765"
+"#,
+    )
+    .expect("TOML deserialization should succeed");
+
+    let expected = "http://127.0.0.1:8765".to_string();
+    assert_eq!(cfg.tool_interceptor, Some(expected.clone()));
+
+    let codex_home = TempDir::new()?;
+    let config = Config::load_from_base_config_with_overrides(
+        cfg,
+        ConfigOverrides::default(),
+        codex_home.abs(),
+    )
+    .await?;
+
+    assert_eq!(config.tool_interceptor, Some(expected));
     Ok(())
 }
 

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -42,6 +42,7 @@ use codex_config::types::OtelConfig;
 use codex_config::types::OtelConfigToml;
 use codex_config::types::OtelExporterKind;
 use codex_config::types::ShellEnvironmentPolicy;
+use codex_config::types::ToolInterceptorsToml;
 use codex_config::types::ToolSuggestConfig;
 use codex_config::types::ToolSuggestDiscoverable;
 use codex_config::types::TuiNotificationSettings;
@@ -592,6 +593,9 @@ pub struct Config {
 
     /// Configured discoverable tools for tool suggestions.
     pub tool_suggest: ToolSuggestConfig,
+
+    /// Local subprocesses that can replace matching tool calls at execution time.
+    pub tool_interceptors: Option<ToolInterceptorsToml>,
 
     /// OTEL configuration (exporter type, endpoint, headers, etc.).
     pub otel: codex_config::types::OtelConfig,
@@ -2268,6 +2272,7 @@ impl Config {
                 .and_then(|feedback| feedback.enabled)
                 .unwrap_or(true),
             tool_suggest,
+            tool_interceptors: cfg.tool_interceptors,
             tui_notifications: cfg
                 .tui
                 .as_ref()

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -42,7 +42,6 @@ use codex_config::types::OtelConfig;
 use codex_config::types::OtelConfigToml;
 use codex_config::types::OtelExporterKind;
 use codex_config::types::ShellEnvironmentPolicy;
-use codex_config::types::ToolInterceptorsToml;
 use codex_config::types::ToolSuggestConfig;
 use codex_config::types::ToolSuggestDiscoverable;
 use codex_config::types::TuiNotificationSettings;
@@ -594,8 +593,8 @@ pub struct Config {
     /// Configured discoverable tools for tool suggestions.
     pub tool_suggest: ToolSuggestConfig,
 
-    /// Local subprocesses that can replace matching tool calls at execution time.
-    pub tool_interceptors: Option<ToolInterceptorsToml>,
+    /// Local HTTP server that can replace tool call outputs before real dispatch.
+    pub tool_interceptor: Option<String>,
 
     /// OTEL configuration (exporter type, endpoint, headers, etc.).
     pub otel: codex_config::types::OtelConfig,
@@ -2272,7 +2271,7 @@ impl Config {
                 .and_then(|feedback| feedback.enabled)
                 .unwrap_or(true),
             tool_suggest,
-            tool_interceptors: cfg.tool_interceptors,
+            tool_interceptor: cfg.tool_interceptor,
             tui_notifications: cfg
                 .tui
                 .as_ref()

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -109,6 +109,7 @@ pub(crate) use skills::skills_load_input_from_config;
 mod skills_watcher;
 mod stream_events_utils;
 pub mod test_support;
+mod tool_interceptors;
 mod unified_exec;
 pub mod windows_sandbox;
 pub use client::X_RESPONSESAPI_INCLUDE_TIMING_METRICS_HEADER;

--- a/codex-rs/core/src/tool_interceptors.rs
+++ b/codex-rs/core/src/tool_interceptors.rs
@@ -1,0 +1,249 @@
+use std::process::Stdio;
+use std::time::Instant;
+
+use codex_config::types::ToolInterceptorHandlerToml;
+use codex_config::types::ToolInterceptorRuleToml;
+use codex_protocol::mcp::CallToolResult;
+use codex_protocol::models::FunctionCallOutputContentItem;
+use codex_utils_absolute_path::AbsolutePathBuf;
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json::Value;
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+
+use crate::function_tool::FunctionCallError;
+use crate::original_image_detail::can_request_original_image_detail;
+use crate::tools::context::FunctionToolOutput;
+use crate::tools::context::McpToolOutput;
+use crate::tools::context::ToolInvocation;
+use crate::tools::context::ToolOutput;
+use crate::tools::context::ToolPayload;
+use crate::tools::registry::AnyToolResult;
+
+#[derive(Serialize)]
+struct ToolInterceptorRequest<'a> {
+    tool_name: String,
+    call_id: &'a str,
+    cwd: &'a AbsolutePathBuf,
+    kind: &'static str,
+    operation: Option<&'a str>,
+    payload: Value,
+}
+
+#[derive(Deserialize)]
+struct ToolInterceptorResponse {
+    output: Option<String>,
+    content_items: Option<Vec<FunctionCallOutputContentItem>>,
+    mcp_result: Option<CallToolResult>,
+    success: Option<bool>,
+}
+
+pub(crate) async fn maybe_intercept(
+    invocation: &ToolInvocation,
+) -> Result<Option<AnyToolResult>, FunctionCallError> {
+    let Some(tool_interceptors) = invocation.turn.config.tool_interceptors.as_ref() else {
+        return Ok(None);
+    };
+
+    let tool_name = invocation.tool_name.display();
+    let Some(rule) = tool_interceptors
+        .rules
+        .iter()
+        .find(|rule| rule.tool == tool_name)
+    else {
+        return Ok(None);
+    };
+
+    let Some(handler) = tool_interceptors.handlers.get(&rule.handler) else {
+        return Err(FunctionCallError::Fatal(format!(
+            "tool interceptor `{}` references missing handler `{}`",
+            rule.tool, rule.handler
+        )));
+    };
+
+    let started = Instant::now();
+    let response = invoke_handler(invocation, &tool_name, rule, handler).await?;
+    let result = interceptor_response_to_tool_result(invocation, response, started);
+    Ok(Some(result))
+}
+
+async fn invoke_handler(
+    invocation: &ToolInvocation,
+    tool_name: &str,
+    rule: &ToolInterceptorRuleToml,
+    handler: &ToolInterceptorHandlerToml,
+) -> Result<ToolInterceptorResponse, FunctionCallError> {
+    if handler.command.trim().is_empty() {
+        return Err(FunctionCallError::Fatal(format!(
+            "tool interceptor handler for `{tool_name}` has an empty command"
+        )));
+    }
+
+    let request = ToolInterceptorRequest {
+        tool_name: tool_name.to_string(),
+        call_id: invocation.call_id.as_str(),
+        cwd: &invocation.turn.cwd,
+        kind: payload_kind(&invocation.payload),
+        operation: rule.operation.as_deref(),
+        payload: payload_json(&invocation.payload),
+    };
+    let request_bytes = serde_json::to_vec(&request).map_err(|err| {
+        FunctionCallError::Fatal(format!("failed to serialize interceptor request: {err}"))
+    })?;
+
+    let mut command = Command::new(&handler.command);
+    command.args(&handler.args);
+    if let Some(cwd) = handler.cwd.as_ref() {
+        command.current_dir(cwd);
+    }
+    command.envs(&handler.env);
+    command.stdin(Stdio::piped());
+    command.stdout(Stdio::piped());
+    command.stderr(Stdio::piped());
+
+    let mut child = command.spawn().map_err(|err| {
+        FunctionCallError::Fatal(format!(
+            "failed to spawn interceptor for `{tool_name}`: {err}"
+        ))
+    })?;
+
+    let Some(mut stdin) = child.stdin.take() else {
+        return Err(FunctionCallError::Fatal(format!(
+            "failed to open interceptor stdin for `{tool_name}`"
+        )));
+    };
+    stdin.write_all(&request_bytes).await.map_err(|err| {
+        FunctionCallError::Fatal(format!(
+            "failed to write interceptor request for `{tool_name}`: {err}"
+        ))
+    })?;
+    drop(stdin);
+
+    let output = child.wait_with_output().await.map_err(|err| {
+        FunctionCallError::Fatal(format!(
+            "failed to read interceptor output for `{tool_name}`: {err}"
+        ))
+    })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(FunctionCallError::RespondToModel(format!(
+            "tool interceptor for `{tool_name}` exited with {}: {}",
+            output.status,
+            stderr.trim()
+        )));
+    }
+
+    serde_json::from_slice::<ToolInterceptorResponse>(&output.stdout).map_err(|err| {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        FunctionCallError::RespondToModel(format!(
+            "tool interceptor for `{tool_name}` returned invalid JSON: {err}; stdout: {}",
+            stdout.trim()
+        ))
+    })
+}
+
+fn interceptor_response_to_tool_result(
+    invocation: &ToolInvocation,
+    response: ToolInterceptorResponse,
+    started: Instant,
+) -> AnyToolResult {
+    let ToolInterceptorResponse {
+        output,
+        content_items,
+        mcp_result,
+        success,
+    } = response;
+
+    let result: Box<dyn ToolOutput> = match &invocation.payload {
+        ToolPayload::Mcp { .. } => Box::new(McpToolOutput {
+            result: mcp_result.unwrap_or_else(|| CallToolResult {
+                content: vec![serde_json::json!({
+                    "type": "text",
+                    "text": output.unwrap_or_default(),
+                })],
+                structured_content: None,
+                is_error: success.map(|success| !success),
+                meta: None,
+            }),
+            wall_time: started.elapsed(),
+            original_image_detail_supported: can_request_original_image_detail(
+                &invocation.turn.model_info,
+            ),
+        }),
+        _ => {
+            if let Some(content_items) = content_items {
+                Box::new(FunctionToolOutput::from_content(content_items, success))
+            } else {
+                Box::new(FunctionToolOutput::from_text(
+                    output.unwrap_or_default(),
+                    success,
+                ))
+            }
+        }
+    };
+
+    AnyToolResult {
+        call_id: invocation.call_id.clone(),
+        payload: invocation.payload.clone(),
+        result,
+    }
+}
+
+fn payload_kind(payload: &ToolPayload) -> &'static str {
+    match payload {
+        ToolPayload::Function { .. } => "function",
+        ToolPayload::ToolSearch { .. } => "tool_search",
+        ToolPayload::Custom { .. } => "custom",
+        ToolPayload::LocalShell { .. } => "local_shell",
+        ToolPayload::Mcp { .. } => "mcp",
+    }
+}
+
+fn payload_json(payload: &ToolPayload) -> Value {
+    match payload {
+        ToolPayload::Function { arguments } => serde_json::json!({
+            "arguments": arguments,
+            "arguments_json": parse_json(arguments),
+        }),
+        ToolPayload::ToolSearch { arguments } => serde_json::json!({
+            "arguments": {
+                "query": &arguments.query,
+                "limit": arguments.limit,
+            },
+        }),
+        ToolPayload::Custom { input } => serde_json::json!({
+            "input": input,
+        }),
+        ToolPayload::LocalShell { params } => serde_json::json!({
+            "arguments": {
+                "command": &params.command,
+                "workdir": &params.workdir,
+                "timeout_ms": params.timeout_ms,
+                "sandbox_permissions": params.sandbox_permissions,
+                "prefix_rule": &params.prefix_rule,
+                "additional_permissions": &params.additional_permissions,
+                "justification": &params.justification,
+            },
+        }),
+        ToolPayload::Mcp {
+            server,
+            tool,
+            raw_arguments,
+        } => serde_json::json!({
+            "server": server,
+            "tool": tool,
+            "arguments": raw_arguments,
+            "arguments_json": parse_json(raw_arguments),
+        }),
+    }
+}
+
+fn parse_json(raw: &str) -> Option<Value> {
+    serde_json::from_str(raw).ok()
+}
+
+#[cfg(test)]
+#[path = "tool_interceptors_tests.rs"]
+mod tests;

--- a/codex-rs/core/src/tool_interceptors.rs
+++ b/codex-rs/core/src/tool_interceptors.rs
@@ -1,16 +1,13 @@
-use std::process::Stdio;
+use std::time::Duration;
 use std::time::Instant;
 
-use codex_config::types::ToolInterceptorHandlerToml;
-use codex_config::types::ToolInterceptorRuleToml;
 use codex_protocol::mcp::CallToolResult;
 use codex_protocol::models::FunctionCallOutputContentItem;
+use codex_tools::ToolSpec;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_json::Value;
-use tokio::io::AsyncWriteExt;
-use tokio::process::Command;
 
 use crate::function_tool::FunctionCallError;
 use crate::original_image_detail::can_request_original_image_detail;
@@ -21,173 +18,270 @@ use crate::tools::context::ToolOutput;
 use crate::tools::context::ToolPayload;
 use crate::tools::registry::AnyToolResult;
 
+const INTERCEPTOR_API_VERSION: u32 = 1;
+const INTERCEPTOR_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+const TOOL_CALL_PATH: &str = "tool-call";
+
 #[derive(Serialize)]
 struct ToolInterceptorRequest<'a> {
+    protocol_version: u32,
+    call: ToolInterceptorCall<'a>,
+    context: ToolInterceptorContext<'a>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_schema: Option<Value>,
+}
+
+#[derive(Serialize)]
+struct ToolInterceptorCall<'a> {
+    id: &'a str,
     tool_name: String,
-    call_id: &'a str,
-    cwd: &'a AbsolutePathBuf,
     kind: &'static str,
-    operation: Option<&'a str>,
-    payload: Value,
+    input: Value,
+    raw_input: Option<&'a str>,
+    mcp: Option<ToolInterceptorMcpCall<'a>>,
+}
+
+#[derive(Serialize)]
+struct ToolInterceptorMcpCall<'a> {
+    server: &'a str,
+    tool: &'a str,
+}
+
+#[derive(Serialize)]
+struct ToolInterceptorContext<'a> {
+    cwd: &'a AbsolutePathBuf,
+    thread_id: String,
+    turn_id: &'a str,
+    trace_id: Option<&'a str>,
+    model: &'a str,
 }
 
 #[derive(Deserialize)]
 struct ToolInterceptorResponse {
-    output: Option<String>,
-    content_items: Option<Vec<FunctionCallOutputContentItem>>,
-    mcp_result: Option<CallToolResult>,
-    success: Option<bool>,
+    protocol_version: u32,
+    #[serde(flatten)]
+    action: ToolInterceptorAction,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+enum ToolInterceptorAction {
+    Continue,
+    Replace { result: ToolInterceptorResult },
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum ToolInterceptorResult {
+    Text {
+        text: String,
+        success: Option<bool>,
+    },
+    ContentItems {
+        content_items: Vec<FunctionCallOutputContentItem>,
+        success: Option<bool>,
+    },
+    Mcp {
+        value: CallToolResult,
+    },
 }
 
 pub(crate) async fn maybe_intercept(
     invocation: &ToolInvocation,
+    tool_schema: Option<&ToolSpec>,
 ) -> Result<Option<AnyToolResult>, FunctionCallError> {
-    let Some(tool_interceptors) = invocation.turn.config.tool_interceptors.as_ref() else {
+    let Some(interceptor_url) = invocation.turn.config.tool_interceptor.as_deref() else {
         return Ok(None);
     };
 
-    let tool_name = invocation.tool_name.display();
-    let Some(rule) = tool_interceptors
-        .rules
-        .iter()
-        .find(|rule| rule.tool == tool_name)
+    let started = Instant::now();
+    let response = call_interceptor(invocation, interceptor_url, tool_schema).await?;
+    let ToolInterceptorAction::Replace {
+        result: replacement,
+    } = response.action
     else {
         return Ok(None);
     };
 
-    let Some(handler) = tool_interceptors.handlers.get(&rule.handler) else {
-        return Err(FunctionCallError::Fatal(format!(
-            "tool interceptor `{}` references missing handler `{}`",
-            rule.tool, rule.handler
-        )));
-    };
-
-    let started = Instant::now();
-    let response = invoke_handler(invocation, &tool_name, rule, handler).await?;
-    let result = interceptor_response_to_tool_result(invocation, response, started);
+    let result = replacement_to_tool_result(invocation, replacement, started)?;
     Ok(Some(result))
 }
 
-async fn invoke_handler(
+async fn call_interceptor(
     invocation: &ToolInvocation,
-    tool_name: &str,
-    rule: &ToolInterceptorRuleToml,
-    handler: &ToolInterceptorHandlerToml,
+    configured_url: &str,
+    tool_schema: Option<&ToolSpec>,
 ) -> Result<ToolInterceptorResponse, FunctionCallError> {
-    if handler.command.trim().is_empty() {
-        return Err(FunctionCallError::Fatal(format!(
-            "tool interceptor handler for `{tool_name}` has an empty command"
-        )));
-    }
-
+    let tool_name = invocation.tool_name.display();
+    let url = interceptor_endpoint(configured_url, &tool_name)?;
     let request = ToolInterceptorRequest {
-        tool_name: tool_name.to_string(),
-        call_id: invocation.call_id.as_str(),
-        cwd: &invocation.turn.cwd,
-        kind: payload_kind(&invocation.payload),
-        operation: rule.operation.as_deref(),
-        payload: payload_json(&invocation.payload),
+        protocol_version: INTERCEPTOR_API_VERSION,
+        call: ToolInterceptorCall {
+            id: invocation.call_id.as_str(),
+            tool_name,
+            kind: payload_kind(&invocation.payload),
+            input: payload_input_json(&invocation.payload),
+            raw_input: raw_input(&invocation.payload),
+            mcp: mcp_call(&invocation.payload),
+        },
+        context: ToolInterceptorContext {
+            cwd: &invocation.turn.cwd,
+            thread_id: invocation.session.conversation_id.to_string(),
+            turn_id: invocation.turn.sub_id.as_str(),
+            trace_id: invocation.turn.trace_id.as_deref(),
+            model: invocation.turn.model_info.slug.as_str(),
+        },
+        tool_schema: tool_schema_json(tool_schema)?,
     };
-    let request_bytes = serde_json::to_vec(&request).map_err(|err| {
-        FunctionCallError::Fatal(format!("failed to serialize interceptor request: {err}"))
+
+    let client = reqwest::Client::builder()
+        .timeout(INTERCEPTOR_REQUEST_TIMEOUT)
+        .build()
+        .map_err(|err| {
+            FunctionCallError::Fatal(format!("failed to build tool interceptor client: {err}"))
+        })?;
+
+    let response = client
+        .post(url.clone())
+        .json(&request)
+        .send()
+        .await
+        .map_err(|err| {
+            FunctionCallError::Fatal(format!("tool interceptor request to `{url}` failed: {err}"))
+        })?;
+
+    let status = response.status();
+    let body = response.bytes().await.map_err(|err| {
+        FunctionCallError::Fatal(format!("failed to read tool interceptor response: {err}"))
     })?;
 
-    let mut command = Command::new(&handler.command);
-    command.args(&handler.args);
-    if let Some(cwd) = handler.cwd.as_ref() {
-        command.current_dir(cwd);
-    }
-    command.envs(&handler.env);
-    command.stdin(Stdio::piped());
-    command.stdout(Stdio::piped());
-    command.stderr(Stdio::piped());
-
-    let mut child = command.spawn().map_err(|err| {
-        FunctionCallError::Fatal(format!(
-            "failed to spawn interceptor for `{tool_name}`: {err}"
-        ))
-    })?;
-
-    let Some(mut stdin) = child.stdin.take() else {
+    if !status.is_success() {
         return Err(FunctionCallError::Fatal(format!(
-            "failed to open interceptor stdin for `{tool_name}`"
-        )));
-    };
-    stdin.write_all(&request_bytes).await.map_err(|err| {
-        FunctionCallError::Fatal(format!(
-            "failed to write interceptor request for `{tool_name}`: {err}"
-        ))
-    })?;
-    drop(stdin);
-
-    let output = child.wait_with_output().await.map_err(|err| {
-        FunctionCallError::Fatal(format!(
-            "failed to read interceptor output for `{tool_name}`: {err}"
-        ))
-    })?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(FunctionCallError::RespondToModel(format!(
-            "tool interceptor for `{tool_name}` exited with {}: {}",
-            output.status,
-            stderr.trim()
+            "tool interceptor `{url}` returned HTTP {status}: {}",
+            String::from_utf8_lossy(&body).trim()
         )));
     }
 
-    serde_json::from_slice::<ToolInterceptorResponse>(&output.stdout).map_err(|err| {
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        FunctionCallError::RespondToModel(format!(
-            "tool interceptor for `{tool_name}` returned invalid JSON: {err}; stdout: {}",
-            stdout.trim()
+    let response = serde_json::from_slice::<ToolInterceptorResponse>(&body).map_err(|err| {
+        FunctionCallError::Fatal(format!(
+            "tool interceptor `{url}` returned invalid JSON: {err}; body: {}",
+            String::from_utf8_lossy(&body).trim()
         ))
-    })
+    })?;
+
+    if response.protocol_version != INTERCEPTOR_API_VERSION {
+        return Err(FunctionCallError::Fatal(format!(
+            "tool interceptor `{url}` returned protocol_version {}, expected {}",
+            response.protocol_version, INTERCEPTOR_API_VERSION
+        )));
+    }
+
+    Ok(response)
 }
 
-fn interceptor_response_to_tool_result(
-    invocation: &ToolInvocation,
-    response: ToolInterceptorResponse,
-    started: Instant,
-) -> AnyToolResult {
-    let ToolInterceptorResponse {
-        output,
-        content_items,
-        mcp_result,
-        success,
-    } = response;
+fn interceptor_endpoint(
+    configured_url: &str,
+    tool_name: &str,
+) -> Result<reqwest::Url, FunctionCallError> {
+    let mut url = reqwest::Url::parse(configured_url).map_err(|err| {
+        FunctionCallError::Fatal(format!(
+            "tool_interceptor must be an HTTP URL for `{tool_name}`: {err}"
+        ))
+    })?;
 
-    let result: Box<dyn ToolOutput> = match &invocation.payload {
-        ToolPayload::Mcp { .. } => Box::new(McpToolOutput {
-            result: mcp_result.unwrap_or_else(|| CallToolResult {
-                content: vec![serde_json::json!({
-                    "type": "text",
-                    "text": output.unwrap_or_default(),
-                })],
-                structured_content: None,
-                is_error: success.map(|success| !success),
-                meta: None,
-            }),
-            wall_time: started.elapsed(),
-            original_image_detail_supported: can_request_original_image_detail(
-                &invocation.turn.model_info,
-            ),
-        }),
-        _ => {
-            if let Some(content_items) = content_items {
-                Box::new(FunctionToolOutput::from_content(content_items, success))
-            } else {
-                Box::new(FunctionToolOutput::from_text(
-                    output.unwrap_or_default(),
-                    success,
-                ))
-            }
+    match url.scheme() {
+        "http" | "https" => {}
+        scheme => {
+            return Err(FunctionCallError::Fatal(format!(
+                "tool_interceptor for `{tool_name}` must use http or https, got `{scheme}`"
+            )));
         }
+    }
+
+    let Some(host) = url.host_str() else {
+        return Err(FunctionCallError::Fatal(format!(
+            "tool_interceptor for `{tool_name}` must include a host"
+        )));
+    };
+    if !matches!(host, "127.0.0.1" | "localhost" | "::1") {
+        return Err(FunctionCallError::Fatal(format!(
+            "tool_interceptor for `{tool_name}` must point to localhost, got `{host}`"
+        )));
+    }
+
+    if matches!(url.path(), "" | "/") {
+        url.set_path(TOOL_CALL_PATH);
+    }
+    Ok(url)
+}
+
+fn replacement_to_tool_result(
+    invocation: &ToolInvocation,
+    replacement: ToolInterceptorResult,
+    started: Instant,
+) -> Result<AnyToolResult, FunctionCallError> {
+    let result: Box<dyn ToolOutput> = match &invocation.payload {
+        ToolPayload::Mcp { .. } => {
+            Box::new(mcp_replacement_to_output(invocation, replacement, started)?)
+        }
+        _ => Box::new(function_replacement_to_output(replacement)?),
     };
 
-    AnyToolResult {
+    Ok(AnyToolResult {
         call_id: invocation.call_id.clone(),
         payload: invocation.payload.clone(),
         result,
+    })
+}
+
+fn mcp_replacement_to_output(
+    invocation: &ToolInvocation,
+    replacement: ToolInterceptorResult,
+    started: Instant,
+) -> Result<McpToolOutput, FunctionCallError> {
+    let result = match replacement {
+        ToolInterceptorResult::Mcp { value } => value,
+        ToolInterceptorResult::Text { text, success } => CallToolResult {
+            content: vec![serde_json::json!({
+                "type": "text",
+                "text": text,
+            })],
+            structured_content: None,
+            is_error: success.map(|success| !success),
+            meta: None,
+        },
+        ToolInterceptorResult::ContentItems { .. } => {
+            return Err(FunctionCallError::Fatal(
+                "tool interceptor returned content_items for an MCP tool; use text or mcp"
+                    .to_string(),
+            ));
+        }
+    };
+
+    Ok(McpToolOutput {
+        result,
+        wall_time: started.elapsed(),
+        original_image_detail_supported: can_request_original_image_detail(
+            &invocation.turn.model_info,
+        ),
+    })
+}
+
+fn function_replacement_to_output(
+    replacement: ToolInterceptorResult,
+) -> Result<FunctionToolOutput, FunctionCallError> {
+    match replacement {
+        ToolInterceptorResult::Text { text, success } => {
+            Ok(FunctionToolOutput::from_text(text, success))
+        }
+        ToolInterceptorResult::ContentItems {
+            content_items,
+            success,
+        } => Ok(FunctionToolOutput::from_content(content_items, success)),
+        ToolInterceptorResult::Mcp { .. } => Err(FunctionCallError::Fatal(
+            "tool interceptor returned mcp for a non-MCP tool; use text or content_items"
+                .to_string(),
+        )),
     }
 }
 
@@ -201,43 +295,64 @@ fn payload_kind(payload: &ToolPayload) -> &'static str {
     }
 }
 
-fn payload_json(payload: &ToolPayload) -> Value {
+fn payload_input_json(payload: &ToolPayload) -> Value {
     match payload {
         ToolPayload::Function { arguments } => serde_json::json!({
-            "arguments": arguments,
             "arguments_json": parse_json(arguments),
         }),
         ToolPayload::ToolSearch { arguments } => serde_json::json!({
-            "arguments": {
-                "query": &arguments.query,
-                "limit": arguments.limit,
-            },
+            "query": &arguments.query,
+            "limit": arguments.limit,
         }),
         ToolPayload::Custom { input } => serde_json::json!({
             "input": input,
         }),
         ToolPayload::LocalShell { params } => serde_json::json!({
-            "arguments": {
-                "command": &params.command,
-                "workdir": &params.workdir,
-                "timeout_ms": params.timeout_ms,
-                "sandbox_permissions": params.sandbox_permissions,
-                "prefix_rule": &params.prefix_rule,
-                "additional_permissions": &params.additional_permissions,
-                "justification": &params.justification,
-            },
+            "command": &params.command,
+            "workdir": &params.workdir,
+            "timeout_ms": params.timeout_ms,
+            "sandbox_permissions": params.sandbox_permissions,
+            "prefix_rule": &params.prefix_rule,
+            "additional_permissions": &params.additional_permissions,
+            "justification": &params.justification,
         }),
-        ToolPayload::Mcp {
-            server,
-            tool,
-            raw_arguments,
-        } => serde_json::json!({
-            "server": server,
-            "tool": tool,
-            "arguments": raw_arguments,
+        ToolPayload::Mcp { raw_arguments, .. } => serde_json::json!({
             "arguments_json": parse_json(raw_arguments),
         }),
     }
+}
+
+fn raw_input(payload: &ToolPayload) -> Option<&str> {
+    match payload {
+        ToolPayload::Function { arguments }
+        | ToolPayload::Mcp {
+            raw_arguments: arguments,
+            ..
+        } => Some(arguments.as_str()),
+        ToolPayload::Custom { input } => Some(input.as_str()),
+        ToolPayload::ToolSearch { .. } | ToolPayload::LocalShell { .. } => None,
+    }
+}
+
+fn mcp_call(payload: &ToolPayload) -> Option<ToolInterceptorMcpCall<'_>> {
+    match payload {
+        ToolPayload::Mcp {
+            server,
+            tool,
+            raw_arguments: _,
+        } => Some(ToolInterceptorMcpCall {
+            server: server.as_str(),
+            tool: tool.as_str(),
+        }),
+        _ => None,
+    }
+}
+
+fn tool_schema_json(tool_schema: Option<&ToolSpec>) -> Result<Option<Value>, FunctionCallError> {
+    tool_schema
+        .map(serde_json::to_value)
+        .transpose()
+        .map_err(|err| FunctionCallError::Fatal(format!("failed to serialize tool schema: {err}")))
 }
 
 fn parse_json(raw: &str) -> Option<Value> {

--- a/codex-rs/core/src/tool_interceptors_tests.rs
+++ b/codex-rs/core/src/tool_interceptors_tests.rs
@@ -1,13 +1,15 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 
-use codex_config::types::ToolInterceptorHandlerToml;
-use codex_config::types::ToolInterceptorRuleToml;
-use codex_config::types::ToolInterceptorsToml;
 use codex_protocol::models::FunctionCallOutputBody;
 use codex_protocol::models::ResponseInputItem;
 use codex_tools::ToolName;
 use pretty_assertions::assert_eq;
+use serde_json::json;
+use wiremock::Mock;
+use wiremock::MockServer;
+use wiremock::ResponseTemplate;
+use wiremock::matchers::method;
+use wiremock::matchers::path;
 
 use super::maybe_intercept;
 use crate::session::tests::make_session_and_context;
@@ -16,59 +18,41 @@ use crate::tools::context::ToolInvocation;
 use crate::tools::context::ToolPayload;
 use crate::turn_diff_tracker::TurnDiffTracker;
 
-fn python() -> Option<std::path::PathBuf> {
-    which::which("python3")
-        .or_else(|_| which::which("python"))
-        .ok()
-}
-
 fn tracker() -> SharedTurnDiffTracker {
     Arc::new(tokio::sync::Mutex::new(TurnDiffTracker::new()))
 }
 
-#[tokio::test]
-async fn function_tool_call_uses_interceptor_output() -> anyhow::Result<()> {
-    let Some(python) = python() else {
-        return Ok(());
-    };
-
-    let temp_dir = tempfile::tempdir()?;
-    let handler_path = temp_dir.path().join("handler.py");
-    std::fs::write(
-        &handler_path,
-        r#"
-import json
-import sys
-
-request = json.load(sys.stdin)
-arguments = request["payload"]["arguments_json"]
-print(json.dumps({
-    "output": f"{request['operation']}:{request['tool_name']}:{arguments['cmd']}",
-    "success": True,
-}))
-"#,
-    )?;
-
+async fn turn_with_interceptor(
+    interceptor_url: String,
+) -> (
+    crate::session::session::Session,
+    crate::session::turn_context::TurnContext,
+) {
     let (session, mut turn) = make_session_and_context().await;
     let mut config = (*turn.config).clone();
-    config.tool_interceptors = Some(ToolInterceptorsToml {
-        handlers: HashMap::from([(
-            "python".to_string(),
-            ToolInterceptorHandlerToml {
-                command: python.to_string_lossy().to_string(),
-                args: vec![handler_path.to_string_lossy().to_string()],
-                cwd: None,
-                env: HashMap::new(),
-            },
-        )]),
-        rules: vec![ToolInterceptorRuleToml {
-            tool: "exec_command".to_string(),
-            handler: "python".to_string(),
-            operation: Some("exec".to_string()),
-        }],
-    });
+    config.tool_interceptor = Some(interceptor_url);
     turn.config = Arc::new(config);
+    (session, turn)
+}
 
+#[tokio::test]
+async fn function_tool_call_uses_interceptor_output() -> anyhow::Result<()> {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/tool-call"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "protocol_version": 1,
+            "action": "replace",
+            "result": {
+                "type": "text",
+                "text": "synthetic exec output",
+                "success": true,
+            },
+        })))
+        .mount(&server)
+        .await;
+
+    let (session, turn) = turn_with_interceptor(server.uri()).await;
     let invocation = ToolInvocation {
         session: Arc::new(session),
         turn: Arc::new(turn),
@@ -80,9 +64,9 @@ print(json.dumps({
         },
     };
 
-    let result = maybe_intercept(&invocation)
+    let result = maybe_intercept(&invocation, None)
         .await?
-        .expect("interceptor should match");
+        .expect("interceptor should replace");
     let response = result.into_response();
 
     let ResponseInputItem::FunctionCallOutput { call_id, output } = response else {
@@ -92,60 +76,64 @@ print(json.dumps({
     assert_eq!(output.success, Some(true));
     assert_eq!(
         output.body,
-        FunctionCallOutputBody::Text("exec:exec_command:date".to_string())
+        FunctionCallOutputBody::Text("synthetic exec output".to_string())
     );
 
     Ok(())
 }
 
 #[tokio::test]
-async fn mcp_tool_call_uses_interceptor_mcp_result() -> anyhow::Result<()> {
-    let Some(python) = python() else {
-        return Ok(());
+async fn tool_call_passes_through_when_interceptor_passes() -> anyhow::Result<()> {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/tool-call"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "protocol_version": 1,
+            "action": "continue",
+        })))
+        .mount(&server)
+        .await;
+
+    let (session, turn) = turn_with_interceptor(server.uri()).await;
+    let invocation = ToolInvocation {
+        session: Arc::new(session),
+        turn: Arc::new(turn),
+        tracker: tracker(),
+        call_id: "call-pass".to_string(),
+        tool_name: ToolName::plain("exec_command"),
+        payload: ToolPayload::Function {
+            arguments: serde_json::json!({"cmd": "date"}).to_string(),
+        },
     };
 
-    let temp_dir = tempfile::tempdir()?;
-    let handler_path = temp_dir.path().join("handler.py");
-    std::fs::write(
-        &handler_path,
-        r#"
-import json
-import sys
+    assert!(maybe_intercept(&invocation, None).await?.is_none());
+    Ok(())
+}
 
-request = json.load(sys.stdin)
-print(json.dumps({
-    "mcp_result": {
-        "content": [{
-            "type": "text",
-            "text": f"fake gmail {request['payload']['arguments_json']['query']}",
-        }],
-        "isError": False,
-    }
-}))
-"#,
-    )?;
+#[tokio::test]
+async fn mcp_tool_call_uses_interceptor_mcp_result() -> anyhow::Result<()> {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/tool-call"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "protocol_version": 1,
+            "action": "replace",
+            "result": {
+                "type": "mcp",
+                "value": {
+                    "content": [{
+                        "type": "text",
+                        "text": "fake gmail in:inbox",
+                    }],
+                    "isError": false,
+                },
+            },
+        })))
+        .mount(&server)
+        .await;
 
     let tool_name = ToolName::namespaced("mcp__codex_apps__gmail", "_search_emails");
-    let (session, mut turn) = make_session_and_context().await;
-    let mut config = (*turn.config).clone();
-    config.tool_interceptors = Some(ToolInterceptorsToml {
-        handlers: HashMap::from([(
-            "python".to_string(),
-            ToolInterceptorHandlerToml {
-                command: python.to_string_lossy().to_string(),
-                args: vec![handler_path.to_string_lossy().to_string()],
-                cwd: None,
-                env: HashMap::new(),
-            },
-        )]),
-        rules: vec![ToolInterceptorRuleToml {
-            tool: tool_name.display(),
-            handler: "python".to_string(),
-            operation: None,
-        }],
-    });
-    turn.config = Arc::new(config);
-
+    let (session, turn) = turn_with_interceptor(server.uri()).await;
     let invocation = ToolInvocation {
         session: Arc::new(session),
         turn: Arc::new(turn),
@@ -159,9 +147,9 @@ print(json.dumps({
         },
     };
 
-    let result = maybe_intercept(&invocation)
+    let result = maybe_intercept(&invocation, None)
         .await?
-        .expect("interceptor should match");
+        .expect("interceptor should replace");
     let response = result.into_response();
 
     let ResponseInputItem::FunctionCallOutput { call_id, output } = response else {

--- a/codex-rs/core/src/tool_interceptors_tests.rs
+++ b/codex-rs/core/src/tool_interceptors_tests.rs
@@ -1,0 +1,179 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use codex_config::types::ToolInterceptorHandlerToml;
+use codex_config::types::ToolInterceptorRuleToml;
+use codex_config::types::ToolInterceptorsToml;
+use codex_protocol::models::FunctionCallOutputBody;
+use codex_protocol::models::ResponseInputItem;
+use codex_tools::ToolName;
+use pretty_assertions::assert_eq;
+
+use super::maybe_intercept;
+use crate::session::tests::make_session_and_context;
+use crate::tools::context::SharedTurnDiffTracker;
+use crate::tools::context::ToolInvocation;
+use crate::tools::context::ToolPayload;
+use crate::turn_diff_tracker::TurnDiffTracker;
+
+fn python() -> Option<std::path::PathBuf> {
+    which::which("python3")
+        .or_else(|_| which::which("python"))
+        .ok()
+}
+
+fn tracker() -> SharedTurnDiffTracker {
+    Arc::new(tokio::sync::Mutex::new(TurnDiffTracker::new()))
+}
+
+#[tokio::test]
+async fn function_tool_call_uses_interceptor_output() -> anyhow::Result<()> {
+    let Some(python) = python() else {
+        return Ok(());
+    };
+
+    let temp_dir = tempfile::tempdir()?;
+    let handler_path = temp_dir.path().join("handler.py");
+    std::fs::write(
+        &handler_path,
+        r#"
+import json
+import sys
+
+request = json.load(sys.stdin)
+arguments = request["payload"]["arguments_json"]
+print(json.dumps({
+    "output": f"{request['operation']}:{request['tool_name']}:{arguments['cmd']}",
+    "success": True,
+}))
+"#,
+    )?;
+
+    let (session, mut turn) = make_session_and_context().await;
+    let mut config = (*turn.config).clone();
+    config.tool_interceptors = Some(ToolInterceptorsToml {
+        handlers: HashMap::from([(
+            "python".to_string(),
+            ToolInterceptorHandlerToml {
+                command: python.to_string_lossy().to_string(),
+                args: vec![handler_path.to_string_lossy().to_string()],
+                cwd: None,
+                env: HashMap::new(),
+            },
+        )]),
+        rules: vec![ToolInterceptorRuleToml {
+            tool: "exec_command".to_string(),
+            handler: "python".to_string(),
+            operation: Some("exec".to_string()),
+        }],
+    });
+    turn.config = Arc::new(config);
+
+    let invocation = ToolInvocation {
+        session: Arc::new(session),
+        turn: Arc::new(turn),
+        tracker: tracker(),
+        call_id: "call-1".to_string(),
+        tool_name: ToolName::plain("exec_command"),
+        payload: ToolPayload::Function {
+            arguments: serde_json::json!({"cmd": "date"}).to_string(),
+        },
+    };
+
+    let result = maybe_intercept(&invocation)
+        .await?
+        .expect("interceptor should match");
+    let response = result.into_response();
+
+    let ResponseInputItem::FunctionCallOutput { call_id, output } = response else {
+        panic!("expected function call output");
+    };
+    assert_eq!(call_id, "call-1");
+    assert_eq!(output.success, Some(true));
+    assert_eq!(
+        output.body,
+        FunctionCallOutputBody::Text("exec:exec_command:date".to_string())
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn mcp_tool_call_uses_interceptor_mcp_result() -> anyhow::Result<()> {
+    let Some(python) = python() else {
+        return Ok(());
+    };
+
+    let temp_dir = tempfile::tempdir()?;
+    let handler_path = temp_dir.path().join("handler.py");
+    std::fs::write(
+        &handler_path,
+        r#"
+import json
+import sys
+
+request = json.load(sys.stdin)
+print(json.dumps({
+    "mcp_result": {
+        "content": [{
+            "type": "text",
+            "text": f"fake gmail {request['payload']['arguments_json']['query']}",
+        }],
+        "isError": False,
+    }
+}))
+"#,
+    )?;
+
+    let tool_name = ToolName::namespaced("mcp__codex_apps__gmail", "_search_emails");
+    let (session, mut turn) = make_session_and_context().await;
+    let mut config = (*turn.config).clone();
+    config.tool_interceptors = Some(ToolInterceptorsToml {
+        handlers: HashMap::from([(
+            "python".to_string(),
+            ToolInterceptorHandlerToml {
+                command: python.to_string_lossy().to_string(),
+                args: vec![handler_path.to_string_lossy().to_string()],
+                cwd: None,
+                env: HashMap::new(),
+            },
+        )]),
+        rules: vec![ToolInterceptorRuleToml {
+            tool: tool_name.display(),
+            handler: "python".to_string(),
+            operation: None,
+        }],
+    });
+    turn.config = Arc::new(config);
+
+    let invocation = ToolInvocation {
+        session: Arc::new(session),
+        turn: Arc::new(turn),
+        tracker: tracker(),
+        call_id: "mcp-call-1".to_string(),
+        tool_name,
+        payload: ToolPayload::Mcp {
+            server: "codex_apps".to_string(),
+            tool: "gmail.search".to_string(),
+            raw_arguments: serde_json::json!({"query": "in:inbox"}).to_string(),
+        },
+    };
+
+    let result = maybe_intercept(&invocation)
+        .await?
+        .expect("interceptor should match");
+    let response = result.into_response();
+
+    let ResponseInputItem::FunctionCallOutput { call_id, output } = response else {
+        panic!("expected function call output");
+    };
+    assert_eq!(call_id, "mcp-call-1");
+    assert_eq!(output.success, Some(true));
+    let Some(text) = output.body.to_text() else {
+        panic!("expected text output");
+    };
+    assert!(text.contains("Wall time: "));
+    assert!(text.contains("fake gmail in:inbox"));
+
+    Ok(())
+}

--- a/codex-rs/core/src/tools/router.rs
+++ b/codex-rs/core/src/tools/router.rs
@@ -298,7 +298,10 @@ impl ToolRouter {
             payload,
         };
 
-        if let Some(result) = crate::tool_interceptors::maybe_intercept(&invocation).await? {
+        let tool_schema = self.find_spec(&invocation.tool_name);
+        if let Some(result) =
+            crate::tool_interceptors::maybe_intercept(&invocation, tool_schema.as_ref()).await?
+        {
             return Ok(result);
         }
 

--- a/codex-rs/core/src/tools/router.rs
+++ b/codex-rs/core/src/tools/router.rs
@@ -298,6 +298,10 @@ impl ToolRouter {
             payload,
         };
 
+        if let Some(result) = crate::tool_interceptors::maybe_intercept(&invocation).await? {
+            return Ok(result);
+        }
+
         self.registry.dispatch_any(invocation).await
     }
 }


### PR DESCRIPTION
## Summary
- add local tool-interceptor server config for Codex exec
- route matching tool calls through the interceptor before normal execution
- support realistic red-teaming runs where connector/local tool calls can be replaced locally

## Validation
- built and used interceptor-enabled Codex binary for the scenario-pack red-team runs
- verified Gmail and Google Drive connector calls were intercepted rather than calling real connectors