### PR TITLE
[shell command] Reject shell globs in known safe Bash commands

### DIFF
--- a/codex-rs/shell-command/src/bash.rs
+++ b/codex-rs/shell-command/src/bash.rs
@@ -152,10 +152,10 @@ fn parse_plain_command_from_node(cmd: tree_sitter::Node, src: &str) -> Option<Ve
                 if word_node.kind() != "word" {
                     return None;
                 }
-                words.push(word_node.utf8_text(src.as_bytes()).ok()?.to_owned());
+                words.push(parse_unquoted_literal(word_node, src)?);
             }
             "word" | "number" => {
-                words.push(child.utf8_text(src.as_bytes()).ok()?.to_owned());
+                words.push(parse_unquoted_literal(child, src)?);
             }
             "string" => {
                 let parsed = parse_double_quoted_string(child, src)?;
@@ -172,8 +172,7 @@ fn parse_plain_command_from_node(cmd: tree_sitter::Node, src: &str) -> Option<Ve
                 for part in child.named_children(&mut concat_cursor) {
                     match part.kind() {
                         "word" | "number" => {
-                            concatenated
-                                .push_str(part.utf8_text(src.as_bytes()).ok()?.to_owned().as_str());
+                            concatenated.push_str(&parse_unquoted_literal(part, src)?);
                         }
                         "string" => {
                             let parsed = parse_double_quoted_string(part, src)?;
@@ -195,6 +194,18 @@ fn parse_plain_command_from_node(cmd: tree_sitter::Node, src: &str) -> Option<Ve
         }
     }
     Some(words)
+}
+
+fn parse_unquoted_literal(node: Node, src: &str) -> Option<String> {
+    let text = node.utf8_text(src.as_bytes()).ok()?;
+    if text.starts_with('~') || text.chars().any(is_unquoted_shell_expansion_char) {
+        return None;
+    }
+    Some(text.to_string())
+}
+
+fn is_unquoted_shell_expansion_char(c: char) -> bool {
+    matches!(c, '*' | '?' | '[' | ']' | '{' | '}')
 }
 
 fn parse_heredoc_command_words(cmd: Node<'_>, src: &str) -> Option<Vec<String>> {
@@ -498,6 +509,26 @@ mod tests {
         // Command substitution in concatenated strings should be rejected
         assert!(parse_seq("rg -g\"$(pwd)\" pattern").is_none());
         assert!(parse_seq("rg -g\"$(echo '*.py')\" pattern").is_none());
+    }
+
+    #[test]
+    fn rejects_unquoted_shell_expansion_words() {
+        assert!(parse_seq("base64 -i input.txt -* cc06_out").is_none());
+        assert!(parse_seq("ls *.rs").is_none());
+        assert!(parse_seq("echo -{o,}").is_none());
+    }
+
+    #[test]
+    fn accepts_quoted_shell_expansion_literals() {
+        assert_eq!(
+            parse_seq(r#"echo "-*" '*.rs' "-{o,}""#).unwrap(),
+            vec![vec![
+                "echo".to_string(),
+                "-*".to_string(),
+                "*.rs".to_string(),
+                "-{o,}".to_string(),
+            ]]
+        );
     }
 
     #[test]

--- a/codex-rs/shell-command/src/command_safety/is_safe_command.rs
+++ b/codex-rs/shell-command/src/command_safety/is_safe_command.rs
@@ -739,6 +739,18 @@ mod tests {
     }
 
     #[test]
+    fn bash_lc_glob_expansion_option_injection_is_not_safe() {
+        assert!(
+            !is_known_safe_command(&vec_str(&[
+                "bash",
+                "-lc",
+                "base64 -i input.txt -* cc06_out",
+            ])),
+            "Unquoted shell expansion can rewrite argv into base64 -o at runtime"
+        );
+    }
+
+    #[test]
     fn direct_powershell_words_use_windows_safelist() {
         let command = vec_str(&["Get-Content", "Cargo.toml"]);
 


### PR DESCRIPTION
## Summary

1. Reject unquoted shell expansion words when parsing Bash scripts for known safe command classification.
2. Preserve quoted literal forms so quoted star patterns still parse as literal argv.
3. Add a regression for the reported Base64 option injection shape.

## Why

The known safe classifier was treating unquoted Bash words as stable argv. Bash can rewrite those words at runtime through glob, bracket, brace, or home directory expansion, so a command that looked read only during classification could become an output writing command when the shell executed it.

This PR keeps the fix inside the shell command parser and the safelist regression. It does not broaden unrelated command policy.

## Validation

1. Local regression reproduced before the parser fix.
2. Local focused regression tests passed after rebasing onto current main.
3. Local full shell command crate passed with 137 tests.
4. AWS macOS VM replicated the raw Bash runtime primitive, then the patched classifier tests and full shell command crate passed with 137 tests.
5. AWS Windows VM ran the patched classifier tests through SSM, then the full shell command crate passed with 188 tests.

## Ticket

CLI 8726
