### PR TITLE
[codex] Eliminate direct writes to GITHUB_ENV

### DIFF
--- a/.github/actions/macos-code-sign/action.yml
+++ b/.github/actions/macos-code-sign/action.yml
@@ -34,6 +34,7 @@ runs:
   using: composite
   steps:
     - name: Configure Apple code signing
+      id: configure_code_signing
       shell: bash
       env:
         KEYCHAIN_PASSWORD: actions
@@ -113,8 +114,8 @@ runs:
 
         rm -f "$cert_path"
 
-        echo "APPLE_CODESIGN_IDENTITY=$APPLE_CODESIGN_IDENTITY" >> "$GITHUB_ENV"
-        echo "APPLE_CODESIGN_KEYCHAIN=$keychain_path" >> "$GITHUB_ENV"
+        echo "codesign-identity=$APPLE_CODESIGN_IDENTITY" >> "$GITHUB_OUTPUT"
+        echo "keychain-path=$keychain_path" >> "$GITHUB_OUTPUT"
         echo "::add-mask::$APPLE_CODESIGN_IDENTITY"
 
     - name: Sign macOS binaries
@@ -123,6 +124,8 @@ runs:
       env:
         TARGET: ${{ inputs.target }}
         BINARIES: ${{ inputs.binaries }}
+        APPLE_CODESIGN_IDENTITY: ${{ steps.configure_code_signing.outputs.codesign-identity }}
+        APPLE_CODESIGN_KEYCHAIN: ${{ steps.configure_code_signing.outputs.keychain-path }}
       run: |
         set -euo pipefail
 
@@ -196,6 +199,8 @@ runs:
       shell: bash
       env:
         TARGET: ${{ inputs.target }}
+        APPLE_CODESIGN_IDENTITY: ${{ steps.configure_code_signing.outputs.codesign-identity }}
+        APPLE_CODESIGN_KEYCHAIN: ${{ steps.configure_code_signing.outputs.keychain-path }}
         APPLE_NOTARIZATION_KEY_P8: ${{ inputs.apple-notarization-key-p8 }}
         APPLE_NOTARIZATION_KEY_ID: ${{ inputs.apple-notarization-key-id }}
         APPLE_NOTARIZATION_ISSUER_ID: ${{ inputs.apple-notarization-issuer-id }}
@@ -239,7 +244,7 @@ runs:
       if: ${{ always() }}
       shell: bash
       env:
-        APPLE_CODESIGN_KEYCHAIN: ${{ env.APPLE_CODESIGN_KEYCHAIN }}
+        APPLE_CODESIGN_KEYCHAIN: ${{ steps.configure_code_signing.outputs.keychain-path }}
       run: |
         set -euo pipefail
         if [[ -n "${APPLE_CODESIGN_KEYCHAIN:-}" ]]; then

--- a/.github/actions/prepare-bazel-ci/action.yml
+++ b/.github/actions/prepare-bazel-ci/action.yml
@@ -21,6 +21,9 @@ outputs:
   repository-cache-hit:
     description: Whether the Bazel repository cache restore found an exact key match.
     value: ${{ steps.cache_bazel_repository_restore.outputs.cache-hit }}
+  bazel-ci-config-path:
+    description: Tab-delimited Bazel CI config consumed by the Bazel wrapper scripts.
+    value: ${{ steps.setup_bazel.outputs.bazel-ci-config-path }}
 
 runs:
   using: composite
@@ -59,6 +62,9 @@ runs:
 
     - name: Set up Bazel execution logs
       shell: bash
+      env:
+        BAZEL_CI_CONFIG_PATH: ${{ steps.setup_bazel.outputs.bazel-ci-config-path }}
       run: |
         mkdir -p "${RUNNER_TEMP}/bazel-execution-logs"
-        echo "CODEX_BAZEL_EXECUTION_LOG_COMPACT_DIR=${RUNNER_TEMP}/bazel-execution-logs" >> "${GITHUB_ENV}"
+        printf 'CODEX_BAZEL_EXECUTION_LOG_COMPACT_DIR\t%s\n' \
+          "${RUNNER_TEMP}/bazel-execution-logs" >> "${BAZEL_CI_CONFIG_PATH}"

--- a/.github/actions/run-argument-comment-lint/action.yml
+++ b/.github/actions/run-argument-comment-lint/action.yml
@@ -13,7 +13,8 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: ./.github/actions/setup-bazel-ci
+    - id: setup_bazel
+      uses: ./.github/actions/setup-bazel-ci
       with:
         target: ${{ inputs.target }}
         install-test-prereqs: true
@@ -29,6 +30,7 @@ runs:
       if: ${{ runner.os != 'Windows' }}
       env:
         BUILDBUDDY_API_KEY: ${{ inputs.buildbuddy-api-key }}
+        CODEX_BAZEL_CI_CONFIG: ${{ steps.setup_bazel.outputs.bazel-ci-config-path }}
       shell: bash
       run: |
         bazel_targets="$(./tools/argument-comment-lint/list-bazel-targets.sh)"
@@ -45,6 +47,7 @@ runs:
       if: ${{ runner.os == 'Windows' }}
       env:
         BUILDBUDDY_API_KEY: ${{ inputs.buildbuddy-api-key }}
+        CODEX_BAZEL_CI_CONFIG: ${{ steps.setup_bazel.outputs.bazel-ci-config-path }}
       shell: bash
       run: |
         ./.github/scripts/run-argument-comment-lint-bazel.sh \

--- a/.github/actions/setup-bazel-ci/action.yml
+++ b/.github/actions/setup-bazel-ci/action.yml
@@ -12,6 +12,9 @@ outputs:
   repository-cache-path:
     description: Filesystem path used for the Bazel repository cache.
     value: ${{ steps.configure_bazel_repository_cache.outputs.repository-cache-path }}
+  bazel-ci-config-path:
+    description: Tab-delimited Bazel CI config consumed by the Bazel wrapper scripts.
+    value: ${{ steps.configure_bazel_ci_config.outputs.config-path }}
 
 runs:
   using: composite
@@ -44,11 +47,22 @@ runs:
         # returns HTTP 400 for that path in the Windows clippy job.
         $repositoryCachePath = Join-Path $HOME '.cache/bazel-repo-cache'
         "repository-cache-path=$repositoryCachePath" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-        "BAZEL_REPOSITORY_CACHE=$repositoryCachePath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+    - name: Configure Bazel CI config
+      id: configure_bazel_ci_config
+      shell: pwsh
+      env:
+        REPOSITORY_CACHE_PATH: ${{ steps.configure_bazel_repository_cache.outputs.repository-cache-path }}
+      run: |
+        $configPath = Join-Path $env:RUNNER_TEMP "bazel-ci-config-$env:GITHUB_RUN_ID-$env:GITHUB_JOB.tsv"
+        "BAZEL_REPOSITORY_CACHE`t$env:REPOSITORY_CACHE_PATH" | Out-File -FilePath $configPath -Encoding utf8NoBOM
+        "config-path=$configPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
     - name: Configure Bazel output root (Windows)
       if: runner.os == 'Windows'
       shell: pwsh
+      env:
+        BAZEL_CI_CONFIG_PATH: ${{ steps.configure_bazel_ci_config.outputs.config-path }}
       run: |
         # Use the shortest available drive to reduce argv/path length issues,
         # but avoid the drive root because some Windows test launchers mis-handle
@@ -56,12 +70,14 @@ runs:
         $hasDDrive = Test-Path 'D:\'
         $bazelOutputUserRoot = if ($hasDDrive) { 'D:\b' } else { 'C:\b' }
         $repoContentsCache = Join-Path $env:RUNNER_TEMP "bazel-repo-contents-cache-$env:GITHUB_RUN_ID-$env:GITHUB_JOB"
-        "BAZEL_OUTPUT_USER_ROOT=$bazelOutputUserRoot" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-        "BAZEL_REPO_CONTENTS_CACHE=$repoContentsCache" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        "BAZEL_OUTPUT_USER_ROOT`t$bazelOutputUserRoot" | Out-File -FilePath $env:BAZEL_CI_CONFIG_PATH -Encoding utf8NoBOM -Append
+        "BAZEL_REPO_CONTENTS_CACHE`t$repoContentsCache" | Out-File -FilePath $env:BAZEL_CI_CONFIG_PATH -Encoding utf8NoBOM -Append
 
-    - name: Expose MSVC SDK environment (Windows)
+    - name: Configure MSVC SDK environment (Windows)
       if: runner.os == 'Windows'
       shell: pwsh
+      env:
+        BAZEL_CI_CONFIG_PATH: ${{ steps.configure_bazel_ci_config.outputs.config-path }}
       run: |
         # Bazel exec-side Rust build scripts do not reliably inherit the MSVC developer
         # shell on GitHub-hosted Windows runners, so discover the latest VS install and
@@ -101,8 +117,8 @@ runs:
         )
 
         # `VsDevCmd.bat` is a batch file, so invoke it under `cmd.exe`, suppress its
-        # banner, then dump the resulting environment with `set`. Re-export only the
-        # approved keys into `GITHUB_ENV` so later steps inherit the same MSVC context.
+        # banner, then dump the resulting environment with `set`. Capture only the
+        # approved keys in the Bazel CI config for later wrapper invocations.
         $envLines = & cmd.exe /c ('"{0}" -no_logo -arch=x64 -host_arch=x64 >nul && set' -f $vsDevCmd)
         foreach ($line in $envLines) {
           if ($line -notmatch '^(.*?)=(.*)$') {
@@ -112,14 +128,15 @@ runs:
           $name = $matches[1]
           $value = $matches[2]
           if ($varsToExport -contains $name) {
-            "$name=$value" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+            Set-Item -Path "Env:$name" -Value $value
+            if ($name -ne 'PATH') {
+              "$name`t$value" | Out-File -FilePath $env:BAZEL_CI_CONFIG_PATH -Encoding utf8NoBOM -Append
+            }
           }
         }
 
-    - name: Compute cache-stable Windows Bazel PATH
-      if: runner.os == 'Windows'
-      shell: pwsh
-      run: ./.github/scripts/compute-bazel-windows-path.ps1
+        $stablePath = ./.github/scripts/compute-bazel-windows-path.ps1
+        "CODEX_BAZEL_WINDOWS_PATH`t$stablePath" | Out-File -FilePath $env:BAZEL_CI_CONFIG_PATH -Encoding utf8NoBOM -Append
 
     - name: Enable Git long paths (Windows)
       if: runner.os == 'Windows'

--- a/.github/actions/setup-rusty-v8-musl/action.yml
+++ b/.github/actions/setup-rusty-v8-musl/action.yml
@@ -4,11 +4,19 @@ inputs:
   target:
     description: Rust musl target triple.
     required: true
+outputs:
+  archive-path:
+    description: Downloaded rusty_v8 archive path for Cargo builds.
+    value: ${{ steps.configure_rusty_v8.outputs.archive-path }}
+  src-binding-path:
+    description: Downloaded rusty_v8 binding source path for Cargo builds.
+    value: ${{ steps.configure_rusty_v8.outputs.src-binding-path }}
 
 runs:
   using: composite
   steps:
     - name: Configure musl rusty_v8 artifact overrides and verify checksums
+      id: configure_rusty_v8
       shell: bash
       env:
         TARGET: ${{ inputs.target }}
@@ -45,5 +53,5 @@ runs:
         fi
 
         (cd "${binding_dir}" && sha256sum -c "${checksums_path}")
-        echo "RUSTY_V8_ARCHIVE=${archive_path}" >> "${GITHUB_ENV}"
-        echo "RUSTY_V8_SRC_BINDING_PATH=${binding_path}" >> "${GITHUB_ENV}"
+        echo "archive-path=${archive_path}" >> "${GITHUB_OUTPUT}"
+        echo "src-binding-path=${binding_path}" >> "${GITHUB_OUTPUT}"

--- a/.github/scripts/compute-bazel-windows-path.ps1
+++ b/.github/scripts/compute-bazel-windows-path.ps1
@@ -8,9 +8,9 @@ This script derives a smaller, cache-stable PATH that keeps the Windows
 toolchain entries Bazel-backed CI tasks need: MSVC and Windows SDK paths,
 MinGW runtime DLL paths for gnullvm-built tests, Git, PowerShell, Node, Python,
 DotSlash, and the standard Windows system directories.
-`setup-bazel-ci` runs this after exporting the MSVC environment, and the script
-publishes the result via `GITHUB_ENV` as `CODEX_BAZEL_WINDOWS_PATH` so later
-steps can pass that explicit PATH to Bazel.
+`setup-bazel-ci` runs this after materializing the MSVC environment, and the
+script returns the derived PATH so the composite action can expose it as an
+explicit output for later Bazel steps.
 #>
 
 $stablePathEntries = New-Object System.Collections.Generic.List[string]
@@ -101,13 +101,9 @@ if ($stablePathEntries.Count -eq 0) {
   throw 'Failed to derive cache-stable Windows PATH.'
 }
 
-if ([string]::IsNullOrWhiteSpace($env:GITHUB_ENV)) {
-  throw 'GITHUB_ENV must be set.'
-}
-
 $stablePath = $stablePathEntries -join ';'
 Write-Host 'Derived CODEX_BAZEL_WINDOWS_PATH entries:'
 foreach ($pathEntry in $stablePathEntries) {
   Write-Host "  $pathEntry"
 }
-"CODEX_BAZEL_WINDOWS_PATH=$stablePath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+Write-Output $stablePath

--- a/.github/scripts/load-bazel-ci-config.sh
+++ b/.github/scripts/load-bazel-ci-config.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+load_bazel_ci_config() {
+  local config_path="${CODEX_BAZEL_CI_CONFIG:-}"
+  if [[ -z "$config_path" ]]; then
+    return
+  fi
+
+  if [[ ! -f "$config_path" ]]; then
+    echo "Bazel CI config file not found: $config_path" >&2
+    exit 1
+  fi
+
+  local name
+  local value
+  while IFS=$'\t' read -r name value; do
+    [[ -n "$name" ]] || continue
+    value="${value%$'\r'}"
+    case "$name" in
+      BAZEL_REPOSITORY_CACHE | \
+      BAZEL_OUTPUT_USER_ROOT | \
+      BAZEL_REPO_CONTENTS_CACHE | \
+      CODEX_BAZEL_EXECUTION_LOG_COMPACT_DIR | \
+      CODEX_BAZEL_WINDOWS_PATH | \
+      INCLUDE | \
+      LIB | \
+      LIBPATH | \
+      UCRTVersion | \
+      UniversalCRTSdkDir | \
+      VCINSTALLDIR | \
+      VCToolsInstallDir | \
+      WindowsLibPath | \
+      WindowsSdkBinPath | \
+      WindowsSdkDir | \
+      WindowsSDKLibVersion | \
+      WindowsSDKVersion)
+        if [[ -z "${!name:-}" ]]; then
+          printf -v "$name" '%s' "$value"
+          export "$name"
+        fi
+        ;;
+      *)
+        echo "Unknown Bazel CI config key: $name" >&2
+        exit 1
+        ;;
+    esac
+  done < "$config_path"
+}

--- a/.github/scripts/run-bazel-ci.sh
+++ b/.github/scripts/run-bazel-ci.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+source "$(dirname "${BASH_SOURCE[0]}")/load-bazel-ci-config.sh"
+load_bazel_ci_config
+
 print_failed_bazel_test_logs=0
 print_failed_bazel_action_summary=0
 remote_download_toplevel=0

--- a/.github/scripts/run-bazel-query-ci.sh
+++ b/.github/scripts/run-bazel-query-ci.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+source "$(dirname "${BASH_SOURCE[0]}")/load-bazel-ci-config.sh"
+load_bazel_ci_config
+
 # Run Bazel queries with the same CI startup settings as the main build/test
 # invocation so target-discovery queries can reuse the same Bazel server.
 

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -82,6 +82,7 @@ jobs:
       - name: bazel test //...
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+          CODEX_BAZEL_CI_CONFIG: ${{ steps.prepare_bazel.outputs.bazel-ci-config-path }}
         shell: bash
         run: |
           bazel_targets=(
@@ -165,6 +166,7 @@ jobs:
       - name: bazel test //...
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+          CODEX_BAZEL_CI_CONFIG: ${{ steps.prepare_bazel.outputs.bazel-ci-config-path }}
         shell: bash
         run: |
           bazel_targets=(
@@ -249,6 +251,7 @@ jobs:
       - name: bazel build --config=clippy lint targets
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+          CODEX_BAZEL_CI_CONFIG: ${{ steps.prepare_bazel.outputs.bazel-ci-config-path }}
         shell: bash
         run: |
           bazel_clippy_args=(
@@ -338,6 +341,7 @@ jobs:
       - name: bazel build verify-release-build targets
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+          CODEX_BAZEL_CI_CONFIG: ${{ steps.prepare_bazel.outputs.bazel-ci-config-path }}
         shell: bash
         run: |
           # This job exists to compile Rust code behind
@@ -383,6 +387,7 @@ jobs:
         if: runner.os == 'Linux'
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+          CODEX_BAZEL_CI_CONFIG: ${{ steps.prepare_bazel.outputs.bazel-ci-config-path }}
         shell: bash
         run: |
           ./.github/scripts/run-bazel-ci.sh \

--- a/.github/workflows/rust-ci-full.yml
+++ b/.github/workflows/rust-ci-full.yml
@@ -110,7 +110,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: ./.github/actions/setup-bazel-ci
+      - id: setup_bazel
+        uses: ./.github/actions/setup-bazel-ci
         with:
           target: ${{ runner.os }}
           install-test-prereqs: true
@@ -124,6 +125,7 @@ jobs:
         if: ${{ runner.os != 'Windows' }}
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+          CODEX_BAZEL_CI_CONFIG: ${{ steps.setup_bazel.outputs.bazel-ci-config-path }}
         shell: bash
         run: |
           bazel_targets="$(./tools/argument-comment-lint/list-bazel-targets.sh)"
@@ -139,6 +141,7 @@ jobs:
         if: ${{ runner.os == 'Windows' }}
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+          CODEX_BAZEL_CI_CONFIG: ${{ steps.setup_bazel.outputs.bazel-ci-config-path }}
         shell: bash
         run: |
           ./.github/scripts/run-argument-comment-lint-bazel.sh \
@@ -438,6 +441,7 @@ jobs:
 
       - if: ${{ matrix.target == 'x86_64-unknown-linux-musl' || matrix.target == 'aarch64-unknown-linux-musl' }}
         name: Configure musl rusty_v8 artifact overrides and verify checksums
+        id: setup_rusty_v8_musl
         uses: ./.github/actions/setup-rusty-v8-musl
         with:
           target: ${{ matrix.target }}
@@ -451,15 +455,32 @@ jobs:
 
       - name: Pre-warm dependency cache (cargo-chef)
         if: ${{ matrix.profile == 'release' }}
+        env:
+          RUSTY_V8_ARCHIVE_OVERRIDE: ${{ steps.setup_rusty_v8_musl.outputs.archive-path }}
+          RUSTY_V8_SRC_BINDING_PATH_OVERRIDE: ${{ steps.setup_rusty_v8_musl.outputs.src-binding-path }}
         shell: bash
         run: |
           set -euo pipefail
+          if [[ -n "${RUSTY_V8_ARCHIVE_OVERRIDE:-}" ]]; then
+            export RUSTY_V8_ARCHIVE="${RUSTY_V8_ARCHIVE_OVERRIDE}"
+            export RUSTY_V8_SRC_BINDING_PATH="${RUSTY_V8_SRC_BINDING_PATH_OVERRIDE}"
+          fi
           RECIPE="${RUNNER_TEMP}/chef-recipe.json"
           cargo chef prepare --recipe-path "$RECIPE"
           cargo chef cook --recipe-path "$RECIPE" --target ${{ matrix.target }} --release
 
       - name: cargo clippy
-        run: cargo clippy --target ${{ matrix.target }} --tests --profile ${{ matrix.profile }} --timings -- -D warnings
+        env:
+          RUSTY_V8_ARCHIVE_OVERRIDE: ${{ steps.setup_rusty_v8_musl.outputs.archive-path }}
+          RUSTY_V8_SRC_BINDING_PATH_OVERRIDE: ${{ steps.setup_rusty_v8_musl.outputs.src-binding-path }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -n "${RUSTY_V8_ARCHIVE_OVERRIDE:-}" ]]; then
+            export RUSTY_V8_ARCHIVE="${RUSTY_V8_ARCHIVE_OVERRIDE}"
+            export RUSTY_V8_SRC_BINDING_PATH="${RUSTY_V8_SRC_BINDING_PATH_OVERRIDE}"
+          fi
+          cargo clippy --target ${{ matrix.target }} --tests --profile ${{ matrix.profile }} --timings -- -D warnings
 
       - name: Upload Cargo timings (clippy)
         if: always()

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -256,15 +256,23 @@ jobs:
 
       - if: ${{ matrix.target == 'x86_64-unknown-linux-musl' || matrix.target == 'aarch64-unknown-linux-musl' }}
         name: Configure musl rusty_v8 artifact overrides and verify checksums
+        id: setup_rusty_v8_musl
         uses: ./.github/actions/setup-rusty-v8-musl
         with:
           target: ${{ matrix.target }}
 
       - if: ${{ contains(matrix.target, 'linux') && matrix.bundle == 'primary' }}
         name: Build bwrap and export digest
+        env:
+          RUSTY_V8_ARCHIVE_OVERRIDE: ${{ steps.setup_rusty_v8_musl.outputs.archive-path }}
+          RUSTY_V8_SRC_BINDING_PATH_OVERRIDE: ${{ steps.setup_rusty_v8_musl.outputs.src-binding-path }}
         shell: bash
         run: |
           set -euo pipefail
+          if [[ -n "${RUSTY_V8_ARCHIVE_OVERRIDE:-}" ]]; then
+            export RUSTY_V8_ARCHIVE="${RUSTY_V8_ARCHIVE_OVERRIDE}"
+            export RUSTY_V8_SRC_BINDING_PATH="${RUSTY_V8_SRC_BINDING_PATH_OVERRIDE}"
+          fi
           target="${{ matrix.target }}"
           cargo build --target "$target" --release --timings --bin bwrap
 
@@ -279,8 +287,15 @@ jobs:
           echo "Built bwrap ${bwrap_path} with sha256:${digest}"
 
       - name: Cargo build
+        env:
+          RUSTY_V8_ARCHIVE_OVERRIDE: ${{ steps.setup_rusty_v8_musl.outputs.archive-path }}
+          RUSTY_V8_SRC_BINDING_PATH_OVERRIDE: ${{ steps.setup_rusty_v8_musl.outputs.src-binding-path }}
         shell: bash
         run: |
+          if [[ -n "${RUSTY_V8_ARCHIVE_OVERRIDE:-}" ]]; then
+            export RUSTY_V8_ARCHIVE="${RUSTY_V8_ARCHIVE_OVERRIDE}"
+            export RUSTY_V8_SRC_BINDING_PATH="${RUSTY_V8_SRC_BINDING_PATH_OVERRIDE}"
+          fi
           build_args=()
           for binary in ${{ matrix.binaries }}; do
             build_args+=(--bin "$binary")

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Build codex with Bazel
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+          CODEX_BAZEL_CI_CONFIG: ${{ steps.setup_bazel.outputs.bazel-ci-config-path }}
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
This eliminates some direct writes to `${GITHUB_ENV}` in our custom (in-repo) actions. The idea behind this is twofold:

1. Reduce the amount of global mutation we do, to make individual steps less stateful (or where stateful, clearly initialized);
2. Eliminate a (minor) source of code injection risk, i.e. where a manipulated input induces us into setting environment variables that can be pivoted into code execution (things like `LD_PRELOAD`).

In practice (2) is not a real security risk at the moment, since the inputs to `${GITHUB_ENV}` are not sufficiently attacker-controllable. But we should still address it for defense-in-depth.