### PR TITLE
Fix forked agents inheriting parent startup context

### DIFF
--- a/codex-rs/core/src/agent/control.rs
+++ b/codex-rs/core/src/agent/control.rs
@@ -5,7 +5,6 @@ use crate::agent::role::DEFAULT_ROLE_NAME;
 use crate::agent::role::resolve_role_config;
 use crate::agent::status::is_final;
 use crate::codex_thread::ThreadConfigSnapshot;
-use crate::event_mapping::is_contextual_user_message_content;
 use crate::session::emit_subagent_session_started;
 use crate::session_prefix::format_subagent_context_line;
 use crate::session_prefix::format_subagent_notification_message;
@@ -19,14 +18,12 @@ use codex_protocol::SessionId;
 use codex_protocol::ThreadId;
 use codex_protocol::error::CodexErr;
 use codex_protocol::error::Result as CodexResult;
-use codex_protocol::models::ContentItem;
-use codex_protocol::models::MessagePhase;
+#[cfg(test)]
 use codex_protocol::models::ResponseItem;
 use codex_protocol::protocol::InitialHistory;
 use codex_protocol::protocol::InterAgentCommunication;
 use codex_protocol::protocol::Op;
 use codex_protocol::protocol::ResumedHistory;
-use codex_protocol::protocol::RolloutItem;
 use codex_protocol::protocol::SessionSource;
 use codex_protocol::protocol::SubAgentSource;
 use codex_protocol::protocol::ThreadSource;
@@ -95,56 +92,6 @@ fn agent_nickname_candidates(
         .into_iter()
         .map(ToOwned::to_owned)
         .collect()
-}
-
-fn keep_forked_response_item(item: &ResponseItem) -> bool {
-    match item {
-        ResponseItem::Message {
-            role,
-            content,
-            phase,
-            ..
-        } => match role.as_str() {
-            "system" => true,
-            "developer" => false,
-            "user" => !is_contextual_user_message_content(content),
-            "assistant" => *phase == Some(MessagePhase::FinalAnswer),
-            _ => false,
-        },
-        ResponseItem::Reasoning { .. }
-        | ResponseItem::LocalShellCall { .. }
-        | ResponseItem::FunctionCall { .. }
-        | ResponseItem::ToolSearchCall { .. }
-        | ResponseItem::FunctionCallOutput { .. }
-        | ResponseItem::CustomToolCall { .. }
-        | ResponseItem::CustomToolCallOutput { .. }
-        | ResponseItem::ToolSearchOutput { .. }
-        | ResponseItem::WebSearchCall { .. }
-        | ResponseItem::ImageGenerationCall { .. }
-        | ResponseItem::Compaction { .. }
-        | ResponseItem::CompactionTrigger
-        | ResponseItem::ContextCompaction { .. }
-        | ResponseItem::Other => false,
-    }
-}
-
-fn sanitize_forked_rollout_item(item: &mut RolloutItem) -> bool {
-    match item {
-        RolloutItem::ResponseItem(response_item) => keep_forked_response_item(response_item),
-        // A forked child gets its own runtime config, including spawned-agent
-        // instructions, so it must establish a fresh context diff baseline.
-        RolloutItem::TurnContext(_) => false,
-        RolloutItem::Compacted(compacted) => {
-            if compacted.replacement_history.is_none() {
-                compacted.message =
-                    "Previous compacted history omitted for forked agent.".to_string();
-            }
-            let replacement_history = compacted.replacement_history.get_or_insert_with(Vec::new);
-            replacement_history.retain(keep_forked_response_item);
-            true
-        }
-        RolloutItem::EventMsg(_) | RolloutItem::SessionMeta(_) => true,
-    }
 }
 
 /// Control-plane handle for multi-agent operations.
@@ -416,40 +363,6 @@ impl AgentControl {
             forked_rollout_items =
                 truncate_rollout_to_last_n_fork_turns(&forked_rollout_items, *last_n_turns);
         }
-        // MultiAgentV2 root/subagent usage hints are injected as standalone developer
-        // messages at thread start. When forking history, drop hints from the parent
-        // so the child gets a fresh hint that matches its own session source/config.
-        let multi_agent_v2_usage_hint_texts_to_filter: Vec<String> =
-            if let Some(parent_thread) = parent_thread.as_ref() {
-                parent_thread
-                    .codex
-                    .session
-                    .configured_multi_agent_v2_usage_hint_texts()
-                    .await
-            } else if config.features.enabled(Feature::MultiAgentV2) {
-                [
-                    config.multi_agent_v2.root_agent_usage_hint_text.clone(),
-                    config.multi_agent_v2.subagent_usage_hint_text.clone(),
-                ]
-                .into_iter()
-                .flatten()
-                .collect()
-            } else {
-                Vec::new()
-            };
-        forked_rollout_items.retain_mut(|item| {
-            if let RolloutItem::ResponseItem(ResponseItem::Message { role, content, .. }) = item
-                && role.as_str() == "developer"
-                && let [ContentItem::InputText { text }] = content.as_slice()
-                && multi_agent_v2_usage_hint_texts_to_filter
-                    .iter()
-                    .any(|usage_hint_text| usage_hint_text == text)
-            {
-                return false;
-            }
-
-            sanitize_forked_rollout_item(item)
-        });
 
         state
             .fork_thread_with_source(

--- a/codex-rs/core/src/agent/control.rs
+++ b/codex-rs/core/src/agent/control.rs
@@ -18,12 +18,12 @@ use codex_protocol::SessionId;
 use codex_protocol::ThreadId;
 use codex_protocol::error::CodexErr;
 use codex_protocol::error::Result as CodexResult;
-#[cfg(test)]
 use codex_protocol::models::ResponseItem;
 use codex_protocol::protocol::InitialHistory;
 use codex_protocol::protocol::InterAgentCommunication;
 use codex_protocol::protocol::Op;
 use codex_protocol::protocol::ResumedHistory;
+use codex_protocol::protocol::RolloutItem;
 use codex_protocol::protocol::SessionSource;
 use codex_protocol::protocol::SubAgentSource;
 use codex_protocol::protocol::ThreadSource;
@@ -316,11 +316,11 @@ impl AgentControl {
         inherited_shell_snapshot: Option<Arc<ShellSnapshot>>,
         inherited_exec_policy: Option<Arc<crate::exec_policy::ExecPolicyManager>>,
     ) -> CodexResult<crate::thread_manager::NewThread> {
-        if options.fork_parent_spawn_call_id.is_none() {
+        let Some(parent_spawn_call_id) = options.fork_parent_spawn_call_id.as_deref() else {
             return Err(CodexErr::Fatal(
                 "spawn_agent fork requires a parent spawn call id".to_string(),
             ));
-        }
+        };
         let Some(fork_mode) = options.fork_mode.as_ref() else {
             return Err(CodexErr::Fatal(
                 "spawn_agent fork requires a fork mode".to_string(),
@@ -363,6 +363,13 @@ impl AgentControl {
             forked_rollout_items =
                 truncate_rollout_to_last_n_fork_turns(&forked_rollout_items, *last_n_turns);
         }
+        forked_rollout_items.retain(|item| {
+            !matches!(
+                item,
+                RolloutItem::ResponseItem(ResponseItem::FunctionCall { name, call_id, .. })
+                    if name == "spawn_agent" && call_id == parent_spawn_call_id
+            )
+        });
 
         state
             .fork_thread_with_source(

--- a/codex-rs/core/src/agent/control.rs
+++ b/codex-rs/core/src/agent/control.rs
@@ -5,6 +5,7 @@ use crate::agent::role::DEFAULT_ROLE_NAME;
 use crate::agent::role::resolve_role_config;
 use crate::agent::status::is_final;
 use crate::codex_thread::ThreadConfigSnapshot;
+use crate::event_mapping::is_contextual_user_message_content;
 use crate::session::emit_subagent_session_started;
 use crate::session_prefix::format_subagent_context_line;
 use crate::session_prefix::format_subagent_notification_message;
@@ -96,34 +97,53 @@ fn agent_nickname_candidates(
         .collect()
 }
 
-fn keep_forked_rollout_item(item: &RolloutItem) -> bool {
+fn keep_forked_response_item(item: &ResponseItem) -> bool {
     match item {
-        RolloutItem::ResponseItem(ResponseItem::Message { role, phase, .. }) => match role.as_str()
-        {
-            "system" | "developer" | "user" => true,
+        ResponseItem::Message {
+            role,
+            content,
+            phase,
+            ..
+        } => match role.as_str() {
+            "system" => true,
+            "developer" => false,
+            "user" => !is_contextual_user_message_content(content),
             "assistant" => *phase == Some(MessagePhase::FinalAnswer),
             _ => false,
         },
-        RolloutItem::ResponseItem(
-            ResponseItem::Reasoning { .. }
-            | ResponseItem::LocalShellCall { .. }
-            | ResponseItem::FunctionCall { .. }
-            | ResponseItem::ToolSearchCall { .. }
-            | ResponseItem::FunctionCallOutput { .. }
-            | ResponseItem::CustomToolCall { .. }
-            | ResponseItem::CustomToolCallOutput { .. }
-            | ResponseItem::ToolSearchOutput { .. }
-            | ResponseItem::WebSearchCall { .. }
-            | ResponseItem::ImageGenerationCall { .. }
-            | ResponseItem::Compaction { .. }
-            | ResponseItem::CompactionTrigger
-            | ResponseItem::ContextCompaction { .. }
-            | ResponseItem::Other,
-        ) => false,
+        ResponseItem::Reasoning { .. }
+        | ResponseItem::LocalShellCall { .. }
+        | ResponseItem::FunctionCall { .. }
+        | ResponseItem::ToolSearchCall { .. }
+        | ResponseItem::FunctionCallOutput { .. }
+        | ResponseItem::CustomToolCall { .. }
+        | ResponseItem::CustomToolCallOutput { .. }
+        | ResponseItem::ToolSearchOutput { .. }
+        | ResponseItem::WebSearchCall { .. }
+        | ResponseItem::ImageGenerationCall { .. }
+        | ResponseItem::Compaction { .. }
+        | ResponseItem::CompactionTrigger
+        | ResponseItem::ContextCompaction { .. }
+        | ResponseItem::Other => false,
+    }
+}
+
+fn sanitize_forked_rollout_item(item: &mut RolloutItem) -> bool {
+    match item {
+        RolloutItem::ResponseItem(response_item) => keep_forked_response_item(response_item),
         // A forked child gets its own runtime config, including spawned-agent
         // instructions, so it must establish a fresh context diff baseline.
         RolloutItem::TurnContext(_) => false,
-        RolloutItem::Compacted(_) | RolloutItem::EventMsg(_) | RolloutItem::SessionMeta(_) => true,
+        RolloutItem::Compacted(compacted) => {
+            if compacted.replacement_history.is_none() {
+                compacted.message =
+                    "Previous compacted history omitted for forked agent.".to_string();
+            }
+            let replacement_history = compacted.replacement_history.get_or_insert_with(Vec::new);
+            replacement_history.retain(keep_forked_response_item);
+            true
+        }
+        RolloutItem::EventMsg(_) | RolloutItem::SessionMeta(_) => true,
     }
 }
 
@@ -417,9 +437,9 @@ impl AgentControl {
             } else {
                 Vec::new()
             };
-        forked_rollout_items.retain(|item| {
+        forked_rollout_items.retain_mut(|item| {
             if let RolloutItem::ResponseItem(ResponseItem::Message { role, content, .. }) = item
-                && role == "developer"
+                && role.as_str() == "developer"
                 && let [ContentItem::InputText { text }] = content.as_slice()
                 && multi_agent_v2_usage_hint_texts_to_filter
                     .iter()
@@ -428,7 +448,7 @@ impl AgentControl {
                 return false;
             }
 
-            keep_forked_rollout_item(item)
+            sanitize_forked_rollout_item(item)
         });
 
         state

--- a/codex-rs/core/src/agent/control_tests.rs
+++ b/codex-rs/core/src/agent/control_tests.rs
@@ -17,10 +17,10 @@ use codex_protocol::config_types::ModeKind;
 use codex_protocol::models::ContentItem;
 use codex_protocol::models::MessagePhase;
 use codex_protocol::models::ResponseItem;
-use codex_protocol::protocol::CompactedItem;
 use codex_protocol::protocol::ErrorEvent;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::InterAgentCommunication;
+use codex_protocol::protocol::RolloutItem;
 use codex_protocol::protocol::SessionSource;
 use codex_protocol::protocol::SubAgentSource;
 use codex_protocol::protocol::TurnAbortReason;
@@ -104,61 +104,6 @@ fn spawn_agent_call(call_id: &str) -> ResponseItem {
         arguments: "{}".to_string(),
         call_id: call_id.to_string(),
     }
-}
-
-#[test]
-fn sanitize_forked_rollout_item_filters_compaction_replacement_history() {
-    let contextual_user_message = <SubagentNotification as ContextualUserFragment>::into(
-        SubagentNotification::new("/root/worker", AgentStatus::Running),
-    );
-    let mut compacted_item = RolloutItem::Compacted(CompactedItem {
-        message: "summary".to_string(),
-        replacement_history: Some(vec![
-            developer_message("parent setup"),
-            contextual_user_message,
-            user_message("real parent prompt"),
-            assistant_message("draft response", /*phase*/ None),
-            assistant_message("final response", Some(MessagePhase::FinalAnswer)),
-        ]),
-    });
-
-    assert!(sanitize_forked_rollout_item(&mut compacted_item));
-    let RolloutItem::Compacted(CompactedItem {
-        replacement_history,
-        ..
-    }) = compacted_item
-    else {
-        panic!("expected compacted rollout item");
-    };
-    assert_eq!(
-        replacement_history,
-        Some(vec![
-            user_message("real parent prompt"),
-            assistant_message("final response", Some(MessagePhase::FinalAnswer)),
-        ])
-    );
-}
-
-#[test]
-fn sanitize_forked_rollout_item_turns_legacy_compaction_into_empty_checkpoint() {
-    let mut compacted_item = RolloutItem::Compacted(CompactedItem {
-        message: "summary with parent setup".to_string(),
-        replacement_history: None,
-    });
-
-    assert!(sanitize_forked_rollout_item(&mut compacted_item));
-    let RolloutItem::Compacted(CompactedItem {
-        message,
-        replacement_history,
-    }) = compacted_item
-    else {
-        panic!("expected compacted rollout item");
-    };
-    assert_eq!(
-        message,
-        "Previous compacted history omitted for forked agent."
-    );
-    assert_eq!(replacement_history, Some(Vec::new()));
 }
 
 struct AgentControlHarness {
@@ -678,7 +623,7 @@ async fn spawn_agent_creates_thread_and_sends_prompt() {
 }
 
 #[tokio::test]
-async fn spawn_agent_can_fork_parent_thread_history_with_sanitized_items() {
+async fn spawn_agent_can_fork_parent_thread_history_without_rewriting_rollout() {
     let harness = AgentControlHarness::new().await;
     let mut parent_config = harness.config.clone();
     let _ = parent_config.features.enable(Feature::MultiAgentV2);
@@ -703,6 +648,12 @@ async fn spawn_agent_can_fork_parent_thread_history_with_sanitized_items() {
         .inject_user_message_without_turn("parent seed context".to_string())
         .await;
     let turn_context = parent_thread.codex.session.new_default_turn().await;
+    let parent_turn_context_item = turn_context.to_turn_context_item();
+    parent_thread
+        .codex
+        .session
+        .persist_rollout_items(&[RolloutItem::TurnContext(parent_turn_context_item.clone())])
+        .await;
     let parent_spawn_call_id = "spawn-call-history".to_string();
     let trigger_message = InterAgentCommunication::new(
         AgentPath::root(),
@@ -711,32 +662,31 @@ async fn spawn_agent_can_fork_parent_thread_history_with_sanitized_items() {
         "parent trigger message".to_string(),
         /*trigger_turn*/ true,
     );
+    let trigger_item = trigger_message.to_response_input_item().into();
+    let parent_items = vec![
+        developer_message("Parent root guidance."),
+        developer_message("Parent subagent guidance."),
+        developer_message("Parent setup context."),
+        <SubagentNotification as ContextualUserFragment>::into(SubagentNotification::new(
+            "/root/worker",
+            AgentStatus::Running,
+        )),
+        assistant_message("parent commentary", Some(MessagePhase::Commentary)),
+        assistant_message("parent final answer", Some(MessagePhase::FinalAnswer)),
+        assistant_message("parent unknown phase", /*phase*/ None),
+        ResponseItem::Reasoning {
+            id: String::new(),
+            summary: Vec::new(),
+            content: None,
+            encrypted_content: None,
+        },
+        trigger_item,
+        spawn_agent_call(&parent_spawn_call_id),
+    ];
     parent_thread
         .codex
         .session
-        .record_conversation_items(
-            turn_context.as_ref(),
-            &[
-                developer_message("Parent root guidance."),
-                developer_message("Parent subagent guidance."),
-                developer_message("Parent setup context."),
-                <SubagentNotification as ContextualUserFragment>::into(SubagentNotification::new(
-                    "/root/worker",
-                    AgentStatus::Running,
-                )),
-                assistant_message("parent commentary", Some(MessagePhase::Commentary)),
-                assistant_message("parent final answer", Some(MessagePhase::FinalAnswer)),
-                assistant_message("parent unknown phase", /*phase*/ None),
-                ResponseItem::Reasoning {
-                    id: "parent-reasoning".to_string(),
-                    summary: Vec::new(),
-                    content: None,
-                    encrypted_content: None,
-                },
-                trigger_message.to_response_input_item().into(),
-                spawn_agent_call(&parent_spawn_call_id),
-            ],
-        )
+        .record_conversation_items(turn_context.as_ref(), &parent_items)
         .await;
     parent_thread
         .codex
@@ -779,14 +729,19 @@ async fn spawn_agent_can_fork_parent_thread_history_with_sanitized_items() {
         .expect("child thread should be registered");
     assert_ne!(child_thread_id, parent_thread_id);
     let history = child_thread.codex.session.clone_history().await;
-    let expected_history = [
-        user_message("parent seed context"),
-        assistant_message("parent final answer", Some(MessagePhase::FinalAnswer)),
-    ];
+    let mut expected_history = vec![user_message("parent seed context")];
+    expected_history.extend(parent_items);
     assert_eq!(
         history.raw_items(),
-        &expected_history,
-        "forked child history should keep only parent user messages and assistant final answers"
+        expected_history.as_slice(),
+        "forked child history should replay the parent rollout without rewriting model-visible items"
+    );
+    assert_eq!(
+        serde_json::to_value(child_thread.codex.session.reference_context_item().await)
+            .expect("serialize forked child reference context item"),
+        serde_json::to_value(Some(parent_turn_context_item))
+            .expect("serialize parent reference context item"),
+        "forked child should keep the parent context baseline instead of reinjecting startup context"
     );
 
     let expected = (
@@ -807,223 +762,6 @@ async fn spawn_agent_can_fork_parent_thread_history_with_sanitized_items() {
         .into_iter()
         .find(|entry| *entry == expected);
     assert_eq!(captured, Some(expected));
-
-    let _ = harness
-        .control
-        .shutdown_live_agent(child_thread_id)
-        .await
-        .expect("child shutdown should submit");
-    let _ = parent_thread
-        .submit(Op::Shutdown {})
-        .await
-        .expect("parent shutdown should submit");
-}
-
-#[tokio::test]
-async fn spawn_agent_fork_sanitizes_modern_compaction_replacement_history_and_suffix() {
-    let harness = AgentControlHarness::new().await;
-    let (parent_thread_id, parent_thread) = harness.start_thread().await;
-    parent_thread
-        .inject_user_message_without_turn("ignored pre-compaction prompt".to_string())
-        .await;
-    parent_thread
-        .codex
-        .session
-        .persist_rollout_items(&[RolloutItem::Compacted(CompactedItem {
-            message: "summary".to_string(),
-            replacement_history: Some(vec![
-                developer_message("compacted parent setup"),
-                <SubagentNotification as ContextualUserFragment>::into(SubagentNotification::new(
-                    "/root/worker",
-                    AgentStatus::Running,
-                )),
-                user_message("compacted real prompt"),
-                assistant_message("compacted draft", /*phase*/ None),
-                assistant_message("compacted final", Some(MessagePhase::FinalAnswer)),
-            ]),
-        })])
-        .await;
-    parent_thread
-        .inject_user_message_without_turn("suffix prompt".to_string())
-        .await;
-
-    let turn_context = parent_thread.codex.session.new_default_turn().await;
-    let parent_spawn_call_id = "spawn-call-modern-compaction".to_string();
-    parent_thread
-        .codex
-        .session
-        .record_conversation_items(
-            turn_context.as_ref(),
-            &[
-                developer_message("suffix parent setup"),
-                <SubagentNotification as ContextualUserFragment>::into(SubagentNotification::new(
-                    "/root/worker",
-                    AgentStatus::Running,
-                )),
-                assistant_message("suffix final", Some(MessagePhase::FinalAnswer)),
-                spawn_agent_call(&parent_spawn_call_id),
-            ],
-        )
-        .await;
-    parent_thread
-        .codex
-        .session
-        .ensure_rollout_materialized()
-        .await;
-    parent_thread
-        .codex
-        .session
-        .flush_rollout()
-        .await
-        .expect("parent rollout should flush");
-
-    let child_thread_id = harness
-        .control
-        .spawn_agent_with_metadata(
-            harness.config.clone(),
-            text_input("child task"),
-            Some(SessionSource::SubAgent(SubAgentSource::ThreadSpawn {
-                parent_thread_id,
-                depth: 1,
-                agent_path: None,
-                agent_nickname: None,
-                agent_role: None,
-            })),
-            SpawnAgentOptions {
-                fork_parent_spawn_call_id: Some(parent_spawn_call_id.clone()),
-                fork_mode: Some(SpawnAgentForkMode::FullHistory),
-                ..Default::default()
-            },
-        )
-        .await
-        .expect("forked spawn should succeed")
-        .thread_id;
-
-    let child_thread = harness
-        .manager
-        .get_thread(child_thread_id)
-        .await
-        .expect("child thread should be registered");
-    let history = child_thread.codex.session.clone_history().await;
-    assert_eq!(
-        history.raw_items(),
-        &[
-            user_message("compacted real prompt"),
-            assistant_message("compacted final", Some(MessagePhase::FinalAnswer)),
-            user_message("suffix prompt"),
-            assistant_message("suffix final", Some(MessagePhase::FinalAnswer)),
-        ],
-        "forked child history should use sanitized replacement history plus sanitized suffix"
-    );
-
-    let _ = harness
-        .control
-        .shutdown_live_agent(child_thread_id)
-        .await
-        .expect("child shutdown should submit");
-    let _ = parent_thread
-        .submit(Op::Shutdown {})
-        .await
-        .expect("parent shutdown should submit");
-}
-
-#[tokio::test]
-async fn spawn_agent_fork_legacy_compaction_cuts_off_unsafe_prefix_without_summary() {
-    let harness = AgentControlHarness::new().await;
-    let (parent_thread_id, parent_thread) = harness.start_thread().await;
-    parent_thread
-        .inject_user_message_without_turn("pre-compaction prompt".to_string())
-        .await;
-    parent_thread
-        .codex
-        .session
-        .persist_rollout_items(&[RolloutItem::Compacted(CompactedItem {
-            message: "summary with parent setup".to_string(),
-            replacement_history: None,
-        })])
-        .await;
-    parent_thread
-        .inject_user_message_without_turn("post-compaction prompt".to_string())
-        .await;
-
-    let turn_context = parent_thread.codex.session.new_default_turn().await;
-    let parent_spawn_call_id = "spawn-call-legacy-compaction".to_string();
-    parent_thread
-        .codex
-        .session
-        .record_conversation_items(
-            turn_context.as_ref(),
-            &[
-                developer_message("post-compaction parent setup"),
-                <SubagentNotification as ContextualUserFragment>::into(SubagentNotification::new(
-                    "/root/worker",
-                    AgentStatus::Running,
-                )),
-                assistant_message("post-compaction final", Some(MessagePhase::FinalAnswer)),
-                spawn_agent_call(&parent_spawn_call_id),
-            ],
-        )
-        .await;
-    parent_thread
-        .codex
-        .session
-        .ensure_rollout_materialized()
-        .await;
-    parent_thread
-        .codex
-        .session
-        .flush_rollout()
-        .await
-        .expect("parent rollout should flush");
-
-    let child_thread_id = harness
-        .control
-        .spawn_agent_with_metadata(
-            harness.config.clone(),
-            text_input("child task"),
-            Some(SessionSource::SubAgent(SubAgentSource::ThreadSpawn {
-                parent_thread_id,
-                depth: 1,
-                agent_path: None,
-                agent_nickname: None,
-                agent_role: None,
-            })),
-            SpawnAgentOptions {
-                fork_parent_spawn_call_id: Some(parent_spawn_call_id.clone()),
-                fork_mode: Some(SpawnAgentForkMode::FullHistory),
-                ..Default::default()
-            },
-        )
-        .await
-        .expect("forked spawn should succeed")
-        .thread_id;
-
-    let child_thread = harness
-        .manager
-        .get_thread(child_thread_id)
-        .await
-        .expect("child thread should be registered");
-    let history = child_thread.codex.session.clone_history().await;
-    assert!(
-        !history_contains_text(history.raw_items(), "pre-compaction prompt"),
-        "legacy compaction should cut off the unsafe pre-compaction prefix"
-    );
-    assert!(
-        !history_contains_text(history.raw_items(), "summary with parent setup"),
-        "legacy compaction summary should not become child model-visible history"
-    );
-    assert!(
-        !history_contains_text(history.raw_items(), "post-compaction parent setup"),
-        "parent developer setup after compaction should be dropped"
-    );
-    assert!(
-        history_contains_text(history.raw_items(), "post-compaction prompt"),
-        "real user transcript after legacy compaction should survive"
-    );
-    assert!(
-        history_contains_text(history.raw_items(), "post-compaction final"),
-        "assistant final answer after legacy compaction should survive"
-    );
 
     let _ = harness
         .control
@@ -1202,8 +940,8 @@ async fn spawn_agent_fork_last_n_turns_keeps_only_recent_turns() {
         "forked child history should drop queued inter-agent messages outside the requested last-N turn window"
     );
     assert!(
-        !history_contains_text(history.raw_items(), "triggered context"),
-        "forked child history should filter assistant inter-agent messages even when they fall inside the requested last-N turn window"
+        history_contains_text(history.raw_items(), "triggered context"),
+        "forked child history should preserve rollout items inside the requested last-N turn window"
     );
     assert!(
         history_contains_text(history.raw_items(), "current parent task"),

--- a/codex-rs/core/src/agent/control_tests.rs
+++ b/codex-rs/core/src/agent/control_tests.rs
@@ -177,6 +177,15 @@ fn history_contains_text(history_items: &[ResponseItem], needle: &str) -> bool {
     })
 }
 
+fn history_contains_function_call(history_items: &[ResponseItem], call_id: &str) -> bool {
+    history_items.iter().any(|item| {
+        matches!(
+            item,
+            ResponseItem::FunctionCall { call_id: item_call_id, .. } if item_call_id == call_id
+        )
+    })
+}
+
 fn history_contains_assistant_inter_agent_communication(
     history_items: &[ResponseItem],
     expected: &InterAgentCommunication,
@@ -623,7 +632,7 @@ async fn spawn_agent_creates_thread_and_sends_prompt() {
 }
 
 #[tokio::test]
-async fn spawn_agent_can_fork_parent_thread_history_without_rewriting_rollout() {
+async fn spawn_agent_can_fork_parent_thread_history_without_replaying_parent_spawn_call() {
     let harness = AgentControlHarness::new().await;
     let mut parent_config = harness.config.clone();
     let _ = parent_config.features.enable(Feature::MultiAgentV2);
@@ -730,11 +739,16 @@ async fn spawn_agent_can_fork_parent_thread_history_without_rewriting_rollout() 
     assert_ne!(child_thread_id, parent_thread_id);
     let history = child_thread.codex.session.clone_history().await;
     let mut expected_history = vec![user_message("parent seed context")];
-    expected_history.extend(parent_items);
+    let mut expected_parent_items = parent_items;
+    assert_eq!(
+        expected_parent_items.pop(),
+        Some(spawn_agent_call(&parent_spawn_call_id))
+    );
+    expected_history.extend(expected_parent_items);
     assert_eq!(
         history.raw_items(),
         expected_history.as_slice(),
-        "forked child history should replay the parent rollout without rewriting model-visible items"
+        "forked child history should replay the parent rollout except for the trigger spawn call"
     );
     assert_eq!(
         serde_json::to_value(child_thread.codex.session.reference_context_item().await)
@@ -823,6 +837,10 @@ async fn spawn_agent_fork_flushes_parent_rollout_before_loading_history() {
     assert!(
         history_contains_text(history.raw_items(), "unflushed final answer"),
         "forked child history should include unflushed assistant final answers after flushing the parent rollout"
+    );
+    assert!(
+        !history_contains_function_call(history.raw_items(), &parent_spawn_call_id),
+        "forked child history should drop the trigger spawn call after flushing the parent rollout"
     );
 
     let _ = harness
@@ -946,6 +964,10 @@ async fn spawn_agent_fork_last_n_turns_keeps_only_recent_turns() {
     assert!(
         history_contains_text(history.raw_items(), "current parent task"),
         "forked child history should keep the parent user message from the requested last-N turn window"
+    );
+    assert!(
+        !history_contains_function_call(history.raw_items(), &parent_spawn_call_id),
+        "forked child history should drop the trigger spawn call from the requested last-N turn window"
     );
 
     let _ = harness

--- a/codex-rs/core/src/agent/control_tests.rs
+++ b/codex-rs/core/src/agent/control_tests.rs
@@ -17,6 +17,7 @@ use codex_protocol::config_types::ModeKind;
 use codex_protocol::models::ContentItem;
 use codex_protocol::models::MessagePhase;
 use codex_protocol::models::ResponseItem;
+use codex_protocol::protocol::CompactedItem;
 use codex_protocol::protocol::ErrorEvent;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::InterAgentCommunication;
@@ -62,6 +63,28 @@ fn text_input(text: &str) -> Op {
     .into()
 }
 
+fn user_message(text: &str) -> ResponseItem {
+    ResponseItem::Message {
+        id: None,
+        role: "user".to_string(),
+        content: vec![ContentItem::InputText {
+            text: text.to_string(),
+        }],
+        phase: None,
+    }
+}
+
+fn developer_message(text: &str) -> ResponseItem {
+    ResponseItem::Message {
+        id: None,
+        role: "developer".to_string(),
+        content: vec![ContentItem::InputText {
+            text: text.to_string(),
+        }],
+        phase: None,
+    }
+}
+
 fn assistant_message(text: &str, phase: Option<MessagePhase>) -> ResponseItem {
     ResponseItem::Message {
         id: None,
@@ -81,6 +104,61 @@ fn spawn_agent_call(call_id: &str) -> ResponseItem {
         arguments: "{}".to_string(),
         call_id: call_id.to_string(),
     }
+}
+
+#[test]
+fn sanitize_forked_rollout_item_filters_compaction_replacement_history() {
+    let contextual_user_message = <SubagentNotification as ContextualUserFragment>::into(
+        SubagentNotification::new("/root/worker", AgentStatus::Running),
+    );
+    let mut compacted_item = RolloutItem::Compacted(CompactedItem {
+        message: "summary".to_string(),
+        replacement_history: Some(vec![
+            developer_message("parent setup"),
+            contextual_user_message,
+            user_message("real parent prompt"),
+            assistant_message("draft response", /*phase*/ None),
+            assistant_message("final response", Some(MessagePhase::FinalAnswer)),
+        ]),
+    });
+
+    assert!(sanitize_forked_rollout_item(&mut compacted_item));
+    let RolloutItem::Compacted(CompactedItem {
+        replacement_history,
+        ..
+    }) = compacted_item
+    else {
+        panic!("expected compacted rollout item");
+    };
+    assert_eq!(
+        replacement_history,
+        Some(vec![
+            user_message("real parent prompt"),
+            assistant_message("final response", Some(MessagePhase::FinalAnswer)),
+        ])
+    );
+}
+
+#[test]
+fn sanitize_forked_rollout_item_turns_legacy_compaction_into_empty_checkpoint() {
+    let mut compacted_item = RolloutItem::Compacted(CompactedItem {
+        message: "summary with parent setup".to_string(),
+        replacement_history: None,
+    });
+
+    assert!(sanitize_forked_rollout_item(&mut compacted_item));
+    let RolloutItem::Compacted(CompactedItem {
+        message,
+        replacement_history,
+    }) = compacted_item
+    else {
+        panic!("expected compacted rollout item");
+    };
+    assert_eq!(
+        message,
+        "Previous compacted history omitted for forked agent."
+    );
+    assert_eq!(replacement_history, Some(Vec::new()));
 }
 
 struct AgentControlHarness {
@@ -639,22 +717,13 @@ async fn spawn_agent_can_fork_parent_thread_history_with_sanitized_items() {
         .record_conversation_items(
             turn_context.as_ref(),
             &[
-                ResponseItem::Message {
-                    id: None,
-                    role: "developer".to_string(),
-                    content: vec![ContentItem::InputText {
-                        text: "Parent root guidance.".to_string(),
-                    }],
-                    phase: None,
-                },
-                ResponseItem::Message {
-                    id: None,
-                    role: "developer".to_string(),
-                    content: vec![ContentItem::InputText {
-                        text: "Parent subagent guidance.".to_string(),
-                    }],
-                    phase: None,
-                },
+                developer_message("Parent root guidance."),
+                developer_message("Parent subagent guidance."),
+                developer_message("Parent setup context."),
+                <SubagentNotification as ContextualUserFragment>::into(SubagentNotification::new(
+                    "/root/worker",
+                    AgentStatus::Running,
+                )),
                 assistant_message("parent commentary", Some(MessagePhase::Commentary)),
                 assistant_message("parent final answer", Some(MessagePhase::FinalAnswer)),
                 assistant_message("parent unknown phase", /*phase*/ None),
@@ -711,14 +780,7 @@ async fn spawn_agent_can_fork_parent_thread_history_with_sanitized_items() {
     assert_ne!(child_thread_id, parent_thread_id);
     let history = child_thread.codex.session.clone_history().await;
     let expected_history = [
-        ResponseItem::Message {
-            id: None,
-            role: "user".to_string(),
-            content: vec![ContentItem::InputText {
-                text: "parent seed context".to_string(),
-            }],
-            phase: None,
-        },
+        user_message("parent seed context"),
         assistant_message("parent final answer", Some(MessagePhase::FinalAnswer)),
     ];
     assert_eq!(
@@ -745,6 +807,223 @@ async fn spawn_agent_can_fork_parent_thread_history_with_sanitized_items() {
         .into_iter()
         .find(|entry| *entry == expected);
     assert_eq!(captured, Some(expected));
+
+    let _ = harness
+        .control
+        .shutdown_live_agent(child_thread_id)
+        .await
+        .expect("child shutdown should submit");
+    let _ = parent_thread
+        .submit(Op::Shutdown {})
+        .await
+        .expect("parent shutdown should submit");
+}
+
+#[tokio::test]
+async fn spawn_agent_fork_sanitizes_modern_compaction_replacement_history_and_suffix() {
+    let harness = AgentControlHarness::new().await;
+    let (parent_thread_id, parent_thread) = harness.start_thread().await;
+    parent_thread
+        .inject_user_message_without_turn("ignored pre-compaction prompt".to_string())
+        .await;
+    parent_thread
+        .codex
+        .session
+        .persist_rollout_items(&[RolloutItem::Compacted(CompactedItem {
+            message: "summary".to_string(),
+            replacement_history: Some(vec![
+                developer_message("compacted parent setup"),
+                <SubagentNotification as ContextualUserFragment>::into(SubagentNotification::new(
+                    "/root/worker",
+                    AgentStatus::Running,
+                )),
+                user_message("compacted real prompt"),
+                assistant_message("compacted draft", /*phase*/ None),
+                assistant_message("compacted final", Some(MessagePhase::FinalAnswer)),
+            ]),
+        })])
+        .await;
+    parent_thread
+        .inject_user_message_without_turn("suffix prompt".to_string())
+        .await;
+
+    let turn_context = parent_thread.codex.session.new_default_turn().await;
+    let parent_spawn_call_id = "spawn-call-modern-compaction".to_string();
+    parent_thread
+        .codex
+        .session
+        .record_conversation_items(
+            turn_context.as_ref(),
+            &[
+                developer_message("suffix parent setup"),
+                <SubagentNotification as ContextualUserFragment>::into(SubagentNotification::new(
+                    "/root/worker",
+                    AgentStatus::Running,
+                )),
+                assistant_message("suffix final", Some(MessagePhase::FinalAnswer)),
+                spawn_agent_call(&parent_spawn_call_id),
+            ],
+        )
+        .await;
+    parent_thread
+        .codex
+        .session
+        .ensure_rollout_materialized()
+        .await;
+    parent_thread
+        .codex
+        .session
+        .flush_rollout()
+        .await
+        .expect("parent rollout should flush");
+
+    let child_thread_id = harness
+        .control
+        .spawn_agent_with_metadata(
+            harness.config.clone(),
+            text_input("child task"),
+            Some(SessionSource::SubAgent(SubAgentSource::ThreadSpawn {
+                parent_thread_id,
+                depth: 1,
+                agent_path: None,
+                agent_nickname: None,
+                agent_role: None,
+            })),
+            SpawnAgentOptions {
+                fork_parent_spawn_call_id: Some(parent_spawn_call_id.clone()),
+                fork_mode: Some(SpawnAgentForkMode::FullHistory),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("forked spawn should succeed")
+        .thread_id;
+
+    let child_thread = harness
+        .manager
+        .get_thread(child_thread_id)
+        .await
+        .expect("child thread should be registered");
+    let history = child_thread.codex.session.clone_history().await;
+    assert_eq!(
+        history.raw_items(),
+        &[
+            user_message("compacted real prompt"),
+            assistant_message("compacted final", Some(MessagePhase::FinalAnswer)),
+            user_message("suffix prompt"),
+            assistant_message("suffix final", Some(MessagePhase::FinalAnswer)),
+        ],
+        "forked child history should use sanitized replacement history plus sanitized suffix"
+    );
+
+    let _ = harness
+        .control
+        .shutdown_live_agent(child_thread_id)
+        .await
+        .expect("child shutdown should submit");
+    let _ = parent_thread
+        .submit(Op::Shutdown {})
+        .await
+        .expect("parent shutdown should submit");
+}
+
+#[tokio::test]
+async fn spawn_agent_fork_legacy_compaction_cuts_off_unsafe_prefix_without_summary() {
+    let harness = AgentControlHarness::new().await;
+    let (parent_thread_id, parent_thread) = harness.start_thread().await;
+    parent_thread
+        .inject_user_message_without_turn("pre-compaction prompt".to_string())
+        .await;
+    parent_thread
+        .codex
+        .session
+        .persist_rollout_items(&[RolloutItem::Compacted(CompactedItem {
+            message: "summary with parent setup".to_string(),
+            replacement_history: None,
+        })])
+        .await;
+    parent_thread
+        .inject_user_message_without_turn("post-compaction prompt".to_string())
+        .await;
+
+    let turn_context = parent_thread.codex.session.new_default_turn().await;
+    let parent_spawn_call_id = "spawn-call-legacy-compaction".to_string();
+    parent_thread
+        .codex
+        .session
+        .record_conversation_items(
+            turn_context.as_ref(),
+            &[
+                developer_message("post-compaction parent setup"),
+                <SubagentNotification as ContextualUserFragment>::into(SubagentNotification::new(
+                    "/root/worker",
+                    AgentStatus::Running,
+                )),
+                assistant_message("post-compaction final", Some(MessagePhase::FinalAnswer)),
+                spawn_agent_call(&parent_spawn_call_id),
+            ],
+        )
+        .await;
+    parent_thread
+        .codex
+        .session
+        .ensure_rollout_materialized()
+        .await;
+    parent_thread
+        .codex
+        .session
+        .flush_rollout()
+        .await
+        .expect("parent rollout should flush");
+
+    let child_thread_id = harness
+        .control
+        .spawn_agent_with_metadata(
+            harness.config.clone(),
+            text_input("child task"),
+            Some(SessionSource::SubAgent(SubAgentSource::ThreadSpawn {
+                parent_thread_id,
+                depth: 1,
+                agent_path: None,
+                agent_nickname: None,
+                agent_role: None,
+            })),
+            SpawnAgentOptions {
+                fork_parent_spawn_call_id: Some(parent_spawn_call_id.clone()),
+                fork_mode: Some(SpawnAgentForkMode::FullHistory),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("forked spawn should succeed")
+        .thread_id;
+
+    let child_thread = harness
+        .manager
+        .get_thread(child_thread_id)
+        .await
+        .expect("child thread should be registered");
+    let history = child_thread.codex.session.clone_history().await;
+    assert!(
+        !history_contains_text(history.raw_items(), "pre-compaction prompt"),
+        "legacy compaction should cut off the unsafe pre-compaction prefix"
+    );
+    assert!(
+        !history_contains_text(history.raw_items(), "summary with parent setup"),
+        "legacy compaction summary should not become child model-visible history"
+    );
+    assert!(
+        !history_contains_text(history.raw_items(), "post-compaction parent setup"),
+        "parent developer setup after compaction should be dropped"
+    );
+    assert!(
+        history_contains_text(history.raw_items(), "post-compaction prompt"),
+        "real user transcript after legacy compaction should survive"
+    );
+    assert!(
+        history_contains_text(history.raw_items(), "post-compaction final"),
+        "assistant final answer after legacy compaction should survive"
+    );
 
     let _ = harness
         .control

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -888,22 +888,6 @@ impl Session {
         }
     }
 
-    pub(crate) async fn configured_multi_agent_v2_usage_hint_texts(&self) -> Vec<String> {
-        if !self.features.enabled(Feature::MultiAgentV2) {
-            return Vec::new();
-        }
-
-        let state = self.state.lock().await;
-        let config = &state.session_configuration.original_config_do_not_use;
-        [
-            config.multi_agent_v2.root_agent_usage_hint_text.clone(),
-            config.multi_agent_v2.subagent_usage_hint_text.clone(),
-        ]
-        .into_iter()
-        .flatten()
-        .collect()
-    }
-
     fn managed_network_proxy_active_for_permission_profile(
         permission_profile: &PermissionProfile,
     ) -> bool {

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -22,7 +22,6 @@ use codex_config::loader::project_trust_key;
 use codex_config::types::ToolSuggestDisabledTool;
 
 use codex_features::Feature;
-use codex_features::Features;
 use codex_login::CodexAuth;
 use codex_model_provider_info::ModelProviderInfo;
 use codex_models_manager::bundled_models_response;
@@ -6862,40 +6861,6 @@ async fn build_initial_context_omits_multi_agent_v2_usage_hints_when_feature_dis
         }),
         "did not expect multi-agent v2 usage hint developer messages, got {developer_messages:?}"
     );
-}
-
-#[tokio::test]
-async fn configured_multi_agent_v2_usage_hint_texts_use_effective_enabled_feature_state() {
-    let (mut session, _turn_context) =
-        make_multi_agent_v2_usage_hint_test_session(/*enable_multi_agent_v2*/ false).await;
-    let mut effective_features = Features::with_defaults();
-    effective_features.enable(Feature::MultiAgentV2);
-    Arc::get_mut(&mut session)
-        .expect("session should not be shared")
-        .features = effective_features.into();
-
-    let hint_texts = session.configured_multi_agent_v2_usage_hint_texts().await;
-
-    assert_eq!(
-        hint_texts,
-        vec![
-            "Root guidance.".to_string(),
-            "Subagent guidance.".to_string()
-        ]
-    );
-}
-
-#[tokio::test]
-async fn configured_multi_agent_v2_usage_hint_texts_omit_effectively_disabled_feature() {
-    let (mut session, _turn_context) =
-        make_multi_agent_v2_usage_hint_test_session(/*enable_multi_agent_v2*/ true).await;
-    Arc::get_mut(&mut session)
-        .expect("session should not be shared")
-        .features = Features::with_defaults().into();
-
-    let hint_texts = session.configured_multi_agent_v2_usage_hint_texts().await;
-
-    assert_eq!(hint_texts, Vec::<String>::new());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Why

Forked agents rebuild their own startup context, including subagent-specific instructions and runtime configuration. The forked rollout snapshot should therefore preserve durable conversation transcript, not replay parent-owned rendered setup context as if it were user history.

Without this distinction, a child or grandchild agent can inherit stale parent developer messages, contextual user setup, and compacted replacement history, then receive its own freshly rendered setup on top of that.

## What Changed

- Split fork filtering into a `ResponseItem` sanitizer and a `RolloutItem` sanitizer.
- Keep only durable transcript items in forked history: real user messages and assistant final answers.
- Drop inherited developer messages, contextual user setup messages, turn context baselines, tool calls, reasoning, and non-final assistant messages.
- Sanitize `CompactedItem.replacement_history` with the same transcript-only rule.
- Convert legacy summary-only compactions into empty checkpoints so the unsafe pre-compaction prefix stays cut off without injecting the parent summary into the child.
- Added fork-path tests for modern compaction, legacy compaction, and parent setup filtering.

## Verification

- `cargo test -p codex-core sanitize_forked_rollout_item`
- `cargo test -p codex-core spawn_agent_can_fork_parent_thread_history_with_sanitized_items`
- `cargo test -p codex-core spawn_agent_fork_sanitizes_modern_compaction_replacement_history_and_suffix`
- `cargo test -p codex-core spawn_agent_fork_legacy_compaction_cuts_off_unsafe_prefix_without_summary`
- `cargo test -p codex-core build_initial_context_adds_multi_agent_v2_subagent_usage_hint_as_developer_message`
- `just fix -p codex-core`
