### PR TITLE
Backup PR 6c - Gate agent roles by runtime capabilities

### DIFF
--- a/codex-rs/core/src/agent/role.rs
+++ b/codex-rs/core/src/agent/role.rs
@@ -11,6 +11,7 @@ use crate::config::Config;
 use crate::config::ConfigOverrides;
 use crate::config::agent_roles::parse_agent_role_file_contents;
 use crate::config::deserialize_config_toml_with_base;
+use crate::runtime_capabilities::RuntimeCapabilities;
 use anyhow::anyhow;
 use codex_app_server_protocol::ConfigLayerSource;
 use codex_config::ConfigLayerEntry;
@@ -18,7 +19,8 @@ use codex_config::ConfigLayerStack;
 use codex_config::ConfigLayerStackOrdering;
 use codex_config::config_toml::ConfigToml;
 use codex_config::loader::resolve_relative_paths_in_config_toml;
-use codex_exec_server::LOCAL_FS;
+use codex_exec_server::ExecutorFileSystem;
+use codex_utils_absolute_path::AbsolutePathBuf;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::path::Path;
@@ -40,6 +42,7 @@ const AGENT_TYPE_UNAVAILABLE_ERROR: &str = "agent type is currently not availabl
 pub(crate) async fn apply_role_to_config(
     config: &mut Config,
     role_name: Option<&str>,
+    runtime_capabilities: &RuntimeCapabilities,
 ) -> Result<(), String> {
     let role_name = role_name.unwrap_or(DEFAULT_ROLE_NAME);
 
@@ -47,7 +50,7 @@ pub(crate) async fn apply_role_to_config(
         .cloned()
         .ok_or_else(|| format!("unknown agent_type '{role_name}'"))?;
 
-    apply_role_to_config_inner(config, role_name, &role)
+    apply_role_to_config_inner(config, role_name, &role, runtime_capabilities)
         .await
         .map_err(|err| {
             tracing::warn!("failed to apply role to config: {err}");
@@ -59,12 +62,20 @@ async fn apply_role_to_config_inner(
     config: &mut Config,
     role_name: &str,
     role: &AgentRoleConfig,
+    runtime_capabilities: &RuntimeCapabilities,
 ) -> anyhow::Result<()> {
     let is_built_in = !config.agent_roles.contains_key(role_name);
     let Some(config_file) = role.config_file.as_ref() else {
         return Ok(());
     };
-    let role_layer_toml = load_role_layer_toml(config, config_file, is_built_in, role_name).await?;
+    let role_layer_toml = load_role_layer_toml(
+        config,
+        config_file,
+        is_built_in,
+        role_name,
+        runtime_capabilities,
+    )
+    .await?;
     if role_layer_toml
         .as_table()
         .is_some_and(toml::map::Map::is_empty)
@@ -73,12 +84,15 @@ async fn apply_role_to_config_inner(
     }
     let (preserve_current_profile, preserve_current_provider) =
         preservation_policy(config, &role_layer_toml);
+    let file_system =
+        runtime_capabilities.require_local_filesystem("applying agent role config")?;
 
     *config = reload::build_next_config(
         config,
         role_layer_toml,
         preserve_current_profile,
         preserve_current_provider,
+        file_system.as_ref(),
     )
     .await?;
     Ok(())
@@ -89,32 +103,37 @@ async fn load_role_layer_toml(
     config_file: &Path,
     is_built_in: bool,
     role_name: &str,
+    runtime_capabilities: &RuntimeCapabilities,
 ) -> anyhow::Result<TomlValue> {
     let (role_config_toml, role_config_base) = if is_built_in {
         let role_config_contents = built_in::config_file_contents(config_file)
             .map(str::to_owned)
             .ok_or(anyhow!("No corresponding config content"))?;
         let role_config_toml: TomlValue = toml::from_str(&role_config_contents)?;
-        (role_config_toml, config.codex_home.as_path())
+        (role_config_toml, config.codex_home.as_path().to_path_buf())
     } else {
-        let role_config_contents = tokio::fs::read_to_string(config_file).await?;
+        let file_system =
+            runtime_capabilities.require_local_filesystem("loading external agent role config")?;
+        let config_file = AbsolutePathBuf::from_absolute_path(config_file)?;
+        let role_config_contents = file_system.read_file_text(&config_file, None).await?;
         let role_config_base = config_file
             .parent()
-            .ok_or(anyhow!("No corresponding config content"))?;
+            .ok_or(anyhow!("No corresponding config content"))?
+            .to_path_buf();
         let role_config_toml = parse_agent_role_file_contents(
             &role_config_contents,
-            config_file,
-            role_config_base,
+            config_file.as_path(),
+            &role_config_base,
             Some(role_name),
         )?
         .config;
         (role_config_toml, role_config_base)
     };
 
-    deserialize_config_toml_with_base(role_config_toml.clone(), role_config_base)?;
+    deserialize_config_toml_with_base(role_config_toml.clone(), &role_config_base)?;
     Ok(resolve_relative_paths_in_config_toml(
         role_config_toml,
-        role_config_base,
+        &role_config_base,
     )?)
 }
 
@@ -157,6 +176,7 @@ mod reload {
         role_layer_toml: TomlValue,
         preserve_current_profile: bool,
         preserve_current_provider: bool,
+        file_system: &dyn ExecutorFileSystem,
     ) -> anyhow::Result<Config> {
         let active_profile_name = preserve_current_profile
             .then_some(config.active_profile.as_deref())
@@ -169,7 +189,7 @@ mod reload {
         }
 
         let mut next_config = Config::load_config_with_layer_stack(
-            LOCAL_FS.as_ref(),
+            file_system,
             merged_config,
             reload_overrides(config, preserve_current_provider),
             config.codex_home.clone(),
@@ -276,46 +296,89 @@ pub(crate) mod spawn_tool_spec {
     use super::*;
 
     /// Builds the spawn-agent tool description text from built-in and configured roles.
-    pub(crate) fn build(user_defined_agent_roles: &BTreeMap<String, AgentRoleConfig>) -> String {
+    pub(crate) async fn build(
+        user_defined_agent_roles: &BTreeMap<String, AgentRoleConfig>,
+        runtime_capabilities: &RuntimeCapabilities,
+    ) -> String {
         let built_in_roles = built_in::configs();
-        build_from_configs(built_in_roles, user_defined_agent_roles)
+        build_from_configs(
+            built_in_roles,
+            user_defined_agent_roles,
+            runtime_capabilities,
+        )
+        .await
+    }
+
+    /// Builds the built-in spawn-agent tool description without external role files.
+    pub(crate) fn build_default() -> String {
+        let formatted_roles = built_in::configs()
+            .iter()
+            .map(|(name, declaration)| {
+                let role_config_contents = declaration
+                    .config_file
+                    .as_ref()
+                    .and_then(|config_file| built_in::config_file_contents(config_file));
+                format_role(name, declaration, role_config_contents)
+            })
+            .collect();
+        format_spec(formatted_roles)
     }
 
     // This function is not inlined for testing purpose.
-    fn build_from_configs(
+    async fn build_from_configs(
         built_in_roles: &BTreeMap<String, AgentRoleConfig>,
         user_defined_roles: &BTreeMap<String, AgentRoleConfig>,
+        runtime_capabilities: &RuntimeCapabilities,
     ) -> String {
         let mut seen = BTreeSet::new();
         let mut formatted_roles = Vec::new();
         for (name, declaration) in user_defined_roles {
             if seen.insert(name.as_str()) {
-                formatted_roles.push(format_role(name, declaration));
+                formatted_roles.push(
+                    format_role_with_runtime_capabilities(name, declaration, runtime_capabilities)
+                        .await,
+                );
             }
         }
         for (name, declaration) in built_in_roles {
             if seen.insert(name.as_str()) {
-                formatted_roles.push(format_role(name, declaration));
+                formatted_roles.push(
+                    format_role_with_runtime_capabilities(name, declaration, runtime_capabilities)
+                        .await,
+                );
             }
         }
 
+        format_spec(formatted_roles)
+    }
+
+    fn format_spec(formatted_roles: Vec<String>) -> String {
         format!(
             "Optional type name for the new agent. If omitted, `{DEFAULT_ROLE_NAME}` is used.\nAvailable roles:\n{}",
             formatted_roles.join("\n"),
         )
     }
 
-    fn format_role(name: &str, declaration: &AgentRoleConfig) -> String {
+    async fn format_role_with_runtime_capabilities(
+        name: &str,
+        declaration: &AgentRoleConfig,
+        runtime_capabilities: &RuntimeCapabilities,
+    ) -> String {
+        let role_config_contents = match declaration.config_file.as_ref() {
+            Some(config_file) => role_config_contents(config_file, runtime_capabilities).await,
+            None => None,
+        };
+        format_role(name, declaration, role_config_contents.as_deref())
+    }
+
+    fn format_role(
+        name: &str,
+        declaration: &AgentRoleConfig,
+        role_config_contents: Option<&str>,
+    ) -> String {
         if let Some(description) = &declaration.description {
-            let locked_settings_note = declaration
-                .config_file
-                .as_ref()
-                .and_then(|config_file| {
-                    built_in::config_file_contents(config_file)
-                        .map(str::to_owned)
-                        .or_else(|| std::fs::read_to_string(config_file).ok())
-                })
-                .and_then(|contents| toml::from_str::<TomlValue>(&contents).ok())
+            let locked_settings_note = role_config_contents
+                .and_then(|contents| toml::from_str::<TomlValue>(contents).ok())
                 .map(|role_toml| {
                     let model = role_toml
                         .get("model")
@@ -346,6 +409,19 @@ pub(crate) mod spawn_tool_spec {
         } else {
             format!("{name}: no description")
         }
+    }
+
+    async fn role_config_contents(
+        config_file: &Path,
+        runtime_capabilities: &RuntimeCapabilities,
+    ) -> Option<String> {
+        if let Some(contents) = built_in::config_file_contents(config_file) {
+            return Some(contents.to_owned());
+        }
+
+        let file_system = runtime_capabilities.local_filesystem()?;
+        let config_file = AbsolutePathBuf::from_absolute_path(config_file).ok()?;
+        file_system.read_file_text(&config_file, None).await.ok()
     }
 }
 

--- a/codex-rs/core/src/agent/role_tests.rs
+++ b/codex-rs/core/src/agent/role_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::RuntimeCapabilities;
 use crate::SkillsManager;
 use crate::config::CONFIG_TOML_FILE;
 use crate::config::ConfigBuilder;
@@ -38,6 +39,16 @@ async fn write_role_config(home: &TempDir, name: &str, contents: &str) -> PathBu
     role_path
 }
 
+fn local_runtime_capabilities() -> RuntimeCapabilities {
+    let environment_manager = codex_exec_server::EnvironmentManager::default_for_tests();
+    RuntimeCapabilities::local(&environment_manager)
+}
+
+async fn apply_role_to_config(config: &mut Config, role_name: Option<&str>) -> Result<(), String> {
+    let runtime_capabilities = local_runtime_capabilities();
+    super::apply_role_to_config(config, role_name, &runtime_capabilities).await
+}
+
 fn session_flags_layer_count(config: &Config) -> usize {
     config
         .config_layer_stack
@@ -71,6 +82,46 @@ async fn apply_role_returns_error_for_unknown_role() {
         .expect_err("unknown role should fail");
 
     assert_eq!(err, "unknown agent_type 'missing-role'");
+}
+
+#[tokio::test]
+async fn apply_embedded_empty_role_without_local_filesystem() {
+    let (_home, mut config) = test_config_with_cli_overrides(Vec::new()).await;
+    let before = config.clone();
+
+    super::apply_role_to_config(
+        &mut config,
+        Some("explorer"),
+        &RuntimeCapabilities::isolated(),
+    )
+    .await
+    .expect("embedded empty role should apply");
+
+    assert_eq!(before, config);
+}
+
+#[tokio::test]
+async fn apply_external_empty_role_requires_local_filesystem() {
+    let (home, mut config) = test_config_with_cli_overrides(Vec::new()).await;
+    let role_path = write_role_config(&home, "empty-role.toml", "").await;
+    config.agent_roles.insert(
+        "custom".to_string(),
+        AgentRoleConfig {
+            description: None,
+            config_file: Some(role_path),
+            nickname_candidates: None,
+        },
+    );
+
+    let err = super::apply_role_to_config(
+        &mut config,
+        Some("custom"),
+        &RuntimeCapabilities::isolated(),
+    )
+    .await
+    .expect_err("external role should require local filesystem");
+
+    assert_eq!(err, AGENT_TYPE_UNAVAILABLE_ERROR);
 }
 
 #[tokio::test]
@@ -674,8 +725,8 @@ enabled = false
     assert_eq!(outcome.is_skill_enabled(skill), false);
 }
 
-#[test]
-fn spawn_tool_spec_build_deduplicates_user_defined_built_in_roles() {
+#[tokio::test]
+async fn spawn_tool_spec_build_deduplicates_user_defined_built_in_roles() {
     let user_defined_roles = BTreeMap::from([
         (
             "explorer".to_string(),
@@ -688,7 +739,7 @@ fn spawn_tool_spec_build_deduplicates_user_defined_built_in_roles() {
         ("researcher".to_string(), AgentRoleConfig::default()),
     ]);
 
-    let spec = spawn_tool_spec::build(&user_defined_roles);
+    let spec = spawn_tool_spec::build(&user_defined_roles, &RuntimeCapabilities::isolated()).await;
 
     assert!(spec.contains("researcher: no description"));
     assert!(spec.contains("explorer: {\nuser override\n}"));
@@ -696,8 +747,8 @@ fn spawn_tool_spec_build_deduplicates_user_defined_built_in_roles() {
     assert!(!spec.contains("Explorers are fast and authoritative."));
 }
 
-#[test]
-fn spawn_tool_spec_lists_user_defined_roles_before_built_ins() {
+#[tokio::test]
+async fn spawn_tool_spec_lists_user_defined_roles_before_built_ins() {
     let user_defined_roles = BTreeMap::from([(
         "aaa".to_string(),
         AgentRoleConfig {
@@ -707,7 +758,7 @@ fn spawn_tool_spec_lists_user_defined_roles_before_built_ins() {
         },
     )]);
 
-    let spec = spawn_tool_spec::build(&user_defined_roles);
+    let spec = spawn_tool_spec::build(&user_defined_roles, &RuntimeCapabilities::isolated()).await;
     let user_index = spec.find("aaa: {\nfirst\n}").expect("find user role");
     let built_in_index = spec
         .find("default: {\nDefault agent.\n}")
@@ -716,8 +767,8 @@ fn spawn_tool_spec_lists_user_defined_roles_before_built_ins() {
     assert!(user_index < built_in_index);
 }
 
-#[test]
-fn spawn_tool_spec_marks_role_locked_model_and_reasoning_effort() {
+#[tokio::test]
+async fn spawn_tool_spec_marks_role_locked_model_and_reasoning_effort() {
     let tempdir = TempDir::new().expect("create temp dir");
     let role_path = tempdir.path().join("researcher.toml");
     fs::write(
@@ -734,15 +785,15 @@ fn spawn_tool_spec_marks_role_locked_model_and_reasoning_effort() {
         },
     )]);
 
-    let spec = spawn_tool_spec::build(&user_defined_roles);
+    let spec = spawn_tool_spec::build(&user_defined_roles, &local_runtime_capabilities()).await;
 
     assert!(spec.contains(
             "Research carefully.\n- This role's model is set to `gpt-5` and its reasoning effort is set to `high`. These settings cannot be changed."
         ));
 }
 
-#[test]
-fn spawn_tool_spec_marks_role_locked_reasoning_effort_only() {
+#[tokio::test]
+async fn spawn_tool_spec_marks_role_locked_reasoning_effort_only() {
     let tempdir = TempDir::new().expect("create temp dir");
     let role_path = tempdir.path().join("reviewer.toml");
     fs::write(
@@ -759,11 +810,35 @@ fn spawn_tool_spec_marks_role_locked_reasoning_effort_only() {
         },
     )]);
 
-    let spec = spawn_tool_spec::build(&user_defined_roles);
+    let spec = spawn_tool_spec::build(&user_defined_roles, &local_runtime_capabilities()).await;
 
     assert!(spec.contains(
             "Review carefully.\n- This role's reasoning effort is set to `medium` and cannot be changed."
         ));
+}
+
+#[tokio::test]
+async fn spawn_tool_spec_lists_external_role_without_locked_note_when_filesystem_is_unavailable() {
+    let tempdir = TempDir::new().expect("create temp dir");
+    let role_path = tempdir.path().join("researcher.toml");
+    fs::write(
+        &role_path,
+        "developer_instructions = \"Research carefully\"\nmodel = \"gpt-5\"\n",
+    )
+    .expect("write role config");
+    let user_defined_roles = BTreeMap::from([(
+        "researcher".to_string(),
+        AgentRoleConfig {
+            description: Some("Research carefully.".to_string()),
+            config_file: Some(role_path),
+            nickname_candidates: None,
+        },
+    )]);
+
+    let spec = spawn_tool_spec::build(&user_defined_roles, &RuntimeCapabilities::isolated()).await;
+
+    assert!(spec.contains("researcher: {\nResearch carefully.\n}"));
+    assert!(!spec.contains("This role's model is set"));
 }
 
 #[test]

--- a/codex-rs/core/src/session/review.rs
+++ b/codex-rs/core/src/session/review.rs
@@ -75,9 +75,13 @@ pub(super) async fn spawn_review_thread(
             .enabled(Feature::MultiAgentV2)
             .then_some(config.multi_agent_v2.default_wait_timeout_ms),
     )
-    .with_agent_type_description(crate::agent::role::spawn_tool_spec::build(
-        &config.agent_roles,
-    ));
+    .with_agent_type_description(
+        crate::agent::role::spawn_tool_spec::build(
+            &config.agent_roles,
+            sess.services.runtime_capabilities.as_ref(),
+        )
+        .await,
+    );
 
     let review_prompt = resolved.prompt.clone();
     let provider = parent_turn_context.provider.clone();

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -3829,9 +3829,13 @@ enabled = false
             nickname_candidates: None,
         },
     );
-    crate::agent::role::apply_role_to_config(&mut child_config, Some("custom"))
-        .await
-        .expect("custom role should apply");
+    crate::agent::role::apply_role_to_config(
+        &mut child_config,
+        Some("custom"),
+        session.services.runtime_capabilities.as_ref(),
+    )
+    .await
+    .expect("custom role should apply");
 
     {
         let mut state = session.state.lock().await;
@@ -4388,7 +4392,9 @@ pub(crate) async fn make_session_and_context() -> (Session, TurnContext) {
         "turn_id".to_string(),
         skills_outcome,
         /*goal_tools_supported*/ true,
-    );
+        services.runtime_capabilities.as_ref(),
+    )
+    .await;
 
     let session = Session {
         conversation_id: thread_id,
@@ -6221,26 +6227,30 @@ where
             .await,
     );
     let turn_environments = turn_environments_for_tests(&environment, &session_configuration.cwd);
-    let turn_context = Arc::new(Session::make_turn_context(
-        thread_id,
-        SessionId::from(thread_id),
-        Some(Arc::clone(&auth_manager)),
-        &session_telemetry,
-        session_configuration.provider.clone(),
-        &session_configuration,
-        services.user_shell.as_ref(),
-        services.shell_zsh_path.as_ref(),
-        services.main_execve_wrapper_exe.as_ref(),
-        per_turn_config,
-        model_info,
-        &models_manager,
-        /*network*/ None,
-        turn_environments,
-        session_configuration.cwd.clone(),
-        "turn_id".to_string(),
-        skills_outcome,
-        /*goal_tools_supported*/ true,
-    ));
+    let turn_context = Arc::new(
+        Session::make_turn_context(
+            thread_id,
+            SessionId::from(thread_id),
+            Some(Arc::clone(&auth_manager)),
+            &session_telemetry,
+            session_configuration.provider.clone(),
+            &session_configuration,
+            services.user_shell.as_ref(),
+            services.shell_zsh_path.as_ref(),
+            services.main_execve_wrapper_exe.as_ref(),
+            per_turn_config,
+            model_info,
+            &models_manager,
+            /*network*/ None,
+            turn_environments,
+            session_configuration.cwd.clone(),
+            "turn_id".to_string(),
+            skills_outcome,
+            /*goal_tools_supported*/ true,
+            services.runtime_capabilities.as_ref(),
+        )
+        .await,
+    );
 
     let session = Arc::new(Session {
         conversation_id: thread_id,

--- a/codex-rs/core/src/session/turn_context.rs
+++ b/codex-rs/core/src/session/turn_context.rs
@@ -247,9 +247,7 @@ impl TurnContext {
                 .enabled(Feature::MultiAgentV2)
                 .then_some(config.multi_agent_v2.default_wait_timeout_ms),
         )
-        .with_agent_type_description(crate::agent::role::spawn_tool_spec::build(
-            &config.agent_roles,
-        ));
+        .with_agent_type_description(self.tools_config.agent_type_description.clone());
 
         Self {
             sub_id: self.sub_id.clone(),
@@ -474,7 +472,7 @@ impl Session {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn make_turn_context(
+    pub(crate) async fn make_turn_context(
         thread_id: ThreadId,
         session_id: SessionId,
         auth_manager: Option<Arc<AuthManager>>,
@@ -493,6 +491,7 @@ impl Session {
         sub_id: String,
         skills_outcome: Arc<SkillLoadOutcome>,
         goal_tools_supported: bool,
+        runtime_capabilities: &RuntimeCapabilities,
     ) -> TurnContext {
         let reasoning_effort = session_configuration.collaboration_mode.reasoning_effort();
         let reasoning_summary = session_configuration
@@ -566,9 +565,13 @@ impl Session {
                 .enabled(Feature::MultiAgentV2)
                 .then_some(per_turn_config.multi_agent_v2.default_wait_timeout_ms),
         )
-        .with_agent_type_description(crate::agent::role::spawn_tool_spec::build(
-            &per_turn_config.agent_roles,
-        ));
+        .with_agent_type_description(
+            crate::agent::role::spawn_tool_spec::build(
+                &per_turn_config.agent_roles,
+                runtime_capabilities,
+            )
+            .await,
+        );
 
         let mut per_turn_config = per_turn_config;
         per_turn_config.service_tier = per_turn_config
@@ -812,7 +815,9 @@ impl Session {
             sub_id,
             skills_outcome,
             goal_tools_supported,
-        );
+            self.services.runtime_capabilities.as_ref(),
+        )
+        .await;
         turn_context.realtime_active = self.conversation.running_state().await.is_some();
 
         if let Some(final_schema) = final_output_json_schema {

--- a/codex-rs/core/src/tools/handlers/multi_agents/spawn.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents/spawn.rs
@@ -94,9 +94,13 @@ async fn handle_spawn_agent(
             args.reasoning_effort,
         )
         .await?;
-        apply_role_to_config(&mut config, role_name)
-            .await
-            .map_err(FunctionCallError::RespondToModel)?;
+        apply_role_to_config(
+            &mut config,
+            role_name,
+            session.services.runtime_capabilities.as_ref(),
+        )
+        .await
+        .map_err(FunctionCallError::RespondToModel)?;
     }
     apply_spawn_agent_service_tier(
         &session,

--- a/codex-rs/core/src/tools/handlers/multi_agents_v2/spawn.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_v2/spawn.rs
@@ -93,9 +93,13 @@ async fn handle_spawn_agent(
             args.reasoning_effort,
         )
         .await?;
-        apply_role_to_config(&mut config, role_name)
-            .await
-            .map_err(FunctionCallError::RespondToModel)?;
+        apply_role_to_config(
+            &mut config,
+            role_name,
+            session.services.runtime_capabilities.as_ref(),
+        )
+        .await
+        .map_err(FunctionCallError::RespondToModel)?;
     }
     apply_spawn_agent_service_tier(
         &session,

--- a/codex-rs/core/src/tools/spec_plan.rs
+++ b/codex-rs/core/src/tools/spec_plan.rs
@@ -105,8 +105,7 @@ fn build_tool_specs_and_registry(
         extension_tool_executors,
         dynamic_tools,
     } = params;
-    let default_agent_type_description =
-        crate::agent::role::spawn_tool_spec::build(&std::collections::BTreeMap::new());
+    let default_agent_type_description = crate::agent::role::spawn_tool_spec::build_default();
     let mut executors = collect_tool_executors(
         config,
         ToolRegistryBuildParams {


### PR DESCRIPTION
Draft backup of the current remote PR-slice worktree for the Execution Order / PR Slices stack. This is a safety snapshot, not the canonical review PR. It is intentionally based on the previous slice branch so the diff stays one slice wide.