### PR TITLE
Fix Windows pseudoconsole attribute handling for sandboxed PTY sessions

### DIFF
--- a/codex-rs/windows-sandbox-rs/src/proc_thread_attr.rs
+++ b/codex-rs/windows-sandbox-rs/src/proc_thread_attr.rs
@@ -1,4 +1,5 @@
 use std::io;
+use std::ffi::c_void;
 use windows_sys::Win32::Foundation::GetLastError;
 use windows_sys::Win32::Foundation::HANDLE;
 use windows_sys::Win32::System::Threading::DeleteProcThreadAttributeList;
@@ -45,14 +46,13 @@ impl ProcThreadAttributeList {
 
     pub fn set_pseudoconsole(&mut self, hpc: isize) -> io::Result<()> {
         let list = self.as_mut_ptr();
-        let mut hpc_value = hpc;
         let ok = unsafe {
             UpdateProcThreadAttribute(
                 list,
                 0,
                 PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE,
-                (&mut hpc_value as *mut isize).cast(),
-                std::mem::size_of::<isize>(),
+                hpc as *mut c_void,
+                std::mem::size_of::<HANDLE>(),
                 std::ptr::null_mut(),
                 std::ptr::null_mut(),
             )

--- a/codex-rs/windows-sandbox-rs/src/proc_thread_attr.rs
+++ b/codex-rs/windows-sandbox-rs/src/proc_thread_attr.rs
@@ -1,5 +1,5 @@
-use std::io;
 use std::ffi::c_void;
+use std::io;
 use windows_sys::Win32::Foundation::GetLastError;
 use windows_sys::Win32::Foundation::HANDLE;
 use windows_sys::Win32::System::Threading::DeleteProcThreadAttributeList;


### PR DESCRIPTION
## Summary
Fix the Windows sandbox PTY spawn path to pass the pseudoconsole handle value directly into `UpdateProcThreadAttribute`.

## Why
Sandboxed `unified_exec` PTY sessions on Windows were failing during child process startup with `0xc0000142` (`STATUS_DLL_INIT_FAILED`). In practice this showed up as PowerShell DLL init popups when the sandboxed background-terminal path tried to launch an interactive shell.

The root cause was that we were passing a pointer to a local `isize` variable instead of the pseudoconsole handle value in the form Windows expects for `PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE`.

## Validation
- `cargo build -p codex-windows-sandbox --bins`
- Reproduced the real sandboxed `codex exec` flow with `windows.sandbox_private_desktop=true`
- Verified a `tty=true` interactive session launched through the normal PowerShell wrapper, printed `READY`, accepted follow-up stdin, and exited cleanly
- Confirmed no new `0xc0000142` / `Application Popup` events appeared after the successful repro