### PR TITLE
Deny Windows protected metadata symlink targets

### DIFF
--- a/codex-rs/windows-sandbox-rs/src/protected_metadata.rs
+++ b/codex-rs/windows-sandbox-rs/src/protected_metadata.rs
@@ -2,6 +2,7 @@ use crate::setup::ProtectedMetadataMode;
 use crate::setup::ProtectedMetadataTarget;
 use anyhow::Context;
 use anyhow::Result;
+use std::collections::HashSet;
 use std::fs::Metadata;
 use std::io;
 use std::os::windows::fs::FileTypeExt;
@@ -60,11 +61,36 @@ pub(crate) fn prepare_protected_metadata_targets(
 }
 
 pub fn protected_metadata_existing_deny_paths(path: &Path) -> Vec<PathBuf> {
-    if std::fs::symlink_metadata(path).is_ok() {
-        vec![path.to_path_buf()]
-    } else {
-        Vec::new()
+    let Ok(metadata) = std::fs::symlink_metadata(path) else {
+        return Vec::new();
+    };
+
+    let mut seen = HashSet::new();
+    let mut paths = Vec::new();
+    push_deny_path(&mut paths, &mut seen, path.to_path_buf());
+
+    let file_type = metadata.file_type();
+    if (is_directory_reparse_point(&metadata)
+        || file_type.is_symlink_dir()
+        || file_type.is_symlink_file())
+        && let Ok(target_path) = dunce::canonicalize(path)
+    {
+        push_deny_path(&mut paths, &mut seen, target_path);
     }
+
+    paths
+}
+
+fn push_deny_path(paths: &mut Vec<PathBuf>, seen: &mut HashSet<String>, path: PathBuf) {
+    if seen.insert(path_text_key(&path)) {
+        paths.push(path);
+    }
+}
+
+fn path_text_key(path: &Path) -> String {
+    path.to_string_lossy()
+        .replace('\\', "/")
+        .to_ascii_lowercase()
 }
 
 fn existing_metadata_path(path: &Path) -> Result<Option<PathBuf>> {
@@ -168,5 +194,37 @@ mod tests {
         );
         assert!(!target.exists());
         assert!(!created.exists());
+    }
+
+    #[test]
+    fn existing_deny_paths_include_symlink_target() {
+        let temp_dir = tempfile::TempDir::new().expect("tempdir");
+        let target_dir = temp_dir.path().join("target-codex");
+        let symlink_dir = temp_dir.path().join(".codex");
+        std::fs::create_dir_all(&target_dir).expect("create target");
+        if let Err(err) = std::os::windows::fs::symlink_dir(&target_dir, &symlink_dir) {
+            eprintln!("skipping symlink test because symlink creation failed: {err}");
+            return;
+        }
+
+        let guard = prepare_protected_metadata_targets(&[ProtectedMetadataTarget {
+            path: symlink_dir.clone(),
+            mode: ProtectedMetadataMode::ExistingDeny,
+        }]);
+        let deny_paths: Vec<PathBuf> = guard.deny_paths().cloned().collect();
+        let canonical_target = dunce::canonicalize(&target_dir).expect("canonical target");
+
+        assert!(
+            deny_paths
+                .iter()
+                .any(|path| path_text_key(path) == path_text_key(&symlink_dir)),
+            "deny paths should include metadata symlink: {deny_paths:?}"
+        );
+        assert!(
+            deny_paths
+                .iter()
+                .any(|path| path_text_key(path) == path_text_key(&canonical_target)),
+            "deny paths should include symlink target: {deny_paths:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

1. Denies writes through Windows protected metadata symlink targets.
2. Extends enforcement beyond normal directory and file targets.

## Why

1. A protected metadata path can be a reparse point or symlink target, and enforcing only the link path is not sufficient.
2. This PR keeps symlink handling reviewable as a narrow behavior change after basic protected metadata enforcement exists.

## Stack Relation

This PR is part 9 of 21 in the Windows protected metadata stack.

1. [PR 20889](https://github.com/openai/codex/pull/20889) Add Windows metadata adapter target type
2. [PR 20890](https://github.com/openai/codex/pull/20890) Add Windows metadata setup target type
3. [PR 20891](https://github.com/openai/codex/pull/20891) Add Windows metadata enforcement guard
4. [PR 21030](https://github.com/openai/codex/pull/21030) Plan Windows metadata targets from filesystem policy
5. [PR 21031](https://github.com/openai/codex/pull/21031) Thread Windows metadata targets through setup request
6. [PR 21032](https://github.com/openai/codex/pull/21032) Pass Windows metadata targets to direct exec
7. [PR 21033](https://github.com/openai/codex/pull/21033) Thread Windows metadata targets through sessions
8. [PR 21035](https://github.com/openai/codex/pull/21035) Enforce Windows protected metadata targets
9. [PR 21036](https://github.com/openai/codex/pull/21036) Deny Windows protected metadata symlink targets
10. [PR 21037](https://github.com/openai/codex/pull/21037) Use Windows metadata targets in debug sandbox
11. [PR 21038](https://github.com/openai/codex/pull/21038) Allow Windows sandbox Git signal pipes
12. [PR 21039](https://github.com/openai/codex/pull/21039) Add Windows legacy Git read root helpers
13. [PR 21040](https://github.com/openai/codex/pull/21040) Grant Windows legacy Git read roots
14. [PR 21041](https://github.com/openai/codex/pull/21041) Inject Git safe directory for Windows legacy sandbox
15. [PR 21042](https://github.com/openai/codex/pull/21042) Test Windows runtime metadata target preparation
16. [PR 21043](https://github.com/openai/codex/pull/21043) Document Windows metadata request boundary
17. [PR 21172](https://github.com/openai/codex/pull/21172) Add Windows missing metadata monitor runtime
18. [PR 21173](https://github.com/openai/codex/pull/21173) Wire Windows metadata monitor through sandbox exits
19. [PR 21174](https://github.com/openai/codex/pull/21174) Add Windows missing metadata deny sentinel
20. [PR 21175](https://github.com/openai/codex/pull/21175) Wire missing Windows metadata to deny sentinel
21. [PR 21184](https://github.com/openai/codex/pull/21184) Use direct deny ACLs for Windows metadata sentinels

## Validation

1. Stack head local format and Rust tests passed on `95ef124d6194bd2126c11928cb3973214f9ac63a`.
2. Azure Windows VM 56 case validation is running on `95ef124d6194bd2126c11928cb3973214f9ac63a`.