### PR TITLE
Backup PR 7 - Add prepared config runtime boundary

### DIFF
--- a/codex-rs/app-server-client/src/lib.rs
+++ b/codex-rs/app-server-client/src/lib.rs
@@ -26,6 +26,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 pub use codex_app_server::app_server_control_socket_path;
+use codex_app_server::config_provider::PreparedConfig;
+use codex_app_server::config_provider::StaticConfigProvider;
 pub use codex_app_server::in_process::DEFAULT_IN_PROCESS_CHANNEL_CAPACITY;
 pub use codex_app_server::in_process::InProcessServerEvent;
 use codex_app_server::in_process::InProcessStartArgs;
@@ -402,9 +404,14 @@ impl InProcessClientStartArgs {
     fn into_runtime_start_args(self) -> InProcessStartArgs {
         let initialize = self.initialize_params();
         let thread_config_loader = configured_thread_config_loader(&self.config);
+        let prepared_config = if self.runtime_capabilities.local_filesystem().is_some() {
+            PreparedConfig::reloadable(self.config)
+        } else {
+            PreparedConfig::new(self.config)
+        };
         InProcessStartArgs {
             arg0_paths: self.arg0_paths,
-            config: self.config,
+            config_provider: Arc::new(StaticConfigProvider::new(prepared_config)),
             cli_overrides: self.cli_overrides,
             loader_overrides: self.loader_overrides,
             strict_config: self.strict_config,
@@ -2220,7 +2227,7 @@ mod tests {
         }
         .into_runtime_start_args();
 
-        assert_eq!(runtime_args.config, config);
+        assert_eq!(runtime_args.config_provider.current().config(), config);
         assert!(Arc::ptr_eq(
             &runtime_args.environment_manager,
             &environment_manager

--- a/codex-rs/app-server/src/config_provider.rs
+++ b/codex-rs/app-server/src/config_provider.rs
@@ -1,0 +1,102 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use codex_config::NoopThreadConfigLoader;
+use codex_config::ThreadConfigContext;
+use codex_config::ThreadConfigLoader;
+use codex_core::config::Config;
+use codex_core::config::ConfigOverrides;
+use codex_utils_absolute_path::AbsolutePathBuf;
+use codex_utils_json_to_toml::json_to_toml;
+
+/// Read-only app-owned access to the prepared config snapshot used at runtime.
+pub trait ConfigProvider: Send + Sync {
+    /// Returns the effective config snapshot that new runtime consumers should use.
+    fn current(&self) -> PreparedConfig;
+}
+
+/// Effective config snapshot prepared by app/bootstrap before core consumes it.
+#[derive(Clone)]
+pub struct PreparedConfig {
+    config: Arc<Config>,
+    reload_thread_config: bool,
+    thread_config_loader: Arc<dyn ThreadConfigLoader>,
+}
+
+impl PreparedConfig {
+    pub fn new(config: Arc<Config>) -> Self {
+        Self {
+            config,
+            reload_thread_config: false,
+            thread_config_loader: Arc::new(NoopThreadConfigLoader),
+        }
+    }
+
+    pub fn reloadable(config: Arc<Config>) -> Self {
+        Self {
+            config,
+            reload_thread_config: true,
+            thread_config_loader: Arc::new(NoopThreadConfigLoader),
+        }
+    }
+
+    pub fn with_thread_config_loader(
+        mut self,
+        thread_config_loader: Arc<dyn ThreadConfigLoader>,
+    ) -> Self {
+        self.thread_config_loader = thread_config_loader;
+        self
+    }
+
+    pub fn config(&self) -> Arc<Config> {
+        Arc::clone(&self.config)
+    }
+
+    pub(crate) fn reloads_thread_config(&self) -> bool {
+        self.reload_thread_config
+    }
+
+    pub(crate) async fn derive_thread_config(
+        &self,
+        request_overrides: Option<HashMap<String, serde_json::Value>>,
+        typesafe_overrides: ConfigOverrides,
+    ) -> std::io::Result<Config> {
+        let session_overrides = request_overrides
+            .unwrap_or_default()
+            .into_iter()
+            .map(|(key, value)| (key, json_to_toml(value)))
+            .collect();
+        let cwd = match typesafe_overrides.cwd.as_deref() {
+            Some(cwd) => AbsolutePathBuf::relative_to_current_dir(cwd)?,
+            None => self.config.cwd.clone(),
+        };
+        let thread_config_layers = self
+            .thread_config_loader
+            .load_config_layers(ThreadConfigContext {
+                thread_id: None,
+                cwd: Some(cwd),
+            })
+            .await
+            .map_err(std::io::Error::other)?;
+        self.config
+            .derive_thread_config(session_overrides, thread_config_layers, typesafe_overrides)
+            .await
+    }
+}
+
+/// Read-only provider for callers that already prepared a fixed config snapshot.
+pub struct StaticConfigProvider {
+    current: PreparedConfig,
+}
+
+impl StaticConfigProvider {
+    pub fn new(current: PreparedConfig) -> Self {
+        Self { current }
+    }
+}
+
+impl ConfigProvider for StaticConfigProvider {
+    fn current(&self) -> PreparedConfig {
+        self.current.clone()
+    }
+}

--- a/codex-rs/app-server/src/in_process.rs
+++ b/codex-rs/app-server/src/in_process.rs
@@ -52,6 +52,11 @@ use std::time::Duration;
 
 use crate::analytics_utils::analytics_events_client_from_config;
 use crate::config_manager::ConfigManager;
+use crate::config_provider::ConfigProvider;
+#[cfg(test)]
+use crate::config_provider::PreparedConfig;
+#[cfg(test)]
+use crate::config_provider::StaticConfigProvider;
 use crate::error_code::OVERLOADED_ERROR_CODE;
 use crate::error_code::internal_error;
 use crate::error_code::invalid_request;
@@ -81,6 +86,7 @@ use codex_config::CloudRequirementsLoader;
 use codex_config::LoaderOverrides;
 use codex_config::ThreadConfigLoader;
 use codex_core::RuntimeCapabilities;
+#[cfg(test)]
 use codex_core::config::Config;
 use codex_core::resolve_installation_id;
 use codex_exec_server::EnvironmentManager;
@@ -114,8 +120,8 @@ fn server_notification_requires_delivery(notification: &ServerNotification) -> b
 pub struct InProcessStartArgs {
     /// Resolved argv0 dispatch paths used by command execution internals.
     pub arg0_paths: Arg0DispatchPaths,
-    /// Shared base config used to initialize core components.
-    pub config: Arc<Config>,
+    /// Prepared read-only config source used to initialize core components.
+    pub config_provider: Arc<dyn ConfigProvider>,
     /// CLI config overrides that are already parsed into TOML values.
     pub cli_overrides: Vec<(String, TomlValue)>,
     /// Loader override knobs used by config API paths.
@@ -371,17 +377,21 @@ pub async fn start(args: InProcessStartArgs) -> IoResult<InProcessClientHandle> 
 
 async fn start_uninitialized(args: InProcessStartArgs) -> IoResult<InProcessClientHandle> {
     let channel_capacity = args.channel_capacity.max(1);
-    let installation_id = resolve_installation_id(&args.config.codex_home).await?;
+    let prepared_config = args
+        .config_provider
+        .current()
+        .with_thread_config_loader(Arc::clone(&args.thread_config_loader));
+    let config = prepared_config.config();
+    let installation_id = resolve_installation_id(&config.codex_home).await?;
     let (client_tx, mut client_rx) = mpsc::channel::<InProcessClientMessage>(channel_capacity);
     let (event_tx, event_rx) = mpsc::channel::<InProcessServerEvent>(channel_capacity);
 
     let runtime_handle = tokio::spawn(async move {
         let (outgoing_tx, mut outgoing_rx) = mpsc::channel::<OutgoingEnvelope>(channel_capacity);
         let auth_manager =
-            AuthManager::shared_from_config(args.config.as_ref(), args.enable_codex_api_key_env)
-                .await;
+            AuthManager::shared_from_config(config.as_ref(), args.enable_codex_api_key_env).await;
         let analytics_events_client =
-            analytics_events_client_from_config(Arc::clone(&auth_manager), args.config.as_ref());
+            analytics_events_client_from_config(Arc::clone(&auth_manager), config.as_ref());
         let outgoing_message_sender = Arc::new(OutgoingMessageSender::new(
             outgoing_tx,
             analytics_events_client.clone(),
@@ -411,7 +421,7 @@ async fn start_uninitialized(args: InProcessStartArgs) -> IoResult<InProcessClie
 
         let processor_outgoing = Arc::clone(&outgoing_message_sender);
         let config_manager = ConfigManager::new(
-            args.config.codex_home.to_path_buf(),
+            config.codex_home.to_path_buf(),
             args.cli_overrides,
             args.loader_overrides,
             args.strict_config,
@@ -426,7 +436,7 @@ async fn start_uninitialized(args: InProcessStartArgs) -> IoResult<InProcessClie
                 outgoing: Arc::clone(&processor_outgoing),
                 analytics_events_client,
                 arg0_paths: args.arg0_paths,
-                config: args.config,
+                prepared_config,
                 config_manager,
                 environment_manager: args.environment_manager,
                 runtime_capabilities: args.runtime_capabilities,
@@ -743,6 +753,7 @@ mod tests {
     use codex_app_server_protocol::TurnItemsView;
     use codex_app_server_protocol::TurnStatus;
     use codex_core::config::ConfigBuilder;
+    use codex_protocol::openai_models::ReasoningEffort;
     use codex_utils_absolute_path::AbsolutePathBuf;
     use pretty_assertions::assert_eq;
     use std::path::Path;
@@ -789,7 +800,7 @@ mod tests {
         let environment_manager = Arc::new(EnvironmentManager::default_for_tests());
         let args = InProcessStartArgs {
             arg0_paths: Arg0DispatchPaths::default(),
-            config,
+            config_provider: Arc::new(StaticConfigProvider::new(PreparedConfig::new(config))),
             cli_overrides: Vec::new(),
             loader_overrides: LoaderOverrides::default(),
             strict_config: false,
@@ -900,6 +911,33 @@ mod tests {
                 .await
                 .expect("in-process runtime should shutdown cleanly");
         }
+    }
+
+    #[tokio::test]
+    async fn isolated_thread_start_uses_prepared_config() {
+        let client = start_isolated_test_client().await;
+        let response = client
+            .request(ClientRequest::ThreadStart {
+                request_id: RequestId::Integer(2),
+                params: ThreadStartParams {
+                    config: Some(HashMap::from([(
+                        "model_reasoning_effort".to_string(),
+                        serde_json::Value::String("high".to_string()),
+                    )])),
+                    ephemeral: Some(true),
+                    ..ThreadStartParams::default()
+                },
+            })
+            .await
+            .expect("request transport should work")
+            .expect("thread/start should succeed");
+        let parsed: ThreadStartResponse =
+            serde_json::from_value(response).expect("thread/start response should parse");
+        assert_eq!(parsed.reasoning_effort, Some(ReasoningEffort::High));
+        client
+            .shutdown()
+            .await
+            .expect("in-process runtime should shutdown cleanly");
     }
 
     #[tokio::test]

--- a/codex-rs/app-server/src/lib.rs
+++ b/codex-rs/app-server/src/lib.rs
@@ -20,6 +20,7 @@ use std::sync::atomic::AtomicBool;
 
 use crate::analytics_utils::analytics_events_client_from_config;
 use crate::config_manager::ConfigManager;
+use crate::config_provider::PreparedConfig;
 use crate::message_processor::MessageProcessor;
 use crate::message_processor::MessageProcessorArgs;
 use crate::outgoing_message::ConnectionId;
@@ -79,6 +80,7 @@ mod command_exec;
 mod config;
 mod config_manager;
 mod config_manager_service;
+pub mod config_provider;
 mod connection_rpc_gate;
 mod dynamic_tools;
 mod error_code;
@@ -687,8 +689,10 @@ pub async fn run_main_with_transport_options(
         AppServerTransport::Off => {}
     }
 
+    let config = Arc::new(config);
+    let prepared_config = PreparedConfig::reloadable(Arc::clone(&config));
     let auth_manager =
-        AuthManager::shared_from_config(&config, /*enable_codex_api_key_env*/ false).await;
+        AuthManager::shared_from_config(config.as_ref(), /*enable_codex_api_key_env*/ false).await;
 
     let remote_control_requested = runtime_options.remote_control_enabled;
     let remote_control_enabled = remote_control_requested && state_db.is_some();
@@ -777,10 +781,13 @@ pub async fn run_main_with_transport_options(
     });
 
     let processor_handle = tokio::spawn({
-        let auth_manager =
-            AuthManager::shared_from_config(&config, /*enable_codex_api_key_env*/ false).await;
+        let auth_manager = AuthManager::shared_from_config(
+            config.as_ref(),
+            /*enable_codex_api_key_env*/ false,
+        )
+        .await;
         let analytics_events_client =
-            analytics_events_client_from_config(Arc::clone(&auth_manager), &config);
+            analytics_events_client_from_config(Arc::clone(&auth_manager), config.as_ref());
         let outgoing_message_sender = Arc::new(OutgoingMessageSender::new(
             outgoing_tx,
             analytics_events_client.clone(),
@@ -791,7 +798,7 @@ pub async fn run_main_with_transport_options(
             outgoing: outgoing_message_sender,
             analytics_events_client,
             arg0_paths,
-            config: Arc::new(config),
+            prepared_config,
             config_manager,
             environment_manager,
             runtime_capabilities,

--- a/codex-rs/app-server/src/message_processor.rs
+++ b/codex-rs/app-server/src/message_processor.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::AtomicBool;
 
 use crate::attestation::app_server_attestation_provider;
 use crate::config_manager::ConfigManager;
+use crate::config_provider::PreparedConfig;
 use crate::connection_rpc_gate::ConnectionRpcGate;
 use crate::error_code::invalid_request;
 use crate::extensions::guardian_agent_spawner;
@@ -67,7 +68,6 @@ use codex_arg0::Arg0DispatchPaths;
 use codex_chatgpt::workspace_settings;
 use codex_core::RuntimeCapabilities;
 use codex_core::ThreadManager;
-use codex_core::config::Config;
 use codex_exec_server::EnvironmentManager;
 use codex_feedback::CodexFeedback;
 use codex_login::AuthManager;
@@ -257,7 +257,7 @@ pub(crate) struct MessageProcessorArgs {
     pub(crate) outgoing: Arc<OutgoingMessageSender>,
     pub(crate) analytics_events_client: AnalyticsEventsClient,
     pub(crate) arg0_paths: Arg0DispatchPaths,
-    pub(crate) config: Arc<Config>,
+    pub(crate) prepared_config: PreparedConfig,
     pub(crate) config_manager: ConfigManager,
     pub(crate) environment_manager: Arc<EnvironmentManager>,
     pub(crate) runtime_capabilities: Arc<RuntimeCapabilities>,
@@ -281,7 +281,7 @@ impl MessageProcessor {
             outgoing,
             analytics_events_client,
             arg0_paths,
-            config,
+            prepared_config,
             config_manager,
             environment_manager,
             runtime_capabilities,
@@ -296,6 +296,7 @@ impl MessageProcessor {
             remote_control_handle,
             plugin_startup_tasks,
         } = args;
+        let config = prepared_config.config();
         auth_manager.set_external_auth(Arc::new(ExternalAuthRefreshBridge {
             outgoing: outgoing.clone(),
         }));
@@ -413,6 +414,7 @@ impl MessageProcessor {
             outgoing.clone(),
             arg0_paths.clone(),
             Arc::clone(&config),
+            prepared_config.clone(),
             config_manager.clone(),
             Arc::clone(&runtime_capabilities),
             Arc::clone(&thread_store),

--- a/codex-rs/app-server/src/message_processor_tracing_tests.rs
+++ b/codex-rs/app-server/src/message_processor_tracing_tests.rs
@@ -3,6 +3,7 @@ use super::MessageProcessor;
 use super::MessageProcessorArgs;
 use crate::analytics_utils::analytics_events_client_from_config;
 use crate::config_manager::ConfigManager;
+use crate::config_provider::PreparedConfig;
 use crate::outgoing_message::ConnectionId;
 use crate::outgoing_message::OutgoingMessageSender;
 use crate::transport::AppServerTransport;
@@ -258,7 +259,7 @@ async fn build_test_processor(
         outgoing,
         analytics_events_client,
         arg0_paths: Arg0DispatchPaths::default(),
-        config,
+        prepared_config: PreparedConfig::new(config),
         config_manager,
         environment_manager,
         runtime_capabilities,

--- a/codex-rs/app-server/src/request_processors/thread_processor.rs
+++ b/codex-rs/app-server/src/request_processors/thread_processor.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::config_provider::PreparedConfig;
 use crate::error_code::method_not_found;
 use codex_protocol::models::BUILT_IN_PERMISSION_PROFILE_DANGER_FULL_ACCESS;
 use codex_protocol::models::BUILT_IN_PERMISSION_PROFILE_WORKSPACE;
@@ -329,6 +330,7 @@ pub(crate) struct ThreadRequestProcessor {
     pub(super) outgoing: Arc<OutgoingMessageSender>,
     pub(super) arg0_paths: Arg0DispatchPaths,
     pub(super) config: Arc<Config>,
+    pub(super) prepared_config: PreparedConfig,
     pub(super) config_manager: ConfigManager,
     pub(super) runtime_capabilities: Arc<RuntimeCapabilities>,
     pub(super) thread_store: Arc<dyn ThreadStore>,
@@ -350,6 +352,7 @@ impl ThreadRequestProcessor {
         outgoing: Arc<OutgoingMessageSender>,
         arg0_paths: Arg0DispatchPaths,
         config: Arc<Config>,
+        prepared_config: PreparedConfig,
         config_manager: ConfigManager,
         runtime_capabilities: Arc<RuntimeCapabilities>,
         thread_store: Arc<dyn ThreadStore>,
@@ -367,6 +370,7 @@ impl ThreadRequestProcessor {
             outgoing,
             arg0_paths,
             config,
+            prepared_config,
             config_manager,
             runtime_capabilities,
             thread_store,
@@ -883,12 +887,14 @@ impl ThreadRequestProcessor {
         };
         let request_trace = request_context.request_trace();
         let config_manager = self.config_manager.clone();
+        let prepared_config = self.prepared_config.clone();
         let runtime_capabilities = Arc::clone(&self.runtime_capabilities);
         let outgoing = Arc::clone(&listener_task_context.outgoing);
         let error_request_id = request_id.clone();
         let thread_start_task = async move {
             if let Err(error) = Self::thread_start_task(
                 listener_task_context,
+                prepared_config,
                 config_manager,
                 runtime_capabilities,
                 request_id,
@@ -974,6 +980,7 @@ impl ThreadRequestProcessor {
     #[allow(clippy::too_many_arguments)]
     async fn thread_start_task(
         listener_task_context: ListenerTaskContext,
+        prepared_config: PreparedConfig,
         config_manager: ConfigManager,
         runtime_capabilities: Arc<RuntimeCapabilities>,
         request_id: ConnectionRequestId,
@@ -991,10 +998,16 @@ impl ThreadRequestProcessor {
     ) -> Result<(), JSONRPCErrorError> {
         let thread_start_started_at = std::time::Instant::now();
         let requested_cwd = typesafe_overrides.cwd.clone();
-        let mut config = config_manager
-            .load_with_overrides(config_overrides.clone(), typesafe_overrides.clone())
-            .await
-            .map_err(|err| config_load_error(&err))?;
+        let mut config = if prepared_config.reloads_thread_config() {
+            config_manager
+                .load_with_overrides(config_overrides.clone(), typesafe_overrides.clone())
+                .await
+        } else {
+            prepared_config
+                .derive_thread_config(config_overrides.clone(), typesafe_overrides.clone())
+                .await
+        }
+        .map_err(|err| config_load_error(&err))?;
 
         // The user may have requested WorkspaceWrite or DangerFullAccess via
         // the command line, though in the process of deriving the Config, it
@@ -1008,7 +1021,8 @@ impl ThreadRequestProcessor {
             config.cwd.as_path(),
         );
 
-        if requested_cwd.is_some()
+        if runtime_capabilities.local_filesystem().is_some()
+            && requested_cwd.is_some()
             && config.active_project.trust_level.is_none()
             && (requested_permissions_trust_project || effective_permissions_trust_project)
         {

--- a/codex-rs/app-server/src/request_processors/thread_processor_tests.rs
+++ b/codex-rs/app-server/src/request_processors/thread_processor_tests.rs
@@ -46,6 +46,7 @@ mod thread_processor_behavior_tests {
     }
 
     use super::super::*;
+    use crate::config_provider::PreparedConfig;
     use crate::outgoing_message::OutgoingEnvelope;
     use crate::outgoing_message::OutgoingMessage;
     use anyhow::Result;
@@ -59,6 +60,7 @@ mod thread_processor_behavior_tests {
     use codex_config::SessionThreadConfig;
     use codex_config::StaticThreadConfigLoader;
     use codex_config::ThreadConfigSource;
+    use codex_core::config::ConfigBuilder;
     use codex_model_provider_info::ModelProviderInfo;
     use codex_model_provider_info::WireApi;
     use codex_protocol::ThreadId;
@@ -621,6 +623,58 @@ mod thread_processor_behavior_tests {
                             "wire_api": "responses",
                         }),
                     ),
+                ])),
+                ConfigOverrides::default(),
+            )
+            .await?;
+
+        assert_eq!(config.model_provider_id, "session");
+        assert_eq!(config.model_provider, session_provider);
+        assert!(!config.features.enabled(Feature::Plugins));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn prepared_config_uses_session_thread_config_model_provider() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let session_provider = ModelProviderInfo {
+            name: "session".to_string(),
+            base_url: Some("http://127.0.0.1:8061/api/codex".to_string()),
+            env_key: None,
+            env_key_instructions: None,
+            experimental_bearer_token: None,
+            auth: None,
+            aws: None,
+            wire_api: WireApi::Responses,
+            query_params: None,
+            http_headers: None,
+            env_http_headers: None,
+            request_max_retries: None,
+            stream_max_retries: None,
+            stream_idle_timeout_ms: None,
+            websocket_connect_timeout_ms: None,
+            requires_openai_auth: false,
+            supports_websockets: true,
+        };
+        let base_config = ConfigBuilder::default()
+            .codex_home(temp_dir.path().to_path_buf())
+            .build()
+            .await?;
+        let config = PreparedConfig::new(Arc::new(base_config))
+            .with_thread_config_loader(Arc::new(StaticThreadConfigLoader::new(vec![
+                ThreadConfigSource::Session(SessionThreadConfig {
+                    model_provider: Some("session".to_string()),
+                    model_providers: HashMap::from([(
+                        "session".to_string(),
+                        session_provider.clone(),
+                    )]),
+                    features: BTreeMap::from([("plugins".to_string(), false)]),
+                }),
+            ])))
+            .derive_thread_config(
+                Some(HashMap::from([
+                    ("model_provider".to_string(), json!("request")),
+                    ("features.plugins".to_string(), json!(true)),
                 ])),
                 ConfigOverrides::default(),
             )

--- a/codex-rs/app-server/tests/suite/conversation_summary.rs
+++ b/codex-rs/app-server/tests/suite/conversation_summary.rs
@@ -3,6 +3,8 @@ use app_test_support::McpProcess;
 use app_test_support::create_fake_rollout;
 use app_test_support::rollout_path;
 use app_test_support::to_response;
+use codex_app_server::config_provider::PreparedConfig;
+use codex_app_server::config_provider::StaticConfigProvider;
 use codex_app_server::in_process;
 use codex_app_server::in_process::InProcessStartArgs;
 use codex_app_server_protocol::ClientInfo;
@@ -148,7 +150,9 @@ async fn get_conversation_summary_by_thread_id_reads_pathless_store_thread() -> 
     let environment_manager = Arc::new(EnvironmentManager::default_for_tests());
     let client = in_process::start(InProcessStartArgs {
         arg0_paths: Arg0DispatchPaths::default(),
-        config: Arc::new(config),
+        config_provider: Arc::new(StaticConfigProvider::new(PreparedConfig::new(Arc::new(
+            config,
+        )))),
         cli_overrides: Vec::new(),
         loader_overrides,
         strict_config: false,

--- a/codex-rs/app-server/tests/suite/v2/mcp_resource.rs
+++ b/codex-rs/app-server/tests/suite/v2/mcp_resource.rs
@@ -7,6 +7,8 @@ use app_test_support::McpProcess;
 use app_test_support::to_response;
 use app_test_support::write_chatgpt_auth;
 use axum::Router;
+use codex_app_server::config_provider::PreparedConfig;
+use codex_app_server::config_provider::StaticConfigProvider;
 use codex_app_server::in_process;
 use codex_app_server::in_process::InProcessStartArgs;
 use codex_app_server_protocol::ClientInfo;
@@ -199,7 +201,9 @@ async fn mcp_resource_read_returns_error_for_unknown_thread() -> Result<()> {
     let environment_manager = Arc::new(EnvironmentManager::default_for_tests());
     let client = in_process::start(InProcessStartArgs {
         arg0_paths: Arg0DispatchPaths::default(),
-        config: Arc::new(config),
+        config_provider: Arc::new(StaticConfigProvider::new(PreparedConfig::new(Arc::new(
+            config,
+        )))),
         cli_overrides: Vec::new(),
         loader_overrides,
         strict_config: false,

--- a/codex-rs/app-server/tests/suite/v2/remote_thread_store.rs
+++ b/codex-rs/app-server/tests/suite/v2/remote_thread_store.rs
@@ -19,6 +19,8 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use app_test_support::create_mock_responses_server_repeating_assistant;
+use codex_app_server::config_provider::PreparedConfig;
+use codex_app_server::config_provider::StaticConfigProvider;
 use codex_app_server::in_process;
 use codex_app_server::in_process::InProcessServerEvent;
 use codex_app_server::in_process::InProcessStartArgs;
@@ -74,7 +76,9 @@ async fn thread_start_with_non_local_thread_store_does_not_create_local_persiste
     let environment_manager = Arc::new(EnvironmentManager::default_for_tests());
     let mut client = in_process::start(InProcessStartArgs {
         arg0_paths: Arg0DispatchPaths::default(),
-        config: Arc::new(config),
+        config_provider: Arc::new(StaticConfigProvider::new(PreparedConfig::new(Arc::new(
+            config,
+        )))),
         cli_overrides: Vec::new(),
         loader_overrides,
         strict_config: false,

--- a/codex-rs/app-server/tests/suite/v2/thread_read.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_read.rs
@@ -5,6 +5,8 @@ use app_test_support::create_mock_responses_server_repeating_assistant;
 use app_test_support::rollout_path;
 use app_test_support::test_absolute_path;
 use app_test_support::to_response;
+use codex_app_server::config_provider::PreparedConfig;
+use codex_app_server::config_provider::StaticConfigProvider;
 use codex_app_server::in_process;
 use codex_app_server::in_process::InProcessStartArgs;
 use codex_app_server_protocol::ClientInfo;
@@ -374,7 +376,9 @@ async fn thread_turns_list_reads_store_history_without_rollout_path() -> Result<
     let environment_manager = Arc::new(EnvironmentManager::default_for_tests());
     let client = in_process::start(InProcessStartArgs {
         arg0_paths: Arg0DispatchPaths::default(),
-        config: Arc::new(config),
+        config_provider: Arc::new(StaticConfigProvider::new(PreparedConfig::new(Arc::new(
+            config,
+        )))),
         cli_overrides: Vec::new(),
         loader_overrides,
         strict_config: false,
@@ -442,7 +446,9 @@ async fn thread_read_loaded_include_turns_reads_store_history_without_rollout_pa
     let environment_manager = Arc::new(EnvironmentManager::default_for_tests());
     let client = in_process::start(InProcessStartArgs {
         arg0_paths: Arg0DispatchPaths::default(),
-        config: Arc::new(config),
+        config_provider: Arc::new(StaticConfigProvider::new(PreparedConfig::new(Arc::new(
+            config,
+        )))),
         cli_overrides: Vec::new(),
         loader_overrides,
         strict_config: false,
@@ -530,7 +536,9 @@ async fn thread_list_includes_store_thread_without_rollout_path() -> Result<()> 
     let environment_manager = Arc::new(EnvironmentManager::default_for_tests());
     let client = in_process::start(InProcessStartArgs {
         arg0_paths: Arg0DispatchPaths::default(),
-        config: Arc::new(config),
+        config_provider: Arc::new(StaticConfigProvider::new(PreparedConfig::new(Arc::new(
+            config,
+        )))),
         cli_overrides: Vec::new(),
         loader_overrides,
         strict_config: false,

--- a/codex-rs/app-server/tests/suite/v2/thread_unarchive.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_unarchive.rs
@@ -2,6 +2,8 @@ use anyhow::Result;
 use app_test_support::McpProcess;
 use app_test_support::create_mock_responses_server_repeating_assistant;
 use app_test_support::to_response;
+use codex_app_server::config_provider::PreparedConfig;
+use codex_app_server::config_provider::StaticConfigProvider;
 use codex_app_server::in_process;
 use codex_app_server::in_process::InProcessStartArgs;
 use codex_app_server_protocol::ClientInfo;
@@ -244,7 +246,9 @@ async fn thread_unarchive_preserves_pathless_store_metadata() -> Result<()> {
     let environment_manager = Arc::new(EnvironmentManager::default_for_tests());
     let client = in_process::start(InProcessStartArgs {
         arg0_paths: Arg0DispatchPaths::default(),
-        config: Arc::new(config),
+        config_provider: Arc::new(StaticConfigProvider::new(PreparedConfig::new(Arc::new(
+            config,
+        )))),
         cli_overrides: Vec::new(),
         loader_overrides,
         strict_config: false,

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -8,6 +8,7 @@ use crate::windows_sandbox::WindowsSandboxLevelExt;
 use crate::windows_sandbox::resolve_windows_sandbox_mode;
 use crate::windows_sandbox::resolve_windows_sandbox_private_desktop;
 use codex_config::CloudRequirementsLoader;
+use codex_config::ConfigLayerEntry;
 use codex_config::ConfigLayerSource;
 use codex_config::ConfigLayerStack;
 use codex_config::ConfigLayerStackOrdering;
@@ -1362,6 +1363,59 @@ impl Config {
                 ..Default::default()
             },
             refreshed_config.codex_home.clone(),
+            config_layer_stack,
+        )
+        .await
+    }
+
+    /// Derives a thread-scoped config from this prepared snapshot without
+    /// loading config layers from disk again.
+    pub async fn derive_thread_config(
+        &self,
+        session_overrides: Vec<(String, TomlValue)>,
+        thread_config_layers: Vec<ConfigLayerEntry>,
+        overrides: ConfigOverrides,
+    ) -> std::io::Result<Self> {
+        let mut layers = self
+            .config_layer_stack
+            .get_layers(
+                ConfigLayerStackOrdering::LowestPrecedenceFirst,
+                /*include_disabled*/ true,
+            )
+            .into_iter()
+            .cloned()
+            .collect::<Vec<_>>();
+        let session_overrides = codex_config::build_cli_overrides_layer(&session_overrides);
+        if session_overrides
+            .as_table()
+            .is_some_and(|table| !table.is_empty())
+        {
+            layers.push(ConfigLayerEntry::new(
+                ConfigLayerSource::SessionFlags,
+                session_overrides,
+            ));
+            layers.sort_by_key(|layer| layer.name.precedence());
+        }
+        layers.extend(thread_config_layers);
+        layers.sort_by_key(|layer| layer.name.precedence());
+        let config_layer_stack = ConfigLayerStack::new(
+            layers,
+            self.config_layer_stack.requirements().clone(),
+            self.config_layer_stack.requirements_toml().clone(),
+        )?
+        .with_user_and_project_exec_policy_rules_ignored(
+            self.config_layer_stack
+                .ignore_user_and_project_exec_policy_rules(),
+        );
+        let cfg = deserialize_config_toml_with_base(
+            config_layer_stack.effective_config(),
+            &self.codex_home,
+        )?;
+        Self::load_config_with_layer_stack(
+            LOCAL_FS.as_ref(),
+            cfg,
+            overrides,
+            self.codex_home.clone(),
             config_layer_stack,
         )
         .await


### PR DESCRIPTION
Draft backup of the current remote PR-slice worktree for the Execution Order / PR Slices stack. This is a safety snapshot, not the canonical review PR. It is intentionally based on the previous slice branch so the diff stays one slice wide.