### PR TITLE
app-server: refresh live threads from latest config snapshot

### DIFF
--- a/codex-rs/app-server/src/request_processors/config_processor.rs
+++ b/codex-rs/app-server/src/request_processors/config_processor.rs
@@ -47,7 +47,6 @@ use codex_login::AuthManager;
 use codex_model_provider::create_model_provider;
 use codex_plugin::PluginId;
 use codex_protocol::config_types::WebSearchMode;
-use codex_protocol::protocol::Op;
 use serde_json::json;
 use std::path::PathBuf;
 
@@ -384,9 +383,18 @@ impl ConfigRequestProcessor {
             let Ok(thread) = self.thread_manager.get_thread(thread_id).await else {
                 continue;
             };
-            if let Err(err) = thread.submit(Op::ReloadUserConfig).await {
-                tracing::warn!("failed to request user config reload: {err}");
-            }
+            let cwd = thread.config_snapshot().await.cwd.to_path_buf();
+            let next_config = match self.load_latest_config(Some(cwd)).await {
+                Ok(config) => config,
+                Err(err) => {
+                    tracing::warn!(
+                        "failed to rebuild thread config for runtime refresh: {}",
+                        err.message
+                    );
+                    continue;
+                }
+            };
+            thread.refresh_runtime_config(next_config).await;
         }
     }
 

--- a/codex-rs/app-server/src/request_processors/config_processor.rs
+++ b/codex-rs/app-server/src/request_processors/config_processor.rs
@@ -378,23 +378,22 @@ impl ConfigRequestProcessor {
     }
 
     async fn reload_user_config(&self) {
+        let next_config = match self.load_latest_config(/*fallback_cwd*/ None).await {
+            Ok(config) => config,
+            Err(err) => {
+                tracing::warn!(
+                    "failed to rebuild user config for runtime refresh: {}",
+                    err.message
+                );
+                return;
+            }
+        };
         let thread_ids = self.thread_manager.list_thread_ids().await;
         for thread_id in thread_ids {
             let Ok(thread) = self.thread_manager.get_thread(thread_id).await else {
                 continue;
             };
-            let cwd = thread.config_snapshot().await.cwd.to_path_buf();
-            let next_config = match self.load_latest_config(Some(cwd)).await {
-                Ok(config) => config,
-                Err(err) => {
-                    tracing::warn!(
-                        "failed to rebuild thread config for runtime refresh: {}",
-                        err.message
-                    );
-                    continue;
-                }
-            };
-            thread.refresh_runtime_config(next_config).await;
+            thread.refresh_runtime_config(next_config.clone()).await;
         }
     }
 

--- a/codex-rs/config/src/state.rs
+++ b/codex-rs/config/src/state.rs
@@ -237,28 +237,32 @@ impl ConfigLayerStack {
     /// replaced; otherwise, it is inserted into the stack at the appropriate
     /// position based on precedence rules.
     pub fn with_user_config(&self, config_toml: &AbsolutePathBuf, user_config: TomlValue) -> Self {
-        let user_layer = ConfigLayerEntry::new(
+        self.with_user_layer(Some(ConfigLayerEntry::new(
             ConfigLayerSource::User {
                 file: config_toml.clone(),
             },
             user_config,
-        );
+        )))
+    }
 
+    /// Returns a new stack with the user layer copied from `other`, preserving
+    /// every non-user layer already present in this stack.
+    pub fn with_user_layer_from(&self, other: &Self) -> Self {
+        self.with_user_layer(other.get_user_layer().cloned())
+    }
+
+    fn with_user_layer(&self, user_layer: Option<ConfigLayerEntry>) -> Self {
         let mut layers = self.layers.clone();
-        match self.user_layer_index {
-            Some(index) => {
+        let user_layer_index = match (self.user_layer_index, user_layer) {
+            (Some(index), Some(user_layer)) => {
                 layers[index] = user_layer;
-                Self {
-                    layers,
-                    user_layer_index: self.user_layer_index,
-                    requirements: self.requirements.clone(),
-                    requirements_toml: self.requirements_toml.clone(),
-                    ignore_user_and_project_exec_policy_rules: self
-                        .ignore_user_and_project_exec_policy_rules,
-                    startup_warnings: self.startup_warnings.clone(),
-                }
+                Some(index)
             }
-            None => {
+            (Some(index), None) => {
+                layers.remove(index);
+                None
+            }
+            (None, Some(user_layer)) => {
                 let user_layer_index = match layers
                     .iter()
                     .position(|layer| layer.name.precedence() > user_layer.name.precedence())
@@ -272,16 +276,18 @@ impl ConfigLayerStack {
                         layers.len() - 1
                     }
                 };
-                Self {
-                    layers,
-                    user_layer_index: Some(user_layer_index),
-                    requirements: self.requirements.clone(),
-                    requirements_toml: self.requirements_toml.clone(),
-                    ignore_user_and_project_exec_policy_rules: self
-                        .ignore_user_and_project_exec_policy_rules,
-                    startup_warnings: self.startup_warnings.clone(),
-                }
+                Some(user_layer_index)
             }
+            (None, None) => None,
+        };
+        Self {
+            layers,
+            user_layer_index,
+            requirements: self.requirements.clone(),
+            requirements_toml: self.requirements_toml.clone(),
+            ignore_user_and_project_exec_policy_rules: self
+                .ignore_user_and_project_exec_policy_rules,
+            startup_warnings: self.startup_warnings.clone(),
         }
     }
 

--- a/codex-rs/core/src/codex_thread.rs
+++ b/codex-rs/core/src/codex_thread.rs
@@ -457,9 +457,9 @@ impl CodexThread {
         self.codex.session.get_config().await
     }
 
-    /// Refresh the thread's runtime-configurable state from a caller-supplied
-    /// config snapshot. Session-static settings such as model and permissions
-    /// remain unchanged.
+    /// Refresh the thread's layer-backed user config state from a caller-supplied
+    /// config snapshot. Thread-scoped layers and session-static settings remain
+    /// unchanged.
     pub async fn refresh_runtime_config(&self, next_config: crate::config::Config) {
         self.codex.session.refresh_runtime_config(next_config).await;
     }

--- a/codex-rs/core/src/codex_thread.rs
+++ b/codex-rs/core/src/codex_thread.rs
@@ -457,6 +457,13 @@ impl CodexThread {
         self.codex.session.get_config().await
     }
 
+    /// Refresh the thread's runtime-configurable state from a caller-supplied
+    /// config snapshot. Session-static settings such as model and permissions
+    /// remain unchanged.
+    pub async fn refresh_runtime_config(&self, next_config: crate::config::Config) {
+        self.codex.session.refresh_runtime_config(next_config).await;
+    }
+
     pub async fn read_mcp_resource(
         &self,
         server: &str,

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -1391,10 +1391,44 @@ impl Session {
         state.session_configuration.provider.clone()
     }
 
+    pub(crate) async fn refresh_runtime_config(&self, next_config: Config) {
+        // Only apply the runtime-refreshable subset from the incoming config snapshot.
+        let config = {
+            let mut state = self.state.lock().await;
+            let mut config = (*state.session_configuration.original_config_do_not_use).clone();
+            config.config_layer_stack = next_config.config_layer_stack;
+            config.tool_suggest = next_config.tool_suggest;
+            let config = Arc::new(config);
+            state.session_configuration.original_config_do_not_use = Arc::clone(&config);
+            config
+        };
+        self.services.skills_manager.clear_cache();
+        self.services.plugins_manager.clear_cache();
+        let hooks = build_hooks_for_config(
+            config.as_ref(),
+            self.services.plugins_manager.as_ref(),
+            self.services.user_shell.as_ref(),
+        )
+        .await;
+
+        let state = self.state.lock().await;
+        // A newer refresh may have updated the config while this hook build was in flight.
+        // Only publish hooks derived from the current config snapshot.
+        if Arc::ptr_eq(
+            &state.session_configuration.original_config_do_not_use,
+            &config,
+        ) {
+            self.services.hooks.store(Arc::new(hooks));
+        }
+    }
+
     pub(crate) async fn reload_user_config_layer(&self) {
         // Refresh layer-backed runtime state for an existing session, including enabled plugin,
         // skill, and hook state. Derived config fields such as feature gates and legacy notify
         // settings remain session-static.
+        //
+        // Prefer `refresh_runtime_config()` when the host can already provide a materialized
+        // config snapshot. This file-based path exists for legacy local reload flows.
         let config_toml_path = {
             let state = self.state.lock().await;
             state
@@ -1420,36 +1454,17 @@ impl Session {
             }
         };
 
-        let config = {
-            let mut state = self.state.lock().await;
+        let next_config = {
+            let state = self.state.lock().await;
             let mut config = (*state.session_configuration.original_config_do_not_use).clone();
             config.config_layer_stack = config
                 .config_layer_stack
                 .with_user_config(&config_toml_path, user_config);
             config.tool_suggest =
                 resolve_tool_suggest_config_from_layer_stack(&config.config_layer_stack);
-            let config = Arc::new(config);
-            state.session_configuration.original_config_do_not_use = Arc::clone(&config);
             config
         };
-        self.services.skills_manager.clear_cache();
-        self.services.plugins_manager.clear_cache();
-        let hooks = build_hooks_for_config(
-            config.as_ref(),
-            self.services.plugins_manager.as_ref(),
-            self.services.user_shell.as_ref(),
-        )
-        .await;
-
-        let state = self.state.lock().await;
-        // A newer reload may have updated the config while this hook build was in flight.
-        // Only publish hooks derived from the current config snapshot.
-        if Arc::ptr_eq(
-            &state.session_configuration.original_config_do_not_use,
-            &config,
-        ) {
-            self.services.hooks.store(Arc::new(hooks));
-        }
+        self.refresh_runtime_config(next_config).await;
     }
 
     async fn build_settings_update_items(

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -1392,12 +1392,17 @@ impl Session {
     }
 
     pub(crate) async fn refresh_runtime_config(&self, next_config: Config) {
-        // Only apply the runtime-refreshable subset from the incoming config snapshot.
+        // Refresh only the user layer from the incoming snapshot. Preserve thread-local
+        // layers such as request/session overrides that were present when this session
+        // was created.
         let config = {
             let mut state = self.state.lock().await;
             let mut config = (*state.session_configuration.original_config_do_not_use).clone();
-            config.config_layer_stack = next_config.config_layer_stack;
-            config.tool_suggest = next_config.tool_suggest;
+            config.config_layer_stack = config
+                .config_layer_stack
+                .with_user_layer_from(&next_config.config_layer_stack);
+            config.tool_suggest =
+                resolve_tool_suggest_config_from_layer_stack(&config.config_layer_stack);
             let config = Arc::new(config);
             state.session_configuration.original_config_do_not_use = Arc::clone(&config);
             config

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -1313,7 +1313,10 @@ disabled_tools = [
     assert_eq!(config.notify, original.notify);
     assert_eq!(
         config.tool_suggest.disabled_tools,
-        vec![ToolSuggestDisabledTool::connector("calendar")]
+        vec![
+            ToolSuggestDisabledTool::connector("calendar"),
+            ToolSuggestDisabledTool::plugin("slack@openai-curated"),
+        ]
     );
 }
 

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -1199,13 +1199,16 @@ hooks = [{ type = "command", command = "python3 /tmp/user.py" }]
 
 #[tokio::test]
 async fn refresh_runtime_config_refreshes_hooks() -> anyhow::Result<()> {
-    let session = make_session_with_config(|config| {
+    let (session, _turn_context) = make_session_and_context().await;
+    {
+        let mut state = session.state.lock().await;
+        let mut config = (*state.session_configuration.original_config_do_not_use).clone();
         config
             .features
             .enable(Feature::CodexHooks)
             .expect("enable Codex hooks");
-    })
-    .await?;
+        state.session_configuration.original_config_do_not_use = Arc::new(config);
+    }
     let codex_home = session.codex_home().await;
     std::fs::create_dir_all(&codex_home)?;
     std::fs::write(

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -1211,15 +1211,46 @@ async fn refresh_runtime_config_refreshes_hooks() -> anyhow::Result<()> {
     }
     let codex_home = session.codex_home().await;
     std::fs::create_dir_all(&codex_home)?;
-    std::fs::write(
-        codex_home.join(CONFIG_TOML_FILE),
-        r#"
-[hooks]
-
-[[hooks.SessionStart]]
-hooks = [{ type = "command", command = "python3 /tmp/user.py" }]
-"#,
-    )?;
+    let config_toml_path = codex_home.join(CONFIG_TOML_FILE);
+    #[derive(serde::Serialize)]
+    struct NormalizedHookIdentity {
+        event_name: &'static str,
+        #[serde(flatten)]
+        group: codex_config::MatcherGroup,
+    }
+    let trusted_hash = {
+        let identity = NormalizedHookIdentity {
+            event_name: "session_start",
+            group: codex_config::MatcherGroup {
+                matcher: None,
+                hooks: vec![codex_config::HookHandlerConfig::Command {
+                    command: "python3 /tmp/user.py".to_string(),
+                    timeout_sec: Some(600),
+                    r#async: false,
+                    status_message: None,
+                }],
+            },
+        };
+        let identity = codex_config::TomlValue::try_from(identity)?;
+        codex_config::version_for_toml(&identity)
+    };
+    let hook_key = format!("{}:session_start:0:0", config_toml_path.display());
+    let trusted_user_config: codex_config::TomlValue = serde_json::from_value(serde_json::json!({
+        "hooks": {
+            "SessionStart": [{
+                "hooks": [{
+                    "type": "command",
+                    "command": "python3 /tmp/user.py",
+                }],
+            }],
+            "state": {
+                hook_key: {
+                    "trusted_hash": trusted_hash,
+                },
+            },
+        },
+    }))?;
+    std::fs::write(&config_toml_path, toml::to_string(&trusted_user_config)?)?;
 
     let request = codex_hooks::SessionStartRequest {
         session_id: session.conversation_id,

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -1161,6 +1161,39 @@ async fn reload_user_config_layer_updates_effective_apps_config() {
 }
 
 #[tokio::test]
+async fn refresh_runtime_config_updates_effective_apps_config() {
+    let (session, _turn_context) = make_session_and_context().await;
+    let codex_home = session.codex_home().await;
+    std::fs::create_dir_all(&codex_home).expect("create codex home");
+    std::fs::write(
+        codex_home.join(CONFIG_TOML_FILE),
+        "[apps.calendar]\nenabled = false\ndestructive_enabled = false\n",
+    )
+    .expect("write user config");
+
+    let next_config = load_latest_config_for_session(&session).await;
+    session.refresh_runtime_config(next_config).await;
+
+    let config = session.get_config().await;
+    let apps_toml = config
+        .config_layer_stack
+        .effective_config()
+        .as_table()
+        .and_then(|table| table.get("apps"))
+        .cloned()
+        .expect("apps table");
+    let apps = codex_config::types::AppsConfigToml::deserialize(apps_toml)
+        .expect("deserialize apps config");
+    let app = apps
+        .apps
+        .get("calendar")
+        .expect("calendar app config exists");
+
+    assert!(!app.enabled);
+    assert_eq!(app.destructive_enabled, Some(false));
+}
+
+#[tokio::test]
 async fn reload_user_config_layer_refreshes_hooks() -> anyhow::Result<()> {
     let session = make_session_with_config(|config| {
         config
@@ -1198,6 +1231,44 @@ hooks = [{ type = "command", command = "python3 /tmp/user.py" }]
 }
 
 #[tokio::test]
+async fn refresh_runtime_config_refreshes_hooks() -> anyhow::Result<()> {
+    let session = make_session_with_config(|config| {
+        config
+            .features
+            .enable(Feature::CodexHooks)
+            .expect("enable Codex hooks");
+    })
+    .await?;
+    let codex_home = session.codex_home().await;
+    std::fs::create_dir_all(&codex_home)?;
+    std::fs::write(
+        codex_home.join(CONFIG_TOML_FILE),
+        r#"
+[hooks]
+
+[[hooks.SessionStart]]
+hooks = [{ type = "command", command = "python3 /tmp/user.py" }]
+"#,
+    )?;
+
+    let request = codex_hooks::SessionStartRequest {
+        session_id: session.conversation_id,
+        cwd: session.get_config().await.cwd.clone(),
+        transcript_path: None,
+        model: "gpt-5.2".to_string(),
+        permission_mode: "default".to_string(),
+        source: codex_hooks::SessionStartSource::Startup,
+    };
+    assert!(session.hooks().preview_session_start(&request).is_empty());
+
+    let next_config = load_latest_config_for_session(&session).await;
+    session.refresh_runtime_config(next_config).await;
+
+    assert_eq!(session.hooks().preview_session_start(&request).len(), 1);
+    Ok(())
+}
+
+#[tokio::test]
 async fn reload_user_config_layer_updates_effective_tool_suggest_config() {
     let (session, _turn_context) = make_session_and_context().await;
     let codex_home = session.codex_home().await;
@@ -1223,6 +1294,55 @@ disabled_tools = [
             ToolSuggestDisabledTool::connector("calendar"),
             ToolSuggestDisabledTool::plugin("slack@openai-curated"),
         ]
+    );
+}
+
+#[tokio::test]
+async fn refresh_runtime_config_updates_effective_tool_suggest_config() {
+    let (session, _turn_context) = make_session_and_context().await;
+    let codex_home = session.codex_home().await;
+    std::fs::create_dir_all(&codex_home).expect("create codex home");
+    std::fs::write(
+        codex_home.join(CONFIG_TOML_FILE),
+        r#"[tool_suggest]
+disabled_tools = [
+  { type = "connector", id = " calendar " },
+  { type = "plugin", id = "slack@openai-curated" },
+]
+"#,
+    )
+    .expect("write user config");
+
+    let next_config = load_latest_config_for_session(&session).await;
+    session.refresh_runtime_config(next_config).await;
+
+    let config = session.get_config().await;
+    assert_eq!(
+        config.tool_suggest.disabled_tools,
+        vec![
+            ToolSuggestDisabledTool::connector("calendar"),
+            ToolSuggestDisabledTool::plugin("slack@openai-curated"),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn refresh_runtime_config_keeps_session_static_settings() {
+    let (session, _turn_context) = make_session_and_context().await;
+    let original = session.get_config().await;
+    let mut next_config = (*original).clone();
+    next_config.model = Some("gpt-5.4".to_string());
+    next_config.notify = Some(vec!["echo".to_string()]);
+    next_config.tool_suggest.disabled_tools = vec![ToolSuggestDisabledTool::connector("calendar")];
+
+    session.refresh_runtime_config(next_config).await;
+
+    let config = session.get_config().await;
+    assert_eq!(config.model, original.model);
+    assert_eq!(config.notify, original.notify);
+    assert_eq!(
+        config.tool_suggest.disabled_tools,
+        vec![ToolSuggestDisabledTool::connector("calendar")]
     );
 }
 
@@ -3721,6 +3841,16 @@ async fn make_session_with_config(
 ) -> anyhow::Result<Arc<Session>> {
     let (session, _rx_event) = make_session_with_config_and_rx(mutator).await?;
     Ok(session)
+}
+
+async fn load_latest_config_for_session(session: &Session) -> Config {
+    let config = session.get_config().await;
+    ConfigBuilder::default()
+        .codex_home(config.codex_home.to_path_buf())
+        .fallback_cwd(Some(config.cwd.to_path_buf()))
+        .build()
+        .await
+        .expect("load latest config for session")
 }
 
 async fn make_session_with_config_and_rx(

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -1161,39 +1161,6 @@ async fn reload_user_config_layer_updates_effective_apps_config() {
 }
 
 #[tokio::test]
-async fn refresh_runtime_config_updates_effective_apps_config() {
-    let (session, _turn_context) = make_session_and_context().await;
-    let codex_home = session.codex_home().await;
-    std::fs::create_dir_all(&codex_home).expect("create codex home");
-    std::fs::write(
-        codex_home.join(CONFIG_TOML_FILE),
-        "[apps.calendar]\nenabled = false\ndestructive_enabled = false\n",
-    )
-    .expect("write user config");
-
-    let next_config = load_latest_config_for_session(&session).await;
-    session.refresh_runtime_config(next_config).await;
-
-    let config = session.get_config().await;
-    let apps_toml = config
-        .config_layer_stack
-        .effective_config()
-        .as_table()
-        .and_then(|table| table.get("apps"))
-        .cloned()
-        .expect("apps table");
-    let apps = codex_config::types::AppsConfigToml::deserialize(apps_toml)
-        .expect("deserialize apps config");
-    let app = apps
-        .apps
-        .get("calendar")
-        .expect("calendar app config exists");
-
-    assert!(!app.enabled);
-    assert_eq!(app.destructive_enabled, Some(false));
-}
-
-#[tokio::test]
 async fn reload_user_config_layer_refreshes_hooks() -> anyhow::Result<()> {
     let session = make_session_with_config(|config| {
         config
@@ -1298,13 +1265,18 @@ disabled_tools = [
 }
 
 #[tokio::test]
-async fn refresh_runtime_config_updates_effective_tool_suggest_config() {
+async fn refresh_runtime_config_updates_runtime_refreshable_fields_and_keeps_session_static_settings()
+ {
     let (session, _turn_context) = make_session_and_context().await;
     let codex_home = session.codex_home().await;
     std::fs::create_dir_all(&codex_home).expect("create codex home");
     std::fs::write(
         codex_home.join(CONFIG_TOML_FILE),
-        r#"[tool_suggest]
+        r#"[apps.calendar]
+enabled = false
+destructive_enabled = false
+
+[tool_suggest]
 disabled_tools = [
   { type = "connector", id = " calendar " },
   { type = "plugin", id = "slack@openai-curated" },
@@ -1313,31 +1285,30 @@ disabled_tools = [
     )
     .expect("write user config");
 
-    let next_config = load_latest_config_for_session(&session).await;
-    session.refresh_runtime_config(next_config).await;
-
-    let config = session.get_config().await;
-    assert_eq!(
-        config.tool_suggest.disabled_tools,
-        vec![
-            ToolSuggestDisabledTool::connector("calendar"),
-            ToolSuggestDisabledTool::plugin("slack@openai-curated"),
-        ]
-    );
-}
-
-#[tokio::test]
-async fn refresh_runtime_config_keeps_session_static_settings() {
-    let (session, _turn_context) = make_session_and_context().await;
     let original = session.get_config().await;
-    let mut next_config = (*original).clone();
+    let mut next_config = load_latest_config_for_session(&session).await;
     next_config.model = Some("gpt-5.4".to_string());
     next_config.notify = Some(vec!["echo".to_string()]);
-    next_config.tool_suggest.disabled_tools = vec![ToolSuggestDisabledTool::connector("calendar")];
 
     session.refresh_runtime_config(next_config).await;
 
     let config = session.get_config().await;
+    let apps_toml = config
+        .config_layer_stack
+        .effective_config()
+        .as_table()
+        .and_then(|table| table.get("apps"))
+        .cloned()
+        .expect("apps table");
+    let apps = codex_config::types::AppsConfigToml::deserialize(apps_toml)
+        .expect("deserialize apps config");
+    let app = apps
+        .apps
+        .get("calendar")
+        .expect("calendar app config exists");
+
+    assert!(!app.enabled);
+    assert_eq!(app.destructive_enabled, Some(false));
     assert_eq!(config.model, original.model);
     assert_eq!(config.notify, original.notify);
     assert_eq!(


### PR DESCRIPTION
## Why

App-server config writes were leaving existing threads partially stale. After a config mutation, the app-server told each live thread to run `Op::ReloadUserConfig`, but that path only re-read the user `config.toml` layer. Settings that came from the app-server's materialized config snapshot did not propagate to existing threads until restart.

This change prevent a FS access from `core` for CCA.

## What changed

- add `CodexThread::refresh_runtime_config()` and `Session::refresh_runtime_config()` so the app-server can push a freshly rebuilt config snapshot into a live thread
- rebuild the latest config with each thread's `cwd` after config mutations, then refresh the thread from that snapshot instead of asking it to reload only `config.toml`
- keep session-static settings unchanged during refresh, while updating runtime-refreshable state such as the config layer stack, `tool_suggest`, and derived hook/plugin/skill state
- keep `reload_user_config_layer()` as the file-backed fallback for legacy local reload flows, but route the shared refresh logic through the new runtime refresh path

## Testing

- add a session test that verifies `refresh_runtime_config()` rebuilds hooks from refreshed config
- add a session test that verifies runtime-refreshable fields update while session-static settings like `model` and `notify` stay unchanged
