### PR TITLE
protocol: require permission profiles for user turns

### DIFF
--- a/codex-rs/core/src/guardian/review_session.rs
+++ b/codex-rs/core/src/guardian/review_session.rs
@@ -714,7 +714,7 @@ async fn run_review_on_session(
             approval_policy: AskForApproval::Never,
             approvals_reviewer: None,
             sandbox_policy: None,
-            permission_profile: Some(permission_profile),
+            permission_profile,
             model: params.model.clone(),
             effort: params.reasoning_effort,
             summary: Some(params.reasoning_summary),

--- a/codex-rs/core/src/session/handlers.rs
+++ b/codex-rs/core/src/session/handlers.rs
@@ -134,7 +134,7 @@ pub(super) async fn user_input_or_turn_inner(
             cwd,
             approval_policy,
             approvals_reviewer,
-            sandbox_policy,
+            sandbox_policy: _,
             permission_profile,
             model,
             effort,
@@ -156,24 +156,15 @@ pub(super) async fn user_input_or_turn_inner(
                     },
                 })
             });
-            let clear_active_permission_profile =
-                permission_profile.is_none() && sandbox_policy.is_some();
-            let permission_profile = permission_profile_with_legacy_fallback(
-                sess,
-                sandbox_policy.as_ref(),
-                permission_profile,
-                Some(cwd.as_path()),
-            )
-            .await;
             (
                 items,
                 SessionSettingsUpdate {
                     cwd: Some(cwd),
                     approval_policy: Some(approval_policy),
                     approvals_reviewer,
-                    permission_profile,
+                    permission_profile: Some(permission_profile),
                     active_permission_profile: None,
-                    clear_active_permission_profile,
+                    clear_active_permission_profile: false,
                     windows_sandbox_level: None,
                     collaboration_mode,
                     reasoning_summary: summary,

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -4248,7 +4248,7 @@ async fn user_turn_updates_approvals_reviewer() {
             approval_policy: config.permissions.approval_policy.value(),
             approvals_reviewer: Some(codex_config::types::ApprovalsReviewer::AutoReview),
             sandbox_policy: None,
-            permission_profile: Some(config.permissions.permission_profile()),
+            permission_profile: config.permissions.permission_profile(),
             model: turn_context.model_info.slug.clone(),
             effort: config.model_reasoning_effort,
             summary: config.model_reasoning_summary,

--- a/codex-rs/core/tests/common/test_codex.rs
+++ b/codex-rs/core/tests/common/test_codex.rs
@@ -212,9 +212,9 @@ pub fn turn_permission_fields(
     _cwd: &Path,
 ) -> (
     Option<codex_protocol::protocol::SandboxPolicy>,
-    Option<PermissionProfile>,
+    PermissionProfile,
 ) {
-    (None, Some(permission_profile))
+    (None, permission_profile)
 }
 
 pub struct TestCodexBuilder {
@@ -704,8 +704,6 @@ impl TestCodex {
         service_tier: Option<Option<ServiceTier>>,
         environments: Option<Vec<TurnEnvironmentSelection>>,
     ) -> Result<()> {
-        let (sandbox_policy, permission_profile) =
-            turn_permission_fields(permission_profile, self.config.cwd.as_path());
         let session_model = self.session_configured.model.clone();
         self.codex
             .submit(Op::UserTurn {
@@ -718,7 +716,7 @@ impl TestCodex {
                 cwd: self.config.cwd.to_path_buf(),
                 approval_policy,
                 approvals_reviewer: None,
-                sandbox_policy,
+                sandbox_policy: None,
                 permission_profile,
                 model: session_model,
                 effort: None,

--- a/codex-rs/core/tests/suite/prompt_caching.rs
+++ b/codex-rs/core/tests/suite/prompt_caching.rs
@@ -447,7 +447,7 @@ async fn overrides_turn_context_but_keeps_cached_prefix_and_key_constant() -> an
             approval_policy: Some(AskForApproval::Never),
             approvals_reviewer: None,
             sandbox_policy,
-            permission_profile,
+            permission_profile: Some(permission_profile),
             windows_sandbox_level: None,
             model: None,
             effort: Some(Some(ReasoningEffort::High)),

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -541,20 +541,17 @@ pub enum Op {
         /// When omitted, the session keeps the current setting
         approvals_reviewer: Option<ApprovalsReviewer>,
 
-        /// Legacy sandbox policy to use for tool calls such as `local_shell`.
+        /// Deprecated legacy sandbox policy field.
         ///
-        /// When omitted, `permission_profile` is used as the canonical source
-        /// of permissions. This field is kept only as a compatibility fallback
-        /// for older callers that have not migrated to `permission_profile`.
+        /// `permission_profile` is required and is the canonical source for
+        /// `UserTurn` operations. This field is ignored by core and remains
+        /// only as a temporary compatibility slot while callers finish
+        /// migrating.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         sandbox_policy: Option<SandboxPolicy>,
 
         /// Full permissions profile to use for tool calls such as `local_shell`.
-        ///
-        /// When omitted, `sandbox_policy` is used as a legacy compatibility
-        /// projection.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        permission_profile: Option<PermissionProfile>,
+        permission_profile: PermissionProfile,
 
         /// Must be a valid model slug for the configured client session
         /// associated with this conversation.

--- a/codex-rs/tui/src/app_command.rs
+++ b/codex-rs/tui/src/app_command.rs
@@ -24,8 +24,6 @@ use codex_protocol::user_input::UserInput;
 use serde::Serialize;
 use serde_json::Value;
 
-use crate::permission_compat::legacy_compatible_sandbox_policy;
-
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub(crate) enum AppCommand {
@@ -377,7 +375,7 @@ impl AppCommand {
                 approval_policy,
                 approvals_reviewer,
                 sandbox_policy: None,
-                permission_profile: Some(permission_profile),
+                permission_profile,
                 model,
                 effort,
                 summary,
@@ -592,7 +590,7 @@ impl From<Op> for AppCommand {
                 approval_policy,
                 approvals_reviewer,
                 sandbox_policy,
-                permission_profile: Some(permission_profile),
+                permission_profile,
                 model,
                 effort,
                 summary,
@@ -601,12 +599,7 @@ impl From<Op> for AppCommand {
                 collaboration_mode,
                 personality,
             } => {
-                if environments.is_none()
-                    && sandbox_policy.as_ref().is_none_or(|sandbox_policy| {
-                        legacy_compatible_sandbox_policy(&permission_profile, cwd.as_path())
-                            == *sandbox_policy
-                    })
-                {
+                if environments.is_none() {
                     Self::UserTurn {
                         items,
                         cwd,
@@ -628,7 +621,7 @@ impl From<Op> for AppCommand {
                         approval_policy,
                         approvals_reviewer,
                         sandbox_policy,
-                        permission_profile: Some(permission_profile),
+                        permission_profile,
                         model,
                         effort,
                         summary,

--- a/codex-rs/tui/src/chatwidget/tests/composer_submission.rs
+++ b/codex-rs/tui/src/chatwidget/tests/composer_submission.rs
@@ -150,7 +150,7 @@ async fn submission_includes_configured_permission_profile() {
         } => permission_profile,
         other => panic!("expected Op::UserTurn, got {other:?}"),
     };
-    assert_eq!(permission_profile, Some(expected_permission_profile));
+    assert_eq!(permission_profile, expected_permission_profile);
 }
 
 #[tokio::test]
@@ -198,7 +198,7 @@ async fn submission_keeps_profile_when_legacy_projection_is_external() {
         } => permission_profile,
         other => panic!("expected Op::UserTurn, got {other:?}"),
     };
-    assert_eq!(permission_profile, Some(expected_permission_profile));
+    assert_eq!(permission_profile, expected_permission_profile);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Why

`Op::UserTurn` is the explicit turn submission path where callers already provide the complete turn context. Keeping `permission_profile` optional meant core still had to preserve a legacy `SandboxPolicy` fallback for this path, even though every migrated caller should know the canonical permissions profile at submission time.

This PR makes `permission_profile` required for `UserTurn` so core no longer has to derive command permissions from the legacy sandbox field for explicit turns. The legacy `sandbox_policy` slot is left in place temporarily but is ignored for `UserTurn`; follow-up PRs can remove it once the remaining mechanical test/helper callsites stop carrying it.

## What Changed

- Changes `Op::UserTurn.permission_profile` from `Option<PermissionProfile>` to required `PermissionProfile`.
- Updates core turn handling to use the required profile directly instead of calling the legacy fallback helper.
- Updates TUI command conversion and tests for the non-optional profile shape.
- Keeps `UserInputWithTurnContext` and `OverrideTurnContext` legacy fallback behavior unchanged because those are still compatibility update surfaces.

## Verification

- `cargo check -p codex-protocol -p codex-core -p codex-tui --tests`















---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20441).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* __->__ #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373