### PR TITLE
memories: configure consolidation permissions directly

### DIFF
--- a/codex-rs/memories/write/src/phase2.rs
+++ b/codex-rs/memories/write/src/phase2.rs
@@ -17,9 +17,10 @@ use codex_config::Constrained;
 use codex_core::config::Config;
 use codex_features::Feature;
 use codex_protocol::ThreadId;
+use codex_protocol::models::PermissionProfile;
+use codex_protocol::permissions::NetworkSandboxPolicy;
 use codex_protocol::protocol::AgentStatus;
 use codex_protocol::protocol::AskForApproval;
-use codex_protocol::protocol::SandboxPolicy;
 use codex_protocol::protocol::TokenUsage;
 use codex_protocol::user_input::UserInput;
 use codex_state::Stage1Output;
@@ -315,18 +316,16 @@ mod agent {
             .features
             .disable(Feature::SkillMcpDependencyInstall);
 
-        // Sandbox policy
-        let writable_roots = vec![root];
         // The consolidation agent only needs local memory-root write access and no network.
-        let consolidation_sandbox_policy = SandboxPolicy::WorkspaceWrite {
-            writable_roots,
-            network_access: false,
-            exclude_tmpdir_env_var: true,
-            exclude_slash_tmp: true,
-        };
+        let permission_profile = PermissionProfile::workspace_write_with(
+            std::slice::from_ref(&root),
+            NetworkSandboxPolicy::Restricted,
+            /*exclude_tmpdir_env_var*/ true,
+            /*exclude_slash_tmp*/ true,
+        );
         agent_config
             .permissions
-            .set_legacy_sandbox_policy(consolidation_sandbox_policy, agent_config.cwd.as_path())
+            .set_permission_profile(permission_profile)
             .ok()?;
 
         agent_config.model = Some(


### PR DESCRIPTION
## Why

Memory phase 2 runs an internal consolidation agent with a very small permission envelope: it should write only under the memory workspace, avoid network access, and avoid temp-directory write carve-outs.

That path was still constructing a legacy `SandboxPolicy::WorkspaceWrite` and immediately projecting it back into `Permissions`. As the runtime model moves to `PermissionProfile`, this is unnecessary legacy plumbing and another place where future permission changes would have to reason about the old abstraction.

## What Changed

- Replaced the phase-2 consolidation `SandboxPolicy::WorkspaceWrite` construction with `PermissionProfile::workspace_write_with(...)`.
- Kept the effective behavior aligned with the old worker sandbox: restricted network, explicit memory-root write access, `exclude_tmpdir_env_var = true`, and `exclude_slash_tmp = true`.
- Removed the `SandboxPolicy` import from `memories/write/src/phase2.rs`.

## Verification

```shell
cargo test -p codex-memories-write
```













































































---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20365).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* __->__ #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373