### PR TITLE
Fix /review interrupt and TUI exit wedges

### DIFF
--- a/codex-rs/core/src/codex_delegate.rs
+++ b/codex-rs/core/src/codex_delegate.rs
@@ -94,7 +94,8 @@ pub(crate) async fn run_codex_thread_interactive(
         parent_trace: None,
         analytics_events_client: Some(parent_session.services.analytics_events_client.clone()),
     }))
-    .await?;
+    .or_cancel(&cancel_token)
+    .await??;
     if parent_session.enabled(codex_features::Feature::GeneralAnalytics) {
         let thread_config = codex.thread_config_snapshot().await;
         let client_metadata = parent_session.app_server_client_metadata().await;

--- a/codex-rs/core/src/codex_delegate_tests.rs
+++ b/codex-rs/core/src/codex_delegate_tests.rs
@@ -154,6 +154,32 @@ async fn forward_ops_preserves_submission_trace_context() {
 }
 
 #[tokio::test]
+async fn run_codex_thread_interactive_respects_pre_cancelled_spawn() {
+    let (parent_session, parent_ctx, _rx_events) =
+        crate::session::tests::make_session_and_context_with_rx().await;
+    let cancel_token = CancellationToken::new();
+    cancel_token.cancel();
+
+    let result = timeout(
+        Duration::from_secs(/*secs*/ 1),
+        run_codex_thread_interactive(
+            parent_ctx.config.as_ref().clone(),
+            Arc::clone(&parent_session.services.auth_manager),
+            Arc::clone(&parent_session.services.models_manager),
+            parent_session,
+            parent_ctx,
+            cancel_token,
+            SubAgentSource::Review,
+            /*initial_history*/ None,
+        ),
+    )
+    .await
+    .expect("cancelled delegate spawn should not hang");
+
+    assert!(matches!(result, Err(CodexErr::TurnAborted)));
+}
+
+#[tokio::test]
 async fn handle_request_permissions_uses_tool_call_id_for_round_trip() {
     let (parent_session, parent_ctx, rx_events) =
         crate::session::tests::make_session_and_context_with_rx().await;

--- a/codex-rs/tui/src/app/event_dispatch.rs
+++ b/codex-rs/tui/src/app/event_dispatch.rs
@@ -5,6 +5,8 @@
 
 use super::*;
 
+const SHUTDOWN_FIRST_EXIT_TIMEOUT: Duration = Duration::from_secs(/*secs*/ 2);
+
 impl App {
     pub(super) async fn handle_event(
         &mut self,
@@ -1640,7 +1642,20 @@ impl App {
                 self.pending_shutdown_exit_thread_id =
                     self.active_thread_id.or(self.chat_widget.thread_id());
                 if self.pending_shutdown_exit_thread_id.is_some() {
-                    self.shutdown_current_thread(app_server).await;
+                    // This is a UI escape-hatch budget, not a protocol
+                    // deadline. A healthy local thread/unsubscribe round trip
+                    // should finish comfortably inside two seconds, while a
+                    // longer wait makes Ctrl+C feel broken when the app-server
+                    // is already wedged.
+                    if tokio::time::timeout(
+                        SHUTDOWN_FIRST_EXIT_TIMEOUT,
+                        self.shutdown_current_thread(app_server),
+                    )
+                    .await
+                    .is_err()
+                    {
+                        tracing::warn!("timed out waiting for app-server thread shutdown");
+                    }
                 }
                 self.pending_shutdown_exit_thread_id = None;
                 AppRunControl::Exit(ExitReason::UserRequested)


### PR DESCRIPTION
Addresses #11267

## Summary
`/review` can be interrupted while it is still spawning the review sub-agent. That spawn path lives in `codex-core` and did not observe the task cancellation token until after `Codex::spawn` returned, so an interrupted review could keep building a child session and leave the TUI in a wedged state.

The TUI exit path also waited indefinitely for app-server `thread/unsubscribe`, which made Ctrl+C look broken if the app-server was already stuck. This makes interactive delegate startup cancellation-aware and bounds the TUI shutdown-first unsubscribe wait with a short UI escape-hatch timeout.

## Testing
I reproed the hang using the steps in the bug report. Confirmed hang no longer exists after fix.