### PR TITLE
Grant Windows legacy Git read roots

### DIFF
--- a/codex-rs/windows-sandbox-rs/src/lib.rs
+++ b/codex-rs/windows-sandbox-rs/src/lib.rs
@@ -267,6 +267,8 @@ mod windows_impl {
     use super::acl::add_deny_write_ace;
     use super::acl::allow_named_pipe_device;
     use super::acl::allow_null_device;
+    use super::acl::ensure_allow_mask_aces;
+    use super::acl::ensure_allow_mask_aces_with_inheritance;
     use super::acl::revoke_ace;
     use super::allow::AllowDenyPaths;
     use super::allow::compute_allow_paths;
@@ -279,6 +281,8 @@ mod windows_impl {
     use super::process::create_process_as_user;
     use super::protected_metadata::prepare_protected_metadata_targets;
     use super::sandbox_utils::ensure_codex_home_exists;
+    use super::spawn_prep::legacy_session_direct_read_paths;
+    use super::spawn_prep::legacy_session_executable_read_roots;
     use super::spawn_prep::prepare_legacy_spawn_context;
     use super::token::convert_string_sid_to_sid;
     use super::token::create_workspace_write_token_with_caps_from;
@@ -295,6 +299,8 @@ mod windows_impl {
     use windows_sys::Win32::Foundation::HANDLE;
     use windows_sys::Win32::Foundation::HANDLE_FLAG_INHERIT;
     use windows_sys::Win32::Foundation::SetHandleInformation;
+    use windows_sys::Win32::Storage::FileSystem::FILE_GENERIC_EXECUTE;
+    use windows_sys::Win32::Storage::FileSystem::FILE_GENERIC_READ;
     use windows_sys::Win32::System::Pipes::CreatePipe;
     use windows_sys::Win32::System::Threading::GetExitCodeProcess;
     use windows_sys::Win32::System::Threading::INFINITE;
@@ -443,6 +449,8 @@ mod windows_impl {
         let persist_aces = is_workspace_write;
         let AllowDenyPaths { allow, mut deny } =
             compute_allow_paths(&policy, sandbox_policy_cwd, &current_dir, &env_map);
+        let read_roots = legacy_session_executable_read_roots(&env_map, &command);
+        let direct_read_paths = legacy_session_direct_read_paths(&env_map);
         let protected_metadata_guard =
             prepare_protected_metadata_targets(protected_metadata_targets);
         for path in protected_metadata_guard.deny_paths() {
@@ -455,7 +463,32 @@ mod windows_impl {
         }
         let canonical_cwd = canonicalize_path(&current_dir);
         let mut guards: Vec<(PathBuf, *mut c_void)> = Vec::new();
+        let read_execute_mask = FILE_GENERIC_READ | FILE_GENERIC_EXECUTE;
         unsafe {
+            let read_execute_sids: Vec<*mut c_void> = match psid_workspace {
+                Some(psid) => vec![psid_generic, psid],
+                None => vec![psid_generic],
+            };
+            for p in &read_roots {
+                if let Ok(added) = ensure_allow_mask_aces(p, &read_execute_sids, read_execute_mask)
+                    && added
+                    && !persist_aces
+                {
+                    guards.push((p.clone(), psid_generic));
+                }
+            }
+            for p in &direct_read_paths {
+                if let Ok(added) = ensure_allow_mask_aces_with_inheritance(
+                    p,
+                    &read_execute_sids,
+                    read_execute_mask,
+                    /*inheritance*/ 0,
+                ) && added
+                    && !persist_aces
+                {
+                    guards.push((p.clone(), psid_generic));
+                }
+            }
             for p in &allow {
                 let psid = if is_workspace_write && is_command_cwd_root(p, &canonical_cwd) {
                     psid_workspace.unwrap_or(psid_generic)

--- a/codex-rs/windows-sandbox-rs/src/spawn_prep.rs
+++ b/codex-rs/windows-sandbox-rs/src/spawn_prep.rs
@@ -2,6 +2,8 @@ use crate::acl::add_allow_ace;
 use crate::acl::add_deny_write_ace;
 use crate::acl::allow_named_pipe_device;
 use crate::acl::allow_null_device;
+use crate::acl::ensure_allow_mask_aces;
+use crate::acl::ensure_allow_mask_aces_with_inheritance;
 use crate::allow::AllowDenyPaths;
 use crate::allow::compute_allow_paths;
 use crate::cap::load_or_create_cap_sids;
@@ -36,6 +38,8 @@ use windows_sys::Win32::Foundation::CloseHandle;
 use windows_sys::Win32::Foundation::HANDLE;
 use windows_sys::Win32::Foundation::HLOCAL;
 use windows_sys::Win32::Foundation::LocalFree;
+use windows_sys::Win32::Storage::FileSystem::FILE_GENERIC_EXECUTE;
+use windows_sys::Win32::Storage::FileSystem::FILE_GENERIC_READ;
 
 pub(crate) struct SpawnContext {
     pub(crate) policy: SandboxPolicy,
@@ -220,6 +224,7 @@ pub(crate) fn apply_legacy_session_acl_rules(
     sandbox_policy_cwd: &Path,
     current_dir: &Path,
     env_map: &HashMap<String, String>,
+    command: &[String],
     psid_generic: &LocalSid,
     psid_workspace: Option<&LocalSid>,
     persist_aces: bool,
@@ -229,8 +234,35 @@ pub(crate) fn apply_legacy_session_acl_rules(
         compute_allow_paths(policy, sandbox_policy_cwd, current_dir, env_map);
     deny.extend(additional_deny_paths.iter().cloned());
     let mut guards: Vec<PathBuf> = Vec::new();
+    let read_roots = legacy_session_executable_read_roots(env_map, command);
+    let direct_read_paths = legacy_session_direct_read_paths(env_map);
+    let read_execute_mask = FILE_GENERIC_READ | FILE_GENERIC_EXECUTE;
     let canonical_cwd = canonicalize_path(current_dir);
     unsafe {
+        let read_execute_sids: Vec<*mut std::ffi::c_void> = match psid_workspace {
+            Some(psid_workspace) => vec![psid_generic.as_ptr(), psid_workspace.as_ptr()],
+            None => vec![psid_generic.as_ptr()],
+        };
+        for p in &read_roots {
+            if let Ok(added) = ensure_allow_mask_aces(p, &read_execute_sids, read_execute_mask)
+                && added
+                && !persist_aces
+            {
+                guards.push(p.clone());
+            }
+        }
+        for p in &direct_read_paths {
+            if let Ok(added) = ensure_allow_mask_aces_with_inheritance(
+                p,
+                &read_execute_sids,
+                read_execute_mask,
+                /*inheritance*/ 0,
+            ) && added
+                && !persist_aces
+            {
+                guards.push(p.clone());
+            }
+        }
         for p in &allow {
             let psid = if matches!(policy, SandboxPolicy::WorkspaceWrite { .. })
                 && is_command_cwd_root(p, &canonical_cwd)
@@ -265,7 +297,6 @@ pub(crate) fn apply_legacy_session_acl_rules(
     guards
 }
 
-#[allow(dead_code)]
 pub(crate) fn legacy_session_executable_read_roots(
     env_map: &HashMap<String, String>,
     command: &[String],
@@ -296,7 +327,6 @@ pub(crate) fn legacy_session_executable_read_roots(
     canonical_existing_deduped(roots)
 }
 
-#[allow(dead_code)]
 pub(crate) fn legacy_session_direct_read_paths(env_map: &HashMap<String, String>) -> Vec<PathBuf> {
     let mut paths = Vec::new();
 
@@ -308,7 +338,6 @@ pub(crate) fn legacy_session_direct_read_paths(env_map: &HashMap<String, String>
     canonical_existing_deduped(paths)
 }
 
-#[allow(dead_code)]
 fn add_git_for_windows_support_roots(
     env_map: &HashMap<String, String>,
     tool_root: &Path,
@@ -326,7 +355,6 @@ fn add_git_for_windows_support_roots(
     }
 }
 
-#[allow(dead_code)]
 fn legacy_session_home_dirs(env_map: &HashMap<String, String>) -> Vec<PathBuf> {
     let mut homes = Vec::new();
 
@@ -346,12 +374,10 @@ fn legacy_session_home_dirs(env_map: &HashMap<String, String>) -> Vec<PathBuf> {
     canonical_existing_deduped(homes)
 }
 
-#[allow(dead_code)]
 fn env_path(env_map: &HashMap<String, String>, name: &str) -> Option<PathBuf> {
     env_value(env_map, name).map(PathBuf::from)
 }
 
-#[allow(dead_code)]
 fn env_value(env_map: &HashMap<String, String>, name: &str) -> Option<String> {
     env_map
         .iter()
@@ -359,7 +385,6 @@ fn env_value(env_map: &HashMap<String, String>, name: &str) -> Option<String> {
         .map(|(_, value)| value.clone())
 }
 
-#[allow(dead_code)]
 fn canonical_existing_deduped(paths: Vec<PathBuf>) -> Vec<PathBuf> {
     let mut deduped = Vec::new();
     for path in paths {
@@ -374,7 +399,6 @@ fn canonical_existing_deduped(paths: Vec<PathBuf>) -> Vec<PathBuf> {
     deduped
 }
 
-#[allow(dead_code)]
 fn windows_tool_root_for_path_dir(path: &Path) -> Option<PathBuf> {
     let name = path.file_name()?.to_string_lossy();
     if !name.eq_ignore_ascii_case("cmd") && !name.eq_ignore_ascii_case("bin") {

--- a/codex-rs/windows-sandbox-rs/src/unified_exec/backends/legacy.rs
+++ b/codex-rs/windows-sandbox-rs/src/unified_exec/backends/legacy.rs
@@ -337,6 +337,7 @@ pub(crate) async fn spawn_windows_sandbox_session_legacy(
         sandbox_policy_cwd,
         &common.current_dir,
         &env_map,
+        &command,
         &security.psid_generic,
         security.psid_workspace.as_ref(),
         persist_aces,


### PR DESCRIPTION
## Summary

1. Grants Windows legacy Git read roots to the sandbox.
2. Uses the helper introduced in the previous PR to keep the grant list scoped.

## Why

1. Existing Git repositories should remain discoverable even while protected metadata cannot be modified.
2. This PR wires the read only compatibility grants after the helper logic is available.

## Stack Relation

This PR is part 13 of 21 in the Windows protected metadata stack.

1. [PR 20889](https://github.com/openai/codex/pull/20889) Add Windows metadata adapter target type
2. [PR 20890](https://github.com/openai/codex/pull/20890) Add Windows metadata setup target type
3. [PR 20891](https://github.com/openai/codex/pull/20891) Add Windows metadata enforcement guard
4. [PR 21030](https://github.com/openai/codex/pull/21030) Plan Windows metadata targets from filesystem policy
5. [PR 21031](https://github.com/openai/codex/pull/21031) Thread Windows metadata targets through setup request
6. [PR 21032](https://github.com/openai/codex/pull/21032) Pass Windows metadata targets to direct exec
7. [PR 21033](https://github.com/openai/codex/pull/21033) Thread Windows metadata targets through sessions
8. [PR 21035](https://github.com/openai/codex/pull/21035) Enforce Windows protected metadata targets
9. [PR 21036](https://github.com/openai/codex/pull/21036) Deny Windows protected metadata symlink targets
10. [PR 21037](https://github.com/openai/codex/pull/21037) Use Windows metadata targets in debug sandbox
11. [PR 21038](https://github.com/openai/codex/pull/21038) Allow Windows sandbox Git signal pipes
12. [PR 21039](https://github.com/openai/codex/pull/21039) Add Windows legacy Git read root helpers
13. [PR 21040](https://github.com/openai/codex/pull/21040) Grant Windows legacy Git read roots
14. [PR 21041](https://github.com/openai/codex/pull/21041) Inject Git safe directory for Windows legacy sandbox
15. [PR 21042](https://github.com/openai/codex/pull/21042) Test Windows runtime metadata target preparation
16. [PR 21043](https://github.com/openai/codex/pull/21043) Document Windows metadata request boundary
17. [PR 21172](https://github.com/openai/codex/pull/21172) Add Windows missing metadata monitor runtime
18. [PR 21173](https://github.com/openai/codex/pull/21173) Wire Windows metadata monitor through sandbox exits
19. [PR 21174](https://github.com/openai/codex/pull/21174) Add Windows missing metadata deny sentinel
20. [PR 21175](https://github.com/openai/codex/pull/21175) Wire missing Windows metadata to deny sentinel
21. [PR 21184](https://github.com/openai/codex/pull/21184) Use direct deny ACLs for Windows metadata sentinels

## Validation

1. Stack head local format and Rust tests passed on `95ef124d6194bd2126c11928cb3973214f9ac63a`.
2. Azure Windows VM 56 case validation is running on `95ef124d6194bd2126c11928cb3973214f9ac63a`.