### PR TITLE
[codex] Add issue labeler area labels

### DIFF
--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -44,7 +44,7 @@ jobs:
             6. iOS — Issues with the Codex iOS app.
 
             - Additionally add zero or more of the following labels that are relevant to the issue content. Prefer a small set of precise labels over many broad ones.
-            - For agent-area issues, prefer the most specific applicable label. Use "agent" only as a fallback for agent-related issues that do not fit a more specific agent-area label. Prefer "app-server" over "session" or "config" when the issue is about app-server protocol, API, RPC, schema, launch, or bridge behavior.
+            - For agent-area issues, prefer the most specific applicable label. Use "agent" only as a fallback for agent-related issues that do not fit a more specific agent-area label. Prefer "app-server" over "session" or "config" when the issue is about app-server protocol, API, RPC, schema, launch, or bridge behavior. Use "memory" for agentic memory storage/retrieval and "performance" for high process memory utilization or memory leaks.
             1. windows-os — Bugs or friction specific to Windows environments (always when PowerShell is mentioned, path handling, copy/paste, OS-specific auth or tooling failures).
             2. mcp — Topics involving Model Context Protocol servers/clients.
             3. mcp-server — Problems related to the codex mcp-server command, where codex runs as an MCP server.
@@ -68,7 +68,15 @@ jobs:
             21. session - Issues involving session or thread management, including resume, fork, archive, rename/title, thread history, rollout persistence, compaction, checkpoints, retention, and cross-session state.
             22. config - Issues involving config.toml, config keys, config key merging, config updates, profiles, hooks config, project config, agent role TOMLs, instruction/personality config, and config schema behavior.
             23. plan - Issues involving plan mode, planning workflows, or plan-specific tools/behavior.
-            24. agent - Fallback only for core agent loop or agent-related issues that do not fit app-server, connectivity, subagent, session, config, or plan.
+            24. computer-use - Issues involving agentic computer use or SkyComputerUseService.
+            25. browser - Issues involving agentic browser use, IAB, or the built-in browser within the Codex app.
+            26. memory - Issues involving agentic memory storage and retrieval.
+            27. imagen - Issues involving image generation.
+            28. remote - Issues involving remote access, remote control, or SSH.
+            29. performance - Issues involving slow, laggy performance, high memory utilization, or memory leaks.
+            30. automations - Issues involving scheduled automation tasks or heartbeats.
+            31. pets - Issues involving pets avatars and animations.
+            32. agent - Fallback only for core agent loop or agent-related issues that do not fit app-server, connectivity, subagent, session, config, plan, computer-use, browser, memory, imagen, remote, performance, automations, or pets.
 
             Issue number: ${{ github.event.issue.number }}
 


### PR DESCRIPTION
## Why

The automated issue labeler needs more precise area labels for newly opened GitHub issues so triage can distinguish new Codex app and agent feature surfaces without falling back to broad labels.

## What Changed

- Added labeler prompt entries for `computer-use`, `browser`, `memory`, `imagen`, `remote`, `performance`, `automations`, and `pets` in `.github/workflows/issue-labeler.yml`.
- Updated the agent-area guidance so `memory` is used for agentic memory storage/retrieval and `performance` is used for slow behavior, high memory utilization, and leaks.
- Expanded the fallback `agent` guidance so Codex prefers the new specific labels when applicable.

## Verification

- Parsed `.github/workflows/issue-labeler.yml` with `yq e '.'`.
- Ran `git diff --check` for the workflow change.