### PR TITLE
[rollout-trace] Trace untraced websocket prewarm prefixes

### DIFF
--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -251,6 +251,28 @@ pub struct ModelClientSession {
 struct LastResponse {
     response_id: String,
     items_added: Vec<ResponseItem>,
+    traceable_for_replay: bool,
+}
+
+struct IncrementalInputDelta {
+    input: Vec<ResponseItem>,
+    omitted_prefix: Vec<ResponseItem>,
+}
+
+struct PreparedWebsocketRequest {
+    request: ResponsesWsRequest,
+    input_mode: WebsocketRequestTraceInputMode,
+}
+
+enum WebsocketRequestTraceInputMode {
+    FullSnapshot,
+    Incremental {
+        previous_response_id: String,
+    },
+    IncrementalWithUntracedPrefix {
+        previous_response_id: String,
+        prefix_input: Vec<ResponseItem>,
+    },
 }
 
 #[derive(Debug, Default)]
@@ -991,7 +1013,7 @@ impl ModelClientSession {
         request: &ResponsesApiRequest,
         last_response: Option<&LastResponse>,
         allow_empty_delta: bool,
-    ) -> Option<Vec<ResponseItem>> {
+    ) -> Option<IncrementalInputDelta> {
         // Checks whether the current request is an incremental extension of the previous request.
         // We only reuse an incremental input delta when non-input request fields are unchanged and
         // `input` is a strict
@@ -1018,7 +1040,10 @@ impl ModelClientSession {
         if request.input.starts_with(&baseline)
             && (allow_empty_delta || baseline_len < request.input.len())
         {
-            Some(request.input[baseline_len..].to_vec())
+            Some(IncrementalInputDelta {
+                input: request.input[baseline_len..].to_vec(),
+                omitted_prefix: baseline,
+            })
         } else {
             trace!("incremental request failed, items didn't match");
             None
@@ -1039,28 +1064,54 @@ impl ModelClientSession {
         &mut self,
         payload: ResponseCreateWsRequest,
         request: &ResponsesApiRequest,
-    ) -> ResponsesWsRequest {
+    ) -> PreparedWebsocketRequest {
         let Some(last_response) = self.get_last_response() else {
-            return ResponsesWsRequest::ResponseCreate(payload);
+            return PreparedWebsocketRequest {
+                request: ResponsesWsRequest::ResponseCreate(payload),
+                input_mode: WebsocketRequestTraceInputMode::FullSnapshot,
+            };
         };
-        let Some(incremental_items) = self.get_incremental_items(
+        let Some(incremental) = self.get_incremental_items(
             request,
             Some(&last_response),
             /*allow_empty_delta*/ true,
         ) else {
-            return ResponsesWsRequest::ResponseCreate(payload);
+            return PreparedWebsocketRequest {
+                request: ResponsesWsRequest::ResponseCreate(payload),
+                input_mode: WebsocketRequestTraceInputMode::FullSnapshot,
+            };
         };
 
         if last_response.response_id.is_empty() {
             trace!("incremental request failed, no previous response id");
-            return ResponsesWsRequest::ResponseCreate(payload);
+            return PreparedWebsocketRequest {
+                request: ResponsesWsRequest::ResponseCreate(payload),
+                input_mode: WebsocketRequestTraceInputMode::FullSnapshot,
+            };
         }
 
-        ResponsesWsRequest::ResponseCreate(ResponseCreateWsRequest {
-            previous_response_id: Some(last_response.response_id),
-            input: incremental_items,
-            ..payload
-        })
+        let previous_response_id = last_response.response_id;
+        let input_mode = if last_response.traceable_for_replay {
+            WebsocketRequestTraceInputMode::Incremental {
+                previous_response_id: previous_response_id.clone(),
+            }
+        } else if incremental.omitted_prefix.is_empty() {
+            WebsocketRequestTraceInputMode::FullSnapshot
+        } else {
+            WebsocketRequestTraceInputMode::IncrementalWithUntracedPrefix {
+                previous_response_id: previous_response_id.clone(),
+                prefix_input: incremental.omitted_prefix,
+            }
+        };
+
+        PreparedWebsocketRequest {
+            request: ResponsesWsRequest::ResponseCreate(ResponseCreateWsRequest {
+                previous_response_id: Some(previous_response_id),
+                input: incremental.input,
+                ..payload
+            }),
+            input_mode,
+        }
     }
 
     /// Opportunistically preconnects a websocket for this turn-scoped client session.
@@ -1269,6 +1320,7 @@ impl ModelClientSession {
                         stream,
                         session_telemetry.clone(),
                         inference_trace_attempt,
+                        /*traceable_for_replay*/ true,
                     );
                     return Ok(stream);
                 }
@@ -1408,8 +1460,10 @@ impl ModelClientSession {
                 Err(err) => return Err(map_api_error(err)),
             }
 
-            let mut ws_request = self.prepare_websocket_request(ws_payload, &request);
-            let request_input_mode = websocket_trace_request_input_mode(&ws_request, &request);
+            let PreparedWebsocketRequest {
+                request: mut ws_request,
+                input_mode,
+            } = self.prepare_websocket_request(ws_payload, &request);
             self.websocket_session.last_request = Some(request);
             let inference_trace_attempt = if warmup {
                 // Prewarm sends `generate=false`; it is connection setup, not a
@@ -1419,7 +1473,26 @@ impl ModelClientSession {
                 inference_trace.start_attempt()
             };
             stamp_ws_stream_request_start_ms(&mut ws_request);
-            inference_trace_attempt.record_started(&ws_request, request_input_mode);
+            match input_mode {
+                WebsocketRequestTraceInputMode::FullSnapshot => inference_trace_attempt
+                    .record_started(&ws_request, InferenceRequestInputMode::FullSnapshot),
+                WebsocketRequestTraceInputMode::Incremental {
+                    previous_response_id,
+                } => inference_trace_attempt.record_started(
+                    &ws_request,
+                    InferenceRequestInputMode::Incremental {
+                        previous_response_id,
+                    },
+                ),
+                WebsocketRequestTraceInputMode::IncrementalWithUntracedPrefix {
+                    previous_response_id,
+                    prefix_input,
+                } => inference_trace_attempt.record_started_with_untraced_prefix(
+                    &ws_request,
+                    previous_response_id,
+                    &prefix_input,
+                ),
+            }
             let websocket_connection =
                 self.websocket_session.connection.as_ref().ok_or_else(|| {
                     map_api_error(ApiError::Stream(
@@ -1444,6 +1517,7 @@ impl ModelClientSession {
                 stream_result,
                 session_telemetry.clone(),
                 inference_trace_attempt,
+                !warmup && inference_trace.is_enabled(),
             );
             self.websocket_session.last_response_rx = Some(last_request_rx);
             return Ok(WebsocketStreamOutcome::Stream(stream));
@@ -1644,30 +1718,6 @@ fn stamp_ws_stream_request_start_ms(request: &mut ResponsesWsRequest) {
         );
 }
 
-/// Describes whether the websocket wire payload still contains the logical full input.
-///
-/// A websocket request can reuse `previous_response_id` while omitting zero visible
-/// items, notably after empty startup prewarm. The reducer should treat that as a
-/// full snapshot even though the transport-level parent id is present.
-fn websocket_trace_request_input_mode(
-    request: &ResponsesWsRequest,
-    logical_request: &ResponsesApiRequest,
-) -> InferenceRequestInputMode {
-    let ResponsesWsRequest::ResponseCreate(payload) = request else {
-        return InferenceRequestInputMode::FullSnapshot;
-    };
-    let Some(previous_response_id) = payload.previous_response_id.as_ref() else {
-        return InferenceRequestInputMode::FullSnapshot;
-    };
-    if payload.input == logical_request.input {
-        InferenceRequestInputMode::FullSnapshot
-    } else {
-        InferenceRequestInputMode::Incremental {
-            previous_response_id: previous_response_id.clone(),
-        }
-    }
-}
-
 /// Builds the extra headers attached to Responses API requests.
 ///
 /// These headers implement Codex-specific conventions:
@@ -1743,6 +1793,7 @@ fn map_response_stream(
     api_stream: codex_api::ResponseStream,
     session_telemetry: SessionTelemetry,
     inference_trace_attempt: InferenceTraceAttempt,
+    traceable_for_replay: bool,
 ) -> (ResponseStream, oneshot::Receiver<LastResponse>) {
     let codex_api::ResponseStream {
         rx_event,
@@ -1757,6 +1808,7 @@ fn map_response_stream(
         api_stream,
         session_telemetry,
         inference_trace_attempt,
+        traceable_for_replay,
     )
 }
 
@@ -1765,6 +1817,7 @@ fn map_response_events<S>(
     api_stream: S,
     session_telemetry: SessionTelemetry,
     inference_trace_attempt: InferenceTraceAttempt,
+    traceable_for_replay: bool,
 ) -> (ResponseStream, oneshot::Receiver<LastResponse>)
 where
     S: futures::Stream<Item = std::result::Result<ResponseEvent, ApiError>>
@@ -1843,6 +1896,7 @@ where
                         let _ = sender.send(LastResponse {
                             response_id: response_id.clone(),
                             items_added: std::mem::take(&mut items_added),
+                            traceable_for_replay,
                         });
                     }
                     if tx_event

--- a/codex-rs/core/src/client_tests.rs
+++ b/codex-rs/core/src/client_tests.rs
@@ -349,6 +349,7 @@ async fn dropped_response_stream_traces_cancelled_partial_output() -> anyhow::Re
         api_stream,
         test_session_telemetry(),
         attempt,
+        /*traceable_for_replay*/ true,
     );
 
     let observed = stream
@@ -398,6 +399,7 @@ async fn response_stream_records_last_model_feedback_ids() {
         api_stream,
         test_session_telemetry(),
         InferenceTraceAttempt::disabled(),
+        /*traceable_for_replay*/ false,
     );
 
     while stream.next().await.is_some() {}
@@ -439,6 +441,7 @@ async fn dropped_backpressured_response_stream_traces_cancelled_partial_output()
         api_stream,
         test_session_telemetry(),
         attempt,
+        /*traceable_for_replay*/ true,
     );
 
     // Fill the mapper channel with non-terminal events, then yield one output

--- a/codex-rs/core/tests/suite/client_websockets.rs
+++ b/codex-rs/core/tests/suite/client_websockets.rs
@@ -30,6 +30,11 @@ use codex_protocol::protocol::Op;
 use codex_protocol::protocol::SessionSource;
 use codex_protocol::protocol::W3cTraceContext;
 use codex_protocol::user_input::UserInput;
+use codex_rollout_trace::ConversationPart;
+use codex_rollout_trace::InferenceTraceContext;
+use codex_rollout_trace::RawTraceEventPayload;
+use codex_rollout_trace::TraceWriter;
+use codex_rollout_trace::replay_bundle;
 use core_test_support::load_default_config_for_test;
 use core_test_support::responses::WebSocketConnectionConfig;
 use core_test_support::responses::WebSocketTestServer;
@@ -602,6 +607,101 @@ async fn responses_websocket_preconnect_is_reused_even_with_header_changes() {
 
     assert_eq!(server.handshakes().len(), 1);
     assert_eq!(server.single_connection().len(), 1);
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn responses_websocket_traces_untraced_prewarm_prefix_for_replay() {
+    skip_if_no_network!();
+
+    let server = start_websocket_server(vec![vec![
+        vec![ev_response_created("warm-1"), ev_completed("warm-1")],
+        vec![ev_response_created("resp-1"), ev_completed("resp-1")],
+    ]])
+    .await;
+
+    let harness = websocket_harness_with_options(&server, /*runtime_metrics_enabled*/ true).await;
+    let mut client_session = harness.client.new_session();
+    let prompt = prompt_with_input(vec![message_item("hello")]);
+    client_session
+        .prewarm_websocket(
+            &prompt,
+            &harness.model_info,
+            &harness.session_telemetry,
+            harness.effort,
+            harness.summary,
+            /*service_tier*/ None,
+            /*turn_metadata_header*/ None,
+        )
+        .await
+        .expect("websocket prewarm failed");
+
+    let trace_dir = TempDir::new().expect("create trace dir");
+    let writer = Arc::new(
+        TraceWriter::create(
+            trace_dir.path(),
+            "trace-1".to_string(),
+            "rollout-1".to_string(),
+            "thread-root".to_string(),
+        )
+        .expect("create trace writer"),
+    );
+    writer
+        .append(RawTraceEventPayload::ThreadStarted {
+            thread_id: "thread-root".to_string(),
+            agent_path: "/root".to_string(),
+            metadata_payload: None,
+        })
+        .expect("write thread start");
+    writer
+        .append(RawTraceEventPayload::CodexTurnStarted {
+            codex_turn_id: "turn-1".to_string(),
+            thread_id: "thread-root".to_string(),
+        })
+        .expect("write turn start");
+    let inference_trace = InferenceTraceContext::enabled(
+        writer,
+        "thread-root".to_string(),
+        "turn-1".to_string(),
+        harness.model_info.slug.clone(),
+        "mock-ws".to_string(),
+    );
+    let mut stream = client_session
+        .stream(
+            &prompt,
+            &harness.model_info,
+            &harness.session_telemetry,
+            harness.effort,
+            harness.summary,
+            /*service_tier*/ None,
+            /*turn_metadata_header*/ None,
+            &inference_trace,
+        )
+        .await
+        .expect("websocket stream failed");
+    while let Some(event) = stream.next().await {
+        if matches!(event, Ok(ResponseEvent::Completed { .. })) {
+            break;
+        }
+    }
+
+    let rollout = replay_bundle(trace_dir.path()).expect("trace should replay");
+    let inference = rollout
+        .inference_calls
+        .values()
+        .next()
+        .expect("recorded inference call");
+    assert_eq!(rollout.inference_calls.len(), 1);
+    assert_eq!(inference.request_item_ids.len(), 1);
+    assert_eq!(
+        rollout.conversation_items[&inference.request_item_ids[0]]
+            .body
+            .parts,
+        vec![ConversationPart::Text {
+            text: "hello".to_string(),
+        }],
+    );
 
     server.shutdown().await;
 }

--- a/codex-rs/rollout-trace/src/inference.rs
+++ b/codex-rs/rollout-trace/src/inference.rs
@@ -92,6 +92,11 @@ struct TracedResponseStreamOutput<'a> {
     output_items: Vec<JsonValue>,
 }
 
+#[derive(Serialize)]
+struct TracedRequestInputPrefix<'a> {
+    input: &'a [ResponseItem],
+}
+
 impl InferenceTraceContext {
     /// Builds a context that accepts trace calls and records nothing.
     pub fn disabled() -> Self {
@@ -132,6 +137,11 @@ impl InferenceTraceContext {
                 terminal_recorded: AtomicBool::new(false),
             }),
         }
+    }
+
+    /// Returns true when this context will write trace events.
+    pub fn is_enabled(&self) -> bool {
+        matches!(self.state, InferenceTraceContextState::Enabled(_))
     }
 }
 
@@ -193,6 +203,53 @@ impl InferenceTraceAttempt {
                 model: attempt.context.model.clone(),
                 provider_name: attempt.context.provider_name.clone(),
                 request_input_mode: Some(request_input_mode),
+                request_payload,
+            },
+        );
+    }
+
+    /// Records an incremental provider request whose omitted prefix came from an untraced response.
+    pub fn record_started_with_untraced_prefix(
+        &self,
+        request: &impl Serialize,
+        previous_response_id: String,
+        prefix_input: &[ResponseItem],
+    ) {
+        let InferenceTraceAttemptState::Enabled(attempt) = &self.state else {
+            return;
+        };
+        let Some(request_payload) = write_json_payload_best_effort(
+            &attempt.context.writer,
+            RawPayloadKind::InferenceRequest,
+            request,
+        ) else {
+            return;
+        };
+        let prefix = TracedRequestInputPrefix {
+            input: prefix_input,
+        };
+        let Some(prefix_payload) = write_json_payload_best_effort(
+            &attempt.context.writer,
+            RawPayloadKind::InferenceRequest,
+            &prefix,
+        ) else {
+            return;
+        };
+
+        append_with_context_best_effort(
+            &attempt.context,
+            RawTraceEventPayload::InferenceStarted {
+                inference_call_id: attempt.inference_call_id.clone(),
+                thread_id: attempt.context.thread_id.clone(),
+                codex_turn_id: attempt.context.codex_turn_id.clone(),
+                model: attempt.context.model.clone(),
+                provider_name: attempt.context.provider_name.clone(),
+                request_input_mode: Some(
+                    InferenceRequestInputMode::IncrementalWithUntracedPrefix {
+                        previous_response_id,
+                        prefix_payload,
+                    },
+                ),
                 request_payload,
             },
         );

--- a/codex-rs/rollout-trace/src/raw_event.rs
+++ b/codex-rs/rollout-trace/src/raw_event.rs
@@ -69,7 +69,7 @@ pub enum RawToolCallRequester {
 /// transport can still send a `previous_response_id` when that parent omitted no
 /// model-visible items, so replay needs this trace-side semantic fact rather than
 /// guessing solely from the wire payload.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum InferenceRequestInputMode {
     /// The request payload contains the whole model-visible input snapshot.
@@ -78,6 +78,16 @@ pub enum InferenceRequestInputMode {
     Incremental {
         /// Responses API `response.id` whose traced request/response items form the omitted prefix.
         previous_response_id: String,
+    },
+    /// The request payload contains only items appended after an untraced prior response.
+    ///
+    /// `prefix_payload` is a trace-only request-shaped payload containing the model-visible
+    /// `input` prefix omitted by `previous_response_id`.
+    IncrementalWithUntracedPrefix {
+        /// Responses API `response.id` whose response was used by the provider but was not traced.
+        previous_response_id: String,
+        /// Request-shaped payload containing the omitted model-visible prefix.
+        prefix_payload: RawPayloadRef,
     },
 }
 
@@ -274,6 +284,15 @@ impl RawTraceEventPayload {
             RawTraceEventPayload::ThreadStarted {
                 metadata_payload, ..
             } => metadata_payload.iter().collect(),
+            RawTraceEventPayload::InferenceStarted {
+                request_input_mode:
+                    Some(InferenceRequestInputMode::IncrementalWithUntracedPrefix {
+                        prefix_payload,
+                        ..
+                    }),
+                request_payload,
+                ..
+            } => vec![request_payload, prefix_payload],
             RawTraceEventPayload::InferenceStarted {
                 request_payload, ..
             }

--- a/codex-rs/rollout-trace/src/reducer/conversation.rs
+++ b/codex-rs/rollout-trace/src/reducer/conversation.rs
@@ -42,23 +42,9 @@ impl TraceReducer {
         request_payload: &RawPayloadRef,
     ) -> Result<Vec<String>> {
         let payload = self.read_payload_json(request_payload)?;
-        let Some(input) = payload.get("input") else {
-            bail!(
-                "inference request payload {} did not contain input",
-                request_payload.raw_payload_id
-            );
-        };
-        let Some(request_items) = input.as_array() else {
-            bail!(
-                "inference request payload {} had non-array input",
-                request_payload.raw_payload_id
-            );
-        };
-
-        let items = normalize::normalize_model_items(request_items, request_payload)?;
-
         let payload_previous_response_id =
             payload.get("previous_response_id").and_then(Value::as_str);
+        let items = self.normalized_request_items(request_payload, &payload)?;
         // Old bundles predate request-input reduction metadata. Preserve their
         // existing replay behavior by deriving the legacy interpretation from
         // the transport payload only when the explicit mode is absent.
@@ -84,31 +70,18 @@ impl TraceReducer {
             InferenceRequestInputMode::Incremental {
                 previous_response_id,
             } => {
-                if payload_previous_response_id != Some(previous_response_id.as_str()) {
-                    bail!(
-                        "incremental inference request {inference_call_id} recorded previous_response_id {previous_response_id}, \
-                         but payload previous_response_id was {payload_previous_response_id:?}"
-                    );
-                }
+                Self::ensure_incremental_previous_response_id_matches(
+                    inference_call_id,
+                    payload_previous_response_id,
+                    &previous_response_id,
+                )?;
                 // Streaming follow-up requests can send only the new input plus a
                 // `previous_response_id`. The trace model still exposes the full
                 // model-visible input, so rebuild the omitted prefix from the
                 // previous request and response before reducing this delta.
-                let previous_items = self
-                    .rollout
-                    .inference_calls
-                    .values()
-                    .find(|inference| {
-                        inference.thread_id == thread_id
-                            && inference.response_id.as_deref()
-                                == Some(previous_response_id.as_str())
-                    })
-                    .map(|inference| {
-                        let mut ids = inference.request_item_ids.clone();
-                        ids.extend(inference.response_item_ids.clone());
-                        ids
-                    });
-                let Some(mut item_ids) = previous_items else {
+                let Some(mut item_ids) =
+                    self.traced_response_snapshot(thread_id, &previous_response_id)
+                else {
                     bail!(
                         "incremental inference request {inference_call_id} referenced unknown previous_response_id {previous_response_id}"
                     );
@@ -123,6 +96,53 @@ impl TraceReducer {
                         start_index: item_ids.len(),
                         mode: ReconcileMode::AppendOnly,
                         snapshot_override: None,
+                    },
+                )?;
+                item_ids.extend(delta_item_ids);
+                item_ids
+            }
+            InferenceRequestInputMode::IncrementalWithUntracedPrefix {
+                previous_response_id,
+                prefix_payload,
+            } => {
+                Self::ensure_incremental_previous_response_id_matches(
+                    inference_call_id,
+                    payload_previous_response_id,
+                    &previous_response_id,
+                )?;
+                if self
+                    .traced_response_snapshot(thread_id, &previous_response_id)
+                    .is_some()
+                {
+                    bail!(
+                        "incremental inference request {inference_call_id} recorded untraced prefix for traced previous_response_id {previous_response_id}"
+                    );
+                }
+                let prefix_payload_json = self.read_payload_json(&prefix_payload)?;
+                let prefix_items =
+                    self.normalized_request_items(&prefix_payload, &prefix_payload_json)?;
+                let mut item_ids = self.reconcile_conversation_items(
+                    prefix_items,
+                    ReconcileItems {
+                        thread_id,
+                        codex_turn_id,
+                        wall_time_unix_ms,
+                        produced_by: Vec::new(),
+                        start_index: 0,
+                        mode: ReconcileMode::FullSnapshot,
+                        snapshot_override: None,
+                    },
+                )?;
+                let delta_item_ids = self.reconcile_conversation_items(
+                    items,
+                    ReconcileItems {
+                        thread_id,
+                        codex_turn_id,
+                        wall_time_unix_ms,
+                        produced_by: Vec::new(),
+                        start_index: item_ids.len(),
+                        mode: ReconcileMode::AppendOnly,
+                        snapshot_override: Some(&item_ids),
                     },
                 )?;
                 item_ids.extend(delta_item_ids);
@@ -150,6 +170,60 @@ impl TraceReducer {
         self.thread_conversation_snapshots
             .insert(thread_id.to_string(), request_item_ids.clone());
         Ok(request_item_ids)
+    }
+
+    fn normalized_request_items(
+        &self,
+        request_payload: &RawPayloadRef,
+        payload: &Value,
+    ) -> Result<Vec<NormalizedConversationItem>> {
+        let Some(input) = payload.get("input") else {
+            bail!(
+                "inference request payload {} did not contain input",
+                request_payload.raw_payload_id
+            );
+        };
+        let Some(request_items) = input.as_array() else {
+            bail!(
+                "inference request payload {} had non-array input",
+                request_payload.raw_payload_id
+            );
+        };
+
+        normalize::normalize_model_items(request_items, request_payload)
+    }
+
+    fn ensure_incremental_previous_response_id_matches(
+        inference_call_id: &InferenceCallId,
+        payload_previous_response_id: Option<&str>,
+        previous_response_id: &str,
+    ) -> Result<()> {
+        if payload_previous_response_id != Some(previous_response_id) {
+            bail!(
+                "incremental inference request {inference_call_id} recorded previous_response_id {previous_response_id}, \
+                 but payload previous_response_id was {payload_previous_response_id:?}"
+            );
+        }
+        Ok(())
+    }
+
+    fn traced_response_snapshot(
+        &self,
+        thread_id: &str,
+        previous_response_id: &str,
+    ) -> Option<Vec<String>> {
+        self.rollout
+            .inference_calls
+            .values()
+            .find(|inference| {
+                inference.thread_id == thread_id
+                    && inference.response_id.as_deref() == Some(previous_response_id)
+            })
+            .map(|inference| {
+                let mut ids = inference.request_item_ids.clone();
+                ids.extend(inference.response_item_ids.clone());
+                ids
+            })
     }
 
     /// Reduces an inference response payload into conversation items produced by the call.

--- a/codex-rs/rollout-trace/src/reducer/conversation_tests.rs
+++ b/codex-rs/rollout-trace/src/reducer/conversation_tests.rs
@@ -728,6 +728,55 @@ fn initial_untraced_websocket_prewarm_response_reduces_full_delta_input() -> any
 }
 
 #[test]
+fn incremental_request_with_untraced_prefix_reconstructs_missing_parent() -> anyhow::Result<()> {
+    let temp = TempDir::new()?;
+    let writer = create_started_writer(&temp)?;
+    start_turn(&writer, "turn-1")?;
+
+    let prefix = writer.write_json_payload(
+        RawPayloadKind::InferenceRequest,
+        &json!({
+            "input": [message("user", "prewarmed")]
+        }),
+    )?;
+    let request = writer.write_json_payload(
+        RawPayloadKind::InferenceRequest,
+        &json!({
+            "previous_response_id": "warm-1",
+            "input": []
+        }),
+    )?;
+    append_inference_start_for_thread_with_mode(
+        &writer,
+        "thread-root",
+        "turn-1",
+        "inference-1",
+        Some(
+            crate::InferenceRequestInputMode::IncrementalWithUntracedPrefix {
+                previous_response_id: "warm-1".to_string(),
+                prefix_payload: prefix,
+            },
+        ),
+        request,
+    )?;
+
+    let rollout = replay_bundle(temp.path())?;
+    let inference = &rollout.inference_calls["inference-1"];
+
+    assert_eq!(inference.request_item_ids.len(), 1);
+    assert_eq!(
+        rollout.conversation_items[&inference.request_item_ids[0]]
+            .body
+            .parts,
+        vec![ConversationPart::Text {
+            text: "prewarmed".to_string(),
+        }],
+    );
+
+    Ok(())
+}
+
+#[test]
 fn later_unknown_previous_response_id_is_reducer_error() -> anyhow::Result<()> {
     let temp = TempDir::new()?;
     let writer = create_started_writer(&temp)?;


### PR DESCRIPTION
## Summary

- record a trace-only omitted-prefix payload when websocket incremental input depends on an untraced previous response
- keep traced parents as normal incremental replay and empty startup prewarm follow-ups as full snapshots
- add reducer and websocket producer coverage for replaying a non-empty prewarm follow-up

## Test plan

- `cargo test -p codex-rollout-trace incremental_request_with_untraced_prefix_reconstructs_missing_parent`
- `cargo test -p codex-core responses_websocket_traces_untraced_prewarm_prefix_for_replay`
- `cargo test -p codex-rollout-trace`
- `just fix -p codex-rollout-trace`
- `just fix -p codex-core`
- `just fmt`

Note: `cargo test -p codex-core` currently aborts before completing on unrelated `agent::control::tests::resume_closed_child_reopens_open_descendants` stack overflow/SIGABRT.
