### PR TITLE
Fix duplicate CLI issue template description

### DIFF
--- a/.github/ISSUE_TEMPLATE/3-cli.yml
+++ b/.github/ISSUE_TEMPLATE/3-cli.yml
@@ -41,9 +41,9 @@ body:
     id: terminal
     attributes:
       label: What terminal emulator and version are you using (if applicable)?
-      description: Also note any multiplexer in use (screen / tmux / zellij)
       description: |
-        E.g, VSCode, Terminal.app, iTerm2, Ghostty, Windows Terminal (WSL / PowerShell)
+        Also note any multiplexer in use (screen / tmux / zellij).
+        E.g., VS Code, Terminal.app, iTerm2, Ghostty, Windows Terminal (WSL / PowerShell)
   - type: textarea
     id: actual
     attributes:


### PR DESCRIPTION
Fixes #21270.

The CLI bug report template defined `description` twice for the terminal emulator field. Because duplicate YAML keys are ambiguous and parsers generally keep the later value, the form could drop the multiplexer guidance.

This combines that guidance with the terminal examples under a single block scalar in `.github/ISSUE_TEMPLATE/3-cli.yml`.