### PR TITLE
[codex] Apply a Dependabot cooldown of 7 days

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,25 +6,37 @@ updates:
     directory: .github/actions/codex
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
   - package-ecosystem: cargo
     directories:
       - codex-rs
       - codex-rs/*
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
   - package-ecosystem: devcontainers
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
   - package-ecosystem: docker
     directory: codex-cli
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
   - package-ecosystem: rust-toolchain
     directory: codex-rs
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
This adds 7-day cooldowns to all of our Dependabot ecosystem blocks. Our Dependabot runs will continue at the same cadence as before, but the scheduled PRs will no suggest updates that are fewer than 7 days old themselves. This serves two purposes: to let dependencies "bake" for a bit in terms of stability before we adopt them, and to give third-party security services/tooling a chance to detect and revoke malware.

This should have no functional changes/consequences besides how rapidly we get (non-security) updates. Dependabot security PRs can still be scheduled and will bypass the cooldown.