### PR TITLE
Split approval matrix test groups

### DIFF
--- a/codex-rs/core/tests/suite/approvals.rs
+++ b/codex-rs/core/tests/suite/approvals.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
+use anyhow::Context;
 use anyhow::Result;
 use codex_config::types::ApprovalsReviewer;
 use codex_core::CodexThread;
@@ -51,7 +52,6 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 use tempfile::TempDir;
-use test_case::test_case;
 use wiremock::Mock;
 use wiremock::MockServer;
 use wiremock::Request;
@@ -578,16 +578,6 @@ enum ScenarioGroup {
     WorkspaceWrite,
     ApplyPatch,
     UnifiedExec,
-}
-
-impl ScenarioGroup {
-    const ALL: &'static [Self] = &[
-        Self::DangerFullAccess,
-        Self::ReadOnly,
-        Self::WorkspaceWrite,
-        Self::ApplyPatch,
-        Self::UnifiedExec,
-    ];
 }
 
 struct CommandResult {
@@ -1680,38 +1670,29 @@ fn scenarios() -> Vec<ScenarioSpec> {
     ]
 }
 
-macro_rules! approval_matrix_group_tests {
-    ($(($group:ident, $case_name:literal)),+ $(,)?) => {
-        const TESTED_SCENARIO_GROUPS: &[ScenarioGroup] = &[$(ScenarioGroup::$group),+];
-
-        $(#[test_case(ScenarioGroup::$group ; $case_name)])+
-        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-        async fn approval_matrix_covers_group(group: ScenarioGroup) -> Result<()> {
-            run_scenario_group(group).await
-        }
-    };
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_matrix_covers_danger_full_access_modes() -> Result<()> {
+    run_scenario_group(ScenarioGroup::DangerFullAccess).await
 }
 
-approval_matrix_group_tests! {
-    (DangerFullAccess, "danger_full_access"),
-    (ReadOnly, "read_only"),
-    (WorkspaceWrite, "workspace_write"),
-    (ApplyPatch, "apply_patch"),
-    (UnifiedExec, "unified_exec"),
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_matrix_covers_read_only_modes() -> Result<()> {
+    run_scenario_group(ScenarioGroup::ReadOnly).await
 }
 
-#[test]
-fn approval_matrix_group_tests_cover_all_groups() {
-    assert_eq!(TESTED_SCENARIO_GROUPS, ScenarioGroup::ALL);
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_matrix_covers_workspace_write_modes() -> Result<()> {
+    run_scenario_group(ScenarioGroup::WorkspaceWrite).await
+}
 
-    for group in ScenarioGroup::ALL {
-        assert!(
-            scenarios()
-                .iter()
-                .any(|scenario| scenario_group(scenario) == *group),
-            "expected at least one approval scenario for {group:?}",
-        );
-    }
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_matrix_covers_apply_patch_modes() -> Result<()> {
+    run_scenario_group(ScenarioGroup::ApplyPatch).await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_matrix_covers_unified_exec_modes() -> Result<()> {
+    run_scenario_group(ScenarioGroup::UnifiedExec).await
 }
 
 async fn run_scenario_group(group: ScenarioGroup) -> Result<()> {
@@ -1724,7 +1705,9 @@ async fn run_scenario_group(group: ScenarioGroup) -> Result<()> {
     assert!(!scenarios.is_empty(), "expected scenarios for {group:?}");
 
     for scenario in scenarios {
-        run_scenario(&scenario).await?;
+        run_scenario(&scenario)
+            .await
+            .with_context(|| format!("approval scenario failed: {}", scenario.name))?;
     }
 
     Ok(())

--- a/codex-rs/core/tests/suite/approvals.rs
+++ b/codex-rs/core/tests/suite/approvals.rs
@@ -52,6 +52,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 use tempfile::TempDir;
+use test_case::test_case;
 use wiremock::Mock;
 use wiremock::MockServer;
 use wiremock::Request;
@@ -1670,29 +1671,14 @@ fn scenarios() -> Vec<ScenarioSpec> {
     ]
 }
 
+#[test_case(ScenarioGroup::DangerFullAccess ; "danger_full_access")]
+#[test_case(ScenarioGroup::ReadOnly ; "read_only")]
+#[test_case(ScenarioGroup::WorkspaceWrite ; "workspace_write")]
+#[test_case(ScenarioGroup::ApplyPatch ; "apply_patch")]
+#[test_case(ScenarioGroup::UnifiedExec ; "unified_exec")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn approval_matrix_covers_danger_full_access_modes() -> Result<()> {
-    run_scenario_group(ScenarioGroup::DangerFullAccess).await
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn approval_matrix_covers_read_only_modes() -> Result<()> {
-    run_scenario_group(ScenarioGroup::ReadOnly).await
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn approval_matrix_covers_workspace_write_modes() -> Result<()> {
-    run_scenario_group(ScenarioGroup::WorkspaceWrite).await
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn approval_matrix_covers_apply_patch_modes() -> Result<()> {
-    run_scenario_group(ScenarioGroup::ApplyPatch).await
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn approval_matrix_covers_unified_exec_modes() -> Result<()> {
-    run_scenario_group(ScenarioGroup::UnifiedExec).await
+async fn approval_matrix_covers_group(group: ScenarioGroup) -> Result<()> {
+    run_scenario_group(group).await
 }
 
 async fn run_scenario_group(group: ScenarioGroup) -> Result<()> {

--- a/codex-rs/core/tests/suite/approvals.rs
+++ b/codex-rs/core/tests/suite/approvals.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
+use anyhow::Context;
 use anyhow::Result;
 use codex_config::types::ApprovalsReviewer;
 use codex_core::CodexThread;
@@ -568,6 +569,15 @@ struct ScenarioSpec {
     model_override: Option<&'static str>,
     outcome: Outcome,
     expectation: Expectation,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ScenarioGroup {
+    DangerFullAccess,
+    ReadOnly,
+    WorkspaceWrite,
+    ApplyPatch,
+    UnifiedExec,
 }
 
 struct CommandResult {
@@ -1661,14 +1671,64 @@ fn scenarios() -> Vec<ScenarioSpec> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn approval_matrix_covers_all_modes() -> Result<()> {
+async fn approval_matrix_covers_danger_full_access_modes() -> Result<()> {
+    run_scenario_group(ScenarioGroup::DangerFullAccess).await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_matrix_covers_read_only_modes() -> Result<()> {
+    run_scenario_group(ScenarioGroup::ReadOnly).await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_matrix_covers_workspace_write_modes() -> Result<()> {
+    run_scenario_group(ScenarioGroup::WorkspaceWrite).await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_matrix_covers_apply_patch_modes() -> Result<()> {
+    run_scenario_group(ScenarioGroup::ApplyPatch).await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_matrix_covers_unified_exec_modes() -> Result<()> {
+    run_scenario_group(ScenarioGroup::UnifiedExec).await
+}
+
+async fn run_scenario_group(group: ScenarioGroup) -> Result<()> {
     skip_if_no_network!(Ok(()));
 
-    for scenario in scenarios() {
-        run_scenario(&scenario).await?;
+    let scenarios = scenarios()
+        .into_iter()
+        .filter(|scenario| scenario_group(scenario) == group)
+        .collect::<Vec<_>>();
+    assert!(!scenarios.is_empty(), "expected scenarios for {group:?}");
+
+    for scenario in scenarios {
+        run_scenario(&scenario)
+            .await
+            .with_context(|| format!("approval scenario failed: {}", scenario.name))?;
     }
 
     Ok(())
+}
+
+fn scenario_group(scenario: &ScenarioSpec) -> ScenarioGroup {
+    match &scenario.action {
+        ActionKind::ApplyPatchFunction { .. } | ActionKind::ApplyPatchShell { .. } => {
+            ScenarioGroup::ApplyPatch
+        }
+        ActionKind::RunUnifiedExecCommand { .. } => ScenarioGroup::UnifiedExec,
+        ActionKind::WriteFile { .. }
+        | ActionKind::FetchUrlNoProxy { .. }
+        | ActionKind::FetchUrl { .. }
+        | ActionKind::RunCommand { .. } => match &scenario.sandbox_policy {
+            SandboxPolicy::DangerFullAccess => ScenarioGroup::DangerFullAccess,
+            SandboxPolicy::ReadOnly { .. } => ScenarioGroup::ReadOnly,
+            SandboxPolicy::WorkspaceWrite { .. } => ScenarioGroup::WorkspaceWrite,
+            SandboxPolicy::ExternalSandbox { .. } => ScenarioGroup::WorkspaceWrite,
+        },
+    }
 }
 
 async fn run_scenario(scenario: &ScenarioSpec) -> Result<()> {

--- a/codex-rs/core/tests/suite/approvals.rs
+++ b/codex-rs/core/tests/suite/approvals.rs
@@ -1,6 +1,5 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use anyhow::Context;
 use anyhow::Result;
 use codex_config::types::ApprovalsReviewer;
 use codex_core::CodexThread;
@@ -52,6 +51,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 use tempfile::TempDir;
+use test_case::test_case;
 use wiremock::Mock;
 use wiremock::MockServer;
 use wiremock::Request;
@@ -569,15 +569,6 @@ struct ScenarioSpec {
     model_override: Option<&'static str>,
     outcome: Outcome,
     expectation: Expectation,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum ScenarioGroup {
-    DangerFullAccess,
-    ReadOnly,
-    WorkspaceWrite,
-    ApplyPatch,
-    UnifiedExec,
 }
 
 struct CommandResult {
@@ -1670,65 +1661,63 @@ fn scenarios() -> Vec<ScenarioSpec> {
     ]
 }
 
+#[test_case("danger_full_access_on_request_allows_outside_write" ; "danger_full_access_on_request_allows_outside_write")]
+#[test_case("danger_full_access_on_request_allows_outside_write_gpt_5_1_no_exit" ; "danger_full_access_on_request_allows_outside_write_gpt_5_1_no_exit")]
+#[test_case("danger_full_access_on_request_allows_network" ; "danger_full_access_on_request_allows_network")]
+#[test_case("danger_full_access_on_request_allows_network_gpt_5_1_no_exit" ; "danger_full_access_on_request_allows_network_gpt_5_1_no_exit")]
+#[test_case("trusted_command_unless_trusted_runs_without_prompt" ; "trusted_command_unless_trusted_runs_without_prompt")]
+#[test_case("trusted_command_unless_trusted_runs_without_prompt_gpt_5_1_no_exit" ; "trusted_command_unless_trusted_runs_without_prompt_gpt_5_1_no_exit")]
+#[test_case("cat_redirect_unless_trusted_requires_approval" ; "cat_redirect_unless_trusted_requires_approval")]
+#[test_case("cat_redirect_on_request_requires_approval" ; "cat_redirect_on_request_requires_approval")]
+#[test_case("danger_full_access_on_failure_allows_outside_write" ; "danger_full_access_on_failure_allows_outside_write")]
+#[test_case("danger_full_access_on_failure_allows_outside_write_gpt_5_1_no_exit" ; "danger_full_access_on_failure_allows_outside_write_gpt_5_1_no_exit")]
+#[test_case("danger_full_access_unless_trusted_requests_approval" ; "danger_full_access_unless_trusted_requests_approval")]
+#[test_case("danger_full_access_unless_trusted_requests_approval_gpt_5_1_no_exit" ; "danger_full_access_unless_trusted_requests_approval_gpt_5_1_no_exit")]
+#[test_case("danger_full_access_never_allows_outside_write" ; "danger_full_access_never_allows_outside_write")]
+#[test_case("danger_full_access_never_allows_outside_write_gpt_5_1_no_exit" ; "danger_full_access_never_allows_outside_write_gpt_5_1_no_exit")]
+#[test_case("read_only_on_request_requires_approval" ; "read_only_on_request_requires_approval")]
+#[test_case("read_only_on_request_requires_approval_gpt_5_1_no_exit" ; "read_only_on_request_requires_approval_gpt_5_1_no_exit")]
+#[test_case("trusted_command_on_request_read_only_runs_without_prompt" ; "trusted_command_on_request_read_only_runs_without_prompt")]
+#[test_case("trusted_command_on_request_read_only_runs_without_prompt_gpt_5_1_no_exit" ; "trusted_command_on_request_read_only_runs_without_prompt_gpt_5_1_no_exit")]
+#[test_case("read_only_on_request_blocks_network" ; "read_only_on_request_blocks_network")]
+#[test_case("read_only_on_request_denied_blocks_execution" ; "read_only_on_request_denied_blocks_execution")]
+#[test_case("read_only_on_failure_escalates_after_sandbox_error" ; "read_only_on_failure_escalates_after_sandbox_error")]
+#[test_case("read_only_on_failure_escalates_after_sandbox_error_gpt_5_1_no_exit" ; "read_only_on_failure_escalates_after_sandbox_error_gpt_5_1_no_exit")]
+#[test_case("read_only_on_request_network_escalates_when_approved" ; "read_only_on_request_network_escalates_when_approved")]
+#[test_case("read_only_on_request_network_escalates_when_approved_gpt_5_1_no_exit" ; "read_only_on_request_network_escalates_when_approved_gpt_5_1_no_exit")]
+#[test_case("apply_patch_shell_command_requires_patch_approval" ; "apply_patch_shell_command_requires_patch_approval")]
+#[test_case("apply_patch_function_auto_inside_workspace" ; "apply_patch_function_auto_inside_workspace")]
+#[test_case("apply_patch_function_danger_allows_outside_workspace" ; "apply_patch_function_danger_allows_outside_workspace")]
+#[test_case("apply_patch_function_outside_requires_patch_approval" ; "apply_patch_function_outside_requires_patch_approval")]
+#[test_case("apply_patch_function_outside_denied_blocks_patch" ; "apply_patch_function_outside_denied_blocks_patch")]
+#[test_case("apply_patch_shell_command_outside_requires_patch_approval" ; "apply_patch_shell_command_outside_requires_patch_approval")]
+#[test_case("apply_patch_function_unless_trusted_requires_patch_approval" ; "apply_patch_function_unless_trusted_requires_patch_approval")]
+#[test_case("apply_patch_function_never_rejects_outside_workspace" ; "apply_patch_function_never_rejects_outside_workspace")]
+#[test_case("read_only_unless_trusted_requires_approval" ; "read_only_unless_trusted_requires_approval")]
+#[test_case("read_only_unless_trusted_requires_approval_gpt_5_1_no_exit" ; "read_only_unless_trusted_requires_approval_gpt_5_1_no_exit")]
+#[test_case("read_only_never_reports_sandbox_failure" ; "read_only_never_reports_sandbox_failure")]
+#[test_case("trusted_command_never_runs_without_prompt" ; "trusted_command_never_runs_without_prompt")]
+#[test_case("workspace_write_on_request_allows_workspace_write" ; "workspace_write_on_request_allows_workspace_write")]
+#[test_case("workspace_write_network_disabled_blocks_network" ; "workspace_write_network_disabled_blocks_network")]
+#[test_case("workspace_write_on_request_requires_approval_outside_workspace" ; "workspace_write_on_request_requires_approval_outside_workspace")]
+#[test_case("workspace_write_network_enabled_allows_network" ; "workspace_write_network_enabled_allows_network")]
+#[test_case("workspace_write_on_failure_escalates_outside_workspace" ; "workspace_write_on_failure_escalates_outside_workspace")]
+#[test_case("workspace_write_unless_trusted_requires_approval_outside_workspace" ; "workspace_write_unless_trusted_requires_approval_outside_workspace")]
+#[test_case("workspace_write_never_blocks_outside_workspace" ; "workspace_write_never_blocks_outside_workspace")]
+#[test_case("unified exec on request no approval for safe command" ; "unified_exec_on_request_no_approval_for_safe_command")]
+#[test_case("unified exec on request escalated requires approval" ; "unified_exec_on_request_escalated_requires_approval")]
+#[test_case("unified exec on request requires approval unless trusted" ; "unified_exec_on_request_requires_approval_unless_trusted")]
+#[test_case("safe command with heredoc and redirect still requires approval" ; "safe_command_with_heredoc_and_redirect_still_requires_approval")]
+#[test_case("compound command with one safe command still requires approval" ; "compound_command_with_one_safe_command_still_requires_approval")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn approval_matrix_covers_danger_full_access_modes() -> Result<()> {
-    run_scenario_group(ScenarioGroup::DangerFullAccess).await
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn approval_matrix_covers_read_only_modes() -> Result<()> {
-    run_scenario_group(ScenarioGroup::ReadOnly).await
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn approval_matrix_covers_workspace_write_modes() -> Result<()> {
-    run_scenario_group(ScenarioGroup::WorkspaceWrite).await
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn approval_matrix_covers_apply_patch_modes() -> Result<()> {
-    run_scenario_group(ScenarioGroup::ApplyPatch).await
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn approval_matrix_covers_unified_exec_modes() -> Result<()> {
-    run_scenario_group(ScenarioGroup::UnifiedExec).await
-}
-
-async fn run_scenario_group(group: ScenarioGroup) -> Result<()> {
+async fn approval_matrix_covers_scenario(scenario_name: &str) -> Result<()> {
     skip_if_no_network!(Ok(()));
 
-    let scenarios = scenarios()
+    let scenario = scenarios()
         .into_iter()
-        .filter(|scenario| scenario_group(scenario) == group)
-        .collect::<Vec<_>>();
-    assert!(!scenarios.is_empty(), "expected scenarios for {group:?}");
-
-    for scenario in scenarios {
-        run_scenario(&scenario)
-            .await
-            .with_context(|| format!("approval scenario failed: {}", scenario.name))?;
-    }
-
-    Ok(())
-}
-
-fn scenario_group(scenario: &ScenarioSpec) -> ScenarioGroup {
-    match &scenario.action {
-        ActionKind::ApplyPatchFunction { .. } | ActionKind::ApplyPatchShell { .. } => {
-            ScenarioGroup::ApplyPatch
-        }
-        ActionKind::RunUnifiedExecCommand { .. } => ScenarioGroup::UnifiedExec,
-        ActionKind::WriteFile { .. }
-        | ActionKind::FetchUrlNoProxy { .. }
-        | ActionKind::FetchUrl { .. }
-        | ActionKind::RunCommand { .. } => match &scenario.sandbox_policy {
-            SandboxPolicy::DangerFullAccess => ScenarioGroup::DangerFullAccess,
-            SandboxPolicy::ReadOnly { .. } => ScenarioGroup::ReadOnly,
-            SandboxPolicy::WorkspaceWrite { .. } => ScenarioGroup::WorkspaceWrite,
-            SandboxPolicy::ExternalSandbox { .. } => ScenarioGroup::WorkspaceWrite,
-        },
-    }
+        .find(|scenario| scenario.name == scenario_name)
+        .unwrap_or_else(|| panic!("missing approval scenario: {scenario_name}"));
+    run_scenario(&scenario).await
 }
 
 async fn run_scenario(scenario: &ScenarioSpec) -> Result<()> {

--- a/codex-rs/core/tests/suite/approvals.rs
+++ b/codex-rs/core/tests/suite/approvals.rs
@@ -571,6 +571,25 @@ struct ScenarioSpec {
     expectation: Expectation,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ScenarioGroup {
+    DangerFullAccess,
+    ReadOnly,
+    WorkspaceWrite,
+    ApplyPatch,
+    UnifiedExec,
+}
+
+impl ScenarioGroup {
+    const ALL: &'static [Self] = &[
+        Self::DangerFullAccess,
+        Self::ReadOnly,
+        Self::WorkspaceWrite,
+        Self::ApplyPatch,
+        Self::UnifiedExec,
+    ];
+}
+
 struct CommandResult {
     exit_code: Option<i64>,
     stdout: String,
@@ -1661,63 +1680,72 @@ fn scenarios() -> Vec<ScenarioSpec> {
     ]
 }
 
-#[test_case("danger_full_access_on_request_allows_outside_write" ; "danger_full_access_on_request_allows_outside_write")]
-#[test_case("danger_full_access_on_request_allows_outside_write_gpt_5_1_no_exit" ; "danger_full_access_on_request_allows_outside_write_gpt_5_1_no_exit")]
-#[test_case("danger_full_access_on_request_allows_network" ; "danger_full_access_on_request_allows_network")]
-#[test_case("danger_full_access_on_request_allows_network_gpt_5_1_no_exit" ; "danger_full_access_on_request_allows_network_gpt_5_1_no_exit")]
-#[test_case("trusted_command_unless_trusted_runs_without_prompt" ; "trusted_command_unless_trusted_runs_without_prompt")]
-#[test_case("trusted_command_unless_trusted_runs_without_prompt_gpt_5_1_no_exit" ; "trusted_command_unless_trusted_runs_without_prompt_gpt_5_1_no_exit")]
-#[test_case("cat_redirect_unless_trusted_requires_approval" ; "cat_redirect_unless_trusted_requires_approval")]
-#[test_case("cat_redirect_on_request_requires_approval" ; "cat_redirect_on_request_requires_approval")]
-#[test_case("danger_full_access_on_failure_allows_outside_write" ; "danger_full_access_on_failure_allows_outside_write")]
-#[test_case("danger_full_access_on_failure_allows_outside_write_gpt_5_1_no_exit" ; "danger_full_access_on_failure_allows_outside_write_gpt_5_1_no_exit")]
-#[test_case("danger_full_access_unless_trusted_requests_approval" ; "danger_full_access_unless_trusted_requests_approval")]
-#[test_case("danger_full_access_unless_trusted_requests_approval_gpt_5_1_no_exit" ; "danger_full_access_unless_trusted_requests_approval_gpt_5_1_no_exit")]
-#[test_case("danger_full_access_never_allows_outside_write" ; "danger_full_access_never_allows_outside_write")]
-#[test_case("danger_full_access_never_allows_outside_write_gpt_5_1_no_exit" ; "danger_full_access_never_allows_outside_write_gpt_5_1_no_exit")]
-#[test_case("read_only_on_request_requires_approval" ; "read_only_on_request_requires_approval")]
-#[test_case("read_only_on_request_requires_approval_gpt_5_1_no_exit" ; "read_only_on_request_requires_approval_gpt_5_1_no_exit")]
-#[test_case("trusted_command_on_request_read_only_runs_without_prompt" ; "trusted_command_on_request_read_only_runs_without_prompt")]
-#[test_case("trusted_command_on_request_read_only_runs_without_prompt_gpt_5_1_no_exit" ; "trusted_command_on_request_read_only_runs_without_prompt_gpt_5_1_no_exit")]
-#[test_case("read_only_on_request_blocks_network" ; "read_only_on_request_blocks_network")]
-#[test_case("read_only_on_request_denied_blocks_execution" ; "read_only_on_request_denied_blocks_execution")]
-#[test_case("read_only_on_failure_escalates_after_sandbox_error" ; "read_only_on_failure_escalates_after_sandbox_error")]
-#[test_case("read_only_on_failure_escalates_after_sandbox_error_gpt_5_1_no_exit" ; "read_only_on_failure_escalates_after_sandbox_error_gpt_5_1_no_exit")]
-#[test_case("read_only_on_request_network_escalates_when_approved" ; "read_only_on_request_network_escalates_when_approved")]
-#[test_case("read_only_on_request_network_escalates_when_approved_gpt_5_1_no_exit" ; "read_only_on_request_network_escalates_when_approved_gpt_5_1_no_exit")]
-#[test_case("apply_patch_shell_command_requires_patch_approval" ; "apply_patch_shell_command_requires_patch_approval")]
-#[test_case("apply_patch_function_auto_inside_workspace" ; "apply_patch_function_auto_inside_workspace")]
-#[test_case("apply_patch_function_danger_allows_outside_workspace" ; "apply_patch_function_danger_allows_outside_workspace")]
-#[test_case("apply_patch_function_outside_requires_patch_approval" ; "apply_patch_function_outside_requires_patch_approval")]
-#[test_case("apply_patch_function_outside_denied_blocks_patch" ; "apply_patch_function_outside_denied_blocks_patch")]
-#[test_case("apply_patch_shell_command_outside_requires_patch_approval" ; "apply_patch_shell_command_outside_requires_patch_approval")]
-#[test_case("apply_patch_function_unless_trusted_requires_patch_approval" ; "apply_patch_function_unless_trusted_requires_patch_approval")]
-#[test_case("apply_patch_function_never_rejects_outside_workspace" ; "apply_patch_function_never_rejects_outside_workspace")]
-#[test_case("read_only_unless_trusted_requires_approval" ; "read_only_unless_trusted_requires_approval")]
-#[test_case("read_only_unless_trusted_requires_approval_gpt_5_1_no_exit" ; "read_only_unless_trusted_requires_approval_gpt_5_1_no_exit")]
-#[test_case("read_only_never_reports_sandbox_failure" ; "read_only_never_reports_sandbox_failure")]
-#[test_case("trusted_command_never_runs_without_prompt" ; "trusted_command_never_runs_without_prompt")]
-#[test_case("workspace_write_on_request_allows_workspace_write" ; "workspace_write_on_request_allows_workspace_write")]
-#[test_case("workspace_write_network_disabled_blocks_network" ; "workspace_write_network_disabled_blocks_network")]
-#[test_case("workspace_write_on_request_requires_approval_outside_workspace" ; "workspace_write_on_request_requires_approval_outside_workspace")]
-#[test_case("workspace_write_network_enabled_allows_network" ; "workspace_write_network_enabled_allows_network")]
-#[test_case("workspace_write_on_failure_escalates_outside_workspace" ; "workspace_write_on_failure_escalates_outside_workspace")]
-#[test_case("workspace_write_unless_trusted_requires_approval_outside_workspace" ; "workspace_write_unless_trusted_requires_approval_outside_workspace")]
-#[test_case("workspace_write_never_blocks_outside_workspace" ; "workspace_write_never_blocks_outside_workspace")]
-#[test_case("unified exec on request no approval for safe command" ; "unified_exec_on_request_no_approval_for_safe_command")]
-#[test_case("unified exec on request escalated requires approval" ; "unified_exec_on_request_escalated_requires_approval")]
-#[test_case("unified exec on request requires approval unless trusted" ; "unified_exec_on_request_requires_approval_unless_trusted")]
-#[test_case("safe command with heredoc and redirect still requires approval" ; "safe_command_with_heredoc_and_redirect_still_requires_approval")]
-#[test_case("compound command with one safe command still requires approval" ; "compound_command_with_one_safe_command_still_requires_approval")]
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn approval_matrix_covers_scenario(scenario_name: &str) -> Result<()> {
+macro_rules! approval_matrix_group_tests {
+    ($(($group:ident, $case_name:literal)),+ $(,)?) => {
+        const TESTED_SCENARIO_GROUPS: &[ScenarioGroup] = &[$(ScenarioGroup::$group),+];
+
+        $(#[test_case(ScenarioGroup::$group ; $case_name)])+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn approval_matrix_covers_group(group: ScenarioGroup) -> Result<()> {
+            run_scenario_group(group).await
+        }
+    };
+}
+
+approval_matrix_group_tests! {
+    (DangerFullAccess, "danger_full_access"),
+    (ReadOnly, "read_only"),
+    (WorkspaceWrite, "workspace_write"),
+    (ApplyPatch, "apply_patch"),
+    (UnifiedExec, "unified_exec"),
+}
+
+#[test]
+fn approval_matrix_group_tests_cover_all_groups() {
+    assert_eq!(TESTED_SCENARIO_GROUPS, ScenarioGroup::ALL);
+
+    for group in ScenarioGroup::ALL {
+        assert!(
+            scenarios()
+                .iter()
+                .any(|scenario| scenario_group(scenario) == *group),
+            "expected at least one approval scenario for {group:?}",
+        );
+    }
+}
+
+async fn run_scenario_group(group: ScenarioGroup) -> Result<()> {
     skip_if_no_network!(Ok(()));
 
-    let scenario = scenarios()
+    let scenarios = scenarios()
         .into_iter()
-        .find(|scenario| scenario.name == scenario_name)
-        .unwrap_or_else(|| panic!("missing approval scenario: {scenario_name}"));
-    run_scenario(&scenario).await
+        .filter(|scenario| scenario_group(scenario) == group)
+        .collect::<Vec<_>>();
+    assert!(!scenarios.is_empty(), "expected scenarios for {group:?}");
+
+    for scenario in scenarios {
+        run_scenario(&scenario).await?;
+    }
+
+    Ok(())
+}
+
+fn scenario_group(scenario: &ScenarioSpec) -> ScenarioGroup {
+    match &scenario.action {
+        ActionKind::ApplyPatchFunction { .. } | ActionKind::ApplyPatchShell { .. } => {
+            ScenarioGroup::ApplyPatch
+        }
+        ActionKind::RunUnifiedExecCommand { .. } => ScenarioGroup::UnifiedExec,
+        ActionKind::WriteFile { .. }
+        | ActionKind::FetchUrlNoProxy { .. }
+        | ActionKind::FetchUrl { .. }
+        | ActionKind::RunCommand { .. } => match &scenario.sandbox_policy {
+            SandboxPolicy::DangerFullAccess => ScenarioGroup::DangerFullAccess,
+            SandboxPolicy::ReadOnly { .. } => ScenarioGroup::ReadOnly,
+            SandboxPolicy::WorkspaceWrite { .. } => ScenarioGroup::WorkspaceWrite,
+            SandboxPolicy::ExternalSandbox { .. } => ScenarioGroup::WorkspaceWrite,
+        },
+    }
 }
 
 async fn run_scenario(scenario: &ScenarioSpec) -> Result<()> {


### PR DESCRIPTION
## Why

Recent `main` CI repeatedly timed out in:

- `codex-core::all suite::approvals::approval_matrix_covers_all_modes`

It failed in runs [24909500958](https://github.com/openai/codex/actions/runs/24909500958), [24908076251](https://github.com/openai/codex/actions/runs/24908076251), [24906197645](https://github.com/openai/codex/actions/runs/24906197645), [24905823212](https://github.com/openai/codex/actions/runs/24905823212), [24903439629](https://github.com/openai/codex/actions/runs/24903439629), [24903336028](https://github.com/openai/codex/actions/runs/24903336028), and [24898949647](https://github.com/openai/codex/actions/runs/24898949647).

The failure pattern was a 60s Linux remote timeout. Logs showed many approval scenarios completing before the single matrix test timed out.

## Root Cause

`approval_matrix_covers_all_modes` packed every approval/sandbox/tool scenario into one test case. That made the test vulnerable to normal CI variance: one slow scenario or a slow process startup could push the whole monolithic case past the 60s per-test timeout. It also hid which part of the matrix was slow because the runner only reported the one large matrix test.

## What Changed

- Keep the shared `scenarios()` table as the single source of approval matrix coverage.
- Use one `#[test_case]` per `ScenarioGroup` to generate five async Tokio tests: danger/full-access, read-only, workspace-write, apply-patch, and unified-exec.
- Keep the group runner small and add per-scenario error context so a failure still reports the specific scenario name.

## Why This Should Be Reliable

Each scenario group now has its own test harness timeout instead of sharing one timeout window with the full matrix. That removes the long sequential loop from a single test while keeping the implementation compact and easy to scan.

The tests still run through the same scenario definitions and runner, so this preserves coverage. `test-case` already composes with `#[tokio::test]` in this crate and is already available for test code.

## Verification

- `cargo test -p codex-core --test all approval_matrix_ -- --list`
- `cargo test -p codex-core --test all approval_matrix_`
