### PR TITLE
Keep network denial test on local exec

### DIFF
--- a/codex-rs/core/tests/suite/unified_exec.rs
+++ b/codex-rs/core/tests/suite/unified_exec.rs
@@ -917,7 +917,7 @@ allow_local_binding = true
                 .set_permission_profile(permission_profile_for_config)
                 .expect("set permission profile");
         });
-    let test = builder.build_with_remote_env(server).await?;
+    let test = builder.build(server).await?;
     assert!(
         test.config.permissions.network.is_some(),
         "expected managed network proxy config to be present"


### PR DESCRIPTION
## Why

`rust-ci-full` was failing `suite::unified_exec::unified_exec_network_denial_emits_failed_background_end_event` in the Docker-backed remote lane before the test reached its intended network-denial assertion. The observed failure was remote exec startup rejecting the request with `No such file or directory (os error 2)`, so the test was waiting for the wrong event.

## What changed

- keep this shared network-denial fixture on the normal local test harness even when full-ci remote environment variables are set globally
- leave the rest of the unified exec remote coverage unchanged

## Validation

- reproduced the CI-shaped failure on a devbox with the Docker-backed remote env and Bazel filter for `unified_exec_network_denial_emits_failed_background_end_event`
- synced this patch to the same devbox and reran the same focused Bazel target/filter; it passed with `RC=0`
- adversarial pre-PR review found no concrete issues