### PR TITLE
Show session ids in resume picker details

### DIFF
--- a/codex-rs/tui/src/resume_picker.rs
+++ b/codex-rs/tui/src/resume_picker.rs
@@ -2929,12 +2929,12 @@ fn render_expanded_session_details(
     width: u16,
 ) -> Vec<Line<'static>> {
     let reference = state.relative_time_reference.unwrap_or_else(Utc::now);
-    let session = row
-        .thread_name
-        .as_deref()
-        .map(str::to_string)
-        .or_else(|| row.thread_id.map(|thread_id| thread_id.to_string()))
-        .unwrap_or_else(|| "-".to_string());
+    let session = match (row.thread_name.as_deref(), row.thread_id) {
+        (Some(thread_name), Some(thread_id)) => format!("{thread_name} ({thread_id})"),
+        (Some(thread_name), None) => thread_name.to_string(),
+        (None, Some(thread_id)) => thread_id.to_string(),
+        (None, None) => "-".to_string(),
+    };
     let directory = row
         .cwd
         .as_ref()
@@ -3387,7 +3387,9 @@ mod tests {
         let expected_directory =
             format_directory_display(row.cwd.as_deref().expect("cwd"), /*max_width*/ None);
 
-        assert!(rendered.contains("Session:    feat(tui): add raw scrollback mode"));
+        assert!(rendered.contains(
+            "Session:    feat(tui): add raw scrollback mode (019dabc1-0ef5-7431-b81c-03037f51f62c)"
+        ));
         assert!(rendered.contains("Created:    17 minutes ago · 2026-05-02 14:31:08"));
         assert!(rendered.contains("Updated:    now · 2026-05-02 14:48:19"));
         assert!(rendered.contains(&format!("Directory:  {expected_directory}")));


### PR DESCRIPTION
## Why

PR #23234 updates the resume messaging for renamed threads to tell users to pick `<name> (<thread-id>)` from the resume picker, but the expanded picker details still hid the session id once a thread had a name.

That left a mismatch between the new guidance text and the picker UI. When duplicate thread names exist, the expanded `Session:` field should continue to expose the id so the user can verify they are about to resume the right session.

## What Changed

- show `<thread-name> (<thread-id>)` in the resume picker `Session:` field when both values are available
- keep the existing fallback behavior for unnamed sessions or rows without an id
- update the existing picker rendering test to cover the combined session label

## How to Test

1. Check out this branch on top of `etraut/clarify-resume-hints`.
2. Start Codex, create or resume a session, and rename it.
3. Open `codex resume` and expand the renamed session entry.
4. Confirm the `Session:` field shows `<thread-name> (<thread-id>)` instead of hiding the id.

Also verify that:
1. A session without a thread name still shows just the thread id in the `Session:` field.
2. The main row title in the picker is unchanged; this PR only updates the expanded details view.

Targeted tests:
- `cargo test -p codex-tui expanded_session_details_include_metadata`

Note: `cargo test -p codex-tui` still fails in this worktree because of an unrelated existing stack overflow in `app::tests::discard_side_thread_removes_agent_navigation_entry`.
