### PR TITLE
[codex-rs] request user input tool prompt change

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/turn_start.rs
+++ b/codex-rs/app-server/tests/suite/v2/turn_start.rs
@@ -1175,7 +1175,7 @@ async fn turn_start_uses_thread_feature_overrides_for_request_user_input_tool_de
 
     let request = response_mock.single_request();
     let payload_text = request.body_json().to_string();
-    assert!(payload_text.contains("This tool is only available in Default or Plan mode."));
+    assert!(payload_text.contains("This tool is only available in Default or Plan mode. In Default mode, this tool is only available for artifact creation (documents, spreadsheets, presentations, pdfs) requests. Read the corresponding skills on how to invoke the tool before doing so."));
 
     Ok(())
 }

--- a/codex-rs/core/src/tools/handlers/request_user_input_spec.rs
+++ b/codex-rs/core/src/tools/handlers/request_user_input_spec.rs
@@ -116,9 +116,15 @@ pub fn normalize_request_user_input_args(
 
 pub fn request_user_input_tool_description(available_modes: &[ModeKind]) -> String {
     let allowed_modes = format_allowed_modes(available_modes);
-    format!(
+    let mut description = format!(
         "Request user input for one to three short questions and wait for the response. This tool is only available in {allowed_modes}."
-    )
+    );
+    if available_modes.contains(&ModeKind::Default) {
+        description.push_str(
+            " In Default mode, this tool is only available for artifact creation (documents, spreadsheets, presentations, pdfs) requests. Read the corresponding skills on how to invoke the tool before doing so.",
+        );
+    }
+    description
 }
 
 fn format_allowed_modes(available_modes: &[ModeKind]) -> String {

--- a/codex-rs/core/src/tools/handlers/request_user_input_spec_tests.rs
+++ b/codex-rs/core/src/tools/handlers/request_user_input_spec_tests.rs
@@ -140,6 +140,6 @@ fn request_user_input_tool_description_mentions_available_modes() {
     );
     assert_eq!(
         request_user_input_tool_description(&default_mode_enabled_available_modes()),
-        "Request user input for one to three short questions and wait for the response. This tool is only available in Default or Plan mode.".to_string()
+        "Request user input for one to three short questions and wait for the response. This tool is only available in Default or Plan mode. In Default mode, this tool is only available for artifact creation (documents, spreadsheets, presentations, pdfs) requests. Read the corresponding skills on how to invoke the tool before doing so.".to_string()
     );
 }


### PR DESCRIPTION
change the prompt such that when it's available in default mode, only use it when an artifact is requested
