### PR TITLE
release: bundle bwrap with Linux codex DotSlash artifact

### DIFF
--- a/.github/dotslash-config.json
+++ b/.github/dotslash-config.json
@@ -11,11 +11,11 @@
           "path": "codex"
         },
         "linux-x86_64": {
-          "regex": "^codex-x86_64-unknown-linux-musl\\.zst$",
+          "regex": "^codex-x86_64-unknown-linux-musl-bundle\\.tar\\.zst$",
           "path": "codex"
         },
         "linux-aarch64": {
-          "regex": "^codex-aarch64-unknown-linux-musl\\.zst$",
+          "regex": "^codex-aarch64-unknown-linux-musl-bundle\\.tar\\.zst$",
           "path": "codex"
         },
         "windows-x86_64": {

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -379,6 +379,17 @@ jobs:
             fi
           done
 
+          if [[ "${{ matrix.target }}" == *linux* && "${{ matrix.bundle }}" == "primary" ]]; then
+            bundle_root="${RUNNER_TEMP}/codex-${{ matrix.target }}-bundle"
+            rm -rf "$bundle_root"
+            mkdir -p "$bundle_root/codex-resources"
+            cp "$dest/codex-${{ matrix.target }}" "$bundle_root/codex"
+            cp "$dest/bwrap-${{ matrix.target }}" "$bundle_root/codex-resources/bwrap"
+            chmod 0755 "$bundle_root/codex" "$bundle_root/codex-resources/bwrap"
+            tar -C "$bundle_root" -cf - codex codex-resources/bwrap |
+              zstd -T0 -19 -o "$dest/codex-${{ matrix.target }}-bundle.tar.zst"
+          fi
+
           if [[ "${{ matrix.build_dmg }}" == "true" ]]; then
             cp target/${{ matrix.target }}/release/codex-${{ matrix.target }}.dmg "$dest/codex-${{ matrix.target }}.dmg"
           fi
@@ -402,7 +413,7 @@ jobs:
             base="$(basename "$f")"
             # Skip files that are already archives (shouldn't happen, but be
             # safe).
-            if [[ "$base" == *.tar.gz || "$base" == *.zip || "$base" == *.dmg ]]; then
+            if [[ "$base" == *.tar.gz || "$base" == *.tar.zst || "$base" == *.zip || "$base" == *.dmg ]]; then
               continue
             fi
 
@@ -422,8 +433,8 @@ jobs:
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: ${{ matrix.artifact_name }}
-          # Upload the per-binary .zst files as well as the new .tar.gz
-          # equivalents we generated in the previous step.
+          # Upload the per-binary .zst files, .tar.gz equivalents, and any
+          # prebuilt archives staged above.
           path: |
             codex-rs/dist/${{ matrix.target }}/*
 


### PR DESCRIPTION
## Why

#21255 changed the Linux sandbox fallback so Codex can use a bundled `codex-resources/bwrap` executable when no suitable system `bwrap` is available. That lookup is relative to the native Codex executable returned by
`std::env::current_exe()`, as implemented in [`bundled_bwrap.rs`](https://github.com/openai/codex/blob/9766d3d51cec885114b6d6c53a02e9efbaf87171/codex-rs/linux-sandbox/src/bundled_bwrap.rs#L83-L93).

The release already publishes a separate `bwrap` DotSlash output, but the Linux `codex` DotSlash output still pointed at a single-binary `.zst` payload. Running the `codex` DotSlash manifest only materializes the native `codex` executable; it does not also create sibling files from the separate `bwrap` manifest. The fallback path therefore needs the Linux `codex` DotSlash artifact itself to include the real `bwrap` executable at `codex-resources/bwrap`.

## What changed

- stage a Linux primary `codex-<target>-bundle.tar.zst` release artifact containing `codex` and `codex-resources/bwrap`
- point the Linux `codex` DotSlash outputs at that bundle tarball
- leave the standalone `bwrap` DotSlash output in place for consumers that want to fetch `bwrap` directly

## Verification

- `jq . .github/dotslash-config.json`
- Ruby YAML parse of `.github/workflows/rust-release.yml`
