### PR TITLE
session: tag turns with permission profiles

### DIFF
--- a/codex-rs/core/src/session/rollout_reconstruction_tests.rs
+++ b/codex-rs/core/src/session/rollout_reconstruction_tests.rs
@@ -9,6 +9,7 @@ use codex_protocol::protocol::CompactedItem;
 use codex_protocol::protocol::InitialHistory;
 use codex_protocol::protocol::InterAgentCommunication;
 use codex_protocol::protocol::ResumedHistory;
+use codex_protocol::protocol::SandboxPolicy;
 use pretty_assertions::assert_eq;
 use std::path::PathBuf;
 
@@ -52,6 +53,16 @@ fn inter_agent_assistant_message(text: &str) -> ResponseItem {
     }
 }
 
+fn legacy_sandbox_policy_for_rollout_fixture(turn_context: &TurnContext) -> SandboxPolicy {
+    let file_system_sandbox_policy = turn_context.file_system_sandbox_policy();
+    codex_sandboxing::compatibility_sandbox_policy_for_permission_profile(
+        &turn_context.permission_profile,
+        &file_system_sandbox_policy,
+        turn_context.network_sandbox_policy(),
+        turn_context.cwd.as_path(),
+    )
+}
+
 #[tokio::test]
 async fn record_initial_history_resumed_bare_turn_context_does_not_hydrate_previous_turn_settings()
 {
@@ -64,7 +75,7 @@ async fn record_initial_history_resumed_bare_turn_context_does_not_hydrate_previ
         current_date: turn_context.current_date.clone(),
         timezone: turn_context.timezone.clone(),
         approval_policy: turn_context.approval_policy.value(),
-        sandbox_policy: Some(turn_context.sandbox_policy()),
+        sandbox_policy: Some(legacy_sandbox_policy_for_rollout_fixture(&turn_context)),
         permission_profile: None,
         network: None,
         file_system_sandbox_policy: None,
@@ -105,7 +116,7 @@ async fn record_initial_history_resumed_hydrates_previous_turn_settings_from_lif
         current_date: turn_context.current_date.clone(),
         timezone: turn_context.timezone.clone(),
         approval_policy: turn_context.approval_policy.value(),
-        sandbox_policy: Some(turn_context.sandbox_policy()),
+        sandbox_policy: Some(legacy_sandbox_policy_for_rollout_fixture(&turn_context)),
         permission_profile: None,
         network: None,
         file_system_sandbox_policy: None,
@@ -915,7 +926,7 @@ async fn record_initial_history_resumed_turn_context_after_compaction_reestablis
         current_date: turn_context.current_date.clone(),
         timezone: turn_context.timezone.clone(),
         approval_policy: turn_context.approval_policy.value(),
-        sandbox_policy: Some(turn_context.sandbox_policy()),
+        sandbox_policy: Some(legacy_sandbox_policy_for_rollout_fixture(&turn_context)),
         permission_profile: None,
         network: None,
         file_system_sandbox_policy: None,
@@ -993,7 +1004,7 @@ async fn record_initial_history_resumed_turn_context_after_compaction_reestablis
             current_date: turn_context.current_date.clone(),
             timezone: turn_context.timezone.clone(),
             approval_policy: turn_context.approval_policy.value(),
-            sandbox_policy: Some(turn_context.sandbox_policy()),
+            sandbox_policy: Some(legacy_sandbox_policy_for_rollout_fixture(&turn_context)),
             permission_profile: None,
             network: None,
             file_system_sandbox_policy: None,
@@ -1024,7 +1035,7 @@ async fn record_initial_history_resumed_aborted_turn_without_id_clears_active_tu
         current_date: turn_context.current_date.clone(),
         timezone: turn_context.timezone.clone(),
         approval_policy: turn_context.approval_policy.value(),
-        sandbox_policy: Some(turn_context.sandbox_policy()),
+        sandbox_policy: Some(legacy_sandbox_policy_for_rollout_fixture(&turn_context)),
         permission_profile: None,
         network: None,
         file_system_sandbox_policy: None,
@@ -1139,7 +1150,7 @@ async fn record_initial_history_resumed_unmatched_abort_preserves_active_turn_fo
         current_date: turn_context.current_date.clone(),
         timezone: turn_context.timezone.clone(),
         approval_policy: turn_context.approval_policy.value(),
-        sandbox_policy: Some(turn_context.sandbox_policy()),
+        sandbox_policy: Some(legacy_sandbox_policy_for_rollout_fixture(&turn_context)),
         permission_profile: None,
         network: None,
         file_system_sandbox_policy: None,
@@ -1253,7 +1264,7 @@ async fn record_initial_history_resumed_trailing_incomplete_turn_compaction_clea
         current_date: turn_context.current_date.clone(),
         timezone: turn_context.timezone.clone(),
         approval_policy: turn_context.approval_policy.value(),
-        sandbox_policy: Some(turn_context.sandbox_policy()),
+        sandbox_policy: Some(legacy_sandbox_policy_for_rollout_fixture(&turn_context)),
         permission_profile: None,
         network: None,
         file_system_sandbox_policy: None,
@@ -1405,7 +1416,7 @@ async fn record_initial_history_resumed_replaced_incomplete_compacted_turn_clear
         current_date: turn_context.current_date.clone(),
         timezone: turn_context.timezone.clone(),
         approval_policy: turn_context.approval_policy.value(),
-        sandbox_policy: Some(turn_context.sandbox_policy()),
+        sandbox_policy: Some(legacy_sandbox_policy_for_rollout_fixture(&turn_context)),
         permission_profile: None,
         network: None,
         file_system_sandbox_policy: None,

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -1738,6 +1738,14 @@ async fn fork_startup_context_then_first_turn_diff_snapshot() -> anyhow::Result<
 async fn record_initial_history_forked_hydrates_previous_turn_settings() {
     let (session, turn_context) = make_session_and_context().await;
     let previous_model = "forked-rollout-model";
+    let file_system_sandbox_policy = turn_context.file_system_sandbox_policy();
+    let legacy_sandbox_policy =
+        codex_sandboxing::compatibility_sandbox_policy_for_permission_profile(
+            &turn_context.permission_profile,
+            &file_system_sandbox_policy,
+            turn_context.network_sandbox_policy(),
+            turn_context.cwd.as_path(),
+        );
     let previous_context_item = TurnContextItem {
         turn_id: Some(turn_context.sub_id.clone()),
         trace_id: turn_context.trace_id.clone(),
@@ -1745,7 +1753,7 @@ async fn record_initial_history_forked_hydrates_previous_turn_settings() {
         current_date: turn_context.current_date.clone(),
         timezone: turn_context.timezone.clone(),
         approval_policy: turn_context.approval_policy.value(),
-        sandbox_policy: Some(turn_context.sandbox_policy()),
+        sandbox_policy: Some(legacy_sandbox_policy),
         permission_profile: None,
         network: None,
         file_system_sandbox_policy: None,

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -1820,7 +1820,7 @@ async fn try_run_sampling_request(
     feedback_tags!(
         model = turn_context.model_info.slug.clone(),
         approval_policy = turn_context.approval_policy.value(),
-        sandbox_policy = &turn_context.sandbox_policy(),
+        permission_profile = &turn_context.permission_profile,
         effort = turn_context.reasoning_effort,
         auth_mode = sess.services.auth_manager.auth_mode(),
         features = sess.features.enabled_features(),

--- a/codex-rs/core/src/session/turn_context.rs
+++ b/codex-rs/core/src/session/turn_context.rs
@@ -4,7 +4,6 @@ use codex_model_provider::SharedModelProvider;
 use codex_model_provider::create_model_provider;
 use codex_protocol::models::AdditionalPermissionProfile;
 use codex_protocol::protocol::TurnEnvironmentSelection;
-use codex_sandboxing::compatibility_sandbox_policy_for_permission_profile;
 use codex_sandboxing::policy_transforms::effective_file_system_sandbox_policy;
 use codex_sandboxing::policy_transforms::effective_network_sandbox_policy;
 use std::sync::atomic::AtomicBool;
@@ -104,17 +103,6 @@ impl TurnContext {
 
     pub(crate) fn network_sandbox_policy(&self) -> NetworkSandboxPolicy {
         self.permission_profile.network_sandbox_policy()
-    }
-
-    pub(crate) fn sandbox_policy(&self) -> SandboxPolicy {
-        let file_system_sandbox_policy = self.file_system_sandbox_policy();
-        let network_sandbox_policy = self.network_sandbox_policy();
-        compatibility_sandbox_policy_for_permission_profile(
-            &self.permission_profile,
-            &file_system_sandbox_policy,
-            network_sandbox_policy,
-            &self.cwd,
-        )
     }
 
     pub(crate) fn model_context_window(&self) -> Option<i64> {


### PR DESCRIPTION
## Why

`TurnContext` already carries the canonical `PermissionProfile` for a turn. Keeping a `TurnContext::sandbox_policy()` convenience method made it easy for production code to re-project that profile into the legacy `SandboxPolicy` shape even when the caller did not actually need a legacy boundary payload.

This change keeps legacy projection explicit: new turn telemetry records the canonical profile, while tests that intentionally construct old rollout records build the compatibility `sandbox_policy` locally as a fixture detail.

## What Changed

- Removed `TurnContext::sandbox_policy()` from the core session turn context.
- Changed sampling feedback tags from `sandbox_policy` to `permission_profile` so feedback captures the canonical permission model instead of a lossy compatibility projection.
- Updated legacy rollout reconstruction fixtures to call a test-local helper when they need a `TurnContextItem` with `permission_profile: None` and a legacy `sandbox_policy`.

## Verification

- `cd codex-rs && cargo check -p codex-core --tests`
- `cd codex-rs && just fix -p codex-core`






















---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20432).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* __->__ #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373