### PR TITLE
Fix MCP permission policy sync

### DIFF
--- a/codex-rs/core/src/session/mcp.rs
+++ b/codex-rs/core/src/session/mcp.rs
@@ -229,7 +229,7 @@ impl Session {
             &mcp_servers,
             store_mode,
             auth_statuses,
-            &turn_context.config.permissions.approval_policy,
+            &turn_context.approval_policy,
             turn_context.sub_id.clone(),
             self.get_tx_event(),
             turn_context.sandbox_policy.get().clone(),

--- a/codex-rs/core/src/session/turn_context.rs
+++ b/codex-rs/core/src/session/turn_context.rs
@@ -612,8 +612,7 @@ impl Session {
         {
             let mcp_connection_manager = self.services.mcp_connection_manager.read().await;
             mcp_connection_manager.set_approval_policy(&session_configuration.approval_policy);
-            mcp_connection_manager
-                .set_sandbox_policy(per_turn_config.permissions.sandbox_policy.get());
+            mcp_connection_manager.set_sandbox_policy(session_configuration.sandbox_policy.get());
         }
 
         let model_info = self


### PR DESCRIPTION
###### Why/Context/Summary

Repro: start a session outside Full Access, switch permissions to Full Access, then submit a new turn that triggers MCP/CUA permission handling.

The turn used the live Full Access `SessionConfiguration`, but the MCP coordinator was still synced from the stale `original_config_do_not_use` / per-turn config copy. That left the coordinator with an old sandbox policy, so empty MCP permission elicitations could be denied instead of auto-accepted.

Fix: update/rebuild the MCP connection manager from the live turn/session approval and sandbox policy fields.

###### Test plan

```sh
just fmt
cargo test -p codex-core --lib
cargo test -p codex-core --lib mcp_tool_call::tests
```
