### PR TITLE
[codex] Reject full-history spawn overrides

### DIFF
--- a/codex-rs/core/root_agent_prompt.md
+++ b/codex-rs/core/root_agent_prompt.md
@@ -25,7 +25,7 @@ a near-duplicate. Use `followup_task` when the agent is already working on the s
 
 ## Forking agents
 
-When calling `spawn_agent`, the `fork_turns` argument only determines the initial context of the agent. `"fork_turns":"all"` gives the new agent the entire conversation up to the fork point. `"fork_turns":"none"` gives the new agent only the message you provide. All subagents can call tools and inherit your working directory.
+When calling `spawn_agent`, the `fork_turns` argument only determines the initial context of the agent. `"fork_turns":"all"` gives the new agent the entire conversation up to the fork point. `"fork_turns":"none"` gives the new agent only the message you provide. Full-history forks inherit the parent role/model configuration, so use `"fork_turns":"none"` or a positive integer when setting `agent_type`, `model`, or `reasoning_effort`. All subagents can call tools and inherit your working directory.
 
 Forked agents are a superpower, answering the thought experiment, "What would you do if you could clone yourself?" They have all of the context of the user's messages, your messages, tool calls and results, they know everything you know from the point they are forked. When spawning an agent, always explicitly provide a `fork_turns` value; default to `"fork_turns":"all"` for subagents unless you need less context.
 

--- a/codex-rs/core/src/tools/handlers/multi_agents_tests.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_tests.rs
@@ -119,27 +119,6 @@ fn thread_manager() -> ThreadManager {
     )
 }
 
-async fn spawned_thread_id_after(
-    manager: &ThreadManager,
-    before_thread_ids: &[ThreadId],
-) -> ThreadId {
-    let mut spawned_thread_ids = manager
-        .list_thread_ids()
-        .await
-        .into_iter()
-        .filter(|thread_id| !before_thread_ids.contains(thread_id))
-        .collect::<Vec<_>>();
-    spawned_thread_ids.sort_by_key(ToString::to_string);
-    assert_eq!(
-        spawned_thread_ids.len(),
-        1,
-        "spawn_agent should add exactly one child thread"
-    );
-    spawned_thread_ids
-        .pop()
-        .expect("spawned thread id should be present")
-}
-
 async fn install_role_with_model_override(turn: &mut TurnContext) -> String {
     let role_name = "fork-context-role".to_string();
     tokio::fs::create_dir_all(&turn.config.codex_home)
@@ -426,13 +405,8 @@ async fn spawn_agent_fork_context_ignores_child_model_overrides() {
 }
 
 #[test]
-fn multi_agent_v2_spawn_fork_turns_all_ignores_agent_type_override() {
+fn multi_agent_v2_spawn_fork_turns_all_rejects_agent_type_override() {
     run_large_stack_async(|| async {
-        #[derive(Debug, Deserialize)]
-        struct SpawnAgentResult {
-            task_name: String,
-        }
-
         let (mut session, mut turn) = make_session_and_context().await;
         let role_name = install_role_with_model_override(&mut turn).await;
         let manager = thread_manager();
@@ -455,7 +429,7 @@ fn multi_agent_v2_spawn_fork_turns_all_ignores_agent_type_override() {
         let session = Arc::new(session);
         let turn = Arc::new(turn);
 
-        let output = SpawnAgentHandlerV2
+        let err = SpawnAgentHandlerV2
             .handle(invocation(
                 session.clone(),
                 turn,
@@ -468,32 +442,21 @@ fn multi_agent_v2_spawn_fork_turns_all_ignores_agent_type_override() {
                 })),
             ))
             .await
-            .expect("fork_turns=all should ignore agent_type overrides");
-        let (content, _) = expect_text_output(output);
-        let result: SpawnAgentResult =
-            serde_json::from_str(&content).expect("spawn_agent result should be json");
-        assert_eq!(result.task_name, "/root/fork_context_v2");
-        let agent_id = spawned_thread_id_after(&manager, &before_thread_ids).await;
-        let snapshot = manager
-            .get_thread(agent_id)
-            .await
-            .expect("spawned agent thread should exist")
-            .config_snapshot()
-            .await;
-        assert_ne!(snapshot.model, "gpt-5-role-override");
-        assert_ne!(snapshot.model_provider_id, "ollama");
-        assert_eq!(snapshot.session_source.get_agent_role(), None);
+            .expect_err("fork_turns=all should reject unapplied agent_type overrides");
+
+        assert_eq!(
+            err,
+            FunctionCallError::RespondToModel(
+                "fork_turns=`all` cannot be combined with agent_type, model, or reasoning_effort because full-history forks inherit the parent configuration. Use fork_turns=`none` or a positive integer to apply child overrides.".to_string()
+            )
+        );
+        assert_eq!(manager.list_thread_ids().await, before_thread_ids);
     });
 }
 
 #[test]
-fn multi_agent_v2_spawn_defaults_to_full_fork_and_ignores_child_model_overrides() {
+fn multi_agent_v2_spawn_defaults_to_full_fork_rejects_child_model_overrides() {
     run_large_stack_async(|| async {
-        #[derive(Debug, Deserialize)]
-        struct SpawnAgentResult {
-            task_name: String,
-        }
-
         let (mut session, mut turn) = make_session_and_context().await;
         let manager = thread_manager();
         let root = manager
@@ -502,7 +465,6 @@ fn multi_agent_v2_spawn_defaults_to_full_fork_and_ignores_child_model_overrides(
             .expect("root thread should start");
         session.services.agent_control = manager.agent_control();
         session.conversation_id = root.thread_id;
-        let parent_reasoning_effort = turn.config.model_reasoning_effort;
         let before_thread_ids = manager.list_thread_ids().await;
         let mut config = (*turn.config).clone();
         config
@@ -513,7 +475,7 @@ fn multi_agent_v2_spawn_defaults_to_full_fork_and_ignores_child_model_overrides(
         let session = Arc::new(session);
         let turn = Arc::new(turn);
 
-        let output = SpawnAgentHandlerV2
+        let err = SpawnAgentHandlerV2
             .handle(invocation(
                 session.clone(),
                 turn,
@@ -526,20 +488,15 @@ fn multi_agent_v2_spawn_defaults_to_full_fork_and_ignores_child_model_overrides(
                 })),
             ))
             .await
-            .expect("default full fork should ignore child model overrides");
-        let (content, _) = expect_text_output(output);
-        let result: SpawnAgentResult =
-            serde_json::from_str(&content).expect("spawn_agent result should be json");
-        assert_eq!(result.task_name, "/root/fork_context_v2");
-        let agent_id = spawned_thread_id_after(&manager, &before_thread_ids).await;
-        let snapshot = manager
-            .get_thread(agent_id)
-            .await
-            .expect("spawned agent thread should exist")
-            .config_snapshot()
-            .await;
-        assert_ne!(snapshot.model, "gpt-5-child-override");
-        assert_eq!(snapshot.reasoning_effort, parent_reasoning_effort);
+            .expect_err("default full fork should reject unapplied model overrides");
+
+        assert_eq!(
+            err,
+            FunctionCallError::RespondToModel(
+                "fork_turns=`all` cannot be combined with agent_type, model, or reasoning_effort because full-history forks inherit the parent configuration. Use fork_turns=`none` or a positive integer to apply child overrides.".to_string()
+            )
+        );
+        assert_eq!(manager.list_thread_ids().await, before_thread_ids);
     });
 }
 
@@ -1563,107 +1520,109 @@ async fn spawn_agent_errors_when_manager_dropped() {
     );
 }
 
-#[tokio::test]
-async fn multi_agent_v2_spawn_returns_path_and_send_message_accepts_relative_path() {
-    #[derive(Debug, Deserialize)]
-    struct SpawnAgentResult {
-        task_name: String,
-        nickname: Option<String>,
-    }
+#[test]
+fn multi_agent_v2_spawn_returns_path_and_send_message_accepts_relative_path() {
+    run_large_stack_async(|| async {
+        #[derive(Debug, Deserialize)]
+        struct SpawnAgentResult {
+            task_name: String,
+            nickname: Option<String>,
+        }
 
-    let (mut session, mut turn) = make_session_and_context().await;
-    let manager = thread_manager();
-    let root = manager
-        .start_thread((*turn.config).clone())
-        .await
-        .expect("root thread should start");
-    session.services.agent_control = manager.agent_control();
-    session.conversation_id = root.thread_id;
-    let mut config = (*turn.config).clone();
-    config
-        .features
-        .enable(Feature::MultiAgentV2)
-        .expect("test config should allow feature update");
-    turn.config = Arc::new(config);
+        let (mut session, mut turn) = make_session_and_context().await;
+        let manager = thread_manager();
+        let root = manager
+            .start_thread((*turn.config).clone())
+            .await
+            .expect("root thread should start");
+        session.services.agent_control = manager.agent_control();
+        session.conversation_id = root.thread_id;
+        let mut config = (*turn.config).clone();
+        config
+            .features
+            .enable(Feature::MultiAgentV2)
+            .expect("test config should allow feature update");
+        turn.config = Arc::new(config);
 
-    let session = Arc::new(session);
-    let turn = Arc::new(turn);
-    let spawn_output = SpawnAgentHandlerV2
-        .handle(invocation(
-            session.clone(),
-            turn.clone(),
-            "spawn_agent",
-            function_payload(json!({
-                "message": "inspect this repo",
-                "task_name": "test_process"
-            })),
-        ))
-        .await
-        .expect("spawn_agent should succeed");
-    let (content, _) = expect_text_output(spawn_output);
-    let spawn_result: SpawnAgentResult =
-        serde_json::from_str(&content).expect("spawn result should parse");
-    assert_eq!(spawn_result.task_name, "/root/test_process");
-    assert!(spawn_result.nickname.is_some());
+        let session = Arc::new(session);
+        let turn = Arc::new(turn);
+        let spawn_output = SpawnAgentHandlerV2
+            .handle(invocation(
+                session.clone(),
+                turn.clone(),
+                "spawn_agent",
+                function_payload(json!({
+                    "message": "inspect this repo",
+                    "task_name": "test_process"
+                })),
+            ))
+            .await
+            .expect("spawn_agent should succeed");
+        let (content, _) = expect_text_output(spawn_output);
+        let spawn_result: SpawnAgentResult =
+            serde_json::from_str(&content).expect("spawn result should parse");
+        assert_eq!(spawn_result.task_name, "/root/test_process");
+        assert!(spawn_result.nickname.is_some());
 
-    let child_thread_id = session
-        .services
-        .agent_control
-        .resolve_agent_reference(
-            session.conversation_id,
-            &turn.session_source,
-            "test_process",
-        )
-        .await
-        .expect("relative path should resolve");
-    let child_snapshot = manager
-        .get_thread(child_thread_id)
-        .await
-        .expect("child thread should exist")
-        .config_snapshot()
-        .await;
-    assert_eq!(
-        child_snapshot.session_source.get_agent_path().as_deref(),
-        Some("/root/test_process")
-    );
-    assert!(manager.captured_ops().iter().any(|(id, op)| {
-        *id == child_thread_id
-            && matches!(
-                op,
-                Op::InterAgentCommunication { communication }
-                    if communication.author == AgentPath::root()
-                        && communication.recipient.as_str() == "/root/test_process"
-                        && communication.other_recipients.is_empty()
-                        && communication.content == "inspect this repo"
-                        && communication.trigger_turn
+        let child_thread_id = session
+            .services
+            .agent_control
+            .resolve_agent_reference(
+                session.conversation_id,
+                &turn.session_source,
+                "test_process",
             )
-    }));
+            .await
+            .expect("relative path should resolve");
+        let child_snapshot = manager
+            .get_thread(child_thread_id)
+            .await
+            .expect("child thread should exist")
+            .config_snapshot()
+            .await;
+        assert_eq!(
+            child_snapshot.session_source.get_agent_path().as_deref(),
+            Some("/root/test_process")
+        );
+        assert!(manager.captured_ops().iter().any(|(id, op)| {
+            *id == child_thread_id
+                && matches!(
+                    op,
+                    Op::InterAgentCommunication { communication }
+                        if communication.author == AgentPath::root()
+                            && communication.recipient.as_str() == "/root/test_process"
+                            && communication.other_recipients.is_empty()
+                            && communication.content == "inspect this repo"
+                            && communication.trigger_turn
+                )
+        }));
 
-    SendMessageHandlerV2
-        .handle(invocation(
-            session.clone(),
-            turn.clone(),
-            "send_message",
-            function_payload(json!({
-                "target": "test_process",
-                "message": "continue"
-            })),
-        ))
-        .await
-        .expect("send_message should accept v2 path");
+        SendMessageHandlerV2
+            .handle(invocation(
+                session.clone(),
+                turn.clone(),
+                "send_message",
+                function_payload(json!({
+                    "target": "test_process",
+                    "message": "continue"
+                })),
+            ))
+            .await
+            .expect("send_message should accept v2 path");
 
-    assert!(manager.captured_ops().iter().any(|(id, op)| {
-        *id == child_thread_id
-            && matches!(
-                op,
-                Op::InterAgentCommunication { communication }
-                    if communication.author == AgentPath::root()
-                        && communication.recipient.as_str() == "/root/test_process"
-                        && communication.other_recipients.is_empty()
-                        && communication.content == "continue"
-                        && !communication.trigger_turn
-            )
-    }));
+        assert!(manager.captured_ops().iter().any(|(id, op)| {
+            *id == child_thread_id
+                && matches!(
+                    op,
+                    Op::InterAgentCommunication { communication }
+                        if communication.author == AgentPath::root()
+                            && communication.recipient.as_str() == "/root/test_process"
+                            && communication.other_recipients.is_empty()
+                            && communication.content == "continue"
+                            && !communication.trigger_turn
+                )
+        }));
+    });
 }
 
 #[tokio::test]
@@ -2804,43 +2763,45 @@ async fn multi_agent_v2_interrupted_turn_does_not_notify_parent() {
     assert_eq!(notifications, Vec::<String>::new());
 }
 
-#[tokio::test]
-async fn multi_agent_v2_spawn_omits_agent_id_when_named() {
-    let (mut session, mut turn) = make_session_and_context().await;
-    let manager = thread_manager();
-    let root = manager
-        .start_thread((*turn.config).clone())
-        .await
-        .expect("root thread should start");
-    session.services.agent_control = manager.agent_control();
-    session.conversation_id = root.thread_id;
-    let mut config = (*turn.config).clone();
-    config
-        .features
-        .enable(Feature::MultiAgentV2)
-        .expect("test config should allow feature update");
-    turn.config = Arc::new(config);
+#[test]
+fn multi_agent_v2_spawn_omits_agent_id_when_named() {
+    run_large_stack_async(|| async {
+        let (mut session, mut turn) = make_session_and_context().await;
+        let manager = thread_manager();
+        let root = manager
+            .start_thread((*turn.config).clone())
+            .await
+            .expect("root thread should start");
+        session.services.agent_control = manager.agent_control();
+        session.conversation_id = root.thread_id;
+        let mut config = (*turn.config).clone();
+        config
+            .features
+            .enable(Feature::MultiAgentV2)
+            .expect("test config should allow feature update");
+        turn.config = Arc::new(config);
 
-    let output = SpawnAgentHandlerV2
-        .handle(invocation(
-            Arc::new(session),
-            Arc::new(turn),
-            "spawn_agent",
-            function_payload(json!({
-                "message": "inspect this repo",
-                "task_name": "test_process"
-            })),
-        ))
-        .await
-        .expect("spawn_agent should succeed");
-    let (content, success) = expect_text_output(output);
-    let result: serde_json::Value =
-        serde_json::from_str(&content).expect("spawn_agent result should be json");
+        let output = SpawnAgentHandlerV2
+            .handle(invocation(
+                Arc::new(session),
+                Arc::new(turn),
+                "spawn_agent",
+                function_payload(json!({
+                    "message": "inspect this repo",
+                    "task_name": "test_process"
+                })),
+            ))
+            .await
+            .expect("spawn_agent should succeed");
+        let (content, success) = expect_text_output(output);
+        let result: serde_json::Value =
+            serde_json::from_str(&content).expect("spawn_agent result should be json");
 
-    assert!(result.get("agent_id").is_none());
-    assert_eq!(result["task_name"], "/root/test_process");
-    assert!(result.get("nickname").is_some());
-    assert_eq!(success, Some(true));
+        assert!(result.get("agent_id").is_none());
+        assert_eq!(result["task_name"], "/root/test_process");
+        assert!(result.get("nickname").is_some());
+        assert_eq!(success, Some(true));
+    });
 }
 
 #[tokio::test]

--- a/codex-rs/core/src/tools/handlers/multi_agents_v2/spawn.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_v2/spawn.rs
@@ -22,6 +22,8 @@ use std::collections::HashSet;
 
 pub(crate) struct Handler;
 
+const FULL_HISTORY_WITH_CHILD_CONFIG_ERROR: &str = "fork_turns=`all` cannot be combined with agent_type, model, or reasoning_effort because full-history forks inherit the parent configuration. Use fork_turns=`none` or a positive integer to apply child overrides.";
+
 impl ToolHandler for Handler {
     type Output = SpawnAgentResult;
 
@@ -70,6 +72,7 @@ impl ToolHandler for Handler {
             ));
         }
         let fork_mode = if is_watchdog { None } else { args.fork_mode()? };
+        reject_full_history_child_config_overrides(role_name, &args, &fork_mode)?;
         let initial_operation = parse_collab_input(Some(args.message), /*items*/ None)?;
         let prompt = render_input_preview(&initial_operation);
         session
@@ -257,6 +260,26 @@ impl ToolHandler for Handler {
             })
         }
     }
+}
+
+fn reject_full_history_child_config_overrides(
+    role_name: Option<&str>,
+    args: &SpawnAgentArgs,
+    fork_mode: &Option<SpawnAgentForkMode>,
+) -> Result<(), FunctionCallError> {
+    if !matches!(fork_mode, Some(SpawnAgentForkMode::FullHistory)) {
+        return Ok(());
+    }
+
+    let has_role_override =
+        role_name.is_some_and(|role_name| !role_name.eq_ignore_ascii_case(DEFAULT_ROLE_NAME));
+    if has_role_override || args.model.is_some() || args.reasoning_effort.is_some() {
+        return Err(FunctionCallError::RespondToModel(
+            FULL_HISTORY_WITH_CHILD_CONFIG_ERROR.to_string(),
+        ));
+    }
+
+    Ok(())
 }
 
 async fn spawn_watchdog(

--- a/codex-rs/tools/src/agent_tool.rs
+++ b/codex-rs/tools/src/agent_tool.rs
@@ -671,7 +671,7 @@ fn spawn_agent_common_properties_v2(agent_type_description: &str) -> BTreeMap<St
         (
             "fork_turns".to_string(),
             JsonSchema::string(Some(
-                "Optional number of turns to fork. Defaults to `all`. Use `none`, `all`, or a positive integer string such as `3` to fork only the most recent turns."
+                "Optional number of turns to fork. Defaults to `all`. Use `none`, `all`, or a positive integer string such as `3` to fork only the most recent turns. Full-history forks (`all` or omitted) inherit the parent role/model configuration, so use `none` or a positive integer when setting agent_type, model, or reasoning_effort."
                     .to_string(),
             )),
         ),

--- a/codex-rs/tools/src/agent_tool_tests.rs
+++ b/codex-rs/tools/src/agent_tool_tests.rs
@@ -73,6 +73,14 @@ fn spawn_agent_tool_v2_requires_task_name_and_lists_visible_models() {
     assert!(properties.contains_key("task_name"));
     assert!(properties.contains_key("message"));
     assert!(properties.contains_key("fork_turns"));
+    assert!(
+        properties
+            .get("fork_turns")
+            .and_then(|schema| schema.description.as_deref())
+            .is_some_and(|description| description.contains(
+                "Full-history forks (`all` or omitted) inherit the parent role/model configuration"
+            ))
+    );
     assert!(!properties.contains_key("items"));
     assert!(!properties.contains_key("fork_context"));
     assert_eq!(


### PR DESCRIPTION
## Summary

This changes the MultiAgentV2 `spawn_agent` path to fail fast when a full-history fork (`fork_turns: "all"` or an omitted `fork_turns`) is combined with `agent_type`, `model`, or `reasoning_effort` overrides.

Full-history forks currently inherit the parent thread configuration. That means those child override fields are not applied in that path, which can make a session look like it requested an oracle/model override while the spawned child actually runs with the parent model. The guard turns that silent mismatch into a model-facing error and tells the caller to use `fork_turns: "none"` or a positive turn count when child role/model overrides need to apply.

The PR also updates the tool schema and root-agent prompt so agents get the rule before they call the tool, and it adjusts the tests that used to assert the old silent-ignore behavior.

## Why this is useful

- Prevents misleading rollout traces where a tool call appears to request one agent/model but the spawned thread records another.
- Makes oracle/model override failures explicit and actionable instead of silently inheriting parent config.
- Preserves full-history fork behavior for plain context cloning while steering configurable subagents to fork modes that actually apply child config.

## Validation

- `cargo test -p codex-core multi_agent_v2_spawn -- --nocapture`
- `cargo test -p codex-tools spawn_agent_tool_v2_requires_task_name_and_lists_visible_models -- --nocapture`
- `cargo test -p codex-core root_agent_prompt_requires_explicit_fork_turns -- --nocapture`
- `git diff --check`