### PR TITLE
build: reduce Rust dev debuginfo

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -65,6 +65,10 @@ common:ci --verbose_failures
 common:ci --build_metadata=REPO_URL=https://github.com/openai/codex.git
 common:ci --build_metadata=ROLE=CI
 common:ci --build_metadata=VISIBILITY=PUBLIC
+# rules_rust derives debug level from Bazel toolchain/compilation-mode settings,
+# not Cargo profiles. Keep CI Rust actions explicit and lean.
+common:ci --@rules_rust//rust/settings:extra_rustc_flag=-Cdebuginfo=0
+common:ci --@rules_rust//rust/settings:extra_exec_rustc_flag=-Cdebuginfo=0
 
 # Disable disk cache in CI since we have a remote one and aren't using persistent workers.
 common:ci --disk_cache=

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -430,6 +430,11 @@ ignored = [
     "codex-v8-poc",
 ]
 
+[profile.dev]
+# Keep line tables/backtraces while avoiding expensive full variable debug info
+# across local dev builds.
+debug = 1
+
 [profile.dev-small]
 inherits = "dev"
 opt-level = 0


### PR DESCRIPTION
## What changed

This PR makes the default Cargo dev profile use line-tables-only debug info:

```toml
[profile.dev]
debug = 1
```

That keeps useful backtraces while avoiding the cost of full variable debug
info in normal local dev builds.

This also makes the Bazel CI setting explicit with `-Cdebuginfo=0` for target
and exec-configuration Rust actions. Bazel/rules_rust does not read Cargo
profiles for this setting, and the current fastbuild action already emitted
`--codegen=debuginfo=0`; the Bazel part of this PR makes that choice direct in
our build configuration.

## Why

The slow codex-core rebuilds are dominated by debug-info codegen, not parsing
or type checking. On a warm-dependency package rebuild, the baseline
codex-core compile was about 39.5s wall / 38.9s rustc total, with
codegen_crate around 14.0s and LLVM_passes around 13.4s. Setting codex-core
to line-tables-only debug info brought that to about 27.2s wall / 26.7s rustc
total, with codegen_crate around 3.1s and LLVM_passes around 2.8s.

`debug = 0` was only about another 0.7s faster than `debug = 1` in the
codex-core measurement, so `debug = 1` is the better default dev tradeoff: it
captures nearly all of the compile-time win while preserving basic
debuggability.

I also sampled other first-party crates instead of keeping a codex-core-only
package override. codex-app-server showed the same pattern: rustc total
dropped from 15.85s to 10.48s, while codegen_crate plus LLVM_passes dropped
from about 13.47s to 3.23s. codex-app-server-protocol had a smaller but still
real improvement, 16.05s to 14.58s total, and smaller crates showed modest
wins. That points to a workspace dev-profile policy rather than a
hand-maintained list of large crates.

## Relationship to #18612

[#18612](https://github.com/openai/codex/pull/18612) added the `dev-small`
profile. That remains useful when someone wants a working local build quickly
and is willing to opt in with `cargo build --profile dev-small`.

This PR is deliberately less aggressive: it changes the common default dev
profile while preserving line tables/backtraces. `dev-small` remains the
explicit "build quickly, no debuggability concern" path.

## Other investigation

I looked for another structural win comparable to
[#16631](https://github.com/openai/codex/pull/16631) and
[#16630](https://github.com/openai/codex/pull/16630), but did not find one.
The attempted TOML monomorphization changes were noisy or worse in
measurement, and the async task changes reduced some instantiations but only
translated to roughly a one-second improvement while being much more
disruptive. The debug-info setting was the one repeatable, material win that
survived measurement.

## Verification

- `just bazel-lock-update`
- `just bazel-lock-check`
- `cargo check -p codex-core --lib`
- `cargo test -p codex-core --lib`
- Bazel `aquery --config=ci-linux` confirmed `--codegen=debuginfo=0` and
  `-Cdebuginfo=0` for `//codex-rs/core:core`


---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/18844).
* #18846
* __->__ #18844
