### PR TITLE
config: accept `minus` in TUI keymap config

### DIFF
--- a/codex-rs/config/src/tui_keymap.rs
+++ b/codex-rs/config/src/tui_keymap.rs
@@ -494,6 +494,7 @@ fn normalize_key_name(key: &str, original: &str) -> Result<String, String> {
             | "page-up"
             | "page-down"
             | "space"
+            | "minus"
     ) {
         return Ok(alias.to_string());
     }
@@ -508,7 +509,7 @@ fn normalize_key_name(key: &str, original: &str) -> Result<String, String> {
     Err(format!(
         "unknown key `{key}` in keybinding `{original}`. \
 Use a printable character (for example `a`), function keys (`f1`-`f12`), \
-or one of: enter, tab, backspace, esc, delete, arrows, home/end, page-up/page-down, space.\n\
+or one of: enter, tab, backspace, esc, delete, arrows, home/end, page-up/page-down, space, minus.\n\
 See the Codex keymap documentation for supported actions and examples."
     ))
 }
@@ -516,6 +517,7 @@ See the Codex keymap documentation for supported actions and examples."
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn misplaced_action_at_keymap_root_is_rejected() {
@@ -580,5 +582,31 @@ mod tests {
         "#;
         let keymap: TuiKeymap = toml::from_str(toml_input).expect("valid config");
         assert!(keymap.global.open_transcript.is_some());
+    }
+
+    #[test]
+    fn minus_bindings_under_global_context_are_accepted() {
+        for (spec, expected) in [
+            (
+                "minus",
+                KeybindingsSpec::One(KeybindingSpec("minus".to_string())),
+            ),
+            (
+                "alt-minus",
+                KeybindingsSpec::One(KeybindingSpec("alt-minus".to_string())),
+            ),
+        ] {
+            let toml_input = format!(
+                r#"
+                [global]
+                open_transcript = "{spec}"
+                "#
+            );
+            let keymap: TuiKeymap = toml::from_str(&toml_input).expect("valid config");
+            let mut expected_keymap = TuiKeymap::default();
+            expected_keymap.global.open_transcript = Some(expected);
+
+            assert_eq!(keymap, expected_keymap);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #22128.

The `/keymap` flow already persists the `-` key as `minus`, and the runtime keymap parser already accepts that spelling. `codex-config` was the missing leg: it rejected `minus` during config deserialization, so a binding saved by Codex could fail on the next startup or config reload.

## What Changed

- Accept `minus` as a valid canonical key name in `tui.keymap` config normalization.
- Update the config validation message so its supported-key list includes `minus`.
- Add regression coverage that deserializes both `minus` and `alt-minus` under `[tui.keymap.global]` and verifies the normalized config shape.

## How to Test

1. Start Codex TUI.
2. Run `/keymap`.
3. Assign the `-` key to an action and save the change.
4. Restart Codex or reload the config.
5. Confirm the config loads normally and the saved binding remains usable instead of failing on `minus`.
6. As a focused regression check, repeat with a modifier form such as `alt--` captured through `/keymap`, which persists as `alt-minus` and should also reload successfully.

Targeted tests:
- `cargo test -p codex-config`
