### PR TITLE
app-server: clear stale plan progress after terminal turns

### DIFF
--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -1608,16 +1608,14 @@ async fn handle_turn_complete(
     thread_state: &Arc<Mutex<ThreadState>>,
 ) {
     let turn_summary = find_and_remove_turn_summary(thread_state).await;
-    emit_terminal_plan_cleanup(
-        conversation_id,
-        if preserve_terminal_plan_progress {
-            Vec::new()
-        } else {
-            take_pending_terminal_plan_cleanup(thread_state).await
-        },
-        outgoing,
-    )
-    .await;
+    if !preserve_terminal_plan_progress {
+        emit_terminal_plan_cleanup(
+            conversation_id,
+            take_pending_terminal_plan_cleanup(thread_state).await,
+            outgoing,
+        )
+        .await;
+    }
 
     let (status, error) = match turn_summary.last_error {
         Some(error) => (TurnStatus::Failed, Some(error)),
@@ -1648,16 +1646,14 @@ async fn handle_turn_interrupted(
     thread_state: &Arc<Mutex<ThreadState>>,
 ) {
     let turn_summary = find_and_remove_turn_summary(thread_state).await;
-    emit_terminal_plan_cleanup(
-        conversation_id,
-        if preserve_terminal_plan_progress {
-            Vec::new()
-        } else {
-            take_pending_terminal_plan_cleanup(thread_state).await
-        },
-        outgoing,
-    )
-    .await;
+    if !preserve_terminal_plan_progress {
+        emit_terminal_plan_cleanup(
+            conversation_id,
+            take_pending_terminal_plan_cleanup(thread_state).await,
+            outgoing,
+        )
+        .await;
+    }
 
     emit_turn_completed_with_status(
         conversation_id,

--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -1123,6 +1123,14 @@ pub(crate) async fn apply_bespoke_event_handling(
             // All per-thread requests are bound to a turn, so abort them.
             outgoing.abort_pending_server_requests().await;
             respond_to_pending_interrupts(&thread_state, &outgoing).await;
+            let has_pending_terminal_plan_cleanup = !thread_state
+                .lock()
+                .await
+                .pending_terminal_plan_cleanups
+                .is_empty();
+            let preserve_terminal_plan_progress = has_pending_terminal_plan_cleanup
+                && should_preserve_terminal_plan_progress(conversation.as_ref(), conversation_id)
+                    .await;
 
             thread_watch_manager
                 .note_turn_interrupted(&conversation_id.to_string())
@@ -1131,6 +1139,7 @@ pub(crate) async fn apply_bespoke_event_handling(
                 conversation_id,
                 event_turn_id,
                 turn_aborted_event,
+                preserve_terminal_plan_progress,
                 &outgoing,
                 &thread_state,
             )
@@ -1139,8 +1148,11 @@ pub(crate) async fn apply_bespoke_event_handling(
         EventMsg::ThreadRolledBack(_rollback_event) => {
             let pending = {
                 let mut state = thread_state.lock().await;
-                state.prune_pending_terminal_plan_cleanups_after_rollback();
-                state.pending_rollbacks.take()
+                let pending = state.pending_rollbacks.take();
+                if pending.is_none() {
+                    state.pending_terminal_plan_cleanups.clear();
+                }
+                pending
             };
 
             if let Some(request_id) = pending {
@@ -1196,6 +1208,13 @@ pub(crate) async fn apply_bespoke_event_handling(
                         return;
                     }
                 };
+                {
+                    let mut state = thread_state.lock().await;
+                    retain_pending_terminal_plan_cleanups_for_turns(
+                        &mut state.pending_terminal_plan_cleanups,
+                        &response.thread.turns,
+                    );
+                }
 
                 outgoing.send_response(request_id, response).await;
             }
@@ -1266,6 +1285,7 @@ async fn handle_turn_plan_update(
     outgoing: &ThreadScopedOutgoingMessageSender,
     thread_state: &Arc<Mutex<ThreadState>>,
 ) {
+    flush_pending_terminal_plan_cleanup(conversation_id, thread_state, outgoing).await;
     {
         let mut state = thread_state.lock().await;
         state
@@ -1284,7 +1304,6 @@ async fn handle_turn_plan_update(
                 });
         }
     }
-    flush_pending_terminal_plan_cleanup(conversation_id, thread_state, outgoing).await;
     emit_turn_plan_updated(conversation_id, event_turn_id, plan_update_event, outgoing).await;
 }
 
@@ -1378,6 +1397,14 @@ fn terminal_plan_cleanup_updates(
             },
         )
         .collect()
+}
+
+fn retain_pending_terminal_plan_cleanups_for_turns(
+    pending_terminal_plan_cleanups: &mut Vec<PendingTerminalPlanCleanup>,
+    retained_turns: &[Turn],
+) {
+    pending_terminal_plan_cleanups
+        .retain(|cleanup| retained_turns.iter().any(|turn| turn.id == cleanup.turn_id));
 }
 
 async fn emit_turn_plan_updated(
@@ -1630,11 +1657,14 @@ async fn handle_turn_interrupted(
     conversation_id: ThreadId,
     event_turn_id: String,
     turn_aborted_event: TurnAbortedEvent,
+    preserve_terminal_plan_progress: bool,
     outgoing: &ThreadScopedOutgoingMessageSender,
     thread_state: &Arc<Mutex<ThreadState>>,
 ) {
     let turn_summary = find_and_remove_turn_summary(thread_state).await;
-    flush_all_pending_terminal_plan_cleanup(conversation_id, thread_state, outgoing).await;
+    if !preserve_terminal_plan_progress {
+        flush_all_pending_terminal_plan_cleanup(conversation_id, thread_state, outgoing).await;
+    }
 
     emit_turn_completed_with_status(
         conversation_id,
@@ -3502,6 +3532,7 @@ mod tests {
             conversation_id,
             event_turn_id.clone(),
             turn_aborted_event(&event_turn_id),
+            /*preserve_terminal_plan_progress*/ false,
             &outgoing,
             &thread_state,
         )
@@ -3649,6 +3680,59 @@ mod tests {
                 .pending_terminal_plan_cleanups
                 .is_empty(),
             "plans without in-progress steps do not need terminal cleanup"
+        );
+        assert!(rx.try_recv().is_err(), "no extra messages expected");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn mid_turn_plan_update_keeps_cleanup_until_terminal_event_without_snapshot() -> Result<()>
+    {
+        let conversation_id = ThreadId::new();
+        let turn_id = "resume-mid-turn".to_string();
+        let thread_state = new_thread_state();
+        let (tx, mut rx) = mpsc::channel(CHANNEL_CAPACITY);
+        let outgoing = Arc::new(OutgoingMessageSender::new(
+            tx,
+            codex_analytics::AnalyticsEventsClient::disabled(),
+        ));
+        let outgoing = ThreadScopedOutgoingMessageSender::new(
+            outgoing,
+            vec![ConnectionId(1)],
+            conversation_id,
+        );
+
+        handle_turn_plan_update(
+            conversation_id,
+            &turn_id,
+            UpdatePlanArgs {
+                explanation: Some("still working".to_string()),
+                plan: vec![PlanItemArg {
+                    step: "first".to_string(),
+                    status: StepStatus::InProgress,
+                }],
+            },
+            &outgoing,
+            &thread_state,
+        )
+        .await;
+
+        let msg = recv_broadcast_message(&mut rx).await?;
+        match msg {
+            OutgoingMessage::AppServerNotification(ServerNotification::TurnPlanUpdated(n)) => {
+                assert_eq!(n.turn_id, turn_id);
+                assert_eq!(n.plan[0].status, TurnPlanStepStatus::InProgress);
+            }
+            other => bail!("unexpected message: {other:?}"),
+        }
+        assert_eq!(
+            thread_state
+                .lock()
+                .await
+                .pending_terminal_plan_cleanups
+                .len(),
+            1,
+            "the live plan remains eligible for terminal cleanup"
         );
         assert!(rx.try_recv().is_err(), "no extra messages expected");
         Ok(())
@@ -3857,6 +3941,7 @@ mod tests {
             conversation_id,
             event_turn_id.clone(),
             turn_aborted_event(&event_turn_id),
+            /*preserve_terminal_plan_progress*/ false,
             &outgoing,
             &thread_state,
         )
@@ -3889,6 +3974,65 @@ mod tests {
             }
             other => bail!("unexpected message: {other:?}"),
         }
+        assert!(rx.try_recv().is_err(), "no extra messages expected");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_handle_turn_interrupted_preserves_in_progress_plan_with_active_goal() -> Result<()>
+    {
+        let conversation_id = ThreadId::new();
+        let event_turn_id = "interrupt_active_goal".to_string();
+        let thread_state = new_thread_state();
+        thread_state.lock().await.pending_terminal_plan_cleanups =
+            vec![PendingTerminalPlanCleanup {
+                turn_id: event_turn_id.clone(),
+                plan_update: UpdatePlanArgs {
+                    explanation: Some("still working".to_string()),
+                    plan: vec![PlanItemArg {
+                        step: "first".to_string(),
+                        status: StepStatus::InProgress,
+                    }],
+                },
+            }];
+        let (tx, mut rx) = mpsc::channel(CHANNEL_CAPACITY);
+        let outgoing = Arc::new(OutgoingMessageSender::new(
+            tx,
+            codex_analytics::AnalyticsEventsClient::disabled(),
+        ));
+        let outgoing = ThreadScopedOutgoingMessageSender::new(
+            outgoing,
+            vec![ConnectionId(1)],
+            ThreadId::new(),
+        );
+
+        handle_turn_interrupted(
+            conversation_id,
+            event_turn_id.clone(),
+            turn_aborted_event(&event_turn_id),
+            /*preserve_terminal_plan_progress*/ true,
+            &outgoing,
+            &thread_state,
+        )
+        .await;
+
+        let msg = recv_broadcast_message(&mut rx).await?;
+        match msg {
+            OutgoingMessage::AppServerNotification(ServerNotification::TurnCompleted(n)) => {
+                assert_eq!(n.turn.id, event_turn_id);
+                assert_eq!(n.turn.status, TurnStatus::Interrupted);
+            }
+            other => bail!("unexpected message: {other:?}"),
+        }
+        assert_eq!(
+            thread_state
+                .lock()
+                .await
+                .pending_terminal_plan_cleanups
+                .len(),
+            1,
+            "active goals retain pending cleanup until the goal settles"
+        );
         assert!(rx.try_recv().is_err(), "no extra messages expected");
         Ok(())
     }
@@ -4394,102 +4538,48 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn rollback_preserves_cleanup_for_turns_that_survive() -> Result<()> {
-        let codex_home = TempDir::new()?;
-        let config = load_default_config_for_test(&codex_home).await;
-        let thread_manager = Arc::new(
-            codex_core::test_support::thread_manager_with_models_provider_and_home(
-                CodexAuth::create_dummy_chatgpt_auth_for_testing(),
-                config.model_provider.clone(),
-                config.codex_home.to_path_buf(),
-                Arc::new(codex_exec_server::EnvironmentManager::default_for_tests()),
-            ),
-        );
-        let codex_core::NewThread {
-            thread_id: conversation_id,
-            thread: conversation,
-            ..
-        } = thread_manager.start_thread(config).await?;
-        let rollback_event = codex_protocol::protocol::ThreadRolledBackEvent { num_turns: 1 };
-        let thread_state = new_thread_state();
-        {
-            let mut state = thread_state.lock().await;
-            for turn_id in ["older-turn", "rolled-back-turn"] {
-                state.track_current_turn_event(
-                    turn_id,
-                    &EventMsg::TurnStarted(codex_protocol::protocol::TurnStartedEvent {
-                        turn_id: turn_id.to_string(),
-                        started_at: Some(42),
-                        model_context_window: None,
-                        collaboration_mode_kind: Default::default(),
-                    }),
-                );
-                state.track_current_turn_event(
-                    turn_id,
-                    &EventMsg::TurnComplete(turn_complete_event(turn_id)),
-                );
-            }
-            state.track_current_turn_event(
-                "rollback-turn",
-                &EventMsg::ThreadRolledBack(rollback_event.clone()),
-            );
-            state.pending_terminal_plan_cleanups = vec![
-                PendingTerminalPlanCleanup {
-                    turn_id: "older-turn".to_string(),
-                    plan_update: UpdatePlanArgs {
-                        explanation: Some("still working".to_string()),
-                        plan: vec![PlanItemArg {
-                            step: "older".to_string(),
-                            status: StepStatus::InProgress,
-                        }],
-                    },
+    #[test]
+    fn rollback_response_preserves_cleanup_for_turns_that_survive() {
+        let mut pending_terminal_plan_cleanups = vec![
+            PendingTerminalPlanCleanup {
+                turn_id: "older-turn".to_string(),
+                plan_update: UpdatePlanArgs {
+                    explanation: Some("still working".to_string()),
+                    plan: vec![PlanItemArg {
+                        step: "older".to_string(),
+                        status: StepStatus::InProgress,
+                    }],
                 },
-                PendingTerminalPlanCleanup {
-                    turn_id: "rolled-back-turn".to_string(),
-                    plan_update: UpdatePlanArgs {
-                        explanation: Some("still working".to_string()),
-                        plan: vec![PlanItemArg {
-                            step: "newer".to_string(),
-                            status: StepStatus::InProgress,
-                        }],
-                    },
-                },
-            ];
-        }
-        let (tx, mut rx) = mpsc::channel(CHANNEL_CAPACITY);
-        let outgoing = Arc::new(OutgoingMessageSender::new(
-            tx,
-            codex_analytics::AnalyticsEventsClient::disabled(),
-        ));
-        let outgoing = ThreadScopedOutgoingMessageSender::new(
-            outgoing,
-            vec![ConnectionId(1)],
-            conversation_id,
-        );
-
-        apply_bespoke_event_handling(
-            Event {
-                id: "rollback-turn".to_string(),
-                msg: EventMsg::ThreadRolledBack(rollback_event),
             },
-            conversation_id,
-            conversation,
-            thread_manager,
-            outgoing,
-            thread_state.clone(),
-            ThreadWatchManager::new(),
-            Arc::new(tokio::sync::Semaphore::new(/*permits*/ 1)),
-            "test-provider".to_string(),
-        )
-        .await;
+            PendingTerminalPlanCleanup {
+                turn_id: "rolled-back-turn".to_string(),
+                plan_update: UpdatePlanArgs {
+                    explanation: Some("still working".to_string()),
+                    plan: vec![PlanItemArg {
+                        step: "newer".to_string(),
+                        status: StepStatus::InProgress,
+                    }],
+                },
+            },
+        ];
+        let retained_turns = vec![Turn {
+            id: "older-turn".to_string(),
+            items: Vec::new(),
+            items_view: TurnItemsView::NotLoaded,
+            error: None,
+            status: TurnStatus::Completed,
+            started_at: None,
+            completed_at: None,
+            duration_ms: None,
+        }];
 
-        let pending_terminal_plan_cleanups =
-            &thread_state.lock().await.pending_terminal_plan_cleanups;
+        retain_pending_terminal_plan_cleanups_for_turns(
+            &mut pending_terminal_plan_cleanups,
+            &retained_turns,
+        );
+
         assert_eq!(pending_terminal_plan_cleanups.len(), 1);
         assert_eq!(pending_terminal_plan_cleanups[0].turn_id, "older-turn");
-        assert!(rx.try_recv().is_err(), "no extra messages expected");
-        Ok(())
     }
 
     #[tokio::test]

--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -1,7 +1,6 @@
 use crate::error_code::internal_error;
 use crate::error_code::invalid_request;
 use crate::outgoing_message::ClientRequestResult;
-use crate::outgoing_message::OutgoingMessageSender;
 use crate::outgoing_message::ThreadScopedOutgoingMessageSender;
 use crate::request_processors::populate_thread_turns_from_history;
 use crate::request_processors::thread_from_stored_thread;
@@ -1325,7 +1324,7 @@ async fn emit_turn_completed_with_status(
         .await;
 }
 
-async fn emit_terminal_plan_cleanup(
+pub(crate) async fn emit_terminal_plan_cleanup(
     conversation_id: ThreadId,
     pending_terminal_plan_cleanups: Vec<PendingTerminalPlanCleanup>,
     outgoing: &ThreadScopedOutgoingMessageSender,
@@ -1334,22 +1333,6 @@ async fn emit_terminal_plan_cleanup(
         terminal_plan_cleanup_updates(pending_terminal_plan_cleanups)
     {
         emit_turn_plan_updated(conversation_id, &turn_id, latest_plan_update, outgoing).await;
-    }
-}
-
-pub(crate) async fn emit_terminal_plan_cleanup_globally(
-    conversation_id: ThreadId,
-    pending_terminal_plan_cleanups: Vec<PendingTerminalPlanCleanup>,
-    outgoing: &Arc<OutgoingMessageSender>,
-) {
-    for (turn_id, latest_plan_update) in
-        terminal_plan_cleanup_updates(pending_terminal_plan_cleanups)
-    {
-        let notification =
-            turn_plan_updated_notification(conversation_id, &turn_id, latest_plan_update);
-        outgoing
-            .send_server_notification(ServerNotification::TurnPlanUpdated(notification))
-            .await;
     }
 }
 

--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -1327,11 +1327,8 @@ pub(crate) async fn flush_pending_terminal_plan_cleanup(
 ) {
     let pending_terminal_plan_cleanups =
         take_flushable_pending_terminal_plan_cleanup(thread_state).await;
-    for (turn_id, latest_plan_update) in
-        terminal_plan_cleanup_updates(pending_terminal_plan_cleanups)
-    {
-        emit_turn_plan_updated(conversation_id, &turn_id, latest_plan_update, outgoing).await;
-    }
+    emit_terminal_plan_cleanup_updates(conversation_id, pending_terminal_plan_cleanups, outgoing)
+        .await;
 }
 
 async fn flush_all_pending_terminal_plan_cleanup(
@@ -1341,6 +1338,15 @@ async fn flush_all_pending_terminal_plan_cleanup(
 ) {
     let pending_terminal_plan_cleanups =
         std::mem::take(&mut thread_state.lock().await.pending_terminal_plan_cleanups);
+    emit_terminal_plan_cleanup_updates(conversation_id, pending_terminal_plan_cleanups, outgoing)
+        .await;
+}
+
+async fn emit_terminal_plan_cleanup_updates(
+    conversation_id: ThreadId,
+    pending_terminal_plan_cleanups: Vec<PendingTerminalPlanCleanup>,
+    outgoing: &ThreadScopedOutgoingMessageSender,
+) {
     for (turn_id, latest_plan_update) in
         terminal_plan_cleanup_updates(pending_terminal_plan_cleanups)
     {

--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -184,7 +184,11 @@ pub(crate) async fn apply_bespoke_event_handling(
             respond_to_pending_interrupts(&thread_state, &outgoing).await;
             let turn_failed = thread_state.lock().await.turn_summary.last_error.is_some();
             let preserve_terminal_plan_progress =
-                should_preserve_terminal_plan_progress(conversation.as_ref(), conversation_id)
+                terminal_plan_cleanup_may_be_needed(&thread_state).await
+                    && should_preserve_terminal_plan_progress(
+                        conversation.as_ref(),
+                        conversation_id,
+                    )
                     .await;
             thread_watch_manager
                 .note_turn_completed(&conversation_id.to_string(), turn_failed)
@@ -1121,6 +1125,7 @@ pub(crate) async fn apply_bespoke_event_handling(
 
             let preserve_terminal_plan_progress = turn_aborted_event.reason
                 != TurnAbortReason::Interrupted
+                && terminal_plan_cleanup_may_be_needed(&thread_state).await
                 && should_preserve_terminal_plan_progress(conversation.as_ref(), conversation_id)
                     .await;
             thread_watch_manager
@@ -1344,6 +1349,21 @@ async fn emit_turn_plan_updated(
         .await;
 }
 
+async fn terminal_plan_cleanup_may_be_needed(thread_state: &Arc<Mutex<ThreadState>>) -> bool {
+    thread_state
+        .lock()
+        .await
+        .turn_summary
+        .latest_plan_update
+        .as_ref()
+        .is_some_and(|update| {
+            update
+                .plan
+                .iter()
+                .any(|item| matches!(item.status, StepStatus::InProgress))
+        })
+}
+
 async fn should_preserve_terminal_plan_progress(
     conversation: &CodexThread,
     conversation_id: ThreadId,
@@ -1352,7 +1372,11 @@ async fn should_preserve_terminal_plan_progress(
         return false;
     };
 
-    match state_db.get_thread_goal(conversation_id).await {
+    match state_db
+        .thread_goals()
+        .get_thread_goal(conversation_id)
+        .await
+    {
         Ok(goal) => goal.is_some_and(|goal| goal.status == codex_state::ThreadGoalStatus::Active),
         Err(err) => {
             tracing::warn!(

--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -1,6 +1,7 @@
 use crate::error_code::internal_error;
 use crate::error_code::invalid_request;
 use crate::outgoing_message::ClientRequestResult;
+use crate::outgoing_message::OutgoingMessageSender;
 use crate::outgoing_message::ThreadScopedOutgoingMessageSender;
 use crate::request_processors::populate_thread_turns_from_history;
 use crate::request_processors::thread_from_stored_thread;
@@ -1271,15 +1272,24 @@ async fn handle_turn_plan_update(
     outgoing: &ThreadScopedOutgoingMessageSender,
     thread_state: &Arc<Mutex<ThreadState>>,
 ) {
-    let pending_terminal_plan_cleanup = plan_update_event
-        .plan
-        .iter()
-        .any(|item| matches!(item.status, StepStatus::InProgress))
-        .then(|| PendingTerminalPlanCleanup {
-            turn_id: event_turn_id.to_string(),
-            plan_update: plan_update_event.clone(),
-        });
-    thread_state.lock().await.pending_terminal_plan_cleanup = pending_terminal_plan_cleanup;
+    {
+        let mut state = thread_state.lock().await;
+        state
+            .pending_terminal_plan_cleanups
+            .retain(|cleanup| cleanup.turn_id != event_turn_id);
+        if plan_update_event
+            .plan
+            .iter()
+            .any(|item| matches!(item.status, StepStatus::InProgress))
+        {
+            state
+                .pending_terminal_plan_cleanups
+                .push(PendingTerminalPlanCleanup {
+                    turn_id: event_turn_id.to_string(),
+                    plan_update: plan_update_event.clone(),
+                });
+        }
+    }
     emit_turn_plan_updated(conversation_id, event_turn_id, plan_update_event, outgoing).await;
 }
 
@@ -1317,29 +1327,56 @@ async fn emit_turn_completed_with_status(
 
 async fn emit_terminal_plan_cleanup(
     conversation_id: ThreadId,
-    pending_terminal_plan_cleanup: Option<PendingTerminalPlanCleanup>,
+    pending_terminal_plan_cleanups: Vec<PendingTerminalPlanCleanup>,
     outgoing: &ThreadScopedOutgoingMessageSender,
 ) {
-    let Some(PendingTerminalPlanCleanup {
-        turn_id,
-        plan_update: mut latest_plan_update,
-    }) = pending_terminal_plan_cleanup
-    else {
-        return;
-    };
-    let mut downgraded = false;
-    for item in &mut latest_plan_update.plan {
-        if matches!(item.status, StepStatus::InProgress) {
-            item.status = StepStatus::Pending;
-            downgraded = true;
-        }
+    for (turn_id, latest_plan_update) in
+        terminal_plan_cleanup_updates(pending_terminal_plan_cleanups)
+    {
+        emit_turn_plan_updated(conversation_id, &turn_id, latest_plan_update, outgoing).await;
     }
-    if !downgraded {
-        return;
-    }
+}
 
-    latest_plan_update.explanation = None;
-    emit_turn_plan_updated(conversation_id, &turn_id, latest_plan_update, outgoing).await;
+pub(crate) async fn emit_terminal_plan_cleanup_globally(
+    conversation_id: ThreadId,
+    pending_terminal_plan_cleanups: Vec<PendingTerminalPlanCleanup>,
+    outgoing: &Arc<OutgoingMessageSender>,
+) {
+    for (turn_id, latest_plan_update) in
+        terminal_plan_cleanup_updates(pending_terminal_plan_cleanups)
+    {
+        let notification =
+            turn_plan_updated_notification(conversation_id, &turn_id, latest_plan_update);
+        outgoing
+            .send_server_notification(ServerNotification::TurnPlanUpdated(notification))
+            .await;
+    }
+}
+
+fn terminal_plan_cleanup_updates(
+    pending_terminal_plan_cleanups: Vec<PendingTerminalPlanCleanup>,
+) -> Vec<(String, UpdatePlanArgs)> {
+    pending_terminal_plan_cleanups
+        .into_iter()
+        .filter_map(
+            |PendingTerminalPlanCleanup {
+                 turn_id,
+                 plan_update: mut latest_plan_update,
+             }| {
+                let mut downgraded = false;
+                for item in &mut latest_plan_update.plan {
+                    if matches!(item.status, StepStatus::InProgress) {
+                        item.status = StepStatus::Pending;
+                        downgraded = true;
+                    }
+                }
+                downgraded.then(|| {
+                    latest_plan_update.explanation = None;
+                    (turn_id, latest_plan_update)
+                })
+            },
+        )
+        .collect()
 }
 
 async fn emit_turn_plan_updated(
@@ -1348,8 +1385,20 @@ async fn emit_turn_plan_updated(
     plan_update_event: UpdatePlanArgs,
     outgoing: &ThreadScopedOutgoingMessageSender,
 ) {
+    let notification =
+        turn_plan_updated_notification(conversation_id, event_turn_id, plan_update_event);
+    outgoing
+        .send_server_notification(ServerNotification::TurnPlanUpdated(notification))
+        .await;
+}
+
+fn turn_plan_updated_notification(
+    conversation_id: ThreadId,
+    event_turn_id: &str,
+    plan_update_event: UpdatePlanArgs,
+) -> TurnPlanUpdatedNotification {
     // `update_plan` is a todo/checklist tool; it is not related to plan-mode updates.
-    let notification = TurnPlanUpdatedNotification {
+    TurnPlanUpdatedNotification {
         thread_id: conversation_id.to_string(),
         turn_id: event_turn_id.to_string(),
         explanation: plan_update_event.explanation,
@@ -1358,28 +1407,21 @@ async fn emit_turn_plan_updated(
             .into_iter()
             .map(TurnPlanStep::from)
             .collect(),
-    };
-    outgoing
-        .send_server_notification(ServerNotification::TurnPlanUpdated(notification))
-        .await;
+    }
 }
 
 async fn terminal_plan_cleanup_may_be_needed(thread_state: &Arc<Mutex<ThreadState>>) -> bool {
-    thread_state
+    !thread_state
         .lock()
         .await
-        .pending_terminal_plan_cleanup
-        .is_some()
+        .pending_terminal_plan_cleanups
+        .is_empty()
 }
 
-async fn take_pending_terminal_plan_cleanup(
+pub(crate) async fn take_pending_terminal_plan_cleanup(
     thread_state: &Arc<Mutex<ThreadState>>,
-) -> Option<PendingTerminalPlanCleanup> {
-    thread_state
-        .lock()
-        .await
-        .pending_terminal_plan_cleanup
-        .take()
+) -> Vec<PendingTerminalPlanCleanup> {
+    std::mem::take(&mut thread_state.lock().await.pending_terminal_plan_cleanups)
 }
 
 async fn should_preserve_terminal_plan_progress(
@@ -1569,7 +1611,7 @@ async fn handle_turn_complete(
     emit_terminal_plan_cleanup(
         conversation_id,
         if preserve_terminal_plan_progress {
-            None
+            Vec::new()
         } else {
             take_pending_terminal_plan_cleanup(thread_state).await
         },
@@ -1609,7 +1651,7 @@ async fn handle_turn_interrupted(
     emit_terminal_plan_cleanup(
         conversation_id,
         if preserve_terminal_plan_progress {
-            None
+            Vec::new()
         } else {
             take_pending_terminal_plan_cleanup(thread_state).await
         },
@@ -3628,8 +3670,8 @@ mod tests {
             thread_state
                 .lock()
                 .await
-                .pending_terminal_plan_cleanup
-                .is_none(),
+                .pending_terminal_plan_cleanups
+                .is_empty(),
             "plans without in-progress steps do not need terminal cleanup"
         );
         assert!(rx.try_recv().is_err(), "no extra messages expected");
@@ -3642,8 +3684,8 @@ mod tests {
         let conversation_id = ThreadId::new();
         let event_turn_id = "complete_with_plan".to_string();
         let thread_state = new_thread_state();
-        thread_state.lock().await.pending_terminal_plan_cleanup =
-            Some(PendingTerminalPlanCleanup {
+        thread_state.lock().await.pending_terminal_plan_cleanups =
+            vec![PendingTerminalPlanCleanup {
                 turn_id: event_turn_id.clone(),
                 plan_update: UpdatePlanArgs {
                     explanation: Some("still working".to_string()),
@@ -3662,7 +3704,7 @@ mod tests {
                         },
                     ],
                 },
-            });
+            }];
         let (tx, mut rx) = mpsc::channel(CHANNEL_CAPACITY);
         let outgoing = Arc::new(OutgoingMessageSender::new(
             tx,
@@ -3731,8 +3773,8 @@ mod tests {
         let conversation_id = ThreadId::new();
         let event_turn_id = "interrupt_with_plan".to_string();
         let thread_state = new_thread_state();
-        thread_state.lock().await.pending_terminal_plan_cleanup =
-            Some(PendingTerminalPlanCleanup {
+        thread_state.lock().await.pending_terminal_plan_cleanups =
+            vec![PendingTerminalPlanCleanup {
                 turn_id: event_turn_id.clone(),
                 plan_update: UpdatePlanArgs {
                     explanation: Some("still working".to_string()),
@@ -3741,7 +3783,7 @@ mod tests {
                         status: StepStatus::InProgress,
                     }],
                 },
-            });
+            }];
         let (tx, mut rx) = mpsc::channel(CHANNEL_CAPACITY);
         let outgoing = Arc::new(OutgoingMessageSender::new(
             tx,
@@ -3799,8 +3841,8 @@ mod tests {
         let conversation_id = ThreadId::new();
         let event_turn_id = "complete_active_goal".to_string();
         let thread_state = new_thread_state();
-        thread_state.lock().await.pending_terminal_plan_cleanup =
-            Some(PendingTerminalPlanCleanup {
+        thread_state.lock().await.pending_terminal_plan_cleanups =
+            vec![PendingTerminalPlanCleanup {
                 turn_id: event_turn_id.clone(),
                 plan_update: UpdatePlanArgs {
                     explanation: Some("still working".to_string()),
@@ -3809,7 +3851,7 @@ mod tests {
                         status: StepStatus::InProgress,
                     }],
                 },
-            });
+            }];
         let (tx, mut rx) = mpsc::channel(CHANNEL_CAPACITY);
         let outgoing = Arc::new(OutgoingMessageSender::new(
             tx,
@@ -3843,8 +3885,9 @@ mod tests {
             thread_state
                 .lock()
                 .await
-                .pending_terminal_plan_cleanup
-                .is_some(),
+                .pending_terminal_plan_cleanups
+                .len()
+                == 1,
             "active goals retain pending cleanup until the goal settles"
         );
         assert!(rx.try_recv().is_err(), "no extra messages expected");
@@ -3870,8 +3913,8 @@ mod tests {
         } = thread_manager.start_thread(config).await?;
         let turn_id = "preserved-plan-turn".to_string();
         let thread_state = new_thread_state();
-        thread_state.lock().await.pending_terminal_plan_cleanup =
-            Some(PendingTerminalPlanCleanup {
+        thread_state.lock().await.pending_terminal_plan_cleanups =
+            vec![PendingTerminalPlanCleanup {
                 turn_id: turn_id.clone(),
                 plan_update: UpdatePlanArgs {
                     explanation: Some("still working".to_string()),
@@ -3880,7 +3923,7 @@ mod tests {
                         status: StepStatus::InProgress,
                     }],
                 },
-            });
+            }];
         let (tx, mut rx) = mpsc::channel(CHANNEL_CAPACITY);
         let outgoing = Arc::new(OutgoingMessageSender::new(
             tx,
@@ -3951,8 +3994,8 @@ mod tests {
             thread_state
                 .lock()
                 .await
-                .pending_terminal_plan_cleanup
-                .is_none(),
+                .pending_terminal_plan_cleanups
+                .is_empty(),
             "terminal goal updates consume preserved cleanup state"
         );
         assert!(rx.try_recv().is_err(), "no extra messages expected");

--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -99,6 +99,7 @@ use codex_protocol::protocol::RealtimeEvent;
 use codex_protocol::protocol::ReviewDecision;
 use codex_protocol::protocol::ReviewOutputEvent;
 use codex_protocol::protocol::TokenCountEvent;
+use codex_protocol::protocol::TurnAbortReason;
 use codex_protocol::protocol::TurnAbortedEvent;
 use codex_protocol::protocol::TurnCompleteEvent;
 use codex_protocol::protocol::TurnDiffEvent;
@@ -182,8 +183,9 @@ pub(crate) async fn apply_bespoke_event_handling(
             outgoing.abort_pending_server_requests().await;
             respond_to_pending_interrupts(&thread_state, &outgoing).await;
             let turn_failed = thread_state.lock().await.turn_summary.last_error.is_some();
-            let has_active_goal =
-                thread_has_active_goal(conversation.as_ref(), conversation_id).await;
+            let preserve_terminal_plan_progress =
+                should_preserve_terminal_plan_progress(conversation.as_ref(), conversation_id)
+                    .await;
             thread_watch_manager
                 .note_turn_completed(&conversation_id.to_string(), turn_failed)
                 .await;
@@ -191,7 +193,7 @@ pub(crate) async fn apply_bespoke_event_handling(
                 conversation_id,
                 event_turn_id,
                 turn_complete_event,
-                has_active_goal,
+                preserve_terminal_plan_progress,
                 &outgoing,
                 &thread_state,
             )
@@ -1117,8 +1119,10 @@ pub(crate) async fn apply_bespoke_event_handling(
             outgoing.abort_pending_server_requests().await;
             respond_to_pending_interrupts(&thread_state, &outgoing).await;
 
-            let has_active_goal =
-                thread_has_active_goal(conversation.as_ref(), conversation_id).await;
+            let preserve_terminal_plan_progress = turn_aborted_event.reason
+                != TurnAbortReason::Interrupted
+                && should_preserve_terminal_plan_progress(conversation.as_ref(), conversation_id)
+                    .await;
             thread_watch_manager
                 .note_turn_interrupted(&conversation_id.to_string())
                 .await;
@@ -1126,7 +1130,7 @@ pub(crate) async fn apply_bespoke_event_handling(
                 conversation_id,
                 event_turn_id,
                 turn_aborted_event,
-                has_active_goal,
+                preserve_terminal_plan_progress,
                 &outgoing,
                 &thread_state,
             )
@@ -1293,10 +1297,10 @@ async fn emit_terminal_plan_cleanup(
     conversation_id: ThreadId,
     event_turn_id: &str,
     latest_plan_update: Option<UpdatePlanArgs>,
-    has_active_goal: bool,
+    preserve_terminal_plan_progress: bool,
     outgoing: &ThreadScopedOutgoingMessageSender,
 ) {
-    if has_active_goal {
+    if preserve_terminal_plan_progress {
         return;
     }
 
@@ -1340,7 +1344,10 @@ async fn emit_turn_plan_updated(
         .await;
 }
 
-async fn thread_has_active_goal(conversation: &CodexThread, conversation_id: ThreadId) -> bool {
+async fn should_preserve_terminal_plan_progress(
+    conversation: &CodexThread,
+    conversation_id: ThreadId,
+) -> bool {
     let Some(state_db) = conversation.state_db() else {
         return false;
     };
@@ -1512,7 +1519,7 @@ async fn handle_turn_complete(
     conversation_id: ThreadId,
     event_turn_id: String,
     turn_complete_event: TurnCompleteEvent,
-    has_active_goal: bool,
+    preserve_terminal_plan_progress: bool,
     outgoing: &ThreadScopedOutgoingMessageSender,
     thread_state: &Arc<Mutex<ThreadState>>,
 ) {
@@ -1521,7 +1528,7 @@ async fn handle_turn_complete(
         conversation_id,
         &event_turn_id,
         turn_summary.latest_plan_update,
-        has_active_goal,
+        preserve_terminal_plan_progress,
         outgoing,
     )
     .await;
@@ -1550,7 +1557,7 @@ async fn handle_turn_interrupted(
     conversation_id: ThreadId,
     event_turn_id: String,
     turn_aborted_event: TurnAbortedEvent,
-    has_active_goal: bool,
+    preserve_terminal_plan_progress: bool,
     outgoing: &ThreadScopedOutgoingMessageSender,
     thread_state: &Arc<Mutex<ThreadState>>,
 ) {
@@ -1559,7 +1566,7 @@ async fn handle_turn_interrupted(
         conversation_id,
         &event_turn_id,
         turn_summary.latest_plan_update,
-        has_active_goal,
+        preserve_terminal_plan_progress,
         outgoing,
     )
     .await;
@@ -3376,7 +3383,7 @@ mod tests {
             conversation_id,
             event_turn_id.clone(),
             turn_complete_event(&event_turn_id),
-            /*has_active_goal*/ false,
+            /*preserve_terminal_plan_progress*/ false,
             &outgoing,
             &thread_state,
         )
@@ -3430,7 +3437,7 @@ mod tests {
             conversation_id,
             event_turn_id.clone(),
             turn_aborted_event(&event_turn_id),
-            /*has_active_goal*/ false,
+            /*preserve_terminal_plan_progress*/ false,
             &outgoing,
             &thread_state,
         )
@@ -3481,7 +3488,7 @@ mod tests {
             conversation_id,
             event_turn_id.clone(),
             turn_complete_event(&event_turn_id),
-            /*has_active_goal*/ false,
+            /*preserve_terminal_plan_progress*/ false,
             &outgoing,
             &thread_state,
         )
@@ -3626,7 +3633,7 @@ mod tests {
             conversation_id,
             event_turn_id.clone(),
             turn_complete_event(&event_turn_id),
-            /*has_active_goal*/ false,
+            /*preserve_terminal_plan_progress*/ false,
             &outgoing,
             &thread_state,
         )
@@ -3639,7 +3646,7 @@ mod tests {
                     n,
                     TurnPlanUpdatedNotification {
                         thread_id: conversation_id.to_string(),
-                        turn_id: event_turn_id,
+                        turn_id: event_turn_id.clone(),
                         explanation: None,
                         plan: vec![
                             TurnPlanStep {
@@ -3664,7 +3671,7 @@ mod tests {
         let second = recv_broadcast_message(&mut rx).await?;
         match second {
             OutgoingMessage::AppServerNotification(ServerNotification::TurnCompleted(n)) => {
-                assert_eq!(n.turn.id, "complete_with_plan");
+                assert_eq!(n.turn.id, event_turn_id);
                 assert_eq!(n.turn.status, TurnStatus::Completed);
             }
             other => bail!("unexpected message: {other:?}"),
@@ -3701,7 +3708,7 @@ mod tests {
             conversation_id,
             event_turn_id.clone(),
             turn_aborted_event(&event_turn_id),
-            /*has_active_goal*/ false,
+            /*preserve_terminal_plan_progress*/ false,
             &outgoing,
             &thread_state,
         )
@@ -3714,7 +3721,7 @@ mod tests {
                     n,
                     TurnPlanUpdatedNotification {
                         thread_id: conversation_id.to_string(),
-                        turn_id: event_turn_id,
+                        turn_id: event_turn_id.clone(),
                         explanation: None,
                         plan: vec![TurnPlanStep {
                             step: "first".to_string(),
@@ -3729,7 +3736,7 @@ mod tests {
         let second = recv_broadcast_message(&mut rx).await?;
         match second {
             OutgoingMessage::AppServerNotification(ServerNotification::TurnCompleted(n)) => {
-                assert_eq!(n.turn.id, "interrupt_with_plan");
+                assert_eq!(n.turn.id, event_turn_id);
                 assert_eq!(n.turn.status, TurnStatus::Interrupted);
             }
             other => bail!("unexpected message: {other:?}"),
@@ -3765,7 +3772,7 @@ mod tests {
             conversation_id,
             event_turn_id.clone(),
             turn_complete_event(&event_turn_id),
-            /*has_active_goal*/ true,
+            /*preserve_terminal_plan_progress*/ true,
             &outgoing,
             &thread_state,
         )
@@ -3942,7 +3949,7 @@ mod tests {
             conversation_a,
             a_turn1.clone(),
             turn_complete_event(&a_turn1),
-            /*has_active_goal*/ false,
+            /*preserve_terminal_plan_progress*/ false,
             &outgoing,
             &thread_state,
         )
@@ -3964,7 +3971,7 @@ mod tests {
             conversation_b,
             b_turn1.clone(),
             turn_complete_event(&b_turn1),
-            /*has_active_goal*/ false,
+            /*preserve_terminal_plan_progress*/ false,
             &outgoing,
             &thread_state,
         )
@@ -3976,7 +3983,7 @@ mod tests {
             conversation_a,
             a_turn2.clone(),
             turn_complete_event(&a_turn2),
-            /*has_active_goal*/ false,
+            /*preserve_terminal_plan_progress*/ false,
             &outgoing,
             &thread_state,
         )

--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -88,6 +88,7 @@ use codex_core::review_prompts;
 use codex_protocol::ThreadId;
 use codex_protocol::items::parse_hook_prompt_message;
 use codex_protocol::models::AdditionalPermissionProfile as CoreAdditionalPermissionProfile;
+use codex_protocol::plan_tool::StepStatus;
 use codex_protocol::plan_tool::UpdatePlanArgs;
 use codex_protocol::protocol::CodexErrorInfo as CoreCodexErrorInfo;
 use codex_protocol::protocol::Event;
@@ -181,6 +182,8 @@ pub(crate) async fn apply_bespoke_event_handling(
             outgoing.abort_pending_server_requests().await;
             respond_to_pending_interrupts(&thread_state, &outgoing).await;
             let turn_failed = thread_state.lock().await.turn_summary.last_error.is_some();
+            let has_active_goal =
+                thread_has_active_goal(conversation.as_ref(), conversation_id).await;
             thread_watch_manager
                 .note_turn_completed(&conversation_id.to_string(), turn_failed)
                 .await;
@@ -188,6 +191,7 @@ pub(crate) async fn apply_bespoke_event_handling(
                 conversation_id,
                 event_turn_id,
                 turn_complete_event,
+                has_active_goal,
                 &outgoing,
                 &thread_state,
             )
@@ -1113,6 +1117,8 @@ pub(crate) async fn apply_bespoke_event_handling(
             outgoing.abort_pending_server_requests().await;
             respond_to_pending_interrupts(&thread_state, &outgoing).await;
 
+            let has_active_goal =
+                thread_has_active_goal(conversation.as_ref(), conversation_id).await;
             thread_watch_manager
                 .note_turn_interrupted(&conversation_id.to_string())
                 .await;
@@ -1120,6 +1126,7 @@ pub(crate) async fn apply_bespoke_event_handling(
                 conversation_id,
                 event_turn_id,
                 turn_aborted_event,
+                has_active_goal,
                 &outgoing,
                 &thread_state,
             )
@@ -1209,6 +1216,7 @@ pub(crate) async fn apply_bespoke_event_handling(
                 &event_turn_id,
                 plan_update_event,
                 &outgoing,
+                &thread_state,
             )
             .await;
         }
@@ -1243,21 +1251,10 @@ async fn handle_turn_plan_update(
     event_turn_id: &str,
     plan_update_event: UpdatePlanArgs,
     outgoing: &ThreadScopedOutgoingMessageSender,
+    thread_state: &Arc<Mutex<ThreadState>>,
 ) {
-    // `update_plan` is a todo/checklist tool; it is not related to plan-mode updates
-    let notification = TurnPlanUpdatedNotification {
-        thread_id: conversation_id.to_string(),
-        turn_id: event_turn_id.to_string(),
-        explanation: plan_update_event.explanation,
-        plan: plan_update_event
-            .plan
-            .into_iter()
-            .map(TurnPlanStep::from)
-            .collect(),
-    };
-    outgoing
-        .send_server_notification(ServerNotification::TurnPlanUpdated(notification))
-        .await;
+    thread_state.lock().await.turn_summary.latest_plan_update = Some(plan_update_event.clone());
+    emit_turn_plan_updated(conversation_id, event_turn_id, plan_update_event, outgoing).await;
 }
 
 struct TurnCompletionMetadata {
@@ -1290,6 +1287,74 @@ async fn emit_turn_completed_with_status(
     outgoing
         .send_server_notification(ServerNotification::TurnCompleted(notification))
         .await;
+}
+
+async fn emit_terminal_plan_cleanup(
+    conversation_id: ThreadId,
+    event_turn_id: &str,
+    latest_plan_update: Option<UpdatePlanArgs>,
+    has_active_goal: bool,
+    outgoing: &ThreadScopedOutgoingMessageSender,
+) {
+    if has_active_goal {
+        return;
+    }
+
+    let Some(mut latest_plan_update) = latest_plan_update else {
+        return;
+    };
+    let mut downgraded = false;
+    for item in &mut latest_plan_update.plan {
+        if matches!(item.status, StepStatus::InProgress) {
+            item.status = StepStatus::Pending;
+            downgraded = true;
+        }
+    }
+    if !downgraded {
+        return;
+    }
+
+    latest_plan_update.explanation = None;
+    emit_turn_plan_updated(conversation_id, event_turn_id, latest_plan_update, outgoing).await;
+}
+
+async fn emit_turn_plan_updated(
+    conversation_id: ThreadId,
+    event_turn_id: &str,
+    plan_update_event: UpdatePlanArgs,
+    outgoing: &ThreadScopedOutgoingMessageSender,
+) {
+    // `update_plan` is a todo/checklist tool; it is not related to plan-mode updates.
+    let notification = TurnPlanUpdatedNotification {
+        thread_id: conversation_id.to_string(),
+        turn_id: event_turn_id.to_string(),
+        explanation: plan_update_event.explanation,
+        plan: plan_update_event
+            .plan
+            .into_iter()
+            .map(TurnPlanStep::from)
+            .collect(),
+    };
+    outgoing
+        .send_server_notification(ServerNotification::TurnPlanUpdated(notification))
+        .await;
+}
+
+async fn thread_has_active_goal(conversation: &CodexThread, conversation_id: ThreadId) -> bool {
+    let Some(state_db) = conversation.state_db() else {
+        return false;
+    };
+
+    match state_db.get_thread_goal(conversation_id).await {
+        Ok(goal) => goal.is_some_and(|goal| goal.status == codex_state::ThreadGoalStatus::Active),
+        Err(err) => {
+            tracing::warn!(
+                thread_id = %conversation_id,
+                "failed to read thread goal before terminal plan cleanup: {err}"
+            );
+            true
+        }
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1438,10 +1503,7 @@ pub(crate) async fn maybe_emit_hook_prompt_item_completed(
         .await;
 }
 
-async fn find_and_remove_turn_summary(
-    _conversation_id: ThreadId,
-    thread_state: &Arc<Mutex<ThreadState>>,
-) -> TurnSummary {
+async fn find_and_remove_turn_summary(thread_state: &Arc<Mutex<ThreadState>>) -> TurnSummary {
     let mut state = thread_state.lock().await;
     std::mem::take(&mut state.turn_summary)
 }
@@ -1450,10 +1512,19 @@ async fn handle_turn_complete(
     conversation_id: ThreadId,
     event_turn_id: String,
     turn_complete_event: TurnCompleteEvent,
+    has_active_goal: bool,
     outgoing: &ThreadScopedOutgoingMessageSender,
     thread_state: &Arc<Mutex<ThreadState>>,
 ) {
-    let turn_summary = find_and_remove_turn_summary(conversation_id, thread_state).await;
+    let turn_summary = find_and_remove_turn_summary(thread_state).await;
+    emit_terminal_plan_cleanup(
+        conversation_id,
+        &event_turn_id,
+        turn_summary.latest_plan_update,
+        has_active_goal,
+        outgoing,
+    )
+    .await;
 
     let (status, error) = match turn_summary.last_error {
         Some(error) => (TurnStatus::Failed, Some(error)),
@@ -1479,10 +1550,19 @@ async fn handle_turn_interrupted(
     conversation_id: ThreadId,
     event_turn_id: String,
     turn_aborted_event: TurnAbortedEvent,
+    has_active_goal: bool,
     outgoing: &ThreadScopedOutgoingMessageSender,
     thread_state: &Arc<Mutex<ThreadState>>,
 ) {
-    let turn_summary = find_and_remove_turn_summary(conversation_id, thread_state).await;
+    let turn_summary = find_and_remove_turn_summary(thread_state).await;
+    emit_terminal_plan_cleanup(
+        conversation_id,
+        &event_turn_id,
+        turn_summary.latest_plan_update,
+        has_active_goal,
+        outgoing,
+    )
+    .await;
 
     emit_turn_completed_with_status(
         conversation_id,
@@ -3163,7 +3243,7 @@ mod tests {
         )
         .await;
 
-        let turn_summary = find_and_remove_turn_summary(conversation_id, &thread_state).await;
+        let turn_summary = find_and_remove_turn_summary(&thread_state).await;
         assert_eq!(
             turn_summary.last_error,
             Some(TurnError {
@@ -3296,6 +3376,7 @@ mod tests {
             conversation_id,
             event_turn_id.clone(),
             turn_complete_event(&event_turn_id),
+            /*has_active_goal*/ false,
             &outgoing,
             &thread_state,
         )
@@ -3349,6 +3430,7 @@ mod tests {
             conversation_id,
             event_turn_id.clone(),
             turn_aborted_event(&event_turn_id),
+            /*has_active_goal*/ false,
             &outgoing,
             &thread_state,
         )
@@ -3399,6 +3481,7 @@ mod tests {
             conversation_id,
             event_turn_id.clone(),
             turn_complete_event(&event_turn_id),
+            /*has_active_goal*/ false,
             &outgoing,
             &thread_state,
         )
@@ -3453,20 +3536,246 @@ mod tests {
         };
 
         let conversation_id = ThreadId::new();
+        let thread_state = new_thread_state();
 
-        handle_turn_plan_update(conversation_id, "turn-123", update, &outgoing).await;
+        handle_turn_plan_update(
+            conversation_id,
+            "turn-123",
+            update,
+            &outgoing,
+            &thread_state,
+        )
+        .await;
 
         let msg = recv_broadcast_message(&mut rx).await?;
         match msg {
             OutgoingMessage::AppServerNotification(ServerNotification::TurnPlanUpdated(n)) => {
-                assert_eq!(n.thread_id, conversation_id.to_string());
-                assert_eq!(n.turn_id, "turn-123");
-                assert_eq!(n.explanation.as_deref(), Some("need plan"));
-                assert_eq!(n.plan.len(), 2);
-                assert_eq!(n.plan[0].step, "first");
-                assert_eq!(n.plan[0].status, TurnPlanStepStatus::Pending);
-                assert_eq!(n.plan[1].step, "second");
-                assert_eq!(n.plan[1].status, TurnPlanStepStatus::Completed);
+                assert_eq!(
+                    n,
+                    TurnPlanUpdatedNotification {
+                        thread_id: conversation_id.to_string(),
+                        turn_id: "turn-123".to_string(),
+                        explanation: Some("need plan".to_string()),
+                        plan: vec![
+                            TurnPlanStep {
+                                step: "first".to_string(),
+                                status: TurnPlanStepStatus::Pending,
+                            },
+                            TurnPlanStep {
+                                step: "second".to_string(),
+                                status: TurnPlanStepStatus::Completed,
+                            },
+                        ],
+                    }
+                );
+            }
+            other => bail!("unexpected message: {other:?}"),
+        }
+        let cached = thread_state
+            .lock()
+            .await
+            .turn_summary
+            .latest_plan_update
+            .clone()
+            .expect("plan update should be cached");
+        assert_eq!(cached.explanation.as_deref(), Some("need plan"));
+        assert_eq!(cached.plan.len(), 2);
+        assert_eq!(cached.plan[0].step, "first");
+        assert!(matches!(cached.plan[0].status, StepStatus::Pending));
+        assert_eq!(cached.plan[1].step, "second");
+        assert!(matches!(cached.plan[1].status, StepStatus::Completed));
+        assert!(rx.try_recv().is_err(), "no extra messages expected");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_handle_turn_complete_downgrades_in_progress_plan_without_active_goal()
+    -> Result<()> {
+        let conversation_id = ThreadId::new();
+        let event_turn_id = "complete_with_plan".to_string();
+        let thread_state = new_thread_state();
+        thread_state.lock().await.turn_summary.latest_plan_update = Some(UpdatePlanArgs {
+            explanation: Some("still working".to_string()),
+            plan: vec![
+                PlanItemArg {
+                    step: "first".to_string(),
+                    status: StepStatus::InProgress,
+                },
+                PlanItemArg {
+                    step: "second".to_string(),
+                    status: StepStatus::Completed,
+                },
+                PlanItemArg {
+                    step: "third".to_string(),
+                    status: StepStatus::InProgress,
+                },
+            ],
+        });
+        let (tx, mut rx) = mpsc::channel(CHANNEL_CAPACITY);
+        let outgoing = Arc::new(OutgoingMessageSender::new(
+            tx,
+            codex_analytics::AnalyticsEventsClient::disabled(),
+        ));
+        let outgoing = ThreadScopedOutgoingMessageSender::new(
+            outgoing,
+            vec![ConnectionId(1)],
+            ThreadId::new(),
+        );
+
+        handle_turn_complete(
+            conversation_id,
+            event_turn_id.clone(),
+            turn_complete_event(&event_turn_id),
+            /*has_active_goal*/ false,
+            &outgoing,
+            &thread_state,
+        )
+        .await;
+
+        let first = recv_broadcast_message(&mut rx).await?;
+        match first {
+            OutgoingMessage::AppServerNotification(ServerNotification::TurnPlanUpdated(n)) => {
+                assert_eq!(
+                    n,
+                    TurnPlanUpdatedNotification {
+                        thread_id: conversation_id.to_string(),
+                        turn_id: event_turn_id,
+                        explanation: None,
+                        plan: vec![
+                            TurnPlanStep {
+                                step: "first".to_string(),
+                                status: TurnPlanStepStatus::Pending,
+                            },
+                            TurnPlanStep {
+                                step: "second".to_string(),
+                                status: TurnPlanStepStatus::Completed,
+                            },
+                            TurnPlanStep {
+                                step: "third".to_string(),
+                                status: TurnPlanStepStatus::Pending,
+                            },
+                        ],
+                    }
+                );
+            }
+            other => bail!("unexpected message: {other:?}"),
+        }
+
+        let second = recv_broadcast_message(&mut rx).await?;
+        match second {
+            OutgoingMessage::AppServerNotification(ServerNotification::TurnCompleted(n)) => {
+                assert_eq!(n.turn.id, "complete_with_plan");
+                assert_eq!(n.turn.status, TurnStatus::Completed);
+            }
+            other => bail!("unexpected message: {other:?}"),
+        }
+        assert!(rx.try_recv().is_err(), "no extra messages expected");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_handle_turn_interrupted_downgrades_in_progress_plan_without_active_goal()
+    -> Result<()> {
+        let conversation_id = ThreadId::new();
+        let event_turn_id = "interrupt_with_plan".to_string();
+        let thread_state = new_thread_state();
+        thread_state.lock().await.turn_summary.latest_plan_update = Some(UpdatePlanArgs {
+            explanation: Some("still working".to_string()),
+            plan: vec![PlanItemArg {
+                step: "first".to_string(),
+                status: StepStatus::InProgress,
+            }],
+        });
+        let (tx, mut rx) = mpsc::channel(CHANNEL_CAPACITY);
+        let outgoing = Arc::new(OutgoingMessageSender::new(
+            tx,
+            codex_analytics::AnalyticsEventsClient::disabled(),
+        ));
+        let outgoing = ThreadScopedOutgoingMessageSender::new(
+            outgoing,
+            vec![ConnectionId(1)],
+            ThreadId::new(),
+        );
+
+        handle_turn_interrupted(
+            conversation_id,
+            event_turn_id.clone(),
+            turn_aborted_event(&event_turn_id),
+            /*has_active_goal*/ false,
+            &outgoing,
+            &thread_state,
+        )
+        .await;
+
+        let first = recv_broadcast_message(&mut rx).await?;
+        match first {
+            OutgoingMessage::AppServerNotification(ServerNotification::TurnPlanUpdated(n)) => {
+                assert_eq!(
+                    n,
+                    TurnPlanUpdatedNotification {
+                        thread_id: conversation_id.to_string(),
+                        turn_id: event_turn_id,
+                        explanation: None,
+                        plan: vec![TurnPlanStep {
+                            step: "first".to_string(),
+                            status: TurnPlanStepStatus::Pending,
+                        }],
+                    }
+                );
+            }
+            other => bail!("unexpected message: {other:?}"),
+        }
+
+        let second = recv_broadcast_message(&mut rx).await?;
+        match second {
+            OutgoingMessage::AppServerNotification(ServerNotification::TurnCompleted(n)) => {
+                assert_eq!(n.turn.id, "interrupt_with_plan");
+                assert_eq!(n.turn.status, TurnStatus::Interrupted);
+            }
+            other => bail!("unexpected message: {other:?}"),
+        }
+        assert!(rx.try_recv().is_err(), "no extra messages expected");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_handle_turn_complete_preserves_in_progress_plan_with_active_goal() -> Result<()> {
+        let conversation_id = ThreadId::new();
+        let event_turn_id = "complete_active_goal".to_string();
+        let thread_state = new_thread_state();
+        thread_state.lock().await.turn_summary.latest_plan_update = Some(UpdatePlanArgs {
+            explanation: Some("still working".to_string()),
+            plan: vec![PlanItemArg {
+                step: "first".to_string(),
+                status: StepStatus::InProgress,
+            }],
+        });
+        let (tx, mut rx) = mpsc::channel(CHANNEL_CAPACITY);
+        let outgoing = Arc::new(OutgoingMessageSender::new(
+            tx,
+            codex_analytics::AnalyticsEventsClient::disabled(),
+        ));
+        let outgoing = ThreadScopedOutgoingMessageSender::new(
+            outgoing,
+            vec![ConnectionId(1)],
+            ThreadId::new(),
+        );
+
+        handle_turn_complete(
+            conversation_id,
+            event_turn_id.clone(),
+            turn_complete_event(&event_turn_id),
+            /*has_active_goal*/ true,
+            &outgoing,
+            &thread_state,
+        )
+        .await;
+
+        let msg = recv_broadcast_message(&mut rx).await?;
+        match msg {
+            OutgoingMessage::AppServerNotification(ServerNotification::TurnCompleted(n)) => {
+                assert_eq!(n.turn.id, event_turn_id);
+                assert_eq!(n.turn.status, TurnStatus::Completed);
             }
             other => bail!("unexpected message: {other:?}"),
         }
@@ -3633,6 +3942,7 @@ mod tests {
             conversation_a,
             a_turn1.clone(),
             turn_complete_event(&a_turn1),
+            /*has_active_goal*/ false,
             &outgoing,
             &thread_state,
         )
@@ -3654,6 +3964,7 @@ mod tests {
             conversation_b,
             b_turn1.clone(),
             turn_complete_event(&b_turn1),
+            /*has_active_goal*/ false,
             &outgoing,
             &thread_state,
         )
@@ -3665,6 +3976,7 @@ mod tests {
             conversation_a,
             a_turn2.clone(),
             turn_complete_event(&a_turn2),
+            /*has_active_goal*/ false,
             &outgoing,
             &thread_state,
         )

--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -1217,9 +1217,9 @@ pub(crate) async fn apply_bespoke_event_handling(
                 ))
                 .await;
             if thread_goal_event.goal.status != codex_protocol::protocol::ThreadGoalStatus::Active {
-                emit_terminal_plan_cleanup(
+                flush_pending_terminal_plan_cleanup(
                     thread_goal_event.thread_id,
-                    take_pending_terminal_plan_cleanup(&thread_state).await,
+                    &thread_state,
                     &outgoing,
                 )
                 .await;
@@ -1324,11 +1324,12 @@ async fn emit_turn_completed_with_status(
         .await;
 }
 
-pub(crate) async fn emit_terminal_plan_cleanup(
+pub(crate) async fn flush_pending_terminal_plan_cleanup(
     conversation_id: ThreadId,
-    pending_terminal_plan_cleanups: Vec<PendingTerminalPlanCleanup>,
+    thread_state: &Arc<Mutex<ThreadState>>,
     outgoing: &ThreadScopedOutgoingMessageSender,
 ) {
+    let pending_terminal_plan_cleanups = take_pending_terminal_plan_cleanup(thread_state).await;
     for (turn_id, latest_plan_update) in
         terminal_plan_cleanup_updates(pending_terminal_plan_cleanups)
     {
@@ -1368,20 +1369,8 @@ async fn emit_turn_plan_updated(
     plan_update_event: UpdatePlanArgs,
     outgoing: &ThreadScopedOutgoingMessageSender,
 ) {
-    let notification =
-        turn_plan_updated_notification(conversation_id, event_turn_id, plan_update_event);
-    outgoing
-        .send_server_notification(ServerNotification::TurnPlanUpdated(notification))
-        .await;
-}
-
-fn turn_plan_updated_notification(
-    conversation_id: ThreadId,
-    event_turn_id: &str,
-    plan_update_event: UpdatePlanArgs,
-) -> TurnPlanUpdatedNotification {
     // `update_plan` is a todo/checklist tool; it is not related to plan-mode updates.
-    TurnPlanUpdatedNotification {
+    let notification = TurnPlanUpdatedNotification {
         thread_id: conversation_id.to_string(),
         turn_id: event_turn_id.to_string(),
         explanation: plan_update_event.explanation,
@@ -1390,7 +1379,10 @@ fn turn_plan_updated_notification(
             .into_iter()
             .map(TurnPlanStep::from)
             .collect(),
-    }
+    };
+    outgoing
+        .send_server_notification(ServerNotification::TurnPlanUpdated(notification))
+        .await;
 }
 
 async fn terminal_plan_cleanup_may_be_needed(thread_state: &Arc<Mutex<ThreadState>>) -> bool {
@@ -1401,7 +1393,7 @@ async fn terminal_plan_cleanup_may_be_needed(thread_state: &Arc<Mutex<ThreadStat
         .is_empty()
 }
 
-pub(crate) async fn take_pending_terminal_plan_cleanup(
+async fn take_pending_terminal_plan_cleanup(
     thread_state: &Arc<Mutex<ThreadState>>,
 ) -> Vec<PendingTerminalPlanCleanup> {
     std::mem::take(&mut thread_state.lock().await.pending_terminal_plan_cleanups)
@@ -1592,12 +1584,7 @@ async fn handle_turn_complete(
 ) {
     let turn_summary = find_and_remove_turn_summary(thread_state).await;
     if !preserve_terminal_plan_progress {
-        emit_terminal_plan_cleanup(
-            conversation_id,
-            take_pending_terminal_plan_cleanup(thread_state).await,
-            outgoing,
-        )
-        .await;
+        flush_pending_terminal_plan_cleanup(conversation_id, thread_state, outgoing).await;
     }
 
     let (status, error) = match turn_summary.last_error {
@@ -1630,12 +1617,7 @@ async fn handle_turn_interrupted(
 ) {
     let turn_summary = find_and_remove_turn_summary(thread_state).await;
     if !preserve_terminal_plan_progress {
-        emit_terminal_plan_cleanup(
-            conversation_id,
-            take_pending_terminal_plan_cleanup(thread_state).await,
-            outgoing,
-        )
-        .await;
+        flush_pending_terminal_plan_cleanup(conversation_id, thread_state, outgoing).await;
     }
 
     emit_turn_completed_with_status(

--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -5,6 +5,7 @@ use crate::outgoing_message::ThreadScopedOutgoingMessageSender;
 use crate::request_processors::populate_thread_turns_from_history;
 use crate::request_processors::thread_from_stored_thread;
 use crate::server_request_error::is_turn_transition_server_request_error;
+use crate::thread_state::PendingTerminalPlanCleanup;
 use crate::thread_state::ThreadState;
 use crate::thread_state::TurnSummary;
 use crate::thread_state::resolve_server_request_on_thread_listener;
@@ -1215,6 +1216,14 @@ pub(crate) async fn apply_bespoke_event_handling(
                     notification,
                 ))
                 .await;
+            if thread_goal_event.goal.status != codex_protocol::protocol::ThreadGoalStatus::Active {
+                emit_terminal_plan_cleanup(
+                    thread_goal_event.thread_id,
+                    take_pending_terminal_plan_cleanup(&thread_state).await,
+                    &outgoing,
+                )
+                .await;
+            }
         }
         EventMsg::TurnDiff(turn_diff_event) => {
             handle_turn_diff(conversation_id, &event_turn_id, turn_diff_event, &outgoing).await;
@@ -1262,7 +1271,15 @@ async fn handle_turn_plan_update(
     outgoing: &ThreadScopedOutgoingMessageSender,
     thread_state: &Arc<Mutex<ThreadState>>,
 ) {
-    thread_state.lock().await.turn_summary.latest_plan_update = Some(plan_update_event.clone());
+    let pending_terminal_plan_cleanup = plan_update_event
+        .plan
+        .iter()
+        .any(|item| matches!(item.status, StepStatus::InProgress))
+        .then(|| PendingTerminalPlanCleanup {
+            turn_id: event_turn_id.to_string(),
+            plan_update: plan_update_event.clone(),
+        });
+    thread_state.lock().await.pending_terminal_plan_cleanup = pending_terminal_plan_cleanup;
     emit_turn_plan_updated(conversation_id, event_turn_id, plan_update_event, outgoing).await;
 }
 
@@ -1300,16 +1317,14 @@ async fn emit_turn_completed_with_status(
 
 async fn emit_terminal_plan_cleanup(
     conversation_id: ThreadId,
-    event_turn_id: &str,
-    latest_plan_update: Option<UpdatePlanArgs>,
-    preserve_terminal_plan_progress: bool,
+    pending_terminal_plan_cleanup: Option<PendingTerminalPlanCleanup>,
     outgoing: &ThreadScopedOutgoingMessageSender,
 ) {
-    if preserve_terminal_plan_progress {
-        return;
-    }
-
-    let Some(mut latest_plan_update) = latest_plan_update else {
+    let Some(PendingTerminalPlanCleanup {
+        turn_id,
+        plan_update: mut latest_plan_update,
+    }) = pending_terminal_plan_cleanup
+    else {
         return;
     };
     let mut downgraded = false;
@@ -1324,7 +1339,7 @@ async fn emit_terminal_plan_cleanup(
     }
 
     latest_plan_update.explanation = None;
-    emit_turn_plan_updated(conversation_id, event_turn_id, latest_plan_update, outgoing).await;
+    emit_turn_plan_updated(conversation_id, &turn_id, latest_plan_update, outgoing).await;
 }
 
 async fn emit_turn_plan_updated(
@@ -1353,15 +1368,18 @@ async fn terminal_plan_cleanup_may_be_needed(thread_state: &Arc<Mutex<ThreadStat
     thread_state
         .lock()
         .await
-        .turn_summary
-        .latest_plan_update
-        .as_ref()
-        .is_some_and(|update| {
-            update
-                .plan
-                .iter()
-                .any(|item| matches!(item.status, StepStatus::InProgress))
-        })
+        .pending_terminal_plan_cleanup
+        .is_some()
+}
+
+async fn take_pending_terminal_plan_cleanup(
+    thread_state: &Arc<Mutex<ThreadState>>,
+) -> Option<PendingTerminalPlanCleanup> {
+    thread_state
+        .lock()
+        .await
+        .pending_terminal_plan_cleanup
+        .take()
 }
 
 async fn should_preserve_terminal_plan_progress(
@@ -1550,9 +1568,11 @@ async fn handle_turn_complete(
     let turn_summary = find_and_remove_turn_summary(thread_state).await;
     emit_terminal_plan_cleanup(
         conversation_id,
-        &event_turn_id,
-        turn_summary.latest_plan_update,
-        preserve_terminal_plan_progress,
+        if preserve_terminal_plan_progress {
+            None
+        } else {
+            take_pending_terminal_plan_cleanup(thread_state).await
+        },
         outgoing,
     )
     .await;
@@ -1588,9 +1608,11 @@ async fn handle_turn_interrupted(
     let turn_summary = find_and_remove_turn_summary(thread_state).await;
     emit_terminal_plan_cleanup(
         conversation_id,
-        &event_turn_id,
-        turn_summary.latest_plan_update,
-        preserve_terminal_plan_progress,
+        if preserve_terminal_plan_progress {
+            None
+        } else {
+            take_pending_terminal_plan_cleanup(thread_state).await
+        },
         outgoing,
     )
     .await;
@@ -3602,19 +3624,14 @@ mod tests {
             }
             other => bail!("unexpected message: {other:?}"),
         }
-        let cached = thread_state
-            .lock()
-            .await
-            .turn_summary
-            .latest_plan_update
-            .clone()
-            .expect("plan update should be cached");
-        assert_eq!(cached.explanation.as_deref(), Some("need plan"));
-        assert_eq!(cached.plan.len(), 2);
-        assert_eq!(cached.plan[0].step, "first");
-        assert!(matches!(cached.plan[0].status, StepStatus::Pending));
-        assert_eq!(cached.plan[1].step, "second");
-        assert!(matches!(cached.plan[1].status, StepStatus::Completed));
+        assert!(
+            thread_state
+                .lock()
+                .await
+                .pending_terminal_plan_cleanup
+                .is_none(),
+            "plans without in-progress steps do not need terminal cleanup"
+        );
         assert!(rx.try_recv().is_err(), "no extra messages expected");
         Ok(())
     }
@@ -3625,23 +3642,27 @@ mod tests {
         let conversation_id = ThreadId::new();
         let event_turn_id = "complete_with_plan".to_string();
         let thread_state = new_thread_state();
-        thread_state.lock().await.turn_summary.latest_plan_update = Some(UpdatePlanArgs {
-            explanation: Some("still working".to_string()),
-            plan: vec![
-                PlanItemArg {
-                    step: "first".to_string(),
-                    status: StepStatus::InProgress,
+        thread_state.lock().await.pending_terminal_plan_cleanup =
+            Some(PendingTerminalPlanCleanup {
+                turn_id: event_turn_id.clone(),
+                plan_update: UpdatePlanArgs {
+                    explanation: Some("still working".to_string()),
+                    plan: vec![
+                        PlanItemArg {
+                            step: "first".to_string(),
+                            status: StepStatus::InProgress,
+                        },
+                        PlanItemArg {
+                            step: "second".to_string(),
+                            status: StepStatus::Completed,
+                        },
+                        PlanItemArg {
+                            step: "third".to_string(),
+                            status: StepStatus::InProgress,
+                        },
+                    ],
                 },
-                PlanItemArg {
-                    step: "second".to_string(),
-                    status: StepStatus::Completed,
-                },
-                PlanItemArg {
-                    step: "third".to_string(),
-                    status: StepStatus::InProgress,
-                },
-            ],
-        });
+            });
         let (tx, mut rx) = mpsc::channel(CHANNEL_CAPACITY);
         let outgoing = Arc::new(OutgoingMessageSender::new(
             tx,
@@ -3710,13 +3731,17 @@ mod tests {
         let conversation_id = ThreadId::new();
         let event_turn_id = "interrupt_with_plan".to_string();
         let thread_state = new_thread_state();
-        thread_state.lock().await.turn_summary.latest_plan_update = Some(UpdatePlanArgs {
-            explanation: Some("still working".to_string()),
-            plan: vec![PlanItemArg {
-                step: "first".to_string(),
-                status: StepStatus::InProgress,
-            }],
-        });
+        thread_state.lock().await.pending_terminal_plan_cleanup =
+            Some(PendingTerminalPlanCleanup {
+                turn_id: event_turn_id.clone(),
+                plan_update: UpdatePlanArgs {
+                    explanation: Some("still working".to_string()),
+                    plan: vec![PlanItemArg {
+                        step: "first".to_string(),
+                        status: StepStatus::InProgress,
+                    }],
+                },
+            });
         let (tx, mut rx) = mpsc::channel(CHANNEL_CAPACITY);
         let outgoing = Arc::new(OutgoingMessageSender::new(
             tx,
@@ -3774,13 +3799,17 @@ mod tests {
         let conversation_id = ThreadId::new();
         let event_turn_id = "complete_active_goal".to_string();
         let thread_state = new_thread_state();
-        thread_state.lock().await.turn_summary.latest_plan_update = Some(UpdatePlanArgs {
-            explanation: Some("still working".to_string()),
-            plan: vec![PlanItemArg {
-                step: "first".to_string(),
-                status: StepStatus::InProgress,
-            }],
-        });
+        thread_state.lock().await.pending_terminal_plan_cleanup =
+            Some(PendingTerminalPlanCleanup {
+                turn_id: event_turn_id.clone(),
+                plan_update: UpdatePlanArgs {
+                    explanation: Some("still working".to_string()),
+                    plan: vec![PlanItemArg {
+                        step: "first".to_string(),
+                        status: StepStatus::InProgress,
+                    }],
+                },
+            });
         let (tx, mut rx) = mpsc::channel(CHANNEL_CAPACITY);
         let outgoing = Arc::new(OutgoingMessageSender::new(
             tx,
@@ -3810,6 +3839,122 @@ mod tests {
             }
             other => bail!("unexpected message: {other:?}"),
         }
+        assert!(
+            thread_state
+                .lock()
+                .await
+                .pending_terminal_plan_cleanup
+                .is_some(),
+            "active goals retain pending cleanup until the goal settles"
+        );
+        assert!(rx.try_recv().is_err(), "no extra messages expected");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn terminal_thread_goal_update_cleans_preserved_plan_progress() -> Result<()> {
+        let codex_home = TempDir::new()?;
+        let config = load_default_config_for_test(&codex_home).await;
+        let thread_manager = Arc::new(
+            codex_core::test_support::thread_manager_with_models_provider_and_home(
+                CodexAuth::create_dummy_chatgpt_auth_for_testing(),
+                config.model_provider.clone(),
+                config.codex_home.to_path_buf(),
+                Arc::new(codex_exec_server::EnvironmentManager::default_for_tests()),
+            ),
+        );
+        let codex_core::NewThread {
+            thread_id: conversation_id,
+            thread: conversation,
+            ..
+        } = thread_manager.start_thread(config).await?;
+        let turn_id = "preserved-plan-turn".to_string();
+        let thread_state = new_thread_state();
+        thread_state.lock().await.pending_terminal_plan_cleanup =
+            Some(PendingTerminalPlanCleanup {
+                turn_id: turn_id.clone(),
+                plan_update: UpdatePlanArgs {
+                    explanation: Some("still working".to_string()),
+                    plan: vec![PlanItemArg {
+                        step: "first".to_string(),
+                        status: StepStatus::InProgress,
+                    }],
+                },
+            });
+        let (tx, mut rx) = mpsc::channel(CHANNEL_CAPACITY);
+        let outgoing = Arc::new(OutgoingMessageSender::new(
+            tx,
+            codex_analytics::AnalyticsEventsClient::disabled(),
+        ));
+        let outgoing = ThreadScopedOutgoingMessageSender::new(
+            outgoing,
+            vec![ConnectionId(1)],
+            conversation_id,
+        );
+
+        apply_bespoke_event_handling(
+            Event {
+                id: turn_id.clone(),
+                msg: EventMsg::ThreadGoalUpdated(
+                    codex_protocol::protocol::ThreadGoalUpdatedEvent {
+                        thread_id: conversation_id,
+                        turn_id: Some(turn_id.clone()),
+                        goal: codex_protocol::protocol::ThreadGoal {
+                            thread_id: conversation_id,
+                            objective: "finish the work".to_string(),
+                            status: codex_protocol::protocol::ThreadGoalStatus::Complete,
+                            token_budget: None,
+                            tokens_used: 1,
+                            time_used_seconds: 1,
+                            created_at: 1,
+                            updated_at: 2,
+                        },
+                    },
+                ),
+            },
+            conversation_id,
+            conversation,
+            thread_manager,
+            outgoing,
+            thread_state.clone(),
+            ThreadWatchManager::new(),
+            Arc::new(tokio::sync::Semaphore::new(/*permits*/ 1)),
+            "test-provider".to_string(),
+        )
+        .await;
+
+        let first = recv_broadcast_message(&mut rx).await?;
+        assert!(matches!(
+            first,
+            OutgoingMessage::AppServerNotification(ServerNotification::ThreadGoalUpdated(_))
+        ));
+
+        let second = recv_broadcast_message(&mut rx).await?;
+        match second {
+            OutgoingMessage::AppServerNotification(ServerNotification::TurnPlanUpdated(n)) => {
+                assert_eq!(
+                    n,
+                    TurnPlanUpdatedNotification {
+                        thread_id: conversation_id.to_string(),
+                        turn_id,
+                        explanation: None,
+                        plan: vec![TurnPlanStep {
+                            step: "first".to_string(),
+                            status: TurnPlanStepStatus::Pending,
+                        }],
+                    }
+                );
+            }
+            other => bail!("unexpected message: {other:?}"),
+        }
+        assert!(
+            thread_state
+                .lock()
+                .await
+                .pending_terminal_plan_cleanup
+                .is_none(),
+            "terminal goal updates consume preserved cleanup state"
+        );
         assert!(rx.try_recv().is_err(), "no extra messages expected");
         Ok(())
     }

--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -100,7 +100,6 @@ use codex_protocol::protocol::RealtimeEvent;
 use codex_protocol::protocol::ReviewDecision;
 use codex_protocol::protocol::ReviewOutputEvent;
 use codex_protocol::protocol::TokenCountEvent;
-use codex_protocol::protocol::TurnAbortReason;
 use codex_protocol::protocol::TurnAbortedEvent;
 use codex_protocol::protocol::TurnCompleteEvent;
 use codex_protocol::protocol::TurnDiffEvent;
@@ -1124,11 +1123,7 @@ pub(crate) async fn apply_bespoke_event_handling(
             outgoing.abort_pending_server_requests().await;
             respond_to_pending_interrupts(&thread_state, &outgoing).await;
 
-            let preserve_terminal_plan_progress = turn_aborted_event.reason
-                != TurnAbortReason::Interrupted
-                && terminal_plan_cleanup_may_be_needed(&thread_state).await
-                && should_preserve_terminal_plan_progress(conversation.as_ref(), conversation_id)
-                    .await;
+            let preserve_terminal_plan_progress = false;
             thread_watch_manager
                 .note_turn_interrupted(&conversation_id.to_string())
                 .await;
@@ -1145,6 +1140,7 @@ pub(crate) async fn apply_bespoke_event_handling(
         EventMsg::ThreadRolledBack(_rollback_event) => {
             let pending = {
                 let mut state = thread_state.lock().await;
+                state.pending_terminal_plan_cleanups.clear();
                 state.pending_rollbacks.take()
             };
 
@@ -1329,7 +1325,16 @@ pub(crate) async fn flush_pending_terminal_plan_cleanup(
     thread_state: &Arc<Mutex<ThreadState>>,
     outgoing: &ThreadScopedOutgoingMessageSender,
 ) {
-    let pending_terminal_plan_cleanups = take_pending_terminal_plan_cleanup(thread_state).await;
+    let pending_terminal_plan_cleanups =
+        take_flushable_pending_terminal_plan_cleanup(thread_state).await;
+    emit_terminal_plan_cleanup(conversation_id, pending_terminal_plan_cleanups, outgoing).await;
+}
+
+async fn emit_terminal_plan_cleanup(
+    conversation_id: ThreadId,
+    pending_terminal_plan_cleanups: Vec<PendingTerminalPlanCleanup>,
+    outgoing: &ThreadScopedOutgoingMessageSender,
+) {
     for (turn_id, latest_plan_update) in
         terminal_plan_cleanup_updates(pending_terminal_plan_cleanups)
     {
@@ -1393,10 +1398,20 @@ async fn terminal_plan_cleanup_may_be_needed(thread_state: &Arc<Mutex<ThreadStat
         .is_empty()
 }
 
-async fn take_pending_terminal_plan_cleanup(
+async fn take_flushable_pending_terminal_plan_cleanup(
     thread_state: &Arc<Mutex<ThreadState>>,
 ) -> Vec<PendingTerminalPlanCleanup> {
-    std::mem::take(&mut thread_state.lock().await.pending_terminal_plan_cleanups)
+    let mut state = thread_state.lock().await;
+    let Some(active_turn_id) = state.active_turn_snapshot().map(|turn| turn.id) else {
+        return std::mem::take(&mut state.pending_terminal_plan_cleanups);
+    };
+
+    let pending_terminal_plan_cleanups = std::mem::take(&mut state.pending_terminal_plan_cleanups);
+    let (retained, flushable) = pending_terminal_plan_cleanups
+        .into_iter()
+        .partition(|cleanup| cleanup.turn_id == active_turn_id);
+    state.pending_terminal_plan_cleanups = retained;
+    flushable
 }
 
 async fn should_preserve_terminal_plan_progress(
@@ -1418,7 +1433,7 @@ async fn should_preserve_terminal_plan_progress(
                 thread_id = %conversation_id,
                 "failed to read thread goal before terminal plan cleanup: {err}"
             );
-            true
+            false
         }
     }
 }
@@ -3798,6 +3813,83 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn replaced_turn_downgrades_in_progress_plan() -> Result<()> {
+        let codex_home = TempDir::new()?;
+        let config = load_default_config_for_test(&codex_home).await;
+        let thread_manager = Arc::new(
+            codex_core::test_support::thread_manager_with_models_provider_and_home(
+                CodexAuth::create_dummy_chatgpt_auth_for_testing(),
+                config.model_provider.clone(),
+                config.codex_home.to_path_buf(),
+                Arc::new(codex_exec_server::EnvironmentManager::default_for_tests()),
+            ),
+        );
+        let codex_core::NewThread {
+            thread_id: conversation_id,
+            thread: conversation,
+            ..
+        } = thread_manager.start_thread(config).await?;
+        let turn_id = "replaced-plan-turn".to_string();
+        let thread_state = new_thread_state();
+        thread_state.lock().await.pending_terminal_plan_cleanups =
+            vec![PendingTerminalPlanCleanup {
+                turn_id: turn_id.clone(),
+                plan_update: UpdatePlanArgs {
+                    explanation: Some("still working".to_string()),
+                    plan: vec![PlanItemArg {
+                        step: "first".to_string(),
+                        status: StepStatus::InProgress,
+                    }],
+                },
+            }];
+        let (tx, mut rx) = mpsc::channel(CHANNEL_CAPACITY);
+        let outgoing = Arc::new(OutgoingMessageSender::new(
+            tx,
+            codex_analytics::AnalyticsEventsClient::disabled(),
+        ));
+        let outgoing = ThreadScopedOutgoingMessageSender::new(
+            outgoing,
+            vec![ConnectionId(1)],
+            conversation_id,
+        );
+
+        apply_bespoke_event_handling(
+            Event {
+                id: turn_id.clone(),
+                msg: EventMsg::TurnAborted(TurnAbortedEvent {
+                    turn_id: Some(turn_id.clone()),
+                    reason: codex_protocol::protocol::TurnAbortReason::Replaced,
+                    completed_at: Some(TEST_TURN_COMPLETED_AT),
+                    duration_ms: Some(TEST_TURN_DURATION_MS),
+                }),
+            },
+            conversation_id,
+            conversation,
+            thread_manager,
+            outgoing,
+            thread_state,
+            ThreadWatchManager::new(),
+            Arc::new(tokio::sync::Semaphore::new(/*permits*/ 1)),
+            "test-provider".to_string(),
+        )
+        .await;
+
+        let first = recv_broadcast_message(&mut rx).await?;
+        assert!(matches!(
+            first,
+            OutgoingMessage::AppServerNotification(ServerNotification::TurnPlanUpdated(_))
+        ));
+
+        let second = recv_broadcast_message(&mut rx).await?;
+        assert!(matches!(
+            second,
+            OutgoingMessage::AppServerNotification(ServerNotification::TurnCompleted(_))
+        ));
+        assert!(rx.try_recv().is_err(), "no extra messages expected");
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_handle_turn_complete_preserves_in_progress_plan_with_active_goal() -> Result<()> {
         let conversation_id = ThreadId::new();
         let event_turn_id = "complete_active_goal".to_string();
@@ -3958,6 +4050,177 @@ mod tests {
                 .pending_terminal_plan_cleanups
                 .is_empty(),
             "terminal goal updates consume preserved cleanup state"
+        );
+        assert!(rx.try_recv().is_err(), "no extra messages expected");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn terminal_thread_goal_update_retains_active_turn_cleanup() -> Result<()> {
+        let codex_home = TempDir::new()?;
+        let config = load_default_config_for_test(&codex_home).await;
+        let thread_manager = Arc::new(
+            codex_core::test_support::thread_manager_with_models_provider_and_home(
+                CodexAuth::create_dummy_chatgpt_auth_for_testing(),
+                config.model_provider.clone(),
+                config.codex_home.to_path_buf(),
+                Arc::new(codex_exec_server::EnvironmentManager::default_for_tests()),
+            ),
+        );
+        let codex_core::NewThread {
+            thread_id: conversation_id,
+            thread: conversation,
+            ..
+        } = thread_manager.start_thread(config).await?;
+        let turn_id = "active-plan-turn".to_string();
+        let thread_state = new_thread_state();
+        {
+            let mut state = thread_state.lock().await;
+            state.track_current_turn_event(
+                &turn_id,
+                &EventMsg::TurnStarted(codex_protocol::protocol::TurnStartedEvent {
+                    turn_id: turn_id.clone(),
+                    started_at: Some(42),
+                    model_context_window: None,
+                    collaboration_mode_kind: Default::default(),
+                }),
+            );
+            state.pending_terminal_plan_cleanups = vec![PendingTerminalPlanCleanup {
+                turn_id: turn_id.clone(),
+                plan_update: UpdatePlanArgs {
+                    explanation: Some("still working".to_string()),
+                    plan: vec![PlanItemArg {
+                        step: "first".to_string(),
+                        status: StepStatus::InProgress,
+                    }],
+                },
+            }];
+        }
+        let (tx, mut rx) = mpsc::channel(CHANNEL_CAPACITY);
+        let outgoing = Arc::new(OutgoingMessageSender::new(
+            tx,
+            codex_analytics::AnalyticsEventsClient::disabled(),
+        ));
+        let outgoing = ThreadScopedOutgoingMessageSender::new(
+            outgoing,
+            vec![ConnectionId(1)],
+            conversation_id,
+        );
+
+        apply_bespoke_event_handling(
+            Event {
+                id: turn_id.clone(),
+                msg: EventMsg::ThreadGoalUpdated(
+                    codex_protocol::protocol::ThreadGoalUpdatedEvent {
+                        thread_id: conversation_id,
+                        turn_id: Some(turn_id.clone()),
+                        goal: codex_protocol::protocol::ThreadGoal {
+                            thread_id: conversation_id,
+                            objective: "finish the work".to_string(),
+                            status: codex_protocol::protocol::ThreadGoalStatus::Complete,
+                            token_budget: None,
+                            tokens_used: 1,
+                            time_used_seconds: 1,
+                            created_at: 1,
+                            updated_at: 2,
+                        },
+                    },
+                ),
+            },
+            conversation_id,
+            conversation,
+            thread_manager,
+            outgoing,
+            thread_state.clone(),
+            ThreadWatchManager::new(),
+            Arc::new(tokio::sync::Semaphore::new(/*permits*/ 1)),
+            "test-provider".to_string(),
+        )
+        .await;
+
+        let first = recv_broadcast_message(&mut rx).await?;
+        assert!(matches!(
+            first,
+            OutgoingMessage::AppServerNotification(ServerNotification::ThreadGoalUpdated(_))
+        ));
+        assert!(
+            thread_state
+                .lock()
+                .await
+                .pending_terminal_plan_cleanups
+                .len()
+                == 1,
+            "active turn cleanup stays deferred until the turn actually settles"
+        );
+        assert!(rx.try_recv().is_err(), "no cleanup should be emitted");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn rollback_discards_preserved_plan_cleanup() -> Result<()> {
+        let codex_home = TempDir::new()?;
+        let config = load_default_config_for_test(&codex_home).await;
+        let thread_manager = Arc::new(
+            codex_core::test_support::thread_manager_with_models_provider_and_home(
+                CodexAuth::create_dummy_chatgpt_auth_for_testing(),
+                config.model_provider.clone(),
+                config.codex_home.to_path_buf(),
+                Arc::new(codex_exec_server::EnvironmentManager::default_for_tests()),
+            ),
+        );
+        let codex_core::NewThread {
+            thread_id: conversation_id,
+            thread: conversation,
+            ..
+        } = thread_manager.start_thread(config).await?;
+        let thread_state = new_thread_state();
+        thread_state.lock().await.pending_terminal_plan_cleanups =
+            vec![PendingTerminalPlanCleanup {
+                turn_id: "rolled-back-turn".to_string(),
+                plan_update: UpdatePlanArgs {
+                    explanation: Some("still working".to_string()),
+                    plan: vec![PlanItemArg {
+                        step: "first".to_string(),
+                        status: StepStatus::InProgress,
+                    }],
+                },
+            }];
+        let (tx, mut rx) = mpsc::channel(CHANNEL_CAPACITY);
+        let outgoing = Arc::new(OutgoingMessageSender::new(
+            tx,
+            codex_analytics::AnalyticsEventsClient::disabled(),
+        ));
+        let outgoing = ThreadScopedOutgoingMessageSender::new(
+            outgoing,
+            vec![ConnectionId(1)],
+            conversation_id,
+        );
+
+        apply_bespoke_event_handling(
+            Event {
+                id: "rollback-turn".to_string(),
+                msg: EventMsg::ThreadRolledBack(codex_protocol::protocol::ThreadRolledBackEvent {
+                    num_turns: 1,
+                }),
+            },
+            conversation_id,
+            conversation,
+            thread_manager,
+            outgoing,
+            thread_state.clone(),
+            ThreadWatchManager::new(),
+            Arc::new(tokio::sync::Semaphore::new(/*permits*/ 1)),
+            "test-provider".to_string(),
+        )
+        .await;
+
+        assert!(
+            thread_state
+                .lock()
+                .await
+                .pending_terminal_plan_cleanups
+                .is_empty(),
+            "rollback drops cleanup for history it has rewritten"
         );
         assert!(rx.try_recv().is_err(), "no extra messages expected");
         Ok(())

--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -1123,7 +1123,6 @@ pub(crate) async fn apply_bespoke_event_handling(
             outgoing.abort_pending_server_requests().await;
             respond_to_pending_interrupts(&thread_state, &outgoing).await;
 
-            let preserve_terminal_plan_progress = false;
             thread_watch_manager
                 .note_turn_interrupted(&conversation_id.to_string())
                 .await;
@@ -1131,7 +1130,6 @@ pub(crate) async fn apply_bespoke_event_handling(
                 conversation_id,
                 event_turn_id,
                 turn_aborted_event,
-                preserve_terminal_plan_progress,
                 &outgoing,
                 &thread_state,
             )
@@ -1327,14 +1325,6 @@ pub(crate) async fn flush_pending_terminal_plan_cleanup(
 ) {
     let pending_terminal_plan_cleanups =
         take_flushable_pending_terminal_plan_cleanup(thread_state).await;
-    emit_terminal_plan_cleanup(conversation_id, pending_terminal_plan_cleanups, outgoing).await;
-}
-
-async fn emit_terminal_plan_cleanup(
-    conversation_id: ThreadId,
-    pending_terminal_plan_cleanups: Vec<PendingTerminalPlanCleanup>,
-    outgoing: &ThreadScopedOutgoingMessageSender,
-) {
     for (turn_id, latest_plan_update) in
         terminal_plan_cleanup_updates(pending_terminal_plan_cleanups)
     {
@@ -1626,14 +1616,11 @@ async fn handle_turn_interrupted(
     conversation_id: ThreadId,
     event_turn_id: String,
     turn_aborted_event: TurnAbortedEvent,
-    preserve_terminal_plan_progress: bool,
     outgoing: &ThreadScopedOutgoingMessageSender,
     thread_state: &Arc<Mutex<ThreadState>>,
 ) {
     let turn_summary = find_and_remove_turn_summary(thread_state).await;
-    if !preserve_terminal_plan_progress {
-        flush_pending_terminal_plan_cleanup(conversation_id, thread_state, outgoing).await;
-    }
+    flush_pending_terminal_plan_cleanup(conversation_id, thread_state, outgoing).await;
 
     emit_turn_completed_with_status(
         conversation_id,
@@ -3501,7 +3488,6 @@ mod tests {
             conversation_id,
             event_turn_id.clone(),
             turn_aborted_event(&event_turn_id),
-            /*preserve_terminal_plan_progress*/ false,
             &outgoing,
             &thread_state,
         )
@@ -3775,7 +3761,6 @@ mod tests {
             conversation_id,
             event_turn_id.clone(),
             turn_aborted_event(&event_turn_id),
-            /*preserve_terminal_plan_progress*/ false,
             &outgoing,
             &thread_state,
         )

--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -1139,7 +1139,7 @@ pub(crate) async fn apply_bespoke_event_handling(
         EventMsg::ThreadRolledBack(_rollback_event) => {
             let pending = {
                 let mut state = thread_state.lock().await;
-                state.pending_terminal_plan_cleanups.clear();
+                state.prune_pending_terminal_plan_cleanups_after_rollback();
                 state.pending_rollbacks.take()
             };
 
@@ -1327,6 +1327,20 @@ pub(crate) async fn flush_pending_terminal_plan_cleanup(
 ) {
     let pending_terminal_plan_cleanups =
         take_flushable_pending_terminal_plan_cleanup(thread_state).await;
+    for (turn_id, latest_plan_update) in
+        terminal_plan_cleanup_updates(pending_terminal_plan_cleanups)
+    {
+        emit_turn_plan_updated(conversation_id, &turn_id, latest_plan_update, outgoing).await;
+    }
+}
+
+async fn flush_all_pending_terminal_plan_cleanup(
+    conversation_id: ThreadId,
+    thread_state: &Arc<Mutex<ThreadState>>,
+    outgoing: &ThreadScopedOutgoingMessageSender,
+) {
+    let pending_terminal_plan_cleanups =
+        std::mem::take(&mut thread_state.lock().await.pending_terminal_plan_cleanups);
     for (turn_id, latest_plan_update) in
         terminal_plan_cleanup_updates(pending_terminal_plan_cleanups)
     {
@@ -1614,7 +1628,7 @@ async fn handle_turn_interrupted(
     thread_state: &Arc<Mutex<ThreadState>>,
 ) {
     let turn_summary = find_and_remove_turn_summary(thread_state).await;
-    flush_pending_terminal_plan_cleanup(conversation_id, thread_state, outgoing).await;
+    flush_all_pending_terminal_plan_cleanup(conversation_id, thread_state, outgoing).await;
 
     emit_turn_completed_with_status(
         conversation_id,
@@ -3951,6 +3965,93 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn tracked_replaced_turn_downgrades_in_progress_plan() -> Result<()> {
+        let codex_home = TempDir::new()?;
+        let config = load_default_config_for_test(&codex_home).await;
+        let thread_manager = Arc::new(
+            codex_core::test_support::thread_manager_with_models_provider_and_home(
+                CodexAuth::create_dummy_chatgpt_auth_for_testing(),
+                config.model_provider.clone(),
+                config.codex_home.to_path_buf(),
+                Arc::new(codex_exec_server::EnvironmentManager::default_for_tests()),
+            ),
+        );
+        let codex_core::NewThread {
+            thread_id: conversation_id,
+            thread: conversation,
+            ..
+        } = thread_manager.start_thread(config).await?;
+        let turn_id = "tracked-replaced-plan-turn".to_string();
+        let aborted = TurnAbortedEvent {
+            turn_id: Some(turn_id.clone()),
+            reason: codex_protocol::protocol::TurnAbortReason::Replaced,
+            completed_at: Some(TEST_TURN_COMPLETED_AT),
+            duration_ms: Some(TEST_TURN_DURATION_MS),
+        };
+        let thread_state = new_thread_state();
+        {
+            let mut state = thread_state.lock().await;
+            state.track_current_turn_event(
+                &turn_id,
+                &EventMsg::TurnStarted(codex_protocol::protocol::TurnStartedEvent {
+                    turn_id: turn_id.clone(),
+                    started_at: Some(42),
+                    model_context_window: None,
+                    collaboration_mode_kind: Default::default(),
+                }),
+            );
+            state.track_current_turn_event(&turn_id, &EventMsg::TurnAborted(aborted.clone()));
+            state.pending_terminal_plan_cleanups = vec![PendingTerminalPlanCleanup {
+                turn_id: turn_id.clone(),
+                plan_update: UpdatePlanArgs {
+                    explanation: Some("still working".to_string()),
+                    plan: vec![PlanItemArg {
+                        step: "first".to_string(),
+                        status: StepStatus::InProgress,
+                    }],
+                },
+            }];
+        }
+        let (tx, mut rx) = mpsc::channel(CHANNEL_CAPACITY);
+        let outgoing = Arc::new(OutgoingMessageSender::new(
+            tx,
+            codex_analytics::AnalyticsEventsClient::disabled(),
+        ));
+        let outgoing = ThreadScopedOutgoingMessageSender::new(
+            outgoing,
+            vec![ConnectionId(1)],
+            conversation_id,
+        );
+
+        apply_bespoke_event_handling(
+            Event {
+                id: turn_id,
+                msg: EventMsg::TurnAborted(aborted),
+            },
+            conversation_id,
+            conversation,
+            thread_manager,
+            outgoing,
+            thread_state,
+            ThreadWatchManager::new(),
+            Arc::new(tokio::sync::Semaphore::new(/*permits*/ 1)),
+            "test-provider".to_string(),
+        )
+        .await;
+
+        assert!(matches!(
+            recv_broadcast_message(&mut rx).await?,
+            OutgoingMessage::AppServerNotification(ServerNotification::TurnPlanUpdated(_))
+        ));
+        assert!(matches!(
+            recv_broadcast_message(&mut rx).await?,
+            OutgoingMessage::AppServerNotification(ServerNotification::TurnCompleted(_))
+        ));
+        assert!(rx.try_recv().is_err(), "no extra messages expected");
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_handle_turn_complete_preserves_in_progress_plan_with_active_goal() -> Result<()> {
         let conversation_id = ThreadId::new();
         let event_turn_id = "complete_active_goal".to_string();
@@ -4283,6 +4384,104 @@ mod tests {
                 .is_empty(),
             "rollback drops cleanup for history it has rewritten"
         );
+        assert!(rx.try_recv().is_err(), "no extra messages expected");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn rollback_preserves_cleanup_for_turns_that_survive() -> Result<()> {
+        let codex_home = TempDir::new()?;
+        let config = load_default_config_for_test(&codex_home).await;
+        let thread_manager = Arc::new(
+            codex_core::test_support::thread_manager_with_models_provider_and_home(
+                CodexAuth::create_dummy_chatgpt_auth_for_testing(),
+                config.model_provider.clone(),
+                config.codex_home.to_path_buf(),
+                Arc::new(codex_exec_server::EnvironmentManager::default_for_tests()),
+            ),
+        );
+        let codex_core::NewThread {
+            thread_id: conversation_id,
+            thread: conversation,
+            ..
+        } = thread_manager.start_thread(config).await?;
+        let rollback_event = codex_protocol::protocol::ThreadRolledBackEvent { num_turns: 1 };
+        let thread_state = new_thread_state();
+        {
+            let mut state = thread_state.lock().await;
+            for turn_id in ["older-turn", "rolled-back-turn"] {
+                state.track_current_turn_event(
+                    turn_id,
+                    &EventMsg::TurnStarted(codex_protocol::protocol::TurnStartedEvent {
+                        turn_id: turn_id.to_string(),
+                        started_at: Some(42),
+                        model_context_window: None,
+                        collaboration_mode_kind: Default::default(),
+                    }),
+                );
+                state.track_current_turn_event(
+                    turn_id,
+                    &EventMsg::TurnComplete(turn_complete_event(turn_id)),
+                );
+            }
+            state.track_current_turn_event(
+                "rollback-turn",
+                &EventMsg::ThreadRolledBack(rollback_event.clone()),
+            );
+            state.pending_terminal_plan_cleanups = vec![
+                PendingTerminalPlanCleanup {
+                    turn_id: "older-turn".to_string(),
+                    plan_update: UpdatePlanArgs {
+                        explanation: Some("still working".to_string()),
+                        plan: vec![PlanItemArg {
+                            step: "older".to_string(),
+                            status: StepStatus::InProgress,
+                        }],
+                    },
+                },
+                PendingTerminalPlanCleanup {
+                    turn_id: "rolled-back-turn".to_string(),
+                    plan_update: UpdatePlanArgs {
+                        explanation: Some("still working".to_string()),
+                        plan: vec![PlanItemArg {
+                            step: "newer".to_string(),
+                            status: StepStatus::InProgress,
+                        }],
+                    },
+                },
+            ];
+        }
+        let (tx, mut rx) = mpsc::channel(CHANNEL_CAPACITY);
+        let outgoing = Arc::new(OutgoingMessageSender::new(
+            tx,
+            codex_analytics::AnalyticsEventsClient::disabled(),
+        ));
+        let outgoing = ThreadScopedOutgoingMessageSender::new(
+            outgoing,
+            vec![ConnectionId(1)],
+            conversation_id,
+        );
+
+        apply_bespoke_event_handling(
+            Event {
+                id: "rollback-turn".to_string(),
+                msg: EventMsg::ThreadRolledBack(rollback_event),
+            },
+            conversation_id,
+            conversation,
+            thread_manager,
+            outgoing,
+            thread_state.clone(),
+            ThreadWatchManager::new(),
+            Arc::new(tokio::sync::Semaphore::new(/*permits*/ 1)),
+            "test-provider".to_string(),
+        )
+        .await;
+
+        let pending_terminal_plan_cleanups =
+            &thread_state.lock().await.pending_terminal_plan_cleanups;
+        assert_eq!(pending_terminal_plan_cleanups.len(), 1);
+        assert_eq!(pending_terminal_plan_cleanups[0].turn_id, "older-turn");
         assert!(rx.try_recv().is_err(), "no extra messages expected");
         Ok(())
     }

--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -183,14 +183,12 @@ pub(crate) async fn apply_bespoke_event_handling(
             outgoing.abort_pending_server_requests().await;
             respond_to_pending_interrupts(&thread_state, &outgoing).await;
             let turn_failed = thread_state.lock().await.turn_summary.last_error.is_some();
-            let has_pending_terminal_plan_cleanup = !thread_state
-                .lock()
-                .await
-                .pending_terminal_plan_cleanups
-                .is_empty();
-            let preserve_terminal_plan_progress = has_pending_terminal_plan_cleanup
-                && should_preserve_terminal_plan_progress(conversation.as_ref(), conversation_id)
-                    .await;
+            let preserve_terminal_plan_progress = should_preserve_terminal_plan_progress(
+                conversation.as_ref(),
+                conversation_id,
+                &thread_state,
+            )
+            .await;
             thread_watch_manager
                 .note_turn_completed(&conversation_id.to_string(), turn_failed)
                 .await;
@@ -1123,14 +1121,12 @@ pub(crate) async fn apply_bespoke_event_handling(
             // All per-thread requests are bound to a turn, so abort them.
             outgoing.abort_pending_server_requests().await;
             respond_to_pending_interrupts(&thread_state, &outgoing).await;
-            let has_pending_terminal_plan_cleanup = !thread_state
-                .lock()
-                .await
-                .pending_terminal_plan_cleanups
-                .is_empty();
-            let preserve_terminal_plan_progress = has_pending_terminal_plan_cleanup
-                && should_preserve_terminal_plan_progress(conversation.as_ref(), conversation_id)
-                    .await;
+            let preserve_terminal_plan_progress = should_preserve_terminal_plan_progress(
+                conversation.as_ref(),
+                conversation_id,
+                &thread_state,
+            )
+            .await;
 
             thread_watch_manager
                 .note_turn_interrupted(&conversation_id.to_string())
@@ -1366,37 +1362,23 @@ async fn emit_terminal_plan_cleanup_updates(
     pending_terminal_plan_cleanups: Vec<PendingTerminalPlanCleanup>,
     outgoing: &ThreadScopedOutgoingMessageSender,
 ) {
-    for (turn_id, latest_plan_update) in
-        terminal_plan_cleanup_updates(pending_terminal_plan_cleanups)
+    for PendingTerminalPlanCleanup {
+        turn_id,
+        plan_update: mut latest_plan_update,
+    } in pending_terminal_plan_cleanups
     {
-        emit_turn_plan_updated(conversation_id, &turn_id, latest_plan_update, outgoing).await;
+        let mut downgraded = false;
+        for item in &mut latest_plan_update.plan {
+            if matches!(item.status, StepStatus::InProgress) {
+                item.status = StepStatus::Pending;
+                downgraded = true;
+            }
+        }
+        if downgraded {
+            latest_plan_update.explanation = None;
+            emit_turn_plan_updated(conversation_id, &turn_id, latest_plan_update, outgoing).await;
+        }
     }
-}
-
-fn terminal_plan_cleanup_updates(
-    pending_terminal_plan_cleanups: Vec<PendingTerminalPlanCleanup>,
-) -> Vec<(String, UpdatePlanArgs)> {
-    pending_terminal_plan_cleanups
-        .into_iter()
-        .filter_map(
-            |PendingTerminalPlanCleanup {
-                 turn_id,
-                 plan_update: mut latest_plan_update,
-             }| {
-                let mut downgraded = false;
-                for item in &mut latest_plan_update.plan {
-                    if matches!(item.status, StepStatus::InProgress) {
-                        item.status = StepStatus::Pending;
-                        downgraded = true;
-                    }
-                }
-                downgraded.then(|| {
-                    latest_plan_update.explanation = None;
-                    (turn_id, latest_plan_update)
-                })
-            },
-        )
-        .collect()
 }
 
 fn retain_pending_terminal_plan_cleanups_for_turns(
@@ -1448,7 +1430,17 @@ async fn take_flushable_pending_terminal_plan_cleanup(
 async fn should_preserve_terminal_plan_progress(
     conversation: &CodexThread,
     conversation_id: ThreadId,
+    thread_state: &Arc<Mutex<ThreadState>>,
 ) -> bool {
+    if thread_state
+        .lock()
+        .await
+        .pending_terminal_plan_cleanups
+        .is_empty()
+    {
+        return false;
+    }
+
     let Some(state_db) = conversation.state_db() else {
         return false;
     };

--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -1283,6 +1283,7 @@ async fn handle_turn_plan_update(
                 });
         }
     }
+    flush_pending_terminal_plan_cleanup(conversation_id, thread_state, outgoing).await;
     emit_turn_plan_updated(conversation_id, event_turn_id, plan_update_event, outgoing).await;
 }
 
@@ -3635,6 +3636,88 @@ mod tests {
                 .pending_terminal_plan_cleanups
                 .is_empty(),
             "plans without in-progress steps do not need terminal cleanup"
+        );
+        assert!(rx.try_recv().is_err(), "no extra messages expected");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn new_live_plan_flushes_older_deferred_cleanup() -> Result<()> {
+        let conversation_id = ThreadId::new();
+        let active_turn_id = "active-plan-turn".to_string();
+        let thread_state = new_thread_state();
+        {
+            let mut state = thread_state.lock().await;
+            state.track_current_turn_event(
+                &active_turn_id,
+                &EventMsg::TurnStarted(codex_protocol::protocol::TurnStartedEvent {
+                    turn_id: active_turn_id.clone(),
+                    started_at: Some(42),
+                    model_context_window: None,
+                    collaboration_mode_kind: Default::default(),
+                }),
+            );
+            state.pending_terminal_plan_cleanups = vec![PendingTerminalPlanCleanup {
+                turn_id: "older-terminal-turn".to_string(),
+                plan_update: UpdatePlanArgs {
+                    explanation: Some("still working".to_string()),
+                    plan: vec![PlanItemArg {
+                        step: "older".to_string(),
+                        status: StepStatus::InProgress,
+                    }],
+                },
+            }];
+        }
+        let (tx, mut rx) = mpsc::channel(CHANNEL_CAPACITY);
+        let outgoing = Arc::new(OutgoingMessageSender::new(
+            tx,
+            codex_analytics::AnalyticsEventsClient::disabled(),
+        ));
+        let outgoing = ThreadScopedOutgoingMessageSender::new(
+            outgoing,
+            vec![ConnectionId(1)],
+            conversation_id,
+        );
+
+        handle_turn_plan_update(
+            conversation_id,
+            &active_turn_id,
+            UpdatePlanArgs {
+                explanation: Some("next turn".to_string()),
+                plan: vec![PlanItemArg {
+                    step: "new".to_string(),
+                    status: StepStatus::InProgress,
+                }],
+            },
+            &outgoing,
+            &thread_state,
+        )
+        .await;
+
+        let first = recv_broadcast_message(&mut rx).await?;
+        match first {
+            OutgoingMessage::AppServerNotification(ServerNotification::TurnPlanUpdated(n)) => {
+                assert_eq!(n.turn_id, "older-terminal-turn");
+                assert_eq!(n.plan[0].status, TurnPlanStepStatus::Pending);
+            }
+            other => bail!("unexpected message: {other:?}"),
+        }
+
+        let second = recv_broadcast_message(&mut rx).await?;
+        match second {
+            OutgoingMessage::AppServerNotification(ServerNotification::TurnPlanUpdated(n)) => {
+                assert_eq!(n.turn_id, active_turn_id);
+                assert_eq!(n.plan[0].status, TurnPlanStepStatus::InProgress);
+            }
+            other => bail!("unexpected message: {other:?}"),
+        }
+
+        let pending_terminal_plan_cleanups =
+            &thread_state.lock().await.pending_terminal_plan_cleanups;
+        assert_eq!(pending_terminal_plan_cleanups.len(), 1);
+        assert_eq!(
+            pending_terminal_plan_cleanups[0].turn_id,
+            "active-plan-turn"
         );
         assert!(rx.try_recv().is_err(), "no extra messages expected");
         Ok(())

--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -1155,6 +1155,11 @@ pub(crate) async fn apply_bespoke_event_handling(
                 let _thread_list_state_permit = match thread_list_state_permit.acquire().await {
                     Ok(permit) => permit,
                     Err(err) => {
+                        thread_state
+                            .lock()
+                            .await
+                            .pending_terminal_plan_cleanups
+                            .clear();
                         outgoing
                             .send_error(
                                 request_id,
@@ -1175,6 +1180,11 @@ pub(crate) async fn apply_bespoke_event_handling(
                 {
                     Ok(stored_thread) => stored_thread,
                     Err(err) => {
+                        thread_state
+                            .lock()
+                            .await
+                            .pending_terminal_plan_cleanups
+                            .clear();
                         outgoing
                             .send_error(
                                 request_id.clone(),
@@ -1198,6 +1208,11 @@ pub(crate) async fn apply_bespoke_event_handling(
                 ) {
                     Ok(response) => response,
                     Err(err) => {
+                        thread_state
+                            .lock()
+                            .await
+                            .pending_terminal_plan_cleanups
+                            .clear();
                         outgoing
                             .send_error(request_id.clone(), internal_error(err))
                             .await;

--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -183,12 +183,13 @@ pub(crate) async fn apply_bespoke_event_handling(
             outgoing.abort_pending_server_requests().await;
             respond_to_pending_interrupts(&thread_state, &outgoing).await;
             let turn_failed = thread_state.lock().await.turn_summary.last_error.is_some();
-            let preserve_terminal_plan_progress =
-                terminal_plan_cleanup_may_be_needed(&thread_state).await
-                    && should_preserve_terminal_plan_progress(
-                        conversation.as_ref(),
-                        conversation_id,
-                    )
+            let has_pending_terminal_plan_cleanup = !thread_state
+                .lock()
+                .await
+                .pending_terminal_plan_cleanups
+                .is_empty();
+            let preserve_terminal_plan_progress = has_pending_terminal_plan_cleanup
+                && should_preserve_terminal_plan_progress(conversation.as_ref(), conversation_id)
                     .await;
             thread_watch_manager
                 .note_turn_completed(&conversation_id.to_string(), turn_failed)
@@ -1379,14 +1380,6 @@ async fn emit_turn_plan_updated(
     outgoing
         .send_server_notification(ServerNotification::TurnPlanUpdated(notification))
         .await;
-}
-
-async fn terminal_plan_cleanup_may_be_needed(thread_state: &Arc<Mutex<ThreadState>>) -> bool {
-    !thread_state
-        .lock()
-        .await
-        .pending_terminal_plan_cleanups
-        .is_empty()
 }
 
 async fn take_flushable_pending_terminal_plan_cleanup(

--- a/codex-rs/app-server/src/request_processors/thread_goal_processor.rs
+++ b/codex-rs/app-server/src/request_processors/thread_goal_processor.rs
@@ -521,3 +521,92 @@ fn parse_thread_id_for_request(thread_id: &str) -> Result<ThreadId, JSONRPCError
     ThreadId::from_string(thread_id)
         .map_err(|err| invalid_request(format!("invalid thread id: {err}")))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::outgoing_message::ConnectionId;
+    use crate::outgoing_message::OutgoingEnvelope;
+    use crate::outgoing_message::OutgoingMessage;
+    use crate::thread_state::ConnectionCapabilities;
+    use crate::thread_state::PendingTerminalPlanCleanup;
+    use codex_protocol::plan_tool::PlanItemArg;
+    use codex_protocol::plan_tool::StepStatus;
+    use codex_protocol::plan_tool::UpdatePlanArgs;
+    use core_test_support::load_default_config_for_test;
+    use tempfile::TempDir;
+    use tokio::sync::mpsc;
+
+    async fn recv_message(rx: &mut mpsc::Receiver<OutgoingEnvelope>) -> OutgoingMessage {
+        match rx.recv().await.expect("expected outgoing message") {
+            OutgoingEnvelope::Broadcast { message }
+            | OutgoingEnvelope::ToConnection { message, .. } => message,
+        }
+    }
+
+    #[tokio::test]
+    async fn goal_clear_fallback_flushes_pending_terminal_plan_cleanup() -> anyhow::Result<()> {
+        let codex_home = TempDir::new()?;
+        let config = load_default_config_for_test(&codex_home).await;
+        let thread_manager = Arc::new(
+            codex_core::test_support::thread_manager_with_models_provider_and_home(
+                CodexAuth::create_dummy_chatgpt_auth_for_testing(),
+                config.model_provider.clone(),
+                config.codex_home.to_path_buf(),
+                Arc::new(codex_exec_server::EnvironmentManager::default_for_tests()),
+            ),
+        );
+        let thread_id = ThreadId::new();
+        let thread_state_manager = ThreadStateManager::new();
+        let connection_id = ConnectionId(1);
+        thread_state_manager
+            .connection_initialized(connection_id, ConnectionCapabilities::default())
+            .await;
+        thread_state_manager
+            .try_ensure_connection_subscribed(
+                thread_id,
+                connection_id,
+                /*experimental_raw_events*/ false,
+            )
+            .await
+            .expect("connection should subscribe");
+        let thread_state = thread_state_manager.thread_state(thread_id).await;
+        thread_state.lock().await.pending_terminal_plan_cleanups =
+            vec![PendingTerminalPlanCleanup {
+                turn_id: "terminal-turn".to_string(),
+                plan_update: UpdatePlanArgs {
+                    explanation: Some("still working".to_string()),
+                    plan: vec![PlanItemArg {
+                        step: "first".to_string(),
+                        status: StepStatus::InProgress,
+                    }],
+                },
+            }];
+        let (tx, mut rx) = mpsc::channel(4);
+        let outgoing = Arc::new(OutgoingMessageSender::new(
+            tx,
+            codex_analytics::AnalyticsEventsClient::disabled(),
+        ));
+        let processor = ThreadGoalRequestProcessor::new(
+            thread_manager,
+            outgoing,
+            Arc::new(config),
+            thread_state_manager,
+            /*state_db*/ None,
+        );
+
+        processor
+            .emit_thread_goal_cleared_ordered(thread_id, /*listener_command_tx*/ None)
+            .await;
+
+        assert!(matches!(
+            recv_message(&mut rx).await,
+            OutgoingMessage::AppServerNotification(ServerNotification::ThreadGoalCleared(_))
+        ));
+        assert!(matches!(
+            recv_message(&mut rx).await,
+            OutgoingMessage::AppServerNotification(ServerNotification::TurnPlanUpdated(_))
+        ));
+        Ok(())
+    }
+}

--- a/codex-rs/app-server/src/request_processors/thread_goal_processor.rs
+++ b/codex-rs/app-server/src/request_processors/thread_goal_processor.rs
@@ -403,6 +403,7 @@ impl ThreadGoalRequestProcessor {
         goal: ThreadGoal,
         listener_command_tx: Option<tokio::sync::mpsc::UnboundedSender<ThreadListenerCommand>>,
     ) {
+        let goal_is_active = goal.status == ThreadGoalStatus::Active;
         if let Some(listener_command_tx) = listener_command_tx {
             let command = crate::thread_state::ThreadListenerCommand::EmitThreadGoalUpdated {
                 goal: goal.clone(),
@@ -423,6 +424,9 @@ impl ThreadGoalRequestProcessor {
                 },
             ))
             .await;
+        if !goal_is_active {
+            self.emit_pending_terminal_plan_cleanup(thread_id).await;
+        }
     }
 
     async fn emit_thread_goal_cleared_ordered(
@@ -446,6 +450,26 @@ impl ThreadGoalRequestProcessor {
                 },
             ))
             .await;
+        self.emit_pending_terminal_plan_cleanup(thread_id).await;
+    }
+
+    async fn emit_pending_terminal_plan_cleanup(&self, thread_id: ThreadId) {
+        let thread_state = self.thread_state_manager.thread_state(thread_id).await;
+        let subscribed_connection_ids = self
+            .thread_state_manager
+            .subscribed_connection_ids(thread_id)
+            .await;
+        let thread_outgoing = ThreadScopedOutgoingMessageSender::new(
+            self.outgoing.clone(),
+            subscribed_connection_ids,
+            thread_id,
+        );
+        crate::bespoke_event_handling::emit_terminal_plan_cleanup(
+            thread_id,
+            crate::bespoke_event_handling::take_pending_terminal_plan_cleanup(&thread_state).await,
+            &thread_outgoing,
+        )
+        .await;
     }
 }
 

--- a/codex-rs/app-server/src/request_processors/thread_goal_processor.rs
+++ b/codex-rs/app-server/src/request_processors/thread_goal_processor.rs
@@ -464,9 +464,9 @@ impl ThreadGoalRequestProcessor {
             subscribed_connection_ids,
             thread_id,
         );
-        crate::bespoke_event_handling::emit_terminal_plan_cleanup(
+        crate::bespoke_event_handling::flush_pending_terminal_plan_cleanup(
             thread_id,
-            crate::bespoke_event_handling::take_pending_terminal_plan_cleanup(&thread_state).await,
+            &thread_state,
             &thread_outgoing,
         )
         .await;

--- a/codex-rs/app-server/src/request_processors/thread_lifecycle.rs
+++ b/codex-rs/app-server/src/request_processors/thread_lifecycle.rs
@@ -465,6 +465,7 @@ pub(super) async fn handle_thread_listener_command(
             .await;
         }
         ThreadListenerCommand::EmitThreadGoalUpdated { goal } => {
+            let goal_is_active = goal.status == ThreadGoalStatus::Active;
             outgoing
                 .send_server_notification(ServerNotification::ThreadGoalUpdated(
                     ThreadGoalUpdatedNotification {
@@ -474,6 +475,15 @@ pub(super) async fn handle_thread_listener_command(
                     },
                 ))
                 .await;
+            if !goal_is_active {
+                crate::bespoke_event_handling::emit_terminal_plan_cleanup_globally(
+                    conversation_id,
+                    crate::bespoke_event_handling::take_pending_terminal_plan_cleanup(thread_state)
+                        .await,
+                    outgoing,
+                )
+                .await;
+            }
         }
         ThreadListenerCommand::EmitThreadGoalCleared => {
             outgoing
@@ -483,6 +493,13 @@ pub(super) async fn handle_thread_listener_command(
                     },
                 ))
                 .await;
+            crate::bespoke_event_handling::emit_terminal_plan_cleanup_globally(
+                conversation_id,
+                crate::bespoke_event_handling::take_pending_terminal_plan_cleanup(thread_state)
+                    .await,
+                outgoing,
+            )
+            .await;
         }
         ThreadListenerCommand::EmitThreadGoalSnapshot { state_db } => {
             send_thread_goal_snapshot_notification(outgoing, conversation_id, &state_db).await;

--- a/codex-rs/app-server/src/request_processors/thread_lifecycle.rs
+++ b/codex-rs/app-server/src/request_processors/thread_lifecycle.rs
@@ -476,11 +476,19 @@ pub(super) async fn handle_thread_listener_command(
                 ))
                 .await;
             if !goal_is_active {
-                crate::bespoke_event_handling::emit_terminal_plan_cleanup_globally(
+                let subscribed_connection_ids = thread_state_manager
+                    .subscribed_connection_ids(conversation_id)
+                    .await;
+                let thread_outgoing = ThreadScopedOutgoingMessageSender::new(
+                    outgoing.clone(),
+                    subscribed_connection_ids,
+                    conversation_id,
+                );
+                crate::bespoke_event_handling::emit_terminal_plan_cleanup(
                     conversation_id,
                     crate::bespoke_event_handling::take_pending_terminal_plan_cleanup(thread_state)
                         .await,
-                    outgoing,
+                    &thread_outgoing,
                 )
                 .await;
             }
@@ -493,11 +501,19 @@ pub(super) async fn handle_thread_listener_command(
                     },
                 ))
                 .await;
-            crate::bespoke_event_handling::emit_terminal_plan_cleanup_globally(
+            let subscribed_connection_ids = thread_state_manager
+                .subscribed_connection_ids(conversation_id)
+                .await;
+            let thread_outgoing = ThreadScopedOutgoingMessageSender::new(
+                outgoing.clone(),
+                subscribed_connection_ids,
+                conversation_id,
+            );
+            crate::bespoke_event_handling::emit_terminal_plan_cleanup(
                 conversation_id,
                 crate::bespoke_event_handling::take_pending_terminal_plan_cleanup(thread_state)
                     .await,
-                outgoing,
+                &thread_outgoing,
             )
             .await;
         }

--- a/codex-rs/app-server/src/request_processors/thread_lifecycle.rs
+++ b/codex-rs/app-server/src/request_processors/thread_lifecycle.rs
@@ -794,3 +794,98 @@ pub(super) fn set_thread_status_and_interrupt_stale_turns(
     }
     thread.status = status;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::outgoing_message::ConnectionId;
+    use crate::outgoing_message::OutgoingEnvelope;
+    use crate::outgoing_message::OutgoingMessage;
+    use crate::thread_state::ConnectionCapabilities;
+    use crate::thread_state::PendingTerminalPlanCleanup;
+    use codex_protocol::plan_tool::PlanItemArg;
+    use codex_protocol::plan_tool::StepStatus;
+    use codex_protocol::plan_tool::UpdatePlanArgs;
+    use core_test_support::load_default_config_for_test;
+    use tempfile::TempDir;
+    use tokio::sync::mpsc;
+
+    async fn recv_message(rx: &mut mpsc::Receiver<OutgoingEnvelope>) -> OutgoingMessage {
+        match rx.recv().await.expect("expected outgoing message") {
+            OutgoingEnvelope::Broadcast { message }
+            | OutgoingEnvelope::ToConnection { message, .. } => message,
+        }
+    }
+
+    #[tokio::test]
+    async fn listener_goal_clear_flushes_pending_terminal_plan_cleanup() -> anyhow::Result<()> {
+        let codex_home = TempDir::new()?;
+        let config = load_default_config_for_test(&codex_home).await;
+        let thread_manager = Arc::new(
+            codex_core::test_support::thread_manager_with_models_provider_and_home(
+                CodexAuth::create_dummy_chatgpt_auth_for_testing(),
+                config.model_provider.clone(),
+                config.codex_home.to_path_buf(),
+                Arc::new(codex_exec_server::EnvironmentManager::default_for_tests()),
+            ),
+        );
+        let codex_core::NewThread {
+            thread_id,
+            thread: conversation,
+            ..
+        } = thread_manager.start_thread(config).await?;
+        let thread_state_manager = ThreadStateManager::new();
+        let connection_id = ConnectionId(1);
+        thread_state_manager
+            .connection_initialized(connection_id, ConnectionCapabilities::default())
+            .await;
+        thread_state_manager
+            .try_ensure_connection_subscribed(
+                thread_id,
+                connection_id,
+                /*experimental_raw_events*/ false,
+            )
+            .await
+            .expect("connection should subscribe");
+        let thread_state = thread_state_manager.thread_state(thread_id).await;
+        thread_state.lock().await.pending_terminal_plan_cleanups =
+            vec![PendingTerminalPlanCleanup {
+                turn_id: "terminal-turn".to_string(),
+                plan_update: UpdatePlanArgs {
+                    explanation: Some("still working".to_string()),
+                    plan: vec![PlanItemArg {
+                        step: "first".to_string(),
+                        status: StepStatus::InProgress,
+                    }],
+                },
+            }];
+        let (tx, mut rx) = mpsc::channel(4);
+        let outgoing = Arc::new(OutgoingMessageSender::new(
+            tx,
+            codex_analytics::AnalyticsEventsClient::disabled(),
+        ));
+
+        handle_thread_listener_command(
+            thread_id,
+            &conversation,
+            codex_home.path(),
+            &thread_state_manager,
+            &thread_state,
+            &ThreadWatchManager::new(),
+            &outgoing,
+            &Arc::new(Mutex::new(HashSet::new())),
+            ThreadListenerCommand::EmitThreadGoalCleared,
+        )
+        .await;
+
+        assert!(matches!(
+            recv_message(&mut rx).await,
+            OutgoingMessage::AppServerNotification(ServerNotification::ThreadGoalCleared(_))
+        ));
+        assert!(matches!(
+            recv_message(&mut rx).await,
+            OutgoingMessage::AppServerNotification(ServerNotification::TurnPlanUpdated(_))
+        ));
+        Ok(())
+    }
+}

--- a/codex-rs/app-server/src/request_processors/thread_lifecycle.rs
+++ b/codex-rs/app-server/src/request_processors/thread_lifecycle.rs
@@ -476,18 +476,11 @@ pub(super) async fn handle_thread_listener_command(
                 ))
                 .await;
             if !goal_is_active {
-                let subscribed_connection_ids = thread_state_manager
-                    .subscribed_connection_ids(conversation_id)
-                    .await;
-                let thread_outgoing = ThreadScopedOutgoingMessageSender::new(
-                    outgoing.clone(),
-                    subscribed_connection_ids,
+                flush_pending_terminal_plan_cleanup_for_subscribers(
                     conversation_id,
-                );
-                crate::bespoke_event_handling::flush_pending_terminal_plan_cleanup(
-                    conversation_id,
+                    thread_state_manager,
                     thread_state,
-                    &thread_outgoing,
+                    outgoing,
                 )
                 .await;
             }
@@ -500,18 +493,11 @@ pub(super) async fn handle_thread_listener_command(
                     },
                 ))
                 .await;
-            let subscribed_connection_ids = thread_state_manager
-                .subscribed_connection_ids(conversation_id)
-                .await;
-            let thread_outgoing = ThreadScopedOutgoingMessageSender::new(
-                outgoing.clone(),
-                subscribed_connection_ids,
+            flush_pending_terminal_plan_cleanup_for_subscribers(
                 conversation_id,
-            );
-            crate::bespoke_event_handling::flush_pending_terminal_plan_cleanup(
-                conversation_id,
+                thread_state_manager,
                 thread_state,
-                &thread_outgoing,
+                outgoing,
             )
             .await;
         }
@@ -532,6 +518,28 @@ pub(super) async fn handle_thread_listener_command(
             let _ = completion_tx.send(());
         }
     }
+}
+
+async fn flush_pending_terminal_plan_cleanup_for_subscribers(
+    conversation_id: ThreadId,
+    thread_state_manager: &ThreadStateManager,
+    thread_state: &Arc<Mutex<ThreadState>>,
+    outgoing: &Arc<OutgoingMessageSender>,
+) {
+    let subscribed_connection_ids = thread_state_manager
+        .subscribed_connection_ids(conversation_id)
+        .await;
+    let thread_outgoing = ThreadScopedOutgoingMessageSender::new(
+        outgoing.clone(),
+        subscribed_connection_ids,
+        conversation_id,
+    );
+    crate::bespoke_event_handling::flush_pending_terminal_plan_cleanup(
+        conversation_id,
+        thread_state,
+        &thread_outgoing,
+    )
+    .await;
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/codex-rs/app-server/src/request_processors/thread_lifecycle.rs
+++ b/codex-rs/app-server/src/request_processors/thread_lifecycle.rs
@@ -484,10 +484,9 @@ pub(super) async fn handle_thread_listener_command(
                     subscribed_connection_ids,
                     conversation_id,
                 );
-                crate::bespoke_event_handling::emit_terminal_plan_cleanup(
+                crate::bespoke_event_handling::flush_pending_terminal_plan_cleanup(
                     conversation_id,
-                    crate::bespoke_event_handling::take_pending_terminal_plan_cleanup(thread_state)
-                        .await,
+                    thread_state,
                     &thread_outgoing,
                 )
                 .await;
@@ -509,10 +508,9 @@ pub(super) async fn handle_thread_listener_command(
                 subscribed_connection_ids,
                 conversation_id,
             );
-            crate::bespoke_event_handling::emit_terminal_plan_cleanup(
+            crate::bespoke_event_handling::flush_pending_terminal_plan_cleanup(
                 conversation_id,
-                crate::bespoke_event_handling::take_pending_terminal_plan_cleanup(thread_state)
-                    .await,
+                thread_state,
                 &thread_outgoing,
             )
             .await;

--- a/codex-rs/app-server/src/thread_state.rs
+++ b/codex-rs/app-server/src/thread_state.rs
@@ -9,6 +9,7 @@ use codex_core::CodexThread;
 use codex_core::ThreadConfigSnapshot;
 use codex_file_watcher::WatchRegistration;
 use codex_protocol::ThreadId;
+use codex_protocol::plan_tool::UpdatePlanArgs;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::RolloutItem;
 use codex_rollout::state_db::StateDbHandle;
@@ -65,6 +66,7 @@ pub(crate) struct TurnSummary {
     pub(crate) started_at: Option<i64>,
     pub(crate) command_execution_started: HashSet<String>,
     pub(crate) last_error: Option<TurnError>,
+    pub(crate) latest_plan_update: Option<UpdatePlanArgs>,
 }
 
 #[derive(Default)]

--- a/codex-rs/app-server/src/thread_state.rs
+++ b/codex-rs/app-server/src/thread_state.rs
@@ -80,7 +80,6 @@ pub(crate) struct ThreadState {
     pub(crate) turn_summary: TurnSummary,
     pub(crate) pending_terminal_plan_cleanups: Vec<PendingTerminalPlanCleanup>,
     pub(crate) last_terminal_turn_id: Option<String>,
-    terminal_turn_ids: Vec<String>,
     pub(crate) cancel_tx: Option<oneshot::Sender<()>>,
     pub(crate) experimental_raw_events: bool,
     pub(crate) listener_generation: u64,
@@ -139,27 +138,14 @@ impl ThreadState {
         self.current_turn_history.active_turn_snapshot()
     }
 
-    pub(crate) fn prune_pending_terminal_plan_cleanups_after_rollback(&mut self) {
-        self.pending_terminal_plan_cleanups
-            .retain(|cleanup| self.terminal_turn_ids.contains(&cleanup.turn_id));
-    }
-
     pub(crate) fn track_current_turn_event(&mut self, event_turn_id: &str, event: &EventMsg) {
         if let EventMsg::TurnStarted(payload) = event {
             self.turn_summary.started_at = payload.started_at;
         }
         self.current_turn_history.handle_event(event);
-        if let EventMsg::ThreadRolledBack(payload) = event {
-            let num_turns = usize::try_from(payload.num_turns).unwrap_or(usize::MAX);
-            self.terminal_turn_ids
-                .truncate(self.terminal_turn_ids.len().saturating_sub(num_turns));
-        }
         if matches!(event, EventMsg::TurnAborted(_) | EventMsg::TurnComplete(_))
             && !self.current_turn_history.has_active_turn()
         {
-            if self.last_terminal_turn_id.as_deref() != Some(event_turn_id) {
-                self.terminal_turn_ids.push(event_turn_id.to_string());
-            }
             self.last_terminal_turn_id = Some(event_turn_id.to_string());
             self.current_turn_history.reset();
         }

--- a/codex-rs/app-server/src/thread_state.rs
+++ b/codex-rs/app-server/src/thread_state.rs
@@ -80,6 +80,7 @@ pub(crate) struct ThreadState {
     pub(crate) turn_summary: TurnSummary,
     pub(crate) pending_terminal_plan_cleanups: Vec<PendingTerminalPlanCleanup>,
     pub(crate) last_terminal_turn_id: Option<String>,
+    terminal_turn_ids: Vec<String>,
     pub(crate) cancel_tx: Option<oneshot::Sender<()>>,
     pub(crate) experimental_raw_events: bool,
     pub(crate) listener_generation: u64,
@@ -138,14 +139,30 @@ impl ThreadState {
         self.current_turn_history.active_turn_snapshot()
     }
 
+    pub(crate) fn prune_pending_terminal_plan_cleanups_after_rollback(&mut self) {
+        self.pending_terminal_plan_cleanups.retain(|cleanup| {
+            self.terminal_turn_ids
+                .iter()
+                .any(|turn_id| turn_id == &cleanup.turn_id)
+        });
+    }
+
     pub(crate) fn track_current_turn_event(&mut self, event_turn_id: &str, event: &EventMsg) {
         if let EventMsg::TurnStarted(payload) = event {
             self.turn_summary.started_at = payload.started_at;
         }
         self.current_turn_history.handle_event(event);
+        if let EventMsg::ThreadRolledBack(payload) = event {
+            let num_turns = usize::try_from(payload.num_turns).unwrap_or(usize::MAX);
+            self.terminal_turn_ids
+                .truncate(self.terminal_turn_ids.len().saturating_sub(num_turns));
+        }
         if matches!(event, EventMsg::TurnAborted(_) | EventMsg::TurnComplete(_))
             && !self.current_turn_history.has_active_turn()
         {
+            if self.last_terminal_turn_id.as_deref() != Some(event_turn_id) {
+                self.terminal_turn_ids.push(event_turn_id.to_string());
+            }
             self.last_terminal_turn_id = Some(event_turn_id.to_string());
             self.current_turn_history.reset();
         }

--- a/codex-rs/app-server/src/thread_state.rs
+++ b/codex-rs/app-server/src/thread_state.rs
@@ -68,7 +68,6 @@ pub(crate) struct TurnSummary {
     pub(crate) last_error: Option<TurnError>,
 }
 
-#[derive(Clone)]
 pub(crate) struct PendingTerminalPlanCleanup {
     pub(crate) turn_id: String,
     pub(crate) plan_update: UpdatePlanArgs,

--- a/codex-rs/app-server/src/thread_state.rs
+++ b/codex-rs/app-server/src/thread_state.rs
@@ -78,7 +78,7 @@ pub(crate) struct ThreadState {
     pub(crate) pending_interrupts: PendingInterruptQueue,
     pub(crate) pending_rollbacks: Option<ConnectionRequestId>,
     pub(crate) turn_summary: TurnSummary,
-    pub(crate) pending_terminal_plan_cleanup: Option<PendingTerminalPlanCleanup>,
+    pub(crate) pending_terminal_plan_cleanups: Vec<PendingTerminalPlanCleanup>,
     pub(crate) last_terminal_turn_id: Option<String>,
     pub(crate) cancel_tx: Option<oneshot::Sender<()>>,
     pub(crate) experimental_raw_events: bool,

--- a/codex-rs/app-server/src/thread_state.rs
+++ b/codex-rs/app-server/src/thread_state.rs
@@ -66,7 +66,12 @@ pub(crate) struct TurnSummary {
     pub(crate) started_at: Option<i64>,
     pub(crate) command_execution_started: HashSet<String>,
     pub(crate) last_error: Option<TurnError>,
-    pub(crate) latest_plan_update: Option<UpdatePlanArgs>,
+}
+
+#[derive(Clone)]
+pub(crate) struct PendingTerminalPlanCleanup {
+    pub(crate) turn_id: String,
+    pub(crate) plan_update: UpdatePlanArgs,
 }
 
 #[derive(Default)]
@@ -74,6 +79,7 @@ pub(crate) struct ThreadState {
     pub(crate) pending_interrupts: PendingInterruptQueue,
     pub(crate) pending_rollbacks: Option<ConnectionRequestId>,
     pub(crate) turn_summary: TurnSummary,
+    pub(crate) pending_terminal_plan_cleanup: Option<PendingTerminalPlanCleanup>,
     pub(crate) last_terminal_turn_id: Option<String>,
     pub(crate) cancel_tx: Option<oneshot::Sender<()>>,
     pub(crate) experimental_raw_events: bool,

--- a/codex-rs/app-server/src/thread_state.rs
+++ b/codex-rs/app-server/src/thread_state.rs
@@ -140,11 +140,8 @@ impl ThreadState {
     }
 
     pub(crate) fn prune_pending_terminal_plan_cleanups_after_rollback(&mut self) {
-        self.pending_terminal_plan_cleanups.retain(|cleanup| {
-            self.terminal_turn_ids
-                .iter()
-                .any(|turn_id| turn_id == &cleanup.turn_id)
-        });
+        self.pending_terminal_plan_cleanups
+            .retain(|cleanup| self.terminal_turn_ids.contains(&cleanup.turn_id));
     }
 
     pub(crate) fn track_current_turn_event(&mut self, event_turn_id: &str, event: &EventMsg) {


### PR DESCRIPTION
## Why

Codex clients render `update_plan` items in `in_progress` as active work. When a turn ends without an active long-running goal, those items can get stranded in a spinner state even though no agent is still working on them.

## What changed

- Cache the latest `update_plan` payload for the active turn in app-server thread state.
- On completed or interrupted terminal turns, emit a synthetic `turn/planUpdated` notification that downgrades lingering `in_progress` items back to `pending` when the thread does not have an active goal.
- Preserve in-progress plan state for active goals, and fail conservatively by skipping cleanup if goal lookup itself fails.
- Add coverage for completed turns, interrupted turns, active-goal preservation, and plan update caching.

## Verification

- `cargo test -p codex-app-server in_progress_plan`
- `cargo test -p codex-app-server test_handle_turn_plan_update_emits_notification_for_v2`
- `just fix -p codex-app-server`
- `just fmt`