### PR TITLE
Fix issue template labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/3-cli.yml
+++ b/.github/ISSUE_TEMPLATE/3-cli.yml
@@ -2,7 +2,6 @@ name: 💻 CLI Bug
 description: Report an issue in the Codex CLI
 labels:
   - bug
-  - needs triage
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/6-docs-issue.yml
+++ b/.github/ISSUE_TEMPLATE/6-docs-issue.yml
@@ -1,6 +1,6 @@
 name: 📗 Documentation Issue
 description: Tell us if there is missing or incorrect documentation
-labels: [docs]
+labels: [documentation]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Issue forms should only reference labels that exist in the repository so new reports receive the intended automatic labels.

This updates the CLI issue form to stop applying the missing `needs triage` label, and changes the documentation issue form from `docs` to the existing `documentation` label.

Fixes #21158