### PR TITLE
Add Code Review skill

### DIFF
--- a/.codex/skills/code-review-breaking-changes/SKILL.md
+++ b/.codex/skills/code-review-breaking-changes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-breaking-changes
-description: Breacking 
+description: Breaking changes
 ---
 
 Search for breaking changes in external integration surfaces:
@@ -9,4 +9,4 @@ Search for breaking changes in external integration surfaces:
 - configuration loading
 - resuming sessions from existing rollouts
 
-Do not stop  after finding one issue, analyze all possible ways breaking changes can happen.
+Do not stop after finding one issue; analyze all possible ways breaking changes can happen.

--- a/.codex/skills/code-review-breaking-changes/SKILL.md
+++ b/.codex/skills/code-review-breaking-changes/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: code-breaking-changes
+description: Breacking 
+---
+
+Search for breaking changes in external integration surfaces:
+- app-server APIs
+- CLI parameters
+- configuration loading
+- resuming sessions from existing rollouts
+
+Do not stop  after finding one issue, analyze all possible ways breaking changes can happen.

--- a/.codex/skills/code-review-change-size/SKILL.md
+++ b/.codex/skills/code-review-change-size/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: code-review-change-size
+description: Change size guidance (800 lines)
+---
+
+Unless the change is mechanical the total number of changed lines should not exceed 800 lines.
+For complex logic changes the size should be under 500 lines.
+
+If the change is larger consider how the change can be done in stages. This must be well informed and reasearch ed suggestion. 
+Optimize for the ease of review, group mechanical changes separately from complex logic changes.

--- a/.codex/skills/code-review-change-size/SKILL.md
+++ b/.codex/skills/code-review-change-size/SKILL.md
@@ -6,5 +6,6 @@ description: Change size guidance (800 lines)
 Unless the change is mechanical the total number of changed lines should not exceed 800 lines.
 For complex logic changes the size should be under 500 lines.
 
-If the change is larger consider how the change can be done in stages. This must be well informed and reasearch ed suggestion. 
-Optimize for the ease of review, group mechanical changes separately from complex logic changes.
+If the change is larger, explain whether it can be split into reviewable stages and identify the smallest coherent stage to land first.
+Base the staging suggestion on the actual diff, dependencies, and affected call sites.
+

--- a/.codex/skills/code-review-context/SKILL.md
+++ b/.codex/skills/code-review-context/SKILL.md
@@ -5,7 +5,8 @@ description: Model visible context
 
 Codex maintains a context (history of messages) that is sent to the model in inference requests.
 
-1. No history rewrite - the context must be build up incrementally.  
-2. Avoid frequent changes to context that cause cache misses. 
-3. No unbounded items - everything injected in the model context must have a bounded size.
-4. Hightlight new individual items that can cross >1k tokens as P0. These need and additional manual review.
+1. No history rewrite - the context must be built up incrementally.
+2. Avoid frequent changes to context that cause cache misses.
+3. No unbounded items - everything injected in the model context must have a bounded size and a hard cap. 
+4. No items larger than 10K tokens.
+5. Highlight new individual items that can cross >1k tokens as P0. These need an additional manual review.

--- a/.codex/skills/code-review-context/SKILL.md
+++ b/.codex/skills/code-review-context/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: code-review-context
+description: Model visible context
+---
+
+Codex maintains a context (history of messages) that is sent to the model in inference requests.
+
+1. No history rewrite - the context must be build up incrementally.  
+2. Avoid frequent changes to context that cause cache misses. 
+3. No unbounded items - everything injected in the model context must have a bounded size.
+4. Hightlight new individual items that can cross >1k tokens as P0. These need and additional manual review.

--- a/.codex/skills/code-review-testing/SKILL.md
+++ b/.codex/skills/code-review-testing/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: code-review-testing
+description: Test authoring guidance
+---
+
+For agent changes prefer integration tests over unit tests. Integration tests are under `core/suite` and use `test_codex` to set up a test instance of codex.
+
+Features change change the agent logic MUST add an integration test:
+- Provide a list of major logic changes and user-facing behaviors that need to be tested.
+
+Check whether there are existing helpers to make tests more streamlined and readable.

--- a/.codex/skills/code-review-testing/SKILL.md
+++ b/.codex/skills/code-review-testing/SKILL.md
@@ -5,7 +5,10 @@ description: Test authoring guidance
 
 For agent changes prefer integration tests over unit tests. Integration tests are under `core/suite` and use `test_codex` to set up a test instance of codex.
 
-Features change change the agent logic MUST add an integration test:
+Features that change the agent logic MUST add an integration test:
 - Provide a list of major logic changes and user-facing behaviors that need to be tested.
+
+If unit tests are needed, put them in a dedicated test file (*_tests.rs).
+Avoid test-only functions in the main implementation.
 
 Check whether there are existing helpers to make tests more streamlined and readable.

--- a/.codex/skills/code-review/SKILL.md
+++ b/.codex/skills/code-review/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: code-review
+description: Run a final code review on a pull request
+---
+
+Use subagents to review code using all code-review-* skills in this repository. One subagent per skill. Pass full skill path to subagents. Use xhigh reasoning.
+
+You can return an unlimited number of findings. 
+Use raw Markdown to report findings.
+Number findings for the ease of reference.
+
+If the GitHub user running the review is the owner of the pull request add a `code-reviewed` label.
+Do not leave GitHub comments unless explicitly asked.
+

--- a/.codex/skills/code-review/SKILL.md
+++ b/.codex/skills/code-review/SKILL.md
@@ -3,12 +3,12 @@ name: code-review
 description: Run a final code review on a pull request
 ---
 
-Use subagents to review code using all code-review-* skills in this repository. One subagent per skill. Pass full skill path to subagents. Use xhigh reasoning.
+Use subagents to review code using all code-review-* skills in this repository other than this orchestrator. One subagent per skill. Pass full skill path to subagents. Use xhigh reasoning.
 
-You can return an unlimited number of findings. 
+Make sure to return every single issue. You can return an unlimited number of findings.
 Use raw Markdown to report findings.
-Number findings for the ease of reference.
+Number findings for ease of reference.
+Each finding must include a specific file path and line number.
 
 If the GitHub user running the review is the owner of the pull request add a `code-reviewed` label.
 Do not leave GitHub comments unless explicitly asked.
-


### PR DESCRIPTION
Adds a skill that centralizes rules used during code review for codex.