### PR TITLE
Track MCP server entrypoint usage

### DIFF
--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -915,6 +915,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
                 arg0_paths.clone(),
                 root_config_overrides,
                 strict_config || root_strict_config,
+                codex_mcp_server::McpServerEntrypoint::CodexCliSubcommand,
             )
             .await?;
         }

--- a/codex-rs/mcp-server/src/lib.rs
+++ b/codex-rs/mcp-server/src/lib.rs
@@ -52,14 +52,32 @@ pub use crate::patch_approval::PatchApprovalResponse;
 /// plenty for an interactive CLI.
 const CHANNEL_CAPACITY: usize = 128;
 const DEFAULT_ANALYTICS_ENABLED: bool = true;
+const MCP_SERVER_METRIC: &str = "codex.mcp_server";
+const MCP_SERVER_ENTRYPOINT_TAG: &str = "entrypoint";
 const OTEL_SERVICE_NAME: &str = "codex_mcp_server";
 
 type IncomingMessage = JsonRpcMessage<ClientRequest, Value, ClientNotification>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum McpServerEntrypoint {
+    CodexCliSubcommand,
+    StandaloneBinary,
+}
+
+impl McpServerEntrypoint {
+    fn telemetry_tag_value(self) -> &'static str {
+        match self {
+            Self::CodexCliSubcommand => "codex_cli_subcommand",
+            Self::StandaloneBinary => "standalone_binary",
+        }
+    }
+}
 
 pub async fn run_main(
     arg0_paths: Arg0DispatchPaths,
     cli_config_overrides: CliConfigOverrides,
     strict_config: bool,
+    entrypoint: McpServerEntrypoint,
 ) -> IoResult<()> {
     // Parse CLI overrides once and derive the base Config eagerly so later
     // components do not need to work with raw TOML values.
@@ -91,6 +109,13 @@ pub async fn run_main(
         )
     })?;
     codex_core::otel_init::record_process_start(otel.as_ref(), OTEL_SERVICE_NAME);
+    if let Some(metrics) = otel.as_ref().and_then(|provider| provider.metrics()) {
+        let _ = metrics.counter(
+            MCP_SERVER_METRIC,
+            /*inc*/ 1,
+            &[(MCP_SERVER_ENTRYPOINT_TAG, entrypoint.telemetry_tag_value())],
+        );
+    }
     codex_core::otel_init::install_sqlite_telemetry(otel.as_ref(), OTEL_SERVICE_NAME);
     let state_db = codex_core::init_state_db(&config).await;
     let environment_manager = Arc::new(

--- a/codex-rs/mcp-server/src/main.rs
+++ b/codex-rs/mcp-server/src/main.rs
@@ -1,5 +1,6 @@
 use codex_arg0::Arg0DispatchPaths;
 use codex_arg0::arg0_dispatch_or_else;
+use codex_mcp_server::McpServerEntrypoint;
 use codex_mcp_server::run_main;
 use codex_utils_cli::CliConfigOverrides;
 
@@ -9,6 +10,7 @@ fn main() -> anyhow::Result<()> {
             arg0_paths,
             CliConfigOverrides::default(),
             /*strict_config*/ false,
+            McpServerEntrypoint::StandaloneBinary,
         )
         .await?;
         Ok(())


### PR DESCRIPTION
## Why

We want to evaluate deprecating `codex mcp-server`, but the existing MCP-server startup signal is too coarse for that decision: the shared runtime records `codex.process.start`, which only says that the MCP server runtime started. It does not distinguish the CLI subcommand from the standalone `codex-mcp-server` binary.

This adds a dedicated usage metric, `codex.mcp_server{entrypoint=...}`, so we can measure the legacy CLI entry point directly before deciding whether to remove it.

## What changed

- Added a `codex.mcp_server` counter tagged by `entrypoint`.
- Tagged launches from `codex mcp-server` as `codex_cli_subcommand`.
- Tagged launches from the standalone `codex-mcp-server` binary as `standalone_binary`.
- Left the existing shared process-start telemetry in place.

Relevant code:
- [MCP server metric emission](https://github.com/openai/codex/blob/664206891f9deba032694d91f3aa490695c03151/codex-rs/mcp-server/src/lib.rs#L55-L118)
- [`codex mcp-server` launch tagging](https://github.com/openai/codex/blob/664206891f9deba032694d91f3aa490695c03151/codex-rs/cli/src/main.rs#L914-L918)

## Verification

- `cargo test -p codex-mcp-server`
- `cargo test -p codex-cli` *(the crate run reached unrelated `plugin_cli` coverage and then hit the existing environment-sensitive `plugin_list_excludes_unconfigured_repo_local_marketplaces` failure because a local marketplace file is present on this machine)*
