### PR TITLE
do not attempt ACLs on installed codex dir

### DIFF
--- a/codex-rs/windows-sandbox-rs/src/setup_orchestrator.rs
+++ b/codex-rs/windows-sandbox-rs/src/setup_orchestrator.rs
@@ -345,16 +345,9 @@ fn profile_read_roots(user_profile: &Path) -> Vec<PathBuf> {
 }
 
 fn gather_helper_read_roots(codex_home: &Path) -> Vec<PathBuf> {
-    let mut roots = Vec::new();
-    if let Ok(exe) = std::env::current_exe()
-        && let Some(dir) = exe.parent()
-    {
-        roots.push(dir.to_path_buf());
-    }
     let helper_dir = helper_bin_dir(codex_home);
     let _ = std::fs::create_dir_all(&helper_dir);
-    roots.push(helper_dir);
-    roots
+    vec![helper_dir]
 }
 
 fn gather_legacy_full_read_roots(


### PR DESCRIPTION
We used to attempt a read-ACL on the same dir as `codex.exe` to grant the sandbox user the ability to invoke `codex-command-runner.exe`. That worked for the CLI case but it always fails for the installed desktop app.

We have another solution already in place that copies `codex-command-runner.exe` to `CODEX_HOME/.sandbox-bin` so we don't even need this anymore. It causes a scary looking error in the logs that is a non-issue and is therefore confusing
