### PR TITLE
fix: windows snapshot for external_agent_config_migration::tests::prompt_snapshot did not match windows output

### DIFF
--- a/codex-rs/tui/src/snapshots/codex_tui__external_agent_config_migration__tests__external_agent_config_migration_prompt_windows.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__external_agent_config_migration__tests__external_agent_config_migration_prompt_windows.snap
@@ -2,6 +2,7 @@
 source: tui/src/external_agent_config_migration.rs
 expression: rendered
 ---
+
   > External agent config detected
   We found settings from another agent that you can add to this project.
   Select what to import
@@ -9,7 +10,7 @@ expression: rendered
     [x] Migrate /Users/alex/.claude/settings.json into /Users/alex/.codex/con…
 
   Project: C:\workspace\project
-    [x] Migrate enabled plugins from .claude\settings.json (4 marketplaces, 6…
+    [x] Migrate enabled plugins from .claude/settings.json (4 marketplaces, 6…
         • acme-tools: deployer, formatter, +1 more
         • team-marketplace: asana
         • debug: sample


### PR DESCRIPTION
Fix a snapshot test that is failing on Windows, but is currently missed by Bazel due to https://github.com/openai/codex/pull/18913. We see this failing on Cargo builds on Windows, though.

This Bazel vs. Cargo inconsistency explains why https://github.com/openai/codex/pull/18768 did not fix the Cargo Windows build.