### PR TITLE
Add exec-server websocket reconnect foundation

### DIFF
--- a/codex-rs/exec-server/README.md
+++ b/codex-rs/exec-server/README.md
@@ -27,7 +27,7 @@ Environment
        |    |- current ExecServerConnection?
        |    |- one in-flight reconnect attempt
        |    |- terminal reconnect error?
-       |    `- durable process_sessions: HashMap<ProcessId, Arc<ProcessSession>>
+       |    `- tracked process_sessions: HashMap<ProcessId, Weak<ProcessSession>>
        |- RemoteProcess -> RemoteExecProcess -> ProcessSessionHandle
        |- RemoteFileSystem
        `- HttpClient for RemoteExecServerClient
@@ -65,15 +65,17 @@ The main roles are:
   HTTP capability so all remote APIs share one reconnecting session.
 - `RemoteExecServerSession`: durable logical-session state behind the client.
   It remembers the resumable session id, current live connection, one shared
-  reconnect attempt, tracked process sessions, and any terminal resume error.
+  reconnect attempt, weak references to process sessions that may need rebinding,
+  and any terminal resume error.
 - `ExecServerConnection`: one live JSON-RPC transport binding. It owns
   connection-local routing for notifications and streamed HTTP response bodies.
 - `Inner`: private per-connection machinery behind `ExecServerConnection`.
   It owns the `RpcClient`, reader task, disconnect latch, connection-local
   process notification routes, connection-local HTTP body stream routes, and
   initialized session id for that live binding.
-- `ProcessSession`: durable per-process client state. It keeps the local event
-  log, wake cursor, and failure state that must survive connection replacement.
+- `ProcessSession`: durable per-process client state owned by the live process
+  handle. It keeps the local event log, wake cursor, and failure state that must
+  survive connection replacement while that handle still exists.
 - `ProcessSessionHandle`: process-facing handle used by `RemoteExecProcess`.
   It routes reads, writes, terminate, and unregister through either a focused
   direct connection test path or the logical reconnecting client path.
@@ -89,6 +91,9 @@ Reconnect invariants:
   reconnect loop per API surface.
 - Reconnect resumes the same logical session id and rebinds tracked
   `ProcessSession` routes onto the replacement `ExecServerConnection`.
+- When a reconnecting process session loses its transport, it emits a local
+  `ResyncRequired` event and wake so callers blocked on pushed events or wake
+  notifications know to recover through `process/read(afterSeq)`.
 - `process/read` may retry once after a transport-close race because its
   `afterSeq` cursor makes the replay read-only and recoverable.
 - `process/start`, `process/write`, `process/terminate`, filesystem RPCs, and

--- a/codex-rs/exec-server/README.md
+++ b/codex-rs/exec-server/README.md
@@ -14,6 +14,60 @@ This crate owns the transport, protocol, and filesystem/process handlers. The
 top-level `codex` binary owns hidden helper dispatch for sandboxed
 filesystem operations and `codex-linux-sandbox`.
 
+## Client And Session Ownership
+
+Remote environments expose one logical exec-server client to the rest of Codex.
+That client is not the same thing as one websocket connection.
+
+```text
+Environment
+  `- RemoteExecServerClient
+       |- RemoteExecServerSession
+       |    |- logical session id
+       |    |- current ExecServerConnection
+       |    |- one in-flight reconnect attempt
+       |    |- durable ProcessSession map
+       |    `- terminal resume error, when reconnect can no longer succeed
+       |- RemoteProcess -> ProcessSessionHandle -> ProcessSession
+       |- RemoteFileSystem
+       `- HttpClient
+```
+
+The main roles are:
+
+- `RemoteExecServerClient`: environment-owned logical client. `Environment`
+  clones this into the remote process backend, remote filesystem, and remote
+  HTTP capability so all remote APIs share one reconnecting session.
+- `RemoteExecServerSession`: durable logical-session state behind the client.
+  It remembers the resumable session id, current live connection, one shared
+  reconnect attempt, tracked process sessions, and any terminal resume error.
+- `ExecServerConnection`: one live JSON-RPC transport binding. It owns
+  connection-local routing for notifications and streamed HTTP response bodies.
+- `ProcessSession`: durable per-process client state. It keeps the local event
+  log, wake cursor, and failure state that must survive connection replacement.
+- `ProcessSessionHandle`: process-facing handle used by `RemoteExecProcess`.
+  It routes reads, writes, terminate, and unregister through either a focused
+  direct connection test path or the logical reconnecting client path.
+- `RemoteProcess`, `RemoteFileSystem`, and `HttpClient`: thin capability
+  adapters. They should not own reconnect state themselves.
+
+Reconnect invariants:
+
+- There is one shared reconnect attempt per `RemoteExecServerClient`, not one
+  reconnect loop per API surface.
+- Reconnect resumes the same logical session id and rebinds tracked
+  `ProcessSession` routes onto the replacement `ExecServerConnection`.
+- `process/read` may retry once after a transport-close race because its
+  `afterSeq` cursor makes the replay read-only and recoverable.
+- `process/start`, `process/write`, `process/terminate`, filesystem RPCs, and
+  `http/request` are not replayed after an ambiguous mid-request disconnect.
+  They reconnect before later calls, but an in-flight call that may already
+  have reached the server returns an error instead of risking duplicate side
+  effects.
+- Streamed HTTP bodies are connection-local. A reconnect can start a later
+  HTTP request, but it cannot resume body-delta delivery for an already-open
+  stream.
+
 ## Transport
 
 The server speaks the shared `codex-app-server-protocol` message envelope on

--- a/codex-rs/exec-server/README.md
+++ b/codex-rs/exec-server/README.md
@@ -7,7 +7,7 @@ JSON-RPC server for spawning and controlling subprocesses through
 It provides:
 
 - a CLI entrypoint: `codex exec-server`
-- a Rust client: `ExecServerClient`
+- a Rust connection client: `ExecServerConnection`
 - a small protocol module with shared request/response types
 
 This crate owns the transport, protocol, and filesystem/process handlers. The
@@ -21,16 +21,41 @@ That client is not the same thing as one websocket connection.
 
 ```text
 Environment
-  `- RemoteExecServerClient
+  `- one RemoteExecServerClient
        |- RemoteExecServerSession
-       |    |- logical session id
-       |    |- current ExecServerConnection
+       |    |- logical_session_id
+       |    |- current ExecServerConnection?
        |    |- one in-flight reconnect attempt
-       |    |- durable ProcessSession map
-       |    `- terminal resume error, when reconnect can no longer succeed
-       |- RemoteProcess -> ProcessSessionHandle -> ProcessSession
+       |    |- terminal reconnect error?
+       |    `- durable process_sessions: HashMap<ProcessId, Arc<ProcessSession>>
+       |- RemoteProcess -> RemoteExecProcess -> ProcessSessionHandle
        |- RemoteFileSystem
-       `- HttpClient
+       `- HttpClient for RemoteExecServerClient
+
+ExecServerConnection
+  `- Inner
+       |- RpcClient
+       |- reader task
+       |- disconnect latch
+       |- connection-local process_session_routes
+       |- connection-local HTTP body stream routes
+       `- initialized session_id for this live binding
+
+ProcessSessionHandle
+  |- process_id
+  |- Arc<ProcessSession>
+  `- ProcessSessionControl
+
+ProcessSession
+  |- wake channel
+  |- event log
+  |- ordered event buffer
+  |- failure state
+  `- disconnect policy
+
+ProcessSessionControl
+  |- Connection(ExecServerConnection) for direct/test one-shot sessions
+  `- RemoteClient(RemoteExecServerClient) for reconnecting remote environments
 ```
 
 The main roles are:
@@ -43,11 +68,18 @@ The main roles are:
   reconnect attempt, tracked process sessions, and any terminal resume error.
 - `ExecServerConnection`: one live JSON-RPC transport binding. It owns
   connection-local routing for notifications and streamed HTTP response bodies.
+- `Inner`: private per-connection machinery behind `ExecServerConnection`.
+  It owns the `RpcClient`, reader task, disconnect latch, connection-local
+  process notification routes, connection-local HTTP body stream routes, and
+  initialized session id for that live binding.
 - `ProcessSession`: durable per-process client state. It keeps the local event
   log, wake cursor, and failure state that must survive connection replacement.
 - `ProcessSessionHandle`: process-facing handle used by `RemoteExecProcess`.
   It routes reads, writes, terminate, and unregister through either a focused
   direct connection test path or the logical reconnecting client path.
+- `ProcessSessionControl`: small command-path enum for a
+  `ProcessSessionHandle`. It is not an owner; it only chooses direct
+  `ExecServerConnection` versus reconnecting `RemoteExecServerClient`.
 - `RemoteProcess`, `RemoteFileSystem`, and `HttpClient`: thin capability
   adapters. They should not own reconnect state themselves.
 
@@ -67,6 +99,14 @@ Reconnect invariants:
 - Streamed HTTP bodies are connection-local. A reconnect can start a later
   HTTP request, but it cannot resume body-delta delivery for an already-open
   stream.
+- Rendezvous uses the same logical split. The relay websocket and relay
+  `stream_id` are transport beneath the exec-server logical session for the
+  first reconnect slice. If a rendezvous websocket dies, the harness/client
+  may establish a fresh relay stream, then re-run exec-server initialize with
+  the prior `session_id` as `resume_session_id`. Existing process state recovers
+  through `process/read(after_seq)`, not relay-frame replay. Full same-stream
+  relay resume/replay remains a later protocol slice that requires endpoint-held
+  seq/ack/replay state.
 
 ## Transport
 

--- a/codex-rs/exec-server/src/client.rs
+++ b/codex-rs/exec-server/src/client.rs
@@ -12,7 +12,7 @@ use futures::FutureExt;
 use futures::future::BoxFuture;
 use serde_json::Value;
 use tokio::sync::Mutex;
-use tokio::sync::OnceCell;
+use tokio::sync::Notify;
 use tokio::sync::mpsc;
 use tokio::sync::watch;
 
@@ -25,6 +25,7 @@ use crate::client_api::ExecServerTransportParams;
 use crate::client_api::HttpClient;
 use crate::client_api::RemoteExecServerConnectArgs;
 use crate::client_api::StdioExecServerConnectArgs;
+use crate::client_transport::ENVIRONMENT_CLIENT_NAME;
 use crate::connection::JsonRpcConnection;
 use crate::process::ExecProcessEvent;
 use crate::process::ExecProcessEventLog;
@@ -128,11 +129,12 @@ impl RemoteExecServerConnectArgs {
     }
 }
 
-pub(crate) struct SessionState {
+pub(crate) struct ProcessSession {
     wake_tx: watch::Sender<u64>,
     events: ExecProcessEventLog,
     ordered_events: StdMutex<OrderedSessionEvents>,
     failure: Mutex<Option<String>>,
+    disconnect_behavior: ProcessSessionDisconnectBehavior,
 }
 
 #[derive(Default)]
@@ -145,30 +147,46 @@ struct OrderedSessionEvents {
 }
 
 #[derive(Clone)]
-pub(crate) struct Session {
-    client: ExecServerClient,
+pub(crate) struct ProcessSessionHandle {
+    control: ProcessSessionControl,
     process_id: ProcessId,
-    state: Arc<SessionState>,
+    session: Arc<ProcessSession>,
+}
+
+#[derive(Clone)]
+enum ProcessSessionControl {
+    #[cfg(test)]
+    // Direct connections are used by one-shot callers and focused client tests.
+    Connection(ExecServerConnection),
+    // Remote environments use the logical client so process sessions survive
+    // connection replacement across reconnect.
+    RemoteClient(RemoteExecServerClient),
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ProcessSessionDisconnectBehavior {
+    Fail,
+    Preserve,
 }
 
 struct Inner {
-    client: RpcClient,
+    rpc_client: RpcClient,
     // The remote transport delivers one shared notification stream for every
-    // process on the connection. Keep a local process_id -> session registry so
-    // we can turn those connection-global notifications into process wakeups
+    // process on the connection. Keep a local process_id -> session route map
+    // so we can turn those connection-global notifications into process wakeups
     // without making notifications the source of truth for output delivery.
-    sessions: ArcSwap<HashMap<ProcessId, Arc<SessionState>>>,
+    process_session_routes: ArcSwap<HashMap<ProcessId, Arc<ProcessSession>>>,
     // ArcSwap makes reads cheap on the hot notification path, but writes still
     // need serialization so concurrent register/remove operations do not
     // overwrite each other's copy-on-write updates.
-    sessions_write_lock: Mutex<()>,
+    process_session_routes_write_lock: Mutex<()>,
     // Once the transport closes, every executor operation should fail quickly
-    // with the same canonical message. This client never reconnects, so the
-    // latch only moves from unset to set once.
+    // with the same canonical message. This connection never reconnects, so
+    // the latch only moves from unset to set once.
     disconnected: OnceLock<String>,
     // Streaming HTTP responses are keyed by a client-generated request id
     // because they share the same connection-global notification channel as
-    // process output. Keep the routing table local to the client so higher
+    // process output. Keep the routing table local to the connection so higher
     // layers can consume body chunks like a normal byte stream.
     http_body_streams: ArcSwap<HashMap<String, mpsc::Sender<HttpRequestBodyDeltaNotification>>>,
     http_body_stream_failures: ArcSwap<HashMap<String, String>>,
@@ -185,43 +203,273 @@ impl Drop for Inner {
 }
 
 #[derive(Clone)]
-pub struct ExecServerClient {
+pub struct ExecServerConnection {
     inner: Arc<Inner>,
 }
 
 #[derive(Clone)]
-pub(crate) struct LazyRemoteExecServerClient {
+pub(crate) struct RemoteExecServerClient {
     transport_params: ExecServerTransportParams,
-    client: Arc<OnceCell<ExecServerClient>>,
+    session: Arc<StdMutex<RemoteExecServerSession>>,
 }
 
-impl LazyRemoteExecServerClient {
+// Shared state for one logical remote exec-server client. The logical client
+// owns resumable session identity and durable process session state; individual
+// ExecServerConnection values only bind that state to one live transport.
+struct RemoteExecServerSession {
+    connection: Option<ExecServerConnection>,
+    connection_attempt: Option<Arc<Notify>>,
+    logical_session_id: Option<String>,
+    terminal_error: Option<TerminalReconnectError>,
+    process_sessions: HashMap<ProcessId, Arc<ProcessSession>>,
+}
+
+enum RemoteExecServerConnectionAction {
+    Ready(ExecServerConnection),
+    Wait(BoxFuture<'static, ()>),
+    Connect {
+        connection_attempt: Arc<Notify>,
+        resume_session_id: Option<String>,
+        process_sessions: Vec<(ProcessId, Arc<ProcessSession>)>,
+    },
+}
+
+#[derive(Clone)]
+struct TerminalReconnectError {
+    code: i64,
+    message: String,
+}
+
+impl RemoteExecServerClient {
     pub(crate) fn new(transport_params: ExecServerTransportParams) -> Self {
         Self {
             transport_params,
-            client: Arc::new(OnceCell::new()),
+            session: Arc::new(StdMutex::new(RemoteExecServerSession {
+                connection: None,
+                connection_attempt: None,
+                logical_session_id: None,
+                terminal_error: None,
+                process_sessions: HashMap::new(),
+            })),
         }
     }
 
-    pub(crate) async fn get(&self) -> Result<ExecServerClient, ExecServerError> {
-        self.client
-            // TODO: Add reconnect/disconnect handling here instead of reusing
-            // the first successfully initialized connection forever.
-            .get_or_try_init(|| {
-                let transport_params = self.transport_params.clone();
-                async move { ExecServerClient::connect_for_transport(transport_params).await }
-            })
+    pub(crate) async fn connection(&self) -> Result<ExecServerConnection, ExecServerError> {
+        loop {
+            match self.next_connection_action()? {
+                RemoteExecServerConnectionAction::Ready(connection) => return Ok(connection),
+                RemoteExecServerConnectionAction::Wait(connection_attempt) => {
+                    connection_attempt.await;
+                }
+                RemoteExecServerConnectionAction::Connect {
+                    connection_attempt,
+                    resume_session_id,
+                    process_sessions,
+                } => {
+                    let connection = self
+                        .connect_and_rebind(resume_session_id.clone(), process_sessions)
+                        .await;
+                    return self.finish_connection_attempt(
+                        connection_attempt,
+                        resume_session_id,
+                        connection,
+                    );
+                }
+            }
+        }
+    }
+
+    pub(crate) async fn register_process_session(
+        &self,
+        process_id: &ProcessId,
+    ) -> Result<ProcessSessionHandle, ExecServerError> {
+        let process_session = Arc::new(ProcessSession::new(
+            ProcessSessionDisconnectBehavior::Preserve,
+        ));
+        {
+            let mut session = self.lock_session();
+            if session.process_sessions.contains_key(process_id) {
+                return Err(ExecServerError::Protocol(format!(
+                    "session already registered for process {process_id}"
+                )));
+            }
+            session
+                .process_sessions
+                .insert(process_id.clone(), Arc::clone(&process_session));
+        }
+
+        let connection = self.connection().await?;
+        if let Err(err) = connection
+            .register_process_session_route(process_id, Arc::clone(&process_session))
             .await
-            .cloned()
+        {
+            self.unregister_process_session(process_id).await;
+            return Err(err);
+        }
+
+        Ok(ProcessSessionHandle {
+            control: ProcessSessionControl::RemoteClient(self.clone()),
+            process_id: process_id.clone(),
+            session: process_session,
+        })
+    }
+
+    async fn read(&self, params: ReadParams) -> Result<ReadResponse, ExecServerError> {
+        let connection = self.connection().await?;
+        match connection.read(params.clone()).await {
+            Ok(response) => Ok(response),
+            Err(err) if is_transport_closed_error(&err) && self.supports_reconnect() => {
+                self.connection().await?.read(params).await
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    async fn write(
+        &self,
+        process_id: &ProcessId,
+        chunk: Vec<u8>,
+    ) -> Result<WriteResponse, ExecServerError> {
+        self.connection().await?.write(process_id, chunk).await
+    }
+
+    async fn terminate(
+        &self,
+        process_id: &ProcessId,
+    ) -> Result<TerminateResponse, ExecServerError> {
+        self.connection().await?.terminate(process_id).await
+    }
+
+    async fn unregister_process_session(&self, process_id: &ProcessId) {
+        let connection = {
+            let mut session = self.lock_session();
+            session.process_sessions.remove(process_id);
+            session.connection.clone()
+        };
+        if let Some(connection) = connection {
+            connection.unregister_process_session(process_id).await;
+        }
+    }
+
+    fn next_connection_action(&self) -> Result<RemoteExecServerConnectionAction, ExecServerError> {
+        let mut session = self.lock_session();
+        if let Some(error) = &session.terminal_error {
+            return Err(error.to_exec_server_error());
+        }
+
+        if let Some(connection) = &session.connection {
+            if let Some(error) = connection.disconnected_error() {
+                if !self.supports_reconnect() {
+                    return Err(error);
+                }
+            } else {
+                return Ok(RemoteExecServerConnectionAction::Ready(connection.clone()));
+            }
+        }
+
+        if let Some(connection_attempt) = &session.connection_attempt {
+            let connection_attempt = Arc::clone(connection_attempt).notified_owned();
+            return Ok(RemoteExecServerConnectionAction::Wait(
+                connection_attempt.boxed(),
+            ));
+        }
+
+        let connection_attempt = Arc::new(Notify::new());
+        let resume_session_id = session.logical_session_id.clone();
+        let process_sessions = session
+            .process_sessions
+            .iter()
+            .map(|(process_id, process_session)| (process_id.clone(), Arc::clone(process_session)))
+            .collect();
+        session.connection_attempt = Some(Arc::clone(&connection_attempt));
+        Ok(RemoteExecServerConnectionAction::Connect {
+            connection_attempt,
+            resume_session_id,
+            process_sessions,
+        })
+    }
+
+    async fn connect_and_rebind(
+        &self,
+        resume_session_id: Option<String>,
+        process_sessions: Vec<(ProcessId, Arc<ProcessSession>)>,
+    ) -> Result<ExecServerConnection, ExecServerError> {
+        let connection = self.connect(resume_session_id).await?;
+        for (process_id, process_session) in process_sessions {
+            connection
+                .register_process_session_route(&process_id, process_session)
+                .await?;
+        }
+        Ok(connection)
+    }
+
+    fn finish_connection_attempt(
+        &self,
+        connection_attempt: Arc<Notify>,
+        resume_session_id: Option<String>,
+        connection: Result<ExecServerConnection, ExecServerError>,
+    ) -> Result<ExecServerConnection, ExecServerError> {
+        let mut session = self.lock_session();
+        if let Err(err) = &connection {
+            if resume_session_id.is_some()
+                && let Some(terminal_error) = TerminalReconnectError::from_error(err)
+            {
+                session.terminal_error = Some(terminal_error);
+            }
+        } else if let Ok(connection) = &connection {
+            session.logical_session_id = connection.session_id();
+            session.connection = Some(connection.clone());
+        }
+        session.connection_attempt = None;
+        connection_attempt.notify_waiters();
+        connection
+    }
+
+    fn lock_session(&self) -> std::sync::MutexGuard<'_, RemoteExecServerSession> {
+        self.session
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    async fn connect(
+        &self,
+        resume_session_id: Option<String>,
+    ) -> Result<ExecServerConnection, ExecServerError> {
+        match &self.transport_params {
+            ExecServerTransportParams::WebSocketUrl {
+                websocket_url,
+                connect_timeout,
+                initialize_timeout,
+            } => {
+                ExecServerConnection::connect_websocket(RemoteExecServerConnectArgs {
+                    websocket_url: websocket_url.clone(),
+                    client_name: ENVIRONMENT_CLIENT_NAME.to_string(),
+                    connect_timeout: *connect_timeout,
+                    initialize_timeout: *initialize_timeout,
+                    resume_session_id,
+                })
+                .await
+            }
+            ExecServerTransportParams::StdioCommand { .. } => {
+                ExecServerConnection::connect_for_transport(self.transport_params.clone()).await
+            }
+        }
+    }
+
+    fn supports_reconnect(&self) -> bool {
+        matches!(
+            &self.transport_params,
+            ExecServerTransportParams::WebSocketUrl { .. }
+        )
     }
 }
 
-impl HttpClient for LazyRemoteExecServerClient {
+impl HttpClient for RemoteExecServerClient {
     fn http_request(
         &self,
         params: crate::HttpRequestParams,
     ) -> BoxFuture<'_, Result<crate::HttpRequestResponse, ExecServerError>> {
-        async move { self.get().await?.http_request(params).await }.boxed()
+        async move { self.connection().await?.http_request(params).await }.boxed()
     }
 
     fn http_request_stream(
@@ -231,7 +479,7 @@ impl HttpClient for LazyRemoteExecServerClient {
         '_,
         Result<(crate::HttpRequestResponse, crate::HttpResponseBodyStream), ExecServerError>,
     > {
-        async move { self.get().await?.http_request_stream(params).await }.boxed()
+        async move { self.connection().await?.http_request_stream(params).await }.boxed()
     }
 }
 
@@ -275,7 +523,7 @@ pub enum ExecServerError {
     ExecutorRegistryRequest(#[from] reqwest::Error),
 }
 
-impl ExecServerClient {
+impl ExecServerConnection {
     pub async fn initialize(
         &self,
         options: ExecServerClientConnectOptions,
@@ -289,7 +537,7 @@ impl ExecServerClient {
         timeout(initialize_timeout, async {
             let response: InitializeResponse = self
                 .inner
-                .client
+                .rpc_client
                 .call(
                     INITIALIZE_METHOD,
                     &InitializeParams {
@@ -397,23 +645,33 @@ impl ExecServerClient {
         self.call(FS_COPY_METHOD, &params).await
     }
 
-    pub(crate) async fn register_session(
+    #[cfg(test)]
+    pub(crate) async fn register_process_session(
         &self,
         process_id: &ProcessId,
-    ) -> Result<Session, ExecServerError> {
-        let state = Arc::new(SessionState::new());
-        self.inner
-            .insert_session(process_id, Arc::clone(&state))
+    ) -> Result<ProcessSessionHandle, ExecServerError> {
+        let session = Arc::new(ProcessSession::new(ProcessSessionDisconnectBehavior::Fail));
+        self.register_process_session_route(process_id, Arc::clone(&session))
             .await?;
-        Ok(Session {
-            client: self.clone(),
+        Ok(ProcessSessionHandle {
+            control: ProcessSessionControl::Connection(self.clone()),
             process_id: process_id.clone(),
-            state,
+            session,
         })
     }
 
-    pub(crate) async fn unregister_session(&self, process_id: &ProcessId) {
-        self.inner.remove_session(process_id).await;
+    async fn register_process_session_route(
+        &self,
+        process_id: &ProcessId,
+        session: Arc<ProcessSession>,
+    ) -> Result<(), ExecServerError> {
+        self.inner
+            .insert_process_session_route(process_id, session)
+            .await
+    }
+
+    pub(crate) async fn unregister_process_session(&self, process_id: &ProcessId) {
+        self.inner.remove_process_session_route(process_id).await;
     }
 
     pub fn session_id(&self) -> Option<String> {
@@ -422,6 +680,10 @@ impl ExecServerClient {
             .read()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .clone()
+    }
+
+    fn disconnected_error(&self) -> Option<ExecServerError> {
+        self.inner.disconnected_error()
     }
 
     pub(crate) async fn connect(
@@ -462,9 +724,9 @@ impl ExecServerClient {
             });
 
             Inner {
-                client: rpc_client,
-                sessions: ArcSwap::from_pointee(HashMap::new()),
-                sessions_write_lock: Mutex::new(()),
+                rpc_client,
+                process_session_routes: ArcSwap::from_pointee(HashMap::new()),
+                process_session_routes_write_lock: Mutex::new(()),
                 disconnected: OnceLock::new(),
                 http_body_streams: ArcSwap::from_pointee(HashMap::new()),
                 http_body_stream_failures: ArcSwap::from_pointee(HashMap::new()),
@@ -475,14 +737,14 @@ impl ExecServerClient {
             }
         });
 
-        let client = Self { inner };
-        client.initialize(options).await?;
-        Ok(client)
+        let connection = Self { inner };
+        connection.initialize(options).await?;
+        Ok(connection)
     }
 
     async fn notify_initialized(&self) -> Result<(), ExecServerError> {
         self.inner
-            .client
+            .rpc_client
             .notify(INITIALIZED_METHOD, &serde_json::json!({}))
             .await
             .map_err(ExecServerError::Json)
@@ -500,13 +762,13 @@ impl ExecServerClient {
             return Err(error);
         }
 
-        match self.inner.client.call(method, params).await {
+        match self.inner.rpc_client.call(method, params).await {
             Ok(response) => Ok(response),
             Err(error) => {
                 let error = ExecServerError::from(error);
                 if is_transport_closed_error(&error) {
                     // A call can race with disconnect after the preflight
-                    // check. Only the reader task drains sessions so queued
+                    // check. Only the reader task drains routes so queued
                     // process notifications stay ordered before disconnect.
                     let message = disconnected_message(/*reason*/ None);
                     let message = record_disconnected(&self.inner, message);
@@ -532,8 +794,8 @@ impl From<RpcCallError> for ExecServerError {
     }
 }
 
-impl SessionState {
-    fn new() -> Self {
+impl ProcessSession {
+    fn new(disconnect_behavior: ProcessSessionDisconnectBehavior) -> Self {
         let (wake_tx, _wake_rx) = watch::channel(0);
         Self {
             wake_tx,
@@ -543,6 +805,7 @@ impl SessionState {
             ),
             ordered_events: StdMutex::new(OrderedSessionEvents::default()),
             failure: Mutex::new(None),
+            disconnect_behavior,
         }
     }
 
@@ -638,17 +901,17 @@ impl SessionState {
     }
 }
 
-impl Session {
+impl ProcessSessionHandle {
     pub(crate) fn process_id(&self) -> &ProcessId {
         &self.process_id
     }
 
     pub(crate) fn subscribe_wake(&self) -> watch::Receiver<u64> {
-        self.state.subscribe()
+        self.session.subscribe()
     }
 
     pub(crate) fn subscribe_events(&self) -> ExecProcessEventReceiver {
-        self.state.subscribe_events()
+        self.session.subscribe_events()
     }
 
     pub(crate) async fn read(
@@ -657,41 +920,104 @@ impl Session {
         max_bytes: Option<usize>,
         wait_ms: Option<u64>,
     ) -> Result<ReadResponse, ExecServerError> {
-        if let Some(response) = self.state.failed_response().await {
+        if let Some(response) = self.session.failed_response().await {
             return Ok(response);
         }
 
-        match self
-            .client
-            .read(ReadParams {
-                process_id: self.process_id.clone(),
-                after_seq,
-                max_bytes,
-                wait_ms,
-            })
-            .await
-        {
+        let params = ReadParams {
+            process_id: self.process_id.clone(),
+            after_seq,
+            max_bytes,
+            wait_ms,
+        };
+        match self.control.read(params).await {
             Ok(response) => Ok(response),
-            Err(err) if is_transport_closed_error(&err) => {
+            Err(err)
+                if is_transport_closed_error(&err)
+                    && self.session.disconnect_behavior
+                        == ProcessSessionDisconnectBehavior::Fail =>
+            {
                 let message = disconnected_message(/*reason*/ None);
-                self.state.set_failure(message.clone()).await;
-                Ok(self.state.synthesized_failure(message))
+                self.session.set_failure(message.clone()).await;
+                Ok(self.session.synthesized_failure(message))
             }
             Err(err) => Err(err),
         }
     }
 
     pub(crate) async fn write(&self, chunk: Vec<u8>) -> Result<WriteResponse, ExecServerError> {
-        self.client.write(&self.process_id, chunk).await
+        self.control.write(&self.process_id, chunk).await
     }
 
     pub(crate) async fn terminate(&self) -> Result<(), ExecServerError> {
-        self.client.terminate(&self.process_id).await?;
+        self.control.terminate(&self.process_id).await?;
         Ok(())
     }
 
     pub(crate) async fn unregister(&self) {
-        self.client.unregister_session(&self.process_id).await;
+        self.control
+            .unregister_process_session(&self.process_id)
+            .await;
+    }
+}
+
+impl ProcessSessionControl {
+    async fn read(&self, params: ReadParams) -> Result<ReadResponse, ExecServerError> {
+        match self {
+            #[cfg(test)]
+            Self::Connection(connection) => connection.read(params).await,
+            Self::RemoteClient(client) => client.read(params).await,
+        }
+    }
+
+    async fn write(
+        &self,
+        process_id: &ProcessId,
+        chunk: Vec<u8>,
+    ) -> Result<WriteResponse, ExecServerError> {
+        match self {
+            #[cfg(test)]
+            Self::Connection(connection) => connection.write(process_id, chunk).await,
+            Self::RemoteClient(client) => client.write(process_id, chunk).await,
+        }
+    }
+
+    async fn terminate(
+        &self,
+        process_id: &ProcessId,
+    ) -> Result<TerminateResponse, ExecServerError> {
+        match self {
+            #[cfg(test)]
+            Self::Connection(connection) => connection.terminate(process_id).await,
+            Self::RemoteClient(client) => client.terminate(process_id).await,
+        }
+    }
+
+    async fn unregister_process_session(&self, process_id: &ProcessId) {
+        match self {
+            #[cfg(test)]
+            Self::Connection(connection) => connection.unregister_process_session(process_id).await,
+            Self::RemoteClient(client) => client.unregister_process_session(process_id).await,
+        }
+    }
+}
+
+impl TerminalReconnectError {
+    fn from_error(error: &ExecServerError) -> Option<Self> {
+        match error {
+            ExecServerError::Server { code, message } if *code == -32600 => Some(Self {
+                code: *code,
+                message: message.clone(),
+            }),
+            _ => None,
+        }
+    }
+
+    fn to_exec_server_error(&self) -> ExecServerError {
+        ExecServerError::Server {
+            code: self.code,
+            message: self.message.clone(),
+        }
     }
 }
 
@@ -710,51 +1036,57 @@ impl Inner {
         }
     }
 
-    fn get_session(&self, process_id: &ProcessId) -> Option<Arc<SessionState>> {
-        self.sessions.load().get(process_id).cloned()
+    fn get_process_session_route(&self, process_id: &ProcessId) -> Option<Arc<ProcessSession>> {
+        self.process_session_routes.load().get(process_id).cloned()
     }
 
-    async fn insert_session(
+    async fn insert_process_session_route(
         &self,
         process_id: &ProcessId,
-        session: Arc<SessionState>,
+        session: Arc<ProcessSession>,
     ) -> Result<(), ExecServerError> {
-        let _sessions_write_guard = self.sessions_write_lock.lock().await;
+        let _routes_write_guard = self.process_session_routes_write_lock.lock().await;
         // Do not register a process session that can never receive executor
         // notifications. Without this check, remote MCP startup could create a
         // dead session and wait for process output that will never arrive.
         if let Some(error) = self.disconnected_error() {
             return Err(error);
         }
-        let sessions = self.sessions.load();
-        if sessions.contains_key(process_id) {
+        let routes = self.process_session_routes.load();
+        if let Some(existing_session) = routes.get(process_id) {
+            if Arc::ptr_eq(existing_session, &session) {
+                return Ok(());
+            }
             return Err(ExecServerError::Protocol(format!(
                 "session already registered for process {process_id}"
             )));
         }
-        let mut next_sessions = sessions.as_ref().clone();
-        next_sessions.insert(process_id.clone(), session);
-        self.sessions.store(Arc::new(next_sessions));
+        let mut next_routes = routes.as_ref().clone();
+        next_routes.insert(process_id.clone(), session);
+        self.process_session_routes.store(Arc::new(next_routes));
         Ok(())
     }
 
-    async fn remove_session(&self, process_id: &ProcessId) -> Option<Arc<SessionState>> {
-        let _sessions_write_guard = self.sessions_write_lock.lock().await;
-        let sessions = self.sessions.load();
-        let session = sessions.get(process_id).cloned();
+    async fn remove_process_session_route(
+        &self,
+        process_id: &ProcessId,
+    ) -> Option<Arc<ProcessSession>> {
+        let _routes_write_guard = self.process_session_routes_write_lock.lock().await;
+        let routes = self.process_session_routes.load();
+        let session = routes.get(process_id).cloned();
         session.as_ref()?;
-        let mut next_sessions = sessions.as_ref().clone();
-        next_sessions.remove(process_id);
-        self.sessions.store(Arc::new(next_sessions));
+        let mut next_routes = routes.as_ref().clone();
+        next_routes.remove(process_id);
+        self.process_session_routes.store(Arc::new(next_routes));
         session
     }
 
-    async fn take_all_sessions(&self) -> HashMap<ProcessId, Arc<SessionState>> {
-        let _sessions_write_guard = self.sessions_write_lock.lock().await;
-        let sessions = self.sessions.load();
-        let drained_sessions = sessions.as_ref().clone();
-        self.sessions.store(Arc::new(HashMap::new()));
-        drained_sessions
+    async fn take_all_process_session_routes(&self) -> HashMap<ProcessId, Arc<ProcessSession>> {
+        let _routes_write_guard = self.process_session_routes_write_lock.lock().await;
+        let routes = self.process_session_routes.load();
+        let drained_routes = routes.as_ref().clone();
+        self.process_session_routes.store(Arc::new(HashMap::new()));
+        drained_routes
     }
 }
 
@@ -779,9 +1111,9 @@ fn is_transport_closed_error(error: &ExecServerError) -> bool {
 }
 
 fn record_disconnected(inner: &Arc<Inner>, message: String) -> String {
-    // The first observer records the canonical disconnect reason. Session
-    // draining stays with the reader task so it can preserve notification
-    // ordering before publishing the terminal failure.
+    // The first observer records the canonical disconnect reason. Process
+    // session route draining stays with the reader task so it can preserve
+    // notification ordering before publishing the terminal failure.
     if let Some(message) = inner.set_disconnected(message.clone()) {
         message
     } else {
@@ -789,20 +1121,22 @@ fn record_disconnected(inner: &Arc<Inner>, message: String) -> String {
     }
 }
 
-async fn fail_all_sessions(inner: &Arc<Inner>, message: String) {
-    let sessions = inner.take_all_sessions().await;
+async fn fail_all_process_sessions(inner: &Arc<Inner>, message: String) {
+    let routes = inner.take_all_process_session_routes().await;
 
-    for (_, session) in sessions {
-        // Sessions synthesize a closed read response and emit a pushed Failed
-        // event. That covers both polling consumers and streaming consumers
-        // such as executor-backed MCP stdio.
-        session.set_failure(message.clone()).await;
+    for (_, session) in routes {
+        // One-shot sessions synthesize a closed read response and emit a
+        // pushed Failed event. Reconnecting remote sessions keep their local
+        // event state so a reattached client can bind them again.
+        if session.disconnect_behavior == ProcessSessionDisconnectBehavior::Fail {
+            session.set_failure(message.clone()).await;
+        }
     }
 }
 
 /// Fails all in-flight work that depends on the shared JSON-RPC transport.
 async fn fail_all_in_flight_work(inner: &Arc<Inner>, message: String) {
-    fail_all_sessions(inner, message.clone()).await;
+    fail_all_process_sessions(inner, message.clone()).await;
     inner.fail_all_http_body_streams(message).await;
 }
 
@@ -814,7 +1148,7 @@ async fn handle_server_notification(
         EXEC_OUTPUT_DELTA_METHOD => {
             let params: ExecOutputDeltaNotification =
                 serde_json::from_value(notification.params.unwrap_or(Value::Null))?;
-            if let Some(session) = inner.get_session(&params.process_id) {
+            if let Some(session) = inner.get_process_session_route(&params.process_id) {
                 session.note_change(params.seq);
                 let published_closed =
                     session.publish_ordered_event(ExecProcessEvent::Output(ProcessOutputChunk {
@@ -823,28 +1157,28 @@ async fn handle_server_notification(
                         chunk: params.chunk,
                     }));
                 if published_closed {
-                    inner.remove_session(&params.process_id).await;
+                    inner.remove_process_session_route(&params.process_id).await;
                 }
             }
         }
         EXEC_EXITED_METHOD => {
             let params: ExecExitedNotification =
                 serde_json::from_value(notification.params.unwrap_or(Value::Null))?;
-            if let Some(session) = inner.get_session(&params.process_id) {
+            if let Some(session) = inner.get_process_session_route(&params.process_id) {
                 session.note_change(params.seq);
                 let published_closed = session.publish_ordered_event(ExecProcessEvent::Exited {
                     seq: params.seq,
                     exit_code: params.exit_code,
                 });
                 if published_closed {
-                    inner.remove_session(&params.process_id).await;
+                    inner.remove_process_session_route(&params.process_id).await;
                 }
             }
         }
         EXEC_CLOSED_METHOD => {
             let params: ExecClosedNotification =
                 serde_json::from_value(notification.params.unwrap_or(Value::Null))?;
-            if let Some(session) = inner.get_session(&params.process_id) {
+            if let Some(session) = inner.get_process_session_route(&params.process_id) {
                 session.note_change(params.seq);
                 // Closed is terminal, but it can arrive before tail output or
                 // exited. Keep routing this process until the ordered publisher
@@ -852,7 +1186,7 @@ async fn handle_server_notification(
                 let published_closed =
                     session.publish_ordered_event(ExecProcessEvent::Closed { seq: params.seq });
                 if published_closed {
-                    inner.remove_session(&params.process_id).await;
+                    inner.remove_process_session_route(&params.process_id).await;
                 }
             }
         }
@@ -891,8 +1225,8 @@ mod tests {
     use tokio::time::sleep;
     use tokio::time::timeout;
 
-    use super::ExecServerClient;
     use super::ExecServerClientConnectOptions;
+    use super::ExecServerConnection;
     use crate::ProcessId;
     #[cfg(not(windows))]
     use crate::client_api::DEFAULT_REMOTE_EXEC_SERVER_INITIALIZE_TIMEOUT;
@@ -940,7 +1274,7 @@ mod tests {
     #[cfg(not(windows))]
     #[tokio::test]
     async fn connect_stdio_command_initializes_json_rpc_client() {
-        let client = ExecServerClient::connect_stdio_command(StdioExecServerConnectArgs {
+        let client = ExecServerConnection::connect_stdio_command(StdioExecServerConnectArgs {
             command: StdioExecServerCommand {
                 program: "sh".to_string(),
                 args: vec![
@@ -963,7 +1297,7 @@ mod tests {
     #[cfg(not(windows))]
     #[tokio::test]
     async fn connect_for_transport_initializes_stdio_command() {
-        let client = ExecServerClient::connect_for_transport(
+        let client = ExecServerConnection::connect_for_transport(
             ExecServerTransportParams::StdioCommand {
                 command: StdioExecServerCommand {
                     program: "sh".to_string(),
@@ -986,7 +1320,7 @@ mod tests {
     #[cfg(windows)]
     #[tokio::test]
     async fn connect_stdio_command_initializes_json_rpc_client_on_windows() {
-        let client = ExecServerClient::connect_stdio_command(StdioExecServerConnectArgs {
+        let client = ExecServerConnection::connect_stdio_command(StdioExecServerConnectArgs {
             command: StdioExecServerCommand {
                 program: "powershell".to_string(),
                 args: vec![
@@ -1024,7 +1358,7 @@ mod tests {
             shell_quote(child_pid_file.as_path()),
         );
 
-        let client = ExecServerClient::connect_stdio_command(StdioExecServerConnectArgs {
+        let client = ExecServerConnection::connect_stdio_command(StdioExecServerConnectArgs {
             command: StdioExecServerCommand {
                 program: "sh".to_string(),
                 args: vec!["-c".to_string(), stdio_script],
@@ -1067,7 +1401,7 @@ mod tests {
             shell_quote(pid_file.as_path()),
         );
 
-        let result = ExecServerClient::connect_stdio_command(StdioExecServerConnectArgs {
+        let result = ExecServerConnection::connect_stdio_command(StdioExecServerConnectArgs {
             command: StdioExecServerCommand {
                 program: "sh".to_string(),
                 args: vec!["-c".to_string(), stdio_script],
@@ -1161,7 +1495,7 @@ mod tests {
             }
         });
 
-        let client = ExecServerClient::connect(
+        let client = ExecServerConnection::connect(
             JsonRpcConnection::from_stdio(
                 client_stdout,
                 client_stdin,
@@ -1174,7 +1508,7 @@ mod tests {
 
         let process_id = ProcessId::from("reordered");
         let session = client
-            .register_session(&process_id)
+            .register_process_session(&process_id)
             .await
             .expect("session should register");
         let mut events = session.subscribe_events();
@@ -1303,7 +1637,7 @@ mod tests {
             drop(server_writer);
         });
 
-        let client = ExecServerClient::connect(
+        let client = ExecServerConnection::connect(
             JsonRpcConnection::from_stdio(
                 client_stdout,
                 client_stdin,
@@ -1316,7 +1650,7 @@ mod tests {
 
         let process_id = ProcessId::from("disconnect");
         let session = client
-            .register_session(&process_id)
+            .register_process_session(&process_id)
             .await
             .expect("session should register");
         let mut events = session.subscribe_events();
@@ -1344,7 +1678,9 @@ mod tests {
         );
         assert!(response.closed);
 
-        let new_session = client.register_session(&ProcessId::from("new")).await;
+        let new_session = client
+            .register_process_session(&ProcessId::from("new"))
+            .await;
         assert!(matches!(
             new_session,
             Err(super::ExecServerError::Disconnected(_))
@@ -1390,7 +1726,7 @@ mod tests {
             }
         });
 
-        let client = ExecServerClient::connect(
+        let client = ExecServerConnection::connect(
             JsonRpcConnection::from_stdio(
                 client_stdout,
                 client_stdin,
@@ -1404,11 +1740,11 @@ mod tests {
         let noisy_process_id = ProcessId::from("noisy");
         let quiet_process_id = ProcessId::from("quiet");
         let _noisy_session = client
-            .register_session(&noisy_process_id)
+            .register_process_session(&noisy_process_id)
             .await
             .expect("noisy session should register");
         let quiet_session = client
-            .register_session(&quiet_process_id)
+            .register_process_session(&quiet_process_id)
             .await
             .expect("quiet session should register");
         let mut quiet_wake_rx = quiet_session.subscribe_wake();

--- a/codex-rs/exec-server/src/client.rs
+++ b/codex-rs/exec-server/src/client.rs
@@ -81,6 +81,8 @@ use crate::rpc::RpcClient;
 use crate::rpc::RpcClientEvent;
 
 pub(crate) mod http_client;
+#[cfg(test)]
+mod reconnect_tests;
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const INITIALIZE_TIMEOUT: Duration = Duration::from_secs(10);

--- a/codex-rs/exec-server/src/client.rs
+++ b/codex-rs/exec-server/src/client.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
 use std::sync::OnceLock;
+use std::sync::Weak;
 use std::sync::atomic::AtomicU64;
 use std::time::Duration;
 
@@ -16,6 +17,7 @@ use tokio::sync::Notify;
 use tokio::sync::mpsc;
 use tokio::sync::watch;
 
+use tokio::time::sleep;
 use tokio::time::timeout;
 use tracing::debug;
 
@@ -88,6 +90,8 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const INITIALIZE_TIMEOUT: Duration = Duration::from_secs(10);
 const PROCESS_EVENT_CHANNEL_CAPACITY: usize = 256;
 const PROCESS_EVENT_RETAINED_BYTES: usize = 1024 * 1024;
+const TRANSIENT_RESUME_CONFLICT_RETRY_DELAY: Duration = Duration::from_millis(10);
+const TRANSIENT_RESUME_CONFLICT_RETRY_LIMIT: usize = 3;
 
 impl Default for ExecServerClientConnectOptions {
     fn default() -> Self {
@@ -216,14 +220,15 @@ pub(crate) struct RemoteExecServerClient {
 }
 
 // Shared state for one logical remote exec-server client. The logical client
-// owns resumable session identity and durable process session state; individual
-// ExecServerConnection values only bind that state to one live transport.
+// owns resumable session identity and tracks live process sessions that may
+// need rebinding; individual ExecServerConnection values only bind that state
+// to one live transport.
 struct RemoteExecServerSession {
     connection: Option<ExecServerConnection>,
     connection_attempt: Option<Arc<Notify>>,
     logical_session_id: Option<String>,
     terminal_error: Option<TerminalReconnectError>,
-    process_sessions: HashMap<ProcessId, Arc<ProcessSession>>,
+    process_sessions: HashMap<ProcessId, Weak<ProcessSession>>,
 }
 
 enum RemoteExecServerConnectionAction {
@@ -257,6 +262,7 @@ impl RemoteExecServerClient {
     }
 
     pub(crate) async fn connection(&self) -> Result<ExecServerConnection, ExecServerError> {
+        let mut transient_resume_conflicts = 0;
         loop {
             match self.next_connection_action()? {
                 RemoteExecServerConnectionAction::Ready(connection) => return Ok(connection),
@@ -271,11 +277,22 @@ impl RemoteExecServerClient {
                     let connection = self
                         .connect_and_rebind(resume_session_id.clone(), process_sessions)
                         .await;
-                    return self.finish_connection_attempt(
+                    match self.finish_connection_attempt(
                         connection_attempt,
                         resume_session_id,
                         connection,
-                    );
+                    ) {
+                        Ok(connection) => return Ok(connection),
+                        Err(err)
+                            if transient_resume_conflicts
+                                < TRANSIENT_RESUME_CONFLICT_RETRY_LIMIT
+                                && is_transient_resume_conflict(&err) =>
+                        {
+                            transient_resume_conflicts += 1;
+                            sleep(TRANSIENT_RESUME_CONFLICT_RETRY_DELAY).await;
+                        }
+                        Err(err) => return Err(err),
+                    }
                 }
             }
         }
@@ -284,23 +301,34 @@ impl RemoteExecServerClient {
     pub(crate) async fn register_process_session(
         &self,
         process_id: &ProcessId,
-    ) -> Result<ProcessSessionHandle, ExecServerError> {
+    ) -> Result<(ProcessSessionHandle, ExecServerConnection), ExecServerError> {
         let process_session = Arc::new(ProcessSession::new(
             ProcessSessionDisconnectBehavior::Preserve,
         ));
         {
             let mut session = self.lock_session();
-            if session.process_sessions.contains_key(process_id) {
+            if session
+                .process_sessions
+                .get(process_id)
+                .and_then(Weak::upgrade)
+                .is_some()
+            {
                 return Err(ExecServerError::Protocol(format!(
                     "session already registered for process {process_id}"
                 )));
             }
             session
                 .process_sessions
-                .insert(process_id.clone(), Arc::clone(&process_session));
+                .insert(process_id.clone(), Arc::downgrade(&process_session));
         }
 
-        let connection = self.connection().await?;
+        let connection = match self.connection().await {
+            Ok(connection) => connection,
+            Err(err) => {
+                self.unregister_process_session(process_id).await;
+                return Err(err);
+            }
+        };
         if let Err(err) = connection
             .register_process_session_route(process_id, Arc::clone(&process_session))
             .await
@@ -309,11 +337,14 @@ impl RemoteExecServerClient {
             return Err(err);
         }
 
-        Ok(ProcessSessionHandle {
-            control: ProcessSessionControl::RemoteClient(self.clone()),
-            process_id: process_id.clone(),
-            session: process_session,
-        })
+        Ok((
+            ProcessSessionHandle {
+                control: ProcessSessionControl::RemoteClient(self.clone()),
+                process_id: process_id.clone(),
+                session: process_session,
+            },
+            connection,
+        ))
     }
 
     async fn read(&self, params: ReadParams) -> Result<ReadResponse, ExecServerError> {
@@ -378,11 +409,16 @@ impl RemoteExecServerClient {
 
         let connection_attempt = Arc::new(Notify::new());
         let resume_session_id = session.logical_session_id.clone();
-        let process_sessions = session
+        let mut process_sessions = Vec::new();
+        session
             .process_sessions
-            .iter()
-            .map(|(process_id, process_session)| (process_id.clone(), Arc::clone(process_session)))
-            .collect();
+            .retain(|process_id, process_session| {
+                let Some(process_session) = process_session.upgrade() else {
+                    return false;
+                };
+                process_sessions.push((process_id.clone(), process_session));
+                true
+            });
         session.connection_attempt = Some(Arc::clone(&connection_attempt));
         Ok(RemoteExecServerConnectionAction::Connect {
             connection_attempt,
@@ -824,6 +860,16 @@ impl ProcessSession {
         let _ = self.wake_tx.send(next);
     }
 
+    fn notify_wake(&self) {
+        let next = (*self.wake_tx.borrow()).saturating_add(1);
+        let _ = self.wake_tx.send(next);
+    }
+
+    fn note_resync_required(&self) {
+        self.notify_wake();
+        self.events.publish(ExecProcessEvent::ResyncRequired);
+    }
+
     /// Publishes a process event only when all earlier sequenced events have
     /// already been published.
     ///
@@ -875,8 +921,7 @@ impl ProcessSession {
             *failure = Some(message.clone());
         }
         drop(failure);
-        let next = (*self.wake_tx.borrow()).saturating_add(1);
-        let _ = self.wake_tx.send(next);
+        self.notify_wake();
         if should_publish {
             let _ = self.publish_ordered_event(ExecProcessEvent::Failed(message));
         }
@@ -1007,10 +1052,14 @@ impl ProcessSessionControl {
 impl TerminalReconnectError {
     fn from_error(error: &ExecServerError) -> Option<Self> {
         match error {
-            ExecServerError::Server { code, message } if *code == -32600 => Some(Self {
-                code: *code,
-                message: message.clone(),
-            }),
+            ExecServerError::Server { code, message }
+                if *code == -32600 && message.starts_with("unknown session id ") =>
+            {
+                Some(Self {
+                    code: *code,
+                    message: message.clone(),
+                })
+            }
             _ => None,
         }
     }
@@ -1123,6 +1172,14 @@ fn record_disconnected(inner: &Arc<Inner>, message: String) -> String {
     }
 }
 
+fn is_transient_resume_conflict(error: &ExecServerError) -> bool {
+    matches!(
+        error,
+        ExecServerError::Server { code, message }
+            if *code == -32600 && message.ends_with("is already attached to another connection")
+    )
+}
+
 async fn fail_all_process_sessions(inner: &Arc<Inner>, message: String) {
     let routes = inner.take_all_process_session_routes().await;
 
@@ -1130,8 +1187,13 @@ async fn fail_all_process_sessions(inner: &Arc<Inner>, message: String) {
         // One-shot sessions synthesize a closed read response and emit a
         // pushed Failed event. Reconnecting remote sessions keep their local
         // event state so a reattached client can bind them again.
-        if session.disconnect_behavior == ProcessSessionDisconnectBehavior::Fail {
-            session.set_failure(message.clone()).await;
+        match session.disconnect_behavior {
+            ProcessSessionDisconnectBehavior::Fail => {
+                session.set_failure(message.clone()).await;
+            }
+            ProcessSessionDisconnectBehavior::Preserve => {
+                session.note_resync_required();
+            }
         }
     }
 }

--- a/codex-rs/exec-server/src/client/http_client.rs
+++ b/codex-rs/exec-server/src/client/http_client.rs
@@ -3,7 +3,7 @@
 //! This module is the facade for the environment-owned [`crate::HttpClient`]
 //! capability:
 //! - [`ReqwestHttpClient`] executes requests directly with `reqwest`
-//! - [`ExecServerClient`] forwards requests over the JSON-RPC transport
+//! - [`ExecServerConnection`] forwards requests over the JSON-RPC transport
 //! - [`HttpResponseBodyStream`] presents buffered local bodies and streamed
 //!   remote `http/request/bodyDelta` notifications through one byte-stream API
 //!
@@ -11,7 +11,7 @@
 //! - orchestrator process: holds an `Arc<dyn HttpClient>` and chooses local or
 //!   remote execution
 //! - remote runtime: serves the `http/request` RPC and runs the concrete local
-//!   HTTP request there when the orchestrator uses [`ExecServerClient`]
+//!   HTTP request there when the orchestrator uses [`ExecServerConnection`]
 
 #[path = "reqwest_http_client.rs"]
 mod reqwest_http_client;

--- a/codex-rs/exec-server/src/client/reconnect_tests.rs
+++ b/codex-rs/exec-server/src/client/reconnect_tests.rs
@@ -823,7 +823,7 @@ async fn remote_client_retries_transient_resume_conflict() -> Result<()> {
         second
             .write_error(
                 request.id,
-                -32600,
+                /*code*/ -32600,
                 "session session-1 is already attached to another connection",
             )
             .await;
@@ -868,7 +868,11 @@ async fn remote_client_caches_unknown_session_resume_failure() -> Result<()> {
         server_connections.fetch_add(1, Ordering::SeqCst);
         let request = second.read_request(INITIALIZE_METHOD).await;
         second
-            .write_error(request.id, -32600, "unknown session id session-1")
+            .write_error(
+                request.id,
+                /*code*/ -32600,
+                "unknown session id session-1",
+            )
             .await;
 
         let extra_connection = timeout(Duration::from_millis(200), listener.accept()).await;

--- a/codex-rs/exec-server/src/client/reconnect_tests.rs
+++ b/codex-rs/exec-server/src/client/reconnect_tests.rs
@@ -1,6 +1,8 @@
 use anyhow::Context;
 use anyhow::Result;
 use base64::Engine as _;
+use codex_app_server_protocol::JSONRPCError;
+use codex_app_server_protocol::JSONRPCErrorError;
 use codex_app_server_protocol::JSONRPCMessage;
 use codex_app_server_protocol::JSONRPCNotification;
 use codex_app_server_protocol::JSONRPCRequest;
@@ -34,6 +36,7 @@ use crate::RemoveOptions;
 use crate::client_api::ExecServerTransportParams;
 use crate::client_api::HttpClient;
 use crate::process::ExecBackend;
+use crate::process::ExecProcessEvent;
 use crate::protocol::ByteChunk;
 use crate::protocol::EXEC_METHOD;
 use crate::protocol::EXEC_READ_METHOD;
@@ -306,6 +309,23 @@ impl WebSocketJsonRpcPeer {
         self.write_message(JSONRPCMessage::Response(JSONRPCResponse {
             id,
             result: serde_json::to_value(result).expect("json-rpc response should serialize"),
+        }))
+        .await;
+    }
+
+    async fn write_error(
+        &mut self,
+        id: codex_app_server_protocol::RequestId,
+        code: i64,
+        message: impl Into<String>,
+    ) {
+        self.write_message(JSONRPCMessage::Error(JSONRPCError {
+            id,
+            error: JSONRPCErrorError {
+                code,
+                message: message.into(),
+                data: None,
+            },
         }))
         .await;
     }
@@ -690,6 +710,283 @@ async fn remote_client_reuses_one_reconnect_attempt_for_concurrent_callers() -> 
 
     server.await.expect("test websocket server should finish");
     assert_eq!(accepted_connections.load(Ordering::SeqCst), 2);
+    Ok(())
+}
+
+#[tokio::test]
+async fn remote_process_disconnect_notifies_resync_before_cursor_recovery() -> Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .context("test websocket listener should bind")?;
+    let websocket_url = format!("ws://{}", listener.local_addr()?);
+    let (disconnect_tx, disconnect_rx) = tokio::sync::oneshot::channel();
+    let server = tokio::spawn(async move {
+        let mut first = WebSocketJsonRpcPeer::accept(&listener).await;
+        first
+            .complete_initialize(/*expected_resume_session_id*/ None, "session-1")
+            .await;
+        let start_request = first.read_request(EXEC_METHOD).await;
+        first
+            .write_response(
+                start_request.id,
+                ExecResponse {
+                    process_id: ProcessId::from("proc"),
+                },
+            )
+            .await;
+        disconnect_rx
+            .await
+            .expect("test should trigger idle disconnect");
+        drop(first);
+
+        let mut second = WebSocketJsonRpcPeer::accept(&listener).await;
+        second
+            .complete_initialize(Some("session-1"), "session-1")
+            .await;
+        let read_request = second.read_request(EXEC_READ_METHOD).await;
+        assert_eq!(
+            decode_request_params::<ReadParams>(&read_request),
+            ReadParams {
+                process_id: ProcessId::from("proc"),
+                after_seq: None,
+                max_bytes: None,
+                wait_ms: Some(0),
+            }
+        );
+        second
+            .write_response(read_request.id, successful_read_response())
+            .await;
+    });
+
+    let client = test_remote_client(websocket_url);
+    let process = RemoteProcess::new(client);
+    let started = process
+        .start(test_exec_params(&ProcessId::from("proc")))
+        .await?;
+    let mut wake = started.process.subscribe_wake();
+    let mut events = started.process.subscribe_events();
+    disconnect_tx
+        .send(())
+        .expect("idle disconnect should signal");
+
+    timeout(Duration::from_secs(1), wake.changed())
+        .await
+        .context("idle process wake should surface transport resync")??;
+    assert_eq!(
+        timeout(Duration::from_secs(1), events.recv())
+            .await
+            .context("idle process event should surface transport resync")??,
+        ExecProcessEvent::ResyncRequired
+    );
+    assert_eq!(
+        started
+            .process
+            .read(
+                /*after_seq*/ None,
+                /*max_bytes*/ None,
+                /*wait_ms*/ Some(0),
+            )
+            .await?,
+        successful_read_response()
+    );
+
+    server.await.expect("test websocket server should finish");
+    Ok(())
+}
+
+#[tokio::test]
+async fn remote_client_retries_transient_resume_conflict() -> Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .context("test websocket listener should bind")?;
+    let websocket_url = format!("ws://{}", listener.local_addr()?);
+    let accepted_connections = Arc::new(AtomicUsize::new(0));
+    let server_connections = Arc::clone(&accepted_connections);
+    let server = tokio::spawn(async move {
+        let mut first = WebSocketJsonRpcPeer::accept(&listener).await;
+        server_connections.fetch_add(1, Ordering::SeqCst);
+        first
+            .complete_initialize(/*expected_resume_session_id*/ None, "session-1")
+            .await;
+        drop(first);
+
+        let mut second = WebSocketJsonRpcPeer::accept(&listener).await;
+        server_connections.fetch_add(1, Ordering::SeqCst);
+        let request = second.read_request(INITIALIZE_METHOD).await;
+        assert_eq!(
+            decode_request_params::<InitializeParams>(&request),
+            InitializeParams {
+                client_name: crate::client_transport::ENVIRONMENT_CLIENT_NAME.to_string(),
+                resume_session_id: Some("session-1".to_string()),
+            }
+        );
+        second
+            .write_error(
+                request.id,
+                -32600,
+                "session session-1 is already attached to another connection",
+            )
+            .await;
+
+        let mut third = WebSocketJsonRpcPeer::accept(&listener).await;
+        server_connections.fetch_add(1, Ordering::SeqCst);
+        third
+            .complete_initialize(Some("session-1"), "session-1")
+            .await;
+    });
+
+    let client = test_remote_client(websocket_url);
+    let first_connection = client.connection().await?;
+    wait_for_disconnect(&first_connection).await;
+    assert_eq!(
+        client.connection().await?.session_id(),
+        Some("session-1".to_string())
+    );
+
+    server.await.expect("test websocket server should finish");
+    assert_eq!(accepted_connections.load(Ordering::SeqCst), 3);
+    Ok(())
+}
+
+#[tokio::test]
+async fn remote_client_caches_unknown_session_resume_failure() -> Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .context("test websocket listener should bind")?;
+    let websocket_url = format!("ws://{}", listener.local_addr()?);
+    let accepted_connections = Arc::new(AtomicUsize::new(0));
+    let server_connections = Arc::clone(&accepted_connections);
+    let server = tokio::spawn(async move {
+        let mut first = WebSocketJsonRpcPeer::accept(&listener).await;
+        server_connections.fetch_add(1, Ordering::SeqCst);
+        first
+            .complete_initialize(/*expected_resume_session_id*/ None, "session-1")
+            .await;
+        drop(first);
+
+        let mut second = WebSocketJsonRpcPeer::accept(&listener).await;
+        server_connections.fetch_add(1, Ordering::SeqCst);
+        let request = second.read_request(INITIALIZE_METHOD).await;
+        second
+            .write_error(request.id, -32600, "unknown session id session-1")
+            .await;
+
+        let extra_connection = timeout(Duration::from_millis(200), listener.accept()).await;
+        assert!(
+            extra_connection.is_err(),
+            "terminal resume failure should not open another websocket"
+        );
+    });
+
+    let client = test_remote_client(websocket_url);
+    let first_connection = client.connection().await?;
+    wait_for_disconnect(&first_connection).await;
+    let first_error = match client.connection().await {
+        Ok(_) => panic!("unknown session should fail reconnect"),
+        Err(err) => err,
+    };
+    assert_eq!(
+        first_error.to_string(),
+        "exec-server rejected request (-32600): unknown session id session-1"
+    );
+    let second_error = match client.connection().await {
+        Ok(_) => panic!("unknown session should stay terminal"),
+        Err(err) => err,
+    };
+    assert_eq!(
+        second_error.to_string(),
+        "exec-server rejected request (-32600): unknown session id session-1"
+    );
+
+    server.await.expect("test websocket server should finish");
+    assert_eq!(accepted_connections.load(Ordering::SeqCst), 2);
+    Ok(())
+}
+
+#[tokio::test]
+async fn remote_process_start_releases_session_after_initial_connect_failure() -> Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .context("test websocket listener should bind")?;
+    let websocket_url = format!("ws://{}", listener.local_addr()?);
+    let server = tokio::spawn(async move {
+        let first = WebSocketJsonRpcPeer::accept(&listener).await;
+        drop(first);
+
+        let mut second = WebSocketJsonRpcPeer::accept(&listener).await;
+        second
+            .complete_initialize(/*expected_resume_session_id*/ None, "session-1")
+            .await;
+        let request = second.read_request(EXEC_METHOD).await;
+        second
+            .write_response(
+                request.id,
+                ExecResponse {
+                    process_id: ProcessId::from("proc"),
+                },
+            )
+            .await;
+    });
+
+    let client = test_remote_client(websocket_url);
+    let process = RemoteProcess::new(client);
+    let params = test_exec_params(&ProcessId::from("proc"));
+    assert!(
+        process.start(params.clone()).await.is_err(),
+        "initial connect should fail before dispatch"
+    );
+    let started = process.start(params).await?;
+    assert_eq!(started.process.process_id(), &ProcessId::from("proc"));
+
+    server.await.expect("test websocket server should finish");
+    Ok(())
+}
+
+#[tokio::test]
+async fn remote_process_drop_releases_session_for_process_id_reuse() -> Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .context("test websocket listener should bind")?;
+    let websocket_url = format!("ws://{}", listener.local_addr()?);
+    let server = tokio::spawn(async move {
+        let mut peer = WebSocketJsonRpcPeer::accept(&listener).await;
+        peer.complete_initialize(/*expected_resume_session_id*/ None, "session-1")
+            .await;
+        for _ in 0..2 {
+            let request = peer.read_request(EXEC_METHOD).await;
+            peer.write_response(
+                request.id,
+                ExecResponse {
+                    process_id: ProcessId::from("proc"),
+                },
+            )
+            .await;
+        }
+    });
+
+    let client = test_remote_client(websocket_url);
+    let process = RemoteProcess::new(client);
+    let params = test_exec_params(&ProcessId::from("proc"));
+    let started = process.start(params.clone()).await?;
+    drop(started);
+    let restarted = timeout(Duration::from_secs(1), async {
+        loop {
+            match process.start(params.clone()).await {
+                Ok(restarted) => return Ok(restarted),
+                Err(crate::ExecServerError::Protocol(message))
+                    if message == "session already registered for process proc" =>
+                {
+                    tokio::task::yield_now().await;
+                }
+                Err(err) => return Err(err),
+            }
+        }
+    })
+    .await
+    .context("dropped process session should unregister")??;
+    assert_eq!(restarted.process.process_id(), &ProcessId::from("proc"));
+
+    server.await.expect("test websocket server should finish");
     Ok(())
 }
 

--- a/codex-rs/exec-server/src/client/reconnect_tests.rs
+++ b/codex-rs/exec-server/src/client/reconnect_tests.rs
@@ -1,0 +1,776 @@
+use anyhow::Context;
+use anyhow::Result;
+use base64::Engine as _;
+use codex_app_server_protocol::JSONRPCMessage;
+use codex_app_server_protocol::JSONRPCNotification;
+use codex_app_server_protocol::JSONRPCRequest;
+use codex_app_server_protocol::JSONRPCResponse;
+use codex_utils_absolute_path::AbsolutePathBuf;
+use futures::SinkExt;
+use futures::StreamExt;
+use pretty_assertions::assert_eq;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use tokio::net::TcpListener;
+use tokio::net::TcpStream;
+use tokio::time::Duration;
+use tokio::time::timeout;
+use tokio_tungstenite::WebSocketStream;
+use tokio_tungstenite::accept_async;
+use tokio_tungstenite::tungstenite::Message;
+
+use super::ExecServerConnection;
+use super::RemoteExecServerClient;
+use crate::CopyOptions;
+use crate::CreateDirectoryOptions;
+use crate::ExecutorFileSystem;
+use crate::HttpHeader;
+use crate::ProcessId;
+use crate::ReadDirectoryEntry;
+use crate::RemoveOptions;
+use crate::client_api::ExecServerTransportParams;
+use crate::client_api::HttpClient;
+use crate::process::ExecBackend;
+use crate::protocol::ByteChunk;
+use crate::protocol::EXEC_METHOD;
+use crate::protocol::EXEC_READ_METHOD;
+use crate::protocol::EXEC_TERMINATE_METHOD;
+use crate::protocol::EXEC_WRITE_METHOD;
+use crate::protocol::ExecParams;
+use crate::protocol::ExecResponse;
+use crate::protocol::FS_COPY_METHOD;
+use crate::protocol::FS_CREATE_DIRECTORY_METHOD;
+use crate::protocol::FS_GET_METADATA_METHOD;
+use crate::protocol::FS_READ_DIRECTORY_METHOD;
+use crate::protocol::FS_READ_FILE_METHOD;
+use crate::protocol::FS_REMOVE_METHOD;
+use crate::protocol::FS_WRITE_FILE_METHOD;
+use crate::protocol::FsCopyResponse;
+use crate::protocol::FsCreateDirectoryResponse;
+use crate::protocol::FsGetMetadataResponse;
+use crate::protocol::FsReadDirectoryEntry;
+use crate::protocol::FsReadDirectoryResponse;
+use crate::protocol::FsReadFileResponse;
+use crate::protocol::FsRemoveResponse;
+use crate::protocol::FsWriteFileResponse;
+use crate::protocol::HTTP_REQUEST_BODY_DELTA_METHOD;
+use crate::protocol::HTTP_REQUEST_METHOD;
+use crate::protocol::HttpRequestBodyDeltaNotification;
+use crate::protocol::HttpRequestParams;
+use crate::protocol::HttpRequestResponse;
+use crate::protocol::INITIALIZE_METHOD;
+use crate::protocol::INITIALIZED_METHOD;
+use crate::protocol::InitializeParams;
+use crate::protocol::InitializeResponse;
+use crate::protocol::ReadParams;
+use crate::protocol::ReadResponse;
+use crate::protocol::TerminateResponse;
+use crate::protocol::WriteResponse;
+use crate::protocol::WriteStatus;
+use crate::remote_file_system::RemoteFileSystem;
+use crate::remote_process::RemoteProcess;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RemoteApi {
+    Start,
+    Read,
+    Write,
+    Terminate,
+    FsReadFile,
+    FsWriteFile,
+    FsCreateDirectory,
+    FsGetMetadata,
+    FsReadDirectory,
+    FsRemove,
+    FsCopy,
+    HttpRequest,
+    HttpRequestStream,
+}
+
+impl RemoteApi {
+    const ALL: [Self; 13] = [
+        Self::Start,
+        Self::Read,
+        Self::Write,
+        Self::Terminate,
+        Self::FsReadFile,
+        Self::FsWriteFile,
+        Self::FsCreateDirectory,
+        Self::FsGetMetadata,
+        Self::FsReadDirectory,
+        Self::FsRemove,
+        Self::FsCopy,
+        Self::HttpRequest,
+        Self::HttpRequestStream,
+    ];
+
+    const NON_REPLAYABLE: [Self; 12] = [
+        Self::Start,
+        Self::Write,
+        Self::Terminate,
+        Self::FsReadFile,
+        Self::FsWriteFile,
+        Self::FsCreateDirectory,
+        Self::FsGetMetadata,
+        Self::FsReadDirectory,
+        Self::FsRemove,
+        Self::FsCopy,
+        Self::HttpRequest,
+        Self::HttpRequestStream,
+    ];
+
+    fn method(self) -> &'static str {
+        match self {
+            Self::Start => EXEC_METHOD,
+            Self::Read => EXEC_READ_METHOD,
+            Self::Write => EXEC_WRITE_METHOD,
+            Self::Terminate => EXEC_TERMINATE_METHOD,
+            Self::FsReadFile => FS_READ_FILE_METHOD,
+            Self::FsWriteFile => FS_WRITE_FILE_METHOD,
+            Self::FsCreateDirectory => FS_CREATE_DIRECTORY_METHOD,
+            Self::FsGetMetadata => FS_GET_METADATA_METHOD,
+            Self::FsReadDirectory => FS_READ_DIRECTORY_METHOD,
+            Self::FsRemove => FS_REMOVE_METHOD,
+            Self::FsCopy => FS_COPY_METHOD,
+            Self::HttpRequest | Self::HttpRequestStream => HTTP_REQUEST_METHOD,
+        }
+    }
+
+    async fn respond_success(self, peer: &mut WebSocketJsonRpcPeer, request: JSONRPCRequest) {
+        match self {
+            Self::Start => {
+                peer.write_response(
+                    request.id,
+                    ExecResponse {
+                        process_id: ProcessId::from("proc"),
+                    },
+                )
+                .await;
+            }
+            Self::Read => {
+                peer.write_response(request.id, successful_read_response())
+                    .await;
+            }
+            Self::Write => {
+                peer.write_response(
+                    request.id,
+                    WriteResponse {
+                        status: WriteStatus::Accepted,
+                    },
+                )
+                .await;
+            }
+            Self::Terminate => {
+                peer.write_response(request.id, TerminateResponse { running: false })
+                    .await;
+            }
+            Self::FsReadFile => {
+                peer.write_response(
+                    request.id,
+                    FsReadFileResponse {
+                        data_base64: base64::engine::general_purpose::STANDARD
+                            .encode(b"remote file"),
+                    },
+                )
+                .await;
+            }
+            Self::FsWriteFile => {
+                peer.write_response(request.id, FsWriteFileResponse {})
+                    .await;
+            }
+            Self::FsCreateDirectory => {
+                peer.write_response(request.id, FsCreateDirectoryResponse {})
+                    .await;
+            }
+            Self::FsGetMetadata => {
+                peer.write_response(
+                    request.id,
+                    FsGetMetadataResponse {
+                        is_directory: false,
+                        is_file: true,
+                        is_symlink: false,
+                        created_at_ms: 11,
+                        modified_at_ms: 22,
+                    },
+                )
+                .await;
+            }
+            Self::FsReadDirectory => {
+                peer.write_response(
+                    request.id,
+                    FsReadDirectoryResponse {
+                        entries: vec![FsReadDirectoryEntry {
+                            file_name: "entry.txt".to_string(),
+                            is_directory: false,
+                            is_file: true,
+                        }],
+                    },
+                )
+                .await;
+            }
+            Self::FsRemove => {
+                peer.write_response(request.id, FsRemoveResponse {}).await;
+            }
+            Self::FsCopy => {
+                peer.write_response(request.id, FsCopyResponse {}).await;
+            }
+            Self::HttpRequest => {
+                peer.write_response(request.id, successful_http_response())
+                    .await;
+            }
+            Self::HttpRequestStream => {
+                let params: HttpRequestParams = decode_request_params(&request);
+                assert!(params.stream_response);
+                peer.write_response(request.id, successful_http_stream_response())
+                    .await;
+                peer.write_notification(
+                    HTTP_REQUEST_BODY_DELTA_METHOD,
+                    HttpRequestBodyDeltaNotification {
+                        request_id: params.request_id,
+                        seq: 1,
+                        delta: ByteChunk::from(Vec::new()),
+                        done: true,
+                        error: None,
+                    },
+                )
+                .await;
+            }
+        }
+    }
+}
+
+struct WebSocketJsonRpcPeer {
+    websocket: WebSocketStream<TcpStream>,
+}
+
+impl WebSocketJsonRpcPeer {
+    async fn accept(listener: &TcpListener) -> Self {
+        let (stream, _) = timeout(Duration::from_secs(1), listener.accept())
+            .await
+            .expect("websocket accept should not time out")
+            .expect("websocket accept should succeed");
+        let websocket = accept_async(stream)
+            .await
+            .expect("websocket handshake should succeed");
+        Self { websocket }
+    }
+
+    async fn complete_initialize(
+        &mut self,
+        expected_resume_session_id: Option<&str>,
+        session_id: &str,
+    ) {
+        let request = self.read_request(INITIALIZE_METHOD).await;
+        assert_eq!(
+            decode_request_params::<InitializeParams>(&request),
+            InitializeParams {
+                client_name: crate::client_transport::ENVIRONMENT_CLIENT_NAME.to_string(),
+                resume_session_id: expected_resume_session_id.map(ToOwned::to_owned),
+            }
+        );
+        self.write_response(
+            request.id,
+            InitializeResponse {
+                session_id: session_id.to_string(),
+            },
+        )
+        .await;
+        self.read_notification(INITIALIZED_METHOD).await;
+    }
+
+    async fn read_request(&mut self, expected_method: &str) -> JSONRPCRequest {
+        let message = self.read_message().await;
+        let JSONRPCMessage::Request(request) = message else {
+            panic!("expected JSON-RPC request `{expected_method}`, got {message:?}");
+        };
+        assert_eq!(request.method, expected_method);
+        request
+    }
+
+    async fn read_notification(&mut self, expected_method: &str) -> JSONRPCNotification {
+        let message = self.read_message().await;
+        let JSONRPCMessage::Notification(notification) = message else {
+            panic!("expected JSON-RPC notification `{expected_method}`, got {message:?}");
+        };
+        assert_eq!(notification.method, expected_method);
+        notification
+    }
+
+    async fn write_response<T>(&mut self, id: codex_app_server_protocol::RequestId, result: T)
+    where
+        T: serde::Serialize,
+    {
+        self.write_message(JSONRPCMessage::Response(JSONRPCResponse {
+            id,
+            result: serde_json::to_value(result).expect("json-rpc response should serialize"),
+        }))
+        .await;
+    }
+
+    async fn write_notification<T>(&mut self, method: &str, params: T)
+    where
+        T: serde::Serialize,
+    {
+        self.write_message(JSONRPCMessage::Notification(JSONRPCNotification {
+            method: method.to_string(),
+            params: Some(
+                serde_json::to_value(params).expect("json-rpc notification should serialize"),
+            ),
+        }))
+        .await;
+    }
+
+    async fn read_message(&mut self) -> JSONRPCMessage {
+        loop {
+            let message = timeout(Duration::from_secs(1), self.websocket.next())
+                .await
+                .expect("websocket read should not time out")
+                .expect("websocket should stay open")
+                .expect("websocket read should succeed");
+            match message {
+                Message::Text(text) => {
+                    return serde_json::from_str(text.as_ref())
+                        .expect("websocket text should contain json-rpc");
+                }
+                Message::Binary(bytes) => {
+                    return serde_json::from_slice(&bytes)
+                        .expect("websocket binary should contain json-rpc");
+                }
+                Message::Ping(payload) => {
+                    self.websocket
+                        .send(Message::Pong(payload))
+                        .await
+                        .expect("websocket pong should send");
+                }
+                Message::Pong(_) => {}
+                Message::Close(frame) => panic!("websocket closed unexpectedly: {frame:?}"),
+                Message::Frame(_) => panic!("unexpected raw websocket frame"),
+            }
+        }
+    }
+
+    async fn write_message(&mut self, message: JSONRPCMessage) {
+        let encoded = serde_json::to_string(&message).expect("json-rpc message should serialize");
+        self.websocket
+            .send(Message::Text(encoded.into()))
+            .await
+            .expect("websocket message should send");
+    }
+}
+
+fn decode_request_params<T>(request: &JSONRPCRequest) -> T
+where
+    T: serde::de::DeserializeOwned,
+{
+    serde_json::from_value(
+        request
+            .params
+            .clone()
+            .expect("json-rpc request should include params"),
+    )
+    .expect("json-rpc request params should deserialize")
+}
+
+fn test_remote_client(websocket_url: String) -> RemoteExecServerClient {
+    RemoteExecServerClient::new(ExecServerTransportParams::websocket_url(websocket_url))
+}
+
+fn test_exec_params(process_id: &ProcessId) -> ExecParams {
+    ExecParams {
+        process_id: process_id.clone(),
+        argv: vec!["/bin/echo".to_string(), "hello".to_string()],
+        cwd: std::env::current_dir().expect("current directory should be available"),
+        env_policy: /*env_policy*/ None,
+        env: HashMap::new(),
+        tty: false,
+        pipe_stdin: false,
+        arg0: None,
+    }
+}
+
+fn successful_read_response() -> ReadResponse {
+    ReadResponse {
+        chunks: Vec::new(),
+        next_seq: 9,
+        exited: false,
+        exit_code: None,
+        closed: false,
+        failure: None,
+    }
+}
+
+fn successful_http_response() -> HttpRequestResponse {
+    HttpRequestResponse {
+        status: 200,
+        headers: vec![HttpHeader {
+            name: "content-type".to_string(),
+            value: "text/plain".to_string(),
+        }],
+        body: ByteChunk::from(b"ok".to_vec()),
+    }
+}
+
+fn successful_http_stream_response() -> HttpRequestResponse {
+    HttpRequestResponse {
+        body: ByteChunk::from(Vec::new()),
+        ..successful_http_response()
+    }
+}
+
+fn test_http_request_params() -> HttpRequestParams {
+    HttpRequestParams {
+        method: "GET".to_string(),
+        url: "https://example.com/test".to_string(),
+        headers: Vec::new(),
+        body: None,
+        timeout_ms: Some(123),
+        request_id: "caller-request".to_string(),
+        stream_response: false,
+    }
+}
+
+fn absolute_test_path(name: &str) -> AbsolutePathBuf {
+    let path = std::env::temp_dir().join(name);
+    AbsolutePathBuf::from_absolute_path(&path).expect("absolute path")
+}
+
+async fn wait_for_disconnect(connection: &ExecServerConnection) {
+    timeout(Duration::from_secs(1), async {
+        loop {
+            if connection.disconnected_error().is_some() {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("connection should notice disconnect");
+}
+
+async fn invoke_remote_api(client: &RemoteExecServerClient, api: RemoteApi) -> Result<()> {
+    let process_id = ProcessId::from("proc");
+    match api {
+        RemoteApi::Start => {
+            let process = RemoteProcess::new(client.clone());
+            let started = process.start(test_exec_params(&process_id)).await?;
+            assert_eq!(started.process.process_id(), &process_id);
+        }
+        RemoteApi::Read => {
+            assert_eq!(
+                client
+                    .read(ReadParams {
+                        process_id,
+                        after_seq: Some(7),
+                        max_bytes: Some(1024),
+                        wait_ms: Some(25),
+                    })
+                    .await?,
+                successful_read_response()
+            );
+        }
+        RemoteApi::Write => {
+            assert_eq!(
+                client.write(&process_id, b"stdin".to_vec()).await?,
+                WriteResponse {
+                    status: WriteStatus::Accepted,
+                }
+            );
+        }
+        RemoteApi::Terminate => {
+            assert_eq!(
+                client.terminate(&process_id).await?,
+                TerminateResponse { running: false }
+            );
+        }
+        RemoteApi::FsReadFile => {
+            let file_system = RemoteFileSystem::new(client.clone());
+            assert_eq!(
+                file_system
+                    .read_file(&absolute_test_path("remote-read"), /*sandbox*/ None)
+                    .await?,
+                b"remote file".to_vec()
+            );
+        }
+        RemoteApi::FsWriteFile => {
+            let file_system = RemoteFileSystem::new(client.clone());
+            file_system
+                .write_file(
+                    &absolute_test_path("remote-write"),
+                    b"contents".to_vec(),
+                    /*sandbox*/ None,
+                )
+                .await?;
+        }
+        RemoteApi::FsCreateDirectory => {
+            let file_system = RemoteFileSystem::new(client.clone());
+            file_system
+                .create_directory(
+                    &absolute_test_path("remote-dir"),
+                    CreateDirectoryOptions { recursive: true },
+                    /*sandbox*/ None,
+                )
+                .await?;
+        }
+        RemoteApi::FsGetMetadata => {
+            let file_system = RemoteFileSystem::new(client.clone());
+            assert_eq!(
+                file_system
+                    .get_metadata(&absolute_test_path("remote-meta"), /*sandbox*/ None)
+                    .await?,
+                crate::FileMetadata {
+                    is_directory: false,
+                    is_file: true,
+                    is_symlink: false,
+                    created_at_ms: 11,
+                    modified_at_ms: 22,
+                }
+            );
+        }
+        RemoteApi::FsReadDirectory => {
+            let file_system = RemoteFileSystem::new(client.clone());
+            assert_eq!(
+                file_system
+                    .read_directory(&absolute_test_path("remote-list"), /*sandbox*/ None)
+                    .await?,
+                vec![ReadDirectoryEntry {
+                    file_name: "entry.txt".to_string(),
+                    is_directory: false,
+                    is_file: true,
+                }]
+            );
+        }
+        RemoteApi::FsRemove => {
+            let file_system = RemoteFileSystem::new(client.clone());
+            file_system
+                .remove(
+                    &absolute_test_path("remote-remove"),
+                    RemoveOptions {
+                        recursive: true,
+                        force: true,
+                    },
+                    /*sandbox*/ None,
+                )
+                .await?;
+        }
+        RemoteApi::FsCopy => {
+            let file_system = RemoteFileSystem::new(client.clone());
+            file_system
+                .copy(
+                    &absolute_test_path("remote-copy-source"),
+                    &absolute_test_path("remote-copy-destination"),
+                    CopyOptions { recursive: true },
+                    /*sandbox*/ None,
+                )
+                .await?;
+        }
+        RemoteApi::HttpRequest => {
+            assert_eq!(
+                client.http_request(test_http_request_params()).await?,
+                successful_http_response()
+            );
+        }
+        RemoteApi::HttpRequestStream => {
+            let (response, mut body) = client
+                .http_request_stream(test_http_request_params())
+                .await?;
+            assert_eq!(response, successful_http_stream_response());
+            assert_eq!(body.recv().await?, None);
+        }
+    }
+    Ok(())
+}
+
+async fn assert_remote_api_reconnects_before_dispatch(api: RemoteApi) -> Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .context("test websocket listener should bind")?;
+    let websocket_url = format!("ws://{}", listener.local_addr()?);
+    let server = tokio::spawn(async move {
+        let mut first = WebSocketJsonRpcPeer::accept(&listener).await;
+        first
+            .complete_initialize(/*expected_resume_session_id*/ None, "session-1")
+            .await;
+        drop(first);
+
+        let mut second = WebSocketJsonRpcPeer::accept(&listener).await;
+        second
+            .complete_initialize(Some("session-1"), "session-1")
+            .await;
+        let request = second.read_request(api.method()).await;
+        api.respond_success(&mut second, request).await;
+    });
+
+    let client = test_remote_client(websocket_url);
+    let first_connection = client.connection().await?;
+    wait_for_disconnect(&first_connection).await;
+    invoke_remote_api(&client, api).await?;
+
+    server.await.expect("test websocket server should finish");
+    Ok(())
+}
+
+async fn assert_remote_api_does_not_replay_after_disconnect(api: RemoteApi) -> Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .context("test websocket listener should bind")?;
+    let websocket_url = format!("ws://{}", listener.local_addr()?);
+    let request_count = Arc::new(AtomicUsize::new(0));
+    let server_request_count = Arc::clone(&request_count);
+    let server = tokio::spawn(async move {
+        let mut peer = WebSocketJsonRpcPeer::accept(&listener).await;
+        peer.complete_initialize(/*expected_resume_session_id*/ None, "session-1")
+            .await;
+        let _request = peer.read_request(api.method()).await;
+        server_request_count.fetch_add(1, Ordering::SeqCst);
+        drop(peer);
+
+        let reconnect = timeout(Duration::from_millis(200), listener.accept()).await;
+        assert!(
+            reconnect.is_err(),
+            "{api:?} should not reconnect during ambiguous replay window"
+        );
+    });
+
+    let client = test_remote_client(websocket_url);
+    let error = invoke_remote_api(&client, api)
+        .await
+        .expect_err("ambiguous disconnect should fail");
+    assert!(
+        error.to_string().contains("exec-server transport"),
+        "unexpected {api:?} error: {error:#}"
+    );
+
+    server.await.expect("test websocket server should finish");
+    assert_eq!(request_count.load(Ordering::SeqCst), 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn remote_client_reuses_one_reconnect_attempt_for_concurrent_callers() -> Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .context("test websocket listener should bind")?;
+    let websocket_url = format!("ws://{}", listener.local_addr()?);
+    let accepted_connections = Arc::new(AtomicUsize::new(0));
+    let server_connections = Arc::clone(&accepted_connections);
+    let server = tokio::spawn(async move {
+        let mut first = WebSocketJsonRpcPeer::accept(&listener).await;
+        server_connections.fetch_add(1, Ordering::SeqCst);
+        first
+            .complete_initialize(/*expected_resume_session_id*/ None, "session-1")
+            .await;
+        drop(first);
+
+        let mut second = WebSocketJsonRpcPeer::accept(&listener).await;
+        server_connections.fetch_add(1, Ordering::SeqCst);
+        second
+            .complete_initialize(Some("session-1"), "session-1")
+            .await;
+
+        let extra_connection = timeout(Duration::from_millis(200), listener.accept()).await;
+        assert!(
+            extra_connection.is_err(),
+            "concurrent callers should share the resumed websocket"
+        );
+    });
+
+    let client = test_remote_client(websocket_url);
+    let first_connection = client.connection().await?;
+    wait_for_disconnect(&first_connection).await;
+
+    let (first_reconnected, second_reconnected) =
+        tokio::join!(client.connection(), client.connection());
+    assert_eq!(
+        first_reconnected?.session_id(),
+        second_reconnected?.session_id()
+    );
+
+    server.await.expect("test websocket server should finish");
+    assert_eq!(accepted_connections.load(Ordering::SeqCst), 2);
+    Ok(())
+}
+
+#[tokio::test]
+async fn remote_client_reconnects_before_dispatching_every_remote_api() -> Result<()> {
+    for api in RemoteApi::ALL {
+        assert_remote_api_reconnects_before_dispatch(api).await?;
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn remote_client_replays_cursor_read_once_after_disconnect() -> Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .context("test websocket listener should bind")?;
+    let websocket_url = format!("ws://{}", listener.local_addr()?);
+    let first_request = Arc::new(StdMutex::new(None));
+    let replayed_request = Arc::new(StdMutex::new(None));
+    let server_first_request = Arc::clone(&first_request);
+    let server_replayed_request = Arc::clone(&replayed_request);
+    let server = tokio::spawn(async move {
+        let mut first = WebSocketJsonRpcPeer::accept(&listener).await;
+        first
+            .complete_initialize(/*expected_resume_session_id*/ None, "session-1")
+            .await;
+        let request = first.read_request(EXEC_READ_METHOD).await;
+        *server_first_request
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) =
+            Some(decode_request_params::<ReadParams>(&request));
+        drop(first);
+
+        let mut second = WebSocketJsonRpcPeer::accept(&listener).await;
+        second
+            .complete_initialize(Some("session-1"), "session-1")
+            .await;
+        let request = second.read_request(EXEC_READ_METHOD).await;
+        *server_replayed_request
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) =
+            Some(decode_request_params::<ReadParams>(&request));
+        second
+            .write_response(request.id, successful_read_response())
+            .await;
+    });
+
+    let client = test_remote_client(websocket_url);
+    let params = ReadParams {
+        process_id: ProcessId::from("proc"),
+        after_seq: Some(7),
+        max_bytes: Some(1024),
+        wait_ms: Some(25),
+    };
+    assert_eq!(
+        client.read(params.clone()).await?,
+        successful_read_response()
+    );
+
+    server.await.expect("test websocket server should finish");
+    assert_eq!(
+        first_request
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone(),
+        Some(params.clone())
+    );
+    assert_eq!(
+        replayed_request
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone(),
+        Some(params)
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn remote_client_does_not_replay_non_read_apis_after_disconnect() -> Result<()> {
+    for api in RemoteApi::NON_REPLAYABLE {
+        assert_remote_api_does_not_replay_after_disconnect(api).await?;
+    }
+    Ok(())
+}

--- a/codex-rs/exec-server/src/client/rpc_http_client.rs
+++ b/codex-rs/exec-server/src/client/rpc_http_client.rs
@@ -14,7 +14,7 @@ use tokio::sync::mpsc;
 use super::HttpResponseBodyStream;
 use super::response_body_stream::HttpBodyStreamRegistration;
 use crate::HttpClient;
-use crate::client::ExecServerClient;
+use crate::client::ExecServerConnection;
 use crate::client::ExecServerError;
 use crate::protocol::HTTP_REQUEST_METHOD;
 use crate::protocol::HttpRequestParams;
@@ -23,7 +23,7 @@ use crate::protocol::HttpRequestResponse;
 /// Maximum queued body frames per streamed HTTP response.
 const HTTP_BODY_DELTA_CHANNEL_CAPACITY: usize = 256;
 
-impl ExecServerClient {
+impl ExecServerConnection {
     /// Performs an HTTP request and buffers the response body.
     pub async fn http_request(
         &self,
@@ -67,14 +67,14 @@ impl ExecServerClient {
     }
 }
 
-impl HttpClient for ExecServerClient {
+impl HttpClient for ExecServerConnection {
     /// Orchestrator-side adapter that forwards buffered HTTP requests to the
     /// remote runtime over the shared JSON-RPC connection.
     fn http_request(
         &self,
         params: HttpRequestParams,
     ) -> BoxFuture<'_, Result<HttpRequestResponse, ExecServerError>> {
-        async move { ExecServerClient::http_request(self, params).await }.boxed()
+        async move { ExecServerConnection::http_request(self, params).await }.boxed()
     }
 
     /// Orchestrator-side adapter that forwards streamed HTTP requests to the
@@ -83,6 +83,6 @@ impl HttpClient for ExecServerClient {
         &self,
         params: HttpRequestParams,
     ) -> BoxFuture<'_, Result<(HttpRequestResponse, HttpResponseBodyStream), ExecServerError>> {
-        async move { ExecServerClient::http_request_stream(self, params).await }.boxed()
+        async move { ExecServerConnection::http_request_stream(self, params).await }.boxed()
     }
 }

--- a/codex-rs/exec-server/src/client_transport.rs
+++ b/codex-rs/exec-server/src/client_transport.rs
@@ -9,7 +9,7 @@ use tracing::warn;
 
 use codex_utils_rustls_provider::ensure_rustls_crypto_provider;
 
-use crate::ExecServerClient;
+use crate::ExecServerConnection;
 use crate::ExecServerError;
 use crate::client_api::RemoteExecServerConnectArgs;
 use crate::client_api::StdioExecServerCommand;
@@ -17,9 +17,9 @@ use crate::client_api::StdioExecServerConnectArgs;
 use crate::connection::JsonRpcConnection;
 use crate::relay::harness_connection_from_websocket;
 
-const ENVIRONMENT_CLIENT_NAME: &str = "codex-environment";
+pub(crate) const ENVIRONMENT_CLIENT_NAME: &str = "codex-environment";
 
-impl ExecServerClient {
+impl ExecServerConnection {
     pub(crate) async fn connect_for_transport(
         transport_params: crate::client_api::ExecServerTransportParams,
     ) -> Result<Self, ExecServerError> {

--- a/codex-rs/exec-server/src/connection.rs
+++ b/codex-rs/exec-server/src/connection.rs
@@ -401,19 +401,6 @@ impl JsonRpcConnection {
                                         break;
                                     }
                                 }
-                                Ok(JsonRpcWebSocketFrame::Ping(payload)) => {
-                                    if let Err(err) = websocket.send(M::pong(payload)).await {
-                                        send_disconnected(
-                                            &incoming_tx,
-                                            &disconnected_tx,
-                                            Some(format!(
-                                                "failed to write websocket pong to {connection_label}: {err}"
-                                            )),
-                                        )
-                                        .await;
-                                        break;
-                                    }
-                                }
                                 Ok(JsonRpcWebSocketFrame::Close) => {
                                     send_disconnected(
                                         &incoming_tx,
@@ -477,7 +464,6 @@ impl JsonRpcConnection {
 
 enum JsonRpcWebSocketFrame {
     Message(JSONRPCMessage),
-    Ping(bytes::Bytes),
     Close,
     Ignore,
 }
@@ -486,7 +472,6 @@ trait JsonRpcWebSocketMessage: Send + 'static {
     fn parse_jsonrpc_frame(self) -> Result<JsonRpcWebSocketFrame, serde_json::Error>;
     fn from_text(text: String) -> Self;
     fn ping() -> Self;
-    fn pong(payload: bytes::Bytes) -> Self;
 }
 
 impl JsonRpcWebSocketMessage for Message {
@@ -499,8 +484,9 @@ impl JsonRpcWebSocketMessage for Message {
                 serde_json::from_slice(bytes.as_ref()).map(JsonRpcWebSocketFrame::Message)
             }
             Message::Close(_) => Ok(JsonRpcWebSocketFrame::Close),
-            Message::Ping(payload) => Ok(JsonRpcWebSocketFrame::Ping(payload)),
-            Message::Pong(_) | Message::Frame(_) => Ok(JsonRpcWebSocketFrame::Ignore),
+            Message::Ping(_) | Message::Pong(_) | Message::Frame(_) => {
+                Ok(JsonRpcWebSocketFrame::Ignore)
+            }
         }
     }
 
@@ -510,10 +496,6 @@ impl JsonRpcWebSocketMessage for Message {
 
     fn ping() -> Self {
         Self::Ping(Vec::new().into())
-    }
-
-    fn pong(payload: bytes::Bytes) -> Self {
-        Self::Pong(payload)
     }
 }
 
@@ -527,8 +509,9 @@ impl JsonRpcWebSocketMessage for AxumWebSocketMessage {
                 serde_json::from_slice(bytes.as_ref()).map(JsonRpcWebSocketFrame::Message)
             }
             AxumWebSocketMessage::Close(_) => Ok(JsonRpcWebSocketFrame::Close),
-            AxumWebSocketMessage::Ping(payload) => Ok(JsonRpcWebSocketFrame::Ping(payload)),
-            AxumWebSocketMessage::Pong(_) => Ok(JsonRpcWebSocketFrame::Ignore),
+            AxumWebSocketMessage::Ping(_) | AxumWebSocketMessage::Pong(_) => {
+                Ok(JsonRpcWebSocketFrame::Ignore)
+            }
         }
     }
 
@@ -538,10 +521,6 @@ impl JsonRpcWebSocketMessage for AxumWebSocketMessage {
 
     fn ping() -> Self {
         Self::Ping(Vec::new().into())
-    }
-
-    fn pong(payload: bytes::Bytes) -> Self {
-        Self::Pong(payload)
     }
 }
 
@@ -627,23 +606,6 @@ mod tests {
     use tokio_tungstenite::connect_async;
 
     use super::*;
-
-    #[tokio::test]
-    async fn websocket_connection_pongs_server_ping() -> anyhow::Result<()> {
-        let (client_websocket, mut server_websocket) = websocket_pair().await?;
-        let connection = JsonRpcConnection::from_websocket(client_websocket, "test".into());
-
-        server_websocket
-            .send(Message::Ping(b"check".to_vec().into()))
-            .await?;
-        let message = timeout(Duration::from_secs(1), server_websocket.next())
-            .await?
-            .expect("websocket should stay open")?;
-        assert_eq!(message, Message::Pong(b"check".to_vec().into()));
-
-        drop(connection);
-        Ok(())
-    }
 
     #[tokio::test]
     async fn websocket_connection_sends_configured_ping() -> anyhow::Result<()> {
@@ -733,7 +695,7 @@ mod tests {
 
         connection.outgoing_tx.send(message.clone()).await?;
         control.wait_for_blocked_write().await?;
-        control.send_inbound(Message::Ping(b"check".to_vec().into()))?;
+        control.send_inbound(Message::Pong(b"check".to_vec().into()))?;
         assert!(
             timeout(Duration::from_millis(50), connection.incoming_rx.recv())
                 .await
@@ -745,11 +707,6 @@ mod tests {
             timeout(Duration::from_secs(1), outbound_rx.next()).await?,
             Some(Message::Text(text)) if serde_json::from_str::<JSONRPCMessage>(&text)? == message
         ));
-        assert!(matches!(
-            timeout(Duration::from_secs(1), outbound_rx.next()).await?,
-            Some(Message::Pong(payload)) if payload.as_ref() == b"check"
-        ));
-
         drop(connection);
         Ok(())
     }

--- a/codex-rs/exec-server/src/connection.rs
+++ b/codex-rs/exec-server/src/connection.rs
@@ -610,6 +610,8 @@ fn serialize_jsonrpc_message(message: &JSONRPCMessage) -> Result<String, serde_j
 
 #[cfg(test)]
 mod tests {
+    use codex_app_server_protocol::JSONRPCRequest;
+    use codex_app_server_protocol::RequestId;
     use tokio::net::TcpListener;
     use tokio::time::timeout;
     use tokio_tungstenite::accept_async;
@@ -647,6 +649,62 @@ mod tests {
             .await?
             .expect("websocket should stay open")?;
         assert!(matches!(message, Message::Ping(_)));
+
+        drop(connection);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn websocket_connection_ignores_server_pong() -> anyhow::Result<()> {
+        let (client_websocket, mut server_websocket) = websocket_pair().await?;
+        let mut connection = JsonRpcConnection::from_websocket(client_websocket, "test".into());
+
+        server_websocket
+            .send(Message::Pong(b"check".to_vec().into()))
+            .await?;
+        assert!(
+            timeout(Duration::from_millis(50), connection.incoming_rx.recv())
+                .await
+                .is_err()
+        );
+
+        drop(connection);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn websocket_connection_reports_server_close() -> anyhow::Result<()> {
+        let (client_websocket, mut server_websocket) = websocket_pair().await?;
+        let mut connection = JsonRpcConnection::from_websocket(client_websocket, "test".into());
+
+        server_websocket.close(None).await?;
+        assert!(matches!(
+            timeout(Duration::from_secs(1), connection.incoming_rx.recv()).await?,
+            Some(JsonRpcConnectionEvent::Disconnected { reason: None })
+        ));
+
+        drop(connection);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn websocket_connection_accepts_binary_jsonrpc_message() -> anyhow::Result<()> {
+        let (client_websocket, mut server_websocket) = websocket_pair().await?;
+        let mut connection = JsonRpcConnection::from_websocket(client_websocket, "test".into());
+        let message = JSONRPCMessage::Request(JSONRPCRequest {
+            id: RequestId::Integer(1),
+            method: "test".to_string(),
+            params: None,
+            trace: None,
+        });
+
+        server_websocket
+            .send(Message::Binary(serde_json::to_vec(&message)?.into()))
+            .await?;
+        assert!(matches!(
+            timeout(Duration::from_secs(1), connection.incoming_rx.recv()).await?,
+            Some(JsonRpcConnectionEvent::Message(actual)) if actual == message
+        ));
 
         drop(connection);
         Ok(())

--- a/codex-rs/exec-server/src/connection.rs
+++ b/codex-rs/exec-server/src/connection.rs
@@ -323,11 +323,11 @@ impl JsonRpcConnection {
     where
         S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     {
-        Self::from_websocket_stream(stream, connection_label, /*ping_interval*/ None)
+        Self::from_websocket_stream(stream, connection_label, Some(WEBSOCKET_KEEPALIVE_INTERVAL))
     }
 
     pub(crate) fn from_axum_websocket(stream: AxumWebSocket, connection_label: String) -> Self {
-        Self::from_websocket_stream(stream, connection_label, Some(WEBSOCKET_KEEPALIVE_INTERVAL))
+        Self::from_websocket_stream(stream, connection_label, /*ping_interval*/ None)
     }
 
     fn from_websocket_stream<T, M, E>(

--- a/codex-rs/exec-server/src/connection.rs
+++ b/codex-rs/exec-server/src/connection.rs
@@ -323,37 +323,20 @@ impl JsonRpcConnection {
     where
         S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     {
-        let (websocket_writer, websocket_reader) = stream.split();
-        Self::from_websocket_parts(
-            websocket_writer,
-            websocket_reader,
-            connection_label,
-            Some(WEBSOCKET_KEEPALIVE_INTERVAL),
-        )
+        Self::from_websocket_stream(stream, connection_label, /*ping_interval*/ None)
     }
 
     pub(crate) fn from_axum_websocket(stream: AxumWebSocket, connection_label: String) -> Self {
-        let (websocket_writer, websocket_reader) = stream.split();
-        Self::from_websocket_parts(
-            websocket_writer,
-            websocket_reader,
-            connection_label,
-            // Axum only wraps inbound exec-server websocket accepts. Outbound websocket clients
-            // own keepalive pings so one side does not accidentally create redundant traffic.
-            /*keepalive_interval*/
-            None,
-        )
+        Self::from_websocket_stream(stream, connection_label, Some(WEBSOCKET_KEEPALIVE_INTERVAL))
     }
 
-    fn from_websocket_parts<W, R, M, E>(
-        mut websocket_writer: W,
-        mut websocket_reader: R,
+    fn from_websocket_stream<T, M, E>(
+        mut websocket: T,
         connection_label: String,
-        keepalive_interval: Option<Duration>,
+        ping_interval: Option<Duration>,
     ) -> Self
     where
-        W: Sink<M, Error = E> + Unpin + Send + 'static,
-        R: Stream<Item = Result<M, E>> + Unpin + Send + 'static,
+        T: Sink<M, Error = E> + Stream<Item = Result<M, E>> + Unpin + Send + 'static,
         M: JsonRpcWebSocketMessage,
         E: std::fmt::Display + Send + 'static,
     {
@@ -361,116 +344,117 @@ impl JsonRpcConnection {
         let (incoming_tx, incoming_rx) = mpsc::channel(CHANNEL_CAPACITY);
         let (disconnected_tx, disconnected_rx) = watch::channel(false);
 
-        let reader_label = connection_label.clone();
-        let incoming_tx_for_reader = incoming_tx.clone();
-        let disconnected_tx_for_reader = disconnected_tx.clone();
-        let reader_task = tokio::spawn(async move {
+        let websocket_task = tokio::spawn(async move {
+            let mut ping_interval = ping_interval.map(|ping_interval| {
+                let mut interval = tokio::time::interval_at(
+                    tokio::time::Instant::now() + ping_interval,
+                    ping_interval,
+                );
+                interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+                interval
+            });
+
             loop {
-                match websocket_reader.next().await {
-                    Some(Ok(message)) => match message.parse_jsonrpc_frame() {
-                        Ok(JsonRpcWebSocketFrame::Message(message)) => {
-                            if incoming_tx_for_reader
-                                .send(JsonRpcConnectionEvent::Message(message))
-                                .await
-                                .is_err()
-                            {
-                                break;
-                            }
+                tokio::select! {
+                    maybe_message = outgoing_rx.recv() => {
+                        let Some(message) = maybe_message else {
+                            break;
+                        };
+                        if let Err(reason) = send_websocket_jsonrpc_message(
+                            &mut websocket,
+                            &connection_label,
+                            &message,
+                        )
+                        .await
+                        {
+                            send_disconnected(&incoming_tx, &disconnected_tx, Some(reason)).await;
+                            break;
                         }
-                        Err(err) => {
-                            send_malformed_message(
-                                &incoming_tx_for_reader,
-                                Some(format!(
-                                    "failed to parse websocket JSON-RPC message from {reader_label}: {err}"
-                                )),
-                            )
-                            .await;
+                    }
+                    _ = async {
+                        match ping_interval.as_mut() {
+                            Some(interval) => interval.tick().await,
+                            None => std::future::pending().await,
                         }
-                        Ok(JsonRpcWebSocketFrame::Close) => {
+                    } => {
+                        if let Err(err) = websocket.send(M::ping()).await {
                             send_disconnected(
-                                &incoming_tx_for_reader,
-                                &disconnected_tx_for_reader,
-                                /*reason*/ None,
+                                &incoming_tx,
+                                &disconnected_tx,
+                                Some(format!(
+                                    "failed to write websocket ping to {connection_label}: {err}"
+                                )),
                             )
                             .await;
                             break;
                         }
-                        Ok(JsonRpcWebSocketFrame::Ignore) => {}
-                    },
-                    Some(Err(err)) => {
-                        send_disconnected(
-                            &incoming_tx_for_reader,
-                            &disconnected_tx_for_reader,
-                            Some(format!(
-                                "failed to read websocket JSON-RPC message from {reader_label}: {err}"
-                            )),
-                        )
-                        .await;
-                        break;
                     }
-                    None => {
-                        send_disconnected(
-                            &incoming_tx_for_reader,
-                            &disconnected_tx_for_reader,
-                            /*reason*/ None,
-                        )
-                        .await;
-                        break;
-                    }
-                }
-            }
-        });
-
-        let writer_task = tokio::spawn(async move {
-            if let Some(keepalive_interval) = keepalive_interval {
-                let mut keepalive = tokio::time::interval_at(
-                    tokio::time::Instant::now() + keepalive_interval,
-                    keepalive_interval,
-                );
-                keepalive.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-                loop {
-                    tokio::select! {
-                        maybe_message = outgoing_rx.recv() => {
-                            let Some(message) = maybe_message else {
-                                break;
-                            };
-                            if let Err(reason) = send_websocket_jsonrpc_message(
-                                &mut websocket_writer,
-                                &connection_label,
-                                &message,
-                            )
-                            .await
-                            {
-                                send_disconnected(&incoming_tx, &disconnected_tx, Some(reason)).await;
-                                break;
-                            }
-                        }
-                        _ = keepalive.tick() => {
-                            if let Err(err) = websocket_writer.send(M::ping()).await {
+                    incoming_message = websocket.next() => {
+                        match incoming_message {
+                            Some(Ok(message)) => match message.parse_jsonrpc_frame() {
+                                Ok(JsonRpcWebSocketFrame::Message(message)) => {
+                                    if incoming_tx
+                                        .send(JsonRpcConnectionEvent::Message(message))
+                                        .await
+                                        .is_err()
+                                    {
+                                        break;
+                                    }
+                                }
+                                Ok(JsonRpcWebSocketFrame::Ping(payload)) => {
+                                    if let Err(err) = websocket.send(M::pong(payload)).await {
+                                        send_disconnected(
+                                            &incoming_tx,
+                                            &disconnected_tx,
+                                            Some(format!(
+                                                "failed to write websocket pong to {connection_label}: {err}"
+                                            )),
+                                        )
+                                        .await;
+                                        break;
+                                    }
+                                }
+                                Ok(JsonRpcWebSocketFrame::Close) => {
+                                    send_disconnected(
+                                        &incoming_tx,
+                                        &disconnected_tx,
+                                        /*reason*/ None,
+                                    )
+                                    .await;
+                                    break;
+                                }
+                                Ok(JsonRpcWebSocketFrame::Ignore) => {}
+                                Err(err) => {
+                                    send_malformed_message(
+                                        &incoming_tx,
+                                        Some(format!(
+                                            "failed to parse websocket JSON-RPC message from {connection_label}: {err}"
+                                        )),
+                                    )
+                                    .await;
+                                }
+                            },
+                            Some(Err(err)) => {
                                 send_disconnected(
                                     &incoming_tx,
                                     &disconnected_tx,
                                     Some(format!(
-                                        "failed to write websocket ping to {connection_label}: {err}"
+                                        "failed to read websocket JSON-RPC message from {connection_label}: {err}"
                                     )),
                                 )
                                 .await;
                                 break;
                             }
+                            None => {
+                                send_disconnected(
+                                    &incoming_tx,
+                                    &disconnected_tx,
+                                    /*reason*/ None,
+                                )
+                                .await;
+                                break;
+                            }
                         }
-                    }
-                }
-            } else {
-                while let Some(message) = outgoing_rx.recv().await {
-                    if let Err(reason) = send_websocket_jsonrpc_message(
-                        &mut websocket_writer,
-                        &connection_label,
-                        &message,
-                    )
-                    .await
-                    {
-                        send_disconnected(&incoming_tx, &disconnected_tx, Some(reason)).await;
-                        break;
                     }
                 }
             }
@@ -480,7 +464,7 @@ impl JsonRpcConnection {
             outgoing_tx,
             incoming_rx,
             disconnected_rx,
-            task_handles: vec![reader_task, writer_task],
+            task_handles: vec![websocket_task],
             transport: JsonRpcTransport::Plain,
         }
     }
@@ -493,6 +477,7 @@ impl JsonRpcConnection {
 
 enum JsonRpcWebSocketFrame {
     Message(JSONRPCMessage),
+    Ping(bytes::Bytes),
     Close,
     Ignore,
 }
@@ -501,6 +486,7 @@ trait JsonRpcWebSocketMessage: Send + 'static {
     fn parse_jsonrpc_frame(self) -> Result<JsonRpcWebSocketFrame, serde_json::Error>;
     fn from_text(text: String) -> Self;
     fn ping() -> Self;
+    fn pong(payload: bytes::Bytes) -> Self;
 }
 
 impl JsonRpcWebSocketMessage for Message {
@@ -513,9 +499,8 @@ impl JsonRpcWebSocketMessage for Message {
                 serde_json::from_slice(bytes.as_ref()).map(JsonRpcWebSocketFrame::Message)
             }
             Message::Close(_) => Ok(JsonRpcWebSocketFrame::Close),
-            Message::Ping(_) | Message::Pong(_) | Message::Frame(_) => {
-                Ok(JsonRpcWebSocketFrame::Ignore)
-            }
+            Message::Ping(payload) => Ok(JsonRpcWebSocketFrame::Ping(payload)),
+            Message::Pong(_) | Message::Frame(_) => Ok(JsonRpcWebSocketFrame::Ignore),
         }
     }
 
@@ -525,6 +510,10 @@ impl JsonRpcWebSocketMessage for Message {
 
     fn ping() -> Self {
         Self::Ping(Vec::new().into())
+    }
+
+    fn pong(payload: bytes::Bytes) -> Self {
+        Self::Pong(payload)
     }
 }
 
@@ -538,9 +527,8 @@ impl JsonRpcWebSocketMessage for AxumWebSocketMessage {
                 serde_json::from_slice(bytes.as_ref()).map(JsonRpcWebSocketFrame::Message)
             }
             AxumWebSocketMessage::Close(_) => Ok(JsonRpcWebSocketFrame::Close),
-            AxumWebSocketMessage::Ping(_) | AxumWebSocketMessage::Pong(_) => {
-                Ok(JsonRpcWebSocketFrame::Ignore)
-            }
+            AxumWebSocketMessage::Ping(payload) => Ok(JsonRpcWebSocketFrame::Ping(payload)),
+            AxumWebSocketMessage::Pong(_) => Ok(JsonRpcWebSocketFrame::Ignore),
         }
     }
 
@@ -550,6 +538,10 @@ impl JsonRpcWebSocketMessage for AxumWebSocketMessage {
 
     fn ping() -> Self {
         Self::Ping(Vec::new().into())
+    }
+
+    fn pong(payload: bytes::Bytes) -> Self {
+        Self::Pong(payload)
     }
 }
 
@@ -618,71 +610,60 @@ fn serialize_jsonrpc_message(message: &JSONRPCMessage) -> Result<String, serde_j
 
 #[cfg(test)]
 mod tests {
-    use std::pin::Pin;
-
-    use futures::channel::mpsc as futures_mpsc;
-    use futures::stream;
-    use futures::task::Context;
-    use futures::task::Poll;
+    use tokio::net::TcpListener;
     use tokio::time::timeout;
+    use tokio_tungstenite::accept_async;
+    use tokio_tungstenite::connect_async;
 
     use super::*;
 
-    struct TestWebSocketSink {
-        message_tx: futures_mpsc::UnboundedSender<Message>,
-    }
+    #[tokio::test]
+    async fn websocket_connection_pongs_server_ping() -> anyhow::Result<()> {
+        let (client_websocket, mut server_websocket) = websocket_pair().await?;
+        let connection = JsonRpcConnection::from_websocket(client_websocket, "test".into());
 
-    impl Sink<Message> for TestWebSocketSink {
-        type Error = std::convert::Infallible;
+        server_websocket
+            .send(Message::Ping(b"check".to_vec().into()))
+            .await?;
+        let message = timeout(Duration::from_secs(1), server_websocket.next())
+            .await?
+            .expect("websocket should stay open")?;
+        assert_eq!(message, Message::Pong(b"check".to_vec().into()));
 
-        fn poll_ready(
-            self: Pin<&mut Self>,
-            _cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
-            Poll::Ready(Ok(()))
-        }
-
-        fn start_send(self: Pin<&mut Self>, item: Message) -> Result<(), Self::Error> {
-            self.get_mut()
-                .message_tx
-                .unbounded_send(item)
-                .expect("test websocket receiver should stay open");
-            Ok(())
-        }
-
-        fn poll_flush(
-            self: Pin<&mut Self>,
-            _cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
-            Poll::Ready(Ok(()))
-        }
-
-        fn poll_close(
-            self: Pin<&mut Self>,
-            _cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
-            Poll::Ready(Ok(()))
-        }
+        drop(connection);
+        Ok(())
     }
 
     #[tokio::test]
-    async fn websocket_connection_sends_keepalive_ping() {
-        let (message_tx, mut message_rx) = futures_mpsc::unbounded::<Message>();
-        let websocket_writer = TestWebSocketSink { message_tx };
-        let websocket_reader = stream::pending::<Result<Message, std::convert::Infallible>>();
-        let connection = JsonRpcConnection::from_websocket_parts(
-            websocket_writer,
-            websocket_reader,
+    async fn websocket_connection_sends_configured_ping() -> anyhow::Result<()> {
+        let (client_websocket, mut server_websocket) = websocket_pair().await?;
+        let connection = JsonRpcConnection::from_websocket_stream(
+            client_websocket,
             "test".into(),
             Some(WEBSOCKET_KEEPALIVE_INTERVAL),
         );
 
-        let message = timeout(Duration::from_secs(1), message_rx.next())
-            .await
-            .expect("keepalive ping should arrive before timeout")
-            .expect("keepalive ping should be sent");
+        let message = timeout(Duration::from_secs(1), server_websocket.next())
+            .await?
+            .expect("websocket should stay open")?;
         assert!(matches!(message, Message::Ping(_)));
 
         drop(connection);
+        Ok(())
+    }
+
+    async fn websocket_pair() -> anyhow::Result<(
+        WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
+        WebSocketStream<tokio::net::TcpStream>,
+    )> {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let websocket_url = format!("ws://{}", listener.local_addr()?);
+        let server_task = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await?;
+            accept_async(stream).await.map_err(anyhow::Error::from)
+        });
+        let (client_websocket, _) = connect_async(websocket_url).await?;
+        let server_websocket = server_task.await??;
+        Ok((client_websocket, server_websocket))
     }
 }

--- a/codex-rs/exec-server/src/connection.rs
+++ b/codex-rs/exec-server/src/connection.rs
@@ -722,12 +722,17 @@ mod tests {
     #[tokio::test]
     async fn websocket_connection_keeps_outbound_message_while_send_is_backpressured()
     -> anyhow::Result<()> {
-        let (websocket, control, mut outbound_rx) = ControlledWebSocket::new(false);
-        let mut connection =
-            JsonRpcConnection::from_websocket_stream(websocket, "test".into(), None);
+        let (websocket, control, mut outbound_rx) =
+            ControlledWebSocket::new(/*write_ready*/ false);
+        let mut connection = JsonRpcConnection::from_websocket_stream(
+            websocket,
+            "test".into(),
+            /*ping_interval*/ None,
+        );
         let message = test_jsonrpc_message();
 
         connection.outgoing_tx.send(message.clone()).await?;
+        control.wait_for_blocked_write().await?;
         control.send_inbound(Message::Ping(b"check".to_vec().into()))?;
         assert!(
             timeout(Duration::from_millis(50), connection.incoming_rx.recv())
@@ -777,12 +782,16 @@ mod tests {
         inbound_rx: futures_mpsc::UnboundedReceiver<Result<Message, std::convert::Infallible>>,
         outbound_tx: futures_mpsc::UnboundedSender<Message>,
         write_ready: Arc<AtomicBool>,
+        write_blocked: Arc<AtomicBool>,
+        write_blocked_waker: Arc<AtomicWaker>,
         write_waker: Arc<AtomicWaker>,
     }
 
     struct ControlledWebSocketHandle {
         inbound_tx: futures_mpsc::UnboundedSender<Result<Message, std::convert::Infallible>>,
         write_ready: Arc<AtomicBool>,
+        write_blocked: Arc<AtomicBool>,
+        write_blocked_waker: Arc<AtomicWaker>,
         write_waker: Arc<AtomicWaker>,
     }
 
@@ -797,17 +806,23 @@ mod tests {
             let (inbound_tx, inbound_rx) = futures_mpsc::unbounded();
             let (outbound_tx, outbound_rx) = futures_mpsc::unbounded();
             let write_ready = Arc::new(AtomicBool::new(write_ready));
+            let write_blocked = Arc::new(AtomicBool::new(false));
+            let write_blocked_waker = Arc::new(AtomicWaker::new());
             let write_waker = Arc::new(AtomicWaker::new());
             (
                 Self {
                     inbound_rx,
                     outbound_tx,
                     write_ready: Arc::clone(&write_ready),
+                    write_blocked: Arc::clone(&write_blocked),
+                    write_blocked_waker: Arc::clone(&write_blocked_waker),
                     write_waker: Arc::clone(&write_waker),
                 },
                 ControlledWebSocketHandle {
                     inbound_tx,
                     write_ready,
+                    write_blocked,
+                    write_blocked_waker,
                     write_waker,
                 },
                 outbound_rx,
@@ -826,6 +841,22 @@ mod tests {
             self.write_ready.store(true, Ordering::Release);
             self.write_waker.wake();
         }
+
+        async fn wait_for_blocked_write(&self) -> anyhow::Result<()> {
+            timeout(
+                Duration::from_secs(1),
+                futures::future::poll_fn(|cx| {
+                    if self.write_blocked.load(Ordering::Acquire) {
+                        Poll::Ready(())
+                    } else {
+                        self.write_blocked_waker.register(cx.waker());
+                        Poll::Pending
+                    }
+                }),
+            )
+            .await?;
+            Ok(())
+        }
     }
 
     impl Sink<Message> for ControlledWebSocket {
@@ -835,6 +866,8 @@ mod tests {
             if self.write_ready.load(Ordering::Acquire) {
                 Poll::Ready(Ok(()))
             } else {
+                self.write_blocked.store(true, Ordering::Release);
+                self.write_blocked_waker.wake();
                 self.write_waker.register(cx.waker());
                 Poll::Pending
             }

--- a/codex-rs/exec-server/src/connection.rs
+++ b/codex-rs/exec-server/src/connection.rs
@@ -323,11 +323,11 @@ impl JsonRpcConnection {
     where
         S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     {
-        Self::from_websocket_stream(stream, connection_label, Some(WEBSOCKET_KEEPALIVE_INTERVAL))
+        Self::from_websocket_stream(stream, connection_label, /*ping_interval*/ None)
     }
 
     pub(crate) fn from_axum_websocket(stream: AxumWebSocket, connection_label: String) -> Self {
-        Self::from_websocket_stream(stream, connection_label, /*ping_interval*/ None)
+        Self::from_websocket_stream(stream, connection_label, Some(WEBSOCKET_KEEPALIVE_INTERVAL))
     }
 
     fn from_websocket_stream<T, M, E>(

--- a/codex-rs/exec-server/src/connection.rs
+++ b/codex-rs/exec-server/src/connection.rs
@@ -610,8 +610,17 @@ fn serialize_jsonrpc_message(message: &JSONRPCMessage) -> Result<String, serde_j
 
 #[cfg(test)]
 mod tests {
+    use std::pin::Pin;
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::Ordering;
+    use std::task::Context;
+    use std::task::Poll;
+
     use codex_app_server_protocol::JSONRPCRequest;
     use codex_app_server_protocol::RequestId;
+    use futures::channel::mpsc as futures_mpsc;
+    use futures::task::AtomicWaker;
     use tokio::net::TcpListener;
     use tokio::time::timeout;
     use tokio_tungstenite::accept_async;
@@ -710,6 +719,36 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn websocket_connection_keeps_outbound_message_while_send_is_backpressured()
+    -> anyhow::Result<()> {
+        let (websocket, control, mut outbound_rx) = ControlledWebSocket::new(false);
+        let mut connection =
+            JsonRpcConnection::from_websocket_stream(websocket, "test".into(), None);
+        let message = test_jsonrpc_message();
+
+        connection.outgoing_tx.send(message.clone()).await?;
+        control.send_inbound(Message::Ping(b"check".to_vec().into()))?;
+        assert!(
+            timeout(Duration::from_millis(50), connection.incoming_rx.recv())
+                .await
+                .is_err()
+        );
+
+        control.set_write_ready();
+        assert!(matches!(
+            timeout(Duration::from_secs(1), outbound_rx.next()).await?,
+            Some(Message::Text(text)) if serde_json::from_str::<JSONRPCMessage>(&text)? == message
+        ));
+        assert!(matches!(
+            timeout(Duration::from_secs(1), outbound_rx.next()).await?,
+            Some(Message::Pong(payload)) if payload.as_ref() == b"check"
+        ));
+
+        drop(connection);
+        Ok(())
+    }
+
     async fn websocket_pair() -> anyhow::Result<(
         WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
         WebSocketStream<tokio::net::TcpStream>,
@@ -723,5 +762,111 @@ mod tests {
         let (client_websocket, _) = connect_async(websocket_url).await?;
         let server_websocket = server_task.await??;
         Ok((client_websocket, server_websocket))
+    }
+
+    fn test_jsonrpc_message() -> JSONRPCMessage {
+        JSONRPCMessage::Request(JSONRPCRequest {
+            id: RequestId::Integer(1),
+            method: "test".to_string(),
+            params: None,
+            trace: None,
+        })
+    }
+
+    struct ControlledWebSocket {
+        inbound_rx: futures_mpsc::UnboundedReceiver<Result<Message, std::convert::Infallible>>,
+        outbound_tx: futures_mpsc::UnboundedSender<Message>,
+        write_ready: Arc<AtomicBool>,
+        write_waker: Arc<AtomicWaker>,
+    }
+
+    struct ControlledWebSocketHandle {
+        inbound_tx: futures_mpsc::UnboundedSender<Result<Message, std::convert::Infallible>>,
+        write_ready: Arc<AtomicBool>,
+        write_waker: Arc<AtomicWaker>,
+    }
+
+    impl ControlledWebSocket {
+        fn new(
+            write_ready: bool,
+        ) -> (
+            Self,
+            ControlledWebSocketHandle,
+            futures_mpsc::UnboundedReceiver<Message>,
+        ) {
+            let (inbound_tx, inbound_rx) = futures_mpsc::unbounded();
+            let (outbound_tx, outbound_rx) = futures_mpsc::unbounded();
+            let write_ready = Arc::new(AtomicBool::new(write_ready));
+            let write_waker = Arc::new(AtomicWaker::new());
+            (
+                Self {
+                    inbound_rx,
+                    outbound_tx,
+                    write_ready: Arc::clone(&write_ready),
+                    write_waker: Arc::clone(&write_waker),
+                },
+                ControlledWebSocketHandle {
+                    inbound_tx,
+                    write_ready,
+                    write_waker,
+                },
+                outbound_rx,
+            )
+        }
+    }
+
+    impl ControlledWebSocketHandle {
+        fn send_inbound(&self, message: Message) -> anyhow::Result<()> {
+            self.inbound_tx
+                .unbounded_send(Ok(message))
+                .map_err(anyhow::Error::from)
+        }
+
+        fn set_write_ready(&self) {
+            self.write_ready.store(true, Ordering::Release);
+            self.write_waker.wake();
+        }
+    }
+
+    impl Sink<Message> for ControlledWebSocket {
+        type Error = std::convert::Infallible;
+
+        fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            if self.write_ready.load(Ordering::Acquire) {
+                Poll::Ready(Ok(()))
+            } else {
+                self.write_waker.register(cx.waker());
+                Poll::Pending
+            }
+        }
+
+        fn start_send(self: Pin<&mut Self>, item: Message) -> Result<(), Self::Error> {
+            self.outbound_tx
+                .unbounded_send(item)
+                .expect("test outbound receiver should stay open");
+            Ok(())
+        }
+
+        fn poll_flush(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_close(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl Stream for ControlledWebSocket {
+        type Item = Result<Message, std::convert::Infallible>;
+
+        fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            Pin::new(&mut self.inbound_rx).poll_next(cx)
+        }
     }
 }

--- a/codex-rs/exec-server/src/environment.rs
+++ b/codex-rs/exec-server/src/environment.rs
@@ -6,7 +6,7 @@ use crate::ExecServerError;
 use crate::ExecServerRuntimePaths;
 use crate::ExecutorFileSystem;
 use crate::HttpClient;
-use crate::client::LazyRemoteExecServerClient;
+use crate::client::RemoteExecServerClient;
 use crate::client::http_client::ReqwestHttpClient;
 use crate::client_api::ExecServerTransportParams;
 use crate::environment_provider::DefaultEnvironmentProvider;
@@ -403,7 +403,7 @@ impl Environment {
             } => Some(exec_server_url.clone()),
             ExecServerTransportParams::StdioCommand { .. } => None,
         };
-        let client = LazyRemoteExecServerClient::new(remote_transport.clone());
+        let client = RemoteExecServerClient::new(remote_transport.clone());
         let exec_backend: Arc<dyn ExecBackend> = Arc::new(RemoteProcess::new(client.clone()));
         let filesystem: Arc<dyn ExecutorFileSystem> =
             Arc::new(RemoteFileSystem::new(client.clone()));

--- a/codex-rs/exec-server/src/lib.rs
+++ b/codex-rs/exec-server/src/lib.rs
@@ -23,8 +23,9 @@ mod runtime_paths;
 mod sandboxed_file_system;
 mod server;
 
-pub use client::ExecServerClient;
+pub use client::ExecServerConnection;
 pub use client::ExecServerError;
+pub type ExecServerClient = ExecServerConnection;
 pub use client::http_client::HttpResponseBodyStream;
 pub use client::http_client::ReqwestHttpClient;
 pub use client_api::ExecServerClientConnectOptions;

--- a/codex-rs/exec-server/src/process.rs
+++ b/codex-rs/exec-server/src/process.rs
@@ -23,13 +23,16 @@ pub struct StartedExecProcess {
 /// The stream is scoped to one [`ExecProcess`] handle. `Output` events carry
 /// stdout, stderr, or pty bytes. `Exited` reports the process exit status, while
 /// `Closed` means all output streams have ended and no more output events will
-/// arrive. `Failed` is used when the process session cannot continue, for
-/// example because the remote executor connection disconnected.
+/// arrive. `ResyncRequired` means a reconnecting remote process session should
+/// recover through [`ExecProcess::read`] using its last delivered sequence.
+/// `Failed` is used when the process session cannot continue, for example
+/// because a direct one-shot executor connection disconnected.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ExecProcessEvent {
     Output(ProcessOutputChunk),
     Exited { seq: u64, exit_code: i32 },
     Closed { seq: u64 },
+    ResyncRequired,
     Failed(String),
 }
 
@@ -60,13 +63,14 @@ struct ExecProcessEventHistory {
 impl ExecProcessEvent {
     /// Sequence number used to order process-owned events.
     ///
-    /// `Failed` is intentionally unsequenced because it is synthesized by the
-    /// client when the session or transport fails, not emitted by the process.
+    /// `ResyncRequired` and `Failed` are intentionally unsequenced because they
+    /// are synthesized by the client when the session or transport changes,
+    /// not emitted by the process.
     pub(crate) fn seq(&self) -> Option<u64> {
         match self {
             ExecProcessEvent::Output(chunk) => Some(chunk.seq),
             ExecProcessEvent::Exited { seq, .. } | ExecProcessEvent::Closed { seq } => Some(*seq),
-            ExecProcessEvent::Failed(_) => None,
+            ExecProcessEvent::ResyncRequired | ExecProcessEvent::Failed(_) => None,
         }
     }
 
@@ -74,7 +78,9 @@ impl ExecProcessEvent {
         match self {
             ExecProcessEvent::Output(chunk) => chunk.chunk.0.len(),
             ExecProcessEvent::Failed(message) => message.len(),
-            ExecProcessEvent::Exited { .. } | ExecProcessEvent::Closed { .. } => 0,
+            ExecProcessEvent::Exited { .. }
+            | ExecProcessEvent::Closed { .. }
+            | ExecProcessEvent::ResyncRequired => 0,
         }
     }
 }

--- a/codex-rs/exec-server/src/relay.rs
+++ b/codex-rs/exec-server/src/relay.rs
@@ -19,7 +19,6 @@ use crate::connection::CHANNEL_CAPACITY;
 use crate::connection::JsonRpcConnection;
 use crate::connection::JsonRpcConnectionEvent;
 use crate::connection::JsonRpcTransport;
-use crate::connection::WEBSOCKET_KEEPALIVE_INTERVAL;
 use crate::relay_proto::RelayData;
 use crate::relay_proto::RelayMessageFrame;
 use crate::relay_proto::RelayResume;
@@ -148,113 +147,16 @@ where
     S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
     let stream_id = Uuid::new_v4().to_string();
-    let (mut websocket_writer, mut websocket_reader) = stream.split();
     let (outgoing_tx, mut outgoing_rx) = mpsc::channel(CHANNEL_CAPACITY);
     let (incoming_tx, incoming_rx) = mpsc::channel(CHANNEL_CAPACITY);
     let (disconnected_tx, disconnected_rx) = watch::channel(false);
 
-    let reader_label = connection_label;
-    let reader_stream_id = stream_id.clone();
-    let incoming_tx_for_reader = incoming_tx;
-    let disconnected_tx_for_reader = disconnected_tx.clone();
-    let reader_task = tokio::spawn(async move {
-        loop {
-            match websocket_reader.next().await {
-                Some(Ok(Message::Binary(payload))) => {
-                    let frame = match decode_relay_message_frame(payload.as_ref()) {
-                        Ok(frame) => frame,
-                        Err(err) => {
-                            let _ = incoming_tx_for_reader
-                                .send(JsonRpcConnectionEvent::MalformedMessage {
-                                    reason: format!(
-                                        "failed to parse relay message frame from {reader_label}: {err}"
-                                    ),
-                                })
-                                .await;
-                            continue;
-                        }
-                    };
-                    if frame.stream_id != reader_stream_id {
-                        continue;
-                    }
-                    let kind = match frame.validate() {
-                        Ok(kind) => kind,
-                        Err(err) => {
-                            let _ = incoming_tx_for_reader
-                                .send(JsonRpcConnectionEvent::MalformedMessage {
-                                    reason: err.to_string(),
-                                })
-                                .await;
-                            continue;
-                        }
-                    };
-                    match kind {
-                        RelayFrameBodyKind::Data => match frame.into_jsonrpc_message() {
-                            Ok(message) => {
-                                if incoming_tx_for_reader
-                                    .send(JsonRpcConnectionEvent::Message(message))
-                                    .await
-                                    .is_err()
-                                {
-                                    break;
-                                }
-                            }
-                            Err(err) => {
-                                let _ = incoming_tx_for_reader
-                                    .send(JsonRpcConnectionEvent::MalformedMessage {
-                                        reason: err.to_string(),
-                                    })
-                                    .await;
-                            }
-                        },
-                        RelayFrameBodyKind::Reset => {
-                            let _ = disconnected_tx_for_reader.send(true);
-                            let _ = incoming_tx_for_reader
-                                .send(JsonRpcConnectionEvent::Disconnected {
-                                    reason: frame.into_reset_reason(),
-                                })
-                                .await;
-                            break;
-                        }
-                        RelayFrameBodyKind::Ack
-                        | RelayFrameBodyKind::Resume
-                        | RelayFrameBodyKind::Heartbeat => {}
-                    }
-                }
-                Some(Ok(Message::Close(_))) | None => {
-                    let _ = disconnected_tx_for_reader.send(true);
-                    let _ = incoming_tx_for_reader
-                        .send(JsonRpcConnectionEvent::Disconnected { reason: None })
-                        .await;
-                    break;
-                }
-                Some(Ok(Message::Ping(_) | Message::Pong(_) | Message::Frame(_))) => {}
-                Some(Ok(Message::Text(_))) => {
-                    let _ = incoming_tx_for_reader
-                        .send(JsonRpcConnectionEvent::MalformedMessage {
-                            reason: "relay exec-server transport expects binary protobuf frames"
-                                .to_string(),
-                        })
-                        .await;
-                }
-                Some(Err(err)) => {
-                    let _ = disconnected_tx_for_reader.send(true);
-                    let _ = incoming_tx_for_reader
-                        .send(JsonRpcConnectionEvent::Disconnected {
-                            reason: Some(format!(
-                                "failed to read relay websocket frame from {reader_label}: {err}"
-                            )),
-                        })
-                        .await;
-                    break;
-                }
-            }
-        }
-    });
-
-    let writer_task = tokio::spawn(async move {
+    let websocket_task = tokio::spawn(async move {
+        let mut websocket = stream;
+        let reader_label = connection_label;
+        let reader_stream_id = stream_id.clone();
         let resume = RelayMessageFrame::resume(stream_id.clone());
-        if websocket_writer
+        if websocket
             .send(Message::Binary(encode_relay_message_frame(&resume).into()))
             .await
             .is_err()
@@ -263,11 +165,6 @@ where
             return;
         }
 
-        let mut keepalive = tokio::time::interval_at(
-            tokio::time::Instant::now() + WEBSOCKET_KEEPALIVE_INTERVAL,
-            WEBSOCKET_KEEPALIVE_INTERVAL,
-        );
-        keepalive.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         let mut next_seq = 0u32;
         loop {
             tokio::select! {
@@ -284,7 +181,7 @@ where
                     };
                     let frame = RelayMessageFrame::data(stream_id.clone(), next_seq, payload);
                     next_seq = next_seq.wrapping_add(1);
-                    if websocket_writer
+                    if websocket
                         .send(Message::Binary(encode_relay_message_frame(&frame).into()))
                         .await
                         .is_err()
@@ -293,10 +190,102 @@ where
                         break;
                     }
                 }
-                _ = keepalive.tick() => {
-                    if websocket_writer.send(Message::Ping(Vec::new().into())).await.is_err() {
-                        let _ = disconnected_tx.send(true);
-                        break;
+                incoming_message = websocket.next() => {
+                    match incoming_message {
+                        Some(Ok(Message::Binary(payload))) => {
+                            let frame = match decode_relay_message_frame(payload.as_ref()) {
+                                Ok(frame) => frame,
+                                Err(err) => {
+                                    let _ = incoming_tx
+                                        .send(JsonRpcConnectionEvent::MalformedMessage {
+                                            reason: format!(
+                                                "failed to parse relay message frame from {reader_label}: {err}"
+                                            ),
+                                        })
+                                        .await;
+                                    continue;
+                                }
+                            };
+                            if frame.stream_id != reader_stream_id {
+                                continue;
+                            }
+                            let kind = match frame.validate() {
+                                Ok(kind) => kind,
+                                Err(err) => {
+                                    let _ = incoming_tx
+                                        .send(JsonRpcConnectionEvent::MalformedMessage {
+                                            reason: err.to_string(),
+                                        })
+                                        .await;
+                                    continue;
+                                }
+                            };
+                            match kind {
+                                RelayFrameBodyKind::Data => match frame.into_jsonrpc_message() {
+                                    Ok(message) => {
+                                        if incoming_tx
+                                            .send(JsonRpcConnectionEvent::Message(message))
+                                            .await
+                                            .is_err()
+                                        {
+                                            break;
+                                        }
+                                    }
+                                    Err(err) => {
+                                        let _ = incoming_tx
+                                            .send(JsonRpcConnectionEvent::MalformedMessage {
+                                                reason: err.to_string(),
+                                            })
+                                            .await;
+                                    }
+                                },
+                                RelayFrameBodyKind::Reset => {
+                                    let _ = disconnected_tx.send(true);
+                                    let _ = incoming_tx
+                                        .send(JsonRpcConnectionEvent::Disconnected {
+                                            reason: frame.into_reset_reason(),
+                                        })
+                                        .await;
+                                    break;
+                                }
+                                RelayFrameBodyKind::Ack
+                                | RelayFrameBodyKind::Resume
+                                | RelayFrameBodyKind::Heartbeat => {}
+                            }
+                        }
+                        Some(Ok(Message::Ping(payload))) => {
+                            if websocket.send(Message::Pong(payload)).await.is_err() {
+                                let _ = disconnected_tx.send(true);
+                                break;
+                            }
+                        }
+                        Some(Ok(Message::Close(_))) | None => {
+                            let _ = disconnected_tx.send(true);
+                            let _ = incoming_tx
+                                .send(JsonRpcConnectionEvent::Disconnected { reason: None })
+                                .await;
+                            break;
+                        }
+                        Some(Ok(Message::Pong(_) | Message::Frame(_))) => {}
+                        Some(Ok(Message::Text(_))) => {
+                            let _ = incoming_tx
+                                .send(JsonRpcConnectionEvent::MalformedMessage {
+                                    reason: "relay exec-server transport expects binary protobuf frames"
+                                        .to_string(),
+                                })
+                                .await;
+                        }
+                        Some(Err(err)) => {
+                            let _ = disconnected_tx.send(true);
+                            let _ = incoming_tx
+                                .send(JsonRpcConnectionEvent::Disconnected {
+                                    reason: Some(format!(
+                                        "failed to read relay websocket frame from {reader_label}: {err}"
+                                    )),
+                                })
+                                .await;
+                            break;
+                        }
                     }
                 }
             }
@@ -307,7 +296,7 @@ where
         outgoing_tx,
         incoming_rx,
         disconnected_rx,
-        task_handles: vec![reader_task, writer_task],
+        task_handles: vec![websocket_task],
         transport: JsonRpcTransport::Plain,
     }
 }
@@ -318,59 +307,48 @@ pub(crate) async fn run_multiplexed_executor<S>(
 ) where
     S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
-    let (mut websocket_writer, mut websocket_reader) = stream.split();
+    let mut websocket = stream;
     let (physical_outgoing_tx, mut physical_outgoing_rx) =
         mpsc::channel::<Vec<u8>>(CHANNEL_CAPACITY);
-    let writer_task = tokio::spawn(async move {
-        let mut keepalive = tokio::time::interval_at(
-            tokio::time::Instant::now() + WEBSOCKET_KEEPALIVE_INTERVAL,
-            WEBSOCKET_KEEPALIVE_INTERVAL,
-        );
-        keepalive.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-        loop {
-            tokio::select! {
-                maybe_encoded = physical_outgoing_rx.recv() => {
-                    let Some(encoded) = maybe_encoded else {
-                        break;
-                    };
-                    if websocket_writer
-                        .send(Message::Binary(encoded.into()))
-                        .await
-                        .is_err()
-                    {
-                        break;
-                    }
-                }
-                _ = keepalive.tick() => {
-                    if websocket_writer.send(Message::Ping(Vec::new().into())).await.is_err() {
-                        break;
-                    }
-                }
-            }
-        }
-    });
 
     let mut streams: HashMap<String, VirtualStream> = HashMap::new();
     loop {
-        let frame = match websocket_reader.next().await {
-            Some(Ok(Message::Binary(payload))) => {
-                match decode_relay_message_frame(payload.as_ref()) {
-                    Ok(frame) => frame,
-                    Err(err) => {
-                        warn!("dropping malformed relay message frame from harness: {err}");
-                        continue;
-                    }
+        let frame = tokio::select! {
+            maybe_encoded = physical_outgoing_rx.recv() => {
+                let Some(encoded) = maybe_encoded else {
+                    break;
+                };
+                if websocket.send(Message::Binary(encoded.into())).await.is_err() {
+                    break;
                 }
-            }
-            Some(Ok(Message::Close(_))) | None => break,
-            Some(Ok(Message::Ping(_) | Message::Pong(_) | Message::Frame(_))) => continue,
-            Some(Ok(Message::Text(_))) => {
-                warn!("dropping non-binary relay message frame from harness");
                 continue;
             }
-            Some(Err(err)) => {
-                debug!("multiplexed executor websocket read failed: {err}");
-                break;
+            incoming_message = websocket.next() => match incoming_message {
+                Some(Ok(Message::Binary(payload))) => {
+                    match decode_relay_message_frame(payload.as_ref()) {
+                        Ok(frame) => frame,
+                        Err(err) => {
+                            warn!("dropping malformed relay message frame from harness: {err}");
+                            continue;
+                        }
+                    }
+                }
+                Some(Ok(Message::Ping(payload))) => {
+                    if websocket.send(Message::Pong(payload)).await.is_err() {
+                        break;
+                    }
+                    continue;
+                }
+                Some(Ok(Message::Close(_))) | None => break,
+                Some(Ok(Message::Pong(_) | Message::Frame(_))) => continue,
+                Some(Ok(Message::Text(_))) => {
+                    warn!("dropping non-binary relay message frame from harness");
+                    continue;
+                }
+                Some(Err(err)) => {
+                    debug!("multiplexed executor websocket read failed: {err}");
+                    break;
+                }
             }
         };
 
@@ -423,7 +401,6 @@ pub(crate) async fn run_multiplexed_executor<S>(
         stream.disconnect(/*reason*/ None).await;
     }
     drop(physical_outgoing_tx);
-    let _ = writer_task.await;
 }
 
 struct VirtualStream {
@@ -511,14 +488,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn multiplexed_executor_sends_keepalive_ping() -> anyhow::Result<()> {
+    async fn multiplexed_executor_pongs_server_ping() -> anyhow::Result<()> {
         let (client_websocket, mut server_websocket) = websocket_pair().await?;
         let executor_task = tokio::spawn(run_multiplexed_executor(
             client_websocket,
             ConnectionProcessor::new(test_runtime_paths()?),
         ));
 
-        read_keepalive_ping(&mut server_websocket).await?;
+        server_websocket
+            .send(Message::Ping(b"check".to_vec().into()))
+            .await?;
+        read_pong(&mut server_websocket).await?;
 
         executor_task.abort();
         let _ = executor_task.await;
@@ -526,11 +506,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn harness_connection_sends_keepalive_ping() -> anyhow::Result<()> {
+    async fn harness_connection_pongs_server_ping() -> anyhow::Result<()> {
         let (client_websocket, mut server_websocket) = websocket_pair().await?;
         let connection = harness_connection_from_websocket(client_websocket, "test".to_string());
 
-        read_keepalive_ping(&mut server_websocket).await?;
+        server_websocket
+            .send(Message::Ping(b"check".to_vec().into()))
+            .await?;
+        read_pong(&mut server_websocket).await?;
 
         drop(connection);
         Ok(())
@@ -551,17 +534,21 @@ mod tests {
         Ok((client_websocket, server_websocket))
     }
 
-    async fn read_keepalive_ping(
+    async fn read_pong(
         websocket: &mut WebSocketStream<tokio::net::TcpStream>,
     ) -> anyhow::Result<()> {
         loop {
             let Some(message) = timeout(Duration::from_secs(1), websocket.next()).await? else {
-                anyhow::bail!("websocket closed before keepalive ping");
+                anyhow::bail!("websocket closed before pong");
             };
             match message? {
-                Message::Ping(_) => return Ok(()),
-                Message::Binary(_) | Message::Text(_) | Message::Pong(_) | Message::Frame(_) => {}
-                Message::Close(_) => anyhow::bail!("websocket closed before keepalive ping"),
+                Message::Pong(payload) if payload.as_ref() == b"check" => return Ok(()),
+                Message::Binary(_)
+                | Message::Text(_)
+                | Message::Ping(_)
+                | Message::Pong(_)
+                | Message::Frame(_) => {}
+                Message::Close(_) => anyhow::bail!("websocket closed before pong"),
             }
         }
     }

--- a/codex-rs/exec-server/src/relay.rs
+++ b/codex-rs/exec-server/src/relay.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 
 use codex_app_server_protocol::JSONRPCMessage;
+use futures::Sink;
 use futures::SinkExt;
+use futures::Stream;
 use futures::StreamExt;
 use prost::Message as ProstMessage;
 use tokio::io::AsyncRead;
@@ -140,12 +142,13 @@ fn jsonrpc_payload(message: &JSONRPCMessage) -> Result<Vec<u8>, ExecServerError>
     serde_json::to_vec(message).map_err(ExecServerError::Json)
 }
 
-pub(crate) fn harness_connection_from_websocket<S>(
-    stream: WebSocketStream<S>,
+pub(crate) fn harness_connection_from_websocket<T, E>(
+    stream: T,
     connection_label: String,
 ) -> JsonRpcConnection
 where
-    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    T: Sink<Message, Error = E> + Stream<Item = Result<Message, E>> + Unpin + Send + 'static,
+    E: std::fmt::Display + Send + 'static,
 {
     let stream_id = Uuid::new_v4().to_string();
     let (outgoing_tx, mut outgoing_rx) = mpsc::channel(CHANNEL_CAPACITY);
@@ -492,10 +495,20 @@ fn spawn_virtual_stream(
 
 #[cfg(test)]
 mod tests {
+    use std::pin::Pin;
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::Ordering;
+    use std::task::Context;
+    use std::task::Poll;
     use std::time::Duration;
 
     use codex_app_server_protocol::JSONRPCRequest;
     use codex_app_server_protocol::RequestId;
+    use futures::Sink;
+    use futures::Stream;
+    use futures::channel::mpsc as futures_mpsc;
+    use futures::task::AtomicWaker;
     use tokio::net::TcpListener;
     use tokio::time::timeout;
     use tokio_tungstenite::accept_async;
@@ -606,6 +619,48 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn harness_connection_keeps_outbound_frame_while_send_is_backpressured()
+    -> anyhow::Result<()> {
+        let (websocket, control, mut outbound_rx) = ControlledWebSocket::new(true);
+        let mut connection = harness_connection_from_websocket(websocket, "test".to_string());
+        let Message::Binary(resume_payload) = timeout(Duration::from_secs(1), outbound_rx.next())
+            .await?
+            .expect("resume frame")
+        else {
+            anyhow::bail!("expected relay resume frame");
+        };
+        let stream_id = decode_relay_message_frame(resume_payload.as_ref())?.stream_id;
+        let message = test_jsonrpc_message();
+
+        control.set_write_blocked();
+        connection.outgoing_tx.send(message.clone()).await?;
+        control.send_inbound(Message::Ping(b"check".to_vec().into()))?;
+        assert!(
+            timeout(Duration::from_millis(50), connection.incoming_rx.recv())
+                .await
+                .is_err()
+        );
+
+        control.set_write_ready();
+        let Message::Binary(data_payload) = timeout(Duration::from_secs(1), outbound_rx.next())
+            .await?
+            .expect("data frame")
+        else {
+            anyhow::bail!("expected relay data frame");
+        };
+        let frame = decode_relay_message_frame(data_payload.as_ref())?;
+        assert_eq!(frame.stream_id, stream_id);
+        assert_eq!(frame.into_jsonrpc_message()?, message);
+        assert!(matches!(
+            timeout(Duration::from_secs(1), outbound_rx.next()).await?,
+            Some(Message::Pong(payload)) if payload.as_ref() == b"check"
+        ));
+
+        drop(connection);
+        Ok(())
+    }
+
     async fn websocket_pair() -> anyhow::Result<(
         WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
         WebSocketStream<tokio::net::TcpStream>,
@@ -660,6 +715,107 @@ mod tests {
                 | Message::Frame(_) => {}
                 Message::Close(_) => anyhow::bail!("websocket closed before pong"),
             }
+        }
+    }
+
+    struct ControlledWebSocket {
+        inbound_rx: futures_mpsc::UnboundedReceiver<Result<Message, std::convert::Infallible>>,
+        outbound_tx: futures_mpsc::UnboundedSender<Message>,
+        write_ready: Arc<AtomicBool>,
+        write_waker: Arc<AtomicWaker>,
+    }
+
+    struct ControlledWebSocketHandle {
+        inbound_tx: futures_mpsc::UnboundedSender<Result<Message, std::convert::Infallible>>,
+        write_ready: Arc<AtomicBool>,
+        write_waker: Arc<AtomicWaker>,
+    }
+
+    impl ControlledWebSocket {
+        fn new(
+            write_ready: bool,
+        ) -> (
+            Self,
+            ControlledWebSocketHandle,
+            futures_mpsc::UnboundedReceiver<Message>,
+        ) {
+            let (inbound_tx, inbound_rx) = futures_mpsc::unbounded();
+            let (outbound_tx, outbound_rx) = futures_mpsc::unbounded();
+            let write_ready = Arc::new(AtomicBool::new(write_ready));
+            let write_waker = Arc::new(AtomicWaker::new());
+            (
+                Self {
+                    inbound_rx,
+                    outbound_tx,
+                    write_ready: Arc::clone(&write_ready),
+                    write_waker: Arc::clone(&write_waker),
+                },
+                ControlledWebSocketHandle {
+                    inbound_tx,
+                    write_ready,
+                    write_waker,
+                },
+                outbound_rx,
+            )
+        }
+    }
+
+    impl ControlledWebSocketHandle {
+        fn send_inbound(&self, message: Message) -> anyhow::Result<()> {
+            self.inbound_tx
+                .unbounded_send(Ok(message))
+                .map_err(anyhow::Error::from)
+        }
+
+        fn set_write_blocked(&self) {
+            self.write_ready.store(false, Ordering::Release);
+        }
+
+        fn set_write_ready(&self) {
+            self.write_ready.store(true, Ordering::Release);
+            self.write_waker.wake();
+        }
+    }
+
+    impl Sink<Message> for ControlledWebSocket {
+        type Error = std::convert::Infallible;
+
+        fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            if self.write_ready.load(Ordering::Acquire) {
+                Poll::Ready(Ok(()))
+            } else {
+                self.write_waker.register(cx.waker());
+                Poll::Pending
+            }
+        }
+
+        fn start_send(self: Pin<&mut Self>, item: Message) -> Result<(), Self::Error> {
+            self.outbound_tx
+                .unbounded_send(item)
+                .expect("test outbound receiver should stay open");
+            Ok(())
+        }
+
+        fn poll_flush(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_close(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl Stream for ControlledWebSocket {
+        type Item = Result<Message, std::convert::Infallible>;
+
+        fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            Pin::new(&mut self.inbound_rx).poll_next(cx)
         }
     }
 }

--- a/codex-rs/exec-server/src/relay.rs
+++ b/codex-rs/exec-server/src/relay.rs
@@ -268,12 +268,6 @@ where
                                 | RelayFrameBodyKind::Heartbeat => {}
                             }
                         }
-                        Some(Ok(Message::Ping(payload))) => {
-                            if websocket.send(Message::Pong(payload)).await.is_err() {
-                                let _ = disconnected_tx.send(true);
-                                break;
-                            }
-                        }
                         Some(Ok(Message::Close(_))) | None => {
                             let _ = disconnected_tx.send(true);
                             let _ = incoming_tx
@@ -281,7 +275,7 @@ where
                                 .await;
                             break;
                         }
-                        Some(Ok(Message::Pong(_) | Message::Frame(_))) => {}
+                        Some(Ok(Message::Ping(_) | Message::Pong(_) | Message::Frame(_))) => {}
                         Some(Ok(Message::Text(_))) => {
                             let _ = incoming_tx
                                 .send(JsonRpcConnectionEvent::MalformedMessage {
@@ -359,14 +353,8 @@ pub(crate) async fn run_multiplexed_executor<S>(
                         }
                     }
                 }
-                Some(Ok(Message::Ping(payload))) => {
-                    if websocket.send(Message::Pong(payload)).await.is_err() {
-                        break;
-                    }
-                    continue;
-                }
                 Some(Ok(Message::Close(_))) | None => break,
-                Some(Ok(Message::Pong(_) | Message::Frame(_))) => continue,
+                Some(Ok(Message::Ping(_) | Message::Pong(_) | Message::Frame(_))) => continue,
                 Some(Ok(Message::Text(_))) => {
                     warn!("dropping non-binary relay message frame from harness");
                     continue;
@@ -517,46 +505,6 @@ mod tests {
 
     use super::*;
 
-    fn test_runtime_paths() -> anyhow::Result<crate::ExecServerRuntimePaths> {
-        crate::ExecServerRuntimePaths::new(
-            std::env::current_exe()?,
-            /*codex_linux_sandbox_exe*/ None,
-        )
-        .map_err(anyhow::Error::from)
-    }
-
-    #[tokio::test]
-    async fn multiplexed_executor_pongs_server_ping() -> anyhow::Result<()> {
-        let (client_websocket, mut server_websocket) = websocket_pair().await?;
-        let executor_task = tokio::spawn(run_multiplexed_executor(
-            client_websocket,
-            ConnectionProcessor::new(test_runtime_paths()?),
-        ));
-
-        server_websocket
-            .send(Message::Ping(b"check".to_vec().into()))
-            .await?;
-        read_pong(&mut server_websocket).await?;
-
-        executor_task.abort();
-        let _ = executor_task.await;
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn harness_connection_pongs_server_ping() -> anyhow::Result<()> {
-        let (client_websocket, mut server_websocket) = websocket_pair().await?;
-        let connection = harness_connection_from_websocket(client_websocket, "test".to_string());
-
-        server_websocket
-            .send(Message::Ping(b"check".to_vec().into()))
-            .await?;
-        read_pong(&mut server_websocket).await?;
-
-        drop(connection);
-        Ok(())
-    }
-
     #[tokio::test]
     async fn harness_connection_receives_relay_data() -> anyhow::Result<()> {
         let (client_websocket, mut server_websocket) = websocket_pair().await?;
@@ -637,7 +585,7 @@ mod tests {
         control.set_write_blocked();
         connection.outgoing_tx.send(message.clone()).await?;
         control.wait_for_blocked_write().await?;
-        control.send_inbound(Message::Ping(b"check".to_vec().into()))?;
+        control.send_inbound(Message::Pong(b"check".to_vec().into()))?;
         assert!(
             timeout(Duration::from_millis(50), connection.incoming_rx.recv())
                 .await
@@ -654,11 +602,6 @@ mod tests {
         let frame = decode_relay_message_frame(data_payload.as_ref())?;
         assert_eq!(frame.stream_id, stream_id);
         assert_eq!(frame.into_jsonrpc_message()?, message);
-        assert!(matches!(
-            timeout(Duration::from_secs(1), outbound_rx.next()).await?,
-            Some(Message::Pong(payload)) if payload.as_ref() == b"check"
-        ));
-
         drop(connection);
         Ok(())
     }
@@ -699,25 +642,6 @@ mod tests {
             params: None,
             trace: None,
         })
-    }
-
-    async fn read_pong(
-        websocket: &mut WebSocketStream<tokio::net::TcpStream>,
-    ) -> anyhow::Result<()> {
-        loop {
-            let Some(message) = timeout(Duration::from_secs(1), websocket.next()).await? else {
-                anyhow::bail!("websocket closed before pong");
-            };
-            match message? {
-                Message::Pong(payload) if payload.as_ref() == b"check" => return Ok(()),
-                Message::Binary(_)
-                | Message::Text(_)
-                | Message::Ping(_)
-                | Message::Pong(_)
-                | Message::Frame(_) => {}
-                Message::Close(_) => anyhow::bail!("websocket closed before pong"),
-            }
-        }
     }
 
     struct ControlledWebSocket {

--- a/codex-rs/exec-server/src/relay.rs
+++ b/codex-rs/exec-server/src/relay.rs
@@ -19,6 +19,7 @@ use crate::connection::CHANNEL_CAPACITY;
 use crate::connection::JsonRpcConnection;
 use crate::connection::JsonRpcConnectionEvent;
 use crate::connection::JsonRpcTransport;
+use crate::connection::WEBSOCKET_KEEPALIVE_INTERVAL;
 use crate::relay_proto::RelayData;
 use crate::relay_proto::RelayMessageFrame;
 use crate::relay_proto::RelayResume;
@@ -166,6 +167,11 @@ where
         }
 
         let mut next_seq = 0u32;
+        let mut keepalive = tokio::time::interval_at(
+            tokio::time::Instant::now() + WEBSOCKET_KEEPALIVE_INTERVAL,
+            WEBSOCKET_KEEPALIVE_INTERVAL,
+        );
+        keepalive.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
             tokio::select! {
                 maybe_message = outgoing_rx.recv() => {
@@ -186,6 +192,12 @@ where
                         .await
                         .is_err()
                     {
+                        let _ = disconnected_tx.send(true);
+                        break;
+                    }
+                }
+                _ = keepalive.tick() => {
+                    if websocket.send(Message::Ping(Vec::new().into())).await.is_err() {
                         let _ = disconnected_tx.send(true);
                         break;
                     }
@@ -312,6 +324,11 @@ pub(crate) async fn run_multiplexed_executor<S>(
         mpsc::channel::<Vec<u8>>(CHANNEL_CAPACITY);
 
     let mut streams: HashMap<String, VirtualStream> = HashMap::new();
+    let mut keepalive = tokio::time::interval_at(
+        tokio::time::Instant::now() + WEBSOCKET_KEEPALIVE_INTERVAL,
+        WEBSOCKET_KEEPALIVE_INTERVAL,
+    );
+    keepalive.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     loop {
         let frame = tokio::select! {
             maybe_encoded = physical_outgoing_rx.recv() => {
@@ -319,6 +336,12 @@ pub(crate) async fn run_multiplexed_executor<S>(
                     break;
                 };
                 if websocket.send(Message::Binary(encoded.into())).await.is_err() {
+                    break;
+                }
+                continue;
+            }
+            _ = keepalive.tick() => {
+                if websocket.send(Message::Ping(Vec::new().into())).await.is_err() {
                     break;
                 }
                 continue;

--- a/codex-rs/exec-server/src/relay.rs
+++ b/codex-rs/exec-server/src/relay.rs
@@ -622,7 +622,8 @@ mod tests {
     #[tokio::test]
     async fn harness_connection_keeps_outbound_frame_while_send_is_backpressured()
     -> anyhow::Result<()> {
-        let (websocket, control, mut outbound_rx) = ControlledWebSocket::new(true);
+        let (websocket, control, mut outbound_rx) =
+            ControlledWebSocket::new(/*write_ready*/ true);
         let mut connection = harness_connection_from_websocket(websocket, "test".to_string());
         let Message::Binary(resume_payload) = timeout(Duration::from_secs(1), outbound_rx.next())
             .await?
@@ -635,6 +636,7 @@ mod tests {
 
         control.set_write_blocked();
         connection.outgoing_tx.send(message.clone()).await?;
+        control.wait_for_blocked_write().await?;
         control.send_inbound(Message::Ping(b"check".to_vec().into()))?;
         assert!(
             timeout(Duration::from_millis(50), connection.incoming_rx.recv())
@@ -722,12 +724,16 @@ mod tests {
         inbound_rx: futures_mpsc::UnboundedReceiver<Result<Message, std::convert::Infallible>>,
         outbound_tx: futures_mpsc::UnboundedSender<Message>,
         write_ready: Arc<AtomicBool>,
+        write_blocked: Arc<AtomicBool>,
+        write_blocked_waker: Arc<AtomicWaker>,
         write_waker: Arc<AtomicWaker>,
     }
 
     struct ControlledWebSocketHandle {
         inbound_tx: futures_mpsc::UnboundedSender<Result<Message, std::convert::Infallible>>,
         write_ready: Arc<AtomicBool>,
+        write_blocked: Arc<AtomicBool>,
+        write_blocked_waker: Arc<AtomicWaker>,
         write_waker: Arc<AtomicWaker>,
     }
 
@@ -742,17 +748,23 @@ mod tests {
             let (inbound_tx, inbound_rx) = futures_mpsc::unbounded();
             let (outbound_tx, outbound_rx) = futures_mpsc::unbounded();
             let write_ready = Arc::new(AtomicBool::new(write_ready));
+            let write_blocked = Arc::new(AtomicBool::new(false));
+            let write_blocked_waker = Arc::new(AtomicWaker::new());
             let write_waker = Arc::new(AtomicWaker::new());
             (
                 Self {
                     inbound_rx,
                     outbound_tx,
                     write_ready: Arc::clone(&write_ready),
+                    write_blocked: Arc::clone(&write_blocked),
+                    write_blocked_waker: Arc::clone(&write_blocked_waker),
                     write_waker: Arc::clone(&write_waker),
                 },
                 ControlledWebSocketHandle {
                     inbound_tx,
                     write_ready,
+                    write_blocked,
+                    write_blocked_waker,
                     write_waker,
                 },
                 outbound_rx,
@@ -775,6 +787,22 @@ mod tests {
             self.write_ready.store(true, Ordering::Release);
             self.write_waker.wake();
         }
+
+        async fn wait_for_blocked_write(&self) -> anyhow::Result<()> {
+            timeout(
+                Duration::from_secs(1),
+                futures::future::poll_fn(|cx| {
+                    if self.write_blocked.load(Ordering::Acquire) {
+                        Poll::Ready(())
+                    } else {
+                        self.write_blocked_waker.register(cx.waker());
+                        Poll::Pending
+                    }
+                }),
+            )
+            .await?;
+            Ok(())
+        }
     }
 
     impl Sink<Message> for ControlledWebSocket {
@@ -784,6 +812,8 @@ mod tests {
             if self.write_ready.load(Ordering::Acquire) {
                 Poll::Ready(Ok(()))
             } else {
+                self.write_blocked.store(true, Ordering::Release);
+                self.write_blocked_waker.wake();
                 self.write_waker.register(cx.waker());
                 Poll::Pending
             }

--- a/codex-rs/exec-server/src/relay.rs
+++ b/codex-rs/exec-server/src/relay.rs
@@ -471,6 +471,8 @@ fn spawn_virtual_stream(
 mod tests {
     use std::time::Duration;
 
+    use codex_app_server_protocol::JSONRPCRequest;
+    use codex_app_server_protocol::RequestId;
     use tokio::net::TcpListener;
     use tokio::time::timeout;
     use tokio_tungstenite::accept_async;
@@ -519,6 +521,68 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn harness_connection_receives_relay_data() -> anyhow::Result<()> {
+        let (client_websocket, mut server_websocket) = websocket_pair().await?;
+        let mut connection =
+            harness_connection_from_websocket(client_websocket, "test".to_string());
+        let stream_id = read_resume_stream_id(&mut server_websocket).await?;
+        let message = test_jsonrpc_message();
+
+        server_websocket
+            .send(Message::Binary(
+                encode_relay_message_frame(&RelayMessageFrame::data(
+                    stream_id,
+                    /*seq*/ 0,
+                    jsonrpc_payload(&message)?,
+                ))
+                .into(),
+            ))
+            .await?;
+        assert!(matches!(
+            timeout(Duration::from_secs(1), connection.incoming_rx.recv()).await?,
+            Some(JsonRpcConnectionEvent::Message(actual)) if actual == message
+        ));
+
+        drop(connection);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn harness_connection_reports_text_frames_as_malformed() -> anyhow::Result<()> {
+        let (client_websocket, mut server_websocket) = websocket_pair().await?;
+        let mut connection =
+            harness_connection_from_websocket(client_websocket, "test".to_string());
+
+        read_resume_stream_id(&mut server_websocket).await?;
+        server_websocket.send(Message::Text("nope".into())).await?;
+        assert!(matches!(
+            timeout(Duration::from_secs(1), connection.incoming_rx.recv()).await?,
+            Some(JsonRpcConnectionEvent::MalformedMessage { reason })
+                if reason == "relay exec-server transport expects binary protobuf frames"
+        ));
+
+        drop(connection);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn harness_connection_reports_server_close() -> anyhow::Result<()> {
+        let (client_websocket, mut server_websocket) = websocket_pair().await?;
+        let mut connection =
+            harness_connection_from_websocket(client_websocket, "test".to_string());
+
+        read_resume_stream_id(&mut server_websocket).await?;
+        server_websocket.close(None).await?;
+        assert!(matches!(
+            timeout(Duration::from_secs(1), connection.incoming_rx.recv()).await?,
+            Some(JsonRpcConnectionEvent::Disconnected { reason: None })
+        ));
+
+        drop(connection);
+        Ok(())
+    }
+
     async fn websocket_pair() -> anyhow::Result<(
         WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
         WebSocketStream<tokio::net::TcpStream>,
@@ -532,6 +596,29 @@ mod tests {
         let (client_websocket, _) = connect_async(websocket_url).await?;
         let server_websocket = server_task.await??;
         Ok((client_websocket, server_websocket))
+    }
+
+    async fn read_resume_stream_id(
+        websocket: &mut WebSocketStream<tokio::net::TcpStream>,
+    ) -> anyhow::Result<String> {
+        let message = timeout(Duration::from_secs(1), websocket.next())
+            .await?
+            .expect("websocket should stay open")?;
+        let Message::Binary(payload) = message else {
+            anyhow::bail!("expected relay resume frame, got {message:?}");
+        };
+        let frame = decode_relay_message_frame(payload.as_ref())?;
+        assert_eq!(frame.validate()?, RelayFrameBodyKind::Resume);
+        Ok(frame.stream_id)
+    }
+
+    fn test_jsonrpc_message() -> JSONRPCMessage {
+        JSONRPCMessage::Request(JSONRPCRequest {
+            id: RequestId::Integer(1),
+            method: "test".to_string(),
+            params: None,
+            trace: None,
+        })
     }
 
     async fn read_pong(

--- a/codex-rs/exec-server/src/remote_file_system.rs
+++ b/codex-rs/exec-server/src/remote_file_system.rs
@@ -14,7 +14,7 @@ use crate::FileSystemResult;
 use crate::FileSystemSandboxContext;
 use crate::ReadDirectoryEntry;
 use crate::RemoveOptions;
-use crate::client::LazyRemoteExecServerClient;
+use crate::client::RemoteExecServerClient;
 use crate::protocol::FsCopyParams;
 use crate::protocol::FsCreateDirectoryParams;
 use crate::protocol::FsGetMetadataParams;
@@ -28,11 +28,11 @@ const NOT_FOUND_ERROR_CODE: i64 = -32004;
 
 #[derive(Clone)]
 pub(crate) struct RemoteFileSystem {
-    client: LazyRemoteExecServerClient,
+    client: RemoteExecServerClient,
 }
 
 impl RemoteFileSystem {
-    pub(crate) fn new(client: LazyRemoteExecServerClient) -> Self {
+    pub(crate) fn new(client: RemoteExecServerClient) -> Self {
         trace!("remote fs new");
         Self { client }
     }
@@ -46,8 +46,8 @@ impl ExecutorFileSystem for RemoteFileSystem {
         sandbox: Option<&FileSystemSandboxContext>,
     ) -> FileSystemResult<Vec<u8>> {
         trace!("remote fs read_file");
-        let client = self.client.get().await.map_err(map_remote_error)?;
-        let response = client
+        let connection = self.client.connection().await.map_err(map_remote_error)?;
+        let response = connection
             .fs_read_file(FsReadFileParams {
                 path: path.clone(),
                 sandbox: remote_sandbox_context(sandbox),
@@ -69,8 +69,8 @@ impl ExecutorFileSystem for RemoteFileSystem {
         sandbox: Option<&FileSystemSandboxContext>,
     ) -> FileSystemResult<()> {
         trace!("remote fs write_file");
-        let client = self.client.get().await.map_err(map_remote_error)?;
-        client
+        let connection = self.client.connection().await.map_err(map_remote_error)?;
+        connection
             .fs_write_file(FsWriteFileParams {
                 path: path.clone(),
                 data_base64: STANDARD.encode(contents),
@@ -88,8 +88,8 @@ impl ExecutorFileSystem for RemoteFileSystem {
         sandbox: Option<&FileSystemSandboxContext>,
     ) -> FileSystemResult<()> {
         trace!("remote fs create_directory");
-        let client = self.client.get().await.map_err(map_remote_error)?;
-        client
+        let connection = self.client.connection().await.map_err(map_remote_error)?;
+        connection
             .fs_create_directory(FsCreateDirectoryParams {
                 path: path.clone(),
                 recursive: Some(options.recursive),
@@ -106,8 +106,8 @@ impl ExecutorFileSystem for RemoteFileSystem {
         sandbox: Option<&FileSystemSandboxContext>,
     ) -> FileSystemResult<FileMetadata> {
         trace!("remote fs get_metadata");
-        let client = self.client.get().await.map_err(map_remote_error)?;
-        let response = client
+        let connection = self.client.connection().await.map_err(map_remote_error)?;
+        let response = connection
             .fs_get_metadata(FsGetMetadataParams {
                 path: path.clone(),
                 sandbox: remote_sandbox_context(sandbox),
@@ -129,8 +129,8 @@ impl ExecutorFileSystem for RemoteFileSystem {
         sandbox: Option<&FileSystemSandboxContext>,
     ) -> FileSystemResult<Vec<ReadDirectoryEntry>> {
         trace!("remote fs read_directory");
-        let client = self.client.get().await.map_err(map_remote_error)?;
-        let response = client
+        let connection = self.client.connection().await.map_err(map_remote_error)?;
+        let response = connection
             .fs_read_directory(FsReadDirectoryParams {
                 path: path.clone(),
                 sandbox: remote_sandbox_context(sandbox),
@@ -155,8 +155,8 @@ impl ExecutorFileSystem for RemoteFileSystem {
         sandbox: Option<&FileSystemSandboxContext>,
     ) -> FileSystemResult<()> {
         trace!("remote fs remove");
-        let client = self.client.get().await.map_err(map_remote_error)?;
-        client
+        let connection = self.client.connection().await.map_err(map_remote_error)?;
+        connection
             .fs_remove(FsRemoveParams {
                 path: path.clone(),
                 recursive: Some(options.recursive),
@@ -176,8 +176,8 @@ impl ExecutorFileSystem for RemoteFileSystem {
         sandbox: Option<&FileSystemSandboxContext>,
     ) -> FileSystemResult<()> {
         trace!("remote fs copy");
-        let client = self.client.get().await.map_err(map_remote_error)?;
-        client
+        let connection = self.client.connection().await.map_err(map_remote_error)?;
+        connection
             .fs_copy(FsCopyParams {
                 source_path: source_path.clone(),
                 destination_path: destination_path.clone(),

--- a/codex-rs/exec-server/src/remote_process.rs
+++ b/codex-rs/exec-server/src/remote_process.rs
@@ -1,8 +1,10 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use tokio::runtime::Handle;
 use tokio::sync::watch;
 use tracing::trace;
+use tracing::warn;
 
 use crate::ExecBackend;
 use crate::ExecProcess;
@@ -35,8 +37,7 @@ impl RemoteProcess {
 impl ExecBackend for RemoteProcess {
     async fn start(&self, params: ExecParams) -> Result<StartedExecProcess, ExecServerError> {
         let process_id = params.process_id.clone();
-        let session = self.client.register_process_session(&process_id).await?;
-        let connection = self.client.connection().await?;
+        let (session, connection) = self.client.register_process_session(&process_id).await?;
         if let Err(err) = connection.exec(params).await {
             session.unregister().await;
             return Err(err);
@@ -85,8 +86,14 @@ impl ExecProcess for RemoteExecProcess {
 impl Drop for RemoteExecProcess {
     fn drop(&mut self) {
         let session = self.session.clone();
-        tokio::spawn(async move {
+        let Ok(handle) = Handle::try_current() else {
+            warn!(
+                "Could not schedule remote exec process unregister on drop: no Tokio runtime is available"
+            );
+            return;
+        };
+        std::mem::drop(handle.spawn(async move {
             session.unregister().await;
-        });
+        }));
     }
 }

--- a/codex-rs/exec-server/src/remote_process.rs
+++ b/codex-rs/exec-server/src/remote_process.rs
@@ -9,23 +9,23 @@ use crate::ExecProcess;
 use crate::ExecProcessEventReceiver;
 use crate::ExecServerError;
 use crate::StartedExecProcess;
-use crate::client::LazyRemoteExecServerClient;
-use crate::client::Session;
+use crate::client::ProcessSessionHandle;
+use crate::client::RemoteExecServerClient;
 use crate::protocol::ExecParams;
 use crate::protocol::ReadResponse;
 use crate::protocol::WriteResponse;
 
 #[derive(Clone)]
 pub(crate) struct RemoteProcess {
-    client: LazyRemoteExecServerClient,
+    client: RemoteExecServerClient,
 }
 
 struct RemoteExecProcess {
-    session: Session,
+    session: ProcessSessionHandle,
 }
 
 impl RemoteProcess {
-    pub(crate) fn new(client: LazyRemoteExecServerClient) -> Self {
+    pub(crate) fn new(client: RemoteExecServerClient) -> Self {
         trace!("remote process new");
         Self { client }
     }
@@ -35,9 +35,9 @@ impl RemoteProcess {
 impl ExecBackend for RemoteProcess {
     async fn start(&self, params: ExecParams) -> Result<StartedExecProcess, ExecServerError> {
         let process_id = params.process_id.clone();
-        let client = self.client.get().await?;
-        let session = client.register_session(&process_id).await?;
-        if let Err(err) = client.exec(params).await {
+        let session = self.client.register_process_session(&process_id).await?;
+        let connection = self.client.connection().await?;
+        if let Err(err) = connection.exec(params).await {
             session.unregister().await;
             return Err(err);
         }

--- a/codex-rs/exec-server/tests/exec_process.rs
+++ b/codex-rs/exec-server/tests/exec_process.rs
@@ -166,6 +166,7 @@ async fn collect_process_output_from_events(
                 drop(session);
                 return Ok((stdout, stderr, exit_code, true));
             }
+            ExecProcessEvent::ResyncRequired => continue,
             ExecProcessEvent::Failed(message) => {
                 anyhow::bail!("process failed before closed state: {message}");
             }
@@ -189,6 +190,7 @@ async fn collect_process_event_snapshots(
                 ProcessEventSnapshot::Exited { seq, exit_code }
             }
             ExecProcessEvent::Closed { seq } => ProcessEventSnapshot::Closed { seq },
+            ExecProcessEvent::ResyncRequired => continue,
             ExecProcessEvent::Failed(message) => {
                 anyhow::bail!("process failed before closed state: {message}");
             }

--- a/codex-rs/exec-server/tests/exec_process.rs
+++ b/codex-rs/exec-server/tests/exec_process.rs
@@ -541,7 +541,7 @@ async fn assert_exec_process_preserves_queued_events_before_subscribe(
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 // Serialize tests that launch a real exec-server process through the full CLI.
 #[serial_test::serial(remote_exec_server)]
-async fn remote_exec_process_reports_transport_disconnect() -> Result<()> {
+async fn remote_exec_process_surfaces_reconnect_failure_after_server_shutdown() -> Result<()> {
     let mut context = create_process_context(/*use_remote*/ true).await?;
     let session = context
         .backend
@@ -562,7 +562,6 @@ async fn remote_exec_process_reports_transport_disconnect() -> Result<()> {
         .await?;
 
     let process = Arc::clone(&session.process);
-    let mut events = process.subscribe_events();
     let process_for_pending_read = Arc::clone(&process);
     let pending_read = tokio::spawn(async move {
         process_for_pending_read
@@ -579,36 +578,33 @@ async fn remote_exec_process_reports_transport_disconnect() -> Result<()> {
         .expect("remote context should include exec-server harness");
     server.shutdown().await?;
 
-    let event = timeout(Duration::from_secs(2), events.recv()).await??;
-    let ExecProcessEvent::Failed(event_message) = event else {
-        anyhow::bail!("expected process failure event, got {event:?}");
-    };
+    let pending_error = timeout(Duration::from_secs(2), pending_read)
+        .await
+        .context("timed out waiting for pending read after reconnect failure")??
+        .expect_err("pending read should fail after reconnect fails");
     assert!(
-        event_message.starts_with("exec-server transport disconnected"),
-        "unexpected failure event: {event_message}"
+        pending_error
+            .to_string()
+            .starts_with("failed to connect to exec-server websocket"),
+        "unexpected pending read error: {pending_error}"
     );
 
-    let pending_response = timeout(Duration::from_secs(2), pending_read).await???;
-    let pending_message = pending_response
-        .failure
-        .expect("pending read should surface disconnect as a failure");
+    let read_error = timeout(
+        Duration::from_secs(2),
+        process.read(
+            /*after_seq*/ None,
+            /*max_bytes*/ None,
+            /*wait_ms*/ Some(0),
+        ),
+    )
+    .await
+    .context("timed out waiting for read after reconnect failure")?
+    .expect_err("read after reconnect failure should fail");
     assert!(
-        pending_message.starts_with("exec-server transport disconnected"),
-        "unexpected pending failure message: {pending_message}"
-    );
-
-    let mut wake_rx = process.subscribe_wake();
-    let response = read_process_until_change(process, &mut wake_rx, /*after_seq*/ None).await?;
-    let message = response
-        .failure
-        .expect("disconnect should surface as a failure");
-    assert!(
-        message.starts_with("exec-server transport disconnected"),
-        "unexpected failure message: {message}"
-    );
-    assert!(
-        response.closed,
-        "disconnect should close the process session"
+        read_error
+            .to_string()
+            .starts_with("failed to connect to exec-server websocket"),
+        "unexpected read error: {read_error}"
     );
 
     let write_result = timeout(
@@ -621,7 +617,7 @@ async fn remote_exec_process_reports_transport_disconnect() -> Result<()> {
     assert!(
         write_error
             .to_string()
-            .starts_with("exec-server transport disconnected"),
+            .starts_with("failed to connect to exec-server websocket"),
         "unexpected write error: {write_error}"
     );
 

--- a/codex-rs/rmcp-client/src/executor_process_transport.rs
+++ b/codex-rs/rmcp-client/src/executor_process_transport.rs
@@ -193,6 +193,15 @@ impl ExecutorProcessTransport {
                     self.note_seq(seq);
                     self.closed = true;
                 }
+                Ok(ExecProcessEvent::ResyncRequired) => {
+                    if let Err(error) = self.recover_process_events().await {
+                        warn!(
+                            "Failed to resync remote MCP server output stream ({}): {error}",
+                            self.program_name
+                        );
+                        self.closed = true;
+                    }
+                }
                 Ok(ExecProcessEvent::Failed(message)) => {
                     warn!(
                         "Remote MCP server process failed ({}): {message}",
@@ -205,7 +214,7 @@ impl ExecutorProcessTransport {
                         "Remote MCP server output stream lagged ({}): skipped {skipped} events",
                         self.program_name
                     );
-                    if let Err(error) = self.recover_lagged_events().await {
+                    if let Err(error) = self.recover_process_events().await {
                         warn!(
                             "Failed to recover remote MCP server output stream ({}): {error}",
                             self.program_name
@@ -232,7 +241,7 @@ impl ExecutorProcessTransport {
         true
     }
 
-    async fn recover_lagged_events(&mut self) -> io::Result<()> {
+    async fn recover_process_events(&mut self) -> io::Result<()> {
         let response = self
             .process
             .read(


### PR DESCRIPTION
## Summary
- split the old remote exec-server client into a durable logical client/session layer and replaceable live connection bindings
- add same-host websocket reconnect for remote exec-server environments, shared across process, filesystem, and HTTP capabilities
- define the first reconnect/idempotency slice explicitly: resume sessions and recover cursor reads, but do not replay ambiguous side-effecting RPCs
- keep rendezvous harness URLs on the same reconnect path while leaving full relay-frame reliable-message resume/replay to the later endpoint-owned protocol slice

## Why
Remote exec-server environments currently treat a websocket drop as terminal even when the same exec-server process is still alive. That is too fragile for the same-host case we want first: laptop sleep, tunnel churn, websocket close races, or rendezvous route replacement should not force the rest of Codex to know that the transport changed underneath it.

This PR establishes the reconnect boundary at the environment-owned remote exec-server client. The rest of Codex should keep holding one logical remote environment capability while that client swaps the underlying live `ExecServerConnection` as needed.

The important constraint is that reconnect is not the same as replaying every request. A transport can die after the server accepted an RPC but before the client saw the response. For this slice, the protocol only has one operation with a built-in replay cursor: `process/read(afterSeq)`. Everything else must reconnect before later calls, but an ambiguous in-flight call returns an error instead of risking duplicate side effects.

## What Changed
### Client/session restructuring
The old lazy remote client held onto the first successful connection forever. This PR replaces that with a logical `RemoteExecServerClient` that owns durable `RemoteExecServerSession` state:

- current live `ExecServerConnection`, if any
- resumable logical exec-server `session_id`
- one shared in-flight reconnect attempt for the whole logical client
- weakly tracked live `ProcessSession`s that may need rebinding while their process handles still exist
- terminal resume failure state when the prior session is definitively gone

`ExecServerConnection` is now the name for one live JSON-RPC transport binding. It owns connection-local machinery such as the `RpcClient`, reader task, disconnect latch, process notification routes, and streamed HTTP body routes. The public `ExecServerClient` name remains as a type alias so existing callers do not need an API migration in this PR.

`RemoteProcess`, `RemoteFileSystem`, and the remote `HttpClient` implementation are now thin adapters over the shared logical `RemoteExecServerClient`; they do not own separate reconnect loops.

### Reconnect semantics
When a websocket-backed remote client notices a dead transport, the next remote API call asks the shared logical client for a connection. The client either reuses the live binding, waits for the one reconnect attempt already in progress, or creates one replacement connection and resumes the prior exec-server `session_id`.

After resume, tracked process session routes are rebound onto the replacement `ExecServerConnection` so existing `RemoteExecProcess` handles continue through the same logical client state. The logical client does not own those sessions forever: `RemoteExecProcess` handles own the durable `ProcessSession` state, and the reconnect session keeps only weak references needed to rebind still-live handles.

Preserved remote process sessions now emit a local `ResyncRequired` event and wake when their transport disappears. Push-based consumers can use that signal to recover through `process/read(afterSeq)` instead of waiting forever for another pushed event. Direct one-shot/test sessions still fail terminally on disconnect.

Resume error handling is intentionally narrow:

- `unknown session id ...` is treated as terminal and cached for later callers.
- `session ... is already attached to another connection` is treated as a transient resume race and retried briefly.

### Idempotency / replay rules
This PR does **not** add general request idempotency keys. Instead it makes the first replay boundary explicit at the API layer:

- `process/read(afterSeq)` may reconnect and retry once after a transport-close race because the cursor makes the read recoverable and duplicate-safe.
- `process/start`, `process/write`, `process/terminate`, filesystem RPCs, and `http/request` reconnect before later calls but are **not** replayed after an ambiguous mid-request disconnect.
- streamed HTTP response bodies remain connection-local; a later request can reconnect, but an already-open body-delta stream is not resumed in this slice.

That keeps this foundation honest: we recover the operation that already has a read cursor, and we surface ambiguity for operations that would need explicit idempotency keys or stronger protocol semantics before automatic replay is safe.

### Rendezvous / relay behavior
Rendezvous harness URLs are still represented as `ExecServerTransportParams::WebSocketUrl`, so they take the same logical reconnect path as direct websocket URLs. `client_transport` continues to detect `?role=harness` and wrap the websocket in the relay transport before exec-server initialize/resume runs over it.

For this slice, reconnecting a rendezvous-backed client means establishing a fresh relay websocket/stream, then resuming the exec-server logical session above that relay binding and recovering process output through `process/read(afterSeq)`.

This is intentionally **not** full reliable-message relay replay. The Reliable Messages design has harness and executor retain seq/ack/unacked state and resend remaining relay segments end-to-end after same-`stream_id` resume. That endpoint-owned relay resume/retry protocol is a later slice; this PR only makes the exec-server client/session layer resilient to replacement of the underlying websocket or relay binding.

## Validation
- added focused reconnect coverage for shared reconnect attempts, reconnect-before-dispatch across remote APIs, cursor-read replay, and no replay for ambiguous non-read APIs
- added regressions for idle process resync notification, transient resume-conflict retry, terminal unknown-session caching, process-session cleanup after start/connect failure, and process-id reuse after a dropped remote handle
- ran focused remote Bazel tests for `//codex-rs/exec-server:exec-server-unit-tests` and `//codex-rs/rmcp-client:rmcp-client-unit-tests`
- generated an `exec-server` coverage report with `cargo llvm-cov` on the devbox while checking the new reconnect paths
