### PR TITLE
guide Windows to use -WindowStyle Hidden for Start-Process calls

### DIFF
--- a/codex-rs/tools/src/local_tool.rs
+++ b/codex-rs/tools/src/local_tool.rs
@@ -173,7 +173,7 @@ Examples of valid command strings:
 - running an inline Python script: ["powershell.exe", "-Command", "@'\\nprint('Hello, world!')\\n'@ | python -"]
 
 {}"#,
-                windows_shell_guidance()
+            windows_shell_guidance()
         )
     } else {
         r#"Runs a shell command and returns its output.

--- a/codex-rs/tools/src/local_tool.rs
+++ b/codex-rs/tools/src/local_tool.rs
@@ -72,7 +72,7 @@ pub fn create_exec_command_tool(options: CommandToolOptions) -> ToolSpec {
         description: if cfg!(windows) {
             format!(
                 "Runs a command in a PTY, returning output or a session ID for ongoing interaction.\n\n{}",
-                windows_destructive_filesystem_guidance()
+                windows_shell_guidance()
             )
         } else {
             "Runs a command in a PTY, returning output or a session ID for ongoing interaction."
@@ -173,7 +173,7 @@ Examples of valid command strings:
 - running an inline Python script: ["powershell.exe", "-Command", "@'\\nprint('Hello, world!')\\n'@ | python -"]
 
 {}"#,
-            windows_destructive_filesystem_guidance()
+                windows_shell_guidance()
         )
     } else {
         r#"Runs a shell command and returns its output.
@@ -244,7 +244,7 @@ Examples of valid command strings:
 - running an inline Python script: "@'\\nprint('Hello, world!')\\n'@ | python -"
 
 {}"#,
-            windows_destructive_filesystem_guidance()
+            windows_shell_guidance()
         )
     } else {
         r#"Runs a shell command and returns its output.
@@ -421,10 +421,11 @@ fn file_system_permissions_schema() -> JsonSchema {
     )
 }
 
-fn windows_destructive_filesystem_guidance() -> &'static str {
+fn windows_shell_guidance() -> &'static str {
     r#"Windows safety rules:
 - Do not compose destructive filesystem commands across shells. Do not enumerate paths in PowerShell and then pass them to `cmd /c`, batch builtins, or another shell for deletion or moving. Use one shell end-to-end, prefer native PowerShell cmdlets such as `Remove-Item` / `Move-Item` with `-LiteralPath`, and avoid string-built shell commands for file operations.
-- Before any recursive delete or move on Windows, verify the resolved absolute target paths stay within the intended workspace or explicitly named target directory. Never issue a recursive delete or move against a computed path if the final target has not been checked."#
+- Before any recursive delete or move on Windows, verify the resolved absolute target paths stay within the intended workspace or explicitly named target directory. Never issue a recursive delete or move against a computed path if the final target has not been checked.
+- When using `Start-Process` to launch a background helper or service, pass `-WindowStyle Hidden` unless the user explicitly asked for a visible interactive window. Use visible windows only for interactive tools the user needs to see or control."#
 }
 
 #[cfg(test)]

--- a/codex-rs/tools/src/local_tool_tests.rs
+++ b/codex-rs/tools/src/local_tool_tests.rs
@@ -101,7 +101,7 @@ fn exec_command_tool_matches_expected_spec() {
     let description = if cfg!(windows) {
         format!(
             "Runs a command in a PTY, returning output or a session ID for ongoing interaction.{}",
-            windows_shell_guidance()
+            windows_shell_guidance_description()
         )
     } else {
         "Runs a command in a PTY, returning output or a session ID for ongoing interaction."

--- a/codex-rs/tools/src/local_tool_tests.rs
+++ b/codex-rs/tools/src/local_tool_tests.rs
@@ -3,7 +3,7 @@ use pretty_assertions::assert_eq;
 use std::collections::BTreeMap;
 
 fn windows_shell_safety_description() -> String {
-    format!("\n\n{}", windows_destructive_filesystem_guidance())
+    format!("\n\n{}", windows_shell_guidance())
 }
 
 #[test]
@@ -24,7 +24,7 @@ Examples of valid command strings:
 - setting an env var: ["powershell.exe", "-Command", "$env:FOO='bar'; echo $env:FOO"]
 - running an inline Python script: ["powershell.exe", "-Command", "@'\\nprint('Hello, world!')\\n'@ | python -"]"#
             .to_string()
-            + &windows_shell_safety_description()
+            + &windows_shell_guidance()
     } else {
         r#"Runs a shell command and returns its output.
 - The arguments to `shell` will be passed to execvp(). Most terminal commands should be prefixed with ["bash", "-lc"].
@@ -269,7 +269,7 @@ Examples of valid command strings:
 - running an inline Python script: ["powershell.exe", "-Command", "@'\\nprint('Hello, world!')\\n'@ | python -"]
 
 {}"#,
-            windows_destructive_filesystem_guidance()
+            windows_shell_guidance()
         )
     } else {
         r#"Runs a shell command and returns its output.

--- a/codex-rs/tools/src/local_tool_tests.rs
+++ b/codex-rs/tools/src/local_tool_tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use pretty_assertions::assert_eq;
 use std::collections::BTreeMap;
 
-fn windows_shell_safety_description() -> String {
+fn windows_shell_guidance_description() -> String {
     format!("\n\n{}", windows_shell_guidance())
 }
 
@@ -24,7 +24,7 @@ Examples of valid command strings:
 - setting an env var: ["powershell.exe", "-Command", "$env:FOO='bar'; echo $env:FOO"]
 - running an inline Python script: ["powershell.exe", "-Command", "@'\\nprint('Hello, world!')\\n'@ | python -"]"#
             .to_string()
-            + &windows_shell_guidance()
+            + &windows_shell_guidance_description()
     } else {
         r#"Runs a shell command and returns its output.
 - The arguments to `shell` will be passed to execvp(). Most terminal commands should be prefixed with ["bash", "-lc"].
@@ -101,7 +101,7 @@ fn exec_command_tool_matches_expected_spec() {
     let description = if cfg!(windows) {
         format!(
             "Runs a command in a PTY, returning output or a session ID for ongoing interaction.{}",
-            windows_shell_safety_description()
+            windows_shell_guidance()
         )
     } else {
         "Runs a command in a PTY, returning output or a session ID for ongoing interaction."
@@ -346,7 +346,7 @@ Examples of valid command strings:
 - setting an env var: "$env:FOO='bar'; echo $env:FOO"
 - running an inline Python script: "@'\\nprint('Hello, world!')\\n'@ | python -""#
             .to_string()
-            + &windows_shell_safety_description()
+            + &windows_shell_guidance_description()
     } else {
         r#"Runs a shell command and returns its output.
 - Always set the `workdir` param when using the shell_command function. Do not use `cd` unless absolutely necessary."#


### PR DESCRIPTION
Sometimes codex runs `Start-Process` to start up a service or something similar, which launches a user-visible powershell window that probably doesn't get cleaned up.  This instruction change encourages it to do so using a hidden window.

This was reported in https://openai.slack.com/archives/C09K6H5DZC4/p1776741272870519

One caveat is that this change won't do anything to cleanup these processes, but it will stop them from polluting the user's visible workspace