### PR TITLE
tui: handle terminal thread-read fallback errors

### DIFF
--- a/codex-rs/tui/src/app/session_lifecycle.rs
+++ b/codex-rs/tui/src/app/session_lifecycle.rs
@@ -103,6 +103,12 @@ impl App {
         })
     }
 
+    fn unavailable_live_thread_attach_error(thread_id: ThreadId) -> color_eyre::Report {
+        color_eyre::eyre::eyre!(
+            "Agent thread {thread_id} is not yet available for replay or live attach."
+        )
+    }
+
     /// Updates cached picker metadata and then mirrors any visible-label change into the footer.
     ///
     /// These two writes stay paired so the picker rows and contextual footer continue to describe
@@ -226,9 +232,16 @@ impl App {
                         (thread, turns)
                     }
                     Err(err) if Self::can_fallback_from_include_turns_error(&err) => {
-                        let thread = app_server
+                        let thread = match app_server
                             .thread_read(thread_id, /*include_turns*/ false)
-                            .await?;
+                            .await
+                        {
+                            Ok(thread) => thread,
+                            Err(err) if Self::is_terminal_thread_read_error(&err) => {
+                                return Err(Self::unavailable_live_thread_attach_error(thread_id));
+                            }
+                            Err(err) => return Err(err),
+                        };
                         (thread, Vec::new())
                     }
                     Err(err) => return Err(err),
@@ -236,9 +249,7 @@ impl App {
                 if turns.is_empty() {
                     // A `thread/read` fallback without turns would create a blank local replay
                     // channel with no live listener attached, which blocks later real re-attach.
-                    return Err(color_eyre::eyre::eyre!(
-                        "Agent thread {thread_id} is not yet available for replay or live attach."
-                    ));
+                    return Err(Self::unavailable_live_thread_attach_error(thread_id));
                 }
                 let mut session = self.session_state_for_thread_read(thread_id, &thread).await;
                 // `thread/read` can seed replay state, but it does not attach the app-server


### PR DESCRIPTION
## Why

The TUI live-attach fallback path can race when a thread appears in picker metadata but is no longer loaded by the app-server. In that case, `thread/read` with `includeTurns: true` can fail with the expected fallback condition, but the follow-up metadata-only `thread/read` can then return a terminal `thread not loaded` error instead of an empty thread payload.

That leaked a low-level `thread/read failed during TUI session lookup` error and made `attach_live_thread_for_selection_rejects_empty_non_ephemeral_fallback_threads` flaky. The user-facing behavior should be the same as the empty fallback case: the thread is not yet available for replay or live attach.

Net effect: selecting a not-yet-materialized/unavailable subagent no longer creates a blank replay channel and no longer leaks the raw "thread not loaded" error.

## What changed

- Added a shared helper for the unavailable live-attach error message.
- When metadata-only fallback `thread/read` returns a terminal `thread not loaded` error, map it to the same unavailable-thread error used for empty fallback reads.
- Preserve non-terminal `thread/read` errors so transient or unexpected failures still surface normally.

## Verification

- `cargo test -p codex-tui attach_live_thread_for_selection_rejects_empty_non_ephemeral_fallback_threads -- --nocapture`