### PR TITLE
Fix memories announcement copy

### DIFF
--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -793,7 +793,7 @@ pub const FEATURES: &[FeatureSpec] = &[
         stage: Stage::Experimental {
             name: "Memories",
             menu_description: "Allow Codex to create new memories from conversations and bring relevant memories into new conversations.",
-            announcement: "NEW: Codex can now generate and use memories. Try it now with `/memories`",
+            announcement: "NEW: Codex can now generate and use memories. Try this now with `/memories`.",
         },
         default_enabled: false,
     },


### PR DESCRIPTION
Fixes #21306.

The memories experimental announcement currently tells users to "Try it now with /memories". This updates the copy to the reporter-provided wording so the startup tip reads more naturally and ends with punctuation.

The change is limited to the `Feature::MemoryTool` announcement string in `codex-rs/features/src/lib.rs`.