### PR TITLE
tui tests: assert permission profiles directly

### DIFF
--- a/codex-rs/tui/src/app/tests.rs
+++ b/codex-rs/tui/src/app/tests.rs
@@ -3001,7 +3001,7 @@ async fn side_fork_config_is_ephemeral_and_appends_developer_guardrails() {
     let mut app = make_test_app().await;
     app.config.developer_instructions = Some("Existing developer policy.".to_string());
     let original_approval_policy = app.config.permissions.approval_policy.value();
-    let original_sandbox_policy = app.config.legacy_sandbox_policy();
+    let original_permission_profile = app.config.permissions.permission_profile();
 
     let fork_config = app.side_fork_config();
 
@@ -3010,7 +3010,10 @@ async fn side_fork_config_is_ephemeral_and_appends_developer_guardrails() {
         fork_config.permissions.approval_policy.value(),
         original_approval_policy
     );
-    assert_eq!(fork_config.legacy_sandbox_policy(), original_sandbox_policy);
+    assert_eq!(
+        fork_config.permissions.permission_profile(),
+        original_permission_profile
+    );
     let developer_instructions = fork_config
         .developer_instructions
         .as_deref()

--- a/codex-rs/tui/src/app_server_session.rs
+++ b/codex-rs/tui/src/app_server_session.rs
@@ -1893,10 +1893,9 @@ mod tests {
             instruction_sources: vec![test_path_buf("/tmp/project/AGENTS.md").abs()],
             approval_policy: codex_protocol::protocol::AskForApproval::Never.into(),
             approvals_reviewer: codex_app_server_protocol::ApprovalsReviewer::User,
-            sandbox: read_only_profile
-                .to_legacy_sandbox_policy(test_path_buf("/tmp/project").as_path())
-                .expect("read-only profile must be legacy-compatible")
-                .into(),
+            sandbox: codex_app_server_protocol::SandboxPolicy::ReadOnly {
+                network_access: false,
+            },
             permission_profile: Some(read_only_profile.clone().into()),
             active_permission_profile: None,
             reasoning_effort: None,

--- a/codex-rs/tui/src/chatwidget/tests/history_replay.rs
+++ b/codex-rs/tui/src/chatwidget/tests/history_replay.rs
@@ -276,9 +276,6 @@ async fn session_configured_syncs_widget_config_permissions_and_cwd() {
             &expected_file_system_policy,
             NetworkSandboxPolicy::Restricted,
         );
-    let expected_sandbox = expected_permission_profile
-        .to_legacy_sandbox_policy(expected_cwd.as_path())
-        .expect("permission profile should project to legacy sandbox policy");
     let configured = codex_protocol::protocol::SessionConfiguredEvent {
         session_id: ThreadId::new(),
         forked_from_id: None,
@@ -309,10 +306,6 @@ async fn session_configured_syncs_widget_config_permissions_and_cwd() {
         AskForApproval::Never
     );
     assert_eq!(
-        &chat.config_ref().legacy_sandbox_policy(),
-        &expected_sandbox
-    );
-    assert_eq!(
         chat.config_ref().permissions.permission_profile(),
         expected_permission_profile
     );
@@ -335,9 +328,6 @@ async fn session_configured_external_sandbox_keeps_external_runtime_policy() {
     let expected_permission_profile = PermissionProfile::External {
         network: NetworkSandboxPolicy::Restricted,
     };
-    let expected_sandbox = expected_permission_profile
-        .to_legacy_sandbox_policy(test_path_buf("/home/user/external").as_path())
-        .expect("external profile should project to legacy sandbox policy");
     let configured = codex_protocol::protocol::SessionConfiguredEvent {
         session_id: ThreadId::new(),
         forked_from_id: None,
@@ -347,7 +337,7 @@ async fn session_configured_external_sandbox_keeps_external_runtime_policy() {
         service_tier: None,
         approval_policy: AskForApproval::Never,
         approvals_reviewer: ApprovalsReviewer::User,
-        permission_profile: expected_permission_profile,
+        permission_profile: expected_permission_profile.clone(),
         active_permission_profile: None,
         cwd: test_path_buf("/home/user/external").abs(),
         reasoning_effort: Some(ReasoningEffortConfig::default()),
@@ -364,8 +354,8 @@ async fn session_configured_external_sandbox_keeps_external_runtime_policy() {
     });
 
     assert_eq!(
-        &chat.config_ref().legacy_sandbox_policy(),
-        &expected_sandbox
+        chat.config_ref().permissions.permission_profile(),
+        expected_permission_profile
     );
     assert_eq!(
         chat.config_ref()


### PR DESCRIPTION
## Why

The TUI production path still has one intentional `SandboxPolicy` compatibility boundary for remote app-server requests, but several local tests were also validating behavior by converting `PermissionProfile` values back into legacy sandbox policies.

Those test assertions made permission-profile behavior look dependent on the old abstraction. This PR changes the tests to assert the canonical profile/runtime state directly.

## What Changed

- Updated `side_fork_config_is_ephemeral_and_appends_developer_guardrails` to compare inherited `PermissionProfile` values instead of legacy sandbox projections.
- Updated session-configured history replay tests to verify the stored `PermissionProfile`, filesystem sandbox kind, network policy, and cwd directly.
- Replaced one app-server response fixture’s derived legacy sandbox value with the explicit v2 `ReadOnly` compatibility payload required by that response shape.

## Verification

- `cargo check -p codex-tui --tests`
- `cargo test -p codex-tui session_configured`
- `cargo test -p codex-tui side_fork_config_is_ephemeral_and_appends_developer_guardrails`
- `cargo test -p codex-tui turn_permissions`
- `just fix -p codex-tui`







---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20459).
* #20469
* #20468
* #20467
* #20466
* #20465
* __->__ #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373