### PR TITLE
app-server: test persisted active permission profile

### DIFF
--- a/codex-rs/app-server/src/request_processors/thread_processor_tests.rs
+++ b/codex-rs/app-server/src/request_processors/thread_processor_tests.rs
@@ -496,6 +496,58 @@ mod thread_processor_behavior_tests {
     }
 
     #[test]
+    fn persisted_thread_permission_state_uses_latest_turn_active_profile() {
+        let cwd = test_path_buf("/tmp/project").abs();
+        let workspace_root = test_path_buf("/tmp/workspace").abs();
+        let active_permission_profile =
+            codex_protocol::models::ActivePermissionProfile::new(":workspace");
+        let permission_profile = codex_protocol::models::PermissionProfile::workspace_write();
+
+        let history = codex_protocol::protocol::InitialHistory::Forked(vec![
+            codex_protocol::protocol::RolloutItem::TurnContext(
+                codex_protocol::protocol::TurnContextItem {
+                    turn_id: Some("turn-1".to_string()),
+                    trace_id: None,
+                    cwd: cwd.to_path_buf(),
+                    workspace_roots: vec![workspace_root.clone()],
+                    current_date: None,
+                    timezone: None,
+                    approval_policy: AskForApproval::Never,
+                    sandbox_policy: SandboxPolicy::new_workspace_write_policy(),
+                    permission_profile: Some(permission_profile.clone()),
+                    active_permission_profile: Some(active_permission_profile.clone()),
+                    network: None,
+                    file_system_sandbox_policy: None,
+                    model: "gpt-5".to_string(),
+                    personality: None,
+                    collaboration_mode: None,
+                    realtime_active: None,
+                    effort: None,
+                    summary: codex_protocol::config_types::ReasoningSummary::Auto,
+                    user_instructions: None,
+                    developer_instructions: None,
+                    final_output_json_schema: None,
+                    truncation_policy: None,
+                },
+            ),
+        ]);
+
+        let persisted = persisted_thread_permission_state(
+            &history,
+            Some(cwd.as_path()),
+            /*fallback_sandbox_policy*/ None,
+        )
+        .expect("permission state should be reconstructed");
+
+        assert_eq!(persisted.permission_profile, permission_profile);
+        assert_eq!(
+            persisted.active_permission_profile,
+            Some(active_permission_profile)
+        );
+        assert_eq!(persisted.workspace_roots, vec![workspace_root]);
+    }
+
+    #[test]
     fn config_load_error_marks_cloud_requirements_failures_for_relogin() {
         let err = std::io::Error::other(CloudRequirementsLoadError::new(
             CloudRequirementsLoadErrorCode::Auth,


### PR DESCRIPTION
## Why

This is the first focused regression-test PR split out of the permissions migration. It verifies that rollout reconstruction preserves the active named profile when the latest turn context still carries the matching canonical permission profile.

## What Changed

- Adds `persisted_thread_permission_state_uses_latest_turn_active_profile` in `app-server/src/request_processors/thread_processor_tests.rs`.
- Covers reconstructing `permission_profile`, `active_permission_profile`, and `workspace_roots` from a persisted `TurnContextItem`.

## Verification Strategy

- `cargo test -p codex-app-server persisted_thread_permission_state`






---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/22328).
* #22330
* #22329
* __->__ #22328
* #22327
* #22266