### PR TITLE
Add Codex app selector options 

### DIFF
--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -109,7 +109,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.0"
+version = "0.129.0-alpha.2"
 # Track the edition for all workspace crates in one place. Individual
 # crates can still override this value, but keeping it here means new
 # crates created with `cargo new -w ...` automatically inherit the 2024

--- a/codex-rs/cli/src/app_cmd.rs
+++ b/codex-rs/cli/src/app_cmd.rs
@@ -1,5 +1,9 @@
 use clap::Parser;
+use codex_utils_cli::CliConfigOverrides;
 use std::path::PathBuf;
+
+use crate::app_selector::app_selector_from_options;
+use crate::app_selector::validate_download_url_selector_combination;
 
 #[derive(Debug, Parser)]
 pub struct AppCommand {
@@ -10,16 +14,48 @@ pub struct AppCommand {
     /// Override the app installer download URL (advanced).
     #[arg(long = "download-url")]
     pub download_url_override: Option<String>,
+
+    /// Open a specific installed Codex app bundle by bundle identifier.
+    #[arg(
+        long = "bundle-id",
+        value_name = "BUNDLE_ID",
+        conflicts_with = "app_path"
+    )]
+    pub bundle_id: Option<String>,
+
+    /// Open a specific installed Codex .app bundle at this path.
+    #[arg(
+        long = "app-path",
+        value_name = "APP_PATH",
+        conflicts_with = "bundle_id"
+    )]
+    pub app_path: Option<PathBuf>,
 }
 
-pub async fn run_app(cmd: AppCommand) -> anyhow::Result<()> {
+pub async fn run_app(cmd: AppCommand, config_overrides: CliConfigOverrides) -> anyhow::Result<()> {
+    let selector =
+        app_selector_from_options(cmd.bundle_id, cmd.app_path).map_err(anyhow::Error::msg)?;
+    validate_download_url_selector_combination(&selector, &cmd.download_url_override)
+        .map_err(anyhow::Error::msg)?;
     let workspace = std::fs::canonicalize(&cmd.path).unwrap_or(cmd.path);
     #[cfg(target_os = "macos")]
     {
-        crate::desktop_app::run_app_open_or_install(workspace, cmd.download_url_override).await
+        crate::desktop_app::run_app_open_or_install(
+            workspace,
+            cmd.download_url_override,
+            selector,
+            config_overrides.raw_overrides,
+        )
+        .await
     }
     #[cfg(target_os = "windows")]
     {
-        crate::desktop_app::run_app_open_or_install(workspace, cmd.download_url_override).await
+        crate::desktop_app::run_app_open_or_install(
+            workspace,
+            cmd.download_url_override,
+            selector,
+            config_overrides.raw_overrides,
+        )
+        .await
     }
 }

--- a/codex-rs/cli/src/app_selector.rs
+++ b/codex-rs/cli/src/app_selector.rs
@@ -1,0 +1,103 @@
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DesktopAppSelector {
+    BundleId(String),
+    AppPath(PathBuf),
+}
+
+pub fn app_selector_from_options(
+    bundle_id: Option<String>,
+    app_path: Option<PathBuf>,
+) -> Result<Option<DesktopAppSelector>, String> {
+    match (bundle_id, app_path) {
+        (Some(bundle_id), None) => {
+            let bundle_id = bundle_id.trim();
+            if bundle_id.is_empty() {
+                return Err("--bundle-id must not be empty".to_string());
+            }
+            Ok(Some(DesktopAppSelector::BundleId(bundle_id.to_string())))
+        }
+        (None, Some(app_path)) => Ok(Some(DesktopAppSelector::AppPath(app_path))),
+        (None, None) => Ok(None),
+        (Some(_), Some(_)) => Err("--bundle-id and --app-path cannot be used together".to_string()),
+    }
+}
+
+pub fn validate_download_url_selector_combination(
+    selector: &Option<DesktopAppSelector>,
+    download_url_override: &Option<String>,
+) -> Result<(), String> {
+    if selector.is_some() && download_url_override.is_some() {
+        Err("--download-url cannot be used with --bundle-id or --app-path".to_string())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DesktopAppSelector;
+    use super::app_selector_from_options;
+    use super::validate_download_url_selector_combination;
+    use std::path::PathBuf;
+
+    #[test]
+    fn selects_bundle_id_route() {
+        assert_eq!(
+            app_selector_from_options(Some("com.openai.codex.nightly".to_string()), None).unwrap(),
+            Some(DesktopAppSelector::BundleId(
+                "com.openai.codex.nightly".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn selects_app_path_route() {
+        assert_eq!(
+            app_selector_from_options(
+                None,
+                Some(PathBuf::from("/Applications/Codex (Nightly).app"))
+            )
+            .unwrap(),
+            Some(DesktopAppSelector::AppPath(PathBuf::from(
+                "/Applications/Codex (Nightly).app"
+            )))
+        );
+    }
+
+    #[test]
+    fn rejects_empty_bundle_id_selector() {
+        assert_eq!(
+            app_selector_from_options(Some("   ".to_string()), None).unwrap_err(),
+            "--bundle-id must not be empty"
+        );
+    }
+
+    #[test]
+    fn rejects_conflicting_selectors() {
+        assert_eq!(
+            app_selector_from_options(
+                Some("com.openai.codex.nightly".to_string()),
+                Some(PathBuf::from("/Applications/Codex (Nightly).app"))
+            )
+            .unwrap_err(),
+            "--bundle-id and --app-path cannot be used together"
+        );
+    }
+
+    #[test]
+    fn rejects_download_url_with_selector() {
+        let selector = Some(DesktopAppSelector::BundleId(
+            "com.openai.codex.nightly".to_string(),
+        ));
+        assert_eq!(
+            validate_download_url_selector_combination(
+                &selector,
+                &Some("https://example.test/Codex.dmg".to_string())
+            )
+            .unwrap_err(),
+            "--download-url cannot be used with --bundle-id or --app-path"
+        );
+    }
+}

--- a/codex-rs/cli/src/desktop_app/mac.rs
+++ b/codex-rs/cli/src/desktop_app/mac.rs
@@ -5,6 +5,11 @@ use std::path::PathBuf;
 use tempfile::Builder;
 use tokio::process::Command;
 
+use super::DesktopAppSelector;
+use super::open_args::OpenTarget;
+use super::open_args::build_open_args;
+use super::open_args::display_open_args;
+
 const CODEX_DMG_URL_ARM64: &str = "https://persistent.oaistatic.com/codex-app-prod/Codex.dmg";
 const CODEX_DMG_URL_X64: &str =
     "https://persistent.oaistatic.com/codex-app-prod/Codex-latest-x64.dmg";
@@ -12,13 +17,20 @@ const CODEX_DMG_URL_X64: &str =
 pub async fn run_mac_app_open_or_install(
     workspace: PathBuf,
     download_url_override: Option<String>,
+    selector: Option<DesktopAppSelector>,
+    config_overrides: Vec<String>,
 ) -> anyhow::Result<()> {
+    if let Some(selector) = selector {
+        open_selected_codex_app(selector, &workspace, &config_overrides).await?;
+        return Ok(());
+    }
+
     if let Some(app_path) = find_existing_codex_app_path() {
         eprintln!(
             "Opening Codex Desktop at {app_path}...",
             app_path = app_path.display()
         );
-        open_codex_app(&app_path, &workspace).await?;
+        open_codex_app(OpenTarget::AppPath(app_path), &workspace, &config_overrides).await?;
         return Ok(());
     }
     eprintln!("Codex Desktop not found; downloading installer...");
@@ -37,7 +49,49 @@ pub async fn run_mac_app_open_or_install(
         "Launching Codex Desktop from {installed_app}...",
         installed_app = installed_app.display()
     );
-    open_codex_app(&installed_app, &workspace).await?;
+    open_codex_app(
+        OpenTarget::AppPath(installed_app),
+        &workspace,
+        &config_overrides,
+    )
+    .await?;
+    Ok(())
+}
+
+async fn open_selected_codex_app(
+    selector: DesktopAppSelector,
+    workspace: &Path,
+    config_overrides: &[String],
+) -> anyhow::Result<()> {
+    match selector {
+        DesktopAppSelector::BundleId(bundle_id) => {
+            eprintln!("Opening Codex Desktop bundle {bundle_id}...");
+            open_codex_app(OpenTarget::BundleId(bundle_id), workspace, config_overrides).await
+        }
+        DesktopAppSelector::AppPath(app_path) => {
+            validate_app_path_selector(&app_path)?;
+            eprintln!(
+                "Opening Codex Desktop at {app_path}...",
+                app_path = app_path.display()
+            );
+            open_codex_app(OpenTarget::AppPath(app_path), workspace, config_overrides).await
+        }
+    }
+}
+
+fn validate_app_path_selector(app_path: &Path) -> anyhow::Result<()> {
+    if app_path.extension().is_none_or(|ext| ext != "app") {
+        anyhow::bail!(
+            "--app-path must point to a .app bundle: {app_path}",
+            app_path = app_path.display()
+        );
+    }
+    if !app_path.is_dir() {
+        anyhow::bail!(
+            "--app-path does not exist or is not a directory: {app_path}",
+            app_path = app_path.display()
+        );
+    }
     Ok(())
 }
 
@@ -77,15 +131,18 @@ fn candidate_codex_app_paths() -> Vec<PathBuf> {
     paths
 }
 
-async fn open_codex_app(app_path: &Path, workspace: &Path) -> anyhow::Result<()> {
+async fn open_codex_app(
+    target: OpenTarget,
+    workspace: &Path,
+    config_overrides: &[String],
+) -> anyhow::Result<()> {
     eprintln!(
         "Opening workspace {workspace}...",
         workspace = workspace.display()
     );
+    let open_args = build_open_args(&target, workspace, config_overrides);
     let status = Command::new("open")
-        .arg("-a")
-        .arg(app_path)
-        .arg(workspace)
+        .args(&open_args)
         .status()
         .await
         .context("failed to invoke `open`")?;
@@ -95,9 +152,8 @@ async fn open_codex_app(app_path: &Path, workspace: &Path) -> anyhow::Result<()>
     }
 
     anyhow::bail!(
-        "`open -a {app_path} {workspace}` exited with {status}",
-        app_path = app_path.display(),
-        workspace = workspace.display()
+        "`open {args}` exited with {status}",
+        args = display_open_args(&open_args),
     );
 }
 
@@ -311,6 +367,42 @@ mod tests {
         assert_eq!(
             parse_hdiutil_attach_mount_point(output).as_deref(),
             Some("/Volumes/Codex Installer")
+        );
+    }
+
+    #[test]
+    fn builds_open_args_for_bundle_id_with_config_overrides() {
+        assert_eq!(
+            args_as_strings(build_open_args(
+                &OpenTarget::BundleId("com.openai.codex.nightly".to_string()),
+                Path::new("/tmp/workspace"),
+                &[
+                    "features.foo=true".to_string(),
+                    "hooks.on_event=[\"echo hi\"]".to_string(),
+                ],
+            )),
+            vec![
+                "-b",
+                "com.openai.codex.nightly",
+                "/tmp/workspace",
+                "--args",
+                "-c",
+                "features.foo=true",
+                "-c",
+                "hooks.on_event=[\"echo hi\"]",
+            ]
+        );
+    }
+
+    #[test]
+    fn builds_open_args_for_app_path_without_config_overrides() {
+        assert_eq!(
+            args_as_strings(build_open_args(
+                &OpenTarget::AppPath(PathBuf::from("/Applications/Codex (Nightly).app")),
+                Path::new("/tmp/workspace"),
+                &[],
+            )),
+            vec!["-a", "/Applications/Codex (Nightly).app", "/tmp/workspace",]
         );
     }
 }

--- a/codex-rs/cli/src/desktop_app/mod.rs
+++ b/codex-rs/cli/src/desktop_app/mod.rs
@@ -1,22 +1,39 @@
 #[cfg(target_os = "macos")]
 mod mac;
+#[cfg(target_os = "macos")]
+mod open_args;
 #[cfg(target_os = "windows")]
 mod windows;
+
+use std::path::PathBuf;
+
+use crate::app_selector::DesktopAppSelector;
 
 /// Run the app install/open logic for the current OS.
 #[cfg(target_os = "macos")]
 pub async fn run_app_open_or_install(
-    workspace: std::path::PathBuf,
+    workspace: PathBuf,
     download_url_override: Option<String>,
+    selector: Option<DesktopAppSelector>,
+    config_overrides: Vec<String>,
 ) -> anyhow::Result<()> {
-    mac::run_mac_app_open_or_install(workspace, download_url_override).await
+    mac::run_mac_app_open_or_install(workspace, download_url_override, selector, config_overrides)
+        .await
 }
 
 /// Run the app install/open logic for the current OS.
 #[cfg(target_os = "windows")]
 pub async fn run_app_open_or_install(
-    workspace: std::path::PathBuf,
+    workspace: PathBuf,
     download_url_override: Option<String>,
+    selector: Option<DesktopAppSelector>,
+    config_overrides: Vec<String>,
 ) -> anyhow::Result<()> {
-    windows::run_windows_app_open_or_install(workspace, download_url_override).await
+    windows::run_windows_app_open_or_install(
+        workspace,
+        download_url_override,
+        selector,
+        config_overrides,
+    )
+    .await
 }

--- a/codex-rs/cli/src/desktop_app/open_args.rs
+++ b/codex-rs/cli/src/desktop_app/open_args.rs
@@ -1,0 +1,118 @@
+use std::ffi::OsString;
+use std::path::Path;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum OpenTarget {
+    BundleId(String),
+    AppPath(PathBuf),
+}
+
+pub(crate) fn build_open_args(
+    target: &OpenTarget,
+    workspace: &Path,
+    config_overrides: &[String],
+) -> Vec<OsString> {
+    let mut args = Vec::new();
+    match target {
+        OpenTarget::BundleId(bundle_id) => {
+            args.push(OsString::from("-b"));
+            args.push(OsString::from(bundle_id.as_str()));
+        }
+        OpenTarget::AppPath(app_path) => {
+            args.push(OsString::from("-a"));
+            args.push(app_path.as_os_str().to_os_string());
+        }
+    }
+    args.push(workspace.as_os_str().to_os_string());
+    if !config_overrides.is_empty() {
+        args.push(OsString::from("--args"));
+        for override_kv in config_overrides {
+            args.push(OsString::from("-c"));
+            args.push(OsString::from(override_kv));
+        }
+    }
+    args
+}
+
+pub(crate) fn display_open_args(args: &[OsString]) -> String {
+    args.iter()
+        .map(|arg| arg.to_string_lossy())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OpenTarget;
+    use super::build_open_args;
+    use super::display_open_args;
+    use std::path::Path;
+    use std::path::PathBuf;
+
+    fn args_as_strings(args: Vec<std::ffi::OsString>) -> Vec<String> {
+        args.into_iter()
+            .map(|arg| arg.to_string_lossy().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn builds_open_args_for_bundle_id_with_config_overrides() {
+        assert_eq!(
+            args_as_strings(build_open_args(
+                &OpenTarget::BundleId("com.openai.codex.nightly".to_string()),
+                Path::new("/tmp/workspace"),
+                &[
+                    "hooks.on_event=[\"echo hi\"]".to_string(),
+                    "features.experimental_foo=true".to_string(),
+                    "features.experimental_bar=false".to_string(),
+                ],
+            )),
+            vec![
+                "-b",
+                "com.openai.codex.nightly",
+                "/tmp/workspace",
+                "--args",
+                "-c",
+                "hooks.on_event=[\"echo hi\"]",
+                "-c",
+                "features.experimental_foo=true",
+                "-c",
+                "features.experimental_bar=false",
+            ]
+        );
+    }
+
+    #[test]
+    fn builds_open_args_for_app_path_with_config_overrides() {
+        assert_eq!(
+            args_as_strings(build_open_args(
+                &OpenTarget::AppPath(PathBuf::from("/Applications/Codex (Nightly).app")),
+                Path::new("/tmp/workspace"),
+                &["model=o3".to_string()],
+            )),
+            vec![
+                "-a",
+                "/Applications/Codex (Nightly).app",
+                "/tmp/workspace",
+                "--args",
+                "-c",
+                "model=o3",
+            ]
+        );
+    }
+
+    #[test]
+    fn displays_open_args_for_error_messages() {
+        let args = build_open_args(
+            &OpenTarget::BundleId("com.openai.codex.nightly".to_string()),
+            Path::new("/tmp/workspace"),
+            &[],
+        );
+
+        assert_eq!(
+            display_open_args(&args),
+            "-b com.openai.codex.nightly /tmp/workspace"
+        );
+    }
+}

--- a/codex-rs/cli/src/desktop_app/windows.rs
+++ b/codex-rs/cli/src/desktop_app/windows.rs
@@ -3,6 +3,8 @@ use std::path::Path;
 use std::path::PathBuf;
 use tokio::process::Command;
 
+use super::DesktopAppSelector;
+
 const CODEX_WINDOWS_INSTALLER_URL: &str =
     "https://get.microsoft.com/installer/download/9PLM9XGG6VKS?cid=website_cta_psi";
 const CODEX_MICROSOFT_STORE_WEB_URL: &str = "https://apps.microsoft.com/detail/9plm9xgg6vks";
@@ -10,7 +12,16 @@ const CODEX_MICROSOFT_STORE_WEB_URL: &str = "https://apps.microsoft.com/detail/9
 pub async fn run_windows_app_open_or_install(
     workspace: PathBuf,
     download_url_override: Option<String>,
+    selector: Option<DesktopAppSelector>,
+    config_overrides: Vec<String>,
 ) -> anyhow::Result<()> {
+    if selector.is_some() {
+        anyhow::bail!("--bundle-id/--app-path are only supported by `codex app` on macOS");
+    }
+    if !config_overrides.is_empty() {
+        anyhow::bail!("-c/--enable/--disable overrides are only forwarded by `codex app` on macOS");
+    }
+
     if let Some(app_id) = find_codex_app_id().await? {
         eprintln!("Opening Codex Desktop...");
         open_installed_codex_app(&app_id).await?;

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -42,6 +42,8 @@ use supports_color::Stream;
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 mod app_cmd;
 #[cfg(any(target_os = "macos", target_os = "windows"))]
+mod app_selector;
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 mod desktop_app;
 mod marketplace_cmd;
 mod mcp_cmd;
@@ -895,7 +897,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
                 root_remote_auth_token_env.as_deref(),
                 "app",
             )?;
-            app_cmd::run_app(app_cli).await?;
+            app_cmd::run_app(app_cli, root_config_overrides).await?;
         }
         Some(Subcommand::Resume(ResumeCommand {
             session_id,


### PR DESCRIPTION
## Summary
- Add `codex app --bundle-id <BUNDLE_ID>` and `--app-path <APP_PATH>` selector options for opening a specific installed Codex Desktop app on macOS.
- Keep the stable fallback unchanged when no selector is provided: existing installed Codex app discovery/download/install behavior remains the default path.
- Preserve invocation-local overrides by forwarding `--enable`/`--disable`/`-c` raw overrides through macOS `open` as `--args -c ...`.

## Validation
- `cd codex-rs && rustc --edition=2024 --test cli/src/app_selector.rs -o /tmp/codex_app_selector_tests && /tmp/codex_app_selector_tests --nocapture`
- `cd codex-rs && rustc --edition=2024 --test cli/src/desktop_app/open_args.rs -o /tmp/codex_open_args_tests && /tmp/codex_open_args_tests --nocapture`
- `git diff --check`
- `cd codex-rs && cargo fmt -- --check --config imports_granularity=Item` (passes; rustfmt warns the configured imports granularity option is nightly-only on this toolchain)
- User-run help evidence from `/tmp/codex-selector-build.TzgKe0`: `cargo run -p codex-cli -- app --help` succeeded and includes `--bundle-id <BUNDLE_ID>` and `--app-path <APP_PATH>`.
- Downstream Nightly KG smoke: PASS.
