### PR TITLE
rollout-trace: record permission profiles

### DIFF
--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -526,7 +526,7 @@ impl Session {
                 model: session_configuration.collaboration_mode.model().to_string(),
                 provider_name: config.model_provider_id.clone(),
                 approval_policy: session_configuration.approval_policy.value().to_string(),
-                sandbox_policy: format!("{:?}", session_configuration.sandbox_policy()),
+                permission_profile: format!("{:?}", session_configuration.permission_profile()),
             };
             let rollout_thread_trace = if matches!(
                 session_configuration.session_source,

--- a/codex-rs/core/src/tools/tool_dispatch_trace_tests.rs
+++ b/codex-rs/core/src/tools/tool_dispatch_trace_tests.rs
@@ -286,7 +286,7 @@ fn attach_test_trace(session: &mut Session, turn: &TurnContext, root: &Path) -> 
                 model: "gpt-test".to_string(),
                 provider_name: "test-provider".to_string(),
                 approval_policy: "never".to_string(),
-                sandbox_policy: "danger-full-access".to_string(),
+                permission_profile: "Disabled".to_string(),
             },
         )?;
     rollout_thread_trace.record_codex_turn_started(turn.sub_id.as_str());

--- a/codex-rs/rollout-trace/src/thread.rs
+++ b/codex-rs/rollout-trace/src/thread.rs
@@ -58,7 +58,7 @@ pub struct ThreadStartedTraceMetadata {
     pub model: String,
     pub provider_name: String,
     pub approval_policy: String,
-    pub sandbox_policy: String,
+    pub permission_profile: String,
 }
 
 /// Trace-only payload for a child completion notification delivered to its parent.

--- a/codex-rs/rollout-trace/src/thread_tests.rs
+++ b/codex-rs/rollout-trace/src/thread_tests.rs
@@ -37,7 +37,7 @@ fn create_in_root_writes_replayable_lifecycle_events() -> anyhow::Result<()> {
             model: "gpt-test".to_string(),
             provider_name: "test-provider".to_string(),
             approval_policy: "never".to_string(),
-            sandbox_policy: "DangerFullAccess".to_string(),
+            permission_profile: "Disabled".to_string(),
         },
     )?;
 
@@ -84,7 +84,7 @@ fn spawned_thread_start_appends_to_root_bundle() -> anyhow::Result<()> {
         model: "gpt-test".to_string(),
         provider_name: "test-provider".to_string(),
         approval_policy: "never".to_string(),
-        sandbox_policy: "DangerFullAccess".to_string(),
+        permission_profile: "Disabled".to_string(),
     });
     child_trace.record_ended(RolloutStatus::Completed);
     let bundle_dir = single_bundle_dir(temp.path())?;
@@ -201,7 +201,7 @@ fn minimal_metadata(thread_id: ThreadId) -> ThreadStartedTraceMetadata {
         model: "gpt-test".to_string(),
         provider_name: "test-provider".to_string(),
         approval_policy: "never".to_string(),
-        sandbox_policy: "danger-full-access".to_string(),
+        permission_profile: "Disabled".to_string(),
     }
 }
 


### PR DESCRIPTION
## Why

Rollout trace thread metadata still recorded the legacy `SandboxPolicy` projection even though the session configuration is now driven by `PermissionProfile`. That kept trace metadata tied to a lossy compatibility shape and made new trace bundles look like they were still sourced from the old sandbox abstraction.

## What Changed

- Replaces `ThreadStartedTraceMetadata.sandbox_policy` with `permission_profile`.
- Records the active session `PermissionProfile` when creating rollout thread traces.
- Updates rollout trace tests and tool-dispatch trace fixtures to seed the new metadata field directly.

## Verification

- `cd codex-rs && cargo check -p codex-rollout-trace -p codex-core --tests`
- `cd codex-rs && just fix -p codex-rollout-trace`
- `cd codex-rs && just fix -p codex-core`



















---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20436).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* __->__ #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373