### PR TITLE
Bump phase-two default model to gpt-5.5

### DIFF
--- a/codex-rs/core/src/memories/mod.rs
+++ b/codex-rs/core/src/memories/mod.rs
@@ -67,7 +67,7 @@ mod phase_one {
 /// Phase 2 (aka `Consolidation`).
 mod phase_two {
     /// Default model used for phase 2.
-    pub(super) const MODEL: &str = "gpt-5.4";
+    pub(super) const MODEL: &str = "gpt-5.5";
     /// Default reasoning effort used for phase 2.
     pub(super) const REASONING_EFFORT: super::ReasoningEffort = super::ReasoningEffort::Medium;
     /// Lease duration (seconds) for phase-2 consolidation job ownership.


### PR DESCRIPTION
### Motivation
- Use the newer `gpt-5.5` model for phase-2 (Consolidation) to leverage improved reasoning and performance compared to `gpt-5.4`.

### Description
- Update the `phase_two::MODEL` constant from `"gpt-5.4"` to `"gpt-5.5"` in `core/src/memories/mod.rs`.

### Testing
- Ran `cargo test` (unit and integration tests) and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_i_69ea8e442e38832aa41c33caf467bde1)