### PR TITLE
feat(tui): improve transcript overlay UX [ 1 of 3 ]

### DIFF
--- a/codex-rs/config/src/tui_keymap.rs
+++ b/codex-rs/config/src/tui_keymap.rs
@@ -335,6 +335,10 @@ pub struct TuiPagerKeymap {
     pub close: Option<KeybindingsSpec>,
     /// Close the transcript overlay via its dedicated toggle key.
     pub close_transcript: Option<KeybindingsSpec>,
+    /// Jump to the previous user prompt in the transcript overlay.
+    pub previous_user_prompt: Option<KeybindingsSpec>,
+    /// Jump to the next user prompt in the transcript overlay.
+    pub next_user_prompt: Option<KeybindingsSpec>,
 }
 
 /// List selection context keybindings for popup-style selectable lists.

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -2842,8 +2842,10 @@
               "half_page_up": null,
               "jump_bottom": null,
               "jump_top": null,
+              "next_user_prompt": null,
               "page_down": null,
               "page_up": null,
+              "previous_user_prompt": null,
               "scroll_down": null,
               "scroll_up": null
             },
@@ -3526,8 +3528,10 @@
             "half_page_up": null,
             "jump_bottom": null,
             "jump_top": null,
+            "next_user_prompt": null,
             "page_down": null,
             "page_up": null,
+            "previous_user_prompt": null,
             "scroll_down": null,
             "scroll_up": null
           }
@@ -3749,6 +3753,14 @@
           ],
           "description": "Jump to the beginning."
         },
+        "next_user_prompt": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/KeybindingsSpec"
+            }
+          ],
+          "description": "Jump to the next user prompt in the transcript overlay."
+        },
         "page_down": {
           "allOf": [
             {
@@ -3764,6 +3776,14 @@
             }
           ],
           "description": "Scroll up by one page."
+        },
+        "previous_user_prompt": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/KeybindingsSpec"
+            }
+          ],
+          "description": "Jump to the previous user prompt in the transcript overlay."
         },
         "scroll_down": {
           "allOf": [

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -171,6 +171,7 @@ use crossterm::event::KeyModifiers;
 use ratatui::backend::Backend;
 use ratatui::layout::Rect;
 use ratatui::style::Stylize;
+use ratatui::text::Line;
 use ratatui::widgets::Paragraph;
 use ratatui::widgets::Wrap;
 use std::collections::BTreeMap;

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -62,6 +62,7 @@ use crate::multi_agents::format_agent_picker_item_name;
 use crate::multi_agents::next_agent_shortcut_matches;
 use crate::multi_agents::previous_agent_shortcut_matches;
 use crate::pager_overlay::Overlay;
+use crate::pager_overlay::TranscriptOverlayState;
 use crate::render::highlight::highlight_bash_to_lines;
 use crate::render::renderable::Renderable;
 use crate::resume_picker::SessionSelection;
@@ -170,7 +171,6 @@ use crossterm::event::KeyModifiers;
 use ratatui::backend::Backend;
 use ratatui::layout::Rect;
 use ratatui::style::Stylize;
-use ratatui::text::Line;
 use ratatui::widgets::Paragraph;
 use ratatui::widgets::Wrap;
 use std::collections::BTreeMap;
@@ -498,6 +498,7 @@ pub(crate) struct App {
 
     // Pager overlay state (Transcript or Static like Diff)
     pub(crate) overlay: Option<Overlay>,
+    pub(crate) transcript_overlay_state: TranscriptOverlayState,
     pub(crate) deferred_history_lines: Vec<crate::terminal_hyperlinks::HyperlinkLine>,
     has_emitted_history_lines: bool,
     transcript_reflow: TranscriptReflowState,
@@ -982,6 +983,8 @@ Fix the config and retry.\n\
 See the Codex keymap documentation for supported actions and examples."
             )
         })?;
+        let transcript_overlay_state =
+            TranscriptOverlayState::new(chat_widget.history_render_mode());
         #[cfg(not(debug_assertions))]
         let upgrade_version = crate::updates::get_upgrade_version(&config);
 
@@ -1003,6 +1006,7 @@ See the Codex keymap documentation for supported actions and examples."
             keymap: runtime_keymap,
             transcript_cells: Vec::new(),
             overlay: None,
+            transcript_overlay_state,
             deferred_history_lines: Vec::new(),
             has_emitted_history_lines: false,
             transcript_reflow: TranscriptReflowState::default(),

--- a/codex-rs/tui/src/app/input.rs
+++ b/codex-rs/tui/src/app/input.rs
@@ -83,6 +83,7 @@ impl App {
         } else {
             self.chat_widget.set_raw_output_mode(enabled);
         }
+        self.transcript_overlay_state.render_mode = self.chat_widget.history_render_mode();
         if let Err(err) = self.reflow_transcript_now(tui) {
             tracing::warn!(error = %err, "failed to reflow transcript after raw output mode toggle");
             self.chat_widget
@@ -166,14 +167,10 @@ impl App {
             return;
         }
 
-        if app_keymap_shortcuts_available && self.keymap.app.open_transcript.is_pressed(key_event) {
-            // Enter alternate screen and set viewport to full size.
-            let _ = tui.enter_alt_screen();
-            self.overlay = Some(Overlay::new_transcript(
-                self.transcript_cells.clone(),
-                self.keymap.pager.clone(),
-            ));
-            tui.frame_requester().schedule_frame();
+        if self.transcript_shortcut_available()
+            && self.keymap.app.open_transcript.is_pressed(key_event)
+        {
+            self.open_transcript_overlay(tui);
             return;
         }
 
@@ -280,6 +277,10 @@ impl App {
         self.overlay.is_none() && self.chat_widget.no_modal_or_popup_active()
     }
 
+    fn transcript_shortcut_available(&self) -> bool {
+        self.overlay.is_none()
+    }
+
     pub(super) fn refresh_status_line(&mut self) {
         self.chat_widget.refresh_status_line();
     }
@@ -298,5 +299,6 @@ mod tests {
         app.chat_widget.open_keymap_debug(&keymap);
 
         assert!(!app.app_keymap_shortcuts_available());
+        assert!(app.transcript_shortcut_available());
     }
 }

--- a/codex-rs/tui/src/app/test_support.rs
+++ b/codex-rs/tui/src/app/test_support.rs
@@ -30,6 +30,9 @@ pub(super) async fn make_test_app() -> App {
         file_search,
         transcript_cells: Vec::new(),
         overlay: None,
+        transcript_overlay_state: crate::pager_overlay::TranscriptOverlayState::new(
+            crate::history_cell::HistoryRenderMode::Rich,
+        ),
         deferred_history_lines: Vec::new(),
         has_emitted_history_lines: false,
         transcript_reflow: TranscriptReflowState::default(),

--- a/codex-rs/tui/src/app/tests.rs
+++ b/codex-rs/tui/src/app/tests.rs
@@ -3775,6 +3775,9 @@ async fn make_test_app() -> App {
         file_search,
         transcript_cells: Vec::new(),
         overlay: None,
+        transcript_overlay_state: crate::pager_overlay::TranscriptOverlayState::new(
+            crate::history_cell::HistoryRenderMode::Rich,
+        ),
         deferred_history_lines: Vec::new(),
         has_emitted_history_lines: false,
         transcript_reflow: TranscriptReflowState::default(),
@@ -3838,6 +3841,9 @@ async fn make_test_app_with_channels() -> (
             file_search,
             transcript_cells: Vec::new(),
             overlay: None,
+            transcript_overlay_state: crate::pager_overlay::TranscriptOverlayState::new(
+                crate::history_cell::HistoryRenderMode::Rich,
+            ),
             deferred_history_lines: Vec::new(),
             has_emitted_history_lines: false,
             transcript_reflow: TranscriptReflowState::default(),
@@ -4960,6 +4966,9 @@ async fn queued_rollback_syncs_overlay_and_clears_deferred_history() {
     app.overlay = Some(Overlay::new_transcript(
         app.transcript_cells.clone(),
         app.keymap.pager.clone(),
+        app.keymap.app.copy.clone(),
+        app.keymap.app.toggle_raw_output.clone(),
+        app.transcript_overlay_state,
     ));
     app.deferred_history_lines = vec![Line::from("stale buffered line").into()];
     app.backtrack.overlay_preview_active = true;
@@ -5495,6 +5504,11 @@ async fn clear_only_ui_reset_preserves_chat_session_state() {
     app.overlay = Some(Overlay::new_transcript(
         app.transcript_cells.clone(),
         crate::keymap::RuntimeKeymap::defaults().pager,
+        Vec::new(),
+        Vec::new(),
+        crate::pager_overlay::TranscriptOverlayState::new(
+            crate::history_cell::HistoryRenderMode::Rich,
+        ),
     ));
     app.deferred_history_lines = vec![Line::from("stale buffered line").into()];
     app.has_emitted_history_lines = true;

--- a/codex-rs/tui/src/app_backtrack.rs
+++ b/codex-rs/tui/src/app_backtrack.rs
@@ -35,6 +35,7 @@ use crate::app_event::AppEvent;
 use crate::history_cell::AgentMessageCell;
 use crate::history_cell::SessionInfoCell;
 use crate::history_cell::UserHistoryCell;
+use crate::key_hint::KeyBindingListExt;
 use crate::pager_overlay::Overlay;
 use crate::tui;
 use crate::tui::TuiEvent;
@@ -104,9 +105,9 @@ pub(crate) struct PendingBacktrackRollback {
 impl App {
     /// Route overlay events while the transcript overlay is active.
     ///
-    /// If backtrack preview is active, Esc / Left steps selection, Right steps forward, Enter
-    /// confirms. Otherwise, Esc begins preview mode and all other events are forwarded to the
-    /// overlay.
+    /// If backtrack preview is active, Esc / previous-prompt steps selection, next-prompt steps
+    /// forward, Enter confirms. Otherwise, Esc or a prompt-selection key begins preview mode and
+    /// all other events are forwarded to the overlay.
     pub(crate) async fn handle_backtrack_overlay_event(
         &mut self,
         tui: &mut tui::Tui,
@@ -122,19 +123,15 @@ impl App {
                     self.overlay_step_backtrack(tui, event)?;
                     Ok(true)
                 }
-                TuiEvent::Key(KeyEvent {
-                    code: KeyCode::Left,
-                    kind: KeyEventKind::Press | KeyEventKind::Repeat,
-                    ..
-                }) => {
+                TuiEvent::Key(key_event)
+                    if self.keymap.pager.previous_user_prompt.is_pressed(key_event) =>
+                {
                     self.overlay_step_backtrack(tui, event)?;
                     Ok(true)
                 }
-                TuiEvent::Key(KeyEvent {
-                    code: KeyCode::Right,
-                    kind: KeyEventKind::Press | KeyEventKind::Repeat,
-                    ..
-                }) => {
+                TuiEvent::Key(key_event)
+                    if self.keymap.pager.next_user_prompt.is_pressed(key_event) =>
+                {
                     self.overlay_step_backtrack_forward(tui, event)?;
                     Ok(true)
                 }
@@ -151,13 +148,19 @@ impl App {
                     Ok(true)
                 }
             }
-        } else if let TuiEvent::Key(KeyEvent {
-            code: KeyCode::Esc,
-            kind: KeyEventKind::Press | KeyEventKind::Repeat,
-            ..
-        }) = event
+        } else if let TuiEvent::Key(key_event) = event
+            && (matches!(
+                key_event,
+                KeyEvent {
+                    code: KeyCode::Esc,
+                    kind: KeyEventKind::Press | KeyEventKind::Repeat,
+                    ..
+                }
+            ) || self.keymap.pager.previous_user_prompt.is_pressed(key_event)
+                || self.keymap.pager.next_user_prompt.is_pressed(key_event))
         {
-            // First Esc in transcript overlay: begin backtrack preview at latest user message.
+            // First Esc / prompt-selection key in transcript overlay: begin backtrack preview at
+            // latest user message.
             self.begin_overlay_backtrack_preview(tui);
             Ok(true)
         } else {
@@ -496,7 +499,8 @@ impl App {
         Ok(())
     }
 
-    /// Handle Right in overlay backtrack preview: step selection forward if armed, else forward.
+    /// Handle next-prompt in overlay backtrack preview: step selection forward if armed, else
+    /// forward.
     fn overlay_step_backtrack_forward(
         &mut self,
         tui: &mut tui::Tui,

--- a/codex-rs/tui/src/app_backtrack.rs
+++ b/codex-rs/tui/src/app_backtrack.rs
@@ -433,26 +433,46 @@ impl App {
             return Ok(());
         }
 
-        let (copy_selection, copy_latest, close_overlay) = if let Some(overlay) = &mut self.overlay
+        let (scroll_selection, copy_selection, copy_latest, close_overlay) = if let Some(overlay) =
+            &mut self.overlay
         {
             overlay.handle_event(tui, event)?;
-            let (copy_selection, copy_latest) = match overlay {
+            let (scroll_selection, copy_selection, copy_latest) = match overlay {
                 Overlay::Transcript(transcript) => {
+                    let scroll_selection = transcript.take_scroll_selected_user_cell();
                     if transcript.take_copy_requested() {
                         match transcript.selected_user_cell() {
-                            Some(user_cell_idx) => (Some(user_cell_idx), false),
-                            None => (None, true),
+                            Some(user_cell_idx) => (scroll_selection, Some(user_cell_idx), false),
+                            None => (scroll_selection, None, true),
                         }
                     } else {
-                        (None, false)
+                        (scroll_selection, None, false)
                     }
                 }
-                Overlay::Static(_) => (None, false),
+                Overlay::Static(_) => (None, None, false),
             };
-            (copy_selection, copy_latest, overlay.is_done())
+            (
+                scroll_selection,
+                copy_selection,
+                copy_latest,
+                overlay.is_done(),
+            )
         } else {
-            (None, false, false)
+            (None, None, false, false)
         };
+        if let Some(user_cell_idx) = scroll_selection
+            && self
+                .transcript_cells
+                .get(user_cell_idx)
+                .is_some_and(|cell| cell.is_user_prompt())
+            && let Some(nth_user_message) =
+                user_count(&self.transcript_cells[..=user_cell_idx]).checked_sub(1)
+        {
+            self.backtrack.primed = true;
+            self.backtrack.base_id = self.chat_widget.thread_id();
+            self.backtrack.overlay_preview_active = true;
+            self.backtrack.nth_user_message = nth_user_message;
+        }
         let copy_status = if let Some(user_cell_idx) = copy_selection {
             Some(self.copy_transcript_turn(user_cell_idx))
         } else if copy_latest {

--- a/codex-rs/tui/src/app_backtrack.rs
+++ b/codex-rs/tui/src/app_backtrack.rs
@@ -235,12 +235,18 @@ impl App {
         self.overlay = Some(Overlay::new_transcript(
             self.transcript_cells.clone(),
             self.keymap.pager.clone(),
+            self.keymap.app.copy.clone(),
+            self.keymap.app.toggle_raw_output.clone(),
+            self.transcript_overlay_state,
         ));
         tui.frame_requester().schedule_frame();
     }
 
     /// Close transcript overlay and restore normal UI.
     pub(crate) fn close_transcript_overlay(&mut self, tui: &mut tui::Tui) {
+        if let Some(Overlay::Transcript(transcript)) = &self.overlay {
+            self.transcript_overlay_state = transcript.state();
+        }
         let _ = tui.leave_alt_screen();
         let was_backtrack = self.backtrack.overlay_preview_active;
         if !self.deferred_history_lines.is_empty() {
@@ -424,14 +430,49 @@ impl App {
             return Ok(());
         }
 
-        if let Some(overlay) = &mut self.overlay {
+        let (copy_selection, copy_latest, close_overlay) = if let Some(overlay) = &mut self.overlay
+        {
             overlay.handle_event(tui, event)?;
-            if overlay.is_done() {
-                self.close_transcript_overlay(tui);
-                tui.frame_requester().schedule_frame();
-            }
+            let (copy_selection, copy_latest) = match overlay {
+                Overlay::Transcript(transcript) => {
+                    if transcript.take_copy_requested() {
+                        match transcript.selected_user_cell() {
+                            Some(user_cell_idx) => (Some(user_cell_idx), false),
+                            None => (None, true),
+                        }
+                    } else {
+                        (None, false)
+                    }
+                }
+                Overlay::Static(_) => (None, false),
+            };
+            (copy_selection, copy_latest, overlay.is_done())
+        } else {
+            (None, false, false)
+        };
+        if let Some(user_cell_idx) = copy_selection {
+            self.copy_transcript_turn(user_cell_idx);
+        } else if copy_latest {
+            self.chat_widget.copy_last_agent_markdown();
+        }
+        if close_overlay {
+            self.close_transcript_overlay(tui);
+            tui.frame_requester().schedule_frame();
         }
         Ok(())
+    }
+
+    fn copy_transcript_turn(&mut self, user_cell_idx: usize) {
+        let Some(user_cell) = self.transcript_cells.get(user_cell_idx).and_then(|cell| {
+            cell.as_any()
+                .downcast_ref::<crate::history_cell::UserHistoryCell>()
+        }) else {
+            self.chat_widget.copy_last_agent_markdown();
+            return;
+        };
+        let user_turn_count = user_count(&self.transcript_cells[..=user_cell_idx]);
+        self.chat_widget
+            .copy_agent_turn_markdown(user_turn_count, &user_cell.message);
     }
 
     /// Handle Enter in overlay backtrack preview: confirm selection and reset state.
@@ -664,7 +705,6 @@ fn user_positions_iter(
     cells: &[Arc<dyn crate::history_cell::HistoryCell>],
 ) -> impl Iterator<Item = usize> + '_ {
     let session_start_type = TypeId::of::<SessionInfoCell>();
-    let user_type = TypeId::of::<UserHistoryCell>();
     let type_of = |cell: &Arc<dyn crate::history_cell::HistoryCell>| cell.as_any().type_id();
 
     let start = cells
@@ -676,7 +716,7 @@ fn user_positions_iter(
         .iter()
         .enumerate()
         .skip(start)
-        .filter_map(move |(idx, cell)| (type_of(cell) == user_type).then_some(idx))
+        .filter_map(move |(idx, cell)| cell.is_user_prompt().then_some(idx))
 }
 
 #[cfg(test)]

--- a/codex-rs/tui/src/app_backtrack.rs
+++ b/codex-rs/tui/src/app_backtrack.rs
@@ -37,6 +37,7 @@ use crate::history_cell::SessionInfoCell;
 use crate::history_cell::UserHistoryCell;
 use crate::key_hint::KeyBindingListExt;
 use crate::pager_overlay::Overlay;
+use crate::pager_overlay::TranscriptOverlayState;
 use crate::tui;
 use crate::tui::TuiEvent;
 use codex_protocol::ThreadId;
@@ -149,19 +150,27 @@ impl App {
                 }
             }
         } else if let TuiEvent::Key(key_event) = event
-            && (matches!(
+            && matches!(
                 key_event,
                 KeyEvent {
                     code: KeyCode::Esc,
                     kind: KeyEventKind::Press | KeyEventKind::Repeat,
                     ..
                 }
-            ) || self.keymap.pager.previous_user_prompt.is_pressed(key_event)
-                || self.keymap.pager.next_user_prompt.is_pressed(key_event))
+            )
         {
-            // First Esc / prompt-selection key in transcript overlay: begin backtrack preview at
-            // latest user message.
-            self.begin_overlay_backtrack_preview(tui);
+            // First Esc in transcript overlay: begin backtrack preview at latest user message.
+            self.begin_overlay_backtrack_preview(tui, OverlayBacktrackStart::Latest);
+            Ok(true)
+        } else if let TuiEvent::Key(key_event) = event
+            && self.keymap.pager.previous_user_prompt.is_pressed(key_event)
+        {
+            self.begin_overlay_backtrack_preview(tui, OverlayBacktrackStart::Previous);
+            Ok(true)
+        } else if let TuiEvent::Key(key_event) = event
+            && self.keymap.pager.next_user_prompt.is_pressed(key_event)
+        {
+            self.begin_overlay_backtrack_preview(tui, OverlayBacktrackStart::Next);
             Ok(true)
         } else {
             // Not in backtrack mode: forward events to the overlay widget.
@@ -235,13 +244,21 @@ impl App {
     /// Open transcript overlay (enters alternate screen and shows full transcript).
     pub(crate) fn open_transcript_overlay(&mut self, tui: &mut tui::Tui) {
         let _ = tui.enter_alt_screen();
-        self.overlay = Some(Overlay::new_transcript(
+        let transcript_overlay_state = transcript_overlay_state_for_open(
+            self.transcript_overlay_state,
+            &self.transcript_cells,
+        );
+        let mut overlay = Overlay::new_transcript(
             self.transcript_cells.clone(),
             self.keymap.pager.clone(),
             self.keymap.app.copy.clone(),
             self.keymap.app.toggle_raw_output.clone(),
-            self.transcript_overlay_state,
-        ));
+            transcript_overlay_state,
+        );
+        if let Overlay::Transcript(transcript) = &mut overlay {
+            transcript.set_highlight_cell(transcript_overlay_state.highlight_cell);
+        }
+        self.overlay = Some(overlay);
         tui.frame_requester().schedule_frame();
     }
 
@@ -313,8 +330,12 @@ impl App {
         self.step_backtrack_and_highlight(tui);
     }
 
-    /// When overlay is already open, begin preview mode and select latest user message.
-    fn begin_overlay_backtrack_preview(&mut self, tui: &mut tui::Tui) {
+    /// When overlay is already open, begin preview mode and select the requested user message.
+    fn begin_overlay_backtrack_preview(
+        &mut self,
+        tui: &mut tui::Tui,
+        start: OverlayBacktrackStart,
+    ) {
         if !has_backtrack_target(&self.transcript_cells) {
             self.close_transcript_overlay(tui);
             self.chat_widget
@@ -326,9 +347,10 @@ impl App {
         self.backtrack.primed = true;
         self.backtrack.base_id = self.chat_widget.thread_id();
         self.backtrack.overlay_preview_active = true;
-        let count = user_count(&self.transcript_cells);
-        if let Some(last) = count.checked_sub(1) {
-            self.apply_backtrack_selection_internal(last);
+        if let Some(nth_user_message) =
+            initial_overlay_backtrack_selection(user_count(&self.transcript_cells), start)
+        {
+            self.apply_backtrack_selection_internal(nth_user_message);
         }
         tui.frame_requester().schedule_frame();
     }
@@ -722,6 +744,32 @@ fn has_backtrack_target(cells: &[Arc<dyn crate::history_cell::HistoryCell>]) -> 
     user_count(cells) > 0
 }
 
+#[derive(Clone, Copy)]
+enum OverlayBacktrackStart {
+    Latest,
+    Previous,
+    Next,
+}
+
+fn initial_overlay_backtrack_selection(
+    user_count: usize,
+    start: OverlayBacktrackStart,
+) -> Option<usize> {
+    let last = user_count.checked_sub(1)?;
+    Some(match start {
+        OverlayBacktrackStart::Latest | OverlayBacktrackStart::Next => last,
+        OverlayBacktrackStart::Previous => last.saturating_sub(1),
+    })
+}
+
+fn transcript_overlay_state_for_open(
+    mut state: TranscriptOverlayState,
+    cells: &[Arc<dyn crate::history_cell::HistoryCell>],
+) -> TranscriptOverlayState {
+    state.highlight_cell = user_positions_iter(cells).last();
+    state
+}
+
 fn nth_user_position(
     cells: &[Arc<dyn crate::history_cell::HistoryCell>],
     nth: usize,
@@ -782,6 +830,7 @@ mod tests {
     use super::*;
     use crate::history_cell::AgentMessageCell;
     use crate::history_cell::HistoryCell;
+    use crate::history_cell::HistoryRenderMode;
     use pretty_assertions::assert_eq;
     use ratatui::prelude::Line;
     use std::sync::Arc;
@@ -1030,6 +1079,104 @@ mod tests {
         }) as Arc<dyn HistoryCell>);
 
         assert!(has_backtrack_target(&cells));
+    }
+
+    #[test]
+    fn transcript_overlay_open_selects_latest_user_prompt() {
+        let cells: Vec<Arc<dyn HistoryCell>> = vec![
+            Arc::new(UserHistoryCell {
+                message: "first".to_string(),
+                text_elements: Vec::new(),
+                local_image_paths: Vec::new(),
+                remote_image_urls: Vec::new(),
+            }) as Arc<dyn HistoryCell>,
+            Arc::new(AgentMessageCell::new(
+                vec![Line::from("assistant")],
+                /*is_first_line*/ true,
+            )) as Arc<dyn HistoryCell>,
+            Arc::new(UserHistoryCell {
+                message: "second".to_string(),
+                text_elements: Vec::new(),
+                local_image_paths: Vec::new(),
+                remote_image_urls: Vec::new(),
+            }) as Arc<dyn HistoryCell>,
+        ];
+        let stale_state = TranscriptOverlayState {
+            scroll_offset: 4,
+            highlight_cell: Some(0),
+            render_mode: HistoryRenderMode::Raw,
+        };
+
+        let state = transcript_overlay_state_for_open(stale_state, &cells);
+
+        assert_eq!(
+            state,
+            TranscriptOverlayState {
+                scroll_offset: 4,
+                highlight_cell: Some(2),
+                render_mode: HistoryRenderMode::Raw,
+            }
+        );
+    }
+
+    #[test]
+    fn transcript_overlay_open_clears_stale_selection_without_user_prompt() {
+        let cells: Vec<Arc<dyn HistoryCell>> = vec![Arc::new(AgentMessageCell::new(
+            vec![Line::from("assistant")],
+            /*is_first_line*/ true,
+        )) as Arc<dyn HistoryCell>];
+        let stale_state = TranscriptOverlayState {
+            scroll_offset: 4,
+            highlight_cell: Some(0),
+            render_mode: HistoryRenderMode::Raw,
+        };
+
+        let state = transcript_overlay_state_for_open(stale_state, &cells);
+
+        assert_eq!(
+            state,
+            TranscriptOverlayState {
+                scroll_offset: 4,
+                highlight_cell: None,
+                render_mode: HistoryRenderMode::Raw,
+            }
+        );
+    }
+
+    #[test]
+    fn first_previous_prompt_key_starts_on_previous_prompt() {
+        assert_eq!(
+            initial_overlay_backtrack_selection(
+                /*user_count*/ 3,
+                OverlayBacktrackStart::Previous,
+            ),
+            Some(1)
+        );
+        assert_eq!(
+            initial_overlay_backtrack_selection(
+                /*user_count*/ 3,
+                OverlayBacktrackStart::Latest
+            ),
+            Some(2)
+        );
+        assert_eq!(
+            initial_overlay_backtrack_selection(/*user_count*/ 3, OverlayBacktrackStart::Next),
+            Some(2)
+        );
+        assert_eq!(
+            initial_overlay_backtrack_selection(
+                /*user_count*/ 1,
+                OverlayBacktrackStart::Previous,
+            ),
+            Some(0)
+        );
+        assert_eq!(
+            initial_overlay_backtrack_selection(
+                /*user_count*/ 0,
+                OverlayBacktrackStart::Previous,
+            ),
+            None
+        );
     }
 
     #[test]

--- a/codex-rs/tui/src/app_backtrack.rs
+++ b/codex-rs/tui/src/app_backtrack.rs
@@ -453,10 +453,17 @@ impl App {
         } else {
             (None, false, false)
         };
-        if let Some(user_cell_idx) = copy_selection {
-            self.copy_transcript_turn(user_cell_idx);
+        let copy_status = if let Some(user_cell_idx) = copy_selection {
+            Some(self.copy_transcript_turn(user_cell_idx))
         } else if copy_latest {
-            self.chat_widget.copy_last_agent_markdown();
+            Some(self.chat_widget.copy_last_agent_markdown_for_overlay())
+        } else {
+            None
+        };
+        if let Some(status) = copy_status
+            && let Some(Overlay::Transcript(transcript)) = &mut self.overlay
+        {
+            transcript.show_copy_status(&status, tui);
         }
         if close_overlay {
             self.close_transcript_overlay(tui);
@@ -465,17 +472,16 @@ impl App {
         Ok(())
     }
 
-    fn copy_transcript_turn(&mut self, user_cell_idx: usize) {
+    fn copy_transcript_turn(&mut self, user_cell_idx: usize) -> crate::chatwidget::CopyStatus {
         let Some(user_cell) = self.transcript_cells.get(user_cell_idx).and_then(|cell| {
             cell.as_any()
                 .downcast_ref::<crate::history_cell::UserHistoryCell>()
         }) else {
-            self.chat_widget.copy_last_agent_markdown();
-            return;
+            return self.chat_widget.copy_last_agent_markdown_for_overlay();
         };
         let user_turn_count = user_count(&self.transcript_cells[..=user_cell_idx]);
         self.chat_widget
-            .copy_agent_turn_markdown(user_turn_count, &user_cell.message);
+            .copy_agent_turn_markdown_for_overlay(user_turn_count, &user_cell.message)
     }
 
     /// Handle Enter in overlay backtrack preview: confirm selection and reset state.

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -193,6 +193,24 @@ use tracing::debug;
 use tracing::warn;
 
 const DEFAULT_MODEL_DISPLAY_NAME: &str = "loading";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum CopyStatus {
+    Success(String),
+    Error(String),
+}
+
+impl CopyStatus {
+    pub(crate) fn message(&self) -> &str {
+        match self {
+            Self::Success(message) | Self::Error(message) => message,
+        }
+    }
+
+    pub(crate) fn is_success(&self) -> bool {
+        matches!(self, Self::Success(_))
+    }
+}
 const MULTI_AGENT_ENABLE_TITLE: &str = "Enable subagents?";
 const MULTI_AGENT_ENABLE_YES: &str = "Yes, enable";
 const MULTI_AGENT_ENABLE_NO: &str = "Not now";

--- a/codex-rs/tui/src/chatwidget/interaction.rs
+++ b/codex-rs/tui/src/chatwidget/interaction.rs
@@ -225,15 +225,25 @@ impl ChatWidget {
 
     /// Copy the last agent response (raw markdown) to the system clipboard.
     pub(crate) fn copy_last_agent_markdown(&mut self) {
-        self.copy_last_agent_markdown_with(crate::clipboard_copy::copy_to_clipboard);
+        let status = self.copy_last_agent_markdown_for_overlay();
+        self.record_copy_status(&status);
+        self.request_redraw();
     }
 
-    pub(crate) fn copy_agent_turn_markdown(&mut self, user_turn_count: usize, user_prompt: &str) {
+    pub(crate) fn copy_last_agent_markdown_for_overlay(&mut self) -> CopyStatus {
+        self.copy_last_agent_markdown_with(crate::clipboard_copy::copy_to_clipboard)
+    }
+
+    pub(crate) fn copy_agent_turn_markdown_for_overlay(
+        &mut self,
+        user_turn_count: usize,
+        user_prompt: &str,
+    ) -> CopyStatus {
         self.copy_agent_turn_markdown_with(
             user_turn_count,
             user_prompt,
             crate::clipboard_copy::copy_to_clipboard,
-        );
+        )
     }
 
     pub(crate) fn truncate_agent_copy_history_to_user_turn_count(
@@ -248,23 +258,16 @@ impl ChatWidget {
     pub(super) fn copy_last_agent_markdown_with(
         &mut self,
         copy_fn: impl FnOnce(&str) -> Result<Option<crate::clipboard_copy::ClipboardLease>, String>,
-    ) {
+    ) -> CopyStatus {
         match self.transcript.last_agent_markdown.clone() {
-            Some(markdown) if !markdown.is_empty() => self.copy_markdown_with_status(
-                &markdown,
-                "Copied last message to clipboard",
-                copy_fn,
-            ),
-            _ if self.transcript.copy_history_evicted_by_rollback => {
-                self.add_to_history(history_cell::new_error_event(format!(
-                    "Cannot copy that response after rewinding. Only the most recent {MAX_AGENT_COPY_HISTORY} responses are available to /copy."
-                )));
+            Some(markdown) if !markdown.is_empty() => {
+                self.copy_markdown_result(&markdown, "Copied last message to clipboard", copy_fn)
             }
-            _ => self.add_to_history(history_cell::new_error_event(
-                "No agent response to copy".into(),
+            _ if self.transcript.copy_history_evicted_by_rollback => CopyStatus::Error(format!(
+                "Cannot copy that response after rewinding. Only the most recent {MAX_AGENT_COPY_HISTORY} responses are available to /copy."
             )),
+            _ => CopyStatus::Error("No agent response to copy".into()),
         }
-        self.request_redraw();
     }
 
     pub(super) fn copy_agent_turn_markdown_with(
@@ -272,43 +275,43 @@ impl ChatWidget {
         user_turn_count: usize,
         user_prompt: &str,
         copy_fn: impl FnOnce(&str) -> Result<Option<crate::clipboard_copy::ClipboardLease>, String>,
-    ) {
+    ) -> CopyStatus {
         match self
             .transcript
             .agent_markdown_for_user_turn(user_turn_count)
         {
             Some(markdown) if !markdown.is_empty() => {
                 let markdown = format!("## User\n\n{user_prompt}\n\n## Assistant\n\n{markdown}");
-                self.copy_markdown_with_status(
-                    &markdown,
-                    "Copied selected turn to clipboard",
-                    copy_fn,
-                );
+                self.copy_markdown_result(&markdown, "Copied selected turn to clipboard", copy_fn)
             }
-            _ => self.add_to_history(history_cell::new_error_event(
-                "No agent response to copy for selected prompt".into(),
-            )),
+            _ => CopyStatus::Error("No agent response to copy for selected prompt".into()),
         }
-        self.request_redraw();
     }
 
-    fn copy_markdown_with_status(
+    fn copy_markdown_result(
         &mut self,
         markdown: &str,
         success_message: &str,
         copy_fn: impl FnOnce(&str) -> Result<Option<crate::clipboard_copy::ClipboardLease>, String>,
-    ) {
+    ) -> CopyStatus {
         match copy_fn(markdown) {
             Ok(lease) => {
                 self.clipboard_lease = lease;
-                self.add_to_history(history_cell::new_info_event(
-                    success_message.into(),
-                    /*hint*/ None,
-                ));
+                CopyStatus::Success(success_message.into())
             }
-            Err(error) => self.add_to_history(history_cell::new_error_event(format!(
-                "Copy failed: {error}"
-            ))),
+            Err(error) => CopyStatus::Error(format!("Copy failed: {error}")),
+        }
+    }
+
+    fn record_copy_status(&mut self, status: &CopyStatus) {
+        match status {
+            CopyStatus::Success(message) => self.add_to_history(history_cell::new_info_event(
+                message.clone(),
+                /*hint*/ None,
+            )),
+            CopyStatus::Error(message) => {
+                self.add_to_history(history_cell::new_error_event(message.clone()))
+            }
         }
     }
 

--- a/codex-rs/tui/src/chatwidget/interaction.rs
+++ b/codex-rs/tui/src/chatwidget/interaction.rs
@@ -228,6 +228,14 @@ impl ChatWidget {
         self.copy_last_agent_markdown_with(crate::clipboard_copy::copy_to_clipboard);
     }
 
+    pub(crate) fn copy_agent_turn_markdown(&mut self, user_turn_count: usize, user_prompt: &str) {
+        self.copy_agent_turn_markdown_with(
+            user_turn_count,
+            user_prompt,
+            crate::clipboard_copy::copy_to_clipboard,
+        );
+    }
+
     pub(crate) fn truncate_agent_copy_history_to_user_turn_count(
         &mut self,
         user_turn_count: usize,
@@ -242,18 +250,11 @@ impl ChatWidget {
         copy_fn: impl FnOnce(&str) -> Result<Option<crate::clipboard_copy::ClipboardLease>, String>,
     ) {
         match self.transcript.last_agent_markdown.clone() {
-            Some(markdown) if !markdown.is_empty() => match copy_fn(&markdown) {
-                Ok(lease) => {
-                    self.clipboard_lease = lease;
-                    self.add_to_history(history_cell::new_info_event(
-                        "Copied last message to clipboard".into(),
-                        /*hint*/ None,
-                    ));
-                }
-                Err(error) => self.add_to_history(history_cell::new_error_event(format!(
-                    "Copy failed: {error}"
-                ))),
-            },
+            Some(markdown) if !markdown.is_empty() => self.copy_markdown_with_status(
+                &markdown,
+                "Copied last message to clipboard",
+                copy_fn,
+            ),
             _ if self.transcript.copy_history_evicted_by_rollback => {
                 self.add_to_history(history_cell::new_error_event(format!(
                     "Cannot copy that response after rewinding. Only the most recent {MAX_AGENT_COPY_HISTORY} responses are available to /copy."
@@ -264,6 +265,51 @@ impl ChatWidget {
             )),
         }
         self.request_redraw();
+    }
+
+    pub(super) fn copy_agent_turn_markdown_with(
+        &mut self,
+        user_turn_count: usize,
+        user_prompt: &str,
+        copy_fn: impl FnOnce(&str) -> Result<Option<crate::clipboard_copy::ClipboardLease>, String>,
+    ) {
+        match self
+            .transcript
+            .agent_markdown_for_user_turn(user_turn_count)
+        {
+            Some(markdown) if !markdown.is_empty() => {
+                let markdown = format!("## User\n\n{user_prompt}\n\n## Assistant\n\n{markdown}");
+                self.copy_markdown_with_status(
+                    &markdown,
+                    "Copied selected turn to clipboard",
+                    copy_fn,
+                );
+            }
+            _ => self.add_to_history(history_cell::new_error_event(
+                "No agent response to copy for selected prompt".into(),
+            )),
+        }
+        self.request_redraw();
+    }
+
+    fn copy_markdown_with_status(
+        &mut self,
+        markdown: &str,
+        success_message: &str,
+        copy_fn: impl FnOnce(&str) -> Result<Option<crate::clipboard_copy::ClipboardLease>, String>,
+    ) {
+        match copy_fn(markdown) {
+            Ok(lease) => {
+                self.clipboard_lease = lease;
+                self.add_to_history(history_cell::new_info_event(
+                    success_message.into(),
+                    /*hint*/ None,
+                ));
+            }
+            Err(error) => self.add_to_history(history_cell::new_error_event(format!(
+                "Copy failed: {error}"
+            ))),
+        }
     }
 
     #[cfg(test)]

--- a/codex-rs/tui/src/chatwidget/tests/slash_commands.rs
+++ b/codex-rs/tui/src/chatwidget/tests/slash_commands.rs
@@ -1473,6 +1473,30 @@ async fn slash_copy_stores_clipboard_lease_and_preserves_it_on_failure() {
 }
 
 #[tokio::test]
+async fn transcript_turn_copy_includes_user_prompt_and_agent_markdown() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    chat.transcript.record_visible_user_turn();
+    chat.transcript
+        .record_agent_markdown("first response".to_string());
+
+    chat.copy_agent_turn_markdown_with(/*user_turn_count*/ 1, "first prompt", |markdown| {
+        assert_eq!(
+            markdown,
+            "## User\n\nfirst prompt\n\n## Assistant\n\nfirst response"
+        );
+        Ok(Some(crate::clipboard_copy::ClipboardLease::test()))
+    });
+
+    let cells = drain_insert_history(&mut rx);
+    assert_eq!(cells.len(), 1, "expected one success message");
+    let rendered = lines_to_single_string(&cells[0]);
+    assert!(
+        rendered.contains("Copied selected turn to clipboard"),
+        "expected success message, got {rendered:?}"
+    );
+}
+
+#[tokio::test]
 async fn slash_copy_state_is_preserved_during_running_task() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
 

--- a/codex-rs/tui/src/chatwidget/tests/slash_commands.rs
+++ b/codex-rs/tui/src/chatwidget/tests/slash_commands.rs
@@ -1443,32 +1443,36 @@ async fn slash_copy_stores_clipboard_lease_and_preserves_it_on_failure() {
     let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
     chat.transcript.last_agent_markdown = Some("copy me".to_string());
 
-    chat.copy_last_agent_markdown_with(|markdown| {
+    let status = chat.copy_last_agent_markdown_with(|markdown| {
         assert_eq!(markdown, "copy me");
         Ok(Some(crate::clipboard_copy::ClipboardLease::test()))
     });
 
+    assert_eq!(
+        status,
+        crate::chatwidget::CopyStatus::Success("Copied last message to clipboard".into())
+    );
     assert!(chat.clipboard_lease.is_some());
     let cells = drain_insert_history(&mut rx);
-    assert_eq!(cells.len(), 1, "expected one success message");
-    let rendered = lines_to_single_string(&cells[0]);
     assert!(
-        rendered.contains("Copied last message to clipboard"),
-        "expected success message, got {rendered:?}"
+        cells.is_empty(),
+        "expected overlay-style helper not to add history"
     );
 
-    chat.copy_last_agent_markdown_with(|markdown| {
+    let status = chat.copy_last_agent_markdown_with(|markdown| {
         assert_eq!(markdown, "copy me");
         Err("blocked".into())
     });
 
+    assert_eq!(
+        status,
+        crate::chatwidget::CopyStatus::Error("Copy failed: blocked".into())
+    );
     assert!(chat.clipboard_lease.is_some());
     let cells = drain_insert_history(&mut rx);
-    assert_eq!(cells.len(), 1, "expected one failure message");
-    let rendered = lines_to_single_string(&cells[0]);
     assert!(
-        rendered.contains("Copy failed: blocked"),
-        "expected failure message, got {rendered:?}"
+        cells.is_empty(),
+        "expected overlay-style helper not to add history"
     );
 }
 
@@ -1479,20 +1483,26 @@ async fn transcript_turn_copy_includes_user_prompt_and_agent_markdown() {
     chat.transcript
         .record_agent_markdown("first response".to_string());
 
-    chat.copy_agent_turn_markdown_with(/*user_turn_count*/ 1, "first prompt", |markdown| {
-        assert_eq!(
-            markdown,
-            "## User\n\nfirst prompt\n\n## Assistant\n\nfirst response"
-        );
-        Ok(Some(crate::clipboard_copy::ClipboardLease::test()))
-    });
+    let status = chat.copy_agent_turn_markdown_with(
+        /*user_turn_count*/ 1,
+        "first prompt",
+        |markdown| {
+            assert_eq!(
+                markdown,
+                "## User\n\nfirst prompt\n\n## Assistant\n\nfirst response"
+            );
+            Ok(Some(crate::clipboard_copy::ClipboardLease::test()))
+        },
+    );
 
+    assert_eq!(
+        status,
+        crate::chatwidget::CopyStatus::Success("Copied selected turn to clipboard".into())
+    );
     let cells = drain_insert_history(&mut rx);
-    assert_eq!(cells.len(), 1, "expected one success message");
-    let rendered = lines_to_single_string(&cells[0]);
     assert!(
-        rendered.contains("Copied selected turn to clipboard"),
-        "expected success message, got {rendered:?}"
+        cells.is_empty(),
+        "expected overlay-style helper not to add history"
     );
 }
 

--- a/codex-rs/tui/src/chatwidget/transcript.rs
+++ b/codex-rs/tui/src/chatwidget/transcript.rs
@@ -106,6 +106,13 @@ impl TranscriptState {
         self.saw_copy_source_this_turn = false;
     }
 
+    pub(super) fn agent_markdown_for_user_turn(&self, user_turn_count: usize) -> Option<&str> {
+        self.agent_turn_markdowns
+            .iter()
+            .find(|entry| entry.user_turn_count == user_turn_count)
+            .map(|entry| entry.markdown.as_str())
+    }
+
     pub(super) fn reset_turn_flags(&mut self) {
         self.saw_copy_source_this_turn = false;
         self.saw_plan_update_this_turn = false;

--- a/codex-rs/tui/src/footer_hints.rs
+++ b/codex-rs/tui/src/footer_hints.rs
@@ -1,0 +1,235 @@
+use crate::color::is_light;
+use crate::terminal_palette::default_bg;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::Color;
+use ratatui::style::Style;
+use ratatui::style::Styled as _;
+use ratatui::style::Stylize as _;
+use ratatui::text::Line;
+use ratatui::widgets::WidgetRef;
+use unicode_width::UnicodeWidthStr;
+
+const FOOTER_COMPACT_BREAKPOINT: u16 = 120;
+const FOOTER_HINT_LEFT_PADDING: usize = 1;
+const FOOTER_HINT_GAP: usize = 3;
+
+#[derive(Clone, Debug)]
+pub(crate) struct FooterHint {
+    key: String,
+    wide_label: String,
+    compact_label: String,
+    priority: u8,
+}
+
+impl FooterHint {
+    pub(crate) fn new(
+        key: impl Into<String>,
+        wide_label: impl Into<String>,
+        compact_label: impl Into<String>,
+        priority: u8,
+    ) -> Self {
+        Self {
+            key: key.into(),
+            wide_label: wide_label.into(),
+            compact_label: compact_label.into(),
+            priority,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum FooterHintLabelMode {
+    Wide,
+    Compact,
+    KeyOnly,
+}
+
+pub(crate) fn footer_hint_line_for_row(hints: &[FooterHint], width: u16) -> Line<'static> {
+    if width >= FOOTER_COMPACT_BREAKPOINT
+        && let Some(line) = fit_footer_hints(hints, FooterHintLabelMode::Wide, width)
+    {
+        return line;
+    }
+    if let Some(line) = fit_footer_hints(hints, FooterHintLabelMode::Compact, width) {
+        return line;
+    }
+    if let Some(line) = fit_footer_hints(hints, FooterHintLabelMode::KeyOnly, width) {
+        return line;
+    }
+
+    let mut retained = (0..hints.len()).collect::<Vec<_>>();
+    retained.sort_by_key(|idx| hints[*idx].priority);
+    for retain_count in (1..=retained.len()).rev() {
+        let mut candidate_indices = retained[..retain_count].to_vec();
+        candidate_indices.sort_unstable();
+        let candidate = candidate_indices
+            .iter()
+            .map(|idx| &hints[*idx])
+            .collect::<Vec<_>>();
+        if let Some(line) = fit_footer_hint_refs(&candidate, FooterHintLabelMode::KeyOnly, width) {
+            return line;
+        }
+    }
+    Line::default()
+}
+
+pub(crate) fn render_footer_separator(area: Rect, buf: &mut Buffer, label: String) {
+    if area.width == 0 {
+        return;
+    }
+
+    Line::from("─".repeat(area.width as usize).dim()).render_ref(area, buf);
+    if label.is_empty() {
+        return;
+    }
+
+    let label_width = UnicodeWidthStr::width(label.as_str()) as u16;
+    if label_width < area.width {
+        let label_area = Rect::new(
+            area.x + area.width - label_width - 1,
+            area.y,
+            label_width,
+            1,
+        );
+        Line::from(label.dim()).render_ref(label_area, buf);
+    }
+}
+
+fn fit_footer_hints(
+    hints: &[FooterHint],
+    mode: FooterHintLabelMode,
+    width: u16,
+) -> Option<Line<'static>> {
+    let hint_refs = hints.iter().collect::<Vec<_>>();
+    fit_footer_hint_refs(&hint_refs, mode, width)
+}
+
+fn fit_footer_hint_refs(
+    hints: &[&FooterHint],
+    mode: FooterHintLabelMode,
+    width: u16,
+) -> Option<Line<'static>> {
+    let gap_width = FOOTER_HINT_GAP;
+    if footer_hints_width(hints, mode, gap_width) > width as usize {
+        return None;
+    }
+
+    let mut spans = vec![
+        " ".repeat(FOOTER_HINT_LEFT_PADDING)
+            .set_style(footer_hint_label_style()),
+    ];
+    for (idx, hint) in hints.iter().enumerate() {
+        if idx > 0 {
+            spans.push(" ".repeat(gap_width).set_style(footer_hint_label_style()));
+        }
+        spans.push(hint.key.clone().set_style(footer_hint_key_style()));
+        let label = match mode {
+            FooterHintLabelMode::Wide => Some(hint.wide_label.as_str()),
+            FooterHintLabelMode::Compact => Some(hint.compact_label.as_str()),
+            FooterHintLabelMode::KeyOnly => None,
+        };
+        if let Some(label) = label {
+            spans.push(" ".set_style(footer_hint_label_style()));
+            spans.push(label.to_string().set_style(footer_hint_label_style()));
+        }
+    }
+    Some(spans.into())
+}
+
+fn footer_hint_key_style() -> Style {
+    if default_bg().is_some_and(is_light) {
+        Style::default().fg(Color::Black)
+    } else {
+        Style::default()
+    }
+}
+
+fn footer_hint_label_style() -> Style {
+    if default_bg().is_some_and(is_light) {
+        Style::default().fg(Color::DarkGray)
+    } else {
+        Style::default().dim()
+    }
+}
+
+fn footer_hints_width(hints: &[&FooterHint], mode: FooterHintLabelMode, gap_width: usize) -> usize {
+    FOOTER_HINT_LEFT_PADDING
+        + hints
+            .iter()
+            .enumerate()
+            .map(|(idx, hint)| {
+                let label_width = match mode {
+                    FooterHintLabelMode::Wide => {
+                        1 + UnicodeWidthStr::width(hint.wide_label.as_str())
+                    }
+                    FooterHintLabelMode::Compact => {
+                        1 + UnicodeWidthStr::width(hint.compact_label.as_str())
+                    }
+                    FooterHintLabelMode::KeyOnly => 0,
+                };
+                let hint_width = UnicodeWidthStr::width(hint.key.as_str()) + label_width;
+                if idx == 0 {
+                    hint_width
+                } else {
+                    hint_width + gap_width
+                }
+            })
+            .sum::<usize>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn line_text(line: Line<'static>) -> String {
+        line.spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect()
+    }
+
+    #[test]
+    fn footer_hint_line_uses_wide_labels_when_width_allows() {
+        let hints = [FooterHint::new(
+            "enter",
+            "resume session",
+            "resume",
+            /*priority*/ 0,
+        )];
+
+        let rendered = line_text(footer_hint_line_for_row(&hints, /*width*/ 140));
+
+        assert!(rendered.contains("enter resume session"));
+    }
+
+    #[test]
+    fn footer_hint_line_compacts_below_breakpoint() {
+        let hints = [FooterHint::new(
+            "enter",
+            "resume session",
+            "resume",
+            /*priority*/ 0,
+        )];
+
+        let rendered = line_text(footer_hint_line_for_row(&hints, /*width*/ 80));
+
+        assert!(rendered.contains("enter resume"));
+        assert!(!rendered.contains("resume session"));
+    }
+
+    #[test]
+    fn footer_hint_line_drops_low_priority_hints_when_narrow() {
+        let hints = [
+            FooterHint::new("a", "alpha", "alpha", /*priority*/ 0),
+            FooterHint::new("b", "bravo", "bravo", /*priority*/ 9),
+            FooterHint::new("c", "charlie", "charlie", /*priority*/ 1),
+        ];
+
+        let rendered = line_text(footer_hint_line_for_row(&hints, /*width*/ 6));
+
+        assert!(rendered.contains('a'));
+        assert!(rendered.contains('c'));
+        assert!(!rendered.contains('b'));
+    }
+}

--- a/codex-rs/tui/src/footer_hints.rs
+++ b/codex-rs/tui/src/footer_hints.rs
@@ -1,4 +1,6 @@
 use crate::color::is_light;
+use crate::line_truncation::line_width;
+use crate::line_truncation::truncate_line_with_ellipsis_if_overflow;
 use crate::terminal_palette::default_bg;
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
@@ -7,6 +9,7 @@ use ratatui::style::Style;
 use ratatui::style::Styled as _;
 use ratatui::style::Stylize as _;
 use ratatui::text::Line;
+use ratatui::widgets::Widget;
 use ratatui::widgets::WidgetRef;
 use unicode_width::UnicodeWidthStr;
 
@@ -96,6 +99,62 @@ pub(crate) fn render_footer_separator(area: Rect, buf: &mut Buffer, label: Strin
     }
 }
 
+pub(crate) fn render_footer_line_with_optional_right(
+    area: Rect,
+    buf: &mut Buffer,
+    left: Line<'static>,
+    right: Option<Line<'static>>,
+) {
+    let Some(right) = right else {
+        left.render(area, buf);
+        return;
+    };
+    if area.width == 0 {
+        return;
+    }
+
+    let right_width = line_width(&right) as u16;
+    if right_width > area.width {
+        truncate_line_with_ellipsis_if_overflow(right, area.width as usize).render(area, buf);
+        return;
+    }
+
+    let left_width = line_width(&left) as u16;
+    let gap = u16::from(left_width > 0 && right_width > 0);
+    let left_area_width = area.width.saturating_sub(right_width).saturating_sub(gap);
+    if left_area_width == 0 {
+        right.render(
+            Rect {
+                x: area.x + area.width - right_width,
+                y: area.y,
+                width: right_width,
+                height: 1,
+            },
+            buf,
+        );
+        return;
+    }
+
+    truncate_line_with_ellipsis_if_overflow(left, left_area_width as usize).render(
+        Rect {
+            x: area.x,
+            y: area.y,
+            width: left_area_width,
+            height: 1,
+        },
+        buf,
+    );
+    right.render(
+        Rect {
+            x: area.x + area.width - right_width,
+            y: area.y,
+            width: right_width,
+            height: 1,
+        },
+        buf,
+    );
+}
+
 fn fit_footer_hints(
     hints: &[FooterHint],
     mode: FooterHintLabelMode,
@@ -181,6 +240,19 @@ fn footer_hints_width(hints: &[&FooterHint], mode: FooterHintLabelMode, gap_widt
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ratatui::buffer::Buffer;
+    use ratatui::layout::Rect;
+
+    fn buffer_text(buf: &Buffer, area: Rect) -> String {
+        let mut out = String::new();
+        for y in area.y..area.bottom() {
+            for x in area.x..area.right() {
+                let symbol = buf[(x, y)].symbol();
+                out.push(symbol.chars().next().unwrap_or(' '));
+            }
+        }
+        out
+    }
 
     fn line_text(line: Line<'static>) -> String {
         line.spans
@@ -231,5 +303,73 @@ mod tests {
         assert!(rendered.contains('a'));
         assert!(rendered.contains('c'));
         assert!(!rendered.contains('b'));
+    }
+
+    #[test]
+    fn footer_line_renders_left_and_right_when_both_fit() {
+        let area = Rect::new(
+            /*x*/ 0, /*y*/ 0, /*width*/ 24, /*height*/ 1,
+        );
+        let mut buf = Buffer::empty(area);
+
+        render_footer_line_with_optional_right(
+            area,
+            &mut buf,
+            Line::from("left"),
+            Some(Line::from("right")),
+        );
+
+        assert_eq!(buffer_text(&buf, area), "left               right");
+    }
+
+    #[test]
+    fn footer_line_truncates_left_when_right_fits() {
+        let area = Rect::new(
+            /*x*/ 0, /*y*/ 0, /*width*/ 16, /*height*/ 1,
+        );
+        let mut buf = Buffer::empty(area);
+
+        render_footer_line_with_optional_right(
+            area,
+            &mut buf,
+            Line::from("long left status"),
+            Some(Line::from("ok")),
+        );
+
+        assert_eq!(buffer_text(&buf, area), "long left st… ok");
+    }
+
+    #[test]
+    fn footer_line_renders_right_only_when_space_is_tight() {
+        let area = Rect::new(
+            /*x*/ 0, /*y*/ 0, /*width*/ 5, /*height*/ 1,
+        );
+        let mut buf = Buffer::empty(area);
+
+        render_footer_line_with_optional_right(
+            area,
+            &mut buf,
+            Line::from("left"),
+            Some(Line::from("right")),
+        );
+
+        assert_eq!(buffer_text(&buf, area), "right");
+    }
+
+    #[test]
+    fn footer_line_truncates_right_when_it_overflows_area() {
+        let area = Rect::new(
+            /*x*/ 0, /*y*/ 0, /*width*/ 4, /*height*/ 1,
+        );
+        let mut buf = Buffer::empty(area);
+
+        render_footer_line_with_optional_right(
+            area,
+            &mut buf,
+            Line::from("left"),
+            Some(Line::from("status")),
+        );
+
+        assert_eq!(buffer_text(&buf, area), "sta…");
     }
 }

--- a/codex-rs/tui/src/footer_hints.rs
+++ b/codex-rs/tui/src/footer_hints.rs
@@ -99,6 +99,14 @@ pub(crate) fn render_footer_separator(area: Rect, buf: &mut Buffer, label: Strin
     }
 }
 
+pub(crate) fn first_fitting_right_label(width: u16, labels: &[String]) -> String {
+    labels
+        .iter()
+        .find(|label| UnicodeWidthStr::width(label.as_str()) < width as usize)
+        .cloned()
+        .unwrap_or_default()
+}
+
 pub(crate) fn render_footer_line_with_optional_right(
     area: Rect,
     buf: &mut Buffer,
@@ -371,5 +379,26 @@ mod tests {
         );
 
         assert_eq!(buffer_text(&buf, area), "sta…");
+    }
+
+    #[test]
+    fn first_fitting_right_label_picks_first_that_fits() {
+        let labels = vec![
+            " 10 / 120 · 55% ".to_string(),
+            " 10/120 · 55% ".to_string(),
+            " 55% ".to_string(),
+        ];
+
+        assert_eq!(
+            first_fitting_right_label(/*width*/ 15, &labels),
+            " 10/120 · 55% "
+        );
+    }
+
+    #[test]
+    fn first_fitting_right_label_returns_empty_when_nothing_fits() {
+        let labels = vec![" 100% ".to_string()];
+
+        assert_eq!(first_fitting_right_label(/*width*/ 4, &labels), "");
     }
 }

--- a/codex-rs/tui/src/history_cell/hook_cell.rs
+++ b/codex-rs/tui/src/history_cell/hook_cell.rs
@@ -11,12 +11,15 @@
 //!    first drawn.
 //! 4. Completed runs only persist when they have output or a non-success status.
 use super::HistoryCell;
+use super::plain_hyperlink_lines;
 use super::plain_lines;
+use crate::history_cell::HistoryRenderMode;
 use crate::motion::MotionMode;
 use crate::motion::ReducedMotionIndicator;
 use crate::motion::activity_indicator;
 use crate::motion::shimmer_text;
 use crate::render::renderable::Renderable;
+use crate::terminal_hyperlinks::HyperlinkLine;
 use codex_app_server_protocol::HookEventName;
 use codex_app_server_protocol::HookOutputEntry;
 use codex_app_server_protocol::HookOutputEntryKind;
@@ -344,6 +347,21 @@ impl HistoryCell for HookCell {
         self.display_lines(width)
     }
 
+    fn transcript_lines_for_mode(&self, width: u16, mode: HistoryRenderMode) -> Vec<Line<'static>> {
+        match mode {
+            HistoryRenderMode::Rich => self.rich_transcript_lines(width),
+            HistoryRenderMode::Raw => self.raw_lines(),
+        }
+    }
+
+    fn transcript_hyperlink_lines_for_mode(
+        &self,
+        width: u16,
+        mode: HistoryRenderMode,
+    ) -> Vec<HyperlinkLine> {
+        plain_hyperlink_lines(self.transcript_lines_for_mode(width, mode))
+    }
+
     fn raw_lines(&self) -> Vec<Line<'static>> {
         plain_lines(self.display_lines(u16::MAX))
     }
@@ -360,6 +378,45 @@ impl HistoryCell for HookCell {
             .find_map(|run| run.state.start_time())?
             .elapsed();
         Some(elapsed.as_millis() as u64 / 600)
+    }
+}
+
+impl HookCell {
+    fn rich_transcript_lines(&self, _width: u16) -> Vec<Line<'static>> {
+        let mut lines = Vec::new();
+        let mut running_group: Option<RunningHookGroup> = None;
+        for run in &self.runs {
+            if !run.state.should_render() {
+                continue;
+            }
+
+            let Some(key) = run.running_group_key() else {
+                if let Some(group) = running_group.take() {
+                    push_running_hook_group(&mut lines, &group, self.animations_enabled);
+                }
+                push_hook_line_separator(&mut lines);
+                run.push_rich_transcript_lines(&mut lines, self.animations_enabled);
+                continue;
+            };
+
+            if let Some(group) = running_group.as_mut()
+                && group.key == key
+            {
+                group.count += 1;
+                group.start_time = earliest_instant(group.start_time, run.state.start_time());
+                continue;
+            }
+
+            if let Some(group) =
+                running_group.replace(RunningHookGroup::new(key, run.state.start_time()))
+            {
+                push_running_hook_group(&mut lines, &group, self.animations_enabled);
+            }
+        }
+        if let Some(group) = running_group {
+            push_running_hook_group(&mut lines, &group, self.animations_enabled);
+        }
+        lines
     }
 }
 
@@ -457,6 +514,52 @@ impl HookRunCell {
                         } else {
                             lines.push(format!("{HOOK_OUTPUT_BODY_INDENT}{line}").into());
                         }
+                    }
+                }
+            }
+            HookRunState::PendingReveal { .. } => {}
+        }
+    }
+
+    fn push_rich_transcript_lines(&self, lines: &mut Vec<Line<'static>>, animations_enabled: bool) {
+        let label = hook_event_label(self.event_name);
+        match &self.state {
+            HookRunState::VisibleRunning { start_time, .. }
+            | HookRunState::QuietLinger { start_time, .. } => {
+                let hook_text = format!("Running {label} hook");
+                push_running_hook_header(
+                    lines,
+                    &hook_text,
+                    Some(*start_time),
+                    self.status_message.as_deref(),
+                    animations_enabled,
+                );
+            }
+            HookRunState::Completed { status, entries } => {
+                let status_text = format!("{status:?}").to_lowercase();
+                let bullet = hook_completed_bullet(*status, entries);
+                lines.push(
+                    vec![
+                        bullet,
+                        " ".into(),
+                        format!("{label} hook ({status_text})").into(),
+                    ]
+                    .into(),
+                );
+                for entry in entries {
+                    if entry.kind == HookOutputEntryKind::Context {
+                        let line_count = entry.text.lines().count().max(1);
+                        let label = if line_count == 1 { "line" } else { "lines" };
+                        lines.push(
+                            format!(
+                                "  hook context: [collapsed in rich transcript; {line_count} {label}]"
+                            )
+                            .into(),
+                        );
+                    } else {
+                        lines.push(
+                            format!("  {}{}", hook_output_prefix(entry.kind), entry.text).into(),
+                        );
                     }
                 }
             }
@@ -878,6 +981,58 @@ mod tests {
             .iter()
             .map(|span| span.content.as_ref())
             .collect::<String>()
+    }
+
+    #[test]
+    fn rich_transcript_collapses_hook_context_but_raw_keeps_it() {
+        let mut run = hook_run_summary("hook-1");
+        run.status = HookRunStatus::Completed;
+        run.status_message = None;
+        run.entries = vec![
+            HookOutputEntry {
+                kind: HookOutputEntryKind::Context,
+                text: "line one\nline two".to_string(),
+            },
+            HookOutputEntry {
+                kind: HookOutputEntryKind::Warning,
+                text: "stay visible".to_string(),
+            },
+        ];
+        let cell = HookCell::new_completed(run, /*animations_enabled*/ false);
+
+        let rich = cell
+            .transcript_lines_for_mode(/*width*/ 80, HistoryRenderMode::Rich)
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|span| span.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>();
+        let raw = cell
+            .transcript_lines_for_mode(/*width*/ 80, HistoryRenderMode::Raw)
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|span| span.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>();
+
+        assert!(
+            rich.iter()
+                .any(|line| line.contains("collapsed in rich transcript"))
+        );
+        assert!(
+            rich.iter()
+                .any(|line| line.contains("warning: stay visible"))
+        );
+        assert!(
+            raw.iter()
+                .any(|line| line.contains("hook context: line one"))
+        );
     }
 
     fn hook_run_summary(id: &str) -> HookRunSummary {

--- a/codex-rs/tui/src/history_cell/messages.rs
+++ b/codex-rs/tui/src/history_cell/messages.rs
@@ -191,6 +191,47 @@ impl HistoryCell for UserHistoryCell {
         }
         lines
     }
+
+    fn transcript_lines_for_mode(&self, width: u16, mode: HistoryRenderMode) -> Vec<Line<'static>> {
+        match mode {
+            HistoryRenderMode::Rich => self.injected_context_summary().map_or_else(
+                || self.display_lines(width),
+                |summary| vec![Line::from(summary)],
+            ),
+            HistoryRenderMode::Raw => self.raw_lines(),
+        }
+    }
+
+    fn transcript_hyperlink_lines_for_mode(
+        &self,
+        width: u16,
+        mode: HistoryRenderMode,
+    ) -> Vec<HyperlinkLine> {
+        plain_hyperlink_lines(self.transcript_lines_for_mode(width, mode))
+    }
+
+    fn is_user_prompt(&self) -> bool {
+        self.injected_context_summary().is_none()
+    }
+}
+
+impl UserHistoryCell {
+    fn injected_context_summary(&self) -> Option<String> {
+        let label = if self.message.starts_with("# AGENTS.md instructions for ") {
+            "AGENTS.md instructions"
+        } else if self.message.starts_with("<environment_context>") {
+            "environment context"
+        } else if self.message.starts_with("<permissions instructions>") {
+            "permissions instructions"
+        } else {
+            return None;
+        };
+        let line_count = self.message.lines().count().max(1);
+        let noun = if line_count == 1 { "line" } else { "lines" };
+        Some(format!(
+            "{label}: [collapsed in rich transcript; {line_count} {noun}]"
+        ))
+    }
 }
 
 #[derive(Debug)]

--- a/codex-rs/tui/src/history_cell/mod.rs
+++ b/codex-rs/tui/src/history_cell/mod.rs
@@ -253,13 +253,38 @@ pub(crate) trait HistoryCell: std::fmt::Debug + Send + Sync + Any {
         plain_hyperlink_lines(self.transcript_lines(width))
     }
 
+    /// Returns transcript overlay lines for the selected render mode.
+    fn transcript_lines_for_mode(&self, width: u16, mode: HistoryRenderMode) -> Vec<Line<'static>> {
+        match mode {
+            HistoryRenderMode::Rich => self.transcript_lines(width),
+            HistoryRenderMode::Raw => self.raw_lines(),
+        }
+    }
+
+    /// Returns transcript-overlay lines plus terminal hyperlink metadata for the selected mode.
+    fn transcript_hyperlink_lines_for_mode(
+        &self,
+        width: u16,
+        mode: HistoryRenderMode,
+    ) -> Vec<HyperlinkLine> {
+        match mode {
+            HistoryRenderMode::Rich => self.transcript_hyperlink_lines(width),
+            HistoryRenderMode::Raw => plain_hyperlink_lines(self.raw_lines()),
+        }
+    }
+
     /// Returns the number of viewport rows for the transcript overlay.
     ///
     /// Uses the same `Paragraph::line_count` measurement as
     /// `desired_height`. Contains a workaround for a ratatui bug where
     /// a single whitespace-only line reports 2 rows instead of 1.
+    #[allow(dead_code)]
     fn desired_transcript_height(&self, width: u16) -> u16 {
-        let lines = visible_lines(self.transcript_hyperlink_lines(width));
+        self.desired_transcript_height_for_mode(width, HistoryRenderMode::Rich)
+    }
+
+    fn desired_transcript_height_for_mode(&self, width: u16, mode: HistoryRenderMode) -> u16 {
+        let lines = visible_lines(self.transcript_hyperlink_lines_for_mode(width, mode));
         // Workaround: ratatui's line_count returns 2 for a single
         // whitespace-only line. Clamp to 1 in that case.
         if let [line] = &lines[..]
@@ -279,6 +304,10 @@ pub(crate) trait HistoryCell: std::fmt::Debug + Send + Sync + Any {
     }
 
     fn is_stream_continuation(&self) -> bool {
+        false
+    }
+
+    fn is_user_prompt(&self) -> bool {
         false
     }
 

--- a/codex-rs/tui/src/history_cell/tests.rs
+++ b/codex-rs/tui/src/history_cell/tests.rs
@@ -2005,6 +2005,33 @@ fn user_history_cell_height_matches_rendered_lines_with_remote_images() {
 }
 
 #[test]
+fn injected_context_collapses_only_in_rich_transcript_mode() {
+    let cell = UserHistoryCell {
+        message: "# AGENTS.md instructions for /tmp/example\nline one\nline two".to_string(),
+        text_elements: Vec::new(),
+        local_image_paths: Vec::new(),
+        remote_image_urls: Vec::new(),
+    };
+
+    let rich = render_lines(&cell.transcript_lines_for_mode(/*width*/ 80, HistoryRenderMode::Rich));
+    let raw = render_lines(&cell.transcript_lines_for_mode(/*width*/ 80, HistoryRenderMode::Raw));
+
+    assert_eq!(
+        rich,
+        vec!["AGENTS.md instructions: [collapsed in rich transcript; 3 lines]"]
+    );
+    assert_eq!(
+        raw,
+        vec![
+            "# AGENTS.md instructions for /tmp/example",
+            "line one",
+            "line two",
+        ]
+    );
+    assert!(!cell.is_user_prompt());
+}
+
+#[test]
 fn user_history_cell_trims_trailing_blank_message_lines() {
     let cell = UserHistoryCell {
         message: "line one\n\n   \n\t \n".to_string(),

--- a/codex-rs/tui/src/keymap.rs
+++ b/codex-rs/tui/src/keymap.rs
@@ -221,6 +221,8 @@ pub(crate) struct PagerKeymap {
     pub(crate) jump_bottom: Vec<KeyBinding>,
     pub(crate) close: Vec<KeyBinding>,
     pub(crate) close_transcript: Vec<KeyBinding>,
+    pub(crate) previous_user_prompt: Vec<KeyBinding>,
+    pub(crate) next_user_prompt: Vec<KeyBinding>,
 }
 
 /// Generic list picker keybindings shared across popup list views.
@@ -749,6 +751,8 @@ impl RuntimeKeymap {
             jump_bottom: resolve_local!(keymap, defaults, pager, jump_bottom),
             close: resolve_local!(keymap, defaults, pager, close),
             close_transcript: resolve_local!(keymap, defaults, pager, close_transcript),
+            previous_user_prompt: resolve_local!(keymap, defaults, pager, previous_user_prompt),
+            next_user_prompt: resolve_local!(keymap, defaults, pager, next_user_prompt),
         };
 
         let approval = ApprovalKeymap {
@@ -1087,6 +1091,8 @@ impl RuntimeKeymap {
                 jump_bottom: default_bindings![plain(KeyCode::End)],
                 close: default_bindings![plain(KeyCode::Char('q')), ctrl(KeyCode::Char('c'))],
                 close_transcript: default_bindings![ctrl(KeyCode::Char('t'))],
+                previous_user_prompt: default_bindings![alt(KeyCode::Up)],
+                next_user_prompt: default_bindings![alt(KeyCode::Down)],
             },
             list: ListKeymap {
                 move_up: default_bindings![
@@ -1553,6 +1559,11 @@ impl RuntimeKeymap {
                 ("jump_bottom", self.pager.jump_bottom.as_slice()),
                 ("close", self.pager.close.as_slice()),
                 ("close_transcript", self.pager.close_transcript.as_slice()),
+                (
+                    "previous_user_prompt",
+                    self.pager.previous_user_prompt.as_slice(),
+                ),
+                ("next_user_prompt", self.pager.next_user_prompt.as_slice()),
             ],
         )?;
 
@@ -1569,6 +1580,11 @@ impl RuntimeKeymap {
                 ("jump_bottom", self.pager.jump_bottom.as_slice()),
                 ("close", self.pager.close.as_slice()),
                 ("close_transcript", self.pager.close_transcript.as_slice()),
+                (
+                    "previous_user_prompt",
+                    self.pager.previous_user_prompt.as_slice(),
+                ),
+                ("next_user_prompt", self.pager.next_user_prompt.as_slice()),
             ],
             TRANSCRIPT_BACKTRACK_RESERVED_BINDINGS,
             [],

--- a/codex-rs/tui/src/keymap.rs
+++ b/codex-rs/tui/src/keymap.rs
@@ -1091,8 +1091,8 @@ impl RuntimeKeymap {
                 jump_bottom: default_bindings![plain(KeyCode::End)],
                 close: default_bindings![plain(KeyCode::Char('q')), ctrl(KeyCode::Char('c'))],
                 close_transcript: default_bindings![ctrl(KeyCode::Char('t'))],
-                previous_user_prompt: default_bindings![alt(KeyCode::Up)],
-                next_user_prompt: default_bindings![alt(KeyCode::Down)],
+                previous_user_prompt: default_bindings![plain(KeyCode::Left), alt(KeyCode::Up)],
+                next_user_prompt: default_bindings![plain(KeyCode::Right), alt(KeyCode::Down)],
             },
             list: ListKeymap {
                 move_up: default_bindings![
@@ -1802,14 +1802,6 @@ const TRANSCRIPT_BACKTRACK_RESERVED_BINDINGS: &[(&str, KeyBinding)] = &[
     (
         "fixed.transcript_edit_previous",
         key_hint::plain(KeyCode::Esc),
-    ),
-    (
-        "fixed.transcript_edit_previous",
-        key_hint::plain(KeyCode::Left),
-    ),
-    (
-        "fixed.transcript_edit_next",
-        key_hint::plain(KeyCode::Right),
     ),
     (
         "fixed.transcript_confirm_edit",
@@ -2642,9 +2634,26 @@ mod tests {
     #[test]
     fn rejects_pager_bindings_that_collide_with_transcript_backtrack_keys() {
         let mut keymap = TuiKeymap::default();
-        keymap.pager.close = Some(one("left"));
+        keymap.pager.close = Some(one("enter"));
 
-        expect_conflict(&keymap, "close", "fixed.transcript_edit_previous");
+        expect_conflict(&keymap, "close", "fixed.transcript_confirm_edit");
+    }
+
+    #[test]
+    fn pager_prompt_selection_defaults_to_left_and_right_arrows() {
+        let runtime = RuntimeKeymap::defaults();
+
+        assert_eq!(
+            runtime.pager.previous_user_prompt,
+            vec![key_hint::plain(KeyCode::Left), key_hint::alt(KeyCode::Up)]
+        );
+        assert_eq!(
+            runtime.pager.next_user_prompt,
+            vec![
+                key_hint::plain(KeyCode::Right),
+                key_hint::alt(KeyCode::Down)
+            ]
+        );
     }
 
     #[test]

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -133,6 +133,7 @@ mod external_agent_config_migration;
 mod external_agent_config_migration_startup;
 mod external_editor;
 mod file_search;
+mod footer_hints;
 mod frames;
 mod get_git_diff;
 mod git_action_directives;

--- a/codex-rs/tui/src/pager_overlay.rs
+++ b/codex-rs/tui/src/pager_overlay.rs
@@ -19,6 +19,9 @@ use std::io::Result;
 use std::sync::Arc;
 
 use crate::chatwidget::ActiveCellTranscriptKey;
+use crate::footer_hints::FooterHint;
+use crate::footer_hints::footer_hint_line_for_row;
+use crate::footer_hints::render_footer_separator;
 use crate::history_cell::HistoryCell;
 use crate::history_cell::HistoryRenderMode;
 use crate::history_cell::UserHistoryCell;
@@ -43,7 +46,6 @@ use ratatui::layout::Rect;
 use ratatui::style::Style;
 use ratatui::style::Stylize;
 use ratatui::text::Line;
-use ratatui::text::Span;
 use ratatui::text::Text;
 use ratatui::widgets::Clear;
 use ratatui::widgets::Paragraph;
@@ -125,25 +127,12 @@ fn first_or_empty(bindings: &[KeyBinding]) -> Vec<KeyBinding> {
     bindings.first().copied().into_iter().collect()
 }
 
-// Render a single line of key hints from (key(s), description) pairs.
-fn render_key_hints(area: Rect, buf: &mut Buffer, pairs: &[(Vec<KeyBinding>, &str)]) {
-    let mut spans: Vec<Span<'static>> = vec![" ".into()];
-    let mut first = true;
-    for (keys, desc) in pairs {
-        if !first {
-            spans.push("   ".into());
-        }
-        for (i, key) in keys.iter().enumerate() {
-            if i > 0 {
-                spans.push("/".into());
-            }
-            spans.push(Span::from(key));
-        }
-        spans.push(" ".into());
-        spans.push(Span::from(desc.to_string()));
-        first = false;
-    }
-    Paragraph::new(vec![Line::from(spans).dim()]).render_ref(area, buf);
+fn key_label(bindings: &[KeyBinding]) -> String {
+    bindings
+        .iter()
+        .map(KeyBinding::display_label)
+        .collect::<Vec<_>>()
+        .join("/")
 }
 
 /// Generic widget for rendering a pager view.
@@ -223,11 +212,11 @@ impl PagerView {
 
     fn render(&mut self, area: Rect, buf: &mut Buffer) {
         Clear.render(area, buf);
-        self.render_header(area, buf);
         let content_area = self.content_area(area);
         self.update_last_content_height(content_area.height);
         let content_height = self.content_height(content_area.width);
         self.last_rendered_height = Some(content_height);
+        self.render_header(area, content_area, buf, content_height);
         // If there is a pending request to scroll a specific chunk into view,
         // satisfy it now that wrapping is up to date for this width.
         if let Some(idx) = self.pending_scroll_chunk.take() {
@@ -242,12 +231,13 @@ impl PagerView {
         self.render_bottom_bar(area, content_area, buf, content_height);
     }
 
-    fn render_header(&self, area: Rect, buf: &mut Buffer) {
-        Span::from("/ ".repeat(area.width as usize / 2))
+    fn render_header(&self, area: Rect, content_area: Rect, buf: &mut Buffer, total_len: usize) {
+        let header = Rect::new(area.x, area.y, area.width, 1);
+        render_footer_separator(header, buf, String::new());
+        let percent = self.scroll_percent(content_area.height, total_len);
+        format!(" {} · {percent}% ", self.title)
             .dim()
-            .render_ref(area, buf);
-        let header = format!("/ {}", self.title);
-        header.dim().render_ref(area, buf);
+            .render_ref(header, buf);
     }
 
     fn render_content(&mut self, area: Rect, buf: &mut Buffer) {
@@ -310,31 +300,23 @@ impl PagerView {
         full_area: Rect,
         content_area: Rect,
         buf: &mut Buffer,
-        total_len: usize,
+        _total_len: usize,
     ) {
         let sep_y = content_area.bottom();
         let sep_rect = Rect::new(full_area.x, sep_y, full_area.width, 1);
 
-        Span::from("─".repeat(sep_rect.width as usize))
-            .dim()
-            .render_ref(sep_rect, buf);
-        let percent = if total_len == 0 {
-            100
-        } else {
-            let max_scroll = total_len.saturating_sub(content_area.height as usize);
-            if max_scroll == 0 {
-                100
-            } else {
-                (((self.scroll_offset.min(max_scroll)) as f32 / max_scroll as f32) * 100.0).round()
-                    as u8
-            }
-        };
-        let pct_text = format!(" {percent}% ");
-        let pct_w = pct_text.chars().count() as u16;
-        let pct_x = sep_rect.x + sep_rect.width - pct_w - 1;
-        Span::from(pct_text)
-            .dim()
-            .render_ref(Rect::new(pct_x, sep_rect.y, pct_w, 1), buf);
+        render_footer_separator(sep_rect, buf, String::new());
+    }
+
+    fn scroll_percent(&self, content_height: u16, total_len: usize) -> u8 {
+        if total_len == 0 {
+            return 100;
+        }
+        let max_scroll = total_len.saturating_sub(content_height as usize);
+        if max_scroll == 0 {
+            return 100;
+        }
+        (((self.scroll_offset.min(max_scroll)) as f32 / max_scroll as f32) * 100.0).round() as u8
     }
 
     fn handle_key_event(&mut self, tui: &mut tui::Tui, key_event: KeyEvent) -> Result<()> {
@@ -567,7 +549,7 @@ impl TranscriptOverlay {
         Self {
             view: PagerView::new(
                 Self::render_cells(&transcript_cells, state.highlight_cell, state.render_mode),
-                "T R A N S C R I P T".to_string(),
+                "Transcript".to_string(),
                 state.scroll_offset,
                 keymap,
             ),
@@ -592,7 +574,7 @@ impl TranscriptOverlay {
             .enumerate()
             .flat_map(|(i, c)| {
                 let mut v: Vec<Box<dyn Renderable>> = Vec::new();
-                let mut cell_renderable = if c.as_any().is::<UserHistoryCell>() {
+                let base_renderable = if c.as_any().is::<UserHistoryCell>() {
                     Box::new(CachedRenderable::new(CellRenderable {
                         cell: c.clone(),
                         style: if highlight_cell == Some(i) {
@@ -609,6 +591,7 @@ impl TranscriptOverlay {
                         render_mode,
                     })) as Box<dyn Renderable>
                 };
+                let mut cell_renderable = base_renderable;
                 if !c.is_stream_continuation() && i > 0 {
                     cell_renderable = Box::new(InsetRenderable::new(
                         cell_renderable,
@@ -853,6 +836,29 @@ impl TranscriptOverlay {
         self.set_highlight_cell(Some(next_prompt));
     }
 
+    fn header_title(&self) -> String {
+        let total = self
+            .cells
+            .iter()
+            .filter(|cell| cell.is_user_prompt())
+            .count();
+        let Some(highlight_cell) = self.highlight_cell else {
+            let noun = if total == 1 { "prompt" } else { "prompts" };
+            return format!("Transcript · {total} {noun}");
+        };
+        let selected = self
+            .cells
+            .iter()
+            .take(highlight_cell.saturating_add(1))
+            .filter(|cell| cell.is_user_prompt())
+            .count();
+        if selected == 0 || total == 0 {
+            let noun = if total == 1 { "prompt" } else { "prompts" };
+            return format!("Transcript · {total} {noun}");
+        }
+        format!("Transcript · {selected}/{total}")
+    }
+
     fn rebuild_renderables(&mut self) {
         let tail_renderable = self.take_live_tail_renderable();
         self.view.renderables =
@@ -898,69 +904,108 @@ impl TranscriptOverlay {
     fn render_hints(&self, area: Rect, buf: &mut Buffer) {
         let line1 = Rect::new(area.x, area.y, area.width, 1);
         let line2 = Rect::new(area.x, area.y.saturating_add(1), area.width, 1);
-        render_key_hints(
-            line1,
-            buf,
-            &[
-                (
-                    first_or_empty(&self.view.keymap.scroll_up)
-                        .into_iter()
-                        .chain(first_or_empty(&self.view.keymap.scroll_down))
-                        .collect(),
-                    "to scroll",
-                ),
-                (
-                    first_or_empty(&self.view.keymap.page_up)
-                        .into_iter()
-                        .chain(first_or_empty(&self.view.keymap.page_down))
-                        .collect(),
-                    "to page",
-                ),
-                (
-                    first_or_empty(&self.view.keymap.jump_top)
-                        .into_iter()
-                        .chain(first_or_empty(&self.view.keymap.jump_bottom))
-                        .collect(),
-                    "to jump",
-                ),
-                (
-                    first_or_empty(&self.view.keymap.previous_user_prompt)
-                        .into_iter()
-                        .chain(first_or_empty(&self.view.keymap.next_user_prompt))
-                        .collect(),
-                    "to prompts",
-                ),
-            ],
-        );
+        let scroll_keys = first_or_empty(&self.view.keymap.scroll_up)
+            .into_iter()
+            .chain(first_or_empty(&self.view.keymap.scroll_down))
+            .collect::<Vec<_>>();
+        let page_keys = first_or_empty(&self.view.keymap.page_up)
+            .into_iter()
+            .chain(first_or_empty(&self.view.keymap.page_down))
+            .collect::<Vec<_>>();
+        let jump_keys = first_or_empty(&self.view.keymap.jump_top)
+            .into_iter()
+            .chain(first_or_empty(&self.view.keymap.jump_bottom))
+            .collect::<Vec<_>>();
+        let prompt_keys = first_or_empty(&self.view.keymap.previous_user_prompt)
+            .into_iter()
+            .chain(first_or_empty(&self.view.keymap.next_user_prompt))
+            .collect::<Vec<_>>();
+        let navigation_hints = vec![
+            FooterHint::new(
+                key_label(&scroll_keys),
+                "scroll",
+                "scroll",
+                /*priority*/ 1,
+            ),
+            FooterHint::new(
+                key_label(&prompt_keys),
+                "prompts",
+                "prompts",
+                /*priority*/ 2,
+            ),
+            FooterHint::new(key_label(&page_keys), "page", "page", /*priority*/ 6),
+            FooterHint::new(key_label(&jump_keys), "jump", "jump", /*priority*/ 7),
+        ];
+        footer_hint_line_for_row(&navigation_hints, area.width).render_ref(line1, buf);
 
-        let mut pairs: Vec<(Vec<KeyBinding>, &str)> = Vec::new();
+        let mut action_hints = Vec::new();
+        action_hints.push(FooterHint::new(
+            key_label(&first_or_empty(&self.view.keymap.close)),
+            "quit",
+            "quit",
+            /*priority*/ 0,
+        ));
         if !self.copy_keymap.is_empty() {
-            pairs.push((first_or_empty(&self.copy_keymap), "to copy"));
+            action_hints.push(FooterHint::new(
+                key_label(&first_or_empty(&self.copy_keymap)),
+                "copy",
+                "copy",
+                /*priority*/ 3,
+            ));
         }
         if !self.toggle_raw_output_keymap.is_empty() {
-            pairs.push((first_or_empty(&self.toggle_raw_output_keymap), "raw"));
-        }
-        pairs.push((first_or_empty(&self.view.keymap.close), "to quit"));
-        if self.highlight_cell.is_some() {
-            pairs.push((
-                vec![
-                    key_hint::plain(KeyCode::Esc),
-                    key_hint::plain(KeyCode::Left),
-                ],
-                "to edit prev",
+            let mode_label = match self.render_mode {
+                HistoryRenderMode::Rich => "raw",
+                HistoryRenderMode::Raw => "rich",
+            };
+            action_hints.push(FooterHint::new(
+                key_label(&first_or_empty(&self.toggle_raw_output_keymap)),
+                mode_label,
+                mode_label,
+                /*priority*/ 4,
             ));
-            pairs.push((vec![key_hint::plain(KeyCode::Right)], "to edit next"));
-            pairs.push((vec![key_hint::plain(KeyCode::Enter)], "to edit message"));
-        } else {
-            pairs.push((vec![key_hint::plain(KeyCode::Esc)], "to edit prev"));
         }
-        render_key_hints(line2, buf, &pairs);
+        if self.highlight_cell.is_some() {
+            let previous_edit_keys = std::iter::once(key_hint::plain(KeyCode::Esc))
+                .chain(first_or_empty(&self.view.keymap.previous_user_prompt))
+                .collect::<Vec<_>>();
+            action_hints.push(FooterHint::new(
+                key_label(&previous_edit_keys),
+                "edit prev",
+                "prev",
+                /*priority*/ 8,
+            ));
+            action_hints.push(FooterHint::new(
+                key_label(&first_or_empty(&self.view.keymap.next_user_prompt)),
+                "edit next",
+                "next",
+                /*priority*/ 9,
+            ));
+            action_hints.push(FooterHint::new(
+                key_label(&[key_hint::plain(KeyCode::Enter)]),
+                "edit message",
+                "edit",
+                /*priority*/ 10,
+            ));
+        } else {
+            let previous_edit_keys = std::iter::once(key_hint::plain(KeyCode::Esc))
+                .chain(first_or_empty(&self.view.keymap.previous_user_prompt))
+                .collect::<Vec<_>>();
+            action_hints.push(FooterHint::new(
+                key_label(&previous_edit_keys),
+                "edit prev",
+                "prev",
+                /*priority*/ 8,
+            ));
+        }
+        footer_hint_line_for_row(&action_hints, area.width).render_ref(line2, buf);
     }
 
     pub(crate) fn render(&mut self, area: Rect, buf: &mut Buffer) {
         let top_h = area.height.saturating_sub(3);
         let top = Rect::new(area.x, area.y, area.width, top_h);
         let bottom = Rect::new(area.x, area.y + top_h, area.width, 3);
+        self.view.title = self.header_title();
         self.view.render(top, buf);
         self.render_hints(bottom, buf);
     }
@@ -1057,36 +1102,37 @@ impl StaticOverlay {
     fn render_hints(&self, area: Rect, buf: &mut Buffer) {
         let line1 = Rect::new(area.x, area.y, area.width, 1);
         let line2 = Rect::new(area.x, area.y.saturating_add(1), area.width, 1);
-        render_key_hints(
-            line1,
-            buf,
-            &[
-                (
-                    first_or_empty(&self.view.keymap.scroll_up)
-                        .into_iter()
-                        .chain(first_or_empty(&self.view.keymap.scroll_down))
-                        .collect(),
-                    "to scroll",
-                ),
-                (
-                    first_or_empty(&self.view.keymap.page_up)
-                        .into_iter()
-                        .chain(first_or_empty(&self.view.keymap.page_down))
-                        .collect(),
-                    "to page",
-                ),
-                (
-                    first_or_empty(&self.view.keymap.jump_top)
-                        .into_iter()
-                        .chain(first_or_empty(&self.view.keymap.jump_bottom))
-                        .collect(),
-                    "to jump",
-                ),
-            ],
-        );
-        let pairs: Vec<(Vec<KeyBinding>, &str)> =
-            vec![(first_or_empty(&self.view.keymap.close), "to quit")];
-        render_key_hints(line2, buf, &pairs);
+        let scroll_keys = first_or_empty(&self.view.keymap.scroll_up)
+            .into_iter()
+            .chain(first_or_empty(&self.view.keymap.scroll_down))
+            .collect::<Vec<_>>();
+        let page_keys = first_or_empty(&self.view.keymap.page_up)
+            .into_iter()
+            .chain(first_or_empty(&self.view.keymap.page_down))
+            .collect::<Vec<_>>();
+        let jump_keys = first_or_empty(&self.view.keymap.jump_top)
+            .into_iter()
+            .chain(first_or_empty(&self.view.keymap.jump_bottom))
+            .collect::<Vec<_>>();
+        let navigation_hints = vec![
+            FooterHint::new(
+                key_label(&scroll_keys),
+                "scroll",
+                "scroll",
+                /*priority*/ 1,
+            ),
+            FooterHint::new(key_label(&page_keys), "page", "page", /*priority*/ 6),
+            FooterHint::new(key_label(&jump_keys), "jump", "jump", /*priority*/ 7),
+        ];
+        footer_hint_line_for_row(&navigation_hints, area.width).render_ref(line1, buf);
+
+        let action_hints = vec![FooterHint::new(
+            key_label(&first_or_empty(&self.view.keymap.close)),
+            "quit",
+            "quit",
+            /*priority*/ 0,
+        )];
+        footer_hint_line_for_row(&action_hints, area.width).render_ref(line2, buf);
     }
 
     pub(crate) fn render(&mut self, area: Rect, buf: &mut Buffer) {
@@ -1164,11 +1210,13 @@ mod tests {
     use crate::diff_model::FileChange;
     use crate::exec_cell::CommandOutput;
     use crate::history_cell;
+    use crate::history_cell::AgentMessageCell;
     use crate::history_cell::HistoryCell;
     use crate::history_cell::new_patch_event;
     use codex_protocol::parse_command::ParsedCommand;
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
+    use ratatui::style::Modifier;
     use ratatui::text::Text;
 
     #[derive(Debug)]
@@ -1407,6 +1455,52 @@ mod tests {
 
         overlay.move_prompt_selection(PromptSelectionDirection::Next);
         assert_eq!(overlay.selected_user_cell(), Some(2));
+    }
+
+    #[test]
+    fn transcript_header_counts_selected_user_prompt() {
+        let mut overlay = transcript_overlay(vec![
+            user_cell("first"),
+            Arc::new(AgentMessageCell::new(
+                vec![Line::from("assistant")],
+                /*is_first_line*/ true,
+            )),
+            user_cell("second"),
+        ]);
+
+        assert_eq!(overlay.header_title(), "Transcript · 2 prompts");
+
+        overlay.move_prompt_selection(PromptSelectionDirection::Previous);
+        assert_eq!(overlay.header_title(), "Transcript · 2/2");
+
+        overlay.move_prompt_selection(PromptSelectionDirection::Previous);
+        assert_eq!(overlay.header_title(), "Transcript · 1/2");
+    }
+
+    #[test]
+    fn selected_user_prompt_keeps_reversed_style_without_role_gutter() {
+        let mut overlay = transcript_overlay(vec![user_cell("selected prompt")]);
+        overlay.set_highlight_cell(Some(0));
+        let area = Rect::new(
+            /*x*/ 0, /*y*/ 0, /*width*/ 60, /*height*/ 8,
+        );
+        let mut buf = Buffer::empty(area);
+
+        overlay.render(area, &mut buf);
+        let rendered = buffer_to_text(&buf, area);
+
+        assert!(!rendered.contains('▌'));
+        assert!(!rendered.contains('│'));
+        let prompt_marker = (area.y..area.bottom())
+            .flat_map(|y| (area.x..area.right()).map(move |x| (x, y)))
+            .find(|(x, y)| buf[(*x, *y)].symbol() == "›")
+            .expect("expected selected prompt marker");
+        assert!(
+            buf[prompt_marker]
+                .style()
+                .add_modifier
+                .contains(Modifier::REVERSED)
+        );
     }
 
     #[test]

--- a/codex-rs/tui/src/pager_overlay.rs
+++ b/codex-rs/tui/src/pager_overlay.rs
@@ -151,8 +151,8 @@ struct PagerView {
     last_content_height: Option<usize>,
     last_rendered_height: Option<usize>,
     layout: Option<PagerLayout>,
-    /// If set, on next render ensure this chunk is visible.
-    pending_scroll_chunk: Option<usize>,
+    /// If set, on next render position this row of the chunk near the upper third.
+    pending_anchor_chunk: Option<(usize, usize)>,
 }
 
 #[derive(Debug)]
@@ -180,7 +180,7 @@ impl PagerView {
             last_content_height: None,
             last_rendered_height: None,
             layout: None,
-            pending_scroll_chunk: None,
+            pending_anchor_chunk: None,
         }
     }
 
@@ -225,15 +225,8 @@ impl PagerView {
         self.update_last_content_height(content_area.height);
         let content_height = self.content_height(content_area.width);
         self.last_rendered_height = Some(content_height);
+        self.resolve_pending_scroll(content_area, content_height);
         self.render_header(area, content_area, buf, content_height);
-        // If there is a pending request to scroll a specific chunk into view,
-        // satisfy it now that wrapping is up to date for this width.
-        if let Some(idx) = self.pending_scroll_chunk.take() {
-            self.ensure_chunk_visible(idx, content_area);
-        }
-        self.scroll_offset = self
-            .scroll_offset
-            .min(content_height.saturating_sub(content_area.height as usize));
 
         self.render_content(content_area, buf);
 
@@ -331,7 +324,7 @@ impl PagerView {
         (((self.scroll_offset.min(max_scroll)) as f32 / max_scroll as f32) * 100.0).round() as u8
     }
 
-    fn handle_key_event(&mut self, tui: &mut tui::Tui, key_event: KeyEvent) -> Result<()> {
+    fn handle_key_event(&mut self, tui: &mut tui::Tui, key_event: KeyEvent) -> Result<bool> {
         match key_event {
             e if self.keymap.scroll_up.is_pressed(e) => {
                 self.scroll_offset = self.scroll_offset.saturating_sub(1);
@@ -364,12 +357,12 @@ impl PagerView {
                 self.scroll_offset = usize::MAX;
             }
             _ => {
-                return Ok(());
+                return Ok(false);
             }
         }
         tui.frame_requester()
             .schedule_frame_in(crate::tui::TARGET_FRAME_INTERVAL);
-        Ok(())
+        Ok(true)
     }
 
     /// Returns the height of one page in content rows.
@@ -415,25 +408,35 @@ impl PagerView {
         self.scroll_offset >= max_scroll
     }
 
-    /// Request that the given text chunk index be scrolled into view on next render.
-    fn scroll_chunk_into_view(&mut self, chunk_index: usize) {
-        self.pending_scroll_chunk = Some(chunk_index);
+    fn resolve_pending_scroll(&mut self, area: Rect, content_height: usize) {
+        if let Some((idx, row_offset)) = self.pending_anchor_chunk.take() {
+            self.position_chunk_at_upper_third(idx, row_offset, area);
+        }
+        self.scroll_offset = self
+            .scroll_offset
+            .min(content_height.saturating_sub(area.height as usize));
     }
 
-    fn ensure_chunk_visible(&mut self, idx: usize, area: Rect) {
+    fn clamped_scroll_offset(&mut self, area: Rect) -> usize {
+        self.scroll_offset.min(
+            self.content_height(area.width)
+                .saturating_sub(area.height as usize),
+        )
+    }
+
+    /// Request that a row inside a selected chunk be anchored on next render.
+    fn scroll_chunk_to_upper_third(&mut self, chunk_index: usize, row_offset: usize) {
+        self.pending_anchor_chunk = Some((chunk_index, row_offset));
+    }
+
+    fn position_chunk_at_upper_third(&mut self, idx: usize, row_offset: usize, area: Rect) {
         if area.height == 0 || idx >= self.renderables.len() {
             return;
         }
         let layout = self.layout(area.width);
-        let first = layout.offsets[idx];
-        let last = first.saturating_add(layout.heights[idx]);
-        let current_top = self.scroll_offset;
-        let current_bottom = current_top.saturating_add(area.height.saturating_sub(1) as usize);
-        if first < current_top {
-            self.scroll_offset = first;
-        } else if last > current_bottom {
-            self.scroll_offset = last.saturating_sub(area.height.saturating_sub(1) as usize);
-        }
+        let row = layout.offsets[idx].saturating_add(row_offset);
+        let anchor = (area.height as usize) / 3;
+        self.scroll_offset = row.saturating_sub(anchor);
     }
 }
 
@@ -526,6 +529,7 @@ pub(crate) struct TranscriptOverlay {
     copy_keymap: Vec<KeyBinding>,
     toggle_raw_output_keymap: Vec<KeyBinding>,
     copy_requested: bool,
+    scroll_selected_user_cell: Option<usize>,
     footer_status: Option<FooterStatus>,
     /// Cache key for the render-only live tail appended after committed cells.
     live_tail_key: Option<LiveTailKey>,
@@ -584,6 +588,7 @@ impl TranscriptOverlay {
             copy_keymap,
             toggle_raw_output_keymap,
             copy_requested: false,
+            scroll_selected_user_cell: None,
             footer_status: None,
             live_tail_key: None,
             is_done: false,
@@ -787,10 +792,27 @@ impl TranscriptOverlay {
     }
 
     pub(crate) fn set_highlight_cell(&mut self, cell: Option<usize>) {
-        self.highlight_cell = cell;
-        self.rebuild_renderables();
-        if let Some(idx) = self.highlight_cell {
-            self.view.scroll_chunk_into_view(idx);
+        self.set_highlight_cell_with_placement(cell, PromptSelectionPlacement::AnchorUpperThird);
+    }
+
+    fn set_highlight_cell_preserving_viewport(&mut self, cell: Option<usize>) {
+        self.set_highlight_cell_with_placement(cell, PromptSelectionPlacement::PreserveViewport);
+    }
+
+    fn set_highlight_cell_with_placement(
+        &mut self,
+        cell: Option<usize>,
+        placement: PromptSelectionPlacement,
+    ) {
+        let prompt_row_offset = cell.map(|idx| self.prompt_first_text_row_offset(idx));
+        if self.highlight_cell != cell {
+            self.highlight_cell = cell;
+            self.rebuild_renderables();
+        }
+        if let (Some(idx), Some(row_offset), PromptSelectionPlacement::AnchorUpperThird) =
+            (cell, prompt_row_offset, placement)
+        {
+            self.view.scroll_chunk_to_upper_third(idx, row_offset);
         }
     }
 
@@ -812,6 +834,10 @@ impl TranscriptOverlay {
 
     pub(crate) fn take_copy_requested(&mut self) -> bool {
         std::mem::take(&mut self.copy_requested)
+    }
+
+    pub(crate) fn take_scroll_selected_user_cell(&mut self) -> Option<usize> {
+        self.scroll_selected_user_cell.take()
     }
 
     pub(crate) fn show_copy_status(&mut self, status: &CopyStatus, tui: &mut tui::Tui) {
@@ -866,6 +892,78 @@ impl TranscriptOverlay {
             None => last_prompt,
         };
         self.set_highlight_cell(Some(next_prompt));
+    }
+
+    fn prompt_first_text_row_offset(&self, idx: usize) -> usize {
+        let inter_cell_spacing = usize::from(
+            idx > 0
+                && self
+                    .cells
+                    .get(idx)
+                    .is_some_and(|cell| !cell.is_stream_continuation()),
+        );
+        let rich_prompt_padding = usize::from(matches!(self.render_mode, HistoryRenderMode::Rich));
+        inter_cell_spacing.saturating_add(rich_prompt_padding)
+    }
+
+    fn prompt_entering_viewport(
+        &mut self,
+        width: u16,
+        height: u16,
+        before: usize,
+        after: usize,
+    ) -> Option<usize> {
+        if before == after || height == 0 {
+            return None;
+        }
+        let offsets = self.view.layout(width).offsets.clone();
+        let prompts = self
+            .cells
+            .iter()
+            .enumerate()
+            .filter(|(_, cell)| cell.is_user_prompt())
+            .map(|(idx, _)| {
+                (
+                    idx,
+                    offsets[idx].saturating_add(self.prompt_first_text_row_offset(idx)),
+                )
+            });
+        if after > before {
+            let previous_bottom = before.saturating_add(height as usize);
+            let current_bottom = after.saturating_add(height as usize);
+            prompts
+                .filter(|(_, row)| previous_bottom <= *row && *row < current_bottom)
+                .map(|(idx, _)| idx)
+                .next_back()
+        } else {
+            prompts
+                .filter(|(_, row)| after <= *row && *row < before)
+                .map(|(idx, _)| idx)
+                .next()
+        }
+    }
+
+    fn handle_viewport_key_event(&mut self, tui: &mut tui::Tui, key_event: KeyEvent) -> Result<()> {
+        let top_h = tui.terminal.viewport_area.height.saturating_sub(3);
+        let top = Rect::new(
+            tui.terminal.viewport_area.x,
+            tui.terminal.viewport_area.y,
+            tui.terminal.viewport_area.width,
+            top_h,
+        );
+        let content_area = self.view.content_area(top);
+        let before = self.view.clamped_scroll_offset(content_area);
+        if !self.view.handle_key_event(tui, key_event)? {
+            return Ok(());
+        }
+        let after = self.view.clamped_scroll_offset(content_area);
+        if let Some(cell_idx) =
+            self.prompt_entering_viewport(content_area.width, content_area.height, before, after)
+        {
+            self.set_highlight_cell_preserving_viewport(Some(cell_idx));
+            self.scroll_selected_user_cell = Some(cell_idx);
+        }
+        Ok(())
     }
 
     fn header_title(&self) -> String {
@@ -1083,6 +1181,7 @@ impl TranscriptOverlay {
         self.view.title = self.header_title();
         let content_area = self.view.content_area(top);
         let total_len = self.view.content_height(content_area.width);
+        self.view.resolve_pending_scroll(content_area, total_len);
         self.view.footer_separator_label =
             self.footer_progress_label(content_area.height, total_len, top.width);
         self.view.render(top, buf);
@@ -1124,7 +1223,7 @@ impl TranscriptOverlay {
                         self.copy_requested = true;
                         Ok(())
                     }
-                    other => self.view.handle_key_event(tui, other),
+                    other => self.handle_viewport_key_event(tui, other),
                 }
             }
             TuiEvent::Draw | TuiEvent::Resize => {
@@ -1149,6 +1248,12 @@ impl TranscriptOverlay {
 enum PromptSelectionDirection {
     Previous,
     Next,
+}
+
+#[derive(Clone, Copy)]
+enum PromptSelectionPlacement {
+    AnchorUpperThird,
+    PreserveViewport,
 }
 
 pub(crate) struct StaticOverlay {
@@ -1234,7 +1339,7 @@ impl StaticOverlay {
                     self.is_done = true;
                     Ok(())
                 }
-                other => self.view.handle_key_event(tui, other),
+                other => self.view.handle_key_event(tui, other).map(|_| ()),
             },
             TuiEvent::Draw | TuiEvent::Resize => {
                 tui.draw(u16::MAX, |frame| {
@@ -1592,6 +1697,126 @@ mod tests {
                 /*content_height*/ 5, /*total_len*/ 12, /*width*/ 80
             ),
             " 1 / 2 · 100% "
+        );
+    }
+
+    #[test]
+    fn transcript_scroll_selects_prompt_when_its_first_line_enters_from_below() {
+        let mut overlay = transcript_overlay(vec![
+            user_cell("first"),
+            Arc::new(TestCell {
+                lines: (0..8)
+                    .map(|idx| Line::from(format!("answer-{idx}")))
+                    .collect(),
+            }),
+            user_cell("second"),
+            Arc::new(TestCell {
+                lines: vec![Line::from("after second")],
+            }),
+        ]);
+        let area = Rect::new(
+            /*x*/ 0, /*y*/ 0, /*width*/ 60, /*height*/ 12,
+        );
+        let mut buf = Buffer::empty(area);
+        overlay.render(area, &mut buf);
+        let top = Rect::new(area.x, area.y, area.width, area.height.saturating_sub(3));
+        let content_area = overlay.view.content_area(top);
+        let second_row = {
+            let layout = overlay.view.layout(content_area.width);
+            layout.offsets[2].saturating_add(overlay.prompt_first_text_row_offset(2))
+        };
+
+        let before = second_row.saturating_sub(content_area.height as usize);
+        let after = before.saturating_add(1);
+        let selected = overlay.prompt_entering_viewport(
+            content_area.width,
+            content_area.height,
+            before,
+            after,
+        );
+        overlay.view.scroll_offset = after;
+        overlay.set_highlight_cell_preserving_viewport(selected);
+        overlay.render(area, &mut buf);
+
+        assert_eq!(selected, Some(2));
+        assert_eq!(overlay.selected_user_cell(), Some(2));
+        assert_eq!(overlay.view.scroll_offset, after);
+        assert_snapshot!(
+            "transcript_scroll_selects_prompt_entering_from_below",
+            buffer_to_text(&buf, area)
+        );
+    }
+
+    #[test]
+    fn transcript_scroll_selects_prompt_when_its_first_line_enters_from_above() {
+        let mut overlay = transcript_overlay(vec![
+            user_cell("first"),
+            Arc::new(TestCell {
+                lines: (0..16)
+                    .map(|idx| Line::from(format!("answer-{idx}")))
+                    .collect(),
+            }),
+        ]);
+        let area = Rect::new(
+            /*x*/ 0, /*y*/ 0, /*width*/ 60, /*height*/ 12,
+        );
+        let mut buf = Buffer::empty(area);
+        overlay.render(area, &mut buf);
+        let top = Rect::new(area.x, area.y, area.width, area.height.saturating_sub(3));
+        let content_area = overlay.view.content_area(top);
+
+        let selected = overlay.prompt_entering_viewport(
+            content_area.width,
+            content_area.height,
+            /*before*/ 2,
+            /*after*/ 1,
+        );
+        overlay.view.scroll_offset = 1;
+        overlay.set_highlight_cell_preserving_viewport(selected);
+
+        assert_eq!(selected, Some(0));
+        assert_eq!(overlay.selected_user_cell(), Some(0));
+        assert_eq!(overlay.view.scroll_offset, 1);
+    }
+
+    #[test]
+    fn explicit_prompt_selection_anchors_prompt_in_upper_third() {
+        let mut overlay = transcript_overlay(vec![
+            user_cell("first"),
+            Arc::new(TestCell {
+                lines: (0..12)
+                    .map(|idx| Line::from(format!("before-{idx}")))
+                    .collect(),
+            }),
+            user_cell("second"),
+            Arc::new(TestCell {
+                lines: (0..12)
+                    .map(|idx| Line::from(format!("after-{idx}")))
+                    .collect(),
+            }),
+        ]);
+        let area = Rect::new(
+            /*x*/ 0, /*y*/ 0, /*width*/ 60, /*height*/ 15,
+        );
+        let mut buf = Buffer::empty(area);
+        overlay.render(area, &mut buf);
+
+        overlay.set_highlight_cell(Some(2));
+        overlay.render(area, &mut buf);
+
+        let top = Rect::new(area.x, area.y, area.width, area.height.saturating_sub(3));
+        let content_area = overlay.view.content_area(top);
+        let selected_row = {
+            let layout = overlay.view.layout(content_area.width);
+            layout.offsets[2].saturating_add(overlay.prompt_first_text_row_offset(2))
+        };
+        assert_eq!(
+            selected_row.saturating_sub(overlay.view.scroll_offset),
+            (content_area.height as usize) / 3,
+        );
+        assert_snapshot!(
+            "explicit_prompt_selection_anchors_prompt_in_upper_third",
+            buffer_to_text(&buf, area)
         );
     }
 
@@ -2064,7 +2289,7 @@ mod tests {
     }
 
     #[test]
-    fn pager_view_ensure_chunk_visible_scrolls_down_when_needed() {
+    fn pager_view_positions_selected_chunk_in_upper_third() {
         let mut pv = pager_view(
             vec![
                 paragraph_block("a", /*lines*/ 1),
@@ -2076,30 +2301,14 @@ mod tests {
         );
         let area = Rect::new(0, 0, 20, 8);
 
-        pv.scroll_offset = 0;
         let content_area = pv.content_area(area);
-        pv.ensure_chunk_visible(/*idx*/ 2, content_area);
+        pv.position_chunk_at_upper_third(/*idx*/ 2, /*row_offset*/ 0, content_area);
 
-        let mut buf = Buffer::empty(area);
-        pv.render(area, &mut buf);
-        let rendered = buffer_to_text(&buf, area);
-
-        assert!(
-            rendered.contains("c0"),
-            "expected chunk top in view: {rendered:?}"
-        );
-        assert!(
-            rendered.contains("c1"),
-            "expected chunk middle in view: {rendered:?}"
-        );
-        assert!(
-            rendered.contains("c2"),
-            "expected chunk bottom in view: {rendered:?}"
-        );
+        assert_eq!(pv.scroll_offset, 2);
     }
 
     #[test]
-    fn pager_view_ensure_chunk_visible_scrolls_up_when_needed() {
+    fn pager_view_upper_third_position_clamps_at_start() {
         let mut pv = pager_view(
             vec![
                 paragraph_block("a", /*lines*/ 2),
@@ -2112,7 +2321,7 @@ mod tests {
         let area = Rect::new(0, 0, 20, 3);
 
         pv.scroll_offset = 6;
-        pv.ensure_chunk_visible(/*idx*/ 0, area);
+        pv.position_chunk_at_upper_third(/*idx*/ 0, /*row_offset*/ 0, area);
 
         assert_eq!(pv.scroll_offset, 0);
     }

--- a/codex-rs/tui/src/pager_overlay.rs
+++ b/codex-rs/tui/src/pager_overlay.rs
@@ -23,6 +23,7 @@ use std::time::Instant;
 use crate::chatwidget::ActiveCellTranscriptKey;
 use crate::chatwidget::CopyStatus;
 use crate::footer_hints::FooterHint;
+use crate::footer_hints::first_fitting_right_label;
 use crate::footer_hints::footer_hint_line_for_row;
 use crate::footer_hints::render_footer_line_with_optional_right;
 use crate::footer_hints::render_footer_separator;
@@ -144,6 +145,8 @@ struct PagerView {
     renderables: Vec<Box<dyn Renderable>>,
     scroll_offset: usize,
     title: String,
+    footer_separator_label: String,
+    show_header_progress: bool,
     keymap: PagerKeymap,
     last_content_height: Option<usize>,
     last_rendered_height: Option<usize>,
@@ -171,6 +174,8 @@ impl PagerView {
             renderables,
             scroll_offset,
             title,
+            footer_separator_label: String::new(),
+            show_header_progress: true,
             keymap,
             last_content_height: None,
             last_rendered_height: None,
@@ -238,10 +243,13 @@ impl PagerView {
     fn render_header(&self, area: Rect, content_area: Rect, buf: &mut Buffer, total_len: usize) {
         let header = Rect::new(area.x, area.y, area.width, 1);
         render_footer_separator(header, buf, String::new());
-        let percent = self.scroll_percent(content_area.height, total_len);
-        format!(" {} · {percent}% ", self.title)
-            .dim()
-            .render_ref(header, buf);
+        let title = if self.show_header_progress {
+            let percent = self.scroll_percent(content_area.height, total_len);
+            format!(" {} · {percent}% ", self.title)
+        } else {
+            format!(" {} ", self.title)
+        };
+        title.dim().render_ref(header, buf);
     }
 
     fn render_content(&mut self, area: Rect, buf: &mut Buffer) {
@@ -309,7 +317,7 @@ impl PagerView {
         let sep_y = content_area.bottom();
         let sep_rect = Rect::new(full_area.x, sep_y, full_area.width, 1);
 
-        render_footer_separator(sep_rect, buf, String::new());
+        render_footer_separator(sep_rect, buf, self.footer_separator_label.clone());
     }
 
     fn scroll_percent(&self, content_height: u16, total_len: usize) -> u8 {
@@ -560,12 +568,16 @@ impl TranscriptOverlay {
         state: TranscriptOverlayState,
     ) -> Self {
         Self {
-            view: PagerView::new(
-                Self::render_cells(&transcript_cells, state.highlight_cell, state.render_mode),
-                "Transcript".to_string(),
-                state.scroll_offset,
-                keymap,
-            ),
+            view: {
+                let mut view = PagerView::new(
+                    Self::render_cells(&transcript_cells, state.highlight_cell, state.render_mode),
+                    "Transcript".to_string(),
+                    state.scroll_offset,
+                    keymap,
+                );
+                view.show_header_progress = false;
+                view
+            },
             cells: transcript_cells,
             highlight_cell: state.highlight_cell,
             render_mode: state.render_mode,
@@ -857,26 +869,34 @@ impl TranscriptOverlay {
     }
 
     fn header_title(&self) -> String {
+        "Transcript".to_string()
+    }
+
+    fn footer_progress_label(&self, content_height: u16, total_len: usize, width: u16) -> String {
         let total = self
             .cells
             .iter()
             .filter(|cell| cell.is_user_prompt())
             .count();
-        let Some(highlight_cell) = self.highlight_cell else {
-            let noun = if total == 1 { "prompt" } else { "prompts" };
-            return format!("Transcript · {total} {noun}");
-        };
         let selected = self
-            .cells
-            .iter()
-            .take(highlight_cell.saturating_add(1))
-            .filter(|cell| cell.is_user_prompt())
-            .count();
-        if selected == 0 || total == 0 {
-            let noun = if total == 1 { "prompt" } else { "prompts" };
-            return format!("Transcript · {total} {noun}");
-        }
-        format!("Transcript · {selected}/{total}")
+            .highlight_cell
+            .and_then(|highlight_cell| {
+                let selected = self
+                    .cells
+                    .iter()
+                    .take(highlight_cell.saturating_add(1))
+                    .filter(|cell| cell.is_user_prompt())
+                    .count();
+                (selected > 0).then_some(selected)
+            })
+            .unwrap_or(total);
+        let percent = self.view.scroll_percent(content_height, total_len);
+        let labels = [
+            format!(" {selected} / {total} · {percent}% "),
+            format!(" {selected}/{total} · {percent}% "),
+            format!(" {percent}% "),
+        ];
+        first_fitting_right_label(width, &labels)
     }
 
     fn rebuild_renderables(&mut self) {
@@ -1061,6 +1081,10 @@ impl TranscriptOverlay {
         let top = Rect::new(area.x, area.y, area.width, top_h);
         let bottom = Rect::new(area.x, area.y + top_h, area.width, 3);
         self.view.title = self.header_title();
+        let content_area = self.view.content_area(top);
+        let total_len = self.view.content_height(content_area.width);
+        self.view.footer_separator_label =
+            self.footer_progress_label(content_area.height, total_len, top.width);
         self.view.render(top, buf);
         self.render_hints(bottom, buf);
     }
@@ -1517,7 +1541,7 @@ mod tests {
     }
 
     #[test]
-    fn transcript_header_counts_selected_user_prompt() {
+    fn transcript_header_title_is_stable() {
         let mut overlay = transcript_overlay(vec![
             user_cell("first"),
             Arc::new(AgentMessageCell::new(
@@ -1527,13 +1551,48 @@ mod tests {
             user_cell("second"),
         ]);
 
-        assert_eq!(overlay.header_title(), "Transcript · 2 prompts");
+        assert_eq!(overlay.header_title(), "Transcript");
 
         overlay.move_prompt_selection(PromptSelectionDirection::Previous);
-        assert_eq!(overlay.header_title(), "Transcript · 2/2");
+        assert_eq!(overlay.header_title(), "Transcript");
 
         overlay.move_prompt_selection(PromptSelectionDirection::Previous);
-        assert_eq!(overlay.header_title(), "Transcript · 1/2");
+        assert_eq!(overlay.header_title(), "Transcript");
+    }
+
+    #[test]
+    fn transcript_footer_progress_label_counts_selected_user_prompt() {
+        let mut overlay = transcript_overlay(vec![
+            user_cell("first"),
+            Arc::new(AgentMessageCell::new(
+                vec![Line::from("assistant")],
+                /*is_first_line*/ true,
+            )),
+            user_cell("second"),
+        ]);
+
+        assert_eq!(
+            overlay.footer_progress_label(
+                /*content_height*/ 5, /*total_len*/ 12, /*width*/ 80
+            ),
+            " 2 / 2 · 100% "
+        );
+
+        overlay.move_prompt_selection(PromptSelectionDirection::Previous);
+        assert_eq!(
+            overlay.footer_progress_label(
+                /*content_height*/ 5, /*total_len*/ 12, /*width*/ 80
+            ),
+            " 2 / 2 · 100% "
+        );
+
+        overlay.move_prompt_selection(PromptSelectionDirection::Previous);
+        assert_eq!(
+            overlay.footer_progress_label(
+                /*content_height*/ 5, /*total_len*/ 12, /*width*/ 80
+            ),
+            " 1 / 2 · 100% "
+        );
     }
 
     #[test]

--- a/codex-rs/tui/src/pager_overlay.rs
+++ b/codex-rs/tui/src/pager_overlay.rs
@@ -17,10 +17,14 @@
 
 use std::io::Result;
 use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
 
 use crate::chatwidget::ActiveCellTranscriptKey;
+use crate::chatwidget::CopyStatus;
 use crate::footer_hints::FooterHint;
 use crate::footer_hints::footer_hint_line_for_row;
+use crate::footer_hints::render_footer_line_with_optional_right;
 use crate::footer_hints::render_footer_separator;
 use crate::history_cell::HistoryCell;
 use crate::history_cell::HistoryRenderMode;
@@ -514,9 +518,18 @@ pub(crate) struct TranscriptOverlay {
     copy_keymap: Vec<KeyBinding>,
     toggle_raw_output_keymap: Vec<KeyBinding>,
     copy_requested: bool,
+    footer_status: Option<FooterStatus>,
     /// Cache key for the render-only live tail appended after committed cells.
     live_tail_key: Option<LiveTailKey>,
     is_done: bool,
+}
+
+const FOOTER_STATUS_TTL: Duration = Duration::from_secs(2);
+
+#[derive(Clone)]
+struct FooterStatus {
+    line: Line<'static>,
+    expires_at: Instant,
 }
 
 /// Cache key for the active-cell "live tail" appended to the transcript overlay.
@@ -559,6 +572,7 @@ impl TranscriptOverlay {
             copy_keymap,
             toggle_raw_output_keymap,
             copy_requested: false,
+            footer_status: None,
             live_tail_key: None,
             is_done: false,
         }
@@ -788,6 +802,12 @@ impl TranscriptOverlay {
         std::mem::take(&mut self.copy_requested)
     }
 
+    pub(crate) fn show_copy_status(&mut self, status: &CopyStatus, tui: &mut tui::Tui) {
+        self.show_copy_status_at(status, Instant::now());
+        tui.frame_requester().schedule_frame();
+        tui.frame_requester().schedule_frame_in(FOOTER_STATUS_TTL);
+    }
+
     pub(crate) fn selected_user_cell(&self) -> Option<usize> {
         self.highlight_cell.filter(|idx| {
             self.cells
@@ -901,6 +921,33 @@ impl TranscriptOverlay {
         renderable
     }
 
+    fn show_copy_status_at(&mut self, status: &CopyStatus, now: Instant) {
+        let line = if status.is_success() {
+            Line::from(status.message().to_string().green())
+        } else {
+            Line::from(status.message().to_string().red())
+        };
+        self.footer_status = Some(FooterStatus {
+            line,
+            expires_at: now + FOOTER_STATUS_TTL,
+        });
+    }
+
+    fn clear_footer_status(&mut self) -> bool {
+        self.footer_status.take().is_some()
+    }
+
+    fn clear_expired_footer_status_at(&mut self, now: Instant) -> bool {
+        if self
+            .footer_status
+            .as_ref()
+            .is_some_and(|status| status.expires_at <= now)
+        {
+            return self.clear_footer_status();
+        }
+        false
+    }
+
     fn render_hints(&self, area: Rect, buf: &mut Buffer) {
         let line1 = Rect::new(area.x, area.y, area.width, 1);
         let line2 = Rect::new(area.x, area.y.saturating_add(1), area.width, 1);
@@ -936,7 +983,14 @@ impl TranscriptOverlay {
             FooterHint::new(key_label(&page_keys), "page", "page", /*priority*/ 6),
             FooterHint::new(key_label(&jump_keys), "jump", "jump", /*priority*/ 7),
         ];
-        footer_hint_line_for_row(&navigation_hints, area.width).render_ref(line1, buf);
+        render_footer_line_with_optional_right(
+            line1,
+            buf,
+            footer_hint_line_for_row(&navigation_hints, area.width),
+            self.footer_status
+                .as_ref()
+                .map(|status| status.line.clone()),
+        );
 
         let mut action_hints = Vec::new();
         action_hints.push(FooterHint::new(
@@ -1002,6 +1056,7 @@ impl TranscriptOverlay {
     }
 
     pub(crate) fn render(&mut self, area: Rect, buf: &mut Buffer) {
+        self.clear_expired_footer_status_at(Instant::now());
         let top_h = area.height.saturating_sub(3);
         let top = Rect::new(area.x, area.y, area.width, top_h);
         let bottom = Rect::new(area.x, area.y + top_h, area.width, 3);
@@ -1014,37 +1069,40 @@ impl TranscriptOverlay {
 impl TranscriptOverlay {
     pub(crate) fn handle_event(&mut self, tui: &mut tui::Tui, event: TuiEvent) -> Result<()> {
         match event {
-            TuiEvent::Key(key_event) => match key_event {
-                e if self.view.keymap.close.is_pressed(e)
-                    || self.view.keymap.close_transcript.is_pressed(e) =>
-                {
-                    self.is_done = true;
-                    Ok(())
+            TuiEvent::Key(key_event) => {
+                self.clear_footer_status();
+                match key_event {
+                    e if self.view.keymap.close.is_pressed(e)
+                        || self.view.keymap.close_transcript.is_pressed(e) =>
+                    {
+                        self.is_done = true;
+                        Ok(())
+                    }
+                    e if self.view.keymap.previous_user_prompt.is_pressed(e) => {
+                        self.move_prompt_selection(PromptSelectionDirection::Previous);
+                        tui.frame_requester()
+                            .schedule_frame_in(crate::tui::TARGET_FRAME_INTERVAL);
+                        Ok(())
+                    }
+                    e if self.view.keymap.next_user_prompt.is_pressed(e) => {
+                        self.move_prompt_selection(PromptSelectionDirection::Next);
+                        tui.frame_requester()
+                            .schedule_frame_in(crate::tui::TARGET_FRAME_INTERVAL);
+                        Ok(())
+                    }
+                    e if self.toggle_raw_output_keymap.is_pressed(e) => {
+                        self.toggle_render_mode();
+                        tui.frame_requester()
+                            .schedule_frame_in(crate::tui::TARGET_FRAME_INTERVAL);
+                        Ok(())
+                    }
+                    e if self.copy_keymap.is_pressed(e) => {
+                        self.copy_requested = true;
+                        Ok(())
+                    }
+                    other => self.view.handle_key_event(tui, other),
                 }
-                e if self.view.keymap.previous_user_prompt.is_pressed(e) => {
-                    self.move_prompt_selection(PromptSelectionDirection::Previous);
-                    tui.frame_requester()
-                        .schedule_frame_in(crate::tui::TARGET_FRAME_INTERVAL);
-                    Ok(())
-                }
-                e if self.view.keymap.next_user_prompt.is_pressed(e) => {
-                    self.move_prompt_selection(PromptSelectionDirection::Next);
-                    tui.frame_requester()
-                        .schedule_frame_in(crate::tui::TARGET_FRAME_INTERVAL);
-                    Ok(())
-                }
-                e if self.toggle_raw_output_keymap.is_pressed(e) => {
-                    self.toggle_render_mode();
-                    tui.frame_requester()
-                        .schedule_frame_in(crate::tui::TARGET_FRAME_INTERVAL);
-                    Ok(())
-                }
-                e if self.copy_keymap.is_pressed(e) => {
-                    self.copy_requested = true;
-                    Ok(())
-                }
-                other => self.view.handle_key_event(tui, other),
-            },
+            }
             TuiEvent::Draw | TuiEvent::Resize => {
                 tui.draw(u16::MAX, |frame| {
                     self.render(frame.area(), frame.buffer);
@@ -1206,6 +1264,7 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::Arc;
     use std::time::Duration;
+    use std::time::Instant;
 
     use crate::diff_model::FileChange;
     use crate::exec_cell::CommandOutput;
@@ -1214,7 +1273,7 @@ mod tests {
     use crate::history_cell::HistoryCell;
     use crate::history_cell::new_patch_event;
     use codex_protocol::parse_command::ParsedCommand;
-    use ratatui::Terminal;
+    use ratatui::Terminal as RatatuiTerminal;
     use ratatui::backend::TestBackend;
     use ratatui::style::Modifier;
     use ratatui::text::Text;
@@ -1339,7 +1398,7 @@ mod tests {
                 lines: vec![Line::from("gamma")],
             }),
         ]);
-        let mut term = Terminal::new(TestBackend::new(40, 10)).expect("term");
+        let mut term = RatatuiTerminal::new(TestBackend::new(40, 10)).expect("term");
         term.draw(|f| overlay.render(f.area(), f.buffer_mut()))
             .expect("draw");
         assert_snapshot!(term.backend());
@@ -1381,7 +1440,7 @@ mod tests {
             |_| Some(vec![HyperlinkLine::from("tail")]),
         );
 
-        let mut term = Terminal::new(TestBackend::new(40, 10)).expect("term");
+        let mut term = RatatuiTerminal::new(TestBackend::new(40, 10)).expect("term");
         term.draw(|f| overlay.render(f.area(), f.buffer_mut()))
             .expect("draw");
         assert_snapshot!(term.backend());
@@ -1548,6 +1607,12 @@ mod tests {
         out
     }
 
+    fn render_snapshot(overlay: &mut TranscriptOverlay, area: Rect) -> String {
+        let mut buf = Buffer::empty(area);
+        overlay.render(area, &mut buf);
+        buffer_to_text(&buf, area)
+    }
+
     #[test]
     fn transcript_overlay_apply_patch_scroll_vt100_clears_previous_page() {
         let cwd = PathBuf::from("/repo");
@@ -1614,6 +1679,94 @@ mod tests {
     }
 
     #[test]
+    fn transcript_overlay_footer_status_snapshot() {
+        let mut overlay = transcript_overlay(vec![user_cell("prompt")]);
+        overlay.show_copy_status_at(
+            &CopyStatus::Success("Copied selected turn to clipboard".into()),
+            Instant::now(),
+        );
+
+        assert_snapshot!(
+            "transcript_overlay_footer_status",
+            render_snapshot(
+                &mut overlay,
+                Rect::new(
+                    /*x*/ 0, /*y*/ 0, /*width*/ 80, /*height*/ 8
+                ),
+            )
+        );
+    }
+
+    #[test]
+    fn transcript_overlay_footer_status_snapshot_narrow() {
+        let mut overlay = transcript_overlay(vec![user_cell("prompt")]);
+        overlay.show_copy_status_at(
+            &CopyStatus::Error("No agent response to copy for selected prompt".into()),
+            Instant::now(),
+        );
+
+        assert_snapshot!(
+            "transcript_overlay_footer_status_narrow",
+            render_snapshot(
+                &mut overlay,
+                Rect::new(
+                    /*x*/ 0, /*y*/ 0, /*width*/ 28, /*height*/ 8
+                ),
+            )
+        );
+    }
+
+    #[test]
+    fn transcript_overlay_footer_status_can_be_cleared_immediately() {
+        let mut overlay = transcript_overlay(vec![user_cell("prompt")]);
+        overlay.show_copy_status_at(
+            &CopyStatus::Success("Copied selected turn to clipboard".into()),
+            Instant::now(),
+        );
+        assert!(overlay.clear_footer_status());
+
+        assert!(overlay.footer_status.is_none());
+    }
+
+    #[test]
+    fn transcript_overlay_footer_status_clears_after_expiry() {
+        let mut overlay = transcript_overlay(vec![user_cell("prompt")]);
+        overlay.show_copy_status_at(
+            &CopyStatus::Success("Copied selected turn to clipboard".into()),
+            Instant::now() - FOOTER_STATUS_TTL,
+        );
+
+        let _ = render_snapshot(
+            &mut overlay,
+            Rect::new(
+                /*x*/ 0, /*y*/ 0, /*width*/ 60, /*height*/ 8,
+            ),
+        );
+
+        assert!(overlay.footer_status.is_none());
+    }
+
+    #[test]
+    fn transcript_overlay_footer_status_replaces_previous_message() {
+        let mut overlay = transcript_overlay(vec![user_cell("prompt")]);
+        overlay.show_copy_status_at(
+            &CopyStatus::Error("Copy failed: blocked".into()),
+            Instant::now(),
+        );
+        overlay.show_copy_status_at(
+            &CopyStatus::Success("Copied selected turn to clipboard".into()),
+            Instant::now(),
+        );
+
+        let status = overlay.footer_status.as_ref().expect("status").line.clone();
+        assert_eq!(status.spans.len(), 1);
+        assert_eq!(
+            status.spans[0].content.as_ref(),
+            "Copied selected turn to clipboard"
+        );
+    }
+
+    #[test]
     fn transcript_overlay_keeps_scroll_pinned_at_bottom() {
         let mut overlay = transcript_overlay(
             (0..20)
@@ -1624,7 +1777,7 @@ mod tests {
                 })
                 .collect(),
         );
-        let mut term = Terminal::new(TestBackend::new(40, 12)).expect("term");
+        let mut term = RatatuiTerminal::new(TestBackend::new(40, 12)).expect("term");
         term.draw(|f| overlay.render(f.area(), f.buffer_mut()))
             .expect("draw");
 
@@ -1651,7 +1804,7 @@ mod tests {
                 })
                 .collect(),
         );
-        let mut term = Terminal::new(TestBackend::new(40, 12)).expect("term");
+        let mut term = RatatuiTerminal::new(TestBackend::new(40, 12)).expect("term");
         term.draw(|f| overlay.render(f.area(), f.buffer_mut()))
             .expect("draw");
 
@@ -1725,7 +1878,7 @@ mod tests {
             vec!["one".into(), "two".into(), "three".into()],
             "S T A T I C",
         );
-        let mut term = Terminal::new(TestBackend::new(40, 10)).expect("term");
+        let mut term = RatatuiTerminal::new(TestBackend::new(40, 10)).expect("term");
         term.draw(|f| overlay.render(f.area(), f.buffer_mut()))
             .expect("draw");
         assert_snapshot!(term.backend());
@@ -1831,7 +1984,7 @@ mod tests {
             vec!["a very long line that should wrap when rendered within a narrow pager overlay width".into()],
             "S T A T I C",
         );
-        let mut term = Terminal::new(TestBackend::new(24, 8)).expect("term");
+        let mut term = RatatuiTerminal::new(TestBackend::new(24, 8)).expect("term");
         term.draw(|f| overlay.render(f.area(), f.buffer_mut()))
             .expect("draw");
         assert_snapshot!(term.backend());

--- a/codex-rs/tui/src/pager_overlay.rs
+++ b/codex-rs/tui/src/pager_overlay.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 
 use crate::chatwidget::ActiveCellTranscriptKey;
 use crate::history_cell::HistoryCell;
+use crate::history_cell::HistoryRenderMode;
 use crate::history_cell::UserHistoryCell;
 use crate::key_hint;
 use crate::key_hint::KeyBinding;
@@ -55,9 +56,38 @@ pub(crate) enum Overlay {
     Static(StaticOverlay),
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct TranscriptOverlayState {
+    pub(crate) scroll_offset: usize,
+    pub(crate) highlight_cell: Option<usize>,
+    pub(crate) render_mode: HistoryRenderMode,
+}
+
+impl TranscriptOverlayState {
+    pub(crate) fn new(render_mode: HistoryRenderMode) -> Self {
+        Self {
+            scroll_offset: usize::MAX,
+            highlight_cell: None,
+            render_mode,
+        }
+    }
+}
+
 impl Overlay {
-    pub(crate) fn new_transcript(cells: Vec<Arc<dyn HistoryCell>>, keymap: PagerKeymap) -> Self {
-        Self::Transcript(TranscriptOverlay::new(cells, keymap))
+    pub(crate) fn new_transcript(
+        cells: Vec<Arc<dyn HistoryCell>>,
+        keymap: PagerKeymap,
+        copy_keymap: Vec<KeyBinding>,
+        toggle_raw_output_keymap: Vec<KeyBinding>,
+        state: TranscriptOverlayState,
+    ) -> Self {
+        Self::Transcript(TranscriptOverlay::new(
+            cells,
+            keymap,
+            copy_keymap,
+            toggle_raw_output_keymap,
+            state,
+        ))
     }
 
     pub(crate) fn new_static_with_lines(
@@ -124,8 +154,17 @@ struct PagerView {
     keymap: PagerKeymap,
     last_content_height: Option<usize>,
     last_rendered_height: Option<usize>,
+    layout: Option<PagerLayout>,
     /// If set, on next render ensure this chunk is visible.
     pending_scroll_chunk: Option<usize>,
+}
+
+#[derive(Debug)]
+struct PagerLayout {
+    width: u16,
+    offsets: Arc<[usize]>,
+    heights: Arc<[usize]>,
+    total_height: usize,
 }
 
 impl PagerView {
@@ -142,15 +181,44 @@ impl PagerView {
             keymap,
             last_content_height: None,
             last_rendered_height: None,
+            layout: None,
             pending_scroll_chunk: None,
         }
     }
 
-    fn content_height(&self, width: u16) -> usize {
-        self.renderables
-            .iter()
-            .map(|c| c.desired_height(width) as usize)
-            .sum()
+    fn invalidate_layout(&mut self) {
+        self.layout = None;
+    }
+
+    fn content_height(&mut self, width: u16) -> usize {
+        self.layout(width).total_height
+    }
+
+    fn layout(&mut self, width: u16) -> &PagerLayout {
+        let needs_rebuild = self.layout.as_ref().is_none_or(|layout| {
+            layout.width != width || layout.heights.len() != self.renderables.len()
+        });
+        if needs_rebuild {
+            let mut offsets = Vec::with_capacity(self.renderables.len());
+            let mut heights = Vec::with_capacity(self.renderables.len());
+            let mut total_height = 0usize;
+            for renderable in &self.renderables {
+                offsets.push(total_height);
+                let height = renderable.desired_height(width) as usize;
+                heights.push(height);
+                total_height = total_height.saturating_add(height);
+            }
+            self.layout = Some(PagerLayout {
+                width,
+                offsets: offsets.into(),
+                heights: heights.into(),
+                total_height,
+            });
+        }
+        match self.layout.as_ref() {
+            Some(layout) => layout,
+            None => unreachable!("pager layout missing after rebuild"),
+        }
     }
 
     fn render(&mut self, area: Rect, buf: &mut Buffer) {
@@ -182,12 +250,31 @@ impl PagerView {
         header.dim().render_ref(area, buf);
     }
 
-    fn render_content(&self, area: Rect, buf: &mut Buffer) {
-        let mut y = -(self.scroll_offset as isize);
+    fn render_content(&mut self, area: Rect, buf: &mut Buffer) {
+        let (offsets, heights) = {
+            let layout = self.layout(area.width);
+            (layout.offsets.clone(), layout.heights.clone())
+        };
+        if offsets.is_empty() {
+            for y in area.y..area.bottom() {
+                if area.width == 0 {
+                    break;
+                }
+                buf[(area.x, y)] = Cell::from('~');
+                for x in area.x + 1..area.right() {
+                    buf[(x, y)] = Cell::from(' ');
+                }
+            }
+            return;
+        }
+        let first_visible = offsets
+            .partition_point(|offset| *offset <= self.scroll_offset)
+            .saturating_sub(1);
+        let mut y = offsets[first_visible] as isize - self.scroll_offset as isize;
         let mut drawn_bottom = area.y;
-        for renderable in &self.renderables {
+        for (idx, renderable) in self.renderables.iter().enumerate().skip(first_visible) {
             let top = y;
-            let height = renderable.desired_height(area.width) as isize;
+            let height = heights[idx] as isize;
             y += height;
             let bottom = y;
             if bottom < area.y as isize {
@@ -343,13 +430,9 @@ impl PagerView {
         if area.height == 0 || idx >= self.renderables.len() {
             return;
         }
-        let first = self
-            .renderables
-            .iter()
-            .take(idx)
-            .map(|r| r.desired_height(area.width) as usize)
-            .sum();
-        let last = first + self.renderables[idx].desired_height(area.width) as usize;
+        let layout = self.layout(area.width);
+        let first = layout.offsets[idx];
+        let last = first.saturating_add(layout.heights[idx]);
         let current_top = self.scroll_offset;
         let current_bottom = current_top.saturating_add(area.height.saturating_sub(1) as usize);
         if first < current_top {
@@ -394,11 +477,14 @@ impl Renderable for CachedRenderable {
 struct CellRenderable {
     cell: Arc<dyn HistoryCell>,
     style: Style,
+    render_mode: HistoryRenderMode,
 }
 
 impl Renderable for CellRenderable {
     fn render(&self, area: Rect, buf: &mut Buffer) {
-        let hyperlink_lines = self.cell.transcript_hyperlink_lines(area.width);
+        let hyperlink_lines = self
+            .cell
+            .transcript_hyperlink_lines_for_mode(area.width, self.render_mode);
         let p = Paragraph::new(Text::from(visible_lines(hyperlink_lines.clone())))
             .style(self.style)
             .wrap(Wrap { trim: false });
@@ -407,7 +493,8 @@ impl Renderable for CellRenderable {
     }
 
     fn desired_height(&self, width: u16) -> u16 {
-        self.cell.desired_transcript_height(width)
+        self.cell
+            .desired_transcript_height_for_mode(width, self.render_mode)
     }
 }
 
@@ -441,6 +528,10 @@ pub(crate) struct TranscriptOverlay {
     /// Committed transcript cells (does not include the live tail).
     cells: Vec<Arc<dyn HistoryCell>>,
     highlight_cell: Option<usize>,
+    render_mode: HistoryRenderMode,
+    copy_keymap: Vec<KeyBinding>,
+    toggle_raw_output_keymap: Vec<KeyBinding>,
+    copy_requested: bool,
     /// Cache key for the render-only live tail appended after committed cells.
     live_tail_key: Option<LiveTailKey>,
     is_done: bool,
@@ -466,16 +557,26 @@ impl TranscriptOverlay {
     ///
     /// This overlay does not own the "active cell"; callers may optionally append a live tail via
     /// `sync_live_tail` during draws to reflect in-flight activity.
-    pub(crate) fn new(transcript_cells: Vec<Arc<dyn HistoryCell>>, keymap: PagerKeymap) -> Self {
+    pub(crate) fn new(
+        transcript_cells: Vec<Arc<dyn HistoryCell>>,
+        keymap: PagerKeymap,
+        copy_keymap: Vec<KeyBinding>,
+        toggle_raw_output_keymap: Vec<KeyBinding>,
+        state: TranscriptOverlayState,
+    ) -> Self {
         Self {
             view: PagerView::new(
-                Self::render_cells(&transcript_cells, /*highlight_cell*/ None),
+                Self::render_cells(&transcript_cells, state.highlight_cell, state.render_mode),
                 "T R A N S C R I P T".to_string(),
-                usize::MAX,
+                state.scroll_offset,
                 keymap,
             ),
             cells: transcript_cells,
-            highlight_cell: None,
+            highlight_cell: state.highlight_cell,
+            render_mode: state.render_mode,
+            copy_keymap,
+            toggle_raw_output_keymap,
+            copy_requested: false,
             live_tail_key: None,
             is_done: false,
         }
@@ -484,6 +585,7 @@ impl TranscriptOverlay {
     fn render_cells(
         cells: &[Arc<dyn HistoryCell>],
         highlight_cell: Option<usize>,
+        render_mode: HistoryRenderMode,
     ) -> Vec<Box<dyn Renderable>> {
         cells
             .iter()
@@ -498,11 +600,13 @@ impl TranscriptOverlay {
                         } else {
                             user_message_style()
                         },
+                        render_mode,
                     })) as Box<dyn Renderable>
                 } else {
                     Box::new(CachedRenderable::new(CellRenderable {
                         cell: c.clone(),
                         style: Style::default(),
+                        render_mode,
                     })) as Box<dyn Renderable>
                 };
                 if !c.is_stream_continuation() && i > 0 {
@@ -534,7 +638,9 @@ impl TranscriptOverlay {
         let had_prior_cells = !self.cells.is_empty();
         let tail_renderable = self.take_live_tail_renderable();
         self.cells.push(cell);
-        self.view.renderables = Self::render_cells(&self.cells, self.highlight_cell);
+        self.view.renderables =
+            Self::render_cells(&self.cells, self.highlight_cell, self.render_mode);
+        self.view.invalidate_layout();
         if let Some(tail) = tail_renderable {
             let tail = if !had_prior_cells
                 && self
@@ -663,6 +769,7 @@ impl TranscriptOverlay {
                     !self.cells.is_empty(),
                     key.is_stream_continuation,
                 ));
+                self.view.invalidate_layout();
             }
         }
         if follow_bottom {
@@ -686,12 +793,74 @@ impl TranscriptOverlay {
         self.view.is_scrolled_to_bottom()
     }
 
+    pub(crate) fn state(&self) -> TranscriptOverlayState {
+        TranscriptOverlayState {
+            scroll_offset: self.view.scroll_offset,
+            highlight_cell: self.highlight_cell,
+            render_mode: self.render_mode,
+        }
+    }
+
+    pub(crate) fn take_copy_requested(&mut self) -> bool {
+        std::mem::take(&mut self.copy_requested)
+    }
+
+    pub(crate) fn selected_user_cell(&self) -> Option<usize> {
+        self.highlight_cell.filter(|idx| {
+            self.cells
+                .get(*idx)
+                .is_some_and(|cell| cell.is_user_prompt())
+        })
+    }
+
+    fn toggle_render_mode(&mut self) {
+        self.render_mode = match self.render_mode {
+            HistoryRenderMode::Rich => HistoryRenderMode::Raw,
+            HistoryRenderMode::Raw => HistoryRenderMode::Rich,
+        };
+        self.rebuild_renderables();
+    }
+
+    fn move_prompt_selection(&mut self, direction: PromptSelectionDirection) {
+        let prompt_positions = self
+            .cells
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, cell)| cell.is_user_prompt().then_some(idx))
+            .collect::<Vec<_>>();
+        let Some(last_prompt) = prompt_positions.last().copied() else {
+            return;
+        };
+
+        let next_prompt = match self.highlight_cell {
+            Some(current) => {
+                let current_idx = prompt_positions
+                    .iter()
+                    .position(|idx| *idx == current)
+                    .unwrap_or(prompt_positions.len().saturating_sub(1));
+                match direction {
+                    PromptSelectionDirection::Previous => {
+                        prompt_positions[current_idx.saturating_sub(1)]
+                    }
+                    PromptSelectionDirection::Next => prompt_positions
+                        .get(current_idx.saturating_add(1))
+                        .copied()
+                        .unwrap_or(last_prompt),
+                }
+            }
+            None => last_prompt,
+        };
+        self.set_highlight_cell(Some(next_prompt));
+    }
+
     fn rebuild_renderables(&mut self) {
         let tail_renderable = self.take_live_tail_renderable();
-        self.view.renderables = Self::render_cells(&self.cells, self.highlight_cell);
+        self.view.renderables =
+            Self::render_cells(&self.cells, self.highlight_cell, self.render_mode);
         if let Some(tail) = tail_renderable {
             self.view.renderables.push(tail);
         }
+        self.view.invalidate_layout();
     }
 
     /// Removes and returns the cached live-tail renderable, if present.
@@ -700,7 +869,12 @@ impl TranscriptOverlay {
     /// cell renderables, so this relies on the live tail always being the final entry in
     /// `view.renderables` when present.
     fn take_live_tail_renderable(&mut self) -> Option<Box<dyn Renderable>> {
-        (self.view.renderables.len() > self.cells.len()).then(|| self.view.renderables.pop())?
+        let tail = (self.view.renderables.len() > self.cells.len())
+            .then(|| self.view.renderables.pop())?;
+        if tail.is_some() {
+            self.view.invalidate_layout();
+        }
+        tail
     }
 
     fn live_tail_renderable(
@@ -749,11 +923,24 @@ impl TranscriptOverlay {
                         .collect(),
                     "to jump",
                 ),
+                (
+                    first_or_empty(&self.view.keymap.previous_user_prompt)
+                        .into_iter()
+                        .chain(first_or_empty(&self.view.keymap.next_user_prompt))
+                        .collect(),
+                    "to prompts",
+                ),
             ],
         );
 
-        let mut pairs: Vec<(Vec<KeyBinding>, &str)> =
-            vec![(first_or_empty(&self.view.keymap.close), "to quit")];
+        let mut pairs: Vec<(Vec<KeyBinding>, &str)> = Vec::new();
+        if !self.copy_keymap.is_empty() {
+            pairs.push((first_or_empty(&self.copy_keymap), "to copy"));
+        }
+        if !self.toggle_raw_output_keymap.is_empty() {
+            pairs.push((first_or_empty(&self.toggle_raw_output_keymap), "raw"));
+        }
+        pairs.push((first_or_empty(&self.view.keymap.close), "to quit"));
         if self.highlight_cell.is_some() {
             pairs.push((
                 vec![
@@ -789,6 +976,28 @@ impl TranscriptOverlay {
                     self.is_done = true;
                     Ok(())
                 }
+                e if self.view.keymap.previous_user_prompt.is_pressed(e) => {
+                    self.move_prompt_selection(PromptSelectionDirection::Previous);
+                    tui.frame_requester()
+                        .schedule_frame_in(crate::tui::TARGET_FRAME_INTERVAL);
+                    Ok(())
+                }
+                e if self.view.keymap.next_user_prompt.is_pressed(e) => {
+                    self.move_prompt_selection(PromptSelectionDirection::Next);
+                    tui.frame_requester()
+                        .schedule_frame_in(crate::tui::TARGET_FRAME_INTERVAL);
+                    Ok(())
+                }
+                e if self.toggle_raw_output_keymap.is_pressed(e) => {
+                    self.toggle_render_mode();
+                    tui.frame_requester()
+                        .schedule_frame_in(crate::tui::TARGET_FRAME_INTERVAL);
+                    Ok(())
+                }
+                e if self.copy_keymap.is_pressed(e) => {
+                    self.copy_requested = true;
+                    Ok(())
+                }
                 other => self.view.handle_key_event(tui, other),
             },
             TuiEvent::Draw | TuiEvent::Resize => {
@@ -808,6 +1017,11 @@ impl TranscriptOverlay {
     pub(crate) fn committed_cell_count(&self) -> usize {
         self.cells.len()
     }
+}
+
+enum PromptSelectionDirection {
+    Previous,
+    Next,
 }
 
 pub(crate) struct StaticOverlay {
@@ -990,7 +1204,23 @@ mod tests {
     }
 
     fn transcript_overlay(cells: Vec<Arc<dyn HistoryCell>>) -> TranscriptOverlay {
-        TranscriptOverlay::new(cells, default_pager_keymap())
+        let keymap = crate::keymap::RuntimeKeymap::defaults();
+        TranscriptOverlay::new(
+            cells,
+            keymap.pager,
+            keymap.app.copy,
+            keymap.app.toggle_raw_output,
+            TranscriptOverlayState::new(HistoryRenderMode::Rich),
+        )
+    }
+
+    fn user_cell(message: &str) -> Arc<dyn HistoryCell> {
+        Arc::new(UserHistoryCell {
+            message: message.to_string(),
+            text_elements: Vec::new(),
+            local_image_paths: Vec::new(),
+            remote_image_urls: Vec::new(),
+        })
     }
 
     fn static_overlay(lines: Vec<Line<'static>>, title: &str) -> StaticOverlay {
@@ -1138,6 +1368,45 @@ mod tests {
                 .symbol()
                 .contains(&format!("\x1b]8;;{destination}\x07"))
         }));
+    }
+
+    #[test]
+    fn transcript_overlay_state_round_trips_scroll_selection_and_mode() {
+        let keymap = crate::keymap::RuntimeKeymap::defaults();
+        let state = TranscriptOverlayState {
+            scroll_offset: 3,
+            highlight_cell: Some(0),
+            render_mode: HistoryRenderMode::Raw,
+        };
+        let overlay = TranscriptOverlay::new(
+            vec![user_cell("prompt")],
+            keymap.pager,
+            keymap.app.copy,
+            keymap.app.toggle_raw_output,
+            state,
+        );
+
+        assert_eq!(overlay.state(), state);
+    }
+
+    #[test]
+    fn prompt_navigation_moves_between_user_prompts() {
+        let mut overlay = transcript_overlay(vec![
+            user_cell("first"),
+            Arc::new(TestCell {
+                lines: vec![Line::from("assistant")],
+            }),
+            user_cell("second"),
+        ]);
+
+        overlay.move_prompt_selection(PromptSelectionDirection::Previous);
+        assert_eq!(overlay.selected_user_cell(), Some(2));
+
+        overlay.move_prompt_selection(PromptSelectionDirection::Previous);
+        assert_eq!(overlay.selected_user_cell(), Some(0));
+
+        overlay.move_prompt_selection(PromptSelectionDirection::Next);
+        assert_eq!(overlay.selected_user_cell(), Some(2));
     }
 
     #[test]
@@ -1476,7 +1745,7 @@ mod tests {
 
     #[test]
     fn pager_view_content_height_counts_renderables() {
-        let pv = pager_view(
+        let mut pv = pager_view(
             vec![
                 paragraph_block("a", /*lines*/ 2),
                 paragraph_block("b", /*lines*/ 3),

--- a/codex-rs/tui/src/pager_overlay.rs
+++ b/codex-rs/tui/src/pager_overlay.rs
@@ -1723,7 +1723,7 @@ mod tests {
         let content_area = overlay.view.content_area(top);
         let second_row = {
             let layout = overlay.view.layout(content_area.width);
-            layout.offsets[2].saturating_add(overlay.prompt_first_text_row_offset(2))
+            layout.offsets[2].saturating_add(overlay.prompt_first_text_row_offset(/*idx*/ 2))
         };
 
         let before = second_row.saturating_sub(content_area.height as usize);
@@ -1808,7 +1808,7 @@ mod tests {
         let content_area = overlay.view.content_area(top);
         let selected_row = {
             let layout = overlay.view.layout(content_area.width);
-            layout.offsets[2].saturating_add(overlay.prompt_first_text_row_offset(2))
+            layout.offsets[2].saturating_add(overlay.prompt_first_text_row_offset(/*idx*/ 2))
         };
         assert_eq!(
             selected_row.saturating_sub(overlay.view.scroll_offset),

--- a/codex-rs/tui/src/resume_picker.rs
+++ b/codex-rs/tui/src/resume_picker.rs
@@ -10,6 +10,7 @@ use crate::app_server_session::AppServerSession;
 use crate::color::blend;
 use crate::color::is_light;
 use crate::footer_hints::FooterHint;
+use crate::footer_hints::first_fitting_right_label;
 use crate::footer_hints::footer_hint_line_for_row;
 use crate::footer_hints::render_footer_separator;
 use crate::git_action_directives::parse_assistant_markdown;
@@ -2067,10 +2068,7 @@ fn picker_footer_progress_label(state: &PickerState, list_height: u16, width: u1
         format!(" {position}/{total} · {percent}% "),
         format!(" {percent}% "),
     ];
-    labels
-        .into_iter()
-        .find(|label| UnicodeWidthStr::width(label.as_str()) < width as usize)
-        .unwrap_or_default()
+    first_fitting_right_label(width, &labels)
 }
 
 fn picker_footer_percent(state: &PickerState, list_height: u16) -> u8 {

--- a/codex-rs/tui/src/resume_picker.rs
+++ b/codex-rs/tui/src/resume_picker.rs
@@ -9,6 +9,9 @@ mod transcript;
 use crate::app_server_session::AppServerSession;
 use crate::color::blend;
 use crate::color::is_light;
+use crate::footer_hints::FooterHint;
+use crate::footer_hints::footer_hint_line_for_row;
+use crate::footer_hints::render_footer_separator;
 use crate::git_action_directives::parse_assistant_markdown;
 use crate::key_hint::KeyBindingListExt;
 use crate::key_hint::is_plain_text_key_event;
@@ -73,9 +76,6 @@ const SESSION_META_MIN_CWD_WIDTH: usize = 30;
 const SESSION_META_MAX_CWD_WIDTH: usize = 72;
 const SESSION_META_BRANCH_ICON: &str = "";
 const SESSION_META_CWD_ICON: &str = "⌁";
-const FOOTER_COMPACT_BREAKPOINT: u16 = 120;
-const FOOTER_HINT_LEFT_PADDING: usize = 1;
-const FOOTER_HINT_GAP: usize = 3;
 const PICKER_CHROME_HEIGHT: u16 = 8;
 const PICKER_LIST_HORIZONTAL_INSET: u16 = 4;
 
@@ -2023,13 +2023,6 @@ fn filter_mode_label(filter_mode: SessionFilterMode) -> &'static str {
     }
 }
 
-struct PickerFooterHint {
-    key: &'static str,
-    wide_label: String,
-    compact_label: String,
-    priority: u8,
-}
-
 fn render_picker_footer(
     frame: &mut crate::custom_terminal::Frame,
     area: Rect,
@@ -2041,9 +2034,9 @@ fn render_picker_footer(
     }
 
     let separator = Rect::new(area.x, area.y, area.width, 1);
-    render_picker_footer_separator(
-        frame,
+    render_footer_separator(
         separator,
+        frame.buffer,
         picker_footer_progress_label(state, list_height, area.width),
     );
 
@@ -2054,30 +2047,6 @@ fn render_picker_footer(
             break;
         }
         frame.render_widget_ref(line, Rect::new(area.x, y, area.width, 1));
-    }
-}
-
-fn render_picker_footer_separator(
-    frame: &mut crate::custom_terminal::Frame,
-    area: Rect,
-    progress_label: String,
-) {
-    if area.width == 0 {
-        return;
-    }
-
-    let separator = "─".repeat(area.width as usize);
-    frame.render_widget_ref(Line::from(separator.dim()), area);
-
-    let progress_width = UnicodeWidthStr::width(progress_label.as_str()) as u16;
-    if progress_width < area.width {
-        let percent_area = Rect::new(
-            area.x + area.width - progress_width - 1,
-            area.y,
-            progress_width,
-            1,
-        );
-        frame.render_widget_ref(Line::from(progress_label.dim()), percent_area);
     }
 }
 
@@ -2147,23 +2116,10 @@ fn picker_footer_scroll_percent(state: &PickerState, list_height: u16) -> u8 {
 fn footer_hint_lines(state: &PickerState, width: u16) -> Vec<Line<'static>> {
     if state.is_transcript_loading() {
         let hints = [
-            PickerFooterHint {
-                key: "loading",
-                wide_label: String::from("transcript"),
-                compact_label: String::from("transcript"),
-                priority: 0,
-            },
-            PickerFooterHint {
-                key: "ctrl+c",
-                wide_label: String::from("quit"),
-                compact_label: String::from("quit"),
-                priority: 1,
-            },
+            FooterHint::new("loading", "transcript", "transcript", /*priority*/ 0),
+            FooterHint::new("ctrl+c", "quit", "quit", /*priority*/ 1),
         ];
-        let line = fit_footer_hints(&hints, FooterHintLabelMode::Wide, width)
-            .or_else(|| fit_footer_hints(&hints, FooterHintLabelMode::Compact, width))
-            .or_else(|| fit_footer_hints(&hints, FooterHintLabelMode::KeyOnly, width))
-            .unwrap_or_default();
+        let line = footer_hint_line_for_row(&hints, width);
         return vec![line, Line::default()];
     }
 
@@ -2189,97 +2145,28 @@ fn footer_hint_lines(state: &PickerState, width: u16) -> Vec<Line<'static>> {
         SessionListDensity::Dense => "comfy",
     };
     let first_row_hints = vec![
-        PickerFooterHint {
-            key: "enter",
-            wide_label: action_label.to_string(),
-            compact_label: action_label.to_string(),
-            priority: 0,
-        },
-        PickerFooterHint {
-            key: "esc",
-            wide_label: esc_label.to_string(),
-            compact_label: esc_compact_label.to_string(),
-            priority: 1,
-        },
-        PickerFooterHint {
-            key: "ctrl+c",
-            wide_label: ctrl_c_label.to_string(),
-            compact_label: ctrl_c_label.to_string(),
-            priority: 2,
-        },
-        PickerFooterHint {
-            key: "tab",
-            wide_label: String::from("focus sort/filter"),
-            compact_label: String::from("focus"),
-            priority: 7,
-        },
-        PickerFooterHint {
-            key: "←/→",
-            wide_label: String::from("change option"),
-            compact_label: String::from("option"),
-            priority: 8,
-        },
+        FooterHint::new("enter", action_label, action_label, /*priority*/ 0),
+        FooterHint::new("esc", esc_label, esc_compact_label, /*priority*/ 1),
+        FooterHint::new("ctrl+c", ctrl_c_label, ctrl_c_label, /*priority*/ 2),
+        FooterHint::new("tab", "focus sort/filter", "focus", /*priority*/ 7),
+        FooterHint::new("←/→", "change option", "option", /*priority*/ 8),
     ];
     let second_row_hints = vec![
-        PickerFooterHint {
-            key: "ctrl+o",
-            wide_label: density_label.to_string(),
-            compact_label: density_compact_label.to_string(),
-            priority: 3,
-        },
-        PickerFooterHint {
-            key: "ctrl+t",
-            wide_label: String::from("transcript"),
-            compact_label: String::from("preview"),
-            priority: 4,
-        },
-        PickerFooterHint {
-            key: "ctrl+e",
-            wide_label: String::from("expand"),
-            compact_label: String::from("exp"),
-            priority: 6,
-        },
-        PickerFooterHint {
-            key: "↑/↓",
-            wide_label: String::from("browse"),
-            compact_label: String::from("browse"),
-            priority: 5,
-        },
+        FooterHint::new(
+            "ctrl+o",
+            density_label,
+            density_compact_label,
+            /*priority*/ 3,
+        ),
+        FooterHint::new("ctrl+t", "transcript", "preview", /*priority*/ 4),
+        FooterHint::new("ctrl+e", "expand", "exp", /*priority*/ 6),
+        FooterHint::new("↑/↓", "browse", "browse", /*priority*/ 5),
     ];
 
     vec![
-        hint_line_for_row(&first_row_hints, width),
-        hint_line_for_row(&second_row_hints, width),
+        footer_hint_line_for_row(&first_row_hints, width),
+        footer_hint_line_for_row(&second_row_hints, width),
     ]
-}
-
-fn hint_line_for_row(hints: &[PickerFooterHint], width: u16) -> Line<'static> {
-    if width >= FOOTER_COMPACT_BREAKPOINT
-        && let Some(line) = fit_footer_hints(hints, FooterHintLabelMode::Wide, width)
-    {
-        return line;
-    }
-    if let Some(line) = fit_footer_hints(hints, FooterHintLabelMode::Compact, width) {
-        return line;
-    }
-    if let Some(line) = fit_footer_hints(hints, FooterHintLabelMode::KeyOnly, width) {
-        return line;
-    }
-
-    let mut retained = (0..hints.len()).collect::<Vec<_>>();
-    retained.sort_by_key(|idx| hints[*idx].priority);
-    for retain_count in (1..=retained.len()).rev() {
-        let mut candidate_indices = retained[..retain_count].to_vec();
-        candidate_indices.sort_unstable();
-        let candidate = candidate_indices
-            .iter()
-            .map(|idx| &hints[*idx])
-            .collect::<Vec<_>>();
-        if let Some(line) = fit_footer_hint_refs(&candidate, FooterHintLabelMode::KeyOnly, width) {
-            return line;
-        }
-    }
-    Line::default()
 }
 
 fn render_transcript_loading_overlay(frame: &mut crate::custom_terminal::Frame, area: Rect) {
@@ -2329,99 +2216,6 @@ fn transcript_loading_overlay_style() -> Style {
         ((255, 255, 255), 0.14)
     };
     Style::default().bg(best_color(blend(overlay, bg, alpha)))
-}
-
-#[derive(Clone, Copy)]
-enum FooterHintLabelMode {
-    Wide,
-    Compact,
-    KeyOnly,
-}
-
-fn fit_footer_hints(
-    hints: &[PickerFooterHint],
-    mode: FooterHintLabelMode,
-    width: u16,
-) -> Option<Line<'static>> {
-    let hint_refs = hints.iter().collect::<Vec<_>>();
-    fit_footer_hint_refs(&hint_refs, mode, width)
-}
-
-fn fit_footer_hint_refs(
-    hints: &[&PickerFooterHint],
-    mode: FooterHintLabelMode,
-    width: u16,
-) -> Option<Line<'static>> {
-    let gap_width = FOOTER_HINT_GAP;
-    if footer_hints_width(hints, mode, gap_width) > width as usize {
-        return None;
-    }
-
-    let mut spans = vec![
-        " ".repeat(FOOTER_HINT_LEFT_PADDING)
-            .set_style(footer_hint_label_style()),
-    ];
-    for (idx, hint) in hints.iter().enumerate() {
-        if idx > 0 {
-            spans.push(" ".repeat(gap_width).set_style(footer_hint_label_style()));
-        }
-        spans.push(hint.key.set_style(footer_hint_key_style()));
-        let label = match mode {
-            FooterHintLabelMode::Wide => Some(hint.wide_label.as_str()),
-            FooterHintLabelMode::Compact => Some(hint.compact_label.as_str()),
-            FooterHintLabelMode::KeyOnly => None,
-        };
-        if let Some(label) = label {
-            spans.push(" ".set_style(footer_hint_label_style()));
-            spans.push(label.to_string().set_style(footer_hint_label_style()));
-        }
-    }
-    Some(spans.into())
-}
-
-fn footer_hint_key_style() -> Style {
-    if default_bg().is_some_and(is_light) {
-        Style::default().fg(Color::Black)
-    } else {
-        Style::default()
-    }
-}
-
-fn footer_hint_label_style() -> Style {
-    if default_bg().is_some_and(is_light) {
-        Style::default().fg(Color::DarkGray)
-    } else {
-        Style::default().dim()
-    }
-}
-
-fn footer_hints_width(
-    hints: &[&PickerFooterHint],
-    mode: FooterHintLabelMode,
-    gap_width: usize,
-) -> usize {
-    FOOTER_HINT_LEFT_PADDING
-        + hints
-            .iter()
-            .enumerate()
-            .map(|(idx, hint)| {
-                let label_width = match mode {
-                    FooterHintLabelMode::Wide => {
-                        1 + UnicodeWidthStr::width(hint.wide_label.as_str())
-                    }
-                    FooterHintLabelMode::Compact => {
-                        1 + UnicodeWidthStr::width(hint.compact_label.as_str())
-                    }
-                    FooterHintLabelMode::KeyOnly => 0,
-                };
-                let hint_width = UnicodeWidthStr::width(hint.key) + label_width;
-                if idx == 0 {
-                    hint_width
-                } else {
-                    hint_width + gap_width
-                }
-            })
-            .sum::<usize>()
 }
 
 fn render_list(frame: &mut crate::custom_terminal::Frame, area: Rect, state: &PickerState) {

--- a/codex-rs/tui/src/resume_picker.rs
+++ b/codex-rs/tui/src/resume_picker.rs
@@ -980,6 +980,11 @@ impl PickerState {
         self.overlay = Some(Overlay::new_transcript(
             cells.clone(),
             self.pager_keymap.clone(),
+            Vec::new(),
+            Vec::new(),
+            crate::pager_overlay::TranscriptOverlayState::new(
+                crate::history_cell::HistoryRenderMode::Rich,
+            ),
         ));
         self.pending_transcript_open = None;
         self.transcript_loading_frame_shown = false;

--- a/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__explicit_prompt_selection_anchors_prompt_in_upper_third.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__explicit_prompt_selection_anchors_prompt_in_upper_third.snap
@@ -1,0 +1,18 @@
+---
+source: tui/src/pager_overlay.rs
+expression: "buffer_to_text(&buf, area)"
+---
+ Transcript ────────────────────────────────────────────────
+before-11
+
+
+› second
+
+
+after-0
+after-1
+after-2
+after-3
+────────────────────────────────────────────── 2 / 2 · 65% ─
+ ↑/↓ scroll   ←/→ prompts   pgup/pgdn page   home/end jump
+ q   ctrl + o   ⌥ + r   esc/←   →   enter/← prev

--- a/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__static_overlay_snapshot_basic.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__static_overlay_snapshot_basic.snap
@@ -2,13 +2,13 @@
 source: tui/src/pager_overlay.rs
 expression: term.backend()
 ---
-"/ S T A T I C / / / / / / / / / / / / / "
+" S T A T I C · 100% ────────────────────"
 "one                                     "
 "two                                     "
 "three                                   "
 "~                                       "
 "~                                       "
-"───────────────────────────────── 100% ─"
-" ↑/↓ to scroll   pgup/pgdn to page   hom"
-" q to quit                              "
+"────────────────────────────────────────"
+" ↑/↓   pgup/pgdn   home/end             "
+" q quit                                 "
 "                                        "

--- a/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__static_overlay_wraps_long_lines.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__static_overlay_wraps_long_lines.snap
@@ -2,11 +2,11 @@
 source: tui/src/pager_overlay.rs
 expression: term.backend()
 ---
-"/ S T A T I C / / / / / "
+" S T A T I C · 0% ──────"
 "a very long line that   "
 "should wrap when        "
 "rendered within a narrow"
-"─────────────────── 0% ─"
-" ↑/↓ to scroll   pgup/pg"
-" q to quit              "
+"────────────────────────"
+" ↑/↓   pgup/pgdn        "
+" q quit                 "
 "                        "

--- a/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__transcript_overlay_apply_patch_scroll_vt100.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__transcript_overlay_apply_patch_scroll_vt100.snap
@@ -2,7 +2,7 @@
 source: tui/src/pager_overlay.rs
 expression: snapshot
 ---
-/ T R A N S C R I P T / / / / / / / / / / / / / / / / / / / / / / / / / / / / /
+ Transcript · 0 prompts · 0% ───────────────────────────────────────────────────
 • Added foo.txt (+2 -0)
     1 +hello
     2 +world
@@ -10,6 +10,6 @@ expression: snapshot
 • Added foo.txt (+2 -0)
     1 +hello
     2 +world
-─────────────────────────────────────────────────────────────────────────── 0% ─
- ↑/↓ to scroll   pgup/pgdn to page   home/end to jump
- q to quit   esc to edit prev
+────────────────────────────────────────────────────────────────────────────────
+ ↑/↓ scroll   ←/→ prompts   pgup/pgdn page   home/end jump
+ q quit   ctrl + o copy   ⌥ + r raw   esc/← prev

--- a/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__transcript_overlay_apply_patch_scroll_vt100.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__transcript_overlay_apply_patch_scroll_vt100.snap
@@ -2,7 +2,7 @@
 source: tui/src/pager_overlay.rs
 expression: snapshot
 ---
- Transcript · 0 prompts · 0% ───────────────────────────────────────────────────
+ Transcript ────────────────────────────────────────────────────────────────────
 • Added foo.txt (+2 -0)
     1 +hello
     2 +world
@@ -10,6 +10,6 @@ expression: snapshot
 • Added foo.txt (+2 -0)
     1 +hello
     2 +world
-────────────────────────────────────────────────────────────────────────────────
+─────────────────────────────────────────────────────────────────── 0 / 0 · 0% ─
  ↑/↓ scroll   ←/→ prompts   pgup/pgdn page   home/end jump
  q quit   ctrl + o copy   ⌥ + r raw   esc/← prev

--- a/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__transcript_overlay_footer_status.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__transcript_overlay_footer_status.snap
@@ -2,10 +2,10 @@
 source: tui/src/pager_overlay.rs
 expression: "render_snapshot(&mut overlay, Rect::new(0, 0, 80, 8),)"
 ---
- Transcript · 1 prompt · 100% ──────────────────────────────────────────────────
+ Transcript ────────────────────────────────────────────────────────────────────
 
 › prompt
 
-────────────────────────────────────────────────────────────────────────────────
+───────────────────────────────────────────────────────────────── 1 / 1 · 100% ─
  ↑/↓ scroll   ←/→ prompts   pgup/pgdn page   … Copied selected turn to clipboard
  q quit   ctrl + o copy   ⌥ + r raw   esc/← prev

--- a/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__transcript_overlay_footer_status.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__transcript_overlay_footer_status.snap
@@ -1,0 +1,11 @@
+---
+source: tui/src/pager_overlay.rs
+expression: "render_snapshot(&mut overlay, Rect::new(0, 0, 80, 8),)"
+---
+ Transcript · 1 prompt · 100% ──────────────────────────────────────────────────
+
+› prompt
+
+────────────────────────────────────────────────────────────────────────────────
+ ↑/↓ scroll   ←/→ prompts   pgup/pgdn page   … Copied selected turn to clipboard
+ q quit   ctrl + o copy   ⌥ + r raw   esc/← prev

--- a/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__transcript_overlay_footer_status_narrow.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__transcript_overlay_footer_status_narrow.snap
@@ -1,0 +1,11 @@
+---
+source: tui/src/pager_overlay.rs
+expression: "render_snapshot(&mut overlay, Rect::new(0, 0, 28, 8),)"
+---
+ Transcript · 1 prompt · 100
+
+› prompt
+
+────────────────────────────
+No agent response to copy f…
+ q   ctrl + o   ⌥ + r

--- a/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__transcript_overlay_footer_status_narrow.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__transcript_overlay_footer_status_narrow.snap
@@ -2,10 +2,10 @@
 source: tui/src/pager_overlay.rs
 expression: "render_snapshot(&mut overlay, Rect::new(0, 0, 28, 8),)"
 ---
- Transcript · 1 prompt · 100
+ Transcript ────────────────
 
 › prompt
 
-────────────────────────────
+───────────── 1 / 1 · 100% ─
 No agent response to copy f…
  q   ctrl + o   ⌥ + r

--- a/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__transcript_overlay_renders_live_tail.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__transcript_overlay_renders_live_tail.snap
@@ -2,13 +2,13 @@
 source: tui/src/pager_overlay.rs
 expression: term.backend()
 ---
-"/ T R A N S C R I P T / / / / / / / / / "
+" Transcript · 0 prompts · 100% ─────────"
 "alpha                                   "
 "                                        "
 "tail                                    "
 "~                                       "
 "~                                       "
-"───────────────────────────────── 100% ─"
-" ↑/↓ to scroll   pgup/pgdn to page   hom"
-" q to quit   esc to edit prev           "
+"────────────────────────────────────────"
+" ↑/↓   ←/→   pgup/pgdn   home/end       "
+" q   ctrl + o   ⌥ + r   esc/←           "
 "                                        "

--- a/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__transcript_overlay_renders_live_tail.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__transcript_overlay_renders_live_tail.snap
@@ -2,13 +2,13 @@
 source: tui/src/pager_overlay.rs
 expression: term.backend()
 ---
-" Transcript · 0 prompts · 100% ─────────"
+" Transcript ────────────────────────────"
 "alpha                                   "
 "                                        "
 "tail                                    "
 "~                                       "
 "~                                       "
-"────────────────────────────────────────"
+"───────────────────────── 0 / 0 · 100% ─"
 " ↑/↓   ←/→   pgup/pgdn   home/end       "
 " q   ctrl + o   ⌥ + r   esc/←           "
 "                                        "

--- a/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__transcript_overlay_snapshot_basic.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__transcript_overlay_snapshot_basic.snap
@@ -2,13 +2,13 @@
 source: tui/src/pager_overlay.rs
 expression: term.backend()
 ---
-"/ T R A N S C R I P T / / / / / / / / / "
+" Transcript · 0 prompts · 100% ─────────"
 "alpha                                   "
 "                                        "
 "beta                                    "
 "                                        "
 "gamma                                   "
-"───────────────────────────────── 100% ─"
-" ↑/↓ to scroll   pgup/pgdn to page   hom"
-" ctrl + o to copy   ⌥ + r raw   q to qui"
+"────────────────────────────────────────"
+" ↑/↓   ←/→   pgup/pgdn   home/end       "
+" q   ctrl + o   ⌥ + r   esc/←           "
 "                                        "

--- a/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__transcript_overlay_snapshot_basic.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__transcript_overlay_snapshot_basic.snap
@@ -10,5 +10,5 @@ expression: term.backend()
 "gamma                                   "
 "───────────────────────────────── 100% ─"
 " ↑/↓ to scroll   pgup/pgdn to page   hom"
-" q to quit   esc to edit prev           "
+" ctrl + o to copy   ⌥ + r raw   q to qui"
 "                                        "

--- a/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__transcript_overlay_snapshot_basic.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__transcript_overlay_snapshot_basic.snap
@@ -2,13 +2,13 @@
 source: tui/src/pager_overlay.rs
 expression: term.backend()
 ---
-" Transcript · 0 prompts · 100% ─────────"
+" Transcript ────────────────────────────"
 "alpha                                   "
 "                                        "
 "beta                                    "
 "                                        "
 "gamma                                   "
-"────────────────────────────────────────"
+"───────────────────────── 0 / 0 · 100% ─"
 " ↑/↓   ←/→   pgup/pgdn   home/end       "
 " q   ctrl + o   ⌥ + r   esc/←           "
 "                                        "

--- a/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__transcript_scroll_selects_prompt_entering_from_below.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__transcript_scroll_selects_prompt_entering_from_below.snap
@@ -1,0 +1,15 @@
+---
+source: tui/src/pager_overlay.rs
+expression: "buffer_to_text(&buf, area)"
+---
+ Transcript ────────────────────────────────────────────────
+answer-4
+answer-5
+answer-6
+answer-7
+
+
+› second
+────────────────────────────────────────────── 2 / 2 · 73% ─
+ ↑/↓ scroll   ←/→ prompts   pgup/pgdn page   home/end jump
+ q   ctrl + o   ⌥ + r   esc/←   →   enter/← prev


### PR DESCRIPTION
## Summary

The transcript overlay is useful for navigating long sessions, but before this change it still felt like a generic pager: prompt-to-prompt navigation was clumsy, transcript-specific actions were hard to discover, and copy feedback polluted the conversation instead of staying in the overlay.

This PR turns `Ctrl+T` into a dedicated transcript surface. It improves prompt navigation, gives the overlay its own header and footer treatment, and keeps copy feedback local to the transcript view.

## Why

The old transcript path reused pager and resume-picker building blocks that were serviceable but not well-matched to transcript-specific workflows. For longer conversations, the key gaps were:
- moving directly between user prompts
- understanding what transcript actions were available from inside the overlay
- seeing copy success or failure without mutating transcript history

## What Changed

- introduced a dedicated transcript overlay renderer instead of routing the UI through the resume picker transcript view
- added transcript-specific navigation and actions inside `Ctrl+T`, including prompt navigation, copy, and raw/rich mode toggling
- added focused header state so the overlay can show prompt counts and selection state
- extracted shared responsive footer hint rendering and used it for transcript-specific hints
- changed overlay-triggered copy to show transient success/failure status in the footer instead of inserting transcript info/error cells
- preserved normal copy behavior outside the transcript overlay
- added targeted snapshot and behavior coverage for transcript overlay rendering, footer composition, live-tail behavior, and copy-result handling

## How to Test

1. Start Codex and open any session with multiple user prompts and assistant replies.
2. Press `Ctrl+T` to open the transcript overlay.
3. Use `Left` / `Right` or `Alt+Up` / `Alt+Down` to move between user prompts.
4. Confirm the header updates to show the selected prompt position and the footer shows transcript-specific hints.
5. Press `Ctrl+O`.
6. Confirm copy feedback appears inline in the overlay footer instead of inserting a new transcript message.
7. Press `Alt+R` and confirm the overlay toggles between rich and raw transcript modes.
8. Also verify the failure path: trigger copy from a transcript state with no available assistant markdown and confirm the footer shows the error inline rather than mutating transcript history.

Targeted tests:
- `cargo test -p codex-tui pager_overlay::tests`
- `cargo test -p codex-tui chatwidget::tests::slash_commands`

## Documentation

No docs changes are needed for `developers.openai.com/codex`.
