### PR TITLE
Fix remote compaction with deferred dynamic tools

### DIFF
--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -12,6 +12,7 @@ use crate::context_manager::estimate_response_item_model_visible_bytes;
 use crate::context_manager::is_codex_generated_item;
 use crate::session::session::Session;
 use crate::session::turn::built_tools;
+use crate::session::turn::model_visible_specs_for_prompt;
 use crate::session::turn_context::TurnContext;
 use codex_analytics::CompactionImplementation;
 use codex_analytics::CompactionPhase;
@@ -165,7 +166,7 @@ async fn run_remote_compact_task_inner_impl(
     .await?;
     let prompt = Prompt {
         input: prompt_input,
-        tools: tool_router.model_visible_specs(),
+        tools: model_visible_specs_for_prompt(tool_router.as_ref(), turn_context.as_ref()),
         parallel_tool_calls: turn_context.model_info.supports_parallel_tool_calls,
         base_instructions,
         personality: turn_context.personality,

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -945,21 +945,7 @@ pub(crate) fn build_prompt(
     turn_context: &TurnContext,
     base_instructions: BaseInstructions,
 ) -> Prompt {
-    let deferred_dynamic_tools = turn_context
-        .dynamic_tools
-        .iter()
-        .filter(|tool| tool.defer_loading)
-        .map(|tool| ToolName::new(tool.namespace.clone(), tool.name.clone()))
-        .collect::<HashSet<_>>();
-    let tools = if deferred_dynamic_tools.is_empty() {
-        router.model_visible_specs()
-    } else {
-        router
-            .model_visible_specs()
-            .into_iter()
-            .filter_map(|spec| filter_deferred_dynamic_tool_spec(spec, &deferred_dynamic_tools))
-            .collect()
-    };
+    let tools = model_visible_specs_for_prompt(router, turn_context);
 
     Prompt {
         input,
@@ -971,6 +957,36 @@ pub(crate) fn build_prompt(
         output_schema_strict: !crate::guardian::is_guardian_reviewer_source(
             &turn_context.session_source,
         ),
+    }
+}
+
+pub(crate) fn model_visible_specs_for_prompt(
+    router: &ToolRouter,
+    turn_context: &TurnContext,
+) -> Vec<ToolSpec> {
+    filter_deferred_dynamic_tool_specs(
+        router.model_visible_specs(),
+        turn_context.dynamic_tools.as_slice(),
+    )
+}
+
+fn filter_deferred_dynamic_tool_specs(
+    specs: Vec<ToolSpec>,
+    dynamic_tools: &[codex_protocol::dynamic_tools::DynamicToolSpec],
+) -> Vec<ToolSpec> {
+    let deferred_dynamic_tools = dynamic_tools
+        .iter()
+        .filter(|tool| tool.defer_loading)
+        .map(|tool| ToolName::new(tool.namespace.clone(), tool.name.clone()))
+        .collect::<HashSet<_>>();
+
+    if deferred_dynamic_tools.is_empty() {
+        specs
+    } else {
+        specs
+            .into_iter()
+            .filter_map(|spec| filter_deferred_dynamic_tool_spec(spec, &deferred_dynamic_tools))
+            .collect()
     }
 }
 
@@ -1000,6 +1016,99 @@ fn filter_deferred_dynamic_tool_spec(
             }
         }
         spec => Some(spec),
+    }
+}
+
+#[cfg(test)]
+mod prompt_tool_filter_tests {
+    use super::*;
+    use codex_protocol::dynamic_tools::DynamicToolSpec;
+    use codex_tools::AdditionalProperties;
+    use codex_tools::JsonSchema;
+    use codex_tools::ResponsesApiNamespace;
+    use codex_tools::ResponsesApiTool;
+    use serde_json::json;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn filters_deferred_dynamic_tools_from_prompt_specs() {
+        let dynamic_tools = vec![DynamicToolSpec {
+            namespace: Some("codex_app".to_string()),
+            name: "automation_update".to_string(),
+            description: "Create, update, view, or delete recurring automations.".to_string(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "mode": { "type": "string" },
+                },
+                "required": ["mode"],
+                "additionalProperties": false,
+            }),
+            defer_loading: true,
+        }];
+        let specs = vec![
+            ToolSpec::ToolSearch {
+                execution: "sync".to_string(),
+                description: "Search deferred tools".to_string(),
+                parameters: object_schema(),
+            },
+            ToolSpec::Namespace(ResponsesApiNamespace {
+                name: "codex_app".to_string(),
+                description: "Tools in the codex_app namespace.".to_string(),
+                tools: vec![
+                    ResponsesApiNamespaceTool::Function(function_tool(
+                        "automation_update",
+                        Some(true),
+                    )),
+                    ResponsesApiNamespaceTool::Function(function_tool(
+                        "visible_tool",
+                        /*defer_loading*/ None,
+                    )),
+                ],
+            }),
+            ToolSpec::Function(function_tool("plain_tool", /*defer_loading*/ None)),
+        ];
+
+        let filtered = filter_deferred_dynamic_tool_specs(specs, &dynamic_tools);
+
+        assert_eq!(
+            filtered,
+            vec![
+                ToolSpec::ToolSearch {
+                    execution: "sync".to_string(),
+                    description: "Search deferred tools".to_string(),
+                    parameters: object_schema(),
+                },
+                ToolSpec::Namespace(ResponsesApiNamespace {
+                    name: "codex_app".to_string(),
+                    description: "Tools in the codex_app namespace.".to_string(),
+                    tools: vec![ResponsesApiNamespaceTool::Function(function_tool(
+                        "visible_tool",
+                        /*defer_loading*/ None,
+                    ))],
+                }),
+                ToolSpec::Function(function_tool("plain_tool", /*defer_loading*/ None)),
+            ]
+        );
+    }
+
+    fn function_tool(name: &str, defer_loading: Option<bool>) -> ResponsesApiTool {
+        ResponsesApiTool {
+            name: name.to_string(),
+            description: format!("{name} description"),
+            strict: false,
+            defer_loading,
+            parameters: object_schema(),
+            output_schema: None,
+        }
+    }
+
+    fn object_schema() -> JsonSchema {
+        JsonSchema::object(
+            BTreeMap::new(),
+            /*required*/ None,
+            Some(AdditionalProperties::Boolean(false)),
+        )
     }
 }
 


### PR DESCRIPTION
Remote compaction was rebuilding its compact prompt with the raw model-visible tool list, while normal model turns first remove any dynamic tool specs marked for deferred loading. After tool discovery started enabling deferred dynamic tools more often, compact requests could carry `defer_loading` entries into a compact path that may not preserve the paired top-level `tool_search` tool, producing the `tools.defer_loading requires tools.tool_search` failure at compaction time.

This moves the normal-turn prompt filtering into a shared helper and uses it when remote compaction builds its prompt. The compact request now sees the same model-visible tool set as an ordinary turn: `tool_search` remains available for discovery, and deferred dynamic tool definitions are kept out of the prompt until searched for.

I smoke-tested the API contract against the real compact endpoint using the exact Codex App dynamic tool introduced in openai/openai#849632: `codex_app::automation_update` with `deferLoading: true`, alongside the app's other dynamic tools. A compact request that included the deferred `automation_update` tool but no top-level `tool_search` failed with the reported 400: `Invalid Value: 'tools.defer_loading'. Deferred tools require tools.tool_search.` The same request shape after filtering out deferred dynamic tool definitions returned 200 with a compacted `message` and `compaction_summary`.

As a control, the live endpoint currently accepts the raw tool list when `tool_search` is present. The bug is the fragile coupling: if `defer_loading` survives into any compact request shape where `tool_search` is absent, compaction hard-fails before model work starts. Matching normal-turn filtering removes that failure mode entirely.

Fixes #19486.
