### PR TITLE
Wire Windows metadata monitor through sandbox exits

### DIFF
--- a/codex-rs/windows-sandbox-rs/src/elevated_impl.rs
+++ b/codex-rs/windows-sandbox-rs/src/elevated_impl.rs
@@ -131,6 +131,7 @@ mod windows_impl {
             allow_null_device(psid_to_use);
             allow_named_pipe_device(psid_to_use);
         }
+        let protected_metadata_runtime = protected_metadata_guard.into_runtime()?;
 
         (|| -> Result<CaptureResult> {
             let spawn_request = SpawnRequest {
@@ -183,8 +184,7 @@ mod windows_impl {
                 }
             };
 
-            let protected_metadata_violations =
-                protected_metadata_guard.cleanup_created_monitored_paths()?;
+            let protected_metadata_violations = protected_metadata_runtime.finish()?;
             if !protected_metadata_violations.is_empty() && exit_code == 0 {
                 exit_code = 1;
             }

--- a/codex-rs/windows-sandbox-rs/src/lib.rs
+++ b/codex-rs/windows-sandbox-rs/src/lib.rs
@@ -522,6 +522,7 @@ mod windows_impl {
                 allow_named_pipe_device(psid);
             }
         }
+        let protected_metadata_runtime = protected_metadata_guard.into_runtime()?;
         let (stdin_pair, stdout_pair, stderr_pair) = unsafe { setup_stdio_pipes()? };
         let ((in_r, in_w), (out_r, out_w), (err_r, err_w)) = (stdin_pair, stdout_pair, stderr_pair);
         let spawn_res = unsafe {
@@ -638,8 +639,7 @@ mod windows_impl {
         } else {
             exit_code_u32 as i32
         };
-        let protected_metadata_violations =
-            protected_metadata_guard.cleanup_created_monitored_paths()?;
+        let protected_metadata_violations = protected_metadata_runtime.finish()?;
         if !protected_metadata_violations.is_empty() && exit_code == 0 {
             exit_code = 1;
         }

--- a/codex-rs/windows-sandbox-rs/src/protected_metadata.rs
+++ b/codex-rs/windows-sandbox-rs/src/protected_metadata.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use crate::setup::ProtectedMetadataMode;
 use crate::setup::ProtectedMetadataTarget;
 use crate::winutil::to_wide;

--- a/codex-rs/windows-sandbox-rs/src/unified_exec/backends/elevated.rs
+++ b/codex-rs/windows-sandbox-rs/src/unified_exec/backends/elevated.rs
@@ -45,6 +45,7 @@ pub(crate) async fn spawn_windows_sandbox_session_elevated(
     )?;
 
     let protected_metadata_guard = prepare_protected_metadata_targets(protected_metadata_targets);
+    let protected_metadata_runtime = protected_metadata_guard.into_runtime()?;
     let spawn_request = SpawnRequest {
         command: command.clone(),
         cwd: cwd.to_path_buf(),
@@ -104,7 +105,7 @@ pub(crate) async fn spawn_windows_sandbox_session_elevated(
         stdout_tx,
         stderr_rx.as_ref().map(|(tx, _rx)| tx.clone()),
         exit_tx,
-        Some(protected_metadata_guard),
+        Some(protected_metadata_runtime),
     );
 
     Ok(finish_driver_spawn(

--- a/codex-rs/windows-sandbox-rs/src/unified_exec/backends/legacy.rs
+++ b/codex-rs/windows-sandbox-rs/src/unified_exec/backends/legacy.rs
@@ -10,7 +10,7 @@ use crate::process::StderrMode;
 use crate::process::StdinMode;
 use crate::process::read_handle_loop;
 use crate::process::spawn_process_with_pipes;
-use crate::protected_metadata::ProtectedMetadataGuard;
+use crate::protected_metadata::ProtectedMetadataRuntime;
 use crate::protected_metadata::prepare_protected_metadata_targets;
 use crate::setup::ProtectedMetadataTarget;
 use crate::spawn_prep::LocalSid;
@@ -208,7 +208,7 @@ fn finalize_exit(
     output_join: std::thread::JoinHandle<()>,
     guards: Vec<PathBuf>,
     cap_sid: Option<String>,
-    protected_metadata_guard: ProtectedMetadataGuard,
+    protected_metadata_runtime: ProtectedMetadataRuntime,
     logs_base_dir: Option<&Path>,
     command: Vec<String>,
 ) {
@@ -226,21 +226,20 @@ fn finalize_exit(
     };
 
     let _ = output_join.join();
-    let protected_metadata_failure =
-        match protected_metadata_guard.cleanup_created_monitored_paths() {
-            Ok(paths) => {
-                if !paths.is_empty() && exit_code == 0 {
-                    exit_code = 1;
-                }
-                None
+    let protected_metadata_failure = match protected_metadata_runtime.finish() {
+        Ok(paths) => {
+            if !paths.is_empty() && exit_code == 0 {
+                exit_code = 1;
             }
-            Err(err) => {
-                if exit_code == 0 {
-                    exit_code = 1;
-                }
-                Some(format!("protected metadata cleanup failed: {err:#}"))
+            None
+        }
+        Err(err) => {
+            if exit_code == 0 {
+                exit_code = 1;
             }
-        };
+            Some(format!("protected metadata cleanup failed: {err:#}"))
+        }
+    };
     let _ = exit_tx.send(exit_code);
 
     unsafe {
@@ -343,6 +342,7 @@ pub(crate) async fn spawn_windows_sandbox_session_legacy(
         persist_aces,
         &additional_deny_write_paths,
     );
+    let protected_metadata_runtime = protected_metadata_guard.into_runtime()?;
 
     let (writer_tx, writer_rx) = mpsc::channel::<Vec<u8>>(128);
     let (stdout_tx, stdout_rx) = broadcast::channel::<Vec<u8>>(256);
@@ -433,7 +433,7 @@ pub(crate) async fn spawn_windows_sandbox_session_legacy(
             output_join,
             guards_for_wait,
             cap_sid_for_wait,
-            protected_metadata_guard,
+            protected_metadata_runtime,
             common.logs_base_dir.as_deref(),
             command_for_wait,
         );

--- a/codex-rs/windows-sandbox-rs/src/unified_exec/backends/windows_common.rs
+++ b/codex-rs/windows-sandbox-rs/src/unified_exec/backends/windows_common.rs
@@ -6,7 +6,7 @@ use crate::ipc_framed::ResizePayload;
 use crate::ipc_framed::StdinPayload;
 use crate::ipc_framed::decode_bytes;
 use crate::ipc_framed::encode_bytes;
-use crate::protected_metadata::ProtectedMetadataGuard;
+use crate::protected_metadata::ProtectedMetadataRuntime;
 use anyhow::Result;
 use codex_utils_pty::ProcessDriver;
 use codex_utils_pty::SpawnedProcess;
@@ -98,7 +98,7 @@ pub(crate) fn start_runner_stdout_reader(
     stdout_tx: broadcast::Sender<Vec<u8>>,
     stderr_tx: Option<broadcast::Sender<Vec<u8>>>,
     exit_tx: oneshot::Sender<i32>,
-    protected_metadata_guard: Option<ProtectedMetadataGuard>,
+    protected_metadata_runtime: Option<ProtectedMetadataRuntime>,
 ) {
     std::thread::spawn(move || {
         loop {
@@ -143,8 +143,8 @@ pub(crate) fn start_runner_stdout_reader(
                 }
                 Message::Exit { payload } => {
                     let mut exit_code = payload.exit_code;
-                    if let Some(protected_metadata_guard) = protected_metadata_guard {
-                        match protected_metadata_guard.cleanup_created_monitored_paths() {
+                    if let Some(protected_metadata_runtime) = protected_metadata_runtime {
+                        match protected_metadata_runtime.finish() {
                             Ok(paths) => {
                                 if !paths.is_empty() && exit_code == 0 {
                                     exit_code = 1;


### PR DESCRIPTION
## Summary

1. Wires the missing metadata monitor through Windows sandbox command exits.
2. Ensures listeners are closed and cleanup runs after sandboxed commands finish.

## Why

1. The monitor runtime must be attached to the sandbox lifecycle to enforce paths created during a command.
2. This PR connects the runtime without changing sentinel ACL behavior, which keeps the lifecycle wiring separate from the final hardening slices.

## Stack Relation

This PR is part 18 of 21 in the Windows protected metadata stack.

1. [PR 20889](https://github.com/openai/codex/pull/20889) Add Windows metadata adapter target type
2. [PR 20890](https://github.com/openai/codex/pull/20890) Add Windows metadata setup target type
3. [PR 20891](https://github.com/openai/codex/pull/20891) Add Windows metadata enforcement guard
4. [PR 21030](https://github.com/openai/codex/pull/21030) Plan Windows metadata targets from filesystem policy
5. [PR 21031](https://github.com/openai/codex/pull/21031) Thread Windows metadata targets through setup request
6. [PR 21032](https://github.com/openai/codex/pull/21032) Pass Windows metadata targets to direct exec
7. [PR 21033](https://github.com/openai/codex/pull/21033) Thread Windows metadata targets through sessions
8. [PR 21035](https://github.com/openai/codex/pull/21035) Enforce Windows protected metadata targets
9. [PR 21036](https://github.com/openai/codex/pull/21036) Deny Windows protected metadata symlink targets
10. [PR 21037](https://github.com/openai/codex/pull/21037) Use Windows metadata targets in debug sandbox
11. [PR 21038](https://github.com/openai/codex/pull/21038) Allow Windows sandbox Git signal pipes
12. [PR 21039](https://github.com/openai/codex/pull/21039) Add Windows legacy Git read root helpers
13. [PR 21040](https://github.com/openai/codex/pull/21040) Grant Windows legacy Git read roots
14. [PR 21041](https://github.com/openai/codex/pull/21041) Inject Git safe directory for Windows legacy sandbox
15. [PR 21042](https://github.com/openai/codex/pull/21042) Test Windows runtime metadata target preparation
16. [PR 21043](https://github.com/openai/codex/pull/21043) Document Windows metadata request boundary
17. [PR 21172](https://github.com/openai/codex/pull/21172) Add Windows missing metadata monitor runtime
18. [PR 21173](https://github.com/openai/codex/pull/21173) Wire Windows metadata monitor through sandbox exits
19. [PR 21174](https://github.com/openai/codex/pull/21174) Add Windows missing metadata deny sentinel
20. [PR 21175](https://github.com/openai/codex/pull/21175) Wire missing Windows metadata to deny sentinel
21. [PR 21184](https://github.com/openai/codex/pull/21184) Use direct deny ACLs for Windows metadata sentinels

## Validation

1. Stack head local format and Rust tests passed on `95ef124d6194bd2126c11928cb3973214f9ac63a`.
2. Azure Windows VM 56 case validation is running on `95ef124d6194bd2126c11928cb3973214f9ac63a`.