### PR TITLE
[codex] Emit OTEL user prompts from turn recording

### DIFF
--- a/codex-rs/core/src/session/handlers.rs
+++ b/codex-rs/core/src/session/handlers.rs
@@ -244,17 +244,13 @@ pub(super) async fn user_input_or_turn_inner(
         )
         .await
     {
-        Ok(_) => {
-            current_context.session_telemetry.user_prompt(&items);
-            Some(items)
-        }
+        Ok(_) => Some(items),
         Err(SteerInputError::NoActiveTurn(items)) => {
             if let Some(responsesapi_client_metadata) = responsesapi_client_metadata {
                 current_context
                     .turn_metadata_state
                     .set_responsesapi_client_metadata(responsesapi_client_metadata);
             }
-            current_context.session_telemetry.user_prompt(&items);
             sess.refresh_mcp_servers_if_requested(
                 &current_context,
                 Some(sess.mcp_elicitation_reviewer()),

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -2947,6 +2947,7 @@ impl Session {
         input: &[UserInput],
         response_item: ResponseItem,
     ) {
+        turn_context.session_telemetry.user_prompt(input);
         // Persist the user message to history, but emit the turn item from `UserInput` so
         // UI-only `text_elements` are preserved. `ResponseItem::Message` does not carry
         // those spans, and `record_response_item_and_emit_turn_item` would drop them.
@@ -2993,52 +2994,54 @@ impl Session {
             return Err(SteerInputError::EmptyInput);
         }
 
-        let mut active = self.active_turn.lock().await;
-        let Some(active_turn) = active.as_mut() else {
-            return Err(SteerInputError::NoActiveTurn(input));
-        };
+        let active_turn_id = {
+            let mut active = self.active_turn.lock().await;
+            let Some(active_turn) = active.as_mut() else {
+                return Err(SteerInputError::NoActiveTurn(input));
+            };
 
-        let Some((active_turn_id, _)) = active_turn.tasks.first() else {
-            return Err(SteerInputError::NoActiveTurn(input));
-        };
+            let Some((active_turn_id, active_task)) = active_turn.tasks.first() else {
+                return Err(SteerInputError::NoActiveTurn(input));
+            };
+            let active_turn_id = active_turn_id.clone();
 
-        if let Some(expected_turn_id) = expected_turn_id
-            && expected_turn_id != active_turn_id
-        {
-            return Err(SteerInputError::ExpectedTurnMismatch {
-                expected: expected_turn_id.to_string(),
-                actual: active_turn_id.clone(),
-            });
-        }
-
-        match active_turn.tasks.first().map(|(_, task)| task.kind) {
-            Some(crate::state::TaskKind::Regular) => {}
-            Some(crate::state::TaskKind::Review) => {
-                return Err(SteerInputError::ActiveTurnNotSteerable {
-                    turn_kind: NonSteerableTurnKind::Review,
+            if let Some(expected_turn_id) = expected_turn_id
+                && expected_turn_id != active_turn_id
+            {
+                return Err(SteerInputError::ExpectedTurnMismatch {
+                    expected: expected_turn_id.to_string(),
+                    actual: active_turn_id,
                 });
             }
-            Some(crate::state::TaskKind::Compact) => {
-                return Err(SteerInputError::ActiveTurnNotSteerable {
-                    turn_kind: NonSteerableTurnKind::Compact,
-                });
+
+            match active_task.kind {
+                crate::state::TaskKind::Regular => {}
+                crate::state::TaskKind::Review => {
+                    return Err(SteerInputError::ActiveTurnNotSteerable {
+                        turn_kind: NonSteerableTurnKind::Review,
+                    });
+                }
+                crate::state::TaskKind::Compact => {
+                    return Err(SteerInputError::ActiveTurnNotSteerable {
+                        turn_kind: NonSteerableTurnKind::Compact,
+                    });
+                }
             }
-            None => return Err(SteerInputError::NoActiveTurn(input)),
-        }
 
-        if let Some(responsesapi_client_metadata) = responsesapi_client_metadata
-            && let Some((_, active_task)) = active_turn.tasks.first()
-        {
-            active_task
-                .turn_context
-                .turn_metadata_state
-                .set_responsesapi_client_metadata(responsesapi_client_metadata);
-        }
+            if let Some(responsesapi_client_metadata) = responsesapi_client_metadata {
+                active_task
+                    .turn_context
+                    .turn_metadata_state
+                    .set_responsesapi_client_metadata(responsesapi_client_metadata);
+            }
 
-        let mut turn_state = active_turn.turn_state.lock().await;
-        turn_state.push_pending_input(input.into());
-        turn_state.accept_mailbox_delivery_for_current_turn();
-        Ok(active_turn_id.clone())
+            let mut turn_state = active_turn.turn_state.lock().await;
+            turn_state.push_pending_input(input.into());
+            turn_state.accept_mailbox_delivery_for_current_turn();
+            active_turn_id
+        };
+
+        Ok(active_turn_id)
     }
 
     /// Returns the input if there was no task running to inject into.

--- a/codex-rs/core/tests/suite/otel.rs
+++ b/codex-rs/core/tests/suite/otel.rs
@@ -24,10 +24,13 @@ use core_test_support::responses::mount_sse_once;
 use core_test_support::responses::sse;
 use core_test_support::responses::sse_response;
 use core_test_support::responses::start_mock_server;
+use core_test_support::streaming_sse::StreamingSseChunk;
+use core_test_support::streaming_sse::start_streaming_sse_server;
 use core_test_support::test_codex::TestCodex;
 use core_test_support::test_codex::test_codex;
 use core_test_support::wait_for_event;
 use std::sync::Mutex;
+use tokio::sync::oneshot;
 use tracing::Level;
 use tracing_test::traced_test;
 
@@ -130,6 +133,91 @@ async fn responses_api_emits_api_request_event() {
             .find(|line| line.contains("codex.conversation_starts"))
             .map(|_| Ok(()))
             .unwrap_or_else(|| Err("expected codex.conversation_starts event".to_string()))
+    });
+
+    logs_assert(|lines: &[&str]| {
+        lines
+            .iter()
+            .find(|line| line.contains("codex.user_prompt") && line.contains("prompt_length=5"))
+            .map(|_| Ok(()))
+            .unwrap_or_else(|| Err("expected codex.user_prompt event".to_string()))
+    });
+}
+
+#[tokio::test]
+#[traced_test]
+async fn steer_input_emits_user_prompt_event() {
+    let (complete_first_response_tx, complete_first_response_rx) = oneshot::channel();
+    let (server, _completions) = start_streaming_sse_server(vec![
+        vec![
+            StreamingSseChunk {
+                gate: None,
+                body: sse(vec![
+                    ev_response_created("resp-1"),
+                    ev_assistant_message("msg-1", "Working"),
+                ]),
+            },
+            StreamingSseChunk {
+                gate: Some(complete_first_response_rx),
+                body: sse(vec![ev_completed("resp-1")]),
+            },
+        ],
+        vec![StreamingSseChunk {
+            gate: None,
+            body: sse(vec![
+                ev_response_created("resp-2"),
+                ev_assistant_message("msg-2", "Done"),
+                ev_completed("resp-2"),
+            ]),
+        }],
+    ])
+    .await;
+
+    let TestCodex { codex, .. } = test_codex()
+        .build_with_streaming_server(&server)
+        .await
+        .unwrap();
+
+    codex
+        .submit(Op::UserInput {
+            environments: None,
+            items: vec![UserInput::Text {
+                text: "initial prompt".into(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+            responsesapi_client_metadata: None,
+        })
+        .await
+        .unwrap();
+
+    wait_for_event(&codex, |ev| matches!(ev, EventMsg::TurnStarted(_))).await;
+    server.wait_for_request_count(/*count*/ 1).await;
+
+    codex
+        .steer_input(
+            vec![UserInput::Text {
+                text: "queued telemetry prompt".into(),
+                text_elements: Vec::new(),
+            }],
+            /*expected_turn_id*/ None,
+            /*responsesapi_client_metadata*/ None,
+        )
+        .await
+        .unwrap();
+
+    complete_first_response_tx
+        .send(())
+        .expect("first response gate should still be open");
+    wait_for_event(&codex, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+    server.shutdown().await;
+
+    logs_assert(|lines: &[&str]| {
+        lines
+            .iter()
+            .find(|line| line.contains("codex.user_prompt") && line.contains("prompt_length=23"))
+            .map(|_| Ok(()))
+            .unwrap_or_else(|| Err("expected codex.user_prompt for steered input".to_string()))
     });
 }
 


### PR DESCRIPTION
## Summary

This fixes missing `codex.user_prompt` OTEL events for inputs that enter the turn through paths other than the top-level submission handler, notably app-server `turn/steer` and queued pending user input.

## Root Cause

Prompt telemetry was emitted from `user_input_or_turn_inner`, before the turn pipeline recorded the user message. App-server `turn/steer` calls `Session::steer_input` directly, which queued accepted input without passing through that handler-side telemetry emission. The result was sessions that could contain tool calls and commands, but no corresponding prompt telemetry event.

## Changes

- Move `codex.user_prompt` emission into `Session::record_user_prompt_and_emit_turn_item`, the shared path that records accepted user messages into a turn.
- Remove duplicate handler-side prompt emissions now that the recording path owns the telemetry.
- Keep `Session::steer_input` focused on validation, metadata attachment, and queuing accepted same-turn input.
- Add OTEL regression coverage for normal user input and steered user input.

## Notes

This preserves existing privacy behavior: prompt text remains redacted unless `otel.log_user_prompt` is enabled, while `prompt_length` continues to be emitted.

`thread/inject_items` remains intentionally outside `codex.user_prompt` because it appends raw Responses API history without starting a user turn.

## Validation

- `just fmt`
- `cargo test -p codex-core responses_api_emits_api_request_event`
- `cargo test -p codex-core steer_input_emits_user_prompt_event`
- `cargo test -p codex-core steer_input_returns_active_turn_id`

A broader `cargo test -p codex-core` run was attempted and is currently blocked by an unrelated existing stack overflow in `tools::handlers::multi_agents::tests::tool_handlers_cascade_close_and_resume_and_keep_explicitly_closed_subtrees_closed`; rerunning that exact test in isolation reproduces the stack overflow.