### PR TITLE
Store fast service tier in config

### DIFF
--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -73,6 +73,7 @@ use codex_otel::current_span_w3c_trace_context;
 use codex_protocol::SessionId;
 use codex_protocol::ThreadId;
 use codex_protocol::config_types::ReasoningSummary as ReasoningSummaryConfig;
+use codex_protocol::config_types::ServiceTier;
 use codex_protocol::config_types::Verbosity as VerbosityConfig;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::openai_models::ModelInfo;
@@ -740,8 +741,9 @@ impl ModelClient {
             prompt.output_schema_strict,
         );
         let prompt_cache_key = Some(self.state.thread_id.to_string());
-        let service_tier =
-            service_tier.filter(|service_tier| model_info.supports_service_tier(service_tier));
+        let service_tier = service_tier
+            .map(|service_tier| ServiceTier::request_value_for(&service_tier).to_string())
+            .filter(|service_tier| model_info.supports_service_tier(service_tier));
         let request = ResponsesApiRequest {
             model: model_info.slug.clone(),
             instructions: instructions.clone(),

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -742,7 +742,12 @@ impl ModelClient {
         );
         let prompt_cache_key = Some(self.state.thread_id.to_string());
         let service_tier = service_tier
-            .map(|service_tier| ServiceTier::request_value_for(&service_tier).to_string())
+            .map(|configured_service_tier| {
+                match ServiceTier::from_request_value(&configured_service_tier) {
+                    Some(service_tier) => service_tier.request_value().to_string(),
+                    None => configured_service_tier,
+                }
+            })
             .filter(|service_tier| model_info.supports_service_tier(service_tier));
         let request = ResponsesApiRequest {
             model: model_info.slug.clone(),

--- a/codex-rs/core/src/config/edit.rs
+++ b/codex-rs/core/src/config/edit.rs
@@ -536,9 +536,13 @@ impl ConfigDocument {
             }),
             ConfigEdit::SetServiceTier { service_tier } => Ok(self.write_profile_value(
                 &["service_tier"],
-                service_tier
-                    .as_ref()
-                    .map(|service_tier| value(ServiceTier::config_value_for(service_tier))),
+                service_tier.as_ref().map(|service_tier| {
+                    let config_value = match ServiceTier::from_request_value(service_tier) {
+                        Some(service_tier) => service_tier.config_value(),
+                        None => service_tier,
+                    };
+                    value(config_value)
+                }),
             )),
             ConfigEdit::SetModelPersonality { personality } => Ok(self.write_profile_value(
                 &["personality"],

--- a/codex-rs/core/src/config/edit.rs
+++ b/codex-rs/core/src/config/edit.rs
@@ -7,6 +7,7 @@ use codex_config::types::SessionPickerViewMode;
 use codex_config::types::ToolSuggestDisabledTool;
 use codex_features::FEATURES;
 use codex_protocol::config_types::Personality;
+use codex_protocol::config_types::ServiceTier;
 use codex_protocol::config_types::TrustLevel;
 use codex_protocol::openai_models::ReasoningEffort;
 use std::collections::BTreeMap;
@@ -537,7 +538,7 @@ impl ConfigDocument {
                 &["service_tier"],
                 service_tier
                     .as_ref()
-                    .map(|service_tier| value(service_tier.clone())),
+                    .map(|service_tier| value(ServiceTier::config_value_for(service_tier))),
             )),
             ConfigEdit::SetModelPersonality { personality } => Ok(self.write_profile_value(
                 &["personality"],

--- a/codex-rs/core/src/config/edit_tests.rs
+++ b/codex-rs/core/src/config/edit_tests.rs
@@ -3,6 +3,7 @@ use codex_config::types::AppToolApproval;
 use codex_config::types::McpServerToolConfig;
 use codex_config::types::McpServerTransportConfig;
 use codex_config::types::SessionPickerViewMode;
+use codex_protocol::config_types::ServiceTier;
 use codex_protocol::openai_models::ReasoningEffort;
 use pretty_assertions::assert_eq;
 #[cfg(unix)]
@@ -47,6 +48,38 @@ fn builder_with_edits_applies_custom_paths() {
 
     let contents = std::fs::read_to_string(codex_home.join(CONFIG_TOML_FILE)).expect("read config");
     assert_eq!(contents, "enabled = true\n");
+}
+
+#[test]
+fn blocking_set_service_tier_persists_priority_alias_as_fast() {
+    let tmp = tempdir().expect("tmpdir");
+    let codex_home = tmp.path();
+
+    ConfigEditsBuilder::new(codex_home)
+        .set_service_tier(Some(ServiceTier::Fast.request_value().to_string()))
+        .apply_blocking()
+        .expect("persist");
+
+    let contents = std::fs::read_to_string(codex_home.join(CONFIG_TOML_FILE)).expect("read config");
+    let expected_service_tier = ServiceTier::Fast.config_value();
+    assert_eq!(
+        contents,
+        format!("service_tier = {expected_service_tier:?}\n")
+    );
+}
+
+#[test]
+fn blocking_set_service_tier_preserves_custom_value() {
+    let tmp = tempdir().expect("tmpdir");
+    let codex_home = tmp.path();
+
+    ConfigEditsBuilder::new(codex_home)
+        .set_service_tier(Some("experimental-tier-id".to_string()))
+        .apply_blocking()
+        .expect("persist");
+
+    let contents = std::fs::read_to_string(codex_home.join(CONFIG_TOML_FILE)).expect("read config");
+    assert_eq!(contents, "service_tier = \"experimental-tier-id\"\n");
 }
 
 #[test]

--- a/codex-rs/protocol/src/config_types.rs
+++ b/codex-rs/protocol/src/config_types.rs
@@ -370,20 +370,6 @@ impl ServiceTier {
         }
     }
 
-    pub fn config_value_for(value: &str) -> &str {
-        match Self::from_request_value(value) {
-            Some(service_tier) => service_tier.config_value(),
-            None => value,
-        }
-    }
-
-    pub fn request_value_for(value: &str) -> &str {
-        match Self::from_request_value(value) {
-            Some(service_tier) => service_tier.request_value(),
-            None => value,
-        }
-    }
-
     pub fn from_request_value(value: &str) -> Option<Self> {
         match value {
             "fast" | "priority" => Some(Self::Fast),
@@ -702,10 +688,10 @@ mod tests {
     #[test]
     fn service_tier_aliases_have_distinct_config_and_request_values() {
         let values = ["fast", "priority", "flex", "experimental-tier-id"].map(|value| {
-            (
-                ServiceTier::config_value_for(value),
-                ServiceTier::request_value_for(value),
-            )
+            match ServiceTier::from_request_value(value) {
+                Some(service_tier) => (service_tier.config_value(), service_tier.request_value()),
+                None => (value, value),
+            }
         });
 
         assert_eq!(

--- a/codex-rs/protocol/src/config_types.rs
+++ b/codex-rs/protocol/src/config_types.rs
@@ -356,10 +356,31 @@ pub enum ServiceTier {
 }
 
 impl ServiceTier {
+    pub const fn config_value(self) -> &'static str {
+        match self {
+            Self::Fast => "fast",
+            Self::Flex => "flex",
+        }
+    }
+
     pub const fn request_value(self) -> &'static str {
         match self {
             Self::Fast => "priority",
             Self::Flex => "flex",
+        }
+    }
+
+    pub fn config_value_for(value: &str) -> &str {
+        match Self::from_request_value(value) {
+            Some(service_tier) => service_tier.config_value(),
+            None => value,
+        }
+    }
+
+    pub fn request_value_for(value: &str) -> &str {
+        match Self::from_request_value(value) {
+            Some(service_tier) => service_tier.request_value(),
+            None => value,
         }
     }
 
@@ -676,6 +697,26 @@ mod tests {
             let mode: ModeKind = serde_json::from_str(&json).expect("deserialize mode");
             assert_eq!(ModeKind::Default, mode);
         }
+    }
+
+    #[test]
+    fn service_tier_aliases_have_distinct_config_and_request_values() {
+        let values = ["fast", "priority", "flex", "experimental-tier-id"].map(|value| {
+            (
+                ServiceTier::config_value_for(value),
+                ServiceTier::request_value_for(value),
+            )
+        });
+
+        assert_eq!(
+            values,
+            [
+                ("fast", "priority"),
+                ("fast", "priority"),
+                ("flex", "flex"),
+                ("experimental-tier-id", "experimental-tier-id"),
+            ]
+        );
     }
 
     #[test]

--- a/codex-rs/protocol/src/openai_models.rs
+++ b/codex-rs/protocol/src/openai_models.rs
@@ -489,7 +489,10 @@ impl ModelPreset {
 
 impl ModelInfo {
     pub fn supports_service_tier(&self, service_tier: &str) -> bool {
-        let service_tier = ServiceTier::request_value_for(service_tier);
+        let service_tier = match ServiceTier::from_request_value(service_tier) {
+            Some(service_tier) => service_tier.request_value(),
+            None => service_tier,
+        };
         self.service_tiers
             .iter()
             .any(|tier| tier.id == service_tier)

--- a/codex-rs/protocol/src/openai_models.rs
+++ b/codex-rs/protocol/src/openai_models.rs
@@ -489,6 +489,7 @@ impl ModelPreset {
 
 impl ModelInfo {
     pub fn supports_service_tier(&self, service_tier: &str) -> bool {
+        let service_tier = ServiceTier::request_value_for(service_tier);
         self.service_tiers
             .iter()
             .any(|tier| tier.id == service_tier)


### PR DESCRIPTION
## Summary

The fast service tier has two names depending on where it appears: config should keep the user-facing value `fast`, while requests sent to the API need `priority`. Before this change, the config path reused the request value, so selecting fast mode could persist `service_tier = "priority"` and config loading treated legacy `fast` as the request value too. That made config less readable and mixed storage semantics with request semantics.

This separates the two forms:

- Defines explicit config and request values for known service tiers.
- Persists `fast` for the fast tier even when the UI/catalog supplies `priority`.
- Normalizes both `fast` and `priority` to `priority` immediately before building Responses requests and when checking model tier support.
- Preserves unknown service tier strings unchanged.

## Testing

- Added unit coverage for alias mapping in `codex-rs/protocol/src/config_types.rs`.
- Added config edit tests for persisting `priority` as `fast` and preserving arbitrary tier values.
- Not run locally, per repo instruction.
