### PR TITLE
[codex] Use serial_test for Windows sandbox tests

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -3771,6 +3771,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
+ "serial_test",
  "tempfile",
  "tokio",
  "windows 0.58.0",

--- a/codex-rs/windows-sandbox-rs/Cargo.toml
+++ b/codex-rs/windows-sandbox-rs/Cargo.toml
@@ -89,6 +89,7 @@ version = "0.52"
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
+serial_test = { workspace = true }
 
 [build-dependencies]
 winres = "0.1"

--- a/codex-rs/windows-sandbox-rs/src/unified_exec/tests.rs
+++ b/codex-rs/windows-sandbox-rs/src/unified_exec/tests.rs
@@ -7,6 +7,7 @@ use crate::ipc_framed::read_frame;
 use crate::run_windows_sandbox_capture;
 use codex_utils_pty::ProcessDriver;
 use pretty_assertions::assert_eq;
+use serial_test::serial;
 use std::collections::HashMap;
 use std::fs;
 use std::fs::OpenOptions;
@@ -14,8 +15,6 @@ use std::io::Seek;
 use std::io::SeekFrom;
 use std::path::Path;
 use std::path::PathBuf;
-use std::sync::Mutex;
-use std::sync::MutexGuard;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
@@ -28,13 +27,6 @@ use tokio::sync::oneshot;
 use tokio::time::timeout;
 
 static TEST_HOME_COUNTER: AtomicU64 = AtomicU64::new(0);
-static LEGACY_PROCESS_TEST_LOCK: Mutex<()> = Mutex::new(());
-
-fn legacy_process_test_guard() -> MutexGuard<'static, ()> {
-    LEGACY_PROCESS_TEST_LOCK
-        .lock()
-        .expect("legacy Windows sandbox process test lock poisoned")
-}
 
 fn current_thread_runtime() -> tokio::runtime::Runtime {
     Builder::new_current_thread()
@@ -137,8 +129,8 @@ async fn collect_stdout_and_exit(
 }
 
 #[test]
+#[serial(windows_sandbox_legacy_process)]
 fn legacy_non_tty_cmd_emits_output() {
-    let _guard = legacy_process_test_guard();
     let runtime = current_thread_runtime();
     runtime.block_on(async move {
         let cwd = sandbox_cwd();
@@ -173,11 +165,11 @@ fn legacy_non_tty_cmd_emits_output() {
 }
 
 #[test]
+#[serial(windows_sandbox_legacy_process)]
 fn legacy_non_tty_powershell_emits_output() {
     let Some(pwsh) = pwsh_path() else {
         return;
     };
-    let _guard = legacy_process_test_guard();
     let runtime = current_thread_runtime();
     runtime.block_on(async move {
         let cwd = sandbox_cwd();
@@ -358,11 +350,11 @@ fn runner_resizer_sends_resize_frame() {
 }
 
 #[test]
+#[serial(windows_sandbox_legacy_process)]
 fn legacy_capture_powershell_emits_output() {
     let Some(pwsh) = pwsh_path() else {
         return;
     };
-    let _guard = legacy_process_test_guard();
     let cwd = sandbox_cwd();
     let codex_home = sandbox_home("legacy-capture-pwsh");
     println!("capture pwsh codex_home={}", codex_home.path().display());
@@ -395,11 +387,11 @@ fn legacy_capture_powershell_emits_output() {
 }
 
 #[test]
+#[serial(windows_sandbox_legacy_process)]
 fn legacy_tty_powershell_emits_output_and_accepts_input() {
     let Some(pwsh) = pwsh_path() else {
         return;
     };
-    let _guard = legacy_process_test_guard();
     let runtime = current_thread_runtime();
     runtime.block_on(async move {
         let cwd = sandbox_cwd();


### PR DESCRIPTION
## Why

Follow-up to #19453. The merged fix serialized the legacy Windows sandbox process tests with a crate-local mutex. The earlier version in dc8f32f used serial_test for this, which keeps the intent clearer and avoids bespoke synchronization code.

## What Changed

- Added serial_test as a dev-dependency for codex-windows-sandbox.
- Replaced the local Mutex guard with use serial_test::serial.
- Applied one named serial group to the same legacy cmd/PowerShell sandbox tests.

## Verification

- just fmt
- cargo test -p codex-windows-sandbox
- just bazel-lock-update
- just bazel-lock-check
- just fix -p codex-windows-sandbox