### PR TITLE
fix: increase Bazel timeout to 45 minutes

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -17,7 +17,11 @@ concurrency:
   cancel-in-progress: ${{ github.ref_name != 'main' }}
 jobs:
   test:
-    timeout-minutes: 30
+    # Ideally, this would be only 30 minutes, but a no-cache-hit Windows build
+    # seems to trip this limit and starting over is painful when it happens.
+    # Ultimately we need true distributed builds (e.g.,
+    # https://www.buildbuddy.io/docs/rbe-setup/) to speed things up.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Unfortunately, if most of the build graph is invalidated such that there are few cache hits, the Windows Bazel build for all the tests often takes more than `30` minutes, so this PR increases the timeout to `45` minutes until we set up distributed builds.