### PR TITLE
codex-otel: validate provider span attributes consistently

### DIFF
--- a/codex-rs/otel/src/provider.rs
+++ b/codex-rs/otel/src/provider.rs
@@ -88,14 +88,12 @@ impl OtelProvider {
             return Ok(None);
         }
 
-        // Provider setup below installs process-global OTEL state that cannot
-        // be rolled back, so reject invalid trace metadata before any setup
-        // path can mutate those globals.
-        if trace_enabled && settings.span_attributes.keys().any(String::is_empty) {
-            return Err(Box::new(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                "configured span attribute key must not be empty",
-            )));
+        // Provider setup installs process-global OTEL state that cannot be
+        // rolled back. Validate trace metadata before any setup path can
+        // mutate those globals, and keep span attribute checks aligned with
+        // config loading when traces are exported.
+        if trace_enabled {
+            crate::config::validate_span_attributes(&settings.span_attributes)?;
         }
         crate::trace_context::validate_tracestate_entries(&settings.tracestate)?;
 


### PR DESCRIPTION
Provider initialization installs process-global OTEL state, so invalid
trace metadata needs to fail before setup begins.

Use the same span attribute validator as config loading when traces are
exported so provider startup enforces the config contract without
duplicating validation logic.
