### PR TITLE
Use `--locked` in cargo build and lint invocations

### DIFF
--- a/.github/workflows/rust-ci-full.yml
+++ b/.github/workflows/rust-ci-full.yml
@@ -445,7 +445,7 @@ jobs:
           cargo chef cook --recipe-path "$RECIPE" --target ${{ matrix.target }} --release
 
       - name: cargo clippy
-        run: cargo clippy --target ${{ matrix.target }} --tests --profile ${{ matrix.profile }} --timings -- -D warnings
+        run: cargo clippy --target ${{ matrix.target }} --tests --profile ${{ matrix.profile }} --timings --locked -- -D warnings
 
       - name: Upload Cargo timings (clippy)
         if: always()

--- a/.github/workflows/rust-release-argument-comment-lint.yml
+++ b/.github/workflows/rust-release-argument-comment-lint.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Cargo build
         working-directory: tools/argument-comment-lint
         shell: bash
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --release --target ${{ matrix.target }} --locked
 
       - name: Stage artifact
         shell: bash

--- a/.github/workflows/rust-release-windows.yml
+++ b/.github/workflows/rust-release-windows.yml
@@ -109,7 +109,7 @@ jobs:
           for binary in ${{ matrix.binaries }}; do
             build_args+=(--bin "$binary")
           done
-          cargo build --target ${{ matrix.target }} --release --timings "${build_args[@]}"
+          cargo build --target ${{ matrix.target }} --release --timings --locked "${build_args[@]}"
 
       - name: Upload Cargo timings
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -261,7 +261,7 @@ jobs:
         run: |
           set -euo pipefail
           target="${{ matrix.target }}"
-          cargo build --target "$target" --release --timings --bin bwrap
+          cargo build --target "$target" --release --timings --locked --bin bwrap
 
           bwrap_path="target/${target}/release/bwrap"
           if [[ ! -f "$bwrap_path" ]]; then
@@ -281,7 +281,7 @@ jobs:
             build_args+=(--bin "$binary")
           done
           echo "CARGO_PROFILE_RELEASE_LTO: ${CARGO_PROFILE_RELEASE_LTO}"
-          cargo build --target ${{ matrix.target }} --release --timings "${build_args[@]}"
+          cargo build --target ${{ matrix.target }} --release --timings --locked "${build_args[@]}"
 
       - name: Upload Cargo timings
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7


### PR DESCRIPTION
This ensures CI fails if the committed lockfile is outdated