### PR TITLE
tests: use permission profiles in suite turn submits

### DIFF
--- a/codex-rs/core/tests/suite/apply_patch_cli.rs
+++ b/codex-rs/core/tests/suite/apply_patch_cli.rs
@@ -18,7 +18,6 @@ use codex_protocol::permissions::NetworkSandboxPolicy;
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::Op;
-use codex_protocol::protocol::SandboxPolicy;
 use codex_protocol::user_input::UserInput;
 #[cfg(target_os = "linux")]
 use codex_sandboxing::landlock::CODEX_LINUX_SANDBOX_ARG0;
@@ -36,6 +35,7 @@ use core_test_support::skip_if_remote;
 use core_test_support::test_codex::TestCodexBuilder;
 use core_test_support::test_codex::TestCodexHarness;
 use core_test_support::test_codex::test_codex;
+use core_test_support::test_codex::turn_permission_fields;
 use core_test_support::wait_for_event;
 use core_test_support::wait_for_event_with_timeout;
 use serde_json::json;
@@ -64,6 +64,8 @@ async fn apply_patch_harness_with(
 async fn submit_without_wait(harness: &TestCodexHarness, prompt: &str) -> Result<()> {
     let test = harness.test();
     let session_model = test.session_configured.model.clone();
+    let (sandbox_policy, permission_profile) =
+        turn_permission_fields(PermissionProfile::Disabled, harness.cwd());
     test.codex
         .submit(Op::UserTurn {
             environments: None,
@@ -75,8 +77,8 @@ async fn submit_without_wait(harness: &TestCodexHarness, prompt: &str) -> Result
             cwd: harness.cwd().to_path_buf(),
             approval_policy: AskForApproval::Never,
             approvals_reviewer: None,
-            sandbox_policy: SandboxPolicy::DangerFullAccess,
-            permission_profile: None,
+            sandbox_policy,
+            permission_profile,
             model: session_model,
             effort: None,
             summary: None,

--- a/codex-rs/core/tests/suite/hooks.rs
+++ b/codex-rs/core/tests/suite/hooks.rs
@@ -1943,9 +1943,9 @@ print(json.dumps({{
         fs::remove_file(&marker).context("remove leftover plugin pre tool use marker")?;
     }
 
-    test.submit_turn_with_policy(
+    test.submit_turn_with_permission_profile(
         "run the shell command blocked by a plugin hook",
-        codex_protocol::protocol::SandboxPolicy::DangerFullAccess,
+        PermissionProfile::Disabled,
     )
     .await?;
 


### PR DESCRIPTION
## Why

A couple of integration test helpers were still passing `SandboxPolicy::DangerFullAccess` for ordinary turn submission. These tests are not validating the legacy policy bridge; they just need the turn to run without sandbox restrictions. Using `PermissionProfile` directly keeps the tests aligned with the canonical permissions model and removes more incidental legacy usage.

## What Changed

- Updated the apply-patch CLI helper that constructs `Op::UserTurn` directly to populate both permission fields from `PermissionProfile::Disabled` via `turn_permission_fields(...)`.
- Updated the plugin hook test to call `submit_turn_with_permission_profile(...)` instead of `submit_turn_with_policy(...)`.
- Removed the `SandboxPolicy` import from `core/tests/suite/apply_patch_cli.rs`.

## Verification

```shell
cargo test -p codex-core apply_patch_cli_move_without_content_change_has_no_turn_diff -- --nocapture
cargo test -p codex-core plugin_pre_tool_use_blocks_shell_command_before_execution -- --nocapture
```









































































---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20370).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* __->__ #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373