### PR TITLE
Publish Linux runtime wheels with glibc-compatible tags

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -413,10 +413,10 @@ jobs:
               platform_tag="macosx_10_9_x86_64"
               ;;
             aarch64-unknown-linux-musl)
-              platform_tag="musllinux_1_1_aarch64"
+              platform_tag="manylinux_2_17_aarch64"
               ;;
             x86_64-unknown-linux-musl)
-              platform_tag="musllinux_1_1_x86_64"
+              platform_tag="manylinux_2_17_x86_64"
               ;;
             *)
               echo "No Python runtime wheel platform tag for ${{ matrix.target }}"


### PR DESCRIPTION
## Why

The Python SDK depends on `openai-codex-cli-bin` runtime wheels being installable on the Linux hosts our users actually run. The release workflow currently tags the Linux runtime artifacts as `musllinux_*`, which makes pip ignore them on normal glibc distributions even though the bundled Rust executables are intended to run there.

## What changed

- Tag the Linux runtime wheels as `manylinux_2_17_aarch64` and `manylinux_2_17_x86_64` instead of `musllinux_1_1_*`.
- Keep the existing runtime wheel build and publish flow unchanged otherwise.

## Verification

- Confirmed the wheel-tag issue against the PyPA platform-tag rules for `manylinux` vs `musllinux`.
- This PR is now intentionally scoped to the tag correction only; the broader Python runtime release workflow has already landed on `main` through the merged stack.

## Follow-up

After publishing the next alpha from this branch, install the SDK/runtime in a fresh glibc Linux environment and confirm pip resolves the tagged Linux wheel as expected.