### PR TITLE
tui: centralize legacy sandbox projection

### DIFF
--- a/codex-rs/tui/src/app/event_dispatch.rs
+++ b/codex-rs/tui/src/app/event_dispatch.rs
@@ -746,18 +746,10 @@ impl App {
                     self.chat_widget.show_windows_sandbox_setup_status();
                     self.windows_sandbox.setup_started_at = Some(Instant::now());
                     let session_telemetry = self.session_telemetry.clone();
-                    let Ok(policy) = permission_profile
-                        .to_legacy_sandbox_policy(policy_cwd.as_path())
-                        .inspect_err(|err| {
-                            tracing::error!(
-                                %err,
-                                "approval preset permissions cannot be projected for elevated Windows sandbox setup"
-                            );
-                        })
-                    else {
-                        tx.send(AppEvent::OpenWindowsSandboxFallbackPrompt { preset });
-                        return Ok(AppRunControl::Continue);
-                    };
+                    let policy = crate::permission_compat::legacy_compatible_sandbox_policy(
+                        &permission_profile,
+                        policy_cwd.as_path(),
+                    );
                     tokio::task::spawn_blocking(move || {
                         let result = crate::legacy_core::windows_sandbox::run_elevated_setup(
                             &policy,
@@ -831,18 +823,10 @@ impl App {
                     let session_telemetry = self.session_telemetry.clone();
 
                     self.chat_widget.show_windows_sandbox_setup_status();
-                    let Ok(policy) = permission_profile
-                        .to_legacy_sandbox_policy(policy_cwd.as_path())
-                        .inspect_err(|err| {
-                            tracing::error!(
-                                %err,
-                                "approval preset permissions cannot be projected for legacy Windows sandbox setup"
-                            );
-                        })
-                    else {
-                        tx.send(AppEvent::OpenWindowsSandboxFallbackPrompt { preset });
-                        return Ok(AppRunControl::Continue);
-                    };
+                    let policy = crate::permission_compat::legacy_compatible_sandbox_policy(
+                        &permission_profile,
+                        policy_cwd.as_path(),
+                    );
                     tokio::task::spawn_blocking(move || {
                         if let Err(err) =
                             crate::legacy_core::windows_sandbox::run_legacy_setup_preflight(

--- a/codex-rs/tui/src/app/platform_actions.rs
+++ b/codex-rs/tui/src/app/platform_actions.rs
@@ -21,10 +21,10 @@ impl App {
         permission_profile: PermissionProfile,
         tx: AppEventSender,
     ) {
-        let Ok(sandbox_policy) = permission_profile.to_legacy_sandbox_policy(cwd.as_path()) else {
-            send_world_writable_scan_failed(&tx);
-            return;
-        };
+        let sandbox_policy = crate::permission_compat::legacy_compatible_sandbox_policy(
+            &permission_profile,
+            cwd.as_path(),
+        );
 
         tokio::task::spawn_blocking(move || {
             let logs_base_dir_path = logs_base_dir.as_path();

--- a/codex-rs/tui/src/app_command.rs
+++ b/codex-rs/tui/src/app_command.rs
@@ -24,7 +24,7 @@ use codex_protocol::user_input::UserInput;
 use serde::Serialize;
 use serde_json::Value;
 
-use crate::permission_compat::legacy_compatible_permission_profile;
+use crate::permission_compat::legacy_compatible_sandbox_policy;
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -371,15 +371,8 @@ impl AppCommand {
                 collaboration_mode,
                 personality,
             } => {
-                let legacy_profile =
-                    legacy_compatible_permission_profile(&permission_profile, cwd.as_path());
-                let sandbox_policy = legacy_profile
-                    .to_legacy_sandbox_policy(cwd.as_path())
-                    .unwrap_or_else(|err| {
-                        unreachable!(
-                            "legacy-compatible permissions must project to legacy policy: {err}"
-                        )
-                    });
+                let sandbox_policy =
+                    legacy_compatible_sandbox_policy(&permission_profile, cwd.as_path());
                 Op::UserTurn {
                     items,
                     environments: None,
@@ -613,9 +606,8 @@ impl From<Op> for AppCommand {
                 personality,
             } => {
                 if environments.is_none()
-                    && legacy_compatible_permission_profile(&permission_profile, cwd.as_path())
-                        .to_legacy_sandbox_policy(cwd.as_path())
-                        .is_ok_and(|compatible_policy| compatible_policy == sandbox_policy)
+                    && legacy_compatible_sandbox_policy(&permission_profile, cwd.as_path())
+                        == sandbox_policy
                 {
                     Self::UserTurn {
                         items,

--- a/codex-rs/tui/src/app_server_session.rs
+++ b/codex-rs/tui/src/app_server_session.rs
@@ -3,7 +3,7 @@ use crate::bottom_pane::FeedbackAudience;
 use crate::legacy_core::append_message_history_entry;
 use crate::legacy_core::config::Config;
 use crate::legacy_core::message_history_metadata;
-use crate::permission_compat::legacy_compatible_permission_profile;
+use crate::permission_compat::legacy_compatible_sandbox_policy;
 use crate::status::StatusAccountDisplay;
 use crate::status::plan_type_display_name;
 use codex_app_server_client::AppServerClient;
@@ -1159,15 +1159,7 @@ fn turn_permissions_overrides(
     };
     let sandbox_policy = (matches!(thread_params_mode, ThreadParamsMode::Remote)
         || permissions.is_none())
-    .then(|| {
-        let legacy_profile = legacy_compatible_permission_profile(permission_profile, cwd);
-        let policy = legacy_profile
-            .to_legacy_sandbox_policy(cwd)
-            .unwrap_or_else(|err| {
-                unreachable!("legacy-compatible permissions must project to legacy policy: {err}")
-            });
-        policy.into()
-    });
+    .then(|| legacy_compatible_sandbox_policy(permission_profile, cwd).into());
     (sandbox_policy, permissions)
 }
 

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -9682,14 +9682,11 @@ impl ChatWidget {
         }
         let cwd = self.config.cwd.clone();
         let env_map: std::collections::HashMap<String, String> = std::env::vars().collect();
-        let Ok(policy) = self
-            .config
-            .permissions
-            .permission_profile()
-            .to_legacy_sandbox_policy(self.config.cwd.as_path())
-        else {
-            return Some((Vec::new(), 0, true));
-        };
+        let permission_profile = self.config.permissions.permission_profile();
+        let policy = crate::permission_compat::legacy_compatible_sandbox_policy(
+            &permission_profile,
+            self.config.cwd.as_path(),
+        );
         match codex_windows_sandbox::apply_world_writable_scan_and_denies(
             self.config.codex_home.as_path(),
             cwd.as_path(),

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -2210,9 +2210,10 @@ mod tests {
             .clone()
             .unwrap_or_else(|| "gpt-5.1".to_string());
         let permission_profile = config.permissions.permission_profile();
-        let sandbox_policy = permission_profile
-            .to_legacy_sandbox_policy(config.cwd.as_path())
-            .expect("configured permissions must have a legacy compatibility projection");
+        let sandbox_policy = permission_compat::legacy_compatible_sandbox_policy(
+            &permission_profile,
+            config.cwd.as_path(),
+        );
         TurnContextItem {
             turn_id: None,
             trace_id: None,

--- a/codex-rs/tui/src/permission_compat.rs
+++ b/codex-rs/tui/src/permission_compat.rs
@@ -4,8 +4,20 @@
 use codex_protocol::models::PermissionProfile;
 use codex_protocol::permissions::FileSystemSandboxPolicy;
 use codex_protocol::permissions::NetworkSandboxPolicy;
+use codex_protocol::protocol::SandboxPolicy;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use std::path::Path;
+
+pub(crate) fn legacy_compatible_sandbox_policy(
+    permission_profile: &PermissionProfile,
+    cwd: &Path,
+) -> SandboxPolicy {
+    legacy_compatible_permission_profile(permission_profile, cwd)
+        .to_legacy_sandbox_policy(cwd)
+        .unwrap_or_else(|err| {
+            unreachable!("legacy-compatible permissions must project to legacy policy: {err}")
+        })
+}
 
 pub(crate) fn legacy_compatible_permission_profile(
     permission_profile: &PermissionProfile,


### PR DESCRIPTION
## Summary

Centralizes the TUI's compatibility projection from canonical `PermissionProfile` values to legacy `SandboxPolicy` values in `permission_compat`.

This updates the remaining runtime TUI paths that still need a legacy sandbox field, including user-turn conversion, app-server thread parameter projection, app turn context construction, Windows sandbox setup, and the world-writable scan.

## Why

The TUI now carries permissions as `PermissionProfile`, but a few downstream boundaries still require `SandboxPolicy`. Some profile-backed permissions are valid and enforceable even when they cannot be represented by the strict legacy bridge. Those paths should project through the compatibility profile helper rather than fail, downgrade, or duplicate conversion logic at each callsite.

This keeps the `PermissionProfile` as the source of truth inside the TUI while limiting legacy projection to explicit compatibility boundaries.

## Verification

- `just fmt`
- `cargo test -p codex-tui permission_compat`
- `cargo test -p codex-tui turn_permissions_overrides`
- `cargo test -p codex-tui app_command`
- `cargo test -p codex-tui --lib --no-run`
- `just fix -p codex-tui`

I also tried `cargo test -p codex-tui`; it hit a local stack overflow in `attach_live_thread_for_selection_rejects_unmaterialized_fallback_threads`, which also reproduces when run by itself and appears unrelated to this patch.


































---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20420).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* __->__ #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373