### PR TITLE
Display blended token count in status line

### DIFF
--- a/codex-rs/tui/src/chatwidget/status_surfaces.rs
+++ b/codex-rs/tui/src/chatwidget/status_surfaces.rs
@@ -592,7 +592,7 @@ impl ChatWidget {
             StatusLineItem::Status => Some(self.run_state_status_text()),
             StatusLineItem::UsedTokens => {
                 let usage = self.status_line_total_usage();
-                let total = usage.tokens_in_context_window();
+                let total = usage.blended_total();
                 if total <= 0 {
                     None
                 } else {

--- a/codex-rs/tui/src/token_usage.rs
+++ b/codex-rs/tui/src/token_usage.rs
@@ -34,6 +34,8 @@ impl TokenUsage {
         (self.non_cached_input() + self.output_tokens.max(0)).max(0)
     }
 
+    /// Returns the raw `total_tokens` value. For `last_token_usage`, this is the latest active
+    /// context size; for `total_token_usage`, this is the accumulated session total.
     pub(crate) fn tokens_in_context_window(&self) -> i64 {
         self.total_tokens
     }


### PR DESCRIPTION
## Why

The configurable `/statusline` and terminal title can display session token usage. That display was using the raw total token count, which includes cached input tokens, so it significantly overstated the token usage compared with the blended token count shown elsewhere (in `/status` and tracked in goals). This inconsistency resulted in user confusion. We don't want to report cached tokens because we don't charge for them and they are somewhat of an implementation detail that users shouldn't care about.

## What changed

- Use `TokenUsage::blended_total()` for the `used-tokens` status surface item so cached input is excluded.
- Add a brief comment to `tokens_in_context_window()` clarifying that it returns raw `total_tokens`, whose meaning depends on whether the caller has last-turn or accumulated usage.