### PR TITLE
fix(network-proxy): tighten network proxy bypass defaults

### DIFF
--- a/codex-rs/network-proxy/src/proxy.rs
+++ b/codex-rs/network-proxy/src/proxy.rs
@@ -422,7 +422,6 @@ pub const NO_PROXY_ENV_KEYS: &[&str] = &[
 
 pub const DEFAULT_NO_PROXY_VALUE: &str = concat!(
     "localhost,127.0.0.1,::1,",
-    "169.254.0.0/16,",
     "10.0.0.0/8,",
     "172.16.0.0/12,",
     "192.168.0.0/16"
@@ -1009,7 +1008,7 @@ mod tests {
         assert!(no_proxy.contains("10.0.0.0/8"));
         assert!(no_proxy.contains("172.16.0.0/12"));
         assert!(no_proxy.contains("192.168.0.0/16"));
-        assert!(no_proxy.contains("169.254.0.0/16"));
+        assert!(!no_proxy.contains("169.254.0.0/16"));
         assert_eq!(env.get(PROXY_ACTIVE_ENV_KEY), Some(&"1".to_string()));
         assert_eq!(env.get(ALLOW_LOCAL_BINDING_ENV_KEY), Some(&"0".to_string()));
         assert_eq!(


### PR DESCRIPTION
## Why
Managed sessions use `NO_PROXY` to keep a small set of destinations on the direct path by default. The old default also bypassed all IPv4 link-local addresses in `169.254.0.0/16`, which includes metadata endpoints such as `169.254.169.254`. Because `NO_PROXY` is evaluated by the client before the request reaches the managed proxy, requests to that range could skip proxy-side allowlist and local-binding checks entirely. On hosts where a link-local metadata service is reachable, that creates a path to sensitive environment metadata or credentials outside the intended enforcement point.

## What changed
- remove the default IPv4 link-local `169.254.0.0/16` bypass from the managed proxy environment
- keep the existing loopback and private-network defaults unchanged
- update the regression assertion to lock in the narrower default

## Security impact
Link-local requests now stay on the managed-proxy path by default, so the proxy can apply configured policy before they reach metadata-style endpoints or other link-local services.

## Verification
- `cargo test -p codex-network-proxy`
