### PR TITLE
[codex] Minimize, explain GitHub Actions permissions

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -10,6 +10,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   # Cancel previous actions from the same PR or branch except 'main' branch.
   # See https://docs.github.com/en/actions/using-jobs/using-concurrency and https://docs.github.com/en/actions/learn-github-actions/contexts for more info.

--- a/.github/workflows/blob-size-policy.yml
+++ b/.github/workflows/blob-size-policy.yml
@@ -3,6 +3,9 @@ name: blob-size-policy
 on:
   pull_request: {}
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Blob size policy

--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   cargo-deny:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   pull_request: {}
   push: { branches: [main] }
 
+permissions:
+  actions: read
+  contents: read
+
 jobs:
   build-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -5,11 +5,7 @@ on:
   pull_request_target:
     types: [opened, closed, synchronize]
 
-permissions:
-  actions: write
-  contents: write
-  pull-requests: write
-  statuses: write
+permissions: {}
 
 jobs:
   cla:
@@ -17,6 +13,11 @@ jobs:
     # and contributors who signed previously do not receive duplicate CLA notifications.
     if: ${{ github.repository_owner == 'openai' }}
     runs-on: ubuntu-latest
+    permissions:
+      actions: write # needed by the CLA action
+      contents: write # needed to update CLA signatures
+      pull-requests: write # needed to lock merged PRs
+      statuses: write # needed to report CLA status
     steps:
       - uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         # Run on close only if the PR was merged. This will lock the PR to preserve

--- a/.github/workflows/close-stale-contributor-prs.yml
+++ b/.github/workflows/close-stale-contributor-prs.yml
@@ -5,16 +5,17 @@ on:
   schedule:
     - cron: "0 6 * * *"
 
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   close-stale-contributor-prs:
     # Prevent scheduled runs on forks
     if: github.repository == 'openai/codex'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write # needed to comment on stale PRs
+      pull-requests: write # needed to close stale PRs
     steps:
       - name: Close inactive PRs from contributors
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0

--- a/.github/workflows/rust-ci-full.yml
+++ b/.github/workflows/rust-ci-full.yml
@@ -6,6 +6,8 @@ on:
       - "**full-ci**"
   workflow_dispatch:
 
+permissions: {}
+
 # CI builds in debug (dev) for faster signal.
 env:
   # Cargo's libgit2 transport has been flaky on macOS when fetching git
@@ -18,6 +20,8 @@ jobs:
   general:
     name: Format / etc
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: codex-rs
@@ -34,6 +38,8 @@ jobs:
   cargo_shear:
     name: cargo shear
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: codex-rs
@@ -52,6 +58,8 @@ jobs:
   argument_comment_lint_package:
     name: Argument comment lint package
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     env:
       CARGO_DYLINT_VERSION: 5.0.0
       DYLINT_LINK_VERSION: 5.0.0
@@ -93,6 +101,8 @@ jobs:
   argument_comment_lint_prebuilt:
     name: Argument comment lint - ${{ matrix.name }}
     runs-on: ${{ matrix.runs_on || matrix.runner }}
+    permissions:
+      contents: read
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -152,6 +162,8 @@ jobs:
   lint_build:
     name: Lint/Build — ${{ matrix.runner }} - ${{ matrix.target }}${{ matrix.profile == 'release' && ' (release)' || '' }}
     runs-on: ${{ matrix.runs_on || matrix.runner }}
+    permissions:
+      contents: read
     timeout-minutes: 30
     defaults:
       run:
@@ -525,6 +537,8 @@ jobs:
   tests:
     name: Tests — ${{ matrix.runner }} - ${{ matrix.target }}${{ matrix.remote_env == 'true' && ' (remote)' || '' }}
     runs-on: ${{ matrix.runs_on || matrix.runner }}
+    permissions:
+      contents: read
     # Perhaps we can bring this back down to 30m once we finish the cutover
     # from tui_app_server/ to tui/. Incidentally, windows-arm64 was the main
     # offender for exceeding the timeout.

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -3,11 +3,15 @@ on:
   pull_request: {}
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   # --- Detect what changed so the fast PR workflow only runs relevant jobs ----
   changed:
     name: Detect changed areas
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     outputs:
       argument_comment_lint: ${{ steps.detect.outputs.argument_comment_lint }}
       argument_comment_lint_package: ${{ steps.detect.outputs.argument_comment_lint_package }}
@@ -56,6 +60,8 @@ jobs:
   general:
     name: Format / etc
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     needs: changed
     if: ${{ needs.changed.outputs.codex == 'true' || needs.changed.outputs.workflows == 'true' }}
     defaults:
@@ -74,6 +80,8 @@ jobs:
   cargo_shear:
     name: cargo shear
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     needs: changed
     if: ${{ needs.changed.outputs.codex == 'true' || needs.changed.outputs.workflows == 'true' }}
     defaults:
@@ -94,6 +102,8 @@ jobs:
   argument_comment_lint_package:
     name: Argument comment lint package
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     needs: changed
     if: ${{ needs.changed.outputs.argument_comment_lint_package == 'true' }}
     env:
@@ -144,6 +154,8 @@ jobs:
   argument_comment_lint_prebuilt:
     name: Argument comment lint - ${{ matrix.name }}
     runs-on: ${{ matrix.runs_on || matrix.runner }}
+    permissions:
+      contents: read
     timeout-minutes: ${{ matrix.timeout_minutes }}
     needs: changed
     strategy:

--- a/.github/workflows/rust-release-argument-comment-lint.yml
+++ b/.github/workflows/rust-release-argument-comment-lint.yml
@@ -7,6 +7,8 @@ on:
         required: true
         type: boolean
 
+permissions: {}
+
 jobs:
   skip:
     if: ${{ !inputs.publish }}
@@ -18,6 +20,8 @@ jobs:
     if: ${{ inputs.publish }}
     name: Build - ${{ matrix.runner }} - ${{ matrix.target }}
     runs-on: ${{ matrix.runs_on || matrix.runner }}
+    permissions:
+      contents: read
     timeout-minutes: 60
     env:
       CARGO_DYLINT_VERSION: 5.0.0

--- a/.github/workflows/rust-release-prepare.yml
+++ b/.github/workflows/rust-release-prepare.yml
@@ -8,15 +8,16 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   prepare:
     # Prevent scheduled runs on forks (no secrets, wastes Actions minutes)
     if: github.repository == 'openai/codex'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # needed to push the update branch
+      pull-requests: write # needed to open the update PR
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/rust-release-windows.yml
+++ b/.github/workflows/rust-release-windows.yml
@@ -144,7 +144,7 @@ jobs:
     timeout-minutes: 90
     permissions:
       contents: read
-      id-token: write
+      id-token: write # needed for Windows code signing
     defaults:
       run:
         working-directory: codex-rs

--- a/.github/workflows/rust-release-zsh.yml
+++ b/.github/workflows/rust-release-zsh.yml
@@ -3,6 +3,9 @@ name: rust-release-zsh
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 env:
   ZSH_COMMIT: 77045ef899e53b9598bebc5a41db93a548a40ca6
   ZSH_PATCH: codex-rs/shell-escalation/patches/zsh-exec-wrapper.patch

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -11,6 +11,8 @@ on:
     tags:
       - "rust-v*.*.*"
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
@@ -18,6 +20,8 @@ concurrency:
 jobs:
   tag-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -56,7 +60,7 @@ jobs:
     timeout-minutes: 90
     permissions:
       contents: read
-      id-token: write
+      id-token: write # needed for Linux code signing
     defaults:
       run:
         working-directory: codex-rs
@@ -445,6 +449,9 @@ jobs:
 
   build-windows:
     needs: tag-check
+    permissions:
+      contents: read
+      id-token: write # needed for Windows code signing
     uses: ./.github/workflows/rust-release-windows.yml
     with:
       release-lto: ${{ contains(github.ref_name, '-alpha') && 'thin' || 'fat' }}
@@ -453,6 +460,8 @@ jobs:
   argument-comment-lint-release-assets:
     name: argument-comment-lint release assets
     needs: tag-check
+    permissions:
+      contents: read
     uses: ./.github/workflows/rust-release-argument-comment-lint.yml
     with:
       publish: true
@@ -460,6 +469,8 @@ jobs:
   zsh-release-assets:
     name: zsh release assets
     needs: tag-check
+    permissions:
+      contents: read
     uses: ./.github/workflows/rust-release-zsh.yml
 
   release:
@@ -471,7 +482,7 @@ jobs:
     name: release
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write # needed to publish the release
       actions: read
     outputs:
       version: ${{ steps.release_name.outputs.name }}
@@ -640,7 +651,7 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     permissions:
-      id-token: write # Required for OIDC
+      id-token: write # needed for npm trusted publishing
       contents: read
 
     steps:
@@ -813,7 +824,7 @@ jobs:
   update-branch:
     name: Update latest-alpha-cli branch
     permissions:
-      contents: write
+      contents: write # needed to update latest-alpha-cli
     needs: release
     runs-on: ubuntu-latest
 

--- a/.github/workflows/rusty-v8-release.yml
+++ b/.github/workflows/rusty-v8-release.yml
@@ -5,6 +5,8 @@ on:
     tags:
       - "rusty-v8-v*.*.*"
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}::${{ github.ref_name }}
   cancel-in-progress: false
@@ -12,6 +14,8 @@ concurrency:
 jobs:
   metadata:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       release_tag: ${{ steps.release_tag.outputs.release_tag }}
       v8_version: ${{ steps.v8_version.outputs.version }}
@@ -148,7 +152,7 @@ jobs:
       - build
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write # needed to publish the release
       actions: read
 
     steps:

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request: {}
 
+permissions:
+  contents: read
+
 jobs:
   sdks:
     runs-on:

--- a/.github/workflows/v8-canary.yml
+++ b/.github/workflows/v8-canary.yml
@@ -29,6 +29,8 @@ on:
       - "third_party/v8/**"
   workflow_dispatch:
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}::${{ github.event.pull_request.number > 0 && format('pr-{0}', github.event.pull_request.number) || github.ref_name }}
   cancel-in-progress: ${{ github.ref_name != 'main' }}
@@ -36,6 +38,8 @@ concurrency:
 jobs:
   metadata:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       v8_version: ${{ steps.v8_version.outputs.version }}
 


### PR DESCRIPTION
This attempts to ratchet down our GitHub Actions permissions even further. We now drop permissions explicitly at the workflow level, and only broaden them at the per-job level where needed. If a broadened permission includes write, we include a comment explaining it.

Like with #21622 this is a medium-risk change, since workflows don't have statically discoverable permission requirements. Please ping ww@ on any breakage.