### PR TITLE
test: set Rust test thread stack size

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -33,6 +33,10 @@ common:windows --test_env=PATH
 common:windows --test_env=SYSTEMROOT
 common:windows --test_env=COMSPEC
 common:windows --test_env=WINDIR
+# Rust's libtest harness runs test bodies on std-spawned threads. The default
+# 2 MiB stack can be too small for large async test futures on Windows CI; see
+# https://github.com/openai/codex/pull/19067 for the motivating failure.
+common --test_env=RUST_MIN_STACK=8388608 # 8 MiB
 
 common --test_output=errors
 common --bes_results_url=https://app.buildbuddy.io/invocation/

--- a/.github/workflows/rust-ci-full.yml
+++ b/.github/workflows/rust-ci-full.yml
@@ -76,6 +76,8 @@ jobs:
       - name: Test argument comment lint package
         working-directory: tools/argument-comment-lint
         run: cargo test
+        env:
+          RUST_MIN_STACK: "8388608" # 8 MiB
 
   argument_comment_lint_prebuilt:
     name: Argument comment lint - ${{ matrix.name }}
@@ -671,6 +673,7 @@ jobs:
         run: cargo nextest run --no-fail-fast --target ${{ matrix.target }} --cargo-profile ci-test --timings
         env:
           RUST_BACKTRACE: 1
+          RUST_MIN_STACK: "8388608" # 8 MiB
           NEXTEST_STATUS_LEVEL: leak
 
       - name: Upload Cargo timings (nextest)

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -131,6 +131,8 @@ jobs:
       - name: Test argument comment lint package
         working-directory: tools/argument-comment-lint
         run: cargo test
+        env:
+          RUST_MIN_STACK: "8388608" # 8 MiB
 
   argument_comment_lint_prebuilt:
     name: Argument comment lint - ${{ matrix.name }}

--- a/defs.bzl
+++ b/defs.bzl
@@ -18,11 +18,11 @@ PLATFORMS = [
 WINDOWS_RUSTC_LINK_FLAGS = select({
     "@rules_rs//rs/experimental/platforms/constraints:windows_gnullvm": [
         "-C",
-        "link-arg=-Wl,--stack,8388608",
+        "link-arg=-Wl,--stack,8388608",  # 8 MiB
     ],
     "@rules_rs//rs/experimental/platforms/constraints:windows_msvc": [
         "-C",
-        "link-arg=/STACK:8388608",
+        "link-arg=/STACK:8388608",  # 8 MiB
         "-C",
         "link-arg=/NODEFAULTLIB:libucrt.lib",
         "-C",

--- a/justfile
+++ b/justfile
@@ -1,6 +1,8 @@
 set working-directory := "codex-rs"
 set positional-arguments
 
+rust_min_stack := "8388608" # 8 MiB
+
 # Display help
 help:
     just -l
@@ -49,7 +51,7 @@ install:
 # Prefer this for routine local runs. Workspace crate features are banned, so
 # there should be no need to add `--all-features`.
 test:
-    cargo nextest run --no-fail-fast
+    RUST_MIN_STACK={{ rust_min_stack }} cargo nextest run --no-fail-fast
 
 # Build and run Codex from source using Bazel.
 # Note we have to use the combination of `[no-cd]` and `--run_under="cd $PWD &&"`


### PR DESCRIPTION
## Summary

Set `RUST_MIN_STACK=8388608` for Rust test entry points so libtest-spawned test threads get an 8 MiB stack.

The Windows BuildBuddy failure on #18893 showed `//codex-rs/tui:tui-unit-tests` exiting with a stack overflow in a `#[tokio::test]` even though later test binaries in the shard printed successful summaries. Default `#[tokio::test]` uses a current-thread Tokio runtime, which means the async test body is driven on libtest's std-spawned test thread. Increasing the test thread stack addresses that failure mode directly.

To date, we have been fixing these stack-pressure problems with localized future-size reductions, such as #13429, and by adding `Box::pin()` in specific async wrapper chains. This gives us a baseline test-runner stack size instead of continuing to patch individual tests only after CI finds another large async future.

## What changed

- Added `common --test_env=RUST_MIN_STACK=8388608` in `.bazelrc` so Bazel test actions receive the env var through Bazel's cache-keyed test environment path.
- Set the same `RUST_MIN_STACK` value for Cargo/nextest CI entry points and `just test`.
- Annotated the existing Windows Bazel linker stack reserve as 8 MiB so it stays aligned with the libtest thread stack size.

## Testing

- `just --list`
- parsed `.github/workflows/rust-ci.yml` and `.github/workflows/rust-ci-full.yml` with Ruby's YAML loader
- compared `bazel aquery` `TestRunner` action keys before/after explicit `--test_env=RUST_MIN_STACK=...` and after moving the Bazel env to `.bazelrc`
- `bazel test //codex-rs/tui:tui-unit-tests --test_output=errors`
  - failed locally on the existing sandbox-specific status snapshot permission mismatch, but loaded the Starlark changes and ran the TUI test shards
