### PR TITLE
Backup PR 6b - Gate MCP local fallback by runtime capabilities

### DIFF
--- a/codex-rs/core/src/session/mcp.rs
+++ b/codex-rs/core/src/session/mcp.rs
@@ -1,3 +1,4 @@
+use super::turn_context::TurnEnvironment;
 use super::*;
 use codex_mcp::ElicitationReviewRequest;
 use codex_mcp::ElicitationReviewer;
@@ -59,6 +60,30 @@ impl ElicitationReviewer for GuardianMcpElicitationReviewer {
 impl Session {
     pub(crate) fn mcp_elicitation_reviewer(self: &Arc<Self>) -> ElicitationReviewerHandle {
         Arc::new(GuardianMcpElicitationReviewer::new(self))
+    }
+
+    pub(super) fn mcp_runtime_environment(
+        &self,
+        turn_environment: Option<&TurnEnvironment>,
+        cwd: &AbsolutePathBuf,
+    ) -> CodexResult<McpRuntimeEnvironment> {
+        let (environment, cwd) = match turn_environment {
+            Some(turn_environment) => (
+                Arc::clone(&turn_environment.environment),
+                turn_environment.cwd.to_path_buf(),
+            ),
+            None => (
+                match self.services.environment_manager.default_environment() {
+                    Some(environment) => environment,
+                    None => self
+                        .services
+                        .runtime_capabilities
+                        .require_local_environment("MCP runtime environment")?,
+                },
+                cwd.to_path_buf(),
+            ),
+        };
+        Ok(McpRuntimeEnvironment::new(environment, cwd))
     }
 
     #[expect(
@@ -289,19 +314,15 @@ impl Session {
             host_owned_codex_apps_enabled(&mcp_config, auth.as_ref());
         let auth_statuses =
             compute_auth_statuses(mcp_servers.iter(), store_mode, auth.as_ref()).await;
-        let mcp_runtime_environment = match turn_context.environments.primary() {
-            Some(turn_environment) => McpRuntimeEnvironment::new(
-                Arc::clone(&turn_environment.environment),
-                turn_environment.cwd.to_path_buf(),
-            ),
-            None => McpRuntimeEnvironment::new(
-                self.services
-                    .environment_manager
-                    .default_environment()
-                    .unwrap_or_else(|| self.services.environment_manager.local_environment()),
-                #[allow(deprecated)]
-                turn_context.cwd.to_path_buf(),
-            ),
+        #[allow(deprecated)]
+        let mcp_runtime_environment = match self
+            .mcp_runtime_environment(turn_context.environments.primary(), &turn_context.cwd)
+        {
+            Ok(runtime_environment) => runtime_environment,
+            Err(err) => {
+                warn!("failed to refresh MCP servers: {err}");
+                return;
+            }
         };
         {
             let mut guard = self.services.mcp_startup_cancellation_token.lock().await;

--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -1050,19 +1050,10 @@ impl Session {
             })?
             .primary()
             .cloned();
-            let mcp_runtime_environment = match turn_environment {
-                Some(turn_environment) => McpRuntimeEnvironment::new(
-                    Arc::clone(&turn_environment.environment),
-                    turn_environment.cwd.to_path_buf(),
-                ),
-                None => McpRuntimeEnvironment::new(
-                    sess.services
-                        .environment_manager
-                        .default_environment()
-                        .unwrap_or_else(|| sess.services.environment_manager.local_environment()),
-                    session_configuration.cwd.to_path_buf(),
-                ),
-            };
+            let mcp_runtime_environment = sess.mcp_runtime_environment(
+                turn_environment.as_ref(),
+                &session_configuration.cwd,
+            )?;
             let (mcp_connection_manager, cancel_token) = McpConnectionManager::new(
                 &mcp_servers,
                 config.mcp_oauth_credentials_store_mode,

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -4412,6 +4412,22 @@ pub(crate) async fn make_session_and_context() -> (Session, TurnContext) {
     (session, turn_context)
 }
 
+#[tokio::test]
+async fn mcp_runtime_environment_preserves_selected_or_default_environment() {
+    let (mut session, turn_context) = make_session_and_context().await;
+    session.services.runtime_capabilities = Arc::new(RuntimeCapabilities::isolated());
+
+    #[allow(deprecated)]
+    let default_environment =
+        session.mcp_runtime_environment(/*turn_environment*/ None, &turn_context.cwd);
+    assert!(default_environment.is_ok());
+
+    #[allow(deprecated)]
+    let selected_environment =
+        session.mcp_runtime_environment(turn_context.environments.primary(), &turn_context.cwd);
+    assert!(selected_environment.is_ok());
+}
+
 async fn make_session_with_config(
     mutator: impl FnOnce(&mut Config),
 ) -> anyhow::Result<Arc<Session>> {


### PR DESCRIPTION
Draft backup of the current remote PR-slice worktree for the Execution Order / PR Slices stack. This is a safety snapshot, not the canonical review PR. It is intentionally based on the previous slice branch so the diff stays one slice wide.