### PR TITLE
Keep plugin test home alive during MCP startup

### DIFF
--- a/codex-rs/core/tests/suite/plugins.rs
+++ b/codex-rs/core/tests/suite/plugins.rs
@@ -291,9 +291,12 @@ async fn explicit_plugin_mentions_inject_plugin_guidance() -> Result<()> {
     write_plugin_mcp_plugin(codex_home.as_ref(), &rmcp_test_server_bin);
     write_plugin_app_plugin(codex_home.as_ref());
 
-    let codex =
-        build_apps_enabled_plugin_test_codex(&server, codex_home, apps_server.chatgpt_base_url)
-            .await?;
+    let codex = build_apps_enabled_plugin_test_codex(
+        &server,
+        Arc::clone(&codex_home),
+        apps_server.chatgpt_base_url,
+    )
+    .await?;
     wait_for_sample_mcp_ready(&codex).await?;
 
     codex

--- a/codex-rs/core/tests/suite/plugins.rs
+++ b/codex-rs/core/tests/suite/plugins.rs
@@ -292,9 +292,12 @@ async fn explicit_plugin_mentions_inject_plugin_guidance() -> Result<()> {
     write_plugin_mcp_plugin(codex_home.as_ref(), &rmcp_test_server_bin);
     write_plugin_app_plugin(codex_home.as_ref());
 
-    let codex =
-        build_apps_enabled_plugin_test_codex(&server, codex_home, apps_server.chatgpt_base_url)
-            .await?;
+    let codex = build_apps_enabled_plugin_test_codex(
+        &server,
+        Arc::clone(&codex_home),
+        apps_server.chatgpt_base_url,
+    )
+    .await?;
     wait_for_sample_mcp_ready(&codex).await?;
 
     codex


### PR DESCRIPTION
## Why

The explicit plugin mention test could drop its temporary Codex home while the sample MCP server was still starting. On slower CI machines, that turns into a timing-sensitive startup race rather than a plugin behavior failure.

Failure evidence: [macOS ARM test job](https://github.com/openai/codex/actions/runs/26113530208/job/76796704509) with uploaded [nextest JUnit artifact](https://github.com/openai/codex/actions/runs/26113530208/artifacts/7090960065)

## What changed

- retain the plugin test `TempDir` for the full MCP startup window
- match the lifetime pattern already used by nearby plugin tests

## CI evidence

Recent failed `rust-ci-full` test runs that exposed this flake family:
- https://github.com/openai/codex/actions/runs/26115775739
- https://github.com/openai/codex/actions/runs/26114840740
- https://github.com/openai/codex/actions/runs/26114668996
- https://github.com/openai/codex/actions/runs/26113530208

Those failed test lanes uploaded nextest JUnit artifacts successfully. Representative artifacts from the latest run:
- https://github.com/openai/codex/actions/runs/26115775739/artifacts/7091965331
- https://github.com/openai/codex/actions/runs/26115775739/artifacts/7092022050
- https://github.com/openai/codex/actions/runs/26115775739/artifacts/7091820251

## Walkthrough

- Issue: the explicit plugin mention test could drop its temporary Codex home while the sample MCP server was still starting.
- Likely introducing change: the explicit plugin mention fixture plus later MCP readiness wait.
- Fix: keep the `TempDir` alive across the MCP startup window by retaining the outer `Arc<TempDir>` for the duration of the test.

## Devbox evidence

Focused remote command:
```shell
ssh -t dev 'cd /home/dev-user/code/codex-worktrees/starr-fullci-6-plugin-mcp-tempdir-20260519/codex-rs && export PATH=$HOME/code/openai/project/dotslash-gen/bin:$HOME/.local/bin:$PATH && export CARGO_TARGET_DIR=/tmp/codex-target/pr22910 && cargo test -p codex-core --test all suite::plugins::explicit_plugin_mentions_inject_plugin_guidance -- --exact --nocapture'
```

Result: not reproduced on the current stacked head because the branch failed before the focused test started.

Devbox log snippet:
```text
Focused devbox validation was attempted from the mirrored worktree, but the current stacked head did not reach the test body because the shared parent fails to compile first: `error[E0004]: non-exhaustive patterns: tools::sandboxing::ToolError::Failed(_) not covered` at `core/src/unified_exec/process_manager.rs:223`.
```

Prior CI failure snippet:
```text
`suite::plugins::explicit_plugin_mentions_inject_plugin_guidance` failed with `Error: plugin MCP server failed to start: No such file or directory (os error 2)` in the macOS ARM lane, then passed on retry.
```

