### PR TITLE
Wire missing Windows metadata to deny sentinel

### DIFF
--- a/codex-rs/cli/src/debug_sandbox.rs
+++ b/codex-rs/cli/src/debug_sandbox.rs
@@ -478,7 +478,7 @@ fn windows_debug_protected_metadata_targets(
             let mode = if std::fs::symlink_metadata(path.as_path()).is_ok() {
                 codex_windows_sandbox::ProtectedMetadataMode::ExistingDeny
             } else {
-                codex_windows_sandbox::ProtectedMetadataMode::MissingCreationMonitor
+                codex_windows_sandbox::ProtectedMetadataMode::MissingDenySentinel
             };
             targets.push(codex_windows_sandbox::ProtectedMetadataTarget {
                 path: path.as_path().to_path_buf(),

--- a/codex-rs/core/src/exec.rs
+++ b/codex-rs/core/src/exec.rs
@@ -121,13 +121,18 @@ pub(crate) struct WindowsProtectedMetadataTarget {
     pub(crate) mode: WindowsProtectedMetadataMode,
 }
 
-/// Layer: Windows adapter layer. The enforcement layer needs to know why a
-/// protected metadata path is absent instead of treating every missing path as
-/// an existing filesystem object.
+/// Layer: Windows adapter layer. The enforcement layer needs to know whether a
+/// protected metadata path already exists or must be denied before the command
+/// can create it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum WindowsProtectedMetadataMode {
+    /// The protected metadata object exists before launch, so the Windows
+    /// sandbox should deny writes to the object and any canonical target.
     ExistingDeny,
-    MissingCreationMonitor,
+    /// The protected metadata object is absent before launch, so the Windows
+    /// sandbox should create and deny-list a temporary sentinel before command
+    /// execution can begin.
+    MissingDenySentinel,
 }
 
 fn windows_sandbox_uses_elevated_backend(
@@ -666,8 +671,8 @@ async fn exec_windows_sandbox(
                         WindowsProtectedMetadataMode::ExistingDeny => {
                             codex_windows_sandbox::ProtectedMetadataMode::ExistingDeny
                         }
-                        WindowsProtectedMetadataMode::MissingCreationMonitor => {
-                            codex_windows_sandbox::ProtectedMetadataMode::MissingCreationMonitor
+                        WindowsProtectedMetadataMode::MissingDenySentinel => {
+                            codex_windows_sandbox::ProtectedMetadataMode::MissingDenySentinel
                         }
                     };
                     codex_windows_sandbox::ProtectedMetadataTarget {
@@ -1361,7 +1366,7 @@ fn windows_protected_metadata_mode(path: &AbsolutePathBuf) -> WindowsProtectedMe
         return WindowsProtectedMetadataMode::ExistingDeny;
     }
 
-    WindowsProtectedMetadataMode::MissingCreationMonitor
+    WindowsProtectedMetadataMode::MissingDenySentinel
 }
 
 fn has_reopened_writable_descendant(

--- a/codex-rs/core/src/exec_tests.rs
+++ b/codex-rs/core/src/exec_tests.rs
@@ -666,15 +666,15 @@ fn windows_restricted_token_supports_full_read_split_write_read_carveouts() {
             protected_metadata_targets: vec![
                 WindowsProtectedMetadataTarget {
                     path: cwd.join(".agents"),
-                    mode: WindowsProtectedMetadataMode::MissingCreationMonitor,
+                    mode: WindowsProtectedMetadataMode::MissingDenySentinel,
                 },
                 WindowsProtectedMetadataTarget {
                     path: cwd.join(".codex"),
-                    mode: WindowsProtectedMetadataMode::MissingCreationMonitor,
+                    mode: WindowsProtectedMetadataMode::MissingDenySentinel,
                 },
                 WindowsProtectedMetadataTarget {
                     path: cwd.join(".git"),
-                    mode: WindowsProtectedMetadataMode::MissingCreationMonitor,
+                    mode: WindowsProtectedMetadataMode::MissingDenySentinel,
                 },
             ],
         }))
@@ -778,15 +778,15 @@ fn windows_elevated_supports_split_write_read_carveouts() {
             protected_metadata_targets: vec![
                 WindowsProtectedMetadataTarget {
                     path: expected_root.join(".agents"),
-                    mode: WindowsProtectedMetadataMode::MissingCreationMonitor,
+                    mode: WindowsProtectedMetadataMode::MissingDenySentinel,
                 },
                 WindowsProtectedMetadataTarget {
                     path: expected_root.join(".codex"),
-                    mode: WindowsProtectedMetadataMode::MissingCreationMonitor,
+                    mode: WindowsProtectedMetadataMode::MissingDenySentinel,
                 },
                 WindowsProtectedMetadataTarget {
                     path: expected_root.join(".git"),
-                    mode: WindowsProtectedMetadataMode::MissingCreationMonitor,
+                    mode: WindowsProtectedMetadataMode::MissingDenySentinel,
                 },
             ],
         }))
@@ -840,11 +840,11 @@ fn windows_metadata_plan_marks_existing_metadata_for_deny() {
             protected_metadata_targets: vec![
                 WindowsProtectedMetadataTarget {
                     path: cwd.join(".agents"),
-                    mode: WindowsProtectedMetadataMode::MissingCreationMonitor,
+                    mode: WindowsProtectedMetadataMode::MissingDenySentinel,
                 },
                 WindowsProtectedMetadataTarget {
                     path: cwd.join(".codex"),
-                    mode: WindowsProtectedMetadataMode::MissingCreationMonitor,
+                    mode: WindowsProtectedMetadataMode::MissingDenySentinel,
                 },
                 WindowsProtectedMetadataTarget {
                     path: cwd.join(".git"),
@@ -856,7 +856,7 @@ fn windows_metadata_plan_marks_existing_metadata_for_deny() {
 }
 
 #[test]
-fn windows_metadata_plan_does_not_materialize_nested_missing_git() {
+fn windows_metadata_plan_uses_sentinel_for_nested_missing_git() {
     let temp_dir = tempfile::TempDir::new().expect("tempdir");
     let repo = dunce::canonicalize(temp_dir.path())
         .expect("canonical temp dir")
@@ -904,15 +904,15 @@ fn windows_metadata_plan_does_not_materialize_nested_missing_git() {
             protected_metadata_targets: vec![
                 WindowsProtectedMetadataTarget {
                     path: cwd.join(".agents"),
-                    mode: WindowsProtectedMetadataMode::MissingCreationMonitor,
+                    mode: WindowsProtectedMetadataMode::MissingDenySentinel,
                 },
                 WindowsProtectedMetadataTarget {
                     path: cwd.join(".codex"),
-                    mode: WindowsProtectedMetadataMode::MissingCreationMonitor,
+                    mode: WindowsProtectedMetadataMode::MissingDenySentinel,
                 },
                 WindowsProtectedMetadataTarget {
                     path: cwd.join(".git"),
-                    mode: WindowsProtectedMetadataMode::MissingCreationMonitor,
+                    mode: WindowsProtectedMetadataMode::MissingDenySentinel,
                 },
             ],
         }))
@@ -973,15 +973,15 @@ fn windows_shell_runtime_path_resolves_metadata_overrides() {
         vec![
             WindowsProtectedMetadataTarget {
                 path: cwd.join(".agents"),
-                mode: WindowsProtectedMetadataMode::MissingCreationMonitor,
+                mode: WindowsProtectedMetadataMode::MissingDenySentinel,
             },
             WindowsProtectedMetadataTarget {
                 path: cwd.join(".codex"),
-                mode: WindowsProtectedMetadataMode::MissingCreationMonitor,
+                mode: WindowsProtectedMetadataMode::MissingDenySentinel,
             },
             WindowsProtectedMetadataTarget {
                 path: cwd.join(".git"),
-                mode: WindowsProtectedMetadataMode::MissingCreationMonitor,
+                mode: WindowsProtectedMetadataMode::MissingDenySentinel,
             },
         ]
     );

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -190,8 +190,8 @@ fn protected_metadata_targets_for_windows_session(
                         WindowsProtectedMetadataMode::ExistingDeny => {
                             codex_windows_sandbox::ProtectedMetadataMode::ExistingDeny
                         }
-                        WindowsProtectedMetadataMode::MissingCreationMonitor => {
-                            codex_windows_sandbox::ProtectedMetadataMode::MissingCreationMonitor
+                        WindowsProtectedMetadataMode::MissingDenySentinel => {
+                            codex_windows_sandbox::ProtectedMetadataMode::MissingDenySentinel
                         }
                     };
                     codex_windows_sandbox::ProtectedMetadataTarget {

--- a/codex-rs/core/src/unified_exec/process_manager_tests.rs
+++ b/codex-rs/core/src/unified_exec/process_manager_tests.rs
@@ -183,15 +183,15 @@ fn open_session_prepares_windows_metadata_overrides_for_unified_exec() {
         vec![
             crate::exec::WindowsProtectedMetadataTarget {
                 path: cwd.join(".agents"),
-                mode: crate::exec::WindowsProtectedMetadataMode::MissingCreationMonitor,
+                mode: crate::exec::WindowsProtectedMetadataMode::MissingDenySentinel,
             },
             crate::exec::WindowsProtectedMetadataTarget {
                 path: cwd.join(".codex"),
-                mode: crate::exec::WindowsProtectedMetadataMode::MissingCreationMonitor,
+                mode: crate::exec::WindowsProtectedMetadataMode::MissingDenySentinel,
             },
             crate::exec::WindowsProtectedMetadataTarget {
                 path: cwd.join(".git"),
-                mode: crate::exec::WindowsProtectedMetadataMode::MissingCreationMonitor,
+                mode: crate::exec::WindowsProtectedMetadataMode::MissingDenySentinel,
             },
         ]
     );


### PR DESCRIPTION
## Summary

1. Wires missing Windows protected metadata targets to the deny sentinel mode.
2. Keeps the policy decision for missing `.git`, `.codex`, and `.agents` paths connected to setup enforcement.

## Why

1. Missing protected metadata paths must become sentinel targets before sandboxed commands run.
2. This PR connects the mode added in the previous slice to the existing target planning and setup request flow.

## Stack Relation

This PR is part 20 of 21 in the Windows protected metadata stack.

1. [PR 20889](https://github.com/openai/codex/pull/20889) Add Windows metadata adapter target type
2. [PR 20890](https://github.com/openai/codex/pull/20890) Add Windows metadata setup target type
3. [PR 20891](https://github.com/openai/codex/pull/20891) Add Windows metadata enforcement guard
4. [PR 21030](https://github.com/openai/codex/pull/21030) Plan Windows metadata targets from filesystem policy
5. [PR 21031](https://github.com/openai/codex/pull/21031) Thread Windows metadata targets through setup request
6. [PR 21032](https://github.com/openai/codex/pull/21032) Pass Windows metadata targets to direct exec
7. [PR 21033](https://github.com/openai/codex/pull/21033) Thread Windows metadata targets through sessions
8. [PR 21035](https://github.com/openai/codex/pull/21035) Enforce Windows protected metadata targets
9. [PR 21036](https://github.com/openai/codex/pull/21036) Deny Windows protected metadata symlink targets
10. [PR 21037](https://github.com/openai/codex/pull/21037) Use Windows metadata targets in debug sandbox
11. [PR 21038](https://github.com/openai/codex/pull/21038) Allow Windows sandbox Git signal pipes
12. [PR 21039](https://github.com/openai/codex/pull/21039) Add Windows legacy Git read root helpers
13. [PR 21040](https://github.com/openai/codex/pull/21040) Grant Windows legacy Git read roots
14. [PR 21041](https://github.com/openai/codex/pull/21041) Inject Git safe directory for Windows legacy sandbox
15. [PR 21042](https://github.com/openai/codex/pull/21042) Test Windows runtime metadata target preparation
16. [PR 21043](https://github.com/openai/codex/pull/21043) Document Windows metadata request boundary
17. [PR 21172](https://github.com/openai/codex/pull/21172) Add Windows missing metadata monitor runtime
18. [PR 21173](https://github.com/openai/codex/pull/21173) Wire Windows metadata monitor through sandbox exits
19. [PR 21174](https://github.com/openai/codex/pull/21174) Add Windows missing metadata deny sentinel
20. [PR 21175](https://github.com/openai/codex/pull/21175) Wire missing Windows metadata to deny sentinel
21. [PR 21184](https://github.com/openai/codex/pull/21184) Use direct deny ACLs for Windows metadata sentinels

## Validation

1. Stack head local format and Rust tests passed on `95ef124d6194bd2126c11928cb3973214f9ac63a`.
2. Azure Windows VM 56 case validation is running on `95ef124d6194bd2126c11928cb3973214f9ac63a`.