### PR TITLE
Fix Windows sandbox clippy clones

### DIFF
--- a/codex-rs/windows-sandbox-rs/src/bin/setup_main/win.rs
+++ b/codex-rs/windows-sandbox-rs/src/bin/setup_main/win.rs
@@ -1034,7 +1034,7 @@ mod tests {
         let deny_sids = workspace_write_cap_sids_for_path(
             &codex_home,
             &workspace,
-            &[workspace.clone(), active_root.clone()],
+            &[workspace.clone(), active_root],
             &deny_path,
         )
         .expect("deny sids");
@@ -1070,7 +1070,7 @@ mod tests {
         let deny_sids = workspace_write_cap_sids_for_path(
             &codex_home,
             &workspace,
-            &[workspace.clone(), active_root.clone()],
+            &[workspace.clone(), active_root],
             &deny_path,
         )
         .expect("deny sids");


### PR DESCRIPTION
## Summary
- remove two redundant `PathBuf` clones in Windows sandbox setup tests
- fix current `rust-ci-full` Windows clippy failures on `main`

## Validation
- `just fmt`
- attempted on `dev`: `cargo clippy --target x86_64-pc-windows-msvc --tests --profile dev --timings -- -D warnings`
  - blocked by missing MSVC cross toolchain on the Linux devbox (`lib.exe` / MSVC C toolchain unavailable)
- live failure evidence: main `rust-ci-full` runs 25880209898 and 25879137967 failed on `windows-sandbox-rs/src/bin/setup_main/win.rs` with `clippy::redundant_clone` at the two edited callsites