### PR TITLE
Disable empty Cargo test targets

### DIFF
--- a/codex-rs/agent-graph-store/Cargo.toml
+++ b/codex-rs/agent-graph-store/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 [lib]
 name = "codex_agent_graph_store"
 path = "src/lib.rs"
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/ansi-escape/Cargo.toml
+++ b/codex-rs/ansi-escape/Cargo.toml
@@ -7,6 +7,8 @@ license.workspace = true
 [lib]
 name = "codex_ansi_escape"
 path = "src/lib.rs"
+test = false
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/app-server-client/Cargo.toml
+++ b/codex-rs/app-server-client/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [lib]
 name = "codex_app_server_client"
 path = "src/lib.rs"
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/app-server-protocol/Cargo.toml
+++ b/codex-rs/app-server-protocol/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [lib]
 name = "codex_app_server_protocol"
 path = "src/lib.rs"
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/app-server-test-client/Cargo.toml
+++ b/codex-rs/app-server-test-client/Cargo.toml
@@ -23,3 +23,7 @@ tracing-subscriber = { workspace = true }
 tungstenite = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
+
+[lib]
+test = false
+doctest = false

--- a/codex-rs/app-server-transport/Cargo.toml
+++ b/codex-rs/app-server-transport/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [lib]
 name = "codex_app_server_transport"
 path = "src/lib.rs"
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/app-server/Cargo.toml
+++ b/codex-rs/app-server/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/bin/notify_capture.rs"
 [lib]
 name = "codex_app_server"
 path = "src/lib.rs"
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/app-server/tests/common/Cargo.toml
+++ b/codex-rs/app-server/tests/common/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 
 [lib]
 path = "lib.rs"
+test = false
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/apply-patch/Cargo.toml
+++ b/codex-rs/apply-patch/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [lib]
 name = "codex_apply_patch"
 path = "src/lib.rs"
+doctest = false
 
 [[bin]]
 name = "apply_patch"

--- a/codex-rs/arg0/Cargo.toml
+++ b/codex-rs/arg0/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [lib]
 name = "codex_arg0"
 path = "src/lib.rs"
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/async-utils/Cargo.toml
+++ b/codex-rs/async-utils/Cargo.toml
@@ -14,3 +14,6 @@ tokio-util.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true
+
+[lib]
+doctest = false

--- a/codex-rs/backend-client/Cargo.toml
+++ b/codex-rs/backend-client/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 
 [lib]
 path = "src/lib.rs"
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/builtin-mcps/Cargo.toml
+++ b/codex-rs/builtin-mcps/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 [lib]
 name = "codex_builtin_mcps"
 path = "src/lib.rs"
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/chatgpt/Cargo.toml
+++ b/codex-rs/chatgpt/Cargo.toml
@@ -27,3 +27,6 @@ codex-utils-cargo-bin = { workspace = true }
 pretty_assertions = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
+
+[lib]
+doctest = false

--- a/codex-rs/cli/Cargo.toml
+++ b/codex-rs/cli/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 [lib]
 name = "codex_cli"
 path = "src/lib.rs"
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/cloud-requirements/Cargo.toml
+++ b/codex-rs/cloud-requirements/Cargo.toml
@@ -30,3 +30,6 @@ tracing = { workspace = true }
 pretty_assertions = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "test-util", "time"] }
+
+[lib]
+doctest = false

--- a/codex-rs/cloud-tasks-client/Cargo.toml
+++ b/codex-rs/cloud-tasks-client/Cargo.toml
@@ -7,6 +7,8 @@ version.workspace = true
 [lib]
 name = "codex_cloud_tasks_client"
 path = "src/lib.rs"
+test = false
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/cloud-tasks-mock-client/Cargo.toml
+++ b/codex-rs/cloud-tasks-mock-client/Cargo.toml
@@ -8,6 +8,8 @@ version.workspace = true
 [lib]
 name = "codex_cloud_tasks_mock_client"
 path = "src/lib.rs"
+test = false
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/cloud-tasks/Cargo.toml
+++ b/codex-rs/cloud-tasks/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 [lib]
 name = "codex_cloud_tasks"
 path = "src/lib.rs"
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/codex-api/Cargo.toml
+++ b/codex-rs/codex-api/Cargo.toml
@@ -39,3 +39,6 @@ reqwest = { workspace = true }
 
 [lints]
 workspace = true
+
+[lib]
+doctest = false

--- a/codex-rs/codex-backend-openapi-models/Cargo.toml
+++ b/codex-rs/codex-backend-openapi-models/Cargo.toml
@@ -7,6 +7,8 @@ license.workspace = true
 [lib]
 name = "codex_backend_openapi_models"
 path = "src/lib.rs"
+test = false
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/codex-client/Cargo.toml
+++ b/codex-rs/codex-client/Cargo.toml
@@ -35,3 +35,6 @@ pretty_assertions = { workspace = true }
 rcgen = { workspace = true }
 tempfile = { workspace = true }
 tracing-subscriber = { workspace = true }
+
+[lib]
+doctest = false

--- a/codex-rs/codex-experimental-api-macros/Cargo.toml
+++ b/codex-rs/codex-experimental-api-macros/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 
 [lib]
 proc-macro = true
+test = false
+doctest = false
 
 [dependencies]
 proc-macro2 = "1"

--- a/codex-rs/codex-mcp/Cargo.toml
+++ b/codex-rs/codex-mcp/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 [lib]
 name = "codex_mcp"
 path = "src/lib.rs"
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/collaboration-mode-templates/Cargo.toml
+++ b/codex-rs/collaboration-mode-templates/Cargo.toml
@@ -8,6 +8,7 @@ version.workspace = true
 doctest = false
 name = "codex_collaboration_mode_templates"
 path = "src/lib.rs"
+test = false
 
 [lints]
 workspace = true

--- a/codex-rs/config/Cargo.toml
+++ b/codex-rs/config/Cargo.toml
@@ -66,3 +66,6 @@ tokio = { workspace = true, features = ["full"] }
 tokio-stream = { workspace = true, features = ["net"] }
 tonic = { workspace = true, features = ["router", "transport"] }
 tonic-prost-build = { version = "=0.14.3", default-features = false, features = ["transport"] }
+
+[lib]
+doctest = false

--- a/codex-rs/connectors/Cargo.toml
+++ b/codex-rs/connectors/Cargo.toml
@@ -16,3 +16,6 @@ urlencoding = { workspace = true }
 [dev-dependencies]
 pretty_assertions = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+[lib]
+doctest = false

--- a/codex-rs/core-api/Cargo.toml
+++ b/codex-rs/core-api/Cargo.toml
@@ -8,6 +8,7 @@ version.workspace = true
 doctest = false
 name = "codex_core_api"
 path = "src/lib.rs"
+test = false
 
 [lints]
 workspace = true

--- a/codex-rs/core/Cargo.toml
+++ b/codex-rs/core/Cargo.toml
@@ -5,7 +5,6 @@ name = "codex-core"
 version.workspace = true
 
 [lib]
-doctest = false
 name = "codex_core"
 path = "src/lib.rs"
 

--- a/codex-rs/core/tests/common/Cargo.toml
+++ b/codex-rs/core/tests/common/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [lib]
 path = "lib.rs"
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/exec/Cargo.toml
+++ b/codex-rs/exec/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 [lib]
 name = "codex_exec"
 path = "src/lib.rs"
+doctest = false
 
 [[test]]
 name = "all"

--- a/codex-rs/execpolicy-legacy/Cargo.toml
+++ b/codex-rs/execpolicy-legacy/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 [lib]
 name = "codex_execpolicy_legacy"
 path = "src/lib.rs"
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/execpolicy/Cargo.toml
+++ b/codex-rs/execpolicy/Cargo.toml
@@ -8,6 +8,7 @@ description = "Codex exec policy: prefix-based Starlark rules for command decisi
 [lib]
 name = "codex_execpolicy"
 path = "src/lib.rs"
+doctest = false
 
 [[bin]]
 name = "codex-execpolicy"

--- a/codex-rs/feedback/Cargo.toml
+++ b/codex-rs/feedback/Cargo.toml
@@ -17,3 +17,6 @@ tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
+
+[lib]
+doctest = false

--- a/codex-rs/file-search/Cargo.toml
+++ b/codex-rs/file-search/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 [lib]
 name = "codex_file_search"
 path = "src/lib.rs"
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/file-system/Cargo.toml
+++ b/codex-rs/file-system/Cargo.toml
@@ -12,3 +12,7 @@ async-trait = { workspace = true }
 codex-protocol = { workspace = true }
 codex-utils-absolute-path = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+
+[lib]
+test = false
+doctest = false

--- a/codex-rs/git-utils/Cargo.toml
+++ b/codex-rs/git-utils/Cargo.toml
@@ -33,3 +33,6 @@ walkdir = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
+
+[lib]
+doctest = false

--- a/codex-rs/install-context/Cargo.toml
+++ b/codex-rs/install-context/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [lib]
 name = "codex_install_context"
 path = "src/lib.rs"
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/keyring-store/Cargo.toml
+++ b/codex-rs/keyring-store/Cargo.toml
@@ -22,3 +22,7 @@ keyring = { workspace = true, features = ["windows-native"] }
 
 [target.'cfg(any(target_os = "freebsd", target_os = "openbsd"))'.dependencies]
 keyring = { workspace = true, features = ["sync-secret-service"] }
+
+[lib]
+test = false
+doctest = false

--- a/codex-rs/linux-sandbox/Cargo.toml
+++ b/codex-rs/linux-sandbox/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 [lib]
 name = "codex_linux_sandbox"
 path = "src/lib.rs"
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/lmstudio/Cargo.toml
+++ b/codex-rs/lmstudio/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [lib]
 name = "codex_lmstudio"
 path = "src/lib.rs"
+doctest = false
 
 
 [dependencies]

--- a/codex-rs/login/Cargo.toml
+++ b/codex-rs/login/Cargo.toml
@@ -52,3 +52,6 @@ regex-lite = { workspace = true }
 serial_test = { workspace = true }
 tempfile = { workspace = true }
 wiremock = { workspace = true }
+
+[lib]
+doctest = false

--- a/codex-rs/mcp-server/Cargo.toml
+++ b/codex-rs/mcp-server/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 [lib]
 name = "codex_mcp_server"
 path = "src/lib.rs"
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/mcp-server/tests/common/Cargo.toml
+++ b/codex-rs/mcp-server/tests/common/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 
 [lib]
 path = "lib.rs"
+test = false
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/memories/mcp/Cargo.toml
+++ b/codex-rs/memories/mcp/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 [lib]
 name = "codex_memories_mcp"
 path = "src/lib.rs"
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/memories/read/Cargo.toml
+++ b/codex-rs/memories/read/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 [lib]
 name = "codex_memories_read"
 path = "src/lib.rs"
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/memories/write/Cargo.toml
+++ b/codex-rs/memories/write/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 [lib]
 name = "codex_memories_write"
 path = "src/lib.rs"
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/message-history/Cargo.toml
+++ b/codex-rs/message-history/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [lib]
 name = "codex_message_history"
 path = "src/lib.rs"
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/network-proxy/Cargo.toml
+++ b/codex-rs/network-proxy/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [lib]
 name = "codex_network_proxy"
 path = "src/lib.rs"
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/ollama/Cargo.toml
+++ b/codex-rs/ollama/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [lib]
 name = "codex_ollama"
 path = "src/lib.rs"
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/process-hardening/Cargo.toml
+++ b/codex-rs/process-hardening/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [lib]
 name = "codex_process_hardening"
 path = "src/lib.rs"
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/protocol/Cargo.toml
+++ b/codex-rs/protocol/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 [lib]
 name = "codex_protocol"
 path = "src/lib.rs"
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/realtime-webrtc/Cargo.toml
+++ b/codex-rs/realtime-webrtc/Cargo.toml
@@ -7,6 +7,8 @@ license.workspace = true
 [lib]
 name = "codex_realtime_webrtc"
 path = "src/lib.rs"
+test = false
+doctest = false
 
 [dependencies]
 thiserror = { workspace = true }

--- a/codex-rs/responses-api-proxy/Cargo.toml
+++ b/codex-rs/responses-api-proxy/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [lib]
 name = "codex_responses_api_proxy"
 path = "src/lib.rs"
+doctest = false
 
 [[bin]]
 name = "codex-responses-api-proxy"

--- a/codex-rs/rmcp-client/Cargo.toml
+++ b/codex-rs/rmcp-client/Cargo.toml
@@ -78,3 +78,6 @@ keyring = { workspace = true, features = ["windows-native"] }
 
 [target.'cfg(any(target_os = "freebsd", target_os = "openbsd"))'.dependencies]
 keyring = { workspace = true, features = ["sync-secret-service"] }
+
+[lib]
+doctest = false

--- a/codex-rs/sandboxing/Cargo.toml
+++ b/codex-rs/sandboxing/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [lib]
 name = "codex_sandboxing"
 path = "src/lib.rs"
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/secrets/Cargo.toml
+++ b/codex-rs/secrets/Cargo.toml
@@ -25,3 +25,6 @@ tracing = { workspace = true }
 keyring = { workspace = true }
 pretty_assertions = { workspace = true }
 tempfile = { workspace = true }
+
+[lib]
+doctest = false

--- a/codex-rs/shell-command/Cargo.toml
+++ b/codex-rs/shell-command/Cargo.toml
@@ -24,3 +24,6 @@ which = { workspace = true }
 [dev-dependencies]
 anyhow = { workspace = true }
 pretty_assertions = { workspace = true }
+
+[lib]
+doctest = false

--- a/codex-rs/shell-escalation/Cargo.toml
+++ b/codex-rs/shell-escalation/Cargo.toml
@@ -37,3 +37,6 @@ tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 [dev-dependencies]
 pretty_assertions = { workspace = true }
 tempfile = { workspace = true }
+
+[lib]
+doctest = false

--- a/codex-rs/stdio-to-uds/Cargo.toml
+++ b/codex-rs/stdio-to-uds/Cargo.toml
@@ -11,6 +11,8 @@ path = "src/main.rs"
 [lib]
 name = "codex_stdio_to_uds"
 path = "src/lib.rs"
+test = false
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/terminal-detection/Cargo.toml
+++ b/codex-rs/terminal-detection/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [lib]
 name = "codex_terminal_detection"
 path = "src/lib.rs"
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/test-binary-support/Cargo.toml
+++ b/codex-rs/test-binary-support/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 
 [lib]
 path = "lib.rs"
+test = false
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/thread-store/Cargo.toml
+++ b/codex-rs/thread-store/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 [lib]
 name = "codex_thread_store"
 path = "src/lib.rs"
+doctest = false
 
 [[example]]
 name = "generate-proto"

--- a/codex-rs/tools/Cargo.toml
+++ b/codex-rs/tools/Cargo.toml
@@ -26,3 +26,6 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
+
+[lib]
+doctest = false

--- a/codex-rs/tui/Cargo.toml
+++ b/codex-rs/tui/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/bin/md-events.rs"
 [lib]
 name = "codex_tui"
 path = "src/lib.rs"
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/uds/Cargo.toml
+++ b/codex-rs/uds/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [lib]
 name = "codex_uds"
 path = "src/lib.rs"
+doctest = false
 
 [lints]
 workspace = true

--- a/codex-rs/utils/absolute-path/Cargo.toml
+++ b/codex-rs/utils/absolute-path/Cargo.toml
@@ -22,3 +22,6 @@ ts-rs = { workspace = true, features = [
 pretty_assertions = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
+
+[lib]
+doctest = false

--- a/codex-rs/utils/approval-presets/Cargo.toml
+++ b/codex-rs/utils/approval-presets/Cargo.toml
@@ -9,3 +9,7 @@ workspace = true
 
 [dependencies]
 codex-protocol = { workspace = true }
+
+[lib]
+test = false
+doctest = false

--- a/codex-rs/utils/cache/Cargo.toml
+++ b/codex-rs/utils/cache/Cargo.toml
@@ -14,3 +14,6 @@ tokio = { workspace = true, features = ["sync", "rt", "rt-multi-thread"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
+
+[lib]
+doctest = false

--- a/codex-rs/utils/cargo-bin/Cargo.toml
+++ b/codex-rs/utils/cargo-bin/Cargo.toml
@@ -11,3 +11,7 @@ workspace = true
 assert_cmd = { workspace = true }
 runfiles = { workspace = true }
 thiserror = { workspace = true }
+
+[lib]
+test = false
+doctest = false

--- a/codex-rs/utils/cli/Cargo.toml
+++ b/codex-rs/utils/cli/Cargo.toml
@@ -15,3 +15,6 @@ toml = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
+
+[lib]
+doctest = false

--- a/codex-rs/utils/elapsed/Cargo.toml
+++ b/codex-rs/utils/elapsed/Cargo.toml
@@ -6,3 +6,6 @@ license.workspace = true
 
 [lints]
 workspace = true
+
+[lib]
+doctest = false

--- a/codex-rs/utils/fuzzy-match/Cargo.toml
+++ b/codex-rs/utils/fuzzy-match/Cargo.toml
@@ -6,3 +6,6 @@ license.workspace = true
 
 [lints]
 workspace = true
+
+[lib]
+doctest = false

--- a/codex-rs/utils/home-dir/Cargo.toml
+++ b/codex-rs/utils/home-dir/Cargo.toml
@@ -14,3 +14,6 @@ dirs = { workspace = true }
 [dev-dependencies]
 pretty_assertions = { workspace = true }
 tempfile = { workspace = true }
+
+[lib]
+doctest = false

--- a/codex-rs/utils/image/Cargo.toml
+++ b/codex-rs/utils/image/Cargo.toml
@@ -17,3 +17,6 @@ tokio = { workspace = true, features = ["fs", "rt", "rt-multi-thread", "macros"]
 
 [dev-dependencies]
 image = { workspace = true, features = ["jpeg", "png", "gif", "webp"] }
+
+[lib]
+doctest = false

--- a/codex-rs/utils/json-to-toml/Cargo.toml
+++ b/codex-rs/utils/json-to-toml/Cargo.toml
@@ -13,3 +13,6 @@ pretty_assertions = { workspace = true }
 
 [lints]
 workspace = true
+
+[lib]
+doctest = false

--- a/codex-rs/utils/oss/Cargo.toml
+++ b/codex-rs/utils/oss/Cargo.toml
@@ -12,3 +12,6 @@ codex-core = { workspace = true }
 codex-lmstudio = { workspace = true }
 codex-model-provider-info = { workspace = true }
 codex-ollama = { workspace = true }
+
+[lib]
+doctest = false

--- a/codex-rs/utils/output-truncation/Cargo.toml
+++ b/codex-rs/utils/output-truncation/Cargo.toml
@@ -13,3 +13,6 @@ codex-utils-string = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
+
+[lib]
+doctest = false

--- a/codex-rs/utils/path-utils/Cargo.toml
+++ b/codex-rs/utils/path-utils/Cargo.toml
@@ -15,3 +15,6 @@ tempfile = { workspace = true }
 [dev-dependencies]
 pretty_assertions = { workspace = true }
 tempfile = { workspace = true }
+
+[lib]
+doctest = false

--- a/codex-rs/utils/pty/Cargo.toml
+++ b/codex-rs/utils/pty/Cargo.toml
@@ -32,3 +32,6 @@ winapi = { version = "0.3.9", features = [
 ] }
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
+
+[lib]
+doctest = false

--- a/codex-rs/utils/readiness/Cargo.toml
+++ b/codex-rs/utils/readiness/Cargo.toml
@@ -16,3 +16,6 @@ tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
 
 [lints]
 workspace = true
+
+[lib]
+doctest = false

--- a/codex-rs/utils/rustls-provider/Cargo.toml
+++ b/codex-rs/utils/rustls-provider/Cargo.toml
@@ -9,3 +9,7 @@ workspace = true
 
 [dependencies]
 rustls = { workspace = true }
+
+[lib]
+test = false
+doctest = false

--- a/codex-rs/utils/sandbox-summary/Cargo.toml
+++ b/codex-rs/utils/sandbox-summary/Cargo.toml
@@ -15,3 +15,6 @@ codex-protocol = { workspace = true }
 [dev-dependencies]
 codex-utils-absolute-path = { workspace = true }
 pretty_assertions = { workspace = true }
+
+[lib]
+doctest = false

--- a/codex-rs/utils/sleep-inhibitor/Cargo.toml
+++ b/codex-rs/utils/sleep-inhibitor/Cargo.toml
@@ -23,3 +23,6 @@ windows-sys = { version = "0.61.2", features = [
     "Win32_System_SystemServices",
     "Win32_System_Threading",
 ] }
+
+[lib]
+doctest = false

--- a/codex-rs/utils/stream-parser/Cargo.toml
+++ b/codex-rs/utils/stream-parser/Cargo.toml
@@ -9,3 +9,6 @@ workspace = true
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
+
+[lib]
+doctest = false

--- a/codex-rs/utils/string/Cargo.toml
+++ b/codex-rs/utils/string/Cargo.toml
@@ -14,3 +14,6 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
+
+[lib]
+doctest = false

--- a/codex-rs/utils/template/Cargo.toml
+++ b/codex-rs/utils/template/Cargo.toml
@@ -9,3 +9,6 @@ workspace = true
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
+
+[lib]
+doctest = false

--- a/codex-rs/v8-poc/Cargo.toml
+++ b/codex-rs/v8-poc/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [lib]
 name = "codex_v8_poc"
 path = "src/lib.rs"
+doctest = false
 
 [features]
 sandbox = ["v8/v8_enable_sandbox"]

--- a/codex-rs/windows-sandbox-rs/Cargo.toml
+++ b/codex-rs/windows-sandbox-rs/Cargo.toml
@@ -8,6 +8,7 @@ version.workspace = true
 [lib]
 name = "codex_windows_sandbox"
 path = "src/lib.rs"
+doctest = false
 
 [[bin]]
 name = "codex-windows-sandbox-setup"


### PR DESCRIPTION
## Summary

`cargo test` has entails both running standard Rust tests and doctests. It turns out that the doctest discovery is fairly slow, and it's a cost you pay even for crates that don't include any doctests.

This PR disables doctests with `doctest = false` for crates that lack any doctests.

For the collection of crates below, this speeds up test execution by >4x.

E.g., before this PR:

```
Benchmark 1: cargo test     -p codex-utils-absolute-path     -p codex-utils-cache     -p codex-utils-cli     -p codex-utils-home-dir     -p codex-utils-output-truncation     -p codex-utils-path     -p codex-utils-string     -p codex-utils-template     -p codex-utils-elapsed     -p codex-utils-json-to-toml
  Time (mean ± σ):      1.849 s ±  4.455 s    [User: 0.752 s, System: 1.367 s]
  Range (min … max):    0.418 s … 14.529 s    10 runs
```

And after:

```
Benchmark 1: cargo test     -p codex-utils-absolute-path     -p codex-utils-cache     -p codex-utils-cli     -p codex-utils-home-dir     -p codex-utils-output-truncation     -p codex-utils-path     -p codex-utils-string     -p codex-utils-template     -p codex-utils-elapsed     -p codex-utils-json-to-toml
  Time (mean ± σ):     428.6 ms ±   6.9 ms    [User: 187.7 ms, System: 219.7 ms]
  Range (min … max):   418.0 ms … 436.8 ms    10 runs
```

For a single crate, with >2x speedup, before:

```
Benchmark 1: cargo test -p codex-utils-string
  Time (mean ± σ):     491.1 ms ±   9.0 ms    [User: 229.8 ms, System: 234.9 ms]
  Range (min … max):   480.9 ms … 512.0 ms    10 runs
```

And after:

```
Benchmark 1: cargo test -p codex-utils-string
  Time (mean ± σ):     213.9 ms ±   4.3 ms    [User: 112.8 ms, System: 84.0 ms]
  Range (min … max):   206.8 ms … 221.0 ms    13 runs
```