### PR TITLE
Stabilize rollback event waits in flaky core tests

### DIFF
--- a/codex-rs/core/tests/suite/compact_resume_fork.rs
+++ b/codex-rs/core/tests/suite/compact_resume_fork.rs
@@ -41,6 +41,7 @@ use serde_json::Value;
 use serde_json::json;
 use std::sync::Arc;
 use tempfile::TempDir;
+use tokio::time::Duration;
 use wiremock::MockServer;
 
 const AFTER_SECOND_RESUME: &str = "AFTER_SECOND_RESUME";
@@ -456,8 +457,12 @@ async fn snapshot_rollback_past_compaction_replays_append_only_history() -> Resu
     base.submit(Op::ThreadRollback { num_turns: 1 })
         .await
         .expect("submit thread rollback");
-    let rollback_event =
-        wait_for_event(&base, |ev| matches!(ev, EventMsg::ThreadRolledBack(_))).await;
+    let rollback_event = core_test_support::wait_for_event_with_timeout(
+        &base,
+        |ev| matches!(ev, EventMsg::ThreadRolledBack(_)),
+        Duration::from_secs(20),
+    )
+    .await;
     let EventMsg::ThreadRolledBack(rollback_event) = rollback_event else {
         panic!("expected thread rolled back event");
     };
@@ -570,9 +575,11 @@ async fn snapshot_rollback_followup_turn_trims_context_updates() -> Result<()> {
     conversation
         .submit(Op::ThreadRollback { num_turns: 1 })
         .await?;
-    let rollback_event = wait_for_event(&conversation, |ev| {
-        matches!(ev, EventMsg::ThreadRolledBack(_))
-    })
+    let rollback_event = core_test_support::wait_for_event_with_timeout(
+        &conversation,
+        |ev| matches!(ev, EventMsg::ThreadRolledBack(_)),
+        Duration::from_secs(20),
+    )
     .await;
     let EventMsg::ThreadRolledBack(rollback_event) = rollback_event else {
         panic!("expected thread rolled back event");

--- a/codex-rs/core/tests/suite/model_switching.rs
+++ b/codex-rs/core/tests/suite/model_switching.rs
@@ -37,6 +37,7 @@ use core_test_support::wait_for_event;
 use pretty_assertions::assert_eq;
 use std::path::Path;
 use std::path::PathBuf;
+use tokio::time::Duration;
 use wiremock::MockServer;
 
 fn read_only_user_turn(test: &TestCodex, items: Vec<UserInput>, model: String) -> Op {
@@ -785,9 +786,11 @@ async fn thread_rollback_after_generated_image_drops_entire_image_turn_history()
     test.codex
         .submit(Op::ThreadRollback { num_turns: 1 })
         .await?;
-    wait_for_event(&test.codex, |ev| {
-        matches!(ev, EventMsg::ThreadRolledBack(_))
-    })
+    core_test_support::wait_for_event_with_timeout(
+        &test.codex,
+        |ev| matches!(ev, EventMsg::ThreadRolledBack(_)),
+        Duration::from_secs(20),
+    )
     .await;
 
     test.codex


### PR DESCRIPTION
## Why

Recent `rust-ci-full` failure analysis ranked these rollback-event waits among the recurring remote Linux test failures. In the recovered devbox repro lane, the focused loop failed before the patch while waiting for `ThreadRolledBack`.

## What changed

- extend the three rollback-specific `ThreadRolledBack` waits to `20s`
- keep the change test-only and scoped to the compact/model-switching flake family

## Validation

- reproduced on `dev-4` before patch with:
  `cargo nextest run -p codex-core --test all suite::compact_resume_fork::snapshot_rollback_past_compaction_replays_append_only_history suite::compact_resume_fork::snapshot_rollback_followup_turn_trims_context_updates suite::model_switching::thread_rollback_after_generated_image_drops_entire_image_turn_history --no-fail-fast --cargo-profile ci-test`
- after patch, 40/40 focused iterations passed on `dev-4`
- adversarial pre-PR review found no concrete issues in the one-commit diff