### PR TITLE
fix: prevent fmt from updating Python SDK lockfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -33,8 +33,8 @@ app-server-test-client *args:
 # Format Rust and Python SDK code.
 fmt:
     cargo fmt -- --config imports_granularity=Item 2>/dev/null
-    uv run --project ../sdk/python --extra dev ruff check --fix --fix-only ../sdk/python
-    uv run --project ../sdk/python --extra dev ruff format ../sdk/python
+    uv run --frozen --project ../sdk/python --extra dev ruff check --fix --fix-only ../sdk/python
+    uv run --frozen --project ../sdk/python --extra dev ruff format ../sdk/python
 
 fix *args:
     cargo clippy --fix --tests --allow-dirty "$@"

--- a/sdk/python/tests/test_artifact_workflow_and_binaries.py
+++ b/sdk/python/tests/test_artifact_workflow_and_binaries.py
@@ -66,8 +66,8 @@ def test_root_fmt_recipe_formats_rust_and_python_sdk() -> None:
         "previous_attribute": "# Format Rust and Python SDK code.",
         "commands": [
             "cargo fmt -- --config imports_granularity=Item 2>/dev/null",
-            "uv run --project ../sdk/python --extra dev ruff check --fix --fix-only ../sdk/python",
-            "uv run --project ../sdk/python --extra dev ruff format ../sdk/python",
+            "uv run --frozen --project ../sdk/python --extra dev ruff check --fix --fix-only ../sdk/python",
+            "uv run --frozen --project ../sdk/python --extra dev ruff format ../sdk/python",
         ],
     }
 


### PR DESCRIPTION
## Why

`just fmt` should align source formatting without resolving dependencies or rewriting lockfiles. The Python SDK formatting steps run through `uv`, so differing local `uv` versions could decide the SDK lock was stale and mutate `sdk/python/uv.lock` before Ruff ran.

## What

- Add `--frozen` to both Python SDK `uv run ... ruff` commands in the root `fmt` recipe.
- Update the existing Python SDK artifact workflow guard test so future changes keep the formatter recipe non-lock-mutating.

## Verification

- `uv run --frozen --project ../sdk/python --extra dev pytest ../sdk/python/tests/test_artifact_workflow_and_binaries.py -q`