### PR TITLE
[codex] include originator on usage snapshot requests

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/rate_limits.rs
+++ b/codex-rs/app-server/tests/suite/v2/rate_limits.rs
@@ -5,6 +5,7 @@ use app_test_support::to_response;
 use app_test_support::write_chatgpt_auth;
 use codex_app_server_protocol::AddCreditsNudgeCreditType;
 use codex_app_server_protocol::AddCreditsNudgeEmailStatus;
+use codex_app_server_protocol::ClientInfo;
 use codex_app_server_protocol::GetAccountRateLimitsResponse;
 use codex_app_server_protocol::JSONRPCError;
 use codex_app_server_protocol::JSONRPCResponse;
@@ -149,12 +150,21 @@ async fn get_account_rate_limits_returns_snapshot() -> Result<()> {
         .and(path("/api/codex/usage"))
         .and(header("authorization", "Bearer chatgpt-token"))
         .and(header("chatgpt-account-id", "account-123"))
+        .and(header("originator", "codex-tui"))
         .respond_with(ResponseTemplate::new(200).set_body_json(response_body))
         .mount(&server)
         .await;
 
     let mut mcp = McpProcess::new_with_env(codex_home.path(), &[("OPENAI_API_KEY", None)]).await?;
-    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+    timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.initialize_with_client_info(ClientInfo {
+            name: "codex-tui".to_string(),
+            title: None,
+            version: "0.1.0".to_string(),
+        }),
+    )
+    .await??;
 
     let request_id = mcp.send_get_account_rate_limits_request().await?;
 

--- a/codex-rs/backend-client/src/client.rs
+++ b/codex-rs/backend-client/src/client.rs
@@ -10,6 +10,7 @@ use codex_client::build_reqwest_client_with_custom_ca;
 use codex_client::with_chatgpt_cloudflare_cookie_store;
 use codex_login::CodexAuth;
 use codex_login::default_client::get_codex_user_agent;
+use codex_login::default_client::originator;
 use codex_protocol::account::PlanType as AccountPlanType;
 use codex_protocol::protocol::CreditsSnapshot;
 use codex_protocol::protocol::RateLimitReachedType;
@@ -204,6 +205,7 @@ impl Client {
 
     fn headers(&self) -> HeaderMap {
         let mut h = HeaderMap::new();
+        h.insert("originator", originator().header_value);
         if let Some(ua) = &self.user_agent {
             h.insert(USER_AGENT, ua.clone());
         } else {


### PR DESCRIPTION
## Summary
- include the process originator on backend-client requests
- cover the app-server rate-limit snapshot path for `codex-tui`

## Context
`/api/codex/usage` snapshots currently drop the surface identity even though app-server initialization already sets it from `clientInfo.name`. This keeps startup snapshot requests aligned with the rest of Codex request plumbing and lets downstream usage handling distinguish CLI/TUI traffic from other surfaces.