### PR TITLE
feat(rollouts): store EventMsg::McpToolCallEnd in limited history mode

### DIFF
--- a/codex-rs/rollout/src/policy.rs
+++ b/codex-rs/rollout/src/policy.rs
@@ -94,6 +94,7 @@ fn event_msg_persistence_mode(ev: &EventMsg) -> Option<EventPersistenceMode> {
         | EventMsg::AgentMessage(_)
         | EventMsg::AgentReasoning(_)
         | EventMsg::AgentReasoningRawContent(_)
+        | EventMsg::McpToolCallEnd(_)
         | EventMsg::TokenCount(_)
         | EventMsg::ThreadNameUpdated(_)
         | EventMsg::ContextCompacted(_)
@@ -120,7 +121,6 @@ fn event_msg_persistence_mode(ev: &EventMsg) -> Option<EventPersistenceMode> {
         | EventMsg::WebSearchEnd(_)
         | EventMsg::ExecCommandEnd(_)
         | EventMsg::PatchApplyEnd(_)
-        | EventMsg::McpToolCallEnd(_)
         | EventMsg::ViewImageToolCall(_)
         | EventMsg::CollabAgentSpawnEnd(_)
         | EventMsg::CollabAgentInteractionEnd(_)
@@ -183,44 +183,5 @@ fn event_msg_persistence_mode(ev: &EventMsg) -> Option<EventPersistenceMode> {
         | EventMsg::CollabCloseBegin(_)
         | EventMsg::CollabResumeBegin(_)
         | EventMsg::ImageGenerationBegin(_) => None,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::EventPersistenceMode;
-    use super::should_persist_event_msg;
-    use codex_protocol::ThreadId;
-    use codex_protocol::protocol::EventMsg;
-    use codex_protocol::protocol::ImageGenerationEndEvent;
-    use codex_protocol::protocol::ThreadNameUpdatedEvent;
-
-    #[test]
-    fn persists_image_generation_end_events_in_limited_mode() {
-        let event = EventMsg::ImageGenerationEnd(ImageGenerationEndEvent {
-            call_id: "ig_123".into(),
-            status: "completed".into(),
-            revised_prompt: Some("final prompt".into()),
-            result: "Zm9v".into(),
-            saved_path: None,
-        });
-
-        assert!(should_persist_event_msg(
-            &event,
-            EventPersistenceMode::Limited
-        ));
-    }
-
-    #[test]
-    fn persists_thread_name_updates_in_limited_mode() {
-        let event = EventMsg::ThreadNameUpdated(ThreadNameUpdatedEvent {
-            thread_id: ThreadId::new(),
-            thread_name: Some("saved-session".to_string()),
-        });
-
-        assert!(should_persist_event_msg(
-            &event,
-            EventPersistenceMode::Limited
-        ));
     }
 }


### PR DESCRIPTION
Similar to https://github.com/openai/codex/pull/20463, we want to persist MCP tool calls even in limited history mode because we want a client to be able to reconnect to a running app-server that has called, let's say, a slack MCP and the slack MCP responded with an elicitation, we want to be able to show that elicitation when a client reconnects.