### PR TITLE
mcp: send sandbox metadata as permission profile only

### DIFF
--- a/codex-rs/codex-mcp/src/runtime.rs
+++ b/codex-rs/codex-mcp/src/runtime.rs
@@ -11,7 +11,6 @@ use std::time::Duration;
 
 use codex_exec_server::Environment;
 use codex_protocol::models::PermissionProfile;
-use codex_protocol::protocol::SandboxPolicy;
 
 use serde::Deserialize;
 use serde::Serialize;
@@ -21,7 +20,6 @@ use serde::Serialize;
 pub struct SandboxState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub permission_profile: Option<PermissionProfile>,
-    pub sandbox_policy: SandboxPolicy,
     pub codex_linux_sandbox_exe: Option<PathBuf>,
     pub sandbox_cwd: PathBuf,
     #[serde(default)]

--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -578,7 +578,6 @@ async fn augment_mcp_tool_request_meta_with_sandbox_state(
 
     let sandbox_state = serde_json::to_value(SandboxState {
         permission_profile: Some(turn_context.permission_profile()),
-        sandbox_policy: turn_context.sandbox_policy(),
         codex_linux_sandbox_exe: turn_context.codex_linux_sandbox_exe.clone(),
         sandbox_cwd: turn_context.cwd.to_path_buf(),
         use_legacy_landlock: turn_context.features.use_legacy_landlock(),

--- a/codex-rs/core/tests/suite/rmcp_client.rs
+++ b/codex-rs/core/tests/suite/rmcp_client.rs
@@ -821,13 +821,11 @@ async fn stdio_mcp_tool_call_includes_sandbox_state_meta() -> anyhow::Result<()>
     let sandbox_meta = meta
         .get(MCP_SANDBOX_STATE_META_CAPABILITY)
         .expect("sandbox state metadata should be present");
-    let (sandbox_policy, _) =
-        turn_permission_fields(PermissionProfile::read_only(), fixture.config.cwd.as_path());
-    let expected_sandbox_policy = serde_json::to_value(&sandbox_policy)?;
     assert_eq!(
-        sandbox_meta.get("sandboxPolicy"),
-        Some(&expected_sandbox_policy)
+        sandbox_meta.get("permissionProfile"),
+        Some(&serde_json::to_value(PermissionProfile::read_only())?)
     );
+    assert_eq!(sandbox_meta.get("sandboxPolicy"), None);
     assert_eq!(
         sandbox_meta.get("sandboxCwd").and_then(Value::as_str),
         fixture.config.cwd.as_path().to_str()


### PR DESCRIPTION
## Summary

Removes the legacy `sandboxPolicy` field from MCP sandbox-state metadata.

MCP servers that opt into `codex/sandbox-state-meta` now receive the canonical `permissionProfile` plus the existing sandbox cwd, Linux sandbox path, and Landlock flag. The duplicated legacy compatibility projection is no longer serialized in `SandboxState`.

## Why

`SandboxState` already included `permissionProfile`, and the legacy `sandboxPolicy` projection is lossy for profiles with richer file-system rules. This keeps MCP metadata aligned with the permission-profile migration and removes `SandboxPolicy` usage from `codex-rs/codex-mcp/src`.

## Verification

- `just fmt`
- `cargo test -p codex-mcp`
- `cargo test -p codex-core --test all --no-run`
- `just fix -p codex-mcp -p codex-core`

I also tried `cargo test -p codex-core stdio_mcp_tool_call_includes_sandbox_state_meta`; the direct Cargo run failed before exercising the assertion because it could not locate the `test_stdio_server` helper binary. CI/Bazel provides that runfile setup.
































---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20422).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* __->__ #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373