### PR TITLE
Use /goal resume for paused goals

### DIFF
--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -219,7 +219,7 @@ pub(crate) enum AppEvent {
         mode: ThreadGoalSetMode,
     },
 
-    /// Pause or unpause the current thread goal.
+    /// Pause or resume the current thread goal.
     SetThreadGoalStatus {
         thread_id: ThreadId,
         status: ThreadGoalStatus,

--- a/codex-rs/tui/src/bottom_pane/footer.rs
+++ b/codex-rs/tui/src/bottom_pane/footer.rs
@@ -548,7 +548,7 @@ pub(crate) fn goal_status_indicator_line(
                 "Pursuing goal".to_string()
             }
         }
-        GoalStatusIndicator::Paused => "Goal paused (/goal to unpause)".to_string(),
+        GoalStatusIndicator::Paused => "Goal paused (/goal resume)".to_string(),
         GoalStatusIndicator::BudgetLimited { usage } => {
             if let Some(usage) = usage {
                 format!("Goal unmet ({usage})")

--- a/codex-rs/tui/src/chatwidget/goal_menu.rs
+++ b/codex-rs/tui/src/chatwidget/goal_menu.rs
@@ -45,7 +45,7 @@ fn goal_summary_lines(goal: &AppThreadGoal) -> Vec<Line<'static>> {
     }
     let command_hint = match goal.status {
         AppThreadGoalStatus::Active => "Commands: /goal pause, /goal clear",
-        AppThreadGoalStatus::Paused => "Commands: /goal unpause, /goal clear",
+        AppThreadGoalStatus::Paused => "Commands: /goal resume, /goal clear",
         AppThreadGoalStatus::BudgetLimited | AppThreadGoalStatus::Complete => {
             "Commands: /goal clear"
         }

--- a/codex-rs/tui/src/chatwidget/slash_dispatch.rs
+++ b/codex-rs/tui/src/chatwidget/slash_dispatch.rs
@@ -617,7 +617,7 @@ impl ChatWidget {
                 let control_command = match trimmed.to_ascii_lowercase().as_str() {
                     "clear" => Some(GoalControlCommand::Clear),
                     "pause" => Some(GoalControlCommand::SetStatus(AppThreadGoalStatus::Paused)),
-                    "unpause" => Some(GoalControlCommand::SetStatus(AppThreadGoalStatus::Active)),
+                    "resume" => Some(GoalControlCommand::SetStatus(AppThreadGoalStatus::Active)),
                     _ => None,
                 };
                 if let Some(command) = control_command {

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__goal_menu_paused.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__goal_menu_paused.snap
@@ -8,4 +8,4 @@ Objective: Keep improving the bare goal command until it feels calm and useful.
 Time used: 1m
 Tokens used: 12.5K
 
-Commands: /goal unpause, /goal clear
+Commands: /goal resume, /goal clear

--- a/codex-rs/tui/src/chatwidget/tests/slash_commands.rs
+++ b/codex-rs/tui/src/chatwidget/tests/slash_commands.rs
@@ -810,7 +810,7 @@ async fn goal_control_slash_commands_emit_goal_events() {
     let cases = [
         ("/goal clear", None),
         ("/goal pause", Some(AppThreadGoalStatus::Paused)),
-        ("/goal unpause", Some(AppThreadGoalStatus::Active)),
+        ("/goal resume", Some(AppThreadGoalStatus::Active)),
     ];
 
     for (command, status) in cases {

--- a/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
+++ b/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
@@ -1842,10 +1842,7 @@ fn goal_status_indicator_line_formats_goal_text() {
             },
             "Goal unmet (4K / 5K tokens)",
         ),
-        (
-            GoalStatusIndicator::Paused,
-            "Goal paused (/goal to unpause)",
-        ),
+        (GoalStatusIndicator::Paused, "Goal paused (/goal resume)"),
         (
             GoalStatusIndicator::BudgetLimited { usage: None },
             "Goal abandoned",


### PR DESCRIPTION
## Why

The paused goal statusline currently points users at `/goal` to unpause a goal, but bare `/goal` is the summary command and does not change the goal state. Instead of making `/goal` mutate state only when a goal is paused, this gives the action an explicit command that reads naturally in the UI.

## What Changed

- Replace `/goal unpause` with `/goal resume` for reactivating a paused goal.
- Update the paused goal statusline and `/goal` summary copy to point at `/goal resume`.
