### PR TITLE
[codex] Fix core test support Cargo dependency

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -4261,6 +4261,7 @@ dependencies = [
  "reqwest",
  "serde_json",
  "shlex",
+ "similar",
  "tempfile",
  "tokio",
  "tokio-tungstenite",

--- a/codex-rs/core/tests/common/Cargo.toml
+++ b/codex-rs/core/tests/common/Cargo.toml
@@ -33,6 +33,7 @@ opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true }
 regex-lite = { workspace = true }
 serde_json = { workspace = true }
+similar = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["net", "time"] }
 tokio-tungstenite = { workspace = true }


### PR DESCRIPTION
## Summary

- add the missing `similar` workspace dependency to `core_test_support`
- update `codex-rs/Cargo.lock` so the test-support package dependency set matches the manifest

## Root Cause

The post-merge `rust-ci-full` run compiles `core_test_support` through Cargo with `--tests`. `context_snapshot.rs` uses `similar::{ChangeTag, TextDiff}`, but `codex-rs/core/tests/common/Cargo.toml` did not declare `similar`. Bazel passed because `codex-rs/core/tests/common/BUILD.bazel` already lists `@crates//:similar`.

## Validation

- `cargo check -p core_test_support`
- `cargo clippy -p core_test_support --tests -- -D warnings`
- `cargo test -p core_test_support`
- `just bazel-lock-update`
- `just bazel-lock-check`
- `git diff --check`
