### PR TITLE
Tune Windows nextest scheduling

### DIFF
--- a/.github/workflows/rust-ci-full.yml
+++ b/.github/workflows/rust-ci-full.yml
@@ -521,10 +521,10 @@ jobs:
   tests:
     name: Tests — ${{ matrix.runner }} - ${{ matrix.target }}${{ matrix.remote_env == 'true' && ' (remote)' || '' }}
     runs-on: ${{ matrix.runs_on || matrix.runner }}
-    # Perhaps we can bring this back down to 30m once we finish the cutover
-    # from tui_app_server/ to tui/. Incidentally, windows-arm64 was the main
-    # offender for exceeding the timeout.
-    timeout-minutes: 45
+    # Perhaps we can bring this back down once we finish the cutover from
+    # tui_app_server/ to tui/. Incidentally, windows-arm64 was the main offender
+    # for exceeding the timeout.
+    timeout-minutes: ${{ matrix.timeout_minutes || 45 }}
     defaults:
       run:
         working-directory: codex-rs
@@ -566,6 +566,7 @@ jobs:
           - runner: windows-arm64
             target: aarch64-pc-windows-msvc
             profile: dev
+            timeout_minutes: 75
             runs_on:
               group: codex-runners
               labels: codex-windows-arm64
@@ -652,8 +653,7 @@ jobs:
 
       - uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532 # v2.62.49
         with:
-          tool: nextest
-          version: 0.9.103
+          tool: nextest@0.9.103
 
       - name: Enable unprivileged user namespaces (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/rust-ci-full.yml
+++ b/.github/workflows/rust-ci-full.yml
@@ -1,10 +1,21 @@
 name: rust-ci-full
+run-name: >-
+  rust-ci-full${{
+    github.event_name == 'workflow_dispatch' &&
+    format(' windows-nextest-{0}', inputs.windows_nextest_threads) ||
+    ''
+  }}
 on:
   push:
     branches:
       - main
       - "**full-ci**"
   workflow_dispatch:
+    inputs:
+      windows_nextest_threads:
+        description: "Optional nextest --test-threads override for Windows test jobs"
+        required: false
+        type: string
 
 # CI builds in debug (dev) for faster signal.
 
@@ -524,6 +535,7 @@ jobs:
       USE_SCCACHE: ${{ (startsWith(matrix.runner, 'windows') || (matrix.runner == 'macos-15-xlarge' && matrix.target == 'x86_64-apple-darwin')) && 'false' || 'true' }}
       CARGO_INCREMENTAL: "0"
       SCCACHE_CACHE_SIZE: 10G
+      WINDOWS_NEXTEST_THREADS: ${{ github.event_name == 'workflow_dispatch' && inputs.windows_nextest_threads || '' }}
 
     strategy:
       fail-fast: false
@@ -666,7 +678,19 @@ jobs:
 
       - name: tests
         id: test
-        run: cargo nextest run --no-fail-fast --target ${{ matrix.target }} --cargo-profile ci-test --timings
+        shell: bash
+        run: |
+          set -euo pipefail
+          nextest_args=(
+            --no-fail-fast
+            --target "${{ matrix.target }}"
+            --cargo-profile ci-test
+            --timings
+          )
+          if [[ "${{ runner.os }}" == "Windows" && -n "${WINDOWS_NEXTEST_THREADS}" ]]; then
+            nextest_args+=(--test-threads "${WINDOWS_NEXTEST_THREADS}")
+          fi
+          cargo nextest run "${nextest_args[@]}"
         env:
           RUST_BACKTRACE: 1
           RUST_MIN_STACK: "8388608" # 8 MiB

--- a/codex-rs/.config/nextest.toml
+++ b/codex-rs/.config/nextest.toml
@@ -14,6 +14,9 @@ max-threads = 1
 [test-groups.windows_sandbox_legacy_sessions]
 max-threads = 1
 
+[test-groups.windows_process_heavy]
+max-threads = 1
+
 [[profile.default.overrides]]
 # Do not add new tests here
 filter = 'test(rmcp_client) | test(humanlike_typing_1000_chars_appears_live_no_placeholder)'
@@ -26,6 +29,41 @@ slow-timeout = { period = "30s", terminate-after = 2 }
 [[profile.default.overrides]]
 filter = 'package(codex-app-server-protocol) & (test(typescript_schema_fixtures_match_generated) | test(json_schema_fixtures_match_generated) | test(generate_ts_with_experimental_api_retains_experimental_entries) | test(generated_ts_optional_nullable_fields_only_in_params) | test(generate_json_filters_experimental_fields_and_methods))'
 test-group = 'app_server_protocol_codegen'
+
+[[profile.default.overrides]]
+# These Windows CI tests launch full Codex/app-server process trees. They have
+# repeatedly timed out when nextest schedules them alongside similar tests.
+platform = 'cfg(windows)'
+filter = 'package(codex-core) & kind(test) & (test(cli_stream) | test(realtime_conversation))'
+test-group = 'windows_process_heavy'
+threads-required = "num-test-threads"
+slow-timeout = { period = "1m", terminate-after = 4 }
+
+[[profile.default.overrides]]
+# The exec resume tests spawn the CLI and touch shared session state on disk.
+platform = 'cfg(windows)'
+filter = 'package(codex-exec) & kind(test) & test(exec_resume)'
+test-group = 'windows_process_heavy'
+threads-required = "num-test-threads"
+slow-timeout = { period = "1m", terminate-after = 4 }
+
+[[profile.default.overrides]]
+# Keep the specific app-server subprocess-heavy cases isolated on Windows. This
+# must stay before the broader codex-app-server override below.
+platform = 'cfg(windows)'
+filter = 'package(codex-app-server) & kind(test) & (test(thread_fork_can_exclude_turns_and_skip_restored_token_usage) | test(turn_start_resolves_sticky_thread_environments_and_turn_overrides) | test(message_processor_tracing_tests))'
+test-group = 'windows_process_heavy'
+threads-required = "num-test-threads"
+slow-timeout = { period = "1m", terminate-after = 4 }
+
+[[profile.default.overrides]]
+# These tests create restricted-token Windows child processes and private
+# desktops. Running them alone avoids contention with other subprocess tests.
+platform = 'cfg(windows)'
+filter = 'package(codex-windows-sandbox) & kind(test) & test(legacy_)'
+test-group = 'windows_process_heavy'
+threads-required = "num-test-threads"
+slow-timeout = { period = "1m", terminate-after = 4 }
 
 [[profile.default.overrides]]
 # These integration tests spawn a fresh app-server subprocess per case.


### PR DESCRIPTION
Stack: 3/5. Base: `starr/windows-ci-test-hardening`.

Depends on: https://github.com/openai/codex/pull/21588

## Summary
- Add a workflow-dispatch override for Windows nextest thread count.
- Serialize process-heavy tests under nextest on Windows.
- Give the Windows arm64 test lane enough timeout headroom for observed compile + test latency.
- Pin nextest using taiki-e/install-action's supported tool syntax.

## Validation
- Split from the prior full-stack Windows CI stabilization branch, which had repeated green Windows `rust-ci-full` runs.
- This PR is intentionally draft while stacked CI and review passes run.
