### PR TITLE
[codex] Lowercase TUI service tier commands

### DIFF
--- a/codex-rs/tui/src/chatwidget/service_tiers.rs
+++ b/codex-rs/tui/src/chatwidget/service_tiers.rs
@@ -88,7 +88,7 @@ impl ChatWidget {
                             .into_iter()
                             .map(|tier| ServiceTierCommand {
                                 id: tier.id,
-                                name: tier.name,
+                                name: tier.name.to_lowercase(),
                                 description: tier.description,
                             })
                             .collect()

--- a/codex-rs/tui/src/chatwidget/tests/slash_commands.rs
+++ b/codex-rs/tui/src/chatwidget/tests/slash_commands.rs
@@ -66,12 +66,17 @@ fn next_add_to_history_event(rx: &mut tokio::sync::mpsc::UnboundedReceiver<AppEv
 async fn service_tier_commands_lowercase_catalog_names() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual(Some("gpt-5.4")).await;
     let mut preset = get_available_model(&chat, "gpt-5.4");
+    let expected_description = preset.service_tiers[0].description.clone();
     preset.service_tiers[0].name = "Fast".to_string();
     chat.model_catalog = std::sync::Arc::new(ModelCatalog::new(vec![preset]));
 
     assert_eq!(
         chat.current_model_service_tier_commands(),
-        vec![fast_tier_command()]
+        vec![ServiceTierCommand {
+            id: ServiceTier::Fast.request_value().to_string(),
+            name: "fast".to_string(),
+            description: expected_description,
+        }]
     );
 }
 

--- a/codex-rs/tui/src/chatwidget/tests/slash_commands.rs
+++ b/codex-rs/tui/src/chatwidget/tests/slash_commands.rs
@@ -63,6 +63,19 @@ fn next_add_to_history_event(rx: &mut tokio::sync::mpsc::UnboundedReceiver<AppEv
 }
 
 #[tokio::test]
+async fn service_tier_commands_lowercase_catalog_names() {
+    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(Some("gpt-5.4")).await;
+    let mut preset = get_available_model(&chat, "gpt-5.4");
+    preset.service_tiers[0].name = "Fast".to_string();
+    chat.model_catalog = std::sync::Arc::new(ModelCatalog::new(vec![preset]));
+
+    assert_eq!(
+        chat.current_model_service_tier_commands(),
+        vec![fast_tier_command()]
+    );
+}
+
+#[tokio::test]
 async fn slash_compact_eagerly_queues_follow_up_before_turn_start() {
     let (mut chat, mut rx, mut op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
 


### PR DESCRIPTION
## Why

Service-tier slash commands are built from model-catalog metadata. If the catalog returns a name like `Fast`, the TUI currently exposes `/Fast` and exact dispatch expects that casing, which is inconsistent with the lowercase command style used elsewhere.

## What

- Lowercase service-tier command names when converting catalog tiers into `ServiceTierCommand` values.
- Add regression coverage that seeds a catalog tier named `Fast` and expects the generated command to be `fast`.

## Testing

Not run locally per repo instruction; PR CI should run the new `service_tier_commands_lowercase_catalog_names` coverage.