### PR TITLE
Use remote plugin IDs for detail reads and enlarge list pages

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1859,7 +1859,6 @@ dependencies = [
  "codex-model-provider-info",
  "codex-models-manager",
  "codex-otel",
- "codex-plugin",
  "codex-protocol",
  "codex-rmcp-client",
  "codex-rollout",

--- a/codex-rs/app-server/Cargo.toml
+++ b/codex-rs/app-server/Cargo.toml
@@ -40,7 +40,6 @@ codex-exec-server = { workspace = true }
 codex-features = { workspace = true }
 codex-git-utils = { workspace = true }
 codex-otel = { workspace = true }
-codex-plugin = { workspace = true }
 codex-shell-command = { workspace = true }
 codex-utils-cli = { workspace = true }
 codex-utils-pty = { workspace = true }

--- a/codex-rs/app-server/src/codex_message_processor/plugins.rs
+++ b/codex-rs/app-server/src/codex_message_processor/plugins.rs
@@ -1,5 +1,4 @@
 use super::*;
-use codex_plugin::validate_plugin_segment;
 
 impl CodexMessageProcessor {
     pub(super) async fn plugin_list(
@@ -289,20 +288,24 @@ impl CodexMessageProcessor {
                 let remote_plugin_service_config = RemotePluginServiceConfig {
                     chatgpt_base_url: config.chatgpt_base_url.clone(),
                 };
-                if let Err(err) = validate_plugin_segment(&plugin_name, "plugin name") {
+                if plugin_name.is_empty()
+                    || !plugin_name
+                        .chars()
+                        .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' || ch == '~')
+                {
                     self.send_invalid_request_error(
                         request_id,
-                        format!("invalid remote plugin id: {err}"),
+                        "invalid remote plugin id: only ASCII letters, digits, `_`, `-`, and `~` are allowed"
+                            .to_string(),
                     )
                     .await;
                     return;
                 }
-                let remote_plugin_id = format!("{plugin_name}@{remote_marketplace_name}");
                 let remote_detail = match codex_core_plugins::remote::fetch_remote_plugin_detail(
                     &remote_plugin_service_config,
                     auth.as_ref(),
                     &remote_marketplace_name,
-                    &remote_plugin_id,
+                    &plugin_name,
                 )
                 .await
                 {

--- a/codex-rs/app-server/tests/suite/v2/plugin_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/plugin_list.rs
@@ -963,7 +963,7 @@ async fn plugin_list_includes_remote_marketplaces_when_remote_plugin_enabled() -
     let global_directory_body = r#"{
   "plugins": [
     {
-      "id": "linear@chatgpt-global",
+      "id": "plugins~Plugin_linear",
       "name": "linear",
       "scope": "GLOBAL",
       "installation_policy": "AVAILABLE",
@@ -997,7 +997,7 @@ async fn plugin_list_includes_remote_marketplaces_when_remote_plugin_enabled() -
     let global_installed_body = r#"{
   "plugins": [
     {
-      "id": "linear@chatgpt-global",
+      "id": "plugins~Plugin_linear",
       "name": "linear",
       "scope": "GLOBAL",
       "installation_policy": "AVAILABLE",
@@ -1027,6 +1027,7 @@ async fn plugin_list_includes_remote_marketplaces_when_remote_plugin_enabled() -
     Mock::given(method("GET"))
         .and(path("/backend-api/ps/plugins/list"))
         .and(query_param("scope", "GLOBAL"))
+        .and(query_param("limit", "200"))
         .and(header("authorization", "Bearer chatgpt-token"))
         .and(header("chatgpt-account-id", "account-123"))
         .respond_with(ResponseTemplate::new(200).set_body_string(global_directory_body))
@@ -1035,6 +1036,7 @@ async fn plugin_list_includes_remote_marketplaces_when_remote_plugin_enabled() -
     Mock::given(method("GET"))
         .and(path("/backend-api/ps/plugins/list"))
         .and(query_param("scope", "WORKSPACE"))
+        .and(query_param("limit", "200"))
         .and(header("authorization", "Bearer chatgpt-token"))
         .and(header("chatgpt-account-id", "account-123"))
         .respond_with(ResponseTemplate::new(200).set_body_string(empty_page_body))
@@ -1085,7 +1087,7 @@ async fn plugin_list_includes_remote_marketplaces_when_remote_plugin_enabled() -
         Some("ChatGPT Plugins")
     );
     assert_eq!(remote_marketplace.plugins.len(), 1);
-    assert_eq!(remote_marketplace.plugins[0].id, "linear@chatgpt-global");
+    assert_eq!(remote_marketplace.plugins[0].id, "plugins~Plugin_linear");
     assert_eq!(remote_marketplace.plugins[0].name, "linear");
     assert_eq!(remote_marketplace.plugins[0].source, PluginSource::Remote);
     assert_eq!(remote_marketplace.plugins[0].installed, true);
@@ -1144,7 +1146,7 @@ async fn plugin_list_remote_marketplace_replaces_local_marketplace_with_same_nam
     let global_directory_body = r#"{
   "plugins": [
     {
-      "id": "linear@chatgpt-global",
+      "id": "plugins~Plugin_linear",
       "name": "linear",
       "scope": "GLOBAL",
       "installation_policy": "AVAILABLE",
@@ -1170,30 +1172,27 @@ async fn plugin_list_remote_marketplace_replaces_local_marketplace_with_same_nam
     "next_page_token": null
   }
 }"#;
-    for (path_suffix, scope, body) in [
-        (
-            "/backend-api/ps/plugins/list",
-            "GLOBAL",
-            global_directory_body,
-        ),
-        ("/backend-api/ps/plugins/list", "WORKSPACE", empty_page_body),
-        (
-            "/backend-api/ps/plugins/installed",
-            "GLOBAL",
-            empty_page_body,
-        ),
-        (
-            "/backend-api/ps/plugins/installed",
-            "WORKSPACE",
-            empty_page_body,
-        ),
+    for (scope, body) in [
+        ("GLOBAL", global_directory_body),
+        ("WORKSPACE", empty_page_body),
     ] {
         Mock::given(method("GET"))
-            .and(path(path_suffix))
+            .and(path("/backend-api/ps/plugins/list"))
             .and(query_param("scope", scope))
+            .and(query_param("limit", "200"))
             .and(header("authorization", "Bearer chatgpt-token"))
             .and(header("chatgpt-account-id", "account-123"))
             .respond_with(ResponseTemplate::new(200).set_body_string(body))
+            .mount(&server)
+            .await;
+    }
+    for scope in ["GLOBAL", "WORKSPACE"] {
+        Mock::given(method("GET"))
+            .and(path("/backend-api/ps/plugins/installed"))
+            .and(query_param("scope", scope))
+            .and(header("authorization", "Bearer chatgpt-token"))
+            .and(header("chatgpt-account-id", "account-123"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(empty_page_body))
             .mount(&server)
             .await;
     }

--- a/codex-rs/app-server/tests/suite/v2/plugin_read.rs
+++ b/codex-rs/app-server/tests/suite/v2/plugin_read.rs
@@ -161,7 +161,7 @@ async fn plugin_read_reads_remote_plugin_details_when_remote_plugin_enabled() ->
     )?;
 
     let detail_body = r#"{
-  "id": "linear@chatgpt-global",
+  "id": "plugins~Plugin_linear",
   "name": "linear",
   "scope": "GLOBAL",
   "installation_policy": "AVAILABLE",
@@ -192,7 +192,7 @@ async fn plugin_read_reads_remote_plugin_details_when_remote_plugin_enabled() ->
     let installed_body = r#"{
   "plugins": [
     {
-      "id": "linear@chatgpt-global",
+      "id": "plugins~Plugin_linear",
       "name": "linear",
       "scope": "GLOBAL",
       "installation_policy": "AVAILABLE",
@@ -230,7 +230,7 @@ async fn plugin_read_reads_remote_plugin_details_when_remote_plugin_enabled() ->
 }"#;
 
     Mock::given(method("GET"))
-        .and(path("/backend-api/ps/plugins/linear@chatgpt-global"))
+        .and(path("/backend-api/ps/plugins/plugins~Plugin_linear"))
         .and(header("authorization", "Bearer chatgpt-token"))
         .and(header("chatgpt-account-id", "account-123"))
         .respond_with(ResponseTemplate::new(200).set_body_string(detail_body))
@@ -252,7 +252,7 @@ async fn plugin_read_reads_remote_plugin_details_when_remote_plugin_enabled() ->
         .send_plugin_read_request(PluginReadParams {
             marketplace_path: None,
             remote_marketplace_name: Some("chatgpt-global".to_string()),
-            plugin_name: "linear".to_string(),
+            plugin_name: "plugins~Plugin_linear".to_string(),
         })
         .await?;
 
@@ -266,7 +266,7 @@ async fn plugin_read_reads_remote_plugin_details_when_remote_plugin_enabled() ->
     assert_eq!(response.plugin.marketplace_name, "chatgpt-global");
     assert_eq!(response.plugin.marketplace_path, None);
     assert_eq!(response.plugin.summary.source, PluginSource::Remote);
-    assert_eq!(response.plugin.summary.id, "linear@chatgpt-global");
+    assert_eq!(response.plugin.summary.id, "plugins~Plugin_linear");
     assert_eq!(response.plugin.summary.name, "linear");
     assert_eq!(response.plugin.summary.installed, true);
     assert_eq!(response.plugin.summary.enabled, false);
@@ -300,7 +300,7 @@ async fn plugin_read_maps_missing_remote_plugin_to_invalid_request() -> Result<(
     )?;
 
     Mock::given(method("GET"))
-        .and(path("/backend-api/ps/plugins/missing@chatgpt-global"))
+        .and(path("/backend-api/ps/plugins/plugins~Plugin_missing"))
         .and(header("authorization", "Bearer chatgpt-token"))
         .and(header("chatgpt-account-id", "account-123"))
         .respond_with(ResponseTemplate::new(404).set_body_string(r#"{"detail":"not found"}"#))
@@ -314,7 +314,7 @@ async fn plugin_read_maps_missing_remote_plugin_to_invalid_request() -> Result<(
         .send_plugin_read_request(PluginReadParams {
             marketplace_path: None,
             remote_marketplace_name: Some("chatgpt-global".to_string()),
-            plugin_name: "missing".to_string(),
+            plugin_name: "plugins~Plugin_missing".to_string(),
         })
         .await?;
 
@@ -408,7 +408,11 @@ async fn plugin_read_rejects_invalid_remote_plugin_name() -> Result<()> {
 
     assert_eq!(err.error.code, -32600);
     assert!(err.error.message.contains("invalid remote plugin id"));
-    assert!(err.error.message.contains("invalid plugin name"));
+    assert!(
+        err.error
+            .message
+            .contains("only ASCII letters, digits, `_`, `-`, and `~` are allowed")
+    );
     Ok(())
 }
 

--- a/codex-rs/core-plugins/src/remote.rs
+++ b/codex-rs/core-plugins/src/remote.rs
@@ -17,6 +17,7 @@ pub const REMOTE_GLOBAL_MARKETPLACE_DISPLAY_NAME: &str = "ChatGPT Plugins";
 pub const REMOTE_WORKSPACE_MARKETPLACE_DISPLAY_NAME: &str = "ChatGPT Workspace Plugins";
 
 const REMOTE_PLUGIN_CATALOG_TIMEOUT: Duration = Duration::from_secs(30);
+const REMOTE_PLUGIN_LIST_PAGE_LIMIT: u32 = 200;
 const MAX_REMOTE_DEFAULT_PROMPT_LEN: usize = 128;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -567,6 +568,7 @@ async fn get_remote_plugin_list_page(
     let client = build_reqwest_client();
     let mut request = authenticated_request(client.get(&url), auth)?;
     request = request.query(&[("scope", scope.api_value())]);
+    request = request.query(&[("limit", REMOTE_PLUGIN_LIST_PAGE_LIMIT)]);
     if let Some(page_token) = page_token {
         request = request.query(&[("pageToken", page_token)]);
     }


### PR DESCRIPTION
1. For remote plugin use plugin id (plugin name) directly for read plugin details;
2. Request up to 200 remote plugins per directory list page.