### PR TITLE
[codex] fix builtin MCP Windows path test

### DIFF
--- a/codex-rs/builtin-mcps/src/lib.rs
+++ b/codex-rs/builtin-mcps/src/lib.rs
@@ -109,7 +109,7 @@ mod tests {
                     "builtin-mcp".to_string(),
                     "memories".to_string(),
                     "--codex-home".to_string(),
-                    "/tmp/codex-home".to_string(),
+                    codex_home.as_path().to_string_lossy().into_owned(),
                 ],
                 env: None,
                 env_vars: Vec::new(),


### PR DESCRIPTION
## Summary
- make the builtin MCP config test derive the expected `--codex-home` argument from `AbsolutePathBuf`

## Why
`AbsolutePathBuf::try_from("/tmp/codex-home")` is rendered as `D:\\tmp\\codex-home` on Windows, but the test asserted the Unix literal `"/tmp/codex-home"`. That made the Windows Bazel job fail even though the production code was behaving correctly.

## Impact
This keeps the test cross-platform while preserving the same transport assertion on Unix and Windows.

## Validation
- `cargo test -p codex-builtin-mcps`
