### PR TITLE
[codex] Preserve MCP result metadata in exec events

### DIFF
--- a/codex-rs/exec/src/event_processor_with_jsonl_output.rs
+++ b/codex-rs/exec/src/event_processor_with_jsonl_output.rs
@@ -224,6 +224,7 @@ impl EventProcessorWithJsonOutput {
                     result: result.map(|result| McpToolCallItemResult {
                         content: result.content,
                         structured_content: result.structured_content,
+                        meta: result.meta,
                     }),
                     error: error.map(|error| McpToolCallItemError {
                         message: error.message,

--- a/codex-rs/exec/src/exec_events.rs
+++ b/codex-rs/exec/src/exec_events.rs
@@ -267,6 +267,9 @@ pub struct McpToolCallItemResult {
     // easy to export.
     pub content: Vec<JsonValue>,
     pub structured_content: Option<JsonValue>,
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional, rename = "_meta")]
+    pub meta: Option<JsonValue>,
 }
 
 /// Error details reported by a failed MCP tool invocation.

--- a/codex-rs/exec/tests/event_processor_with_json_output.rs
+++ b/codex-rs/exec/tests/event_processor_with_json_output.rs
@@ -541,6 +541,7 @@ fn mcp_tool_call_begin_and_end_emit_item_events() {
                         result: Some(McpToolCallItemResult {
                             content: Vec::new(),
                             structured_content: None,
+                            meta: None,
                         }),
                         error: None,
                         status: McpToolCallStatus::Completed,
@@ -601,7 +602,7 @@ fn mcp_tool_call_failure_sets_failed_status() {
 }
 
 #[test]
-fn mcp_tool_call_defaults_arguments_and_preserves_structured_content() {
+fn mcp_tool_call_defaults_arguments_and_preserves_structured_content_and_meta() {
     let mut processor = EventProcessorWithJsonOutput::new(/*last_message_path*/ None);
 
     let started =
@@ -636,7 +637,11 @@ fn mcp_tool_call_defaults_arguments_and_preserves_structured_content() {
                         "text": "done",
                     })],
                     structured_content: Some(json!({ "status": "ok" })),
-                    meta: None,
+                    meta: Some(json!({
+                        "raw_messages": [
+                            { "ref_id": "abc123" }
+                        ],
+                    })),
                 })),
                 error: None,
                 duration_ms: Some(10),
@@ -682,6 +687,11 @@ fn mcp_tool_call_defaults_arguments_and_preserves_structured_content() {
                                 "text": "done",
                             })],
                             structured_content: Some(json!({ "status": "ok" })),
+                            meta: Some(json!({
+                                "raw_messages": [
+                                    { "ref_id": "abc123" }
+                                ],
+                            })),
                         }),
                         error: None,
                         status: McpToolCallStatus::Completed,


### PR DESCRIPTION
## Summary

Preserve MCP tool result `_meta` when app-server thread items are converted into `codex exec --json` thread events.

## Root cause

`McpToolCallItemResult` in the exec event schema only exposed `content` and `structured_content`, so the event processor dropped the app-server protocol result metadata even though upstream MCP result types already carried it.

## Changes

- Add `_meta` to `McpToolCallItemResult` with matching serde/TS renames.
- Pass `result.meta` through in `EventProcessorWithJsonOutput`.
- Extend the MCP event processor test to assert metadata survives alongside structured content.

## Validation

- `just fmt`
- `cargo test -p codex-exec --test all event_processor_with_json_output::mcp_tool_call`