### PR TITLE
Stop spelling skills extra roots in TUI requests

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol/common.rs
+++ b/codex-rs/app-server-protocol/src/protocol/common.rs
@@ -1674,7 +1674,10 @@ mod tests {
 
         let plugin_list = ClientRequest::PluginList {
             request_id: request_id(),
-            params: v2::PluginListParams { cwds: None },
+            params: v2::PluginListParams {
+                cwds: None,
+                marketplace_kinds: None,
+            },
         };
         assert_eq!(
             plugin_list.serialization_scope(),

--- a/codex-rs/app-server-protocol/src/protocol/v2/plugin.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2/plugin.rs
@@ -15,7 +15,7 @@ use serde::Serialize;
 use std::path::PathBuf;
 use ts_rs::TS;
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export_to = "v2/")]
 pub struct SkillsListParams {

--- a/codex-rs/tui/src/app/background_requests.rs
+++ b/codex-rs/tui/src/app/background_requests.rs
@@ -648,7 +648,7 @@ pub(super) async fn fetch_skills_list(
             params: SkillsListParams {
                 cwds: vec![cwd],
                 force_reload: true,
-                per_cwd_extra_user_roots: None,
+                ..Default::default()
             },
         })
         .await

--- a/codex-rs/tui/src/app/thread_routing.rs
+++ b/codex-rs/tui/src/app/thread_routing.rs
@@ -621,7 +621,7 @@ impl App {
                         .skills_list(codex_app_server_protocol::SkillsListParams {
                             cwds: cwds.clone(),
                             force_reload: *force_reload,
-                            per_cwd_extra_user_roots: None,
+                            ..Default::default()
                         })
                         .await,
                     "failed to refresh skills",


### PR DESCRIPTION
## Summary
- Add `Default` for `SkillsListParams` so callers can rely on the existing `None` default for extra roots.
- Update the TUI `skills/list` call sites to stop explicitly spelling `per_cwd_extra_user_roots: None`.
- Include the one-line `PluginListParams` test initializer fix needed for protocol tests on current `main`.

## Why
This lets the client-side cleanup land before the server/API removal. The TUI still sends the same effective request today, but the call sites no longer explicitly depend on the extra-roots field.

## Validation
- `just fmt`
- `cargo test -p codex-app-server-protocol skills_list_params_serialization_uses_force_reload`
- `cargo check -p codex-tui`
- `just fix -p codex-app-server-protocol`
- `just fix -p codex-tui` was run once, but clippy rewrote the TUI struct update back to the explicit `None`; the intended TUI cleanup was reapplied and validated with `cargo check -p codex-tui`.