### PR TITLE
Allow generated messages to opt out of compaction history

### DIFF
--- a/codex-rs/app-server-protocol/schema/json/ClientRequest.json
+++ b/codex-rs/app-server-protocol/schema/json/ClientRequest.json
@@ -2263,6 +2263,9 @@
                 "null"
               ]
             },
+            "exclude_from_compaction": {
+              "type": "boolean"
+            },
             "id": {
               "type": [
                 "string",

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
@@ -12580,6 +12580,9 @@
                   "null"
                 ]
               },
+              "exclude_from_compaction": {
+                "type": "boolean"
+              },
               "id": {
                 "type": [
                   "string",

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
@@ -9295,6 +9295,9 @@
                 "null"
               ]
             },
+            "exclude_from_compaction": {
+              "type": "boolean"
+            },
             "id": {
               "type": [
                 "string",

--- a/codex-rs/app-server-protocol/schema/json/v2/RawResponseItemCompletedNotification.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/RawResponseItemCompletedNotification.json
@@ -351,6 +351,9 @@
                 "null"
               ]
             },
+            "exclude_from_compaction": {
+              "type": "boolean"
+            },
             "id": {
               "type": [
                 "string",

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadResumeParams.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadResumeParams.json
@@ -691,6 +691,9 @@
                 "null"
               ]
             },
+            "exclude_from_compaction": {
+              "type": "boolean"
+            },
             "id": {
               "type": [
                 "string",

--- a/codex-rs/app-server-protocol/schema/typescript/ResponseItem.ts
+++ b/codex-rs/app-server-protocol/schema/typescript/ResponseItem.ts
@@ -11,7 +11,7 @@ import type { ReasoningItemContent } from "./ReasoningItemContent";
 import type { ReasoningItemReasoningSummary } from "./ReasoningItemReasoningSummary";
 import type { WebSearchAction } from "./WebSearchAction";
 
-export type ResponseItem = { "type": "message", role: string, content: Array<ContentItem>, end_turn?: boolean, phase?: MessagePhase, } | { "type": "reasoning", summary: Array<ReasoningItemReasoningSummary>, content?: Array<ReasoningItemContent>, encrypted_content: string | null, } | { "type": "local_shell_call",
+export type ResponseItem = { "type": "message", role: string, content: Array<ContentItem>, end_turn?: boolean, phase?: MessagePhase, exclude_from_compaction?: boolean, } | { "type": "reasoning", summary: Array<ReasoningItemReasoningSummary>, content?: Array<ReasoningItemContent>, encrypted_content: string | null, } | { "type": "local_shell_call",
 /**
  * Set when using the Responses API.
  */

--- a/codex-rs/app-server-protocol/src/protocol/thread_history.rs
+++ b/codex-rs/app-server-protocol/src/protocol/thread_history.rs
@@ -3098,6 +3098,7 @@ mod tests {
                 }],
                 end_turn: None,
                 phase: None,
+                exclude_from_compaction: false,
             }),
             RolloutItem::EventMsg(EventMsg::TurnComplete(TurnCompleteEvent {
                 turn_id: "turn-a".into(),

--- a/codex-rs/app-server/tests/suite/v2/compaction.rs
+++ b/codex-rs/app-server/tests/suite/v2/compaction.rs
@@ -136,6 +136,7 @@ async fn auto_compaction_remote_emits_started_and_completed_items() -> Result<()
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
         ResponseItem::Compaction {
             encrypted_content: "ENCRYPTED_COMPACTION_SUMMARY".to_string(),

--- a/codex-rs/app-server/tests/suite/v2/thread_inject_items.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_inject_items.rs
@@ -61,6 +61,7 @@ async fn thread_inject_items_adds_raw_response_items_to_thread_history() -> Resu
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     };
 
     let inject_req = mcp
@@ -197,6 +198,7 @@ async fn thread_inject_items_adds_raw_response_items_after_a_turn() -> Result<()
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     };
     let injected_value = serde_json::to_value(&injected_item)?;
 

--- a/codex-rs/app-server/tests/suite/v2/thread_resume.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_resume.rs
@@ -1097,6 +1097,7 @@ async fn thread_resume_rejects_history_when_thread_is_running() -> Result<()> {
                 }],
                 end_turn: None,
                 phase: None,
+                exclude_from_compaction: false,
             }]),
             ..Default::default()
         })
@@ -1926,6 +1927,7 @@ async fn thread_resume_supports_history_and_overrides() -> Result<()> {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     }];
 
     // Resume with explicit history and override the model.

--- a/codex-rs/codex-api/tests/clients.rs
+++ b/codex-rs/codex-api/tests/clients.rs
@@ -425,6 +425,7 @@ async fn azure_default_store_attaches_ids_and_headers() -> Result<()> {
             content: vec![ContentItem::InputText { text: "hi".into() }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         }],
         tools: Vec::new(),
         tool_choice: "auto".into(),

--- a/codex-rs/core/src/agent/control_tests.rs
+++ b/codex-rs/core/src/agent/control_tests.rs
@@ -67,6 +67,7 @@ fn assistant_message(text: &str, phase: Option<MessagePhase>) -> ResponseItem {
             text: text.to_string(),
         }],
         end_turn: None,
+        exclude_from_compaction: false,
         phase,
     }
 }
@@ -521,6 +522,7 @@ async fn append_message_records_assistant_message() {
                 }],
                 end_turn: None,
                 phase: None,
+                exclude_from_compaction: false,
             },
         )
         .await
@@ -679,6 +681,7 @@ async fn spawn_agent_can_fork_parent_thread_history_with_sanitized_items() {
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
         assistant_message("parent final answer", Some(MessagePhase::FinalAnswer)),
     ];

--- a/codex-rs/core/src/arc_monitor.rs
+++ b/codex-rs/core/src/arc_monitor.rs
@@ -330,6 +330,7 @@ fn build_arc_monitor_message_item(
             role,
             content,
             phase: Some(MessagePhase::FinalAnswer),
+            exclude_from_compaction: false,
             ..
         } if role == "assistant" => content_items_to_text(content)
             .map(|text| build_arc_monitor_text_message("assistant", "output_text", text)),

--- a/codex-rs/core/src/arc_monitor_tests.rs
+++ b/codex-rs/core/src/arc_monitor_tests.rs
@@ -67,6 +67,7 @@ async fn build_arc_monitor_request_includes_relevant_history_and_null_policies()
                 }],
                 end_turn: None,
                 phase: None,
+                exclude_from_compaction: false,
             }],
             &turn_context,
         )
@@ -96,6 +97,7 @@ async fn build_arc_monitor_request_includes_relevant_history_and_null_policies()
                 }],
                 end_turn: None,
                 phase: Some(MessagePhase::Commentary),
+                exclude_from_compaction: false,
             }],
             &turn_context,
         )
@@ -110,6 +112,7 @@ async fn build_arc_monitor_request_includes_relevant_history_and_null_policies()
                 }],
                 end_turn: None,
                 phase: Some(MessagePhase::FinalAnswer),
+                exclude_from_compaction: false,
             }],
             &turn_context,
         )
@@ -124,6 +127,7 @@ async fn build_arc_monitor_request_includes_relevant_history_and_null_policies()
                 }],
                 end_turn: None,
                 phase: None,
+                exclude_from_compaction: false,
             }],
             &turn_context,
         )
@@ -279,6 +283,7 @@ async fn monitor_action_posts_expected_arc_request() {
                 }],
                 end_turn: None,
                 phase: None,
+                exclude_from_compaction: false,
             }],
             &turn_context,
         )
@@ -360,6 +365,7 @@ async fn monitor_action_uses_env_url_and_token_overrides() {
                 }],
                 end_turn: None,
                 phase: None,
+                exclude_from_compaction: false,
             }],
             &turn_context,
         )
@@ -430,6 +436,7 @@ async fn monitor_action_rejects_legacy_response_fields() {
                 }],
                 end_turn: None,
                 phase: None,
+                exclude_from_compaction: false,
             }],
             &turn_context,
         )

--- a/codex-rs/core/src/codex_thread.rs
+++ b/codex-rs/core/src/codex_thread.rs
@@ -232,6 +232,7 @@ impl CodexThread {
             content: vec![ContentItem::InputText { text: message }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         };
         let pending_item = match pending_message_input_item(&message) {
             Ok(pending_item) => pending_item,

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -511,6 +511,7 @@ fn build_compacted_history_with_limit(
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         });
     }
 
@@ -526,6 +527,7 @@ fn build_compacted_history_with_limit(
         content: vec![ContentItem::InputText { text: summary_text }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     });
 
     history

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -154,7 +154,7 @@ async fn run_remote_compact_task_inner_impl(
         .cloned()
         .collect();
 
-    let prompt_input = history.for_prompt(&turn_context.model_info.input_modalities);
+    let prompt_input = history.for_compaction_prompt(&turn_context.model_info.input_modalities);
     let tool_router = built_tools(
         sess.as_ref(),
         turn_context.as_ref(),

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -271,6 +271,10 @@ pub(crate) async fn process_compacted_history(
 ///   they parse as `TurnItem::UserMessage`.
 fn should_keep_compacted_history_item(item: &ResponseItem) -> bool {
     match item {
+        ResponseItem::Message {
+            exclude_from_compaction: true,
+            ..
+        } => false,
         ResponseItem::Message { role, .. } if role == "developer" => false,
         ResponseItem::Message { role, .. } if role == "user" => {
             matches!(

--- a/codex-rs/core/src/compact_tests.rs
+++ b/codex-rs/core/src/compact_tests.rs
@@ -65,6 +65,7 @@ fn collect_user_messages_extracts_user_text_only() {
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
         ResponseItem::Message {
             id: Some("user".to_string()),
@@ -74,6 +75,7 @@ fn collect_user_messages_extracts_user_text_only() {
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
         ResponseItem::Other,
     ];
@@ -99,6 +101,7 @@ do things
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
         ResponseItem::Message {
             id: None,
@@ -108,6 +111,7 @@ do things
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
         ResponseItem::Message {
             id: None,
@@ -117,6 +121,7 @@ do things
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
     ];
 
@@ -225,6 +230,7 @@ async fn process_compacted_history_replaces_developer_messages() {
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
         ResponseItem::Message {
             id: None,
@@ -234,6 +240,7 @@ async fn process_compacted_history_replaces_developer_messages() {
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
         ResponseItem::Message {
             id: None,
@@ -243,6 +250,7 @@ async fn process_compacted_history_replaces_developer_messages() {
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
     ];
     let (refreshed, mut expected) = process_compacted_history_with_test_session(
@@ -258,6 +266,7 @@ async fn process_compacted_history_replaces_developer_messages() {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     });
     assert_eq!(refreshed, expected);
 }
@@ -272,6 +281,7 @@ async fn process_compacted_history_reinjects_full_initial_context() {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     }];
     let (refreshed, mut expected) = process_compacted_history_with_test_session(
         compacted_history,
@@ -286,7 +296,51 @@ async fn process_compacted_history_reinjects_full_initial_context() {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     });
+    assert_eq!(refreshed, expected);
+}
+
+#[tokio::test]
+async fn process_compacted_history_drops_items_marked_excluded_from_compaction() {
+    let compacted_history = vec![
+        ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![ContentItem::InputText {
+                text: "generated warning".to_string(),
+            }],
+            end_turn: None,
+            phase: None,
+            exclude_from_compaction: true,
+        },
+        ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![ContentItem::InputText {
+                text: "real user message".to_string(),
+            }],
+            end_turn: None,
+            phase: None,
+            exclude_from_compaction: false,
+        },
+    ];
+    let (refreshed, mut expected) = process_compacted_history_with_test_session(
+        compacted_history,
+        /*previous_turn_settings*/ None,
+    )
+    .await;
+    expected.push(ResponseItem::Message {
+        id: None,
+        role: "user".to_string(),
+        content: vec![ContentItem::InputText {
+            text: "real user message".to_string(),
+        }],
+        end_turn: None,
+        phase: None,
+        exclude_from_compaction: false,
+    });
+
     assert_eq!(refreshed, expected);
 }
 
@@ -306,6 +360,7 @@ keep me updated
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
         ResponseItem::Message {
             id: None,
@@ -319,6 +374,7 @@ keep me updated
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
         ResponseItem::Message {
             id: None,
@@ -332,6 +388,7 @@ keep me updated
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
         ResponseItem::Message {
             id: None,
@@ -341,6 +398,7 @@ keep me updated
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
         ResponseItem::Message {
             id: None,
@@ -350,6 +408,7 @@ keep me updated
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
     ];
     let (refreshed, mut expected) = process_compacted_history_with_test_session(
@@ -365,6 +424,7 @@ keep me updated
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     });
     assert_eq!(refreshed, expected);
 }
@@ -380,6 +440,7 @@ async fn process_compacted_history_inserts_context_before_last_real_user_message
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
         ResponseItem::Message {
             id: None,
@@ -389,6 +450,7 @@ async fn process_compacted_history_inserts_context_before_last_real_user_message
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
         ResponseItem::Message {
             id: None,
@@ -398,6 +460,7 @@ async fn process_compacted_history_inserts_context_before_last_real_user_message
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
     ];
 
@@ -415,6 +478,7 @@ async fn process_compacted_history_inserts_context_before_last_real_user_message
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
         ResponseItem::Message {
             id: None,
@@ -424,6 +488,7 @@ async fn process_compacted_history_inserts_context_before_last_real_user_message
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
     ];
     expected.extend(initial_context);
@@ -435,6 +500,7 @@ async fn process_compacted_history_inserts_context_before_last_real_user_message
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     });
     assert_eq!(refreshed, expected);
 }
@@ -449,6 +515,7 @@ async fn process_compacted_history_reinjects_model_switch_message() {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     }];
     let previous_turn_settings = PreviousTurnSettings {
         model: "previous-regular-model".to_string(),
@@ -479,6 +546,7 @@ async fn process_compacted_history_reinjects_model_switch_message() {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     });
     assert_eq!(refreshed, expected);
 }
@@ -494,6 +562,7 @@ fn insert_initial_context_before_last_real_user_or_summary_keeps_summary_last() 
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
         ResponseItem::Message {
             id: None,
@@ -503,6 +572,7 @@ fn insert_initial_context_before_last_real_user_or_summary_keeps_summary_last() 
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
         ResponseItem::Message {
             id: None,
@@ -512,6 +582,7 @@ fn insert_initial_context_before_last_real_user_or_summary_keeps_summary_last() 
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
     ];
     let initial_context = vec![ResponseItem::Message {
@@ -522,6 +593,7 @@ fn insert_initial_context_before_last_real_user_or_summary_keeps_summary_last() 
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     }];
 
     let refreshed =
@@ -535,6 +607,7 @@ fn insert_initial_context_before_last_real_user_or_summary_keeps_summary_last() 
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
         ResponseItem::Message {
             id: None,
@@ -544,6 +617,7 @@ fn insert_initial_context_before_last_real_user_or_summary_keeps_summary_last() 
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
         ResponseItem::Message {
             id: None,
@@ -553,6 +627,7 @@ fn insert_initial_context_before_last_real_user_or_summary_keeps_summary_last() 
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
         ResponseItem::Message {
             id: None,
@@ -562,6 +637,7 @@ fn insert_initial_context_before_last_real_user_or_summary_keeps_summary_last() 
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
     ];
     assert_eq!(refreshed, expected);
@@ -580,6 +656,7 @@ fn insert_initial_context_before_last_real_user_or_summary_keeps_compaction_last
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     }];
 
     let refreshed =
@@ -593,6 +670,7 @@ fn insert_initial_context_before_last_real_user_or_summary_keeps_compaction_last
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
         ResponseItem::Compaction {
             encrypted_content: "encrypted".to_string(),

--- a/codex-rs/core/src/context/fragment.rs
+++ b/codex-rs/core/src/context/fragment.rs
@@ -83,6 +83,7 @@ pub trait ContextualUserFragment {
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         }
     }
 }

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -121,6 +121,15 @@ impl ContextManager {
         self.normalize_history(input_modalities);
         self.items
             .retain(|item| !matches!(item, ResponseItem::GhostSnapshot { .. }));
+        for item in &mut self.items {
+            if let ResponseItem::Message {
+                exclude_from_compaction,
+                ..
+            } = item
+            {
+                *exclude_from_compaction = false;
+            }
+        }
         self.items
     }
 

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -118,9 +118,38 @@ impl ContextManager {
     /// include `InputModality::Image`, images are stripped from messages and tool
     /// outputs.
     pub(crate) fn for_prompt(mut self, input_modalities: &[InputModality]) -> Vec<ResponseItem> {
-        self.normalize_history(input_modalities);
+        self.prepare_for_prompt(input_modalities, CompactionExclusionPolicy::Keep);
         self.items
-            .retain(|item| !matches!(item, ResponseItem::GhostSnapshot { .. }));
+    }
+
+    /// Returns the history prepared for the remote compaction endpoint.
+    pub(crate) fn for_compaction_prompt(
+        mut self,
+        input_modalities: &[InputModality],
+    ) -> Vec<ResponseItem> {
+        self.prepare_for_prompt(input_modalities, CompactionExclusionPolicy::Drop);
+        self.items
+    }
+
+    fn prepare_for_prompt(
+        &mut self,
+        input_modalities: &[InputModality],
+        compaction_exclusion_policy: CompactionExclusionPolicy,
+    ) {
+        self.normalize_history(input_modalities);
+        self.items.retain(|item| {
+            !matches!(item, ResponseItem::GhostSnapshot { .. })
+                && !matches!(
+                    (compaction_exclusion_policy, item),
+                    (
+                        CompactionExclusionPolicy::Drop,
+                        ResponseItem::Message {
+                            exclude_from_compaction: true,
+                            ..
+                        }
+                    )
+                )
+        });
         for item in &mut self.items {
             if let ResponseItem::Message {
                 exclude_from_compaction,
@@ -130,7 +159,6 @@ impl ContextManager {
                 *exclude_from_compaction = false;
             }
         }
-        self.items
     }
 
     /// Returns raw items in the history.
@@ -463,6 +491,12 @@ impl ContextManager {
         }
         cut_idx
     }
+}
+
+#[derive(Clone, Copy)]
+enum CompactionExclusionPolicy {
+    Keep,
+    Drop,
 }
 
 fn truncate_function_output_payload(

--- a/codex-rs/core/src/context_manager/history_tests.rs
+++ b/codex-rs/core/src/context_manager/history_tests.rs
@@ -43,6 +43,7 @@ fn assistant_msg(text: &str) -> ResponseItem {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     }
 }
 
@@ -62,6 +63,7 @@ fn inter_agent_assistant_msg(text: &str) -> ResponseItem {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     }
 }
 
@@ -82,6 +84,7 @@ fn user_msg(text: &str) -> ResponseItem {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     }
 }
 
@@ -94,6 +97,7 @@ fn user_input_text_msg(text: &str) -> ResponseItem {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     }
 }
 
@@ -106,6 +110,7 @@ fn developer_msg(text: &str) -> ResponseItem {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     }
 }
 
@@ -121,6 +126,7 @@ fn developer_msg_with_fragments(texts: &[&str]) -> ResponseItem {
             .collect(),
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     }
 }
 
@@ -202,6 +208,7 @@ fn filters_non_api_messages() {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     };
     let reasoning = reasoning_msg("thinking...");
     h.record_items([&system, &reasoning, &ResponseItem::Other], policy);
@@ -233,6 +240,7 @@ fn filters_non_api_messages() {
                 }],
                 end_turn: None,
                 phase: None,
+                exclude_from_compaction: false,
             },
             ResponseItem::Message {
                 id: None,
@@ -242,6 +250,7 @@ fn filters_non_api_messages() {
                 }],
                 end_turn: None,
                 phase: None,
+                exclude_from_compaction: false,
             }
         ]
     );
@@ -322,6 +331,25 @@ fn for_prompt_preserves_inter_agent_assistant_messages() {
 }
 
 #[test]
+fn for_prompt_strips_compaction_exclusion_marker() {
+    let mut item = user_input_text_msg("generated warning");
+    let ResponseItem::Message {
+        exclude_from_compaction,
+        ..
+    } = &mut item
+    else {
+        panic!("expected message item");
+    };
+    *exclude_from_compaction = true;
+    let history = create_history_with_items(vec![item]);
+
+    let prompt_items = history.for_prompt(&default_input_modalities());
+
+    let expected = vec![user_input_text_msg("generated warning")];
+    assert_eq!(prompt_items, expected);
+}
+
+#[test]
 fn drop_last_n_user_turns_treats_inter_agent_assistant_messages_as_instruction_turns() {
     let first_turn = user_input_text_msg("first");
     let first_reply = assistant_msg("done");
@@ -392,6 +420,7 @@ fn for_prompt_strips_images_when_model_does_not_support_images() {
             ],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
         ResponseItem::FunctionCall {
             id: None,
@@ -455,6 +484,7 @@ fn for_prompt_strips_images_when_model_does_not_support_images() {
             ],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
         ResponseItem::FunctionCall {
             id: None,
@@ -514,6 +544,7 @@ fn for_prompt_strips_images_when_model_does_not_support_images() {
         ],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     }]);
     let preserved = with_images.for_prompt(&modalities);
     assert_eq!(preserved.len(), 1);
@@ -542,6 +573,7 @@ fn for_prompt_preserves_image_generation_calls_when_images_are_supported() {
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
     ]);
 
@@ -562,6 +594,7 @@ fn for_prompt_preserves_image_generation_calls_when_images_are_supported() {
                 }],
                 end_turn: None,
                 phase: None,
+                exclude_from_compaction: false,
             }
         ]
     );
@@ -578,6 +611,7 @@ fn for_prompt_clears_image_generation_result_when_images_are_unsupported() {
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
         ResponseItem::ImageGenerationCall {
             id: "ig_123".to_string(),
@@ -598,6 +632,7 @@ fn for_prompt_clears_image_generation_result_when_images_are_unsupported() {
                 }],
                 end_turn: None,
                 phase: None,
+                exclude_from_compaction: false,
             },
             ResponseItem::ImageGenerationCall {
                 id: "ig_123".to_string(),
@@ -760,6 +795,7 @@ fn replace_last_turn_images_does_not_touch_user_images() {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     }];
     let mut history = create_history_with_items(items.clone());
 
@@ -1692,6 +1728,7 @@ fn image_data_url_payload_does_not_dominate_message_estimate() {
         ],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     };
     let text_only_item = ResponseItem::Message {
         id: None,
@@ -1701,6 +1738,7 @@ fn image_data_url_payload_does_not_dominate_message_estimate() {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     };
 
     let raw_len = serde_json::to_string(&image_item).unwrap().len() as i64;
@@ -1775,6 +1813,7 @@ fn non_base64_image_urls_are_unchanged() {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     };
     let function_output_item = ResponseItem::FunctionCallOutput {
         call_id: "call-1".to_string(),
@@ -1807,6 +1846,7 @@ fn data_url_without_base64_marker_is_unchanged() {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     };
 
     assert_eq!(
@@ -1848,6 +1888,7 @@ fn mixed_case_data_url_markers_are_adjusted() {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     };
 
     let raw_len = serde_json::to_string(&item).unwrap().len() as i64;
@@ -1881,6 +1922,7 @@ fn multiple_inline_images_apply_multiple_fixed_costs() {
         ],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     };
 
     let raw_len = serde_json::to_string(&item).unwrap().len() as i64;
@@ -1964,6 +2006,7 @@ fn text_only_items_unchanged() {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     };
 
     let estimated = estimate_response_item_model_visible_bytes(&item);

--- a/codex-rs/core/src/context_manager/history_tests.rs
+++ b/codex-rs/core/src/context_manager/history_tests.rs
@@ -350,6 +350,26 @@ fn for_prompt_strips_compaction_exclusion_marker() {
 }
 
 #[test]
+fn for_compaction_prompt_drops_items_marked_excluded_from_compaction() {
+    let mut generated_warning = user_input_text_msg("generated warning");
+    let ResponseItem::Message {
+        exclude_from_compaction,
+        ..
+    } = &mut generated_warning
+    else {
+        panic!("expected message item");
+    };
+    *exclude_from_compaction = true;
+    let real_user_message = user_input_text_msg("keep me");
+    let history = create_history_with_items(vec![generated_warning, real_user_message.clone()]);
+
+    assert_eq!(
+        history.for_compaction_prompt(&default_input_modalities()),
+        vec![real_user_message]
+    );
+}
+
+#[test]
 fn drop_last_n_user_turns_treats_inter_agent_assistant_messages_as_instruction_turns() {
     let first_turn = user_input_text_msg("first");
     let first_reply = assistant_msg("done");

--- a/codex-rs/core/src/context_manager/updates.rs
+++ b/codex-rs/core/src/context_manager/updates.rs
@@ -199,6 +199,7 @@ fn build_text_message(role: &str, text_sections: Vec<String>) -> Option<Response
         content,
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     })
 }
 

--- a/codex-rs/core/src/event_mapping_tests.rs
+++ b/codex-rs/core/src/event_mapping_tests.rs
@@ -36,6 +36,7 @@ fn parses_user_message_with_text_and_two_images() {
         ],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     };
 
     let turn_item = parse_turn_item(&item).expect("expected user message turn item");
@@ -80,6 +81,7 @@ fn skips_local_image_label_text() {
         ],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     };
 
     let turn_item = parse_turn_item(&item).expect("expected user message turn item");
@@ -110,6 +112,7 @@ fn parses_assistant_message_input_text_for_backward_compatibility() {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     };
 
     let turn_item = parse_turn_item(&item).expect("expected assistant message turn item");
@@ -160,6 +163,7 @@ fn skips_unnamed_image_label_text() {
         ],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     };
 
     let turn_item = parse_turn_item(&item).expect("expected user message turn item");
@@ -190,6 +194,7 @@ fn skips_user_instructions_and_env() {
                 }],
                 end_turn: None,
             phase: None,
+                exclude_from_compaction: false,
             },
             ResponseItem::Message {
                 id: None,
@@ -199,6 +204,7 @@ fn skips_user_instructions_and_env() {
                 }],
                 end_turn: None,
             phase: None,
+                exclude_from_compaction: false,
             },
             ResponseItem::Message {
                 id: None,
@@ -208,6 +214,7 @@ fn skips_user_instructions_and_env() {
                 }],
                 end_turn: None,
             phase: None,
+                exclude_from_compaction: false,
             },
             ResponseItem::Message {
                 id: None,
@@ -218,6 +225,7 @@ fn skips_user_instructions_and_env() {
                 }],
                 end_turn: None,
             phase: None,
+                exclude_from_compaction: false,
             },
             ResponseItem::Message {
                 id: None,
@@ -227,6 +235,7 @@ fn skips_user_instructions_and_env() {
                 }],
                 end_turn: None,
             phase: None,
+                exclude_from_compaction: false,
             },
             ResponseItem::Message {
                 id: None,
@@ -243,6 +252,7 @@ fn skips_user_instructions_and_env() {
                 ],
                 end_turn: None,
                 phase: None,
+                exclude_from_compaction: false,
             },
         ];
 
@@ -294,6 +304,7 @@ fn parses_hook_prompt_and_hides_other_contextual_fragments() {
         ],
         end_turn: None,
         phase: None,
+                exclude_from_compaction: false,
     };
 
     let turn_item = parse_turn_item(&item).expect("expected hook prompt turn item");
@@ -323,6 +334,7 @@ fn parses_agent_message() {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     };
 
     let turn_item = parse_turn_item(&item).expect("expected agent message turn item");

--- a/codex-rs/core/src/guardian/tests.rs
+++ b/codex-rs/core/src/guardian/tests.rs
@@ -177,6 +177,7 @@ async fn seed_guardian_parent_history(session: &Arc<Session>, turn: &Arc<TurnCon
                     }],
                     end_turn: None,
                     phase: None,
+                    exclude_from_compaction: false,
                 },
                 ResponseItem::FunctionCall {
                     id: None,
@@ -200,6 +201,7 @@ async fn seed_guardian_parent_history(session: &Arc<Session>, turn: &Arc<TurnCon
                     }],
                     end_turn: None,
                     phase: None,
+                    exclude_from_compaction: false,
                 },
             ],
             turn.as_ref(),
@@ -344,6 +346,7 @@ async fn build_guardian_prompt_delta_mode_preserves_original_numbering() -> anyh
                     }],
                     end_turn: None,
                     phase: None,
+                    exclude_from_compaction: false,
                 },
                 ResponseItem::Message {
                     id: None,
@@ -353,6 +356,7 @@ async fn build_guardian_prompt_delta_mode_preserves_original_numbering() -> anyh
                     }],
                     end_turn: None,
                     phase: None,
+                    exclude_from_compaction: false,
                 },
             ],
             turn.as_ref(),
@@ -477,6 +481,7 @@ async fn build_guardian_prompt_stale_delta_version_falls_back_to_full_prompt() -
                     }],
                     end_turn: None,
                     phase: None,
+                    exclude_from_compaction: false,
                 },
                 ResponseItem::Message {
                     id: None,
@@ -486,6 +491,7 @@ async fn build_guardian_prompt_stale_delta_version_falls_back_to_full_prompt() -
                     }],
                     end_turn: None,
                     phase: None,
+                    exclude_from_compaction: false,
                 },
             ],
             /*reference_context_item*/ None,
@@ -502,6 +508,7 @@ async fn build_guardian_prompt_stale_delta_version_falls_back_to_full_prompt() -
                     }],
                     end_turn: None,
                     phase: None,
+                    exclude_from_compaction: false,
                 },
                 ResponseItem::Message {
                     id: None,
@@ -511,6 +518,7 @@ async fn build_guardian_prompt_stale_delta_version_falls_back_to_full_prompt() -
                     }],
                     end_turn: None,
                     phase: None,
+                    exclude_from_compaction: false,
                 },
             ],
             turn.as_ref(),
@@ -560,6 +568,7 @@ fn collect_guardian_transcript_entries_skips_contextual_user_messages() {
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
         ResponseItem::Message {
             id: None,
@@ -569,6 +578,7 @@ fn collect_guardian_transcript_entries_skips_contextual_user_messages() {
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
     ];
 
@@ -595,6 +605,7 @@ fn collect_guardian_transcript_entries_includes_recent_tool_calls_and_output() {
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
         ResponseItem::FunctionCall {
             id: None,
@@ -617,6 +628,7 @@ fn collect_guardian_transcript_entries_includes_recent_tool_calls_and_output() {
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
     ];
 
@@ -1342,6 +1354,7 @@ async fn guardian_reuses_prompt_cache_key_and_appends_prior_reviews() -> anyhow:
                     }],
                     end_turn: None,
                     phase: None,
+                    exclude_from_compaction: false,
                 },
                 ResponseItem::Message {
                     id: None,
@@ -1351,6 +1364,7 @@ async fn guardian_reuses_prompt_cache_key_and_appends_prior_reviews() -> anyhow:
                     }],
                     end_turn: None,
                     phase: None,
+                    exclude_from_compaction: false,
                 },
             ],
             turn.as_ref(),
@@ -1388,6 +1402,7 @@ async fn guardian_reuses_prompt_cache_key_and_appends_prior_reviews() -> anyhow:
                     }],
                     end_turn: None,
                     phase: None,
+                    exclude_from_compaction: false,
                 },
                 ResponseItem::Message {
                     id: None,
@@ -1397,6 +1412,7 @@ async fn guardian_reuses_prompt_cache_key_and_appends_prior_reviews() -> anyhow:
                     }],
                     end_turn: None,
                     phase: None,
+                    exclude_from_compaction: false,
                 },
             ],
             turn.as_ref(),
@@ -1775,6 +1791,7 @@ async fn guardian_parallel_reviews_fork_from_last_committed_trunk_history() -> a
                         }],
                         end_turn: None,
                         phase: None,
+                exclude_from_compaction: false,
                     },
                     ResponseItem::Message {
                         id: None,
@@ -1784,6 +1801,7 @@ async fn guardian_parallel_reviews_fork_from_last_committed_trunk_history() -> a
                         }],
                         end_turn: None,
                         phase: None,
+                exclude_from_compaction: false,
                     },
                 ],
                 turn.as_ref(),
@@ -1844,6 +1862,7 @@ async fn guardian_parallel_reviews_fork_from_last_committed_trunk_history() -> a
                         }],
                         end_turn: None,
                         phase: None,
+                exclude_from_compaction: false,
                     },
                     ResponseItem::Message {
                         id: None,
@@ -1853,6 +1872,7 @@ async fn guardian_parallel_reviews_fork_from_last_committed_trunk_history() -> a
                         }],
                         end_turn: None,
                         phase: None,
+                exclude_from_compaction: false,
                     },
                 ],
                 turn.as_ref(),

--- a/codex-rs/core/src/memories/phase1.rs
+++ b/codex-rs/core/src/memories/phase1.rs
@@ -334,6 +334,7 @@ mod job {
                 }],
                 end_turn: None,
                 phase: None,
+                exclude_from_compaction: false,
             }],
             tools: Vec::new(),
             parallel_tool_calls: false,
@@ -493,6 +494,7 @@ mod job {
             content,
             end_turn,
             phase,
+            exclude_from_compaction,
         } = item
         else {
             return should_persist_response_item_for_memories(item).then(|| item.clone());
@@ -521,6 +523,7 @@ mod job {
             content,
             end_turn: *end_turn,
             phase: phase.clone(),
+            exclude_from_compaction: *exclude_from_compaction,
         })
     }
 }

--- a/codex-rs/core/src/memories/phase1_tests.rs
+++ b/codex-rs/core/src/memories/phase1_tests.rs
@@ -26,6 +26,7 @@ fn serializes_memory_rollout_with_agents_removed_but_environment_kept() {
         ],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     };
     let skill_message = ResponseItem::Message {
         id: None,
@@ -36,6 +37,7 @@ fn serializes_memory_rollout_with_agents_removed_but_environment_kept() {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     };
     let subagent_message = ResponseItem::Message {
         id: None,
@@ -46,6 +48,7 @@ fn serializes_memory_rollout_with_agents_removed_but_environment_kept() {
         }],
         end_turn: None,
         phase: None,
+                exclude_from_compaction: false,
     };
 
     let serialized = serialize_filtered_rollout_response_items(&[
@@ -68,6 +71,7 @@ fn serializes_memory_rollout_with_agents_removed_but_environment_kept() {
                 }],
                 end_turn: None,
                 phase: None,
+                exclude_from_compaction: false,
             },
             subagent_message,
         ]

--- a/codex-rs/core/src/realtime_context_tests.rs
+++ b/codex-rs/core/src/realtime_context_tests.rs
@@ -72,6 +72,7 @@ fn message(role: &str, content: ContentItem) -> ResponseItem {
         content: vec![content],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     }
 }
 

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -2341,6 +2341,7 @@ impl Session {
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: true,
         };
 
         self.record_conversation_items(ctx, &[item]).await;

--- a/codex-rs/core/src/session/rollout_reconstruction_tests.rs
+++ b/codex-rs/core/src/session/rollout_reconstruction_tests.rs
@@ -21,6 +21,7 @@ fn user_message(text: &str) -> ResponseItem {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     }
 }
 
@@ -33,6 +34,7 @@ fn assistant_message(text: &str) -> ResponseItem {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     }
 }
 
@@ -52,6 +54,7 @@ fn inter_agent_assistant_message(text: &str) -> ResponseItem {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     }
 }
 

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -161,6 +161,7 @@ fn user_message(text: &str) -> ResponseItem {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     }
 }
 
@@ -173,6 +174,7 @@ fn assistant_message(text: &str) -> ResponseItem {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     }
 }
 
@@ -233,6 +235,7 @@ fn skill_message(text: &str) -> ResponseItem {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     }
 }
 
@@ -1233,6 +1236,7 @@ async fn reconstruct_history_uses_replacement_history_verbatim() {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     };
     let replacement_history = vec![
         summary_item.clone(),
@@ -1244,6 +1248,7 @@ async fn reconstruct_history_uses_replacement_history_verbatim() {
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
     ];
     let rollout_items = vec![RolloutItem::Compacted(CompactedItem {
@@ -4742,7 +4747,12 @@ async fn record_model_warning_appends_user_message() {
     let last = history_items.last().expect("warning recorded");
 
     match last {
-        ResponseItem::Message { role, content, .. } => {
+        ResponseItem::Message {
+            role,
+            content,
+            exclude_from_compaction,
+            ..
+        } => {
             assert_eq!(role, "user");
             assert_eq!(
                 content,
@@ -4750,6 +4760,7 @@ async fn record_model_warning_appends_user_message() {
                     text: "Warning: too many unified exec processes".to_string(),
                 }]
             );
+            assert!(*exclude_from_compaction);
         }
         other => panic!("expected user message, got {other:?}"),
     }
@@ -5457,6 +5468,7 @@ async fn record_context_updates_and_set_reference_context_item_reinjects_full_co
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     };
     session
         .record_into_history(std::slice::from_ref(&compacted_summary), &turn_context)
@@ -6050,6 +6062,7 @@ async fn task_finish_emits_turn_item_lifecycle_for_leftover_pending_user_input()
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     };
     assert!(
         history.raw_items().iter().any(|item| item == &expected),
@@ -6742,6 +6755,7 @@ async fn sample_rollout(
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     };
     live_history.record_items(
         std::iter::once(&user1),
@@ -6757,6 +6771,7 @@ async fn sample_rollout(
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     };
     live_history.record_items(
         std::iter::once(&assistant1),
@@ -6784,6 +6799,7 @@ async fn sample_rollout(
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     };
     live_history.record_items(
         std::iter::once(&user2),
@@ -6799,6 +6815,7 @@ async fn sample_rollout(
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     };
     live_history.record_items(
         std::iter::once(&assistant2),
@@ -6826,6 +6843,7 @@ async fn sample_rollout(
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     };
     live_history.record_items(
         std::iter::once(&user3),
@@ -6841,6 +6859,7 @@ async fn sample_rollout(
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     };
     live_history.record_items(
         std::iter::once(&assistant3),

--- a/codex-rs/core/src/session/tests/guardian_tests.rs
+++ b/codex-rs/core/src/session/tests/guardian_tests.rs
@@ -568,6 +568,7 @@ async fn process_compacted_history_preserves_separate_guardian_developer_message
                 }],
                 end_turn: None,
                 phase: None,
+                exclude_from_compaction: false,
             },
             ResponseItem::Message {
                 id: None,
@@ -577,6 +578,7 @@ async fn process_compacted_history_preserves_separate_guardian_developer_message
                 }],
                 end_turn: None,
                 phase: None,
+                exclude_from_compaction: false,
             },
         ],
         InitialContextInjection::BeforeLastUserMessage,

--- a/codex-rs/core/src/stream_events_utils_tests.rs
+++ b/codex-rs/core/src/stream_events_utils_tests.rs
@@ -30,6 +30,7 @@ fn assistant_output_text_with_phase(text: &str, phase: Option<MessagePhase>) -> 
         }],
         end_turn: Some(true),
         phase,
+        exclude_from_compaction: false,
     }
 }
 

--- a/codex-rs/core/src/tasks/review.rs
+++ b/codex-rs/core/src/tasks/review.rs
@@ -251,6 +251,7 @@ pub(crate) async fn exit_review_mode(
                 content: vec![ContentItem::InputText { text: user_message }],
                 end_turn: None,
                 phase: None,
+                exclude_from_compaction: false,
             }],
         )
         .await;
@@ -272,6 +273,7 @@ pub(crate) async fn exit_review_mode(
                 }],
                 end_turn: None,
                 phase: None,
+                exclude_from_compaction: false,
             },
         )
         .await;

--- a/codex-rs/core/src/thread_manager_tests.rs
+++ b/codex-rs/core/src/thread_manager_tests.rs
@@ -29,6 +29,7 @@ fn user_msg(text: &str) -> ResponseItem {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     }
 }
 fn assistant_msg(text: &str) -> ResponseItem {
@@ -40,6 +41,7 @@ fn assistant_msg(text: &str) -> ResponseItem {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     }
 }
 

--- a/codex-rs/core/src/thread_rollout_truncation_tests.rs
+++ b/codex-rs/core/src/thread_rollout_truncation_tests.rs
@@ -16,6 +16,7 @@ fn user_msg(text: &str) -> ResponseItem {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     }
 }
 
@@ -28,6 +29,7 @@ fn assistant_msg(text: &str) -> ResponseItem {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     }
 }
 

--- a/codex-rs/core/src/tools/handlers/multi_agents_tests.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_tests.rs
@@ -2361,6 +2361,7 @@ async fn resume_agent_restores_closed_agent_and_accepts_send_input() {
                 }],
                 end_turn: None,
                 phase: None,
+                exclude_from_compaction: false,
             })]),
             AuthManager::from_auth_for_testing(CodexAuth::from_api_key("dummy")),
             /*persist_extended_history*/ false,

--- a/codex-rs/core/src/turn_timing_tests.rs
+++ b/codex-rs/core/src/turn_timing_tests.rs
@@ -104,6 +104,7 @@ fn response_item_records_turn_ttft_for_first_output_signals() {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     }));
 }
 
@@ -117,6 +118,7 @@ fn response_item_records_turn_ttft_ignores_empty_non_output_items() {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     }));
     assert!(!response_item_records_turn_ttft(
         &ResponseItem::FunctionCallOutput {

--- a/codex-rs/core/tests/common/responses.rs
+++ b/codex-rs/core/tests/common/responses.rs
@@ -681,6 +681,7 @@ pub fn user_message_item(text: &str) -> ResponseItem {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     }
 }
 

--- a/codex-rs/core/tests/responses_headers.rs
+++ b/codex-rs/core/tests/responses_headers.rs
@@ -120,6 +120,7 @@ async fn responses_stream_includes_subagent_header_on_review() {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     }];
 
     let mut stream = client_session
@@ -247,6 +248,7 @@ async fn responses_stream_includes_subagent_header_on_other() {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     }];
 
     let mut stream = client_session
@@ -363,6 +365,7 @@ async fn responses_respects_model_info_overrides_from_config() {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     }];
 
     let mut stream = client_session

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -290,6 +290,7 @@ async fn resume_includes_initial_messages_and_sends_prior_items() {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     };
     let prior_user_json = serde_json::to_value(&prior_user).unwrap();
     writeln!(
@@ -312,6 +313,7 @@ async fn resume_includes_initial_messages_and_sends_prior_items() {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     };
     let prior_system_json = serde_json::to_value(&prior_system).unwrap();
     writeln!(
@@ -334,6 +336,7 @@ async fn resume_includes_initial_messages_and_sends_prior_items() {
         }],
         end_turn: None,
         phase: Some(MessagePhase::Commentary),
+        exclude_from_compaction: false,
     };
     let prior_item_json = serde_json::to_value(&prior_item).unwrap();
     writeln!(
@@ -517,6 +520,7 @@ async fn resume_replays_legacy_js_repl_image_rollout_shapes() {
                 }],
                 end_turn: None,
                 phase: None,
+                exclude_from_compaction: false,
             }),
         },
     ];
@@ -903,6 +907,7 @@ async fn send_provider_auth_request(server: &MockServer, auth: ModelProviderAuth
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     });
 
     let mut stream = client_session
@@ -2227,6 +2232,7 @@ async fn azure_responses_request_includes_store_and_reasoning_ids() {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     });
     prompt.input.push(ResponseItem::WebSearchCall {
         id: Some("web-search-id".into()),

--- a/codex-rs/core/tests/suite/client_websockets.rs
+++ b/codex-rs/core/tests/suite/client_websockets.rs
@@ -1702,6 +1702,7 @@ fn message_item(text: &str) -> ResponseItem {
         content: vec![ContentItem::InputText { text: text.into() }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     }
 }
 
@@ -1712,6 +1713,7 @@ fn assistant_message_item(id: &str, text: &str) -> ResponseItem {
         content: vec![ContentItem::OutputText { text: text.into() }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     }
 }
 

--- a/codex-rs/core/tests/suite/compact.rs
+++ b/codex-rs/core/tests/suite/compact.rs
@@ -1617,6 +1617,7 @@ async fn auto_compact_runs_after_resume_when_token_usage_is_over_limit() {
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
         codex_protocol::models::ResponseItem::Compaction {
             encrypted_content: "ENCRYPTED_COMPACTION_SUMMARY".to_string(),
@@ -2858,6 +2859,7 @@ async fn auto_compact_counts_encrypted_reasoning_before_last_user() {
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
         codex_protocol::models::ResponseItem::Compaction {
             encrypted_content: "ENCRYPTED_COMPACTION_SUMMARY".to_string(),
@@ -2982,6 +2984,7 @@ async fn auto_compact_runs_when_reasoning_header_clears_between_turns() {
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
         codex_protocol::models::ResponseItem::Compaction {
             encrypted_content: "ENCRYPTED_COMPACTION_SUMMARY".to_string(),

--- a/codex-rs/core/tests/suite/compact_remote.rs
+++ b/codex-rs/core/tests/suite/compact_remote.rs
@@ -1183,6 +1183,7 @@ async fn remote_compact_persists_replacement_history_in_rollout() -> Result<()> 
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
     ];
     let compact_mock = responses::mount_compact_json_once(
@@ -1322,6 +1323,7 @@ async fn remote_compact_and_resume_refresh_stale_developer_instructions() -> Res
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
         ResponseItem::Compaction {
             encrypted_content: "ENCRYPTED_COMPACTION_SUMMARY".to_string(),
@@ -1460,6 +1462,7 @@ async fn remote_compact_refreshes_stale_developer_instructions_without_resume() 
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         },
         ResponseItem::Compaction {
             encrypted_content: "ENCRYPTED_COMPACTION_SUMMARY".to_string(),

--- a/codex-rs/core/tests/suite/image_rollout.rs
+++ b/codex-rs/core/tests/suite/image_rollout.rs
@@ -165,6 +165,7 @@ async fn copy_paste_local_image_persists_rollout_request_shape() -> anyhow::Resu
         ],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     };
 
     assert_eq!(actual, expected);
@@ -253,6 +254,7 @@ async fn drag_drop_image_persists_rollout_request_shape() -> anyhow::Result<()> 
         ],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     };
 
     assert_eq!(actual, expected);

--- a/codex-rs/core/tests/suite/prompt_debug_tests.rs
+++ b/codex-rs/core/tests/suite/prompt_debug_tests.rs
@@ -40,6 +40,7 @@ async fn build_prompt_input_includes_context_and_user_message() -> Result<()> {
         }],
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     };
     assert_eq!(input.last(), Some(&expected_user_message));
     assert!(input.iter().any(|item| {

--- a/codex-rs/core/tests/suite/realtime_conversation.rs
+++ b/codex-rs/core/tests/suite/realtime_conversation.rs
@@ -1607,6 +1607,7 @@ async fn conversation_startup_context_current_thread_selects_many_turns_by_budge
                     content: vec![ContentItem::InputText { text: user_turn }],
                     end_turn: None,
                     phase: None,
+                    exclude_from_compaction: false,
                 }),
                 RolloutItem::ResponseItem(ResponseItem::Message {
                     id: None,
@@ -1616,6 +1617,7 @@ async fn conversation_startup_context_current_thread_selects_many_turns_by_budge
                     }],
                     end_turn: None,
                     phase: None,
+                    exclude_from_compaction: false,
                 }),
             ]
         })

--- a/codex-rs/core/tests/suite/review.rs
+++ b/codex-rs/core/tests/suite/review.rs
@@ -540,6 +540,7 @@ async fn review_input_isolated_from_parent_history() {
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         };
         let user_json = serde_json::to_value(&user).unwrap();
         let user_line = serde_json::json!({
@@ -560,6 +561,7 @@ async fn review_input_isolated_from_parent_history() {
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         };
         let assistant_json = serde_json::to_value(&assistant).unwrap();
         let assistant_line = serde_json::json!({

--- a/codex-rs/protocol/src/items.rs
+++ b/codex-rs/protocol/src/items.rs
@@ -268,6 +268,7 @@ pub fn build_hook_prompt_message(fragments: &[HookPromptFragment]) -> Option<Res
         content,
         end_turn: None,
         phase: None,
+        exclude_from_compaction: false,
     })
 }
 

--- a/codex-rs/protocol/src/models.rs
+++ b/codex-rs/protocol/src/models.rs
@@ -461,6 +461,10 @@ pub enum ResponseItem {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         #[ts(optional)]
         phase: Option<MessagePhase>,
+        // Local-only marker for generated transcript items that should not be
+        // carried forward into replacement history after compaction.
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        exclude_from_compaction: bool,
     },
     Reasoning {
         #[serde(default, skip_serializing)]
@@ -810,6 +814,7 @@ impl From<ResponseInputItem> for ResponseItem {
                 id: None,
                 end_turn: None,
                 phase: None,
+                exclude_from_compaction: false,
             },
             ResponseInputItem::FunctionCallOutput { call_id, output } => {
                 Self::FunctionCallOutput { call_id, output }

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -2992,6 +2992,7 @@ impl From<CompactedItem> for ResponseItem {
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         }
     }
 }

--- a/codex-rs/rollout/src/tests.rs
+++ b/codex-rs/rollout/src/tests.rs
@@ -1181,6 +1181,7 @@ async fn test_updated_at_uses_file_mtime() -> Result<()> {
                 }],
                 end_turn: None,
                 phase: None,
+                exclude_from_compaction: false,
             }),
         };
         writeln!(file, "{}", serde_json::to_string(&response_line)?)?;

--- a/codex-rs/state/src/extract.rs
+++ b/codex-rs/state/src/extract.rs
@@ -179,6 +179,7 @@ mod tests {
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         });
 
         apply_rollout_item(&mut metadata, &item, "test-provider");

--- a/codex-rs/tui/src/app/side.rs
+++ b/codex-rs/tui/src/app/side.rs
@@ -442,6 +442,7 @@ impl App {
             }],
             end_turn: None,
             phase: None,
+            exclude_from_compaction: false,
         }
     }
 

--- a/codex-rs/tui/src/app/thread_session_state.rs
+++ b/codex-rs/tui/src/app/thread_session_state.rs
@@ -108,6 +108,7 @@ mod tests {
             approval_policy: AskForApproval::Never,
             approvals_reviewer: ApprovalsReviewer::User,
             sandbox_policy: SandboxPolicy::new_read_only_policy(),
+            permission_profile: None,
             cwd: cwd.abs(),
             instruction_source_paths: Vec::new(),
             reasoning_effort: None,
@@ -155,7 +156,7 @@ mod tests {
             .insert(side_thread_id, SideThreadState::new(main_thread_id));
         app.config.permissions.approval_policy =
             codex_config::Constrained::allow_any(AskForApproval::OnRequest);
-        app.config.approvals_reviewer = ApprovalsReviewer::GuardianSubagent;
+        app.config.approvals_reviewer = ApprovalsReviewer::AutoReview;
         app.config.permissions.sandbox_policy =
             codex_config::Constrained::allow_any(SandboxPolicy::new_workspace_write_policy());
 
@@ -164,7 +165,7 @@ mod tests {
 
         let expected_main_session = ThreadSessionState {
             approval_policy: AskForApproval::OnRequest,
-            approvals_reviewer: ApprovalsReviewer::GuardianSubagent,
+            approvals_reviewer: ApprovalsReviewer::AutoReview,
             sandbox_policy: SandboxPolicy::new_workspace_write_policy(),
             ..main_session
         };


### PR DESCRIPTION
## Summary
- add a local-only `exclude_from_compaction` marker to response message items
- filter marked messages out of compacted history and scrub the marker before sending prompt input
- mark generated model-warning user messages so they do not survive compaction
- add focused regression coverage for compaction filtering, prompt scrubbing, and warning-message marking

## Tests
- `CODEX_SKIP_VENDORED_BWRAP=1 cargo test -p codex-core process_compacted_history_drops_items_marked_excluded_from_compaction`
- `CODEX_SKIP_VENDORED_BWRAP=1 cargo test -p codex-core for_prompt_strips_compaction_exclusion_marker`
- `CODEX_SKIP_VENDORED_BWRAP=1 cargo test -p codex-core record_model_warning_appends_user_message`
- `CODEX_SKIP_VENDORED_BWRAP=1 just fix -p codex-core`