### PR TITLE
Emit unified exec end on startup failure

### DIFF
--- a/codex-rs/core/src/tools/runtimes/unified_exec.rs
+++ b/codex-rs/core/src/tools/runtimes/unified_exec.rs
@@ -280,7 +280,11 @@ impl<'a> ToolRuntime<UnifiedExecRequest, UnifiedExecProcess> for UnifiedExecRunt
         if let UnifiedExecShellMode::ZshFork(zsh_fork_config) = &self.shell_mode {
             let command =
                 build_sandbox_command(&command, &req.cwd, &env, req.additional_permissions.clone())
-                    .map_err(|_| ToolError::Codex(CodexErr::InvalidRequest("missing command line for PTY".into())))?;
+                    .map_err(|_| {
+                        ToolError::Codex(CodexErr::InvalidRequest(
+                            "missing command line for PTY".into(),
+                        ))
+                    })?;
             let options = unified_exec_options(attempt.network_denial_cancellation_token.clone());
             let mut exec_env = attempt
                 .env_for(command, options, managed_network)
@@ -331,7 +335,11 @@ impl<'a> ToolRuntime<UnifiedExecRequest, UnifiedExecProcess> for UnifiedExecRunt
         }
         let command =
             build_sandbox_command(&command, &req.cwd, &env, req.additional_permissions.clone())
-                .map_err(|_| ToolError::Codex(CodexErr::InvalidRequest("missing command line for PTY".into())))?;
+                .map_err(|_| {
+                    ToolError::Codex(CodexErr::InvalidRequest(
+                        "missing command line for PTY".into(),
+                    ))
+                })?;
         let options = unified_exec_options(attempt.network_denial_cancellation_token.clone());
         let mut exec_env = attempt
             .env_for(command, options, managed_network)

--- a/codex-rs/core/src/tools/runtimes/unified_exec.rs
+++ b/codex-rs/core/src/tools/runtimes/unified_exec.rs
@@ -280,7 +280,7 @@ impl<'a> ToolRuntime<UnifiedExecRequest, UnifiedExecProcess> for UnifiedExecRunt
         if let UnifiedExecShellMode::ZshFork(zsh_fork_config) = &self.shell_mode {
             let command =
                 build_sandbox_command(&command, &req.cwd, &env, req.additional_permissions.clone())
-                    .map_err(|_| ToolError::Rejected("missing command line for PTY".to_string()))?;
+                    .map_err(|_| ToolError::Codex(CodexErr::InvalidRequest("missing command line for PTY".into())))?;
             let options = unified_exec_options(attempt.network_denial_cancellation_token.clone());
             let mut exec_env = attempt
                 .env_for(command, options, managed_network)
@@ -319,7 +319,7 @@ impl<'a> ToolRuntime<UnifiedExecRequest, UnifiedExecProcess> for UnifiedExecRunt
                                     network_policy_decision: None,
                                 }))
                             }
-                            other => ToolError::Rejected(other.to_string()),
+                            other => ToolError::Codex(CodexErr::Fatal(other.to_string())),
                         });
                 }
                 None => {
@@ -331,7 +331,7 @@ impl<'a> ToolRuntime<UnifiedExecRequest, UnifiedExecProcess> for UnifiedExecRunt
         }
         let command =
             build_sandbox_command(&command, &req.cwd, &env, req.additional_permissions.clone())
-                .map_err(|_| ToolError::Rejected("missing command line for PTY".to_string()))?;
+                .map_err(|_| ToolError::Codex(CodexErr::InvalidRequest("missing command line for PTY".into())))?;
         let options = unified_exec_options(attempt.network_denial_cancellation_token.clone());
         let mut exec_env = attempt
             .env_for(command, options, managed_network)
@@ -353,7 +353,7 @@ impl<'a> ToolRuntime<UnifiedExecRequest, UnifiedExecProcess> for UnifiedExecRunt
                         network_policy_decision: None,
                     }))
                 }
-                other => ToolError::Rejected(other.to_string()),
+                other => ToolError::Codex(CodexErr::Fatal(other.to_string())),
             })
     }
 }

--- a/codex-rs/core/src/unified_exec/errors.rs
+++ b/codex-rs/core/src/unified_exec/errors.rs
@@ -18,6 +18,8 @@ pub(crate) enum UnifiedExecError {
     StdinClosed,
     #[error("missing command line for unified exec request")]
     MissingCommandLine,
+    #[error("{message}")]
+    Rejected { message: String },
     #[error("Command denied by sandbox: {message}")]
     SandboxDenied {
         message: String,
@@ -32,6 +34,10 @@ impl UnifiedExecError {
 
     pub(crate) fn process_failed(message: String) -> Self {
         Self::ProcessFailed { message }
+    }
+
+    pub(crate) fn rejected(message: String) -> Self {
+        Self::Rejected { message }
     }
 
     pub(crate) fn sandbox_denied(message: String, output: ExecToolCallOutput) -> Self {

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -398,10 +398,6 @@ impl UnifiedExecProcessManager {
             }
             Err(err) => {
                 let failure = match &err {
-                    UnifiedExecError::MissingCommandLine => ToolEventFailure::Rejected {
-                        message: err.to_string(),
-                        applied_patch_delta: None,
-                    },
                     UnifiedExecError::Rejected { message } => ToolEventFailure::Rejected {
                         message: message.clone(),
                         applied_patch_delta: None,

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -398,6 +398,10 @@ impl UnifiedExecProcessManager {
             }
             Err(err) => {
                 let failure = match &err {
+                    UnifiedExecError::MissingCommandLine => ToolEventFailure::Rejected {
+                        message: err.to_string(),
+                        applied_patch_delta: None,
+                    },
                     UnifiedExecError::Rejected { message } => ToolEventFailure::Rejected {
                         message: message.clone(),
                         applied_patch_delta: None,

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -386,7 +386,6 @@ impl UnifiedExecProcessManager {
             ExecCommandSource::UnifiedExecStartup,
             Some(request.process_id.to_string()),
         );
-        emitter.emit(event_ctx, ToolEventStage::Begin).await;
 
         let process = self
             .open_session_with_sandbox(&request, cwd.clone(), context)
@@ -397,6 +396,7 @@ impl UnifiedExecProcessManager {
                 (Arc::new(process), deferred_network_approval)
             }
             Err(err) => {
+                emitter.emit(event_ctx, ToolEventStage::Begin).await;
                 let failure = match &err {
                     UnifiedExecError::Rejected { message } => ToolEventFailure::Rejected {
                         message: message.clone(),
@@ -414,6 +414,7 @@ impl UnifiedExecProcessManager {
                 return Err(err);
             }
         };
+        emitter.emit(event_ctx, ToolEventStage::Begin).await;
         if let Some(deferred) = deferred_network_approval.as_ref() {
             terminate_process_on_network_denial(
                 Arc::clone(&process),

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -19,6 +19,7 @@ use crate::sandboxing::ExecServerEnvConfig;
 use crate::tools::context::ExecCommandToolOutput;
 use crate::tools::events::ToolEmitter;
 use crate::tools::events::ToolEventCtx;
+use crate::tools::events::ToolEventFailure;
 use crate::tools::events::ToolEventStage;
 use crate::tools::network_approval::DeferredNetworkApproval;
 use crate::tools::network_approval::finish_deferred_network_approval;
@@ -372,27 +373,6 @@ impl UnifiedExecProcessManager {
         context: &UnifiedExecContext,
     ) -> Result<ExecCommandToolOutput, UnifiedExecError> {
         let cwd = request.cwd.clone();
-        let process = self
-            .open_session_with_sandbox(&request, cwd.clone(), context)
-            .await;
-
-        let (process, mut deferred_network_approval) = match process {
-            Ok((process, deferred_network_approval)) => {
-                (Arc::new(process), deferred_network_approval)
-            }
-            Err(err) => {
-                self.release_process_id(request.process_id).await;
-                return Err(err);
-            }
-        };
-        if let Some(deferred) = deferred_network_approval.as_ref() {
-            terminate_process_on_network_denial(
-                Arc::clone(&process),
-                Arc::downgrade(&context.session),
-                deferred.clone(),
-            );
-        }
-
         let transcript = Arc::new(tokio::sync::Mutex::new(HeadTailBuffer::default()));
         let event_ctx = ToolEventCtx::new(
             context.session.as_ref(),
@@ -407,6 +387,41 @@ impl UnifiedExecProcessManager {
             Some(request.process_id.to_string()),
         );
         emitter.emit(event_ctx, ToolEventStage::Begin).await;
+
+        let process = self
+            .open_session_with_sandbox(&request, cwd.clone(), context)
+            .await;
+
+        let (process, mut deferred_network_approval) = match process {
+            Ok((process, deferred_network_approval)) => {
+                (Arc::new(process), deferred_network_approval)
+            }
+            Err(err) => {
+                let failure = match &err {
+                    UnifiedExecError::MissingCommandLine => ToolEventFailure::Rejected {
+                        message: "missing command line for unified exec request".to_string(),
+                        applied_patch_delta: None,
+                    },
+                    UnifiedExecError::Rejected { message } => ToolEventFailure::Rejected {
+                        message: message.clone(),
+                        applied_patch_delta: None,
+                    },
+                    _ => ToolEventFailure::Message(format!("execution error: {err:?}")),
+                };
+                emitter
+                    .emit(event_ctx, ToolEventStage::Failure(failure))
+                    .await;
+                self.release_process_id(request.process_id).await;
+                return Err(err);
+            }
+        };
+        if let Some(deferred) = deferred_network_approval.as_ref() {
+            terminate_process_on_network_denial(
+                Arc::clone(&process),
+                Arc::downgrade(&context.session),
+                deferred.clone(),
+            );
+        }
 
         start_streaming_output(&process, context, Arc::clone(&transcript));
         let start = Instant::now();
@@ -1085,6 +1100,7 @@ impl UnifiedExecProcessManager {
                     };
                     UnifiedExecError::sandbox_denied(message, output)
                 }
+                ToolError::Rejected(message) => UnifiedExecError::rejected(message),
                 other => UnifiedExecError::create_process(format!("{other:?}")),
             })
     }

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -398,14 +398,13 @@ impl UnifiedExecProcessManager {
             }
             Err(err) => {
                 let failure = match &err {
-                    UnifiedExecError::MissingCommandLine => ToolEventFailure::Rejected {
-                        message: "missing command line for unified exec request".to_string(),
-                        applied_patch_delta: None,
-                    },
                     UnifiedExecError::Rejected { message } => ToolEventFailure::Rejected {
                         message: message.clone(),
                         applied_patch_delta: None,
                     },
+                    UnifiedExecError::SandboxDenied { output, .. } => {
+                        ToolEventFailure::Output(output.clone())
+                    }
                     _ => ToolEventFailure::Message(format!("execution error: {err:?}")),
                 };
                 emitter

--- a/codex-rs/core/src/unified_exec/process_manager_tests.rs
+++ b/codex-rs/core/src/unified_exec/process_manager_tests.rs
@@ -231,6 +231,73 @@ async fn failed_initial_end_for_unstored_process_uses_fallback_output() {
     );
 }
 
+#[tokio::test]
+async fn startup_rejection_emits_begin_then_declined_end() {
+    let (session, turn, rx_event) = crate::session::tests::make_session_and_context_with_rx().await;
+    let context = UnifiedExecContext::new(
+        Arc::clone(&session),
+        Arc::clone(&turn),
+        "call-unified-empty".to_string(),
+    );
+    let process_id = session
+        .services
+        .unified_exec_manager
+        .allocate_process_id()
+        .await;
+    let request = ExecCommandRequest {
+        command: Vec::new(),
+        hook_command: String::new(),
+        process_id,
+        yield_time_ms: 1000,
+        max_output_tokens: None,
+        cwd: turn.cwd.clone(),
+        environment: turn
+            .environments
+            .primary_environment()
+            .expect("primary environment"),
+        network: None,
+        tty: true,
+        sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
+        additional_permissions: None,
+        additional_permissions_preapproved: false,
+        justification: None,
+        prefix_rule: None,
+    };
+
+    let err = session
+        .services
+        .unified_exec_manager
+        .exec_command(request, &context)
+        .await
+        .expect_err("empty unified exec command should fail");
+    assert!(matches!(
+        err,
+        crate::unified_exec::UnifiedExecError::MissingCommandLine
+    ));
+
+    let begin_event = tokio::time::timeout(Duration::from_secs(1), rx_event.recv())
+        .await
+        .expect("timed out waiting for begin event")
+        .expect("event channel closed");
+    let codex_protocol::protocol::EventMsg::ExecCommandBegin(begin_event) = begin_event.msg else {
+        panic!("expected ExecCommandBegin event");
+    };
+    assert_eq!(begin_event.call_id, "call-unified-empty");
+
+    let end_event = tokio::time::timeout(Duration::from_secs(1), rx_event.recv())
+        .await
+        .expect("timed out waiting for end event")
+        .expect("event channel closed");
+    let codex_protocol::protocol::EventMsg::ExecCommandEnd(end_event) = end_event.msg else {
+        panic!("expected ExecCommandEnd event");
+    };
+    assert_eq!(end_event.call_id, "call-unified-empty");
+    assert_eq!(
+        end_event.status,
+        codex_protocol::protocol::ExecCommandStatus::Declined
+    );
+}
+
 #[test]
 fn pruning_prefers_exited_processes_outside_recently_used() {
     let now = Instant::now();

--- a/codex-rs/core/src/unified_exec/process_manager_tests.rs
+++ b/codex-rs/core/src/unified_exec/process_manager_tests.rs
@@ -271,10 +271,10 @@ async fn startup_failure_emits_begin_then_failed_end() {
         .exec_command(request, &context)
         .await
         .expect_err("empty unified exec command should fail");
-    assert!(matches!(
-        err,
-        crate::unified_exec::UnifiedExecError::MissingCommandLine
-    ));
+    assert!(
+        err.to_string().contains("missing command line for PTY"),
+        "unexpected startup error: {err}"
+    );
 
     let begin_event = tokio::time::timeout(Duration::from_secs(1), rx_event.recv())
         .await

--- a/codex-rs/core/src/unified_exec/process_manager_tests.rs
+++ b/codex-rs/core/src/unified_exec/process_manager_tests.rs
@@ -232,6 +232,7 @@ async fn failed_initial_end_for_unstored_process_uses_fallback_output() {
 }
 
 #[tokio::test]
+#[cfg_attr(target_os = "windows", ignore = "empty PTY startup hangs on windows")]
 async fn startup_failure_emits_begin_then_failed_end() {
     let (session, turn, rx_event) = crate::session::tests::make_session_and_context_with_rx().await;
     let context = UnifiedExecContext::new(

--- a/codex-rs/core/src/unified_exec/process_manager_tests.rs
+++ b/codex-rs/core/src/unified_exec/process_manager_tests.rs
@@ -251,6 +251,7 @@ async fn startup_rejection_emits_begin_then_declined_end() {
         yield_time_ms: 1000,
         max_output_tokens: None,
         cwd: turn.cwd.clone(),
+        sandbox_cwd: turn.cwd.clone(),
         environment: turn
             .environments
             .primary_environment()

--- a/codex-rs/core/src/unified_exec/process_manager_tests.rs
+++ b/codex-rs/core/src/unified_exec/process_manager_tests.rs
@@ -248,6 +248,7 @@ async fn startup_failure_emits_begin_then_failed_end() {
         codex_exec_server::Environment::create_for_tests(Some("not-a-websocket-url".to_string()))
             .expect("remote test environment"),
     );
+    #[allow(deprecated)]
     let request = ExecCommandRequest {
         command: vec!["echo".to_string(), "hello".to_string()],
         hook_command: String::new(),

--- a/codex-rs/core/src/unified_exec/process_manager_tests.rs
+++ b/codex-rs/core/src/unified_exec/process_manager_tests.rs
@@ -232,31 +232,31 @@ async fn failed_initial_end_for_unstored_process_uses_fallback_output() {
 }
 
 #[tokio::test]
-#[cfg_attr(target_os = "windows", ignore = "empty PTY startup hangs on windows")]
 async fn startup_failure_emits_begin_then_failed_end() {
     let (session, turn, rx_event) = crate::session::tests::make_session_and_context_with_rx().await;
     let context = UnifiedExecContext::new(
         Arc::clone(&session),
         Arc::clone(&turn),
-        "call-unified-empty".to_string(),
+        "call-unified-startup-failure".to_string(),
     );
     let process_id = session
         .services
         .unified_exec_manager
         .allocate_process_id()
         .await;
+    let invalid_remote = Arc::new(
+        codex_exec_server::Environment::create_for_tests(Some("not-a-websocket-url".to_string()))
+            .expect("remote test environment"),
+    );
     let request = ExecCommandRequest {
-        command: Vec::new(),
+        command: vec!["echo".to_string(), "hello".to_string()],
         hook_command: String::new(),
         process_id,
         yield_time_ms: 1000,
         max_output_tokens: None,
         cwd: turn.cwd.clone(),
         sandbox_cwd: turn.cwd.clone(),
-        environment: turn
-            .environments
-            .primary_environment()
-            .expect("primary environment"),
+        environment: invalid_remote,
         network: None,
         tty: true,
         sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
@@ -271,11 +271,8 @@ async fn startup_failure_emits_begin_then_failed_end() {
         .unified_exec_manager
         .exec_command(request, &context)
         .await
-        .expect_err("empty unified exec command should fail");
-    assert!(
-        err.to_string().contains("missing command line for PTY"),
-        "unexpected startup error: {err}"
-    );
+        .expect_err("unreachable remote exec-server should fail startup");
+    assert!(matches!(err, UnifiedExecError::CreateProcess { .. }));
 
     let begin_event = tokio::time::timeout(Duration::from_secs(1), rx_event.recv())
         .await
@@ -284,7 +281,7 @@ async fn startup_failure_emits_begin_then_failed_end() {
     let codex_protocol::protocol::EventMsg::ExecCommandBegin(begin_event) = begin_event.msg else {
         panic!("expected ExecCommandBegin event");
     };
-    assert_eq!(begin_event.call_id, "call-unified-empty");
+    assert_eq!(begin_event.call_id, "call-unified-startup-failure");
 
     let end_event = tokio::time::timeout(Duration::from_secs(1), rx_event.recv())
         .await
@@ -293,7 +290,7 @@ async fn startup_failure_emits_begin_then_failed_end() {
     let codex_protocol::protocol::EventMsg::ExecCommandEnd(end_event) = end_event.msg else {
         panic!("expected ExecCommandEnd event");
     };
-    assert_eq!(end_event.call_id, "call-unified-empty");
+    assert_eq!(end_event.call_id, "call-unified-startup-failure");
     assert_eq!(
         end_event.status,
         codex_protocol::protocol::ExecCommandStatus::Failed

--- a/codex-rs/core/src/unified_exec/process_manager_tests.rs
+++ b/codex-rs/core/src/unified_exec/process_manager_tests.rs
@@ -232,7 +232,7 @@ async fn failed_initial_end_for_unstored_process_uses_fallback_output() {
 }
 
 #[tokio::test]
-async fn startup_rejection_emits_begin_then_declined_end() {
+async fn startup_failure_emits_begin_then_failed_end() {
     let (session, turn, rx_event) = crate::session::tests::make_session_and_context_with_rx().await;
     let context = UnifiedExecContext::new(
         Arc::clone(&session),
@@ -295,7 +295,7 @@ async fn startup_rejection_emits_begin_then_declined_end() {
     assert_eq!(end_event.call_id, "call-unified-empty");
     assert_eq!(
         end_event.status,
-        codex_protocol::protocol::ExecCommandStatus::Declined
+        codex_protocol::protocol::ExecCommandStatus::Failed
     );
 }
 


### PR DESCRIPTION
## Why

When unified exec fails during startup, callers still need the same begin/end event pair they get from a started process. Without the failed end event, remote/full-ci flows can leave the tool call looking incomplete even though startup already failed.

## What changed

- emit `ExecCommandBegin` plus the appropriate failed/declined `ExecCommandEnd` when startup fails before a process is stored
- keep successful-start `ExecCommandBegin` emission after process creation so interrupt behavior does not regress
- preserve rejected and sandbox-denied startup failure semantics while surfacing generic startup failures as failed exec endings
- cover the startup-failure path with a deterministic malformed-remote fixture that stays enabled on Windows

## Stack

- [PR #22199](https://github.com/openai/codex/pull/22199) Isolate tmp-dependent tests from ambient git
- [PR #22201](https://github.com/openai/codex/pull/22201) Use remote fs for turn diff repo root
- [PR #22200](https://github.com/openai/codex/pull/22200) Emit unified exec end on startup failure
- [PR #22389](https://github.com/openai/codex/pull/22389) Stabilize remote routing e2e tests

## Validation

- Current-head CI is green.
- No local Codex test run; relying on CI for this stack.