### PR TITLE
tests: use permission profiles in small core fixtures

### DIFF
--- a/codex-rs/core/src/agent/role_tests.rs
+++ b/codex-rs/core/src/agent/role_tests.rs
@@ -512,7 +512,8 @@ model_reasoning_effort = "high"
 #[tokio::test]
 #[cfg(not(windows))]
 async fn apply_role_does_not_materialize_default_sandbox_workspace_write_fields() {
-    use codex_protocol::protocol::SandboxPolicy;
+    use codex_protocol::permissions::NetworkSandboxPolicy;
+
     let (home, mut config) = test_config_with_cli_overrides(vec![
         (
             "sandbox_mode".to_string(),
@@ -574,12 +575,13 @@ writable_roots = ["./sandbox-root"]
         false
     );
 
-    match &config.legacy_sandbox_policy() {
-        SandboxPolicy::WorkspaceWrite { network_access, .. } => {
-            assert_eq!(*network_access, true);
-        }
-        other => panic!("expected workspace-write sandbox policy, got {other:?}"),
-    }
+    assert_eq!(
+        config
+            .permissions
+            .permission_profile()
+            .network_sandbox_policy(),
+        NetworkSandboxPolicy::Enabled,
+    );
 }
 
 #[tokio::test]

--- a/codex-rs/core/src/unified_exec/process_manager_tests.rs
+++ b/codex-rs/core/src/unified_exec/process_manager_tests.rs
@@ -71,16 +71,9 @@ fn exec_server_params_use_env_policy_overlay_contract() {
         .expect("current dir")
         .try_into()
         .expect("absolute path");
-    let sandbox_policy = codex_protocol::protocol::SandboxPolicy::DangerFullAccess;
-    let file_system_sandbox_policy =
-        codex_protocol::permissions::FileSystemSandboxPolicy::from(&sandbox_policy);
+    let permission_profile = codex_protocol::models::PermissionProfile::Disabled;
+    let file_system_sandbox_policy = permission_profile.file_system_sandbox_policy();
     let network_sandbox_policy = codex_protocol::permissions::NetworkSandboxPolicy::Restricted;
-    let permission_profile =
-        codex_protocol::models::PermissionProfile::from_runtime_permissions_with_enforcement(
-            codex_protocol::models::SandboxEnforcement::from_legacy_sandbox_policy(&sandbox_policy),
-            &file_system_sandbox_policy,
-            network_sandbox_policy,
-        );
     let request = ExecRequest {
         command: vec!["bash".to_string(), "-lc".to_string(), "true".to_string()],
         cwd: cwd.clone(),


### PR DESCRIPTION
## Why

A few small core tests still created `SandboxPolicy` values solely to derive permission-profile state. Those fixtures were not testing the legacy bridge itself, so keeping them on `SandboxPolicy` makes the remaining migration audit noisier than necessary.

## What Changed

- Updated the unified exec process-manager test to use `PermissionProfile::Disabled` directly, then derive the filesystem runtime policy from that profile.
- Updated the role config test to assert the resulting profile's network policy instead of converting the full config back through `legacy_sandbox_policy()`.
- Removed two incidental legacy policy constructions from tests that are validating non-legacy behavior.

## Verification

```shell
cargo test -p codex-core exec_server_params_use_env_policy_overlay_contract
cargo test -p codex-core apply_role_does_not_materialize_default_sandbox_workspace_write_fields
```











































































---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20368).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* __->__ #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373