### PR TITLE
test(tui): relax configured pet load timeout

### DIFF
--- a/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
+++ b/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
@@ -434,7 +434,7 @@ async fn configured_pet_load_is_deferred_until_after_construction() {
     let chat = ChatWidget::new_with_app_event(init);
 
     assert!(!chat.ambient_pet_image_enabled());
-    let event = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+    let event = tokio::time::timeout(std::time::Duration::from_secs(/*secs*/ 30), rx.recv())
         .await
         .unwrap()
         .unwrap();


### PR DESCRIPTION
## Why

Windows CI has been timing out in `configured_pet_load_is_deferred_until_after_construction` while waiting for the deferred configured-pet load event.

The test still needs to prove construction returns before the pet image is available, but the background load slices the built-in pet spritesheet into frame cache files. That work can exceed the old 2 second deadline on slower or more contended CI machines.

## What Changed

- Increased the test wait for `ConfiguredPetLoaded` from 2 seconds to 30 seconds.
- Kept the post-construction assertion intact so the test still verifies that the pet is not loaded synchronously during `ChatWidget` construction.

## How to Test

Targeted tests:
- `cargo test -p codex-tui configured_pet_load_is_deferred_until_after_construction`
- `just argument-comment-lint`

Additional check:
- `cargo test -p codex-tui` was run, but the broader crate suite did not complete successfully due to unrelated existing failures:
  - `status::tests::status_permissions_full_disk_managed_without_network_is_external_sandbox`
  - `status::tests::status_permissions_full_disk_managed_with_network_is_danger_full_access`
  - later abort in `tests::fork_last_filters_latest_session_by_cwd_unless_show_all` from stack overflow
