### PR TITLE
Make thread archive idempotent for archived threads

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -2945,7 +2945,7 @@ impl CodexMessageProcessor {
             .thread_store
             .read_thread(StoreReadThreadParams {
                 thread_id,
-                include_archived: false,
+                include_archived: true,
                 include_history: false,
             })
             .await

--- a/codex-rs/app-server/tests/suite/v2/thread_archive.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_archive.rs
@@ -166,6 +166,89 @@ async fn thread_archive_requires_materialized_rollout() -> Result<()> {
 }
 
 #[tokio::test]
+async fn thread_archive_is_idempotent_for_already_archived_thread() -> Result<()> {
+    let server = create_mock_responses_server_repeating_assistant("Done").await;
+    let codex_home = TempDir::new()?;
+    create_config_toml(codex_home.path(), &server.uri())?;
+
+    let thread_id = create_fake_rollout(
+        codex_home.path(),
+        "2025-01-01T00-00-00",
+        "2025-01-01T00:00:00Z",
+        "parent",
+        Some("mock_provider"),
+        /*git_info*/ None,
+    )?;
+    let rollout_path = find_thread_path_by_id_str(codex_home.path(), &thread_id)
+        .await?
+        .expect("active rollout path");
+
+    let mut mcp = McpProcess::new(codex_home.path()).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let archive_id = mcp
+        .send_thread_archive_request(ThreadArchiveParams {
+            thread_id: thread_id.clone(),
+        })
+        .await?;
+    let archive_resp: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(archive_id)),
+    )
+    .await??;
+    let _: ThreadArchiveResponse = to_response::<ThreadArchiveResponse>(archive_resp)?;
+
+    let archive_notification = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_notification_message("thread/archived"),
+    )
+    .await??;
+    let archived_notification: ThreadArchivedNotification = serde_json::from_value(
+        archive_notification
+            .params
+            .expect("thread/archived notification params"),
+    )?;
+    assert_eq!(archived_notification.thread_id, thread_id);
+
+    let archived_rollout_path = find_archived_thread_path_by_id_str(codex_home.path(), &thread_id)
+        .await?
+        .expect("archived rollout path");
+    assert_paths_match_on_disk(
+        &archived_rollout_path,
+        &codex_home
+            .path()
+            .join(ARCHIVED_SESSIONS_SUBDIR)
+            .join(rollout_path.file_name().expect("rollout file name")),
+    )?;
+    assert!(
+        find_thread_path_by_id_str(codex_home.path(), &thread_id)
+            .await?
+            .is_none(),
+        "thread should no longer have an active rollout"
+    );
+
+    let archive_again_id = mcp
+        .send_thread_archive_request(ThreadArchiveParams {
+            thread_id: thread_id.clone(),
+        })
+        .await?;
+    let archive_again_resp: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(archive_again_id)),
+    )
+    .await??;
+    let _: ThreadArchiveResponse = to_response::<ThreadArchiveResponse>(archive_again_resp)?;
+
+    let archived_rollout_path_after =
+        find_archived_thread_path_by_id_str(codex_home.path(), &thread_id)
+            .await?
+            .expect("archived rollout path after second archive");
+    assert_paths_match_on_disk(&archived_rollout_path_after, &archived_rollout_path)?;
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn thread_archive_archives_spawned_descendants() -> Result<()> {
     let server = create_mock_responses_server_repeating_assistant("Done").await;
     let codex_home = TempDir::new()?;


### PR DESCRIPTION
## Summary

Makes `thread/archive` idempotent when the requested parent thread is already archived.

The only behavior change is that the archive handler reads the parent thread with `include_archived: true`, matching the descendant handling it already had. If the parent is already archived, it now returns a successful empty archive response instead of surfacing `no rollout found for thread id`.

## Why

Users in `#codex-app-feedback` reported that archiving a task/thread could show `Failed to archive conversation`, with the sidebar row disappearing briefly and then returning. Several reports also had the "Worktree cleaned up" banner, but the cleanup path appears to run only after a successful archive response, so that looks like a red herring rather than the direct cause.

The likely failure mode is:

1. The app still has a visible/stale active row for a thread that the server already considers archived.
2. The user archives it again.
3. The server tries to read the parent using the active-only path.
4. Because the rollout has already moved to archived storage, the request fails.

That is a poor user experience and it violates the product invariant we want: visible active threads should never be archived. Enforcing the UI invariant is still worthwhile, but this server-side change is a very small, safe backstop that prevents users from getting stuck when stale UI state leaks through.

## Safety

- Does not change the API shape.
- Does not change worktree cleanup behavior.
- Keeps `thread_archive_requires_materialized_rollout` intact: archiving a thread that never materialized a rollout still fails.
- Only turns "archive something already archived" into a no-op success.
- Adds regression coverage for archive -> archive again.

## Tests

- `just fmt`
- `cargo test -p codex-app-server thread_archive_is_idempotent_for_already_archived_thread`
- `cargo test -p codex-app-server suite::v2::thread_archive`
