### PR TITLE
test(tui): update status surface snapshots

### DIFF
--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__status_line_setup_popup_hardcoded_only.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__status_line_setup_popup_hardcoded_only.snap
@@ -7,14 +7,14 @@ expression: status_line_popup_snapshot(&mut chat)
 
   Type to search
   >
-› [x] project-root          Project root directory (omitted when unavailable)
+› [x] project-name          Project name (omitted when unavailable)
   [x] git-branch            Current Git branch (omitted when unavailable)
-  [x] thread-title          Current thread title (omitted unless changed by user)
-  [ ] model-name            Current model name
+  [x] thread-title          Current thread title (omitted when unavailable)
+  [ ] model                 Current model name
   [ ] model-with-reasoning  Current model name with reasoning level
   [ ] current-dir           Current working directory
+  [ ] run-state             Compact session run-state text (Ready, Working, Thinking)
   [ ] context-remaining     Percentage of context window remaining (omitted when unknown)
-  [ ] context-used          Percentage of context window used (omitted when unknown)
 
   my-project · feat/awesome-feature · thread title
   Use ↑↓ to navigate, ←→ to move, space to select, enter to confirm, esc to cancel.

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__status_line_setup_popup_live_only.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__status_line_setup_popup_live_only.snap
@@ -7,14 +7,14 @@ expression: status_line_popup_snapshot(&mut chat)
 
   Type to search
   >
-› [x] project-root          Project root directory (omitted when unavailable)
+› [x] project-name          Project name (omitted when unavailable)
   [x] git-branch            Current Git branch (omitted when unavailable)
-  [x] thread-title          Current thread title (omitted unless changed by user)
-  [ ] model-name            Current model name
+  [x] thread-title          Current thread title (omitted when unavailable)
+  [ ] model                 Current model name
   [ ] model-with-reasoning  Current model name with reasoning level
   [ ] current-dir           Current working directory
+  [ ] run-state             Compact session run-state text (Ready, Working, Thinking)
   [ ] context-remaining     Percentage of context window remaining (omitted when unknown)
-  [ ] context-used          Percentage of context window used (omitted when unknown)
 
   preview-live-root · feature/live-preview-branch · Live preview thread
   Use ↑↓ to navigate, ←→ to move, space to select, enter to confirm, esc to cancel.

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__status_line_setup_popup_mixed.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__status_line_setup_popup_mixed.snap
@@ -7,14 +7,14 @@ expression: status_line_popup_snapshot(&mut chat)
 
   Type to search
   >
-› [x] project-root          Project root directory (omitted when unavailable)
+› [x] project-name          Project name (omitted when unavailable)
   [x] git-branch            Current Git branch (omitted when unavailable)
-  [x] thread-title          Current thread title (omitted unless changed by user)
-  [ ] model-name            Current model name
+  [x] thread-title          Current thread title (omitted when unavailable)
+  [ ] model                 Current model name
   [ ] model-with-reasoning  Current model name with reasoning level
   [ ] current-dir           Current working directory
+  [ ] run-state             Compact session run-state text (Ready, Working, Thinking)
   [ ] context-remaining     Percentage of context window remaining (omitted when unknown)
-  [ ] context-used          Percentage of context window used (omitted when unknown)
 
   my-project · feature/mixed-preview · Mixed preview thread
   Use ↑↓ to navigate, ←→ to move, space to select, enter to confirm, esc to cancel.

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__terminal_title_setup_popup_hardcoded_only.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__terminal_title_setup_popup_hardcoded_only.snap
@@ -7,14 +7,14 @@ expression: terminal_title_popup_snapshot(&mut chat)
 
   Type to search
   >
-› [x] thread         Current thread title (omitted until available)
+› [x] thread-title   Current thread title (omitted when unavailable)
   [x] git-branch     Current Git branch (omitted when unavailable)
   [x] task-progress  Latest task progress from update_plan (omitted until available)
   [ ] app-name       Codex app name
-  [ ] project        Project name (falls back to current directory name)
+  [ ] project-name   Project name (falls back to current directory name)
+  [ ] current-dir    Current working directory
   [ ] spinner        Animated task spinner (omitted while idle or when animations are off)
   [ ] run-state      Compact session run-state text (Ready, Working, Thinking)
-  [ ] model          Current model name
 
   thread title | feat/awesome-feature | Tasks 0/0
   Use ↑↓ to navigate, ←→ to move, space to select, enter to confirm, esc to cancel.

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__terminal_title_setup_popup_live_only.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__terminal_title_setup_popup_live_only.snap
@@ -7,14 +7,14 @@ expression: terminal_title_popup_snapshot(&mut chat)
 
   Type to search
   >
-› [x] project        Project name (falls back to current directory name)
-  [x] thread         Current thread title (omitted until available)
+› [x] project-name   Project name (falls back to current directory name)
+  [x] thread-title   Current thread title (omitted when unavailable)
   [x] git-branch     Current Git branch (omitted when unavailable)
   [x] task-progress  Latest task progress from update_plan (omitted until available)
   [ ] app-name       Codex app name
+  [ ] current-dir    Current working directory
   [ ] spinner        Animated task spinner (omitted while idle or when animations are off)
   [ ] run-state      Compact session run-state text (Ready, Working, Thinking)
-  [ ] model          Current model name
 
   preview-live-root | Live preview thread | feature/live-preview-branch | Tasks 2/5
   Use ↑↓ to navigate, ←→ to move, space to select, enter to confirm, esc to cancel.

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__terminal_title_setup_popup_mixed.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__terminal_title_setup_popup_mixed.snap
@@ -7,14 +7,14 @@ expression: terminal_title_popup_snapshot(&mut chat)
 
   Type to search
   >
-› [x] project        Project name (falls back to current directory name)
-  [x] thread         Current thread title (omitted until available)
+› [x] project-name   Project name (falls back to current directory name)
+  [x] thread-title   Current thread title (omitted when unavailable)
   [x] task-progress  Latest task progress from update_plan (omitted until available)
   [ ] app-name       Codex app name
+  [ ] current-dir    Current working directory
   [ ] spinner        Animated task spinner (omitted while idle or when animations are off)
   [ ] run-state      Compact session run-state text (Ready, Working, Thinking)
   [ ] git-branch     Current Git branch (omitted when unavailable)
-  [ ] model          Current model name
 
   project | Mixed preview thread | Tasks 0/0
   Use ↑↓ to navigate, ←→ to move, space to select, enter to confirm, esc to cancel.


### PR DESCRIPTION
## Why

There appears to be a Bazel vs. Cargo test coverage mismatch which should be fixed by https://github.com/openai/codex/pull/18913. This PR aims to fix the missed tests before updating the Bazel config.

`cargo test -p codex-tui` was failing because a small set of committed TUI snapshots no longer matched the current status-surface item labels and descriptions. Those stale snapshots covered the status-line and terminal-title setup popups under `tui/src/chatwidget/snapshots`.

This PR intentionally isolates only the expected-output updates. The follow-up stacked PR changes the Bazel test launcher behavior; keeping the snapshot churn separate makes that build-system change easier to review.

## What Changed

Updated six `codex-tui` snapshot files for `chatwidget::tests::status_surface_previews`:

- status-line setup snapshots now expect the canonical `project-name` and `model` item labels, the updated `thread-title` description, and the `run-state` option.
- terminal-title setup snapshots now expect `project-name` and `thread-title`, include `current-dir`, and no longer include the removed `model` row.

No production code or Bazel configuration changes are included in this PR.

## Verification

- `cargo test -p codex-tui`
- `cargo insta pending-snapshots --manifest-path tui/Cargo.toml`

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/18912).
* #18913
* __->__ #18912
