### PR TITLE
Refactor log DB into LogWriter interface

### DIFF
--- a/codex-rs/state/src/log_db.rs
+++ b/codex-rs/state/src/log_db.rs
@@ -91,7 +91,6 @@ where
     fn flush(&self) -> impl Future<Output = ()> + Send + '_;
 }
 
-#[derive(Clone)]
 pub struct LogDbLayer {
     sender: mpsc::Sender<LogDbCommand>,
     process_uuid: String,
@@ -99,6 +98,15 @@ pub struct LogDbLayer {
 
 pub fn start(state_db: std::sync::Arc<StateRuntime>) -> LogDbLayer {
     LogDbLayer::start(state_db)
+}
+
+impl Clone for LogDbLayer {
+    fn clone(&self) -> Self {
+        Self {
+            sender: self.sender.clone(),
+            process_uuid: self.process_uuid.clone(),
+        }
+    }
 }
 
 impl LogDbLayer {
@@ -128,11 +136,6 @@ impl LogDbLayer {
 
     fn try_send(&self, entry: LogEntry) {
         let _ = self.sender.try_send(LogDbCommand::Entry(Box::new(entry)));
-    }
-
-    #[cfg(test)]
-    fn max_capacity(&self) -> usize {
-        self.sender.max_capacity()
     }
 }
 
@@ -185,7 +188,32 @@ where
     }
 
     fn on_event(&self, event: &Event<'_>, ctx: tracing_subscriber::layer::Context<'_, S>) {
-        let entry = self.format_event(event, ctx);
+        let metadata = event.metadata();
+        let mut visitor = MessageVisitor::default();
+        event.record(&mut visitor);
+        let thread_id = visitor
+            .thread_id
+            .clone()
+            .or_else(|| event_thread_id(event, &ctx));
+        let feedback_log_body = format_feedback_log_body(event, &ctx);
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_else(|_| Duration::from_secs(0));
+        let entry = LogEntry {
+            ts: now.as_secs() as i64,
+            ts_nanos: now.subsec_nanos() as i64,
+            level: metadata.level().as_str().to_string(),
+            target: metadata.target().to_string(),
+            message: visitor.message,
+            feedback_log_body: Some(feedback_log_body),
+            thread_id,
+            process_uuid: Some(self.process_uuid.clone()),
+            module_path: metadata.module_path().map(ToString::to_string),
+            file: metadata.file().map(ToString::to_string),
+            line: metadata.line().map(|line| line as i64),
+        };
+
         self.try_send(entry);
     }
 }
@@ -199,97 +227,9 @@ where
     }
 }
 
-impl LogDbLayer {
-    fn format_event<S>(
-        &self,
-        event: &Event<'_>,
-        ctx: tracing_subscriber::layer::Context<'_, S>,
-    ) -> LogEntry
-    where
-        S: tracing::Subscriber + for<'a> LookupSpan<'a>,
-    {
-        let metadata = event.metadata();
-        let mut visitor = MessageVisitor::default();
-        event.record(&mut visitor);
-        let thread_id = visitor
-            .thread_id
-            .clone()
-            .or_else(|| event_thread_id(event, &ctx));
-        let feedback_log_body = format_feedback_log_body(event, &ctx);
-
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_else(|_| Duration::from_secs(0));
-        LogEntry {
-            ts: now.as_secs() as i64,
-            ts_nanos: now.subsec_nanos() as i64,
-            level: metadata.level().as_str().to_string(),
-            target: metadata.target().to_string(),
-            message: visitor.message,
-            feedback_log_body: Some(feedback_log_body),
-            thread_id,
-            process_uuid: Some(self.process_uuid.clone()),
-            module_path: metadata.module_path().map(ToString::to_string),
-            file: metadata.file().map(ToString::to_string),
-            line: metadata.line().map(|line| line as i64),
-        }
-    }
-}
-
 enum LogDbCommand {
     Entry(Box<LogEntry>),
     Flush(oneshot::Sender<()>),
-}
-
-async fn run_inserter(
-    state_db: std::sync::Arc<StateRuntime>,
-    mut receiver: mpsc::Receiver<LogDbCommand>,
-    config: LogSinkQueueConfig,
-) {
-    let mut buffer = Vec::with_capacity(config.batch_size);
-    let mut ticker = tokio::time::interval(config.flush_interval);
-    loop {
-        tokio::select! {
-            maybe_command = receiver.recv() => {
-                match maybe_command {
-                    Some(LogDbCommand::Entry(entry)) => {
-                        buffer.push(*entry);
-                        if buffer.len() >= config.batch_size {
-                            insert_batch(&state_db, &mut buffer).await;
-                        }
-                    }
-                    Some(LogDbCommand::Flush(reply)) => {
-                        insert_batch(&state_db, &mut buffer).await;
-                        let _ = reply.send(());
-                    }
-                    None => {
-                        insert_batch(&state_db, &mut buffer).await;
-                        break;
-                    }
-                }
-            }
-            _ = ticker.tick() => {
-                insert_batch(&state_db, &mut buffer).await;
-            }
-        }
-    }
-}
-
-async fn insert_batch(state_db: &StateRuntime, buffer: &mut Vec<LogEntry>) {
-    if buffer.is_empty() {
-        return;
-    }
-    let entries = buffer.split_off(0);
-    let _ = state_db.insert_logs(entries.as_slice()).await;
-}
-
-fn current_process_log_uuid() -> &'static str {
-    static PROCESS_LOG_UUID: OnceLock<String> = OnceLock::new();
-    PROCESS_LOG_UUID.get_or_init(|| {
-        let pid = std::process::id();
-        let process_uuid = Uuid::new_v4();
-        format!("pid:{pid}:{process_uuid}")
-    })
 }
 
 #[derive(Debug)]
@@ -409,6 +349,57 @@ fn append_fields(fields: &mut String, values: &Record<'_>) {
     let mut formatted = FormattedFields::<DefaultFields>::new(std::mem::take(fields));
     let _ = formatter.add_fields(&mut formatted, values);
     *fields = formatted.fields;
+}
+
+fn current_process_log_uuid() -> &'static str {
+    static PROCESS_LOG_UUID: OnceLock<String> = OnceLock::new();
+    PROCESS_LOG_UUID.get_or_init(|| {
+        let pid = std::process::id();
+        let process_uuid = Uuid::new_v4();
+        format!("pid:{pid}:{process_uuid}")
+    })
+}
+
+async fn run_inserter(
+    state_db: std::sync::Arc<StateRuntime>,
+    mut receiver: mpsc::Receiver<LogDbCommand>,
+    config: LogSinkQueueConfig,
+) {
+    let mut buffer = Vec::with_capacity(config.batch_size);
+    let mut ticker = tokio::time::interval(config.flush_interval);
+    loop {
+        tokio::select! {
+            maybe_command = receiver.recv() => {
+                match maybe_command {
+                    Some(LogDbCommand::Entry(entry)) => {
+                        buffer.push(*entry);
+                        if buffer.len() >= config.batch_size {
+                            flush(&state_db, &mut buffer).await;
+                        }
+                    }
+                    Some(LogDbCommand::Flush(reply)) => {
+                        flush(&state_db, &mut buffer).await;
+                        let _ = reply.send(());
+                    }
+                    None => {
+                        flush(&state_db, &mut buffer).await;
+                        break;
+                    }
+                }
+            }
+            _ = ticker.tick() => {
+                flush(&state_db, &mut buffer).await;
+            }
+        }
+    }
+}
+
+async fn flush(state_db: &StateRuntime, buffer: &mut Vec<LogEntry>) {
+    if buffer.is_empty() {
+        return;
+    }
+    let entries = buffer.split_off(0);
+    let _ = state_db.insert_logs(entries.as_slice()).await;
 }
 
 #[derive(Default)]
@@ -641,27 +632,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn start_with_config_uses_configured_queue_capacity() {
-        let codex_home = temp_codex_home();
-        let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
-            .await
-            .expect("initialize runtime");
-
-        let layer = LogDbLayer::start_with_config(
-            runtime,
-            LogSinkQueueConfig {
-                queue_capacity: 3,
-                batch_size: 2,
-                flush_interval: std::time::Duration::from_secs(60),
-            },
-        );
-
-        assert_eq!(layer.max_capacity(), 3);
-
-        let _ = tokio::fs::remove_dir_all(codex_home).await;
-    }
-
-    #[tokio::test]
     async fn configured_batch_size_flushes_without_explicit_flush() {
         let codex_home = temp_codex_home();
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
@@ -802,43 +772,5 @@ mod tests {
             .await
             .expect("flush task completes")
             .expect("flush task succeeds");
-    }
-
-    #[tokio::test]
-    async fn receiver_close_drains_buffered_entries() {
-        let codex_home = temp_codex_home();
-        let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
-            .await
-            .expect("initialize runtime");
-        let layer = LogDbLayer::start_with_config(
-            runtime.clone(),
-            LogSinkQueueConfig {
-                queue_capacity: 8,
-                batch_size: 8,
-                flush_interval: std::time::Duration::from_secs(60),
-            },
-        );
-
-        layer.try_send(test_entry("drained-on-close"));
-        drop(layer);
-
-        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(1);
-        loop {
-            let rows = runtime
-                .query_logs(&crate::LogQuery::default())
-                .await
-                .expect("query logs after receiver close");
-            if !rows.is_empty() {
-                assert_eq!(rows[0].message.as_deref(), Some("drained-on-close"));
-                break;
-            }
-            assert!(
-                tokio::time::Instant::now() < deadline,
-                "timed out waiting for receiver close drain"
-            );
-            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-        }
-
-        let _ = tokio::fs::remove_dir_all(codex_home).await;
     }
 }

--- a/codex-rs/state/src/log_db.rs
+++ b/codex-rs/state/src/log_db.rs
@@ -1,8 +1,10 @@
-//! Tracing log export into the state SQLite database.
+//! Tracing log export into a bounded buffered sink.
 //!
-//! This module provides a `tracing_subscriber::Layer` that captures events and
-//! inserts them into the dedicated `logs` SQLite database. The writer runs in a
-//! background task and batches inserts to keep logging overhead low.
+//! This module provides a `tracing_subscriber::Layer` that captures events,
+//! formats each one into a `LogEntry`, and sends entries to one configured
+//! buffered writer. The default writer inserts into the dedicated `logs` SQLite
+//! database from a background task and batches inserts to keep logging overhead
+//! low.
 //!
 //! ## Usage
 //!
@@ -18,6 +20,8 @@
 //! # }
 //! ```
 
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::OnceLock;
 use std::time::Duration;
 use std::time::SystemTime;
@@ -45,37 +49,147 @@ use crate::StateRuntime;
 const LOG_QUEUE_CAPACITY: usize = 512;
 const LOG_BATCH_SIZE: usize = 128;
 const LOG_FLUSH_INTERVAL: Duration = Duration::from_secs(2);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct LogSinkQueueConfig {
+    pub queue_capacity: usize,
+    pub batch_size: usize,
+    pub flush_interval: Duration,
+}
+
+impl Default for LogSinkQueueConfig {
+    fn default() -> Self {
+        Self {
+            queue_capacity: LOG_QUEUE_CAPACITY,
+            batch_size: LOG_BATCH_SIZE,
+            flush_interval: LOG_FLUSH_INTERVAL,
+        }
+    }
+}
+
+impl LogSinkQueueConfig {
+    fn normalized(self) -> Self {
+        Self {
+            queue_capacity: self.queue_capacity.max(1),
+            batch_size: self.batch_size.max(1),
+            flush_interval: if self.flush_interval.is_zero() {
+                LOG_FLUSH_INTERVAL
+            } else {
+                self.flush_interval
+            },
+        }
+    }
+}
+
+/// Destination-specific writer for batches produced by `BufferedLogSink`.
+pub trait LogBatchWriter: Send + 'static {
+    fn write_batch<'a>(
+        &'a mut self,
+        entries: Vec<LogEntry>,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
+}
+
+pub struct BufferedLogSink<W> {
+    sender: mpsc::Sender<LogSinkCommand>,
+    _writer: std::marker::PhantomData<fn() -> W>,
+}
+
+impl<W> Clone for BufferedLogSink<W> {
+    fn clone(&self) -> Self {
+        Self {
+            sender: self.sender.clone(),
+            _writer: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<W> BufferedLogSink<W>
+where
+    W: LogBatchWriter,
+{
+    pub fn start(writer: W, config: LogSinkQueueConfig) -> Self {
+        let config = config.normalized();
+        let (sender, receiver) = mpsc::channel(config.queue_capacity);
+        tokio::spawn(run_buffered_sink(writer, receiver, config));
+        Self {
+            sender,
+            _writer: std::marker::PhantomData,
+        }
+    }
+
+    pub fn try_send(&self, entry: LogEntry) {
+        let _ = self.sender.try_send(LogSinkCommand::Entry(Box::new(entry)));
+    }
+
+    pub async fn flush(&self) {
+        let (tx, rx) = oneshot::channel();
+        if self.sender.send(LogSinkCommand::Flush(tx)).await.is_ok() {
+            let _ = rx.await;
+        }
+    }
+
+    #[cfg(test)]
+    fn max_capacity(&self) -> usize {
+        self.sender.max_capacity()
+    }
+}
+
+pub struct SqliteLogWriter {
+    state_db: std::sync::Arc<StateRuntime>,
+}
+
+impl SqliteLogWriter {
+    fn new(state_db: std::sync::Arc<StateRuntime>) -> Self {
+        Self { state_db }
+    }
+}
+
+impl LogBatchWriter for SqliteLogWriter {
+    fn write_batch<'a>(
+        &'a mut self,
+        entries: Vec<LogEntry>,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(async move {
+            let _ = self.state_db.insert_logs(entries.as_slice()).await;
+        })
+    }
+}
+
 pub struct LogDbLayer {
-    sender: mpsc::Sender<LogDbCommand>,
+    sink: BufferedLogSink<SqliteLogWriter>,
     process_uuid: String,
 }
 
 pub fn start(state_db: std::sync::Arc<StateRuntime>) -> LogDbLayer {
-    let process_uuid = current_process_log_uuid().to_string();
-    let (sender, receiver) = mpsc::channel(LOG_QUEUE_CAPACITY);
-    tokio::spawn(run_inserter(std::sync::Arc::clone(&state_db), receiver));
-
-    LogDbLayer {
-        sender,
-        process_uuid,
-    }
+    LogDbLayer::start(state_db)
 }
 
 impl Clone for LogDbLayer {
     fn clone(&self) -> Self {
         Self {
-            sender: self.sender.clone(),
+            sink: self.sink.clone(),
             process_uuid: self.process_uuid.clone(),
         }
     }
 }
 
 impl LogDbLayer {
-    pub async fn flush(&self) {
-        let (tx, rx) = oneshot::channel();
-        if self.sender.send(LogDbCommand::Flush(tx)).await.is_ok() {
-            let _ = rx.await;
+    pub fn start(state_db: std::sync::Arc<StateRuntime>) -> Self {
+        Self::start_with_config(state_db, LogSinkQueueConfig::default())
+    }
+
+    pub fn start_with_config(
+        state_db: std::sync::Arc<StateRuntime>,
+        config: LogSinkQueueConfig,
+    ) -> Self {
+        Self {
+            sink: BufferedLogSink::start(SqliteLogWriter::new(state_db), config),
+            process_uuid: current_process_log_uuid().to_string(),
         }
+    }
+
+    pub async fn flush(&self) {
+        self.sink.flush().await;
     }
 }
 
@@ -128,6 +242,20 @@ where
     }
 
     fn on_event(&self, event: &Event<'_>, ctx: tracing_subscriber::layer::Context<'_, S>) {
+        let entry = self.format_event(event, ctx);
+        self.sink.try_send(entry);
+    }
+}
+
+impl LogDbLayer {
+    fn format_event<S>(
+        &self,
+        event: &Event<'_>,
+        ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) -> LogEntry
+    where
+        S: tracing::Subscriber + for<'a> LookupSpan<'a>,
+    {
         let metadata = event.metadata();
         let mut visitor = MessageVisitor::default();
         event.record(&mut visitor);
@@ -140,7 +268,7 @@ where
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_else(|_| Duration::from_secs(0));
-        let entry = LogEntry {
+        LogEntry {
             ts: now.as_secs() as i64,
             ts_nanos: now.subsec_nanos() as i64,
             level: metadata.level().as_str().to_string(),
@@ -152,15 +280,69 @@ where
             module_path: metadata.module_path().map(ToString::to_string),
             file: metadata.file().map(ToString::to_string),
             line: metadata.line().map(|line| line as i64),
-        };
-
-        let _ = self.sender.try_send(LogDbCommand::Entry(Box::new(entry)));
+        }
     }
 }
 
-enum LogDbCommand {
+enum LogSinkCommand {
     Entry(Box<LogEntry>),
     Flush(oneshot::Sender<()>),
+}
+
+async fn run_buffered_sink<W>(
+    mut writer: W,
+    mut receiver: mpsc::Receiver<LogSinkCommand>,
+    config: LogSinkQueueConfig,
+) where
+    W: LogBatchWriter,
+{
+    let mut buffer = Vec::with_capacity(config.batch_size);
+    let mut ticker = tokio::time::interval(config.flush_interval);
+    loop {
+        tokio::select! {
+            maybe_command = receiver.recv() => {
+                match maybe_command {
+                    Some(LogSinkCommand::Entry(entry)) => {
+                        buffer.push(*entry);
+                        if buffer.len() >= config.batch_size {
+                            flush(&mut writer, &mut buffer).await;
+                        }
+                    }
+                    Some(LogSinkCommand::Flush(reply)) => {
+                        flush(&mut writer, &mut buffer).await;
+                        let _ = reply.send(());
+                    }
+                    None => {
+                        flush(&mut writer, &mut buffer).await;
+                        break;
+                    }
+                }
+            }
+            _ = ticker.tick() => {
+                flush(&mut writer, &mut buffer).await;
+            }
+        }
+    }
+}
+
+async fn flush<W>(writer: &mut W, buffer: &mut Vec<LogEntry>)
+where
+    W: LogBatchWriter,
+{
+    if buffer.is_empty() {
+        return;
+    }
+    let entries = buffer.split_off(0);
+    writer.write_batch(entries).await;
+}
+
+fn current_process_log_uuid() -> &'static str {
+    static PROCESS_LOG_UUID: OnceLock<String> = OnceLock::new();
+    PROCESS_LOG_UUID.get_or_init(|| {
+        let pid = std::process::id();
+        let process_uuid = Uuid::new_v4();
+        format!("pid:{pid}:{process_uuid}")
+    })
 }
 
 #[derive(Debug)]
@@ -282,56 +464,6 @@ fn append_fields(fields: &mut String, values: &Record<'_>) {
     *fields = formatted.fields;
 }
 
-fn current_process_log_uuid() -> &'static str {
-    static PROCESS_LOG_UUID: OnceLock<String> = OnceLock::new();
-    PROCESS_LOG_UUID.get_or_init(|| {
-        let pid = std::process::id();
-        let process_uuid = Uuid::new_v4();
-        format!("pid:{pid}:{process_uuid}")
-    })
-}
-
-async fn run_inserter(
-    state_db: std::sync::Arc<StateRuntime>,
-    mut receiver: mpsc::Receiver<LogDbCommand>,
-) {
-    let mut buffer = Vec::with_capacity(LOG_BATCH_SIZE);
-    let mut ticker = tokio::time::interval(LOG_FLUSH_INTERVAL);
-    loop {
-        tokio::select! {
-            maybe_command = receiver.recv() => {
-                match maybe_command {
-                    Some(LogDbCommand::Entry(entry)) => {
-                        buffer.push(*entry);
-                        if buffer.len() >= LOG_BATCH_SIZE {
-                            flush(&state_db, &mut buffer).await;
-                        }
-                    }
-                    Some(LogDbCommand::Flush(reply)) => {
-                        flush(&state_db, &mut buffer).await;
-                        let _ = reply.send(());
-                    }
-                    None => {
-                        flush(&state_db, &mut buffer).await;
-                        break;
-                    }
-                }
-            }
-            _ = ticker.tick() => {
-                flush(&state_db, &mut buffer).await;
-            }
-        }
-    }
-}
-
-async fn flush(state_db: &std::sync::Arc<StateRuntime>, buffer: &mut Vec<LogEntry>) {
-    if buffer.is_empty() {
-        return;
-    }
-    let entries = buffer.split_off(0);
-    let _ = state_db.insert_logs(entries.as_slice()).await;
-}
-
 #[derive(Default)]
 struct MessageVisitor {
     message: Option<String>,
@@ -384,6 +516,7 @@ mod tests {
     use std::io;
     use std::sync::Arc;
     use std::sync::Mutex;
+    use std::sync::MutexGuard;
 
     use pretty_assertions::assert_eq;
     use tracing_subscriber::filter::Targets;
@@ -392,6 +525,67 @@ mod tests {
     use tracing_subscriber::util::SubscriberInitExt;
 
     use super::*;
+
+    #[derive(Default)]
+    struct TestWriter {
+        batches: Arc<Mutex<Vec<Vec<LogEntry>>>>,
+    }
+
+    impl TestWriter {
+        fn batches(&self) -> MutexGuard<'_, Vec<Vec<LogEntry>>> {
+            self.batches.lock().expect("test writer mutex poisoned")
+        }
+    }
+
+    impl LogBatchWriter for TestWriter {
+        fn write_batch<'a>(
+            &'a mut self,
+            entries: Vec<LogEntry>,
+        ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+            Box::pin(async move {
+                self.batches().push(entries);
+            })
+        }
+    }
+
+    fn temp_codex_home() -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("codex-state-log-db-{}", Uuid::new_v4()))
+    }
+
+    async fn wait_for_log_count(runtime: &StateRuntime, expected: usize) -> Vec<crate::LogRow> {
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+        loop {
+            let rows = runtime
+                .query_logs(&crate::LogQuery::default())
+                .await
+                .expect("query logs");
+            if rows.len() == expected {
+                return rows;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "timed out waiting for {expected} logs; saw {}",
+                rows.len()
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    }
+
+    fn test_entry(message: &str) -> LogEntry {
+        LogEntry {
+            ts: 1,
+            ts_nanos: 2,
+            level: "INFO".to_string(),
+            target: "test".to_string(),
+            message: Some(message.to_string()),
+            feedback_log_body: Some(message.to_string()),
+            thread_id: Some("thread-1".to_string()),
+            process_uuid: Some("process-1".to_string()),
+            module_path: Some("module".to_string()),
+            file: Some("file.rs".to_string()),
+            line: Some(7),
+        }
+    }
 
     #[derive(Clone, Default)]
     struct SharedWriter {
@@ -435,8 +629,7 @@ mod tests {
 
     #[tokio::test]
     async fn sqlite_feedback_logs_match_feedback_formatter_shape() {
-        let codex_home =
-            std::env::temp_dir().join(format!("codex-state-log-db-{}", Uuid::new_v4()));
+        let codex_home = temp_codex_home();
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
             .await
             .expect("initialize runtime");
@@ -494,8 +687,7 @@ mod tests {
 
     #[tokio::test]
     async fn flush_persists_logs_for_query() {
-        let codex_home =
-            std::env::temp_dir().join(format!("codex-state-log-db-{}", Uuid::new_v4()));
+        let codex_home = temp_codex_home();
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
             .await
             .expect("initialize runtime");
@@ -522,5 +714,195 @@ mod tests {
         assert_eq!(after_flush[0].message.as_deref(), Some("buffered-log"));
 
         let _ = tokio::fs::remove_dir_all(codex_home).await;
+    }
+
+    #[tokio::test]
+    async fn start_with_config_uses_configured_queue_capacity() {
+        let codex_home = temp_codex_home();
+        let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
+            .await
+            .expect("initialize runtime");
+
+        let layer = LogDbLayer::start_with_config(
+            runtime,
+            LogSinkQueueConfig {
+                queue_capacity: 3,
+                batch_size: 2,
+                flush_interval: std::time::Duration::from_secs(60),
+            },
+        );
+
+        assert_eq!(layer.sink.max_capacity(), 3);
+
+        let _ = tokio::fs::remove_dir_all(codex_home).await;
+    }
+
+    #[tokio::test]
+    async fn configured_batch_size_flushes_without_explicit_flush() {
+        let codex_home = temp_codex_home();
+        let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
+            .await
+            .expect("initialize runtime");
+        let layer = LogDbLayer::start_with_config(
+            runtime.clone(),
+            LogSinkQueueConfig {
+                queue_capacity: 8,
+                batch_size: 2,
+                flush_interval: std::time::Duration::from_secs(60),
+            },
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        let guard = tracing_subscriber::registry()
+            .with(
+                layer
+                    .clone()
+                    .with_filter(Targets::new().with_default(tracing::Level::TRACE)),
+            )
+            .set_default();
+
+        tracing::info!("first-batch-log");
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        assert_eq!(
+            runtime
+                .query_logs(&crate::LogQuery::default())
+                .await
+                .expect("query logs before batch fills")
+                .len(),
+            0
+        );
+
+        tracing::info!("second-batch-log");
+        let after_batch = wait_for_log_count(&runtime, 2).await;
+        drop(guard);
+
+        assert_eq!(
+            after_batch
+                .iter()
+                .map(|row| row.message.as_deref())
+                .collect::<Vec<_>>(),
+            vec![Some("first-batch-log"), Some("second-batch-log")]
+        );
+
+        let _ = tokio::fs::remove_dir_all(codex_home).await;
+    }
+
+    #[tokio::test]
+    async fn configured_flush_interval_persists_buffered_logs() {
+        let codex_home = temp_codex_home();
+        let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
+            .await
+            .expect("initialize runtime");
+        let layer = LogDbLayer::start_with_config(
+            runtime.clone(),
+            LogSinkQueueConfig {
+                queue_capacity: 8,
+                batch_size: 128,
+                flush_interval: std::time::Duration::from_millis(10),
+            },
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        let guard = tracing_subscriber::registry()
+            .with(
+                layer
+                    .clone()
+                    .with_filter(Targets::new().with_default(tracing::Level::TRACE)),
+            )
+            .set_default();
+
+        tracing::info!("interval-log");
+        let after_interval = wait_for_log_count(&runtime, 1).await;
+        drop(guard);
+
+        assert_eq!(after_interval[0].message.as_deref(), Some("interval-log"));
+
+        let _ = tokio::fs::remove_dir_all(codex_home).await;
+    }
+
+    #[tokio::test]
+    async fn event_queue_drops_new_entries_when_full() {
+        let (sender, mut receiver) = mpsc::channel(1);
+        let sink = BufferedLogSink::<TestWriter> {
+            sender,
+            _writer: std::marker::PhantomData,
+        };
+
+        sink.try_send(test_entry("first-queued-log"));
+        sink.try_send(test_entry("dropped-log"));
+
+        match receiver.try_recv().expect("first entry queued") {
+            LogSinkCommand::Entry(entry) => {
+                assert_eq!(*entry, test_entry("first-queued-log"));
+            }
+            LogSinkCommand::Flush(_) => panic!("expected queued entry"),
+        }
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn flush_waits_for_queue_capacity_and_receiver_processing() {
+        let writer = TestWriter::default();
+        let batches = Arc::clone(&writer.batches);
+        let sink = BufferedLogSink::start(
+            writer,
+            LogSinkQueueConfig {
+                queue_capacity: 1,
+                batch_size: 8,
+                flush_interval: std::time::Duration::from_secs(60),
+            },
+        );
+
+        sink.try_send(test_entry("queued-before-flush"));
+        let flush_task = tokio::spawn({
+            let sink = sink.clone();
+            async move {
+                sink.flush().await;
+            }
+        });
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), flush_task)
+            .await
+            .expect("flush task completes")
+            .expect("flush task succeeds");
+
+        let batches = batches.lock().expect("test writer mutex poisoned");
+        assert_eq!(
+            batches.as_slice(),
+            &[vec![test_entry("queued-before-flush")]]
+        );
+    }
+
+    #[tokio::test]
+    async fn receiver_close_drains_buffered_entries() {
+        let writer = TestWriter::default();
+        let batches = Arc::clone(&writer.batches);
+        let sink = BufferedLogSink::start(
+            writer,
+            LogSinkQueueConfig {
+                queue_capacity: 8,
+                batch_size: 8,
+                flush_interval: std::time::Duration::from_secs(60),
+            },
+        );
+
+        sink.try_send(test_entry("drained-on-close"));
+        drop(sink);
+
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(1);
+        loop {
+            {
+                let batches = batches.lock().expect("test writer mutex poisoned");
+                if !batches.is_empty() {
+                    assert_eq!(batches.as_slice(), &[vec![test_entry("drained-on-close")]]);
+                    break;
+                }
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "timed out waiting for receiver close drain"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
     }
 }

--- a/codex-rs/state/src/log_db.rs
+++ b/codex-rs/state/src/log_db.rs
@@ -93,7 +93,7 @@ where
 
 #[derive(Clone)]
 pub struct LogDbLayer {
-    sender: mpsc::Sender<LogSinkCommand>,
+    sender: mpsc::Sender<LogDbCommand>,
     process_uuid: String,
 }
 
@@ -112,7 +112,7 @@ impl LogDbLayer {
     ) -> Self {
         let config = config.normalized();
         let (sender, receiver) = mpsc::channel(config.queue_capacity);
-        tokio::spawn(run_log_db_sink(state_db, receiver, config));
+        tokio::spawn(run_inserter(state_db, receiver, config));
         Self {
             sender,
             process_uuid: current_process_log_uuid().to_string(),
@@ -121,13 +121,13 @@ impl LogDbLayer {
 
     pub async fn flush(&self) {
         let (tx, rx) = oneshot::channel();
-        if self.sender.send(LogSinkCommand::Flush(tx)).await.is_ok() {
+        if self.sender.send(LogDbCommand::Flush(tx)).await.is_ok() {
             let _ = rx.await;
         }
     }
 
     fn try_send(&self, entry: LogEntry) {
-        let _ = self.sender.try_send(LogSinkCommand::Entry(Box::new(entry)));
+        let _ = self.sender.try_send(LogDbCommand::Entry(Box::new(entry)));
     }
 
     #[cfg(test)]
@@ -236,14 +236,14 @@ impl LogDbLayer {
     }
 }
 
-enum LogSinkCommand {
+enum LogDbCommand {
     Entry(Box<LogEntry>),
     Flush(oneshot::Sender<()>),
 }
 
-async fn run_log_db_sink(
+async fn run_inserter(
     state_db: std::sync::Arc<StateRuntime>,
-    mut receiver: mpsc::Receiver<LogSinkCommand>,
+    mut receiver: mpsc::Receiver<LogDbCommand>,
     config: LogSinkQueueConfig,
 ) {
     let mut buffer = Vec::with_capacity(config.batch_size);
@@ -252,30 +252,30 @@ async fn run_log_db_sink(
         tokio::select! {
             maybe_command = receiver.recv() => {
                 match maybe_command {
-                    Some(LogSinkCommand::Entry(entry)) => {
+                    Some(LogDbCommand::Entry(entry)) => {
                         buffer.push(*entry);
                         if buffer.len() >= config.batch_size {
-                            flush_batch(&state_db, &mut buffer).await;
+                            insert_batch(&state_db, &mut buffer).await;
                         }
                     }
-                    Some(LogSinkCommand::Flush(reply)) => {
-                        flush_batch(&state_db, &mut buffer).await;
+                    Some(LogDbCommand::Flush(reply)) => {
+                        insert_batch(&state_db, &mut buffer).await;
                         let _ = reply.send(());
                     }
                     None => {
-                        flush_batch(&state_db, &mut buffer).await;
+                        insert_batch(&state_db, &mut buffer).await;
                         break;
                     }
                 }
             }
             _ = ticker.tick() => {
-                flush_batch(&state_db, &mut buffer).await;
+                insert_batch(&state_db, &mut buffer).await;
             }
         }
     }
 }
 
-async fn flush_batch(state_db: &StateRuntime, buffer: &mut Vec<LogEntry>) {
+async fn insert_batch(state_db: &StateRuntime, buffer: &mut Vec<LogEntry>) {
     if buffer.is_empty() {
         return;
     }
@@ -756,52 +756,52 @@ mod tests {
         layer.try_send(test_entry("dropped-log"));
 
         match receiver.try_recv().expect("first entry queued") {
-            LogSinkCommand::Entry(entry) => {
-                assert_eq!(*entry, test_entry("first-queued-log"));
+            LogDbCommand::Entry(entry) => {
+                assert_eq!(entry.message.as_deref(), Some("first-queued-log"));
             }
-            LogSinkCommand::Flush(_) => panic!("expected queued entry"),
+            LogDbCommand::Flush(_) => panic!("expected queued entry"),
         }
         assert!(receiver.try_recv().is_err());
     }
 
     #[tokio::test]
     async fn flush_waits_for_queue_capacity_and_receiver_processing() {
-        let codex_home = temp_codex_home();
-        let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
-            .await
-            .expect("initialize runtime");
-        let layer = LogDbLayer::start_with_config(
-            runtime.clone(),
-            LogSinkQueueConfig {
-                queue_capacity: 1,
-                batch_size: 8,
-                flush_interval: std::time::Duration::from_secs(60),
-            },
-        );
+        let (sender, mut receiver) = mpsc::channel(1);
+        let layer = LogDbLayer {
+            sender,
+            process_uuid: "process-1".to_string(),
+        };
 
         layer.try_send(test_entry("queued-before-flush"));
-        let flush_task = tokio::spawn({
+        let mut flush_task = tokio::spawn({
             let layer = layer.clone();
             async move {
                 layer.flush().await;
             }
         });
 
-        tokio::time::timeout(std::time::Duration::from_secs(1), flush_task)
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        assert!(!flush_task.is_finished());
+
+        match receiver.recv().await.expect("queued entry") {
+            LogDbCommand::Entry(entry) => {
+                assert_eq!(entry.message.as_deref(), Some("queued-before-flush"));
+            }
+            LogDbCommand::Flush(_) => panic!("expected queued entry"),
+        }
+
+        match receiver.recv().await.expect("flush command") {
+            LogDbCommand::Flush(reply) => {
+                assert!(!flush_task.is_finished());
+                let _ = reply.send(());
+            }
+            LogDbCommand::Entry(_) => panic!("expected flush command"),
+        }
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), &mut flush_task)
             .await
             .expect("flush task completes")
             .expect("flush task succeeds");
-
-        let rows = runtime
-            .query_logs(&crate::LogQuery::default())
-            .await
-            .expect("query logs after flush");
-        assert_eq!(
-            rows.into_iter().map(|row| row.message).collect::<Vec<_>>(),
-            vec![Some("queued-before-flush".to_string())]
-        );
-
-        let _ = tokio::fs::remove_dir_all(codex_home).await;
     }
 
     #[tokio::test]

--- a/codex-rs/state/src/log_db.rs
+++ b/codex-rs/state/src/log_db.rs
@@ -736,7 +736,7 @@ mod tests {
         );
 
         tracing::info!("second-batch-log");
-        let after_batch = wait_for_log_count(&runtime, 2).await;
+        let after_batch = wait_for_log_count(&runtime, /*expected*/ 2).await;
         drop(guard);
 
         assert_eq!(
@@ -775,7 +775,7 @@ mod tests {
             .set_default();
 
         tracing::info!("interval-log");
-        let after_interval = wait_for_log_count(&runtime, 1).await;
+        let after_interval = wait_for_log_count(&runtime, /*expected*/ 1).await;
         drop(guard);
 
         assert_eq!(after_interval[0].message.as_deref(), Some("interval-log"));

--- a/codex-rs/state/src/log_db.rs
+++ b/codex-rs/state/src/log_db.rs
@@ -105,7 +105,7 @@ impl BufferedLogSink {
     }
 
     pub fn try_send(&self, entry: LogEntry) {
-        let _ = self.sender.try_send(LogSinkCommand::Entry(entry));
+        let _ = self.sender.try_send(LogSinkCommand::Entry(Box::new(entry)));
     }
 
     pub async fn flush(&self) {
@@ -126,13 +126,8 @@ struct SqliteLogWriter {
 }
 
 impl LogBatchWriter for SqliteLogWriter {
-    fn write_batch<'a>(
-        &'a mut self,
-        entries: Vec<LogEntry>,
-    ) -> impl Future<Output = ()> + Send + 'a {
-        async move {
-            let _ = self.state_db.insert_logs(entries.as_slice()).await;
-        }
+    async fn write_batch(&mut self, entries: Vec<LogEntry>) {
+        let _ = self.state_db.insert_logs(entries.as_slice()).await;
     }
 }
 
@@ -258,7 +253,7 @@ impl LogDbLayer {
 }
 
 enum LogSinkCommand {
-    Entry(LogEntry),
+    Entry(Box<LogEntry>),
     Flush(oneshot::Sender<()>),
 }
 
@@ -276,7 +271,7 @@ async fn run_buffered_sink<W>(
             maybe_command = receiver.recv() => {
                 match maybe_command {
                     Some(LogSinkCommand::Entry(entry)) => {
-                        buffer.push(entry);
+                        buffer.push(*entry);
                         if buffer.len() >= config.batch_size {
                             flush(&mut writer, &mut buffer).await;
                         }
@@ -511,13 +506,8 @@ mod tests {
     }
 
     impl LogBatchWriter for TestWriter {
-        fn write_batch<'a>(
-            &'a mut self,
-            entries: Vec<LogEntry>,
-        ) -> impl Future<Output = ()> + Send + 'a {
-            async move {
-                self.batches().push(entries);
-            }
+        async fn write_batch(&mut self, entries: Vec<LogEntry>) {
+            self.batches().push(entries);
         }
     }
 
@@ -803,7 +793,7 @@ mod tests {
 
         match receiver.try_recv().expect("first entry queued") {
             LogSinkCommand::Entry(entry) => {
-                assert_eq!(entry, test_entry("first-queued-log"));
+                assert_eq!(*entry, test_entry("first-queued-log"));
             }
             LogSinkCommand::Flush(_) => panic!("expected queued entry"),
         }

--- a/codex-rs/state/src/log_db.rs
+++ b/codex-rs/state/src/log_db.rs
@@ -1,10 +1,9 @@
-//! Tracing log export into a bounded buffered sink.
+//! Tracing log export into the local SQLite log database.
 //!
 //! This module provides a `tracing_subscriber::Layer` that captures events,
-//! formats each one into a `LogEntry`, and sends entries to one configured
-//! buffered writer. The default writer inserts into the dedicated `logs` SQLite
-//! database from a background task and batches inserts to keep logging overhead
-//! low.
+//! formats each one into a `LogEntry`, and sends entries to a bounded background
+//! queue. The background task inserts into the dedicated `logs` SQLite database
+//! in batches to keep logging overhead low.
 //!
 //! ## Usage
 //!
@@ -80,60 +79,21 @@ impl LogSinkQueueConfig {
     }
 }
 
-/// Destination-specific writer for batches produced by `BufferedLogSink`.
-pub trait LogBatchWriter: Send + 'static {
-    fn write_batch<'a>(
-        &'a mut self,
-        entries: Vec<LogEntry>,
-    ) -> impl Future<Output = ()> + Send + 'a;
-}
-
-#[derive(Clone)]
-pub struct BufferedLogSink {
-    sender: mpsc::Sender<LogSinkCommand>,
-}
-
-impl BufferedLogSink {
-    pub fn start<W>(writer: W, config: LogSinkQueueConfig) -> Self
-    where
-        W: LogBatchWriter,
-    {
-        let config = config.normalized();
-        let (sender, receiver) = mpsc::channel(config.queue_capacity);
-        tokio::spawn(run_buffered_sink(writer, receiver, config));
-        Self { sender }
-    }
-
-    pub fn try_send(&self, entry: LogEntry) {
-        let _ = self.sender.try_send(LogSinkCommand::Entry(Box::new(entry)));
-    }
-
-    pub async fn flush(&self) {
-        let (tx, rx) = oneshot::channel();
-        if self.sender.send(LogSinkCommand::Flush(tx)).await.is_ok() {
-            let _ = rx.await;
-        }
-    }
-
-    #[cfg(test)]
-    fn max_capacity(&self) -> usize {
-        self.sender.max_capacity()
-    }
-}
-
-struct SqliteLogWriter {
-    state_db: std::sync::Arc<StateRuntime>,
-}
-
-impl LogBatchWriter for SqliteLogWriter {
-    async fn write_batch(&mut self, entries: Vec<LogEntry>) {
-        let _ = self.state_db.insert_logs(entries.as_slice()).await;
-    }
+/// A tracing log writer that can flush entries accepted by its queue.
+///
+/// Implementations should keep `Layer::on_event` non-blocking for ordinary log
+/// events. `flush` should wait for entries accepted before the flush command to
+/// be processed by the writer.
+pub trait LogWriter<S>: Layer<S>
+where
+    S: tracing::Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn flush(&self) -> impl Future<Output = ()> + Send + '_;
 }
 
 #[derive(Clone)]
 pub struct LogDbLayer {
-    sink: BufferedLogSink,
+    sender: mpsc::Sender<LogSinkCommand>,
     process_uuid: String,
 }
 
@@ -150,14 +110,29 @@ impl LogDbLayer {
         state_db: std::sync::Arc<StateRuntime>,
         config: LogSinkQueueConfig,
     ) -> Self {
+        let config = config.normalized();
+        let (sender, receiver) = mpsc::channel(config.queue_capacity);
+        tokio::spawn(run_log_db_sink(state_db, receiver, config));
         Self {
-            sink: BufferedLogSink::start(SqliteLogWriter { state_db }, config),
+            sender,
             process_uuid: current_process_log_uuid().to_string(),
         }
     }
 
     pub async fn flush(&self) {
-        self.sink.flush().await;
+        let (tx, rx) = oneshot::channel();
+        if self.sender.send(LogSinkCommand::Flush(tx)).await.is_ok() {
+            let _ = rx.await;
+        }
+    }
+
+    fn try_send(&self, entry: LogEntry) {
+        let _ = self.sender.try_send(LogSinkCommand::Entry(Box::new(entry)));
+    }
+
+    #[cfg(test)]
+    fn max_capacity(&self) -> usize {
+        self.sender.max_capacity()
     }
 }
 
@@ -211,7 +186,16 @@ where
 
     fn on_event(&self, event: &Event<'_>, ctx: tracing_subscriber::layer::Context<'_, S>) {
         let entry = self.format_event(event, ctx);
-        self.sink.try_send(entry);
+        self.try_send(entry);
+    }
+}
+
+impl<S> LogWriter<S> for LogDbLayer
+where
+    S: tracing::Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn flush(&self) -> impl Future<Output = ()> + Send + '_ {
+        LogDbLayer::flush(self)
     }
 }
 
@@ -257,13 +241,11 @@ enum LogSinkCommand {
     Flush(oneshot::Sender<()>),
 }
 
-async fn run_buffered_sink<W>(
-    mut writer: W,
+async fn run_log_db_sink(
+    state_db: std::sync::Arc<StateRuntime>,
     mut receiver: mpsc::Receiver<LogSinkCommand>,
     config: LogSinkQueueConfig,
-) where
-    W: LogBatchWriter,
-{
+) {
     let mut buffer = Vec::with_capacity(config.batch_size);
     let mut ticker = tokio::time::interval(config.flush_interval);
     loop {
@@ -273,35 +255,32 @@ async fn run_buffered_sink<W>(
                     Some(LogSinkCommand::Entry(entry)) => {
                         buffer.push(*entry);
                         if buffer.len() >= config.batch_size {
-                            flush(&mut writer, &mut buffer).await;
+                            flush_batch(&state_db, &mut buffer).await;
                         }
                     }
                     Some(LogSinkCommand::Flush(reply)) => {
-                        flush(&mut writer, &mut buffer).await;
+                        flush_batch(&state_db, &mut buffer).await;
                         let _ = reply.send(());
                     }
                     None => {
-                        flush(&mut writer, &mut buffer).await;
+                        flush_batch(&state_db, &mut buffer).await;
                         break;
                     }
                 }
             }
             _ = ticker.tick() => {
-                flush(&mut writer, &mut buffer).await;
+                flush_batch(&state_db, &mut buffer).await;
             }
         }
     }
 }
 
-async fn flush<W>(writer: &mut W, buffer: &mut Vec<LogEntry>)
-where
-    W: LogBatchWriter,
-{
+async fn flush_batch(state_db: &StateRuntime, buffer: &mut Vec<LogEntry>) {
     if buffer.is_empty() {
         return;
     }
     let entries = buffer.split_off(0);
-    writer.write_batch(entries).await;
+    let _ = state_db.insert_logs(entries.as_slice()).await;
 }
 
 fn current_process_log_uuid() -> &'static str {
@@ -484,7 +463,6 @@ mod tests {
     use std::io;
     use std::sync::Arc;
     use std::sync::Mutex;
-    use std::sync::MutexGuard;
 
     use pretty_assertions::assert_eq;
     use tracing_subscriber::filter::Targets;
@@ -493,23 +471,6 @@ mod tests {
     use tracing_subscriber::util::SubscriberInitExt;
 
     use super::*;
-
-    #[derive(Default)]
-    struct TestWriter {
-        batches: Arc<Mutex<Vec<Vec<LogEntry>>>>,
-    }
-
-    impl TestWriter {
-        fn batches(&self) -> MutexGuard<'_, Vec<Vec<LogEntry>>> {
-            self.batches.lock().expect("test writer mutex poisoned")
-        }
-    }
-
-    impl LogBatchWriter for TestWriter {
-        async fn write_batch(&mut self, entries: Vec<LogEntry>) {
-            self.batches().push(entries);
-        }
-    }
 
     fn temp_codex_home() -> std::path::PathBuf {
         std::env::temp_dir().join(format!("codex-state-log-db-{}", Uuid::new_v4()))
@@ -695,7 +656,7 @@ mod tests {
             },
         );
 
-        assert_eq!(layer.sink.max_capacity(), 3);
+        assert_eq!(layer.max_capacity(), 3);
 
         let _ = tokio::fs::remove_dir_all(codex_home).await;
     }
@@ -786,10 +747,13 @@ mod tests {
     #[tokio::test]
     async fn event_queue_drops_new_entries_when_full() {
         let (sender, mut receiver) = mpsc::channel(1);
-        let sink = BufferedLogSink { sender };
+        let layer = LogDbLayer {
+            sender,
+            process_uuid: "process-1".to_string(),
+        };
 
-        sink.try_send(test_entry("first-queued-log"));
-        sink.try_send(test_entry("dropped-log"));
+        layer.try_send(test_entry("first-queued-log"));
+        layer.try_send(test_entry("dropped-log"));
 
         match receiver.try_recv().expect("first entry queued") {
             LogSinkCommand::Entry(entry) => {
@@ -802,10 +766,12 @@ mod tests {
 
     #[tokio::test]
     async fn flush_waits_for_queue_capacity_and_receiver_processing() {
-        let writer = TestWriter::default();
-        let batches = Arc::clone(&writer.batches);
-        let sink = BufferedLogSink::start(
-            writer,
+        let codex_home = temp_codex_home();
+        let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
+            .await
+            .expect("initialize runtime");
+        let layer = LogDbLayer::start_with_config(
+            runtime.clone(),
             LogSinkQueueConfig {
                 queue_capacity: 1,
                 batch_size: 8,
@@ -813,11 +779,11 @@ mod tests {
             },
         );
 
-        sink.try_send(test_entry("queued-before-flush"));
+        layer.try_send(test_entry("queued-before-flush"));
         let flush_task = tokio::spawn({
-            let sink = sink.clone();
+            let layer = layer.clone();
             async move {
-                sink.flush().await;
+                layer.flush().await;
             }
         });
 
@@ -826,19 +792,26 @@ mod tests {
             .expect("flush task completes")
             .expect("flush task succeeds");
 
-        let batches = batches.lock().expect("test writer mutex poisoned");
+        let rows = runtime
+            .query_logs(&crate::LogQuery::default())
+            .await
+            .expect("query logs after flush");
         assert_eq!(
-            batches.as_slice(),
-            &[vec![test_entry("queued-before-flush")]]
+            rows.into_iter().map(|row| row.message).collect::<Vec<_>>(),
+            vec![Some("queued-before-flush".to_string())]
         );
+
+        let _ = tokio::fs::remove_dir_all(codex_home).await;
     }
 
     #[tokio::test]
     async fn receiver_close_drains_buffered_entries() {
-        let writer = TestWriter::default();
-        let batches = Arc::clone(&writer.batches);
-        let sink = BufferedLogSink::start(
-            writer,
+        let codex_home = temp_codex_home();
+        let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
+            .await
+            .expect("initialize runtime");
+        let layer = LogDbLayer::start_with_config(
+            runtime.clone(),
             LogSinkQueueConfig {
                 queue_capacity: 8,
                 batch_size: 8,
@@ -846,17 +819,18 @@ mod tests {
             },
         );
 
-        sink.try_send(test_entry("drained-on-close"));
-        drop(sink);
+        layer.try_send(test_entry("drained-on-close"));
+        drop(layer);
 
         let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(1);
         loop {
-            {
-                let batches = batches.lock().expect("test writer mutex poisoned");
-                if !batches.is_empty() {
-                    assert_eq!(batches.as_slice(), &[vec![test_entry("drained-on-close")]]);
-                    break;
-                }
+            let rows = runtime
+                .query_logs(&crate::LogQuery::default())
+                .await
+                .expect("query logs after receiver close");
+            if !rows.is_empty() {
+                assert_eq!(rows[0].message.as_deref(), Some("drained-on-close"));
+                break;
             }
             assert!(
                 tokio::time::Instant::now() < deadline,
@@ -864,5 +838,7 @@ mod tests {
             );
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         }
+
+        let _ = tokio::fs::remove_dir_all(codex_home).await;
     }
 }

--- a/codex-rs/state/src/log_db.rs
+++ b/codex-rs/state/src/log_db.rs
@@ -105,7 +105,7 @@ impl BufferedLogSink {
     }
 
     pub fn try_send(&self, entry: LogEntry) {
-        let _ = self.sender.try_send(LogSinkCommand::Entry(Box::new(entry)));
+        let _ = self.sender.try_send(LogSinkCommand::Entry(entry));
     }
 
     pub async fn flush(&self) {
@@ -121,14 +121,8 @@ impl BufferedLogSink {
     }
 }
 
-pub struct SqliteLogWriter {
+struct SqliteLogWriter {
     state_db: std::sync::Arc<StateRuntime>,
-}
-
-impl SqliteLogWriter {
-    fn new(state_db: std::sync::Arc<StateRuntime>) -> Self {
-        Self { state_db }
-    }
 }
 
 impl LogBatchWriter for SqliteLogWriter {
@@ -142,6 +136,7 @@ impl LogBatchWriter for SqliteLogWriter {
     }
 }
 
+#[derive(Clone)]
 pub struct LogDbLayer {
     sink: BufferedLogSink,
     process_uuid: String,
@@ -149,15 +144,6 @@ pub struct LogDbLayer {
 
 pub fn start(state_db: std::sync::Arc<StateRuntime>) -> LogDbLayer {
     LogDbLayer::start(state_db)
-}
-
-impl Clone for LogDbLayer {
-    fn clone(&self) -> Self {
-        Self {
-            sink: self.sink.clone(),
-            process_uuid: self.process_uuid.clone(),
-        }
-    }
 }
 
 impl LogDbLayer {
@@ -170,7 +156,7 @@ impl LogDbLayer {
         config: LogSinkQueueConfig,
     ) -> Self {
         Self {
-            sink: BufferedLogSink::start(SqliteLogWriter::new(state_db), config),
+            sink: BufferedLogSink::start(SqliteLogWriter { state_db }, config),
             process_uuid: current_process_log_uuid().to_string(),
         }
     }
@@ -272,7 +258,7 @@ impl LogDbLayer {
 }
 
 enum LogSinkCommand {
-    Entry(Box<LogEntry>),
+    Entry(LogEntry),
     Flush(oneshot::Sender<()>),
 }
 
@@ -290,7 +276,7 @@ async fn run_buffered_sink<W>(
             maybe_command = receiver.recv() => {
                 match maybe_command {
                     Some(LogSinkCommand::Entry(entry)) => {
-                        buffer.push(*entry);
+                        buffer.push(entry);
                         if buffer.len() >= config.batch_size {
                             flush(&mut writer, &mut buffer).await;
                         }
@@ -817,7 +803,7 @@ mod tests {
 
         match receiver.try_recv().expect("first entry queued") {
             LogSinkCommand::Entry(entry) => {
-                assert_eq!(*entry, test_entry("first-queued-log"));
+                assert_eq!(entry, test_entry("first-queued-log"));
             }
             LogSinkCommand::Flush(_) => panic!("expected queued entry"),
         }

--- a/codex-rs/state/src/log_db.rs
+++ b/codex-rs/state/src/log_db.rs
@@ -88,32 +88,20 @@ pub trait LogBatchWriter: Send + 'static {
     ) -> impl Future<Output = ()> + Send + 'a;
 }
 
-pub struct BufferedLogSink<W> {
+#[derive(Clone)]
+pub struct BufferedLogSink {
     sender: mpsc::Sender<LogSinkCommand>,
-    _writer: std::marker::PhantomData<fn() -> W>,
 }
 
-impl<W> Clone for BufferedLogSink<W> {
-    fn clone(&self) -> Self {
-        Self {
-            sender: self.sender.clone(),
-            _writer: std::marker::PhantomData,
-        }
-    }
-}
-
-impl<W> BufferedLogSink<W>
-where
-    W: LogBatchWriter,
-{
-    pub fn start(writer: W, config: LogSinkQueueConfig) -> Self {
+impl BufferedLogSink {
+    pub fn start<W>(writer: W, config: LogSinkQueueConfig) -> Self
+    where
+        W: LogBatchWriter,
+    {
         let config = config.normalized();
         let (sender, receiver) = mpsc::channel(config.queue_capacity);
         tokio::spawn(run_buffered_sink(writer, receiver, config));
-        Self {
-            sender,
-            _writer: std::marker::PhantomData,
-        }
+        Self { sender }
     }
 
     pub fn try_send(&self, entry: LogEntry) {
@@ -155,7 +143,7 @@ impl LogBatchWriter for SqliteLogWriter {
 }
 
 pub struct LogDbLayer {
-    sink: BufferedLogSink<SqliteLogWriter>,
+    sink: BufferedLogSink,
     process_uuid: String,
 }
 
@@ -822,10 +810,7 @@ mod tests {
     #[tokio::test]
     async fn event_queue_drops_new_entries_when_full() {
         let (sender, mut receiver) = mpsc::channel(1);
-        let sink = BufferedLogSink::<TestWriter> {
-            sender,
-            _writer: std::marker::PhantomData,
-        };
+        let sink = BufferedLogSink { sender };
 
         sink.try_send(test_entry("first-queued-log"));
         sink.try_send(test_entry("dropped-log"));

--- a/codex-rs/state/src/log_db.rs
+++ b/codex-rs/state/src/log_db.rs
@@ -21,7 +21,6 @@
 //! ```
 
 use std::future::Future;
-use std::pin::Pin;
 use std::sync::OnceLock;
 use std::time::Duration;
 use std::time::SystemTime;
@@ -86,7 +85,7 @@ pub trait LogBatchWriter: Send + 'static {
     fn write_batch<'a>(
         &'a mut self,
         entries: Vec<LogEntry>,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
+    ) -> impl Future<Output = ()> + Send + 'a;
 }
 
 pub struct BufferedLogSink<W> {
@@ -148,10 +147,10 @@ impl LogBatchWriter for SqliteLogWriter {
     fn write_batch<'a>(
         &'a mut self,
         entries: Vec<LogEntry>,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
-        Box::pin(async move {
+    ) -> impl Future<Output = ()> + Send + 'a {
+        async move {
             let _ = self.state_db.insert_logs(entries.as_slice()).await;
-        })
+        }
     }
 }
 
@@ -541,10 +540,10 @@ mod tests {
         fn write_batch<'a>(
             &'a mut self,
             entries: Vec<LogEntry>,
-        ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
-            Box::pin(async move {
+        ) -> impl Future<Output = ()> + Send + 'a {
+            async move {
                 self.batches().push(entries);
-            })
+            }
         }
     }
 

--- a/codex-rs/state/src/model/log.rs
+++ b/codex-rs/state/src/model/log.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 use sqlx::FromRow;
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct LogEntry {
     pub ts: i64,
     pub ts_nanos: i64,

--- a/codex-rs/state/src/model/log.rs
+++ b/codex-rs/state/src/model/log.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 use sqlx::FromRow;
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct LogEntry {
     pub ts: i64,
     pub ts_nanos: i64,


### PR DESCRIPTION
## Why

This prepares feedback log capture for a future remote app-server hook sink without changing the current local SQLite upload path. The important boundary is now intentionally small: a log sink is a tracing `Layer` that can also flush entries it has accepted.

That keeps the existing SQLite implementation simple while giving the upcoming gRPC sink a place to fit beside it. SQLite and gRPC have different worker/write semantics, so this PR avoids introducing a shared buffered-sink abstraction and instead lets each `LogWriter` own the buffering mechanics it needs.

## What Changed

- Added `LogSinkQueueConfig` with the existing local defaults: queue capacity `512`, batch size `128`, and flush interval `2s`.
- Added `LogDbLayer::start_with_config(...)` while preserving `LogDbLayer::start(...)` and `log_db::start(...)` defaults.
- Introduced the `LogWriter` trait as the minimal shared interface: `tracing_subscriber::Layer` plus `flush()`.
- Made `LogDbLayer` implement `LogWriter`.
- Kept tracing event formatting inside `LogDbLayer`; it still creates one `LogEntry` per tracing event before queueing it for SQLite.
- Kept normal event capture best-effort and non-blocking via bounded `try_send`.

## Behavior Notes

This does not change the SQLite schema, retention behavior, `/feedback/upload`, or Sentry upload behavior. Normal log events still drop when the queue is full; explicit `flush()` still waits for queue capacity and receiver processing before returning.

## Verification

- `cargo test -p codex-state log_db`
- `cargo test -p codex-state`
- `just fix -p codex-state`

The added tests cover configured batch-size flushing, configured interval flushing, queue-full drops, and the flush barrier semantics.
