### PR TITLE
thread-store: stop exposing legacy sandbox policy

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -9912,7 +9912,6 @@ mod tests {
     use codex_protocol::permissions::FileSystemSandboxEntry;
     use codex_protocol::permissions::NetworkSandboxPolicy;
     use codex_protocol::protocol::AskForApproval;
-    use codex_protocol::protocol::SandboxPolicy;
     use codex_protocol::protocol::SessionSource;
     use codex_protocol::protocol::SubAgentSource;
     use codex_thread_store::StoredThread;
@@ -10094,7 +10093,6 @@ mod tests {
             agent_path: None,
             git_info: None,
             approval_mode: AskForApproval::OnRequest,
-            sandbox_policy: SandboxPolicy::new_read_only_policy(),
             token_usage: None,
             first_user_message: Some("first user message".to_string()),
             history: None,

--- a/codex-rs/core/src/realtime_context_tests.rs
+++ b/codex-rs/core/src/realtime_context_tests.rs
@@ -13,7 +13,6 @@ use chrono::Utc;
 use codex_git_utils::GitSha;
 use codex_protocol::ThreadId;
 use codex_protocol::models::ContentItem;
-use codex_protocol::models::PermissionProfile;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::GitInfo;
@@ -28,8 +27,6 @@ use std::process::Command;
 use tempfile::TempDir;
 
 fn stored_thread(cwd: &str, title: &str, first_user_message: &str) -> StoredThread {
-    let permission_profile = PermissionProfile::read_only();
-
     StoredThread {
         thread_id: ThreadId::new(),
         rollout_path: Some(PathBuf::from("/tmp/rollout.jsonl")),
@@ -60,9 +57,6 @@ fn stored_thread(cwd: &str, title: &str, first_user_message: &str) -> StoredThre
             repository_url: None,
         }),
         approval_mode: AskForApproval::Never,
-        sandbox_policy: permission_profile
-            .to_legacy_sandbox_policy(std::path::Path::new(cwd))
-            .expect("read-only permission profile should have a legacy projection"),
         token_usage: None,
         first_user_message: Some(first_user_message.to_string()),
         history: None,

--- a/codex-rs/thread-store/src/in_memory.rs
+++ b/codex-rs/thread-store/src/in_memory.rs
@@ -10,7 +10,6 @@ use chrono::Utc;
 use codex_protocol::ThreadId;
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::RolloutItem;
-use codex_protocol::protocol::SandboxPolicy;
 
 use crate::AppendThreadItemsParams;
 use crate::ArchiveThreadParams;
@@ -277,7 +276,6 @@ fn stored_thread_from_state(
         agent_path: None,
         git_info: None,
         approval_mode: AskForApproval::Never,
-        sandbox_policy: SandboxPolicy::new_read_only_policy(),
         token_usage: None,
         first_user_message: None,
         history,

--- a/codex-rs/thread-store/src/local/helpers.rs
+++ b/codex-rs/thread-store/src/local/helpers.rs
@@ -11,7 +11,6 @@ use codex_git_utils::GitSha;
 use codex_protocol::ThreadId;
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::GitInfo;
-use codex_protocol::protocol::SandboxPolicy;
 use codex_protocol::protocol::SessionSource;
 use codex_rollout::ThreadItem;
 
@@ -126,7 +125,6 @@ pub(super) fn stored_thread_from_rollout_item(
         agent_path: None,
         git_info,
         approval_mode: AskForApproval::OnRequest,
-        sandbox_policy: SandboxPolicy::new_read_only_policy(),
         token_usage: None,
         first_user_message: item.first_user_message,
         history: None,

--- a/codex-rs/thread-store/src/local/read_thread.rs
+++ b/codex-rs/thread-store/src/local/read_thread.rs
@@ -1,7 +1,6 @@
 use chrono::DateTime;
 use chrono::Utc;
 use codex_protocol::protocol::AskForApproval;
-use codex_protocol::protocol::SandboxPolicy;
 use codex_protocol::protocol::SessionMetaLine;
 use codex_protocol::protocol::SessionSource;
 use codex_rollout::RolloutRecorder;
@@ -261,10 +260,6 @@ async fn stored_thread_from_sqlite_metadata(
             metadata.git_origin_url,
         ),
         approval_mode: parse_or_default(&metadata.approval_mode, AskForApproval::OnRequest),
-        sandbox_policy: parse_or_default(
-            &metadata.sandbox_policy,
-            SandboxPolicy::new_read_only_policy(),
-        ),
         token_usage: None,
         first_user_message: metadata.first_user_message,
         history: None,
@@ -327,7 +322,6 @@ fn stored_thread_from_meta_line(
         agent_path: meta_line.meta.agent_path,
         git_info: meta_line.git,
         approval_mode: AskForApproval::OnRequest,
-        sandbox_policy: SandboxPolicy::new_read_only_policy(),
         token_usage: None,
         first_user_message: None,
         history: None,

--- a/codex-rs/thread-store/src/remote/helpers.rs
+++ b/codex-rs/thread-store/src/remote/helpers.rs
@@ -12,7 +12,6 @@ use codex_protocol::openai_models::ReasoningEffort;
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::GitInfo;
 use codex_protocol::protocol::RolloutItem;
-use codex_protocol::protocol::SandboxPolicy;
 use codex_protocol::protocol::SessionSource;
 use codex_protocol::protocol::SubAgentSource;
 use codex_protocol::protocol::ThreadMemoryMode;
@@ -299,12 +298,6 @@ pub(super) fn stored_thread_from_proto(
             .map(|json| deserialize_json(json, "approval_mode"))
             .transpose()?
             .unwrap_or(AskForApproval::OnRequest),
-        sandbox_policy: thread
-            .sandbox_policy_json
-            .as_deref()
-            .map(|json| deserialize_json(json, "sandbox_policy"))
-            .transpose()?
-            .unwrap_or_else(SandboxPolicy::new_read_only_policy),
         token_usage: thread
             .token_usage_json
             .as_deref()
@@ -343,9 +336,7 @@ pub(super) fn stored_thread_to_proto(thread: StoredThread) -> proto::StoredThrea
             .rollout_path
             .map(|path| path.to_string_lossy().into_owned()),
         approval_mode_json: Some(serialize_json(&thread.approval_mode, "approval_mode").unwrap()),
-        sandbox_policy_json: Some(
-            serialize_json(&thread.sandbox_policy, "sandbox_policy").unwrap(),
-        ),
+        sandbox_policy_json: None,
         token_usage_json: thread
             .token_usage
             .as_ref()

--- a/codex-rs/thread-store/src/types.rs
+++ b/codex-rs/thread-store/src/types.rs
@@ -9,7 +9,6 @@ use codex_protocol::openai_models::ReasoningEffort;
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::GitInfo;
 use codex_protocol::protocol::RolloutItem;
-use codex_protocol::protocol::SandboxPolicy;
 use codex_protocol::protocol::SessionSource;
 use codex_protocol::protocol::ThreadMemoryMode as MemoryMode;
 use codex_protocol::protocol::TokenUsage;
@@ -204,8 +203,6 @@ pub struct StoredThread {
     pub git_info: Option<GitInfo>,
     /// Approval mode captured for the thread.
     pub approval_mode: AskForApproval,
-    /// Sandbox policy captured for the thread.
-    pub sandbox_policy: SandboxPolicy,
     /// Last observed token usage.
     pub token_usage: Option<TokenUsage>,
     /// First user message observed for this thread, if any.


### PR DESCRIPTION
## Summary

Removes the legacy `sandbox_policy` field from the thread-store domain model.

`StoredThread` summaries no longer parse, carry, or re-serialize `SandboxPolicy`; the field was only being populated from legacy metadata defaults and was not read by production callers. The remote thread-store proto field remains in place as an ignored wire-compatibility field, but the Rust domain object stops exposing it.

## Why

Thread metadata persistence still stores a legacy sandbox projection for older readers, but thread-store consumers should not treat that projection as canonical permission state. Removing it from `StoredThread` avoids carrying stale or lossy `SandboxPolicy` values through list/read paths while the migration continues around `PermissionProfile`.

This also reduces `SandboxPolicy` usage to zero under `codex-rs/thread-store/src`.

## Verification

- `just fmt`
- `cargo test -p codex-thread-store`
- `cargo test -p codex-core realtime_context`
- `cargo test -p codex-app-server summary_from_stored_thread_preserves_millisecond_precision`
- `just fix -p codex-thread-store -p codex-core -p codex-app-server`

































---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20421).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* __->__ #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373