### PR TITLE
Test Windows runtime metadata target preparation

### DIFF
--- a/codex-rs/core/src/exec_tests.rs
+++ b/codex-rs/core/src/exec_tests.rs
@@ -920,6 +920,74 @@ fn windows_metadata_plan_does_not_materialize_nested_missing_git() {
 }
 
 #[test]
+fn windows_shell_runtime_path_resolves_metadata_overrides() {
+    let temp_dir = tempfile::TempDir::new().expect("tempdir");
+    let cwd = dunce::canonicalize(temp_dir.path())
+        .expect("canonical temp dir")
+        .abs();
+    let manager = codex_sandboxing::SandboxManager::new();
+    let permissions = PermissionProfile::workspace_write_with(
+        &[],
+        NetworkSandboxPolicy::Restricted,
+        /*exclude_tmpdir_env_var*/ true,
+        /*exclude_slash_tmp*/ true,
+    );
+    let request = manager
+        .transform(codex_sandboxing::SandboxTransformRequest {
+            command: codex_sandboxing::SandboxCommand {
+                program: "cmd.exe".into(),
+                args: vec!["/c".to_string(), "echo ok".to_string()],
+                cwd: cwd.clone(),
+                env: HashMap::new(),
+                additional_permissions: None,
+            },
+            permissions: &permissions,
+            sandbox: SandboxType::WindowsRestrictedToken,
+            enforce_managed_network: false,
+            network: None,
+            sandbox_policy_cwd: &cwd,
+            codex_linux_sandbox_exe: None,
+            use_legacy_landlock: false,
+            windows_sandbox_level: WindowsSandboxLevel::RestrictedToken,
+            windows_sandbox_private_desktop: false,
+        })
+        .expect("transform");
+    let mut exec_request = crate::sandboxing::ExecRequest::from_sandbox_exec_request(
+        request,
+        crate::sandboxing::ExecOptions {
+            expiration: ExecExpiration::DefaultTimeout,
+            capture_policy: ExecCapturePolicy::ShellTool,
+        },
+        cwd.clone(),
+    );
+
+    assert_eq!(exec_request.windows_sandbox_filesystem_overrides, None);
+
+    ensure_windows_sandbox_filesystem_overrides(&mut exec_request).expect("resolve overrides");
+
+    let overrides = exec_request
+        .windows_sandbox_filesystem_overrides
+        .expect("metadata overrides");
+    assert_eq!(
+        overrides.protected_metadata_targets,
+        vec![
+            WindowsProtectedMetadataTarget {
+                path: cwd.join(".agents"),
+                mode: WindowsProtectedMetadataMode::MissingCreationMonitor,
+            },
+            WindowsProtectedMetadataTarget {
+                path: cwd.join(".codex"),
+                mode: WindowsProtectedMetadataMode::MissingCreationMonitor,
+            },
+            WindowsProtectedMetadataTarget {
+                path: cwd.join(".git"),
+                mode: WindowsProtectedMetadataMode::MissingCreationMonitor,
+            },
+        ]
+    );
+}
+
+#[test]
 fn windows_elevated_rejects_unreadable_split_carveouts() {
     let temp_dir = tempfile::TempDir::new().expect("tempdir");
     let blocked = temp_dir.path().join("blocked");


### PR DESCRIPTION
## Summary

1. Adds focused tests for Windows runtime metadata target preparation.
2. Covers the target preparation behavior before the stack moves into documentation and monitor work.

## Why

1. The enforcement stack depends on target preparation producing the exact paths setup will protect.
2. This PR gives reviewers a narrow regression point for the runtime preparation path without adding unrelated behavior.

## Stack Relation

This PR is part 15 of 21 in the Windows protected metadata stack.

1. [PR 20889](https://github.com/openai/codex/pull/20889) Add Windows metadata adapter target type
2. [PR 20890](https://github.com/openai/codex/pull/20890) Add Windows metadata setup target type
3. [PR 20891](https://github.com/openai/codex/pull/20891) Add Windows metadata enforcement guard
4. [PR 21030](https://github.com/openai/codex/pull/21030) Plan Windows metadata targets from filesystem policy
5. [PR 21031](https://github.com/openai/codex/pull/21031) Thread Windows metadata targets through setup request
6. [PR 21032](https://github.com/openai/codex/pull/21032) Pass Windows metadata targets to direct exec
7. [PR 21033](https://github.com/openai/codex/pull/21033) Thread Windows metadata targets through sessions
8. [PR 21035](https://github.com/openai/codex/pull/21035) Enforce Windows protected metadata targets
9. [PR 21036](https://github.com/openai/codex/pull/21036) Deny Windows protected metadata symlink targets
10. [PR 21037](https://github.com/openai/codex/pull/21037) Use Windows metadata targets in debug sandbox
11. [PR 21038](https://github.com/openai/codex/pull/21038) Allow Windows sandbox Git signal pipes
12. [PR 21039](https://github.com/openai/codex/pull/21039) Add Windows legacy Git read root helpers
13. [PR 21040](https://github.com/openai/codex/pull/21040) Grant Windows legacy Git read roots
14. [PR 21041](https://github.com/openai/codex/pull/21041) Inject Git safe directory for Windows legacy sandbox
15. [PR 21042](https://github.com/openai/codex/pull/21042) Test Windows runtime metadata target preparation
16. [PR 21043](https://github.com/openai/codex/pull/21043) Document Windows metadata request boundary
17. [PR 21172](https://github.com/openai/codex/pull/21172) Add Windows missing metadata monitor runtime
18. [PR 21173](https://github.com/openai/codex/pull/21173) Wire Windows metadata monitor through sandbox exits
19. [PR 21174](https://github.com/openai/codex/pull/21174) Add Windows missing metadata deny sentinel
20. [PR 21175](https://github.com/openai/codex/pull/21175) Wire missing Windows metadata to deny sentinel
21. [PR 21184](https://github.com/openai/codex/pull/21184) Use direct deny ACLs for Windows metadata sentinels

## Validation

1. Stack head local format and Rust tests passed on `95ef124d6194bd2126c11928cb3973214f9ac63a`.
2. Azure Windows VM 56 case validation is running on `95ef124d6194bd2126c11928cb3973214f9ac63a`.