### PR TITLE
Add gpt-image-2 to bundled OpenAI Docs skill

### DIFF
--- a/codex-rs/skills/src/assets/samples/openai-docs/references/latest-model.md
+++ b/codex-rs/skills/src/assets/samples/openai-docs/references/latest-model.md
@@ -16,7 +16,8 @@ This file is a curated helper. Every recommendation here must be verified agains
 | `gpt-4.1-nano` | Fastest and cheapest no-reasoning text |
 | `gpt-5.3-codex` | Agentic coding, code editing, and tool-heavy coding workflows |
 | `gpt-5.1-codex-mini` | Cheaper coding workflows |
-| `gpt-image-1.5` | Best image generation and edit quality |
+| `gpt-image-2` | Best image generation and edit quality |
+| `gpt-image-1.5` | Less expensive image generation and edit quality |
 | `gpt-image-1-mini` | Cost-optimized image generation |
 | `gpt-4o-mini-tts` | Text-to-speech |
 | `gpt-4o-mini-transcribe` | Speech-to-text, fast and cost-efficient |


### PR DESCRIPTION
## Summary
- Mirrors openai/skills#374 in the Codex bundled OpenAI Docs skill
- Adds `gpt-image-2` as the best image generation/edit model
- Updates `gpt-image-1.5` to less expensive image generation/edit quality

## Test plan
- `git diff --check`