### PR TITLE
Fix plugin list workspace settings test isolation

### DIFF
--- a/codex-rs/app-server/tests/common/mcp_process.rs
+++ b/codex-rs/app-server/tests/common/mcp_process.rs
@@ -118,6 +118,15 @@ impl McpProcess {
         Self::new_with_env(codex_home, &[(DISABLE_MANAGED_CONFIG_ENV_VAR, Some("1"))]).await
     }
 
+    pub async fn new_without_managed_config_with_env(
+        codex_home: &Path,
+        env_overrides: &[(&str, Option<&str>)],
+    ) -> anyhow::Result<Self> {
+        let mut all_env_overrides = vec![(DISABLE_MANAGED_CONFIG_ENV_VAR, Some("1"))];
+        all_env_overrides.extend_from_slice(env_overrides);
+        Self::new_with_env(codex_home, &all_env_overrides).await
+    }
+
     pub async fn new_with_plugin_startup_tasks(codex_home: &Path) -> anyhow::Result<Self> {
         Self::new_with_env_and_args(codex_home, &[], &[]).await
     }

--- a/codex-rs/app-server/tests/suite/v2/plugin_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/plugin_list.rs
@@ -307,7 +307,15 @@ async fn plugin_list_returns_empty_when_workspace_codex_plugins_disabled() -> Re
         .mount(&server)
         .await;
 
-    let mut mcp = McpProcess::new_without_managed_config(codex_home.path()).await?;
+    let home = codex_home.path().to_string_lossy().into_owned();
+    let mut mcp = McpProcess::new_without_managed_config_with_env(
+        codex_home.path(),
+        &[
+            ("HOME", Some(home.as_str())),
+            ("USERPROFILE", Some(home.as_str())),
+        ],
+    )
+    .await?;
     timeout(DEFAULT_TIMEOUT, mcp.initialize()).await??;
 
     let request_id = mcp
@@ -388,7 +396,15 @@ async fn plugin_list_reuses_cached_workspace_codex_plugins_setting() -> Result<(
         .mount(&server)
         .await;
 
-    let mut mcp = McpProcess::new_without_managed_config(codex_home.path()).await?;
+    let home = codex_home.path().to_string_lossy().into_owned();
+    let mut mcp = McpProcess::new_without_managed_config_with_env(
+        codex_home.path(),
+        &[
+            ("HOME", Some(home.as_str())),
+            ("USERPROFILE", Some(home.as_str())),
+        ],
+    )
+    .await?;
     timeout(DEFAULT_TIMEOUT, mcp.initialize()).await??;
 
     for _ in 0..2 {


### PR DESCRIPTION
Fixes test that often fails locally when running `cargo test`
- Add an app-server test helper that combines managed-config isolation with custom env overrides.
- Isolate `HOME` / `USERPROFILE` in plugin-list workspace settings tests so host home marketplaces do not affect results.