### PR TITLE
Fix Bazel cargo_bin runfiles paths

### DIFF
--- a/codex-rs/utils/cargo-bin/src/lib.rs
+++ b/codex-rs/utils/cargo-bin/src/lib.rs
@@ -91,10 +91,15 @@ fn resolve_bin_from_env(key: &str, value: OsString) -> Result<PathBuf, CargoBinE
         let runfiles = runfiles::Runfiles::create().map_err(|err| CargoBinError::CurrentExe {
             source: std::io::Error::other(err),
         })?;
-        if let Some(resolved) = runfiles::rlocation!(runfiles, &raw)
-            && resolved.exists()
-        {
-            return Ok(resolved);
+        if let Some(mut resolved) = runfiles::rlocation!(runfiles, &raw) {
+            if !resolved.is_absolute() {
+                resolved = std::env::current_dir()
+                    .map_err(|source| CargoBinError::CurrentDir { source })?
+                    .join(resolved);
+            }
+            if resolved.exists() {
+                return Ok(resolved);
+            }
         }
     } else if raw.is_absolute() && raw.exists() {
         return Ok(raw);


### PR DESCRIPTION
## Summary

Fix a Bazel-only path resolution bug in `codex_utils_cargo_bin::cargo_bin`.

Under Bazel runfiles, `rlocation` can return a relative `bazel-out/...` path even though `cargo_bin()` documents that it returns an absolute path. That can break callers that store the returned binary path and later spawn it after changing cwd, because the relative path is resolved from the wrong directory.

This patch absolutizes the runfiles-resolved path before returning it.
