### PR TITLE
ci: reuse Bazel CI startup for target-discovery queries

### DIFF
--- a/.github/scripts/run-argument-comment-lint-bazel.sh
+++ b/.github/scripts/run-argument-comment-lint-bazel.sh
@@ -2,16 +2,6 @@
 
 set -euo pipefail
 
-ci_config=ci-linux
-case "${RUNNER_OS:-}" in
-  macOS)
-    ci_config=ci-macos
-    ;;
-  Windows)
-    ci_config=ci-windows
-    ;;
-esac
-
 bazel_lint_args=("$@")
 if [[ "${RUNNER_OS:-}" == "Windows" ]]; then
   has_host_platform_override=0
@@ -44,29 +34,6 @@ if [[ "${RUNNER_OS:-}" == "Windows" ]]; then
   bazel_lint_args+=("--skip_incompatible_explicit_targets")
 fi
 
-bazel_startup_args=()
-if [[ -n "${BAZEL_OUTPUT_USER_ROOT:-}" ]]; then
-  bazel_startup_args+=("--output_user_root=${BAZEL_OUTPUT_USER_ROOT}")
-fi
-
-run_bazel() {
-  if [[ "${RUNNER_OS:-}" == "Windows" ]]; then
-    MSYS2_ARG_CONV_EXCL='*' bazel "$@"
-    return
-  fi
-
-  bazel "$@"
-}
-
-run_bazel_with_startup_args() {
-  if [[ ${#bazel_startup_args[@]} -gt 0 ]]; then
-    run_bazel "${bazel_startup_args[@]}" "$@"
-    return
-  fi
-
-  run_bazel "$@"
-}
-
 read_query_labels() {
   local query="$1"
   local query_stdout
@@ -74,12 +41,10 @@ read_query_labels() {
   query_stdout="$(mktemp)"
   query_stderr="$(mktemp)"
 
-  if ! run_bazel_with_startup_args \
-    --noexperimental_remote_repo_contents_cache \
-    query \
+  if ! ./.github/scripts/run-bazel-query-ci.sh \
     --keep_going \
     --output=label \
-    "$query" >"$query_stdout" 2>"$query_stderr"; then
+    -- "$query" >"$query_stdout" 2>"$query_stderr"; then
     cat "$query_stderr" >&2
     rm -f "$query_stdout" "$query_stderr"
     exit 1

--- a/.github/scripts/run-bazel-query-ci.sh
+++ b/.github/scripts/run-bazel-query-ci.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Run Bazel queries with the same CI startup settings as the main build/test
+# invocation so target-discovery queries can reuse the same Bazel server.
+
+query_args=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --)
+      shift
+      break
+      ;;
+    *)
+      query_args+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 [<bazel query args>...] -- <query expression>" >&2
+  exit 1
+fi
+
+query_expression="$1"
+
+ci_config=ci-linux
+case "${RUNNER_OS:-}" in
+  macOS)
+    ci_config=ci-macos
+    ;;
+  Windows)
+    ci_config=ci-windows
+    ;;
+esac
+
+bazel_startup_args=()
+if [[ -n "${BAZEL_OUTPUT_USER_ROOT:-}" ]]; then
+  bazel_startup_args+=("--output_user_root=${BAZEL_OUTPUT_USER_ROOT}")
+fi
+
+run_bazel() {
+  if [[ "${RUNNER_OS:-}" == "Windows" ]]; then
+    MSYS2_ARG_CONV_EXCL='*' bazel "$@"
+    return
+  fi
+
+  bazel "$@"
+}
+
+bazel_query_args=(--noexperimental_remote_repo_contents_cache query)
+if [[ -n "${BUILDBUDDY_API_KEY:-}" ]]; then
+  bazel_query_args+=(
+    "--config=${ci_config}"
+    "--remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}"
+  )
+fi
+
+if [[ -n "${BAZEL_REPO_CONTENTS_CACHE:-}" ]]; then
+  bazel_query_args+=("--repo_contents_cache=${BAZEL_REPO_CONTENTS_CACHE}")
+fi
+
+if [[ -n "${BAZEL_REPOSITORY_CACHE:-}" ]]; then
+  bazel_query_args+=("--repository_cache=${BAZEL_REPOSITORY_CACHE}")
+fi
+
+bazel_query_args+=("${query_args[@]}" "$query_expression")
+
+if (( ${#bazel_startup_args[@]} > 0 )); then
+  run_bazel "${bazel_startup_args[@]}" "${bazel_query_args[@]}"
+else
+  run_bazel "${bazel_query_args[@]}"
+fi

--- a/scripts/list-bazel-clippy-targets.sh
+++ b/scripts/list-bazel-clippy-targets.sh
@@ -6,8 +6,14 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${repo_root}"
 
 # Resolve the dynamic targets before printing anything so callers do not
-# continue with a partial list if `bazel query` fails.
-manual_rust_test_targets="$(bazel query 'kind("rust_test rule", attr(tags, "manual", //codex-rs/... except //codex-rs/v8-poc/...))')"
+# continue with a partial list if `bazel query` fails. Reuse the same CI Bazel
+# server settings as the subsequent build so Windows jobs do not cold-start a
+# second Bazel server just for target discovery.
+manual_rust_test_targets="$(
+  ./.github/scripts/run-bazel-query-ci.sh \
+    --output=label \
+    -- 'kind("rust_test rule", attr(tags, "manual", //codex-rs/... except //codex-rs/v8-poc/...))'
+)"
 
 printf '%s\n' \
   "//codex-rs/..." \

--- a/tools/argument-comment-lint/list-bazel-targets.sh
+++ b/tools/argument-comment-lint/list-bazel-targets.sh
@@ -10,4 +10,6 @@ cd "${repo_root}"
 # Add only those manual rust_test targets explicitly so inline `#[cfg(test)]`
 # call sites are linted without pulling in unrelated manual release targets.
 printf '%s\n' "//codex-rs/..."
-bazel query 'kind("rust_test rule", attr(tags, "manual", //codex-rs/...))'
+./.github/scripts/run-bazel-query-ci.sh \
+  --output=label \
+  -- 'kind("rust_test rule", attr(tags, "manual", //codex-rs/...))'


### PR DESCRIPTION
## Why

A rerun of the Windows Bazel clippy job after [#19161](https://github.com/openai/codex/pull/19161) had exactly the cache behavior we wanted in BuildBuddy: zero action-cache misses. Even so, the GitHub job still took a little over five minutes.

The problem was that the job was paying for two separate Bazel startup paths:

1. a `bazel query` to discover extra lint targets
2. the real `bazel build --config=clippy ...` invocation

On Windows, that query was bypassing the CI Bazel wrapper, so it did not reuse the same `--output_user_root`, CI config, or remote-cache setup as the real build. In practice that meant the rerun could still cold-start a separate Bazel server before the actual clippy build even began.

## What

- add `.github/scripts/run-bazel-query-ci.sh` to run CI-side Bazel queries with the same startup and cache-related flags as the main Bazel command
- switch `scripts/list-bazel-clippy-targets.sh` to use that helper for manual `rust_test` target discovery
- switch `tools/argument-comment-lint/list-bazel-targets.sh` to use the same helper
- simplify `.github/scripts/run-argument-comment-lint-bazel.sh` so its Windows-only query path also goes through the shared helper

This keeps the target-discovery queries aligned with the later build/test invocation instead of treating them as a separate cold Bazel session.

## Verification

- `bash -n .github/scripts/run-bazel-query-ci.sh`
- `bash -n scripts/list-bazel-clippy-targets.sh`
- `bash -n tools/argument-comment-lint/list-bazel-targets.sh`
- `bash -n .github/scripts/run-argument-comment-lint-bazel.sh`
- mocked a Windows invocation of `run-bazel-query-ci.sh` and verified it forwards `--output_user_root`, `--config=ci-windows`, the BuildBuddy auth header, and the repository cache flags

## Docs

No documentation updates are needed.
