### PR TITLE
Refresh remote plugin cache on auth changes

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -740,9 +740,6 @@ impl CodexMessageProcessor {
 
     pub(crate) fn handle_config_mutation(&self) {
         self.clear_plugin_related_caches();
-        self.thread_manager
-            .plugins_manager()
-            .clear_remote_installed_plugins_cache();
     }
 
     pub(crate) fn effective_plugins_changed_callback(
@@ -775,37 +772,41 @@ impl CodexMessageProcessor {
     }
 
     fn clear_plugin_related_caches(&self) {
-        let plugins_manager = self.thread_manager.plugins_manager();
-        plugins_manager.clear_cache();
+        self.thread_manager.plugins_manager().clear_cache();
         self.thread_manager.skills_manager().clear_cache();
     }
 
-    async fn clear_remote_plugin_auth_state_for_thread_manager(
-        thread_manager: &Arc<ThreadManager>,
+    async fn maybe_refresh_remote_installed_plugins_cache_for_current_config(
         config_manager: &ConfigManager,
+        thread_manager: &Arc<ThreadManager>,
+        auth: Option<CodexAuth>,
     ) {
-        if !thread_manager
-            .plugins_manager()
-            .clear_remote_installed_plugins_cache()
-        {
-            return;
-        }
-
-        let config = match config_manager
+        match config_manager
             .load_latest_config(/*fallback_cwd*/ None)
             .await
         {
-            Ok(config) => config,
+            Ok(config) => {
+                let refresh_thread_manager = Arc::clone(thread_manager);
+                let refresh_config = config.clone();
+                thread_manager
+                    .plugins_manager()
+                    .maybe_start_remote_installed_plugins_cache_refresh(
+                        &config.plugins_config_input(),
+                        auth,
+                        Some(Arc::new(move || {
+                            Self::spawn_effective_plugins_changed_task(
+                                Arc::clone(&refresh_thread_manager),
+                                refresh_config.clone(),
+                            );
+                        })),
+                    );
+            }
             Err(err) => {
                 warn!(
-                    "failed to reload config after remote plugin auth state changed, clearing plugin-related caches only: {err}"
+                    "failed to reload config after account changed, skipping remote installed plugins cache refresh: {err}"
                 );
-                thread_manager.plugins_manager().clear_cache();
-                thread_manager.skills_manager().clear_cache();
-                return;
             }
-        };
-        Self::spawn_effective_plugins_changed_task(Arc::clone(thread_manager), config);
+        }
     }
 
     fn current_account_updated_notification(&self) -> AccountUpdatedNotification {
@@ -1597,8 +1598,7 @@ impl CodexMessageProcessor {
             });
         }
 
-        let outgoing = self.outgoing.clone();
-        let auth_manager = self.auth_manager.clone();
+        let outgoing_clone = self.outgoing.clone();
         let config_manager = self.config_manager.clone();
         let thread_manager = Arc::clone(&self.thread_manager);
         let chatgpt_base_url = self.config.chatgpt_base_url.clone();
@@ -1619,42 +1619,16 @@ impl CodexMessageProcessor {
                 }
             };
 
-            let account_updated_payload = if success {
-                auth_manager.reload().await;
-                Self::clear_remote_plugin_auth_state_for_thread_manager(
-                    &thread_manager,
-                    &config_manager,
-                )
-                .await;
-                config_manager
-                    .replace_cloud_requirements_loader(auth_manager.clone(), chatgpt_base_url);
-                config_manager
-                    .sync_default_client_residency_requirement()
-                    .await;
-                auth_manager
-                    .auth_cached()
-                    .map(|auth| AccountUpdatedNotification {
-                        auth_mode: Some(auth.api_auth_mode()),
-                        plan_type: auth.account_plan_type(),
-                    })
-            } else {
-                None
-            };
-
-            let payload_v2 = AccountLoginCompletedNotification {
-                login_id: Some(login_id.to_string()),
+            Self::send_chatgpt_login_completion_notifications(
+                &outgoing_clone,
+                config_manager,
+                thread_manager,
+                chatgpt_base_url,
+                login_id,
                 success,
-                error: error_msg,
-            };
-            outgoing
-                .send_server_notification(ServerNotification::AccountLoginCompleted(payload_v2))
-                .await;
-
-            if let Some(payload_v2) = account_updated_payload {
-                outgoing
-                    .send_server_notification(ServerNotification::AccountUpdated(payload_v2))
-                    .await;
-            }
+                error_msg,
+            )
+            .await;
 
             // Clear the active login if it matches this attempt. It may have been replaced or cancelled.
             let mut guard = active_login.lock().await;
@@ -1700,8 +1674,7 @@ impl CodexMessageProcessor {
         let verification_url = device_code.verification_url.clone();
         let user_code = device_code.user_code.clone();
 
-        let outgoing = self.outgoing.clone();
-        let auth_manager = self.auth_manager.clone();
+        let outgoing_clone = self.outgoing.clone();
         let config_manager = self.config_manager.clone();
         let thread_manager = Arc::clone(&self.thread_manager);
         let chatgpt_base_url = self.config.chatgpt_base_url.clone();
@@ -1719,42 +1692,16 @@ impl CodexMessageProcessor {
                 }
             };
 
-            let account_updated_payload = if success {
-                auth_manager.reload().await;
-                Self::clear_remote_plugin_auth_state_for_thread_manager(
-                    &thread_manager,
-                    &config_manager,
-                )
-                .await;
-                config_manager
-                    .replace_cloud_requirements_loader(auth_manager.clone(), chatgpt_base_url);
-                config_manager
-                    .sync_default_client_residency_requirement()
-                    .await;
-                auth_manager
-                    .auth_cached()
-                    .map(|auth| AccountUpdatedNotification {
-                        auth_mode: Some(auth.api_auth_mode()),
-                        plan_type: auth.account_plan_type(),
-                    })
-            } else {
-                None
-            };
-
-            let payload_v2 = AccountLoginCompletedNotification {
-                login_id: Some(login_id.to_string()),
+            Self::send_chatgpt_login_completion_notifications(
+                &outgoing_clone,
+                config_manager,
+                thread_manager,
+                chatgpt_base_url,
+                login_id,
                 success,
-                error: error_msg,
-            };
-            outgoing
-                .send_server_notification(ServerNotification::AccountLoginCompleted(payload_v2))
-                .await;
-
-            if let Some(payload_v2) = account_updated_payload {
-                outgoing
-                    .send_server_notification(ServerNotification::AccountUpdated(payload_v2))
-                    .await;
-            }
+                error_msg,
+            )
+            .await;
 
             let mut guard = active_login.lock().await;
             if guard.as_ref().map(ActiveLogin::login_id) == Some(login_id) {
@@ -1877,9 +1824,10 @@ impl CodexMessageProcessor {
     }
 
     async fn send_login_success_notifications(&self, login_id: Option<Uuid>) {
-        Self::clear_remote_plugin_auth_state_for_thread_manager(
-            &self.thread_manager,
+        Self::maybe_refresh_remote_installed_plugins_cache_for_current_config(
             &self.config_manager,
+            &self.thread_manager,
+            self.auth_manager.auth_cached(),
         )
         .await;
 
@@ -1899,6 +1847,50 @@ impl CodexMessageProcessor {
                 self.current_account_updated_notification(),
             ))
             .await;
+    }
+
+    async fn send_chatgpt_login_completion_notifications(
+        outgoing: &OutgoingMessageSender,
+        config_manager: ConfigManager,
+        thread_manager: Arc<ThreadManager>,
+        chatgpt_base_url: String,
+        login_id: Uuid,
+        success: bool,
+        error_msg: Option<String>,
+    ) {
+        let payload_v2 = AccountLoginCompletedNotification {
+            login_id: Some(login_id.to_string()),
+            success,
+            error: error_msg,
+        };
+        outgoing
+            .send_server_notification(ServerNotification::AccountLoginCompleted(payload_v2))
+            .await;
+
+        if success {
+            let auth_manager = thread_manager.auth_manager();
+            auth_manager.reload().await;
+            config_manager
+                .replace_cloud_requirements_loader(auth_manager.clone(), chatgpt_base_url);
+            config_manager
+                .sync_default_client_residency_requirement()
+                .await;
+
+            let auth = auth_manager.auth_cached();
+            Self::maybe_refresh_remote_installed_plugins_cache_for_current_config(
+                &config_manager,
+                &thread_manager,
+                auth.clone(),
+            )
+            .await;
+            let payload_v2 = AccountUpdatedNotification {
+                auth_mode: auth.as_ref().map(CodexAuth::api_auth_mode),
+                plan_type: auth.as_ref().and_then(CodexAuth::account_plan_type),
+            };
+            outgoing
+                .send_server_notification(ServerNotification::AccountUpdated(payload_v2))
+                .await;
+        }
     }
 
     async fn logout_common(&self) -> std::result::Result<Option<AuthMode>, JSONRPCErrorError> {
@@ -1921,9 +1913,10 @@ impl CodexMessageProcessor {
             }
         }
 
-        Self::clear_remote_plugin_auth_state_for_thread_manager(
-            &self.thread_manager,
+        Self::maybe_refresh_remote_installed_plugins_cache_for_current_config(
             &self.config_manager,
+            &self.thread_manager,
+            self.auth_manager.auth_cached(),
         )
         .await;
 

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -740,6 +740,9 @@ impl CodexMessageProcessor {
 
     pub(crate) fn handle_config_mutation(&self) {
         self.clear_plugin_related_caches();
+        self.thread_manager
+            .plugins_manager()
+            .clear_remote_installed_plugins_cache();
     }
 
     pub(crate) fn effective_plugins_changed_callback(
@@ -772,8 +775,37 @@ impl CodexMessageProcessor {
     }
 
     fn clear_plugin_related_caches(&self) {
-        self.thread_manager.plugins_manager().clear_cache();
+        let plugins_manager = self.thread_manager.plugins_manager();
+        plugins_manager.clear_cache();
         self.thread_manager.skills_manager().clear_cache();
+    }
+
+    async fn clear_remote_plugin_auth_state_for_thread_manager(
+        thread_manager: &Arc<ThreadManager>,
+        config_manager: &ConfigManager,
+    ) {
+        if !thread_manager
+            .plugins_manager()
+            .clear_remote_installed_plugins_cache()
+        {
+            return;
+        }
+
+        let config = match config_manager
+            .load_latest_config(/*fallback_cwd*/ None)
+            .await
+        {
+            Ok(config) => config,
+            Err(err) => {
+                warn!(
+                    "failed to reload config after remote plugin auth state changed, clearing plugin-related caches only: {err}"
+                );
+                thread_manager.plugins_manager().clear_cache();
+                thread_manager.skills_manager().clear_cache();
+                return;
+            }
+        };
+        Self::spawn_effective_plugins_changed_task(Arc::clone(thread_manager), config);
     }
 
     fn current_account_updated_notification(&self) -> AccountUpdatedNotification {
@@ -1565,11 +1597,12 @@ impl CodexMessageProcessor {
             });
         }
 
-        let outgoing_clone = self.outgoing.clone();
-        let active_login = self.active_login.clone();
+        let outgoing = self.outgoing.clone();
         let auth_manager = self.auth_manager.clone();
         let config_manager = self.config_manager.clone();
+        let thread_manager = Arc::clone(&self.thread_manager);
         let chatgpt_base_url = self.config.chatgpt_base_url.clone();
+        let active_login = self.active_login.clone();
         let auth_url = server.auth_url.clone();
         tokio::spawn(async move {
             let (success, error_msg) = match tokio::time::timeout(
@@ -1586,16 +1619,42 @@ impl CodexMessageProcessor {
                 }
             };
 
-            Self::send_chatgpt_login_completion_notifications(
-                &outgoing_clone,
-                auth_manager,
-                config_manager,
-                chatgpt_base_url,
-                login_id,
+            let account_updated_payload = if success {
+                auth_manager.reload().await;
+                Self::clear_remote_plugin_auth_state_for_thread_manager(
+                    &thread_manager,
+                    &config_manager,
+                )
+                .await;
+                config_manager
+                    .replace_cloud_requirements_loader(auth_manager.clone(), chatgpt_base_url);
+                config_manager
+                    .sync_default_client_residency_requirement()
+                    .await;
+                auth_manager
+                    .auth_cached()
+                    .map(|auth| AccountUpdatedNotification {
+                        auth_mode: Some(auth.api_auth_mode()),
+                        plan_type: auth.account_plan_type(),
+                    })
+            } else {
+                None
+            };
+
+            let payload_v2 = AccountLoginCompletedNotification {
+                login_id: Some(login_id.to_string()),
                 success,
-                error_msg,
-            )
-            .await;
+                error: error_msg,
+            };
+            outgoing
+                .send_server_notification(ServerNotification::AccountLoginCompleted(payload_v2))
+                .await;
+
+            if let Some(payload_v2) = account_updated_payload {
+                outgoing
+                    .send_server_notification(ServerNotification::AccountUpdated(payload_v2))
+                    .await;
+            }
 
             // Clear the active login if it matches this attempt. It may have been replaced or cancelled.
             let mut guard = active_login.lock().await;
@@ -1641,11 +1700,12 @@ impl CodexMessageProcessor {
         let verification_url = device_code.verification_url.clone();
         let user_code = device_code.user_code.clone();
 
-        let outgoing_clone = self.outgoing.clone();
-        let active_login = self.active_login.clone();
+        let outgoing = self.outgoing.clone();
         let auth_manager = self.auth_manager.clone();
         let config_manager = self.config_manager.clone();
+        let thread_manager = Arc::clone(&self.thread_manager);
         let chatgpt_base_url = self.config.chatgpt_base_url.clone();
+        let active_login = self.active_login.clone();
         tokio::spawn(async move {
             let (success, error_msg) = tokio::select! {
                 _ = cancel.cancelled() => {
@@ -1659,16 +1719,42 @@ impl CodexMessageProcessor {
                 }
             };
 
-            Self::send_chatgpt_login_completion_notifications(
-                &outgoing_clone,
-                auth_manager,
-                config_manager,
-                chatgpt_base_url,
-                login_id,
+            let account_updated_payload = if success {
+                auth_manager.reload().await;
+                Self::clear_remote_plugin_auth_state_for_thread_manager(
+                    &thread_manager,
+                    &config_manager,
+                )
+                .await;
+                config_manager
+                    .replace_cloud_requirements_loader(auth_manager.clone(), chatgpt_base_url);
+                config_manager
+                    .sync_default_client_residency_requirement()
+                    .await;
+                auth_manager
+                    .auth_cached()
+                    .map(|auth| AccountUpdatedNotification {
+                        auth_mode: Some(auth.api_auth_mode()),
+                        plan_type: auth.account_plan_type(),
+                    })
+            } else {
+                None
+            };
+
+            let payload_v2 = AccountLoginCompletedNotification {
+                login_id: Some(login_id.to_string()),
                 success,
-                error_msg,
-            )
-            .await;
+                error: error_msg,
+            };
+            outgoing
+                .send_server_notification(ServerNotification::AccountLoginCompleted(payload_v2))
+                .await;
+
+            if let Some(payload_v2) = account_updated_payload {
+                outgoing
+                    .send_server_notification(ServerNotification::AccountUpdated(payload_v2))
+                    .await;
+            }
 
             let mut guard = active_login.lock().await;
             if guard.as_ref().map(ActiveLogin::login_id) == Some(login_id) {
@@ -1791,6 +1877,12 @@ impl CodexMessageProcessor {
     }
 
     async fn send_login_success_notifications(&self, login_id: Option<Uuid>) {
+        Self::clear_remote_plugin_auth_state_for_thread_manager(
+            &self.thread_manager,
+            &self.config_manager,
+        )
+        .await;
+
         let payload_login_completed = AccountLoginCompletedNotification {
             login_id: login_id.map(|id| id.to_string()),
             success: true,
@@ -1807,43 +1899,6 @@ impl CodexMessageProcessor {
                 self.current_account_updated_notification(),
             ))
             .await;
-    }
-
-    async fn send_chatgpt_login_completion_notifications(
-        outgoing: &OutgoingMessageSender,
-        auth_manager: Arc<AuthManager>,
-        config_manager: ConfigManager,
-        chatgpt_base_url: String,
-        login_id: Uuid,
-        success: bool,
-        error_msg: Option<String>,
-    ) {
-        let payload_v2 = AccountLoginCompletedNotification {
-            login_id: Some(login_id.to_string()),
-            success,
-            error: error_msg,
-        };
-        outgoing
-            .send_server_notification(ServerNotification::AccountLoginCompleted(payload_v2))
-            .await;
-
-        if success {
-            auth_manager.reload().await;
-            config_manager
-                .replace_cloud_requirements_loader(auth_manager.clone(), chatgpt_base_url);
-            config_manager
-                .sync_default_client_residency_requirement()
-                .await;
-
-            let auth = auth_manager.auth_cached();
-            let payload_v2 = AccountUpdatedNotification {
-                auth_mode: auth.as_ref().map(CodexAuth::api_auth_mode),
-                plan_type: auth.as_ref().and_then(CodexAuth::account_plan_type),
-            };
-            outgoing
-                .send_server_notification(ServerNotification::AccountUpdated(payload_v2))
-                .await;
-        }
     }
 
     async fn logout_common(&self) -> std::result::Result<Option<AuthMode>, JSONRPCErrorError> {
@@ -1865,6 +1920,12 @@ impl CodexMessageProcessor {
                 });
             }
         }
+
+        Self::clear_remote_plugin_auth_state_for_thread_manager(
+            &self.thread_manager,
+            &self.config_manager,
+        )
+        .await;
 
         // Reflect the current auth method after logout (likely None).
         Ok(self

--- a/codex-rs/core-plugins/src/manager.rs
+++ b/codex-rs/core-plugins/src/manager.rs
@@ -121,25 +121,8 @@ struct CachedFeaturedPluginIds {
     featured_plugin_ids: Vec<String>,
 }
 
-// Auth changes clear the cache, but an in-flight refresh for the old account can still finish
-// later. Keep the key with each refresh result so stale responses cannot publish old account state.
-#[derive(Clone, PartialEq, Eq)]
-struct RemoteInstalledPluginsCacheKey {
-    chatgpt_base_url: String,
-    account_id: Option<String>,
-    chatgpt_user_id: Option<String>,
-    is_workspace_account: bool,
-}
-
-#[derive(Clone, PartialEq)]
-struct CachedRemoteInstalledPlugins {
-    key: RemoteInstalledPluginsCacheKey,
-    plugins: Vec<RemoteInstalledPlugin>,
-}
-
 struct RemoteInstalledPluginsCacheRefreshRequest {
     service_config: RemotePluginServiceConfig,
-    cache_key: Option<RemoteInstalledPluginsCacheKey>,
     auth: Option<CodexAuth>,
     notify: RemoteInstalledPluginsCacheRefreshNotify,
     // App-server attaches side effects such as skills metadata invalidation and MCP refreshes when
@@ -202,25 +185,6 @@ fn featured_plugin_ids_cache_key(
         chatgpt_user_id: auth.and_then(CodexAuth::get_chatgpt_user_id),
         is_workspace_account: auth.is_some_and(CodexAuth::is_workspace_account),
     }
-}
-
-fn remote_installed_plugins_cache_key(
-    config: &PluginsConfigInput,
-    auth: Option<&CodexAuth>,
-) -> Option<RemoteInstalledPluginsCacheKey> {
-    if !config.remote_plugin_enabled {
-        return None;
-    }
-    let auth = auth?;
-    if !auth.uses_codex_backend() {
-        return None;
-    }
-    Some(RemoteInstalledPluginsCacheKey {
-        chatgpt_base_url: config.chatgpt_base_url.clone(),
-        account_id: auth.get_account_id(),
-        chatgpt_user_id: auth.get_chatgpt_user_id(),
-        is_workspace_account: auth.is_workspace_account(),
-    })
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -423,10 +387,7 @@ pub struct PluginsManager {
     configured_marketplace_upgrade_state: RwLock<ConfiguredMarketplaceUpgradeState>,
     non_curated_cache_refresh_state: RwLock<NonCuratedCacheRefreshState>,
     cached_enabled_outcome: RwLock<Option<CachedPluginLoadOutcome>>,
-    remote_installed_plugins_cache: RwLock<Option<CachedRemoteInstalledPlugins>>,
-    // Set before each remote `/installed` refresh so older in-flight responses cannot publish
-    // plugin state for an account that is no longer current.
-    current_remote_installed_plugins_cache_key: RwLock<Option<RemoteInstalledPluginsCacheKey>>,
+    remote_installed_plugins_cache: RwLock<Option<Vec<RemoteInstalledPlugin>>>,
     remote_installed_plugins_cache_refresh_state: RwLock<RemoteInstalledPluginsCacheRefreshState>,
     remote_sync_lock: Semaphore,
     restriction_product: Option<Product>,
@@ -466,7 +427,6 @@ impl PluginsManager {
             non_curated_cache_refresh_state: RwLock::new(NonCuratedCacheRefreshState::default()),
             cached_enabled_outcome: RwLock::new(None),
             remote_installed_plugins_cache: RwLock::new(None),
-            current_remote_installed_plugins_cache_key: RwLock::new(None),
             remote_installed_plugins_cache_refresh_state: RwLock::new(
                 RemoteInstalledPluginsCacheRefreshState::default(),
             ),
@@ -591,17 +551,22 @@ impl PluginsManager {
         config_version: &str,
         plugin_hooks_enabled: bool,
     ) -> Option<PluginLoadOutcome> {
-        let cache = match self.cached_enabled_outcome.read() {
-            Ok(cache) => cache,
-            Err(err) => err.into_inner(),
-        };
-        let cache = cache.as_ref()?;
-        if cache.config_version == config_version
-            && cache.plugin_hooks_enabled == plugin_hooks_enabled
-        {
-            Some(cache.outcome.clone())
-        } else {
-            None
+        match self.cached_enabled_outcome.read() {
+            Ok(cache) => cache
+                .as_ref()
+                .filter(|cached| {
+                    cached.config_version == config_version
+                        && cached.plugin_hooks_enabled == plugin_hooks_enabled
+                })
+                .map(|cached| cached.outcome.clone()),
+            Err(err) => err
+                .into_inner()
+                .as_ref()
+                .filter(|cached| {
+                    cached.config_version == config_version
+                        && cached.plugin_hooks_enabled == plugin_hooks_enabled
+                })
+                .map(|cached| cached.outcome.clone()),
         }
     }
 
@@ -612,108 +577,33 @@ impl PluginsManager {
         if !config.remote_plugin_enabled {
             return HashMap::new();
         }
-        let current_cache_key = match self.current_remote_installed_plugins_cache_key.read() {
-            Ok(cache_key) => cache_key.clone(),
-            Err(err) => err.into_inner().clone(),
-        };
-        let Some(current_cache_key) = current_cache_key else {
-            return HashMap::new();
-        };
 
         let cache = match self.remote_installed_plugins_cache.read() {
             Ok(cache) => cache,
             Err(err) => err.into_inner(),
         };
-        let Some(cache) = cache.as_ref() else {
+        let Some(plugins) = cache.as_ref() else {
             return HashMap::new();
         };
-        if cache.key != current_cache_key {
-            return HashMap::new();
-        }
 
-        remote_installed_plugins_to_config(&cache.plugins, &self.store)
+        remote_installed_plugins_to_config(plugins, &self.store)
     }
 
-    fn remote_installed_plugins_cache_key_matches(
-        current_cache_key: Option<&RemoteInstalledPluginsCacheKey>,
-        cache_key: Option<&RemoteInstalledPluginsCacheKey>,
-    ) -> bool {
-        match (current_cache_key, cache_key) {
-            (Some(current_cache_key), Some(cache_key)) => current_cache_key == cache_key,
-            (None, None) => true,
-            (Some(_), None) | (None, Some(_)) => false,
-        }
-    }
-
-    fn set_current_remote_installed_plugins_cache_key(
-        &self,
-        next_cache_key: Option<RemoteInstalledPluginsCacheKey>,
-    ) -> bool {
-        let mut current_cache_key = match self.current_remote_installed_plugins_cache_key.write() {
-            Ok(cache_key) => cache_key,
-            Err(err) => err.into_inner(),
-        };
-        if *current_cache_key == next_cache_key {
-            return false;
-        }
-        *current_cache_key = next_cache_key;
-        drop(current_cache_key);
-
-        let cache_changed = self.clear_remote_installed_plugins_cache_entry();
-        if !cache_changed {
-            self.clear_enabled_outcome_cache();
-        }
-        true
-    }
-
-    fn write_remote_installed_plugins_cache_if_current(
-        &self,
-        key: RemoteInstalledPluginsCacheKey,
-        plugins: Vec<RemoteInstalledPlugin>,
-    ) -> Option<bool> {
-        // Hold the current-key read lock through the cache write so an account switch cannot race
-        // between the freshness check and publishing the refreshed installed state.
-        let current_cache_key = match self.current_remote_installed_plugins_cache_key.read() {
-            Ok(cache_key) => cache_key,
-            Err(err) => err.into_inner(),
-        };
-        if !Self::remote_installed_plugins_cache_key_matches(current_cache_key.as_ref(), Some(&key))
-        {
-            return None;
-        }
-
+    fn write_remote_installed_plugins_cache(&self, plugins: Vec<RemoteInstalledPlugin>) -> bool {
         let mut cache = match self.remote_installed_plugins_cache.write() {
             Ok(cache) => cache,
             Err(err) => err.into_inner(),
         };
-        let new_cache = CachedRemoteInstalledPlugins { key, plugins };
-        if cache.as_ref().is_some_and(|cache| cache == &new_cache) {
-            return Some(false);
+        if cache.as_ref().is_some_and(|cache| cache.eq(&plugins)) {
+            return false;
         }
-        *cache = Some(new_cache);
+        *cache = Some(plugins);
         drop(cache);
-        drop(current_cache_key);
         self.clear_enabled_outcome_cache();
-        Some(true)
+        true
     }
 
     pub fn clear_remote_installed_plugins_cache(&self) -> bool {
-        let mut current_cache_key = match self.current_remote_installed_plugins_cache_key.write() {
-            Ok(cache_key) => cache_key,
-            Err(err) => err.into_inner(),
-        };
-        let current_key_changed = current_cache_key.is_some();
-        *current_cache_key = None;
-        drop(current_cache_key);
-
-        let cache_changed = self.clear_remote_installed_plugins_cache_entry();
-        if current_key_changed && !cache_changed {
-            self.clear_enabled_outcome_cache();
-        }
-        current_key_changed || cache_changed
-    }
-
-    fn clear_remote_installed_plugins_cache_entry(&self) -> bool {
         let mut cache = match self.remote_installed_plugins_cache.write() {
             Ok(cache) => cache,
             Err(err) => err.into_inner(),
@@ -725,21 +615,6 @@ impl PluginsManager {
         drop(cache);
         self.clear_enabled_outcome_cache();
         true
-    }
-
-    fn clear_remote_installed_plugins_cache_entry_if_current(
-        &self,
-        cache_key: Option<&RemoteInstalledPluginsCacheKey>,
-    ) -> Option<bool> {
-        let current_cache_key = match self.current_remote_installed_plugins_cache_key.read() {
-            Ok(cache_key) => cache_key,
-            Err(err) => err.into_inner(),
-        };
-        if !Self::remote_installed_plugins_cache_key_matches(current_cache_key.as_ref(), cache_key)
-        {
-            return None;
-        }
-        Some(self.clear_remote_installed_plugins_cache_entry())
     }
 
     pub fn maybe_start_remote_installed_plugins_cache_refresh(
@@ -784,11 +659,6 @@ impl PluginsManager {
         self.schedule_remote_installed_plugins_cache_refresh(
             RemoteInstalledPluginsCacheRefreshRequest {
                 service_config: remote_plugin_service_config(config),
-                cache_key: {
-                    let cache_key = remote_installed_plugins_cache_key(config, auth.as_ref());
-                    self.set_current_remote_installed_plugins_cache_key(cache_key.clone());
-                    cache_key
-                },
                 auth,
                 notify,
                 on_effective_plugins_changed,
@@ -1833,29 +1703,12 @@ impl PluginsManager {
                 Ok(installed_plugins) => {
                     // TODO(remote plugins): reconcile missing or stale local bundles before
                     // publishing remote installed state as effective local plugin config.
-                    let (accepted, changed) = match request.cache_key {
-                        Some(cache_key) => {
-                            match self.write_remote_installed_plugins_cache_if_current(
-                                cache_key,
-                                installed_plugins,
-                            ) {
-                                Some(changed) => (true, changed),
-                                None => (false, false),
-                            }
-                        }
-                        None => match self.clear_remote_installed_plugins_cache_entry_if_current(
-                            /*cache_key*/ None,
-                        ) {
-                            Some(changed) => (true, changed),
-                            None => (false, false),
-                        },
-                    };
-                    let should_notify = accepted
-                        && (changed
-                            || matches!(
-                                request.notify,
-                                RemoteInstalledPluginsCacheRefreshNotify::AfterSuccessfulRefresh
-                            ));
+                    let changed = self.write_remote_installed_plugins_cache(installed_plugins);
+                    let should_notify = changed
+                        || matches!(
+                            request.notify,
+                            RemoteInstalledPluginsCacheRefreshNotify::AfterSuccessfulRefresh
+                        );
                     if should_notify
                         && let Some(on_effective_plugins_changed) =
                             request.on_effective_plugins_changed
@@ -1867,11 +1720,7 @@ impl PluginsManager {
                     RemotePluginCatalogError::AuthRequired
                     | RemotePluginCatalogError::UnsupportedAuthMode,
                 ) => {
-                    let changed = self
-                        .clear_remote_installed_plugins_cache_entry_if_current(
-                            request.cache_key.as_ref(),
-                        )
-                        .unwrap_or(false);
+                    let changed = self.clear_remote_installed_plugins_cache();
                     if changed
                         && let Some(on_effective_plugins_changed) =
                             request.on_effective_plugins_changed

--- a/codex-rs/core-plugins/src/manager.rs
+++ b/codex-rs/core-plugins/src/manager.rs
@@ -121,8 +121,25 @@ struct CachedFeaturedPluginIds {
     featured_plugin_ids: Vec<String>,
 }
 
+// Auth changes clear the cache, but an in-flight refresh for the old account can still finish
+// later. Keep the key with each refresh result so stale responses cannot publish old account state.
+#[derive(Clone, PartialEq, Eq)]
+struct RemoteInstalledPluginsCacheKey {
+    chatgpt_base_url: String,
+    account_id: Option<String>,
+    chatgpt_user_id: Option<String>,
+    is_workspace_account: bool,
+}
+
+#[derive(Clone, PartialEq)]
+struct CachedRemoteInstalledPlugins {
+    key: RemoteInstalledPluginsCacheKey,
+    plugins: Vec<RemoteInstalledPlugin>,
+}
+
 struct RemoteInstalledPluginsCacheRefreshRequest {
     service_config: RemotePluginServiceConfig,
+    cache_key: Option<RemoteInstalledPluginsCacheKey>,
     auth: Option<CodexAuth>,
     notify: RemoteInstalledPluginsCacheRefreshNotify,
     // App-server attaches side effects such as skills metadata invalidation and MCP refreshes when
@@ -185,6 +202,25 @@ fn featured_plugin_ids_cache_key(
         chatgpt_user_id: auth.and_then(CodexAuth::get_chatgpt_user_id),
         is_workspace_account: auth.is_some_and(CodexAuth::is_workspace_account),
     }
+}
+
+fn remote_installed_plugins_cache_key(
+    config: &PluginsConfigInput,
+    auth: Option<&CodexAuth>,
+) -> Option<RemoteInstalledPluginsCacheKey> {
+    if !config.remote_plugin_enabled {
+        return None;
+    }
+    let auth = auth?;
+    if !auth.uses_codex_backend() {
+        return None;
+    }
+    Some(RemoteInstalledPluginsCacheKey {
+        chatgpt_base_url: config.chatgpt_base_url.clone(),
+        account_id: auth.get_account_id(),
+        chatgpt_user_id: auth.get_chatgpt_user_id(),
+        is_workspace_account: auth.is_workspace_account(),
+    })
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -387,9 +423,10 @@ pub struct PluginsManager {
     configured_marketplace_upgrade_state: RwLock<ConfiguredMarketplaceUpgradeState>,
     non_curated_cache_refresh_state: RwLock<NonCuratedCacheRefreshState>,
     cached_enabled_outcome: RwLock<Option<CachedPluginLoadOutcome>>,
-    // TODO(remote plugins): reset this cache when ChatGPT auth/account state changes so stale
-    // remote installed state cannot remain effective for a different account.
-    remote_installed_plugins_cache: RwLock<Option<Vec<RemoteInstalledPlugin>>>,
+    remote_installed_plugins_cache: RwLock<Option<CachedRemoteInstalledPlugins>>,
+    // Set before each remote `/installed` refresh so older in-flight responses cannot publish
+    // plugin state for an account that is no longer current.
+    current_remote_installed_plugins_cache_key: RwLock<Option<RemoteInstalledPluginsCacheKey>>,
     remote_installed_plugins_cache_refresh_state: RwLock<RemoteInstalledPluginsCacheRefreshState>,
     remote_sync_lock: Semaphore,
     restriction_product: Option<Product>,
@@ -429,6 +466,7 @@ impl PluginsManager {
             non_curated_cache_refresh_state: RwLock::new(NonCuratedCacheRefreshState::default()),
             cached_enabled_outcome: RwLock::new(None),
             remote_installed_plugins_cache: RwLock::new(None),
+            current_remote_installed_plugins_cache_key: RwLock::new(None),
             remote_installed_plugins_cache_refresh_state: RwLock::new(
                 RemoteInstalledPluginsCacheRefreshState::default(),
             ),
@@ -553,22 +591,17 @@ impl PluginsManager {
         config_version: &str,
         plugin_hooks_enabled: bool,
     ) -> Option<PluginLoadOutcome> {
-        match self.cached_enabled_outcome.read() {
-            Ok(cache) => cache
-                .as_ref()
-                .filter(|cached| {
-                    cached.config_version == config_version
-                        && cached.plugin_hooks_enabled == plugin_hooks_enabled
-                })
-                .map(|cached| cached.outcome.clone()),
-            Err(err) => err
-                .into_inner()
-                .as_ref()
-                .filter(|cached| {
-                    cached.config_version == config_version
-                        && cached.plugin_hooks_enabled == plugin_hooks_enabled
-                })
-                .map(|cached| cached.outcome.clone()),
+        let cache = match self.cached_enabled_outcome.read() {
+            Ok(cache) => cache,
+            Err(err) => err.into_inner(),
+        };
+        let cache = cache.as_ref()?;
+        if cache.config_version == config_version
+            && cache.plugin_hooks_enabled == plugin_hooks_enabled
+        {
+            Some(cache.outcome.clone())
+        } else {
+            None
         }
     }
 
@@ -579,33 +612,108 @@ impl PluginsManager {
         if !config.remote_plugin_enabled {
             return HashMap::new();
         }
+        let current_cache_key = match self.current_remote_installed_plugins_cache_key.read() {
+            Ok(cache_key) => cache_key.clone(),
+            Err(err) => err.into_inner().clone(),
+        };
+        let Some(current_cache_key) = current_cache_key else {
+            return HashMap::new();
+        };
 
         let cache = match self.remote_installed_plugins_cache.read() {
             Ok(cache) => cache,
             Err(err) => err.into_inner(),
         };
-        let Some(plugins) = cache.as_ref() else {
+        let Some(cache) = cache.as_ref() else {
             return HashMap::new();
         };
+        if cache.key != current_cache_key {
+            return HashMap::new();
+        }
 
-        remote_installed_plugins_to_config(plugins, &self.store)
+        remote_installed_plugins_to_config(&cache.plugins, &self.store)
     }
 
-    fn write_remote_installed_plugins_cache(&self, plugins: Vec<RemoteInstalledPlugin>) -> bool {
+    fn remote_installed_plugins_cache_key_matches(
+        current_cache_key: Option<&RemoteInstalledPluginsCacheKey>,
+        cache_key: Option<&RemoteInstalledPluginsCacheKey>,
+    ) -> bool {
+        match (current_cache_key, cache_key) {
+            (Some(current_cache_key), Some(cache_key)) => current_cache_key == cache_key,
+            (None, None) => true,
+            (Some(_), None) | (None, Some(_)) => false,
+        }
+    }
+
+    fn set_current_remote_installed_plugins_cache_key(
+        &self,
+        next_cache_key: Option<RemoteInstalledPluginsCacheKey>,
+    ) -> bool {
+        let mut current_cache_key = match self.current_remote_installed_plugins_cache_key.write() {
+            Ok(cache_key) => cache_key,
+            Err(err) => err.into_inner(),
+        };
+        if *current_cache_key == next_cache_key {
+            return false;
+        }
+        *current_cache_key = next_cache_key;
+        drop(current_cache_key);
+
+        let cache_changed = self.clear_remote_installed_plugins_cache_entry();
+        if !cache_changed {
+            self.clear_enabled_outcome_cache();
+        }
+        true
+    }
+
+    fn write_remote_installed_plugins_cache_if_current(
+        &self,
+        key: RemoteInstalledPluginsCacheKey,
+        plugins: Vec<RemoteInstalledPlugin>,
+    ) -> Option<bool> {
+        // Hold the current-key read lock through the cache write so an account switch cannot race
+        // between the freshness check and publishing the refreshed installed state.
+        let current_cache_key = match self.current_remote_installed_plugins_cache_key.read() {
+            Ok(cache_key) => cache_key,
+            Err(err) => err.into_inner(),
+        };
+        if !Self::remote_installed_plugins_cache_key_matches(current_cache_key.as_ref(), Some(&key))
+        {
+            return None;
+        }
+
         let mut cache = match self.remote_installed_plugins_cache.write() {
             Ok(cache) => cache,
             Err(err) => err.into_inner(),
         };
-        if cache.as_ref().is_some_and(|cache| cache.eq(&plugins)) {
-            return false;
+        let new_cache = CachedRemoteInstalledPlugins { key, plugins };
+        if cache.as_ref().is_some_and(|cache| cache == &new_cache) {
+            return Some(false);
         }
-        *cache = Some(plugins);
+        *cache = Some(new_cache);
         drop(cache);
+        drop(current_cache_key);
         self.clear_enabled_outcome_cache();
-        true
+        Some(true)
     }
 
     pub fn clear_remote_installed_plugins_cache(&self) -> bool {
+        let mut current_cache_key = match self.current_remote_installed_plugins_cache_key.write() {
+            Ok(cache_key) => cache_key,
+            Err(err) => err.into_inner(),
+        };
+        let current_key_changed = current_cache_key.is_some();
+        *current_cache_key = None;
+        drop(current_cache_key);
+
+        let cache_changed = self.clear_remote_installed_plugins_cache_entry();
+        if current_key_changed && !cache_changed {
+            self.clear_enabled_outcome_cache();
+        }
+        current_key_changed || cache_changed
+    }
+
+    fn clear_remote_installed_plugins_cache_entry(&self) -> bool {
         let mut cache = match self.remote_installed_plugins_cache.write() {
             Ok(cache) => cache,
             Err(err) => err.into_inner(),
@@ -617,6 +725,21 @@ impl PluginsManager {
         drop(cache);
         self.clear_enabled_outcome_cache();
         true
+    }
+
+    fn clear_remote_installed_plugins_cache_entry_if_current(
+        &self,
+        cache_key: Option<&RemoteInstalledPluginsCacheKey>,
+    ) -> Option<bool> {
+        let current_cache_key = match self.current_remote_installed_plugins_cache_key.read() {
+            Ok(cache_key) => cache_key,
+            Err(err) => err.into_inner(),
+        };
+        if !Self::remote_installed_plugins_cache_key_matches(current_cache_key.as_ref(), cache_key)
+        {
+            return None;
+        }
+        Some(self.clear_remote_installed_plugins_cache_entry())
     }
 
     pub fn maybe_start_remote_installed_plugins_cache_refresh(
@@ -661,6 +784,11 @@ impl PluginsManager {
         self.schedule_remote_installed_plugins_cache_refresh(
             RemoteInstalledPluginsCacheRefreshRequest {
                 service_config: remote_plugin_service_config(config),
+                cache_key: {
+                    let cache_key = remote_installed_plugins_cache_key(config, auth.as_ref());
+                    self.set_current_remote_installed_plugins_cache_key(cache_key.clone());
+                    cache_key
+                },
                 auth,
                 notify,
                 on_effective_plugins_changed,
@@ -1705,12 +1833,29 @@ impl PluginsManager {
                 Ok(installed_plugins) => {
                     // TODO(remote plugins): reconcile missing or stale local bundles before
                     // publishing remote installed state as effective local plugin config.
-                    let changed = self.write_remote_installed_plugins_cache(installed_plugins);
-                    let should_notify = changed
-                        || matches!(
-                            request.notify,
-                            RemoteInstalledPluginsCacheRefreshNotify::AfterSuccessfulRefresh
-                        );
+                    let (accepted, changed) = match request.cache_key {
+                        Some(cache_key) => {
+                            match self.write_remote_installed_plugins_cache_if_current(
+                                cache_key,
+                                installed_plugins,
+                            ) {
+                                Some(changed) => (true, changed),
+                                None => (false, false),
+                            }
+                        }
+                        None => match self.clear_remote_installed_plugins_cache_entry_if_current(
+                            /*cache_key*/ None,
+                        ) {
+                            Some(changed) => (true, changed),
+                            None => (false, false),
+                        },
+                    };
+                    let should_notify = accepted
+                        && (changed
+                            || matches!(
+                                request.notify,
+                                RemoteInstalledPluginsCacheRefreshNotify::AfterSuccessfulRefresh
+                            ));
                     if should_notify
                         && let Some(on_effective_plugins_changed) =
                             request.on_effective_plugins_changed
@@ -1722,7 +1867,11 @@ impl PluginsManager {
                     RemotePluginCatalogError::AuthRequired
                     | RemotePluginCatalogError::UnsupportedAuthMode,
                 ) => {
-                    let changed = self.clear_remote_installed_plugins_cache();
+                    let changed = self
+                        .clear_remote_installed_plugins_cache_entry_if_current(
+                            request.cache_key.as_ref(),
+                        )
+                        .unwrap_or(false);
                     if changed
                         && let Some(on_effective_plugins_changed) =
                             request.on_effective_plugins_changed

--- a/codex-rs/core-plugins/src/manager_tests.rs
+++ b/codex-rs/core-plugins/src/manager_tests.rs
@@ -345,13 +345,22 @@ remote_plugin = true
     );
 
     let config = load_config(codex_home.path(), codex_home.path()).await;
+    let auth = CodexAuth::create_dummy_chatgpt_auth_for_testing();
+    let remote_cache_key = remote_installed_plugins_cache_key(&config, Some(&auth)).unwrap();
     let manager = PluginsManager::new(codex_home.path().to_path_buf());
-    manager.write_remote_installed_plugins_cache(vec![RemoteInstalledPlugin {
-        marketplace_name: "chatgpt-global".to_string(),
-        id: "plugins~Plugin_linear".to_string(),
-        name: "linear".to_string(),
-        enabled: true,
-    }]);
+    manager.set_current_remote_installed_plugins_cache_key(Some(remote_cache_key.clone()));
+    assert_eq!(
+        manager.write_remote_installed_plugins_cache_if_current(
+            remote_cache_key,
+            vec![RemoteInstalledPlugin {
+                marketplace_name: "chatgpt-global".to_string(),
+                id: "plugins~Plugin_linear".to_string(),
+                name: "linear".to_string(),
+                enabled: true,
+            }],
+        ),
+        Some(true)
+    );
 
     let outcome = manager.plugins_for_config(&config).await;
     assert_eq!(
@@ -374,16 +383,136 @@ remote_plugin = true
     );
 
     let config = load_config(codex_home.path(), codex_home.path()).await;
+    let auth = CodexAuth::create_dummy_chatgpt_auth_for_testing();
+    let remote_cache_key = remote_installed_plugins_cache_key(&config, Some(&auth)).unwrap();
     let manager = PluginsManager::new(codex_home.path().to_path_buf());
-    manager.write_remote_installed_plugins_cache(vec![RemoteInstalledPlugin {
+    manager.set_current_remote_installed_plugins_cache_key(Some(remote_cache_key.clone()));
+    assert_eq!(
+        manager.write_remote_installed_plugins_cache_if_current(
+            remote_cache_key,
+            vec![RemoteInstalledPlugin {
+                marketplace_name: "chatgpt-global".to_string(),
+                id: "plugins~Plugin_linear".to_string(),
+                name: "linear".to_string(),
+                enabled: true,
+            }],
+        ),
+        Some(true)
+    );
+
+    let outcome = manager.plugins_for_config(&config).await;
+    assert_eq!(outcome, PluginLoadOutcome::default());
+}
+
+#[tokio::test]
+async fn remote_installed_cache_ignores_entries_for_different_account() {
+    let codex_home = TempDir::new().unwrap();
+    let plugin_base = codex_home
+        .path()
+        .join("plugins/cache/chatgpt-global/linear");
+    write_plugin(&plugin_base, "local", "linear");
+    write_file(
+        &codex_home.path().join(CONFIG_TOML_FILE),
+        r#"[features]
+plugins = true
+remote_plugin = true
+"#,
+    );
+
+    let config = load_config(codex_home.path(), codex_home.path()).await;
+    let auth = CodexAuth::create_dummy_chatgpt_auth_for_testing();
+    let current_cache_key = remote_installed_plugins_cache_key(&config, Some(&auth)).unwrap();
+    let other_account_cache_key = RemoteInstalledPluginsCacheKey {
+        account_id: Some("other_account".to_string()),
+        ..current_cache_key.clone()
+    };
+    let manager = PluginsManager::new(codex_home.path().to_path_buf());
+    let remote_plugins = vec![RemoteInstalledPlugin {
         marketplace_name: "chatgpt-global".to_string(),
         id: "plugins~Plugin_linear".to_string(),
         name: "linear".to_string(),
         enabled: true,
-    }]);
+    }];
+    manager.set_current_remote_installed_plugins_cache_key(Some(current_cache_key.clone()));
+    assert_eq!(
+        manager.write_remote_installed_plugins_cache_if_current(
+            other_account_cache_key.clone(),
+            remote_plugins.clone(),
+        ),
+        None
+    );
+
+    let stale_outcome = manager.plugins_for_config(&config).await;
+    assert_eq!(stale_outcome, PluginLoadOutcome::default());
+
+    assert_eq!(
+        manager.write_remote_installed_plugins_cache_if_current(current_cache_key, remote_plugins),
+        Some(true)
+    );
+    let current_outcome = manager.plugins_for_config(&config).await;
+    assert_eq!(
+        current_outcome.effective_skill_roots(),
+        vec![AbsolutePathBuf::try_from(plugin_base.join("local/skills")).unwrap()]
+    );
+    assert_eq!(current_outcome.plugins().len(), 1);
+    assert_eq!(
+        current_outcome.plugins()[0].config_name,
+        "linear@chatgpt-global"
+    );
+
+    manager.set_current_remote_installed_plugins_cache_key(Some(other_account_cache_key));
+    let switched_account_outcome = manager.plugins_for_config(&config).await;
+    assert_eq!(switched_account_outcome, PluginLoadOutcome::default());
+}
+
+#[tokio::test]
+async fn remote_installed_cache_entry_clear_preserves_current_account_key() {
+    let codex_home = TempDir::new().unwrap();
+    let plugin_base = codex_home
+        .path()
+        .join("plugins/cache/chatgpt-global/linear");
+    write_plugin(&plugin_base, "local", "linear");
+    write_file(
+        &codex_home.path().join(CONFIG_TOML_FILE),
+        r#"[features]
+plugins = true
+remote_plugin = true
+"#,
+    );
+
+    let config = load_config(codex_home.path(), codex_home.path()).await;
+    let auth = CodexAuth::create_dummy_chatgpt_auth_for_testing();
+    let cache_key = remote_installed_plugins_cache_key(&config, Some(&auth)).unwrap();
+    let manager = PluginsManager::new(codex_home.path().to_path_buf());
+    let remote_plugins = vec![RemoteInstalledPlugin {
+        marketplace_name: "chatgpt-global".to_string(),
+        id: "plugins~Plugin_linear".to_string(),
+        name: "linear".to_string(),
+        enabled: true,
+    }];
+
+    manager.set_current_remote_installed_plugins_cache_key(Some(cache_key.clone()));
+    assert_eq!(
+        manager.write_remote_installed_plugins_cache_if_current(
+            cache_key.clone(),
+            remote_plugins.clone(),
+        ),
+        Some(true)
+    );
+    assert_eq!(
+        manager.clear_remote_installed_plugins_cache_entry_if_current(Some(&cache_key)),
+        Some(true)
+    );
+    assert_eq!(
+        manager.write_remote_installed_plugins_cache_if_current(cache_key, remote_plugins),
+        Some(true)
+    );
 
     let outcome = manager.plugins_for_config(&config).await;
-    assert_eq!(outcome, PluginLoadOutcome::default());
+    assert_eq!(
+        outcome.effective_skill_roots(),
+        vec![AbsolutePathBuf::try_from(plugin_base.join("local/skills")).unwrap()]
+    );
 }
 
 #[tokio::test]
@@ -1118,14 +1247,8 @@ async fn plugins_for_config_reloads_when_plugin_hooks_enablement_changes() {
             .is_empty()
     );
 
-    write_file(
-        &codex_home.path().join(CONFIG_TOML_FILE),
-        &plugin_config_toml_with_plugin_hooks(
-            /*enabled*/ true, /*plugins_feature_enabled*/ true,
-            /*plugin_hooks_feature_enabled*/ true,
-        ),
-    );
-    let config_with_plugin_hooks = load_config(codex_home.path(), codex_home.path()).await;
+    let mut config_with_plugin_hooks = config_without_plugin_hooks;
+    config_with_plugin_hooks.plugin_hooks_enabled = true;
     let with_plugin_hooks = manager.plugins_for_config(&config_with_plugin_hooks).await;
     assert_eq!(with_plugin_hooks.effective_plugin_hook_sources().len(), 1);
 }

--- a/codex-rs/core-plugins/src/manager_tests.rs
+++ b/codex-rs/core-plugins/src/manager_tests.rs
@@ -345,22 +345,13 @@ remote_plugin = true
     );
 
     let config = load_config(codex_home.path(), codex_home.path()).await;
-    let auth = CodexAuth::create_dummy_chatgpt_auth_for_testing();
-    let remote_cache_key = remote_installed_plugins_cache_key(&config, Some(&auth)).unwrap();
     let manager = PluginsManager::new(codex_home.path().to_path_buf());
-    manager.set_current_remote_installed_plugins_cache_key(Some(remote_cache_key.clone()));
-    assert_eq!(
-        manager.write_remote_installed_plugins_cache_if_current(
-            remote_cache_key,
-            vec![RemoteInstalledPlugin {
-                marketplace_name: "chatgpt-global".to_string(),
-                id: "plugins~Plugin_linear".to_string(),
-                name: "linear".to_string(),
-                enabled: true,
-            }],
-        ),
-        Some(true)
-    );
+    manager.write_remote_installed_plugins_cache(vec![RemoteInstalledPlugin {
+        marketplace_name: "chatgpt-global".to_string(),
+        id: "plugins~Plugin_linear".to_string(),
+        name: "linear".to_string(),
+        enabled: true,
+    }]);
 
     let outcome = manager.plugins_for_config(&config).await;
     assert_eq!(
@@ -383,136 +374,16 @@ remote_plugin = true
     );
 
     let config = load_config(codex_home.path(), codex_home.path()).await;
-    let auth = CodexAuth::create_dummy_chatgpt_auth_for_testing();
-    let remote_cache_key = remote_installed_plugins_cache_key(&config, Some(&auth)).unwrap();
     let manager = PluginsManager::new(codex_home.path().to_path_buf());
-    manager.set_current_remote_installed_plugins_cache_key(Some(remote_cache_key.clone()));
-    assert_eq!(
-        manager.write_remote_installed_plugins_cache_if_current(
-            remote_cache_key,
-            vec![RemoteInstalledPlugin {
-                marketplace_name: "chatgpt-global".to_string(),
-                id: "plugins~Plugin_linear".to_string(),
-                name: "linear".to_string(),
-                enabled: true,
-            }],
-        ),
-        Some(true)
-    );
+    manager.write_remote_installed_plugins_cache(vec![RemoteInstalledPlugin {
+        marketplace_name: "chatgpt-global".to_string(),
+        id: "plugins~Plugin_linear".to_string(),
+        name: "linear".to_string(),
+        enabled: true,
+    }]);
 
     let outcome = manager.plugins_for_config(&config).await;
     assert_eq!(outcome, PluginLoadOutcome::default());
-}
-
-#[tokio::test]
-async fn remote_installed_cache_ignores_entries_for_different_account() {
-    let codex_home = TempDir::new().unwrap();
-    let plugin_base = codex_home
-        .path()
-        .join("plugins/cache/chatgpt-global/linear");
-    write_plugin(&plugin_base, "local", "linear");
-    write_file(
-        &codex_home.path().join(CONFIG_TOML_FILE),
-        r#"[features]
-plugins = true
-remote_plugin = true
-"#,
-    );
-
-    let config = load_config(codex_home.path(), codex_home.path()).await;
-    let auth = CodexAuth::create_dummy_chatgpt_auth_for_testing();
-    let current_cache_key = remote_installed_plugins_cache_key(&config, Some(&auth)).unwrap();
-    let other_account_cache_key = RemoteInstalledPluginsCacheKey {
-        account_id: Some("other_account".to_string()),
-        ..current_cache_key.clone()
-    };
-    let manager = PluginsManager::new(codex_home.path().to_path_buf());
-    let remote_plugins = vec![RemoteInstalledPlugin {
-        marketplace_name: "chatgpt-global".to_string(),
-        id: "plugins~Plugin_linear".to_string(),
-        name: "linear".to_string(),
-        enabled: true,
-    }];
-    manager.set_current_remote_installed_plugins_cache_key(Some(current_cache_key.clone()));
-    assert_eq!(
-        manager.write_remote_installed_plugins_cache_if_current(
-            other_account_cache_key.clone(),
-            remote_plugins.clone(),
-        ),
-        None
-    );
-
-    let stale_outcome = manager.plugins_for_config(&config).await;
-    assert_eq!(stale_outcome, PluginLoadOutcome::default());
-
-    assert_eq!(
-        manager.write_remote_installed_plugins_cache_if_current(current_cache_key, remote_plugins),
-        Some(true)
-    );
-    let current_outcome = manager.plugins_for_config(&config).await;
-    assert_eq!(
-        current_outcome.effective_skill_roots(),
-        vec![AbsolutePathBuf::try_from(plugin_base.join("local/skills")).unwrap()]
-    );
-    assert_eq!(current_outcome.plugins().len(), 1);
-    assert_eq!(
-        current_outcome.plugins()[0].config_name,
-        "linear@chatgpt-global"
-    );
-
-    manager.set_current_remote_installed_plugins_cache_key(Some(other_account_cache_key));
-    let switched_account_outcome = manager.plugins_for_config(&config).await;
-    assert_eq!(switched_account_outcome, PluginLoadOutcome::default());
-}
-
-#[tokio::test]
-async fn remote_installed_cache_entry_clear_preserves_current_account_key() {
-    let codex_home = TempDir::new().unwrap();
-    let plugin_base = codex_home
-        .path()
-        .join("plugins/cache/chatgpt-global/linear");
-    write_plugin(&plugin_base, "local", "linear");
-    write_file(
-        &codex_home.path().join(CONFIG_TOML_FILE),
-        r#"[features]
-plugins = true
-remote_plugin = true
-"#,
-    );
-
-    let config = load_config(codex_home.path(), codex_home.path()).await;
-    let auth = CodexAuth::create_dummy_chatgpt_auth_for_testing();
-    let cache_key = remote_installed_plugins_cache_key(&config, Some(&auth)).unwrap();
-    let manager = PluginsManager::new(codex_home.path().to_path_buf());
-    let remote_plugins = vec![RemoteInstalledPlugin {
-        marketplace_name: "chatgpt-global".to_string(),
-        id: "plugins~Plugin_linear".to_string(),
-        name: "linear".to_string(),
-        enabled: true,
-    }];
-
-    manager.set_current_remote_installed_plugins_cache_key(Some(cache_key.clone()));
-    assert_eq!(
-        manager.write_remote_installed_plugins_cache_if_current(
-            cache_key.clone(),
-            remote_plugins.clone(),
-        ),
-        Some(true)
-    );
-    assert_eq!(
-        manager.clear_remote_installed_plugins_cache_entry_if_current(Some(&cache_key)),
-        Some(true)
-    );
-    assert_eq!(
-        manager.write_remote_installed_plugins_cache_if_current(cache_key, remote_plugins),
-        Some(true)
-    );
-
-    let outcome = manager.plugins_for_config(&config).await;
-    assert_eq!(
-        outcome.effective_skill_roots(),
-        vec![AbsolutePathBuf::try_from(plugin_base.join("local/skills")).unwrap()]
-    );
 }
 
 #[tokio::test]
@@ -1247,8 +1118,14 @@ async fn plugins_for_config_reloads_when_plugin_hooks_enablement_changes() {
             .is_empty()
     );
 
-    let mut config_with_plugin_hooks = config_without_plugin_hooks;
-    config_with_plugin_hooks.plugin_hooks_enabled = true;
+    write_file(
+        &codex_home.path().join(CONFIG_TOML_FILE),
+        &plugin_config_toml_with_plugin_hooks(
+            /*enabled*/ true, /*plugins_feature_enabled*/ true,
+            /*plugin_hooks_feature_enabled*/ true,
+        ),
+    );
+    let config_with_plugin_hooks = load_config(codex_home.path(), codex_home.path()).await;
     let with_plugin_hooks = manager.plugins_for_config(&config_with_plugin_hooks).await;
     assert_eq!(with_plugin_hooks.effective_plugin_hook_sources().len(), 1);
 }


### PR DESCRIPTION
## Summary
- Refresh the remote installed-plugin cache after login/logout instead of keying it by account or eagerly clearing it.
- Reuse the existing single-flight remote installed refresh loop so newer queued auth refreshes replace older pending requests and the API result eventually overwrites or clears the cache.
- Keep derived plugin/skills cache and MCP refresh side effects behind the existing effective-plugin-changed task when the refreshed installed state changes.
- Leave `clear_plugin_related_caches` scoped to derived plugin/skills caches so share mutations do not drop remote installed plugins.

## Tests
- `cargo fmt --all --manifest-path codex-rs/Cargo.toml` (passes; stable rustfmt warns that `imports_granularity = Item` is nightly-only)
- `cargo test -p codex-core-plugins remote_installed_cache`
- `cargo test -p codex-app-server skills_list_loads_remote_installed_plugin_skills_from_cache`