### PR TITLE
Fix codex-rs README grammar

### DIFF
--- a/codex-rs/README.md
+++ b/codex-rs/README.md
@@ -94,7 +94,7 @@ In `workspace-write`, Codex also includes `~/.codex/memories` in its writable ro
 
 This folder is the root of a Cargo workspace. It contains quite a bit of experimental code, but here are the key crates:
 
-- [`core/`](./core) contains the business logic for Codex. Ultimately, we hope this to be a library crate that is generally useful for building other Rust/native applications that use Codex.
+- [`core/`](./core) contains the business logic for Codex. Ultimately, we hope this becomes a library crate that is generally useful for building other Rust/native applications that use Codex.
 - [`exec/`](./exec) "headless" CLI for use in automation.
 - [`tui/`](./tui) CLI that launches a fullscreen TUI built with [Ratatui](https://ratatui.rs/).
 - [`cli/`](./cli) CLI multitool that provides the aforementioned CLIs via subcommands.


### PR DESCRIPTION
## Why

Issue #19418 points out a small grammar issue in `codex-rs/README.md` under "Code Organization." The current sentence says "we hope this to be," which reads awkwardly.

Fixes #19418.

## What changed

Updated the `core/` crate description so the sentence reads "we hope this becomes a library crate."

## Verification

Documentation-only change. Reviewed the Markdown diff.
