### PR TITLE
fix(bwrap): emit libcap after standalone archive

### DIFF
--- a/codex-rs/bwrap/build.rs
+++ b/codex-rs/bwrap/build.rs
@@ -35,6 +35,7 @@ fn try_build_bwrap() -> Result<(), String> {
     let out_dir = PathBuf::from(env::var("OUT_DIR").map_err(|err| err.to_string())?);
     let src_dir = resolve_bwrap_source_dir(&manifest_dir)?;
     let libcap = pkg_config::Config::new()
+        .cargo_metadata(false)
         .probe("libcap")
         .map_err(|err| format!("libcap not available via pkg-config: {err}"))?;
 
@@ -65,6 +66,12 @@ fn try_build_bwrap() -> Result<(), String> {
     }
 
     build.compile("standalone_bwrap");
+    for link_path in libcap.link_paths {
+        println!("cargo:rustc-link-search=native={}", link_path.display());
+    }
+    for lib in libcap.libs {
+        println!("cargo:rustc-link-lib={lib}");
+    }
     println!("cargo:rustc-cfg=bwrap_available");
     Ok(())
 }


### PR DESCRIPTION
## Why

#21255 added the standalone `codex-bwrap` binary. In the Cargo build, [`pkg_config::probe("libcap")`](https://github.com/openai/codex/blob/a736cb55a2bce57b4c8e5a4fe56f70c2b2ad892b/codex-rs/bwrap/build.rs#L37-L39) emits `-lcap` before [`cc::Build::compile("standalone_bwrap")`](https://github.com/openai/codex/blob/a736cb55a2bce57b4c8e5a4fe56f70c2b2ad892b/codex-rs/bwrap/build.rs#L50-L67) adds the static bwrap archive. The Linux musl link then sees `-lcap -lstandalone_bwrap`; because static archives are resolved left-to-right, `cap_from_name` is still undefined once `standalone_bwrap` introduces that reference.

The musl setup already builds `libcap.a` and exposes it through [`libcap.pc`](https://github.com/openai/codex/blob/a736cb55a2bce57b4c8e5a4fe56f70c2b2ad892b/.github/scripts/install-musl-build-tools.sh#L78-L88), so the failure is link ordering rather than a missing dependency.

## What changed

- probe `libcap` with `cargo_metadata(false)` so `pkg-config` does not emit its link flags early
- emit the discovered `libcap` search paths and libraries after `standalone_bwrap` is compiled, preserving the needed static-link order

## Verification

- `cargo test -p codex-bwrap`
- `cargo clippy -p codex-bwrap --all-targets`

The affected Linux musl release link is exercised by CI, which is the path this fix targets.