### PR TITLE
Avoid duplicate codex_apps tool refresh on force refetch

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/app_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/app_list.rs
@@ -3,6 +3,8 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use anyhow::Result;
@@ -1160,6 +1162,7 @@ async fn list_apps_force_refetch_patches_updates_from_cached_snapshots() -> Resu
     } = to_response(warm_response)?;
     assert_eq!(warm_data, warm_second_update.data);
     assert!(warm_next_cursor.is_none());
+    assert_eq!(server_control.tools_list_call_count(), 1);
 
     server_control.set_connectors(vec![AppInfo {
         id: "alpha".to_string(),
@@ -1263,6 +1266,7 @@ async fn list_apps_force_refetch_patches_updates_from_cached_snapshots() -> Resu
     } = to_response(refetch_response)?;
     assert_eq!(refetch_data, expected_final);
     assert!(refetch_next_cursor.is_none());
+    assert_eq!(server_control.tools_list_call_count(), 2);
 
     server_handle.abort();
     Ok(())
@@ -1397,12 +1401,21 @@ struct AppsServerState {
 #[derive(Clone)]
 struct AppListMcpServer {
     tools: Arc<StdMutex<Vec<Tool>>>,
+    tools_list_call_count: Arc<AtomicUsize>,
     tools_delay: Duration,
 }
 
 impl AppListMcpServer {
-    fn new(tools: Arc<StdMutex<Vec<Tool>>>, tools_delay: Duration) -> Self {
-        Self { tools, tools_delay }
+    fn new(
+        tools: Arc<StdMutex<Vec<Tool>>>,
+        tools_list_call_count: Arc<AtomicUsize>,
+        tools_delay: Duration,
+    ) -> Self {
+        Self {
+            tools,
+            tools_list_call_count,
+            tools_delay,
+        }
     }
 }
 
@@ -1410,6 +1423,7 @@ impl AppListMcpServer {
 struct AppsServerControl {
     response: Arc<StdMutex<serde_json::Value>>,
     tools: Arc<StdMutex<Vec<Tool>>>,
+    tools_list_call_count: Arc<AtomicUsize>,
 }
 
 impl AppsServerControl {
@@ -1428,6 +1442,10 @@ impl AppsServerControl {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         *tools_guard = tools;
     }
+
+    fn tools_list_call_count(&self) -> usize {
+        self.tools_list_call_count.load(Ordering::Relaxed)
+    }
 }
 
 impl ServerHandler for AppListMcpServer {
@@ -1445,8 +1463,10 @@ impl ServerHandler for AppListMcpServer {
     ) -> impl std::future::Future<Output = Result<ListToolsResult, rmcp::ErrorData>> + Send + '_
     {
         let tools = self.tools.clone();
+        let tools_list_call_count = Arc::clone(&self.tools_list_call_count);
         let tools_delay = self.tools_delay;
         async move {
+            tools_list_call_count.fetch_add(1, Ordering::Relaxed);
             if tools_delay > Duration::ZERO {
                 tokio::time::sleep(tools_delay).await;
             }
@@ -1519,6 +1539,7 @@ async fn start_apps_server_with_delays_and_control_inner(
         json!({ "apps": connectors, "next_token": null }),
     ));
     let tools = Arc::new(StdMutex::new(tools));
+    let tools_list_call_count = Arc::new(AtomicUsize::new(0));
     let state = AppsServerState {
         expected_bearer: "Bearer chatgpt-token".to_string(),
         expected_account_id: "account-123".to_string(),
@@ -1530,6 +1551,7 @@ async fn start_apps_server_with_delays_and_control_inner(
     let server_control = AppsServerControl {
         response,
         tools: tools.clone(),
+        tools_list_call_count: Arc::clone(&tools_list_call_count),
     };
 
     let listener = TcpListener::bind("127.0.0.1:0").await?;
@@ -1538,7 +1560,14 @@ async fn start_apps_server_with_delays_and_control_inner(
     let mcp_service = StreamableHttpService::new(
         {
             let tools = tools.clone();
-            move || Ok(AppListMcpServer::new(tools.clone(), tools_delay))
+            let tools_list_call_count = Arc::clone(&tools_list_call_count);
+            move || {
+                Ok(AppListMcpServer::new(
+                    tools.clone(),
+                    Arc::clone(&tools_list_call_count),
+                    tools_delay,
+                ))
+            }
         },
         Arc::new(LocalSessionManager::default()),
         StreamableHttpServerConfig::default(),

--- a/codex-rs/core/src/connectors.rs
+++ b/codex-rs/core/src/connectors.rs
@@ -284,17 +284,24 @@ pub async fn list_accessible_connectors_from_mcp_tools_with_environment_manager(
     .await;
 
     let refreshed_tools = if force_refetch {
-        match mcp_connection_manager
-            .hard_refresh_codex_apps_tools_cache()
-            .await
-        {
-            Ok(tools) => Some(tools),
-            Err(err) => {
-                warn!(
-                    "failed to force-refresh tools for MCP server '{CODEX_APPS_MCP_SERVER_NAME}', using cached/startup tools: {err:#}"
-                );
-                None
-            }
+        let codex_apps_ready = if let Some(cfg) = mcp_servers.get(CODEX_APPS_MCP_SERVER_NAME) {
+            let timeout = cfg
+                .configured_config()
+                .and_then(|config| config.startup_timeout_sec)
+                .unwrap_or(CONNECTORS_READY_TIMEOUT_ON_EMPTY_TOOLS);
+            mcp_connection_manager
+                .wait_for_server_ready(CODEX_APPS_MCP_SERVER_NAME, timeout)
+                .await
+        } else {
+            false
+        };
+        if codex_apps_ready {
+            Some(mcp_connection_manager.list_all_tools().await)
+        } else {
+            warn!(
+                "failed to force-refresh tools for MCP server '{CODEX_APPS_MCP_SERVER_NAME}', using cached/startup tools"
+            );
+            None
         }
     } else {
         None


### PR DESCRIPTION
## Why

`app/list(force_refetch = true)` creates a fresh temporary `McpConnectionManager` so it can read current `codex_apps` tools. That fresh manager already performs an uncached `tools/list` during startup and writes the result into the Codex Apps tools cache.

The old force-refetch branch then immediately called `hard_refresh_codex_apps_tools_cache()` on that same fresh manager, which issued a second uncached `tools/list` against the same server connection before any caller could observe the first result. That duplicated a live inventory request without making the data any fresher.

This is separate from the repeated in-process inventory reads that can happen during normal `codex exec` startup. Those reads reuse the already-loaded tool snapshot; the redundant network call was specific to the fresh-manager force-refetch flow.

Relevant code:

- [`list_accessible_connectors_from_mcp_tools_with_environment_manager`](https://github.com/openai/codex/blob/361dff228e061b48ce88789b1fdeb1a5c71ab480/codex-rs/core/src/connectors.rs#L286-L315)

## What changed

- For `force_refetch`, wait for the freshly-created temporary manager's `codex_apps` startup to complete, then reuse `list_all_tools()` from that manager instead of forcing a second live refresh.
- Keep the existing fallback behavior when `codex_apps` is not ready: continue with the startup/cached tools path rather than changing visible behavior.
- Extend the existing app-list integration coverage to count `tools/list` calls and assert:
  - the warm request performs one inventory fetch
  - the later force-refetch request adds exactly one more fetch, not two

Regression coverage:

- [`list_apps_force_refetch_patches_updates_from_cached_snapshots`](https://github.com/openai/codex/blob/361dff228e061b48ce88789b1fdeb1a5c71ab480/codex-rs/app-server/tests/suite/v2/app_list.rs#L1165-L1269)

## Verification

- `cargo test -p codex-app-server list_apps_force_refetch_patches_updates_from_cached_snapshots`
- `cargo test -p codex-core connectors`
- `just fix -p codex-core`
