### PR TITLE
Fix: use function apply_patch tool for Bedrock model

### DIFF
--- a/codex-rs/model-provider/src/amazon_bedrock/catalog.rs
+++ b/codex-rs/model-provider/src/amazon_bedrock/catalog.rs
@@ -1,6 +1,7 @@
 use codex_models_manager::bundled_models_response;
 use codex_models_manager::model_info::model_info_from_slug;
 use codex_protocol::config_types::ReasoningSummary;
+use codex_protocol::openai_models::ApplyPatchToolType;
 use codex_protocol::openai_models::ConfigShellToolType;
 use codex_protocol::openai_models::InputModality;
 use codex_protocol::openai_models::ModelInfo;
@@ -38,6 +39,7 @@ fn gpt_5_4_cmb_bedrock_model(priority: i32) -> ModelInfo {
 
     model.slug = GPT_5_4_CMB_MODEL_ID.to_string();
     model.priority = priority;
+    model.apply_patch_tool_type = Some(ApplyPatchToolType::Function);
     model
 }
 
@@ -137,6 +139,7 @@ mod tests {
 
         gpt_5_4_model.slug = GPT_5_4_CMB_MODEL_ID.to_string();
         gpt_5_4_model.priority = cmb_model.priority;
+        gpt_5_4_model.apply_patch_tool_type = Some(ApplyPatchToolType::Function);
 
         assert_eq!(*cmb_model, gpt_5_4_model);
     }


### PR DESCRIPTION
## Why

`openai.gpt-5.4-cmb` is served through the Amazon Bedrock provider, whose request validator currently accepts `function` and `mcp` tool specs but rejects Responses `custom` tools. The CMB catalog entry reuses the bundled `gpt-5.4` metadata, which marks `apply_patch_tool_type` as `freeform`. That causes Codex to include an `apply_patch` tool with `type: "custom"`, so even heavily disabled sessions can fail before the model runs with:

```text
Invalid tools: unknown variant `custom`, expected `function` or `mcp`
```

This is provider-specific: the model should still expose `apply_patch`, but for Bedrock it needs to use the JSON/function tool shape instead of the freeform/custom shape.

## What Changed

- Override the `openai.gpt-5.4-cmb` static catalog entry to set `apply_patch_tool_type` to `function` after inheriting the rest of the `gpt-5.4` model metadata.
- Update the catalog test expectation so the CMB entry continues to track `gpt-5.4` metadata except for this Bedrock-specific tool shape override.

## Verification

- `cargo test -p codex-model-provider`
- `just fix -p codex-model-provider`
