### PR TITLE
app-server: compare resume sandbox from permission profile

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -8603,21 +8603,24 @@ fn collect_resume_override_mismatches(
         }
     }
     if let Some(requested_sandbox) = request.sandbox.as_ref() {
-        let active_sandbox = config_snapshot.sandbox_policy();
+        let active_sandbox = thread_response_sandbox_policy(
+            &config_snapshot.permission_profile,
+            config_snapshot.cwd.as_path(),
+        );
         let sandbox_matches = matches!(
             (requested_sandbox, &active_sandbox),
             (
                 SandboxMode::ReadOnly,
-                codex_protocol::protocol::SandboxPolicy::ReadOnly { .. }
+                codex_app_server_protocol::SandboxPolicy::ReadOnly { .. }
             ) | (
                 SandboxMode::WorkspaceWrite,
-                codex_protocol::protocol::SandboxPolicy::WorkspaceWrite { .. }
+                codex_app_server_protocol::SandboxPolicy::WorkspaceWrite { .. }
             ) | (
                 SandboxMode::DangerFullAccess,
-                codex_protocol::protocol::SandboxPolicy::DangerFullAccess
+                codex_app_server_protocol::SandboxPolicy::DangerFullAccess
             ) | (
                 SandboxMode::DangerFullAccess,
-                codex_protocol::protocol::SandboxPolicy::ExternalSandbox { .. }
+                codex_app_server_protocol::SandboxPolicy::ExternalSandbox { .. }
             )
         );
         if !sandbox_matches {

--- a/codex-rs/core/src/codex_thread.rs
+++ b/codex-rs/core/src/codex_thread.rs
@@ -57,18 +57,6 @@ pub struct ThreadConfigSnapshot {
     pub session_source: SessionSource,
 }
 
-impl ThreadConfigSnapshot {
-    pub fn sandbox_policy(&self) -> SandboxPolicy {
-        let file_system_sandbox_policy = self.permission_profile.file_system_sandbox_policy();
-        codex_sandboxing::compatibility_sandbox_policy_for_permission_profile(
-            &self.permission_profile,
-            &file_system_sandbox_policy,
-            self.permission_profile.network_sandbox_policy(),
-            self.cwd.as_path(),
-        )
-    }
-}
-
 /// Turn context overrides that app-server validates before starting a turn.
 #[derive(Clone, Default)]
 pub struct CodexThreadTurnContextOverrides {

--- a/codex-rs/core/src/tools/handlers/multi_agents_tests.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_tests.rs
@@ -1783,7 +1783,6 @@ async fn spawn_agent_reapplies_runtime_sandbox_after_role_config() {
     let (mut session, mut turn) = make_session_and_context().await;
     let manager = thread_manager();
     session.services.agent_control = manager.agent_control();
-    let expected_sandbox = turn.config.legacy_sandbox_policy();
     let mut expected_permission_profile = turn.config.permissions.permission_profile();
     let PermissionProfile::Managed { file_system, .. } = &mut expected_permission_profile else {
         panic!("test fixture should use managed permissions");
@@ -1840,7 +1839,6 @@ async fn spawn_agent_reapplies_runtime_sandbox_after_role_config() {
         .expect("spawned agent thread should exist")
         .config_snapshot()
         .await;
-    assert_eq!(snapshot.sandbox_policy(), expected_sandbox);
     assert_eq!(snapshot.approval_policy, AskForApproval::OnRequest);
     assert_eq!(snapshot.permission_profile, expected_permission_profile);
     let child_thread = manager


### PR DESCRIPTION
## Summary

Removes `ThreadConfigSnapshot::sandbox_policy()` and keeps app-server resume mismatch checks based on the snapshot's `PermissionProfile`.

The only production use of the snapshot helper was app-server's running-thread resume validation. That code now uses the same response compatibility projection it already uses for thread responses, and the multi-agent test now asserts the canonical `permission_profile` directly.

## Why

`ThreadConfigSnapshot` should expose the canonical permission state, not a convenience legacy projection. Keeping the compatibility projection local to the app-server response/mismatch boundary makes the remaining `SandboxPolicy` usage easier to isolate and eventually remove.

## Verification

- `just fmt`
- `cargo test -p codex-core spawn_agent_reapplies_runtime_sandbox_after_role_config`
- `cargo test -p codex-app-server collect_resume_override_mismatches_includes_service_tier`
- `just fix -p codex-core -p codex-app-server`































---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20423).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* __->__ #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373