### PR TITLE
Clarify PR template invitation requirement

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 # External (non-OpenAI) Pull Request Requirements
 
-Before opening this Pull Request, please read the dedicated "Contributing" markdown file or your PR may be closed:
+External code contributions are by invitation only. Please read the dedicated "Contributing" markdown file for details:
 https://github.com/openai/codex/blob/main/docs/contributing.md
 
 If your PR conforms to our contribution guidelines, replace this text with a detailed and high quality description of your changes.


### PR DESCRIPTION
Addresses #19856

## Summary
- Clarifies that external code contributions are invitation only.
- Points contributors to `docs/contributing.md` for the full policy instead of using the previous warning phrasing.
