### PR TITLE
Hide deferred tools from code mode prompt

### DIFF
--- a/codex-rs/core/src/tools/spec_plan.rs
+++ b/codex-rs/core/src/tools/spec_plan.rs
@@ -242,9 +242,19 @@ fn build_code_mode_executors(
             executor.spec()
         })
         .collect::<Vec<_>>();
-    let namespace_descriptions = code_mode_namespace_descriptions(&code_mode_nested_tool_specs);
+    let code_mode_prompt_tool_specs = executors
+        .iter()
+        .filter_map(|executor| {
+            if executor.exposure() != ToolExposure::Direct {
+                return None;
+            }
+
+            executor.spec()
+        })
+        .collect::<Vec<_>>();
+    let namespace_descriptions = code_mode_namespace_descriptions(&code_mode_prompt_tool_specs);
     let mut enabled_tools =
-        collect_code_mode_exec_prompt_tool_definitions(code_mode_nested_tool_specs.iter());
+        collect_code_mode_exec_prompt_tool_definitions(code_mode_prompt_tool_specs.iter());
     enabled_tools
         .sort_by(|left, right| compare_code_mode_tools(left, right, &namespace_descriptions));
 


### PR DESCRIPTION
## Why

`rust-ci-full` found that deferred tools were still being expanded into the code mode `exec` prompt description even though they are intentionally omitted from the initial prompt surface.

Failure evidence: [Ubuntu test job](https://github.com/openai/codex/actions/runs/26051613631/job/76589353085)

```xml
<testcase name="suite::code_mode::code_mode_only_guides_all_tools_search_and_calls_deferred_app_tools" classname="codex-core::all" time="2.169">
  <failure ...>
    assertion failed: !exec_description.contains("calendar_timezone_option_99")
  </failure>
</testcase>
```

## What changed

- keep deferred tools in code mode's nested runtime surface so `ALL_TOOLS` and `tools[...]` still work
- build the prompt-visible code mode tool definitions and namespace descriptions from `ToolExposure::Direct` tools only
- preserve `DirectModelOnly` exclusion from the nested code mode surface

## CI evidence

Recent failed `rust-ci-full` test runs that exposed this flake family:
- https://github.com/openai/codex/actions/runs/26115775739
- https://github.com/openai/codex/actions/runs/26114840740
- https://github.com/openai/codex/actions/runs/26114668996
- https://github.com/openai/codex/actions/runs/26113530208

Those failed test lanes uploaded nextest JUnit artifacts successfully. Representative artifacts from the latest run:
- https://github.com/openai/codex/actions/runs/26115775739/artifacts/7091965331
- https://github.com/openai/codex/actions/runs/26115775739/artifacts/7092022050
- https://github.com/openai/codex/actions/runs/26115775739/artifacts/7091820251

## Walkthrough

- Issue: code mode used the full nested runtime tool set to render the `exec` description, so deferred app/MCP tool names leaked into the initial prompt.
- Fix: split the derived spec lists in `spec_plan`: the runtime keeps the full nested callable set, while the prompt description is rendered from direct nested tools only.

## Devbox evidence

Attempted targeted pre-fix repro on `dev` from the PR base commit:

```sh
ssh -t dev 'cd /home/dev-user/code/codex-worktrees/repro-22740-base-20260519/codex-rs && export PATH=$HOME/code/openai/project/dotslash-gen/bin:$HOME/.local/bin:$PATH && cargo nextest run -p codex-core suite::code_mode::code_mode_only_guides_all_tools_search_and_calls_deferred_app_tools --cargo-profile ci-test --target x86_64-unknown-linux-gnu --no-fail-fast'
```

The devbox did not reach the test body because its worktree volume was full during compile:

```text
error: failed to write to `.../target/x86_64-unknown-linux-gnu/ci-test/deps/...`: No space left on device (os error 28)
error: command `.../cargo test --no-run ... --package codex-core --profile ci-test --target x86_64-unknown-linux-gnu` exited with code 101
```

The prior CI failure remains the useful behavior repro:

```text
thread 'suite::code_mode::code_mode_only_guides_all_tools_search_and_calls_deferred_app_tools' panicked at core/tests/suite/code_mode.rs:451:5:
assertion failed: !exec_description.contains("calendar_timezone_option_99")
```
