### PR TITLE
tests: isolate codex home for live cli

### DIFF
--- a/codex-rs/core/tests/common/lib.rs
+++ b/codex-rs/core/tests/common/lib.rs
@@ -33,7 +33,13 @@ pub mod test_codex_exec;
 pub mod tracing;
 pub mod zsh_fork;
 
-static TEST_ARG0_PATH_ENTRY: OnceLock<Option<Arg0PathEntryGuard>> = OnceLock::new();
+struct TestArg0PathEntry {
+    _codex_home: TempDir,
+    arg0: Arg0PathEntryGuard,
+    _previous_codex_home: Option<std::ffi::OsString>,
+}
+
+static TEST_ARG0_PATH_ENTRY: OnceLock<Option<TestArg0PathEntry>> = OnceLock::new();
 
 #[ctor]
 fn enable_deterministic_unified_exec_process_ids_for_tests() {
@@ -43,7 +49,30 @@ fn enable_deterministic_unified_exec_process_ids_for_tests() {
 
 #[ctor]
 fn configure_arg0_dispatch_for_test_binaries() {
-    let _ = TEST_ARG0_PATH_ENTRY.get_or_init(codex_arg0::arg0_dispatch);
+    let _ = TEST_ARG0_PATH_ENTRY.get_or_init(|| {
+        let codex_home = TempDir::new().expect("create temp codex home for arg0 aliases");
+        let previous_codex_home = std::env::var_os("CODEX_HOME");
+        // Safety: this ctor runs at process startup before test threads begin.
+        unsafe {
+            std::env::set_var("CODEX_HOME", codex_home.path());
+        }
+
+        let arg0 = codex_arg0::arg0_dispatch().expect("configure arg0 aliases for test binary");
+        match previous_codex_home.as_ref() {
+            Some(value) => unsafe {
+                std::env::set_var("CODEX_HOME", value);
+            },
+            None => unsafe {
+                std::env::remove_var("CODEX_HOME");
+            },
+        }
+
+        Some(TestArg0PathEntry {
+            _codex_home: codex_home,
+            arg0,
+            _previous_codex_home: previous_codex_home,
+        })
+    });
 }
 
 #[ctor]
@@ -225,7 +254,7 @@ pub fn find_codex_linux_sandbox_exe() -> Result<PathBuf, CargoBinError> {
     if let Some(path) = TEST_ARG0_PATH_ENTRY
         .get()
         .and_then(Option::as_ref)
-        .and_then(|path_entry| path_entry.paths().codex_linux_sandbox_exe.clone())
+        .and_then(|path_entry| path_entry.arg0.paths().codex_linux_sandbox_exe.clone())
     {
         return Ok(path);
     }

--- a/codex-rs/core/tests/common/lib.rs
+++ b/codex-rs/core/tests/common/lib.rs
@@ -33,13 +33,7 @@ pub mod test_codex_exec;
 pub mod tracing;
 pub mod zsh_fork;
 
-struct TestArg0PathEntry {
-    _codex_home: TempDir,
-    _arg0: Arg0PathEntryGuard,
-    _previous_codex_home: Option<std::ffi::OsString>,
-}
-
-static TEST_ARG0_PATH_ENTRY: OnceLock<Option<TestArg0PathEntry>> = OnceLock::new();
+static TEST_ARG0_PATH_ENTRY: OnceLock<Option<Arg0PathEntryGuard>> = OnceLock::new();
 
 #[ctor]
 fn enable_deterministic_unified_exec_process_ids_for_tests() {
@@ -49,30 +43,7 @@ fn enable_deterministic_unified_exec_process_ids_for_tests() {
 
 #[ctor]
 fn configure_arg0_dispatch_for_test_binaries() {
-    let _ = TEST_ARG0_PATH_ENTRY.get_or_init(|| {
-        let codex_home = TempDir::new().expect("create temp codex home for arg0 aliases");
-        let previous_codex_home = std::env::var_os("CODEX_HOME");
-        // Safety: this ctor runs at process startup before test threads begin.
-        unsafe {
-            std::env::set_var("CODEX_HOME", codex_home.path());
-        }
-
-        let arg0 = codex_arg0::arg0_dispatch().expect("configure arg0 aliases for test binary");
-        match previous_codex_home.as_ref() {
-            Some(value) => unsafe {
-                std::env::set_var("CODEX_HOME", value);
-            },
-            None => unsafe {
-                std::env::remove_var("CODEX_HOME");
-            },
-        }
-
-        Some(TestArg0PathEntry {
-            _codex_home: codex_home,
-            _arg0: arg0,
-            _previous_codex_home: previous_codex_home,
-        })
-    });
+    let _ = TEST_ARG0_PATH_ENTRY.get_or_init(codex_arg0::arg0_dispatch);
 }
 
 #[ctor]
@@ -254,7 +225,7 @@ pub fn find_codex_linux_sandbox_exe() -> Result<PathBuf, CargoBinError> {
     if let Some(path) = TEST_ARG0_PATH_ENTRY
         .get()
         .and_then(Option::as_ref)
-        .and_then(|path_entry| path_entry._arg0.paths().codex_linux_sandbox_exe.clone())
+        .and_then(|path_entry| path_entry.paths().codex_linux_sandbox_exe.clone())
     {
         return Ok(path);
     }

--- a/codex-rs/core/tests/common/lib.rs
+++ b/codex-rs/core/tests/common/lib.rs
@@ -35,7 +35,7 @@ pub mod zsh_fork;
 
 struct TestArg0PathEntry {
     _codex_home: TempDir,
-    arg0: Arg0PathEntryGuard,
+    _arg0: Arg0PathEntryGuard,
     _previous_codex_home: Option<std::ffi::OsString>,
 }
 
@@ -69,7 +69,7 @@ fn configure_arg0_dispatch_for_test_binaries() {
 
         Some(TestArg0PathEntry {
             _codex_home: codex_home,
-            arg0,
+            _arg0: arg0,
             _previous_codex_home: previous_codex_home,
         })
     });
@@ -254,7 +254,7 @@ pub fn find_codex_linux_sandbox_exe() -> Result<PathBuf, CargoBinError> {
     if let Some(path) = TEST_ARG0_PATH_ENTRY
         .get()
         .and_then(Option::as_ref)
-        .and_then(|path_entry| path_entry.arg0.paths().codex_linux_sandbox_exe.clone())
+        .and_then(|path_entry| path_entry._arg0.paths().codex_linux_sandbox_exe.clone())
     {
         return Ok(path);
     }

--- a/codex-rs/core/tests/suite/live_cli.rs
+++ b/codex-rs/core/tests/suite/live_cli.rs
@@ -23,6 +23,9 @@ fn run_live(prompt: &str) -> (assert_cmd::assert::Assert, TempDir) {
     use std::thread;
 
     let dir = TempDir::new().unwrap();
+    let home = TempDir::new().unwrap();
+    let codex_home = home.path().join(".codex");
+    std::fs::create_dir_all(&codex_home).unwrap();
 
     // Build a plain `std::process::Command` so we have full control over the underlying stdio
     // handles. `assert_cmd`’s own `Command` wrapper always forces stdout/stderr to be piped
@@ -33,6 +36,8 @@ fn run_live(prompt: &str) -> (assert_cmd::assert::Assert, TempDir) {
     let mut cmd = Command::new(codex_utils_cargo_bin::cargo_bin("codex-rs").unwrap());
     cmd.current_dir(dir.path());
     cmd.env("OPENAI_API_KEY", require_api_key());
+    cmd.env("HOME", home.path());
+    cmd.env("CODEX_HOME", &codex_home);
 
     // We want three things at once:
     //   1. live streaming of the child’s stdout/stderr while the test is running


### PR DESCRIPTION
## Why

Some core integration-test paths were creating Codex state under ambient `~/.codex`. In environments where `HOME=/tmp`, that showed up as `/tmp/.codex`, which is host-level shared state and makes these tests environment/order sensitive.

The affected paths were:

- `core/tests/suite/live_cli.rs`: `run_live()` spawned the real CLI with a temp cwd, but without an isolated home, so the child resolved Codex home from ambient `HOME`.
- core / exec-server integration test binaries using `configure_test_binary_dispatch(...)`: their startup ctor installs arg0 helper aliases like `apply_patch` and `codex-linux-sandbox`. Full `arg0_dispatch()` also installs aliases from ambient Codex-home resolution, so test-binary startup could create `CODEX_HOME/tmp/arg0`; with `HOME=/tmp`, that became `/tmp/.codex/tmp/arg0/...`.

## What changed

- `live_cli` now gives the spawned CLI a temp `HOME` and temp `CODEX_HOME`.
- arg0 alias setup now has an explicit-home form, `prepend_path_entry_for_codex_aliases_in(...)`, so test helpers can place alias state under a temp directory without relying on ambient `CODEX_HOME`.
- helper re-entry behavior is preserved with `dispatch_arg0_if_needed()`, so aliases like `apply_patch` and `codex-linux-sandbox` still dispatch correctly before test alias installation.
- core test support keeps the temp Codex home alive for the lifetime of the test binary, matching the alias lifetime.

## Verification

Verified on `dev2` with `HOME=/tmp` that the focused core test-binary startup path no longer recreates `/tmp/.codex`.

Also checked the exact `live_cli` test path under `HOME=/tmp`; on `dev2` it still hits the existing remote-only `cargo_bin("codex-rs")` resolution failure before spawning the child, but `/tmp/.codex` remains absent after the run.
