### PR TITLE
[codex] Normalize codex_hooks aliases during config merge

### DIFF
--- a/codex-rs/config/src/key_aliases.rs
+++ b/codex-rs/config/src/key_aliases.rs
@@ -8,11 +8,18 @@ struct ConfigKeyAlias {
     canonical_key: &'static str,
 }
 
-const CONFIG_KEY_ALIASES: &[ConfigKeyAlias] = &[ConfigKeyAlias {
-    table_path: &["memories"],
-    legacy_key: "no_memories_if_mcp_or_web_search",
-    canonical_key: "disable_on_external_context",
-}];
+const CONFIG_KEY_ALIASES: &[ConfigKeyAlias] = &[
+    ConfigKeyAlias {
+        table_path: &["memories"],
+        legacy_key: "no_memories_if_mcp_or_web_search",
+        canonical_key: "disable_on_external_context",
+    },
+    ConfigKeyAlias {
+        table_path: &["features"],
+        legacy_key: "codex_hooks",
+        canonical_key: "hooks",
+    },
+];
 
 pub(crate) fn normalize_key_aliases(path: &[String], table: &mut TomlMap<String, TomlValue>) {
     for alias in CONFIG_KEY_ALIASES {

--- a/codex-rs/config/src/merge_tests.rs
+++ b/codex-rs/config/src/merge_tests.rs
@@ -98,3 +98,77 @@ disable_on_external_context = true
     );
     assert_eq!(base, expected);
 }
+
+#[test]
+fn merge_toml_values_normalizes_legacy_feature_key_from_base_layer() {
+    let mut base = parse_toml(
+        r#"
+[features]
+codex_hooks = false
+"#,
+    );
+    let overlay = parse_toml(
+        r#"
+[features]
+hooks = true
+"#,
+    );
+
+    merge_toml_values(&mut base, &overlay);
+
+    let expected = parse_toml(
+        r#"
+[features]
+hooks = true
+"#,
+    );
+    assert_eq!(base, expected);
+}
+
+#[test]
+fn merge_toml_values_normalizes_legacy_feature_key_from_overlay_layer() {
+    let mut base = parse_toml(
+        r#"
+[features]
+hooks = true
+"#,
+    );
+    let overlay = parse_toml(
+        r#"
+[features]
+codex_hooks = false
+"#,
+    );
+
+    merge_toml_values(&mut base, &overlay);
+
+    let expected = parse_toml(
+        r#"
+[features]
+hooks = false
+"#,
+    );
+    assert_eq!(base, expected);
+}
+
+#[test]
+fn merge_toml_values_prefers_canonical_feature_key_when_one_layer_has_both_names() {
+    let mut base = TomlValue::Table(toml::map::Map::new());
+    let overlay = parse_toml(
+        r#"
+[features]
+hooks = true
+codex_hooks = false
+"#,
+    );
+
+    merge_toml_values(&mut base, &overlay);
+
+    let expected = parse_toml(
+        r#"
+[features]
+hooks = true
+"#,
+    );
+    assert_eq!(base, expected);
+}


### PR DESCRIPTION
# Why

Issue #22148 reports that Codex can show the deprecated `[features].codex_hooks` notice even when the user's active config has already migrated to `[features].hooks = true`.

I reproduced the underlying merge bug in a clean `origin/main` worktree with a two-layer config stack:

- lower-precedence layer: `[features] hooks = true`
- higher-precedence layer: `[features] codex_hooks = false`

Before this change, config merge preserved both keys. That leaves the legacy alias alive long enough to record the deprecation notice, while the canonical `hooks = true` entry still wins later when the merged feature map is applied. That matches the false-warning behavior described in the issue and the Desktop internal override shape called out in the thread.

# What

- Canonicalize `[features].codex_hooks` to `[features].hooks` during config merge, alongside the existing key-alias normalization pass.
- Add regression coverage for:
  - legacy feature key in the base layer
  - legacy feature key in the overlay layer
  - canonical and legacy feature keys appearing together in one layer

# Repro

In a clean `origin/main` worktree, I added a focused merge regression for:

```toml
[features]
hooks = true
```

overlaid by:

```toml
[features]
codex_hooks = false
```

The test fails on unmodified `origin/main` because merge output still contains both `codex_hooks = false` and `hooks = true`, instead of collapsing to canonical `hooks = false`.

# Validation

- `just fmt`
- `cargo test -p codex-config merge_toml_values_normalizes_legacy_feature_key_from_overlay_layer`
- `cargo test -p codex-config`
- `git diff --check`
