### PR TITLE
tests: submit websocket turns with permission profiles

### DIFF
--- a/codex-rs/core/tests/common/test_codex.rs
+++ b/codex-rs/core/tests/common/test_codex.rs
@@ -630,15 +630,6 @@ impl TestCodex {
         .await
     }
 
-    pub async fn submit_turn_with_policy(
-        &self,
-        prompt: &str,
-        sandbox_policy: SandboxPolicy,
-    ) -> Result<()> {
-        self.submit_turn_with_policies(prompt, AskForApproval::Never, sandbox_policy)
-            .await
-    }
-
     pub async fn submit_turn_with_service_tier(
         &self,
         prompt: &str,
@@ -649,26 +640,6 @@ impl TestCodex {
             AskForApproval::Never,
             PermissionProfile::Disabled,
             Some(service_tier),
-            /*environments*/ None,
-        )
-        .await
-    }
-
-    pub async fn submit_turn_with_policies(
-        &self,
-        prompt: &str,
-        approval_policy: AskForApproval,
-        sandbox_policy: SandboxPolicy,
-    ) -> Result<()> {
-        let permission_profile = PermissionProfile::from_legacy_sandbox_policy_for_cwd(
-            &sandbox_policy,
-            self.config.cwd.as_path(),
-        );
-        self.submit_turn_with_context(
-            prompt,
-            approval_policy,
-            permission_profile,
-            /*service_tier*/ None,
             /*environments*/ None,
         )
         .await
@@ -894,16 +865,6 @@ impl TestCodexHarness {
         // Box the submit-and-wait path so callers do not inline the full turn
         // future into their own async state.
         Box::pin(self.test.submit_turn(prompt)).await
-    }
-
-    pub async fn submit_with_policy(
-        &self,
-        prompt: &str,
-        sandbox_policy: SandboxPolicy,
-    ) -> Result<()> {
-        self.test
-            .submit_turn_with_policy(prompt, sandbox_policy)
-            .await
     }
 
     pub async fn submit_with_permission_profile(

--- a/codex-rs/core/tests/suite/agent_websocket.rs
+++ b/codex-rs/core/tests/suite/agent_websocket.rs
@@ -38,8 +38,11 @@ async fn websocket_test_codex_shell_chain() -> Result<()> {
     let mut builder = test_codex().with_windows_cmd_shell();
 
     let test = builder.build_with_websocket_server(&server).await?;
-    test.submit_turn_with_policy("run the echo command", test.config.legacy_sandbox_policy())
-        .await?;
+    test.submit_turn_with_permission_profile(
+        "run the echo command",
+        test.config.permissions.permission_profile(),
+    )
+    .await?;
 
     let connection = server.single_connection();
     assert_eq!(connection.len(), 2);
@@ -82,7 +85,7 @@ async fn websocket_first_turn_uses_startup_prewarm_and_create() -> Result<()> {
 
     let mut builder = test_codex();
     let test = builder.build_with_websocket_server(&server).await?;
-    test.submit_turn_with_policy("hello", test.config.legacy_sandbox_policy())
+    test.submit_turn_with_permission_profile("hello", test.config.permissions.permission_profile())
         .await?;
 
     assert_eq!(server.handshakes().len(), 1);
@@ -129,7 +132,7 @@ async fn websocket_first_turn_handles_handshake_delay_with_startup_prewarm() -> 
 
     let mut builder = test_codex();
     let test = builder.build_with_websocket_server(&server).await?;
-    test.submit_turn_with_policy("hello", test.config.legacy_sandbox_policy())
+    test.submit_turn_with_permission_profile("hello", test.config.permissions.permission_profile())
         .await?;
 
     assert_eq!(server.handshakes().len(), 1);
@@ -182,8 +185,11 @@ async fn websocket_v2_test_codex_shell_chain() -> Result<()> {
     });
 
     let test = builder.build_with_websocket_server(&server).await?;
-    test.submit_turn_with_policy("run the echo command", test.config.legacy_sandbox_policy())
-        .await?;
+    test.submit_turn_with_permission_profile(
+        "run the echo command",
+        test.config.permissions.permission_profile(),
+    )
+    .await?;
 
     let connection = server.single_connection();
     assert_eq!(connection.len(), 3);


### PR DESCRIPTION
## Why

`core/tests/common/test_codex.rs` still exposed `submit_turn_with_policy()` helpers that converted `SandboxPolicy` into `PermissionProfile` before submitting turns. The websocket tests were the remaining callers, so they could exercise the same behavior directly through permission profiles.

Removing these helpers keeps new tests from accidentally reaching for the legacy sandbox abstraction when submitting `Op::UserTurn`.

## What Changed

- Updated websocket suite turn submission to call `submit_turn_with_permission_profile()` with the active test config permissions.
- Removed `submit_turn_with_policy()`, `submit_turn_with_policies()`, and `submit_with_policy()` from the shared `TestCodex` helpers.
- Preserved the existing compatibility helper that derives the required legacy `sandbox_policy` field from a `PermissionProfile` for direct `Op::UserTurn` construction.

## Verification

- `cargo test -p codex-core websocket_first_turn_uses_startup_prewarm_and_create -- --nocapture`
- `just fix -p codex-core`
































































---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20381).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* __->__ #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373