### PR TITLE
otel: report conversation permissions from profiles

### DIFF
--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -640,6 +640,7 @@ impl Session {
                 )],
             );
 
+            let permission_profile = config.permissions.permission_profile();
             session_telemetry.conversation_starts(
                 config.model_provider.name.as_str(),
                 session_configuration.collaboration_mode.reasoning_effort(),
@@ -649,9 +650,8 @@ impl Session {
                 config.model_context_window,
                 config.model_auto_compact_token_limit,
                 config.permissions.approval_policy.value(),
-                config
-                    .permissions
-                    .legacy_sandbox_policy(session_configuration.cwd.as_path()),
+                &permission_profile,
+                session_configuration.cwd.as_path(),
                 mcp_servers.keys().map(String::as_str).collect(),
                 config.active_profile.clone(),
             );

--- a/codex-rs/otel/src/events/session_telemetry.rs
+++ b/codex-rs/otel/src/events/session_telemetry.rs
@@ -33,11 +33,11 @@ use codex_api::ApiError;
 use codex_api::ResponseEvent;
 use codex_protocol::ThreadId;
 use codex_protocol::config_types::ReasoningSummary;
+use codex_protocol::models::PermissionProfile;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::openai_models::ReasoningEffort;
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::ReviewDecision;
-use codex_protocol::protocol::SandboxPolicy;
 use codex_protocol::protocol::SessionSource;
 use codex_protocol::user_input::UserInput;
 use eventsource_stream::Event as StreamEvent;
@@ -47,6 +47,7 @@ use reqwest::Error;
 use reqwest::Response;
 use std::borrow::Cow;
 use std::future::Future;
+use std::path::Path;
 use std::time::Duration;
 use std::time::Instant;
 use tokio::time::error::Elapsed;
@@ -335,13 +336,18 @@ impl SessionTelemetry {
         context_window: Option<i64>,
         auto_compact_token_limit: Option<i64>,
         approval_policy: AskForApproval,
-        sandbox_policy: SandboxPolicy,
+        permission_profile: &PermissionProfile,
+        permission_profile_cwd: &Path,
         mcp_servers: Vec<&str>,
         active_profile: Option<String>,
     ) {
         if active_profile.is_some() {
             self.counter(PROFILE_USAGE_METRIC, /*inc*/ 1, &[]);
         }
+        let sandbox_policy = permission_profile
+            .to_legacy_sandbox_policy(permission_profile_cwd)
+            .map(|policy| policy.to_string())
+            .unwrap_or_else(|_| "custom".to_string());
         log_and_trace_event!(
             self,
             common: {

--- a/codex-rs/otel/tests/suite/otel_export_routing_policy.rs
+++ b/codex-rs/otel/tests/suite/otel_export_routing_policy.rs
@@ -20,8 +20,8 @@ use tracing_subscriber::layer::SubscriberExt;
 
 use codex_protocol::ThreadId;
 use codex_protocol::config_types::ReasoningSummary;
+use codex_protocol::models::PermissionProfile;
 use codex_protocol::protocol::AskForApproval;
-use codex_protocol::protocol::SandboxPolicy;
 use codex_protocol::protocol::SessionSource;
 use codex_protocol::user_input::UserInput;
 
@@ -508,7 +508,8 @@ fn otel_export_routing_policy_routes_api_request_auth_observability() {
             /*context_window*/ None,
             /*auto_compact_token_limit*/ None,
             AskForApproval::Never,
-            SandboxPolicy::DangerFullAccess,
+            &PermissionProfile::Disabled,
+            std::path::Path::new("/"),
             Vec::new(),
             /*active_profile*/ None,
         );


### PR DESCRIPTION
## Why

`SessionTelemetry::conversation_starts()` still accepted a legacy `SandboxPolicy` even though the session configuration is now permission-profile backed. That forced callers to compute a legacy projection before telemetry, keeping another production API pinned to `SandboxPolicy` for a value that is only used as a compatibility tag.

This change makes telemetry consume the canonical `PermissionProfile` and derive the existing `sandbox_policy` tag internally, preserving the emitted telemetry shape while moving the call boundary away from the legacy type.

## What Changed

- Changed `SessionTelemetry::conversation_starts()` to take `&PermissionProfile` plus the cwd used for legacy projection.
- Kept the existing `sandbox_policy` telemetry attribute by projecting the profile to a legacy string when possible, or reporting `custom` for profiles that cannot be represented by the old abstraction.
- Updated session startup to pass the configured permission profile directly.
- Updated the otel export-routing test to use `PermissionProfile::Disabled` instead of `SandboxPolicy::DangerFullAccess`.

## Verification

- `cargo test -p codex-otel`
- `cargo test -p codex-core session_configured_reports_permission_profile_for_external_sandbox -- --nocapture`


















































---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20400).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* __->__ #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373