### PR TITLE
Normalize feature aliases during config merge

### DIFF
--- a/codex-rs/config/src/key_aliases.rs
+++ b/codex-rs/config/src/key_aliases.rs
@@ -1,6 +1,9 @@
 use toml::Value as TomlValue;
 use toml::map::Map as TomlMap;
 
+use codex_features::canonical_feature_for_key;
+use codex_features::feature_for_key;
+
 #[derive(Debug, Clone, Copy)]
 struct ConfigKeyAlias {
     table_path: &'static [&'static str],
@@ -26,6 +29,29 @@ pub(crate) fn normalize_key_aliases(path: &[String], table: &mut TomlMap<String,
                 .entry(alias.canonical_key.to_string())
                 .or_insert(value);
         }
+    }
+
+    if path.iter().map(String::as_str).eq(["features"]) {
+        normalize_feature_key_aliases(table);
+    }
+}
+
+fn normalize_feature_key_aliases(table: &mut TomlMap<String, TomlValue>) {
+    let legacy_keys: Vec<String> = table
+        .keys()
+        .filter(|key| canonical_feature_for_key(key).is_none())
+        .filter(|key| feature_for_key(key).is_some())
+        .cloned()
+        .collect();
+
+    for legacy_key in legacy_keys {
+        let Some(value) = table.remove(&legacy_key) else {
+            continue;
+        };
+        let Some(feature) = feature_for_key(&legacy_key) else {
+            continue;
+        };
+        table.entry(feature.key().to_string()).or_insert(value);
     }
 }
 

--- a/codex-rs/config/src/merge_tests.rs
+++ b/codex-rs/config/src/merge_tests.rs
@@ -98,3 +98,55 @@ disable_on_external_context = true
     );
     assert_eq!(base, expected);
 }
+
+#[test]
+fn merge_toml_values_normalizes_legacy_feature_key_from_overlay_layer() {
+    let mut base = parse_toml(
+        r#"
+[features]
+hooks = true
+"#,
+    );
+    let overlay = parse_toml(
+        r#"
+[features]
+codex_hooks = false
+"#,
+    );
+
+    merge_toml_values(&mut base, &overlay);
+
+    let expected = parse_toml(
+        r#"
+[features]
+hooks = false
+"#,
+    );
+    assert_eq!(base, expected);
+}
+
+#[test]
+fn merge_toml_values_normalizes_legacy_feature_key_from_base_layer() {
+    let mut base = parse_toml(
+        r#"
+[features]
+codex_hooks = true
+"#,
+    );
+    let overlay = parse_toml(
+        r#"
+[features]
+hooks = false
+"#,
+    );
+
+    merge_toml_values(&mut base, &overlay);
+
+    let expected = parse_toml(
+        r#"
+[features]
+hooks = false
+"#,
+    );
+    assert_eq!(base, expected);
+}


### PR DESCRIPTION
## What
- normalize legacy feature aliases inside `[features]` during config merge
- add regression tests for mixed canonical/legacy feature keys across config layers

## Why
We hit a config-merging bug where user config used `hooks = true` while project config used the legacy alias `codex_hooks = false`. Both keys survived the layer merge, then later resolved to the same feature in sorted-map order, so the canonical `hooks = true` entry won and re-enabled hooks. In practice that caused Codex to ignore the project-local hook disable and prompt to trust repo hooks.

## How
- canonicalize legacy feature keys in `[features]` before merged config layers are applied
- keep the existing "prefer canonical when both exist" behavior within a single table
- cover both overlay/base legacy-vs-canonical combinations in merge tests

## Validation
- `just fix -p codex-config`
- `cargo test -p codex-config merge_toml_values_normalizes_legacy_feature_key`

Issue: none