### PR TITLE
Drop duplicate contiguous user messages during compaction

### DIFF
--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -393,9 +393,10 @@ pub fn content_items_to_text(content: &[ContentItem]) -> Option<String> {
 }
 
 pub(crate) fn collect_user_messages(items: &[ResponseItem]) -> Vec<String> {
-    items
-        .iter()
-        .filter_map(|item| match crate::event_mapping::parse_turn_item(item) {
+    let mut messages = Vec::new();
+    let mut previous_message: Option<String> = Some(String::new());
+    for item in items {
+        let message = match crate::event_mapping::parse_turn_item(item) {
             Some(TurnItem::UserMessage(user)) => {
                 if is_summary_message(&user.message()) {
                     None
@@ -404,8 +405,21 @@ pub(crate) fn collect_user_messages(items: &[ResponseItem]) -> Vec<String> {
                 }
             }
             _ => None,
-        })
-        .collect()
+        };
+        let Some(message) = message else {
+            previous_message = None;
+            continue;
+        };
+        if message.is_empty() {
+            continue;
+        }
+        if previous_message.as_deref() == Some(message.as_str()) {
+            continue;
+        }
+        previous_message = Some(message.clone());
+        messages.push(message);
+    }
+    messages
 }
 
 pub(crate) fn is_summary_message(message: &str) -> bool {

--- a/codex-rs/core/src/compact_tests.rs
+++ b/codex-rs/core/src/compact_tests.rs
@@ -126,6 +126,70 @@ do things
 }
 
 #[test]
+fn collect_user_messages_drops_contiguous_duplicates_and_empty_messages() {
+    let items = vec![
+        ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![ContentItem::InputText {
+                text: String::new(),
+            }],
+            end_turn: None,
+            phase: None,
+        },
+        ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![ContentItem::InputText {
+                text: "repeat".to_string(),
+            }],
+            end_turn: None,
+            phase: None,
+        },
+        ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![ContentItem::InputText {
+                text: "repeat".to_string(),
+            }],
+            end_turn: None,
+            phase: None,
+        },
+        ResponseItem::Message {
+            id: None,
+            role: "assistant".to_string(),
+            content: vec![ContentItem::OutputText {
+                text: "keeps the next user message non-contiguous".to_string(),
+            }],
+            end_turn: None,
+            phase: None,
+        },
+        ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![ContentItem::InputText {
+                text: "repeat".to_string(),
+            }],
+            end_turn: None,
+            phase: None,
+        },
+        ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![ContentItem::InputText {
+                text: String::new(),
+            }],
+            end_turn: None,
+            phase: None,
+        },
+    ];
+
+    let collected = collect_user_messages(&items);
+
+    assert_eq!(vec!["repeat".to_string(), "repeat".to_string()], collected);
+}
+
+#[test]
 fn build_token_limited_compacted_history_truncates_overlong_user_messages() {
     // Use a small truncation limit so the test remains fast while still validating
     // that oversized user content is truncated.


### PR DESCRIPTION
## Summary
- drop empty user messages from the user-message list preserved during compaction
- drop duplicate contiguous user messages while preserving repeated user text separated by non-user items
- add focused regression coverage for the compaction collector behavior

## Tests
- `CODEX_SKIP_VENDORED_BWRAP=1 cargo test -p codex-core collect_user_messages_drops_contiguous_duplicates_and_empty_messages`
- `CODEX_SKIP_VENDORED_BWRAP=1 just fix -p codex-core`