### PR TITLE
Inject Git safe directory for Windows legacy sandbox

### DIFF
--- a/codex-rs/windows-sandbox-rs/src/lib.rs
+++ b/codex-rs/windows-sandbox-rs/src/lib.rs
@@ -388,7 +388,7 @@ mod windows_impl {
             &mut env_map,
             &command,
             /*inherit_path*/ false,
-            /*add_git_safe_directory*/ false,
+            /*add_git_safe_directory*/ true,
         )?;
         let policy = common.policy;
         let current_dir = common.current_dir;

--- a/codex-rs/windows-sandbox-rs/src/unified_exec/backends/legacy.rs
+++ b/codex-rs/windows-sandbox-rs/src/unified_exec/backends/legacy.rs
@@ -320,7 +320,7 @@ pub(crate) async fn spawn_windows_sandbox_session_legacy(
         &mut env_map,
         &command,
         /*inherit_path*/ false,
-        /*add_git_safe_directory*/ false,
+        /*add_git_safe_directory*/ true,
     )?;
     if !common.policy.has_full_disk_read_access() {
         anyhow::bail!("Restricted read-only access requires the elevated Windows sandbox backend");


### PR DESCRIPTION
## Summary

1. Injects Git safe directory configuration for Windows legacy sandbox runs.
2. Keeps Git trust configuration separate from ACL and read root changes.

## Why

1. Git may reject repositories inside the sandbox if the protected metadata and sandbox identity make ownership look unsafe.
2. This PR adds the minimal safe directory setup needed for Git discovery to work with the earlier compatibility grants.

## Stack Relation

This PR is part 14 of 21 in the Windows protected metadata stack.

1. [PR 20889](https://github.com/openai/codex/pull/20889) Add Windows metadata adapter target type
2. [PR 20890](https://github.com/openai/codex/pull/20890) Add Windows metadata setup target type
3. [PR 20891](https://github.com/openai/codex/pull/20891) Add Windows metadata enforcement guard
4. [PR 21030](https://github.com/openai/codex/pull/21030) Plan Windows metadata targets from filesystem policy
5. [PR 21031](https://github.com/openai/codex/pull/21031) Thread Windows metadata targets through setup request
6. [PR 21032](https://github.com/openai/codex/pull/21032) Pass Windows metadata targets to direct exec
7. [PR 21033](https://github.com/openai/codex/pull/21033) Thread Windows metadata targets through sessions
8. [PR 21035](https://github.com/openai/codex/pull/21035) Enforce Windows protected metadata targets
9. [PR 21036](https://github.com/openai/codex/pull/21036) Deny Windows protected metadata symlink targets
10. [PR 21037](https://github.com/openai/codex/pull/21037) Use Windows metadata targets in debug sandbox
11. [PR 21038](https://github.com/openai/codex/pull/21038) Allow Windows sandbox Git signal pipes
12. [PR 21039](https://github.com/openai/codex/pull/21039) Add Windows legacy Git read root helpers
13. [PR 21040](https://github.com/openai/codex/pull/21040) Grant Windows legacy Git read roots
14. [PR 21041](https://github.com/openai/codex/pull/21041) Inject Git safe directory for Windows legacy sandbox
15. [PR 21042](https://github.com/openai/codex/pull/21042) Test Windows runtime metadata target preparation
16. [PR 21043](https://github.com/openai/codex/pull/21043) Document Windows metadata request boundary
17. [PR 21172](https://github.com/openai/codex/pull/21172) Add Windows missing metadata monitor runtime
18. [PR 21173](https://github.com/openai/codex/pull/21173) Wire Windows metadata monitor through sandbox exits
19. [PR 21174](https://github.com/openai/codex/pull/21174) Add Windows missing metadata deny sentinel
20. [PR 21175](https://github.com/openai/codex/pull/21175) Wire missing Windows metadata to deny sentinel
21. [PR 21184](https://github.com/openai/codex/pull/21184) Use direct deny ACLs for Windows metadata sentinels

## Validation

1. Stack head local format and Rust tests passed on `95ef124d6194bd2126c11928cb3973214f9ac63a`.
2. Azure Windows VM 56 case validation is running on `95ef124d6194bd2126c11928cb3973214f9ac63a`.