### PR TITLE
ci: keep argument comment lint checks materialized

### DIFF
--- a/.github/actions/run-argument-comment-lint/action.yml
+++ b/.github/actions/run-argument-comment-lint/action.yml
@@ -1,0 +1,54 @@
+name: Run argument comment lint
+description: Run argument-comment-lint on codex-rs via Bazel.
+
+inputs:
+  target:
+    description: Runner target passed to setup-bazel-ci.
+    required: true
+  buildbuddy-api-key:
+    description: BuildBuddy API key used by Bazel CI.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - uses: ./.github/actions/setup-bazel-ci
+      with:
+        target: ${{ inputs.target }}
+        install-test-prereqs: true
+
+    - name: Install Linux sandbox build dependencies
+      if: ${{ runner.os == 'Linux' }}
+      shell: bash
+      run: |
+        sudo DEBIAN_FRONTEND=noninteractive apt-get update
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends pkg-config libcap-dev
+
+    - name: Run argument comment lint on codex-rs via Bazel
+      if: ${{ runner.os != 'Windows' }}
+      env:
+        BUILDBUDDY_API_KEY: ${{ inputs.buildbuddy-api-key }}
+      shell: bash
+      run: |
+        bazel_targets="$(./tools/argument-comment-lint/list-bazel-targets.sh)"
+        ./.github/scripts/run-bazel-ci.sh \
+          -- \
+          build \
+          --config=argument-comment-lint \
+          --keep_going \
+          --build_metadata=COMMIT_SHA=${GITHUB_SHA} \
+          -- \
+          ${bazel_targets}
+
+    - name: Run argument comment lint on codex-rs via Bazel
+      if: ${{ runner.os == 'Windows' }}
+      env:
+        BUILDBUDDY_API_KEY: ${{ inputs.buildbuddy-api-key }}
+      shell: bash
+      run: |
+        ./.github/scripts/run-argument-comment-lint-bazel.sh \
+          --config=argument-comment-lint \
+          --platforms=//:local_windows \
+          --keep_going \
+          --build_metadata=COMMIT_SHA=${GITHUB_SHA}

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -41,6 +41,7 @@ jobs:
           for f in "${files[@]}"; do
             [[ $f == codex-rs/* ]] && codex=true
             [[ $f == codex-rs/* || $f == tools/argument-comment-lint/* || $f == justfile ]] && argument_comment_lint=true
+            [[ $f == defs.bzl || $f == workspace_root_test_launcher.sh.tpl || $f == workspace_root_test_launcher.bat.tpl ]] && argument_comment_lint=true
             [[ $f == tools/argument-comment-lint/* || $f == .github/workflows/rust-ci.yml || $f == .github/workflows/rust-ci-full.yml ]] && argument_comment_lint_package=true
             [[ $f == .github/* ]] && workflows=true
           done
@@ -136,7 +137,6 @@ jobs:
     runs-on: ${{ matrix.runs_on || matrix.runner }}
     timeout-minutes: ${{ matrix.timeout_minutes }}
     needs: changed
-    if: ${{ needs.changed.outputs.argument_comment_lint == 'true' || needs.changed.outputs.workflows == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -154,43 +154,28 @@ jobs:
               group: codex-runners
               labels: codex-windows-x64
     steps:
+      - name: Check whether argument comment lint should run
+        id: argument_comment_lint_gate
+        shell: bash
+        env:
+          ARGUMENT_COMMENT_LINT: ${{ needs.changed.outputs.argument_comment_lint }}
+          WORKFLOWS: ${{ needs.changed.outputs.workflows }}
+        run: |
+          if [[ "$ARGUMENT_COMMENT_LINT" == "true" || "$WORKFLOWS" == "true" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "No argument-comment-lint relevant changes."
+          echo "run=false" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: ./.github/actions/setup-bazel-ci
+        if: ${{ steps.argument_comment_lint_gate.outputs.run == 'true' }}
+      - name: Run argument comment lint on codex-rs via Bazel
+        if: ${{ steps.argument_comment_lint_gate.outputs.run == 'true' }}
+        uses: ./.github/actions/run-argument-comment-lint
         with:
           target: ${{ runner.os }}
-          install-test-prereqs: true
-      - name: Install Linux sandbox build dependencies
-        if: ${{ runner.os == 'Linux' }}
-        shell: bash
-        run: |
-          sudo DEBIAN_FRONTEND=noninteractive apt-get update
-          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends pkg-config libcap-dev
-      - name: Run argument comment lint on codex-rs via Bazel
-        if: ${{ runner.os != 'Windows' }}
-        env:
-          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
-        shell: bash
-        run: |
-          bazel_targets="$(./tools/argument-comment-lint/list-bazel-targets.sh)"
-          ./.github/scripts/run-bazel-ci.sh \
-            -- \
-            build \
-            --config=argument-comment-lint \
-            --keep_going \
-            --build_metadata=COMMIT_SHA=${GITHUB_SHA} \
-            -- \
-            ${bazel_targets}
-      - name: Run argument comment lint on codex-rs via Bazel
-        if: ${{ runner.os == 'Windows' }}
-        env:
-          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
-        shell: bash
-        run: |
-          ./.github/scripts/run-argument-comment-lint-bazel.sh \
-            --config=argument-comment-lint \
-            --platforms=//:local_windows \
-            --keep_going \
-            --build_metadata=COMMIT_SHA=${GITHUB_SHA}
+          buildbuddy-api-key: ${{ secrets.BUILDBUDDY_API_KEY }}
 
   # --- Gatherer job that you mark as the ONLY required status -----------------
   results:


### PR DESCRIPTION
## Why

The fast `rust-ci` workflow decides whether to run the cross-platform `argument-comment-lint` job based on changed paths. PRs that touch Rust-adjacent Bazel wrapper files, such as `defs.bzl` or `workspace_root_test_launcher.*.tpl`, can change how Rust tests and lint targets behave without changing any `.rs` files.

When that detector returned false, GitHub skipped the matrix job before expanding it. That produced a single skipped check named `Argument comment lint - ${{ matrix.name }}` instead of the Linux, macOS, and Windows check names that branch protection expects, leaving the PR unable to go green when those matrix checks are required.

## What Changed

- Treat root Bazel wrapper files as `argument-comment-lint` relevant changes.
- Keep the `argument_comment_lint_prebuilt` matrix job materialized for every PR so the per-platform check names always exist.
- Add a single gate step that decides whether the real lint work should run.
- Move the checkout-adjacent Bazel setup and OS-specific lint commands into `.github/actions/run-argument-comment-lint/action.yml` so the workflow does not repeat the same path-detection condition on each step.

## Verification

- Parsed `.github/workflows/rust-ci.yml` and `.github/actions/run-argument-comment-lint/action.yml` with Python YAML loading.
- Simulated the workflow path-matching shell conditions for the root Bazel wrapper files and confirmed they set `argument_comment_lint=true`.
