### PR TITLE
[codex] support hook input rewrites

### DIFF
--- a/codex-rs/core/src/function_tool.rs
+++ b/codex-rs/core/src/function_tool.rs
@@ -4,6 +4,8 @@ use thiserror::Error;
 pub enum FunctionCallError {
     #[error("{0}")]
     RespondToModel(String),
+    #[error("tool input rewritten by hook")]
+    UpdatedInput(serde_json::Value),
     #[error("LocalShellCall without call_id or id")]
     MissingLocalShellCallId,
     #[error("Fatal error: {0}")]

--- a/codex-rs/core/src/hook_runtime.rs
+++ b/codex-rs/core/src/hook_runtime.rs
@@ -10,6 +10,7 @@ use codex_hooks::PermissionRequestRequest;
 use codex_hooks::PostToolUseOutcome;
 use codex_hooks::PostToolUseRequest;
 use codex_hooks::PreToolUseOutcome;
+use codex_hooks::PreToolUsePermissionDecision;
 use codex_hooks::PreToolUseRequest;
 use codex_hooks::SessionStartOutcome;
 use codex_hooks::UserPromptSubmitOutcome;
@@ -42,6 +43,16 @@ pub(crate) struct HookRuntimeOutcome {
     pub should_stop: bool,
     pub additional_contexts: Vec<String>,
 }
+
+pub(crate) enum PreToolUseHookResult {
+    Continue {
+        updated_input: Option<Value>,
+        permission_decision: Option<PreToolUsePermissionDecision>,
+    },
+    Blocked(String),
+}
+
+pub(crate) const MAX_HOOK_INPUT_REWRITES: usize = 8;
 
 pub(crate) enum PendingInputHookDisposition {
     Accepted(Box<PendingInputRecord>),
@@ -140,7 +151,7 @@ pub(crate) async fn run_pre_tool_use_hooks(
     tool_use_id: String,
     tool_name: &HookToolName,
     tool_input: &Value,
-) -> Option<String> {
+) -> PreToolUseHookResult {
     let request = PreToolUseRequest {
         session_id: sess.conversation_id,
         turn_id: turn_context.sub_id.clone(),
@@ -162,31 +173,42 @@ pub(crate) async fn run_pre_tool_use_hooks(
         should_block,
         block_reason,
         additional_contexts,
+        updated_input,
+        permission_decision,
     } = hooks.run_pre_tool_use(request).await;
     emit_hook_completed_events(sess, turn_context, hook_events).await;
     record_additional_contexts(sess, turn_context, additional_contexts).await;
 
-    if should_block {
-        block_reason.map(|reason| {
-            if (tool_name.name() == "Bash" || tool_name.name() == "apply_patch")
-                && let Some(command) = tool_input.get("command").and_then(Value::as_str)
-            {
-                format!("Command blocked by PreToolUse hook: {reason}. Command: {command}")
-            } else {
-                format!(
-                    "Tool call blocked by PreToolUse hook: {reason}. Tool: {}",
-                    tool_name.name()
-                )
-            }
-        })
+    if !should_block {
+        return PreToolUseHookResult::Continue {
+            updated_input,
+            permission_decision,
+        };
+    }
+
+    let Some(reason) = block_reason else {
+        return PreToolUseHookResult::Continue {
+            updated_input: None,
+            permission_decision: None,
+        };
+    };
+
+    if (tool_name.name() == "Bash" || tool_name.name() == "apply_patch")
+        && let Some(command) = tool_input.get("command").and_then(Value::as_str)
+    {
+        PreToolUseHookResult::Blocked(format!(
+            "Command blocked by PreToolUse hook: {reason}. Command: {command}"
+        ))
     } else {
-        None
+        PreToolUseHookResult::Blocked(format!(
+            "Tool call blocked by PreToolUse hook: {reason}. Tool: {}",
+            tool_name.name()
+        ))
     }
 }
 
 // PermissionRequest hooks share the same preview/start/completed event flow as
-// other hook types, but they return an optional decision instead of mutating
-// tool input or post-run state.
+// other hook types and return an optional approval-time decision.
 pub(crate) async fn run_permission_request_hooks(
     sess: &Arc<Session>,
     turn_context: &Arc<TurnContext>,

--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -25,6 +25,7 @@ use crate::guardian::guardian_timeout_message;
 use crate::guardian::new_guardian_review_id;
 use crate::guardian::review_approval_request;
 use crate::guardian::routes_approval_to_guardian;
+use crate::hook_runtime::MAX_HOOK_INPUT_REWRITES;
 use crate::hook_runtime::run_permission_request_hooks;
 use crate::mcp_openai_file::rewrite_mcp_tool_arguments_for_openai_files;
 use crate::mcp_tool_approval_templates::RenderedMcpToolApprovalParam;
@@ -40,6 +41,7 @@ use codex_analytics::build_track_events_context;
 use codex_config::types::AppToolApproval;
 use codex_features::Feature;
 use codex_hooks::PermissionRequestDecision;
+use codex_hooks::PreToolUsePermissionDecision;
 use codex_mcp::CODEX_APPS_MCP_SERVER_NAME;
 use codex_mcp::McpPermissionPromptAutoApproveContext;
 use codex_mcp::SandboxState;
@@ -91,6 +93,10 @@ const MCP_TOOL_CALL_EVENT_RESULT_MAX_BYTES: usize = DEFAULT_OUTPUT_BYTES_CAP;
 
 /// Handles the specified tool call and dispatches the appropriate MCP tool-call
 /// item lifecycle events to the `Session`.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "MCP approval dispatch carries invocation, policy, and hook state together"
+)]
 pub(crate) async fn handle_mcp_tool_call(
     sess: Arc<Session>,
     turn_context: &Arc<TurnContext>,
@@ -99,6 +105,7 @@ pub(crate) async fn handle_mcp_tool_call(
     tool_name: String,
     hook_tool_name: String,
     arguments: String,
+    pre_tool_use_permission_decision: Option<PreToolUsePermissionDecision>,
 ) -> HandledMcpToolCall {
     // Parse the `arguments` as JSON. An empty string is OK, but invalid JSON
     // is not.
@@ -197,18 +204,46 @@ pub(crate) async fn handle_mcp_tool_call(
     )
     .await;
 
-    if let Some(decision) = maybe_request_mcp_tool_approval(
-        &sess,
-        turn_context,
-        &call_id,
-        &invocation,
-        &hook_tool_name,
-        metadata.as_ref(),
-        approval_mode,
-    )
-    .await
-    {
+    let mut invocation = invocation;
+    let mut input_rewrites = 0;
+    loop {
+        let Some(decision) = maybe_request_mcp_tool_approval(
+            &sess,
+            turn_context,
+            &call_id,
+            &invocation,
+            &hook_tool_name,
+            metadata.as_ref(),
+            approval_mode,
+            pre_tool_use_permission_decision.as_ref(),
+        )
+        .await
+        else {
+            break;
+        };
+        let tool_input = invocation
+            .arguments
+            .clone()
+            .unwrap_or_else(|| JsonValue::Object(serde_json::Map::new()));
         let result = match decision {
+            McpToolApprovalDecision::AcceptWithUpdatedInput(updated_input) => {
+                input_rewrites += 1;
+                if input_rewrites > MAX_HOOK_INPUT_REWRITES {
+                    notify_mcp_tool_call_skip(
+                        sess.as_ref(),
+                        turn_context.as_ref(),
+                        &call_id,
+                        invocation,
+                        mcp_app_resource_uri.clone(),
+                        "hook input rewrite limit exceeded".to_string(),
+                        /*already_started*/ true,
+                    )
+                    .await
+                } else {
+                    invocation.arguments = Some(updated_input);
+                    continue;
+                }
+            }
             McpToolApprovalDecision::Accept
             | McpToolApprovalDecision::AcceptForSession
             | McpToolApprovalDecision::AcceptAndRemember => {
@@ -275,8 +310,7 @@ pub(crate) async fn handle_mcp_tool_call(
 
         return HandledMcpToolCall {
             result: CallToolResult::from_result(result),
-            tool_input: arguments_value
-                .unwrap_or_else(|| JsonValue::Object(serde_json::Map::new())),
+            tool_input,
         };
     }
 
@@ -815,6 +849,7 @@ async fn maybe_track_codex_app_used(
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum McpToolApprovalDecision {
     Accept,
+    AcceptWithUpdatedInput(JsonValue),
     AcceptForSession,
     AcceptAndRemember,
     Decline { message: Option<String> },
@@ -1018,6 +1053,10 @@ fn mcp_tool_approval_prompt_options(
     }
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "MCP approval dispatch carries invocation, policy, and hook state together"
+)]
 async fn maybe_request_mcp_tool_approval(
     sess: &Arc<Session>,
     turn_context: &Arc<TurnContext>,
@@ -1026,7 +1065,18 @@ async fn maybe_request_mcp_tool_approval(
     hook_tool_name: &str,
     metadata: Option<&McpToolApprovalMetadata>,
     approval_mode: AppToolApproval,
+    pre_tool_use_permission_decision: Option<&PreToolUsePermissionDecision>,
 ) -> Option<McpToolApprovalDecision> {
+    if matches!(
+        pre_tool_use_permission_decision,
+        Some(PreToolUsePermissionDecision::Allow)
+    ) {
+        return None;
+    }
+    let force_user_prompt = matches!(
+        pre_tool_use_permission_decision,
+        Some(PreToolUsePermissionDecision::Ask { .. })
+    );
     if mcp_permission_prompt_is_auto_approved(
         turn_context.approval_policy.value(),
         &turn_context.permission_profile(),
@@ -1034,20 +1084,24 @@ async fn maybe_request_mcp_tool_approval(
             approvals_reviewer: Some(turn_context.config.approvals_reviewer),
             tool_approval_mode: Some(approval_mode),
         },
-    ) {
+    ) && !force_user_prompt
+    {
         return None;
     }
 
     let annotations = metadata.and_then(|metadata| metadata.annotations.as_ref());
     let approval_required = requires_mcp_tool_approval(annotations);
-    if !approval_required && approval_mode != AppToolApproval::Prompt {
+    if !approval_required && approval_mode != AppToolApproval::Prompt && !force_user_prompt {
         return None;
     }
 
-    let mut monitor_reason = None;
+    let mut monitor_reason = match pre_tool_use_permission_decision {
+        Some(PreToolUsePermissionDecision::Ask { reason }) => reason.clone(),
+        Some(PreToolUsePermissionDecision::Allow) | None => None,
+    };
     let auto_approved_by_policy = approval_mode == AppToolApproval::Approve;
 
-    if auto_approved_by_policy {
+    if auto_approved_by_policy && !force_user_prompt {
         match maybe_monitor_auto_approved_mcp_tool_call(
             sess,
             turn_context,
@@ -1072,35 +1126,51 @@ async fn maybe_request_mcp_tool_approval(
     let session_approval_key = session_mcp_tool_approval_key(invocation, metadata, approval_mode);
     let persistent_approval_key =
         persistent_mcp_tool_approval_key(invocation, metadata, approval_mode);
-    if let Some(key) = session_approval_key.as_ref()
+    if !force_user_prompt
+        && let Some(key) = session_approval_key.as_ref()
         && mcp_tool_approval_is_remembered(sess, key).await
     {
         return Some(McpToolApprovalDecision::Accept);
     }
 
-    match run_permission_request_hooks(
-        sess,
-        turn_context,
-        call_id,
-        PermissionRequestPayload {
-            tool_name: HookToolName::new(hook_tool_name),
-            tool_input: invocation
-                .arguments
-                .clone()
-                .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new())),
-        },
-    )
-    .await
+    let permission_request_tool_input = invocation
+        .arguments
+        .clone()
+        .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new()));
+    if !force_user_prompt
+        && let Some(decision) = run_permission_request_hooks(
+            sess,
+            turn_context,
+            call_id,
+            PermissionRequestPayload {
+                tool_name: HookToolName::new(hook_tool_name),
+                tool_input: permission_request_tool_input.clone(),
+            },
+        )
+        .await
     {
-        Some(PermissionRequestDecision::Allow) => {
-            return Some(McpToolApprovalDecision::Accept);
+        match decision {
+            PermissionRequestDecision::Allow {
+                updated_input: Some(updated_input),
+            } => {
+                if updated_input == permission_request_tool_input {
+                    return Some(McpToolApprovalDecision::Accept);
+                }
+                return Some(McpToolApprovalDecision::AcceptWithUpdatedInput(
+                    updated_input,
+                ));
+            }
+            PermissionRequestDecision::Allow {
+                updated_input: None,
+            } => {
+                return Some(McpToolApprovalDecision::Accept);
+            }
+            PermissionRequestDecision::Deny { message } => {
+                return Some(McpToolApprovalDecision::Decline {
+                    message: Some(message),
+                });
+            }
         }
-        Some(PermissionRequestDecision::Deny { message }) => {
-            return Some(McpToolApprovalDecision::Decline {
-                message: Some(message),
-            });
-        }
-        None => {}
     }
 
     let tool_call_mcp_elicitation_enabled = turn_context
@@ -1108,7 +1178,7 @@ async fn maybe_request_mcp_tool_approval(
         .features
         .enabled(Feature::ToolCallMcpElicitation);
 
-    if routes_approval_to_guardian(turn_context) {
+    if !force_user_prompt && routes_approval_to_guardian(turn_context) {
         let review_id = new_guardian_review_id();
         let decision = review_approval_request(
             sess,
@@ -1846,6 +1916,7 @@ async fn apply_mcp_tool_approval_decision(
             }
         }
         McpToolApprovalDecision::Accept
+        | McpToolApprovalDecision::AcceptWithUpdatedInput(_)
         | McpToolApprovalDecision::Decline { .. }
         | McpToolApprovalDecision::Cancel
         | McpToolApprovalDecision::BlockedBySafetyMonitor(_) => {}

--- a/codex-rs/core/src/mcp_tool_call_tests.rs
+++ b/codex-rs/core/src/mcp_tool_call_tests.rs
@@ -1941,6 +1941,7 @@ async fn approve_mode_skips_when_annotations_do_not_require_approval() {
         "mcp__test__tool",
         Some(&metadata),
         AppToolApproval::Approve,
+        /*pre_tool_use_permission_decision*/ None,
     )
     .await;
 
@@ -2014,6 +2015,7 @@ async fn guardian_mode_skips_auto_when_annotations_do_not_require_approval() {
         "mcp__test__tool",
         Some(&metadata),
         AppToolApproval::Auto,
+        /*pre_tool_use_permission_decision*/ None,
     )
     .await;
 
@@ -2070,6 +2072,7 @@ async fn permission_request_hook_allows_mcp_tool_call() {
         "mcp__memory__create_entities",
         Some(&metadata),
         AppToolApproval::Auto,
+        /*pre_tool_use_permission_decision*/ None,
     )
     .await;
 
@@ -2097,6 +2100,81 @@ async fn permission_request_hook_allows_mcp_tool_call() {
                 }]
             }
         })]
+    );
+}
+
+#[tokio::test]
+async fn permission_request_hook_can_update_mcp_tool_input() {
+    let (mut session, turn_context) = make_session_and_context().await;
+    install_mcp_permission_request_hook(
+        &mut session,
+        &turn_context,
+        "mcp__memory__.*",
+        &serde_json::json!({
+            "hookSpecificOutput": {
+                "hookEventName": "PermissionRequest",
+                "decision": {
+                    "behavior": "allow",
+                    "updatedInput": {
+                        "entities": [{
+                            "name": "Grace",
+                            "entityType": "person"
+                        }]
+                    }
+                }
+            }
+        }),
+    );
+    let session = Arc::new(session);
+    let turn_context = Arc::new(turn_context);
+    let invocation = McpInvocation {
+        server: "memory".to_string(),
+        tool: "create_entities".to_string(),
+        arguments: Some(serde_json::json!({
+            "entities": [{
+                "name": "Ada",
+                "entityType": "person"
+            }]
+        })),
+    };
+    let metadata = McpToolApprovalMetadata {
+        annotations: Some(annotations(
+            Some(false),
+            Some(true),
+            /*open_world*/ None,
+        )),
+        connector_id: None,
+        connector_name: None,
+        connector_description: None,
+        tool_title: Some("Create entities".to_string()),
+        tool_description: None,
+        mcp_app_resource_uri: None,
+        codex_apps_meta: None,
+        openai_file_input_params: None,
+    };
+
+    let decision = maybe_request_mcp_tool_approval(
+        &session,
+        &turn_context,
+        "call-mcp-hook",
+        &invocation,
+        "mcp__memory__create_entities",
+        Some(&metadata),
+        AppToolApproval::Auto,
+        /*pre_tool_use_permission_decision*/ None,
+    )
+    .await;
+
+    assert_eq!(
+        decision,
+        Some(McpToolApprovalDecision::AcceptWithUpdatedInput(
+            serde_json::json!({
+                "entities": [{
+                    "name": "Grace",
+                    "entityType": "person"
+                }]
+            })
+        ))
     );
 }
 
@@ -2130,6 +2208,7 @@ async fn permission_request_hook_uses_hook_tool_name_without_metadata() {
         "mcp__memory__create_entities",
         /*metadata*/ None,
         AppToolApproval::Auto,
+        /*pre_tool_use_permission_decision*/ None,
     )
     .await;
 
@@ -2207,6 +2286,7 @@ async fn permission_request_hook_runs_after_remembered_mcp_approval() {
         "mcp__memory__create_entities",
         Some(&metadata),
         AppToolApproval::Auto,
+        /*pre_tool_use_permission_decision*/ None,
     )
     .await;
 
@@ -2287,6 +2367,7 @@ async fn guardian_mode_mcp_denial_returns_rationale_message() {
         "mcp__test__tool",
         Some(&metadata),
         AppToolApproval::Auto,
+        /*pre_tool_use_permission_decision*/ None,
     )
     .await;
 
@@ -2344,6 +2425,7 @@ async fn prompt_mode_waits_for_approval_when_annotations_do_not_require_approval
                 "mcp__test__tool",
                 Some(&metadata),
                 AppToolApproval::Prompt,
+                /*pre_tool_use_permission_decision*/ None,
             )
             .await
         })
@@ -2419,6 +2501,7 @@ async fn approve_mode_skips_arc_interrupt_for_model() {
         "mcp__test__tool",
         Some(&metadata),
         AppToolApproval::Approve,
+        /*pre_tool_use_permission_decision*/ None,
     )
     .await;
 
@@ -2486,6 +2569,7 @@ async fn custom_approve_mode_skips_arc_interrupt_for_model() {
         "mcp__test__tool",
         Some(&metadata),
         AppToolApproval::Approve,
+        /*pre_tool_use_permission_decision*/ None,
     )
     .await;
 
@@ -2553,6 +2637,7 @@ async fn approve_mode_skips_arc_interrupt_without_annotations() {
         "mcp__test__tool",
         Some(&metadata),
         AppToolApproval::Approve,
+        /*pre_tool_use_permission_decision*/ None,
     )
     .await;
 
@@ -2630,6 +2715,7 @@ async fn full_access_mode_skips_arc_monitor_for_all_approval_modes() {
             "mcp__test__tool",
             Some(&metadata),
             approval_mode,
+            /*pre_tool_use_permission_decision*/ None,
         )
         .await;
 
@@ -2733,6 +2819,7 @@ async fn approve_mode_skips_arc_and_guardian_in_every_permission_mode() {
             "mcp__test__tool",
             Some(&metadata),
             AppToolApproval::Approve,
+            /*pre_tool_use_permission_decision*/ None,
         )
         .await;
 

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -978,6 +978,7 @@ async fn danger_full_access_tool_attempts_do_not_enforce_managed_network() -> an
         turn: Arc::clone(&turn),
         call_id: "probe-call".to_string(),
         tool_name: "probe".to_string(),
+        pre_tool_use_permission_decision: None,
     };
 
     orchestrator
@@ -8264,6 +8265,7 @@ async fn create_goal_tool_rejects_existing_goal() {
                 })
                 .to_string(),
             },
+            pre_tool_use_permission_decision: None,
         })
         .await
         .expect("initial create_goal should succeed");
@@ -8284,6 +8286,7 @@ async fn create_goal_tool_rejects_existing_goal() {
                 })
                 .to_string(),
             },
+            pre_tool_use_permission_decision: None,
         })
         .await;
 
@@ -8327,6 +8330,7 @@ async fn update_goal_tool_rejects_pausing_goal() {
                 })
                 .to_string(),
             },
+            pre_tool_use_permission_decision: None,
         })
         .await
         .expect("initial create_goal should succeed");
@@ -8346,6 +8350,7 @@ async fn update_goal_tool_rejects_pausing_goal() {
                 })
                 .to_string(),
             },
+            pre_tool_use_permission_decision: None,
         })
         .await;
 
@@ -8388,6 +8393,7 @@ async fn update_goal_tool_marks_goal_complete() {
                 })
                 .to_string(),
             },
+            pre_tool_use_permission_decision: None,
         })
         .await
         .expect("initial create_goal should succeed");
@@ -8407,6 +8413,7 @@ async fn update_goal_tool_marks_goal_complete() {
                 })
                 .to_string(),
             },
+            pre_tool_use_permission_decision: None,
         })
         .await
         .expect("update_goal should mark the goal complete");
@@ -8494,6 +8501,7 @@ async fn rejects_escalated_permissions_when_policy_not_on_request() {
                 })
                 .to_string(),
             },
+            pre_tool_use_permission_decision: None,
         })
         .await;
 
@@ -8567,6 +8575,7 @@ async fn unified_exec_rejects_escalated_permissions_when_policy_not_on_request()
                 })
                 .to_string(),
             },
+            pre_tool_use_permission_decision: None,
         })
         .await;
 

--- a/codex-rs/core/src/session/tests/guardian_tests.rs
+++ b/codex-rs/core/src/session/tests/guardian_tests.rs
@@ -349,6 +349,7 @@ async fn guardian_allows_shell_additional_permissions_requests_past_policy_valid
                 })
                 .to_string(),
             },
+            pre_tool_use_permission_decision: None,
         })
         .await;
 
@@ -470,6 +471,7 @@ async fn strict_auto_review_turn_grant_forces_guardian_for_shell_policy_skip() {
                 })
                 .to_string(),
             },
+            pre_tool_use_permission_decision: None,
         })
         .await;
 
@@ -516,6 +518,7 @@ async fn guardian_allows_unified_exec_additional_permissions_requests_past_polic
                 })
                 .to_string(),
             },
+            pre_tool_use_permission_decision: None,
         })
         .await;
 
@@ -637,6 +640,7 @@ async fn shell_handler_allows_sticky_turn_permissions_without_inline_request_per
                 })
                 .to_string(),
             },
+            pre_tool_use_permission_decision: None,
         })
         .await;
 

--- a/codex-rs/core/src/stream_events_utils.rs
+++ b/codex-rs/core/src/stream_events_utils.rs
@@ -336,6 +336,11 @@ pub(crate) async fn handle_output_item_done(
 
             output.needs_follow_up = true;
         }
+        Err(FunctionCallError::UpdatedInput(_)) => {
+            return Err(CodexErr::Fatal(
+                "updated tool input escaped dispatch".to_string(),
+            ));
+        }
         // A fatal error occurred; surface it back into history.
         Err(FunctionCallError::Fatal(message)) => {
             return Err(CodexErr::Fatal(message));

--- a/codex-rs/core/src/tools/context.rs
+++ b/codex-rs/core/src/tools/context.rs
@@ -7,6 +7,7 @@ use crate::tools::TELEMETRY_PREVIEW_MAX_LINES;
 use crate::tools::TELEMETRY_PREVIEW_TRUNCATION_NOTICE;
 use crate::turn_diff_tracker::TurnDiffTracker;
 use crate::unified_exec::resolve_max_tokens;
+use codex_hooks::PreToolUsePermissionDecision;
 use codex_protocol::mcp::CallToolResult;
 use codex_protocol::models::DEFAULT_IMAGE_DETAIL;
 use codex_protocol::models::FunctionCallOutputBody;
@@ -54,6 +55,7 @@ pub struct ToolInvocation {
     pub tool_name: ToolName,
     pub source: ToolCallSource,
     pub payload: ToolPayload,
+    pub pre_tool_use_permission_decision: Option<PreToolUsePermissionDecision>,
 }
 
 #[derive(Clone, Debug)]

--- a/codex-rs/core/src/tools/events.rs
+++ b/codex-rs/core/src/tools/events.rs
@@ -353,6 +353,9 @@ impl ToolEmitter {
                 let result = Err(FunctionCallError::RespondToModel(normalized));
                 (event, result)
             }
+            Err(ToolError::UpdatedInput(updated_input)) => {
+                return Err(FunctionCallError::UpdatedInput(updated_input));
+            }
         };
         self.emit(ctx, event).await;
         result

--- a/codex-rs/core/src/tools/handlers/apply_patch.rs
+++ b/codex-rs/core/src/tools/handlers/apply_patch.rs
@@ -22,6 +22,8 @@ use crate::tools::events::ToolEmitter;
 use crate::tools::events::ToolEventCtx;
 use crate::tools::handlers::apply_granted_turn_permissions;
 use crate::tools::handlers::parse_arguments;
+use crate::tools::handlers::rewrite_function_string_argument;
+use crate::tools::handlers::updated_hook_command;
 use crate::tools::hook_names::HookToolName;
 use crate::tools::orchestrator::ToolOrchestrator;
 use crate::tools::registry::PostToolUsePayload;
@@ -323,6 +325,29 @@ impl ToolHandler for ApplyPatchHandler {
         })
     }
 
+    fn with_updated_hook_input(
+        &self,
+        mut invocation: ToolInvocation,
+        updated_input: serde_json::Value,
+    ) -> Result<ToolInvocation, FunctionCallError> {
+        let patch = updated_hook_command(&updated_input)?;
+        invocation.payload = match invocation.payload {
+            ToolPayload::Function { arguments } => ToolPayload::Function {
+                arguments: rewrite_function_string_argument(
+                    &arguments,
+                    "apply_patch",
+                    "input",
+                    patch,
+                )?,
+            },
+            ToolPayload::Custom { .. } => ToolPayload::Custom {
+                input: patch.to_string(),
+            },
+            payload => payload,
+        };
+        Ok(invocation)
+    }
+
     fn post_tool_use_payload(
         &self,
         invocation: &ToolInvocation,
@@ -348,6 +373,7 @@ impl ToolHandler for ApplyPatchHandler {
             call_id,
             tool_name,
             payload,
+            pre_tool_use_permission_decision,
             ..
         } = invocation;
 
@@ -426,6 +452,8 @@ impl ToolHandler for ApplyPatchHandler {
                             turn: turn.clone(),
                             call_id: call_id.clone(),
                             tool_name: tool_name.display(),
+                            pre_tool_use_permission_decision: pre_tool_use_permission_decision
+                                .clone(),
                         };
                         let out = orchestrator
                             .run(
@@ -478,6 +506,7 @@ pub(crate) async fn intercept_apply_patch(
     tracker: Option<&SharedTurnDiffTracker>,
     call_id: &str,
     tool_name: &str,
+    pre_tool_use_permission_decision: Option<codex_hooks::PreToolUsePermissionDecision>,
 ) -> Result<Option<FunctionToolOutput>, FunctionCallError> {
     let sandbox = turn
         .environments
@@ -534,6 +563,7 @@ pub(crate) async fn intercept_apply_patch(
                         turn: turn.clone(),
                         call_id: call_id.to_string(),
                         tool_name: tool_name.to_string(),
+                        pre_tool_use_permission_decision: pre_tool_use_permission_decision.clone(),
                     };
                     let out = orchestrator
                         .run(

--- a/codex-rs/core/src/tools/handlers/apply_patch_tests.rs
+++ b/codex-rs/core/src/tools/handlers/apply_patch_tests.rs
@@ -39,6 +39,7 @@ async fn invocation_for_payload(payload: ToolPayload) -> ToolInvocation {
         tool_name: codex_tools::ToolName::plain("apply_patch"),
         source: crate::tools::context::ToolCallSource::Direct,
         payload,
+        pre_tool_use_permission_decision: None,
     }
 }
 

--- a/codex-rs/core/src/tools/handlers/mcp.rs
+++ b/codex-rs/core/src/tools/handlers/mcp.rs
@@ -48,6 +48,26 @@ impl ToolHandler for McpHandler {
         })
     }
 
+    fn with_updated_hook_input(
+        &self,
+        mut invocation: ToolInvocation,
+        updated_input: Value,
+    ) -> Result<ToolInvocation, FunctionCallError> {
+        invocation.payload = match invocation.payload {
+            ToolPayload::Mcp { server, tool, .. } => ToolPayload::Mcp {
+                server,
+                tool,
+                raw_arguments: serde_json::to_string(&updated_input).map_err(|err| {
+                    FunctionCallError::RespondToModel(format!(
+                        "failed to serialize rewritten MCP arguments: {err}"
+                    ))
+                })?,
+            },
+            payload => payload,
+        };
+        Ok(invocation)
+    }
+
     fn post_tool_use_payload(
         &self,
         invocation: &ToolInvocation,
@@ -73,6 +93,7 @@ impl ToolHandler for McpHandler {
             turn,
             call_id,
             payload,
+            pre_tool_use_permission_decision,
             ..
         } = invocation;
 
@@ -101,6 +122,7 @@ impl ToolHandler for McpHandler {
             tool,
             self.tool_name.display(),
             arguments_str,
+            pre_tool_use_permission_decision,
         )
         .await;
 
@@ -162,6 +184,7 @@ mod tests {
                 tool_name: codex_tools::ToolName::namespaced("mcp__memory__", "create_entities"),
                 source: ToolCallSource::Direct,
                 payload,
+                pre_tool_use_permission_decision: None,
             }),
             Some(PreToolUsePayload {
                 tool_name: HookToolName::new("mcp__memory__create_entities"),
@@ -215,6 +238,7 @@ mod tests {
             tool_name: codex_tools::ToolName::namespaced("mcp__filesystem__", "read_file"),
             source: ToolCallSource::Direct,
             payload,
+            pre_tool_use_permission_decision: None,
         };
         assert_eq!(
             handler.post_tool_use_payload(&invocation, &output),

--- a/codex-rs/core/src/tools/handlers/mod.rs
+++ b/codex-rs/core/src/tools/handlers/mod.rs
@@ -24,6 +24,7 @@ use codex_sandboxing::policy_transforms::normalize_additional_permissions;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use codex_utils_absolute_path::AbsolutePathBufGuard;
 use serde::Deserialize;
+use serde_json::Map;
 use serde_json::Value;
 use std::path::Path;
 
@@ -79,6 +80,47 @@ where
 {
     let _guard = AbsolutePathBufGuard::new(base_path);
     parse_arguments(arguments)
+}
+
+fn updated_hook_command(updated_input: &Value) -> Result<&str, FunctionCallError> {
+    updated_input
+        .get("command")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            FunctionCallError::RespondToModel(
+                "hook returned updatedInput without string field `command`".to_string(),
+            )
+        })
+}
+
+fn rewrite_function_arguments(
+    arguments: &str,
+    tool_name: &str,
+    rewrite: impl FnOnce(&mut Map<String, Value>),
+) -> Result<String, FunctionCallError> {
+    let mut arguments: Value = parse_arguments(arguments)?;
+    let Value::Object(arguments) = &mut arguments else {
+        return Err(FunctionCallError::RespondToModel(format!(
+            "{tool_name} arguments must be an object"
+        )));
+    };
+    rewrite(arguments);
+    serde_json::to_string(&arguments).map_err(|err| {
+        FunctionCallError::RespondToModel(format!(
+            "failed to serialize rewritten {tool_name} arguments: {err}"
+        ))
+    })
+}
+
+fn rewrite_function_string_argument(
+    arguments: &str,
+    tool_name: &str,
+    field_name: &str,
+    value: &str,
+) -> Result<String, FunctionCallError> {
+    rewrite_function_arguments(arguments, tool_name, |arguments| {
+        arguments.insert(field_name.to_string(), Value::String(value.to_string()));
+    })
 }
 
 fn resolve_workdir_base_path(

--- a/codex-rs/core/src/tools/handlers/multi_agents_tests.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_tests.rs
@@ -78,6 +78,7 @@ fn invocation(
         tool_name: codex_tools::ToolName::plain(tool_name),
         source: crate::tools::context::ToolCallSource::Direct,
         payload,
+        pre_tool_use_permission_decision: None,
     }
 }
 

--- a/codex-rs/core/src/tools/handlers/request_user_input_tests.rs
+++ b/codex-rs/core/src/tools/handlers/request_user_input_tests.rs
@@ -53,6 +53,7 @@ async fn multi_agent_v2_request_user_input_rejects_subagent_threads() {
             })
             .to_string(),
         },
+        pre_tool_use_permission_decision: None,
     })
     .await;
 

--- a/codex-rs/core/src/tools/handlers/shell.rs
+++ b/codex-rs/core/src/tools/handlers/shell.rs
@@ -25,6 +25,9 @@ use crate::tools::handlers::normalize_and_validate_additional_permissions;
 use crate::tools::handlers::parse_arguments;
 use crate::tools::handlers::parse_arguments_with_base_path;
 use crate::tools::handlers::resolve_workdir_base_path;
+use crate::tools::handlers::rewrite_function_arguments;
+use crate::tools::handlers::rewrite_function_string_argument;
+use crate::tools::handlers::updated_hook_command;
 use crate::tools::hook_names::HookToolName;
 use crate::tools::orchestrator::ToolOrchestrator;
 use crate::tools::registry::PostToolUsePayload;
@@ -98,6 +101,7 @@ struct RunExecLikeArgs {
     call_id: String,
     freeform: bool,
     shell_runtime_backend: ShellRuntimeBackend,
+    pre_tool_use_permission_decision: Option<codex_hooks::PreToolUsePermissionDecision>,
 }
 
 impl ShellHandler {
@@ -234,6 +238,7 @@ impl ToolHandler for ShellHandler {
             tracker,
             call_id,
             payload,
+            pre_tool_use_permission_decision,
             ..
         } = invocation;
 
@@ -263,6 +268,7 @@ impl ToolHandler for ShellHandler {
             call_id,
             freeform: false,
             shell_runtime_backend: ShellRuntimeBackend::Generic,
+            pre_tool_use_permission_decision,
         })
         .await
     }
@@ -312,6 +318,7 @@ impl ToolHandler for ContainerExecHandler {
             tracker,
             call_id,
             payload,
+            pre_tool_use_permission_decision,
             ..
         } = invocation;
 
@@ -341,6 +348,7 @@ impl ToolHandler for ContainerExecHandler {
             call_id,
             freeform: false,
             shell_runtime_backend: ShellRuntimeBackend::Generic,
+            pre_tool_use_permission_decision,
         })
         .await
     }
@@ -376,6 +384,41 @@ impl ToolHandler for LocalShellHandler {
         })
     }
 
+    fn with_updated_hook_input(
+        &self,
+        mut invocation: ToolInvocation,
+        updated_input: JsonValue,
+    ) -> Result<ToolInvocation, FunctionCallError> {
+        let command = updated_hook_command(&updated_input)?;
+        invocation.payload = match invocation.payload {
+            ToolPayload::Function { arguments } => {
+                let command = shlex::split(command).ok_or_else(|| {
+                    FunctionCallError::RespondToModel(
+                        "hook returned shell input with an invalid command string".to_string(),
+                    )
+                })?;
+                ToolPayload::Function {
+                    arguments: rewrite_function_arguments(&arguments, "shell", |arguments| {
+                        arguments.insert(
+                            "command".to_string(),
+                            JsonValue::Array(command.into_iter().map(JsonValue::String).collect()),
+                        );
+                    })?,
+                }
+            }
+            ToolPayload::LocalShell { mut params } => {
+                params.command = shlex::split(command).ok_or_else(|| {
+                    FunctionCallError::RespondToModel(
+                        "hook returned shell input with an invalid command string".to_string(),
+                    )
+                })?;
+                ToolPayload::LocalShell { params }
+            }
+            payload => payload,
+        };
+        Ok(invocation)
+    }
+
     fn post_tool_use_payload(
         &self,
         invocation: &ToolInvocation,
@@ -399,6 +442,7 @@ impl ToolHandler for LocalShellHandler {
             tracker,
             call_id,
             payload,
+            pre_tool_use_permission_decision,
             ..
         } = invocation;
 
@@ -422,6 +466,7 @@ impl ToolHandler for LocalShellHandler {
             call_id,
             freeform: false,
             shell_runtime_backend: ShellRuntimeBackend::Generic,
+            pre_tool_use_permission_decision,
         })
         .await
     }
@@ -491,6 +536,27 @@ impl ToolHandler for ShellCommandHandler {
         })
     }
 
+    fn with_updated_hook_input(
+        &self,
+        mut invocation: ToolInvocation,
+        updated_input: JsonValue,
+    ) -> Result<ToolInvocation, FunctionCallError> {
+        let ToolPayload::Function { arguments } = invocation.payload else {
+            return Err(FunctionCallError::RespondToModel(
+                "hook input rewrite received unsupported shell_command payload".to_string(),
+            ));
+        };
+        invocation.payload = ToolPayload::Function {
+            arguments: rewrite_function_string_argument(
+                &arguments,
+                "shell_command",
+                "command",
+                updated_hook_command(&updated_input)?,
+            )?,
+        };
+        Ok(invocation)
+    }
+
     fn post_tool_use_payload(
         &self,
         invocation: &ToolInvocation,
@@ -514,6 +580,7 @@ impl ToolHandler for ShellCommandHandler {
             tracker,
             call_id,
             payload,
+            pre_tool_use_permission_decision,
             ..
         } = invocation;
 
@@ -554,6 +621,7 @@ impl ToolHandler for ShellCommandHandler {
             call_id,
             freeform: true,
             shell_runtime_backend: self.shell_runtime_backend(),
+            pre_tool_use_permission_decision,
         })
         .await
     }
@@ -573,6 +641,7 @@ impl ShellHandler {
             call_id,
             freeform,
             shell_runtime_backend,
+            pre_tool_use_permission_decision,
         } = args;
 
         let mut exec_params = exec_params;
@@ -656,6 +725,7 @@ impl ShellHandler {
             Some(&tracker),
             &call_id,
             tool_name.as_str(),
+            pre_tool_use_permission_decision.clone(),
         )
         .await?
         {
@@ -727,6 +797,7 @@ impl ShellHandler {
             turn: turn.clone(),
             call_id: call_id.clone(),
             tool_name,
+            pre_tool_use_permission_decision,
         };
         let out = orchestrator
             .run(

--- a/codex-rs/core/src/tools/handlers/shell_tests.rs
+++ b/codex-rs/core/src/tools/handlers/shell_tests.rs
@@ -233,6 +233,7 @@ async fn local_shell_pre_tool_use_payload_uses_joined_command() {
             tool_name: codex_tools::ToolName::plain("local_shell"),
             source: crate::tools::context::ToolCallSource::Direct,
             payload,
+            pre_tool_use_permission_decision: None,
         }),
         Some(crate::tools::registry::PreToolUsePayload {
             tool_name: HookToolName::bash(),
@@ -261,6 +262,7 @@ async fn shell_command_pre_tool_use_payload_uses_raw_command() {
             tool_name: codex_tools::ToolName::plain("shell_command"),
             source: crate::tools::context::ToolCallSource::Direct,
             payload,
+            pre_tool_use_permission_decision: None,
         }),
         Some(crate::tools::registry::PreToolUsePayload {
             tool_name: HookToolName::bash(),
@@ -292,6 +294,7 @@ async fn build_post_tool_use_payload_uses_tool_output_wire_value() {
         tool_name: codex_tools::ToolName::plain("shell_command"),
         source: ToolCallSource::Direct,
         payload,
+        pre_tool_use_permission_decision: None,
     };
     assert_eq!(
         handler.post_tool_use_payload(&invocation, &output),

--- a/codex-rs/core/src/tools/handlers/unified_exec.rs
+++ b/codex-rs/core/src/tools/handlers/unified_exec.rs
@@ -14,6 +14,8 @@ use crate::tools::handlers::normalize_and_validate_additional_permissions;
 use crate::tools::handlers::parse_arguments;
 use crate::tools::handlers::parse_arguments_with_base_path;
 use crate::tools::handlers::resolve_tool_environment;
+use crate::tools::handlers::rewrite_function_string_argument;
+use crate::tools::handlers::updated_hook_command;
 use crate::tools::hook_names::HookToolName;
 use crate::tools::registry::PostToolUsePayload;
 use crate::tools::registry::PreToolUsePayload;
@@ -162,6 +164,27 @@ impl ToolHandler for ExecCommandHandler {
             })
     }
 
+    fn with_updated_hook_input(
+        &self,
+        mut invocation: ToolInvocation,
+        updated_input: serde_json::Value,
+    ) -> Result<ToolInvocation, FunctionCallError> {
+        let ToolPayload::Function { arguments } = invocation.payload else {
+            return Err(FunctionCallError::RespondToModel(
+                "hook input rewrite received unsupported exec_command payload".to_string(),
+            ));
+        };
+        invocation.payload = ToolPayload::Function {
+            arguments: rewrite_function_string_argument(
+                &arguments,
+                "exec_command",
+                "cmd",
+                updated_hook_command(&updated_input)?,
+            )?,
+        };
+        Ok(invocation)
+    }
+
     fn post_tool_use_payload(
         &self,
         invocation: &ToolInvocation,
@@ -177,6 +200,7 @@ impl ToolHandler for ExecCommandHandler {
             tracker,
             call_id,
             payload,
+            pre_tool_use_permission_decision,
             ..
         } = invocation;
 
@@ -190,7 +214,10 @@ impl ToolHandler for ExecCommandHandler {
         };
 
         let manager: &UnifiedExecProcessManager = &session.services.unified_exec_manager;
-        let context = UnifiedExecContext::new(session.clone(), turn.clone(), call_id.clone());
+        let context = UnifiedExecContext {
+            pre_tool_use_permission_decision,
+            ..UnifiedExecContext::new(session.clone(), turn.clone(), call_id.clone())
+        };
         let environment_args: ExecCommandEnvironmentArgs = parse_arguments(&arguments)?;
         let Some(turn_environment) =
             resolve_tool_environment(turn.as_ref(), environment_args.environment_id.as_deref())?
@@ -307,6 +334,7 @@ impl ToolHandler for ExecCommandHandler {
             Some(&tracker),
             &context.call_id,
             "exec_command",
+            context.pre_tool_use_permission_decision.clone(),
         )
         .await?
         {
@@ -349,6 +377,9 @@ impl ToolHandler for ExecCommandHandler {
             .await
         {
             Ok(response) => Ok(response),
+            Err(UnifiedExecError::UpdatedInput(updated_input)) => {
+                Err(FunctionCallError::UpdatedInput(updated_input))
+            }
             Err(UnifiedExecError::SandboxDenied { output, .. }) => {
                 let output_text = output.aggregated_output.text;
                 let original_token_count = approx_token_count(&output_text);

--- a/codex-rs/core/src/tools/handlers/unified_exec_tests.rs
+++ b/codex-rs/core/src/tools/handlers/unified_exec_tests.rs
@@ -31,6 +31,7 @@ async fn invocation_for_payload(
         tool_name: codex_tools::ToolName::plain(tool_name),
         source: ToolCallSource::Direct,
         payload,
+        pre_tool_use_permission_decision: None,
     }
 }
 
@@ -196,6 +197,7 @@ async fn exec_command_pre_tool_use_payload_uses_raw_command() {
             tool_name: codex_tools::ToolName::plain("exec_command"),
             source: crate::tools::context::ToolCallSource::Direct,
             payload,
+            pre_tool_use_permission_decision: None,
         }),
         Some(crate::tools::registry::PreToolUsePayload {
             tool_name: HookToolName::bash(),
@@ -222,6 +224,7 @@ async fn exec_command_pre_tool_use_payload_skips_write_stdin() {
             tool_name: codex_tools::ToolName::plain("write_stdin"),
             source: crate::tools::context::ToolCallSource::Direct,
             payload,
+            pre_tool_use_permission_decision: None,
         }),
         None
     );

--- a/codex-rs/core/src/tools/network_approval.rs
+++ b/codex-rs/core/src/tools/network_approval.rs
@@ -473,7 +473,29 @@ impl NetworkApprovalService {
         .await
         {
             match permission_request_decision {
-                PermissionRequestDecision::Allow => {
+                PermissionRequestDecision::Allow {
+                    updated_input: Some(_),
+                } => {
+                    if let Some(owner_call) = owner_call.as_ref() {
+                        self.record_call_outcome(
+                            &owner_call.registration_id,
+                            NetworkApprovalOutcome::DeniedByPolicy(
+                                "updatedInput is not supported for network approval requests"
+                                    .to_string(),
+                            ),
+                        )
+                        .await;
+                    }
+                    pending.set_decision(PendingApprovalDecision::Deny).await;
+                    let mut pending_approvals = self.pending_host_approvals.lock().await;
+                    pending_approvals.remove(&key);
+                    return NetworkDecision::deny(
+                        "updatedInput is not supported for network approval requests",
+                    );
+                }
+                PermissionRequestDecision::Allow {
+                    updated_input: None,
+                } => {
                     pending
                         .set_decision(PendingApprovalDecision::AllowOnce)
                         .await;

--- a/codex-rs/core/src/tools/orchestrator.rs
+++ b/codex-rs/core/src/tools/orchestrator.rs
@@ -27,6 +27,7 @@ use crate::tools::sandboxing::ToolError;
 use crate::tools::sandboxing::ToolRuntime;
 use crate::tools::sandboxing::default_exec_approval_requirement;
 use codex_hooks::PermissionRequestDecision;
+use codex_hooks::PreToolUsePermissionDecision;
 use codex_otel::ToolDecisionSource;
 use codex_protocol::error::CodexErr;
 use codex_protocol::error::SandboxErr;
@@ -76,6 +77,7 @@ impl ToolOrchestrator {
             turn: tool_ctx.turn.clone(),
             call_id: tool_ctx.call_id.clone(),
             tool_name: tool_ctx.tool_name.clone(),
+            pre_tool_use_permission_decision: tool_ctx.pre_tool_use_permission_decision.clone(),
         };
         let attempt_with_network_approval = SandboxAttempt {
             sandbox: attempt.sandbox,
@@ -148,8 +150,57 @@ impl ToolOrchestrator {
         let requirement = tool.exec_approval_requirement(req).unwrap_or_else(|| {
             default_exec_approval_requirement(approval_policy, &file_system_sandbox_policy)
         });
-        match requirement {
-            ExecApprovalRequirement::Skip { .. } => {
+        match (&tool_ctx.pre_tool_use_permission_decision, requirement) {
+            (
+                Some(PreToolUsePermissionDecision::Allow),
+                ExecApprovalRequirement::Forbidden { reason },
+            )
+            | (
+                Some(PreToolUsePermissionDecision::Ask { .. }),
+                ExecApprovalRequirement::Forbidden { reason },
+            ) => {
+                return Err(ToolError::Rejected(reason));
+            }
+            (
+                Some(PreToolUsePermissionDecision::Allow),
+                ExecApprovalRequirement::Skip { .. }
+                | ExecApprovalRequirement::NeedsApproval { .. },
+            ) => {
+                otel.tool_decision(
+                    otel_tn,
+                    otel_ci,
+                    &ReviewDecision::Approved,
+                    ToolDecisionSource::Config,
+                );
+                already_approved = true;
+            }
+            (
+                Some(PreToolUsePermissionDecision::Ask { reason }),
+                ExecApprovalRequirement::Skip { .. }
+                | ExecApprovalRequirement::NeedsApproval { reason: _, .. },
+            ) => {
+                let approval_ctx = ApprovalCtx {
+                    session: &tool_ctx.session,
+                    turn: &tool_ctx.turn,
+                    call_id: &tool_ctx.call_id,
+                    guardian_review_id: None,
+                    retry_reason: reason.clone(),
+                    network_approval_context: None,
+                };
+                let decision = Self::request_approval(
+                    tool,
+                    req,
+                    tool_ctx.call_id.as_str(),
+                    approval_ctx,
+                    tool_ctx,
+                    /*evaluate_permission_request_hooks*/ false,
+                    &otel,
+                )
+                .await?;
+                Self::reject_if_not_approved(tool_ctx, None, decision).await?;
+                already_approved = true;
+            }
+            (None, ExecApprovalRequirement::Skip { .. }) => {
                 if strict_auto_review {
                     let guardian_review_id = Some(new_guardian_review_id());
                     let approval_ctx = ApprovalCtx {
@@ -182,10 +233,10 @@ impl ToolOrchestrator {
                     );
                 }
             }
-            ExecApprovalRequirement::Forbidden { reason } => {
+            (None, ExecApprovalRequirement::Forbidden { reason }) => {
                 return Err(ToolError::Rejected(reason));
             }
-            ExecApprovalRequirement::NeedsApproval { reason, .. } => {
+            (None, ExecApprovalRequirement::NeedsApproval { reason, .. }) => {
                 let guardian_review_id = use_guardian.then(new_guardian_review_id);
                 let approval_ctx = ApprovalCtx {
                     session: &tool_ctx.session,
@@ -398,6 +449,7 @@ impl ToolOrchestrator {
         if evaluate_permission_request_hooks
             && let Some(permission_request) = tool.permission_request_payload(req)
         {
+            let permission_request_for_noop_check = permission_request.clone();
             match run_permission_request_hooks(
                 approval_ctx.session,
                 approval_ctx.turn,
@@ -406,7 +458,24 @@ impl ToolOrchestrator {
             )
             .await
             {
-                Some(PermissionRequestDecision::Allow) => {
+                Some(PermissionRequestDecision::Allow {
+                    updated_input: Some(updated_input),
+                }) => {
+                    if !permission_request_for_noop_check.updated_input_is_noop(&updated_input) {
+                        return Err(ToolError::UpdatedInput(updated_input));
+                    }
+                    let decision = ReviewDecision::Approved;
+                    otel.tool_decision(
+                        &tool_ctx.tool_name,
+                        &tool_ctx.call_id,
+                        &decision,
+                        ToolDecisionSource::Config,
+                    );
+                    return Ok(decision);
+                }
+                Some(PermissionRequestDecision::Allow {
+                    updated_input: None,
+                }) => {
                     let decision = ReviewDecision::Approved;
                     otel.tool_decision(
                         &tool_ctx.tool_name,

--- a/codex-rs/core/src/tools/orchestrator.rs
+++ b/codex-rs/core/src/tools/orchestrator.rs
@@ -197,7 +197,8 @@ impl ToolOrchestrator {
                     &otel,
                 )
                 .await?;
-                Self::reject_if_not_approved(tool_ctx, None, decision).await?;
+                Self::reject_if_not_approved(tool_ctx, /*guardian_review_id*/ None, decision)
+                    .await?;
                 already_approved = true;
             }
             (None, ExecApprovalRequirement::Skip { .. }) => {

--- a/codex-rs/core/src/tools/registry.rs
+++ b/codex-rs/core/src/tools/registry.rs
@@ -5,6 +5,7 @@ use std::time::Instant;
 
 use crate::function_tool::FunctionCallError;
 use crate::goals::GoalRuntimeEvent;
+use crate::hook_runtime::MAX_HOOK_INPUT_REWRITES;
 use crate::hook_runtime::record_additional_contexts;
 use crate::hook_runtime::run_post_tool_use_hooks;
 use crate::hook_runtime::run_pre_tool_use_hooks;
@@ -79,6 +80,20 @@ pub trait ToolHandler: Send + Sync {
         _result: &Self::Output,
     ) -> Option<PostToolUsePayload> {
         None
+    }
+
+    /// Rebuilds a tool invocation from hook-facing `tool_input`.
+    ///
+    /// Tools that opt into input-rewriting hooks should invert the same stable
+    /// hook contract they expose from `pre_tool_use_payload`.
+    fn with_updated_hook_input(
+        &self,
+        _invocation: ToolInvocation,
+        _updated_input: Value,
+    ) -> Result<ToolInvocation, FunctionCallError> {
+        Err(FunctionCallError::RespondToModel(
+            "tool does not support hook input rewriting".to_string(),
+        ))
     }
 
     /// Creates an optional consumer for streamed tool argument diffs.
@@ -169,6 +184,12 @@ trait AnyToolHandler: Send + Sync {
 
     fn pre_tool_use_payload(&self, invocation: &ToolInvocation) -> Option<PreToolUsePayload>;
 
+    fn with_updated_hook_input(
+        &self,
+        invocation: ToolInvocation,
+        updated_input: Value,
+    ) -> Result<ToolInvocation, FunctionCallError>;
+
     fn create_diff_consumer(&self) -> Option<Box<dyn ToolArgumentDiffConsumer>>;
     fn handle_any<'a>(
         &'a self,
@@ -192,6 +213,14 @@ where
         ToolHandler::pre_tool_use_payload(self, invocation)
     }
 
+    fn with_updated_hook_input(
+        &self,
+        invocation: ToolInvocation,
+        updated_input: Value,
+    ) -> Result<ToolInvocation, FunctionCallError> {
+        ToolHandler::with_updated_hook_input(self, invocation, updated_input)
+    }
+
     fn create_diff_consumer(&self) -> Option<Box<dyn ToolArgumentDiffConsumer>> {
         ToolHandler::create_diff_consumer(self)
     }
@@ -200,9 +229,25 @@ where
         invocation: ToolInvocation,
     ) -> BoxFuture<'a, Result<AnyToolResult, FunctionCallError>> {
         Box::pin(async move {
+            let mut invocation = invocation;
+            let mut rewrites = 0;
+            let output = loop {
+                match self.handle(invocation.clone()).await {
+                    Err(FunctionCallError::UpdatedInput(updated_input)) => {
+                        rewrites += 1;
+                        if rewrites > MAX_HOOK_INPUT_REWRITES {
+                            return Err(FunctionCallError::RespondToModel(
+                                "hook input rewrite limit exceeded".to_string(),
+                            ));
+                        }
+                        invocation =
+                            ToolHandler::with_updated_hook_input(self, invocation, updated_input)?;
+                    }
+                    result => break result?,
+                }
+            };
             let call_id = invocation.call_id.clone();
             let payload = invocation.payload.clone();
-            let output = self.handle(invocation.clone()).await?;
             let post_tool_use_payload =
                 ToolHandler::post_tool_use_payload(self, &invocation, &output);
             Ok(AnyToolResult {
@@ -260,7 +305,7 @@ impl ToolRegistry {
     )]
     pub(crate) async fn dispatch_any(
         &self,
-        invocation: ToolInvocation,
+        mut invocation: ToolInvocation,
     ) -> Result<AnyToolResult, FunctionCallError> {
         let tool_name = invocation.tool_name.clone();
         let display_name = tool_name.display();
@@ -350,8 +395,8 @@ impl ToolRegistry {
             return Err(err);
         }
 
-        if let Some(pre_tool_use_payload) = handler.pre_tool_use_payload(&invocation)
-            && let Some(message) = run_pre_tool_use_hooks(
+        if let Some(pre_tool_use_payload) = handler.pre_tool_use_payload(&invocation) {
+            match run_pre_tool_use_hooks(
                 &invocation.session,
                 &invocation.turn,
                 invocation.call_id.clone(),
@@ -359,10 +404,24 @@ impl ToolRegistry {
                 &pre_tool_use_payload.tool_input,
             )
             .await
-        {
-            let err = FunctionCallError::RespondToModel(message);
-            dispatch_trace.record_failed(&err);
-            return Err(err);
+            {
+                crate::hook_runtime::PreToolUseHookResult::Blocked(message) => {
+                    let err = FunctionCallError::RespondToModel(message);
+                    dispatch_trace.record_failed(&err);
+                    return Err(err);
+                }
+                crate::hook_runtime::PreToolUseHookResult::Continue {
+                    updated_input: Some(updated_input),
+                    permission_decision,
+                } => {
+                    invocation = handler.with_updated_hook_input(invocation, updated_input)?;
+                    invocation.pre_tool_use_permission_decision = permission_decision;
+                }
+                crate::hook_runtime::PreToolUseHookResult::Continue {
+                    updated_input: None,
+                    permission_decision: _,
+                } => {}
+            }
         }
 
         let is_mutating = handler.is_mutating(&invocation).await;

--- a/codex-rs/core/src/tools/router.rs
+++ b/codex-rs/core/src/tools/router.rs
@@ -291,6 +291,7 @@ impl ToolRouter {
             tool_name,
             source,
             payload,
+            pre_tool_use_permission_decision: None,
         };
 
         self.registry.dispatch_any(invocation).await

--- a/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
+++ b/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
@@ -420,7 +420,21 @@ impl CoreShellActionProvider {
                 )
                 .await
                 {
-                    Some(PermissionRequestDecision::Allow) => {
+                    Some(PermissionRequestDecision::Allow {
+                        updated_input: Some(_),
+                    }) => {
+                        return PromptDecision {
+                            decision: ReviewDecision::Denied,
+                            guardian_review_id: None,
+                            rejection_message: Some(
+                                "updatedInput is not supported for intercepted exec approvals"
+                                    .to_string(),
+                            ),
+                        };
+                    }
+                    Some(PermissionRequestDecision::Allow {
+                        updated_input: None,
+                    }) => {
                         return PromptDecision {
                             decision: ReviewDecision::Approved,
                             guardian_review_id: None,

--- a/codex-rs/core/src/tools/sandboxing.rs
+++ b/codex-rs/core/src/tools/sandboxing.rs
@@ -154,6 +154,14 @@ impl PermissionRequestPayload {
             tool_input: serde_json::Value::Object(tool_input),
         }
     }
+
+    pub(crate) fn updated_input_is_noop(&self, updated_input: &serde_json::Value) -> bool {
+        if self.tool_name.name() == "Bash" {
+            return self.tool_input.get("command") == updated_input.get("command");
+        }
+
+        self.tool_input == *updated_input
+    }
 }
 
 // Specifies what tool orchestrator should do with a given tool call.
@@ -345,11 +353,13 @@ pub(crate) struct ToolCtx {
     pub turn: Arc<TurnContext>,
     pub call_id: String,
     pub tool_name: String,
+    pub pre_tool_use_permission_decision: Option<codex_hooks::PreToolUsePermissionDecision>,
 }
 
 #[derive(Debug)]
 pub(crate) enum ToolError {
     Rejected(String),
+    UpdatedInput(serde_json::Value),
     Codex(CodexErr),
 }
 

--- a/codex-rs/core/src/tools/sandboxing_tests.rs
+++ b/codex-rs/core/src/tools/sandboxing_tests.rs
@@ -35,6 +35,30 @@ fn bash_permission_request_payload_includes_description_when_present() {
 }
 
 #[test]
+fn bash_updated_input_noop_ignores_description() {
+    let payload = PermissionRequestPayload::bash(
+        "echo hi".to_string(),
+        Some("network-access example.com".to_string()),
+    );
+
+    assert!(payload.updated_input_is_noop(&json!({ "command": "echo hi" })));
+}
+
+#[test]
+fn non_bash_updated_input_noop_requires_full_equality() {
+    let payload = PermissionRequestPayload {
+        tool_name: HookToolName::apply_patch(),
+        tool_input: json!({ "command": "patch" }),
+    };
+
+    assert!(payload.updated_input_is_noop(&json!({ "command": "patch" })));
+    assert!(!payload.updated_input_is_noop(&json!({
+        "command": "patch",
+        "description": "ignored"
+    })));
+}
+
+#[test]
 fn external_sandbox_skips_exec_approval_on_request() {
     let sandbox_policy = SandboxPolicy::ExternalSandbox {
         network_access: NetworkAccess::Restricted,

--- a/codex-rs/core/src/tools/tool_dispatch_trace_tests.rs
+++ b/codex-rs/core/src/tools/tool_dispatch_trace_tests.rs
@@ -266,6 +266,7 @@ fn test_invocation_with_payload(
         tool_name,
         source,
         payload,
+        pre_tool_use_permission_decision: None,
     }
 }
 

--- a/codex-rs/core/src/unified_exec/errors.rs
+++ b/codex-rs/core/src/unified_exec/errors.rs
@@ -1,4 +1,5 @@
 use codex_protocol::exec_output::ExecToolCallOutput;
+use serde_json::Value;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -23,6 +24,8 @@ pub(crate) enum UnifiedExecError {
         message: String,
         output: ExecToolCallOutput,
     },
+    #[error("tool input rewritten by hook")]
+    UpdatedInput(Value),
 }
 
 impl UnifiedExecError {

--- a/codex-rs/core/src/unified_exec/mod.rs
+++ b/codex-rs/core/src/unified_exec/mod.rs
@@ -75,6 +75,7 @@ pub(crate) struct UnifiedExecContext {
     pub session: Arc<Session>,
     pub turn: Arc<TurnContext>,
     pub call_id: String,
+    pub pre_tool_use_permission_decision: Option<codex_hooks::PreToolUsePermissionDecision>,
 }
 
 impl UnifiedExecContext {
@@ -83,6 +84,7 @@ impl UnifiedExecContext {
             session,
             turn,
             call_id,
+            pre_tool_use_permission_decision: None,
         }
     }
 }

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -221,6 +221,9 @@ async fn finish_deferred_network_approval_for_session(
 fn network_approval_error_message(err: ToolError) -> String {
     match err {
         ToolError::Rejected(message) => message,
+        ToolError::UpdatedInput(_) => {
+            "updatedInput is not supported for deferred network approvals".to_string()
+        }
         ToolError::Codex(err) => err.to_string(),
     }
 }
@@ -1041,6 +1044,7 @@ impl UnifiedExecProcessManager {
             turn: context.turn.clone(),
             call_id: context.call_id.clone(),
             tool_name: "exec_command".to_string(),
+            pre_tool_use_permission_decision: context.pre_tool_use_permission_decision.clone(),
         };
         orchestrator
             .run(
@@ -1062,6 +1066,9 @@ impl UnifiedExecProcessManager {
                         output.aggregated_output.text.clone()
                     };
                     UnifiedExecError::sandbox_denied(message, output)
+                }
+                ToolError::UpdatedInput(updated_input) => {
+                    UnifiedExecError::UpdatedInput(updated_input)
                 }
                 other => UnifiedExecError::create_process(format!("{other:?}")),
             })

--- a/codex-rs/core/tests/suite/hooks.rs
+++ b/codex-rs/core/tests/suite/hooks.rs
@@ -307,6 +307,64 @@ elif mode == "exit_2":
     Ok(())
 }
 
+fn write_updating_pre_tool_use_hook(
+    home: &Path,
+    matcher: &str,
+    updated_input: &Value,
+) -> Result<()> {
+    write_updating_pre_tool_use_hook_with_decision(home, matcher, "allow", updated_input)
+}
+
+fn write_updating_pre_tool_use_hook_with_decision(
+    home: &Path,
+    matcher: &str,
+    permission_decision: &str,
+    updated_input: &Value,
+) -> Result<()> {
+    let script_path = home.join("pre_tool_use_hook.py");
+    let log_path = home.join("pre_tool_use_hook_log.jsonl");
+    let updated_input_json =
+        serde_json::to_string(updated_input).context("serialize updated pre tool input")?;
+    let script = format!(
+        r#"import json
+from pathlib import Path
+import sys
+
+payload = json.load(sys.stdin)
+
+with Path(r"{log_path}").open("a", encoding="utf-8") as handle:
+    handle.write(json.dumps(payload) + "\n")
+
+print(json.dumps({{
+    "hookSpecificOutput": {{
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "{permission_decision}",
+        "updatedInput": {updated_input_json}
+    }}
+}}))
+"#,
+        log_path = log_path.display(),
+        permission_decision = permission_decision,
+        updated_input_json = updated_input_json,
+    );
+    let hooks = serde_json::json!({
+        "hooks": {
+            "PreToolUse": [{
+                "matcher": matcher,
+                "hooks": [{
+                    "type": "command",
+                    "command": format!("python3 {}", script_path.display()),
+                    "statusMessage": "rewriting pre tool input",
+                }]
+            }]
+        }
+    });
+
+    fs::write(&script_path, script).context("write updating pre tool use hook script")?;
+    fs::write(home.join("hooks.json"), hooks.to_string()).context("write hooks.json")?;
+    Ok(())
+}
+
 fn write_pre_tool_use_hook_toml(
     home: &Path,
     script_name: &str,
@@ -444,6 +502,121 @@ elif mode == "exit_2":
     });
 
     fs::write(&script_path, script).context("write permission request hook script")?;
+    fs::write(home.join("hooks.json"), hooks.to_string()).context("write hooks.json")?;
+    Ok(())
+}
+
+fn write_updating_permission_request_hook(
+    home: &Path,
+    matcher: &str,
+    updated_input: &Value,
+) -> Result<()> {
+    let script_path = home.join("permission_request_hook.py");
+    let log_path = home.join("permission_request_hook_log.jsonl");
+    let updated_input_json =
+        serde_json::to_string(updated_input).context("serialize updated permission input")?;
+    let script = format!(
+        r#"import json
+from pathlib import Path
+import sys
+
+payload = json.load(sys.stdin)
+
+with Path(r"{log_path}").open("a", encoding="utf-8") as handle:
+    handle.write(json.dumps(payload) + "\n")
+
+print(json.dumps({{
+    "hookSpecificOutput": {{
+        "hookEventName": "PermissionRequest",
+        "decision": {{
+            "behavior": "allow",
+            "updatedInput": {updated_input_json}
+        }}
+    }}
+}}))
+"#,
+        log_path = log_path.display(),
+        updated_input_json = updated_input_json,
+    );
+    let hooks = serde_json::json!({
+        "hooks": {
+            "PermissionRequest": [{
+                "matcher": matcher,
+                "hooks": [{
+                    "type": "command",
+                    "command": format!("python3 {}", script_path.display()),
+                    "statusMessage": "rewriting permission request input",
+                }]
+            }]
+        }
+    });
+
+    fs::write(&script_path, script).context("write updating permission hook script")?;
+    fs::write(home.join("hooks.json"), hooks.to_string()).context("write hooks.json")?;
+    Ok(())
+}
+
+fn write_rewriting_then_denying_permission_request_hook(
+    home: &Path,
+    matcher: &str,
+    original_command: &str,
+    updated_input: &Value,
+) -> Result<()> {
+    let script_path = home.join("permission_request_hook.py");
+    let log_path = home.join("permission_request_hook_log.jsonl");
+    let original_command_json =
+        serde_json::to_string(original_command).context("serialize original permission input")?;
+    let updated_input_json =
+        serde_json::to_string(updated_input).context("serialize updated permission input")?;
+    let script = format!(
+        r#"import json
+from pathlib import Path
+import sys
+
+payload = json.load(sys.stdin)
+
+with Path(r"{log_path}").open("a", encoding="utf-8") as handle:
+    handle.write(json.dumps(payload) + "\n")
+
+if payload["tool_input"]["command"] == {original_command_json}:
+    print(json.dumps({{
+        "hookSpecificOutput": {{
+            "hookEventName": "PermissionRequest",
+            "decision": {{
+                "behavior": "allow",
+                "updatedInput": {updated_input_json}
+            }}
+        }}
+    }}))
+else:
+    print(json.dumps({{
+        "hookSpecificOutput": {{
+            "hookEventName": "PermissionRequest",
+            "decision": {{
+                "behavior": "deny",
+                "message": "rewritten command denied"
+            }}
+        }}
+    }}))
+"#,
+        log_path = log_path.display(),
+        original_command_json = original_command_json,
+        updated_input_json = updated_input_json,
+    );
+    let hooks = serde_json::json!({
+        "hooks": {
+            "PermissionRequest": [{
+                "matcher": matcher,
+                "hooks": [{
+                    "type": "command",
+                    "command": format!("python3 {}", script_path.display()),
+                    "statusMessage": "rewriting then denying permission request input",
+                }]
+            }]
+        }
+    });
+
+    fs::write(&script_path, script).context("write rewrite-then-deny permission hook script")?;
     fs::write(home.join("hooks.json"), hooks.to_string()).context("write hooks.json")?;
     Ok(())
 }
@@ -1506,6 +1679,194 @@ async fn permission_request_hook_allows_shell_command_without_user_approval() ->
 }
 
 #[tokio::test]
+async fn permission_request_hook_rewrites_shell_command_before_execution() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let call_id = "permissionrequest-shell-command-rewrite";
+    let original_marker = std::env::temp_dir().join("permissionrequest-shell-command-original");
+    let rewritten_marker = std::env::temp_dir().join("permissionrequest-shell-command-rewritten");
+    let original_command = format!("rm -f {}", original_marker.display());
+    let rewritten_command = format!("printf rewritten > {}", rewritten_marker.display());
+    let args = serde_json::json!({ "command": original_command });
+    let responses = mount_sse_sequence(
+        &server,
+        vec![
+            sse(vec![
+                ev_response_created("resp-1"),
+                core_test_support::responses::ev_function_call(
+                    call_id,
+                    "shell_command",
+                    &serde_json::to_string(&args)?,
+                ),
+                ev_completed("resp-1"),
+            ]),
+            sse(vec![
+                ev_response_created("resp-2"),
+                ev_assistant_message("msg-1", "permission hook rewrote it"),
+                ev_completed("resp-2"),
+            ]),
+        ],
+    )
+    .await;
+
+    let updated_input = serde_json::json!({ "command": rewritten_command.clone() });
+    let mut builder = test_codex()
+        .with_pre_build_hook(move |home| {
+            if let Err(error) =
+                write_updating_permission_request_hook(home, "^Bash$", &updated_input)
+            {
+                panic!("failed to write updating permission hook fixture: {error}");
+            }
+        })
+        .with_config(trust_discovered_hooks);
+    let test = builder.build(&server).await?;
+
+    if original_marker.exists() {
+        fs::remove_file(&original_marker).context("remove stale original permission marker")?;
+    }
+    if rewritten_marker.exists() {
+        fs::remove_file(&rewritten_marker).context("remove stale rewritten permission marker")?;
+    }
+    fs::write(&original_marker, "seed").context("create original permission marker")?;
+
+    test.submit_turn_with_approval_and_permission_profile(
+        "run the rewritten shell command after hook approval",
+        AskForApproval::OnRequest,
+        PermissionProfile::Disabled,
+    )
+    .await?;
+
+    let requests = responses.requests();
+    assert_eq!(requests.len(), 2);
+    requests[1].function_call_output(call_id);
+    assert!(
+        original_marker.exists(),
+        "original command should not execute after permission rewrite"
+    );
+    assert_eq!(
+        fs::read_to_string(&rewritten_marker).context("read rewritten permission marker")?,
+        "rewritten"
+    );
+
+    let hook_inputs = read_permission_request_hook_inputs(test.codex_home_path())?;
+    assert_eq!(hook_inputs.len(), 1);
+    assert_permission_request_hook_input(
+        &hook_inputs[0],
+        "Bash",
+        &original_command,
+        /*description*/ None,
+    );
+    assert!(hook_inputs[0].get("tool_use_id").is_none());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn permission_request_hook_rechecks_rewritten_shell_command() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let call_id = "permissionrequest-shell-command-recheck";
+    let original_marker =
+        std::env::temp_dir().join("permissionrequest-shell-command-recheck-original");
+    let rewritten_marker =
+        std::env::temp_dir().join("permissionrequest-shell-command-recheck-rewritten");
+    let original_command = format!("rm -f {}", original_marker.display());
+    let rewritten_command = format!("rm -f {}", rewritten_marker.display());
+    let args = serde_json::json!({ "command": original_command });
+    let responses = mount_sse_sequence(
+        &server,
+        vec![
+            sse(vec![
+                ev_response_created("resp-1"),
+                core_test_support::responses::ev_function_call(
+                    call_id,
+                    "shell_command",
+                    &serde_json::to_string(&args)?,
+                ),
+                ev_completed("resp-1"),
+            ]),
+            sse(vec![
+                ev_response_created("resp-2"),
+                ev_assistant_message("msg-1", "rewritten command was denied"),
+                ev_completed("resp-2"),
+            ]),
+        ],
+    )
+    .await;
+
+    let updated_input = serde_json::json!({ "command": rewritten_command.clone() });
+    let original_command_for_hook = original_command.clone();
+    let mut builder = test_codex()
+        .with_pre_build_hook(move |home| {
+            if let Err(error) = write_rewriting_then_denying_permission_request_hook(
+                home,
+                "^Bash$",
+                &original_command_for_hook,
+                &updated_input,
+            ) {
+                panic!("failed to write rewrite-then-deny permission hook fixture: {error}");
+            }
+        })
+        .with_config(trust_discovered_hooks);
+    let test = builder.build(&server).await?;
+
+    if original_marker.exists() {
+        fs::remove_file(&original_marker).context("remove stale original permission marker")?;
+    }
+    if rewritten_marker.exists() {
+        fs::remove_file(&rewritten_marker).context("remove stale rewritten permission marker")?;
+    }
+    fs::write(&original_marker, "seed").context("create original permission marker")?;
+    fs::write(&rewritten_marker, "seed").context("create rewritten permission marker")?;
+
+    test.submit_turn_with_approval_and_permission_profile(
+        "recheck the rewritten shell command before execution",
+        AskForApproval::OnRequest,
+        PermissionProfile::Disabled,
+    )
+    .await?;
+
+    let requests = responses.requests();
+    assert_eq!(requests.len(), 2);
+    let output_item = requests[1].function_call_output(call_id);
+    let output = output_item
+        .get("output")
+        .and_then(Value::as_str)
+        .expect("shell command output string");
+    assert!(
+        output.contains("rewritten command denied"),
+        "re-evaluated rewritten input should be denied"
+    );
+    assert!(
+        original_marker.exists(),
+        "original shell command should not execute after rewrite"
+    );
+    assert!(
+        rewritten_marker.exists(),
+        "rewritten shell command should not execute after re-evaluation"
+    );
+
+    let hook_inputs = read_permission_request_hook_inputs(test.codex_home_path())?;
+    assert_eq!(hook_inputs.len(), 2);
+    assert_permission_request_hook_input(
+        &hook_inputs[0],
+        "Bash",
+        &original_command,
+        /*description*/ None,
+    );
+    assert_permission_request_hook_input(
+        &hook_inputs[1],
+        "Bash",
+        &rewritten_command,
+        /*description*/ None,
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn permission_request_hook_allows_apply_patch_with_write_alias() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
@@ -1575,6 +1936,98 @@ async fn permission_request_hook_allows_apply_patch_with_write_alias() -> Result
         &patch,
         /*description*/ None,
     )?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn permission_request_hook_rewrites_apply_patch_before_execution() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let call_id = "permissionrequest-apply-patch-rewrite";
+    let original_file = "permission_request_apply_patch_original.txt";
+    let rewritten_file = "permission_request_apply_patch_rewritten.txt";
+    let original_path = format!("../{original_file}");
+    let rewritten_path = format!("../{rewritten_file}");
+    let original_patch = format!(
+        r#"*** Begin Patch
+*** Add File: {original_path}
++original
+*** End Patch"#
+    );
+    let rewritten_patch = format!(
+        r#"*** Begin Patch
+*** Add File: {rewritten_path}
++rewritten
+*** End Patch"#
+    );
+    let responses = mount_sse_sequence(
+        &server,
+        vec![
+            sse(vec![
+                ev_response_created("resp-1"),
+                ev_apply_patch_function_call(call_id, &original_patch),
+                ev_completed("resp-1"),
+            ]),
+            sse(vec![
+                ev_response_created("resp-2"),
+                ev_assistant_message("msg-1", "permission hook rewrote apply_patch"),
+                ev_completed("resp-2"),
+            ]),
+        ],
+    )
+    .await;
+
+    let updated_input = serde_json::json!({ "command": rewritten_patch.clone() });
+    let mut builder = test_codex()
+        .with_pre_build_hook(move |home| {
+            if let Err(error) =
+                write_updating_permission_request_hook(home, "^apply_patch$", &updated_input)
+            {
+                panic!("failed to write updating permission hook fixture: {error}");
+            }
+        })
+        .with_config(|config| {
+            config.include_apply_patch_tool = true;
+            trust_discovered_hooks(config);
+        });
+    let test = builder.build(&server).await?;
+
+    test.submit_turn_with_approval_and_permission_profile(
+        "apply the rewritten patch after hook approval",
+        AskForApproval::OnRequest,
+        restrictive_workspace_write_profile(),
+    )
+    .await?;
+
+    let requests = responses.requests();
+    assert_eq!(requests.len(), 2);
+    requests[1].function_call_output(call_id);
+    assert!(
+        !test.workspace_path(&original_path).exists(),
+        "original patch should not create its target file"
+    );
+    assert_eq!(
+        fs::read_to_string(test.workspace_path(&rewritten_path))
+            .context("read rewritten permission apply_patch file")?,
+        "rewritten\n"
+    );
+
+    let hook_inputs = read_permission_request_hook_inputs(test.codex_home_path())?;
+    assert_eq!(hook_inputs.len(), 2);
+    assert_permission_request_hook_input(
+        &hook_inputs[0],
+        "apply_patch",
+        &original_patch,
+        /*description*/ None,
+    );
+    assert_permission_request_hook_input(
+        &hook_inputs[1],
+        "apply_patch",
+        &rewritten_patch,
+        /*description*/ None,
+    );
 
     Ok(())
 }
@@ -2081,6 +2534,79 @@ async fn blocked_pre_tool_use_records_additional_context_for_shell_command() -> 
         !marker.exists(),
         "blocked command should not create marker file"
     );
+    Ok(())
+}
+
+#[tokio::test]
+async fn pre_tool_use_rewrites_shell_command_before_execution() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let call_id = "pretooluse-shell-command-rewrite";
+    let original_marker = std::env::temp_dir().join("pretooluse-shell-command-original-marker");
+    let rewritten_marker = std::env::temp_dir().join("pretooluse-shell-command-rewritten-marker");
+    let original_command = format!("printf original > {}", original_marker.display());
+    let rewritten_command = format!("printf rewritten > {}", rewritten_marker.display());
+    let args = serde_json::json!({ "command": original_command });
+    let responses = mount_sse_sequence(
+        &server,
+        vec![
+            sse(vec![
+                ev_response_created("resp-1"),
+                core_test_support::responses::ev_function_call(
+                    call_id,
+                    "shell_command",
+                    &serde_json::to_string(&args)?,
+                ),
+                ev_completed("resp-1"),
+            ]),
+            sse(vec![
+                ev_response_created("resp-2"),
+                ev_assistant_message("msg-1", "hook rewrote it"),
+                ev_completed("resp-2"),
+            ]),
+        ],
+    )
+    .await;
+
+    let updated_input = serde_json::json!({ "command": rewritten_command });
+    let mut builder = test_codex()
+        .with_pre_build_hook(move |home| {
+            if let Err(error) = write_updating_pre_tool_use_hook(home, "^Bash$", &updated_input) {
+                panic!("failed to write updating pre tool use hook fixture: {error}");
+            }
+        })
+        .with_config(trust_discovered_hooks);
+    let test = builder.build(&server).await?;
+
+    if original_marker.exists() {
+        fs::remove_file(&original_marker).context("remove stale original pre tool marker")?;
+    }
+    if rewritten_marker.exists() {
+        fs::remove_file(&rewritten_marker).context("remove stale rewritten pre tool marker")?;
+    }
+
+    test.submit_turn_with_permission_profile(
+        "run the rewritten shell command",
+        PermissionProfile::Disabled,
+    )
+    .await?;
+
+    let requests = responses.requests();
+    assert_eq!(requests.len(), 2);
+    requests[1].function_call_output(call_id);
+    assert!(
+        !original_marker.exists(),
+        "original shell command should not execute after rewrite"
+    );
+    assert_eq!(
+        fs::read_to_string(&rewritten_marker).context("read rewritten pre tool marker")?,
+        "rewritten"
+    );
+
+    let hook_inputs = read_pre_tool_use_hook_inputs(test.codex_home_path())?;
+    assert_eq!(hook_inputs.len(), 1);
+    assert_eq!(hook_inputs[0]["tool_input"]["command"], original_command);
 
     Ok(())
 }
@@ -2671,6 +3197,80 @@ async fn pre_tool_use_blocks_apply_patch_before_execution() -> Result<()> {
     assert_eq!(hook_inputs[0]["tool_name"], "apply_patch");
     assert_eq!(hook_inputs[0]["tool_use_id"], call_id);
     assert_eq!(hook_inputs[0]["tool_input"]["command"], patch);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn pre_tool_use_rewrites_apply_patch_before_execution() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let call_id = "pretooluse-apply-patch-rewrite";
+    let original_file = "pre_tool_use_apply_patch_original.txt";
+    let rewritten_file = "pre_tool_use_apply_patch_rewritten.txt";
+    let original_patch = format!(
+        r#"*** Begin Patch
+*** Add File: {original_file}
++original
+*** End Patch"#
+    );
+    let rewritten_patch = format!(
+        r#"*** Begin Patch
+*** Add File: {rewritten_file}
++rewritten
+*** End Patch"#
+    );
+    let responses = mount_sse_sequence(
+        &server,
+        vec![
+            sse(vec![
+                ev_response_created("resp-1"),
+                ev_apply_patch_function_call(call_id, &original_patch),
+                ev_completed("resp-1"),
+            ]),
+            sse(vec![
+                ev_response_created("resp-2"),
+                ev_assistant_message("msg-1", "apply_patch rewritten"),
+                ev_completed("resp-2"),
+            ]),
+        ],
+    )
+    .await;
+
+    let updated_input = serde_json::json!({ "command": rewritten_patch });
+    let mut builder = test_codex()
+        .with_pre_build_hook(move |home| {
+            if let Err(error) =
+                write_updating_pre_tool_use_hook(home, "^apply_patch$", &updated_input)
+            {
+                panic!("failed to write updating pre tool use hook fixture: {error}");
+            }
+        })
+        .with_config(|config| {
+            config.include_apply_patch_tool = true;
+            trust_discovered_hooks(config);
+        });
+    let test = builder.build(&server).await?;
+
+    test.submit_turn("apply the rewritten patch").await?;
+
+    let requests = responses.requests();
+    assert_eq!(requests.len(), 2);
+    requests[1].function_call_output(call_id);
+    assert!(
+        !test.workspace_path(original_file).exists(),
+        "original patch should not create its target file"
+    );
+    assert_eq!(
+        fs::read_to_string(test.workspace_path(rewritten_file))
+            .context("read rewritten apply_patch file")?,
+        "rewritten\n"
+    );
+
+    let hook_inputs = read_pre_tool_use_hook_inputs(test.codex_home_path())?;
+    assert_eq!(hook_inputs.len(), 1);
+    assert_eq!(hook_inputs[0]["tool_input"]["command"], original_patch);
 
     Ok(())
 }

--- a/codex-rs/core/tests/suite/hooks_mcp.rs
+++ b/codex-rs/core/tests/suite/hooks_mcp.rs
@@ -74,6 +74,50 @@ print(json.dumps({{
     Ok(())
 }
 
+fn write_updating_pre_tool_use_hook(home: &Path, updated_message: &str) -> Result<()> {
+    let script_path = home.join("pre_tool_use_hook.py");
+    let log_path = home.join("pre_tool_use_hook_log.jsonl");
+    let updated_message_json =
+        serde_json::to_string(updated_message).context("serialize updated MCP message")?;
+    let script = format!(
+        r#"import json
+from pathlib import Path
+import sys
+
+payload = json.load(sys.stdin)
+
+with Path(r"{log_path}").open("a", encoding="utf-8") as handle:
+    handle.write(json.dumps(payload) + "\n")
+
+print(json.dumps({{
+    "hookSpecificOutput": {{
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "allow",
+        "updatedInput": {{ "message": {updated_message_json} }}
+    }}
+}}))
+"#,
+        log_path = log_path.display(),
+        updated_message_json = updated_message_json,
+    );
+    let hooks = serde_json::json!({
+        "hooks": {
+            "PreToolUse": [{
+                "matcher": RMCP_HOOK_MATCHER,
+                "hooks": [{
+                    "type": "command",
+                    "command": format!("python3 {}", script_path.display()),
+                    "statusMessage": "rewriting MCP pre tool input",
+                }]
+            }]
+        }
+    });
+
+    fs::write(&script_path, script).context("write updating pre tool use hook script")?;
+    fs::write(home.join("hooks.json"), hooks.to_string()).context("write hooks.json")?;
+    Ok(())
+}
+
 fn write_post_tool_use_hook(home: &Path, additional_context: &str) -> Result<()> {
     let script_path = home.join("post_tool_use_hook.py");
     let log_path = home.join("post_tool_use_hook_log.jsonl");
@@ -245,6 +289,76 @@ async fn pre_tool_use_blocks_mcp_tool_before_execution() -> Result<()> {
         Path::new(transcript_path).exists(),
         "pre tool use hook transcript_path should be materialized on disk",
     );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pre_tool_use_rewrites_mcp_tool_before_execution() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let call_id = "pretooluse-rmcp-echo-rewrite";
+    let rewritten_message = "rewritten mcp hook input";
+    let arguments = json!({ "message": RMCP_ECHO_MESSAGE }).to_string();
+    let call_mock = mount_sse_once(
+        &server,
+        sse(vec![
+            ev_response_created("resp-1"),
+            ev_function_call_with_namespace(call_id, RMCP_NAMESPACE, "echo", &arguments),
+            ev_completed("resp-1"),
+        ]),
+    )
+    .await;
+    let final_mock = mount_sse_once(
+        &server,
+        sse(vec![
+            ev_response_created("resp-2"),
+            ev_assistant_message("msg-1", "mcp pre hook rewrote it"),
+            ev_completed("resp-2"),
+        ]),
+    )
+    .await;
+
+    let rmcp_test_server_bin = stdio_server_bin()?;
+    let test = test_codex()
+        .with_pre_build_hook(move |home| {
+            if let Err(error) = write_updating_pre_tool_use_hook(home, rewritten_message) {
+                panic!("failed to write MCP updating pre tool use hook fixture: {error}");
+            }
+        })
+        .with_config(move |config| {
+            enable_hooks_and_rmcp_server(config, rmcp_test_server_bin, AppToolApproval::Approve);
+        })
+        .build(&server)
+        .await?;
+
+    test.submit_turn("call the rmcp echo tool with the MCP pre hook rewrite")
+        .await?;
+
+    let final_request = final_mock.single_request();
+    let output_item = final_request.function_call_output(call_id);
+    let output = output_item
+        .get("output")
+        .and_then(Value::as_str)
+        .expect("MCP tool output string");
+    assert!(
+        output.contains(&format!("ECHOING: {rewritten_message}")),
+        "MCP tool should execute the rewritten input",
+    );
+    assert!(
+        !output.contains(RMCP_ECHO_MESSAGE),
+        "MCP tool should not execute the original input",
+    );
+
+    let hook_inputs = read_hook_inputs(test.codex_home_path(), "pre_tool_use_hook_log.jsonl")?;
+    assert_eq!(hook_inputs.len(), 1);
+    assert_eq!(
+        hook_inputs[0]["tool_input"],
+        json!({ "message": RMCP_ECHO_MESSAGE }),
+    );
+
+    call_mock.single_request();
 
     Ok(())
 }

--- a/codex-rs/hooks/schema/generated/permission-request.command.output.schema.json
+++ b/codex-rs/hooks/schema/generated/permission-request.command.output.schema.json
@@ -37,7 +37,7 @@
         },
         "updatedInput": {
           "default": null,
-          "description": "Reserved for a future input-rewrite capability.\n\nPermissionRequest hooks currently fail closed if this field is present."
+          "description": "Replaces the entire tool input object when `behavior` is `allow`."
         },
         "updatedPermissions": {
           "default": null,

--- a/codex-rs/hooks/schema/generated/pre-tool-use.command.output.schema.json
+++ b/codex-rs/hooks/schema/generated/pre-tool-use.command.output.schema.json
@@ -43,7 +43,8 @@
           "type": "string"
         },
         "updatedInput": {
-          "default": null
+          "default": null,
+          "description": "Replaces the entire tool input object when paired with `allow` or `ask`."
         }
       },
       "required": [

--- a/codex-rs/hooks/src/engine/output_parser.rs
+++ b/codex-rs/hooks/src/engine/output_parser.rs
@@ -17,13 +17,19 @@ pub(crate) struct PreToolUseOutput {
     pub universal: UniversalOutput,
     pub block_reason: Option<String>,
     pub additional_context: Option<String>,
+    pub updated_input: Option<serde_json::Value>,
+    pub permission_decision: Option<crate::events::pre_tool_use::PreToolUsePermissionDecision>,
     pub invalid_reason: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum PermissionRequestDecision {
-    Allow,
-    Deny { message: String },
+    Allow {
+        updated_input: Option<serde_json::Value>,
+    },
+    Deny {
+        message: String,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -125,11 +131,45 @@ pub(crate) fn parse_pre_tool_use(stdout: &str) -> Option<PreToolUseOutput> {
     } else {
         None
     };
+    let updated_input = if invalid_reason.is_none() {
+        hook_specific_output.and_then(|output| {
+            matches!(
+                output.permission_decision,
+                Some(
+                    PreToolUsePermissionDecisionWire::Allow | PreToolUsePermissionDecisionWire::Ask
+                )
+            )
+            .then(|| output.updated_input.clone())
+            .flatten()
+        })
+    } else {
+        None
+    };
+    let permission_decision = if invalid_reason.is_none() && updated_input.is_some() {
+        hook_specific_output.and_then(|output| match output.permission_decision {
+            Some(PreToolUsePermissionDecisionWire::Allow) => {
+                Some(crate::events::pre_tool_use::PreToolUsePermissionDecision::Allow)
+            }
+            Some(PreToolUsePermissionDecisionWire::Ask) => Some(
+                crate::events::pre_tool_use::PreToolUsePermissionDecision::Ask {
+                    reason: output
+                        .permission_decision_reason
+                        .as_deref()
+                        .and_then(trimmed_reason),
+                },
+            ),
+            Some(PreToolUsePermissionDecisionWire::Deny) | None => None,
+        })
+    } else {
+        None
+    };
 
     Some(PreToolUseOutput {
         universal,
         block_reason,
         additional_context,
+        updated_input,
+        permission_decision,
         invalid_reason,
     })
 }
@@ -301,7 +341,9 @@ fn unsupported_permission_request_hook_specific_output(
     decision: Option<&PermissionRequestDecisionWire>,
 ) -> Option<String> {
     let decision = decision?;
-    if decision.updated_input.is_some() {
+    if decision.updated_input.is_some()
+        && !matches!(decision.behavior, PermissionRequestBehaviorWire::Allow)
+    {
         Some("PermissionRequest hook returned unsupported updatedInput".to_string())
     } else if decision.updated_permissions.is_some() {
         Some("PermissionRequest hook returned unsupported updatedPermissions".to_string())
@@ -316,7 +358,9 @@ fn permission_request_decision(
     decision: &PermissionRequestDecisionWire,
 ) -> PermissionRequestDecision {
     match decision.behavior {
-        PermissionRequestBehaviorWire::Allow => PermissionRequestDecision::Allow,
+        PermissionRequestBehaviorWire::Allow => PermissionRequestDecision::Allow {
+            updated_input: decision.updated_input.clone(),
+        },
         PermissionRequestBehaviorWire::Deny => PermissionRequestDecision::Deny {
             message: decision
                 .message
@@ -340,34 +384,39 @@ fn unsupported_post_tool_use_hook_specific_output(
 fn unsupported_pre_tool_use_hook_specific_output(
     output: &crate::schema::PreToolUseHookSpecificOutputWire,
 ) -> Option<String> {
-    if output.updated_input.is_some() {
-        Some("PreToolUse hook returned unsupported updatedInput".to_string())
-    } else {
-        match output.permission_decision {
-            Some(PreToolUsePermissionDecisionWire::Allow) => {
-                Some("PreToolUse hook returned unsupported permissionDecision:allow".to_string())
+    match output.permission_decision {
+        Some(PreToolUsePermissionDecisionWire::Allow)
+        | Some(PreToolUsePermissionDecisionWire::Ask)
+            if output.updated_input.is_some() =>
+        {
+            None
+        }
+        Some(PreToolUsePermissionDecisionWire::Allow) => {
+            Some("PreToolUse hook returned unsupported permissionDecision:allow".to_string())
+        }
+        Some(PreToolUsePermissionDecisionWire::Ask) => {
+            Some("PreToolUse hook returned unsupported permissionDecision:ask".to_string())
+        }
+        Some(PreToolUsePermissionDecisionWire::Deny) => {
+            if output
+                .permission_decision_reason
+                .as_deref()
+                .and_then(trimmed_reason)
+                .is_none()
+            {
+                Some(invalid_pre_tool_use_reason_message())
+            } else {
+                None
             }
-            Some(PreToolUsePermissionDecisionWire::Ask) => {
-                Some("PreToolUse hook returned unsupported permissionDecision:ask".to_string())
-            }
-            Some(PreToolUsePermissionDecisionWire::Deny) => {
-                if output
-                    .permission_decision_reason
-                    .as_deref()
-                    .and_then(trimmed_reason)
-                    .is_none()
-                {
-                    Some(invalid_pre_tool_use_reason_message())
-                } else {
-                    None
-                }
-            }
-            None => {
-                if output.permission_decision_reason.is_some() {
-                    Some("PreToolUse hook returned permissionDecisionReason without permissionDecision".to_string())
-                } else {
-                    None
-                }
+        }
+        None => {
+            if output.permission_decision_reason.is_some() {
+                Some(
+                    "PreToolUse hook returned permissionDecisionReason without permissionDecision"
+                        .to_string(),
+                )
+            } else {
+                None
             }
         }
     }
@@ -418,9 +467,10 @@ mod tests {
     use serde_json::json;
 
     use super::parse_permission_request;
+    use super::parse_pre_tool_use;
 
     #[test]
-    fn permission_request_rejects_reserved_updated_input_field() {
+    fn permission_request_accepts_allow_updated_input_field() {
         let parsed = parse_permission_request(
             &json!({
                 "continue": true,
@@ -428,6 +478,31 @@ mod tests {
                     "hookEventName": "PermissionRequest",
                     "decision": {
                         "behavior": "allow",
+                        "updatedInput": {}
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .expect("permission request hook output should parse");
+
+        assert_eq!(
+            parsed.decision,
+            Some(super::PermissionRequestDecision::Allow {
+                updated_input: Some(json!({})),
+            })
+        );
+    }
+
+    #[test]
+    fn permission_request_rejects_deny_updated_input_field() {
+        let parsed = parse_permission_request(
+            &json!({
+                "continue": true,
+                "hookSpecificOutput": {
+                    "hookEventName": "PermissionRequest",
+                    "decision": {
+                        "behavior": "deny",
                         "updatedInput": {}
                     }
                 }
@@ -486,5 +561,54 @@ mod tests {
             parsed.invalid_reason,
             Some("PermissionRequest hook returned unsupported interrupt:true".to_string())
         );
+    }
+
+    #[test]
+    fn pre_tool_use_accepts_ask_updated_input_field() {
+        let parsed = parse_pre_tool_use(
+            &json!({
+                "continue": true,
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "ask",
+                    "permissionDecisionReason": "show rewritten command",
+                    "updatedInput": { "command": "echo rewritten" }
+                }
+            })
+            .to_string(),
+        )
+        .expect("pre tool use hook output should parse");
+
+        assert_eq!(
+            parsed.updated_input,
+            Some(json!({ "command": "echo rewritten" }))
+        );
+        assert_eq!(
+            parsed.permission_decision,
+            Some(
+                crate::events::pre_tool_use::PreToolUsePermissionDecision::Ask {
+                    reason: Some("show rewritten command".to_string()),
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn pre_tool_use_ignores_deferred_updated_input_field() {
+        let parsed = parse_pre_tool_use(
+            &json!({
+                "continue": true,
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "updatedInput": { "command": "echo ignored" }
+                }
+            })
+            .to_string(),
+        )
+        .expect("pre tool use hook output should parse");
+
+        assert_eq!(parsed.invalid_reason, None);
+        assert_eq!(parsed.updated_input, None);
+        assert_eq!(parsed.permission_decision, None);
     }
 }

--- a/codex-rs/hooks/src/events/permission_request.rs
+++ b/codex-rs/hooks/src/events/permission_request.rs
@@ -1,9 +1,9 @@
 //! Permission-request hook execution.
 //!
 //! This event runs in the approval path, before guardian or user approval UI is
-//! shown. Unlike `pre_tool_use`, handlers do not rewrite tool input or block by
-//! stopping execution outright; instead they can return a concrete allow/deny
-//! decision, or decline to decide and let the normal approval flow continue.
+//! shown. Handlers can return a concrete allow/deny decision, or decline to
+//! decide and let the normal approval flow continue. `allow` decisions may also
+//! replace tool input before the request is evaluated again.
 //!
 //! The event also mirrors the rest of the hook system's lifecycle:
 //!
@@ -47,7 +47,7 @@ pub struct PermissionRequestRequest {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PermissionRequestDecision {
-    Allow,
+    Allow { updated_input: Option<Value> },
     Deny { message: String },
 }
 
@@ -154,8 +154,10 @@ fn resolve_permission_request_decision<'a>(
     let mut resolved_allow = None;
     for decision in decisions {
         match decision {
-            PermissionRequestDecision::Allow => {
-                resolved_allow = Some(PermissionRequestDecision::Allow);
+            PermissionRequestDecision::Allow { updated_input } => {
+                resolved_allow = Some(PermissionRequestDecision::Allow {
+                    updated_input: updated_input.clone(),
+                });
             }
             PermissionRequestDecision::Deny { message } => {
                 return Some(PermissionRequestDecision::Deny {
@@ -219,8 +221,8 @@ fn parse_completed(
                         });
                     } else if let Some(parsed_decision) = parsed.decision {
                         match parsed_decision {
-                            output_parser::PermissionRequestDecision::Allow => {
-                                decision = Some(PermissionRequestDecision::Allow);
+                            output_parser::PermissionRequestDecision::Allow { updated_input } => {
+                                decision = Some(PermissionRequestDecision::Allow { updated_input });
                             }
                             output_parser::PermissionRequestDecision::Deny { message } => {
                                 status = HookRunStatus::Blocked;
@@ -294,7 +296,9 @@ mod tests {
     #[test]
     fn permission_request_deny_overrides_earlier_allow() {
         let decisions = [
-            PermissionRequestDecision::Allow,
+            PermissionRequestDecision::Allow {
+                updated_input: None,
+            },
             PermissionRequestDecision::Deny {
                 message: "repo deny".to_string(),
             },
@@ -311,13 +315,38 @@ mod tests {
     #[test]
     fn permission_request_returns_allow_when_no_handler_denies() {
         let decisions = [
-            PermissionRequestDecision::Allow,
-            PermissionRequestDecision::Allow,
+            PermissionRequestDecision::Allow {
+                updated_input: None,
+            },
+            PermissionRequestDecision::Allow {
+                updated_input: None,
+            },
         ];
 
         assert_eq!(
             resolve_permission_request_decision(decisions.iter()),
-            Some(PermissionRequestDecision::Allow)
+            Some(PermissionRequestDecision::Allow {
+                updated_input: None,
+            })
+        );
+    }
+
+    #[test]
+    fn permission_request_keeps_highest_precedence_allow_update() {
+        let decisions = [
+            PermissionRequestDecision::Allow {
+                updated_input: Some(serde_json::json!({ "command": "first" })),
+            },
+            PermissionRequestDecision::Allow {
+                updated_input: Some(serde_json::json!({ "command": "second" })),
+            },
+        ];
+
+        assert_eq!(
+            resolve_permission_request_decision(decisions.iter()),
+            Some(PermissionRequestDecision::Allow {
+                updated_input: Some(serde_json::json!({ "command": "second" })),
+            })
         );
     }
 

--- a/codex-rs/hooks/src/events/pre_tool_use.rs
+++ b/codex-rs/hooks/src/events/pre_tool_use.rs
@@ -18,6 +18,12 @@ use crate::engine::dispatcher;
 use crate::engine::output_parser;
 use crate::schema::PreToolUseCommandInput;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PreToolUsePermissionDecision {
+    Allow,
+    Ask { reason: Option<String> },
+}
+
 #[derive(Debug, Clone)]
 pub struct PreToolUseRequest {
     pub session_id: ThreadId,
@@ -38,6 +44,8 @@ pub struct PreToolUseOutcome {
     pub should_block: bool,
     pub block_reason: Option<String>,
     pub additional_contexts: Vec<String>,
+    pub updated_input: Option<Value>,
+    pub permission_decision: Option<PreToolUsePermissionDecision>,
 }
 
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -45,6 +53,8 @@ struct PreToolUseHandlerData {
     should_block: bool,
     block_reason: Option<String>,
     additional_contexts_for_model: Vec<String>,
+    updated_input: Option<Value>,
+    permission_decision: Option<PreToolUsePermissionDecision>,
 }
 
 pub(crate) fn preview(
@@ -81,6 +91,8 @@ pub(crate) async fn run(
             should_block: false,
             block_reason: None,
             additional_contexts: Vec::new(),
+            updated_input: None,
+            permission_decision: None,
         };
     }
 
@@ -116,6 +128,19 @@ pub(crate) async fn run(
             .iter()
             .map(|result| result.data.additional_contexts_for_model.as_slice()),
     );
+    let (updated_input, permission_decision) = if should_block {
+        (None, None)
+    } else {
+        results
+            .iter()
+            .rev()
+            .find_map(|result| {
+                result.data.updated_input.clone().map(|updated_input| {
+                    (Some(updated_input), result.data.permission_decision.clone())
+                })
+            })
+            .unwrap_or((None, None))
+    };
 
     PreToolUseOutcome {
         hook_events: results
@@ -127,6 +152,8 @@ pub(crate) async fn run(
         should_block,
         block_reason,
         additional_contexts,
+        updated_input,
+        permission_decision,
     }
 }
 
@@ -161,6 +188,8 @@ fn parse_completed(
     let mut should_block = false;
     let mut block_reason = None;
     let mut additional_contexts_for_model = Vec::new();
+    let mut updated_input = None;
+    let mut permission_decision = None;
 
     match run_result.error.as_deref() {
         Some(error) => {
@@ -203,6 +232,10 @@ fn parse_completed(
                                 kind: HookOutputEntryKind::Feedback,
                                 text: reason,
                             });
+                        }
+                        if !should_block {
+                            updated_input = parsed.updated_input;
+                            permission_decision = parsed.permission_decision;
                         }
                     }
                 } else if trimmed_stdout.starts_with('{') || trimmed_stdout.starts_with('[') {
@@ -258,6 +291,8 @@ fn parse_completed(
             should_block,
             block_reason,
             additional_contexts_for_model,
+            updated_input,
+            permission_decision,
         },
     }
 }
@@ -268,6 +303,8 @@ fn serialization_failure_outcome(hook_events: Vec<HookCompletedEvent>) -> PreToo
         should_block: false,
         block_reason: None,
         additional_contexts: Vec::new(),
+        updated_input: None,
+        permission_decision: None,
     }
 }
 
@@ -283,6 +320,7 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use super::PreToolUseHandlerData;
+    use super::PreToolUsePermissionDecision;
     use super::command_input_json;
     use super::parse_completed;
     use super::preview;
@@ -320,6 +358,8 @@ mod tests {
                 should_block: true,
                 block_reason: Some("do not run that".to_string()),
                 additional_contexts_for_model: Vec::new(),
+                updated_input: None,
+                permission_decision: None,
             }
         );
         assert_eq!(parsed.completed.run.status, HookRunStatus::Blocked);
@@ -330,6 +370,60 @@ mod tests {
                 text: "do not run that".to_string(),
             }]
         );
+    }
+
+    #[test]
+    fn permission_decision_allow_can_update_input() {
+        let parsed = parse_completed(
+            &handler(),
+            run_result(
+                Some(0),
+                r#"{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","updatedInput":{"command":"echo rewritten"}}}"#,
+                "",
+            ),
+            Some("turn-1".to_string()),
+        );
+
+        assert_eq!(
+            parsed.data,
+            PreToolUseHandlerData {
+                should_block: false,
+                block_reason: None,
+                additional_contexts_for_model: Vec::new(),
+                updated_input: Some(serde_json::json!({ "command": "echo rewritten" })),
+                permission_decision: Some(PreToolUsePermissionDecision::Allow),
+            }
+        );
+        assert_eq!(parsed.completed.run.status, HookRunStatus::Completed);
+        assert_eq!(parsed.completed.run.entries, vec![]);
+    }
+
+    #[test]
+    fn permission_decision_ask_can_update_input() {
+        let parsed = parse_completed(
+            &handler(),
+            run_result(
+                Some(0),
+                r#"{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask","permissionDecisionReason":"please confirm","updatedInput":{"command":"echo rewritten"}}}"#,
+                "",
+            ),
+            Some("turn-1".to_string()),
+        );
+
+        assert_eq!(
+            parsed.data,
+            PreToolUseHandlerData {
+                should_block: false,
+                block_reason: None,
+                additional_contexts_for_model: Vec::new(),
+                updated_input: Some(serde_json::json!({ "command": "echo rewritten" })),
+                permission_decision: Some(PreToolUsePermissionDecision::Ask {
+                    reason: Some("please confirm".to_string()),
+                }),
+            }
+        );
+        assert_eq!(parsed.completed.run.status, HookRunStatus::Completed);
+        assert_eq!(parsed.completed.run.entries, vec![]);
     }
 
     #[test]
@@ -350,6 +444,8 @@ mod tests {
                 should_block: true,
                 block_reason: Some("do not run that".to_string()),
                 additional_contexts_for_model: Vec::new(),
+                updated_input: None,
+                permission_decision: None,
             }
         );
         assert_eq!(parsed.completed.run.status, HookRunStatus::Blocked);
@@ -380,6 +476,8 @@ mod tests {
                 should_block: true,
                 block_reason: Some("do not run that".to_string()),
                 additional_contexts_for_model: vec!["remember this".to_string()],
+                updated_input: None,
+                permission_decision: None,
             }
         );
         assert_eq!(parsed.completed.run.status, HookRunStatus::Blocked);
@@ -416,6 +514,8 @@ mod tests {
                 should_block: false,
                 block_reason: None,
                 additional_contexts_for_model: Vec::new(),
+                updated_input: None,
+                permission_decision: None,
             }
         );
         assert_eq!(parsed.completed.run.status, HookRunStatus::Failed);
@@ -442,6 +542,8 @@ mod tests {
                 should_block: false,
                 block_reason: None,
                 additional_contexts_for_model: Vec::new(),
+                updated_input: None,
+                permission_decision: None,
             }
         );
         assert_eq!(parsed.completed.run.status, HookRunStatus::Failed);
@@ -472,6 +574,8 @@ mod tests {
                 should_block: true,
                 block_reason: Some("do not run that".to_string()),
                 additional_contexts_for_model: vec!["nope".to_string()],
+                updated_input: None,
+                permission_decision: None,
             }
         );
         assert_eq!(parsed.completed.run.status, HookRunStatus::Blocked);
@@ -504,6 +608,8 @@ mod tests {
                 should_block: false,
                 block_reason: None,
                 additional_contexts_for_model: Vec::new(),
+                updated_input: None,
+                permission_decision: None,
             }
         );
         assert_eq!(parsed.completed.run.status, HookRunStatus::Completed);
@@ -524,6 +630,8 @@ mod tests {
                 should_block: false,
                 block_reason: None,
                 additional_contexts_for_model: Vec::new(),
+                updated_input: None,
+                permission_decision: None,
             }
         );
         assert_eq!(parsed.completed.run.status, HookRunStatus::Failed);
@@ -550,6 +658,8 @@ mod tests {
                 should_block: true,
                 block_reason: Some("blocked by policy".to_string()),
                 additional_contexts_for_model: Vec::new(),
+                updated_input: None,
+                permission_decision: None,
             }
         );
         assert_eq!(parsed.completed.run.status, HookRunStatus::Blocked);

--- a/codex-rs/hooks/src/lib.rs
+++ b/codex-rs/hooks/src/lib.rs
@@ -35,6 +35,7 @@ pub use events::permission_request::PermissionRequestRequest;
 pub use events::post_tool_use::PostToolUseOutcome;
 pub use events::post_tool_use::PostToolUseRequest;
 pub use events::pre_tool_use::PreToolUseOutcome;
+pub use events::pre_tool_use::PreToolUsePermissionDecision;
 pub use events::pre_tool_use::PreToolUseRequest;
 pub use events::session_start::SessionStartOutcome;
 pub use events::session_start::SessionStartRequest;

--- a/codex-rs/hooks/src/schema.rs
+++ b/codex-rs/hooks/src/schema.rs
@@ -138,9 +138,7 @@ pub(crate) struct PermissionRequestHookSpecificOutputWire {
 #[serde(deny_unknown_fields)]
 pub(crate) struct PermissionRequestDecisionWire {
     pub behavior: PermissionRequestBehaviorWire,
-    /// Reserved for a future input-rewrite capability.
-    ///
-    /// PermissionRequest hooks currently fail closed if this field is present.
+    /// Replaces the entire tool input object when `behavior` is `allow`.
     #[serde(default)]
     pub updated_input: Option<Value>,
     /// Reserved for a future permission-rewrite capability.
@@ -186,6 +184,7 @@ pub(crate) struct PreToolUseHookSpecificOutputWire {
     pub permission_decision: Option<PreToolUsePermissionDecisionWire>,
     #[serde(default)]
     pub permission_decision_reason: Option<String>,
+    /// Replaces the entire tool input object when paired with `allow` or `ask`.
     #[serde(default)]
     pub updated_input: Option<Value>,
     #[serde(default)]


### PR DESCRIPTION
# Why

Hooks can currently inspect tool input, but callers cannot safely substitute a rewritten payload while preserving the approval semantics around that new payload. That leaves sanitizing or normalizing hook workflows unable to change what actually runs.

# What

- Add `updatedInput` support for `PreToolUse` and `PermissionRequest` hook outputs.
- Let `PreToolUse` rewrites carry `allow` or `ask` semantics into shell, apply_patch, unified exec, and MCP execution paths.
- Let `PermissionRequest` rewrites replace the full input, then re-enter normal approval evaluation so rewritten input is checked again before execution.
- Regenerate hook schemas and add coverage for shell/apply_patch/MCP rewrites, ask parsing, no-op handling, and rewritten-input re-evaluation.

## Validation

- `cargo test -p codex-hooks`
- `cargo test -p codex-core --lib mcp_tool_call::tests::permission_request_hook_can_update_mcp_tool_input`
- `cargo test -p codex-core --test all suite::hooks::permission_request_hook_rewrites_shell_command_before_execution -- --exact`
- `cargo test -p codex-core --test all suite::hooks::permission_request_hook_rechecks_rewritten_shell_command -- --exact`
- `cargo test -p codex-core --test all suite::hooks::pre_tool_use_rewrites_shell_command_before_execution -- --exact`
- `just fmt`
- `just fix -p codex-core`
- `just fix -p codex-hooks`

`cargo test -p codex-core --lib` was also attempted; it aborted in the existing `tools::handlers::multi_agents::tests::multi_agent_v2_close_agent_accepts_task_name_target` test with a stack overflow unrelated to this change.
