### PR TITLE
[codex] isolate plugin/list from config serialization queue

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol/common.rs
+++ b/codex-rs/app-server-protocol/src/protocol/common.rs
@@ -621,7 +621,7 @@ client_request_definitions! {
     },
     PluginList => "plugin/list" {
         params: v2::PluginListParams,
-        serialization: global_shared_read("config"),
+        serialization: global_shared_read("plugin-list"),
         response: v2::PluginListResponse,
     },
     PluginRead => "plugin/read" {
@@ -1685,7 +1685,9 @@ mod tests {
         };
         assert_eq!(
             plugin_list.serialization_scope(),
-            Some(ClientRequestSerializationScope::GlobalSharedRead("config"))
+            Some(ClientRequestSerializationScope::GlobalSharedRead(
+                "plugin-list"
+            ))
         );
 
         let plugin_uninstall = ClientRequest::PluginUninstall {

--- a/codex-rs/app-server-protocol/src/protocol/common.rs
+++ b/codex-rs/app-server-protocol/src/protocol/common.rs
@@ -626,7 +626,7 @@ client_request_definitions! {
     },
     PluginRead => "plugin/read" {
         params: v2::PluginReadParams,
-        serialization: global("config"),
+        serialization: global_shared_read("plugin-list"),
         response: v2::PluginReadResponse,
     },
     PluginSkillRead => "plugin/skill/read" {
@@ -1685,6 +1685,21 @@ mod tests {
         };
         assert_eq!(
             plugin_list.serialization_scope(),
+            Some(ClientRequestSerializationScope::GlobalSharedRead(
+                "plugin-list"
+            ))
+        );
+
+        let plugin_read = ClientRequest::PluginRead {
+            request_id: request_id(),
+            params: v2::PluginReadParams {
+                marketplace_path: Some(absolute_path("/tmp/marketplace")),
+                remote_marketplace_name: None,
+                plugin_name: "plugin-a".to_string(),
+            },
+        };
+        assert_eq!(
+            plugin_read.serialization_scope(),
             Some(ClientRequestSerializationScope::GlobalSharedRead(
                 "plugin-list"
             ))

--- a/codex-rs/app-server-protocol/src/protocol/common.rs
+++ b/codex-rs/app-server-protocol/src/protocol/common.rs
@@ -621,12 +621,12 @@ client_request_definitions! {
     },
     PluginList => "plugin/list" {
         params: v2::PluginListParams,
-        serialization: global_shared_read("plugin-list"),
+        serialization: global_shared_read("plugin-read"),
         response: v2::PluginListResponse,
     },
     PluginRead => "plugin/read" {
         params: v2::PluginReadParams,
-        serialization: global_shared_read("plugin-list"),
+        serialization: global_shared_read("plugin-read"),
         response: v2::PluginReadResponse,
     },
     PluginSkillRead => "plugin/skill/read" {
@@ -1686,7 +1686,7 @@ mod tests {
         assert_eq!(
             plugin_list.serialization_scope(),
             Some(ClientRequestSerializationScope::GlobalSharedRead(
-                "plugin-list"
+                "plugin-read"
             ))
         );
 
@@ -1701,7 +1701,7 @@ mod tests {
         assert_eq!(
             plugin_read.serialization_scope(),
             Some(ClientRequestSerializationScope::GlobalSharedRead(
-                "plugin-list"
+                "plugin-read"
             ))
         );
 


### PR DESCRIPTION
## Summary
- move `plugin/list` from the shared `config` read queue onto a dedicated `plugin-list` shared-read queue
- move `plugin/read` onto that same dedicated shared-read queue as well
- keep the existing scheduler behavior unchanged
- allow plugin list/read operations to proceed independently of config-family writes, accepting temporary stale or transient read errors during concurrent mutations

## Validation
- `just fmt`
- `cargo test -p codex-app-server-protocol`