### PR TITLE
Publish Python runtime wheels on release

### DIFF
--- a/.github/workflows/rust-release-windows.yml
+++ b/.github/workflows/rust-release-windows.yml
@@ -216,6 +216,45 @@ jobs:
               "$dest/${binary}-${{ matrix.target }}.exe"
           done
 
+      - name: Build Python runtime wheel
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          case "${{ matrix.target }}" in
+            aarch64-pc-windows-msvc)
+              platform_tag="win_arm64"
+              ;;
+            x86_64-pc-windows-msvc)
+              platform_tag="win_amd64"
+              ;;
+            *)
+              echo "No Python runtime wheel platform tag for ${{ matrix.target }}"
+              exit 1
+              ;;
+          esac
+
+          python -m pip install build
+
+          stage_dir="${RUNNER_TEMP}/openai-codex-cli-bin-${{ matrix.target }}"
+          wheel_dir="${GITHUB_WORKSPACE}/python-runtime-dist/${{ matrix.target }}"
+          python "${GITHUB_WORKSPACE}/sdk/python/scripts/update_sdk_artifacts.py" \
+            stage-runtime \
+            "$stage_dir" \
+            "${GITHUB_WORKSPACE}/codex-rs/target/${{ matrix.target }}/release/codex.exe" \
+            --codex-version "${GITHUB_REF_NAME}" \
+            --platform-tag "$platform_tag" \
+            --resource-binary "${GITHUB_WORKSPACE}/codex-rs/target/${{ matrix.target }}/release/codex-command-runner.exe" \
+            --resource-binary "${GITHUB_WORKSPACE}/codex-rs/target/${{ matrix.target }}/release/codex-windows-sandbox-setup.exe"
+          python -m build --wheel --outdir "$wheel_dir" "$stage_dir"
+
+      - name: Upload Python runtime wheel
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: python-runtime-wheel-${{ matrix.target }}
+          path: python-runtime-dist/${{ matrix.target }}/*.whl
+          if-no-files-found: error
+
       - name: Install DotSlash
         uses: facebook/install-dotslash@1e4e7b3e07eaca387acb98f1d4720e0bee8dbb6a # v2
 

--- a/.github/workflows/rust-release-windows.yml
+++ b/.github/workflows/rust-release-windows.yml
@@ -238,6 +238,8 @@ jobs:
 
           stage_dir="${RUNNER_TEMP}/openai-codex-cli-bin-${{ matrix.target }}"
           wheel_dir="${GITHUB_WORKSPACE}/python-runtime-dist/${{ matrix.target }}"
+          # Keep the helpers next to codex.exe in the runtime wheel so Windows
+          # sandbox/elevation lookup matches the standalone release zip.
           python "${GITHUB_WORKSPACE}/sdk/python/scripts/update_sdk_artifacts.py" \
             stage-runtime \
             "$stage_dir" \

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -860,6 +860,7 @@ jobs:
     name: publish-python-runtime
     needs: release
     runs-on: ubuntu-latest
+    environment: pypi
     permissions:
       id-token: write # Required for PyPI trusted publishing.
       contents: read

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -853,13 +853,16 @@ jobs:
           done
 
   # Publish the platform-specific Python runtime wheels using PyPI trusted publishing.
-  # PyPI project configuration must trust this workflow and job.
+  # PyPI project configuration must trust this workflow and job. Keep this
+  # non-blocking while the Python runtime publishing path is new; failures still
+  # need release follow-up, but should not invalidate the Rust release itself.
   publish-python-runtime:
     # Publish to PyPI for stable releases and alpha pre-releases with numeric suffixes.
     if: ${{ needs.release.outputs.should_publish_python_runtime == 'true' }}
     name: publish-python-runtime
     needs: release
     runs-on: ubuntu-latest
+    continue-on-error: true
     environment: pypi
     permissions:
       id-token: write # Required for PyPI trusted publishing.

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -394,6 +394,51 @@ jobs:
             cp target/${{ matrix.target }}/release/codex-${{ matrix.target }}.dmg "$dest/codex-${{ matrix.target }}.dmg"
           fi
 
+      - name: Build Python runtime wheel
+        if: ${{ matrix.bundle == 'primary' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          case "${{ matrix.target }}" in
+            aarch64-apple-darwin)
+              platform_tag="macosx_11_0_arm64"
+              ;;
+            x86_64-apple-darwin)
+              platform_tag="macosx_10_9_x86_64"
+              ;;
+            aarch64-unknown-linux-musl)
+              platform_tag="musllinux_1_1_aarch64"
+              ;;
+            x86_64-unknown-linux-musl)
+              platform_tag="musllinux_1_1_x86_64"
+              ;;
+            *)
+              echo "No Python runtime wheel platform tag for ${{ matrix.target }}"
+              exit 1
+              ;;
+          esac
+
+          python3 -m pip install build
+
+          stage_dir="${RUNNER_TEMP}/openai-codex-cli-bin-${{ matrix.target }}"
+          wheel_dir="${GITHUB_WORKSPACE}/python-runtime-dist/${{ matrix.target }}"
+          python3 "${GITHUB_WORKSPACE}/sdk/python/scripts/update_sdk_artifacts.py" \
+            stage-runtime \
+            "$stage_dir" \
+            "${GITHUB_WORKSPACE}/codex-rs/target/${{ matrix.target }}/release/codex" \
+            --codex-version "${GITHUB_REF_NAME}" \
+            --platform-tag "$platform_tag"
+          python3 -m build --wheel --outdir "$wheel_dir" "$stage_dir"
+
+      - name: Upload Python runtime wheel
+        if: ${{ matrix.bundle == 'primary' }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: python-runtime-wheel-${{ matrix.target }}
+          path: python-runtime-dist/${{ matrix.target }}/*.whl
+          if-no-files-found: error
+
       - name: Compress artifacts
         shell: bash
         run: |
@@ -473,6 +518,7 @@ jobs:
       tag: ${{ github.ref_name }}
       should_publish_npm: ${{ steps.npm_publish_settings.outputs.should_publish }}
       npm_tag: ${{ steps.npm_publish_settings.outputs.npm_tag }}
+      should_publish_python_runtime: ${{ steps.python_runtime_publish_settings.outputs.should_publish }}
 
     steps:
       - name: Checkout repository
@@ -545,6 +591,22 @@ jobs:
           else
             echo "should_publish=false" >> "$GITHUB_OUTPUT"
             echo "npm_tag=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Determine Python runtime publish settings
+        id: python_runtime_publish_settings
+        env:
+          VERSION: ${{ steps.release_name.outputs.name }}
+        run: |
+          set -euo pipefail
+          version="${VERSION}"
+
+          if [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          elif [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-alpha\.[0-9]+$ ]]; then
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Setup pnpm
@@ -779,6 +841,44 @@ jobs:
 
             exit "${publish_status}"
           done
+
+  # Publish the platform-specific Python runtime wheels using PyPI trusted publishing.
+  # PyPI project configuration must trust this workflow and job.
+  publish-python-runtime:
+    # Publish to PyPI for stable releases and alpha pre-releases with numeric suffixes.
+    if: ${{ needs.release.outputs.should_publish_python_runtime == 'true' }}
+    name: publish-python-runtime
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for PyPI trusted publishing.
+      contents: read
+
+    steps:
+      - name: Download Python runtime wheels from release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.release.outputs.tag }}
+          RELEASE_VERSION: ${{ needs.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          python_version="$RELEASE_VERSION"
+          python_version="${python_version/-alpha./a}"
+          python_version="${python_version/-beta./b}"
+          python_version="${python_version/-rc./rc}"
+
+          mkdir -p dist/python-runtime
+          gh release download "$RELEASE_TAG" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --pattern "openai_codex_cli_bin-${python_version}-*.whl" \
+            --dir dist/python-runtime
+          ls -lh dist/python-runtime
+
+      - name: Publish Python runtime wheels to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          packages-dir: dist/python-runtime
+          skip-existing: true
 
   winget:
     name: winget

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -423,12 +423,22 @@ jobs:
 
           stage_dir="${RUNNER_TEMP}/openai-codex-cli-bin-${{ matrix.target }}"
           wheel_dir="${GITHUB_WORKSPACE}/python-runtime-dist/${{ matrix.target }}"
+          resource_args=()
+          if [[ "${{ matrix.target }}" == *linux* ]]; then
+            # Keep bwrap in the runtime wheel so Linux sandbox fallback behavior
+            # matches the standalone release bundle on hosts without system bwrap.
+            resource_args+=(
+              --resource-binary
+              "${GITHUB_WORKSPACE}/codex-rs/target/${{ matrix.target }}/release/bwrap"
+            )
+          fi
           python3 "${GITHUB_WORKSPACE}/sdk/python/scripts/update_sdk_artifacts.py" \
             stage-runtime \
             "$stage_dir" \
             "${GITHUB_WORKSPACE}/codex-rs/target/${{ matrix.target }}/release/codex" \
             --codex-version "${GITHUB_REF_NAME}" \
-            --platform-tag "$platform_tag"
+            --platform-tag "$platform_tag" \
+            "${resource_args[@]}"
           python3 -m build --wheel --outdir "$wheel_dir" "$stage_dir"
 
       - name: Upload Python runtime wheel

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -886,7 +886,7 @@ jobs:
           ls -lh dist/python-runtime
 
       - name: Publish Python runtime wheels to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           packages-dir: dist/python-runtime
           skip-existing: true

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -91,7 +91,7 @@ This supports the CI release flow:
 - run `generate-types` before packaging
 - stage `openai-codex-app-server-sdk` once with an exact `openai-codex-cli-bin==...` dependency
 - stage `openai-codex-cli-bin` on each supported platform runner with the same pinned runtime version
-- build and publish `openai-codex-cli-bin` as platform wheels only; do not publish an sdist
+- build and publish `openai-codex-cli-bin` as platform wheels only through PyPI trusted publishing; do not publish an sdist
 
 ## Compatibility and versioning
 

--- a/sdk/python/scripts/update_sdk_artifacts.py
+++ b/sdk/python/scripts/update_sdk_artifacts.py
@@ -60,6 +60,10 @@ def staged_runtime_bin_path(root: Path) -> Path:
     return root / "src" / "codex_cli_bin" / "bin" / runtime_binary_name()
 
 
+def staged_runtime_resource_path(root: Path, resource: Path) -> Path:
+    return root / "src" / "codex_cli_bin" / "bin" / resource.name
+
+
 def run(cmd: list[str], cwd: Path) -> None:
     subprocess.run(cmd, cwd=str(cwd), check=True)
 
@@ -211,6 +215,7 @@ def stage_python_runtime_package(
     codex_version: str,
     binary_path: Path,
     platform_tag: str | None = None,
+    resource_binaries: Sequence[Path] = (),
 ) -> Path:
     package_version = normalize_codex_version(codex_version)
     _copy_package_tree(python_runtime_root(), staging_dir)
@@ -230,6 +235,13 @@ def stage_python_runtime_package(
         out_bin.chmod(
             out_bin.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
         )
+    for resource_binary in resource_binaries:
+        out_resource = staged_runtime_resource_path(staging_dir, resource_binary)
+        shutil.copy2(resource_binary, out_resource)
+        if not _is_windows():
+            out_resource.chmod(
+                out_resource.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+            )
     return staging_dir
 
 
@@ -632,7 +644,9 @@ class PublicFieldSpec:
 class CliOps:
     generate_types: Callable[[], None]
     stage_python_sdk_package: Callable[[Path, str], Path]
-    stage_python_runtime_package: Callable[[Path, str, Path, str | None], Path]
+    stage_python_runtime_package: Callable[
+        [Path, str, Path, str | None, Sequence[Path]], Path
+    ]
     current_sdk_version: Callable[[], str]
 
 
@@ -1047,6 +1061,13 @@ def build_parser() -> argparse.ArgumentParser:
             "macosx_11_0_arm64 or musllinux_1_1_x86_64."
         ),
     )
+    stage_runtime_parser.add_argument(
+        "--resource-binary",
+        action="append",
+        default=[],
+        type=Path,
+        help="Additional executable to package beside the codex runtime binary.",
+    )
     return parser
 
 
@@ -1101,6 +1122,7 @@ def run_command(args: argparse.Namespace, ops: CliOps) -> None:
             codex_version,
             args.runtime_binary.resolve(),
             args.platform_tag,
+            tuple(path.resolve() for path in args.resource_binary),
         )
 
 

--- a/sdk/python/scripts/update_sdk_artifacts.py
+++ b/sdk/python/scripts/update_sdk_artifacts.py
@@ -239,9 +239,9 @@ def stage_python_runtime_package(
             out_bin.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
         )
     for resource_binary in resource_binaries:
-        # Windows sandbox support needs helper executables next to codex.exe.
-        # The option is generic so release workflows own the platform-specific
-        # list without baking Windows names into the staging script.
+        # Some release targets need helper executables beside the main binary
+        # (for example Linux bwrap or Windows sandbox helpers). Keep this
+        # generic so release workflows own the platform-specific list.
         out_resource = staged_runtime_resource_path(staging_dir, resource_binary)
         shutil.copy2(resource_binary, out_resource)
         if not _is_windows():

--- a/sdk/python/scripts/update_sdk_artifacts.py
+++ b/sdk/python/scripts/update_sdk_artifacts.py
@@ -61,6 +61,9 @@ def staged_runtime_bin_path(root: Path) -> Path:
 
 
 def staged_runtime_resource_path(root: Path, resource: Path) -> Path:
+    # Runtime wheels include the whole bin/ directory, so helper executables
+    # should be staged beside the main Codex binary instead of changing the
+    # package template for each platform.
     return root / "src" / "codex_cli_bin" / "bin" / resource.name
 
 
@@ -236,6 +239,9 @@ def stage_python_runtime_package(
             out_bin.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
         )
     for resource_binary in resource_binaries:
+        # Windows sandbox support needs helper executables next to codex.exe.
+        # The option is generic so release workflows own the platform-specific
+        # list without baking Windows names into the staging script.
         out_resource = staged_runtime_resource_path(staging_dir, resource_binary)
         shutil.copy2(resource_binary, out_resource)
         if not _is_windows():

--- a/sdk/python/tests/test_artifact_workflow_and_binaries.py
+++ b/sdk/python/tests/test_artifact_workflow_and_binaries.py
@@ -379,6 +379,34 @@ def test_stage_runtime_release_copies_resource_binaries(tmp_path: Path) -> None:
     }
 
 
+def test_runtime_resource_binaries_are_included_by_wheel_config(
+    tmp_path: Path,
+) -> None:
+    script = _load_update_script_module()
+    fake_binary = tmp_path / script.runtime_binary_name()
+    helper = tmp_path / "helper"
+    fake_binary.write_text("fake codex\n")
+    helper.write_text("fake helper\n")
+
+    staged = script.stage_python_runtime_package(
+        tmp_path / "runtime-stage",
+        "1.2.3",
+        fake_binary,
+        resource_binaries=(helper,),
+    )
+
+    pyproject = tomllib.loads((staged / "pyproject.toml").read_text())
+    assert {
+        "include": pyproject["tool"]["hatch"]["build"]["targets"]["wheel"]["include"],
+        "helper": (
+            staged / "src" / "codex_cli_bin" / "bin" / "helper"
+        ).read_text(),
+    } == {
+        "include": ["src/codex_cli_bin/bin/**"],
+        "helper": "fake helper\n",
+    }
+
+
 def test_stage_sdk_release_injects_exact_runtime_pin(tmp_path: Path) -> None:
     script = _load_update_script_module()
     staged = script.stage_python_sdk_package(

--- a/sdk/python/tests/test_artifact_workflow_and_binaries.py
+++ b/sdk/python/tests/test_artifact_workflow_and_binaries.py
@@ -8,6 +8,7 @@ import sys
 import tomllib
 import urllib.error
 from pathlib import Path
+from typing import Sequence
 
 import pytest
 
@@ -350,6 +351,34 @@ def test_stage_runtime_release_can_pin_wheel_platform_tag(tmp_path: Path) -> Non
     assert 'platform-tag = "musllinux_1_1_x86_64"' in pyproject
 
 
+def test_stage_runtime_release_copies_resource_binaries(tmp_path: Path) -> None:
+    script = _load_update_script_module()
+    fake_binary = tmp_path / script.runtime_binary_name()
+    command_runner = tmp_path / "codex-command-runner.exe"
+    setup = tmp_path / "codex-windows-sandbox-setup.exe"
+    fake_binary.write_text("fake codex\n")
+    command_runner.write_text("fake command runner\n")
+    setup.write_text("fake setup\n")
+
+    staged = script.stage_python_runtime_package(
+        tmp_path / "runtime-stage",
+        "1.2.3",
+        fake_binary,
+        resource_binaries=(command_runner, setup),
+    )
+
+    assert {
+        path.relative_to(
+            staged / "src" / "codex_cli_bin" / "bin"
+        ).as_posix(): path.read_text()
+        for path in (staged / "src" / "codex_cli_bin" / "bin").iterdir()
+    } == {
+        script.runtime_binary_name(): "fake codex\n",
+        "codex-command-runner.exe": "fake command runner\n",
+        "codex-windows-sandbox-setup.exe": "fake setup\n",
+    }
+
+
 def test_stage_sdk_release_injects_exact_runtime_pin(tmp_path: Path) -> None:
     script = _load_update_script_module()
     staged = script.stage_python_sdk_package(
@@ -436,6 +465,7 @@ def test_stage_sdk_runs_type_generation_before_staging(tmp_path: Path) -> None:
         _runtime_version: str,
         _runtime_binary: Path,
         _platform_tag: str | None,
+        _resource_binaries: Sequence[Path],
     ) -> Path:
         raise AssertionError("runtime staging should not run for stage-sdk")
 
@@ -476,7 +506,11 @@ def test_stage_sdk_rejects_mismatched_legacy_versions(tmp_path: Path) -> None:
 def test_stage_runtime_stages_binary_without_type_generation(tmp_path: Path) -> None:
     script = _load_update_script_module()
     fake_binary = tmp_path / script.runtime_binary_name()
+    command_runner = tmp_path / "codex-command-runner.exe"
+    setup = tmp_path / "codex-windows-sandbox-setup.exe"
     fake_binary.write_text("fake codex\n")
+    command_runner.write_text("fake command runner\n")
+    setup.write_text("fake setup\n")
     calls: list[str] = []
     args = script.parse_args(
         [
@@ -487,6 +521,10 @@ def test_stage_runtime_stages_binary_without_type_generation(tmp_path: Path) -> 
             "rust-v0.116.0-alpha.1",
             "--platform-tag",
             "musllinux_1_1_x86_64",
+            "--resource-binary",
+            str(command_runner),
+            "--resource-binary",
+            str(setup),
         ]
     )
 
@@ -501,8 +539,12 @@ def test_stage_runtime_stages_binary_without_type_generation(tmp_path: Path) -> 
         codex_version: str,
         _runtime_binary: Path,
         platform_tag: str | None,
+        resource_binaries: Sequence[Path],
     ) -> Path:
-        calls.append(f"stage_runtime:{codex_version}:{platform_tag}")
+        calls.append(
+            f"stage_runtime:{codex_version}:{platform_tag}:"
+            f"{','.join(path.name for path in resource_binaries)}"
+        )
         return tmp_path / "runtime-stage"
 
     def fake_current_sdk_version() -> str:
@@ -517,7 +559,10 @@ def test_stage_runtime_stages_binary_without_type_generation(tmp_path: Path) -> 
 
     script.run_command(args, ops)
 
-    assert calls == ["stage_runtime:0.116.0a1:musllinux_1_1_x86_64"]
+    assert calls == [
+        "stage_runtime:0.116.0a1:musllinux_1_1_x86_64:"
+        "codex-command-runner.exe,codex-windows-sandbox-setup.exe"
+    ]
 
 
 def test_default_runtime_is_resolved_from_installed_runtime_package(

--- a/sdk/python/tests/test_artifact_workflow_and_binaries.py
+++ b/sdk/python/tests/test_artifact_workflow_and_binaries.py
@@ -354,17 +354,17 @@ def test_stage_runtime_release_can_pin_wheel_platform_tag(tmp_path: Path) -> Non
 def test_stage_runtime_release_copies_resource_binaries(tmp_path: Path) -> None:
     script = _load_update_script_module()
     fake_binary = tmp_path / script.runtime_binary_name()
-    command_runner = tmp_path / "codex-command-runner.exe"
-    setup = tmp_path / "codex-windows-sandbox-setup.exe"
+    helper = tmp_path / "helper"
+    fallback = tmp_path / "fallback-helper"
     fake_binary.write_text("fake codex\n")
-    command_runner.write_text("fake command runner\n")
-    setup.write_text("fake setup\n")
+    helper.write_text("fake helper\n")
+    fallback.write_text("fake fallback\n")
 
     staged = script.stage_python_runtime_package(
         tmp_path / "runtime-stage",
         "1.2.3",
         fake_binary,
-        resource_binaries=(command_runner, setup),
+        resource_binaries=(helper, fallback),
     )
 
     assert {
@@ -374,8 +374,8 @@ def test_stage_runtime_release_copies_resource_binaries(tmp_path: Path) -> None:
         for path in (staged / "src" / "codex_cli_bin" / "bin").iterdir()
     } == {
         script.runtime_binary_name(): "fake codex\n",
-        "codex-command-runner.exe": "fake command runner\n",
-        "codex-windows-sandbox-setup.exe": "fake setup\n",
+        "fallback-helper": "fake fallback\n",
+        "helper": "fake helper\n",
     }
 
 
@@ -506,11 +506,11 @@ def test_stage_sdk_rejects_mismatched_legacy_versions(tmp_path: Path) -> None:
 def test_stage_runtime_stages_binary_without_type_generation(tmp_path: Path) -> None:
     script = _load_update_script_module()
     fake_binary = tmp_path / script.runtime_binary_name()
-    command_runner = tmp_path / "codex-command-runner.exe"
-    setup = tmp_path / "codex-windows-sandbox-setup.exe"
+    helper = tmp_path / "helper"
+    fallback = tmp_path / "fallback-helper"
     fake_binary.write_text("fake codex\n")
-    command_runner.write_text("fake command runner\n")
-    setup.write_text("fake setup\n")
+    helper.write_text("fake helper\n")
+    fallback.write_text("fake fallback\n")
     calls: list[str] = []
     args = script.parse_args(
         [
@@ -522,9 +522,9 @@ def test_stage_runtime_stages_binary_without_type_generation(tmp_path: Path) -> 
             "--platform-tag",
             "musllinux_1_1_x86_64",
             "--resource-binary",
-            str(command_runner),
+            str(helper),
             "--resource-binary",
-            str(setup),
+            str(fallback),
         ]
     )
 
@@ -560,8 +560,7 @@ def test_stage_runtime_stages_binary_without_type_generation(tmp_path: Path) -> 
     script.run_command(args, ops)
 
     assert calls == [
-        "stage_runtime:0.116.0a1:musllinux_1_1_x86_64:"
-        "codex-command-runner.exe,codex-windows-sandbox-setup.exe"
+        "stage_runtime:0.116.0a1:musllinux_1_1_x86_64:helper,fallback-helper"
     ]
 
 


### PR DESCRIPTION
## Why

Published Python SDK builds depend on an exact `openai-codex-cli-bin` runtime package, but the release workflow did not publish that runtime package to PyPI. That left the SDK packaging story incomplete: release artifacts could produce Codex binaries, but Python users still needed a matching wheel carrying the platform-specific runtime and helper executables.

This PR is stacked on #21787 so release jobs can include helper binaries in runtime wheels: Linux wheels include `bwrap` for sandbox fallback, and Windows wheels include the signed sandbox/elevation helpers beside `codex.exe`.

## What changed

- Builds platform-specific `openai-codex-cli-bin` wheels from signed release binaries on macOS, Linux, and Windows release runners.
- Packages Linux `bwrap` into musllinux runtime wheels.
- Packages Windows sandbox helper executables into Windows runtime wheels.
- Uploads runtime wheels as GitHub release assets and publishes them to PyPI using trusted publishing from the `pypi` GitHub environment.
- Keeps the new Python runtime publish job non-blocking so failures need follow-up but do not fail the Rust release workflow.
- Pins the PyPA publish action to the `v1.13.0` commit SHA for reproducible release publishing.
- Documents that runtime wheels are platform wheels published through PyPI trusted publishing.

## Testing

- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/rust-release.yml .github/workflows/rust-release-windows.yml`
- `git diff --check`

CI is the real end-to-end verification for the release workflow path.