### PR TITLE
telemetry: tag sandboxes from permission profiles

### DIFF
--- a/codex-rs/core/src/sandbox_tags.rs
+++ b/codex-rs/core/src/sandbox_tags.rs
@@ -1,23 +1,9 @@
 use codex_protocol::config_types::WindowsSandboxLevel;
 use codex_protocol::models::PermissionProfile;
-#[cfg(test)]
-use codex_protocol::protocol::SandboxPolicy;
 use codex_sandboxing::SandboxType;
 use codex_sandboxing::get_platform_sandbox;
 use codex_sandboxing::policy_transforms::should_require_platform_sandbox;
 use std::path::Path;
-
-#[cfg(test)]
-pub(crate) fn sandbox_tag(
-    policy: &SandboxPolicy,
-    windows_sandbox_level: WindowsSandboxLevel,
-) -> &'static str {
-    permission_profile_sandbox_tag(
-        &PermissionProfile::from_legacy_sandbox_policy(policy),
-        windows_sandbox_level,
-        /*enforce_managed_network*/ false,
-    )
-}
 
 pub(crate) fn permission_profile_sandbox_tag(
     profile: &PermissionProfile,

--- a/codex-rs/core/src/sandbox_tags_tests.rs
+++ b/codex-rs/core/src/sandbox_tags_tests.rs
@@ -1,6 +1,5 @@
 use super::permission_profile_policy_tag;
 use super::permission_profile_sandbox_tag;
-use super::sandbox_tag;
 use codex_protocol::config_types::WindowsSandboxLevel;
 use codex_protocol::models::ManagedFileSystemPermissions;
 use codex_protocol::models::PermissionProfile;
@@ -10,8 +9,6 @@ use codex_protocol::permissions::FileSystemSandboxEntry;
 use codex_protocol::permissions::FileSystemSandboxKind;
 use codex_protocol::permissions::FileSystemSandboxPolicy;
 use codex_protocol::permissions::NetworkSandboxPolicy;
-use codex_protocol::protocol::NetworkAccess;
-use codex_protocol::protocol::SandboxPolicy;
 use codex_sandboxing::SandboxType;
 use codex_sandboxing::get_platform_sandbox;
 use codex_utils_absolute_path::AbsolutePathBuf;
@@ -20,29 +17,32 @@ use std::path::Path;
 
 #[test]
 fn danger_full_access_is_untagged_even_when_linux_sandbox_defaults_apply() {
-    let actual = sandbox_tag(
-        &SandboxPolicy::DangerFullAccess,
+    let actual = permission_profile_sandbox_tag(
+        &PermissionProfile::Disabled,
         WindowsSandboxLevel::Disabled,
+        /*enforce_managed_network*/ false,
     );
     assert_eq!(actual, "none");
 }
 
 #[test]
 fn external_sandbox_keeps_external_tag_when_linux_sandbox_defaults_apply() {
-    let actual = sandbox_tag(
-        &SandboxPolicy::ExternalSandbox {
-            network_access: NetworkAccess::Enabled,
+    let actual = permission_profile_sandbox_tag(
+        &PermissionProfile::External {
+            network: NetworkSandboxPolicy::Enabled,
         },
         WindowsSandboxLevel::Disabled,
+        /*enforce_managed_network*/ false,
     );
     assert_eq!(actual, "external");
 }
 
 #[test]
 fn default_linux_sandbox_uses_platform_sandbox_tag() {
-    let actual = sandbox_tag(
-        &SandboxPolicy::new_read_only_policy(),
+    let actual = permission_profile_sandbox_tag(
+        &PermissionProfile::read_only(),
         WindowsSandboxLevel::Disabled,
+        /*enforce_managed_network*/ false,
     );
     let expected = get_platform_sandbox(/*windows_sandbox_enabled*/ false)
         .map(SandboxType::as_metric_tag)

--- a/codex-rs/core/src/turn_metadata_tests.rs
+++ b/codex-rs/core/src/turn_metadata_tests.rs
@@ -1,9 +1,8 @@
 use super::*;
 
-use crate::sandbox_tags::sandbox_tag;
+use crate::sandbox_tags::permission_profile_sandbox_tag;
 use codex_protocol::models::PermissionProfile;
 use codex_protocol::openai_models::ReasoningEffort as ReasoningEffortConfig;
-use codex_protocol::protocol::SandboxPolicy;
 use codex_protocol::protocol::ThreadSource;
 use core_test_support::PathBufExt;
 use core_test_support::PathExt;
@@ -89,7 +88,6 @@ async fn build_turn_metadata_header_includes_has_changes_for_clean_repo() {
 fn turn_metadata_state_uses_platform_sandbox_tag() {
     let temp_dir = TempDir::new().expect("temp dir");
     let cwd = temp_dir.path().abs();
-    let sandbox_policy = SandboxPolicy::new_read_only_policy();
     let permission_profile = PermissionProfile::read_only();
 
     let state = TurnMetadataState::new(
@@ -110,7 +108,11 @@ fn turn_metadata_state_uses_platform_sandbox_tag() {
     let thread_id = json.get("thread_id").and_then(Value::as_str);
     let thread_source = json.get("thread_source").and_then(Value::as_str);
 
-    let expected_sandbox = sandbox_tag(&sandbox_policy, WindowsSandboxLevel::Disabled);
+    let expected_sandbox = permission_profile_sandbox_tag(
+        &permission_profile,
+        WindowsSandboxLevel::Disabled,
+        /*enforce_managed_network*/ false,
+    );
     assert_eq!(sandbox_name, Some(expected_sandbox));
     assert_eq!(session_id, Some("session-a"));
     assert_eq!(thread_id, Some("thread-a"));


### PR DESCRIPTION
## Why

Sandbox telemetry tags should be derived from the active permission profile, not from a legacy `SandboxPolicy`, so the tagging code stays aligned with the permissions migration and does not preserve a policy-shaped production helper only for tests.

## What Changed

- Removed the production `sandbox_tag(&SandboxPolicy, ...)` helper.
- Updated sandbox tag tests to construct the relevant `PermissionProfile` values directly.
- Kept the platform-specific sandbox tag behavior under the existing `permission_profile_sandbox_tag` path.

## How To Review

The production change is in `codex-rs/core/src/sandbox_tags.rs`. Most of the diff is test cleanup that replaces legacy policy setup with permission profiles, so review the expected tag assertions rather than the old helper mechanics.

## Verification

- `cargo test -p codex-core sandbox_tag`









---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/22791).
* #22795
* #22792
* __->__ #22791