### PR TITLE
ci: add macOS keychain entitlements

### DIFF
--- a/.github/actions/macos-code-sign/codex.entitlements.plist
+++ b/.github/actions/macos-code-sign/codex.entitlements.plist
@@ -2,7 +2,15 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.application-identifier</key>
+	<string>2DC432GLL2.com.openai.codex</string>
+	<key>com.apple.developer.team-identifier</key>
+	<string>2DC432GLL2</string>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>2DC432GLL2.com.openai.codex</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

- add macOS application and team identifiers to the release signing entitlements
- add a Codex keychain access group for release-signed macOS binaries
- keep the existing JIT entitlement unchanged

## Why

Codex release binaries are signed with the OpenAI Developer ID team, but the current entitlements plist only grants JIT. macOS Keychain and Secure Enclave operations that create persistent keys can require the process to carry an application identifier and keychain access group. Adding these entitlements gives release-signed binaries a stable Keychain namespace for Codex-owned device keys.

## Validation

- `plutil -lint .github/actions/macos-code-sign/codex.entitlements.plist`
