### PR TITLE
fix(tui): suppress taskkill output for MCP teardown on Windows

### DIFF
--- a/codex-rs/rmcp-client/src/stdio_server_launcher.rs
+++ b/codex-rs/rmcp-client/src/stdio_server_launcher.rs
@@ -341,6 +341,9 @@ impl LocalProcessTerminator {
             .arg(self.pid.to_string())
             .arg("/T")
             .arg("/F")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
             .status();
     }
 


### PR DESCRIPTION
## Why

On native Windows, running `/mcp` can leak `taskkill`'s normal `SUCCESS:` messages into the Codex TUI while the temporary MCP inventory process tree is being torn down. That corrupts the screen even though MCP itself is working correctly.

Fixes #20845.

## What Changed

- Redirect the Windows-only MCP teardown `taskkill` subprocess to null stdio so its console output cannot reach the TUI.

## How to Test

1. On native Windows, configure a stdio MCP server, for example:
   ```powershell
   codex mcp add sequential-thinking -- npx -y @modelcontextprotocol/server-sequential-thinking
   ```
2. With the latest released Codex CLI, start Codex and run `/mcp`.
3. Confirm the current behavior: `taskkill` `SUCCESS:` lines appear in the TUI during the MCP refresh.
4. Switch to this branch's build, start Codex again, and run `/mcp`.
5. Confirm the MCP inventory still renders normally and the `taskkill` lines no longer appear.
6. Repeat `/mcp` once more on this branch to verify the regression does not recur on repeated inventory requests.

Targeted tests:
- `cargo test -p codex-rmcp-client`
- `cargo test -p codex-rmcp-client --test process_group_cleanup --quiet`
