### PR TITLE
Emit unified exec end on startup failure

### DIFF
--- a/codex-rs/core/src/unified_exec/errors.rs
+++ b/codex-rs/core/src/unified_exec/errors.rs
@@ -18,6 +18,8 @@ pub(crate) enum UnifiedExecError {
     StdinClosed,
     #[error("missing command line for unified exec request")]
     MissingCommandLine,
+    #[error("{message}")]
+    Rejected { message: String },
     #[error("Command denied by sandbox: {message}")]
     SandboxDenied {
         message: String,
@@ -32,6 +34,10 @@ impl UnifiedExecError {
 
     pub(crate) fn process_failed(message: String) -> Self {
         Self::ProcessFailed { message }
+    }
+
+    pub(crate) fn rejected(message: String) -> Self {
+        Self::Rejected { message }
     }
 
     pub(crate) fn sandbox_denied(message: String, output: ExecToolCallOutput) -> Self {

--- a/codex-rs/core/src/unified_exec/errors.rs
+++ b/codex-rs/core/src/unified_exec/errors.rs
@@ -23,6 +23,8 @@ pub(crate) enum UnifiedExecError {
         message: String,
         output: ExecToolCallOutput,
     },
+    #[error("Command rejected: {message}")]
+    Rejected { message: String },
 }
 
 impl UnifiedExecError {
@@ -36,5 +38,9 @@ impl UnifiedExecError {
 
     pub(crate) fn sandbox_denied(message: String, output: ExecToolCallOutput) -> Self {
         Self::SandboxDenied { message, output }
+    }
+
+    pub(crate) fn rejected(message: String) -> Self {
+        Self::Rejected { message }
     }
 }

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -19,6 +19,7 @@ use crate::sandboxing::ExecServerEnvConfig;
 use crate::tools::context::ExecCommandToolOutput;
 use crate::tools::events::ToolEmitter;
 use crate::tools::events::ToolEventCtx;
+use crate::tools::events::ToolEventFailure;
 use crate::tools::events::ToolEventStage;
 use crate::tools::network_approval::DeferredNetworkApproval;
 use crate::tools::network_approval::finish_deferred_network_approval;
@@ -381,6 +382,25 @@ impl UnifiedExecProcessManager {
                 (Arc::new(process), deferred_network_approval)
             }
             Err(err) => {
+                let event_ctx = ToolEventCtx::new(
+                    context.session.as_ref(),
+                    context.turn.as_ref(),
+                    &context.call_id,
+                    /*turn_diff_tracker*/ None,
+                );
+                let emitter = ToolEmitter::unified_exec(
+                    &request.command,
+                    cwd.clone(),
+                    ExecCommandSource::UnifiedExecStartup,
+                    Some(request.process_id.to_string()),
+                );
+                emitter.emit(event_ctx, ToolEventStage::Begin).await;
+                emitter
+                    .emit(
+                        event_ctx,
+                        ToolEventStage::Failure(startup_failure_event(&err)),
+                    )
+                    .await;
                 self.release_process_id(request.process_id).await;
                 return Err(err);
             }
@@ -1276,6 +1296,13 @@ impl UnifiedExecProcessManager {
             unregister_network_approval_for_entry(&entry).await;
             entry.process.terminate();
         }
+    }
+}
+
+fn startup_failure_event(err: &UnifiedExecError) -> ToolEventFailure<'_> {
+    match err {
+        UnifiedExecError::SandboxDenied { output, .. } => ToolEventFailure::Output(output.clone()),
+        _ => ToolEventFailure::Message(format!("execution error: {err:?}")),
     }
 }
 

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -1104,6 +1104,7 @@ impl UnifiedExecProcessManager {
                     };
                     UnifiedExecError::sandbox_denied(message, output)
                 }
+                ToolError::Rejected(message) => UnifiedExecError::rejected(message),
                 other => UnifiedExecError::create_process(format!("{other:?}")),
             })
     }
@@ -1302,6 +1303,10 @@ impl UnifiedExecProcessManager {
 fn startup_failure_event(err: &UnifiedExecError) -> ToolEventFailure<'_> {
     match err {
         UnifiedExecError::SandboxDenied { output, .. } => ToolEventFailure::Output(output.clone()),
+        UnifiedExecError::Rejected { message } => ToolEventFailure::Rejected {
+            message: message.clone(),
+            applied_patch_delta: None,
+        },
         _ => ToolEventFailure::Message(format!("execution error: {err:?}")),
     }
 }

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -19,6 +19,7 @@ use crate::sandboxing::ExecServerEnvConfig;
 use crate::tools::context::ExecCommandToolOutput;
 use crate::tools::events::ToolEmitter;
 use crate::tools::events::ToolEventCtx;
+use crate::tools::events::ToolEventFailure;
 use crate::tools::events::ToolEventStage;
 use crate::tools::network_approval::DeferredNetworkApproval;
 use crate::tools::network_approval::finish_deferred_network_approval;
@@ -381,6 +382,7 @@ impl UnifiedExecProcessManager {
                 (Arc::new(process), deferred_network_approval)
             }
             Err(err) => {
+                emit_startup_failure_events(context, &request, cwd.clone(), &err).await;
                 self.release_process_id(request.process_id).await;
                 return Err(err);
             }
@@ -1086,6 +1088,10 @@ impl UnifiedExecProcessManager {
                     };
                     UnifiedExecError::sandbox_denied(message, output)
                 }
+                ToolError::Rejected(message) if message == "rejected by user" => {
+                    UnifiedExecError::rejected(message)
+                }
+                ToolError::Rejected(message) => UnifiedExecError::create_process(message),
                 other => UnifiedExecError::create_process(format!("{other:?}")),
             })
     }
@@ -1279,6 +1285,40 @@ impl UnifiedExecProcessManager {
             entry.process.terminate();
         }
     }
+}
+
+async fn emit_startup_failure_events(
+    context: &UnifiedExecContext,
+    request: &ExecCommandRequest,
+    cwd: AbsolutePathBuf,
+    err: &UnifiedExecError,
+) {
+    let event_ctx = ToolEventCtx::new(
+        context.session.as_ref(),
+        context.turn.as_ref(),
+        &context.call_id,
+        /*turn_diff_tracker*/ None,
+    );
+    let emitter = ToolEmitter::unified_exec(
+        &request.command,
+        cwd,
+        ExecCommandSource::UnifiedExecStartup,
+        Some(request.process_id.to_string()),
+    );
+    emitter.emit(event_ctx, ToolEventStage::Begin).await;
+    let failure = match err {
+        UnifiedExecError::MissingCommandLine => {
+            ToolEventFailure::Message("missing command line for unified exec request".to_string())
+        }
+        UnifiedExecError::Rejected { message } => ToolEventFailure::Rejected {
+            message: message.clone(),
+            applied_patch_delta: None,
+        },
+        _ => ToolEventFailure::Message(format!("execution error: {err:?}")),
+    };
+    emitter
+        .emit(event_ctx, ToolEventStage::Failure(failure))
+        .await;
 }
 
 enum ProcessStatus {

--- a/codex-rs/core/src/unified_exec/process_manager_tests.rs
+++ b/codex-rs/core/src/unified_exec/process_manager_tests.rs
@@ -1,7 +1,94 @@
 use super::*;
+use crate::session::turn_context::TurnContext;
+use codex_protocol::exec_output::ExecToolCallOutput;
+use codex_protocol::exec_output::StreamOutput;
 use pretty_assertions::assert_eq;
 use tokio::time::Duration;
 use tokio::time::Instant;
+
+fn startup_failure_test_request(turn: &TurnContext, process_id: i32) -> ExecCommandRequest {
+    ExecCommandRequest {
+        command: Vec::new(),
+        shell_type: crate::shell::ShellType::Sh,
+        hook_command: String::new(),
+        process_id,
+        yield_time_ms: 1000,
+        max_output_tokens: None,
+        #[allow(deprecated)]
+        cwd: turn.cwd.clone(),
+        #[allow(deprecated)]
+        sandbox_cwd: turn.cwd.clone(),
+        environment: turn
+            .environments
+            .primary_environment()
+            .expect("primary environment"),
+        network: None,
+        tty: true,
+        sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
+        additional_permissions: None,
+        additional_permissions_preapproved: false,
+        justification: None,
+        prefix_rule: None,
+    }
+}
+
+async fn emit_startup_failure_end_event(
+    call_id: &str,
+    err: &UnifiedExecError,
+) -> codex_protocol::protocol::ExecCommandEndEvent {
+    let (session, turn, rx_event) = crate::session::tests::make_session_and_context_with_rx().await;
+    let context =
+        UnifiedExecContext::new(Arc::clone(&session), Arc::clone(&turn), call_id.to_string());
+    let process_id = session
+        .services
+        .unified_exec_manager
+        .allocate_process_id()
+        .await;
+    let request = startup_failure_test_request(turn.as_ref(), process_id);
+    let selected_cwd = turn
+        .environments
+        .primary()
+        .expect("primary turn environment")
+        .cwd
+        .clone();
+    let event_ctx = ToolEventCtx::new(
+        context.session.as_ref(),
+        context.turn.as_ref(),
+        &context.call_id,
+        /*turn_diff_tracker*/ None,
+    );
+    let emitter = ToolEmitter::unified_exec(
+        &request.command,
+        selected_cwd,
+        ExecCommandSource::UnifiedExecStartup,
+        Some(request.process_id.to_string()),
+    );
+    emitter.emit(event_ctx, ToolEventStage::Begin).await;
+    emitter
+        .emit(
+            event_ctx,
+            ToolEventStage::Failure(startup_failure_event(err)),
+        )
+        .await;
+
+    let begin_event = tokio::time::timeout(Duration::from_secs(1), rx_event.recv())
+        .await
+        .expect("timed out waiting for begin event")
+        .expect("event channel closed");
+    let codex_protocol::protocol::EventMsg::ExecCommandBegin(begin_event) = begin_event.msg else {
+        panic!("expected ExecCommandBegin event");
+    };
+    assert_eq!(begin_event.call_id, call_id);
+
+    let end_event = tokio::time::timeout(Duration::from_secs(1), rx_event.recv())
+        .await
+        .expect("timed out waiting for end event")
+        .expect("event channel closed");
+    let codex_protocol::protocol::EventMsg::ExecCommandEnd(end_event) = end_event.msg else {
+        panic!("expected ExecCommandEnd event");
+    };
+    end_event
+}
 
 #[test]
 fn unified_exec_env_injects_defaults() {
@@ -224,6 +311,43 @@ async fn failed_initial_end_for_unstored_process_uses_fallback_output() {
         end_event.aggregated_output,
         "PRE_DENIAL_MARKER\nNetwork access denied"
     );
+}
+
+#[tokio::test]
+async fn startup_create_process_failure_emits_begin_then_failed_end() {
+    let err = crate::unified_exec::UnifiedExecError::create_process(
+        "missing command line for PTY".to_string(),
+    );
+    let end_event = emit_startup_failure_end_event("call-unified-empty", &err).await;
+    assert_eq!(end_event.call_id, "call-unified-empty");
+    assert_eq!(
+        end_event.status,
+        codex_protocol::protocol::ExecCommandStatus::Failed
+    );
+}
+
+#[tokio::test]
+async fn startup_sandbox_denied_failure_preserves_captured_output() {
+    let err = crate::unified_exec::UnifiedExecError::sandbox_denied(
+        "sandbox denied".to_string(),
+        ExecToolCallOutput {
+            exit_code: 13,
+            stderr: StreamOutput::new("stderr marker".to_string()),
+            aggregated_output: StreamOutput::new("captured denial output".to_string()),
+            ..Default::default()
+        },
+    );
+
+    let end_event = emit_startup_failure_end_event("call-unified-sandbox-denied", &err).await;
+
+    assert_eq!(end_event.call_id, "call-unified-sandbox-denied");
+    assert_eq!(
+        end_event.status,
+        codex_protocol::protocol::ExecCommandStatus::Failed
+    );
+    assert_eq!(end_event.exit_code, 13);
+    assert_eq!(end_event.stderr, "stderr marker");
+    assert_eq!(end_event.aggregated_output, "captured denial output");
 }
 
 #[test]

--- a/codex-rs/core/src/unified_exec/process_manager_tests.rs
+++ b/codex-rs/core/src/unified_exec/process_manager_tests.rs
@@ -350,6 +350,20 @@ async fn startup_sandbox_denied_failure_preserves_captured_output() {
     assert_eq!(end_event.aggregated_output, "captured denial output");
 }
 
+#[tokio::test]
+async fn startup_rejected_failure_emits_declined_end() {
+    let err = crate::unified_exec::UnifiedExecError::rejected("rejected by user".to_string());
+
+    let end_event = emit_startup_failure_end_event("call-unified-rejected", &err).await;
+
+    assert_eq!(end_event.call_id, "call-unified-rejected");
+    assert_eq!(
+        end_event.status,
+        codex_protocol::protocol::ExecCommandStatus::Declined
+    );
+    assert_eq!(end_event.aggregated_output, "rejected by user");
+}
+
 #[test]
 fn pruning_prefers_exited_processes_outside_recently_used() {
     let now = Instant::now();

--- a/codex-rs/core/src/unified_exec/process_manager_tests.rs
+++ b/codex-rs/core/src/unified_exec/process_manager_tests.rs
@@ -232,6 +232,77 @@ async fn failed_initial_end_for_unstored_process_uses_fallback_output() {
     );
 }
 
+#[tokio::test]
+async fn startup_create_process_failure_emits_begin_then_failed_end() {
+    let (session, turn, rx_event) = crate::session::tests::make_session_and_context_with_rx().await;
+    let context = UnifiedExecContext::new(
+        Arc::clone(&session),
+        Arc::clone(&turn),
+        "call-unified-empty".to_string(),
+    );
+    let process_id = session
+        .services
+        .unified_exec_manager
+        .allocate_process_id()
+        .await;
+    let request = ExecCommandRequest {
+        command: Vec::new(),
+        shell_type: crate::shell::ShellType::Sh,
+        hook_command: String::new(),
+        process_id,
+        yield_time_ms: 1000,
+        max_output_tokens: None,
+        #[allow(deprecated)]
+        cwd: turn.cwd.clone(),
+        #[allow(deprecated)]
+        sandbox_cwd: turn.cwd.clone(),
+        environment: turn
+            .environments
+            .primary_environment()
+            .expect("primary environment"),
+        network: None,
+        tty: true,
+        sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
+        additional_permissions: None,
+        additional_permissions_preapproved: false,
+        justification: None,
+        prefix_rule: None,
+    };
+
+    let err = crate::unified_exec::UnifiedExecError::create_process(
+        "missing command line for PTY".to_string(),
+    );
+    let selected_cwd = turn
+        .environments
+        .primary()
+        .expect("primary turn environment")
+        .cwd
+        .clone();
+    emit_startup_failure_events(&context, &request, selected_cwd, &err).await;
+
+    let begin_event = tokio::time::timeout(Duration::from_secs(1), rx_event.recv())
+        .await
+        .expect("timed out waiting for begin event")
+        .expect("event channel closed");
+    let codex_protocol::protocol::EventMsg::ExecCommandBegin(begin_event) = begin_event.msg else {
+        panic!("expected ExecCommandBegin event");
+    };
+    assert_eq!(begin_event.call_id, "call-unified-empty");
+
+    let end_event = tokio::time::timeout(Duration::from_secs(1), rx_event.recv())
+        .await
+        .expect("timed out waiting for end event")
+        .expect("event channel closed");
+    let codex_protocol::protocol::EventMsg::ExecCommandEnd(end_event) = end_event.msg else {
+        panic!("expected ExecCommandEnd event");
+    };
+    assert_eq!(end_event.call_id, "call-unified-empty");
+    assert_eq!(
+        end_event.status,
+        codex_protocol::protocol::ExecCommandStatus::Failed
+    );
+}
+
 #[test]
 fn pruning_prefers_exited_processes_outside_recently_used() {
     let now = Instant::now();


### PR DESCRIPTION
## Why

Remote `rust-ci-full` exposed unified exec startup failures that happen before a process record exists. In that path, clients could receive the startup error without the matching exec end lifecycle event, leaving the tool call half-open from the app-server/client perspective. Approval rejections in the same startup path also need to stay declined rather than being reported as generic execution failures.

Failure evidence: [remote Ubuntu test job](https://github.com/openai/codex/actions/runs/26115775739/job/76804530177) with uploaded [nextest JUnit artifact](https://github.com/openai/codex/actions/runs/26115775739/artifacts/7091965331)

## What changed

- emit the matching unified exec end event when startup fails before the process is stored
- preserve captured sandbox-denial output in that startup-failure event path
- preserve startup approval rejections as declined exec endings
- keep the successful-startup begin event at its original point after process creation so long-running session interrupt behavior does not regress
- add focused regression coverage for failed, sandbox-denied, and rejected startup endings

## Validation

- `cargo test -p codex-core startup_ -- --nocapture`
- `cargo test -p codex-core --test all unified_exec_interrupt_preserves_long_running_session -- --nocapture`
