### PR TITLE
Stabilize debug clear memories integration test

### DIFF
--- a/codex-rs/cli/tests/debug_clear_memories.rs
+++ b/codex-rs/cli/tests/debug_clear_memories.rs
@@ -105,7 +105,7 @@ INSERT INTO jobs (
     let memory_root = codex_home.path().join("memories");
     std::fs::create_dir_all(&memory_root)?;
     std::fs::write(memory_root.join("memory_summary.md"), "stale memory")?;
-    drop(pool);
+    pool.close().await;
 
     let mut cmd = codex_command(codex_home.path())?;
     cmd.args(["debug", "clear-memories"])
@@ -127,6 +127,7 @@ INSERT INTO jobs (
     assert_eq!(memory_jobs_count, 0);
     assert!(memory_root.exists());
     assert_eq!(std::fs::read_dir(memory_root)?.count(), 0);
+    pool.close().await;
 
     Ok(())
 }


### PR DESCRIPTION
## Why

`debug_clear_memories_resets_state_and_removes_memory_dir` can be flaky because the test drops its `sqlx::SqlitePool` immediately before invoking `codex debug clear-memories`. Dropping the pool does not wait for all SQLite connections to close, so the CLI can race with still-open test connections.

## What changed

- Await `pool.close()` before spawning `codex debug clear-memories`.
- Close the reopened verification pool before the temp `CODEX_HOME` is torn down.

## Verification

- `cargo test -p codex-cli --test debug_clear_memories debug_clear_memories_resets_state_and_removes_memory_dir`