### PR TITLE
Fix thread-store archived live fallback

### DIFF
--- a/codex-rs/thread-store/src/local/read_thread.rs
+++ b/codex-rs/thread-store/src/local/read_thread.rs
@@ -71,6 +71,11 @@ pub(super) async fn read_thread(
         })?;
 
     let mut thread = read_thread_from_rollout_path(store, path).await?;
+    if !params.include_archived && thread.archived_at.is_some() {
+        return Err(ThreadStoreError::InvalidRequest {
+            message: format!("thread {thread_id} is archived"),
+        });
+    }
     attach_history_if_requested(&mut thread, params.include_history).await?;
     Ok(thread)
 }


### PR DESCRIPTION
## Summary
- reject archived rollout fallback results for active-only thread reads
- keeps active-only reads consistent when a live writer was resumed from an archived source

## Validation
- cargo test -p codex-thread-store load_history_uses_live_writer_rollout_path_for_archived_source -- --nocapture (3 consecutive passes)
- cargo test -p codex-thread-store
- just fmt
- just fix -p codex-thread-store