### PR TITLE
Tolerate unknown config enum values

### DIFF
--- a/codex-rs/config/src/lib.rs
+++ b/codex-rs/config/src/lib.rs
@@ -24,6 +24,7 @@ mod state;
 mod thread_config;
 mod tui_keymap;
 pub mod types;
+mod unknown_enum_values;
 
 pub const CONFIG_TOML_FILE: &str = "config.toml";
 
@@ -126,3 +127,4 @@ pub use thread_config::ThreadConfigLoader;
 pub use thread_config::ThreadConfigSource;
 pub use thread_config::UserThreadConfig;
 pub use toml::Value as TomlValue;
+pub use unknown_enum_values::sanitize_unknown_enum_values;

--- a/codex-rs/config/src/state.rs
+++ b/codex-rs/config/src/state.rs
@@ -1,5 +1,6 @@
 use crate::config_requirements::ConfigRequirements;
 use crate::config_requirements::ConfigRequirementsToml;
+use crate::unknown_enum_values::sanitize_unknown_enum_values;
 
 use super::fingerprint::record_origins;
 use super::fingerprint::version_for_toml;
@@ -214,6 +215,18 @@ impl ConfigLayerStack {
 
     pub fn startup_warnings(&self) -> Option<&[String]> {
         self.startup_warnings.as_deref()
+    }
+
+    pub fn sanitize_unknown_enum_values(&mut self) -> Vec<String> {
+        let mut warnings = Vec::new();
+        for layer in &mut self.layers {
+            let layer_warnings = sanitize_unknown_enum_values(&mut layer.config);
+            if !layer_warnings.is_empty() {
+                layer.version = version_for_toml(&layer.config);
+                warnings.extend(layer_warnings);
+            }
+        }
+        warnings
     }
 
     /// Returns the raw user config layer, if any.

--- a/codex-rs/config/src/unknown_enum_values.rs
+++ b/codex-rs/config/src/unknown_enum_values.rs
@@ -21,8 +21,17 @@ use codex_protocol::config_types::WebSearchContextSize;
 use codex_protocol::config_types::WebSearchMode;
 use codex_protocol::openai_models::ReasoningEffort;
 use codex_protocol::protocol::AskForApproval;
+use serde::Deserialize;
 use serde::de::DeserializeOwned;
 use toml::Value as TomlValue;
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum LenientEnum<T> {
+    Known(T),
+    Unknown(String),
+    Other(TomlValue),
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum PathSegment {
@@ -117,17 +126,16 @@ where
 {
     let paths = matching_paths(root, path);
     for value_path in paths {
-        let Some(raw_value) = value_at_path(root, &value_path)
-            .and_then(TomlValue::as_str)
-            .map(str::to_string)
-        else {
+        let Some(value) = value_at_path(root, &value_path).cloned() else {
             continue;
         };
-        if TomlValue::String(raw_value.clone()).try_into::<T>().is_ok() {
-            continue;
-        }
-
-        warn_and_remove(root, &value_path, &value_path, &raw_value, warnings);
+        match value.try_into::<LenientEnum<T>>() {
+            Ok(LenientEnum::Known(_)) => {}
+            Ok(LenientEnum::Unknown(raw_value)) => {
+                warn_and_remove(root, &value_path, &value_path, &raw_value, warnings);
+            }
+            Ok(LenientEnum::Other(_)) | Err(_) => {}
+        };
     }
 }
 
@@ -143,21 +151,23 @@ fn sanitize_tagged_enum<T>(
     for parent_path in parent_paths {
         let mut tag_path = parent_path.clone();
         tag_path.push(tag_key.to_string());
-        let Some(raw_value) = value_at_path(root, &tag_path)
-            .and_then(TomlValue::as_str)
-            .map(str::to_string)
-        else {
+        let Some(value) = value_at_path(root, &parent_path).cloned() else {
             continue;
         };
-        if value_at_path(root, &parent_path)
-            .cloned()
-            .and_then(|value| value.try_into::<T>().ok())
-            .is_some()
-        {
-            continue;
-        }
-
-        warn_and_remove(root, &tag_path, &parent_path, &raw_value, warnings);
+        match value.try_into::<LenientEnum<T>>() {
+            Ok(LenientEnum::Known(_)) => {}
+            Ok(LenientEnum::Other(table_value)) => {
+                let Some(raw_value) = table_value
+                    .get(tag_key)
+                    .and_then(TomlValue::as_str)
+                    .map(str::to_string)
+                else {
+                    continue;
+                };
+                warn_and_remove(root, &tag_path, &parent_path, &raw_value, warnings);
+            }
+            Ok(LenientEnum::Unknown(_)) | Err(_) => {}
+        };
     }
 }
 

--- a/codex-rs/config/src/unknown_enum_values.rs
+++ b/codex-rs/config/src/unknown_enum_values.rs
@@ -1,27 +1,27 @@
-use crate::config_toml::RealtimeTransport;
-use crate::config_toml::RealtimeVoice;
-use crate::config_toml::RealtimeWsMode;
-use crate::config_toml::RealtimeWsVersion;
-use crate::config_toml::ThreadStoreToml;
-use crate::types::ApprovalsReviewer;
-use crate::types::AuthCredentialsStoreMode;
-use crate::types::HistoryPersistence;
-use crate::types::OAuthCredentialsStoreMode;
-use crate::types::Personality;
-use crate::types::ServiceTier;
-use crate::types::UriBasedFileOpener;
-use crate::types::WebSearchMode;
-use crate::types::WindowsSandboxModeToml;
-use codex_protocol::config_types::ForcedLoginMethod;
-use codex_protocol::config_types::ReasoningSummary;
-use codex_protocol::config_types::SandboxMode;
-use codex_protocol::config_types::TrustLevel;
-use codex_protocol::config_types::Verbosity;
-use codex_protocol::config_types::WebSearchContextSize;
-use codex_protocol::openai_models::ReasoningEffort;
-use codex_protocol::protocol::AskForApproval;
-use serde::Deserialize;
+use crate::config_toml::ConfigToml;
+use schemars::r#gen::SchemaSettings;
+use schemars::schema::RootSchema;
+use schemars::schema::Schema;
+use schemars::schema::SchemaObject;
+use serde_json::Value as JsonValue;
+use std::collections::BTreeSet;
+use std::sync::OnceLock;
 use toml::Value as TomlValue;
+
+static CONFIG_ENUM_FIELDS: OnceLock<Vec<EnumField>> = OnceLock::new();
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct EnumField {
+    value_path: Vec<PathSegment>,
+    remove_path: Vec<PathSegment>,
+    allowed_values: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PathSegment {
+    Key(String),
+    MapValue,
+}
 
 /// Removes unrecognized string values from enum-typed config fields.
 ///
@@ -32,241 +32,310 @@ use toml::Value as TomlValue;
 pub fn sanitize_unknown_enum_values(root: &mut TomlValue) -> Vec<String> {
     let mut warnings = Vec::new();
 
-    sanitize_enum::<AskForApproval>(root, &["approval_policy"], &mut warnings);
-    sanitize_enum::<ApprovalsReviewer>(root, &["approvals_reviewer"], &mut warnings);
-    sanitize_enum::<SandboxMode>(root, &["sandbox_mode"], &mut warnings);
-    sanitize_enum::<ForcedLoginMethod>(root, &["forced_login_method"], &mut warnings);
-    sanitize_enum::<AuthCredentialsStoreMode>(root, &["cli_auth_credentials_store"], &mut warnings);
-    sanitize_enum::<OAuthCredentialsStoreMode>(
-        root,
-        &["mcp_oauth_credentials_store"],
-        &mut warnings,
-    );
-    sanitize_enum::<UriBasedFileOpener>(root, &["file_opener"], &mut warnings);
-    sanitize_enum::<ReasoningEffort>(root, &["model_reasoning_effort"], &mut warnings);
-    sanitize_enum::<ReasoningEffort>(root, &["plan_mode_reasoning_effort"], &mut warnings);
-    sanitize_enum::<ReasoningSummary>(root, &["model_reasoning_summary"], &mut warnings);
-    sanitize_enum::<Verbosity>(root, &["model_verbosity"], &mut warnings);
-    sanitize_enum::<Personality>(root, &["personality"], &mut warnings);
-    sanitize_enum::<ServiceTier>(root, &["service_tier"], &mut warnings);
-    sanitize_enum::<WebSearchMode>(root, &["web_search"], &mut warnings);
-    sanitize_enum::<HistoryPersistence>(root, &["history", "persistence"], &mut warnings);
-    sanitize_enum::<WindowsSandboxModeToml>(root, &["windows", "sandbox"], &mut warnings);
-    sanitize_enum::<RealtimeWsVersion>(root, &["realtime", "version"], &mut warnings);
-    sanitize_enum::<RealtimeWsMode>(root, &["realtime", "type"], &mut warnings);
-    sanitize_enum::<RealtimeTransport>(root, &["realtime", "transport"], &mut warnings);
-    sanitize_enum::<RealtimeVoice>(root, &["realtime", "voice"], &mut warnings);
-    sanitize_tagged_enum::<ThreadStoreToml>(
-        root,
-        &["experimental_thread_store"],
-        "type",
-        &mut warnings,
-    );
-    sanitize_enum::<WebSearchContextSize>(
-        root,
-        &["tools", "web_search", "context_size"],
-        &mut warnings,
-    );
-
-    sanitize_table_entries(
-        root,
-        &["profiles"],
-        |value, prefix, warnings| {
-            sanitize_enum_with_prefix::<ServiceTier>(value, prefix, &["service_tier"], warnings);
-            sanitize_enum_with_prefix::<AskForApproval>(
-                value,
-                prefix,
-                &["approval_policy"],
-                warnings,
-            );
-            sanitize_enum_with_prefix::<ApprovalsReviewer>(
-                value,
-                prefix,
-                &["approvals_reviewer"],
-                warnings,
-            );
-            sanitize_enum_with_prefix::<SandboxMode>(value, prefix, &["sandbox_mode"], warnings);
-            sanitize_enum_with_prefix::<ReasoningEffort>(
-                value,
-                prefix,
-                &["model_reasoning_effort"],
-                warnings,
-            );
-            sanitize_enum_with_prefix::<ReasoningEffort>(
-                value,
-                prefix,
-                &["plan_mode_reasoning_effort"],
-                warnings,
-            );
-            sanitize_enum_with_prefix::<ReasoningSummary>(
-                value,
-                prefix,
-                &["model_reasoning_summary"],
-                warnings,
-            );
-            sanitize_enum_with_prefix::<Verbosity>(value, prefix, &["model_verbosity"], warnings);
-            sanitize_enum_with_prefix::<Personality>(value, prefix, &["personality"], warnings);
-            sanitize_enum_with_prefix::<WebSearchMode>(value, prefix, &["web_search"], warnings);
-            sanitize_enum_with_prefix::<WindowsSandboxModeToml>(
-                value,
-                prefix,
-                &["windows", "sandbox"],
-                warnings,
-            );
-            sanitize_enum_with_prefix::<WebSearchContextSize>(
-                value,
-                prefix,
-                &["tools", "web_search", "context_size"],
-                warnings,
-            );
-        },
-        &mut warnings,
-    );
-
-    sanitize_table_entries(
-        root,
-        &["projects"],
-        |value, prefix, warnings| {
-            sanitize_enum_with_prefix::<TrustLevel>(value, prefix, &["trust_level"], warnings);
-        },
-        &mut warnings,
-    );
+    for field in config_enum_fields() {
+        sanitize_enum_field(root, field, &mut warnings);
+    }
 
     warnings
 }
 
-fn sanitize_enum<T>(root: &mut TomlValue, path: &[&str], warnings: &mut Vec<String>)
-where
-    T: for<'de> Deserialize<'de>,
-{
-    sanitize_enum_with_prefix::<T>(root, &[], path, warnings);
+fn config_enum_fields() -> &'static [EnumField] {
+    CONFIG_ENUM_FIELDS.get_or_init(|| {
+        let root_schema = config_root_schema();
+        let root = Schema::Object(root_schema.schema.clone());
+        let mut fields = Vec::new();
+        collect_enum_fields(&root, &root_schema, &mut Vec::new(), &mut fields);
+        fields
+    })
 }
 
-fn sanitize_enum_with_prefix<T>(
-    root: &mut TomlValue,
-    prefix: &[String],
-    path: &[&str],
-    warnings: &mut Vec<String>,
-) where
-    T: for<'de> Deserialize<'de>,
-{
-    let Some(value) = value_at_path(root, path) else {
+fn config_root_schema() -> RootSchema {
+    SchemaSettings::draft07()
+        .with(|settings| {
+            settings.option_add_null_type = false;
+        })
+        .into_generator()
+        .into_root_schema_for::<ConfigToml>()
+}
+
+fn collect_enum_fields(
+    schema: &Schema,
+    root_schema: &RootSchema,
+    path: &mut Vec<PathSegment>,
+    fields: &mut Vec<EnumField>,
+) {
+    let Schema::Object(schema_object) = schema else {
         return;
     };
-    let Some(raw_value) = value.as_str() else {
-        return;
-    };
-    let parsed: Result<T, _> = value.clone().try_into();
-    if parsed.is_ok() {
+    let schema_object = resolve_schema_object(schema_object, root_schema);
+
+    if let Some(allowed_values) = string_enum_values(schema_object) {
+        push_enum_field(path, path, allowed_values, fields);
         return;
     }
 
-    let field_path = display_path(prefix, path);
-    warnings.push(format!(
-        "Ignoring unrecognized config value `{raw_value}` for `{field_path}`; using the default for this setting."
-    ));
-    tracing::warn!(
-        field = field_path,
-        value = raw_value,
-        "ignoring unrecognized config enum value"
-    );
-    remove_value_at_path(root, path);
+    if collect_string_union_enum(schema_object, path, fields) {
+        return;
+    }
+    if collect_tagged_union_enum(schema_object, path, fields) {
+        return;
+    }
+
+    if let Some(subschemas) = schema_object.subschemas.as_ref() {
+        for schema in subschemas.all_of.iter().flatten() {
+            collect_enum_fields(schema, root_schema, path, fields);
+        }
+        for schema in subschemas.any_of.iter().flatten() {
+            collect_enum_fields(schema, root_schema, path, fields);
+        }
+        for schema in subschemas.one_of.iter().flatten() {
+            collect_enum_fields(schema, root_schema, path, fields);
+        }
+    }
+
+    let Some(object) = schema_object.object.as_ref() else {
+        return;
+    };
+
+    for (property, property_schema) in &object.properties {
+        path.push(PathSegment::Key(property.clone()));
+        collect_enum_fields(property_schema, root_schema, path, fields);
+        path.pop();
+    }
+
+    if let Some(additional_properties) = object.additional_properties.as_ref() {
+        path.push(PathSegment::MapValue);
+        collect_enum_fields(additional_properties, root_schema, path, fields);
+        path.pop();
+    }
 }
 
-fn sanitize_tagged_enum<T>(
-    root: &mut TomlValue,
-    path: &[&str],
-    tag: &str,
-    warnings: &mut Vec<String>,
-) where
-    T: for<'de> Deserialize<'de>,
-{
-    let Some(value) = value_at_path(root, path) else {
+fn resolve_schema_object<'a>(
+    schema_object: &'a SchemaObject,
+    root_schema: &'a RootSchema,
+) -> &'a SchemaObject {
+    let Some(reference) = schema_object.reference.as_deref() else {
+        return schema_object;
+    };
+    let Some(definition_name) = reference.strip_prefix("#/definitions/") else {
+        return schema_object;
+    };
+    let Some(Schema::Object(definition)) = root_schema.definitions.get(definition_name) else {
+        return schema_object;
+    };
+    resolve_schema_object(definition, root_schema)
+}
+
+fn collect_string_union_enum(
+    schema_object: &SchemaObject,
+    path: &[PathSegment],
+    fields: &mut Vec<EnumField>,
+) -> bool {
+    let Some(subschemas) = schema_object.subschemas.as_ref() else {
+        return false;
+    };
+    let Some(one_of) = subschemas.one_of.as_ref() else {
+        return false;
+    };
+
+    let mut allowed_values = BTreeSet::new();
+    let mut found_string_enum = false;
+    for schema in one_of {
+        let Schema::Object(variant) = schema else {
+            continue;
+        };
+        let Some(values) = string_enum_values(variant) else {
+            continue;
+        };
+        found_string_enum = true;
+        allowed_values.extend(values);
+    }
+
+    if found_string_enum {
+        push_enum_field(path, path, allowed_values, fields);
+    }
+    found_string_enum
+}
+
+fn collect_tagged_union_enum(
+    schema_object: &SchemaObject,
+    path: &[PathSegment],
+    fields: &mut Vec<EnumField>,
+) -> bool {
+    let Some(subschemas) = schema_object.subschemas.as_ref() else {
+        return false;
+    };
+    let Some(one_of) = subschemas.one_of.as_ref() else {
+        return false;
+    };
+
+    let mut allowed_values = BTreeSet::new();
+    for schema in one_of {
+        let Schema::Object(variant) = schema else {
+            return false;
+        };
+        let Some(object) = variant.object.as_ref() else {
+            return false;
+        };
+        let Some(tag_schema) = object.properties.get("type") else {
+            return false;
+        };
+        let Schema::Object(tag_schema) = tag_schema else {
+            return false;
+        };
+        let Some(values) = string_enum_values(tag_schema) else {
+            return false;
+        };
+        allowed_values.extend(values);
+    }
+
+    if allowed_values.is_empty() {
+        return false;
+    }
+
+    let mut value_path = path.to_vec();
+    value_path.push(PathSegment::Key("type".to_string()));
+    push_enum_field(&value_path, path, allowed_values, fields);
+    true
+}
+
+fn string_enum_values(schema_object: &SchemaObject) -> Option<BTreeSet<String>> {
+    let values = schema_object.enum_values.as_ref()?;
+    let mut allowed_values = BTreeSet::new();
+    for value in values {
+        let JsonValue::String(value) = value else {
+            return None;
+        };
+        allowed_values.insert(value.clone());
+    }
+    (!allowed_values.is_empty()).then_some(allowed_values)
+}
+
+fn push_enum_field(
+    value_path: &[PathSegment],
+    remove_path: &[PathSegment],
+    allowed_values: BTreeSet<String>,
+    fields: &mut Vec<EnumField>,
+) {
+    let field = EnumField {
+        value_path: value_path.to_vec(),
+        remove_path: remove_path.to_vec(),
+        allowed_values,
+    };
+    if !fields.contains(&field) {
+        fields.push(field);
+    }
+}
+
+fn sanitize_enum_field(root: &mut TomlValue, field: &EnumField, warnings: &mut Vec<String>) {
+    let paths = matching_paths(root, &field.value_path);
+    for value_path in paths {
+        let Some(raw_value) = value_at_path(root, &value_path).and_then(TomlValue::as_str) else {
+            continue;
+        };
+        if field.allowed_values.contains(raw_value) {
+            continue;
+        }
+
+        let field_path = display_path(&value_path);
+        warnings.push(format!(
+            "Ignoring unrecognized config value `{raw_value}` for `{field_path}`; using the default for this setting."
+        ));
+        tracing::warn!(
+            field = field_path,
+            value = raw_value,
+            "ignoring unrecognized config enum value"
+        );
+
+        let remove_path = remove_path_for_match(field, &value_path);
+        remove_value_at_path(root, &remove_path);
+    }
+}
+
+fn matching_paths(root: &TomlValue, path: &[PathSegment]) -> Vec<Vec<String>> {
+    let mut matches = Vec::new();
+    collect_matching_paths(root, path, &mut Vec::new(), &mut matches);
+    matches
+}
+
+fn collect_matching_paths(
+    value: &TomlValue,
+    path: &[PathSegment],
+    current_path: &mut Vec<String>,
+    matches: &mut Vec<Vec<String>>,
+) {
+    let Some((segment, rest)) = path.split_first() else {
+        matches.push(current_path.clone());
         return;
     };
     let Some(table) = value.as_table() else {
         return;
     };
-    let Some(raw_value) = table.get(tag).and_then(TomlValue::as_str) else {
-        return;
-    };
-    let parsed: Result<T, _> = value.clone().try_into();
-    if parsed.is_ok() {
-        return;
-    }
 
-    let field_path = display_path(&[], path);
-    warnings.push(format!(
-        "Ignoring unrecognized config value `{raw_value}` for `{field_path}.{tag}`; using the default for this setting."
-    ));
-    tracing::warn!(
-        field = format!("{field_path}.{tag}"),
-        value = raw_value,
-        "ignoring unrecognized config enum value"
-    );
-    remove_value_at_path(root, path);
-}
-
-fn sanitize_table_entries(
-    root: &mut TomlValue,
-    path: &[&str],
-    mut sanitize_entry: impl FnMut(&mut TomlValue, &[String], &mut Vec<String>),
-    warnings: &mut Vec<String>,
-) {
-    let Some(TomlValue::Table(table)) = value_at_path_mut(root, path) else {
-        return;
-    };
-
-    for (key, value) in table {
-        let mut prefix = path
-            .iter()
-            .map(|part| (*part).to_string())
-            .collect::<Vec<_>>();
-        prefix.push(key.clone());
-        sanitize_entry(value, &prefix, warnings);
+    match segment {
+        PathSegment::Key(key) => {
+            let Some(value) = table.get(key) else {
+                return;
+            };
+            current_path.push(key.clone());
+            collect_matching_paths(value, rest, current_path, matches);
+            current_path.pop();
+        }
+        PathSegment::MapValue => {
+            for (key, value) in table {
+                current_path.push(key.clone());
+                collect_matching_paths(value, rest, current_path, matches);
+                current_path.pop();
+            }
+        }
     }
 }
 
-fn value_at_path_mut<'a>(root: &'a mut TomlValue, path: &[&str]) -> Option<&'a mut TomlValue> {
+fn remove_path_for_match(field: &EnumField, value_path: &[String]) -> Vec<String> {
+    field
+        .remove_path
+        .iter()
+        .zip(value_path.iter())
+        .map(|(segment, matched)| match segment {
+            PathSegment::Key(key) => key.clone(),
+            PathSegment::MapValue => matched.clone(),
+        })
+        .collect()
+}
+
+fn value_at_path<'a>(root: &'a TomlValue, path: &[String]) -> Option<&'a TomlValue> {
     let mut value = root;
     for part in path {
-        value = value.as_table_mut()?.get_mut(*part)?;
+        value = value.as_table()?.get(part)?;
     }
     Some(value)
 }
 
-fn value_at_path<'a>(root: &'a TomlValue, path: &[&str]) -> Option<&'a TomlValue> {
-    let mut value = root;
-    for part in path {
-        value = value.as_table()?.get(*part)?;
-    }
-    Some(value)
-}
-
-fn remove_value_at_path(root: &mut TomlValue, path: &[&str]) {
+fn remove_value_at_path(root: &mut TomlValue, path: &[String]) {
     let Some((last, parent_path)) = path.split_last() else {
         return;
     };
-    let Some(parent) = value_at_path_mut(root, parent_path).and_then(TomlValue::as_table_mut)
-    else {
-        return;
-    };
-    parent.remove(*last);
+
+    let mut value = root;
+    for part in parent_path {
+        let Some(next) = value.as_table_mut().and_then(|table| table.get_mut(part)) else {
+            return;
+        };
+        value = next;
+    }
+
+    if let Some(table) = value.as_table_mut() {
+        table.remove(last);
+    }
 }
 
-fn display_path(prefix: &[String], path: &[&str]) -> String {
-    prefix
-        .iter()
-        .map(String::as_str)
-        .chain(path.iter().copied())
-        .collect::<Vec<_>>()
-        .join(".")
+fn display_path(path: &[String]) -> String {
+    path.join(".")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config_toml::ConfigToml;
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -336,7 +405,7 @@ approval_policy = "on-request"
             (
                 None,
                 None,
-                Some(AskForApproval::OnRequest),
+                Some(codex_protocol::protocol::AskForApproval::OnRequest),
                 vec![
                     "Ignoring unrecognized config value `ultrafast` for `service_tier`; using the default for this setting.".to_string(),
                     "Ignoring unrecognized config value `verbose` for `model_reasoning_summary`; using the default for this setting.".to_string(),
@@ -348,6 +417,31 @@ approval_policy = "on-request"
                 config.approval_policy,
                 warnings,
             )
+        );
+    }
+
+    #[test]
+    fn unknown_tagged_enum_removes_the_parent_field() {
+        let mut value: TomlValue = toml::from_str(
+            r#"
+[experimental_thread_store]
+type = "future"
+endpoint = "https://example.test"
+"#,
+        )
+        .expect("config should parse as TOML");
+
+        let warnings = sanitize_unknown_enum_values(&mut value);
+        let expected: TomlValue = toml::from_str("").expect("expected TOML should parse");
+
+        assert_eq!(
+            (
+                expected,
+                vec![
+                    "Ignoring unrecognized config value `future` for `experimental_thread_store.type`; using the default for this setting.".to_string(),
+                ],
+            ),
+            (value, warnings)
         );
     }
 }

--- a/codex-rs/config/src/unknown_enum_values.rs
+++ b/codex-rs/config/src/unknown_enum_values.rs
@@ -1,26 +1,59 @@
-use crate::config_toml::ConfigToml;
-use schemars::r#gen::SchemaSettings;
-use schemars::schema::RootSchema;
-use schemars::schema::Schema;
-use schemars::schema::SchemaObject;
-use serde_json::Value as JsonValue;
-use std::collections::BTreeSet;
-use std::sync::OnceLock;
+use crate::config_toml::RealtimeTransport;
+use crate::config_toml::RealtimeWsMode;
+use crate::config_toml::ThreadStoreToml;
+use crate::types::ApprovalsReviewer;
+use crate::types::AuthCredentialsStoreMode;
+use crate::types::HistoryPersistence;
+use crate::types::NotificationCondition;
+use crate::types::NotificationMethod;
+use crate::types::OAuthCredentialsStoreMode;
+use crate::types::UriBasedFileOpener;
+use crate::types::WindowsSandboxModeToml;
+use codex_protocol::config_types::AltScreenMode;
+use codex_protocol::config_types::ForcedLoginMethod;
+use codex_protocol::config_types::Personality;
+use codex_protocol::config_types::ReasoningSummary;
+use codex_protocol::config_types::SandboxMode;
+use codex_protocol::config_types::ServiceTier;
+use codex_protocol::config_types::TrustLevel;
+use codex_protocol::config_types::Verbosity;
+use codex_protocol::config_types::WebSearchContextSize;
+use codex_protocol::config_types::WebSearchMode;
+use codex_protocol::openai_models::ReasoningEffort;
+use codex_protocol::protocol::AskForApproval;
+use serde::de::DeserializeOwned;
 use toml::Value as TomlValue;
-
-static CONFIG_ENUM_FIELDS: OnceLock<Vec<EnumField>> = OnceLock::new();
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct EnumField {
-    value_path: Vec<PathSegment>,
-    remove_path: Vec<PathSegment>,
-    allowed_values: BTreeSet<String>,
-}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum PathSegment {
-    Key(String),
+    Key(&'static str),
     MapValue,
+}
+
+macro_rules! sanitize_config_enums {
+    ($root:expr, $warnings:expr, {$($ty:ty => [$($path:tt).+],)+}) => {
+        $(
+            sanitize_enum::<$ty>($root, &path_segments!($($path).+), $warnings);
+        )+
+    };
+}
+
+macro_rules! path_segments {
+    ($($path:tt).+) => {
+        vec![$(path_segment!($path)),+]
+    };
+}
+
+macro_rules! path_segment {
+    (*) => {
+        PathSegment::MapValue
+    };
+    (r#type) => {
+        PathSegment::Key("type")
+    };
+    ($key:ident) => {
+        PathSegment::Key(stringify!($key))
+    };
 }
 
 /// Removes unrecognized string values from enum-typed config fields.
@@ -32,224 +65,119 @@ enum PathSegment {
 pub fn sanitize_unknown_enum_values(root: &mut TomlValue) -> Vec<String> {
     let mut warnings = Vec::new();
 
-    for field in config_enum_fields() {
-        sanitize_enum_field(root, field, &mut warnings);
-    }
+    sanitize_config_enums!(root, &mut warnings, {
+        AskForApproval => [approval_policy],
+        ApprovalsReviewer => [approvals_reviewer],
+        SandboxMode => [sandbox_mode],
+        ForcedLoginMethod => [forced_login_method],
+        AuthCredentialsStoreMode => [cli_auth_credentials_store],
+        OAuthCredentialsStoreMode => [mcp_oauth_credentials_store],
+        UriBasedFileOpener => [file_opener],
+        ReasoningEffort => [model_reasoning_effort],
+        ReasoningEffort => [plan_mode_reasoning_effort],
+        ReasoningSummary => [model_reasoning_summary],
+        Verbosity => [model_verbosity],
+        Personality => [personality],
+        ServiceTier => [service_tier],
+        WebSearchMode => [web_search],
+        HistoryPersistence => [history.persistence],
+        NotificationMethod => [tui.notification_method],
+        NotificationCondition => [tui.notification_condition],
+        AltScreenMode => [tui.alternate_screen],
+        WebSearchContextSize => [tools.web_search.context_size],
+        TrustLevel => [projects.*.trust_level],
+        RealtimeWsMode => [realtime.r#type],
+        RealtimeTransport => [realtime.transport],
+        WindowsSandboxModeToml => [windows.sandbox],
+        AskForApproval => [profiles.*.approval_policy],
+        ApprovalsReviewer => [profiles.*.approvals_reviewer],
+        SandboxMode => [profiles.*.sandbox_mode],
+        ReasoningEffort => [profiles.*.model_reasoning_effort],
+        ReasoningEffort => [profiles.*.plan_mode_reasoning_effort],
+        ReasoningSummary => [profiles.*.model_reasoning_summary],
+        Verbosity => [profiles.*.model_verbosity],
+        Personality => [profiles.*.personality],
+        ServiceTier => [profiles.*.service_tier],
+        WebSearchMode => [profiles.*.web_search],
+        WebSearchContextSize => [profiles.*.tools.web_search.context_size],
+    });
+    sanitize_tagged_enum::<ThreadStoreToml>(
+        root,
+        &path_segments!(experimental_thread_store),
+        "type",
+        &mut warnings,
+    );
 
     warnings
 }
 
-fn config_enum_fields() -> &'static [EnumField] {
-    CONFIG_ENUM_FIELDS.get_or_init(|| {
-        let root_schema = config_root_schema();
-        let root = Schema::Object(root_schema.schema.clone());
-        let mut fields = Vec::new();
-        collect_enum_fields(&root, &root_schema, &mut Vec::new(), &mut fields);
-        fields
-    })
-}
-
-fn config_root_schema() -> RootSchema {
-    SchemaSettings::draft07()
-        .with(|settings| {
-            settings.option_add_null_type = false;
-        })
-        .into_generator()
-        .into_root_schema_for::<ConfigToml>()
-}
-
-fn collect_enum_fields(
-    schema: &Schema,
-    root_schema: &RootSchema,
-    path: &mut Vec<PathSegment>,
-    fields: &mut Vec<EnumField>,
-) {
-    let Schema::Object(schema_object) = schema else {
-        return;
-    };
-    let schema_object = resolve_schema_object(schema_object, root_schema);
-
-    if let Some(allowed_values) = string_enum_values(schema_object) {
-        push_enum_field(path, path, allowed_values, fields);
-        return;
-    }
-
-    if collect_string_union_enum(schema_object, path, fields) {
-        return;
-    }
-    if collect_tagged_union_enum(schema_object, path, fields) {
-        return;
-    }
-
-    if let Some(subschemas) = schema_object.subschemas.as_ref() {
-        for schema in subschemas.all_of.iter().flatten() {
-            collect_enum_fields(schema, root_schema, path, fields);
-        }
-        for schema in subschemas.any_of.iter().flatten() {
-            collect_enum_fields(schema, root_schema, path, fields);
-        }
-        for schema in subschemas.one_of.iter().flatten() {
-            collect_enum_fields(schema, root_schema, path, fields);
-        }
-    }
-
-    let Some(object) = schema_object.object.as_ref() else {
-        return;
-    };
-
-    for (property, property_schema) in &object.properties {
-        path.push(PathSegment::Key(property.clone()));
-        collect_enum_fields(property_schema, root_schema, path, fields);
-        path.pop();
-    }
-
-    if let Some(additional_properties) = object.additional_properties.as_ref() {
-        path.push(PathSegment::MapValue);
-        collect_enum_fields(additional_properties, root_schema, path, fields);
-        path.pop();
-    }
-}
-
-fn resolve_schema_object<'a>(
-    schema_object: &'a SchemaObject,
-    root_schema: &'a RootSchema,
-) -> &'a SchemaObject {
-    let Some(reference) = schema_object.reference.as_deref() else {
-        return schema_object;
-    };
-    let Some(definition_name) = reference.strip_prefix("#/definitions/") else {
-        return schema_object;
-    };
-    let Some(Schema::Object(definition)) = root_schema.definitions.get(definition_name) else {
-        return schema_object;
-    };
-    resolve_schema_object(definition, root_schema)
-}
-
-fn collect_string_union_enum(
-    schema_object: &SchemaObject,
-    path: &[PathSegment],
-    fields: &mut Vec<EnumField>,
-) -> bool {
-    let Some(subschemas) = schema_object.subschemas.as_ref() else {
-        return false;
-    };
-    let Some(one_of) = subschemas.one_of.as_ref() else {
-        return false;
-    };
-
-    let mut allowed_values = BTreeSet::new();
-    let mut found_string_enum = false;
-    for schema in one_of {
-        let Schema::Object(variant) = schema else {
-            continue;
-        };
-        let Some(values) = string_enum_values(variant) else {
-            continue;
-        };
-        found_string_enum = true;
-        allowed_values.extend(values);
-    }
-
-    if found_string_enum {
-        push_enum_field(path, path, allowed_values, fields);
-    }
-    found_string_enum
-}
-
-fn collect_tagged_union_enum(
-    schema_object: &SchemaObject,
-    path: &[PathSegment],
-    fields: &mut Vec<EnumField>,
-) -> bool {
-    let Some(subschemas) = schema_object.subschemas.as_ref() else {
-        return false;
-    };
-    let Some(one_of) = subschemas.one_of.as_ref() else {
-        return false;
-    };
-
-    let mut allowed_values = BTreeSet::new();
-    for schema in one_of {
-        let Schema::Object(variant) = schema else {
-            return false;
-        };
-        let Some(object) = variant.object.as_ref() else {
-            return false;
-        };
-        let Some(tag_schema) = object.properties.get("type") else {
-            return false;
-        };
-        let Schema::Object(tag_schema) = tag_schema else {
-            return false;
-        };
-        let Some(values) = string_enum_values(tag_schema) else {
-            return false;
-        };
-        allowed_values.extend(values);
-    }
-
-    if allowed_values.is_empty() {
-        return false;
-    }
-
-    let mut value_path = path.to_vec();
-    value_path.push(PathSegment::Key("type".to_string()));
-    push_enum_field(&value_path, path, allowed_values, fields);
-    true
-}
-
-fn string_enum_values(schema_object: &SchemaObject) -> Option<BTreeSet<String>> {
-    let values = schema_object.enum_values.as_ref()?;
-    let mut allowed_values = BTreeSet::new();
-    for value in values {
-        let JsonValue::String(value) = value else {
-            return None;
-        };
-        allowed_values.insert(value.clone());
-    }
-    (!allowed_values.is_empty()).then_some(allowed_values)
-}
-
-fn push_enum_field(
-    value_path: &[PathSegment],
-    remove_path: &[PathSegment],
-    allowed_values: BTreeSet<String>,
-    fields: &mut Vec<EnumField>,
-) {
-    let field = EnumField {
-        value_path: value_path.to_vec(),
-        remove_path: remove_path.to_vec(),
-        allowed_values,
-    };
-    if !fields.contains(&field) {
-        fields.push(field);
-    }
-}
-
-fn sanitize_enum_field(root: &mut TomlValue, field: &EnumField, warnings: &mut Vec<String>) {
-    let paths = matching_paths(root, &field.value_path);
+fn sanitize_enum<T>(root: &mut TomlValue, path: &[PathSegment], warnings: &mut Vec<String>)
+where
+    T: DeserializeOwned,
+{
+    let paths = matching_paths(root, path);
     for value_path in paths {
-        let Some(raw_value) = value_at_path(root, &value_path).and_then(TomlValue::as_str) else {
+        let Some(raw_value) = value_at_path(root, &value_path)
+            .and_then(TomlValue::as_str)
+            .map(str::to_string)
+        else {
             continue;
         };
-        if field.allowed_values.contains(raw_value) {
+        if TomlValue::String(raw_value.clone()).try_into::<T>().is_ok() {
             continue;
         }
 
-        let field_path = display_path(&value_path);
-        warnings.push(format!(
-            "Ignoring unrecognized config value `{raw_value}` for `{field_path}`; using the default for this setting."
-        ));
-        tracing::warn!(
-            field = field_path,
-            value = raw_value,
-            "ignoring unrecognized config enum value"
-        );
-
-        let remove_path = remove_path_for_match(field, &value_path);
-        remove_value_at_path(root, &remove_path);
+        warn_and_remove(root, &value_path, &value_path, &raw_value, warnings);
     }
+}
+
+fn sanitize_tagged_enum<T>(
+    root: &mut TomlValue,
+    path: &[PathSegment],
+    tag_key: &'static str,
+    warnings: &mut Vec<String>,
+) where
+    T: DeserializeOwned,
+{
+    let parent_paths = matching_paths(root, path);
+    for parent_path in parent_paths {
+        let mut tag_path = parent_path.clone();
+        tag_path.push(tag_key.to_string());
+        let Some(raw_value) = value_at_path(root, &tag_path)
+            .and_then(TomlValue::as_str)
+            .map(str::to_string)
+        else {
+            continue;
+        };
+        if value_at_path(root, &parent_path)
+            .cloned()
+            .and_then(|value| value.try_into::<T>().ok())
+            .is_some()
+        {
+            continue;
+        }
+
+        warn_and_remove(root, &tag_path, &parent_path, &raw_value, warnings);
+    }
+}
+
+fn warn_and_remove(
+    root: &mut TomlValue,
+    value_path: &[String],
+    remove_path: &[String],
+    raw_value: &str,
+    warnings: &mut Vec<String>,
+) {
+    let field_path = value_path.join(".");
+    warnings.push(format!(
+        "Ignoring unrecognized config value `{raw_value}` for `{field_path}`; using the default for this setting."
+    ));
+    tracing::warn!(
+        field = field_path,
+        value = raw_value,
+        "ignoring unrecognized config enum value"
+    );
+    remove_value_at_path(root, remove_path);
 }
 
 fn matching_paths(root: &TomlValue, path: &[PathSegment]) -> Vec<Vec<String>> {
@@ -259,189 +187,152 @@ fn matching_paths(root: &TomlValue, path: &[PathSegment]) -> Vec<Vec<String>> {
 }
 
 fn collect_matching_paths(
-    value: &TomlValue,
-    path: &[PathSegment],
-    current_path: &mut Vec<String>,
+    current: &TomlValue,
+    remaining_path: &[PathSegment],
+    matched_path: &mut Vec<String>,
     matches: &mut Vec<Vec<String>>,
 ) {
-    let Some((segment, rest)) = path.split_first() else {
-        matches.push(current_path.clone());
-        return;
-    };
-    let Some(table) = value.as_table() else {
+    let Some((segment, remaining_path)) = remaining_path.split_first() else {
+        matches.push(matched_path.clone());
         return;
     };
 
     match segment {
         PathSegment::Key(key) => {
-            let Some(value) = table.get(key) else {
+            let Some(next) = current.get(*key) else {
                 return;
             };
-            current_path.push(key.clone());
-            collect_matching_paths(value, rest, current_path, matches);
-            current_path.pop();
+            matched_path.push((*key).to_string());
+            collect_matching_paths(next, remaining_path, matched_path, matches);
+            matched_path.pop();
         }
         PathSegment::MapValue => {
-            for (key, value) in table {
-                current_path.push(key.clone());
-                collect_matching_paths(value, rest, current_path, matches);
-                current_path.pop();
+            let Some(table) = current.as_table() else {
+                return;
+            };
+            for (key, next) in table {
+                matched_path.push(key.clone());
+                collect_matching_paths(next, remaining_path, matched_path, matches);
+                matched_path.pop();
             }
         }
     }
 }
 
-fn remove_path_for_match(field: &EnumField, value_path: &[String]) -> Vec<String> {
-    field
-        .remove_path
-        .iter()
-        .zip(value_path.iter())
-        .map(|(segment, matched)| match segment {
-            PathSegment::Key(key) => key.clone(),
-            PathSegment::MapValue => matched.clone(),
-        })
-        .collect()
-}
-
 fn value_at_path<'a>(root: &'a TomlValue, path: &[String]) -> Option<&'a TomlValue> {
-    let mut value = root;
-    for part in path {
-        value = value.as_table()?.get(part)?;
+    let mut current = root;
+    for segment in path {
+        current = current.get(segment)?;
     }
-    Some(value)
+    Some(current)
 }
 
 fn remove_value_at_path(root: &mut TomlValue, path: &[String]) {
-    let Some((last, parent_path)) = path.split_last() else {
+    let Some((last_segment, parent_path)) = path.split_last() else {
         return;
     };
 
-    let mut value = root;
-    for part in parent_path {
-        let Some(next) = value.as_table_mut().and_then(|table| table.get_mut(part)) else {
-            return;
-        };
-        value = next;
-    }
-
-    if let Some(table) = value.as_table_mut() {
-        table.remove(last);
-    }
+    let Some(parent) = value_at_path_mut(root, parent_path) else {
+        return;
+    };
+    let Some(table) = parent.as_table_mut() else {
+        return;
+    };
+    table.remove(last_segment);
 }
 
-fn display_path(path: &[String]) -> String {
-    path.join(".")
+fn value_at_path_mut<'a>(root: &'a mut TomlValue, path: &[String]) -> Option<&'a mut TomlValue> {
+    let mut current = root;
+    for segment in path {
+        current = current.get_mut(segment)?;
+    }
+    Some(current)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config_toml::ConfigToml;
     use pretty_assertions::assert_eq;
 
     #[test]
     fn unknown_config_enum_values_are_removed_with_warnings() {
-        let mut value: TomlValue = toml::from_str(
-            r#"
+        let mut value = r#"
+approval_policy = "maybe"
+model = "gpt-5"
 service_tier = "ultrafast"
-sandbox_mode = "workspace-write"
 
-[profiles.future]
-model_reasoning_effort = "huge"
-model_verbosity = "high"
+[profiles.work]
+model = "gpt-5-codex"
+model_reasoning_effort = "maximum"
 
 [projects."/tmp/project"]
-trust_level = "very-trusted"
-
-[tools.web_search]
-context_size = "massive"
-"#,
-        )
-        .expect("config should parse as TOML");
+trust_level = "somewhat"
+"#
+        .parse::<TomlValue>()
+        .expect("config should parse as toml");
 
         let warnings = sanitize_unknown_enum_values(&mut value);
-        let expected: TomlValue = toml::from_str(
-            r#"
-sandbox_mode = "workspace-write"
 
-[profiles.future]
-model_verbosity = "high"
+        let expected_value = r#"
+model = "gpt-5"
+
+[profiles.work]
+model = "gpt-5-codex"
 
 [projects."/tmp/project"]
-
-[tools.web_search]
-"#,
-        )
-        .expect("expected TOML should parse");
-
-        assert_eq!(
-            (
-                expected,
-                vec![
-                    "Ignoring unrecognized config value `ultrafast` for `service_tier`; using the default for this setting.".to_string(),
-                    "Ignoring unrecognized config value `huge` for `profiles.future.model_reasoning_effort`; using the default for this setting.".to_string(),
-                    "Ignoring unrecognized config value `very-trusted` for `projects./tmp/project.trust_level`; using the default for this setting.".to_string(),
-                    "Ignoring unrecognized config value `massive` for `tools.web_search.context_size`; using the default for this setting.".to_string(),
-                ],
-            ),
-            (value, warnings)
-        );
+"#
+        .parse::<TomlValue>()
+        .expect("expected config should parse as toml");
+        let expected_warnings = vec![
+            "Ignoring unrecognized config value `maybe` for `approval_policy`; using the default for this setting.".to_string(),
+            "Ignoring unrecognized config value `ultrafast` for `service_tier`; using the default for this setting.".to_string(),
+            "Ignoring unrecognized config value `somewhat` for `projects./tmp/project.trust_level`; using the default for this setting.".to_string(),
+            "Ignoring unrecognized config value `maximum` for `profiles.work.model_reasoning_effort`; using the default for this setting.".to_string(),
+        ];
+        assert_eq!((value, warnings), (expected_value, expected_warnings));
     }
 
     #[test]
     fn unknown_config_enum_values_allow_config_toml_deserialization() {
-        let mut value: TomlValue = toml::from_str(
-            r#"
+        let mut value = r#"
+model = "gpt-5"
 service_tier = "ultrafast"
-model_reasoning_summary = "verbose"
-approval_policy = "on-request"
-"#,
-        )
-        .expect("config should parse as TOML");
+"#
+        .parse::<TomlValue>()
+        .expect("config should parse as toml");
 
         let warnings = sanitize_unknown_enum_values(&mut value);
         let config: ConfigToml = value.try_into().expect("config should deserialize");
 
-        assert_eq!(
-            (
-                None,
-                None,
-                Some(codex_protocol::protocol::AskForApproval::OnRequest),
-                vec![
-                    "Ignoring unrecognized config value `ultrafast` for `service_tier`; using the default for this setting.".to_string(),
-                    "Ignoring unrecognized config value `verbose` for `model_reasoning_summary`; using the default for this setting.".to_string(),
-                ],
-            ),
-            (
-                config.service_tier,
-                config.model_reasoning_summary,
-                config.approval_policy,
-                warnings,
-            )
-        );
+        let expected_warnings = vec![
+            "Ignoring unrecognized config value `ultrafast` for `service_tier`; using the default for this setting.".to_string(),
+        ];
+        assert_eq!((config.service_tier, warnings), (None, expected_warnings));
     }
 
     #[test]
     fn unknown_tagged_enum_removes_the_parent_field() {
-        let mut value: TomlValue = toml::from_str(
-            r#"
+        let mut value = r#"
+model = "gpt-5"
+
 [experimental_thread_store]
-type = "future"
-endpoint = "https://example.test"
-"#,
-        )
-        .expect("config should parse as TOML");
+type = "future_store"
+endpoint = "https://example.com"
+"#
+        .parse::<TomlValue>()
+        .expect("config should parse as toml");
 
         let warnings = sanitize_unknown_enum_values(&mut value);
-        let expected: TomlValue = toml::from_str("").expect("expected TOML should parse");
 
-        assert_eq!(
-            (
-                expected,
-                vec![
-                    "Ignoring unrecognized config value `future` for `experimental_thread_store.type`; using the default for this setting.".to_string(),
-                ],
-            ),
-            (value, warnings)
-        );
+        let expected_value = r#"
+model = "gpt-5"
+"#
+        .parse::<TomlValue>()
+        .expect("expected config should parse as toml");
+        let expected_warnings = vec![
+            "Ignoring unrecognized config value `future_store` for `experimental_thread_store.type`; using the default for this setting.".to_string(),
+        ];
+        assert_eq!((value, warnings), (expected_value, expected_warnings));
     }
 }

--- a/codex-rs/config/src/unknown_enum_values.rs
+++ b/codex-rs/config/src/unknown_enum_values.rs
@@ -1,0 +1,353 @@
+use crate::config_toml::RealtimeTransport;
+use crate::config_toml::RealtimeVoice;
+use crate::config_toml::RealtimeWsMode;
+use crate::config_toml::RealtimeWsVersion;
+use crate::config_toml::ThreadStoreToml;
+use crate::types::ApprovalsReviewer;
+use crate::types::AuthCredentialsStoreMode;
+use crate::types::HistoryPersistence;
+use crate::types::OAuthCredentialsStoreMode;
+use crate::types::Personality;
+use crate::types::ServiceTier;
+use crate::types::UriBasedFileOpener;
+use crate::types::WebSearchMode;
+use crate::types::WindowsSandboxModeToml;
+use codex_protocol::config_types::ForcedLoginMethod;
+use codex_protocol::config_types::ReasoningSummary;
+use codex_protocol::config_types::SandboxMode;
+use codex_protocol::config_types::TrustLevel;
+use codex_protocol::config_types::Verbosity;
+use codex_protocol::config_types::WebSearchContextSize;
+use codex_protocol::openai_models::ReasoningEffort;
+use codex_protocol::protocol::AskForApproval;
+use serde::Deserialize;
+use toml::Value as TomlValue;
+
+/// Removes unrecognized string values from enum-typed config fields.
+///
+/// This keeps older clients from failing to load a config written by a newer
+/// client that knows about a newly added enum variant. The field is treated as
+/// unset, so the normal default/resolution path applies. Non-string shape
+/// errors are left intact and still fail during typed deserialization.
+pub fn sanitize_unknown_enum_values(root: &mut TomlValue) -> Vec<String> {
+    let mut warnings = Vec::new();
+
+    sanitize_enum::<AskForApproval>(root, &["approval_policy"], &mut warnings);
+    sanitize_enum::<ApprovalsReviewer>(root, &["approvals_reviewer"], &mut warnings);
+    sanitize_enum::<SandboxMode>(root, &["sandbox_mode"], &mut warnings);
+    sanitize_enum::<ForcedLoginMethod>(root, &["forced_login_method"], &mut warnings);
+    sanitize_enum::<AuthCredentialsStoreMode>(root, &["cli_auth_credentials_store"], &mut warnings);
+    sanitize_enum::<OAuthCredentialsStoreMode>(
+        root,
+        &["mcp_oauth_credentials_store"],
+        &mut warnings,
+    );
+    sanitize_enum::<UriBasedFileOpener>(root, &["file_opener"], &mut warnings);
+    sanitize_enum::<ReasoningEffort>(root, &["model_reasoning_effort"], &mut warnings);
+    sanitize_enum::<ReasoningEffort>(root, &["plan_mode_reasoning_effort"], &mut warnings);
+    sanitize_enum::<ReasoningSummary>(root, &["model_reasoning_summary"], &mut warnings);
+    sanitize_enum::<Verbosity>(root, &["model_verbosity"], &mut warnings);
+    sanitize_enum::<Personality>(root, &["personality"], &mut warnings);
+    sanitize_enum::<ServiceTier>(root, &["service_tier"], &mut warnings);
+    sanitize_enum::<WebSearchMode>(root, &["web_search"], &mut warnings);
+    sanitize_enum::<HistoryPersistence>(root, &["history", "persistence"], &mut warnings);
+    sanitize_enum::<WindowsSandboxModeToml>(root, &["windows", "sandbox"], &mut warnings);
+    sanitize_enum::<RealtimeWsVersion>(root, &["realtime", "version"], &mut warnings);
+    sanitize_enum::<RealtimeWsMode>(root, &["realtime", "type"], &mut warnings);
+    sanitize_enum::<RealtimeTransport>(root, &["realtime", "transport"], &mut warnings);
+    sanitize_enum::<RealtimeVoice>(root, &["realtime", "voice"], &mut warnings);
+    sanitize_tagged_enum::<ThreadStoreToml>(
+        root,
+        &["experimental_thread_store"],
+        "type",
+        &mut warnings,
+    );
+    sanitize_enum::<WebSearchContextSize>(
+        root,
+        &["tools", "web_search", "context_size"],
+        &mut warnings,
+    );
+
+    sanitize_table_entries(
+        root,
+        &["profiles"],
+        |value, prefix, warnings| {
+            sanitize_enum_with_prefix::<ServiceTier>(value, prefix, &["service_tier"], warnings);
+            sanitize_enum_with_prefix::<AskForApproval>(
+                value,
+                prefix,
+                &["approval_policy"],
+                warnings,
+            );
+            sanitize_enum_with_prefix::<ApprovalsReviewer>(
+                value,
+                prefix,
+                &["approvals_reviewer"],
+                warnings,
+            );
+            sanitize_enum_with_prefix::<SandboxMode>(value, prefix, &["sandbox_mode"], warnings);
+            sanitize_enum_with_prefix::<ReasoningEffort>(
+                value,
+                prefix,
+                &["model_reasoning_effort"],
+                warnings,
+            );
+            sanitize_enum_with_prefix::<ReasoningEffort>(
+                value,
+                prefix,
+                &["plan_mode_reasoning_effort"],
+                warnings,
+            );
+            sanitize_enum_with_prefix::<ReasoningSummary>(
+                value,
+                prefix,
+                &["model_reasoning_summary"],
+                warnings,
+            );
+            sanitize_enum_with_prefix::<Verbosity>(value, prefix, &["model_verbosity"], warnings);
+            sanitize_enum_with_prefix::<Personality>(value, prefix, &["personality"], warnings);
+            sanitize_enum_with_prefix::<WebSearchMode>(value, prefix, &["web_search"], warnings);
+            sanitize_enum_with_prefix::<WindowsSandboxModeToml>(
+                value,
+                prefix,
+                &["windows", "sandbox"],
+                warnings,
+            );
+            sanitize_enum_with_prefix::<WebSearchContextSize>(
+                value,
+                prefix,
+                &["tools", "web_search", "context_size"],
+                warnings,
+            );
+        },
+        &mut warnings,
+    );
+
+    sanitize_table_entries(
+        root,
+        &["projects"],
+        |value, prefix, warnings| {
+            sanitize_enum_with_prefix::<TrustLevel>(value, prefix, &["trust_level"], warnings);
+        },
+        &mut warnings,
+    );
+
+    warnings
+}
+
+fn sanitize_enum<T>(root: &mut TomlValue, path: &[&str], warnings: &mut Vec<String>)
+where
+    T: for<'de> Deserialize<'de>,
+{
+    sanitize_enum_with_prefix::<T>(root, &[], path, warnings);
+}
+
+fn sanitize_enum_with_prefix<T>(
+    root: &mut TomlValue,
+    prefix: &[String],
+    path: &[&str],
+    warnings: &mut Vec<String>,
+) where
+    T: for<'de> Deserialize<'de>,
+{
+    let Some(value) = value_at_path(root, path) else {
+        return;
+    };
+    let Some(raw_value) = value.as_str() else {
+        return;
+    };
+    let parsed: Result<T, _> = value.clone().try_into();
+    if parsed.is_ok() {
+        return;
+    }
+
+    let field_path = display_path(prefix, path);
+    warnings.push(format!(
+        "Ignoring unrecognized config value `{raw_value}` for `{field_path}`; using the default for this setting."
+    ));
+    tracing::warn!(
+        field = field_path,
+        value = raw_value,
+        "ignoring unrecognized config enum value"
+    );
+    remove_value_at_path(root, path);
+}
+
+fn sanitize_tagged_enum<T>(
+    root: &mut TomlValue,
+    path: &[&str],
+    tag: &str,
+    warnings: &mut Vec<String>,
+) where
+    T: for<'de> Deserialize<'de>,
+{
+    let Some(value) = value_at_path(root, path) else {
+        return;
+    };
+    let Some(table) = value.as_table() else {
+        return;
+    };
+    let Some(raw_value) = table.get(tag).and_then(TomlValue::as_str) else {
+        return;
+    };
+    let parsed: Result<T, _> = value.clone().try_into();
+    if parsed.is_ok() {
+        return;
+    }
+
+    let field_path = display_path(&[], path);
+    warnings.push(format!(
+        "Ignoring unrecognized config value `{raw_value}` for `{field_path}.{tag}`; using the default for this setting."
+    ));
+    tracing::warn!(
+        field = format!("{field_path}.{tag}"),
+        value = raw_value,
+        "ignoring unrecognized config enum value"
+    );
+    remove_value_at_path(root, path);
+}
+
+fn sanitize_table_entries(
+    root: &mut TomlValue,
+    path: &[&str],
+    mut sanitize_entry: impl FnMut(&mut TomlValue, &[String], &mut Vec<String>),
+    warnings: &mut Vec<String>,
+) {
+    let Some(TomlValue::Table(table)) = value_at_path_mut(root, path) else {
+        return;
+    };
+
+    for (key, value) in table {
+        let mut prefix = path
+            .iter()
+            .map(|part| (*part).to_string())
+            .collect::<Vec<_>>();
+        prefix.push(key.clone());
+        sanitize_entry(value, &prefix, warnings);
+    }
+}
+
+fn value_at_path_mut<'a>(root: &'a mut TomlValue, path: &[&str]) -> Option<&'a mut TomlValue> {
+    let mut value = root;
+    for part in path {
+        value = value.as_table_mut()?.get_mut(*part)?;
+    }
+    Some(value)
+}
+
+fn value_at_path<'a>(root: &'a TomlValue, path: &[&str]) -> Option<&'a TomlValue> {
+    let mut value = root;
+    for part in path {
+        value = value.as_table()?.get(*part)?;
+    }
+    Some(value)
+}
+
+fn remove_value_at_path(root: &mut TomlValue, path: &[&str]) {
+    let Some((last, parent_path)) = path.split_last() else {
+        return;
+    };
+    let Some(parent) = value_at_path_mut(root, parent_path).and_then(TomlValue::as_table_mut)
+    else {
+        return;
+    };
+    parent.remove(*last);
+}
+
+fn display_path(prefix: &[String], path: &[&str]) -> String {
+    prefix
+        .iter()
+        .map(String::as_str)
+        .chain(path.iter().copied())
+        .collect::<Vec<_>>()
+        .join(".")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config_toml::ConfigToml;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn unknown_config_enum_values_are_removed_with_warnings() {
+        let mut value: TomlValue = toml::from_str(
+            r#"
+service_tier = "ultrafast"
+sandbox_mode = "workspace-write"
+
+[profiles.future]
+model_reasoning_effort = "huge"
+model_verbosity = "high"
+
+[projects."/tmp/project"]
+trust_level = "very-trusted"
+
+[tools.web_search]
+context_size = "massive"
+"#,
+        )
+        .expect("config should parse as TOML");
+
+        let warnings = sanitize_unknown_enum_values(&mut value);
+        let expected: TomlValue = toml::from_str(
+            r#"
+sandbox_mode = "workspace-write"
+
+[profiles.future]
+model_verbosity = "high"
+
+[projects."/tmp/project"]
+
+[tools.web_search]
+"#,
+        )
+        .expect("expected TOML should parse");
+
+        assert_eq!(
+            (
+                expected,
+                vec![
+                    "Ignoring unrecognized config value `ultrafast` for `service_tier`; using the default for this setting.".to_string(),
+                    "Ignoring unrecognized config value `huge` for `profiles.future.model_reasoning_effort`; using the default for this setting.".to_string(),
+                    "Ignoring unrecognized config value `very-trusted` for `projects./tmp/project.trust_level`; using the default for this setting.".to_string(),
+                    "Ignoring unrecognized config value `massive` for `tools.web_search.context_size`; using the default for this setting.".to_string(),
+                ],
+            ),
+            (value, warnings)
+        );
+    }
+
+    #[test]
+    fn unknown_config_enum_values_allow_config_toml_deserialization() {
+        let mut value: TomlValue = toml::from_str(
+            r#"
+service_tier = "ultrafast"
+model_reasoning_summary = "verbose"
+approval_policy = "on-request"
+"#,
+        )
+        .expect("config should parse as TOML");
+
+        let warnings = sanitize_unknown_enum_values(&mut value);
+        let config: ConfigToml = value.try_into().expect("config should deserialize");
+
+        assert_eq!(
+            (
+                None,
+                None,
+                Some(AskForApproval::OnRequest),
+                vec![
+                    "Ignoring unrecognized config value `ultrafast` for `service_tier`; using the default for this setting.".to_string(),
+                    "Ignoring unrecognized config value `verbose` for `model_reasoning_summary`; using the default for this setting.".to_string(),
+                ],
+            ),
+            (
+                config.service_tier,
+                config.model_reasoning_summary,
+                config.approval_policy,
+                warnings,
+            )
+        );
+    }
+}

--- a/codex-rs/config/src/unknown_enum_values.rs
+++ b/codex-rs/config/src/unknown_enum_values.rs
@@ -29,8 +29,7 @@ use toml::Value as TomlValue;
 #[serde(untagged)]
 enum LenientEnum<T> {
     Known(T),
-    Unknown(String),
-    Other(TomlValue),
+    Unknown(TomlValue),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -131,10 +130,10 @@ where
         };
         match value.try_into::<LenientEnum<T>>() {
             Ok(LenientEnum::Known(_)) => {}
-            Ok(LenientEnum::Unknown(raw_value)) => {
+            Ok(LenientEnum::Unknown(TomlValue::String(raw_value))) => {
                 warn_and_remove(root, &value_path, &value_path, &raw_value, warnings);
             }
-            Ok(LenientEnum::Other(_)) | Err(_) => {}
+            Ok(LenientEnum::Unknown(_)) | Err(_) => {}
         };
     }
 }
@@ -156,7 +155,7 @@ fn sanitize_tagged_enum<T>(
         };
         match value.try_into::<LenientEnum<T>>() {
             Ok(LenientEnum::Known(_)) => {}
-            Ok(LenientEnum::Other(table_value)) => {
+            Ok(LenientEnum::Unknown(table_value)) => {
                 let Some(raw_value) = table_value
                     .get(tag_key)
                     .and_then(TomlValue::as_str)
@@ -166,7 +165,7 @@ fn sanitize_tagged_enum<T>(
                 };
                 warn_and_remove(root, &tag_path, &parent_path, &raw_value, warnings);
             }
-            Ok(LenientEnum::Unknown(_)) | Err(_) => {}
+            Err(_) => {}
         };
     }
 }

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -35,6 +35,7 @@ use codex_config::loader::load_config_layers_state;
 use codex_config::loader::project_trust_key;
 use codex_config::profile_toml::ConfigProfile;
 use codex_config::sandbox_mode_requirement_for_permission_profile;
+use codex_config::sanitize_unknown_enum_values;
 use codex_config::types::ApprovalsReviewer;
 use codex_config::types::AuthCredentialsStoreMode;
 use codex_config::types::DEFAULT_OTEL_ENVIRONMENT;
@@ -951,7 +952,7 @@ impl ConfigBuilder {
             None => AbsolutePathBuf::current_dir()?,
         };
         harness_overrides.cwd = Some(cwd.to_path_buf());
-        let config_layer_stack = load_config_layers_state(
+        let mut config_layer_stack = load_config_layers_state(
             LOCAL_FS.as_ref(),
             &codex_home,
             Some(cwd),
@@ -963,6 +964,7 @@ impl ConfigBuilder {
                 .unwrap_or(&codex_config::NoopThreadConfigLoader),
         )
         .await?;
+        let unknown_enum_warnings = config_layer_stack.sanitize_unknown_enum_values();
         let merged_toml = config_layer_stack.effective_config();
 
         // Note that each layer in ConfigLayerStack should have resolved
@@ -1017,20 +1019,25 @@ impl ConfigBuilder {
                 lock_config_layer_stack,
             )
             .await?;
+            config
+                .startup_warnings
+                .splice(0..0, unknown_enum_warnings.clone());
             config.config_lock_toml = Some(Arc::new(expected_lock_config));
             config.config_lock_allow_codex_version_mismatch = allow_codex_version_mismatch;
             config.config_lock_save_fields_resolved_from_model_catalog =
                 save_fields_resolved_from_model_catalog;
             return Ok(config);
         }
-        Config::load_config_with_layer_stack(
+        let mut config = Config::load_config_with_layer_stack(
             LOCAL_FS.as_ref(),
             config_toml,
             harness_overrides,
             codex_home,
             config_layer_stack,
         )
-        .await
+        .await?;
+        config.startup_warnings.splice(0..0, unknown_enum_warnings);
+        Ok(config)
     }
 
     #[cfg(test)]
@@ -1159,6 +1166,7 @@ impl Config {
         })?;
         let cli_layer = codex_config::build_cli_overrides_layer(&cli_overrides);
         codex_config::merge_toml_values(&mut merged, &cli_layer);
+        sanitize_unknown_enum_values(&mut merged);
         let codex_home = AbsolutePathBuf::from_absolute_path_checked(codex_home)?;
         let config_toml = deserialize_config_toml_with_base(merged, &codex_home)?;
         Self::load_config_with_layer_stack(
@@ -1225,6 +1233,8 @@ pub async fn load_config_as_toml_with_cli_and_loader_overrides(
     )
     .await?;
 
+    let mut config_layer_stack = config_layer_stack;
+    config_layer_stack.sanitize_unknown_enum_values();
     let merged_toml = config_layer_stack.effective_config();
     let cfg = deserialize_config_toml_with_base(merged_toml, codex_home).map_err(|e| {
         tracing::error!("Failed to deserialize overridden config: {e}");
@@ -1241,6 +1251,8 @@ pub fn deserialize_config_toml_with_base(
     // This guard ensures that any relative paths that is deserialized into an
     // [AbsolutePathBuf] is resolved against `config_base_dir`.
     let _guard = AbsolutePathBufGuard::new(config_base_dir);
+    let mut root_value = root_value;
+    sanitize_unknown_enum_values(&mut root_value);
     root_value
         .try_into()
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))

--- a/codex-rs/core/tests/suite/config_unknown_enum_values.rs
+++ b/codex-rs/core/tests/suite/config_unknown_enum_values.rs
@@ -1,0 +1,35 @@
+use codex_protocol::protocol::EventMsg;
+use codex_protocol::protocol::WarningEvent;
+use core_test_support::responses::start_mock_server;
+use core_test_support::test_codex::test_codex;
+use core_test_support::wait_for_event;
+use pretty_assertions::assert_eq;
+
+const CONFIG_TOML: &str = "config.toml";
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unknown_config_enum_value_emits_startup_warning_and_uses_default() {
+    let server = start_mock_server().await;
+    let mut builder = test_codex().with_pre_build_hook(|home| {
+        std::fs::write(home.join(CONFIG_TOML), "service_tier = \"ultrafast\"\n")
+            .expect("seed config.toml");
+    });
+
+    let test = builder.build(&server).await.expect("create conversation");
+    let warning = wait_for_event(&test.codex, |event| {
+        matches!(
+            event,
+            EventMsg::Warning(WarningEvent { message })
+                if message.contains("service_tier") && message.contains("ultrafast")
+        )
+    })
+    .await;
+
+    assert_eq!(None, test.config.service_tier);
+    assert_eq!(
+        EventMsg::Warning(WarningEvent {
+            message: "Ignoring unrecognized config value `ultrafast` for `service_tier`; using the default for this setting.".to_string(),
+        }),
+        warning
+    );
+}

--- a/codex-rs/core/tests/suite/mod.rs
+++ b/codex-rs/core/tests/suite/mod.rs
@@ -44,6 +44,7 @@ mod collaboration_instructions;
 mod compact;
 mod compact_remote;
 mod compact_resume_fork;
+mod config_unknown_enum_values;
 mod deprecation_notice;
 mod exec;
 mod exec_policy;


### PR DESCRIPTION
## Why

Codex apps on the same machine can be on different versions. When a newer app writes a newly added config enum value, an older CLI or app currently fails while reading `config.toml`. That makes adding enum variants risky for settings like `service_tier`, approvals, sandboxing, auth storage, reasoning controls, personality, and web search.

This PR makes config loading handle that mixed-version case gracefully: an unrecognized string enum value is treated as if that setting was absent, and startup emits a warning explaining which value was ignored.

## What changed

- Added a small generic config-layer sanitizer with an explicit registry of enum-valued config paths.
- The sanitizer removes only unrecognized string enum values; wrong shapes and other invalid config still fail normally.
- Sanitization runs per config layer before merging, so an unknown higher-precedence value does not mask a valid lower-precedence value.
- Startup warnings from this sanitizer flow through the existing `Config.startup_warnings` path and are emitted as `EventMsg::Warning` when a Codex session starts.
- Added integration coverage that writes `service_tier = "ultrafast"` to `config.toml`, starts a test session, and asserts the default value plus warning event behavior.

## Verification

- Added `unknown_config_enum_value_emits_startup_warning_and_uses_default` integration coverage.
- Ran `cargo check -p codex-config`.
- Ran `cargo check -p codex-core`.