### PR TITLE
docs: avoid stale SandboxPolicy references

### DIFF
--- a/codex-rs/core/src/spawn.rs
+++ b/codex-rs/core/src/spawn.rs
@@ -30,7 +30,7 @@ pub enum StdioPolicy {
     Inherit,
 }
 
-/// Spawns the appropriate child process for the ExecParams and SandboxPolicy,
+/// Spawns the appropriate child process for the prepared exec request,
 /// ensuring the args and environment variables used to create the `Command`
 /// (and `Child`) honor the configuration.
 ///

--- a/codex-rs/utils/cli/src/sandbox_mode_cli_arg.rs
+++ b/codex-rs/utils/cli/src/sandbox_mode_cli_arg.rs
@@ -1,10 +1,9 @@
 //! Standard type to use with the `--sandbox` (`-s`) CLI option.
 //!
-//! This mirrors the variants of [`codex_protocol::protocol::SandboxPolicy`], but
-//! without any of the associated data so it can be expressed as a simple flag
-//! on the command-line. Users that need to tweak the advanced options for
-//! `workspace-write` can continue to do so via `-c` overrides or their
-//! `config.toml`.
+//! This mirrors the legacy sandbox mode names, but without any associated data
+//! so it can be expressed as a simple flag on the command-line. Users that need
+//! to tweak the advanced options for `workspace-write` can continue to do so
+//! via `-c` overrides or their `config.toml`.
 
 use clap::ValueEnum;
 use codex_protocol::config_types::SandboxMode;


### PR DESCRIPTION
## Why

A couple of comments still referred to `SandboxPolicy` in places that no longer work directly in terms of that type. Those stale references make the remaining `rg '\bSandboxPolicy\b'` audit noisier than it needs to be.

## What Changed

- Updated the `spawn` request documentation to refer to the prepared exec request rather than `SandboxPolicy`.
- Updated the `--sandbox` CLI helper module docs to describe legacy sandbox mode names without linking the old policy type.

## Verification

Documentation-only change; formatted with `just fmt`.


---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/20468).
* #20469
* __->__ #20468
* #20467
* #20466
* #20465
* #20459
* #20456
* #20455
* #20452
* #20450
* #20449
* #20446
* #20441
* #20440
* #20438
* #20436
* #20433
* #20432
* #20431
* #20430
* #20429
* #20428
* #20426
* #20424
* #20423
* #20422
* #20421
* #20420
* #20414
* #20412
* #20411
* #20410
* #20409
* #20408
* #20407
* #20406
* #20404
* #20403
* #20401
* #20400
* #20398
* #20397
* #20396
* #20394
* #20393
* #20390
* #20389
* #20388
* #20387
* #20386
* #20384
* #20382
* #20381
* #20380
* #20378
* #20376
* #20375
* #20372
* #20370
* #20369
* #20368
* #20367
* #20365
* #20363
* #20362
* #20360
* #20359
* #20358
* #20357
* #20356
* #20355
* #20373