### PR TITLE
Use fast Windows work drive for CI temp and caches

### DIFF
--- a/.github/actions/setup-bazel-ci/action.yml
+++ b/.github/actions/setup-bazel-ci/action.yml
@@ -35,6 +35,11 @@ runs:
     - name: Set up Bazel
       uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
 
+    - name: Configure Dev Drive (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: ./.github/scripts/setup-dev-drive.ps1
+
     - name: Configure Bazel repository cache
       id: configure_bazel_repository_cache
       shell: pwsh
@@ -42,7 +47,12 @@ runs:
         # Keep the repository cache under HOME on all runners. Windows `D:\a`
         # cache paths match `.bazelrc`, but `actions/cache/restore` currently
         # returns HTTP 400 for that path in the Windows clippy job.
-        $repositoryCachePath = Join-Path $HOME '.cache/bazel-repo-cache'
+        $cacheRoot = if ($env:RUNNER_OS -eq 'Windows' -and $env:DEV_DRIVE) {
+          $env:DEV_DRIVE
+        } else {
+          $HOME
+        }
+        $repositoryCachePath = Join-Path $cacheRoot '.cache/bazel-repo-cache'
         "repository-cache-path=$repositoryCachePath" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
         "BAZEL_REPOSITORY_CACHE=$repositoryCachePath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
@@ -50,11 +60,10 @@ runs:
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
-        # Use the shortest available drive to reduce argv/path length issues,
-        # but avoid the drive root because some Windows test launchers mis-handle
-        # MANIFEST paths there.
-        $hasDDrive = Test-Path 'D:\'
-        $bazelOutputUserRoot = if ($hasDDrive) { 'D:\b' } else { 'C:\b' }
+        # Keep Bazel on the fast Windows work drive, but avoid the drive root
+        # because some Windows test launchers mis-handle MANIFEST paths there.
+        $driveRoot = if ($env:DEV_DRIVE) { $env:DEV_DRIVE } elseif (Test-Path 'D:\') { 'D:' } else { 'C:' }
+        $bazelOutputUserRoot = Join-Path $driveRoot 'b'
         $repoContentsCache = Join-Path $env:RUNNER_TEMP "bazel-repo-contents-cache-$env:GITHUB_RUN_ID-$env:GITHUB_JOB"
         "BAZEL_OUTPUT_USER_ROOT=$bazelOutputUserRoot" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         "BAZEL_REPO_CONTENTS_CACHE=$repoContentsCache" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/.github/actions/setup-bazel-ci/action.yml
+++ b/.github/actions/setup-bazel-ci/action.yml
@@ -64,7 +64,7 @@ runs:
         # because some Windows test launchers mis-handle MANIFEST paths there.
         $driveRoot = if ($env:DEV_DRIVE) { $env:DEV_DRIVE } elseif (Test-Path 'D:\') { 'D:' } else { 'C:' }
         $bazelOutputUserRoot = Join-Path $driveRoot 'b'
-        $repoContentsCache = Join-Path $env:RUNNER_TEMP "bazel-repo-contents-cache-$env:GITHUB_RUN_ID-$env:GITHUB_JOB"
+        $repoContentsCache = Join-Path $env:TEMP "bazel-repo-contents-cache-$env:GITHUB_RUN_ID-$env:GITHUB_JOB"
         "BAZEL_OUTPUT_USER_ROOT=$bazelOutputUserRoot" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         "BAZEL_REPO_CONTENTS_CACHE=$repoContentsCache" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 

--- a/.github/scripts/setup-dev-drive.ps1
+++ b/.github/scripts/setup-dev-drive.ps1
@@ -1,14 +1,19 @@
-# Configure a fast drive for Windows CI jobs.
+# Configure a Dev Drive for Windows CI jobs.
 #
-# GitHub-hosted Windows runners do not always expose a secondary D: volume. When
-# they do not, try to create a Dev Drive VHD and fall back to C: if the runner
-# image does not allow that provisioning path.
+# Try to create a Dev Drive VHD explicitly so Windows temp-heavy paths can use a
+# trusted ReFS Dev Drive. Fall back to the runner-provided D: drive, then C:, if
+# the runner image does not allow that provisioning path.
 
-function Use-FallbackDrive {
+function Select-FallbackDrive {
     param([string]$Reason)
 
-    Write-Warning "$Reason Falling back to C:"
-    return "C:"
+    if (Test-Path "D:\") {
+        Write-Warning "$Reason Falling back to existing drive at D:"
+        return "D:"
+    } else {
+        Write-Warning "$Reason Falling back to C:"
+        return "C:"
+    }
 }
 
 function Invoke-BestEffort {
@@ -21,44 +26,40 @@ function Invoke-BestEffort {
     }
 }
 
-if (Test-Path "D:\") {
-    Write-Output "Using existing drive at D:"
-    $Drive = "D:"
-} else {
-    try {
-        $VhdPath = Join-Path $env:RUNNER_TEMP "codex-dev-drive.vhdx"
-        $SizeBytes = 64GB
+try {
+    $VhdPath = Join-Path $env:RUNNER_TEMP "codex-dev-drive.vhdx"
+    $SizeBytes = 64GB
 
-        if (Test-Path $VhdPath) {
-            Remove-Item -Path $VhdPath -Force
-        }
-
-        New-VHD -Path $VhdPath -SizeBytes $SizeBytes -Dynamic -ErrorAction Stop | Out-Null
-        $Mounted = Mount-VHD -Path $VhdPath -Passthru -ErrorAction Stop
-        $Disk = $Mounted | Get-Disk -ErrorAction Stop
-        $Disk | Initialize-Disk -PartitionStyle GPT -ErrorAction Stop
-        $Partition = $Disk | New-Partition -AssignDriveLetter -UseMaximumSize -ErrorAction Stop
-        $Volume = $Partition | Format-Volume -FileSystem ReFS -NewFileSystemLabel "CodexDevDrive" -DevDrive -Confirm:$false -Force -ErrorAction Stop
-
-        $Drive = "$($Volume.DriveLetter):"
-
-        Invoke-BestEffort { fsutil devdrv trust $Drive } "Trusting Dev Drive $Drive"
-        Invoke-BestEffort { fsutil devdrv enable /disallowAv } "Disabling AV filter attachment for Dev Drives"
-        try {
-            Dismount-VHD -Path $VhdPath
-            Mount-VHD -Path $VhdPath | Out-Null
-        } catch {
-            Write-Warning "Remounting Dev Drive $Drive failed: $($_.Exception.Message)"
-            if (-not (Test-Path "$Drive\")) {
-                throw
-            }
-        }
-        Invoke-BestEffort { fsutil devdrv query $Drive } "Querying Dev Drive $Drive"
-
-        Write-Output "Using Dev Drive at $Drive"
-    } catch {
-        $Drive = Use-FallbackDrive "Failed to create Dev Drive: $($_.Exception.Message)"
+    if (Test-Path $VhdPath) {
+        Remove-Item -Path $VhdPath -Force
     }
+
+    New-VHD -Path $VhdPath -SizeBytes $SizeBytes -Dynamic -ErrorAction Stop | Out-Null
+    $Mounted = Mount-VHD -Path $VhdPath -Passthru -ErrorAction Stop
+    $Disk = $Mounted | Get-Disk -ErrorAction Stop
+    $Disk | Initialize-Disk -PartitionStyle GPT -ErrorAction Stop
+    $Partition = $Disk | New-Partition -AssignDriveLetter -UseMaximumSize -ErrorAction Stop
+    $Volume = $Partition | Format-Volume -FileSystem ReFS -NewFileSystemLabel "CodexDevDrive" -DevDrive -Confirm:$false -Force -ErrorAction Stop
+
+    $Drive = "$($Volume.DriveLetter):"
+
+    Invoke-BestEffort { fsutil devdrv trust $Drive } "Trusting Dev Drive $Drive"
+    Invoke-BestEffort { fsutil devdrv enable /disallowAv } "Disabling AV filter attachment for Dev Drives"
+    try {
+        Dismount-VHD -Path $VhdPath
+        Mount-VHD -Path $VhdPath | Out-Null
+    } catch {
+        Write-Warning "Remounting Dev Drive $Drive failed: $($_.Exception.Message)"
+        if (-not (Test-Path "$Drive\")) {
+            throw
+        }
+    }
+    Invoke-BestEffort { fsutil devdrv query $Drive } "Querying Dev Drive $Drive"
+
+    Write-Output "Using Dev Drive at $Drive"
+} catch {
+    $Drive = Select-FallbackDrive "Failed to create Dev Drive: $($_.Exception.Message)"
+    Invoke-BestEffort { fsutil devdrv query $Drive } "Querying fallback drive $Drive"
 }
 
 $Tmp = "$Drive\codex-tmp"

--- a/.github/scripts/setup-dev-drive.ps1
+++ b/.github/scripts/setup-dev-drive.ps1
@@ -44,6 +44,15 @@ if (Test-Path "D:\") {
 
         Invoke-BestEffort { fsutil devdrv trust $Drive } "Trusting Dev Drive $Drive"
         Invoke-BestEffort { fsutil devdrv enable /disallowAv } "Disabling AV filter attachment for Dev Drives"
+        try {
+            Dismount-VHD -Path $VhdPath
+            Mount-VHD -Path $VhdPath | Out-Null
+        } catch {
+            Write-Warning "Remounting Dev Drive $Drive failed: $($_.Exception.Message)"
+            if (-not (Test-Path "$Drive\")) {
+                throw
+            }
+        }
         Invoke-BestEffort { fsutil devdrv query $Drive } "Querying Dev Drive $Drive"
 
         Write-Output "Using Dev Drive at $Drive"
@@ -55,8 +64,12 @@ if (Test-Path "D:\") {
 $Tmp = "$Drive\codex-tmp"
 New-Item -Path $Tmp -ItemType Directory -Force | Out-Null
 
+$CargoTargetDir = "$Drive\codex-cargo-target"
+New-Item -Path $CargoTargetDir -ItemType Directory -Force | Out-Null
+
 @(
     "DEV_DRIVE=$Drive"
+    "CARGO_TARGET_DIR=$CargoTargetDir"
     "TMP=$Tmp"
     "TEMP=$Tmp"
 ) | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/.github/scripts/setup-dev-drive.ps1
+++ b/.github/scripts/setup-dev-drive.ps1
@@ -1,0 +1,62 @@
+# Configure a fast drive for Windows CI jobs.
+#
+# GitHub-hosted Windows runners do not always expose a secondary D: volume. When
+# they do not, try to create a Dev Drive VHD and fall back to C: if the runner
+# image does not allow that provisioning path.
+
+function Use-FallbackDrive {
+    param([string]$Reason)
+
+    Write-Warning "$Reason Falling back to C:"
+    return "C:"
+}
+
+function Invoke-BestEffort {
+    param([scriptblock]$Script, [string]$Description)
+
+    try {
+        & $Script
+    } catch {
+        Write-Warning "$Description failed: $($_.Exception.Message)"
+    }
+}
+
+if (Test-Path "D:\") {
+    Write-Output "Using existing drive at D:"
+    $Drive = "D:"
+} else {
+    try {
+        $VhdPath = Join-Path $env:RUNNER_TEMP "codex-dev-drive.vhdx"
+        $SizeBytes = 64GB
+
+        if (Test-Path $VhdPath) {
+            Remove-Item -Path $VhdPath -Force
+        }
+
+        New-VHD -Path $VhdPath -SizeBytes $SizeBytes -Dynamic -ErrorAction Stop | Out-Null
+        $Mounted = Mount-VHD -Path $VhdPath -Passthru -ErrorAction Stop
+        $Disk = $Mounted | Get-Disk -ErrorAction Stop
+        $Disk | Initialize-Disk -PartitionStyle GPT -ErrorAction Stop
+        $Partition = $Disk | New-Partition -AssignDriveLetter -UseMaximumSize -ErrorAction Stop
+        $Volume = $Partition | Format-Volume -FileSystem ReFS -NewFileSystemLabel "CodexDevDrive" -DevDrive -Confirm:$false -Force -ErrorAction Stop
+
+        $Drive = "$($Volume.DriveLetter):"
+
+        Invoke-BestEffort { fsutil devdrv trust $Drive } "Trusting Dev Drive $Drive"
+        Invoke-BestEffort { fsutil devdrv enable /disallowAv } "Disabling AV filter attachment for Dev Drives"
+        Invoke-BestEffort { fsutil devdrv query $Drive } "Querying Dev Drive $Drive"
+
+        Write-Output "Using Dev Drive at $Drive"
+    } catch {
+        $Drive = Use-FallbackDrive "Failed to create Dev Drive: $($_.Exception.Message)"
+    }
+}
+
+$Tmp = "$Drive\codex-tmp"
+New-Item -Path $Tmp -ItemType Directory -Force | Out-Null
+
+@(
+    "DEV_DRIVE=$Drive"
+    "TMP=$Tmp"
+    "TEMP=$Tmp"
+) | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/.github/scripts/setup-dev-drive.ps1
+++ b/.github/scripts/setup-dev-drive.ps1
@@ -1,19 +1,14 @@
-# Configure a Dev Drive for Windows CI jobs.
+# Configure a fast drive for Windows CI jobs.
 #
-# Try to create a Dev Drive VHD explicitly so Windows temp-heavy paths can use a
-# trusted ReFS Dev Drive. Fall back to the runner-provided D: drive, then C:, if
-# the runner image does not allow that provisioning path.
+# GitHub-hosted Windows runners do not always expose a secondary D: volume. When
+# they do not, try to create a Dev Drive VHD and fall back to C: if the runner
+# image does not allow that provisioning path.
 
-function Select-FallbackDrive {
+function Use-FallbackDrive {
     param([string]$Reason)
 
-    if (Test-Path "D:\") {
-        Write-Warning "$Reason Falling back to existing drive at D:"
-        return "D:"
-    } else {
-        Write-Warning "$Reason Falling back to C:"
-        return "C:"
-    }
+    Write-Warning "$Reason Falling back to C:"
+    return "C:"
 }
 
 function Invoke-BestEffort {
@@ -26,40 +21,44 @@ function Invoke-BestEffort {
     }
 }
 
-try {
-    $VhdPath = Join-Path $env:RUNNER_TEMP "codex-dev-drive.vhdx"
-    $SizeBytes = 64GB
-
-    if (Test-Path $VhdPath) {
-        Remove-Item -Path $VhdPath -Force
-    }
-
-    New-VHD -Path $VhdPath -SizeBytes $SizeBytes -Dynamic -ErrorAction Stop | Out-Null
-    $Mounted = Mount-VHD -Path $VhdPath -Passthru -ErrorAction Stop
-    $Disk = $Mounted | Get-Disk -ErrorAction Stop
-    $Disk | Initialize-Disk -PartitionStyle GPT -ErrorAction Stop
-    $Partition = $Disk | New-Partition -AssignDriveLetter -UseMaximumSize -ErrorAction Stop
-    $Volume = $Partition | Format-Volume -FileSystem ReFS -NewFileSystemLabel "CodexDevDrive" -DevDrive -Confirm:$false -Force -ErrorAction Stop
-
-    $Drive = "$($Volume.DriveLetter):"
-
-    Invoke-BestEffort { fsutil devdrv trust $Drive } "Trusting Dev Drive $Drive"
-    Invoke-BestEffort { fsutil devdrv enable /disallowAv } "Disabling AV filter attachment for Dev Drives"
+if (Test-Path "D:\") {
+    Write-Output "Using existing drive at D:"
+    $Drive = "D:"
+} else {
     try {
-        Dismount-VHD -Path $VhdPath
-        Mount-VHD -Path $VhdPath | Out-Null
-    } catch {
-        Write-Warning "Remounting Dev Drive $Drive failed: $($_.Exception.Message)"
-        if (-not (Test-Path "$Drive\")) {
-            throw
-        }
-    }
-    Invoke-BestEffort { fsutil devdrv query $Drive } "Querying Dev Drive $Drive"
+        $VhdPath = Join-Path $env:RUNNER_TEMP "codex-dev-drive.vhdx"
+        $SizeBytes = 64GB
 
-    Write-Output "Using Dev Drive at $Drive"
-} catch {
-    $Drive = Select-FallbackDrive "Failed to create Dev Drive: $($_.Exception.Message)"
-    Invoke-BestEffort { fsutil devdrv query $Drive } "Querying fallback drive $Drive"
+        if (Test-Path $VhdPath) {
+            Remove-Item -Path $VhdPath -Force
+        }
+
+        New-VHD -Path $VhdPath -SizeBytes $SizeBytes -Dynamic -ErrorAction Stop | Out-Null
+        $Mounted = Mount-VHD -Path $VhdPath -Passthru -ErrorAction Stop
+        $Disk = $Mounted | Get-Disk -ErrorAction Stop
+        $Disk | Initialize-Disk -PartitionStyle GPT -ErrorAction Stop
+        $Partition = $Disk | New-Partition -AssignDriveLetter -UseMaximumSize -ErrorAction Stop
+        $Volume = $Partition | Format-Volume -FileSystem ReFS -NewFileSystemLabel "CodexDevDrive" -DevDrive -Confirm:$false -Force -ErrorAction Stop
+
+        $Drive = "$($Volume.DriveLetter):"
+
+        Invoke-BestEffort { fsutil devdrv trust $Drive } "Trusting Dev Drive $Drive"
+        Invoke-BestEffort { fsutil devdrv enable /disallowAv } "Disabling AV filter attachment for Dev Drives"
+        try {
+            Dismount-VHD -Path $VhdPath
+            Mount-VHD -Path $VhdPath | Out-Null
+        } catch {
+            Write-Warning "Remounting Dev Drive $Drive failed: $($_.Exception.Message)"
+            if (-not (Test-Path "$Drive\")) {
+                throw
+            }
+        }
+        Invoke-BestEffort { fsutil devdrv query $Drive } "Querying Dev Drive $Drive"
+
+        Write-Output "Using Dev Drive at $Drive"
+    } catch {
+        $Drive = Use-FallbackDrive "Failed to create Dev Drive: $($_.Exception.Message)"
+    }
 }
 
 $Tmp = "$Drive\codex-tmp"

--- a/.github/workflows/rust-ci-full.yml
+++ b/.github/workflows/rust-ci-full.yml
@@ -161,6 +161,7 @@ jobs:
       # mixed-architecture archives under sccache.
       USE_SCCACHE: ${{ (startsWith(matrix.runner, 'windows') || (matrix.runner == 'macos-15-xlarge' && matrix.target == 'x86_64-apple-darwin')) && 'false' || 'true' }}
       CARGO_INCREMENTAL: "0"
+      CARGO_TARGET_DIR: ${{ github.workspace }}/codex-rs/target
       SCCACHE_CACHE_SIZE: 10G
       # In rust-ci, representative release-profile checks use thin LTO for faster feedback.
       CARGO_PROFILE_RELEASE_LTO: ${{ matrix.profile == 'release' && 'thin' || 'fat' }}
@@ -470,7 +471,7 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: cargo-timings-rust-ci-clippy-${{ matrix.target }}-${{ matrix.profile }}
-          path: codex-rs/target/**/cargo-timings/cargo-timing.html
+          path: ${{ env.CARGO_TARGET_DIR }}/**/cargo-timings/cargo-timing.html
           if-no-files-found: warn
 
       # Save caches explicitly; make non-fatal so cache packaging
@@ -541,6 +542,7 @@ jobs:
       # mixed-architecture archives under sccache.
       USE_SCCACHE: ${{ (startsWith(matrix.runner, 'windows') || (matrix.runner == 'macos-15-xlarge' && matrix.target == 'x86_64-apple-darwin')) && 'false' || 'true' }}
       CARGO_INCREMENTAL: "0"
+      CARGO_TARGET_DIR: ${{ github.workspace }}/codex-rs/target
       SCCACHE_CACHE_SIZE: 10G
 
     strategy:
@@ -701,7 +703,7 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: cargo-timings-rust-ci-nextest-${{ matrix.target }}-${{ matrix.profile }}
-          path: codex-rs/target/**/cargo-timings/cargo-timing.html
+          path: ${{ env.CARGO_TARGET_DIR }}/**/cargo-timings/cargo-timing.html
           if-no-files-found: warn
 
       - name: Save cargo home cache

--- a/.github/workflows/rust-ci-full.yml
+++ b/.github/workflows/rust-ci-full.yml
@@ -248,6 +248,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Configure Dev Drive (Windows)
+        if: ${{ runner.os == 'Windows' }}
+        shell: pwsh
+        run: ../.github/scripts/setup-dev-drive.ps1
       - name: Install Linux build dependencies
         if: ${{ runner.os == 'Linux' }}
         shell: bash
@@ -576,6 +580,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Configure Dev Drive (Windows)
+        if: ${{ runner.os == 'Windows' }}
+        shell: pwsh
+        run: ../.github/scripts/setup-dev-drive.ps1
       - name: Install Linux build dependencies
         if: ${{ runner.os == 'Linux' }}
         shell: bash


### PR DESCRIPTION
## Summary

- Add a Windows CI setup script that uses the existing `D:` runner work drive when present, provisions a Dev Drive VHD only when no secondary drive exists, and falls back to `C:`.
- Export `DEV_DRIVE`, `TMP`/`TEMP`, and `CARGO_TARGET_DIR` so temp-heavy Rust and Bazel paths use the selected Windows drive.
- Wire the shared Bazel CI action and Windows `rust-ci-full` build/test jobs through that setup, including Bazel repository cache and repo contents cache paths.

## Validation

- Not run locally; this is a CI workflow-only change.
- Previous CI on this branch passed before the rebase, and Windows logs showed the setup choosing `D:` with `DEV_DRIVE=D:`, `TMP`/`TEMP=D:\codex-tmp`, `CARGO_TARGET_DIR=D:\codex-cargo-target`, `BAZEL_OUTPUT_USER_ROOT=D:\b`, and Bazel repository caches on the selected drive.
