### PR TITLE
session: stop exposing legacy sandbox policy

### DIFF
--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -2,7 +2,6 @@ use super::*;
 use crate::goals::GoalRuntimeState;
 use codex_protocol::permissions::FileSystemPath;
 use codex_protocol::permissions::FileSystemSpecialPath;
-use codex_protocol::protocol::SandboxPolicy;
 use tokio::sync::Semaphore;
 
 /// Context for an initialized model agent
@@ -105,20 +104,6 @@ impl SessionConfiguration {
         self.active_permission_profile.clone()
     }
 
-    pub(super) fn sandbox_policy(&self) -> SandboxPolicy {
-        self.permission_profile()
-            .to_legacy_sandbox_policy(&self.cwd)
-            .unwrap_or_else(|_| {
-                let file_system_sandbox_policy = self.file_system_sandbox_policy();
-                codex_sandboxing::compatibility_sandbox_policy_for_permission_profile(
-                    self.permission_profile.get(),
-                    &file_system_sandbox_policy,
-                    self.network_sandbox_policy(),
-                    &self.cwd,
-                )
-            })
-    }
-
     pub(super) fn file_system_sandbox_policy(&self) -> FileSystemSandboxPolicy {
         self.permission_profile.get().file_system_sandbox_policy()
     }
@@ -146,9 +131,15 @@ impl SessionConfiguration {
 
     pub(crate) fn apply(&self, updates: &SessionSettingsUpdate) -> ConstraintResult<Self> {
         let mut next_configuration = self.clone();
-        let current_sandbox_policy = self.sandbox_policy();
         let current_file_system_sandbox_policy = self.file_system_sandbox_policy();
         let current_network_sandbox_policy = self.network_sandbox_policy();
+        let current_sandbox_policy =
+            codex_sandboxing::compatibility_sandbox_policy_for_permission_profile(
+                self.permission_profile.get(),
+                &current_file_system_sandbox_policy,
+                current_network_sandbox_policy,
+                &self.cwd,
+            );
         let legacy_file_system_projection =
             FileSystemSandboxPolicy::from_legacy_sandbox_policy_preserving_deny_entries(
                 &current_sandbox_policy,

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -3043,8 +3043,14 @@ async fn session_configuration_apply_permission_profile_accepts_direct_write_roo
         updated.file_system_sandbox_policy(),
         file_system_sandbox_policy
     );
+    let updated_file_system_policy = updated.file_system_sandbox_policy();
     assert_eq!(
-        updated.sandbox_policy(),
+        codex_sandboxing::compatibility_sandbox_policy_for_permission_profile(
+            &updated.permission_profile(),
+            &updated_file_system_policy,
+            updated.network_sandbox_policy(),
+            updated.cwd.as_path(),
+        ),
         codex_sandboxing::compatibility_sandbox_policy_for_permission_profile(
             &permission_profile,
             &file_system_sandbox_policy,
@@ -3176,7 +3182,12 @@ async fn session_configuration_apply_rederives_legacy_file_system_policy_on_cwd_
         .expect("cwd-only update should succeed");
 
     let expected_file_system_policy = FileSystemSandboxPolicy::from_legacy_sandbox_policy_for_cwd(
-        &updated.sandbox_policy(),
+        &codex_sandboxing::compatibility_sandbox_policy_for_permission_profile(
+            &updated.permission_profile(),
+            &updated.file_system_sandbox_policy(),
+            updated.network_sandbox_policy(),
+            updated.cwd.as_path(),
+        ),
         &project_root,
     );
     assert!(


### PR DESCRIPTION
## Why

`SessionConfiguration` should expose the canonical permission profile and runtime policies, not a convenience `SandboxPolicy` projection. The only remaining session-level caller needed a legacy projection as a temporary bridge for cwd-only updates that were originally loaded from legacy-compatible workspace policies.

This keeps that compatibility behavior local to `apply()` while removing the public-ish session helper that invited new session code to keep depending on `SandboxPolicy`.

## What Changed

- Removed `SessionConfiguration::sandbox_policy()`.
- Computes the legacy compatibility projection directly inside `SessionConfiguration::apply()` for the existing cwd-rebind fallback.
- Updated session tests to compare against explicit compatibility projections from the active `PermissionProfile` and runtime filesystem/network policies.

## Verification

- `cargo check -p codex-core --tests`
- `just fix -p codex-core`













---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20450).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* __->__ #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373