### PR TITLE
test support: derive turn sandbox from permission profiles

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -4161,6 +4161,7 @@ dependencies = [
  "codex-model-provider-info",
  "codex-models-manager",
  "codex-protocol",
+ "codex-sandboxing",
  "codex-utils-absolute-path",
  "codex-utils-cargo-bin",
  "ctor 0.6.3",

--- a/codex-rs/core/tests/common/Cargo.toml
+++ b/codex-rs/core/tests/common/Cargo.toml
@@ -23,6 +23,7 @@ codex-login = { workspace = true }
 codex-model-provider-info = { workspace = true }
 codex-models-manager = { workspace = true }
 codex-protocol = { workspace = true }
+codex-sandboxing = { workspace = true }
 codex-utils-absolute-path = { workspace = true }
 codex-utils-cargo-bin = { workspace = true }
 ctor = { workspace = true }

--- a/codex-rs/core/tests/common/test_codex.rs
+++ b/codex-rs/core/tests/common/test_codex.rs
@@ -39,6 +39,7 @@ use codex_protocol::protocol::SessionConfiguredEvent;
 use codex_protocol::protocol::SessionSource;
 use codex_protocol::protocol::TurnEnvironmentSelection;
 use codex_protocol::user_input::UserInput;
+use codex_sandboxing::compatibility_sandbox_policy_for_permission_profile;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use futures::future::BoxFuture;
 use serde_json::Value;
@@ -209,9 +210,13 @@ pub fn turn_permission_fields(
     permission_profile: PermissionProfile,
     cwd: &Path,
 ) -> (SandboxPolicy, Option<PermissionProfile>) {
-    let sandbox_policy = permission_profile
-        .to_legacy_sandbox_policy(cwd)
-        .unwrap_or_else(|_| SandboxPolicy::new_read_only_policy());
+    let file_system_sandbox_policy = permission_profile.file_system_sandbox_policy();
+    let sandbox_policy = compatibility_sandbox_policy_for_permission_profile(
+        &permission_profile,
+        &file_system_sandbox_policy,
+        permission_profile.network_sandbox_policy(),
+        cwd,
+    );
     (sandbox_policy, Some(permission_profile))
 }
 


### PR DESCRIPTION
## Why

`turn_permission_fields()` is the common test helper for building direct `Op::UserTurn` payloads from a `PermissionProfile`. It still used the strict `to_legacy_sandbox_policy()` bridge and silently downgraded unbridgeable profiles to read-only. That made tests less faithful to the permission profile they were exercising.

## What Changed

- Derives the legacy `sandbox_policy` compatibility field with `compatibility_sandbox_policy_for_permission_profile()` instead of falling back to read-only.
- Adds `codex-sandboxing` as an internal test-support dependency so the helper uses the same compatibility projection as production code.
- Keeps `permission_profile` on the turn unchanged, preserving the canonical permission payload while still filling the legacy field required by `Op::UserTurn`.

## Verification

- `cargo test -p codex-core --tests --no-run`
- `just bazel-lock-update`
- `just bazel-lock-check`
- `just fix -p codex-core`



































---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20414).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* __->__ #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373