### PR TITLE
Let EnvironmentProvider produce local environments

### DIFF
--- a/codex-rs/exec-server/src/environment.rs
+++ b/codex-rs/exec-server/src/environment.rs
@@ -114,11 +114,7 @@ impl EnvironmentManager {
         local_runtime_paths: Option<ExecServerRuntimePaths>,
     ) -> Self {
         let provider = DefaultEnvironmentProvider::new(exec_server_url, local_runtime_paths);
-        match Self::from_snapshot(
-            provider
-                .snapshot_inner()
-                .expect("default provider should create valid environments"),
-        ) {
+        match provider.snapshot_inner().and_then(Self::from_snapshot) {
             Ok(manager) => manager,
             Err(err) => panic!("default provider should create valid environments: {err}"),
         }
@@ -132,9 +128,10 @@ impl EnvironmentManager {
     ) -> Self {
         let local_environment = Environment::local(local_runtime_paths.clone());
         let provider = DefaultEnvironmentProvider::new(exec_server_url, Some(local_runtime_paths));
-        let mut snapshot = provider
-            .snapshot_inner()
-            .expect("default provider should create valid environments");
+        let mut snapshot = match provider.snapshot_inner() {
+            Ok(snapshot) => snapshot,
+            Err(err) => panic!("default provider should create valid environments: {err}"),
+        };
         if snapshot.local_environment.is_none() {
             snapshot.local_environment = Some(local_environment);
         }

--- a/codex-rs/exec-server/src/environment.rs
+++ b/codex-rs/exec-server/src/environment.rs
@@ -42,7 +42,6 @@ pub struct EnvironmentManager {
     default_environment: Option<String>,
     environments: RwLock<HashMap<String, Arc<Environment>>>,
     local_environment: Option<Arc<Environment>>,
-    local_runtime_paths: Option<ExecServerRuntimePaths>,
 }
 
 pub const LOCAL_ENVIRONMENT_ID: &str = "local";
@@ -51,14 +50,14 @@ pub const REMOTE_ENVIRONMENT_ID: &str = "remote";
 impl EnvironmentManager {
     /// Builds a test-only manager without configured sandbox helper paths.
     pub fn default_for_tests() -> Self {
+        let local_environment = Arc::new(Environment::default_for_tests());
         Self {
             default_environment: Some(LOCAL_ENVIRONMENT_ID.to_string()),
             environments: RwLock::new(HashMap::from([(
                 LOCAL_ENVIRONMENT_ID.to_string(),
-                Arc::new(Environment::default_for_tests()),
+                Arc::clone(&local_environment),
             )])),
-            local_environment: Some(Arc::new(Environment::default_for_tests())),
-            local_runtime_paths: None,
+            local_environment: Some(local_environment),
         }
     }
 
@@ -68,7 +67,6 @@ impl EnvironmentManager {
             default_environment: None,
             environments: RwLock::new(HashMap::new()),
             local_environment: None,
-            local_runtime_paths: None,
         }
     }
 
@@ -90,8 +88,9 @@ impl EnvironmentManager {
         codex_home: impl AsRef<std::path::Path>,
         local_runtime_paths: Option<ExecServerRuntimePaths>,
     ) -> Result<Self, ExecServerError> {
-        let provider = environment_provider_from_codex_home(codex_home.as_ref())?;
-        Self::from_snapshot(provider.snapshot().await?, local_runtime_paths)
+        let provider =
+            environment_provider_from_codex_home(codex_home.as_ref(), local_runtime_paths)?;
+        Self::from_provider(provider.as_ref()).await
     }
 
     /// Builds a manager from the legacy environment-variable provider without
@@ -99,16 +98,27 @@ impl EnvironmentManager {
     pub async fn from_env(
         local_runtime_paths: Option<ExecServerRuntimePaths>,
     ) -> Result<Self, ExecServerError> {
-        let provider = DefaultEnvironmentProvider::from_env();
-        Self::from_snapshot(provider.snapshot().await?, local_runtime_paths)
+        let provider = DefaultEnvironmentProvider::from_env(local_runtime_paths);
+        Self::from_provider(&provider).await
+    }
+
+    pub async fn from_provider<P>(provider: &P) -> Result<Self, ExecServerError>
+    where
+        P: EnvironmentProvider + ?Sized,
+    {
+        Self::from_snapshot(provider.snapshot().await?)
     }
 
     async fn from_default_provider_url(
         exec_server_url: Option<String>,
         local_runtime_paths: Option<ExecServerRuntimePaths>,
     ) -> Self {
-        let provider = DefaultEnvironmentProvider::new(exec_server_url);
-        match Self::from_snapshot(provider.snapshot_inner(), local_runtime_paths) {
+        let provider = DefaultEnvironmentProvider::new(exec_server_url, local_runtime_paths);
+        match Self::from_snapshot(
+            provider
+                .snapshot_inner()
+                .expect("default provider should create valid environments"),
+        ) {
             Ok(manager) => manager,
             Err(err) => panic!("default provider should create valid environments: {err}"),
         }
@@ -120,40 +130,36 @@ impl EnvironmentManager {
         exec_server_url: Option<String>,
         local_runtime_paths: ExecServerRuntimePaths,
     ) -> Self {
-        let mut snapshot = DefaultEnvironmentProvider::new(exec_server_url).snapshot_inner();
-        snapshot.include_local = true;
-        match Self::from_snapshot(snapshot, Some(local_runtime_paths)) {
+        let local_environment = Environment::local(local_runtime_paths.clone());
+        let provider = DefaultEnvironmentProvider::new(exec_server_url, Some(local_runtime_paths));
+        let mut snapshot = provider
+            .snapshot_inner()
+            .expect("default provider should create valid environments");
+        if snapshot.local_environment.is_none() {
+            snapshot.local_environment = Some(local_environment);
+        }
+        match Self::from_snapshot(snapshot) {
             Ok(manager) => manager,
             Err(err) => panic!("test provider with local should create valid environments: {err}"),
         }
     }
 
-    fn from_snapshot(
-        snapshot: EnvironmentProviderSnapshot,
-        local_runtime_paths: Option<ExecServerRuntimePaths>,
-    ) -> Result<Self, ExecServerError> {
+    fn from_snapshot(snapshot: EnvironmentProviderSnapshot) -> Result<Self, ExecServerError> {
         let EnvironmentProviderSnapshot {
             environments,
+            local_environment,
             default,
-            include_local,
         } = snapshot;
         let mut environment_map =
-            HashMap::with_capacity(environments.len() + usize::from(include_local));
-        let local_environment = if include_local {
-            let local_runtime_paths = local_runtime_paths.clone().ok_or_else(|| {
-                ExecServerError::Protocol(
-                    "local environment requires configured runtime paths".to_string(),
-                )
-            })?;
-            let local_environment = Arc::new(Environment::local(local_runtime_paths));
+            HashMap::with_capacity(environments.len() + usize::from(local_environment.is_some()));
+        let local_environment = local_environment.map(|local_environment| {
+            let local_environment = Arc::new(local_environment);
             environment_map.insert(
                 LOCAL_ENVIRONMENT_ID.to_string(),
                 Arc::clone(&local_environment),
             );
-            Some(local_environment)
-        } else {
-            None
-        };
+            local_environment
+        });
         for (id, environment) in environments {
             if id.is_empty() {
                 return Err(ExecServerError::Protocol(
@@ -189,7 +195,6 @@ impl EnvironmentManager {
             default_environment,
             environments: RwLock::new(environment_map),
             local_environment,
-            local_runtime_paths,
         })
     }
 
@@ -269,7 +274,7 @@ impl EnvironmentManager {
             ));
         };
         let environment =
-            Environment::remote_inner(exec_server_url, self.local_runtime_paths.clone());
+            Environment::remote_inner(exec_server_url, /*local_runtime_paths*/ None);
         self.environments
             .write()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -541,11 +546,10 @@ mod tests {
                 Environment::create_for_tests(Some("ws://127.0.0.1:8765".to_string()))
                     .expect("remote environment"),
             )],
+            local_environment: None,
             default: EnvironmentDefault::EnvironmentId(REMOTE_ENVIRONMENT_ID.to_string()),
-            include_local: false,
         };
-        let manager = EnvironmentManager::from_snapshot(snapshot, Some(test_runtime_paths()))
-            .expect("environment manager");
+        let manager = EnvironmentManager::from_snapshot(snapshot).expect("environment manager");
 
         assert_eq!(
             manager.default_environment_id(),
@@ -565,11 +569,10 @@ mod tests {
     async fn environment_manager_rejects_empty_environment_id() {
         let snapshot = EnvironmentProviderSnapshot {
             environments: vec![("".to_string(), Environment::default_for_tests())],
+            local_environment: None,
             default: EnvironmentDefault::Disabled,
-            include_local: false,
         };
-        let err = EnvironmentManager::from_snapshot(snapshot, Some(test_runtime_paths()))
-            .expect_err("empty id should fail");
+        let err = EnvironmentManager::from_snapshot(snapshot).expect_err("empty id should fail");
 
         assert_eq!(
             err.to_string(),
@@ -584,11 +587,10 @@ mod tests {
                 LOCAL_ENVIRONMENT_ID.to_string(),
                 Environment::default_for_tests(),
             )],
+            local_environment: None,
             default: EnvironmentDefault::Disabled,
-            include_local: false,
         };
-        let err = EnvironmentManager::from_snapshot(snapshot, Some(test_runtime_paths()))
-            .expect_err("local id should fail");
+        let err = EnvironmentManager::from_snapshot(snapshot).expect_err("local id should fail");
 
         assert_eq!(
             err.to_string(),
@@ -604,11 +606,10 @@ mod tests {
                 Environment::create_for_tests(Some("ws://127.0.0.1:8765".to_string()))
                     .expect("remote environment"),
             )],
+            local_environment: Some(Environment::local(test_runtime_paths())),
             default: EnvironmentDefault::EnvironmentId("devbox".to_string()),
-            include_local: true,
         };
-        let manager = EnvironmentManager::from_snapshot(snapshot, Some(test_runtime_paths()))
-            .expect("manager");
+        let manager = EnvironmentManager::from_snapshot(snapshot).expect("manager");
 
         assert_eq!(manager.default_environment_id(), Some("devbox"));
         assert_eq!(
@@ -626,11 +627,10 @@ mod tests {
                 Environment::create_for_tests(Some("ws://127.0.0.1:8765".to_string()))
                     .expect("remote environment"),
             )],
+            local_environment: Some(Environment::local(test_runtime_paths())),
             default: EnvironmentDefault::Disabled,
-            include_local: true,
         };
-        let manager = EnvironmentManager::from_snapshot(snapshot, Some(test_runtime_paths()))
-            .expect("manager");
+        let manager = EnvironmentManager::from_snapshot(snapshot).expect("manager");
 
         assert_eq!(manager.default_environment_id(), None);
         assert!(manager.default_environment().is_none());
@@ -650,11 +650,11 @@ mod tests {
                 Environment::create_for_tests(Some("ws://127.0.0.1:8765".to_string()))
                     .expect("remote environment"),
             )],
+            local_environment: Some(Environment::local(test_runtime_paths())),
             default: EnvironmentDefault::EnvironmentId("missing".to_string()),
-            include_local: true,
         };
-        let err = EnvironmentManager::from_snapshot(snapshot, Some(test_runtime_paths()))
-            .expect_err("unknown default should fail");
+        let err =
+            EnvironmentManager::from_snapshot(snapshot).expect_err("unknown default should fail");
 
         assert_eq!(
             err.to_string(),
@@ -728,16 +728,12 @@ mod tests {
 
     #[tokio::test]
     async fn environment_manager_snapshot_without_local_environment_disables_local_default() {
-        let mut snapshot = EnvironmentProviderSnapshot {
+        let snapshot = EnvironmentProviderSnapshot {
             environments: Vec::new(),
-            default: EnvironmentDefault::EnvironmentId(LOCAL_ENVIRONMENT_ID.to_string()),
-            include_local: true,
+            local_environment: None,
+            default: EnvironmentDefault::Disabled,
         };
-        snapshot.include_local = false;
-        snapshot.default = EnvironmentDefault::Disabled;
-        let manager =
-            EnvironmentManager::from_snapshot(snapshot, /*local_runtime_paths*/ None)
-                .expect("environment manager");
+        let manager = EnvironmentManager::from_snapshot(snapshot).expect("environment manager");
 
         assert!(manager.default_environment().is_none());
         assert_eq!(manager.default_environment_id(), None);

--- a/codex-rs/exec-server/src/environment_provider.rs
+++ b/codex-rs/exec-server/src/environment_provider.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 
 use crate::Environment;
 use crate::ExecServerError;
+use crate::ExecServerRuntimePaths;
 use crate::environment::CODEX_EXEC_SERVER_URL_ENV_VAR;
 use crate::environment::LOCAL_ENVIRONMENT_ID;
 use crate::environment::REMOTE_ENVIRONMENT_ID;
@@ -10,9 +11,8 @@ use crate::environment::REMOTE_ENVIRONMENT_ID;
 ///
 /// Implementations own a startup snapshot containing both the available
 /// environment list in configured order and the default environment
-/// selection. Providers should only return provider-owned remote environments;
-/// `include_local` controls whether `EnvironmentManager` should add the local
-/// environment to the snapshot.
+/// selection. Providers should return provider-owned named environments in
+/// `environments` and use `local_environment` for the reserved local slot.
 #[async_trait]
 pub trait EnvironmentProvider: Send + Sync {
     /// Returns the provider-owned environment startup snapshot.
@@ -22,8 +22,8 @@ pub trait EnvironmentProvider: Send + Sync {
 #[derive(Clone, Debug)]
 pub struct EnvironmentProviderSnapshot {
     pub environments: Vec<(String, Environment)>,
+    pub local_environment: Option<Environment>,
     pub default: EnvironmentDefault,
-    pub include_local: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -36,20 +36,30 @@ pub enum EnvironmentDefault {
 #[derive(Clone, Debug)]
 pub struct DefaultEnvironmentProvider {
     exec_server_url: Option<String>,
+    local_runtime_paths: Option<ExecServerRuntimePaths>,
 }
 
 impl DefaultEnvironmentProvider {
     /// Builds a provider from an already-read raw `CODEX_EXEC_SERVER_URL` value.
-    pub fn new(exec_server_url: Option<String>) -> Self {
-        Self { exec_server_url }
+    pub fn new(
+        exec_server_url: Option<String>,
+        local_runtime_paths: Option<ExecServerRuntimePaths>,
+    ) -> Self {
+        Self {
+            exec_server_url,
+            local_runtime_paths,
+        }
     }
 
     /// Builds a provider by reading `CODEX_EXEC_SERVER_URL`.
-    pub fn from_env() -> Self {
-        Self::new(std::env::var(CODEX_EXEC_SERVER_URL_ENV_VAR).ok())
+    pub fn from_env(local_runtime_paths: Option<ExecServerRuntimePaths>) -> Self {
+        Self::new(
+            std::env::var(CODEX_EXEC_SERVER_URL_ENV_VAR).ok(),
+            local_runtime_paths,
+        )
     }
 
-    pub(crate) fn snapshot_inner(&self) -> EnvironmentProviderSnapshot {
+    pub(crate) fn snapshot_inner(&self) -> Result<EnvironmentProviderSnapshot, ExecServerError> {
         let mut environments = Vec::new();
         let (exec_server_url, disabled) = normalize_exec_server_url(self.exec_server_url.clone());
 
@@ -63,7 +73,17 @@ impl DefaultEnvironmentProvider {
         let has_remote = environments
             .iter()
             .any(|(id, _environment)| id == REMOTE_ENVIRONMENT_ID);
-        let include_local = !disabled && !has_remote;
+        let local_environment = if disabled || has_remote {
+            None
+        } else {
+            Some(Environment::local(
+                self.local_runtime_paths.clone().ok_or_else(|| {
+                    ExecServerError::Protocol(
+                        "local environment requires configured runtime paths".to_string(),
+                    )
+                })?,
+            ))
+        };
         let default = if disabled {
             EnvironmentDefault::Disabled
         } else if has_remote {
@@ -72,18 +92,18 @@ impl DefaultEnvironmentProvider {
             EnvironmentDefault::EnvironmentId(LOCAL_ENVIRONMENT_ID.to_string())
         };
 
-        EnvironmentProviderSnapshot {
+        Ok(EnvironmentProviderSnapshot {
             environments,
+            local_environment,
             default,
-            include_local,
-        }
+        })
     }
 }
 
 #[async_trait]
 impl EnvironmentProvider for DefaultEnvironmentProvider {
     async fn snapshot(&self) -> Result<EnvironmentProviderSnapshot, ExecServerError> {
-        Ok(self.snapshot_inner())
+        self.snapshot_inner()
     }
 }
 
@@ -103,18 +123,29 @@ mod tests {
 
     use super::*;
 
+    fn test_runtime_paths() -> ExecServerRuntimePaths {
+        ExecServerRuntimePaths::new(
+            std::env::current_exe().expect("current exe"),
+            /*codex_linux_sandbox_exe*/ None,
+        )
+        .expect("runtime paths")
+    }
+
     #[tokio::test]
     async fn default_provider_requests_local_environment_when_url_is_missing() {
-        let provider = DefaultEnvironmentProvider::new(/*exec_server_url*/ None);
+        let provider = DefaultEnvironmentProvider::new(
+            /*exec_server_url*/ None,
+            Some(test_runtime_paths()),
+        );
         let snapshot = provider.snapshot().await.expect("environments");
         let EnvironmentProviderSnapshot {
             environments,
+            local_environment,
             default,
-            include_local,
         } = snapshot;
         let environments: HashMap<_, _> = environments.into_iter().collect();
 
-        assert!(include_local);
+        assert!(local_environment.is_some());
         assert!(!environments.contains_key(LOCAL_ENVIRONMENT_ID));
         assert!(!environments.contains_key(REMOTE_ENVIRONMENT_ID));
         assert_eq!(
@@ -125,16 +156,17 @@ mod tests {
 
     #[tokio::test]
     async fn default_provider_requests_local_environment_when_url_is_empty() {
-        let provider = DefaultEnvironmentProvider::new(Some(String::new()));
+        let provider =
+            DefaultEnvironmentProvider::new(Some(String::new()), Some(test_runtime_paths()));
         let snapshot = provider.snapshot().await.expect("environments");
         let EnvironmentProviderSnapshot {
             environments,
+            local_environment,
             default,
-            include_local,
         } = snapshot;
         let environments: HashMap<_, _> = environments.into_iter().collect();
 
-        assert!(include_local);
+        assert!(local_environment.is_some());
         assert!(!environments.contains_key(LOCAL_ENVIRONMENT_ID));
         assert!(!environments.contains_key(REMOTE_ENVIRONMENT_ID));
         assert_eq!(
@@ -145,16 +177,17 @@ mod tests {
 
     #[tokio::test]
     async fn default_provider_omits_local_environment_for_none_value() {
-        let provider = DefaultEnvironmentProvider::new(Some("none".to_string()));
+        let provider =
+            DefaultEnvironmentProvider::new(Some("none".to_string()), Some(test_runtime_paths()));
         let snapshot = provider.snapshot().await.expect("environments");
         let EnvironmentProviderSnapshot {
             environments,
+            local_environment,
             default,
-            include_local,
         } = snapshot;
         let environments: HashMap<_, _> = environments.into_iter().collect();
 
-        assert!(!include_local);
+        assert!(local_environment.is_none());
         assert!(!environments.contains_key(LOCAL_ENVIRONMENT_ID));
         assert!(!environments.contains_key(REMOTE_ENVIRONMENT_ID));
         assert_eq!(default, EnvironmentDefault::Disabled);
@@ -162,16 +195,19 @@ mod tests {
 
     #[tokio::test]
     async fn default_provider_adds_remote_environment_for_websocket_url() {
-        let provider = DefaultEnvironmentProvider::new(Some("ws://127.0.0.1:8765".to_string()));
+        let provider = DefaultEnvironmentProvider::new(
+            Some("ws://127.0.0.1:8765".to_string()),
+            Some(test_runtime_paths()),
+        );
         let snapshot = provider.snapshot().await.expect("environments");
         let EnvironmentProviderSnapshot {
             environments,
+            local_environment,
             default,
-            include_local,
         } = snapshot;
         let environments: HashMap<_, _> = environments.into_iter().collect();
 
-        assert!(!include_local);
+        assert!(local_environment.is_none());
         assert!(!environments.contains_key(LOCAL_ENVIRONMENT_ID));
         let remote_environment = &environments[REMOTE_ENVIRONMENT_ID];
         assert!(remote_environment.is_remote());
@@ -187,13 +223,30 @@ mod tests {
 
     #[tokio::test]
     async fn default_provider_normalizes_exec_server_url() {
-        let provider = DefaultEnvironmentProvider::new(Some(" ws://127.0.0.1:8765 ".to_string()));
+        let provider = DefaultEnvironmentProvider::new(
+            Some(" ws://127.0.0.1:8765 ".to_string()),
+            Some(test_runtime_paths()),
+        );
         let snapshot = provider.snapshot().await.expect("environments");
         let environments: HashMap<_, _> = snapshot.environments.into_iter().collect();
 
         assert_eq!(
             environments[REMOTE_ENVIRONMENT_ID].exec_server_url(),
             Some("ws://127.0.0.1:8765")
+        );
+    }
+
+    #[tokio::test]
+    async fn default_provider_requires_runtime_paths_for_local_environment() {
+        let provider = DefaultEnvironmentProvider::new(/*exec_server_url*/ None, None);
+        let err = provider
+            .snapshot()
+            .await
+            .expect_err("local environment should require runtime paths");
+
+        assert_eq!(
+            err.to_string(),
+            "exec-server protocol error: local environment requires configured runtime paths"
         );
     }
 }

--- a/codex-rs/exec-server/src/environment_provider.rs
+++ b/codex-rs/exec-server/src/environment_provider.rs
@@ -238,7 +238,9 @@ mod tests {
 
     #[tokio::test]
     async fn default_provider_requires_runtime_paths_for_local_environment() {
-        let provider = DefaultEnvironmentProvider::new(/*exec_server_url*/ None, None);
+        let provider = DefaultEnvironmentProvider::new(
+            /*exec_server_url*/ None, /*local_runtime_paths*/ None,
+        );
         let err = provider
             .snapshot()
             .await

--- a/codex-rs/exec-server/src/environment_toml.rs
+++ b/codex-rs/exec-server/src/environment_toml.rs
@@ -489,9 +489,12 @@ mod tests {
 
     #[tokio::test]
     async fn toml_provider_requires_runtime_paths_for_local_environment() {
-        let provider =
-            TomlEnvironmentProvider::new_with_config_dir(EnvironmentsToml::default(), None, None)
-                .expect("provider");
+        let provider = TomlEnvironmentProvider::new_with_config_dir(
+            EnvironmentsToml::default(),
+            /*config_dir*/ None,
+            /*local_runtime_paths*/ None,
+        )
+        .expect("provider");
         let err = provider
             .snapshot()
             .await

--- a/codex-rs/exec-server/src/environment_toml.rs
+++ b/codex-rs/exec-server/src/environment_toml.rs
@@ -12,6 +12,7 @@ use crate::DefaultEnvironmentProvider;
 use crate::Environment;
 use crate::EnvironmentProvider;
 use crate::ExecServerError;
+use crate::ExecServerRuntimePaths;
 use crate::client_api::DEFAULT_REMOTE_EXEC_SERVER_CONNECT_TIMEOUT;
 use crate::client_api::DEFAULT_REMOTE_EXEC_SERVER_INITIALIZE_TIMEOUT;
 use crate::client_api::ExecServerTransportParams;
@@ -53,17 +54,28 @@ struct TomlEnvironmentProvider {
     default: EnvironmentDefault,
     include_local: bool,
     environments: Vec<(String, ExecServerTransportParams)>,
+    local_runtime_paths: Option<ExecServerRuntimePaths>,
+}
+
+#[cfg(test)]
+fn test_runtime_paths() -> ExecServerRuntimePaths {
+    ExecServerRuntimePaths::new(
+        std::env::current_exe().expect("current exe"),
+        /*codex_linux_sandbox_exe*/ None,
+    )
+    .expect("runtime paths")
 }
 
 impl TomlEnvironmentProvider {
     #[cfg(test)]
     fn new(config: EnvironmentsToml) -> Result<Self, ExecServerError> {
-        Self::new_with_config_dir(config, /*config_dir*/ None)
+        Self::new_with_config_dir(config, /*config_dir*/ None, Some(test_runtime_paths()))
     }
 
     fn new_with_config_dir(
         config: EnvironmentsToml,
         config_dir: Option<&Path>,
+        local_runtime_paths: Option<ExecServerRuntimePaths>,
     ) -> Result<Self, ExecServerError> {
         let EnvironmentsToml {
             default,
@@ -90,6 +102,7 @@ impl TomlEnvironmentProvider {
             default,
             include_local,
             environments: parsed_environments,
+            local_runtime_paths,
         })
     }
 }
@@ -108,10 +121,22 @@ impl EnvironmentProvider for TomlEnvironmentProvider {
             ));
         }
 
+        let local_environment = if self.include_local {
+            Some(Environment::local(
+                self.local_runtime_paths.clone().ok_or_else(|| {
+                    ExecServerError::Protocol(
+                        "local environment requires configured runtime paths".to_string(),
+                    )
+                })?,
+            ))
+        } else {
+            None
+        };
+
         Ok(EnvironmentProviderSnapshot {
             environments,
+            local_environment,
             default: self.default.clone(),
-            include_local: self.include_local,
         })
     }
 }
@@ -204,6 +229,7 @@ fn normalize_stdio_cwd(
 
 pub(crate) fn environment_provider_from_codex_home(
     codex_home: &Path,
+    local_runtime_paths: Option<ExecServerRuntimePaths>,
 ) -> Result<Box<dyn EnvironmentProvider>, ExecServerError> {
     let path = codex_home.join(ENVIRONMENTS_TOML_FILE);
     if !path.try_exists().map_err(|err| {
@@ -212,13 +238,16 @@ pub(crate) fn environment_provider_from_codex_home(
             path.display()
         ))
     })? {
-        return Ok(Box::new(DefaultEnvironmentProvider::from_env()));
+        return Ok(Box::new(DefaultEnvironmentProvider::from_env(
+            local_runtime_paths,
+        )));
     }
 
     let environments = load_environments_toml(&path)?;
     Ok(Box::new(TomlEnvironmentProvider::new_with_config_dir(
         environments,
         Some(codex_home),
+        local_runtime_paths,
     )?))
 }
 
@@ -374,8 +403,8 @@ mod tests {
         let snapshot = provider.snapshot().await.expect("environments");
         let EnvironmentProviderSnapshot {
             environments,
+            local_environment,
             default,
-            include_local,
         } = snapshot;
         let environment_ids: Vec<_> = environments
             .iter()
@@ -384,7 +413,7 @@ mod tests {
         assert_eq!(environment_ids, vec!["devbox", "ssh-dev"]);
         let environments: HashMap<_, _> = environments.into_iter().collect();
 
-        assert!(include_local);
+        assert!(local_environment.is_some());
         assert!(!environments.contains_key(LOCAL_ENVIRONMENT_ID));
         assert_eq!(
             environments["devbox"].exec_server_url(),
@@ -403,7 +432,7 @@ mod tests {
         let provider = TomlEnvironmentProvider::new(EnvironmentsToml::default()).expect("provider");
         let snapshot = provider.snapshot().await.expect("environments");
 
-        assert!(snapshot.include_local);
+        assert!(snapshot.local_environment.is_some());
         assert_eq!(
             snapshot.default,
             EnvironmentDefault::EnvironmentId(LOCAL_ENVIRONMENT_ID.to_string())
@@ -420,7 +449,7 @@ mod tests {
         .expect("provider");
         let snapshot = provider.snapshot().await.expect("environments");
 
-        assert!(snapshot.include_local);
+        assert!(snapshot.local_environment.is_some());
         assert_eq!(snapshot.default, EnvironmentDefault::Disabled);
     }
 
@@ -438,7 +467,7 @@ mod tests {
         .expect("provider");
         let snapshot = provider.snapshot().await.expect("environments");
 
-        assert!(!snapshot.include_local);
+        assert!(snapshot.local_environment.is_none());
         assert_eq!(
             snapshot.default,
             EnvironmentDefault::EnvironmentId("ssh-dev".to_string())
@@ -454,8 +483,24 @@ mod tests {
         .expect("provider");
         let snapshot = provider.snapshot().await.expect("environments");
 
-        assert!(!snapshot.include_local);
+        assert!(snapshot.local_environment.is_none());
         assert_eq!(snapshot.default, EnvironmentDefault::Disabled);
+    }
+
+    #[tokio::test]
+    async fn toml_provider_requires_runtime_paths_for_local_environment() {
+        let provider =
+            TomlEnvironmentProvider::new_with_config_dir(EnvironmentsToml::default(), None, None)
+                .expect("provider");
+        let err = provider
+            .snapshot()
+            .await
+            .expect_err("local environment should require runtime paths");
+
+        assert_eq!(
+            err.to_string(),
+            "exec-server protocol error: local environment requires configured runtime paths"
+        );
     }
 
     #[test]
@@ -574,6 +619,7 @@ mod tests {
                 }],
             },
             Some(config_dir.path()),
+            Some(test_runtime_paths()),
         )
         .expect("provider");
 
@@ -842,7 +888,8 @@ include_local = false
         .expect("write environments.toml");
 
         let provider =
-            environment_provider_from_codex_home(codex_home.path()).expect("environment provider");
+            environment_provider_from_codex_home(codex_home.path(), Some(test_runtime_paths()))
+                .expect("environment provider");
 
         let snapshot = provider.snapshot().await.expect("environments");
         let environment_ids: Vec<_> = snapshot
@@ -851,7 +898,7 @@ include_local = false
             .map(|(id, _environment)| id)
             .collect();
 
-        assert!(!snapshot.include_local);
+        assert!(snapshot.local_environment.is_none());
         assert!(!environment_ids.contains(&LOCAL_ENVIRONMENT_ID.to_string()));
         assert_eq!(snapshot.default, EnvironmentDefault::Disabled);
     }
@@ -861,7 +908,8 @@ include_local = false
         let codex_home = tempdir().expect("tempdir");
 
         let provider =
-            environment_provider_from_codex_home(codex_home.path()).expect("environment provider");
+            environment_provider_from_codex_home(codex_home.path(), Some(test_runtime_paths()))
+                .expect("environment provider");
 
         let snapshot = provider.snapshot().await.expect("environments");
         let environment_ids: Vec<_> = snapshot
@@ -870,7 +918,7 @@ include_local = false
             .map(|(id, _environment)| id)
             .collect();
 
-        assert!(snapshot.include_local);
+        assert!(snapshot.local_environment.is_some());
         assert!(!environment_ids.contains(&LOCAL_ENVIRONMENT_ID.to_string()));
         assert_eq!(
             snapshot.default,


### PR DESCRIPTION
## Summary
- move startup local-environment construction into `EnvironmentProvider` implementations
- let provider snapshots carry `local_environment: Option<Environment>` instead of `include_local`
- keep `EnvironmentManager` as snapshot validator/registry while preserving optional-local behavior from #23369

## Validation
- `/Users/starr/dotfiles/skills/codex-applied-devbox/scripts/sync-worktree-and-test /Users/starr/code/codex-worktrees/env-provider-local-cand3 //codex-rs/exec-server:all`
