### PR TITLE
[codex] Ignore stale background rate-limit refreshes

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -504,6 +504,10 @@ pub(crate) struct App {
     // Serialize hook enablement writes per hook so stale completions cannot
     // persist an older toggle after a newer one.
     pending_hook_enabled_writes: HashMap<String, Option<bool>>,
+    // Background rate-limit reads can complete out of order. Track request
+    // generations so stale snapshots never overwrite newer account state.
+    next_rate_limit_refresh_generation: u64,
+    latest_applied_rate_limit_refresh_generation: Option<u64>,
 }
 
 fn active_turn_not_steerable_turn_error(error: &TypedRequestError) -> Option<AppServerTurnError> {
@@ -887,6 +891,8 @@ See the Codex keymap documentation for supported actions and examples."
             pending_app_server_requests: PendingAppServerRequests::default(),
             pending_plugin_enabled_writes: HashMap::new(),
             pending_hook_enabled_writes: HashMap::new(),
+            next_rate_limit_refresh_generation: 0,
+            latest_applied_rate_limit_refresh_generation: None,
         };
         if let Some(started) = initial_started_thread {
             app.enqueue_primary_thread_session(started.session, started.turns)

--- a/codex-rs/tui/src/app/background_requests.rs
+++ b/codex-rs/tui/src/app/background_requests.rs
@@ -40,13 +40,20 @@ impl App {
         app_server: &AppServerSession,
         origin: RateLimitRefreshOrigin,
     ) {
+        let refresh_generation = self.next_rate_limit_refresh_generation;
+        self.next_rate_limit_refresh_generation =
+            self.next_rate_limit_refresh_generation.saturating_add(1);
         let request_handle = app_server.request_handle();
         let app_event_tx = self.app_event_tx.clone();
         tokio::spawn(async move {
             let result = fetch_account_rate_limits(request_handle)
                 .await
                 .map_err(|err| err.to_string());
-            app_event_tx.send(AppEvent::RateLimitsLoaded { origin, result });
+            app_event_tx.send(AppEvent::RateLimitsLoaded {
+                refresh_generation,
+                origin,
+                result,
+            });
         });
     }
 

--- a/codex-rs/tui/src/app/event_dispatch.rs
+++ b/codex-rs/tui/src/app/event_dispatch.rs
@@ -648,29 +648,15 @@ impl App {
                 self.chat_widget
                     .finish_add_credits_nudge_email_request(result);
             }
-            AppEvent::RateLimitsLoaded { origin, result } => match result {
-                Ok(snapshots) => {
-                    for snapshot in snapshots {
-                        self.chat_widget.on_rate_limit_snapshot(Some(snapshot));
-                    }
-                    match origin {
-                        RateLimitRefreshOrigin::StartupPrefetch => {
-                            tui.frame_requester().schedule_frame();
-                        }
-                        RateLimitRefreshOrigin::StatusCommand { request_id } => {
-                            self.chat_widget
-                                .finish_status_rate_limit_refresh(request_id);
-                        }
-                    }
+            AppEvent::RateLimitsLoaded {
+                refresh_generation,
+                origin,
+                result,
+            } => {
+                if self.handle_rate_limits_loaded(refresh_generation, origin, result) {
+                    tui.frame_requester().schedule_frame();
                 }
-                Err(err) => {
-                    tracing::warn!("account/rateLimits/read failed during TUI refresh: {err}");
-                    if let RateLimitRefreshOrigin::StatusCommand { request_id } = origin {
-                        self.chat_widget
-                            .finish_status_rate_limit_refresh(request_id);
-                    }
-                }
-            },
+            }
             AppEvent::ConnectorsLoaded { result, is_final } => {
                 self.chat_widget.on_connectors_loaded(result, is_final);
             }
@@ -1908,6 +1894,40 @@ impl App {
             }
         }
         Ok(AppRunControl::Continue)
+    }
+
+    pub(super) fn handle_rate_limits_loaded(
+        &mut self,
+        refresh_generation: u64,
+        origin: RateLimitRefreshOrigin,
+        result: std::result::Result<Vec<RateLimitSnapshot>, String>,
+    ) -> bool {
+        let mut should_schedule_frame = false;
+        match result {
+            Ok(snapshots) => {
+                let is_stale = self
+                    .latest_applied_rate_limit_refresh_generation
+                    .is_some_and(|latest_generation| latest_generation >= refresh_generation);
+                if !is_stale {
+                    self.latest_applied_rate_limit_refresh_generation = Some(refresh_generation);
+                    for snapshot in snapshots {
+                        self.chat_widget.on_rate_limit_snapshot(Some(snapshot));
+                    }
+                    should_schedule_frame =
+                        matches!(origin, RateLimitRefreshOrigin::StartupPrefetch);
+                }
+            }
+            Err(err) => {
+                tracing::warn!("account/rateLimits/read failed during TUI refresh: {err}");
+            }
+        }
+
+        if let RateLimitRefreshOrigin::StatusCommand { request_id } = origin {
+            self.chat_widget
+                .finish_status_rate_limit_refresh(request_id);
+        }
+
+        should_schedule_frame
     }
 
     async fn apply_keymap_capture(

--- a/codex-rs/tui/src/app/test_support.rs
+++ b/codex-rs/tui/src/app/test_support.rs
@@ -60,6 +60,8 @@ pub(super) async fn make_test_app() -> App {
         pending_app_server_requests: PendingAppServerRequests::default(),
         pending_plugin_enabled_writes: HashMap::new(),
         pending_hook_enabled_writes: HashMap::new(),
+        next_rate_limit_refresh_generation: 0,
+        latest_applied_rate_limit_refresh_generation: None,
     }
 }
 

--- a/codex-rs/tui/src/app/tests.rs
+++ b/codex-rs/tui/src/app/tests.rs
@@ -122,6 +122,24 @@ async fn handle_mcp_inventory_result_clears_committed_loading_cell() {
     assert_eq!(app.transcript_cells.len(), 0);
 }
 
+#[tokio::test]
+async fn stale_rate_limit_refresh_generations_do_not_move_backward() {
+    let mut app = make_test_app().await;
+
+    app.handle_rate_limits_loaded(
+        /*refresh_generation*/ 2,
+        RateLimitRefreshOrigin::StartupPrefetch,
+        Ok(vec![]),
+    );
+    app.handle_rate_limits_loaded(
+        /*refresh_generation*/ 1,
+        RateLimitRefreshOrigin::StartupPrefetch,
+        Ok(vec![]),
+    );
+
+    assert_eq!(app.latest_applied_rate_limit_refresh_generation, Some(2));
+}
+
 #[test]
 fn startup_waiting_gate_is_only_for_fresh_or_exit_session_selection() {
     assert_eq!(
@@ -3775,6 +3793,8 @@ async fn make_test_app() -> App {
         pending_app_server_requests: PendingAppServerRequests::default(),
         pending_plugin_enabled_writes: HashMap::new(),
         pending_hook_enabled_writes: HashMap::new(),
+        next_rate_limit_refresh_generation: 0,
+        latest_applied_rate_limit_refresh_generation: None,
     }
 }
 
@@ -3836,6 +3856,8 @@ async fn make_test_app_with_channels() -> (
             pending_app_server_requests: PendingAppServerRequests::default(),
             pending_plugin_enabled_writes: HashMap::new(),
             pending_hook_enabled_writes: HashMap::new(),
+            next_rate_limit_refresh_generation: 0,
+            latest_applied_rate_limit_refresh_generation: None,
         },
         rx,
         op_rx,

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -241,6 +241,8 @@ pub(crate) enum AppEvent {
 
     /// Result of refreshing rate limits.
     RateLimitsLoaded {
+        /// Monotonic request generation assigned when the background refresh starts.
+        refresh_generation: u64,
         origin: RateLimitRefreshOrigin,
         result: Result<Vec<RateLimitSnapshot>, String>,
     },


### PR DESCRIPTION
## Summary
- assign generations to background rate-limit refreshes
- ignore out-of-order completions so older snapshots cannot overwrite newer state
