### PR TITLE
[codex] Fix macOS sandbox platform allowances for document rendering

### DIFF
--- a/codex-rs/sandboxing/src/seatbelt_base_policy.sbpl
+++ b/codex-rs/sandboxing/src/seatbelt_base_policy.sbpl
@@ -55,7 +55,9 @@
   (sysctl-name "hw.vectorunit")
   (sysctl-name "machdep.cpu.brand_string")
   (sysctl-name "kern.argmax")
+  (sysctl-name "kern.bootargs")
   (sysctl-name "kern.hostname")
+  (sysctl-name "kern.iossupportversion")
   (sysctl-name "kern.maxfilesperproc")
   (sysctl-name "kern.maxproc")
   (sysctl-name "kern.osproductversion")
@@ -66,6 +68,8 @@
   (sysctl-name "kern.secure_kernel")
   (sysctl-name "kern.usrstack64")
   (sysctl-name "kern.version")
+  (sysctl-name "kern.willshutdown")
+  (sysctl-name "security.mac.lockdown_mode_state")
   (sysctl-name "sysctl.proc_cputype")
   (sysctl-name "vm.loadavg")
   (sysctl-name-prefix "hw.perflevel")
@@ -102,6 +106,16 @@
   (global-name "com.apple.PowerManagement.control")
 )
 
+; AppKit and CoreServices can be initialized by app-bundle CLIs even when
+; running in headless modes such as document conversion.
+(allow mach-lookup
+  (global-name "com.apple.CoreServices.coreservicesd")
+  (global-name "com.apple.coreservices.launchservicesd")
+  (global-name "com.apple.hiservices-xpcservice")
+  (global-name "com.apple.lsd.mapdb")
+  (global-name "com.apple.windowserver.active")
+)
+
 ; allow openpty()
 (allow pseudo-tty)
 (allow file-read* file-write* file-ioctl (literal "/dev/ptmx"))
@@ -120,3 +134,8 @@
   (global-name "com.apple.cfprefsd.agent")
   (local-name "com.apple.cfprefsd.agent"))
 (allow user-preference-read)
+
+; LibreOffice uses a single-instance AF_UNIX pipe named OSL_PIPE_* under
+; /private/tmp even for headless document conversion.
+(allow system-socket (socket-domain AF_UNIX))
+(allow network-bind (prefix "/private/tmp/OSL_PIPE_"))

--- a/codex-rs/sandboxing/src/seatbelt_base_policy.sbpl
+++ b/codex-rs/sandboxing/src/seatbelt_base_policy.sbpl
@@ -55,9 +55,7 @@
   (sysctl-name "hw.vectorunit")
   (sysctl-name "machdep.cpu.brand_string")
   (sysctl-name "kern.argmax")
-  (sysctl-name "kern.bootargs")
   (sysctl-name "kern.hostname")
-  (sysctl-name "kern.iossupportversion")
   (sysctl-name "kern.maxfilesperproc")
   (sysctl-name "kern.maxproc")
   (sysctl-name "kern.osproductversion")
@@ -68,8 +66,6 @@
   (sysctl-name "kern.secure_kernel")
   (sysctl-name "kern.usrstack64")
   (sysctl-name "kern.version")
-  (sysctl-name "kern.willshutdown")
-  (sysctl-name "security.mac.lockdown_mode_state")
   (sysctl-name "sysctl.proc_cputype")
   (sysctl-name "vm.loadavg")
   (sysctl-name-prefix "hw.perflevel")
@@ -106,13 +102,10 @@
   (global-name "com.apple.PowerManagement.control")
 )
 
-; AppKit and CoreServices can be initialized by app-bundle CLIs even when
-; running in headless modes such as document conversion.
+; LibreOffice initializes AppKit/CoreServices even for headless document
+; conversion. Keep this to the services observed as required for that flow.
 (allow mach-lookup
-  (global-name "com.apple.CoreServices.coreservicesd")
   (global-name "com.apple.coreservices.launchservicesd")
-  (global-name "com.apple.hiservices-xpcservice")
-  (global-name "com.apple.lsd.mapdb")
   (global-name "com.apple.windowserver.active")
 )
 

--- a/codex-rs/sandboxing/src/seatbelt_tests.rs
+++ b/codex-rs/sandboxing/src/seatbelt_tests.rs
@@ -141,14 +141,7 @@ fn full_disk_read_policy_keeps_appkit_platform_ipc_allowances() {
     );
 
     for required in [
-        "(sysctl-name \"kern.bootargs\")",
-        "(sysctl-name \"kern.iossupportversion\")",
-        "(sysctl-name \"kern.willshutdown\")",
-        "(sysctl-name \"security.mac.lockdown_mode_state\")",
-        "(global-name \"com.apple.CoreServices.coreservicesd\")",
         "(global-name \"com.apple.coreservices.launchservicesd\")",
-        "(global-name \"com.apple.hiservices-xpcservice\")",
-        "(global-name \"com.apple.lsd.mapdb\")",
         "(global-name \"com.apple.windowserver.active\")",
         "(allow system-socket (socket-domain AF_UNIX))",
         "(allow network-bind (prefix \"/private/tmp/OSL_PIPE_\"))",
@@ -160,6 +153,13 @@ fn full_disk_read_policy_keeps_appkit_platform_ipc_allowances() {
     }
 
     for overly_broad in [
+        "(sysctl-name \"kern.bootargs\")",
+        "(sysctl-name \"kern.iossupportversion\")",
+        "(sysctl-name \"kern.willshutdown\")",
+        "(sysctl-name \"security.mac.lockdown_mode_state\")",
+        "(global-name \"com.apple.CoreServices.coreservicesd\")",
+        "(global-name \"com.apple.hiservices-xpcservice\")",
+        "(global-name \"com.apple.lsd.mapdb\")",
         "(global-name \"com.apple.windowserver\")",
         "(global-name \"com.apple.ViewBridgeAuxiliary\")",
         "(allow network-bind (local unix-socket (subpath \"/private/tmp\")))",

--- a/codex-rs/sandboxing/src/seatbelt_tests.rs
+++ b/codex-rs/sandboxing/src/seatbelt_tests.rs
@@ -1,5 +1,6 @@
 use super::CreateSeatbeltCommandArgsParams;
 use super::MACOS_PATH_TO_SEATBELT_EXECUTABLE;
+use super::MACOS_RESTRICTED_READ_ONLY_PLATFORM_DEFAULTS;
 use super::MACOS_SEATBELT_BASE_POLICY;
 use super::ProxyPolicyInputs;
 use super::UnixDomainSocketPolicy;
@@ -106,6 +107,69 @@ fn base_policy_allows_node_cpu_sysctls() {
         MACOS_SEATBELT_BASE_POLICY.contains("(sysctl-name \"hw.model\")"),
         "base policy must allow hardware model lookup for os.cpus()"
     );
+}
+
+#[test]
+fn full_disk_read_policy_keeps_appkit_platform_ipc_allowances() {
+    let cwd = TempDir::new().expect("temp cwd");
+    let file_system_policy = FileSystemSandboxPolicy::workspace_write(
+        &[],
+        /*exclude_tmpdir_env_var*/ false,
+        /*exclude_slash_tmp*/ false,
+    );
+    assert!(file_system_policy.has_full_disk_read_access());
+    assert!(!file_system_policy.include_platform_defaults());
+
+    let args = create_seatbelt_command_args(CreateSeatbeltCommandArgsParams {
+        command: vec!["/usr/bin/true".to_string()],
+        file_system_sandbox_policy: &file_system_policy,
+        network_sandbox_policy: NetworkSandboxPolicy::Restricted,
+        sandbox_policy_cwd: cwd.path(),
+        enforce_managed_network: false,
+        network: None,
+        extra_allow_unix_sockets: &[],
+    });
+    let policy = seatbelt_policy_arg(&args);
+
+    assert!(
+        policy.contains("; allow read-only file operations\n(allow file-read*)"),
+        "workspace-write policy should retain full-disk read access:\n{policy}"
+    );
+    assert!(
+        !policy.contains(MACOS_RESTRICTED_READ_ONLY_PLATFORM_DEFAULTS),
+        "full-disk read policy should skip restricted read-only platform defaults:\n{policy}"
+    );
+
+    for required in [
+        "(sysctl-name \"kern.bootargs\")",
+        "(sysctl-name \"kern.iossupportversion\")",
+        "(sysctl-name \"kern.willshutdown\")",
+        "(sysctl-name \"security.mac.lockdown_mode_state\")",
+        "(global-name \"com.apple.CoreServices.coreservicesd\")",
+        "(global-name \"com.apple.coreservices.launchservicesd\")",
+        "(global-name \"com.apple.hiservices-xpcservice\")",
+        "(global-name \"com.apple.lsd.mapdb\")",
+        "(global-name \"com.apple.windowserver.active\")",
+        "(allow system-socket (socket-domain AF_UNIX))",
+        "(allow network-bind (prefix \"/private/tmp/OSL_PIPE_\"))",
+    ] {
+        assert!(
+            policy.contains(required),
+            "workspace-write policy should include {required} from base policy:\n{policy}"
+        );
+    }
+
+    for overly_broad in [
+        "(global-name \"com.apple.windowserver\")",
+        "(global-name \"com.apple.ViewBridgeAuxiliary\")",
+        "(allow network-bind (local unix-socket (subpath \"/private/tmp\")))",
+        "(allow network-outbound (remote unix-socket (subpath \"/private/tmp\")))",
+    ] {
+        assert!(
+            !policy.contains(overly_broad),
+            "workspace-write policy should not include overly broad allowance {overly_broad}:\n{policy}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fix macOS Seatbelt policy generation for document rendering tools such as LibreOffice that initialize AppKit/CoreServices even when running headless.

`workspace-write` has full-disk file read access, so Codex intentionally skips `restricted_read_only_platform_defaults.sbpl`. That part is still correct for file reads, but it meant non-file macOS platform permissions were also skipped. This moves the minimal observed required platform allowances into the always-on base policy without broadening file access.

After local exploration prompted by review feedback, the base-policy additions are narrowed to:
- `com.apple.coreservices.launchservicesd`
- `com.apple.windowserver.active`
- LibreOffice's `/private/tmp/OSL_PIPE_*` AF_UNIX bind pattern only

The follow-up exploration found these initially proposed allowances were not required for the repro and are no longer added:
- `kern.bootargs`
- `kern.iossupportversion`
- `kern.willshutdown`
- `security.mac.lockdown_mode_state`
- `com.apple.CoreServices.coreservicesd`
- `com.apple.hiservices-xpcservice`
- `com.apple.lsd.mapdb`

The regression test verifies `workspace-write` still has full-disk read and still skips the restricted defaults, while retaining the remaining base allowances. It also checks that broader WindowServer/ViewBridge/temp-socket rules and the removed noisy allowances are not present.

## Risk notes

The revised set is smaller, but the remaining permissions are still sensitive. The local matrix showed `launchservicesd` avoids the abort, `windowserver.active` avoids a hang, and the `OSL_PIPE_*` bind is required for LibreOffice to produce output. It does not by itself prove these belong in always-on base policy versus a narrower document-rendering path, so keeping this as draft for sandbox review.

Renderer-side alternatives tested and found insufficient:
- `SAL_USE_VCLPLUGIN=svp`
- `--nolockcheck --nodefault --nologo --nofirststartwizard`

## Testing

- `just fmt`
- `RUSTUP_TOOLCHAIN=1.93.1 cargo test -p codex-sandboxing`
- `RUSTUP_TOOLCHAIN=1.93.1 cargo build -p codex-cli --bin codex`
- Verified the real Documents `render_docx.py` command succeeds under revised `codex sandbox macos --permissions-profile :workspace`
- Verified output artifacts under `/private/tmp/codex-lo-repro/revised-pr-policy-render`: `python-docx-minimal.pdf`, `page-1.png`
- `just fix -p codex-sandboxing`
- `git diff --check`