### PR TITLE
ci: pin npm staging smoke test to a recent rust-release run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,16 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          # Use a rust-release version that includes all native binaries.
-          CODEX_VERSION=0.115.0
+          # Use a recent successful rust-release run that published the full
+          # cross-platform native payload required by the npm package layout.
+          # Passing the workflow URL directly avoids relying on old rust-v*
+          # branches remaining discoverable via `gh run list --branch ...`.
+          CODEX_VERSION=0.125.0
+          WORKFLOW_URL="https://github.com/openai/codex/actions/runs/24901475298"
           OUTPUT_DIR="${RUNNER_TEMP}"
           python3 ./scripts/stage_npm_packages.py \
             --release-version "$CODEX_VERSION" \
+            --workflow-url "$WORKFLOW_URL" \
             --package codex \
             --output-dir "$OUTPUT_DIR"
           PACK_OUTPUT="${OUTPUT_DIR}/codex-npm-${CODEX_VERSION}.tgz"


### PR DESCRIPTION
## Why

The `build-test` workflow stages a representative `codex` npm tarball by asking `scripts/stage_npm_packages.py` to look up a past `rust-release` run for a hardcoded release version. That started failing in CI because the representative version in `.github/workflows/ci.yml` was stale:

- the workflow was still using `0.115.0`
- `stage_npm_packages.py` resolves native artifacts by looking for a `rust-release` run on the `rust-v<version>` branch
- that lookup no longer found a matching run for `rust-v0.115.0`, so the smoke test failed before it could stage the package

This PR makes that smoke test depend on a known-good recent release run instead of an older branch lookup that is no longer reliable.

## What Changed

- Updated the representative release version in `.github/workflows/ci.yml` from `0.115.0` to `0.125.0`.
- Added an explicit `WORKFLOW_URL` pointing at a recent successful `rust-release` run: `https://github.com/openai/codex/actions/runs/24901475298`.
- Passed that URL to `scripts/stage_npm_packages.py` via `--workflow-url` so the job can reuse the expected native artifacts directly instead of relying on `gh run list --branch rust-v<version>` to discover them.

That keeps the npm staging smoke test representative while making it less sensitive to older release branch history disappearing from the GitHub Actions lookup path.

## Verification

- Inspected the failing CI log from `build-test` and confirmed the failure came from `scripts/stage_npm_packages.py` being unable to resolve `rust-v0.115.0`.
- Confirmed that `https://github.com/openai/codex/actions/runs/24901475298` is a successful `rust-release` run for `rust-v0.125.0`.
