### PR TITLE
Stabilize guardian shell timeout test

### DIFF
--- a/codex-rs/core/src/session/tests/guardian_tests.rs
+++ b/codex-rs/core/src/session/tests/guardian_tests.rs
@@ -406,6 +406,7 @@ async fn strict_auto_review_turn_grant_forces_guardian_for_shell_command_policy_
     );
     let session = Arc::new(session);
     let turn_context = Arc::new(turn_context_raw);
+    let expiration_ms: u64 = if cfg!(windows) { 2_500 } else { 1_000 };
 
     let handler = crate::tools::handlers::ShellCommandHandler::from(
         codex_tools::ShellCommandBackendConfig::Classic,
@@ -426,7 +427,7 @@ async fn strict_auto_review_turn_grant_forces_guardian_for_shell_command_policy_
                     "command": "echo hi",
                     "login": false,
                     "workdir": workdir,
-                    "timeout_ms": 1_000_u64,
+                    "timeout_ms": expiration_ms,
                 })
                 .to_string(),
             },

--- a/codex-rs/core/src/session/tests/guardian_tests.rs
+++ b/codex-rs/core/src/session/tests/guardian_tests.rs
@@ -49,6 +49,8 @@ use tempfile::tempdir;
 use tokio::time::timeout;
 use tokio_util::sync::CancellationToken;
 
+const QUICK_SHELL_TIMEOUT_MS: u64 = if cfg!(windows) { 2_500 } else { 1_000 };
+
 fn expect_text_output<T>(output: &T) -> String
 where
     T: ToolOutput + ?Sized,
@@ -302,8 +304,6 @@ async fn guardian_allows_shell_command_additional_permissions_requests_past_poli
     );
     let session = Arc::new(session);
     let turn_context = Arc::new(turn_context_raw);
-    let expiration_ms: u64 = if cfg!(windows) { 2_500 } else { 1_000 };
-
     let handler = crate::tools::handlers::ShellCommandHandler::from(
         codex_tools::ShellCommandBackendConfig::Classic,
     );
@@ -323,7 +323,7 @@ async fn guardian_allows_shell_command_additional_permissions_requests_past_poli
                     "command": "echo hi",
                     "login": false,
                     "workdir": workdir,
-                    "timeout_ms": expiration_ms,
+                    "timeout_ms": QUICK_SHELL_TIMEOUT_MS,
                     "sandbox_permissions": SandboxPermissions::WithAdditionalPermissions,
                     "additional_permissions": PermissionProfile {
                         network: Some(NetworkPermissions {
@@ -406,8 +406,6 @@ async fn strict_auto_review_turn_grant_forces_guardian_for_shell_command_policy_
     );
     let session = Arc::new(session);
     let turn_context = Arc::new(turn_context_raw);
-    let expiration_ms: u64 = if cfg!(windows) { 2_500 } else { 1_000 };
-
     let handler = crate::tools::handlers::ShellCommandHandler::from(
         codex_tools::ShellCommandBackendConfig::Classic,
     );
@@ -427,7 +425,7 @@ async fn strict_auto_review_turn_grant_forces_guardian_for_shell_command_policy_
                     "command": "echo hi",
                     "login": false,
                     "workdir": workdir,
-                    "timeout_ms": expiration_ms,
+                    "timeout_ms": QUICK_SHELL_TIMEOUT_MS,
                 })
                 .to_string(),
             },


### PR DESCRIPTION
## Why

Recent Windows `rust-ci-full` failures showed `session::tests::guardian_tests::strict_auto_review_turn_grant_forces_guardian_for_shell_command_policy_skip` timing out at the test’s hard `1_000ms` shell budget even though the command is just `echo hi`.

Failure evidence: [latest completed Windows x64 test job](https://github.com/openai/codex/actions/runs/26138722960/job/76881308783) and earlier [JUnit-backed Windows x64 failure](https://github.com/openai/codex/actions/runs/26114840740/job/76801273285)

## What changed

- reuse one platform-specific quick shell timeout budget across the sibling guardian shell-command tests
- keep the non-Windows timeout unchanged
- give Windows the existing `2_500ms` budget already used by the adjacent guardian shell test

## CI evidence

Recent failed `rust-ci-full` test runs that exposed this flake family:
- https://github.com/openai/codex/actions/runs/26138722960
- https://github.com/openai/codex/actions/runs/26115775739
- https://github.com/openai/codex/actions/runs/26114840740
- https://github.com/openai/codex/actions/runs/26114668996
- https://github.com/openai/codex/actions/runs/26113530208

Those failed test lanes uploaded nextest JUnit artifacts successfully. Representative artifacts from the latest run:
- https://github.com/openai/codex/actions/runs/26115775739/artifacts/7091965331
- https://github.com/openai/codex/actions/runs/26115775739/artifacts/7092022050
- https://github.com/openai/codex/actions/runs/26115775739/artifacts/7091820251

## Walkthrough

- Issue: the strict Guardian shell test used a `1_000ms` timeout that is too tight on Windows for this path.
- Likely introducing change: the strict auto-review Guardian shell test plus later shell handler reshaping.
- Fix: reuse the same Windows-specific quick-shell timeout budget already used by the adjacent Guardian shell test.

## Devbox evidence

Focused validation on `dev` passed from the mirrored PR worktree:

```bash
ssh -o ClearAllForwardings=yes dev 'cd /home/dev-user/code/codex-worktrees/starr-fullci-8-guardian-shell-timeout-20260519 && export PATH=$HOME/code/openai/project/dotslash-gen/bin:$HOME/.local/bin:$PATH && bazel test --bes_backend= --bes_results_url= --test_filter=strict_auto_review_turn_grant_forces_guardian_for_shell_command_policy_skip //codex-rs/core:core-unit-tests'
```

```text
//codex-rs/core:core-unit-tests                                          PASSED in 6.9s
Executed 1 out of 1 test: 1 test passes.
```

Representative prior CI failure:

```text
session::tests::guardian_tests::strict_auto_review_turn_grant_forces_guardian_for_shell_command_policy_skip ... FAILED
expected Ok result: RespondToModel("Exit code: 124
Wall time: 1 seconds
Output:
command timed out after 1049 milliseconds
")
```

