### PR TITLE
Clarify cloud requirements error messages

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -10398,7 +10398,7 @@ mod tests {
         let err = std::io::Error::other(CloudRequirementsLoadError::new(
             CloudRequirementsLoadErrorCode::RequestFailed,
             /*status_code*/ None,
-            "failed to load your workspace-managed config",
+            "failed to load cloud requirements (workspace-managed policies)",
         ));
 
         let error = config_load_error(&err);
@@ -10408,7 +10408,7 @@ mod tests {
             Some(json!({
                 "reason": "cloudRequirements",
                 "errorCode": "RequestFailed",
-                "detail": "failed to load your workspace-managed config",
+                "detail": "failed to load cloud requirements (workspace-managed policies)",
             }))
         );
     }

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -10398,7 +10398,7 @@ mod tests {
         let err = std::io::Error::other(CloudRequirementsLoadError::new(
             CloudRequirementsLoadErrorCode::RequestFailed,
             /*status_code*/ None,
-            "failed to load cloud requirements (workspace-managed policies)",
+            "Failed to load cloud requirements (workspace-managed policies).",
         ));
 
         let error = config_load_error(&err);
@@ -10408,7 +10408,7 @@ mod tests {
             Some(json!({
                 "reason": "cloudRequirements",
                 "errorCode": "RequestFailed",
-                "detail": "failed to load cloud requirements (workspace-managed policies)",
+                "detail": "Failed to load cloud requirements (workspace-managed policies).",
             }))
         );
     }

--- a/codex-rs/cloud-requirements/src/lib.rs
+++ b/codex-rs/cloud-requirements/src/lib.rs
@@ -50,9 +50,18 @@ const CLOUD_REQUIREMENTS_CACHE_TTL: Duration = Duration::from_secs(30 * 60);
 const CLOUD_REQUIREMENTS_FETCH_ATTEMPT_METRIC: &str = "codex.cloud_requirements.fetch_attempt";
 const CLOUD_REQUIREMENTS_FETCH_FINAL_METRIC: &str = "codex.cloud_requirements.fetch_final";
 const CLOUD_REQUIREMENTS_LOAD_METRIC: &str = "codex.cloud_requirements.load";
-const CLOUD_REQUIREMENTS_LOAD_FAILED_MESSAGE: &str = "Failed to load cloud requirements (workspace-managed policies).";
-const CLOUD_REQUIREMENTS_PARSE_FAILED_MESSAGE: &str = "Cloud requirements (workspace-managed policies) are invalid and could not be parsed. Please contact your workspace admin.";
-const CLOUD_REQUIREMENTS_AUTH_RECOVERY_FAILED_MESSAGE: &str = "Your authentication session could not be refreshed automatically. Please log out and sign in again.";
+const CLOUD_REQUIREMENTS_LOAD_FAILED_MESSAGE: &str = concat!(
+    "Failed to load cloud requirements ",
+    "(workspace-managed policies)."
+);
+const CLOUD_REQUIREMENTS_PARSE_FAILED_MESSAGE: &str = concat!(
+    "Cloud requirements (workspace-managed policies) are invalid and could not be parsed. ",
+    "Please contact your workspace admin."
+);
+const CLOUD_REQUIREMENTS_AUTH_RECOVERY_FAILED_MESSAGE: &str = concat!(
+    "Your authentication session could not be refreshed automatically. ",
+    "Please log out and sign in again."
+);
 const CLOUD_REQUIREMENTS_CACHE_WRITE_HMAC_KEY: &[u8] =
     b"codex-cloud-requirements-cache-v3-064f8542-75b4-494c-a294-97d3ce597271";
 const CLOUD_REQUIREMENTS_CACHE_READ_HMAC_KEYS: &[&[u8]] =

--- a/codex-rs/cloud-requirements/src/lib.rs
+++ b/codex-rs/cloud-requirements/src/lib.rs
@@ -50,10 +50,8 @@ const CLOUD_REQUIREMENTS_CACHE_TTL: Duration = Duration::from_secs(30 * 60);
 const CLOUD_REQUIREMENTS_FETCH_ATTEMPT_METRIC: &str = "codex.cloud_requirements.fetch_attempt";
 const CLOUD_REQUIREMENTS_FETCH_FINAL_METRIC: &str = "codex.cloud_requirements.fetch_final";
 const CLOUD_REQUIREMENTS_LOAD_METRIC: &str = "codex.cloud_requirements.load";
-const CLOUD_REQUIREMENTS_LOAD_FAILED_MESSAGE: &str = concat!(
-    "Failed to load cloud requirements ",
-    "(workspace-managed policies)."
-);
+const CLOUD_REQUIREMENTS_LOAD_FAILED_MESSAGE: &str =
+    "Failed to load cloud requirements (workspace-managed policies).";
 const CLOUD_REQUIREMENTS_PARSE_FAILED_MESSAGE: &str = concat!(
     "Cloud requirements (workspace-managed policies) are invalid and could not be parsed. ",
     "Please contact your workspace admin."

--- a/codex-rs/cloud-requirements/src/lib.rs
+++ b/codex-rs/cloud-requirements/src/lib.rs
@@ -50,8 +50,9 @@ const CLOUD_REQUIREMENTS_CACHE_TTL: Duration = Duration::from_secs(30 * 60);
 const CLOUD_REQUIREMENTS_FETCH_ATTEMPT_METRIC: &str = "codex.cloud_requirements.fetch_attempt";
 const CLOUD_REQUIREMENTS_FETCH_FINAL_METRIC: &str = "codex.cloud_requirements.fetch_final";
 const CLOUD_REQUIREMENTS_LOAD_METRIC: &str = "codex.cloud_requirements.load";
-const CLOUD_REQUIREMENTS_LOAD_FAILED_MESSAGE: &str = "failed to load your workspace-managed config";
-const CLOUD_REQUIREMENTS_PARSE_FAILED_MESSAGE: &str = "Your workspace-managed config is invalid and could not be parsed. Please contact your workspace admin.";
+const CLOUD_REQUIREMENTS_LOAD_FAILED_MESSAGE: &str =
+    "failed to load cloud requirements (workspace-managed policies)";
+const CLOUD_REQUIREMENTS_PARSE_FAILED_MESSAGE: &str = "Cloud requirements (workspace-managed policies) are invalid and could not be parsed. Please contact your workspace admin.";
 const CLOUD_REQUIREMENTS_AUTH_RECOVERY_FAILED_MESSAGE: &str = "Your authentication session could not be refreshed automatically. Please log out and sign in again.";
 const CLOUD_REQUIREMENTS_CACHE_WRITE_HMAC_KEY: &[u8] =
     b"codex-cloud-requirements-cache-v3-064f8542-75b4-494c-a294-97d3ce597271";
@@ -2083,10 +2084,7 @@ enabled = false
             .await
             .expect("cloud requirements task")
             .expect_err("cloud requirements retry exhaustion should fail closed");
-        assert_eq!(
-            err.to_string(),
-            "failed to load your workspace-managed config"
-        );
+        assert_eq!(err.to_string(), CLOUD_REQUIREMENTS_LOAD_FAILED_MESSAGE);
         assert_eq!(err.code(), CloudRequirementsLoadErrorCode::RequestFailed);
         assert_eq!(
             fetcher.request_count.load(Ordering::SeqCst),

--- a/codex-rs/cloud-requirements/src/lib.rs
+++ b/codex-rs/cloud-requirements/src/lib.rs
@@ -50,8 +50,7 @@ const CLOUD_REQUIREMENTS_CACHE_TTL: Duration = Duration::from_secs(30 * 60);
 const CLOUD_REQUIREMENTS_FETCH_ATTEMPT_METRIC: &str = "codex.cloud_requirements.fetch_attempt";
 const CLOUD_REQUIREMENTS_FETCH_FINAL_METRIC: &str = "codex.cloud_requirements.fetch_final";
 const CLOUD_REQUIREMENTS_LOAD_METRIC: &str = "codex.cloud_requirements.load";
-const CLOUD_REQUIREMENTS_LOAD_FAILED_MESSAGE: &str =
-    "failed to load cloud requirements (workspace-managed policies)";
+const CLOUD_REQUIREMENTS_LOAD_FAILED_MESSAGE: &str = "Failed to load cloud requirements (workspace-managed policies).";
 const CLOUD_REQUIREMENTS_PARSE_FAILED_MESSAGE: &str = "Cloud requirements (workspace-managed policies) are invalid and could not be parsed. Please contact your workspace admin.";
 const CLOUD_REQUIREMENTS_AUTH_RECOVERY_FAILED_MESSAGE: &str = "Your authentication session could not be refreshed automatically. Please log out and sign in again.";
 const CLOUD_REQUIREMENTS_CACHE_WRITE_HMAC_KEY: &[u8] =


### PR DESCRIPTION
## Why
The current cloud-requirements failures say `workspace-managed config`, which is ambiguous and can read like it refers to local managed config such as `managed_config.toml`.

This code path only applies to cloud requirements, so the user-facing message should name that source directly.

## What changed
- Updated the load failure in [`codex-rs/cloud-requirements/src/lib.rs`](https://github.com/openai/codex/blob/46e704d1f93054daa9a3b5a9100333c540c81d50/codex-rs/cloud-requirements/src/lib.rs) to say `failed to load cloud requirements (workspace-managed policies)`.
- Updated the parse failure in the same file to use the same `cloud requirements (workspace-managed policies)` terminology.
- Kept `workspace-managed` hyphenated because it is used as a compound modifier.
- Updated the matching assertion in [`codex-rs/app-server/src/codex_message_processor.rs`](https://github.com/openai/codex/blob/46e704d1f93054daa9a3b5a9100333c540c81d50/codex-rs/app-server/src/codex_message_processor.rs).
- Reused `CLOUD_REQUIREMENTS_LOAD_FAILED_MESSAGE` in the `codex-cloud-requirements` test where the test is asserting that crate-local contract directly.

## Testing
`cargo test -p codex-cloud-requirements`
