### PR TITLE
Persist /goal commands in history

### DIFF
--- a/codex-rs/tui/src/chatwidget/slash_dispatch.rs
+++ b/codex-rs/tui/src/chatwidget/slash_dispatch.rs
@@ -230,6 +230,7 @@ impl ChatWidget {
                 if let Some(thread_id) = self.thread_id {
                     self.app_event_tx
                         .send(AppEvent::OpenThreadGoalMenu { thread_id });
+                    self.append_message_history_entry("/goal".to_string());
                 } else {
                     self.add_info_message(
                         GOAL_USAGE.to_string(),
@@ -685,6 +686,7 @@ impl ChatWidget {
                                 .send(AppEvent::SetThreadGoalStatus { thread_id, status });
                         }
                     }
+                    self.append_message_history_entry(format!("/goal {trimmed}"));
                     if source == SlashCommandDispatchSource::Live {
                         self.bottom_pane.drain_pending_submission_state();
                     }
@@ -735,6 +737,7 @@ impl ChatWidget {
                     objective: objective.to_string(),
                     mode: ThreadGoalSetMode::ConfirmIfExists,
                 });
+                self.append_message_history_entry(format!("/goal {trimmed}"));
                 if source == SlashCommandDispatchSource::Live {
                     self.bottom_pane.drain_pending_submission_state();
                 }


### PR DESCRIPTION
## Summary

A user reported that `/goal` was not saved to the TUI command history, which made it unavailable for later recall even though other accepted input paths persist history entries.

This updates the TUI goal slash-command dispatch so successful `/goal` invocations append the command text to message history. The change covers the bare `/goal` menu command, goal control commands such as `/goal pause`, and objective-setting commands such as `/goal improve benchmark coverage`.

## Verification

- `cargo test -p codex-tui goal_slash_command -- --nocapture`