### PR TITLE
[plugins] Allow MSFT curated plugins in tool_suggest

### DIFF
--- a/codex-rs/core-plugins/src/lib.rs
+++ b/codex-rs/core-plugins/src/lib.rs
@@ -14,3 +14,19 @@ pub mod toggles;
 
 pub const OPENAI_CURATED_MARKETPLACE_NAME: &str = "openai-curated";
 pub const OPENAI_BUNDLED_MARKETPLACE_NAME: &str = "openai-bundled";
+
+pub const TOOL_SUGGEST_DISCOVERABLE_PLUGIN_ALLOWLIST: &[&str] = &[
+    "github@openai-curated",
+    "notion@openai-curated",
+    "slack@openai-curated",
+    "gmail@openai-curated",
+    "google-calendar@openai-curated",
+    "google-drive@openai-curated",
+    "teams@openai-curated",
+    "sharepoint@openai-curated",
+    "outlook-email@openai-curated",
+    "outlook-calendar@openai-curated",
+    "linear@openai-curated",
+    "figma@openai-curated",
+    "computer-use@openai-bundled",
+];

--- a/codex-rs/core/src/plugins/discoverable.rs
+++ b/codex-rs/core/src/plugins/discoverable.rs
@@ -8,20 +8,9 @@ use crate::config::Config;
 use codex_config::types::ToolSuggestDiscoverableType;
 use codex_core_plugins::OPENAI_BUNDLED_MARKETPLACE_NAME;
 use codex_core_plugins::OPENAI_CURATED_MARKETPLACE_NAME;
+use codex_core_plugins::TOOL_SUGGEST_DISCOVERABLE_PLUGIN_ALLOWLIST;
 use codex_features::Feature;
 use codex_tools::DiscoverablePluginInfo;
-
-const TOOL_SUGGEST_DISCOVERABLE_PLUGIN_ALLOWLIST: &[&str] = &[
-    "github@openai-curated",
-    "notion@openai-curated",
-    "slack@openai-curated",
-    "gmail@openai-curated",
-    "google-calendar@openai-curated",
-    "google-drive@openai-curated",
-    "linear@openai-curated",
-    "figma@openai-curated",
-    "computer-use@openai-bundled",
-];
 
 const TOOL_SUGGEST_DISCOVERABLE_MARKETPLACE_ALLOWLIST: &[&str] = &[
     OPENAI_BUNDLED_MARKETPLACE_NAME,

--- a/codex-rs/core/src/plugins/discoverable_tests.rs
+++ b/codex-rs/core/src/plugins/discoverable_tests.rs
@@ -43,6 +43,35 @@ async fn list_tool_suggest_discoverable_plugins_returns_uninstalled_curated_plug
 }
 
 #[tokio::test]
+async fn list_tool_suggest_discoverable_plugins_returns_microsoft_curated_plugins() {
+    let codex_home = tempdir().expect("tempdir should succeed");
+    let curated_root = curated_plugins_repo_path(codex_home.path());
+    write_openai_curated_marketplace(
+        &curated_root,
+        &["teams", "sharepoint", "outlook-email", "outlook-calendar"],
+    );
+    write_plugins_feature_config(codex_home.path());
+
+    let config = load_plugins_config(codex_home.path()).await;
+    let discoverable_plugins = list_tool_suggest_discoverable_plugins(&config)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        discoverable_plugins
+            .into_iter()
+            .map(|plugin| plugin.id)
+            .collect::<Vec<_>>(),
+        vec![
+            "outlook-calendar@openai-curated".to_string(),
+            "outlook-email@openai-curated".to_string(),
+            "sharepoint@openai-curated".to_string(),
+            "teams@openai-curated".to_string(),
+        ]
+    );
+}
+
+#[tokio::test]
 async fn list_tool_suggest_discoverable_plugins_deduplicates_allowlisted_configured_plugin() {
     let codex_home = tempdir().expect("tempdir should succeed");
     let plugin_id = TOOL_SUGGEST_DISCOVERABLE_PLUGIN_ALLOWLIST


### PR DESCRIPTION
## Summary
- [x] Move the allowlist out of core crate
- [x] Add Teams, SharePoint, Outlook Email, and Outlook Calendar to the tool_suggest discoverable plugin allowlist
- [x] Add focused coverage for Microsoft curated plugin discovery

## Testing
- just fmt
- cargo test -p codex-core-plugins
- cargo test -p codex-core list_tool_suggest_discoverable_plugins_returns_