### PR TITLE
Backup PR 8 - Prepare global AGENTS instructions

### DIFF
--- a/codex-rs/app-server/src/mcp_refresh.rs
+++ b/codex-rs/app-server/src/mcp_refresh.rs
@@ -187,6 +187,7 @@ mod tests {
         let thread_manager = Arc::new_cyclic(|thread_manager| {
             ThreadManager::new(
                 &good_config,
+                good_config.prepared_instructions(),
                 auth_manager,
                 SessionSource::Exec,
                 environment_manager,

--- a/codex-rs/app-server/src/message_processor.rs
+++ b/codex-rs/app-server/src/message_processor.rs
@@ -308,6 +308,7 @@ impl MessageProcessor {
         let thread_manager = Arc::new_cyclic(|thread_manager| {
             ThreadManager::new(
                 config.as_ref(),
+                config.prepared_instructions(),
                 auth_manager.clone(),
                 session_source,
                 environment_manager,

--- a/codex-rs/core/src/agents_md.rs
+++ b/codex-rs/core/src/agents_md.rs
@@ -16,6 +16,7 @@
 //! 3.  We do **not** walk past the project root.
 
 use crate::config::Config;
+use crate::config::PreparedInstructions;
 use codex_app_server_protocol::ConfigLayerSource;
 use codex_config::ConfigLayerStackOrdering;
 use codex_config::default_project_root_markers;
@@ -85,20 +86,43 @@ impl<'a> AgentsMdManager<'a> {
         &self,
         environment: Option<&Environment>,
     ) -> Option<String> {
+        let prepared_instructions = self.config.prepared_instructions();
+        self.user_instructions_from_prepared(&prepared_instructions, environment)
+            .await
+    }
+
+    /// Combines prepared ambient/global instructions with AGENTS.md content
+    /// read from the selected environment.
+    pub(crate) async fn user_instructions_from_prepared(
+        &self,
+        prepared_instructions: &PreparedInstructions,
+        environment: Option<&Environment>,
+    ) -> Option<String> {
         let fs = environment?.get_filesystem();
-        self.user_instructions_with_fs(fs.as_ref()).await
+        self.user_instructions_from_prepared_with_fs(prepared_instructions, fs.as_ref())
+            .await
     }
 
     pub(crate) async fn user_instructions_with_fs(
         &self,
         fs: &dyn ExecutorFileSystem,
     ) -> Option<String> {
+        let prepared_instructions = self.config.prepared_instructions();
+        self.user_instructions_from_prepared_with_fs(&prepared_instructions, fs)
+            .await
+    }
+
+    async fn user_instructions_from_prepared_with_fs(
+        &self,
+        prepared_instructions: &PreparedInstructions,
+        fs: &dyn ExecutorFileSystem,
+    ) -> Option<String> {
         let agents_md_docs = self.read_agents_md(fs).await;
 
         let mut output = String::new();
 
-        if let Some(instructions) = self.config.user_instructions.clone() {
-            output.push_str(&instructions);
+        if let Some(instructions) = prepared_instructions.global_agents_md.as_deref() {
+            output.push_str(instructions);
         }
 
         match agents_md_docs {

--- a/codex-rs/core/src/agents_md_tests.rs
+++ b/codex-rs/core/src/agents_md_tests.rs
@@ -231,6 +231,23 @@ async fn keeps_existing_instructions_when_doc_missing() {
     assert_eq!(res, Some(INSTRUCTIONS.to_string()));
 }
 
+#[tokio::test]
+async fn prepared_global_instructions_preserve_project_doc_reads() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    fs::write(tmp.path().join("AGENTS.md"), "proj doc").unwrap();
+
+    let mut config = make_config(&tmp, /*limit*/ 4096, Some("prepared")).await;
+    let prepared_instructions = config.prepared_instructions();
+    config.user_instructions = Some("mutated".to_string());
+
+    let res = AgentsMdManager::new(&config)
+        .user_instructions_from_prepared_with_fs(&prepared_instructions, LOCAL_FS.as_ref())
+        .await
+        .expect("prepared instructions should combine with project docs");
+
+    assert_eq!(res, format!("prepared{AGENTS_MD_SEPARATOR}proj doc"));
+}
+
 /// When both the repository root and the working directory contain
 /// AGENTS.md files, their contents are concatenated from root to cwd.
 #[tokio::test]

--- a/codex-rs/core/src/codex_delegate.rs
+++ b/codex-rs/core/src/codex_delegate.rs
@@ -75,6 +75,7 @@ pub(crate) async fn run_codex_thread_interactive(
     let (tx_sub, rx_sub) = async_channel::bounded(SUBMISSION_CHANNEL_CAPACITY);
     let (tx_ops, rx_ops) = async_channel::bounded(SUBMISSION_CHANNEL_CAPACITY);
     let CodexSpawnOk { codex, .. } = Box::pin(Codex::spawn(CodexSpawnArgs {
+        prepared_instructions: parent_session.services.prepared_instructions.clone(),
         config,
         installation_id: parent_session.installation_id.clone(),
         auth_manager,

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -503,6 +503,27 @@ pub enum ThreadStoreConfig {
     InMemory { id: String },
 }
 
+/// Instruction text prepared while loading ambient/global configuration.
+///
+/// Project AGENTS.md text is intentionally excluded because it must be read
+/// from the environment selected for the session.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PreparedInstructions {
+    pub(crate) global_agents_md: Option<String>,
+}
+
+impl PreparedInstructions {
+    fn from_global_agents_md(global_agents_md: Option<crate::agents_md::LoadedAgentsMd>) -> Self {
+        Self {
+            global_agents_md: global_agents_md.map(|loaded| loaded.contents),
+        }
+    }
+
+    fn into_user_instructions(self) -> Option<String> {
+        self.global_agents_md
+    }
+}
+
 /// Application configuration loaded from disk and merged with overrides.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Config {
@@ -1197,6 +1218,13 @@ impl ConfigBuilder {
 }
 
 impl Config {
+    /// Returns ambient/global instruction text prepared during config loading.
+    pub fn prepared_instructions(&self) -> PreparedInstructions {
+        PreparedInstructions {
+            global_agents_md: self.user_instructions.clone(),
+        }
+    }
+
     pub fn legacy_sandbox_policy(&self) -> SandboxPolicy {
         self.permissions.legacy_sandbox_policy(self.cwd.as_path())
     }
@@ -2486,9 +2514,10 @@ impl Config {
             guardian_policy_config_source: _,
         } = config_layer_stack.requirements().clone();
 
-        let user_instructions = AgentsMdManager::load_global_instructions(fs, Some(&codex_home))
-            .await
-            .map(|loaded| loaded.contents);
+        let user_instructions = PreparedInstructions::from_global_agents_md(
+            AgentsMdManager::load_global_instructions(fs, Some(&codex_home)).await,
+        )
+        .into_user_instructions();
         let mut startup_warnings = config_layer_stack
             .startup_warnings()
             .unwrap_or_default()

--- a/codex-rs/core/src/prompt_debug.rs
+++ b/codex-rs/core/src/prompt_debug.rs
@@ -50,6 +50,7 @@ pub async fn build_prompt_input(
     let runtime_capabilities = Arc::new(RuntimeCapabilities::local(environment_manager.as_ref()));
     let thread_manager = ThreadManager::new(
         &config,
+        config.prepared_instructions(),
         Arc::clone(&auth_manager),
         SessionSource::Exec,
         environment_manager,

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -174,6 +174,7 @@ use crate::config::Constrained;
 use crate::config::ConstraintResult;
 use crate::config::PermissionProfileSnapshot;
 use crate::config::PermissionProfileState;
+use crate::config::PreparedInstructions;
 use crate::config::StartedNetworkProxy;
 use crate::config::resolve_web_search_mode_for_turn;
 use crate::context_manager::ContextManager;
@@ -388,6 +389,7 @@ pub struct CodexSpawnOk {
 
 pub(crate) struct CodexSpawnArgs {
     pub(crate) config: Config,
+    pub(crate) prepared_instructions: PreparedInstructions,
     pub(crate) installation_id: String,
     pub(crate) auth_manager: Arc<AuthManager>,
     pub(crate) models_manager: SharedModelsManager,
@@ -453,6 +455,7 @@ impl Codex {
     async fn spawn_internal(args: CodexSpawnArgs) -> CodexResult<CodexSpawnOk> {
         let CodexSpawnArgs {
             mut config,
+            prepared_instructions,
             installation_id,
             auth_manager,
             models_manager,
@@ -506,7 +509,7 @@ impl Codex {
 
         let primary_environment = environment_selections.primary_environment();
         let user_instructions = AgentsMdManager::new(&config)
-            .user_instructions(primary_environment.as_deref())
+            .user_instructions_from_prepared(&prepared_instructions, primary_environment.as_deref())
             .await;
 
         let exec_policy = if crate::guardian::is_guardian_reviewer_source(&session_source) {
@@ -661,6 +664,7 @@ impl Codex {
             agent_control,
             environment_manager,
             runtime_capabilities,
+            prepared_instructions,
             analytics_events_client,
             thread_store,
             parent_rollout_thread_trace,

--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -440,6 +440,7 @@ impl Session {
         agent_control: AgentControl,
         environment_manager: Arc<EnvironmentManager>,
         runtime_capabilities: Arc<RuntimeCapabilities>,
+        prepared_instructions: PreparedInstructions,
         analytics_events_client: Option<AnalyticsEventsClient>,
         thread_store: Arc<dyn ThreadStore>,
         parent_rollout_thread_trace: ThreadTraceContext,
@@ -947,6 +948,7 @@ impl Session {
                 code_mode_service: crate::tools::code_mode::CodeModeService::new(),
                 environment_manager,
                 runtime_capabilities,
+                prepared_instructions,
             };
             services
                 .model_client

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -4177,6 +4177,7 @@ async fn session_new_fails_when_zsh_fork_enabled_without_zsh_path() {
         AgentControl::default(),
         environment_manager,
         runtime_capabilities,
+        config.prepared_instructions(),
         /*analytics_events_client*/ None,
         Arc::new(codex_thread_store::LocalThreadStore::new(
             codex_thread_store::LocalThreadStoreConfig::from_config(config.as_ref()),
@@ -4542,6 +4543,7 @@ async fn make_session_with_config_and_rx(
         AgentControl::default(),
         environment_manager,
         runtime_capabilities,
+        config.prepared_instructions(),
         /*analytics_events_client*/ None,
         Arc::new(codex_thread_store::LocalThreadStore::new(
             codex_thread_store::LocalThreadStoreConfig::from_config(config.as_ref()),
@@ -4648,6 +4650,7 @@ async fn make_session_with_history_source_and_agent_control_and_rx(
         agent_control,
         environment_manager,
         runtime_capabilities,
+        config.prepared_instructions(),
         /*analytics_events_client*/ None,
         Arc::new(codex_thread_store::LocalThreadStore::new(
             codex_thread_store::LocalThreadStoreConfig::from_config(config.as_ref()),

--- a/codex-rs/core/src/session/tests/guardian_tests.rs
+++ b/codex-rs/core/src/session/tests/guardian_tests.rs
@@ -681,6 +681,7 @@ async fn guardian_subagent_does_not_inherit_parent_exec_policy_rules() {
     let environment_manager = Arc::new(EnvironmentManager::default_for_tests());
     let runtime_capabilities = Arc::new(RuntimeCapabilities::local(environment_manager.as_ref()));
     let CodexSpawnOk { codex, .. } = Codex::spawn(CodexSpawnArgs {
+        prepared_instructions: config.prepared_instructions(),
         config,
         installation_id: "11111111-1111-4111-8111-111111111111".to_string(),
         auth_manager,

--- a/codex-rs/core/src/state/service.rs
+++ b/codex-rs/core/src/state/service.rs
@@ -5,6 +5,7 @@ use crate::SkillsManager;
 use crate::agent::AgentControl;
 use crate::attestation::AttestationProvider;
 use crate::client::ModelClient;
+use crate::config::PreparedInstructions;
 use crate::config::StartedNetworkProxy;
 use crate::exec_policy::ExecPolicyManager;
 use crate::guardian::GuardianRejection;
@@ -80,4 +81,6 @@ pub(crate) struct SessionServices {
     pub(crate) environment_manager: Arc<EnvironmentManager>,
     /// Startup-selected runtime authority bundle reused by session-owned child spawn paths.
     pub(crate) runtime_capabilities: Arc<RuntimeCapabilities>,
+    /// Ambient/global instruction payload prepared before selected-environment project-doc reads.
+    pub(crate) prepared_instructions: PreparedInstructions,
 }

--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -3,6 +3,7 @@ use crate::agent::AgentControl;
 use crate::attestation::AttestationProvider;
 use crate::codex_thread::CodexThread;
 use crate::config::Config;
+use crate::config::PreparedInstructions;
 use crate::config::ThreadStoreConfig;
 use crate::environment_selection::default_thread_environment_selections;
 use crate::environment_selection::resolve_environment_selections;
@@ -204,6 +205,7 @@ pub(crate) struct ThreadManagerState {
     models_manager: SharedModelsManager,
     environment_manager: Arc<EnvironmentManager>,
     runtime_capabilities: Arc<RuntimeCapabilities>,
+    prepared_instructions: PreparedInstructions,
     skills_manager: Arc<SkillsManager>,
     plugins_manager: Arc<PluginsManager>,
     mcp_manager: Arc<McpManager>,
@@ -246,6 +248,7 @@ impl ThreadManager {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         config: &Config,
+        prepared_instructions: PreparedInstructions,
         auth_manager: Arc<AuthManager>,
         session_source: SessionSource,
         environment_manager: Arc<EnvironmentManager>,
@@ -277,6 +280,7 @@ impl ThreadManager {
                 models_manager: build_models_manager(config, auth_manager.clone()),
                 environment_manager,
                 runtime_capabilities,
+                prepared_instructions,
                 skills_manager,
                 plugins_manager,
                 mcp_manager,
@@ -381,6 +385,7 @@ impl ThreadManager {
                     .models_manager(codex_home, /*config_model_catalog*/ None),
                 environment_manager,
                 runtime_capabilities,
+                prepared_instructions: PreparedInstructions::default(),
                 skills_manager,
                 plugins_manager,
                 mcp_manager,
@@ -1208,6 +1213,7 @@ impl ThreadManagerState {
         let CodexSpawnOk {
             codex, thread_id, ..
         } = Codex::spawn(CodexSpawnArgs {
+            prepared_instructions: self.prepared_instructions.clone(),
             config,
             installation_id: self.installation_id.clone(),
             auth_manager,

--- a/codex-rs/core/src/thread_manager_tests.rs
+++ b/codex-rs/core/src/thread_manager_tests.rs
@@ -503,6 +503,7 @@ async fn resume_and_fork_do_not_restore_thread_environments_from_rollout() {
     let (environment_manager, runtime_capabilities) = local_runtime();
     let manager = ThreadManager::new(
         &config,
+        config.prepared_instructions(),
         auth_manager.clone(),
         SessionSource::Exec,
         environment_manager,
@@ -623,6 +624,7 @@ async fn explicit_installation_id_skips_codex_home_file() {
     let (environment_manager, runtime_capabilities) = local_runtime();
     let manager = ThreadManager::new(
         &config,
+        config.prepared_instructions(),
         auth_manager,
         SessionSource::Exec,
         environment_manager,
@@ -664,6 +666,7 @@ async fn resume_active_thread_from_rollout_returns_running_thread() {
     let (environment_manager, runtime_capabilities) = local_runtime();
     let manager = ThreadManager::new(
         &config,
+        config.prepared_instructions(),
         auth_manager.clone(),
         SessionSource::Exec,
         environment_manager,
@@ -723,6 +726,7 @@ async fn resume_stopped_thread_from_rollout_spawns_new_thread() {
     let (environment_manager, runtime_capabilities) = local_runtime();
     let manager = ThreadManager::new(
         &config,
+        config.prepared_instructions(),
         auth_manager.clone(),
         SessionSource::Exec,
         environment_manager,
@@ -789,6 +793,7 @@ async fn resume_stopped_thread_from_rollout_preserves_thread_source() {
     let (environment_manager, runtime_capabilities) = local_runtime();
     let manager = ThreadManager::new(
         &config,
+        config.prepared_instructions(),
         auth_manager.clone(),
         SessionSource::Exec,
         environment_manager,
@@ -881,6 +886,7 @@ async fn rollout_path_resume_and_fork_read_history_through_thread_store() {
     let (environment_manager, runtime_capabilities) = local_runtime();
     let manager = ThreadManager::new(
         &config,
+        config.prepared_instructions(),
         auth_manager.clone(),
         SessionSource::Exec,
         environment_manager,
@@ -986,6 +992,7 @@ async fn new_uses_active_provider_for_model_refresh() {
     let (environment_manager, runtime_capabilities) = local_runtime();
     let manager = ThreadManager::new(
         &config,
+        config.prepared_instructions(),
         auth_manager,
         SessionSource::Exec,
         environment_manager,
@@ -1206,6 +1213,7 @@ async fn interrupted_fork_snapshot_does_not_synthesize_turn_id_for_legacy_histor
     let (environment_manager, runtime_capabilities) = local_runtime();
     let manager = ThreadManager::new(
         &config,
+        config.prepared_instructions(),
         auth_manager.clone(),
         SessionSource::Exec,
         environment_manager,
@@ -1316,6 +1324,7 @@ async fn interrupted_fork_snapshot_preserves_explicit_turn_id() {
     let (environment_manager, runtime_capabilities) = local_runtime();
     let manager = ThreadManager::new(
         &config,
+        config.prepared_instructions(),
         auth_manager.clone(),
         SessionSource::Exec,
         environment_manager,
@@ -1415,6 +1424,7 @@ async fn interrupted_fork_snapshot_uses_persisted_mid_turn_history_without_live_
     let (environment_manager, runtime_capabilities) = local_runtime();
     let manager = ThreadManager::new(
         &config,
+        config.prepared_instructions(),
         auth_manager.clone(),
         SessionSource::Exec,
         environment_manager,
@@ -1560,6 +1570,7 @@ async fn resumed_thread_keeps_paused_goal_paused() -> anyhow::Result<()> {
     let (environment_manager, runtime_capabilities) = local_runtime();
     let manager = ThreadManager::new(
         &config,
+        config.prepared_instructions(),
         auth_manager.clone(),
         SessionSource::Exec,
         environment_manager,

--- a/codex-rs/core/src/tools/handlers/multi_agents_tests.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_tests.rs
@@ -3732,6 +3732,7 @@ async fn tool_handlers_cascade_close_and_resume_and_keep_explicitly_closed_subtr
     let runtime_capabilities = Arc::new(RuntimeCapabilities::local(environment_manager.as_ref()));
     let manager = ThreadManager::new(
         &config,
+        config.prepared_instructions(),
         AuthManager::from_auth_for_testing(CodexAuth::from_api_key("dummy")),
         SessionSource::Exec,
         environment_manager,

--- a/codex-rs/core/tests/common/test_codex.rs
+++ b/codex-rs/core/tests/common/test_codex.rs
@@ -469,6 +469,7 @@ impl TestCodexBuilder {
         let installation_id = resolve_installation_id(&config.codex_home).await?;
         let thread_manager = ThreadManager::new(
             &config,
+            config.prepared_instructions(),
             codex_core::test_support::auth_manager_from_auth(auth.clone()),
             SessionSource::Exec,
             Arc::clone(&environment_manager),

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -1129,6 +1129,7 @@ async fn prefers_apikey_when_config_prefers_apikey_even_with_chatgpt_tokens() {
     let runtime_capabilities = Arc::new(RuntimeCapabilities::local(environment_manager.as_ref()));
     let thread_manager = ThreadManager::new(
         &config,
+        config.prepared_instructions(),
         auth_manager,
         SessionSource::Exec,
         environment_manager,

--- a/codex-rs/mcp-server/src/message_processor.rs
+++ b/codex-rs/mcp-server/src/message_processor.rs
@@ -68,6 +68,7 @@ impl MessageProcessor {
             Arc::new(RuntimeCapabilities::local(environment_manager.as_ref()));
         let thread_manager = Arc::new(ThreadManager::new(
             config.as_ref(),
+            config.prepared_instructions(),
             auth_manager,
             SessionSource::Mcp,
             environment_manager,

--- a/codex-rs/thread-manager-sample/src/main.rs
+++ b/codex-rs/thread-manager-sample/src/main.rs
@@ -122,6 +122,7 @@ async fn run_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
     let installation_id = resolve_installation_id(&config.codex_home).await?;
     let thread_manager = ThreadManager::new(
         &config,
+        config.prepared_instructions(),
         auth_manager,
         SessionSource::Exec,
         environment_manager,


### PR DESCRIPTION
Draft backup of the committed PR 8 snapshot from the current remote PR-slice worktree. This is a safety snapshot, not the canonical review PR. The worktree still has additional uncommitted edits that are not included here; this backup is only the committed head stacked on the previous backup branch.