### PR TITLE
Support multi-env list_dir routing

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -3274,6 +3274,8 @@ pub struct FsReadDirectoryEntry {
     pub is_directory: bool,
     /// Whether this entry resolves to a regular file.
     pub is_file: bool,
+    /// Whether this entry itself is a symbolic link.
+    pub is_symlink: bool,
 }
 
 /// Directory entries returned by `fs/readDirectory`.

--- a/codex-rs/app-server/src/request_processors/fs_processor.rs
+++ b/codex-rs/app-server/src/request_processors/fs_processor.rs
@@ -133,6 +133,7 @@ impl FsRequestProcessor {
                     file_name: entry.file_name,
                     is_directory: entry.is_directory,
                     is_file: entry.is_file,
+                    is_symlink: entry.is_symlink,
                 })
                 .collect(),
         })

--- a/codex-rs/app-server/tests/suite/v2/fs.rs
+++ b/codex-rs/app-server/tests/suite/v2/fs.rs
@@ -270,11 +270,13 @@ async fn fs_methods_cover_current_fs_utils_surface() -> Result<()> {
                 file_name: "nested".to_string(),
                 is_directory: true,
                 is_file: false,
+                is_symlink: false,
             },
             FsReadDirectoryEntry {
                 file_name: "root.txt".to_string(),
                 is_directory: false,
                 is_file: true,
+                is_symlink: false,
             },
         ]
     );

--- a/codex-rs/core/src/session/turn_context.rs
+++ b/codex-rs/core/src/session/turn_context.rs
@@ -276,6 +276,14 @@ impl TurnContext {
         &self,
         additional_permissions: Option<AdditionalPermissionProfile>,
     ) -> FileSystemSandboxContext {
+        self.file_system_sandbox_context_for_cwd(&self.cwd, additional_permissions)
+    }
+
+    pub(crate) fn file_system_sandbox_context_for_cwd(
+        &self,
+        cwd: &AbsolutePathBuf,
+        additional_permissions: Option<AdditionalPermissionProfile>,
+    ) -> FileSystemSandboxContext {
         let (base_file_system_sandbox_policy, base_network_sandbox_policy) =
             self.permission_profile.to_runtime_permissions();
         let file_system_sandbox_policy = effective_file_system_sandbox_policy(
@@ -293,7 +301,7 @@ impl TurnContext {
         );
         FileSystemSandboxContext {
             permissions,
-            cwd: Some(self.cwd.clone()),
+            cwd: Some(cwd.clone()),
             windows_sandbox_level: self.windows_sandbox_level,
             windows_sandbox_private_desktop: self
                 .config

--- a/codex-rs/core/src/tools/handlers/list_dir.rs
+++ b/codex-rs/core/src/tools/handlers/list_dir.rs
@@ -1,13 +1,16 @@
 use std::collections::VecDeque;
 use std::ffi::OsStr;
-use std::fs::FileType;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::Arc;
 
+use codex_exec_server::ExecutorFileSystem;
+use codex_exec_server::FileSystemSandboxContext;
+use codex_exec_server::ReadDirectoryEntry;
 use codex_protocol::permissions::ReadDenyMatcher;
+use codex_utils_absolute_path::AbsolutePathBuf;
 use codex_utils_string::take_bytes_at_char_boundary;
 use serde::Deserialize;
-use tokio::fs;
 
 use crate::function_tool::FunctionCallError;
 use crate::tools::context::FunctionToolOutput;
@@ -39,6 +42,8 @@ fn default_depth() -> usize {
 #[derive(Deserialize)]
 struct ListDirArgs {
     dir_path: String,
+    #[serde(default)]
+    environment_id: Option<String>,
     #[serde(default = "default_offset")]
     offset: usize,
     #[serde(default = "default_limit")]
@@ -70,6 +75,7 @@ impl ToolHandler for ListDirHandler {
 
         let ListDirArgs {
             dir_path,
+            environment_id,
             offset,
             limit,
             depth,
@@ -94,16 +100,22 @@ impl ToolHandler for ListDirHandler {
         }
 
         let path = PathBuf::from(&dir_path);
-        if !path.is_absolute() {
-            return Err(FunctionCallError::RespondToModel(
-                "dir_path must be an absolute path".to_string(),
-            ));
-        }
+        let path = AbsolutePathBuf::from_absolute_path_checked(&path).map_err(|_| {
+            FunctionCallError::RespondToModel("dir_path must be an absolute path".to_string())
+        })?;
+        let Some(turn_environment) = turn.environments.select(environment_id.as_deref()) else {
+            let message = environment_id.map_or_else(
+                || "list_dir is unavailable in this session".to_string(),
+                |environment_id| format!("unknown turn environment id `{environment_id}`"),
+            );
+            return Err(FunctionCallError::RespondToModel(message));
+        };
+        let cwd = turn_environment.cwd.clone();
         let file_system_sandbox_policy = turn.file_system_sandbox_policy();
-        let read_deny_matcher = ReadDenyMatcher::new(&file_system_sandbox_policy, &turn.cwd);
+        let read_deny_matcher = ReadDenyMatcher::new(&file_system_sandbox_policy, &cwd);
         if read_deny_matcher
             .as_ref()
-            .is_some_and(|matcher| matcher.is_read_denied(&path))
+            .is_some_and(|matcher| matcher.is_read_denied(path.as_path()))
         {
             return Err(FunctionCallError::RespondToModel(format!(
                 "{DENY_READ_POLICY_MESSAGE}: `{}`",
@@ -111,9 +123,20 @@ impl ToolHandler for ListDirHandler {
             )));
         }
 
-        let entries =
-            list_dir_slice_with_policy(&path, offset, limit, depth, read_deny_matcher.as_ref())
-                .await?;
+        let sandbox = turn_environment.environment.is_remote().then(|| {
+            turn.file_system_sandbox_context_for_cwd(&cwd, /*additional_permissions*/ None)
+        });
+        let fs = turn_environment.environment.get_filesystem();
+        let entries = list_dir_slice_with_policy(
+            fs,
+            &path,
+            offset,
+            limit,
+            depth,
+            read_deny_matcher.as_ref(),
+            sandbox.as_ref(),
+        )
+        .await?;
         let mut output = Vec::with_capacity(entries.len() + 1);
         output.push(format!("Absolute path: {}", path.display()));
         output.extend(entries);
@@ -122,14 +145,25 @@ impl ToolHandler for ListDirHandler {
 }
 
 async fn list_dir_slice_with_policy(
-    path: &Path,
+    fs: Arc<dyn ExecutorFileSystem>,
+    path: &AbsolutePathBuf,
     offset: usize,
     limit: usize,
     depth: usize,
     read_deny_matcher: Option<&ReadDenyMatcher>,
+    sandbox: Option<&FileSystemSandboxContext>,
 ) -> Result<Vec<String>, FunctionCallError> {
     let mut entries = Vec::new();
-    collect_entries(path, Path::new(""), depth, read_deny_matcher, &mut entries).await?;
+    collect_entries(
+        fs,
+        path,
+        Path::new(""),
+        depth,
+        read_deny_matcher,
+        sandbox,
+        &mut entries,
+    )
+    .await?;
 
     if entries.is_empty() {
         return Ok(Vec::new());
@@ -162,47 +196,43 @@ async fn list_dir_slice_with_policy(
 }
 
 async fn collect_entries(
-    dir_path: &Path,
+    fs: Arc<dyn ExecutorFileSystem>,
+    dir_path: &AbsolutePathBuf,
     relative_prefix: &Path,
     depth: usize,
     read_deny_matcher: Option<&ReadDenyMatcher>,
+    sandbox: Option<&FileSystemSandboxContext>,
     entries: &mut Vec<DirEntry>,
 ) -> Result<(), FunctionCallError> {
     let mut queue = VecDeque::new();
-    queue.push_back((dir_path.to_path_buf(), relative_prefix.to_path_buf(), depth));
+    queue.push_back((dir_path.clone(), relative_prefix.to_path_buf(), depth));
 
     while let Some((current_dir, prefix, remaining_depth)) = queue.pop_front() {
-        let mut read_dir = fs::read_dir(&current_dir).await.map_err(|err| {
-            FunctionCallError::RespondToModel(format!("failed to read directory: {err}"))
-        })?;
-
         let mut dir_entries = Vec::new();
 
-        while let Some(entry) = read_dir.next_entry().await.map_err(|err| {
-            FunctionCallError::RespondToModel(format!("failed to read directory: {err}"))
-        })? {
-            let entry_path = entry.path();
+        for entry in fs
+            .read_directory(&current_dir, sandbox)
+            .await
+            .map_err(|err| {
+                FunctionCallError::RespondToModel(format!("failed to read directory: {err}"))
+            })?
+        {
+            let entry_path = current_dir.join(&entry.file_name);
             if let Some(read_deny_matcher) = read_deny_matcher
-                && read_deny_matcher.is_read_denied(&entry_path)
+                && read_deny_matcher.is_read_denied(entry_path.as_path())
             {
                 continue;
             }
-
-            let file_type = entry.file_type().await.map_err(|err| {
-                FunctionCallError::RespondToModel(format!("failed to inspect entry: {err}"))
-            })?;
-
-            let file_name = entry.file_name();
             let relative_path = if prefix.as_os_str().is_empty() {
-                PathBuf::from(&file_name)
+                PathBuf::from(&entry.file_name)
             } else {
-                prefix.join(&file_name)
+                prefix.join(&entry.file_name)
             };
 
-            let display_name = format_entry_component(&file_name);
+            let display_name = format_entry_component(OsStr::new(&entry.file_name));
             let display_depth = prefix.components().count();
             let sort_key = format_entry_name(&relative_path);
-            let kind = DirEntryKind::from(&file_type);
+            let kind = DirEntryKind::from(&entry);
             dir_entries.push((
                 entry_path,
                 relative_path,
@@ -275,13 +305,13 @@ enum DirEntryKind {
     Other,
 }
 
-impl From<&FileType> for DirEntryKind {
-    fn from(file_type: &FileType) -> Self {
-        if file_type.is_symlink() {
+impl From<&ReadDirectoryEntry> for DirEntryKind {
+    fn from(entry: &ReadDirectoryEntry) -> Self {
+        if entry.is_symlink {
             DirEntryKind::Symlink
-        } else if file_type.is_dir() {
+        } else if entry.is_directory {
             DirEntryKind::Directory
-        } else if file_type.is_file() {
+        } else if entry.is_file {
             DirEntryKind::File
         } else {
             DirEntryKind::Other

--- a/codex-rs/core/src/tools/handlers/list_dir_tests.rs
+++ b/codex-rs/core/src/tools/handlers/list_dir_tests.rs
@@ -13,7 +13,17 @@ async fn list_dir_slice(
     limit: usize,
     depth: usize,
 ) -> Result<Vec<String>, FunctionCallError> {
-    list_dir_slice_with_policy(path, offset, limit, depth, /*read_deny_matcher*/ None).await
+    let path = AbsolutePathBuf::from_absolute_path(path).expect("absolute temp path");
+    list_dir_slice_with_policy(
+        codex_exec_server::LOCAL_FS.clone(),
+        &path,
+        offset,
+        limit,
+        depth,
+        /*read_deny_matcher*/ None,
+        /*sandbox*/ None,
+    )
+    .await
 }
 
 #[tokio::test]
@@ -74,6 +84,24 @@ async fn lists_directory_entries() {
     ];
 
     assert_eq!(entries, expected);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn lists_broken_symlinks() {
+    use std::os::unix::fs::symlink;
+
+    let temp = tempdir().expect("create tempdir");
+    let dir_path = temp.path();
+    symlink(dir_path.join("missing.txt"), dir_path.join("broken")).expect("create broken symlink");
+
+    let entries = list_dir_slice(
+        dir_path, /*offset*/ 1, /*limit*/ 20, /*depth*/ 1,
+    )
+    .await
+    .expect("list directory");
+
+    assert_eq!(entries, vec!["broken@".to_string()]);
 }
 
 #[tokio::test]
@@ -314,12 +342,16 @@ async fn hides_denied_entries_and_prunes_denied_subtrees() {
     ]);
 
     let read_deny_matcher = ReadDenyMatcher::new(&policy, dir_path);
+    let absolute_dir_path =
+        AbsolutePathBuf::from_absolute_path(dir_path).expect("absolute temp path");
     let entries = list_dir_slice_with_policy(
-        dir_path,
+        codex_exec_server::LOCAL_FS.clone(),
+        &absolute_dir_path,
         /*offset*/ 1,
         /*limit*/ 20,
         /*depth*/ 3,
         read_deny_matcher.as_ref(),
+        /*sandbox*/ None,
     )
     .await
     .expect("list directory");

--- a/codex-rs/core/tests/suite/remote_env.rs
+++ b/codex-rs/core/tests/suite/remote_env.rs
@@ -22,7 +22,6 @@ use core_test_support::responses::ev_assistant_message;
 use core_test_support::responses::ev_completed;
 use core_test_support::responses::ev_function_call;
 use core_test_support::responses::ev_response_created;
-use core_test_support::responses::mount_sse_once;
 use core_test_support::responses::mount_sse_sequence;
 use core_test_support::responses::sse;
 use core_test_support::responses::start_mock_server;
@@ -60,6 +59,15 @@ async fn shell_command_test(server: &wiremock::MockServer) -> Result<TestCodex> 
         })
         .build_remote_aware(server)
         .await
+}
+
+async fn list_dir_test(server: &wiremock::MockServer) -> Result<TestCodex> {
+    let mut builder = test_codex().with_config(|config| {
+        config
+            .experimental_supported_tools
+            .push("list_dir".to_string());
+    });
+    builder.build_remote_aware(server).await
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -230,6 +238,38 @@ async fn shell_command_routing_output(
         .with_context(|| format!("missing function_call_output for {call_id}"))
 }
 
+async fn list_dir_routing_output(
+    test: &TestCodex,
+    server: &wiremock::MockServer,
+    call_id: &str,
+    arguments: Value,
+    environments: Option<Vec<TurnEnvironmentSelection>>,
+) -> Result<String> {
+    let response_mock = mount_sse_sequence(
+        server,
+        vec![
+            sse(vec![
+                ev_response_created("resp-1"),
+                ev_function_call(call_id, "list_dir", &serde_json::to_string(&arguments)?),
+                ev_completed("resp-1"),
+            ]),
+            sse(vec![
+                ev_response_created("resp-2"),
+                ev_assistant_message("msg-1", "done"),
+                ev_completed("resp-2"),
+            ]),
+        ],
+    )
+    .await;
+
+    test.submit_turn_with_environments("route list dir", environments)
+        .await?;
+
+    response_mock
+        .function_call_output_text(call_id)
+        .with_context(|| format!("missing function_call_output for {call_id}"))
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn exec_command_routes_to_selected_remote_environment() -> Result<()> {
     skip_if_no_network!(Ok(()));
@@ -365,6 +405,79 @@ async fn shell_command_routes_to_selected_remote_environment() -> Result<()> {
     assert!(
         !output.contains("local-routing"),
         "shell_command should not route to local: {output}",
+    );
+
+    test.fs()
+        .remove(
+            &remote_cwd,
+            RemoveOptions {
+                recursive: true,
+                force: true,
+            },
+            /*sandbox*/ None,
+        )
+        .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn list_dir_routes_to_selected_remote_environment() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+    let Some(_remote_env) = get_remote_test_env() else {
+        return Ok(());
+    };
+
+    let server = start_mock_server().await;
+    let test = list_dir_test(&server).await?;
+    let local_cwd = TempDir::new()?;
+    fs::write(local_cwd.path().join("marker-local.txt"), "local-routing")?;
+    let local_selection = TurnEnvironmentSelection {
+        environment_id: LOCAL_ENVIRONMENT_ID.to_string(),
+        cwd: local_cwd.path().abs(),
+    };
+    let remote_cwd = PathBuf::from(format!(
+        "/tmp/codex-list-dir-routing-{}",
+        SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis()
+    ))
+    .abs();
+    test.fs()
+        .create_directory(
+            &remote_cwd,
+            CreateDirectoryOptions { recursive: true },
+            /*sandbox*/ None,
+        )
+        .await?;
+    test.fs()
+        .write_file(
+            &remote_cwd.join("marker-remote.txt"),
+            b"remote-routing".to_vec(),
+            /*sandbox*/ None,
+        )
+        .await?;
+    let remote_selection = TurnEnvironmentSelection {
+        environment_id: REMOTE_ENVIRONMENT_ID.to_string(),
+        cwd: remote_cwd.clone(),
+    };
+    let multi_env_output = list_dir_routing_output(
+        &test,
+        &server,
+        "call-list-dir-multi-env",
+        json!({
+            "dir_path": remote_cwd.to_string_lossy(),
+            "depth": 1,
+            "environment_id": REMOTE_ENVIRONMENT_ID,
+        }),
+        Some(vec![local_selection, remote_selection]),
+    )
+    .await?;
+    assert!(
+        multi_env_output.contains("marker-remote.txt"),
+        "unexpected multi-env list_dir output: {multi_env_output}",
+    );
+    assert!(
+        !multi_env_output.contains("marker-local.txt"),
+        "multi-env list_dir should not route to local: {multi_env_output}",
     );
 
     test.fs()

--- a/codex-rs/exec-server/src/fs_helper.rs
+++ b/codex-rs/exec-server/src/fs_helper.rs
@@ -229,6 +229,7 @@ pub(crate) async fn run_direct_request(
                     file_name: entry.file_name,
                     is_directory: entry.is_directory,
                     is_file: entry.is_file,
+                    is_symlink: entry.is_symlink,
                 })
                 .collect();
             Ok(FsHelperPayload::ReadDirectory(FsReadDirectoryResponse {

--- a/codex-rs/exec-server/src/local_file_system.rs
+++ b/codex-rs/exec-server/src/local_file_system.rs
@@ -305,13 +305,13 @@ impl ExecutorFileSystem for DirectFileSystem {
         let mut entries = Vec::new();
         let mut read_dir = tokio::fs::read_dir(path.as_path()).await?;
         while let Some(entry) = read_dir.next_entry().await? {
-            let Ok(metadata) = tokio::fs::metadata(entry.path()).await else {
-                continue;
-            };
+            let symlink_metadata = tokio::fs::symlink_metadata(entry.path()).await?;
+            let metadata = tokio::fs::metadata(entry.path()).await.ok();
             entries.push(ReadDirectoryEntry {
                 file_name: entry.file_name().to_string_lossy().into_owned(),
-                is_directory: metadata.is_dir(),
-                is_file: metadata.is_file(),
+                is_directory: metadata.as_ref().is_some_and(std::fs::Metadata::is_dir),
+                is_file: metadata.as_ref().is_some_and(std::fs::Metadata::is_file),
+                is_symlink: symlink_metadata.file_type().is_symlink(),
             });
         }
         Ok(entries)

--- a/codex-rs/exec-server/src/protocol.rs
+++ b/codex-rs/exec-server/src/protocol.rs
@@ -224,6 +224,7 @@ pub struct FsReadDirectoryEntry {
     pub file_name: String,
     pub is_directory: bool,
     pub is_file: bool,
+    pub is_symlink: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/codex-rs/exec-server/src/remote_file_system.rs
+++ b/codex-rs/exec-server/src/remote_file_system.rs
@@ -144,6 +144,7 @@ impl ExecutorFileSystem for RemoteFileSystem {
                 file_name: entry.file_name,
                 is_directory: entry.is_directory,
                 is_file: entry.is_file,
+                is_symlink: entry.is_symlink,
             })
             .collect())
     }

--- a/codex-rs/exec-server/src/sandboxed_file_system.rs
+++ b/codex-rs/exec-server/src/sandboxed_file_system.rs
@@ -168,6 +168,7 @@ impl ExecutorFileSystem for SandboxedFileSystem {
                 file_name: entry.file_name,
                 is_directory: entry.is_directory,
                 is_file: entry.is_file,
+                is_symlink: entry.is_symlink,
             })
             .collect())
     }

--- a/codex-rs/exec-server/src/server/file_system_handler.rs
+++ b/codex-rs/exec-server/src/server/file_system_handler.rs
@@ -120,6 +120,7 @@ impl FileSystemHandler {
                 file_name: entry.file_name,
                 is_directory: entry.is_directory,
                 is_file: entry.is_file,
+                is_symlink: entry.is_symlink,
             })
             .collect();
         Ok(FsReadDirectoryResponse { entries })

--- a/codex-rs/exec-server/tests/file_system.rs
+++ b/codex-rs/exec-server/tests/file_system.rs
@@ -418,11 +418,13 @@ async fn file_system_methods_cover_surface_area(use_remote: bool) -> Result<()> 
                 file_name: "nested".to_string(),
                 is_directory: true,
                 is_file: false,
+                is_symlink: false,
             },
             ReadDirectoryEntry {
                 file_name: "root.txt".to_string(),
                 is_directory: false,
                 is_file: true,
+                is_symlink: false,
             },
         ]
     );

--- a/codex-rs/file-system/src/lib.rs
+++ b/codex-rs/file-system/src/lib.rs
@@ -42,6 +42,7 @@ pub struct ReadDirectoryEntry {
     pub file_name: String,
     pub is_directory: bool,
     pub is_file: bool,
+    pub is_symlink: bool,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]

--- a/codex-rs/tools/src/lib.rs
+++ b/codex-rs/tools/src/lib.rs
@@ -150,6 +150,7 @@ pub use tool_spec::create_image_generation_tool;
 pub use tool_spec::create_local_shell_tool;
 pub use tool_spec::create_tools_json_for_responses_api;
 pub use tool_spec::create_web_search_tool;
+pub use utility_tool::ListDirToolOptions;
 pub use utility_tool::create_list_dir_tool;
 pub use utility_tool::create_test_sync_tool;
 pub use view_image::ViewImageToolOptions;

--- a/codex-rs/tools/src/local_tool.rs
+++ b/codex-rs/tools/src/local_tool.rs
@@ -1,6 +1,7 @@
 use crate::JsonSchema;
 use crate::ResponsesApiTool;
 use crate::ToolSpec;
+use crate::tool_spec::maybe_insert_environment_id_parameter;
 use serde_json::Value;
 use serde_json::json;
 use std::collections::BTreeMap;
@@ -70,14 +71,7 @@ pub(crate) fn create_exec_command_tool_with_environment_id(
             )),
         );
     }
-    if include_environment_id {
-        properties.insert(
-            "environment_id".to_string(),
-            JsonSchema::string(Some(
-                "Optional environment id from the <environment_context> block. If omitted, uses the primary environment.".to_string(),
-            )),
-        );
-    }
+    maybe_insert_environment_id_parameter(&mut properties, include_environment_id);
     properties.extend(create_approval_parameters(
         options.exec_permission_approvals_enabled,
     ));

--- a/codex-rs/tools/src/tool_registry_plan.rs
+++ b/codex-rs/tools/src/tool_registry_plan.rs
@@ -1,4 +1,5 @@
 use crate::CommandToolOptions;
+use crate::ListDirToolOptions;
 use crate::REQUEST_PLUGIN_INSTALL_TOOL_NAME;
 use crate::REQUEST_USER_INPUT_TOOL_NAME;
 use crate::ResponsesApiNamespace;
@@ -136,9 +137,9 @@ pub fn build_tool_registry_plan(
         );
     }
 
+    let include_environment_id = matches!(config.environment_mode, ToolEnvironmentMode::Multiple);
+
     if config.environment_mode.has_environment() {
-        let include_environment_id =
-            matches!(config.environment_mode, ToolEnvironmentMode::Multiple);
         match &config.shell_type {
             ConfigShellToolType::Default => {
                 plan.push_spec(
@@ -364,7 +365,9 @@ pub fn build_tool_registry_plan(
             .any(|tool| tool == "list_dir")
     {
         plan.push_spec(
-            create_list_dir_tool(),
+            create_list_dir_tool(ListDirToolOptions {
+                include_environment_id,
+            }),
             /*supports_parallel_tool_calls*/ true,
             config.code_mode_enabled,
         );

--- a/codex-rs/tools/src/tool_registry_plan_tests.rs
+++ b/codex-rs/tools/src/tool_registry_plan_tests.rs
@@ -650,6 +650,51 @@ fn disabled_environment_omits_environment_backed_tools() {
 }
 
 #[test]
+fn list_dir_spec_includes_environment_id_only_for_multiple_selected_environments() {
+    let model_info = model_info();
+    let available_models = Vec::new();
+    let mut tools_config = ToolsConfig::new(&ToolsConfigParams {
+        model_info: &model_info,
+        available_models: &available_models,
+        features: &Features::with_defaults(),
+        image_generation_tool_auth_allowed: true,
+        web_search_mode: Some(WebSearchMode::Cached),
+        session_source: SessionSource::Cli,
+        permission_profile: &PermissionProfile::Disabled,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
+    });
+    tools_config
+        .experimental_supported_tools
+        .push("list_dir".to_string());
+
+    let (single_environment_tools, _) = build_specs(
+        &tools_config,
+        /*mcp_tools*/ None,
+        /*deferred_mcp_tools*/ None,
+        &[],
+    );
+    assert_process_tool_environment_id(
+        &single_environment_tools,
+        "list_dir",
+        /*expected_present*/ false,
+    );
+
+    let multi_environment_config =
+        tools_config.with_environment_mode(ToolEnvironmentMode::Multiple);
+    let (multi_environment_tools, _) = build_specs(
+        &multi_environment_config,
+        /*mcp_tools*/ None,
+        /*deferred_mcp_tools*/ None,
+        &[],
+    );
+    assert_process_tool_environment_id(
+        &multi_environment_tools,
+        "list_dir",
+        /*expected_present*/ true,
+    );
+}
+
+#[test]
 fn test_build_specs_agent_job_worker_tools_enabled() {
     let model_info = model_info();
     let mut features = Features::with_defaults();

--- a/codex-rs/tools/src/tool_spec.rs
+++ b/codex-rs/tools/src/tool_spec.rs
@@ -12,6 +12,7 @@ use codex_protocol::config_types::WebSearchUserLocationType;
 use codex_protocol::openai_models::WebSearchToolType;
 use serde::Serialize;
 use serde_json::Value;
+use std::collections::BTreeMap;
 
 const WEB_SEARCH_TEXT_AND_IMAGE_CONTENT_TYPES: [&str; 2] = ["text", "image"];
 
@@ -82,6 +83,20 @@ impl From<LoadableToolSpec> for ToolSpec {
 
 pub fn create_local_shell_tool() -> ToolSpec {
     ToolSpec::LocalShell {}
+}
+
+pub fn maybe_insert_environment_id_parameter(
+    properties: &mut BTreeMap<String, JsonSchema>,
+    include_environment_id: bool,
+) {
+    if include_environment_id {
+        properties.insert(
+            "environment_id".to_string(),
+            JsonSchema::string(Some(
+                "Optional environment id from the <environment_context> block. If omitted, uses the primary environment.".to_string(),
+            )),
+        );
+    }
 }
 
 pub fn create_image_generation_tool(output_format: &str) -> ToolSpec {

--- a/codex-rs/tools/src/utility_tool.rs
+++ b/codex-rs/tools/src/utility_tool.rs
@@ -1,10 +1,16 @@
 use crate::JsonSchema;
 use crate::ResponsesApiTool;
 use crate::ToolSpec;
+use crate::tool_spec::maybe_insert_environment_id_parameter;
 use std::collections::BTreeMap;
 
-pub fn create_list_dir_tool() -> ToolSpec {
-    let properties = BTreeMap::from([
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ListDirToolOptions {
+    pub include_environment_id: bool,
+}
+
+pub fn create_list_dir_tool(options: ListDirToolOptions) -> ToolSpec {
+    let mut properties = BTreeMap::from([
         (
             "dir_path".to_string(),
             JsonSchema::string(Some("Absolute path to the directory to list.".to_string())),
@@ -26,15 +32,20 @@ pub fn create_list_dir_tool() -> ToolSpec {
             )),
         ),
     ]);
+    maybe_insert_environment_id_parameter(&mut properties, options.include_environment_id);
 
     ToolSpec::Function(ResponsesApiTool {
         name: "list_dir".to_string(),
         description:
-            "Lists entries in a local directory with 1-indexed entry numbers and simple type labels."
+            "Lists entries in a directory with 1-indexed entry numbers and simple type labels."
                 .to_string(),
         strict: false,
         defer_loading: None,
-        parameters: JsonSchema::object(properties, Some(vec!["dir_path".to_string()]), Some(false.into())),
+        parameters: JsonSchema::object(
+            properties,
+            Some(vec!["dir_path".to_string()]),
+            Some(false.into()),
+        ),
         output_schema: None,
     })
 }

--- a/codex-rs/tools/src/utility_tool_tests.rs
+++ b/codex-rs/tools/src/utility_tool_tests.rs
@@ -6,15 +6,18 @@ use std::collections::BTreeMap;
 #[test]
 fn list_dir_tool_matches_expected_spec() {
     assert_eq!(
-        create_list_dir_tool(),
+        create_list_dir_tool(ListDirToolOptions {
+            include_environment_id: false,
+        }),
         ToolSpec::Function(ResponsesApiTool {
             name: "list_dir".to_string(),
             description:
-                "Lists entries in a local directory with 1-indexed entry numbers and simple type labels."
+                "Lists entries in a directory with 1-indexed entry numbers and simple type labels."
                     .to_string(),
             strict: false,
             defer_loading: None,
-            parameters: JsonSchema::object(BTreeMap::from([
+            parameters: JsonSchema::object(
+                BTreeMap::from([
                     (
                         "depth".to_string(),
                         JsonSchema::number(Some(
@@ -41,7 +44,10 @@ fn list_dir_tool_matches_expected_spec() {
                                 .to_string(),
                         )),
                     ),
-                ]), Some(vec!["dir_path".to_string()]), Some(false.into())),
+                ]),
+                Some(vec!["dir_path".to_string()]),
+                Some(false.into())
+            ),
             output_schema: None,
         })
     );


### PR DESCRIPTION
## Why

This PR is the `list_dir` slice of the multi-environment tool stack. Keeping it separate from shell, view_image, and apply_patch makes the review boundary one tool family wide.

Stack:
- https://github.com/openai/codex/pull/20647
- https://github.com/openai/codex/pull/21142
- this PR

## What changed

- Exposes optional `environment_id` on `list_dir` only when multiple environments are selected.
- Resolves the selected environment before filesystem access and routes directory reads through that environment filesystem.
- Uses the selected environment cwd for read-deny matching and remote filesystem sandbox context.
- Adds focused list_dir unit coverage plus remote-env routing coverage for empty, single, and multiple selected environments.

## Verification

- `just fmt`
- `git diff --check`

Local Cargo validation is blocked by the Codex repo guardrail that requires devbox/Bazel validation instead of laptop-local Cargo.