### PR TITLE
fix: default unknown tool schemas to empty schemas

### DIFF
--- a/codex-rs/core/src/tools/spec_plan_model_tests.rs
+++ b/codex-rs/core/src/tools/spec_plan_model_tests.rs
@@ -907,7 +907,7 @@ async fn search_tool_description_falls_back_to_connector_name_without_descriptio
 }
 
 #[tokio::test]
-async fn test_mcp_tool_property_missing_type_defaults_to_string() {
+async fn test_mcp_tool_property_missing_type_defaults_to_empty_schema() {
     let config = test_config().await;
     let model_info = construct_model_info_offline("gpt-5.4", &config);
     let mut features = Features::with_defaults();
@@ -950,10 +950,7 @@ async fn test_mcp_tool_property_missing_type_defaults_to_string() {
             name: "search".to_string(),
             parameters: JsonSchema::object(
                 /*properties*/
-                BTreeMap::from([(
-                    "query".to_string(),
-                    JsonSchema::string(Some("search query".to_string())),
-                )]),
+                BTreeMap::from([("query".to_string(), JsonSchema::default())]),
                 /*required*/ None,
                 /*additional_properties*/ None
             ),

--- a/codex-rs/core/src/tools/spec_tests.rs
+++ b/codex-rs/core/src/tools/spec_tests.rs
@@ -18,6 +18,8 @@ use codex_protocol::openai_models::ModelInfo;
 use codex_protocol::protocol::SessionSource;
 use codex_tools::DiscoverableTool;
 use codex_tools::JsonSchema;
+use codex_tools::JsonSchemaPrimitiveType;
+use codex_tools::JsonSchemaType;
 use codex_tools::REQUEST_PLUGIN_INSTALL_TOOL_NAME;
 use codex_tools::ResponsesApiNamespaceTool;
 use codex_tools::ResponsesApiTool;
@@ -1013,7 +1015,7 @@ async fn direct_mcp_tools_register_namespaced_handlers() {
 }
 
 #[tokio::test]
-async fn test_mcp_tool_property_missing_type_defaults_to_string() {
+async fn test_mcp_tool_property_missing_type_defaults_to_open_object() {
     let config = test_config().await;
     let model_info = construct_model_info_offline("gpt-5.4", &config);
     let mut features = Features::with_defaults();
@@ -1059,7 +1061,13 @@ async fn test_mcp_tool_property_missing_type_defaults_to_string() {
                 /*properties*/
                 BTreeMap::from([(
                     "query".to_string(),
-                    JsonSchema::string(Some("search query".to_string())),
+                    JsonSchema {
+                        schema_type: Some(JsonSchemaType::Single(JsonSchemaPrimitiveType::Object)),
+                        description: Some("search query".to_string()),
+                        properties: Some(BTreeMap::new()),
+                        additional_properties: Some(true.into()),
+                        ..Default::default()
+                    },
                 )]),
                 /*required*/ None,
                 /*additional_properties*/ None

--- a/codex-rs/tools/src/dynamic_tool_tests.rs
+++ b/codex-rs/tools/src/dynamic_tool_tests.rs
@@ -29,7 +29,15 @@ fn parse_dynamic_tool_sanitizes_input_schema() {
             input_schema: JsonSchema::object(
                 BTreeMap::from([(
                     "id".to_string(),
-                    JsonSchema::string(Some("Ticket identifier".to_string()),),
+                    JsonSchema {
+                        schema_type: Some(crate::JsonSchemaType::Single(
+                            crate::JsonSchemaPrimitiveType::Object,
+                        )),
+                        description: Some("Ticket identifier".to_string()),
+                        properties: Some(BTreeMap::new()),
+                        additional_properties: Some(true.into()),
+                        ..Default::default()
+                    },
                 )]),
                 /*required*/ None,
                 /*additional_properties*/ None

--- a/codex-rs/tools/src/dynamic_tool_tests.rs
+++ b/codex-rs/tools/src/dynamic_tool_tests.rs
@@ -27,18 +27,7 @@ fn parse_dynamic_tool_sanitizes_input_schema() {
             name: "lookup_ticket".to_string(),
             description: "Fetch a ticket".to_string(),
             input_schema: JsonSchema::object(
-                BTreeMap::from([(
-                    "id".to_string(),
-                    JsonSchema {
-                        schema_type: Some(crate::JsonSchemaType::Single(
-                            crate::JsonSchemaPrimitiveType::Object,
-                        )),
-                        description: Some("Ticket identifier".to_string()),
-                        properties: Some(BTreeMap::new()),
-                        additional_properties: Some(true.into()),
-                        ..Default::default()
-                    },
-                )]),
+                BTreeMap::from([("id".to_string(), JsonSchema::default(),)]),
                 /*required*/ None,
                 /*additional_properties*/ None
             ),

--- a/codex-rs/tools/src/json_schema.rs
+++ b/codex-rs/tools/src/json_schema.rs
@@ -228,7 +228,10 @@ fn sanitize_json_schema(value: &mut JsonValue) {
                 {
                     schema_types.push(JsonSchemaPrimitiveType::Number);
                 } else {
-                    schema_types.push(JsonSchemaPrimitiveType::String);
+                    // With no schema hints, fall back to an open object so unknown
+                    // tool argument shapes can still carry arbitrary named fields.
+                    schema_types.push(JsonSchemaPrimitiveType::Object);
+                    map.insert("additionalProperties".to_string(), JsonValue::Bool(true));
                 }
             }
 

--- a/codex-rs/tools/src/json_schema.rs
+++ b/codex-rs/tools/src/json_schema.rs
@@ -166,6 +166,7 @@ pub fn parse_tool_input_schema(input_schema: &JsonValue) -> Result<JsonSchema, s
 /// - Collapses `const` into single-value `enum`.
 /// - Fills required child fields for object/array schema types, including
 ///   nullable unions, with permissive defaults when absent.
+/// - Coerces object schemas with no recognized schema hints into `{}`.
 fn sanitize_json_schema(value: &mut JsonValue) {
     match value {
         JsonValue::Bool(_) => {
@@ -228,10 +229,8 @@ fn sanitize_json_schema(value: &mut JsonValue) {
                 {
                     schema_types.push(JsonSchemaPrimitiveType::Number);
                 } else {
-                    // With no schema hints, fall back to an open object so unknown
-                    // tool argument shapes can still carry arbitrary named fields.
-                    schema_types.push(JsonSchemaPrimitiveType::Object);
-                    map.insert("additionalProperties".to_string(), JsonValue::Bool(true));
+                    map.clear();
+                    return;
                 }
             }
 

--- a/codex-rs/tools/src/json_schema_tests.rs
+++ b/codex-rs/tools/src/json_schema_tests.rs
@@ -34,7 +34,7 @@ fn parse_tool_input_schema_infers_object_shape_and_defaults_properties() {
     //
     // Expected normalization behavior:
     // - `properties` implies an object schema when `type` is omitted.
-    // - The child property keeps its description and defaults to a string type.
+    // - The child property keeps its description and defaults to an open object.
     let schema = parse_tool_input_schema(&serde_json::json!({
         "properties": {
             "query": {"description": "search query"}
@@ -47,7 +47,13 @@ fn parse_tool_input_schema_infers_object_shape_and_defaults_properties() {
         JsonSchema::object(
             BTreeMap::from([(
                 "query".to_string(),
-                JsonSchema::string(Some("search query".to_string())),
+                JsonSchema {
+                    schema_type: Some(JsonSchemaType::Single(JsonSchemaPrimitiveType::Object)),
+                    description: Some("search query".to_string()),
+                    properties: Some(BTreeMap::new()),
+                    additional_properties: Some(true.into()),
+                    ..Default::default()
+                },
             )]),
             /*required*/ None,
             /*additional_properties*/ None
@@ -250,16 +256,73 @@ fn parse_tool_input_schema_infers_string_from_enum_const_and_format_keywords() {
 }
 
 #[test]
-fn parse_tool_input_schema_defaults_empty_schema_to_string() {
+fn parse_tool_input_schema_defaults_empty_schema_to_open_object() {
     // Example schema shape:
     // {}
     //
     // Expected normalization behavior:
     // - With no structural hints at all, the normalizer falls back to a
-    //   permissive string schema.
+    //   permissive object schema.
     let schema = parse_tool_input_schema(&serde_json::json!({})).expect("parse schema");
 
-    assert_eq!(schema, JsonSchema::string(/*description*/ None));
+    assert_eq!(
+        schema,
+        JsonSchema::object(BTreeMap::new(), /*required*/ None, Some(true.into()))
+    );
+}
+
+#[test]
+fn parse_tool_input_schema_defaults_nested_empty_schema_to_open_object() {
+    // Example schema shape:
+    // {
+    //   "type": "object",
+    //   "properties": {
+    //     "metadata": {
+    //       "properties": {
+    //         "extra": {}
+    //       }
+    //     }
+    //   }
+    // }
+    //
+    // Expected normalization behavior:
+    // - The sanitizer recurses through nested object properties.
+    // - The innermost `extra` field has no hints, so it falls back to an open
+    //   object.
+    let schema = parse_tool_input_schema(&serde_json::json!({
+        "type": "object",
+        "properties": {
+            "metadata": {
+                "properties": {
+                    "extra": {}
+                }
+            }
+        }
+    }))
+    .expect("parse schema");
+
+    assert_eq!(
+        schema,
+        JsonSchema::object(
+            BTreeMap::from([(
+                "metadata".to_string(),
+                JsonSchema::object(
+                    BTreeMap::from([(
+                        "extra".to_string(),
+                        JsonSchema::object(
+                            BTreeMap::new(),
+                            /*required*/ None,
+                            Some(true.into()),
+                        ),
+                    )]),
+                    /*required*/ None,
+                    /*additional_properties*/ None,
+                )
+            )]),
+            /*required*/ None,
+            /*additional_properties*/ None,
+        )
+    );
 }
 
 #[test]

--- a/codex-rs/tools/src/json_schema_tests.rs
+++ b/codex-rs/tools/src/json_schema_tests.rs
@@ -34,7 +34,8 @@ fn parse_tool_input_schema_infers_object_shape_and_defaults_properties() {
     //
     // Expected normalization behavior:
     // - `properties` implies an object schema when `type` is omitted.
-    // - The child property keeps its description and defaults to an open object.
+    // - The child property has no recognized schema hints, so it is coerced to
+    //   an empty permissive schema.
     let schema = parse_tool_input_schema(&serde_json::json!({
         "properties": {
             "query": {"description": "search query"}
@@ -45,20 +46,31 @@ fn parse_tool_input_schema_infers_object_shape_and_defaults_properties() {
     assert_eq!(
         schema,
         JsonSchema::object(
-            BTreeMap::from([(
-                "query".to_string(),
-                JsonSchema {
-                    schema_type: Some(JsonSchemaType::Single(JsonSchemaPrimitiveType::Object)),
-                    description: Some("search query".to_string()),
-                    properties: Some(BTreeMap::new()),
-                    additional_properties: Some(true.into()),
-                    ..Default::default()
-                },
-            )]),
+            BTreeMap::from([("query".to_string(), JsonSchema::default())]),
             /*required*/ None,
             /*additional_properties*/ None
         )
     );
+}
+
+#[test]
+fn parse_tool_input_schema_coerces_unrecognized_object_schema_to_empty_schema() {
+    // Example schema shape:
+    // {
+    //   "description": "Ticket identifier",
+    //   "title": "Ticket ID"
+    // }
+    //
+    // Expected normalization behavior:
+    // - Object schemas with no recognized schema hints are treated as
+    //   malformed and coerced to the empty permissive schema.
+    let schema = parse_tool_input_schema(&serde_json::json!({
+        "description": "Ticket identifier",
+        "title": "Ticket ID"
+    }))
+    .expect("parse schema");
+
+    assert_eq!(schema, JsonSchema::default());
 }
 
 #[test]
@@ -256,23 +268,20 @@ fn parse_tool_input_schema_infers_string_from_enum_const_and_format_keywords() {
 }
 
 #[test]
-fn parse_tool_input_schema_defaults_empty_schema_to_open_object() {
+fn parse_tool_input_schema_preserves_empty_schema() {
     // Example schema shape:
     // {}
     //
     // Expected normalization behavior:
-    // - With no structural hints at all, the normalizer falls back to a
-    //   permissive object schema.
+    // - An empty JSON Schema is already a valid permissive schema, so it stays
+    //   empty rather than being rewritten as an object schema.
     let schema = parse_tool_input_schema(&serde_json::json!({})).expect("parse schema");
 
-    assert_eq!(
-        schema,
-        JsonSchema::object(BTreeMap::new(), /*required*/ None, Some(true.into()))
-    );
+    assert_eq!(schema, JsonSchema::default());
 }
 
 #[test]
-fn parse_tool_input_schema_defaults_nested_empty_schema_to_open_object() {
+fn parse_tool_input_schema_preserves_nested_empty_schema() {
     // Example schema shape:
     // {
     //   "type": "object",
@@ -287,8 +296,7 @@ fn parse_tool_input_schema_defaults_nested_empty_schema_to_open_object() {
     //
     // Expected normalization behavior:
     // - The sanitizer recurses through nested object properties.
-    // - The innermost `extra` field has no hints, so it falls back to an open
-    //   object.
+    // - The innermost `extra` field is an empty JSON Schema and stays empty.
     let schema = parse_tool_input_schema(&serde_json::json!({
         "type": "object",
         "properties": {
@@ -307,14 +315,7 @@ fn parse_tool_input_schema_defaults_nested_empty_schema_to_open_object() {
             BTreeMap::from([(
                 "metadata".to_string(),
                 JsonSchema::object(
-                    BTreeMap::from([(
-                        "extra".to_string(),
-                        JsonSchema::object(
-                            BTreeMap::new(),
-                            /*required*/ None,
-                            Some(true.into()),
-                        ),
-                    )]),
+                    BTreeMap::from([("extra".to_string(), JsonSchema::default())]),
                     /*required*/ None,
                     /*additional_properties*/ None,
                 )


### PR DESCRIPTION
## Why

Some tool providers, especially MCP servers and dynamic tool sources, can supply schema nodes that omit `type` and have no recognized JSON Schema shape hints. Previously, `sanitize_json_schema` filled those unknown nodes in as `string`, which made the schema parseable but invented a scalar constraint that the provider did not specify. For description-only fields, that could incorrectly steer tool arguments away from the provider's actual accepted shape.

The Responses API accepts permissive empty schemas such as `{}` at nested property positions, so Codex should preserve that permissive meaning instead of coercing unknown schema nodes into a misleading scalar type.

## What Changed

- Changed the no-hints fallback in `codex-rs/tools/src/json_schema.rs` to clear unrecognized object schema nodes to `{}`.
- Empty schemas now remain `{}` rather than becoming `type: "string"`.
- Description-only or otherwise metadata-only nested property schemas now become `{}` while surrounding object/array/string/number inference still applies when recognized hints are present.
- Updated `codex-tools` and `codex-core` tests to cover top-level empty schemas, nested empty schemas, metadata-only malformed schemas, dynamic tools, and MCP tool specs.

## Verification

- `cargo test -p codex-tools`
- `cargo test -p codex-core test_mcp_tool_property_missing_type_defaults_to_empty_schema`
- Manually verified the real Responses API behavior for both empty-schema positions:
  - Top-level function `parameters: {}` is accepted and echoed back as `{"type":"object","properties":{}}`; when forced to call the tool, Responses emitted empty object arguments: `"arguments": "{}"`.
  - Nested property schema `{}` is accepted and preserved as `{}`; when forced to call a tool with `metadata.extra`, Responses emitted `"arguments": "{\"metadata\":{\"extra\":\"codex schema sanitizer behavior\"}}"`.
