### PR TITLE
ci: disable remote downloader without BuildBuddy

### DIFF
--- a/.github/scripts/run-bazel-ci.sh
+++ b/.github/scripts/run-bazel-ci.sh
@@ -365,14 +365,16 @@ else
   # --noexperimental_remote_repo_contents_cache:
   #   disable remote repo contents cache enabled in .bazelrc startup options.
   #   https://bazel.build/reference/command-line-reference#startup_options-flag--experimental_remote_repo_contents_cache
-  # --remote_cache= and --remote_executor=:
-  #   clear remote cache/execution endpoints configured in .bazelrc.
+  # --remote_cache=, --remote_executor=, and --experimental_remote_downloader=:
+  #   clear remote cache/execution/download endpoints configured in .bazelrc.
   #   https://bazel.build/reference/command-line-reference#common_options-flag--remote_cache
   #   https://bazel.build/reference/command-line-reference#common_options-flag--remote_executor
+  #   https://bazel.build/reference/command-line-reference#common_options-flag--experimental_remote_downloader
   bazel_run_args=(
     "${bazel_args[@]}"
     --remote_cache=
     --remote_executor=
+    --experimental_remote_downloader=
   )
   if (( ${#post_config_bazel_args[@]} > 0 )); then
     bazel_run_args+=("${post_config_bazel_args[@]}")

--- a/.github/scripts/test_run_bazel_ci.py
+++ b/.github/scripts/test_run_bazel_ci.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUN_BAZEL_CI = REPO_ROOT / ".github" / "scripts" / "run-bazel-ci.sh"
+
+
+class RunBazelCiTest(unittest.TestCase):
+    def test_local_fallback_disables_remote_services(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            fake_bin = temp_path / "bin"
+            fake_bin.mkdir()
+            args_path = temp_path / "bazel-args.txt"
+            fake_bazel = fake_bin / "bazel"
+            fake_bazel.write_text(
+                textwrap.dedent(
+                    f"""\
+                    #!/usr/bin/env bash
+                    printf '%s\n' "$@" > {args_path}
+                    """
+                ),
+                encoding="utf-8",
+            )
+            fake_bazel.chmod(0o755)
+
+            env = os.environ.copy()
+            env.pop("BUILDBUDDY_API_KEY", None)
+            env["PATH"] = f"{fake_bin}:{env['PATH']}"
+
+            subprocess.run(
+                [
+                    str(RUN_BAZEL_CI),
+                    "--",
+                    "build",
+                    "--",
+                    "//codex-rs/protocol:protocol",
+                ],
+                cwd=REPO_ROOT,
+                env=env,
+                check=True,
+                text=True,
+                capture_output=True,
+            )
+
+            self.assertEqual(
+                args_path.read_text(encoding="utf-8").splitlines(),
+                [
+                    "--noexperimental_remote_repo_contents_cache",
+                    "build",
+                    "--remote_cache=",
+                    "--remote_executor=",
+                    "--experimental_remote_downloader=",
+                    "--",
+                    "//codex-rs/protocol:protocol",
+                ],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- clear `--experimental_remote_downloader` in the no-`BUILDBUDDY_API_KEY` Bazel fallback
- keep fork PR CI local when BuildBuddy credentials are unavailable

## Failure addressed
- unrelated failure observed on [PR #20020 Bazel job](https://github.com/openai/codex/actions/runs/25065718793/job/73432173340): `The remote downloader can only be used in combination with gRPC caching`
- unrelated failure observed on [PR #20020 sdk job](https://github.com/openai/codex/actions/runs/25065718817/job/73432172949) with the same Bazel error before SDK build steps ran
- these failures are unrelated to PR #20020, which only adds one protocol unit test

## Test plan
- `bash -n .github/scripts/run-bazel-ci.sh`