### PR TITLE
Add Windows metadata enforcement guard

### DIFF
--- a/codex-rs/windows-sandbox-rs/src/lib.rs
+++ b/codex-rs/windows-sandbox-rs/src/lib.rs
@@ -26,6 +26,7 @@ windows_modules!(
     path_normalization,
     policy,
     process,
+    protected_metadata,
     token,
     wfp,
     wfp_setup,

--- a/codex-rs/windows-sandbox-rs/src/protected_metadata.rs
+++ b/codex-rs/windows-sandbox-rs/src/protected_metadata.rs
@@ -1,0 +1,174 @@
+#![allow(dead_code)]
+
+use crate::setup::ProtectedMetadataMode;
+use crate::setup::ProtectedMetadataTarget;
+use anyhow::Context;
+use anyhow::Result;
+use std::fs::Metadata;
+use std::io;
+use std::os::windows::fs::FileTypeExt;
+use std::os::windows::fs::MetadataExt;
+use std::path::Path;
+use std::path::PathBuf;
+use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_REPARSE_POINT;
+
+/// Layer: Windows enforcement layer. Existing metadata objects can be protected
+/// with ACLs; missing names are monitored and removed if the sandbox creates
+/// them.
+#[derive(Debug)]
+pub(crate) struct ProtectedMetadataGuard {
+    deny_paths: Vec<PathBuf>,
+    monitored_paths: Vec<PathBuf>,
+}
+
+impl ProtectedMetadataGuard {
+    pub(crate) fn deny_paths(&self) -> impl Iterator<Item = &PathBuf> {
+        self.deny_paths.iter()
+    }
+
+    pub(crate) fn cleanup_created_monitored_paths(&self) -> Result<Vec<PathBuf>> {
+        let mut removed = Vec::new();
+        for path in &self.monitored_paths {
+            let Some(existing_path) = existing_metadata_path(path)? else {
+                continue;
+            };
+            remove_metadata_path(&existing_path)
+                .with_context(|| format!("failed to remove protected metadata {}", path.display()))?;
+            removed.push(existing_path);
+        }
+        Ok(removed)
+    }
+}
+
+pub(crate) fn prepare_protected_metadata_targets(
+    targets: &[ProtectedMetadataTarget],
+) -> ProtectedMetadataGuard {
+    let mut deny_paths = Vec::new();
+    let mut monitored_paths = Vec::new();
+    for target in targets {
+        match target.mode {
+            ProtectedMetadataMode::ExistingDeny => {
+                deny_paths.extend(protected_metadata_existing_deny_paths(&target.path));
+            }
+            ProtectedMetadataMode::MissingCreationMonitor => {
+                monitored_paths.push(target.path.clone());
+            }
+        }
+    }
+    ProtectedMetadataGuard {
+        deny_paths,
+        monitored_paths,
+    }
+}
+
+pub fn protected_metadata_existing_deny_paths(path: &Path) -> Vec<PathBuf> {
+    if std::fs::symlink_metadata(path).is_ok() {
+        vec![path.to_path_buf()]
+    } else {
+        Vec::new()
+    }
+}
+
+fn existing_metadata_path(path: &Path) -> Result<Option<PathBuf>> {
+    match std::fs::symlink_metadata(path) {
+        Ok(_) => return Ok(Some(path.to_path_buf())),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+        Err(err) => {
+            return Err(err)
+                .with_context(|| format!("failed to inspect protected metadata {}", path.display()));
+        }
+    }
+
+    let Some(parent) = path.parent() else {
+        return Ok(None);
+    };
+    let Some(expected_name) = path.file_name().and_then(|name| name.to_str()) else {
+        return Ok(None);
+    };
+    let entries = match std::fs::read_dir(parent) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => {
+            return Err(err)
+                .with_context(|| format!("failed to scan protected metadata parent {}", parent.display()));
+        }
+    };
+
+    for entry in entries {
+        let entry = entry.with_context(|| {
+            format!(
+                "failed to read protected metadata parent entry {}",
+                parent.display()
+            )
+        })?;
+        if entry
+            .file_name()
+            .to_str()
+            .is_some_and(|name| name.eq_ignore_ascii_case(expected_name))
+        {
+            return Ok(Some(entry.path()));
+        }
+    }
+    Ok(None)
+}
+
+fn remove_metadata_path(path: &Path) -> Result<()> {
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => {
+            return Err(err)
+                .with_context(|| format!("failed to inspect protected metadata {}", path.display()));
+        }
+    };
+    let file_type = metadata.file_type();
+    if is_directory_reparse_point(&metadata) || file_type.is_symlink_dir() {
+        std::fs::remove_dir(path)
+            .with_context(|| format!("failed to remove protected metadata {}", path.display()))?;
+    } else if file_type.is_symlink_file() {
+        std::fs::remove_file(path)
+            .with_context(|| format!("failed to remove protected metadata {}", path.display()))?;
+    } else if metadata.is_dir() {
+        std::fs::remove_dir_all(path)
+            .with_context(|| format!("failed to remove protected metadata {}", path.display()))?;
+    } else {
+        std::fs::remove_file(path)
+            .with_context(|| format!("failed to remove protected metadata {}", path.display()))?;
+    }
+    Ok(())
+}
+
+fn is_directory_reparse_point(metadata: &Metadata) -> bool {
+    metadata.is_dir() && (metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT) != 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::setup::ProtectedMetadataMode;
+    use crate::setup::ProtectedMetadataTarget;
+
+    #[test]
+    fn cleanup_created_monitored_paths_removes_case_variant() {
+        let temp_dir = tempfile::TempDir::new().expect("tempdir");
+        let target = temp_dir.path().join(".git");
+        let created = temp_dir.path().join(".GIT");
+        std::fs::create_dir_all(&created).expect("create metadata");
+        let guard = prepare_protected_metadata_targets(&[ProtectedMetadataTarget {
+            path: target.clone(),
+            mode: ProtectedMetadataMode::MissingCreationMonitor,
+        }]);
+
+        let removed = guard.cleanup_created_monitored_paths().expect("cleanup");
+        assert_eq!(removed.len(), 1);
+        assert!(
+            removed[0]
+                .file_name()
+                .is_some_and(|name| name.eq_ignore_ascii_case(".git")),
+            "removed path should be a .git case variant: {}",
+            removed[0].display()
+        );
+        assert!(!target.exists());
+        assert!(!created.exists());
+    }
+}


### PR DESCRIPTION
## Summary

1. Adds the Windows protected metadata enforcement guard.
2. Keeps the guard independent from caller wiring and monitor behavior.

## Why

1. This PR creates the enforcement primitive before any execution path depends on it.
2. The stack needs a small guard object that owns setup cleanup and protected target restoration semantics instead of spreading that responsibility through sandbox launch code.

## Stack Relation

This PR is part 3 of 21 in the Windows protected metadata stack.

1. [PR 20889](https://github.com/openai/codex/pull/20889) Add Windows metadata adapter target type
2. [PR 20890](https://github.com/openai/codex/pull/20890) Add Windows metadata setup target type
3. [PR 20891](https://github.com/openai/codex/pull/20891) Add Windows metadata enforcement guard
4. [PR 21030](https://github.com/openai/codex/pull/21030) Plan Windows metadata targets from filesystem policy
5. [PR 21031](https://github.com/openai/codex/pull/21031) Thread Windows metadata targets through setup request
6. [PR 21032](https://github.com/openai/codex/pull/21032) Pass Windows metadata targets to direct exec
7. [PR 21033](https://github.com/openai/codex/pull/21033) Thread Windows metadata targets through sessions
8. [PR 21035](https://github.com/openai/codex/pull/21035) Enforce Windows protected metadata targets
9. [PR 21036](https://github.com/openai/codex/pull/21036) Deny Windows protected metadata symlink targets
10. [PR 21037](https://github.com/openai/codex/pull/21037) Use Windows metadata targets in debug sandbox
11. [PR 21038](https://github.com/openai/codex/pull/21038) Allow Windows sandbox Git signal pipes
12. [PR 21039](https://github.com/openai/codex/pull/21039) Add Windows legacy Git read root helpers
13. [PR 21040](https://github.com/openai/codex/pull/21040) Grant Windows legacy Git read roots
14. [PR 21041](https://github.com/openai/codex/pull/21041) Inject Git safe directory for Windows legacy sandbox
15. [PR 21042](https://github.com/openai/codex/pull/21042) Test Windows runtime metadata target preparation
16. [PR 21043](https://github.com/openai/codex/pull/21043) Document Windows metadata request boundary
17. [PR 21172](https://github.com/openai/codex/pull/21172) Add Windows missing metadata monitor runtime
18. [PR 21173](https://github.com/openai/codex/pull/21173) Wire Windows metadata monitor through sandbox exits
19. [PR 21174](https://github.com/openai/codex/pull/21174) Add Windows missing metadata deny sentinel
20. [PR 21175](https://github.com/openai/codex/pull/21175) Wire missing Windows metadata to deny sentinel
21. [PR 21184](https://github.com/openai/codex/pull/21184) Use direct deny ACLs for Windows metadata sentinels

## Validation

1. Stack head local format and Rust tests passed on `95ef124d6194bd2126c11928cb3973214f9ac63a`.
2. Azure Windows VM 56 case validation is running on `95ef124d6194bd2126c11928cb3973214f9ac63a`.