### PR TITLE
rollout tests: seed turn contexts from permission profiles

### DIFF
--- a/codex-rs/rollout/src/recorder_tests.rs
+++ b/codex-rs/rollout/src/recorder_tests.rs
@@ -4,13 +4,13 @@ use super::*;
 use crate::config::RolloutConfig;
 use chrono::TimeZone;
 use codex_protocol::config_types::ReasoningSummary as ReasoningSummaryConfig;
+use codex_protocol::models::PermissionProfile;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::protocol::AgentMessageEvent;
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::RolloutItem;
 use codex_protocol::protocol::RolloutLine;
-use codex_protocol::protocol::SandboxPolicy;
 use codex_protocol::protocol::TurnContextItem;
 use codex_protocol::protocol::UserMessageEvent;
 use pretty_assertions::assert_eq;
@@ -1095,6 +1095,7 @@ async fn resume_candidate_matches_cwd_reads_latest_turn_context() -> std::io::Re
 
     let path = write_session_file(home.path(), "2025-01-03T13-00-00", Uuid::from_u128(9012))?;
     let mut file = std::fs::OpenOptions::new().append(true).open(&path)?;
+    let permission_profile = PermissionProfile::read_only();
     let turn_context = RolloutLine {
         timestamp: "2025-01-03T13:00:01Z".to_string(),
         item: RolloutItem::TurnContext(TurnContextItem {
@@ -1104,8 +1105,8 @@ async fn resume_candidate_matches_cwd_reads_latest_turn_context() -> std::io::Re
             current_date: None,
             timezone: None,
             approval_policy: AskForApproval::Never,
-            sandbox_policy: SandboxPolicy::new_read_only_policy(),
-            permission_profile: None,
+            sandbox_policy: permission_profile.to_legacy_sandbox_policy(latest_cwd.as_path())?,
+            permission_profile: Some(permission_profile),
             network: None,
             file_system_sandbox_policy: None,
             model: "test-model".to_string(),


### PR DESCRIPTION
## Why

One rollout recorder test still built a `TurnContextItem` from `SandboxPolicy::new_read_only_policy()` even though the runtime permission model now has direct read-only profile construction. That kept a small test-only dependency on the legacy type and made the fixture less representative of current turn context data.

## What Changed

- Seeded the recorder test fixture from `PermissionProfile::read_only()`.
- Derived the required legacy `sandbox_policy` compatibility field from that profile.
- Populated `TurnContextItem.permission_profile` in the fixture so the test exercises the current rollout shape.

## Verification

- `cargo test -p codex-rollout resume_candidate_matches_cwd_reads_latest_turn_context -- --nocapture`















































---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20404).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* __->__ #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373