### PR TITLE
Remove remote plugin uninstall prefix gate

### DIFF
--- a/codex-rs/app-server/src/request_processors/plugins.rs
+++ b/codex-rs/app-server/src/request_processors/plugins.rs
@@ -4,7 +4,6 @@ use crate::error_code::invalid_request;
 use codex_app_server_protocol::PluginAvailability;
 use codex_app_server_protocol::PluginInstallPolicy;
 use codex_config::types::McpServerConfig;
-use codex_core_plugins::remote::is_valid_remote_plugin_id;
 use codex_core_plugins::remote::validate_remote_plugin_id;
 use codex_mcp::McpOAuthLoginSupport;
 use codex_mcp::oauth_login_support;
@@ -1014,14 +1013,7 @@ impl PluginRequestProcessor {
         params: PluginUninstallParams,
     ) -> Result<PluginUninstallResponse, JSONRPCErrorError> {
         let PluginUninstallParams { plugin_id } = params;
-        if codex_plugin::PluginId::parse(&plugin_id).is_err()
-            && !is_valid_remote_uninstall_plugin_id(&plugin_id)
-        {
-            return Err(invalid_request(
-                "invalid plugin id: expected a local plugin id in the form `plugin@marketplace` or a remote plugin id starting with `plugins~`, `plugins_`, `app_`, `asdk_app_`, or `connector_`",
-            ));
-        }
-        if is_valid_remote_uninstall_plugin_id(&plugin_id) {
+        if codex_plugin::PluginId::parse(&plugin_id).is_err() {
             return self.remote_plugin_uninstall_response(plugin_id).await;
         }
         let plugins_manager = self.thread_manager.plugins_manager();
@@ -1146,15 +1138,6 @@ impl PluginRequestProcessor {
         })?;
         Ok(PluginUninstallResponse {})
     }
-}
-
-fn is_valid_remote_uninstall_plugin_id(plugin_name: &str) -> bool {
-    is_valid_remote_plugin_id(plugin_name)
-        && (plugin_name.starts_with("plugins~")
-            || plugin_name.starts_with("plugins_")
-            || plugin_name.starts_with("app_")
-            || plugin_name.starts_with("asdk_app_")
-            || plugin_name.starts_with("connector_"))
 }
 
 async fn load_plugin_app_summaries(

--- a/codex-rs/app-server/src/request_processors/plugins.rs
+++ b/codex-rs/app-server/src/request_processors/plugins.rs
@@ -1013,12 +1013,13 @@ impl PluginRequestProcessor {
         params: PluginUninstallParams,
     ) -> Result<PluginUninstallResponse, JSONRPCErrorError> {
         let PluginUninstallParams { plugin_id } = params;
-        match codex_plugin::PluginId::parse(&plugin_id) {
-            Ok(_) => {}
-            Err(_) if is_valid_remote_plugin_id(&plugin_id) => {
-                return self.remote_plugin_uninstall_response(plugin_id).await;
-            }
-            Err(_) => return Err(invalid_request("invalid remote plugin id")),
+        if codex_plugin::PluginId::parse(&plugin_id).is_err()
+            && !is_valid_remote_plugin_id(&plugin_id)
+        {
+            return Err(invalid_request("invalid remote plugin id"));
+        }
+        if codex_plugin::PluginId::parse(&plugin_id).is_err() {
+            return self.remote_plugin_uninstall_response(plugin_id).await;
         }
         let plugins_manager = self.thread_manager.plugins_manager();
 

--- a/codex-rs/app-server/src/request_processors/plugins.rs
+++ b/codex-rs/app-server/src/request_processors/plugins.rs
@@ -1013,11 +1013,12 @@ impl PluginRequestProcessor {
         params: PluginUninstallParams,
     ) -> Result<PluginUninstallResponse, JSONRPCErrorError> {
         let PluginUninstallParams { plugin_id } = params;
-        if codex_plugin::PluginId::parse(&plugin_id).is_err() {
-            if !is_valid_remote_plugin_id(&plugin_id) {
-                return Err(invalid_request("invalid remote plugin id"));
+        match codex_plugin::PluginId::parse(&plugin_id) {
+            Ok(_) => {}
+            Err(_) if is_valid_remote_plugin_id(&plugin_id) => {
+                return self.remote_plugin_uninstall_response(plugin_id).await;
             }
-            return self.remote_plugin_uninstall_response(plugin_id).await;
+            Err(_) => return Err(invalid_request("invalid remote plugin id")),
         }
         let plugins_manager = self.thread_manager.plugins_manager();
 

--- a/codex-rs/app-server/src/request_processors/plugins.rs
+++ b/codex-rs/app-server/src/request_processors/plugins.rs
@@ -1014,6 +1014,9 @@ impl PluginRequestProcessor {
     ) -> Result<PluginUninstallResponse, JSONRPCErrorError> {
         let PluginUninstallParams { plugin_id } = params;
         if codex_plugin::PluginId::parse(&plugin_id).is_err() {
+            if !is_valid_remote_plugin_id(&plugin_id) {
+                return Err(invalid_request("invalid remote plugin id"));
+            }
             return self.remote_plugin_uninstall_response(plugin_id).await;
         }
         let plugins_manager = self.thread_manager.plugins_manager();

--- a/codex-rs/app-server/src/request_processors/plugins.rs
+++ b/codex-rs/app-server/src/request_processors/plugins.rs
@@ -4,6 +4,7 @@ use crate::error_code::invalid_request;
 use codex_app_server_protocol::PluginAvailability;
 use codex_app_server_protocol::PluginInstallPolicy;
 use codex_config::types::McpServerConfig;
+use codex_core_plugins::remote::is_valid_remote_plugin_id;
 use codex_core_plugins::remote::validate_remote_plugin_id;
 use codex_mcp::McpOAuthLoginSupport;
 use codex_mcp::oauth_login_support;
@@ -1018,7 +1019,7 @@ impl PluginRequestProcessor {
         {
             return Err(invalid_request("invalid remote plugin id"));
         }
-        if codex_plugin::PluginId::parse(&plugin_id).is_err() {
+        if is_valid_remote_plugin_id(&plugin_id) {
             return self.remote_plugin_uninstall_response(plugin_id).await;
         }
         let plugins_manager = self.thread_manager.plugins_manager();

--- a/codex-rs/app-server/tests/suite/v2/plugin_uninstall.rs
+++ b/codex-rs/app-server/tests/suite/v2/plugin_uninstall.rs
@@ -27,6 +27,7 @@ use wiremock::matchers::path;
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
 const REMOTE_PLUGIN_ID: &str = "plugins~Plugin_linear";
 const WORKSPACE_REMOTE_PLUGIN_ID: &str = "plugins_69f27c3e67848191a45cbaa5f2adb39d";
+const UNKNOWN_PREFIX_REMOTE_PLUGIN_ID: &str = "newremote_69f27c3e67848191a45cbaa5f2adb39d";
 
 #[tokio::test]
 async fn plugin_uninstall_removes_plugin_cache_and_config_entry() -> Result<()> {
@@ -398,6 +399,79 @@ async fn plugin_uninstall_accepts_workspace_remote_plugin_id_shape() -> Result<(
 }
 
 #[tokio::test]
+async fn plugin_uninstall_accepts_remote_plugin_id_without_known_prefix() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    let server = MockServer::start().await;
+    write_remote_plugin_catalog_config(
+        codex_home.path(),
+        &format!("{}/backend-api/", server.uri()),
+    )?;
+    write_chatgpt_auth(
+        codex_home.path(),
+        ChatGptAuthFixture::new("chatgpt-token")
+            .account_id("account-123")
+            .chatgpt_user_id("user-123")
+            .chatgpt_account_id("account-123"),
+        AuthCredentialsStoreMode::File,
+    )?;
+    mount_remote_plugin_detail_with_name(
+        &server,
+        UNKNOWN_PREFIX_REMOTE_PLUGIN_ID,
+        "new-tool",
+        "1.0.0",
+        "GLOBAL",
+    )
+    .await;
+
+    Mock::given(method("POST"))
+        .and(path(format!(
+            "/backend-api/plugins/{UNKNOWN_PREFIX_REMOTE_PLUGIN_ID}/uninstall"
+        )))
+        .and(header("authorization", "Bearer chatgpt-token"))
+        .and(header("chatgpt-account-id", "account-123"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(format!(
+            r#"{{"id":"{UNKNOWN_PREFIX_REMOTE_PLUGIN_ID}","enabled":false}}"#
+        )))
+        .mount(&server)
+        .await;
+
+    let remote_plugin_cache_root = codex_home
+        .path()
+        .join("plugins/cache/chatgpt-global/new-tool");
+    std::fs::create_dir_all(remote_plugin_cache_root.join("1.0.0/.codex-plugin"))?;
+    std::fs::write(
+        remote_plugin_cache_root.join("1.0.0/.codex-plugin/plugin.json"),
+        r#"{"name":"new-tool","version":"1.0.0"}"#,
+    )?;
+
+    let mut mcp = McpProcess::new(codex_home.path()).await?;
+    timeout(DEFAULT_TIMEOUT, mcp.initialize()).await??;
+
+    let request_id = mcp
+        .send_plugin_uninstall_request(PluginUninstallParams {
+            plugin_id: UNKNOWN_PREFIX_REMOTE_PLUGIN_ID.to_string(),
+        })
+        .await?;
+    let response: JSONRPCResponse = timeout(
+        DEFAULT_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+    let response: PluginUninstallResponse = to_response(response)?;
+
+    assert_eq!(response, PluginUninstallResponse {});
+    wait_for_remote_plugin_request_count(
+        &server,
+        "POST",
+        &format!("/plugins/{UNKNOWN_PREFIX_REMOTE_PLUGIN_ID}/uninstall"),
+        /*expected_count*/ 1,
+    )
+    .await?;
+    assert!(!remote_plugin_cache_root.exists());
+    Ok(())
+}
+
+#[tokio::test]
 async fn plugin_uninstall_rejects_before_post_when_remote_detail_fetch_fails() -> Result<()> {
     let codex_home = TempDir::new()?;
     let server = MockServer::start().await;
@@ -454,7 +528,7 @@ async fn plugin_uninstall_rejects_before_post_when_remote_detail_fetch_fails() -
 }
 
 #[tokio::test]
-async fn plugin_uninstall_rejects_invalid_plugin_id_before_remote_path() -> Result<()> {
+async fn plugin_uninstall_rejects_remote_plugin_id_with_spaces_before_network_call() -> Result<()> {
     let codex_home = TempDir::new()?;
     let server = MockServer::start().await;
     write_remote_plugin_catalog_config(
@@ -477,7 +551,7 @@ async fn plugin_uninstall_rejects_invalid_plugin_id_before_remote_path() -> Resu
     .await??;
 
     assert_eq!(err.error.code, -32600);
-    assert!(err.error.message.contains("invalid plugin id"));
+    assert!(err.error.message.contains("invalid remote plugin id"));
     wait_for_remote_plugin_request_count(
         &server,
         "POST",
@@ -512,7 +586,7 @@ async fn plugin_uninstall_rejects_invalid_remote_plugin_id_before_network_call()
     .await??;
 
     assert_eq!(err.error.code, -32600);
-    assert!(err.error.message.contains("invalid plugin id"));
+    assert!(err.error.message.contains("invalid remote plugin id"));
     wait_for_remote_plugin_request_count(
         &server,
         "POST",
@@ -546,7 +620,7 @@ async fn plugin_uninstall_rejects_empty_remote_plugin_id() -> Result<()> {
     .await??;
 
     assert_eq!(err.error.code, -32600);
-    assert!(err.error.message.contains("invalid plugin id"));
+    assert!(err.error.message.contains("invalid remote plugin id"));
 
     Ok(())
 }

--- a/codex-rs/app-server/tests/suite/v2/plugin_uninstall.rs
+++ b/codex-rs/app-server/tests/suite/v2/plugin_uninstall.rs
@@ -27,7 +27,6 @@ use wiremock::matchers::path;
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
 const REMOTE_PLUGIN_ID: &str = "plugins~Plugin_linear";
 const WORKSPACE_REMOTE_PLUGIN_ID: &str = "plugins_69f27c3e67848191a45cbaa5f2adb39d";
-const UNKNOWN_PREFIX_REMOTE_PLUGIN_ID: &str = "newremote_69f27c3e67848191a45cbaa5f2adb39d";
 
 #[tokio::test]
 async fn plugin_uninstall_removes_plugin_cache_and_config_entry() -> Result<()> {
@@ -391,79 +390,6 @@ async fn plugin_uninstall_accepts_workspace_remote_plugin_id_shape() -> Result<(
         &server,
         "POST",
         &format!("/plugins/{WORKSPACE_REMOTE_PLUGIN_ID}/uninstall"),
-        /*expected_count*/ 1,
-    )
-    .await?;
-    assert!(!remote_plugin_cache_root.exists());
-    Ok(())
-}
-
-#[tokio::test]
-async fn plugin_uninstall_accepts_remote_plugin_id_without_known_prefix() -> Result<()> {
-    let codex_home = TempDir::new()?;
-    let server = MockServer::start().await;
-    write_remote_plugin_catalog_config(
-        codex_home.path(),
-        &format!("{}/backend-api/", server.uri()),
-    )?;
-    write_chatgpt_auth(
-        codex_home.path(),
-        ChatGptAuthFixture::new("chatgpt-token")
-            .account_id("account-123")
-            .chatgpt_user_id("user-123")
-            .chatgpt_account_id("account-123"),
-        AuthCredentialsStoreMode::File,
-    )?;
-    mount_remote_plugin_detail_with_name(
-        &server,
-        UNKNOWN_PREFIX_REMOTE_PLUGIN_ID,
-        "new-tool",
-        "1.0.0",
-        "GLOBAL",
-    )
-    .await;
-
-    Mock::given(method("POST"))
-        .and(path(format!(
-            "/backend-api/plugins/{UNKNOWN_PREFIX_REMOTE_PLUGIN_ID}/uninstall"
-        )))
-        .and(header("authorization", "Bearer chatgpt-token"))
-        .and(header("chatgpt-account-id", "account-123"))
-        .respond_with(ResponseTemplate::new(200).set_body_string(format!(
-            r#"{{"id":"{UNKNOWN_PREFIX_REMOTE_PLUGIN_ID}","enabled":false}}"#
-        )))
-        .mount(&server)
-        .await;
-
-    let remote_plugin_cache_root = codex_home
-        .path()
-        .join("plugins/cache/chatgpt-global/new-tool");
-    std::fs::create_dir_all(remote_plugin_cache_root.join("1.0.0/.codex-plugin"))?;
-    std::fs::write(
-        remote_plugin_cache_root.join("1.0.0/.codex-plugin/plugin.json"),
-        r#"{"name":"new-tool","version":"1.0.0"}"#,
-    )?;
-
-    let mut mcp = McpProcess::new(codex_home.path()).await?;
-    timeout(DEFAULT_TIMEOUT, mcp.initialize()).await??;
-
-    let request_id = mcp
-        .send_plugin_uninstall_request(PluginUninstallParams {
-            plugin_id: UNKNOWN_PREFIX_REMOTE_PLUGIN_ID.to_string(),
-        })
-        .await?;
-    let response: JSONRPCResponse = timeout(
-        DEFAULT_TIMEOUT,
-        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
-    )
-    .await??;
-    let response: PluginUninstallResponse = to_response(response)?;
-
-    assert_eq!(response, PluginUninstallResponse {});
-    wait_for_remote_plugin_request_count(
-        &server,
-        "POST",
-        &format!("/plugins/{UNKNOWN_PREFIX_REMOTE_PLUGIN_ID}/uninstall"),
         /*expected_count*/ 1,
     )
     .await?;


### PR DESCRIPTION
## Summary

Remove the hardcoded remote plugin ID prefix allow-list from app-server uninstall routing. IDs that do not parse as local `plugin@marketplace` IDs now flow through the remote uninstall path, where the existing remote ID safety validation still rejects empty IDs, spaces, slashes, and other unsafe characters before URL/cache use.

## Why

Plugin-service owns the backend remote plugin ID contract. Codex should not require remote IDs to start with the local hardcoded prefixes `plugins~`, `plugins_`, `app_`, `asdk_app_`, or `connector_`, because newer backend ID families could otherwise be rejected before plugin-service sees the request.

## Validation

- `just fmt`
- `cargo test -p codex-app-server plugin_uninstall`
- `just fix -p codex-app-server`
- `git diff --check`