### PR TITLE
[Codex] Add browser use external feature flag

### DIFF
--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -373,6 +373,9 @@
             "browser_use": {
               "type": "boolean"
             },
+            "browser_use_external": {
+              "type": "boolean"
+            },
             "child_agents_md": {
               "type": "boolean"
             },
@@ -3374,6 +3377,9 @@
           "$ref": "#/definitions/FeatureToml_for_AppsMcpPathOverrideConfigToml"
         },
         "browser_use": {
+          "type": "boolean"
+        },
+        "browser_use_external": {
           "type": "boolean"
         },
         "child_agents_md": {

--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -172,6 +172,10 @@ pub enum Feature {
     ///
     /// Requirements-only gate: this should be set from requirements, not user config.
     BrowserUse,
+    /// Allow Browser Use integration with external browsers.
+    ///
+    /// Requirements-only gate: this should be set from requirements, not user config.
+    BrowserUseExternal,
     /// Allow Codex Computer Use.
     ///
     /// Requirements-only gate: this should be set from requirements, not user config.
@@ -911,6 +915,12 @@ pub const FEATURES: &[FeatureSpec] = &[
     FeatureSpec {
         id: Feature::BrowserUse,
         key: "browser_use",
+        stage: Stage::Stable,
+        default_enabled: true,
+    },
+    FeatureSpec {
+        id: Feature::BrowserUseExternal,
+        key: "browser_use_external",
         stage: Stage::Stable,
         default_enabled: true,
     },

--- a/codex-rs/features/src/tests.rs
+++ b/codex-rs/features/src/tests.rs
@@ -157,6 +157,13 @@ fn browser_controls_are_stable_and_enabled_by_default() {
     assert_eq!(Feature::BrowserUse.default_enabled(), true);
     assert_eq!(feature_for_key("browser_use"), Some(Feature::BrowserUse));
 
+    assert_eq!(Feature::BrowserUseExternal.stage(), Stage::Stable);
+    assert_eq!(Feature::BrowserUseExternal.default_enabled(), true);
+    assert_eq!(
+        feature_for_key("browser_use_external"),
+        Some(Feature::BrowserUseExternal)
+    );
+
     assert_eq!(Feature::ComputerUse.stage(), Stage::Stable);
     assert_eq!(Feature::ComputerUse.default_enabled(), true);
     assert_eq!(feature_for_key("computer_use"), Some(Feature::ComputerUse));


### PR DESCRIPTION
## Summary

- Adds a separate feature control for external-browser Browser Use integrations.
- Registers `browser_use_external` as a stable, default-enabled requirements-owned feature key.
- Updates feature registry tests and regenerates the config schema.

Codex validation:
- `cargo fmt -- --config imports_granularity=Item`
- `cargo run -p codex-core --bin codex-write-config-schema`
- `cargo test -p codex-features`

## Addendum

This gives enterprise policy a coarse control for Browser Use outside the Codex-managed in-app browser. The existing `browser_use` feature is the Browser Use control, while `browser_use_external` can gate extension/native integrations for external browsers as that surface grows
