### PR TITLE
fix(tui): preserve Shift+Enter in tmux csi-u panes

### DIFF
--- a/codex-rs/tui/src/tui/keyboard_modes.rs
+++ b/codex-rs/tui/src/tui/keyboard_modes.rs
@@ -125,16 +125,81 @@ pub(super) fn enable_keyboard_enhancement() {
 
     let _ = execute!(
         stdout(),
+        DisableModifyOtherKeys,
         PushKeyboardEnhancementFlags(
             KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
                 | KeyboardEnhancementFlags::REPORT_EVENT_TYPES
                 | KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS
         )
     );
+
+    if tmux_should_enable_modify_other_keys() {
+        let _ = execute!(stdout(), EnableModifyOtherKeys);
+    }
+}
+
+fn running_in_tmux_session() -> bool {
+    tmux_session_detected(
+        std::env::var("TMUX").ok().as_deref(),
+        std::env::var("TMUX_PANE").ok().as_deref(),
+    )
+}
+
+fn tmux_session_detected(tmux: Option<&str>, tmux_pane: Option<&str>) -> bool {
+    tmux.is_some() || tmux_pane.is_some()
+}
+
+fn tmux_should_enable_modify_other_keys() -> bool {
+    tmux_should_enable_modify_other_keys_for(
+        running_in_tmux_session(),
+        read_tmux_extended_keys_format().as_deref(),
+    )
+}
+
+fn tmux_should_enable_modify_other_keys_for(
+    running_in_tmux_session: bool,
+    extended_keys_format: Option<&str>,
+) -> bool {
+    // If tmux cannot be queried, still request mode 2; otherwise csi-u panes
+    // can stay in VT10x. Explicit xterm format is avoided because crossterm
+    // does not parse tmux's xterm-style extended-key sequences as Enter.
+    running_in_tmux_session && matches!(extended_keys_format, Some("csi-u") | None)
+}
+
+fn read_tmux_extended_keys_format() -> Option<String> {
+    for args in [
+        ["display-message", "-p", "#{extended-keys-format}"],
+        ["show-options", "-gqv", "extended-keys-format"],
+    ] {
+        let output = std::process::Command::new("tmux")
+            .args(args)
+            .stdin(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .output()
+            .ok()?;
+
+        if !output.status.success() {
+            continue;
+        }
+
+        if let Some(value) = String::from_utf8(output.stdout)
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+        {
+            return Some(value);
+        }
+    }
+
+    None
 }
 
 pub(super) fn restore_keyboard_enhancement_stack() {
-    let _ = execute!(stdout(), PopKeyboardEnhancementFlags);
+    let _ = execute!(
+        stdout(),
+        PopKeyboardEnhancementFlags,
+        DisableModifyOtherKeys
+    );
 }
 
 pub(super) fn reset_keyboard_reporting_after_exit() {
@@ -169,6 +234,28 @@ impl Command for ResetKeyboardEnhancementFlags {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct EnableModifyOtherKeys;
+
+impl Command for EnableModifyOtherKeys {
+    fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
+        f.write_str("\x1b[>4;2m")
+    }
+
+    #[cfg(windows)]
+    fn execute_winapi(&self) -> std::io::Result<()> {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "modifyOtherKeys enable is not implemented for the legacy Windows API",
+        ))
+    }
+
+    #[cfg(windows)]
+    fn is_ansi_code_supported(&self) -> bool {
+        false
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct DisableModifyOtherKeys;
 
 impl Command for DisableModifyOtherKeys {
@@ -193,9 +280,12 @@ impl Command for DisableModifyOtherKeys {
 #[cfg(test)]
 mod tests {
     use super::DisableModifyOtherKeys;
+    use super::EnableModifyOtherKeys;
     use super::ResetKeyboardEnhancementFlags;
     use super::keyboard_enhancement_disabled_for;
     use super::parse_bool_env;
+    use super::tmux_session_detected;
+    use super::tmux_should_enable_modify_other_keys_for;
     use super::vscode_terminal_detected;
     use crossterm::Command;
     use pretty_assertions::assert_eq;
@@ -269,8 +359,48 @@ mod tests {
     }
 
     #[test]
+    fn tmux_session_detection_accepts_tmux_or_tmux_pane() {
+        assert!(tmux_session_detected(
+            Some("/tmp/tmux-501/default,1,0"),
+            /*tmux_pane*/ None
+        ));
+        assert!(tmux_session_detected(/*tmux*/ None, Some("%0")));
+        assert!(!tmux_session_detected(
+            /*tmux*/ None, /*tmux_pane*/ None
+        ));
+    }
+
+    #[test]
+    fn tmux_modify_other_keys_requests_csi_u_or_unknown_format() {
+        assert!(tmux_should_enable_modify_other_keys_for(
+            /*running_in_tmux_session*/ true,
+            Some("csi-u")
+        ));
+        assert!(tmux_should_enable_modify_other_keys_for(
+            /*running_in_tmux_session*/ true, /*extended_keys_format*/ None
+        ));
+        assert!(!tmux_should_enable_modify_other_keys_for(
+            /*running_in_tmux_session*/ true,
+            Some("xterm")
+        ));
+        assert!(!tmux_should_enable_modify_other_keys_for(
+            /*running_in_tmux_session*/ true,
+            Some("")
+        ));
+        assert!(!tmux_should_enable_modify_other_keys_for(
+            /*running_in_tmux_session*/ false,
+            Some("csi-u")
+        ));
+    }
+
+    #[test]
     fn reset_keyboard_enhancement_flags_clears_all_pushed_levels() {
         assert_eq!(ansi_for(ResetKeyboardEnhancementFlags), "\x1b[<u");
+    }
+
+    #[test]
+    fn enable_modify_other_keys_requests_xterm_keyboard_reporting() {
+        assert_eq!(ansi_for(EnableModifyOtherKeys), "\x1b[>4;2m");
     }
 
     #[test]


### PR DESCRIPTION
## Why

Inside tmux, `Shift+Enter` can still reach Codex as a plain `Enter` even when tmux has extended keys enabled. In `csi-u` tmux panes, Codex needs to request `modifyOtherKeys` mode 2 so tmux moves the pane from `VT10x` into extended-key mode and preserves the Shift modifier. Without that extra request, composer `Shift+Enter` submits the draft instead of inserting a newline.

Fixes #21699.

## What Changed

- Detect tmux sessions and read the active `extended-keys-format`, preferring the pane-local value before falling back to the global option.
- Request `modifyOtherKeys` mode 2 for tmux panes using `csi-u` extended keys, and reset it when restoring keyboard reporting.
- Add unit coverage for tmux detection, the format gate, and the emitted `modifyOtherKeys` escape sequence.

## How to Test

1. In tmux, configure:
   ```tmux
   set-option -g extended-keys on
   set-option -g extended-keys-format csi-u
   ```
2. Start Codex in a fresh tmux pane from this branch.
3. From another pane, confirm the Codex pane reports `mode=Ext 2`:
   ```bash
   tmux list-panes -a -F '#{session_name}:#{window_index}.#{pane_index} mode=#{pane_key_mode} cmd=#{pane_current_command}'
   ```
4. Type a draft in the composer and press `Shift+Enter`; confirm it inserts a newline instead of submitting.
5. Also confirm plain `Enter` still submits as before.

Targeted tests:
- `cargo test -p codex-tui`

## Notes

- Manual verification used both real `Shift+Enter` in iTerm2/tmux and `tmux send-keys ... S-Enter` to confirm the tmux pane changes from `VT10x` to `Ext 2` and preserves newline behavior.
- On this checkout, the broader `codex-tui` test run currently reaches unrelated existing failures in `status::tests::*` plus a later stack overflow in `tests::fork_last_filters_latest_session_by_cwd_unless_show_all`.
