### PR TITLE
Enable unavailable dummy tools by default

### DIFF
--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -845,8 +845,8 @@ pub const FEATURES: &[FeatureSpec] = &[
     FeatureSpec {
         id: Feature::UnavailableDummyTools,
         key: "unavailable_dummy_tools",
-        stage: Stage::UnderDevelopment,
-        default_enabled: false,
+        stage: Stage::Stable,
+        default_enabled: true,
     },
     FeatureSpec {
         id: Feature::ToolSuggest,

--- a/codex-rs/features/src/tests.rs
+++ b/codex-rs/features/src/tests.rs
@@ -160,12 +160,6 @@ fn browser_controls_are_stable_and_enabled_by_default() {
 }
 
 #[test]
-fn unavailable_dummy_tools_is_stable_and_enabled_by_default() {
-    assert_eq!(Feature::UnavailableDummyTools.stage(), Stage::Stable);
-    assert_eq!(Feature::UnavailableDummyTools.default_enabled(), true);
-}
-
-#[test]
 fn general_analytics_is_stable_and_enabled_by_default() {
     assert_eq!(Feature::GeneralAnalytics.stage(), Stage::Stable);
     assert_eq!(Feature::GeneralAnalytics.default_enabled(), true);

--- a/codex-rs/features/src/tests.rs
+++ b/codex-rs/features/src/tests.rs
@@ -160,12 +160,9 @@ fn browser_controls_are_stable_and_enabled_by_default() {
 }
 
 #[test]
-fn unavailable_dummy_tools_is_under_development_and_disabled_by_default() {
-    assert_eq!(
-        Feature::UnavailableDummyTools.stage(),
-        Stage::UnderDevelopment
-    );
-    assert_eq!(Feature::UnavailableDummyTools.default_enabled(), false);
+fn unavailable_dummy_tools_is_stable_and_enabled_by_default() {
+    assert_eq!(Feature::UnavailableDummyTools.stage(), Stage::Stable);
+    assert_eq!(Feature::UnavailableDummyTools.default_enabled(), true);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Mark `unavailable_dummy_tools` as a stable feature and enable it by default
- Update the feature registry test to match the new default state

## Testing
- `just fmt`
- `cargo test -p codex-features`