### PR TITLE
Chore: better published unsigned artifacts

### DIFF
--- a/.github/dotslash-unsigned-config.json
+++ b/.github/dotslash-unsigned-config.json
@@ -84,6 +84,18 @@
         }
       }
     },
+    "bwrap": {
+      "platforms": {
+        "linux-x86_64": {
+          "regex": "^bwrap-x86_64-unknown-linux-musl\\.zst$",
+          "path": "bwrap"
+        },
+        "linux-aarch64": {
+          "regex": "^bwrap-aarch64-unknown-linux-musl\\.zst$",
+          "path": "bwrap"
+        }
+      }
+    },
     "codex-command-runner": {
       "platforms": {
         "windows-x86_64": {

--- a/.github/dotslash-unsigned-config.json
+++ b/.github/dotslash-unsigned-config.json
@@ -1,0 +1,112 @@
+{
+  "outputs": {
+    "codex-unsigned": {
+      "platforms": {
+        "macos-aarch64": {
+          "regex": "^codex-aarch64-apple-darwin-unsigned\\.zst$",
+          "path": "codex"
+        },
+        "macos-x86_64": {
+          "regex": "^codex-x86_64-apple-darwin-unsigned\\.zst$",
+          "path": "codex"
+        },
+        "linux-x86_64": {
+          "regex": "^codex-x86_64-unknown-linux-musl-bundle\\.tar\\.zst$",
+          "path": "codex"
+        },
+        "linux-aarch64": {
+          "regex": "^codex-aarch64-unknown-linux-musl-bundle\\.tar\\.zst$",
+          "path": "codex"
+        },
+        "windows-x86_64": {
+          "regex": "^codex-x86_64-pc-windows-msvc\\.exe\\.zst$",
+          "path": "codex.exe"
+        },
+        "windows-aarch64": {
+          "regex": "^codex-aarch64-pc-windows-msvc\\.exe\\.zst$",
+          "path": "codex.exe"
+        }
+      }
+    },
+    "codex-app-server-unsigned": {
+      "platforms": {
+        "macos-aarch64": {
+          "regex": "^codex-app-server-aarch64-apple-darwin-unsigned\\.zst$",
+          "path": "codex-app-server"
+        },
+        "macos-x86_64": {
+          "regex": "^codex-app-server-x86_64-apple-darwin-unsigned\\.zst$",
+          "path": "codex-app-server"
+        },
+        "linux-x86_64": {
+          "regex": "^codex-app-server-x86_64-unknown-linux-musl\\.zst$",
+          "path": "codex-app-server"
+        },
+        "linux-aarch64": {
+          "regex": "^codex-app-server-aarch64-unknown-linux-musl\\.zst$",
+          "path": "codex-app-server"
+        },
+        "windows-x86_64": {
+          "regex": "^codex-app-server-x86_64-pc-windows-msvc\\.exe\\.zst$",
+          "path": "codex-app-server.exe"
+        },
+        "windows-aarch64": {
+          "regex": "^codex-app-server-aarch64-pc-windows-msvc\\.exe\\.zst$",
+          "path": "codex-app-server.exe"
+        }
+      }
+    },
+    "codex-responses-api-proxy-unsigned": {
+      "platforms": {
+        "macos-aarch64": {
+          "regex": "^codex-responses-api-proxy-aarch64-apple-darwin-unsigned\\.zst$",
+          "path": "codex-responses-api-proxy"
+        },
+        "macos-x86_64": {
+          "regex": "^codex-responses-api-proxy-x86_64-apple-darwin-unsigned\\.zst$",
+          "path": "codex-responses-api-proxy"
+        },
+        "linux-x86_64": {
+          "regex": "^codex-responses-api-proxy-x86_64-unknown-linux-musl\\.zst$",
+          "path": "codex-responses-api-proxy"
+        },
+        "linux-aarch64": {
+          "regex": "^codex-responses-api-proxy-aarch64-unknown-linux-musl\\.zst$",
+          "path": "codex-responses-api-proxy"
+        },
+        "windows-x86_64": {
+          "regex": "^codex-responses-api-proxy-x86_64-pc-windows-msvc\\.exe\\.zst$",
+          "path": "codex-responses-api-proxy.exe"
+        },
+        "windows-aarch64": {
+          "regex": "^codex-responses-api-proxy-aarch64-pc-windows-msvc\\.exe\\.zst$",
+          "path": "codex-responses-api-proxy.exe"
+        }
+      }
+    },
+    "codex-command-runner": {
+      "platforms": {
+        "windows-x86_64": {
+          "regex": "^codex-command-runner-x86_64-pc-windows-msvc\\.exe\\.zst$",
+          "path": "codex-command-runner.exe"
+        },
+        "windows-aarch64": {
+          "regex": "^codex-command-runner-aarch64-pc-windows-msvc\\.exe\\.zst$",
+          "path": "codex-command-runner.exe"
+        }
+      }
+    },
+    "codex-windows-sandbox-setup": {
+      "platforms": {
+        "windows-x86_64": {
+          "regex": "^codex-windows-sandbox-setup-x86_64-pc-windows-msvc\\.exe\\.zst$",
+          "path": "codex-windows-sandbox-setup.exe"
+        },
+        "windows-aarch64": {
+          "regex": "^codex-windows-sandbox-setup-aarch64-pc-windows-msvc\\.exe\\.zst$",
+          "path": "codex-windows-sandbox-setup.exe"
+        }
+      }
+    }
+  }
+}

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -631,7 +631,7 @@ jobs:
       - name: List
         run: ls -R dist/
 
-      - name: Keep only unsigned macOS artifacts
+      - name: Prune artifacts excluded from unsigned macOS release
         if: ${{ env.SIGN_MACOS == 'false' }}
         run: |
           find dist -mindepth 1 -maxdepth 1 -type d \

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -573,7 +573,6 @@ jobs:
     uses: ./.github/workflows/rust-release-zsh.yml
 
   release:
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.sign_macos }}
     needs:
       - build
       - build-windows
@@ -584,9 +583,12 @@ jobs:
     permissions:
       contents: write
       actions: read
+    env:
+      SIGN_MACOS: ${{ github.event_name != 'workflow_dispatch' || inputs.sign_macos }}
     outputs:
       version: ${{ steps.release_name.outputs.name }}
       tag: ${{ github.ref_name }}
+      sign_macos: ${{ steps.release_mode.outputs.sign_macos }}
       should_publish_npm: ${{ steps.npm_publish_settings.outputs.should_publish }}
       npm_tag: ${{ steps.npm_publish_settings.outputs.npm_tag }}
       should_publish_python_runtime: ${{ steps.python_runtime_publish_settings.outputs.should_publish }}
@@ -596,6 +598,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: Define release mode
+        id: release_mode
+        run: |
+          echo "sign_macos=${SIGN_MACOS}" >> "$GITHUB_OUTPUT"
 
       - name: Generate release notes from tag commit message
         id: release_notes
@@ -623,6 +630,22 @@ jobs:
 
       - name: List
         run: ls -R dist/
+
+      - name: Keep only unsigned macOS artifacts
+        if: ${{ env.SIGN_MACOS == 'false' }}
+        run: |
+          find dist -mindepth 1 -maxdepth 1 -type d \
+            ! -name '*-apple-darwin*-unsigned' \
+            ! -name 'aarch64-unknown-linux-musl' \
+            ! -name 'x86_64-unknown-linux-musl' \
+            ! -name 'aarch64-pc-windows-msvc' \
+            ! -name 'x86_64-pc-windows-msvc' \
+            -exec rm -rf {} +
+
+          if ! find dist -type f -name '*-apple-darwin*-unsigned*' | grep -q .; then
+            echo "No unsigned macOS artifacts found in downloaded workflow artifacts."
+            exit 1
+          fi
 
       - name: Delete entries from dist/ that should not go in the release
         run: |
@@ -655,6 +678,12 @@ jobs:
           set -euo pipefail
           version="${VERSION}"
 
+          if [[ "${SIGN_MACOS}" != "true" ]]; then
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            echo "npm_tag=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           if [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "should_publish=true" >> "$GITHUB_OUTPUT"
             echo "npm_tag=" >> "$GITHUB_OUTPUT"
@@ -674,6 +703,11 @@ jobs:
           set -euo pipefail
           version="${VERSION}"
 
+          if [[ "${SIGN_MACOS}" != "true" ]]; then
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           if [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "should_publish=true" >> "$GITHUB_OUTPUT"
           elif [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-alpha\.[0-9]+$ ]]; then
@@ -683,21 +717,25 @@ jobs:
           fi
 
       - name: Setup pnpm
+        if: ${{ env.SIGN_MACOS == 'true' }}
         uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
         with:
           run_install: false
 
       - name: Setup Node.js for npm packaging
+        if: ${{ env.SIGN_MACOS == 'true' }}
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
 
       - name: Install dependencies
+        if: ${{ env.SIGN_MACOS == 'true' }}
         run: pnpm install --frozen-lockfile
 
       # stage_npm_packages.py requires DotSlash when staging releases.
       - uses: facebook/install-dotslash@1e4e7b3e07eaca387acb98f1d4720e0bee8dbb6a # v2
       - name: Stage npm packages
+        if: ${{ env.SIGN_MACOS == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_VERSION: ${{ steps.release_name.outputs.name }}
@@ -709,6 +747,7 @@ jobs:
             --package codex-sdk
 
       - name: Stage installer scripts
+        if: ${{ env.SIGN_MACOS == 'true' }}
         run: |
           cp scripts/install/install.sh dist/install.sh
           cp scripts/install/install.ps1 dist/install.ps1
@@ -720,25 +759,37 @@ jobs:
           tag_name: ${{ github.ref_name }}
           body_path: ${{ steps.release_notes.outputs.path }}
           files: dist/**
+          make_latest: ${{ env.SIGN_MACOS == 'true' && !contains(steps.release_name.outputs.name, '-') }}
           # Mark as prerelease only when the version has a suffix after x.y.z
           # (e.g. -alpha, -beta). Otherwise publish a normal release.
           prerelease: ${{ contains(steps.release_name.outputs.name, '-') }}
 
-      - uses: facebook/dotslash-publish-release@9c9ec027515c34db9282a09a25a9cab5880b2c52 # v2
+      - if: ${{ env.SIGN_MACOS == 'true' }}
+        uses: facebook/dotslash-publish-release@9c9ec027515c34db9282a09a25a9cab5880b2c52 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag: ${{ github.ref_name }}
           config: .github/dotslash-config.json
 
-      - uses: facebook/dotslash-publish-release@9c9ec027515c34db9282a09a25a9cab5880b2c52 # v2
+      - if: ${{ env.SIGN_MACOS == 'false' }}
+        uses: facebook/dotslash-publish-release@9c9ec027515c34db9282a09a25a9cab5880b2c52 # v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag: ${{ github.ref_name }}
+          config: .github/dotslash-unsigned-config.json
+
+      - if: ${{ env.SIGN_MACOS == 'true' }}
+        uses: facebook/dotslash-publish-release@9c9ec027515c34db9282a09a25a9cab5880b2c52 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag: ${{ github.ref_name }}
           config: .github/dotslash-zsh-config.json
 
-      - uses: facebook/dotslash-publish-release@9c9ec027515c34db9282a09a25a9cab5880b2c52 # v2
+      - if: ${{ env.SIGN_MACOS == 'true' }}
+        uses: facebook/dotslash-publish-release@9c9ec027515c34db9282a09a25a9cab5880b2c52 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -748,7 +799,7 @@ jobs:
       - name: Trigger developers.openai.com deploy
         # Only trigger the deploy if the release is not a pre-release.
         # The deploy is used to update the developers.openai.com website with the new config schema json file.
-        if: ${{ !contains(steps.release_name.outputs.name, '-') }}
+        if: ${{ env.SIGN_MACOS == 'true' && !contains(steps.release_name.outputs.name, '-') }}
         continue-on-error: true
         env:
           DEV_WEBSITE_VERCEL_DEPLOY_HOOK_URL: ${{ secrets.DEV_WEBSITE_VERCEL_DEPLOY_HOOK_URL }}
@@ -962,7 +1013,7 @@ jobs:
     needs: release
     # Only publish stable/mainline releases to WinGet; pre-releases include a
     # '-' in the semver string (e.g., 1.2.3-alpha.1).
-    if: ${{ !contains(needs.release.outputs.version, '-') }}
+    if: ${{ needs.release.outputs.sign_macos == 'true' && !contains(needs.release.outputs.version, '-') }}
     # This job only invokes a GitHub Action to open/update the winget-pkgs PR;
     # it does not execute Windows-only tooling, so Linux is sufficient.
     runs-on: ubuntu-latest
@@ -982,6 +1033,7 @@ jobs:
 
   update-branch:
     name: Update latest-alpha-cli branch
+    if: ${{ needs.release.outputs.sign_macos == 'true' }}
     permissions:
       contents: write
     needs: release

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -637,7 +637,9 @@ jobs:
           find dist -mindepth 1 -maxdepth 1 -type d \
             ! -name '*-apple-darwin*-unsigned' \
             ! -name 'aarch64-unknown-linux-musl' \
+            ! -name 'aarch64-unknown-linux-musl-app-server' \
             ! -name 'x86_64-unknown-linux-musl' \
+            ! -name 'x86_64-unknown-linux-musl-app-server' \
             ! -name 'aarch64-pc-windows-msvc' \
             ! -name 'x86_64-pc-windows-msvc' \
             -exec rm -rf {} +


### PR DESCRIPTION
This is the exact same change as @bolinfest made but he could not push because of github action change permission. 

## Why

The `rust-release` workflow can now be run manually with `sign_macos=false` to skip macOS signing, but that path previously stopped before creating a GitHub Release. That left the unsigned macOS binaries available only as workflow-run artifacts, which are awkward to fetch from automation and cannot be retrieved with a simple unauthenticated `curl`.

For the unsigned path we still should not perform the normal release side effects: no npm or Python publishing, no WinGet publishing, no `latest-alpha-cli` branch update, and no promotion to GitHub's latest release. The goal is only to make the build outputs easy to fetch from the release page.

## What changed

- Allow the `release` job in `.github/workflows/rust-release.yml` to run for `workflow_dispatch` runs with `sign_macos=false`.
- For unsigned runs, keep the unsigned macOS artifacts plus the normal Linux and Windows release artifacts needed for DotSlash, then create/update the GitHub Release with `make_latest: false`.
- Keep the normal publish/promote paths gated to signed releases:
  - npm staging and publish
  - Python runtime publish
  - WinGet publish
  - `latest-alpha-cli` update
  - developer-site deploy
  - normal DotSlash release files
- Add `.github/dotslash-unsigned-config.json`, which publishes `*-unsigned` DotSlash files that use unsigned macOS artifacts and the normal Linux/Windows artifacts.


## What I added
PLEASE READ THIS!!!
I added `codex-command-runner` and `codex-windows-sandbox-setup` entries to `.github/dotslash-unsigned-config.json` so that with `sign_macos=false` we would still get the dotslash files for those artifacts which are necessary for windows builds. 