### PR TITLE
Silence Windows taskkill during MCP cleanup

### DIFF
--- a/codex-rs/rmcp-client/src/stdio_server_launcher.rs
+++ b/codex-rs/rmcp-client/src/stdio_server_launcher.rs
@@ -15,6 +15,8 @@ use std::collections::HashMap;
 use std::ffi::OsString;
 use std::future::Future;
 use std::io;
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::Arc;
@@ -197,6 +199,9 @@ impl StdioServerLauncher for LocalStdioServerLauncher {
 #[cfg(unix)]
 const PROCESS_GROUP_TERM_GRACE_PERIOD: Duration = Duration::from_secs(2);
 
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x08000000;
+
 #[cfg(unix)]
 struct LocalProcessTerminator {
     process_group_id: u32,
@@ -341,6 +346,10 @@ impl LocalProcessTerminator {
             .arg(self.pid.to_string())
             .arg("/T")
             .arg("/F")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .creation_flags(CREATE_NO_WINDOW)
             .status();
     }
 


### PR DESCRIPTION
Fixes #20845.

On Windows, stdio MCP server cleanup uses `taskkill /T /F` to terminate the MCP server process tree. Because that helper process inherited Codex’s terminal handles, `taskkill` could print its `SUCCESS` messages directly into the TUI whenever `/mcp` cleaned up or restarted a stdio server.

This PR keeps the same Windows process-tree cleanup behavior, but runs `taskkill` quietly by redirecting stdin, stdout, and stderr to null and setting `CREATE_NO_WINDOW` in `codex-rs/rmcp-client/src/stdio_server_launcher.rs`.