### PR TITLE
Resume queued prompts after blocked UserPromptSubmit hook

### DIFF
--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -4029,6 +4029,13 @@ impl ChatWidget {
     }
 
     fn on_hook_completed(&mut self, completed: codex_app_server_protocol::HookRunSummary) {
+        let blocked_user_prompt_submit = self.user_turn_pending_start
+            && completed.event_name == codex_app_server_protocol::HookEventName::UserPromptSubmit
+            && matches!(
+                completed.status,
+                codex_app_server_protocol::HookRunStatus::Blocked
+                    | codex_app_server_protocol::HookRunStatus::Stopped
+            );
         let completed_existing_run = self
             .active_hook_cell
             .as_mut()
@@ -4054,6 +4061,10 @@ impl ChatWidget {
         }
         self.flush_completed_hook_output();
         self.finish_active_hook_cell_if_idle();
+        if blocked_user_prompt_submit {
+            self.user_turn_pending_start = false;
+            self.maybe_send_next_queued_input();
+        }
         self.request_redraw();
     }
 

--- a/codex-rs/tui/src/chatwidget/tests/app_server.rs
+++ b/codex-rs/tui/src/chatwidget/tests/app_server.rs
@@ -171,6 +171,84 @@ async fn live_app_server_turn_completed_clears_working_status_after_answer_item(
 }
 
 #[tokio::test]
+async fn blocked_user_prompt_submit_hook_continues_queued_inputs() {
+    let (mut chat, _rx, mut op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    chat.thread_id = Some(ThreadId::new());
+
+    chat.handle_server_notification(
+        ServerNotification::TurnStarted(TurnStartedNotification {
+            thread_id: "thread-1".to_string(),
+            turn: AppServerTurn {
+                id: "turn-1".to_string(),
+                items: Vec::new(),
+                status: AppServerTurnStatus::InProgress,
+                error: None,
+                started_at: Some(0),
+                completed_at: None,
+                duration_ms: None,
+            },
+        }),
+        /*replay_kind*/ None,
+    );
+
+    for text in ["blocked prompt", "allowed prompt"] {
+        chat.bottom_pane
+            .set_composer_text(text.to_string(), Vec::new(), Vec::new());
+        chat.handle_key_event(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+    }
+
+    chat.handle_server_notification(
+        ServerNotification::TurnCompleted(TurnCompletedNotification {
+            thread_id: "thread-1".to_string(),
+            turn: AppServerTurn {
+                id: "turn-1".to_string(),
+                items: Vec::new(),
+                status: AppServerTurnStatus::Completed,
+                error: None,
+                started_at: Some(0),
+                completed_at: Some(1),
+                duration_ms: Some(1),
+            },
+        }),
+        /*replay_kind*/ None,
+    );
+
+    assert_matches!(
+        next_submit_op(&mut op_rx),
+        Op::UserTurn { items, .. }
+            if items
+                == vec![AppServerUserInput::Text {
+                    text: "blocked prompt".to_string(),
+                    text_elements: Vec::new(),
+                }]
+    );
+
+    handle_hook_completed(
+        &mut chat,
+        hook_run(
+            "user-prompt-submit:0:/tmp/hooks.json",
+            AppServerHookEventName::UserPromptSubmit,
+            AppServerHookRunStatus::Blocked,
+            "checking queued prompt policy",
+            vec![AppServerHookOutputEntry {
+                kind: AppServerHookOutputEntryKind::Feedback,
+                text: "blocked prompt".to_string(),
+            }],
+        ),
+    );
+
+    assert_matches!(
+        next_submit_op(&mut op_rx),
+        Op::UserTurn { items, .. }
+            if items
+                == vec![AppServerUserInput::Text {
+                    text: "allowed prompt".to_string(),
+                    text_elements: Vec::new(),
+                }]
+    );
+}
+
+#[tokio::test]
 async fn live_app_server_turn_started_sets_feedback_turn_id() {
     let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
 


### PR DESCRIPTION
### Motivation
- A `UserPromptSubmit` hook that returns `Blocked`/`Stopped` could leave `user_turn_pending_start` set and prevent queued follow-up prompts from being processed, causing the input queue to stall.

### Description
- Detect when a `HookRunSummary` for `UserPromptSubmit` has `Blocked` or `Stopped` status while `user_turn_pending_start` is set and treat it as a blocked user-prompt-submit case in `ChatWidget::on_hook_completed`.
- Clear `user_turn_pending_start` and invoke `maybe_send_next_queued_input()` when a blocked/stopped `UserPromptSubmit` run is observed so queued inputs can continue draining.
- Add a regression test `blocked_user_prompt_submit_hook_continues_queued_inputs` in `codex-rs/tui/src/chatwidget/tests/app_server.rs` that queues two prompts, simulates a blocked `UserPromptSubmit` for the first, and asserts the second is submitted.

### Testing
- Ran `just fmt` which completed successfully.
- Ran `git diff --check` which reported no issues.
- Attempted `cargo test -p codex-tui`, but the invocation failed in this environment due to missing system build dependencies (`libcap` for `codex-linux-sandbox` vendored bubblewrap) so the full test suite could not complete.
- Attempted `CODEX_SKIP_VENDORED_BWRAP=1 cargo test -p codex-tui` to work around that, but the build failed when `v8` attempted to download a prebuilt `librusty_v8` artifact and the proxy returned `403 Forbidden`, so the test run could not finish here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_i_69f4e0cb4d1883228770b37ecb6bddaa)