### PR TITLE
ci: publish codex-app-server release artifacts

### DIFF
--- a/.github/actions/linux-code-sign/action.yml
+++ b/.github/actions/linux-code-sign/action.yml
@@ -7,6 +7,9 @@ inputs:
   artifacts-dir:
     description: Absolute path to the directory containing built binaries to sign.
     required: true
+  binaries:
+    description: Space-delimited binary basenames to sign.
+    default: "codex codex-responses-api-proxy"
 
 runs:
   using: composite
@@ -18,6 +21,7 @@ runs:
       shell: bash
       env:
         ARTIFACTS_DIR: ${{ inputs.artifacts-dir }}
+        BINARIES: ${{ inputs.binaries }}
         COSIGN_EXPERIMENTAL: "1"
         COSIGN_YES: "true"
         COSIGN_OIDC_CLIENT_ID: "sigstore"
@@ -31,7 +35,7 @@ runs:
           exit 1
         fi
 
-        for binary in codex codex-responses-api-proxy; do
+        for binary in ${BINARIES}; do
           artifact="${dest}/${binary}"
           if [[ ! -f "$artifact" ]]; then
             echo "Binary $artifact not found"

--- a/.github/actions/macos-code-sign/action.yml
+++ b/.github/actions/macos-code-sign/action.yml
@@ -4,6 +4,9 @@ inputs:
   target:
     description: Rust compilation target triple (e.g. aarch64-apple-darwin).
     required: true
+  binaries:
+    description: Space-delimited binary basenames to sign and notarize.
+    default: "codex codex-responses-api-proxy"
   sign-binaries:
     description: Whether to sign and notarize the macOS binaries.
     required: false
@@ -119,6 +122,7 @@ runs:
       shell: bash
       env:
         TARGET: ${{ inputs.target }}
+        BINARIES: ${{ inputs.binaries }}
       run: |
         set -euo pipefail
 
@@ -134,7 +138,7 @@ runs:
 
         entitlements_path="$GITHUB_ACTION_PATH/codex.entitlements.plist"
 
-        for binary in codex codex-responses-api-proxy; do
+        for binary in ${BINARIES}; do
           path="codex-rs/target/${TARGET}/release/${binary}"
           codesign --force --options runtime --timestamp --entitlements "$entitlements_path" --sign "$APPLE_CODESIGN_IDENTITY" "${keychain_args[@]}" "$path"
         done
@@ -144,6 +148,7 @@ runs:
       shell: bash
       env:
         TARGET: ${{ inputs.target }}
+        BINARIES: ${{ inputs.binaries }}
         APPLE_NOTARIZATION_KEY_P8: ${{ inputs.apple-notarization-key-p8 }}
         APPLE_NOTARIZATION_KEY_ID: ${{ inputs.apple-notarization-key-id }}
         APPLE_NOTARIZATION_ISSUER_ID: ${{ inputs.apple-notarization-issuer-id }}
@@ -182,8 +187,9 @@ runs:
           notarize_submission "$binary" "$archive_path" "$notary_key_path"
         }
 
-        notarize_binary "codex"
-        notarize_binary "codex-responses-api-proxy"
+        for binary in ${BINARIES}; do
+          notarize_binary "${binary}"
+        done
 
     - name: Sign and notarize macOS dmg
       if: ${{ inputs.sign-dmg == 'true' }}

--- a/.github/actions/windows-code-sign/action.yml
+++ b/.github/actions/windows-code-sign/action.yml
@@ -4,6 +4,9 @@ inputs:
   target:
     description: Target triple for the artifacts to sign.
     required: true
+  binaries:
+    description: Space-delimited binary basenames to sign.
+    default: "codex codex-responses-api-proxy codex-windows-sandbox-setup codex-command-runner"
   client-id:
     description: Azure Trusted Signing client ID.
     required: true
@@ -33,6 +36,23 @@ runs:
         tenant-id: ${{ inputs.tenant-id }}
         subscription-id: ${{ inputs.subscription-id }}
 
+    - name: Prepare file list
+      id: prepare
+      shell: bash
+      env:
+        TARGET: ${{ inputs.target }}
+        BINARIES: ${{ inputs.binaries }}
+      run: |
+        set -euo pipefail
+
+        {
+          echo "files<<EOF"
+          for binary in ${BINARIES}; do
+            echo "${GITHUB_WORKSPACE}/codex-rs/target/${TARGET}/release/${binary}.exe"
+          done
+          echo "EOF"
+        } >> "$GITHUB_OUTPUT"
+
     - name: Sign Windows binaries with Azure Trusted Signing
       uses: azure/trusted-signing-action@1d365fec12862c4aa68fcac418143d73f0cea293 # v0
       with:
@@ -50,8 +70,4 @@ runs:
         exclude-azure-developer-cli-credential: true
         exclude-interactive-browser-credential: true
         cache-dependencies: false
-        files: |
-          ${{ github.workspace }}/codex-rs/target/${{ inputs.target }}/release/codex.exe
-          ${{ github.workspace }}/codex-rs/target/${{ inputs.target }}/release/codex-responses-api-proxy.exe
-          ${{ github.workspace }}/codex-rs/target/${{ inputs.target }}/release/codex-windows-sandbox-setup.exe
-          ${{ github.workspace }}/codex-rs/target/${{ inputs.target }}/release/codex-command-runner.exe
+        files: ${{ steps.prepare.outputs.files }}

--- a/.github/dotslash-config.json
+++ b/.github/dotslash-config.json
@@ -28,6 +28,34 @@
         }
       }
     },
+    "codex-app-server": {
+      "platforms": {
+        "macos-aarch64": {
+          "regex": "^codex-app-server-aarch64-apple-darwin\\.zst$",
+          "path": "codex-app-server"
+        },
+        "macos-x86_64": {
+          "regex": "^codex-app-server-x86_64-apple-darwin\\.zst$",
+          "path": "codex-app-server"
+        },
+        "linux-x86_64": {
+          "regex": "^codex-app-server-x86_64-unknown-linux-musl\\.zst$",
+          "path": "codex-app-server"
+        },
+        "linux-aarch64": {
+          "regex": "^codex-app-server-aarch64-unknown-linux-musl\\.zst$",
+          "path": "codex-app-server"
+        },
+        "windows-x86_64": {
+          "regex": "^codex-app-server-x86_64-pc-windows-msvc\\.exe\\.zst$",
+          "path": "codex-app-server.exe"
+        },
+        "windows-aarch64": {
+          "regex": "^codex-app-server-aarch64-pc-windows-msvc\\.exe\\.zst$",
+          "path": "codex-app-server.exe"
+        }
+      }
+    },
     "codex-responses-api-proxy": {
       "platforms": {
         "macos-aarch64": {

--- a/.github/workflows/rust-release-windows.yml
+++ b/.github/workflows/rust-release-windows.yml
@@ -40,28 +40,42 @@ jobs:
           - runner: windows-x64
             target: x86_64-pc-windows-msvc
             bundle: primary
-            build_args: --bin codex --bin codex-responses-api-proxy
+            binaries: "codex codex-responses-api-proxy"
             runs_on:
               group: codex-runners
               labels: codex-windows-x64
           - runner: windows-arm64
             target: aarch64-pc-windows-msvc
             bundle: primary
-            build_args: --bin codex --bin codex-responses-api-proxy
+            binaries: "codex codex-responses-api-proxy"
             runs_on:
               group: codex-runners
               labels: codex-windows-arm64
           - runner: windows-x64
             target: x86_64-pc-windows-msvc
             bundle: helpers
-            build_args: --bin codex-windows-sandbox-setup --bin codex-command-runner
+            binaries: "codex-windows-sandbox-setup codex-command-runner"
             runs_on:
               group: codex-runners
               labels: codex-windows-x64
           - runner: windows-arm64
             target: aarch64-pc-windows-msvc
             bundle: helpers
-            build_args: --bin codex-windows-sandbox-setup --bin codex-command-runner
+            binaries: "codex-windows-sandbox-setup codex-command-runner"
+            runs_on:
+              group: codex-runners
+              labels: codex-windows-arm64
+          - runner: windows-x64
+            target: x86_64-pc-windows-msvc
+            bundle: app-server
+            binaries: "codex-app-server"
+            runs_on:
+              group: codex-runners
+              labels: codex-windows-x64
+          - runner: windows-arm64
+            target: aarch64-pc-windows-msvc
+            bundle: app-server
+            binaries: "codex-app-server"
             runs_on:
               group: codex-runners
               labels: codex-windows-arm64
@@ -89,7 +103,11 @@ jobs:
       - name: Cargo build (Windows binaries)
         shell: bash
         run: |
-          cargo build --target ${{ matrix.target }} --release --timings ${{ matrix.build_args }}
+          build_args=()
+          for binary in ${{ matrix.binaries }}; do
+            build_args+=(--bin "$binary")
+          done
+          cargo build --target ${{ matrix.target }} --release --timings "${build_args[@]}"
 
       - name: Upload Cargo timings
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
@@ -103,13 +121,9 @@ jobs:
         run: |
           output_dir="target/${{ matrix.target }}/release/staged-${{ matrix.bundle }}"
           mkdir -p "$output_dir"
-          if [[ "${{ matrix.bundle }}" == "primary" ]]; then
-            cp target/${{ matrix.target }}/release/codex.exe "$output_dir/codex.exe"
-            cp target/${{ matrix.target }}/release/codex-responses-api-proxy.exe "$output_dir/codex-responses-api-proxy.exe"
-          else
-            cp target/${{ matrix.target }}/release/codex-windows-sandbox-setup.exe "$output_dir/codex-windows-sandbox-setup.exe"
-            cp target/${{ matrix.target }}/release/codex-command-runner.exe "$output_dir/codex-command-runner.exe"
-          fi
+          for binary in ${{ matrix.binaries }}; do
+            cp "target/${{ matrix.target }}/release/${binary}.exe" "$output_dir/${binary}.exe"
+          done
 
       - name: Upload Windows binaries
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
@@ -130,6 +144,8 @@ jobs:
     defaults:
       run:
         working-directory: codex-rs
+    env:
+      WINDOWS_BINARIES: "codex codex-responses-api-proxy codex-windows-sandbox-setup codex-command-runner codex-app-server"
 
     strategy:
       fail-fast: false
@@ -161,19 +177,25 @@ jobs:
           name: windows-binaries-${{ matrix.target }}-helpers
           path: codex-rs/target/${{ matrix.target }}/release
 
+      - name: Download prebuilt Windows app-server binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: windows-binaries-${{ matrix.target }}-app-server
+          path: codex-rs/target/${{ matrix.target }}/release
+
       - name: Verify binaries
         shell: bash
         run: |
           set -euo pipefail
-          ls -lh target/${{ matrix.target }}/release/codex.exe
-          ls -lh target/${{ matrix.target }}/release/codex-responses-api-proxy.exe
-          ls -lh target/${{ matrix.target }}/release/codex-windows-sandbox-setup.exe
-          ls -lh target/${{ matrix.target }}/release/codex-command-runner.exe
+          for binary in ${WINDOWS_BINARIES}; do
+            ls -lh "target/${{ matrix.target }}/release/${binary}.exe"
+          done
 
       - name: Sign Windows binaries with Azure Trusted Signing
         uses: ./.github/actions/windows-code-sign
         with:
           target: ${{ matrix.target }}
+          binaries: ${{ env.WINDOWS_BINARIES }}
           client-id: ${{ secrets.AZURE_TRUSTED_SIGNING_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TRUSTED_SIGNING_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_TRUSTED_SIGNING_SUBSCRIPTION_ID }}
@@ -187,10 +209,10 @@ jobs:
           dest="dist/${{ matrix.target }}"
           mkdir -p "$dest"
 
-          cp target/${{ matrix.target }}/release/codex.exe "$dest/codex-${{ matrix.target }}.exe"
-          cp target/${{ matrix.target }}/release/codex-responses-api-proxy.exe "$dest/codex-responses-api-proxy-${{ matrix.target }}.exe"
-          cp target/${{ matrix.target }}/release/codex-windows-sandbox-setup.exe "$dest/codex-windows-sandbox-setup-${{ matrix.target }}.exe"
-          cp target/${{ matrix.target }}/release/codex-command-runner.exe "$dest/codex-command-runner-${{ matrix.target }}.exe"
+          for binary in ${WINDOWS_BINARIES}; do
+            cp "target/${{ matrix.target }}/release/${binary}.exe" \
+              "$dest/${binary}-${{ matrix.target }}.exe"
+          done
 
       - name: Install DotSlash
         uses: facebook/install-dotslash@1e4e7b3e07eaca387acb98f1d4720e0bee8dbb6a # v2

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -47,7 +47,7 @@ jobs:
 
   build:
     needs: tag-check
-    name: Build - ${{ matrix.runner }} - ${{ matrix.target }}
+    name: Build - ${{ matrix.runner }} - ${{ matrix.target }} - ${{ matrix.bundle }}
     runs-on: ${{ matrix.runs_on || matrix.runner }}
     timeout-minutes: 60
     permissions:
@@ -67,13 +67,53 @@ jobs:
         include:
           - runner: macos-15-xlarge
             target: aarch64-apple-darwin
+            bundle: primary
+            artifact_name: aarch64-apple-darwin
+            binaries: "codex codex-responses-api-proxy"
+            build_dmg: "true"
+          - runner: macos-15-xlarge
+            target: aarch64-apple-darwin
+            bundle: app-server
+            artifact_name: aarch64-apple-darwin-app-server
+            binaries: "codex-app-server"
+            build_dmg: "false"
           - runner: macos-15-xlarge
             target: x86_64-apple-darwin
+            bundle: primary
+            artifact_name: x86_64-apple-darwin
+            binaries: "codex codex-responses-api-proxy"
+            build_dmg: "true"
+          - runner: macos-15-xlarge
+            target: x86_64-apple-darwin
+            bundle: app-server
+            artifact_name: x86_64-apple-darwin-app-server
+            binaries: "codex-app-server"
+            build_dmg: "false"
           # Release artifacts intentionally ship MUSL-linked Linux binaries.
           - runner: ubuntu-24.04
             target: x86_64-unknown-linux-musl
+            bundle: primary
+            artifact_name: x86_64-unknown-linux-musl
+            binaries: "codex codex-responses-api-proxy"
+            build_dmg: "false"
+          - runner: ubuntu-24.04
+            target: x86_64-unknown-linux-musl
+            bundle: app-server
+            artifact_name: x86_64-unknown-linux-musl-app-server
+            binaries: "codex-app-server"
+            build_dmg: "false"
           - runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
+            bundle: primary
+            artifact_name: aarch64-unknown-linux-musl
+            binaries: "codex codex-responses-api-proxy"
+            build_dmg: "false"
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+            bundle: app-server
+            artifact_name: aarch64-unknown-linux-musl-app-server
+            binaries: "codex-app-server"
+            build_dmg: "false"
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -216,13 +256,17 @@ jobs:
       - name: Cargo build
         shell: bash
         run: |
+          build_args=()
+          for binary in ${{ matrix.binaries }}; do
+            build_args+=(--bin "$binary")
+          done
           echo "CARGO_PROFILE_RELEASE_LTO: ${CARGO_PROFILE_RELEASE_LTO}"
-          cargo build --target ${{ matrix.target }} --release --timings --bin codex --bin codex-responses-api-proxy
+          cargo build --target ${{ matrix.target }} --release --timings "${build_args[@]}"
 
       - name: Upload Cargo timings
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
-          name: cargo-timings-rust-release-${{ matrix.target }}
+          name: cargo-timings-rust-release-${{ matrix.target }}-${{ matrix.bundle }}
           path: codex-rs/target/**/cargo-timings/cargo-timing.html
           if-no-files-found: warn
 
@@ -232,12 +276,14 @@ jobs:
         with:
           target: ${{ matrix.target }}
           artifacts-dir: ${{ github.workspace }}/codex-rs/target/${{ matrix.target }}/release
+          binaries: ${{ matrix.binaries }}
 
       - if: ${{ runner.os == 'macOS' }}
         name: MacOS code signing (binaries)
         uses: ./.github/actions/macos-code-sign
         with:
           target: ${{ matrix.target }}
+          binaries: ${{ matrix.binaries }}
           sign-binaries: "true"
           sign-dmg: "false"
           apple-certificate: ${{ secrets.APPLE_CERTIFICATE_P12 }}
@@ -246,7 +292,7 @@ jobs:
           apple-notarization-key-id: ${{ secrets.APPLE_NOTARIZATION_KEY_ID }}
           apple-notarization-issuer-id: ${{ secrets.APPLE_NOTARIZATION_ISSUER_ID }}
 
-      - if: ${{ runner.os == 'macOS' }}
+      - if: ${{ runner.os == 'macOS' && matrix.build_dmg == 'true' }}
         name: Build macOS dmg
         shell: bash
         run: |
@@ -261,23 +307,17 @@ jobs:
           # The previous "MacOS code signing (binaries)" step signs + notarizes the
           # built artifacts in `${release_dir}`. This step packages *those same*
           # signed binaries into a dmg.
-          codex_binary_path="${release_dir}/codex"
-          proxy_binary_path="${release_dir}/codex-responses-api-proxy"
-
           rm -rf "$dmg_root"
           mkdir -p "$dmg_root"
 
-          if [[ ! -f "$codex_binary_path" ]]; then
-            echo "Binary $codex_binary_path not found"
-            exit 1
-          fi
-          if [[ ! -f "$proxy_binary_path" ]]; then
-            echo "Binary $proxy_binary_path not found"
-            exit 1
-          fi
-
-          ditto "$codex_binary_path" "${dmg_root}/codex"
-          ditto "$proxy_binary_path" "${dmg_root}/codex-responses-api-proxy"
+          for binary in ${{ matrix.binaries }}; do
+            binary_path="${release_dir}/${binary}"
+            if [[ ! -f "${binary_path}" ]]; then
+              echo "Binary ${binary_path} not found"
+              exit 1
+            fi
+            ditto "${binary_path}" "${dmg_root}/${binary}"
+          done
 
           rm -f "$dmg_path"
           hdiutil create \
@@ -292,7 +332,7 @@ jobs:
             exit 1
           fi
 
-      - if: ${{ runner.os == 'macOS' }}
+      - if: ${{ runner.os == 'macOS' && matrix.build_dmg == 'true' }}
         name: MacOS code signing (dmg)
         uses: ./.github/actions/macos-code-sign
         with:
@@ -311,15 +351,15 @@ jobs:
           dest="dist/${{ matrix.target }}"
           mkdir -p "$dest"
 
-          cp target/${{ matrix.target }}/release/codex "$dest/codex-${{ matrix.target }}"
-          cp target/${{ matrix.target }}/release/codex-responses-api-proxy "$dest/codex-responses-api-proxy-${{ matrix.target }}"
+          for binary in ${{ matrix.binaries }}; do
+            cp "target/${{ matrix.target }}/release/${binary}" "$dest/${binary}-${{ matrix.target }}"
+            if [[ "${{ matrix.target }}" == *linux* ]]; then
+              cp "target/${{ matrix.target }}/release/${binary}.sigstore" \
+                "$dest/${binary}-${{ matrix.target }}.sigstore"
+            fi
+          done
 
-          if [[ "${{ matrix.target }}" == *linux* ]]; then
-            cp target/${{ matrix.target }}/release/codex.sigstore "$dest/codex-${{ matrix.target }}.sigstore"
-            cp target/${{ matrix.target }}/release/codex-responses-api-proxy.sigstore "$dest/codex-responses-api-proxy-${{ matrix.target }}.sigstore"
-          fi
-
-          if [[ "${{ matrix.target }}" == *apple-darwin ]]; then
+          if [[ "${{ matrix.build_dmg }}" == "true" ]]; then
             cp target/${{ matrix.target }}/release/codex-${{ matrix.target }}.dmg "$dest/codex-${{ matrix.target }}.dmg"
           fi
 
@@ -361,7 +401,7 @@ jobs:
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
-          name: ${{ matrix.target }}
+          name: ${{ matrix.artifact_name }}
           # Upload the per-binary .zst files as well as the new .tar.gz
           # equivalents we generated in the previous step.
           path: |


### PR DESCRIPTION
## Why
The VS Code extension and desktop app do not need the full TUI binary, and `codex-app-server` is materially smaller than standalone `codex`. We still want to publish it as an official release artifact, but building it by tacking another `--bin` onto the existing release `cargo build` invocations would lengthen those jobs.

This change keeps `codex-app-server` on its own release bundle so it can build in parallel with the existing `codex` and helper bundles.

## What changed
- Made `.github/workflows/rust-release.yml` bundle-aware so each macOS and Linux MUSL target now builds either the existing `primary` bundle (`codex` and `codex-responses-api-proxy`) or a standalone `app-server` bundle (`codex-app-server`).
- Preserved the historical artifact names for the primary macOS/Linux bundles so `scripts/stage_npm_packages.py` and `codex-cli/scripts/install_native_deps.py` continue to find release assets under the paths they already expect, while giving the new app-server artifacts distinct names.
- Added a matching `app-server` bundle to `.github/workflows/rust-release-windows.yml`, and updated the final Windows packaging job to download, sign, stage, and archive `codex-app-server.exe` alongside the existing release binaries.
- Generalized the shared signing actions in `.github/actions/linux-code-sign/action.yml`, `.github/actions/macos-code-sign/action.yml`, and `.github/actions/windows-code-sign/action.yml` so each workflow row declares its binaries once and reuses that list for build, signing, and staging.
- Added `codex-app-server` to `.github/dotslash-config.json` so releases also publish a generated DotSlash manifest for the standalone app-server binary.
- Kept the macOS DMG focused on the existing `primary` bundle; `codex-app-server` ships as the regular standalone archives and DotSlash manifest.

## Verification
- Parsed the modified workflow and action YAML files locally with `python3` + `yaml.safe_load(...)`.
- Parsed `.github/dotslash-config.json` locally with `python3` + `json.loads(...)`.
- Reviewed the resulting release matrices, artifact names, and packaging paths to confirm that `codex-app-server` is built separately on macOS, Linux MUSL, and Windows, while the existing npm staging and Windows `codex` zip bundling contracts remain intact.
