### PR TITLE
Increase plugin hook env test timeout

### DIFF
--- a/codex-rs/hooks/src/engine/mod_tests.rs
+++ b/codex-rs/hooks/src/engine/mod_tests.rs
@@ -373,7 +373,7 @@ print(json.dumps({
                 matcher: Some("Bash".to_string()),
                 hooks: vec![HookHandlerConfig::Command {
                     command: format!("python3 {}", script_path.display()),
-                    timeout_sec: Some(15),
+                    timeout_sec: Some(10),
                     r#async: false,
                     status_message: None,
                 }],
@@ -425,12 +425,7 @@ print(json.dumps({
 
     assert_eq!(outcome.hook_events.len(), 1);
     assert_eq!(outcome.hook_events[0].run.source, HookSource::Plugin);
-    assert_eq!(
-        outcome.hook_events[0].run.status,
-        HookRunStatus::Completed,
-        "plugin hook entries: {:?}",
-        outcome.hook_events[0].run.entries,
-    );
+    assert_eq!(outcome.hook_events[0].run.status, HookRunStatus::Completed);
     assert_eq!(outcome.hook_events[0].run.entries.len(), 1);
     assert_eq!(
         outcome.hook_events[0].run.entries[0].kind,

--- a/codex-rs/hooks/src/engine/mod_tests.rs
+++ b/codex-rs/hooks/src/engine/mod_tests.rs
@@ -373,7 +373,7 @@ print(json.dumps({
                 matcher: Some("Bash".to_string()),
                 hooks: vec![HookHandlerConfig::Command {
                     command: format!("python3 {}", script_path.display()),
-                    timeout_sec: Some(5),
+                    timeout_sec: Some(15),
                     r#async: false,
                     status_message: None,
                 }],
@@ -425,7 +425,12 @@ print(json.dumps({
 
     assert_eq!(outcome.hook_events.len(), 1);
     assert_eq!(outcome.hook_events[0].run.source, HookSource::Plugin);
-    assert_eq!(outcome.hook_events[0].run.status, HookRunStatus::Completed);
+    assert_eq!(
+        outcome.hook_events[0].run.status,
+        HookRunStatus::Completed,
+        "plugin hook entries: {:?}",
+        outcome.hook_events[0].run.entries,
+    );
     assert_eq!(outcome.hook_events[0].run.entries.len(), 1);
     assert_eq!(
         outcome.hook_events[0].run.entries[0].kind,


### PR DESCRIPTION
# Why

`plugin_hook_sources_run_with_plugin_env_and_plugin_source` can still fail on Windows after the earlier file-based assertion cleanup because the hook process itself occasionally exceeds the old 5s timeout under CI load. When that happens, the hook run ends as `Failed` before the test can inspect its structured output.

The Windows Bazel failure showed the hook run itself failing after nearly 8 seconds:

```text
---- engine::tests::plugin_hook_sources_run_with_plugin_env_and_plugin_source stdout ----
thread 'engine::tests::plugin_hook_sources_run_with_plugin_env_and_plugin_source' panicked at hooks/src\engine\mod_tests.rs:428:5:
assertion failed: `(left == right)`
Diff < left / right > :
<Failed
>Completed
...
test result: FAILED. 78 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 7.96s
```

# What

- raise the flaky plugin hook env test timeout from 5s to 10s so it matches the other executed hook tests in this module

# Validation

- `cargo test -p codex-hooks`