### PR TITLE
Fix Windows sandbox helper discovery in Cargo tests

### DIFF
--- a/.github/workflows/rust-ci-full.yml
+++ b/.github/workflows/rust-ci-full.yml
@@ -680,6 +680,16 @@ jobs:
           echo "CODEX_TEST_REMOTE_ENV=${CODEX_TEST_REMOTE_ENV}" >> "$GITHUB_ENV"
           echo "CODEX_TEST_REMOTE_EXEC_SERVER_URL=${CODEX_TEST_REMOTE_EXEC_SERVER_URL}" >> "$GITHUB_ENV"
 
+      - name: Build Windows sandbox test helpers
+        if: runner.os == 'Windows'
+        run: |
+          cargo build `
+            --target ${{ matrix.target }} `
+            --profile ci-test `
+            -p codex-windows-sandbox `
+            --bin codex-windows-sandbox-setup `
+            --bin codex-command-runner
+
       - name: tests
         id: test
         run: cargo nextest run --no-fail-fast --target ${{ matrix.target }} --cargo-profile ci-test --timings

--- a/codex-rs/core/tests/suite/windows_sandbox.rs
+++ b/codex-rs/core/tests/suite/windows_sandbox.rs
@@ -54,11 +54,32 @@ fn stage_windows_sandbox_helpers() -> anyhow::Result<()> {
     let resources_dir = test_exe_dir.join("codex-resources");
     std::fs::create_dir_all(&resources_dir)?;
     for helper_name in ["codex-windows-sandbox-setup", "codex-command-runner"] {
-        let helper = codex_utils_cargo_bin::cargo_bin(helper_name)?;
+        let helper = windows_sandbox_helper_path(test_exe_dir, helper_name)?;
         let file_name = Path::new(helper_name).with_extension("exe");
         std::fs::copy(helper, resources_dir.join(file_name))?;
     }
     Ok(())
+}
+
+fn windows_sandbox_helper_path(
+    test_exe_dir: &Path,
+    helper_name: &str,
+) -> anyhow::Result<std::path::PathBuf> {
+    let cargo_bin_error = match codex_utils_cargo_bin::cargo_bin(helper_name) {
+        Ok(helper) => return Ok(helper),
+        Err(error) => error,
+    };
+
+    let helper = test_exe_dir
+        .parent()
+        .context("Windows test executable directory should have a parent directory")?
+        .join(Path::new(helper_name).with_extension("exe"));
+    anyhow::ensure!(
+        helper.exists(),
+        "failed to resolve Windows sandbox helper {helper_name:?} via cargo_bin ({cargo_bin_error}); fallback path does not exist at {}",
+        helper.display(),
+    );
+    Ok(helper)
 }
 
 #[tokio::test]

--- a/codex-rs/core/tests/suite/windows_sandbox.rs
+++ b/codex-rs/core/tests/suite/windows_sandbox.rs
@@ -54,7 +54,21 @@ fn stage_windows_sandbox_helpers() -> anyhow::Result<()> {
     let resources_dir = test_exe_dir.join("codex-resources");
     std::fs::create_dir_all(&resources_dir)?;
     for helper_name in ["codex-windows-sandbox-setup", "codex-command-runner"] {
-        let helper = codex_utils_cargo_bin::cargo_bin(helper_name)?;
+        let helper = match codex_utils_cargo_bin::cargo_bin(helper_name) {
+            Ok(helper) => helper,
+            Err(cargo_bin_error) => {
+                let helper = test_exe_dir
+                    .parent()
+                    .context("Windows test executable directory should have a parent directory")?
+                    .join(Path::new(helper_name).with_extension("exe"));
+                anyhow::ensure!(
+                    helper.exists(),
+                    "failed to resolve Windows sandbox helper {helper_name:?} via cargo_bin ({cargo_bin_error}); fallback path does not exist at {}",
+                    helper.display(),
+                );
+                helper
+            }
+        };
         let file_name = Path::new(helper_name).with_extension("exe");
         std::fs::copy(helper, resources_dir.join(file_name))?;
     }


### PR DESCRIPTION
## Why

Windows Cargo/nextest lanes can run without Bazel-style runfiles, so the Windows sandbox tests need a Cargo-layout fallback when `codex_utils_cargo_bin::cargo_bin(...)` cannot resolve helper binaries. Without that fallback, the test can fail even when the helpers already exist in the sibling Cargo target directory.

Failure evidence: [Windows x64 test job](https://github.com/openai/codex/actions/runs/26115775739/job/76804530401)

## What changed

- keep Windows sandbox helper lookup local to `codex-rs/core/tests/suite/windows_sandbox.rs`
- fall back from `cargo_bin(...)` to the sibling Cargo target binary path under the current test executable directory
- fail with the original `cargo_bin` error plus the checked fallback path if neither lookup succeeds

## Verification

I did not run local validation for this recovery pass. The branch was recovered onto current `main` and narrowed to the one intended test file; current CI will provide the authoritative Windows signal.
