### PR TITLE
core tests: submit turns with permission profiles

### DIFF
--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -63,6 +63,7 @@ use core_test_support::responses::sse_failed;
 use core_test_support::skip_if_no_network;
 use core_test_support::test_codex::TestCodex;
 use core_test_support::test_codex::test_codex;
+use core_test_support::test_codex::turn_permission_fields;
 use core_test_support::wait_for_event;
 use dunce::canonicalize as normalize_path;
 use futures::StreamExt;
@@ -1725,6 +1726,10 @@ async fn user_turn_collaboration_mode_overrides_model_and_effort() -> anyhow::Re
         session_configured,
         ..
     } = test_codex().with_model("gpt-5.4").build(&server).await?;
+    let (sandbox_policy, permission_profile) = turn_permission_fields(
+        config.permissions.permission_profile(),
+        config.cwd.as_path(),
+    );
 
     let collaboration_mode = CollaborationMode {
         mode: ModeKind::Default,
@@ -1745,8 +1750,8 @@ async fn user_turn_collaboration_mode_overrides_model_and_effort() -> anyhow::Re
             cwd: config.cwd.to_path_buf(),
             approval_policy: config.permissions.approval_policy.value(),
             approvals_reviewer: None,
-            sandbox_policy: config.legacy_sandbox_policy(),
-            permission_profile: None,
+            sandbox_policy,
+            permission_profile,
             model: session_configured.model.clone(),
             effort: Some(ReasoningEffort::Low),
             summary: Some(
@@ -1856,6 +1861,10 @@ async fn user_turn_explicit_reasoning_summary_overrides_model_catalog_default() 
         })
         .build(&server)
         .await?;
+    let (sandbox_policy, permission_profile) = turn_permission_fields(
+        config.permissions.permission_profile(),
+        config.cwd.as_path(),
+    );
 
     codex
         .submit(Op::UserTurn {
@@ -1867,8 +1876,8 @@ async fn user_turn_explicit_reasoning_summary_overrides_model_catalog_default() 
             cwd: config.cwd.to_path_buf(),
             approval_policy: config.permissions.approval_policy.value(),
             approvals_reviewer: None,
-            sandbox_policy: config.legacy_sandbox_policy(),
-            permission_profile: None,
+            sandbox_policy,
+            permission_profile,
             model: session_configured.model,
             effort: None,
             summary: Some(ReasoningSummary::Concise),

--- a/codex-rs/core/tests/suite/collaboration_instructions.rs
+++ b/codex-rs/core/tests/suite/collaboration_instructions.rs
@@ -14,6 +14,7 @@ use core_test_support::responses::sse;
 use core_test_support::responses::start_mock_server;
 use core_test_support::skip_if_no_network;
 use core_test_support::test_codex::test_codex;
+use core_test_support::test_codex::turn_permission_fields;
 use core_test_support::wait_for_event;
 use pretty_assertions::assert_eq;
 use serde_json::Value;
@@ -174,6 +175,10 @@ async fn collaboration_instructions_added_on_user_turn() -> Result<()> {
     let test = test_codex().build(&server).await?;
     let collab_text = "turn instructions";
     let collaboration_mode = collab_mode_with_instructions(Some(collab_text));
+    let (sandbox_policy, permission_profile) = turn_permission_fields(
+        test.config.permissions.permission_profile(),
+        test.config.cwd.as_path(),
+    );
 
     test.codex
         .submit(Op::UserTurn {
@@ -185,8 +190,8 @@ async fn collaboration_instructions_added_on_user_turn() -> Result<()> {
             cwd: test.config.cwd.to_path_buf(),
             approval_policy: test.config.permissions.approval_policy.value(),
             approvals_reviewer: None,
-            sandbox_policy: test.config.legacy_sandbox_policy(),
-            permission_profile: None,
+            sandbox_policy,
+            permission_profile,
             model: test.session_configured.model.clone(),
             effort: None,
             summary: Some(
@@ -279,6 +284,10 @@ async fn user_turn_overrides_collaboration_instructions_after_override() -> Resu
     let base_mode = collab_mode_with_instructions(Some(base_text));
     let turn_text = "turn override";
     let turn_mode = collab_mode_with_instructions(Some(turn_text));
+    let (sandbox_policy, permission_profile) = turn_permission_fields(
+        test.config.permissions.permission_profile(),
+        test.config.cwd.as_path(),
+    );
 
     test.codex
         .submit(Op::OverrideTurnContext {
@@ -307,8 +316,8 @@ async fn user_turn_overrides_collaboration_instructions_after_override() -> Resu
             cwd: test.config.cwd.to_path_buf(),
             approval_policy: test.config.permissions.approval_policy.value(),
             approvals_reviewer: None,
-            sandbox_policy: test.config.legacy_sandbox_policy(),
-            permission_profile: None,
+            sandbox_policy,
+            permission_profile,
             model: test.session_configured.model.clone(),
             effort: None,
             summary: Some(

--- a/codex-rs/core/tests/suite/prompt_caching.rs
+++ b/codex-rs/core/tests/suite/prompt_caching.rs
@@ -439,16 +439,15 @@ async fn overrides_turn_context_but_keeps_cached_prefix_and_key_constant() -> an
         /*exclude_tmpdir_env_var*/ true,
         /*exclude_slash_tmp*/ true,
     );
-    let sandbox_policy = permission_profile
-        .to_legacy_sandbox_policy(config.cwd.as_path())
-        .expect("workspace profile should have legacy projection");
+    let (sandbox_policy, permission_profile) =
+        turn_permission_fields(permission_profile, config.cwd.as_path());
     codex
         .submit(Op::OverrideTurnContext {
             cwd: None,
             approval_policy: Some(AskForApproval::Never),
             approvals_reviewer: None,
             sandbox_policy: Some(sandbox_policy),
-            permission_profile: Some(permission_profile),
+            permission_profile,
             windows_sandbox_level: None,
             model: None,
             effort: Some(Some(ReasoningEffort::High)),
@@ -832,7 +831,10 @@ async fn send_user_turn_with_no_changes_does_not_send_environment_context() -> a
 
     let default_cwd = config.cwd.clone();
     let default_approval_policy = config.permissions.approval_policy.value();
-    let default_sandbox_policy = &config.legacy_sandbox_policy();
+    let (default_sandbox_policy, default_permission_profile) = turn_permission_fields(
+        config.permissions.permission_profile(),
+        default_cwd.as_path(),
+    );
     let default_model = session_configured.model;
     let default_effort = config.model_reasoning_effort;
     let default_summary = config.model_reasoning_summary;
@@ -848,7 +850,7 @@ async fn send_user_turn_with_no_changes_does_not_send_environment_context() -> a
             approval_policy: default_approval_policy,
             approvals_reviewer: None,
             sandbox_policy: default_sandbox_policy.clone(),
-            permission_profile: None,
+            permission_profile: default_permission_profile.clone(),
             model: default_model.clone(),
             effort: default_effort,
             summary: Some(default_summary.unwrap_or(ReasoningSummary::Auto)),
@@ -871,7 +873,7 @@ async fn send_user_turn_with_no_changes_does_not_send_environment_context() -> a
             approval_policy: default_approval_policy,
             approvals_reviewer: None,
             sandbox_policy: default_sandbox_policy.clone(),
-            permission_profile: None,
+            permission_profile: default_permission_profile.clone(),
             model: default_model.clone(),
             effort: default_effort,
             summary: Some(default_summary.unwrap_or(ReasoningSummary::Auto)),
@@ -962,7 +964,10 @@ async fn send_user_turn_with_changes_sends_environment_context() -> anyhow::Resu
 
     let default_cwd = config.cwd.clone();
     let default_approval_policy = config.permissions.approval_policy.value();
-    let default_sandbox_policy = &config.legacy_sandbox_policy();
+    let (default_sandbox_policy, default_permission_profile) = turn_permission_fields(
+        config.permissions.permission_profile(),
+        default_cwd.as_path(),
+    );
     let default_model = session_configured.model;
     let default_effort = config.model_reasoning_effort;
     let default_summary = config.model_reasoning_summary;
@@ -978,7 +983,7 @@ async fn send_user_turn_with_changes_sends_environment_context() -> anyhow::Resu
             approval_policy: default_approval_policy,
             approvals_reviewer: None,
             sandbox_policy: default_sandbox_policy.clone(),
-            permission_profile: None,
+            permission_profile: default_permission_profile.clone(),
             model: default_model,
             effort: default_effort,
             summary: Some(default_summary.unwrap_or(ReasoningSummary::Auto)),

--- a/codex-rs/core/tests/suite/remote_models.rs
+++ b/codex-rs/core/tests/suite/remote_models.rs
@@ -152,6 +152,8 @@ async fn remote_models_config_context_window_override_clamps_to_max_context_wind
         })
         .build(&server)
         .await?;
+    let (sandbox_policy, permission_profile) =
+        turn_permission_fields(config.permissions.permission_profile(), cwd.path());
 
     codex
         .submit(Op::UserTurn {
@@ -163,13 +165,13 @@ async fn remote_models_config_context_window_override_clamps_to_max_context_wind
             cwd: cwd.path().to_path_buf(),
             approval_policy: config.permissions.approval_policy.value(),
             approvals_reviewer: None,
-            sandbox_policy: config.legacy_sandbox_policy(),
+            sandbox_policy,
             model: requested_model.to_string(),
             effort: None,
             summary: None,
             service_tier: None,
             collaboration_mode: None,
-            permission_profile: None,
+            permission_profile,
             personality: None,
             environments: None,
         })
@@ -230,6 +232,8 @@ async fn remote_models_config_override_above_max_uses_max_context_window() -> Re
         })
         .build(&server)
         .await?;
+    let (sandbox_policy, permission_profile) =
+        turn_permission_fields(config.permissions.permission_profile(), cwd.path());
 
     codex
         .submit(Op::UserTurn {
@@ -241,13 +245,13 @@ async fn remote_models_config_override_above_max_uses_max_context_window() -> Re
             cwd: cwd.path().to_path_buf(),
             approval_policy: config.permissions.approval_policy.value(),
             approvals_reviewer: None,
-            sandbox_policy: config.legacy_sandbox_policy(),
+            sandbox_policy,
             model: requested_model.to_string(),
             effort: None,
             summary: None,
             service_tier: None,
             collaboration_mode: None,
-            permission_profile: None,
+            permission_profile,
             personality: None,
             environments: None,
         })
@@ -307,6 +311,8 @@ async fn remote_models_use_context_window_when_config_override_is_absent() -> Re
         })
         .build(&server)
         .await?;
+    let (sandbox_policy, permission_profile) =
+        turn_permission_fields(config.permissions.permission_profile(), cwd.path());
 
     codex
         .submit(Op::UserTurn {
@@ -318,13 +324,13 @@ async fn remote_models_use_context_window_when_config_override_is_absent() -> Re
             cwd: cwd.path().to_path_buf(),
             approval_policy: config.permissions.approval_policy.value(),
             approvals_reviewer: None,
-            sandbox_policy: config.legacy_sandbox_policy(),
+            sandbox_policy,
             model: requested_model.to_string(),
             effort: None,
             summary: None,
             service_tier: None,
             collaboration_mode: None,
-            permission_profile: None,
+            permission_profile,
             personality: None,
             environments: None,
         })
@@ -397,6 +403,8 @@ async fn remote_models_long_model_slug_is_sent_with_high_reasoning() -> Result<(
         })
         .build(&server)
         .await?;
+    let (sandbox_policy, permission_profile) =
+        turn_permission_fields(config.permissions.permission_profile(), cwd.path());
 
     codex
         .submit(Op::UserTurn {
@@ -408,8 +416,8 @@ async fn remote_models_long_model_slug_is_sent_with_high_reasoning() -> Result<(
             cwd: cwd.path().to_path_buf(),
             approval_policy: config.permissions.approval_policy.value(),
             approvals_reviewer: None,
-            sandbox_policy: config.legacy_sandbox_policy(),
-            permission_profile: None,
+            sandbox_policy,
+            permission_profile,
             model: requested_model.to_string(),
             effort: None,
             summary: None,
@@ -458,6 +466,8 @@ async fn namespaced_model_slug_uses_catalog_metadata_without_fallback_warning() 
         .with_model(requested_model)
         .build(&server)
         .await?;
+    let (sandbox_policy, permission_profile) =
+        turn_permission_fields(config.permissions.permission_profile(), cwd.path());
 
     codex
         .submit(Op::UserTurn {
@@ -469,8 +479,8 @@ async fn namespaced_model_slug_uses_catalog_metadata_without_fallback_warning() 
             cwd: cwd.path().to_path_buf(),
             approval_policy: config.permissions.approval_policy.value(),
             approvals_reviewer: None,
-            sandbox_policy: config.legacy_sandbox_policy(),
-            permission_profile: None,
+            sandbox_policy,
+            permission_profile,
             model: requested_model.to_string(),
             effort: None,
             summary: Some(

--- a/codex-rs/core/tests/suite/truncation.rs
+++ b/codex-rs/core/tests/suite/truncation.rs
@@ -22,6 +22,7 @@ use core_test_support::responses::start_mock_server;
 use core_test_support::skip_if_no_network;
 use core_test_support::stdio_server_bin;
 use core_test_support::test_codex::test_codex;
+use core_test_support::test_codex::turn_permission_fields;
 use core_test_support::wait_for_event;
 use serde_json::Value;
 use serde_json::json;
@@ -508,8 +509,8 @@ async fn mcp_image_output_preserves_image_and_no_text_summary() -> Result<()> {
     });
     let fixture = builder.build(&server).await?;
     let session_model = fixture.session_configured.model.clone();
-    let permission_profile = PermissionProfile::read_only();
-    let sandbox_policy = permission_profile.to_legacy_sandbox_policy(fixture.cwd.path())?;
+    let (sandbox_policy, permission_profile) =
+        turn_permission_fields(PermissionProfile::read_only(), fixture.cwd.path());
 
     fixture
         .codex
@@ -524,7 +525,7 @@ async fn mcp_image_output_preserves_image_and_no_text_summary() -> Result<()> {
             approval_policy: AskForApproval::Never,
             approvals_reviewer: None,
             sandbox_policy,
-            permission_profile: Some(permission_profile),
+            permission_profile,
             model: session_model,
             effort: None,
             summary: None,


### PR DESCRIPTION
## Summary
- updates core integration tests that construct `Op::UserTurn` directly to send the canonical `permission_profile`
- keeps the required legacy `sandbox_policy` field populated from the permission profile compatibility projection while that protocol field still exists
- removes accidental `config.legacy_sandbox_policy()` and direct `to_legacy_sandbox_policy()` use from these modern direct-turn test paths

## Review Notes
- This is test-only and does not change production turn handling.
- The migrated tests cover model metadata, collaboration instruction overrides, client request construction, prompt-caching turn overrides, and truncation/MCP request paths.
- The only remaining `legacy_sandbox_policy()` use in the core integration suite is `resume_warning`, which intentionally builds legacy rollout history with `permission_profile: None`.

## Verification
- `cd codex-rs && just fmt`
- `cd codex-rs && cargo check -p codex-core --tests`
- `cd codex-rs && just fix -p codex-core`























---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20431).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* __->__ #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373