### PR TITLE
[codex] Stop Windows sandbox setup after filter installation failure

### DIFF
--- a/codex-rs/windows-sandbox-rs/src/bin/setup_main/win.rs
+++ b/codex-rs/windows-sandbox-rs/src/bin/setup_main/win.rs
@@ -610,7 +610,13 @@ fn run_setup_full(payload: &Payload, log: &mut File, sbx_dir: &Path) -> Result<(
             |message| {
                 let _ = log_line(log, message);
             },
-        );
+        )
+        .map_err(|err| {
+            anyhow::Error::new(SetupFailure::new(
+                SetupErrorCode::HelperFirewallRuleCreateOrAddFailed,
+                format!("install WFP filters failed: {err}"),
+            ))
+        })?;
     }
 
     if payload.read_roots.is_empty() {

--- a/codex-rs/windows-sandbox-rs/src/wfp_setup.rs
+++ b/codex-rs/windows-sandbox-rs/src/wfp_setup.rs
@@ -128,48 +128,61 @@ pub fn install_wfp_filters<F>(
     offline_username: &str,
     otel: Option<&StatsigMetricsSettings>,
     mut log: F,
-) where
+) -> Result<()>
+where
     F: FnMut(&str),
 {
-    let metric = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        install_wfp_filters_for_account(offline_username)
-    })) {
+    let (metric, install_result) = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(
+        || install_wfp_filters_for_account(offline_username),
+    )) {
         Ok(Ok(installed_filter_count)) => {
             log(&format!(
                 "WFP setup succeeded for {offline_username} with {installed_filter_count} installed filters"
             ));
-            WfpSetupMetric {
-                outcome: WfpSetupMetricOutcome::Success,
-                target_account: offline_username.to_string(),
-                installed_filter_count,
-                error: None,
-            }
+            (
+                WfpSetupMetric {
+                    outcome: WfpSetupMetricOutcome::Success,
+                    target_account: offline_username.to_string(),
+                    installed_filter_count,
+                    error: None,
+                },
+                Ok(()),
+            )
         }
         Ok(Err(err)) => {
             let error = err.to_string();
-            log(&format!(
-                "WFP setup failed for {offline_username}: {error}; continuing elevated setup"
-            ));
-            WfpSetupMetric {
-                outcome: WfpSetupMetricOutcome::Failure,
-                target_account: offline_username.to_string(),
-                installed_filter_count: 0,
-                error: Some(error),
-            }
+            log(&format!("WFP setup failed for {offline_username}: {error}"));
+            (
+                WfpSetupMetric {
+                    outcome: WfpSetupMetricOutcome::Failure,
+                    target_account: offline_username.to_string(),
+                    installed_filter_count: 0,
+                    error: Some(error.clone()),
+                },
+                Err(anyhow::anyhow!(
+                    "WFP setup failed for {offline_username}: {error}"
+                )),
+            )
         }
         Err(panic_payload) => {
             let error = panic_payload_to_string(panic_payload);
             log(&format!(
-                "WFP setup panicked for {offline_username}: {error}; continuing elevated setup"
+                "WFP setup panicked for {offline_username}: {error}"
             ));
-            WfpSetupMetric {
-                outcome: WfpSetupMetricOutcome::Failure,
-                target_account: offline_username.to_string(),
-                installed_filter_count: 0,
-                error: Some(format!("panic: {error}")),
-            }
+            (
+                WfpSetupMetric {
+                    outcome: WfpSetupMetricOutcome::Failure,
+                    target_account: offline_username.to_string(),
+                    installed_filter_count: 0,
+                    error: Some(format!("panic: {error}")),
+                },
+                Err(anyhow::anyhow!(
+                    "WFP setup panicked for {offline_username}: {error}"
+                )),
+            )
         }
     };
 
     emit_wfp_setup_metric_safely(codex_home, otel, offline_username, &metric, &mut log);
+    install_result
 }


### PR DESCRIPTION
## What changed
- Treat Windows sandbox filter installation failures as setup failures.
- Preserve the existing logging and telemetry around filter installation.
- Avoid reporting offline sandbox setup as successful when its required filter setup did not complete.

## Validation
- `cargo test -p codex-windows-sandbox`
- `cargo check -p codex-windows-sandbox --target x86_64-pc-windows-msvc` attempted; blocked on this Linux host by missing MSVC tooling (`lib.exe`).
- `python3 tools/argument-comment-lint/run-prebuilt-linter.py` attempted; blocked while compiling unrelated Linux sandbox support because `libcap.pc` is unavailable in this environment.
