### PR TITLE
tests: use permission profiles in guardian config checks

### DIFF
--- a/codex-rs/core/src/guardian/tests.rs
+++ b/codex-rs/core/src/guardian/tests.rs
@@ -38,7 +38,6 @@ use codex_protocol::protocol::GuardianRiskLevel;
 use codex_protocol::protocol::GuardianUserAuthorization;
 use codex_protocol::protocol::ReviewDecision;
 use codex_protocol::protocol::RolloutItem;
-use codex_protocol::protocol::SandboxPolicy;
 use codex_protocol::protocol::TurnCompleteEvent;
 use core_test_support::PathBufExt;
 use core_test_support::TempDirExt;
@@ -2168,9 +2167,7 @@ async fn guardian_review_session_config_preserves_parent_network_proxy() {
     );
     assert_eq!(
         guardian_config.permissions.permission_profile,
-        Constrained::allow_only(PermissionProfile::from_legacy_sandbox_policy(
-            &SandboxPolicy::new_read_only_policy(),
-        ))
+        Constrained::allow_only(PermissionProfile::read_only())
     );
 }
 
@@ -2232,9 +2229,7 @@ async fn guardian_review_session_config_uses_live_network_proxy_state() {
             NetworkProxySpec::from_config_and_constraints(
                 live_network,
                 /*requirements*/ None,
-                &PermissionProfile::from_legacy_sandbox_policy(
-                    &SandboxPolicy::new_read_only_policy(),
-                ),
+                &PermissionProfile::read_only(),
             )
             .expect("live network proxy spec")
         )


### PR DESCRIPTION
## Why

Guardian config tests were still constructing read-only permission expectations by creating a legacy `SandboxPolicy` and projecting it into a `PermissionProfile`. The code under test stores guardian permissions as profiles, so the test fixture should use the canonical shape directly.

## What Changed

- Removed the `SandboxPolicy` import from `core/src/guardian/tests.rs`.
- Replaced read-only guardian permission expectations with `PermissionProfile::read_only()`.
- Kept the guardian review-session behavior unchanged: guardian sessions still force read-only permissions and preserve the expected network proxy state.

## Verification

- `cargo test -p codex-core guardian_review_session_config`















































































---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20362).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* __->__ #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373