### PR TITLE
feat(app-server): move v2 `sessionId` onto `Thread`

### DIFF
--- a/codex-rs/analytics/src/analytics_client_tests.rs
+++ b/codex-rs/analytics/src/analytics_client_tests.rs
@@ -128,6 +128,7 @@ fn sample_thread_with_metadata(
 ) -> Thread {
     Thread {
         id: thread_id.to_string(),
+        session_id: format!("session-{thread_id}"),
         forked_from_id: None,
         preview: "first prompt".to_string(),
         ephemeral,
@@ -154,7 +155,6 @@ fn sample_thread_start_response(
     model: &str,
 ) -> ClientResponsePayload {
     ClientResponsePayload::ThreadStart(ThreadStartResponse {
-        session_id: format!("session-{thread_id}"),
         thread: sample_thread_with_metadata(
             thread_id,
             ephemeral,
@@ -216,7 +216,6 @@ fn sample_thread_resume_response_with_source(
     thread_source: Option<AppServerThreadSource>,
 ) -> ClientResponsePayload {
     ClientResponsePayload::ThreadResume(ThreadResumeResponse {
-        session_id: format!("session-{thread_id}"),
         thread: sample_thread_with_metadata(thread_id, ephemeral, source, thread_source),
         model: model.to_string(),
         model_provider: "openai".to_string(),

--- a/codex-rs/analytics/src/client_tests.rs
+++ b/codex-rs/analytics/src/client_tests.rs
@@ -76,6 +76,7 @@ fn sample_thread_archive_request() -> ClientRequest {
 fn sample_thread(thread_id: &str) -> Thread {
     Thread {
         id: thread_id.to_string(),
+        session_id: format!("session-{thread_id}"),
         forked_from_id: None,
         preview: "first prompt".to_string(),
         ephemeral: false,
@@ -102,7 +103,6 @@ fn sample_permission_profile() -> AppServerPermissionProfile {
 
 fn sample_thread_start_response() -> ClientResponsePayload {
     ClientResponsePayload::ThreadStart(ThreadStartResponse {
-        session_id: "session-1".to_string(),
         thread: sample_thread("thread-1"),
         model: "gpt-5".to_string(),
         model_provider: "openai".to_string(),
@@ -120,7 +120,6 @@ fn sample_thread_start_response() -> ClientResponsePayload {
 
 fn sample_thread_resume_response() -> ClientResponsePayload {
     ClientResponsePayload::ThreadResume(ThreadResumeResponse {
-        session_id: "session-2".to_string(),
         thread: sample_thread("thread-2"),
         model: "gpt-5".to_string(),
         model_provider: "openai".to_string(),
@@ -138,7 +137,6 @@ fn sample_thread_resume_response() -> ClientResponsePayload {
 
 fn sample_thread_fork_response() -> ClientResponsePayload {
     ClientResponsePayload::ThreadFork(ThreadForkResponse {
-        session_id: "session-3".to_string(),
         thread: sample_thread("thread-3"),
         model: "gpt-5".to_string(),
         model_provider: "openai".to_string(),

--- a/codex-rs/app-server-protocol/schema/json/ServerNotification.json
+++ b/codex-rs/app-server-protocol/schema/json/ServerNotification.json
@@ -3074,10 +3074,7 @@
         },
         "sessionId": {
           "description": "Session id shared by threads that belong to the same session tree.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": "string"
         },
         "source": {
           "allOf": [
@@ -3127,6 +3124,7 @@
         "id",
         "modelProvider",
         "preview",
+        "sessionId",
         "source",
         "status",
         "turns",

--- a/codex-rs/app-server-protocol/schema/json/ServerNotification.json
+++ b/codex-rs/app-server-protocol/schema/json/ServerNotification.json
@@ -3072,6 +3072,13 @@
           "description": "Usually the first user message in the thread, if available.",
           "type": "string"
         },
+        "sessionId": {
+          "description": "Session id shared by threads that belong to the same session tree.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "source": {
           "allOf": [
             {

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
@@ -15345,6 +15345,13 @@
             "description": "Usually the first user message in the thread, if available.",
             "type": "string"
           },
+          "sessionId": {
+            "description": "Session id shared by threads that belong to the same session tree.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "source": {
             "allOf": [
               {
@@ -15663,11 +15670,6 @@
                 "type": "null"
               }
             ]
-          },
-          "sessionId": {
-            "default": "",
-            "description": "Session id shared by threads that belong to the same session tree.",
-            "type": "string"
           },
           "thread": {
             "$ref": "#/definitions/v2/Thread"
@@ -17176,11 +17178,6 @@
               }
             ]
           },
-          "sessionId": {
-            "default": "",
-            "description": "Session id shared by threads that belong to the same session tree.",
-            "type": "string"
-          },
           "thread": {
             "$ref": "#/definitions/v2/Thread"
           }
@@ -17503,11 +17500,6 @@
                 "type": "null"
               }
             ]
-          },
-          "sessionId": {
-            "default": "",
-            "description": "Session id shared by threads that belong to the same session tree.",
-            "type": "string"
           },
           "thread": {
             "$ref": "#/definitions/v2/Thread"

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
@@ -15347,10 +15347,7 @@
           },
           "sessionId": {
             "description": "Session id shared by threads that belong to the same session tree.",
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": "string"
           },
           "source": {
             "allOf": [
@@ -15400,6 +15397,7 @@
           "id",
           "modelProvider",
           "preview",
+          "sessionId",
           "source",
           "status",
           "turns",

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
@@ -13233,10 +13233,7 @@
         },
         "sessionId": {
           "description": "Session id shared by threads that belong to the same session tree.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": "string"
         },
         "source": {
           "allOf": [
@@ -13286,6 +13283,7 @@
         "id",
         "modelProvider",
         "preview",
+        "sessionId",
         "source",
         "status",
         "turns",

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
@@ -13231,6 +13231,13 @@
           "description": "Usually the first user message in the thread, if available.",
           "type": "string"
         },
+        "sessionId": {
+          "description": "Session id shared by threads that belong to the same session tree.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "source": {
           "allOf": [
             {
@@ -13549,11 +13556,6 @@
               "type": "null"
             }
           ]
-        },
-        "sessionId": {
-          "default": "",
-          "description": "Session id shared by threads that belong to the same session tree.",
-          "type": "string"
         },
         "thread": {
           "$ref": "#/definitions/Thread"
@@ -15062,11 +15064,6 @@
             }
           ]
         },
-        "sessionId": {
-          "default": "",
-          "description": "Session id shared by threads that belong to the same session tree.",
-          "type": "string"
-        },
         "thread": {
           "$ref": "#/definitions/Thread"
         }
@@ -15389,11 +15386,6 @@
               "type": "null"
             }
           ]
-        },
-        "sessionId": {
-          "default": "",
-          "description": "Session id shared by threads that belong to the same session tree.",
-          "type": "string"
         },
         "thread": {
           "$ref": "#/definitions/Thread"

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadForkResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadForkResponse.json
@@ -1403,6 +1403,13 @@
           "description": "Usually the first user message in the thread, if available.",
           "type": "string"
         },
+        "sessionId": {
+          "description": "Session id shared by threads that belong to the same session tree.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "source": {
           "allOf": [
             {
@@ -2618,11 +2625,6 @@
           "type": "null"
         }
       ]
-    },
-    "sessionId": {
-      "default": "",
-      "description": "Session id shared by threads that belong to the same session tree.",
-      "type": "string"
     },
     "thread": {
       "$ref": "#/definitions/Thread"

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadForkResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadForkResponse.json
@@ -1405,10 +1405,7 @@
         },
         "sessionId": {
           "description": "Session id shared by threads that belong to the same session tree.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": "string"
         },
         "source": {
           "allOf": [
@@ -1458,6 +1455,7 @@
         "id",
         "modelProvider",
         "preview",
+        "sessionId",
         "source",
         "status",
         "turns",

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadListResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadListResponse.json
@@ -855,10 +855,7 @@
         },
         "sessionId": {
           "description": "Session id shared by threads that belong to the same session tree.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": "string"
         },
         "source": {
           "allOf": [
@@ -908,6 +905,7 @@
         "id",
         "modelProvider",
         "preview",
+        "sessionId",
         "source",
         "status",
         "turns",

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadListResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadListResponse.json
@@ -853,6 +853,13 @@
           "description": "Usually the first user message in the thread, if available.",
           "type": "string"
         },
+        "sessionId": {
+          "description": "Session id shared by threads that belong to the same session tree.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "source": {
           "allOf": [
             {

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadMetadataUpdateResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadMetadataUpdateResponse.json
@@ -855,10 +855,7 @@
         },
         "sessionId": {
           "description": "Session id shared by threads that belong to the same session tree.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": "string"
         },
         "source": {
           "allOf": [
@@ -908,6 +905,7 @@
         "id",
         "modelProvider",
         "preview",
+        "sessionId",
         "source",
         "status",
         "turns",

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadMetadataUpdateResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadMetadataUpdateResponse.json
@@ -853,6 +853,13 @@
           "description": "Usually the first user message in the thread, if available.",
           "type": "string"
         },
+        "sessionId": {
+          "description": "Session id shared by threads that belong to the same session tree.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "source": {
           "allOf": [
             {

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadReadResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadReadResponse.json
@@ -855,10 +855,7 @@
         },
         "sessionId": {
           "description": "Session id shared by threads that belong to the same session tree.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": "string"
         },
         "source": {
           "allOf": [
@@ -908,6 +905,7 @@
         "id",
         "modelProvider",
         "preview",
+        "sessionId",
         "source",
         "status",
         "turns",

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadReadResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadReadResponse.json
@@ -853,6 +853,13 @@
           "description": "Usually the first user message in the thread, if available.",
           "type": "string"
         },
+        "sessionId": {
+          "description": "Session id shared by threads that belong to the same session tree.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "source": {
           "allOf": [
             {

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadResumeResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadResumeResponse.json
@@ -1403,6 +1403,13 @@
           "description": "Usually the first user message in the thread, if available.",
           "type": "string"
         },
+        "sessionId": {
+          "description": "Session id shared by threads that belong to the same session tree.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "source": {
           "allOf": [
             {
@@ -2618,11 +2625,6 @@
           "type": "null"
         }
       ]
-    },
-    "sessionId": {
-      "default": "",
-      "description": "Session id shared by threads that belong to the same session tree.",
-      "type": "string"
     },
     "thread": {
       "$ref": "#/definitions/Thread"

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadResumeResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadResumeResponse.json
@@ -1405,10 +1405,7 @@
         },
         "sessionId": {
           "description": "Session id shared by threads that belong to the same session tree.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": "string"
         },
         "source": {
           "allOf": [
@@ -1458,6 +1455,7 @@
         "id",
         "modelProvider",
         "preview",
+        "sessionId",
         "source",
         "status",
         "turns",

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadRollbackResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadRollbackResponse.json
@@ -855,10 +855,7 @@
         },
         "sessionId": {
           "description": "Session id shared by threads that belong to the same session tree.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": "string"
         },
         "source": {
           "allOf": [
@@ -908,6 +905,7 @@
         "id",
         "modelProvider",
         "preview",
+        "sessionId",
         "source",
         "status",
         "turns",

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadRollbackResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadRollbackResponse.json
@@ -853,6 +853,13 @@
           "description": "Usually the first user message in the thread, if available.",
           "type": "string"
         },
+        "sessionId": {
+          "description": "Session id shared by threads that belong to the same session tree.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "source": {
           "allOf": [
             {

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadStartResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadStartResponse.json
@@ -1403,6 +1403,13 @@
           "description": "Usually the first user message in the thread, if available.",
           "type": "string"
         },
+        "sessionId": {
+          "description": "Session id shared by threads that belong to the same session tree.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "source": {
           "allOf": [
             {
@@ -2618,11 +2625,6 @@
           "type": "null"
         }
       ]
-    },
-    "sessionId": {
-      "default": "",
-      "description": "Session id shared by threads that belong to the same session tree.",
-      "type": "string"
     },
     "thread": {
       "$ref": "#/definitions/Thread"

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadStartResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadStartResponse.json
@@ -1405,10 +1405,7 @@
         },
         "sessionId": {
           "description": "Session id shared by threads that belong to the same session tree.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": "string"
         },
         "source": {
           "allOf": [
@@ -1458,6 +1455,7 @@
         "id",
         "modelProvider",
         "preview",
+        "sessionId",
         "source",
         "status",
         "turns",

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadStartedNotification.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadStartedNotification.json
@@ -855,10 +855,7 @@
         },
         "sessionId": {
           "description": "Session id shared by threads that belong to the same session tree.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": "string"
         },
         "source": {
           "allOf": [
@@ -908,6 +905,7 @@
         "id",
         "modelProvider",
         "preview",
+        "sessionId",
         "source",
         "status",
         "turns",

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadStartedNotification.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadStartedNotification.json
@@ -853,6 +853,13 @@
           "description": "Usually the first user message in the thread, if available.",
           "type": "string"
         },
+        "sessionId": {
+          "description": "Session id shared by threads that belong to the same session tree.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "source": {
           "allOf": [
             {

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadUnarchiveResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadUnarchiveResponse.json
@@ -855,10 +855,7 @@
         },
         "sessionId": {
           "description": "Session id shared by threads that belong to the same session tree.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": "string"
         },
         "source": {
           "allOf": [
@@ -908,6 +905,7 @@
         "id",
         "modelProvider",
         "preview",
+        "sessionId",
         "source",
         "status",
         "turns",

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadUnarchiveResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadUnarchiveResponse.json
@@ -853,6 +853,13 @@
           "description": "Usually the first user message in the thread, if available.",
           "type": "string"
         },
+        "sessionId": {
+          "description": "Session id shared by threads that belong to the same session tree.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "source": {
           "allOf": [
             {

--- a/codex-rs/app-server-protocol/schema/typescript/v2/Thread.ts
+++ b/codex-rs/app-server-protocol/schema/typescript/v2/Thread.ts
@@ -10,6 +10,10 @@ import type { Turn } from "./Turn";
 
 export type Thread = { id: string,
 /**
+ * Session id shared by threads that belong to the same session tree.
+ */
+sessionId: string | null,
+/**
  * Source thread id when this thread was created by forking another thread.
  */
 forkedFromId: string | null,

--- a/codex-rs/app-server-protocol/schema/typescript/v2/Thread.ts
+++ b/codex-rs/app-server-protocol/schema/typescript/v2/Thread.ts
@@ -12,7 +12,7 @@ export type Thread = { id: string,
 /**
  * Session id shared by threads that belong to the same session tree.
  */
-sessionId: string | null,
+sessionId: string,
 /**
  * Source thread id when this thread was created by forking another thread.
  */

--- a/codex-rs/app-server-protocol/schema/typescript/v2/ThreadForkResponse.ts
+++ b/codex-rs/app-server-protocol/schema/typescript/v2/ThreadForkResponse.ts
@@ -9,10 +9,7 @@ import type { AskForApproval } from "./AskForApproval";
 import type { SandboxPolicy } from "./SandboxPolicy";
 import type { Thread } from "./Thread";
 
-export type ThreadForkResponse = {/**
- * Session id shared by threads that belong to the same session tree.
- */
-sessionId: string, thread: Thread, model: string, modelProvider: string, serviceTier: ServiceTier | null, cwd: AbsolutePathBuf, /**
+export type ThreadForkResponse = {thread: Thread, model: string, modelProvider: string, serviceTier: ServiceTier | null, cwd: AbsolutePathBuf, /**
  * Instruction source files currently loaded for this thread.
  */
 instructionSources: Array<AbsolutePathBuf>, approvalPolicy: AskForApproval, /**

--- a/codex-rs/app-server-protocol/schema/typescript/v2/ThreadResumeResponse.ts
+++ b/codex-rs/app-server-protocol/schema/typescript/v2/ThreadResumeResponse.ts
@@ -9,10 +9,7 @@ import type { AskForApproval } from "./AskForApproval";
 import type { SandboxPolicy } from "./SandboxPolicy";
 import type { Thread } from "./Thread";
 
-export type ThreadResumeResponse = {/**
- * Session id shared by threads that belong to the same session tree.
- */
-sessionId: string, thread: Thread, model: string, modelProvider: string, serviceTier: ServiceTier | null, cwd: AbsolutePathBuf, /**
+export type ThreadResumeResponse = {thread: Thread, model: string, modelProvider: string, serviceTier: ServiceTier | null, cwd: AbsolutePathBuf, /**
  * Instruction source files currently loaded for this thread.
  */
 instructionSources: Array<AbsolutePathBuf>, approvalPolicy: AskForApproval, /**

--- a/codex-rs/app-server-protocol/schema/typescript/v2/ThreadStartResponse.ts
+++ b/codex-rs/app-server-protocol/schema/typescript/v2/ThreadStartResponse.ts
@@ -9,10 +9,7 @@ import type { AskForApproval } from "./AskForApproval";
 import type { SandboxPolicy } from "./SandboxPolicy";
 import type { Thread } from "./Thread";
 
-export type ThreadStartResponse = {/**
- * Session id shared by threads that belong to the same session tree.
- */
-sessionId: string, thread: Thread, model: string, modelProvider: string, serviceTier: ServiceTier | null, cwd: AbsolutePathBuf, /**
+export type ThreadStartResponse = {thread: Thread, model: string, modelProvider: string, serviceTier: ServiceTier | null, cwd: AbsolutePathBuf, /**
  * Instruction source files currently loaded for this thread.
  */
 instructionSources: Array<AbsolutePathBuf>, approvalPolicy: AskForApproval, /**

--- a/codex-rs/app-server-protocol/src/protocol/common.rs
+++ b/codex-rs/app-server-protocol/src/protocol/common.rs
@@ -2178,7 +2178,7 @@ mod tests {
             response: v2::ThreadStartResponse {
                 thread: v2::Thread {
                     id: "67e55044-10b1-426f-9247-bb680e5fe0c8".to_string(),
-                    session_id: Some("67e55044-10b1-426f-9247-bb680e5fe0c7".to_string()),
+                    session_id: "67e55044-10b1-426f-9247-bb680e5fe0c7".to_string(),
                     forked_from_id: None,
                     preview: "first prompt".to_string(),
                     ephemeral: true,

--- a/codex-rs/app-server-protocol/src/protocol/common.rs
+++ b/codex-rs/app-server-protocol/src/protocol/common.rs
@@ -2176,9 +2176,9 @@ mod tests {
         let response = ClientResponse::ThreadStart {
             request_id: RequestId::Integer(7),
             response: v2::ThreadStartResponse {
-                session_id: "67e55044-10b1-426f-9247-bb680e5fe0c7".to_string(),
                 thread: v2::Thread {
                     id: "67e55044-10b1-426f-9247-bb680e5fe0c8".to_string(),
+                    session_id: Some("67e55044-10b1-426f-9247-bb680e5fe0c7".to_string()),
                     forked_from_id: None,
                     preview: "first prompt".to_string(),
                     ephemeral: true,
@@ -2218,9 +2218,9 @@ mod tests {
                 "method": "thread/start",
                 "id": 7,
                 "response": {
-                    "sessionId": "67e55044-10b1-426f-9247-bb680e5fe0c7",
                     "thread": {
                         "id": "67e55044-10b1-426f-9247-bb680e5fe0c8",
+                        "sessionId": "67e55044-10b1-426f-9247-bb680e5fe0c7",
                         "forkedFromId": null,
                         "preview": "first prompt",
                         "ephemeral": true,

--- a/codex-rs/app-server-protocol/src/protocol/v2/tests.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2/tests.rs
@@ -3441,6 +3441,7 @@ fn thread_lifecycle_responses_default_missing_optional_fields() {
     let response = json!({
         "thread": {
             "id": "thread-id",
+            "sessionId": "thread-id",
             "forkedFromId": null,
             "preview": "",
             "ephemeral": false,
@@ -3483,9 +3484,6 @@ fn thread_lifecycle_responses_default_missing_optional_fields() {
     assert_eq!(start.active_permission_profile, None);
     assert_eq!(resume.active_permission_profile, None);
     assert_eq!(fork.active_permission_profile, None);
-    assert_eq!(start.thread.session_id, None);
-    assert_eq!(resume.thread.session_id, None);
-    assert_eq!(fork.thread.session_id, None);
 }
 
 #[test]

--- a/codex-rs/app-server-protocol/src/protocol/v2/tests.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2/tests.rs
@@ -3437,7 +3437,7 @@ fn thread_start_params_preserve_explicit_null_service_tier() {
 }
 
 #[test]
-fn thread_lifecycle_responses_default_missing_compat_fields() {
+fn thread_lifecycle_responses_default_missing_optional_fields() {
     let response = json!({
         "thread": {
             "id": "thread-id",
@@ -3483,6 +3483,9 @@ fn thread_lifecycle_responses_default_missing_compat_fields() {
     assert_eq!(start.active_permission_profile, None);
     assert_eq!(resume.active_permission_profile, None);
     assert_eq!(fork.active_permission_profile, None);
+    assert_eq!(start.thread.session_id, None);
+    assert_eq!(resume.thread.session_id, None);
+    assert_eq!(fork.thread.session_id, None);
 }
 
 #[test]

--- a/codex-rs/app-server-protocol/src/protocol/v2/thread.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2/thread.rs
@@ -189,9 +189,6 @@ pub struct MockExperimentalMethodResponse {
 #[serde(rename_all = "camelCase")]
 #[ts(export_to = "v2/")]
 pub struct ThreadStartResponse {
-    /// Session id shared by threads that belong to the same session tree.
-    #[serde(default)]
-    pub session_id: String,
     pub thread: Thread,
     pub model: String,
     pub model_provider: String,
@@ -307,9 +304,6 @@ pub struct ThreadResumeParams {
 #[serde(rename_all = "camelCase")]
 #[ts(export_to = "v2/")]
 pub struct ThreadResumeResponse {
-    /// Session id shared by threads that belong to the same session tree.
-    #[serde(default)]
-    pub session_id: String,
     pub thread: Thread,
     pub model: String,
     pub model_provider: String,
@@ -419,9 +413,6 @@ pub struct ThreadForkParams {
 #[serde(rename_all = "camelCase")]
 #[ts(export_to = "v2/")]
 pub struct ThreadForkResponse {
-    /// Session id shared by threads that belong to the same session tree.
-    #[serde(default)]
-    pub session_id: String,
     pub thread: Thread,
     pub model: String,
     pub model_provider: String,

--- a/codex-rs/app-server-protocol/src/protocol/v2/thread_data.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2/thread_data.rs
@@ -104,6 +104,8 @@ pub struct GitInfo {
 #[ts(export_to = "v2/")]
 pub struct Thread {
     pub id: String,
+    /// Session id shared by threads that belong to the same session tree.
+    pub session_id: Option<String>,
     /// Source thread id when this thread was created by forking another thread.
     pub forked_from_id: Option<String>,
     /// Usually the first user message in the thread, if available.

--- a/codex-rs/app-server-protocol/src/protocol/v2/thread_data.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2/thread_data.rs
@@ -105,7 +105,7 @@ pub struct GitInfo {
 pub struct Thread {
     pub id: String,
     /// Session id shared by threads that belong to the same session tree.
-    pub session_id: Option<String>,
+    pub session_id: String,
     /// Source thread id when this thread was created by forking another thread.
     pub forked_from_id: Option<String>,
     /// Usually the first user message in the thread, if available.

--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -303,7 +303,7 @@ Example:
 { "id": 12, "result": { "thread": { "id": "thr_123", "turns": [], … } } }
 ```
 
-To branch from a stored session, call `thread/fork` with the `thread.id`. This creates a new thread id and emits a `thread/started` notification for it. The returned `thread.sessionId` identifies the session tree that the fork belongs to. For persisted-only thread views where that grouping is not known, `thread.sessionId` is `null`; callers that only need a stable grouping key can fall back to `thread.id`. When the source history includes persisted token usage, the server also emits `thread/tokenUsage/updated` for the new thread immediately after the response. If the source thread is actively running, the fork snapshots it as if the current turn had been interrupted first. Pass `ephemeral: true` when the fork should stay in-memory only:
+To branch from a stored session, call `thread/fork` with the `thread.id`. This creates a new thread id and emits a `thread/started` notification for it. The returned `thread.sessionId` identifies the current session tree root. Root threads use their own `thread.id` as `thread.sessionId`; stored sub-agent threads derive it from their persisted spawn ancestry. When the source history includes persisted token usage, the server also emits `thread/tokenUsage/updated` for the new thread immediately after the response. If the source thread is actively running, the fork snapshots it as if the current turn had been interrupted first. Pass `ephemeral: true` when the fork should stay in-memory only:
 
 ```json
 { "method": "thread/fork", "id": 12, "params": { "threadId": "thr_123", "ephemeral": true } }

--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -303,7 +303,7 @@ Example:
 { "id": 12, "result": { "thread": { "id": "thr_123", "turns": [], … } } }
 ```
 
-To branch from a stored session, call `thread/fork` with the `thread.id`. This creates a new thread id and emits a `thread/started` notification for it. The returned `thread.sessionId` identifies the current session tree root. Root threads use their own `thread.id` as `thread.sessionId`; stored sub-agent threads derive it from their persisted spawn ancestry. When the source history includes persisted token usage, the server also emits `thread/tokenUsage/updated` for the new thread immediately after the response. If the source thread is actively running, the fork snapshots it as if the current turn had been interrupted first. Pass `ephemeral: true` when the fork should stay in-memory only:
+To branch from a stored session, call `thread/fork` with the `thread.id`. This creates a new thread id and emits a `thread/started` notification for it. The returned `thread.sessionId` identifies the current live session tree root. Root threads use their own `thread.id` as `thread.sessionId`; stored threads that are not loaded also report their own `thread.id`, because resuming one makes it the root of a new live session tree. When the source history includes persisted token usage, the server also emits `thread/tokenUsage/updated` for the new thread immediately after the response. If the source thread is actively running, the fork snapshots it as if the current turn had been interrupted first. Pass `ephemeral: true` when the fork should stay in-memory only:
 
 ```json
 { "method": "thread/fork", "id": 12, "params": { "threadId": "thr_123", "ephemeral": true } }

--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -303,11 +303,11 @@ Example:
 { "id": 12, "result": { "thread": { "id": "thr_123", "turns": [], … } } }
 ```
 
-To branch from a stored session, call `thread/fork` with the `thread.id`. This creates a new thread id and emits a `thread/started` notification for it. The response includes the forked thread's `sessionId`, so clients do not need to infer it from the new thread id. When the source history includes persisted token usage, the server also emits `thread/tokenUsage/updated` for the new thread immediately after the response. If the source thread is actively running, the fork snapshots it as if the current turn had been interrupted first. Pass `ephemeral: true` when the fork should stay in-memory only:
+To branch from a stored session, call `thread/fork` with the `thread.id`. This creates a new thread id and emits a `thread/started` notification for it. The returned `thread.sessionId` identifies the session tree that the fork belongs to. For persisted-only thread views where that grouping is not known, `thread.sessionId` is `null`; callers that only need a stable grouping key can fall back to `thread.id`. When the source history includes persisted token usage, the server also emits `thread/tokenUsage/updated` for the new thread immediately after the response. If the source thread is actively running, the fork snapshots it as if the current turn had been interrupted first. Pass `ephemeral: true` when the fork should stay in-memory only:
 
 ```json
 { "method": "thread/fork", "id": 12, "params": { "threadId": "thr_123", "ephemeral": true } }
-{ "id": 12, "result": { "sessionId": "thr_456", "thread": { "id": "thr_456", … } } }
+{ "id": 12, "result": { "thread": { "id": "thr_456", "sessionId": "thr_456", … } } }
 { "method": "thread/started", "params": { "thread": { … } } }
 ```
 

--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -1190,6 +1190,7 @@ pub(crate) async fn apply_bespoke_event_handling(
                     .await;
                 let response = match thread_rollback_response_from_stored_thread(
                     stored_thread,
+                    conversation.session_configured().session_id.to_string(),
                     fallback_model_provider.as_str(),
                     &fallback_cwd,
                     loaded_status,
@@ -1543,13 +1544,18 @@ async fn handle_thread_rollback_failed(
 
 fn thread_rollback_response_from_stored_thread(
     stored_thread: codex_thread_store::StoredThread,
+    session_id: String,
     fallback_model_provider: &str,
     fallback_cwd: &AbsolutePathBuf,
     loaded_status: ThreadStatus,
 ) -> std::result::Result<ThreadRollbackResponse, String> {
     let thread_id = stored_thread.thread_id;
-    let (mut thread, history) =
-        thread_from_stored_thread(stored_thread, fallback_model_provider, fallback_cwd);
+    let (mut thread, history) = thread_from_stored_thread(
+        stored_thread,
+        session_id,
+        fallback_model_provider,
+        fallback_cwd,
+    );
     let Some(history) = history else {
         return Err(format!(
             "thread {thread_id} did not include persisted history after rollback"
@@ -2200,6 +2206,7 @@ mod tests {
 
         let response = thread_rollback_response_from_stored_thread(
             stored_thread,
+            thread_id.to_string(),
             "fallback-provider",
             &fallback_cwd,
             ThreadStatus::NotLoaded,

--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -1550,12 +1550,9 @@ fn thread_rollback_response_from_stored_thread(
     loaded_status: ThreadStatus,
 ) -> std::result::Result<ThreadRollbackResponse, String> {
     let thread_id = stored_thread.thread_id;
-    let (mut thread, history) = thread_from_stored_thread(
-        stored_thread,
-        session_id,
-        fallback_model_provider,
-        fallback_cwd,
-    );
+    let (mut thread, history) =
+        thread_from_stored_thread(stored_thread, fallback_model_provider, fallback_cwd);
+    thread.session_id = session_id;
     let Some(history) = history else {
         return Err(format!(
             "thread {thread_id} did not include persisted history after rollback"

--- a/codex-rs/app-server/src/request_processors/thread_lifecycle.rs
+++ b/codex-rs/app-server/src/request_processors/thread_lifecycle.rs
@@ -599,7 +599,7 @@ pub(super) async fn handle_pending_thread_resume_request(
     let active_permission_profile =
         thread_response_active_permission_profile(active_permission_profile);
     let session_id = conversation.session_configured().session_id.to_string();
-    thread.session_id = Some(session_id);
+    thread.session_id = session_id;
 
     let response = ThreadResumeResponse {
         thread,

--- a/codex-rs/app-server/src/request_processors/thread_lifecycle.rs
+++ b/codex-rs/app-server/src/request_processors/thread_lifecycle.rs
@@ -599,9 +599,9 @@ pub(super) async fn handle_pending_thread_resume_request(
     let active_permission_profile =
         thread_response_active_permission_profile(active_permission_profile);
     let session_id = conversation.session_configured().session_id.to_string();
+    thread.session_id = Some(session_id);
 
     let response = ThreadResumeResponse {
-        session_id,
         thread,
         model,
         model_provider: model_provider_id,

--- a/codex-rs/app-server/src/request_processors/thread_processor.rs
+++ b/codex-rs/app-server/src/request_processors/thread_processor.rs
@@ -1096,7 +1096,7 @@ impl ThreadRequestProcessor {
             .await;
         let mut thread = build_thread_from_snapshot(
             thread_id,
-            Some(session_configured.session_id.to_string()),
+            session_configured.session_id.to_string(),
             &config_snapshot,
             session_configured.rollout_path.clone(),
         );
@@ -1529,9 +1529,9 @@ impl ThreadRequestProcessor {
             ..Default::default()
         };
 
+        let loaded_thread = self.thread_manager.get_thread(thread_uuid).await.ok();
         let updated_thread = {
             let _thread_list_state_permit = self.acquire_thread_list_state_permit().await?;
-            let loaded_thread = self.thread_manager.get_thread(thread_uuid).await.ok();
             if let Some(loaded_thread) = loaded_thread.as_ref() {
                 if loaded_thread.config_snapshot().await.ephemeral {
                     return Err(invalid_request(format!(
@@ -1552,9 +1552,15 @@ impl ThreadRequestProcessor {
             }
             .map_err(|err| thread_store_write_error("update thread metadata", err))?
         };
+        let session_id = if let Some(loaded_thread) = loaded_thread.as_ref() {
+            loaded_thread.session_configured().session_id.to_string()
+        } else {
+            self.stored_thread_session_id(&updated_thread).await
+        };
 
         let (mut thread, _) = thread_from_stored_thread(
             updated_thread,
+            session_id,
             self.config.model_provider_id.as_str(),
             &self.config.cwd,
         );
@@ -1603,18 +1609,17 @@ impl ThreadRequestProcessor {
             .map_err(|err| invalid_request(format!("invalid thread id: {err}")))?;
 
         let fallback_provider = self.config.model_provider_id.clone();
-        let mut thread = self
+        let stored_thread = self
             .thread_store
             .unarchive_thread(StoreArchiveThreadParams { thread_id })
             .await
-            .map_err(|err| thread_store_archive_error("unarchive", err))
-            .and_then(|stored_thread| {
-                summary_from_stored_thread(stored_thread, fallback_provider.as_str())
-                    .map(|summary| summary_to_thread(summary, &self.config.cwd))
-                    .ok_or_else(|| {
-                        internal_error(format!("failed to read unarchived thread {thread_id}"))
-                    })
+            .map_err(|err| thread_store_archive_error("unarchive", err))?;
+        let session_id = self.stored_thread_session_id(&stored_thread).await;
+        let summary = summary_from_stored_thread(stored_thread, fallback_provider.as_str())
+            .ok_or_else(|| {
+                internal_error(format!("failed to read unarchived thread {thread_id}"))
             })?;
+        let mut thread = summary_to_thread(summary, session_id, &self.config.cwd);
 
         thread.status = resolve_thread_status(
             self.thread_watch_manager
@@ -1810,8 +1815,10 @@ impl ThreadRequestProcessor {
         let fallback_provider = self.config.model_provider_id.clone();
 
         for stored_thread in stored_threads {
+            let session_id = self.stored_thread_session_id(&stored_thread).await;
             let (thread, _) = thread_from_stored_thread(
                 stored_thread,
+                session_id,
                 fallback_provider.as_str(),
                 &self.config.cwd,
             );
@@ -1996,8 +2003,13 @@ impl ThreadRequestProcessor {
             .await
         {
             Ok(stored_thread) => {
-                let (mut thread, history) =
-                    thread_from_stored_thread(stored_thread, fallback_provider, &self.config.cwd);
+                let session_id = self.stored_thread_session_id(&stored_thread).await;
+                let (mut thread, history) = thread_from_stored_thread(
+                    stored_thread,
+                    session_id,
+                    fallback_provider,
+                    &self.config.cwd,
+                );
                 if include_turns && let Some(history) = history {
                     thread.turns = build_api_turns_from_rollout_items(&history.items);
                 }
@@ -2040,7 +2052,7 @@ impl ThreadRequestProcessor {
             if thread.path.is_none() {
                 thread.path = fallback_thread.path.clone();
             }
-            thread.session_id = fallback_thread.session_id.clone();
+            thread.session_id.clone_from(&fallback_thread.session_id);
             thread.ephemeral = fallback_thread.ephemeral;
             thread
         } else {
@@ -2226,7 +2238,7 @@ impl ThreadRequestProcessor {
             let config_snapshot = thread.config_snapshot().await;
             let loaded_thread = build_thread_from_snapshot(
                 thread_id,
-                Some(thread.session_configured().session_id.to_string()),
+                thread.session_configured().session_id.to_string(),
                 &config_snapshot,
                 thread.rollout_path(),
             );
@@ -2657,6 +2669,7 @@ impl ThreadRequestProcessor {
             summary_source_thread.history = None;
             let thread_summary = self.stored_thread_to_api_thread(
                 summary_source_thread,
+                existing_thread.session_configured().session_id.to_string(),
                 config_snapshot.model_provider_id.as_str(),
                 /*include_turns*/ false,
             );
@@ -2788,11 +2801,16 @@ impl ThreadRequestProcessor {
     fn stored_thread_to_api_thread(
         &self,
         stored_thread: StoredThread,
+        session_id: String,
         fallback_provider: &str,
         include_turns: bool,
     ) -> Thread {
-        let (mut thread, history) =
-            thread_from_stored_thread(stored_thread, fallback_provider, &self.config.cwd);
+        let (mut thread, history) = thread_from_stored_thread(
+            stored_thread,
+            session_id,
+            fallback_provider,
+            &self.config.cwd,
+        );
         if include_turns && let Some(history) = history {
             populate_thread_turns_from_history(
                 &mut thread,
@@ -2816,6 +2834,44 @@ impl ThreadRequestProcessor {
             })
             .await
             .map_err(thread_store_resume_read_error)
+    }
+
+    async fn stored_thread_session_id(&self, stored_thread: &StoredThread) -> String {
+        let mut current_thread = stored_thread.clone();
+        let mut visited = HashSet::new();
+
+        loop {
+            let Some(parent_thread_id) = thread_spawn_parent_thread_id(&current_thread.source)
+            else {
+                return current_thread.thread_id.to_string();
+            };
+            if !visited.insert(parent_thread_id) {
+                warn!(
+                    "detected thread spawn ancestry cycle while resolving session id for thread {}",
+                    stored_thread.thread_id
+                );
+                return parent_thread_id.to_string();
+            }
+
+            match self
+                .thread_store
+                .read_thread(StoreReadThreadParams {
+                    thread_id: parent_thread_id,
+                    include_archived: true,
+                    include_history: false,
+                })
+                .await
+            {
+                Ok(parent_thread) => current_thread = parent_thread,
+                Err(err) => {
+                    warn!(
+                        "failed to read parent thread {parent_thread_id} while resolving session id for thread {}: {err}",
+                        stored_thread.thread_id
+                    );
+                    return parent_thread_id.to_string();
+                }
+            }
+        }
     }
 
     async fn load_thread_from_resume_source_or_send_internal(
@@ -2861,6 +2917,7 @@ impl ThreadRequestProcessor {
                         };
                     Ok(thread_from_stored_thread(
                         stored_thread,
+                        session_id.clone(),
                         fallback_provider,
                         &self.config.cwd,
                     )
@@ -2877,6 +2934,7 @@ impl ThreadRequestProcessor {
                     {
                         Ok(stored_thread) => Ok(thread_from_stored_thread(
                             stored_thread,
+                            session_id.clone(),
                             fallback_provider,
                             &self.config.cwd,
                         )
@@ -2890,7 +2948,7 @@ impl ThreadRequestProcessor {
             InitialHistory::Forked(items) => {
                 let mut thread = build_thread_from_snapshot(
                     thread_id,
-                    Some(session_id.clone()),
+                    session_id.clone(),
                     &config_snapshot,
                     Some(rollout_path.into()),
                 );
@@ -2903,7 +2961,7 @@ impl ThreadRequestProcessor {
         };
         let mut thread = thread?;
         thread.id = thread_id.to_string();
-        thread.session_id = Some(session_id);
+        thread.session_id = session_id;
         thread.path = Some(rollout_path.to_path_buf());
         if include_turns {
             let history_items = thread_history.get_rollout_items();
@@ -3079,6 +3137,7 @@ impl ThreadRequestProcessor {
                 .await?;
             self.stored_thread_to_api_thread(
                 stored_thread,
+                session_configured.session_id.to_string(),
                 fallback_model_provider.as_str(),
                 include_turns,
             )
@@ -3087,7 +3146,7 @@ impl ThreadRequestProcessor {
             // forked thread names do not inherit the source thread name
             let mut thread = build_thread_from_snapshot(
                 thread_id,
-                Some(session_configured.session_id.to_string()),
+                session_configured.session_id.to_string(),
                 &config_snapshot,
                 /*path*/ None,
             );
@@ -3102,7 +3161,7 @@ impl ThreadRequestProcessor {
             }
             thread
         };
-        thread.session_id = Some(session_configured.session_id.to_string());
+        thread.session_id = session_configured.session_id.to_string();
         thread.thread_source = forked_thread
             .config_snapshot()
             .await
@@ -3669,6 +3728,7 @@ fn set_thread_name_from_title(thread: &mut Thread, title: String) {
 
 pub(crate) fn thread_from_stored_thread(
     thread: StoredThread,
+    session_id: String,
     fallback_provider: &str,
     fallback_cwd: &AbsolutePathBuf,
 ) -> (Thread, Option<codex_thread_store::StoredThreadHistory>) {
@@ -3693,7 +3753,7 @@ pub(crate) fn thread_from_stored_thread(
     let history = thread.history;
     let thread = Thread {
         id: thread.thread_id.to_string(),
-        session_id: None,
+        session_id,
         forked_from_id: thread.forked_from_id.map(|id| id.to_string()),
         preview: thread.first_user_message.unwrap_or(thread.preview),
         ephemeral: false,
@@ -3717,6 +3777,19 @@ pub(crate) fn thread_from_stored_thread(
         turns: Vec::new(),
     };
     (thread, history)
+}
+
+fn thread_spawn_parent_thread_id(
+    source: &codex_protocol::protocol::SessionSource,
+) -> Option<ThreadId> {
+    match source {
+        codex_protocol::protocol::SessionSource::SubAgent(
+            codex_protocol::protocol::SubAgentSource::ThreadSpawn {
+                parent_thread_id, ..
+            },
+        ) => Some(*parent_thread_id),
+        _ => None,
+    }
 }
 
 fn summary_from_stored_thread(
@@ -3890,7 +3963,7 @@ fn permission_profile_trusts_project(
 
 fn build_thread_from_snapshot(
     thread_id: ThreadId,
-    session_id: Option<String>,
+    session_id: String,
     config_snapshot: &ThreadConfigSnapshot,
     path: Option<PathBuf>,
 ) -> Thread {
@@ -3925,7 +3998,7 @@ fn build_thread_from_loaded_snapshot(
 ) -> Thread {
     build_thread_from_snapshot(
         thread_id,
-        Some(loaded_thread.session_configured().session_id.to_string()),
+        loaded_thread.session_configured().session_id.to_string(),
         config_snapshot,
         loaded_thread.rollout_path(),
     )

--- a/codex-rs/app-server/src/request_processors/thread_processor.rs
+++ b/codex-rs/app-server/src/request_processors/thread_processor.rs
@@ -1096,6 +1096,7 @@ impl ThreadRequestProcessor {
             .await;
         let mut thread = build_thread_from_snapshot(
             thread_id,
+            Some(session_configured.session_id.to_string()),
             &config_snapshot,
             session_configured.rollout_path.clone(),
         );
@@ -1148,7 +1149,6 @@ impl ThreadRequestProcessor {
             thread_response_active_permission_profile(config_snapshot.active_permission_profile);
 
         let response = ThreadStartResponse {
-            session_id: session_configured.session_id.to_string(),
             thread: thread.clone(),
             model: config_snapshot.model,
             model_provider: config_snapshot.model_provider_id,
@@ -2040,6 +2040,7 @@ impl ThreadRequestProcessor {
             if thread.path.is_none() {
                 thread.path = fallback_thread.path.clone();
             }
+            thread.session_id = fallback_thread.session_id.clone();
             thread.ephemeral = fallback_thread.ephemeral;
             thread
         } else {
@@ -2223,8 +2224,12 @@ impl ThreadRequestProcessor {
     ) {
         if let Ok(thread) = self.thread_manager.get_thread(thread_id).await {
             let config_snapshot = thread.config_snapshot().await;
-            let loaded_thread =
-                build_thread_from_snapshot(thread_id, &config_snapshot, thread.rollout_path());
+            let loaded_thread = build_thread_from_snapshot(
+                thread_id,
+                Some(thread.session_configured().session_id.to_string()),
+                &config_snapshot,
+                thread.rollout_path(),
+            );
             self.thread_watch_manager.upsert_thread(loaded_thread).await;
         }
 
@@ -2477,7 +2482,6 @@ impl ThreadRequestProcessor {
                 );
 
                 let response = ThreadResumeResponse {
-                    session_id: session_configured.session_id.to_string(),
                     thread,
                     model: session_configured.model,
                     model_provider: session_configured.model_provider_id,
@@ -2824,6 +2828,7 @@ impl ThreadRequestProcessor {
         include_turns: bool,
     ) -> std::result::Result<Thread, String> {
         let config_snapshot = thread.config_snapshot().await;
+        let session_id = thread.session_configured().session_id.to_string();
         let thread = match thread_history {
             InitialHistory::Resumed(resumed) => {
                 let fallback_provider = config_snapshot.model_provider_id.as_str();
@@ -2885,6 +2890,7 @@ impl ThreadRequestProcessor {
             InitialHistory::Forked(items) => {
                 let mut thread = build_thread_from_snapshot(
                     thread_id,
+                    Some(session_id.clone()),
                     &config_snapshot,
                     Some(rollout_path.into()),
                 );
@@ -2897,6 +2903,7 @@ impl ThreadRequestProcessor {
         };
         let mut thread = thread?;
         thread.id = thread_id.to_string();
+        thread.session_id = Some(session_id);
         thread.path = Some(rollout_path.to_path_buf());
         if include_turns {
             let history_items = thread_history.get_rollout_items();
@@ -3078,8 +3085,12 @@ impl ThreadRequestProcessor {
         } else {
             let config_snapshot = forked_thread.config_snapshot().await;
             // forked thread names do not inherit the source thread name
-            let mut thread =
-                build_thread_from_snapshot(thread_id, &config_snapshot, /*path*/ None);
+            let mut thread = build_thread_from_snapshot(
+                thread_id,
+                Some(session_configured.session_id.to_string()),
+                &config_snapshot,
+                /*path*/ None,
+            );
             thread.preview = preview_from_rollout_items(&history_items);
             thread.forked_from_id = Some(source_thread_id.to_string());
             if include_turns {
@@ -3091,6 +3102,7 @@ impl ThreadRequestProcessor {
             }
             thread
         };
+        thread.session_id = Some(session_configured.session_id.to_string());
         thread.thread_source = forked_thread
             .config_snapshot()
             .await
@@ -3116,7 +3128,6 @@ impl ThreadRequestProcessor {
             thread_response_active_permission_profile(config_snapshot.active_permission_profile);
 
         let response = ThreadForkResponse {
-            session_id: session_configured.session_id.to_string(),
             thread: thread.clone(),
             model: session_configured.model,
             model_provider: session_configured.model_provider_id,
@@ -3682,6 +3693,7 @@ pub(crate) fn thread_from_stored_thread(
     let history = thread.history;
     let thread = Thread {
         id: thread.thread_id.to_string(),
+        session_id: None,
         forked_from_id: thread.forked_from_id.map(|id| id.to_string()),
         preview: thread.first_user_message.unwrap_or(thread.preview),
         ephemeral: false,
@@ -3878,12 +3890,14 @@ fn permission_profile_trusts_project(
 
 fn build_thread_from_snapshot(
     thread_id: ThreadId,
+    session_id: Option<String>,
     config_snapshot: &ThreadConfigSnapshot,
     path: Option<PathBuf>,
 ) -> Thread {
     let now = time::OffsetDateTime::now_utc().unix_timestamp();
     Thread {
         id: thread_id.to_string(),
+        session_id,
         forked_from_id: None,
         preview: String::new(),
         ephemeral: config_snapshot.ephemeral,
@@ -3909,7 +3923,12 @@ fn build_thread_from_loaded_snapshot(
     config_snapshot: &ThreadConfigSnapshot,
     loaded_thread: &CodexThread,
 ) -> Thread {
-    build_thread_from_snapshot(thread_id, config_snapshot, loaded_thread.rollout_path())
+    build_thread_from_snapshot(
+        thread_id,
+        Some(loaded_thread.session_configured().session_id.to_string()),
+        config_snapshot,
+        loaded_thread.rollout_path(),
+    )
 }
 
 #[cfg(test)]

--- a/codex-rs/app-server/src/request_processors/thread_processor.rs
+++ b/codex-rs/app-server/src/request_processors/thread_processor.rs
@@ -1552,18 +1552,14 @@ impl ThreadRequestProcessor {
             }
             .map_err(|err| thread_store_write_error("update thread metadata", err))?
         };
-        let session_id = if let Some(loaded_thread) = loaded_thread.as_ref() {
-            loaded_thread.session_configured().session_id.to_string()
-        } else {
-            self.stored_thread_session_id(&updated_thread).await
-        };
-
         let (mut thread, _) = thread_from_stored_thread(
             updated_thread,
-            session_id,
             self.config.model_provider_id.as_str(),
             &self.config.cwd,
         );
+        if let Some(loaded_thread) = loaded_thread.as_ref() {
+            thread.session_id = loaded_thread.session_configured().session_id.to_string();
+        }
         self.attach_thread_name(thread_uuid, &mut thread).await;
         thread.status = resolve_thread_status(
             self.thread_watch_manager
@@ -1614,12 +1610,11 @@ impl ThreadRequestProcessor {
             .unarchive_thread(StoreArchiveThreadParams { thread_id })
             .await
             .map_err(|err| thread_store_archive_error("unarchive", err))?;
-        let session_id = self.stored_thread_session_id(&stored_thread).await;
         let summary = summary_from_stored_thread(stored_thread, fallback_provider.as_str())
             .ok_or_else(|| {
                 internal_error(format!("failed to read unarchived thread {thread_id}"))
             })?;
-        let mut thread = summary_to_thread(summary, session_id, &self.config.cwd);
+        let mut thread = summary_to_thread(summary, &self.config.cwd);
 
         thread.status = resolve_thread_status(
             self.thread_watch_manager
@@ -1815,10 +1810,8 @@ impl ThreadRequestProcessor {
         let fallback_provider = self.config.model_provider_id.clone();
 
         for stored_thread in stored_threads {
-            let session_id = self.stored_thread_session_id(&stored_thread).await;
             let (thread, _) = thread_from_stored_thread(
                 stored_thread,
-                session_id,
                 fallback_provider.as_str(),
                 &self.config.cwd,
             );
@@ -2003,13 +1996,8 @@ impl ThreadRequestProcessor {
             .await
         {
             Ok(stored_thread) => {
-                let session_id = self.stored_thread_session_id(&stored_thread).await;
-                let (mut thread, history) = thread_from_stored_thread(
-                    stored_thread,
-                    session_id,
-                    fallback_provider,
-                    &self.config.cwd,
-                );
+                let (mut thread, history) =
+                    thread_from_stored_thread(stored_thread, fallback_provider, &self.config.cwd);
                 if include_turns && let Some(history) = history {
                     thread.turns = build_api_turns_from_rollout_items(&history.items);
                 }
@@ -2667,12 +2655,12 @@ impl ThreadRequestProcessor {
             }
             let mut summary_source_thread = source_thread;
             summary_source_thread.history = None;
-            let thread_summary = self.stored_thread_to_api_thread(
+            let mut thread_summary = self.stored_thread_to_api_thread(
                 summary_source_thread,
-                existing_thread.session_configured().session_id.to_string(),
                 config_snapshot.model_provider_id.as_str(),
                 /*include_turns*/ false,
             );
+            thread_summary.session_id = existing_thread.session_configured().session_id.to_string();
             let mut config_for_instruction_sources = self.config.as_ref().clone();
             config_for_instruction_sources.cwd = config_snapshot.cwd.clone();
             let instruction_sources =
@@ -2801,16 +2789,11 @@ impl ThreadRequestProcessor {
     fn stored_thread_to_api_thread(
         &self,
         stored_thread: StoredThread,
-        session_id: String,
         fallback_provider: &str,
         include_turns: bool,
     ) -> Thread {
-        let (mut thread, history) = thread_from_stored_thread(
-            stored_thread,
-            session_id,
-            fallback_provider,
-            &self.config.cwd,
-        );
+        let (mut thread, history) =
+            thread_from_stored_thread(stored_thread, fallback_provider, &self.config.cwd);
         if include_turns && let Some(history) = history {
             populate_thread_turns_from_history(
                 &mut thread,
@@ -2834,44 +2817,6 @@ impl ThreadRequestProcessor {
             })
             .await
             .map_err(thread_store_resume_read_error)
-    }
-
-    async fn stored_thread_session_id(&self, stored_thread: &StoredThread) -> String {
-        let mut current_thread = stored_thread.clone();
-        let mut visited = HashSet::new();
-
-        loop {
-            let Some(parent_thread_id) = thread_spawn_parent_thread_id(&current_thread.source)
-            else {
-                return current_thread.thread_id.to_string();
-            };
-            if !visited.insert(parent_thread_id) {
-                warn!(
-                    "detected thread spawn ancestry cycle while resolving session id for thread {}",
-                    stored_thread.thread_id
-                );
-                return parent_thread_id.to_string();
-            }
-
-            match self
-                .thread_store
-                .read_thread(StoreReadThreadParams {
-                    thread_id: parent_thread_id,
-                    include_archived: true,
-                    include_history: false,
-                })
-                .await
-            {
-                Ok(parent_thread) => current_thread = parent_thread,
-                Err(err) => {
-                    warn!(
-                        "failed to read parent thread {parent_thread_id} while resolving session id for thread {}: {err}",
-                        stored_thread.thread_id
-                    );
-                    return parent_thread_id.to_string();
-                }
-            }
-        }
     }
 
     async fn load_thread_from_resume_source_or_send_internal(
@@ -2917,7 +2862,6 @@ impl ThreadRequestProcessor {
                         };
                     Ok(thread_from_stored_thread(
                         stored_thread,
-                        session_id.clone(),
                         fallback_provider,
                         &self.config.cwd,
                     )
@@ -2934,7 +2878,6 @@ impl ThreadRequestProcessor {
                     {
                         Ok(stored_thread) => Ok(thread_from_stored_thread(
                             stored_thread,
-                            session_id.clone(),
                             fallback_provider,
                             &self.config.cwd,
                         )
@@ -3137,7 +3080,6 @@ impl ThreadRequestProcessor {
                 .await?;
             self.stored_thread_to_api_thread(
                 stored_thread,
-                session_configured.session_id.to_string(),
                 fallback_model_provider.as_str(),
                 include_turns,
             )
@@ -3728,7 +3670,6 @@ fn set_thread_name_from_title(thread: &mut Thread, title: String) {
 
 pub(crate) fn thread_from_stored_thread(
     thread: StoredThread,
-    session_id: String,
     fallback_provider: &str,
     fallback_cwd: &AbsolutePathBuf,
 ) -> (Thread, Option<codex_thread_store::StoredThreadHistory>) {
@@ -3751,9 +3692,10 @@ pub(crate) fn thread_from_stored_thread(
         thread.agent_role.clone(),
     );
     let history = thread.history;
+    let thread_id = thread.thread_id.to_string();
     let thread = Thread {
-        id: thread.thread_id.to_string(),
-        session_id,
+        id: thread_id.clone(),
+        session_id: thread_id,
         forked_from_id: thread.forked_from_id.map(|id| id.to_string()),
         preview: thread.first_user_message.unwrap_or(thread.preview),
         ephemeral: false,
@@ -3777,19 +3719,6 @@ pub(crate) fn thread_from_stored_thread(
         turns: Vec::new(),
     };
     (thread, history)
-}
-
-fn thread_spawn_parent_thread_id(
-    source: &codex_protocol::protocol::SessionSource,
-) -> Option<ThreadId> {
-    match source {
-        codex_protocol::protocol::SessionSource::SubAgent(
-            codex_protocol::protocol::SubAgentSource::ThreadSpawn {
-                parent_thread_id, ..
-            },
-        ) => Some(*parent_thread_id),
-        _ => None,
-    }
 }
 
 fn summary_from_stored_thread(

--- a/codex-rs/app-server/src/request_processors/thread_processor_tests.rs
+++ b/codex-rs/app-server/src/request_processors/thread_processor_tests.rs
@@ -962,7 +962,7 @@ mod thread_processor_behavior_tests {
 
         let summary = read_summary_from_rollout(path.as_path(), "fallback").await?;
         let fallback_cwd = AbsolutePathBuf::from_absolute_path("/")?;
-        let thread = summary_to_thread(summary, conversation_id.to_string(), &fallback_cwd);
+        let thread = summary_to_thread(summary, &fallback_cwd);
 
         assert_eq!(thread.agent_nickname, Some("atlas".to_string()));
         assert_eq!(thread.agent_role, Some("explorer".to_string()));
@@ -1102,7 +1102,7 @@ mod thread_processor_behavior_tests {
         );
 
         let fallback_cwd = AbsolutePathBuf::from_absolute_path("/")?;
-        let thread = summary_to_thread(summary, conversation_id.to_string(), &fallback_cwd);
+        let thread = summary_to_thread(summary, &fallback_cwd);
 
         assert_eq!(thread.agent_nickname, Some("atlas".to_string()));
         assert_eq!(thread.agent_role, Some("explorer".to_string()));

--- a/codex-rs/app-server/src/request_processors/thread_processor_tests.rs
+++ b/codex-rs/app-server/src/request_processors/thread_processor_tests.rs
@@ -962,7 +962,7 @@ mod thread_processor_behavior_tests {
 
         let summary = read_summary_from_rollout(path.as_path(), "fallback").await?;
         let fallback_cwd = AbsolutePathBuf::from_absolute_path("/")?;
-        let thread = summary_to_thread(summary, &fallback_cwd);
+        let thread = summary_to_thread(summary, conversation_id.to_string(), &fallback_cwd);
 
         assert_eq!(thread.agent_nickname, Some("atlas".to_string()));
         assert_eq!(thread.agent_role, Some("explorer".to_string()));
@@ -1102,7 +1102,7 @@ mod thread_processor_behavior_tests {
         );
 
         let fallback_cwd = AbsolutePathBuf::from_absolute_path("/")?;
-        let thread = summary_to_thread(summary, &fallback_cwd);
+        let thread = summary_to_thread(summary, conversation_id.to_string(), &fallback_cwd);
 
         assert_eq!(thread.agent_nickname, Some("atlas".to_string()));
         assert_eq!(thread.agent_role, Some("explorer".to_string()));

--- a/codex-rs/app-server/src/request_processors/thread_summary.rs
+++ b/codex-rs/app-server/src/request_processors/thread_summary.rs
@@ -231,6 +231,7 @@ pub(super) fn thread_started_notification(mut thread: Thread) -> ThreadStartedNo
 
 pub(crate) fn summary_to_thread(
     summary: ConversationSummary,
+    session_id: String,
     fallback_cwd: &AbsolutePathBuf,
 ) -> Thread {
     let ConversationSummary {
@@ -265,7 +266,7 @@ pub(crate) fn summary_to_thread(
 
     Thread {
         id: conversation_id.to_string(),
-        session_id: None,
+        session_id,
         forked_from_id: None,
         preview,
         ephemeral: false,

--- a/codex-rs/app-server/src/request_processors/thread_summary.rs
+++ b/codex-rs/app-server/src/request_processors/thread_summary.rs
@@ -231,7 +231,6 @@ pub(super) fn thread_started_notification(mut thread: Thread) -> ThreadStartedNo
 
 pub(crate) fn summary_to_thread(
     summary: ConversationSummary,
-    session_id: String,
     fallback_cwd: &AbsolutePathBuf,
 ) -> Thread {
     let ConversationSummary {
@@ -264,9 +263,10 @@ pub(crate) fn summary_to_thread(
                 fallback_cwd.clone()
             });
 
+    let thread_id = conversation_id.to_string();
     Thread {
-        id: conversation_id.to_string(),
-        session_id,
+        id: thread_id.clone(),
+        session_id: thread_id,
         forked_from_id: None,
         preview,
         ephemeral: false,

--- a/codex-rs/app-server/src/request_processors/thread_summary.rs
+++ b/codex-rs/app-server/src/request_processors/thread_summary.rs
@@ -265,6 +265,7 @@ pub(crate) fn summary_to_thread(
 
     Thread {
         id: conversation_id.to_string(),
+        session_id: None,
         forked_from_id: None,
         preview,
         ephemeral: false,

--- a/codex-rs/app-server/src/request_processors/turn_processor.rs
+++ b/codex-rs/app-server/src/request_processors/turn_processor.rs
@@ -933,8 +933,12 @@ impl TurnRequestProcessor {
             .await
         {
             Ok(stored_thread) => {
-                let (mut thread, _) =
-                    thread_from_stored_thread(stored_thread, fallback_provider, &self.config.cwd);
+                let (mut thread, _) = thread_from_stored_thread(
+                    stored_thread,
+                    review_thread.session_configured().session_id.to_string(),
+                    fallback_provider,
+                    &self.config.cwd,
+                );
                 self.thread_watch_manager
                     .upsert_thread_silently(thread.clone())
                     .await;

--- a/codex-rs/app-server/src/request_processors/turn_processor.rs
+++ b/codex-rs/app-server/src/request_processors/turn_processor.rs
@@ -933,12 +933,9 @@ impl TurnRequestProcessor {
             .await
         {
             Ok(stored_thread) => {
-                let (mut thread, _) = thread_from_stored_thread(
-                    stored_thread,
-                    review_thread.session_configured().session_id.to_string(),
-                    fallback_provider,
-                    &self.config.cwd,
-                );
+                let (mut thread, _) =
+                    thread_from_stored_thread(stored_thread, fallback_provider, &self.config.cwd);
+                thread.session_id = review_thread.session_configured().session_id.to_string();
                 self.thread_watch_manager
                     .upsert_thread_silently(thread.clone())
                     .await;

--- a/codex-rs/app-server/src/thread_status.rs
+++ b/codex-rs/app-server/src/thread_status.rs
@@ -889,7 +889,7 @@ mod tests {
     fn test_thread(thread_id: &str, source: codex_app_server_protocol::SessionSource) -> Thread {
         Thread {
             id: thread_id.to_string(),
-            session_id: Some(thread_id.to_string()),
+            session_id: thread_id.to_string(),
             forked_from_id: None,
             preview: String::new(),
             ephemeral: false,

--- a/codex-rs/app-server/src/thread_status.rs
+++ b/codex-rs/app-server/src/thread_status.rs
@@ -889,6 +889,7 @@ mod tests {
     fn test_thread(thread_id: &str, source: codex_app_server_protocol::SessionSource) -> Thread {
         Thread {
             id: thread_id.to_string(),
+            session_id: Some(thread_id.to_string()),
             forked_from_id: None,
             preview: String::new(),
             ephemeral: false,

--- a/codex-rs/app-server/tests/suite/v2/review.rs
+++ b/codex-rs/app-server/tests/suite/v2/review.rs
@@ -363,6 +363,7 @@ async fn review_start_with_detached_delivery_returns_new_thread_id() -> Result<(
     let started: ThreadStartedNotification =
         serde_json::from_value(notification.params.expect("params must be present"))?;
     assert_eq!(started.thread.id, review_thread_id);
+    assert_eq!(started.thread.session_id, review_thread_id);
 
     Ok(())
 }

--- a/codex-rs/app-server/tests/suite/v2/thread_fork.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_fork.rs
@@ -101,9 +101,7 @@ async fn thread_fork_creates_new_thread_and_emits_started() -> Result<()> {
     )
     .await??;
     let fork_result = fork_resp.result.clone();
-    let ThreadForkResponse {
-        session_id, thread, ..
-    } = to_response::<ThreadForkResponse>(fork_resp)?;
+    let ThreadForkResponse { thread, .. } = to_response::<ThreadForkResponse>(fork_resp)?;
 
     // Wire contract: thread title field is `name`, serialized as null when unset.
     let thread_json = fork_result
@@ -111,9 +109,19 @@ async fn thread_fork_creates_new_thread_and_emits_started() -> Result<()> {
         .and_then(Value::as_object)
         .expect("thread/fork result.thread must be an object");
     assert_eq!(
+        thread_json.get("sessionId").and_then(Value::as_str),
+        thread.session_id.as_deref(),
+        "forked threads should serialize `sessionId` on the thread object"
+    );
+    assert_eq!(
         thread_json.get("name"),
         Some(&Value::Null),
         "forked threads do not inherit a name; expected `name: null`"
+    );
+    assert_eq!(
+        fork_result.get("sessionId"),
+        None,
+        "thread/fork should not serialize a top-level `sessionId`"
     );
 
     let after_contents = std::fs::read_to_string(&original_path)?;
@@ -123,7 +131,7 @@ async fn thread_fork_creates_new_thread_and_emits_started() -> Result<()> {
     );
 
     assert_ne!(thread.id, conversation_id);
-    assert_eq!(session_id, thread.id);
+    assert_eq!(thread.session_id, Some(thread.id.clone()));
     assert_eq!(thread.forked_from_id, Some(conversation_id.clone()));
     assert_eq!(thread.preview, preview);
     assert_eq!(thread.model_provider, "mock_provider");

--- a/codex-rs/app-server/tests/suite/v2/thread_fork.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_fork.rs
@@ -110,7 +110,7 @@ async fn thread_fork_creates_new_thread_and_emits_started() -> Result<()> {
         .expect("thread/fork result.thread must be an object");
     assert_eq!(
         thread_json.get("sessionId").and_then(Value::as_str),
-        thread.session_id.as_deref(),
+        Some(thread.session_id.as_str()),
         "forked threads should serialize `sessionId` on the thread object"
     );
     assert_eq!(
@@ -131,7 +131,7 @@ async fn thread_fork_creates_new_thread_and_emits_started() -> Result<()> {
     );
 
     assert_ne!(thread.id, conversation_id);
-    assert_eq!(thread.session_id, Some(thread.id.clone()));
+    assert_eq!(thread.session_id, thread.id);
     assert_eq!(thread.forked_from_id, Some(conversation_id.clone()));
     assert_eq!(thread.preview, preview);
     assert_eq!(thread.model_provider, "mock_provider");

--- a/codex-rs/app-server/tests/suite/v2/thread_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_list.rs
@@ -843,7 +843,7 @@ async fn thread_list_filters_by_source_kind_subagent_thread_spawn() -> Result<()
         /*git_info*/ None,
     )?;
 
-    let parent_thread_id = ThreadId::from_string(&cli_id)?;
+    let parent_thread_id = ThreadId::from_string(&Uuid::new_v4().to_string())?;
     let subagent_id = create_fake_rollout_with_source(
         codex_home.path(),
         "2025-02-01T11-00-00",
@@ -879,7 +879,7 @@ async fn thread_list_filters_by_source_kind_subagent_thread_spawn() -> Result<()
     assert_eq!(ids, vec![subagent_id.as_str()]);
     assert_ne!(cli_id, subagent_id);
     assert!(matches!(data[0].source, SessionSource::SubAgent(_)));
-    assert_eq!(data[0].session_id, cli_id);
+    assert_eq!(data[0].session_id, subagent_id);
 
     Ok(())
 }

--- a/codex-rs/app-server/tests/suite/v2/thread_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_list.rs
@@ -843,7 +843,7 @@ async fn thread_list_filters_by_source_kind_subagent_thread_spawn() -> Result<()
         /*git_info*/ None,
     )?;
 
-    let parent_thread_id = ThreadId::from_string(&Uuid::new_v4().to_string())?;
+    let parent_thread_id = ThreadId::from_string(&cli_id)?;
     let subagent_id = create_fake_rollout_with_source(
         codex_home.path(),
         "2025-02-01T11-00-00",
@@ -879,6 +879,7 @@ async fn thread_list_filters_by_source_kind_subagent_thread_spawn() -> Result<()
     assert_eq!(ids, vec![subagent_id.as_str()]);
     assert_ne!(cli_id, subagent_id);
     assert!(matches!(data[0].source, SessionSource::SubAgent(_)));
+    assert_eq!(data[0].session_id, cli_id);
 
     Ok(())
 }

--- a/codex-rs/app-server/tests/suite/v2/thread_metadata_update.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_metadata_update.rs
@@ -77,6 +77,7 @@ async fn thread_metadata_update_patches_git_branch_and_returns_updated_thread() 
         to_response::<ThreadMetadataUpdateResponse>(update_resp)?;
 
     assert_eq!(updated.id, thread.id);
+    assert_eq!(updated.session_id, thread.session_id);
     assert_eq!(
         updated.git_info,
         Some(GitInfo {
@@ -90,6 +91,10 @@ async fn thread_metadata_update_patches_git_branch_and_returns_updated_thread() 
         .get("thread")
         .and_then(Value::as_object)
         .expect("thread/metadata/update result.thread must be an object");
+    assert_eq!(
+        updated_thread_json.get("sessionId").and_then(Value::as_str),
+        Some(thread.session_id.as_str())
+    );
     let updated_git_info_json = updated_thread_json
         .get("gitInfo")
         .and_then(Value::as_object)

--- a/codex-rs/app-server/tests/suite/v2/thread_resume.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_resume.rs
@@ -272,7 +272,7 @@ async fn thread_resume_tracks_thread_initialized_analytics() -> Result<()> {
     .await??;
     let ThreadResumeResponse { thread, .. } = to_response::<ThreadResumeResponse>(resume_resp)?;
     assert!(
-        thread.session_id.as_ref().is_some_and(|id| !id.is_empty()),
+        !thread.session_id.is_empty(),
         "session id should not be empty"
     );
     assert_eq!(thread.thread_source, Some(ThreadSource::User));

--- a/codex-rs/app-server/tests/suite/v2/thread_resume.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_resume.rs
@@ -270,10 +270,11 @@ async fn thread_resume_tracks_thread_initialized_analytics() -> Result<()> {
         mcp.read_stream_until_response_message(RequestId::Integer(resume_id)),
     )
     .await??;
-    let ThreadResumeResponse {
-        session_id, thread, ..
-    } = to_response::<ThreadResumeResponse>(resume_resp)?;
-    assert!(!session_id.is_empty(), "session id should not be empty");
+    let ThreadResumeResponse { thread, .. } = to_response::<ThreadResumeResponse>(resume_resp)?;
+    assert!(
+        thread.session_id.as_ref().is_some_and(|id| !id.is_empty()),
+        "session id should not be empty"
+    );
     assert_eq!(thread.thread_source, Some(ThreadSource::User));
 
     let payload = wait_for_analytics_payload(&server, DEFAULT_READ_TIMEOUT).await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_rollback.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_rollback.rs
@@ -119,10 +119,15 @@ async fn thread_rollback_drops_last_turns_and_persists_to_rollout() -> Result<()
         .and_then(Value::as_object)
         .expect("thread/rollback result.thread must be an object");
     assert_eq!(rolled_back_thread.name, None);
+    assert_eq!(rolled_back_thread.session_id, thread.session_id);
     assert_eq!(
         thread_json.get("name"),
         Some(&Value::Null),
         "thread/rollback must serialize `name: null` when unset"
+    );
+    assert_eq!(
+        thread_json.get("sessionId").and_then(Value::as_str),
+        Some(thread.session_id.as_str())
     );
 
     assert_eq!(rolled_back_thread.turns.len(), 1);

--- a/codex-rs/app-server/tests/suite/v2/thread_start.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_start.rs
@@ -126,7 +126,7 @@ async fn thread_start_creates_thread_and_emits_started() -> Result<()> {
         ..
     } = to_response::<ThreadStartResponse>(resp)?;
     assert!(
-        thread.session_id.as_ref().is_some_and(|id| !id.is_empty()),
+        !thread.session_id.is_empty(),
         "session id should not be empty"
     );
     assert!(!thread.id.is_empty(), "thread id should not be empty");
@@ -159,7 +159,7 @@ async fn thread_start_creates_thread_and_emits_started() -> Result<()> {
         .expect("thread/start result.thread must be an object");
     assert_eq!(
         thread_json.get("sessionId").and_then(Value::as_str),
-        thread.session_id.as_deref(),
+        Some(thread.session_id.as_str()),
         "new threads should serialize `sessionId` on the thread object"
     );
     assert_eq!(

--- a/codex-rs/app-server/tests/suite/v2/thread_start.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_start.rs
@@ -121,12 +121,14 @@ async fn thread_start_creates_thread_and_emits_started() -> Result<()> {
     .await??;
     let resp_result = resp.result.clone();
     let ThreadStartResponse {
-        session_id,
         thread,
         model_provider,
         ..
     } = to_response::<ThreadStartResponse>(resp)?;
-    assert!(!session_id.is_empty(), "session id should not be empty");
+    assert!(
+        thread.session_id.as_ref().is_some_and(|id| !id.is_empty()),
+        "session id should not be empty"
+    );
     assert!(!thread.id.is_empty(), "thread id should not be empty");
     assert!(
         thread.preview.is_empty(),
@@ -156,9 +158,19 @@ async fn thread_start_creates_thread_and_emits_started() -> Result<()> {
         .and_then(Value::as_object)
         .expect("thread/start result.thread must be an object");
     assert_eq!(
+        thread_json.get("sessionId").and_then(Value::as_str),
+        thread.session_id.as_deref(),
+        "new threads should serialize `sessionId` on the thread object"
+    );
+    assert_eq!(
         thread_json.get("name"),
         Some(&Value::Null),
         "new threads should serialize `name: null`"
+    );
+    assert_eq!(
+        resp_result.get("sessionId"),
+        None,
+        "thread/start should not serialize a top-level `sessionId`"
     );
     assert_eq!(
         thread_json.get("ephemeral").and_then(Value::as_bool),

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -1060,7 +1060,7 @@ fn session_configured_from_thread_start_response(
     config: &Config,
 ) -> Result<SessionConfiguredEvent, String> {
     session_configured_from_thread_response(
-        &response.session_id,
+        &response.thread.session_id,
         &response.thread.id,
         response.thread.name.clone(),
         response.thread.path.clone(),
@@ -1085,7 +1085,7 @@ fn session_configured_from_thread_resume_response(
     config: &Config,
 ) -> Result<SessionConfiguredEvent, String> {
     session_configured_from_thread_response(
-        &response.session_id,
+        &response.thread.session_id,
         &response.thread.id,
         response.thread.name.clone(),
         response.thread.path.clone(),

--- a/codex-rs/exec/src/lib_tests.rs
+++ b/codex-rs/exec/src/lib_tests.rs
@@ -244,6 +244,7 @@ async fn resume_lookup_model_providers_filters_only_last_lookup() {
 fn turn_items_for_thread_returns_matching_turn_items() {
     let thread = AppServerThread {
         id: "thread-1".to_string(),
+        session_id: "thread-1".to_string(),
         forked_from_id: None,
         preview: String::new(),
         ephemeral: false,
@@ -473,9 +474,9 @@ async fn session_configured_from_thread_response_uses_permission_profile_from_re
 
 fn sample_thread_start_response() -> ThreadStartResponse {
     ThreadStartResponse {
-        session_id: "67e55044-10b1-426f-9247-bb680e5fe0c7".to_string(),
         thread: codex_app_server_protocol::Thread {
             id: "67e55044-10b1-426f-9247-bb680e5fe0c8".to_string(),
+            session_id: "67e55044-10b1-426f-9247-bb680e5fe0c7".to_string(),
             forked_from_id: None,
             preview: String::new(),
             ephemeral: false,

--- a/codex-rs/tui/src/app/loaded_threads.rs
+++ b/codex-rs/tui/src/app/loaded_threads.rs
@@ -118,6 +118,7 @@ mod tests {
     fn test_thread(thread_id: ThreadId, source: SessionSource) -> Thread {
         Thread {
             id: thread_id.to_string(),
+            session_id: thread_id.to_string(),
             forked_from_id: None,
             preview: String::new(),
             ephemeral: false,

--- a/codex-rs/tui/src/app/tests.rs
+++ b/codex-rs/tui/src/app/tests.rs
@@ -2940,6 +2940,7 @@ async fn inactive_thread_started_notification_initializes_replay_session() -> Re
         ServerNotification::ThreadStarted(ThreadStartedNotification {
             thread: Thread {
                 id: agent_thread_id.to_string(),
+                session_id: agent_thread_id.to_string(),
                 forked_from_id: None,
                 preview: "agent thread".to_string(),
                 ephemeral: false,
@@ -3022,6 +3023,7 @@ async fn inactive_thread_started_notification_preserves_primary_model_when_path_
         ServerNotification::ThreadStarted(ThreadStartedNotification {
             thread: Thread {
                 id: agent_thread_id.to_string(),
+                session_id: agent_thread_id.to_string(),
                 forked_from_id: None,
                 preview: "agent thread".to_string(),
                 ephemeral: false,
@@ -3077,6 +3079,7 @@ async fn thread_read_session_state_does_not_reuse_primary_permission_profile() {
 
     let thread = Thread {
         id: read_thread_id.to_string(),
+        session_id: read_thread_id.to_string(),
         forked_from_id: None,
         preview: "read thread".to_string(),
         ephemeral: false,
@@ -5041,6 +5044,7 @@ async fn thread_rollback_response_discards_queued_active_thread_events() {
         &ThreadRollbackResponse {
             thread: Thread {
                 id: thread_id.to_string(),
+                session_id: thread_id.to_string(),
                 forked_from_id: None,
                 preview: String::new(),
                 ephemeral: false,

--- a/codex-rs/tui/src/app/thread_session_state.rs
+++ b/codex-rs/tui/src/app/thread_session_state.rs
@@ -322,6 +322,7 @@ mod tests {
         };
         let read_thread = Thread {
             id: read_thread_id.to_string(),
+            session_id: read_thread_id.to_string(),
             forked_from_id: None,
             preview: "read thread".to_string(),
             ephemeral: false,

--- a/codex-rs/tui/src/app_server_session.rs
+++ b/codex-rs/tui/src/app_server_session.rs
@@ -1813,9 +1813,9 @@ mod tests {
         let forked_from_id = ThreadId::new();
         let read_only_profile = PermissionProfile::read_only();
         let response = ThreadResumeResponse {
-            session_id: ThreadId::new().to_string(),
             thread: codex_app_server_protocol::Thread {
                 id: thread_id.to_string(),
+                session_id: ThreadId::new().to_string(),
                 forked_from_id: Some(forked_from_id.to_string()),
                 preview: "hello".to_string(),
                 ephemeral: false,

--- a/codex-rs/tui/src/resume_picker.rs
+++ b/codex-rs/tui/src/resume_picker.rs
@@ -5684,6 +5684,7 @@ session_picker_view = "dense"
         let thread_id = ThreadId::new();
         let thread = Thread {
             id: thread_id.to_string(),
+            session_id: thread_id.to_string(),
             forked_from_id: None,
             preview: String::from("remote thread"),
             ephemeral: false,
@@ -5717,6 +5718,7 @@ session_picker_view = "dense"
         let thread_id = ThreadId::new();
         let thread = Thread {
             id: thread_id.to_string(),
+            session_id: thread_id.to_string(),
             forked_from_id: None,
             preview: String::from("preview"),
             ephemeral: false,
@@ -5783,6 +5785,7 @@ session_picker_view = "dense"
         let thread_id = ThreadId::new();
         let thread = Thread {
             id: thread_id.to_string(),
+            session_id: thread_id.to_string(),
             forked_from_id: None,
             preview: String::from("preview"),
             ephemeral: false,
@@ -5839,6 +5842,7 @@ session_picker_view = "dense"
         let thread_id = ThreadId::new();
         let thread = Thread {
             id: thread_id.to_string(),
+            session_id: thread_id.to_string(),
             forked_from_id: None,
             preview: String::from("preview"),
             ephemeral: false,


### PR DESCRIPTION
## Why

`session_id` and `thread_id` are separate identities after #20437, but app-server only surfaced `sessionId` on the `thread/start`, `thread/resume`, and `thread/fork` response envelopes. Other thread-bearing surfaces such as `thread/list`, `thread/read`, `thread/started`, `thread/rollback`, `thread/metadata/update`, and `thread/unarchive` either lacked the grouping key or forced clients to special-case those three responses.

Making `sessionId` part of the reusable `Thread` payload gives every v2 API surface one place to expose session-tree identity.

## Mental model
  1. thread.sessionId lives on `Thread`
  2. It is a view/runtime identity for the current live session tree, not durable stored lineage metadata
  3. When app-server has a live loaded thread, it copies the real value from core’s session_configured.session_id
  4. When it only has stored/unloaded data, it falls back to thread.sessionId = thread.id

## What changed

- Added `sessionId` to the v2 [`Thread`](https://github.com/openai/codex/blob/8fc9e9b4cf81b6f61d432e71f1eb266f6f104b63/codex-rs/app-server-protocol/src/protocol/v2/thread_data.rs#L105-L109).
- Removed the duplicate top-level `sessionId` fields from `thread/start`, `thread/resume`, and `thread/fork`; clients should now read `response.thread.sessionId`.
- Populated `thread.sessionId` when building live thread responses, replaying loaded threads, and returning stored-thread summaries so the field is present across start, resume, fork, list, read, rollback, metadata-update, unarchive, and `thread/started` paths. See [`load_thread_from_resume_source_or_send_internal`](https://github.com/openai/codex/blob/8fc9e9b4cf81b6f61d432e71f1eb266f6f104b63/codex-rs/app-server/src/request_processors/thread_processor.rs#L2824-L2918) and [`thread_from_stored_thread`](https://github.com/openai/codex/blob/8fc9e9b4cf81b6f61d432e71f1eb266f6f104b63/codex-rs/app-server/src/request_processors/thread_processor.rs#L3671-L3719).
- Preserved the stored-thread fallback: if a thread has not been loaded into a live session tree yet, `thread.sessionId` falls back to `thread.id`; once the thread is live again, the field reports the active session tree root.
- Regenerated the JSON/TypeScript schemas and updated the app-server README examples to show [`thread.sessionId`](https://github.com/openai/codex/blob/8fc9e9b4cf81b6f61d432e71f1eb266f6f104b63/codex-rs/app-server/README.md#L306-L310) on the thread object.