### PR TITLE
tests: use disabled profile in exec capture check

### DIFF
--- a/codex-rs/core/src/exec_tests.rs
+++ b/codex-rs/core/src/exec_tests.rs
@@ -347,8 +347,7 @@ async fn process_exec_tool_call_preserves_full_buffer_capture_policy() -> Result
     ];
 
     let cwd = codex_utils_absolute_path::AbsolutePathBuf::current_dir()?;
-    let sandbox_policy = SandboxPolicy::DangerFullAccess;
-    let permission_profile = PermissionProfile::from_legacy_sandbox_policy(&sandbox_policy);
+    let permission_profile = PermissionProfile::Disabled;
     let output = process_exec_tool_call(
         ExecParams {
             command,


### PR DESCRIPTION
## Why

The full-buffer exec capture test only needs an unsandboxed/disabled permission profile. It previously constructed `SandboxPolicy::DangerFullAccess` solely to convert it to `PermissionProfile::Disabled`, which kept an unnecessary dependency on the legacy abstraction.

## What Changed

- Replaced the legacy bridge in `process_exec_tool_call_preserves_full_buffer_capture_policy` with `PermissionProfile::Disabled`.
- Left the remaining `SandboxPolicy` uses in `exec_tests.rs` intact because they exercise Windows sandbox compatibility paths that still take legacy policy input.

## Verification

- `cargo test -p codex-core process_exec_tool_call_preserves_full_buffer_capture_policy -- --nocapture`
- `just fmt`
- `just fix -p codex-core`

























































---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20389).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* __->__ #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373