### PR TITLE
[codex] suspend legacy notify deprecation warning

### DIFF
--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -577,20 +577,6 @@ impl Session {
                 .notify
                 .as_ref()
                 .is_some_and(|argv| !argv.is_empty() && !argv[0].is_empty());
-            if legacy_notify_configured {
-                post_session_configured_events.push(Event {
-                    id: INITIAL_SUBMIT_ID.to_owned(),
-                    msg: EventMsg::DeprecationNotice(DeprecationNoticeEvent {
-                        summary:
-                            "`notify` is deprecated and will be removed in a future release."
-                                .to_string(),
-                        details: Some(
-                            "Switch to a `Stop` hook for end-of-turn automation. See https://developers.openai.com/codex/hooks."
-                                .to_string(),
-                        ),
-                    }),
-                });
-            }
             for message in &config.startup_warnings {
                 post_session_configured_events.push(Event {
                     id: "".to_owned(),

--- a/codex-rs/core/tests/suite/deprecation_notice.rs
+++ b/codex-rs/core/tests/suite/deprecation_notice.rs
@@ -116,38 +116,6 @@ async fn emits_deprecation_notice_for_experimental_instructions_file() -> anyhow
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn emits_deprecation_notice_for_notify() -> anyhow::Result<()> {
-    skip_if_no_network!(Ok(()));
-
-    let server = start_mock_server().await;
-
-    let mut builder = test_codex().with_config(|config| {
-        config.notify = Some(vec!["notify-send".to_string(), "Codex".to_string()]);
-    });
-
-    let TestCodex { codex, .. } = builder.build(&server).await?;
-
-    let notice = wait_for_event_match(&codex, |event| match event {
-        EventMsg::DeprecationNotice(ev) if ev.summary.contains("`notify`") => Some(ev.clone()),
-        _ => None,
-    })
-    .await;
-
-    let DeprecationNoticeEvent { summary, details } = notice;
-    assert_eq!(
-        summary,
-        "`notify` is deprecated and will be removed in a future release.".to_string(),
-    );
-    assert_eq!(
-        details.as_deref(),
-        Some(
-            "Switch to a `Stop` hook for end-of-turn automation. See https://developers.openai.com/codex/hooks."
-        ),
-    );
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn emits_deprecation_notice_for_web_search_feature_flag_values() -> anyhow::Result<()> {
     skip_if_no_network!(Ok(()));
 


### PR DESCRIPTION
# Why

The legacy `notify` deprecation notice currently reaches users whose configuration comes from the computer use plugin. We should avoid surfacing that warning until the plugin has migrated off `notify`, so users do not get a warning they cannot act on yet.

# What

- stop emitting the startup deprecation notice for configured legacy `notify`
- remove the regression test that asserted that notice
- keep the legacy usage metrics from #20524 in place so we can still observe migration progress before reintroducing the warning later

# Testing

- `just fmt`
- `cargo test -p codex-core emits_deprecation_notice_for_experimental_instructions_file`
