### PR TITLE
Avoid phase2 agent for empty memory housekeeping

### DIFF
--- a/codex-rs/memories/write/src/phase2.rs
+++ b/codex-rs/memories/write/src/phase2.rs
@@ -16,6 +16,7 @@ use crate::workspace::write_workspace_diff;
 use codex_config::Constrained;
 use codex_core::config::Config;
 use codex_features::Feature;
+use codex_git_utils::GitBaselineChangeStatus;
 use codex_protocol::ThreadId;
 use codex_protocol::protocol::AgentStatus;
 use codex_protocol::protocol::AskForApproval;
@@ -150,6 +151,43 @@ pub async fn run(context: Arc<MemoryStartupContext>, config: Arc<Config>) {
             "succeeded_no_workspace_changes",
         )
         .await;
+        return;
+    }
+    let rollout_summaries_prefix = format!("{}/", crate::artifacts::ROLLOUT_SUMMARIES_SUBDIR);
+    let extensions_prefix = format!("{}/", crate::artifacts::EXTENSIONS_SUBDIR);
+    if raw_memories.is_empty()
+        && workspace_diff.changes.iter().all(|change| {
+            change.path == crate::artifacts::RAW_MEMORIES_FILENAME
+                || change.path.starts_with(&rollout_summaries_prefix)
+                || (change.status == GitBaselineChangeStatus::Deleted
+                    && change.path.starts_with(&extensions_prefix))
+        })
+    {
+        match reset_memory_workspace_baseline(&root).await {
+            Ok(()) => {
+                job::succeed(
+                    context.as_ref(),
+                    db.as_ref(),
+                    &claim,
+                    new_watermark,
+                    &raw_memories,
+                    "succeeded_empty_input_housekeeping",
+                )
+                .await;
+            }
+            Err(err) => {
+                tracing::error!(
+                    "failed resetting memory workspace baseline after empty phase-2 housekeeping: {err}"
+                );
+                job::failed(
+                    context.as_ref(),
+                    db.as_ref(),
+                    &claim,
+                    "failed_workspace_commit",
+                )
+                .await;
+            }
+        }
         return;
     }
 

--- a/codex-rs/memories/write/src/startup_tests.rs
+++ b/codex-rs/memories/write/src/startup_tests.rs
@@ -221,15 +221,9 @@ async fn memories_startup_phase2_prunes_old_extension_resources_without_stage1_i
     let test = build_test_codex(&server, home.clone()).await?;
     trigger_memories_startup(&test).await;
 
-    let request = wait_for_single_request(&phase2).await;
-    let prompt = phase2_prompt_text(&request);
-    assert!(
-        prompt.contains("phase2_workspace_diff.md"),
-        "expected workspace diff file in prompt: {prompt}"
-    );
-
     wait_for_file_removed(&old_file).await?;
     wait_for_phase2_workspace_reset(&home.path().join("memories")).await?;
+    assert_eq!(phase2.requests().len(), 0);
 
     shutdown_test_codex(&test).await?;
     Ok(())


### PR DESCRIPTION
## Summary
- treat empty memory phase-2 input changes as local housekeeping
- reset the managed memory workspace after pruning without spawning a consolidation agent
- update the Windows-flaky startup regression to assert no model request is needed

## Testing
- `cargo test -p codex-memories-write memories_startup_phase2_prunes_old_extension_resources_without_stage1_input -- --nocapture` (3 consecutive runs)
- `cargo test -p codex-memories-write`
- `just fix -p codex-memories-write`