### PR TITLE
[Codex] Register browser requirements feature keys

### DIFF
--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -341,6 +341,9 @@
             "apps": {
               "type": "boolean"
             },
+            "browser_use": {
+              "type": "boolean"
+            },
             "child_agents_md": {
               "type": "boolean"
             },
@@ -411,6 +414,9 @@
               "type": "boolean"
             },
             "image_generation": {
+              "type": "boolean"
+            },
+            "in_app_browser": {
               "type": "boolean"
             },
             "include_apply_patch_tool": {
@@ -2344,6 +2350,9 @@
         "apps": {
           "type": "boolean"
         },
+        "browser_use": {
+          "type": "boolean"
+        },
         "child_agents_md": {
           "type": "boolean"
         },
@@ -2414,6 +2423,9 @@
           "type": "boolean"
         },
         "image_generation": {
+          "type": "boolean"
+        },
+        "in_app_browser": {
           "type": "boolean"
         },
         "include_apply_patch_tool": {

--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -6341,6 +6341,32 @@ async fn feature_requirements_normalize_effective_feature_values() -> std::io::R
 }
 
 #[tokio::test]
+async fn browser_feature_requirements_are_valid() -> std::io::Result<()> {
+    let codex_home = TempDir::new()?;
+
+    let config = ConfigBuilder::without_managed_config_for_tests()
+        .codex_home(codex_home.path().to_path_buf())
+        .cloud_requirements(CloudRequirementsLoader::new(async {
+            Ok(Some(crate::config_loader::ConfigRequirementsToml {
+                feature_requirements: Some(crate::config_loader::FeatureRequirementsToml {
+                    entries: BTreeMap::from([
+                        ("in_app_browser".to_string(), false),
+                        ("browser_use".to_string(), false),
+                    ]),
+                }),
+                ..Default::default()
+            }))
+        }))
+        .build()
+        .await?;
+
+    assert!(!config.features.enabled(Feature::InAppBrowser));
+    assert!(!config.features.enabled(Feature::BrowserUse));
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn explicit_feature_config_is_normalized_by_requirements() -> std::io::Result<()> {
     let codex_home = TempDir::new()?;
     std::fs::write(

--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -156,6 +156,14 @@ pub enum Feature {
     ToolSuggest,
     /// Enable plugins.
     Plugins,
+    /// Allow the in-app browser pane in desktop apps.
+    ///
+    /// Requirements-only gate: this should be set from requirements, not user config.
+    InAppBrowser,
+    /// Allow Browser Use agent integration in desktop apps.
+    ///
+    /// Requirements-only gate: this should be set from requirements, not user config.
+    BrowserUse,
     /// Temporary internal-only flag for PS-backed remote plugin catalog development.
     RemotePlugin,
     /// Show the startup prompt for migrating external agent config into Codex.
@@ -845,6 +853,18 @@ pub const FEATURES: &[FeatureSpec] = &[
     FeatureSpec {
         id: Feature::Plugins,
         key: "plugins",
+        stage: Stage::Stable,
+        default_enabled: true,
+    },
+    FeatureSpec {
+        id: Feature::InAppBrowser,
+        key: "in_app_browser",
+        stage: Stage::Stable,
+        default_enabled: true,
+    },
+    FeatureSpec {
+        id: Feature::BrowserUse,
+        key: "browser_use",
         stage: Stage::Stable,
         default_enabled: true,
     },

--- a/codex-rs/features/src/tests.rs
+++ b/codex-rs/features/src/tests.rs
@@ -151,6 +151,20 @@ fn tool_search_is_stable_and_enabled_by_default() {
 }
 
 #[test]
+fn browser_controls_are_stable_and_enabled_by_default() {
+    assert_eq!(Feature::InAppBrowser.stage(), Stage::Stable);
+    assert_eq!(Feature::InAppBrowser.default_enabled(), true);
+    assert_eq!(
+        feature_for_key("in_app_browser"),
+        Some(Feature::InAppBrowser)
+    );
+
+    assert_eq!(Feature::BrowserUse.stage(), Stage::Stable);
+    assert_eq!(Feature::BrowserUse.default_enabled(), true);
+    assert_eq!(feature_for_key("browser_use"), Some(Feature::BrowserUse));
+}
+
+#[test]
 fn unavailable_dummy_tools_is_under_development_and_disabled_by_default() {
     assert_eq!(
         Feature::UnavailableDummyTools.stage(),


### PR DESCRIPTION
## Summary
- register `in_app_browser` and `browser_use` as stable feature keys
- allow requirements/MDM feature requirements to pin those desktop browser controls
- add coverage for browser requirements being accepted by config loading

## Testing
- `cargo fmt --all` (`just fmt` unavailable locally; rustfmt warned about nightly-only `imports_granularity` config)
- `cargo test -p codex-features`
- `cargo test -p codex-core browser_feature_requirements_are_valid`
- Tested manually by setting in `requirements.toml` and seeing after app restart state to reflect the setting was correct (at the time hiding the `Browser Use` setting when the enterprise setting was set to false
