### PR TITLE
session tests: configure permissions with profiles

### DIFF
--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -47,7 +47,6 @@ use codex_protocol::permissions::FileSystemSandboxPolicy;
 use codex_protocol::permissions::FileSystemSpecialPath;
 use codex_protocol::permissions::NetworkSandboxPolicy;
 use codex_protocol::protocol::NonSteerableTurnKind;
-use codex_protocol::protocol::SandboxPolicy;
 use codex_protocol::request_permissions::PermissionGrantScope;
 use codex_protocol::request_permissions::RequestPermissionProfile;
 use tracing::Span;
@@ -1588,19 +1587,15 @@ async fn record_initial_history_reconstructs_forked_transcript() {
 async fn session_configured_reports_permission_profile_for_external_sandbox() -> anyhow::Result<()>
 {
     let server = start_mock_server().await;
-    let sandbox_policy = SandboxPolicy::ExternalSandbox {
-        network_access: codex_protocol::protocol::NetworkAccess::Restricted,
-    };
     let expected_permission_profile = PermissionProfile::External {
         network: NetworkSandboxPolicy::Restricted,
     };
     let config_permission_profile = expected_permission_profile.clone();
     let mut builder = test_codex().with_config(move |config| {
-        config.permissions.permission_profile =
-            codex_config::Constrained::allow_any(config_permission_profile);
         config
-            .set_legacy_sandbox_policy(sandbox_policy)
-            .expect("set sandbox policy");
+            .permissions
+            .set_permission_profile(config_permission_profile)
+            .expect("set permission profile");
     });
 
     let test = builder.build(&server).await?;
@@ -3029,7 +3024,7 @@ async fn session_configuration_apply_permission_profile_accepts_direct_write_roo
     let file_system_sandbox_policy =
         FileSystemSandboxPolicy::restricted(vec![FileSystemSandboxEntry {
             path: FileSystemPath::Path {
-                path: external_write_path.clone(),
+                path: external_write_path,
             },
             access: FileSystemAccessMode::Write,
         }]);
@@ -3052,12 +3047,12 @@ async fn session_configuration_apply_permission_profile_accepts_direct_write_roo
     );
     assert_eq!(
         updated.sandbox_policy(),
-        SandboxPolicy::WorkspaceWrite {
-            writable_roots: vec![external_write_path],
-            network_access: false,
-            exclude_tmpdir_env_var: true,
-            exclude_slash_tmp: true,
-        }
+        codex_sandboxing::compatibility_sandbox_policy_for_permission_profile(
+            &permission_profile,
+            &file_system_sandbox_policy,
+            NetworkSandboxPolicy::Restricted,
+            session_configuration.cwd.as_path(),
+        )
     );
 }
 
@@ -3154,21 +3149,24 @@ async fn session_configuration_apply_rederives_legacy_file_system_policy_on_cwd_
     let project_root = workspace.path().join("project");
     let original_cwd = project_root.join("subdir");
     session_configuration.cwd = original_cwd.abs();
-    let sandbox_policy = SandboxPolicy::WorkspaceWrite {
-        writable_roots: Vec::new(),
-        network_access: false,
-        exclude_tmpdir_env_var: true,
-        exclude_slash_tmp: true,
-    };
+    let permission_profile = PermissionProfile::workspace_write_with(
+        &[],
+        NetworkSandboxPolicy::Restricted,
+        /*exclude_tmpdir_env_var*/ true,
+        /*exclude_slash_tmp*/ true,
+    );
+    let sandbox_policy = permission_profile
+        .to_legacy_sandbox_policy(session_configuration.cwd.as_path())
+        .expect("workspace profile should project to legacy sandbox");
     let file_system_sandbox_policy = FileSystemSandboxPolicy::from_legacy_sandbox_policy_for_cwd(
         &sandbox_policy,
         &session_configuration.cwd,
     );
     session_configuration.permission_profile = codex_config::Constrained::allow_any(
         PermissionProfile::from_runtime_permissions_with_enforcement(
-            SandboxEnforcement::from_legacy_sandbox_policy(&sandbox_policy),
+            SandboxEnforcement::Managed,
             &file_system_sandbox_policy,
-            NetworkSandboxPolicy::from(&sandbox_policy),
+            NetworkSandboxPolicy::Restricted,
         ),
     );
 


### PR DESCRIPTION
## Why

A few `codex-core` session unit tests still constructed `SandboxPolicy` values directly even though the session configuration is now profile-backed. These tests should exercise the same `PermissionProfile` entry points that production config uses, while still verifying the legacy projection methods where compatibility behavior is the assertion.

## What Changed

- External sandbox session configuration now uses `config.permissions.set_permission_profile(...)` with `PermissionProfile::External`.
- Direct write-root and cwd-update session tests build the source permissions from `PermissionProfile` and only derive legacy values at the assertion/compatibility boundary.
- `rg '\bSandboxPolicy\b' codex-rs/core/src/session/tests.rs` no longer matches anything.

## Verification

```shell
cargo test -p codex-core --lib --no-run
```








































---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20409).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* __->__ #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373