### PR TITLE
Add MCP app feature flag

### DIFF
--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -400,6 +400,9 @@
             "enable_fanout": {
               "type": "boolean"
             },
+            "enable_mcp_apps": {
+              "type": "boolean"
+            },
             "enable_request_compression": {
               "type": "boolean"
             },
@@ -2605,6 +2608,9 @@
           "type": "boolean"
         },
         "enable_fanout": {
+          "type": "boolean"
+        },
+        "enable_mcp_apps": {
           "type": "boolean"
         },
         "enable_request_compression": {

--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -146,6 +146,8 @@ pub enum Feature {
     SpawnCsv,
     /// Enable apps.
     Apps,
+    /// Enable MCP apps.
+    EnableMcpApps,
     /// Enable the tool_search tool for apps.
     ToolSearch,
     /// Always defer MCP tools behind tool_search instead of exposing small sets directly.
@@ -833,6 +835,12 @@ pub const FEATURES: &[FeatureSpec] = &[
         key: "apps",
         stage: Stage::Stable,
         default_enabled: true,
+    },
+    FeatureSpec {
+        id: Feature::EnableMcpApps,
+        key: "enable_mcp_apps",
+        stage: Stage::UnderDevelopment,
+        default_enabled: false,
     },
     FeatureSpec {
         id: Feature::ToolSearch,


### PR DESCRIPTION
## Summary
- Add the `enable_mcp_apps` feature flag to the `codex-features` registry
- Keep it under development and disabled by default

## Testing
- Unit tests for `codex-features` passed
- Formatting passed