### PR TITLE
config tests: assert sandbox-mode fallbacks via profiles

### DIFF
--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -3174,10 +3174,10 @@ async fn profile_sandbox_mode_overrides_base() -> std::io::Result<()> {
     )
     .await?;
 
-    assert!(matches!(
-        &config.legacy_sandbox_policy(),
-        &SandboxPolicy::DangerFullAccess
-    ));
+    assert_eq!(
+        config.permissions.permission_profile(),
+        PermissionProfile::Disabled
+    );
 
     Ok(())
 }
@@ -3208,15 +3208,22 @@ async fn cli_override_takes_precedence_over_profile_sandbox_mode() -> std::io::R
         Config::load_from_base_config_with_overrides(cfg, overrides, codex_home.abs()).await?;
 
     if cfg!(target_os = "windows") {
-        assert!(matches!(
-            &config.legacy_sandbox_policy(),
-            SandboxPolicy::ReadOnly { .. }
-        ));
+        assert_eq!(
+            config.permissions.permission_profile(),
+            PermissionProfile::read_only()
+        );
     } else {
-        assert!(matches!(
-            &config.legacy_sandbox_policy(),
-            SandboxPolicy::WorkspaceWrite { .. }
-        ));
+        assert!(
+            config
+                .permissions
+                .file_system_sandbox_policy()
+                .can_write_path_with_cwd(config.cwd.as_path(), config.cwd.as_path()),
+            "Expected workspace-write permissions"
+        );
+        assert_eq!(
+            config.permissions.network_sandbox_policy(),
+            NetworkSandboxPolicy::Restricted
+        );
     }
 
     Ok(())
@@ -7500,20 +7507,22 @@ async fn test_untrusted_project_gets_unless_trusted_approval_policy() -> anyhow:
 
     // Verify that untrusted projects still get WorkspaceWrite sandbox (or ReadOnly on Windows)
     if cfg!(target_os = "windows") {
-        assert!(
-            matches!(
-                &config.legacy_sandbox_policy(),
-                SandboxPolicy::ReadOnly { .. }
-            ),
-            "Expected ReadOnly on Windows"
+        assert_eq!(
+            config.permissions.permission_profile(),
+            PermissionProfile::read_only(),
+            "Expected ReadOnly permissions on Windows"
         );
     } else {
         assert!(
-            matches!(
-                &config.legacy_sandbox_policy(),
-                SandboxPolicy::WorkspaceWrite { .. }
-            ),
-            "Expected WorkspaceWrite sandbox for untrusted project"
+            config
+                .permissions
+                .file_system_sandbox_policy()
+                .can_write_path_with_cwd(config.cwd.as_path(), config.cwd.as_path()),
+            "Expected workspace permissions for untrusted project"
+        );
+        assert_eq!(
+            config.permissions.network_sandbox_policy(),
+            NetworkSandboxPolicy::Restricted
         );
     }
 
@@ -7536,8 +7545,8 @@ async fn requirements_disallowing_default_sandbox_falls_back_to_required_default
         .build()
         .await?;
     assert_eq!(
-        config.legacy_sandbox_policy(),
-        SandboxPolicy::new_read_only_policy()
+        config.permissions.permission_profile(),
+        PermissionProfile::read_only()
     );
     Ok(())
 }
@@ -7578,8 +7587,8 @@ async fn explicit_sandbox_mode_falls_back_when_disallowed_by_requirements() -> s
         .build()
         .await?;
     assert_eq!(
-        config.legacy_sandbox_policy(),
-        SandboxPolicy::new_read_only_policy()
+        config.permissions.permission_profile(),
+        PermissionProfile::read_only()
     );
     Ok(())
 }


### PR DESCRIPTION
## Why

Sandbox-mode fallback tests still asserted `legacy_sandbox_policy()` even though the config loader now computes a canonical `PermissionProfile` first. These assertions should verify the active permission profile/runtime policy unless the test is specifically about the legacy compatibility projection.

## What Changed

- Changed profile-vs-base and CLI sandbox override tests to assert the derived permission profile/runtime filesystem policy.
- Changed untrusted-project and requirements fallback tests to assert permission-profile outcomes directly.
- Left legacy-root tests unchanged where they still validate compatibility behavior for `sandbox_workspace_write` and additional writable roots.

## Verification

```shell
cargo test -p codex-core profile_sandbox_mode_overrides_base
cargo test -p codex-core cli_override_takes_precedence_over_profile_sandbox_mode
cargo test -p codex-core test_untrusted_project_gets_unless_trusted_approval_policy
cargo test -p codex-core requirements_disallowing_default_sandbox_falls_back_to_required_default
cargo test -p codex-core explicit_sandbox_mode_falls_back_when_disallowed_by_requirements
just fix -p codex-core
```



---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20467).
* #20469
* #20468
* __->__ #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373