### PR TITLE
Make proxy decider test DNS independent

### DIFF
--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -786,9 +786,7 @@ async fn managed_network_proxy_decider_survives_full_access_start() -> anyhow::R
 
     let mut stream = tokio::net::TcpStream::connect(started_proxy.proxy().http_addr()).await?;
     stream
-        .write_all(
-            b"GET http://example.com/ HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n",
-        )
+        .write_all(b"GET http://8.8.8.8/ HTTP/1.1\r\nHost: 8.8.8.8\r\nConnection: close\r\n\r\n")
         .await?;
     let mut buffer = [0_u8; 4096];
     let bytes_read = tokio::time::timeout(StdDuration::from_secs(2), stream.read(&mut buffer))


### PR DESCRIPTION
## Why

The managed network proxy decider test is meant to prove that the decider still runs after the session starts in full-access mode and then returns to workspace-write restrictions. On Mike's devbox, the test's `example.com` request can be classified by ambient DNS as local/private before the decider is consulted, so the same shard becomes flaky even though the proxy behavior is correct.

## What changed

- use public IP literal `8.8.8.8` in the proxy request instead of `example.com`
- keep the assertion focused on the decider path, without depending on ambient DNS resolution

## Stack

- [PR #22199](https://github.com/openai/codex/pull/22199) Isolate tmp-dependent tests from ambient git
- [PR #22201](https://github.com/openai/codex/pull/22201) Use remote fs for turn diff repo root
- [PR #22200](https://github.com/openai/codex/pull/22200) Emit unified exec end on startup failure
- [PR #22389](https://github.com/openai/codex/pull/22389) Stabilize remote routing e2e tests
- this PR Make proxy decider test DNS independent

## Validation

- On `dev`: `bazel test //codex-rs/core:core-unit-tests --test_filter=managed_network_proxy_decider_survives_full_access_start --runs_per_test=10 --test_output=errors` passed with 80 shard/run executions.
- Broader full remote validation is being rerun from the new top of stack.