### PR TITLE
tests: remove sandbox policy fixture from rollout trace

### DIFF
--- a/codex-rs/rollout-trace/src/thread_tests.rs
+++ b/codex-rs/rollout-trace/src/thread_tests.rs
@@ -7,7 +7,6 @@ use codex_protocol::AgentPath;
 use codex_protocol::ThreadId;
 use codex_protocol::protocol::AgentStatus;
 use codex_protocol::protocol::EventMsg;
-use codex_protocol::protocol::SandboxPolicy;
 use codex_protocol::protocol::SessionSource;
 use codex_protocol::protocol::SubAgentSource;
 use tempfile::TempDir;
@@ -38,7 +37,7 @@ fn create_in_root_writes_replayable_lifecycle_events() -> anyhow::Result<()> {
             model: "gpt-test".to_string(),
             provider_name: "test-provider".to_string(),
             approval_policy: "never".to_string(),
-            sandbox_policy: format!("{:?}", SandboxPolicy::DangerFullAccess),
+            sandbox_policy: "DangerFullAccess".to_string(),
         },
     )?;
 
@@ -85,7 +84,7 @@ fn spawned_thread_start_appends_to_root_bundle() -> anyhow::Result<()> {
         model: "gpt-test".to_string(),
         provider_name: "test-provider".to_string(),
         approval_policy: "never".to_string(),
-        sandbox_policy: format!("{:?}", SandboxPolicy::DangerFullAccess),
+        sandbox_policy: "DangerFullAccess".to_string(),
     });
     child_trace.record_ended(RolloutStatus::Completed);
     let bundle_dir = single_bundle_dir(temp.path())?;


### PR DESCRIPTION
## Why

A rollout trace test imported `SandboxPolicy` only to format the legacy `DangerFullAccess` string into fixture metadata. That does not need the enum and keeps an unnecessary reference to the old abstraction in a trace-only test.

## What Changed

- Removed the `SandboxPolicy` import from rollout trace tests.
- Preserved the serialized fixture value by writing `"DangerFullAccess"` directly.

## Verification

- `cargo test -p codex-rollout-trace`
- `just fmt`
- `just fix -p codex-rollout-trace`




























































---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20386).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* __->__ #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373