### PR TITLE
fix: document cargo deny advisory exceptions

### DIFF
--- a/codex-rs/.cargo/audit.toml
+++ b/codex-rs/.cargo/audit.toml
@@ -4,6 +4,8 @@ ignore = [
     "RUSTSEC-2024-0388", # derivative 2.2.0 via starlark; upstream crate is unmaintained
     "RUSTSEC-2025-0057", # fxhash 0.2.1 via starlark_map; upstream crate is unmaintained
     "RUSTSEC-2024-0436", # paste 1.0.15 via starlark/ratatui; upstream crate is unmaintained
+    "RUSTSEC-2026-0097", # rand 0.8.5 via age/codex-secrets, oauth2/rmcp, and codex-windows-sandbox; remove when these paths move to rand >=0.8.6
+    "RUSTSEC-2026-0002", # lru 0.12.5 via pinned nornagon/ratatui v0.29.0; remove when ratatui moves to lru >=0.16.3
     "RUSTSEC-2024-0320", # yaml-rust via syntect; remove when syntect drops or updates it
     "RUSTSEC-2025-0141", # bincode via syntect; remove when syntect drops or updates it
 ]

--- a/codex-rs/deny.toml
+++ b/codex-rs/deny.toml
@@ -75,6 +75,8 @@ ignore = [
     { id = "RUSTSEC-2024-0388", reason = "derivative is unmaintained; pulled in via starlark v0.13.0 used by execpolicy/cli/core; no fixed release yet" },
     { id = "RUSTSEC-2025-0057", reason = "fxhash is unmaintained; pulled in via starlark_map/starlark v0.13.0 used by execpolicy/cli/core; no fixed release yet" },
     { id = "RUSTSEC-2024-0436", reason = "paste is unmaintained; pulled in via ratatui/rmcp/starlark used by tui/execpolicy; no fixed release yet" },
+    { id = "RUSTSEC-2026-0097", reason = "rand 0.8.5 is pulled in via age/codex-secrets, oauth2/rmcp, and codex-windows-sandbox; remove when these paths move to rand >=0.8.6" },
+    { id = "RUSTSEC-2026-0002", reason = "lru 0.12.5 is pulled in by pinned nornagon/ratatui v0.29.0 used by codex-tui/ansi-to-tui; remove when ratatui moves to lru >=0.16.3" },
     # TODO(fcoury): remove this exception when syntect drops yaml-rust and bincode, or updates to versions that have fixed the vulnerabilities.
     { id = "RUSTSEC-2024-0320", reason = "yaml-rust is unmaintained; pulled in via syntect v5.3.0 used by codex-tui for syntax highlighting; no fixed release yet" },
     { id = "RUSTSEC-2025-0141", reason = "bincode is unmaintained; pulled in via syntect v5.3.0 used by codex-tui for syntax highlighting; no fixed release yet" },


### PR DESCRIPTION
## Why

`cargo deny check` is blocked by two current RustSec advisories in the transitive dependency graph. This PR keeps the required cargo-deny unblock focused on documenting the accepted advisory exceptions and their removal conditions.

`RUSTSEC-2026-0097` is for `rand 0.8.5`, which is pulled in through `age`/`codex-secrets`, `oauth2`/`rmcp`, and `codex-windows-sandbox`. The stacked follow-up in #19003 removes this exception by updating the lockfile to patched rand releases.

`RUSTSEC-2026-0002` is for `lru 0.12.5`, which comes from the pinned `nornagon/ratatui v0.29.0` revision used by `codex-tui` and `ansi-to-tui`. A direct `cargo update -p lru@0.12.5` cannot move it; the exception should be removed when the ratatui pin moves to `lru >=0.16.3`.

## What Changed

- Added synchronized `RUSTSEC-2026-0097` ignores in `codex-rs/deny.toml` and `codex-rs/.cargo/audit.toml`, with the rand offender paths and removal condition.
- Added synchronized `RUSTSEC-2026-0002` ignores in the same files, with the `lru -> ratatui` offender path and removal condition.

## Verification

- `cargo deny check`

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/19000).
* #19003
* __->__ #19000