### PR TITLE
test: make async cancellation test deterministic

### DIFF
--- a/codex-rs/async-utils/src/lib.rs
+++ b/codex-rs/async-utils/src/lib.rs
@@ -34,6 +34,7 @@ where
 mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
+    use std::future::pending;
     use std::time::Duration;
     use tokio::task;
     use tokio::time::sleep;
@@ -58,12 +59,7 @@ mod tests {
             token_clone.cancel();
         });
 
-        let result = async {
-            sleep(Duration::from_millis(100)).await;
-            7
-        }
-        .or_cancel(&token)
-        .await;
+        let result = pending::<i32>().or_cancel(&token).await;
 
         cancel_handle.await.expect("cancel task panicked");
         assert_eq!(Err(CancelErr::Cancelled), result);


### PR DESCRIPTION
## Summary

- Make `returns_err_when_token_cancelled_first` use `std::future::pending()` as the work future so cancellation deterministically wins.
- Keep the delayed cancellation task so the test still exercises asynchronous cancellation rather than an already-cancelled token.

## Test Plan

- `cargo test -p codex-async-utils`