### PR TITLE
core: box descendant resume future to avoid stack overflow

### DIFF
--- a/codex-rs/core/src/agent/control.rs
+++ b/codex-rs/core/src/agent/control.rs
@@ -499,13 +499,12 @@ impl AgentControl {
                             agent_nickname: None,
                             agent_role: None,
                         });
-                    match self
-                        .resume_single_agent_from_rollout(
-                            config.clone(),
-                            child_thread_id,
-                            child_session_source,
-                        )
-                        .await
+                    match Box::pin(self.resume_single_agent_from_rollout(
+                        config.clone(),
+                        child_thread_id,
+                        child_session_source,
+                    ))
+                    .await
                     {
                         Ok(_) => true,
                         Err(err) => {


### PR DESCRIPTION
## Summary
- box the descendant `resume_single_agent_from_rollout(...)` future inside `AgentControl::resume_agent_from_rollout`
- reduce async stack pressure on the subtree-resume path without changing behavior or timeouts
- fix the isolated stack overflow in `agent::control::tests::resume_agent_from_rollout_skips_descendants_when_parent_resume_fails`

## Verification
- `cargo test -p codex-core --lib agent::control::tests::resume_agent_from_rollout_skips_descendants_when_parent_resume_fails -- --exact`
- same exact test rerun 3 consecutive times after the fix
- `cargo test -p codex-core` *(the repaired target passed; the crate later aborted in the pre-existing sibling stack overflow `agent::control::tests::spawn_agent_fork_last_n_turns_keeps_only_recent_turns`)*
- `just fix -p codex-core`
- `git diff --check`

## Notes
- `just fmt` reached the Rust formatting step, but the repo-wide Python formatter phase could not complete in this sandbox because `uv` could not reach PyPI to download `pathspec`.