### PR TITLE
[repro] main Windows sideband Bazel test

### DIFF
--- a/codex-rs/core/tests/suite/realtime_conversation.rs
+++ b/codex-rs/core/tests/suite/realtime_conversation.rs
@@ -739,6 +739,8 @@ async fn conversation_webrtc_close_while_sideband_connecting_drops_pending_join(
 async fn conversation_webrtc_sideband_connect_failure_closes_with_error() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
+    std::hint::black_box("force-main-sideband-windows-repro");
+
     let server = start_mock_server().await;
     Mock::given(method("POST"))
         .and(path_regex(".*/realtime/calls$"))


### PR DESCRIPTION
## Why

This is a draft proof PR for #21652. The goal is to show whether `conversation_webrtc_sideband_connect_failure_closes_with_error` fails from `main` when Windows Bazel is forced to execute a fresh test binary.

A prior comment-only branch did not prove this because it could still allow cached Bazel outputs. This PR changes the exact test binary with a behaviorless `std::hint::black_box(...)` marker, leaving the test semantics unchanged while forcing a new action key.

## What changed

- Added a no-op marker inside `codex-rs/core/tests/suite/realtime_conversation.rs` in `conversation_webrtc_sideband_connect_failure_closes_with_error`.
- No production behavior changes. This PR is not intended to merge.

## Expected signal

- Watch `Bazel test on windows-latest for x86_64-pc-windows-gnullvm`.
- If the hypothesis is right, the same test should fail there without the `request_max_retries = Some(0)` fix from #21652.

## Verification

- `just fmt`
- `cargo test -p codex-core --test all conversation_webrtc_sideband_connect_failure_closes_with_error`
