### PR TITLE
test: deflake realtime sideband close

### DIFF
--- a/codex-rs/core/tests/common/responses.rs
+++ b/codex-rs/core/tests/common/responses.rs
@@ -1246,7 +1246,10 @@ pub async fn start_websocket_server_with_headers(
             };
 
             if let Some(delay) = connection.accept_delay {
-                tokio::time::sleep(delay).await;
+                tokio::select! {
+                    _ = &mut shutdown_rx => return,
+                    _ = tokio::time::sleep(delay) => {}
+                }
             }
 
             let response_headers = connection.response_headers.clone();

--- a/codex-rs/core/tests/suite/realtime_conversation.rs
+++ b/codex-rs/core/tests/suite/realtime_conversation.rs
@@ -662,7 +662,10 @@ async fn conversation_webrtc_close_while_sideband_connecting_drops_pending_join(
     let realtime_server = start_websocket_server_with_headers(vec![WebSocketConnectionConfig {
         requests: vec![vec![]],
         response_headers: Vec::new(),
-        accept_delay: Some(Duration::from_millis(500)),
+        // Keep the sideband handshake pending beyond the stale-event observation window below.
+        // Slow CI runners can otherwise complete the mock accept before the close path gets to
+        // abort the sideband task, which makes the negative handshake assertion scheduler-racy.
+        accept_delay: Some(Duration::from_secs(5)),
         close_after_requests: false,
     }])
     .await;

--- a/codex-rs/core/tests/suite/realtime_conversation.rs
+++ b/codex-rs/core/tests/suite/realtime_conversation.rs
@@ -649,6 +649,8 @@ async fn conversation_webrtc_start_posts_generated_session() -> Result<()> {
 async fn conversation_webrtc_close_while_sideband_connecting_drops_pending_join() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
+    let sideband_accept_delay = Duration::from_millis(700);
+    let stale_sideband_observation_window = Duration::from_secs(1);
     let server = start_mock_server().await;
     Mock::given(method("POST"))
         .and(path_regex(".*/realtime/calls$"))
@@ -662,10 +664,9 @@ async fn conversation_webrtc_close_while_sideband_connecting_drops_pending_join(
     let realtime_server = start_websocket_server_with_headers(vec![WebSocketConnectionConfig {
         requests: vec![vec![]],
         response_headers: Vec::new(),
-        // Keep the sideband handshake pending beyond the stale-event observation window below.
-        // Slow CI runners can otherwise complete the mock accept before the close path gets to
-        // abort the sideband task, which makes the negative handshake assertion scheduler-racy.
-        accept_delay: Some(Duration::from_secs(5)),
+        // Keep the sideband handshake pending through the close path on slow CI without adding a
+        // multi-second fixed tail when the mock websocket server shuts down.
+        accept_delay: Some(sideband_accept_delay),
         close_after_requests: false,
     }])
     .await;
@@ -711,7 +712,7 @@ async fn conversation_webrtc_close_while_sideband_connecting_drops_pending_join(
     .await;
     assert_eq!(closed.reason.as_deref(), Some("requested"));
 
-    let stale_event = timeout(Duration::from_millis(700), async {
+    let stale_event = timeout(stale_sideband_observation_window, async {
         wait_for_event_match(&test.codex, |msg| match msg {
             EventMsg::RealtimeConversationRealtime(RealtimeConversationRealtimeEvent {
                 payload: RealtimeEvent::Error(message),

--- a/codex-rs/core/tests/suite/realtime_conversation.rs
+++ b/codex-rs/core/tests/suite/realtime_conversation.rs
@@ -649,8 +649,8 @@ async fn conversation_webrtc_start_posts_generated_session() -> Result<()> {
 async fn conversation_webrtc_close_while_sideband_connecting_drops_pending_join() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
-    let sideband_accept_delay = Duration::from_millis(700);
-    let stale_sideband_observation_window = Duration::from_secs(1);
+    let sideband_accept_delay = Duration::from_secs(5);
+    let stale_sideband_observation_window = Duration::from_millis(700);
     let server = start_mock_server().await;
     Mock::given(method("POST"))
         .and(path_regex(".*/realtime/calls$"))
@@ -664,8 +664,8 @@ async fn conversation_webrtc_close_while_sideband_connecting_drops_pending_join(
     let realtime_server = start_websocket_server_with_headers(vec![WebSocketConnectionConfig {
         requests: vec![vec![]],
         response_headers: Vec::new(),
-        // Keep the sideband handshake pending through the close path on slow CI without adding a
-        // multi-second fixed tail when the mock websocket server shuts down.
+        // Keep the sideband handshake pending beyond the stale-event observation window below
+        // without adding a multi-second fixed tail when the mock websocket server shuts down.
         accept_delay: Some(sideband_accept_delay),
         close_after_requests: false,
     }])


### PR DESCRIPTION
## Why

`conversation_webrtc_close_while_sideband_connecting_drops_pending_join` was flaky on slow CI because the mocked sideband handshake could finish before the close path aborted the pending join task. When that race wins, the test observes the wrong event sequence even though the product behavior is unchanged.

Failure evidence: [remote Ubuntu test job](https://github.com/openai/codex/actions/runs/26116725532/job/76807810858) with uploaded [nextest JUnit artifact](https://github.com/openai/codex/actions/runs/26116725532/artifacts/7092348148)

## What changed

- keep the mocked sideband accept delayed past the stale-event observation window
- make websocket mock shutdown interrupt that delay so the test does not pay a fixed multi-second teardown tail
- make the close-while-connecting case deterministic instead of scheduler-sensitive

## CI evidence

Recent failed `rust-ci-full` test runs that exposed this flake family:
- https://github.com/openai/codex/actions/runs/26115775739
- https://github.com/openai/codex/actions/runs/26114840740
- https://github.com/openai/codex/actions/runs/26114668996
- https://github.com/openai/codex/actions/runs/26113530208

Those failed test lanes uploaded nextest JUnit artifacts successfully. Representative artifacts from the latest run:
- https://github.com/openai/codex/actions/runs/26115775739/artifacts/7091965331
- https://github.com/openai/codex/actions/runs/26115775739/artifacts/7092022050
- https://github.com/openai/codex/actions/runs/26115775739/artifacts/7091820251

## Walkthrough

- Issue: the realtime close-while-sideband-connecting test was scheduler-sensitive, and the first deflake shape traded that for a teardown tail.
- Likely introducing change: the original realtime sideband close test; the follow-up regression was the fixed 5s accept delay.
- Fix: keep the handshake pending beyond the negative observation window, while letting websocket-server shutdown interrupt the artificial accept delay so teardown stays bounded.

## Devbox evidence

Focused validation on `dev` passed from the mirrored PR worktree:

```bash
ssh -o ClearAllForwardings=yes dev 'cd /home/dev-user/code/codex-worktrees/codex-nightly-realtime-sideband-close-flake-20260519 && export PATH=$HOME/code/openai/project/dotslash-gen/bin:$HOME/.local/bin:$PATH && bazel test --bes_backend= --bes_results_url= --test_filter=conversation_webrtc_close_while_sideband_connecting_drops_pending_join //codex-rs/core:core-all-test'
```

```text
//codex-rs/core:core-all-test                                            PASSED in 1.6s
Executed 1 out of 1 test: 1 test passes.
```

Representative prior CI failure:

```text
suite::realtime_conversation::conversation_webrtc_close_while_sideband_connecting_drops_pending_join ... FAILED
thread 'suite::realtime_conversation::conversation_webrtc_close_while_sideband_connecting_drops_pending_join' panicked at core/tests/suite/realtime_conversation.rs:729:5:
pending sideband task should abort before websocket handshake completes
```
