### PR TITLE
feat: update Bedrock Mantle endpoint and GPT-5.4 model ID

### DIFF
--- a/codex-rs/model-provider-info/src/lib.rs
+++ b/codex-rs/model-provider-info/src/lib.rs
@@ -36,7 +36,8 @@ const OPENAI_PROVIDER_NAME: &str = "OpenAI";
 pub const OPENAI_PROVIDER_ID: &str = "openai";
 const AMAZON_BEDROCK_PROVIDER_NAME: &str = "Amazon Bedrock";
 pub const AMAZON_BEDROCK_PROVIDER_ID: &str = "amazon-bedrock";
-pub const AMAZON_BEDROCK_DEFAULT_BASE_URL: &str = "https://bedrock-mantle.us-east-1.api.aws/v1";
+pub const AMAZON_BEDROCK_DEFAULT_BASE_URL: &str =
+    "https://bedrock-mantle.us-east-1.api.aws/openai/v1";
 const CHAT_WIRE_API_REMOVED_ERROR: &str = "`wire_api = \"chat\"` is no longer supported.\nHow to fix: set `wire_api = \"responses\"` in your provider config.\nMore info: https://github.com/openai/codex/discussions/7782";
 pub const LEGACY_OLLAMA_CHAT_PROVIDER_ID: &str = "ollama-chat";
 pub const OLLAMA_CHAT_PROVIDER_REMOVED_ERROR: &str = "`ollama-chat` is no longer supported.\nHow to fix: replace `ollama-chat` with `ollama` in `model_provider`, `oss_provider`, or `--local-provider`.\nMore info: https://github.com/openai/codex/discussions/7782";

--- a/codex-rs/model-provider-info/src/model_provider_info_tests.rs
+++ b/codex-rs/model-provider-info/src/model_provider_info_tests.rs
@@ -245,7 +245,7 @@ fn test_create_amazon_bedrock_provider() {
         ModelProviderInfo::create_amazon_bedrock_provider(/*aws*/ None),
         ModelProviderInfo {
             name: "Amazon Bedrock".to_string(),
-            base_url: Some("https://bedrock-mantle.us-east-1.api.aws/v1".to_string()),
+            base_url: Some("https://bedrock-mantle.us-east-1.api.aws/openai/v1".to_string()),
             env_key: None,
             env_key_instructions: None,
             experimental_bearer_token: None,

--- a/codex-rs/model-provider/src/amazon_bedrock/catalog.rs
+++ b/codex-rs/model-provider/src/amazon_bedrock/catalog.rs
@@ -15,7 +15,7 @@ use codex_protocol::openai_models::WebSearchToolType;
 const GPT_OSS_CONTEXT_WINDOW: i64 = 128_000;
 const GPT_5_4_CONTEXT_WINDOW: i64 = 272_000;
 const GPT_5_4_MAX_CONTEXT_WINDOW: i64 = 1_000_000;
-const GPT_5_4_CMB_MODEL_ID: &str = "openai.gpt-5.4-cmb";
+const GPT_5_4_CMB_MODEL_ID: &str = "openai.gpt-5.4";
 
 pub(crate) fn static_model_catalog() -> ModelsResponse {
     ModelsResponse {

--- a/codex-rs/model-provider/src/amazon_bedrock/mantle.rs
+++ b/codex-rs/model-provider/src/amazon_bedrock/mantle.rs
@@ -37,7 +37,7 @@ pub(super) fn region_from_config(aws: &ModelProviderAwsAuthInfo) -> Option<Strin
 
 pub(super) fn base_url(region: &str) -> Result<String> {
     if BEDROCK_MANTLE_SUPPORTED_REGIONS.contains(&region) {
-        Ok(format!("https://bedrock-mantle.{region}.api.aws/v1"))
+        Ok(format!("https://bedrock-mantle.{region}.api.aws/openai/v1"))
     } else {
         Err(CodexErr::Fatal(format!(
             "Amazon Bedrock Mantle does not support region `{region}`"
@@ -55,7 +55,7 @@ mod tests {
     fn base_url_uses_region_endpoint() {
         assert_eq!(
             base_url("ap-northeast-1").expect("supported region"),
-            "https://bedrock-mantle.ap-northeast-1.api.aws/v1"
+            "https://bedrock-mantle.ap-northeast-1.api.aws/openai/v1"
         );
     }
 

--- a/codex-rs/model-provider/src/amazon_bedrock/mod.rs
+++ b/codex-rs/model-provider/src/amazon_bedrock/mod.rs
@@ -122,7 +122,7 @@ mod tests {
 
         assert_eq!(
             api_provider.base_url,
-            "https://bedrock-mantle.eu-central-1.api.aws/v1"
+            "https://bedrock-mantle.eu-central-1.api.aws/openai/v1"
         );
     }
 

--- a/codex-rs/model-provider/src/provider.rs
+++ b/codex-rs/model-provider/src/provider.rs
@@ -461,7 +461,7 @@ mod tests {
         assert_eq!(
             model_ids,
             vec![
-                "openai.gpt-5.4-cmb",
+                "openai.gpt-5.4",
                 "openai.gpt-oss-120b",
                 "openai.gpt-oss-20b"
             ]
@@ -474,7 +474,7 @@ mod tests {
             .find(|preset| preset.is_default)
             .expect("Bedrock catalog should have a default model");
 
-        assert_eq!(default_model.model, "openai.gpt-5.4-cmb");
+        assert_eq!(default_model.model, "openai.gpt-5.4");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Amazon Bedrock Mantle's OpenAI-compatible endpoint now lives under `/openai/v1`, and the GPT-5.4 Mantle model ID no longer uses the `-cmb` suffix. This updates Codex's built-in Bedrock provider configuration so generated providers and the static Bedrock catalog use the current endpoint and model ID.

## Changes

- Update the Bedrock Mantle base URL from `https://bedrock-mantle.{region}.api.aws/v1` to `https://bedrock-mantle.{region}.api.aws/openai/v1`.
- Update the Amazon Bedrock default base URL in `codex-model-provider-info`.
- Change the Bedrock GPT-5.4 catalog slug from `openai.gpt-5.4-cmb` to `openai.gpt-5.4`.
- Align provider and catalog tests with the new URL and model ID.

## Test Plan

- Manual smoke test:

  ```shell
  target/debug/codex \
      -m openai.gpt-5.4 \
      -c 'model_provider="amazon-bedrock"' \
      -c 'model_providers.amazon-bedrock.aws.region="us-west-2"'
  ```
