### PR TITLE
Use Windows metadata targets in debug sandbox

### DIFF
--- a/codex-rs/cli/src/debug_sandbox.rs
+++ b/codex-rs/cli/src/debug_sandbox.rs
@@ -360,6 +360,11 @@ async fn run_command_under_windows_session(
         WindowsSandboxLevel::from_config(config),
         WindowsSandboxLevel::Elevated
     );
+    let file_system_sandbox_policy = config.permissions.file_system_sandbox_policy();
+    let protected_metadata_targets = windows_debug_protected_metadata_targets(
+        &file_system_sandbox_policy,
+        sandbox_policy_cwd.as_path(),
+    );
 
     let spawned = if use_elevated {
         spawn_windows_sandbox_session_elevated(
@@ -372,7 +377,7 @@ async fn run_command_under_windows_session(
             None,
             /*tty*/ false,
             /*stdin_open*/ true,
-            &[],
+            &protected_metadata_targets,
             config.permissions.windows_sandbox_private_desktop,
         )
         .await
@@ -387,7 +392,7 @@ async fn run_command_under_windows_session(
             None,
             /*tty*/ false,
             /*stdin_open*/ true,
-            &[],
+            &protected_metadata_targets,
             config.permissions.windows_sandbox_private_desktop,
         )
         .await
@@ -459,6 +464,31 @@ async fn run_command_under_windows_session(
     })
     .await;
     std::process::exit(exit_code);
+}
+
+#[cfg(target_os = "windows")]
+fn windows_debug_protected_metadata_targets(
+    file_system_sandbox_policy: &codex_protocol::permissions::FileSystemSandboxPolicy,
+    cwd: &std::path::Path,
+) -> Vec<codex_windows_sandbox::ProtectedMetadataTarget> {
+    let mut targets = Vec::new();
+    for writable_root in file_system_sandbox_policy.get_writable_roots_with_cwd(cwd) {
+        for metadata_name in writable_root.protected_metadata_names {
+            let path = writable_root.root.join(metadata_name);
+            let mode = if std::fs::symlink_metadata(path.as_path()).is_ok() {
+                codex_windows_sandbox::ProtectedMetadataMode::ExistingDeny
+            } else {
+                codex_windows_sandbox::ProtectedMetadataMode::MissingCreationMonitor
+            };
+            targets.push(codex_windows_sandbox::ProtectedMetadataTarget {
+                path: path.as_path().to_path_buf(),
+                mode,
+            });
+        }
+    }
+    targets.sort_by(|a, b| a.path.cmp(&b.path));
+    targets.dedup_by(|a, b| a.path == b.path && a.mode == b.mode);
+    targets
 }
 
 async fn spawn_debug_sandbox_child(


### PR DESCRIPTION
## Summary

1. Uses Windows protected metadata targets in the debug sandbox path.
2. Keeps debug behavior aligned with normal Windows sandbox setup.

## Why

1. Debug sandbox launch should exercise the same metadata protection path as normal execution.
2. Keeping this as its own PR makes the debug entry point coverage visible without mixing it into the main enforcement PR.

## Stack Relation

This PR is part 10 of 21 in the Windows protected metadata stack.

1. [PR 20889](https://github.com/openai/codex/pull/20889) Add Windows metadata adapter target type
2. [PR 20890](https://github.com/openai/codex/pull/20890) Add Windows metadata setup target type
3. [PR 20891](https://github.com/openai/codex/pull/20891) Add Windows metadata enforcement guard
4. [PR 21030](https://github.com/openai/codex/pull/21030) Plan Windows metadata targets from filesystem policy
5. [PR 21031](https://github.com/openai/codex/pull/21031) Thread Windows metadata targets through setup request
6. [PR 21032](https://github.com/openai/codex/pull/21032) Pass Windows metadata targets to direct exec
7. [PR 21033](https://github.com/openai/codex/pull/21033) Thread Windows metadata targets through sessions
8. [PR 21035](https://github.com/openai/codex/pull/21035) Enforce Windows protected metadata targets
9. [PR 21036](https://github.com/openai/codex/pull/21036) Deny Windows protected metadata symlink targets
10. [PR 21037](https://github.com/openai/codex/pull/21037) Use Windows metadata targets in debug sandbox
11. [PR 21038](https://github.com/openai/codex/pull/21038) Allow Windows sandbox Git signal pipes
12. [PR 21039](https://github.com/openai/codex/pull/21039) Add Windows legacy Git read root helpers
13. [PR 21040](https://github.com/openai/codex/pull/21040) Grant Windows legacy Git read roots
14. [PR 21041](https://github.com/openai/codex/pull/21041) Inject Git safe directory for Windows legacy sandbox
15. [PR 21042](https://github.com/openai/codex/pull/21042) Test Windows runtime metadata target preparation
16. [PR 21043](https://github.com/openai/codex/pull/21043) Document Windows metadata request boundary
17. [PR 21172](https://github.com/openai/codex/pull/21172) Add Windows missing metadata monitor runtime
18. [PR 21173](https://github.com/openai/codex/pull/21173) Wire Windows metadata monitor through sandbox exits
19. [PR 21174](https://github.com/openai/codex/pull/21174) Add Windows missing metadata deny sentinel
20. [PR 21175](https://github.com/openai/codex/pull/21175) Wire missing Windows metadata to deny sentinel
21. [PR 21184](https://github.com/openai/codex/pull/21184) Use direct deny ACLs for Windows metadata sentinels

## Validation

1. Stack head local format and Rust tests passed on `95ef124d6194bd2126c11928cb3973214f9ac63a`.
2. Azure Windows VM 56 case validation is running on `95ef124d6194bd2126c11928cb3973214f9ac63a`.