### PR TITLE
fix(login): unblock server on cancellation

### DIFF
--- a/codex-rs/login/src/server.rs
+++ b/codex-rs/login/src/server.rs
@@ -121,15 +121,17 @@ impl LoginServer {
 }
 
 /// Handle used to signal the login server loop to exit.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct ShutdownHandle {
     shutdown_notify: Arc<tokio::sync::Notify>,
+    server: Arc<Server>,
 }
 
 impl ShutdownHandle {
     /// Signals the login loop to terminate.
     pub fn shutdown(&self) {
         self.shutdown_notify.notify_waiters();
+        self.server.unblock();
     }
 }
 
@@ -183,6 +185,7 @@ pub fn run_login_server(opts: ServerOptions) -> io::Result<LoginServer> {
     };
 
     let shutdown_notify = Arc::new(tokio::sync::Notify::new());
+    let shutdown_server = server.clone();
     let server_handle = {
         let shutdown_notify = shutdown_notify.clone();
         let server = server;
@@ -242,7 +245,10 @@ pub fn run_login_server(opts: ServerOptions) -> io::Result<LoginServer> {
         auth_url,
         actual_port,
         server_handle,
-        shutdown_handle: ShutdownHandle { shutdown_notify },
+        shutdown_handle: ShutdownHandle {
+            shutdown_notify,
+            server: shutdown_server,
+        },
     })
 }
 


### PR DESCRIPTION
## Summary

- unblock the tiny_http login server immediately when cancellation is requested
- remove a narrow race where the fallback-port login server test could wait for shutdown after cance
 
## Testing
- cargo test -p codex-login --test all suite::login_server_e2e::falls_back_to_registered_fallback_port_when_default_port_is_in_use -- --nocapture (3 consecutive runs)
- cargo test -p codex-login\n- just fix -p codex-login