### PR TITLE
Enable plugin hooks by default

### DIFF
--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -976,8 +976,8 @@ pub const FEATURES: &[FeatureSpec] = &[
     FeatureSpec {
         id: Feature::PluginHooks,
         key: "plugin_hooks",
-        stage: Stage::UnderDevelopment,
-        default_enabled: false,
+        stage: Stage::Stable,
+        default_enabled: true,
     },
     FeatureSpec {
         id: Feature::InAppBrowser,

--- a/codex-rs/features/src/tests.rs
+++ b/codex-rs/features/src/tests.rs
@@ -184,6 +184,12 @@ fn tool_search_is_stable_and_enabled_by_default() {
 }
 
 #[test]
+fn plugin_hooks_are_stable_and_enabled_by_default() {
+    assert_eq!(Feature::PluginHooks.stage(), Stage::Stable);
+    assert_eq!(Feature::PluginHooks.default_enabled(), true);
+}
+
+#[test]
 fn browser_controls_are_stable_and_enabled_by_default() {
     assert_eq!(Feature::InAppBrowser.stage(), Stage::Stable);
     assert_eq!(Feature::InAppBrowser.default_enabled(), true);


### PR DESCRIPTION
# Why

Plugin-bundled hooks are already wired through the plugin manager, session setup, and app-server hook listing paths. Keeping `plugin_hooks` disabled by default means users still need an explicit feature opt-in before that existing behavior participates in normal plugin loading.

# What

- mark `plugin_hooks` as stable and enable it by default
- add feature-registry test coverage for the new default/stage pairing

Validation:

- `cargo test -p codex-features`
- `just fmt`
