### PR TITLE
[codex] Cover adjacent ripgrep unsafe spellings

### DIFF
--- a/codex-rs/shell-command/src/bash.rs
+++ b/codex-rs/shell-command/src/bash.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::path::PathBuf;
 
 use tree_sitter::Node;
@@ -115,8 +116,55 @@ pub fn extract_bash_command(command: &[String]) -> Option<(&str, &str)> {
 pub fn parse_shell_lc_plain_commands(command: &[String]) -> Option<Vec<Vec<String>>> {
     let (_, script) = extract_bash_command(command)?;
 
-    let tree = try_parse_shell(script)?;
-    try_parse_word_only_commands_sequence(&tree, script)
+    let script = strip_line_continuations(script);
+    let tree = try_parse_shell(&script)?;
+    try_parse_word_only_commands_sequence(&tree, &script)
+}
+
+fn strip_line_continuations(script: &str) -> Cow<'_, str> {
+    if !script.contains("\\\n") {
+        return Cow::Borrowed(script);
+    }
+
+    let mut stripped = String::with_capacity(script.len());
+    let mut chars = script.chars().peekable();
+    let mut escaped = false;
+    let mut in_double_quote = false;
+    let mut in_single_quote = false;
+    let mut stripped_any = false;
+
+    while let Some(ch) = chars.next() {
+        if escaped {
+            stripped.push(ch);
+            escaped = false;
+        } else if ch == '\\' && !in_single_quote {
+            if chars.peek() == Some(&'\n') {
+                chars.next();
+                stripped_any = true;
+                continue;
+            }
+
+            stripped.push(ch);
+            escaped = true;
+        } else {
+            match ch {
+                '\'' if !in_double_quote => {
+                    in_single_quote = !in_single_quote;
+                }
+                '"' if !in_single_quote => {
+                    in_double_quote = !in_double_quote;
+                }
+                _ => {}
+            }
+            stripped.push(ch);
+        }
+    }
+
+    if stripped_any {
+        Cow::Owned(stripped)
+    } else {
+        Cow::Borrowed(script)
+    }
 }
 
 /// Returns the parsed argv for a single shell command in a here-doc style
@@ -272,6 +320,7 @@ fn unescape_unquoted_word(raw: &str) -> Option<String> {
         }
 
         match chars.next() {
+            Some('\n') => {}
             Some(escaped) => unescaped.push(escaped),
             None => return None,
         }
@@ -404,6 +453,34 @@ mod tests {
                 "--pre=./pre.sh".to_string(),
                 "pattern".to_string(),
             ]]
+        );
+    }
+
+    #[test]
+    fn shell_lc_parser_removes_line_continuations_outside_single_quotes() {
+        assert_eq!(
+            parse_shell_lc_plain_commands(&[
+                "bash".to_string(),
+                "-lc".to_string(),
+                "echo foo\\\nbar".to_string(),
+            ]),
+            Some(vec![vec!["echo".to_string(), "foobar".to_string()]])
+        );
+        assert_eq!(
+            parse_shell_lc_plain_commands(&[
+                "bash".to_string(),
+                "-lc".to_string(),
+                "echo \"foo\\\nbar\"".to_string(),
+            ]),
+            Some(vec![vec!["echo".to_string(), "foobar".to_string()]])
+        );
+        assert_eq!(
+            parse_shell_lc_plain_commands(&[
+                "bash".to_string(),
+                "-lc".to_string(),
+                "echo 'foo\\\nbar'".to_string(),
+            ]),
+            Some(vec![vec!["echo".to_string(), "foo\\\nbar".to_string()]])
         );
     }
 

--- a/codex-rs/shell-command/src/command_safety/is_safe_command.rs
+++ b/codex-rs/shell-command/src/command_safety/is_safe_command.rs
@@ -570,7 +570,10 @@ mod tests {
         // Unsafe flags that do not take an argument (present verbatim).
         for args in [
             vec_str(&["rg", "--search-zip", "files"]),
+            vec_str(&["rg", "--search-zip=true", "files"]),
             vec_str(&["rg", "-z", "files"]),
+            vec_str(&["rg", "-zn", "files"]),
+            vec_str(&["rg", "-nz", "files"]),
         ] {
             assert!(
                 !is_safe_to_call_with_exec(&args),
@@ -599,6 +602,9 @@ mod tests {
             r"rg --\pre=./pre.sh files",
             r"rg --hostname\-bin=hostname files",
             r"rg -\z files",
+            r"rg -\zn needle .",
+            "rg --pr\\\ne=./pre.sh files",
+            "rg \"--pr\\\ne=./pre.sh\" files",
         ] {
             assert!(
                 !is_known_safe_command(&vec_str(&["bash", "-lc", script])),

--- a/codex-rs/shell-command/src/command_safety/ripgrep.rs
+++ b/codex-rs/shell-command/src/command_safety/ripgrep.rs
@@ -35,7 +35,10 @@ fn is_unsafe_ripgrep_arg(arg: &str, arg_case: RipgrepArgCase) -> bool {
         // out of an abundance of caution.
         "--search-zip" => true,
         "-z" => true,
-        _ => false,
+        _ => {
+            normalized.starts_with("--search-zip=")
+                || ripgrep_short_options_contain_search_zip(arg, arg_case)
+        }
     }
 }
 
@@ -57,6 +60,33 @@ fn normalize_arg(arg: &str, arg_case: RipgrepArgCase) -> Cow<'_, str> {
     }
 }
 
+fn ripgrep_short_options_contain_search_zip(arg: &str, arg_case: RipgrepArgCase) -> bool {
+    let Some(short_options) = arg.strip_prefix('-') else {
+        return false;
+    };
+    if short_options.is_empty() || short_options.starts_with('-') {
+        return false;
+    }
+
+    for option in short_options.chars() {
+        if option == 'z' || (arg_case == RipgrepArgCase::AsciiInsensitive && option == 'Z') {
+            return true;
+        }
+        if ripgrep_short_option_takes_value(option) {
+            return false;
+        }
+    }
+
+    false
+}
+
+fn ripgrep_short_option_takes_value(option: char) -> bool {
+    matches!(
+        option,
+        'A' | 'B' | 'C' | 'E' | 'M' | 'T' | 'd' | 'e' | 'f' | 'g' | 'j' | 'm' | 'r' | 't'
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -73,7 +103,10 @@ mod tests {
             vec_str(&["rg", "--hostname-bin", "pwned", "files"]),
             vec_str(&["rg", "--hostname-bin=pwned", "files"]),
             vec_str(&["rg", "--search-zip", "files"]),
+            vec_str(&["rg", "--search-zip=true", "files"]),
             vec_str(&["rg", "-z", "files"]),
+            vec_str(&["rg", "-zn", "files"]),
+            vec_str(&["rg", "-nz", "files"]),
         ] {
             assert!(
                 !is_safe_ripgrep_command(&args, RipgrepArgCase::Sensitive),
@@ -88,12 +121,21 @@ mod tests {
             vec_str(&["rg", "--PRE", "pwned", "files"]),
             vec_str(&["rg", "--HOSTNAME-BIN=pwned", "files"]),
             vec_str(&["rg", "--SEARCH-ZIP", "files"]),
+            vec_str(&["rg", "--SEARCH-ZIP=true", "files"]),
             vec_str(&["rg", "-Z", "files"]),
+            vec_str(&["rg", "-ZN", "files"]),
+            vec_str(&["rg", "-Fz", "needle", "."]),
         ] {
             assert!(
                 !is_safe_ripgrep_command(&args, RipgrepArgCase::AsciiInsensitive),
                 "expected {args:?} to be unsafe with case insensitive matching",
             );
         }
+
+        let args = vec_str(&["rg", "-fz", "needle", "."]);
+        assert!(
+            is_safe_ripgrep_command(&args, RipgrepArgCase::AsciiInsensitive),
+            "expected lowercase -f to consume z as its pattern-file value",
+        );
     }
 }


### PR DESCRIPTION
## Summary

1. Add line continuation handling for shell parsed command words.
2. Cover adjacent ripgrep unsafe option spellings.
3. Keep this separate from PR 21392 so that report stays scoped to the proven macOS path.

## Validation

1. Focused shell command ripgrep tests passed.

## Base

1. Stacked on PR 21611.
