### PR TITLE
app-server: flush stdio responses

### DIFF
--- a/codex-rs/app-server/src/transport/stdio.rs
+++ b/codex-rs/app-server/src/transport/stdio.rs
@@ -90,6 +90,10 @@ pub(crate) async fn start_stdio_connection(
                 error!("Failed to write to stdout: {err}");
                 break;
             }
+            if let Err(err) = stdout.flush().await {
+                error!("Failed to flush stdout: {err}");
+                break;
+            }
             if let Some(write_complete_tx) = queued_message.write_complete_tx {
                 let _ = write_complete_tx.send(());
             }


### PR DESCRIPTION
## Why

A [Windows Cargo build](https://github.com/openai/codex/actions/runs/24754807756/job/72425641062) on `main` timed out while several process-heavy suites were running. The `codex-app-server` account failures did not reach account logic: the test harness wrote the first `initialize` JSON-RPC request and then timed out waiting for the response line.

The stdio transport already appends a newline before writing each serialized message, but that newline is only the JSON-RPC framing delimiter. It is not a portable flush guarantee, especially when stdout is connected to a pipe rather than a terminal. Today `tokio::io::stdout()` likely makes `write_all` sufficient in practice, but the app-server writer already has a `write_complete_tx` signal, so the cleaner contract is to complete that signal only after the writer has explicitly flushed the peer-facing stream.

## What Changed

This updates [`codex-rs/app-server/src/transport/stdio.rs`](https://github.com/openai/codex/blob/04d83c97b21a1efba9967bbc0990e8f8e6bbb248/codex-rs/app-server/src/transport/stdio.rs#L82-L100) to call `stdout.flush().await` after writing each outgoing stdio message. Flush errors are handled the same way as write errors: log and exit the writer loop.

This is narrower than serializing whole nextest groups because it directly tightens the stdio response path involved in the observed `mcp.initialize()` timeout.

## Verification

- `cargo test -p codex-app-server`