### PR TITLE
fix: reduce ConfigBuilder::build stack usage

### DIFF
--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -923,6 +923,11 @@ impl ConfigBuilder {
     }
 
     pub async fn build(self) -> std::io::Result<Config> {
+        // Keep the large config-loading future off small runtime thread stacks.
+        Box::pin(self.build_inner()).await
+    }
+
+    async fn build_inner(self) -> std::io::Result<Config> {
         let Self {
             codex_home,
             cli_overrides,


### PR DESCRIPTION
## Why

`ConfigBuilder::build` performs a large amount of async config loading. Leaving that entire future on the caller stack makes config startup more fragile on small runtime worker stacks.

## What changed

- keep `ConfigBuilder::build` as a thin wrapper that boxes the config-loading future before awaiting it
- move the existing implementation into a private `build_inner` method so the large async state machine lives on the heap instead of the runtime thread stack

## Testing

- Not run locally