### PR TITLE
tests: stabilize Windows process-heavy nextest group

### DIFF
--- a/codex-rs/.config/nextest.toml
+++ b/codex-rs/.config/nextest.toml
@@ -14,6 +14,9 @@ max-threads = 1
 [test-groups.windows_sandbox_legacy_sessions]
 max-threads = 1
 
+[test-groups.windows_process_heavy]
+max-threads = 2
+
 [[profile.default.overrides]]
 # Do not add new tests here
 filter = 'test(rmcp_client) | test(humanlike_typing_1000_chars_appears_live_no_placeholder)'
@@ -44,3 +47,14 @@ test-group = 'core_apply_patch_cli_integration'
 # Serialize them to avoid exhausting Windows session/global desktop resources in CI.
 filter = 'package(codex-windows-sandbox) & test(legacy_)'
 test-group = 'windows_sandbox_legacy_sessions'
+
+[[profile.default.overrides]]
+# These cases spawn CLI, thread-manager, or stdio subprocesses and are the main
+# Windows rust-ci-full timeout cluster when too many process-heavy tests launch
+# together. Limit only this observed Windows-only family instead of widening the
+# default timeout or reducing concurrency for unrelated tests.
+platform = 'cfg(windows)'
+filter = 'test(suite::resume::) | test(suite::cli_stream::) | test(start_thread_uses_all_default_environments_from_codex_home) | test(connect_stdio_command_initializes_json_rpc_client_on_windows)'
+test-group = 'windows_process_heavy'
+slow-timeout = { period = "30s", terminate-after = 2 }
+retries = 1


### PR DESCRIPTION
## Summary
- add a Windows-only nextest group for the observed process-heavy timeout cluster
- cap that group at 2 concurrent tests
- give only that family a 60s total slow timeout and one retry

## Motivation
Recent rust-ci-full failure analysis showed the 30s timeout bucket dominated by Windows resume, cli_stream, thread-manager, and Windows stdio-client tests. This keeps the mitigation scoped to that observed family instead of widening global timeouts or lowering unrelated test concurrency.

## Validation
- `git diff --check`
- `rust-ci-full` workflow_dispatch run on this branch: https://github.com/openai/codex/actions/runs/26048321824
- Windows x64 evidence from that run: `suite::cli_stream::integration_creates_and_checks_session_file` surfaced as `FLAKY 2/2` instead of failing the job outright, showing the scoped retry covered one of the observed process-heavy timeout cases.
- The same run still failed for unrelated existing issues: code mode/calendar assertion, missing `codex-windows-sandbox-setup`, `auth_env`, and legacy PowerShell sandbox timeouts. Windows ARM64 was cancelled after the workflow had already gone red, so it did not add independent signal in this run.
