### PR TITLE
Document Windows metadata request boundary

### DIFF
--- a/codex-rs/windows-sandbox-rs/src/setup_main_win.rs
+++ b/codex-rs/windows-sandbox-rs/src/setup_main_win.rs
@@ -79,6 +79,8 @@ use sandbox_users::resolve_sandbox_users_group_sid;
 use sandbox_users::resolve_sid;
 use sandbox_users::sid_bytes_to_psid;
 
+/// Layer: Windows enforcement request boundary. Helper-process copy of the
+/// setup payload decoded from the orchestrator.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 struct Payload {
     version: u32,

--- a/codex-rs/windows-sandbox-rs/src/setup_orchestrator.rs
+++ b/codex-rs/windows-sandbox-rs/src/setup_orchestrator.rs
@@ -91,6 +91,9 @@ pub struct SandboxSetupRequest<'a> {
     pub proxy_enforced: bool,
 }
 
+/// Layer: Windows enforcement request boundary. These overrides are already
+/// projected by the adapter layer; setup code only packages them for the helper
+/// process.
 #[derive(Default)]
 pub struct SetupRootOverrides {
     pub read_roots: Option<Vec<PathBuf>>,
@@ -430,6 +433,8 @@ pub(crate) fn gather_write_roots(
     out
 }
 
+/// Layer: Windows enforcement request boundary. Serialized setup-helper process
+/// input; this carries prepared enforcement data, not policy decisions.
 #[derive(Serialize)]
 struct ElevationPayload {
     version: u32,


### PR DESCRIPTION
## Summary

1. Documents the Windows protected metadata request boundary.
2. Records which layer owns policy planning, setup payloads, and enforcement.

## Why

1. The stack crosses core policy, Windows setup, and runtime enforcement, so reviewers need the contract written down.
2. This PR documents the boundary after the initial behavior and tests exist, before the missing metadata monitor is added.

## Stack Relation

This PR is part 16 of 21 in the Windows protected metadata stack.

1. [PR 20889](https://github.com/openai/codex/pull/20889) Add Windows metadata adapter target type
2. [PR 20890](https://github.com/openai/codex/pull/20890) Add Windows metadata setup target type
3. [PR 20891](https://github.com/openai/codex/pull/20891) Add Windows metadata enforcement guard
4. [PR 21030](https://github.com/openai/codex/pull/21030) Plan Windows metadata targets from filesystem policy
5. [PR 21031](https://github.com/openai/codex/pull/21031) Thread Windows metadata targets through setup request
6. [PR 21032](https://github.com/openai/codex/pull/21032) Pass Windows metadata targets to direct exec
7. [PR 21033](https://github.com/openai/codex/pull/21033) Thread Windows metadata targets through sessions
8. [PR 21035](https://github.com/openai/codex/pull/21035) Enforce Windows protected metadata targets
9. [PR 21036](https://github.com/openai/codex/pull/21036) Deny Windows protected metadata symlink targets
10. [PR 21037](https://github.com/openai/codex/pull/21037) Use Windows metadata targets in debug sandbox
11. [PR 21038](https://github.com/openai/codex/pull/21038) Allow Windows sandbox Git signal pipes
12. [PR 21039](https://github.com/openai/codex/pull/21039) Add Windows legacy Git read root helpers
13. [PR 21040](https://github.com/openai/codex/pull/21040) Grant Windows legacy Git read roots
14. [PR 21041](https://github.com/openai/codex/pull/21041) Inject Git safe directory for Windows legacy sandbox
15. [PR 21042](https://github.com/openai/codex/pull/21042) Test Windows runtime metadata target preparation
16. [PR 21043](https://github.com/openai/codex/pull/21043) Document Windows metadata request boundary
17. [PR 21172](https://github.com/openai/codex/pull/21172) Add Windows missing metadata monitor runtime
18. [PR 21173](https://github.com/openai/codex/pull/21173) Wire Windows metadata monitor through sandbox exits
19. [PR 21174](https://github.com/openai/codex/pull/21174) Add Windows missing metadata deny sentinel
20. [PR 21175](https://github.com/openai/codex/pull/21175) Wire missing Windows metadata to deny sentinel
21. [PR 21184](https://github.com/openai/codex/pull/21184) Use direct deny ACLs for Windows metadata sentinels

## Validation

1. Stack head local format and Rust tests passed on `95ef124d6194bd2126c11928cb3973214f9ac63a`.
2. Azure Windows VM 56 case validation is running on `95ef124d6194bd2126c11928cb3973214f9ac63a`.