### PR TITLE
add typed approval request families

### DIFF
--- a/codex-rs/core/src/approval_request.rs
+++ b/codex-rs/core/src/approval_request.rs
@@ -20,8 +20,8 @@ use codex_utils_absolute_path::AbsolutePathBuf;
 use serde::Serialize;
 use serde_json::Value;
 
-use super::GUARDIAN_MAX_ACTION_STRING_TOKENS;
-use super::prompt::guardian_truncate_text;
+use crate::guardian::GUARDIAN_MAX_ACTION_STRING_TOKENS;
+use crate::guardian::guardian_truncate_text;
 use crate::tools::hook_names::HookToolName;
 use crate::tools::sandboxing::PermissionRequestPayload;
 
@@ -31,7 +31,15 @@ use crate::tools::sandboxing::PermissionRequestPayload;
 /// guardian review, approval hooks, and user-prompt transports deriving their
 /// own projections from it.
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) enum GuardianApprovalRequest {
+pub(crate) enum ApprovalRequest {
+    Command(CommandApprovalRequest),
+    ApplyPatch(ApplyPatchApprovalRequest),
+    McpToolCall(McpToolCallApprovalRequest),
+    RequestPermissions(RequestPermissionsApprovalRequest),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum CommandApprovalRequest {
     Shell {
         id: String,
         command: Vec<String>,
@@ -60,47 +68,65 @@ pub(crate) enum GuardianApprovalRequest {
         cwd: AbsolutePathBuf,
         additional_permissions: Option<AdditionalPermissionProfile>,
     },
-    ApplyPatch {
-        id: String,
-        cwd: AbsolutePathBuf,
-        files: Vec<AbsolutePathBuf>,
-        changes: HashMap<PathBuf, FileChange>,
-        patch: String,
-    },
     NetworkAccess {
         id: String,
         turn_id: String,
         target: String,
         hook_command: String,
+        cwd: AbsolutePathBuf,
         host: String,
         protocol: NetworkApprovalProtocol,
         port: u16,
         trigger: Option<GuardianNetworkAccessTrigger>,
     },
-    McpToolCall {
-        id: String,
-        server: String,
-        tool_name: String,
-        hook_tool_name: String,
-        arguments: Option<Value>,
-        connector_id: Option<String>,
-        connector_name: Option<String>,
-        connector_description: Option<String>,
-        tool_title: Option<String>,
-        tool_description: Option<String>,
-        annotations: Option<GuardianMcpAnnotations>,
-    },
-    RequestPermissions {
-        id: String,
-        turn_id: String,
-        reason: Option<String>,
-        permissions: RequestPermissionProfile,
-        cwd: AbsolutePathBuf,
-    },
 }
 
-impl GuardianApprovalRequest {
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ApplyPatchApprovalRequest {
+    pub(crate) id: String,
+    pub(crate) cwd: AbsolutePathBuf,
+    pub(crate) files: Vec<AbsolutePathBuf>,
+    pub(crate) changes: HashMap<PathBuf, FileChange>,
+    pub(crate) patch: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct McpToolCallApprovalRequest {
+    pub(crate) id: String,
+    pub(crate) server: String,
+    pub(crate) tool_name: String,
+    pub(crate) hook_tool_name: String,
+    pub(crate) arguments: Option<Value>,
+    pub(crate) connector_id: Option<String>,
+    pub(crate) connector_name: Option<String>,
+    pub(crate) connector_description: Option<String>,
+    pub(crate) tool_title: Option<String>,
+    pub(crate) tool_description: Option<String>,
+    pub(crate) annotations: Option<GuardianMcpAnnotations>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct RequestPermissionsApprovalRequest {
+    pub(crate) id: String,
+    pub(crate) turn_id: String,
+    pub(crate) reason: Option<String>,
+    pub(crate) permissions: RequestPermissionProfile,
+    pub(crate) cwd: AbsolutePathBuf,
+}
+
+impl ApprovalRequest {
     pub(crate) fn permission_request_payload(&self) -> Option<PermissionRequestPayload> {
+        match self {
+            Self::Command(request) => Some(request.permission_request_payload()),
+            Self::ApplyPatch(request) => Some(request.permission_request_payload()),
+            Self::McpToolCall(request) => Some(request.permission_request_payload()),
+            Self::RequestPermissions(_) => None,
+        }
+    }
+}
+
+impl CommandApprovalRequest {
+    pub(crate) fn permission_request_payload(&self) -> PermissionRequestPayload {
         match self {
             Self::Shell {
                 hook_command,
@@ -111,44 +137,26 @@ impl GuardianApprovalRequest {
                 hook_command,
                 justification,
                 ..
-            } => Some(PermissionRequestPayload::bash(
-                hook_command.clone(),
-                justification.clone(),
-            )),
+            } => PermissionRequestPayload::bash(hook_command.clone(), justification.clone()),
             #[cfg(unix)]
             Self::Execve { program, argv, .. } => {
                 let mut command = vec![program.clone()];
                 if argv.len() > 1 {
                     command.extend_from_slice(&argv[1..]);
                 }
-                Some(PermissionRequestPayload::bash(
+                PermissionRequestPayload::bash(
                     codex_shell_command::parse_command::shlex_join(&command),
                     /*description*/ None,
-                ))
+                )
             }
-            Self::ApplyPatch { patch, .. } => Some(PermissionRequestPayload {
-                tool_name: HookToolName::apply_patch(),
-                tool_input: serde_json::json!({ "command": patch }),
-            }),
             Self::NetworkAccess {
                 target,
                 hook_command,
                 ..
-            } => Some(PermissionRequestPayload::bash(
+            } => PermissionRequestPayload::bash(
                 hook_command.clone(),
                 Some(format!("network-access {target}")),
-            )),
-            Self::McpToolCall {
-                hook_tool_name,
-                arguments,
-                ..
-            } => Some(PermissionRequestPayload {
-                tool_name: HookToolName::new(hook_tool_name.clone()),
-                tool_input: arguments
-                    .clone()
-                    .unwrap_or_else(|| Value::Object(serde_json::Map::new())),
-            }),
-            Self::RequestPermissions { .. } => None,
+            ),
         }
     }
 
@@ -162,8 +170,7 @@ impl GuardianApprovalRequest {
         proposed_execpolicy_amendment: Option<ExecPolicyAmendment>,
         proposed_network_policy_amendments: Option<Vec<NetworkPolicyAmendment>>,
         available_decisions: Option<Vec<ReviewDecision>>,
-        fallback_cwd: Option<AbsolutePathBuf>,
-    ) -> Option<ExecApprovalRequestEvent> {
+    ) -> ExecApprovalRequestEvent {
         match self {
             Self::Shell {
                 id,
@@ -178,7 +185,7 @@ impl GuardianApprovalRequest {
                 cwd,
                 additional_permissions,
                 ..
-            } => Some(ExecApprovalRequestEvent {
+            } => ExecApprovalRequestEvent {
                 call_id: id.clone(),
                 approval_id,
                 turn_id,
@@ -191,7 +198,7 @@ impl GuardianApprovalRequest {
                 additional_permissions: additional_permissions.clone(),
                 available_decisions,
                 parsed_cmd: codex_shell_command::parse_command::parse_command(command),
-            }),
+            },
             #[cfg(unix)]
             Self::Execve {
                 id,
@@ -199,7 +206,7 @@ impl GuardianApprovalRequest {
                 cwd,
                 additional_permissions,
                 ..
-            } => Some(ExecApprovalRequestEvent {
+            } => ExecApprovalRequestEvent {
                 call_id: id.clone(),
                 approval_id,
                 turn_id,
@@ -212,17 +219,17 @@ impl GuardianApprovalRequest {
                 additional_permissions: additional_permissions.clone(),
                 available_decisions,
                 parsed_cmd: codex_shell_command::parse_command::parse_command(argv),
-            }),
+            },
             Self::NetworkAccess {
                 id,
                 turn_id,
                 target,
+                cwd,
                 host,
                 protocol,
                 ..
             } => {
                 let command = vec!["network-access".to_string(), target.clone()];
-                let cwd = fallback_cwd?;
                 let network_approval_context = Some(NetworkApprovalContext {
                     host: host.clone(),
                     protocol: *protocol,
@@ -240,12 +247,12 @@ impl GuardianApprovalRequest {
                             },
                         ])
                     });
-                Some(ExecApprovalRequestEvent {
+                ExecApprovalRequestEvent {
                     call_id: id.clone(),
                     approval_id,
                     turn_id: turn_id.clone(),
                     command: command.clone(),
-                    cwd,
+                    cwd: cwd.clone(),
                     reason,
                     network_approval_context,
                     proposed_execpolicy_amendment: None,
@@ -253,11 +260,17 @@ impl GuardianApprovalRequest {
                     additional_permissions: None,
                     available_decisions,
                     parsed_cmd: codex_shell_command::parse_command::parse_command(&command),
-                })
+                }
             }
-            Self::ApplyPatch { .. }
-            | Self::McpToolCall { .. }
-            | Self::RequestPermissions { .. } => None,
+        }
+    }
+}
+
+impl ApplyPatchApprovalRequest {
+    pub(crate) fn permission_request_payload(&self) -> PermissionRequestPayload {
+        PermissionRequestPayload {
+            tool_name: HookToolName::apply_patch(),
+            tool_input: serde_json::json!({ "command": self.patch }),
         }
     }
 
@@ -266,48 +279,62 @@ impl GuardianApprovalRequest {
         turn_id: String,
         reason: Option<String>,
         grant_root: Option<PathBuf>,
-    ) -> Option<ApplyPatchApprovalRequestEvent> {
-        match self {
-            Self::ApplyPatch { id, changes, .. } => Some(ApplyPatchApprovalRequestEvent {
-                call_id: id.clone(),
-                turn_id,
-                changes: changes.clone(),
-                reason,
-                grant_root,
-            }),
-            Self::Shell { .. }
-            | Self::ExecCommand { .. }
-            | Self::NetworkAccess { .. }
-            | Self::McpToolCall { .. }
-            | Self::RequestPermissions { .. } => None,
-            #[cfg(unix)]
-            Self::Execve { .. } => None,
+    ) -> ApplyPatchApprovalRequestEvent {
+        ApplyPatchApprovalRequestEvent {
+            call_id: self.id.clone(),
+            turn_id,
+            changes: self.changes.clone(),
+            reason,
+            grant_root,
         }
     }
+}
 
-    pub(crate) fn request_permissions_event(&self) -> Option<RequestPermissionsEvent> {
-        match self {
-            Self::RequestPermissions {
-                id,
-                turn_id,
-                reason,
-                permissions,
-                cwd,
-            } => Some(RequestPermissionsEvent {
-                call_id: id.clone(),
-                turn_id: turn_id.clone(),
-                reason: reason.clone(),
-                permissions: permissions.clone(),
-                cwd: Some(cwd.clone()),
-            }),
-            Self::Shell { .. }
-            | Self::ExecCommand { .. }
-            | Self::ApplyPatch { .. }
-            | Self::NetworkAccess { .. }
-            | Self::McpToolCall { .. } => None,
-            #[cfg(unix)]
-            Self::Execve { .. } => None,
+impl McpToolCallApprovalRequest {
+    pub(crate) fn permission_request_payload(&self) -> PermissionRequestPayload {
+        PermissionRequestPayload {
+            tool_name: HookToolName::new(self.hook_tool_name.clone()),
+            tool_input: self
+                .arguments
+                .clone()
+                .unwrap_or_else(|| Value::Object(serde_json::Map::new())),
         }
+    }
+}
+
+impl RequestPermissionsApprovalRequest {
+    pub(crate) fn request_permissions_event(&self) -> RequestPermissionsEvent {
+        RequestPermissionsEvent {
+            call_id: self.id.clone(),
+            turn_id: self.turn_id.clone(),
+            reason: self.reason.clone(),
+            permissions: self.permissions.clone(),
+            cwd: Some(self.cwd.clone()),
+        }
+    }
+}
+
+impl From<CommandApprovalRequest> for ApprovalRequest {
+    fn from(value: CommandApprovalRequest) -> Self {
+        Self::Command(value)
+    }
+}
+
+impl From<ApplyPatchApprovalRequest> for ApprovalRequest {
+    fn from(value: ApplyPatchApprovalRequest) -> Self {
+        Self::ApplyPatch(value)
+    }
+}
+
+impl From<McpToolCallApprovalRequest> for ApprovalRequest {
+    fn from(value: McpToolCallApprovalRequest) -> Self {
+        Self::McpToolCall(value)
+    }
+}
+
+impl From<RequestPermissionsApprovalRequest> for ApprovalRequest {
+    fn from(value: RequestPermissionsApprovalRequest) -> Self {
+        Self::RequestPermissions(value)
     }
 }
 
@@ -492,10 +519,10 @@ pub(crate) struct FormattedGuardianAction {
 }
 
 pub(crate) fn guardian_approval_request_to_json(
-    action: &GuardianApprovalRequest,
+    action: &ApprovalRequest,
 ) -> serde_json::Result<Value> {
     match action {
-        GuardianApprovalRequest::Shell {
+        ApprovalRequest::Command(CommandApprovalRequest::Shell {
             id: _,
             command,
             cwd,
@@ -503,7 +530,7 @@ pub(crate) fn guardian_approval_request_to_json(
             additional_permissions,
             justification,
             ..
-        } => serialize_command_guardian_action(
+        }) => serialize_command_guardian_action(
             "shell",
             command,
             cwd,
@@ -512,7 +539,7 @@ pub(crate) fn guardian_approval_request_to_json(
             justification.as_ref(),
             /*tty*/ None,
         ),
-        GuardianApprovalRequest::ExecCommand {
+        ApprovalRequest::Command(CommandApprovalRequest::ExecCommand {
             id: _,
             command,
             cwd,
@@ -521,7 +548,7 @@ pub(crate) fn guardian_approval_request_to_json(
             justification,
             tty,
             ..
-        } => serialize_command_guardian_action(
+        }) => serialize_command_guardian_action(
             "exec_command",
             command,
             cwd,
@@ -531,33 +558,33 @@ pub(crate) fn guardian_approval_request_to_json(
             Some(*tty),
         ),
         #[cfg(unix)]
-        GuardianApprovalRequest::Execve {
+        ApprovalRequest::Command(CommandApprovalRequest::Execve {
             id: _,
             source,
             program,
             argv,
             cwd,
             additional_permissions,
-        } => serialize_guardian_action(ExecveApprovalAction {
+        }) => serialize_guardian_action(ExecveApprovalAction {
             tool: guardian_command_source_tool_name(*source),
             program,
             argv,
             cwd,
             additional_permissions: additional_permissions.as_ref(),
         }),
-        GuardianApprovalRequest::ApplyPatch {
+        ApprovalRequest::ApplyPatch(ApplyPatchApprovalRequest {
             id: _,
             cwd,
             files,
             changes: _,
             patch,
-        } => Ok(serde_json::json!({
+        }) => Ok(serde_json::json!({
             "tool": "apply_patch",
             "cwd": cwd,
             "files": files,
             "patch": patch,
         })),
-        GuardianApprovalRequest::NetworkAccess {
+        ApprovalRequest::Command(CommandApprovalRequest::NetworkAccess {
             id: _,
             turn_id: _,
             target,
@@ -566,7 +593,7 @@ pub(crate) fn guardian_approval_request_to_json(
             port,
             trigger,
             ..
-        } => serialize_guardian_action(NetworkAccessApprovalAction {
+        }) => serialize_guardian_action(NetworkAccessApprovalAction {
             tool: "network_access",
             target,
             host,
@@ -574,7 +601,7 @@ pub(crate) fn guardian_approval_request_to_json(
             port: *port,
             trigger: trigger.as_ref(),
         }),
-        GuardianApprovalRequest::McpToolCall {
+        ApprovalRequest::McpToolCall(McpToolCallApprovalRequest {
             id: _,
             server,
             tool_name,
@@ -586,7 +613,7 @@ pub(crate) fn guardian_approval_request_to_json(
             tool_description,
             annotations,
             ..
-        } => serialize_guardian_action(McpToolCallApprovalAction {
+        }) => serialize_guardian_action(McpToolCallApprovalAction {
             tool: "mcp_tool_call",
             server,
             tool_name,
@@ -598,13 +625,13 @@ pub(crate) fn guardian_approval_request_to_json(
             tool_description: tool_description.as_ref(),
             annotations: annotations.as_ref(),
         }),
-        GuardianApprovalRequest::RequestPermissions {
+        ApprovalRequest::RequestPermissions(RequestPermissionsApprovalRequest {
             id: _,
             turn_id,
             reason,
             permissions,
             ..
-        } => serialize_guardian_action(RequestPermissionsApprovalAction {
+        }) => serialize_guardian_action(RequestPermissionsApprovalAction {
             tool: "request_permissions",
             turn_id,
             reason: reason.as_ref(),
@@ -613,36 +640,34 @@ pub(crate) fn guardian_approval_request_to_json(
     }
 }
 
-pub(crate) fn guardian_assessment_action(
-    action: &GuardianApprovalRequest,
-) -> GuardianAssessmentAction {
+pub(crate) fn guardian_assessment_action(action: &ApprovalRequest) -> GuardianAssessmentAction {
     match action {
-        GuardianApprovalRequest::Shell { command, cwd, .. } => {
+        ApprovalRequest::Command(CommandApprovalRequest::Shell { command, cwd, .. }) => {
             command_assessment_action(GuardianCommandSource::Shell, command, cwd)
         }
-        GuardianApprovalRequest::ExecCommand { command, cwd, .. } => {
+        ApprovalRequest::Command(CommandApprovalRequest::ExecCommand { command, cwd, .. }) => {
             command_assessment_action(GuardianCommandSource::UnifiedExec, command, cwd)
         }
         #[cfg(unix)]
-        GuardianApprovalRequest::Execve {
+        ApprovalRequest::Command(CommandApprovalRequest::Execve {
             source,
             program,
             argv,
             cwd,
             ..
-        } => GuardianAssessmentAction::Execve {
+        }) => GuardianAssessmentAction::Execve {
             source: *source,
             program: program.clone(),
             argv: argv.clone(),
             cwd: cwd.clone(),
         },
-        GuardianApprovalRequest::ApplyPatch { cwd, files, .. } => {
+        ApprovalRequest::ApplyPatch(ApplyPatchApprovalRequest { cwd, files, .. }) => {
             GuardianAssessmentAction::ApplyPatch {
                 cwd: cwd.clone(),
                 files: files.clone(),
             }
         }
-        GuardianApprovalRequest::NetworkAccess {
+        ApprovalRequest::Command(CommandApprovalRequest::NetworkAccess {
             id: _id,
             turn_id: _turn_id,
             target,
@@ -651,128 +676,128 @@ pub(crate) fn guardian_assessment_action(
             port,
             trigger: _trigger,
             ..
-        } => GuardianAssessmentAction::NetworkAccess {
+        }) => GuardianAssessmentAction::NetworkAccess {
             target: target.clone(),
             host: host.clone(),
             protocol: *protocol,
             port: *port,
         },
-        GuardianApprovalRequest::McpToolCall {
+        ApprovalRequest::McpToolCall(McpToolCallApprovalRequest {
             server,
             tool_name,
             connector_id,
             connector_name,
             tool_title,
             ..
-        } => GuardianAssessmentAction::McpToolCall {
+        }) => GuardianAssessmentAction::McpToolCall {
             server: server.clone(),
             tool_name: tool_name.clone(),
             connector_id: connector_id.clone(),
             connector_name: connector_name.clone(),
             tool_title: tool_title.clone(),
         },
-        GuardianApprovalRequest::RequestPermissions {
+        ApprovalRequest::RequestPermissions(RequestPermissionsApprovalRequest {
             reason,
             permissions,
             ..
-        } => GuardianAssessmentAction::RequestPermissions {
+        }) => GuardianAssessmentAction::RequestPermissions {
             reason: reason.clone(),
             permissions: permissions.clone(),
         },
     }
 }
 
-pub(crate) fn guardian_reviewed_action(
-    request: &GuardianApprovalRequest,
-) -> GuardianReviewedAction {
+pub(crate) fn guardian_reviewed_action(request: &ApprovalRequest) -> GuardianReviewedAction {
     match request {
-        GuardianApprovalRequest::Shell {
+        ApprovalRequest::Command(CommandApprovalRequest::Shell {
             sandbox_permissions,
             additional_permissions,
             ..
-        } => GuardianReviewedAction::Shell {
+        }) => GuardianReviewedAction::Shell {
             sandbox_permissions: *sandbox_permissions,
             additional_permissions: additional_permissions.clone(),
         },
-        GuardianApprovalRequest::ExecCommand {
+        ApprovalRequest::Command(CommandApprovalRequest::ExecCommand {
             sandbox_permissions,
             additional_permissions,
             tty,
             ..
-        } => GuardianReviewedAction::UnifiedExec {
+        }) => GuardianReviewedAction::UnifiedExec {
             sandbox_permissions: *sandbox_permissions,
             additional_permissions: additional_permissions.clone(),
             tty: *tty,
         },
         #[cfg(unix)]
-        GuardianApprovalRequest::Execve {
+        ApprovalRequest::Command(CommandApprovalRequest::Execve {
             source,
             program,
             additional_permissions,
             ..
-        } => GuardianReviewedAction::Execve {
+        }) => GuardianReviewedAction::Execve {
             source: *source,
             program: program.clone(),
             additional_permissions: additional_permissions.clone(),
         },
-        GuardianApprovalRequest::ApplyPatch { .. } => GuardianReviewedAction::ApplyPatch {},
-        GuardianApprovalRequest::NetworkAccess { protocol, port, .. } => {
-            GuardianReviewedAction::NetworkAccess {
-                protocol: *protocol,
-                port: *port,
-            }
-        }
-        GuardianApprovalRequest::McpToolCall {
+        ApprovalRequest::ApplyPatch(..) => GuardianReviewedAction::ApplyPatch {},
+        ApprovalRequest::Command(CommandApprovalRequest::NetworkAccess {
+            protocol, port, ..
+        }) => GuardianReviewedAction::NetworkAccess {
+            protocol: *protocol,
+            port: *port,
+        },
+        ApprovalRequest::McpToolCall(McpToolCallApprovalRequest {
             server,
             tool_name,
             connector_id,
             connector_name,
             tool_title,
             ..
-        } => GuardianReviewedAction::McpToolCall {
+        }) => GuardianReviewedAction::McpToolCall {
             server: server.clone(),
             tool_name: tool_name.clone(),
             connector_id: connector_id.clone(),
             connector_name: connector_name.clone(),
             tool_title: tool_title.clone(),
         },
-        GuardianApprovalRequest::RequestPermissions { .. } => {
-            GuardianReviewedAction::RequestPermissions {}
-        }
+        ApprovalRequest::RequestPermissions(..) => GuardianReviewedAction::RequestPermissions {},
     }
 }
 
-pub(crate) fn guardian_request_target_item_id(request: &GuardianApprovalRequest) -> Option<&str> {
+pub(crate) fn guardian_request_target_item_id(request: &ApprovalRequest) -> Option<&str> {
     match request {
-        GuardianApprovalRequest::Shell { id, .. }
-        | GuardianApprovalRequest::ExecCommand { id, .. }
-        | GuardianApprovalRequest::ApplyPatch { id, .. }
-        | GuardianApprovalRequest::McpToolCall { id, .. }
-        | GuardianApprovalRequest::RequestPermissions { id, .. } => Some(id),
-        GuardianApprovalRequest::NetworkAccess { .. } => None,
+        ApprovalRequest::Command(CommandApprovalRequest::Shell { id, .. })
+        | ApprovalRequest::Command(CommandApprovalRequest::ExecCommand { id, .. })
+        | ApprovalRequest::ApplyPatch(ApplyPatchApprovalRequest { id, .. })
+        | ApprovalRequest::McpToolCall(McpToolCallApprovalRequest { id, .. })
+        | ApprovalRequest::RequestPermissions(RequestPermissionsApprovalRequest { id, .. }) => {
+            Some(id)
+        }
+        ApprovalRequest::Command(CommandApprovalRequest::NetworkAccess { .. }) => None,
         #[cfg(unix)]
-        GuardianApprovalRequest::Execve { id, .. } => Some(id),
+        ApprovalRequest::Command(CommandApprovalRequest::Execve { id, .. }) => Some(id),
     }
 }
 
 pub(crate) fn guardian_request_turn_id<'a>(
-    request: &'a GuardianApprovalRequest,
+    request: &'a ApprovalRequest,
     default_turn_id: &'a str,
 ) -> &'a str {
     match request {
-        GuardianApprovalRequest::NetworkAccess { turn_id, .. }
-        | GuardianApprovalRequest::RequestPermissions { turn_id, .. } => turn_id,
-        GuardianApprovalRequest::Shell { .. }
-        | GuardianApprovalRequest::ExecCommand { .. }
-        | GuardianApprovalRequest::ApplyPatch { .. }
-        | GuardianApprovalRequest::McpToolCall { .. } => default_turn_id,
+        ApprovalRequest::Command(CommandApprovalRequest::NetworkAccess { turn_id, .. })
+        | ApprovalRequest::RequestPermissions(RequestPermissionsApprovalRequest {
+            turn_id, ..
+        }) => turn_id,
+        ApprovalRequest::Command(CommandApprovalRequest::Shell { .. })
+        | ApprovalRequest::Command(CommandApprovalRequest::ExecCommand { .. })
+        | ApprovalRequest::ApplyPatch(..)
+        | ApprovalRequest::McpToolCall(..) => default_turn_id,
         #[cfg(unix)]
-        GuardianApprovalRequest::Execve { .. } => default_turn_id,
+        ApprovalRequest::Command(CommandApprovalRequest::Execve { .. }) => default_turn_id,
     }
 }
 
 pub(crate) fn format_guardian_action_pretty(
-    action: &GuardianApprovalRequest,
+    action: &ApprovalRequest,
 ) -> serde_json::Result<FormattedGuardianAction> {
     let value = guardian_approval_request_to_json(action)?;
     let (value, truncated) = truncate_guardian_action_value(value);
@@ -792,7 +817,7 @@ mod tests {
 
     #[test]
     fn exec_approval_event_is_projected_from_shell_request() {
-        let request = GuardianApprovalRequest::Shell {
+        let request = CommandApprovalRequest::Shell {
             id: "call-1".to_string(),
             command: vec!["echo".to_string(), "hi".to_string()],
             hook_command: "echo hi".to_string(),
@@ -802,18 +827,15 @@ mod tests {
             justification: Some("because".to_string()),
         };
 
-        let event = request
-            .exec_approval_event(
-                "turn-1".to_string(),
-                Some("approval-1".to_string()),
-                Some("retry".to_string()),
-                /*network_approval_context*/ None,
-                /*proposed_execpolicy_amendment*/ None,
-                /*proposed_network_policy_amendments*/ None,
-                Some(vec![ReviewDecision::Approved, ReviewDecision::Abort]),
-                /*fallback_cwd*/ None,
-            )
-            .expect("exec approval event");
+        let event = request.exec_approval_event(
+            "turn-1".to_string(),
+            Some("approval-1".to_string()),
+            Some("retry".to_string()),
+            /*network_approval_context*/ None,
+            /*proposed_execpolicy_amendment*/ None,
+            /*proposed_network_policy_amendments*/ None,
+            Some(vec![ReviewDecision::Approved, ReviewDecision::Abort]),
+        );
 
         assert_eq!(event.call_id, "call-1");
         assert_eq!(event.approval_id.as_deref(), Some("approval-1"));
@@ -830,7 +852,7 @@ mod tests {
     fn apply_patch_approval_event_is_projected_from_request() {
         let path = test_path_buf("/tmp/file.txt");
         let abs_path = path.abs();
-        let request = GuardianApprovalRequest::ApplyPatch {
+        let request = ApplyPatchApprovalRequest {
             id: "call-1".to_string(),
             cwd: test_path_buf("/tmp").abs(),
             files: vec![abs_path],
@@ -843,13 +865,11 @@ mod tests {
             patch: "*** Begin Patch".to_string(),
         };
 
-        let event = request
-            .apply_patch_approval_event(
-                "turn-1".to_string(),
-                Some("needs write".to_string()),
-                /*grant_root*/ None,
-            )
-            .expect("apply_patch approval event");
+        let event = request.apply_patch_approval_event(
+            "turn-1".to_string(),
+            Some("needs write".to_string()),
+            /*grant_root*/ None,
+        );
 
         assert_eq!(event.call_id, "call-1");
         assert_eq!(event.turn_id, "turn-1");
@@ -867,7 +887,7 @@ mod tests {
 
     #[test]
     fn request_permissions_event_is_projected_from_request() {
-        let request = GuardianApprovalRequest::RequestPermissions {
+        let request = RequestPermissionsApprovalRequest {
             id: "call-1".to_string(),
             turn_id: "turn-1".to_string(),
             reason: Some("need outbound network".to_string()),
@@ -880,9 +900,7 @@ mod tests {
             cwd: test_path_buf("/tmp").abs(),
         };
 
-        let event = request
-            .request_permissions_event()
-            .expect("request_permissions event");
+        let event = request.request_permissions_event();
 
         assert_eq!(event.call_id, "call-1");
         assert_eq!(event.turn_id, "turn-1");
@@ -901,29 +919,27 @@ mod tests {
 
     #[test]
     fn network_exec_approval_event_is_projected_from_request() {
-        let request = GuardianApprovalRequest::NetworkAccess {
+        let request = CommandApprovalRequest::NetworkAccess {
             id: "network-1".to_string(),
             turn_id: "turn-1".to_string(),
             target: "https://example.com:443".to_string(),
             hook_command: "curl https://example.com".to_string(),
+            cwd: test_path_buf("/tmp").abs(),
             host: "example.com".to_string(),
             protocol: NetworkApprovalProtocol::Https,
             port: 443,
             trigger: None,
         };
 
-        let event = request
-            .exec_approval_event(
-                "ignored-turn".to_string(),
-                /*approval_id*/ None,
-                Some("need network".to_string()),
-                /*network_approval_context*/ None,
-                /*proposed_execpolicy_amendment*/ None,
-                /*proposed_network_policy_amendments*/ None,
-                /*available_decisions*/ None,
-                Some(test_path_buf("/tmp").abs()),
-            )
-            .expect("network exec approval event");
+        let event = request.exec_approval_event(
+            "ignored-turn".to_string(),
+            /*approval_id*/ None,
+            Some("need network".to_string()),
+            /*network_approval_context*/ None,
+            /*proposed_execpolicy_amendment*/ None,
+            /*proposed_network_policy_amendments*/ None,
+            /*available_decisions*/ None,
+        );
 
         assert_eq!(event.call_id, "network-1");
         assert_eq!(event.turn_id, "turn-1");

--- a/codex-rs/core/src/codex_delegate.rs
+++ b/codex-rs/core/src/codex_delegate.rs
@@ -29,9 +29,10 @@ use tokio::sync::Mutex;
 use tokio::time::timeout;
 use tokio_util::sync::CancellationToken;
 
+use crate::approval_request::ApplyPatchApprovalRequest;
+use crate::approval_request::CommandApprovalRequest;
 use crate::config::Config;
 use crate::environment_selection::ResolvedTurnEnvironments;
-use crate::guardian::GuardianApprovalRequest;
 use crate::guardian::new_guardian_review_id;
 use crate::guardian::routes_approval_to_guardian;
 use crate::guardian::spawn_approval_request_review;
@@ -451,7 +452,7 @@ async fn handle_exec_approval(
         ..
     } = event;
     let hook_command = shlex_join(&command);
-    let approval_request = GuardianApprovalRequest::Shell {
+    let approval_request = CommandApprovalRequest::Shell {
         id: call_id.clone(),
         command,
         hook_command,
@@ -470,7 +471,7 @@ async fn handle_exec_approval(
             Arc::clone(parent_session),
             Arc::clone(parent_ctx),
             new_guardian_review_id(),
-            approval_request.clone(),
+            approval_request.clone().into(),
             reason.clone(),
             GuardianApprovalRequestSource::DelegatedSubagent,
             review_cancel.clone(),
@@ -493,7 +494,6 @@ async fn handle_exec_approval(
                 network_approval_context,
                 proposed_execpolicy_amendment,
                 available_decisions,
-                /*fallback_cwd*/ None,
             ),
             parent_session,
             &approval_id_for_op,
@@ -556,7 +556,7 @@ async fn handle_patch_approval(
         })
         .collect::<Vec<_>>()
         .join("\n");
-    let approval_request = GuardianApprovalRequest::ApplyPatch {
+    let approval_request = ApplyPatchApprovalRequest {
         id: approval_id.clone(),
         cwd: parent_ctx.cwd.clone(),
         files: changes
@@ -572,7 +572,7 @@ async fn handle_patch_approval(
             Arc::clone(parent_session),
             Arc::clone(parent_ctx),
             new_guardian_review_id(),
-            approval_request.clone(),
+            approval_request.clone().into(),
             reason.clone(),
             GuardianApprovalRequestSource::DelegatedSubagent,
             review_cancel.clone(),

--- a/codex-rs/core/src/guardian/mod.rs
+++ b/codex-rs/core/src/guardian/mod.rs
@@ -11,7 +11,6 @@
 //! 3. Fail closed on timeout, execution failure, or malformed output.
 //! 4. Apply the guardian's explicit allow/deny outcome.
 
-mod approval_request;
 mod prompt;
 mod review;
 mod review_session;
@@ -23,10 +22,7 @@ use codex_protocol::protocol::GuardianAssessmentOutcome;
 use serde::Deserialize;
 use serde::Serialize;
 
-pub(crate) use approval_request::GuardianApprovalRequest;
-pub(crate) use approval_request::GuardianMcpAnnotations;
-pub(crate) use approval_request::GuardianNetworkAccessTrigger;
-pub(crate) use approval_request::guardian_approval_request_to_json;
+pub(crate) use crate::approval_request::guardian_approval_request_to_json;
 pub(crate) use review::guardian_rejection_message;
 pub(crate) use review::guardian_timeout_message;
 pub(crate) use review::is_guardian_reviewer_source;
@@ -51,7 +47,7 @@ const GUARDIAN_MAX_MESSAGE_TRANSCRIPT_TOKENS: usize = 10_000;
 const GUARDIAN_MAX_TOOL_TRANSCRIPT_TOKENS: usize = 10_000;
 const GUARDIAN_MAX_MESSAGE_ENTRY_TOKENS: usize = 2_000;
 const GUARDIAN_MAX_TOOL_ENTRY_TOKENS: usize = 1_000;
-const GUARDIAN_MAX_ACTION_STRING_TOKENS: usize = 16_000;
+pub(crate) const GUARDIAN_MAX_ACTION_STRING_TOKENS: usize = 16_000;
 const GUARDIAN_RECENT_ENTRY_LIMIT: usize = 40;
 const TRUNCATION_TAG: &str = "truncated";
 
@@ -121,11 +117,11 @@ impl GuardianRejectionCircuitBreaker {
 }
 
 #[cfg(test)]
-use approval_request::format_guardian_action_pretty;
+use crate::approval_request::format_guardian_action_pretty;
 #[cfg(test)]
-use approval_request::guardian_assessment_action;
+use crate::approval_request::guardian_assessment_action;
 #[cfg(test)]
-use approval_request::guardian_request_turn_id;
+use crate::approval_request::guardian_request_turn_id;
 #[cfg(test)]
 use prompt::GuardianPromptMode;
 #[cfg(test)]
@@ -144,8 +140,7 @@ use prompt::guardian_output_schema;
 pub(crate) use prompt::guardian_policy_prompt;
 #[cfg(test)]
 pub(crate) use prompt::guardian_policy_prompt_with_config;
-#[cfg(test)]
-use prompt::guardian_truncate_text;
+pub(crate) use prompt::guardian_truncate_text;
 #[cfg(test)]
 use prompt::parse_guardian_assessment;
 #[cfg(test)]

--- a/codex-rs/core/src/guardian/prompt.rs
+++ b/codex-rs/core/src/guardian/prompt.rs
@@ -20,10 +20,11 @@ use super::GUARDIAN_MAX_MESSAGE_TRANSCRIPT_TOKENS;
 use super::GUARDIAN_MAX_TOOL_ENTRY_TOKENS;
 use super::GUARDIAN_MAX_TOOL_TRANSCRIPT_TOKENS;
 use super::GUARDIAN_RECENT_ENTRY_LIMIT;
-use super::GuardianApprovalRequest;
 use super::GuardianAssessment;
 use super::TRUNCATION_TAG;
-use super::approval_request::format_guardian_action_pretty;
+use crate::approval_request::ApprovalRequest;
+use crate::approval_request::CommandApprovalRequest;
+use crate::approval_request::format_guardian_action_pretty;
 
 /// Transcript entry retained for guardian review after filtering.
 #[derive(Debug, PartialEq, Eq)]
@@ -89,7 +90,7 @@ pub(crate) enum GuardianPromptMode {
 pub(crate) async fn build_guardian_prompt_items(
     session: &Session,
     retry_reason: Option<String>,
-    request: GuardianApprovalRequest,
+    request: ApprovalRequest,
     mode: GuardianPromptMode,
 ) -> serde_json::Result<GuardianPromptItems> {
     let history = session.clone_history().await;
@@ -173,7 +174,7 @@ pub(crate) async fn build_guardian_prompt_items(
         push_text(format!("\n{note}\n"));
     }
     match &request {
-        GuardianApprovalRequest::NetworkAccess { trigger, .. } => {
+        ApprovalRequest::Command(CommandApprovalRequest::NetworkAccess { trigger, .. }) => {
             push_text(">>> APPROVAL REQUEST START\n".to_string());
             push_text("Below is a proposed network access request under review.\n".to_string());
             if trigger.is_some() {

--- a/codex-rs/core/src/guardian/review.rs
+++ b/codex-rs/core/src/guardian/review.rs
@@ -26,20 +26,20 @@ use crate::session::turn_context::TurnContext;
 
 use super::GUARDIAN_REVIEW_TIMEOUT;
 use super::GUARDIAN_REVIEWER_NAME;
-use super::GuardianApprovalRequest;
 use super::GuardianAssessment;
 use super::GuardianAssessmentOutcome;
 use super::GuardianRejection;
 use super::GuardianRejectionCircuitBreakerAction;
-use super::approval_request::guardian_assessment_action;
-use super::approval_request::guardian_request_target_item_id;
-use super::approval_request::guardian_request_turn_id;
-use super::approval_request::guardian_reviewed_action;
 use super::prompt::guardian_output_schema;
 use super::prompt::parse_guardian_assessment;
 use super::review_session::GuardianReviewSessionOutcome;
 use super::review_session::GuardianReviewSessionParams;
 use super::review_session::build_guardian_review_session_config;
+use crate::approval_request::ApprovalRequest;
+use crate::approval_request::guardian_assessment_action;
+use crate::approval_request::guardian_request_target_item_id;
+use crate::approval_request::guardian_request_turn_id;
+use crate::approval_request::guardian_reviewed_action;
 
 const GUARDIAN_REJECTION_INSTRUCTIONS: &str = concat!(
     "The agent must not attempt to achieve the same outcome via workaround, ",
@@ -234,7 +234,7 @@ async fn run_guardian_review(
     session: Arc<Session>,
     turn: Arc<TurnContext>,
     review_id: String,
-    request: GuardianApprovalRequest,
+    request: ApprovalRequest,
     retry_reason: Option<String>,
     approval_request_source: GuardianApprovalRequestSource,
     external_cancel: Option<CancellationToken>,
@@ -523,7 +523,7 @@ pub(crate) async fn review_approval_request(
     session: &Arc<Session>,
     turn: &Arc<TurnContext>,
     review_id: String,
-    request: GuardianApprovalRequest,
+    request: ApprovalRequest,
     retry_reason: Option<String>,
 ) -> ReviewDecision {
     // Box the delegated review future so callers do not inline the entire
@@ -544,7 +544,7 @@ pub(crate) async fn review_approval_request_with_cancel(
     session: &Arc<Session>,
     turn: &Arc<TurnContext>,
     review_id: String,
-    request: GuardianApprovalRequest,
+    request: ApprovalRequest,
     retry_reason: Option<String>,
     approval_request_source: GuardianApprovalRequestSource,
     cancel_token: CancellationToken,
@@ -565,7 +565,7 @@ pub(crate) fn spawn_approval_request_review(
     session: Arc<Session>,
     turn: Arc<TurnContext>,
     review_id: String,
-    request: GuardianApprovalRequest,
+    request: ApprovalRequest,
     retry_reason: Option<String>,
     approval_request_source: GuardianApprovalRequestSource,
     cancel_token: CancellationToken,
@@ -610,7 +610,7 @@ pub(crate) fn spawn_approval_request_review(
 pub(super) async fn run_guardian_review_session(
     session: Arc<Session>,
     turn: Arc<TurnContext>,
-    request: GuardianApprovalRequest,
+    request: ApprovalRequest,
     retry_reason: Option<String>,
     schema: serde_json::Value,
     external_cancel: Option<CancellationToken>,

--- a/codex-rs/core/src/guardian/review_session.rs
+++ b/codex-rs/core/src/guardian/review_session.rs
@@ -46,12 +46,14 @@ use codex_utils_absolute_path::AbsolutePathBuf;
 
 use super::GUARDIAN_REVIEW_TIMEOUT;
 use super::GUARDIAN_REVIEWER_NAME;
-use super::GuardianApprovalRequest;
 use super::prompt::GuardianPromptMode;
 use super::prompt::GuardianTranscriptCursor;
 use super::prompt::build_guardian_prompt_items;
 use super::prompt::guardian_policy_prompt;
 use super::prompt::guardian_policy_prompt_with_config;
+use crate::approval_request::ApprovalRequest;
+#[cfg(test)]
+use crate::approval_request::CommandApprovalRequest;
 
 const GUARDIAN_INTERRUPT_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 #[derive(Debug)]
@@ -67,7 +69,7 @@ pub(crate) struct GuardianReviewSessionParams {
     pub(crate) parent_session: Arc<Session>,
     pub(crate) parent_turn: Arc<TurnContext>,
     pub(crate) spawn_config: Config,
-    pub(crate) request: GuardianApprovalRequest,
+    pub(crate) request: ApprovalRequest,
     pub(crate) retry_reason: Option<String>,
     pub(crate) schema: Value,
     pub(crate) model: String,
@@ -1101,7 +1103,7 @@ mod tests {
             parent_session: Arc::new(session),
             parent_turn: Arc::new(turn),
             spawn_config,
-            request: GuardianApprovalRequest::Shell {
+            request: ApprovalRequest::Command(CommandApprovalRequest::Shell {
                 id: "shell-1".to_string(),
                 command: vec!["git".to_string(), "status".to_string()],
                 hook_command: "git status".to_string(),
@@ -1109,7 +1111,7 @@ mod tests {
                 sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
                 additional_permissions: None,
                 justification: Some("Inspect repo state.".to_string()),
-            },
+            }),
             retry_reason: None,
             schema: super::super::prompt::guardian_output_schema(),
             model,

--- a/codex-rs/core/src/guardian/tests.rs
+++ b/codex-rs/core/src/guardian/tests.rs
@@ -1,13 +1,19 @@
 use std::collections::HashMap;
 
 use super::*;
+use crate::approval_request::ApplyPatchApprovalRequest;
+use crate::approval_request::ApprovalRequest;
+use crate::approval_request::CommandApprovalRequest;
+use crate::approval_request::GuardianMcpAnnotations;
+use crate::approval_request::GuardianNetworkAccessTrigger;
+use crate::approval_request::McpToolCallApprovalRequest;
+use crate::approval_request::guardian_request_target_item_id;
 use crate::config::Config;
 use crate::config::ConfigOverrides;
 use crate::config::Constrained;
 use crate::config::ManagedFeatures;
 use crate::config::NetworkProxySpec;
 use crate::config::test_config;
-use crate::guardian::approval_request::guardian_request_target_item_id;
 use crate::session::session::Session;
 use crate::session::turn_context::TurnContext;
 use crate::test_support;
@@ -313,7 +319,7 @@ async fn build_guardian_prompt_full_mode_preserves_initial_review_format() -> an
     let prompt = build_guardian_prompt_items(
         session.as_ref(),
         Some("Sandbox denied outbound git push to github.com.".to_string()),
-        GuardianApprovalRequest::Shell {
+        ApprovalRequest::Command(CommandApprovalRequest::Shell {
             id: "shell-1".to_string(),
             command: vec!["git".to_string(), "push".to_string()],
             hook_command: "git push".to_string(),
@@ -321,7 +327,7 @@ async fn build_guardian_prompt_full_mode_preserves_initial_review_format() -> an
             sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
             additional_permissions: None,
             justification: Some("Need to push the reviewed docs fix.".to_string()),
-        },
+        }),
         GuardianPromptMode::Full,
     )
     .await?;
@@ -368,7 +374,7 @@ async fn build_guardian_prompt_delta_mode_preserves_original_numbering() -> anyh
     let prompt = build_guardian_prompt_items(
         session.as_ref(),
         /*retry_reason*/ None,
-        GuardianApprovalRequest::Shell {
+        ApprovalRequest::Command(CommandApprovalRequest::Shell {
             id: "shell-2".to_string(),
             command: vec!["git".to_string(), "push".to_string()],
             hook_command: "git push".to_string(),
@@ -376,7 +382,7 @@ async fn build_guardian_prompt_delta_mode_preserves_original_numbering() -> anyh
             sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
             additional_permissions: None,
             justification: Some("Need to push the second docs fix.".to_string()),
-        },
+        }),
         GuardianPromptMode::Delta {
             cursor: GuardianTranscriptCursor {
                 parent_history_version: 0,
@@ -407,7 +413,7 @@ async fn build_guardian_prompt_delta_mode_handles_empty_delta() -> anyhow::Resul
     let prompt = build_guardian_prompt_items(
         session.as_ref(),
         /*retry_reason*/ None,
-        GuardianApprovalRequest::Shell {
+        ApprovalRequest::Command(CommandApprovalRequest::Shell {
             id: "shell-2".to_string(),
             command: vec!["git".to_string(), "push".to_string()],
             hook_command: "git push".to_string(),
@@ -415,7 +421,7 @@ async fn build_guardian_prompt_delta_mode_handles_empty_delta() -> anyhow::Resul
             sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
             additional_permissions: None,
             justification: Some("Need to push the second docs fix.".to_string()),
-        },
+        }),
         GuardianPromptMode::Delta {
             cursor: GuardianTranscriptCursor {
                 parent_history_version: 0,
@@ -443,7 +449,7 @@ async fn build_guardian_prompt_stale_delta_cursor_falls_back_to_full_prompt() ->
     let prompt = build_guardian_prompt_items(
         session.as_ref(),
         /*retry_reason*/ None,
-        GuardianApprovalRequest::Shell {
+        ApprovalRequest::Command(CommandApprovalRequest::Shell {
             id: "shell-3".to_string(),
             command: vec!["git".to_string(), "push".to_string()],
             hook_command: "git push".to_string(),
@@ -451,7 +457,7 @@ async fn build_guardian_prompt_stale_delta_cursor_falls_back_to_full_prompt() ->
             sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
             additional_permissions: None,
             justification: Some("Need to push the docs fix.".to_string()),
-        },
+        }),
         GuardianPromptMode::Delta {
             cursor: GuardianTranscriptCursor {
                 parent_history_version: 0,
@@ -525,7 +531,7 @@ async fn build_guardian_prompt_stale_delta_version_falls_back_to_full_prompt() -
     let prompt = build_guardian_prompt_items(
         session.as_ref(),
         /*retry_reason*/ None,
-        GuardianApprovalRequest::Shell {
+        ApprovalRequest::Command(CommandApprovalRequest::Shell {
             id: "shell-4".to_string(),
             command: vec!["git".to_string(), "push".to_string()],
             hook_command: "git push".to_string(),
@@ -533,7 +539,7 @@ async fn build_guardian_prompt_stale_delta_version_falls_back_to_full_prompt() -
             sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
             additional_permissions: None,
             justification: Some("Need to push after the compaction.".to_string()),
-        },
+        }),
         GuardianPromptMode::Delta {
             cursor: GuardianTranscriptCursor {
                 parent_history_version: 0,
@@ -690,13 +696,13 @@ fn guardian_truncate_text_keeps_prefix_suffix_and_xml_marker() {
 #[test]
 fn format_guardian_action_pretty_truncates_large_string_fields() -> serde_json::Result<()> {
     let patch = "line\n".repeat(100_000);
-    let action = GuardianApprovalRequest::ApplyPatch {
+    let action = ApprovalRequest::ApplyPatch(ApplyPatchApprovalRequest {
         id: "patch-1".to_string(),
         cwd: test_path_buf("/tmp").abs(),
         files: Vec::new(),
         changes: HashMap::new(),
         patch: patch.clone(),
-    };
+    });
 
     let rendered = format_guardian_action_pretty(&action)?;
 
@@ -710,13 +716,13 @@ fn format_guardian_action_pretty_truncates_large_string_fields() -> serde_json::
 #[test]
 fn format_guardian_action_pretty_reports_no_truncation_for_small_payload() -> serde_json::Result<()>
 {
-    let action = GuardianApprovalRequest::ApplyPatch {
+    let action = ApprovalRequest::ApplyPatch(ApplyPatchApprovalRequest {
         id: "patch-1".to_string(),
         cwd: test_path_buf("/tmp").abs(),
         files: Vec::new(),
         changes: HashMap::new(),
         patch: "line\n".to_string(),
-    };
+    });
 
     let rendered = format_guardian_action_pretty(&action)?;
 
@@ -727,7 +733,7 @@ fn format_guardian_action_pretty_reports_no_truncation_for_small_payload() -> se
 
 #[test]
 fn guardian_approval_request_to_json_renders_mcp_tool_call_shape() -> serde_json::Result<()> {
-    let action = GuardianApprovalRequest::McpToolCall {
+    let action = ApprovalRequest::McpToolCall(McpToolCallApprovalRequest {
         id: "call-1".to_string(),
         server: "mcp_server".to_string(),
         tool_name: "browser_navigate".to_string(),
@@ -745,7 +751,7 @@ fn guardian_approval_request_to_json_renders_mcp_tool_call_shape() -> serde_json
             open_world_hint: None,
             read_only_hint: Some(false),
         }),
-    };
+    });
 
     assert_eq!(
         guardian_approval_request_to_json(&action)?,
@@ -770,11 +776,12 @@ fn guardian_approval_request_to_json_renders_mcp_tool_call_shape() -> serde_json
 #[test]
 fn guardian_approval_request_to_json_renders_network_access_trigger() -> serde_json::Result<()> {
     let cwd = test_path_buf("/repo").abs();
-    let action = GuardianApprovalRequest::NetworkAccess {
+    let action = ApprovalRequest::Command(CommandApprovalRequest::NetworkAccess {
         id: "network-1".to_string(),
         turn_id: "turn-1".to_string(),
         target: "https://example.com:443".to_string(),
         hook_command: "curl https://example.com".to_string(),
+        cwd: cwd.clone(),
         host: "example.com".to_string(),
         protocol: NetworkApprovalProtocol::Https,
         port: 443,
@@ -788,7 +795,7 @@ fn guardian_approval_request_to_json_renders_network_access_trigger() -> serde_j
             justification: Some("Fetch the release metadata.".to_string()),
             tty: None,
         }),
-    };
+    });
 
     assert_eq!(
         guardian_approval_request_to_json(&action)?,
@@ -821,11 +828,12 @@ async fn build_guardian_prompt_items_explains_network_access_review_scope() -> a
     let prompt = build_guardian_prompt_items(
         session.as_ref(),
         Some("Network access to \"example.com\" is blocked by policy.".to_string()),
-        GuardianApprovalRequest::NetworkAccess {
+        ApprovalRequest::Command(CommandApprovalRequest::NetworkAccess {
             id: "network-1".to_string(),
             turn_id: "turn-1".to_string(),
             target: "https://example.com:443".to_string(),
             hook_command: "curl https://example.com".to_string(),
+            cwd: cwd.clone(),
             host: "example.com".to_string(),
             protocol: NetworkApprovalProtocol::Https,
             port: 443,
@@ -839,7 +847,7 @@ async fn build_guardian_prompt_items_explains_network_access_review_scope() -> a
                 justification: Some("Fetch the release metadata.".to_string()),
                 tty: None,
             }),
-        },
+        }),
         GuardianPromptMode::Full,
     )
     .await?;
@@ -886,14 +894,14 @@ async fn build_guardian_prompt_items_explains_network_access_review_scope() -> a
 fn guardian_assessment_action_redacts_apply_patch_patch_text() {
     let cwd = test_path_buf("/tmp").abs();
     let file = test_path_buf("/tmp/guardian.txt").abs();
-    let action = GuardianApprovalRequest::ApplyPatch {
+    let action = ApprovalRequest::ApplyPatch(ApplyPatchApprovalRequest {
         id: "patch-1".to_string(),
         cwd: cwd.clone(),
         files: vec![file.clone()],
         changes: HashMap::new(),
         patch: "*** Begin Patch\n*** Update File: guardian.txt\n@@\n+secret\n*** End Patch"
             .to_string(),
-    };
+    });
 
     assert_eq!(
         serde_json::to_value(guardian_assessment_action(&action)).expect("serialize action"),
@@ -907,24 +915,25 @@ fn guardian_assessment_action_redacts_apply_patch_patch_text() {
 
 #[test]
 fn guardian_request_turn_id_prefers_network_access_owner_turn() {
-    let network_access = GuardianApprovalRequest::NetworkAccess {
+    let network_access = ApprovalRequest::Command(CommandApprovalRequest::NetworkAccess {
         id: "network-1".to_string(),
         turn_id: "owner-turn".to_string(),
         target: "https://example.com:443".to_string(),
         hook_command: "network-access https://example.com:443".to_string(),
+        cwd: test_path_buf("/tmp").abs(),
         host: "example.com".to_string(),
         protocol: NetworkApprovalProtocol::Https,
         port: 443,
         trigger: None,
-    };
-    let apply_patch = GuardianApprovalRequest::ApplyPatch {
+    });
+    let apply_patch = ApprovalRequest::ApplyPatch(ApplyPatchApprovalRequest {
         id: "patch-1".to_string(),
         cwd: test_path_buf("/tmp").abs(),
         files: vec![test_path_buf("/tmp/guardian.txt").abs()],
         changes: HashMap::new(),
         patch: "*** Begin Patch\n*** Update File: guardian.txt\n@@\n+hello\n*** End Patch"
             .to_string(),
-    };
+    });
 
     assert_eq!(
         guardian_request_turn_id(&network_access, "fallback-turn"),
@@ -938,11 +947,12 @@ fn guardian_request_turn_id_prefers_network_access_owner_turn() {
 
 #[test]
 fn guardian_request_target_item_id_omits_network_access_trigger_call_id() {
-    let network_access = GuardianApprovalRequest::NetworkAccess {
+    let network_access = ApprovalRequest::Command(CommandApprovalRequest::NetworkAccess {
         id: "network-1".to_string(),
         turn_id: "owner-turn".to_string(),
         target: "https://example.com:443".to_string(),
         hook_command: "network-access https://example.com:443".to_string(),
+        cwd: test_path_buf("/tmp").abs(),
         host: "example.com".to_string(),
         protocol: NetworkApprovalProtocol::Https,
         port: 443,
@@ -956,7 +966,7 @@ fn guardian_request_target_item_id_omits_network_access_trigger_call_id() {
             justification: None,
             tty: None,
         }),
-    };
+    });
 
     assert_eq!(guardian_request_target_item_id(&network_access), None);
 }
@@ -971,14 +981,14 @@ async fn cancelled_guardian_review_emits_terminal_abort_without_warning() {
         &session,
         &turn,
         "review-cancelled-guardian".to_string(),
-        GuardianApprovalRequest::ApplyPatch {
+        ApprovalRequest::ApplyPatch(ApplyPatchApprovalRequest {
             id: "patch-1".to_string(),
             cwd: test_path_buf("/tmp").abs(),
             files: vec![test_path_buf("/tmp/guardian.txt").abs()],
             changes: HashMap::new(),
             patch: "*** Begin Patch\n*** Update File: guardian.txt\n@@\n+hello\n*** End Patch"
                 .to_string(),
-        },
+        }),
         /*retry_reason*/ None,
         GuardianApprovalRequestSource::MainTurn,
         cancel_token,
@@ -1261,7 +1271,7 @@ async fn guardian_review_request_layout_matches_model_visible_request_snapshot()
     let turn = Arc::new(turn);
     seed_guardian_parent_history(&session, &turn).await;
 
-    let request = GuardianApprovalRequest::Shell {
+    let request = ApprovalRequest::Command(CommandApprovalRequest::Shell {
         id: "shell-1".to_string(),
         command: vec![
             "git".to_string(),
@@ -1274,7 +1284,7 @@ async fn guardian_review_request_layout_matches_model_visible_request_snapshot()
         sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
         additional_permissions: None,
         justification: Some("Need to push the reviewed docs fix to the repo remote.".to_string()),
-    };
+    });
 
     let outcome = run_guardian_review_session_for_test(
         Arc::clone(&session),
@@ -1372,7 +1382,7 @@ async fn build_guardian_prompt_items_includes_parent_session_id() -> anyhow::Res
     let prompt = build_guardian_prompt_items(
         &session,
         /*retry_reason*/ None,
-        GuardianApprovalRequest::Shell {
+        ApprovalRequest::Command(CommandApprovalRequest::Shell {
             id: "shell-1".to_string(),
             command: vec!["git".to_string(), "status".to_string()],
             hook_command: "git status".to_string(),
@@ -1380,7 +1390,7 @@ async fn build_guardian_prompt_items_includes_parent_session_id() -> anyhow::Res
             sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
             additional_permissions: None,
             justification: None,
-        },
+        }),
         GuardianPromptMode::Full,
     )
     .await?;
@@ -1447,7 +1457,7 @@ async fn guardian_reuses_prompt_cache_key_and_appends_prior_reviews() -> anyhow:
     let (session, turn) = guardian_test_session_and_turn(&server).await;
     seed_guardian_parent_history(&session, &turn).await;
 
-    let first_request = GuardianApprovalRequest::Shell {
+    let first_request = ApprovalRequest::Command(CommandApprovalRequest::Shell {
         id: "shell-1".to_string(),
         command: vec!["git".to_string(), "push".to_string()],
         hook_command: "git push".to_string(),
@@ -1455,7 +1465,7 @@ async fn guardian_reuses_prompt_cache_key_and_appends_prior_reviews() -> anyhow:
         sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
         additional_permissions: None,
         justification: Some("Need to push the first docs fix.".to_string()),
-    };
+    });
     let first_outcome = run_guardian_review_session_for_test(
         Arc::clone(&session),
         Arc::clone(&turn),
@@ -1488,7 +1498,7 @@ async fn guardian_reuses_prompt_cache_key_and_appends_prior_reviews() -> anyhow:
             turn.as_ref(),
         )
         .await;
-    let second_request = GuardianApprovalRequest::Shell {
+    let second_request = ApprovalRequest::Command(CommandApprovalRequest::Shell {
         id: "shell-2".to_string(),
         command: vec![
             "git".to_string(),
@@ -1500,7 +1510,7 @@ async fn guardian_reuses_prompt_cache_key_and_appends_prior_reviews() -> anyhow:
         sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
         additional_permissions: None,
         justification: Some("Need to push the second docs fix.".to_string()),
-    };
+    });
     let second_outcome = run_guardian_review_session_for_test(
         Arc::clone(&session),
         Arc::clone(&turn),
@@ -1533,7 +1543,7 @@ async fn guardian_reuses_prompt_cache_key_and_appends_prior_reviews() -> anyhow:
             turn.as_ref(),
         )
         .await;
-    let third_request = GuardianApprovalRequest::Shell {
+    let third_request = ApprovalRequest::Command(CommandApprovalRequest::Shell {
         id: "shell-3".to_string(),
         command: vec!["git".to_string(), "push".to_string()],
         hook_command: "git push".to_string(),
@@ -1541,7 +1551,7 @@ async fn guardian_reuses_prompt_cache_key_and_appends_prior_reviews() -> anyhow:
         sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
         additional_permissions: None,
         justification: Some("Need to push the third docs fix.".to_string()),
-    };
+    });
     let third_outcome = run_guardian_review_session_for_test(
         Arc::clone(&session),
         Arc::clone(&turn),
@@ -1729,7 +1739,7 @@ async fn guardian_reused_trunk_ignores_stale_prior_turn_completion() -> anyhow::
     let first_outcome = run_guardian_review_session_for_test(
         Arc::clone(&session),
         Arc::clone(&turn),
-        GuardianApprovalRequest::Shell {
+        ApprovalRequest::Command(CommandApprovalRequest::Shell {
             id: "shell-1".to_string(),
             command: vec!["git".to_string(), "push".to_string()],
             hook_command: "git push".to_string(),
@@ -1737,7 +1747,7 @@ async fn guardian_reused_trunk_ignores_stale_prior_turn_completion() -> anyhow::
             sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
             additional_permissions: None,
             justification: Some("Need to push the first docs fix.".to_string()),
-        },
+        }),
         /*retry_reason*/ None,
         guardian_output_schema(),
         /*external_cancel*/ None,
@@ -1772,7 +1782,7 @@ async fn guardian_reused_trunk_ignores_stale_prior_turn_completion() -> anyhow::
     let second_outcome = run_guardian_review_session_for_test(
         Arc::clone(&session),
         Arc::clone(&turn),
-        GuardianApprovalRequest::Shell {
+        ApprovalRequest::Command(CommandApprovalRequest::Shell {
             id: "shell-2".to_string(),
             command: vec!["git".to_string(), "push".to_string()],
             hook_command: "git push".to_string(),
@@ -1780,7 +1790,7 @@ async fn guardian_reused_trunk_ignores_stale_prior_turn_completion() -> anyhow::
             sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
             additional_permissions: None,
             justification: Some("Need to push the second docs fix.".to_string()),
-        },
+        }),
         /*retry_reason*/ None,
         guardian_output_schema(),
         /*external_cancel*/ None,
@@ -1852,7 +1862,7 @@ async fn guardian_review_surfaces_responses_api_errors_in_rejection_reason() -> 
         &session,
         &turn,
         "review-shell-guardian-error".to_string(),
-        GuardianApprovalRequest::Shell {
+        ApprovalRequest::Command(CommandApprovalRequest::Shell {
             id: "shell-guardian-error".to_string(),
             command: vec!["git".to_string(), "push".to_string()],
             hook_command: "git push".to_string(),
@@ -1860,7 +1870,7 @@ async fn guardian_review_surfaces_responses_api_errors_in_rejection_reason() -> 
             sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
             additional_permissions: None,
             justification: Some("Need to push the reviewed docs fix.".to_string()),
-        },
+        }),
         /*retry_reason*/ None,
     )
     .await;
@@ -1987,7 +1997,7 @@ async fn guardian_parallel_reviews_fork_from_last_committed_trunk_history() -> a
         let (session, turn) = guardian_test_session_and_turn_with_base_url(server.uri()).await;
         seed_guardian_parent_history(&session, &turn).await;
 
-        let initial_request = GuardianApprovalRequest::Shell {
+        let initial_request = ApprovalRequest::Command(CommandApprovalRequest::Shell {
             id: "shell-guardian-1".to_string(),
             command: vec!["git".to_string(), "status".to_string()],
             hook_command: "git status".to_string(),
@@ -1995,7 +2005,7 @@ async fn guardian_parallel_reviews_fork_from_last_committed_trunk_history() -> a
             sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
             additional_permissions: None,
             justification: Some("Inspect repo state before proceeding.".to_string()),
-        };
+        });
         assert_eq!(
             review_approval_request(
                 &session,
@@ -2031,7 +2041,7 @@ async fn guardian_parallel_reviews_fork_from_last_committed_trunk_history() -> a
             )
             .await;
 
-        let second_request = GuardianApprovalRequest::Shell {
+        let second_request = ApprovalRequest::Command(CommandApprovalRequest::Shell {
             id: "shell-guardian-2".to_string(),
             command: vec!["git".to_string(), "diff".to_string()],
             hook_command: "git diff".to_string(),
@@ -2039,8 +2049,8 @@ async fn guardian_parallel_reviews_fork_from_last_committed_trunk_history() -> a
             sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
             additional_permissions: None,
             justification: Some("Inspect pending changes before proceeding.".to_string()),
-        };
-        let third_request = GuardianApprovalRequest::Shell {
+        });
+        let third_request = ApprovalRequest::Command(CommandApprovalRequest::Shell {
             id: "shell-guardian-3".to_string(),
             command: vec!["git".to_string(), "push".to_string()],
             hook_command: "git push".to_string(),
@@ -2048,7 +2058,7 @@ async fn guardian_parallel_reviews_fork_from_last_committed_trunk_history() -> a
             sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
             additional_permissions: None,
             justification: Some("Inspect whether pushing is safe before proceeding.".to_string()),
-        };
+        });
 
         let session_for_second = Arc::clone(&session);
         let turn_for_second = Arc::clone(&turn);

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -6,6 +6,7 @@
 #![deny(clippy::print_stdout, clippy::print_stderr)]
 
 mod apply_patch;
+mod approval_request;
 mod apps;
 mod arc_monitor;
 mod client;

--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -10,6 +10,9 @@ use codex_app_server_protocol::McpServerElicitationRequest;
 use codex_app_server_protocol::McpServerElicitationRequestParams;
 use tracing::error;
 
+use crate::approval_request::ApprovalRequest;
+use crate::approval_request::GuardianMcpAnnotations;
+use crate::approval_request::McpToolCallApprovalRequest;
 use crate::arc_monitor::ArcMonitorOutcome;
 use crate::arc_monitor::monitor_action;
 use crate::config::Config;
@@ -17,8 +20,6 @@ use crate::config::edit::ConfigEdit;
 use crate::config::edit::ConfigEditsBuilder;
 use crate::config::load_global_mcp_servers;
 use crate::connectors;
-use crate::guardian::GuardianApprovalRequest;
-use crate::guardian::GuardianMcpAnnotations;
 use crate::guardian::guardian_approval_request_to_json;
 use crate::guardian::guardian_rejection_message;
 use crate::guardian::guardian_timeout_message;
@@ -883,7 +884,7 @@ struct McpToolApprovalPromptOptions {
 
 struct McpToolApprovalElicitationRequest<'a> {
     server: &'a str,
-    approval_request: &'a GuardianApprovalRequest,
+    approval_request: &'a ApprovalRequest,
     tool_params: Option<&'a serde_json::Value>,
     tool_params_display: Option<&'a [RenderedMcpToolApprovalParam]>,
     question: RequestUserInputQuestion,
@@ -942,12 +943,12 @@ struct McpToolApprovalKey {
 
 /// Builds the user-facing MCP approval prompt from the canonical approval request.
 fn mcp_tool_approval_prompt(
-    approval_request: &GuardianApprovalRequest,
+    approval_request: &ApprovalRequest,
     question_id: String,
     prompt_options: McpToolApprovalPromptOptions,
     monitor_reason: Option<&str>,
 ) -> Option<McpToolApprovalPrompt> {
-    let GuardianApprovalRequest::McpToolCall {
+    let ApprovalRequest::McpToolCall(McpToolCallApprovalRequest {
         server,
         tool_name,
         arguments,
@@ -955,7 +956,7 @@ fn mcp_tool_approval_prompt(
         connector_name,
         tool_title,
         ..
-    } = approval_request
+    }) = approval_request
     else {
         return None;
     };
@@ -1002,11 +1003,11 @@ fn mcp_tool_approval_prompt(
 /// Converts a guardian MCP approval decision into the legacy RequestUserInput
 /// response shape used by delegated compatibility flows.
 pub(crate) fn mcp_tool_approval_compat_response(
-    approval_request: &GuardianApprovalRequest,
+    approval_request: &ApprovalRequest,
     question: &RequestUserInputQuestion,
     decision: ReviewDecision,
 ) -> Option<RequestUserInputResponse> {
-    let GuardianApprovalRequest::McpToolCall { .. } = approval_request else {
+    let ApprovalRequest::McpToolCall(..) = approval_request else {
         return None;
     };
 
@@ -1293,8 +1294,8 @@ pub(crate) fn build_mcp_tool_approval_request(
     hook_tool_name: &str,
     invocation: &McpInvocation,
     metadata: Option<&McpToolApprovalMetadata>,
-) -> GuardianApprovalRequest {
-    GuardianApprovalRequest::McpToolCall {
+) -> ApprovalRequest {
+    McpToolCallApprovalRequest {
         id: call_id.to_string(),
         server: invocation.server.clone(),
         tool_name: invocation.tool.clone(),
@@ -1313,6 +1314,7 @@ pub(crate) fn build_mcp_tool_approval_request(
                 read_only_hint: annotations.read_only_hint,
             }),
     }
+    .into()
 }
 
 async fn mcp_tool_approval_decision_from_guardian(
@@ -1588,12 +1590,12 @@ fn build_mcp_tool_approval_elicitation_request(
 }
 
 fn build_mcp_tool_approval_elicitation_meta(
-    approval_request: &GuardianApprovalRequest,
+    approval_request: &ApprovalRequest,
     tool_params: Option<&JsonValue>,
     tool_params_display: Option<&[RenderedMcpToolApprovalParam]>,
     prompt_options: McpToolApprovalPromptOptions,
 ) -> Option<JsonValue> {
-    let GuardianApprovalRequest::McpToolCall {
+    let ApprovalRequest::McpToolCall(McpToolCallApprovalRequest {
         server,
         connector_id,
         connector_name,
@@ -1601,7 +1603,7 @@ fn build_mcp_tool_approval_elicitation_meta(
         tool_title,
         tool_description,
         ..
-    } = approval_request
+    }) = approval_request
     else {
         return None;
     };

--- a/codex-rs/core/src/mcp_tool_call_tests.rs
+++ b/codex-rs/core/src/mcp_tool_call_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
+use crate::approval_request::ApprovalRequest;
+use crate::approval_request::GuardianMcpAnnotations;
 use crate::config::ConfigBuilder;
-use crate::guardian::GuardianApprovalRequest;
-use crate::guardian::GuardianMcpAnnotations;
 use crate::session::tests::make_session_and_context;
 use crate::session::tests::make_session_and_context_with_rx;
 use crate::state::ActiveTurn;
@@ -110,7 +110,7 @@ fn approval_prompt_request(
     tool_name: &str,
     arguments: Option<serde_json::Value>,
     metadata: Option<&McpToolApprovalMetadata>,
-) -> GuardianApprovalRequest {
+) -> ApprovalRequest {
     build_mcp_tool_approval_request(
         "call-1",
         tool_name,
@@ -1314,7 +1314,7 @@ fn guardian_mcp_review_request_includes_invocation_metadata() {
 
     assert_eq!(
         request,
-        GuardianApprovalRequest::McpToolCall {
+        ApprovalRequest::McpToolCall(McpToolCallApprovalRequest {
             id: "call-1".to_string(),
             server: CODEX_APPS_MCP_SERVER_NAME.to_string(),
             tool_name: "browser_navigate".to_string(),
@@ -1328,7 +1328,7 @@ fn guardian_mcp_review_request_includes_invocation_metadata() {
             tool_title: Some("Navigate".to_string()),
             tool_description: Some("Open a page".to_string()),
             annotations: None,
-        }
+        })
     );
 }
 
@@ -1356,7 +1356,7 @@ fn guardian_mcp_review_request_includes_annotations_when_present() {
 
     assert_eq!(
         request,
-        GuardianApprovalRequest::McpToolCall {
+        ApprovalRequest::McpToolCall(McpToolCallApprovalRequest {
             id: "call-1".to_string(),
             server: "custom_server".to_string(),
             tool_name: "dangerous_tool".to_string(),
@@ -1372,7 +1372,7 @@ fn guardian_mcp_review_request_includes_annotations_when_present() {
                 open_world_hint: Some(true),
                 read_only_hint: Some(false),
             }),
-        }
+        })
     );
 }
 

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -14,6 +14,9 @@ use crate::agent::Mailbox;
 use crate::agent::MailboxReceiver;
 use crate::agent::agent_status_from_event;
 use crate::agent::status::is_final;
+use crate::approval_request::ApplyPatchApprovalRequest;
+use crate::approval_request::CommandApprovalRequest;
+use crate::approval_request::RequestPermissionsApprovalRequest;
 use crate::build_available_skills;
 use crate::commit_attribution::commit_message_trailer_instruction;
 use crate::compact;
@@ -32,7 +35,6 @@ use crate::context::PersonalitySpecInstructions;
 use crate::default_skill_metadata_budget;
 use crate::environment_selection::ResolvedTurnEnvironments;
 use crate::exec_policy::ExecPolicyManager;
-use crate::guardian::GuardianApprovalRequest;
 use crate::installation_id::resolve_installation_id;
 use crate::parse_turn_item;
 use crate::path_utils::normalize_for_native_workdir;
@@ -1845,13 +1847,12 @@ impl Session {
     pub async fn request_command_approval_for_request(
         &self,
         turn_context: &TurnContext,
-        approval_request: GuardianApprovalRequest,
+        approval_request: CommandApprovalRequest,
         approval_id: Option<String>,
         reason: Option<String>,
         network_approval_context: Option<NetworkApprovalContext>,
         proposed_execpolicy_amendment: Option<ExecPolicyAmendment>,
         available_decisions: Option<Vec<ReviewDecision>>,
-        fallback_cwd: Option<AbsolutePathBuf>,
     ) -> ReviewDecision {
         let proposed_network_policy_amendments = network_approval_context.as_ref().map(|context| {
             vec![
@@ -1865,7 +1866,7 @@ impl Session {
                 },
             ]
         });
-        let Some(event) = approval_request.exec_approval_event(
+        let event = approval_request.exec_approval_event(
             turn_context.sub_id.clone(),
             approval_id,
             reason,
@@ -1873,10 +1874,7 @@ impl Session {
             proposed_execpolicy_amendment,
             proposed_network_policy_amendments,
             available_decisions,
-            fallback_cwd,
-        ) else {
-            unreachable!("request_command_approval_for_request requires command-like approvals");
-        };
+        );
         self.request_exec_approval_event(turn_context, event).await
     }
 
@@ -1930,17 +1928,15 @@ impl Session {
     pub async fn request_patch_approval_for_request(
         &self,
         turn_context: &TurnContext,
-        approval_request: GuardianApprovalRequest,
+        approval_request: ApplyPatchApprovalRequest,
         reason: Option<String>,
         grant_root: Option<PathBuf>,
     ) -> oneshot::Receiver<ReviewDecision> {
-        let Some(event) = approval_request.apply_patch_approval_event(
+        let event = approval_request.apply_patch_approval_event(
             turn_context.sub_id.clone(),
             reason,
             grant_root,
-        ) else {
-            unreachable!("request_patch_approval_for_request requires apply_patch approvals");
-        };
+        );
         self.request_apply_patch_approval_event(turn_context, event)
             .await
     }
@@ -2029,7 +2025,7 @@ impl Session {
         }
 
         let requested_permissions = args.permissions;
-        let approval_request = GuardianApprovalRequest::RequestPermissions {
+        let approval_request = RequestPermissionsApprovalRequest {
             id: call_id.clone(),
             turn_id: turn_context.sub_id.clone(),
             reason: args.reason.clone(),
@@ -2049,7 +2045,7 @@ impl Session {
                 session,
                 turn,
                 review_id,
-                approval_request.clone(),
+                approval_request.clone().into(),
                 /*retry_reason*/ None,
                 codex_analytics::GuardianApprovalRequestSource::MainTurn,
                 cancellation_token.clone(),
@@ -2129,9 +2125,7 @@ impl Session {
             warn!("Overwriting existing pending request_permissions for call_id: {call_id}");
         }
 
-        let Some(event) = approval_request.request_permissions_event() else {
-            unreachable!("request_permissions event projection must exist");
-        };
+        let event = approval_request.request_permissions_event();
         self.send_event(turn_context.as_ref(), EventMsg::RequestPermissions(event))
             .await;
         tokio::select! {

--- a/codex-rs/core/src/tools/network_approval.rs
+++ b/codex-rs/core/src/tools/network_approval.rs
@@ -1,5 +1,5 @@
-use crate::guardian::GuardianApprovalRequest;
-use crate::guardian::GuardianNetworkAccessTrigger;
+use crate::approval_request::CommandApprovalRequest;
+use crate::approval_request::GuardianNetworkAccessTrigger;
 use crate::guardian::guardian_rejection_message;
 use crate::guardian::guardian_timeout_message;
 use crate::guardian::new_guardian_review_id;
@@ -463,13 +463,14 @@ impl NetworkApprovalService {
             || format!("network-access {target}"),
             |call| call.command.clone(),
         );
-        let approval_request = GuardianApprovalRequest::NetworkAccess {
+        let approval_request = CommandApprovalRequest::NetworkAccess {
             id: guardian_approval_id.clone(),
             turn_id: owner_call
                 .as_ref()
                 .map_or_else(|| turn_context.sub_id.clone(), |call| call.turn_id.clone()),
             target: target.clone(),
             hook_command: command,
+            cwd: turn_context.cwd.clone(),
             host: request.host.clone(),
             protocol,
             port: key.port,
@@ -477,10 +478,7 @@ impl NetworkApprovalService {
         };
         if let Some(permission_request_decision) =
             run_permission_request_hooks(&session, &turn_context, &guardian_approval_id, {
-                let Some(payload) = approval_request.permission_request_payload() else {
-                    unreachable!("network approvals always project a permission request payload");
-                };
-                payload
+                approval_request.permission_request_payload()
             })
             .await
         {
@@ -515,7 +513,7 @@ impl NetworkApprovalService {
                 &session,
                 &turn_context,
                 review_id,
-                approval_request,
+                approval_request.clone().into(),
                 Some(policy_denial_message.clone()),
             )
             .await
@@ -530,7 +528,6 @@ impl NetworkApprovalService {
                     /*network_approval_context*/ None,
                     /*proposed_execpolicy_amendment*/ None,
                     available_decisions,
-                    Some(turn_context.cwd.clone()),
                 )
                 .await
         };

--- a/codex-rs/core/src/tools/orchestrator.rs
+++ b/codex-rs/core/src/tools/orchestrator.rs
@@ -398,7 +398,7 @@ impl ToolOrchestrator {
         if evaluate_permission_request_hooks
             && let Some(permission_request) = approval_request
                 .as_ref()
-                .and_then(crate::guardian::GuardianApprovalRequest::permission_request_payload)
+                .and_then(crate::approval_request::ApprovalRequest::permission_request_payload)
         {
             match run_permission_request_hooks(
                 approval_ctx.session,

--- a/codex-rs/core/src/tools/runtimes/apply_patch.rs
+++ b/codex-rs/core/src/tools/runtimes/apply_patch.rs
@@ -3,8 +3,9 @@
 //! Assumes `apply_patch` verification/approval happened upstream. Reuses the
 //! selected turn environment filesystem for both local and remote turns, with
 //! sandboxing enforced by the explicit filesystem sandbox context.
+use crate::approval_request::ApplyPatchApprovalRequest;
+use crate::approval_request::ApprovalRequest;
 use crate::exec::is_likely_sandbox_denied;
-use crate::guardian::GuardianApprovalRequest;
 use crate::guardian::review_approval_request;
 use crate::tools::sandboxing::Approvable;
 use crate::tools::sandboxing::ApprovalCtx;
@@ -51,8 +52,8 @@ impl ApplyPatchRuntime {
         Self
     }
 
-    fn build_approval_request(req: &ApplyPatchRequest, call_id: &str) -> GuardianApprovalRequest {
-        GuardianApprovalRequest::ApplyPatch {
+    fn build_approval_request(req: &ApplyPatchRequest, call_id: &str) -> ApplyPatchApprovalRequest {
+        ApplyPatchApprovalRequest {
             id: call_id.to_string(),
             cwd: req.action.cwd.clone(),
             files: req.file_paths.clone(),
@@ -114,7 +115,7 @@ impl Approvable<ApplyPatchRequest> for ApplyPatchRuntime {
                     session,
                     turn,
                     review_id,
-                    approval_request.clone(),
+                    approval_request.clone().into(),
                     retry_reason,
                 )
                 .await;
@@ -179,8 +180,8 @@ impl Approvable<ApplyPatchRequest> for ApplyPatchRuntime {
         &self,
         req: &ApplyPatchRequest,
         ctx: &ApprovalCtx<'_>,
-    ) -> Option<GuardianApprovalRequest> {
-        Some(Self::build_approval_request(req, ctx.call_id))
+    ) -> Option<ApprovalRequest> {
+        Some(Self::build_approval_request(req, ctx.call_id).into())
     }
 }
 

--- a/codex-rs/core/src/tools/runtimes/apply_patch_tests.rs
+++ b/codex-rs/core/src/tools/runtimes/apply_patch_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::guardian::GuardianApprovalRequest;
+use crate::approval_request::ApplyPatchApprovalRequest;
 use crate::tools::sandboxing::SandboxAttempt;
 use codex_protocol::config_types::WindowsSandboxLevel;
 use codex_protocol::models::AdditionalPermissionProfile;
@@ -70,7 +70,7 @@ fn guardian_review_request_includes_patch_context() {
 
     assert_eq!(
         guardian_request,
-        GuardianApprovalRequest::ApplyPatch {
+        ApplyPatchApprovalRequest {
             id: "call-1".to_string(),
             cwd: expected_cwd,
             files: request.file_paths,
@@ -99,9 +99,8 @@ fn permission_request_payload_uses_apply_patch_hook_name_and_aliases() {
         permissions_preapproved: false,
     };
 
-    let payload = ApplyPatchRuntime::build_approval_request(&req, "call-1")
-        .permission_request_payload()
-        .expect("permission request payload");
+    let payload =
+        ApplyPatchRuntime::build_approval_request(&req, "call-1").permission_request_payload();
 
     assert_eq!(payload.tool_name.name(), "apply_patch");
     assert_eq!(

--- a/codex-rs/core/src/tools/runtimes/shell.rs
+++ b/codex-rs/core/src/tools/runtimes/shell.rs
@@ -8,10 +8,11 @@ builds sandbox transform inputs, and runs them under the current SandboxAttempt.
 pub(crate) mod unix_escalation;
 pub(crate) mod zsh_fork_backend;
 
+use crate::approval_request::ApprovalRequest;
+use crate::approval_request::CommandApprovalRequest;
+use crate::approval_request::GuardianNetworkAccessTrigger;
 use crate::command_canonicalization::canonicalize_command_for_approval;
 use crate::exec::ExecCapturePolicy;
-use crate::guardian::GuardianApprovalRequest;
-use crate::guardian::GuardianNetworkAccessTrigger;
 use crate::guardian::review_approval_request;
 use crate::sandboxing::ExecOptions;
 use crate::sandboxing::SandboxPermissions;
@@ -120,8 +121,8 @@ impl ShellRuntime {
         })
     }
 
-    fn build_approval_request(req: &ShellRequest, call_id: String) -> GuardianApprovalRequest {
-        GuardianApprovalRequest::Shell {
+    fn build_approval_request(req: &ShellRequest, call_id: String) -> CommandApprovalRequest {
+        CommandApprovalRequest::Shell {
             id: call_id,
             command: req.command.clone(),
             hook_command: req.hook_command.clone(),
@@ -172,7 +173,7 @@ impl Approvable<ShellRequest> for ShellRuntime {
                     session,
                     turn,
                     review_id,
-                    approval_request.clone(),
+                    approval_request.clone().into(),
                     retry_reason,
                 )
                 .await;
@@ -190,7 +191,6 @@ impl Approvable<ShellRequest> for ShellRuntime {
                             .proposed_execpolicy_amendment()
                             .cloned(),
                         available_decisions,
-                        /*fallback_cwd*/ None,
                     )
                     .await
             })
@@ -206,8 +206,8 @@ impl Approvable<ShellRequest> for ShellRuntime {
         &self,
         req: &ShellRequest,
         ctx: &ApprovalCtx<'_>,
-    ) -> Option<GuardianApprovalRequest> {
-        Some(Self::build_approval_request(req, ctx.call_id.to_string()))
+    ) -> Option<ApprovalRequest> {
+        Some(Self::build_approval_request(req, ctx.call_id.to_string()).into())
     }
 
     fn sandbox_mode_for_first_attempt(&self, req: &ShellRequest) -> SandboxOverride {

--- a/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
+++ b/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
@@ -1,9 +1,9 @@
 use super::ShellRequest;
+use crate::approval_request::CommandApprovalRequest;
 use crate::exec::ExecCapturePolicy;
 use crate::exec::ExecExpiration;
 use crate::exec::cancel_when_either;
 use crate::exec::is_likely_sandbox_denied;
-use crate::guardian::GuardianApprovalRequest;
 use crate::guardian::guardian_rejection_message;
 use crate::guardian::guardian_timeout_message;
 use crate::guardian::new_guardian_review_id;
@@ -406,7 +406,7 @@ impl CoreShellActionProvider {
             .pause_for(async move {
                 // 1) Run PermissionRequest hooks
                 let effective_approval_id = approval_id.clone().unwrap_or_else(|| call_id.clone());
-                let approval_request = GuardianApprovalRequest::Execve {
+                let approval_request = CommandApprovalRequest::Execve {
                     id: call_id.clone(),
                     source,
                     program: program.to_string_lossy().into_owned(),
@@ -414,14 +414,12 @@ impl CoreShellActionProvider {
                     cwd: workdir.clone(),
                     additional_permissions: additional_permissions.clone(),
                 };
-                match run_permission_request_hooks(&session, &turn, &effective_approval_id, {
-                    let Some(payload) = approval_request.permission_request_payload() else {
-                        unreachable!(
-                            "execve approvals always project a permission request payload"
-                        );
-                    };
-                    payload
-                })
+                match run_permission_request_hooks(
+                    &session,
+                    &turn,
+                    &effective_approval_id,
+                    approval_request.permission_request_payload(),
+                )
                 .await
                 {
                     Some(PermissionRequestDecision::Allow) => {
@@ -447,7 +445,7 @@ impl CoreShellActionProvider {
                         &session,
                         &turn,
                         review_id.clone(),
-                        approval_request,
+                        approval_request.clone().into(),
                         /*retry_reason*/ None,
                     )
                     .await;
@@ -468,7 +466,6 @@ impl CoreShellActionProvider {
                         /*network_approval_context*/ None,
                         /*proposed_execpolicy_amendment*/ None,
                         Some(vec![ReviewDecision::Approved, ReviewDecision::Abort]),
-                        /*fallback_cwd*/ None,
                     )
                     .await;
                 PromptDecision {

--- a/codex-rs/core/src/tools/runtimes/unified_exec.rs
+++ b/codex-rs/core/src/tools/runtimes/unified_exec.rs
@@ -4,11 +4,12 @@ Runtime: unified exec
 Handles approval + sandbox orchestration for unified exec requests, delegating to
 the process manager to spawn PTYs once an ExecRequest is prepared.
 */
+use crate::approval_request::ApprovalRequest;
+use crate::approval_request::CommandApprovalRequest;
+use crate::approval_request::GuardianNetworkAccessTrigger;
 use crate::command_canonicalization::canonicalize_command_for_approval;
 use crate::exec::ExecCapturePolicy;
 use crate::exec::ExecExpiration;
-use crate::guardian::GuardianApprovalRequest;
-use crate::guardian::GuardianNetworkAccessTrigger;
 use crate::guardian::review_approval_request;
 use crate::sandboxing::ExecOptions;
 use crate::sandboxing::ExecServerEnvConfig;
@@ -110,11 +111,8 @@ impl<'a> UnifiedExecRuntime<'a> {
         }
     }
 
-    fn build_approval_request(
-        req: &UnifiedExecRequest,
-        call_id: String,
-    ) -> GuardianApprovalRequest {
-        GuardianApprovalRequest::ExecCommand {
+    fn build_approval_request(req: &UnifiedExecRequest, call_id: String) -> CommandApprovalRequest {
+        CommandApprovalRequest::ExecCommand {
             id: call_id,
             command: req.command.clone(),
             hook_command: req.hook_command.clone(),
@@ -168,7 +166,7 @@ impl Approvable<UnifiedExecRequest> for UnifiedExecRuntime<'_> {
                     session,
                     turn,
                     review_id,
-                    approval_request.clone(),
+                    approval_request.clone().into(),
                     retry_reason,
                 )
                 .await;
@@ -186,7 +184,6 @@ impl Approvable<UnifiedExecRequest> for UnifiedExecRuntime<'_> {
                             .proposed_execpolicy_amendment()
                             .cloned(),
                         available_decisions,
-                        /*fallback_cwd*/ None,
                     )
                     .await
             })
@@ -205,8 +202,8 @@ impl Approvable<UnifiedExecRequest> for UnifiedExecRuntime<'_> {
         &self,
         req: &UnifiedExecRequest,
         ctx: &ApprovalCtx<'_>,
-    ) -> Option<GuardianApprovalRequest> {
-        Some(Self::build_approval_request(req, ctx.call_id.to_string()))
+    ) -> Option<ApprovalRequest> {
+        Some(Self::build_approval_request(req, ctx.call_id.to_string()).into())
     }
 
     fn sandbox_mode_for_first_attempt(&self, req: &UnifiedExecRequest) -> SandboxOverride {

--- a/codex-rs/core/src/tools/sandboxing.rs
+++ b/codex-rs/core/src/tools/sandboxing.rs
@@ -4,7 +4,7 @@
 //! `ApprovalCtx`, `Approvable`) together with the sandbox orchestration traits
 //! and helpers (`Sandboxable`, `ToolRuntime`, `SandboxAttempt`, etc.).
 
-use crate::guardian::GuardianApprovalRequest;
+use crate::approval_request::ApprovalRequest;
 use crate::sandboxing::ExecOptions;
 use crate::sandboxing::SandboxPermissions;
 use crate::session::session::Session;
@@ -312,11 +312,7 @@ pub(crate) trait Approvable<Req> {
 
     /// Return the canonical approval action for this request when the runtime
     /// participates in approval hooks and/or guardian review.
-    fn approval_request(
-        &self,
-        _req: &Req,
-        _ctx: &ApprovalCtx<'_>,
-    ) -> Option<GuardianApprovalRequest> {
+    fn approval_request(&self, _req: &Req, _ctx: &ApprovalCtx<'_>) -> Option<ApprovalRequest> {
         None
     }
 


### PR DESCRIPTION
# Why

This is a stacked follow-up to #20733. The parent PR gives approvals one canonical description that can be shared by hooks, guardian review, and human prompting. That removes duplicated request shapes, but it also leaves the user-prompt boundary accepting the full cross-surface enum even though command prompts and patch prompts only support their own families.

This PR adds the missing middle layer: keep one shared `ApprovalRequest` envelope for the cross-cutting approval pipeline, while giving each approval family its own concrete type where callers need stronger guarantees. That keeps the long-term model unified without making downstream APIs recover lost specificity with runtime-only checks.

# What

- move the canonical approval model out of `guardian/` into the neutral top-level `approval_request` module
- split the shared model into typed `CommandApprovalRequest`, `ApplyPatchApprovalRequest`, `McpToolCallApprovalRequest`, and `RequestPermissionsApprovalRequest` families under `ApprovalRequest`
- narrow the session prompt APIs so command prompting accepts `CommandApprovalRequest` and patch prompting accepts `ApplyPatchApprovalRequest`
- keep guardian review and hook dispatch on the shared `ApprovalRequest` path via explicit conversions from the typed families
- make `NetworkAccess` carry its own `cwd`, so command-family requests are self-contained before they enter the shared pipeline

# Validation

- `cargo test -p codex-core approval_request::tests`
- `cargo test -p codex-core guardian_review_request_layout_matches_model_visible_request_snapshot`
- `cargo test -p codex-core delegated_mcp_guardian_abort_returns_synthetic_decline_answer`
- `cargo test -p codex-core approval_elicitation_request_uses_message_override_and_preserves_tool_params_keys`
- `cargo test -p codex-core handle_exec_approval_uses_call_id_for_guardian_review_and_approval_id_for_reply`
- `cargo test -p codex-core handle_patch_approval_uses_tool_call_id_for_round_trip`
- `cargo test -p codex-core request_permissions_emits_event_when_granular_policy_allows_requests`

`cargo test -p codex-core` also reached the pre-existing stack overflow in `tools::handlers::multi_agents::tests::tool_handlers_cascade_close_and_resume_and_keep_explicitly_closed_subtrees_closed`.
