### PR TITLE
chore(config) rm experimental_use_freeform_apply_patch

### DIFF
--- a/codex-rs/config/src/config_toml.rs
+++ b/codex-rs/config/src/config_toml.rs
@@ -443,7 +443,6 @@ pub struct ConfigToml {
     pub experimental_instructions_file: Option<AbsolutePathBuf>,
     pub experimental_compact_prompt_file: Option<AbsolutePathBuf>,
     pub experimental_use_unified_exec_tool: Option<bool>,
-    pub experimental_use_freeform_apply_patch: Option<bool>,
     /// Preferred OSS provider for local models, e.g. "lmstudio" or "ollama".
     pub oss_provider: Option<String>,
 }

--- a/codex-rs/config/src/profile_toml.rs
+++ b/codex-rs/config/src/profile_toml.rs
@@ -54,7 +54,6 @@ pub struct ConfigProfile {
     #[schemars(skip)]
     pub experimental_instructions_file: Option<AbsolutePathBuf>,
     pub experimental_compact_prompt_file: Option<AbsolutePathBuf>,
-    pub include_apply_patch_tool: Option<bool>,
     pub include_permissions_instructions: Option<bool>,
     pub include_apps_instructions: Option<bool>,
     pub include_collaboration_mode_instructions: Option<bool>,

--- a/codex-rs/config/src/profile_toml.rs
+++ b/codex-rs/config/src/profile_toml.rs
@@ -60,7 +60,6 @@ pub struct ConfigProfile {
     pub include_collaboration_mode_instructions: Option<bool>,
     pub include_environment_context: Option<bool>,
     pub experimental_use_unified_exec_tool: Option<bool>,
-    pub experimental_use_freeform_apply_patch: Option<bool>,
     pub tools: Option<ToolsToml>,
     pub web_search: Option<WebSearchMode>,
     pub analytics: Option<AnalyticsConfigToml>,

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -347,9 +347,6 @@
         "experimental_compact_prompt_file": {
           "$ref": "#/definitions/AbsolutePathBuf"
         },
-        "experimental_use_freeform_apply_patch": {
-          "type": "boolean"
-        },
         "experimental_use_unified_exec_tool": {
           "type": "boolean"
         },
@@ -428,9 +425,6 @@
               "type": "boolean"
             },
             "exec_permission_approvals": {
-              "type": "boolean"
-            },
-            "experimental_use_freeform_apply_patch": {
               "type": "boolean"
             },
             "experimental_use_unified_exec_tool": {
@@ -4078,9 +4072,6 @@
       ],
       "description": "Experimental / do not use. Selects the thread store implementation."
     },
-    "experimental_use_freeform_apply_patch": {
-      "type": "boolean"
-    },
     "experimental_use_unified_exec_tool": {
       "type": "boolean"
     },
@@ -4159,9 +4150,6 @@
           "type": "boolean"
         },
         "exec_permission_approvals": {
-          "type": "boolean"
-        },
-        "experimental_use_freeform_apply_patch": {
           "type": "boolean"
         },
         "experimental_use_unified_exec_tool": {

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -613,9 +613,6 @@
           },
           "type": "object"
         },
-        "include_apply_patch_tool": {
-          "type": "boolean"
-        },
         "include_apps_instructions": {
           "type": "boolean"
         },

--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -4237,7 +4237,6 @@ async fn legacy_toggles_map_to_features() -> std::io::Result<()> {
     let codex_home = TempDir::new()?;
     let cfg = ConfigToml {
         experimental_use_unified_exec_tool: Some(true),
-        experimental_use_freeform_apply_patch: Some(true),
         ..Default::default()
     };
 
@@ -4248,10 +4247,7 @@ async fn legacy_toggles_map_to_features() -> std::io::Result<()> {
     )
     .await?;
 
-    assert!(config.features.enabled(Feature::ApplyPatchFreeform));
     assert!(config.features.enabled(Feature::UnifiedExec));
-
-    assert!(config.include_apply_patch_tool);
 
     assert!(config.use_experimental_unified_exec_tool);
 

--- a/codex-rs/core/src/config/managed_features.rs
+++ b/codex-rs/core/src/config/managed_features.rs
@@ -269,13 +269,6 @@ fn explicit_feature_settings_in_config(cfg: &ConfigToml) -> Vec<(String, Feature
             enabled,
         ));
     }
-    if let Some(enabled) = cfg.experimental_use_freeform_apply_patch {
-        explicit_settings.push((
-            "experimental_use_freeform_apply_patch".to_string(),
-            Feature::ApplyPatchFreeform,
-            enabled,
-        ));
-    }
     for (profile_name, profile) in &cfg.profiles {
         if let Some(features) = profile.features.as_ref() {
             for (key, enabled) in features.entries() {
@@ -299,13 +292,6 @@ fn explicit_feature_settings_in_config(cfg: &ConfigToml) -> Vec<(String, Feature
             explicit_settings.push((
                 format!("profiles.{profile_name}.experimental_use_unified_exec_tool"),
                 Feature::UnifiedExec,
-                enabled,
-            ));
-        }
-        if let Some(enabled) = profile.experimental_use_freeform_apply_patch {
-            explicit_settings.push((
-                format!("profiles.{profile_name}.experimental_use_freeform_apply_patch"),
-                Feature::ApplyPatchFreeform,
                 enabled,
             ));
         }
@@ -370,14 +356,11 @@ pub(crate) fn validate_feature_requirements_in_config_toml(
             FeatureConfigSource {
                 features: cfg.features.as_ref(),
                 include_apply_patch_tool: None,
-                experimental_use_freeform_apply_patch: cfg.experimental_use_freeform_apply_patch,
                 experimental_use_unified_exec_tool: cfg.experimental_use_unified_exec_tool,
             },
             FeatureConfigSource {
                 features: profile.features.as_ref(),
                 include_apply_patch_tool: profile.include_apply_patch_tool,
-                experimental_use_freeform_apply_patch: profile
-                    .experimental_use_freeform_apply_patch,
                 experimental_use_unified_exec_tool: profile.experimental_use_unified_exec_tool,
             },
             FeatureOverrides::default(),

--- a/codex-rs/core/src/config/managed_features.rs
+++ b/codex-rs/core/src/config/managed_features.rs
@@ -281,13 +281,6 @@ fn explicit_feature_settings_in_config(cfg: &ConfigToml) -> Vec<(String, Feature
                 }
             }
         }
-        if let Some(enabled) = profile.include_apply_patch_tool {
-            explicit_settings.push((
-                format!("profiles.{profile_name}.include_apply_patch_tool"),
-                Feature::ApplyPatchFreeform,
-                enabled,
-            ));
-        }
         if let Some(enabled) = profile.experimental_use_unified_exec_tool {
             explicit_settings.push((
                 format!("profiles.{profile_name}.experimental_use_unified_exec_tool"),
@@ -360,7 +353,7 @@ pub(crate) fn validate_feature_requirements_in_config_toml(
             },
             FeatureConfigSource {
                 features: profile.features.as_ref(),
-                include_apply_patch_tool: profile.include_apply_patch_tool,
+                include_apply_patch_tool: None,
                 experimental_use_unified_exec_tool: profile.experimental_use_unified_exec_tool,
             },
             FeatureOverrides::default(),

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -1873,7 +1873,6 @@ pub struct ConfigOverrides {
     pub developer_instructions: Option<String>,
     pub personality: Option<Personality>,
     pub compact_prompt: Option<String>,
-    pub include_apply_patch_tool: Option<bool>,
     pub show_raw_agent_reasoning: Option<bool>,
     pub tools_web_search_request: Option<bool>,
     pub ephemeral: Option<bool>,
@@ -2162,7 +2161,6 @@ impl Config {
             developer_instructions,
             personality,
             compact_prompt,
-            include_apply_patch_tool: include_apply_patch_tool_override,
             show_raw_agent_reasoning,
             tools_web_search_request: override_tools_web_search_request,
             ephemeral,
@@ -2216,7 +2214,6 @@ impl Config {
         };
         let tool_suggest = resolve_tool_suggest_config(&cfg, &config_layer_stack);
         let feature_overrides = FeatureOverrides {
-            include_apply_patch_tool: include_apply_patch_tool_override,
             web_search_request: override_tools_web_search_request,
         };
 

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -2224,14 +2224,11 @@ impl Config {
             FeatureConfigSource {
                 features: cfg.features.as_ref(),
                 include_apply_patch_tool: None,
-                experimental_use_freeform_apply_patch: cfg.experimental_use_freeform_apply_patch,
                 experimental_use_unified_exec_tool: cfg.experimental_use_unified_exec_tool,
             },
             FeatureConfigSource {
                 features: config_profile.features.as_ref(),
                 include_apply_patch_tool: config_profile.include_apply_patch_tool,
-                experimental_use_freeform_apply_patch: config_profile
-                    .experimental_use_freeform_apply_patch,
                 experimental_use_unified_exec_tool: config_profile
                     .experimental_use_unified_exec_tool,
             },

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -2228,7 +2228,7 @@ impl Config {
             },
             FeatureConfigSource {
                 features: config_profile.features.as_ref(),
-                include_apply_patch_tool: config_profile.include_apply_patch_tool,
+                include_apply_patch_tool: None,
                 experimental_use_unified_exec_tool: config_profile
                     .experimental_use_unified_exec_tool,
             },

--- a/codex-rs/core/src/session/config_lock.rs
+++ b/codex-rs/core/src/session/config_lock.rs
@@ -194,7 +194,6 @@ fn drop_lockfile_inputs(lock_config: &mut ConfigToml) {
     lock_config.default_permissions = None;
     lock_config.permissions = None;
     lock_config.experimental_use_unified_exec_tool = None;
-    lock_config.experimental_use_freeform_apply_patch = None;
 }
 
 fn resolved_config_to_toml<Toml>(

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -423,7 +423,6 @@ pub async fn run_main(cli: Cli, arg0_paths: Arg0DispatchPaths) -> anyhow::Result
         developer_instructions: None,
         personality: None,
         compact_prompt: None,
-        include_apply_patch_tool: None,
         show_raw_agent_reasoning: oss.then_some(true),
         tools_web_search_request: None,
         ephemeral: ephemeral.then_some(true),

--- a/codex-rs/features/src/legacy.rs
+++ b/codex-rs/features/src/legacy.rs
@@ -22,10 +22,6 @@ const ALIASES: &[Alias] = &[
         feature: Feature::UnifiedExec,
     },
     Alias {
-        legacy_key: "experimental_use_freeform_apply_patch",
-        feature: Feature::ApplyPatchFreeform,
-    },
-    Alias {
         legacy_key: "include_apply_patch_tool",
         feature: Feature::ApplyPatchFreeform,
     },
@@ -72,7 +68,6 @@ pub(crate) fn feature_for_key(key: &str) -> Option<Feature> {
 #[derive(Debug, Default)]
 pub(crate) struct LegacyFeatureToggles {
     pub include_apply_patch_tool: Option<bool>,
-    pub experimental_use_freeform_apply_patch: Option<bool>,
     pub experimental_use_unified_exec_tool: Option<bool>,
 }
 
@@ -83,12 +78,6 @@ impl LegacyFeatureToggles {
             Feature::ApplyPatchFreeform,
             self.include_apply_patch_tool,
             "include_apply_patch_tool",
-        );
-        set_if_some(
-            features,
-            Feature::ApplyPatchFreeform,
-            self.experimental_use_freeform_apply_patch,
-            "experimental_use_freeform_apply_patch",
         );
         set_if_some(
             features,

--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -294,7 +294,6 @@ pub struct FeatureOverrides {
 pub struct FeatureConfigSource<'a> {
     pub features: Option<&'a FeaturesToml>,
     pub include_apply_patch_tool: Option<bool>,
-    pub experimental_use_freeform_apply_patch: Option<bool>,
     pub experimental_use_unified_exec_tool: Option<bool>,
 }
 
@@ -470,7 +469,6 @@ impl Features {
         for source in [base, profile] {
             LegacyFeatureToggles {
                 include_apply_patch_tool: source.include_apply_patch_tool,
-                experimental_use_freeform_apply_patch: source.experimental_use_freeform_apply_patch,
                 experimental_use_unified_exec_tool: source.experimental_use_unified_exec_tool,
             }
             .apply(&mut features);

--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -286,7 +286,6 @@ pub struct Features {
 
 #[derive(Debug, Clone, Default)]
 pub struct FeatureOverrides {
-    pub include_apply_patch_tool: Option<bool>,
     pub web_search_request: Option<bool>,
 }
 
@@ -299,11 +298,6 @@ pub struct FeatureConfigSource<'a> {
 
 impl FeatureOverrides {
     fn apply(self, features: &mut Features) {
-        LegacyFeatureToggles {
-            include_apply_patch_tool: self.include_apply_patch_tool,
-            ..Default::default()
-        }
-        .apply(features);
         if let Some(enabled) = self.web_search_request {
             if enabled {
                 features.enable(Feature::WebSearchRequest);

--- a/codex-rs/features/src/tests.rs
+++ b/codex-rs/features/src/tests.rs
@@ -387,7 +387,6 @@ fn from_sources_applies_base_profile_and_overrides() {
         },
         FeatureOverrides {
             web_search_request: Some(false),
-            ..Default::default()
         },
     );
 


### PR DESCRIPTION
## Summary
Get rid of the `experimental_use_freeform_apply_patch` config option, since it is now encoded in model config. No deprecation message since it has been experimental this entire time

## Testing
- [x] Updated unit tests