### PR TITLE
[codex-exec] Make review-policy params test hermetic

### DIFF
--- a/codex-rs/exec/src/lib_tests.rs
+++ b/codex-rs/exec/src/lib_tests.rs
@@ -346,6 +346,7 @@ async fn thread_start_params_include_review_policy_when_review_policy_is_manual_
     let cwd = tempdir().expect("create temp cwd");
     let config = ConfigBuilder::default()
         .codex_home(codex_home.path().to_path_buf())
+        .loader_overrides(LoaderOverrides::without_managed_config_for_tests())
         .harness_overrides(ConfigOverrides {
             approvals_reviewer: Some(ApprovalsReviewer::User),
             ..Default::default()


### PR DESCRIPTION
## Summary
1. Make the manual review policy thread params test independent from system or managed config outside the temp Codex home.
2. Keep the existing explicit legacy sandbox coverage unchanged.

## Why
PR #20095 changed exec thread params to project a legacy sandbox when there is no active permission profile. The test already uses a temp Codex home, so `$CODEX_HOME/config.toml` is isolated. The remaining machine level inputs are config sources outside that temp home, such as system config, system requirements, legacy managed config, and macOS managed preferences.

For a concrete example of this class of input, see the Codex enterprise admin setup docs for example `requirements.toml` policies: https://developers.openai.com/codex/enterprise/admin-setup#example-requirementstoml-policies

This keeps the test focused on approvals reviewer propagation without relying on machine level config.

## Validation
1. cargo fmt for the codex exec crate
2. manual review policy test
3. legacy sandbox no active profile test
4. codex exec lib suite
