### PR TITLE
Serialize legacy Windows PowerShell sandbox tests

### DIFF
--- a/codex-rs/windows-sandbox-rs/src/unified_exec/tests.rs
+++ b/codex-rs/windows-sandbox-rs/src/unified_exec/tests.rs
@@ -7,7 +7,6 @@ use crate::ipc_framed::read_frame;
 use crate::run_windows_sandbox_capture;
 use codex_utils_pty::ProcessDriver;
 use pretty_assertions::assert_eq;
-use serial_test::serial;
 use std::collections::HashMap;
 use std::fs;
 use std::fs::OpenOptions;
@@ -15,6 +14,8 @@ use std::io::Seek;
 use std::io::SeekFrom;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::Mutex;
+use std::sync::MutexGuard;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
@@ -27,6 +28,13 @@ use tokio::sync::oneshot;
 use tokio::time::timeout;
 
 static TEST_HOME_COUNTER: AtomicU64 = AtomicU64::new(0);
+static LEGACY_PROCESS_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+fn legacy_process_test_guard() -> MutexGuard<'static, ()> {
+    LEGACY_PROCESS_TEST_LOCK
+        .lock()
+        .expect("legacy Windows sandbox process test lock poisoned")
+}
 
 fn current_thread_runtime() -> tokio::runtime::Runtime {
     Builder::new_current_thread()
@@ -129,8 +137,8 @@ async fn collect_stdout_and_exit(
 }
 
 #[test]
-#[serial(windows_sandbox_legacy_process)]
 fn legacy_non_tty_cmd_emits_output() {
+    let _guard = legacy_process_test_guard();
     let runtime = current_thread_runtime();
     runtime.block_on(async move {
         let cwd = sandbox_cwd();
@@ -165,11 +173,11 @@ fn legacy_non_tty_cmd_emits_output() {
 }
 
 #[test]
-#[serial(windows_sandbox_legacy_process)]
 fn legacy_non_tty_powershell_emits_output() {
     let Some(pwsh) = pwsh_path() else {
         return;
     };
+    let _guard = legacy_process_test_guard();
     let runtime = current_thread_runtime();
     runtime.block_on(async move {
         let cwd = sandbox_cwd();
@@ -350,11 +358,11 @@ fn runner_resizer_sends_resize_frame() {
 }
 
 #[test]
-#[serial(windows_sandbox_legacy_process)]
 fn legacy_capture_powershell_emits_output() {
     let Some(pwsh) = pwsh_path() else {
         return;
     };
+    let _guard = legacy_process_test_guard();
     let cwd = sandbox_cwd();
     let codex_home = sandbox_home("legacy-capture-pwsh");
     println!("capture pwsh codex_home={}", codex_home.path().display());
@@ -387,11 +395,11 @@ fn legacy_capture_powershell_emits_output() {
 }
 
 #[test]
-#[serial(windows_sandbox_legacy_process)]
 fn legacy_tty_powershell_emits_output_and_accepts_input() {
     let Some(pwsh) = pwsh_path() else {
         return;
     };
+    let _guard = legacy_process_test_guard();
     let runtime = current_thread_runtime();
     runtime.block_on(async move {
         let cwd = sandbox_cwd();

--- a/codex-rs/windows-sandbox-rs/src/unified_exec/tests.rs
+++ b/codex-rs/windows-sandbox-rs/src/unified_exec/tests.rs
@@ -7,6 +7,7 @@ use crate::ipc_framed::read_frame;
 use crate::run_windows_sandbox_capture;
 use codex_utils_pty::ProcessDriver;
 use pretty_assertions::assert_eq;
+use serial_test::serial;
 use std::collections::HashMap;
 use std::fs;
 use std::fs::OpenOptions;
@@ -128,6 +129,7 @@ async fn collect_stdout_and_exit(
 }
 
 #[test]
+#[serial(windows_sandbox_legacy_process)]
 fn legacy_non_tty_cmd_emits_output() {
     let runtime = current_thread_runtime();
     runtime.block_on(async move {
@@ -163,6 +165,7 @@ fn legacy_non_tty_cmd_emits_output() {
 }
 
 #[test]
+#[serial(windows_sandbox_legacy_process)]
 fn legacy_non_tty_powershell_emits_output() {
     let Some(pwsh) = pwsh_path() else {
         return;
@@ -347,6 +350,7 @@ fn runner_resizer_sends_resize_frame() {
 }
 
 #[test]
+#[serial(windows_sandbox_legacy_process)]
 fn legacy_capture_powershell_emits_output() {
     let Some(pwsh) = pwsh_path() else {
         return;
@@ -383,6 +387,7 @@ fn legacy_capture_powershell_emits_output() {
 }
 
 #[test]
+#[serial(windows_sandbox_legacy_process)]
 fn legacy_tty_powershell_emits_output_and_accepts_input() {
     let Some(pwsh) = pwsh_path() else {
         return;


### PR DESCRIPTION
## Why

Recent `main` CI had repeated Windows timeouts in the legacy sandbox process tests:

- `codex-windows-sandbox session::tests::legacy_capture_powershell_emits_output` failed in runs [24909500958](https://github.com/openai/codex/actions/runs/24909500958), [24908076251](https://github.com/openai/codex/actions/runs/24908076251), [24906197645](https://github.com/openai/codex/actions/runs/24906197645), [24905411571](https://github.com/openai/codex/actions/runs/24905411571), [24903336028](https://github.com/openai/codex/actions/runs/24903336028), and [24898949647](https://github.com/openai/codex/actions/runs/24898949647).
- `legacy_tty_powershell_emits_output_and_accepts_input` failed in the same set of runs.
- `legacy_non_tty_cmd_emits_output` failed in runs [24909500958](https://github.com/openai/codex/actions/runs/24909500958), [24908076251](https://github.com/openai/codex/actions/runs/24908076251), [24906197645](https://github.com/openai/codex/actions/runs/24906197645), and [24903336028](https://github.com/openai/codex/actions/runs/24903336028).
- `legacy_non_tty_powershell_emits_output` failed in runs [24908076251](https://github.com/openai/codex/actions/runs/24908076251), [24906197645](https://github.com/openai/codex/actions/runs/24906197645), and [24903336028](https://github.com/openai/codex/actions/runs/24903336028).

These failures were 30s timeouts on Windows x64 and/or arm64 rather than assertion failures.

## Root Cause

The active legacy Windows sandbox process tests all exercise host-level resources: sandbox setup, ACL/user state, private desktop process launch, stdio capture, and PowerShell/cmd child cleanup. Running several of these tests concurrently can leave them competing for the same Windows sandbox setup path and process/session resources, which makes command startup or output collection hang under CI load.

## What Changed

- Added a shared in-process mutex for the active legacy Windows sandbox process tests.
- Held that guard across each legacy cmd/PowerShell process test so those host-resource-heavy cases run one at a time.
- Kept the skipped legacy cmd TTY tests unchanged.

## Why This Should Be Reliable

The tests still use unique homes and run the real legacy sandbox process path, but they no longer overlap the fragile host-level setup and process/session lifecycle. Serializing just this small group removes the concurrency race without reducing the behavioral coverage of each test.

## Verification

- `cargo test -p codex-windows-sandbox`
- GitHub Windows CI is the primary validation signal for the affected tests; on this PR, Windows clippy, Windows release, and Windows local Bazel passed after the serialization fix.
