### PR TITLE
fix(tui): disable enhanced keys for linux vscode terminals

### DIFF
--- a/codex-rs/tui/src/tui/keyboard_modes.rs
+++ b/codex-rs/tui/src/tui/keyboard_modes.rs
@@ -17,24 +17,25 @@ const DISABLE_KEYBOARD_ENHANCEMENT_ENV_VAR: &str = "CODEX_TUI_DISABLE_KEYBOARD_E
 
 pub(super) fn keyboard_enhancement_disabled() -> bool {
     let disable_env = std::env::var(DISABLE_KEYBOARD_ENHANCEMENT_ENV_VAR).ok();
-    let is_wsl = running_in_wsl();
-    let is_vscode_terminal = is_wsl && running_in_vscode_terminal();
-    keyboard_enhancement_disabled_for(disable_env.as_deref(), is_wsl, is_vscode_terminal)
+    let is_linux = cfg!(target_os = "linux");
+    let is_vscode_terminal = is_linux && running_in_vscode_terminal();
+    keyboard_enhancement_disabled_for(disable_env.as_deref(), is_linux, is_vscode_terminal)
 }
 
 fn keyboard_enhancement_disabled_for(
     disable_env: Option<&str>,
-    is_wsl: bool,
+    is_linux: bool,
     is_vscode_terminal: bool,
 ) -> bool {
     if let Some(disabled) = parse_bool_env(disable_env) {
         return disabled;
     }
 
-    // VS Code running a WSL shell can hide TERM_PROGRAM from the Linux process
-    // environment, so `running_in_vscode_terminal` also probes the Windows-side
-    // environment through WSL interop.
-    is_wsl && is_vscode_terminal
+    // VS Code terminals on Linux can turn dead-key composition into malformed key events when
+    // crossterm keyboard enhancement flags are enabled. WSL can hide `TERM_PROGRAM` from the
+    // Linux process environment, so `running_in_vscode_terminal` also probes the Windows-side
+    // environment through WSL interop for that path.
+    is_linux && is_vscode_terminal
 }
 
 fn parse_bool_env(value: Option<&str>) -> Option<bool> {
@@ -62,9 +63,10 @@ fn running_in_wsl() -> bool {
 }
 
 pub(super) fn running_in_vscode_terminal() -> bool {
+    let windows_term_program = running_in_wsl().then(windows_term_program).flatten();
     vscode_terminal_detected(
         std::env::var("TERM_PROGRAM").ok().as_deref(),
-        windows_term_program().as_deref(),
+        windows_term_program.as_deref(),
     )
 }
 
@@ -309,19 +311,19 @@ mod tests {
     }
 
     #[test]
-    fn keyboard_enhancement_auto_disables_for_vscode_in_wsl() {
+    fn keyboard_enhancement_auto_disables_for_vscode_on_linux() {
         assert!(keyboard_enhancement_disabled_for(
-            /*disable_env*/ None, /*is_wsl*/ true, /*is_vscode_terminal*/ true
+            /*disable_env*/ None, /*is_linux*/ true, /*is_vscode_terminal*/ true
         ));
     }
 
     #[test]
-    fn keyboard_enhancement_auto_disable_requires_wsl_and_vscode() {
+    fn keyboard_enhancement_auto_disable_requires_linux_and_vscode() {
         assert!(!keyboard_enhancement_disabled_for(
-            /*disable_env*/ None, /*is_wsl*/ true, /*is_vscode_terminal*/ false
+            /*disable_env*/ None, /*is_linux*/ true, /*is_vscode_terminal*/ false
         ));
         assert!(!keyboard_enhancement_disabled_for(
-            /*disable_env*/ None, /*is_wsl*/ false, /*is_vscode_terminal*/ true
+            /*disable_env*/ None, /*is_linux*/ false, /*is_vscode_terminal*/ true
         ));
     }
 
@@ -329,12 +331,12 @@ mod tests {
     fn keyboard_enhancement_env_flag_overrides_auto_detection() {
         assert!(!keyboard_enhancement_disabled_for(
             Some("0"),
-            /*is_wsl*/ true,
+            /*is_linux*/ true,
             /*is_vscode_terminal*/ true
         ));
         assert!(keyboard_enhancement_disabled_for(
             Some("1"),
-            /*is_wsl*/ false,
+            /*is_linux*/ false,
             /*is_vscode_terminal*/ false
         ));
     }


### PR DESCRIPTION
## Why

[#13638](https://github.com/openai/codex/issues/13638) and [#18741](https://github.com/openai/codex/pull/18741) fixed dead-key composition for WSL + VS Code by skipping crossterm keyboard enhancement flags in that terminal path. [#22839](https://github.com/openai/codex/issues/22839) reports the same malformed-key behavior on a native Linux host reached through VS Code Remote SSH, where `TERM_PROGRAM=vscode` is visible directly in the Linux environment.

The current policy in `codex-rs/tui/src/tui/keyboard_modes.rs` only auto-disables enhanced keys for WSL + VS Code, so native Linux VS Code terminals still fall through to the broken path. This extends the same workaround to Linux VS Code terminals without widening it to non-Linux VS Code terminals, where we do not have the same repro and enhanced keys still help distinguish modified keys such as Shift+Enter.

## What Changed

- Auto-disable keyboard enhancement for Linux VS Code terminals, covering both the original WSL path and native Linux VS Code Remote SSH.
- Keep non-Linux VS Code terminals unchanged.
- Only probe the Windows-side `TERM_PROGRAM` through WSL interop when Codex is actually running in WSL.
- Update the focused keyboard-mode unit coverage to match the broader Linux VS Code policy.

Closes #22839.

## How to Test

Manual smoke was not run locally because this needs a VS Code Remote SSH Linux terminal. Recommended reviewer path:

1. Connect to a Linux host through VS Code Remote SSH and open the integrated terminal.
2. Run plain `codex`.
3. Type dead-key combinations such as `^` then `e`, or an acute dead key then `e`.
4. Confirm Codex receives composed accented characters instead of leaking a raw kitty-style escape sequence such as `^[[13;1:3u`.
5. In the same terminal, run `CODEX_TUI_DISABLE_KEYBOARD_ENHANCEMENT=0 codex` and confirm the old malformed-key path reproduces if that host shows the issue.
6. Spot-check WSL + VS Code with plain `codex` and confirm dead-key composition still works.

Targeted tests:
- `cargo test -p codex-tui tui::keyboard_modes::tests --lib`
- `./tools/argument-comment-lint/run.py -p codex-tui -- --tests`

Local note: `cargo test -p codex-tui` built and started the full suite, then aborted in unrelated test `app::tests::discard_side_thread_removes_agent_navigation_entry` with a stack overflow after hundreds of unrelated tests passed.
