### PR TITLE
utils: summarize permission profiles directly

### DIFF
--- a/codex-rs/tui/src/status/tests.rs
+++ b/codex-rs/tui/src/status/tests.rs
@@ -528,6 +528,7 @@ async fn status_snapshot_shows_auto_review_permissions() {
 async fn status_permissions_full_disk_managed_with_network_is_danger_full_access() {
     let temp_home = TempDir::new().expect("temp home");
     let mut config = test_config(&temp_home).await;
+    config.approvals_reviewer = ApprovalsReviewer::User;
     config
         .permissions
         .approval_policy
@@ -548,9 +549,10 @@ async fn status_permissions_full_disk_managed_with_network_is_danger_full_access
 }
 
 #[tokio::test]
-async fn status_permissions_full_disk_managed_without_network_is_external_sandbox() {
+async fn status_permissions_full_disk_managed_without_network_is_custom_permissions() {
     let temp_home = TempDir::new().expect("temp home");
     let mut config = test_config(&temp_home).await;
+    config.approvals_reviewer = ApprovalsReviewer::User;
     config
         .permissions
         .approval_policy
@@ -566,7 +568,7 @@ async fn status_permissions_full_disk_managed_without_network_is_external_sandbo
 
     assert_eq!(
         permissions_text_for(&config).as_deref(),
-        Some("Custom (external-sandbox, on-request)")
+        Some("Custom (custom permissions, on-request)")
     );
 }
 

--- a/codex-rs/utils/sandbox-summary/src/config_summary.rs
+++ b/codex-rs/utils/sandbox-summary/src/config_summary.rs
@@ -1,7 +1,7 @@
 use codex_core::config::Config;
 use codex_model_provider_info::WireApi;
 
-use crate::sandbox_summary::summarize_sandbox_policy;
+use crate::sandbox_summary::summarize_permission_profile;
 
 /// Build a list of key/value pairs summarizing the effective configuration.
 pub fn create_config_summary_entries(config: &Config, model: &str) -> Vec<(&'static str, String)> {
@@ -15,10 +15,9 @@ pub fn create_config_summary_entries(config: &Config, model: &str) -> Vec<(&'sta
         ),
         (
             "sandbox",
-            summarize_sandbox_policy(
-                &config
-                    .permissions
-                    .legacy_sandbox_policy(config.cwd.as_path()),
+            summarize_permission_profile(
+                &config.permissions.permission_profile(),
+                config.cwd.as_path(),
             ),
         ),
     ];

--- a/codex-rs/utils/sandbox-summary/src/lib.rs
+++ b/codex-rs/utils/sandbox-summary/src/lib.rs
@@ -3,4 +3,3 @@ mod sandbox_summary;
 
 pub use config_summary::create_config_summary_entries;
 pub use sandbox_summary::summarize_permission_profile;
-pub use sandbox_summary::summarize_sandbox_policy;

--- a/codex-rs/utils/sandbox-summary/src/sandbox_summary.rs
+++ b/codex-rs/utils/sandbox-summary/src/sandbox_summary.rs
@@ -1,109 +1,185 @@
 use codex_protocol::models::PermissionProfile;
-use codex_protocol::protocol::NetworkAccess;
-use codex_protocol::protocol::SandboxPolicy;
+use codex_protocol::permissions::FileSystemSandboxPolicy;
+use codex_protocol::permissions::NetworkSandboxPolicy;
 use std::path::Path;
 
-pub fn summarize_sandbox_policy(sandbox_policy: &SandboxPolicy) -> String {
-    match sandbox_policy {
-        SandboxPolicy::DangerFullAccess => "danger-full-access".to_string(),
-        SandboxPolicy::ReadOnly { network_access, .. } => {
-            let mut summary = "read-only".to_string();
-            if *network_access {
-                summary.push_str(" (network access enabled)");
-            }
-            summary
+pub fn summarize_permission_profile(permission_profile: &PermissionProfile, cwd: &Path) -> String {
+    match permission_profile {
+        PermissionProfile::Disabled => "danger-full-access".to_string(),
+        PermissionProfile::External { network } => {
+            summary_with_network("external-sandbox", network.is_enabled())
         }
-        SandboxPolicy::ExternalSandbox { network_access } => {
-            let mut summary = "external-sandbox".to_string();
-            if matches!(network_access, NetworkAccess::Enabled) {
-                summary.push_str(" (network access enabled)");
-            }
-            summary
-        }
-        SandboxPolicy::WorkspaceWrite {
-            writable_roots,
-            network_access,
-            exclude_tmpdir_env_var,
-            exclude_slash_tmp,
-        } => {
-            let mut summary = "workspace-write".to_string();
-
-            let mut writable_entries = Vec::<String>::new();
-            writable_entries.push("workdir".to_string());
-            if !*exclude_slash_tmp {
-                writable_entries.push("/tmp".to_string());
-            }
-            if !*exclude_tmpdir_env_var {
-                writable_entries.push("$TMPDIR".to_string());
-            }
-            writable_entries.extend(
-                writable_roots
-                    .iter()
-                    .map(|p| p.to_string_lossy().to_string()),
-            );
-
-            summary.push_str(&format!(" [{}]", writable_entries.join(", ")));
-            if *network_access {
-                summary.push_str(" (network access enabled)");
-            }
-            summary
-        }
+        PermissionProfile::Managed {
+            file_system,
+            network,
+        } => summarize_managed_profile(&file_system.to_sandbox_policy(), *network, cwd),
     }
 }
 
-pub fn summarize_permission_profile(permission_profile: &PermissionProfile, cwd: &Path) -> String {
-    match permission_profile.to_legacy_sandbox_policy(cwd) {
-        Ok(policy) => summarize_sandbox_policy(&policy),
-        Err(_) => {
-            if permission_profile.network_sandbox_policy().is_enabled() {
-                "custom permissions (network access enabled)".to_string()
-            } else {
-                "custom permissions".to_string()
-            }
+fn summarize_managed_profile(
+    file_system: &FileSystemSandboxPolicy,
+    network: NetworkSandboxPolicy,
+    cwd: &Path,
+) -> String {
+    let network_enabled = network.is_enabled();
+    if file_system.has_full_disk_write_access() {
+        if network_enabled {
+            return "danger-full-access".to_string();
         }
+        return custom_summary(network_enabled);
     }
+
+    let writable_roots = file_system.get_writable_roots_with_cwd(cwd);
+    if writable_roots.is_empty() {
+        if file_system.has_full_disk_read_access() {
+            return summary_with_network("read-only", network_enabled);
+        }
+        return custom_summary(network_enabled);
+    }
+    if !file_system.can_write_path_with_cwd(cwd, cwd) {
+        return custom_summary(network_enabled);
+    }
+
+    let writable_entries = writable_roots
+        .iter()
+        .map(|root| writable_root_display(root.root.as_path(), cwd))
+        .collect::<Vec<_>>();
+    summary_with_network(
+        &format!("workspace-write [{}]", writable_entries.join(", ")),
+        network_enabled,
+    )
+}
+
+fn writable_root_display(root: &Path, cwd: &Path) -> String {
+    if root == cwd {
+        return "workdir".to_string();
+    }
+    if cfg!(unix) && root == Path::new("/tmp") {
+        return "/tmp".to_string();
+    }
+    if root == std::env::temp_dir() {
+        return "$TMPDIR".to_string();
+    }
+    root.display().to_string()
+}
+
+fn summary_with_network(base: &str, network_enabled: bool) -> String {
+    if network_enabled {
+        format!("{base} (network access enabled)")
+    } else {
+        base.to_string()
+    }
+}
+
+fn custom_summary(network_enabled: bool) -> String {
+    summary_with_network("custom permissions", network_enabled)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use codex_protocol::permissions::FileSystemAccessMode;
+    use codex_protocol::permissions::FileSystemPath;
+    use codex_protocol::permissions::FileSystemSandboxEntry;
+    use codex_protocol::permissions::FileSystemSpecialPath;
     use codex_utils_absolute_path::AbsolutePathBuf;
     use pretty_assertions::assert_eq;
 
     #[test]
     fn summarizes_external_sandbox_without_network_access_suffix() {
-        let summary = summarize_sandbox_policy(&SandboxPolicy::ExternalSandbox {
-            network_access: NetworkAccess::Restricted,
-        });
+        let summary = summarize_permission_profile(
+            &PermissionProfile::External {
+                network: NetworkSandboxPolicy::Restricted,
+            },
+            Path::new("/repo"),
+        );
         assert_eq!(summary, "external-sandbox");
     }
 
     #[test]
     fn summarizes_external_sandbox_with_enabled_network() {
-        let summary = summarize_sandbox_policy(&SandboxPolicy::ExternalSandbox {
-            network_access: NetworkAccess::Enabled,
-        });
+        let summary = summarize_permission_profile(
+            &PermissionProfile::External {
+                network: NetworkSandboxPolicy::Enabled,
+            },
+            Path::new("/repo"),
+        );
         assert_eq!(summary, "external-sandbox (network access enabled)");
     }
 
     #[test]
     fn summarizes_read_only_with_enabled_network() {
-        let summary = summarize_sandbox_policy(&SandboxPolicy::ReadOnly {
-            network_access: true,
-        });
+        let file_system = FileSystemSandboxPolicy::restricted(vec![FileSystemSandboxEntry {
+            path: FileSystemPath::Special {
+                value: FileSystemSpecialPath::Root,
+            },
+            access: FileSystemAccessMode::Read,
+        }]);
+        let profile = PermissionProfile::from_runtime_permissions(
+            &file_system,
+            NetworkSandboxPolicy::Enabled,
+        );
+        let summary = summarize_permission_profile(&profile, Path::new("/repo"));
         assert_eq!(summary, "read-only (network access enabled)");
+    }
+
+    #[test]
+    fn unrestricted_filesystem_without_network_is_custom_permissions() {
+        let profile = PermissionProfile::from_runtime_permissions(
+            &FileSystemSandboxPolicy::unrestricted(),
+            NetworkSandboxPolicy::Restricted,
+        );
+        let summary = summarize_permission_profile(&profile, Path::new("/repo"));
+        assert_eq!(summary, "custom permissions");
+    }
+
+    #[test]
+    fn explicit_writable_root_outside_cwd_is_custom_permissions() {
+        let writable_root = AbsolutePathBuf::try_from(if cfg!(windows) {
+            "C:\\outside"
+        } else {
+            "/outside"
+        })
+        .unwrap();
+        let file_system = FileSystemSandboxPolicy::restricted(vec![
+            FileSystemSandboxEntry {
+                path: FileSystemPath::Special {
+                    value: FileSystemSpecialPath::Root,
+                },
+                access: FileSystemAccessMode::Read,
+            },
+            FileSystemSandboxEntry {
+                path: FileSystemPath::Path {
+                    path: writable_root,
+                },
+                access: FileSystemAccessMode::Write,
+            },
+        ]);
+        let profile = PermissionProfile::from_runtime_permissions(
+            &file_system,
+            NetworkSandboxPolicy::Restricted,
+        );
+        let cwd = if cfg!(windows) { "C:\\repo" } else { "/repo" };
+        let summary = summarize_permission_profile(&profile, Path::new(cwd));
+        assert_eq!(summary, "custom permissions");
     }
 
     #[test]
     fn workspace_write_summary_still_includes_network_access() {
         let root = if cfg!(windows) { "C:\\repo" } else { "/repo" };
         let writable_root = AbsolutePathBuf::try_from(root).unwrap();
-        let summary = summarize_sandbox_policy(&SandboxPolicy::WorkspaceWrite {
-            writable_roots: vec![writable_root.clone()],
-            network_access: true,
-            exclude_tmpdir_env_var: true,
-            exclude_slash_tmp: true,
-        });
+        let cwd = if cfg!(windows) {
+            "C:\\workdir"
+        } else {
+            "/workdir"
+        };
+        let profile = PermissionProfile::workspace_write_with(
+            std::slice::from_ref(&writable_root),
+            NetworkSandboxPolicy::Enabled,
+            /*exclude_tmpdir_env_var*/ true,
+            /*exclude_slash_tmp*/ true,
+        );
+        let summary = summarize_permission_profile(&profile, Path::new(cwd));
         assert_eq!(
             summary,
             format!(


### PR DESCRIPTION
## Why

This stack is continuing the migration away from treating `SandboxPolicy` as the canonical runtime permissions model. `codex-utils-sandbox-summary` was already called with a `PermissionProfile`, but immediately converted it back into a legacy sandbox policy to render status/config summary text.

That legacy projection is lossy for newer profile shapes. In particular, a managed profile with unrestricted filesystem access and restricted network access is not the same thing as `PermissionProfile::External`, and a profile that only grants writes outside the active `cwd` should not be described as workspace-write.

## What Changed

- Removed the public `summarize_sandbox_policy()` export.
- Reworked `summarize_permission_profile()` to describe `PermissionProfile::Disabled`, `PermissionProfile::External`, and managed filesystem/network policies directly.
- Updated config summaries to render `config.permissions.permission_profile()` instead of `config.permissions.legacy_sandbox_policy(...)`.
- Treat managed profiles as `workspace-write` only when the active `cwd` is writable; explicit write roots outside `cwd` now summarize as `custom permissions`.
- Added summary coverage for unrestricted-filesystem-with-restricted-network and explicit-writable-root-outside-`cwd` profiles so they are not mislabeled as read-only, external, or workspace-write.
- Updated the TUI status expectation for that managed unrestricted-filesystem/restricted-network profile to show `custom permissions` instead of `external-sandbox`.

## Verification

- `cargo test -p codex-utils-sandbox-summary`
- `cargo test -p codex-tui status_permissions_full_disk_managed_without_network_is_custom_permissions`







































































---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20355).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* __->__ #20355
* #20373