### PR TITLE
[mcp-apps] Persist MCP Apps specific tool call end event.

### DIFF
--- a/codex-rs/rollout/src/policy.rs
+++ b/codex-rs/rollout/src/policy.rs
@@ -115,6 +115,9 @@ fn event_msg_persistence_mode(ev: &EventMsg) -> Option<EventPersistenceMode> {
                 None
             }
         }
+        EventMsg::McpToolCallEnd(event) if event.mcp_app_resource_uri.is_some() => {
+            Some(EventPersistenceMode::Limited)
+        }
         EventMsg::Error(_)
         | EventMsg::GuardianAssessment(_)
         | EventMsg::WebSearchEnd(_)


### PR DESCRIPTION
- [x] Persist a special type of MCP tool calls for triggering MCP App, this type of mcp tool calls has 'mcpAppResourceUri` set. These events are needed so that the Codex App can correctly render the MCP App after resume.

