### PR TITLE
chore: update rand lockfile entries

### DIFF
--- a/codex-rs/.cargo/audit.toml
+++ b/codex-rs/.cargo/audit.toml
@@ -4,7 +4,6 @@ ignore = [
     "RUSTSEC-2024-0388", # derivative 2.2.0 via starlark; upstream crate is unmaintained
     "RUSTSEC-2025-0057", # fxhash 0.2.1 via starlark_map; upstream crate is unmaintained
     "RUSTSEC-2024-0436", # paste 1.0.15 via starlark/ratatui; upstream crate is unmaintained
-    "RUSTSEC-2026-0097", # rand 0.8.5 via age/codex-secrets, oauth2/rmcp, and codex-windows-sandbox; remove when these paths move to rand >=0.8.6
     "RUSTSEC-2026-0002", # lru 0.12.5 via pinned nornagon/ratatui v0.29.0; remove when ratatui moves to lru >=0.16.3
     "RUSTSEC-2024-0320", # yaml-rust via syntect; remove when syntect drops or updates it
     "RUSTSEC-2025-0141", # bincode via syntect; remove when syntect drops or updates it

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -213,7 +213,7 @@ dependencies = [
  "lazy_static",
  "nom 7.1.3",
  "pin-project",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rust-embed",
  "scrypt",
  "sha2",
@@ -234,7 +234,7 @@ dependencies = [
  "hkdf",
  "io_tee",
  "nom 7.1.3",
- "rand 0.8.5",
+ "rand 0.8.6",
  "secrecy",
  "sha2",
 ]
@@ -1759,7 +1759,7 @@ dependencies = [
  "crypto_box",
  "ed25519-dalek",
  "pretty_assertions",
- "rand 0.9.3",
+ "rand 0.9.4",
  "reqwest",
  "serde",
  "serde_json",
@@ -2155,7 +2155,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
  "pretty_assertions",
- "rand 0.9.3",
+ "rand 0.9.4",
  "reqwest",
  "rustls",
  "rustls-native-certs",
@@ -2408,7 +2408,7 @@ dependencies = [
  "opentelemetry_sdk",
  "predicates",
  "pretty_assertions",
- "rand 0.9.3",
+ "rand 0.9.4",
  "regex-lite",
  "reqwest",
  "rmcp",
@@ -2519,7 +2519,7 @@ dependencies = [
  "base64 0.22.1",
  "p256",
  "pretty_assertions",
- "rand 0.9.3",
+ "rand 0.9.4",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -2810,7 +2810,7 @@ dependencies = [
  "once_cell",
  "os_info",
  "pretty_assertions",
- "rand 0.9.3",
+ "rand 0.9.4",
  "regex-lite",
  "reqwest",
  "serde",
@@ -3236,7 +3236,7 @@ dependencies = [
  "codex-keyring-store",
  "keyring",
  "pretty_assertions",
- "rand 0.9.3",
+ "rand 0.9.4",
  "regex",
  "schemars 0.8.22",
  "serde",
@@ -3455,7 +3455,7 @@ dependencies = [
  "pathdiff",
  "pretty_assertions",
  "pulldown-cmark",
- "rand 0.9.3",
+ "rand 0.9.4",
  "ratatui",
  "ratatui-macros",
  "regex-lite",
@@ -3735,7 +3735,7 @@ dependencies = [
  "dunce",
  "glob",
  "pretty_assertions",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "tempfile",
@@ -6793,7 +6793,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.3",
+ "rand 0.9.4",
  "ring",
  "thiserror 2.0.18",
  "tinyvec",
@@ -6815,7 +6815,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.3",
+ "rand 0.9.4",
  "resolv-conf",
  "smallvec",
  "thiserror 2.0.18",
@@ -8517,7 +8517,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -8640,7 +8640,7 @@ dependencies = [
  "chrono",
  "getrandom 0.2.17",
  "http 1.4.0",
- "rand 0.8.5",
+ "rand 0.8.6",
  "reqwest",
  "serde",
  "serde_json",
@@ -9059,7 +9059,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.3",
+ "rand 0.9.4",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -9644,7 +9644,7 @@ checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
 dependencies = [
  "bitflags 2.10.0",
  "num-traits",
- "rand 0.9.3",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax 0.8.8",
@@ -9853,7 +9853,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.3",
+ "rand 0.9.4",
  "ring",
  "rustc-hash 2.1.1",
  "rustls",
@@ -9985,7 +9985,7 @@ dependencies = [
  "rama-http-types",
  "rama-net",
  "rama-utils",
- "rand 0.9.3",
+ "rand 0.9.4",
  "serde",
  "serde_html_form",
  "serde_json",
@@ -10055,7 +10055,7 @@ dependencies = [
  "rama-macros",
  "rama-net",
  "rama-utils",
- "rand 0.9.3",
+ "rand 0.9.4",
  "serde",
  "sha1",
 ]
@@ -10083,7 +10083,7 @@ dependencies = [
  "rama-error",
  "rama-macros",
  "rama-utils",
- "rand 0.9.3",
+ "rand 0.9.4",
  "serde",
  "serde_json",
  "sync_wrapper",
@@ -10157,7 +10157,7 @@ dependencies = [
  "rama-http-types",
  "rama-net",
  "rama-utils",
- "rand 0.9.3",
+ "rand 0.9.4",
  "tokio",
 ]
 
@@ -10226,9 +10226,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -10237,9 +10237,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -10566,7 +10566,7 @@ dependencies = [
  "pastey",
  "pin-project-lite",
  "process-wrap",
- "rand 0.9.3",
+ "rand 0.9.4",
  "reqwest",
  "rmcp-macros",
  "schemars 1.2.1",
@@ -11037,7 +11037,7 @@ dependencies = [
  "hkdf",
  "num",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "sha2",
  "zbus",
@@ -11164,7 +11164,7 @@ version = "0.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26ab054c34b87f96c3e4701bea1888317cde30cc7e4a6136d2c48454ab96661c"
 dependencies = [
- "rand 0.9.3",
+ "rand 0.9.4",
  "sentry-types",
  "serde",
  "serde_json",
@@ -11212,7 +11212,7 @@ checksum = "eecbd63e9d15a26a40675ed180d376fcb434635d2e33de1c24003f61e3e2230d"
 dependencies = [
  "debugid",
  "hex",
- "rand 0.9.3",
+ "rand 0.9.4",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -11749,7 +11749,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "sha1",
@@ -11790,7 +11790,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2",
@@ -13039,7 +13039,7 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
- "rand 0.9.3",
+ "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
  "sha1",
@@ -14504,7 +14504,7 @@ dependencies = [
  "hex",
  "nix 0.29.0",
  "ordered-stream",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_repr",
  "sha1",

--- a/codex-rs/deny.toml
+++ b/codex-rs/deny.toml
@@ -75,7 +75,6 @@ ignore = [
     { id = "RUSTSEC-2024-0388", reason = "derivative is unmaintained; pulled in via starlark v0.13.0 used by execpolicy/cli/core; no fixed release yet" },
     { id = "RUSTSEC-2025-0057", reason = "fxhash is unmaintained; pulled in via starlark_map/starlark v0.13.0 used by execpolicy/cli/core; no fixed release yet" },
     { id = "RUSTSEC-2024-0436", reason = "paste is unmaintained; pulled in via ratatui/rmcp/starlark used by tui/execpolicy; no fixed release yet" },
-    { id = "RUSTSEC-2026-0097", reason = "rand 0.8.5 is pulled in via age/codex-secrets, oauth2/rmcp, and codex-windows-sandbox; remove when these paths move to rand >=0.8.6" },
     { id = "RUSTSEC-2026-0002", reason = "lru 0.12.5 is pulled in by pinned nornagon/ratatui v0.29.0 used by codex-tui/ansi-to-tui; remove when ratatui moves to lru >=0.16.3" },
     # TODO(fcoury): remove this exception when syntect drops yaml-rust and bincode, or updates to versions that have fixed the vulnerabilities.
     { id = "RUSTSEC-2024-0320", reason = "yaml-rust is unmaintained; pulled in via syntect v5.3.0 used by codex-tui for syntax highlighting; no fixed release yet" },


### PR DESCRIPTION
## Why

#19000 documents the currently accepted cargo-deny advisory exceptions. The rand advisory does not need to stay suppressed because the existing dependency constraints can move to patched rand releases with a lockfile-only update.

RustSec lists patched ranges for `RUSTSEC-2026-0097` that include `rand >=0.8.6,<0.9.0` and `rand >=0.9.3,<0.10.0`, so this PR updates the remaining `rand 0.8.5` entries while also moving the workspace `rand 0.9.3` entries to the latest compatible `0.9.x` release.

## What Changed

- Updated `Cargo.lock` from `rand 0.8.5` to `rand 0.8.6`.
- Updated `Cargo.lock` from `rand 0.9.3` to `rand 0.9.4`.
- Removed the `RUSTSEC-2026-0097` ignores from `codex-rs/deny.toml` and `codex-rs/.cargo/audit.toml`.

## Verification

- `cargo deny check`
- `just bazel-lock-check`

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/19003).
* __->__ #19003
* #19000