### PR TITLE
Pass Windows metadata targets to direct exec

### DIFF
--- a/codex-rs/core/src/exec.rs
+++ b/codex-rs/core/src/exec.rs
@@ -647,6 +647,28 @@ async fn exec_windows_sandbox(
                 .collect::<Vec<_>>()
         })
         .unwrap_or_default();
+    let protected_metadata_targets = windows_sandbox_filesystem_overrides
+        .map(|overrides| {
+            overrides
+                .protected_metadata_targets
+                .iter()
+                .map(|target| {
+                    let mode = match target.mode {
+                        WindowsProtectedMetadataMode::ExistingDeny => {
+                            codex_windows_sandbox::ProtectedMetadataMode::ExistingDeny
+                        }
+                        WindowsProtectedMetadataMode::MissingCreationMonitor => {
+                            codex_windows_sandbox::ProtectedMetadataMode::MissingCreationMonitor
+                        }
+                    };
+                    codex_windows_sandbox::ProtectedMetadataTarget {
+                        path: target.path.to_path_buf(),
+                        mode,
+                    }
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
     let spawn_res = tokio::task::spawn_blocking(move || {
         if use_elevated {
             run_windows_sandbox_capture_elevated(
@@ -665,7 +687,7 @@ async fn exec_windows_sandbox(
                         elevated_read_roots_include_platform_defaults,
                     write_roots_override: elevated_write_roots_override.as_deref(),
                     deny_write_paths_override: &elevated_deny_write_paths,
-                    protected_metadata_targets: &[],
+                    protected_metadata_targets: &protected_metadata_targets,
                 },
             )
         } else {
@@ -678,6 +700,7 @@ async fn exec_windows_sandbox(
                 env,
                 timeout_ms,
                 &additional_deny_write_paths,
+                &protected_metadata_targets,
                 windows_sandbox_private_desktop,
             )
         }

--- a/codex-rs/windows-sandbox-rs/src/lib.rs
+++ b/codex-rs/windows-sandbox-rs/src/lib.rs
@@ -258,6 +258,7 @@ pub use stub::run_windows_sandbox_legacy_preflight;
 
 #[cfg(target_os = "windows")]
 mod windows_impl {
+    use super::ProtectedMetadataTarget;
     use super::acl::add_allow_ace;
     use super::acl::add_deny_write_ace;
     use super::acl::allow_null_device;
@@ -350,6 +351,7 @@ mod windows_impl {
             env_map,
             timeout_ms,
             &[],
+            &[],
             use_private_desktop,
         )
     }
@@ -364,6 +366,7 @@ mod windows_impl {
         mut env_map: HashMap<String, String>,
         timeout_ms: Option<u64>,
         additional_deny_write_paths: &[PathBuf],
+        _protected_metadata_targets: &[ProtectedMetadataTarget],
         use_private_desktop: bool,
     ) -> Result<CaptureResult> {
         let common = prepare_legacy_spawn_context(


### PR DESCRIPTION
## Summary

1. Passes Windows protected metadata targets through direct sandbox execution.
2. Keeps the direct exec path aligned with the setup request shape.

## Why

1. Direct exec is one of the Windows sandbox entry points that must enforce protected metadata.
2. This PR wires only that entry point so review can confirm the request field is carried without mixing in session behavior.

## Stack Relation

This PR is part 6 of 21 in the Windows protected metadata stack.

1. [PR 20889](https://github.com/openai/codex/pull/20889) Add Windows metadata adapter target type
2. [PR 20890](https://github.com/openai/codex/pull/20890) Add Windows metadata setup target type
3. [PR 20891](https://github.com/openai/codex/pull/20891) Add Windows metadata enforcement guard
4. [PR 21030](https://github.com/openai/codex/pull/21030) Plan Windows metadata targets from filesystem policy
5. [PR 21031](https://github.com/openai/codex/pull/21031) Thread Windows metadata targets through setup request
6. [PR 21032](https://github.com/openai/codex/pull/21032) Pass Windows metadata targets to direct exec
7. [PR 21033](https://github.com/openai/codex/pull/21033) Thread Windows metadata targets through sessions
8. [PR 21035](https://github.com/openai/codex/pull/21035) Enforce Windows protected metadata targets
9. [PR 21036](https://github.com/openai/codex/pull/21036) Deny Windows protected metadata symlink targets
10. [PR 21037](https://github.com/openai/codex/pull/21037) Use Windows metadata targets in debug sandbox
11. [PR 21038](https://github.com/openai/codex/pull/21038) Allow Windows sandbox Git signal pipes
12. [PR 21039](https://github.com/openai/codex/pull/21039) Add Windows legacy Git read root helpers
13. [PR 21040](https://github.com/openai/codex/pull/21040) Grant Windows legacy Git read roots
14. [PR 21041](https://github.com/openai/codex/pull/21041) Inject Git safe directory for Windows legacy sandbox
15. [PR 21042](https://github.com/openai/codex/pull/21042) Test Windows runtime metadata target preparation
16. [PR 21043](https://github.com/openai/codex/pull/21043) Document Windows metadata request boundary
17. [PR 21172](https://github.com/openai/codex/pull/21172) Add Windows missing metadata monitor runtime
18. [PR 21173](https://github.com/openai/codex/pull/21173) Wire Windows metadata monitor through sandbox exits
19. [PR 21174](https://github.com/openai/codex/pull/21174) Add Windows missing metadata deny sentinel
20. [PR 21175](https://github.com/openai/codex/pull/21175) Wire missing Windows metadata to deny sentinel
21. [PR 21184](https://github.com/openai/codex/pull/21184) Use direct deny ACLs for Windows metadata sentinels

## Validation

1. Stack head local format and Rust tests passed on `95ef124d6194bd2126c11928cb3973214f9ac63a`.
2. Azure Windows VM 56 case validation is running on `95ef124d6194bd2126c11928cb3973214f9ac63a`.