### PR TITLE
windows read grants: accept permission profiles

### DIFF
--- a/codex-rs/core/src/windows_sandbox_read_grants.rs
+++ b/codex-rs/core/src/windows_sandbox_read_grants.rs
@@ -1,12 +1,13 @@
 use crate::windows_sandbox::run_setup_refresh_with_extra_read_roots;
 use anyhow::Result;
-use codex_protocol::protocol::SandboxPolicy;
+use codex_protocol::models::PermissionProfile;
+use codex_sandboxing::compatibility_sandbox_policy_for_permission_profile;
 use std::collections::HashMap;
 use std::path::Path;
 use std::path::PathBuf;
 
 pub fn grant_read_root_non_elevated(
-    policy: &SandboxPolicy,
+    permission_profile: &PermissionProfile,
     policy_cwd: &Path,
     command_cwd: &Path,
     env_map: &HashMap<String, String>,
@@ -24,8 +25,15 @@ pub fn grant_read_root_non_elevated(
     }
 
     let canonical_root = dunce::canonicalize(read_root)?;
+    let file_system_sandbox_policy = permission_profile.file_system_sandbox_policy();
+    let policy = compatibility_sandbox_policy_for_permission_profile(
+        permission_profile,
+        &file_system_sandbox_policy,
+        permission_profile.network_sandbox_policy(),
+        policy_cwd,
+    );
     run_setup_refresh_with_extra_read_roots(
-        policy,
+        &policy,
         policy_cwd,
         command_cwd,
         env_map,

--- a/codex-rs/core/src/windows_sandbox_read_grants_tests.rs
+++ b/codex-rs/core/src/windows_sandbox_read_grants_tests.rs
@@ -1,18 +1,18 @@
 use super::grant_read_root_non_elevated;
-use codex_protocol::protocol::SandboxPolicy;
+use codex_protocol::models::PermissionProfile;
 use std::collections::HashMap;
 use std::path::Path;
 use tempfile::TempDir;
 
-fn policy() -> SandboxPolicy {
-    SandboxPolicy::new_workspace_write_policy()
+fn permission_profile() -> PermissionProfile {
+    PermissionProfile::workspace_write()
 }
 
 #[test]
 fn rejects_relative_path() {
     let tmp = TempDir::new().expect("tempdir");
     let err = grant_read_root_non_elevated(
-        &policy(),
+        &permission_profile(),
         tmp.path(),
         tmp.path(),
         &HashMap::new(),
@@ -28,7 +28,7 @@ fn rejects_missing_path() {
     let tmp = TempDir::new().expect("tempdir");
     let missing = tmp.path().join("does-not-exist");
     let err = grant_read_root_non_elevated(
-        &policy(),
+        &permission_profile(),
         tmp.path(),
         tmp.path(),
         &HashMap::new(),
@@ -45,7 +45,7 @@ fn rejects_file_path() {
     let file_path = tmp.path().join("file.txt");
     std::fs::write(&file_path, "hello").expect("write file");
     let err = grant_read_root_non_elevated(
-        &policy(),
+        &permission_profile(),
         tmp.path(),
         tmp.path(),
         &HashMap::new(),

--- a/codex-rs/tui/src/app/event_dispatch.rs
+++ b/codex-rs/tui/src/app/event_dispatch.rs
@@ -883,10 +883,7 @@ impl App {
                             /*hint*/ None,
                         ));
 
-                    let policy = self
-                        .config
-                        .permissions
-                        .legacy_sandbox_policy(self.config.cwd.as_path());
+                    let permission_profile = self.config.permissions.permission_profile();
                     let policy_cwd = self.config.cwd.clone();
                     let command_cwd = self.config.cwd.clone();
                     let env_map: std::collections::HashMap<String, String> =
@@ -897,7 +894,7 @@ impl App {
                     tokio::task::spawn_blocking(move || {
                         let requested_path = PathBuf::from(path);
                         let event = match crate::legacy_core::grant_read_root_non_elevated(
-                            &policy,
+                            &permission_profile,
                             policy_cwd.as_path(),
                             command_cwd.as_path(),
                             &env_map,


### PR DESCRIPTION
## Why

Continuing the SandboxPolicy migration, the Windows read-root grant path should not require callers to materialize a legacy policy just to refresh Windows sandbox setup. The Windows setup API is still a legacy boundary, but the compatibility projection can live at that boundary.

## What Changed

- Changed `grant_read_root_non_elevated()` to accept a canonical `PermissionProfile`.
- Derives the legacy-compatible Windows setup policy inside the helper, immediately before calling the Windows sandbox setup refresh API.
- Updated the TUI grant-read-root event path to pass `config.permissions.permission_profile()` instead of `config.permissions.legacy_sandbox_policy(...)`.
- Updated read-root grant tests to use `PermissionProfile::workspace_write()` fixtures instead of constructing `SandboxPolicy` directly.

## Verification

- `cargo test -p codex-core --lib windows_sandbox_read_grants`
- `cargo test -p codex-tui --lib --no-run`
- `just fmt`
- `just fix -p codex-core -p codex-tui`







































---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20410).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* __->__ #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373