### PR TITLE
Add Windows legacy Git read root helpers

### DIFF
--- a/codex-rs/windows-sandbox-rs/src/spawn_prep.rs
+++ b/codex-rs/windows-sandbox-rs/src/spawn_prep.rs
@@ -265,6 +265,129 @@ pub(crate) fn apply_legacy_session_acl_rules(
     guards
 }
 
+#[allow(dead_code)]
+pub(crate) fn legacy_session_executable_read_roots(
+    env_map: &HashMap<String, String>,
+    command: &[String],
+) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    if let Some(program) = command.first() {
+        let program_path = PathBuf::from(program);
+        if program_path.is_absolute()
+            && let Some(parent) = program_path.parent()
+        {
+            roots.push(parent.to_path_buf());
+        }
+    }
+
+    for (name, value) in env_map {
+        if !name.eq_ignore_ascii_case("PATH") {
+            continue;
+        }
+        for path in std::env::split_paths(value) {
+            roots.push(path.clone());
+            if let Some(tool_root) = windows_tool_root_for_path_dir(&path) {
+                add_git_for_windows_support_roots(env_map, &tool_root, &mut roots);
+                roots.push(tool_root);
+            }
+        }
+    }
+
+    canonical_existing_deduped(roots)
+}
+
+#[allow(dead_code)]
+pub(crate) fn legacy_session_direct_read_paths(env_map: &HashMap<String, String>) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+
+    for home in legacy_session_home_dirs(env_map) {
+        paths.push(home.clone());
+        paths.push(home.join(".gitconfig"));
+    }
+
+    canonical_existing_deduped(paths)
+}
+
+#[allow(dead_code)]
+fn add_git_for_windows_support_roots(
+    env_map: &HashMap<String, String>,
+    tool_root: &Path,
+    roots: &mut Vec<PathBuf>,
+) {
+    let Some(name) = tool_root.file_name() else {
+        return;
+    };
+    if !name.to_string_lossy().eq_ignore_ascii_case("Git") {
+        return;
+    }
+
+    if let Some(program_data) = env_path(env_map, "PROGRAMDATA") {
+        roots.push(program_data.join("Git"));
+    }
+}
+
+#[allow(dead_code)]
+fn legacy_session_home_dirs(env_map: &HashMap<String, String>) -> Vec<PathBuf> {
+    let mut homes = Vec::new();
+
+    if let Some(user_profile) = env_path(env_map, "USERPROFILE") {
+        homes.push(user_profile);
+    }
+    if let Some(home) = env_path(env_map, "HOME") {
+        homes.push(home);
+    }
+    if let (Some(drive), Some(path)) = (
+        env_value(env_map, "HOMEDRIVE"),
+        env_value(env_map, "HOMEPATH"),
+    ) {
+        homes.push(PathBuf::from(format!("{drive}{path}")));
+    }
+
+    canonical_existing_deduped(homes)
+}
+
+#[allow(dead_code)]
+fn env_path(env_map: &HashMap<String, String>, name: &str) -> Option<PathBuf> {
+    env_value(env_map, name).map(PathBuf::from)
+}
+
+#[allow(dead_code)]
+fn env_value(env_map: &HashMap<String, String>, name: &str) -> Option<String> {
+    env_map
+        .iter()
+        .find(|(key, _)| key.eq_ignore_ascii_case(name))
+        .map(|(_, value)| value.clone())
+}
+
+#[allow(dead_code)]
+fn canonical_existing_deduped(paths: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut deduped = Vec::new();
+    for path in paths {
+        if !path.exists() {
+            continue;
+        }
+        let path = dunce::canonicalize(&path).unwrap_or(path);
+        if !deduped.iter().any(|existing| existing == &path) {
+            deduped.push(path);
+        }
+    }
+    deduped
+}
+
+#[allow(dead_code)]
+fn windows_tool_root_for_path_dir(path: &Path) -> Option<PathBuf> {
+    let name = path.file_name()?.to_string_lossy();
+    if !name.eq_ignore_ascii_case("cmd") && !name.eq_ignore_ascii_case("bin") {
+        return None;
+    }
+    let parent = path.parent()?;
+    let parent_name = parent.file_name()?.to_string_lossy();
+    if parent_name.eq_ignore_ascii_case("Git") {
+        return Some(parent.to_path_buf());
+    }
+    None
+}
+
 pub(crate) fn prepare_elevated_spawn_context(
     policy_json_or_preset: &str,
     sandbox_policy_cwd: &Path,
@@ -343,6 +466,8 @@ pub(crate) fn prepare_elevated_spawn_context(
 #[cfg(test)]
 mod tests {
     use super::SandboxPolicy;
+    use super::legacy_session_direct_read_paths;
+    use super::legacy_session_executable_read_roots;
     use super::prepare_legacy_spawn_context;
     use super::prepare_spawn_context_common;
     use super::should_apply_network_block;
@@ -419,5 +544,47 @@ mod tests {
             env_map.get("HTTP_PROXY"),
             Some(&"http://user.proxy:8080".to_string())
         );
+    }
+
+    #[test]
+    fn legacy_session_read_roots_include_git_support_roots() {
+        let tmp = TempDir::new().expect("tempdir");
+        let git_root = tmp.path().join("Git");
+        let git_cmd = git_root.join("cmd");
+        let program_data_git = tmp.path().join("ProgramData").join("Git");
+        std::fs::create_dir_all(&git_cmd).expect("create git cmd");
+        std::fs::create_dir_all(&program_data_git).expect("create programdata git");
+        let env_map = HashMap::from([
+            ("PATH".to_string(), git_cmd.to_string_lossy().to_string()),
+            (
+                "PROGRAMDATA".to_string(),
+                tmp.path().join("ProgramData").to_string_lossy().to_string(),
+            ),
+        ]);
+
+        let roots = legacy_session_executable_read_roots(&env_map, &["cmd.exe".to_string()]);
+
+        assert!(roots.contains(&dunce::canonicalize(git_root).expect("canonical git root")));
+        assert!(
+            roots.contains(&dunce::canonicalize(program_data_git).expect("canonical programdata"))
+        );
+    }
+
+    #[test]
+    fn legacy_session_direct_read_paths_include_home_git_config() {
+        let tmp = TempDir::new().expect("tempdir");
+        let home = tmp.path().join("profile");
+        std::fs::create_dir_all(&home).expect("create profile");
+        let gitconfig = home.join(".gitconfig");
+        std::fs::write(&gitconfig, "[safe]\n").expect("write git config");
+        let env_map = HashMap::from([(
+            "USERPROFILE".to_string(),
+            home.to_string_lossy().to_string(),
+        )]);
+
+        let paths = legacy_session_direct_read_paths(&env_map);
+
+        assert!(paths.contains(&dunce::canonicalize(home).expect("canonical home")));
+        assert!(paths.contains(&dunce::canonicalize(gitconfig).expect("canonical gitconfig")));
     }
 }


### PR DESCRIPTION
## Summary

1. Adds helper logic for Windows legacy Git read roots.
2. Keeps read root discovery separate from permission granting.

## Why

1. Git discovery can need access to legacy `.git` locations even when the working directory is protected.
2. This PR creates the helper boundary first so the following PR can grant exactly the read roots the helper identifies.

## Stack Relation

This PR is part 12 of 21 in the Windows protected metadata stack.

1. [PR 20889](https://github.com/openai/codex/pull/20889) Add Windows metadata adapter target type
2. [PR 20890](https://github.com/openai/codex/pull/20890) Add Windows metadata setup target type
3. [PR 20891](https://github.com/openai/codex/pull/20891) Add Windows metadata enforcement guard
4. [PR 21030](https://github.com/openai/codex/pull/21030) Plan Windows metadata targets from filesystem policy
5. [PR 21031](https://github.com/openai/codex/pull/21031) Thread Windows metadata targets through setup request
6. [PR 21032](https://github.com/openai/codex/pull/21032) Pass Windows metadata targets to direct exec
7. [PR 21033](https://github.com/openai/codex/pull/21033) Thread Windows metadata targets through sessions
8. [PR 21035](https://github.com/openai/codex/pull/21035) Enforce Windows protected metadata targets
9. [PR 21036](https://github.com/openai/codex/pull/21036) Deny Windows protected metadata symlink targets
10. [PR 21037](https://github.com/openai/codex/pull/21037) Use Windows metadata targets in debug sandbox
11. [PR 21038](https://github.com/openai/codex/pull/21038) Allow Windows sandbox Git signal pipes
12. [PR 21039](https://github.com/openai/codex/pull/21039) Add Windows legacy Git read root helpers
13. [PR 21040](https://github.com/openai/codex/pull/21040) Grant Windows legacy Git read roots
14. [PR 21041](https://github.com/openai/codex/pull/21041) Inject Git safe directory for Windows legacy sandbox
15. [PR 21042](https://github.com/openai/codex/pull/21042) Test Windows runtime metadata target preparation
16. [PR 21043](https://github.com/openai/codex/pull/21043) Document Windows metadata request boundary
17. [PR 21172](https://github.com/openai/codex/pull/21172) Add Windows missing metadata monitor runtime
18. [PR 21173](https://github.com/openai/codex/pull/21173) Wire Windows metadata monitor through sandbox exits
19. [PR 21174](https://github.com/openai/codex/pull/21174) Add Windows missing metadata deny sentinel
20. [PR 21175](https://github.com/openai/codex/pull/21175) Wire missing Windows metadata to deny sentinel
21. [PR 21184](https://github.com/openai/codex/pull/21184) Use direct deny ACLs for Windows metadata sentinels

## Validation

1. Stack head local format and Rust tests passed on `95ef124d6194bd2126c11928cb3973214f9ac63a`.
2. Azure Windows VM 56 case validation is running on `95ef124d6194bd2126c11928cb3973214f9ac63a`.