### PR TITLE
[Extension] Allowlist Chrome Extension in the tool_suggest tool

### DIFF
--- a/codex-rs/core-plugins/src/lib.rs
+++ b/codex-rs/core-plugins/src/lib.rs
@@ -28,5 +28,6 @@ pub const TOOL_SUGGEST_DISCOVERABLE_PLUGIN_ALLOWLIST: &[&str] = &[
     "outlook-calendar@openai-curated",
     "linear@openai-curated",
     "figma@openai-curated",
+    "chrome@openai-bundled",
     "computer-use@openai-bundled",
 ];


### PR DESCRIPTION
### Summary
Allowlist chrome extension in tool_suggest tool

### Screenshot
Allowlist chrome extension in tool_suggest tool
<img width="808" height="309" alt="chrome_internal" src="https://github.com/user-attachments/assets/ed769d77-b635-4a40-a0c5-fbff05af3036" />
