### PR TITLE
tests: use permission profiles in multi-agent config checks

### DIFF
--- a/codex-rs/core/src/tools/handlers/multi_agents_tests.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_tests.rs
@@ -42,7 +42,6 @@ use codex_protocol::protocol::InterAgentCommunication;
 use codex_protocol::protocol::NetworkSandboxPolicy;
 use codex_protocol::protocol::Op;
 use codex_protocol::protocol::RolloutItem;
-use codex_protocol::protocol::SandboxPolicy;
 use codex_protocol::protocol::SessionSource;
 use codex_protocol::protocol::SubAgentSource;
 use codex_protocol::protocol::TurnAbortReason;
@@ -3434,34 +3433,24 @@ async fn tool_handlers_cascade_close_and_resume_and_keep_explicitly_closed_subtr
 
 #[tokio::test]
 async fn build_agent_spawn_config_uses_turn_context_values() {
-    fn pick_allowed_sandbox_policy(
+    fn pick_allowed_permission_profile(
         constraint: &crate::config::Constrained<PermissionProfile>,
-        base: SandboxPolicy,
-        cwd: &std::path::Path,
-    ) -> SandboxPolicy {
+        base: &PermissionProfile,
+    ) -> PermissionProfile {
         let candidates = [
-            SandboxPolicy::new_read_only_policy(),
-            SandboxPolicy::new_workspace_write_policy(),
-            SandboxPolicy::DangerFullAccess,
+            PermissionProfile::read_only(),
+            PermissionProfile::workspace_write(),
+            PermissionProfile::Disabled,
         ];
         candidates
             .into_iter()
             .find(|candidate| {
-                if *candidate == base {
+                if candidate == base {
                     return false;
                 }
-                let file_system_sandbox_policy =
-                    FileSystemSandboxPolicy::from_legacy_sandbox_policy_for_cwd(candidate, cwd);
-                let network_sandbox_policy = NetworkSandboxPolicy::from(candidate);
-                let permission_profile =
-                    PermissionProfile::from_runtime_permissions_with_enforcement(
-                        SandboxEnforcement::from_legacy_sandbox_policy(candidate),
-                        &file_system_sandbox_policy,
-                        network_sandbox_policy,
-                    );
-                constraint.can_set(&permission_profile).is_ok()
+                constraint.can_set(candidate).is_ok()
             })
-            .unwrap_or(base)
+            .unwrap_or_else(|| base.clone())
     }
 
     let (_session, mut turn) = make_session_and_context().await;
@@ -3477,18 +3466,9 @@ async fn build_agent_spawn_config_uses_turn_context_values() {
     let temp_dir = tempfile::tempdir().expect("temp dir");
     turn.cwd = temp_dir.abs();
     turn.codex_linux_sandbox_exe = Some(PathBuf::from("/bin/echo"));
-    let sandbox_policy = pick_allowed_sandbox_policy(
+    let permission_profile = pick_allowed_permission_profile(
         &turn.config.permissions.permission_profile,
-        turn.config.legacy_sandbox_policy(),
-        turn.cwd.as_path(),
-    );
-    let file_system_sandbox_policy =
-        FileSystemSandboxPolicy::from_legacy_sandbox_policy_for_cwd(&sandbox_policy, &turn.cwd);
-    let network_sandbox_policy = NetworkSandboxPolicy::from(&sandbox_policy);
-    let permission_profile = PermissionProfile::from_runtime_permissions_with_enforcement(
-        SandboxEnforcement::from_legacy_sandbox_policy(&sandbox_policy),
-        &file_system_sandbox_policy,
-        network_sandbox_policy,
+        &turn.permission_profile,
     );
     turn.permission_profile = permission_profile.clone();
     turn.approval_policy


### PR DESCRIPTION
## Why

One multi-agent test selected a legacy `SandboxPolicy` candidate only to immediately convert it into a `PermissionProfile`. The test is about preserving turn-context values in spawned-agent config, not the legacy sandbox bridge, so the intermediate policy made the fixture harder to read.

## What Changed

- Replaced the local sandbox-policy candidate helper with a direct `PermissionProfile` candidate helper.
- Removed the remaining `SandboxPolicy` import/reference from `multi_agents_tests.rs`.
- Left the separate runtime-sandbox reapplication test on its existing legacy-derived setup, because that test still validates legacy config reapplication behavior.

## Verification

- `cargo test -p codex-core build_agent_spawn_config_uses_turn_context_values -- --nocapture`
- `just fmt`
- `just fix -p codex-core`



























































---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20387).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* __->__ #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373