### PR TITLE
[codex] Shard exec Bazel integration test

### DIFF
--- a/codex-rs/exec/BUILD.bazel
+++ b/codex-rs/exec/BUILD.bazel
@@ -3,5 +3,8 @@ load("//:defs.bzl", "codex_rust_crate")
 codex_rust_crate(
     name = "exec",
     crate_name = "codex_exec",
+    test_shard_counts = {
+        "exec-all-test": 8,
+    },
     test_tags = ["no-sandbox"],
 )


### PR DESCRIPTION
## Summary

- shard `//codex-rs/exec:exec-all-test` into 8 Bazel shards
- keep the existing `no-sandbox` test tag unchanged

## Why

The Windows Bazel lane has been timing out this aggregated integration test target at the default 300s test timeout. The target runs the combined `codex-rs/exec/tests/all.rs` integration binary; sharding lets Bazel split the Rust test cases across parallel test actions instead of running the whole integration suite as one long action.

## Validation

Not run locally, per the Codex repo workflow for development-phase changes.
