### PR TITLE
app-server: test empty workspace roots roundtrip

### DIFF
--- a/codex-rs/app-server/src/request_processors/thread_processor_tests.rs
+++ b/codex-rs/app-server/src/request_processors/thread_processor_tests.rs
@@ -548,6 +548,49 @@ mod thread_processor_behavior_tests {
     }
 
     #[test]
+    fn persisted_thread_permission_state_preserves_empty_workspace_roots_from_event_roundtrip() {
+        let cwd = test_path_buf("/tmp/project").abs();
+        let thread_id = ThreadId::from_string("67e55044-10b1-426f-9247-bb680e5fe0c8").unwrap();
+        let permission_profile = codex_protocol::models::PermissionProfile::workspace_write();
+        let event = codex_protocol::protocol::EventMsg::SessionConfigured(
+            codex_protocol::protocol::SessionConfiguredEvent {
+                session_id: thread_id.into(),
+                thread_id,
+                forked_from_id: None,
+                thread_source: None,
+                thread_name: None,
+                model: "gpt-5".to_string(),
+                model_provider_id: "mock_provider".to_string(),
+                service_tier: None,
+                approval_policy: AskForApproval::Never,
+                approvals_reviewer: codex_protocol::config_types::ApprovalsReviewer::User,
+                permission_profile: permission_profile.clone(),
+                active_permission_profile: None,
+                cwd: cwd.clone(),
+                workspace_roots: Vec::new(),
+                reasoning_effort: None,
+                initial_messages: None,
+                network_proxy: None,
+                rollout_path: None,
+            },
+        );
+        let event = serde_json::from_value(serde_json::to_value(event).unwrap()).unwrap();
+        let history = codex_protocol::protocol::InitialHistory::Forked(vec![
+            codex_protocol::protocol::RolloutItem::EventMsg(event),
+        ]);
+
+        let persisted = persisted_thread_permission_state(
+            &history,
+            Some(cwd.as_path()),
+            /*fallback_sandbox_policy*/ None,
+        )
+        .expect("permission state should be reconstructed");
+
+        assert_eq!(persisted.permission_profile, permission_profile);
+        assert_eq!(persisted.workspace_roots, Vec::<AbsolutePathBuf>::new());
+    }
+
+    #[test]
     fn config_load_error_marks_cloud_requirements_failures_for_relogin() {
         let err = std::io::Error::other(CloudRequirementsLoadError::new(
             CloudRequirementsLoadErrorCode::Auth,


### PR DESCRIPTION
## Why

This is the second focused regression-test PR split out of the permissions migration. It protects the decision that `workspaceRoots: []` is an explicit value and must not be silently replaced with `cwd` when replaying newer rollout events.

## What Changed

- Adds `persisted_thread_permission_state_preserves_empty_workspace_roots_from_event_roundtrip` in `app-server/src/request_processors/thread_processor_tests.rs`.
- Verifies that a `SessionConfiguredEvent` with empty `workspace_roots` round-trips and reconstructs as an empty workspace-root list.

## Verification Strategy

- `cargo test -p codex-app-server persisted_thread_permission_state`






---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/22329).
* #22330
* __->__ #22329
* #22328
* #22327
* #22266