### PR TITLE
core tests: submit turns with permission profiles

### DIFF
--- a/codex-rs/core/tests/common/test_codex.rs
+++ b/codex-rs/core/tests/common/test_codex.rs
@@ -28,6 +28,7 @@ use codex_model_provider_info::built_in_model_providers;
 use codex_models_manager::bundled_models_response;
 use codex_models_manager::collaboration_mode_presets::CollaborationModesConfig;
 use codex_protocol::config_types::ServiceTier;
+use codex_protocol::models::PermissionProfile;
 use codex_protocol::openai_models::ModelsResponse;
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::EventMsg;
@@ -591,10 +592,19 @@ impl TestCodex {
     }
 
     pub async fn submit_turn(&self, prompt: &str) -> Result<()> {
-        self.submit_turn_with_policies(
+        self.submit_turn_with_permission_profile(prompt, PermissionProfile::Disabled)
+            .await
+    }
+
+    pub async fn submit_turn_with_permission_profile(
+        &self,
+        prompt: &str,
+        permission_profile: PermissionProfile,
+    ) -> Result<()> {
+        self.submit_turn_with_approval_and_permission_profile(
             prompt,
             AskForApproval::Never,
-            SandboxPolicy::DangerFullAccess,
+            permission_profile,
         )
         .await
     }
@@ -613,10 +623,10 @@ impl TestCodex {
         prompt: &str,
         service_tier: Option<ServiceTier>,
     ) -> Result<()> {
-        self.submit_turn_with_context(
+        self.submit_turn_with_permission_profile_context(
             prompt,
             AskForApproval::Never,
-            SandboxPolicy::DangerFullAccess,
+            PermissionProfile::Disabled,
             Some(service_tier),
             /*environments*/ None,
         )
@@ -629,10 +639,30 @@ impl TestCodex {
         approval_policy: AskForApproval,
         sandbox_policy: SandboxPolicy,
     ) -> Result<()> {
+        let permission_profile = PermissionProfile::from_legacy_sandbox_policy_for_cwd(
+            &sandbox_policy,
+            self.config.cwd.as_path(),
+        );
         self.submit_turn_with_context(
             prompt,
             approval_policy,
-            sandbox_policy,
+            permission_profile,
+            /*service_tier*/ None,
+            /*environments*/ None,
+        )
+        .await
+    }
+
+    pub async fn submit_turn_with_approval_and_permission_profile(
+        &self,
+        prompt: &str,
+        approval_policy: AskForApproval,
+        permission_profile: PermissionProfile,
+    ) -> Result<()> {
+        self.submit_turn_with_permission_profile_context(
+            prompt,
+            approval_policy,
+            permission_profile,
             /*service_tier*/ None,
             /*environments*/ None,
         )
@@ -644,11 +674,29 @@ impl TestCodex {
         prompt: &str,
         environments: Option<Vec<TurnEnvironmentSelection>>,
     ) -> Result<()> {
-        self.submit_turn_with_context(
+        self.submit_turn_with_permission_profile_context(
             prompt,
             AskForApproval::Never,
-            SandboxPolicy::DangerFullAccess,
+            PermissionProfile::Disabled,
             /*service_tier*/ None,
+            environments,
+        )
+        .await
+    }
+
+    async fn submit_turn_with_permission_profile_context(
+        &self,
+        prompt: &str,
+        approval_policy: AskForApproval,
+        permission_profile: PermissionProfile,
+        service_tier: Option<Option<ServiceTier>>,
+        environments: Option<Vec<TurnEnvironmentSelection>>,
+    ) -> Result<()> {
+        self.submit_turn_with_context(
+            prompt,
+            approval_policy,
+            permission_profile,
+            service_tier,
             environments,
         )
         .await
@@ -658,10 +706,13 @@ impl TestCodex {
         &self,
         prompt: &str,
         approval_policy: AskForApproval,
-        sandbox_policy: SandboxPolicy,
+        permission_profile: PermissionProfile,
         service_tier: Option<Option<ServiceTier>>,
         environments: Option<Vec<TurnEnvironmentSelection>>,
     ) -> Result<()> {
+        let sandbox_policy = permission_profile
+            .to_legacy_sandbox_policy(self.config.cwd.as_path())
+            .unwrap_or_else(|_| SandboxPolicy::new_read_only_policy());
         let session_model = self.session_configured.model.clone();
         self.codex
             .submit(Op::UserTurn {
@@ -675,7 +726,7 @@ impl TestCodex {
                 approval_policy,
                 approvals_reviewer: None,
                 sandbox_policy,
-                permission_profile: None,
+                permission_profile: Some(permission_profile),
                 model: session_model,
                 effort: None,
                 summary: None,
@@ -832,6 +883,16 @@ impl TestCodexHarness {
     ) -> Result<()> {
         self.test
             .submit_turn_with_policy(prompt, sandbox_policy)
+            .await
+    }
+
+    pub async fn submit_with_permission_profile(
+        &self,
+        prompt: &str,
+        permission_profile: PermissionProfile,
+    ) -> Result<()> {
+        self.test
+            .submit_turn_with_permission_profile(prompt, permission_profile)
             .await
     }
 

--- a/codex-rs/core/tests/suite/openai_file_mcp.rs
+++ b/codex-rs/core/tests/suite/openai_file_mcp.rs
@@ -8,8 +8,8 @@ use anyhow::Result;
 use codex_core::config::Config;
 use codex_features::Feature;
 use codex_login::CodexAuth;
+use codex_protocol::models::PermissionProfile;
 use codex_protocol::protocol::AskForApproval;
-use codex_protocol::protocol::SandboxPolicy;
 use core_test_support::apps_test_server::AppsTestServer;
 use core_test_support::apps_test_server::DOCUMENT_EXTRACT_TEXT_RESOURCE_URI;
 use core_test_support::responses::ev_assistant_message;
@@ -169,10 +169,10 @@ async fn codex_apps_file_params_upload_local_paths_before_mcp_tool_call() -> Res
     let test = builder.build(&server).await?;
     tokio::fs::write(test.cwd.path().join("report.txt"), b"hello world").await?;
 
-    test.submit_turn_with_policies(
+    test.submit_turn_with_approval_and_permission_profile(
         "Extract the report text with the app tool.",
         AskForApproval::Never,
-        SandboxPolicy::DangerFullAccess,
+        PermissionProfile::Disabled,
     )
     .await?;
 

--- a/codex-rs/core/tests/suite/search_tool.rs
+++ b/codex-rs/core/tests/suite/search_tool.rs
@@ -12,11 +12,11 @@ use codex_protocol::dynamic_tools::DynamicToolCallOutputContentItem;
 use codex_protocol::dynamic_tools::DynamicToolResponse;
 use codex_protocol::dynamic_tools::DynamicToolSpec;
 use codex_protocol::models::FunctionCallOutputPayload;
+use codex_protocol::models::PermissionProfile;
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::McpInvocation;
 use codex_protocol::protocol::Op;
-use codex_protocol::protocol::SandboxPolicy;
 use codex_protocol::user_input::UserInput;
 use core_test_support::apps_test_server::AppsTestServer;
 use core_test_support::apps_test_server::CALENDAR_CREATE_EVENT_MCP_APP_RESOURCE_URI;
@@ -157,10 +157,10 @@ async fn search_tool_enabled_by_default_adds_tool_search() -> Result<()> {
     let mut builder = configured_builder(apps_server.chatgpt_base_url.clone());
     let test = builder.build(&server).await?;
 
-    test.submit_turn_with_policies(
+    test.submit_turn_with_approval_and_permission_profile(
         "list tools",
         AskForApproval::Never,
-        SandboxPolicy::DangerFullAccess,
+        PermissionProfile::Disabled,
     )
     .await?;
 
@@ -221,10 +221,10 @@ async fn always_defer_feature_hides_small_app_tool_sets() -> Result<()> {
         });
     let test = builder.build(&server).await?;
 
-    test.submit_turn_with_policies(
+    test.submit_turn_with_approval_and_permission_profile(
         "list tools",
         AskForApproval::Never,
-        SandboxPolicy::DangerFullAccess,
+        PermissionProfile::Disabled,
     )
     .await?;
 
@@ -265,10 +265,10 @@ async fn tool_search_disabled_exposes_apps_tools_directly() -> Result<()> {
         });
     let test = builder.build(&server).await?;
 
-    test.submit_turn_with_policies(
+    test.submit_turn_with_approval_and_permission_profile(
         "list tools",
         AskForApproval::Never,
-        SandboxPolicy::DangerFullAccess,
+        PermissionProfile::Disabled,
     )
     .await?;
 
@@ -311,10 +311,10 @@ async fn search_tool_is_hidden_for_api_key_auth() -> Result<()> {
         .with_config(move |config| configure_apps(config, apps_server.chatgpt_base_url.as_str()));
     let test = builder.build(&server).await?;
 
-    test.submit_turn_with_policies(
+    test.submit_turn_with_approval_and_permission_profile(
         "list tools",
         AskForApproval::Never,
-        SandboxPolicy::DangerFullAccess,
+        PermissionProfile::Disabled,
     )
     .await?;
 
@@ -347,10 +347,10 @@ async fn search_tool_adds_discovery_instructions_to_tool_description() -> Result
     let mut builder = configured_builder(apps_server.chatgpt_base_url.clone());
     let test = builder.build(&server).await?;
 
-    test.submit_turn_with_policies(
+    test.submit_turn_with_approval_and_permission_profile(
         "list tools",
         AskForApproval::Never,
-        SandboxPolicy::DangerFullAccess,
+        PermissionProfile::Disabled,
     )
     .await?;
 
@@ -389,10 +389,10 @@ async fn search_tool_hides_apps_tools_without_search() -> Result<()> {
     let mut builder = configured_builder(apps_server.chatgpt_base_url.clone());
     let test = builder.build(&server).await?;
 
-    test.submit_turn_with_policies(
+    test.submit_turn_with_approval_and_permission_profile(
         "hello tools",
         AskForApproval::Never,
-        SandboxPolicy::DangerFullAccess,
+        PermissionProfile::Disabled,
     )
     .await?;
 
@@ -425,10 +425,10 @@ async fn explicit_app_mentions_expose_apps_tools_without_search() -> Result<()> 
     let mut builder = configured_builder(apps_server.chatgpt_base_url.clone());
     let test = builder.build(&server).await?;
 
-    test.submit_turn_with_policies(
+    test.submit_turn_with_approval_and_permission_profile(
         "Use [$calendar](app://calendar) and then call tools.",
         AskForApproval::Never,
-        SandboxPolicy::DangerFullAccess,
+        PermissionProfile::Disabled,
     )
     .await?;
 
@@ -978,10 +978,10 @@ async fn tool_search_indexes_only_enabled_non_app_mcp_tools() -> Result<()> {
         });
     let test = builder.build(&server).await?;
 
-    test.submit_turn_with_policies(
+    test.submit_turn_with_approval_and_permission_profile(
         "Find the rmcp echo and image tools.",
         AskForApproval::Never,
-        SandboxPolicy::DangerFullAccess,
+        PermissionProfile::Disabled,
     )
     .await?;
 

--- a/codex-rs/core/tests/suite/shell_serialization.rs
+++ b/codex-rs/core/tests/suite/shell_serialization.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::expect_used)]
 
 use anyhow::Result;
-use codex_protocol::protocol::SandboxPolicy;
+use codex_protocol::models::PermissionProfile;
 use core_test_support::assert_regex_match;
 use core_test_support::responses::ev_assistant_message;
 use core_test_support::responses::ev_completed;
@@ -136,9 +136,9 @@ async fn shell_output_stays_json_without_freeform_apply_patch(
     let responses = shell_responses(call_id, vec!["/bin/echo", "shell json"], output_type)?;
     let mock = mount_sse_sequence(&server, responses).await;
 
-    test.submit_turn_with_policy(
+    test.submit_turn_with_permission_profile(
         "run the json shell command",
-        SandboxPolicy::DangerFullAccess,
+        PermissionProfile::Disabled,
     )
     .await?;
 
@@ -192,9 +192,9 @@ async fn shell_output_is_structured_with_freeform_apply_patch(
     let responses = shell_responses(call_id, vec!["/bin/echo", "freeform shell"], output_type)?;
     let mock = mount_sse_sequence(&server, responses).await;
 
-    test.submit_turn_with_policy(
+    test.submit_turn_with_permission_profile(
         "run the structured shell command",
-        SandboxPolicy::DangerFullAccess,
+        PermissionProfile::Disabled,
     )
     .await?;
 
@@ -249,9 +249,9 @@ async fn shell_output_preserves_fixture_json_without_serialization(
     )?;
     let mock = mount_sse_sequence(&server, responses).await;
 
-    test.submit_turn_with_policy(
+    test.submit_turn_with_permission_profile(
         "read the fixture JSON with sed",
-        SandboxPolicy::DangerFullAccess,
+        PermissionProfile::Disabled,
     )
     .await?;
 
@@ -317,9 +317,9 @@ async fn shell_output_structures_fixture_with_serialization(
     )?;
     let mock = mount_sse_sequence(&server, responses).await;
 
-    test.submit_turn_with_policy(
+    test.submit_turn_with_permission_profile(
         "read the fixture JSON with structured output",
-        SandboxPolicy::DangerFullAccess,
+        PermissionProfile::Disabled,
     )
     .await?;
 
@@ -372,9 +372,9 @@ async fn shell_output_for_freeform_tool_records_duration(
     let responses = shell_responses(call_id, vec!["/bin/sh", "-c", "sleep 0.2"], output_type)?;
     let mock = mount_sse_sequence(&server, responses).await;
 
-    test.submit_turn_with_policy(
+    test.submit_turn_with_permission_profile(
         "run the structured shell command",
-        SandboxPolicy::DangerFullAccess,
+        PermissionProfile::Disabled,
     )
     .await?;
 
@@ -429,9 +429,9 @@ async fn shell_output_reserializes_truncated_content(output_type: ShellModelOutp
     let responses = shell_responses(call_id, vec!["/bin/sh", "-c", "seq 1 400"], output_type)?;
     let mock = mount_sse_sequence(&server, responses).await;
 
-    test.submit_turn_with_policy(
+    test.submit_turn_with_permission_profile(
         "run the truncation shell command",
-        SandboxPolicy::DangerFullAccess,
+        PermissionProfile::Disabled,
     )
     .await?;
 
@@ -495,9 +495,9 @@ async fn apply_patch_custom_tool_output_is_structured(
 
     harness
         .test()
-        .submit_turn_with_policy(
+        .submit_turn_with_permission_profile(
             "apply the patch via custom tool",
-            SandboxPolicy::DangerFullAccess,
+            PermissionProfile::Disabled,
         )
         .await?;
 
@@ -537,9 +537,9 @@ async fn apply_patch_custom_tool_call_creates_file(
 
     harness
         .test()
-        .submit_turn_with_policy(
+        .submit_turn_with_permission_profile(
             "apply the patch via custom tool to create a file",
-            SandboxPolicy::DangerFullAccess,
+            PermissionProfile::Disabled,
         )
         .await?;
 
@@ -593,9 +593,9 @@ async fn apply_patch_custom_tool_call_updates_existing_file(
 
     harness
         .test()
-        .submit_turn_with_policy(
+        .submit_turn_with_permission_profile(
             "apply the patch via custom tool to update a file",
-            SandboxPolicy::DangerFullAccess,
+            PermissionProfile::Disabled,
         )
         .await?;
 
@@ -645,9 +645,9 @@ async fn apply_patch_custom_tool_call_reports_failure_output(
 
     harness
         .test()
-        .submit_turn_with_policy(
+        .submit_turn_with_permission_profile(
             "attempt a failing apply_patch via custom tool",
-            SandboxPolicy::DangerFullAccess,
+            PermissionProfile::Disabled,
         )
         .await?;
 
@@ -688,9 +688,9 @@ async fn apply_patch_function_call_output_is_structured(
     .await;
     harness
         .test()
-        .submit_turn_with_policy(
+        .submit_turn_with_permission_profile(
             "apply the patch via function-call apply_patch",
-            SandboxPolicy::DangerFullAccess,
+            PermissionProfile::Disabled,
         )
         .await?;
 
@@ -727,9 +727,9 @@ async fn shell_output_is_structured_for_nonzero_exit(output_type: ShellModelOutp
     let responses = shell_responses(call_id, vec!["/bin/sh", "-c", "exit 42"], output_type)?;
     let mock = mount_sse_sequence(&server, responses).await;
 
-    test.submit_turn_with_policy(
+    test.submit_turn_with_permission_profile(
         "run the failing shell command",
-        SandboxPolicy::DangerFullAccess,
+        PermissionProfile::Disabled,
     )
     .await?;
 
@@ -778,9 +778,9 @@ async fn shell_command_output_is_freeform() -> Result<()> {
     ];
     let mock = mount_sse_sequence(&server, responses).await;
 
-    test.submit_turn_with_policy(
+    test.submit_turn_with_permission_profile(
         "run the shell_command script in the user's shell",
-        SandboxPolicy::DangerFullAccess,
+        PermissionProfile::Disabled,
     )
     .await?;
 
@@ -830,9 +830,9 @@ async fn shell_command_output_is_not_truncated_under_10k_bytes() -> Result<()> {
     ];
     let mock = mount_sse_sequence(&server, responses).await;
 
-    test.submit_turn_with_policy(
+    test.submit_turn_with_permission_profile(
         "run the shell_command script in the user's shell",
-        SandboxPolicy::DangerFullAccess,
+        PermissionProfile::Disabled,
     )
     .await?;
 
@@ -881,9 +881,9 @@ async fn shell_command_output_is_not_truncated_over_10k_bytes() -> Result<()> {
     ];
     let mock = mount_sse_sequence(&server, responses).await;
 
-    test.submit_turn_with_policy(
+    test.submit_turn_with_permission_profile(
         "run the shell_command script in the user's shell",
-        SandboxPolicy::DangerFullAccess,
+        PermissionProfile::Disabled,
     )
     .await?;
 
@@ -929,9 +929,9 @@ async fn local_shell_call_output_is_structured() -> Result<()> {
     ];
     let mock = mount_sse_sequence(&server, responses).await;
 
-    test.submit_turn_with_policy(
+    test.submit_turn_with_permission_profile(
         "run the local shell command",
-        SandboxPolicy::DangerFullAccess,
+        PermissionProfile::Disabled,
     )
     .await?;
 

--- a/codex-rs/core/tests/suite/tool_suggest.rs
+++ b/codex-rs/core/tests/suite/tool_suggest.rs
@@ -8,8 +8,8 @@ use codex_core::config::Config;
 use codex_features::Feature;
 use codex_login::CodexAuth;
 use codex_models_manager::bundled_models_response;
+use codex_protocol::models::PermissionProfile;
 use codex_protocol::protocol::AskForApproval;
-use codex_protocol::protocol::SandboxPolicy;
 use core_test_support::apps_test_server::AppsTestServer;
 use core_test_support::responses::ev_assistant_message;
 use core_test_support::responses::ev_completed;
@@ -111,10 +111,10 @@ async fn tool_suggest_is_available_without_search_tool_after_discovery_attempts(
         });
     let test = builder.build(&server).await?;
 
-    test.submit_turn_with_policies(
+    test.submit_turn_with_approval_and_permission_profile(
         "list tools",
         AskForApproval::Never,
-        SandboxPolicy::DangerFullAccess,
+        PermissionProfile::Disabled,
     )
     .await?;
 

--- a/codex-rs/core/tests/suite/truncation.rs
+++ b/codex-rs/core/tests/suite/truncation.rs
@@ -5,10 +5,10 @@ use anyhow::Context;
 use anyhow::Result;
 use codex_config::types::McpServerConfig;
 use codex_config::types::McpServerTransportConfig;
+use codex_protocol::models::PermissionProfile;
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::Op;
-use codex_protocol::protocol::SandboxPolicy;
 use codex_protocol::user_input::UserInput;
 use core_test_support::assert_regex_match;
 use core_test_support::responses;
@@ -82,7 +82,10 @@ async fn tool_call_output_configured_limit_chars_type() -> Result<()> {
     .await;
 
     fixture
-        .submit_turn_with_policy("trigger big shell output", SandboxPolicy::DangerFullAccess)
+        .submit_turn_with_permission_profile(
+            "trigger big shell output",
+            PermissionProfile::Disabled,
+        )
         .await?;
 
     // Inspect what we sent back to the model; it should contain a truncated
@@ -156,7 +159,10 @@ async fn tool_call_output_exceeds_limit_truncated_chars_limit() -> Result<()> {
     .await;
 
     fixture
-        .submit_turn_with_policy("trigger big shell output", SandboxPolicy::DangerFullAccess)
+        .submit_turn_with_permission_profile(
+            "trigger big shell output",
+            PermissionProfile::Disabled,
+        )
         .await?;
 
     // Inspect what we sent back to the model; it should contain a truncated
@@ -229,7 +235,10 @@ async fn tool_call_output_exceeds_limit_truncated_for_model() -> Result<()> {
     .await;
 
     fixture
-        .submit_turn_with_policy("trigger big shell output", SandboxPolicy::DangerFullAccess)
+        .submit_turn_with_permission_profile(
+            "trigger big shell output",
+            PermissionProfile::Disabled,
+        )
         .await?;
 
     // Inspect what we sent back to the model; it should contain a truncated
@@ -303,7 +312,10 @@ async fn tool_call_output_truncated_only_once() -> Result<()> {
     .await;
 
     fixture
-        .submit_turn_with_policy("trigger big shell output", SandboxPolicy::DangerFullAccess)
+        .submit_turn_with_permission_profile(
+            "trigger big shell output",
+            PermissionProfile::Disabled,
+        )
         .await?;
 
     let output = mock2
@@ -399,9 +411,9 @@ async fn mcp_tool_call_output_exceeds_limit_truncated_for_model() -> Result<()> 
     let fixture = builder.build(&server).await?;
 
     fixture
-        .submit_turn_with_policy(
+        .submit_turn_with_permission_profile(
             "call the rmcp echo tool with a very large message",
-            SandboxPolicy::new_read_only_policy(),
+            PermissionProfile::read_only(),
         )
         .await?;
 
@@ -496,6 +508,8 @@ async fn mcp_image_output_preserves_image_and_no_text_summary() -> Result<()> {
     });
     let fixture = builder.build(&server).await?;
     let session_model = fixture.session_configured.model.clone();
+    let permission_profile = PermissionProfile::read_only();
+    let sandbox_policy = permission_profile.to_legacy_sandbox_policy(fixture.cwd.path())?;
 
     fixture
         .codex
@@ -509,8 +523,8 @@ async fn mcp_image_output_preserves_image_and_no_text_summary() -> Result<()> {
             cwd: fixture.cwd.path().to_path_buf(),
             approval_policy: AskForApproval::Never,
             approvals_reviewer: None,
-            sandbox_policy: SandboxPolicy::new_read_only_policy(),
-            permission_profile: None,
+            sandbox_policy,
+            permission_profile: Some(permission_profile),
             model: session_model,
             effort: None,
             summary: None,
@@ -577,7 +591,7 @@ async fn token_policy_marker_reports_tokens() -> Result<()> {
     .await;
 
     fixture
-        .submit_turn_with_policy("run the shell tool", SandboxPolicy::DangerFullAccess)
+        .submit_turn_with_permission_profile("run the shell tool", PermissionProfile::Disabled)
         .await?;
 
     let output = done_mock
@@ -628,7 +642,7 @@ async fn byte_policy_marker_reports_bytes() -> Result<()> {
     .await;
 
     fixture
-        .submit_turn_with_policy("run the shell tool", SandboxPolicy::DangerFullAccess)
+        .submit_turn_with_permission_profile("run the shell tool", PermissionProfile::Disabled)
         .await?;
 
     let output = done_mock
@@ -680,9 +694,9 @@ async fn shell_command_output_not_truncated_with_custom_limit() -> Result<()> {
     .await;
 
     fixture
-        .submit_turn_with_policy(
+        .submit_turn_with_permission_profile(
             "run big output without truncation",
-            SandboxPolicy::DangerFullAccess,
+            PermissionProfile::Disabled,
         )
         .await?;
 
@@ -777,9 +791,9 @@ async fn mcp_tool_call_output_not_truncated_with_custom_limit() -> Result<()> {
     let fixture = builder.build(&server).await?;
 
     fixture
-        .submit_turn_with_policy(
+        .submit_turn_with_permission_profile(
             "call the rmcp echo tool with a very large message",
-            SandboxPolicy::new_read_only_policy(),
+            PermissionProfile::read_only(),
         )
         .await?;
 

--- a/codex-rs/core/tests/suite/web_search.rs
+++ b/codex-rs/core/tests/suite/web_search.rs
@@ -2,7 +2,7 @@
 
 use codex_features::Feature;
 use codex_protocol::config_types::WebSearchMode;
-use codex_protocol::protocol::SandboxPolicy;
+use codex_protocol::models::PermissionProfile;
 use core_test_support::responses;
 use core_test_support::responses::start_mock_server;
 use core_test_support::skip_if_no_network;
@@ -44,9 +44,9 @@ async fn web_search_mode_cached_sets_external_web_access_false() {
         .await
         .expect("create test Codex conversation");
 
-    test.submit_turn_with_policy(
+    test.submit_turn_with_permission_profile(
         "hello cached web search",
-        SandboxPolicy::new_read_only_policy(),
+        PermissionProfile::read_only(),
     )
     .await
     .expect("submit turn");
@@ -86,9 +86,9 @@ async fn web_search_mode_takes_precedence_over_legacy_flags() {
         .await
         .expect("create test Codex conversation");
 
-    test.submit_turn_with_policy(
+    test.submit_turn_with_permission_profile(
         "hello cached+live flags",
-        SandboxPolicy::new_read_only_policy(),
+        PermissionProfile::read_only(),
     )
     .await
     .expect("submit turn");
@@ -132,9 +132,9 @@ async fn web_search_mode_defaults_to_cached_when_features_disabled() {
         .await
         .expect("create test Codex conversation");
 
-    test.submit_turn_with_policy(
+    test.submit_turn_with_permission_profile(
         "hello default cached web search",
-        SandboxPolicy::new_read_only_policy(),
+        PermissionProfile::read_only(),
     )
     .await
     .expect("submit turn");
@@ -149,7 +149,7 @@ async fn web_search_mode_defaults_to_cached_when_features_disabled() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn web_search_mode_updates_between_turns_with_sandbox_policy() {
+async fn web_search_mode_updates_between_turns_with_permission_profile() {
     skip_if_no_network!();
 
     let server = start_mock_server().await;
@@ -187,10 +187,10 @@ async fn web_search_mode_updates_between_turns_with_sandbox_policy() {
         .await
         .expect("create test Codex conversation");
 
-    test.submit_turn_with_policy("hello cached", SandboxPolicy::new_read_only_policy())
+    test.submit_turn_with_permission_profile("hello cached", PermissionProfile::read_only())
         .await
         .expect("submit first turn");
-    test.submit_turn_with_policy("hello live", SandboxPolicy::DangerFullAccess)
+    test.submit_turn_with_permission_profile("hello live", PermissionProfile::Disabled)
         .await
         .expect("submit second turn");
 
@@ -248,9 +248,9 @@ location = { country = "US", city = "New York", timezone = "America/New_York" }
         .await
         .expect("create test Codex conversation");
 
-    test.submit_turn_with_policy(
+    test.submit_turn_with_permission_profile(
         "hello configured web search",
-        SandboxPolicy::DangerFullAccess,
+        PermissionProfile::Disabled,
     )
     .await
     .expect("submit turn");

--- a/codex-rs/tui/src/app_command.rs
+++ b/codex-rs/tui/src/app_command.rs
@@ -23,6 +23,8 @@ use codex_protocol::user_input::UserInput;
 use serde::Serialize;
 use serde_json::Value;
 
+use crate::permission_compat::legacy_compatible_permission_profile;
+
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub(crate) struct AppCommand(Op);
 
@@ -148,18 +150,12 @@ impl AppCommand {
         collaboration_mode: Option<CollaborationMode>,
         personality: Option<Personality>,
     ) -> Self {
-        let sandbox_policy = permission_profile
+        let legacy_profile =
+            legacy_compatible_permission_profile(&permission_profile, cwd.as_path());
+        let sandbox_policy = legacy_profile
             .to_legacy_sandbox_policy(cwd.as_path())
             .unwrap_or_else(|err| {
-                tracing::warn!(
-                    %err,
-                    "permission profile cannot be projected to legacy UserTurn sandbox; using read-only compatibility fallback"
-                );
-                PermissionProfile::read_only()
-                    .to_legacy_sandbox_policy(cwd.as_path())
-                    .unwrap_or_else(|err| {
-                        unreachable!("read-only permissions must be legacy-compatible: {err}")
-                    })
+                unreachable!("legacy-compatible permissions must project to legacy policy: {err}")
             });
         Self(Op::UserTurn {
             items,

--- a/codex-rs/tui/src/app_server_session.rs
+++ b/codex-rs/tui/src/app_server_session.rs
@@ -3,6 +3,7 @@ use crate::bottom_pane::FeedbackAudience;
 use crate::legacy_core::append_message_history_entry;
 use crate::legacy_core::config::Config;
 use crate::legacy_core::message_history_metadata;
+use crate::permission_compat::legacy_compatible_permission_profile;
 use crate::status::StatusAccountDisplay;
 use crate::status::plan_type_display_name;
 use codex_app_server_client::AppServerClient;
@@ -542,22 +543,15 @@ impl AppServerSession {
     ) -> Result<TurnStartResponse> {
         let request_id = self.next_request_id();
         let sandbox_policy = if matches!(self.thread_params_mode(), ThreadParamsMode::Remote) {
-            let policy =
-                permission_profile
-                    .to_legacy_sandbox_policy(cwd.as_path())
-                    .unwrap_or_else(|err| {
-                        tracing::warn!(
-                            %err,
-                            "permission profile cannot be projected for remote turn/start; using read-only compatibility fallback"
-                        );
-                        PermissionProfile::read_only()
-                            .to_legacy_sandbox_policy(cwd.as_path())
-                            .unwrap_or_else(|err| {
-                                unreachable!(
-                                    "read-only permissions must be legacy-compatible: {err}"
-                                )
-                            })
-                    });
+            let legacy_profile =
+                legacy_compatible_permission_profile(&permission_profile, cwd.as_path());
+            let policy = legacy_profile
+                .to_legacy_sandbox_policy(cwd.as_path())
+                .unwrap_or_else(|err| {
+                    unreachable!(
+                        "legacy-compatible permissions must project to legacy policy: {err}"
+                    )
+                });
             Some(policy.into())
         } else {
             None
@@ -1514,6 +1508,12 @@ mod tests {
     use codex_app_server_protocol::ThreadStatus;
     use codex_app_server_protocol::Turn;
     use codex_app_server_protocol::TurnStatus;
+    use codex_protocol::models::ManagedFileSystemPermissions;
+    use codex_protocol::permissions::FileSystemAccessMode;
+    use codex_protocol::permissions::FileSystemPath;
+    use codex_protocol::permissions::FileSystemSandboxEntry;
+    use codex_protocol::permissions::FileSystemSpecialPath;
+    use codex_protocol::permissions::NetworkSandboxPolicy;
     use codex_utils_absolute_path::test_support::PathBufExt;
     use codex_utils_absolute_path::test_support::test_path_buf;
     use pretty_assertions::assert_eq;
@@ -1604,6 +1604,65 @@ mod tests {
         assert_eq!(start.permission_profile, None);
         assert_eq!(resume.permission_profile, None);
         assert_eq!(fork.permission_profile, None);
+    }
+
+    #[test]
+    fn sandbox_mode_does_not_project_non_cwd_write_roots_for_remote_sessions() {
+        let cwd = test_path_buf("/workspace/project").abs();
+        let extra_root = test_path_buf("/workspace/cache").abs();
+        let permission_profile = PermissionProfile::Managed {
+            file_system: ManagedFileSystemPermissions::Restricted {
+                entries: vec![
+                    FileSystemSandboxEntry {
+                        path: FileSystemPath::Special {
+                            value: FileSystemSpecialPath::Root,
+                        },
+                        access: FileSystemAccessMode::Read,
+                    },
+                    FileSystemSandboxEntry {
+                        path: FileSystemPath::Path { path: extra_root },
+                        access: FileSystemAccessMode::Write,
+                    },
+                ],
+                glob_scan_max_depth: None,
+            },
+            network: NetworkSandboxPolicy::Restricted,
+        };
+
+        assert_eq!(
+            sandbox_mode_from_permission_profile(&permission_profile, cwd.as_path()),
+            Some(codex_app_server_protocol::SandboxMode::ReadOnly)
+        );
+    }
+
+    #[test]
+    fn sandbox_mode_projects_cwd_write_for_remote_sessions() {
+        let cwd = test_path_buf("/workspace/project").abs();
+        let permission_profile = PermissionProfile::Managed {
+            file_system: ManagedFileSystemPermissions::Restricted {
+                entries: vec![
+                    FileSystemSandboxEntry {
+                        path: FileSystemPath::Special {
+                            value: FileSystemSpecialPath::Root,
+                        },
+                        access: FileSystemAccessMode::Read,
+                    },
+                    FileSystemSandboxEntry {
+                        path: FileSystemPath::Special {
+                            value: FileSystemSpecialPath::ProjectRoots { subpath: None },
+                        },
+                        access: FileSystemAccessMode::Write,
+                    },
+                ],
+                glob_scan_max_depth: None,
+            },
+            network: NetworkSandboxPolicy::Restricted,
+        };
+
+        assert_eq!(
+            sandbox_mode_from_permission_profile(&permission_profile, cwd.as_path()),
+            Some(codex_app_server_protocol::SandboxMode::WorkspaceWrite)
+        );
     }
 
     #[tokio::test]

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -150,6 +150,7 @@ mod npm_registry;
 pub(crate) mod onboarding;
 mod oss_selection;
 mod pager_overlay;
+mod permission_compat;
 pub(crate) mod public_widgets;
 mod render;
 mod resize_reflow_cap;

--- a/codex-rs/tui/src/permission_compat.rs
+++ b/codex-rs/tui/src/permission_compat.rs
@@ -1,0 +1,105 @@
+//! Compatibility projections from the canonical permission profile model into
+//! legacy shapes still required by older or remote app-server APIs.
+
+use codex_protocol::models::PermissionProfile;
+use codex_protocol::permissions::FileSystemSandboxPolicy;
+use codex_protocol::permissions::NetworkSandboxPolicy;
+use codex_utils_absolute_path::AbsolutePathBuf;
+use std::path::Path;
+
+pub(crate) fn legacy_compatible_permission_profile(
+    permission_profile: &PermissionProfile,
+    cwd: &Path,
+) -> PermissionProfile {
+    if permission_profile.to_legacy_sandbox_policy(cwd).is_ok() {
+        return permission_profile.clone();
+    }
+
+    let file_system_policy = permission_profile.file_system_sandbox_policy();
+    compatibility_workspace_write_profile(
+        &file_system_policy,
+        permission_profile.network_sandbox_policy(),
+        cwd,
+    )
+}
+
+fn compatibility_workspace_write_profile(
+    file_system_policy: &FileSystemSandboxPolicy,
+    network_policy: NetworkSandboxPolicy,
+    cwd: &Path,
+) -> PermissionProfile {
+    let cwd_abs = AbsolutePathBuf::from_absolute_path(cwd).ok();
+    let writable_roots = file_system_policy
+        .get_writable_roots_with_cwd(cwd)
+        .into_iter()
+        .map(|root| root.root)
+        .filter(|root| cwd_abs.as_ref() != Some(root))
+        .collect::<Vec<_>>();
+    let tmpdir_writable = std::env::var_os("TMPDIR")
+        .filter(|tmpdir| !tmpdir.is_empty())
+        .and_then(|tmpdir| {
+            AbsolutePathBuf::from_absolute_path(std::path::PathBuf::from(tmpdir)).ok()
+        })
+        .is_some_and(|tmpdir| file_system_policy.can_write_path_with_cwd(tmpdir.as_path(), cwd));
+    let slash_tmp = Path::new("/tmp");
+    let slash_tmp_writable = slash_tmp.is_absolute()
+        && slash_tmp.is_dir()
+        && file_system_policy.can_write_path_with_cwd(slash_tmp, cwd);
+
+    PermissionProfile::workspace_write_with(
+        &writable_roots,
+        network_policy,
+        !tmpdir_writable,
+        !slash_tmp_writable,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codex_protocol::models::ManagedFileSystemPermissions;
+    use codex_protocol::permissions::FileSystemAccessMode;
+    use codex_protocol::permissions::FileSystemPath;
+    use codex_protocol::permissions::FileSystemSandboxEntry;
+    use codex_protocol::permissions::FileSystemSpecialPath;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn compatibility_profile_preserves_unbridgeable_write_roots() {
+        let cwd = AbsolutePathBuf::try_from("/workspace/project").expect("absolute cwd");
+        let extra_root = AbsolutePathBuf::try_from("/workspace/extra").expect("absolute root");
+        let permission_profile = PermissionProfile::Managed {
+            file_system: ManagedFileSystemPermissions::Restricted {
+                entries: vec![
+                    FileSystemSandboxEntry {
+                        path: FileSystemPath::Special {
+                            value: FileSystemSpecialPath::Root,
+                        },
+                        access: FileSystemAccessMode::Read,
+                    },
+                    FileSystemSandboxEntry {
+                        path: FileSystemPath::Path {
+                            path: extra_root.clone(),
+                        },
+                        access: FileSystemAccessMode::Write,
+                    },
+                ],
+                glob_scan_max_depth: None,
+            },
+            network: NetworkSandboxPolicy::Restricted,
+        };
+
+        let compatibility_profile =
+            legacy_compatible_permission_profile(&permission_profile, cwd.as_path());
+        let policy = compatibility_profile
+            .to_legacy_sandbox_policy(cwd.as_path())
+            .expect("compatibility profile should project to legacy policy");
+        let roots = policy
+            .get_writable_roots_with_cwd(cwd.as_path())
+            .into_iter()
+            .map(|root| root.root)
+            .collect::<Vec<_>>();
+
+        assert_eq!(roots, vec![extra_root, cwd]);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `PermissionProfile`-based turn submission helpers to `core_test_support`, while keeping the legacy `SandboxPolicy` helper for tests that intentionally exercise legacy fallback behavior.
- Switch the default `TestCodex::submit_turn()` path to send a real `PermissionProfile` plus the required legacy compatibility projection in `Op::UserTurn`.
- Migrate straightforward app/search/shell/truncation tests from `SandboxPolicy::{DangerFullAccess, ReadOnly}` to `PermissionProfile::{Disabled, read_only}`.
- Add a TUI compatibility projection helper for legacy app-server fields so non-legacy writable roots are preserved instead of being downgraded to read-only.
- Fix remote start/resume/fork sandbox-mode projection to classify any managed profile with writable roots as workspace-write, not only profiles that can write `cwd`.
- Reduce `SandboxPolicy` references in `codex-rs/core/tests` from 47 files to 41 files without changing production behavior.

## Testing

- `cargo check -p codex-core --tests`
- `cargo test -p codex-tui compatibility_profile_preserves_unbridgeable_write_roots`
- `cargo test -p codex-tui sandbox_mode_preserves_non_cwd_write_roots_for_remote_sessions`
- `just fmt`
- `just fix -p core_test_support`
- `just fix -p codex-core`


























