### PR TITLE
tests: mutate spawn-agent permission profile directly

### DIFF
--- a/codex-rs/core/src/tools/handlers/multi_agents_tests.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_tests.rs
@@ -25,10 +25,10 @@ use codex_protocol::config_types::ShellEnvironmentPolicy;
 use codex_protocol::models::BaseInstructions;
 use codex_protocol::models::ContentItem;
 use codex_protocol::models::FunctionCallOutputBody;
+use codex_protocol::models::ManagedFileSystemPermissions;
 use codex_protocol::models::PermissionProfile;
 use codex_protocol::models::ResponseInputItem;
 use codex_protocol::models::ResponseItem;
-use codex_protocol::models::SandboxEnforcement;
 use codex_protocol::openai_models::ReasoningEffort;
 use codex_protocol::protocol::AgentStatus;
 use codex_protocol::protocol::AskForApproval;
@@ -36,10 +36,8 @@ use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::FileSystemAccessMode;
 use codex_protocol::protocol::FileSystemPath;
 use codex_protocol::protocol::FileSystemSandboxEntry;
-use codex_protocol::protocol::FileSystemSandboxPolicy;
 use codex_protocol::protocol::InitialHistory;
 use codex_protocol::protocol::InterAgentCommunication;
-use codex_protocol::protocol::NetworkSandboxPolicy;
 use codex_protocol::protocol::Op;
 use codex_protocol::protocol::RolloutItem;
 use codex_protocol::protocol::SessionSource;
@@ -1786,22 +1784,22 @@ async fn spawn_agent_reapplies_runtime_sandbox_after_role_config() {
     let manager = thread_manager();
     session.services.agent_control = manager.agent_control();
     let expected_sandbox = turn.config.legacy_sandbox_policy();
-    let mut expected_file_system_sandbox_policy =
-        FileSystemSandboxPolicy::from_legacy_sandbox_policy_for_cwd(&expected_sandbox, &turn.cwd);
-    expected_file_system_sandbox_policy
-        .entries
-        .push(FileSystemSandboxEntry {
-            path: FileSystemPath::GlobPattern {
-                pattern: "**/.env".to_string(),
-            },
-            access: FileSystemAccessMode::None,
-        });
-    let expected_network_sandbox_policy = NetworkSandboxPolicy::from(&expected_sandbox);
-    let expected_permission_profile = PermissionProfile::from_runtime_permissions_with_enforcement(
-        SandboxEnforcement::from_legacy_sandbox_policy(&expected_sandbox),
-        &expected_file_system_sandbox_policy,
-        expected_network_sandbox_policy,
-    );
+    let mut expected_permission_profile = turn.config.permissions.permission_profile();
+    let PermissionProfile::Managed { file_system, .. } = &mut expected_permission_profile else {
+        panic!("test fixture should use managed permissions");
+    };
+    let ManagedFileSystemPermissions::Restricted { entries, .. } = file_system else {
+        panic!("test fixture should use restricted filesystem permissions");
+    };
+    entries.push(FileSystemSandboxEntry {
+        path: FileSystemPath::GlobPattern {
+            pattern: "**/.env".to_string(),
+        },
+        access: FileSystemAccessMode::None,
+    });
+    let expected_file_system_sandbox_policy =
+        expected_permission_profile.file_system_sandbox_policy();
+    let expected_network_sandbox_policy = expected_permission_profile.network_sandbox_policy();
     turn.approval_policy
         .set(AskForApproval::OnRequest)
         .expect("approval policy should be set");


### PR DESCRIPTION
## Why

One spawn-agent test still rebuilt a runtime permissions fixture by converting through the legacy `SandboxPolicy` bridge and then adding a deny glob. That is exactly the sort of fixture code that can hide lossy behavior while the runtime model is moving to `PermissionProfile`.

## What Changed

- Build the test's expected runtime override from `turn.config.permissions.permission_profile()`.
- Mutate the managed filesystem entries directly to add the `**/.env` deny glob.
- Keep the legacy sandbox assertion only for the config snapshot compatibility field, while deriving child runtime filesystem/network expectations from the final `PermissionProfile`.

## Verification

- `cargo test -p codex-core spawn_agent_reapplies_runtime_sandbox_after_role_config -- --nocapture`
- `just fix -p codex-core`






















































---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20394).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* __->__ #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373