### PR TITLE
Update skill truncation warning copy

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/turn_start.rs
+++ b/codex-rs/app-server/tests/suite/v2/turn_start.rs
@@ -50,6 +50,7 @@ use codex_app_server_protocol::UserInput as V2UserInput;
 use codex_app_server_protocol::WarningNotification;
 use codex_config::config_toml::ConfigToml;
 use codex_core::personality_migration::PERSONALITY_MIGRATION_FILENAME;
+use codex_core::skills::SKILL_METADATA_TRUNCATION_WARNING_MESSAGE;
 use codex_features::FEATURES;
 use codex_features::Feature;
 use codex_protocol::config_types::CollaborationMode;
@@ -322,10 +323,7 @@ async fn turn_start_emits_thread_scoped_warning_notification_for_trimmed_skills(
     let warning: WarningNotification =
         serde_json::from_value(params).expect("deserialize warning notification");
     assert_eq!(warning.thread_id.as_deref(), Some(thread.id.as_str()));
-    assert_eq!(
-        warning.message,
-        "Some enabled skills were not included in the model-visible skills list for this session. Mention a skill by name or path if you need it."
-    );
+    assert_eq!(warning.message, SKILL_METADATA_TRUNCATION_WARNING_MESSAGE);
 
     timeout(
         DEFAULT_READ_TIMEOUT,

--- a/codex-rs/core-skills/src/lib.rs
+++ b/codex-rs/core-skills/src/lib.rs
@@ -23,6 +23,7 @@ pub use model::SkillMetadata;
 pub use model::SkillPolicy;
 pub use model::filter_skill_load_outcome_for_product;
 pub use render::AvailableSkills;
+pub use render::SKILL_METADATA_TRUNCATION_WARNING_MESSAGE;
 pub use render::SkillMetadataBudget;
 pub use render::SkillRenderReport;
 pub use render::build_available_skills;

--- a/codex-rs/core-skills/src/render.rs
+++ b/codex-rs/core-skills/src/render.rs
@@ -9,6 +9,12 @@ use codex_utils_output_truncation::approx_token_count;
 const DEFAULT_SKILL_METADATA_CHAR_BUDGET: usize = 8_000;
 const SKILL_METADATA_CONTEXT_WINDOW_PERCENT: usize = 2;
 
+/// Warning shown when enabled skill metadata exceeds the model-visible budget.
+pub const SKILL_METADATA_TRUNCATION_WARNING_MESSAGE: &str = concat!(
+    "A large number of skills are enabled, so some are excluded from the model-visible skills list ",
+    "for this session. Mention skills by name or path if explicitly needed."
+);
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SkillMetadataBudget {
     Tokens(usize),

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -273,6 +273,7 @@ use crate::rollout::policy::EventPersistenceMode;
 use crate::session_startup_prewarm::SessionStartupPrewarmHandle;
 use crate::shell;
 use crate::shell_snapshot::ShellSnapshot;
+use crate::skills::SKILL_METADATA_TRUNCATION_WARNING_MESSAGE;
 use crate::skills_watcher::SkillsWatcher;
 use crate::skills_watcher::SkillsWatcherEvent;
 use crate::state::ActiveTurn;
@@ -372,8 +373,6 @@ pub struct Codex {
 }
 
 pub(crate) type SessionLoopTermination = Shared<BoxFuture<'static, ()>>;
-
-pub(crate) const THREAD_START_SKILLS_TRIMMED_WARNING_MESSAGE: &str = "Some enabled skills were not included in the model-visible skills list for this session. Mention a skill by name or path if you need it.";
 
 /// Wrapper returned by [`Codex::spawn`] containing the spawned [`Codex`] and
 /// the unique session id.
@@ -2507,7 +2506,7 @@ impl Session {
                     self.send_event_raw(Event {
                         id: String::new(),
                         msg: EventMsg::Warning(WarningEvent {
-                            message: THREAD_START_SKILLS_TRIMMED_WARNING_MESSAGE.to_string(),
+                            message: SKILL_METADATA_TRUNCATION_WARNING_MESSAGE.to_string(),
                         }),
                     })
                     .await;

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -14,6 +14,7 @@ use crate::context::TurnAborted;
 use crate::exec::ExecCapturePolicy;
 use crate::function_tool::FunctionCallError;
 use crate::shell::default_user_shell;
+use crate::skills::SKILL_METADATA_TRUNCATION_WARNING_MESSAGE;
 use crate::skills::SkillRenderSideEffects;
 use crate::skills::render::SkillMetadataBudget;
 use crate::tools::format_exec_output_str;
@@ -4817,7 +4818,7 @@ async fn build_initial_context_trims_skill_metadata_from_context_window_budget()
     assert!(
         developer_texts
             .iter()
-            .all(|text| !text.contains(THREAD_START_SKILLS_TRIMMED_WARNING_MESSAGE)),
+            .all(|text| !text.contains(SKILL_METADATA_TRUNCATION_WARNING_MESSAGE)),
         "expected skill budget warning to stay out of the initial context, got {developer_texts:?}"
     );
     assert!(
@@ -4899,7 +4900,7 @@ async fn build_initial_context_emits_thread_start_skill_warning_on_repeated_buil
     assert!(matches!(
         warning_event.msg,
         EventMsg::Warning(WarningEvent { message })
-            if message == THREAD_START_SKILLS_TRIMMED_WARNING_MESSAGE
+            if message == SKILL_METADATA_TRUNCATION_WARNING_MESSAGE
     ));
 
     let _ = session.build_initial_context(&turn_context).await;
@@ -4910,7 +4911,7 @@ async fn build_initial_context_emits_thread_start_skill_warning_on_repeated_buil
     assert!(matches!(
         warning_event.msg,
         EventMsg::Warning(WarningEvent { message })
-            if message == THREAD_START_SKILLS_TRIMMED_WARNING_MESSAGE
+            if message == SKILL_METADATA_TRUNCATION_WARNING_MESSAGE
     ));
 }
 

--- a/codex-rs/core/src/skills.rs
+++ b/codex-rs/core/src/skills.rs
@@ -16,6 +16,7 @@ use codex_protocol::request_user_input::RequestUserInputResponse;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use tracing::warn;
 
+pub use codex_core_skills::SKILL_METADATA_TRUNCATION_WARNING_MESSAGE;
 pub use codex_core_skills::SkillDependencyInfo;
 pub use codex_core_skills::SkillError;
 pub use codex_core_skills::SkillLoadOutcome;

--- a/codex-rs/tui/src/chatwidget/tests/app_server.rs
+++ b/codex-rs/tui/src/chatwidget/tests/app_server.rs
@@ -1,4 +1,5 @@
 use super::*;
+use codex_core_skills::SKILL_METADATA_TRUNCATION_WARNING_MESSAGE;
 use pretty_assertions::assert_eq;
 
 #[tokio::test]
@@ -191,7 +192,7 @@ async fn live_app_server_warning_notification_renders_message() {
     chat.handle_server_notification(
         ServerNotification::Warning(WarningNotification {
             thread_id: None,
-            message: "Some enabled skills were not included in the model-visible skills list for this session. Mention a skill by name or path if you need it.".to_string(),
+            message: SKILL_METADATA_TRUNCATION_WARNING_MESSAGE.to_string(),
         }),
         /*replay_kind*/ None,
     );
@@ -201,13 +202,11 @@ async fn live_app_server_warning_notification_renders_message() {
     let rendered = lines_to_single_string(&cells[0]);
     let normalized = rendered.split_whitespace().collect::<Vec<_>>().join(" ");
     assert!(
-        normalized.contains(
-            "Some enabled skills were not included in the model-visible skills list for this session."
-        ),
+        normalized.contains("A large number of skills are enabled, so some are excluded"),
         "expected warning notification message, got {rendered}"
     );
     assert!(
-        normalized.contains("Mention a skill by name or path if you need it."),
+        normalized.contains("Mention skills by name or path if explicitly needed."),
         "expected warning guidance, got {rendered}"
     );
 }


### PR DESCRIPTION
## Summary
- Update the enabled-skills truncation warning to describe large skill sets more clearly.
- Move the warning copy into codex-core-skills and reuse it from core, app-server tests, and TUI tests.
- Update warning assertions for app-server and TUI coverage.

## Tests
- `just fmt`
- `cargo test -p codex-core-skills`
- `cargo test -p codex-core build_initial_context_emits_thread_start_skill_warning_on_repeated_builds`
- `cargo test -p codex-app-server turn_start_emits_thread_scoped_warning_notification_for_trimmed_skills`
- `cargo test -p codex-tui live_app_server_warning_notification_renders_message`
- `git diff --check`