### PR TITLE
Add derived default cwd helper

### DIFF
--- a/codex-rs/core/src/session/handlers.rs
+++ b/codex-rs/core/src/session/handlers.rs
@@ -699,8 +699,7 @@ pub async fn review(
         .await;
     sess.refresh_mcp_servers_if_requested(&turn_context, Some(sess.mcp_elicitation_reviewer()))
         .await;
-    #[allow(deprecated)]
-    match resolve_review_request(review_request, &turn_context.cwd) {
+    match resolve_review_request(review_request, turn_context.default_cwd()) {
         Ok(resolved) => {
             spawn_review_thread(
                 Arc::clone(sess),

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -2051,8 +2051,7 @@ impl Session {
             turn_context,
             call_id,
             args,
-            #[allow(deprecated)]
-            turn_context.cwd.clone(),
+            turn_context.default_cwd().clone(),
             cancellation_token,
         )
         .await
@@ -2631,8 +2630,7 @@ impl Session {
                     turn_context.approval_policy.value(),
                     turn_context.config.approvals_reviewer,
                     self.services.exec_policy.current().as_ref(),
-                    #[allow(deprecated)]
-                    &turn_context.cwd,
+                    turn_context.default_cwd(),
                     turn_context
                         .features
                         .enabled(Feature::ExecPermissionApprovals),

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -366,9 +366,8 @@ pub(crate) async fn run_turn(
     let mut stop_hook_active = false;
     // Although from the perspective of codex.rs, TurnDiffTracker has the lifecycle of a Task which contains
     // many turns, from the perspective of the user, it is a single turn.
-    #[allow(deprecated)]
-    let display_root = get_git_repo_root(turn_context.cwd.as_path())
-        .unwrap_or_else(|| turn_context.cwd.clone().into_path_buf());
+    let display_root = get_git_repo_root(turn_context.default_cwd().as_path())
+        .unwrap_or_else(|| turn_context.default_cwd().clone().into_path_buf());
     let turn_diff_tracker = Arc::new(tokio::sync::Mutex::new(TurnDiffTracker::with_display_root(
         display_root,
     )));
@@ -700,8 +699,7 @@ async fn track_turn_resolved_config_analytics(
             model: turn_context.model_info.slug.clone(),
             model_provider: turn_context.config.model_provider_id.clone(),
             permission_profile: turn_context.permission_profile(),
-            #[allow(deprecated)]
-            permission_profile_cwd: turn_context.cwd.to_path_buf(),
+            permission_profile_cwd: turn_context.default_cwd().to_path_buf(),
             reasoning_effort: turn_context.reasoning_effort,
             reasoning_summary: Some(turn_context.reasoning_summary),
             service_tier: turn_context
@@ -997,13 +995,12 @@ pub(crate) fn build_prompt(
 }
 
 #[allow(clippy::too_many_arguments)]
-#[allow(deprecated)]
 #[instrument(level = "trace",
     skip_all,
     fields(
         turn_id = %turn_context.sub_id,
         model = %turn_context.model_info.slug,
-        cwd = %turn_context.cwd.display()
+        cwd = %turn_context.default_cwd().display()
     )
 )]
 async fn run_sampling_request(

--- a/codex-rs/core/src/session/turn_context.rs
+++ b/codex-rs/core/src/session/turn_context.rs
@@ -104,6 +104,13 @@ impl TurnContext {
         self.permission_profile.clone()
     }
 
+    pub(crate) fn default_cwd(&self) -> &AbsolutePathBuf {
+        self.environments
+            .primary()
+            .map(|turn_environment| &turn_environment.cwd)
+            .unwrap_or(&self.config.cwd)
+    }
+
     pub(crate) fn file_system_sandbox_policy(&self) -> FileSystemSandboxPolicy {
         self.permission_profile.file_system_sandbox_policy()
     }

--- a/codex-rs/core/src/tools/network_approval.rs
+++ b/codex-rs/core/src/tools/network_approval.rs
@@ -525,8 +525,7 @@ impl NetworkApprovalService {
                     guardian_approval_id,
                     /*approval_id*/ None,
                     prompt_command,
-                    #[allow(deprecated)]
-                    turn_context.cwd.clone(),
+                    turn_context.default_cwd().clone(),
                     Some(prompt_reason),
                     Some(network_approval_context.clone()),
                     /*proposed_execpolicy_amendment*/ None,


### PR DESCRIPTION
## Summary
- add `TurnContext::default_cwd()` to derive cwd from the primary turn environment with `config.cwd` fallback
- switch the super-easy non-persistent readers off the deprecated stored `TurnContext.cwd` field
- leave MCP, shell, hooks, and persistence/resume follow-ups out of scope

## Testing
- not run (not requested)
