### PR TITLE
Add conditional network proxy prompt guidance

### DIFF
--- a/codex-rs/core/src/context/mod.rs
+++ b/codex-rs/core/src/context/mod.rs
@@ -41,6 +41,7 @@ pub(crate) use hook_additional_context::HookAdditionalContext;
 pub(crate) use image_generation_instructions::ImageGenerationInstructions;
 pub(crate) use model_switch_instructions::ModelSwitchInstructions;
 pub(crate) use network_rule_saved::NetworkRuleSaved;
+pub use permissions_instructions::PermissionsInstructionOptions;
 pub use permissions_instructions::PermissionsInstructions;
 pub(crate) use personality_spec_instructions::PersonalitySpecInstructions;
 pub(crate) use plugin_instructions::PluginInstructions;

--- a/codex-rs/core/src/context/permissions_instructions.rs
+++ b/codex-rs/core/src/context/permissions_instructions.rs
@@ -24,6 +24,7 @@ const APPROVAL_POLICY_ON_REQUEST_RULE: &str =
 const APPROVAL_POLICY_ON_REQUEST_RULE_REQUEST_PERMISSION: &str =
     include_str!("prompts/permissions/approval_policy/on_request_rule_request_permission.md");
 const AUTO_REVIEW_APPROVAL_SUFFIX: &str = "`approvals_reviewer` is `auto_review`: Sandbox escalations with require_escalated will be reviewed for compliance with the policy. If a rejection happens, you should proceed only with a materially safer alternative, or inform the user of the risk and send a final message to ask for approval.";
+const NETWORK_PROXY: &str = include_str!("prompts/permissions/network_proxy.md");
 
 const SANDBOX_MODE_DANGER_FULL_ACCESS: &str =
     include_str!("prompts/permissions/sandbox_mode/danger_full_access.md");
@@ -50,6 +51,7 @@ struct PermissionsPromptConfig<'a> {
     exec_policy: &'a Policy,
     exec_permission_approvals_enabled: bool,
     request_permissions_tool_enabled: bool,
+    managed_network_proxy_active: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -68,6 +70,7 @@ impl PermissionsInstructions {
         cwd: &Path,
         exec_permission_approvals_enabled: bool,
         request_permissions_tool_enabled: bool,
+        managed_network_proxy_active: bool,
     ) -> Self {
         let (sandbox_mode, writable_roots) = sandbox_prompt_from_profile(permission_profile, cwd);
 
@@ -80,6 +83,7 @@ impl PermissionsInstructions {
                 exec_policy,
                 exec_permission_approvals_enabled,
                 request_permissions_tool_enabled,
+                managed_network_proxy_active,
             },
             writable_roots,
         )
@@ -94,6 +98,7 @@ impl PermissionsInstructions {
         cwd: &Path,
         exec_permission_approvals_enabled: bool,
         request_permissions_tool_enabled: bool,
+        managed_network_proxy_active: bool,
     ) -> Self {
         Self::from_permission_profile(
             &PermissionProfile::from_legacy_sandbox_policy(sandbox_policy),
@@ -103,6 +108,7 @@ impl PermissionsInstructions {
             cwd,
             exec_permission_approvals_enabled,
             request_permissions_tool_enabled,
+            managed_network_proxy_active,
         )
     }
 
@@ -114,6 +120,9 @@ impl PermissionsInstructions {
     ) -> Self {
         let mut text = String::new();
         append_section(&mut text, &sandbox_text(sandbox_mode, network_access));
+        if config.managed_network_proxy_active {
+            append_section(&mut text, NETWORK_PROXY.trim_end());
+        }
         append_section(
             &mut text,
             &approval_text(

--- a/codex-rs/core/src/context/permissions_instructions.rs
+++ b/codex-rs/core/src/context/permissions_instructions.rs
@@ -51,7 +51,15 @@ struct PermissionsPromptConfig<'a> {
     exec_policy: &'a Policy,
     exec_permission_approvals_enabled: bool,
     request_permissions_tool_enabled: bool,
-    managed_network_proxy_active: bool,
+    network_proxy_active: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+/// Feature-dependent knobs used while rendering permissions instructions.
+pub struct PermissionsInstructionOptions {
+    pub exec_permission_approvals_enabled: bool,
+    pub request_permissions_tool_enabled: bool,
+    pub network_proxy_active: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -68,9 +76,7 @@ impl PermissionsInstructions {
         approvals_reviewer: ApprovalsReviewer,
         exec_policy: &Policy,
         cwd: &Path,
-        exec_permission_approvals_enabled: bool,
-        request_permissions_tool_enabled: bool,
-        managed_network_proxy_active: bool,
+        options: PermissionsInstructionOptions,
     ) -> Self {
         let (sandbox_mode, writable_roots) = sandbox_prompt_from_profile(permission_profile, cwd);
 
@@ -81,9 +87,9 @@ impl PermissionsInstructions {
                 approval_policy,
                 approvals_reviewer,
                 exec_policy,
-                exec_permission_approvals_enabled,
-                request_permissions_tool_enabled,
-                managed_network_proxy_active,
+                exec_permission_approvals_enabled: options.exec_permission_approvals_enabled,
+                request_permissions_tool_enabled: options.request_permissions_tool_enabled,
+                network_proxy_active: options.network_proxy_active,
             },
             writable_roots,
         )
@@ -96,9 +102,7 @@ impl PermissionsInstructions {
         approvals_reviewer: ApprovalsReviewer,
         exec_policy: &Policy,
         cwd: &Path,
-        exec_permission_approvals_enabled: bool,
-        request_permissions_tool_enabled: bool,
-        managed_network_proxy_active: bool,
+        options: PermissionsInstructionOptions,
     ) -> Self {
         Self::from_permission_profile(
             &PermissionProfile::from_legacy_sandbox_policy(sandbox_policy),
@@ -106,9 +110,7 @@ impl PermissionsInstructions {
             approvals_reviewer,
             exec_policy,
             cwd,
-            exec_permission_approvals_enabled,
-            request_permissions_tool_enabled,
-            managed_network_proxy_active,
+            options,
         )
     }
 
@@ -120,7 +122,7 @@ impl PermissionsInstructions {
     ) -> Self {
         let mut text = String::new();
         append_section(&mut text, &sandbox_text(sandbox_mode, network_access));
-        if config.managed_network_proxy_active {
+        if config.network_proxy_active {
             append_section(&mut text, NETWORK_PROXY.trim_end());
         }
         append_section(

--- a/codex-rs/core/src/context/permissions_instructions_tests.rs
+++ b/codex-rs/core/src/context/permissions_instructions_tests.rs
@@ -38,6 +38,7 @@ fn builds_permissions_with_network_access_override() {
             exec_policy: &Policy::empty(),
             exec_permission_approvals_enabled: false,
             request_permissions_tool_enabled: false,
+            managed_network_proxy_active: false,
         },
         /*writable_roots*/ None,
     );
@@ -70,6 +71,7 @@ fn builds_permissions_from_policy() {
         &PathBuf::from("/tmp"),
         /*exec_permission_approvals_enabled*/ false,
         /*request_permissions_tool_enabled*/ false,
+        /*managed_network_proxy_active*/ false,
     );
     let text = instructions.body();
     assert!(text.contains("Network access is enabled."));
@@ -99,11 +101,53 @@ fn builds_permissions_from_profile() {
         &cwd,
         /*exec_permission_approvals_enabled*/ false,
         /*request_permissions_tool_enabled*/ false,
+        /*managed_network_proxy_active*/ false,
     );
     let text = instructions.body();
     assert!(text.contains("`sandbox_mode` is `workspace-write`"));
     assert!(text.contains("Network access is enabled."));
     assert!(text.contains(writable_root.to_string_lossy().as_ref()));
+}
+
+#[test]
+fn includes_network_proxy_guidance_when_managed_proxy_is_active() {
+    let instructions = PermissionsInstructions::from_permissions_with_network(
+        SandboxMode::WorkspaceWrite,
+        NetworkAccess::Restricted,
+        PermissionsPromptConfig {
+            approval_policy: AskForApproval::Never,
+            approvals_reviewer: ApprovalsReviewer::User,
+            exec_policy: &Policy::empty(),
+            exec_permission_approvals_enabled: false,
+            request_permissions_tool_enabled: false,
+            managed_network_proxy_active: true,
+        },
+        /*writable_roots*/ None,
+    );
+
+    let text = instructions.body();
+    assert!(text.contains("# Network Proxy"));
+    assert!(text.contains("blocked-by-allowlist"));
+    assert!(text.contains("proxy-specific headers or messages"));
+}
+
+#[test]
+fn omits_network_proxy_guidance_when_managed_proxy_is_inactive() {
+    let instructions = PermissionsInstructions::from_permissions_with_network(
+        SandboxMode::WorkspaceWrite,
+        NetworkAccess::Restricted,
+        PermissionsPromptConfig {
+            approval_policy: AskForApproval::Never,
+            approvals_reviewer: ApprovalsReviewer::User,
+            exec_policy: &Policy::empty(),
+            exec_permission_approvals_enabled: false,
+            request_permissions_tool_enabled: false,
+            managed_network_proxy_active: false,
+        },
+        /*writable_roots*/ None,
+    );
+
+    assert!(!instructions.body().contains("# Network Proxy"));
 }
 
 #[test]
@@ -121,6 +165,7 @@ fn includes_request_rule_instructions_for_on_request() {
             exec_policy: &exec_policy,
             exec_permission_approvals_enabled: false,
             request_permissions_tool_enabled: false,
+            managed_network_proxy_active: false,
         },
         /*writable_roots*/ None,
     );
@@ -142,6 +187,7 @@ fn includes_request_permissions_tool_instructions_for_unless_trusted_when_enable
             exec_policy: &Policy::empty(),
             exec_permission_approvals_enabled: false,
             request_permissions_tool_enabled: true,
+            managed_network_proxy_active: false,
         },
         /*writable_roots*/ None,
     );
@@ -162,6 +208,7 @@ fn includes_request_permissions_tool_instructions_for_on_failure_when_enabled() 
             exec_policy: &Policy::empty(),
             exec_permission_approvals_enabled: false,
             request_permissions_tool_enabled: true,
+            managed_network_proxy_active: false,
         },
         /*writable_roots*/ None,
     );
@@ -182,6 +229,7 @@ fn includes_request_permission_rule_instructions_for_on_request_when_enabled() {
             exec_policy: &Policy::empty(),
             exec_permission_approvals_enabled: true,
             request_permissions_tool_enabled: false,
+            managed_network_proxy_active: false,
         },
         /*writable_roots*/ None,
     );
@@ -202,6 +250,7 @@ fn includes_request_permissions_tool_instructions_for_on_request_when_tool_is_en
             exec_policy: &Policy::empty(),
             exec_permission_approvals_enabled: false,
             request_permissions_tool_enabled: true,
+            managed_network_proxy_active: false,
         },
         /*writable_roots*/ None,
     );
@@ -222,6 +271,7 @@ fn on_request_includes_tool_guidance_alongside_inline_permission_guidance_when_b
             exec_policy: &Policy::empty(),
             exec_permission_approvals_enabled: true,
             request_permissions_tool_enabled: true,
+            managed_network_proxy_active: false,
         },
         /*writable_roots*/ None,
     );

--- a/codex-rs/core/src/context/permissions_instructions_tests.rs
+++ b/codex-rs/core/src/context/permissions_instructions_tests.rs
@@ -38,7 +38,7 @@ fn builds_permissions_with_network_access_override() {
             exec_policy: &Policy::empty(),
             exec_permission_approvals_enabled: false,
             request_permissions_tool_enabled: false,
-            managed_network_proxy_active: false,
+            network_proxy_active: false,
         },
         /*writable_roots*/ None,
     );
@@ -69,9 +69,11 @@ fn builds_permissions_from_policy() {
         ApprovalsReviewer::User,
         &Policy::empty(),
         &PathBuf::from("/tmp"),
-        /*exec_permission_approvals_enabled*/ false,
-        /*request_permissions_tool_enabled*/ false,
-        /*managed_network_proxy_active*/ false,
+        PermissionsInstructionOptions {
+            exec_permission_approvals_enabled: false,
+            request_permissions_tool_enabled: false,
+            network_proxy_active: false,
+        },
     );
     let text = instructions.body();
     assert!(text.contains("Network access is enabled."));
@@ -99,9 +101,11 @@ fn builds_permissions_from_profile() {
         ApprovalsReviewer::User,
         &Policy::empty(),
         &cwd,
-        /*exec_permission_approvals_enabled*/ false,
-        /*request_permissions_tool_enabled*/ false,
-        /*managed_network_proxy_active*/ false,
+        PermissionsInstructionOptions {
+            exec_permission_approvals_enabled: false,
+            request_permissions_tool_enabled: false,
+            network_proxy_active: false,
+        },
     );
     let text = instructions.body();
     assert!(text.contains("`sandbox_mode` is `workspace-write`"));
@@ -110,7 +114,7 @@ fn builds_permissions_from_profile() {
 }
 
 #[test]
-fn includes_network_proxy_guidance_when_managed_proxy_is_active() {
+fn includes_network_proxy_guidance_when_proxy_is_active() {
     let instructions = PermissionsInstructions::from_permissions_with_network(
         SandboxMode::WorkspaceWrite,
         NetworkAccess::Restricted,
@@ -120,7 +124,7 @@ fn includes_network_proxy_guidance_when_managed_proxy_is_active() {
             exec_policy: &Policy::empty(),
             exec_permission_approvals_enabled: false,
             request_permissions_tool_enabled: false,
-            managed_network_proxy_active: true,
+            network_proxy_active: true,
         },
         /*writable_roots*/ None,
     );
@@ -132,7 +136,7 @@ fn includes_network_proxy_guidance_when_managed_proxy_is_active() {
 }
 
 #[test]
-fn omits_network_proxy_guidance_when_managed_proxy_is_inactive() {
+fn omits_network_proxy_guidance_when_proxy_is_inactive() {
     let instructions = PermissionsInstructions::from_permissions_with_network(
         SandboxMode::WorkspaceWrite,
         NetworkAccess::Restricted,
@@ -142,7 +146,7 @@ fn omits_network_proxy_guidance_when_managed_proxy_is_inactive() {
             exec_policy: &Policy::empty(),
             exec_permission_approvals_enabled: false,
             request_permissions_tool_enabled: false,
-            managed_network_proxy_active: false,
+            network_proxy_active: false,
         },
         /*writable_roots*/ None,
     );
@@ -165,7 +169,7 @@ fn includes_request_rule_instructions_for_on_request() {
             exec_policy: &exec_policy,
             exec_permission_approvals_enabled: false,
             request_permissions_tool_enabled: false,
-            managed_network_proxy_active: false,
+            network_proxy_active: false,
         },
         /*writable_roots*/ None,
     );
@@ -187,7 +191,7 @@ fn includes_request_permissions_tool_instructions_for_unless_trusted_when_enable
             exec_policy: &Policy::empty(),
             exec_permission_approvals_enabled: false,
             request_permissions_tool_enabled: true,
-            managed_network_proxy_active: false,
+            network_proxy_active: false,
         },
         /*writable_roots*/ None,
     );
@@ -208,7 +212,7 @@ fn includes_request_permissions_tool_instructions_for_on_failure_when_enabled() 
             exec_policy: &Policy::empty(),
             exec_permission_approvals_enabled: false,
             request_permissions_tool_enabled: true,
-            managed_network_proxy_active: false,
+            network_proxy_active: false,
         },
         /*writable_roots*/ None,
     );
@@ -229,7 +233,7 @@ fn includes_request_permission_rule_instructions_for_on_request_when_enabled() {
             exec_policy: &Policy::empty(),
             exec_permission_approvals_enabled: true,
             request_permissions_tool_enabled: false,
-            managed_network_proxy_active: false,
+            network_proxy_active: false,
         },
         /*writable_roots*/ None,
     );
@@ -250,7 +254,7 @@ fn includes_request_permissions_tool_instructions_for_on_request_when_tool_is_en
             exec_policy: &Policy::empty(),
             exec_permission_approvals_enabled: false,
             request_permissions_tool_enabled: true,
-            managed_network_proxy_active: false,
+            network_proxy_active: false,
         },
         /*writable_roots*/ None,
     );
@@ -271,7 +275,7 @@ fn on_request_includes_tool_guidance_alongside_inline_permission_guidance_when_b
             exec_policy: &Policy::empty(),
             exec_permission_approvals_enabled: true,
             request_permissions_tool_enabled: true,
-            managed_network_proxy_active: false,
+            network_proxy_active: false,
         },
         /*writable_roots*/ None,
     );

--- a/codex-rs/core/src/context/prompts/permissions/network_proxy.md
+++ b/codex-rs/core/src/context/prompts/permissions/network_proxy.md
@@ -1,0 +1,14 @@
+# Network Proxy
+
+A managed network proxy is active for model-initiated shell commands. Codex applies proxy environment variables automatically so outbound traffic is checked against the configured network policy.
+
+Honor any `<network>` allow/deny entries in the environment context. Use normal network tools without clearing or overriding proxy-related environment variables. If a required host is not allowed, request additional network permissions instead of working around the proxy.
+
+Interpret proxy failures precisely:
+- `blocked-by-allowlist` means the host is not allowed by the current network policy.
+- `blocked-by-denylist` means the host is explicitly denied by policy.
+- `blocked-by-method-policy` means the current network mode disallows that request method.
+- `blocked-by-mitm-required` means limited HTTPS cannot be enforced for that request without MITM support.
+- A message about local/private network addresses means the sandbox is blocking local or private targets.
+
+Do not infer a proxy denial from a generic network failure alone. Timeouts, hangs, DNS errors, TLS errors, and connection failures are only evidence of proxy policy when accompanied by proxy-specific headers or messages.

--- a/codex-rs/core/src/context/prompts/permissions/network_proxy.md
+++ b/codex-rs/core/src/context/prompts/permissions/network_proxy.md
@@ -1,14 +1,12 @@
 # Network Proxy
 
-A managed network proxy is active for model-initiated shell commands. Codex applies proxy environment variables automatically so outbound traffic is checked against the configured network policy.
+A network proxy is active for model-initiated shell commands. Codex applies proxy environment variables automatically so outbound traffic is checked against the configured network policy.
 
 Honor any `<network>` allow/deny entries in the environment context. Use normal network tools without clearing or overriding proxy-related environment variables. If a required host is not allowed, request additional network permissions instead of working around the proxy.
 
 Interpret proxy failures precisely:
 - `blocked-by-allowlist` means the host is not allowed by the current network policy.
 - `blocked-by-denylist` means the host is explicitly denied by policy.
-- `blocked-by-method-policy` means the current network mode disallows that request method.
-- `blocked-by-mitm-required` means limited HTTPS cannot be enforced for that request without MITM support.
 - A message about local/private network addresses means the sandbox is blocking local or private targets.
 
 Do not infer a proxy denial from a generic network failure alone. Timeouts, hangs, DNS errors, TLS errors, and connection failures are only evidence of proxy policy when accompanied by proxy-specific headers or messages.

--- a/codex-rs/core/src/context/prompts/permissions/network_proxy.md
+++ b/codex-rs/core/src/context/prompts/permissions/network_proxy.md
@@ -9,4 +9,4 @@ Interpret proxy failures precisely:
 - `blocked-by-denylist` means the host is explicitly denied by policy.
 - A message about local/private network addresses means the sandbox is blocking local or private targets.
 
-Do not infer a proxy denial from a generic network failure alone. Timeouts, hangs, DNS errors, TLS errors, and connection failures are only evidence of proxy policy when accompanied by proxy-specific headers or messages.
+Do not infer a proxy denial from a generic network failure alone. Proxy-mediated requests can themselves time out or hang. Treat timeouts, hangs, DNS errors, TLS errors, and connection failures as evidence of proxy policy only when they also include proxy-specific headers or messages.

--- a/codex-rs/core/src/context_manager/updates.rs
+++ b/codex-rs/core/src/context_manager/updates.rs
@@ -2,6 +2,7 @@ use crate::context::CollaborationModeInstructions;
 use crate::context::ContextualUserFragment;
 use crate::context::EnvironmentContext;
 use crate::context::ModelSwitchInstructions;
+use crate::context::PermissionsInstructionOptions;
 use crate::context::PermissionsInstructions;
 use crate::context::PersonalitySpecInstructions;
 use crate::context::RealtimeEndInstructions;
@@ -62,9 +63,15 @@ fn build_permissions_update_item(
             next.config.approvals_reviewer,
             exec_policy,
             &next.cwd,
-            next.features.enabled(Feature::ExecPermissionApprovals),
-            next.features.enabled(Feature::RequestPermissionsTool),
-            next.network.is_some(),
+            PermissionsInstructionOptions {
+                exec_permission_approvals_enabled: next
+                    .features
+                    .enabled(Feature::ExecPermissionApprovals),
+                request_permissions_tool_enabled: next
+                    .features
+                    .enabled(Feature::RequestPermissionsTool),
+                network_proxy_active: next.network.is_some(),
+            },
         )
         .render(),
     )

--- a/codex-rs/core/src/context_manager/updates.rs
+++ b/codex-rs/core/src/context_manager/updates.rs
@@ -64,6 +64,7 @@ fn build_permissions_update_item(
             &next.cwd,
             next.features.enabled(Feature::ExecPermissionApprovals),
             next.features.enabled(Feature::RequestPermissionsTool),
+            next.network.is_some(),
         )
         .render(),
     )

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -2579,6 +2579,7 @@ impl Session {
                     turn_context
                         .features
                         .enabled(Feature::RequestPermissionsTool),
+                    turn_context.network.is_some(),
                 )
                 .render(),
             );

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -27,6 +27,7 @@ use crate::context::AvailableSkillsInstructions;
 use crate::context::CollaborationModeInstructions;
 use crate::context::ContextualUserFragment;
 use crate::context::NetworkRuleSaved;
+use crate::context::PermissionsInstructionOptions;
 use crate::context::PermissionsInstructions;
 use crate::context::PersonalitySpecInstructions;
 use crate::default_skill_metadata_budget;
@@ -2573,13 +2574,15 @@ impl Session {
                     turn_context.config.approvals_reviewer,
                     self.services.exec_policy.current().as_ref(),
                     &turn_context.cwd,
-                    turn_context
-                        .features
-                        .enabled(Feature::ExecPermissionApprovals),
-                    turn_context
-                        .features
-                        .enabled(Feature::RequestPermissionsTool),
-                    turn_context.network.is_some(),
+                    PermissionsInstructionOptions {
+                        exec_permission_approvals_enabled: turn_context
+                            .features
+                            .enabled(Feature::ExecPermissionApprovals),
+                        request_permissions_tool_enabled: turn_context
+                            .features
+                            .enabled(Feature::RequestPermissionsTool),
+                        network_proxy_active: turn_context.network.is_some(),
+                    },
                 )
                 .render(),
             );

--- a/codex-rs/core/tests/suite/permissions_messages.rs
+++ b/codex-rs/core/tests/suite/permissions_messages.rs
@@ -583,6 +583,7 @@ async fn permissions_message_includes_writable_roots() -> Result<()> {
         test.config.cwd.as_path(),
         /*exec_permission_approvals_enabled*/ false,
         /*request_permissions_tool_enabled*/ false,
+        /*managed_network_proxy_active*/ false,
     )
     .render();
     let expected_normalized = normalize_line_endings(&expected);

--- a/codex-rs/core/tests/suite/permissions_messages.rs
+++ b/codex-rs/core/tests/suite/permissions_messages.rs
@@ -3,6 +3,7 @@ use codex_config::ConfigLayerStack;
 use codex_core::ForkSnapshot;
 use codex_core::config::Constrained;
 use codex_core::context::ContextualUserFragment;
+use codex_core::context::PermissionsInstructionOptions;
 use codex_core::context::PermissionsInstructions;
 use codex_core::load_exec_policy;
 use codex_protocol::models::PermissionProfile;
@@ -581,9 +582,11 @@ async fn permissions_message_includes_writable_roots() -> Result<()> {
         test.config.approvals_reviewer,
         &exec_policy,
         test.config.cwd.as_path(),
-        /*exec_permission_approvals_enabled*/ false,
-        /*request_permissions_tool_enabled*/ false,
-        /*managed_network_proxy_active*/ false,
+        PermissionsInstructionOptions {
+            exec_permission_approvals_enabled: false,
+            request_permissions_tool_enabled: false,
+            network_proxy_active: test.session_configured.network_proxy.is_some(),
+        },
     )
     .render();
     let expected_normalized = normalize_line_endings(&expected);


### PR DESCRIPTION
## Why
When a network proxy is active, the model needs enough context to keep proxy routing intact, distinguish explicit policy denials from ordinary network failures, and know when to request more network permission instead of trying to work around the sandbox. Without that guidance, it can misread proxy-mediated failures or override the environment that is enforcing policy.

## What changed
- Add a dedicated `# Network Proxy` section to the permissions instructions bundle when the current turn actually has an active proxy.
- Teach the model to honor `<network>` allow/deny entries, preserve proxy-related environment variables, and request more network permission for hosts outside policy.
- Spell out the useful denial signals (`blocked-by-allowlist`, `blocked-by-denylist`, and local/private target blocks) while clarifying that proxy-mediated clients can also time out or hang, so generic failures alone are not proof of a proxy denial.
- Keep the prompt plumbing explicit by grouping the feature-dependent render flags in `PermissionsInstructionOptions`.

## Testing
- `cargo test -p codex-core includes_network_proxy_guidance_when_proxy_is_active`
- `cargo test -p codex-core permissions_message_includes_writable_roots`
- `cargo clippy -p codex-core --all-targets -- -D warnings`
