### PR TITLE
exec tests: derive thread sandbox from profile

### DIFF
--- a/codex-rs/exec/src/lib_tests.rs
+++ b/codex-rs/exec/src/lib_tests.rs
@@ -460,6 +460,13 @@ async fn session_configured_from_thread_response_uses_permission_profile_from_re
 }
 
 fn sample_thread_start_response() -> ThreadStartResponse {
+    let cwd = test_path_buf("/tmp").abs();
+    let permission_profile = PermissionProfile::workspace_write();
+    let sandbox = permission_profile
+        .to_legacy_sandbox_policy(cwd.as_path())
+        .expect("workspace profile should have a legacy projection")
+        .into();
+
     ThreadStartResponse {
         thread: codex_app_server_protocol::Thread {
             id: "67e55044-10b1-426f-9247-bb680e5fe0c8".to_string(),
@@ -471,7 +478,7 @@ fn sample_thread_start_response() -> ThreadStartResponse {
             updated_at: 0,
             status: codex_app_server_protocol::ThreadStatus::Idle,
             path: Some(PathBuf::from("/tmp/rollout.jsonl")),
-            cwd: test_path_buf("/tmp").abs(),
+            cwd: cwd.clone(),
             cli_version: "0.0.0".to_string(),
             source: codex_app_server_protocol::SessionSource::Cli,
             agent_nickname: None,
@@ -483,16 +490,11 @@ fn sample_thread_start_response() -> ThreadStartResponse {
         model: "gpt-5.4".to_string(),
         model_provider: "openai".to_string(),
         service_tier: None,
-        cwd: test_path_buf("/tmp").abs(),
+        cwd,
         instruction_sources: Vec::new(),
         approval_policy: codex_app_server_protocol::AskForApproval::OnRequest,
         approvals_reviewer: codex_app_server_protocol::ApprovalsReviewer::AutoReview,
-        sandbox: codex_app_server_protocol::SandboxPolicy::WorkspaceWrite {
-            writable_roots: vec![],
-            network_access: false,
-            exclude_tmpdir_env_var: false,
-            exclude_slash_tmp: false,
-        },
+        sandbox,
         permission_profile: None,
         active_permission_profile: None,
         reasoning_effort: None,


### PR DESCRIPTION
## Why

This is another test-fixture step in the SandboxPolicy migration. The app-server response fixture still has to include the legacy `sandbox` field because that is part of the current response shape, but the test should not hand-author that legacy value when the canonical profile can derive it.

## What Changed

- Builds the sample thread-start response from a `PermissionProfile::workspace_write()` fixture.
- Derives the required legacy app-server `sandbox` field from that profile at the response boundary.
- Removes the last direct `SandboxPolicy` reference from `codex-rs/exec/src/lib_tests.rs`.

## Verification

- `cargo test -p codex-exec --lib --no-run`
- `just fmt`
- `just fix -p codex-exec`






































---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20411).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* __->__ #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373