### PR TITLE
Backup PR 5 - Carry runtime capabilities into session services

### DIFF
--- a/codex-rs/core/src/codex_delegate.rs
+++ b/codex-rs/core/src/codex_delegate.rs
@@ -80,7 +80,7 @@ pub(crate) async fn run_codex_thread_interactive(
         auth_manager,
         models_manager,
         environment_manager: Arc::clone(&parent_session.services.environment_manager),
-        runtime_capabilities: Arc::clone(&parent_session.runtime_capabilities),
+        runtime_capabilities: Arc::clone(&parent_session.services.runtime_capabilities),
         skills_manager: Arc::clone(&parent_session.services.skills_manager),
         plugins_manager: Arc::clone(&parent_session.services.plugins_manager),
         mcp_manager: Arc::clone(&parent_session.services.mcp_manager),

--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -16,7 +16,6 @@ use tokio::sync::Semaphore;
 pub(crate) struct Session {
     pub(crate) conversation_id: ThreadId,
     pub(crate) installation_id: String,
-    pub(crate) runtime_capabilities: Arc<RuntimeCapabilities>,
     pub(super) tx_event: Sender<Event>,
     pub(super) agent_status: watch::Sender<AgentStatus>,
     pub(super) out_of_band_elicitation_paused: watch::Sender<bool>,
@@ -947,6 +946,7 @@ impl Session {
                 ),
                 code_mode_service: crate::tools::code_mode::CodeModeService::new(),
                 environment_manager,
+                runtime_capabilities,
             };
             services
                 .model_client
@@ -957,7 +957,6 @@ impl Session {
             let sess = Arc::new(Session {
                 conversation_id: thread_id,
                 installation_id,
-                runtime_capabilities,
                 tx_event: tx_event.clone(),
                 agent_status,
                 out_of_band_elicitation_paused,

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -4281,6 +4281,8 @@ pub(crate) async fn make_session_and_context() -> (Session, TurnContext) {
         codex_exec_server::Environment::create_for_tests(/*exec_server_url*/ None)
             .expect("create environment"),
     );
+    let environment_manager = Arc::new(codex_exec_server::EnvironmentManager::default_for_tests());
+    let runtime_capabilities = Arc::new(RuntimeCapabilities::local(environment_manager.as_ref()));
 
     let services = SessionServices {
         mcp_connection_manager: Arc::new(RwLock::new(
@@ -4348,7 +4350,8 @@ pub(crate) async fn make_session_and_context() -> (Session, TurnContext) {
             /*attestation_provider*/ None,
         ),
         code_mode_service: crate::tools::code_mode::CodeModeService::new(),
-        environment_manager: Arc::new(codex_exec_server::EnvironmentManager::default_for_tests()),
+        environment_manager,
+        runtime_capabilities,
     };
 
     let plugin_outcome = services
@@ -4387,13 +4390,9 @@ pub(crate) async fn make_session_and_context() -> (Session, TurnContext) {
         /*goal_tools_supported*/ true,
     );
 
-    let runtime_capabilities = Arc::new(RuntimeCapabilities::local(
-        services.environment_manager.as_ref(),
-    ));
     let session = Session {
         conversation_id: thread_id,
         installation_id: "11111111-1111-4111-8111-111111111111".to_string(),
-        runtime_capabilities,
         tx_event,
         agent_status: agent_status_tx,
         out_of_band_elicitation_paused: watch::channel(false).0,
@@ -6118,6 +6117,8 @@ where
         codex_exec_server::Environment::create_for_tests(/*exec_server_url*/ None)
             .expect("create environment"),
     );
+    let environment_manager = Arc::new(codex_exec_server::EnvironmentManager::default_for_tests());
+    let runtime_capabilities = Arc::new(RuntimeCapabilities::local(environment_manager.as_ref()));
 
     let services = SessionServices {
         mcp_connection_manager: Arc::new(RwLock::new(
@@ -6185,7 +6186,8 @@ where
             /*attestation_provider*/ None,
         ),
         code_mode_service: crate::tools::code_mode::CodeModeService::new(),
-        environment_manager: Arc::new(codex_exec_server::EnvironmentManager::default_for_tests()),
+        environment_manager,
+        runtime_capabilities,
     };
 
     let plugin_outcome = services
@@ -6224,13 +6226,9 @@ where
         /*goal_tools_supported*/ true,
     ));
 
-    let runtime_capabilities = Arc::new(RuntimeCapabilities::local(
-        services.environment_manager.as_ref(),
-    ));
     let session = Arc::new(Session {
         conversation_id: thread_id,
         installation_id: "11111111-1111-4111-8111-111111111111".to_string(),
-        runtime_capabilities,
         tx_event,
         agent_status: agent_status_tx,
         out_of_band_elicitation_paused: watch::channel(false).0,

--- a/codex-rs/core/src/state/service.rs
+++ b/codex-rs/core/src/state/service.rs
@@ -10,6 +10,7 @@ use crate::exec_policy::ExecPolicyManager;
 use crate::guardian::GuardianRejection;
 use crate::guardian::GuardianRejectionCircuitBreaker;
 use crate::mcp::McpManager;
+use crate::runtime_capabilities::RuntimeCapabilities;
 use crate::tools::code_mode::CodeModeService;
 use crate::tools::network_approval::NetworkApprovalService;
 use crate::tools::sandboxing::ApprovalStore;
@@ -77,4 +78,6 @@ pub(crate) struct SessionServices {
     /// Shared process-level environment registry. Sessions carry an `Arc` handle so they can pass
     /// the same manager through child-thread spawn paths without reconstructing it.
     pub(crate) environment_manager: Arc<EnvironmentManager>,
+    /// Startup-selected runtime authority bundle reused by session-owned child spawn paths.
+    pub(crate) runtime_capabilities: Arc<RuntimeCapabilities>,
 }


### PR DESCRIPTION
Draft backup of the current remote PR-slice worktree for the Execution Order / PR Slices stack. This is a safety snapshot, not the canonical review PR. It is intentionally based on the previous slice branch so the diff stays one slice wide.