### PR TITLE
fix(tui): update permission sync test helpers

### DIFF
--- a/codex-rs/tui/src/app/thread_session_state.rs
+++ b/codex-rs/tui/src/app/thread_session_state.rs
@@ -108,6 +108,7 @@ mod tests {
             approval_policy: AskForApproval::Never,
             approvals_reviewer: ApprovalsReviewer::User,
             sandbox_policy: SandboxPolicy::new_read_only_policy(),
+            permission_profile: None,
             cwd: cwd.abs(),
             instruction_source_paths: Vec::new(),
             reasoning_effort: None,
@@ -155,7 +156,7 @@ mod tests {
             .insert(side_thread_id, SideThreadState::new(main_thread_id));
         app.config.permissions.approval_policy =
             codex_config::Constrained::allow_any(AskForApproval::OnRequest);
-        app.config.approvals_reviewer = ApprovalsReviewer::GuardianSubagent;
+        app.config.approvals_reviewer = ApprovalsReviewer::AutoReview;
         app.config.permissions.sandbox_policy =
             codex_config::Constrained::allow_any(SandboxPolicy::new_workspace_write_policy());
 
@@ -164,7 +165,7 @@ mod tests {
 
         let expected_main_session = ThreadSessionState {
             approval_policy: AskForApproval::OnRequest,
-            approvals_reviewer: ApprovalsReviewer::GuardianSubagent,
+            approvals_reviewer: ApprovalsReviewer::AutoReview,
             sandbox_policy: SandboxPolicy::new_workspace_write_policy(),
             ..main_session
         };


### PR DESCRIPTION
## Why

[#18924](https://github.com/openai/codex/pull/18924) added permission sync regression coverage for preserving permission state after side conversations. Since that PR landed, the surrounding TUI types changed: `ThreadSessionState` now includes `permission_profile`, and the reviewer enum uses `AutoReview` for the automatic review mode. That left current `codex-tui` builds broken when compiling the regression test.

## What Changed

- Add the missing `permission_profile` field to the test fixture.
- Update the test expectation from the legacy `GuardianSubagent` reviewer variant to `AutoReview`.

## Verification

- `cargo test -p codex-tui permission_settings_sync_updates_active_snapshot_without_rewriting_side_thread`

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/19089).
* #19086
* __->__ #19089