### PR TITLE
ci: add Windows cargo-xwin release PoC

### DIFF
--- a/.github/workflows/rust-release-windows-cross-compile-poc.yml
+++ b/.github/workflows/rust-release-windows-cross-compile-poc.yml
@@ -1,0 +1,182 @@
+name: rust-release-windows-cross-compile-poc
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/rust-release-windows-cross-compile-poc.yml"
+  workflow_dispatch:
+    inputs:
+      release_lto:
+        description: Cargo release LTO mode
+        type: choice
+        default: thin
+        options:
+          - thin
+          - fat
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_PROFILE_RELEASE_LTO: ${{ github.event_name == 'workflow_dispatch' && inputs.release_lto || 'thin' }}
+  CARGO_TERM_COLOR: always
+  CARGO_XWIN_VERSION: 0.22.0
+  WINDOWS_TARGET: x86_64-pc-windows-msvc
+  XWIN_ARCH: x86_64
+  XWIN_CACHE_DIR: ${{ github.workspace }}/.xwin-cache
+  XWIN_VARIANT: desktop
+
+jobs:
+  build-windows-binaries:
+    name: Cross-compile Windows release binaries
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    defaults:
+      run:
+        working-directory: codex-rs
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Print runner specs
+        shell: bash
+        run: |
+          set -euo pipefail
+          cpu_model="$(lscpu | awk -F: '/Model name/ {gsub(/^[ \t]+/, "", $2); print $2; exit}')"
+          total_ram="$(awk '/MemTotal/ {printf "%.1f GiB\n", $2 / 1024 / 1024}' /proc/meminfo)"
+          echo "Runner: ${RUNNER_NAME:-unknown}"
+          echo "OS: $(uname -a)"
+          echo "CPU model: ${cpu_model}"
+          echo "Logical CPUs: $(nproc)"
+          echo "Total RAM: ${total_ram}"
+          echo "Disk usage:"
+          df -h .
+
+      - name: Install cross-linker dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update -y
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            clang \
+            cmake \
+            lld \
+            llvm \
+            nasm \
+            ninja-build \
+            pkg-config \
+            strace
+
+      - uses: dtolnay/rust-toolchain@a0b273b48ed29de4470960879e8381ff45632f26 # 1.93.0
+        with:
+          targets: ${{ env.WINDOWS_TARGET }}
+
+      - name: Compute cache key inputs
+        id: lockhash
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "lock_hash=$(sha256sum Cargo.lock | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+          echo "toolchain_hash=$(sha256sum rust-toolchain.toml | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore cargo-xwin cache
+        id: cache_cargo_xwin_restore
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ${{ env.XWIN_CACHE_DIR }}
+          key: cargo-xwin-${{ runner.os }}-${{ env.WINDOWS_TARGET }}-${{ env.CARGO_XWIN_VERSION }}-${{ steps.lockhash.outputs.lock_hash }}-${{ steps.lockhash.outputs.toolchain_hash }}
+          restore-keys: |
+            cargo-xwin-${{ runner.os }}-${{ env.WINDOWS_TARGET }}-${{ env.CARGO_XWIN_VERSION }}-
+
+      - name: Install cargo-xwin
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! cargo xwin --version 2>/dev/null | grep -F "$CARGO_XWIN_VERSION" >/dev/null; then
+            cargo install cargo-xwin --locked --version "$CARGO_XWIN_VERSION"
+          fi
+          cargo xwin --version
+
+      - name: Cache MSVC CRT and Windows SDK
+        shell: bash
+        run: cargo xwin cache xwin
+
+      - name: Build codex-responses-api-proxy
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo xwin build \
+            --release \
+            --target "$WINDOWS_TARGET" \
+            --timings \
+            --bin codex-responses-api-proxy
+
+      - name: Build codex-app-server
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo xwin build \
+            --release \
+            --target "$WINDOWS_TARGET" \
+            --timings \
+            --bin codex-app-server
+
+      - name: Build codex
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo xwin build \
+            --release \
+            --target "$WINDOWS_TARGET" \
+            --timings \
+            --bin codex
+
+      - name: Verify Windows artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          for binary in codex-responses-api-proxy codex-app-server codex; do
+            path="target/${WINDOWS_TARGET}/release/${binary}.exe"
+            ls -lh "$path"
+            file "$path"
+          done
+
+      - name: Upload Cargo timings
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: cargo-timings-rust-release-windows-cross-compile-poc-${{ env.WINDOWS_TARGET }}-primary-app-server
+          path: codex-rs/target/**/cargo-timings/cargo-timing.html
+          if-no-files-found: warn
+
+      - name: Upload Windows binaries
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: windows-cross-compile-poc-${{ env.WINDOWS_TARGET }}-primary-app-server
+          path: |
+            codex-rs/target/${{ env.WINDOWS_TARGET }}/release/codex-responses-api-proxy.exe
+            codex-rs/target/${{ env.WINDOWS_TARGET }}/release/codex-app-server.exe
+            codex-rs/target/${{ env.WINDOWS_TARGET }}/release/codex.exe
+          if-no-files-found: error
+
+      - name: Save cargo-xwin cache
+        if: always() && !cancelled() && steps.cache_cargo_xwin_restore.outputs.cache-hit != 'true'
+        continue-on-error: true
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ${{ env.XWIN_CACHE_DIR }}
+          key: cargo-xwin-${{ runner.os }}-${{ env.WINDOWS_TARGET }}-${{ env.CARGO_XWIN_VERSION }}-${{ steps.lockhash.outputs.lock_hash }}-${{ steps.lockhash.outputs.toolchain_hash }}


### PR DESCRIPTION
## Why

Windows release builds are currently expensive enough that the Windows jobs can dominate release latency. This PR is a proof of concept for building Windows release binaries from Linux with Cargo, using `cargo-xwin` to target `x86_64-pc-windows-msvc`.

The goal is to validate whether Cargo-based cross compilation can build the Windows release binaries we care about before changing the real signed release workflow. This PoC intentionally does not include signing logic.

## What Changed

Adds `.github/workflows/rust-release-windows-cross-compile-poc.yml`, a minimal workflow that:

- runs on `ubuntu-24.04`
- installs the `x86_64-pc-windows-msvc` Rust target
- installs `cargo-xwin`
- caches Cargo registry/git data plus the xwin MSVC CRT and Windows SDK cache
- builds these release binaries:
  - `codex-responses-api-proxy`
  - `codex-app-server`
  - `codex`
- verifies that the outputs are Windows `PE32+` executables
- uploads the binaries and Cargo timing HTML as workflow artifacts

## Toolchain Confidence

This PoC is still a Cargo-based release build: the workflow runs `cargo xwin build --release --target x86_64-pc-windows-msvc`. It is not a Bazel build, and it is not changing the Rust target ABI away from the normal Windows MSVC target.

The important distinction from a native Windows `cargo build --release --target x86_64-pc-windows-msvc` is the host toolchain around Cargo:

- native Windows builds typically use MSVC `link.exe`, an installed Visual Studio toolchain, and the installed Windows SDK
- `cargo-xwin` uses `xwin` to provide the Microsoft CRT and Windows SDK headers/libs on non-Windows hosts
- the cross build uses LLVM tooling, including `lld-link`; `cargo-xwin` defaults C/C++ cross-compilation to `clang-cl`

This is why the PoC verifies the produced files are normal Windows `PE32+` executables for `x86_64-pc-windows-msvc`.

For linker maturity, this is not an obscure linker path. LLVM's Windows `lld` documentation says `lld-link` accepts almost all `link.exe` command-line options and is used to link production Windows builds of large real-world binaries such as Firefox and Chromium:

https://lld.llvm.org/windows_support.html

That does **not** mean Firefox or Chromium use `cargo-xwin`; the relevant point is that the linker family used by this cross-compilation path is already used for major production Windows binaries.

Relevant tool docs:

- `cargo-xwin`: https://github.com/rust-cross/cargo-xwin
- `xwin`: https://github.com/Jake-Shadle/xwin
- LLVM `lld-link`: https://lld.llvm.org/windows_support.html

Before replacing the signed release path, we should still smoke-test the cross-built binaries on Windows and compare any relevant startup/runtime benchmarks. The main risks are compatibility or behavioral differences from `lld-link`, `clang-cl`, or SDK/CRT version differences, not a known systematic Rust runtime performance penalty from cross-compilation itself.

## Workflow Commands

I triggered the successful thin-LTO workflow by pushing updates to the draft PR branch:

```shell
sl pr submit -d
```

That used the workflow's `pull_request` trigger.

I triggered the fat-LTO experiment with:

```shell
gh workflow run rust-release-windows-cross-compile-poc.yml \
  --repo openai/codex \
  --ref pr20485 \
  -f release_lto=fat
```

The build commands executed by the workflow are:

```shell
cargo xwin build \
  --release \
  --target "$WINDOWS_TARGET" \
  --timings \
  --bin codex-responses-api-proxy

cargo xwin build \
  --release \
  --target "$WINDOWS_TARGET" \
  --timings \
  --bin codex-app-server

cargo xwin build \
  --release \
  --target "$WINDOWS_TARGET" \
  --timings \
  --bin codex
```

For both successful runs, `WINDOWS_TARGET` was `x86_64-pc-windows-msvc`.

## Verification

Successful thin-LTO workflow run:

https://github.com/openai/codex/actions/runs/25185982350

Successful thin-LTO job:

https://github.com/openai/codex/actions/runs/25185982350/job/73843273846

Per-binary build step timing from the successful thin-LTO run:

- `codex-responses-api-proxy`: 1m59s
- `codex-app-server`: 23m01s
- `codex`: 16m03s
- total job time: about 42m11s

Successful fat-LTO workflow run:

https://github.com/openai/codex/actions/runs/25190714066

Successful fat-LTO job:

https://github.com/openai/codex/actions/runs/25190714066/job/73859747064

Per-binary build step timing from the successful fat-LTO run:

- `codex-responses-api-proxy`: 1m59s
- `codex-app-server`: 25m01s
- `codex`: 23m58s
- total job time: about 54m30s

These are the durations of each sequential `cargo xwin build` step. Later build steps benefit from dependencies and artifacts produced by earlier steps in the same job.

The workflow verified these output files:

- `target/x86_64-pc-windows-msvc/release/codex-responses-api-proxy.exe`
- `target/x86_64-pc-windows-msvc/release/codex-app-server.exe`
- `target/x86_64-pc-windows-msvc/release/codex.exe`

## Downloading The Binaries

From the GitHub web UI:

1. Open the workflow run:
   - thin LTO: https://github.com/openai/codex/actions/runs/25185982350
   - fat LTO: https://github.com/openai/codex/actions/runs/25190714066
2. Scroll to the bottom of the run page.
3. In **Artifacts**, click `windows-cross-compile-poc-x86_64-pc-windows-msvc-primary-app-server`.

GitHub downloads the artifact as a `.zip`. You must be logged into GitHub and have access to the repo.

From the CLI:

```shell
gh run download 25185982350 \
  --repo openai/codex \
  --name windows-cross-compile-poc-x86_64-pc-windows-msvc-primary-app-server

gh run download 25190714066 \
  --repo openai/codex \
  --name windows-cross-compile-poc-x86_64-pc-windows-msvc-primary-app-server
```

Each artifact contains:

- `codex.exe`
- `codex-app-server.exe`
- `codex-responses-api-proxy.exe`

Both artifacts expire on 2026-07-29.
