### PR TITLE
Reload app-server OTel from thread config

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -11,6 +11,7 @@ use crate::fuzzy_file_search::FuzzyFileSearchSession;
 use crate::fuzzy_file_search::run_fuzzy_file_search;
 use crate::fuzzy_file_search::start_fuzzy_file_search_session;
 use crate::models::supported_models;
+use crate::otel_reload::OtelReloader;
 use crate::outgoing_message::ConnectionId;
 use crate::outgoing_message::ConnectionRequestId;
 use crate::outgoing_message::OutgoingMessageSender;
@@ -488,6 +489,7 @@ pub(crate) struct CodexMessageProcessor {
     background_tasks: TaskTracker,
     feedback: CodexFeedback,
     log_db: Option<LogDbLayer>,
+    otel_reloader: Option<OtelReloader>,
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -509,6 +511,7 @@ struct ListenerTaskContext {
     thread_watch_manager: ThreadWatchManager,
     fallback_model_provider: String,
     codex_home: PathBuf,
+    otel_reloader: Option<OtelReloader>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -640,6 +643,7 @@ pub(crate) struct CodexMessageProcessorArgs {
     pub(crate) cloud_requirements: Arc<RwLock<CloudRequirementsLoader>>,
     pub(crate) feedback: CodexFeedback,
     pub(crate) log_db: Option<LogDbLayer>,
+    pub(crate) otel_reloader: Option<OtelReloader>,
 }
 
 impl CodexMessageProcessor {
@@ -718,6 +722,7 @@ impl CodexMessageProcessor {
             cloud_requirements,
             feedback,
             log_db,
+            otel_reloader,
         } = args;
         Self {
             auth_manager,
@@ -740,6 +745,7 @@ impl CodexMessageProcessor {
             background_tasks: TaskTracker::new(),
             feedback,
             log_db,
+            otel_reloader,
         }
     }
 
@@ -2420,6 +2426,7 @@ impl CodexMessageProcessor {
             thread_watch_manager: self.thread_watch_manager.clone(),
             fallback_model_provider: self.config.model_provider_id.clone(),
             codex_home: self.config.codex_home.to_path_buf(),
+            otel_reloader: self.otel_reloader.clone(),
         };
         let request_trace = request_context.request_trace();
         let runtime_feature_enablement = self.current_runtime_feature_enablement();
@@ -2619,6 +2626,27 @@ impl CodexMessageProcessor {
                     return;
                 }
             };
+        }
+
+        if let Some(otel_reloader) = listener_task_context.otel_reloader.as_ref() {
+            let otel_reload_error = otel_reloader
+                .reload_from_config(&config)
+                .err()
+                .map(|err| err.to_string());
+            if let Some(err) = otel_reload_error {
+                listener_task_context
+                    .outgoing
+                    .send_error(
+                        request_id,
+                        JSONRPCErrorError {
+                            code: INTERNAL_ERROR_CODE,
+                            message: format!("failed to reload otel config: {err}"),
+                            data: None,
+                        },
+                    )
+                    .await;
+                return;
+            }
         }
 
         let instruction_sources = Self::instruction_sources_from_config(&config).await;
@@ -7936,6 +7964,7 @@ impl CodexMessageProcessor {
                 thread_watch_manager: self.thread_watch_manager.clone(),
                 fallback_model_provider: self.config.model_provider_id.clone(),
                 codex_home: self.config.codex_home.to_path_buf(),
+                otel_reloader: self.otel_reloader.clone(),
             },
             conversation_id,
             connection_id,
@@ -8050,6 +8079,7 @@ impl CodexMessageProcessor {
                 thread_watch_manager: self.thread_watch_manager.clone(),
                 fallback_model_provider: self.config.model_provider_id.clone(),
                 codex_home: self.config.codex_home.to_path_buf(),
+                otel_reloader: self.otel_reloader.clone(),
             },
             conversation_id,
             conversation,
@@ -8099,6 +8129,7 @@ impl CodexMessageProcessor {
             thread_watch_manager,
             fallback_model_provider,
             codex_home,
+            otel_reloader: _,
         } = listener_task_context;
         let outgoing_for_task = Arc::clone(&outgoing);
         tokio::spawn(async move {

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -2628,27 +2628,6 @@ impl CodexMessageProcessor {
             };
         }
 
-        if let Some(otel_reloader) = listener_task_context.otel_reloader.as_ref() {
-            let otel_reload_error = otel_reloader
-                .reload_from_config(&config)
-                .err()
-                .map(|err| err.to_string());
-            if let Some(err) = otel_reload_error {
-                listener_task_context
-                    .outgoing
-                    .send_error(
-                        request_id,
-                        JSONRPCErrorError {
-                            code: INTERNAL_ERROR_CODE,
-                            message: format!("failed to reload otel config: {err}"),
-                            data: None,
-                        },
-                    )
-                    .await;
-                return;
-            }
-        }
-
         let instruction_sources = Self::instruction_sources_from_config(&config).await;
         let dynamic_tools = dynamic_tools.unwrap_or_default();
         let core_dynamic_tools = if dynamic_tools.is_empty() {
@@ -2677,6 +2656,31 @@ impl CodexMessageProcessor {
                 .collect()
         };
         let core_dynamic_tool_count = core_dynamic_tools.len();
+        let otel_reload = if let Some(otel_reloader) = listener_task_context.otel_reloader.as_ref()
+        {
+            let otel_reload_result = otel_reloader
+                .reload_from_config(&config)
+                .map_err(|err| err.to_string());
+            match otel_reload_result {
+                Ok(otel_reload) => Some(otel_reload),
+                Err(err) => {
+                    listener_task_context
+                        .outgoing
+                        .send_error(
+                            request_id,
+                            JSONRPCErrorError {
+                                code: INTERNAL_ERROR_CODE,
+                                message: format!("failed to reload otel config: {err}"),
+                                data: None,
+                            },
+                        )
+                        .await;
+                    return;
+                }
+            }
+        } else {
+            None
+        };
 
         match listener_task_context
             .thread_manager
@@ -2702,6 +2706,9 @@ impl CodexMessageProcessor {
             .await
         {
             Ok(new_conv) => {
+                if let Some(otel_reload) = otel_reload {
+                    otel_reload.commit();
+                }
                 let NewThread {
                     thread_id,
                     thread,

--- a/codex-rs/app-server/src/in_process.rs
+++ b/codex-rs/app-server/src/in_process.rs
@@ -404,6 +404,7 @@ fn start_uninitialized(args: InProcessStartArgs) -> InProcessClientHandle {
                 auth_manager,
                 rpc_transport: AppServerRpcTransport::InProcess,
                 remote_control_handle: None,
+                otel_reloader: None,
             }));
             let mut thread_created_rx = processor.thread_created_receiver();
             let session = Arc::new(ConnectionSessionState::default());

--- a/codex-rs/app-server/src/lib.rs
+++ b/codex-rs/app-server/src/lib.rs
@@ -517,13 +517,12 @@ pub async fn run_main_with_transport(
     let log_db_layer = log_db
         .clone()
         .map(|layer| layer.with_filter(Targets::new().with_default(Level::TRACE)));
-    let otel_tracing_layer = otel.as_ref().and_then(|provider| provider.tracing_layer());
-    let (otel_layer, otel_reloader) =
+    let (otel_layer, otel_trace_layer, otel_reloader) =
         otel_reload::OtelReloader::new(&config, otel, default_analytics_enabled);
     let _ = tracing_subscriber::registry()
         .with(stderr_fmt)
         .with(otel_layer)
-        .with(otel_tracing_layer)
+        .with(otel_trace_layer)
         .with(feedback_layer)
         .with(feedback_metadata_layer)
         .with(log_db_layer)

--- a/codex-rs/app-server/src/lib.rs
+++ b/codex-rs/app-server/src/lib.rs
@@ -80,6 +80,7 @@ mod fuzzy_file_search;
 pub mod in_process;
 mod message_processor;
 mod models;
+mod otel_reload;
 mod outgoing_message;
 mod server_request_error;
 mod thread_state;
@@ -516,15 +517,16 @@ pub async fn run_main_with_transport(
     let log_db_layer = log_db
         .clone()
         .map(|layer| layer.with_filter(Targets::new().with_default(Level::TRACE)));
-    let otel_logger_layer = otel.as_ref().and_then(|o| o.logger_layer());
-    let otel_tracing_layer = otel.as_ref().and_then(|o| o.tracing_layer());
+    let otel_tracing_layer = otel.as_ref().and_then(|provider| provider.tracing_layer());
+    let (otel_layer, otel_reloader) =
+        otel_reload::OtelReloader::new(&config, otel, default_analytics_enabled);
     let _ = tracing_subscriber::registry()
         .with(stderr_fmt)
+        .with(otel_layer)
+        .with(otel_tracing_layer)
         .with(feedback_layer)
         .with(feedback_metadata_layer)
         .with(log_db_layer)
-        .with(otel_logger_layer)
-        .with(otel_tracing_layer)
         .try_init();
     for warning in &config_warnings {
         match &warning.details {
@@ -666,6 +668,7 @@ pub async fn run_main_with_transport(
             auth_manager,
             rpc_transport: analytics_rpc_transport(transport),
             remote_control_handle: Some(remote_control_handle),
+            otel_reloader: Some(otel_reloader.clone()),
         }));
         let mut thread_created_rx = processor.thread_created_receiver();
         let mut running_turn_count_rx = processor.subscribe_running_assistant_turn_count();
@@ -887,9 +890,7 @@ pub async fn run_main_with_transport(
         let _ = handle.await;
     }
 
-    if let Some(otel) = otel {
-        otel.shutdown();
-    }
+    otel_reloader.shutdown();
 
     Ok(())
 }

--- a/codex-rs/app-server/src/message_processor.rs
+++ b/codex-rs/app-server/src/message_processor.rs
@@ -14,6 +14,7 @@ use crate::error_code::INVALID_REQUEST_ERROR_CODE;
 use crate::external_agent_config_api::ExternalAgentConfigApi;
 use crate::fs_api::FsApi;
 use crate::fs_watch::FsWatchManager;
+use crate::otel_reload::OtelReloader;
 use crate::outgoing_message::ConnectionId;
 use crate::outgoing_message::ConnectionRequestId;
 use crate::outgoing_message::OutgoingMessageSender;
@@ -242,6 +243,7 @@ pub(crate) struct MessageProcessorArgs {
     pub(crate) auth_manager: Arc<AuthManager>,
     pub(crate) rpc_transport: AppServerRpcTransport,
     pub(crate) remote_control_handle: Option<RemoteControlHandle>,
+    pub(crate) otel_reloader: Option<OtelReloader>,
 }
 
 impl MessageProcessor {
@@ -263,6 +265,7 @@ impl MessageProcessor {
             auth_manager,
             rpc_transport,
             remote_control_handle,
+            otel_reloader,
         } = args;
         auth_manager.set_external_auth(Arc::new(ExternalAuthRefreshBridge {
             outgoing: outgoing.clone(),
@@ -303,6 +306,7 @@ impl MessageProcessor {
             cloud_requirements: cloud_requirements.clone(),
             feedback,
             log_db,
+            otel_reloader,
         });
         // Keep plugin startup warmups aligned at app-server startup.
         // TODO(xl): Move into PluginManager once this no longer depends on config feature gating.

--- a/codex-rs/app-server/src/message_processor/tracing_tests.rs
+++ b/codex-rs/app-server/src/message_processor/tracing_tests.rs
@@ -252,6 +252,7 @@ fn build_test_processor(
         auth_manager,
         rpc_transport: AppServerRpcTransport::Stdio,
         remote_control_handle: None,
+        otel_reloader: None,
     }));
     (processor, outgoing_rx)
 }

--- a/codex-rs/app-server/src/otel_reload.rs
+++ b/codex-rs/app-server/src/otel_reload.rs
@@ -1,0 +1,182 @@
+//! App-server OpenTelemetry reloading for configuration resolved after startup.
+//!
+//! The app server installs its tracing subscriber once, but `thread/start` can
+//! later load project-scoped config from the requested cwd. This module keeps
+//! the installed log layer stable while swapping the underlying OTel provider
+//! when that effective thread config changes.
+
+use codex_config::types::OtelConfig;
+use codex_core::config::Config;
+use codex_otel::OtelLoggerLayer;
+use codex_otel::OtelProvider;
+use std::error::Error;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+#[derive(Clone, Debug, PartialEq)]
+struct OtelProviderKey {
+    otel: OtelConfig,
+    analytics_enabled: Option<bool>,
+    default_analytics_enabled: bool,
+}
+
+struct OtelReloadState {
+    key: Option<OtelProviderKey>,
+    provider: Option<OtelProvider>,
+}
+
+#[derive(Clone)]
+pub(crate) struct OtelReloader {
+    logger_layer: OtelLoggerLayer,
+    state: Arc<Mutex<OtelReloadState>>,
+    default_analytics_enabled: bool,
+}
+
+impl OtelReloader {
+    pub(crate) fn new(
+        initial_config: &Config,
+        provider: Option<OtelProvider>,
+        default_analytics_enabled: bool,
+    ) -> (OtelLoggerLayer, OtelReloader) {
+        let logger_layer = OtelLoggerLayer::from_provider(provider.as_ref());
+        (
+            logger_layer.clone(),
+            OtelReloader {
+                logger_layer,
+                state: Arc::new(Mutex::new(OtelReloadState {
+                    key: Some(provider_key(initial_config, default_analytics_enabled)),
+                    provider,
+                })),
+                default_analytics_enabled,
+            },
+        )
+    }
+
+    pub(crate) fn reload_from_config(&self, config: &Config) -> Result<(), Box<dyn Error>> {
+        let next_key = provider_key(config, self.default_analytics_enabled);
+        {
+            let state = self
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if state.key.as_ref() == Some(&next_key) {
+                return Ok(());
+            }
+        }
+
+        let next_provider = codex_core::otel_init::build_provider(
+            config,
+            env!("CARGO_PKG_VERSION"),
+            Some("codex-app-server"),
+            self.default_analytics_enabled,
+        )?;
+        self.logger_layer.replace_provider(next_provider.as_ref());
+
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.key = Some(next_key);
+        state.provider = next_provider;
+        Ok(())
+    }
+
+    pub(crate) fn shutdown(&self) {
+        self.logger_layer.replace_provider(None);
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.provider.take();
+    }
+}
+
+fn provider_key(config: &Config, default_analytics_enabled: bool) -> OtelProviderKey {
+    OtelProviderKey {
+        otel: config.otel.clone(),
+        analytics_enabled: config.analytics_enabled,
+        default_analytics_enabled,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codex_config::types::OtelExporterKind;
+    use codex_config::types::OtelHttpProtocol;
+    use codex_core::config::ConfigBuilder;
+    use std::collections::HashMap;
+    use std::time::Duration;
+    use tempfile::TempDir;
+    use tokio::time::timeout;
+    use tracing_subscriber::prelude::*;
+    use wiremock::Mock;
+    use wiremock::MockServer;
+    use wiremock::ResponseTemplate;
+    use wiremock::matchers::method;
+    use wiremock::matchers::path;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn reload_from_config_updates_log_exporter() -> Result<(), Box<dyn Error>> {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/logs"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        let codex_home = TempDir::new()?;
+        let initial_config = ConfigBuilder::default()
+            .codex_home(codex_home.path().to_path_buf())
+            .build()
+            .await?;
+        let (layer, reloader) = OtelReloader::new(&initial_config, /*provider*/ None, false);
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let mut project_config = initial_config.clone();
+        project_config.otel.exporter = OtelExporterKind::OtlpHttp {
+            endpoint: format!("{}/v1/logs", server.uri()),
+            headers: HashMap::new(),
+            protocol: OtelHttpProtocol::Json,
+            tls: None,
+        };
+
+        reloader.reload_from_config(&project_config)?;
+        tracing::event!(
+            target: "codex_otel.log_only",
+            tracing::Level::INFO,
+            event.name = "codex.reload_test",
+        );
+        reloader.shutdown();
+
+        let body = wait_for_otel_logs_payload(&server).await?;
+        let body = String::from_utf8(body)?;
+        assert!(
+            body.contains("codex.reload_test"),
+            "expected reloaded OTEL logs to include test event; body prefix: {}",
+            body.chars().take(2000).collect::<String>()
+        );
+        Ok(())
+    }
+
+    async fn wait_for_otel_logs_payload(server: &MockServer) -> Result<Vec<u8>, Box<dyn Error>> {
+        let body = timeout(Duration::from_secs(10), async {
+            loop {
+                let Some(requests) = server.received_requests().await else {
+                    tokio::time::sleep(Duration::from_millis(25)).await;
+                    continue;
+                };
+                if let Some(request) = requests
+                    .iter()
+                    .find(|request| request.method == "POST" && request.url.path() == "/v1/logs")
+                {
+                    return Ok::<Vec<u8>, Box<dyn Error>>(request.body.clone());
+                }
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        })
+        .await??;
+        Ok(body)
+    }
+}

--- a/codex-rs/app-server/src/otel_reload.rs
+++ b/codex-rs/app-server/src/otel_reload.rs
@@ -1,17 +1,21 @@
 //! App-server OpenTelemetry reloading for configuration resolved after startup.
 //!
-//! The app server installs its tracing subscriber once, but `thread/start` can
-//! later load project-scoped config from the requested cwd. This module keeps
-//! the installed log layer stable while swapping the underlying OTel provider
-//! when that effective thread config changes.
+//! The app server installs its tracing subscriber once, before `thread/start`
+//! can load project-scoped config from the requested cwd. This module keeps the
+//! installed OTel layers stable while initializing their provider from the first
+//! effective thread config.
 
 use codex_config::types::OtelConfig;
 use codex_core::config::Config;
 use codex_otel::OtelLoggerLayer;
 use codex_otel::OtelProvider;
+use codex_otel::OtelTraceLayer;
+use codex_otel::OtelTraceLayerHandle;
 use std::error::Error;
 use std::sync::Arc;
 use std::sync::Mutex;
+use tracing::Subscriber;
+use tracing_subscriber::registry::LookupSpan;
 
 #[derive(Clone, Debug, PartialEq)]
 struct OtelProviderKey {
@@ -23,45 +27,68 @@ struct OtelProviderKey {
 struct OtelReloadState {
     key: Option<OtelProviderKey>,
     provider: Option<OtelProvider>,
+    retired_providers: Vec<OtelProvider>,
+    initialized_from_thread_config: bool,
 }
 
 #[derive(Clone)]
 pub(crate) struct OtelReloader {
     logger_layer: OtelLoggerLayer,
+    trace_layer: OtelTraceLayerHandle,
     state: Arc<Mutex<OtelReloadState>>,
     default_analytics_enabled: bool,
 }
 
 impl OtelReloader {
-    pub(crate) fn new(
+    pub(crate) fn new<S>(
         initial_config: &Config,
         provider: Option<OtelProvider>,
         default_analytics_enabled: bool,
-    ) -> (OtelLoggerLayer, OtelReloader) {
+    ) -> (OtelLoggerLayer, OtelTraceLayer<S>, OtelReloader)
+    where
+        S: Subscriber + for<'span> LookupSpan<'span> + Send + Sync + 'static,
+    {
         let logger_layer = OtelLoggerLayer::from_provider(provider.as_ref());
+        let (trace_layer, trace_layer_handle) = OtelTraceLayer::from_provider(provider.as_ref());
         (
             logger_layer.clone(),
+            trace_layer,
             OtelReloader {
                 logger_layer,
+                trace_layer: trace_layer_handle,
                 state: Arc::new(Mutex::new(OtelReloadState {
                     key: Some(provider_key(initial_config, default_analytics_enabled)),
                     provider,
+                    retired_providers: Vec::new(),
+                    initialized_from_thread_config: false,
                 })),
                 default_analytics_enabled,
             },
         )
     }
 
-    pub(crate) fn reload_from_config(&self, config: &Config) -> Result<(), Box<dyn Error>> {
+    pub(crate) fn reload_from_config(
+        &self,
+        config: &Config,
+    ) -> Result<OtelReloadCommit, Box<dyn Error>> {
         let next_key = provider_key(config, self.default_analytics_enabled);
-        {
-            let state = self
-                .state
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            if state.key.as_ref() == Some(&next_key) {
-                return Ok(());
-            }
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if state.key.as_ref() == Some(&next_key) {
+            return Ok(OtelReloadCommit::new(
+                Arc::clone(&self.state),
+                next_key,
+                state.key.clone(),
+                /*old_provider*/ None,
+                self.logger_layer.clone(),
+                self.trace_layer.clone(),
+                /*applied_reload*/ false,
+            ));
+        }
+        if state.initialized_from_thread_config {
+            return Err("app-server OTel config is already initialized from a different effective thread config; restart the app server to use a different project OTel config".into());
         }
 
         let next_provider = codex_core::otel_init::build_provider(
@@ -71,23 +98,104 @@ impl OtelReloader {
             self.default_analytics_enabled,
         )?;
         self.logger_layer.replace_provider(next_provider.as_ref());
-
-        let mut state = self
-            .state
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        state.key = Some(next_key);
-        state.provider = next_provider;
-        Ok(())
+        self.trace_layer.replace_provider(next_provider.as_ref());
+        let previous_key = state.key.clone();
+        state.key = Some(next_key.clone());
+        let old_provider = std::mem::replace(&mut state.provider, next_provider);
+        Ok(OtelReloadCommit::new(
+            Arc::clone(&self.state),
+            next_key,
+            previous_key,
+            old_provider,
+            self.logger_layer.clone(),
+            self.trace_layer.clone(),
+            /*applied_reload*/ true,
+        ))
     }
 
     pub(crate) fn shutdown(&self) {
         self.logger_layer.replace_provider(/*provider*/ None);
+        self.trace_layer.shutdown();
         let mut state = self
             .state
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         state.provider.take();
+        state.retired_providers.clear();
+    }
+}
+
+pub(crate) struct OtelReloadCommit {
+    state: Arc<Mutex<OtelReloadState>>,
+    key: OtelProviderKey,
+    previous_key: Option<OtelProviderKey>,
+    old_provider: Option<OtelProvider>,
+    logger_layer: OtelLoggerLayer,
+    trace_layer: OtelTraceLayerHandle,
+    applied_reload: bool,
+    committed: bool,
+}
+
+impl OtelReloadCommit {
+    fn new(
+        state: Arc<Mutex<OtelReloadState>>,
+        key: OtelProviderKey,
+        previous_key: Option<OtelProviderKey>,
+        old_provider: Option<OtelProvider>,
+        logger_layer: OtelLoggerLayer,
+        trace_layer: OtelTraceLayerHandle,
+        applied_reload: bool,
+    ) -> Self {
+        Self {
+            state,
+            key,
+            previous_key,
+            old_provider,
+            logger_layer,
+            trace_layer,
+            applied_reload,
+            committed: false,
+        }
+    }
+
+    pub(crate) fn commit(mut self) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if state.key.as_ref() == Some(&self.key) {
+            if let Some(old_provider) = self.old_provider.take() {
+                state.retired_providers.push(old_provider);
+            }
+            state.initialized_from_thread_config = true;
+            self.committed = true;
+        }
+    }
+}
+
+impl Drop for OtelReloadCommit {
+    fn drop(&mut self) {
+        if self.committed {
+            return;
+        }
+
+        if !self.applied_reload {
+            return;
+        }
+
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if !state.initialized_from_thread_config && state.key.as_ref() == Some(&self.key) {
+            let _abandoned_provider =
+                std::mem::replace(&mut state.provider, self.old_provider.take());
+            state.key = self.previous_key.clone();
+            self.logger_layer.replace_provider(state.provider.as_ref());
+            self.trace_layer.replace_provider(state.provider.as_ref());
+        } else if let Some(old_provider) = self.old_provider.take() {
+            state.retired_providers.push(old_provider);
+        }
     }
 }
 
@@ -130,12 +238,14 @@ mod tests {
             .codex_home(codex_home.path().to_path_buf())
             .build()
             .await?;
-        let (layer, reloader) = OtelReloader::new(
+        let (logger_layer, trace_layer, reloader) = OtelReloader::new(
             &initial_config,
             /*provider*/ None,
             /*default_analytics_enabled*/ false,
         );
-        let subscriber = tracing_subscriber::registry().with(layer);
+        let subscriber = tracing_subscriber::registry()
+            .with(logger_layer)
+            .with(trace_layer);
         let _guard = tracing::subscriber::set_default(subscriber);
 
         let mut project_config = initial_config.clone();
@@ -146,7 +256,7 @@ mod tests {
             tls: None,
         };
 
-        reloader.reload_from_config(&project_config)?;
+        reloader.reload_from_config(&project_config)?.commit();
         tracing::event!(
             target: "codex_otel.log_only",
             tracing::Level::INFO,
@@ -161,6 +271,113 @@ mod tests {
             "expected reloaded OTEL logs to include test event; body prefix: {}",
             body.chars().take(2000).collect::<String>()
         );
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn reload_from_config_rejects_different_second_config() -> Result<(), Box<dyn Error>> {
+        let server = MockServer::start().await;
+        let codex_home = TempDir::new()?;
+        let initial_config = ConfigBuilder::default()
+            .codex_home(codex_home.path().to_path_buf())
+            .build()
+            .await?;
+        let (_logger_layer, _trace_layer, reloader): (
+            _,
+            OtelTraceLayer<tracing_subscriber::Registry>,
+            _,
+        ) = OtelReloader::new(
+            &initial_config,
+            /*provider*/ None,
+            /*default_analytics_enabled*/ false,
+        );
+
+        let mut first_config = initial_config.clone();
+        first_config.otel.exporter = OtelExporterKind::OtlpHttp {
+            endpoint: format!("{}/v1/logs", server.uri()),
+            headers: HashMap::new(),
+            protocol: OtelHttpProtocol::Json,
+            tls: None,
+        };
+        reloader.reload_from_config(&first_config)?.commit();
+
+        let mut second_config = initial_config;
+        second_config.otel.exporter = OtelExporterKind::OtlpHttp {
+            endpoint: format!("{}/other/logs", server.uri()),
+            headers: HashMap::new(),
+            protocol: OtelHttpProtocol::Json,
+            tls: None,
+        };
+        let err = match reloader.reload_from_config(&second_config) {
+            Ok(_) => panic!("different effective OTel config should be rejected"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string()
+                .contains("already initialized from a different effective thread config"),
+            "unexpected error: {err}"
+        );
+
+        reloader.shutdown();
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn reload_from_config_does_not_pin_until_committed() -> Result<(), Box<dyn Error>> {
+        let server = MockServer::start().await;
+        let codex_home = TempDir::new()?;
+        let initial_config = ConfigBuilder::default()
+            .codex_home(codex_home.path().to_path_buf())
+            .build()
+            .await?;
+        let (_logger_layer, _trace_layer, reloader): (
+            _,
+            OtelTraceLayer<tracing_subscriber::Registry>,
+            _,
+        ) = OtelReloader::new(
+            &initial_config,
+            /*provider*/ None,
+            /*default_analytics_enabled*/ false,
+        );
+
+        let mut first_config = initial_config.clone();
+        first_config.otel.exporter = OtelExporterKind::OtlpHttp {
+            endpoint: format!("{}/v1/logs", server.uri()),
+            headers: HashMap::new(),
+            protocol: OtelHttpProtocol::Json,
+            tls: None,
+        };
+        let first_reload = reloader.reload_from_config(&first_config)?;
+        drop(first_reload);
+        {
+            let state = reloader
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            assert!(state.provider.is_none());
+            assert!(state.retired_providers.is_empty());
+        }
+
+        let mut second_config = initial_config;
+        second_config.otel.exporter = OtelExporterKind::OtlpHttp {
+            endpoint: format!("{}/other/logs", server.uri()),
+            headers: HashMap::new(),
+            protocol: OtelHttpProtocol::Json,
+            tls: None,
+        };
+        reloader.reload_from_config(&second_config)?.commit();
+
+        let err = match reloader.reload_from_config(&first_config) {
+            Ok(_) => panic!("different effective OTel config should be rejected after commit"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string()
+                .contains("already initialized from a different effective thread config"),
+            "unexpected error: {err}"
+        );
+
+        reloader.shutdown();
         Ok(())
     }
 

--- a/codex-rs/app-server/src/otel_reload.rs
+++ b/codex-rs/app-server/src/otel_reload.rs
@@ -82,7 +82,7 @@ impl OtelReloader {
     }
 
     pub(crate) fn shutdown(&self) {
-        self.logger_layer.replace_provider(None);
+        self.logger_layer.replace_provider(/*provider*/ None);
         let mut state = self
             .state
             .lock()
@@ -130,7 +130,11 @@ mod tests {
             .codex_home(codex_home.path().to_path_buf())
             .build()
             .await?;
-        let (layer, reloader) = OtelReloader::new(&initial_config, /*provider*/ None, false);
+        let (layer, reloader) = OtelReloader::new(
+            &initial_config,
+            /*provider*/ None,
+            /*default_analytics_enabled*/ false,
+        );
         let subscriber = tracing_subscriber::registry().with(layer);
         let _guard = tracing::subscriber::set_default(subscriber);
 

--- a/codex-rs/app-server/src/otel_reload.rs
+++ b/codex-rs/app-server/src/otel_reload.rs
@@ -78,6 +78,12 @@ impl OtelReloader {
             .state
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if state.pending_reload {
+            return Err(
+                "app-server OTel config reload is already pending for an effective thread config"
+                    .into(),
+            );
+        }
         if state.key.as_ref() == Some(&next_key) {
             return Ok(OtelReloadCommit::new(
                 Arc::clone(&self.state),
@@ -91,9 +97,6 @@ impl OtelReloader {
         }
         if state.initialized_from_thread_config {
             return Err("app-server OTel config is already initialized from a different effective thread config; restart the app server to use a different project OTel config".into());
-        }
-        if state.pending_reload {
-            return Err("app-server OTel config reload is already pending for a different effective thread config".into());
         }
 
         let next_provider = codex_core::otel_init::build_provider(
@@ -439,6 +442,48 @@ mod tests {
 
         drop(first_reload);
         reloader.reload_from_config(&second_config)?.commit();
+        reloader.shutdown();
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn reload_from_config_rejects_same_config_while_pending() -> Result<(), Box<dyn Error>> {
+        let server = MockServer::start().await;
+        let codex_home = TempDir::new()?;
+        let initial_config = ConfigBuilder::default()
+            .codex_home(codex_home.path().to_path_buf())
+            .build()
+            .await?;
+        let (_logger_layer, _trace_layer, reloader): (
+            _,
+            OtelTraceLayer<tracing_subscriber::Registry>,
+            _,
+        ) = OtelReloader::new(
+            &initial_config,
+            /*provider*/ None,
+            /*default_analytics_enabled*/ false,
+        );
+
+        let mut project_config = initial_config;
+        project_config.otel.exporter = OtelExporterKind::OtlpHttp {
+            endpoint: format!("{}/v1/logs", server.uri()),
+            headers: HashMap::new(),
+            protocol: OtelHttpProtocol::Json,
+            tls: None,
+        };
+        let first_reload = reloader.reload_from_config(&project_config)?;
+
+        let err = match reloader.reload_from_config(&project_config) {
+            Ok(_) => panic!("same effective OTel config should be rejected while pending"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string().contains("reload is already pending"),
+            "unexpected error: {err}"
+        );
+
+        drop(first_reload);
+        reloader.reload_from_config(&project_config)?.commit();
         reloader.shutdown();
         Ok(())
     }

--- a/codex-rs/app-server/src/otel_reload.rs
+++ b/codex-rs/app-server/src/otel_reload.rs
@@ -29,6 +29,7 @@ struct OtelReloadState {
     provider: Option<OtelProvider>,
     retired_providers: Vec<OtelProvider>,
     initialized_from_thread_config: bool,
+    pending_reload: bool,
 }
 
 #[derive(Clone)]
@@ -61,6 +62,7 @@ impl OtelReloader {
                     provider,
                     retired_providers: Vec::new(),
                     initialized_from_thread_config: false,
+                    pending_reload: false,
                 })),
                 default_analytics_enabled,
             },
@@ -90,6 +92,9 @@ impl OtelReloader {
         if state.initialized_from_thread_config {
             return Err("app-server OTel config is already initialized from a different effective thread config; restart the app server to use a different project OTel config".into());
         }
+        if state.pending_reload {
+            return Err("app-server OTel config reload is already pending for a different effective thread config".into());
+        }
 
         let next_provider = codex_core::otel_init::build_provider(
             config,
@@ -102,6 +107,7 @@ impl OtelReloader {
         let previous_key = state.key.clone();
         state.key = Some(next_key.clone());
         let old_provider = std::mem::replace(&mut state.provider, next_provider);
+        state.pending_reload = true;
         Ok(OtelReloadCommit::new(
             Arc::clone(&self.state),
             next_key,
@@ -123,6 +129,7 @@ impl OtelReloader {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         state.provider.take();
         state.retired_providers.clear();
+        state.pending_reload = false;
     }
 }
 
@@ -169,6 +176,7 @@ impl OtelReloadCommit {
                 state.retired_providers.push(old_provider);
             }
             state.initialized_from_thread_config = true;
+            state.pending_reload = false;
             self.committed = true;
         }
     }
@@ -193,10 +201,12 @@ impl Drop for OtelReloadCommit {
                 std::mem::replace(&mut state.provider, self.old_provider.take());
             state.key = self.previous_key.clone();
             self.logger_layer.replace_provider(state.provider.as_ref());
-            self.trace_layer.replace_provider(state.provider.as_ref());
+            self.trace_layer.restore_provider(state.provider.as_ref());
             OtelProvider::replace_global_metrics(state.provider.as_ref());
+            state.pending_reload = false;
         } else if let Some(old_provider) = self.old_provider.take() {
             state.retired_providers.push(old_provider);
+            state.pending_reload = false;
         }
     }
 }
@@ -379,6 +389,56 @@ mod tests {
             "unexpected error: {err}"
         );
 
+        reloader.shutdown();
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn reload_from_config_rejects_different_config_while_pending()
+    -> Result<(), Box<dyn Error>> {
+        let server = MockServer::start().await;
+        let codex_home = TempDir::new()?;
+        let initial_config = ConfigBuilder::default()
+            .codex_home(codex_home.path().to_path_buf())
+            .build()
+            .await?;
+        let (_logger_layer, _trace_layer, reloader): (
+            _,
+            OtelTraceLayer<tracing_subscriber::Registry>,
+            _,
+        ) = OtelReloader::new(
+            &initial_config,
+            /*provider*/ None,
+            /*default_analytics_enabled*/ false,
+        );
+
+        let mut first_config = initial_config.clone();
+        first_config.otel.exporter = OtelExporterKind::OtlpHttp {
+            endpoint: format!("{}/v1/logs", server.uri()),
+            headers: HashMap::new(),
+            protocol: OtelHttpProtocol::Json,
+            tls: None,
+        };
+        let first_reload = reloader.reload_from_config(&first_config)?;
+
+        let mut second_config = initial_config;
+        second_config.otel.exporter = OtelExporterKind::OtlpHttp {
+            endpoint: format!("{}/other/logs", server.uri()),
+            headers: HashMap::new(),
+            protocol: OtelHttpProtocol::Json,
+            tls: None,
+        };
+        let err = match reloader.reload_from_config(&second_config) {
+            Ok(_) => panic!("different effective OTel config should be rejected while pending"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string().contains("reload is already pending"),
+            "unexpected error: {err}"
+        );
+
+        drop(first_reload);
+        reloader.reload_from_config(&second_config)?.commit();
         reloader.shutdown();
         Ok(())
     }

--- a/codex-rs/app-server/src/otel_reload.rs
+++ b/codex-rs/app-server/src/otel_reload.rs
@@ -116,6 +116,7 @@ impl OtelReloader {
     pub(crate) fn shutdown(&self) {
         self.logger_layer.replace_provider(/*provider*/ None);
         self.trace_layer.shutdown();
+        OtelProvider::replace_global_metrics(/*provider*/ None);
         let mut state = self
             .state
             .lock()
@@ -193,6 +194,7 @@ impl Drop for OtelReloadCommit {
             state.key = self.previous_key.clone();
             self.logger_layer.replace_provider(state.provider.as_ref());
             self.trace_layer.replace_provider(state.provider.as_ref());
+            OtelProvider::replace_global_metrics(state.provider.as_ref());
         } else if let Some(old_provider) = self.old_provider.take() {
             state.retired_providers.push(old_provider);
         }

--- a/codex-rs/otel/src/lib.rs
+++ b/codex-rs/otel/src/lib.rs
@@ -1,5 +1,6 @@
 pub(crate) mod config;
 mod events;
+mod logger_layer;
 pub(crate) mod metrics;
 pub(crate) mod provider;
 pub(crate) mod trace_context;
@@ -18,6 +19,7 @@ pub use crate::config::OtelTlsConfig;
 pub use crate::events::session_telemetry::AuthEnvTelemetryMetadata;
 pub use crate::events::session_telemetry::SessionTelemetry;
 pub use crate::events::session_telemetry::SessionTelemetryMetadata;
+pub use crate::logger_layer::OtelLoggerLayer;
 pub use crate::metrics::runtime_metrics::RuntimeMetricTotals;
 pub use crate::metrics::runtime_metrics::RuntimeMetricsSummary;
 pub use crate::metrics::timer::Timer;

--- a/codex-rs/otel/src/lib.rs
+++ b/codex-rs/otel/src/lib.rs
@@ -4,6 +4,7 @@ mod logger_layer;
 pub(crate) mod metrics;
 pub(crate) mod provider;
 pub(crate) mod trace_context;
+mod trace_layer;
 
 mod otlp;
 mod targets;
@@ -32,6 +33,8 @@ pub use crate::trace_context::set_parent_from_context;
 pub use crate::trace_context::set_parent_from_w3c_trace_context;
 pub use crate::trace_context::span_w3c_trace_context;
 pub use crate::trace_context::traceparent_context_from_env;
+pub use crate::trace_layer::OtelTraceLayer;
+pub use crate::trace_layer::OtelTraceLayerHandle;
 pub use codex_utils_string::sanitize_metric_tag_value;
 
 #[derive(Debug, Clone, Serialize, Display)]

--- a/codex-rs/otel/src/logger_layer.rs
+++ b/codex-rs/otel/src/logger_layer.rs
@@ -10,7 +10,6 @@ use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
 use opentelemetry_sdk::logs::SdkLoggerProvider;
 use std::sync::Arc;
 use std::sync::RwLock;
-use tracing::subscriber::Interest;
 use tracing_subscriber::Layer;
 use tracing_subscriber::layer::Context;
 use tracing_subscriber::registry::LookupSpan;
@@ -45,25 +44,6 @@ impl<S> Layer<S> for OtelLoggerLayer
 where
     S: tracing::Subscriber + for<'span> LookupSpan<'span>,
 {
-    fn register_callsite(&self, metadata: &'static tracing::Metadata<'static>) -> Interest {
-        if OtelProvider::log_export_filter(metadata) {
-            Interest::sometimes()
-        } else {
-            Interest::never()
-        }
-    }
-
-    fn enabled(&self, metadata: &tracing::Metadata<'_>, _ctx: Context<'_, S>) -> bool {
-        if !OtelProvider::log_export_filter(metadata) {
-            return false;
-        }
-
-        self.bridge
-            .read()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .is_some()
-    }
-
     fn on_event(&self, event: &tracing::Event<'_>, ctx: Context<'_, S>) {
         if !OtelProvider::log_export_filter(event.metadata()) {
             return;
@@ -83,4 +63,49 @@ fn logger_bridge(provider: Option<&OtelProvider>) -> Option<LoggerBridge> {
     provider
         .and_then(|provider| provider.logger.as_ref())
         .map(OpenTelemetryTracingBridge::new)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+    use tracing::Subscriber;
+    use tracing_subscriber::prelude::*;
+
+    #[derive(Clone, Default)]
+    struct CountingLayer {
+        events: Arc<Mutex<usize>>,
+    }
+
+    impl<S> Layer<S> for CountingLayer
+    where
+        S: Subscriber,
+    {
+        fn on_event(&self, _event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+            let mut events = self
+                .events
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            *events += 1;
+        }
+    }
+
+    #[test]
+    fn non_otel_events_continue_to_reach_other_layers() {
+        let counting_layer = CountingLayer::default();
+        let events = Arc::clone(&counting_layer.events);
+        let subscriber = tracing_subscriber::registry()
+            .with(counting_layer)
+            .with(OtelLoggerLayer::default());
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        tracing::info!(target: "codex_core::unrelated", "visible to other layers");
+
+        assert_eq!(
+            *events
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+            1
+        );
+    }
 }

--- a/codex-rs/otel/src/logger_layer.rs
+++ b/codex-rs/otel/src/logger_layer.rs
@@ -1,0 +1,86 @@
+//! Reloadable OpenTelemetry log layer.
+//!
+//! This layer stays registered with `tracing-subscriber` while allowing callers
+//! to replace the OTel logger provider behind it. It is used by long-lived
+//! processes that discover their effective telemetry config after subscriber
+//! initialization.
+
+use crate::OtelProvider;
+use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
+use opentelemetry_sdk::logs::SdkLoggerProvider;
+use std::sync::Arc;
+use std::sync::RwLock;
+use tracing::subscriber::Interest;
+use tracing_subscriber::Layer;
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::registry::LookupSpan;
+
+type LoggerBridge = OpenTelemetryTracingBridge<
+    SdkLoggerProvider,
+    <SdkLoggerProvider as opentelemetry::logs::LoggerProvider>::Logger,
+>;
+
+#[derive(Clone, Default)]
+pub struct OtelLoggerLayer {
+    bridge: Arc<RwLock<Option<LoggerBridge>>>,
+}
+
+impl OtelLoggerLayer {
+    pub fn from_provider(provider: Option<&OtelProvider>) -> Self {
+        Self {
+            bridge: Arc::new(RwLock::new(logger_bridge(provider))),
+        }
+    }
+
+    pub fn replace_provider(&self, provider: Option<&OtelProvider>) {
+        let mut bridge = self
+            .bridge
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *bridge = logger_bridge(provider);
+    }
+}
+
+impl<S> Layer<S> for OtelLoggerLayer
+where
+    S: tracing::Subscriber + for<'span> LookupSpan<'span>,
+{
+    fn register_callsite(&self, metadata: &'static tracing::Metadata<'static>) -> Interest {
+        if OtelProvider::log_export_filter(metadata) {
+            Interest::sometimes()
+        } else {
+            Interest::never()
+        }
+    }
+
+    fn enabled(&self, metadata: &tracing::Metadata<'_>, _ctx: Context<'_, S>) -> bool {
+        if !OtelProvider::log_export_filter(metadata) {
+            return false;
+        }
+
+        self.bridge
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .is_some()
+    }
+
+    fn on_event(&self, event: &tracing::Event<'_>, ctx: Context<'_, S>) {
+        if !OtelProvider::log_export_filter(event.metadata()) {
+            return;
+        }
+
+        let bridge = self
+            .bridge
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(bridge) = bridge.as_ref() {
+            bridge.on_event(event, ctx);
+        }
+    }
+}
+
+fn logger_bridge(provider: Option<&OtelProvider>) -> Option<LoggerBridge> {
+    provider
+        .and_then(|provider| provider.logger.as_ref())
+        .map(OpenTelemetryTracingBridge::new)
+}

--- a/codex-rs/otel/src/metrics/mod.rs
+++ b/codex-rs/otel/src/metrics/mod.rs
@@ -14,14 +14,25 @@ pub use crate::metrics::error::MetricsError;
 pub use crate::metrics::error::Result;
 pub use names::*;
 use std::sync::OnceLock;
+use std::sync::RwLock;
 pub use tags::SessionMetricTagValues;
 
-static GLOBAL_METRICS: OnceLock<MetricsClient> = OnceLock::new();
+static GLOBAL_METRICS: OnceLock<RwLock<Option<MetricsClient>>> = OnceLock::new();
 
-pub(crate) fn install_global(metrics: MetricsClient) {
-    let _ = GLOBAL_METRICS.set(metrics);
+fn global_metrics() -> &'static RwLock<Option<MetricsClient>> {
+    GLOBAL_METRICS.get_or_init(|| RwLock::new(None))
+}
+
+pub(crate) fn replace_global(metrics: Option<MetricsClient>) {
+    let mut global = global_metrics()
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    *global = metrics;
 }
 
 pub fn global() -> Option<MetricsClient> {
-    GLOBAL_METRICS.get().cloned()
+    global_metrics()
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone()
 }

--- a/codex-rs/otel/src/provider.rs
+++ b/codex-rs/otel/src/provider.rs
@@ -156,6 +156,10 @@ impl OtelProvider {
     pub fn metrics(&self) -> Option<&MetricsClient> {
         self.metrics.as_ref()
     }
+
+    pub fn replace_global_metrics(provider: Option<&Self>) {
+        crate::metrics::replace_global(provider.and_then(|provider| provider.metrics.clone()));
+    }
 }
 
 impl Drop for OtelProvider {

--- a/codex-rs/otel/src/provider.rs
+++ b/codex-rs/otel/src/provider.rs
@@ -84,9 +84,7 @@ impl OtelProvider {
             Some(MetricsClient::new(config)?)
         };
 
-        if let Some(metrics) = metrics.as_ref() {
-            crate::metrics::install_global(metrics.clone());
-        }
+        crate::metrics::replace_global(metrics.clone());
 
         if !log_enabled && !trace_enabled && metrics.is_none() {
             debug!("No OTEL exporter enabled in settings.");

--- a/codex-rs/otel/src/provider.rs
+++ b/codex-rs/otel/src/provider.rs
@@ -84,9 +84,8 @@ impl OtelProvider {
             Some(MetricsClient::new(config)?)
         };
 
-        crate::metrics::replace_global(metrics.clone());
-
         if !log_enabled && !trace_enabled && metrics.is_none() {
+            crate::metrics::replace_global(/*metrics*/ None);
             debug!("No OTEL exporter enabled in settings.");
             return Ok(None);
         }
@@ -109,6 +108,7 @@ impl OtelProvider {
             global::set_tracer_provider(provider);
             global::set_text_map_propagator(TraceContextPropagator::new());
         }
+        crate::metrics::replace_global(metrics.clone());
         Ok(Some(Self {
             logger,
             tracer_provider,

--- a/codex-rs/otel/src/trace_layer.rs
+++ b/codex-rs/otel/src/trace_layer.rs
@@ -33,6 +33,21 @@ struct OtelTraceLayerState<S> {
     active_spans: HashMap<Id, Arc<TraceLayer<S>>>,
 }
 
+impl<S> OtelTraceLayerState<S> {
+    fn prune_inactive_retired(&mut self) {
+        let active_layers = self
+            .active_spans
+            .values()
+            .cloned()
+            .collect::<Vec<Arc<TraceLayer<S>>>>();
+        self.retired.retain(|retired| {
+            active_layers
+                .iter()
+                .any(|active| Arc::ptr_eq(active, retired))
+        });
+    }
+}
+
 impl<S> Default for OtelTraceLayerState<S> {
     fn default() -> Self {
         Self {
@@ -46,12 +61,17 @@ impl<S> Default for OtelTraceLayerState<S> {
 #[derive(Clone)]
 pub struct OtelTraceLayerHandle {
     replace_provider: Arc<ReplaceProviderFn>,
+    restore_provider: Arc<ReplaceProviderFn>,
     shutdown: Arc<dyn Fn() + Send + Sync>,
 }
 
 impl OtelTraceLayerHandle {
     pub fn replace_provider(&self, provider: Option<&OtelProvider>) {
         (self.replace_provider)(provider);
+    }
+
+    pub fn restore_provider(&self, provider: Option<&OtelProvider>) {
+        (self.restore_provider)(provider);
     }
 
     pub fn shutdown(&self) {
@@ -73,10 +93,14 @@ where
             state: Arc::clone(&state),
         };
         let replace_state = Arc::clone(&state);
+        let restore_state = Arc::clone(&state);
         let shutdown_state = Arc::clone(&state);
         let handle = OtelTraceLayerHandle {
             replace_provider: Arc::new(move |provider| {
                 replace_trace_layer(&replace_state, trace_layer(provider));
+            }),
+            restore_provider: Arc::new(move |provider| {
+                restore_trace_layer(&restore_state, trace_layer(provider));
             }),
             shutdown: Arc::new(move || {
                 let mut state = shutdown_state
@@ -123,10 +147,12 @@ where
             .state
             .write()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        state
+        let layer = state
             .active_spans
             .remove(id)
-            .or_else(|| state.current.clone())
+            .or_else(|| state.current.clone());
+        state.prune_inactive_retired();
+        layer
     }
 }
 
@@ -211,7 +237,11 @@ where
             .state
             .read()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let layer = state.current.as_ref()?;
+        let layer = state
+            .current
+            .clone()
+            .or_else(|| state.active_spans.values().next().cloned())
+            .or_else(|| state.retired.last().cloned())?;
         unsafe { Layer::<S>::downcast_raw(layer.as_ref(), id) }
     }
 }
@@ -227,6 +257,18 @@ fn replace_trace_layer<S>(
         state.retired.push(current);
     }
     state.current = next_layer;
+    state.prune_inactive_retired();
+}
+
+fn restore_trace_layer<S>(
+    state: &RwLock<OtelTraceLayerState<S>>,
+    restored_layer: Option<Arc<TraceLayer<S>>>,
+) {
+    let mut state = state
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    state.current = restored_layer;
+    state.prune_inactive_retired();
 }
 
 fn trace_layer<S>(provider: Option<&OtelProvider>) -> Option<Arc<TraceLayer<S>>>
@@ -357,5 +399,40 @@ mod tests {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         assert_eq!(spans.len(), 1);
         assert_eq!(spans[0].events.len(), 1);
+    }
+
+    #[test]
+    fn downcast_uses_active_span_layer_after_provider_is_disabled() {
+        let (provider, _spans) = provider_with_tracer("first");
+        let (layer, handle) = OtelTraceLayer::from_provider(Some(&provider));
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let span = trace_span!("old_span");
+        let _entered = span.enter();
+        let before_disable = current_span_trace_id().expect("trace id before disable");
+
+        handle.replace_provider(/*provider*/ None);
+        let after_disable = current_span_trace_id().expect("trace id after disable");
+
+        assert_eq!(after_disable, before_disable);
+    }
+
+    #[test]
+    fn restore_provider_reclaims_provisional_layer_without_active_spans() {
+        let (first_provider, _first_spans) = provider_with_tracer("first");
+        let (second_provider, _second_spans) = provider_with_tracer("second");
+        let (layer, handle): (OtelTraceLayer<tracing_subscriber::Registry>, _) =
+            OtelTraceLayer::from_provider(Some(&first_provider));
+
+        handle.replace_provider(Some(&second_provider));
+        handle.restore_provider(Some(&first_provider));
+
+        let state = layer
+            .state
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert!(state.current.is_some());
+        assert!(state.retired.is_empty());
     }
 }

--- a/codex-rs/otel/src/trace_layer.rs
+++ b/codex-rs/otel/src/trace_layer.rs
@@ -1,0 +1,331 @@
+//! Reloadable OpenTelemetry trace layer.
+//!
+//! This layer stays registered with `tracing-subscriber` while allowing callers
+//! to replace the OTel tracer behind it. It is used by long-lived processes that
+//! discover their effective telemetry config after subscriber initialization.
+
+use crate::OtelProvider;
+use opentelemetry_sdk::trace::Tracer;
+use std::any::TypeId;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::RwLock;
+use tracing::Event;
+use tracing::Subscriber;
+use tracing::span::Attributes;
+use tracing::span::Id;
+use tracing::span::Record;
+use tracing_subscriber::Layer;
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::registry::LookupSpan;
+
+type TraceLayer<S> = tracing_opentelemetry::OpenTelemetryLayer<S, Tracer>;
+type ReplaceProviderFn = dyn Fn(Option<&OtelProvider>) + Send + Sync;
+
+#[derive(Clone, Default)]
+pub struct OtelTraceLayer<S> {
+    state: Arc<RwLock<OtelTraceLayerState<S>>>,
+}
+
+struct OtelTraceLayerState<S> {
+    current: Option<Arc<TraceLayer<S>>>,
+    retired: Vec<Arc<TraceLayer<S>>>,
+    active_spans: HashMap<Id, Arc<TraceLayer<S>>>,
+}
+
+impl<S> Default for OtelTraceLayerState<S> {
+    fn default() -> Self {
+        Self {
+            current: None,
+            retired: Vec::new(),
+            active_spans: HashMap::new(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct OtelTraceLayerHandle {
+    replace_provider: Arc<ReplaceProviderFn>,
+    shutdown: Arc<dyn Fn() + Send + Sync>,
+}
+
+impl OtelTraceLayerHandle {
+    pub fn replace_provider(&self, provider: Option<&OtelProvider>) {
+        (self.replace_provider)(provider);
+    }
+
+    pub fn shutdown(&self) {
+        (self.shutdown)();
+    }
+}
+
+impl<S> OtelTraceLayer<S>
+where
+    S: Subscriber + for<'span> LookupSpan<'span> + Send + Sync + 'static,
+{
+    pub fn from_provider(provider: Option<&OtelProvider>) -> (Self, OtelTraceLayerHandle) {
+        let state = Arc::new(RwLock::new(OtelTraceLayerState {
+            current: trace_layer(provider),
+            retired: Vec::new(),
+            active_spans: HashMap::new(),
+        }));
+        let layer = Self {
+            state: Arc::clone(&state),
+        };
+        let replace_state = Arc::clone(&state);
+        let shutdown_state = Arc::clone(&state);
+        let handle = OtelTraceLayerHandle {
+            replace_provider: Arc::new(move |provider| {
+                replace_trace_layer(&replace_state, trace_layer(provider));
+            }),
+            shutdown: Arc::new(move || {
+                let mut state = shutdown_state
+                    .write()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                state.current = None;
+                state.retired.clear();
+                state.active_spans.clear();
+            }),
+        };
+        (layer, handle)
+    }
+
+    fn current_layer(&self) -> Option<Arc<TraceLayer<S>>> {
+        self.state
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .current
+            .clone()
+    }
+
+    fn record_span_layer(&self, id: &Id, layer: Arc<TraceLayer<S>>) {
+        self.state
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .active_spans
+            .insert(id.clone(), layer);
+    }
+
+    fn layer_for_span(&self, id: &Id) -> Option<Arc<TraceLayer<S>>> {
+        let state = self
+            .state
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state
+            .active_spans
+            .get(id)
+            .cloned()
+            .or_else(|| state.current.clone())
+    }
+
+    fn remove_span_layer(&self, id: &Id) -> Option<Arc<TraceLayer<S>>> {
+        let mut state = self
+            .state
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state
+            .active_spans
+            .remove(id)
+            .or_else(|| state.current.clone())
+    }
+}
+
+impl<S> Layer<S> for OtelTraceLayer<S>
+where
+    S: Subscriber + for<'span> LookupSpan<'span> + Send + Sync + 'static,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        if !OtelProvider::trace_export_filter(attrs.metadata()) {
+            return;
+        }
+
+        if let Some(layer) = self.current_layer() {
+            layer.on_new_span(attrs, id, ctx);
+            self.record_span_layer(id, layer);
+        }
+    }
+
+    fn on_record(&self, id: &Id, values: &Record<'_>, ctx: Context<'_, S>) {
+        if let Some(layer) = self.layer_for_span(id) {
+            layer.on_record(id, values, ctx);
+        }
+    }
+
+    fn on_follows_from(&self, id: &Id, follows: &Id, ctx: Context<'_, S>) {
+        if let Some(layer) = self.layer_for_span(id) {
+            layer.on_follows_from(id, follows, ctx);
+        }
+    }
+
+    fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
+        if !OtelProvider::trace_export_filter(event.metadata()) {
+            return;
+        }
+
+        if let Some(layer) = self.current_layer() {
+            layer.on_event(event, ctx);
+        }
+    }
+
+    fn on_enter(&self, id: &Id, ctx: Context<'_, S>) {
+        if let Some(layer) = self.layer_for_span(id) {
+            layer.on_enter(id, ctx);
+        }
+    }
+
+    fn on_exit(&self, id: &Id, ctx: Context<'_, S>) {
+        if let Some(layer) = self.layer_for_span(id) {
+            layer.on_exit(id, ctx);
+        }
+    }
+
+    fn on_close(&self, id: Id, ctx: Context<'_, S>) {
+        if let Some(layer) = self.remove_span_layer(&id) {
+            layer.on_close(id, ctx);
+        }
+    }
+
+    fn on_id_change(&self, old: &Id, new: &Id, ctx: Context<'_, S>) {
+        if let Some(layer) = self.layer_for_span(old) {
+            layer.on_id_change(old, new, ctx);
+            let mut state = self
+                .state
+                .write()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if let Some(layer) = state.active_spans.remove(old) {
+                state.active_spans.insert(new.clone(), layer);
+            }
+        }
+    }
+
+    unsafe fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {
+        let state = self
+            .state
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let layer = state.current.as_ref()?;
+        unsafe { Layer::<S>::downcast_raw(layer.as_ref(), id) }
+    }
+}
+
+fn replace_trace_layer<S>(
+    state: &RwLock<OtelTraceLayerState<S>>,
+    next_layer: Option<Arc<TraceLayer<S>>>,
+) {
+    let mut state = state
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if let Some(current) = state.current.take() {
+        state.retired.push(current);
+    }
+    state.current = next_layer;
+}
+
+fn trace_layer<S>(provider: Option<&OtelProvider>) -> Option<Arc<TraceLayer<S>>>
+where
+    S: Subscriber + for<'span> LookupSpan<'span>,
+{
+    provider
+        .and_then(|provider| provider.tracer.clone())
+        .map(|tracer| Arc::new(tracing_opentelemetry::layer().with_tracer(tracer)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::OtelProvider;
+    use crate::current_span_trace_id;
+    use opentelemetry::trace::TracerProvider as _;
+    use opentelemetry_sdk::error::OTelSdkResult;
+    use opentelemetry_sdk::trace::SdkTracerProvider;
+    use opentelemetry_sdk::trace::SpanData;
+    use opentelemetry_sdk::trace::SpanExporter;
+    use std::sync::Mutex;
+    use tracing::trace_span;
+    use tracing_subscriber::prelude::*;
+
+    #[derive(Clone, Debug, Default)]
+    struct RecordingSpanExporter {
+        spans: Arc<Mutex<Vec<SpanData>>>,
+    }
+
+    impl SpanExporter for RecordingSpanExporter {
+        async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
+            self.spans
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .extend(batch);
+            Ok(())
+        }
+    }
+
+    fn provider_with_tracer(scope: &'static str) -> (OtelProvider, Arc<Mutex<Vec<SpanData>>>) {
+        let exporter = RecordingSpanExporter::default();
+        let spans = Arc::clone(&exporter.spans);
+        let tracer_provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter)
+            .build();
+        let tracer = tracer_provider.tracer(scope);
+        let provider = OtelProvider {
+            logger: None,
+            tracer_provider: Some(tracer_provider),
+            tracer: Some(tracer),
+            metrics: None,
+        };
+        (provider, spans)
+    }
+
+    #[test]
+    fn trace_layer_preserves_span_context_downcasting() {
+        let tracer_provider = SdkTracerProvider::builder().build();
+        let tracer = tracer_provider.tracer("codex-otel-tests");
+        let provider = OtelProvider {
+            logger: None,
+            tracer_provider: Some(tracer_provider),
+            tracer: Some(tracer),
+            metrics: None,
+        };
+        let (layer, _handle) = OtelTraceLayer::from_provider(Some(&provider));
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let span = trace_span!("test_span");
+        let _entered = span.enter();
+        let trace_id = current_span_trace_id().expect("trace id");
+
+        assert_eq!(trace_id.len(), 32);
+        assert!(trace_id.chars().all(|ch| ch.is_ascii_hexdigit()));
+        assert_ne!(trace_id, "00000000000000000000000000000000");
+    }
+
+    #[test]
+    fn span_closes_with_original_layer_after_provider_replacement() {
+        let (first_provider, first_spans) = provider_with_tracer("first");
+        let (second_provider, second_spans) = provider_with_tracer("second");
+        let (layer, handle) = OtelTraceLayer::from_provider(Some(&first_provider));
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let span = trace_span!("old_span");
+        {
+            let _entered = span.enter();
+        }
+        handle.replace_provider(Some(&second_provider));
+        drop(span);
+
+        assert_eq!(
+            first_spans
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .len(),
+            1
+        );
+        assert_eq!(
+            second_spans
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .len(),
+            0
+        );
+    }
+}

--- a/codex-rs/otel/src/trace_layer.rs
+++ b/codex-rs/otel/src/trace_layer.rs
@@ -7,6 +7,7 @@
 use crate::OtelProvider;
 use opentelemetry_sdk::trace::Tracer;
 use std::any::TypeId;
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::RwLock;
@@ -21,6 +22,10 @@ use tracing_subscriber::registry::LookupSpan;
 
 type TraceLayer<S> = tracing_opentelemetry::OpenTelemetryLayer<S, Tracer>;
 type ReplaceProviderFn = dyn Fn(Option<&OtelProvider>) + Send + Sync;
+
+thread_local! {
+    static ENTERED_SPANS: RefCell<Vec<Id>> = const { RefCell::new(Vec::new()) };
+}
 
 #[derive(Clone, Default)]
 pub struct OtelTraceLayer<S> {
@@ -108,7 +113,6 @@ where
                     .unwrap_or_else(std::sync::PoisonError::into_inner);
                 state.current = None;
                 state.retired.clear();
-                state.active_spans.clear();
             }),
         };
         (layer, handle)
@@ -204,16 +208,24 @@ where
     fn on_enter(&self, id: &Id, ctx: Context<'_, S>) {
         if let Some(layer) = self.layer_for_span(id) {
             layer.on_enter(id, ctx);
+            ENTERED_SPANS.with(|spans| spans.borrow_mut().push(id.clone()));
         }
     }
 
     fn on_exit(&self, id: &Id, ctx: Context<'_, S>) {
         if let Some(layer) = self.layer_for_span(id) {
             layer.on_exit(id, ctx);
+            ENTERED_SPANS.with(|spans| {
+                let mut spans = spans.borrow_mut();
+                if let Some(position) = spans.iter().rposition(|entered_id| entered_id == id) {
+                    spans.remove(position);
+                }
+            });
         }
     }
 
     fn on_close(&self, id: Id, ctx: Context<'_, S>) {
+        ENTERED_SPANS.with(|spans| spans.borrow_mut().retain(|entered_id| entered_id != &id));
         if let Some(layer) = self.remove_span_layer(&id) {
             layer.on_close(id, ctx);
         }
@@ -230,6 +242,13 @@ where
                 state.active_spans.insert(new.clone(), layer);
             }
         }
+        ENTERED_SPANS.with(|spans| {
+            for entered_id in spans.borrow_mut().iter_mut() {
+                if entered_id == old {
+                    *entered_id = new.clone();
+                }
+            }
+        });
     }
 
     unsafe fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {
@@ -237,11 +256,34 @@ where
             .state
             .read()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let layer = state
-            .current
-            .clone()
-            .or_else(|| state.active_spans.values().next().cloned())
-            .or_else(|| state.retired.last().cloned())?;
+        let entered_layer = ENTERED_SPANS.with(|spans| {
+            spans
+                .borrow()
+                .iter()
+                .rev()
+                .find_map(|id| state.active_spans.get(id).cloned())
+        });
+        let layer = entered_layer.or_else(|| {
+            let mut active_layers = Vec::new();
+            for layer in state.active_spans.values() {
+                if !active_layers
+                    .iter()
+                    .any(|active| Arc::ptr_eq(active, layer))
+                {
+                    active_layers.push(Arc::clone(layer));
+                }
+            }
+            if active_layers.len() == 1 {
+                active_layers.pop()
+            } else {
+                None
+            }
+        })?;
+
+        // SAFETY: the selected layer is owned by `active_spans`, and tracing
+        // keeps that span alive while `OpenTelemetrySpanExt` performs its
+        // downcast. The entered span stack is maintained by this layer rather
+        // than `Span::current()` so downcasting never re-enters tracing.
         unsafe { Layer::<S>::downcast_raw(layer.as_ref(), id) }
     }
 }
@@ -285,6 +327,7 @@ mod tests {
     use super::*;
     use crate::OtelProvider;
     use crate::current_span_trace_id;
+    use crate::span_w3c_trace_context;
     use opentelemetry::trace::TracerProvider as _;
     use opentelemetry_sdk::error::OTelSdkResult;
     use opentelemetry_sdk::trace::SdkTracerProvider;
@@ -416,6 +459,50 @@ mod tests {
         let after_disable = current_span_trace_id().expect("trace id after disable");
 
         assert_eq!(after_disable, before_disable);
+    }
+
+    #[test]
+    fn downcast_uses_original_layer_after_provider_replacement() {
+        let (first_provider, first_spans) = provider_with_tracer("first");
+        let (second_provider, second_spans) = provider_with_tracer("second");
+        let (layer, handle) = OtelTraceLayer::from_provider(Some(&first_provider));
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let span = trace_span!("old_span");
+        handle.replace_provider(Some(&second_provider));
+        let trace = span_w3c_trace_context(&span).expect("trace context after replacement");
+        drop(span);
+
+        assert!(trace.traceparent.is_some());
+        assert_eq!(
+            first_spans
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .len(),
+            1
+        );
+        assert_eq!(
+            second_spans
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .len(),
+            0
+        );
+    }
+
+    #[test]
+    fn downcast_keeps_active_span_layer_after_shutdown() {
+        let (provider, _spans) = provider_with_tracer("first");
+        let (layer, handle) = OtelTraceLayer::from_provider(Some(&provider));
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let span = trace_span!("old_span");
+        handle.shutdown();
+        let trace = span_w3c_trace_context(&span).expect("trace context after shutdown");
+
+        assert!(trace.traceparent.is_some());
     }
 
     #[test]

--- a/codex-rs/otel/src/trace_layer.rs
+++ b/codex-rs/otel/src/trace_layer.rs
@@ -162,7 +162,15 @@ where
             return;
         }
 
-        if let Some(layer) = self.current_layer() {
+        let span_layer = event
+            .parent()
+            .and_then(|id| self.layer_for_span(id))
+            .or_else(|| {
+                ctx.event_span(event)
+                    .and_then(|span| self.layer_for_span(&span.id()))
+            });
+
+        if let Some(layer) = span_layer.or_else(|| self.current_layer()) {
             layer.on_event(event, ctx);
         }
     }
@@ -327,5 +335,27 @@ mod tests {
                 .len(),
             0
         );
+    }
+
+    #[test]
+    fn span_events_use_original_layer_after_provider_replacement() {
+        let (first_provider, first_spans) = provider_with_tracer("first");
+        let (layer, handle) = OtelTraceLayer::from_provider(Some(&first_provider));
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let span = trace_span!("old_span");
+        {
+            let _entered = span.enter();
+            handle.replace_provider(/*provider*/ None);
+            tracing::info!(target: "codex_otel.trace_safe.test", "old_span_event");
+        }
+        drop(span);
+
+        let spans = first_spans
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].events.len(), 1);
     }
 }


### PR DESCRIPTION
Addresses #17110

## Why

The app server installs its tracing subscriber during process startup, before `thread/start` resolves the effective config for the requested cwd. As a result, project-scoped `[otel]` settings from `.codex/config.toml` could be ignored by the app server even though the thread itself loaded that project config.

## What changed

- Added reloadable OTel log and trace layers so the app server can initialize telemetry from the first effective successful `thread/start` config without reinstalling the subscriber.
- Preserve tracing-opentelemetry span-context downcasting so inbound `traceparent` links and child trace headers keep working through the reloadable trace layer.
- Validate dynamic tools before reloading telemetry, then pin the process only after thread creation succeeds.
- Keep retired providers alive until app-server shutdown so existing sessions retain their metrics clients after a reload.
- Update global OTel metrics only after a replacement provider is built successfully, and clear metrics when telemetry is disabled.