### PR TITLE
[codex] add account id to feedback uploads

### DIFF
--- a/codex-rs/app-server/src/request_processors/feedback_processor.rs
+++ b/codex-rs/app-server/src/request_processors/feedback_processor.rs
@@ -72,6 +72,13 @@ impl FeedbackRequestProcessor {
         {
             tracing::info!(target: "feedback_tags", chatgpt_user_id);
         }
+        if let Some(account_id) = self
+            .auth_manager
+            .auth_cached()
+            .and_then(|auth| auth.get_account_id())
+        {
+            tracing::info!(target: "feedback_tags", account_id);
+        }
         let snapshot = self.feedback.snapshot(conversation_id);
         let thread_id = snapshot.thread_id.clone();
         let (feedback_thread_ids, sqlite_feedback_logs, state_db_ctx) = if include_logs {

--- a/codex-rs/feedback/src/lib.rs
+++ b/codex-rs/feedback/src/lib.rs
@@ -757,6 +757,7 @@ mod tests {
         tags.insert("cli_version".to_string(), "wrong-version".to_string());
         tags.insert("session_source".to_string(), "wrong-source".to_string());
         tags.insert("reason".to_string(), "wrong-reason".to_string());
+        tags.insert("account_id".to_string(), "actual-account".to_string());
         tags.insert("model".to_string(), "gpt-5".to_string());
         let snapshot = FeedbackSnapshot {
             bytes: Vec::new(),
@@ -808,6 +809,10 @@ mod tests {
         assert_eq!(
             upload_tags.get("reason").map(String::as_str),
             Some("actual reason")
+        );
+        assert_eq!(
+            upload_tags.get("account_id").map(String::as_str),
+            Some("actual-account")
         );
         assert_eq!(
             upload_tags.get("client_tag").map(String::as_str),


### PR DESCRIPTION
## Why

Feedback uploads already carry auth-derived context like `chatgpt_user_id`, but they do not include the authenticated workspace/account id. Adding `account_id` makes feedback triage easier when a user can operate across multiple ChatGPT workspaces.

## What changed

- emit auth-derived `account_id` into feedback tags in `app-server` before the feedback snapshot is uploaded
- preserve that tag through `codex-feedback` upload tag assembly alongside the existing merge behavior for other tags
- extend `codex-feedback` coverage to assert that snapshot-derived `account_id` is present in uploaded tags

## Verification

- `cargo test -p codex-feedback upload_tags_include_client_tags_and_preserve_reserved_fields`
- `cargo test -p codex-app-server --lib feedback_processor`
