### PR TITLE
Track goal continuation activity separately

### DIFF
--- a/codex-rs/core/src/goals.rs
+++ b/codex-rs/core/src/goals.rs
@@ -13,8 +13,10 @@ use crate::tasks::RegularTask;
 use anyhow::Context;
 use codex_features::Feature;
 use codex_protocol::config_types::ModeKind;
+use codex_protocol::items::TurnItem;
 use codex_protocol::models::ContentItem;
 use codex_protocol::models::ResponseInputItem;
+use codex_protocol::models::ResponseItem;
 use codex_protocol::protocol::Event;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::ThreadGoal;
@@ -90,7 +92,7 @@ pub(crate) enum GoalRuntimeEvent<'a> {
     TurnFinished {
         turn_context: &'a TurnContext,
         turn_completed: bool,
-        tool_calls: u64,
+        continuation_activity_count: u64,
     },
     MaybeContinueIfIdle,
     TaskAborted {
@@ -118,6 +120,30 @@ pub(crate) struct GoalRuntimeState {
 struct GoalContinuationCandidate {
     goal_id: String,
     items: Vec<ResponseInputItem>,
+}
+
+pub(crate) fn turn_item_counts_as_goal_continuation_activity(item: &TurnItem) -> bool {
+    // Keep this match exhaustive so new built-in turn item kinds force a
+    // review of whether they should keep goal auto-continuation alive.
+    match item {
+        TurnItem::UserMessage(_) => false,
+        TurnItem::HookPrompt(_) => false,
+        TurnItem::AgentMessage(_) => false,
+        TurnItem::Plan(_) => false,
+        TurnItem::Reasoning(_) => false,
+        TurnItem::WebSearch(_) => true,
+        TurnItem::ImageGeneration(_) => true,
+        TurnItem::ContextCompaction(_) => false,
+    }
+}
+
+pub(crate) fn response_item_counts_as_goal_continuation_activity_without_turn_item(
+    item: &ResponseItem,
+) -> bool {
+    matches!(
+        item,
+        ResponseItem::ToolSearchCall { execution, .. } if execution != "client"
+    )
 }
 
 impl GoalRuntimeState {
@@ -277,8 +303,8 @@ impl Session {
     /// suppresses that steering, external mutations account best-effort before
     /// changing state, interrupts pause active goals, resumes reactivate paused
     /// goals, explicit maybe-continue events start idle goal continuation turns,
-    /// and no-tool continuation turns suppress the next automatic continuation
-    /// until user/tool/external activity resets it.
+    /// and continuation turns with no counted autonomous activity suppress the
+    /// next automatic continuation until user/tool/external activity resets it.
     pub(crate) fn goal_runtime_apply<'a>(
         self: &'a Arc<Self>,
         event: GoalRuntimeEvent<'a>,
@@ -312,10 +338,14 @@ impl Session {
             GoalRuntimeEvent::TurnFinished {
                 turn_context,
                 turn_completed,
-                tool_calls,
+                continuation_activity_count,
             } => Box::pin(async move {
-                self.finish_thread_goal_turn(turn_context, turn_completed, tool_calls)
-                    .await;
+                self.finish_thread_goal_turn(
+                    turn_context,
+                    turn_completed,
+                    continuation_activity_count,
+                )
+                .await;
                 Ok(())
             }),
             GoalRuntimeEvent::MaybeContinueIfIdle => Box::pin(async move {
@@ -757,7 +787,7 @@ impl Session {
         self: &Arc<Self>,
         turn_context: &TurnContext,
         turn_completed: bool,
-        turn_tool_calls: u64,
+        turn_continuation_activity_count: u64,
     ) {
         if turn_completed
             && let Err(err) = self
@@ -770,7 +800,7 @@ impl Session {
         if self
             .take_thread_goal_continuation_turn(&turn_context.sub_id)
             .await
-            && turn_tool_calls == 0
+            && turn_continuation_activity_count == 0
         {
             self.goal_runtime
                 .continuation_suppressed
@@ -1261,7 +1291,7 @@ impl Session {
             .load(Ordering::SeqCst)
         {
             tracing::debug!(
-                "skipping active goal continuation because the last continuation made no tool calls"
+                "skipping active goal continuation because the last continuation made no counted autonomous activity"
             );
             return None;
         }
@@ -1513,12 +1543,28 @@ mod tests {
     use super::continuation_prompt;
     use super::escape_xml_text;
     use super::goal_token_delta_for_usage;
+    use super::response_item_counts_as_goal_continuation_activity_without_turn_item;
     use super::should_ignore_goal_for_mode;
+    use super::turn_item_counts_as_goal_continuation_activity;
     use codex_protocol::ThreadId;
     use codex_protocol::config_types::ModeKind;
+    use codex_protocol::items::AgentMessageContent;
+    use codex_protocol::items::AgentMessageItem;
+    use codex_protocol::items::ContextCompactionItem;
+    use codex_protocol::items::HookPromptFragment;
+    use codex_protocol::items::HookPromptItem;
+    use codex_protocol::items::ImageGenerationItem;
+    use codex_protocol::items::PlanItem;
+    use codex_protocol::items::ReasoningItem;
+    use codex_protocol::items::TurnItem;
+    use codex_protocol::items::UserMessageItem;
+    use codex_protocol::items::WebSearchItem;
+    use codex_protocol::models::ResponseItem;
+    use codex_protocol::models::WebSearchAction;
     use codex_protocol::protocol::ThreadGoal;
     use codex_protocol::protocol::ThreadGoalStatus;
     use codex_protocol::protocol::TokenUsage;
+    use codex_protocol::user_input::UserInput;
     use std::time::Duration;
     use std::time::Instant;
 
@@ -1541,6 +1587,125 @@ mod tests {
         };
 
         assert_eq!(580, goal_token_delta_for_usage(&usage));
+    }
+
+    #[test]
+    fn turn_item_goal_continuation_activity_matches_expected_variants() {
+        let cases = [
+            (
+                false,
+                TurnItem::UserMessage(UserMessageItem::new(&[UserInput::Text {
+                    text: "hello".to_string(),
+                    text_elements: Vec::new(),
+                }])),
+            ),
+            (
+                false,
+                TurnItem::HookPrompt(HookPromptItem::from_fragments(
+                    None,
+                    vec![HookPromptFragment::from_single_hook("hook text", "hook-1")],
+                )),
+            ),
+            (
+                false,
+                TurnItem::AgentMessage(AgentMessageItem::new(&[AgentMessageContent::Text {
+                    text: "hello".to_string(),
+                }])),
+            ),
+            (
+                false,
+                TurnItem::Plan(PlanItem {
+                    id: "plan-1".to_string(),
+                    text: "plan".to_string(),
+                }),
+            ),
+            (
+                false,
+                TurnItem::Reasoning(ReasoningItem {
+                    id: "reason-1".to_string(),
+                    summary_text: vec!["thinking".to_string()],
+                    raw_content: Vec::new(),
+                }),
+            ),
+            (
+                true,
+                TurnItem::WebSearch(WebSearchItem {
+                    id: "ws-1".to_string(),
+                    query: "benchmark note structure".to_string(),
+                    action: WebSearchAction::Search {
+                        query: Some("benchmark note structure".to_string()),
+                        queries: None,
+                    },
+                }),
+            ),
+            (
+                true,
+                TurnItem::ImageGeneration(ImageGenerationItem {
+                    id: "ig-1".to_string(),
+                    status: "completed".to_string(),
+                    revised_prompt: None,
+                    result: String::new(),
+                    saved_path: None,
+                }),
+            ),
+            (
+                false,
+                TurnItem::ContextCompaction(ContextCompactionItem::new()),
+            ),
+        ];
+
+        for (expected, item) in cases {
+            assert_eq!(
+                expected,
+                turn_item_counts_as_goal_continuation_activity(&item),
+                "unexpected continuation-activity classification for {item:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn raw_response_goal_continuation_activity_only_counts_server_tool_search() {
+        let cases = [
+            (
+                false,
+                ResponseItem::ToolSearchCall {
+                    id: None,
+                    call_id: Some("search-client".to_string()),
+                    status: Some("completed".to_string()),
+                    execution: "client".to_string(),
+                    arguments: serde_json::json!({ "query": "calendar" }),
+                },
+            ),
+            (
+                true,
+                ResponseItem::ToolSearchCall {
+                    id: None,
+                    call_id: Some("search-server".to_string()),
+                    status: Some("completed".to_string()),
+                    execution: "server".to_string(),
+                    arguments: serde_json::json!({ "query": "calendar" }),
+                },
+            ),
+            (
+                false,
+                ResponseItem::WebSearchCall {
+                    id: Some("ws-1".to_string()),
+                    status: Some("completed".to_string()),
+                    action: Some(WebSearchAction::Search {
+                        query: Some("calendar".to_string()),
+                        queries: None,
+                    }),
+                },
+            ),
+        ];
+
+        for (expected, item) in cases {
+            assert_eq!(
+                expected,
+                response_item_counts_as_goal_continuation_activity_without_turn_item(&item),
+                "unexpected raw continuation-activity classification for {item:?}"
+            );
+        }
     }
 
     #[test]

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -33,6 +33,7 @@ use crate::default_skill_metadata_budget;
 use crate::environment_selection::selected_primary_environment;
 use crate::environment_selection::validate_environment_selections;
 use crate::exec_policy::ExecPolicyManager;
+use crate::goals::turn_item_counts_as_goal_continuation_activity;
 use crate::installation_id::resolve_installation_id;
 use crate::parse_turn_item;
 use crate::path_utils::normalize_for_native_workdir;
@@ -1652,6 +1653,10 @@ impl Session {
         turn_context: &TurnContext,
         item: TurnItem,
     ) {
+        if turn_item_counts_as_goal_continuation_activity(&item) {
+            self.record_continuation_activity_for_turn(&turn_context.sub_id)
+                .await;
+        }
         record_turn_ttfm_metric(turn_context, &item).await;
         self.send_event(
             turn_context,
@@ -3082,6 +3087,14 @@ impl Session {
             return;
         };
         turn_state.lock().await.has_memory_citation = true;
+    }
+
+    pub(crate) async fn record_continuation_activity_for_turn(&self, sub_id: &str) {
+        let turn_state = self.turn_state_for_sub_id(sub_id).await;
+        let Some(turn_state) = turn_state else {
+            return;
+        };
+        turn_state.lock().await.record_continuation_activity();
     }
 
     async fn turn_state_for_sub_id(

--- a/codex-rs/core/src/state/turn.rs
+++ b/codex-rs/core/src/state/turn.rs
@@ -118,6 +118,7 @@ pub(crate) struct TurnState {
     granted_permissions: Option<AdditionalPermissionProfile>,
     strict_auto_review_enabled: bool,
     pub(crate) tool_calls: u64,
+    pub(crate) continuation_activity_count: u64,
     pub(crate) has_memory_citation: bool,
     pub(crate) token_usage_at_turn_start: TokenUsage,
 }
@@ -129,6 +130,15 @@ pub(crate) struct PendingRequestPermissions {
 }
 
 impl TurnState {
+    pub(crate) fn record_tool_call(&mut self) {
+        self.tool_calls = self.tool_calls.saturating_add(1);
+        self.record_continuation_activity();
+    }
+
+    pub(crate) fn record_continuation_activity(&mut self) {
+        self.continuation_activity_count = self.continuation_activity_count.saturating_add(1);
+    }
+
     pub(crate) fn insert_pending_approval(
         &mut self,
         key: String,

--- a/codex-rs/core/src/stream_events_utils.rs
+++ b/codex-rs/core/src/stream_events_utils.rs
@@ -11,6 +11,7 @@ use tokio_util::sync::CancellationToken;
 use crate::context::ContextualUserFragment;
 use crate::context::ImageGenerationInstructions;
 use crate::function_tool::FunctionCallError;
+use crate::goals::response_item_counts_as_goal_continuation_activity_without_turn_item;
 use crate::parse_turn_item;
 use crate::session::session::Session;
 use crate::session::turn_context::TurnContext;
@@ -255,14 +256,21 @@ pub(crate) async fn handle_output_item_done(
         }
         // No tool call: convert messages/reasoning into turn items and mark them as complete.
         Ok(None) => {
-            if let Some(turn_item) = handle_non_tool_response_item(
+            let turn_item = handle_non_tool_response_item(
                 ctx.sess.as_ref(),
                 ctx.turn_context.as_ref(),
                 &item,
                 plan_mode,
             )
-            .await
-            {
+            .await;
+            let counts_as_raw_continuation_activity = turn_item.is_none()
+                && response_item_counts_as_goal_continuation_activity_without_turn_item(&item);
+            if counts_as_raw_continuation_activity {
+                ctx.sess
+                    .record_continuation_activity_for_turn(&ctx.turn_context.sub_id)
+                    .await;
+            }
+            if let Some(turn_item) = turn_item {
                 if previously_active_item.is_none() {
                     let mut started_item = turn_item.clone();
                     if let TurnItem::ImageGeneration(item) = &mut started_item {

--- a/codex-rs/core/src/stream_events_utils.rs
+++ b/codex-rs/core/src/stream_events_utils.rs
@@ -263,6 +263,9 @@ pub(crate) async fn handle_output_item_done(
                 plan_mode,
             )
             .await;
+            // Some built-in activity (currently server-executed `tool_search`)
+            // bypasses turn-item normalization, so preserve goal continuation
+            // progress for those response items here.
             let counts_as_raw_continuation_activity = turn_item.is_none()
                 && response_item_counts_as_goal_continuation_activity_without_turn_item(&item);
             if counts_as_raw_continuation_activity {

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -567,6 +567,7 @@ impl Session {
         let mut token_usage_at_turn_start = None;
         let mut turn_had_memory_citation = false;
         let mut turn_tool_calls = 0_u64;
+        let mut turn_continuation_activity_count = 0_u64;
         let mut records_turn_token_usage_on_span = false;
         let turn_state = {
             let mut active = self.active_turn.lock().await;
@@ -590,6 +591,7 @@ impl Session {
             pending_input = ts.take_pending_input();
             turn_had_memory_citation = ts.has_memory_citation;
             turn_tool_calls = ts.tool_calls;
+            turn_continuation_activity_count = ts.continuation_activity_count;
             token_usage_at_turn_start = Some(ts.token_usage_at_turn_start.clone());
         }
         if !pending_input.is_empty() {
@@ -737,7 +739,7 @@ impl Session {
             .goal_runtime_apply(GoalRuntimeEvent::TurnFinished {
                 turn_context: turn_context.as_ref(),
                 turn_completed: should_clear_active_turn,
-                tool_calls: turn_tool_calls,
+                continuation_activity_count: turn_continuation_activity_count,
             })
             .await
         {

--- a/codex-rs/core/src/tools/registry.rs
+++ b/codex-rs/core/src/tools/registry.rs
@@ -309,7 +309,7 @@ impl ToolRegistry {
             let mut active = invocation.session.active_turn.lock().await;
             if let Some(active_turn) = active.as_mut() {
                 let mut turn_state = active_turn.turn_state.lock().await;
-                turn_state.tool_calls = turn_state.tool_calls.saturating_add(1);
+                turn_state.record_tool_call();
             }
         }
 


### PR DESCRIPTION
## Why

Goal auto-continuation currently decides whether to suppress the next continuation turn by looking only at the number of registry-routed tool calls in the previous continuation turn. That misclassifies productive built-in activity like `web_search_call`, `image_generation_call`, and server-executed `tool_search_call` as "no activity," which can cause a goal to stop auto-continuing even though the agent was still making progress.

This change separates the goal-runtime continuation heuristic from the existing tool-call telemetry so we can keep the anti-spin behavior without treating built-in autonomous work as a no-op.

## What changed

- added a separate `continuation_activity_count` to turn state instead of reusing `tool_calls`
- counted registry tool calls toward both tool-call telemetry and goal continuation activity
- moved the goal-specific activity classification into `core/src/goals.rs`, with an exhaustive `TurnItem` helper plus a small fallback for response items that bypass turn-item normalization today
- updated goal continuation suppression to use the new activity counter and refreshed the related comments/log messages
- added compact unit tests in `core/src/goals.rs` for the activity-classification policy

## Verification

- `cargo test -p codex-core continuation_activity`
- `cargo test -p codex-core`  
  Fails in `shell_snapshot::tests::macos_zsh_snapshot_includes_sections` with `Snapshot command timed out for zsh`; this did not appear related to the goal-continuation changes.
