### PR TITLE
Fix remote environment test fixtures

### DIFF
--- a/codex-rs/core/tests/common/test_codex.rs
+++ b/codex-rs/core/tests/common/test_codex.rs
@@ -391,13 +391,22 @@ impl TestCodexBuilder {
             std::env::current_exe()?,
             codex_linux_sandbox_exe,
         )?;
-        let environment_manager = Arc::new(
-            codex_exec_server::EnvironmentManager::create_for_tests(
-                exec_server_url,
-                local_runtime_paths,
-            )
-            .await,
-        );
+        let environment_manager = Arc::new(match exec_server_url {
+            Some(exec_server_url) => {
+                codex_exec_server::EnvironmentManager::create_for_tests_with_local(
+                    Some(exec_server_url),
+                    local_runtime_paths,
+                )
+                .await
+            }
+            None => {
+                codex_exec_server::EnvironmentManager::create_for_tests(
+                    /*exec_server_url*/ None,
+                    local_runtime_paths,
+                )
+                .await
+            }
+        });
         let file_system = test_env.environment().get_filesystem();
         let mut workspace_setups = vec![];
         swap(&mut self.workspace_setups, &mut workspace_setups);

--- a/codex-rs/core/tests/suite/remote_env.rs
+++ b/codex-rs/core/tests/suite/remote_env.rs
@@ -77,7 +77,7 @@ async fn submit_turn_with_approval_and_environments(
             cwd: test.cwd.path().to_path_buf(),
             approval_policy: AskForApproval::OnRequest,
             approvals_reviewer: Some(ApprovalsReviewer::User),
-            sandbox_policy: SandboxPolicy::new_workspace_write_policy(),
+            sandbox_policy: SandboxPolicy::new_read_only_policy(),
             permission_profile: None,
             model: test.session_configured.model.clone(),
             effort: None,

--- a/codex-rs/core/tests/suite/view_image.rs
+++ b/codex-rs/core/tests/suite/view_image.rs
@@ -582,9 +582,7 @@ async fn view_image_routes_to_selected_remote_environment() -> anyhow::Result<()
             /*sandbox*/ None,
         )
         .await?;
-    let png = BASE64_STANDARD.decode(
-        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
-    )?;
+    let png = png_bytes(/*width*/ 1, /*height*/ 1, [0, 255, 0, 255])?;
     test.fs()
         .write_file(&image_path, png, /*sandbox*/ None)
         .await?;

--- a/codex-rs/exec-server/src/environment.rs
+++ b/codex-rs/exec-server/src/environment.rs
@@ -135,6 +135,20 @@ impl EnvironmentManager {
         }
     }
 
+    /// Builds a test-only manager that keeps the provider default while also
+    /// allowing tests to select the local environment explicitly.
+    pub async fn create_for_tests_with_local(
+        exec_server_url: Option<String>,
+        local_runtime_paths: ExecServerRuntimePaths,
+    ) -> Self {
+        let mut snapshot = DefaultEnvironmentProvider::new(exec_server_url).snapshot_inner();
+        snapshot.include_local = true;
+        match Self::from_provider_snapshot(snapshot, local_runtime_paths) {
+            Ok(manager) => manager,
+            Err(err) => panic!("test provider with local should create valid environments: {err}"),
+        }
+    }
+
     /// Builds a manager from a provider-supplied startup snapshot.
     pub async fn from_provider<P>(
         provider: &P,


### PR DESCRIPTION
## Why
The Docker remote-env coverage was failing before it reached the behavior those tests are meant to exercise. The remote-aware test fixture only registered the remote environment, so tests that intentionally select both `local` and `remote` could not start a turn. After that was fixed, two tests exposed stale fixtures: the approval test was auto-approving under workspace-write, and the remote `view_image` test was writing invalid PNG bytes.

## What Changed
- Added `EnvironmentManager::create_for_tests_with_local(...)` so tests can keep the provider default while also selecting `local` explicitly.
- Updated `build_remote_aware()` to use that test-only manager when a remote exec-server URL is present.
- Changed the remote apply-patch approval helper to use `SandboxPolicy::new_read_only_policy()` so the test actually exercises approval caching per environment.
- Replaced the hardcoded remote `view_image` PNG blob with the existing `png_bytes(...)` helper so the test uses a valid image fixture.

## Validation
Ran these isolated Docker remote-env tests on the devbox with `$remote-tests` setup:
- `suite::remote_env::apply_patch_freeform_routes_to_selected_remote_environment`
- `suite::remote_env::apply_patch_approvals_are_remembered_per_environment`
- `suite::remote_env::apply_patch_intercepted_exec_command_routes_to_selected_remote_environment`
- `suite::remote_env::exec_command_routes_to_selected_remote_environment`
- `suite::view_image::view_image_routes_to_selected_remote_environment`

All five pass.