### PR TITLE
[codex] Keep extension tools directly visible

### DIFF
--- a/codex-rs/core/src/tools/handlers/extension_tools.rs
+++ b/codex-rs/core/src/tools/handlers/extension_tools.rs
@@ -22,6 +22,7 @@ use crate::tools::context::ToolOutput;
 use crate::tools::context::ToolPayload;
 use crate::tools::registry::CoreToolRuntime;
 use crate::tools::registry::ToolExecutor;
+use crate::tools::registry::ToolExposure;
 
 pub(crate) struct ExtensionToolAdapter(Arc<dyn codex_tools::ToolExecutor<ExtensionToolCall>>);
 
@@ -38,11 +39,36 @@ impl ToolExecutor<ToolInvocation> for ExtensionToolAdapter {
     }
 
     fn spec(&self) -> ToolSpec {
-        self.0.spec()
+        let mut spec = self.0.spec();
+        if self.0.exposure() == ToolExposure::Deferred {
+            match &mut spec {
+                ToolSpec::Function(tool) => {
+                    tool.defer_loading = None;
+                }
+                ToolSpec::Namespace(namespace) => {
+                    for tool in &mut namespace.tools {
+                        let codex_tools::ResponsesApiNamespaceTool::Function(tool) = tool;
+                        tool.defer_loading = None;
+                    }
+                }
+                ToolSpec::ToolSearch { .. }
+                | ToolSpec::ImageGeneration { .. }
+                | ToolSpec::WebSearch { .. }
+                | ToolSpec::Freeform(_) => {}
+            }
+        }
+        spec
     }
 
-    fn exposure(&self) -> crate::tools::registry::ToolExposure {
-        self.0.exposure()
+    fn exposure(&self) -> ToolExposure {
+        // Extension tools do not yet provide search metadata, so keep them in
+        // the model-visible list even if the shared executor requests deferral.
+        match self.0.exposure() {
+            ToolExposure::Direct => ToolExposure::Direct,
+            ToolExposure::Deferred => ToolExposure::Direct,
+            ToolExposure::DirectModelOnly => ToolExposure::DirectModelOnly,
+            ToolExposure::Hidden => ToolExposure::Hidden,
+        }
     }
 
     fn supports_parallel_tool_calls(&self) -> bool {

--- a/codex-rs/core/src/tools/handlers/extension_tools.rs
+++ b/codex-rs/core/src/tools/handlers/extension_tools.rs
@@ -15,6 +15,7 @@ use crate::tools::registry::CoreToolRuntime;
 use crate::tools::registry::PostToolUsePayload;
 use crate::tools::registry::PreToolUsePayload;
 use crate::tools::registry::ToolExecutor;
+use crate::tools::registry::ToolExposure;
 
 pub(crate) struct ExtensionToolAdapter(Arc<dyn codex_tools::ToolExecutor<ExtensionToolCall>>);
 
@@ -41,8 +42,10 @@ impl ToolExecutor<ToolInvocation> for ExtensionToolAdapter {
         self.0.spec()
     }
 
-    fn exposure(&self) -> crate::tools::registry::ToolExposure {
-        self.0.exposure()
+    fn exposure(&self) -> ToolExposure {
+        // Extension tools do not yet provide search metadata, so keep them in
+        // the model-visible list even if the shared executor requests deferral.
+        ToolExposure::Direct
     }
 
     fn supports_parallel_tool_calls(&self) -> bool {

--- a/codex-rs/core/src/tools/spec_plan_tests.rs
+++ b/codex-rs/core/src/tools/spec_plan_tests.rs
@@ -267,6 +267,49 @@ fn use_bedrock_provider(turn: &mut TurnContext) {
     turn.provider = create_model_provider(provider_info, turn.auth_manager.clone());
 }
 
+struct SpecOnlyExtensionTool {
+    name: &'static str,
+    description: &'static str,
+    exposure: ToolExposure,
+    defer_loading: Option<bool>,
+}
+
+#[async_trait::async_trait]
+impl ToolExecutor<ExtensionToolCall> for SpecOnlyExtensionTool {
+    fn tool_name(&self) -> ToolName {
+        ToolName::plain(self.name)
+    }
+
+    fn spec(&self) -> ToolSpec {
+        ToolSpec::Function(ResponsesApiTool {
+            name: self.name.to_string(),
+            description: self.description.to_string(),
+            strict: true,
+            parameters: codex_tools::JsonSchema::object(
+                BTreeMap::from([(
+                    "message".to_string(),
+                    codex_tools::JsonSchema::string(/*description*/ None),
+                )]),
+                Some(vec!["message".to_string()]),
+                Some(false.into()),
+            ),
+            output_schema: None,
+            defer_loading: self.defer_loading,
+        })
+    }
+
+    fn exposure(&self) -> ToolExposure {
+        self.exposure
+    }
+
+    async fn handle(
+        &self,
+        _call: ExtensionToolCall,
+    ) -> Result<Box<dyn ToolOutput>, codex_tools::FunctionCallError> {
+        panic!("spec planning should not execute extension tools")
+    }
+}
+
 struct WebRunExtensionTool;
 
 #[async_trait::async_trait]
@@ -391,6 +434,65 @@ async fn request_user_input_tool_respects_experimental_config_gate() {
     .await;
     disabled.assert_visible_lacks(&["request_user_input"]);
     disabled.assert_registered_lacks(&["request_user_input"]);
+}
+
+#[tokio::test]
+async fn deferred_extension_tools_remain_model_visible() {
+    let plan = probe_with(
+        |turn| {
+            turn.model_info.supports_search_tool = true;
+        },
+        ToolPlanInputs {
+            extension_tool_executors: vec![
+                Arc::new(SpecOnlyExtensionTool {
+                    name: "extension_echo",
+                    description: "Echoes arguments through an extension tool.",
+                    exposure: ToolExposure::Deferred,
+                    defer_loading: None,
+                }),
+                Arc::new(SpecOnlyExtensionTool {
+                    name: "extension_lazy",
+                    description: "Lazy extension tool.",
+                    exposure: ToolExposure::Deferred,
+                    defer_loading: Some(true),
+                }),
+                Arc::new(SpecOnlyExtensionTool {
+                    name: "extension_model_only",
+                    description: "Model-only extension tool.",
+                    exposure: ToolExposure::DirectModelOnly,
+                    defer_loading: None,
+                }),
+            ],
+            ..Default::default()
+        },
+    )
+    .await;
+
+    plan.assert_visible_contains(&["extension_echo", "extension_lazy", "extension_model_only"]);
+    assert_eq!(plan.exposure("extension_echo"), ToolExposure::Direct);
+    assert_eq!(plan.exposure("extension_lazy"), ToolExposure::Direct);
+    assert_eq!(
+        plan.exposure("extension_model_only"),
+        ToolExposure::DirectModelOnly
+    );
+    assert_eq!(
+        plan.visible_spec("extension_lazy"),
+        &ToolSpec::Function(ResponsesApiTool {
+            name: "extension_lazy".to_string(),
+            description: "Lazy extension tool.".to_string(),
+            strict: true,
+            parameters: codex_tools::JsonSchema::object(
+                BTreeMap::from([(
+                    "message".to_string(),
+                    codex_tools::JsonSchema::string(/*description*/ None),
+                )]),
+                Some(vec!["message".to_string()]),
+                Some(false.into()),
+            ),
+            output_schema: None,
+            defer_loading: None,
+        })
+    );
 }
 
 #[tokio::test]

--- a/codex-rs/core/src/tools/spec_plan_tests.rs
+++ b/codex-rs/core/src/tools/spec_plan_tests.rs
@@ -77,9 +77,18 @@ fn extension_tool_executor(
     name: &str,
     description: &str,
 ) -> Arc<dyn ToolExecutor<ExtensionToolCall>> {
+    extension_tool_executor_with_exposure(name, description, codex_tools::ToolExposure::Direct)
+}
+
+fn extension_tool_executor_with_exposure(
+    name: &str,
+    description: &str,
+    exposure: codex_tools::ToolExposure,
+) -> Arc<dyn ToolExecutor<ExtensionToolCall>> {
     struct SpecOnlyExtensionExecutor {
         name: String,
         description: String,
+        exposure: codex_tools::ToolExposure,
     }
 
     #[async_trait::async_trait]
@@ -106,6 +115,10 @@ fn extension_tool_executor(
             }))
         }
 
+        fn exposure(&self) -> codex_tools::ToolExposure {
+            self.exposure
+        }
+
         async fn handle(
             &self,
             _call: ExtensionToolCall,
@@ -117,6 +130,7 @@ fn extension_tool_executor(
     Arc::new(SpecOnlyExtensionExecutor {
         name: name.to_string(),
         description: description.to_string(),
+        exposure,
     })
 }
 
@@ -158,6 +172,59 @@ fn extension_tools_do_not_replace_builtin_tools() {
             .count(),
         1
     );
+}
+
+#[test]
+fn deferred_extension_tools_remain_model_visible() {
+    let model_info = search_capable_model_info();
+    let mut features = Features::with_defaults();
+    features.enable(Feature::ToolSearch);
+    let available_models = Vec::new();
+    let tools_config = ToolsConfig::new(&ToolsConfigParams {
+        model_info: &model_info,
+        available_models: &available_models,
+        features: &features,
+        image_generation_tool_auth_allowed: true,
+        web_search_mode: Some(WebSearchMode::Cached),
+        session_source: SessionSource::Cli,
+        permission_profile: &PermissionProfile::Disabled,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
+    });
+    let extension_tool_executors = vec![extension_tool_executor_with_exposure(
+        "extension_echo",
+        "Echoes arguments through an extension tool.",
+        codex_tools::ToolExposure::Deferred,
+    )];
+
+    let (tools, registry) = build_specs_with_inputs_for_test(
+        &tools_config,
+        /*mcp_tools*/ None,
+        /*deferred_mcp_tools*/ None,
+        /*discoverable_tools*/ None,
+        &extension_tool_executors,
+        &[],
+    );
+
+    assert_eq!(
+        find_tool(&tools, "extension_echo").clone(),
+        ToolSpec::Function(ResponsesApiTool {
+            name: "extension_echo".to_string(),
+            description: "Echoes arguments through an extension tool.".to_string(),
+            strict: true,
+            parameters: JsonSchema::object(
+                BTreeMap::from([(
+                    "message".to_string(),
+                    JsonSchema::string(/*description*/ None),
+                )]),
+                Some(vec!["message".to_string()]),
+                Some(false.into()),
+            ),
+            output_schema: None,
+            defer_loading: None,
+        })
+    );
+    assert!(registry.has_tool(&ToolName::plain("extension_echo")));
+    assert_lacks_tool_name(&tools, TOOL_SEARCH_TOOL_NAME);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Keep extension-owned tools directly model-visible even when their shared executor reports `ToolExposure::Deferred`.

## Root cause

`ExtensionToolAdapter` started forwarding extension executor exposure, but extension adapters do not yet provide `search_info()`. A deferred extension tool could therefore disappear from the model-visible tool list without becoming discoverable through `tool_search`.

## Changes

- Force `ExtensionToolAdapter` exposure back to `Direct` until extension-backed search metadata exists.
- Add a spec-planning regression test proving a deferred extension executor still appears in the model-visible tool specs.

## Validation

- `just fmt`
- `cargo test -p codex-core deferred_extension_tools_remain_model_visible`
- `cargo test -p codex-core` hit an existing unrelated stack overflow in `agent::control::tests::resume_agent_from_rollout_skips_descendants_when_parent_resume_fails`.
- `just fix -p codex-core`