### PR TITLE
context: remove legacy permissions instructions helper

### DIFF
--- a/codex-rs/core/src/context/permissions_instructions.rs
+++ b/codex-rs/core/src/context/permissions_instructions.rs
@@ -8,7 +8,6 @@ use codex_protocol::permissions::NetworkSandboxPolicy;
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::GranularApprovalConfig;
 use codex_protocol::protocol::NetworkAccess;
-use codex_protocol::protocol::SandboxPolicy;
 use codex_protocol::protocol::WritableRoot;
 use codex_utils_template::Template;
 use std::path::Path;
@@ -82,27 +81,6 @@ impl PermissionsInstructions {
                 request_permissions_tool_enabled,
             },
             writable_roots,
-        )
-    }
-
-    /// Builds permissions instructions from a legacy sandbox policy.
-    pub fn from_policy(
-        sandbox_policy: &SandboxPolicy,
-        approval_policy: AskForApproval,
-        approvals_reviewer: ApprovalsReviewer,
-        exec_policy: &Policy,
-        cwd: &Path,
-        exec_permission_approvals_enabled: bool,
-        request_permissions_tool_enabled: bool,
-    ) -> Self {
-        Self::from_permission_profile(
-            &PermissionProfile::from_legacy_sandbox_policy(sandbox_policy),
-            approval_policy,
-            approvals_reviewer,
-            exec_policy,
-            cwd,
-            exec_permission_approvals_enabled,
-            request_permissions_tool_enabled,
         )
     }
 

--- a/codex-rs/core/src/context/permissions_instructions_tests.rs
+++ b/codex-rs/core/src/context/permissions_instructions_tests.rs
@@ -54,29 +54,6 @@ fn builds_permissions_with_network_access_override() {
 }
 
 #[test]
-fn builds_permissions_from_policy() {
-    let policy = SandboxPolicy::WorkspaceWrite {
-        writable_roots: vec![],
-        network_access: true,
-        exclude_tmpdir_env_var: false,
-        exclude_slash_tmp: false,
-    };
-
-    let instructions = PermissionsInstructions::from_policy(
-        &policy,
-        AskForApproval::UnlessTrusted,
-        ApprovalsReviewer::User,
-        &Policy::empty(),
-        &PathBuf::from("/tmp"),
-        /*exec_permission_approvals_enabled*/ false,
-        /*request_permissions_tool_enabled*/ false,
-    );
-    let text = instructions.body();
-    assert!(text.contains("Network access is enabled."));
-    assert!(text.contains("`approval_policy` is `unless-trusted`"));
-}
-
-#[test]
 fn builds_permissions_from_profile() {
     let cwd = PathBuf::from("/tmp");
     let writable_root =


### PR DESCRIPTION
## Why

The permissions instruction builder should consume the new permissions model directly. Keeping a `SandboxPolicy` conversion helper in this path encourages new code to route through legacy sandbox policy values even when the caller already has a `PermissionProfile`.

## What Changed

- Removed `PermissionsInstructions::from_policy`.
- Removed the test that exercised that legacy helper.
- Left the existing profile-based instruction coverage in place.

## How To Review

Review `codex-rs/core/src/context/permissions_instructions.rs` first. This PR is intentionally narrow: the production behavior should be unchanged for profile callers, and the deleted surface was only a convenience adapter from `SandboxPolicy`.

## Verification

- `cargo test -p codex-core builds_permissions_from_profile`








---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/22790).
* #22795
* #22792
* #22791
* __->__ #22790