### PR TITLE
tests: copy plugin stdio server before launch

### DIFF
--- a/codex-rs/core/tests/suite/plugins.rs
+++ b/codex-rs/core/tests/suite/plugins.rs
@@ -83,6 +83,27 @@ fn write_plugin_mcp_plugin(home: &TempDir, command: &str) {
     .expect("write plugin mcp config");
 }
 
+fn copy_stdio_server_for_plugin_test(home: &TempDir) -> Result<Option<String>> {
+    let rmcp_test_server_bin = match stdio_server_bin() {
+        Ok(bin) => bin,
+        Err(err) => {
+            eprintln!("test_stdio_server binary not available, skipping test: {err}");
+            return Ok(None);
+        }
+    };
+    let target = home.path().join("test_stdio_server");
+    std::fs::copy(std::path::Path::new(&rmcp_test_server_bin), &target)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let mut permissions = std::fs::metadata(&target)?.permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&target, permissions)?;
+    }
+    Ok(Some(target.to_string_lossy().to_string()))
+}
+
 fn write_plugin_app_plugin(home: &TempDir) {
     let plugin_root = write_sample_plugin_manifest_and_config(home);
     std::fs::write(
@@ -293,12 +314,8 @@ async fn explicit_plugin_mentions_inject_plugin_guidance() -> Result<()> {
     .await;
 
     let codex_home = Arc::new(TempDir::new()?);
-    let rmcp_test_server_bin = match stdio_server_bin() {
-        Ok(bin) => bin,
-        Err(err) => {
-            eprintln!("test_stdio_server binary not available, skipping test: {err}");
-            return Ok(());
-        }
+    let Some(rmcp_test_server_bin) = copy_stdio_server_for_plugin_test(codex_home.as_ref())? else {
+        return Ok(());
     };
     write_plugin_skill_plugin(codex_home.as_ref());
     write_plugin_mcp_plugin(codex_home.as_ref(), &rmcp_test_server_bin);
@@ -453,7 +470,9 @@ async fn plugin_mcp_tools_are_listed() -> Result<()> {
     skip_if_no_network!(Ok(()));
     let server = start_mock_server().await;
     let codex_home = Arc::new(TempDir::new()?);
-    let rmcp_test_server_bin = stdio_server_bin()?;
+    let Some(rmcp_test_server_bin) = copy_stdio_server_for_plugin_test(codex_home.as_ref())? else {
+        return Ok(());
+    };
     write_plugin_mcp_plugin(codex_home.as_ref(), &rmcp_test_server_bin);
     let codex = build_plugin_test_codex(&server, codex_home).await?;
     wait_for_sample_mcp_ready(&codex).await?;


### PR DESCRIPTION
## Why

The Linux Bazel build for the permission-profile stack exposed a flaky/plugin-test-specific failure where `suite::plugins::plugin_mcp_tools_are_listed` resolved the `test_stdio_server` runfiles path successfully, but the plugin MCP subprocess later failed to spawn it with `No such file or directory`.

The plugin tests do not need to exercise Bazel runfiles path execution. They only need a stable stdio MCP server binary to validate that plugin-provided MCP tools are discovered and listed.

## What Changed

- Copies the resolved `test_stdio_server` binary into the test temp home before writing the plugin `.mcp.json` config.
- Points plugin MCP startup at the copied executable so the child process launches from a stable local path rather than a runfiles path.
- Keeps the existing local Cargo behavior of skipping these tests when `test_stdio_server` is not available.

## Verification

- `cargo test -p codex-core plugin_mcp_tools_are_listed -- --nocapture`






































































---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20373).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* __->__ #20373