### PR TITLE
tests: use permission profiles in tool sandbox tests

### DIFF
--- a/codex-rs/core/src/sandbox_tags.rs
+++ b/codex-rs/core/src/sandbox_tags.rs
@@ -1,23 +1,9 @@
 use codex_protocol::config_types::WindowsSandboxLevel;
 use codex_protocol::models::PermissionProfile;
-#[cfg(test)]
-use codex_protocol::protocol::SandboxPolicy;
 use codex_sandboxing::SandboxType;
 use codex_sandboxing::get_platform_sandbox;
 use codex_sandboxing::policy_transforms::should_require_platform_sandbox;
 use std::path::Path;
-
-#[cfg(test)]
-pub(crate) fn sandbox_tag(
-    policy: &SandboxPolicy,
-    windows_sandbox_level: WindowsSandboxLevel,
-) -> &'static str {
-    permission_profile_sandbox_tag(
-        &PermissionProfile::from_legacy_sandbox_policy(policy),
-        windows_sandbox_level,
-        /*enforce_managed_network*/ false,
-    )
-}
 
 pub(crate) fn permission_profile_sandbox_tag(
     profile: &PermissionProfile,

--- a/codex-rs/core/src/sandbox_tags_tests.rs
+++ b/codex-rs/core/src/sandbox_tags_tests.rs
@@ -1,6 +1,5 @@
 use super::permission_profile_policy_tag;
 use super::permission_profile_sandbox_tag;
-use super::sandbox_tag;
 use codex_protocol::config_types::WindowsSandboxLevel;
 use codex_protocol::models::ManagedFileSystemPermissions;
 use codex_protocol::models::PermissionProfile;
@@ -10,8 +9,6 @@ use codex_protocol::permissions::FileSystemSandboxEntry;
 use codex_protocol::permissions::FileSystemSandboxKind;
 use codex_protocol::permissions::FileSystemSandboxPolicy;
 use codex_protocol::permissions::NetworkSandboxPolicy;
-use codex_protocol::protocol::NetworkAccess;
-use codex_protocol::protocol::SandboxPolicy;
 use codex_sandboxing::SandboxType;
 use codex_sandboxing::get_platform_sandbox;
 use codex_utils_absolute_path::AbsolutePathBuf;
@@ -20,29 +17,32 @@ use std::path::Path;
 
 #[test]
 fn danger_full_access_is_untagged_even_when_linux_sandbox_defaults_apply() {
-    let actual = sandbox_tag(
-        &SandboxPolicy::DangerFullAccess,
+    let actual = permission_profile_sandbox_tag(
+        &PermissionProfile::Disabled,
         WindowsSandboxLevel::Disabled,
+        /*enforce_managed_network*/ false,
     );
     assert_eq!(actual, "none");
 }
 
 #[test]
 fn external_sandbox_keeps_external_tag_when_linux_sandbox_defaults_apply() {
-    let actual = sandbox_tag(
-        &SandboxPolicy::ExternalSandbox {
-            network_access: NetworkAccess::Enabled,
+    let actual = permission_profile_sandbox_tag(
+        &PermissionProfile::External {
+            network: NetworkSandboxPolicy::Enabled,
         },
         WindowsSandboxLevel::Disabled,
+        /*enforce_managed_network*/ false,
     );
     assert_eq!(actual, "external");
 }
 
 #[test]
 fn default_linux_sandbox_uses_platform_sandbox_tag() {
-    let actual = sandbox_tag(
-        &SandboxPolicy::new_read_only_policy(),
+    let actual = permission_profile_sandbox_tag(
+        &PermissionProfile::read_only(),
         WindowsSandboxLevel::Disabled,
+        /*enforce_managed_network*/ false,
     );
     let expected = get_platform_sandbox(/*windows_sandbox_enabled*/ false)
         .map(SandboxType::as_metric_tag)

--- a/codex-rs/core/src/tools/handlers/apply_patch_tests.rs
+++ b/codex-rs/core/src/tools/handlers/apply_patch_tests.rs
@@ -3,7 +3,6 @@ use codex_apply_patch::MaybeApplyPatchVerified;
 use codex_exec_server::LOCAL_FS;
 use codex_protocol::permissions::FileSystemSandboxPolicy;
 use codex_protocol::protocol::FileChange;
-use codex_protocol::protocol::SandboxPolicy;
 use core_test_support::PathBufExt;
 use core_test_support::PathExt;
 use pretty_assertions::assert_eq;
@@ -237,12 +236,11 @@ fn write_permissions_for_paths_skip_dirs_already_writable_under_workspace_root()
     std::fs::create_dir_all(&nested).expect("create nested dir");
     let file_path = AbsolutePathBuf::try_from(nested.join("file.txt"))
         .expect("nested file path should be absolute");
-    let sandbox_policy = FileSystemSandboxPolicy::from(&SandboxPolicy::WorkspaceWrite {
-        writable_roots: vec![],
-        network_access: false,
-        exclude_tmpdir_env_var: true,
-        exclude_slash_tmp: false,
-    });
+    let sandbox_policy = FileSystemSandboxPolicy::workspace_write(
+        &[],
+        /*exclude_tmpdir_env_var*/ true,
+        /*exclude_slash_tmp*/ false,
+    );
 
     let permissions = write_permissions_for_paths(&[file_path], &sandbox_policy, &cwd);
 
@@ -259,12 +257,11 @@ fn write_permissions_for_paths_keep_dirs_outside_workspace_root() {
     let file_path = AbsolutePathBuf::try_from(outside.join("file.txt"))
         .expect("outside file path should be absolute");
     let cwd_abs = cwd.abs();
-    let sandbox_policy = FileSystemSandboxPolicy::from(&SandboxPolicy::WorkspaceWrite {
-        writable_roots: vec![],
-        network_access: false,
-        exclude_tmpdir_env_var: true,
-        exclude_slash_tmp: true,
-    });
+    let sandbox_policy = FileSystemSandboxPolicy::workspace_write(
+        &[],
+        /*exclude_tmpdir_env_var*/ true,
+        /*exclude_slash_tmp*/ true,
+    );
 
     let permissions = write_permissions_for_paths(&[file_path], &sandbox_policy, &cwd_abs);
     let expected_outside =

--- a/codex-rs/core/src/tools/network_approval_tests.rs
+++ b/codex-rs/core/src/tools/network_approval_tests.rs
@@ -4,7 +4,6 @@ use codex_network_proxy::BlockedRequestArgs;
 use codex_protocol::models::PermissionProfile;
 use codex_protocol::permissions::NetworkSandboxPolicy;
 use codex_protocol::protocol::AskForApproval;
-use codex_protocol::protocol::SandboxPolicy;
 use core_test_support::PathBufExt;
 use core_test_support::test_path_buf;
 use pretty_assertions::assert_eq;
@@ -189,10 +188,10 @@ fn only_never_policy_disables_network_approval_flow() {
 #[test]
 fn network_approval_flow_is_limited_to_restricted_sandbox_modes() {
     assert!(permission_profile_allows_network_approval_flow(
-        &PermissionProfile::from_legacy_sandbox_policy(&SandboxPolicy::new_read_only_policy())
+        &PermissionProfile::read_only()
     ));
     assert!(permission_profile_allows_network_approval_flow(
-        &PermissionProfile::from_legacy_sandbox_policy(&SandboxPolicy::new_workspace_write_policy())
+        &PermissionProfile::workspace_write()
     ));
     assert!(!permission_profile_allows_network_approval_flow(
         &PermissionProfile::Disabled

--- a/codex-rs/core/src/tools/runtimes/apply_patch_tests.rs
+++ b/codex-rs/core/src/tools/runtimes/apply_patch_tests.rs
@@ -4,10 +4,8 @@ use codex_protocol::config_types::WindowsSandboxLevel;
 use codex_protocol::models::AdditionalPermissionProfile;
 use codex_protocol::models::FileSystemPermissions;
 use codex_protocol::models::PermissionProfile;
-use codex_protocol::permissions::FileSystemSandboxPolicy;
 use codex_protocol::permissions::NetworkSandboxPolicy;
 use codex_protocol::protocol::GranularApprovalConfig;
-use codex_protocol::protocol::SandboxPolicy;
 use codex_sandboxing::SandboxManager;
 use codex_sandboxing::SandboxType;
 use codex_sandboxing::policy_transforms::effective_file_system_sandbox_policy;
@@ -136,8 +134,7 @@ fn file_system_sandbox_context_uses_active_attempt() {
         additional_permissions: Some(additional_permissions.clone()),
         permissions_preapproved: false,
     };
-    let sandbox_policy = SandboxPolicy::new_read_only_policy();
-    let file_system_policy = FileSystemSandboxPolicy::from(&sandbox_policy);
+    let file_system_policy = PermissionProfile::read_only().file_system_sandbox_policy();
     let permissions = PermissionProfile::from_runtime_permissions(
         &file_system_policy,
         NetworkSandboxPolicy::Restricted,

--- a/codex-rs/core/src/tools/sandboxing.rs
+++ b/codex-rs/core/src/tools/sandboxing.rs
@@ -19,8 +19,6 @@ use codex_protocol::permissions::FileSystemSandboxKind;
 use codex_protocol::permissions::FileSystemSandboxPolicy;
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::ReviewDecision;
-#[cfg(test)]
-use codex_protocol::protocol::SandboxPolicy;
 use codex_sandboxing::SandboxCommand;
 use codex_sandboxing::SandboxManager;
 use codex_sandboxing::SandboxTransformError;

--- a/codex-rs/core/src/tools/sandboxing_tests.rs
+++ b/codex-rs/core/src/tools/sandboxing_tests.rs
@@ -1,8 +1,9 @@
 use super::*;
 use crate::sandboxing::SandboxPermissions;
 use crate::tools::hook_names::HookToolName;
+use codex_protocol::models::PermissionProfile;
+use codex_protocol::permissions::FileSystemSandboxPolicy;
 use codex_protocol::protocol::GranularApprovalConfig;
-use codex_protocol::protocol::NetworkAccess;
 use pretty_assertions::assert_eq;
 use serde_json::json;
 
@@ -36,13 +37,10 @@ fn bash_permission_request_payload_includes_description_when_present() {
 
 #[test]
 fn external_sandbox_skips_exec_approval_on_request() {
-    let sandbox_policy = SandboxPolicy::ExternalSandbox {
-        network_access: NetworkAccess::Restricted,
-    };
     assert_eq!(
         default_exec_approval_requirement(
             AskForApproval::OnRequest,
-            &FileSystemSandboxPolicy::from(&sandbox_policy),
+            &FileSystemSandboxPolicy::external_sandbox(),
         ),
         ExecApprovalRequirement::Skip {
             bypass_sandbox: false,
@@ -53,11 +51,10 @@ fn external_sandbox_skips_exec_approval_on_request() {
 
 #[test]
 fn restricted_sandbox_requires_exec_approval_on_request() {
-    let sandbox_policy = SandboxPolicy::new_read_only_policy();
     assert_eq!(
         default_exec_approval_requirement(
             AskForApproval::OnRequest,
-            &FileSystemSandboxPolicy::from(&sandbox_policy)
+            &PermissionProfile::read_only().file_system_sandbox_policy()
         ),
         ExecApprovalRequirement::NeedsApproval {
             reason: None,
@@ -76,9 +73,10 @@ fn default_exec_approval_requirement_rejects_sandbox_prompt_when_granular_disabl
         mcp_elicitations: true,
     });
 
-    let sandbox_policy = SandboxPolicy::new_read_only_policy();
-    let requirement =
-        default_exec_approval_requirement(policy, &FileSystemSandboxPolicy::from(&sandbox_policy));
+    let requirement = default_exec_approval_requirement(
+        policy,
+        &PermissionProfile::read_only().file_system_sandbox_policy(),
+    );
 
     assert_eq!(
         requirement,
@@ -98,9 +96,10 @@ fn default_exec_approval_requirement_keeps_prompt_when_granular_allows_sandbox_a
         mcp_elicitations: false,
     });
 
-    let sandbox_policy = SandboxPolicy::new_read_only_policy();
-    let requirement =
-        default_exec_approval_requirement(policy, &FileSystemSandboxPolicy::from(&sandbox_policy));
+    let requirement = default_exec_approval_requirement(
+        policy,
+        &PermissionProfile::read_only().file_system_sandbox_policy(),
+    );
 
     assert_eq!(
         requirement,

--- a/codex-rs/core/src/turn_metadata_tests.rs
+++ b/codex-rs/core/src/turn_metadata_tests.rs
@@ -1,8 +1,7 @@
 use super::*;
 
-use crate::sandbox_tags::sandbox_tag;
+use crate::sandbox_tags::permission_profile_sandbox_tag;
 use codex_protocol::models::PermissionProfile;
-use codex_protocol::protocol::SandboxPolicy;
 use codex_protocol::protocol::SessionSource;
 use codex_protocol::protocol::SubAgentSource;
 use core_test_support::PathBufExt;
@@ -82,7 +81,6 @@ async fn build_turn_metadata_header_includes_has_changes_for_clean_repo() {
 fn turn_metadata_state_uses_platform_sandbox_tag() {
     let temp_dir = TempDir::new().expect("temp dir");
     let cwd = temp_dir.path().abs();
-    let sandbox_policy = SandboxPolicy::new_read_only_policy();
     let permission_profile = PermissionProfile::read_only();
 
     let state = TurnMetadataState::new(
@@ -101,7 +99,11 @@ fn turn_metadata_state_uses_platform_sandbox_tag() {
     let session_id = json.get("session_id").and_then(Value::as_str);
     let thread_source = json.get("thread_source").and_then(Value::as_str);
 
-    let expected_sandbox = sandbox_tag(&sandbox_policy, WindowsSandboxLevel::Disabled);
+    let expected_sandbox = permission_profile_sandbox_tag(
+        &permission_profile,
+        WindowsSandboxLevel::Disabled,
+        /*enforce_managed_network*/ false,
+    );
     assert_eq!(sandbox_name, Some(expected_sandbox));
     assert_eq!(session_id, Some("session-a"));
     assert_eq!(thread_source, Some("user"));


### PR DESCRIPTION
## Why

Tool and sandbox-tag tests were still using `SandboxPolicy` as a fixture format even when the code under test already accepts `PermissionProfile` or `FileSystemSandboxPolicy`. This adds noise to the remaining migration audit and obscures which layer still genuinely needs the legacy type.

## What Changed

- Updated network-approval tests to use `PermissionProfile` presets directly.
- Updated sandboxing tests to pass `FileSystemSandboxPolicy` values directly instead of deriving them from legacy policies.
- Updated apply-patch handler/runtime tests to use `FileSystemSandboxPolicy::workspace_write(...)` and `PermissionProfile::read_only()`.
- Removed an obsolete test-only `SandboxPolicy` import from tool sandboxing code.
- Removed the test-only `sandbox_tag(SandboxPolicy, ...)` helper and made sandbox-tag and turn-metadata tests exercise `permission_profile_sandbox_tag(...)` directly.

## Verification

- `cargo test -p codex-core network_approval_flow_is_limited_to_restricted_sandbox_modes`
- `cargo test -p codex-core default_exec_approval_requirement`
- `cargo test -p codex-core write_permissions_for_paths`
- `cargo test -p codex-core file_system_sandbox_context_uses_active_attempt`
- `cargo test -p codex-core sandbox_tags`
- `cargo test -p codex-core turn_metadata`




















































































---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20358).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* __->__ #20358
* #20357
* #20356
* #20355
* #20373