### PR TITLE
exec-server: use permission profiles in file system handler tests

### DIFF
--- a/codex-rs/exec-server/src/server/file_system_handler.rs
+++ b/codex-rs/exec-server/src/server/file_system_handler.rs
@@ -173,8 +173,8 @@ fn map_fs_error(err: io::Error) -> JSONRPCErrorError {
 
 #[cfg(test)]
 mod tests {
-    use codex_protocol::protocol::NetworkAccess;
-    use codex_protocol::protocol::SandboxPolicy;
+    use codex_protocol::models::PermissionProfile;
+    use codex_protocol::permissions::NetworkSandboxPolicy;
     use codex_utils_absolute_path::AbsolutePathBuf;
     use pretty_assertions::assert_eq;
 
@@ -195,12 +195,12 @@ mod tests {
         let sandbox_cwd =
             AbsolutePathBuf::from_absolute_path(temp_dir.path()).expect("absolute tempdir");
 
-        for (file_name, sandbox_policy) in [
-            ("danger.txt", SandboxPolicy::DangerFullAccess),
+        for (file_name, permission_profile) in [
+            ("danger.txt", PermissionProfile::Disabled),
             (
                 "external.txt",
-                SandboxPolicy::ExternalSandbox {
-                    network_access: NetworkAccess::Restricted,
+                PermissionProfile::External {
+                    network: NetworkSandboxPolicy::Restricted,
                 },
             ),
         ] {
@@ -212,8 +212,8 @@ mod tests {
                 .write_file(FsWriteFileParams {
                     path: path.clone(),
                     data_base64: STANDARD.encode("ok"),
-                    sandbox: Some(FileSystemSandboxContext::from_legacy_sandbox_policy(
-                        sandbox_policy.clone(),
+                    sandbox: Some(FileSystemSandboxContext::from_permission_profile_with_cwd(
+                        permission_profile.clone(),
                         sandbox_cwd.clone(),
                     )),
                 })
@@ -223,8 +223,8 @@ mod tests {
             let response = handler
                 .read_file(FsReadFileParams {
                     path,
-                    sandbox: Some(FileSystemSandboxContext::from_legacy_sandbox_policy(
-                        sandbox_policy,
+                    sandbox: Some(FileSystemSandboxContext::from_permission_profile_with_cwd(
+                        permission_profile,
                         sandbox_cwd.clone(),
                     )),
                 })


### PR DESCRIPTION
## Why

`exec-server` already has `FileSystemSandboxContext::from_permission_profile_with_cwd(...)`, and the file-system handler test was only using `SandboxPolicy` to describe the two no-platform-sandbox cases. Keeping that test on the legacy enum adds noise to the remaining migration audit without exercising any legacy-specific behavior.

## What Changed

- Replaced `SandboxPolicy::DangerFullAccess` with `PermissionProfile::Disabled` in the no-platform-sandbox handler test.
- Replaced `SandboxPolicy::ExternalSandbox` with `PermissionProfile::External` for the external enforcement case.
- Built the test sandbox context through `FileSystemSandboxContext::from_permission_profile_with_cwd(...)`, which is the canonical path for the new permissions model.
- Removed the `SandboxPolicy` import from `exec-server/src/server/file_system_handler.rs`.

## Verification

```shell
cargo test -p codex-exec-server no_platform_sandbox_policies_do_not_require_configured_sandbox_helper
```












































































---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20367).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* __->__ #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373