### PR TITLE
Unqueue plugin list and read requests

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol/common.rs
+++ b/codex-rs/app-server-protocol/src/protocol/common.rs
@@ -621,12 +621,12 @@ client_request_definitions! {
     },
     PluginList => "plugin/list" {
         params: v2::PluginListParams,
-        serialization: global_shared_read("plugin-read"),
+        serialization: None,
         response: v2::PluginListResponse,
     },
     PluginRead => "plugin/read" {
         params: v2::PluginReadParams,
-        serialization: global_shared_read("plugin-read"),
+        serialization: None,
         response: v2::PluginReadResponse,
     },
     PluginSkillRead => "plugin/skill/read" {
@@ -1700,12 +1700,7 @@ mod tests {
                 marketplace_kinds: None,
             },
         };
-        assert_eq!(
-            plugin_list.serialization_scope(),
-            Some(ClientRequestSerializationScope::GlobalSharedRead(
-                "plugin-read"
-            ))
-        );
+        assert_eq!(plugin_list.serialization_scope(), None);
 
         let plugin_read = ClientRequest::PluginRead {
             request_id: request_id(),
@@ -1715,12 +1710,7 @@ mod tests {
                 plugin_name: "plugin-a".to_string(),
             },
         };
-        assert_eq!(
-            plugin_read.serialization_scope(),
-            Some(ClientRequestSerializationScope::GlobalSharedRead(
-                "plugin-read"
-            ))
-        );
+        assert_eq!(plugin_read.serialization_scope(), None);
 
         let plugin_uninstall = ClientRequest::PluginUninstall {
             request_id: request_id(),


### PR DESCRIPTION
## Summary
- remove the app-server `plugin-read` serialization queue from `plugin/list` and `plugin/read`
- allow plugin read/list requests to start immediately instead of waiting behind other plugin read/list requests

## Test plan
- `just fmt`
- `cargo test -p codex-app-server-protocol`