### PR TITLE
Thread Windows metadata targets through setup request

### DIFF
--- a/codex-rs/core/src/exec.rs
+++ b/codex-rs/core/src/exec.rs
@@ -665,6 +665,7 @@ async fn exec_windows_sandbox(
                         elevated_read_roots_include_platform_defaults,
                     write_roots_override: elevated_write_roots_override.as_deref(),
                     deny_write_paths_override: &elevated_deny_write_paths,
+                    protected_metadata_targets: &[],
                 },
             )
         } else {

--- a/codex-rs/windows-sandbox-rs/src/elevated_impl.rs
+++ b/codex-rs/windows-sandbox-rs/src/elevated_impl.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::path::PathBuf;
 
+use crate::setup::ProtectedMetadataTarget;
+
 pub struct ElevatedSandboxCaptureRequest<'a> {
     pub policy_json_or_preset: &'a str,
     pub sandbox_policy_cwd: &'a Path,
@@ -16,6 +18,7 @@ pub struct ElevatedSandboxCaptureRequest<'a> {
     pub read_roots_include_platform_defaults: bool,
     pub write_roots_override: Option<&'a [PathBuf]>,
     pub deny_write_paths_override: &'a [PathBuf],
+    pub protected_metadata_targets: &'a [ProtectedMetadataTarget],
 }
 
 mod windows_impl {
@@ -64,6 +67,7 @@ mod windows_impl {
             read_roots_include_platform_defaults,
             write_roots_override,
             deny_write_paths_override,
+            protected_metadata_targets,
         } = request;
         let policy = parse_policy(policy_json_or_preset)?;
         normalize_null_device_env(&mut env_map);
@@ -86,6 +90,7 @@ mod windows_impl {
             read_roots_include_platform_defaults,
             write_roots_override,
             deny_write_paths_override,
+            protected_metadata_targets,
             proxy_enforced,
         )?;
         // Build capability SID for ACL grants.

--- a/codex-rs/windows-sandbox-rs/src/identity.rs
+++ b/codex-rs/windows-sandbox-rs/src/identity.rs
@@ -140,6 +140,7 @@ pub fn require_logon_sandbox_creds(
     read_roots_include_platform_defaults: bool,
     write_roots_override: Option<&[PathBuf]>,
     deny_write_paths_override: &[PathBuf],
+    protected_metadata_targets: &[crate::setup::ProtectedMetadataTarget],
     proxy_enforced: bool,
 ) -> Result<SandboxCreds> {
     let sandbox_dir = crate::setup::sandbox_dir(codex_home);
@@ -202,6 +203,7 @@ pub fn require_logon_sandbox_creds(
                 read_roots_include_platform_defaults,
                 write_roots: Some(needed_write.clone()),
                 deny_write_paths: Some(deny_write_paths_override.to_vec()),
+                protected_metadata_targets: Some(protected_metadata_targets.to_vec()),
             },
         )?;
         identity = select_identity(network_identity, codex_home)?;
@@ -221,6 +223,7 @@ pub fn require_logon_sandbox_creds(
             read_roots_include_platform_defaults,
             write_roots: Some(needed_write),
             deny_write_paths: Some(deny_write_paths_override.to_vec()),
+            protected_metadata_targets: Some(protected_metadata_targets.to_vec()),
         },
     )?;
     let identity = identity.ok_or_else(|| {

--- a/codex-rs/windows-sandbox-rs/src/setup_main_win.rs
+++ b/codex-rs/windows-sandbox-rs/src/setup_main_win.rs
@@ -8,6 +8,7 @@ use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use codex_otel::StatsigMetricsSettings;
 use codex_windows_sandbox::LOG_FILE_NAME;
+use codex_windows_sandbox::ProtectedMetadataTarget;
 use codex_windows_sandbox::SETUP_VERSION;
 use codex_windows_sandbox::SetupErrorCode;
 use codex_windows_sandbox::SetupErrorReport;
@@ -87,6 +88,9 @@ struct Payload {
     write_roots: Vec<PathBuf>,
     #[serde(default)]
     deny_write_paths: Vec<PathBuf>,
+    #[allow(dead_code)]
+    #[serde(default)]
+    protected_metadata_targets: Vec<ProtectedMetadataTarget>,
     proxy_ports: Vec<u16>,
     #[serde(default)]
     allow_local_binding: bool,

--- a/codex-rs/windows-sandbox-rs/src/setup_orchestrator.rs
+++ b/codex-rs/windows-sandbox-rs/src/setup_orchestrator.rs
@@ -97,6 +97,7 @@ pub struct SetupRootOverrides {
     pub read_roots_include_platform_defaults: bool,
     pub write_roots: Option<Vec<PathBuf>>,
     pub deny_write_paths: Option<Vec<PathBuf>>,
+    pub protected_metadata_targets: Option<Vec<ProtectedMetadataTarget>>,
 }
 
 /// Layer: Windows enforcement request boundary. These targets are projected by
@@ -169,6 +170,7 @@ pub fn run_setup_refresh_with_extra_read_roots(
             read_roots_include_platform_defaults: false,
             write_roots: Some(Vec::new()),
             deny_write_paths: None,
+            protected_metadata_targets: None,
         },
     )
 }
@@ -186,6 +188,8 @@ fn run_setup_refresh_inner(
     }
     let (read_roots, write_roots) = build_payload_roots(&request, &overrides);
     let deny_write_paths = build_payload_deny_write_paths(&request, overrides.deny_write_paths);
+    let protected_metadata_targets =
+        build_payload_protected_metadata_targets(overrides.protected_metadata_targets);
     let network_identity =
         SandboxNetworkIdentity::from_policy(request.policy, request.proxy_enforced);
     let offline_proxy_settings = offline_proxy_settings_from_env(request.env_map, network_identity);
@@ -198,6 +202,7 @@ fn run_setup_refresh_inner(
         read_roots,
         write_roots,
         deny_write_paths,
+        protected_metadata_targets,
         proxy_ports: offline_proxy_settings.proxy_ports,
         allow_local_binding: offline_proxy_settings.allow_local_binding,
         otel: None,
@@ -436,6 +441,8 @@ struct ElevationPayload {
     write_roots: Vec<PathBuf>,
     #[serde(default)]
     deny_write_paths: Vec<PathBuf>,
+    #[serde(default)]
+    protected_metadata_targets: Vec<ProtectedMetadataTarget>,
     proxy_ports: Vec<u16>,
     #[serde(default)]
     allow_local_binding: bool,
@@ -738,6 +745,8 @@ pub fn run_elevated_setup(
     })?;
     let (read_roots, write_roots) = build_payload_roots(&request, &overrides);
     let deny_write_paths = build_payload_deny_write_paths(&request, overrides.deny_write_paths);
+    let protected_metadata_targets =
+        build_payload_protected_metadata_targets(overrides.protected_metadata_targets);
     let network_identity =
         SandboxNetworkIdentity::from_policy(request.policy, request.proxy_enforced);
     let offline_proxy_settings = offline_proxy_settings_from_env(request.env_map, network_identity);
@@ -750,6 +759,7 @@ pub fn run_elevated_setup(
         read_roots,
         write_roots,
         deny_write_paths,
+        protected_metadata_targets,
         proxy_ports: offline_proxy_settings.proxy_ports,
         allow_local_binding: offline_proxy_settings.allow_local_binding,
         real_user: std::env::var("USERNAME").unwrap_or_else(|_| "Administrators".to_string()),
@@ -832,6 +842,12 @@ fn build_payload_deny_write_paths(
         .collect();
     deny_write_paths.extend(allow_deny_paths.deny);
     deny_write_paths
+}
+
+fn build_payload_protected_metadata_targets(
+    explicit_targets: Option<Vec<ProtectedMetadataTarget>>,
+) -> Vec<ProtectedMetadataTarget> {
+    explicit_targets.unwrap_or_default()
 }
 
 fn expand_user_profile_root(roots: Vec<PathBuf>) -> Vec<PathBuf> {
@@ -1345,6 +1361,7 @@ mod tests {
                 read_roots_include_platform_defaults: true,
                 write_roots: None,
                 deny_write_paths: None,
+                protected_metadata_targets: None,
             },
         );
         let expected_helper =
@@ -1392,6 +1409,7 @@ mod tests {
                 read_roots_include_platform_defaults: false,
                 write_roots: None,
                 deny_write_paths: None,
+                protected_metadata_targets: None,
             },
         );
         let expected_helper =

--- a/codex-rs/windows-sandbox-rs/src/spawn_prep.rs
+++ b/codex-rs/windows-sandbox-rs/src/spawn_prep.rs
@@ -17,6 +17,7 @@ use crate::policy::SandboxPolicy;
 use crate::policy::parse_policy;
 use crate::sandbox_utils::ensure_codex_home_exists;
 use crate::sandbox_utils::inject_git_safe_directory;
+use crate::setup::ProtectedMetadataTarget;
 use crate::token::convert_string_sid_to_sid;
 use crate::token::create_readonly_token_with_cap;
 use crate::token::create_workspace_write_token_with_caps_from;
@@ -264,6 +265,7 @@ pub(crate) fn prepare_elevated_spawn_context(
     cwd: &Path,
     env_map: &mut HashMap<String, String>,
     command: &[String],
+    protected_metadata_targets: &[ProtectedMetadataTarget],
 ) -> Result<ElevatedSpawnContext> {
     let common = prepare_spawn_context_common(
         policy_json_or_preset,
@@ -298,6 +300,7 @@ pub(crate) fn prepare_elevated_spawn_context(
         /*read_roots_include_platform_defaults*/ false,
         write_roots_override,
         &deny_write_paths,
+        protected_metadata_targets,
         /*proxy_enforced*/ false,
     )?;
     let caps = load_or_create_cap_sids(codex_home)?;

--- a/codex-rs/windows-sandbox-rs/src/unified_exec/backends/elevated.rs
+++ b/codex-rs/windows-sandbox-rs/src/unified_exec/backends/elevated.rs
@@ -38,6 +38,7 @@ pub(crate) async fn spawn_windows_sandbox_session_elevated(
         cwd,
         &mut env_map,
         &command,
+        &[],
     )?;
 
     let spawn_request = SpawnRequest {


### PR DESCRIPTION
## Summary

1. Threads planned Windows protected metadata targets into the setup request.
2. Keeps execution behavior unchanged until the direct exec and session paths consume the field.

## Why

1. This PR moves the planned target list across the request boundary as its own small wiring step.
2. The full stack needs setup to receive the same metadata decisions that policy planned, without recomputing them in the elevated process.

## Stack Relation

This PR is part 5 of 21 in the Windows protected metadata stack.

1. [PR 20889](https://github.com/openai/codex/pull/20889) Add Windows metadata adapter target type
2. [PR 20890](https://github.com/openai/codex/pull/20890) Add Windows metadata setup target type
3. [PR 20891](https://github.com/openai/codex/pull/20891) Add Windows metadata enforcement guard
4. [PR 21030](https://github.com/openai/codex/pull/21030) Plan Windows metadata targets from filesystem policy
5. [PR 21031](https://github.com/openai/codex/pull/21031) Thread Windows metadata targets through setup request
6. [PR 21032](https://github.com/openai/codex/pull/21032) Pass Windows metadata targets to direct exec
7. [PR 21033](https://github.com/openai/codex/pull/21033) Thread Windows metadata targets through sessions
8. [PR 21035](https://github.com/openai/codex/pull/21035) Enforce Windows protected metadata targets
9. [PR 21036](https://github.com/openai/codex/pull/21036) Deny Windows protected metadata symlink targets
10. [PR 21037](https://github.com/openai/codex/pull/21037) Use Windows metadata targets in debug sandbox
11. [PR 21038](https://github.com/openai/codex/pull/21038) Allow Windows sandbox Git signal pipes
12. [PR 21039](https://github.com/openai/codex/pull/21039) Add Windows legacy Git read root helpers
13. [PR 21040](https://github.com/openai/codex/pull/21040) Grant Windows legacy Git read roots
14. [PR 21041](https://github.com/openai/codex/pull/21041) Inject Git safe directory for Windows legacy sandbox
15. [PR 21042](https://github.com/openai/codex/pull/21042) Test Windows runtime metadata target preparation
16. [PR 21043](https://github.com/openai/codex/pull/21043) Document Windows metadata request boundary
17. [PR 21172](https://github.com/openai/codex/pull/21172) Add Windows missing metadata monitor runtime
18. [PR 21173](https://github.com/openai/codex/pull/21173) Wire Windows metadata monitor through sandbox exits
19. [PR 21174](https://github.com/openai/codex/pull/21174) Add Windows missing metadata deny sentinel
20. [PR 21175](https://github.com/openai/codex/pull/21175) Wire missing Windows metadata to deny sentinel
21. [PR 21184](https://github.com/openai/codex/pull/21184) Use direct deny ACLs for Windows metadata sentinels

## Validation

1. Stack head local format and Rust tests passed on `95ef124d6194bd2126c11928cb3973214f9ac63a`.
2. Azure Windows VM 56 case validation is running on `95ef124d6194bd2126c11928cb3973214f9ac63a`.