### PR TITLE
app-server: fix outgoing sender test setup

### DIFF
--- a/codex-rs/app-server/src/command_exec.rs
+++ b/codex-rs/app-server/src/command_exec.rs
@@ -890,7 +890,10 @@ mod tests {
 
         manager
             .start(StartCommandExecParams {
-                outgoing: Arc::new(OutgoingMessageSender::new(tx)),
+                outgoing: Arc::new(OutgoingMessageSender::new(
+                    tx,
+                    codex_analytics::AnalyticsEventsClient::disabled(),
+                )),
                 request_id: request_id.clone(),
                 process_id: Some("proc-101".to_string()),
                 exec_request: ExecRequest::new(


### PR DESCRIPTION
## Why

[#17088](https://github.com/openai/codex/pull/17088) changed `OutgoingMessageSender::new` to require an `AnalyticsEventsClient`, but one `command_exec` test added earlier on `main` still called the old one-argument constructor. That leaves current `main` failing to compile in Bazel and argument-comment-lint jobs.

## What changed

- Pass `AnalyticsEventsClient::disabled()` to the missed `OutgoingMessageSender::new` test call site in `command_exec.rs`.

## Verification

- `cargo test -p codex-app-server timeout_or_cancellation_reports_cancellation_without_timeout_exit_code`