### PR TITLE
Fix plan mode nudge test after task completion signature change

### DIFF
--- a/codex-rs/tui/src/chatwidget/tests/plan_mode.rs
+++ b/codex-rs/tui/src/chatwidget/tests/plan_mode.rs
@@ -45,7 +45,9 @@ async fn plan_mode_nudge_hides_while_task_or_modal_is_active() {
     chat.pre_draw_tick();
     assert!(!chat.bottom_pane.plan_mode_nudge_visible());
 
-    chat.on_task_complete(/*last_agent_message*/ None, /*from_replay*/ false);
+    chat.on_task_complete(
+        /*last_agent_message*/ None, /*duration_ms*/ None, /*from_replay*/ false,
+    );
     chat.show_selection_view(SelectionViewParams {
         items: vec![SelectionItem {
             name: "Keep planning".to_string(),


### PR DESCRIPTION
Updates the plan mode nudge test to pass the new `duration_ms` argument to task completion.