### PR TITLE
windows setup: derive sandbox from permission profile

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -8072,9 +8072,7 @@ impl CodexMessageProcessor {
                 Ok(config) => {
                     let setup_request = WindowsSandboxSetupRequest {
                         mode,
-                        policy: config
-                            .permissions
-                            .legacy_sandbox_policy(config.cwd.as_path()),
+                        permission_profile: config.permissions.permission_profile(),
                         policy_cwd: config.cwd.to_path_buf(),
                         command_cwd,
                         env_map: std::env::vars().collect(),

--- a/codex-rs/core/src/windows_sandbox.rs
+++ b/codex-rs/core/src/windows_sandbox.rs
@@ -9,7 +9,9 @@ use codex_features::FeaturesToml;
 use codex_login::default_client::originator;
 use codex_otel::sanitize_metric_tag_value;
 use codex_protocol::config_types::WindowsSandboxLevel;
+use codex_protocol::models::PermissionProfile;
 use codex_protocol::protocol::SandboxPolicy;
+use codex_sandboxing::compatibility_sandbox_policy_for_permission_profile;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::path::Path;
@@ -272,7 +274,7 @@ pub enum WindowsSandboxSetupMode {
 #[derive(Debug, Clone)]
 pub struct WindowsSandboxSetupRequest {
     pub mode: WindowsSandboxSetupMode,
-    pub policy: SandboxPolicy,
+    pub permission_profile: PermissionProfile,
     pub policy_cwd: PathBuf,
     pub command_cwd: PathBuf,
     pub env_map: HashMap<String, String>,
@@ -311,13 +313,20 @@ async fn run_windows_sandbox_setup_and_persist(
     request: WindowsSandboxSetupRequest,
 ) -> anyhow::Result<()> {
     let mode = request.mode;
-    let policy = request.policy;
+    let permission_profile = request.permission_profile;
     let policy_cwd = request.policy_cwd;
     let command_cwd = request.command_cwd;
     let env_map = request.env_map;
     let codex_home = request.codex_home;
     let active_profile = request.active_profile;
     let setup_codex_home = codex_home.clone();
+    let file_system_sandbox_policy = permission_profile.file_system_sandbox_policy();
+    let policy = compatibility_sandbox_policy_for_permission_profile(
+        &permission_profile,
+        &file_system_sandbox_policy,
+        permission_profile.network_sandbox_policy(),
+        policy_cwd.as_path(),
+    );
 
     let setup_result = tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
         match mode {


### PR DESCRIPTION
## Why

Windows sandbox setup still has to call legacy Windows sandbox APIs that accept `SandboxPolicy`, but app-server should not be responsible for deriving that compatibility policy. Keeping the projection in core makes `PermissionProfile` the handoff type and confines the old abstraction to the Windows setup boundary.

## What Changed

- Changed `WindowsSandboxSetupRequest` to carry `permission_profile` instead of a precomputed legacy policy.
- Derives the compatibility `SandboxPolicy` inside `run_windows_sandbox_setup_and_persist()` using the setup `policy_cwd`.
- Updated app-server Windows setup handling to pass `config.permissions.permission_profile()` directly.

## Verification

- `cargo test -p codex-core --lib windows_sandbox --no-run`
- `cargo test -p codex-app-server --lib --no-run`
- `just fmt`
- `just fix -p codex-core -p codex-app-server`




































---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20412).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* __->__ #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373