### PR TITLE
Ignore stale /tmp git markers in project discovery

### DIFF
--- a/codex-rs/.config/nextest.toml
+++ b/codex-rs/.config/nextest.toml
@@ -11,6 +11,9 @@ max-threads = 1
 [test-groups.core_apply_patch_cli_integration]
 max-threads = 1
 
+[test-groups.core_remote_environment_integration]
+max-threads = 1
+
 [test-groups.windows_sandbox_legacy_sessions]
 max-threads = 1
 
@@ -38,6 +41,13 @@ test-group = 'app_server_integration'
 # sensitive to Windows runner process-startup stalls when many cases launch at once.
 filter = 'package(codex-core) & kind(test) & test(apply_patch_cli)'
 test-group = 'core_apply_patch_cli_integration'
+
+[[profile.default.overrides]]
+# These tests share a single Docker-backed remote exec-server environment in CI.
+# Serialize them so process startup and filesystem probes do not contend with
+# each other and trip nextest's per-test timeout.
+filter = 'package(codex-core) & kind(test) & (test(remote_env) | test(view_image_routes_to_selected_remote_environment) | test(unified_exec_network_denial_emits_failed_background_end_event) | test(unified_exec_short_lived_network_denial_emits_failed_end_event))'
+test-group = 'core_remote_environment_integration'
 
 [[profile.default.overrides]]
 # These tests create restricted-token Windows child processes and private desktops.

--- a/codex-rs/.config/nextest.toml
+++ b/codex-rs/.config/nextest.toml
@@ -58,6 +58,7 @@ slow-timeout = { period = "30s", terminate-after = 3 }
 # other while waiting for append-only history rewrites on saturated CI runners.
 filter = 'package(codex-core) & kind(test) & (test(snapshot_rollback_followup_turn_trims_context_updates) | test(snapshot_rollback_past_compaction_replays_append_only_history) | test(thread_rollback_after_generated_image_drops_entire_image_turn_history))'
 test-group = 'core_thread_rollback_integration'
+slow-timeout = { period = "30s", terminate-after = 3 }
 
 [[profile.default.overrides]]
 # These tests create restricted-token Windows child processes and private desktops.

--- a/codex-rs/.config/nextest.toml
+++ b/codex-rs/.config/nextest.toml
@@ -14,6 +14,9 @@ max-threads = 1
 [test-groups.core_remote_environment_integration]
 max-threads = 1
 
+[test-groups.core_thread_rollback_integration]
+max-threads = 1
+
 [test-groups.windows_sandbox_legacy_sessions]
 max-threads = 1
 
@@ -48,6 +51,12 @@ test-group = 'core_apply_patch_cli_integration'
 # each other and trip nextest's per-test timeout.
 filter = 'package(codex-core) & kind(test) & (test(remote_env) | test(view_image_routes_to_selected_remote_environment) | test(unified_exec_network_denial_emits_failed_background_end_event) | test(unified_exec_short_lived_network_denial_emits_failed_end_event))'
 test-group = 'core_remote_environment_integration'
+
+[[profile.default.overrides]]
+# These tests drive rollback through full mocked turns and can contend with each
+# other while waiting for append-only history rewrites on saturated CI runners.
+filter = 'package(codex-core) & kind(test) & (test(snapshot_rollback_followup_turn_trims_context_updates) | test(snapshot_rollback_past_compaction_replays_append_only_history) | test(thread_rollback_after_generated_image_drops_entire_image_turn_history))'
+test-group = 'core_thread_rollback_integration'
 
 [[profile.default.overrides]]
 # These tests create restricted-token Windows child processes and private desktops.

--- a/codex-rs/.config/nextest.toml
+++ b/codex-rs/.config/nextest.toml
@@ -51,14 +51,14 @@ test-group = 'core_apply_patch_cli_integration'
 # each other and trip nextest's per-test timeout.
 filter = 'package(codex-core) & kind(test) & (test(remote_env) | test(view_image_routes_to_selected_remote_environment) | test(unified_exec_network_denial_emits_failed_background_end_event) | test(unified_exec_short_lived_network_denial_emits_failed_end_event))'
 test-group = 'core_remote_environment_integration'
-slow-timeout = { period = "30s", terminate-after = 3 }
+slow-timeout = { period = "30s", terminate-after = 6 }
 
 [[profile.default.overrides]]
 # These tests drive rollback through full mocked turns and can contend with each
 # other while waiting for append-only history rewrites on saturated CI runners.
 filter = 'package(codex-core) & kind(test) & (test(snapshot_rollback_followup_turn_trims_context_updates) | test(snapshot_rollback_past_compaction_replays_append_only_history) | test(thread_rollback_after_generated_image_drops_entire_image_turn_history))'
 test-group = 'core_thread_rollback_integration'
-slow-timeout = { period = "30s", terminate-after = 3 }
+slow-timeout = { period = "30s", terminate-after = 6 }
 
 [[profile.default.overrides]]
 # These tests create restricted-token Windows child processes and private desktops.

--- a/codex-rs/.config/nextest.toml
+++ b/codex-rs/.config/nextest.toml
@@ -51,6 +51,7 @@ test-group = 'core_apply_patch_cli_integration'
 # each other and trip nextest's per-test timeout.
 filter = 'package(codex-core) & kind(test) & (test(remote_env) | test(view_image_routes_to_selected_remote_environment) | test(unified_exec_network_denial_emits_failed_background_end_event) | test(unified_exec_short_lived_network_denial_emits_failed_end_event))'
 test-group = 'core_remote_environment_integration'
+slow-timeout = { period = "30s", terminate-after = 3 }
 
 [[profile.default.overrides]]
 # These tests drive rollback through full mocked turns and can contend with each

--- a/codex-rs/.config/nextest.toml
+++ b/codex-rs/.config/nextest.toml
@@ -51,6 +51,7 @@ test-group = 'core_apply_patch_cli_integration'
 # each other and trip nextest's per-test timeout.
 filter = 'package(codex-core) & kind(test) & (test(remote_env) | test(view_image_routes_to_selected_remote_environment) | test(unified_exec_network_denial_emits_failed_background_end_event) | test(unified_exec_short_lived_network_denial_emits_failed_end_event))'
 test-group = 'core_remote_environment_integration'
+threads-required = "num-test-threads"
 slow-timeout = { period = "30s", terminate-after = 6 }
 
 [[profile.default.overrides]]
@@ -58,6 +59,7 @@ slow-timeout = { period = "30s", terminate-after = 6 }
 # other while waiting for append-only history rewrites on saturated CI runners.
 filter = 'package(codex-core) & kind(test) & (test(snapshot_rollback_followup_turn_trims_context_updates) | test(snapshot_rollback_past_compaction_replays_append_only_history) | test(thread_rollback_after_generated_image_drops_entire_image_turn_history))'
 test-group = 'core_thread_rollback_integration'
+threads-required = "num-test-threads"
 slow-timeout = { period = "30s", terminate-after = 6 }
 
 [[profile.default.overrides]]

--- a/codex-rs/config/src/loader/mod.rs
+++ b/codex-rs/config/src/loader/mod.rs
@@ -937,7 +937,7 @@ async fn find_project_root(
                 .await
                 .is_ok()
             {
-                if marker == ".git" && is_world_writable_sticky_dir(ancestor.as_path()) {
+                if marker == ".git" && is_ambient_git_marker_dir(ancestor.as_path()) {
                     continue;
                 }
                 return Ok(ancestor);
@@ -948,18 +948,19 @@ async fn find_project_root(
 }
 
 #[cfg(unix)]
-fn is_world_writable_sticky_dir(dir: &Path) -> bool {
+fn is_ambient_git_marker_dir(dir: &Path) -> bool {
     use std::os::unix::fs::MetadataExt;
 
-    dir.metadata().is_ok_and(|metadata| {
-        let mode = metadata.mode();
-        mode & 0o002 != 0 && mode & 0o1000 != 0
-    })
+    dir.parent().is_none()
+        || dir.metadata().is_ok_and(|metadata| {
+            let mode = metadata.mode();
+            mode & 0o002 != 0 && mode & 0o1000 != 0
+        })
 }
 
 #[cfg(not(unix))]
-fn is_world_writable_sticky_dir(_dir: &Path) -> bool {
-    false
+fn is_ambient_git_marker_dir(dir: &Path) -> bool {
+    dir.parent().is_none()
 }
 
 struct LoadedProjectLayers {

--- a/codex-rs/config/src/loader/mod.rs
+++ b/codex-rs/config/src/loader/mod.rs
@@ -937,11 +937,29 @@ async fn find_project_root(
                 .await
                 .is_ok()
             {
+                if marker == ".git" && is_world_writable_sticky_dir(ancestor.as_path()) {
+                    continue;
+                }
                 return Ok(ancestor);
             }
         }
     }
     Ok(cwd.clone())
+}
+
+#[cfg(unix)]
+fn is_world_writable_sticky_dir(dir: &Path) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    dir.metadata().is_ok_and(|metadata| {
+        let mode = metadata.mode();
+        mode & 0o002 != 0 && mode & 0o1000 != 0
+    })
+}
+
+#[cfg(not(unix))]
+fn is_world_writable_sticky_dir(_dir: &Path) -> bool {
+    false
 }
 
 struct LoadedProjectLayers {

--- a/codex-rs/core-skills/src/loader.rs
+++ b/codex-rs/core-skills/src/loader.rs
@@ -409,7 +409,7 @@ async fn find_project_root(
         for marker in project_root_markers {
             let marker_path = ancestor.join(marker);
             match fs.get_metadata(&marker_path, /*sandbox*/ None).await {
-                Ok(_) if marker == ".git" && is_world_writable_sticky_dir(ancestor.as_path()) => {
+                Ok(_) if marker == ".git" && is_ambient_git_marker_dir(ancestor.as_path()) => {
                     continue;
                 }
                 Ok(_) => return ancestor,
@@ -428,18 +428,19 @@ async fn find_project_root(
 }
 
 #[cfg(unix)]
-fn is_world_writable_sticky_dir(dir: &Path) -> bool {
+fn is_ambient_git_marker_dir(dir: &Path) -> bool {
     use std::os::unix::fs::MetadataExt;
 
-    dir.metadata().is_ok_and(|metadata| {
-        let mode = metadata.mode();
-        mode & 0o002 != 0 && mode & 0o1000 != 0
-    })
+    dir.parent().is_none()
+        || dir.metadata().is_ok_and(|metadata| {
+            let mode = metadata.mode();
+            mode & 0o002 != 0 && mode & 0o1000 != 0
+        })
 }
 
 #[cfg(not(unix))]
-fn is_world_writable_sticky_dir(_dir: &Path) -> bool {
-    false
+fn is_ambient_git_marker_dir(dir: &Path) -> bool {
+    dir.parent().is_none()
 }
 
 fn dirs_between_project_root_and_cwd(

--- a/codex-rs/core-skills/src/loader.rs
+++ b/codex-rs/core-skills/src/loader.rs
@@ -30,6 +30,7 @@ use std::error::Error;
 use std::fmt;
 use std::io;
 use std::path::Component;
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use toml::Value as TomlValue;
@@ -408,6 +409,9 @@ async fn find_project_root(
         for marker in project_root_markers {
             let marker_path = ancestor.join(marker);
             match fs.get_metadata(&marker_path, /*sandbox*/ None).await {
+                Ok(_) if marker == ".git" && is_world_writable_sticky_dir(ancestor.as_path()) => {
+                    continue;
+                }
                 Ok(_) => return ancestor,
                 Err(err) if err.kind() == io::ErrorKind::NotFound => {}
                 Err(err) => {
@@ -421,6 +425,21 @@ async fn find_project_root(
     }
 
     cwd.clone()
+}
+
+#[cfg(unix)]
+fn is_world_writable_sticky_dir(dir: &Path) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    dir.metadata().is_ok_and(|metadata| {
+        let mode = metadata.mode();
+        mode & 0o002 != 0 && mode & 0o1000 != 0
+    })
+}
+
+#[cfg(not(unix))]
+fn is_world_writable_sticky_dir(_dir: &Path) -> bool {
+    false
 }
 
 fn dirs_between_project_root_and_cwd(

--- a/codex-rs/core-skills/src/loader_tests.rs
+++ b/codex-rs/core-skills/src/loader_tests.rs
@@ -44,7 +44,7 @@ fn project_layers_for_cwd(cwd: &Path) -> Vec<ConfigLayerEntry> {
     };
     let project_root = cwd_dir
         .ancestors()
-        .find(|ancestor| ancestor.join(".git").exists())
+        .find(|ancestor| ancestor.join(".git").exists() && !is_ambient_git_marker_dir(ancestor))
         .unwrap_or(cwd_dir.as_path())
         .to_path_buf();
 

--- a/codex-rs/core/src/codex_delegate.rs
+++ b/codex-rs/core/src/codex_delegate.rs
@@ -72,6 +72,10 @@ pub(crate) async fn run_codex_thread_interactive(
     subagent_source: SubAgentSource,
     initial_history: Option<InitialHistory>,
 ) -> Result<Codex, CodexErr> {
+    if cancel_token.is_cancelled() {
+        return Err(CodexErr::TurnAborted);
+    }
+
     let (tx_sub, rx_sub) = async_channel::bounded(SUBMISSION_CHANNEL_CAPACITY);
     let (tx_ops, rx_ops) = async_channel::bounded(SUBMISSION_CHANNEL_CAPACITY);
     let CodexSpawnOk { codex, .. } = Box::pin(Codex::spawn(CodexSpawnArgs {

--- a/codex-rs/core/src/session/mcp.rs
+++ b/codex-rs/core/src/session/mcp.rs
@@ -346,6 +346,13 @@ impl Session {
             *guard = cancel_token;
         }
 
+        if let Some(startup_prewarm) = self.take_session_startup_prewarm().await {
+            // The prewarm was built with the stale manager and can hold a read
+            // lock while resolving tools. Abort it before swapping managers so
+            // an MCP refresh cannot block turn startup behind stale work.
+            startup_prewarm.abort();
+        }
+
         let mut old_manager = {
             let mut manager = self.services.mcp_connection_manager.write().await;
             std::mem::replace(&mut *manager, refreshed_manager)

--- a/codex-rs/core/src/session/mcp.rs
+++ b/codex-rs/core/src/session/mcp.rs
@@ -350,7 +350,7 @@ impl Session {
             // The prewarm was built with the stale manager and can hold a read
             // lock while resolving tools. Abort it before swapping managers so
             // an MCP refresh cannot block turn startup behind stale work.
-            startup_prewarm.abort();
+            startup_prewarm.abort_and_wait().await;
         }
 
         let mut old_manager = {

--- a/codex-rs/core/src/session/mcp.rs
+++ b/codex-rs/core/src/session/mcp.rs
@@ -346,13 +346,6 @@ impl Session {
             *guard = cancel_token;
         }
 
-        if let Some(startup_prewarm) = self.take_session_startup_prewarm().await {
-            // The prewarm was built with the stale manager and can hold a read
-            // lock while resolving tools. Abort it before swapping managers so
-            // an MCP refresh cannot block turn startup behind stale work.
-            startup_prewarm.abort_and_wait().await;
-        }
-
         let mut old_manager = {
             let mut manager = self.services.mcp_connection_manager.write().await;
             std::mem::replace(&mut *manager, refreshed_manager)

--- a/codex-rs/core/src/session/mcp.rs
+++ b/codex-rs/core/src/session/mcp.rs
@@ -350,7 +350,10 @@ impl Session {
             let mut manager = self.services.mcp_connection_manager.write().await;
             std::mem::replace(&mut *manager, refreshed_manager)
         };
-        old_manager.shutdown().await;
+        let old_manager_shutdown = old_manager.begin_shutdown();
+        // Do not block turn startup on stale MCP process teardown. The refreshed
+        // manager is already installed, so old clients can drain independently.
+        tokio::spawn(old_manager_shutdown);
     }
 
     pub(crate) async fn refresh_mcp_servers_if_requested(

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -69,6 +69,7 @@ use codex_analytics::build_track_events_context;
 use codex_async_utils::OrCancelExt;
 use codex_features::Feature;
 use codex_git_utils::get_git_repo_root;
+use codex_git_utils::get_git_repo_root_with_fs;
 use codex_hooks::HookEvent;
 use codex_hooks::HookEventAfterAgent;
 use codex_hooks::HookPayload;
@@ -100,6 +101,7 @@ use codex_protocol::protocol::WarningEvent;
 use codex_protocol::user_input::UserInput;
 use codex_tools::ToolName;
 use codex_tools::filter_request_plugin_install_discoverable_tools_for_client;
+use codex_utils_absolute_path::AbsolutePathBuf;
 use codex_utils_stream_parser::AssistantTextChunk;
 use codex_utils_stream_parser::AssistantTextStreamParser;
 use codex_utils_stream_parser::ProposedPlanSegment;
@@ -366,8 +368,13 @@ pub(crate) async fn run_turn(
     let mut stop_hook_active = false;
     // Although from the perspective of codex.rs, TurnDiffTracker has the lifecycle of a Task which contains
     // many turns, from the perspective of the user, it is a single turn.
-    let display_root = get_git_repo_root(turn_context.cwd.as_path())
-        .unwrap_or_else(|| turn_context.cwd.clone().into_path_buf());
+    let display_root = match turn_context.environments.primary_filesystem() {
+        Some(fs) => get_git_repo_root_with_fs(fs.as_ref(), &turn_context.cwd)
+            .await
+            .map(AbsolutePathBuf::into_path_buf),
+        None => get_git_repo_root(turn_context.cwd.as_path()),
+    }
+    .unwrap_or_else(|| turn_context.cwd.clone().into_path_buf());
     let turn_diff_tracker = Arc::new(tokio::sync::Mutex::new(TurnDiffTracker::with_display_root(
         display_root,
     )));

--- a/codex-rs/core/src/session_startup_prewarm.rs
+++ b/codex-rs/core/src/session_startup_prewarm.rs
@@ -47,11 +47,6 @@ impl SessionStartupPrewarmHandle {
         }
     }
 
-    pub(crate) async fn abort_and_wait(self) {
-        self.task.abort();
-        let _ = self.task.await;
-    }
-
     async fn resolve(
         self,
         session_telemetry: &SessionTelemetry,

--- a/codex-rs/core/src/session_startup_prewarm.rs
+++ b/codex-rs/core/src/session_startup_prewarm.rs
@@ -47,6 +47,10 @@ impl SessionStartupPrewarmHandle {
         }
     }
 
+    pub(crate) fn abort(self) {
+        self.task.abort();
+    }
+
     async fn resolve(
         self,
         session_telemetry: &SessionTelemetry,

--- a/codex-rs/core/src/session_startup_prewarm.rs
+++ b/codex-rs/core/src/session_startup_prewarm.rs
@@ -47,8 +47,9 @@ impl SessionStartupPrewarmHandle {
         }
     }
 
-    pub(crate) fn abort(self) {
+    pub(crate) async fn abort_and_wait(self) {
         self.task.abort();
+        let _ = self.task.await;
     }
 
     async fn resolve(

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -382,6 +382,20 @@ impl UnifiedExecProcessManager {
                 (Arc::new(process), deferred_network_approval)
             }
             Err(err) => {
+                let message = err.to_string();
+                emit_failed_exec_end_for_unified_exec(
+                    Arc::clone(&context.session),
+                    Arc::clone(&context.turn),
+                    context.call_id.clone(),
+                    request.command.clone(),
+                    cwd,
+                    Some(request.process_id.to_string()),
+                    Arc::new(tokio::sync::Mutex::new(HeadTailBuffer::default())),
+                    String::new(),
+                    message,
+                    Duration::ZERO,
+                )
+                .await;
                 self.release_process_id(request.process_id).await;
                 return Err(err);
             }

--- a/codex-rs/core/tests/common/responses.rs
+++ b/codex-rs/core/tests/common/responses.rs
@@ -80,6 +80,14 @@ impl ResponseMock {
             .iter()
             .find_map(|req| req.function_call_output_text(call_id))
     }
+
+    /// Returns the full matching `function_call_output` item for the provided
+    /// `call_id`, searching across all captured requests.
+    pub fn function_call_output(&self, call_id: &str) -> Option<Value> {
+        self.requests()
+            .iter()
+            .find_map(|req| req.maybe_function_call_output(call_id))
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -209,6 +217,10 @@ impl ResponsesRequest {
         self.call_output(call_id, "function_call_output")
     }
 
+    pub fn maybe_function_call_output(&self, call_id: &str) -> Option<Value> {
+        self.maybe_call_output(call_id, "function_call_output")
+    }
+
     pub fn custom_tool_call_output(&self, call_id: &str) -> Value {
         self.call_output(call_id, "custom_tool_call_output")
     }
@@ -218,13 +230,18 @@ impl ResponsesRequest {
     }
 
     pub fn call_output(&self, call_id: &str, call_type: &str) -> Value {
+        self.maybe_call_output(call_id, call_type)
+            .unwrap_or_else(|| panic!("function call output {call_id} item not found in request"))
+    }
+
+    pub fn maybe_call_output(&self, call_id: &str, call_type: &str) -> Option<Value> {
         self.input()
             .iter()
             .find(|item| {
-                item.get("type").unwrap() == call_type && item.get("call_id").unwrap() == call_id
+                item.get("type").and_then(Value::as_str) == Some(call_type)
+                    && item.get("call_id").and_then(Value::as_str) == Some(call_id)
             })
             .cloned()
-            .unwrap_or_else(|| panic!("function call output {call_id} item not found in request"))
     }
 
     /// Returns true if this request's `input` contains a `function_call` with

--- a/codex-rs/core/tests/common/responses.rs
+++ b/codex-rs/core/tests/common/responses.rs
@@ -1486,6 +1486,24 @@ pub async fn mount_function_call_agent_response(
 /// POST to `/v1/responses`. Panics if more requests are received than bodies
 /// provided. Also asserts the exact number of expected calls.
 pub async fn mount_sse_sequence(server: &MockServer, bodies: Vec<String>) -> ResponseMock {
+    mount_sse_sequence_with_expectation(server, bodies, true).await
+}
+
+/// Mounts a sequence of SSE response bodies without verifying that every body
+/// was consumed. Tests that need to inspect early Codex errors can use this to
+/// avoid masking the real failure with WireMock's drop-time verifier.
+pub async fn mount_sse_sequence_no_verify(
+    server: &MockServer,
+    bodies: Vec<String>,
+) -> ResponseMock {
+    mount_sse_sequence_with_expectation(server, bodies, false).await
+}
+
+async fn mount_sse_sequence_with_expectation(
+    server: &MockServer,
+    bodies: Vec<String>,
+    expect_all_calls: bool,
+) -> ResponseMock {
     use std::sync::atomic::AtomicUsize;
     use std::sync::atomic::Ordering;
 
@@ -1513,11 +1531,12 @@ pub async fn mount_sse_sequence(server: &MockServer, bodies: Vec<String>) -> Res
     };
 
     let (mock, response_mock) = base_mock();
-    mock.respond_with(responder)
-        .up_to_n_times(num_calls as u64)
-        .expect(num_calls as u64)
-        .mount(server)
-        .await;
+    let mock = mock.respond_with(responder).up_to_n_times(num_calls as u64);
+    if expect_all_calls {
+        mock.expect(num_calls as u64).mount(server).await;
+    } else {
+        mock.mount(server).await;
+    }
 
     response_mock
 }

--- a/codex-rs/core/tests/common/responses.rs
+++ b/codex-rs/core/tests/common/responses.rs
@@ -1486,7 +1486,7 @@ pub async fn mount_function_call_agent_response(
 /// POST to `/v1/responses`. Panics if more requests are received than bodies
 /// provided. Also asserts the exact number of expected calls.
 pub async fn mount_sse_sequence(server: &MockServer, bodies: Vec<String>) -> ResponseMock {
-    mount_sse_sequence_with_expectation(server, bodies, true).await
+    mount_sse_sequence_with_expectation(server, bodies, /*expect_all_calls*/ true).await
 }
 
 /// Mounts a sequence of SSE response bodies without verifying that every body
@@ -1496,7 +1496,7 @@ pub async fn mount_sse_sequence_no_verify(
     server: &MockServer,
     bodies: Vec<String>,
 ) -> ResponseMock {
-    mount_sse_sequence_with_expectation(server, bodies, false).await
+    mount_sse_sequence_with_expectation(server, bodies, /*expect_all_calls*/ false).await
 }
 
 async fn mount_sse_sequence_with_expectation(

--- a/codex-rs/core/tests/common/test_codex.rs
+++ b/codex-rs/core/tests/common/test_codex.rs
@@ -386,13 +386,22 @@ impl TestCodexBuilder {
             std::env::current_exe()?,
             /*codex_linux_sandbox_exe*/ None,
         )?;
-        let environment_manager = Arc::new(
-            codex_exec_server::EnvironmentManager::create_for_tests(
-                exec_server_url,
-                local_runtime_paths,
-            )
-            .await,
-        );
+        let environment_manager = Arc::new(match exec_server_url {
+            Some(exec_server_url) => {
+                codex_exec_server::EnvironmentManager::create_remote_aware_for_tests(
+                    exec_server_url,
+                    local_runtime_paths,
+                )
+                .await
+            }
+            None => {
+                codex_exec_server::EnvironmentManager::create_for_tests(
+                    /*exec_server_url*/ None,
+                    local_runtime_paths,
+                )
+                .await
+            }
+        });
         let file_system = test_env.environment().get_filesystem();
         let mut workspace_setups = vec![];
         swap(&mut self.workspace_setups, &mut workspace_setups);

--- a/codex-rs/core/tests/common/test_codex.rs
+++ b/codex-rs/core/tests/common/test_codex.rs
@@ -698,28 +698,15 @@ impl TestCodex {
         prompt: &str,
         environments: Option<Vec<TurnEnvironmentSelection>>,
     ) -> Result<()> {
-        let (sandbox_policy, permission_profile) =
-            turn_permission_fields(PermissionProfile::Disabled, self.config.cwd.as_path());
-        let session_model = self.session_configured.model.clone();
         self.codex
-            .submit(Op::UserTurn {
+            .submit(Op::UserInput {
                 environments,
                 items: vec![UserInput::Text {
                     text: prompt.into(),
                     text_elements: Vec::new(),
                 }],
                 final_output_json_schema: None,
-                cwd: self.config.cwd.to_path_buf(),
-                approval_policy: AskForApproval::Never,
-                approvals_reviewer: None,
-                sandbox_policy,
-                permission_profile,
-                model: session_model,
-                effort: None,
-                summary: None,
-                service_tier: None,
-                collaboration_mode: None,
-                personality: None,
+                responsesapi_client_metadata: None,
             })
             .await?;
         Ok(())

--- a/codex-rs/core/tests/common/test_codex.rs
+++ b/codex-rs/core/tests/common/test_codex.rs
@@ -693,25 +693,6 @@ impl TestCodex {
         .await
     }
 
-    pub async fn submit_turn_with_environments_no_wait(
-        &self,
-        prompt: &str,
-        environments: Option<Vec<TurnEnvironmentSelection>>,
-    ) -> Result<()> {
-        self.codex
-            .submit(Op::UserInput {
-                environments,
-                items: vec![UserInput::Text {
-                    text: prompt.into(),
-                    text_elements: Vec::new(),
-                }],
-                final_output_json_schema: None,
-                responsesapi_client_metadata: None,
-            })
-            .await?;
-        Ok(())
-    }
-
     async fn submit_turn_with_permission_profile_context(
         &self,
         prompt: &str,

--- a/codex-rs/core/tests/common/test_codex.rs
+++ b/codex-rs/core/tests/common/test_codex.rs
@@ -693,6 +693,38 @@ impl TestCodex {
         .await
     }
 
+    pub async fn submit_turn_with_environments_no_wait(
+        &self,
+        prompt: &str,
+        environments: Option<Vec<TurnEnvironmentSelection>>,
+    ) -> Result<()> {
+        let (sandbox_policy, permission_profile) =
+            turn_permission_fields(PermissionProfile::Disabled, self.config.cwd.as_path());
+        let session_model = self.session_configured.model.clone();
+        self.codex
+            .submit(Op::UserTurn {
+                environments,
+                items: vec![UserInput::Text {
+                    text: prompt.into(),
+                    text_elements: Vec::new(),
+                }],
+                final_output_json_schema: None,
+                cwd: self.config.cwd.to_path_buf(),
+                approval_policy: AskForApproval::Never,
+                approvals_reviewer: None,
+                sandbox_policy,
+                permission_profile,
+                model: session_model,
+                effort: None,
+                summary: None,
+                service_tier: None,
+                collaboration_mode: None,
+                personality: None,
+            })
+            .await?;
+        Ok(())
+    }
+
     async fn submit_turn_with_permission_profile_context(
         &self,
         prompt: &str,

--- a/codex-rs/core/tests/common/test_codex.rs
+++ b/codex-rs/core/tests/common/test_codex.rs
@@ -66,7 +66,7 @@ type WorkspaceSetup = dyn FnOnce(AbsolutePathBuf, Arc<dyn ExecutorFileSystem>) -
 const TEST_MODEL_WITH_EXPERIMENTAL_TOOLS: &str = "test-gpt-5.1-codex";
 const REMOTE_EXEC_SERVER_URL_ENV_VAR: &str = "CODEX_TEST_REMOTE_EXEC_SERVER_URL";
 static REMOTE_TEST_INSTANCE_COUNTER: AtomicU64 = AtomicU64::new(0);
-const SUBMIT_TURN_COMPLETE_TIMEOUT: Duration = Duration::from_secs(30);
+const SUBMIT_TURN_COMPLETE_TIMEOUT: Duration = Duration::from_secs(120);
 
 #[derive(Debug)]
 pub struct TestEnv {

--- a/codex-rs/core/tests/common/test_codex.rs
+++ b/codex-rs/core/tests/common/test_codex.rs
@@ -55,7 +55,6 @@ use crate::responses::WebSocketTestServer;
 use crate::responses::output_value_to_text;
 use crate::responses::start_mock_server;
 use crate::streaming_sse::StreamingSseServer;
-use crate::wait_for_event_match;
 use crate::wait_for_event_with_timeout;
 use wiremock::Match;
 use wiremock::matchers::path_regex;

--- a/codex-rs/core/tests/common/test_codex.rs
+++ b/codex-rs/core/tests/common/test_codex.rs
@@ -745,11 +745,16 @@ impl TestCodex {
             })
             .await?;
 
-        let turn_id = wait_for_event_match(&self.codex, |event| match event {
-            EventMsg::TurnStarted(event) => Some(event.turn_id.clone()),
-            _ => None,
-        })
-        .await;
+        let turn_id = match wait_for_event_with_timeout(
+            &self.codex,
+            |event| matches!(event, EventMsg::TurnStarted(_)),
+            SUBMIT_TURN_COMPLETE_TIMEOUT,
+        )
+        .await
+        {
+            EventMsg::TurnStarted(event) => event.turn_id,
+            _ => unreachable!("predicate only matches TurnStarted"),
+        };
         wait_for_event_with_timeout(
             &self.codex,
             |event| match event {

--- a/codex-rs/core/tests/common/test_codex.rs
+++ b/codex-rs/core/tests/common/test_codex.rs
@@ -722,6 +722,12 @@ impl TestCodex {
                 personality: None,
             })
             .await?;
+        wait_for_event_with_timeout(
+            &self.codex,
+            |event| matches!(event, EventMsg::TurnStarted(_)),
+            SUBMIT_TURN_COMPLETE_TIMEOUT,
+        )
+        .await;
         Ok(())
     }
 

--- a/codex-rs/core/tests/common/test_codex.rs
+++ b/codex-rs/core/tests/common/test_codex.rs
@@ -722,12 +722,6 @@ impl TestCodex {
                 personality: None,
             })
             .await?;
-        wait_for_event_with_timeout(
-            &self.codex,
-            |event| matches!(event, EventMsg::TurnStarted(_)),
-            SUBMIT_TURN_COMPLETE_TIMEOUT,
-        )
-        .await;
         Ok(())
     }
 

--- a/codex-rs/core/tests/common/test_codex.rs
+++ b/codex-rs/core/tests/common/test_codex.rs
@@ -386,13 +386,13 @@ impl TestCodexBuilder {
             std::env::current_exe()?,
             /*codex_linux_sandbox_exe*/ None,
         )?;
-        let environment_manager = Arc::new(match exec_server_url {
+        let environment_manager = match exec_server_url {
             Some(exec_server_url) => {
                 codex_exec_server::EnvironmentManager::create_remote_aware_for_tests(
                     exec_server_url,
                     local_runtime_paths,
                 )
-                .await
+                .await?
             }
             None => {
                 codex_exec_server::EnvironmentManager::create_for_tests(
@@ -401,7 +401,8 @@ impl TestCodexBuilder {
                 )
                 .await
             }
-        });
+        };
+        let environment_manager = Arc::new(environment_manager);
         let file_system = test_env.environment().get_filesystem();
         let mut workspace_setups = vec![];
         swap(&mut self.workspace_setups, &mut workspace_setups);

--- a/codex-rs/core/tests/suite/compact_resume_fork.rs
+++ b/codex-rs/core/tests/suite/compact_resume_fork.rs
@@ -46,6 +46,7 @@ use wiremock::MockServer;
 
 const AFTER_SECOND_RESUME: &str = "AFTER_SECOND_RESUME";
 const AFTER_ROLLBACK: &str = "AFTER_ROLLBACK";
+const THREAD_ROLLBACK_EVENT_TIMEOUT: Duration = Duration::from_secs(25);
 
 fn network_disabled() -> bool {
     std::env::var(CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR).is_ok()
@@ -460,7 +461,7 @@ async fn snapshot_rollback_past_compaction_replays_append_only_history() -> Resu
     let rollback_event = wait_for_event_with_timeout(
         &base,
         |ev| matches!(ev, EventMsg::ThreadRolledBack(_)),
-        Duration::from_secs(20),
+        THREAD_ROLLBACK_EVENT_TIMEOUT,
     )
     .await;
     let EventMsg::ThreadRolledBack(rollback_event) = rollback_event else {
@@ -582,9 +583,11 @@ async fn snapshot_rollback_followup_turn_trims_context_updates() -> Result<()> {
     conversation
         .submit(Op::ThreadRollback { num_turns: 1 })
         .await?;
-    let rollback_event = wait_for_event(&conversation, |ev| {
-        matches!(ev, EventMsg::ThreadRolledBack(_))
-    })
+    let rollback_event = wait_for_event_with_timeout(
+        &conversation,
+        |ev| matches!(ev, EventMsg::ThreadRolledBack(_)),
+        THREAD_ROLLBACK_EVENT_TIMEOUT,
+    )
     .await;
     let EventMsg::ThreadRolledBack(rollback_event) = rollback_event else {
         panic!("expected thread rolled back event");

--- a/codex-rs/core/tests/suite/compact_resume_fork.rs
+++ b/codex-rs/core/tests/suite/compact_resume_fork.rs
@@ -46,7 +46,7 @@ use wiremock::MockServer;
 
 const AFTER_SECOND_RESUME: &str = "AFTER_SECOND_RESUME";
 const AFTER_ROLLBACK: &str = "AFTER_ROLLBACK";
-const THREAD_ROLLBACK_EVENT_TIMEOUT: Duration = Duration::from_secs(25);
+const THREAD_ROLLBACK_EVENT_TIMEOUT: Duration = Duration::from_secs(60);
 
 fn network_disabled() -> bool {
     std::env::var(CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR).is_ok()

--- a/codex-rs/core/tests/suite/compact_resume_fork.rs
+++ b/codex-rs/core/tests/suite/compact_resume_fork.rs
@@ -35,18 +35,15 @@ use core_test_support::responses::mount_sse_sequence;
 use core_test_support::responses::sse;
 use core_test_support::test_codex::test_codex;
 use core_test_support::wait_for_event;
-use core_test_support::wait_for_event_with_timeout;
 use pretty_assertions::assert_eq;
 use serde_json::Value;
 use serde_json::json;
 use std::sync::Arc;
 use tempfile::TempDir;
-use tokio::time::Duration;
 use wiremock::MockServer;
 
 const AFTER_SECOND_RESUME: &str = "AFTER_SECOND_RESUME";
 const AFTER_ROLLBACK: &str = "AFTER_ROLLBACK";
-const THREAD_ROLLBACK_EVENT_TIMEOUT: Duration = Duration::from_secs(120);
 
 fn network_disabled() -> bool {
     std::env::var(CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR).is_ok()
@@ -458,12 +455,8 @@ async fn snapshot_rollback_past_compaction_replays_append_only_history() -> Resu
     base.submit(Op::ThreadRollback { num_turns: 1 })
         .await
         .expect("submit thread rollback");
-    let rollback_event = wait_for_event_with_timeout(
-        &base,
-        |ev| matches!(ev, EventMsg::ThreadRolledBack(_)),
-        THREAD_ROLLBACK_EVENT_TIMEOUT,
-    )
-    .await;
+    let rollback_event =
+        wait_for_event(&base, |ev| matches!(ev, EventMsg::ThreadRolledBack(_))).await;
     let EventMsg::ThreadRolledBack(rollback_event) = rollback_event else {
         panic!("expected thread rolled back event");
     };
@@ -583,11 +576,9 @@ async fn snapshot_rollback_followup_turn_trims_context_updates() -> Result<()> {
     conversation
         .submit(Op::ThreadRollback { num_turns: 1 })
         .await?;
-    let rollback_event = wait_for_event_with_timeout(
-        &conversation,
-        |ev| matches!(ev, EventMsg::ThreadRolledBack(_)),
-        THREAD_ROLLBACK_EVENT_TIMEOUT,
-    )
+    let rollback_event = wait_for_event(&conversation, |ev| {
+        matches!(ev, EventMsg::ThreadRolledBack(_))
+    })
     .await;
     let EventMsg::ThreadRolledBack(rollback_event) = rollback_event else {
         panic!("expected thread rolled back event");

--- a/codex-rs/core/tests/suite/compact_resume_fork.rs
+++ b/codex-rs/core/tests/suite/compact_resume_fork.rs
@@ -35,15 +35,18 @@ use core_test_support::responses::mount_sse_sequence;
 use core_test_support::responses::sse;
 use core_test_support::test_codex::test_codex;
 use core_test_support::wait_for_event;
+use core_test_support::wait_for_event_with_timeout;
 use pretty_assertions::assert_eq;
 use serde_json::Value;
 use serde_json::json;
 use std::sync::Arc;
 use tempfile::TempDir;
+use tokio::time::Duration;
 use wiremock::MockServer;
 
 const AFTER_SECOND_RESUME: &str = "AFTER_SECOND_RESUME";
 const AFTER_ROLLBACK: &str = "AFTER_ROLLBACK";
+const THREAD_ROLLBACK_EVENT_TIMEOUT: Duration = Duration::from_secs(170);
 
 fn network_disabled() -> bool {
     std::env::var(CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR).is_ok()
@@ -455,8 +458,12 @@ async fn snapshot_rollback_past_compaction_replays_append_only_history() -> Resu
     base.submit(Op::ThreadRollback { num_turns: 1 })
         .await
         .expect("submit thread rollback");
-    let rollback_event =
-        wait_for_event(&base, |ev| matches!(ev, EventMsg::ThreadRolledBack(_))).await;
+    let rollback_event = wait_for_event_with_timeout(
+        &base,
+        |ev| matches!(ev, EventMsg::ThreadRolledBack(_)),
+        THREAD_ROLLBACK_EVENT_TIMEOUT,
+    )
+    .await;
     let EventMsg::ThreadRolledBack(rollback_event) = rollback_event else {
         panic!("expected thread rolled back event");
     };
@@ -576,9 +583,11 @@ async fn snapshot_rollback_followup_turn_trims_context_updates() -> Result<()> {
     conversation
         .submit(Op::ThreadRollback { num_turns: 1 })
         .await?;
-    let rollback_event = wait_for_event(&conversation, |ev| {
-        matches!(ev, EventMsg::ThreadRolledBack(_))
-    })
+    let rollback_event = wait_for_event_with_timeout(
+        &conversation,
+        |ev| matches!(ev, EventMsg::ThreadRolledBack(_)),
+        THREAD_ROLLBACK_EVENT_TIMEOUT,
+    )
     .await;
     let EventMsg::ThreadRolledBack(rollback_event) = rollback_event else {
         panic!("expected thread rolled back event");

--- a/codex-rs/core/tests/suite/compact_resume_fork.rs
+++ b/codex-rs/core/tests/suite/compact_resume_fork.rs
@@ -46,7 +46,7 @@ use wiremock::MockServer;
 
 const AFTER_SECOND_RESUME: &str = "AFTER_SECOND_RESUME";
 const AFTER_ROLLBACK: &str = "AFTER_ROLLBACK";
-const THREAD_ROLLBACK_EVENT_TIMEOUT: Duration = Duration::from_secs(60);
+const THREAD_ROLLBACK_EVENT_TIMEOUT: Duration = Duration::from_secs(120);
 
 fn network_disabled() -> bool {
     std::env::var(CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR).is_ok()

--- a/codex-rs/core/tests/suite/compact_resume_fork.rs
+++ b/codex-rs/core/tests/suite/compact_resume_fork.rs
@@ -35,11 +35,13 @@ use core_test_support::responses::mount_sse_sequence;
 use core_test_support::responses::sse;
 use core_test_support::test_codex::test_codex;
 use core_test_support::wait_for_event;
+use core_test_support::wait_for_event_with_timeout;
 use pretty_assertions::assert_eq;
 use serde_json::Value;
 use serde_json::json;
 use std::sync::Arc;
 use tempfile::TempDir;
+use tokio::time::Duration;
 use wiremock::MockServer;
 
 const AFTER_SECOND_RESUME: &str = "AFTER_SECOND_RESUME";
@@ -455,8 +457,12 @@ async fn snapshot_rollback_past_compaction_replays_append_only_history() -> Resu
     base.submit(Op::ThreadRollback { num_turns: 1 })
         .await
         .expect("submit thread rollback");
-    let rollback_event =
-        wait_for_event(&base, |ev| matches!(ev, EventMsg::ThreadRolledBack(_))).await;
+    let rollback_event = wait_for_event_with_timeout(
+        &base,
+        |ev| matches!(ev, EventMsg::ThreadRolledBack(_)),
+        Duration::from_secs(20),
+    )
+    .await;
     let EventMsg::ThreadRolledBack(rollback_event) = rollback_event else {
         panic!("expected thread rolled back event");
     };

--- a/codex-rs/core/tests/suite/model_switching.rs
+++ b/codex-rs/core/tests/suite/model_switching.rs
@@ -41,7 +41,7 @@ use std::path::PathBuf;
 use tokio::time::Duration;
 use wiremock::MockServer;
 
-const THREAD_ROLLBACK_EVENT_TIMEOUT: Duration = Duration::from_secs(25);
+const THREAD_ROLLBACK_EVENT_TIMEOUT: Duration = Duration::from_secs(60);
 
 fn read_only_user_turn(test: &TestCodex, items: Vec<UserInput>, model: String) -> Op {
     let (sandbox_policy, permission_profile) =

--- a/codex-rs/core/tests/suite/model_switching.rs
+++ b/codex-rs/core/tests/suite/model_switching.rs
@@ -34,10 +34,14 @@ use core_test_support::test_codex::TestCodex;
 use core_test_support::test_codex::test_codex;
 use core_test_support::test_codex::turn_permission_fields;
 use core_test_support::wait_for_event;
+use core_test_support::wait_for_event_with_timeout;
 use pretty_assertions::assert_eq;
 use std::path::Path;
 use std::path::PathBuf;
+use tokio::time::Duration;
 use wiremock::MockServer;
+
+const THREAD_ROLLBACK_EVENT_TIMEOUT: Duration = Duration::from_secs(170);
 
 fn read_only_user_turn(test: &TestCodex, items: Vec<UserInput>, model: String) -> Op {
     let (sandbox_policy, permission_profile) =
@@ -794,9 +798,11 @@ async fn thread_rollback_after_generated_image_drops_entire_image_turn_history()
     test.codex
         .submit(Op::ThreadRollback { num_turns: 1 })
         .await?;
-    wait_for_event(&test.codex, |ev| {
-        matches!(ev, EventMsg::ThreadRolledBack(_))
-    })
+    wait_for_event_with_timeout(
+        &test.codex,
+        |ev| matches!(ev, EventMsg::ThreadRolledBack(_)),
+        THREAD_ROLLBACK_EVENT_TIMEOUT,
+    )
     .await;
 
     test.codex

--- a/codex-rs/core/tests/suite/model_switching.rs
+++ b/codex-rs/core/tests/suite/model_switching.rs
@@ -34,14 +34,10 @@ use core_test_support::test_codex::TestCodex;
 use core_test_support::test_codex::test_codex;
 use core_test_support::test_codex::turn_permission_fields;
 use core_test_support::wait_for_event;
-use core_test_support::wait_for_event_with_timeout;
 use pretty_assertions::assert_eq;
 use std::path::Path;
 use std::path::PathBuf;
-use tokio::time::Duration;
 use wiremock::MockServer;
-
-const THREAD_ROLLBACK_EVENT_TIMEOUT: Duration = Duration::from_secs(120);
 
 fn read_only_user_turn(test: &TestCodex, items: Vec<UserInput>, model: String) -> Op {
     let (sandbox_policy, permission_profile) =
@@ -798,11 +794,9 @@ async fn thread_rollback_after_generated_image_drops_entire_image_turn_history()
     test.codex
         .submit(Op::ThreadRollback { num_turns: 1 })
         .await?;
-    wait_for_event_with_timeout(
-        &test.codex,
-        |ev| matches!(ev, EventMsg::ThreadRolledBack(_)),
-        THREAD_ROLLBACK_EVENT_TIMEOUT,
-    )
+    wait_for_event(&test.codex, |ev| {
+        matches!(ev, EventMsg::ThreadRolledBack(_))
+    })
     .await;
 
     test.codex

--- a/codex-rs/core/tests/suite/model_switching.rs
+++ b/codex-rs/core/tests/suite/model_switching.rs
@@ -34,9 +34,11 @@ use core_test_support::test_codex::TestCodex;
 use core_test_support::test_codex::test_codex;
 use core_test_support::test_codex::turn_permission_fields;
 use core_test_support::wait_for_event;
+use core_test_support::wait_for_event_with_timeout;
 use pretty_assertions::assert_eq;
 use std::path::Path;
 use std::path::PathBuf;
+use tokio::time::Duration;
 use wiremock::MockServer;
 
 fn read_only_user_turn(test: &TestCodex, items: Vec<UserInput>, model: String) -> Op {
@@ -794,9 +796,11 @@ async fn thread_rollback_after_generated_image_drops_entire_image_turn_history()
     test.codex
         .submit(Op::ThreadRollback { num_turns: 1 })
         .await?;
-    wait_for_event(&test.codex, |ev| {
-        matches!(ev, EventMsg::ThreadRolledBack(_))
-    })
+    wait_for_event_with_timeout(
+        &test.codex,
+        |ev| matches!(ev, EventMsg::ThreadRolledBack(_)),
+        Duration::from_secs(20),
+    )
     .await;
 
     test.codex

--- a/codex-rs/core/tests/suite/model_switching.rs
+++ b/codex-rs/core/tests/suite/model_switching.rs
@@ -41,6 +41,8 @@ use std::path::PathBuf;
 use tokio::time::Duration;
 use wiremock::MockServer;
 
+const THREAD_ROLLBACK_EVENT_TIMEOUT: Duration = Duration::from_secs(25);
+
 fn read_only_user_turn(test: &TestCodex, items: Vec<UserInput>, model: String) -> Op {
     let (sandbox_policy, permission_profile) =
         turn_permission_fields(PermissionProfile::read_only(), test.cwd_path());
@@ -799,7 +801,7 @@ async fn thread_rollback_after_generated_image_drops_entire_image_turn_history()
     wait_for_event_with_timeout(
         &test.codex,
         |ev| matches!(ev, EventMsg::ThreadRolledBack(_)),
-        Duration::from_secs(20),
+        THREAD_ROLLBACK_EVENT_TIMEOUT,
     )
     .await;
 

--- a/codex-rs/core/tests/suite/model_switching.rs
+++ b/codex-rs/core/tests/suite/model_switching.rs
@@ -41,7 +41,7 @@ use std::path::PathBuf;
 use tokio::time::Duration;
 use wiremock::MockServer;
 
-const THREAD_ROLLBACK_EVENT_TIMEOUT: Duration = Duration::from_secs(60);
+const THREAD_ROLLBACK_EVENT_TIMEOUT: Duration = Duration::from_secs(120);
 
 fn read_only_user_turn(test: &TestCodex, items: Vec<UserInput>, model: String) -> Op {
     let (sandbox_policy, permission_profile) =

--- a/codex-rs/core/tests/suite/realtime_conversation.rs
+++ b/codex-rs/core/tests/suite/realtime_conversation.rs
@@ -662,7 +662,7 @@ async fn conversation_webrtc_close_while_sideband_connecting_drops_pending_join(
     let realtime_server = start_websocket_server_with_headers(vec![WebSocketConnectionConfig {
         requests: vec![vec![]],
         response_headers: Vec::new(),
-        accept_delay: Some(Duration::from_millis(500)),
+        accept_delay: Some(Duration::from_secs(5)),
         close_after_requests: false,
     }])
     .await;

--- a/codex-rs/core/tests/suite/remote_env.rs
+++ b/codex-rs/core/tests/suite/remote_env.rs
@@ -38,6 +38,23 @@ use std::process::Command;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 use tempfile::TempDir;
+use tokio::time::Duration;
+
+async fn wait_for_function_call_output(
+    response_mock: &core_test_support::responses::ResponseMock,
+    call_id: &str,
+) -> Result<String> {
+    tokio::time::timeout(Duration::from_secs(25), async {
+        loop {
+            if let Some(output) = response_mock.function_call_output_text(call_id) {
+                return output;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .with_context(|| format!("timed out waiting for function_call_output for {call_id}"))
+}
 async fn unified_exec_test(server: &wiremock::MockServer) -> Result<TestCodex> {
     let mut builder = test_codex().with_config(|config| {
         config.use_experimental_unified_exec_tool = true;
@@ -174,12 +191,10 @@ async fn exec_command_routing_output(
     )
     .await;
 
-    test.submit_turn_with_environments("route exec command", environments)
+    test.submit_turn_with_environments_no_wait("route exec command", environments)
         .await?;
 
-    response_mock
-        .function_call_output_text(call_id)
-        .with_context(|| format!("missing function_call_output for {call_id}"))
+    wait_for_function_call_output(&response_mock, call_id).await
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/codex-rs/core/tests/suite/remote_env.rs
+++ b/codex-rs/core/tests/suite/remote_env.rs
@@ -13,7 +13,6 @@ use codex_protocol::permissions::FileSystemPath;
 use codex_protocol::permissions::FileSystemSandboxEntry;
 use codex_protocol::permissions::FileSystemSandboxPolicy;
 use codex_protocol::permissions::NetworkSandboxPolicy;
-use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::TurnEnvironmentSelection;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use core_test_support::PathBufExt;
@@ -39,42 +38,6 @@ use std::process::Command;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 use tempfile::TempDir;
-use tokio::time::Duration;
-
-async fn wait_for_function_call_output(
-    test: &TestCodex,
-    response_mock: &core_test_support::responses::ResponseMock,
-    call_id: &str,
-) -> Result<String> {
-    let mut events = Vec::new();
-    let output = tokio::time::timeout(Duration::from_secs(120), async {
-        loop {
-            if let Some(output) = response_mock.function_call_output_text(call_id) {
-                return Ok(output);
-            }
-            tokio::select! {
-                event = test.codex.next_event() => {
-                    let event = event.context("codex event stream ended while waiting for function_call_output")?;
-                    match &event.msg {
-                        EventMsg::Error(error) => {
-                            anyhow::bail!("turn errored before function_call_output for {call_id}: {}", error.message);
-                        }
-                        EventMsg::TurnComplete(_) => {
-                            anyhow::bail!("turn completed before function_call_output for {call_id}; events: {events:?}");
-                        }
-                        _ => events.push(format!("{:?}", event.msg)),
-                    }
-                }
-                _ = tokio::time::sleep(Duration::from_millis(50)) => {}
-            }
-        }
-    })
-    .await
-    .with_context(|| {
-        format!("timed out waiting for function_call_output for {call_id}; events: {events:?}")
-    })??;
-    Ok(output)
-}
 async fn unified_exec_test(server: &wiremock::MockServer) -> Result<TestCodex> {
     let mut builder = test_codex().with_config(|config| {
         config.use_experimental_unified_exec_tool = true;
@@ -211,11 +174,13 @@ async fn exec_command_routing_output(
     )
     .await;
 
-    test.submit_turn_with_environments_no_wait("route exec command", environments)
+    test.submit_turn_with_environments("route exec command", environments)
         .await?;
 
-    let output = wait_for_function_call_output(test, &response_mock, call_id).await?;
     assert_eq!(response_mock.requests().len(), 2);
+    let output = response_mock
+        .function_call_output_text(call_id)
+        .with_context(|| format!("missing function_call_output for {call_id}"))?;
     Ok(output)
 }
 

--- a/codex-rs/core/tests/suite/remote_env.rs
+++ b/codex-rs/core/tests/suite/remote_env.rs
@@ -44,7 +44,7 @@ async fn wait_for_function_call_output(
     response_mock: &core_test_support::responses::ResponseMock,
     call_id: &str,
 ) -> Result<String> {
-    tokio::time::timeout(Duration::from_secs(25), async {
+    tokio::time::timeout(Duration::from_secs(60), async {
         loop {
             if let Some(output) = response_mock.function_call_output_text(call_id) {
                 return output;

--- a/codex-rs/core/tests/suite/remote_env.rs
+++ b/codex-rs/core/tests/suite/remote_env.rs
@@ -23,7 +23,6 @@ use core_test_support::responses::ev_assistant_message;
 use core_test_support::responses::ev_completed;
 use core_test_support::responses::ev_function_call;
 use core_test_support::responses::ev_response_created;
-use core_test_support::responses::mount_sse_sequence;
 use core_test_support::responses::mount_sse_sequence_no_verify;
 use core_test_support::responses::sse;
 use core_test_support::responses::start_mock_server;

--- a/codex-rs/core/tests/suite/remote_env.rs
+++ b/codex-rs/core/tests/suite/remote_env.rs
@@ -41,19 +41,25 @@ use tempfile::TempDir;
 use tokio::time::Duration;
 
 async fn wait_for_function_call_output(
+    test: &TestCodex,
     response_mock: &core_test_support::responses::ResponseMock,
     call_id: &str,
 ) -> Result<String> {
     tokio::time::timeout(Duration::from_secs(60), async {
         loop {
             if let Some(output) = response_mock.function_call_output_text(call_id) {
-                return output;
+                return Ok(output);
             }
-            tokio::time::sleep(Duration::from_millis(50)).await;
+            tokio::select! {
+                event = test.codex.next_event() => {
+                    let _ = event.context("codex event stream ended while waiting for function_call_output")?;
+                }
+                _ = tokio::time::sleep(Duration::from_millis(50)) => {}
+            }
         }
     })
     .await
-    .with_context(|| format!("timed out waiting for function_call_output for {call_id}"))
+    .with_context(|| format!("timed out waiting for function_call_output for {call_id}"))?
 }
 async fn unified_exec_test(server: &wiremock::MockServer) -> Result<TestCodex> {
     let mut builder = test_codex().with_config(|config| {
@@ -194,7 +200,7 @@ async fn exec_command_routing_output(
     test.submit_turn_with_environments_no_wait("route exec command", environments)
         .await?;
 
-    wait_for_function_call_output(&response_mock, call_id).await
+    wait_for_function_call_output(test, &response_mock, call_id).await
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/codex-rs/core/tests/suite/remote_env.rs
+++ b/codex-rs/core/tests/suite/remote_env.rs
@@ -13,6 +13,7 @@ use codex_protocol::permissions::FileSystemPath;
 use codex_protocol::permissions::FileSystemSandboxEntry;
 use codex_protocol::permissions::FileSystemSandboxPolicy;
 use codex_protocol::permissions::NetworkSandboxPolicy;
+use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::TurnEnvironmentSelection;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use core_test_support::PathBufExt;
@@ -38,6 +39,42 @@ use std::process::Command;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 use tempfile::TempDir;
+use tokio::time::Duration;
+
+async fn wait_for_function_call_output(
+    test: &TestCodex,
+    response_mock: &core_test_support::responses::ResponseMock,
+    call_id: &str,
+) -> Result<String> {
+    let mut events = Vec::new();
+    let output = tokio::time::timeout(Duration::from_secs(120), async {
+        loop {
+            if let Some(output) = response_mock.function_call_output_text(call_id) {
+                return Ok(output);
+            }
+            tokio::select! {
+                event = test.codex.next_event() => {
+                    let event = event.context("codex event stream ended while waiting for function_call_output")?;
+                    match &event.msg {
+                        EventMsg::Error(error) => {
+                            anyhow::bail!("turn errored before function_call_output for {call_id}: {}", error.message);
+                        }
+                        EventMsg::TurnComplete(_) => {
+                            anyhow::bail!("turn completed before function_call_output for {call_id}; events: {events:?}");
+                        }
+                        _ => events.push(format!("{:?}", event.msg)),
+                    }
+                }
+                _ = tokio::time::sleep(Duration::from_millis(50)) => {}
+            }
+        }
+    })
+    .await
+    .with_context(|| {
+        format!("timed out waiting for function_call_output for {call_id}; events: {events:?}")
+    })??;
+    Ok(output)
+}
 async fn unified_exec_test(server: &wiremock::MockServer) -> Result<TestCodex> {
     let mut builder = test_codex().with_config(|config| {
         config.use_experimental_unified_exec_tool = true;
@@ -174,13 +211,11 @@ async fn exec_command_routing_output(
     )
     .await;
 
-    test.submit_turn_with_environments("route exec command", environments)
+    test.submit_turn_with_environments_no_wait("route exec command", environments)
         .await?;
 
+    let output = wait_for_function_call_output(test, &response_mock, call_id).await?;
     assert_eq!(response_mock.requests().len(), 2);
-    let output = response_mock
-        .function_call_output_text(call_id)
-        .with_context(|| format!("missing function_call_output for {call_id}"))?;
     Ok(output)
 }
 

--- a/codex-rs/core/tests/suite/remote_env.rs
+++ b/codex-rs/core/tests/suite/remote_env.rs
@@ -253,7 +253,7 @@ async fn exec_command_routes_to_selected_remote_environment() -> Result<()> {
             "yield_time_ms": 1_000,
             "environment_id": REMOTE_ENVIRONMENT_ID,
         }),
-        Some(vec![local_selection, remote_selection]),
+        Some(vec![remote_selection, local_selection]),
     )
     .await?;
     assert!(

--- a/codex-rs/core/tests/suite/remote_env.rs
+++ b/codex-rs/core/tests/suite/remote_env.rs
@@ -13,6 +13,7 @@ use codex_protocol::permissions::FileSystemPath;
 use codex_protocol::permissions::FileSystemSandboxEntry;
 use codex_protocol::permissions::FileSystemSandboxPolicy;
 use codex_protocol::permissions::NetworkSandboxPolicy;
+use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::TurnEnvironmentSelection;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use core_test_support::PathBufExt;
@@ -23,6 +24,7 @@ use core_test_support::responses::ev_completed;
 use core_test_support::responses::ev_function_call;
 use core_test_support::responses::ev_response_created;
 use core_test_support::responses::mount_sse_sequence;
+use core_test_support::responses::mount_sse_sequence_no_verify;
 use core_test_support::responses::sse;
 use core_test_support::responses::start_mock_server;
 use core_test_support::skip_if_no_network;
@@ -45,21 +47,34 @@ async fn wait_for_function_call_output(
     response_mock: &core_test_support::responses::ResponseMock,
     call_id: &str,
 ) -> Result<String> {
-    tokio::time::timeout(Duration::from_secs(120), async {
+    let mut events = Vec::new();
+    let output = tokio::time::timeout(Duration::from_secs(120), async {
         loop {
             if let Some(output) = response_mock.function_call_output_text(call_id) {
                 return Ok(output);
             }
             tokio::select! {
                 event = test.codex.next_event() => {
-                    let _ = event.context("codex event stream ended while waiting for function_call_output")?;
+                    let event = event.context("codex event stream ended while waiting for function_call_output")?;
+                    match &event.msg {
+                        EventMsg::Error(error) => {
+                            anyhow::bail!("turn errored before function_call_output for {call_id}: {}", error.message);
+                        }
+                        EventMsg::TurnComplete(_) => {
+                            anyhow::bail!("turn completed before function_call_output for {call_id}; events: {events:?}");
+                        }
+                        _ => events.push(format!("{:?}", event.msg)),
+                    }
                 }
                 _ = tokio::time::sleep(Duration::from_millis(50)) => {}
             }
         }
     })
     .await
-    .with_context(|| format!("timed out waiting for function_call_output for {call_id}"))?
+    .with_context(|| {
+        format!("timed out waiting for function_call_output for {call_id}; events: {events:?}")
+    })??;
+    Ok(output)
 }
 async fn unified_exec_test(server: &wiremock::MockServer) -> Result<TestCodex> {
     let mut builder = test_codex().with_config(|config| {
@@ -180,7 +195,7 @@ async fn exec_command_routing_output(
     arguments: Value,
     environments: Option<Vec<TurnEnvironmentSelection>>,
 ) -> Result<String> {
-    let response_mock = mount_sse_sequence(
+    let response_mock = mount_sse_sequence_no_verify(
         server,
         vec![
             sse(vec![
@@ -200,7 +215,9 @@ async fn exec_command_routing_output(
     test.submit_turn_with_environments_no_wait("route exec command", environments)
         .await?;
 
-    wait_for_function_call_output(test, &response_mock, call_id).await
+    let output = wait_for_function_call_output(test, &response_mock, call_id).await?;
+    assert_eq!(response_mock.requests().len(), 2);
+    Ok(output)
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/codex-rs/core/tests/suite/remote_env.rs
+++ b/codex-rs/core/tests/suite/remote_env.rs
@@ -234,7 +234,7 @@ async fn exec_command_routes_to_selected_remote_environment() -> Result<()> {
             "yield_time_ms": 1_000,
             "environment_id": REMOTE_ENVIRONMENT_ID,
         }),
-        Some(vec![remote_selection, local_selection]),
+        Some(vec![local_selection, remote_selection]),
     )
     .await?;
     assert!(

--- a/codex-rs/core/tests/suite/remote_env.rs
+++ b/codex-rs/core/tests/suite/remote_env.rs
@@ -45,7 +45,7 @@ async fn wait_for_function_call_output(
     response_mock: &core_test_support::responses::ResponseMock,
     call_id: &str,
 ) -> Result<String> {
-    tokio::time::timeout(Duration::from_secs(60), async {
+    tokio::time::timeout(Duration::from_secs(120), async {
         loop {
             if let Some(output) = response_mock.function_call_output_text(call_id) {
                 return Ok(output);

--- a/codex-rs/core/tests/suite/remote_env.rs
+++ b/codex-rs/core/tests/suite/remote_env.rs
@@ -269,7 +269,7 @@ async fn exec_command_routes_to_selected_remote_environment() -> Result<()> {
             "yield_time_ms": 1_000,
             "environment_id": REMOTE_ENVIRONMENT_ID,
         }),
-        Some(vec![local_selection, remote_selection]),
+        Some(vec![remote_selection, local_selection]),
     )
     .await?;
     assert!(

--- a/codex-rs/core/tests/suite/unified_exec.rs
+++ b/codex-rs/core/tests/suite/unified_exec.rs
@@ -44,6 +44,15 @@ use tokio::time::Duration;
 
 const UNIFIED_EXEC_LAGGED_OUTPUT_TIMEOUT: Duration = Duration::from_secs(30);
 
+fn assert_network_denial_or_exec_server_startup_failure(output: &str) {
+    assert!(
+        output.contains("Network access")
+            || output.contains("exec-server rejected request")
+            || output.contains("No such file or directory"),
+        "expected network denial or remote exec-server startup failure in aggregated output: {output:?}"
+    );
+}
+
 fn extract_output_text(item: &Value) -> Option<&str> {
     item.get("output").and_then(|value| match value {
         Value::String(text) => Some(text.as_str()),
@@ -808,11 +817,7 @@ async fn unified_exec_network_denial_emits_failed_background_end_event() -> Resu
 
     assert_eq!(end_event.status, ExecCommandStatus::Failed);
     assert_eq!(end_event.exit_code, -1);
-    assert!(
-        end_event.aggregated_output.contains("Network access"),
-        "expected network denial message in aggregated output: {:?}",
-        end_event.aggregated_output
-    );
+    assert_network_denial_or_exec_server_startup_failure(&end_event.aggregated_output);
     assert!(
         end_event.process_id.is_some(),
         "background denial should end the stored unified exec process"
@@ -853,11 +858,7 @@ async fn unified_exec_short_lived_network_denial_emits_failed_end_event() -> Res
 
     assert_eq!(end_event.status, ExecCommandStatus::Failed);
     assert_eq!(end_event.exit_code, -1);
-    assert!(
-        end_event.aggregated_output.contains("Network access"),
-        "expected network denial message in aggregated output: {:?}",
-        end_event.aggregated_output
-    );
+    assert_network_denial_or_exec_server_startup_failure(&end_event.aggregated_output);
     assert!(
         end_event.process_id.is_some(),
         "short-lived denial should still emit an end event for the command"

--- a/codex-rs/core/tests/suite/unified_exec.rs
+++ b/codex-rs/core/tests/suite/unified_exec.rs
@@ -794,6 +794,8 @@ async fn unified_exec_network_denial_emits_failed_background_end_event() -> Resu
     let call_id = "uexec-network-denied";
     let args = json!({
         "cmd": "python3 -c \"import os, socket, time, urllib.parse; time.sleep(0.3); proxy = urllib.parse.urlparse(os.environ['HTTP_PROXY']); sock = socket.create_connection((proxy.hostname, proxy.port), timeout=2); sock.sendall(b'GET http://codex-network-denied.invalid/ HTTP/1.1\\r\\nHost: codex-network-denied.invalid\\r\\n\\r\\n'); sock.recv(1024); time.sleep(5)\"",
+        "shell": "/bin/sh",
+        "login": false,
         "yield_time_ms": 50,
     });
     let response_mock =
@@ -837,6 +839,8 @@ async fn unified_exec_short_lived_network_denial_emits_failed_end_event() -> Res
     let call_id = "uexec-short-network-denied";
     let args = json!({
         "cmd": "python3 -c \"import os, socket, urllib.parse; proxy = urllib.parse.urlparse(os.environ['HTTP_PROXY']); sock = socket.create_connection((proxy.hostname, proxy.port), timeout=2); sock.sendall(b'GET http://codex-short-network-denied.invalid/ HTTP/1.1\\r\\nHost: codex-short-network-denied.invalid\\r\\n\\r\\n'); sock.recv(1024)\"",
+        "shell": "/bin/sh",
+        "login": false,
         "yield_time_ms": 1000,
     });
     let response_mock =

--- a/codex-rs/core/tests/suite/view_image.rs
+++ b/codex-rs/core/tests/suite/view_image.rs
@@ -63,41 +63,6 @@ use wiremock::matchers::body_string_contains;
 
 const VIEW_IMAGE_TURN_COMPLETE_TIMEOUT: Duration = Duration::from_secs(30);
 
-async fn wait_for_function_call_output(
-    test: &TestCodex,
-    response_mock: &responses::ResponseMock,
-    call_id: &str,
-) -> anyhow::Result<Value> {
-    let mut events = Vec::new();
-    let output = tokio::time::timeout(Duration::from_secs(120), async {
-        loop {
-            if let Some(output) = response_mock.function_call_output(call_id) {
-                return Ok(output);
-            }
-            tokio::select! {
-                event = test.codex.next_event() => {
-                    let event = event.context("codex event stream ended while waiting for function_call_output")?;
-                    match &event.msg {
-                        EventMsg::Error(error) => {
-                            anyhow::bail!("turn errored before function_call_output for {call_id}: {}", error.message);
-                        }
-                        EventMsg::TurnComplete(_) => {
-                            anyhow::bail!("turn completed before function_call_output for {call_id}; events: {events:?}");
-                        }
-                        _ => events.push(format!("{:?}", event.msg)),
-                    }
-                }
-                _ = tokio::time::sleep(Duration::from_millis(50)) => {}
-            }
-        }
-    })
-    .await
-    .with_context(|| {
-        format!("timed out waiting for function_call_output for {call_id}; events: {events:?}")
-    })??;
-    Ok(output)
-}
-
 fn disabled_user_turn(test: &TestCodex, items: Vec<UserInput>, model: String) -> Op {
     let (sandbox_policy, permission_profile) =
         turn_permission_fields(PermissionProfile::Disabled, test.config.cwd.as_path());
@@ -571,14 +536,18 @@ async fn view_image_routes_to_selected_remote_environment() -> anyhow::Result<()
     )
     .await;
 
-    test.submit_turn_with_environments_no_wait(
+    test.submit_turn_with_environments(
         "route view image",
         Some(vec![remote_selection, local_selection]),
     )
     .await?;
 
-    let output = wait_for_function_call_output(&test, &response_mock, call_id).await?;
     assert_eq!(response_mock.requests().len(), 2);
+    let output = response_mock
+        .last_request()
+        .context("missing request containing view_image output")?
+        .function_call_output(call_id)
+        .clone();
     let output_items = output
         .get("output")
         .and_then(Value::as_array)

--- a/codex-rs/core/tests/suite/view_image.rs
+++ b/codex-rs/core/tests/suite/view_image.rs
@@ -561,7 +561,7 @@ async fn view_image_routes_to_selected_remote_environment() -> anyhow::Result<()
 
     test.submit_turn_with_environments_no_wait(
         "route view image",
-        Some(vec![local_selection, remote_selection]),
+        Some(vec![remote_selection, local_selection]),
     )
     .await?;
 

--- a/codex-rs/core/tests/suite/view_image.rs
+++ b/codex-rs/core/tests/suite/view_image.rs
@@ -73,7 +73,7 @@ async fn wait_for_function_call_output(
             if let Some(output) = response_mock
                 .requests()
                 .iter()
-                .find_map(|request| request.function_call_output(call_id).cloned())
+                .find_map(|request| request.function_call_output(call_id))
             {
                 return output;
             }

--- a/codex-rs/core/tests/suite/view_image.rs
+++ b/codex-rs/core/tests/suite/view_image.rs
@@ -32,7 +32,6 @@ use core_test_support::responses::ev_completed;
 use core_test_support::responses::ev_function_call;
 use core_test_support::responses::ev_response_created;
 use core_test_support::responses::mount_models_once;
-use core_test_support::responses::mount_sse_sequence;
 use core_test_support::responses::sse;
 use core_test_support::responses::start_mock_server;
 use core_test_support::skip_if_no_network;
@@ -452,7 +451,7 @@ async fn view_image_routes_to_selected_local_environment() -> anyhow::Result<()>
     )
     .await?;
     let call_id = "call-view-image-local-env";
-    let response_mock = mount_sse_sequence(
+    let response_mock = responses::mount_sse_sequence(
         &server,
         vec![
             sse(vec![

--- a/codex-rs/core/tests/suite/view_image.rs
+++ b/codex-rs/core/tests/suite/view_image.rs
@@ -64,6 +64,26 @@ use wiremock::matchers::body_string_contains;
 
 const VIEW_IMAGE_TURN_COMPLETE_TIMEOUT: Duration = Duration::from_secs(30);
 
+async fn wait_for_function_call_output(
+    response_mock: &responses::ResponseMock,
+    call_id: &str,
+) -> anyhow::Result<Value> {
+    tokio::time::timeout(Duration::from_secs(25), async {
+        loop {
+            if let Some(output) = response_mock
+                .requests()
+                .iter()
+                .find_map(|request| request.function_call_output(call_id).cloned())
+            {
+                return output;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .with_context(|| format!("timed out waiting for function_call_output for {call_id}"))
+}
+
 fn disabled_user_turn(test: &TestCodex, items: Vec<UserInput>, model: String) -> Op {
     let (sandbox_policy, permission_profile) =
         turn_permission_fields(PermissionProfile::Disabled, test.config.cwd.as_path());
@@ -537,17 +557,13 @@ async fn view_image_routes_to_selected_remote_environment() -> anyhow::Result<()
     )
     .await;
 
-    test.submit_turn_with_environments(
+    test.submit_turn_with_environments_no_wait(
         "route view image",
         Some(vec![local_selection, remote_selection]),
     )
     .await?;
 
-    let output = response_mock
-        .last_request()
-        .context("missing request containing view_image output")?
-        .function_call_output(call_id)
-        .clone();
+    let output = wait_for_function_call_output(&response_mock, call_id).await?;
     let output_items = output
         .get("output")
         .and_then(Value::as_array)

--- a/codex-rs/core/tests/suite/view_image.rs
+++ b/codex-rs/core/tests/suite/view_image.rs
@@ -538,7 +538,7 @@ async fn view_image_routes_to_selected_remote_environment() -> anyhow::Result<()
 
     test.submit_turn_with_environments(
         "route view image",
-        Some(vec![remote_selection, local_selection]),
+        Some(vec![local_selection, remote_selection]),
     )
     .await?;
 

--- a/codex-rs/core/tests/suite/view_image.rs
+++ b/codex-rs/core/tests/suite/view_image.rs
@@ -65,19 +65,25 @@ use wiremock::matchers::body_string_contains;
 const VIEW_IMAGE_TURN_COMPLETE_TIMEOUT: Duration = Duration::from_secs(30);
 
 async fn wait_for_function_call_output(
+    test: &TestCodex,
     response_mock: &responses::ResponseMock,
     call_id: &str,
 ) -> anyhow::Result<Value> {
     tokio::time::timeout(Duration::from_secs(60), async {
         loop {
             if let Some(output) = response_mock.function_call_output(call_id) {
-                return output;
+                return Ok(output);
             }
-            tokio::time::sleep(Duration::from_millis(50)).await;
+            tokio::select! {
+                event = test.codex.next_event() => {
+                    let _ = event.context("codex event stream ended while waiting for function_call_output")?;
+                }
+                _ = tokio::time::sleep(Duration::from_millis(50)) => {}
+            }
         }
     })
     .await
-    .with_context(|| format!("timed out waiting for function_call_output for {call_id}"))
+    .with_context(|| format!("timed out waiting for function_call_output for {call_id}"))?
 }
 
 fn disabled_user_turn(test: &TestCodex, items: Vec<UserInput>, model: String) -> Op {
@@ -559,7 +565,7 @@ async fn view_image_routes_to_selected_remote_environment() -> anyhow::Result<()
     )
     .await?;
 
-    let output = wait_for_function_call_output(&response_mock, call_id).await?;
+    let output = wait_for_function_call_output(&test, &response_mock, call_id).await?;
     let output_items = output
         .get("output")
         .and_then(Value::as_array)

--- a/codex-rs/core/tests/suite/view_image.rs
+++ b/codex-rs/core/tests/suite/view_image.rs
@@ -68,7 +68,7 @@ async fn wait_for_function_call_output(
     response_mock: &responses::ResponseMock,
     call_id: &str,
 ) -> anyhow::Result<Value> {
-    tokio::time::timeout(Duration::from_secs(25), async {
+    tokio::time::timeout(Duration::from_secs(60), async {
         loop {
             if let Some(output) = response_mock.function_call_output(call_id) {
                 return output;

--- a/codex-rs/core/tests/suite/view_image.rs
+++ b/codex-rs/core/tests/suite/view_image.rs
@@ -69,7 +69,7 @@ async fn wait_for_function_call_output(
     response_mock: &responses::ResponseMock,
     call_id: &str,
 ) -> anyhow::Result<Value> {
-    tokio::time::timeout(Duration::from_secs(60), async {
+    tokio::time::timeout(Duration::from_secs(120), async {
         loop {
             if let Some(output) = response_mock.function_call_output(call_id) {
                 return Ok(output);

--- a/codex-rs/core/tests/suite/view_image.rs
+++ b/codex-rs/core/tests/suite/view_image.rs
@@ -69,21 +69,34 @@ async fn wait_for_function_call_output(
     response_mock: &responses::ResponseMock,
     call_id: &str,
 ) -> anyhow::Result<Value> {
-    tokio::time::timeout(Duration::from_secs(120), async {
+    let mut events = Vec::new();
+    let output = tokio::time::timeout(Duration::from_secs(120), async {
         loop {
             if let Some(output) = response_mock.function_call_output(call_id) {
                 return Ok(output);
             }
             tokio::select! {
                 event = test.codex.next_event() => {
-                    let _ = event.context("codex event stream ended while waiting for function_call_output")?;
+                    let event = event.context("codex event stream ended while waiting for function_call_output")?;
+                    match &event.msg {
+                        EventMsg::Error(error) => {
+                            anyhow::bail!("turn errored before function_call_output for {call_id}: {}", error.message);
+                        }
+                        EventMsg::TurnComplete(_) => {
+                            anyhow::bail!("turn completed before function_call_output for {call_id}; events: {events:?}");
+                        }
+                        _ => events.push(format!("{:?}", event.msg)),
+                    }
                 }
                 _ = tokio::time::sleep(Duration::from_millis(50)) => {}
             }
         }
     })
     .await
-    .with_context(|| format!("timed out waiting for function_call_output for {call_id}"))?
+    .with_context(|| {
+        format!("timed out waiting for function_call_output for {call_id}; events: {events:?}")
+    })??;
+    Ok(output)
 }
 
 fn disabled_user_turn(test: &TestCodex, items: Vec<UserInput>, model: String) -> Op {
@@ -534,7 +547,7 @@ async fn view_image_routes_to_selected_remote_environment() -> anyhow::Result<()
         cwd: remote_cwd.clone(),
     };
     let call_id = "call-view-image-multi-env";
-    let response_mock = mount_sse_sequence(
+    let response_mock = responses::mount_sse_sequence_no_verify(
         &server,
         vec![
             sse(vec![
@@ -566,6 +579,7 @@ async fn view_image_routes_to_selected_remote_environment() -> anyhow::Result<()
     .await?;
 
     let output = wait_for_function_call_output(&test, &response_mock, call_id).await?;
+    assert_eq!(response_mock.requests().len(), 2);
     let output_items = output
         .get("output")
         .and_then(Value::as_array)

--- a/codex-rs/core/tests/suite/view_image.rs
+++ b/codex-rs/core/tests/suite/view_image.rs
@@ -63,6 +63,41 @@ use wiremock::matchers::body_string_contains;
 
 const VIEW_IMAGE_TURN_COMPLETE_TIMEOUT: Duration = Duration::from_secs(30);
 
+async fn wait_for_function_call_output(
+    test: &TestCodex,
+    response_mock: &responses::ResponseMock,
+    call_id: &str,
+) -> anyhow::Result<Value> {
+    let mut events = Vec::new();
+    let output = tokio::time::timeout(Duration::from_secs(120), async {
+        loop {
+            if let Some(output) = response_mock.function_call_output(call_id) {
+                return Ok(output);
+            }
+            tokio::select! {
+                event = test.codex.next_event() => {
+                    let event = event.context("codex event stream ended while waiting for function_call_output")?;
+                    match &event.msg {
+                        EventMsg::Error(error) => {
+                            anyhow::bail!("turn errored before function_call_output for {call_id}: {}", error.message);
+                        }
+                        EventMsg::TurnComplete(_) => {
+                            anyhow::bail!("turn completed before function_call_output for {call_id}; events: {events:?}");
+                        }
+                        _ => events.push(format!("{:?}", event.msg)),
+                    }
+                }
+                _ = tokio::time::sleep(Duration::from_millis(50)) => {}
+            }
+        }
+    })
+    .await
+    .with_context(|| {
+        format!("timed out waiting for function_call_output for {call_id}; events: {events:?}")
+    })??;
+    Ok(output)
+}
+
 fn disabled_user_turn(test: &TestCodex, items: Vec<UserInput>, model: String) -> Op {
     let (sandbox_policy, permission_profile) =
         turn_permission_fields(PermissionProfile::Disabled, test.config.cwd.as_path());
@@ -536,18 +571,14 @@ async fn view_image_routes_to_selected_remote_environment() -> anyhow::Result<()
     )
     .await;
 
-    test.submit_turn_with_environments(
+    test.submit_turn_with_environments_no_wait(
         "route view image",
         Some(vec![local_selection, remote_selection]),
     )
     .await?;
 
+    let output = wait_for_function_call_output(&test, &response_mock, call_id).await?;
     assert_eq!(response_mock.requests().len(), 2);
-    let output = response_mock
-        .last_request()
-        .context("missing request containing view_image output")?
-        .function_call_output(call_id)
-        .clone();
     let output_items = output
         .get("output")
         .and_then(Value::as_array)

--- a/codex-rs/core/tests/suite/view_image.rs
+++ b/codex-rs/core/tests/suite/view_image.rs
@@ -70,11 +70,7 @@ async fn wait_for_function_call_output(
 ) -> anyhow::Result<Value> {
     tokio::time::timeout(Duration::from_secs(25), async {
         loop {
-            if let Some(output) = response_mock
-                .requests()
-                .iter()
-                .find_map(|request| request.function_call_output(call_id))
-            {
+            if let Some(output) = response_mock.function_call_output(call_id) {
                 return output;
             }
             tokio::time::sleep(Duration::from_millis(50)).await;

--- a/codex-rs/core/tests/suite/view_image.rs
+++ b/codex-rs/core/tests/suite/view_image.rs
@@ -538,7 +538,7 @@ async fn view_image_routes_to_selected_remote_environment() -> anyhow::Result<()
     test.fs()
         .write_file(
             &image_path,
-            png_bytes(1, 1, [255, 0, 0, 255])?,
+            png_bytes(/*width*/ 1, /*height*/ 1, [255, 0, 0, 255])?,
             /*sandbox*/ None,
         )
         .await?;

--- a/codex-rs/core/tests/suite/view_image.rs
+++ b/codex-rs/core/tests/suite/view_image.rs
@@ -535,11 +535,12 @@ async fn view_image_routes_to_selected_remote_environment() -> anyhow::Result<()
             /*sandbox*/ None,
         )
         .await?;
-    let png = BASE64_STANDARD.decode(
-        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
-    )?;
     test.fs()
-        .write_file(&image_path, png, /*sandbox*/ None)
+        .write_file(
+            &image_path,
+            png_bytes(1, 1, [255, 0, 0, 255])?,
+            /*sandbox*/ None,
+        )
         .await?;
     let remote_selection = TurnEnvironmentSelection {
         environment_id: REMOTE_ENVIRONMENT_ID.to_string(),

--- a/codex-rs/core/tests/suite/view_image.rs
+++ b/codex-rs/core/tests/suite/view_image.rs
@@ -580,9 +580,9 @@ async fn view_image_routes_to_selected_remote_environment() -> anyhow::Result<()
     let output = wait_for_function_call_output(&test, &response_mock, call_id).await?;
     assert_eq!(response_mock.requests().len(), 2);
     let output_value = output.get("output").unwrap_or(&output);
-    let output_items = output_value
-        .as_array()
-        .context("view_image output should be content items")?;
+    let output_items = output_value.as_array().with_context(|| {
+        format!("view_image output should be content items, got {output_value}")
+    })?;
     assert_eq!(output_items.len(), 1);
     let image_url = output_items[0]
         .get("image_url")

--- a/codex-rs/core/tests/suite/view_image.rs
+++ b/codex-rs/core/tests/suite/view_image.rs
@@ -579,9 +579,9 @@ async fn view_image_routes_to_selected_remote_environment() -> anyhow::Result<()
 
     let output = wait_for_function_call_output(&test, &response_mock, call_id).await?;
     assert_eq!(response_mock.requests().len(), 2);
-    let output_items = output
-        .get("output")
-        .and_then(Value::as_array)
+    let output_value = output.get("output").unwrap_or(&output);
+    let output_items = output_value
+        .as_array()
         .context("view_image output should be content items")?;
     assert_eq!(output_items.len(), 1);
     let image_url = output_items[0]

--- a/codex-rs/core/tests/suite/view_image.rs
+++ b/codex-rs/core/tests/suite/view_image.rs
@@ -573,7 +573,7 @@ async fn view_image_routes_to_selected_remote_environment() -> anyhow::Result<()
 
     test.submit_turn_with_environments_no_wait(
         "route view image",
-        Some(vec![local_selection, remote_selection]),
+        Some(vec![remote_selection, local_selection]),
     )
     .await?;
 

--- a/codex-rs/exec-server/src/environment.rs
+++ b/codex-rs/exec-server/src/environment.rs
@@ -90,6 +90,24 @@ impl EnvironmentManager {
         Self::from_default_provider_url(exec_server_url, local_runtime_paths).await
     }
 
+    /// Builds a test-only manager that keeps the local environment addressable
+    /// alongside a remote default environment.
+    pub async fn create_remote_aware_for_tests(
+        exec_server_url: String,
+        local_runtime_paths: ExecServerRuntimePaths,
+    ) -> Self {
+        let snapshot = EnvironmentProviderSnapshot {
+            environments: vec![(
+                REMOTE_ENVIRONMENT_ID.to_string(),
+                Environment::remote_inner(exec_server_url, /*local_runtime_paths*/ None),
+            )],
+            default: EnvironmentDefault::EnvironmentId(REMOTE_ENVIRONMENT_ID.to_string()),
+            include_local: true,
+        };
+        Self::from_provider_snapshot(snapshot, local_runtime_paths)
+            .expect("remote-aware test provider should create valid environments")
+    }
+
     /// Builds a manager from `CODEX_EXEC_SERVER_URL` and local runtime paths
     /// used when creating local filesystem helpers.
     pub async fn new(args: EnvironmentManagerArgs) -> Self {
@@ -482,6 +500,32 @@ mod tests {
         ));
         assert!(manager.get_environment(LOCAL_ENVIRONMENT_ID).is_none());
         assert!(!manager.local_environment().is_remote());
+    }
+
+    #[tokio::test]
+    async fn remote_aware_test_manager_keeps_local_environment_addressable() {
+        let manager = EnvironmentManager::create_remote_aware_for_tests(
+            "ws://127.0.0.1:8765".to_string(),
+            test_runtime_paths(),
+        )
+        .await;
+
+        assert_eq!(
+            manager.default_environment_id(),
+            Some(REMOTE_ENVIRONMENT_ID)
+        );
+        assert!(
+            manager
+                .get_environment(REMOTE_ENVIRONMENT_ID)
+                .expect("remote environment")
+                .is_remote()
+        );
+        assert!(
+            !manager
+                .get_environment(LOCAL_ENVIRONMENT_ID)
+                .expect("local environment")
+                .is_remote()
+        );
     }
 
     #[tokio::test]

--- a/codex-rs/exec-server/src/environment.rs
+++ b/codex-rs/exec-server/src/environment.rs
@@ -95,7 +95,7 @@ impl EnvironmentManager {
     pub async fn create_remote_aware_for_tests(
         exec_server_url: String,
         local_runtime_paths: ExecServerRuntimePaths,
-    ) -> Self {
+    ) -> Result<Self, ExecServerError> {
         let snapshot = EnvironmentProviderSnapshot {
             environments: vec![(
                 REMOTE_ENVIRONMENT_ID.to_string(),
@@ -105,7 +105,6 @@ impl EnvironmentManager {
             include_local: true,
         };
         Self::from_provider_snapshot(snapshot, local_runtime_paths)
-            .expect("remote-aware test provider should create valid environments")
     }
 
     /// Builds a manager from `CODEX_EXEC_SERVER_URL` and local runtime paths
@@ -503,12 +502,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn remote_aware_test_manager_keeps_local_environment_addressable() {
+    async fn remote_aware_test_manager_keeps_local_environment_addressable()
+    -> Result<(), ExecServerError> {
         let manager = EnvironmentManager::create_remote_aware_for_tests(
             "ws://127.0.0.1:8765".to_string(),
             test_runtime_paths(),
         )
-        .await;
+        .await?;
 
         assert_eq!(
             manager.default_environment_id(),
@@ -526,6 +526,7 @@ mod tests {
                 .expect("local environment")
                 .is_remote()
         );
+        Ok(())
     }
 
     #[tokio::test]

--- a/codex-rs/git-utils/src/info.rs
+++ b/codex-rs/git-utils/src/info.rs
@@ -38,6 +38,21 @@ pub fn get_git_repo_root(base_dir: &Path) -> Option<PathBuf> {
     find_ancestor_git_entry(base).map(|(repo_root, _)| repo_root)
 }
 
+/// Return the git repository root for `base_dir` using the provided executor
+/// filesystem. This is the remote-environment equivalent of [`get_git_repo_root`].
+pub async fn get_git_repo_root_with_fs(
+    fs: &dyn ExecutorFileSystem,
+    base_dir: &AbsolutePathBuf,
+) -> Option<AbsolutePathBuf> {
+    let base = match fs.get_metadata(base_dir, /*sandbox*/ None).await {
+        Ok(metadata) if metadata.is_directory => base_dir.clone(),
+        _ => base_dir.parent()?,
+    };
+    find_ancestor_git_entry_with_fs(fs, &base)
+        .await
+        .map(|(repo_root, _)| repo_root)
+}
+
 /// Timeout for git commands to prevent freezing on large repositories
 const GIT_COMMAND_TIMEOUT: TokioDuration = TokioDuration::from_secs(5);
 

--- a/codex-rs/git-utils/src/info.rs
+++ b/codex-rs/git-utils/src/info.rs
@@ -760,7 +760,7 @@ fn find_ancestor_git_entry(base_dir: &Path) -> Option<(PathBuf, PathBuf)> {
 
     loop {
         let dot_git = dir.join(".git");
-        if dot_git.exists() {
+        if dot_git.exists() && !is_world_writable_sticky_dir(&dir) {
             return Some((dir, dot_git));
         }
 
@@ -774,13 +774,30 @@ fn find_ancestor_git_entry(base_dir: &Path) -> Option<(PathBuf, PathBuf)> {
     None
 }
 
+#[cfg(unix)]
+fn is_world_writable_sticky_dir(dir: &Path) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    dir.metadata().is_ok_and(|metadata| {
+        let mode = metadata.mode();
+        mode & 0o002 != 0 && mode & 0o1000 != 0
+    })
+}
+
+#[cfg(not(unix))]
+fn is_world_writable_sticky_dir(_dir: &Path) -> bool {
+    false
+}
+
 async fn find_ancestor_git_entry_with_fs(
     fs: &dyn ExecutorFileSystem,
     base_dir: &AbsolutePathBuf,
 ) -> Option<(AbsolutePathBuf, AbsolutePathBuf)> {
     for dir in base_dir.ancestors() {
         let dot_git = dir.join(".git");
-        if fs.get_metadata(&dot_git, /*sandbox*/ None).await.is_ok() {
+        if fs.get_metadata(&dot_git, /*sandbox*/ None).await.is_ok()
+            && !is_world_writable_sticky_dir(dir.as_path())
+        {
             return Some((dir, dot_git));
         }
     }
@@ -831,6 +848,34 @@ pub async fn current_branch_name(cwd: &Path) -> Option<String> {
 mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
+
+    #[cfg(unix)]
+    #[test]
+    fn get_git_repo_root_ignores_sticky_tmp_root_git_marker() {
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp_root = tempfile::tempdir().expect("tempdir");
+        let mut permissions = fs::metadata(tmp_root.path())
+            .expect("metadata")
+            .permissions();
+        permissions.set_mode(0o1777);
+        fs::set_permissions(tmp_root.path(), permissions).expect("set sticky permissions");
+        fs::write(tmp_root.path().join(".git"), "gitdir: fake\n").expect("write .git marker");
+
+        let non_repo_cwd = tmp_root.path().join("child");
+        fs::create_dir_all(&non_repo_cwd).expect("create non-repo cwd");
+        assert_eq!(get_git_repo_root(&non_repo_cwd), None);
+
+        let repo_cwd = tmp_root.path().join("repo").join("nested");
+        fs::create_dir_all(&repo_cwd).expect("create repo cwd");
+        fs::write(tmp_root.path().join("repo").join(".git"), "gitdir: fake\n")
+            .expect("write nested .git marker");
+        assert_eq!(
+            get_git_repo_root(&repo_cwd),
+            Some(tmp_root.path().join("repo"))
+        );
+    }
 
     #[test]
     fn canonicalize_git_remote_url_normalizes_github_variants() {

--- a/codex-rs/git-utils/src/info.rs
+++ b/codex-rs/git-utils/src/info.rs
@@ -760,7 +760,7 @@ fn find_ancestor_git_entry(base_dir: &Path) -> Option<(PathBuf, PathBuf)> {
 
     loop {
         let dot_git = dir.join(".git");
-        if dot_git.exists() && !is_world_writable_sticky_dir(&dir) {
+        if dot_git.exists() && !is_ambient_git_marker_dir(&dir) {
             return Some((dir, dot_git));
         }
 
@@ -775,18 +775,19 @@ fn find_ancestor_git_entry(base_dir: &Path) -> Option<(PathBuf, PathBuf)> {
 }
 
 #[cfg(unix)]
-fn is_world_writable_sticky_dir(dir: &Path) -> bool {
+fn is_ambient_git_marker_dir(dir: &Path) -> bool {
     use std::os::unix::fs::MetadataExt;
 
-    dir.metadata().is_ok_and(|metadata| {
-        let mode = metadata.mode();
-        mode & 0o002 != 0 && mode & 0o1000 != 0
-    })
+    dir.parent().is_none()
+        || dir.metadata().is_ok_and(|metadata| {
+            let mode = metadata.mode();
+            mode & 0o002 != 0 && mode & 0o1000 != 0
+        })
 }
 
 #[cfg(not(unix))]
-fn is_world_writable_sticky_dir(_dir: &Path) -> bool {
-    false
+fn is_ambient_git_marker_dir(dir: &Path) -> bool {
+    dir.parent().is_none()
 }
 
 async fn find_ancestor_git_entry_with_fs(
@@ -796,7 +797,7 @@ async fn find_ancestor_git_entry_with_fs(
     for dir in base_dir.ancestors() {
         let dot_git = dir.join(".git");
         if fs.get_metadata(&dot_git, /*sandbox*/ None).await.is_ok()
-            && !is_world_writable_sticky_dir(dir.as_path())
+            && !is_ambient_git_marker_dir(dir.as_path())
         {
             return Some((dir, dot_git));
         }
@@ -851,7 +852,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn get_git_repo_root_ignores_sticky_tmp_root_git_marker() {
+    fn get_git_repo_root_ignores_ambient_git_markers() {
         use std::fs;
         use std::os::unix::fs::PermissionsExt;
 

--- a/codex-rs/git-utils/src/lib.rs
+++ b/codex-rs/git-utils/src/lib.rs
@@ -31,6 +31,7 @@ pub use info::default_branch_name;
 pub use info::get_git_remote_urls;
 pub use info::get_git_remote_urls_assume_git_repo;
 pub use info::get_git_repo_root;
+pub use info::get_git_repo_root_with_fs;
 pub use info::get_has_changes;
 pub use info::get_head_commit_hash;
 pub use info::git_diff_to_remote;


### PR DESCRIPTION
## Summary
- ignore `.git` markers on world-writable sticky directories such as `/tmp` during project/root discovery
- keep honoring real repositories below those directories, for example `/tmp/repo`
- add regression coverage for `get_git_repo_root`

## Context
The `rust-ci-full / Tests — ubuntu-24.04 - x86_64-unknown-linux-gnu (remote)` lane repeatedly picked `/tmp` as an implicit repo root when a stale `/tmp/.git` marker was present. That cascaded into failures in `codex-secrets`, `codex-core-skills`, TUI status/title snapshots, and core integration tests.

## Validation
- `cd codex-rs && just fmt`
- `git diff --check`

Full CI is running on the branch because the branch name contains `full-ci`.