### PR TITLE
app-server: normalize command sandbox overrides as profiles

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -2319,8 +2319,7 @@ impl CodexMessageProcessor {
         };
 
         let effective_permission_profile = if let Some(permission_profile) = permission_profile {
-            let permission_profile =
-                codex_protocol::models::PermissionProfile::from(permission_profile);
+            let permission_profile = PermissionProfile::from(permission_profile);
             let (mut file_system_sandbox_policy, network_sandbox_policy) =
                 permission_profile.to_runtime_permissions();
             let configured_file_system_sandbox_policy =
@@ -2342,19 +2341,11 @@ impl CodexMessageProcessor {
                 .map_err(|err| invalid_request(format!("invalid permission profile: {err}")))?;
             effective_permission_profile
         } else if let Some(policy) = sandbox_policy.map(|policy| policy.to_core()) {
-            self.config
-                .permissions
-                .can_set_legacy_sandbox_policy(&policy, &sandbox_cwd)
-                .map_err(|err| invalid_request(format!("invalid sandbox policy: {err}")))?;
-            let file_system_sandbox_policy =
-                codex_protocol::permissions::FileSystemSandboxPolicy::from_legacy_sandbox_policy_for_cwd(&policy, &sandbox_cwd);
-            let network_sandbox_policy =
-                codex_protocol::permissions::NetworkSandboxPolicy::from(&policy);
             let permission_profile =
-                codex_protocol::models::PermissionProfile::from_runtime_permissions_with_enforcement(
-                    codex_protocol::models::SandboxEnforcement::from_legacy_sandbox_policy(&policy),
-                    &file_system_sandbox_policy,
-                    network_sandbox_policy,
+                permission_profile_from_legacy_sandbox_policy_preserving_configured_denies(
+                    &policy,
+                    &sandbox_cwd,
+                    &self.config.permissions.file_system_sandbox_policy(),
                 );
             self.config
                 .permissions
@@ -9593,11 +9584,23 @@ fn permission_profile_from_legacy_turn_sandbox_policy(
     let sandbox_cwd = cwd.unwrap_or(snapshot.cwd.as_path());
     let configured_file_system_sandbox_policy =
         snapshot.permission_profile.file_system_sandbox_policy();
+    permission_profile_from_legacy_sandbox_policy_preserving_configured_denies(
+        sandbox_policy,
+        sandbox_cwd,
+        &configured_file_system_sandbox_policy,
+    )
+}
+
+fn permission_profile_from_legacy_sandbox_policy_preserving_configured_denies(
+    sandbox_policy: &CoreSandboxPolicy,
+    sandbox_cwd: &Path,
+    configured_file_system_sandbox_policy: &FileSystemSandboxPolicy,
+) -> PermissionProfile {
     let file_system_sandbox_policy =
         FileSystemSandboxPolicy::from_legacy_sandbox_policy_preserving_deny_entries(
             sandbox_policy,
             sandbox_cwd,
-            &configured_file_system_sandbox_policy,
+            configured_file_system_sandbox_policy,
         );
     PermissionProfile::from_runtime_permissions_with_enforcement(
         SandboxEnforcement::from_legacy_sandbox_policy(sandbox_policy),


### PR DESCRIPTION
## Summary
- normalizes legacy app-server `command/exec` `sandboxPolicy` overrides into `PermissionProfile` before execution
- reuses the configured-deny-preserving legacy conversion helper instead of rebuilding command profiles through the older direct legacy projection
- removes the command path dependency on `can_set_legacy_sandbox_policy`, validating the normalized profile through the canonical constrained profile instead

## Review Notes
- The app-server API boundary still accepts `sandboxPolicy` for `command/exec`; this PR only moves the internal command override path onto profiles.
- The legacy command path intentionally preserves its existing sandbox cwd behavior: raw `permissionProfile` uses the command cwd, while legacy `sandboxPolicy` keeps using the server config cwd.
- This improves fidelity for legacy command overrides because configured deny-read restrictions are now preserved in the normalized profile.

## Verification
- `cd codex-rs && just fmt`
- `cd codex-rs && cargo check -p codex-app-server --tests`
- `cd codex-rs && just fix -p codex-app-server`


























---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20429).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* __->__ #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373