### PR TITLE
Speed up Windows x64 Rust tests with archive fanout

### DIFF
--- a/.github/workflows/rust-ci-full.yml
+++ b/.github/workflows/rust-ci-full.yml
@@ -757,6 +757,7 @@ jobs:
     env:
       CARGO_INCREMENTAL: "0"
       WINDOWS_X64_ARCHIVE_FILE: windows-x64-nextest-archive.tar.zst
+      WINDOWS_X64_HELPERS_ARTIFACT: windows-x64-test-helpers
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -798,11 +799,33 @@ jobs:
             --cargo-profile ci-test \
             --timings \
             --archive-file "${archive_dir}/${WINDOWS_X64_ARCHIVE_FILE}"
+      - name: Build Windows sandbox test helpers
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo build \
+            --target x86_64-pc-windows-msvc \
+            --profile ci-test \
+            -p codex-windows-sandbox \
+            --bin codex-windows-sandbox-setup \
+            --bin codex-command-runner
+
+          helper_dir="${RUNNER_TEMP}/${WINDOWS_X64_HELPERS_ARTIFACT}"
+          mkdir -p "${helper_dir}"
+          cp target/x86_64-pc-windows-msvc/ci-test/codex-windows-sandbox-setup.exe "${helper_dir}/"
+          cp target/x86_64-pc-windows-msvc/ci-test/codex-command-runner.exe "${helper_dir}/"
       - name: Upload nextest archive
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: windows-x64-nextest-archive
           path: ${{ runner.temp }}/nextest-archive/${{ env.WINDOWS_X64_ARCHIVE_FILE }}
+          if-no-files-found: error
+          retention-days: 1
+      - name: Upload Windows sandbox test helpers
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: ${{ env.WINDOWS_X64_HELPERS_ARTIFACT }}
+          path: ${{ runner.temp }}/${{ env.WINDOWS_X64_HELPERS_ARTIFACT }}/*.exe
           if-no-files-found: error
           retention-days: 1
       - name: Upload Cargo timings (nextest)
@@ -836,6 +859,7 @@ jobs:
         working-directory: codex-rs
     env:
       WINDOWS_X64_ARCHIVE_FILE: windows-x64-nextest-archive.tar.zst
+      WINDOWS_X64_HELPERS_ARTIFACT: windows-x64-test-helpers
     strategy:
       fail-fast: false
       matrix:
@@ -864,18 +888,32 @@ jobs:
         with:
           name: windows-x64-nextest-archive
           path: ${{ runner.temp }}/windows-x64-nextest-archive
+      - name: Download Windows sandbox test helpers
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ env.WINDOWS_X64_HELPERS_ARTIFACT }}
+          path: ${{ runner.temp }}/${{ env.WINDOWS_X64_HELPERS_ARTIFACT }}
       - name: tests
         id: test
         shell: bash
         run: |
           set -euo pipefail
           archive_file="${RUNNER_TEMP}/windows-x64-nextest-archive/${WINDOWS_X64_ARCHIVE_FILE}"
+          setup_helper_unix="${RUNNER_TEMP}/${WINDOWS_X64_HELPERS_ARTIFACT}/codex-windows-sandbox-setup.exe"
+          command_runner_unix="${RUNNER_TEMP}/${WINDOWS_X64_HELPERS_ARTIFACT}/codex-command-runner.exe"
+          test -f "${setup_helper_unix}"
+          test -f "${command_runner_unix}"
           workspace_root="$(cygpath -w "$(pwd)")"
           extract_dir_unix="${RUNNER_TEMP}/nextest-extract-shard-${{ matrix.shard }}"
           mkdir -p "${extract_dir_unix}"
+          setup_helper="$(cygpath -w "${setup_helper_unix}")"
+          command_runner="$(cygpath -w "${command_runner_unix}")"
           extract_dir="$(cygpath -w "${extract_dir_unix}")"
           archive_file="$(cygpath -w "${archive_file}")"
-          cargo nextest run \
+          env \
+            "CARGO_BIN_EXE_codex_windows_sandbox_setup=${setup_helper}" \
+            "CARGO_BIN_EXE_codex_command_runner=${command_runner}" \
+            cargo nextest run \
             --no-fail-fast \
             --archive-file "${archive_file}" \
             --workspace-remap "${workspace_root}" \

--- a/.github/workflows/rust-ci-full.yml
+++ b/.github/workflows/rust-ci-full.yml
@@ -559,12 +559,6 @@ jobs:
             runs_on:
               group: codex-runners
               labels: codex-linux-arm64
-          - runner: windows-x64
-            target: x86_64-pc-windows-msvc
-            profile: dev
-            runs_on:
-              group: codex-runners
-              labels: codex-windows-x64
           - runner: windows-arm64
             target: aarch64-pc-windows-msvc
             profile: dev
@@ -751,6 +745,153 @@ jobs:
           echo "Tests failed. See logs for details."
           exit 1
 
+  windows_x64_test_archive:
+    name: Build Windows x64 nextest archive
+    runs-on:
+      group: codex-runners
+      labels: codex-windows-x64
+    timeout-minutes: 45
+    defaults:
+      run:
+        working-directory: codex-rs
+    env:
+      CARGO_INCREMENTAL: "0"
+      WINDOWS_X64_ARCHIVE_FILE: windows-x64-nextest-archive.tar.zst
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@a0b273b48ed29de4470960879e8381ff45632f26 # 1.93.0
+        with:
+          targets: x86_64-pc-windows-msvc
+      - name: Compute lockfile hash
+        id: lockhash
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "hash=$(sha256sum Cargo.lock | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+          echo "toolchain_hash=$(sha256sum rust-toolchain.toml | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+      - name: Restore cargo home cache
+        id: cache_cargo_home_restore
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: cargo-home-windows-x64-x86_64-pc-windows-msvc-dev-${{ steps.lockhash.outputs.hash }}-${{ steps.lockhash.outputs.toolchain_hash }}
+          restore-keys: |
+            cargo-home-windows-x64-x86_64-pc-windows-msvc-dev-
+      - uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532 # v2.62.49
+        with:
+          tool: nextest
+          version: 0.9.103
+      - name: Build nextest archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          archive_dir="${RUNNER_TEMP}/nextest-archive"
+          mkdir -p "${archive_dir}"
+          cargo nextest archive \
+            --target x86_64-pc-windows-msvc \
+            --cargo-profile ci-test \
+            --timings \
+            --archive-file "${archive_dir}/${WINDOWS_X64_ARCHIVE_FILE}"
+      - name: Upload nextest archive
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: windows-x64-nextest-archive
+          path: ${{ runner.temp }}/nextest-archive/${{ env.WINDOWS_X64_ARCHIVE_FILE }}
+          if-no-files-found: error
+          retention-days: 1
+      - name: Upload Cargo timings (nextest)
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: cargo-timings-rust-ci-nextest-x86_64-pc-windows-msvc-dev
+          path: codex-rs/target/**/cargo-timings/cargo-timing.html
+          if-no-files-found: warn
+      - name: Save cargo home cache
+        if: always() && !cancelled() && steps.cache_cargo_home_restore.outputs.cache-hit != 'true'
+        continue-on-error: true
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: cargo-home-windows-x64-x86_64-pc-windows-msvc-dev-${{ steps.lockhash.outputs.hash }}-${{ steps.lockhash.outputs.toolchain_hash }}
+
+  windows_x64_archive_tests:
+    name: Tests — windows-x64 shard ${{ matrix.shard }}/6
+    needs: windows_x64_test_archive
+    runs-on:
+      group: codex-runners
+      labels: codex-windows-x64
+    timeout-minutes: 45
+    defaults:
+      run:
+        working-directory: codex-rs
+    env:
+      WINDOWS_X64_ARCHIVE_FILE: windows-x64-nextest-archive.tar.zst
+    strategy:
+      fail-fast: false
+      matrix:
+        shard:
+          - 1
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Install DotSlash
+        uses: facebook/install-dotslash@1e4e7b3e07eaca387acb98f1d4720e0bee8dbb6a # v2
+      - uses: dtolnay/rust-toolchain@a0b273b48ed29de4470960879e8381ff45632f26 # 1.93.0
+        with:
+          targets: x86_64-pc-windows-msvc
+      - uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532 # v2.62.49
+        with:
+          tool: nextest
+          version: 0.9.103
+      - name: Download nextest archive
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: windows-x64-nextest-archive
+          path: ${{ runner.temp }}/windows-x64-nextest-archive
+      - name: tests
+        id: test
+        shell: bash
+        run: |
+          set -euo pipefail
+          archive_file="${RUNNER_TEMP}/windows-x64-nextest-archive/${WINDOWS_X64_ARCHIVE_FILE}"
+          workspace_root="$(cygpath -w "$(pwd)")"
+          extract_dir_unix="${RUNNER_TEMP}/nextest-extract-shard-${{ matrix.shard }}"
+          mkdir -p "${extract_dir_unix}"
+          extract_dir="$(cygpath -w "${extract_dir_unix}")"
+          archive_file="$(cygpath -w "${archive_file}")"
+          cargo nextest run \
+            --no-fail-fast \
+            --archive-file "${archive_file}" \
+            --workspace-remap "${workspace_root}" \
+            --extract-to "${extract_dir}" \
+            --partition "hash:${{ matrix.shard }}/6" \
+            --test-threads 8
+        env:
+          RUST_BACKTRACE: 1
+          RUST_MIN_STACK: "8388608" # 8 MiB
+          NEXTEST_STATUS_LEVEL: leak
+      - name: verify tests passed
+        if: steps.test.outcome == 'failure'
+        run: |
+          echo "Tests failed. See logs for details."
+          exit 1
+
   # --- Gatherer job for the full post-merge workflow --------------------------
   results:
     name: Full CI results
@@ -762,6 +903,7 @@ jobs:
         argument_comment_lint_prebuilt,
         lint_build,
         tests,
+        windows_x64_archive_tests,
       ]
     if: always()
     runs-on: ubuntu-24.04
@@ -775,12 +917,14 @@ jobs:
           echo "shear  : ${{ needs.cargo_shear.result }}"
           echo "lint   : ${{ needs.lint_build.result }}"
           echo "tests  : ${{ needs.tests.result }}"
+          echo "winx64 : ${{ needs.windows_x64_archive_tests.result }}"
           [[ '${{ needs.argument_comment_lint_package.result }}' == 'success' ]] || { echo 'argument_comment_lint_package failed'; exit 1; }
           [[ '${{ needs.argument_comment_lint_prebuilt.result }}' == 'success' ]] || { echo 'argument_comment_lint_prebuilt failed'; exit 1; }
           [[ '${{ needs.general.result }}' == 'success' ]] || { echo 'general failed'; exit 1; }
           [[ '${{ needs.cargo_shear.result }}' == 'success' ]] || { echo 'cargo_shear failed'; exit 1; }
           [[ '${{ needs.lint_build.result }}' == 'success' ]] || { echo 'lint_build failed'; exit 1; }
           [[ '${{ needs.tests.result }}' == 'success' ]] || { echo 'tests failed'; exit 1; }
+          [[ '${{ needs.windows_x64_archive_tests.result }}' == 'success' ]] || { echo 'windows_x64_archive_tests failed'; exit 1; }
 
       - name: sccache summary note
         if: always()


### PR DESCRIPTION
## Summary
- replace the monolithic Windows x64 Rust test row in `rust-ci-full` with one Windows x64 `cargo nextest archive` producer plus six archive-backed Windows x64 test shards
- keep the producer and shard jobs on the default `codex-windows-x64` runner label
- wire the full-ci gatherer to the new Windows x64 shard matrix

## Why
The old Windows x64 Rust full-ci path compiled and ran tests inside one long Windows job. This change builds the nextest archive once, uploads it as a short-lived artifact, then runs partitioned test shards on separate Windows hosts.

## Evidence
- non-XL 6x8 probe run showed roughly 17m17s archive-builder-plus-shards wall time from producer start to last shard completion
- the latest pre-rebase PR run had unrelated Bazel failure; this workflow change is validated by `rust-ci-full` shape rather than local tests

## Validation
- not run locally; GitHub Actions is the validation path for this workflow-only change