### PR TITLE
[codex] Simplify regular turn client session ownership

### DIFF
--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -9,7 +9,6 @@ use crate::build_skill_injections;
 use crate::client::ModelClientSession;
 use crate::client_common::Prompt;
 use crate::client_common::ResponseEvent;
-use crate::collect_env_var_dependencies;
 use crate::collect_explicit_skill_mentions;
 use crate::compact::InitialContextInjection;
 use crate::compact::collect_user_messages;
@@ -40,7 +39,6 @@ use crate::mentions::collect_explicit_plugin_mentions;
 use crate::mentions::collect_tool_mentions_from_messages;
 use crate::parse_turn_item;
 use crate::plugins::build_plugin_injections;
-use crate::resolve_skill_dependencies_for_turn;
 use crate::session::PreviousTurnSettings;
 use crate::session::session::Session;
 use crate::session::turn_context::TurnContext;
@@ -145,7 +143,7 @@ pub(crate) async fn run_turn(
     turn_context: Arc<TurnContext>,
     turn_extension_data: Arc<codex_extension_api::ExtensionData>,
     input: Vec<UserInput>,
-    prewarmed_client_session: Option<ModelClientSession>,
+    client_session: &mut ModelClientSession,
     cancellation_token: CancellationToken,
 ) -> Option<String> {
     if input.is_empty() && !sess.input_queue.has_pending_input(&sess.active_turn).await {
@@ -154,14 +152,12 @@ pub(crate) async fn run_turn(
 
     let model_info = turn_context.model_info.clone();
     let auto_compact_limit = model_info.auto_compact_token_limit().unwrap_or(i64::MAX);
-    let mut client_session =
-        prewarmed_client_session.unwrap_or_else(|| sess.services.model_client.new_session());
     // TODO(ccunningham): Pre-turn compaction runs before context updates and the
     // new user message are recorded. Estimate pending incoming items (context
     // diffs/full reinjection + user input) and trigger compaction preemptively
     // when they would push the thread over the compaction threshold.
     let pre_sampling_compact =
-        match run_pre_sampling_compact(&sess, &turn_context, &mut client_session).await {
+        match run_pre_sampling_compact(&sess, &turn_context, client_session).await {
             Ok(pre_sampling_compact) => pre_sampling_compact,
             Err(err) => {
                 if err.to_codex_protocol_error() == CodexErrorInfo::UsageLimitExceeded
@@ -241,14 +237,6 @@ pub(crate) async fn run_turn(
             &connector_slug_counts,
         )
     });
-    let config = turn_context.config.clone();
-    if config
-        .features
-        .enabled(Feature::SkillEnvVarDependencyPrompt)
-    {
-        let env_var_dependencies = collect_env_var_dependencies(&mentioned_skills);
-        resolve_skill_dependencies_for_turn(&sess, &turn_context, &env_var_dependencies).await;
-    }
 
     maybe_prompt_and_install_mcp_dependencies(
         sess.as_ref(),
@@ -405,10 +393,6 @@ pub(crate) async fn run_turn(
     let mut can_drain_pending_input = input.is_empty();
 
     loop {
-        if run_pending_session_start_hooks(&sess, &turn_context).await {
-            break;
-        }
-
         // Note that pending_input would be something like a message the user
         // submitted through the UI while the model was running. Though the UI
         // may support this, the model might not.
@@ -482,7 +466,7 @@ pub(crate) async fn run_turn(
             Arc::clone(&turn_context),
             Arc::clone(&turn_extension_data),
             Arc::clone(&turn_diff_tracker),
-            &mut client_session,
+            client_session,
             turn_metadata_header.as_deref(),
             sampling_request_input,
             &explicitly_enabled_connectors,
@@ -522,7 +506,7 @@ pub(crate) async fn run_turn(
                     let reset_client_session = match run_auto_compact(
                         &sess,
                         &turn_context,
-                        &mut client_session,
+                        client_session,
                         InitialContextInjection::BeforeLastUserMessage,
                         CompactionReason::ContextLimit,
                         CompactionPhase::MidTurn,

--- a/codex-rs/core/src/tasks/regular.rs
+++ b/codex-rs/core/src/tasks/regular.rs
@@ -68,14 +68,15 @@ impl SessionTask for RegularTask {
             }
         };
         let mut next_input = input;
-        let mut prewarmed_client_session = prewarmed_client_session;
+        let mut client_session =
+            prewarmed_client_session.unwrap_or_else(|| sess.services.model_client.new_session());
         loop {
             let last_agent_message = run_turn(
                 Arc::clone(&sess),
                 Arc::clone(&ctx),
                 Arc::clone(&turn_extension_data),
                 next_input,
-                prewarmed_client_session.take(),
+                &mut client_session,
                 cancellation_token.child_token(),
             )
             .instrument(run_turn_span.clone())


### PR DESCRIPTION
## Why

`RegularTask` owns the retry loop around `run_turn`, so it is the natural place to own the turn-scoped `ModelClientSession`. Keeping the session at that level makes reuse across the regular turn loop explicit instead of having each `run_turn` call materialize or consume an optional prewarmed session.

## What changed

- Create the `ModelClientSession` in `codex-rs/core/src/tasks/regular.rs`, using the startup prewarm session when available and otherwise creating a new model client session.
- Pass `&mut ModelClientSession` into `run_turn` so pre-sampling compaction, sampling requests, and mid-turn compaction all reuse the same session object.
- Remove now-redundant setup inside `run_turn`, including the skill env dependency resolution block and the repeated session-start hook check inside the sampling loop.

## Validation

- `just fmt`
- `cargo check -p codex-core` passed, with warnings from now-unused skill dependency plumbing.
- `cargo test -p codex-core` did not pass. The lib unit test target passed (`1836 passed; 0 failed; 4 ignored`), but `tests/all.rs` failed with 40 integration failures across `cli_stream`, `code_mode`, `hooks_mcp`, `rmcp_client`, `search_tool`, `sqlite_state`, `tools`, `truncation`, and `unified_exec`.
- Targeted reruns also failed:
  - `cargo test -p codex-core suite::search_tool::tool_search_indexes_only_enabled_non_app_mcp_tools --test all -- --nocapture`
  - `cargo test -p codex-core suite::hooks_mcp::pre_tool_use_blocks_mcp_tool_before_execution --test all -- --nocapture`

Both targeted failures reported that the expected wiremock requests were not sent.
