### PR TITLE
Reject agents.max_threads with multi_agent_v2

### DIFF
--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -1948,6 +1948,13 @@ impl Config {
 
         let history = cfg.history.unwrap_or_default();
 
+        let agent_max_threads_from_config = cfg.agents.as_ref().and_then(|agents| agents.max_threads);
+        if features.enabled(Feature::MultiAgentV2) && agent_max_threads_from_config.is_some() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "agents.max_threads cannot be set when multi_agent_v2 is enabled",
+            ));
+        }
         let agent_max_threads = cfg
             .agents
             .as_ref()


### PR DESCRIPTION
## Why

`multi_agent_v2` uses the v2 agent lifecycle, so accepting the legacy `agents.max_threads` limit alongside it creates conflicting configuration semantics. Config load should fail early with a clear error instead of allowing both knobs to be set.

## What Changed

- During config load, detect when the effective `multi_agent_v2` feature is enabled and `agents.max_threads` is explicitly set.
- Return an `InvalidInput` error: `agents.max_threads cannot be set when multi_agent_v2 is enabled`.

## Verification

- `cargo test -p codex-core multi_agent_v2_rejects_agents_max_threads` passed locally with a temporary focused test for this behavior.
- `cargo test -p codex-core` was also run; the new focused path passed, but the crate suite has unrelated pre-existing failures in managed config/proxy/request-permissions tests.