### PR TITLE
session: localize legacy sandbox turn fallback

### DIFF
--- a/codex-rs/core/src/session/handlers.rs
+++ b/codex-rs/core/src/session/handlers.rs
@@ -323,10 +323,14 @@ async fn permission_profile_with_legacy_fallback(
 ) -> Option<PermissionProfile> {
     match (permission_profile, sandbox_policy) {
         (Some(permission_profile), _) => Some(permission_profile),
-        (None, Some(sandbox_policy)) => Some(
-            sess.permission_profile_from_legacy_sandbox_update(sandbox_policy, cwd)
-                .await,
-        ),
+        (None, Some(sandbox_policy)) => {
+            let state = sess.state.lock().await;
+            Some(
+                state
+                    .session_configuration
+                    .permission_profile_from_legacy_sandbox_update(sandbox_policy, cwd),
+            )
+        }
         (None, None) => None,
     }
 }

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -338,7 +338,6 @@ use codex_protocol::protocol::Op;
 use codex_protocol::protocol::RateLimitSnapshot;
 use codex_protocol::protocol::RequestUserInputEvent;
 use codex_protocol::protocol::ReviewDecision;
-use codex_protocol::protocol::SandboxPolicy;
 use codex_protocol::protocol::SessionConfiguredEvent;
 use codex_protocol::protocol::SessionNetworkProxyRuntime;
 use codex_protocol::protocol::SkillDependencies as ProtocolSkillDependencies;
@@ -1352,17 +1351,6 @@ impl Session {
     ) -> ConstraintResult<()> {
         let state = self.state.lock().await;
         state.session_configuration.apply(updates).map(|_| ())
-    }
-
-    pub(crate) async fn permission_profile_from_legacy_sandbox_update(
-        &self,
-        sandbox_policy: &SandboxPolicy,
-        cwd: Option<&Path>,
-    ) -> PermissionProfile {
-        let state = self.state.lock().await;
-        state
-            .session_configuration
-            .permission_profile_from_legacy_sandbox_update(sandbox_policy, cwd)
     }
 
     pub(crate) async fn set_session_startup_prewarm(

--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::goals::GoalRuntimeState;
 use codex_protocol::permissions::FileSystemPath;
 use codex_protocol::permissions::FileSystemSpecialPath;
+use codex_protocol::protocol::SandboxPolicy;
 use tokio::sync::Semaphore;
 
 /// Context for an initialized model agent


### PR DESCRIPTION
## Why

Legacy `SandboxPolicy` turn overrides are now a compatibility fallback rather than the normal session path. The `Session` type still exposed a helper that existed only for one legacy `Op::UserTurn` fallback in `handlers.rs`, which made the compatibility path look like a general session API.

## What Changed

- Moves the legacy turn fallback conversion directly into `permission_profile_with_legacy_fallback()`.
- Removes the corresponding `Session` method so `Session` no longer exposes a one-off `SandboxPolicy` conversion API.
- Keeps the existing behavior intact: when a turn omits `permission_profile` but includes legacy `sandbox_policy`, the handler still derives a `PermissionProfile` from the current session configuration and requested cwd.

## Verification

- `cd codex-rs && cargo check -p codex-core --tests`
- `cd codex-rs && just fix -p codex-core`


















---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20438).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* __->__ #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373