### PR TITLE
Make managed-network unified exec tests local

### DIFF
--- a/codex-rs/core/tests/suite/unified_exec.rs
+++ b/codex-rs/core/tests/suite/unified_exec.rs
@@ -941,7 +941,11 @@ allow_local_binding = true
                 Err(err) => panic!("rebuild config layer stack with network requirements: {err}"),
             };
     });
-    let test = builder.build_remote_aware(server).await?;
+    // TODO: switch this back to `build_remote_aware` once remote exec-server
+    // sandboxing can enforce managed-network proxy denials inside the remote
+    // environment. Until then, these tests intentionally cover the local
+    // sandbox/proxy path only.
+    let test = builder.build(server).await?;
     assert!(
         test.config.permissions.network.is_some(),
         "expected managed network proxy config to be present"


### PR DESCRIPTION
## Summary

Run the managed-network denial unified exec tests against the local test harness instead of the remote exec-server harness.

These tests validate that the managed network proxy denial cancels/fails a unified exec process. The remote exec-server path cannot exercise that behavior correctly until sandboxing support is wired through the remote environment, so the tests are marked with a TODO to switch back once remote exec-server sandboxing can enforce managed-network proxy denials inside the remote environment.

## Validation

- `just fmt`
- `git diff --check`

Cargo tests not run locally; this is intended to be validated by rust-ci-full Linux remote CI.