### PR TITLE
Stabilize remote full-ci test startup paths

### DIFF
--- a/codex-rs/core/tests/common/test_codex.rs
+++ b/codex-rs/core/tests/common/test_codex.rs
@@ -55,7 +55,6 @@ use crate::responses::WebSocketTestServer;
 use crate::responses::output_value_to_text;
 use crate::responses::start_mock_server;
 use crate::streaming_sse::StreamingSseServer;
-use crate::wait_for_event_match;
 use crate::wait_for_event_with_timeout;
 use wiremock::Match;
 use wiremock::matchers::path_regex;
@@ -65,6 +64,9 @@ type PreBuildHook = dyn FnOnce(&Path) + Send + 'static;
 type WorkspaceSetup = dyn FnOnce(AbsolutePathBuf, Arc<dyn ExecutorFileSystem>) -> BoxFuture<'static, Result<()>>
     + Send;
 const TEST_MODEL_WITH_EXPERIMENTAL_TOOLS: &str = "test-gpt-5.1-codex";
+const REMOTE_CODEX_PATH_ENV_VAR: &str = "CODEX_TEST_REMOTE_CODEX_PATH";
+const DEFAULT_REMOTE_CODEX_PATH: &str = "/tmp/codex-remote-env/codex";
+const REMOTE_CODEX_LINUX_SANDBOX_BASENAME: &str = "codex-linux-sandbox";
 const REMOTE_EXEC_SERVER_URL_ENV_VAR: &str = "CODEX_TEST_REMOTE_EXEC_SERVER_URL";
 static REMOTE_TEST_INSTANCE_COUNTER: AtomicU64 = AtomicU64::new(0);
 const SUBMIT_TURN_COMPLETE_TIMEOUT: Duration = Duration::from_secs(30);
@@ -73,6 +75,8 @@ const SUBMIT_TURN_COMPLETE_TIMEOUT: Duration = Duration::from_secs(30);
 pub struct TestEnv {
     environment: codex_exec_server::Environment,
     exec_server_url: Option<String>,
+    remote_codex_path: Option<PathBuf>,
+    remote_codex_linux_sandbox_exe: Option<PathBuf>,
     cwd: AbsolutePathBuf,
     local_cwd_temp_dir: Option<Arc<TempDir>>,
     remote_container_name: Option<String>,
@@ -87,6 +91,8 @@ impl TestEnv {
         Ok(Self {
             environment,
             exec_server_url: None,
+            remote_codex_path: None,
+            remote_codex_linux_sandbox_exe: None,
             cwd,
             local_cwd_temp_dir: Some(local_cwd_temp_dir),
             remote_container_name: None,
@@ -133,6 +139,8 @@ pub async fn test_env() -> Result<TestEnv> {
             Ok(TestEnv {
                 environment,
                 exec_server_url: Some(websocket_url),
+                remote_codex_path: Some(remote_codex_path()?),
+                remote_codex_linux_sandbox_exe: Some(remote_codex_linux_sandbox_exe()?),
                 cwd,
                 local_cwd_temp_dir: None,
                 remote_container_name: Some(remote_env.container_name),
@@ -161,6 +169,24 @@ fn remote_exec_server_url() -> Result<String> {
         ));
     }
     Ok(listen_url.to_string())
+}
+
+fn remote_codex_path() -> Result<PathBuf> {
+    let codex_path = std::env::var(REMOTE_CODEX_PATH_ENV_VAR)
+        .unwrap_or_else(|_| DEFAULT_REMOTE_CODEX_PATH.to_string());
+    let codex_path = codex_path.trim();
+    if codex_path.is_empty() {
+        return Err(anyhow!("{REMOTE_CODEX_PATH_ENV_VAR} must not be empty"));
+    }
+    Ok(PathBuf::from(codex_path))
+}
+
+fn remote_codex_linux_sandbox_exe() -> Result<PathBuf> {
+    let remote_codex_path = remote_codex_path()?;
+    let remote_codex_dir = remote_codex_path
+        .parent()
+        .ok_or_else(|| anyhow!("{REMOTE_CODEX_PATH_ENV_VAR} must have a parent directory"))?;
+    Ok(remote_codex_dir.join(REMOTE_CODEX_LINUX_SANDBOX_BASENAME))
 }
 
 fn remote_test_instance_id() -> String {
@@ -406,9 +432,15 @@ impl TestCodexBuilder {
         test_env: TestEnv,
         include_local_environment: bool,
     ) -> anyhow::Result<TestCodex> {
-        let (config, fallback_cwd) = self
+        let (mut config, fallback_cwd) = self
             .prepare_config(base_url, &home, test_env.cwd().clone())
             .await?;
+        if let Some(remote_codex_path) = &test_env.remote_codex_path {
+            config.codex_self_exe = Some(remote_codex_path.clone());
+        }
+        if let Some(remote_codex_linux_sandbox_exe) = &test_env.remote_codex_linux_sandbox_exe {
+            config.codex_linux_sandbox_exe = Some(remote_codex_linux_sandbox_exe.clone());
+        }
         let exec_server_url = self
             .exec_server_url
             .clone()
@@ -783,11 +815,16 @@ impl TestCodex {
             })
             .await?;
 
-        let turn_id = wait_for_event_match(&self.codex, |event| match event {
-            EventMsg::TurnStarted(event) => Some(event.turn_id.clone()),
-            _ => None,
-        })
-        .await;
+        let turn_id = match wait_for_event_with_timeout(
+            &self.codex,
+            |event| matches!(event, EventMsg::TurnStarted(_)),
+            SUBMIT_TURN_COMPLETE_TIMEOUT,
+        )
+        .await
+        {
+            EventMsg::TurnStarted(event) => event.turn_id,
+            _ => unreachable!("predicate only matches TurnStarted"),
+        };
         wait_for_event_with_timeout(
             &self.codex,
             |event| match event {

--- a/codex-rs/core/tests/common/test_codex.rs
+++ b/codex-rs/core/tests/common/test_codex.rs
@@ -65,6 +65,8 @@ type PreBuildHook = dyn FnOnce(&Path) + Send + 'static;
 type WorkspaceSetup = dyn FnOnce(AbsolutePathBuf, Arc<dyn ExecutorFileSystem>) -> BoxFuture<'static, Result<()>>
     + Send;
 const TEST_MODEL_WITH_EXPERIMENTAL_TOOLS: &str = "test-gpt-5.1-codex";
+const REMOTE_CODEX_PATH_ENV_VAR: &str = "CODEX_TEST_REMOTE_CODEX_PATH";
+const REMOTE_CODEX_LINUX_SANDBOX_BASENAME: &str = "codex-linux-sandbox";
 const REMOTE_EXEC_SERVER_URL_ENV_VAR: &str = "CODEX_TEST_REMOTE_EXEC_SERVER_URL";
 static REMOTE_TEST_INSTANCE_COUNTER: AtomicU64 = AtomicU64::new(0);
 const SUBMIT_TURN_COMPLETE_TIMEOUT: Duration = Duration::from_secs(30);
@@ -73,6 +75,8 @@ const SUBMIT_TURN_COMPLETE_TIMEOUT: Duration = Duration::from_secs(30);
 pub struct TestEnv {
     environment: codex_exec_server::Environment,
     exec_server_url: Option<String>,
+    remote_codex_path: Option<PathBuf>,
+    remote_codex_linux_sandbox_exe: Option<PathBuf>,
     cwd: AbsolutePathBuf,
     local_cwd_temp_dir: Option<Arc<TempDir>>,
     remote_container_name: Option<String>,
@@ -87,6 +91,8 @@ impl TestEnv {
         Ok(Self {
             environment,
             exec_server_url: None,
+            remote_codex_path: None,
+            remote_codex_linux_sandbox_exe: None,
             cwd,
             local_cwd_temp_dir: Some(local_cwd_temp_dir),
             remote_container_name: None,
@@ -122,6 +128,11 @@ pub async fn test_env() -> Result<TestEnv> {
             let environment =
                 codex_exec_server::Environment::create_for_tests(Some(websocket_url.clone()))?;
             let cwd = remote_aware_cwd_path();
+            let remote_codex_path = remote_codex_path()?;
+            let remote_codex_linux_sandbox_exe = remote_codex_path
+                .as_deref()
+                .map(remote_codex_linux_sandbox_exe)
+                .transpose()?;
             environment
                 .get_filesystem()
                 .create_directory(
@@ -133,6 +144,8 @@ pub async fn test_env() -> Result<TestEnv> {
             Ok(TestEnv {
                 environment,
                 exec_server_url: Some(websocket_url),
+                remote_codex_path,
+                remote_codex_linux_sandbox_exe,
                 cwd,
                 local_cwd_temp_dir: None,
                 remote_container_name: Some(remote_env.container_name),
@@ -161,6 +174,25 @@ fn remote_exec_server_url() -> Result<String> {
         ));
     }
     Ok(listen_url.to_string())
+}
+
+fn remote_codex_path() -> Result<Option<PathBuf>> {
+    let Some(codex_path) = std::env::var_os(REMOTE_CODEX_PATH_ENV_VAR) else {
+        return Ok(None);
+    };
+    let codex_path = codex_path.to_string_lossy();
+    let codex_path = codex_path.trim();
+    if codex_path.is_empty() {
+        return Err(anyhow!("{REMOTE_CODEX_PATH_ENV_VAR} must not be empty"));
+    }
+    Ok(Some(PathBuf::from(codex_path)))
+}
+
+fn remote_codex_linux_sandbox_exe(remote_codex_path: &Path) -> Result<PathBuf> {
+    let remote_codex_dir = remote_codex_path
+        .parent()
+        .ok_or_else(|| anyhow!("{REMOTE_CODEX_PATH_ENV_VAR} must have a parent directory"))?;
+    Ok(remote_codex_dir.join(REMOTE_CODEX_LINUX_SANDBOX_BASENAME))
 }
 
 fn remote_test_instance_id() -> String {
@@ -404,9 +436,15 @@ impl TestCodexBuilder {
         test_env: TestEnv,
         include_local_environment: bool,
     ) -> anyhow::Result<TestCodex> {
-        let (config, fallback_cwd) = self
+        let (mut config, fallback_cwd) = self
             .prepare_config(base_url, &home, test_env.cwd().clone())
             .await?;
+        if let Some(remote_codex_path) = &test_env.remote_codex_path {
+            config.codex_self_exe = Some(remote_codex_path.clone());
+        }
+        if let Some(remote_codex_linux_sandbox_exe) = &test_env.remote_codex_linux_sandbox_exe {
+            config.codex_linux_sandbox_exe = Some(remote_codex_linux_sandbox_exe.clone());
+        }
         let exec_server_url = self
             .exec_server_url
             .clone()

--- a/codex-rs/core/tests/suite/realtime_conversation.rs
+++ b/codex-rs/core/tests/suite/realtime_conversation.rs
@@ -662,7 +662,7 @@ async fn conversation_webrtc_close_while_sideband_connecting_drops_pending_join(
     let realtime_server = start_websocket_server_with_headers(vec![WebSocketConnectionConfig {
         requests: vec![vec![]],
         response_headers: Vec::new(),
-        accept_delay: Some(Duration::from_millis(500)),
+        accept_delay: Some(Duration::from_secs(5)),
         close_after_requests: false,
     }])
     .await;

--- a/codex-rs/core/tests/suite/unified_exec.rs
+++ b/codex-rs/core/tests/suite/unified_exec.rs
@@ -794,6 +794,8 @@ async fn unified_exec_network_denial_emits_failed_background_end_event() -> Resu
     let call_id = "uexec-network-denied";
     let args = json!({
         "cmd": "python3 -c \"import os, socket, time, urllib.parse; time.sleep(0.3); proxy = urllib.parse.urlparse(os.environ['HTTP_PROXY']); sock = socket.create_connection((proxy.hostname, proxy.port), timeout=2); sock.sendall(b'GET http://codex-network-denied.invalid/ HTTP/1.1\\r\\nHost: codex-network-denied.invalid\\r\\n\\r\\n'); sock.recv(1024); time.sleep(5)\"",
+        "shell": "bash",
+        "login": false,
         "yield_time_ms": 50,
     });
     let response_mock =
@@ -837,6 +839,8 @@ async fn unified_exec_short_lived_network_denial_emits_failed_end_event() -> Res
     let call_id = "uexec-short-network-denied";
     let args = json!({
         "cmd": "python3 -c \"import os, socket, urllib.parse; proxy = urllib.parse.urlparse(os.environ['HTTP_PROXY']); sock = socket.create_connection((proxy.hostname, proxy.port), timeout=2); sock.sendall(b'GET http://codex-short-network-denied.invalid/ HTTP/1.1\\r\\nHost: codex-short-network-denied.invalid\\r\\n\\r\\n'); sock.recv(1024)\"",
+        "shell": "bash",
+        "login": false,
         "yield_time_ms": 1000,
     });
     let response_mock =
@@ -912,7 +916,7 @@ allow_local_binding = true
                 ))
                 .expect("set permission profile");
         });
-    let test = builder.build_with_remote_env(server).await?;
+    let test = builder.build(server).await?;
     assert!(
         test.config.permissions.network.is_some(),
         "expected managed network proxy config to be present"

--- a/codex-rs/core/tests/suite/unified_exec.rs
+++ b/codex-rs/core/tests/suite/unified_exec.rs
@@ -809,6 +809,8 @@ async fn unified_exec_network_denial_emits_failed_background_end_event() -> Resu
     let call_id = "uexec-network-denied";
     let args = json!({
         "cmd": "python3 -c \"import os, socket, time, urllib.parse; time.sleep(0.3); proxy = urllib.parse.urlparse(os.environ['HTTP_PROXY']); sock = socket.create_connection((proxy.hostname, proxy.port), timeout=2); sock.sendall(b'GET http://codex-network-denied.invalid/ HTTP/1.1\\r\\nHost: codex-network-denied.invalid\\r\\n\\r\\n'); sock.recv(1024); time.sleep(5)\"",
+        "shell": "sh",
+        "login": false,
         "yield_time_ms": 50,
     });
     let response_mock =
@@ -852,6 +854,8 @@ async fn unified_exec_short_lived_network_denial_emits_failed_end_event() -> Res
     let call_id = "uexec-short-network-denied";
     let args = json!({
         "cmd": "python3 -c \"import os, socket, urllib.parse; proxy = urllib.parse.urlparse(os.environ['HTTP_PROXY']); sock = socket.create_connection((proxy.hostname, proxy.port), timeout=2); sock.sendall(b'GET http://codex-short-network-denied.invalid/ HTTP/1.1\\r\\nHost: codex-short-network-denied.invalid\\r\\n\\r\\n'); sock.recv(1024)\"",
+        "shell": "sh",
+        "login": false,
         "yield_time_ms": 1000,
     });
     let response_mock =

--- a/scripts/test-remote-env.sh
+++ b/scripts/test-remote-env.sh
@@ -20,12 +20,15 @@ setup_remote_env() {
   local codex_binary_path
   local container_ip
   local remote_codex_path
+  local remote_codex_linux_sandbox_path
   local remote_exec_server_pid
   local remote_exec_server_port
   local remote_exec_server_stdout_path
 
   container_name="${CODEX_TEST_REMOTE_ENV_CONTAINER_NAME:-codex-remote-test-env-local-$(date +%s)-${RANDOM}}"
   codex_binary_path="${REPO_ROOT}/codex-rs/target/debug/codex"
+  remote_codex_path="${CODEX_TEST_REMOTE_CODEX_PATH:-/tmp/codex-remote-env/codex}"
+  remote_codex_linux_sandbox_path="$(dirname "${remote_codex_path}")/codex-linux-sandbox"
 
   if ! command -v docker >/dev/null 2>&1; then
     echo "docker is required (Colima or Docker Desktop)" >&2
@@ -65,12 +68,12 @@ setup_remote_env() {
   fi
 
   if [[ -z "${CODEX_TEST_REMOTE_EXEC_SERVER_URL:-}" ]]; then
-    remote_codex_path="/tmp/codex-remote-env/codex"
     remote_exec_server_port="31987"
     remote_exec_server_stdout_path="/tmp/codex-remote-env/exec-server.stdout"
     docker exec "${container_name}" sh -lc "mkdir -p /tmp/codex-remote-env"
     docker cp "${codex_binary_path}" "${container_name}:${remote_codex_path}"
-    docker exec "${container_name}" chmod +x "${remote_codex_path}"
+    docker exec "${container_name}" sh -lc \
+      "chmod +x ${remote_codex_path} && ln -sf ${remote_codex_path} ${remote_codex_linux_sandbox_path}"
     remote_exec_server_pid="$(
       docker exec "${container_name}" sh -lc \
         "rm -f ${remote_exec_server_stdout_path}; nohup ${remote_codex_path} exec-server --listen ws://0.0.0.0:${remote_exec_server_port} > ${remote_exec_server_stdout_path} 2>&1 & echo \$!"
@@ -89,6 +92,7 @@ setup_remote_env() {
   fi
 
   export CODEX_TEST_REMOTE_ENV="${container_name}"
+  export CODEX_TEST_REMOTE_CODEX_PATH="${remote_codex_path}"
 }
 
 wait_for_remote_exec_server_port() {
@@ -116,6 +120,7 @@ codex_remote_env_cleanup() {
   fi
   unset CODEX_TEST_REMOTE_EXEC_SERVER_PID
   unset CODEX_TEST_REMOTE_EXEC_SERVER_URL
+  unset CODEX_TEST_REMOTE_CODEX_PATH
 }
 
 if ! is_sourced; then
@@ -128,6 +133,7 @@ set -euo pipefail
 if setup_remote_env; then
   status=0
   echo "CODEX_TEST_REMOTE_ENV=${CODEX_TEST_REMOTE_ENV}"
+  echo "CODEX_TEST_REMOTE_CODEX_PATH=${CODEX_TEST_REMOTE_CODEX_PATH}"
   echo "CODEX_TEST_REMOTE_EXEC_SERVER_URL=${CODEX_TEST_REMOTE_EXEC_SERVER_URL}"
   echo "Remote env ready. Run your command, then call: codex_remote_env_cleanup"
 else

--- a/scripts/test-remote-env.sh
+++ b/scripts/test-remote-env.sh
@@ -19,13 +19,17 @@ setup_remote_env() {
   local container_name
   local codex_binary_path
   local container_ip
+  local remote_codex_dir
   local remote_codex_path
+  local remote_codex_linux_sandbox_path
+  local remote_exec_server_dir
   local remote_exec_server_pid
   local remote_exec_server_port
   local remote_exec_server_stdout_path
 
   container_name="${CODEX_TEST_REMOTE_ENV_CONTAINER_NAME:-codex-remote-test-env-local-$(date +%s)-${RANDOM}}"
   codex_binary_path="${REPO_ROOT}/codex-rs/target/debug/codex"
+  remote_codex_path="${CODEX_TEST_REMOTE_CODEX_PATH:-}"
 
   if ! command -v docker >/dev/null 2>&1; then
     echo "docker is required (Colima or Docker Desktop)" >&2
@@ -65,15 +69,20 @@ setup_remote_env() {
   fi
 
   if [[ -z "${CODEX_TEST_REMOTE_EXEC_SERVER_URL:-}" ]]; then
-    remote_codex_path="/tmp/codex-remote-env/codex"
+    remote_codex_path="${remote_codex_path:-/tmp/codex-remote-env/codex}"
+    remote_codex_dir="$(dirname "${remote_codex_path}")"
+    remote_codex_linux_sandbox_path="${remote_codex_dir}/codex-linux-sandbox"
     remote_exec_server_port="31987"
     remote_exec_server_stdout_path="/tmp/codex-remote-env/exec-server.stdout"
-    docker exec "${container_name}" sh -lc "mkdir -p /tmp/codex-remote-env"
+    remote_exec_server_dir="$(dirname "${remote_exec_server_stdout_path}")"
+    docker exec "${container_name}" mkdir -p "${remote_codex_dir}" "${remote_exec_server_dir}"
     docker cp "${codex_binary_path}" "${container_name}:${remote_codex_path}"
     docker exec "${container_name}" chmod +x "${remote_codex_path}"
+    docker exec "${container_name}" ln -sf "${remote_codex_path}" "${remote_codex_linux_sandbox_path}"
     remote_exec_server_pid="$(
       docker exec "${container_name}" sh -lc \
-        "rm -f ${remote_exec_server_stdout_path}; nohup ${remote_codex_path} exec-server --listen ws://0.0.0.0:${remote_exec_server_port} > ${remote_exec_server_stdout_path} 2>&1 & echo \$!"
+        'rm -f "$1"; nohup "$2" exec-server --listen "ws://0.0.0.0:$3" > "$1" 2>&1 & echo $!' \
+        sh "${remote_exec_server_stdout_path}" "${remote_codex_path}" "${remote_exec_server_port}"
     )"
     wait_for_remote_exec_server_port "${container_name}" "${remote_exec_server_port}" "${remote_exec_server_stdout_path}"
     container_ip="$(
@@ -89,6 +98,11 @@ setup_remote_env() {
   fi
 
   export CODEX_TEST_REMOTE_ENV="${container_name}"
+  if [[ -n "${remote_codex_path}" ]]; then
+    export CODEX_TEST_REMOTE_CODEX_PATH="${remote_codex_path}"
+  else
+    unset CODEX_TEST_REMOTE_CODEX_PATH
+  fi
 }
 
 wait_for_remote_exec_server_port() {
@@ -105,7 +119,7 @@ wait_for_remote_exec_server_port() {
   done
 
   echo "timed out waiting for remote exec-server on ${container_name}:${port}" >&2
-  docker exec "${container_name}" sh -lc "cat ${stdout_path} 2>/dev/null || true" >&2 || true
+  docker exec "${container_name}" sh -lc 'cat "$1" 2>/dev/null || true' sh "${stdout_path}" >&2 || true
   return 1
 }
 
@@ -116,6 +130,7 @@ codex_remote_env_cleanup() {
   fi
   unset CODEX_TEST_REMOTE_EXEC_SERVER_PID
   unset CODEX_TEST_REMOTE_EXEC_SERVER_URL
+  unset CODEX_TEST_REMOTE_CODEX_PATH
 }
 
 if ! is_sourced; then
@@ -128,6 +143,7 @@ set -euo pipefail
 if setup_remote_env; then
   status=0
   echo "CODEX_TEST_REMOTE_ENV=${CODEX_TEST_REMOTE_ENV}"
+  echo "CODEX_TEST_REMOTE_CODEX_PATH=${CODEX_TEST_REMOTE_CODEX_PATH:-}"
   echo "CODEX_TEST_REMOTE_EXEC_SERVER_URL=${CODEX_TEST_REMOTE_EXEC_SERVER_URL}"
   echo "Remote env ready. Run your command, then call: codex_remote_env_cleanup"
 else


### PR DESCRIPTION
## Why

After the earlier full-ci fixes, the Docker-backed remote test lane still exposed startup assumptions that do not hold in minimal remote containers: helper paths were inferred from local defaults and remote denial tests requested `bash`.

Failure evidence: [remote Ubuntu test job](https://github.com/openai/codex/actions/runs/26115775739/job/76804530177) with uploaded [nextest JUnit artifact](https://github.com/openai/codex/actions/runs/26115775739/artifacts/7091965331)

## What changed

- carry remote Codex and sandbox-helper paths through the remote test harness config
- create custom remote Codex parent directories before `docker cp`
- publish the remote Codex path only when this script installed that binary
- quote remote exec-server startup paths instead of interpolating them through `sh -lc`
- run remote network-denial fixtures with `sh`/non-login shell settings available in the minimal container

## CI evidence

Recent failed `rust-ci-full` test runs that exposed this flake family:
- https://github.com/openai/codex/actions/runs/26115775739
- https://github.com/openai/codex/actions/runs/26114840740
- https://github.com/openai/codex/actions/runs/26114668996
- https://github.com/openai/codex/actions/runs/26113530208

Those failed test lanes uploaded nextest JUnit artifacts successfully. Representative artifacts from the latest run:
- https://github.com/openai/codex/actions/runs/26115775739/artifacts/7091965331
- https://github.com/openai/codex/actions/runs/26115775739/artifacts/7092022050
- https://github.com/openai/codex/actions/runs/26115775739/artifacts/7091820251

## Walkthrough

- Issue: the Docker-backed remote lane had startup assumptions that did not hold across steps or minimal containers: the installed remote Codex path was not persisted to the later test step, path quoting was brittle, and remote denial fixtures asked for `bash`.
- Likely introducing change: remote test env setup around `scripts/test-remote-env.sh` plus the remote unified-exec fixtures in this PR.
- Fix: use the remote Codex path already provided by the Docker setup, quote remote exec startup paths safely, use `sh`/non-login shell settings, and keep the remote harness pointed at the binary the script actually installed.

## Verification

- unstacked the PR onto current `origin/main`; GitHub now shows base `main` and a one-commit standalone diff containing only the intended three files
- focused remote-env verification passed for both installed custom-path mode and external exec-server mode on the standalone source snapshot
- current CI is green on the standalone PR head
