### PR TITLE
feat: move auto vaccum

### DIFF
--- a/codex-rs/state/src/runtime.rs
+++ b/codex-rs/state/src/runtime.rs
@@ -172,28 +172,15 @@ fn base_sqlite_options(path: &Path) -> SqliteConnectOptions {
 }
 
 async fn open_state_sqlite(path: &Path, migrator: &Migrator) -> anyhow::Result<SqlitePool> {
+    // New state DBs should use incremental auto-vacuum, but retrofitting an
+    // existing DB requires a full VACUUM. Do not attempt that during process
+    // startup: it is maintenance work that can contend with foreground writers.
     let options = base_sqlite_options(path).auto_vacuum(SqliteAutoVacuum::Incremental);
     let pool = SqlitePoolOptions::new()
         .max_connections(5)
         .connect_with(options)
         .await?;
     migrator.run(&pool).await?;
-    let auto_vacuum = sqlx::query_scalar::<_, i64>("PRAGMA auto_vacuum")
-        .fetch_one(&pool)
-        .await?;
-    if auto_vacuum != SqliteAutoVacuum::Incremental as i64 {
-        // Existing state DBs need one non-transactional `VACUUM` before
-        // SQLite persists `auto_vacuum = INCREMENTAL` in the database header.
-        sqlx::query("PRAGMA auto_vacuum = INCREMENTAL")
-            .execute(&pool)
-            .await?;
-        // We do it on best effort. If the lock can't be acquired, it will be done at next run.
-        let _ = sqlx::query("VACUUM").execute(&pool).await;
-    }
-    // We do it on best effort. If the lock can't be acquired, it will be done at next run.
-    let _ = sqlx::query("PRAGMA incremental_vacuum")
-        .execute(&pool)
-        .await;
     Ok(pool)
 }
 

--- a/codex-rs/state/src/runtime/logs.rs
+++ b/codex-rs/state/src/runtime/logs.rs
@@ -300,10 +300,10 @@ WHERE id IN (
             return Ok(());
         };
         self.delete_logs_before(cutoff.timestamp()).await?;
-        sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
-            .execute(self.logs_pool.as_ref())
-            .await?;
-        sqlx::query("PRAGMA incremental_vacuum")
+        // Startup cleanup should not wait behind or block foreground work.
+        // PASSIVE checkpoints copy whatever is immediately available and skip
+        // frames that would require waiting on active readers or writers.
+        sqlx::query("PRAGMA wal_checkpoint(PASSIVE)")
             .execute(self.logs_pool.as_ref())
             .await?;
         Ok(())


### PR DESCRIPTION
The initial vaccum is not needed anymore. We can consider all the DBs have been reclaimed by now