### PR TITLE
[codex] Make local tool hooks generic

### DIFF
--- a/codex-rs/core/src/tools/handlers/unified_exec_tests.rs
+++ b/codex-rs/core/src/tools/handlers/unified_exec_tests.rs
@@ -226,7 +226,7 @@ async fn exec_command_pre_tool_use_payload_uses_raw_command() {
 }
 
 #[tokio::test]
-async fn exec_command_pre_tool_use_payload_skips_write_stdin() {
+async fn write_stdin_pre_tool_use_payload_uses_generic_input() {
     let payload = ToolPayload::Function {
         arguments: serde_json::json!({ "chars": "echo hi" }).to_string(),
     };
@@ -244,7 +244,10 @@ async fn exec_command_pre_tool_use_payload_skips_write_stdin() {
             source: crate::tools::context::ToolCallSource::Direct,
             payload,
         }),
-        None
+        Some(crate::tools::registry::PreToolUsePayload {
+            tool_name: HookToolName::new("write_stdin"),
+            tool_input: serde_json::json!({ "chars": "echo hi" }),
+        })
     );
 }
 

--- a/codex-rs/core/src/tools/registry.rs
+++ b/codex-rs/core/src/tools/registry.rs
@@ -64,14 +64,49 @@ pub(crate) trait CoreToolRuntime: ToolExecutor<ToolInvocation> {
 
     fn post_tool_use_payload(
         &self,
-        _invocation: &ToolInvocation,
-        _result: &dyn ToolOutput,
+        invocation: &ToolInvocation,
+        result: &dyn ToolOutput,
     ) -> Option<PostToolUsePayload> {
-        None
+        let tool_response = if let Some(response) =
+            result.post_tool_use_response(&invocation.call_id, &invocation.payload)
+        {
+            response
+        } else {
+            match result.to_response_item(&invocation.call_id, &invocation.payload) {
+                ResponseInputItem::FunctionCallOutput { output, .. }
+                | ResponseInputItem::CustomToolCallOutput { output, .. } => {
+                    serde_json::to_value(output).ok()?
+                }
+                ResponseInputItem::McpToolCallOutput { output, .. } => {
+                    serde_json::to_value(output).ok()?
+                }
+                ResponseInputItem::ToolSearchOutput {
+                    status,
+                    execution,
+                    tools,
+                    ..
+                } => serde_json::json!({
+                    "status": status,
+                    "execution": execution,
+                    "tools": tools,
+                }),
+                ResponseInputItem::Message { .. } => return None,
+            }
+        };
+
+        Some(PostToolUsePayload {
+            tool_name: default_hook_tool_name(&self.tool_name()),
+            tool_use_id: result.post_tool_use_id(&invocation.call_id),
+            tool_input: hook_input_from_payload(&invocation.payload)?,
+            tool_response,
+        })
     }
 
-    fn pre_tool_use_payload(&self, _invocation: &ToolInvocation) -> Option<PreToolUsePayload> {
-        None
+    fn pre_tool_use_payload(&self, invocation: &ToolInvocation) -> Option<PreToolUsePayload> {
+        Some(PreToolUsePayload {
+            tool_name: default_hook_tool_name(&self.tool_name()),
+            tool_input: hook_input_from_payload(&invocation.payload)?,
+        })
     }
 
     /// Rebuilds a tool invocation from hook-facing `tool_input`.
@@ -80,12 +115,37 @@ pub(crate) trait CoreToolRuntime: ToolExecutor<ToolInvocation> {
     /// hook contract they expose from `pre_tool_use_payload`.
     fn with_updated_hook_input(
         &self,
-        _invocation: ToolInvocation,
-        _updated_input: Value,
+        mut invocation: ToolInvocation,
+        updated_input: Value,
     ) -> Result<ToolInvocation, FunctionCallError> {
-        Err(FunctionCallError::RespondToModel(
-            "tool does not support hook input rewriting".to_string(),
-        ))
+        let tool_name = self.tool_name();
+        invocation.payload = match invocation.payload {
+            ToolPayload::Function { .. } => {
+                let arguments = serde_json::to_string(&updated_input).map_err(|err| {
+                    FunctionCallError::RespondToModel(format!(
+                        "failed to serialize rewritten {tool_name} arguments: {err}"
+                    ))
+                })?;
+                ToolPayload::Function { arguments }
+            }
+            ToolPayload::ToolSearch { .. } => {
+                let arguments = serde_json::from_value(updated_input).map_err(|err| {
+                    FunctionCallError::RespondToModel(format!(
+                        "failed to parse rewritten {tool_name} arguments: {err}"
+                    ))
+                })?;
+                ToolPayload::ToolSearch { arguments }
+            }
+            ToolPayload::Custom { .. } => match updated_input {
+                Value::String(input) => ToolPayload::Custom { input },
+                _ => {
+                    return Err(FunctionCallError::RespondToModel(format!(
+                        "hook returned updatedInput for custom tool {tool_name} without a string value"
+                    )));
+                }
+            },
+        };
+        Ok(invocation)
     }
 
     /// Creates an optional consumer for streamed tool argument diffs.
@@ -160,6 +220,26 @@ pub(crate) struct PostToolUsePayload {
     pub(crate) tool_input: Value,
     /// Tool result exposed at `tool_response`.
     pub(crate) tool_response: Value,
+}
+
+fn default_hook_tool_name(tool_name: &ToolName) -> HookToolName {
+    HookToolName::new(flat_tool_name(tool_name).into_owned())
+}
+
+fn hook_input_from_payload(payload: &ToolPayload) -> Option<Value> {
+    match payload {
+        ToolPayload::Function { arguments } => {
+            if arguments.trim().is_empty() {
+                return Some(Value::Object(serde_json::Map::new()));
+            }
+            Some(
+                serde_json::from_str(arguments)
+                    .unwrap_or_else(|_| Value::String(arguments.to_string())),
+            )
+        }
+        ToolPayload::ToolSearch { arguments } => serde_json::to_value(arguments).ok(),
+        ToolPayload::Custom { input } => Some(Value::String(input.clone())),
+    }
 }
 
 pub(crate) fn override_tool_exposure(

--- a/codex-rs/core/src/tools/registry_tests.rs
+++ b/codex-rs/core/src/tools/registry_tests.rs
@@ -154,6 +154,137 @@ fn handler_looks_up_namespaced_aliases_explicitly() {
 }
 
 #[tokio::test]
+async fn default_pre_tool_use_payload_uses_function_arguments() {
+    let (session, turn) = crate::session::tests::make_session_and_context().await;
+    let handler = TestHandler {
+        tool_name: codex_tools::ToolName::plain("update_plan"),
+    };
+    let arguments = serde_json::json!({
+        "plan": [{
+            "step": "look around",
+            "status": "in_progress"
+        }]
+    });
+    let invocation = test_invocation_with_payload(
+        session.into(),
+        turn.into(),
+        "call-plan",
+        codex_tools::ToolName::plain("update_plan"),
+        ToolPayload::Function {
+            arguments: arguments.to_string(),
+        },
+    );
+
+    assert_eq!(
+        handler.pre_tool_use_payload(&invocation),
+        Some(PreToolUsePayload {
+            tool_name: HookToolName::new("update_plan"),
+            tool_input: arguments,
+        })
+    );
+}
+
+#[tokio::test]
+async fn default_with_updated_hook_input_rewrites_function_arguments() -> anyhow::Result<()> {
+    let (session, turn) = crate::session::tests::make_session_and_context().await;
+    let handler = TestHandler {
+        tool_name: codex_tools::ToolName::plain("update_plan"),
+    };
+    let invocation = test_invocation(
+        session.into(),
+        turn.into(),
+        "call-plan",
+        codex_tools::ToolName::plain("update_plan"),
+    );
+    let updated_input = serde_json::json!({
+        "plan": [{
+            "step": "look again",
+            "status": "completed"
+        }]
+    });
+
+    let updated = handler.with_updated_hook_input(invocation, updated_input.clone())?;
+    let ToolPayload::Function { arguments } = updated.payload else {
+        panic!("expected rewritten function payload");
+    };
+    let actual: serde_json::Value = serde_json::from_str(&arguments)?;
+    assert_eq!(actual, updated_input);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn default_with_updated_hook_input_rewrites_tool_search_arguments() -> anyhow::Result<()> {
+    let (session, turn) = crate::session::tests::make_session_and_context().await;
+    let handler = TestHandler {
+        tool_name: codex_tools::ToolName::plain("tool_search"),
+    };
+    let invocation = test_invocation_with_payload(
+        session.into(),
+        turn.into(),
+        "call-search",
+        codex_tools::ToolName::plain("tool_search"),
+        ToolPayload::ToolSearch {
+            arguments: codex_protocol::models::SearchToolCallParams {
+                query: "first".to_string(),
+                limit: None,
+            },
+        },
+    );
+
+    let updated = handler.with_updated_hook_input(
+        invocation,
+        serde_json::json!({
+            "query": "second",
+            "limit": 3
+        }),
+    )?;
+    let ToolPayload::ToolSearch { arguments } = updated.payload else {
+        panic!("expected rewritten tool_search payload");
+    };
+    assert_eq!(
+        arguments,
+        codex_protocol::models::SearchToolCallParams {
+            query: "second".to_string(),
+            limit: Some(3),
+        }
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn default_post_tool_use_payload_uses_model_visible_output() {
+    let (session, turn) = crate::session::tests::make_session_and_context().await;
+    let handler = TestHandler {
+        tool_name: codex_tools::ToolName::plain("update_plan"),
+    };
+    let invocation = test_invocation_with_payload(
+        session.into(),
+        turn.into(),
+        "call-plan",
+        codex_tools::ToolName::plain("update_plan"),
+        ToolPayload::Function {
+            arguments: serde_json::json!({"plan": []}).to_string(),
+        },
+    );
+    let output = crate::tools::context::FunctionToolOutput::from_text(
+        "plan updated".to_string(),
+        Some(true),
+    );
+
+    assert_eq!(
+        handler.post_tool_use_payload(&invocation, &output),
+        Some(PostToolUsePayload {
+            tool_name: HookToolName::new("update_plan"),
+            tool_use_id: "call-plan".to_string(),
+            tool_input: serde_json::json!({"plan": []}),
+            tool_response: serde_json::json!("plan updated"),
+        })
+    );
+}
+
+#[tokio::test]
 async fn dispatch_notifies_tool_lifecycle_contributors() -> anyhow::Result<()> {
     let (mut session, turn) = crate::session::tests::make_session_and_context().await;
     let records = Arc::new(std::sync::Mutex::new(Vec::new()));
@@ -240,6 +371,24 @@ fn test_invocation(
     call_id: &str,
     tool_name: codex_tools::ToolName,
 ) -> ToolInvocation {
+    test_invocation_with_payload(
+        session,
+        turn,
+        call_id,
+        tool_name,
+        ToolPayload::Function {
+            arguments: "{}".to_string(),
+        },
+    )
+}
+
+fn test_invocation_with_payload(
+    session: Arc<crate::session::session::Session>,
+    turn: Arc<crate::session::turn_context::TurnContext>,
+    call_id: &str,
+    tool_name: codex_tools::ToolName,
+    payload: ToolPayload,
+) -> ToolInvocation {
     ToolInvocation {
         session,
         turn,
@@ -250,8 +399,6 @@ fn test_invocation(
         call_id: call_id.to_string(),
         tool_name,
         source: crate::tools::context::ToolCallSource::Direct,
-        payload: ToolPayload::Function {
-            arguments: "{}".to_string(),
-        },
+        payload,
     }
 }

--- a/codex-rs/core/tests/suite/hooks.rs
+++ b/codex-rs/core/tests/suite/hooks.rs
@@ -3057,7 +3057,7 @@ async fn pre_tool_use_blocks_apply_patch_with_write_alias() -> Result<()> {
 }
 
 #[tokio::test]
-async fn pre_tool_use_does_not_fire_for_plan_tool() -> Result<()> {
+async fn pre_tool_use_blocks_plan_tool_before_execution() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
     let server = start_mock_server().await;
@@ -3092,7 +3092,7 @@ async fn pre_tool_use_does_not_fire_for_plan_tool() -> Result<()> {
     let mut builder = test_codex()
         .with_pre_build_hook(|home| {
             if let Err(error) =
-                write_pre_tool_use_hook(home, /*matcher*/ None, "json_deny", "should not fire")
+                write_pre_tool_use_hook(home, Some("update_plan"), "json_deny", "should fire")
             {
                 panic!("failed to write pre tool use hook test fixture: {error}");
             }
@@ -3110,15 +3110,16 @@ async fn pre_tool_use_does_not_fire_for_plan_tool() -> Result<()> {
         .and_then(Value::as_str)
         .expect("update plan output string");
     assert!(
-        !output.contains("should not fire"),
-        "non-shell tool output should not be blocked by PreToolUse",
+        output.contains("Tool call blocked by PreToolUse hook: should fire. Tool: update_plan"),
+        "generic tool output should surface the hook reason",
     );
 
-    let hook_log_path = test.codex_home_path().join("pre_tool_use_hook_log.jsonl");
-    assert!(
-        !hook_log_path.exists(),
-        "plan tool should not trigger pre tool use hooks",
-    );
+    let hook_inputs = read_pre_tool_use_hook_inputs(test.codex_home_path())?;
+    assert_eq!(hook_inputs.len(), 1);
+    assert_eq!(hook_inputs[0]["hook_event_name"], "PreToolUse");
+    assert_eq!(hook_inputs[0]["tool_name"], "update_plan");
+    assert_eq!(hook_inputs[0]["tool_use_id"], call_id);
+    assert_eq!(hook_inputs[0]["tool_input"], args);
 
     Ok(())
 }
@@ -3729,7 +3730,7 @@ async fn post_tool_use_records_apply_patch_context_with_edit_alias() -> Result<(
 }
 
 #[tokio::test]
-async fn post_tool_use_does_not_fire_for_plan_tool() -> Result<()> {
+async fn post_tool_use_rewrites_plan_tool_output() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
     let server = start_mock_server().await;
@@ -3763,12 +3764,9 @@ async fn post_tool_use_does_not_fire_for_plan_tool() -> Result<()> {
 
     let mut builder = test_codex()
         .with_pre_build_hook(|home| {
-            if let Err(error) = write_post_tool_use_hook(
-                home,
-                /*matcher*/ None,
-                "decision_block",
-                "should not fire",
-            ) {
+            if let Err(error) =
+                write_post_tool_use_hook(home, Some("update_plan"), "decision_block", "should fire")
+            {
                 panic!("failed to write post tool use hook test fixture: {error}");
             }
         })
@@ -3785,15 +3783,17 @@ async fn post_tool_use_does_not_fire_for_plan_tool() -> Result<()> {
         .and_then(Value::as_str)
         .expect("update plan output string");
     assert!(
-        !output.contains("should not fire"),
-        "non-shell tool output should not be affected by PostToolUse",
+        output.contains("should fire"),
+        "generic tool output should be affected by PostToolUse",
     );
 
-    let hook_log_path = test.codex_home_path().join("post_tool_use_hook_log.jsonl");
-    assert!(
-        !hook_log_path.exists(),
-        "plan tool should not trigger post tool use hooks",
-    );
+    let hook_inputs = read_post_tool_use_hook_inputs(test.codex_home_path())?;
+    assert_eq!(hook_inputs.len(), 1);
+    assert_eq!(hook_inputs[0]["hook_event_name"], "PostToolUse");
+    assert_eq!(hook_inputs[0]["tool_name"], "update_plan");
+    assert_eq!(hook_inputs[0]["tool_use_id"], call_id);
+    assert_eq!(hook_inputs[0]["tool_input"], args);
+    assert_eq!(hook_inputs[0]["tool_response"], "Plan updated");
 
     Ok(())
 }


### PR DESCRIPTION
# Why

PreToolUse and PostToolUse coverage for built-in local tools has been opt-in per tool runtime. That makes every new built-in tool, and every existing tool that missed the wiring, another place where hooks can silently stop applying.

The recent reports around missing hook coverage are symptoms of that shape: the core hook machinery works, but local tools only participate if their runtime remembered to provide the hook payload and updatedInput rewrite path.

# What

This makes the default local tool runtime participate in hooks for local, client-executed tool payloads:

- Builds a generic PreToolUse payload from function, tool_search, and custom tool payloads.
- Applies generic updatedInput rewrites back onto those payloads before execution.
- Builds a generic PostToolUse payload from an explicit typed hook response when available, otherwise from the model-visible tool output.
- Keeps the existing specialized adapters for shell, MCP, apply_patch, and write_stdin behavior where they intentionally project compatibility fields or custom output shapes.
- Adds regression coverage showing that tools like update_plan now fire PreToolUse and PostToolUse hooks without bespoke runtime wiring.

The important design choice is that specialized runtimes can still override the defaults, but the default is no longer "no hooks." That should turn future local built-in tools into coverage-by-default instead of whackamole.

# Deviations / Roadbumps

- Hosted Responses tools are intentionally still out of scope. We skipped them because they do not run through the same local CoreToolRuntime execution path, and true PreToolUse enforcement would be misleading once the hosted tool has already executed upstream.
- The generic custom-tool updatedInput path only accepts string replacement. Object-shaped or otherwise structured custom tools should still provide an explicit adapter so the rewrite remains type-aware.
- For PostToolUse, the fallback uses the model-visible output only when the typed output does not provide an explicit hook response. That kept the change small while preserving existing special-case output contracts.
- Local formatting needed an escalated rerun because the repo formatter touched uv cache state outside the workspace sandbox. That was an environment issue, not a code/design change.

# Validation

- `just fmt`
- `just fix -p codex-core`
- `cargo test -p codex-core write_stdin_pre_tool_use_payload_uses_generic_input`
- `cargo test -p codex-core pre_tool_use_blocks_plan_tool_before_execution`
- `cargo test -p codex-core post_tool_use_rewrites_plan_tool_output`
- `cargo test -p codex-core default_pre_tool_use_payload_uses_function_arguments`
- `cargo test -p codex-core default_with_updated_hook_input_rewrites_function_arguments`
- `cargo test -p codex-core default_with_updated_hook_input_rewrites_tool_search_arguments`
- `cargo test -p codex-core default_post_tool_use_payload_uses_model_visible_output`

I did not run the full codex-core workspace suite locally because it is broader and slower; the targeted coverage exercises the changed hook paths.
