### PR TITLE
Fix feature request Contributing link

### DIFF
--- a/.github/ISSUE_TEMPLATE/5-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/5-feature-request.yml
@@ -10,7 +10,7 @@ body:
 
         Before you submit a feature:
         1. Search existing issues for similar features. If you find one, 👍 it rather than opening a new one.
-        2. The Codex team will try to balance the varying needs of the community when prioritizing or rejecting new features. Not all features will be accepted. See [Contributing](https://github.com/openai/codex#contributing) for more details.
+        2. The Codex team will try to balance the varying needs of the community when prioritizing or rejecting new features. Not all features will be accepted. See [Contributing](https://github.com/openai/codex/blob/main/docs/contributing.md) for more details.
 
   - type: input
     id: variant


### PR DESCRIPTION
Fixes #20870.

## Summary

The feature request template currently links users to the README `#contributing` anchor, but that anchor does not exist. This can confuse users who are trying to understand contribution expectations before filing a request.

This updates `.github/ISSUE_TEMPLATE/5-feature-request.yml` to point `Contributing` at `docs/contributing.md`, matching the repository's existing contribution guidance.