### PR TITLE
Backup PR 6e - Gate connectors fallback by runtime capabilities

### DIFF
--- a/codex-rs/app-server/src/request_processors/apps_processor.rs
+++ b/codex-rs/app-server/src/request_processors/apps_processor.rs
@@ -75,8 +75,17 @@ impl AppsRequestProcessor {
         let request = request_id.clone();
         let outgoing = Arc::clone(&self.outgoing);
         let environment_manager = self.thread_manager.environment_manager();
+        let runtime_capabilities = self.thread_manager.runtime_capabilities();
         tokio::spawn(async move {
-            Self::apps_list_task(outgoing, request, params, config, environment_manager).await;
+            Self::apps_list_task(
+                outgoing,
+                request,
+                params,
+                config,
+                environment_manager,
+                runtime_capabilities,
+            )
+            .await;
         });
         Ok(None)
     }
@@ -87,8 +96,16 @@ impl AppsRequestProcessor {
         params: AppsListParams,
         config: Config,
         environment_manager: Arc<EnvironmentManager>,
+        runtime_capabilities: Arc<RuntimeCapabilities>,
     ) {
-        let result = Self::apps_list_response(&outgoing, params, config, environment_manager).await;
+        let result = Self::apps_list_response(
+            &outgoing,
+            params,
+            config,
+            environment_manager,
+            runtime_capabilities,
+        )
+        .await;
         outgoing.send_result(request_id, result).await;
     }
 
@@ -97,6 +114,7 @@ impl AppsRequestProcessor {
         params: AppsListParams,
         config: Config,
         environment_manager: Arc<EnvironmentManager>,
+        runtime_capabilities: Arc<RuntimeCapabilities>,
     ) -> Result<AppsListResponse, JSONRPCErrorError> {
         let AppsListParams {
             cursor,
@@ -128,6 +146,7 @@ impl AppsRequestProcessor {
                     &accessible_config,
                     force_refetch,
                     &environment_manager,
+                    &runtime_capabilities,
                 )
                 .await
                 .map(|status| status.connectors)

--- a/codex-rs/app-server/src/request_processors/config_processor.rs
+++ b/codex-rs/app-server/src/request_processors/config_processor.rs
@@ -213,6 +213,7 @@ impl ConfigRequestProcessor {
 
         let outgoing = Arc::clone(&self.outgoing);
         let environment_manager = self.thread_manager.environment_manager();
+        let runtime_capabilities = self.thread_manager.runtime_capabilities();
         tokio::spawn(async move {
             let (all_connectors_result, accessible_connectors_result) = tokio::join!(
                 connectors::list_all_connectors_with_options(&config, /*force_refetch*/ true),
@@ -220,6 +221,7 @@ impl ConfigRequestProcessor {
                     &config,
                     /*force_refetch*/ true,
                     &environment_manager,
+                    &runtime_capabilities,
                 ),
             );
             let all_connectors = match all_connectors_result {

--- a/codex-rs/app-server/src/request_processors/plugins.rs
+++ b/codex-rs/app-server/src/request_processors/plugins.rs
@@ -936,9 +936,14 @@ impl PluginRequestProcessor {
                     None => None,
                 };
                 let environment_manager = self.thread_manager.environment_manager();
-                let app_summaries =
-                    load_plugin_app_summaries(&config, &outcome.plugin.apps, &environment_manager)
-                        .await;
+                let runtime_capabilities = self.thread_manager.runtime_capabilities();
+                let app_summaries = load_plugin_app_summaries(
+                    &config,
+                    &outcome.plugin.apps,
+                    &environment_manager,
+                    &runtime_capabilities,
+                )
+                .await;
                 let visible_skills = outcome
                     .plugin
                     .skills
@@ -1014,8 +1019,14 @@ impl PluginRequestProcessor {
                     .map(codex_plugin::AppConnectorId)
                     .collect::<Vec<_>>();
                 let environment_manager = self.thread_manager.environment_manager();
-                let app_summaries =
-                    load_plugin_app_summaries(&config, &plugin_apps, &environment_manager).await;
+                let runtime_capabilities = self.thread_manager.runtime_capabilities();
+                let app_summaries = load_plugin_app_summaries(
+                    &config,
+                    &plugin_apps,
+                    &environment_manager,
+                    &runtime_capabilities,
+                )
+                .await;
                 remote_plugin_detail_to_info(remote_detail, app_summaries)
             }
         };
@@ -1477,12 +1488,14 @@ impl PluginRequestProcessor {
         }
 
         let environment_manager = self.thread_manager.environment_manager();
+        let runtime_capabilities = self.thread_manager.runtime_capabilities();
         let (all_connectors_result, accessible_connectors_result) = tokio::join!(
             connectors::list_all_connectors_with_options(config, /*force_refetch*/ true),
             connectors::list_accessible_connectors_from_mcp_tools_with_environment_manager(
                 config,
                 /*force_refetch*/ true,
-                &environment_manager
+                &environment_manager,
+                &runtime_capabilities,
             ),
         );
 
@@ -1749,6 +1762,7 @@ async fn load_plugin_app_summaries(
     config: &Config,
     plugin_apps: &[codex_plugin::AppConnectorId],
     environment_manager: &EnvironmentManager,
+    runtime_capabilities: &RuntimeCapabilities,
 ) -> Vec<AppSummary> {
     if plugin_apps.is_empty() {
         return Vec::new();
@@ -1772,6 +1786,7 @@ async fn load_plugin_app_summaries(
             config,
             /*force_refetch*/ false,
             environment_manager,
+            runtime_capabilities,
         )
         .await
         {

--- a/codex-rs/core/src/connectors.rs
+++ b/codex-rs/core/src/connectors.rs
@@ -12,6 +12,7 @@ pub use codex_app_server_protocol::AppInfo;
 pub use codex_app_server_protocol::AppMetadata;
 use codex_connectors::ConnectorDirectoryCacheContext;
 use codex_connectors::ConnectorDirectoryCacheKey;
+use codex_exec_server::Environment;
 use codex_exec_server::EnvironmentManager;
 use codex_exec_server::ExecServerRuntimePaths;
 use codex_protocol::models::PermissionProfile;
@@ -23,6 +24,7 @@ use tracing::warn;
 use crate::config::Config;
 use crate::mcp::McpManager;
 use crate::plugins::list_tool_suggest_discoverable_plugins;
+use crate::runtime_capabilities::RuntimeCapabilities;
 use crate::session::INITIAL_SUBMIT_ID;
 use codex_config::AppsRequirementsToml;
 use codex_config::types::AppToolApproval;
@@ -199,10 +201,12 @@ pub async fn list_accessible_connectors_from_mcp_tools_with_options_and_status(
     )?;
     let environment_manager =
         EnvironmentManager::from_codex_home(config.codex_home.clone(), local_runtime_paths).await?;
+    let runtime_capabilities = RuntimeCapabilities::local(&environment_manager);
     list_accessible_connectors_from_mcp_tools_with_environment_manager(
         config,
         force_refetch,
         &environment_manager,
+        &runtime_capabilities,
     )
     .await
 }
@@ -211,6 +215,7 @@ pub async fn list_accessible_connectors_from_mcp_tools_with_environment_manager(
     config: &Config,
     force_refetch: bool,
     environment_manager: &EnvironmentManager,
+    runtime_capabilities: &RuntimeCapabilities,
 ) -> anyhow::Result<AccessibleConnectorsStatus> {
     let auth_manager =
         AuthManager::shared_from_config(config, /*enable_codex_api_key_env*/ false).await;
@@ -261,9 +266,7 @@ pub async fn list_accessible_connectors_from_mcp_tools_with_environment_manager(
     let (tx_event, rx_event) = unbounded();
     drop(rx_event);
 
-    let environment = environment_manager
-        .default_environment()
-        .unwrap_or_else(|| environment_manager.local_environment());
+    let environment = mcp_runtime_environment(environment_manager, runtime_capabilities)?;
 
     let (mut mcp_connection_manager, cancel_token) = McpConnectionManager::new(
         &mcp_servers,
@@ -353,6 +356,16 @@ pub async fn list_accessible_connectors_from_mcp_tools_with_environment_manager(
         connectors: accessible_connectors,
         codex_apps_ready,
     })
+}
+
+fn mcp_runtime_environment(
+    environment_manager: &EnvironmentManager,
+    runtime_capabilities: &RuntimeCapabilities,
+) -> anyhow::Result<Arc<Environment>> {
+    match environment_manager.default_environment() {
+        Some(environment) => Ok(environment),
+        None => Ok(runtime_capabilities.require_local_environment("list accessible connectors")?),
+    }
 }
 
 fn accessible_connectors_cache_key(

--- a/codex-rs/core/src/connectors_tests.rs
+++ b/codex-rs/core/src/connectors_tests.rs
@@ -16,6 +16,8 @@ use codex_config::types::AppsDefaultConfig;
 use codex_connectors::merge::plugin_connector_to_app_info;
 use codex_connectors::metadata::connector_install_url;
 use codex_connectors::metadata::sanitize_name;
+use codex_exec_server::EnvironmentManager;
+use codex_exec_server::ExecServerRuntimePaths;
 use codex_features::Feature;
 use codex_login::CodexAuth;
 use codex_mcp::CODEX_APPS_MCP_SERVER_NAME;
@@ -114,6 +116,42 @@ fn with_accessible_connectors_cache_cleared<R>(f: impl FnOnce() -> R) -> R {
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     *cache_guard = previous;
     result
+}
+
+fn test_runtime_paths() -> ExecServerRuntimePaths {
+    ExecServerRuntimePaths::new(
+        std::env::current_exe().expect("current exe"),
+        /*codex_linux_sandbox_exe*/ None,
+    )
+    .expect("runtime paths")
+}
+
+#[tokio::test]
+async fn mcp_runtime_environment_preserves_configured_default_environment() {
+    let environment_manager = EnvironmentManager::create_for_tests(
+        Some("ws://127.0.0.1:8765".to_string()),
+        test_runtime_paths(),
+    )
+    .await;
+
+    let environment =
+        mcp_runtime_environment(&environment_manager, &RuntimeCapabilities::isolated())
+            .expect("configured default environment should be available");
+
+    assert!(environment.is_remote());
+}
+
+#[test]
+fn mcp_runtime_environment_requires_local_capability_without_default_environment() {
+    let environment_manager = EnvironmentManager::disabled_for_tests(test_runtime_paths());
+
+    let err = mcp_runtime_environment(&environment_manager, &RuntimeCapabilities::isolated())
+        .expect_err("isolated runtime should not get ambient local environment");
+
+    assert_eq!(
+        err.to_string(),
+        "list accessible connectors requires ambient worker-local environment"
+    );
 }
 
 #[test]

--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -423,6 +423,10 @@ impl ThreadManager {
         self.state.environment_manager.clone()
     }
 
+    pub fn runtime_capabilities(&self) -> Arc<RuntimeCapabilities> {
+        Arc::clone(&self.state.runtime_capabilities)
+    }
+
     pub fn default_environment_selections(
         &self,
         cwd: &AbsolutePathBuf,

--- a/codex-rs/tui/src/chatwidget/connectors.rs
+++ b/codex-rs/tui/src/chatwidget/connectors.rs
@@ -49,11 +49,14 @@ impl ChatWidget {
         let environment_manager = Arc::clone(&self.environment_manager);
         let app_event_tx = self.app_event_tx.clone();
         tokio::spawn(async move {
+            let runtime_capabilities =
+                codex_app_server_client::RuntimeCapabilities::local(environment_manager.as_ref());
             let accessible_result =
                 match chatgpt_connectors::list_accessible_connectors_from_mcp_tools_with_environment_manager(
                     &config,
                     force_refetch,
                     &environment_manager,
+                    &runtime_capabilities,
                 )
                 .await
                 {


### PR DESCRIPTION
Draft backup of the current remote PR-slice worktree for the Execution Order / PR Slices stack. This is a safety snapshot, not the canonical review PR. It is intentionally based on the previous slice branch so the diff stays one slice wide.