### PR TITLE
fix(tui): restore alt-enter newline alias

### DIFF
--- a/codex-rs/tui/src/keymap.rs
+++ b/codex-rs/tui/src/keymap.rs
@@ -424,7 +424,8 @@ impl RuntimeKeymap {
                     ctrl(KeyCode::Char('j')),
                     ctrl(KeyCode::Char('m')),
                     plain(KeyCode::Enter),
-                    shift(KeyCode::Enter)
+                    shift(KeyCode::Enter),
+                    alt(KeyCode::Enter)
                 ],
                 move_left: default_bindings![plain(KeyCode::Left), ctrl(KeyCode::Char('b'))],
                 move_right: default_bindings![plain(KeyCode::Right), ctrl(KeyCode::Char('f'))],
@@ -1226,7 +1227,7 @@ mod tests {
 
         keymap.composer.submit = Some(KeybindingsSpec::Many(vec![
             KeybindingSpec("ctrl-enter".to_string()),
-            KeybindingSpec("alt-enter".to_string()),
+            KeybindingSpec("ctrl-shift-enter".to_string()),
         ]));
 
         let runtime = RuntimeKeymap::from_config(&keymap).expect("valid multi-binding");
@@ -1239,7 +1240,7 @@ mod tests {
         keymap.composer.submit = Some(KeybindingsSpec::Many(vec![
             KeybindingSpec("ctrl-enter".to_string()),
             KeybindingSpec("ctrl-enter".to_string()),
-            KeybindingSpec("alt-enter".to_string()),
+            KeybindingSpec("ctrl-shift-enter".to_string()),
         ]));
 
         let runtime = RuntimeKeymap::from_config(&keymap).expect("valid multi-binding");
@@ -1247,7 +1248,7 @@ mod tests {
             runtime.composer.submit,
             vec![
                 key_hint::ctrl(KeyCode::Enter),
-                key_hint::alt(KeyCode::Enter)
+                KeyBinding::new(KeyCode::Enter, KeyModifiers::CONTROL | KeyModifiers::SHIFT)
             ]
         );
     }
@@ -1467,13 +1468,17 @@ mod tests {
     }
 
     #[test]
-    fn default_editor_insert_newline_includes_shift_enter() {
+    fn default_editor_insert_newline_includes_current_aliases() {
         let runtime = RuntimeKeymap::defaults();
-        assert!(
-            runtime
-                .editor
-                .insert_newline
-                .contains(&key_hint::shift(KeyCode::Enter))
+        assert_eq!(
+            runtime.editor.insert_newline,
+            vec![
+                key_hint::ctrl(KeyCode::Char('j')),
+                key_hint::ctrl(KeyCode::Char('m')),
+                key_hint::plain(KeyCode::Enter),
+                key_hint::shift(KeyCode::Enter),
+                key_hint::alt(KeyCode::Enter),
+            ]
         );
     }
 

--- a/codex-rs/tui/src/keymap_setup.rs
+++ b/codex-rs/tui/src/keymap_setup.rs
@@ -1096,7 +1096,7 @@ mod tests {
             &TuiKeymap::default(),
             "composer",
             "submit",
-            &["ctrl-enter".to_string(), "alt-enter".to_string()],
+            &["ctrl-enter".to_string(), "alt-shift-enter".to_string()],
         )
         .expect("multi binding");
         let multi_runtime = RuntimeKeymap::from_config(&multi_keymap).expect("runtime keymap");
@@ -1411,7 +1411,7 @@ mod tests {
             &TuiKeymap::default(),
             "composer",
             "submit",
-            &["ctrl-enter".to_string(), "alt-enter".to_string()],
+            &["ctrl-enter".to_string(), "alt-shift-enter".to_string()],
         )
         .expect("multi binding");
         let runtime = RuntimeKeymap::from_config(&keymap).expect("runtime keymap");
@@ -1532,7 +1532,7 @@ mod tests {
             &TuiKeymap::default(),
             "composer",
             "submit",
-            &["ctrl-enter".to_string(), "alt-enter".to_string()],
+            &["ctrl-enter".to_string(), "alt-shift-enter".to_string()],
         )
         .expect("multi binding");
         let runtime = RuntimeKeymap::from_config(&keymap).expect("runtime keymap");
@@ -1556,12 +1556,12 @@ mod tests {
         else {
             panic!("expected updated keymap");
         };
-        assert_eq!(bindings, vec!["ctrl-shift-enter", "alt-enter"]);
+        assert_eq!(bindings, vec!["ctrl-shift-enter", "alt-shift-enter"]);
         assert_eq!(
             keymap_config.composer.submit,
             Some(KeybindingsSpec::Many(vec![
                 KeybindingSpec("ctrl-shift-enter".to_string()),
-                KeybindingSpec("alt-enter".to_string())
+                KeybindingSpec("alt-shift-enter".to_string())
             ]))
         );
     }
@@ -1572,7 +1572,7 @@ mod tests {
             &TuiKeymap::default(),
             "composer",
             "submit",
-            &["ctrl-enter".to_string(), "alt-enter".to_string()],
+            &["ctrl-enter".to_string(), "ctrl-shift-enter".to_string()],
         )
         .expect("multi binding");
         let runtime = RuntimeKeymap::from_config(&keymap).expect("runtime keymap");
@@ -1581,7 +1581,7 @@ mod tests {
             &runtime,
             "composer",
             "submit",
-            "alt-enter",
+            "ctrl-shift-enter",
             &KeymapEditIntent::ReplaceOne {
                 old_key: "ctrl-enter".to_string(),
             },
@@ -1596,11 +1596,11 @@ mod tests {
         else {
             panic!("expected updated keymap");
         };
-        assert_eq!(bindings, vec!["alt-enter"]);
+        assert_eq!(bindings, vec!["ctrl-shift-enter"]);
         assert_eq!(
             keymap_config.composer.submit,
             Some(KeybindingsSpec::One(KeybindingSpec(
-                "alt-enter".to_string()
+                "ctrl-shift-enter".to_string()
             )))
         );
     }

--- a/codex-rs/tui/src/snapshots/codex_tui__keymap_setup__tests__keymap_action_menu.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__keymap_setup__tests__keymap_action_menu.snap
@@ -22,4 +22,4 @@ Back to shortcuts | Return to the shortcut list. | enabled
 
 replace picker:
 ctrl-enter | Replace this binding. | enabled
-alt-enter | Replace this binding. | enabled
+alt-shift-enter | Replace this binding. | enabled


### PR DESCRIPTION
Fixes https://github.com/openai/codex/issues/20501
Refs #20580.

## Summary
- add Alt+Enter to the built-in editor newline aliases
- update keymap tests that used Alt+Enter as a custom submit binding now that it conflicts with newline
- refresh the keymap action-menu snapshot fixture

## Test Plan
- `just fmt`
- `cargo test -p codex-tui keymap::tests`
- `cargo test -p codex-tui bottom_pane::textarea::tests`
- `cargo test -p codex-tui keymap_setup::tests`
- `cargo test -p codex-tui`
- `cargo insta pending-snapshots`
- `git diff --check`
- `just argument-comment-lint`