### PR TITLE
fix(linux-sandbox): isolate Linux sandbox synthetic mount registry per user for shared codex use case

### DIFF
--- a/codex-rs/linux-sandbox/src/linux_run_main.rs
+++ b/codex-rs/linux-sandbox/src/linux_run_main.rs
@@ -1235,7 +1235,10 @@ fn synthetic_mount_marker_dir(path: &Path) -> PathBuf {
 }
 
 fn synthetic_mount_registry_root() -> PathBuf {
-    std::env::temp_dir().join("codex-bwrap-synthetic-mount-targets")
+    let effective_uid = unsafe { libc::geteuid() };
+    std::env::temp_dir().join(format!(
+        "codex-bwrap-synthetic-mount-targets-{effective_uid}"
+    ))
 }
 
 fn hash_path(path: &Path) -> u64 {

--- a/codex-rs/linux-sandbox/src/linux_run_main_tests.rs
+++ b/codex-rs/linux-sandbox/src/linux_run_main_tests.rs
@@ -298,6 +298,17 @@ fn cleanup_synthetic_mount_targets_removes_only_empty_mount_targets() {
 }
 
 #[test]
+fn synthetic_mount_registry_root_is_unique_to_effective_user() {
+    let effective_uid = unsafe { libc::geteuid() };
+    assert_eq!(
+        synthetic_mount_registry_root(),
+        std::env::temp_dir().join(format!(
+            "codex-bwrap-synthetic-mount-targets-{effective_uid}"
+        ))
+    );
+}
+
+#[test]
 fn cleanup_synthetic_mount_targets_waits_for_other_active_registrations() {
     let temp_dir = tempfile::TempDir::new().expect("tempdir");
     let empty_file = temp_dir.path().join(".git");


### PR DESCRIPTION
## Summary
- make the Linux sandbox synthetic mount registry path unique per effective UID
- keep same-user coordination intact while avoiding collisions between users sharing `/tmp`
- add a regression test for the registry path contract

## Why
Issue #21192 reports that the Linux sandbox currently uses one global temp path at `/tmp/codex-bwrap-synthetic-mount-targets`. If another user creates that directory first, later users can fail to open the shared lock file with `Permission denied`.

## Validation
- `just fmt`
- `cargo test -p codex-linux-sandbox`
- `cargo clippy -p codex-linux-sandbox --all-targets`

Fixes #21192