### PR TITLE
perf(tui): optimize transcript prompt selection [ 2 of 3 ]

### DIFF
--- a/codex-rs/tui/src/app/event_dispatch.rs
+++ b/codex-rs/tui/src/app/event_dispatch.rs
@@ -219,6 +219,13 @@ impl App {
                     );
                 }
             }
+            AppEvent::TranscriptLayoutReady(result) => {
+                if let Some(Overlay::Transcript(transcript)) = &mut self.overlay
+                    && transcript.apply_layout_result(result)
+                {
+                    tui.frame_requester().schedule_frame();
+                }
+            }
             AppEvent::EndInitialHistoryReplayBuffer => {
                 self.finish_initial_history_replay_buffer(tui);
             }

--- a/codex-rs/tui/src/app_backtrack.rs
+++ b/codex-rs/tui/src/app_backtrack.rs
@@ -347,9 +347,8 @@ impl App {
         self.backtrack.primed = true;
         self.backtrack.base_id = self.chat_widget.thread_id();
         self.backtrack.overlay_preview_active = true;
-        if let Some(nth_user_message) =
-            initial_overlay_backtrack_selection(user_count(&self.transcript_cells), start)
-        {
+        let count = self.current_transcript_user_count();
+        if let Some(nth_user_message) = initial_overlay_backtrack_selection(count, start) {
             self.apply_backtrack_selection_internal(nth_user_message);
         }
         tui.frame_requester().schedule_frame();
@@ -357,7 +356,7 @@ impl App {
 
     /// Step selection to the next older user message and update overlay.
     fn step_backtrack_and_highlight(&mut self, tui: &mut tui::Tui) {
-        let count = user_count(&self.transcript_cells);
+        let count = self.current_transcript_user_count();
         if count == 0 {
             return;
         }
@@ -380,7 +379,7 @@ impl App {
 
     /// Step selection to the next newer user message and update overlay.
     fn step_forward_backtrack_and_highlight(&mut self, tui: &mut tui::Tui) {
-        let count = user_count(&self.transcript_cells);
+        let count = self.current_transcript_user_count();
         if count == 0 {
             return;
         }
@@ -401,16 +400,27 @@ impl App {
 
     /// Apply a computed backtrack selection to the overlay and internal counter.
     fn apply_backtrack_selection_internal(&mut self, nth_user_message: usize) {
-        if let Some(cell_idx) = nth_user_position(&self.transcript_cells, nth_user_message) {
-            self.backtrack.nth_user_message = nth_user_message;
-            if let Some(Overlay::Transcript(t)) = &mut self.overlay {
-                t.set_highlight_cell(Some(cell_idx));
-            }
-        } else {
-            self.backtrack.nth_user_message = usize::MAX;
-            if let Some(Overlay::Transcript(t)) = &mut self.overlay {
+        if let Some(Overlay::Transcript(t)) = &mut self.overlay {
+            if t.set_highlighted_user_prompt(nth_user_message).is_some() {
+                self.backtrack.nth_user_message = nth_user_message;
+            } else {
+                self.backtrack.nth_user_message = usize::MAX;
                 t.set_highlight_cell(/*cell*/ None);
             }
+            return;
+        }
+
+        if nth_user_position(&self.transcript_cells, nth_user_message).is_some() {
+            self.backtrack.nth_user_message = nth_user_message;
+        } else {
+            self.backtrack.nth_user_message = usize::MAX;
+        }
+    }
+
+    fn current_transcript_user_count(&self) -> usize {
+        match &self.overlay {
+            Some(Overlay::Transcript(t)) => t.user_prompt_count(),
+            _ => user_count(&self.transcript_cells),
         }
     }
 

--- a/codex-rs/tui/src/app_backtrack.rs
+++ b/codex-rs/tui/src/app_backtrack.rs
@@ -443,8 +443,10 @@ impl App {
         {
             let active_key = self.chat_widget.active_cell_transcript_key();
             let chat_widget = &self.chat_widget;
+            let app_event_tx = self.app_event_tx.clone();
             tui.draw(u16::MAX, |frame| {
-                let width = frame.area().width.max(1);
+                let width = frame.area().width.max(/*other*/ 1);
+                t.ensure_async_layout(width, app_event_tx.clone());
                 t.sync_live_tail(width, active_key, |w| {
                     chat_widget.active_cell_transcript_hyperlink_lines(w)
                 });

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -38,6 +38,7 @@ use crate::bottom_pane::ApprovalRequest;
 use crate::bottom_pane::StatusLineItem;
 use crate::bottom_pane::TerminalTitleItem;
 use crate::chatwidget::UserMessage;
+use crate::transcript_layout::TranscriptLayoutResult;
 use codex_app_server_protocol::AskForApproval;
 use codex_config::types::ApprovalsReviewer;
 use codex_features::Feature;
@@ -575,6 +576,9 @@ pub(crate) enum AppEvent {
     BeginThreadSwitchHistoryReplayBuffer,
 
     InsertHistoryCell(Box<dyn HistoryCell>),
+
+    /// Result of measuring the transcript overlay layout off the UI thread.
+    TranscriptLayoutReady(TranscriptLayoutResult),
 
     /// Finish buffering initial resume replay after all replay events have been queued.
     EndInitialHistoryReplayBuffer,

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -192,6 +192,7 @@ mod text_formatting;
 mod theme_picker;
 mod token_usage;
 mod tooltips;
+mod transcript_layout;
 mod transcript_reflow;
 mod tui;
 mod ui_consts;

--- a/codex-rs/tui/src/pager_overlay.rs
+++ b/codex-rs/tui/src/pager_overlay.rs
@@ -1628,7 +1628,7 @@ mod tests {
 
         let mut selection_plus_render = transcript_overlay(cells);
         selection_plus_render.set_highlight_cell(Some(cell_count.saturating_sub(2)));
-        let mut term = Terminal::new(TestBackend::new(WIDTH, HEIGHT)).expect("term");
+        let mut term = RatatuiTerminal::new(TestBackend::new(WIDTH, HEIGHT)).expect("term");
 
         let render_start = Instant::now();
         for _ in 0..STEPS {

--- a/codex-rs/tui/src/pager_overlay.rs
+++ b/codex-rs/tui/src/pager_overlay.rs
@@ -2032,7 +2032,10 @@ mod tests {
             " 1 / 2 · 100% "
         );
 
-        assert_eq!(overlay.set_highlighted_user_prompt(2), None);
+        assert_eq!(
+            overlay.set_highlighted_user_prompt(/*nth_user_message*/ 2),
+            None
+        );
     }
 
     #[test]

--- a/codex-rs/tui/src/pager_overlay.rs
+++ b/codex-rs/tui/src/pager_overlay.rs
@@ -63,8 +63,8 @@ use ratatui::widgets::WidgetRef;
 use ratatui::widgets::Wrap;
 
 pub(crate) enum Overlay {
-    Transcript(TranscriptOverlay),
-    Static(StaticOverlay),
+    Transcript(Box<TranscriptOverlay>),
+    Static(Box<StaticOverlay>),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -92,13 +92,13 @@ impl Overlay {
         toggle_raw_output_keymap: Vec<KeyBinding>,
         state: TranscriptOverlayState,
     ) -> Self {
-        Self::Transcript(TranscriptOverlay::new(
+        Self::Transcript(Box::new(TranscriptOverlay::new(
             cells,
             keymap,
             copy_keymap,
             toggle_raw_output_keymap,
             state,
-        ))
+        )))
     }
 
     pub(crate) fn new_static_with_lines(
@@ -106,7 +106,7 @@ impl Overlay {
         title: String,
         keymap: PagerKeymap,
     ) -> Self {
-        Self::Static(StaticOverlay::with_title(lines, title, keymap))
+        Self::Static(Box::new(StaticOverlay::with_title(lines, title, keymap)))
     }
 
     pub(crate) fn new_static_with_renderables(
@@ -114,7 +114,11 @@ impl Overlay {
         title: String,
         keymap: PagerKeymap,
     ) -> Self {
-        Self::Static(StaticOverlay::with_renderables(renderables, title, keymap))
+        Self::Static(Box::new(StaticOverlay::with_renderables(
+            renderables,
+            title,
+            keymap,
+        )))
     }
 
     pub(crate) fn handle_event(&mut self, tui: &mut tui::Tui, event: TuiEvent) -> Result<()> {

--- a/codex-rs/tui/src/pager_overlay.rs
+++ b/codex-rs/tui/src/pager_overlay.rs
@@ -1459,6 +1459,23 @@ mod tests {
         })
     }
 
+    fn synthetic_transcript(prompt_count: usize) -> Vec<Arc<dyn HistoryCell>> {
+        let mut cells = Vec::with_capacity(prompt_count.saturating_mul(2));
+        for i in 0..prompt_count {
+            cells.push(user_cell(&format!("prompt {i}")));
+            cells.push(Arc::new(AgentMessageCell::new(
+                vec![
+                    Line::from(format!("assistant response {i}")),
+                    Line::from(
+                        "additional detail to make wrapping and height measurement realistic",
+                    ),
+                ],
+                /*is_first_line*/ true,
+            )) as Arc<dyn HistoryCell>);
+        }
+        cells
+    }
+
     fn static_overlay(lines: Vec<Line<'static>>, title: &str) -> StaticOverlay {
         StaticOverlay::with_title(lines, title.to_string(), default_pager_keymap())
     }
@@ -1552,6 +1569,51 @@ mod tests {
                 .symbol()
                 .contains(&format!("\x1b]8;;{destination}\x07"))
         }));
+    }
+
+    #[test]
+    #[ignore = "local performance probe for transcript prompt selection"]
+    fn transcript_prompt_selection_perf() {
+        const PROMPTS: usize = 1_500;
+        const STEPS: usize = 300;
+        const WIDTH: u16 = 120;
+        const HEIGHT: u16 = 40;
+
+        let cells = synthetic_transcript(PROMPTS);
+        let cell_count = cells.len();
+        let mut selection_only = transcript_overlay(cells.clone());
+        selection_only.set_highlight_cell(Some(cell_count.saturating_sub(2)));
+
+        let selection_start = Instant::now();
+        for _ in 0..STEPS {
+            selection_only.move_prompt_selection(PromptSelectionDirection::Previous);
+            selection_only.move_prompt_selection(PromptSelectionDirection::Next);
+        }
+        let selection_elapsed = selection_start.elapsed();
+
+        let mut selection_plus_render = transcript_overlay(cells);
+        selection_plus_render.set_highlight_cell(Some(cell_count.saturating_sub(2)));
+        let mut term = Terminal::new(TestBackend::new(WIDTH, HEIGHT)).expect("term");
+
+        let render_start = Instant::now();
+        for _ in 0..STEPS {
+            selection_plus_render.move_prompt_selection(PromptSelectionDirection::Previous);
+            term.draw(|f| selection_plus_render.render(f.area(), f.buffer_mut()))
+                .expect("draw previous");
+            selection_plus_render.move_prompt_selection(PromptSelectionDirection::Next);
+            term.draw(|f| selection_plus_render.render(f.area(), f.buffer_mut()))
+                .expect("draw next");
+        }
+        let render_elapsed = render_start.elapsed();
+
+        let operations = STEPS.saturating_mul(2);
+        println!(
+            "transcript_prompt_selection_perf prompts={PROMPTS} cells={cell_count} steps={operations} selection_only_ms={:.3} selection_only_avg_us={:.3} selection_plus_render_ms={:.3} selection_plus_render_avg_us={:.3}",
+            selection_elapsed.as_secs_f64() * 1_000.0,
+            selection_elapsed.as_secs_f64() * 1_000_000.0 / operations as f64,
+            render_elapsed.as_secs_f64() * 1_000.0,
+            render_elapsed.as_secs_f64() * 1_000_000.0 / operations as f64,
+        );
     }
 
     #[test]

--- a/codex-rs/tui/src/pager_overlay.rs
+++ b/codex-rs/tui/src/pager_overlay.rs
@@ -15,6 +15,7 @@
 //! recomputed. `ChatWidget` is responsible for producing a key that changes when the active cell
 //! mutates in place or when its transcript output is time-dependent.
 
+use std::any::TypeId;
 use std::cell::Cell as StdCell;
 use std::io::Result;
 use std::rc::Rc;
@@ -31,6 +32,7 @@ use crate::footer_hints::render_footer_line_with_optional_right;
 use crate::footer_hints::render_footer_separator;
 use crate::history_cell::HistoryCell;
 use crate::history_cell::HistoryRenderMode;
+use crate::history_cell::SessionInfoCell;
 use crate::history_cell::UserHistoryCell;
 use crate::key_hint;
 use crate::key_hint::KeyBinding;
@@ -657,9 +659,11 @@ impl TranscriptOverlay {
     }
 
     fn user_prompt_positions(cells: &[Arc<dyn HistoryCell>]) -> Vec<usize> {
+        let start = session_start_index(cells);
         cells
             .iter()
             .enumerate()
+            .skip(start)
             .filter_map(|(idx, cell)| cell.is_user_prompt().then_some(idx))
             .collect()
     }
@@ -679,10 +683,7 @@ impl TranscriptOverlay {
         let had_prior_cells = !self.cells.is_empty();
         let tail_renderable = self.take_live_tail_renderable();
         self.cells.push(cell);
-        if self.cells.last().is_some_and(|cell| cell.is_user_prompt()) {
-            self.user_prompt_positions
-                .push(self.cells.len().saturating_sub(1));
-        }
+        self.user_prompt_positions = Self::user_prompt_positions(&self.cells);
         self.view.renderables = Self::render_cells(
             &self.cells,
             Rc::clone(&self.highlight_cell),
@@ -1416,11 +1417,28 @@ fn render_offset_content(
     copy_height
 }
 
+fn session_start_index(cells: &[Arc<dyn HistoryCell>]) -> usize {
+    let session_start_type = TypeId::of::<SessionInfoCell>();
+    let type_of = |cell: &Arc<dyn HistoryCell>| cell.as_any().type_id();
+
+    cells
+        .iter()
+        .rposition(|cell| type_of(cell) == session_start_type)
+        .map_or(0, |idx| idx + 1)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::history_cell::ReviewDecision;
+    use codex_app_server_protocol::AskForApproval;
     use codex_app_server_protocol::CommandExecutionSource as ExecCommandSource;
+    use codex_protocol::ThreadId;
+    use codex_protocol::config_types::ApprovalsReviewer;
+    use codex_protocol::models::PermissionProfile;
+    use codex_protocol::openai_models::ReasoningEffort as ReasoningEffortConfig;
+    use codex_utils_absolute_path::test_support::PathBufExt;
+    use codex_utils_absolute_path::test_support::test_path_buf;
     use insta::assert_snapshot;
     use pretty_assertions::assert_eq;
     use std::collections::HashMap;
@@ -1429,6 +1447,7 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
     use std::time::Instant;
+    use tempfile::TempDir;
 
     use crate::diff_model::FileChange;
     use crate::exec_cell::CommandOutput;
@@ -1436,6 +1455,9 @@ mod tests {
     use crate::history_cell::AgentMessageCell;
     use crate::history_cell::HistoryCell;
     use crate::history_cell::new_patch_event;
+    use crate::history_cell::new_session_info;
+    use crate::legacy_core::config::ConfigBuilder;
+    use crate::session_state::ThreadSessionState;
     use codex_protocol::parse_command::ParsedCommand;
     use ratatui::Terminal as RatatuiTerminal;
     use ratatui::backend::TestBackend;
@@ -1509,6 +1531,46 @@ mod tests {
             )) as Arc<dyn HistoryCell>);
         }
         cells
+    }
+
+    fn session_info_cell(cwd: &str) -> Arc<dyn HistoryCell> {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let temp_dir = TempDir::new().expect("tempdir");
+        let config = runtime
+            .block_on(
+                ConfigBuilder::default()
+                    .codex_home(temp_dir.path().to_path_buf())
+                    .build(),
+            )
+            .expect("config");
+        let session = ThreadSessionState {
+            thread_id: ThreadId::new(),
+            forked_from_id: None,
+            fork_parent_title: None,
+            thread_name: None,
+            model: "gpt-test".to_string(),
+            model_provider_id: "test-provider".to_string(),
+            service_tier: None,
+            approval_policy: AskForApproval::Never,
+            approvals_reviewer: ApprovalsReviewer::User,
+            permission_profile: PermissionProfile::read_only(),
+            active_permission_profile: None,
+            cwd: test_path_buf(cwd).abs(),
+            runtime_workspace_roots: Vec::new(),
+            instruction_source_paths: Vec::new(),
+            reasoning_effort: Some(ReasoningEffortConfig::High),
+            message_history: None,
+            network_proxy: None,
+            rollout_path: Some(PathBuf::new()),
+        };
+        Arc::new(new_session_info(
+            &config, "gpt-test", &session, /*is_first_event*/ false,
+            /*tooltip_override*/ None, /*auth_plan*/ None,
+            /*show_fast_status*/ false,
+        )) as Arc<dyn HistoryCell>
     }
 
     fn static_overlay(lines: Vec<Line<'static>>, title: &str) -> StaticOverlay {
@@ -1918,6 +1980,53 @@ mod tests {
             "explicit_prompt_selection_anchors_prompt_in_upper_third",
             buffer_to_text(&buf, area)
         );
+    }
+
+    #[test]
+    fn transcript_prompt_selection_ignores_prompts_before_latest_session_header() {
+        let mut overlay = transcript_overlay(vec![
+            user_cell("old prompt"),
+            Arc::new(AgentMessageCell::new(
+                vec![Line::from("old assistant")],
+                /*is_first_line*/ true,
+            )),
+            session_info_cell("/tmp/project"),
+            user_cell("current first"),
+            Arc::new(AgentMessageCell::new(
+                vec![Line::from("current assistant")],
+                /*is_first_line*/ true,
+            )),
+            user_cell("current second"),
+        ]);
+
+        assert_eq!(overlay.user_prompt_count(), 2);
+        assert_eq!(overlay.header_title(), "Transcript");
+        assert_eq!(
+            overlay.footer_progress_label(
+                /*content_height*/ 5, /*total_len*/ 12, /*width*/ 80
+            ),
+            " 2 / 2 · 100% "
+        );
+
+        overlay.move_prompt_selection(PromptSelectionDirection::Previous);
+        assert_eq!(overlay.selected_user_cell(), Some(5));
+        assert_eq!(
+            overlay.footer_progress_label(
+                /*content_height*/ 5, /*total_len*/ 12, /*width*/ 80
+            ),
+            " 2 / 2 · 100% "
+        );
+
+        overlay.move_prompt_selection(PromptSelectionDirection::Previous);
+        assert_eq!(overlay.selected_user_cell(), Some(3));
+        assert_eq!(
+            overlay.footer_progress_label(
+                /*content_height*/ 5, /*total_len*/ 12, /*width*/ 80
+            ),
+            " 1 / 2 · 100% "
+        );
+
+        assert_eq!(overlay.set_highlighted_user_prompt(2), None);
     }
 
     #[test]

--- a/codex-rs/tui/src/pager_overlay.rs
+++ b/codex-rs/tui/src/pager_overlay.rs
@@ -1566,6 +1566,8 @@ mod tests {
             runtime_workspace_roots: Vec::new(),
             instruction_source_paths: Vec::new(),
             reasoning_effort: Some(ReasoningEffortConfig::High),
+            collaboration_mode: None,
+            personality: None,
             message_history: None,
             network_proxy: None,
             rollout_path: Some(PathBuf::new()),

--- a/codex-rs/tui/src/pager_overlay.rs
+++ b/codex-rs/tui/src/pager_overlay.rs
@@ -23,6 +23,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
 
+use crate::app_event_sender::AppEventSender;
 use crate::chatwidget::ActiveCellTranscriptKey;
 use crate::chatwidget::CopyStatus;
 use crate::footer_hints::FooterHint;
@@ -45,6 +46,9 @@ use crate::style::user_message_style;
 use crate::terminal_hyperlinks::HyperlinkLine;
 use crate::terminal_hyperlinks::mark_buffer_hyperlinks;
 use crate::terminal_hyperlinks::visible_lines;
+use crate::transcript_layout::TranscriptLayoutKey;
+use crate::transcript_layout::TranscriptLayoutResult;
+use crate::transcript_layout::spawn_transcript_layout_worker;
 use crate::tui;
 use crate::tui::TuiEvent;
 use crossterm::event::KeyCode;
@@ -198,6 +202,21 @@ impl PagerView {
 
     fn content_height(&mut self, width: u16) -> usize {
         self.layout(width).total_height
+    }
+
+    fn install_precomputed_layout(&mut self, width: u16, heights: Vec<usize>) {
+        let mut offsets = Vec::with_capacity(heights.len());
+        let mut total_height = 0usize;
+        for height in &heights {
+            offsets.push(total_height);
+            total_height = total_height.saturating_add(*height);
+        }
+        self.layout = Some(PagerLayout {
+            width,
+            offsets: offsets.into(),
+            heights: heights.into(),
+            total_height,
+        });
     }
 
     fn layout(&mut self, width: u16) -> &PagerLayout {
@@ -550,10 +569,12 @@ pub(crate) struct TranscriptOverlay {
     footer_status: Option<FooterStatus>,
     /// Cache key for the render-only live tail appended after committed cells.
     live_tail_key: Option<LiveTailKey>,
+    async_layout: AsyncTranscriptLayout,
     is_done: bool,
 }
 
 const FOOTER_STATUS_TTL: Duration = Duration::from_secs(2);
+const ASYNC_TRANSCRIPT_LAYOUT_CELL_THRESHOLD: usize = 2_000;
 
 #[derive(Clone)]
 struct FooterStatus {
@@ -576,6 +597,29 @@ struct LiveTailKey {
     animation_tick: Option<u64>,
 }
 
+#[derive(Debug)]
+struct AsyncTranscriptLayout {
+    generation: u64,
+    pending: Option<TranscriptLayoutKey>,
+    measured: Option<TranscriptLayoutResult>,
+}
+
+impl AsyncTranscriptLayout {
+    fn new() -> Self {
+        Self {
+            generation: 0,
+            pending: None,
+            measured: None,
+        }
+    }
+
+    fn invalidate(&mut self) {
+        self.generation = self.generation.saturating_add(/*rhs*/ 1);
+        self.pending = None;
+        self.measured = None;
+    }
+}
+
 impl TranscriptOverlay {
     /// Creates a transcript overlay for a fixed set of committed cells.
     ///
@@ -589,14 +633,17 @@ impl TranscriptOverlay {
         state: TranscriptOverlayState,
     ) -> Self {
         let highlight_cell = Rc::new(StdCell::new(state.highlight_cell));
+        let renderables = Self::render_cells(
+            &transcript_cells,
+            Rc::clone(&highlight_cell),
+            state.render_mode,
+        );
+        let user_prompt_positions = Self::user_prompt_positions(&transcript_cells);
+
         Self {
             view: {
                 let mut view = PagerView::new(
-                    Self::render_cells(
-                        &transcript_cells,
-                        Rc::clone(&highlight_cell),
-                        state.render_mode,
-                    ),
+                    renderables,
                     "Transcript".to_string(),
                     state.scroll_offset,
                     keymap,
@@ -604,7 +651,7 @@ impl TranscriptOverlay {
                 view.show_header_progress = false;
                 view
             },
-            user_prompt_positions: Self::user_prompt_positions(&transcript_cells),
+            user_prompt_positions,
             cells: transcript_cells,
             highlight_cell,
             render_mode: state.render_mode,
@@ -614,6 +661,7 @@ impl TranscriptOverlay {
             scroll_selected_user_cell: None,
             footer_status: None,
             live_tail_key: None,
+            async_layout: AsyncTranscriptLayout::new(),
             is_done: false,
         }
     }
@@ -687,6 +735,7 @@ impl TranscriptOverlay {
         let had_prior_cells = !self.cells.is_empty();
         let tail_renderable = self.take_live_tail_renderable();
         self.cells.push(cell);
+        self.invalidate_async_layout();
         self.user_prompt_positions = Self::user_prompt_positions(&self.cells);
         self.view.renderables = Self::render_cells(
             &self.cells,
@@ -726,6 +775,7 @@ impl TranscriptOverlay {
     pub(crate) fn replace_cells(&mut self, cells: Vec<Arc<dyn HistoryCell>>) {
         let follow_bottom = self.view.is_scrolled_to_bottom();
         self.cells = cells;
+        self.invalidate_async_layout();
         self.user_prompt_positions = Self::user_prompt_positions(&self.cells);
         if self
             .highlight_cell
@@ -771,6 +821,7 @@ impl TranscriptOverlay {
             }
             self.cells
                 .splice(clamped_start..clamped_end, std::iter::once(consolidated));
+            self.invalidate_async_layout();
             self.user_prompt_positions = Self::user_prompt_positions(&self.cells);
             if self
                 .highlight_cell
@@ -812,6 +863,7 @@ impl TranscriptOverlay {
         });
 
         if self.live_tail_key == next_key {
+            self.install_measured_layout_if_ready(width);
             return;
         }
         let follow_bottom = self.view.is_scrolled_to_bottom();
@@ -833,6 +885,82 @@ impl TranscriptOverlay {
         if follow_bottom {
             self.view.scroll_offset = usize::MAX;
         }
+        self.install_measured_layout_if_ready(width);
+    }
+
+    pub(crate) fn ensure_async_layout(&mut self, width: u16, app_event_tx: AppEventSender) {
+        if !self.uses_async_layout() {
+            return;
+        }
+        let key = self.layout_key(width);
+        if self
+            .async_layout
+            .measured
+            .as_ref()
+            .is_some_and(|result| result.key == key)
+        {
+            self.install_measured_layout_if_ready(width);
+            return;
+        }
+        if self.async_layout.pending == Some(key) {
+            return;
+        }
+        self.async_layout.pending = Some(key);
+        self.async_layout.measured = None;
+        spawn_transcript_layout_worker(key, self.cells.clone(), app_event_tx);
+    }
+
+    pub(crate) fn apply_layout_result(&mut self, result: TranscriptLayoutResult) -> bool {
+        if result.key != self.layout_key(result.key.width) {
+            return false;
+        }
+        let width = result.key.width;
+        self.async_layout.pending = None;
+        self.async_layout.measured = Some(result);
+        self.install_measured_layout_if_ready(width);
+        true
+    }
+
+    fn uses_async_layout(&self) -> bool {
+        self.cells.len() >= ASYNC_TRANSCRIPT_LAYOUT_CELL_THRESHOLD
+    }
+
+    fn layout_key(&self, width: u16) -> TranscriptLayoutKey {
+        TranscriptLayoutKey {
+            generation: self.async_layout.generation,
+            width,
+            render_mode: self.render_mode,
+            cell_count: self.cells.len(),
+        }
+    }
+
+    fn is_waiting_for_async_layout(&self, width: u16) -> bool {
+        if !self.uses_async_layout() {
+            return false;
+        }
+        let Some(layout) = self.view.layout.as_ref() else {
+            return true;
+        };
+        layout.width != width || layout.heights.len() != self.view.renderables.len()
+    }
+
+    fn install_measured_layout_if_ready(&mut self, width: u16) -> bool {
+        let Some(result) = self.async_layout.measured.as_ref() else {
+            return false;
+        };
+        if result.key != self.layout_key(width) {
+            return false;
+        }
+        let mut heights = result.heights.clone();
+        for renderable in self.view.renderables.iter().skip(self.cells.len()) {
+            heights.push(renderable.desired_height(width) as usize);
+        }
+        self.view.install_precomputed_layout(width, heights);
+        true
+    }
+
+    fn invalidate_async_layout(&mut self) {
+        self.async_layout.invalidate();
     }
 
     pub(crate) fn set_highlight_cell(&mut self, cell: Option<usize>) {
@@ -910,6 +1038,7 @@ impl TranscriptOverlay {
             HistoryRenderMode::Rich => HistoryRenderMode::Raw,
             HistoryRenderMode::Raw => HistoryRenderMode::Rich,
         };
+        self.invalidate_async_layout();
         self.rebuild_renderables();
     }
 
@@ -994,6 +1123,9 @@ impl TranscriptOverlay {
             top_h,
         );
         let content_area = self.view.content_area(top);
+        if self.is_waiting_for_async_layout(content_area.width) {
+            return Ok(());
+        }
         let before = self.view.clamped_scroll_offset(content_area);
         if !self.view.handle_key_event(tui, key_event)? {
             return Ok(());
@@ -1029,6 +1161,26 @@ impl TranscriptOverlay {
             format!(" {selected} / {total} · {percent}% "),
             format!(" {selected}/{total} · {percent}% "),
             format!(" {percent}% "),
+        ];
+        first_fitting_right_label(width, &labels)
+    }
+
+    fn loading_progress_label(&self, width: u16) -> String {
+        let total = self.user_prompt_positions.len();
+        let selected = self
+            .highlight_cell
+            .get()
+            .and_then(|highlight_cell| {
+                let selected = self
+                    .user_prompt_positions
+                    .partition_point(|idx| *idx <= highlight_cell);
+                (selected > 0).then_some(selected)
+            })
+            .unwrap_or(total);
+        let labels = [
+            format!(" {selected} / {total} · loading... "),
+            format!(" {selected}/{total} · loading... "),
+            " loading... ".to_string(),
         ];
         first_fitting_right_label(width, &labels)
     }
@@ -1219,11 +1371,36 @@ impl TranscriptOverlay {
         let bottom = Rect::new(area.x, area.y + top_h, area.width, 3);
         self.view.title = self.header_title();
         let content_area = self.view.content_area(top);
+        self.install_measured_layout_if_ready(content_area.width);
+        if self.is_waiting_for_async_layout(content_area.width) {
+            self.render_loading(top, bottom, buf);
+            return;
+        }
         let total_len = self.view.content_height(content_area.width);
         self.view.resolve_pending_scroll(content_area, total_len);
         self.view.footer_separator_label =
             self.footer_progress_label(content_area.height, total_len, top.width);
         self.view.render(top, buf);
+        self.render_hints(bottom, buf);
+    }
+
+    fn render_loading(&mut self, top: Rect, bottom: Rect, buf: &mut Buffer) {
+        Clear.render(top, buf);
+        let header = Rect::new(top.x, top.y, top.width, /*height*/ 1);
+        render_footer_separator(header, buf, String::new());
+        format!(" {} ", self.header_title())
+            .dim()
+            .render_ref(header, buf);
+
+        let content_area = self.view.content_area(top);
+        if content_area.height > 0 {
+            Paragraph::new("Loading transcript...".dim())
+                .wrap(Wrap { trim: false })
+                .render(content_area, buf);
+        }
+
+        let separator = Rect::new(top.x, content_area.bottom(), top.width, /*height*/ 1);
+        render_footer_separator(separator, buf, self.loading_progress_label(top.width));
         self.render_hints(bottom, buf);
     }
 }
@@ -1535,6 +1712,29 @@ mod tests {
             )) as Arc<dyn HistoryCell>);
         }
         cells
+    }
+
+    fn large_test_cells() -> Vec<Arc<dyn HistoryCell>> {
+        (0..ASYNC_TRANSCRIPT_LAYOUT_CELL_THRESHOLD)
+            .map(|idx| {
+                Arc::new(TestCell {
+                    lines: vec![Line::from(format!("line-{idx}"))],
+                }) as Arc<dyn HistoryCell>
+            })
+            .collect()
+    }
+
+    fn measured_layout_for(
+        overlay: &TranscriptOverlay,
+        width: u16,
+        height: usize,
+    ) -> TranscriptLayoutResult {
+        let cell_count = overlay.committed_cell_count();
+        TranscriptLayoutResult {
+            key: overlay.layout_key(width),
+            heights: vec![height; cell_count],
+            total_height: cell_count.saturating_mul(height),
+        }
     }
 
     fn session_info_cell(cwd: &str) -> Arc<dyn HistoryCell> {
@@ -2096,6 +2296,89 @@ mod tests {
         overlay.render(area, &mut buf);
         let second_selection = prompt_marker_reversed_states(&buf, area);
         assert_eq!(second_selection, vec![false, true]);
+    }
+
+    #[test]
+    fn large_transcript_renders_loading_until_layout_is_ready() {
+        let mut overlay = transcript_overlay(large_test_cells());
+        let area = Rect::new(
+            /*x*/ 0, /*y*/ 0, /*width*/ 80, /*height*/ 10,
+        );
+        let mut buf = Buffer::empty(area);
+
+        overlay.render(area, &mut buf);
+
+        assert!(overlay.view.layout.is_none());
+        assert_snapshot!(
+            "large_transcript_renders_loading_until_layout_is_ready",
+            buffer_to_text(&buf, area)
+        );
+    }
+
+    #[test]
+    fn large_transcript_applies_matching_precomputed_layout() {
+        let mut overlay = transcript_overlay(large_test_cells());
+        let area = Rect::new(
+            /*x*/ 0, /*y*/ 0, /*width*/ 80, /*height*/ 10,
+        );
+        let result = measured_layout_for(&overlay, /*width*/ 80, /*height*/ 1);
+        let committed_cell_count = overlay.committed_cell_count();
+
+        assert!(overlay.apply_layout_result(result));
+
+        let layout = overlay.view.layout(/*width*/ 80);
+        assert_eq!(layout.heights.len(), committed_cell_count);
+        assert_eq!(layout.total_height, committed_cell_count);
+
+        let mut buf = Buffer::empty(area);
+        overlay.render(area, &mut buf);
+        assert!(!buffer_to_text(&buf, area).contains("Loading transcript"));
+    }
+
+    #[test]
+    fn large_transcript_ignores_stale_layout_result() {
+        let mut overlay = transcript_overlay(large_test_cells());
+        let mut result = measured_layout_for(&overlay, /*width*/ 80, /*height*/ 1);
+        result.key.generation = result.key.generation.saturating_add(/*rhs*/ 1);
+
+        assert!(!overlay.apply_layout_result(result));
+        assert!(overlay.view.layout.is_none());
+    }
+
+    #[test]
+    fn prompt_selection_anchors_after_async_layout_arrives() {
+        let cells: Vec<Arc<dyn HistoryCell>> = (0..ASYNC_TRANSCRIPT_LAYOUT_CELL_THRESHOLD)
+            .map(|idx| user_cell(&format!("prompt {idx}")))
+            .collect();
+        let mut overlay = transcript_overlay(cells);
+        let selected = overlay.committed_cell_count() / 2;
+        let area = Rect::new(
+            /*x*/ 0, /*y*/ 0, /*width*/ 80, /*height*/ 15,
+        );
+        let top = Rect::new(
+            area.x,
+            area.y,
+            area.width,
+            area.height.saturating_sub(/*rhs*/ 3),
+        );
+        let content_area = overlay.view.content_area(top);
+
+        overlay.set_highlight_cell(Some(selected));
+        overlay.render(area, &mut Buffer::empty(area));
+        assert!(overlay.view.layout.is_none());
+
+        let result = measured_layout_for(&overlay, /*width*/ 80, /*height*/ 3);
+        assert!(overlay.apply_layout_result(result));
+        overlay.render(area, &mut Buffer::empty(area));
+
+        let selected_row = {
+            let layout = overlay.view.layout(content_area.width);
+            layout.offsets[selected].saturating_add(overlay.prompt_first_text_row_offset(selected))
+        };
+        assert_eq!(
+            selected_row.saturating_sub(overlay.view.scroll_offset),
+            (content_area.height as usize) / 3,
+        );
     }
 
     fn prompt_marker_reversed_states(buf: &Buffer, area: Rect) -> Vec<bool> {

--- a/codex-rs/tui/src/pager_overlay.rs
+++ b/codex-rs/tui/src/pager_overlay.rs
@@ -15,7 +15,9 @@
 //! recomputed. `ChatWidget` is responsible for producing a key that changes when the active cell
 //! mutates in place or when its transcript output is time-dependent.
 
+use std::cell::Cell as StdCell;
 use std::io::Result;
+use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
@@ -473,17 +475,25 @@ impl Renderable for CachedRenderable {
 
 struct CellRenderable {
     cell: Arc<dyn HistoryCell>,
+    cell_index: usize,
     style: Style,
+    selected_style: Option<Style>,
+    highlight_cell: Rc<StdCell<Option<usize>>>,
     render_mode: HistoryRenderMode,
 }
 
 impl Renderable for CellRenderable {
     fn render(&self, area: Rect, buf: &mut Buffer) {
+        let style = if self.highlight_cell.get() == Some(self.cell_index) {
+            self.selected_style.unwrap_or(self.style)
+        } else {
+            self.style
+        };
         let hyperlink_lines = self
             .cell
             .transcript_hyperlink_lines_for_mode(area.width, self.render_mode);
         let p = Paragraph::new(Text::from(visible_lines(hyperlink_lines.clone())))
-            .style(self.style)
+            .style(style)
             .wrap(Wrap { trim: false });
         p.render(area, buf);
         mark_buffer_hyperlinks(buf, area, &hyperlink_lines, /*scroll_rows*/ 0);
@@ -524,7 +534,8 @@ pub(crate) struct TranscriptOverlay {
     view: PagerView,
     /// Committed transcript cells (does not include the live tail).
     cells: Vec<Arc<dyn HistoryCell>>,
-    highlight_cell: Option<usize>,
+    highlight_cell: Rc<StdCell<Option<usize>>>,
+    user_prompt_positions: Vec<usize>,
     render_mode: HistoryRenderMode,
     copy_keymap: Vec<KeyBinding>,
     toggle_raw_output_keymap: Vec<KeyBinding>,
@@ -571,10 +582,15 @@ impl TranscriptOverlay {
         toggle_raw_output_keymap: Vec<KeyBinding>,
         state: TranscriptOverlayState,
     ) -> Self {
+        let highlight_cell = Rc::new(StdCell::new(state.highlight_cell));
         Self {
             view: {
                 let mut view = PagerView::new(
-                    Self::render_cells(&transcript_cells, state.highlight_cell, state.render_mode),
+                    Self::render_cells(
+                        &transcript_cells,
+                        Rc::clone(&highlight_cell),
+                        state.render_mode,
+                    ),
                     "Transcript".to_string(),
                     state.scroll_offset,
                     keymap,
@@ -582,8 +598,9 @@ impl TranscriptOverlay {
                 view.show_header_progress = false;
                 view
             },
+            user_prompt_positions: Self::user_prompt_positions(&transcript_cells),
             cells: transcript_cells,
-            highlight_cell: state.highlight_cell,
+            highlight_cell,
             render_mode: state.render_mode,
             copy_keymap,
             toggle_raw_output_keymap,
@@ -597,7 +614,7 @@ impl TranscriptOverlay {
 
     fn render_cells(
         cells: &[Arc<dyn HistoryCell>],
-        highlight_cell: Option<usize>,
+        highlight_cell: Rc<StdCell<Option<usize>>>,
         render_mode: HistoryRenderMode,
     ) -> Vec<Box<dyn Renderable>> {
         cells
@@ -608,17 +625,19 @@ impl TranscriptOverlay {
                 let base_renderable = if c.as_any().is::<UserHistoryCell>() {
                     Box::new(CachedRenderable::new(CellRenderable {
                         cell: c.clone(),
-                        style: if highlight_cell == Some(i) {
-                            user_message_style().reversed()
-                        } else {
-                            user_message_style()
-                        },
+                        cell_index: i,
+                        style: user_message_style(),
+                        selected_style: Some(user_message_style().reversed()),
+                        highlight_cell: Rc::clone(&highlight_cell),
                         render_mode,
                     })) as Box<dyn Renderable>
                 } else {
                     Box::new(CachedRenderable::new(CellRenderable {
                         cell: c.clone(),
+                        cell_index: i,
                         style: Style::default(),
+                        selected_style: None,
+                        highlight_cell: Rc::clone(&highlight_cell),
                         render_mode,
                     })) as Box<dyn Renderable>
                 };
@@ -637,6 +656,14 @@ impl TranscriptOverlay {
             .collect()
     }
 
+    fn user_prompt_positions(cells: &[Arc<dyn HistoryCell>]) -> Vec<usize> {
+        cells
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, cell)| cell.is_user_prompt().then_some(idx))
+            .collect()
+    }
+
     /// Insert a committed history cell while keeping any cached live tail.
     ///
     /// The live tail is temporarily removed, the committed cells are rebuilt,
@@ -652,8 +679,15 @@ impl TranscriptOverlay {
         let had_prior_cells = !self.cells.is_empty();
         let tail_renderable = self.take_live_tail_renderable();
         self.cells.push(cell);
-        self.view.renderables =
-            Self::render_cells(&self.cells, self.highlight_cell, self.render_mode);
+        if self.cells.last().is_some_and(|cell| cell.is_user_prompt()) {
+            self.user_prompt_positions
+                .push(self.cells.len().saturating_sub(1));
+        }
+        self.view.renderables = Self::render_cells(
+            &self.cells,
+            Rc::clone(&self.highlight_cell),
+            self.render_mode,
+        );
         self.view.invalidate_layout();
         if let Some(tail) = tail_renderable {
             let tail = if !had_prior_cells
@@ -687,11 +721,13 @@ impl TranscriptOverlay {
     pub(crate) fn replace_cells(&mut self, cells: Vec<Arc<dyn HistoryCell>>) {
         let follow_bottom = self.view.is_scrolled_to_bottom();
         self.cells = cells;
+        self.user_prompt_positions = Self::user_prompt_positions(&self.cells);
         if self
             .highlight_cell
+            .get()
             .is_some_and(|idx| idx >= self.cells.len())
         {
-            self.highlight_cell = None;
+            self.highlight_cell.set(None);
         }
         self.rebuild_renderables();
         if follow_bottom {
@@ -718,22 +754,25 @@ impl TranscriptOverlay {
         let clamped_start = range.start.min(clamped_end);
         if clamped_start < clamped_end {
             let removed = clamped_end - clamped_start;
-            if let Some(highlight_cell) = self.highlight_cell.as_mut()
-                && *highlight_cell >= clamped_start
+            if let Some(mut highlight_cell) = self.highlight_cell.get()
+                && highlight_cell >= clamped_start
             {
-                if *highlight_cell < clamped_end {
-                    *highlight_cell = clamped_start;
+                if highlight_cell < clamped_end {
+                    highlight_cell = clamped_start;
                 } else {
-                    *highlight_cell = highlight_cell.saturating_sub(removed.saturating_sub(1));
+                    highlight_cell = highlight_cell.saturating_sub(removed.saturating_sub(1));
                 }
+                self.highlight_cell.set(Some(highlight_cell));
             }
             self.cells
                 .splice(clamped_start..clamped_end, std::iter::once(consolidated));
+            self.user_prompt_positions = Self::user_prompt_positions(&self.cells);
             if self
                 .highlight_cell
+                .get()
                 .is_some_and(|highlight_cell| highlight_cell >= self.cells.len())
             {
-                self.highlight_cell = None;
+                self.highlight_cell.set(None);
             }
             self.rebuild_renderables();
         }
@@ -805,15 +844,22 @@ impl TranscriptOverlay {
         placement: PromptSelectionPlacement,
     ) {
         let prompt_row_offset = cell.map(|idx| self.prompt_first_text_row_offset(idx));
-        if self.highlight_cell != cell {
-            self.highlight_cell = cell;
-            self.rebuild_renderables();
-        }
+        self.highlight_cell.set(cell);
         if let (Some(idx), Some(row_offset), PromptSelectionPlacement::AnchorUpperThird) =
             (cell, prompt_row_offset, placement)
         {
             self.view.scroll_chunk_to_upper_third(idx, row_offset);
         }
+    }
+
+    pub(crate) fn user_prompt_count(&self) -> usize {
+        self.user_prompt_positions.len()
+    }
+
+    pub(crate) fn set_highlighted_user_prompt(&mut self, nth_user_message: usize) -> Option<usize> {
+        let cell_idx = self.user_prompt_positions.get(nth_user_message).copied()?;
+        self.set_highlight_cell(Some(cell_idx));
+        Some(cell_idx)
     }
 
     /// Returns whether the underlying pager view is currently pinned to the bottom.
@@ -827,7 +873,7 @@ impl TranscriptOverlay {
     pub(crate) fn state(&self) -> TranscriptOverlayState {
         TranscriptOverlayState {
             scroll_offset: self.view.scroll_offset,
-            highlight_cell: self.highlight_cell,
+            highlight_cell: self.highlight_cell.get(),
             render_mode: self.render_mode,
         }
     }
@@ -847,7 +893,7 @@ impl TranscriptOverlay {
     }
 
     pub(crate) fn selected_user_cell(&self) -> Option<usize> {
-        self.highlight_cell.filter(|idx| {
+        self.highlight_cell.get().filter(|idx| {
             self.cells
                 .get(*idx)
                 .is_some_and(|cell| cell.is_user_prompt())
@@ -863,27 +909,23 @@ impl TranscriptOverlay {
     }
 
     fn move_prompt_selection(&mut self, direction: PromptSelectionDirection) {
-        let prompt_positions = self
-            .cells
-            .iter()
-            .enumerate()
-            .filter_map(|(idx, cell)| cell.is_user_prompt().then_some(idx))
-            .collect::<Vec<_>>();
-        let Some(last_prompt) = prompt_positions.last().copied() else {
+        let Some(last_prompt) = self.user_prompt_positions.last().copied() else {
             return;
         };
 
-        let next_prompt = match self.highlight_cell {
+        let next_prompt = match self.highlight_cell.get() {
             Some(current) => {
-                let current_idx = prompt_positions
+                let current_idx = self
+                    .user_prompt_positions
                     .iter()
                     .position(|idx| *idx == current)
-                    .unwrap_or(prompt_positions.len().saturating_sub(1));
+                    .unwrap_or(self.user_prompt_positions.len().saturating_sub(1));
                 match direction {
                     PromptSelectionDirection::Previous => {
-                        prompt_positions[current_idx.saturating_sub(1)]
+                        self.user_prompt_positions[current_idx.saturating_sub(1)]
                     }
-                    PromptSelectionDirection::Next => prompt_positions
+                    PromptSelectionDirection::Next => self
+                        .user_prompt_positions
                         .get(current_idx.saturating_add(1))
                         .copied()
                         .unwrap_or(last_prompt),
@@ -917,17 +959,12 @@ impl TranscriptOverlay {
             return None;
         }
         let offsets = self.view.layout(width).offsets.clone();
-        let prompts = self
-            .cells
-            .iter()
-            .enumerate()
-            .filter(|(_, cell)| cell.is_user_prompt())
-            .map(|(idx, _)| {
-                (
-                    idx,
-                    offsets[idx].saturating_add(self.prompt_first_text_row_offset(idx)),
-                )
-            });
+        let prompts = self.user_prompt_positions.iter().copied().map(|idx| {
+            (
+                idx,
+                offsets[idx].saturating_add(self.prompt_first_text_row_offset(idx)),
+            )
+        });
         if after > before {
             let previous_bottom = before.saturating_add(height as usize);
             let current_bottom = after.saturating_add(height as usize);
@@ -971,20 +1008,14 @@ impl TranscriptOverlay {
     }
 
     fn footer_progress_label(&self, content_height: u16, total_len: usize, width: u16) -> String {
-        let total = self
-            .cells
-            .iter()
-            .filter(|cell| cell.is_user_prompt())
-            .count();
+        let total = self.user_prompt_positions.len();
         let selected = self
             .highlight_cell
+            .get()
             .and_then(|highlight_cell| {
                 let selected = self
-                    .cells
-                    .iter()
-                    .take(highlight_cell.saturating_add(1))
-                    .filter(|cell| cell.is_user_prompt())
-                    .count();
+                    .user_prompt_positions
+                    .partition_point(|idx| *idx <= highlight_cell);
                 (selected > 0).then_some(selected)
             })
             .unwrap_or(total);
@@ -999,8 +1030,11 @@ impl TranscriptOverlay {
 
     fn rebuild_renderables(&mut self) {
         let tail_renderable = self.take_live_tail_renderable();
-        self.view.renderables =
-            Self::render_cells(&self.cells, self.highlight_cell, self.render_mode);
+        self.view.renderables = Self::render_cells(
+            &self.cells,
+            Rc::clone(&self.highlight_cell),
+            self.render_mode,
+        );
         if let Some(tail) = tail_renderable {
             self.view.renderables.push(tail);
         }
@@ -1137,7 +1171,7 @@ impl TranscriptOverlay {
                 /*priority*/ 4,
             ));
         }
-        if self.highlight_cell.is_some() {
+        if self.highlight_cell.get().is_some() {
             let previous_edit_keys = std::iter::once(key_hint::plain(KeyCode::Esc))
                 .chain(first_or_empty(&self.view.keymap.previous_user_prompt))
                 .collect::<Vec<_>>();
@@ -1390,6 +1424,7 @@ mod tests {
     use insta::assert_snapshot;
     use pretty_assertions::assert_eq;
     use std::collections::HashMap;
+    use std::io::Write;
     use std::path::PathBuf;
     use std::sync::Arc;
     use std::time::Duration;
@@ -1607,13 +1642,16 @@ mod tests {
         let render_elapsed = render_start.elapsed();
 
         let operations = STEPS.saturating_mul(2);
-        println!(
+        let mut stdout = std::io::stdout().lock();
+        writeln!(
+            stdout,
             "transcript_prompt_selection_perf prompts={PROMPTS} cells={cell_count} steps={operations} selection_only_ms={:.3} selection_only_avg_us={:.3} selection_plus_render_ms={:.3} selection_plus_render_avg_us={:.3}",
             selection_elapsed.as_secs_f64() * 1_000.0,
             selection_elapsed.as_secs_f64() * 1_000_000.0 / operations as f64,
             render_elapsed.as_secs_f64() * 1_000.0,
             render_elapsed.as_secs_f64() * 1_000_000.0 / operations as f64,
-        );
+        )
+        .expect("write perf output");
     }
 
     #[test]
@@ -1909,6 +1947,57 @@ mod tests {
     }
 
     #[test]
+    fn prompt_selection_updates_style_without_rebuilding_layout() {
+        let mut overlay = transcript_overlay(vec![
+            user_cell("first prompt"),
+            Arc::new(AgentMessageCell::new(
+                vec![Line::from("assistant")],
+                /*is_first_line*/ true,
+            )),
+            user_cell("second prompt"),
+        ]);
+        let area = Rect::new(
+            /*x*/ 0, /*y*/ 0, /*width*/ 80, /*height*/ 14,
+        );
+        let mut buf = Buffer::empty(area);
+
+        overlay.render(area, &mut buf);
+        assert!(overlay.view.layout.is_some());
+        let renderable_count = overlay.view.renderables.len();
+
+        overlay.set_highlight_cell(Some(0));
+        assert!(overlay.view.layout.is_some());
+        assert_eq!(overlay.view.renderables.len(), renderable_count);
+        overlay.render(area, &mut buf);
+        let first_selection = prompt_marker_reversed_states(&buf, area);
+        assert_eq!(first_selection, vec![true, false]);
+
+        overlay.set_highlight_cell(Some(2));
+        assert!(overlay.view.layout.is_some());
+        assert_eq!(overlay.view.renderables.len(), renderable_count);
+        overlay.render(area, &mut buf);
+        let second_selection = prompt_marker_reversed_states(&buf, area);
+        assert_eq!(second_selection, vec![false, true]);
+    }
+
+    fn prompt_marker_reversed_states(buf: &Buffer, area: Rect) -> Vec<bool> {
+        let mut states = Vec::new();
+        for y in area.y..area.bottom() {
+            for x in area.x..area.right() {
+                if buf[(x, y)].symbol() == "›" {
+                    states.push(
+                        buf[(x, y)]
+                            .style()
+                            .add_modifier
+                            .contains(Modifier::REVERSED),
+                    );
+                }
+            }
+        }
+        states
+    }
+
+    #[test]
     fn transcript_overlay_sync_live_tail_is_noop_for_identical_key() {
         let mut overlay = transcript_overlay(vec![Arc::new(TestCell {
             lines: vec![Line::from("alpha")],
@@ -2184,7 +2273,7 @@ mod tests {
         );
 
         assert_eq!(
-            overlay.highlight_cell,
+            overlay.highlight_cell.get(),
             Some(2),
             "highlight inside consolidated range should point to replacement cell",
         );
@@ -2211,7 +2300,7 @@ mod tests {
         );
 
         assert_eq!(
-            overlay.highlight_cell,
+            overlay.highlight_cell.get(),
             Some(4),
             "highlight after consolidated range should shift left by removed cells",
         );

--- a/codex-rs/tui/src/session_log.rs
+++ b/codex-rs/tui/src/session_log.rs
@@ -151,6 +151,19 @@ pub(crate) fn log_inbound_app_event(event: &AppEvent) {
             });
             LOGGER.write_json_line(value);
         }
+        AppEvent::TranscriptLayoutReady(result) => {
+            let value = json!({
+                "ts": now_ts(),
+                "dir": "to_tui",
+                "kind": "transcript_layout_ready",
+                "generation": result.key.generation,
+                "width": result.key.width,
+                "cell_count": result.key.cell_count,
+                "height_count": result.heights.len(),
+                "total_height": result.total_height,
+            });
+            LOGGER.write_json_line(value);
+        }
         AppEvent::StartFileSearch(query) => {
             let value = json!({
                 "ts": now_ts(),

--- a/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__large_transcript_renders_loading_until_layout_is_ready.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__large_transcript_renders_loading_until_layout_is_ready.snap
@@ -1,0 +1,13 @@
+---
+source: tui/src/pager_overlay.rs
+expression: "buffer_to_text(&buf, area)"
+---
+ Transcript ────────────────────────────────────────────────────────────────────
+Loading transcript...
+
+
+
+
+─────────────────────────────────────────────────────────── 0 / 0 · loading... ─
+ ↑/↓ scroll   ←/→ prompts   pgup/pgdn page   home/end jump
+ q quit   ctrl + o copy   ⌥ + r raw   esc/← prev

--- a/codex-rs/tui/src/transcript_layout.rs
+++ b/codex-rs/tui/src/transcript_layout.rs
@@ -1,0 +1,158 @@
+use std::fmt;
+use std::sync::Arc;
+use std::thread;
+
+use crate::app_event::AppEvent;
+use crate::app_event_sender::AppEventSender;
+use crate::history_cell::HistoryCell;
+use crate::history_cell::HistoryRenderMode;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct TranscriptLayoutKey {
+    pub(crate) generation: u64,
+    pub(crate) width: u16,
+    pub(crate) render_mode: HistoryRenderMode,
+    pub(crate) cell_count: usize,
+}
+
+pub(crate) struct TranscriptLayoutResult {
+    pub(crate) key: TranscriptLayoutKey,
+    pub(crate) heights: Vec<usize>,
+    pub(crate) total_height: usize,
+}
+
+impl fmt::Debug for TranscriptLayoutResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TranscriptLayoutResult")
+            .field("key", &self.key)
+            .field("height_count", &self.heights.len())
+            .field("total_height", &self.total_height)
+            .finish()
+    }
+}
+
+pub(crate) fn spawn_transcript_layout_worker(
+    key: TranscriptLayoutKey,
+    cells: Vec<Arc<dyn HistoryCell>>,
+    app_event_tx: AppEventSender,
+) {
+    thread::spawn(move || {
+        let heights = measure_transcript_heights(&cells, key.width, key.render_mode);
+        let total_height = heights.iter().copied().sum();
+        app_event_tx.send(AppEvent::TranscriptLayoutReady(TranscriptLayoutResult {
+            key,
+            heights,
+            total_height,
+        }));
+    });
+}
+
+fn measure_transcript_heights(
+    cells: &[Arc<dyn HistoryCell>],
+    width: u16,
+    render_mode: HistoryRenderMode,
+) -> Vec<usize> {
+    let worker_count = layout_worker_count(cells.len());
+    if worker_count <= 1 {
+        return measure_transcript_height_range(cells, width, render_mode, /*start*/ 0);
+    }
+
+    let chunk_size = cells.len().div_ceil(worker_count);
+    let mut chunks = thread::scope(|scope| {
+        let mut handles = Vec::with_capacity(worker_count);
+        for (chunk_idx, chunk) in cells.chunks(chunk_size).enumerate() {
+            let start = chunk_idx.saturating_mul(chunk_size);
+            handles.push(scope.spawn(move || {
+                (
+                    start,
+                    measure_transcript_height_range(chunk, width, render_mode, start),
+                )
+            }));
+        }
+        handles
+            .into_iter()
+            .map(|handle| handle.join().unwrap_or_else(|_| (0, Vec::new())))
+            .collect::<Vec<_>>()
+    });
+    chunks.sort_by_key(|(start, _)| *start);
+
+    let mut heights = Vec::with_capacity(cells.len());
+    for (_, chunk_heights) in chunks {
+        heights.extend(chunk_heights);
+    }
+    heights
+}
+
+fn measure_transcript_height_range(
+    cells: &[Arc<dyn HistoryCell>],
+    width: u16,
+    render_mode: HistoryRenderMode,
+    start: usize,
+) -> Vec<usize> {
+    cells
+        .iter()
+        .enumerate()
+        .map(|(offset, cell)| {
+            let idx = start.saturating_add(offset);
+            let spacing = usize::from(idx > 0 && !cell.is_stream_continuation());
+            spacing.saturating_add(cell.desired_transcript_height_for_mode(width, render_mode) as usize)
+        })
+        .collect()
+}
+
+fn layout_worker_count(cell_count: usize) -> usize {
+    if cell_count == 0 {
+        return 1;
+    }
+    let parallelism = thread::available_parallelism().map_or(/*default*/ 1, usize::from);
+    parallelism.min(/*other*/ 4).min(cell_count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::text::Line;
+
+    #[derive(Debug)]
+    struct TestCell {
+        lines: Vec<Line<'static>>,
+        stream_continuation: bool,
+    }
+
+    impl HistoryCell for TestCell {
+        fn display_lines(&self, _width: u16) -> Vec<Line<'static>> {
+            self.lines.clone()
+        }
+
+        fn raw_lines(&self) -> Vec<Line<'static>> {
+            self.lines.clone()
+        }
+
+        fn is_stream_continuation(&self) -> bool {
+            self.stream_continuation
+        }
+    }
+
+    #[test]
+    fn measures_transcript_heights_with_inter_cell_spacing() {
+        let cells: Vec<Arc<dyn HistoryCell>> = vec![
+            Arc::new(TestCell {
+                lines: vec![Line::from("first")],
+                stream_continuation: false,
+            }),
+            Arc::new(TestCell {
+                lines: vec![Line::from("second")],
+                stream_continuation: false,
+            }),
+            Arc::new(TestCell {
+                lines: vec![Line::from("continuation")],
+                stream_continuation: true,
+            }),
+        ];
+
+        let heights =
+            measure_transcript_heights(&cells, /*width*/ 80, HistoryRenderMode::Rich);
+
+        assert_eq!(heights, vec![1, 2, 1]);
+    }
+}


### PR DESCRIPTION
## Summary

Stacked on top of #23344.

## Why

After the transcript overlay UX pass, prompt selection still had two problems on long or resumed transcripts:

- it did more work than necessary on every move, because selection changes could still rescan transcript cells and rebuild renderables
- it could disagree with backtrack selection on resumed threads, because the overlay counted every visible prompt while backtrack only counts prompts from the current session after the latest `SessionInfoCell`

That combination hurts both responsiveness and correctness: repeated prompt navigation scales poorly on large transcripts, and resumed threads can highlight one prompt while backtrack targets another.

## What Changed

- cached session-scoped user-prompt cell positions inside `TranscriptOverlay`
- kept the highlighted transcript cell in shared state so selection-style changes no longer require rebuilding the renderable layout on every move
- taught `App` to reuse the overlay's session-scoped prompt count and selected-prompt lookup while the transcript overlay is active
- aligned overlay prompt indexing with backtrack's existing session-bound semantics so resumed-history prompts before the latest session header are ignored consistently
- added a local perf probe plus regression coverage for prompt navigation, selection-style updates, state round-tripping, and the resumed-session boundary case
- fixed the perf probe to use the existing ratatui terminal type after rebasing onto the updated base branch

## How to Test

1. Start Codex from this branch and open a conversation with a longer transcript.
2. Open the transcript overlay with `Ctrl+T`.
3. Press `Left` / `Right` or `Alt+Up` / `Alt+Down` repeatedly.
4. Confirm the selected prompt remains responsive even on a longer transcript.
5. Close and reopen the transcript overlay and confirm the selection state still round-trips correctly.
6. Also verify a resumed-history case: open a thread with older prompts from a previous session plus newer prompts after a session header, start backtrack from the transcript overlay, and confirm the highlight and rollback target stay aligned on only the current-session prompts.

Targeted tests:
- `cargo test -p codex-tui prompt_navigation_moves_between_user_prompts`
- `cargo test -p codex-tui transcript_prompt_selection_ignores_prompts_before_latest_session_header`
- `cargo test -p codex-tui prompt_selection_updates_style_without_rebuilding_layout`
- `cargo test -p codex-tui transcript_overlay_state_round_trips_scroll_selection_and_mode`
- `cargo test -p codex-tui transcript_prompt_selection_perf -- --ignored --nocapture`

## Documentation

No docs changes are needed for `developers.openai.com/codex`.
