### PR TITLE
ci: cross-compile Windows Bazel clippy

### DIFF
--- a/.github/scripts/run-bazel-query-ci.sh
+++ b/.github/scripts/run-bazel-query-ci.sh
@@ -6,8 +6,13 @@ set -euo pipefail
 # invocation so target-discovery queries can reuse the same Bazel server.
 
 query_args=()
+windows_cross_compile=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --windows-cross-compile)
+      windows_cross_compile=1
+      shift
+      ;;
     --)
       shift
       break
@@ -20,7 +25,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ $# -ne 1 ]]; then
-  echo "Usage: $0 [<bazel query args>...] -- <query expression>" >&2
+  echo "Usage: $0 [--windows-cross-compile] [<bazel query args>...] -- <query expression>" >&2
   exit 1
 fi
 
@@ -32,7 +37,11 @@ case "${RUNNER_OS:-}" in
     ci_config=ci-macos
     ;;
   Windows)
-    ci_config=ci-windows
+    if [[ $windows_cross_compile -eq 1 ]]; then
+      ci_config=ci-windows-cross
+    else
+      ci_config=ci-windows
+    fi
     ;;
 esac
 

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -251,17 +251,24 @@ jobs:
             --build_metadata=TAG_job=clippy
           )
           bazel_wrapper_args=()
+          bazel_target_list_args=()
           if [[ "${RUNNER_OS}" == "Windows" ]]; then
-            # Keep this aligned with the Windows Bazel test job. With the
-            # default `//:local_windows` host platform, Windows `rust_test`
-            # targets such as `//codex-rs/core:core-all-test` can be skipped
-            # by `--skip_incompatible_explicit_targets`, which hides clippy
-            # diagnostics from integration-test modules.
-            bazel_wrapper_args+=(--windows-msvc-host-platform)
-            bazel_clippy_args+=(--skip_incompatible_explicit_targets)
+            # Keep this aligned with the fast Windows Bazel test job: use
+            # Linux RBE for clippy build actions while targeting Windows
+            # gnullvm. Fork/community PRs without the BuildBuddy secret fall
+            # back inside `run-bazel-ci.sh` to the previous local Windows MSVC
+            # host-platform shape.
+            bazel_wrapper_args+=(--windows-cross-compile)
+            bazel_target_list_args+=(--windows-cross-compile)
+            if [[ -z "${BUILDBUDDY_API_KEY:-}" ]]; then
+              # The fork fallback can see incompatible explicit Windows-cross
+              # internal test binaries in the generated target list. Preserve
+              # the old local-fallback behavior there.
+              bazel_clippy_args+=(--skip_incompatible_explicit_targets)
+            fi
           fi
 
-          bazel_target_lines="$(./scripts/list-bazel-clippy-targets.sh)"
+          bazel_target_lines="$(./scripts/list-bazel-clippy-targets.sh "${bazel_target_list_args[@]}")"
           bazel_targets=()
           while IFS= read -r target; do
             bazel_targets+=("${target}")
@@ -333,7 +340,12 @@ jobs:
           # Rust debug assertions explicitly.
           bazel_wrapper_args=()
           if [[ "${RUNNER_OS}" == "Windows" ]]; then
-            bazel_wrapper_args+=(--windows-msvc-host-platform)
+            # This is build-only signal, so use the same Linux-RBE
+            # cross-compile path as the fast Windows test and clippy jobs.
+            # Fork/community PRs without the BuildBuddy secret fall back
+            # inside `run-bazel-ci.sh` to the previous local Windows MSVC
+            # host-platform shape.
+            bazel_wrapper_args+=(--windows-cross-compile)
           fi
 
           bazel_build_args=(

--- a/scripts/list-bazel-clippy-targets.sh
+++ b/scripts/list-bazel-clippy-targets.sh
@@ -5,15 +5,38 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${repo_root}"
 
+windows_cross_compile=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --windows-cross-compile)
+      windows_cross_compile=1
+      shift
+      ;;
+    *)
+      echo "Usage: $0 [--windows-cross-compile]" >&2
+      exit 1
+      ;;
+  esac
+done
+
 # Resolve the dynamic targets before printing anything so callers do not
 # continue with a partial list if `bazel query` fails. Reuse the same CI Bazel
 # server settings as the subsequent build so Windows jobs do not cold-start a
 # second Bazel server just for target discovery.
-manual_rust_test_targets="$(
-  ./.github/scripts/run-bazel-query-ci.sh \
-    --output=label \
-    -- 'kind("rust_test rule", attr(tags, "manual", //codex-rs/... except //codex-rs/v8-poc/...))'
-)"
+if [[ $windows_cross_compile -eq 1 ]]; then
+  manual_rust_test_targets="$(
+    ./.github/scripts/run-bazel-query-ci.sh \
+      --windows-cross-compile \
+      --output=label \
+      -- 'kind("rust_test rule", attr(tags, "manual", //codex-rs/... except //codex-rs/v8-poc/...))'
+  )"
+else
+  manual_rust_test_targets="$(
+    ./.github/scripts/run-bazel-query-ci.sh \
+      --output=label \
+      -- 'kind("rust_test rule", attr(tags, "manual", //codex-rs/... except //codex-rs/v8-poc/...))'
+  )"
+fi
 if [[ "${RUNNER_OS:-}" != "Windows" ]]; then
   manual_rust_test_targets="$(printf '%s\n' "${manual_rust_test_targets}" | grep -v -- '-windows-cross-bin$' || true)"
 fi


### PR DESCRIPTION
## Why

#20585 moved the Windows Bazel test job to the cross-compile path, but the Windows Bazel clippy and verify-release-build jobs were still using the native Windows/MSVC-host fallback. Those two jobs became the slowest Windows PR legs, even though both are build-only signal and do not need to execute the resulting binaries.

## What Changed

- Switches the Windows Bazel clippy job from `--windows-msvc-host-platform` to `--windows-cross-compile`, so clippy build actions use Linux RBE while still targeting `x86_64-pc-windows-gnullvm`.
- Switches the Windows Bazel verify-release-build job to `--windows-cross-compile` as well. This job only compiles `cfg(not(debug_assertions))` Rust code under `fastbuild`, so it does not need a native Windows build host.
- Keeps the old `--skip_incompatible_explicit_targets` behavior only for fork/community PRs without `BUILDBUDDY_API_KEY`, where `run-bazel-ci.sh` falls back to the local Windows MSVC-host shape.
- Adds `--windows-cross-compile` support to `.github/scripts/run-bazel-query-ci.sh`, so target-discovery queries select the same `ci-windows-cross` config as the subsequent build.
- Threads that option through `scripts/list-bazel-clippy-targets.sh` so the Windows clippy job discovers targets under the same platform shape as the subsequent clippy build.

## Verification

Local checks:

```shell
bash -n .github/scripts/run-bazel-query-ci.sh
bash -n scripts/list-bazel-clippy-targets.sh
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/bazel.yml"); puts "ok"'
RUNNER_OS=Linux ./scripts/list-bazel-clippy-targets.sh | grep -c -- '-windows-cross-bin$'
RUNNER_OS=Windows ./scripts/list-bazel-clippy-targets.sh --windows-cross-compile | grep -c -- '-windows-cross-bin$'
```

The Linux target-list check reported `0` Windows-cross internal test binaries, while the Windows cross target-list check reported `47`, preserving the test-code clippy coverage shape from the existing Windows job.
