### PR TITLE
exec-server: wait for close after observed exit

### DIFF
--- a/codex-rs/exec-server/src/local_process.rs
+++ b/codex-rs/exec-server/src/local_process.rs
@@ -323,8 +323,11 @@ impl LocalProcess {
                 )
             };
 
+            let has_new_terminal_event =
+                response.exited && after_seq < response.next_seq.saturating_sub(1);
             if !response.chunks.is_empty()
-                || response.exited
+                || response.closed
+                || has_new_terminal_event
                 || tokio::time::Instant::now() >= deadline
             {
                 let _total_bytes: usize = response


### PR DESCRIPTION
## Why

Windows CI can flake in `server::handler::tests::output_and_exit_are_retained_after_notification_receiver_closes` after a process has exited but before both output streams have closed. `exec/read` returned immediately whenever `exited` was true, so callers that had already observed the exit event could spin instead of long-polling for the later `closed` state.

## What Changed

- Keep returning immediately when a terminal exit event is newly observable.
- Allow later reads, after the caller has advanced past that event, to wait for `closed` or new output until `wait_ms` expires.

## Verification

- CI pending.