### PR TITLE
Add turn_id to Codex skill invocation analytics

### DIFF
--- a/codex-rs/analytics/src/analytics_client_tests.rs
+++ b/codex-rs/analytics/src/analytics_client_tests.rs
@@ -1835,6 +1835,7 @@ async fn reducer_ingests_skill_invoked_fact() {
                 "skill_scope": "user",
                 "repo_url": null,
                 "thread_id": "thread-1",
+                "turn_id": "turn-1",
                 "invoke_type": "explicit",
                 "model_slug": "gpt-5"
             }

--- a/codex-rs/analytics/src/events.rs
+++ b/codex-rs/analytics/src/events.rs
@@ -82,6 +82,7 @@ pub(crate) struct SkillInvocationEventParams {
     pub(crate) skill_scope: Option<String>,
     pub(crate) repo_url: Option<String>,
     pub(crate) thread_id: Option<String>,
+    pub(crate) turn_id: Option<String>,
     pub(crate) invoke_type: Option<InvocationType>,
     pub(crate) model_slug: Option<String>,
 }

--- a/codex-rs/analytics/src/reducer.rs
+++ b/codex-rs/analytics/src/reducer.rs
@@ -496,6 +496,7 @@ impl AnalyticsReducer {
                     skill_name: invocation.skill_name.clone(),
                     event_params: SkillInvocationEventParams {
                         thread_id: Some(tracking.thread_id.clone()),
+                        turn_id: Some(tracking.turn_id.clone()),
                         invoke_type: Some(invocation.invocation_type),
                         model_slug: Some(tracking.model_slug.clone()),
                         product_client_id: Some(originator().value),


### PR DESCRIPTION
## Summary
- add `turn_id` to the Codex skill invocation analytics payload
- populate it from the existing turn-level `TrackEventsContext`
- update the reducer test expectation so serialized `skill_invocation` events include the turn id

## Why
`chatgpt_skill_resource_invocation` / `fact_skill_product_events` already have backend/schema support for `turn_id`, but Codex skill invocation events were only sending `thread_id`. This caused Codex Desktop skill invocation rows to keep `turn_id` null and prevented reliable turn-level joins with artifact/file events.

## Validation
- `cargo test -p codex-analytics reducer_ingests_skill_invoked_fact`
