### PR TITLE
[codex] Ignore fsmonitor config in Git metadata reads

### DIFF
--- a/codex-rs/core/src/git_info_tests.rs
+++ b/codex-rs/core/src/git_info_tests.rs
@@ -11,6 +11,8 @@ use core_test_support::PathBufExt;
 use core_test_support::PathExt;
 use core_test_support::skip_if_sandbox;
 use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use tempfile::TempDir;
 use tokio::process::Command;
@@ -335,6 +337,46 @@ async fn test_get_has_changes_with_untracked_change_returns_true() {
 
     fs::write(repo_path.join("new_file.txt"), "untracked").expect("write untracked file");
     assert_eq!(get_has_changes(&repo_path).await, Some(true));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn test_get_has_changes_ignores_repo_fsmonitor_config() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let repo_path = create_test_git_repo(&temp_dir).await;
+    let helper_path = repo_path.join("fsmonitor-helper.sh");
+    let marker_path = repo_path.join("fsmonitor-ran");
+
+    fs::write(
+        &helper_path,
+        format!(
+            "#!/bin/sh\nprintf ran > \"{}\"\n",
+            marker_path.to_string_lossy()
+        ),
+    )
+    .expect("write fsmonitor helper");
+    let mut permissions = fs::metadata(&helper_path)
+        .expect("read fsmonitor helper metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&helper_path, permissions).expect("mark fsmonitor helper executable");
+
+    Command::new("git")
+        .args([
+            "config",
+            "core.fsmonitor",
+            helper_path.to_string_lossy().as_ref(),
+        ])
+        .current_dir(&repo_path)
+        .output()
+        .await
+        .expect("configure fsmonitor helper");
+
+    assert_eq!(get_has_changes(&repo_path).await, Some(true));
+    assert!(
+        !marker_path.exists(),
+        "metadata collection should not invoke repository fsmonitor helpers"
+    );
 }
 
 #[tokio::test]

--- a/codex-rs/git-utils/src/info.rs
+++ b/codex-rs/git-utils/src/info.rs
@@ -375,6 +375,7 @@ async fn run_git_command_with_timeout(args: &[&str], cwd: &Path) -> Option<std::
     let mut command = Command::new("git");
     command
         .env("GIT_OPTIONAL_LOCKS", "0")
+        .args(["-c", "core.fsmonitor=false"])
         .args(args)
         .current_dir(cwd)
         .kill_on_drop(true);


### PR DESCRIPTION
## Summary
- keep Git metadata/status subprocesses independent of repository `core.fsmonitor` configuration
- preserve existing working-tree state reporting while making the helper behavior more predictable
- add regression coverage for `get_has_changes` when a repository defines an fsmonitor command

## Validation
- `cargo fmt --all`
- `cargo test -p codex-core test_get_has_changes_`
- `cargo test -p codex-git-utils`