### PR TITLE
bazel: shard slower Rust test targets

### DIFF
--- a/codex-rs/exec/BUILD.bazel
+++ b/codex-rs/exec/BUILD.bazel
@@ -3,5 +3,8 @@ load("//:defs.bzl", "codex_rust_crate")
 codex_rust_crate(
     name = "exec",
     crate_name = "codex_exec",
+    test_shard_counts = {
+        "exec-all-test": 8,
+    },
     test_tags = ["no-sandbox"],
 )

--- a/codex-rs/shell-command/BUILD.bazel
+++ b/codex-rs/shell-command/BUILD.bazel
@@ -4,4 +4,7 @@ codex_rust_crate(
     name = "shell-command",
     crate_name = "codex_shell_command",
     compile_data = ["src/command_safety/powershell_parser.ps1"],
+    test_shard_counts = {
+        "shell-command-unit-tests": 8,
+    },
 )

--- a/codex-rs/state/BUILD.bazel
+++ b/codex-rs/state/BUILD.bazel
@@ -4,4 +4,7 @@ codex_rust_crate(
     name = "state",
     crate_name = "codex_state",
     compile_data = glob(["logs_migrations/**", "migrations/**"]),
+    test_shard_counts = {
+        "state-unit-tests": 4,
+    },
 )


### PR DESCRIPTION
## Why

This is perhaps the best way to view the data: https://app.buildbuddy.io/tests/?sort=maxDuration&direction=desc

Windows Bazel CI spends a meaningful amount of wall time in a few unsharded Rust test binaries. Looking at BuildBuddy spawns and cache-origin invocations, the slowest unsharded candidates were:

- `//codex-rs/shell-command:shell-command-unit-tests`: 177 tests, 112.19s on a local Windows execution in https://app.buildbuddy.io/invocation/687cd84f-7fc2-4d01-b3d4-e63314b1a9e4?target=%2F%2Fcodex-rs%2Fshell-command%3Ashell-command-unit-tests
- `//codex-rs/exec:exec-all-test`: 40.9s in the current Windows invocation, with the Mac run also showing it as one of the larger unsharded test targets
- `//codex-rs/state:state-unit-tests`: 94 tests, 44.92s on a local Windows execution in https://app.buildbuddy.io/invocation/687cd84f-7fc2-4d01-b3d4-e63314b1a9e4?target=%2F%2Fcodex-rs%2Fstate%3Astate-unit-tests

These are good fits for the existing `test_shard_counts` mechanism because they are single Rust test binaries with enough test cases to distribute across Bazel shards.

## What changed

- Shard `shell-command-unit-tests` into 8 shards.
- Shard `exec-all-test` into 8 shards.
- Shard `state-unit-tests` into 4 shards.

I intentionally did not shard `utils/image:image-unit-tests` even though it was about 41s on Windows, because it only has 6 tests and is a better candidate for targeted test optimization or a smaller follow-up.

## Verification

Verified Bazel expansion with:

- `bazel query --output=build //codex-rs/exec:exec-all-test`
- `bazel query --output=build //codex-rs/shell-command:shell-command-unit-tests`
- `bazel query --output=build //codex-rs/state:state-unit-tests`

Those confirmed shard counts of 8, 8, and 4 respectively.