### PR TITLE
[codex-backend] Prefer state git metadata in filtered thread lists

### DIFF
--- a/codex-rs/rollout/src/recorder.rs
+++ b/codex-rs/rollout/src/recorder.rs
@@ -1030,13 +1030,13 @@ fn fill_missing_thread_item_metadata(item: &mut ThreadItem, state_item: ThreadIt
     if item.cwd.is_none() {
         item.cwd = cwd;
     }
-    if item.git_branch.is_none() {
+    if git_branch.is_some() {
         item.git_branch = git_branch;
     }
-    if item.git_sha.is_none() {
+    if git_sha.is_some() {
         item.git_sha = git_sha;
     }
-    if item.git_origin_url.is_none() {
+    if git_origin_url.is_some() {
         item.git_origin_url = git_origin_url;
     }
     if item.source.is_none() {

--- a/codex-rs/rollout/src/recorder_tests.rs
+++ b/codex-rs/rollout/src/recorder_tests.rs
@@ -779,7 +779,7 @@ async fn list_threads_metadata_filter_overlays_state_db_list_metadata() -> std::
 }
 
 #[test]
-fn fill_missing_thread_item_metadata_preserves_filesystem_identity() {
+fn fill_missing_thread_item_metadata_preserves_identity_and_prefers_state_git_fields() {
     let filesystem_thread_id = ThreadId::new();
     let state_thread_id = ThreadId::new();
     let filesystem_path = PathBuf::from("/tmp/filesystem-rollout.jsonl");
@@ -789,9 +789,9 @@ fn fill_missing_thread_item_metadata_preserves_filesystem_identity() {
         thread_id: Some(filesystem_thread_id),
         first_user_message: Some("filesystem message".to_string()),
         cwd: None,
-        git_branch: None,
-        git_sha: None,
-        git_origin_url: None,
+        git_branch: Some("filesystem-branch".to_string()),
+        git_sha: Some("filesystem-sha".to_string()),
+        git_origin_url: Some("https://example.com/filesystem.git".to_string()),
         source: None,
         agent_nickname: None,
         agent_role: None,


### PR DESCRIPTION
### Summary

- `thread/list` filtered filesystem results already overlay state DB metadata, but the existing merge only filled missing git fields.
- Prefer non-null SQLite git metadata over stale non-null rollout values so persisted branch/SHA/origin updates are reflected in filtered thread lists.
- Update the focused merge test to cover stale filesystem git metadata being replaced by state-backed values.

### Testing

now getting expected icons
<img width="426" height="913" alt="Screenshot 2026-04-27 at 1 45 45 PM" src="https://github.com/user-attachments/assets/027fb7e7-f54d-4353-8423-cb76f3c8f5ac" />

