### PR TITLE
feat: add context lines to memories MCP search

### DIFF
--- a/codex-rs/memories/mcp/src/backend.rs
+++ b/codex-rs/memories/mcp/src/backend.rs
@@ -65,6 +65,7 @@ pub struct ReadMemoryResponse {
 pub struct SearchMemoriesRequest {
     pub query: String,
     pub path: Option<String>,
+    pub cursor: Option<String>,
     pub max_results: usize,
 }
 
@@ -73,6 +74,7 @@ pub struct SearchMemoriesResponse {
     pub query: String,
     pub path: Option<String>,
     pub matches: Vec<MemorySearchMatch>,
+    pub next_cursor: Option<String>,
     pub truncated: bool,
 }
 

--- a/codex-rs/memories/mcp/src/backend.rs
+++ b/codex-rs/memories/mcp/src/backend.rs
@@ -66,6 +66,7 @@ pub struct SearchMemoriesRequest {
     pub query: String,
     pub path: Option<String>,
     pub cursor: Option<String>,
+    pub context_lines: usize,
     pub max_results: usize,
 }
 
@@ -95,7 +96,8 @@ pub enum MemoryEntryType {
 pub struct MemorySearchMatch {
     pub path: String,
     pub line_number: usize,
-    pub line: String,
+    pub start_line_number: usize,
+    pub content: String,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/codex-rs/memories/mcp/src/backend.rs
+++ b/codex-rs/memories/mcp/src/backend.rs
@@ -67,6 +67,7 @@ pub struct SearchMemoriesRequest {
     pub path: Option<String>,
     pub cursor: Option<String>,
     pub context_lines: usize,
+    pub case_sensitive: bool,
     pub max_results: usize,
 }
 

--- a/codex-rs/memories/mcp/src/local.rs
+++ b/codex-rs/memories/mcp/src/local.rs
@@ -210,7 +210,15 @@ impl MemoriesBackend for LocalMemoriesBackend {
         reject_symlink(&display_relative_path(&self.root, &start), &metadata)?;
 
         let mut matches = Vec::new();
-        search_entries(&self.root, &start, &metadata, query, &mut matches).await?;
+        search_entries(
+            &self.root,
+            &start,
+            &metadata,
+            query,
+            request.context_lines,
+            &mut matches,
+        )
+        .await?;
         matches.sort_by(|left, right| {
             left.path
                 .cmp(&right.path)
@@ -240,10 +248,11 @@ async fn search_entries(
     current: &Path,
     current_metadata: &std::fs::Metadata,
     query: &str,
+    context_lines: usize,
     matches: &mut Vec<MemorySearchMatch>,
 ) -> Result<(), MemoriesBackendError> {
     if current_metadata.is_file() {
-        search_file(root, current, query, matches).await?;
+        search_file(root, current, query, context_lines, matches).await?;
         return Ok(());
     }
     if !current_metadata.is_dir() {
@@ -262,7 +271,7 @@ async fn search_entries(
             if metadata.is_dir() {
                 pending.push(path);
             } else if metadata.is_file() {
-                search_file(root, &path, query, matches).await?;
+                search_file(root, &path, query, context_lines, matches).await?;
             }
         }
     }
@@ -274,6 +283,7 @@ async fn search_file(
     root: &Path,
     path: &Path,
     query: &str,
+    context_lines: usize,
     matches: &mut Vec<MemorySearchMatch>,
 ) -> Result<(), MemoriesBackendError> {
     let content = match tokio::fs::read_to_string(path).await {
@@ -281,12 +291,19 @@ async fn search_file(
         Err(err) if err.kind() == std::io::ErrorKind::InvalidData => return Ok(()),
         Err(err) => return Err(err.into()),
     };
-    for (idx, line) in content.lines().enumerate() {
+    let lines = content.lines().collect::<Vec<_>>();
+    for (idx, line) in lines.iter().enumerate() {
         if line.contains(query) {
+            let start_index = idx.saturating_sub(context_lines);
+            let end_index = idx
+                .saturating_add(context_lines)
+                .saturating_add(1)
+                .min(lines.len());
             matches.push(MemorySearchMatch {
                 path: display_relative_path(root, path),
                 line_number: idx + 1,
-                line: line.to_string(),
+                start_line_number: start_index + 1,
+                content: lines[start_index..end_index].join("\n"),
             });
         }
     }

--- a/codex-rs/memories/mcp/src/local.rs
+++ b/codex-rs/memories/mcp/src/local.rs
@@ -192,18 +192,44 @@ impl MemoriesBackend for LocalMemoriesBackend {
 
         let max_results = request.max_results.min(MAX_SEARCH_RESULTS);
         let start = self.resolve_scoped_path(request.path.as_deref())?;
+        let start_index = match request.cursor.as_deref() {
+            Some(cursor) => cursor.parse::<usize>().map_err(|_| {
+                MemoriesBackendError::invalid_cursor(cursor, "must be a non-negative integer")
+            })?,
+            None => 0,
+        };
+        let Some(metadata) = Self::metadata_or_none(&start).await? else {
+            return Ok(SearchMemoriesResponse {
+                query: request.query,
+                path: request.path,
+                matches: Vec::new(),
+                next_cursor: None,
+                truncated: false,
+            });
+        };
+        reject_symlink(&display_relative_path(&self.root, &start), &metadata)?;
+
         let mut matches = Vec::new();
-        let truncated =
-            search_entries(&self.root, &start, query, &mut matches, max_results).await?;
+        search_entries(&self.root, &start, &metadata, query, &mut matches).await?;
         matches.sort_by(|left, right| {
             left.path
                 .cmp(&right.path)
                 .then(left.line_number.cmp(&right.line_number))
         });
+        if start_index > matches.len() {
+            return Err(MemoriesBackendError::invalid_cursor(
+                start_index.to_string(),
+                "exceeds result count",
+            ));
+        }
+        let end_index = start_index.saturating_add(max_results).min(matches.len());
+        let next_cursor = (end_index < matches.len()).then(|| end_index.to_string());
+        let truncated = next_cursor.is_some();
         Ok(SearchMemoriesResponse {
             query: request.query,
             path: request.path,
-            matches,
+            matches: matches.drain(start_index..end_index).collect(),
+            next_cursor,
             truncated,
         })
     }
@@ -212,30 +238,21 @@ impl MemoriesBackend for LocalMemoriesBackend {
 async fn search_entries(
     root: &Path,
     current: &Path,
+    current_metadata: &std::fs::Metadata,
     query: &str,
     matches: &mut Vec<MemorySearchMatch>,
-    max_results: usize,
-) -> Result<bool, MemoriesBackendError> {
-    if max_results == 0 {
-        return Ok(false);
+ ) -> Result<(), MemoriesBackendError> {
+    if current_metadata.is_file() {
+        search_file(root, current, query, matches).await?;
+        return Ok(());
     }
-    let Some(metadata) = LocalMemoriesBackend::metadata_or_none(current).await? else {
-        return Ok(false);
-    };
-    reject_symlink(&display_relative_path(root, current), &metadata)?;
-    if metadata.is_file() {
-        return search_file(root, current, query, matches, max_results).await;
-    }
-    if !metadata.is_dir() {
-        return Ok(false);
+    if !current_metadata.is_dir() {
+        return Ok(());
     }
 
     let mut pending = vec![current.to_path_buf()];
     while let Some(dir_path) = pending.pop() {
         for path in read_sorted_dir_paths(&dir_path).await? {
-            if matches.len() >= max_results {
-                return Ok(true);
-            }
             let Some(metadata) = LocalMemoriesBackend::metadata_or_none(&path).await? else {
                 continue;
             };
@@ -244,15 +261,13 @@ async fn search_entries(
             }
             if metadata.is_dir() {
                 pending.push(path);
-            } else if metadata.is_file()
-                && search_file(root, &path, query, matches, max_results).await?
-            {
-                return Ok(true);
+            } else if metadata.is_file() {
+                search_file(root, &path, query, matches).await?;
             }
         }
     }
 
-    Ok(false)
+    Ok(())
 }
 
 async fn search_file(
@@ -260,17 +275,13 @@ async fn search_file(
     path: &Path,
     query: &str,
     matches: &mut Vec<MemorySearchMatch>,
-    max_results: usize,
-) -> Result<bool, MemoriesBackendError> {
+) -> Result<(), MemoriesBackendError> {
     let content = match tokio::fs::read_to_string(path).await {
         Ok(content) => content,
-        Err(err) if err.kind() == std::io::ErrorKind::InvalidData => return Ok(false),
+        Err(err) if err.kind() == std::io::ErrorKind::InvalidData => return Ok(()),
         Err(err) => return Err(err.into()),
     };
     for (idx, line) in content.lines().enumerate() {
-        if matches.len() >= max_results {
-            return Ok(true);
-        }
         if line.contains(query) {
             matches.push(MemorySearchMatch {
                 path: display_relative_path(root, path),
@@ -279,7 +290,7 @@ async fn search_file(
             });
         }
     }
-    Ok(false)
+    Ok(())
 }
 
 async fn read_sorted_dir_paths(dir_path: &Path) -> Result<Vec<PathBuf>, MemoriesBackendError> {

--- a/codex-rs/memories/mcp/src/local.rs
+++ b/codex-rs/memories/mcp/src/local.rs
@@ -216,6 +216,7 @@ impl MemoriesBackend for LocalMemoriesBackend {
             &metadata,
             query,
             request.context_lines,
+            request.case_sensitive,
             &mut matches,
         )
         .await?;
@@ -249,10 +250,11 @@ async fn search_entries(
     current_metadata: &std::fs::Metadata,
     query: &str,
     context_lines: usize,
+    case_sensitive: bool,
     matches: &mut Vec<MemorySearchMatch>,
 ) -> Result<(), MemoriesBackendError> {
     if current_metadata.is_file() {
-        search_file(root, current, query, context_lines, matches).await?;
+        search_file(root, current, query, context_lines, case_sensitive, matches).await?;
         return Ok(());
     }
     if !current_metadata.is_dir() {
@@ -271,7 +273,7 @@ async fn search_entries(
             if metadata.is_dir() {
                 pending.push(path);
             } else if metadata.is_file() {
-                search_file(root, &path, query, context_lines, matches).await?;
+                search_file(root, &path, query, context_lines, case_sensitive, matches).await?;
             }
         }
     }
@@ -284,6 +286,7 @@ async fn search_file(
     path: &Path,
     query: &str,
     context_lines: usize,
+    case_sensitive: bool,
     matches: &mut Vec<MemorySearchMatch>,
 ) -> Result<(), MemoriesBackendError> {
     let content = match tokio::fs::read_to_string(path).await {
@@ -292,8 +295,13 @@ async fn search_file(
         Err(err) => return Err(err.into()),
     };
     let lines = content.lines().collect::<Vec<_>>();
+    let normalized_query = (!case_sensitive).then(|| query.to_lowercase());
     for (idx, line) in lines.iter().enumerate() {
-        if line.contains(query) {
+        let is_match = match normalized_query.as_deref() {
+            Some(query) => line.to_lowercase().contains(query),
+            None => line.contains(query),
+        };
+        if is_match {
             let start_index = idx.saturating_sub(context_lines);
             let end_index = idx
                 .saturating_add(context_lines)

--- a/codex-rs/memories/mcp/src/local.rs
+++ b/codex-rs/memories/mcp/src/local.rs
@@ -241,7 +241,7 @@ async fn search_entries(
     current_metadata: &std::fs::Metadata,
     query: &str,
     matches: &mut Vec<MemorySearchMatch>,
- ) -> Result<(), MemoriesBackendError> {
+) -> Result<(), MemoriesBackendError> {
     if current_metadata.is_file() {
         search_file(root, current, query, matches).await?;
         return Ok(());

--- a/codex-rs/memories/mcp/src/local_tests.rs
+++ b/codex-rs/memories/mcp/src/local_tests.rs
@@ -384,6 +384,7 @@ async fn search_supports_directory_and_file_scopes() {
         .search(SearchMemoriesRequest {
             query: "needle".to_string(),
             path: None,
+            cursor: None,
             max_results: DEFAULT_SEARCH_MAX_RESULTS,
         })
         .await
@@ -396,17 +397,99 @@ async fn search_supports_directory_and_file_scopes() {
             .collect::<Vec<_>>(),
         vec![("MEMORY.md", 2), ("rollout_summaries/a.jsonl", 1)]
     );
+    assert_eq!(response.next_cursor, None);
+    assert_eq!(response.truncated, false);
 
     let file_response = backend(&tempdir)
         .search(SearchMemoriesRequest {
             query: "needle".to_string(),
             path: Some("MEMORY.md".to_string()),
+            cursor: None,
             max_results: DEFAULT_SEARCH_MAX_RESULTS,
         })
         .await
         .expect("search one memory file");
     assert_eq!(file_response.matches.len(), 1);
     assert_eq!(file_response.matches[0].path, "MEMORY.md");
+    assert_eq!(file_response.next_cursor, None);
+    assert_eq!(file_response.truncated, false);
+}
+
+#[tokio::test]
+async fn search_supports_pagination() {
+    let tempdir = TempDir::new().expect("tempdir");
+    tokio::fs::create_dir_all(tempdir.path().join("rollout_summaries"))
+        .await
+        .expect("create rollout summaries dir");
+    tokio::fs::write(tempdir.path().join("MEMORY.md"), "needle one\nneedle two\n")
+        .await
+        .expect("write memory file");
+    tokio::fs::write(
+        tempdir.path().join("rollout_summaries/a.jsonl"),
+        "needle three\n",
+    )
+    .await
+    .expect("write rollout summary");
+
+    let page1 = backend(&tempdir)
+        .search(SearchMemoriesRequest {
+            query: "needle".to_string(),
+            path: None,
+            cursor: None,
+            max_results: 2,
+        })
+        .await
+        .expect("search first page");
+    assert_eq!(
+        page1
+            .matches
+            .iter()
+            .map(|entry| (entry.path.as_str(), entry.line_number))
+            .collect::<Vec<_>>(),
+        vec![("MEMORY.md", 1), ("MEMORY.md", 2)]
+    );
+    assert_eq!(page1.next_cursor.as_deref(), Some("2"));
+    assert_eq!(page1.truncated, true);
+
+    let page2 = backend(&tempdir)
+        .search(SearchMemoriesRequest {
+            query: "needle".to_string(),
+            path: None,
+            cursor: page1.next_cursor,
+            max_results: 2,
+        })
+        .await
+        .expect("search second page");
+    assert_eq!(
+        page2
+            .matches
+            .iter()
+            .map(|entry| (entry.path.as_str(), entry.line_number))
+            .collect::<Vec<_>>(),
+        vec![("rollout_summaries/a.jsonl", 1)]
+    );
+    assert_eq!(page2.next_cursor, None);
+    assert_eq!(page2.truncated, false);
+}
+
+#[tokio::test]
+async fn search_rejects_invalid_cursor() {
+    let tempdir = TempDir::new().expect("tempdir");
+    tokio::fs::write(tempdir.path().join("MEMORY.md"), "needle\n")
+        .await
+        .expect("write memory file");
+
+    let err = backend(&tempdir)
+        .search(SearchMemoriesRequest {
+            query: "needle".to_string(),
+            path: None,
+            cursor: Some("bogus".to_string()),
+            max_results: DEFAULT_SEARCH_MAX_RESULTS,
+        })
+        .await
+        .expect_err("cursor should be rejected");
+
+    assert!(matches!(err, MemoriesBackendError::InvalidCursor { .. }));
 }
 
 #[tokio::test]

--- a/codex-rs/memories/mcp/src/local_tests.rs
+++ b/codex-rs/memories/mcp/src/local_tests.rs
@@ -386,6 +386,7 @@ async fn search_supports_directory_and_file_scopes() {
             path: None,
             cursor: None,
             context_lines: 0,
+            case_sensitive: true,
             max_results: DEFAULT_SEARCH_MAX_RESULTS,
         })
         .await
@@ -416,6 +417,7 @@ async fn search_supports_directory_and_file_scopes() {
             path: Some("MEMORY.md".to_string()),
             cursor: None,
             context_lines: 0,
+            case_sensitive: true,
             max_results: DEFAULT_SEARCH_MAX_RESULTS,
         })
         .await
@@ -455,6 +457,7 @@ async fn search_supports_pagination() {
             path: None,
             cursor: None,
             context_lines: 0,
+            case_sensitive: true,
             max_results: 2,
         })
         .await
@@ -485,6 +488,7 @@ async fn search_supports_pagination() {
             path: None,
             cursor: page1.next_cursor,
             context_lines: 0,
+            case_sensitive: true,
             max_results: 2,
         })
         .await
@@ -518,6 +522,7 @@ async fn search_supports_context_lines() {
             path: None,
             cursor: None,
             context_lines: 1,
+            case_sensitive: true,
             max_results: DEFAULT_SEARCH_MAX_RESULTS,
         })
         .await
@@ -543,6 +548,70 @@ async fn search_supports_context_lines() {
 }
 
 #[tokio::test]
+async fn search_supports_case_insensitive_matching() {
+    let tempdir = TempDir::new().expect("tempdir");
+    tokio::fs::write(tempdir.path().join("MEMORY.md"), "Needle\nneedle\nNEEDLE\n")
+        .await
+        .expect("write memory file");
+
+    let sensitive_response = backend(&tempdir)
+        .search(SearchMemoriesRequest {
+            query: "needle".to_string(),
+            path: None,
+            cursor: None,
+            context_lines: 0,
+            case_sensitive: true,
+            max_results: DEFAULT_SEARCH_MAX_RESULTS,
+        })
+        .await
+        .expect("search with case-sensitive matching");
+    assert_eq!(
+        sensitive_response.matches,
+        vec![MemorySearchMatch {
+            path: "MEMORY.md".to_string(),
+            line_number: 2,
+            start_line_number: 2,
+            content: "needle".to_string(),
+        }]
+    );
+
+    let insensitive_response = backend(&tempdir)
+        .search(SearchMemoriesRequest {
+            query: "needle".to_string(),
+            path: None,
+            cursor: None,
+            context_lines: 0,
+            case_sensitive: false,
+            max_results: DEFAULT_SEARCH_MAX_RESULTS,
+        })
+        .await
+        .expect("search with case-insensitive matching");
+    assert_eq!(
+        insensitive_response.matches,
+        vec![
+            MemorySearchMatch {
+                path: "MEMORY.md".to_string(),
+                line_number: 1,
+                start_line_number: 1,
+                content: "Needle".to_string(),
+            },
+            MemorySearchMatch {
+                path: "MEMORY.md".to_string(),
+                line_number: 2,
+                start_line_number: 2,
+                content: "needle".to_string(),
+            },
+            MemorySearchMatch {
+                path: "MEMORY.md".to_string(),
+                line_number: 3,
+                start_line_number: 3,
+                content: "NEEDLE".to_string(),
+            },
+        ]
+    );
+}
+
+#[tokio::test]
 async fn search_rejects_invalid_cursor() {
     let tempdir = TempDir::new().expect("tempdir");
     tokio::fs::write(tempdir.path().join("MEMORY.md"), "needle\n")
@@ -555,6 +624,7 @@ async fn search_rejects_invalid_cursor() {
             path: None,
             cursor: Some("bogus".to_string()),
             context_lines: 0,
+            case_sensitive: true,
             max_results: DEFAULT_SEARCH_MAX_RESULTS,
         })
         .await
@@ -568,6 +638,7 @@ async fn search_rejects_invalid_cursor() {
             path: None,
             cursor: Some("2".to_string()),
             context_lines: 0,
+            case_sensitive: true,
             max_results: DEFAULT_SEARCH_MAX_RESULTS,
         })
         .await

--- a/codex-rs/memories/mcp/src/local_tests.rs
+++ b/codex-rs/memories/mcp/src/local_tests.rs
@@ -385,17 +385,27 @@ async fn search_supports_directory_and_file_scopes() {
             query: "needle".to_string(),
             path: None,
             cursor: None,
+            context_lines: 0,
             max_results: DEFAULT_SEARCH_MAX_RESULTS,
         })
         .await
         .expect("search all memories");
     assert_eq!(
-        response
-            .matches
-            .iter()
-            .map(|entry| (entry.path.as_str(), entry.line_number))
-            .collect::<Vec<_>>(),
-        vec![("MEMORY.md", 2), ("rollout_summaries/a.jsonl", 1)]
+        response.matches,
+        vec![
+            MemorySearchMatch {
+                path: "MEMORY.md".to_string(),
+                line_number: 2,
+                start_line_number: 2,
+                content: "needle".to_string(),
+            },
+            MemorySearchMatch {
+                path: "rollout_summaries/a.jsonl".to_string(),
+                line_number: 1,
+                start_line_number: 1,
+                content: "needle again".to_string(),
+            },
+        ]
     );
     assert_eq!(response.next_cursor, None);
     assert_eq!(response.truncated, false);
@@ -405,12 +415,20 @@ async fn search_supports_directory_and_file_scopes() {
             query: "needle".to_string(),
             path: Some("MEMORY.md".to_string()),
             cursor: None,
+            context_lines: 0,
             max_results: DEFAULT_SEARCH_MAX_RESULTS,
         })
         .await
         .expect("search one memory file");
-    assert_eq!(file_response.matches.len(), 1);
-    assert_eq!(file_response.matches[0].path, "MEMORY.md");
+    assert_eq!(
+        file_response.matches,
+        vec![MemorySearchMatch {
+            path: "MEMORY.md".to_string(),
+            line_number: 2,
+            start_line_number: 2,
+            content: "needle".to_string(),
+        }]
+    );
     assert_eq!(file_response.next_cursor, None);
     assert_eq!(file_response.truncated, false);
 }
@@ -436,17 +454,27 @@ async fn search_supports_pagination() {
             query: "needle".to_string(),
             path: None,
             cursor: None,
+            context_lines: 0,
             max_results: 2,
         })
         .await
         .expect("search first page");
     assert_eq!(
-        page1
-            .matches
-            .iter()
-            .map(|entry| (entry.path.as_str(), entry.line_number))
-            .collect::<Vec<_>>(),
-        vec![("MEMORY.md", 1), ("MEMORY.md", 2)]
+        page1.matches,
+        vec![
+            MemorySearchMatch {
+                path: "MEMORY.md".to_string(),
+                line_number: 1,
+                start_line_number: 1,
+                content: "needle one".to_string(),
+            },
+            MemorySearchMatch {
+                path: "MEMORY.md".to_string(),
+                line_number: 2,
+                start_line_number: 2,
+                content: "needle two".to_string(),
+            },
+        ]
     );
     assert_eq!(page1.next_cursor.as_deref(), Some("2"));
     assert_eq!(page1.truncated, true);
@@ -456,20 +484,62 @@ async fn search_supports_pagination() {
             query: "needle".to_string(),
             path: None,
             cursor: page1.next_cursor,
+            context_lines: 0,
             max_results: 2,
         })
         .await
         .expect("search second page");
     assert_eq!(
-        page2
-            .matches
-            .iter()
-            .map(|entry| (entry.path.as_str(), entry.line_number))
-            .collect::<Vec<_>>(),
-        vec![("rollout_summaries/a.jsonl", 1)]
+        page2.matches,
+        vec![MemorySearchMatch {
+            path: "rollout_summaries/a.jsonl".to_string(),
+            line_number: 1,
+            start_line_number: 1,
+            content: "needle three".to_string(),
+        }]
     );
     assert_eq!(page2.next_cursor, None);
     assert_eq!(page2.truncated, false);
+}
+
+#[tokio::test]
+async fn search_supports_context_lines() {
+    let tempdir = TempDir::new().expect("tempdir");
+    tokio::fs::write(
+        tempdir.path().join("MEMORY.md"),
+        "alpha\nneedle\nomega\nneedle again\n",
+    )
+    .await
+    .expect("write memory file");
+
+    let response = backend(&tempdir)
+        .search(SearchMemoriesRequest {
+            query: "needle".to_string(),
+            path: None,
+            cursor: None,
+            context_lines: 1,
+            max_results: DEFAULT_SEARCH_MAX_RESULTS,
+        })
+        .await
+        .expect("search with context");
+
+    assert_eq!(
+        response.matches,
+        vec![
+            MemorySearchMatch {
+                path: "MEMORY.md".to_string(),
+                line_number: 2,
+                start_line_number: 1,
+                content: "alpha\nneedle\nomega".to_string(),
+            },
+            MemorySearchMatch {
+                path: "MEMORY.md".to_string(),
+                line_number: 4,
+                start_line_number: 3,
+                content: "omega\nneedle again".to_string(),
+            },
+        ]
+    );
 }
 
 #[tokio::test]
@@ -484,12 +554,29 @@ async fn search_rejects_invalid_cursor() {
             query: "needle".to_string(),
             path: None,
             cursor: Some("bogus".to_string()),
+            context_lines: 0,
             max_results: DEFAULT_SEARCH_MAX_RESULTS,
         })
         .await
         .expect_err("cursor should be rejected");
 
     assert!(matches!(err, MemoriesBackendError::InvalidCursor { .. }));
+
+    let past_end_err = backend(&tempdir)
+        .search(SearchMemoriesRequest {
+            query: "needle".to_string(),
+            path: None,
+            cursor: Some("2".to_string()),
+            context_lines: 0,
+            max_results: DEFAULT_SEARCH_MAX_RESULTS,
+        })
+        .await
+        .expect_err("cursor past end should be rejected");
+
+    assert!(matches!(
+        past_end_err,
+        MemoriesBackendError::InvalidCursor { .. }
+    ));
 }
 
 #[tokio::test]

--- a/codex-rs/memories/mcp/src/schema.rs
+++ b/codex-rs/memories/mcp/src/schema.rs
@@ -75,6 +75,7 @@ pub(crate) fn search_input_schema() -> JsonObject {
         "properties": {
             "query": { "type": "string" },
             "path": { "type": "string" },
+            "cursor": { "type": "string" },
             "max_results": { "type": "integer", "minimum": 1 }
         },
         "required": ["query"],
@@ -88,6 +89,9 @@ pub(crate) fn search_output_schema() -> JsonObject {
         "properties": {
             "query": { "type": "string" },
             "path": {
+                "anyOf": [{ "type": "string" }, { "type": "null" }]
+            },
+            "next_cursor": {
                 "anyOf": [{ "type": "string" }, { "type": "null" }]
             },
             "matches": {
@@ -105,7 +109,7 @@ pub(crate) fn search_output_schema() -> JsonObject {
             },
             "truncated": { "type": "boolean" }
         },
-        "required": ["query", "path", "matches", "truncated"],
+        "required": ["query", "path", "matches", "next_cursor", "truncated"],
         "additionalProperties": false
     }))
 }

--- a/codex-rs/memories/mcp/src/schema.rs
+++ b/codex-rs/memories/mcp/src/schema.rs
@@ -76,6 +76,7 @@ pub(crate) fn search_input_schema() -> JsonObject {
             "query": { "type": "string" },
             "path": { "type": "string" },
             "cursor": { "type": "string" },
+            "context_lines": { "type": "integer", "minimum": 0 },
             "max_results": { "type": "integer", "minimum": 1 }
         },
         "required": ["query"],
@@ -101,9 +102,10 @@ pub(crate) fn search_output_schema() -> JsonObject {
                     "properties": {
                         "path": { "type": "string" },
                         "line_number": { "type": "integer" },
-                        "line": { "type": "string" }
+                        "start_line_number": { "type": "integer" },
+                        "content": { "type": "string" }
                     },
-                    "required": ["path", "line_number", "line"],
+                    "required": ["path", "line_number", "start_line_number", "content"],
                     "additionalProperties": false
                 }
             },

--- a/codex-rs/memories/mcp/src/schema.rs
+++ b/codex-rs/memories/mcp/src/schema.rs
@@ -77,6 +77,7 @@ pub(crate) fn search_input_schema() -> JsonObject {
             "path": { "type": "string" },
             "cursor": { "type": "string" },
             "context_lines": { "type": "integer", "minimum": 0 },
+            "case_sensitive": { "type": "boolean" },
             "max_results": { "type": "integer", "minimum": 1 }
         },
         "required": ["query"],

--- a/codex-rs/memories/mcp/src/server.rs
+++ b/codex-rs/memories/mcp/src/server.rs
@@ -57,6 +57,7 @@ struct ReadArgs {
 struct SearchArgs {
     query: String,
     path: Option<String>,
+    cursor: Option<String>,
     max_results: Option<usize>,
 }
 
@@ -146,6 +147,7 @@ impl<B: MemoriesBackend> ServerHandler for MemoriesMcpServer<B> {
                         .search(SearchMemoriesRequest {
                             query: args.query,
                             path: args.path,
+                            cursor: args.cursor,
                             max_results: clamp_max_results(
                                 args.max_results,
                                 DEFAULT_SEARCH_MAX_RESULTS,
@@ -215,7 +217,7 @@ fn read_tool() -> Tool {
 fn search_tool() -> Tool {
     let mut tool = Tool::new(
         Cow::Borrowed(SEARCH_TOOL_NAME),
-        Cow::Borrowed("Search Codex memory files for exact text matches."),
+        Cow::Borrowed("Search Codex memory files for exact text matches, with pagination."),
         Arc::new(schema::search_input_schema()),
     );
     tool.output_schema = Some(Arc::new(schema::search_output_schema()));

--- a/codex-rs/memories/mcp/src/server.rs
+++ b/codex-rs/memories/mcp/src/server.rs
@@ -58,6 +58,7 @@ struct SearchArgs {
     query: String,
     path: Option<String>,
     cursor: Option<String>,
+    context_lines: Option<usize>,
     max_results: Option<usize>,
 }
 
@@ -148,6 +149,7 @@ impl<B: MemoriesBackend> ServerHandler for MemoriesMcpServer<B> {
                             query: args.query,
                             path: args.path,
                             cursor: args.cursor,
+                            context_lines: args.context_lines.unwrap_or(0),
                             max_results: clamp_max_results(
                                 args.max_results,
                                 DEFAULT_SEARCH_MAX_RESULTS,
@@ -217,7 +219,9 @@ fn read_tool() -> Tool {
 fn search_tool() -> Tool {
     let mut tool = Tool::new(
         Cow::Borrowed(SEARCH_TOOL_NAME),
-        Cow::Borrowed("Search Codex memory files for exact text matches, with pagination."),
+        Cow::Borrowed(
+            "Search Codex memory files for exact text matches, with pagination and optional surrounding context lines.",
+        ),
         Arc::new(schema::search_input_schema()),
     );
     tool.output_schema = Some(Arc::new(schema::search_output_schema()));

--- a/codex-rs/memories/mcp/src/server.rs
+++ b/codex-rs/memories/mcp/src/server.rs
@@ -59,6 +59,7 @@ struct SearchArgs {
     path: Option<String>,
     cursor: Option<String>,
     context_lines: Option<usize>,
+    case_sensitive: Option<bool>,
     max_results: Option<usize>,
 }
 
@@ -150,6 +151,7 @@ impl<B: MemoriesBackend> ServerHandler for MemoriesMcpServer<B> {
                             path: args.path,
                             cursor: args.cursor,
                             context_lines: args.context_lines.unwrap_or(0),
+                            case_sensitive: args.case_sensitive.unwrap_or(true),
                             max_results: clamp_max_results(
                                 args.max_results,
                                 DEFAULT_SEARCH_MAX_RESULTS,
@@ -220,7 +222,7 @@ fn search_tool() -> Tool {
     let mut tool = Tool::new(
         Cow::Borrowed(SEARCH_TOOL_NAME),
         Cow::Borrowed(
-            "Search Codex memory files for exact text matches, with pagination and optional surrounding context lines.",
+            "Search Codex memory files for exact text matches, with pagination, optional surrounding context lines, and optional case-insensitive matching.",
         ),
         Arc::new(schema::search_input_schema()),
     );


### PR DESCRIPTION
## Why

The paginated memories MCP `search` tool still returned only the matching line text, which made it harder for clients to present useful search results or decide whether they needed to follow up with a separate `read` call. Adding a small amount of surrounding context makes individual hits much more usable while keeping the search response deterministic and line-addressable.

## What changed

- add an optional `context_lines` search argument and thread it through the MCP server into the local memories backend
- change search matches to return the matched `line_number` plus a `start_line_number` and multi-line `content` block for the requested context window
- update the search tool schema and description to document the new request/response shape
- extend the local backend tests to cover zero-context matches, contextual results, pagination, and invalid cursors that point past the end of the result set

## Testing

- Added targeted unit coverage in `memories/mcp/src/local_tests.rs`
- GitHub Actions are running for the branch
