### PR TITLE
core: use permission profiles in small read-only contexts

### DIFF
--- a/codex-rs/core/src/context_manager/history_tests.rs
+++ b/codex-rs/core/src/context_manager/history_tests.rs
@@ -13,13 +13,13 @@ use codex_protocol::models::ImageDetail;
 use codex_protocol::models::LocalShellAction;
 use codex_protocol::models::LocalShellExecAction;
 use codex_protocol::models::LocalShellStatus;
+use codex_protocol::models::PermissionProfile;
 use codex_protocol::models::ReasoningItemContent;
 use codex_protocol::models::ReasoningItemReasoningSummary;
 use codex_protocol::openai_models::InputModality;
 use codex_protocol::openai_models::default_input_modalities;
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::InterAgentCommunication;
-use codex_protocol::protocol::SandboxPolicy;
 use codex_protocol::protocol::TurnContextItem;
 use codex_utils_output_truncation::TruncationPolicy;
 use codex_utils_output_truncation::truncate_text;
@@ -119,15 +119,21 @@ fn developer_msg_with_fragments(texts: &[&str]) -> ResponseItem {
 }
 
 fn reference_context_item() -> TurnContextItem {
+    let cwd = PathBuf::from("/tmp/reference-cwd");
+    let permission_profile = PermissionProfile::read_only();
+    let sandbox_policy = permission_profile
+        .to_legacy_sandbox_policy(cwd.as_path())
+        .expect("read-only permission profile should have a legacy projection");
+
     TurnContextItem {
         turn_id: Some("reference-turn".to_string()),
         trace_id: None,
-        cwd: PathBuf::from("/tmp/reference-cwd"),
+        cwd,
         current_date: Some("2026-03-23".to_string()),
         timezone: Some("America/Los_Angeles".to_string()),
         approval_policy: AskForApproval::OnRequest,
-        sandbox_policy: SandboxPolicy::new_read_only_policy(),
-        permission_profile: None,
+        sandbox_policy,
+        permission_profile: Some(permission_profile),
         network: None,
         file_system_sandbox_policy: None,
         model: "gpt-test".to_string(),

--- a/codex-rs/core/src/guardian/review_session.rs
+++ b/codex-rs/core/src/guardian/review_session.rs
@@ -18,7 +18,6 @@ use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::InitialHistory;
 use codex_protocol::protocol::Op;
 use codex_protocol::protocol::RolloutItem;
-use codex_protocol::protocol::SandboxPolicy;
 use codex_protocol::protocol::SubAgentSource;
 use codex_protocol::protocol::TokenUsage;
 use serde_json::Value;
@@ -703,6 +702,19 @@ async fn run_review_on_session(
         .await
         .unwrap_or_default();
 
+    let permission_profile = PermissionProfile::read_only();
+    let sandbox_policy =
+        match permission_profile.to_legacy_sandbox_policy(params.parent_turn.cwd.as_path()) {
+            Ok(sandbox_policy) => sandbox_policy,
+            Err(err) => {
+                return (
+                    GuardianReviewSessionOutcome::SessionFailed(err.into()),
+                    false,
+                    analytics_result,
+                );
+            }
+        };
+
     let submit_result = run_before_review_deadline(
         deadline,
         params.external_cancel.as_ref(),
@@ -712,8 +724,8 @@ async fn run_review_on_session(
             cwd: params.parent_turn.cwd.to_path_buf(),
             approval_policy: AskForApproval::Never,
             approvals_reviewer: None,
-            sandbox_policy: SandboxPolicy::new_read_only_policy(),
-            permission_profile: None,
+            sandbox_policy,
+            permission_profile: Some(permission_profile),
             model: params.model.clone(),
             effort: params.reasoning_effort,
             summary: Some(params.reasoning_summary),

--- a/codex-rs/core/src/realtime_context_tests.rs
+++ b/codex-rs/core/src/realtime_context_tests.rs
@@ -13,10 +13,10 @@ use chrono::Utc;
 use codex_git_utils::GitSha;
 use codex_protocol::ThreadId;
 use codex_protocol::models::ContentItem;
+use codex_protocol::models::PermissionProfile;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::GitInfo;
-use codex_protocol::protocol::SandboxPolicy;
 use codex_protocol::protocol::SessionSource;
 use codex_thread_store::StoredThread;
 use core_test_support::PathBufExt;
@@ -28,6 +28,8 @@ use std::process::Command;
 use tempfile::TempDir;
 
 fn stored_thread(cwd: &str, title: &str, first_user_message: &str) -> StoredThread {
+    let permission_profile = PermissionProfile::read_only();
+
     StoredThread {
         thread_id: ThreadId::new(),
         rollout_path: Some(PathBuf::from("/tmp/rollout.jsonl")),
@@ -58,7 +60,9 @@ fn stored_thread(cwd: &str, title: &str, first_user_message: &str) -> StoredThre
             repository_url: None,
         }),
         approval_mode: AskForApproval::Never,
-        sandbox_policy: SandboxPolicy::new_read_only_policy(),
+        sandbox_policy: permission_profile
+            .to_legacy_sandbox_policy(std::path::Path::new(cwd))
+            .expect("read-only permission profile should have a legacy projection"),
         token_usage: None,
         first_user_message: Some(first_user_message.to_string()),
         history: None,


### PR DESCRIPTION
## Why

The migration away from `SandboxPolicy` should also clean up the small places that still construct read-only legacy policies directly. Even where a legacy protocol field still has to be populated, the source of truth can be a `PermissionProfile` so the new model continues to exercise the compatibility projection.

## What Changed

- Submits guardian review turns with an explicit read-only `PermissionProfile` and derives the required legacy `sandbox_policy` field from that profile.
- Updates realtime-context thread fixtures to derive their stored read-only sandbox policy from `PermissionProfile::read_only()`.
- Updates context-manager turn-context fixtures to carry the read-only `permission_profile` alongside the required legacy projection.
- Removes direct `SandboxPolicy` imports from the touched files.

## Verification

- `cargo test -p codex-core realtime_context -- --nocapture`
- `cargo test -p codex-core context_manager::history -- --nocapture`
- `cargo test -p codex-core guardian_review_session_config -- --nocapture`





































































---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20375).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* __->__ #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373