### PR TITLE
Add Windows metadata adapter target type

### DIFF
--- a/codex-rs/core/src/exec.rs
+++ b/codex-rs/core/src/exec.rs
@@ -95,7 +95,8 @@ pub struct ExecParams {
     pub arg0: Option<String>,
 }
 
-/// Resolved filesystem overrides for the Windows sandbox backends.
+/// Layer: Windows adapter layer. Resolved filesystem overrides for the Windows
+/// sandbox backends.
 ///
 /// The unelevated restricted-token backend only consumes extra deny-write
 /// carveouts on top of the legacy `WorkspaceWrite` allow set. The elevated
@@ -109,6 +110,25 @@ pub(crate) struct WindowsSandboxFilesystemOverrides {
     pub(crate) read_roots_include_platform_defaults: bool,
     pub(crate) write_roots_override: Option<Vec<PathBuf>>,
     pub(crate) additional_deny_write_paths: Vec<AbsolutePathBuf>,
+}
+
+/// Layer: Windows adapter layer. This is the Windows projection of
+/// `WritableRoot::protected_metadata_names` from `FileSystemSandboxPolicy`.
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct WindowsProtectedMetadataTarget {
+    pub(crate) path: AbsolutePathBuf,
+    pub(crate) mode: WindowsProtectedMetadataMode,
+}
+
+/// Layer: Windows adapter layer. The enforcement layer needs to know why a
+/// protected metadata path is absent instead of treating every missing path as
+/// an existing filesystem object.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum WindowsProtectedMetadataMode {
+    ExistingDeny,
+    MissingCreationMonitor,
 }
 
 fn windows_sandbox_uses_elevated_backend(


### PR DESCRIPTION
## Summary

1. Adds the Windows adapter target type for protected metadata names.
2. Keeps policy planning and execution wiring out of this slice.

## Why

1. This PR establishes the adapter layer shape before behavior is wired.
2. Later PRs need one typed object to carry `.git`, `.codex`, and `.agents` decisions from filesystem policy into Windows sandbox setup and enforcement.

## Stack Relation

This PR is part 1 of 21 in the Windows protected metadata stack.

1. [PR 20889](https://github.com/openai/codex/pull/20889) Add Windows metadata adapter target type
2. [PR 20890](https://github.com/openai/codex/pull/20890) Add Windows metadata setup target type
3. [PR 20891](https://github.com/openai/codex/pull/20891) Add Windows metadata enforcement guard
4. [PR 21030](https://github.com/openai/codex/pull/21030) Plan Windows metadata targets from filesystem policy
5. [PR 21031](https://github.com/openai/codex/pull/21031) Thread Windows metadata targets through setup request
6. [PR 21032](https://github.com/openai/codex/pull/21032) Pass Windows metadata targets to direct exec
7. [PR 21033](https://github.com/openai/codex/pull/21033) Thread Windows metadata targets through sessions
8. [PR 21035](https://github.com/openai/codex/pull/21035) Enforce Windows protected metadata targets
9. [PR 21036](https://github.com/openai/codex/pull/21036) Deny Windows protected metadata symlink targets
10. [PR 21037](https://github.com/openai/codex/pull/21037) Use Windows metadata targets in debug sandbox
11. [PR 21038](https://github.com/openai/codex/pull/21038) Allow Windows sandbox Git signal pipes
12. [PR 21039](https://github.com/openai/codex/pull/21039) Add Windows legacy Git read root helpers
13. [PR 21040](https://github.com/openai/codex/pull/21040) Grant Windows legacy Git read roots
14. [PR 21041](https://github.com/openai/codex/pull/21041) Inject Git safe directory for Windows legacy sandbox
15. [PR 21042](https://github.com/openai/codex/pull/21042) Test Windows runtime metadata target preparation
16. [PR 21043](https://github.com/openai/codex/pull/21043) Document Windows metadata request boundary
17. [PR 21172](https://github.com/openai/codex/pull/21172) Add Windows missing metadata monitor runtime
18. [PR 21173](https://github.com/openai/codex/pull/21173) Wire Windows metadata monitor through sandbox exits
19. [PR 21174](https://github.com/openai/codex/pull/21174) Add Windows missing metadata deny sentinel
20. [PR 21175](https://github.com/openai/codex/pull/21175) Wire missing Windows metadata to deny sentinel
21. [PR 21184](https://github.com/openai/codex/pull/21184) Use direct deny ACLs for Windows metadata sentinels

## Validation

1. Stack head local format and Rust tests passed on `95ef124d6194bd2126c11928cb3973214f9ac63a`.
2. Azure Windows VM 56 case validation is running on `95ef124d6194bd2126c11928cb3973214f9ac63a`.