### PR TITLE
fix(network-proxy): harden linux proxy bridge helpers

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -2801,6 +2801,7 @@ dependencies = [
  "cc",
  "clap",
  "codex-core",
+ "codex-process-hardening",
  "codex-protocol",
  "codex-sandboxing",
  "codex-utils-absolute-path",

--- a/codex-rs/linux-sandbox/Cargo.toml
+++ b/codex-rs/linux-sandbox/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 clap = { workspace = true, features = ["derive"] }
+codex-process-hardening = { workspace = true }
 codex-protocol = { workspace = true }
 codex-sandboxing = { workspace = true }
 codex-utils-absolute-path = { workspace = true }

--- a/codex-rs/linux-sandbox/src/landlock.rs
+++ b/codex-rs/linux-sandbox/src/landlock.rs
@@ -176,6 +176,8 @@ fn install_network_seccomp_filter_on_current_thread(
     let mut rules: BTreeMap<i64, Vec<SeccompRule>> = BTreeMap::new();
 
     deny_syscall(&mut rules, libc::SYS_ptrace);
+    deny_syscall(&mut rules, libc::SYS_process_vm_readv);
+    deny_syscall(&mut rules, libc::SYS_process_vm_writev);
     deny_syscall(&mut rules, libc::SYS_io_uring_setup);
     deny_syscall(&mut rules, libc::SYS_io_uring_enter);
     deny_syscall(&mut rules, libc::SYS_io_uring_register);

--- a/codex-rs/linux-sandbox/src/proxy_routing.rs
+++ b/codex-rs/linux-sandbox/src/proxy_routing.rs
@@ -450,7 +450,7 @@ fn spawn_host_bridge(endpoint: SocketAddr, uds_path: &Path) -> io::Result<libc::
 }
 
 fn run_host_bridge(endpoint: SocketAddr, uds_path: &Path, ready_fd: libc::c_int) -> io::Result<()> {
-    set_parent_death_signal()?;
+    harden_bridge_process()?;
     if uds_path.exists() {
         std::fs::remove_file(uds_path)?;
     }
@@ -501,7 +501,7 @@ fn spawn_local_bridge(uds_path: &Path) -> io::Result<u16> {
 }
 
 fn run_local_bridge(uds_path: &Path, ready_fd: libc::c_int) -> io::Result<()> {
-    set_parent_death_signal()?;
+    harden_bridge_process()?;
     let listener = bind_local_loopback_listener()?;
     let port = listener.local_addr()?.port();
 
@@ -609,6 +609,20 @@ fn set_parent_death_signal() -> io::Result<()> {
         Err(io::Error::last_os_error())
     } else if unsafe { libc::getppid() } == 1 {
         Err(io::Error::other("parent process already exited"))
+    } else {
+        Ok(())
+    }
+}
+
+fn harden_bridge_process() -> io::Result<()> {
+    set_parent_death_signal()?;
+    disable_process_dumping()
+}
+
+fn disable_process_dumping() -> io::Result<()> {
+    let res = unsafe { libc::prctl(libc::PR_SET_DUMPABLE, 0, 0, 0, 0) };
+    if res != 0 {
+        Err(io::Error::last_os_error())
     } else {
         Ok(())
     }

--- a/codex-rs/linux-sandbox/src/proxy_routing.rs
+++ b/codex-rs/linux-sandbox/src/proxy_routing.rs
@@ -616,16 +616,7 @@ fn set_parent_death_signal() -> io::Result<()> {
 
 fn harden_bridge_process() -> io::Result<()> {
     set_parent_death_signal()?;
-    disable_process_dumping()
-}
-
-fn disable_process_dumping() -> io::Result<()> {
-    let res = unsafe { libc::prctl(libc::PR_SET_DUMPABLE, 0, 0, 0, 0) };
-    if res != 0 {
-        Err(io::Error::last_os_error())
-    } else {
-        Ok(())
-    }
+    codex_process_hardening::disable_process_dumping()
 }
 
 fn proxy_bidirectional(mut tcp_stream: TcpStream, mut unix_stream: UnixStream) -> io::Result<()> {

--- a/codex-rs/process-hardening/src/lib.rs
+++ b/codex-rs/process-hardening/src/lib.rs
@@ -44,8 +44,12 @@ const SET_RLIMIT_CORE_FAILED_EXIT_CODE: i32 = 7;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub(crate) fn pre_main_hardening_linux() {
     // Disable ptrace attach / mark process non-dumpable.
-    if let Err(err) = disable_process_dumping() {
-        eprintln!("ERROR: prctl(PR_SET_DUMPABLE, 0) failed: {}", err);
+    let ret_code = unsafe { libc::prctl(libc::PR_SET_DUMPABLE, 0, 0, 0, 0) };
+    if ret_code != 0 {
+        eprintln!(
+            "ERROR: prctl(PR_SET_DUMPABLE, 0) failed: {}",
+            std::io::Error::last_os_error()
+        );
         std::process::exit(PRCTL_FAILED_EXIT_CODE);
     }
 
@@ -58,7 +62,7 @@ pub(crate) fn pre_main_hardening_linux() {
 }
 
 /// Mark the current Linux process non-dumpable so same-user processes cannot attach with ptrace.
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(target_os = "linux")]
 pub fn disable_process_dumping() -> std::io::Result<()> {
     let ret_code = unsafe { libc::prctl(libc::PR_SET_DUMPABLE, 0, 0, 0, 0) };
     if ret_code == 0 {

--- a/codex-rs/process-hardening/src/lib.rs
+++ b/codex-rs/process-hardening/src/lib.rs
@@ -44,12 +44,8 @@ const SET_RLIMIT_CORE_FAILED_EXIT_CODE: i32 = 7;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub(crate) fn pre_main_hardening_linux() {
     // Disable ptrace attach / mark process non-dumpable.
-    let ret_code = unsafe { libc::prctl(libc::PR_SET_DUMPABLE, 0, 0, 0, 0) };
-    if ret_code != 0 {
-        eprintln!(
-            "ERROR: prctl(PR_SET_DUMPABLE, 0) failed: {}",
-            std::io::Error::last_os_error()
-        );
+    if let Err(err) = disable_process_dumping() {
+        eprintln!("ERROR: prctl(PR_SET_DUMPABLE, 0) failed: {}", err);
         std::process::exit(PRCTL_FAILED_EXIT_CODE);
     }
 
@@ -59,6 +55,17 @@ pub(crate) fn pre_main_hardening_linux() {
     // Official Codex releases are MUSL-linked, which means that variables such
     // as LD_PRELOAD are ignored anyway, but just to be sure, clear them here.
     remove_env_vars_with_prefix(b"LD_");
+}
+
+/// Mark the current Linux process non-dumpable so same-user processes cannot attach with ptrace.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub fn disable_process_dumping() -> std::io::Result<()> {
+    let ret_code = unsafe { libc::prctl(libc::PR_SET_DUMPABLE, 0, 0, 0, 0) };
+    if ret_code == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
 }
 
 #[cfg(any(target_os = "freebsd", target_os = "openbsd"))]


### PR DESCRIPTION
## Why
The Linux managed-proxy bridge helpers are long-lived child processes in the sandbox networking path. Before this change they stayed dumpable and the network seccomp profile did not block cross-process memory syscalls, so another same-user process could potentially inspect or modify bridge memory instead of interacting only through the intended proxy interface.

## What changed
- reuse the shared `codex-process-hardening` helper to mark bridge helper children non-dumpable before they begin serving
- deny `process_vm_readv` and `process_vm_writev` in the existing network seccomp filter

## Security impact
Bridge helpers are less exposed to same-user cross-process inspection or memory writes, which reduces the chance that sandboxed code can interfere with proxy support processes outside the intended IPC path.

## Verification
- `cargo test -p codex-process-hardening`
- `cargo test -p codex-linux-sandbox`
- attempted `cargo check -p codex-linux-sandbox --target x86_64-unknown-linux-gnu`; blocked on missing `x86_64-linux-gnu-gcc` on this macOS host
