### PR TITLE
Add lazy environment resolution for remote environments

### DIFF
--- a/codex-rs/exec-server/src/client.rs
+++ b/codex-rs/exec-server/src/client.rs
@@ -25,6 +25,8 @@ use crate::client_api::ExecServerClientConnectOptions;
 use crate::client_api::HttpClient;
 use crate::client_api::RemoteExecServerConnectArgs;
 use crate::connection::JsonRpcConnection;
+use crate::environment_provider::EnvironmentResolver;
+use crate::environment_provider::normalize_remote_exec_server_url;
 use crate::process::ExecProcessEvent;
 use crate::process::ExecProcessEventLog;
 use crate::process::ExecProcessEventReceiver;
@@ -180,14 +182,16 @@ pub struct ExecServerClient {
 
 #[derive(Clone)]
 pub(crate) struct LazyRemoteExecServerClient {
-    websocket_url: String,
+    environment_id: String,
+    resolver: Arc<dyn EnvironmentResolver>,
     client: Arc<OnceCell<ExecServerClient>>,
 }
 
 impl LazyRemoteExecServerClient {
-    pub(crate) fn new(websocket_url: String) -> Self {
+    pub(crate) fn new(environment_id: String, resolver: Arc<dyn EnvironmentResolver>) -> Self {
         Self {
-            websocket_url,
+            environment_id,
+            resolver,
             client: Arc::new(OnceCell::new()),
         }
     }
@@ -195,8 +199,13 @@ impl LazyRemoteExecServerClient {
     pub(crate) async fn get(&self) -> Result<ExecServerClient, ExecServerError> {
         self.client
             .get_or_try_init(|| async {
+                let resolved = self.resolver.resolve().await?;
+                let websocket_url = normalize_remote_exec_server_url(
+                    self.environment_id.as_str(),
+                    resolved.exec_server_url,
+                )?;
                 ExecServerClient::connect_websocket(RemoteExecServerConnectArgs {
-                    websocket_url: self.websocket_url.clone(),
+                    websocket_url,
                     client_name: "codex-environment".to_string(),
                     connect_timeout: Duration::from_secs(5),
                     initialize_timeout: Duration::from_secs(5),

--- a/codex-rs/exec-server/src/environment.rs
+++ b/codex-rs/exec-server/src/environment.rs
@@ -8,6 +8,7 @@ use crate::HttpClient;
 use crate::client::LazyRemoteExecServerClient;
 use crate::client::http_client::ReqwestHttpClient;
 use crate::environment_provider::DefaultEnvironmentProvider;
+use crate::environment_provider::EnvironmentConfiguration;
 use crate::environment_provider::EnvironmentConfigurations;
 use crate::environment_provider::EnvironmentProvider;
 use crate::environment_provider::normalize_exec_server_url;
@@ -115,7 +116,8 @@ impl EnvironmentManager {
         )]);
         for (id, configuration) in environment_configurations.into_environments() {
             let environment = Environment::remote_inner(
-                configuration.exec_server_url,
+                id.clone(),
+                configuration,
                 Some(local_runtime_paths.clone()),
             );
             environments.insert(id, Arc::new(environment));
@@ -159,6 +161,7 @@ impl EnvironmentManager {
 /// paths used by filesystem helpers.
 #[derive(Clone)]
 pub struct Environment {
+    is_remote: bool,
     exec_server_url: Option<String>,
     exec_backend: Arc<dyn ExecBackend>,
     filesystem: Arc<dyn ExecutorFileSystem>,
@@ -170,6 +173,7 @@ impl Environment {
     /// Builds a test-only local environment without configured sandbox helper paths.
     pub fn default_for_tests() -> Self {
         Self {
+            is_remote: false,
             exec_server_url: None,
             exec_backend: Arc::new(LocalProcess::default()),
             filesystem: Arc::new(LocalFileSystem::unsandboxed()),
@@ -215,7 +219,12 @@ impl Environment {
         }
 
         Ok(match exec_server_url {
-            Some(exec_server_url) => Self::remote_inner(exec_server_url, local_runtime_paths),
+            Some(exec_server_url) => Self::remote_inner(
+                REMOTE_ENVIRONMENT_ID.to_string(),
+                EnvironmentConfiguration::static_url(exec_server_url)
+                    .expect("normalized remote environment URL should be valid"),
+                local_runtime_paths,
+            ),
             None => match local_runtime_paths {
                 Some(local_runtime_paths) => Self::local(local_runtime_paths),
                 None => Self::default_for_tests(),
@@ -225,6 +234,7 @@ impl Environment {
 
     fn local(local_runtime_paths: ExecServerRuntimePaths) -> Self {
         Self {
+            is_remote: false,
             exec_server_url: None,
             exec_backend: Arc::new(LocalProcess::default()),
             filesystem: Arc::new(LocalFileSystem::with_runtime_paths(
@@ -236,16 +246,19 @@ impl Environment {
     }
 
     fn remote_inner(
-        exec_server_url: String,
+        environment_id: String,
+        configuration: EnvironmentConfiguration,
         local_runtime_paths: Option<ExecServerRuntimePaths>,
     ) -> Self {
-        let client = LazyRemoteExecServerClient::new(exec_server_url.clone());
+        let exec_server_url = configuration.static_exec_server_url().map(str::to_string);
+        let client = LazyRemoteExecServerClient::new(environment_id, configuration.resolver());
         let exec_backend: Arc<dyn ExecBackend> = Arc::new(RemoteProcess::new(client.clone()));
         let filesystem: Arc<dyn ExecutorFileSystem> =
             Arc::new(RemoteFileSystem::new(client.clone()));
 
         Self {
-            exec_server_url: Some(exec_server_url),
+            is_remote: true,
+            exec_server_url,
             exec_backend,
             filesystem,
             http_client: Arc::new(client),
@@ -254,10 +267,13 @@ impl Environment {
     }
 
     pub fn is_remote(&self) -> bool {
-        self.exec_server_url.is_some()
+        self.is_remote
     }
 
-    /// Returns the remote exec-server URL when this environment is remote.
+    /// Returns the statically configured remote exec-server URL when known.
+    ///
+    /// Dynamically resolved remote environments return `None` here and resolve
+    /// their URL on first remote client use.
     pub fn exec_server_url(&self) -> Option<&str> {
         self.exec_server_url.as_deref()
     }
@@ -283,6 +299,8 @@ impl Environment {
 mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
 
     use super::Environment;
     use super::EnvironmentManager;
@@ -293,6 +311,7 @@ mod tests {
     use crate::EnvironmentConfigurations;
     use crate::ExecServerRuntimePaths;
     use crate::ProcessId;
+    use futures::FutureExt;
     use pretty_assertions::assert_eq;
 
     fn test_runtime_paths() -> ExecServerRuntimePaths {
@@ -398,9 +417,8 @@ mod tests {
                 Some(REMOTE_ENVIRONMENT_ID.to_string()),
                 HashMap::from([(
                     REMOTE_ENVIRONMENT_ID.to_string(),
-                    EnvironmentConfiguration {
-                        exec_server_url: "ws://127.0.0.1:8765".to_string(),
-                    },
+                    EnvironmentConfiguration::static_url("ws://127.0.0.1:8765".to_string())
+                        .expect("static environment configuration"),
                 )]),
             )
             .expect("environment configurations"),
@@ -423,6 +441,42 @@ mod tests {
                 .expect("local environment")
                 .is_remote()
         );
+    }
+
+    #[tokio::test]
+    async fn environment_manager_does_not_resolve_dynamic_environment_when_building_cache() {
+        let resolve_count = Arc::new(AtomicUsize::new(0));
+        let configuration = EnvironmentConfiguration::from_resolver_fn({
+            let resolve_count = Arc::clone(&resolve_count);
+            move || {
+                let resolve_count = Arc::clone(&resolve_count);
+                async move {
+                    resolve_count.fetch_add(1, Ordering::SeqCst);
+                    Ok(crate::ResolvedEnvironment {
+                        exec_server_url: "ws://127.0.0.1:8765".to_string(),
+                    })
+                }
+                .boxed()
+            }
+        });
+
+        let manager = EnvironmentManager::from_configurations(
+            EnvironmentConfigurations::new(
+                Some(REMOTE_ENVIRONMENT_ID.to_string()),
+                HashMap::from([(REMOTE_ENVIRONMENT_ID.to_string(), configuration)]),
+            )
+            .expect("environment configurations"),
+            test_runtime_paths(),
+        );
+
+        assert_eq!(resolve_count.load(Ordering::SeqCst), 0);
+        assert!(
+            manager
+                .get_environment(REMOTE_ENVIRONMENT_ID)
+                .expect("remote environment")
+                .is_remote()
+        );
+        assert_eq!(resolve_count.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]

--- a/codex-rs/exec-server/src/environment.rs
+++ b/codex-rs/exec-server/src/environment.rs
@@ -221,8 +221,7 @@ impl Environment {
         Ok(match exec_server_url {
             Some(exec_server_url) => Self::remote_inner(
                 REMOTE_ENVIRONMENT_ID.to_string(),
-                EnvironmentConfiguration::static_url(exec_server_url)
-                    .expect("normalized remote environment URL should be valid"),
+                EnvironmentConfiguration::normalized_static_url(exec_server_url),
                 local_runtime_paths,
             ),
             None => match local_runtime_paths {

--- a/codex-rs/exec-server/src/environment_provider.rs
+++ b/codex-rs/exec-server/src/environment_provider.rs
@@ -1,20 +1,114 @@
 use std::collections::HashMap;
+use std::fmt;
+use std::sync::Arc;
 
 use async_trait::async_trait;
+use futures::future::BoxFuture;
 
 use crate::ExecServerError;
 use crate::environment::CODEX_EXEC_SERVER_URL_ENV_VAR;
 use crate::environment::LOCAL_ENVIRONMENT_ID;
 use crate::environment::REMOTE_ENVIRONMENT_ID;
 
-/// Provider-supplied environment definition consumed by `EnvironmentManager`.
+/// Resolved connection details for a provider-supplied environment.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct EnvironmentConfiguration {
+pub struct ResolvedEnvironment {
     pub exec_server_url: String,
 }
 
+/// Resolves provider-supplied environment connection details on demand.
+#[async_trait]
+pub trait EnvironmentResolver: Send + Sync + fmt::Debug {
+    async fn resolve(&self) -> Result<ResolvedEnvironment, ExecServerError>;
+}
+
+/// Provider-supplied environment definition consumed by `EnvironmentManager`.
+#[derive(Clone, Debug)]
+pub struct EnvironmentConfiguration {
+    static_exec_server_url: Option<String>,
+    resolver: Arc<dyn EnvironmentResolver>,
+}
+
+impl EnvironmentConfiguration {
+    pub fn static_url(exec_server_url: String) -> Result<Self, ExecServerError> {
+        let exec_server_url = normalize_remote_exec_server_url("<static>", exec_server_url)?;
+        Ok(Self {
+            static_exec_server_url: Some(exec_server_url.clone()),
+            resolver: Arc::new(StaticEnvironmentResolver { exec_server_url }),
+        })
+    }
+
+    pub fn with_resolver<R>(resolver: R) -> Self
+    where
+        R: EnvironmentResolver + 'static,
+    {
+        Self {
+            static_exec_server_url: None,
+            resolver: Arc::new(resolver),
+        }
+    }
+
+    pub fn from_resolver_fn<F>(resolver: F) -> Self
+    where
+        F: Fn() -> BoxFuture<'static, Result<ResolvedEnvironment, ExecServerError>>
+            + Send
+            + Sync
+            + 'static,
+    {
+        Self::with_resolver(FnEnvironmentResolver {
+            resolver: Arc::new(resolver),
+        })
+    }
+
+    pub async fn resolve(&self) -> Result<ResolvedEnvironment, ExecServerError> {
+        self.resolver.resolve().await
+    }
+
+    pub(crate) fn static_exec_server_url(&self) -> Option<&str> {
+        self.static_exec_server_url.as_deref()
+    }
+
+    pub(crate) fn resolver(&self) -> Arc<dyn EnvironmentResolver> {
+        Arc::clone(&self.resolver)
+    }
+}
+
+#[derive(Debug)]
+struct StaticEnvironmentResolver {
+    exec_server_url: String,
+}
+
+#[async_trait]
+impl EnvironmentResolver for StaticEnvironmentResolver {
+    async fn resolve(&self) -> Result<ResolvedEnvironment, ExecServerError> {
+        Ok(ResolvedEnvironment {
+            exec_server_url: self.exec_server_url.clone(),
+        })
+    }
+}
+
+struct FnEnvironmentResolver {
+    resolver: Arc<
+        dyn Fn() -> BoxFuture<'static, Result<ResolvedEnvironment, ExecServerError>> + Send + Sync,
+    >,
+}
+
+impl fmt::Debug for FnEnvironmentResolver {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FnEnvironmentResolver")
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait]
+impl EnvironmentResolver for FnEnvironmentResolver {
+    async fn resolve(&self) -> Result<ResolvedEnvironment, ExecServerError> {
+        (self.resolver)().await
+    }
+}
+
 /// Provider-supplied environment snapshot consumed by `EnvironmentManager`.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
 pub struct EnvironmentConfigurations {
     default_environment_id: Option<String>,
     environments: HashMap<String, EnvironmentConfiguration>,
@@ -23,9 +117,9 @@ pub struct EnvironmentConfigurations {
 impl EnvironmentConfigurations {
     pub fn new(
         default_environment_id: Option<String>,
-        mut environments: HashMap<String, EnvironmentConfiguration>,
+        environments: HashMap<String, EnvironmentConfiguration>,
     ) -> Result<Self, ExecServerError> {
-        for (id, configuration) in &mut environments {
+        for id in environments.keys() {
             if id.is_empty() {
                 return Err(ExecServerError::Protocol(
                     "environment configuration id cannot be empty".to_string(),
@@ -35,17 +129,6 @@ impl EnvironmentConfigurations {
                 return Err(ExecServerError::Protocol(format!(
                     "provider environment configurations must not include `{LOCAL_ENVIRONMENT_ID}`"
                 )));
-            }
-
-            match normalize_exec_server_url(Some(configuration.exec_server_url.clone())) {
-                (Some(exec_server_url), false) => {
-                    configuration.exec_server_url = exec_server_url;
-                }
-                (None, false) | (None, true) | (Some(_), true) => {
-                    return Err(ExecServerError::Protocol(format!(
-                        "environment configuration `{id}` must set a remote exec-server URL"
-                    )));
-                }
             }
         }
 
@@ -83,7 +166,8 @@ impl EnvironmentConfigurations {
             default_environment_id: Some(REMOTE_ENVIRONMENT_ID.to_string()),
             environments: HashMap::from([(
                 REMOTE_ENVIRONMENT_ID.to_string(),
-                EnvironmentConfiguration { exec_server_url },
+                EnvironmentConfiguration::static_url(exec_server_url)
+                    .expect("remote default provider configuration should be valid"),
             )]),
         }
     }
@@ -103,6 +187,8 @@ impl EnvironmentConfigurations {
 /// snapshot that `EnvironmentManager` will cache. The local environment is
 /// always supplied by `EnvironmentManager`; providers only need to set
 /// `local` as the default when they want local to be selected by default.
+/// Remote configurations carry their own resolver so providers can choose
+/// between static URLs and dynamic, on-demand endpoint lookup.
 #[async_trait]
 pub trait EnvironmentProvider: Send + Sync {
     /// Returns the environment configurations available for a new manager.
@@ -155,58 +241,81 @@ pub(crate) fn normalize_exec_server_url(exec_server_url: Option<String>) -> (Opt
     }
 }
 
+pub(crate) fn normalize_remote_exec_server_url(
+    environment_id: &str,
+    exec_server_url: String,
+) -> Result<String, ExecServerError> {
+    match normalize_exec_server_url(Some(exec_server_url)) {
+        (Some(exec_server_url), false) => Ok(exec_server_url),
+        (None, false) | (None, true) | (Some(_), true) => Err(ExecServerError::Protocol(format!(
+            "environment configuration `{environment_id}` must resolve to a remote exec-server URL"
+        ))),
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use futures::FutureExt;
     use pretty_assertions::assert_eq;
 
     use super::*;
+
+    fn assert_local_default(configurations: EnvironmentConfigurations) {
+        assert_eq!(
+            configurations.default_environment_id(),
+            Some(LOCAL_ENVIRONMENT_ID)
+        );
+        assert!(configurations.environments.is_empty());
+    }
+
+    fn assert_disabled(configurations: EnvironmentConfigurations) {
+        assert_eq!(configurations.default_environment_id(), None);
+        assert!(configurations.environments.is_empty());
+    }
 
     #[tokio::test]
     async fn default_provider_uses_local_environment_when_url_is_missing() {
         let provider = DefaultEnvironmentProvider::new(/*exec_server_url*/ None);
 
-        assert_eq!(
-            provider.get_environments().await.expect("environments"),
-            EnvironmentConfigurations::local_default()
-        );
+        assert_local_default(provider.get_environments().await.expect("environments"));
     }
 
     #[tokio::test]
     async fn default_provider_uses_local_environment_when_url_is_empty() {
         let provider = DefaultEnvironmentProvider::new(Some(String::new()));
 
-        assert_eq!(
-            provider.get_environments().await.expect("environments"),
-            EnvironmentConfigurations::local_default()
-        );
+        assert_local_default(provider.get_environments().await.expect("environments"));
     }
 
     #[tokio::test]
     async fn default_provider_disables_default_environment_for_none_value() {
         let provider = DefaultEnvironmentProvider::new(Some("none".to_string()));
 
-        assert_eq!(
-            provider.get_environments().await.expect("environments"),
-            EnvironmentConfigurations::disabled()
-        );
+        assert_disabled(provider.get_environments().await.expect("environments"));
     }
 
     #[tokio::test]
     async fn default_provider_adds_remote_environment_for_websocket_url() {
         let provider = DefaultEnvironmentProvider::new(Some("ws://127.0.0.1:8765".to_string()));
 
+        let configurations = provider.get_environments().await.expect("environments");
         assert_eq!(
-            provider.get_environments().await.expect("environments"),
-            EnvironmentConfigurations::new(
-                Some(REMOTE_ENVIRONMENT_ID.to_string()),
-                HashMap::from([(
-                    REMOTE_ENVIRONMENT_ID.to_string(),
-                    EnvironmentConfiguration {
-                        exec_server_url: "ws://127.0.0.1:8765".to_string(),
-                    },
-                )]),
-            )
-            .expect("environment configurations")
+            configurations.default_environment_id(),
+            Some(REMOTE_ENVIRONMENT_ID)
+        );
+        let environment = configurations
+            .environments
+            .get(REMOTE_ENVIRONMENT_ID)
+            .expect("remote configuration");
+        assert_eq!(
+            environment.static_exec_server_url(),
+            Some("ws://127.0.0.1:8765")
+        );
+        assert_eq!(
+            environment.resolve().await.expect("resolved environment"),
+            ResolvedEnvironment {
+                exec_server_url: "ws://127.0.0.1:8765".to_string(),
+            }
         );
     }
 
@@ -216,9 +325,8 @@ mod tests {
             Some(LOCAL_ENVIRONMENT_ID.to_string()),
             HashMap::from([(
                 LOCAL_ENVIRONMENT_ID.to_string(),
-                EnvironmentConfiguration {
-                    exec_server_url: "ws://127.0.0.1:8765".to_string(),
-                },
+                EnvironmentConfiguration::static_url("ws://127.0.0.1:8765".to_string())
+                    .expect("static environment configuration"),
             )]),
         )
         .expect_err("local provider entry should fail");
@@ -242,59 +350,62 @@ mod tests {
     }
 
     #[test]
-    fn environment_configurations_rejects_empty_exec_server_url() {
-        let err = EnvironmentConfigurations::new(
-            Some(REMOTE_ENVIRONMENT_ID.to_string()),
-            HashMap::from([(
-                REMOTE_ENVIRONMENT_ID.to_string(),
-                EnvironmentConfiguration {
-                    exec_server_url: String::new(),
-                },
-            )]),
-        )
-        .expect_err("empty URL should fail");
+    fn static_environment_configuration_rejects_empty_exec_server_url() {
+        let err =
+            EnvironmentConfiguration::static_url(String::new()).expect_err("empty URL should fail");
 
         assert_eq!(
             err.to_string(),
-            "exec-server protocol error: environment configuration `remote` must set a remote exec-server URL"
+            "exec-server protocol error: environment configuration `<static>` must resolve to a remote exec-server URL"
         );
     }
 
     #[test]
-    fn environment_configurations_rejects_disabled_exec_server_url() {
-        let err = EnvironmentConfigurations::new(
-            Some(REMOTE_ENVIRONMENT_ID.to_string()),
-            HashMap::from([(
-                REMOTE_ENVIRONMENT_ID.to_string(),
-                EnvironmentConfiguration {
-                    exec_server_url: "none".to_string(),
-                },
-            )]),
-        )
-        .expect_err("disabled URL should fail");
+    fn static_environment_configuration_rejects_disabled_exec_server_url() {
+        let err = EnvironmentConfiguration::static_url("none".to_string())
+            .expect_err("disabled URL should fail");
 
         assert_eq!(
             err.to_string(),
-            "exec-server protocol error: environment configuration `remote` must set a remote exec-server URL"
+            "exec-server protocol error: environment configuration `<static>` must resolve to a remote exec-server URL"
         );
     }
 
-    #[test]
-    fn environment_configurations_normalizes_exec_server_url() {
-        let configurations = EnvironmentConfigurations::new(
-            Some(REMOTE_ENVIRONMENT_ID.to_string()),
-            HashMap::from([(
-                REMOTE_ENVIRONMENT_ID.to_string(),
-                EnvironmentConfiguration {
-                    exec_server_url: " ws://127.0.0.1:8765 ".to_string(),
-                },
-            )]),
-        )
-        .expect("environment configurations");
+    #[tokio::test]
+    async fn static_environment_configuration_normalizes_exec_server_url() {
+        let configuration =
+            EnvironmentConfiguration::static_url(" ws://127.0.0.1:8765 ".to_string())
+                .expect("environment configurations");
 
         assert_eq!(
-            configurations,
-            EnvironmentConfigurations::remote_default("ws://127.0.0.1:8765".to_string())
+            configuration.static_exec_server_url(),
+            Some("ws://127.0.0.1:8765")
+        );
+        assert_eq!(
+            configuration.resolve().await.expect("resolved environment"),
+            ResolvedEnvironment {
+                exec_server_url: "ws://127.0.0.1:8765".to_string(),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn environment_configuration_can_resolve_from_closure() {
+        let configuration = EnvironmentConfiguration::from_resolver_fn(|| {
+            async {
+                Ok(ResolvedEnvironment {
+                    exec_server_url: "ws://127.0.0.1:8765".to_string(),
+                })
+            }
+            .boxed()
+        });
+
+        assert_eq!(configuration.static_exec_server_url(), None);
+        assert_eq!(
+            configuration.resolve().await.expect("resolved environment"),
+            ResolvedEnvironment {
+                exec_server_url: "ws://127.0.0.1:8765".to_string(),
+            }
         );
     }
 }

--- a/codex-rs/exec-server/src/environment_provider.rs
+++ b/codex-rs/exec-server/src/environment_provider.rs
@@ -19,13 +19,18 @@ pub struct ResolvedEnvironment {
 /// Resolves provider-supplied environment connection details on demand.
 #[async_trait]
 pub trait EnvironmentResolver: Send + Sync + fmt::Debug {
+    /// Returns the static exec-server URL for resolvers that do not need
+    /// asynchronous lookup.
+    fn static_exec_server_url(&self) -> Option<&str> {
+        None
+    }
+
     async fn resolve(&self) -> Result<ResolvedEnvironment, ExecServerError>;
 }
 
 /// Provider-supplied environment definition consumed by `EnvironmentManager`.
 #[derive(Clone, Debug)]
 pub struct EnvironmentConfiguration {
-    static_exec_server_url: Option<String>,
     resolver: Arc<dyn EnvironmentResolver>,
 }
 
@@ -41,7 +46,6 @@ impl EnvironmentConfiguration {
             Ok(normalized) if normalized == exec_server_url
         ));
         Self {
-            static_exec_server_url: Some(exec_server_url.clone()),
             resolver: Arc::new(StaticEnvironmentResolver { exec_server_url }),
         }
     }
@@ -51,7 +55,6 @@ impl EnvironmentConfiguration {
         R: EnvironmentResolver + 'static,
     {
         Self {
-            static_exec_server_url: None,
             resolver: Arc::new(resolver),
         }
     }
@@ -73,7 +76,7 @@ impl EnvironmentConfiguration {
     }
 
     pub(crate) fn static_exec_server_url(&self) -> Option<&str> {
-        self.static_exec_server_url.as_deref()
+        self.resolver.static_exec_server_url()
     }
 
     pub(crate) fn resolver(&self) -> Arc<dyn EnvironmentResolver> {
@@ -88,6 +91,10 @@ struct StaticEnvironmentResolver {
 
 #[async_trait]
 impl EnvironmentResolver for StaticEnvironmentResolver {
+    fn static_exec_server_url(&self) -> Option<&str> {
+        Some(&self.exec_server_url)
+    }
+
     async fn resolve(&self) -> Result<ResolvedEnvironment, ExecServerError> {
         Ok(ResolvedEnvironment {
             exec_server_url: self.exec_server_url.clone(),

--- a/codex-rs/exec-server/src/environment_provider.rs
+++ b/codex-rs/exec-server/src/environment_provider.rs
@@ -32,10 +32,18 @@ pub struct EnvironmentConfiguration {
 impl EnvironmentConfiguration {
     pub fn static_url(exec_server_url: String) -> Result<Self, ExecServerError> {
         let exec_server_url = normalize_remote_exec_server_url("<static>", exec_server_url)?;
-        Ok(Self {
+        Ok(Self::normalized_static_url(exec_server_url))
+    }
+
+    pub(crate) fn normalized_static_url(exec_server_url: String) -> Self {
+        debug_assert!(matches!(
+            normalize_remote_exec_server_url("<static>", exec_server_url.clone()),
+            Ok(normalized) if normalized == exec_server_url
+        ));
+        Self {
             static_exec_server_url: Some(exec_server_url.clone()),
             resolver: Arc::new(StaticEnvironmentResolver { exec_server_url }),
-        })
+        }
     }
 
     pub fn with_resolver<R>(resolver: R) -> Self
@@ -166,8 +174,7 @@ impl EnvironmentConfigurations {
             default_environment_id: Some(REMOTE_ENVIRONMENT_ID.to_string()),
             environments: HashMap::from([(
                 REMOTE_ENVIRONMENT_ID.to_string(),
-                EnvironmentConfiguration::static_url(exec_server_url)
-                    .expect("remote default provider configuration should be valid"),
+                EnvironmentConfiguration::normalized_static_url(exec_server_url),
             )]),
         }
     }

--- a/codex-rs/exec-server/src/lib.rs
+++ b/codex-rs/exec-server/src/lib.rs
@@ -43,6 +43,8 @@ pub use environment_provider::DefaultEnvironmentProvider;
 pub use environment_provider::EnvironmentConfiguration;
 pub use environment_provider::EnvironmentConfigurations;
 pub use environment_provider::EnvironmentProvider;
+pub use environment_provider::EnvironmentResolver;
+pub use environment_provider::ResolvedEnvironment;
 pub use fs_helper::CODEX_FS_HELPER_ARG1;
 pub use fs_helper_main::main as run_fs_helper_main;
 pub use local_file_system::LOCAL_FS;


### PR DESCRIPTION
Stacked on #20058.

## Summary
- Move EnvironmentConfiguration from a stored websocket URL to a resolver-backed descriptor
- Add static and closure-backed resolver constructors for default and dynamic provider cases
- Keep EnvironmentManager as the id -> Environment cache while LazyRemoteExecServerClient resolves the URL on first use

## Validation
- just fmt
- git diff --check
- bazel test --bes_backend= --bes_results_url= --test_output=errors //codex-rs/exec-server:all
