### PR TITLE
Mark goals feature as experimental

### DIFF
--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -949,7 +949,11 @@ pub const FEATURES: &[FeatureSpec] = &[
     FeatureSpec {
         id: Feature::Goals,
         key: "goals",
-        stage: Stage::UnderDevelopment,
+        stage: Stage::Experimental {
+            name: "Goals",
+            menu_description: "Set a persistent goal Codex can continue over time",
+            announcement: "",
+        },
         default_enabled: false,
     },
     FeatureSpec {

--- a/codex-rs/features/src/tests.rs
+++ b/codex-rs/features/src/tests.rs
@@ -231,20 +231,6 @@ fn tool_call_mcp_elicitation_is_stable_and_enabled_by_default() {
 }
 
 #[test]
-fn goals_is_experimental_and_disabled_by_default() {
-    let stage = Feature::Goals.stage();
-
-    assert!(matches!(stage, Stage::Experimental { .. }));
-    assert_eq!(stage.experimental_menu_name(), Some("Goals"));
-    assert_eq!(
-        stage.experimental_menu_description(),
-        Some("Set a persistent goal Codex can continue over time")
-    );
-    assert_eq!(stage.experimental_announcement(), None);
-    assert_eq!(Feature::Goals.default_enabled(), false);
-}
-
-#[test]
 fn remote_control_is_under_development() {
     assert_eq!(Feature::RemoteControl.stage(), Stage::UnderDevelopment);
     assert_eq!(Feature::RemoteControl.default_enabled(), false);

--- a/codex-rs/features/src/tests.rs
+++ b/codex-rs/features/src/tests.rs
@@ -231,6 +231,20 @@ fn tool_call_mcp_elicitation_is_stable_and_enabled_by_default() {
 }
 
 #[test]
+fn goals_is_experimental_and_disabled_by_default() {
+    let stage = Feature::Goals.stage();
+
+    assert!(matches!(stage, Stage::Experimental { .. }));
+    assert_eq!(stage.experimental_menu_name(), Some("Goals"));
+    assert_eq!(
+        stage.experimental_menu_description(),
+        Some("Set a persistent goal Codex can continue over time")
+    );
+    assert_eq!(stage.experimental_announcement(), None);
+    assert_eq!(Feature::Goals.default_enabled(), false);
+}
+
+#[test]
 fn remote_control_is_under_development() {
     assert_eq!(Feature::RemoteControl.stage(), Stage::UnderDevelopment);
     assert_eq!(Feature::RemoteControl.default_enabled(), false);


### PR DESCRIPTION
## Why

The `goals` feature flag is ready to move out of the hidden under-development bucket and into the user-facing experimental surface. Marking it experimental lets users discover it through the experimental features UI while still making clear that it is opt-in.

## What changed

- Changed `goals` from `Stage::UnderDevelopment` to `Stage::Experimental` in `codex-rs/features/src/lib.rs`.
- Added experimental menu metadata for the feature with the description `Set a persistent goal Codex can continue over time`.

## Verification

- `cargo test -p codex-features`
