### PR TITLE
app-server-test-client: select permission profiles by name

### DIFF
--- a/codex-rs/app-server-test-client/src/lib.rs
+++ b/codex-rs/app-server-test-client/src/lib.rs
@@ -48,8 +48,8 @@ use codex_app_server_protocol::JSONRPCResponse;
 use codex_app_server_protocol::LoginAccountResponse;
 use codex_app_server_protocol::ModelListParams;
 use codex_app_server_protocol::ModelListResponse;
+use codex_app_server_protocol::PermissionProfileSelectionParams;
 use codex_app_server_protocol::RequestId;
-use codex_app_server_protocol::SandboxPolicy;
 use codex_app_server_protocol::ServerNotification;
 use codex_app_server_protocol::ServerRequest;
 use codex_app_server_protocol::ThreadDecrementElicitationParams;
@@ -620,11 +620,18 @@ fn shell_quote(input: &str) -> String {
     format!("'{}'", input.replace('\'', "'\\''"))
 }
 
+fn select_permission_profile(id: &str) -> PermissionProfileSelectionParams {
+    PermissionProfileSelectionParams::Profile {
+        id: id.to_string(),
+        modifications: None,
+    }
+}
+
 struct SendMessagePolicies<'a> {
     command_name: &'static str,
     experimental_api: bool,
     approval_policy: Option<AskForApproval>,
-    sandbox_policy: Option<SandboxPolicy>,
+    permission_profile_id: Option<&'static str>,
     dynamic_tools: &'a Option<Vec<DynamicToolSpec>>,
 }
 
@@ -642,7 +649,7 @@ async fn send_message(
             command_name: "send-message",
             experimental_api: false,
             approval_policy: None,
-            sandbox_policy: None,
+            permission_profile_id: None,
             dynamic_tools: &dynamic_tools,
         },
     )
@@ -685,7 +692,7 @@ async fn send_message_v2_endpoint(
             command_name: "send-message-v2",
             experimental_api,
             approval_policy: None,
-            sandbox_policy: None,
+            permission_profile_id: None,
             dynamic_tools,
         },
     )
@@ -741,9 +748,7 @@ async fn trigger_zsh_fork_multi_cmd_approval(
                 ..Default::default()
             };
             turn_params.approval_policy = Some(AskForApproval::OnRequest);
-            turn_params.sandbox_policy = Some(SandboxPolicy::ReadOnly {
-                network_access: false,
-            });
+            turn_params.permissions = Some(select_permission_profile(":read-only"));
 
             let turn_response = client.turn_start(turn_params)?;
             println!("< turn/start response: {turn_response:?}");
@@ -882,9 +887,7 @@ async fn trigger_cmd_approval(
             command_name: "trigger-cmd-approval",
             experimental_api: true,
             approval_policy: Some(AskForApproval::OnRequest),
-            sandbox_policy: Some(SandboxPolicy::ReadOnly {
-                network_access: false,
-            }),
+            permission_profile_id: Some(":read-only"),
             dynamic_tools,
         },
     )
@@ -908,9 +911,7 @@ async fn trigger_patch_approval(
             command_name: "trigger-patch-approval",
             experimental_api: true,
             approval_policy: Some(AskForApproval::OnRequest),
-            sandbox_policy: Some(SandboxPolicy::ReadOnly {
-                network_access: false,
-            }),
+            permission_profile_id: Some(":read-only"),
             dynamic_tools,
         },
     )
@@ -931,7 +932,7 @@ async fn no_trigger_cmd_approval(
             command_name: "no-trigger-cmd-approval",
             experimental_api: true,
             approval_policy: None,
-            sandbox_policy: None,
+            permission_profile_id: None,
             dynamic_tools,
         },
     )
@@ -967,7 +968,9 @@ async fn send_message_v2_with_policies(
                 ..Default::default()
             };
             turn_params.approval_policy = policies.approval_policy;
-            turn_params.sandbox_policy = policies.sandbox_policy;
+            turn_params.permissions = policies
+                .permission_profile_id
+                .map(select_permission_profile);
 
             let turn_response = client.turn_start(turn_params)?;
             println!("< turn/start response: {turn_response:?}");
@@ -1260,7 +1263,7 @@ fn live_elicitation_timeout_pause(
             text_elements: Vec::new(),
         }],
         approval_policy: Some(AskForApproval::Never),
-        sandbox_policy: Some(SandboxPolicy::DangerFullAccess),
+        permissions: Some(select_permission_profile(":danger-no-sandbox")),
         effort: Some(ReasoningEffort::High),
         cwd: Some(workspace),
         ..Default::default()


### PR DESCRIPTION
## Why

This stack is migrating test and support code away from the legacy `SandboxPolicy` turn override path. The app-server test client still constructed legacy sandbox payloads when exercising approval flows, which kept one more non-production caller tied to `sandboxPolicy` even though v2 turn requests now support selecting permission profiles directly.

Using named profiles in this harness keeps the manual/debug flows aligned with the app-server API direction: callers choose a profile such as `:read-only` or `:danger-no-sandbox` instead of synthesizing a legacy policy and asking the server to bridge it.

## What Changed

- Replaced `SandboxPolicy` imports and fields in `codex-rs/app-server-test-client` with `PermissionProfileSelectionParams`.
- Added a small helper for selecting built-in profiles by id.
- Updated approval-triggering flows to request `:read-only` through `TurnStartParams.permissions`.
- Updated the elicitation flow that needs unrestricted execution to request `:danger-no-sandbox` through `TurnStartParams.permissions`.

## Verification

- `cargo test -p codex-app-server-test-client`




















































---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20397).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* __->__ #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373