### PR TITLE
config: gate legacy writable roots from profiles

### DIFF
--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -1698,6 +1698,23 @@ fn apply_managed_filesystem_constraints(
     }
 }
 
+fn accepts_legacy_additional_writable_roots(
+    permission_profile: &PermissionProfile,
+    file_system_sandbox_policy: &FileSystemSandboxPolicy,
+    cwd: &Path,
+) -> bool {
+    // `writable_roots` and memory roots are legacy workspace-write knobs. They
+    // should only extend managed profiles that already grant bounded write
+    // access somewhere, and never disabled/external/full-disk profiles.
+    matches!(
+        permission_profile.enforcement(),
+        SandboxEnforcement::Managed
+    ) && !file_system_sandbox_policy
+        .get_writable_roots_with_cwd(cwd)
+        .is_empty()
+        && !file_system_sandbox_policy.has_full_disk_write_access()
+}
+
 /// Optional overrides for user configuration (e.g., from CLI flags).
 #[derive(Default, Debug, Clone)]
 pub struct ConfigOverrides {
@@ -2166,13 +2183,11 @@ impl Config {
                 } else {
                     NetworkProxyConfig::default()
                 };
-            let sandbox_policy = compatibility_sandbox_policy_for_permission_profile(
+            if accepts_legacy_additional_writable_roots(
                 &permission_profile,
                 &file_system_sandbox_policy,
-                network_sandbox_policy,
                 resolved_cwd.as_path(),
-            );
-            if matches!(sandbox_policy, SandboxPolicy::WorkspaceWrite { .. }) {
+            ) {
                 file_system_sandbox_policy = file_system_sandbox_policy
                     .with_additional_writable_roots(
                         resolved_cwd.as_path(),
@@ -2221,13 +2236,11 @@ impl Config {
                     network_sandbox_policy,
                 )
             };
-            let sandbox_policy = compatibility_sandbox_policy_for_permission_profile(
+            if accepts_legacy_additional_writable_roots(
                 &permission_profile,
                 &file_system_sandbox_policy,
-                network_sandbox_policy,
                 resolved_cwd.as_path(),
-            );
-            if matches!(sandbox_policy, SandboxPolicy::WorkspaceWrite { .. }) {
+            ) {
                 file_system_sandbox_policy = if using_implicit_builtin_profile {
                     file_system_sandbox_policy
                         .with_additional_legacy_workspace_writable_roots(
@@ -2325,13 +2338,11 @@ impl Config {
             // write access to the project roots; read-only, disabled, external,
             // and future non-workspace profiles must not silently grow extra
             // write access.
-            if matches!(permission_profile.enforcement(), SandboxEnforcement::Managed)
-                && file_system_sandbox_policy.can_write_path_with_cwd(
-                    resolved_cwd.as_path(),
-                    resolved_cwd.as_path(),
-                )
-                && !file_system_sandbox_policy.has_full_disk_write_access()
-            {
+            if accepts_legacy_additional_writable_roots(
+                &permission_profile,
+                &file_system_sandbox_policy,
+                resolved_cwd.as_path(),
+            ) {
                 // Keep legacy behavior for extra writable roots while storing
                 // the result as the canonical permission profile. Explicit
                 // extra roots are concrete paths, so their metadata carveouts


### PR DESCRIPTION
## Why

The config loader still had a small profile-mode detour through `SandboxPolicy`: it projected the active `PermissionProfile` into a legacy sandbox policy only to ask whether the result looked like `WorkspaceWrite` before applying legacy `writable_roots` and memory-root additions.

That keeps legacy policy semantics in the middle of config loading even though the canonical runtime model is now `PermissionProfile`. This PR makes that decision from the canonical profile and its runtime filesystem policy instead.

## What Changed

- Added a small helper that says legacy additional writable roots may extend only managed profiles that already grant write access to the active workspace.
- Replaced two temporary `compatibility_sandbox_policy_for_permission_profile(...)` projections in `Config::load_config_with_layer_stack` with that helper.
- Kept disabled, external, read-only, and full-disk profiles from silently growing legacy writable roots.
- Left the existing `Config::legacy_sandbox_policy()` compatibility projection in place for call sites that still need to speak the old API.

## Verification

- `cargo check -p codex-core --tests`
- `cargo test -p codex-core workspace_profile`
- `just fix -p codex-core`








---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20456).
* #20469
* #20468
* #20467
* #20466
* #20465
* #20459
* __->__ #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373