### PR TITLE
core: build permission instructions from profiles only

### DIFF
--- a/codex-rs/core/src/context/permissions_instructions.rs
+++ b/codex-rs/core/src/context/permissions_instructions.rs
@@ -8,7 +8,6 @@ use codex_protocol::permissions::NetworkSandboxPolicy;
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::GranularApprovalConfig;
 use codex_protocol::protocol::NetworkAccess;
-use codex_protocol::protocol::SandboxPolicy;
 use codex_protocol::protocol::WritableRoot;
 use codex_utils_template::Template;
 use std::path::Path;
@@ -82,27 +81,6 @@ impl PermissionsInstructions {
                 request_permissions_tool_enabled,
             },
             writable_roots,
-        )
-    }
-
-    /// Builds permissions instructions from a legacy sandbox policy.
-    pub fn from_policy(
-        sandbox_policy: &SandboxPolicy,
-        approval_policy: AskForApproval,
-        approvals_reviewer: ApprovalsReviewer,
-        exec_policy: &Policy,
-        cwd: &Path,
-        exec_permission_approvals_enabled: bool,
-        request_permissions_tool_enabled: bool,
-    ) -> Self {
-        Self::from_permission_profile(
-            &PermissionProfile::from_legacy_sandbox_policy(sandbox_policy),
-            approval_policy,
-            approvals_reviewer,
-            exec_policy,
-            cwd,
-            exec_permission_approvals_enabled,
-            request_permissions_tool_enabled,
         )
     }
 

--- a/codex-rs/core/src/context/permissions_instructions_tests.rs
+++ b/codex-rs/core/src/context/permissions_instructions_tests.rs
@@ -54,29 +54,6 @@ fn builds_permissions_with_network_access_override() {
 }
 
 #[test]
-fn builds_permissions_from_policy() {
-    let policy = SandboxPolicy::WorkspaceWrite {
-        writable_roots: vec![],
-        network_access: true,
-        exclude_tmpdir_env_var: false,
-        exclude_slash_tmp: false,
-    };
-
-    let instructions = PermissionsInstructions::from_policy(
-        &policy,
-        AskForApproval::UnlessTrusted,
-        ApprovalsReviewer::User,
-        &Policy::empty(),
-        &PathBuf::from("/tmp"),
-        /*exec_permission_approvals_enabled*/ false,
-        /*request_permissions_tool_enabled*/ false,
-    );
-    let text = instructions.body();
-    assert!(text.contains("Network access is enabled."));
-    assert!(text.contains("`approval_policy` is `unless-trusted`"));
-}
-
-#[test]
 fn builds_permissions_from_profile() {
     let cwd = PathBuf::from("/tmp");
     let writable_root =

--- a/codex-rs/core/tests/suite/permissions_messages.rs
+++ b/codex-rs/core/tests/suite/permissions_messages.rs
@@ -575,9 +575,8 @@ async fn permissions_message_includes_writable_roots() -> Result<()> {
     let permissions = permissions_texts(&req.single_request());
     let normalize_line_endings = |s: &str| s.replace("\r\n", "\n");
     let exec_policy = load_exec_policy(&test.config.config_layer_stack).await?;
-    let sandbox_policy = test.config.legacy_sandbox_policy();
-    let expected = PermissionsInstructions::from_policy(
-        &sandbox_policy,
+    let expected = PermissionsInstructions::from_permission_profile(
+        &test.config.permissions.permission_profile(),
         AskForApproval::OnRequest,
         test.config.approvals_reviewer,
         &exec_policy,


### PR DESCRIPTION
## Why

The permissions prompt builder now has a canonical `PermissionProfile` entry point, but it still exposed a legacy `from_policy()` wrapper that converted `SandboxPolicy` back into a profile for tests. Keeping both APIs invites new callsites to continue depending on the old abstraction.

## What Changed

- Removed `PermissionsInstructions::from_policy()`.
- Updated the remaining callers/tests to use `PermissionsInstructions::from_permission_profile()`.
- Kept the rendered prompt behavior unchanged by using the same effective permission profile from config.

## Verification

- `cargo test -p codex-core permissions_instructions`




















































































---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20356).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* __->__ #20356
* #20355
* #20373