### PR TITLE
Mark hooks schema fixtures as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 codex-rs/app-server-protocol/schema/** linguist-generated
+codex-rs/hooks/schema/generated/** linguist-generated


### PR DESCRIPTION
## Summary
- mark generated hooks schema fixture JSON as linguist-generated
- keep the app-server protocol generated schema marking unchanged

## Validation
- `git check-attr linguist-generated -- codex-rs/hooks/schema/generated/post-tool-use.command.output.schema.json`
