### PR TITLE
disallow fileparams metadata for custom mcps

### DIFF
--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -1206,11 +1206,9 @@ fn openai_file_input_params_for_server(
     server: &str,
     meta: Option<&serde_json::Map<String, serde_json::Value>>,
 ) -> Option<Vec<String>> {
-    if server != CODEX_APPS_MCP_SERVER_NAME {
-        return None;
-    }
-
-    Some(declared_openai_file_input_param_names(meta)).filter(|params| !params.is_empty())
+    (server == CODEX_APPS_MCP_SERVER_NAME)
+        .then_some(declared_openai_file_input_param_names(meta))
+        .filter(|params| !params.is_empty())
 }
 
 fn get_mcp_app_resource_uri(

--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -1194,11 +1194,22 @@ pub(crate) async fn lookup_mcp_tool_metadata(
             .and_then(|meta| meta.get(MCP_TOOL_CODEX_APPS_META_KEY))
             .and_then(serde_json::Value::as_object)
             .cloned(),
-        openai_file_input_params: Some(declared_openai_file_input_param_names(
+        openai_file_input_params: openai_file_input_params_for_server(
+            server,
             tool_info.tool.meta.as_deref(),
-        ))
-        .filter(|params| !params.is_empty()),
+        ),
     })
+}
+
+fn openai_file_input_params_for_server(
+    server: &str,
+    meta: Option<&serde_json::Map<String, serde_json::Value>>,
+) -> Option<Vec<String>> {
+    if server != CODEX_APPS_MCP_SERVER_NAME {
+        return None;
+    }
+
+    Some(declared_openai_file_input_param_names(meta)).filter(|params| !params.is_empty())
 }
 
 fn get_mcp_app_resource_uri(

--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -1194,6 +1194,7 @@ pub(crate) async fn lookup_mcp_tool_metadata(
             .and_then(|meta| meta.get(MCP_TOOL_CODEX_APPS_META_KEY))
             .and_then(serde_json::Value::as_object)
             .cloned(),
+        // Disallow custom MCPs from uploading files via fileParams.
         openai_file_input_params: openai_file_input_params_for_server(
             server,
             tool_info.tool.meta.as_deref(),

--- a/codex-rs/core/src/mcp_tool_call_tests.rs
+++ b/codex-rs/core/src/mcp_tool_call_tests.rs
@@ -184,6 +184,23 @@ fn mcp_app_resource_uri_reads_known_tool_meta_keys() {
 }
 
 #[test]
+fn openai_file_params_are_only_honored_for_codex_apps() {
+    let meta = serde_json::json!({
+        "openai/fileParams": ["file"],
+    });
+    let meta = meta.as_object();
+
+    assert_eq!(
+        openai_file_input_params_for_server(CODEX_APPS_MCP_SERVER_NAME, meta),
+        Some(vec!["file".to_string()])
+    );
+    assert_eq!(
+        openai_file_input_params_for_server("minimaltest", meta),
+        None
+    );
+}
+
+#[test]
 fn approval_required_when_read_only_false_and_destructive() {
     let annotations = annotations(Some(false), Some(true), /*open_world*/ None);
     assert_eq!(requires_mcp_tool_approval(Some(&annotations)), true);


### PR DESCRIPTION
## Summary
Disallow fileParams metadata for custom MCPs 

Restricts Codex openai/fileParams handling to the first-party codex_apps MCP server. Custom MCP servers may still advertise the metadata, but Codex now ignores it for upload rewriting, preventing non-Apps tools from receiving signed OpenAI file refs for local paths. Added a regression test for the allowed and denied cases.