### PR TITLE
[codex] Fix interrupt prompt history race

### DIFF
--- a/codex-rs/core/src/hook_runtime.rs
+++ b/codex-rs/core/src/hook_runtime.rs
@@ -273,8 +273,15 @@ pub(crate) async fn drain_turn_start_transcript_inputs(
     sess: &Arc<Session>,
     turn_context: &Arc<TurnContext>,
 ) -> bool {
-    let _guard = turn_context.transcript_serialization_lock.lock().await;
+    let Ok(_permit) = turn_context.transcript_serialization_lock.acquire().await else {
+        return false;
+    };
     if run_pending_session_start_hooks(sess, turn_context).await {
+        turn_context
+            .turn_start_transcript_inputs
+            .lock()
+            .await
+            .clear();
         return false;
     }
 

--- a/codex-rs/core/src/hook_runtime.rs
+++ b/codex-rs/core/src/hook_runtime.rs
@@ -35,6 +35,7 @@ use serde_json::Value;
 use crate::event_mapping::parse_turn_item;
 use crate::session::session::Session;
 use crate::session::turn_context::TurnContext;
+use crate::session::turn_context::TurnStartUserPromptSubmitOutcome;
 use crate::tools::sandboxing::PermissionRequestPayload;
 
 pub(crate) struct HookRuntimeOutcome {
@@ -277,31 +278,48 @@ pub(crate) async fn drain_turn_start_transcript_inputs(
         return false;
     };
     if run_pending_session_start_hooks(sess, turn_context).await {
-        turn_context
-            .turn_start_transcript_inputs
-            .lock()
-            .await
-            .clear();
+        turn_context.lock_turn_start_transcript_inputs().clear();
         return false;
     }
 
     loop {
-        let input = {
-            let inputs = turn_context.turn_start_transcript_inputs.lock().await;
+        let queued_input = {
+            let inputs = turn_context.lock_turn_start_transcript_inputs();
             inputs.first().cloned()
         };
-        let Some(input) = input else {
+        let Some(queued_input) = queued_input else {
             break;
         };
+        let input = queued_input.input;
 
         let initial_input_for_turn: ResponseInputItem = ResponseInputItem::from(input.clone());
         let response_item: ResponseItem = initial_input_for_turn.into();
-        let user_prompt_submit_outcome = run_user_prompt_submit_hooks(
-            sess,
-            turn_context,
-            UserMessageItem::new(&input).message(),
-        )
-        .await;
+        let user_prompt_submit_outcome = match queued_input.user_prompt_submit_outcome {
+            Some(outcome) => outcome,
+            None => {
+                let outcome = run_user_prompt_submit_hooks(
+                    sess,
+                    turn_context,
+                    UserMessageItem::new(&input).message(),
+                )
+                .await;
+                let outcome = TurnStartUserPromptSubmitOutcome {
+                    should_stop: outcome.should_stop,
+                    additional_contexts: outcome.additional_contexts,
+                };
+                {
+                    let mut inputs = turn_context.lock_turn_start_transcript_inputs();
+                    if let Some(queued) = inputs.first_mut()
+                        && queued.input == input
+                        && queued.user_prompt_submit_outcome.is_none()
+                    {
+                        queued.user_prompt_submit_outcome = Some(outcome.clone());
+                    }
+                }
+                outcome
+            }
+        };
+
         if user_prompt_submit_outcome.should_stop {
             record_additional_contexts(
                 sess,
@@ -309,27 +327,42 @@ pub(crate) async fn drain_turn_start_transcript_inputs(
                 user_prompt_submit_outcome.additional_contexts,
             )
             .await;
-            let mut inputs = turn_context.turn_start_transcript_inputs.lock().await;
-            if inputs.first().is_some_and(|queued| queued == &input) {
+            let mut inputs = turn_context.lock_turn_start_transcript_inputs();
+            if inputs.first().is_some_and(|queued| queued.input == input) {
                 inputs.remove(0);
             }
             return false;
         }
 
-        sess.record_user_prompt_and_emit_turn_item(
-            turn_context.as_ref(),
-            input.as_slice(),
-            response_item,
-        )
-        .await;
+        if !queued_input.user_prompt_recorded {
+            sess.record_conversation_items(
+                turn_context.as_ref(),
+                std::slice::from_ref(&response_item),
+            )
+            .await;
+            {
+                let mut inputs = turn_context.lock_turn_start_transcript_inputs();
+                if let Some(queued) = inputs.first_mut()
+                    && queued.input == input
+                {
+                    queued.user_prompt_recorded = true;
+                }
+            }
+            let turn_item = TurnItem::UserMessage(UserMessageItem::new(&input));
+            sess.emit_turn_item_started(turn_context.as_ref(), &turn_item)
+                .await;
+            sess.emit_turn_item_completed(turn_context.as_ref(), turn_item)
+                .await;
+            sess.ensure_rollout_materialized().await;
+        }
         record_additional_contexts(
             sess,
             turn_context,
             user_prompt_submit_outcome.additional_contexts,
         )
         .await;
-        let mut inputs = turn_context.turn_start_transcript_inputs.lock().await;
-        if inputs.first().is_some_and(|queued| queued == &input) {
+        let mut inputs = turn_context.lock_turn_start_transcript_inputs();
+        if inputs.first().is_some_and(|queued| queued.input == input) {
             inputs.remove(0);
         }
     }

--- a/codex-rs/core/src/hook_runtime.rs
+++ b/codex-rs/core/src/hook_runtime.rs
@@ -31,6 +31,7 @@ use codex_protocol::protocol::HookSource;
 use codex_protocol::protocol::HookStartedEvent;
 use codex_protocol::user_input::UserInput;
 use serde_json::Value;
+use tokio::sync::OwnedSemaphorePermit;
 
 use crate::event_mapping::parse_turn_item;
 use crate::session::PreviousTurnSettings;
@@ -280,10 +281,24 @@ pub(crate) async fn drain_turn_start_transcript_inputs(
     turn_context: &Arc<TurnContext>,
     mode: TurnStartTranscriptDrainMode,
 ) -> bool {
-    let Ok(_permit) = turn_context.transcript_serialization_lock.acquire().await else {
+    let Ok(permit) = turn_context
+        .transcript_serialization_lock
+        .clone()
+        .acquire_owned()
+        .await
+    else {
         return false;
     };
 
+    drain_turn_start_transcript_inputs_with_permit(sess, turn_context, mode, permit).await
+}
+
+pub(crate) async fn drain_turn_start_transcript_inputs_with_permit(
+    sess: &Arc<Session>,
+    turn_context: &Arc<TurnContext>,
+    mode: TurnStartTranscriptDrainMode,
+    _permit: OwnedSemaphorePermit,
+) -> bool {
     let has_queued_start_input = !turn_context.lock_turn_start_transcript_inputs().is_empty();
     if !has_queued_start_input && matches!(mode, TurnStartTranscriptDrainMode::InterruptRecovery) {
         return true;

--- a/codex-rs/core/src/hook_runtime.rs
+++ b/codex-rs/core/src/hook_runtime.rs
@@ -33,9 +33,9 @@ use codex_protocol::user_input::UserInput;
 use serde_json::Value;
 
 use crate::event_mapping::parse_turn_item;
+use crate::session::PreviousTurnSettings;
 use crate::session::session::Session;
 use crate::session::turn_context::TurnContext;
-use crate::session::turn_context::TurnStartUserPromptSubmitOutcome;
 use crate::tools::sandboxing::PermissionRequestPayload;
 
 pub(crate) struct HookRuntimeOutcome {
@@ -57,6 +57,11 @@ pub(crate) enum PendingInputRecord {
     ConversationItem {
         response_item: ResponseItem,
     },
+}
+
+pub(crate) enum TurnStartTranscriptDrainMode {
+    RegularTurn,
+    InterruptRecovery,
 }
 
 struct ContextInjectingHookOutcome {
@@ -273,52 +278,45 @@ pub(crate) async fn inspect_pending_input(
 pub(crate) async fn drain_turn_start_transcript_inputs(
     sess: &Arc<Session>,
     turn_context: &Arc<TurnContext>,
+    mode: TurnStartTranscriptDrainMode,
 ) -> bool {
     let Ok(_permit) = turn_context.transcript_serialization_lock.acquire().await else {
         return false;
     };
+
+    let has_queued_start_input = !turn_context.lock_turn_start_transcript_inputs().is_empty();
+    if !has_queued_start_input && matches!(mode, TurnStartTranscriptDrainMode::InterruptRecovery) {
+        return true;
+    }
+
+    // Keep the normal turn-start ordering in one serialized region: context first,
+    // then the user prompt, then hook-provided context and previous-turn settings.
+    sess.record_context_updates_and_set_reference_context_item(turn_context.as_ref())
+        .await;
+
     if run_pending_session_start_hooks(sess, turn_context).await {
         turn_context.lock_turn_start_transcript_inputs().clear();
         return false;
     }
 
+    let mut recorded_start_input = false;
     loop {
-        let queued_input = {
+        let input = {
             let inputs = turn_context.lock_turn_start_transcript_inputs();
-            inputs.first().cloned()
+            inputs.first().map(|queued| queued.input.clone())
         };
-        let Some(queued_input) = queued_input else {
+        let Some(input) = input else {
             break;
         };
-        let input = queued_input.input;
 
         let initial_input_for_turn: ResponseInputItem = ResponseInputItem::from(input.clone());
         let response_item: ResponseItem = initial_input_for_turn.into();
-        let user_prompt_submit_outcome = match queued_input.user_prompt_submit_outcome {
-            Some(outcome) => outcome,
-            None => {
-                let outcome = run_user_prompt_submit_hooks(
-                    sess,
-                    turn_context,
-                    UserMessageItem::new(&input).message(),
-                )
-                .await;
-                let outcome = TurnStartUserPromptSubmitOutcome {
-                    should_stop: outcome.should_stop,
-                    additional_contexts: outcome.additional_contexts,
-                };
-                {
-                    let mut inputs = turn_context.lock_turn_start_transcript_inputs();
-                    if let Some(queued) = inputs.first_mut()
-                        && queued.input == input
-                        && queued.user_prompt_submit_outcome.is_none()
-                    {
-                        queued.user_prompt_submit_outcome = Some(outcome.clone());
-                    }
-                }
-                outcome
-            }
-        };
+        let user_prompt_submit_outcome = run_user_prompt_submit_hooks(
+            sess,
+            turn_context,
+            UserMessageItem::new(&input).message(),
+        )
+        .await;
 
         if user_prompt_submit_outcome.should_stop {
             record_additional_contexts(
@@ -334,27 +332,12 @@ pub(crate) async fn drain_turn_start_transcript_inputs(
             return false;
         }
 
-        if !queued_input.user_prompt_recorded {
-            sess.record_conversation_items(
-                turn_context.as_ref(),
-                std::slice::from_ref(&response_item),
-            )
-            .await;
-            {
-                let mut inputs = turn_context.lock_turn_start_transcript_inputs();
-                if let Some(queued) = inputs.first_mut()
-                    && queued.input == input
-                {
-                    queued.user_prompt_recorded = true;
-                }
-            }
-            let turn_item = TurnItem::UserMessage(UserMessageItem::new(&input));
-            sess.emit_turn_item_started(turn_context.as_ref(), &turn_item)
-                .await;
-            sess.emit_turn_item_completed(turn_context.as_ref(), turn_item)
-                .await;
-            sess.ensure_rollout_materialized().await;
-        }
+        sess.record_user_prompt_and_emit_turn_item(
+            turn_context.as_ref(),
+            input.as_slice(),
+            response_item,
+        )
+        .await;
         record_additional_contexts(
             sess,
             turn_context,
@@ -365,6 +348,15 @@ pub(crate) async fn drain_turn_start_transcript_inputs(
         if inputs.first().is_some_and(|queued| queued.input == input) {
             inputs.remove(0);
         }
+        recorded_start_input = true;
+    }
+
+    if recorded_start_input {
+        sess.set_previous_turn_settings(Some(PreviousTurnSettings {
+            model: turn_context.model_info.slug.clone(),
+            realtime_active: Some(turn_context.realtime_active),
+        }))
+        .await;
     }
 
     true

--- a/codex-rs/core/src/hook_runtime.rs
+++ b/codex-rs/core/src/hook_runtime.rs
@@ -17,6 +17,7 @@ use codex_hooks::UserPromptSubmitRequest;
 use codex_otel::HOOK_RUN_DURATION_METRIC;
 use codex_otel::HOOK_RUN_METRIC;
 use codex_protocol::items::TurnItem;
+use codex_protocol::items::UserMessageItem;
 use codex_protocol::models::DeveloperInstructions;
 use codex_protocol::models::ResponseInputItem;
 use codex_protocol::models::ResponseItem;
@@ -266,6 +267,67 @@ pub(crate) async fn inspect_pending_input(
             response_item,
         }))
     }
+}
+
+pub(crate) async fn drain_turn_start_transcript_inputs(
+    sess: &Arc<Session>,
+    turn_context: &Arc<TurnContext>,
+) -> bool {
+    let _guard = turn_context.transcript_serialization_lock.lock().await;
+    if run_pending_session_start_hooks(sess, turn_context).await {
+        return false;
+    }
+
+    loop {
+        let input = {
+            let inputs = turn_context.turn_start_transcript_inputs.lock().await;
+            inputs.first().cloned()
+        };
+        let Some(input) = input else {
+            break;
+        };
+
+        let initial_input_for_turn: ResponseInputItem = ResponseInputItem::from(input.clone());
+        let response_item: ResponseItem = initial_input_for_turn.into();
+        let user_prompt_submit_outcome = run_user_prompt_submit_hooks(
+            sess,
+            turn_context,
+            UserMessageItem::new(&input).message(),
+        )
+        .await;
+        if user_prompt_submit_outcome.should_stop {
+            record_additional_contexts(
+                sess,
+                turn_context,
+                user_prompt_submit_outcome.additional_contexts,
+            )
+            .await;
+            let mut inputs = turn_context.turn_start_transcript_inputs.lock().await;
+            if inputs.first().is_some_and(|queued| queued == &input) {
+                inputs.remove(0);
+            }
+            return false;
+        }
+
+        sess.record_user_prompt_and_emit_turn_item(
+            turn_context.as_ref(),
+            input.as_slice(),
+            response_item,
+        )
+        .await;
+        record_additional_contexts(
+            sess,
+            turn_context,
+            user_prompt_submit_outcome.additional_contexts,
+        )
+        .await;
+        let mut inputs = turn_context.turn_start_transcript_inputs.lock().await;
+        if inputs.first().is_some_and(|queued| queued == &input) {
+            inputs.remove(0);
+        }
+    }
+
+    true
 }
 
 pub(crate) async fn record_pending_input(

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -128,6 +128,7 @@ use rmcp::model::RequestId;
 use serde_json::Value;
 use tokio::sync::Mutex;
 use tokio::sync::RwLock;
+use tokio::sync::Semaphore;
 use tokio::sync::oneshot;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;

--- a/codex-rs/core/src/session/review.rs
+++ b/codex-rs/core/src/session/review.rs
@@ -139,6 +139,8 @@ pub(super) async fn spawn_review_thread(
         turn_metadata_state,
         turn_skills: TurnSkillsContext::new(parent_turn_context.turn_skills.outcome.clone()),
         turn_timing_state: Arc::new(TurnTimingState::default()),
+        turn_start_transcript_inputs: Arc::new(Mutex::new(Vec::new())),
+        transcript_serialization_lock: Arc::new(Mutex::new(())),
     };
 
     // Seed the child task with the review prompt as the initial user message.

--- a/codex-rs/core/src/session/review.rs
+++ b/codex-rs/core/src/session/review.rs
@@ -139,7 +139,7 @@ pub(super) async fn spawn_review_thread(
         turn_metadata_state,
         turn_skills: TurnSkillsContext::new(parent_turn_context.turn_skills.outcome.clone()),
         turn_timing_state: Arc::new(TurnTimingState::default()),
-        turn_start_transcript_inputs: Arc::new(Mutex::new(Vec::new())),
+        turn_start_transcript_inputs: Arc::new(std::sync::Mutex::new(Vec::new())),
         transcript_serialization_lock: Arc::new(Semaphore::new(1)),
     };
 

--- a/codex-rs/core/src/session/review.rs
+++ b/codex-rs/core/src/session/review.rs
@@ -140,7 +140,7 @@ pub(super) async fn spawn_review_thread(
         turn_skills: TurnSkillsContext::new(parent_turn_context.turn_skills.outcome.clone()),
         turn_timing_state: Arc::new(TurnTimingState::default()),
         turn_start_transcript_inputs: Arc::new(Mutex::new(Vec::new())),
-        transcript_serialization_lock: Arc::new(Mutex::new(())),
+        transcript_serialization_lock: Arc::new(Semaphore::new(1)),
     };
 
     // Seed the child task with the review prompt as the initial user message.

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -5709,6 +5709,62 @@ async fn abort_regular_task_records_prompt_before_interrupt_marker() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[test_log::test]
+async fn abort_non_regular_task_keeps_pending_session_start_source() {
+    let (sess, tc, _rx) = make_session_and_context_with_rx().await;
+    sess.state
+        .lock()
+        .await
+        .set_pending_session_start_source(Some(codex_hooks::SessionStartSource::Startup));
+    let input = vec![UserInput::Text {
+        text: "review this".to_string(),
+        text_elements: Vec::new(),
+    }];
+    sess.spawn_task(
+        Arc::clone(&tc),
+        input,
+        NeverEndingTask {
+            kind: TaskKind::Review,
+            listen_to_cancellation_token: true,
+        },
+    )
+    .await;
+
+    sess.abort_all_tasks(TurnAbortReason::Interrupted).await;
+
+    assert!(matches!(
+        sess.take_pending_session_start_source().await,
+        Some(codex_hooks::SessionStartSource::Startup)
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[test_log::test]
+async fn abort_regular_task_without_start_input_keeps_pending_session_start_source() {
+    let (sess, tc, _rx) = make_session_and_context_with_rx().await;
+    sess.state
+        .lock()
+        .await
+        .set_pending_session_start_source(Some(codex_hooks::SessionStartSource::Startup));
+    sess.spawn_task(
+        Arc::clone(&tc),
+        Vec::new(),
+        NeverEndingTask {
+            kind: TaskKind::Regular,
+            listen_to_cancellation_token: true,
+        },
+    )
+    .await;
+
+    sess.abort_all_tasks(TurnAbortReason::Interrupted).await;
+
+    assert!(matches!(
+        sess.take_pending_session_start_source().await,
+        Some(codex_hooks::SessionStartSource::Startup)
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn task_finish_emits_turn_item_lifecycle_for_leftover_pending_user_input() {
     let (sess, tc, rx) = make_session_and_context_with_rx().await;
     let input = vec![UserInput::Text {

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -368,6 +368,80 @@ async fn interrupting_regular_turn_waiting_on_startup_prewarm_emits_turn_aborted
     );
 }
 
+#[tokio::test]
+async fn session_start_stop_clears_queued_start_input() -> anyhow::Result<()> {
+    let (mut sess, tc) = make_session_and_context().await;
+    std::fs::create_dir_all(&tc.config.codex_home)?;
+    let hook_script = tc.config.codex_home.join("block_session_start_hook.py");
+    std::fs::write(
+        &hook_script,
+        r#"import json
+import sys
+
+json.load(sys.stdin)
+print(json.dumps({"continue": False, "stopReason": "blocked for test"}))
+"#,
+    )?;
+    std::fs::write(
+        tc.config.codex_home.join("hooks.json"),
+        json!({
+            "hooks": {
+                "SessionStart": [{
+                    "hooks": [{
+                        "type": "command",
+                        "command": format!("python3 {}", hook_script.display()),
+                    }]
+                }]
+            }
+        })
+        .to_string(),
+    )?;
+    sess.services.hooks = Hooks::new(HooksConfig {
+        feature_enabled: true,
+        config_layer_stack: Some(tc.config.config_layer_stack.clone()),
+        ..HooksConfig::default()
+    });
+    let sess = Arc::new(sess);
+    let tc = Arc::new(tc);
+    let input = vec![UserInput::Text {
+        text: "prompt blocked by session start".to_string(),
+        text_elements: Vec::new(),
+    }];
+    sess.state
+        .lock()
+        .await
+        .set_pending_session_start_source(Some(codex_hooks::SessionStartSource::Startup));
+    tc.lock_turn_start_transcript_inputs()
+        .push(crate::session::turn_context::TurnStartTranscriptInput { input });
+
+    assert!(
+        !crate::hook_runtime::drain_turn_start_transcript_inputs(
+            &sess,
+            &tc,
+            crate::hook_runtime::TurnStartTranscriptDrainMode::RegularTurn,
+        )
+        .await
+    );
+    assert!(tc.lock_turn_start_transcript_inputs().is_empty());
+
+    assert!(
+        crate::hook_runtime::drain_turn_start_transcript_inputs(
+            &sess,
+            &tc,
+            crate::hook_runtime::TurnStartTranscriptDrainMode::InterruptRecovery,
+        )
+        .await
+    );
+    let history = sess.clone_history().await;
+    assert!(
+        user_input_texts(history.raw_items())
+            .iter()
+            .all(|text| !text.contains("prompt blocked by session start"))
+    );
+
+    Ok(())
+}
+
 fn test_model_client_session() -> crate::client::ModelClientSession {
     crate::client::ModelClient::new(
         /*auth_manager*/ None,

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -55,6 +55,8 @@ use tracing::Span;
 use crate::RolloutRecorderParams;
 use crate::rollout::policy::EventPersistenceMode;
 use crate::rollout::recorder::RolloutRecorder;
+use crate::session::turn_context::TurnStartTranscriptInput;
+use crate::session::turn_context::TurnStartUserPromptSubmitOutcome;
 use crate::state::TaskKind;
 use crate::tasks::SessionTask;
 use crate::tasks::SessionTaskContext;
@@ -5706,6 +5708,56 @@ async fn abort_regular_task_records_prompt_before_interrupt_marker() {
         crate::tasks::interrupted_turn_history_marker(),
     ];
     assert_eq!(history.raw_items(), expected.as_slice());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[test_log::test]
+async fn abort_regular_task_replays_context_without_replaying_prompt() {
+    let (sess, tc, _rx) = make_session_and_context_with_rx().await;
+    let input = vec![UserInput::Text {
+        text: "hello".to_string(),
+        text_elements: Vec::new(),
+    }];
+    let response_item = ResponseItem::Message {
+        id: None,
+        role: "user".to_string(),
+        content: vec![ContentItem::InputText {
+            text: "hello".to_string(),
+        }],
+        end_turn: None,
+        phase: None,
+    };
+    sess.record_conversation_items(tc.as_ref(), std::slice::from_ref(&response_item))
+        .await;
+    tc.lock_turn_start_transcript_inputs()
+        .push(TurnStartTranscriptInput {
+            input,
+            user_prompt_submit_outcome: Some(TurnStartUserPromptSubmitOutcome {
+                should_stop: false,
+                additional_contexts: vec!["hook context".to_string()],
+            }),
+            user_prompt_recorded: true,
+        });
+    sess.spawn_task(
+        Arc::clone(&tc),
+        Vec::new(),
+        NeverEndingTask {
+            kind: TaskKind::Regular,
+            listen_to_cancellation_token: true,
+        },
+    )
+    .await;
+
+    sess.abort_all_tasks(TurnAbortReason::Interrupted).await;
+
+    let history = sess.clone_history().await;
+    let expected = vec![
+        response_item,
+        DeveloperInstructions::new("hook context".to_string()).into(),
+        crate::tasks::interrupted_turn_history_marker(),
+    ];
+    assert_eq!(history.raw_items(), expected.as_slice());
+    assert!(tc.lock_turn_start_transcript_inputs().is_empty());
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -5774,6 +5774,73 @@ impl SessionTask for NeverEndingTask {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[test_log::test]
+async fn abort_regular_task_emits_turn_aborted_only() {
+    let (sess, tc, rx) = make_session_and_context_with_rx().await;
+    let input = vec![UserInput::Text {
+        text: "hello".to_string(),
+        text_elements: Vec::new(),
+    }];
+    sess.spawn_task(
+        Arc::clone(&tc),
+        input,
+        NeverEndingTask {
+            kind: TaskKind::Regular,
+            listen_to_cancellation_token: false,
+        },
+    )
+    .await;
+
+    sess.abort_all_tasks(TurnAbortReason::Interrupted).await;
+
+    // Interrupts persist a model-visible `<turn_aborted>` marker into history, but there is no
+    // separate client-visible event for that marker (only `EventMsg::TurnAborted`).
+    let evt = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+        .await
+        .expect("timeout waiting for event")
+        .expect("event");
+    match evt.msg {
+        EventMsg::TurnAborted(e) => assert_eq!(TurnAbortReason::Interrupted, e.reason),
+        other => panic!("unexpected event: {other:?}"),
+    }
+    // No extra events should be emitted after an abort.
+    assert!(rx.try_recv().is_err());
+}
+
+#[tokio::test]
+async fn abort_gracefully_emits_turn_aborted_only() {
+    let (sess, tc, rx) = make_session_and_context_with_rx().await;
+    let input = vec![UserInput::Text {
+        text: "hello".to_string(),
+        text_elements: Vec::new(),
+    }];
+    sess.spawn_task(
+        Arc::clone(&tc),
+        input,
+        NeverEndingTask {
+            kind: TaskKind::Regular,
+            listen_to_cancellation_token: true,
+        },
+    )
+    .await;
+
+    sess.abort_all_tasks(TurnAbortReason::Interrupted).await;
+
+    // Even if tasks handle cancellation gracefully, interrupts still result in `TurnAborted`
+    // being the only client-visible signal.
+    let evt = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+        .await
+        .expect("timeout waiting for event")
+        .expect("event");
+    match evt.msg {
+        EventMsg::TurnAborted(e) => assert_eq!(TurnAbortReason::Interrupted, e.reason),
+        other => panic!("unexpected event: {other:?}"),
+    }
+    // No extra events should be emitted after an abort.
+    assert!(rx.try_recv().is_err());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[test_log::test]
 async fn abort_non_regular_task_keeps_pending_session_start_source() {
     let (sess, tc, _rx) = make_session_and_context_with_rx().await;
     sess.state

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -144,7 +144,6 @@ use sha2::Sha512;
 use std::path::Path;
 use std::time::Duration;
 use tokio::sync::Semaphore;
-use tokio::time::sleep;
 use tokio::time::timeout;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use wiremock::Mock;
@@ -5669,49 +5668,14 @@ impl SessionTask for NeverEndingTask {
             cancellation_token.cancelled().await;
             return None;
         }
-        loop {
-            sleep(Duration::from_secs(60)).await;
-        }
+        std::future::pending::<Option<String>>().await
     }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[test_log::test]
-async fn abort_regular_task_emits_turn_aborted_only() {
-    let (sess, tc, rx) = make_session_and_context_with_rx().await;
-    let input = vec![UserInput::Text {
-        text: "hello".to_string(),
-        text_elements: Vec::new(),
-    }];
-    sess.spawn_task(
-        Arc::clone(&tc),
-        input,
-        NeverEndingTask {
-            kind: TaskKind::Regular,
-            listen_to_cancellation_token: false,
-        },
-    )
-    .await;
-
-    sess.abort_all_tasks(TurnAbortReason::Interrupted).await;
-
-    // Interrupts persist a model-visible `<turn_aborted>` marker into history, but there is no
-    // separate client-visible event for that marker (only `EventMsg::TurnAborted`).
-    let evt = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
-        .await
-        .expect("timeout waiting for event")
-        .expect("event");
-    match evt.msg {
-        EventMsg::TurnAborted(e) => assert_eq!(TurnAbortReason::Interrupted, e.reason),
-        other => panic!("unexpected event: {other:?}"),
-    }
-    // No extra events should be emitted after an abort.
-    assert!(rx.try_recv().is_err());
-}
-
-#[tokio::test]
-async fn abort_gracefully_emits_turn_aborted_only() {
-    let (sess, tc, rx) = make_session_and_context_with_rx().await;
+async fn abort_regular_task_records_prompt_before_interrupt_marker() {
+    let (sess, tc, _rx) = make_session_and_context_with_rx().await;
     let input = vec![UserInput::Text {
         text: "hello".to_string(),
         text_elements: Vec::new(),
@@ -5728,18 +5692,20 @@ async fn abort_gracefully_emits_turn_aborted_only() {
 
     sess.abort_all_tasks(TurnAbortReason::Interrupted).await;
 
-    // Even if tasks handle cancellation gracefully, interrupts still result in `TurnAborted`
-    // being the only client-visible signal.
-    let evt = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
-        .await
-        .expect("timeout waiting for event")
-        .expect("event");
-    match evt.msg {
-        EventMsg::TurnAborted(e) => assert_eq!(TurnAbortReason::Interrupted, e.reason),
-        other => panic!("unexpected event: {other:?}"),
-    }
-    // No extra events should be emitted after an abort.
-    assert!(rx.try_recv().is_err());
+    let history = sess.clone_history().await;
+    let expected = vec![
+        ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![ContentItem::InputText {
+                text: "hello".to_string(),
+            }],
+            end_turn: None,
+            phase: None,
+        },
+        crate::tasks::interrupted_turn_history_marker(),
+    ];
+    assert_eq!(history.raw_items(), expected.as_slice());
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -5700,49 +5700,6 @@ impl SessionTask for NeverEndingTask {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[test_log::test]
-async fn abort_regular_task_records_context_prompt_before_interrupt_marker() {
-    let (sess, tc, _rx) = make_session_and_context_with_rx().await;
-    let input = vec![UserInput::Text {
-        text: "hello".to_string(),
-        text_elements: Vec::new(),
-    }];
-    let mut expected = sess.build_initial_context(tc.as_ref()).await;
-    expected.push(ResponseItem::Message {
-        id: None,
-        role: "user".to_string(),
-        content: vec![ContentItem::InputText {
-            text: "hello".to_string(),
-        }],
-        end_turn: None,
-        phase: None,
-    });
-    expected.push(crate::tasks::interrupted_turn_history_marker());
-    sess.spawn_task(
-        Arc::clone(&tc),
-        input,
-        NeverEndingTask {
-            kind: TaskKind::Regular,
-            listen_to_cancellation_token: true,
-        },
-    )
-    .await;
-
-    sess.abort_all_tasks(TurnAbortReason::Interrupted).await;
-
-    let history = sess.clone_history().await;
-    assert_eq!(history.raw_items(), expected.as_slice());
-    assert!(tc.lock_turn_start_transcript_inputs().is_empty());
-    assert_eq!(
-        sess.previous_turn_settings().await,
-        Some(PreviousTurnSettings {
-            model: tc.model_info.slug.clone(),
-            realtime_active: Some(tc.realtime_active),
-        })
-    );
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[test_log::test]
 async fn abort_non_regular_task_keeps_pending_session_start_source() {
     let (sess, tc, _rx) = make_session_and_context_with_rx().await;
     sess.state

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -55,8 +55,6 @@ use tracing::Span;
 use crate::RolloutRecorderParams;
 use crate::rollout::policy::EventPersistenceMode;
 use crate::rollout::recorder::RolloutRecorder;
-use crate::session::turn_context::TurnStartTranscriptInput;
-use crate::session::turn_context::TurnStartUserPromptSubmitOutcome;
 use crate::state::TaskKind;
 use crate::tasks::SessionTask;
 use crate::tasks::SessionTaskContext;
@@ -307,12 +305,23 @@ async fn interrupting_regular_turn_waiting_on_startup_prewarm_emits_turn_aborted
         ),
     )
     .await;
-    sess.spawn_task(
-        Arc::clone(&tc),
-        Vec::new(),
-        crate::tasks::RegularTask::new(),
-    )
-    .await;
+    let input = vec![UserInput::Text {
+        text: "hello before prewarm".to_string(),
+        text_elements: Vec::new(),
+    }];
+    let mut expected_history = sess.build_initial_context(tc.as_ref()).await;
+    expected_history.push(ResponseItem::Message {
+        id: None,
+        role: "user".to_string(),
+        content: vec![ContentItem::InputText {
+            text: "hello before prewarm".to_string(),
+        }],
+        end_turn: None,
+        phase: None,
+    });
+    expected_history.push(crate::tasks::interrupted_turn_history_marker());
+    sess.spawn_task(Arc::clone(&tc), input, crate::tasks::RegularTask::new())
+        .await;
 
     let first = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv())
         .await
@@ -325,23 +334,38 @@ async fn interrupting_regular_turn_waiting_on_startup_prewarm_emits_turn_aborted
 
     sess.abort_all_tasks(TurnAbortReason::Interrupted).await;
 
-    let second = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+    let (turn_id, reason, completed_at, duration_ms) =
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                let event = rx.recv().await.expect("channel open");
+                if let EventMsg::TurnAborted(TurnAbortedEvent {
+                    turn_id,
+                    reason,
+                    completed_at,
+                    duration_ms,
+                }) = event.msg
+                {
+                    return (turn_id, reason, completed_at, duration_ms);
+                }
+            }
+        })
         .await
-        .expect("expected turn aborted event")
-        .expect("channel open");
-    let EventMsg::TurnAborted(TurnAbortedEvent {
-        turn_id,
-        reason,
-        completed_at,
-        duration_ms,
-    }) = second.msg
-    else {
-        panic!("expected turn aborted event");
-    };
+        .expect("expected turn aborted event");
     assert_eq!(turn_id, Some(tc.sub_id.clone()));
     assert_eq!(reason, TurnAbortReason::Interrupted);
     assert!(completed_at.is_some());
     assert!(duration_ms.is_some());
+
+    let history = sess.clone_history().await;
+    assert_eq!(history.raw_items(), expected_history.as_slice());
+    assert!(tc.lock_turn_start_transcript_inputs().is_empty());
+    assert_eq!(
+        sess.previous_turn_settings().await,
+        Some(PreviousTurnSettings {
+            model: tc.model_info.slug.clone(),
+            realtime_active: Some(tc.realtime_active),
+        })
+    );
 }
 
 fn test_model_client_session() -> crate::client::ModelClientSession {
@@ -5676,12 +5700,23 @@ impl SessionTask for NeverEndingTask {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[test_log::test]
-async fn abort_regular_task_records_prompt_before_interrupt_marker() {
+async fn abort_regular_task_records_context_prompt_before_interrupt_marker() {
     let (sess, tc, _rx) = make_session_and_context_with_rx().await;
     let input = vec![UserInput::Text {
         text: "hello".to_string(),
         text_elements: Vec::new(),
     }];
+    let mut expected = sess.build_initial_context(tc.as_ref()).await;
+    expected.push(ResponseItem::Message {
+        id: None,
+        role: "user".to_string(),
+        content: vec![ContentItem::InputText {
+            text: "hello".to_string(),
+        }],
+        end_turn: None,
+        phase: None,
+    });
+    expected.push(crate::tasks::interrupted_turn_history_marker());
     sess.spawn_task(
         Arc::clone(&tc),
         input,
@@ -5695,69 +5730,15 @@ async fn abort_regular_task_records_prompt_before_interrupt_marker() {
     sess.abort_all_tasks(TurnAbortReason::Interrupted).await;
 
     let history = sess.clone_history().await;
-    let expected = vec![
-        ResponseItem::Message {
-            id: None,
-            role: "user".to_string(),
-            content: vec![ContentItem::InputText {
-                text: "hello".to_string(),
-            }],
-            end_turn: None,
-            phase: None,
-        },
-        crate::tasks::interrupted_turn_history_marker(),
-    ];
-    assert_eq!(history.raw_items(), expected.as_slice());
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[test_log::test]
-async fn abort_regular_task_replays_context_without_replaying_prompt() {
-    let (sess, tc, _rx) = make_session_and_context_with_rx().await;
-    let input = vec![UserInput::Text {
-        text: "hello".to_string(),
-        text_elements: Vec::new(),
-    }];
-    let response_item = ResponseItem::Message {
-        id: None,
-        role: "user".to_string(),
-        content: vec![ContentItem::InputText {
-            text: "hello".to_string(),
-        }],
-        end_turn: None,
-        phase: None,
-    };
-    sess.record_conversation_items(tc.as_ref(), std::slice::from_ref(&response_item))
-        .await;
-    tc.lock_turn_start_transcript_inputs()
-        .push(TurnStartTranscriptInput {
-            input,
-            user_prompt_submit_outcome: Some(TurnStartUserPromptSubmitOutcome {
-                should_stop: false,
-                additional_contexts: vec!["hook context".to_string()],
-            }),
-            user_prompt_recorded: true,
-        });
-    sess.spawn_task(
-        Arc::clone(&tc),
-        Vec::new(),
-        NeverEndingTask {
-            kind: TaskKind::Regular,
-            listen_to_cancellation_token: true,
-        },
-    )
-    .await;
-
-    sess.abort_all_tasks(TurnAbortReason::Interrupted).await;
-
-    let history = sess.clone_history().await;
-    let expected = vec![
-        response_item,
-        DeveloperInstructions::new("hook context".to_string()).into(),
-        crate::tasks::interrupted_turn_history_marker(),
-    ];
     assert_eq!(history.raw_items(), expected.as_slice());
     assert!(tc.lock_turn_start_transcript_inputs().is_empty());
+    assert_eq!(
+        sess.previous_turn_settings().await,
+        Some(PreviousTurnSettings {
+            model: tc.model_info.slug.clone(),
+            realtime_active: Some(tc.realtime_active),
+        })
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -18,6 +18,7 @@ use crate::compact_remote::run_inline_remote_auto_compact_task;
 use crate::connectors;
 use crate::feedback_tags;
 use crate::hook_runtime::PendingInputHookDisposition;
+use crate::hook_runtime::TurnStartTranscriptDrainMode;
 use crate::hook_runtime::drain_turn_start_transcript_inputs;
 use crate::hook_runtime::emit_hook_completed_events;
 use crate::hook_runtime::inspect_pending_input;
@@ -37,7 +38,6 @@ use crate::mentions::collect_tool_mentions_from_messages;
 use crate::parse_turn_item;
 use crate::plugins::build_plugin_injections;
 use crate::resolve_skill_dependencies_for_turn;
-use crate::session::PreviousTurnSettings;
 use crate::session::session::Session;
 use crate::session::turn_context::TurnContext;
 use crate::stream_events_utils::HandleOutputCtx;
@@ -156,9 +156,6 @@ pub(crate) async fn run_turn(
     }
 
     let skills_outcome = Some(turn_context.turn_skills.outcome.as_ref());
-
-    sess.record_context_updates_and_set_reference_context_item(turn_context.as_ref())
-        .await;
 
     let loaded_plugins = sess
         .services
@@ -284,7 +281,13 @@ pub(crate) async fn run_turn(
         })
         .collect::<Vec<_>>();
 
-    if !drain_turn_start_transcript_inputs(&sess, &turn_context).await {
+    if !drain_turn_start_transcript_inputs(
+        &sess,
+        &turn_context,
+        TurnStartTranscriptDrainMode::RegularTurn,
+    )
+    .await
+    {
         return None;
     }
     sess.services
@@ -297,16 +300,6 @@ pub(crate) async fn run_turn(
     }
     sess.merge_connector_selection(explicitly_enabled_connectors.clone())
         .await;
-    if !input.is_empty() {
-        // Track the previous-turn baseline from the regular user-turn path only so
-        // standalone tasks (compact/shell/review/undo) cannot suppress future
-        // model/realtime injections.
-        sess.set_previous_turn_settings(Some(PreviousTurnSettings {
-            model: turn_context.model_info.slug.clone(),
-            realtime_active: Some(turn_context.realtime_active),
-        }))
-        .await;
-    }
     let agent_task = match sess.ensure_agent_task_registered().await {
         Ok(agent_task) => agent_task,
         Err(error) => {

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -18,12 +18,12 @@ use crate::compact_remote::run_inline_remote_auto_compact_task;
 use crate::connectors;
 use crate::feedback_tags;
 use crate::hook_runtime::PendingInputHookDisposition;
+use crate::hook_runtime::drain_turn_start_transcript_inputs;
 use crate::hook_runtime::emit_hook_completed_events;
 use crate::hook_runtime::inspect_pending_input;
 use crate::hook_runtime::record_additional_contexts;
 use crate::hook_runtime::record_pending_input;
 use crate::hook_runtime::run_pending_session_start_hooks;
-use crate::hook_runtime::run_user_prompt_submit_hooks;
 use crate::injection::ToolMentionKind;
 use crate::injection::app_id_from_path;
 use crate::injection::tool_kind_for_path;
@@ -74,7 +74,6 @@ use codex_protocol::error::CodexErr;
 use codex_protocol::error::Result as CodexResult;
 use codex_protocol::items::PlanItem;
 use codex_protocol::items::TurnItem;
-use codex_protocol::items::UserMessageItem;
 use codex_protocol::items::build_hook_prompt_message;
 use codex_protocol::models::BaseInstructions;
 use codex_protocol::models::ContentItem;
@@ -285,33 +284,9 @@ pub(crate) async fn run_turn(
         })
         .collect::<Vec<_>>();
 
-    if run_pending_session_start_hooks(&sess, &turn_context).await {
+    if !drain_turn_start_transcript_inputs(&sess, &turn_context).await {
         return None;
     }
-    let additional_contexts = if input.is_empty() {
-        Vec::new()
-    } else {
-        let initial_input_for_turn: ResponseInputItem = ResponseInputItem::from(input.clone());
-        let response_item: ResponseItem = initial_input_for_turn.clone().into();
-        let user_prompt_submit_outcome = run_user_prompt_submit_hooks(
-            &sess,
-            &turn_context,
-            UserMessageItem::new(&input).message(),
-        )
-        .await;
-        if user_prompt_submit_outcome.should_stop {
-            record_additional_contexts(
-                &sess,
-                &turn_context,
-                user_prompt_submit_outcome.additional_contexts,
-            )
-            .await;
-            return None;
-        }
-        sess.record_user_prompt_and_emit_turn_item(turn_context.as_ref(), &input, response_item)
-            .await;
-        user_prompt_submit_outcome.additional_contexts
-    };
     sess.services
         .analytics_events_client
         .track_app_mentioned(tracking.clone(), mentioned_app_invocations);
@@ -322,7 +297,6 @@ pub(crate) async fn run_turn(
     }
     sess.merge_connector_selection(explicitly_enabled_connectors.clone())
         .await;
-    record_additional_contexts(&sess, &turn_context, additional_contexts).await;
     if !input.is_empty() {
         // Track the previous-turn baseline from the regular user-turn path only so
         // standalone tasks (compact/shell/review/undo) cannot suppress future

--- a/codex-rs/core/src/session/turn_context.rs
+++ b/codex-rs/core/src/session/turn_context.rs
@@ -72,7 +72,7 @@ pub(crate) struct TurnContext {
     pub(crate) turn_skills: TurnSkillsContext,
     pub(crate) turn_timing_state: Arc<TurnTimingState>,
     pub(crate) turn_start_transcript_inputs: Arc<Mutex<Vec<Vec<UserInput>>>>,
-    pub(crate) transcript_serialization_lock: Arc<Mutex<()>>,
+    pub(crate) transcript_serialization_lock: Arc<Semaphore>,
 }
 impl TurnContext {
     pub(crate) fn model_context_window(&self) -> Option<i64> {
@@ -448,7 +448,7 @@ impl Session {
             turn_skills: TurnSkillsContext::new(skills_outcome),
             turn_timing_state: Arc::new(TurnTimingState::default()),
             turn_start_transcript_inputs: Arc::new(Mutex::new(Vec::new())),
-            transcript_serialization_lock: Arc::new(Mutex::new(())),
+            transcript_serialization_lock: Arc::new(Semaphore::new(1)),
         }
     }
 

--- a/codex-rs/core/src/session/turn_context.rs
+++ b/codex-rs/core/src/session/turn_context.rs
@@ -27,14 +27,6 @@ impl TurnSkillsContext {
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct TurnStartTranscriptInput {
     pub(crate) input: Vec<UserInput>,
-    pub(crate) user_prompt_submit_outcome: Option<TurnStartUserPromptSubmitOutcome>,
-    pub(crate) user_prompt_recorded: bool,
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub(crate) struct TurnStartUserPromptSubmitOutcome {
-    pub(crate) should_stop: bool,
-    pub(crate) additional_contexts: Vec<String>,
 }
 
 /// The context needed for a single turn of the thread.

--- a/codex-rs/core/src/session/turn_context.rs
+++ b/codex-rs/core/src/session/turn_context.rs
@@ -24,6 +24,19 @@ impl TurnSkillsContext {
     }
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct TurnStartTranscriptInput {
+    pub(crate) input: Vec<UserInput>,
+    pub(crate) user_prompt_submit_outcome: Option<TurnStartUserPromptSubmitOutcome>,
+    pub(crate) user_prompt_recorded: bool,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct TurnStartUserPromptSubmitOutcome {
+    pub(crate) should_stop: bool,
+    pub(crate) additional_contexts: Vec<String>,
+}
+
 /// The context needed for a single turn of the thread.
 #[derive(Debug)]
 pub(crate) struct TurnContext {
@@ -71,10 +84,18 @@ pub(crate) struct TurnContext {
     pub(crate) turn_metadata_state: Arc<TurnMetadataState>,
     pub(crate) turn_skills: TurnSkillsContext,
     pub(crate) turn_timing_state: Arc<TurnTimingState>,
-    pub(crate) turn_start_transcript_inputs: Arc<Mutex<Vec<Vec<UserInput>>>>,
+    pub(crate) turn_start_transcript_inputs: Arc<std::sync::Mutex<Vec<TurnStartTranscriptInput>>>,
     pub(crate) transcript_serialization_lock: Arc<Semaphore>,
 }
 impl TurnContext {
+    pub(crate) fn lock_turn_start_transcript_inputs(
+        &self,
+    ) -> std::sync::MutexGuard<'_, Vec<TurnStartTranscriptInput>> {
+        self.turn_start_transcript_inputs
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
     pub(crate) fn model_context_window(&self) -> Option<i64> {
         let effective_context_window_percent = self.model_info.effective_context_window_percent;
         self.model_info
@@ -447,7 +468,7 @@ impl Session {
             turn_metadata_state,
             turn_skills: TurnSkillsContext::new(skills_outcome),
             turn_timing_state: Arc::new(TurnTimingState::default()),
-            turn_start_transcript_inputs: Arc::new(Mutex::new(Vec::new())),
+            turn_start_transcript_inputs: Arc::new(std::sync::Mutex::new(Vec::new())),
             transcript_serialization_lock: Arc::new(Semaphore::new(1)),
         }
     }

--- a/codex-rs/core/src/session/turn_context.rs
+++ b/codex-rs/core/src/session/turn_context.rs
@@ -71,6 +71,8 @@ pub(crate) struct TurnContext {
     pub(crate) turn_metadata_state: Arc<TurnMetadataState>,
     pub(crate) turn_skills: TurnSkillsContext,
     pub(crate) turn_timing_state: Arc<TurnTimingState>,
+    pub(crate) turn_start_transcript_inputs: Arc<Mutex<Vec<Vec<UserInput>>>>,
+    pub(crate) transcript_serialization_lock: Arc<Mutex<()>>,
 }
 impl TurnContext {
     pub(crate) fn model_context_window(&self) -> Option<i64> {
@@ -197,6 +199,8 @@ impl TurnContext {
             turn_metadata_state: self.turn_metadata_state.clone(),
             turn_skills: self.turn_skills.clone(),
             turn_timing_state: Arc::clone(&self.turn_timing_state),
+            turn_start_transcript_inputs: Arc::clone(&self.turn_start_transcript_inputs),
+            transcript_serialization_lock: Arc::clone(&self.transcript_serialization_lock),
         }
     }
 
@@ -443,6 +447,8 @@ impl Session {
             turn_metadata_state,
             turn_skills: TurnSkillsContext::new(skills_outcome),
             turn_timing_state: Arc::new(TurnTimingState::default()),
+            turn_start_transcript_inputs: Arc::new(Mutex::new(Vec::new())),
+            transcript_serialization_lock: Arc::new(Mutex::new(())),
         }
     }
 

--- a/codex-rs/core/src/state/turn.rs
+++ b/codex-rs/core/src/state/turn.rs
@@ -70,6 +70,7 @@ pub(crate) struct RunningTask {
     pub(crate) done: Arc<Notify>,
     pub(crate) kind: TaskKind,
     pub(crate) task: Arc<dyn AnySessionTask>,
+    pub(crate) records_turn_start_transcript: bool,
     pub(crate) cancellation_token: CancellationToken,
     pub(crate) handle: Arc<AbortOnDropHandle<()>>,
     pub(crate) turn_context: Arc<TurnContext>,

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -22,6 +22,7 @@ use tracing::warn;
 use crate::contextual_user_message::TURN_ABORTED_CLOSE_TAG;
 use crate::contextual_user_message::TURN_ABORTED_OPEN_TAG;
 use crate::hook_runtime::PendingInputHookDisposition;
+use crate::hook_runtime::TurnStartTranscriptDrainMode;
 use crate::hook_runtime::drain_turn_start_transcript_inputs;
 use crate::hook_runtime::inspect_pending_input;
 use crate::hook_runtime::record_additional_contexts;
@@ -306,8 +307,6 @@ impl Session {
                 .lock_turn_start_transcript_inputs()
                 .push(TurnStartTranscriptInput {
                     input: input.clone(),
-                    user_prompt_submit_outcome: None,
-                    user_prompt_recorded: false,
                 });
         }
         let mut active = self.active_turn.lock().await;
@@ -629,6 +628,24 @@ impl Session {
             .cancel_git_enrichment_task();
         let session_task = task.task;
 
+        // The startup prompt queue is serialized by the regular turn itself. If an interrupt
+        // lands while that serialization is in progress, wait for the shared drain to finish
+        // before force-aborting the task so history cannot be left half-written.
+        if reason == TurnAbortReason::Interrupted && task.kind == TaskKind::Regular {
+            let has_turn_start_transcript_input = {
+                let inputs = task.turn_context.lock_turn_start_transcript_inputs();
+                !inputs.is_empty()
+            };
+            if has_turn_start_transcript_input {
+                let _ = drain_turn_start_transcript_inputs(
+                    self,
+                    &task.turn_context,
+                    TurnStartTranscriptDrainMode::InterruptRecovery,
+                )
+                .await;
+            }
+        }
+
         select! {
             _ = task.done.notified() => {
             },
@@ -638,16 +655,6 @@ impl Session {
         }
 
         task.handle.abort();
-
-        if reason == TurnAbortReason::Interrupted && task.kind == TaskKind::Regular {
-            let has_turn_start_transcript_input = {
-                let inputs = task.turn_context.lock_turn_start_transcript_inputs();
-                !inputs.is_empty()
-            };
-            if has_turn_start_transcript_input {
-                let _ = drain_turn_start_transcript_inputs(self, &task.turn_context).await;
-            }
-        }
 
         let session_ctx = Arc::new(SessionTaskContext::new(Arc::clone(self)));
         session_task

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -24,6 +24,7 @@ use crate::contextual_user_message::TURN_ABORTED_OPEN_TAG;
 use crate::hook_runtime::PendingInputHookDisposition;
 use crate::hook_runtime::TurnStartTranscriptDrainMode;
 use crate::hook_runtime::drain_turn_start_transcript_inputs;
+use crate::hook_runtime::drain_turn_start_transcript_inputs_with_permit;
 use crate::hook_runtime::inspect_pending_input;
 use crate::hook_runtime::record_additional_contexts;
 use crate::hook_runtime::record_pending_input;
@@ -163,6 +164,11 @@ pub(crate) trait SessionTask: Send + Sync + 'static {
     /// Returns the tracing name for a spawned task span.
     fn span_name(&self) -> &'static str;
 
+    /// Whether this task owns the normal user-turn transcript start sequence.
+    fn records_turn_start_transcript(&self) -> bool {
+        false
+    }
+
     /// Executes the task until completion or cancellation.
     ///
     /// Implementations typically stream protocol events using `session` and
@@ -200,6 +206,8 @@ pub(crate) trait AnySessionTask: Send + Sync + 'static {
 
     fn span_name(&self) -> &'static str;
 
+    fn records_turn_start_transcript(&self) -> bool;
+
     fn run(
         self: Arc<Self>,
         session: Arc<SessionTaskContext>,
@@ -225,6 +233,10 @@ where
 
     fn span_name(&self) -> &'static str {
         SessionTask::span_name(self)
+    }
+
+    fn records_turn_start_transcript(&self) -> bool {
+        SessionTask::records_turn_start_transcript(self)
     }
 
     fn run(
@@ -273,6 +285,7 @@ impl Session {
         let task: Arc<dyn AnySessionTask> = Arc::new(task);
         let task_kind = task.kind();
         let span_name = task.span_name();
+        let records_turn_start_transcript = task.records_turn_start_transcript();
         let started_at = Instant::now();
         turn_context
             .turn_timing_state
@@ -302,7 +315,7 @@ impl Session {
             }
         }
 
-        if task_kind == TaskKind::Regular && !input.is_empty() {
+        if records_turn_start_transcript && !input.is_empty() {
             turn_context
                 .lock_turn_start_transcript_inputs()
                 .push(TurnStartTranscriptInput {
@@ -368,6 +381,7 @@ impl Session {
             handle: Arc::new(AbortOnDropHandle::new(handle)),
             kind: task_kind,
             task,
+            records_turn_start_transcript,
             cancellation_token,
             turn_context: Arc::clone(&turn_context),
             _timer: timer,
@@ -628,35 +642,58 @@ impl Session {
             .cancel_git_enrichment_task();
         let session_task = task.task;
 
-        // The startup prompt queue is serialized by the regular turn itself. If an interrupt
-        // lands while that serialization is in progress, wait for the shared drain to finish
-        // before force-aborting the task so history cannot be left half-written. This can wait
-        // on turn-start hooks, but it keeps hook policy and hook-added context ahead of the
-        // model-visible interrupt marker.
-        if reason == TurnAbortReason::Interrupted && task.kind == TaskKind::Regular {
+        let mut handle_aborted = false;
+        // The startup prompt queue is serialized by the regular turn itself. If the serializer is
+        // idle, grab it and abort the task before recovering the queued prompt; if the serializer
+        // is already active, wait for it to finish before force-aborting so history cannot be left
+        // half-written. This can wait on turn-start hooks, but it keeps hook policy and hook-added
+        // context ahead of the model-visible interrupt marker.
+        if reason == TurnAbortReason::Interrupted && task.records_turn_start_transcript {
             let has_turn_start_transcript_input = {
                 let inputs = task.turn_context.lock_turn_start_transcript_inputs();
                 !inputs.is_empty()
             };
             if has_turn_start_transcript_input {
-                let _ = drain_turn_start_transcript_inputs(
-                    self,
-                    &task.turn_context,
-                    TurnStartTranscriptDrainMode::InterruptRecovery,
-                )
-                .await;
+                match task
+                    .turn_context
+                    .transcript_serialization_lock
+                    .clone()
+                    .try_acquire_owned()
+                {
+                    Ok(permit) => {
+                        task.handle.abort();
+                        handle_aborted = true;
+                        let _ = drain_turn_start_transcript_inputs_with_permit(
+                            self,
+                            &task.turn_context,
+                            TurnStartTranscriptDrainMode::InterruptRecovery,
+                            permit,
+                        )
+                        .await;
+                    }
+                    Err(_) => {
+                        let _ = drain_turn_start_transcript_inputs(
+                            self,
+                            &task.turn_context,
+                            TurnStartTranscriptDrainMode::InterruptRecovery,
+                        )
+                        .await;
+                    }
+                }
             }
         }
 
-        select! {
-            _ = task.done.notified() => {
-            },
-            _ = tokio::time::sleep(Duration::from_millis(GRACEFULL_INTERRUPTION_TIMEOUT_MS)) => {
-                warn!("task {sub_id} didn't complete gracefully after {}ms", GRACEFULL_INTERRUPTION_TIMEOUT_MS);
+        if !handle_aborted {
+            select! {
+                _ = task.done.notified() => {
+                },
+                _ = tokio::time::sleep(Duration::from_millis(GRACEFULL_INTERRUPTION_TIMEOUT_MS)) => {
+                    warn!("task {sub_id} didn't complete gracefully after {}ms", GRACEFULL_INTERRUPTION_TIMEOUT_MS);
+                }
             }
-        }
 
-        task.handle.abort();
+            task.handle.abort();
+        }
 
         let session_ctx = Arc::new(SessionTaskContext::new(Arc::clone(self)));
         session_task

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -630,7 +630,9 @@ impl Session {
 
         // The startup prompt queue is serialized by the regular turn itself. If an interrupt
         // lands while that serialization is in progress, wait for the shared drain to finish
-        // before force-aborting the task so history cannot be left half-written.
+        // before force-aborting the task so history cannot be left half-written. This can wait
+        // on turn-start hooks, but it keeps hook policy and hook-added context ahead of the
+        // model-visible interrupt marker.
         if reason == TurnAbortReason::Interrupted && task.kind == TaskKind::Regular {
             let has_turn_start_transcript_input = {
                 let inputs = task.turn_context.lock_turn_start_transcript_inputs();

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -300,12 +300,6 @@ impl Session {
             }
         }
 
-        let mut active = self.active_turn.lock().await;
-        let turn = active.get_or_insert_with(ActiveTurn::default);
-        debug_assert!(turn.tasks.is_empty());
-        let done_clone = Arc::clone(&done);
-        let session_ctx = Arc::new(SessionTaskContext::new(Arc::clone(self)));
-        let ctx = Arc::clone(&turn_context);
         if task_kind == TaskKind::Regular && !input.is_empty() {
             turn_context
                 .turn_start_transcript_inputs
@@ -313,6 +307,12 @@ impl Session {
                 .await
                 .push(input.clone());
         }
+        let mut active = self.active_turn.lock().await;
+        let turn = active.get_or_insert_with(ActiveTurn::default);
+        debug_assert!(turn.tasks.is_empty());
+        let done_clone = Arc::clone(&done);
+        let session_ctx = Arc::new(SessionTaskContext::new(Arc::clone(self)));
+        let ctx = Arc::clone(&turn_context);
         let task_for_run = Arc::clone(&task);
         let task_cancellation_token = cancellation_token.child_token();
         // Task-owned turn spans keep a core-owned span open for the
@@ -626,11 +626,6 @@ impl Session {
             .cancel_git_enrichment_task();
         let session_task = task.task;
 
-        if reason == TurnAbortReason::Interrupted {
-            self.cleanup_after_interrupt(&task.turn_context).await;
-            let _ = drain_turn_start_transcript_inputs(self, &task.turn_context).await;
-        }
-
         select! {
             _ = task.done.notified() => {
             },
@@ -641,12 +636,26 @@ impl Session {
 
         task.handle.abort();
 
+        if reason == TurnAbortReason::Interrupted && task.kind == TaskKind::Regular {
+            let has_turn_start_transcript_input = !task
+                .turn_context
+                .turn_start_transcript_inputs
+                .lock()
+                .await
+                .is_empty();
+            if has_turn_start_transcript_input {
+                let _ = drain_turn_start_transcript_inputs(self, &task.turn_context).await;
+            }
+        }
+
         let session_ctx = Arc::new(SessionTaskContext::new(Arc::clone(self)));
         session_task
             .abort(session_ctx, Arc::clone(&task.turn_context))
             .await;
 
         if reason == TurnAbortReason::Interrupted {
+            self.cleanup_after_interrupt(&task.turn_context).await;
+
             let marker = interrupted_turn_history_marker();
             self.record_into_history(std::slice::from_ref(&marker), task.turn_context.as_ref())
                 .await;

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -22,6 +22,7 @@ use tracing::warn;
 use crate::contextual_user_message::TURN_ABORTED_CLOSE_TAG;
 use crate::contextual_user_message::TURN_ABORTED_OPEN_TAG;
 use crate::hook_runtime::PendingInputHookDisposition;
+use crate::hook_runtime::drain_turn_start_transcript_inputs;
 use crate::hook_runtime::inspect_pending_input;
 use crate::hook_runtime::record_additional_contexts;
 use crate::hook_runtime::record_pending_input;
@@ -305,6 +306,13 @@ impl Session {
         let done_clone = Arc::clone(&done);
         let session_ctx = Arc::new(SessionTaskContext::new(Arc::clone(self)));
         let ctx = Arc::clone(&turn_context);
+        if task_kind == TaskKind::Regular && !input.is_empty() {
+            turn_context
+                .turn_start_transcript_inputs
+                .lock()
+                .await
+                .push(input.clone());
+        }
         let task_for_run = Arc::clone(&task);
         let task_cancellation_token = cancellation_token.child_token();
         // Task-owned turn spans keep a core-owned span open for the
@@ -618,6 +626,11 @@ impl Session {
             .cancel_git_enrichment_task();
         let session_task = task.task;
 
+        if reason == TurnAbortReason::Interrupted {
+            self.cleanup_after_interrupt(&task.turn_context).await;
+            let _ = drain_turn_start_transcript_inputs(self, &task.turn_context).await;
+        }
+
         select! {
             _ = task.done.notified() => {
             },
@@ -634,8 +647,6 @@ impl Session {
             .await;
 
         if reason == TurnAbortReason::Interrupted {
-            self.cleanup_after_interrupt(&task.turn_context).await;
-
             let marker = interrupted_turn_history_marker();
             self.record_into_history(std::slice::from_ref(&marker), task.turn_context.as_ref())
                 .await;

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -28,6 +28,7 @@ use crate::hook_runtime::record_additional_contexts;
 use crate::hook_runtime::record_pending_input;
 use crate::session::session::Session;
 use crate::session::turn_context::TurnContext;
+use crate::session::turn_context::TurnStartTranscriptInput;
 use crate::state::ActiveTurn;
 use crate::state::RunningTask;
 use crate::state::TaskKind;
@@ -302,10 +303,12 @@ impl Session {
 
         if task_kind == TaskKind::Regular && !input.is_empty() {
             turn_context
-                .turn_start_transcript_inputs
-                .lock()
-                .await
-                .push(input.clone());
+                .lock_turn_start_transcript_inputs()
+                .push(TurnStartTranscriptInput {
+                    input: input.clone(),
+                    user_prompt_submit_outcome: None,
+                    user_prompt_recorded: false,
+                });
         }
         let mut active = self.active_turn.lock().await;
         let turn = active.get_or_insert_with(ActiveTurn::default);
@@ -637,12 +640,10 @@ impl Session {
         task.handle.abort();
 
         if reason == TurnAbortReason::Interrupted && task.kind == TaskKind::Regular {
-            let has_turn_start_transcript_input = !task
-                .turn_context
-                .turn_start_transcript_inputs
-                .lock()
-                .await
-                .is_empty();
+            let has_turn_start_transcript_input = {
+                let inputs = task.turn_context.lock_turn_start_transcript_inputs();
+                !inputs.is_empty()
+            };
             if has_turn_start_transcript_input {
                 let _ = drain_turn_start_transcript_inputs(self, &task.turn_context).await;
             }

--- a/codex-rs/core/src/tasks/regular.rs
+++ b/codex-rs/core/src/tasks/regular.rs
@@ -33,6 +33,10 @@ impl SessionTask for RegularTask {
         "session_task.turn"
     }
 
+    fn records_turn_start_transcript(&self) -> bool {
+        true
+    }
+
     async fn run(
         self: Arc<Self>,
         session: Arc<SessionTaskContext>,


### PR DESCRIPTION
## Summary

Fixes a race where a regular turn could emit `TurnStarted` before the initial user prompt was recorded. If the app interrupted in that window, core could persist `<turn_aborted>` without ever saving the prompt that started the turn.

This change queues accepted regular-turn startup input on the turn context, serializes startup transcript writes through a per-turn lock, and has the interrupt path drain that queue before writing the interrupted-turn marker.

## Root cause

The old regular-turn path recorded the initial user prompt inside `run_turn()`, after client-visible turn startup had already happened. The interrupt path could therefore run before prompt recording and append the abort marker to history first, or as the only item.

## What changed

- Add per-turn storage for startup transcript input and a per-turn serialization lock.
- Queue non-empty regular-turn input before spawning the regular task.
- Move startup prompt serialization into a shared drain helper that runs session-start hooks, user-prompt-submit hooks, prompt recording, and hook additional-context recording.
- Call the same drain helper from the interrupt path before appending `<turn_aborted>`.
- Add a deterministic regression test that asserts interrupted history contains the original user prompt before the abort marker.

## Validation

Passed:

- `just fmt`
- `just fix -p codex-core`
- `git diff --check`
- `cargo test -p codex-core abort_regular_task_records_prompt_before_interrupt_marker`
- `cargo test -p codex-core regular_turn_emits_turn_started_without_waiting_for_startup_prewarm`
- `cargo test -p codex-core interrupting_regular_turn_waiting_on_startup_prewarm_emits_turn_aborted`
- `cargo test -p codex-core blocked_user_prompt_submit_persists_additional_context_for_next_turn`
- `cargo test -p codex-core user_message_item_is_emitted`
- `cargo test -p codex-core abort_review_task_emits_exited_then_aborted_and_records_history`

Also attempted `cargo test -p codex-core`. The lib/unit portion passed (`1682 passed; 0 failed; 3 ignored`), but the integration `tests/all.rs` portion had local environment failures in approval/otel/user-shell env isolation tests. CI should provide the authoritative full-suite signal.