### PR TITLE
fix alpha build

### DIFF
--- a/.github/actions/macos-code-sign/codex.entitlements.plist
+++ b/.github/actions/macos-code-sign/codex.entitlements.plist
@@ -2,15 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.application-identifier</key>
-	<string>2DC432GLL2.com.openai.codex</string>
-	<key>com.apple.developer.team-identifier</key>
-	<string>2DC432GLL2</string>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
-	<key>keychain-access-groups</key>
-	<array>
-		<string>2DC432GLL2.com.openai.codex</string>
-	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Revert of this: https://github.com/openai/codex/pull/19167 as it was causing Codex to get auto-killed on MacOS at startup