### PR TITLE
make rust-release-prepare use env secret

### DIFF
--- a/.github/workflows/rust-release-prepare.yml
+++ b/.github/workflows/rust-release-prepare.yml
@@ -16,6 +16,9 @@ jobs:
   prepare:
     # Prevent scheduled runs on forks (no secrets, wastes Actions minutes)
     if: github.repository == 'openai/codex'
+    environment:
+      name: rust-release-prepare
+      deployment: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
made a `rust-release-prepare` environment with the necessary API key as an environment secret. use this in the workflow rather than the action secret.

once this merges and i confirm it works as intended, ill rm the action secret.