### PR TITLE
guardian: configure review session permissions directly

### DIFF
--- a/codex-rs/core/src/guardian/review_session.rs
+++ b/codex-rs/core/src/guardian/review_session.rs
@@ -896,15 +896,14 @@ pub(crate) fn build_guardian_review_session_config(
     );
     guardian_config.developer_instructions = None;
     guardian_config.permissions.approval_policy = Constrained::allow_only(AskForApproval::Never);
-    let sandbox_policy = SandboxPolicy::new_read_only_policy();
-    guardian_config.permissions.permission_profile = Constrained::allow_only(
-        PermissionProfile::from_legacy_sandbox_policy(&sandbox_policy),
-    );
+    let permission_profile = PermissionProfile::read_only();
+    guardian_config.permissions.permission_profile =
+        Constrained::allow_only(permission_profile.clone());
     guardian_config
         .permissions
-        .set_legacy_sandbox_policy(sandbox_policy, guardian_config.cwd.as_path())
+        .set_permission_profile(permission_profile)
         .map_err(|err| {
-            anyhow::anyhow!("guardian review session could not set sandbox policy: {err}")
+            anyhow::anyhow!("guardian review session could not set permission profile: {err}")
         })?;
     guardian_config.include_apps_instructions = false;
     guardian_config


### PR DESCRIPTION
## Why

Guardian review sessions are internal child sessions that always run with read-only permissions and `AskForApproval::Never`. The config builder was still creating a legacy read-only `SandboxPolicy` and then converting it into the canonical `PermissionProfile`, which made this production path depend on the old abstraction for no behavior-specific reason.

This PR keeps the `Op::UserTurn.sandbox_policy` compatibility field alone, but removes the legacy bridge from guardian session config construction.

## What Changed

- Builds the guardian session permission override with `PermissionProfile::read_only()` directly.
- Constrains and applies that profile through `Permissions::set_permission_profile(...)` instead of `set_legacy_sandbox_policy(...)`.
- Updates the error message to refer to the permission profile being configured.

## Verification

```shell
cargo test -p codex-core guardian_review_session_config
```










































































---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20369).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* __->__ #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373