### PR TITLE
Stabilize pending realtime sideband close test

### DIFF
--- a/codex-rs/core/tests/suite/realtime_conversation.rs
+++ b/codex-rs/core/tests/suite/realtime_conversation.rs
@@ -662,7 +662,9 @@ async fn conversation_webrtc_close_while_sideband_connecting_drops_pending_join(
     let realtime_server = start_websocket_server_with_headers(vec![WebSocketConnectionConfig {
         requests: vec![vec![]],
         response_headers: Vec::new(),
-        accept_delay: Some(Duration::from_millis(500)),
+        // Keep the sideband join pending well past the test's close/assertion window so slow CI
+        // workers do not accidentally complete the handshake before we submit close.
+        accept_delay: Some(Duration::from_secs(5)),
         close_after_requests: false,
     }])
     .await;


### PR DESCRIPTION
## Summary
- keep the delayed realtime sideband handshake pending beyond the test's close/assertion window
- document why the longer delay is intentional on slow CI workers

## Evidence
- rust-ci-full sampled failures hit `conversation_webrtc_close_while_sideband_connecting_drops_pending_join` after about 0.98s and 1.48s with `pending sideband task should abort before websocket handshake completes`
- the test used a 500ms delayed handshake plus a later 700ms stale-event wait, so slow scheduling can let the delayed handshake complete inside the assertion window

## Validation
- `git diff --check`
- focused remote Bazel/Cargo validation was attempted on `dev-3`, but the fresh remote build stalled in cold compile before producing a test result