### PR TITLE
Isolate tmp-dependent tests from ambient git

### DIFF
--- a/codex-rs/core-skills/src/loader_tests.rs
+++ b/codex-rs/core-skills/src/loader_tests.rs
@@ -1726,16 +1726,49 @@ async fn non_git_repo_skills_search_does_not_walk_parents() {
     fs::create_dir_all(&nested_dir).unwrap();
 
     write_skill_at(
-        &outer_dir
-            .path()
-            .join(REPO_ROOT_CONFIG_DIR_NAME)
-            .join(SKILLS_DIR_NAME),
+        &outer_dir.path().join(AGENTS_DIR_NAME).join(SKILLS_DIR_NAME),
         "outer",
         "outer-skill",
         "from outer",
     );
 
-    let cfg = make_config_for_cwd(&codex_home, nested_dir).await;
+    let mut system_config = toml::map::Map::new();
+    system_config.insert(
+        "project_root_markers".to_string(),
+        TomlValue::Array(vec![TomlValue::String(
+            "__codex_test_project_root_marker_that_does_not_exist__".to_string(),
+        )]),
+    );
+    let user_config_path = codex_home.path().join(CONFIG_TOML_FILE);
+    let system_config_path = codex_home.path().join("etc/codex/config.toml");
+    fs::create_dir_all(
+        system_config_path
+            .parent()
+            .expect("system config path should have a parent"),
+    )
+    .expect("create fake system config dir");
+    let cfg = TestConfig {
+        cwd: nested_dir.abs(),
+        config_layer_stack: ConfigLayerStack::new(
+            vec![
+                ConfigLayerEntry::new(
+                    ConfigLayerSource::System {
+                        file: config_file(system_config_path),
+                    },
+                    TomlValue::Table(system_config),
+                ),
+                ConfigLayerEntry::new(
+                    ConfigLayerSource::User {
+                        file: config_file(user_config_path),
+                    },
+                    TomlValue::Table(toml::map::Map::new()),
+                ),
+            ],
+            ConfigRequirements::default(),
+            ConfigRequirementsToml::default(),
+        )
+        .expect("valid config layer stack"),
+    };
 
     let outcome = load_skills_for_test(&cfg).await;
     assert!(

--- a/codex-rs/secrets/src/lib.rs
+++ b/codex-rs/secrets/src/lib.rs
@@ -188,12 +188,21 @@ mod tests {
 
     #[test]
     fn environment_id_fallback_has_cwd_prefix() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let env_id = environment_id_from_cwd(dir.path());
-        let canonical = dir
-            .path()
+        let unique = tempfile::Builder::new()
+            .prefix("codex-secrets-test-")
+            .tempdir()
+            .expect("tempdir");
+        let cwd = PathBuf::from(std::path::MAIN_SEPARATOR.to_string()).join(
+            unique
+                .path()
+                .file_name()
+                .expect("tempdir should have a file name"),
+        );
+        drop(unique);
+        let env_id = environment_id_from_cwd(&cwd);
+        let canonical = cwd
             .canonicalize()
-            .expect("tempdir canonical path should exist")
+            .unwrap_or_else(|_| cwd.clone())
             .to_string_lossy()
             .into_owned();
         let mut hasher = Sha256::new();

--- a/codex-rs/tui/src/chatwidget/tests/helpers.rs
+++ b/codex-rs/tui/src/chatwidget/tests/helpers.rs
@@ -66,11 +66,16 @@ pub(super) fn normalize_snapshot_paths(text: impl Into<String>) -> String {
             .into_iter()
             .rev()
         {
-            let unix_prefix: String = "/tmp/project"
-                .chars()
-                .take(isolated_prefix.chars().count())
-                .collect();
-            text = text.replace(&format!("{isolated_prefix}…"), &format!("{unix_prefix}…"));
+            let normalized = if isolated_prefix.chars().count() >= "/tmp/project".chars().count() {
+                "/tmp/project".to_string()
+            } else {
+                let unix_prefix: String = "/tmp/project"
+                    .chars()
+                    .take(isolated_prefix.chars().count())
+                    .collect();
+                format!("{unix_prefix}…")
+            };
+            text = text.replace(&format!("{isolated_prefix}…"), &normalized);
         }
     }
 

--- a/codex-rs/tui/src/chatwidget/tests/helpers.rs
+++ b/codex-rs/tui/src/chatwidget/tests/helpers.rs
@@ -60,7 +60,18 @@ pub(super) fn normalize_snapshot_paths(text: impl Into<String>) -> String {
         .expect("test project path registry")
         .iter()
     {
-        text = text.replace(isolated_project.to_string_lossy().as_ref(), "/tmp/project");
+        let isolated_project = isolated_project.to_string_lossy();
+        text = text.replace(isolated_project.as_ref(), "/tmp/project");
+        for isolated_prefix in truncated_path_variants(isolated_project.as_ref())
+            .into_iter()
+            .rev()
+        {
+            let unix_prefix: String = "/tmp/project"
+                .chars()
+                .take(isolated_prefix.chars().count())
+                .collect();
+            text = text.replace(&format!("{isolated_prefix}…"), &format!("{unix_prefix}…"));
+        }
     }
 
     for unix_path in ["/tmp/project", "/tmp/hooks.json"] {

--- a/codex-rs/tui/src/chatwidget/tests/helpers.rs
+++ b/codex-rs/tui/src/chatwidget/tests/helpers.rs
@@ -26,11 +26,12 @@ pub(super) async fn test_config() -> Config {
 }
 
 pub(super) fn test_project_path() -> PathBuf {
-    let project = tempfile::Builder::new()
-        .rand_bytes("project".len())
+    let isolated_root = tempfile::Builder::new()
+        .prefix("chatwidget-project-")
         .tempdir_in(std::env::temp_dir())
         .expect("tempdir")
         .keep();
+    let project = isolated_root.join("project");
     std::fs::create_dir_all(project.join(".git")).expect("create test project git marker");
     isolated_test_project_paths()
         .lock()
@@ -89,12 +90,7 @@ pub(super) fn normalize_snapshot_paths(text: impl Into<String>) -> String {
 }
 
 pub(super) fn normalized_backend_snapshot<T: std::fmt::Display>(value: &T) -> String {
-    let platform_test_cwd = test_path_display("/tmp/project");
     let rendered = format!("{value}");
-
-    if platform_test_cwd == "/tmp/project" {
-        return normalize_snapshot_paths(rendered);
-    }
 
     rendered
         .lines()

--- a/codex-rs/tui/src/chatwidget/tests/helpers.rs
+++ b/codex-rs/tui/src/chatwidget/tests/helpers.rs
@@ -1,6 +1,8 @@
 use super::*;
 use codex_app_server_protocol::PluginAvailability;
 use pretty_assertions::assert_eq;
+use std::sync::Mutex;
+use std::sync::OnceLock;
 
 pub(super) async fn test_config() -> Config {
     // Start from the built-in defaults so tests do not inherit host/system config.
@@ -16,7 +18,7 @@ pub(super) async fn test_config() -> Config {
     config.codex_home = codex_home.abs();
     config.sqlite_home = codex_home.clone();
     config.log_dir = codex_home.join("log");
-    config.cwd = PathBuf::from(test_path_display("/tmp/project")).abs();
+    config.cwd = test_project_path().abs();
     config.config_layer_stack = ConfigLayerStack::default();
     config.startup_warnings.clear();
     config.user_instructions = None;
@@ -24,7 +26,22 @@ pub(super) async fn test_config() -> Config {
 }
 
 pub(super) fn test_project_path() -> PathBuf {
-    PathBuf::from(test_path_display("/tmp/project"))
+    let project = tempfile::Builder::new()
+        .rand_bytes("project".len())
+        .tempdir_in(std::env::temp_dir())
+        .expect("tempdir")
+        .keep();
+    std::fs::create_dir_all(project.join(".git")).expect("create test project git marker");
+    isolated_test_project_paths()
+        .lock()
+        .expect("test project path registry")
+        .push(project.clone());
+    project
+}
+
+fn isolated_test_project_paths() -> &'static Mutex<Vec<PathBuf>> {
+    static TEST_PROJECT_PATHS: OnceLock<Mutex<Vec<PathBuf>>> = OnceLock::new();
+    TEST_PROJECT_PATHS.get_or_init(|| Mutex::new(Vec::new()))
 }
 
 pub(super) fn truncated_path_variants(path: &str) -> Vec<String> {
@@ -36,6 +53,14 @@ pub(super) fn truncated_path_variants(path: &str) -> Vec<String> {
 
 pub(super) fn normalize_snapshot_paths(text: impl Into<String>) -> String {
     let mut text = text.into();
+
+    for isolated_project in isolated_test_project_paths()
+        .lock()
+        .expect("test project path registry")
+        .iter()
+    {
+        text = text.replace(isolated_project.to_string_lossy().as_ref(), "/tmp/project");
+    }
 
     for unix_path in ["/tmp/project", "/tmp/hooks.json"] {
         let platform_path = test_path_display(unix_path);
@@ -68,7 +93,7 @@ pub(super) fn normalized_backend_snapshot<T: std::fmt::Display>(value: &T) -> St
     let rendered = format!("{value}");
 
     if platform_test_cwd == "/tmp/project" {
-        return rendered;
+        return normalize_snapshot_paths(rendered);
     }
 
     rendered

--- a/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
+++ b/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
@@ -1917,10 +1917,10 @@ async fn status_line_model_with_reasoning_includes_fast_for_fast_capable_models(
     set_fast_mode_test_catalog(&mut chat);
     assert!(get_available_model(&chat, "gpt-5.4").supports_fast_mode());
     chat.refresh_status_line();
-    let test_cwd = test_path_display("/tmp/project");
+    let test_cwd = normalize_snapshot_paths(test_path_display("/tmp/project"));
 
     assert_eq!(
-        status_line_text(&chat),
+        status_line_text(&chat).map(normalize_snapshot_paths),
         Some(format!("gpt-5.4 xhigh fast · Context 0% used · {test_cwd}"))
     );
 
@@ -1928,7 +1928,7 @@ async fn status_line_model_with_reasoning_includes_fast_for_fast_capable_models(
     chat.refresh_status_line();
 
     assert_eq!(
-        status_line_text(&chat),
+        status_line_text(&chat).map(normalize_snapshot_paths),
         Some(format!(
             "gpt-5.3-codex xhigh · Context 0% used · {test_cwd}"
         ))

--- a/codex-rs/tui/src/chatwidget/tests/status_surface_previews.rs
+++ b/codex-rs/tui/src/chatwidget/tests/status_surface_previews.rs
@@ -191,6 +191,7 @@ async fn status_surface_preview_lines_mixed_snapshot() {
 #[tokio::test]
 async fn status_line_setup_popup_mixed_snapshot() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    cache_project_root(&mut chat, "my-project");
     chat.status_line_branch = Some("feature/mixed-preview".to_string());
     chat.thread_name = Some("Mixed preview thread".to_string());
     chat.config.tui_status_line = Some(vec![

--- a/codex-rs/tui/src/chatwidget/tests/status_surface_previews.rs
+++ b/codex-rs/tui/src/chatwidget/tests/status_surface_previews.rs
@@ -164,19 +164,26 @@ async fn status_surface_preview_lines_mixed_snapshot() {
     chat.status_line_branch = Some("feature/mixed-preview".to_string());
     chat.thread_name = Some("Mixed preview thread".to_string());
 
-    let snapshot = combined_preview_snapshot(
+    let status_line = status_preview_line(
         &mut chat,
         &[
             StatusLineItem::ProjectRoot,
             StatusLineItem::GitBranch,
             StatusLineItem::ThreadTitle,
         ],
+    );
+    chat.status_line_project_root_name_cache = None;
+    let terminal_title = title_preview_line(
+        &mut chat,
         &[
             TerminalTitleItem::Project,
             TerminalTitleItem::Thread,
             TerminalTitleItem::TaskProgress,
         ],
     );
+    let snapshot = normalize_snapshot_paths(format!(
+        "status line: {status_line}\nterminal title: {terminal_title}"
+    ));
 
     assert_chatwidget_snapshot!("status_surface_previews_mixed", snapshot);
 }

--- a/codex-rs/tui/src/chatwidget/tests/status_surface_previews.rs
+++ b/codex-rs/tui/src/chatwidget/tests/status_surface_previews.rs
@@ -250,6 +250,10 @@ async fn terminal_title_setup_popup_mixed_snapshot() {
 #[tokio::test]
 async fn missing_project_root_uses_different_status_and_title_preview_sources() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    chat.status_line_project_root_name_cache = Some(CachedProjectRootName {
+        cwd: chat.config.cwd.to_path_buf(),
+        root_name: None,
+    });
 
     let status_preview = status_preview_line(&mut chat, &[StatusLineItem::ProjectRoot]);
     let title_preview = title_preview_line(&mut chat, &[TerminalTitleItem::Project]);

--- a/codex-rs/tui/src/chatwidget/tests/status_surface_previews.rs
+++ b/codex-rs/tui/src/chatwidget/tests/status_surface_previews.rs
@@ -105,6 +105,7 @@ async fn status_line_setup_popup_live_only_snapshot() {
 #[tokio::test]
 async fn status_surface_preview_lines_hardcoded_only_snapshot() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    cache_project_root(&mut chat, "my-project");
 
     let snapshot = combined_preview_snapshot(
         &mut chat,
@@ -159,6 +160,7 @@ async fn status_line_setup_popup_hardcoded_only_snapshot() {
 #[tokio::test]
 async fn status_surface_preview_lines_mixed_snapshot() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    cache_project_root(&mut chat, "my-project");
     chat.status_line_branch = Some("feature/mixed-preview".to_string());
     chat.thread_name = Some("Mixed preview thread".to_string());
 

--- a/codex-rs/tui/src/chatwidget/tests/status_surface_previews.rs
+++ b/codex-rs/tui/src/chatwidget/tests/status_surface_previews.rs
@@ -145,6 +145,7 @@ async fn thread_title_falls_back_to_thread_id_when_unnamed() {
 #[tokio::test]
 async fn status_line_setup_popup_hardcoded_only_snapshot() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    cache_project_root(&mut chat, "my-project");
     chat.config.tui_status_line = Some(vec![
         "project-name".to_string(),
         "git-branch".to_string(),


### PR DESCRIPTION
## Why

The remote full-ci path has been picking up host-dependent git state from temp directories, which makes unrelated tests fail when `/tmp` or another ancestor looks like a repository. This PR removes that ambient dependency from the first layer of the CI reliability stack.

## What changed

- isolate project-root-sensitive test fixtures from ambient git metadata
- make the TUI chatwidget test project path unique per test run, while normalizing snapshots back to `/tmp/project`
- keep repo-root-sensitive core-skills and secrets tests from depending on whatever git markers happen to exist above their temp paths

## Stack

- [PR #22199](https://github.com/openai/codex/pull/22199) Isolate tmp-dependent tests from ambient git
- [PR #22201](https://github.com/openai/codex/pull/22201) Use remote fs for turn diff repo root
- [PR #22200](https://github.com/openai/codex/pull/22200) Emit unified exec end on startup failure
- [PR #22389](https://github.com/openai/codex/pull/22389) Stabilize remote routing e2e tests

## Validation

- Current-head CI is green.
- No local Codex test run; relying on CI for this stack.