### PR TITLE
Plan Windows metadata targets from filesystem policy

### DIFF
--- a/codex-rs/core/src/exec.rs
+++ b/codex-rs/core/src/exec.rs
@@ -110,11 +110,11 @@ pub(crate) struct WindowsSandboxFilesystemOverrides {
     pub(crate) read_roots_include_platform_defaults: bool,
     pub(crate) write_roots_override: Option<Vec<PathBuf>>,
     pub(crate) additional_deny_write_paths: Vec<AbsolutePathBuf>,
+    pub(crate) protected_metadata_targets: Vec<WindowsProtectedMetadataTarget>,
 }
 
 /// Layer: Windows adapter layer. This is the Windows projection of
 /// `WritableRoot::protected_metadata_names` from `FileSystemSandboxPolicy`.
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct WindowsProtectedMetadataTarget {
     pub(crate) path: AbsolutePathBuf,
@@ -124,7 +124,6 @@ pub(crate) struct WindowsProtectedMetadataTarget {
 /// Layer: Windows adapter layer. The enforcement layer needs to know why a
 /// protected metadata path is absent instead of treating every missing path as
 /// an existing filesystem object.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum WindowsProtectedMetadataMode {
     ExistingDeny,
@@ -1151,7 +1150,9 @@ pub(crate) fn resolve_windows_restricted_token_filesystem_overrides(
         }
     }
 
-    if additional_deny_write_paths.is_empty() {
+    let protected_metadata_targets = windows_protected_metadata_targets(&split_writable_roots)?;
+
+    if additional_deny_write_paths.is_empty() && protected_metadata_targets.is_empty() {
         return Ok(None);
     }
 
@@ -1163,6 +1164,7 @@ pub(crate) fn resolve_windows_restricted_token_filesystem_overrides(
             .into_iter()
             .map(|path| AbsolutePathBuf::from_absolute_path(path).map_err(|err| err.to_string()))
             .collect::<std::result::Result<_, _>>()?,
+        protected_metadata_targets,
     }))
 }
 
@@ -1283,9 +1285,12 @@ pub(crate) fn resolve_windows_elevated_filesystem_overrides(
         Vec::new()
     };
 
+    let protected_metadata_targets = windows_protected_metadata_targets(&split_writable_roots)?;
+
     if read_roots_override.is_none()
         && write_roots_override.is_none()
         && additional_deny_write_paths.is_empty()
+        && protected_metadata_targets.is_empty()
     {
         return Ok(None);
     }
@@ -1296,7 +1301,34 @@ pub(crate) fn resolve_windows_elevated_filesystem_overrides(
         read_roots_override,
         write_roots_override,
         additional_deny_write_paths,
+        protected_metadata_targets,
     }))
+}
+
+fn windows_protected_metadata_targets(
+    writable_roots: &[codex_protocol::protocol::WritableRoot],
+) -> std::result::Result<Vec<WindowsProtectedMetadataTarget>, String> {
+    let mut targets = BTreeSet::new();
+    for writable_root in writable_roots {
+        for metadata_name in &writable_root.protected_metadata_names {
+            let path =
+                normalize_windows_override_path(writable_root.root.join(metadata_name).as_path())?;
+            let path = AbsolutePathBuf::from_absolute_path(path).map_err(|err| err.to_string())?;
+            targets.insert(WindowsProtectedMetadataTarget {
+                mode: windows_protected_metadata_mode(&path),
+                path,
+            });
+        }
+    }
+    Ok(targets.into_iter().collect())
+}
+
+fn windows_protected_metadata_mode(path: &AbsolutePathBuf) -> WindowsProtectedMetadataMode {
+    if std::fs::symlink_metadata(path.as_path()).is_ok() {
+        return WindowsProtectedMetadataMode::ExistingDeny;
+    }
+
+    WindowsProtectedMetadataMode::MissingCreationMonitor
 }
 
 fn has_reopened_writable_descendant(

--- a/codex-rs/core/src/exec_tests.rs
+++ b/codex-rs/core/src/exec_tests.rs
@@ -663,6 +663,20 @@ fn windows_restricted_token_supports_full_read_split_write_read_carveouts() {
             read_roots_include_platform_defaults: false,
             write_roots_override: None,
             additional_deny_write_paths: expected_deny_write_paths,
+            protected_metadata_targets: vec![
+                WindowsProtectedMetadataTarget {
+                    path: cwd.join(".agents"),
+                    mode: WindowsProtectedMetadataMode::MissingCreationMonitor,
+                },
+                WindowsProtectedMetadataTarget {
+                    path: cwd.join(".codex"),
+                    mode: WindowsProtectedMetadataMode::MissingCreationMonitor,
+                },
+                WindowsProtectedMetadataTarget {
+                    path: cwd.join(".git"),
+                    mode: WindowsProtectedMetadataMode::MissingCreationMonitor,
+                },
+            ],
         }))
     );
 }
@@ -700,6 +714,7 @@ fn windows_elevated_supports_split_restricted_read_roots() {
             read_roots_include_platform_defaults: false,
             write_roots_override: None,
             additional_deny_write_paths: vec![],
+            protected_metadata_targets: vec![],
         }))
     );
 }
@@ -707,6 +722,9 @@ fn windows_elevated_supports_split_restricted_read_roots() {
 #[test]
 fn windows_elevated_supports_split_write_read_carveouts() {
     let temp_dir = tempfile::TempDir::new().expect("tempdir");
+    let expected_root = dunce::canonicalize(temp_dir.path())
+        .expect("canonical temp dir")
+        .abs();
     let docs = temp_dir.path().join("docs");
     std::fs::create_dir_all(&docs).expect("create docs");
     let expected_docs = dunce::canonicalize(&docs).expect("canonical docs");
@@ -756,6 +774,146 @@ fn windows_elevated_supports_split_write_read_carveouts() {
             additional_deny_write_paths: vec![
                 codex_utils_absolute_path::AbsolutePathBuf::from_absolute_path(expected_docs)
                     .expect("absolute docs"),
+            ],
+            protected_metadata_targets: vec![
+                WindowsProtectedMetadataTarget {
+                    path: expected_root.join(".agents"),
+                    mode: WindowsProtectedMetadataMode::MissingCreationMonitor,
+                },
+                WindowsProtectedMetadataTarget {
+                    path: expected_root.join(".codex"),
+                    mode: WindowsProtectedMetadataMode::MissingCreationMonitor,
+                },
+                WindowsProtectedMetadataTarget {
+                    path: expected_root.join(".git"),
+                    mode: WindowsProtectedMetadataMode::MissingCreationMonitor,
+                },
+            ],
+        }))
+    );
+}
+
+#[test]
+fn windows_metadata_plan_marks_existing_metadata_for_deny() {
+    let temp_dir = tempfile::TempDir::new().expect("tempdir");
+    let cwd = dunce::canonicalize(temp_dir.path())
+        .expect("canonical temp dir")
+        .abs();
+    std::fs::create_dir_all(cwd.join(".git").as_path()).expect("create .git");
+    let policy = SandboxPolicy::WorkspaceWrite {
+        writable_roots: vec![],
+        network_access: false,
+        exclude_tmpdir_env_var: true,
+        exclude_slash_tmp: true,
+    };
+    let file_system_policy = FileSystemSandboxPolicy::restricted(vec![
+        codex_protocol::permissions::FileSystemSandboxEntry {
+            path: codex_protocol::permissions::FileSystemPath::Special {
+                value: codex_protocol::permissions::FileSystemSpecialPath::Root,
+            },
+            access: codex_protocol::permissions::FileSystemAccessMode::Read,
+        },
+        codex_protocol::permissions::FileSystemSandboxEntry {
+            path: codex_protocol::permissions::FileSystemPath::Special {
+                value: codex_protocol::permissions::FileSystemSpecialPath::project_roots(
+                    /*subpath*/ None,
+                ),
+            },
+            access: codex_protocol::permissions::FileSystemAccessMode::Write,
+        },
+    ]);
+
+    assert_eq!(
+        resolve_windows_elevated_filesystem_overrides(
+            SandboxType::WindowsRestrictedToken,
+            &policy,
+            &file_system_policy,
+            NetworkSandboxPolicy::Restricted,
+            &cwd,
+            /*use_windows_elevated_backend*/ true,
+        ),
+        Ok(Some(WindowsSandboxFilesystemOverrides {
+            read_roots_override: None,
+            read_roots_include_platform_defaults: false,
+            write_roots_override: None,
+            additional_deny_write_paths: vec![],
+            protected_metadata_targets: vec![
+                WindowsProtectedMetadataTarget {
+                    path: cwd.join(".agents"),
+                    mode: WindowsProtectedMetadataMode::MissingCreationMonitor,
+                },
+                WindowsProtectedMetadataTarget {
+                    path: cwd.join(".codex"),
+                    mode: WindowsProtectedMetadataMode::MissingCreationMonitor,
+                },
+                WindowsProtectedMetadataTarget {
+                    path: cwd.join(".git"),
+                    mode: WindowsProtectedMetadataMode::ExistingDeny,
+                },
+            ],
+        }))
+    );
+}
+
+#[test]
+fn windows_metadata_plan_does_not_materialize_nested_missing_git() {
+    let temp_dir = tempfile::TempDir::new().expect("tempdir");
+    let repo = dunce::canonicalize(temp_dir.path())
+        .expect("canonical temp dir")
+        .abs();
+    std::fs::create_dir_all(repo.join(".git").as_path()).expect("create parent .git");
+    let cwd = repo.join("child");
+    std::fs::create_dir_all(cwd.as_path()).expect("create child workspace");
+    let policy = SandboxPolicy::WorkspaceWrite {
+        writable_roots: vec![],
+        network_access: false,
+        exclude_tmpdir_env_var: true,
+        exclude_slash_tmp: true,
+    };
+    let file_system_policy = FileSystemSandboxPolicy::restricted(vec![
+        codex_protocol::permissions::FileSystemSandboxEntry {
+            path: codex_protocol::permissions::FileSystemPath::Special {
+                value: codex_protocol::permissions::FileSystemSpecialPath::Root,
+            },
+            access: codex_protocol::permissions::FileSystemAccessMode::Read,
+        },
+        codex_protocol::permissions::FileSystemSandboxEntry {
+            path: codex_protocol::permissions::FileSystemPath::Special {
+                value: codex_protocol::permissions::FileSystemSpecialPath::project_roots(
+                    /*subpath*/ None,
+                ),
+            },
+            access: codex_protocol::permissions::FileSystemAccessMode::Write,
+        },
+    ]);
+
+    assert_eq!(
+        resolve_windows_elevated_filesystem_overrides(
+            SandboxType::WindowsRestrictedToken,
+            &policy,
+            &file_system_policy,
+            NetworkSandboxPolicy::Restricted,
+            &cwd,
+            /*use_windows_elevated_backend*/ true,
+        ),
+        Ok(Some(WindowsSandboxFilesystemOverrides {
+            read_roots_override: None,
+            read_roots_include_platform_defaults: false,
+            write_roots_override: None,
+            additional_deny_write_paths: vec![],
+            protected_metadata_targets: vec![
+                WindowsProtectedMetadataTarget {
+                    path: cwd.join(".agents"),
+                    mode: WindowsProtectedMetadataMode::MissingCreationMonitor,
+                },
+                WindowsProtectedMetadataTarget {
+                    path: cwd.join(".codex"),
+                    mode: WindowsProtectedMetadataMode::MissingCreationMonitor,
+                },
+                WindowsProtectedMetadataTarget {
+                    path: cwd.join(".git"),
+                    mode: WindowsProtectedMetadataMode::MissingCreationMonitor,
+                },
             ],
         }))
     );


### PR DESCRIPTION
## Summary

1. Plans Windows protected metadata targets from filesystem policy.
2. Converts policy decisions into the adapter target type without invoking setup.

## Why

1. This PR is the planning slice for the stack.
2. Later PRs can only enforce `.git`, `.codex`, and `.agents` consistently if the policy layer first identifies which protected paths exist, which are symlinks, and which are missing.

## Stack Relation

This PR is part 4 of 21 in the Windows protected metadata stack.

1. [PR 20889](https://github.com/openai/codex/pull/20889) Add Windows metadata adapter target type
2. [PR 20890](https://github.com/openai/codex/pull/20890) Add Windows metadata setup target type
3. [PR 20891](https://github.com/openai/codex/pull/20891) Add Windows metadata enforcement guard
4. [PR 21030](https://github.com/openai/codex/pull/21030) Plan Windows metadata targets from filesystem policy
5. [PR 21031](https://github.com/openai/codex/pull/21031) Thread Windows metadata targets through setup request
6. [PR 21032](https://github.com/openai/codex/pull/21032) Pass Windows metadata targets to direct exec
7. [PR 21033](https://github.com/openai/codex/pull/21033) Thread Windows metadata targets through sessions
8. [PR 21035](https://github.com/openai/codex/pull/21035) Enforce Windows protected metadata targets
9. [PR 21036](https://github.com/openai/codex/pull/21036) Deny Windows protected metadata symlink targets
10. [PR 21037](https://github.com/openai/codex/pull/21037) Use Windows metadata targets in debug sandbox
11. [PR 21038](https://github.com/openai/codex/pull/21038) Allow Windows sandbox Git signal pipes
12. [PR 21039](https://github.com/openai/codex/pull/21039) Add Windows legacy Git read root helpers
13. [PR 21040](https://github.com/openai/codex/pull/21040) Grant Windows legacy Git read roots
14. [PR 21041](https://github.com/openai/codex/pull/21041) Inject Git safe directory for Windows legacy sandbox
15. [PR 21042](https://github.com/openai/codex/pull/21042) Test Windows runtime metadata target preparation
16. [PR 21043](https://github.com/openai/codex/pull/21043) Document Windows metadata request boundary
17. [PR 21172](https://github.com/openai/codex/pull/21172) Add Windows missing metadata monitor runtime
18. [PR 21173](https://github.com/openai/codex/pull/21173) Wire Windows metadata monitor through sandbox exits
19. [PR 21174](https://github.com/openai/codex/pull/21174) Add Windows missing metadata deny sentinel
20. [PR 21175](https://github.com/openai/codex/pull/21175) Wire missing Windows metadata to deny sentinel
21. [PR 21184](https://github.com/openai/codex/pull/21184) Use direct deny ACLs for Windows metadata sentinels

## Validation

1. Stack head local format and Rust tests passed on `95ef124d6194bd2126c11928cb3973214f9ac63a`.
2. Azure Windows VM 56 case validation is running on `95ef124d6194bd2126c11928cb3973214f9ac63a`.