### PR TITLE
Defer startup NUX impressions until startup succeeds

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -755,15 +755,13 @@ impl App {
                 &initial_prompt,
                 &initial_images,
             );
-        let startup_tooltip_override =
-            if Self::should_prepare_startup_tooltip_override(&session_selection) {
-                prepare_startup_tooltip_override(&mut config, &available_models, is_first_run).await
-            } else {
-                None
-            };
         let (mut chat_widget, initial_started_thread) = match session_selection {
             SessionSelection::StartFresh | SessionSelection::Exit => {
                 let started = app_server.start_thread(&config).await?;
+                // Only count a startup tooltip once the fresh thread can actually render it.
+                let startup_tooltip_override =
+                    prepare_startup_tooltip_override(&mut config, &available_models, is_first_run)
+                        .await;
                 let init = crate::chatwidget::ChatWidgetInit {
                     config: config.clone(),
                     environment_manager: environment_manager.clone(),

--- a/codex-rs/tui/src/app/tests/startup.rs
+++ b/codex-rs/tui/src/app/tests/startup.rs
@@ -32,28 +32,6 @@ fn startup_waiting_gate_is_only_for_fresh_or_exit_session_selection() {
 }
 
 #[test]
-fn startup_tooltip_override_is_only_prepared_for_fresh_or_exit_session_selection() {
-    assert!(App::should_prepare_startup_tooltip_override(
-        &SessionSelection::StartFresh
-    ));
-    assert!(App::should_prepare_startup_tooltip_override(
-        &SessionSelection::Exit
-    ));
-    assert!(!App::should_prepare_startup_tooltip_override(
-        &SessionSelection::Resume(crate::resume_picker::SessionTarget {
-            path: Some(PathBuf::from("/tmp/restore")),
-            thread_id: ThreadId::new(),
-        })
-    ));
-    assert!(!App::should_prepare_startup_tooltip_override(
-        &SessionSelection::Fork(crate::resume_picker::SessionTarget {
-            path: Some(PathBuf::from("/tmp/fork")),
-            thread_id: ThreadId::new(),
-        })
-    ));
-}
-
-#[test]
 fn startup_paused_goal_prompt_gate_is_only_for_quiet_resume() {
     let resume = SessionSelection::Resume(crate::resume_picker::SessionTarget {
         path: Some(PathBuf::from("/tmp/restore")),

--- a/codex-rs/tui/src/app/thread_routing.rs
+++ b/codex-rs/tui/src/app/thread_routing.rs
@@ -1269,15 +1269,6 @@ impl App {
         )
     }
 
-    pub(super) fn should_prepare_startup_tooltip_override(
-        session_selection: &SessionSelection,
-    ) -> bool {
-        matches!(
-            session_selection,
-            SessionSelection::StartFresh | SessionSelection::Exit
-        )
-    }
-
     pub(super) fn should_prompt_for_paused_goal_after_startup_resume(
         session_selection: &SessionSelection,
         initial_prompt: &Option<String>,


### PR DESCRIPTION
## Why

This is a follow-up to #22573. This problem was surfaced in a code review comment that I missed before merging the previous PR.

Fresh-session startup could prepare a model-availability NUX before `app_server.start_thread(&config)` completed. If thread startup then failed, the TUI never rendered the tooltip, but `prepare_startup_tooltip_override(...)` had already persisted one of the limited impressions.

## What Changed

- Move startup tooltip preparation inside the fresh-thread startup branch, after `start_thread(...)` succeeds.
- Keep resume/fork paths unchanged.
- Remove the now-redundant `should_prepare_startup_tooltip_override(...)` helper and its gate test.

