### PR TITLE
[codex] fix PluginListParams test initializer

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol/common.rs
+++ b/codex-rs/app-server-protocol/src/protocol/common.rs
@@ -1674,7 +1674,10 @@ mod tests {
 
         let plugin_list = ClientRequest::PluginList {
             request_id: request_id(),
-            params: v2::PluginListParams { cwds: None },
+            params: v2::PluginListParams {
+                cwds: None,
+                marketplace_kinds: None,
+            },
         };
         assert_eq!(
             plugin_list.serialization_scope(),


### PR DESCRIPTION
## Summary
- update the app-server protocol test fixture to include the required `marketplace_kinds` field on `PluginListParams`

## Why
`PluginListParams` now requires `marketplace_kinds`, but a later-added test fixture in `common.rs` still constructed the older shape with only `cwds`. That stale initializer breaks the main build with `missing field marketplace_kinds`.

## Impact
This is a test-only repair. It restores compilation without changing the JSON-RPC schema or runtime behavior.

## Validation
- `just fmt`
- `cargo test -p codex-app-server-protocol`