### PR TITLE
[codex] Harden curated plugin git sync cwd

### DIFF
--- a/codex-rs/core-plugins/src/startup_sync.rs
+++ b/codex-rs/core-plugins/src/startup_sync.rs
@@ -24,6 +24,8 @@ const OPENAI_PLUGINS_OWNER: &str = "openai";
 const OPENAI_PLUGINS_REPO: &str = "plugins";
 const CURATED_PLUGINS_RELATIVE_DIR: &str = ".tmp/plugins";
 const CURATED_PLUGINS_SHA_FILE: &str = ".tmp/plugins.sha";
+const CURATED_PLUGINS_CLONE_TEMP_DIR_PREFIX: &str = "plugins-clone-";
+const CURATED_PLUGINS_GIT_CWD_TEMP_DIR_PREFIX: &str = "curated-git-cwd-";
 const CURATED_PLUGINS_BACKUP_ARCHIVE_FALLBACK_VERSION: &str = "export-backup";
 const CURATED_PLUGINS_GIT_TIMEOUT: Duration = Duration::from_secs(30);
 const CURATED_PLUGINS_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
@@ -138,8 +140,9 @@ fn sync_openai_plugins_repo_with_transport_overrides(
 fn sync_openai_plugins_repo_via_git(codex_home: &Path, git_binary: &str) -> Result<String, String> {
     let repo_path = curated_plugins_repo_path(codex_home);
     let sha_path = codex_home.join(CURATED_PLUGINS_SHA_FILE);
-    let remote_sha = git_ls_remote_head_sha(git_binary)?;
-    let local_sha = read_local_git_or_sha_file(&repo_path, &sha_path, git_binary);
+    let git_context = CuratedGitInvocationContext::create(codex_home)?;
+    let remote_sha = git_ls_remote_head_sha(git_binary, &git_context)?;
+    let local_sha = read_local_git_or_sha_file(&repo_path, &sha_path, git_binary, &git_context);
 
     if local_sha.as_deref() == Some(remote_sha.as_str()) && repo_path.join(".git").is_dir() {
         return Ok(remote_sha);
@@ -147,8 +150,8 @@ fn sync_openai_plugins_repo_via_git(codex_home: &Path, git_binary: &str) -> Resu
 
     let staged_repo_dir = prepare_curated_repo_parent_and_temp_dir(&repo_path)?;
     let clone_output = run_git_command_with_timeout(
-        Command::new(git_binary)
-            .env("GIT_OPTIONAL_LOCKS", "0")
+        git_context
+            .command(git_binary)
             .arg("clone")
             .arg("--depth")
             .arg("1")
@@ -159,7 +162,7 @@ fn sync_openai_plugins_repo_via_git(codex_home: &Path, git_binary: &str) -> Resu
     )?;
     ensure_git_success(&clone_output, "git clone curated plugins repo")?;
 
-    let cloned_sha = git_head_sha(staged_repo_dir.path(), git_binary)?;
+    let cloned_sha = git_head_sha(staged_repo_dir.path(), git_binary, &git_context)?;
     if cloned_sha != remote_sha {
         return Err(format!(
             "curated plugins clone HEAD mismatch: expected {remote_sha}, got {cloned_sha}"
@@ -244,7 +247,7 @@ fn prepare_curated_repo_parent_and_temp_dir(repo_path: &Path) -> Result<TempDir,
     remove_stale_curated_repo_temp_dirs(parent, CURATED_PLUGINS_STALE_TEMP_DIR_MAX_AGE);
 
     let clone_dir = tempfile::Builder::new()
-        .prefix("plugins-clone-")
+        .prefix(CURATED_PLUGINS_CLONE_TEMP_DIR_PREFIX)
         .tempdir_in(parent)
         .map_err(|err| {
             format!(
@@ -285,11 +288,14 @@ fn remove_stale_curated_repo_temp_dirs(parent: &Path, max_age: Duration) {
         }
 
         let path = entry.path();
-        let is_plugins_clone_dir = path
-            .file_name()
-            .and_then(|name| name.to_str())
-            .is_some_and(|name| name.starts_with("plugins-clone-"));
-        if !is_plugins_clone_dir {
+        let is_curated_temp_dir =
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| {
+                    name.starts_with(CURATED_PLUGINS_CLONE_TEMP_DIR_PREFIX)
+                        || name.starts_with(CURATED_PLUGINS_GIT_CWD_TEMP_DIR_PREFIX)
+                });
+        if !is_curated_temp_dir {
             continue;
         }
 
@@ -455,9 +461,10 @@ fn read_local_git_or_sha_file(
     repo_path: &Path,
     sha_path: &Path,
     git_binary: &str,
+    git_context: &CuratedGitInvocationContext,
 ) -> Option<String> {
     if repo_path.join(".git").is_dir()
-        && let Ok(sha) = git_head_sha(repo_path, git_binary)
+        && let Ok(sha) = git_head_sha(repo_path, git_binary, git_context)
     {
         return Some(sha);
     }
@@ -465,10 +472,78 @@ fn read_local_git_or_sha_file(
     read_sha_file(sha_path)
 }
 
-fn git_ls_remote_head_sha(git_binary: &str) -> Result<String, String> {
-    let output = run_git_command_with_timeout(
-        Command::new(git_binary)
+/// Isolated process context for curated plugin Git calls.
+///
+/// These commands can run before a project has been trusted. Running Git from a
+/// fresh Codex-owned directory and blocking repository discovery above it
+/// prevents an untrusted project `.git/config` from supplying executable config
+/// such as credential helpers. Global and system Git config still apply so
+/// user-managed proxy and CA settings keep working.
+struct CuratedGitInvocationContext {
+    _cwd: TempDir,
+    cwd_path: PathBuf,
+}
+
+impl CuratedGitInvocationContext {
+    fn create(codex_home: &Path) -> Result<Self, String> {
+        let parent = codex_home.join(".tmp");
+        std::fs::create_dir_all(&parent).map_err(|err| {
+            format!(
+                "failed to create curated plugins git cwd parent {}: {err}",
+                parent.display()
+            )
+        })?;
+        let cwd = tempfile::Builder::new()
+            .prefix(CURATED_PLUGINS_GIT_CWD_TEMP_DIR_PREFIX)
+            .tempdir_in(&parent)
+            .map_err(|err| {
+                format!(
+                    "failed to create curated plugins git cwd in {}: {err}",
+                    parent.display()
+                )
+            })?;
+        let cwd_path = cwd.path().canonicalize().map_err(|err| {
+            format!(
+                "failed to resolve curated plugins git cwd {}: {err}",
+                cwd.path().display()
+            )
+        })?;
+        Ok(Self {
+            _cwd: cwd,
+            cwd_path,
+        })
+    }
+
+    fn command(&self, git_binary: &str) -> Command {
+        let mut command = Command::new(git_binary);
+        command
+            .current_dir(&self.cwd_path)
             .env("GIT_OPTIONAL_LOCKS", "0")
+            .env("GIT_CEILING_DIRECTORIES", &self.cwd_path)
+            .env("GIT_TERMINAL_PROMPT", "0")
+            .env_remove("GIT_CONFIG")
+            .env_remove("GIT_CONFIG_COUNT")
+            .env_remove("GIT_CONFIG_LOCAL")
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_INDEX_FILE")
+            .env_remove("GIT_WORK_TREE");
+        for (key, _) in std::env::vars_os() {
+            let key = key.to_string_lossy();
+            if key.starts_with("GIT_CONFIG_KEY_") || key.starts_with("GIT_CONFIG_VALUE_") {
+                command.env_remove(key.as_ref());
+            }
+        }
+        command
+    }
+}
+
+fn git_ls_remote_head_sha(
+    git_binary: &str,
+    git_context: &CuratedGitInvocationContext,
+) -> Result<String, String> {
+    let output = run_git_command_with_timeout(
+        git_context
+            .command(git_binary)
             .arg("ls-remote")
             .arg("https://github.com/openai/plugins.git")
             .arg("HEAD"),
@@ -492,9 +567,13 @@ fn git_ls_remote_head_sha(git_binary: &str) -> Result<String, String> {
     Ok(sha.to_string())
 }
 
-fn git_head_sha(repo_path: &Path, git_binary: &str) -> Result<String, String> {
-    let output = Command::new(git_binary)
-        .env("GIT_OPTIONAL_LOCKS", "0")
+fn git_head_sha(
+    repo_path: &Path,
+    git_binary: &str,
+    git_context: &CuratedGitInvocationContext,
+) -> Result<String, String> {
+    let output = git_context
+        .command(git_binary)
         .arg("-C")
         .arg(repo_path)
         .arg("rev-parse")

--- a/codex-rs/core-plugins/src/startup_sync_tests.rs
+++ b/codex-rs/core-plugins/src/startup_sync_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use pretty_assertions::assert_eq;
+use std::ffi::OsStr;
 use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
@@ -66,6 +67,12 @@ fn write_curated_plugin_sha(codex_home: &Path) {
     );
 }
 
+fn command_env<'a>(command: &'a Command, key: &str) -> Option<Option<&'a OsStr>> {
+    command
+        .get_envs()
+        .find_map(|(name, value)| (name == OsStr::new(key)).then_some(value))
+}
+
 fn has_plugins_clone_dirs(codex_home: &Path) -> bool {
     let Ok(entries) = std::fs::read_dir(codex_home.join(".tmp")) else {
         return false;
@@ -77,7 +84,7 @@ fn has_plugins_clone_dirs(codex_home: &Path) -> bool {
             && path
                 .file_name()
                 .and_then(|name| name.to_str())
-                .is_some_and(|name| name.starts_with("plugins-clone-"))
+                .is_some_and(|name| name.starts_with(CURATED_PLUGINS_CLONE_TEMP_DIR_PREFIX))
     })
 }
 
@@ -231,24 +238,66 @@ fn remove_stale_curated_repo_temp_dirs_removes_only_matching_directories() {
     let tmp = tempdir().expect("tempdir");
     let parent = tmp.path().join(".tmp");
     let stale_clone_dir = parent.join("plugins-clone-stale");
+    let stale_git_cwd_dir = parent.join("curated-git-cwd-stale");
     let fresh_clone_dir = parent.join("plugins-clone-fresh");
+    let fresh_git_cwd_dir = parent.join("curated-git-cwd-fresh");
     let unrelated_dir = parent.join("plugins-cache");
 
     std::fs::create_dir_all(&stale_clone_dir).expect("create stale clone dir");
+    std::fs::create_dir_all(&stale_git_cwd_dir).expect("create stale git cwd dir");
     std::fs::create_dir_all(&fresh_clone_dir).expect("create fresh clone dir");
+    std::fs::create_dir_all(&fresh_git_cwd_dir).expect("create fresh git cwd dir");
     std::fs::create_dir_all(&unrelated_dir).expect("create unrelated dir");
     set_dir_mtime(
         &stale_clone_dir,
         CURATED_PLUGINS_STALE_TEMP_DIR_MAX_AGE + Duration::from_secs(60),
     )
     .expect("age stale clone dir");
+    set_dir_mtime(
+        &stale_git_cwd_dir,
+        CURATED_PLUGINS_STALE_TEMP_DIR_MAX_AGE + Duration::from_secs(60),
+    )
+    .expect("age stale git cwd dir");
     set_dir_mtime(&fresh_clone_dir, Duration::ZERO).expect("age fresh clone dir");
+    set_dir_mtime(&fresh_git_cwd_dir, Duration::ZERO).expect("age fresh git cwd dir");
 
     remove_stale_curated_repo_temp_dirs(&parent, CURATED_PLUGINS_STALE_TEMP_DIR_MAX_AGE);
 
     assert!(!stale_clone_dir.exists());
+    assert!(!stale_git_cwd_dir.exists());
     assert!(fresh_clone_dir.is_dir());
+    assert!(fresh_git_cwd_dir.is_dir());
     assert!(unrelated_dir.is_dir());
+}
+
+#[test]
+fn curated_git_command_uses_isolated_cwd_without_hiding_global_config() {
+    let tmp = tempdir().expect("tempdir");
+    let git_context = CuratedGitInvocationContext::create(tmp.path()).expect("git context");
+    let command = git_context.command("git");
+
+    assert_eq!(
+        command.get_current_dir(),
+        Some(git_context.cwd_path.as_path())
+    );
+    assert_eq!(
+        command_env(&command, "GIT_OPTIONAL_LOCKS"),
+        Some(Some(OsStr::new("0")))
+    );
+    assert_eq!(
+        command_env(&command, "GIT_CEILING_DIRECTORIES"),
+        Some(Some(git_context.cwd_path.as_os_str()))
+    );
+    assert_eq!(
+        command_env(&command, "GIT_TERMINAL_PROMPT"),
+        Some(Some(OsStr::new("0")))
+    );
+    assert_eq!(command_env(&command, "GIT_CONFIG_NOSYSTEM"), None);
+    assert_eq!(command_env(&command, "GIT_CONFIG_GLOBAL"), None);
+    assert_eq!(command_env(&command, "GIT_CONFIG_SYSTEM"), None);
+    assert_eq!(command_env(&command, "GIT_CONFIG_COUNT"), Some(None));
+    assert_eq!(command_env(&command, "GIT_DIR"), Some(None));
+    assert_eq!(command_env(&command, "GIT_WORK_TREE"), Some(None));
 }
 
 #[cfg(unix)]
@@ -302,6 +351,64 @@ exit 1
     assert!(repo_path.join(".git").is_dir());
     assert_curated_gmail_repo(&repo_path);
     assert_eq!(read_curated_plugins_sha(tmp.path()).as_deref(), Some(sha));
+}
+
+#[cfg(unix)]
+#[test]
+fn sync_openai_plugins_repo_via_git_runs_commands_from_isolated_cwd() {
+    let tmp = tempdir().expect("tempdir");
+    let bin_dir = tempfile::Builder::new()
+        .prefix("fake-git-isolated-cwd-")
+        .tempdir()
+        .expect("tempdir");
+    let git_path = bin_dir.path().join("git");
+    let log_path = tmp.path().join("git-invocations.log");
+    let sha = "0123456789abcdef0123456789abcdef01234567";
+
+    write_executable_script(
+        &git_path,
+        &format!(
+            r#"#!/bin/sh
+record_invocation() {{
+  printf '%s|%s|%s\n' "$1" "$PWD" "$GIT_CEILING_DIRECTORIES" >> "{log_path}"
+}}
+if [ "$1" = "ls-remote" ]; then
+  record_invocation "ls-remote"
+  printf '%s\tHEAD\n' "{sha}"
+  exit 0
+fi
+if [ "$1" = "clone" ]; then
+  record_invocation "clone"
+  dest="$5"
+  mkdir -p "$dest/.git" "$dest/.agents/plugins" "$dest/plugins/gmail/.codex-plugin"
+  printf '{{"name":"openai-curated","plugins":[{{"name":"gmail","source":{{"source":"local","path":"./plugins/gmail"}}}}]}}' > "$dest/.agents/plugins/marketplace.json"
+  printf '%s\n' '{{"name":"gmail"}}' > "$dest/plugins/gmail/.codex-plugin/plugin.json"
+  exit 0
+fi
+if [ "$1" = "-C" ] && [ "$3" = "rev-parse" ] && [ "$4" = "HEAD" ]; then
+  record_invocation "rev-parse"
+  printf '%s\n' "{sha}"
+  exit 0
+fi
+echo "unexpected git invocation: $@" >&2
+exit 1
+"#,
+            log_path = log_path.display()
+        ),
+    );
+
+    sync_openai_plugins_repo_via_git(tmp.path(), git_path.to_str().expect("utf8 path"))
+        .expect("git sync should succeed");
+
+    let log = std::fs::read_to_string(&log_path).expect("read git invocation log");
+    let lines = log.lines().collect::<Vec<_>>();
+    assert_eq!(lines.len(), 3);
+    for line in lines {
+        let parts = line.split('|').collect::<Vec<_>>();
+        assert_eq!(parts.len(), 3);
+        assert_eq!(parts[2], parts[1]);
+        assert!(parts[1].contains("/.tmp/curated-git-cwd-"));
+    }
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary

Harden curated plugin startup sync so its Git subprocesses do not inherit an untrusted project repository as their working directory before the trust prompt.

The sync now creates a short-lived Codex-owned temp directory and runs `ls-remote`, `clone`, and `rev-parse` from there with `GIT_CEILING_DIRECTORIES` set to that directory. This prevents Git from discovering and reading a project-local `.git/config` while preserving user/system Git configuration for proxy and corporate CA settings.

## Root Cause

Curated plugin sync can run during app-server startup, before the TUI trust flow has completed. Its Git commands previously did not set `current_dir`, so they inherited the CLI process CWD. In an untrusted Git checkout, that lets local Git config affect the startup sync Git command.

## Changes

- Added an isolated curated Git invocation context for startup sync Git commands.
- Removed inherited Git environment variables that can redirect repository state or inject config.
- Kept global/system Git config visible so `http.proxy`, `http.sslCAInfo`, and similar managed network settings still work.
- Extended stale temp cleanup to include the new isolated Git CWD temp directories.
- Added regression tests for the command environment, isolated CWD behavior, and stale cleanup.

## Validation

- `just fmt`
- `cargo test -p codex-core-plugins` (191 passed)
- `just fix -p codex-core-plugins`
- `git diff --check`
