### PR TITLE
analytics tests: derive sandbox fixtures from profiles

### DIFF
--- a/codex-rs/analytics/src/analytics_client_tests.rs
+++ b/codex-rs/analytics/src/analytics_client_tests.rs
@@ -66,7 +66,6 @@ use codex_app_server_protocol::InitializeParams;
 use codex_app_server_protocol::JSONRPCErrorError;
 use codex_app_server_protocol::NonSteerableTurnKind;
 use codex_app_server_protocol::RequestId;
-use codex_app_server_protocol::SandboxPolicy as AppServerSandboxPolicy;
 use codex_app_server_protocol::ServerNotification;
 use codex_app_server_protocol::SessionSource as AppServerSessionSource;
 use codex_app_server_protocol::Thread;
@@ -106,6 +105,7 @@ use codex_utils_absolute_path::test_support::test_path_buf;
 use pretty_assertions::assert_eq;
 use serde_json::json;
 use std::collections::HashSet;
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -155,7 +155,10 @@ fn sample_thread_start_response(
         instruction_sources: Vec::new(),
         approval_policy: AppServerAskForApproval::OnFailure,
         approvals_reviewer: AppServerApprovalsReviewer::User,
-        sandbox: AppServerSandboxPolicy::DangerFullAccess,
+        sandbox: CorePermissionProfile::Disabled
+            .to_legacy_sandbox_policy(Path::new("/"))
+            .expect("disabled profile should project to legacy sandbox")
+            .into(),
         permission_profile: None,
         active_permission_profile: None,
         reasoning_effort: None,
@@ -209,7 +212,10 @@ fn sample_thread_resume_response_with_source(
         instruction_sources: Vec::new(),
         approval_policy: AppServerAskForApproval::OnFailure,
         approvals_reviewer: AppServerApprovalsReviewer::User,
-        sandbox: AppServerSandboxPolicy::DangerFullAccess,
+        sandbox: CorePermissionProfile::Disabled
+            .to_legacy_sandbox_policy(Path::new("/"))
+            .expect("disabled profile should project to legacy sandbox")
+            .into(),
         permission_profile: None,
         active_permission_profile: None,
         reasoning_effort: None,

--- a/codex-rs/analytics/src/client_tests.rs
+++ b/codex-rs/analytics/src/client_tests.rs
@@ -7,7 +7,6 @@ use codex_app_server_protocol::ClientRequest;
 use codex_app_server_protocol::ClientResponsePayload;
 use codex_app_server_protocol::PermissionProfile as AppServerPermissionProfile;
 use codex_app_server_protocol::RequestId;
-use codex_app_server_protocol::SandboxPolicy as AppServerSandboxPolicy;
 use codex_app_server_protocol::SessionSource as AppServerSessionSource;
 use codex_app_server_protocol::Thread;
 use codex_app_server_protocol::ThreadArchiveParams;
@@ -26,6 +25,7 @@ use codex_protocol::models::PermissionProfile as CorePermissionProfile;
 use codex_utils_absolute_path::test_support::PathBufExt;
 use codex_utils_absolute_path::test_support::test_path_buf;
 use std::collections::HashSet;
+use std::path::Path;
 use std::sync::Arc;
 use std::sync::Mutex;
 use tokio::sync::mpsc;
@@ -109,7 +109,10 @@ fn sample_thread_start_response() -> ClientResponsePayload {
         instruction_sources: Vec::new(),
         approval_policy: AppServerAskForApproval::OnFailure,
         approvals_reviewer: AppServerApprovalsReviewer::User,
-        sandbox: AppServerSandboxPolicy::DangerFullAccess,
+        sandbox: CorePermissionProfile::Disabled
+            .to_legacy_sandbox_policy(Path::new("/"))
+            .expect("disabled profile should project to legacy sandbox")
+            .into(),
         permission_profile: Some(sample_permission_profile()),
         active_permission_profile: None,
         reasoning_effort: None,
@@ -126,7 +129,10 @@ fn sample_thread_resume_response() -> ClientResponsePayload {
         instruction_sources: Vec::new(),
         approval_policy: AppServerAskForApproval::OnFailure,
         approvals_reviewer: AppServerApprovalsReviewer::User,
-        sandbox: AppServerSandboxPolicy::DangerFullAccess,
+        sandbox: CorePermissionProfile::Disabled
+            .to_legacy_sandbox_policy(Path::new("/"))
+            .expect("disabled profile should project to legacy sandbox")
+            .into(),
         permission_profile: Some(sample_permission_profile()),
         active_permission_profile: None,
         reasoning_effort: None,
@@ -143,7 +149,10 @@ fn sample_thread_fork_response() -> ClientResponsePayload {
         instruction_sources: Vec::new(),
         approval_policy: AppServerAskForApproval::OnFailure,
         approvals_reviewer: AppServerApprovalsReviewer::User,
-        sandbox: AppServerSandboxPolicy::DangerFullAccess,
+        sandbox: CorePermissionProfile::Disabled
+            .to_legacy_sandbox_policy(Path::new("/"))
+            .expect("disabled profile should project to legacy sandbox")
+            .into(),
         permission_profile: Some(sample_permission_profile()),
         active_permission_profile: None,
         reasoning_effort: None,


### PR DESCRIPTION
## Why

The analytics tests only need app-server response fixtures, but those fixtures still named the app-server `SandboxPolicy` enum directly. That is boundary compatibility baggage: the response still has a required legacy `sandbox` field, but the fixture intent is that the session is using disabled permissions.

## What Changed

- Removed direct `SandboxPolicy` imports from analytics tests.
- Derived the required legacy `sandbox` fixture value from `CorePermissionProfile::Disabled` instead of constructing `DangerFullAccess` directly.
- `rg '\bSandboxPolicy\b' codex-rs/analytics/src` no longer matches anything.

## Verification

```shell
cargo test -p codex-analytics --no-run
```









































---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20408).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* __->__ #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373