### PR TITLE
Ensure all mentions of cargo-install are --locked

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,7 +130,7 @@ When UI or text output changes intentionally, update the snapshots as follows:
 
 If you don’t have the tool:
 
-- `cargo install cargo-insta`
+- `cargo install --locked cargo-insta`
 
 ### Test assertions
 

--- a/codex-rs/core/src/exec_policy_tests.rs
+++ b/codex-rs/core/src/exec_policy_tests.rs
@@ -1466,7 +1466,7 @@ async fn request_rule_falls_back_when_prefix_rule_does_not_approve_all_commands(
     let command = vec![
         "bash".to_string(),
         "-lc".to_string(),
-        "cargo install cargo-insta && rm -rf /tmp/codex".to_string(),
+        "cargo install --locked cargo-insta && rm -rf /tmp/codex".to_string(),
     ];
     let manager = ExecPolicyManager::default();
 

--- a/codex-rs/core/src/exec_policy_tests.rs
+++ b/codex-rs/core/src/exec_policy_tests.rs
@@ -1466,7 +1466,7 @@ async fn request_rule_falls_back_when_prefix_rule_does_not_approve_all_commands(
     let command = vec![
         "bash".to_string(),
         "-lc".to_string(),
-        "cargo install --locked cargo-insta && rm -rf /tmp/codex".to_string(),
+        "cargo install cargo-insta && rm -rf /tmp/codex".to_string(),
     ];
     let manager = ExecPolicyManager::default();
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -25,7 +25,7 @@ source "$HOME/.cargo/env"
 rustup component add rustfmt
 rustup component add clippy
 # Install helper tools used by the workspace justfile:
-cargo install just
+cargo install --locked just
 # Optional: install nextest for the `just test` helper
 cargo install --locked cargo-nextest
 

--- a/justfile
+++ b/justfile
@@ -47,7 +47,7 @@ install:
 # Run `cargo nextest` since it's faster than `cargo test`, though including
 # --no-fail-fast is important to ensure all tests are run.
 #
-# Run `cargo install cargo-nextest` if you don't have it installed.
+# Run `cargo install --locked cargo-nextest` if you don't have it installed.
 # Prefer this for routine local runs. Workspace crate features are banned, so
 # there should be no need to add `--all-features`.
 test:

--- a/tools/argument-comment-lint/README.md
+++ b/tools/argument-comment-lint/README.md
@@ -54,7 +54,7 @@ create_openai_url(None, 3);
 Install the required tooling once:
 
 ```bash
-cargo install cargo-dylint dylint-link
+cargo install --locked cargo-dylint dylint-link
 rustup toolchain install nightly-2025-09-18 \
   --component llvm-tools-preview \
   --component rustc-dev \


### PR DESCRIPTION
There's already a preference for this in the codebase, but a few of them have drifted away. Generally `--locked` is preferred to reduce exposure to supply-chain attacks (and just generally improve reproducibility).

In an ideal world these dependencies would maybe even be pinned to versions but Cargo is kinda bad at that for devtools. Still better to use --locked than not.