### PR TITLE
windows-sandbox: accept permission profiles from callers

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -3612,7 +3612,6 @@ dependencies = [
  "codex-utils-sandbox-summary",
  "codex-utils-sleep-inhibitor",
  "codex-utils-string",
- "codex-windows-sandbox",
  "color-eyre",
  "cpal",
  "crossterm",

--- a/codex-rs/core/src/windows_sandbox.rs
+++ b/codex-rs/core/src/windows_sandbox.rs
@@ -10,7 +10,6 @@ use codex_login::default_client::originator;
 use codex_otel::sanitize_metric_tag_value;
 use codex_protocol::config_types::WindowsSandboxLevel;
 use codex_protocol::models::PermissionProfile;
-use codex_protocol::protocol::SandboxPolicy;
 use codex_sandboxing::compatibility_sandbox_policy_for_permission_profile;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
@@ -56,6 +55,19 @@ pub fn windows_sandbox_level_from_config(config: &Config) -> WindowsSandboxLevel
 
 pub fn windows_sandbox_level_from_features(features: &Features) -> WindowsSandboxLevel {
     WindowsSandboxLevel::from_features(features)
+}
+
+fn compatibility_windows_sandbox_policy(
+    permission_profile: &PermissionProfile,
+    policy_cwd: &Path,
+) -> codex_protocol::protocol::SandboxPolicy {
+    let file_system_policy = permission_profile.file_system_sandbox_policy();
+    compatibility_sandbox_policy_for_permission_profile(
+        permission_profile,
+        &file_system_policy,
+        permission_profile.network_sandbox_policy(),
+        policy_cwd,
+    )
 }
 
 pub fn resolve_windows_sandbox_mode(
@@ -175,15 +187,16 @@ pub fn elevated_setup_failure_metric_name(_err: &anyhow::Error) -> &'static str 
 
 #[cfg(target_os = "windows")]
 pub fn run_elevated_setup(
-    policy: &SandboxPolicy,
+    permission_profile: &PermissionProfile,
     policy_cwd: &Path,
     command_cwd: &Path,
     env_map: &HashMap<String, String>,
     codex_home: &Path,
 ) -> anyhow::Result<()> {
+    let policy = compatibility_windows_sandbox_policy(permission_profile, policy_cwd);
     codex_windows_sandbox::run_elevated_setup(
         codex_windows_sandbox::SandboxSetupRequest {
-            policy,
+            policy: &policy,
             policy_cwd,
             command_cwd,
             env_map,
@@ -196,7 +209,7 @@ pub fn run_elevated_setup(
 
 #[cfg(not(target_os = "windows"))]
 pub fn run_elevated_setup(
-    _policy: &SandboxPolicy,
+    _permission_profile: &PermissionProfile,
     _policy_cwd: &Path,
     _command_cwd: &Path,
     _env_map: &HashMap<String, String>,
@@ -207,14 +220,15 @@ pub fn run_elevated_setup(
 
 #[cfg(target_os = "windows")]
 pub fn run_legacy_setup_preflight(
-    policy: &SandboxPolicy,
+    permission_profile: &PermissionProfile,
     policy_cwd: &Path,
     command_cwd: &Path,
     env_map: &HashMap<String, String>,
     codex_home: &Path,
 ) -> anyhow::Result<()> {
+    let policy = compatibility_windows_sandbox_policy(permission_profile, policy_cwd);
     codex_windows_sandbox::run_windows_sandbox_legacy_preflight(
-        policy,
+        &policy,
         policy_cwd,
         codex_home,
         command_cwd,
@@ -224,15 +238,16 @@ pub fn run_legacy_setup_preflight(
 
 #[cfg(target_os = "windows")]
 pub fn run_setup_refresh_with_extra_read_roots(
-    policy: &SandboxPolicy,
+    permission_profile: &PermissionProfile,
     policy_cwd: &Path,
     command_cwd: &Path,
     env_map: &HashMap<String, String>,
     codex_home: &Path,
     extra_read_roots: Vec<PathBuf>,
 ) -> anyhow::Result<()> {
+    let policy = compatibility_windows_sandbox_policy(permission_profile, policy_cwd);
     codex_windows_sandbox::run_setup_refresh_with_extra_read_roots(
-        policy,
+        &policy,
         policy_cwd,
         command_cwd,
         env_map,
@@ -244,7 +259,7 @@ pub fn run_setup_refresh_with_extra_read_roots(
 
 #[cfg(not(target_os = "windows"))]
 pub fn run_legacy_setup_preflight(
-    _policy: &SandboxPolicy,
+    _permission_profile: &PermissionProfile,
     _policy_cwd: &Path,
     _command_cwd: &Path,
     _env_map: &HashMap<String, String>,
@@ -255,7 +270,7 @@ pub fn run_legacy_setup_preflight(
 
 #[cfg(not(target_os = "windows"))]
 pub fn run_setup_refresh_with_extra_read_roots(
-    _policy: &SandboxPolicy,
+    _permission_profile: &PermissionProfile,
     _policy_cwd: &Path,
     _command_cwd: &Path,
     _env_map: &HashMap<String, String>,
@@ -263,6 +278,24 @@ pub fn run_setup_refresh_with_extra_read_roots(
     _extra_read_roots: Vec<PathBuf>,
 ) -> anyhow::Result<()> {
     anyhow::bail!("Windows sandbox read-root refresh is only supported on Windows")
+}
+
+pub fn apply_world_writable_scan_and_denies(
+    logs_base_dir: &Path,
+    cwd: &Path,
+    env_map: &HashMap<String, String>,
+    permission_profile: &PermissionProfile,
+    policy_cwd: &Path,
+    audit_dir: Option<&Path>,
+) -> anyhow::Result<()> {
+    let policy = compatibility_windows_sandbox_policy(permission_profile, policy_cwd);
+    codex_windows_sandbox::apply_world_writable_scan_and_denies(
+        logs_base_dir,
+        cwd,
+        env_map,
+        &policy,
+        audit_dir,
+    )
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -320,20 +353,13 @@ async fn run_windows_sandbox_setup_and_persist(
     let codex_home = request.codex_home;
     let active_profile = request.active_profile;
     let setup_codex_home = codex_home.clone();
-    let file_system_sandbox_policy = permission_profile.file_system_sandbox_policy();
-    let policy = compatibility_sandbox_policy_for_permission_profile(
-        &permission_profile,
-        &file_system_sandbox_policy,
-        permission_profile.network_sandbox_policy(),
-        policy_cwd.as_path(),
-    );
 
     let setup_result = tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
         match mode {
             WindowsSandboxSetupMode::Elevated => {
                 if !sandbox_setup_is_complete(setup_codex_home.as_path()) {
                     run_elevated_setup(
-                        &policy,
+                        &permission_profile,
                         policy_cwd.as_path(),
                         command_cwd.as_path(),
                         &env_map,
@@ -343,7 +369,7 @@ async fn run_windows_sandbox_setup_and_persist(
             }
             WindowsSandboxSetupMode::Unelevated => {
                 run_legacy_setup_preflight(
-                    &policy,
+                    &permission_profile,
                     policy_cwd.as_path(),
                     command_cwd.as_path(),
                     &env_map,

--- a/codex-rs/core/src/windows_sandbox_read_grants.rs
+++ b/codex-rs/core/src/windows_sandbox_read_grants.rs
@@ -1,7 +1,6 @@
 use crate::windows_sandbox::run_setup_refresh_with_extra_read_roots;
 use anyhow::Result;
 use codex_protocol::models::PermissionProfile;
-use codex_sandboxing::compatibility_sandbox_policy_for_permission_profile;
 use std::collections::HashMap;
 use std::path::Path;
 use std::path::PathBuf;
@@ -25,15 +24,8 @@ pub fn grant_read_root_non_elevated(
     }
 
     let canonical_root = dunce::canonicalize(read_root)?;
-    let file_system_sandbox_policy = permission_profile.file_system_sandbox_policy();
-    let policy = compatibility_sandbox_policy_for_permission_profile(
-        permission_profile,
-        &file_system_sandbox_policy,
-        permission_profile.network_sandbox_policy(),
-        policy_cwd,
-    );
     run_setup_refresh_with_extra_read_roots(
-        &policy,
+        permission_profile,
         policy_cwd,
         command_cwd,
         env_map,

--- a/codex-rs/tui/Cargo.toml
+++ b/codex-rs/tui/Cargo.toml
@@ -116,8 +116,6 @@ url = { workspace = true }
 urlencoding = { workspace = true }
 webbrowser = { workspace = true }
 uuid = { workspace = true }
-
-codex-windows-sandbox = { workspace = true }
 tokio-util = { workspace = true, features = ["time"] }
 
 [target.'cfg(not(target_os = "linux"))'.dependencies]

--- a/codex-rs/tui/src/app/event_dispatch.rs
+++ b/codex-rs/tui/src/app/event_dispatch.rs
@@ -746,13 +746,9 @@ impl App {
                     self.chat_widget.show_windows_sandbox_setup_status();
                     self.windows_sandbox.setup_started_at = Some(Instant::now());
                     let session_telemetry = self.session_telemetry.clone();
-                    let policy = crate::permission_compat::legacy_compatible_sandbox_policy(
-                        &permission_profile,
-                        policy_cwd.as_path(),
-                    );
                     tokio::task::spawn_blocking(move || {
                         let result = crate::legacy_core::windows_sandbox::run_elevated_setup(
-                            &policy,
+                            &permission_profile,
                             policy_cwd.as_path(),
                             command_cwd.as_path(),
                             &env_map,
@@ -823,14 +819,10 @@ impl App {
                     let session_telemetry = self.session_telemetry.clone();
 
                     self.chat_widget.show_windows_sandbox_setup_status();
-                    let policy = crate::permission_compat::legacy_compatible_sandbox_policy(
-                        &permission_profile,
-                        policy_cwd.as_path(),
-                    );
                     tokio::task::spawn_blocking(move || {
                         if let Err(err) =
                             crate::legacy_core::windows_sandbox::run_legacy_setup_preflight(
-                                &policy,
+                                &permission_profile,
                                 policy_cwd.as_path(),
                                 command_cwd.as_path(),
                                 &env_map,

--- a/codex-rs/tui/src/app/platform_actions.rs
+++ b/codex-rs/tui/src/app/platform_actions.rs
@@ -21,18 +21,14 @@ impl App {
         permission_profile: PermissionProfile,
         tx: AppEventSender,
     ) {
-        let sandbox_policy = crate::permission_compat::legacy_compatible_sandbox_policy(
-            &permission_profile,
-            cwd.as_path(),
-        );
-
         tokio::task::spawn_blocking(move || {
             let logs_base_dir_path = logs_base_dir.as_path();
-            let result = codex_windows_sandbox::apply_world_writable_scan_and_denies(
+            let result = crate::legacy_core::windows_sandbox::apply_world_writable_scan_and_denies(
                 logs_base_dir_path,
                 cwd.as_path(),
                 &env_map,
-                &sandbox_policy,
+                &permission_profile,
+                cwd.as_path(),
                 Some(logs_base_dir_path),
             );
             if result.is_err() {

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -9683,15 +9683,12 @@ impl ChatWidget {
         let cwd = self.config.cwd.clone();
         let env_map: std::collections::HashMap<String, String> = std::env::vars().collect();
         let permission_profile = self.config.permissions.permission_profile();
-        let policy = crate::permission_compat::legacy_compatible_sandbox_policy(
-            &permission_profile,
-            self.config.cwd.as_path(),
-        );
-        match codex_windows_sandbox::apply_world_writable_scan_and_denies(
+        match crate::legacy_core::windows_sandbox::apply_world_writable_scan_and_denies(
             self.config.codex_home.as_path(),
             cwd.as_path(),
             &env_map,
-            &policy,
+            &permission_profile,
+            self.config.cwd.as_path(),
             Some(self.config.codex_home.as_path()),
         ) {
             Ok(_) => None,


### PR DESCRIPTION
## Why

The TUI had to create legacy `SandboxPolicy` values before asking the Windows sandbox setup and world-writable scan helpers to run. That kept legacy conversion logic in UI code even though the Windows sandbox backend is the only consumer that still needs the legacy policy JSON.

This continues the permissions migration by making core's Windows sandbox boundary accept `PermissionProfile` directly and localizing the compatibility projection inside that boundary.

## What changed

- Updated `codex_core::windows_sandbox` setup/preflight/read-root refresh helpers to take `PermissionProfile` instead of `SandboxPolicy`.
- Added a core wrapper for `apply_world_writable_scan_and_denies()` that takes a `PermissionProfile` and derives the legacy policy internally.
- Removed TUI-side legacy policy construction from Windows elevated setup, legacy setup preflight, and world-writable scan paths.
- Removed a duplicate compatibility projection from `windows_sandbox_read_grants`.

## Verification

- `cargo check -p codex-core -p codex-tui --tests`
- `just fix -p codex-core`
- `just fix -p codex-tui`










---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20455).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* __->__ #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373