### PR TITLE
[codex] Tighten code review skill wording

### DIFF
--- a/.codex/skills/code-review/SKILL.md
+++ b/.codex/skills/code-review/SKILL.md
@@ -5,7 +5,7 @@ description: Run a final code review on a pull request
 
 Use subagents to review code using all code-review-* skills in this repository other than this orchestrator. One subagent per skill. Pass full skill path to subagents. Use xhigh reasoning.
 
-Make sure to return every single issue. You can return an unlimited number of findings.
+You must return every single issue from every subagent. You can return an unlimited number of findings.
 Use raw Markdown to report findings.
 Number findings for ease of reference.
 Each finding must include a specific file path and line number.


### PR DESCRIPTION
## Summary

This updates the code review orchestrator skill wording so the instruction explicitly requires returning every issue from every subagent.

## Impact

The change is limited to `.codex/skills/code-review/SKILL.md` and clarifies review aggregation behavior for future Codex-driven reviews.

## Validation

No tests were run because this is a markdown-only skill wording change.