### PR TITLE
Use Auto-review wording for fallback rationale

### DIFF
--- a/codex-rs/core/src/guardian/prompt.rs
+++ b/codex-rs/core/src/guardian/prompt.rs
@@ -517,10 +517,10 @@ pub(crate) fn parse_guardian_assessment(text: Option<&str>) -> anyhow::Result<Gu
         .filter(|rationale| !rationale.trim().is_empty())
         .unwrap_or_else(|| match outcome {
             super::GuardianAssessmentOutcome::Allow => {
-                "Guardian returned a low-risk allow decision.".to_string()
+                "Auto-review returned a low-risk allow decision.".to_string()
             }
             super::GuardianAssessmentOutcome::Deny => {
-                "Guardian returned a deny decision without a rationale.".to_string()
+                "Auto-review returned a deny decision without a rationale.".to_string()
             }
         });
 

--- a/codex-rs/core/src/guardian/tests.rs
+++ b/codex-rs/core/src/guardian/tests.rs
@@ -1052,7 +1052,23 @@ fn parse_guardian_assessment_treats_bare_allow_as_low_risk() {
             risk_level: GuardianRiskLevel::Low,
             user_authorization: GuardianUserAuthorization::Unknown,
             outcome: GuardianAssessmentOutcome::Allow,
-            rationale: "Guardian returned a low-risk allow decision.".to_string(),
+            rationale: "Auto-review returned a low-risk allow decision.".to_string(),
+        }
+    );
+}
+
+#[test]
+fn parse_guardian_assessment_treats_bare_deny_as_high_risk() {
+    let parsed =
+        parse_guardian_assessment(Some(r#"{"outcome":"deny"}"#)).expect("guardian assessment");
+
+    assert_eq!(
+        parsed,
+        GuardianAssessment {
+            risk_level: GuardianRiskLevel::High,
+            user_authorization: GuardianUserAuthorization::Unknown,
+            outcome: GuardianAssessmentOutcome::Deny,
+            rationale: "Auto-review returned a deny decision without a rationale.".to_string(),
         }
     );
 }


### PR DESCRIPTION
## Why

PR #18797 currently surfaces fallback rationale text that names Guardian directly. 

## What changed

- Updated the bare allow and bare deny fallback rationales in `codex-rs/core/src/guardian/prompt.rs` from Guardian to Auto-review.
- Updated the existing bare allow parser test and added explicit bare deny parser coverage.

## Verification

- `cargo test -p codex-core parse_guardian_assessment_treats_bare`
