### PR TITLE
Fix Linux tmp project test isolation

### DIFF
--- a/codex-rs/core-skills/src/loader_tests.rs
+++ b/codex-rs/core-skills/src/loader_tests.rs
@@ -80,6 +80,21 @@ fn project_layers_for_cwd(cwd: &Path) -> Vec<ConfigLayerEntry> {
 }
 
 async fn make_config_for_cwd(codex_home: &TempDir, cwd: PathBuf) -> TestConfig {
+    make_config_for_cwd_inner(
+        codex_home,
+        cwd,
+        TomlValue::Table(toml::map::Map::new()),
+        /*include_project_layers*/ true,
+    )
+    .await
+}
+
+async fn make_config_for_cwd_inner(
+    codex_home: &TempDir,
+    cwd: PathBuf,
+    system_config: TomlValue,
+    include_project_layers: bool,
+) -> TestConfig {
     let user_config_path = codex_home.path().join(CONFIG_TOML_FILE);
     let system_config_path = codex_home.path().join("etc/codex/config.toml");
     fs::create_dir_all(
@@ -94,7 +109,7 @@ async fn make_config_for_cwd(codex_home: &TempDir, cwd: PathBuf) -> TestConfig {
             ConfigLayerSource::System {
                 file: config_file(system_config_path),
             },
-            TomlValue::Table(toml::map::Map::new()),
+            system_config,
         ),
         ConfigLayerEntry::new(
             ConfigLayerSource::User {
@@ -103,7 +118,9 @@ async fn make_config_for_cwd(codex_home: &TempDir, cwd: PathBuf) -> TestConfig {
             TomlValue::Table(toml::map::Map::new()),
         ),
     ];
-    layers.extend(project_layers_for_cwd(&cwd));
+    if include_project_layers {
+        layers.extend(project_layers_for_cwd(&cwd));
+    }
 
     let cwd_abs = cwd.abs();
     TestConfig {
@@ -1702,7 +1719,20 @@ async fn non_git_repo_skills_search_does_not_walk_parents() {
         "from outer",
     );
 
-    let cfg = make_config_for_cwd(&codex_home, nested_dir).await;
+    let mut system_config = toml::map::Map::new();
+    system_config.insert(
+        "project_root_markers".to_string(),
+        TomlValue::Array(vec![TomlValue::String(
+            "__codex_test_project_root_marker_that_does_not_exist__".to_string(),
+        )]),
+    );
+    let cfg = make_config_for_cwd_inner(
+        &codex_home,
+        nested_dir,
+        TomlValue::Table(system_config),
+        /*include_project_layers*/ false,
+    )
+    .await;
 
     let outcome = load_skills_for_test(&cfg).await;
     assert!(
@@ -1746,6 +1776,7 @@ async fn loads_skills_from_system_cache_when_present() {
 #[tokio::test]
 async fn skill_roots_include_admin_with_lowest_priority() {
     let codex_home = tempfile::tempdir().expect("tempdir");
+    mark_as_git_repo(codex_home.path());
     let cfg = make_config(&codex_home).await;
 
     let scopes: Vec<SkillScope> = super::skill_roots(

--- a/codex-rs/core-skills/src/loader_tests.rs
+++ b/codex-rs/core-skills/src/loader_tests.rs
@@ -80,20 +80,14 @@ fn project_layers_for_cwd(cwd: &Path) -> Vec<ConfigLayerEntry> {
 }
 
 async fn make_config_for_cwd(codex_home: &TempDir, cwd: PathBuf) -> TestConfig {
-    make_config_for_cwd_inner(
-        codex_home,
-        cwd,
-        TomlValue::Table(toml::map::Map::new()),
-        /*include_project_layers*/ true,
-    )
-    .await
+    make_config_for_cwd_with_system_config(codex_home, cwd, TomlValue::Table(toml::map::Map::new()))
+        .await
 }
 
-async fn make_config_for_cwd_inner(
+async fn make_config_for_cwd_with_system_config(
     codex_home: &TempDir,
     cwd: PathBuf,
     system_config: TomlValue,
-    include_project_layers: bool,
 ) -> TestConfig {
     let user_config_path = codex_home.path().join(CONFIG_TOML_FILE);
     let system_config_path = codex_home.path().join("etc/codex/config.toml");
@@ -118,9 +112,7 @@ async fn make_config_for_cwd_inner(
             TomlValue::Table(toml::map::Map::new()),
         ),
     ];
-    if include_project_layers {
-        layers.extend(project_layers_for_cwd(&cwd));
-    }
+    layers.extend(project_layers_for_cwd(&cwd));
 
     let cwd_abs = cwd.abs();
     TestConfig {
@@ -1708,12 +1700,10 @@ async fn non_git_repo_skills_search_does_not_walk_parents() {
     let outer_dir = tempfile::tempdir().expect("tempdir");
     let nested_dir = outer_dir.path().join("nested/inner");
     fs::create_dir_all(&nested_dir).unwrap();
+    mark_as_git_repo(&nested_dir);
 
     write_skill_at(
-        &outer_dir
-            .path()
-            .join(REPO_ROOT_CONFIG_DIR_NAME)
-            .join(SKILLS_DIR_NAME),
+        &outer_dir.path().join(AGENTS_DIR_NAME).join(SKILLS_DIR_NAME),
         "outer",
         "outer-skill",
         "from outer",
@@ -1726,11 +1716,10 @@ async fn non_git_repo_skills_search_does_not_walk_parents() {
             "__codex_test_project_root_marker_that_does_not_exist__".to_string(),
         )]),
     );
-    let cfg = make_config_for_cwd_inner(
+    let cfg = make_config_for_cwd_with_system_config(
         &codex_home,
         nested_dir,
         TomlValue::Table(system_config),
-        /*include_project_layers*/ false,
     )
     .await;
 

--- a/codex-rs/secrets/src/lib.rs
+++ b/codex-rs/secrets/src/lib.rs
@@ -191,13 +191,8 @@ mod tests {
         let cwd = PathBuf::from(std::path::MAIN_SEPARATOR.to_string())
             .join("codex-secrets-test-missing-cwd");
         let env_id = environment_id_from_cwd(&cwd);
-        let canonical = cwd
-            .canonicalize()
-            .unwrap_or_else(|_| cwd.clone())
-            .to_string_lossy()
-            .into_owned();
         let mut hasher = Sha256::new();
-        hasher.update(canonical.as_bytes());
+        hasher.update(cwd.to_string_lossy().as_bytes());
         let digest = hasher.finalize();
         let hex = format!("{digest:x}");
         let short = hex.get(..12).expect("digest has at least 12 chars");

--- a/codex-rs/secrets/src/lib.rs
+++ b/codex-rs/secrets/src/lib.rs
@@ -188,12 +188,12 @@ mod tests {
 
     #[test]
     fn environment_id_fallback_has_cwd_prefix() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let env_id = environment_id_from_cwd(dir.path());
-        let canonical = dir
-            .path()
+        let cwd = PathBuf::from(std::path::MAIN_SEPARATOR.to_string())
+            .join("codex-secrets-test-missing-cwd");
+        let env_id = environment_id_from_cwd(&cwd);
+        let canonical = cwd
             .canonicalize()
-            .expect("tempdir canonical path should exist")
+            .unwrap_or_else(|_| cwd.clone())
             .to_string_lossy()
             .into_owned();
         let mut hasher = Sha256::new();

--- a/codex-rs/tui/src/chatwidget/tests/helpers.rs
+++ b/codex-rs/tui/src/chatwidget/tests/helpers.rs
@@ -3,21 +3,6 @@ use codex_app_server_protocol::PluginAvailability;
 use pretty_assertions::assert_eq;
 use std::sync::OnceLock;
 
-fn isolated_test_project_path() -> &'static PathBuf {
-    static TEST_PROJECT_PATH: OnceLock<PathBuf> = OnceLock::new();
-    TEST_PROJECT_PATH.get_or_init(|| {
-        let root = tempfile::Builder::new()
-            .prefix("chatwidget-project-")
-            .tempdir()
-            .expect("tempdir")
-            .keep();
-        let project = root.join("project");
-        std::fs::create_dir_all(&project).expect("create test project dir");
-        std::fs::write(project.join(".git"), "gitdir: fake\n").expect("mark test project as git");
-        project
-    })
-}
-
 pub(super) async fn test_config() -> Config {
     // Start from the built-in defaults so tests do not inherit host/system config.
     let codex_home = tempfile::Builder::new()
@@ -32,7 +17,7 @@ pub(super) async fn test_config() -> Config {
     config.codex_home = codex_home.abs();
     config.sqlite_home = codex_home.clone();
     config.log_dir = codex_home.join("log");
-    config.cwd = isolated_test_project_path().clone().abs();
+    config.cwd = test_project_path().abs();
     config.config_layer_stack = ConfigLayerStack::default();
     config.startup_warnings.clear();
     config.user_instructions = None;
@@ -40,7 +25,19 @@ pub(super) async fn test_config() -> Config {
 }
 
 pub(super) fn test_project_path() -> PathBuf {
-    isolated_test_project_path().clone()
+    static TEST_PROJECT_PATH: OnceLock<PathBuf> = OnceLock::new();
+    TEST_PROJECT_PATH
+        .get_or_init(|| {
+            let root = tempfile::Builder::new()
+                .prefix("chatwidget-project-")
+                .tempdir()
+                .expect("tempdir")
+                .keep();
+            let project = root.join("project");
+            std::fs::create_dir_all(project.join(".git")).expect("create test project git marker");
+            project
+        })
+        .clone()
 }
 
 pub(super) fn truncated_path_variants(path: &str) -> Vec<String> {
@@ -53,7 +50,7 @@ pub(super) fn truncated_path_variants(path: &str) -> Vec<String> {
 pub(super) fn normalize_snapshot_paths(text: impl Into<String>) -> String {
     let mut text = text.into();
 
-    let isolated_project = isolated_test_project_path().to_string_lossy().into_owned();
+    let isolated_project = test_project_path().to_string_lossy().into_owned();
     text = text.replace(&isolated_project, "/tmp/project");
 
     for unix_path in ["/tmp/project", "/tmp/hooks.json"] {

--- a/codex-rs/tui/src/chatwidget/tests/helpers.rs
+++ b/codex-rs/tui/src/chatwidget/tests/helpers.rs
@@ -1,6 +1,22 @@
 use super::*;
 use codex_app_server_protocol::PluginAvailability;
 use pretty_assertions::assert_eq;
+use std::sync::OnceLock;
+
+fn isolated_test_project_path() -> &'static PathBuf {
+    static TEST_PROJECT_PATH: OnceLock<PathBuf> = OnceLock::new();
+    TEST_PROJECT_PATH.get_or_init(|| {
+        let root = tempfile::Builder::new()
+            .prefix("chatwidget-project-")
+            .tempdir()
+            .expect("tempdir")
+            .keep();
+        let project = root.join("project");
+        std::fs::create_dir_all(&project).expect("create test project dir");
+        std::fs::write(project.join(".git"), "gitdir: fake\n").expect("mark test project as git");
+        project
+    })
+}
 
 pub(super) async fn test_config() -> Config {
     // Start from the built-in defaults so tests do not inherit host/system config.
@@ -16,7 +32,7 @@ pub(super) async fn test_config() -> Config {
     config.codex_home = codex_home.abs();
     config.sqlite_home = codex_home.clone();
     config.log_dir = codex_home.join("log");
-    config.cwd = PathBuf::from(test_path_display("/tmp/project")).abs();
+    config.cwd = isolated_test_project_path().clone().abs();
     config.config_layer_stack = ConfigLayerStack::default();
     config.startup_warnings.clear();
     config.user_instructions = None;
@@ -24,7 +40,7 @@ pub(super) async fn test_config() -> Config {
 }
 
 pub(super) fn test_project_path() -> PathBuf {
-    PathBuf::from(test_path_display("/tmp/project"))
+    isolated_test_project_path().clone()
 }
 
 pub(super) fn truncated_path_variants(path: &str) -> Vec<String> {
@@ -36,6 +52,9 @@ pub(super) fn truncated_path_variants(path: &str) -> Vec<String> {
 
 pub(super) fn normalize_snapshot_paths(text: impl Into<String>) -> String {
     let mut text = text.into();
+
+    let isolated_project = isolated_test_project_path().to_string_lossy().into_owned();
+    text = text.replace(&isolated_project, "/tmp/project");
 
     for unix_path in ["/tmp/project", "/tmp/hooks.json"] {
         let platform_path = test_path_display(unix_path);

--- a/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
+++ b/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
@@ -1512,7 +1512,7 @@ async fn status_line_model_with_reasoning_includes_fast_for_fast_capable_models(
     let test_cwd = test_path_display("/tmp/project");
 
     assert_eq!(
-        status_line_text(&chat),
+        status_line_text(&chat).map(normalize_snapshot_paths),
         Some(format!("gpt-5.4 xhigh fast · Context 0% used · {test_cwd}"))
     );
 
@@ -1520,7 +1520,7 @@ async fn status_line_model_with_reasoning_includes_fast_for_fast_capable_models(
     chat.refresh_status_line();
 
     assert_eq!(
-        status_line_text(&chat),
+        status_line_text(&chat).map(normalize_snapshot_paths),
         Some(format!(
             "gpt-5.3-codex xhigh · Context 0% used · {test_cwd}"
         ))


### PR DESCRIPTION
## Summary
- isolate chatwidget test cwd behind a temp `project/` git root while preserving normalized `/tmp/project` expectations
- make core-skills parent-walk tests independent of ambient `/tmp` project markers
- keep the secrets cwd-hash fallback test off `/tmp` so CI parent git state cannot change the expected environment id

## CI failure signature
This targets the Linux Cargo CI failures from `rust-ci-full` run https://github.com/openai/codex/actions/runs/25340331991, where `/tmp` appeared repo-like and caused tests using synthetic `/tmp/project` paths to discover `tmp` instead of `project`/`my-project`, include repo-scope skill roots unexpectedly, and compute a different secrets cwd fallback.

## Validation
- `cd codex-rs && just fmt`
- `git diff --check`

Cargo tests/checks were not run locally per instruction; this is intended to be validated by CI.