### PR TITLE
analytics: distinguish custom managed permission profiles

### DIFF
--- a/codex-rs/analytics/src/analytics_client_tests.rs
+++ b/codex-rs/analytics/src/analytics_client_tests.rs
@@ -98,7 +98,6 @@ use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::HookEventName;
 use codex_protocol::protocol::HookRunStatus;
 use codex_protocol::protocol::HookSource;
-use codex_protocol::protocol::SandboxPolicy;
 use codex_protocol::protocol::SessionSource;
 use codex_protocol::protocol::SubAgentSource;
 use codex_protocol::protocol::TokenUsage;
@@ -313,9 +312,7 @@ fn sample_turn_resolved_config(turn_id: &str) -> TurnResolvedConfigFact {
         session_source: SessionSource::Exec,
         model: "gpt-5".to_string(),
         model_provider: "openai".to_string(),
-        permission_profile: CorePermissionProfile::from_legacy_sandbox_policy(
-            &SandboxPolicy::new_read_only_policy(),
-        ),
+        permission_profile: CorePermissionProfile::read_only(),
         permission_profile_cwd: PathBuf::from("/tmp"),
         reasoning_effort: None,
         reasoning_summary: None,

--- a/codex-rs/analytics/src/reducer.rs
+++ b/codex-rs/analytics/src/reducer.rs
@@ -979,7 +979,7 @@ fn sandbox_policy_mode(permission_profile: &PermissionProfile, cwd: &Path) -> &'
                 if permission_profile.network_sandbox_policy().is_enabled() {
                     "full_access"
                 } else {
-                    "external_sandbox"
+                    "custom_permissions"
                 }
             } else if file_system_policy
                 .get_writable_roots_with_cwd(cwd)
@@ -1089,7 +1089,7 @@ mod tests {
     use codex_protocol::permissions::NetworkSandboxPolicy;
 
     #[test]
-    fn managed_full_disk_with_restricted_network_reports_external_sandbox() {
+    fn managed_full_disk_with_restricted_network_reports_custom_permissions() {
         let permission_profile = PermissionProfile::from_runtime_permissions_with_enforcement(
             SandboxEnforcement::Managed,
             &FileSystemSandboxPolicy::unrestricted(),
@@ -1098,7 +1098,7 @@ mod tests {
 
         assert_eq!(
             sandbox_policy_mode(&permission_profile, Path::new("/")),
-            "external_sandbox"
+            "custom_permissions"
         );
     }
 }


### PR DESCRIPTION
## Why

Analytics still collapsed a managed permission profile with unrestricted filesystem access and restricted network access into the `external_sandbox` telemetry bucket. That loses the same distinction this stack is trying to preserve elsewhere: external sandbox means enforcement is delegated outside Codex, while managed custom permissions are still represented by Codex's `PermissionProfile` model.

## What Changed

- Updated the analytics `sandbox_policy` classifier to report `custom_permissions` for managed unrestricted-filesystem/restricted-network profiles.
- Updated the reducer test to capture that distinction explicitly.
- Replaced a read-only analytics test fixture that still built a `PermissionProfile` through `SandboxPolicy` with `PermissionProfile::read_only()`.

## Verification

- `cargo test -p codex-analytics managed_full_disk_with_restricted_network_reports_custom_permissions`














































































---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20363).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* __->__ #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373