### PR TITLE
Pass Codex product SKU to ChatGPT backend

### DIFF
--- a/codex-rs/chatgpt/src/chatgpt_client.rs
+++ b/codex-rs/chatgpt/src/chatgpt_client.rs
@@ -6,6 +6,9 @@ use anyhow::Context;
 use serde::de::DeserializeOwned;
 use std::time::Duration;
 
+const OAI_PRODUCT_SKU_HEADER: &str = "OAI-Product-Sku";
+const CODEX_PRODUCT_SKU: &str = "codex";
+
 /// Make a GET request to the ChatGPT backend API.
 pub(crate) async fn chatgpt_get_request<T: DeserializeOwned>(
     config: &Config,
@@ -46,6 +49,7 @@ pub(crate) async fn chatgpt_get_request_with_timeout<T: DeserializeOwned>(
     let mut request = client
         .get(&url)
         .headers(codex_model_provider::auth_provider_from_auth(&auth).to_auth_headers())
+        .header(OAI_PRODUCT_SKU_HEADER, CODEX_PRODUCT_SKU)
         .header("Content-Type", "application/json");
 
     if let Some(timeout) = timeout {


### PR DESCRIPTION
# Description

We need to set the appropriate Product SKU for full functionality for the apps endpoints for each type of client

# Testing

`./target/debug/codex --enable app`

<img width="1786" height="398" alt="CleanShot 2026-05-12 at 11 51 25@2x" src="https://github.com/user-attachments/assets/2142f768-fc72-4fcb-8f39-9bd0d8569170" />

Regular slack flows seem to work, also curling these endpoints with the correct SKU returns the right apps 