### PR TITLE
Add minimal exec-server websocket reconnect

### DIFF
--- a/codex-rs/core/tests/suite/remote_env.rs
+++ b/codex-rs/core/tests/suite/remote_env.rs
@@ -46,6 +46,7 @@ use serde_json::json;
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
+use std::time::Duration;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 use tempfile::TempDir;
@@ -151,6 +152,42 @@ async fn remote_test_env_can_connect_and_use_filesystem() -> Result<()> {
     file_system
         .write_file(&file_path_abs, payload.clone(), /*sandbox*/ None)
         .await?;
+    let actual = file_system
+        .read_file(&file_path_abs, /*sandbox*/ None)
+        .await?;
+    assert_eq!(actual, payload);
+
+    file_system
+        .remove(
+            &file_path_abs,
+            RemoveOptions {
+                recursive: false,
+                force: true,
+            },
+            /*sandbox*/ None,
+        )
+        .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn remote_test_env_reconnects_after_exec_server_websocket_disconnect() -> Result<()> {
+    let Some(_remote_env) = get_remote_test_env() else {
+        return Ok(());
+    };
+
+    let test_env = test_env().await?;
+    let file_system = test_env.environment().get_filesystem();
+    let file_path_abs = remote_test_file_path().abs();
+    let payload = b"remote-test-env-reconnect".to_vec();
+
+    file_system
+        .write_file(&file_path_abs, payload.clone(), /*sandbox*/ None)
+        .await?;
+    remote_exec("ss -K state established '( sport = :31987 )'")?;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
     let actual = file_system
         .read_file(&file_path_abs, /*sandbox*/ None)
         .await?;

--- a/codex-rs/core/tests/suite/remote_env.rs
+++ b/codex-rs/core/tests/suite/remote_env.rs
@@ -43,10 +43,10 @@ use core_test_support::wait_for_event;
 use pretty_assertions::assert_eq;
 use serde_json::Value;
 use serde_json::json;
+use serial_test::serial;
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
-use std::time::Duration;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 use tempfile::TempDir;
@@ -172,6 +172,7 @@ async fn remote_test_env_can_connect_and_use_filesystem() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
 async fn remote_test_env_reconnects_after_exec_server_websocket_disconnect() -> Result<()> {
     let Some(_remote_env) = get_remote_test_env() else {
         return Ok(());
@@ -186,7 +187,6 @@ async fn remote_test_env_reconnects_after_exec_server_websocket_disconnect() -> 
         .write_file(&file_path_abs, payload.clone(), /*sandbox*/ None)
         .await?;
     remote_exec("ss -K state established '( sport = :31987 )'")?;
-    tokio::time::sleep(Duration::from_millis(100)).await;
 
     let actual = file_system
         .read_file(&file_path_abs, /*sandbox*/ None)

--- a/codex-rs/exec-server/src/client.rs
+++ b/codex-rs/exec-server/src/client.rs
@@ -12,10 +12,10 @@ use futures::FutureExt;
 use futures::future::BoxFuture;
 use serde_json::Value;
 use tokio::sync::Mutex;
-use tokio::sync::OnceCell;
 use tokio::sync::mpsc;
 use tokio::sync::watch;
 
+use tokio::time::sleep;
 use tokio::time::timeout;
 use tracing::debug;
 
@@ -83,6 +83,11 @@ pub(crate) mod http_client;
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const INITIALIZE_TIMEOUT: Duration = Duration::from_secs(10);
+const RECONNECT_DELAYS: [Duration; 3] = [
+    Duration::from_millis(100),
+    Duration::from_millis(250),
+    Duration::from_millis(500),
+];
 const PROCESS_EVENT_CHANNEL_CAPACITY: usize = 256;
 const PROCESS_EVENT_RETAINED_BYTES: usize = 1024 * 1024;
 
@@ -192,27 +197,101 @@ pub struct ExecServerClient {
 #[derive(Clone)]
 pub(crate) struct LazyRemoteExecServerClient {
     transport_params: ExecServerTransportParams,
-    client: Arc<OnceCell<ExecServerClient>>,
+    state: Arc<Mutex<LazyRemoteExecServerClientState>>,
+}
+
+enum LazyRemoteExecServerClientState {
+    Uninitialized,
+    Connected(ExecServerClient),
+    TerminalResumeError { code: i64, message: String },
 }
 
 impl LazyRemoteExecServerClient {
     pub(crate) fn new(transport_params: ExecServerTransportParams) -> Self {
         Self {
             transport_params,
-            client: Arc::new(OnceCell::new()),
+            state: Arc::new(Mutex::new(LazyRemoteExecServerClientState::Uninitialized)),
         }
     }
 
     pub(crate) async fn get(&self) -> Result<ExecServerClient, ExecServerError> {
-        self.client
-            // TODO: Add reconnect/disconnect handling here instead of reusing
-            // the first successfully initialized connection forever.
-            .get_or_try_init(|| {
-                let transport_params = self.transport_params.clone();
-                async move { ExecServerClient::connect_for_transport(transport_params).await }
-            })
+        let mut state = self.state.lock().await;
+        match &*state {
+            LazyRemoteExecServerClientState::TerminalResumeError { code, message } => {
+                return Err(ExecServerError::Server {
+                    code: *code,
+                    message: message.clone(),
+                });
+            }
+            LazyRemoteExecServerClientState::Connected(client) if !client.is_disconnected() => {
+                return Ok(client.clone());
+            }
+            LazyRemoteExecServerClientState::Connected(client) => {
+                if !matches!(
+                    &self.transport_params,
+                    ExecServerTransportParams::WebSocketUrl { .. }
+                ) {
+                    return Ok(client.clone());
+                }
+
+                let session_id = client.session_id().ok_or_else(|| {
+                    ExecServerError::Protocol(
+                        "disconnected exec-server websocket client has no session id".to_string(),
+                    )
+                })?;
+                match self.reconnect_websocket(session_id).await {
+                    Ok(client) => {
+                        *state = LazyRemoteExecServerClientState::Connected(client.clone());
+                        return Ok(client);
+                    }
+                    Err(ExecServerError::Server { code, message }) => {
+                        debug!("caching terminal exec-server websocket resume failure");
+                        *state = LazyRemoteExecServerClientState::TerminalResumeError {
+                            code,
+                            message: message.clone(),
+                        };
+                        return Err(ExecServerError::Server { code, message });
+                    }
+                    Err(err) => return Err(err),
+                }
+            }
+            LazyRemoteExecServerClientState::Uninitialized => {}
+        }
+
+        let client =
+            ExecServerClient::connect_for_transport(self.transport_params.clone(), None).await?;
+        *state = LazyRemoteExecServerClientState::Connected(client.clone());
+        Ok(client)
+    }
+
+    async fn reconnect_websocket(
+        &self,
+        session_id: String,
+    ) -> Result<ExecServerClient, ExecServerError> {
+        let mut last_error = None;
+        for (attempt_index, delay) in RECONNECT_DELAYS.into_iter().enumerate() {
+            let attempt = attempt_index + 1;
+            sleep(delay).await;
+            debug!(attempt, "reconnecting exec-server websocket");
+            match ExecServerClient::connect_for_transport(
+                self.transport_params.clone(),
+                Some(session_id.clone()),
+            )
             .await
-            .cloned()
+            {
+                Ok(client) => {
+                    debug!(attempt, "reconnected exec-server websocket");
+                    return Ok(client);
+                }
+                Err(err) if is_retryable_reconnect_error(&err) => {
+                    debug!(attempt, error = %err, "exec-server websocket reconnect attempt failed");
+                    last_error = Some(err);
+                }
+                Err(err) => return Err(err),
+            }
+        }
+
+        Err(last_error.expect("reconnect attempts should record a retryable error"))
     }
 }
 
@@ -422,6 +501,10 @@ impl ExecServerClient {
             .read()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .clone()
+    }
+
+    fn is_disconnected(&self) -> bool {
+        self.inner.disconnected.get().is_some()
     }
 
     pub(crate) async fn connect(
@@ -778,6 +861,15 @@ fn is_transport_closed_error(error: &ExecServerError) -> bool {
     )
 }
 
+fn is_retryable_reconnect_error(error: &ExecServerError) -> bool {
+    matches!(
+        error,
+        ExecServerError::WebSocketConnectTimeout { .. }
+            | ExecServerError::WebSocketConnect { .. }
+            | ExecServerError::InitializeTimedOut { .. }
+    )
+}
+
 fn record_disconnected(inner: &Arc<Inner>, message: String) -> String {
     // The first observer records the canonical disconnect reason. Session
     // draining stays with the reader task so it can preserve notification
@@ -870,33 +962,44 @@ async fn handle_server_notification(
 
 #[cfg(test)]
 mod tests {
+    use codex_app_server_protocol::JSONRPCError;
+    use codex_app_server_protocol::JSONRPCErrorError;
     use codex_app_server_protocol::JSONRPCMessage;
     use codex_app_server_protocol::JSONRPCNotification;
     use codex_app_server_protocol::JSONRPCResponse;
+    use futures::SinkExt;
+    use futures::StreamExt;
     use pretty_assertions::assert_eq;
     use std::collections::HashMap;
     #[cfg(unix)]
     use std::path::Path;
     #[cfg(unix)]
     use std::process::Command;
+    use std::sync::Arc;
     use tokio::io::AsyncBufReadExt;
     use tokio::io::AsyncWrite;
     use tokio::io::AsyncWriteExt;
     use tokio::io::BufReader;
     use tokio::io::duplex;
+    use tokio::net::TcpListener;
+    use tokio::net::TcpStream;
     use tokio::sync::mpsc;
     use tokio::sync::oneshot;
     use tokio::time::Duration;
     #[cfg(unix)]
     use tokio::time::sleep;
     use tokio::time::timeout;
+    use tokio_tungstenite::WebSocketStream;
+    use tokio_tungstenite::accept_async;
+    use tokio_tungstenite::tungstenite::Message;
 
     use super::ExecServerClient;
     use super::ExecServerClientConnectOptions;
+    use super::ExecServerError;
+    use super::LazyRemoteExecServerClient;
     use crate::ProcessId;
     #[cfg(not(windows))]
     use crate::client_api::DEFAULT_REMOTE_EXEC_SERVER_INITIALIZE_TIMEOUT;
-    #[cfg(not(windows))]
     use crate::client_api::ExecServerTransportParams;
     use crate::client_api::StdioExecServerCommand;
     use crate::client_api::StdioExecServerConnectArgs;
@@ -935,6 +1038,96 @@ mod tests {
             .write_all(format!("{encoded}\n").as_bytes())
             .await
             .expect("json-rpc line should write");
+    }
+
+    async fn accept_websocket(listener: &TcpListener) -> WebSocketStream<TcpStream> {
+        let (stream, _) = listener.accept().await.expect("listener should accept");
+        accept_async(stream)
+            .await
+            .expect("websocket handshake should succeed")
+    }
+
+    async fn read_jsonrpc_websocket(websocket: &mut WebSocketStream<TcpStream>) -> JSONRPCMessage {
+        loop {
+            match timeout(Duration::from_secs(1), websocket.next())
+                .await
+                .expect("json-rpc websocket read should not time out")
+                .expect("websocket should stay open")
+                .expect("websocket frame should read")
+            {
+                Message::Text(text) => {
+                    return serde_json::from_str(text.as_ref())
+                        .expect("json-rpc text frame should parse");
+                }
+                Message::Binary(bytes) => {
+                    return serde_json::from_slice(bytes.as_ref())
+                        .expect("json-rpc binary frame should parse");
+                }
+                Message::Ping(_) | Message::Pong(_) => {}
+                other => panic!("expected json-rpc websocket frame, got {other:?}"),
+            }
+        }
+    }
+
+    async fn write_jsonrpc_websocket(
+        websocket: &mut WebSocketStream<TcpStream>,
+        message: JSONRPCMessage,
+    ) {
+        let encoded = serde_json::to_string(&message).expect("json-rpc should serialize");
+        websocket
+            .send(Message::Text(encoded.into()))
+            .await
+            .expect("json-rpc websocket frame should write");
+    }
+
+    async fn complete_websocket_initialize(
+        websocket: &mut WebSocketStream<TcpStream>,
+        session_id: &str,
+        expected_resume_session_id: Option<&str>,
+    ) {
+        let initialize = read_jsonrpc_websocket(websocket).await;
+        let request = match initialize {
+            JSONRPCMessage::Request(request) if request.method == INITIALIZE_METHOD => request,
+            other => panic!("expected initialize request, got {other:?}"),
+        };
+        let params: crate::protocol::InitializeParams =
+            serde_json::from_value(request.params.expect("initialize params should exist"))
+                .expect("initialize params should deserialize");
+        assert_eq!(
+            params.resume_session_id.as_deref(),
+            expected_resume_session_id
+        );
+        write_jsonrpc_websocket(
+            websocket,
+            JSONRPCMessage::Response(JSONRPCResponse {
+                id: request.id,
+                result: serde_json::to_value(InitializeResponse {
+                    session_id: session_id.to_string(),
+                })
+                .expect("initialize response should serialize"),
+            }),
+        )
+        .await;
+
+        let initialized = read_jsonrpc_websocket(websocket).await;
+        match initialized {
+            JSONRPCMessage::Notification(notification)
+                if notification.method == INITIALIZED_METHOD => {}
+            other => panic!("expected initialized notification, got {other:?}"),
+        }
+    }
+
+    async fn wait_for_disconnect(client: &ExecServerClient) {
+        timeout(Duration::from_secs(1), async {
+            loop {
+                if client.is_disconnected() {
+                    return;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("client should observe disconnect");
     }
 
     #[cfg(not(windows))]
@@ -976,6 +1169,7 @@ mod tests {
                 },
                 initialize_timeout: DEFAULT_REMOTE_EXEC_SERVER_INITIALIZE_TIMEOUT,
             },
+            None,
         )
         .await
         .expect("stdio transport should connect");
@@ -1352,6 +1546,140 @@ mod tests {
 
         drop(client);
         server.await.expect("server task should finish");
+    }
+
+    #[tokio::test]
+    async fn lazy_websocket_client_reconnects_with_previous_session_id() {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("listener should bind");
+        let websocket_url = format!(
+            "ws://{}",
+            listener.local_addr().expect("listener should have address")
+        );
+        let server = tokio::spawn(async move {
+            let mut first = accept_websocket(&listener).await;
+            complete_websocket_initialize(&mut first, "session-1", None).await;
+            first
+                .close(None)
+                .await
+                .expect("first websocket should close");
+
+            let mut second = accept_websocket(&listener).await;
+            complete_websocket_initialize(&mut second, "session-1", Some("session-1")).await;
+        });
+
+        let lazy = LazyRemoteExecServerClient::new(ExecServerTransportParams::WebSocketUrl {
+            websocket_url,
+            connect_timeout: Duration::from_secs(1),
+            initialize_timeout: Duration::from_secs(1),
+        });
+        let first = lazy.get().await.expect("first client should connect");
+        wait_for_disconnect(&first).await;
+
+        let second = lazy.get().await.expect("client should reconnect");
+        assert_eq!(second.session_id().as_deref(), Some("session-1"));
+        assert!(
+            !Arc::ptr_eq(&first.inner, &second.inner),
+            "reconnect should replace the cached client"
+        );
+
+        server.await.expect("server task should finish");
+    }
+
+    #[tokio::test]
+    async fn lazy_websocket_client_caches_terminal_resume_error() {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("listener should bind");
+        let websocket_url = format!(
+            "ws://{}",
+            listener.local_addr().expect("listener should have address")
+        );
+        let server = tokio::spawn(async move {
+            let mut first = accept_websocket(&listener).await;
+            complete_websocket_initialize(&mut first, "session-1", None).await;
+            first
+                .close(None)
+                .await
+                .expect("first websocket should close");
+
+            let mut second = accept_websocket(&listener).await;
+            let initialize = read_jsonrpc_websocket(&mut second).await;
+            let request = match initialize {
+                JSONRPCMessage::Request(request) if request.method == INITIALIZE_METHOD => request,
+                other => panic!("expected initialize request, got {other:?}"),
+            };
+            let params: crate::protocol::InitializeParams =
+                serde_json::from_value(request.params.expect("initialize params should exist"))
+                    .expect("initialize params should deserialize");
+            assert_eq!(params.resume_session_id.as_deref(), Some("session-1"));
+            write_jsonrpc_websocket(
+                &mut second,
+                JSONRPCMessage::Error(JSONRPCError {
+                    id: request.id,
+                    error: JSONRPCErrorError {
+                        code: -32600,
+                        message: "unknown session id session-1".to_string(),
+                        data: None,
+                    },
+                }),
+            )
+            .await;
+
+            timeout(Duration::from_millis(700), listener.accept())
+                .await
+                .is_ok()
+        });
+
+        let lazy = LazyRemoteExecServerClient::new(ExecServerTransportParams::WebSocketUrl {
+            websocket_url,
+            connect_timeout: Duration::from_secs(1),
+            initialize_timeout: Duration::from_secs(1),
+        });
+        let first = lazy.get().await.expect("first client should connect");
+        wait_for_disconnect(&first).await;
+
+        for _ in 0..2 {
+            let err = lazy.get().await.expect_err("resume should stay rejected");
+            assert!(matches!(
+                err,
+                ExecServerError::Server {
+                    code: -32600,
+                    ref message,
+                } if message == "unknown session id session-1"
+            ));
+        }
+
+        assert!(
+            !server.await.expect("server task should finish"),
+            "cached terminal resume error should avoid another reconnect"
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn lazy_stdio_client_remains_one_shot_after_disconnect() {
+        let lazy = LazyRemoteExecServerClient::new(ExecServerTransportParams::StdioCommand {
+            command: StdioExecServerCommand {
+                program: "sh".to_string(),
+                args: vec![
+                    "-c".to_string(),
+                    "read _line; printf '%s\\n' '{\"id\":1,\"result\":{\"sessionId\":\"stdio-test\"}}'; read _line".to_string(),
+                ],
+                env: HashMap::new(),
+                cwd: None,
+            },
+            initialize_timeout: Duration::from_secs(1),
+        });
+        let first = lazy.get().await.expect("first client should connect");
+        wait_for_disconnect(&first).await;
+
+        let second = lazy.get().await.expect("stdio client should stay cached");
+        assert!(
+            Arc::ptr_eq(&first.inner, &second.inner),
+            "stdio client should not reconnect after disconnect"
+        );
     }
 
     #[tokio::test]

--- a/codex-rs/exec-server/src/client.rs
+++ b/codex-rs/exec-server/src/client.rs
@@ -195,38 +195,38 @@ pub struct ExecServerClient {
 }
 
 #[derive(Clone)]
-pub(crate) struct LazyRemoteExecServerClient {
+pub(crate) struct RemoteExecServerClient {
     transport_params: ExecServerTransportParams,
-    state: Arc<Mutex<LazyRemoteExecServerClientState>>,
+    state: Arc<Mutex<RemoteExecServerClientState>>,
 }
 
-enum LazyRemoteExecServerClientState {
+enum RemoteExecServerClientState {
     Uninitialized,
     Connected(ExecServerClient),
     TerminalResumeError { code: i64, message: String },
 }
 
-impl LazyRemoteExecServerClient {
+impl RemoteExecServerClient {
     pub(crate) fn new(transport_params: ExecServerTransportParams) -> Self {
         Self {
             transport_params,
-            state: Arc::new(Mutex::new(LazyRemoteExecServerClientState::Uninitialized)),
+            state: Arc::new(Mutex::new(RemoteExecServerClientState::Uninitialized)),
         }
     }
 
     pub(crate) async fn get(&self) -> Result<ExecServerClient, ExecServerError> {
         let mut state = self.state.lock().await;
         match &*state {
-            LazyRemoteExecServerClientState::TerminalResumeError { code, message } => {
+            RemoteExecServerClientState::TerminalResumeError { code, message } => {
                 return Err(ExecServerError::Server {
                     code: *code,
                     message: message.clone(),
                 });
             }
-            LazyRemoteExecServerClientState::Connected(client) if !client.is_disconnected() => {
+            RemoteExecServerClientState::Connected(client) if !client.is_disconnected() => {
                 return Ok(client.clone());
             }
-            LazyRemoteExecServerClientState::Connected(client) => {
+            RemoteExecServerClientState::Connected(client) => {
                 if !matches!(
                     &self.transport_params,
                     ExecServerTransportParams::WebSocketUrl { .. }
@@ -241,13 +241,13 @@ impl LazyRemoteExecServerClient {
                 })?;
                 match self.reconnect_websocket(session_id).await {
                     Ok(client) => {
-                        *state = LazyRemoteExecServerClientState::Connected(client.clone());
+                        *state = RemoteExecServerClientState::Connected(client.clone());
                         return Ok(client);
                     }
                     Err(err) => {
                         if let Some((code, message)) = terminal_resume_error(&err) {
                             debug!("caching terminal exec-server websocket resume failure");
-                            *state = LazyRemoteExecServerClientState::TerminalResumeError {
+                            *state = RemoteExecServerClientState::TerminalResumeError {
                                 code,
                                 message: message.clone(),
                             };
@@ -257,12 +257,15 @@ impl LazyRemoteExecServerClient {
                     }
                 }
             }
-            LazyRemoteExecServerClientState::Uninitialized => {}
+            RemoteExecServerClientState::Uninitialized => {}
         }
 
-        let client =
-            ExecServerClient::connect_for_transport(self.transport_params.clone(), None).await?;
-        *state = LazyRemoteExecServerClientState::Connected(client.clone());
+        let client = ExecServerClient::connect_for_transport(
+            self.transport_params.clone(),
+            /*resume_session_id*/ None,
+        )
+        .await?;
+        *state = RemoteExecServerClientState::Connected(client.clone());
         Ok(client)
     }
 
@@ -297,7 +300,7 @@ impl LazyRemoteExecServerClient {
     }
 }
 
-impl HttpClient for LazyRemoteExecServerClient {
+impl HttpClient for RemoteExecServerClient {
     fn http_request(
         &self,
         params: crate::HttpRequestParams,
@@ -1005,7 +1008,7 @@ mod tests {
     use super::ExecServerClient;
     use super::ExecServerClientConnectOptions;
     use super::ExecServerError;
-    use super::LazyRemoteExecServerClient;
+    use super::RemoteExecServerClient;
     use crate::ProcessId;
     #[cfg(not(windows))]
     use crate::client_api::DEFAULT_REMOTE_EXEC_SERVER_INITIALIZE_TIMEOUT;
@@ -1558,7 +1561,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn lazy_websocket_client_reconnects_with_previous_session_id() {
+    async fn remote_websocket_client_reconnects_with_previous_session_id() {
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
             .expect("listener should bind");
@@ -1578,15 +1581,15 @@ mod tests {
             complete_websocket_initialize(&mut second, "session-1", Some("session-1")).await;
         });
 
-        let lazy = LazyRemoteExecServerClient::new(ExecServerTransportParams::WebSocketUrl {
+        let client = RemoteExecServerClient::new(ExecServerTransportParams::WebSocketUrl {
             websocket_url,
             connect_timeout: Duration::from_secs(1),
             initialize_timeout: Duration::from_secs(1),
         });
-        let first = lazy.get().await.expect("first client should connect");
+        let first = client.get().await.expect("first client should connect");
         wait_for_disconnect(&first).await;
 
-        let second = lazy.get().await.expect("client should reconnect");
+        let second = client.get().await.expect("client should reconnect");
         assert_eq!(second.session_id().as_deref(), Some("session-1"));
         assert!(
             !Arc::ptr_eq(&first.inner, &second.inner),
@@ -1597,7 +1600,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn lazy_websocket_client_caches_terminal_resume_error() {
+    async fn remote_websocket_client_caches_terminal_resume_error() {
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
             .expect("listener should bind");
@@ -1641,16 +1644,19 @@ mod tests {
                 .is_ok()
         });
 
-        let lazy = LazyRemoteExecServerClient::new(ExecServerTransportParams::WebSocketUrl {
+        let client = RemoteExecServerClient::new(ExecServerTransportParams::WebSocketUrl {
             websocket_url,
             connect_timeout: Duration::from_secs(1),
             initialize_timeout: Duration::from_secs(1),
         });
-        let first = lazy.get().await.expect("first client should connect");
+        let first = client.get().await.expect("first client should connect");
         wait_for_disconnect(&first).await;
 
         for _ in 0..2 {
-            let err = lazy.get().await.expect_err("resume should stay rejected");
+            let err = match client.get().await {
+                Ok(_) => panic!("resume should stay rejected"),
+                Err(err) => err,
+            };
             assert!(matches!(
                 err,
                 ExecServerError::Server {
@@ -1668,8 +1674,8 @@ mod tests {
 
     #[cfg(not(windows))]
     #[tokio::test]
-    async fn lazy_stdio_client_remains_one_shot_after_disconnect() {
-        let lazy = LazyRemoteExecServerClient::new(ExecServerTransportParams::StdioCommand {
+    async fn remote_stdio_client_remains_one_shot_after_disconnect() {
+        let client = RemoteExecServerClient::new(ExecServerTransportParams::StdioCommand {
             command: StdioExecServerCommand {
                 program: "sh".to_string(),
                 args: vec![
@@ -1681,10 +1687,10 @@ mod tests {
             },
             initialize_timeout: Duration::from_secs(1),
         });
-        let first = lazy.get().await.expect("first client should connect");
+        let first = client.get().await.expect("first client should connect");
         wait_for_disconnect(&first).await;
 
-        let second = lazy.get().await.expect("stdio client should stay cached");
+        let second = client.get().await.expect("stdio client should stay cached");
         assert!(
             Arc::ptr_eq(&first.inner, &second.inner),
             "stdio client should not reconnect after disconnect"

--- a/codex-rs/exec-server/src/client.rs
+++ b/codex-rs/exec-server/src/client.rs
@@ -244,15 +244,17 @@ impl LazyRemoteExecServerClient {
                         *state = LazyRemoteExecServerClientState::Connected(client.clone());
                         return Ok(client);
                     }
-                    Err(ExecServerError::Server { code, message }) => {
-                        debug!("caching terminal exec-server websocket resume failure");
-                        *state = LazyRemoteExecServerClientState::TerminalResumeError {
-                            code,
-                            message: message.clone(),
-                        };
-                        return Err(ExecServerError::Server { code, message });
+                    Err(err) => {
+                        if let Some((code, message)) = terminal_resume_error(&err) {
+                            debug!("caching terminal exec-server websocket resume failure");
+                            *state = LazyRemoteExecServerClientState::TerminalResumeError {
+                                code,
+                                message: message.clone(),
+                            };
+                            return Err(ExecServerError::Server { code, message });
+                        }
+                        return Err(err);
                     }
-                    Err(err) => return Err(err),
                 }
             }
             LazyRemoteExecServerClientState::Uninitialized => {}
@@ -868,6 +870,13 @@ fn is_retryable_reconnect_error(error: &ExecServerError) -> bool {
             | ExecServerError::WebSocketConnect { .. }
             | ExecServerError::InitializeTimedOut { .. }
     )
+}
+
+fn terminal_resume_error(error: &ExecServerError) -> Option<(i64, String)> {
+    let ExecServerError::Server { code, message } = error else {
+        return None;
+    };
+    (!is_transport_closed_error(error)).then(|| (*code, message.clone()))
 }
 
 fn record_disconnected(inner: &Arc<Inner>, message: String) -> String {

--- a/codex-rs/exec-server/src/client.rs
+++ b/codex-rs/exec-server/src/client.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::collections::HashMap;
+use std::future::Future;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
 use std::sync::OnceLock;
@@ -269,6 +270,24 @@ impl RemoteExecServerClient {
         Ok(client)
     }
 
+    pub(crate) async fn request<T, F, Fut>(&self, mut request: F) -> Result<T, ExecServerError>
+    where
+        F: FnMut(ExecServerClient) -> Fut,
+        Fut: Future<Output = Result<T, ExecServerError>>,
+    {
+        let client = self.get().await?;
+        match request(client.clone()).await {
+            Ok(response) => Ok(response),
+            Err(err) if is_transport_closed_error(&err) => {
+                client.mark_disconnected(&err);
+                debug!("retrying exec-server request after websocket disconnect");
+                let client = self.get().await?;
+                request(client).await
+            }
+            Err(err) => Err(err),
+        }
+    }
+
     async fn reconnect_websocket(
         &self,
         session_id: String,
@@ -305,7 +324,14 @@ impl HttpClient for RemoteExecServerClient {
         &self,
         params: crate::HttpRequestParams,
     ) -> BoxFuture<'_, Result<crate::HttpRequestResponse, ExecServerError>> {
-        async move { self.get().await?.http_request(params).await }.boxed()
+        async move {
+            self.request(|client| {
+                let params = params.clone();
+                async move { client.http_request(params).await }
+            })
+            .await
+        }
+        .boxed()
     }
 
     fn http_request_stream(
@@ -315,7 +341,14 @@ impl HttpClient for RemoteExecServerClient {
         '_,
         Result<(crate::HttpRequestResponse, crate::HttpResponseBodyStream), ExecServerError>,
     > {
-        async move { self.get().await?.http_request_stream(params).await }.boxed()
+        async move {
+            self.request(|client| {
+                let params = params.clone();
+                async move { client.http_request_stream(params).await }
+            })
+            .await
+        }
+        .boxed()
     }
 }
 
@@ -510,6 +543,10 @@ impl ExecServerClient {
 
     fn is_disconnected(&self) -> bool {
         self.inner.disconnected.get().is_some()
+    }
+
+    fn mark_disconnected(&self, error: &ExecServerError) {
+        let _ = self.inner.set_disconnected(error.to_string());
     }
 
     pub(crate) async fn connect(
@@ -872,14 +909,24 @@ fn is_retryable_reconnect_error(error: &ExecServerError) -> bool {
         ExecServerError::WebSocketConnectTimeout { .. }
             | ExecServerError::WebSocketConnect { .. }
             | ExecServerError::InitializeTimedOut { .. }
+    ) || matches!(
+        error,
+        ExecServerError::Server {
+            code: -32600,
+            message,
+        } if message.contains("is already attached to another connection")
     )
 }
 
 fn terminal_resume_error(error: &ExecServerError) -> Option<(i64, String)> {
-    let ExecServerError::Server { code, message } = error else {
-        return None;
-    };
-    (!is_transport_closed_error(error)).then(|| (*code, message.clone()))
+    match error {
+        ExecServerError::Server { code, message }
+            if *code == -32600 && message.starts_with("unknown session id ") =>
+        {
+            Some((*code, message.clone()))
+        }
+        _ => None,
+    }
 }
 
 fn record_disconnected(inner: &Arc<Inner>, message: String) -> String {

--- a/codex-rs/exec-server/src/client.rs
+++ b/codex-rs/exec-server/src/client.rs
@@ -13,6 +13,7 @@ use futures::FutureExt;
 use futures::future::BoxFuture;
 use serde_json::Value;
 use tokio::sync::Mutex;
+use tokio::sync::Semaphore;
 use tokio::sync::mpsc;
 use tokio::sync::watch;
 
@@ -199,6 +200,7 @@ pub struct ExecServerClient {
 pub(crate) struct RemoteExecServerClient {
     transport_params: ExecServerTransportParams,
     state: Arc<Mutex<RemoteExecServerClientState>>,
+    connect_lock: Arc<Semaphore>,
 }
 
 enum RemoteExecServerClientState {
@@ -212,62 +214,94 @@ impl RemoteExecServerClient {
         Self {
             transport_params,
             state: Arc::new(Mutex::new(RemoteExecServerClientState::Uninitialized)),
+            connect_lock: Arc::new(Semaphore::new(1)),
         }
     }
 
     pub(crate) async fn get(&self) -> Result<ExecServerClient, ExecServerError> {
-        let mut state = self.state.lock().await;
+        if let Some(client) = self.cached_connected_client().await? {
+            return Ok(client);
+        }
+
+        let _connect_guard = self.connect_lock.acquire().await.map_err(|_| {
+            ExecServerError::Protocol("exec-server connect lock closed".to_string())
+        })?;
+        if let Some(client) = self.cached_connected_client().await? {
+            return Ok(client);
+        }
+
+        let reconnect_session_id = {
+            let state = self.state.lock().await;
+            match &*state {
+                RemoteExecServerClientState::Connected(client) => {
+                    Some(client.session_id().ok_or_else(|| {
+                        ExecServerError::Protocol(
+                            "disconnected exec-server websocket client has no session id"
+                                .to_string(),
+                        )
+                    })?)
+                }
+                RemoteExecServerClientState::Uninitialized => None,
+                RemoteExecServerClientState::TerminalResumeError { .. } => {
+                    unreachable!("cached terminal errors return above")
+                }
+            }
+        };
+        let client = match reconnect_session_id {
+            Some(session_id) => self.reconnect_websocket(session_id).await,
+            None => {
+                ExecServerClient::connect_for_transport(
+                    self.transport_params.clone(),
+                    /*resume_session_id*/ None,
+                )
+                .await
+            }
+        };
+
+        match client {
+            Ok(client) => {
+                let mut state = self.state.lock().await;
+                *state = RemoteExecServerClientState::Connected(client.clone());
+                Ok(client)
+            }
+            Err(err) => {
+                if let Some((code, message)) = terminal_resume_error(&err) {
+                    debug!("caching terminal exec-server websocket resume failure");
+                    let mut state = self.state.lock().await;
+                    *state = RemoteExecServerClientState::TerminalResumeError {
+                        code,
+                        message: message.clone(),
+                    };
+                    return Err(ExecServerError::Server { code, message });
+                }
+                Err(err)
+            }
+        }
+    }
+
+    async fn cached_connected_client(&self) -> Result<Option<ExecServerClient>, ExecServerError> {
+        let state = self.state.lock().await;
         match &*state {
             RemoteExecServerClientState::TerminalResumeError { code, message } => {
-                return Err(ExecServerError::Server {
+                Err(ExecServerError::Server {
                     code: *code,
                     message: message.clone(),
-                });
+                })
             }
             RemoteExecServerClientState::Connected(client) if !client.is_disconnected() => {
-                return Ok(client.clone());
+                Ok(Some(client.clone()))
             }
-            RemoteExecServerClientState::Connected(client) => {
+            RemoteExecServerClientState::Connected(client)
                 if !matches!(
                     &self.transport_params,
                     ExecServerTransportParams::WebSocketUrl { .. }
-                ) {
-                    return Ok(client.clone());
-                }
-
-                let session_id = client.session_id().ok_or_else(|| {
-                    ExecServerError::Protocol(
-                        "disconnected exec-server websocket client has no session id".to_string(),
-                    )
-                })?;
-                match self.reconnect_websocket(session_id).await {
-                    Ok(client) => {
-                        *state = RemoteExecServerClientState::Connected(client.clone());
-                        return Ok(client);
-                    }
-                    Err(err) => {
-                        if let Some((code, message)) = terminal_resume_error(&err) {
-                            debug!("caching terminal exec-server websocket resume failure");
-                            *state = RemoteExecServerClientState::TerminalResumeError {
-                                code,
-                                message: message.clone(),
-                            };
-                            return Err(ExecServerError::Server { code, message });
-                        }
-                        return Err(err);
-                    }
-                }
+                ) =>
+            {
+                Ok(Some(client.clone()))
             }
-            RemoteExecServerClientState::Uninitialized => {}
+            RemoteExecServerClientState::Connected(_)
+            | RemoteExecServerClientState::Uninitialized => Ok(None),
         }
-
-        let client = ExecServerClient::connect_for_transport(
-            self.transport_params.clone(),
-            /*resume_session_id*/ None,
-        )
-        .await?;
-        *state = RemoteExecServerClientState::Connected(client.clone());
-        Ok(client)
     }
 
     pub(crate) async fn request<T, F, Fut>(&self, mut request: F) -> Result<T, ExecServerError>
@@ -315,7 +349,11 @@ impl RemoteExecServerClient {
             }
         }
 
-        Err(last_error.expect("reconnect attempts should record a retryable error"))
+        Err(last_error.ok_or_else(|| {
+            ExecServerError::Protocol(
+                "exec-server websocket reconnect exhausted without retryable error".to_string(),
+            )
+        })?)
     }
 }
 

--- a/codex-rs/exec-server/src/client.rs
+++ b/codex-rs/exec-server/src/client.rs
@@ -1228,7 +1228,7 @@ mod tests {
                 },
                 initialize_timeout: DEFAULT_REMOTE_EXEC_SERVER_INITIALIZE_TIMEOUT,
             },
-            None,
+            /*resume_session_id*/ None,
         )
         .await
         .expect("stdio transport should connect");
@@ -1618,7 +1618,12 @@ mod tests {
         );
         let server = tokio::spawn(async move {
             let mut first = accept_websocket(&listener).await;
-            complete_websocket_initialize(&mut first, "session-1", None).await;
+            complete_websocket_initialize(
+                &mut first,
+                "session-1",
+                /*expected_resume_session_id*/ None,
+            )
+            .await;
             first
                 .close(None)
                 .await
@@ -1657,7 +1662,12 @@ mod tests {
         );
         let server = tokio::spawn(async move {
             let mut first = accept_websocket(&listener).await;
-            complete_websocket_initialize(&mut first, "session-1", None).await;
+            complete_websocket_initialize(
+                &mut first,
+                "session-1",
+                /*expected_resume_session_id*/ None,
+            )
+            .await;
             first
                 .close(None)
                 .await

--- a/codex-rs/exec-server/src/client_transport.rs
+++ b/codex-rs/exec-server/src/client_transport.rs
@@ -22,6 +22,7 @@ const ENVIRONMENT_CLIENT_NAME: &str = "codex-environment";
 impl ExecServerClient {
     pub(crate) async fn connect_for_transport(
         transport_params: crate::client_api::ExecServerTransportParams,
+        resume_session_id: Option<String>,
     ) -> Result<Self, ExecServerError> {
         match transport_params {
             crate::client_api::ExecServerTransportParams::WebSocketUrl {
@@ -34,7 +35,7 @@ impl ExecServerClient {
                     client_name: ENVIRONMENT_CLIENT_NAME.to_string(),
                     connect_timeout,
                     initialize_timeout,
-                    resume_session_id: None,
+                    resume_session_id,
                 })
                 .await
             }

--- a/codex-rs/exec-server/src/environment.rs
+++ b/codex-rs/exec-server/src/environment.rs
@@ -6,7 +6,7 @@ use crate::ExecServerError;
 use crate::ExecServerRuntimePaths;
 use crate::ExecutorFileSystem;
 use crate::HttpClient;
-use crate::client::LazyRemoteExecServerClient;
+use crate::client::RemoteExecServerClient;
 use crate::client::http_client::ReqwestHttpClient;
 use crate::client_api::ExecServerTransportParams;
 use crate::environment_provider::DefaultEnvironmentProvider;
@@ -403,7 +403,7 @@ impl Environment {
             } => Some(exec_server_url.clone()),
             ExecServerTransportParams::StdioCommand { .. } => None,
         };
-        let client = LazyRemoteExecServerClient::new(remote_transport.clone());
+        let client = RemoteExecServerClient::new(remote_transport.clone());
         let exec_backend: Arc<dyn ExecBackend> = Arc::new(RemoteProcess::new(client.clone()));
         let filesystem: Arc<dyn ExecutorFileSystem> =
             Arc::new(RemoteFileSystem::new(client.clone()));

--- a/codex-rs/exec-server/src/remote_file_system.rs
+++ b/codex-rs/exec-server/src/remote_file_system.rs
@@ -46,11 +46,15 @@ impl ExecutorFileSystem for RemoteFileSystem {
         sandbox: Option<&FileSystemSandboxContext>,
     ) -> FileSystemResult<Vec<u8>> {
         trace!("remote fs read_file");
-        let client = self.client.get().await.map_err(map_remote_error)?;
-        let response = client
-            .fs_read_file(FsReadFileParams {
-                path: path.clone(),
-                sandbox: remote_sandbox_context(sandbox),
+        let params = FsReadFileParams {
+            path: path.clone(),
+            sandbox: remote_sandbox_context(sandbox),
+        };
+        let response = self
+            .client
+            .request(|client| {
+                let params = params.clone();
+                async move { client.fs_read_file(params).await }
             })
             .await
             .map_err(map_remote_error)?;
@@ -69,12 +73,15 @@ impl ExecutorFileSystem for RemoteFileSystem {
         sandbox: Option<&FileSystemSandboxContext>,
     ) -> FileSystemResult<()> {
         trace!("remote fs write_file");
-        let client = self.client.get().await.map_err(map_remote_error)?;
-        client
-            .fs_write_file(FsWriteFileParams {
-                path: path.clone(),
-                data_base64: STANDARD.encode(contents),
-                sandbox: remote_sandbox_context(sandbox),
+        let params = FsWriteFileParams {
+            path: path.clone(),
+            data_base64: STANDARD.encode(contents),
+            sandbox: remote_sandbox_context(sandbox),
+        };
+        self.client
+            .request(|client| {
+                let params = params.clone();
+                async move { client.fs_write_file(params).await }
             })
             .await
             .map_err(map_remote_error)?;
@@ -88,12 +95,15 @@ impl ExecutorFileSystem for RemoteFileSystem {
         sandbox: Option<&FileSystemSandboxContext>,
     ) -> FileSystemResult<()> {
         trace!("remote fs create_directory");
-        let client = self.client.get().await.map_err(map_remote_error)?;
-        client
-            .fs_create_directory(FsCreateDirectoryParams {
-                path: path.clone(),
-                recursive: Some(options.recursive),
-                sandbox: remote_sandbox_context(sandbox),
+        let params = FsCreateDirectoryParams {
+            path: path.clone(),
+            recursive: Some(options.recursive),
+            sandbox: remote_sandbox_context(sandbox),
+        };
+        self.client
+            .request(|client| {
+                let params = params.clone();
+                async move { client.fs_create_directory(params).await }
             })
             .await
             .map_err(map_remote_error)?;
@@ -106,11 +116,15 @@ impl ExecutorFileSystem for RemoteFileSystem {
         sandbox: Option<&FileSystemSandboxContext>,
     ) -> FileSystemResult<FileMetadata> {
         trace!("remote fs get_metadata");
-        let client = self.client.get().await.map_err(map_remote_error)?;
-        let response = client
-            .fs_get_metadata(FsGetMetadataParams {
-                path: path.clone(),
-                sandbox: remote_sandbox_context(sandbox),
+        let params = FsGetMetadataParams {
+            path: path.clone(),
+            sandbox: remote_sandbox_context(sandbox),
+        };
+        let response = self
+            .client
+            .request(|client| {
+                let params = params.clone();
+                async move { client.fs_get_metadata(params).await }
             })
             .await
             .map_err(map_remote_error)?;
@@ -129,11 +143,15 @@ impl ExecutorFileSystem for RemoteFileSystem {
         sandbox: Option<&FileSystemSandboxContext>,
     ) -> FileSystemResult<Vec<ReadDirectoryEntry>> {
         trace!("remote fs read_directory");
-        let client = self.client.get().await.map_err(map_remote_error)?;
-        let response = client
-            .fs_read_directory(FsReadDirectoryParams {
-                path: path.clone(),
-                sandbox: remote_sandbox_context(sandbox),
+        let params = FsReadDirectoryParams {
+            path: path.clone(),
+            sandbox: remote_sandbox_context(sandbox),
+        };
+        let response = self
+            .client
+            .request(|client| {
+                let params = params.clone();
+                async move { client.fs_read_directory(params).await }
             })
             .await
             .map_err(map_remote_error)?;
@@ -155,13 +173,16 @@ impl ExecutorFileSystem for RemoteFileSystem {
         sandbox: Option<&FileSystemSandboxContext>,
     ) -> FileSystemResult<()> {
         trace!("remote fs remove");
-        let client = self.client.get().await.map_err(map_remote_error)?;
-        client
-            .fs_remove(FsRemoveParams {
-                path: path.clone(),
-                recursive: Some(options.recursive),
-                force: Some(options.force),
-                sandbox: remote_sandbox_context(sandbox),
+        let params = FsRemoveParams {
+            path: path.clone(),
+            recursive: Some(options.recursive),
+            force: Some(options.force),
+            sandbox: remote_sandbox_context(sandbox),
+        };
+        self.client
+            .request(|client| {
+                let params = params.clone();
+                async move { client.fs_remove(params).await }
             })
             .await
             .map_err(map_remote_error)?;
@@ -176,13 +197,16 @@ impl ExecutorFileSystem for RemoteFileSystem {
         sandbox: Option<&FileSystemSandboxContext>,
     ) -> FileSystemResult<()> {
         trace!("remote fs copy");
-        let client = self.client.get().await.map_err(map_remote_error)?;
-        client
-            .fs_copy(FsCopyParams {
-                source_path: source_path.clone(),
-                destination_path: destination_path.clone(),
-                recursive: options.recursive,
-                sandbox: remote_sandbox_context(sandbox),
+        let params = FsCopyParams {
+            source_path: source_path.clone(),
+            destination_path: destination_path.clone(),
+            recursive: options.recursive,
+            sandbox: remote_sandbox_context(sandbox),
+        };
+        self.client
+            .request(|client| {
+                let params = params.clone();
+                async move { client.fs_copy(params).await }
             })
             .await
             .map_err(map_remote_error)?;

--- a/codex-rs/exec-server/src/remote_file_system.rs
+++ b/codex-rs/exec-server/src/remote_file_system.rs
@@ -14,7 +14,7 @@ use crate::FileSystemResult;
 use crate::FileSystemSandboxContext;
 use crate::ReadDirectoryEntry;
 use crate::RemoveOptions;
-use crate::client::LazyRemoteExecServerClient;
+use crate::client::RemoteExecServerClient;
 use crate::protocol::FsCopyParams;
 use crate::protocol::FsCreateDirectoryParams;
 use crate::protocol::FsGetMetadataParams;
@@ -28,11 +28,11 @@ const NOT_FOUND_ERROR_CODE: i64 = -32004;
 
 #[derive(Clone)]
 pub(crate) struct RemoteFileSystem {
-    client: LazyRemoteExecServerClient,
+    client: RemoteExecServerClient,
 }
 
 impl RemoteFileSystem {
-    pub(crate) fn new(client: LazyRemoteExecServerClient) -> Self {
+    pub(crate) fn new(client: RemoteExecServerClient) -> Self {
         trace!("remote fs new");
         Self { client }
     }

--- a/codex-rs/exec-server/src/remote_process.rs
+++ b/codex-rs/exec-server/src/remote_process.rs
@@ -9,7 +9,7 @@ use crate::ExecProcess;
 use crate::ExecProcessEventReceiver;
 use crate::ExecServerError;
 use crate::StartedExecProcess;
-use crate::client::LazyRemoteExecServerClient;
+use crate::client::RemoteExecServerClient;
 use crate::client::Session;
 use crate::protocol::ExecParams;
 use crate::protocol::ReadResponse;
@@ -17,7 +17,7 @@ use crate::protocol::WriteResponse;
 
 #[derive(Clone)]
 pub(crate) struct RemoteProcess {
-    client: LazyRemoteExecServerClient,
+    client: RemoteExecServerClient,
 }
 
 struct RemoteExecProcess {
@@ -25,7 +25,7 @@ struct RemoteExecProcess {
 }
 
 impl RemoteProcess {
-    pub(crate) fn new(client: LazyRemoteExecServerClient) -> Self {
+    pub(crate) fn new(client: RemoteExecServerClient) -> Self {
         trace!("remote process new");
         Self { client }
     }

--- a/codex-rs/exec-server/src/remote_process.rs
+++ b/codex-rs/exec-server/src/remote_process.rs
@@ -35,12 +35,21 @@ impl RemoteProcess {
 impl ExecBackend for RemoteProcess {
     async fn start(&self, params: ExecParams) -> Result<StartedExecProcess, ExecServerError> {
         let process_id = params.process_id.clone();
-        let client = self.client.get().await?;
-        let session = client.register_session(&process_id).await?;
-        if let Err(err) = client.exec(params).await {
-            session.unregister().await;
-            return Err(err);
-        }
+        let session = self
+            .client
+            .request(|client| {
+                let params = params.clone();
+                let process_id = process_id.clone();
+                async move {
+                    let session = client.register_session(&process_id).await?;
+                    if let Err(err) = client.exec(params).await {
+                        session.unregister().await;
+                        return Err(err);
+                    }
+                    Ok(session)
+                }
+            })
+            .await?;
 
         Ok(StartedExecProcess {
             process: Arc::new(RemoteExecProcess { session }),

--- a/scripts/test-remote-env.sh
+++ b/scripts/test-remote-env.sh
@@ -59,7 +59,7 @@ setup_remote_env() {
     --privileged \
     --security-opt seccomp=unconfined \
     ubuntu:24.04 sleep infinity >/dev/null
-  if ! docker exec "${container_name}" sh -lc "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y python3 zsh bubblewrap"; then
+  if ! docker exec "${container_name}" sh -lc "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y python3 zsh bubblewrap iproute2"; then
     docker rm -f "${container_name}" >/dev/null 2>&1 || true
     return 1
   fi


### PR DESCRIPTION
## Summary
- add minimal websocket-only exec-server client reconnect for later new remote ops
- cache terminal resume failures and keep stdio one-shot
- add Docker-backed remote env regression that drops the live exec-server websocket and verifies the next remote filesystem op reconnects

## Validation
- `bazel test --bes_backend= --bes_results_url= //codex-rs/exec-server:exec-server-unit-tests`
- `bazel build --bes_backend= --bes_results_url= //codex-rs/exec-server:exec-server`
- `bazel build --bes_backend= --bes_results_url= //codex-rs/core:core-all-test`
- `source scripts/test-remote-env.sh; cd codex-rs; cargo test -p codex-core --test all remote_test_env_reconnects_after_exec_server_websocket_disconnect -- --nocapture`
