### PR TITLE
Use `CARGO_NET_GIT_FETCH_WITH_CLI` in `rust-ci-full` for more reliable git fetches

### DIFF
--- a/.github/workflows/rust-ci-full.yml
+++ b/.github/workflows/rust-ci-full.yml
@@ -7,6 +7,11 @@ on:
   workflow_dispatch:
 
 # CI builds in debug (dev) for faster signal.
+env:
+  # Cargo's libgit2 transport has been flaky on macOS when fetching git
+  # dependencies with nested submodules. Use the system git CLI, which has
+  # better network/proxy behavior and matches Cargo's own suggested fallback.
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
 
 jobs:
   # --- CI that doesn't need specific targets ---------------------------------


### PR DESCRIPTION
Cargo uses libgit2 by default. In uv, we gave up this entirely and always call out to the git CLI because it is much more reliable. This is a part of my attempt to reduce flakes in `rust-ci-full`.