### PR TITLE
test: isolate remote thread store regression from plugin warmups

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/remote_thread_store.rs
+++ b/codex-rs/app-server/tests/suite/v2/remote_thread_store.rs
@@ -54,6 +54,8 @@ async fn thread_start_with_non_local_thread_store_does_not_create_local_persiste
     let server = create_mock_responses_server_repeating_assistant("Done").await;
     let codex_home = TempDir::new()?;
     let store_id = Uuid::new_v4().to_string();
+    // Plugin startup warmups may create `.tmp` under codex_home. Disable them
+    // here so this regression stays focused on thread persistence artifacts.
     create_config_toml_with_thread_store(codex_home.path(), &server.uri(), &store_id)?;
 
     let loader_overrides = LoaderOverrides::without_managed_config_for_tests();
@@ -248,6 +250,9 @@ base_url = "{server_uri}/v1"
 wire_api = "responses"
 request_max_retries = 0
 stream_max_retries = 0
+
+[features]
+plugins = false
 "#
         ),
     )


### PR DESCRIPTION
Follow-up to #19266.

## Why

`thread_start_with_non_local_thread_store_does_not_create_local_persistence` is meant to catch accidental local thread persistence when a non-local thread store is configured. The Windows flake reported in [this BuildBuddy invocation](https://app.buildbuddy.io/invocation/0b75dde4-6828-4e7b-a35b-e45b73fb005d) showed that the assertion was tripping on an unexpected top-level `.tmp` entry:

```diff
 {
+    ".tmp",
     "config.toml",
     "installation_id",
     "memories",
     "skills",
 }
```

That `.tmp` does not appear to come from `tempfile::TempDir`; it comes from unrelated plugin startup work that can legitimately materialize `codex_home/.tmp`, including the startup remote plugin sync marker in [`core/src/plugins/startup_sync.rs`](https://github.com/openai/codex/blob/bce74c70ce058982534507330ff33f7b196708ef/codex-rs/core/src/plugins/startup_sync.rs#L13-L15) and the curated plugin snapshot under [`.tmp/plugins`](https://github.com/openai/codex/blob/bce74c70ce058982534507330ff33f7b196708ef/codex-rs/core-plugins/src/startup_sync.rs#L25-L26).

That makes the regression race unrelated background startup tasks instead of validating the thread-store invariant it was added to cover. Rather than weakening the assertion to allow arbitrary `.tmp` entries, this change isolates the test from plugin warmups so it can stay strict about unexpected local thread persistence artifacts.

## What changed

- disable plugins in the generated config used by `app-server/tests/suite/v2/remote_thread_store.rs`
- keep the existing `codex_home` assertions unchanged so the test still fails if local session or sqlite persistence is introduced

## Verification

- `cargo test -p codex-app-server suite::v2::remote_thread_store::thread_start_with_non_local_thread_store_does_not_create_local_persistence -- --exact`
