### PR TITLE
Release Windows legacy session exit before output drain

### DIFF
--- a/codex-rs/windows-sandbox-rs/src/unified_exec/backends/legacy.rs
+++ b/codex-rs/windows-sandbox-rs/src/unified_exec/backends/legacy.rs
@@ -225,7 +225,6 @@ fn finalize_exit(
         raw_exit as i32
     };
 
-    let _ = output_join.join();
     let protected_metadata_failure = match protected_metadata_runtime.finish() {
         Ok(paths) => {
             if !paths.is_empty() && exit_code == 0 {
@@ -240,8 +239,6 @@ fn finalize_exit(
             Some(format!("protected metadata cleanup failed: {err:#}"))
         }
     };
-    let _ = exit_tx.send(exit_code);
-
     unsafe {
         if thread_handle != 0 && thread_handle != INVALID_HANDLE_VALUE {
             CloseHandle(thread_handle);
@@ -270,6 +267,12 @@ fn finalize_exit(
             }
         }
     }
+
+    // Publish the process result after policy cleanup. Output readers may wait
+    // for late pipe EOF from console helpers, but callers already have their
+    // own bounded output drain after observing the exit.
+    let _ = exit_tx.send(exit_code);
+    let _ = output_join.join();
 }
 
 fn resize_conpty_handle(hpc: &Arc<StdMutex<Option<HANDLE>>>, size: TerminalSize) -> Result<()> {


### PR DESCRIPTION
## Summary
1. Let the legacy Windows session backend publish exit after child completion and protected metadata cleanup.
2. Keep output reader joining after exit publication so late pipe EOF cannot block callers for minutes.

## Why
The Windows validation stack exercises `codex sandbox windows`. That path can finish the child process and policy cleanup, then wait on output reader EOF from console helpers before sending the exit to the caller. That made each VM case take about four minutes. This PR keeps the exit boundary tied to process completion and cleanup, while the caller bounded output drain remains responsible for tail output.

## Stack Relation
This is PR 21 of 21. It sits after the protected metadata enforcement stack so the final head can be validated with the Windows 56 case VM run in a practical time. It does not change which metadata paths are protected.

## Validation
1. Rust formatting passed.
2. Windows sandbox crate tests passed.
3. Core Windows focused tests passed.
4. Scoped lint fixes passed for the Windows sandbox crate and core crate.
5. Windows VM validation is running on the final stack head.