### PR TITLE
[codex] Coordinate OpenAI docs sample with API key setup

### DIFF
--- a/codex-rs/skills/src/assets/samples/openai-docs/SKILL.md
+++ b/codex-rs/skills/src/assets/samples/openai-docs/SKILL.md
@@ -8,6 +8,12 @@ description: "Use when the user asks how to build with OpenAI products or APIs a
 
 Provide authoritative, current guidance from OpenAI developer docs using the developers.openai.com MCP server. Always prioritize the developer docs MCP tools over web.run for OpenAI-related questions. This skill also owns model selection, API model migration, and prompt-upgrade guidance. Only if the MCP server is installed and returns no meaningful results should you fall back to web search.
 
+## API Key Setup
+
+For requests to build, run, configure, debug, or implement an API-backed app, script, CLI, generator, or tool, use `openai-platform-api-key` first when available. After that credential gate is resolved, return here for current docs as needed.
+
+Use this skill directly for docs-only questions, citations, model/API guidance, conceptual explanations, and examples that do not require building or running an API-backed artifact.
+
 ## Quick start
 
 - Use `mcp__openaiDeveloperDocs__search_openai_docs` to find the most relevant doc pages.


### PR DESCRIPTION
## Summary
- Add the same API key setup coordination guidance to the embedded OpenAI Docs sample skill in `codex-rs/skills`.
- Keep the skill description/frontmatter unchanged; the coordination lives only in the body.
- Preserve direct OpenAI Docs routing for docs-only questions, citations, model/API guidance, conceptual explanations, and non-building examples.

## Why
The Codex repo carries its own OpenAI Docs skill variant under `codex-rs/skills/src/assets/samples`. This keeps that embedded sample aligned with the other OpenAI Docs variants patched in the related PRs.

## Validation
- `cargo test -p codex-skills`
- `git diff --check`