### PR TITLE
state: derive metadata sandbox from permission profiles

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -3454,7 +3454,7 @@ impl CodexMessageProcessor {
             builder.model_provider = Some(model_provider.clone());
             builder.cwd = config_snapshot.cwd.to_path_buf();
             builder.cli_version = Some(env!("CARGO_PKG_VERSION").to_string());
-            builder.sandbox_policy = config_snapshot.sandbox_policy();
+            builder.permission_profile = config_snapshot.permission_profile;
             builder.approval_mode = config_snapshot.approval_policy;
             let metadata = builder.build(model_provider.as_str());
             if let Err(err) = state_db_ctx.insert_thread_if_absent(&metadata).await {

--- a/codex-rs/rollout/src/metadata.rs
+++ b/codex-rs/rollout/src/metadata.rs
@@ -12,7 +12,6 @@ use chrono::Utc;
 use codex_protocol::ThreadId;
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::RolloutItem;
-use codex_protocol::protocol::SandboxPolicy;
 use codex_protocol::protocol::SessionMetaLine;
 use codex_protocol::protocol::SessionSource;
 use codex_state::BackfillState;
@@ -54,7 +53,6 @@ pub(crate) fn builder_from_session_meta(
     builder.agent_path = session_meta.meta.agent_path.clone();
     builder.cwd = session_meta.meta.cwd.clone();
     builder.cli_version = Some(session_meta.meta.cli_version.clone());
-    builder.sandbox_policy = SandboxPolicy::new_read_only_policy();
     builder.approval_mode = AskForApproval::OnRequest;
     if let Some(git) = session_meta.git.as_ref() {
         builder.git_sha = git.commit_hash.as_ref().map(|sha| sha.0.clone());

--- a/codex-rs/state/src/model/thread_metadata.rs
+++ b/codex-rs/state/src/model/thread_metadata.rs
@@ -2,9 +2,9 @@ use anyhow::Result;
 use chrono::DateTime;
 use chrono::Utc;
 use codex_protocol::ThreadId;
+use codex_protocol::models::PermissionProfile;
 use codex_protocol::openai_models::ReasoningEffort;
 use codex_protocol::protocol::AskForApproval;
-use codex_protocol::protocol::SandboxPolicy;
 use codex_protocol::protocol::SessionSource;
 use sqlx::Row;
 use sqlx::sqlite::SqliteRow;
@@ -129,8 +129,9 @@ pub struct ThreadMetadataBuilder {
     pub cwd: PathBuf,
     /// Version of the CLI that created the thread.
     pub cli_version: Option<String>,
-    /// The sandbox policy.
-    pub sandbox_policy: SandboxPolicy,
+    /// Runtime permissions, projected to the legacy `sandbox_policy` string
+    /// stored in the state DB when metadata is built.
+    pub permission_profile: PermissionProfile,
     /// The approval mode.
     pub approval_mode: AskForApproval,
     /// The archive timestamp, if the thread is archived.
@@ -163,7 +164,7 @@ impl ThreadMetadataBuilder {
             model_provider: None,
             cwd: PathBuf::new(),
             cli_version: None,
-            sandbox_policy: SandboxPolicy::new_read_only_policy(),
+            permission_profile: PermissionProfile::read_only(),
             approval_mode: AskForApproval::OnRequest,
             archived_at: None,
             git_sha: None,
@@ -175,7 +176,11 @@ impl ThreadMetadataBuilder {
     /// Build canonical thread metadata, filling missing values from defaults.
     pub fn build(&self, default_provider: &str) -> ThreadMetadata {
         let source = crate::extract::enum_to_string(&self.source);
-        let sandbox_policy = crate::extract::enum_to_string(&self.sandbox_policy);
+        let sandbox_policy = self
+            .permission_profile
+            .to_legacy_sandbox_policy(self.cwd.as_path())
+            .map(|policy| crate::extract::enum_to_string(&policy))
+            .unwrap_or_else(|_| "custom".to_string());
         let approval_mode = crate::extract::enum_to_string(&self.approval_mode);
         let created_at = canonicalize_datetime(self.created_at);
         let updated_at = self
@@ -465,13 +470,25 @@ pub struct BackfillStats {
 #[cfg(test)]
 mod tests {
     use super::ThreadMetadata;
+    use super::ThreadMetadataBuilder;
     use super::ThreadRow;
     use chrono::DateTime;
     use chrono::Utc;
     use codex_protocol::ThreadId;
+    use codex_protocol::models::PermissionProfile;
     use codex_protocol::openai_models::ReasoningEffort;
+    use codex_protocol::protocol::SessionSource;
     use pretty_assertions::assert_eq;
     use std::path::PathBuf;
+
+    fn metadata_builder() -> ThreadMetadataBuilder {
+        ThreadMetadataBuilder::new(
+            ThreadId::from_string("00000000-0000-0000-0000-000000000123").expect("valid thread id"),
+            PathBuf::from("/tmp/rollout-123.jsonl"),
+            DateTime::<Utc>::from_timestamp(1_700_000_000, 0).expect("timestamp"),
+            SessionSource::Cli,
+        )
+    }
 
     fn thread_row(reasoning_effort: Option<&str>) -> ThreadRow {
         ThreadRow {
@@ -548,5 +565,35 @@ mod tests {
             metadata,
             expected_thread_metadata(/*reasoning_effort*/ None)
         );
+    }
+
+    #[test]
+    fn thread_metadata_builder_projects_permission_profile_to_legacy_sandbox_string() {
+        let mut builder = metadata_builder();
+        builder.cwd = PathBuf::from("/tmp/workspace");
+        builder.permission_profile = PermissionProfile::workspace_write();
+
+        let metadata = builder.build("openai");
+
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&metadata.sandbox_policy)
+                .expect("sandbox policy should be valid json"),
+            serde_json::json!({
+                "type": "workspace-write",
+                "network_access": false,
+                "exclude_tmpdir_env_var": false,
+                "exclude_slash_tmp": false,
+            })
+        );
+    }
+
+    #[test]
+    fn thread_metadata_builder_projects_disabled_profile_to_legacy_sandbox_string() {
+        let mut builder = metadata_builder();
+        builder.permission_profile = PermissionProfile::Disabled;
+
+        let metadata = builder.build("openai");
+
+        assert_eq!(metadata.sandbox_policy, r#"{"type":"danger-full-access"}"#);
     }
 }

--- a/codex-rs/state/src/runtime/test_support.rs
+++ b/codex-rs/state/src/runtime/test_support.rs
@@ -9,8 +9,6 @@ use codex_protocol::openai_models::ReasoningEffort;
 #[cfg(test)]
 use codex_protocol::protocol::AskForApproval;
 #[cfg(test)]
-use codex_protocol::protocol::SandboxPolicy;
-#[cfg(test)]
 use std::path::Path;
 #[cfg(test)]
 use std::path::PathBuf;
@@ -57,7 +55,7 @@ pub(super) fn test_thread_metadata(
         cwd,
         cli_version: "0.0.0".to_string(),
         title: String::new(),
-        sandbox_policy: crate::extract::enum_to_string(&SandboxPolicy::new_read_only_policy()),
+        sandbox_policy: r#"{"type":"read-only"}"#.to_string(),
         approval_mode: crate::extract::enum_to_string(&AskForApproval::OnRequest),
         tokens_used: 0,
         first_user_message: Some("hello".to_string()),


### PR DESCRIPTION
## Why

`ThreadMetadataBuilder` was one of the remaining internal state/rollout callsites that still carried `SandboxPolicy` as its input. The state database still has a legacy `sandbox_policy` string column, so this PR keeps that storage format intact while moving the builder API to the canonical runtime permissions model.

This keeps the compatibility boundary explicit: callers provide a `PermissionProfile`, and the builder performs the best-effort legacy projection only when producing `ThreadMetadata` for storage.

## What Changed

- Replaced `ThreadMetadataBuilder.sandbox_policy` with `ThreadMetadataBuilder.permission_profile`.
- Defaulted new metadata builders to `PermissionProfile::read_only()` instead of constructing a legacy read-only policy.
- Projected the profile back into the existing `sandbox_policy` string in `ThreadMetadataBuilder::build()`, using `"custom"` when the profile cannot be represented by the legacy policy shape.
- Updated app-server metadata creation to seed the builder from the thread config snapshot’s `permission_profile`.
- Removed rollout metadata setup code that explicitly constructed the legacy read-only policy just to seed the builder.
- Added state-model coverage for workspace and disabled profile projections so the storage-boundary behavior is pinned down.

## Verification

- `cargo test -p codex-state`
- `cargo test -p codex-rollout metadata`
- `cargo check -p codex-app-server`














































---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20401).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* __->__ #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373