### PR TITLE
TUI: Remove core protocol dependency [6/6]

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -106,7 +106,6 @@ use codex_app_server_protocol::PluginReadResponse;
 use codex_app_server_protocol::PluginUninstallParams;
 use codex_app_server_protocol::PluginUninstallResponse;
 use codex_app_server_protocol::RateLimitSnapshot;
-use codex_app_server_protocol::RequestId;
 use codex_app_server_protocol::SendAddCreditsNudgeEmailParams;
 use codex_app_server_protocol::ServerNotification;
 use codex_app_server_protocol::ServerRequest;
@@ -215,19 +214,6 @@ const THREAD_EVENT_CHANNEL_CAPACITY: usize = 32768;
 enum ThreadInteractiveRequest {
     Approval(ApprovalRequest),
     McpServerElicitation(McpServerElicitationFormRequest),
-}
-
-fn app_server_request_id_to_mcp_request_id(
-    request_id: &codex_app_server_protocol::RequestId,
-) -> codex_protocol::mcp::RequestId {
-    match request_id {
-        codex_app_server_protocol::RequestId::String(value) => {
-            codex_protocol::mcp::RequestId::String(value.clone())
-        }
-        codex_app_server_protocol::RequestId::Integer(value) => {
-            codex_protocol::mcp::RequestId::Integer(*value)
-        }
-    }
 }
 
 /// Extracts `receiver_thread_ids` from collab agent tool-call notifications.

--- a/codex-rs/tui/src/app/app_server_requests.rs
+++ b/codex-rs/tui/src/app/app_server_requests.rs
@@ -8,13 +8,10 @@ use crate::app_server_session::AppServerSession;
 use codex_app_server_protocol::CommandExecutionRequestApprovalResponse;
 use codex_app_server_protocol::FileChangeRequestApprovalResponse;
 use codex_app_server_protocol::JSONRPCErrorError;
-use codex_app_server_protocol::McpServerElicitationAction;
 use codex_app_server_protocol::McpServerElicitationRequestResponse;
 use codex_app_server_protocol::PermissionsRequestApprovalResponse;
 use codex_app_server_protocol::RequestId as AppServerRequestId;
 use codex_app_server_protocol::ServerRequest;
-use codex_app_server_protocol::ToolRequestUserInputResponse;
-use codex_protocol::mcp::RequestId as McpRequestId;
 
 impl App {
     pub(super) async fn reject_app_server_request(
@@ -65,7 +62,7 @@ pub(crate) enum ResolvedAppServerRequest {
     },
     McpElicitation {
         server_name: String,
-        request_id: McpRequestId,
+        request_id: AppServerRequestId,
     },
 }
 
@@ -75,7 +72,7 @@ pub(super) struct PendingAppServerRequests {
     file_change_approvals: HashMap<String, AppServerRequestId>,
     permissions_approvals: HashMap<String, AppServerRequestId>,
     user_inputs: HashMap<String, VecDeque<PendingUserInputRequest>>,
-    mcp_requests: HashMap<McpLegacyRequestKey, AppServerRequestId>,
+    mcp_requests: HashMap<McpRequestKey, AppServerRequestId>,
 }
 
 impl PendingAppServerRequests {
@@ -122,9 +119,9 @@ impl PendingAppServerRequests {
             }
             ServerRequest::McpServerElicitationRequest { request_id, params } => {
                 self.mcp_requests.insert(
-                    McpLegacyRequestKey {
+                    McpRequestKey {
                         server_name: params.server_name.clone(),
-                        request_id: app_server_request_id_to_mcp_request_id(request_id),
+                        request_id: request_id.clone(),
                     },
                     request_id.clone(),
                 );
@@ -173,7 +170,9 @@ impl PendingAppServerRequests {
                             decision: decision.clone(),
                         })
                         .map_err(|err| {
-                            format!("failed to serialize command execution approval response: {err}")
+                            format!(
+                                "failed to serialize command execution approval response: {err}"
+                            )
                         })?,
                     })
                 })
@@ -217,19 +216,7 @@ impl PendingAppServerRequests {
                 .map(|pending| {
                     Ok::<AppServerRequestResolution, String>(AppServerRequestResolution {
                         request_id: pending.request_id,
-                        result: serde_json::to_value(
-                            serde_json::from_value::<ToolRequestUserInputResponse>(
-                                serde_json::to_value(response).map_err(|err| {
-                                    format!("failed to encode request_user_input response: {err}")
-                                })?,
-                            )
-                            .map_err(|err| {
-                                format!(
-                                    "failed to decode request_user_input response for app-server: {err}"
-                                )
-                            })?,
-                        )
-                        .map_err(|err| {
+                        result: serde_json::to_value(response).map_err(|err| {
                             format!("failed to serialize request_user_input response: {err}")
                         })?,
                     })
@@ -243,7 +230,7 @@ impl PendingAppServerRequests {
                 meta,
             } => self
                 .mcp_requests
-                .remove(&McpLegacyRequestKey {
+                .remove(&McpRequestKey {
                     server_name: server_name.to_string(),
                     request_id: request_id.clone(),
                 })
@@ -251,17 +238,7 @@ impl PendingAppServerRequests {
                     Ok::<AppServerRequestResolution, String>(AppServerRequestResolution {
                         request_id,
                         result: serde_json::to_value(McpServerElicitationRequestResponse {
-                            action: match decision {
-                                codex_protocol::approvals::ElicitationAction::Accept => {
-                                    McpServerElicitationAction::Accept
-                                }
-                                codex_protocol::approvals::ElicitationAction::Decline => {
-                                    McpServerElicitationAction::Decline
-                                }
-                                codex_protocol::approvals::ElicitationAction::Cancel => {
-                                    McpServerElicitationAction::Cancel
-                                }
-                            },
+                            action: *decision,
                             content: content.clone(),
                             meta: meta.clone(),
                         })
@@ -404,16 +381,9 @@ struct PendingUserInputRequest {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct McpLegacyRequestKey {
+struct McpRequestKey {
     server_name: String,
-    request_id: McpRequestId,
-}
-
-fn app_server_request_id_to_mcp_request_id(request_id: &AppServerRequestId) -> McpRequestId {
-    match request_id {
-        AppServerRequestId::String(value) => McpRequestId::String(value.clone()),
-        AppServerRequestId::Integer(value) => McpRequestId::Integer(*value),
-    }
+    request_id: AppServerRequestId,
 }
 
 #[cfg(test)]
@@ -429,6 +399,7 @@ mod tests {
     use codex_app_server_protocol::FileChangeRequestApprovalParams;
     use codex_app_server_protocol::McpElicitationObjectType;
     use codex_app_server_protocol::McpElicitationSchema;
+    use codex_app_server_protocol::McpServerElicitationAction;
     use codex_app_server_protocol::McpServerElicitationRequest;
     use codex_app_server_protocol::McpServerElicitationRequestParams;
     use codex_app_server_protocol::PermissionGrantScope;
@@ -439,8 +410,6 @@ mod tests {
     use codex_app_server_protocol::ToolRequestUserInputAnswer;
     use codex_app_server_protocol::ToolRequestUserInputParams;
     use codex_app_server_protocol::ToolRequestUserInputResponse;
-    use codex_protocol::approvals::ElicitationAction;
-    use codex_protocol::mcp::RequestId as McpRequestId;
     use codex_protocol::models::FileSystemPermissions;
     use codex_protocol::models::NetworkPermissions;
     use codex_protocol::request_permissions::RequestPermissionProfile;
@@ -591,10 +560,10 @@ mod tests {
         let user_input = pending
             .take_resolution(&Op::UserInputAnswer {
                 id: "turn-2".to_string(),
-                response: codex_protocol::request_user_input::RequestUserInputResponse {
+                response: ToolRequestUserInputResponse {
                     answers: std::iter::once((
                         "question".to_string(),
-                        codex_protocol::request_user_input::RequestUserInputAnswer {
+                        ToolRequestUserInputAnswer {
                             answers: vec!["yes".to_string()],
                         },
                     ))
@@ -648,8 +617,8 @@ mod tests {
         let resolution = pending
             .take_resolution(&Op::ResolveElicitation {
                 server_name: "example".to_string(),
-                request_id: McpRequestId::Integer(12),
-                decision: ElicitationAction::Accept,
+                request_id: AppServerRequestId::Integer(12),
+                decision: McpServerElicitationAction::Accept,
                 content: Some(json!({ "answer": "yes" })),
                 meta: Some(json!({ "source": "tui" })),
             })
@@ -802,7 +771,7 @@ mod tests {
             pending.resolve_notification(&AppServerRequestId::Integer(12)),
             Some(ResolvedAppServerRequest::McpElicitation {
                 server_name: "example".to_string(),
-                request_id: McpRequestId::Integer(12),
+                request_id: AppServerRequestId::Integer(12),
             })
         );
     }
@@ -843,7 +812,7 @@ mod tests {
             });
         }
 
-        let response = codex_protocol::request_user_input::RequestUserInputResponse {
+        let response = ToolRequestUserInputResponse {
             answers: HashMap::new(),
         };
         let first_response = pending

--- a/codex-rs/tui/src/app/background_requests.rs
+++ b/codex-rs/tui/src/app/background_requests.rs
@@ -7,6 +7,7 @@
 use super::*;
 use codex_app_server_protocol::MarketplaceAddParams;
 use codex_app_server_protocol::MarketplaceAddResponse;
+use codex_app_server_protocol::RequestId;
 use codex_utils_absolute_path::AbsolutePathBuf;
 
 impl App {

--- a/codex-rs/tui/src/app/pending_interactive_replay.rs
+++ b/codex-rs/tui/src/app/pending_interactive_replay.rs
@@ -9,11 +9,11 @@ use std::collections::HashSet;
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct ElicitationRequestKey {
     server_name: String,
-    request_id: codex_protocol::mcp::RequestId,
+    request_id: AppServerRequestId,
 }
 
 impl ElicitationRequestKey {
-    fn new(server_name: String, request_id: codex_protocol::mcp::RequestId) -> Self {
+    fn new(server_name: String, request_id: AppServerRequestId) -> Self {
         Self {
             server_name,
             request_id,
@@ -207,10 +207,8 @@ impl PendingInteractiveReplayState {
                 );
             }
             ServerRequest::McpServerElicitationRequest { request_id, params } => {
-                let key = ElicitationRequestKey::new(
-                    params.server_name.clone(),
-                    app_server_request_id_to_mcp_request_id(request_id),
-                );
+                let key =
+                    ElicitationRequestKey::new(params.server_name.clone(), request_id.clone());
                 self.elicitation_requests.insert(key.clone());
                 self.pending_requests_by_request_id.insert(
                     request_id.clone(),
@@ -310,7 +308,7 @@ impl PendingInteractiveReplayState {
                 self.elicitation_requests
                     .remove(&ElicitationRequestKey::new(
                         params.server_name.clone(),
-                        app_server_request_id_to_mcp_request_id(request_id),
+                        request_id.clone(),
                     ));
             }
             ServerRequest::ToolRequestUserInput { params, .. } => {
@@ -365,7 +363,7 @@ impl PendingInteractiveReplayState {
                 .elicitation_requests
                 .contains(&ElicitationRequestKey::new(
                     params.server_name.clone(),
-                    app_server_request_id_to_mcp_request_id(request_id),
+                    request_id.clone(),
                 )),
             ServerRequest::ToolRequestUserInput { params, .. } => {
                 self.request_user_input_call_ids.contains(&params.item_id)
@@ -548,10 +546,7 @@ impl PendingInteractiveReplayState {
             (
                 PendingInteractiveRequest::Elicitation(key),
                 ServerRequest::McpServerElicitationRequest { request_id, params },
-            ) => {
-                key.server_name == params.server_name
-                    && key.request_id == app_server_request_id_to_mcp_request_id(request_id)
-            }
+            ) => key.server_name == params.server_name && key.request_id == *request_id,
             (
                 PendingInteractiveRequest::RequestPermissions { turn_id, item_id },
                 ServerRequest::PermissionsRequestApproval { params, .. },
@@ -565,15 +560,6 @@ impl PendingInteractiveReplayState {
     }
 }
 
-fn app_server_request_id_to_mcp_request_id(
-    request_id: &AppServerRequestId,
-) -> codex_protocol::mcp::RequestId {
-    match request_id {
-        AppServerRequestId::String(value) => codex_protocol::mcp::RequestId::String(value.clone()),
-        AppServerRequestId::Integer(value) => codex_protocol::mcp::RequestId::Integer(*value),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::super::ThreadBufferedEvent;
@@ -584,6 +570,7 @@ mod tests {
     use codex_app_server_protocol::FileChangeRequestApprovalParams;
     use codex_app_server_protocol::McpElicitationObjectType;
     use codex_app_server_protocol::McpElicitationSchema;
+    use codex_app_server_protocol::McpServerElicitationAction;
     use codex_app_server_protocol::McpServerElicitationRequest;
     use codex_app_server_protocol::McpServerElicitationRequestParams;
     use codex_app_server_protocol::RequestId as AppServerRequestId;
@@ -592,6 +579,7 @@ mod tests {
     use codex_app_server_protocol::ServerRequestResolvedNotification;
     use codex_app_server_protocol::ThreadClosedNotification;
     use codex_app_server_protocol::ToolRequestUserInputParams;
+    use codex_app_server_protocol::ToolRequestUserInputResponse;
     use codex_app_server_protocol::Turn;
     use codex_app_server_protocol::TurnCompletedNotification;
     use codex_app_server_protocol::TurnStatus;
@@ -723,7 +711,7 @@ mod tests {
 
         store.note_outbound_op(&Op::UserInputAnswer {
             id: "turn-1".to_string(),
-            response: codex_protocol::request_user_input::RequestUserInputResponse {
+            response: ToolRequestUserInputResponse {
                 answers: HashMap::new(),
             },
         });
@@ -808,7 +796,7 @@ mod tests {
 
         store.note_outbound_op(&Op::UserInputAnswer {
             id: "turn-1".to_string(),
-            response: codex_protocol::request_user_input::RequestUserInputResponse {
+            response: ToolRequestUserInputResponse {
                 answers: HashMap::new(),
             },
         });
@@ -832,7 +820,7 @@ mod tests {
 
         store.note_outbound_op(&Op::UserInputAnswer {
             id: "turn-1".to_string(),
-            response: codex_protocol::request_user_input::RequestUserInputResponse {
+            response: ToolRequestUserInputResponse {
                 answers: HashMap::new(),
             },
         });
@@ -887,13 +875,13 @@ mod tests {
     #[test]
     fn thread_event_snapshot_drops_resolved_elicitation_after_outbound_resolution() {
         let mut store = ThreadEventStore::new(/*capacity*/ 8);
-        let request_id = codex_protocol::mcp::RequestId::String("request-1".to_string());
+        let request_id = AppServerRequestId::String("request-1".to_string());
         store.push_request(elicitation_request("server-1", "request-1", "turn-1"));
 
         store.note_outbound_op(&Op::ResolveElicitation {
             server_name: "server-1".to_string(),
             request_id,
-            decision: codex_protocol::approvals::ElicitationAction::Accept,
+            decision: McpServerElicitationAction::Accept,
             content: None,
             meta: None,
         });

--- a/codex-rs/tui/src/app/thread_routing.rs
+++ b/codex-rs/tui/src/app/thread_routing.rs
@@ -264,7 +264,7 @@ impl App {
             ServerRequest::McpServerElicitationRequest { request_id, params } => {
                 if let Some(request) = McpServerElicitationFormRequest::from_app_server_request(
                     thread_id,
-                    app_server_request_id_to_mcp_request_id(request_id),
+                    request_id.clone(),
                     params.clone(),
                 ) {
                     Some(ThreadInteractiveRequest::McpServerElicitation(request))
@@ -274,7 +274,7 @@ impl App {
                             thread_id,
                             thread_label,
                             server_name: params.server_name.clone(),
-                            request_id: app_server_request_id_to_mcp_request_id(request_id),
+                            request_id: request_id.clone(),
                             message: match &params.request {
                                 codex_app_server_protocol::McpServerElicitationRequest::Form {
                                     message,

--- a/codex-rs/tui/src/app_command.rs
+++ b/codex-rs/tui/src/app_command.rs
@@ -3,23 +3,23 @@ use std::path::PathBuf;
 use codex_app_server_protocol::AskForApproval;
 use codex_app_server_protocol::CommandExecutionApprovalDecision;
 use codex_app_server_protocol::FileChangeApprovalDecision;
+use codex_app_server_protocol::McpServerElicitationAction;
+use codex_app_server_protocol::RequestId as AppServerRequestId;
 use codex_app_server_protocol::ReviewTarget;
 use codex_app_server_protocol::ThreadRealtimeAudioChunk;
 use codex_app_server_protocol::ThreadRealtimeStartTransport;
+use codex_app_server_protocol::ToolRequestUserInputResponse;
 use codex_app_server_protocol::UserInput;
 use codex_config::types::ApprovalsReviewer;
-use codex_protocol::approvals::ElicitationAction;
 use codex_protocol::approvals::GuardianAssessmentEvent;
 use codex_protocol::config_types::CollaborationMode;
 use codex_protocol::config_types::Personality;
 use codex_protocol::config_types::ReasoningSummary as ReasoningSummaryConfig;
 use codex_protocol::config_types::ServiceTier;
 use codex_protocol::config_types::WindowsSandboxLevel;
-use codex_protocol::mcp::RequestId as McpRequestId;
 use codex_protocol::models::PermissionProfile;
 use codex_protocol::openai_models::ReasoningEffort as ReasoningEffortConfig;
 use codex_protocol::request_permissions::RequestPermissionsResponse;
-use codex_protocol::request_user_input::RequestUserInputResponse;
 use serde::Serialize;
 use serde_json::Value;
 
@@ -75,14 +75,14 @@ pub(crate) enum AppCommand {
     },
     ResolveElicitation {
         server_name: String,
-        request_id: McpRequestId,
-        decision: ElicitationAction,
+        request_id: AppServerRequestId,
+        decision: McpServerElicitationAction,
         content: Option<Value>,
         meta: Option<Value>,
     },
     UserInputAnswer {
         id: String,
-        response: RequestUserInputResponse,
+        response: ToolRequestUserInputResponse,
     },
     RequestPermissionsResponse {
         id: String,
@@ -222,8 +222,8 @@ impl AppCommand {
 
     pub(crate) fn resolve_elicitation(
         server_name: String,
-        request_id: McpRequestId,
-        decision: ElicitationAction,
+        request_id: AppServerRequestId,
+        decision: McpServerElicitationAction,
         content: Option<Value>,
         meta: Option<Value>,
     ) -> Self {
@@ -236,7 +236,7 @@ impl AppCommand {
         }
     }
 
-    pub(crate) fn user_input_answer(id: String, response: RequestUserInputResponse) -> Self {
+    pub(crate) fn user_input_answer(id: String, response: ToolRequestUserInputResponse) -> Self {
         Self::UserInputAnswer { id, response }
     }
 

--- a/codex-rs/tui/src/app_event_sender.rs
+++ b/codex-rs/tui/src/app_event_sender.rs
@@ -8,13 +8,13 @@ use std::path::PathBuf;
 use crate::app_command::AppCommand;
 use codex_app_server_protocol::CommandExecutionApprovalDecision;
 use codex_app_server_protocol::FileChangeApprovalDecision;
+use codex_app_server_protocol::McpServerElicitationAction;
+use codex_app_server_protocol::RequestId as AppServerRequestId;
 use codex_app_server_protocol::ReviewTarget;
 use codex_app_server_protocol::ThreadRealtimeAudioChunk;
+use codex_app_server_protocol::ToolRequestUserInputResponse;
 use codex_protocol::ThreadId;
-use codex_protocol::approvals::ElicitationAction;
-use codex_protocol::mcp::RequestId as McpRequestId;
 use codex_protocol::request_permissions::RequestPermissionsResponse;
-use codex_protocol::request_user_input::RequestUserInputResponse;
 use tokio::sync::mpsc::UnboundedSender;
 
 use crate::app_event::AppEvent;
@@ -73,7 +73,7 @@ impl AppEventSender {
         )));
     }
 
-    pub(crate) fn user_input_answer(&self, id: String, response: RequestUserInputResponse) {
+    pub(crate) fn user_input_answer(&self, id: String, response: ToolRequestUserInputResponse) {
         self.send(AppEvent::CodexOp(AppCommand::user_input_answer(
             id, response,
         )));
@@ -119,8 +119,8 @@ impl AppEventSender {
         &self,
         thread_id: ThreadId,
         server_name: String,
-        request_id: McpRequestId,
-        decision: ElicitationAction,
+        request_id: AppServerRequestId,
+        decision: McpServerElicitationAction,
         content: Option<serde_json::Value>,
         meta: Option<serde_json::Value>,
     ) {

--- a/codex-rs/tui/src/bottom_pane/app_link_view.rs
+++ b/codex-rs/tui/src/bottom_pane/app_link_view.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 use crate::app_command::AppCommand as Op;
+use codex_app_server_protocol::McpServerElicitationAction;
+use codex_app_server_protocol::RequestId as AppServerRequestId;
 use codex_protocol::ThreadId;
-use codex_protocol::approvals::ElicitationAction;
-use codex_protocol::mcp::RequestId as McpRequestId;
 use crossterm::event::KeyCode;
 use crossterm::event::KeyEvent;
 use crossterm::event::KeyModifiers;
@@ -50,7 +50,7 @@ pub(crate) enum AppLinkSuggestionType {
 pub(crate) struct AppLinkElicitationTarget {
     pub(crate) thread_id: ThreadId,
     pub(crate) server_name: String,
-    pub(crate) request_id: McpRequestId,
+    pub(crate) request_id: AppServerRequestId,
 }
 
 pub(crate) struct AppLinkViewParams {
@@ -148,7 +148,7 @@ impl AppLinkView {
         self.elicitation_target.is_some()
     }
 
-    fn resolve_elicitation(&self, decision: ElicitationAction) {
+    fn resolve_elicitation(&self, decision: McpServerElicitationAction) {
         let Some(target) = self.elicitation_target.as_ref() else {
             return;
         };
@@ -163,7 +163,7 @@ impl AppLinkView {
     }
 
     fn decline_tool_suggestion(&mut self) {
-        self.resolve_elicitation(ElicitationAction::Decline);
+        self.resolve_elicitation(McpServerElicitationAction::Decline);
         self.complete = true;
     }
 
@@ -182,7 +182,7 @@ impl AppLinkView {
             force_refetch: true,
         });
         if self.is_tool_suggestion() {
-            self.resolve_elicitation(ElicitationAction::Accept);
+            self.resolve_elicitation(McpServerElicitationAction::Accept);
         }
         self.complete = true;
     }
@@ -199,7 +199,7 @@ impl AppLinkView {
             enabled: self.is_enabled,
         });
         if self.is_tool_suggestion() {
-            self.resolve_elicitation(ElicitationAction::Accept);
+            self.resolve_elicitation(McpServerElicitationAction::Accept);
             self.complete = true;
         }
     }
@@ -466,7 +466,7 @@ impl BottomPaneView for AppLinkView {
 
     fn on_ctrl_c(&mut self) -> CancellationEvent {
         if self.is_tool_suggestion() {
-            self.resolve_elicitation(ElicitationAction::Decline);
+            self.resolve_elicitation(McpServerElicitationAction::Decline);
         }
         self.complete = true;
         CancellationEvent::Handled
@@ -582,7 +582,7 @@ mod tests {
             thread_id: ThreadId::try_from("00000000-0000-0000-0000-000000000001")
                 .expect("valid thread id"),
             server_name: "codex_apps".to_string(),
-            request_id: McpRequestId::String("request-1".to_string()),
+            request_id: AppServerRequestId::String("request-1".to_string()),
         }
     }
 
@@ -856,8 +856,8 @@ mod tests {
                     op,
                     Op::ResolveElicitation {
                         server_name: "codex_apps".to_string(),
-                        request_id: McpRequestId::String("request-1".to_string()),
-                        decision: ElicitationAction::Accept,
+                        request_id: AppServerRequestId::String("request-1".to_string()),
+                        decision: McpServerElicitationAction::Accept,
                         content: None,
                         meta: None,
                     }
@@ -898,8 +898,8 @@ mod tests {
                     op,
                     Op::ResolveElicitation {
                         server_name: "codex_apps".to_string(),
-                        request_id: McpRequestId::String("request-1".to_string()),
-                        decision: ElicitationAction::Decline,
+                        request_id: AppServerRequestId::String("request-1".to_string()),
+                        decision: McpServerElicitationAction::Decline,
                         content: None,
                         meta: None,
                     }
@@ -948,8 +948,8 @@ mod tests {
                     op,
                     Op::ResolveElicitation {
                         server_name: "codex_apps".to_string(),
-                        request_id: McpRequestId::String("request-1".to_string()),
-                        decision: ElicitationAction::Accept,
+                        request_id: AppServerRequestId::String("request-1".to_string()),
+                        decision: McpServerElicitationAction::Accept,
                         content: None,
                         meta: None,
                     }
@@ -984,7 +984,7 @@ mod tests {
         assert!(
             view.dismiss_app_server_request(&ResolvedAppServerRequest::McpElicitation {
                 server_name: "codex_apps".to_string(),
-                request_id: McpRequestId::String("request-1".to_string()),
+                request_id: AppServerRequestId::String("request-1".to_string()),
             })
         );
         assert!(view.is_complete());
@@ -1013,7 +1013,7 @@ mod tests {
         assert!(
             !view.dismiss_app_server_request(&ResolvedAppServerRequest::McpElicitation {
                 server_name: "other_server".to_string(),
-                request_id: McpRequestId::String("request-1".to_string()),
+                request_id: AppServerRequestId::String("request-1".to_string()),
             })
         );
         assert!(!view.is_complete());

--- a/codex-rs/tui/src/bottom_pane/approval_overlay.rs
+++ b/codex-rs/tui/src/bottom_pane/approval_overlay.rs
@@ -45,12 +45,12 @@ use codex_app_server_protocol::FileSystemAccessMode;
 use codex_app_server_protocol::FileSystemPath;
 use codex_app_server_protocol::FileSystemSandboxEntry;
 use codex_app_server_protocol::FileSystemSpecialPath;
+use codex_app_server_protocol::McpServerElicitationAction;
 use codex_app_server_protocol::NetworkApprovalContext;
 use codex_app_server_protocol::NetworkPolicyRuleAction;
+use codex_app_server_protocol::RequestId;
 use codex_features::Features;
 use codex_protocol::ThreadId;
-use codex_protocol::approvals::ElicitationAction;
-use codex_protocol::mcp::RequestId;
 use codex_protocol::request_permissions::PermissionGrantScope;
 use codex_protocol::request_permissions::RequestPermissionProfile;
 use codex_utils_absolute_path::AbsolutePathBuf;
@@ -432,7 +432,7 @@ impl ApprovalOverlay {
         &self,
         server_name: &str,
         request_id: &RequestId,
-        decision: ElicitationAction,
+        decision: McpServerElicitationAction,
     ) {
         let Some(thread_id) = self
             .current_request
@@ -496,7 +496,7 @@ impl ApprovalOverlay {
                     self.handle_elicitation_decision(
                         server_name,
                         request_id,
-                        ElicitationAction::Cancel,
+                        McpServerElicitationAction::Cancel,
                     );
                 }
             }
@@ -748,7 +748,7 @@ enum ApprovalDecision {
     Command(CommandExecutionApprovalDecision),
     FileChange(FileChangeApprovalDecision),
     Permissions(PermissionsDecision),
-    McpElicitation(ElicitationAction),
+    McpElicitation(McpServerElicitationAction),
 }
 
 #[derive(Clone, Copy)]
@@ -1049,17 +1049,17 @@ fn elicitation_options(keymap: &ApprovalKeymap) -> Vec<ApprovalOption> {
     vec![
         ApprovalOption {
             label: "Yes, provide the requested info".to_string(),
-            decision: ApprovalDecision::McpElicitation(ElicitationAction::Accept),
+            decision: ApprovalDecision::McpElicitation(McpServerElicitationAction::Accept),
             shortcuts: keymap.approve.clone(),
         },
         ApprovalOption {
             label: "No, but continue without it".to_string(),
-            decision: ApprovalDecision::McpElicitation(ElicitationAction::Decline),
+            decision: ApprovalDecision::McpElicitation(McpServerElicitationAction::Decline),
             shortcuts: decline_shortcuts,
         },
         ApprovalOption {
             label: "Cancel this request".to_string(),
-            decision: ApprovalDecision::McpElicitation(ElicitationAction::Cancel),
+            decision: ApprovalDecision::McpElicitation(McpServerElicitationAction::Cancel),
             shortcuts: cancel_shortcuts,
         },
     ]
@@ -1258,7 +1258,7 @@ mod tests {
                 break;
             }
         }
-        assert_eq!(decision, Some(ElicitationAction::Cancel));
+        assert_eq!(decision, Some(McpServerElicitationAction::Cancel));
     }
 
     #[test]
@@ -2128,7 +2128,7 @@ mod tests {
                 break;
             }
         }
-        assert_eq!(decision, Some(ElicitationAction::Cancel));
+        assert_eq!(decision, Some(McpServerElicitationAction::Cancel));
     }
 
     #[test]
@@ -2162,7 +2162,7 @@ mod tests {
                 break;
             }
         }
-        assert_eq!(esc_decision, Some(ElicitationAction::Cancel));
+        assert_eq!(esc_decision, Some(McpServerElicitationAction::Cancel));
 
         let (tx_raw, mut rx) = unbounded_channel::<AppEvent>();
         let tx = AppEventSender::new(tx_raw);
@@ -2192,7 +2192,7 @@ mod tests {
                 break;
             }
         }
-        assert_eq!(n_decision, Some(ElicitationAction::Decline));
+        assert_eq!(n_decision, Some(McpServerElicitationAction::Decline));
     }
 
     #[test]

--- a/codex-rs/tui/src/bottom_pane/bottom_pane_view.rs
+++ b/codex-rs/tui/src/bottom_pane/bottom_pane_view.rs
@@ -2,7 +2,7 @@ use crate::app::app_server_requests::ResolvedAppServerRequest;
 use crate::bottom_pane::ApprovalRequest;
 use crate::bottom_pane::McpServerElicitationFormRequest;
 use crate::render::renderable::Renderable;
-use codex_protocol::request_user_input::RequestUserInputEvent;
+use codex_app_server_protocol::ToolRequestUserInputParams;
 use crossterm::event::KeyEvent;
 
 use super::CancellationEvent;
@@ -101,8 +101,8 @@ pub(crate) trait BottomPaneView: Renderable {
     /// consumed.
     fn try_consume_user_input_request(
         &mut self,
-        request: RequestUserInputEvent,
-    ) -> Option<RequestUserInputEvent> {
+        request: ToolRequestUserInputParams,
+    ) -> Option<ToolRequestUserInputParams> {
         Some(request)
     }
 

--- a/codex-rs/tui/src/bottom_pane/mcp_server_elicitation.rs
+++ b/codex-rs/tui/src/bottom_pane/mcp_server_elicitation.rs
@@ -7,13 +7,11 @@ use crate::app_command::AppCommand as Op;
 use codex_app_server_protocol::McpElicitationEnumSchema;
 use codex_app_server_protocol::McpElicitationPrimitiveSchema;
 use codex_app_server_protocol::McpElicitationSingleSelectEnumSchema;
+use codex_app_server_protocol::McpServerElicitationAction;
 use codex_app_server_protocol::McpServerElicitationRequest;
 use codex_app_server_protocol::McpServerElicitationRequestParams;
+use codex_app_server_protocol::RequestId as AppServerRequestId;
 use codex_protocol::ThreadId;
-use codex_protocol::approvals::ElicitationAction;
-use codex_protocol::approvals::ElicitationRequest;
-use codex_protocol::approvals::ElicitationRequestEvent;
-use codex_protocol::mcp::RequestId as McpRequestId;
 use codex_protocol::user_input::TextElement;
 use crossterm::event::KeyCode;
 use crossterm::event::KeyEvent;
@@ -166,7 +164,7 @@ struct McpToolApprovalDisplayParam {
 pub(crate) struct McpServerElicitationFormRequest {
     thread_id: ThreadId,
     server_name: String,
-    request_id: McpRequestId,
+    request_id: AppServerRequestId,
     message: String,
     approval_display_params: Vec<McpToolApprovalDisplayParam>,
     response_mode: McpServerElicitationResponseMode,
@@ -206,7 +204,7 @@ impl FooterTip {
 impl McpServerElicitationFormRequest {
     pub(crate) fn from_app_server_request(
         thread_id: ThreadId,
-        request_id: McpRequestId,
+        request_id: AppServerRequestId,
         request: McpServerElicitationRequestParams,
     ) -> Option<Self> {
         let McpServerElicitationRequestParams {
@@ -234,33 +232,10 @@ impl McpServerElicitationFormRequest {
         )
     }
 
-    pub(crate) fn from_event(
-        thread_id: ThreadId,
-        request: ElicitationRequestEvent,
-    ) -> Option<Self> {
-        let ElicitationRequest::Form {
-            meta,
-            message,
-            requested_schema,
-        } = request.request
-        else {
-            return None;
-        };
-
-        Self::from_parts(
-            thread_id,
-            request.server_name,
-            request.id,
-            meta,
-            message,
-            requested_schema,
-        )
-    }
-
     fn from_parts(
         thread_id: ThreadId,
         server_name: String,
-        request_id: McpRequestId,
+        request_id: AppServerRequestId,
         meta: Option<Value>,
         message: String,
         requested_schema: Value,
@@ -388,7 +363,7 @@ impl McpServerElicitationFormRequest {
         self.server_name.as_str()
     }
 
-    pub(crate) fn request_id(&self) -> &McpRequestId {
+    pub(crate) fn request_id(&self) -> &AppServerRequestId {
         &self.request_id
     }
 }
@@ -1140,7 +1115,7 @@ impl McpServerElicitationOverlay {
             self.request.thread_id,
             self.request.server_name.clone(),
             self.request.request_id.clone(),
-            ElicitationAction::Cancel,
+            McpServerElicitationAction::Cancel,
             /*content*/ None,
             /*meta*/ None,
         );
@@ -1167,22 +1142,22 @@ impl McpServerElicitationOverlay {
         if self.request.response_mode == McpServerElicitationResponseMode::ApprovalAction {
             let (decision, meta) =
                 match self.field_value(/*idx*/ 0).as_ref().and_then(Value::as_str) {
-                    Some(APPROVAL_ACCEPT_ONCE_VALUE) => (ElicitationAction::Accept, None),
+                    Some(APPROVAL_ACCEPT_ONCE_VALUE) => (McpServerElicitationAction::Accept, None),
                     Some(APPROVAL_ACCEPT_SESSION_VALUE) => (
-                        ElicitationAction::Accept,
+                        McpServerElicitationAction::Accept,
                         Some(serde_json::json!({
                             APPROVAL_PERSIST_KEY: APPROVAL_PERSIST_SESSION_VALUE,
                         })),
                     ),
                     Some(APPROVAL_ACCEPT_ALWAYS_VALUE) => (
-                        ElicitationAction::Accept,
+                        McpServerElicitationAction::Accept,
                         Some(serde_json::json!({
                             APPROVAL_PERSIST_KEY: APPROVAL_PERSIST_ALWAYS_VALUE,
                         })),
                     ),
-                    Some(APPROVAL_DECLINE_VALUE) => (ElicitationAction::Decline, None),
-                    Some(APPROVAL_CANCEL_VALUE) => (ElicitationAction::Cancel, None),
-                    _ => (ElicitationAction::Cancel, None),
+                    Some(APPROVAL_DECLINE_VALUE) => (McpServerElicitationAction::Decline, None),
+                    Some(APPROVAL_CANCEL_VALUE) => (McpServerElicitationAction::Cancel, None),
+                    _ => (McpServerElicitationAction::Cancel, None),
                 };
             self.app_event_tx.resolve_elicitation(
                 self.request.thread_id,
@@ -1206,7 +1181,7 @@ impl McpServerElicitationOverlay {
             self.request.thread_id,
             self.request.server_name.clone(),
             self.request.request_id.clone(),
-            ElicitationAction::Accept,
+            McpServerElicitationAction::Accept,
             Some(Value::Object(content)),
             /*meta*/ None,
         );
@@ -1732,17 +1707,33 @@ mod tests {
         message: &str,
         requested_schema: Value,
         meta: Option<Value>,
-    ) -> ElicitationRequestEvent {
-        ElicitationRequestEvent {
+    ) -> McpServerElicitationRequestParams {
+        McpServerElicitationRequestParams {
+            thread_id: "thread-1".to_string(),
             turn_id: Some("turn-1".to_string()),
             server_name: "server-1".to_string(),
-            id: McpRequestId::String("request-1".to_string()),
-            request: ElicitationRequest::Form {
+            request: McpServerElicitationRequest::Form {
                 meta,
                 message: message.to_string(),
-                requested_schema,
+                requested_schema: serde_json::from_value(requested_schema)
+                    .expect("test schema should deserialize"),
             },
         }
+    }
+
+    fn request_id(value: &str) -> AppServerRequestId {
+        AppServerRequestId::String(value.to_string())
+    }
+
+    fn from_form_request(
+        thread_id: ThreadId,
+        request: McpServerElicitationRequestParams,
+    ) -> Option<McpServerElicitationFormRequest> {
+        McpServerElicitationFormRequest::from_app_server_request(
+            thread_id,
+            request_id("request-1"),
+            request,
+        )
     }
 
     fn empty_object_schema() -> Value {
@@ -1816,7 +1807,7 @@ mod tests {
     #[test]
     fn parses_boolean_form_request() {
         let thread_id = ThreadId::default();
-        let request = McpServerElicitationFormRequest::from_event(
+        let request = from_form_request(
             thread_id,
             form_request(
                 "Allow this request?",
@@ -1841,7 +1832,7 @@ mod tests {
             McpServerElicitationFormRequest {
                 thread_id,
                 server_name: "server-1".to_string(),
-                request_id: McpRequestId::String("request-1".to_string()),
+                request_id: request_id("request-1"),
                 message: "Allow this request?".to_string(),
                 approval_display_params: Vec::new(),
                 response_mode: McpServerElicitationResponseMode::FormContent,
@@ -1873,7 +1864,7 @@ mod tests {
 
     #[test]
     fn unsupported_numeric_form_falls_back() {
-        let request = McpServerElicitationFormRequest::from_event(
+        let request = from_form_request(
             ThreadId::default(),
             form_request(
                 "Pick a number",
@@ -1894,11 +1885,15 @@ mod tests {
     }
 
     #[test]
-    fn missing_schema_uses_approval_actions() {
+    fn empty_object_schema_uses_approval_actions() {
         let thread_id = ThreadId::default();
-        let request = McpServerElicitationFormRequest::from_event(
+        let request = from_form_request(
             thread_id,
-            form_request("Allow this request?", Value::Null, /*meta*/ None),
+            form_request(
+                "Allow this request?",
+                empty_object_schema(),
+                /*meta*/ None,
+            ),
         )
         .expect("expected approval fallback");
 
@@ -1907,7 +1902,7 @@ mod tests {
             McpServerElicitationFormRequest {
                 thread_id,
                 server_name: "server-1".to_string(),
-                request_id: McpRequestId::String("request-1".to_string()),
+                request_id: request_id("request-1"),
                 message: "Allow this request?".to_string(),
                 approval_display_params: Vec::new(),
                 response_mode: McpServerElicitationResponseMode::ApprovalAction,
@@ -1945,7 +1940,7 @@ mod tests {
     #[test]
     fn empty_tool_approval_schema_uses_approval_actions() {
         let thread_id = ThreadId::default();
-        let request = McpServerElicitationFormRequest::from_event(
+        let request = from_form_request(
             thread_id,
             form_request(
                 "Allow this request?",
@@ -1964,7 +1959,7 @@ mod tests {
             McpServerElicitationFormRequest {
                 thread_id,
                 server_name: "server-1".to_string(),
-                request_id: McpRequestId::String("request-1".to_string()),
+                request_id: request_id("request-1"),
                 message: "Allow this request?".to_string(),
                 approval_display_params: Vec::new(),
                 response_mode: McpServerElicitationResponseMode::ApprovalAction,
@@ -1996,7 +1991,7 @@ mod tests {
 
     #[test]
     fn tool_suggestion_meta_is_parsed_into_request_payload() {
-        let request = McpServerElicitationFormRequest::from_event(
+        let request = from_form_request(
             ThreadId::default(),
             form_request(
                 "Suggest Google Calendar",
@@ -2029,7 +2024,7 @@ mod tests {
 
     #[test]
     fn plugin_tool_suggestion_meta_without_install_url_is_parsed_into_request_payload() {
-        let request = McpServerElicitationFormRequest::from_event(
+        let request = from_form_request(
             ThreadId::default(),
             form_request(
                 "Suggest Slack",
@@ -2061,7 +2056,7 @@ mod tests {
 
     #[test]
     fn tool_approval_display_params_prefer_explicit_display_order() {
-        let request = McpServerElicitationFormRequest::from_event(
+        let request = from_form_request(
             ThreadId::default(),
             form_request(
                 "Allow Calendar to create an event",
@@ -2110,7 +2105,7 @@ mod tests {
     fn submit_sends_accept_with_typed_content() {
         let (tx, mut rx) = test_sender();
         let thread_id = ThreadId::default();
-        let request = McpServerElicitationFormRequest::from_event(
+        let request = from_form_request(
             thread_id,
             form_request(
                 "Allow this request?",
@@ -2150,8 +2145,8 @@ mod tests {
             op,
             Op::ResolveElicitation {
                 server_name: "server-1".to_string(),
-                request_id: McpRequestId::String("request-1".to_string()),
-                decision: ElicitationAction::Accept,
+                request_id: request_id("request-1"),
+                decision: McpServerElicitationAction::Accept,
                 content: Some(serde_json::json!({
                     "confirmed": true,
                 })),
@@ -2164,7 +2159,7 @@ mod tests {
     fn empty_tool_approval_schema_session_choice_sets_persist_meta() {
         let (tx, mut rx) = test_sender();
         let thread_id = ThreadId::default();
-        let request = McpServerElicitationFormRequest::from_event(
+        let request = from_form_request(
             thread_id,
             form_request(
                 "Allow this request?",
@@ -2204,8 +2199,8 @@ mod tests {
             op,
             Op::ResolveElicitation {
                 server_name: "server-1".to_string(),
-                request_id: McpRequestId::String("request-1".to_string()),
-                decision: ElicitationAction::Accept,
+                request_id: request_id("request-1"),
+                decision: McpServerElicitationAction::Accept,
                 content: None,
                 meta: Some(serde_json::json!({
                     APPROVAL_PERSIST_KEY: APPROVAL_PERSIST_SESSION_VALUE,
@@ -2218,7 +2213,7 @@ mod tests {
     fn empty_tool_approval_schema_always_allow_sets_persist_meta() {
         let (tx, mut rx) = test_sender();
         let thread_id = ThreadId::default();
-        let request = McpServerElicitationFormRequest::from_event(
+        let request = from_form_request(
             thread_id,
             form_request(
                 "Allow this request?",
@@ -2258,8 +2253,8 @@ mod tests {
             op,
             Op::ResolveElicitation {
                 server_name: "server-1".to_string(),
-                request_id: McpRequestId::String("request-1".to_string()),
-                decision: ElicitationAction::Accept,
+                request_id: request_id("request-1"),
+                decision: McpServerElicitationAction::Accept,
                 content: None,
                 meta: Some(serde_json::json!({
                     APPROVAL_PERSIST_KEY: APPROVAL_PERSIST_ALWAYS_VALUE,
@@ -2272,7 +2267,7 @@ mod tests {
     fn ctrl_c_cancels_elicitation() {
         let (tx, mut rx) = test_sender();
         let thread_id = ThreadId::default();
-        let request = McpServerElicitationFormRequest::from_event(
+        let request = from_form_request(
             thread_id,
             form_request(
                 "Allow this request?",
@@ -2311,8 +2306,8 @@ mod tests {
             op,
             Op::ResolveElicitation {
                 server_name: "server-1".to_string(),
-                request_id: McpRequestId::String("request-1".to_string()),
-                decision: ElicitationAction::Cancel,
+                request_id: request_id("request-1"),
+                decision: McpServerElicitationAction::Cancel,
                 content: None,
                 meta: None,
             }
@@ -2322,7 +2317,7 @@ mod tests {
     #[test]
     fn queues_requests_fifo() {
         let (tx, _rx) = test_sender();
-        let first = McpServerElicitationFormRequest::from_event(
+        let first = from_form_request(
             ThreadId::default(),
             form_request(
                 "First",
@@ -2339,7 +2334,7 @@ mod tests {
             ),
         )
         .expect("expected supported form");
-        let second = McpServerElicitationFormRequest::from_event(
+        let second = from_form_request(
             ThreadId::default(),
             form_request(
                 "Second",
@@ -2356,7 +2351,7 @@ mod tests {
             ),
         )
         .expect("expected supported form");
-        let third = McpServerElicitationFormRequest::from_event(
+        let third = from_form_request(
             ThreadId::default(),
             form_request(
                 "Third",
@@ -2405,7 +2400,7 @@ mod tests {
             },
         });
         let mut overlay = McpServerElicitationOverlay::new(
-            McpServerElicitationFormRequest::from_event(
+            from_form_request(
                 thread_id,
                 form_request("First", supported_form_schema.clone(), /*meta*/ None),
             )
@@ -2416,16 +2411,18 @@ mod tests {
             /*disable_paste_burst*/ false,
         );
         overlay.try_consume_mcp_server_elicitation_request(
-            McpServerElicitationFormRequest::from_event(
+            McpServerElicitationFormRequest::from_app_server_request(
                 thread_id,
-                ElicitationRequestEvent {
+                request_id("request-2"),
+                McpServerElicitationRequestParams {
+                    thread_id: "thread-1".to_string(),
                     turn_id: Some("turn-2".to_string()),
                     server_name: "server-1".to_string(),
-                    id: McpRequestId::String("request-2".to_string()),
-                    request: ElicitationRequest::Form {
+                    request: McpServerElicitationRequest::Form {
                         meta: None,
                         message: "Second".to_string(),
-                        requested_schema: supported_form_schema,
+                        requested_schema: serde_json::from_value(supported_form_schema)
+                            .expect("test schema should deserialize"),
                     },
                 },
             )
@@ -2435,7 +2432,7 @@ mod tests {
         assert!(
             overlay.dismiss_app_server_request(&ResolvedAppServerRequest::McpElicitation {
                 server_name: "server-1".to_string(),
-                request_id: McpRequestId::String("request-1".to_string()),
+                request_id: request_id("request-1"),
             })
         );
         assert_eq!(overlay.request.message, "Second");
@@ -2447,7 +2444,7 @@ mod tests {
         assert!(
             overlay.dismiss_app_server_request(&ResolvedAppServerRequest::McpElicitation {
                 server_name: "server-1".to_string(),
-                request_id: McpRequestId::String("request-2".to_string()),
+                request_id: request_id("request-2"),
             })
         );
         assert!(overlay.is_complete());
@@ -2460,7 +2457,7 @@ mod tests {
     #[test]
     fn boolean_form_snapshot() {
         let (tx, _rx) = test_sender();
-        let request = McpServerElicitationFormRequest::from_event(
+        let request = from_form_request(
             ThreadId::default(),
             form_request(
                 "Allow this request?",
@@ -2493,7 +2490,7 @@ mod tests {
     #[test]
     fn approval_form_tool_approval_snapshot() {
         let (tx, _rx) = test_sender();
-        let request = McpServerElicitationFormRequest::from_event(
+        let request = from_form_request(
             ThreadId::default(),
             form_request(
                 "Allow this request?",
@@ -2520,7 +2517,7 @@ mod tests {
     #[test]
     fn message_only_form_snapshot() {
         let (tx, _rx) = test_sender();
-        let request = McpServerElicitationFormRequest::from_event(
+        let request = from_form_request(
             ThreadId::default(),
             form_request(
                 "Boolean elicit MCP example: do you confirm?",
@@ -2543,7 +2540,7 @@ mod tests {
     #[test]
     fn message_only_form_with_persist_options_snapshot() {
         let (tx, _rx) = test_sender();
-        let request = McpServerElicitationFormRequest::from_event(
+        let request = from_form_request(
             ThreadId::default(),
             form_request(
                 "Boolean elicit MCP example: do you confirm?",
@@ -2571,7 +2568,7 @@ mod tests {
     #[test]
     fn approval_form_tool_approval_with_persist_options_snapshot() {
         let (tx, _rx) = test_sender();
-        let request = McpServerElicitationFormRequest::from_event(
+        let request = from_form_request(
             ThreadId::default(),
             form_request(
                 "Allow this request?",
@@ -2601,7 +2598,7 @@ mod tests {
     #[test]
     fn approval_form_tool_approval_with_param_summary_snapshot() {
         let (tx, _rx) = test_sender();
-        let request = McpServerElicitationFormRequest::from_event(
+        let request = from_form_request(
             ThreadId::default(),
             form_request(
                 "Allow Calendar to create an event",

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -31,11 +31,11 @@ use crate::render::renderable::RenderableItem;
 use crate::tui::FrameRequester;
 pub(crate) use bottom_pane_view::BottomPaneView;
 use bottom_pane_view::ViewCompletion;
+use codex_app_server_protocol::ToolRequestUserInputParams;
 use codex_core_skills::model::SkillMetadata;
 use codex_features::Features;
 use codex_file_search::FileMatch;
 use codex_plugin::PluginCapabilitySummary;
-use codex_protocol::request_user_input::RequestUserInputEvent;
 use codex_protocol::user_input::TextElement;
 use crossterm::event::KeyCode;
 use crossterm::event::KeyEvent;
@@ -1205,7 +1205,7 @@ impl BottomPane {
     }
 
     /// Called when the agent requests user input.
-    pub fn push_user_input_request(&mut self, request: RequestUserInputEvent) {
+    pub fn push_user_input_request(&mut self, request: ToolRequestUserInputParams) {
         let request = if let Some(view) = self.view_stack.last_mut() {
             match view.try_consume_user_input_request(request) {
                 Some(request) => request,

--- a/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
@@ -33,9 +33,12 @@ use crate::render::renderable::Renderable;
 
 #[cfg(test)]
 use crate::app_command::AppCommand as Op;
-use codex_protocol::request_user_input::RequestUserInputAnswer;
-use codex_protocol::request_user_input::RequestUserInputEvent;
-use codex_protocol::request_user_input::RequestUserInputResponse;
+use codex_app_server_protocol::ToolRequestUserInputAnswer;
+#[cfg(test)]
+use codex_app_server_protocol::ToolRequestUserInputOption;
+use codex_app_server_protocol::ToolRequestUserInputParams;
+use codex_app_server_protocol::ToolRequestUserInputQuestion;
+use codex_app_server_protocol::ToolRequestUserInputResponse;
 use codex_protocol::user_input::TextElement;
 use unicode_width::UnicodeWidthStr;
 
@@ -122,9 +125,9 @@ impl FooterTip {
 
 pub(crate) struct RequestUserInputOverlay {
     app_event_tx: AppEventSender,
-    request: RequestUserInputEvent,
+    request: ToolRequestUserInputParams,
     // Queue of incoming requests to process after the current one.
-    queue: VecDeque<RequestUserInputEvent>,
+    queue: VecDeque<ToolRequestUserInputParams>,
     // Reuse the shared chat composer so notes/freeform answers match the
     // primary input styling and behavior.
     composer: ChatComposer,
@@ -139,7 +142,7 @@ pub(crate) struct RequestUserInputOverlay {
 
 impl RequestUserInputOverlay {
     pub(crate) fn new(
-        request: RequestUserInputEvent,
+        request: ToolRequestUserInputParams,
         app_event_tx: AppEventSender,
         has_input_focus: bool,
         enhanced_keys_supported: bool,
@@ -179,9 +182,7 @@ impl RequestUserInputOverlay {
         self.current_idx
     }
 
-    fn current_question(
-        &self,
-    ) -> Option<&codex_protocol::request_user_input::RequestUserInputQuestion> {
+    fn current_question(&self) -> Option<&ToolRequestUserInputQuestion> {
         self.request.questions.get(self.current_index())
     }
 
@@ -586,9 +587,7 @@ impl RequestUserInputOverlay {
         self.pending_submission_draft = None;
     }
 
-    fn options_len_for_question(
-        question: &codex_protocol::request_user_input::RequestUserInputQuestion,
-    ) -> usize {
+    fn options_len_for_question(question: &ToolRequestUserInputQuestion) -> usize {
         let options_len = question
             .options
             .as_ref()
@@ -601,9 +600,7 @@ impl RequestUserInputOverlay {
         }
     }
 
-    fn other_option_enabled_for_question(
-        question: &codex_protocol::request_user_input::RequestUserInputQuestion,
-    ) -> bool {
+    fn other_option_enabled_for_question(question: &ToolRequestUserInputQuestion) -> bool {
         question.is_other
             && question
                 .options
@@ -612,7 +609,7 @@ impl RequestUserInputOverlay {
     }
 
     fn option_label_for_index(
-        question: &codex_protocol::request_user_input::RequestUserInputQuestion,
+        question: &ToolRequestUserInputQuestion,
         idx: usize,
     ) -> Option<String> {
         let options = question.options.as_ref()?;
@@ -753,14 +750,14 @@ impl RequestUserInputOverlay {
             }
             answers.insert(
                 question.id.clone(),
-                RequestUserInputAnswer {
+                ToolRequestUserInputAnswer {
                     answers: answer_list,
                 },
             );
         }
         self.app_event_tx.user_input_answer(
             self.request.turn_id.clone(),
-            RequestUserInputResponse {
+            ToolRequestUserInputResponse {
                 answers: answers.clone(),
             },
         );
@@ -781,8 +778,8 @@ impl RequestUserInputOverlay {
 
         let queue_len = self.queue.len();
         self.queue
-            .retain(|queued_request| queued_request.call_id != *call_id);
-        if self.request.call_id == *call_id {
+            .retain(|queued_request| queued_request.item_id != *call_id);
+        if self.request.item_id == *call_id {
             self.advance_queue_or_complete();
             return true;
         }
@@ -1294,8 +1291,8 @@ impl BottomPaneView for RequestUserInputOverlay {
 
     fn try_consume_user_input_request(
         &mut self,
-        request: RequestUserInputEvent,
-    ) -> Option<RequestUserInputEvent> {
+        request: ToolRequestUserInputParams,
+    ) -> Option<ToolRequestUserInputParams> {
         self.queue.push_back(request);
         None
     }
@@ -1311,8 +1308,6 @@ mod tests {
     use crate::app_event::AppEvent;
     use crate::bottom_pane::selection_popup_common::menu_surface_inset;
     use crate::render::renderable::Renderable;
-    use codex_protocol::request_user_input::RequestUserInputQuestion;
-    use codex_protocol::request_user_input::RequestUserInputQuestionOption;
     use pretty_assertions::assert_eq;
     use ratatui::buffer::Buffer;
     use ratatui::layout::Rect;
@@ -1340,23 +1335,23 @@ mod tests {
         );
     }
 
-    fn question_with_options(id: &str, header: &str) -> RequestUserInputQuestion {
-        RequestUserInputQuestion {
+    fn question_with_options(id: &str, header: &str) -> ToolRequestUserInputQuestion {
+        ToolRequestUserInputQuestion {
             id: id.to_string(),
             header: header.to_string(),
             question: "Choose an option.".to_string(),
             is_other: false,
             is_secret: false,
             options: Some(vec![
-                RequestUserInputQuestionOption {
+                ToolRequestUserInputOption {
                     label: "Option 1".to_string(),
                     description: "First choice.".to_string(),
                 },
-                RequestUserInputQuestionOption {
+                ToolRequestUserInputOption {
                     label: "Option 2".to_string(),
                     description: "Second choice.".to_string(),
                 },
-                RequestUserInputQuestionOption {
+                ToolRequestUserInputOption {
                     label: "Option 3".to_string(),
                     description: "Third choice.".to_string(),
                 },
@@ -1364,23 +1359,23 @@ mod tests {
         }
     }
 
-    fn question_with_options_and_other(id: &str, header: &str) -> RequestUserInputQuestion {
-        RequestUserInputQuestion {
+    fn question_with_options_and_other(id: &str, header: &str) -> ToolRequestUserInputQuestion {
+        ToolRequestUserInputQuestion {
             id: id.to_string(),
             header: header.to_string(),
             question: "Choose an option.".to_string(),
             is_other: true,
             is_secret: false,
             options: Some(vec![
-                RequestUserInputQuestionOption {
+                ToolRequestUserInputOption {
                     label: "Option 1".to_string(),
                     description: "First choice.".to_string(),
                 },
-                RequestUserInputQuestionOption {
+                ToolRequestUserInputOption {
                     label: "Option 2".to_string(),
                     description: "Second choice.".to_string(),
                 },
-                RequestUserInputQuestionOption {
+                ToolRequestUserInputOption {
                     label: "Option 3".to_string(),
                     description: "Third choice.".to_string(),
                 },
@@ -1388,27 +1383,27 @@ mod tests {
         }
     }
 
-    fn question_with_wrapped_options(id: &str, header: &str) -> RequestUserInputQuestion {
-        RequestUserInputQuestion {
+    fn question_with_wrapped_options(id: &str, header: &str) -> ToolRequestUserInputQuestion {
+        ToolRequestUserInputQuestion {
             id: id.to_string(),
             header: header.to_string(),
             question: "Choose the next step for this task.".to_string(),
             is_other: false,
             is_secret: false,
             options: Some(vec![
-                RequestUserInputQuestionOption {
+                ToolRequestUserInputOption {
                     label: "Discuss a code change".to_string(),
                     description:
                         "Walk through a plan, then implement it together with careful checks."
                             .to_string(),
                 },
-                RequestUserInputQuestionOption {
+                ToolRequestUserInputOption {
                     label: "Run targeted tests".to_string(),
                     description:
                         "Pick the most relevant crate and validate the current behavior first."
                             .to_string(),
                 },
-                RequestUserInputQuestionOption {
+                ToolRequestUserInputOption {
                     label: "Review the diff".to_string(),
                     description:
                         "Summarize the changes and highlight the most important risks and gaps."
@@ -1418,19 +1413,19 @@ mod tests {
         }
     }
 
-    fn question_with_very_long_option_text(id: &str, header: &str) -> RequestUserInputQuestion {
-        RequestUserInputQuestion {
+    fn question_with_very_long_option_text(id: &str, header: &str) -> ToolRequestUserInputQuestion {
+        ToolRequestUserInputQuestion {
             id: id.to_string(),
             header: header.to_string(),
             question: "Choose one option.".to_string(),
             is_other: false,
             is_secret: false,
             options: Some(vec![
-                RequestUserInputQuestionOption {
+                ToolRequestUserInputOption {
                     label: "Job: running/completed/failed/expired; Run/Experiment: succeeded/failed/unknown (Recommended when triaging long-running background work and status transitions)".to_string(),
                     description: "Keep async job statuses for progress tracking and include enough context for debugging retries, stale workers, and unexpected expiration paths.".to_string(),
                 },
-                RequestUserInputQuestionOption {
+                ToolRequestUserInputOption {
                     label: "Add a short status model".to_string(),
                     description: "Simpler labels with less detail for quick rollouts.".to_string(),
                 },
@@ -1438,8 +1433,8 @@ mod tests {
         }
     }
 
-    fn question_with_long_scroll_options(id: &str, header: &str) -> RequestUserInputQuestion {
-        RequestUserInputQuestion {
+    fn question_with_long_scroll_options(id: &str, header: &str) -> ToolRequestUserInputQuestion {
+        ToolRequestUserInputQuestion {
             id: id.to_string(),
             header: header.to_string(),
             question:
@@ -1448,19 +1443,19 @@ mod tests {
             is_other: false,
             is_secret: false,
             options: Some(vec![
-                RequestUserInputQuestionOption {
+                ToolRequestUserInputOption {
                     label: "Use Detailed Hint A (Recommended)".to_string(),
                     description: "Select this if you want a deliberately overextended explanatory hint that reads like a miniature specification, including context, rationale, expected behavior, and an explicit statement that this choice is mainly for testing how gracefully the interface wraps, truncates, and preserves readability under unusually verbose helper text conditions.".to_string(),
                 },
-                RequestUserInputQuestionOption {
+                ToolRequestUserInputOption {
                     label: "Use Detailed Hint B".to_string(),
                     description: "Select this if you want an equally verbose but differently phrased guidance block that emphasizes user-facing clarity, spacing tolerance, multiline wrapping, visual hierarchy interactions, and whether long descriptive metadata remains understandable when scanned quickly in a constrained layout where cognitive load is already high.".to_string(),
                 },
-                RequestUserInputQuestionOption {
+                ToolRequestUserInputOption {
                     label: "Use Detailed Hint C".to_string(),
                     description: "Select this when you specifically want to verify that navigating downward will keep the currently highlighted option visible, even when previous options consume many wrapped lines and would otherwise push the selection out of the viewport.".to_string(),
                 },
-                RequestUserInputQuestionOption {
+                ToolRequestUserInputOption {
                     label: "None of the above".to_string(),
                     description:
                         "Use this only if the previous long-form options do not apply.".to_string(),
@@ -1469,8 +1464,8 @@ mod tests {
         }
     }
 
-    fn question_without_options(id: &str, header: &str) -> RequestUserInputQuestion {
-        RequestUserInputQuestion {
+    fn question_without_options(id: &str, header: &str) -> ToolRequestUserInputQuestion {
+        ToolRequestUserInputQuestion {
             id: id.to_string(),
             header: header.to_string(),
             question: "Share details.".to_string(),
@@ -1482,10 +1477,11 @@ mod tests {
 
     fn request_event(
         turn_id: &str,
-        questions: Vec<RequestUserInputQuestion>,
-    ) -> RequestUserInputEvent {
-        RequestUserInputEvent {
-            call_id: "call-1".to_string(),
+        questions: Vec<ToolRequestUserInputQuestion>,
+    ) -> ToolRequestUserInputParams {
+        ToolRequestUserInputParams {
+            thread_id: "thread-1".to_string(),
+            item_id: "call-1".to_string(),
             turn_id: turn_id.to_string(),
             questions,
         }
@@ -1545,13 +1541,15 @@ mod tests {
             /*enhanced_keys_supported*/ false,
             /*disable_paste_burst*/ false,
         );
-        overlay.try_consume_user_input_request(RequestUserInputEvent {
-            call_id: "call-2".to_string(),
+        overlay.try_consume_user_input_request(ToolRequestUserInputParams {
+            thread_id: "thread-1".to_string(),
+            item_id: "call-2".to_string(),
             turn_id: "turn-2".to_string(),
             questions: vec![question_with_options("q2", "Second")],
         });
-        overlay.try_consume_user_input_request(RequestUserInputEvent {
-            call_id: "call-3".to_string(),
+        overlay.try_consume_user_input_request(ToolRequestUserInputParams {
+            thread_id: "thread-1".to_string(),
+            item_id: "call-3".to_string(),
             turn_id: "turn-3".to_string(),
             questions: vec![question_with_options("q3", "Third")],
         });
@@ -1566,8 +1564,9 @@ mod tests {
     fn resolved_request_dismisses_overlay_without_emitting_events() {
         let (tx, mut rx) = test_sender();
         let mut overlay = RequestUserInputOverlay::new(
-            RequestUserInputEvent {
-                call_id: "call-1".to_string(),
+            ToolRequestUserInputParams {
+                thread_id: "thread-1".to_string(),
+                item_id: "call-1".to_string(),
                 turn_id: "turn-1".to_string(),
                 questions: vec![question_with_options("q1", "First")],
             },
@@ -1593,8 +1592,9 @@ mod tests {
     fn resolved_current_request_advances_to_next_same_turn_prompt() {
         let (tx, mut rx) = test_sender();
         let mut overlay = RequestUserInputOverlay::new(
-            RequestUserInputEvent {
-                call_id: "call-1".to_string(),
+            ToolRequestUserInputParams {
+                thread_id: "thread-1".to_string(),
+                item_id: "call-1".to_string(),
                 turn_id: "turn-1".to_string(),
                 questions: vec![question_with_options("q1", "First")],
             },
@@ -1603,8 +1603,9 @@ mod tests {
             /*enhanced_keys_supported*/ false,
             /*disable_paste_burst*/ false,
         );
-        overlay.try_consume_user_input_request(RequestUserInputEvent {
-            call_id: "call-2".to_string(),
+        overlay.try_consume_user_input_request(ToolRequestUserInputParams {
+            thread_id: "thread-1".to_string(),
+            item_id: "call-2".to_string(),
             turn_id: "turn-1".to_string(),
             questions: vec![question_with_options("q2", "Second")],
         });
@@ -1616,7 +1617,7 @@ mod tests {
         );
 
         assert!(!overlay.done, "newer same-turn prompt should stay pending");
-        assert_eq!(overlay.request.call_id, "call-2");
+        assert_eq!(overlay.request.item_id, "call-2");
         assert_eq!(overlay.request.turn_id, "turn-1");
         assert_eq!(overlay.request.questions[0].id, "q2");
         assert!(
@@ -1629,8 +1630,9 @@ mod tests {
     fn resolved_queued_request_removes_only_that_prompt() {
         let (tx, mut rx) = test_sender();
         let mut overlay = RequestUserInputOverlay::new(
-            RequestUserInputEvent {
-                call_id: "call-1".to_string(),
+            ToolRequestUserInputParams {
+                thread_id: "thread-1".to_string(),
+                item_id: "call-1".to_string(),
                 turn_id: "turn-1".to_string(),
                 questions: vec![question_with_options("q1", "First")],
             },
@@ -1639,13 +1641,15 @@ mod tests {
             /*enhanced_keys_supported*/ false,
             /*disable_paste_burst*/ false,
         );
-        overlay.try_consume_user_input_request(RequestUserInputEvent {
-            call_id: "call-2".to_string(),
+        overlay.try_consume_user_input_request(ToolRequestUserInputParams {
+            thread_id: "thread-1".to_string(),
+            item_id: "call-2".to_string(),
             turn_id: "turn-1".to_string(),
             questions: vec![question_with_options("q2", "Second")],
         });
-        overlay.try_consume_user_input_request(RequestUserInputEvent {
-            call_id: "call-3".to_string(),
+        overlay.try_consume_user_input_request(ToolRequestUserInputParams {
+            thread_id: "thread-1".to_string(),
+            item_id: "call-3".to_string(),
             turn_id: "turn-1".to_string(),
             questions: vec![question_with_options("q3", "Third")],
         });
@@ -1656,13 +1660,13 @@ mod tests {
             })
         );
 
-        assert_eq!(overlay.request.call_id, "call-1");
+        assert_eq!(overlay.request.item_id, "call-1");
         assert!(
             rx.try_recv().is_err(),
             "dismissing a stale queued request should not emit an event"
         );
         overlay.submit_answers();
-        assert_eq!(overlay.request.call_id, "call-3");
+        assert_eq!(overlay.request.item_id, "call-3");
         assert_eq!(overlay.request.questions[0].id, "q3");
         assert!(
             rx.try_recv().is_ok(),
@@ -1752,13 +1756,13 @@ mod tests {
         let mut expected = HashMap::new();
         expected.insert(
             "q1".to_string(),
-            RequestUserInputAnswer {
+            ToolRequestUserInputAnswer {
                 answers: vec!["Option 1".to_string()],
             },
         );
         expected.insert(
             "q2".to_string(),
-            RequestUserInputAnswer {
+            ToolRequestUserInputAnswer {
                 answers: vec!["Option 1".to_string()],
             },
         );
@@ -2851,30 +2855,30 @@ mod tests {
         let mut overlay = RequestUserInputOverlay::new(
             request_event(
                 "turn-1",
-                vec![RequestUserInputQuestion {
+                vec![ToolRequestUserInputQuestion {
                     id: "q1".to_string(),
                     header: "Next Step".to_string(),
                     question: "What would you like to do next?".to_string(),
                     is_other: false,
                     is_secret: false,
                     options: Some(vec![
-                        RequestUserInputQuestionOption {
+                        ToolRequestUserInputOption {
                             label: "Discuss a code change (Recommended)".to_string(),
                             description: "Walk through a plan and edit code together.".to_string(),
                         },
-                        RequestUserInputQuestionOption {
+                        ToolRequestUserInputOption {
                             label: "Run tests".to_string(),
                             description: "Pick a crate and run its tests.".to_string(),
                         },
-                        RequestUserInputQuestionOption {
+                        ToolRequestUserInputOption {
                             label: "Review a diff".to_string(),
                             description: "Summarize or review current changes.".to_string(),
                         },
-                        RequestUserInputQuestionOption {
+                        ToolRequestUserInputOption {
                             label: "Refactor".to_string(),
                             description: "Tighten structure and remove dead code.".to_string(),
                         },
-                        RequestUserInputQuestionOption {
+                        ToolRequestUserInputOption {
                             label: "Ship it".to_string(),
                             description: "Finalize and open a PR.".to_string(),
                         },
@@ -2903,30 +2907,30 @@ mod tests {
         let mut overlay = RequestUserInputOverlay::new(
             request_event(
                 "turn-1",
-                vec![RequestUserInputQuestion {
+                vec![ToolRequestUserInputQuestion {
                     id: "q1".to_string(),
                     header: "Next Step".to_string(),
                     question: "What would you like to do next?".to_string(),
                     is_other: false,
                     is_secret: false,
                     options: Some(vec![
-                        RequestUserInputQuestionOption {
+                        ToolRequestUserInputOption {
                             label: "Discuss a code change (Recommended)".to_string(),
                             description: "Walk through a plan and edit code together.".to_string(),
                         },
-                        RequestUserInputQuestionOption {
+                        ToolRequestUserInputOption {
                             label: "Run tests".to_string(),
                             description: "Pick a crate and run its tests.".to_string(),
                         },
-                        RequestUserInputQuestionOption {
+                        ToolRequestUserInputOption {
                             label: "Review a diff".to_string(),
                             description: "Summarize or review current changes.".to_string(),
                         },
-                        RequestUserInputQuestionOption {
+                        ToolRequestUserInputOption {
                             label: "Refactor".to_string(),
                             description: "Tighten structure and remove dead code.".to_string(),
                         },
-                        RequestUserInputQuestionOption {
+                        ToolRequestUserInputOption {
                             label: "Ship it".to_string(),
                             description: "Finalize and open a PR.".to_string(),
                         },

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -100,10 +100,13 @@ use codex_app_server_protocol::FileChangeRequestApprovalParams;
 use codex_app_server_protocol::GuardianApprovalReviewAction;
 use codex_app_server_protocol::ItemCompletedNotification;
 use codex_app_server_protocol::ItemStartedNotification;
+use codex_app_server_protocol::McpServerElicitationRequest;
+use codex_app_server_protocol::McpServerElicitationRequestParams;
 use codex_app_server_protocol::McpServerStatusDetail;
 use codex_app_server_protocol::ModelVerification as AppServerModelVerification;
 use codex_app_server_protocol::RateLimitReachedType;
 use codex_app_server_protocol::RateLimitSnapshot;
+use codex_app_server_protocol::RequestId as AppServerRequestId;
 use codex_app_server_protocol::ReviewTarget;
 use codex_app_server_protocol::ServerNotification;
 use codex_app_server_protocol::ServerRequest;
@@ -139,7 +142,6 @@ use codex_otel::SessionTelemetry;
 use codex_plugin::PluginCapabilitySummary;
 use codex_protocol::ThreadId;
 use codex_protocol::account::PlanType;
-use codex_protocol::approvals::ElicitationRequestEvent;
 use codex_protocol::approvals::GuardianAssessmentAction;
 use codex_protocol::approvals::GuardianAssessmentDecisionSource;
 use codex_protocol::approvals::GuardianAssessmentEvent;
@@ -160,8 +162,6 @@ use codex_protocol::parse_command::ParsedCommand;
 use codex_protocol::plan_tool::PlanItemArg as UpdatePlanItemArg;
 use codex_protocol::plan_tool::StepStatus as UpdatePlanItemStatus;
 use codex_protocol::request_permissions::RequestPermissionsEvent;
-use codex_protocol::request_user_input::RequestUserInputEvent;
-use codex_protocol::request_user_input::RequestUserInputQuestionOption;
 use codex_protocol::user_input::ByteRange;
 use codex_protocol::user_input::TextElement;
 use codex_terminal_detection::Multiplexer;
@@ -321,12 +321,7 @@ use self::goal_status::GoalStatusState;
 use self::goal_status::goal_status_indicator_from_app_goal;
 mod goal_menu;
 mod interrupts;
-use self::interrupts::ExecCommandBeginEvent;
-use self::interrupts::ExecCommandEndEvent;
 use self::interrupts::InterruptManager;
-use self::interrupts::McpToolCallBeginEvent;
-use self::interrupts::McpToolCallEndEvent;
-use self::interrupts::PatchApplyEndEvent;
 mod keymap_picker;
 mod mcp_startup;
 use self::mcp_startup::McpStartupStatus;
@@ -437,6 +432,20 @@ fn is_standard_tool_call(parsed_cmd: &[ParsedCommand]) -> bool {
         && parsed_cmd
             .iter()
             .all(|parsed| !matches!(parsed, ParsedCommand::Unknown { .. }))
+}
+
+fn command_execution_command_and_parsed(
+    command: &str,
+    command_actions: &[codex_app_server_protocol::CommandAction],
+) -> (Vec<String>, Vec<ParsedCommand>) {
+    (
+        split_command_string(command),
+        command_actions
+            .iter()
+            .cloned()
+            .map(codex_app_server_protocol::CommandAction::into_core)
+            .collect(),
+    )
 }
 
 const RATE_LIMIT_WARNING_THRESHOLDS: [f64; 3] = [75.0, 90.0, 95.0];
@@ -1557,19 +1566,6 @@ impl ThreadItemRenderSource {
     }
 }
 
-fn app_server_request_id_to_mcp_request_id(
-    request_id: &codex_app_server_protocol::RequestId,
-) -> codex_protocol::mcp::RequestId {
-    match request_id {
-        codex_app_server_protocol::RequestId::String(value) => {
-            codex_protocol::mcp::RequestId::String(value.clone())
-        }
-        codex_app_server_protocol::RequestId::Integer(value) => {
-            codex_protocol::mcp::RequestId::Integer(*value)
-        }
-    }
-}
-
 fn exec_approval_request_from_params(
     params: CommandExecutionRequestApprovalParams,
     fallback_cwd: &AbsolutePathBuf,
@@ -1617,35 +1613,6 @@ fn request_permissions_from_params(
     }
 }
 
-fn request_user_input_from_params(params: ToolRequestUserInputParams) -> RequestUserInputEvent {
-    RequestUserInputEvent {
-        turn_id: params.turn_id,
-        call_id: params.item_id,
-        questions: params
-            .questions
-            .into_iter()
-            .map(
-                |question| codex_protocol::request_user_input::RequestUserInputQuestion {
-                    id: question.id,
-                    header: question.header,
-                    question: question.question,
-                    is_other: question.is_other,
-                    is_secret: question.is_secret,
-                    options: question.options.map(|options| {
-                        options
-                            .into_iter()
-                            .map(|option| RequestUserInputQuestionOption {
-                                label: option.label,
-                                description: option.description,
-                            })
-                            .collect()
-                    }),
-                },
-            )
-            .collect(),
-    }
-}
-
 fn token_usage_info_from_app_server(token_usage: ThreadTokenUsage) -> TokenUsageInfo {
     TokenUsageInfo {
         total_token_usage: TokenUsage {
@@ -1663,25 +1630,6 @@ fn token_usage_info_from_app_server(token_usage: ThreadTokenUsage) -> TokenUsage
             reasoning_output_tokens: token_usage.last.reasoning_output_tokens,
         },
         model_context_window: token_usage.model_context_window,
-    }
-}
-
-fn web_search_action_to_core(
-    action: codex_app_server_protocol::WebSearchAction,
-) -> codex_protocol::models::WebSearchAction {
-    match action {
-        codex_app_server_protocol::WebSearchAction::Search { query, queries } => {
-            codex_protocol::models::WebSearchAction::Search { query, queries }
-        }
-        codex_app_server_protocol::WebSearchAction::OpenPage { url } => {
-            codex_protocol::models::WebSearchAction::OpenPage { url }
-        }
-        codex_app_server_protocol::WebSearchAction::FindInPage { url, pattern } => {
-            codex_protocol::models::WebSearchAction::FindInPage { url, pattern }
-        }
-        codex_app_server_protocol::WebSearchAction::Other => {
-            codex_protocol::models::WebSearchAction::Other
-        }
     }
 }
 
@@ -3631,15 +3579,20 @@ impl ChatWidget {
         self.request_redraw();
     }
 
-    fn on_elicitation_request(&mut self, ev: ElicitationRequestEvent) {
-        let ev2 = ev.clone();
+    fn on_elicitation_request(
+        &mut self,
+        request_id: AppServerRequestId,
+        params: McpServerElicitationRequestParams,
+    ) {
+        let request_id2 = request_id.clone();
+        let params2 = params.clone();
         self.defer_or_handle(
-            |q| q.push_elicitation(ev),
-            |s| s.handle_elicitation_request_now(ev2),
+            |q| q.push_elicitation(request_id, params),
+            |s| s.handle_elicitation_request_now(request_id2, params2),
         );
     }
 
-    fn on_request_user_input(&mut self, ev: RequestUserInputEvent) {
+    fn on_request_user_input(&mut self, ev: ToolRequestUserInputParams) {
         let ev2 = ev.clone();
         self.defer_or_handle(
             |q| q.push_user_input(ev),
@@ -3655,21 +3608,38 @@ impl ChatWidget {
         );
     }
 
-    fn on_exec_command_begin(&mut self, ev: ExecCommandBeginEvent) {
+    fn on_command_execution_started(&mut self, item: ThreadItem) {
+        let ThreadItem::CommandExecution {
+            id,
+            command,
+            process_id,
+            source,
+            command_actions,
+            ..
+        } = &item
+        else {
+            return;
+        };
+        let (_command, parsed_cmd) = command_execution_command_and_parsed(command, command_actions);
         self.flush_answer_stream_with_separator();
-        if is_unified_exec_source(ev.source) {
-            self.track_unified_exec_process_begin(&ev);
+        if is_unified_exec_source(*source) {
+            if *source == ExecCommandSource::UnifiedExecStartup {
+                self.track_unified_exec_process_begin(id, process_id.as_deref(), command);
+            }
             if !self.bottom_pane.is_task_running() {
                 return;
             }
             // Unified exec may be parsed as Unknown; keep the working indicator visible regardless.
             self.bottom_pane.ensure_status_indicator();
-            if !is_standard_tool_call(&ev.parsed_cmd) {
+            if !is_standard_tool_call(&parsed_cmd) {
                 return;
             }
         }
-        let ev2 = ev.clone();
-        self.defer_or_handle(|q| q.push_exec_begin(ev), |s| s.handle_exec_begin_now(ev2));
+        let item2 = item.clone();
+        self.defer_or_handle(
+            |q| q.push_item_started(item),
+            |s| s.handle_command_execution_started_now(item2),
+        );
     }
 
     fn on_exec_command_output_delta(&mut self, call_id: &str, delta: &str) {
@@ -3778,17 +3748,26 @@ impl ChatWidget {
         self.request_redraw();
     }
 
-    fn on_patch_apply_end(&mut self, event: PatchApplyEndEvent) {
-        let ev2 = event.clone();
+    fn on_file_change_completed(&mut self, item: ThreadItem) {
+        let item2 = item.clone();
         self.defer_or_handle(
-            |q| q.push_patch_end(event),
-            |s| s.handle_patch_apply_end_now(ev2),
+            |q| q.push_item_completed(item),
+            |s| s.handle_file_change_completed_now(item2),
         );
     }
 
-    fn on_exec_command_end(&mut self, ev: ExecCommandEndEvent) {
-        if is_unified_exec_source(ev.source) {
-            if let Some(process_id) = ev.process_id.as_deref()
+    fn on_command_execution_completed(&mut self, item: ThreadItem) {
+        let ThreadItem::CommandExecution {
+            id,
+            process_id,
+            source,
+            ..
+        } = &item
+        else {
+            return;
+        };
+        if is_unified_exec_source(*source) {
+            if let Some(process_id) = process_id.as_deref()
                 && self
                     .unified_exec_wait_streak
                     .as_ref()
@@ -3796,33 +3775,39 @@ impl ChatWidget {
             {
                 self.flush_unified_exec_wait_streak();
             }
-            self.track_unified_exec_process_end(&ev);
+            self.track_unified_exec_process_end(id, process_id.as_deref());
             if !self.bottom_pane.is_task_running() {
                 return;
             }
         }
-        let ev2 = ev.clone();
-        self.defer_or_handle(|q| q.push_exec_end(ev), |s| s.handle_exec_end_now(ev2));
+        let item2 = item.clone();
+        self.defer_or_handle(
+            |q| q.push_item_completed(item),
+            |s| s.handle_command_execution_completed_now(item2),
+        );
     }
 
-    fn track_unified_exec_process_begin(&mut self, ev: &ExecCommandBeginEvent) {
-        if ev.source != ExecCommandSource::UnifiedExecStartup {
-            return;
-        }
-        let key = ev.process_id.clone().unwrap_or(ev.call_id.to_string());
-        let command_display = strip_bash_lc_and_escape(&ev.command);
+    fn track_unified_exec_process_begin(
+        &mut self,
+        call_id: &str,
+        process_id: Option<&str>,
+        command: &str,
+    ) {
+        let key = process_id.unwrap_or(call_id).to_string();
+        let command = split_command_string(command);
+        let command_display = strip_bash_lc_and_escape(&command);
         if let Some(existing) = self
             .unified_exec_processes
             .iter_mut()
             .find(|process| process.key == key)
         {
-            existing.call_id = ev.call_id.clone();
+            existing.call_id = call_id.to_string();
             existing.command_display = command_display;
             existing.recent_chunks.clear();
         } else {
             self.unified_exec_processes.push(UnifiedExecProcessSummary {
                 key,
-                call_id: ev.call_id.clone(),
+                call_id: call_id.to_string(),
                 command_display,
                 recent_chunks: Vec::new(),
             });
@@ -3830,8 +3815,8 @@ impl ChatWidget {
         self.sync_unified_exec_footer();
     }
 
-    fn track_unified_exec_process_end(&mut self, ev: &ExecCommandEndEvent) {
-        let key = ev.process_id.clone().unwrap_or(ev.call_id.to_string());
+    fn track_unified_exec_process_end(&mut self, call_id: &str, process_id: Option<&str>) {
+        let key = process_id.unwrap_or(call_id);
         let before = self.unified_exec_processes.len();
         self.unified_exec_processes
             .retain(|process| process.key != key);
@@ -3875,14 +3860,20 @@ impl ChatWidget {
         }
     }
 
-    fn on_mcp_tool_call_begin(&mut self, ev: McpToolCallBeginEvent) {
-        let ev2 = ev.clone();
-        self.defer_or_handle(|q| q.push_mcp_begin(ev), |s| s.handle_mcp_begin_now(ev2));
+    fn on_mcp_tool_call_started(&mut self, item: ThreadItem) {
+        let item2 = item.clone();
+        self.defer_or_handle(
+            |q| q.push_item_started(item),
+            |s| s.handle_mcp_tool_call_started_now(item2),
+        );
     }
 
-    fn on_mcp_tool_call_end(&mut self, ev: McpToolCallEndEvent) {
-        let ev2 = ev.clone();
-        self.defer_or_handle(|q| q.push_mcp_end(ev), |s| s.handle_mcp_end_now(ev2));
+    fn on_mcp_tool_call_completed(&mut self, item: ThreadItem) {
+        let item2 = item.clone();
+        self.defer_or_handle(
+            |q| q.push_item_completed(item),
+            |s| s.handle_mcp_tool_call_completed_now(item2),
+        );
     }
 
     fn on_web_search_begin(&mut self, call_id: String) {
@@ -3901,7 +3892,7 @@ impl ChatWidget {
         &mut self,
         call_id: String,
         query: String,
-        action: codex_protocol::models::WebSearchAction,
+        action: codex_app_server_protocol::WebSearchAction,
     ) {
         self.flush_answer_stream_with_separator();
         let mut handled = false;
@@ -4287,7 +4278,7 @@ impl ChatWidget {
     /// standalone history entry instead of replacing or flushing the unrelated active exploring
     /// cell. If this method treated every unknown end as "complete the active cell", the UI could
     /// merge unrelated commands and hide still-running exploring work.
-    pub(crate) fn handle_exec_end_now(&mut self, ev: ExecCommandEndEvent) {
+    pub(crate) fn handle_command_execution_completed_now(&mut self, item: ThreadItem) {
         enum ExecEndTarget {
             // Normal case: the active exec cell already tracks this call id.
             ActiveTracked,
@@ -4298,13 +4289,36 @@ impl ChatWidget {
             NewCell,
         }
 
-        let running = self.running_commands.remove(&ev.call_id);
-        if self.suppressed_exec_calls.remove(&ev.call_id) {
+        let ThreadItem::CommandExecution {
+            id,
+            command,
+            process_id: _,
+            source,
+            command_actions,
+            aggregated_output,
+            exit_code,
+            duration_ms,
+            ..
+        } = item
+        else {
+            return;
+        };
+        let event_command = split_command_string(&command);
+        let event_parsed = command_actions
+            .into_iter()
+            .map(codex_app_server_protocol::CommandAction::into_core)
+            .collect();
+        let duration = Duration::from_millis(duration_ms.unwrap_or_default().max(0) as u64);
+        let exit_code = exit_code.unwrap_or_default();
+        let aggregated_output = aggregated_output.unwrap_or_default();
+
+        let running = self.running_commands.remove(&id);
+        if self.suppressed_exec_calls.remove(&id) {
             return;
         }
         let (command, parsed, source) = match running {
             Some(rc) => (rc.command, rc.parsed_cmd, rc.source),
-            None => (ev.command.clone(), ev.parsed_cmd.clone(), ev.source),
+            None => (event_command, event_parsed, source),
         };
         let parsed = self.annotate_skill_reads_in_parsed_cmd(parsed);
         let is_unified_exec_interaction =
@@ -4312,11 +4326,7 @@ impl ChatWidget {
         let is_user_shell = source == ExecCommandSource::UserShell;
         let end_target = match self.active_cell.as_ref() {
             Some(cell) => match cell.as_any().downcast_ref::<ExecCell>() {
-                Some(exec_cell)
-                    if exec_cell
-                        .iter_calls()
-                        .any(|call| call.call_id == ev.call_id) =>
-                {
+                Some(exec_cell) if exec_cell.iter_calls().any(|call| call.call_id == id) => {
                     ExecEndTarget::ActiveTracked
                 }
                 Some(exec_cell) if exec_cell.is_active() => {
@@ -4331,15 +4341,15 @@ impl ChatWidget {
         // instead render the interaction-specific content elsewhere in the UI.
         let output = if is_unified_exec_interaction {
             CommandOutput {
-                exit_code: ev.exit_code,
+                exit_code,
                 formatted_output: String::new(),
                 aggregated_output: String::new(),
             }
         } else {
             CommandOutput {
-                exit_code: ev.exit_code,
-                formatted_output: ev.formatted_output.clone(),
-                aggregated_output: ev.aggregated_output.clone(),
+                exit_code,
+                formatted_output: aggregated_output.clone(),
+                aggregated_output,
             }
         };
 
@@ -4350,8 +4360,8 @@ impl ChatWidget {
                     .as_mut()
                     .and_then(|c| c.as_any_mut().downcast_mut::<ExecCell>())
                 {
-                    let completed = cell.complete_call(&ev.call_id, output, ev.duration);
-                    debug_assert!(completed, "active exec cell should contain {}", ev.call_id);
+                    let completed = cell.complete_call(&id, output, duration);
+                    debug_assert!(completed, "active exec cell should contain {id}");
                     if cell.should_flush() {
                         self.flush_active_cell();
                     } else {
@@ -4362,19 +4372,15 @@ impl ChatWidget {
             }
             ExecEndTarget::OrphanHistoryWhileActiveExec => {
                 let mut orphan = new_active_exec_command(
-                    ev.call_id.clone(),
+                    id.clone(),
                     command,
                     parsed,
                     source,
-                    ev.interaction_input.clone(),
+                    None,
                     self.config.animations,
                 );
-                let completed = orphan.complete_call(&ev.call_id, output, ev.duration);
-                debug_assert!(
-                    completed,
-                    "new orphan exec cell should contain {}",
-                    ev.call_id
-                );
+                let completed = orphan.complete_call(&id, output, duration);
+                debug_assert!(completed, "new orphan exec cell should contain {id}");
                 self.needs_final_message_separator = true;
                 self.app_event_tx
                     .send(AppEvent::InsertHistoryCell(Box::new(orphan)));
@@ -4383,15 +4389,15 @@ impl ChatWidget {
             ExecEndTarget::NewCell => {
                 self.flush_active_cell();
                 let mut cell = new_active_exec_command(
-                    ev.call_id.clone(),
+                    id.clone(),
                     command,
                     parsed,
                     source,
-                    ev.interaction_input.clone(),
+                    None,
                     self.config.animations,
                 );
-                let completed = cell.complete_call(&ev.call_id, output, ev.duration);
-                debug_assert!(completed, "new exec cell should contain {}", ev.call_id);
+                let completed = cell.complete_call(&id, output, duration);
+                debug_assert!(completed, "new exec cell should contain {id}");
                 if cell.should_flush() {
                     self.add_to_history(cell);
                 } else {
@@ -4408,11 +4414,14 @@ impl ChatWidget {
         }
     }
 
-    pub(crate) fn handle_patch_apply_end_now(&mut self, event: PatchApplyEndEvent) {
+    pub(crate) fn handle_file_change_completed_now(&mut self, item: ThreadItem) {
+        let ThreadItem::FileChange { status, .. } = item else {
+            return;
+        };
         // If the patch was successful, just let the "Edited" block stand.
         // Otherwise, add a failure block.
-        if !event.success {
-            self.add_to_history(history_cell::new_patch_apply_failure(event.stderr));
+        if matches!(status, codex_app_server_protocol::PatchApplyStatus::Failed) {
+            self.add_to_history(history_cell::new_patch_apply_failure(String::new()));
         }
         // Mark that actual work was done (patch applied)
         self.had_work_activity = true;
@@ -4460,24 +4469,35 @@ impl ChatWidget {
         });
     }
 
-    pub(crate) fn handle_elicitation_request_now(&mut self, ev: ElicitationRequestEvent) {
+    pub(crate) fn handle_elicitation_request_now(
+        &mut self,
+        request_id: AppServerRequestId,
+        params: McpServerElicitationRequestParams,
+    ) {
         self.flush_answer_stream_with_separator();
 
         self.notify(Notification::ElicitationRequested {
-            server_name: ev.server_name.clone(),
+            server_name: params.server_name.clone(),
         });
 
         let thread_id = self.thread_id.unwrap_or_default();
-        if let Some(request) = McpServerElicitationFormRequest::from_event(thread_id, ev.clone()) {
+        if let Some(request) = McpServerElicitationFormRequest::from_app_server_request(
+            thread_id,
+            request_id.clone(),
+            params.clone(),
+        ) {
             self.bottom_pane
                 .push_mcp_server_elicitation_request(request);
         } else {
             let request = ApprovalRequest::McpElicitation {
                 thread_id,
                 thread_label: None,
-                server_name: ev.server_name,
-                request_id: ev.id,
-                message: ev.request.message().to_string(),
+                server_name: params.server_name,
+                request_id,
+                message: match params.request {
+                    McpServerElicitationRequest::Form { message, .. }
+                    | McpServerElicitationRequest::Url { message, .. } => message,
+                },
             };
             self.bottom_pane
                 .push_approval_request(request, &self.config.features);
@@ -4500,7 +4520,7 @@ impl ChatWidget {
         self.request_redraw();
     }
 
-    pub(crate) fn handle_request_user_input_now(&mut self, ev: RequestUserInputEvent) {
+    pub(crate) fn handle_request_user_input_now(&mut self, ev: ToolRequestUserInputParams) {
         self.flush_answer_stream_with_separator();
         let question_count = ev.questions.len();
         let summary = Notification::user_input_request_summary(&ev.questions);
@@ -4528,25 +4548,32 @@ impl ChatWidget {
         self.request_redraw();
     }
 
-    pub(crate) fn handle_exec_begin_now(&mut self, ev: ExecCommandBeginEvent) {
+    pub(crate) fn handle_command_execution_started_now(&mut self, item: ThreadItem) {
+        let ThreadItem::CommandExecution {
+            id,
+            command,
+            source,
+            command_actions,
+            ..
+        } = item
+        else {
+            return;
+        };
+        let (command, parsed_cmd) =
+            command_execution_command_and_parsed(&command, &command_actions);
         // Ensure the status indicator is visible while the command runs.
         self.bottom_pane.ensure_status_indicator();
-        let parsed_cmd = self.annotate_skill_reads_in_parsed_cmd(ev.parsed_cmd.clone());
+        let parsed_cmd = self.annotate_skill_reads_in_parsed_cmd(parsed_cmd);
         self.running_commands.insert(
-            ev.call_id.clone(),
+            id.clone(),
             RunningCommand {
-                command: ev.command.clone(),
+                command: command.clone(),
                 parsed_cmd: parsed_cmd.clone(),
-                source: ev.source,
+                source,
             },
         );
-        let is_wait_interaction = matches!(ev.source, ExecCommandSource::UnifiedExecInteraction)
-            && ev
-                .interaction_input
-                .as_deref()
-                .map(str::is_empty)
-                .unwrap_or(true);
-        let command_display = ev.command.join(" ");
+        let is_wait_interaction = matches!(source, ExecCommandSource::UnifiedExecInteraction);
+        let command_display = command.join(" ");
         let should_suppress_unified_wait = is_wait_interaction
             && self
                 .last_unified_wait
@@ -4558,20 +4585,19 @@ impl ChatWidget {
             self.last_unified_wait = None;
         }
         if should_suppress_unified_wait {
-            self.suppressed_exec_calls.insert(ev.call_id);
+            self.suppressed_exec_calls.insert(id);
             return;
         }
-        let interaction_input = ev.interaction_input.clone();
         if let Some(cell) = self
             .active_cell
             .as_mut()
             .and_then(|c| c.as_any_mut().downcast_mut::<ExecCell>())
             && let Some(new_exec) = cell.with_added_call(
-                ev.call_id.clone(),
-                ev.command.clone(),
+                id.clone(),
+                command.clone(),
                 parsed_cmd.clone(),
-                ev.source,
-                interaction_input.clone(),
+                source,
+                None,
             )
         {
             *cell = new_exec;
@@ -4580,11 +4606,11 @@ impl ChatWidget {
             self.flush_active_cell();
 
             self.active_cell = Some(Box::new(new_active_exec_command(
-                ev.call_id.clone(),
-                ev.command.clone(),
+                id,
+                command,
                 parsed_cmd,
-                ev.source,
-                interaction_input,
+                source,
+                None,
                 self.config.animations,
             )));
             self.bump_active_cell_revision();
@@ -4593,40 +4619,78 @@ impl ChatWidget {
         self.request_redraw();
     }
 
-    pub(crate) fn handle_mcp_begin_now(&mut self, ev: McpToolCallBeginEvent) {
+    pub(crate) fn handle_mcp_tool_call_started_now(&mut self, item: ThreadItem) {
+        let ThreadItem::McpToolCall {
+            id,
+            server,
+            tool,
+            arguments,
+            ..
+        } = item
+        else {
+            return;
+        };
         self.flush_answer_stream_with_separator();
         self.flush_active_cell();
         self.active_cell = Some(Box::new(history_cell::new_active_mcp_tool_call(
-            ev.call_id,
-            ev.invocation,
+            id,
+            McpInvocation {
+                server,
+                tool,
+                arguments: Some(arguments),
+            },
             self.config.animations,
         )));
         self.bump_active_cell_revision();
         self.request_redraw();
     }
-    pub(crate) fn handle_mcp_end_now(&mut self, ev: McpToolCallEndEvent) {
+
+    pub(crate) fn handle_mcp_tool_call_completed_now(&mut self, item: ThreadItem) {
         self.flush_answer_stream_with_separator();
 
-        let McpToolCallEndEvent {
-            call_id,
-            invocation,
-            duration,
+        let ThreadItem::McpToolCall {
+            id,
+            server,
+            tool,
+            arguments,
             result,
-        } = ev;
+            error,
+            duration_ms,
+            ..
+        } = item
+        else {
+            return;
+        };
+        let invocation = McpInvocation {
+            server,
+            tool,
+            arguments: Some(arguments),
+        };
+        let duration = Duration::from_millis(duration_ms.unwrap_or_default().max(0) as u64);
+        let result = match (result, error) {
+            (_, Some(error)) => Err(error.message),
+            (Some(result), None) => {
+                let result = *result;
+                Ok(codex_protocol::mcp::CallToolResult {
+                    content: result.content,
+                    structured_content: result.structured_content,
+                    is_error: Some(false),
+                    meta: None,
+                })
+            }
+            (None, None) => Err("MCP tool call completed without a result".to_string()),
+        };
 
         let extra_cell = match self
             .active_cell
             .as_mut()
             .and_then(|cell| cell.as_any_mut().downcast_mut::<McpToolCallCell>())
         {
-            Some(cell) if cell.call_id() == call_id => cell.complete(duration, result),
+            Some(cell) if cell.call_id() == id => cell.complete(duration, result),
             _ => {
                 self.flush_active_cell();
-                let mut cell = history_cell::new_active_mcp_tool_call(
-                    call_id,
-                    invocation,
-                    self.config.animations,
-                );
+                let mut cell =
+                    history_cell::new_active_mcp_tool_call(id, invocation, self.config.animations);
                 let extra_cell = cell.complete(duration, result);
                 self.active_cell = Some(Box::new(cell));
                 extra_cell
@@ -4639,6 +4703,29 @@ impl ChatWidget {
         }
         // Mark that actual work was done (MCP tool call)
         self.had_work_activity = true;
+    }
+
+    pub(crate) fn handle_queued_item_started_now(&mut self, item: ThreadItem) {
+        match item {
+            item @ ThreadItem::CommandExecution { .. } => {
+                self.handle_command_execution_started_now(item);
+            }
+            item @ ThreadItem::McpToolCall { .. } => {
+                self.handle_mcp_tool_call_started_now(item);
+            }
+            _ => {}
+        }
+    }
+
+    pub(crate) fn handle_queued_item_completed_now(&mut self, item: ThreadItem) {
+        match item {
+            item @ ThreadItem::CommandExecution { .. } => {
+                self.handle_command_execution_completed_now(item);
+            }
+            item @ ThreadItem::FileChange { .. } => self.handle_file_change_completed_now(item),
+            item @ ThreadItem::McpToolCall { .. } => self.handle_mcp_tool_call_completed_now(item),
+            _ => {}
+        }
     }
 
     pub(crate) fn new_with_app_event(common: ChatWidgetInit) -> Self {
@@ -5922,113 +6009,23 @@ impl ChatWidget {
                 }
                 self.on_agent_reasoning_final();
             }
-            ThreadItem::CommandExecution {
-                id,
-                command,
-                cwd: _,
-                process_id,
-                source,
-                status,
-                command_actions,
-                aggregated_output,
-                exit_code,
-                duration_ms,
-            } => {
-                if matches!(
-                    status,
-                    codex_app_server_protocol::CommandExecutionStatus::InProgress
-                ) {
-                    self.on_exec_command_begin(ExecCommandBeginEvent {
-                        call_id: id,
-                        process_id,
-                        command: split_command_string(&command),
-                        parsed_cmd: command_actions
-                            .into_iter()
-                            .map(codex_app_server_protocol::CommandAction::into_core)
-                            .collect(),
-                        source,
-                        interaction_input: None,
-                    });
-                } else {
-                    let aggregated_output = aggregated_output.unwrap_or_default();
-                    self.on_exec_command_end(ExecCommandEndEvent {
-                        call_id: id,
-                        process_id,
-                        command: split_command_string(&command),
-                        parsed_cmd: command_actions
-                            .into_iter()
-                            .map(codex_app_server_protocol::CommandAction::into_core)
-                            .collect(),
-                        source,
-                        interaction_input: None,
-                        aggregated_output: aggregated_output.clone(),
-                        exit_code: exit_code.unwrap_or_default(),
-                        duration: Duration::from_millis(
-                            duration_ms.unwrap_or_default().max(0) as u64
-                        ),
-                        formatted_output: aggregated_output,
-                    });
-                }
-            }
-            ThreadItem::FileChange {
-                id: _,
-                changes: _,
-                status,
-            } => {
-                if !matches!(
-                    status,
-                    codex_app_server_protocol::PatchApplyStatus::InProgress
-                ) {
-                    self.on_patch_apply_end(PatchApplyEndEvent {
-                        stderr: String::new(),
-                        success: !matches!(
-                            status,
-                            codex_app_server_protocol::PatchApplyStatus::Failed
-                        ),
-                    });
-                }
-            }
-            ThreadItem::McpToolCall {
-                id,
-                server,
-                tool,
-                arguments,
-                result,
-                error,
-                duration_ms,
+            item @ ThreadItem::CommandExecution {
+                status: codex_app_server_protocol::CommandExecutionStatus::InProgress,
                 ..
-            } => {
-                self.on_mcp_tool_call_end(McpToolCallEndEvent {
-                    call_id: id,
-                    invocation: McpInvocation {
-                        server,
-                        tool,
-                        arguments: Some(arguments),
-                    },
-                    duration: Duration::from_millis(duration_ms.unwrap_or_default().max(0) as u64),
-                    result: match (result, error) {
-                        (_, Some(error)) => Err(error.message),
-                        (Some(result), None) => {
-                            let result = *result;
-                            Ok(codex_protocol::mcp::CallToolResult {
-                                content: result.content,
-                                structured_content: result.structured_content,
-                                is_error: Some(false),
-                                meta: None,
-                            })
-                        }
-                        (None, None) => Err("MCP tool call completed without a result".to_string()),
-                    },
-                });
-            }
+            } => self.on_command_execution_started(item),
+            item @ ThreadItem::CommandExecution { .. } => self.on_command_execution_completed(item),
+            ThreadItem::FileChange {
+                status: codex_app_server_protocol::PatchApplyStatus::InProgress,
+                ..
+            } => {}
+            item @ ThreadItem::FileChange { .. } => self.on_file_change_completed(item),
+            item @ ThreadItem::McpToolCall { .. } => self.on_mcp_tool_call_completed(item),
             ThreadItem::WebSearch { id, query, action } => {
                 self.on_web_search_begin(id.clone());
                 self.on_web_search_end(
                     id,
                     query,
-                    action
-                        .map(web_search_action_to_core)
-                        .unwrap_or(codex_protocol::models::WebSearchAction::Other),
+                    action.unwrap_or(codex_app_server_protocol::WebSearchAction::Other),
                 );
             }
             ThreadItem::ImageView { id: _, path } => {
@@ -6104,16 +6101,13 @@ impl ChatWidget {
                 );
             }
             ServerRequest::McpServerElicitationRequest { request_id, params } => {
-                self.on_mcp_server_elicitation_request(
-                    app_server_request_id_to_mcp_request_id(&request_id),
-                    params,
-                );
+                self.on_elicitation_request(request_id, params);
             }
             ServerRequest::PermissionsRequestApproval { params, .. } => {
                 self.on_request_permissions(request_permissions_from_params(params));
             }
             ServerRequest::ToolRequestUserInput { params, .. } => {
-                self.on_request_user_input(request_user_input_from_params(params));
+                self.on_request_user_input(params);
             }
             ServerRequest::DynamicToolCall { .. }
             | ServerRequest::ChatgptAuthTokensRefresh { .. }
@@ -6364,42 +6358,6 @@ impl ChatWidget {
         self.on_list_skills(response);
     }
 
-    fn on_mcp_server_elicitation_request(
-        &mut self,
-        request_id: codex_protocol::mcp::RequestId,
-        params: codex_app_server_protocol::McpServerElicitationRequestParams,
-    ) {
-        let request = codex_protocol::approvals::ElicitationRequestEvent {
-            turn_id: params.turn_id,
-            server_name: params.server_name,
-            id: request_id,
-            request: match params.request {
-                codex_app_server_protocol::McpServerElicitationRequest::Form {
-                    meta,
-                    message,
-                    requested_schema,
-                } => codex_protocol::approvals::ElicitationRequest::Form {
-                    meta,
-                    message,
-                    requested_schema: serde_json::to_value(requested_schema)
-                        .unwrap_or(serde_json::Value::Null),
-                },
-                codex_app_server_protocol::McpServerElicitationRequest::Url {
-                    meta,
-                    message,
-                    url,
-                    elicitation_id,
-                } => codex_protocol::approvals::ElicitationRequest::Url {
-                    meta,
-                    message,
-                    url,
-                    elicitation_id,
-                },
-            },
-        };
-        self.on_elicitation_request(request);
-    }
-
     fn handle_turn_completed_notification(
         &mut self,
         notification: TurnCompletedNotification,
@@ -6452,46 +6410,11 @@ impl ChatWidget {
         from_replay: bool,
     ) {
         match notification.item {
-            ThreadItem::CommandExecution {
-                id,
-                command,
-                cwd: _,
-                process_id,
-                source,
-                command_actions,
-                ..
-            } => {
-                self.on_exec_command_begin(ExecCommandBeginEvent {
-                    call_id: id,
-                    process_id,
-                    command: split_command_string(&command),
-                    parsed_cmd: command_actions
-                        .into_iter()
-                        .map(codex_app_server_protocol::CommandAction::into_core)
-                        .collect(),
-                    source,
-                    interaction_input: None,
-                });
-            }
+            item @ ThreadItem::CommandExecution { .. } => self.on_command_execution_started(item),
             ThreadItem::FileChange { id: _, changes, .. } => {
                 self.on_patch_apply_begin(file_update_changes_to_display(changes));
             }
-            ThreadItem::McpToolCall {
-                id,
-                server,
-                tool,
-                arguments,
-                ..
-            } => {
-                self.on_mcp_tool_call_begin(McpToolCallBeginEvent {
-                    call_id: id,
-                    invocation: McpInvocation {
-                        server,
-                        tool,
-                        arguments: Some(arguments),
-                    },
-                });
-            }
+            item @ ThreadItem::McpToolCall { .. } => self.on_mcp_tool_call_started(item),
             ThreadItem::WebSearch { id, .. } => {
                 self.on_web_search_begin(id);
             }
@@ -10981,7 +10904,7 @@ impl Notification {
     }
 
     fn user_input_request_summary(
-        questions: &[codex_protocol::request_user_input::RequestUserInputQuestion],
+        questions: &[codex_app_server_protocol::ToolRequestUserInputQuestion],
     ) -> Option<String> {
         let first_question = questions.first()?;
         let summary = if first_question.header.trim().is_empty() {

--- a/codex-rs/tui/src/chatwidget/interrupts.rs
+++ b/codex-rs/tui/src/chatwidget/interrupts.rs
@@ -1,77 +1,30 @@
 //! Queue prompt overlays and deferred tool activity while another interrupt is visible.
 
 use std::collections::VecDeque;
-use std::time::Duration;
 
 use crate::app::app_server_requests::ResolvedAppServerRequest;
 use crate::approval_events::ApplyPatchApprovalRequestEvent;
 use crate::approval_events::ExecApprovalRequestEvent;
-use crate::history_cell::McpInvocation;
-use codex_app_server_protocol::CommandExecutionSource;
-use codex_protocol::approvals::ElicitationRequestEvent;
-use codex_protocol::mcp::CallToolResult;
-use codex_protocol::parse_command::ParsedCommand;
+use codex_app_server_protocol::McpServerElicitationRequestParams;
+use codex_app_server_protocol::RequestId as AppServerRequestId;
+use codex_app_server_protocol::ThreadItem;
+use codex_app_server_protocol::ToolRequestUserInputParams;
 use codex_protocol::request_permissions::RequestPermissionsEvent;
-use codex_protocol::request_user_input::RequestUserInputEvent;
 
 use super::ChatWidget;
-
-#[derive(Debug, Clone)]
-pub(crate) struct ExecCommandBeginEvent {
-    pub(crate) call_id: String,
-    pub(crate) process_id: Option<String>,
-    pub(crate) command: Vec<String>,
-    pub(crate) parsed_cmd: Vec<ParsedCommand>,
-    pub(crate) source: CommandExecutionSource,
-    pub(crate) interaction_input: Option<String>,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct ExecCommandEndEvent {
-    pub(crate) call_id: String,
-    pub(crate) process_id: Option<String>,
-    pub(crate) command: Vec<String>,
-    pub(crate) parsed_cmd: Vec<ParsedCommand>,
-    pub(crate) source: CommandExecutionSource,
-    pub(crate) interaction_input: Option<String>,
-    pub(crate) aggregated_output: String,
-    pub(crate) exit_code: i32,
-    pub(crate) duration: Duration,
-    pub(crate) formatted_output: String,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct McpToolCallBeginEvent {
-    pub(crate) call_id: String,
-    pub(crate) invocation: McpInvocation,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct McpToolCallEndEvent {
-    pub(crate) call_id: String,
-    pub(crate) invocation: McpInvocation,
-    pub(crate) duration: Duration,
-    pub(crate) result: Result<CallToolResult, String>,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct PatchApplyEndEvent {
-    pub(crate) success: bool,
-    pub(crate) stderr: String,
-}
 
 #[derive(Debug)]
 pub(crate) enum QueuedInterrupt {
     ExecApproval(ExecApprovalRequestEvent),
     ApplyPatchApproval(ApplyPatchApprovalRequestEvent),
-    Elicitation(ElicitationRequestEvent),
+    Elicitation {
+        request_id: AppServerRequestId,
+        params: McpServerElicitationRequestParams,
+    },
     RequestPermissions(RequestPermissionsEvent),
-    RequestUserInput(RequestUserInputEvent),
-    ExecBegin(ExecCommandBeginEvent),
-    ExecEnd(ExecCommandEndEvent),
-    McpBegin(McpToolCallBeginEvent),
-    McpEnd(McpToolCallEndEvent),
-    PatchEnd(PatchApplyEndEvent),
+    RequestUserInput(ToolRequestUserInputParams),
+    ItemStarted(ThreadItem),
+    ItemCompleted(ThreadItem),
 }
 
 #[derive(Default)]
@@ -100,8 +53,13 @@ impl InterruptManager {
             .push_back(QueuedInterrupt::ApplyPatchApproval(ev));
     }
 
-    pub(crate) fn push_elicitation(&mut self, ev: ElicitationRequestEvent) {
-        self.queue.push_back(QueuedInterrupt::Elicitation(ev));
+    pub(crate) fn push_elicitation(
+        &mut self,
+        request_id: AppServerRequestId,
+        params: McpServerElicitationRequestParams,
+    ) {
+        self.queue
+            .push_back(QueuedInterrupt::Elicitation { request_id, params });
     }
 
     pub(crate) fn push_request_permissions(&mut self, ev: RequestPermissionsEvent) {
@@ -109,28 +67,16 @@ impl InterruptManager {
             .push_back(QueuedInterrupt::RequestPermissions(ev));
     }
 
-    pub(crate) fn push_user_input(&mut self, ev: RequestUserInputEvent) {
+    pub(crate) fn push_user_input(&mut self, ev: ToolRequestUserInputParams) {
         self.queue.push_back(QueuedInterrupt::RequestUserInput(ev));
     }
 
-    pub(crate) fn push_exec_begin(&mut self, ev: ExecCommandBeginEvent) {
-        self.queue.push_back(QueuedInterrupt::ExecBegin(ev));
+    pub(crate) fn push_item_started(&mut self, item: ThreadItem) {
+        self.queue.push_back(QueuedInterrupt::ItemStarted(item));
     }
 
-    pub(crate) fn push_exec_end(&mut self, ev: ExecCommandEndEvent) {
-        self.queue.push_back(QueuedInterrupt::ExecEnd(ev));
-    }
-
-    pub(crate) fn push_mcp_begin(&mut self, ev: McpToolCallBeginEvent) {
-        self.queue.push_back(QueuedInterrupt::McpBegin(ev));
-    }
-
-    pub(crate) fn push_mcp_end(&mut self, ev: McpToolCallEndEvent) {
-        self.queue.push_back(QueuedInterrupt::McpEnd(ev));
-    }
-
-    pub(crate) fn push_patch_end(&mut self, ev: PatchApplyEndEvent) {
-        self.queue.push_back(QueuedInterrupt::PatchEnd(ev));
+    pub(crate) fn push_item_completed(&mut self, item: ThreadItem) {
+        self.queue.push_back(QueuedInterrupt::ItemCompleted(item));
     }
 
     pub(crate) fn remove_resolved_prompt(&mut self, request: &ResolvedAppServerRequest) -> bool {
@@ -145,14 +91,15 @@ impl InterruptManager {
             match q {
                 QueuedInterrupt::ExecApproval(ev) => chat.handle_exec_approval_now(ev),
                 QueuedInterrupt::ApplyPatchApproval(ev) => chat.handle_apply_patch_approval_now(ev),
-                QueuedInterrupt::Elicitation(ev) => chat.handle_elicitation_request_now(ev),
+                QueuedInterrupt::Elicitation { request_id, params } => {
+                    chat.handle_elicitation_request_now(request_id, params);
+                }
                 QueuedInterrupt::RequestPermissions(ev) => chat.handle_request_permissions_now(ev),
                 QueuedInterrupt::RequestUserInput(ev) => chat.handle_request_user_input_now(ev),
-                QueuedInterrupt::ExecBegin(ev) => chat.handle_exec_begin_now(ev),
-                QueuedInterrupt::ExecEnd(ev) => chat.handle_exec_end_now(ev),
-                QueuedInterrupt::McpBegin(ev) => chat.handle_mcp_begin_now(ev),
-                QueuedInterrupt::McpEnd(ev) => chat.handle_mcp_end_now(ev),
-                QueuedInterrupt::PatchEnd(ev) => chat.handle_patch_apply_end_now(ev),
+                QueuedInterrupt::ItemStarted(item) => chat.handle_queued_item_started_now(item),
+                QueuedInterrupt::ItemCompleted(item) => {
+                    chat.handle_queued_item_completed_now(item);
+                }
             }
         }
     }
@@ -169,11 +116,11 @@ impl QueuedInterrupt {
                 matches!(request, ResolvedAppServerRequest::FileChangeApproval { id }
                     if ev.call_id == id.as_str())
             }
-            QueuedInterrupt::Elicitation(ev) => {
+            QueuedInterrupt::Elicitation { request_id, params } => {
                 matches!(request, ResolvedAppServerRequest::McpElicitation {
                     server_name,
-                    request_id,
-                } if ev.server_name == server_name.as_str() && &ev.id == request_id)
+                    request_id: resolved_request_id,
+                } if params.server_name == server_name.as_str() && request_id == resolved_request_id)
             }
             QueuedInterrupt::RequestPermissions(ev) => {
                 matches!(request, ResolvedAppServerRequest::PermissionsApproval { id }
@@ -181,13 +128,9 @@ impl QueuedInterrupt {
             }
             QueuedInterrupt::RequestUserInput(ev) => {
                 matches!(request, ResolvedAppServerRequest::UserInput { call_id }
-                    if ev.call_id == call_id.as_str())
+                    if ev.item_id == call_id.as_str())
             }
-            QueuedInterrupt::ExecBegin(_)
-            | QueuedInterrupt::ExecEnd(_)
-            | QueuedInterrupt::McpBegin(_)
-            | QueuedInterrupt::McpEnd(_)
-            | QueuedInterrupt::PatchEnd(_) => false,
+            QueuedInterrupt::ItemStarted(_) | QueuedInterrupt::ItemCompleted(_) => false,
         }
     }
 }
@@ -195,16 +138,18 @@ impl QueuedInterrupt {
 #[cfg(test)]
 mod tests {
     use crate::approval_events::ExecApprovalRequestEvent;
-    use codex_app_server_protocol::CommandExecutionSource as ExecCommandSource;
-    use codex_protocol::request_user_input::RequestUserInputEvent;
+    use codex_app_server_protocol::CommandExecutionSource;
+    use codex_app_server_protocol::CommandExecutionStatus;
+    use codex_app_server_protocol::ThreadItem;
     use codex_utils_absolute_path::AbsolutePathBuf;
     use pretty_assertions::assert_eq;
 
     use super::*;
 
-    fn user_input(call_id: &str, turn_id: &str) -> RequestUserInputEvent {
-        RequestUserInputEvent {
-            call_id: call_id.to_string(),
+    fn user_input(call_id: &str, turn_id: &str) -> ToolRequestUserInputParams {
+        ToolRequestUserInputParams {
+            thread_id: "thread-1".to_string(),
+            item_id: call_id.to_string(),
             turn_id: turn_id.to_string(),
             questions: Vec::new(),
         }
@@ -226,14 +171,18 @@ mod tests {
         }
     }
 
-    fn exec_begin(call_id: &str) -> ExecCommandBeginEvent {
-        ExecCommandBeginEvent {
-            call_id: call_id.to_string(),
+    fn command_execution(call_id: &str) -> ThreadItem {
+        ThreadItem::CommandExecution {
+            id: call_id.to_string(),
+            command: "true".to_string(),
+            cwd: AbsolutePathBuf::current_dir().expect("current dir"),
             process_id: None,
-            command: vec!["true".to_string()],
-            parsed_cmd: Vec::new(),
-            source: ExecCommandSource::Agent,
-            interaction_input: None,
+            source: CommandExecutionSource::Agent,
+            status: CommandExecutionStatus::InProgress,
+            command_actions: Vec::new(),
+            aggregated_output: None,
+            exit_code: None,
+            duration_ms: None,
         }
     }
 
@@ -253,7 +202,7 @@ mod tests {
         let Some(QueuedInterrupt::RequestUserInput(remaining)) = manager.queue.front() else {
             panic!("expected remaining queued user input");
         };
-        assert_eq!(remaining.call_id, "call-a");
+        assert_eq!(remaining.item_id, "call-a");
     }
 
     #[test]
@@ -279,7 +228,7 @@ mod tests {
     #[test]
     fn remove_resolved_prompt_keeps_lifecycle_events() {
         let mut manager = InterruptManager::new();
-        manager.push_exec_begin(exec_begin("call"));
+        manager.push_item_started(command_execution("call"));
 
         assert!(
             !manager.remove_resolved_prompt(&ResolvedAppServerRequest::ExecApproval {
@@ -290,7 +239,7 @@ mod tests {
         assert_eq!(manager.queue.len(), 1);
         assert!(matches!(
             manager.queue.front(),
-            Some(QueuedInterrupt::ExecBegin(_))
+            Some(QueuedInterrupt::ItemStarted(_))
         ));
     }
 }

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -4,8 +4,6 @@
 //! snapshot-based so that layout regressions and status/header changes show up as stable,
 //! reviewable diffs.
 
-pub(super) use super::interrupts::ExecCommandBeginEvent;
-pub(super) use super::interrupts::ExecCommandEndEvent;
 pub(super) use super::*;
 pub(super) use crate::app_command::AppCommand as Op;
 pub(super) use crate::app_event::AppEvent;
@@ -108,6 +106,9 @@ pub(super) use codex_app_server_protocol::ThreadClosedNotification;
 pub(super) use codex_app_server_protocol::ThreadItem as AppServerThreadItem;
 pub(super) use codex_app_server_protocol::ThreadRealtimeClosedNotification;
 pub(super) use codex_app_server_protocol::ThreadRealtimeErrorNotification;
+pub(super) use codex_app_server_protocol::ToolRequestUserInputOption;
+pub(super) use codex_app_server_protocol::ToolRequestUserInputParams;
+pub(super) use codex_app_server_protocol::ToolRequestUserInputQuestion;
 pub(super) use codex_app_server_protocol::Turn as AppServerTurn;
 pub(super) use codex_app_server_protocol::TurnCompletedNotification;
 pub(super) use codex_app_server_protocol::TurnError as AppServerTurnError;
@@ -162,9 +163,6 @@ pub(super) use codex_protocol::plan_tool::PlanItemArg;
 pub(super) use codex_protocol::plan_tool::StepStatus;
 pub(super) use codex_protocol::plan_tool::UpdatePlanArgs;
 pub(super) use codex_protocol::request_permissions::RequestPermissionProfile;
-pub(super) use codex_protocol::request_user_input::RequestUserInputEvent;
-pub(super) use codex_protocol::request_user_input::RequestUserInputQuestion;
-pub(super) use codex_protocol::request_user_input::RequestUserInputQuestionOption;
 pub(super) use codex_protocol::user_input::TextElement;
 pub(super) use codex_terminal_detection::Multiplexer;
 pub(super) use codex_terminal_detection::TerminalInfo;

--- a/codex-rs/tui/src/chatwidget/tests/exec_flow.rs
+++ b/codex-rs/tui/src/chatwidget/tests/exec_flow.rs
@@ -347,20 +347,24 @@ async fn exec_end_without_begin_uses_event_command() {
         "-lc".to_string(),
         "echo orphaned".to_string(),
     ];
-    let parsed_cmd = codex_shell_command::parse_command::parse_command(&command);
+    let command_actions = codex_shell_command::parse_command::parse_command(&command)
+        .into_iter()
+        .map(|parsed| AppServerCommandAction::from_core_with_cwd(parsed, &chat.config.cwd))
+        .collect();
+    let cwd = chat.config.cwd.clone();
     handle_exec_end(
         &mut chat,
-        ExecCommandEndEvent {
-            call_id: "call-orphan".to_string(),
+        AppServerThreadItem::CommandExecution {
+            id: "call-orphan".to_string(),
+            command: codex_shell_command::parse_command::shlex_join(&command),
+            cwd,
             process_id: None,
-            command,
-            parsed_cmd,
             source: ExecCommandSource::Agent,
-            interaction_input: None,
-            aggregated_output: "done".to_string(),
-            exit_code: 0,
-            duration: std::time::Duration::from_millis(5),
-            formatted_output: "done".to_string(),
+            status: AppServerCommandExecutionStatus::Completed,
+            command_actions,
+            aggregated_output: Some("done".to_string()),
+            exit_code: Some(0),
+            duration_ms: Some(5),
         },
     );
 

--- a/codex-rs/tui/src/chatwidget/tests/helpers.rs
+++ b/codex-rs/tui/src/chatwidget/tests/helpers.rs
@@ -922,23 +922,28 @@ pub(super) fn begin_exec_with_source(
     call_id: &str,
     raw_cmd: &str,
     source: ExecCommandSource,
-) -> ExecCommandBeginEvent {
+) -> AppServerThreadItem {
     // Build the full command vec and parse it using core's parser,
     // then convert to protocol variants for the event payload.
     let command = vec!["bash".to_string(), "-lc".to_string(), raw_cmd.to_string()];
-    let parsed_cmd: Vec<ParsedCommand> =
-        codex_shell_command::parse_command::parse_command(&command);
-    let interaction_input = None;
-    let event = ExecCommandBeginEvent {
-        call_id: call_id.to_string(),
+    let command_actions = codex_shell_command::parse_command::parse_command(&command)
+        .into_iter()
+        .map(|parsed| AppServerCommandAction::from_core_with_cwd(parsed, &chat.config.cwd))
+        .collect();
+    let item = AppServerThreadItem::CommandExecution {
+        id: call_id.to_string(),
+        command: codex_shell_command::parse_command::shlex_join(&command),
+        cwd: chat.config.cwd.clone(),
         process_id: None,
-        command,
-        parsed_cmd,
         source,
-        interaction_input,
+        status: AppServerCommandExecutionStatus::InProgress,
+        command_actions,
+        aggregated_output: None,
+        exit_code: None,
+        duration_ms: None,
     };
-    handle_exec_begin(chat, event.clone());
-    event
+    handle_exec_begin(chat, item.clone());
+    item
 }
 
 pub(super) fn begin_unified_exec_startup(
@@ -946,28 +951,25 @@ pub(super) fn begin_unified_exec_startup(
     call_id: &str,
     process_id: &str,
     raw_cmd: &str,
-) -> ExecCommandBeginEvent {
+) -> AppServerThreadItem {
     let command = vec!["bash".to_string(), "-lc".to_string(), raw_cmd.to_string()];
-    let event = ExecCommandBeginEvent {
-        call_id: call_id.to_string(),
+    let item = AppServerThreadItem::CommandExecution {
+        id: call_id.to_string(),
+        command: codex_shell_command::parse_command::shlex_join(&command),
+        cwd: chat.config.cwd.clone(),
         process_id: Some(process_id.to_string()),
-        command,
-        parsed_cmd: Vec::new(),
         source: ExecCommandSource::UnifiedExecStartup,
-        interaction_input: None,
+        status: AppServerCommandExecutionStatus::InProgress,
+        command_actions: Vec::new(),
+        aggregated_output: None,
+        exit_code: None,
+        duration_ms: None,
     };
-    handle_exec_begin(chat, event.clone());
-    event
+    handle_exec_begin(chat, item.clone());
+    item
 }
 
-pub(super) fn handle_exec_begin(chat: &mut ChatWidget, event: ExecCommandBeginEvent) {
-    let cwd = chat.config.cwd.clone();
-    let command_actions = event
-        .parsed_cmd
-        .iter()
-        .cloned()
-        .map(|parsed| AppServerCommandAction::from_core_with_cwd(parsed, &cwd))
-        .collect();
+pub(super) fn handle_exec_begin(chat: &mut ChatWidget, item: AppServerThreadItem) {
     chat.handle_server_notification(
         ServerNotification::ItemStarted(ItemStartedNotification {
             thread_id: thread_id(chat),
@@ -975,18 +977,7 @@ pub(super) fn handle_exec_begin(chat: &mut ChatWidget, event: ExecCommandBeginEv
                 .last_turn_id
                 .clone()
                 .unwrap_or_else(|| "turn-1".to_string()),
-            item: AppServerThreadItem::CommandExecution {
-                id: event.call_id,
-                command: codex_shell_command::parse_command::shlex_join(&event.command),
-                cwd,
-                process_id: event.process_id,
-                source: event.source,
-                status: AppServerCommandExecutionStatus::InProgress,
-                command_actions,
-                aggregated_output: None,
-                exit_code: None,
-                duration_ms: None,
-            },
+            item,
         }),
         /*replay_kind*/ None,
     );
@@ -1151,13 +1142,13 @@ pub(super) fn begin_exec(
     chat: &mut ChatWidget,
     call_id: &str,
     raw_cmd: &str,
-) -> ExecCommandBeginEvent {
+) -> AppServerThreadItem {
     begin_exec_with_source(chat, call_id, raw_cmd, ExecCommandSource::Agent)
 }
 
 pub(super) fn end_exec(
     chat: &mut ChatWidget,
-    begin_event: ExecCommandBeginEvent,
+    begin_item: AppServerThreadItem,
     stdout: &str,
     stderr: &str,
     exit_code: i32,
@@ -1167,45 +1158,40 @@ pub(super) fn end_exec(
     } else {
         format!("{stdout}{stderr}")
     };
-    let ExecCommandBeginEvent {
-        call_id,
+    let AppServerThreadItem::CommandExecution {
+        id,
         command,
-        parsed_cmd,
-        source,
-        interaction_input,
+        cwd,
         process_id,
-    } = begin_event;
+        source,
+        command_actions,
+        ..
+    } = begin_item
+    else {
+        panic!("expected command execution item");
+    };
     handle_exec_end(
         chat,
-        ExecCommandEndEvent {
-            call_id,
-            process_id,
+        AppServerThreadItem::CommandExecution {
+            id,
             command,
-            parsed_cmd,
+            cwd,
+            process_id,
             source,
-            interaction_input,
-            aggregated_output: aggregated.clone(),
-            exit_code,
-            duration: std::time::Duration::from_millis(5),
-            formatted_output: aggregated,
+            status: if exit_code == 0 {
+                AppServerCommandExecutionStatus::Completed
+            } else {
+                AppServerCommandExecutionStatus::Failed
+            },
+            command_actions,
+            aggregated_output: (!aggregated.is_empty()).then_some(aggregated),
+            exit_code: Some(exit_code),
+            duration_ms: Some(5),
         },
     );
 }
 
-pub(super) fn handle_exec_end(chat: &mut ChatWidget, event: ExecCommandEndEvent) {
-    let cwd = chat.config.cwd.clone();
-    let duration_ms = i64::try_from(event.duration.as_millis()).unwrap_or(i64::MAX);
-    let command_actions = event
-        .parsed_cmd
-        .iter()
-        .cloned()
-        .map(|parsed| AppServerCommandAction::from_core_with_cwd(parsed, &cwd))
-        .collect();
-    let status = if event.exit_code == 0 {
-        AppServerCommandExecutionStatus::Completed
-    } else {
-        AppServerCommandExecutionStatus::Failed
-    };
+pub(super) fn handle_exec_end(chat: &mut ChatWidget, item: AppServerThreadItem) {
     chat.handle_server_notification(
         ServerNotification::ItemCompleted(ItemCompletedNotification {
             thread_id: thread_id(chat),
@@ -1213,19 +1199,7 @@ pub(super) fn handle_exec_end(chat: &mut ChatWidget, event: ExecCommandEndEvent)
                 .last_turn_id
                 .clone()
                 .unwrap_or_else(|| "turn-1".to_string()),
-            item: AppServerThreadItem::CommandExecution {
-                id: event.call_id,
-                command: codex_shell_command::parse_command::shlex_join(&event.command),
-                cwd,
-                process_id: event.process_id,
-                source: event.source,
-                status,
-                command_actions,
-                aggregated_output: (!event.aggregated_output.is_empty())
-                    .then_some(event.aggregated_output),
-                exit_code: Some(event.exit_code),
-                duration_ms: Some(duration_ms),
-            },
+            item,
         }),
         /*replay_kind*/ None,
     );

--- a/codex-rs/tui/src/chatwidget/tests/plan_mode.rs
+++ b/codex-rs/tui/src/chatwidget/tests/plan_mode.rs
@@ -582,16 +582,17 @@ async fn request_user_input_notification_overrides_pending_agent_turn_complete_n
     chat.notify(Notification::AgentTurnComplete {
         response: "done".to_string(),
     });
-    chat.handle_request_user_input_now(RequestUserInputEvent {
-        call_id: "call-1".to_string(),
+    chat.handle_request_user_input_now(ToolRequestUserInputParams {
+        thread_id: "thread-1".to_string(),
+        item_id: "call-1".to_string(),
         turn_id: "turn-1".to_string(),
-        questions: vec![RequestUserInputQuestion {
+        questions: vec![ToolRequestUserInputQuestion {
             id: "reasoning_scope".to_string(),
             header: "Reasoning scope".to_string(),
             question: "Which reasoning scope should I use?".to_string(),
             is_other: false,
             is_secret: false,
-            options: Some(vec![RequestUserInputQuestionOption {
+            options: Some(vec![ToolRequestUserInputOption {
                 label: "Plan only".to_string(),
                 description: "Update only Plan mode.".to_string(),
             }]),
@@ -610,16 +611,17 @@ async fn handle_request_user_input_sets_pending_notification() {
     chat.config.tui_notifications.notifications =
         Notifications::Custom(vec!["plan-mode-prompt".to_string()]);
 
-    chat.handle_request_user_input_now(RequestUserInputEvent {
-        call_id: "call-1".to_string(),
+    chat.handle_request_user_input_now(ToolRequestUserInputParams {
+        thread_id: "thread-1".to_string(),
+        item_id: "call-1".to_string(),
         turn_id: "turn-1".to_string(),
-        questions: vec![RequestUserInputQuestion {
+        questions: vec![ToolRequestUserInputQuestion {
             id: "reasoning_scope".to_string(),
             header: "Reasoning scope".to_string(),
             question: "Which reasoning scope should I use?".to_string(),
             is_other: false,
             is_secret: false,
-            options: Some(vec![RequestUserInputQuestionOption {
+            options: Some(vec![ToolRequestUserInputOption {
                 label: "Plan only".to_string(),
                 description: "Update only Plan mode.".to_string(),
             }]),

--- a/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
+++ b/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
@@ -2659,7 +2659,7 @@ async fn chatwidget_exec_and_status_layout_vt100_snapshot() {
     );
 
     let command = vec!["bash".into(), "-lc".into(), "rg \"Change Approved\"".into()];
-    let parsed_cmd = vec![
+    let parsed_cmd = [
         ParsedCommand::Search {
             query: Some("Change Approved".into()),
             path: None,
@@ -2671,30 +2671,40 @@ async fn chatwidget_exec_and_status_layout_vt100_snapshot() {
             path: "diff_render.rs".into(),
         },
     ];
+    let command_actions = parsed_cmd
+        .iter()
+        .cloned()
+        .map(|parsed| AppServerCommandAction::from_core_with_cwd(parsed, &chat.config.cwd))
+        .collect::<Vec<_>>();
+    let cwd = chat.config.cwd.clone();
     handle_exec_begin(
         &mut chat,
-        ExecCommandBeginEvent {
-            call_id: "c1".into(),
+        AppServerThreadItem::CommandExecution {
+            id: "c1".into(),
+            command: codex_shell_command::parse_command::shlex_join(&command),
+            cwd: cwd.clone(),
             process_id: None,
-            command: command.clone(),
-            parsed_cmd: parsed_cmd.clone(),
             source: ExecCommandSource::Agent,
-            interaction_input: None,
+            status: AppServerCommandExecutionStatus::InProgress,
+            command_actions: command_actions.clone(),
+            aggregated_output: None,
+            exit_code: None,
+            duration_ms: None,
         },
     );
     handle_exec_end(
         &mut chat,
-        ExecCommandEndEvent {
-            call_id: "c1".into(),
+        AppServerThreadItem::CommandExecution {
+            id: "c1".into(),
+            command: codex_shell_command::parse_command::shlex_join(&command),
+            cwd,
             process_id: None,
-            command,
-            parsed_cmd,
             source: ExecCommandSource::Agent,
-            interaction_input: None,
-            aggregated_output: String::new(),
-            exit_code: 0,
-            duration: std::time::Duration::from_millis(16000),
-            formatted_output: String::new(),
+            status: AppServerCommandExecutionStatus::Completed,
+            command_actions,
+            aggregated_output: None,
+            exit_code: Some(0),
+            duration_ms: Some(16000),
         },
     );
     handle_turn_started(&mut chat, "turn-1");

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -21,7 +21,6 @@ use crate::exec_cell::spinner;
 use crate::exec_command::relativize_to_home;
 use crate::exec_command::strip_bash_lc_and_escape;
 use crate::legacy_core::config::Config;
-use crate::legacy_core::web_search_detail;
 use crate::live_wrap::take_prefix_by_width;
 use crate::markdown::append_markdown;
 use crate::render::line_utils::line_to_static;
@@ -52,6 +51,9 @@ use codex_app_server_protocol::McpServerStatusDetail;
 use codex_app_server_protocol::PermissionProfile as AppServerPermissionProfile;
 use codex_app_server_protocol::PermissionProfileFileSystemPermissions;
 use codex_app_server_protocol::PermissionProfileNetworkPermissions;
+use codex_app_server_protocol::ToolRequestUserInputAnswer;
+use codex_app_server_protocol::ToolRequestUserInputQuestion;
+use codex_app_server_protocol::WebSearchAction;
 use codex_config::types::McpServerTransportConfig;
 #[cfg(test)]
 use codex_mcp::qualified_mcp_tool_name_prefix;
@@ -64,14 +66,11 @@ use codex_protocol::mcp::Resource;
 #[cfg(test)]
 use codex_protocol::mcp::ResourceTemplate;
 use codex_protocol::models::PermissionProfile;
-use codex_protocol::models::WebSearchAction;
 use codex_protocol::models::local_image_label_text;
 use codex_protocol::openai_models::ReasoningEffort as ReasoningEffortConfig;
 use codex_protocol::plan_tool::PlanItemArg;
 use codex_protocol::plan_tool::StepStatus;
 use codex_protocol::plan_tool::UpdatePlanArgs;
-use codex_protocol::request_user_input::RequestUserInputAnswer;
-use codex_protocol::request_user_input::RequestUserInputQuestion;
 use codex_protocol::user_input::TextElement;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use codex_utils_cli::format_env_display;
@@ -1777,6 +1776,42 @@ fn web_search_header(completed: bool) -> &'static str {
     }
 }
 
+fn web_search_action_detail(action: &WebSearchAction) -> String {
+    match action {
+        WebSearchAction::Search { query, queries } => {
+            query.clone().filter(|q| !q.is_empty()).unwrap_or_else(|| {
+                let items = queries.as_ref();
+                let first = items
+                    .and_then(|queries| queries.first())
+                    .cloned()
+                    .unwrap_or_default();
+                if items.is_some_and(|queries| queries.len() > 1) && !first.is_empty() {
+                    format!("{first} ...")
+                } else {
+                    first
+                }
+            })
+        }
+        WebSearchAction::OpenPage { url } => url.clone().unwrap_or_default(),
+        WebSearchAction::FindInPage { url, pattern } => match (pattern, url) {
+            (Some(pattern), Some(url)) => format!("'{pattern}' in {url}"),
+            (Some(pattern), None) => format!("'{pattern}'"),
+            (None, Some(url)) => url.clone(),
+            (None, None) => String::new(),
+        },
+        WebSearchAction::Other => String::new(),
+    }
+}
+
+fn web_search_detail(action: Option<&WebSearchAction>, query: &str) -> String {
+    let detail = action.map(web_search_action_detail).unwrap_or_default();
+    if detail.is_empty() {
+        query.to_string()
+    } else {
+        detail
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct WebSearchCell {
     call_id: String,
@@ -2458,8 +2493,8 @@ pub(crate) fn new_mcp_inventory_loading(animations_enabled: bool) -> McpInventor
 /// Renders a completed (or interrupted) request_user_input exchange in history.
 #[derive(Debug)]
 pub(crate) struct RequestUserInputResultCell {
-    pub(crate) questions: Vec<RequestUserInputQuestion>,
-    pub(crate) answers: HashMap<String, RequestUserInputAnswer>,
+    pub(crate) questions: Vec<ToolRequestUserInputQuestion>,
+    pub(crate) answers: HashMap<String, ToolRequestUserInputAnswer>,
     pub(crate) interrupted: bool,
 }
 
@@ -2583,7 +2618,7 @@ fn wrap_with_prefix(
 /// Split a request_user_input answer into option labels and an optional freeform note.
 /// Notes are encoded as "user_note: <text>" entries in the answers list.
 fn split_request_user_input_answer(
-    answer: &RequestUserInputAnswer,
+    answer: &ToolRequestUserInputAnswer,
 ) -> (Vec<String>, Option<String>) {
     let mut options = Vec::new();
     let mut note = None;
@@ -3045,7 +3080,6 @@ mod tests {
     use codex_otel::RuntimeMetricsSummary;
     use codex_protocol::ThreadId;
     use codex_protocol::account::PlanType;
-    use codex_protocol::models::WebSearchAction;
     use codex_protocol::parse_command::ParsedCommand;
     use dirs::home_dir;
     use pretty_assertions::assert_eq;


### PR DESCRIPTION
## Why

This is PR 6 of 6 in a stacked refactor that removes the TUI's dependency on `codex_protocol::protocol`. It finishes the stack by converting the last prompt-flow and interrupt-queue edges to app-server-facing types or TUI-local state.

After this layer, `codex-rs/tui/src` and `codex-rs/tui/tests` no longer reference `codex_protocol::protocol`.

## What Changed

- Reworked queued tool interrupt handling to store app-server thread items or local display state instead of core protocol event structs.
- Switched remaining prompt flows to app-server request/response types where they cross the app-server boundary.
- Completed the final sweep so TUI sources and tests have no remaining `codex_protocol::protocol` imports.

## Stack

This PR is part 6 of 6:

1. #20154 - bulk core-protocol import replacement
2. #20155 - MCP startup state simplification
3. #20156 - legacy ChatWidget test event shim removal
4. #20157 - user input and approval model simplification
5. #20158 - session resume and internal event simplification
6. **#20159** - final app-server prompt flow cleanup

## Verification

- `cargo check -p codex-tui` was run for this layer while constructing the stack.
- `cargo test -p codex-tui` passed on the top of the stack.
- `cargo insta pending-snapshots --manifest-path tui/Cargo.toml` reported no pending snapshots.
- `rg "codex_protocol::protocol" codex-rs/tui/src codex-rs/tui/tests` reported no matches.
