### PR TITLE
[codex] fix plugin CLI active user layer compile

### DIFF
--- a/codex-rs/cli/src/marketplace_cmd.rs
+++ b/codex-rs/cli/src/marketplace_cmd.rs
@@ -152,7 +152,7 @@ async fn run_list(overrides: Vec<(String, toml::Value)>) -> Result<()> {
         .context("failed to load configuration")?;
     let configured_marketplaces = config
         .config_layer_stack
-        .get_user_layer()
+        .get_active_user_layer()
         .and_then(|layer| layer.config.get("marketplaces"))
         .and_then(toml::Value::as_table);
     let Some(configured_marketplaces) = configured_marketplaces else {

--- a/codex-rs/cli/src/plugin_cmd.rs
+++ b/codex-rs/cli/src/plugin_cmd.rs
@@ -349,7 +349,7 @@ fn configured_marketplace_snapshot_issues(
     load_errors: &[MarketplaceListError],
     marketplace_name: Option<&str>,
 ) -> Vec<ConfiguredMarketplaceSnapshotIssue> {
-    let Some(user_layer) = plugins_input.config_layer_stack.get_user_layer() else {
+    let Some(user_layer) = plugins_input.config_layer_stack.get_active_user_layer() else {
         return Vec::new();
     };
     let Some(configured_marketplaces) = user_layer


### PR DESCRIPTION
## Why

PR #21396 merged after #17141 removed the old `ConfigLayerStack::get_user_layer()` API. The new plugin CLI call sites still used that stale API, which caused `main` to fail compilation.

## What Changed

- update `codex plugin marketplace list` to read configured marketplaces through `get_active_user_layer()`
- update the plugin snapshot validation helper to use `get_active_user_layer()`

This preserves the intended active writable user-layer behavior from the profile-aware config API while fixing the stale call sites.

## Validation

- `cargo check -p codex-cli`
- `cargo test -p codex-cli --test plugin_cli`
- `git diff --check`
