### PR TITLE
Add unsigned macOS release artifacts

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -10,6 +10,13 @@ on:
   push:
     tags:
       - "rust-v*.*.*"
+  workflow_dispatch:
+    inputs:
+      sign_macos:
+        description: "Sign and notarize macOS release artifacts."
+        required: false
+        type: boolean
+        default: true
 
 concurrency:
   group: ${{ github.workflow }}
@@ -64,6 +71,7 @@ jobs:
       # 2026-03-04: temporarily change releases to use thin LTO because
       # Ubuntu ARM is timing out at 60 minutes.
       CARGO_PROFILE_RELEASE_LTO: ${{ contains(github.ref_name, '-alpha') && 'thin' || 'thin' }}
+      SIGN_MACOS: ${{ github.event_name != 'workflow_dispatch' || inputs.sign_macos }}
 
     strategy:
       fail-fast: false
@@ -336,7 +344,7 @@ jobs:
           artifacts-dir: ${{ github.workspace }}/codex-rs/target/${{ matrix.target }}/release
           binaries: ${{ matrix.binaries }}
 
-      - if: ${{ runner.os == 'macOS' }}
+      - if: ${{ runner.os == 'macOS' && env.SIGN_MACOS == 'true' }}
         name: MacOS code signing (binaries)
         uses: ./.github/actions/macos-code-sign
         with:
@@ -350,7 +358,7 @@ jobs:
           apple-notarization-key-id: ${{ secrets.APPLE_NOTARIZATION_KEY_ID }}
           apple-notarization-issuer-id: ${{ secrets.APPLE_NOTARIZATION_ISSUER_ID }}
 
-      - if: ${{ runner.os == 'macOS' && matrix.build_dmg == 'true' }}
+      - if: ${{ runner.os == 'macOS' && matrix.build_dmg == 'true' && env.SIGN_MACOS == 'true' }}
         name: Build macOS dmg
         shell: bash
         run: |
@@ -390,7 +398,7 @@ jobs:
             exit 1
           fi
 
-      - if: ${{ runner.os == 'macOS' && matrix.build_dmg == 'true' }}
+      - if: ${{ runner.os == 'macOS' && matrix.build_dmg == 'true' && env.SIGN_MACOS == 'true' }}
         name: MacOS code signing (dmg)
         uses: ./.github/actions/macos-code-sign
         with:
@@ -404,6 +412,7 @@ jobs:
           apple-notarization-issuer-id: ${{ secrets.APPLE_NOTARIZATION_ISSUER_ID }}
 
       - name: Stage artifacts
+        if: ${{ runner.os != 'macOS' || env.SIGN_MACOS == 'true' }}
         shell: bash
         run: |
           dest="dist/${{ matrix.target }}"
@@ -433,7 +442,7 @@ jobs:
           fi
 
       - name: Build Python runtime wheel
-        if: ${{ matrix.bundle == 'primary' }}
+        if: ${{ matrix.bundle == 'primary' && (runner.os != 'macOS' || env.SIGN_MACOS == 'true') }}
         shell: bash
         run: |
           set -euo pipefail
@@ -484,7 +493,7 @@ jobs:
           "${RUNNER_TEMP}/python-runtime-build-venv/bin/python" -m build --wheel --outdir "$wheel_dir" "$stage_dir"
 
       - name: Upload Python runtime wheel
-        if: ${{ matrix.bundle == 'primary' }}
+        if: ${{ matrix.bundle == 'primary' && (runner.os != 'macOS' || env.SIGN_MACOS == 'true') }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: python-runtime-wheel-${{ matrix.target }}
@@ -492,6 +501,7 @@ jobs:
           if-no-files-found: error
 
       - name: Compress artifacts
+        if: ${{ runner.os != 'macOS' || env.SIGN_MACOS == 'true' }}
         shell: bash
         run: |
           # Path that contains the uncompressed binaries for the current
@@ -528,6 +538,7 @@ jobs:
           done
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        if: ${{ runner.os != 'macOS' || env.SIGN_MACOS == 'true' }}
         with:
           name: ${{ matrix.artifact_name }}
           # Upload the per-binary .zst files, .tar.gz equivalents, and any
@@ -571,12 +582,25 @@ jobs:
       should_publish_npm: ${{ steps.npm_publish_settings.outputs.should_publish }}
       npm_tag: ${{ steps.npm_publish_settings.outputs.npm_tag }}
       should_publish_python_runtime: ${{ steps.python_runtime_publish_settings.outputs.should_publish }}
+      sign_macos: ${{ steps.release_options.outputs.sign_macos }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: Resolve release options
+        id: release_options
+        env:
+          SIGN_MACOS: ${{ github.event_name != 'workflow_dispatch' || inputs.sign_macos }}
+        run: |
+          set -euo pipefail
+          if [[ "${SIGN_MACOS}" == "true" ]]; then
+            echo "sign_macos=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "sign_macos=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Generate release notes from tag commit message
         id: release_notes
@@ -636,6 +660,12 @@ jobs:
           set -euo pipefail
           version="${VERSION}"
 
+          if [[ "${{ steps.release_options.outputs.sign_macos }}" != "true" ]]; then
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            echo "npm_tag=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           if [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "should_publish=true" >> "$GITHUB_OUTPUT"
             echo "npm_tag=" >> "$GITHUB_OUTPUT"
@@ -655,6 +685,11 @@ jobs:
           set -euo pipefail
           version="${VERSION}"
 
+          if [[ "${{ steps.release_options.outputs.sign_macos }}" != "true" ]]; then
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           if [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "should_publish=true" >> "$GITHUB_OUTPUT"
           elif [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-alpha\.[0-9]+$ ]]; then
@@ -664,21 +699,26 @@ jobs:
           fi
 
       - name: Setup pnpm
+        if: ${{ steps.release_options.outputs.sign_macos == 'true' }}
         uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
         with:
           run_install: false
 
       - name: Setup Node.js for npm packaging
+        if: ${{ steps.release_options.outputs.sign_macos == 'true' }}
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
 
       - name: Install dependencies
+        if: ${{ steps.release_options.outputs.sign_macos == 'true' }}
         run: pnpm install --frozen-lockfile
 
       # stage_npm_packages.py requires DotSlash when staging releases.
-      - uses: facebook/install-dotslash@1e4e7b3e07eaca387acb98f1d4720e0bee8dbb6a # v2
+      - if: ${{ steps.release_options.outputs.sign_macos == 'true' }}
+        uses: facebook/install-dotslash@1e4e7b3e07eaca387acb98f1d4720e0bee8dbb6a # v2
       - name: Stage npm packages
+        if: ${{ steps.release_options.outputs.sign_macos == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_VERSION: ${{ steps.release_name.outputs.name }}
@@ -701,25 +741,29 @@ jobs:
           tag_name: ${{ github.ref_name }}
           body_path: ${{ steps.release_notes.outputs.path }}
           files: dist/**
+          make_latest: ${{ steps.release_options.outputs.sign_macos == 'true' && !contains(steps.release_name.outputs.name, '-') }}
           # Mark as prerelease only when the version has a suffix after x.y.z
           # (e.g. -alpha, -beta). Otherwise publish a normal release.
           prerelease: ${{ contains(steps.release_name.outputs.name, '-') }}
 
-      - uses: facebook/dotslash-publish-release@9c9ec027515c34db9282a09a25a9cab5880b2c52 # v2
+      - if: ${{ steps.release_options.outputs.sign_macos == 'true' }}
+        uses: facebook/dotslash-publish-release@9c9ec027515c34db9282a09a25a9cab5880b2c52 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag: ${{ github.ref_name }}
           config: .github/dotslash-config.json
 
-      - uses: facebook/dotslash-publish-release@9c9ec027515c34db9282a09a25a9cab5880b2c52 # v2
+      - if: ${{ steps.release_options.outputs.sign_macos == 'true' }}
+        uses: facebook/dotslash-publish-release@9c9ec027515c34db9282a09a25a9cab5880b2c52 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag: ${{ github.ref_name }}
           config: .github/dotslash-zsh-config.json
 
-      - uses: facebook/dotslash-publish-release@9c9ec027515c34db9282a09a25a9cab5880b2c52 # v2
+      - if: ${{ steps.release_options.outputs.sign_macos == 'true' }}
+        uses: facebook/dotslash-publish-release@9c9ec027515c34db9282a09a25a9cab5880b2c52 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -744,7 +788,7 @@ jobs:
   # npm docs: https://docs.npmjs.com/trusted-publishers
   publish-npm:
     # Publish to npm for stable releases and alpha pre-releases with numeric suffixes.
-    if: ${{ needs.release.outputs.should_publish_npm == 'true' }}
+    if: ${{ needs.release.outputs.sign_macos == 'true' && needs.release.outputs.should_publish_npm == 'true' }}
     name: publish-npm
     needs: release
     runs-on: ubuntu-latest
@@ -902,7 +946,7 @@ jobs:
   # need release follow-up, but should not invalidate the Rust release itself.
   publish-python-runtime:
     # Publish to PyPI for stable releases and alpha pre-releases with numeric suffixes.
-    if: ${{ needs.release.outputs.should_publish_python_runtime == 'true' }}
+    if: ${{ needs.release.outputs.sign_macos == 'true' && needs.release.outputs.should_publish_python_runtime == 'true' }}
     name: publish-python-runtime
     needs: release
     runs-on: ubuntu-latest
@@ -963,6 +1007,7 @@ jobs:
 
   update-branch:
     name: Update latest-alpha-cli branch
+    if: ${{ needs.release.outputs.sign_macos == 'true' }}
     permissions:
       contents: write
     needs: release

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -566,6 +566,7 @@ jobs:
     uses: ./.github/workflows/rust-release-zsh.yml
 
   release:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.sign_macos }}
     needs:
       - build
       - build-windows
@@ -582,25 +583,12 @@ jobs:
       should_publish_npm: ${{ steps.npm_publish_settings.outputs.should_publish }}
       npm_tag: ${{ steps.npm_publish_settings.outputs.npm_tag }}
       should_publish_python_runtime: ${{ steps.python_runtime_publish_settings.outputs.should_publish }}
-      sign_macos: ${{ steps.release_options.outputs.sign_macos }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-
-      - name: Resolve release options
-        id: release_options
-        env:
-          SIGN_MACOS: ${{ github.event_name != 'workflow_dispatch' || inputs.sign_macos }}
-        run: |
-          set -euo pipefail
-          if [[ "${SIGN_MACOS}" == "true" ]]; then
-            echo "sign_macos=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "sign_macos=false" >> "$GITHUB_OUTPUT"
-          fi
 
       - name: Generate release notes from tag commit message
         id: release_notes
@@ -660,12 +648,6 @@ jobs:
           set -euo pipefail
           version="${VERSION}"
 
-          if [[ "${{ steps.release_options.outputs.sign_macos }}" != "true" ]]; then
-            echo "should_publish=false" >> "$GITHUB_OUTPUT"
-            echo "npm_tag=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
           if [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "should_publish=true" >> "$GITHUB_OUTPUT"
             echo "npm_tag=" >> "$GITHUB_OUTPUT"
@@ -685,11 +667,6 @@ jobs:
           set -euo pipefail
           version="${VERSION}"
 
-          if [[ "${{ steps.release_options.outputs.sign_macos }}" != "true" ]]; then
-            echo "should_publish=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
           if [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "should_publish=true" >> "$GITHUB_OUTPUT"
           elif [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-alpha\.[0-9]+$ ]]; then
@@ -699,26 +676,21 @@ jobs:
           fi
 
       - name: Setup pnpm
-        if: ${{ steps.release_options.outputs.sign_macos == 'true' }}
         uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
         with:
           run_install: false
 
       - name: Setup Node.js for npm packaging
-        if: ${{ steps.release_options.outputs.sign_macos == 'true' }}
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
 
       - name: Install dependencies
-        if: ${{ steps.release_options.outputs.sign_macos == 'true' }}
         run: pnpm install --frozen-lockfile
 
       # stage_npm_packages.py requires DotSlash when staging releases.
-      - if: ${{ steps.release_options.outputs.sign_macos == 'true' }}
-        uses: facebook/install-dotslash@1e4e7b3e07eaca387acb98f1d4720e0bee8dbb6a # v2
+      - uses: facebook/install-dotslash@1e4e7b3e07eaca387acb98f1d4720e0bee8dbb6a # v2
       - name: Stage npm packages
-        if: ${{ steps.release_options.outputs.sign_macos == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_VERSION: ${{ steps.release_name.outputs.name }}
@@ -741,29 +713,25 @@ jobs:
           tag_name: ${{ github.ref_name }}
           body_path: ${{ steps.release_notes.outputs.path }}
           files: dist/**
-          make_latest: ${{ steps.release_options.outputs.sign_macos == 'true' && !contains(steps.release_name.outputs.name, '-') }}
           # Mark as prerelease only when the version has a suffix after x.y.z
           # (e.g. -alpha, -beta). Otherwise publish a normal release.
           prerelease: ${{ contains(steps.release_name.outputs.name, '-') }}
 
-      - if: ${{ steps.release_options.outputs.sign_macos == 'true' }}
-        uses: facebook/dotslash-publish-release@9c9ec027515c34db9282a09a25a9cab5880b2c52 # v2
+      - uses: facebook/dotslash-publish-release@9c9ec027515c34db9282a09a25a9cab5880b2c52 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag: ${{ github.ref_name }}
           config: .github/dotslash-config.json
 
-      - if: ${{ steps.release_options.outputs.sign_macos == 'true' }}
-        uses: facebook/dotslash-publish-release@9c9ec027515c34db9282a09a25a9cab5880b2c52 # v2
+      - uses: facebook/dotslash-publish-release@9c9ec027515c34db9282a09a25a9cab5880b2c52 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag: ${{ github.ref_name }}
           config: .github/dotslash-zsh-config.json
 
-      - if: ${{ steps.release_options.outputs.sign_macos == 'true' }}
-        uses: facebook/dotslash-publish-release@9c9ec027515c34db9282a09a25a9cab5880b2c52 # v2
+      - uses: facebook/dotslash-publish-release@9c9ec027515c34db9282a09a25a9cab5880b2c52 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -788,7 +756,7 @@ jobs:
   # npm docs: https://docs.npmjs.com/trusted-publishers
   publish-npm:
     # Publish to npm for stable releases and alpha pre-releases with numeric suffixes.
-    if: ${{ needs.release.outputs.sign_macos == 'true' && needs.release.outputs.should_publish_npm == 'true' }}
+    if: ${{ needs.release.outputs.should_publish_npm == 'true' }}
     name: publish-npm
     needs: release
     runs-on: ubuntu-latest
@@ -946,7 +914,7 @@ jobs:
   # need release follow-up, but should not invalidate the Rust release itself.
   publish-python-runtime:
     # Publish to PyPI for stable releases and alpha pre-releases with numeric suffixes.
-    if: ${{ needs.release.outputs.sign_macos == 'true' && needs.release.outputs.should_publish_python_runtime == 'true' }}
+    if: ${{ needs.release.outputs.should_publish_python_runtime == 'true' }}
     name: publish-python-runtime
     needs: release
     runs-on: ubuntu-latest
@@ -1007,7 +975,6 @@ jobs:
 
   update-branch:
     name: Update latest-alpha-cli branch
-    if: ${{ needs.release.outputs.sign_macos == 'true' }}
     permissions:
       contents: write
     needs: release

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -32,9 +32,16 @@ jobs:
       - uses: dtolnay/rust-toolchain@a0b273b48ed29de4470960879e8381ff45632f26 # 1.93.0
       - name: Validate tag matches Cargo.toml version
         shell: bash
+        env:
+          SIGN_MACOS: ${{ github.event_name != 'workflow_dispatch' || inputs.sign_macos }}
         run: |
           set -euo pipefail
           echo "::group::Tag validation"
+
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" && "${SIGN_MACOS}" == "true" ]]; then
+            echo "❌  Manual rust-release runs must set sign_macos=false"
+            exit 1
+          fi
 
           # 1. Must be a tag and match the regex
           [[ "${GITHUB_REF_TYPE}" == "tag" ]] \

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -295,6 +295,39 @@ jobs:
           path: codex-rs/target/**/cargo-timings/cargo-timing.html
           if-no-files-found: warn
 
+      - if: ${{ runner.os == 'macOS' }}
+        name: Stage unsigned macOS artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          target="${{ matrix.target }}"
+          release_dir="target/${target}/release"
+          dest="unsigned-dist/${target}"
+          mkdir -p "$dest"
+
+          for binary in ${{ matrix.binaries }}; do
+            binary_path="${release_dir}/${binary}"
+            unsigned_name="${binary}-${target}-unsigned"
+            unsigned_path="${dest}/${unsigned_name}"
+            if [[ ! -f "${binary_path}" ]]; then
+              echo "Binary ${binary_path} not found"
+              exit 1
+            fi
+
+            cp "${binary_path}" "${unsigned_path}"
+            tar -C "$dest" -czf "${unsigned_path}.tar.gz" "${unsigned_name}"
+            zstd -T0 -19 --rm "${unsigned_path}"
+          done
+
+      - if: ${{ runner.os == 'macOS' }}
+        name: Upload unsigned macOS artifacts
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: ${{ matrix.artifact_name }}-unsigned
+          path: codex-rs/unsigned-dist/${{ matrix.target }}/*
+          if-no-files-found: error
+
       - if: ${{ contains(matrix.target, 'linux') }}
         name: Cosign Linux artifacts
         uses: ./.github/actions/linux-code-sign


### PR DESCRIPTION
## Summary
- Upload unsigned macOS release binaries before signing so they remain available from the workflow run if signing fails
- Add a manual `workflow_dispatch` option, `sign_macos`, defaulting to `true`
- When `sign_macos=false`, skip macOS signing, signed-name macOS artifacts, DMGs, npm/DotSlash/PyPI publishing, latest release marking, and `latest-alpha-cli` updates


## Process
HAVE NOT TESTED YET BUT we should be able to run
```
gh workflow run rust-release.yml \
  -R openai/codex \
  --ref rust-v0.132.0 \
  -f sign_macos=false
```

which will then start the rust-release script with `sign_macos` and therefore do not codesign mac and also no release afterward. 