### PR TITLE
Ensure the Cargo.lock file is up-to-date in pull request CI

### DIFF
--- a/.github/workflows/rust-ci-full.yml
+++ b/.github/workflows/rust-ci-full.yml
@@ -21,6 +21,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@a0b273b48ed29de4470960879e8381ff45632f26 # 1.93.0
         with:
           components: rustfmt
+      - name: Check Cargo.lock is up to date
+        run: cargo metadata --locked --format-version 1 >/dev/null
       - name: cargo fmt
         run: cargo fmt -- --config imports_granularity=Item --check
 

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -65,6 +65,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@a0b273b48ed29de4470960879e8381ff45632f26 # 1.93.0
         with:
           components: rustfmt
+      - name: Check Cargo.lock is up to date
+        run: cargo metadata --locked --format-version 1 >/dev/null
       - name: cargo fmt
         run: cargo fmt -- --config imports_granularity=Item --check
 

--- a/codex-rs/docs/bazel.md
+++ b/codex-rs/docs/bazel.md
@@ -32,10 +32,10 @@ just bazel-lock-update
 This runs `bazel mod deps --lockfile_mode=update` and updates `MODULE.bazel.lock` if needed.
 Commit the lockfile changes along with your Cargo lockfile update.
 
-To verify lockfile alignment locally (the same check CI runs), use:
+To verify lockfile alignment locally (the same checks CI runs), use:
 
 ```bash
-just bazel-lock-check
+just lock-check
 ```
 
 In some cases, an upstream crate may need a patch or a `crate.annotation` in `../MODULE.bzl`

--- a/justfile
+++ b/justfile
@@ -44,6 +44,11 @@ install:
     rustup show active-toolchain
     cargo fetch
 
+cargo-lock-check:
+    cargo metadata --locked --format-version 1 >/dev/null
+
+lock-check: cargo-lock-check bazel-lock-check
+
 # Run `cargo nextest` since it's faster than `cargo test`, though including
 # --no-fail-fast is important to ensure all tests are run.
 #


### PR DESCRIPTION
In #21602, I added `--locked` to our Cargo invocations to ensure there was not lockfile drift.

That pull request passed CI, but the merged commit immediately started failing lint jobs on `main`. I discovered we were not running clippy via Cargo, just Bazel, on pull requests. This addresses that oversight by ensuring we check the `Cargo.lock` and Bazel lockfiles are up-to-date on pull requests.

#21602 was reverted in https://github.com/openai/codex/pull/21646 because it regressed releases, which intentionally mutate the version in the `Cargo.toml` but do not update the lockfile. This restores some of the change, but does not restore use of `--locked` in releases. We can update the release workflow to use `cargo update -p <name>` to update the lockfile after we patch the version, then restore the rest of #21602.