### PR TITLE
test: fix multi-agent service tier assertion

### DIFF
--- a/codex-rs/core/src/tools/handlers/multi_agents_tests.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_tests.rs
@@ -804,7 +804,7 @@ service_tier = "priority"
     );
     turn.config = Arc::new(config);
 
-    let err = SpawnAgentHandler::default()
+    let result = SpawnAgentHandler::default()
         .handle(invocation(
             Arc::new(session),
             Arc::new(turn),
@@ -815,15 +815,14 @@ service_tier = "priority"
                 "service_tier": "turbo"
             })),
         ))
-        .await
-        .expect_err("invalid spawn service tier should still be rejected");
+        .await;
 
     assert_eq!(
-        err,
-        FunctionCallError::RespondToModel(
+        result.err(),
+        Some(FunctionCallError::RespondToModel(
             "Service tier `turbo` is not supported for model `gpt-5.4`. Supported service tiers: priority"
                 .to_string()
-        )
+        ))
     );
 }
 


### PR DESCRIPTION
## Why

`openai/codex#22169` added a regression test that expects an invalid child `service_tier` to be rejected, but the test used `Result::expect_err` on `SpawnAgentHandler::handle`. That requires the `Ok` type to implement `Debug`, and this handler returns `Box<dyn ToolOutput>`, so Bazel failed while compiling `codex-core` tests before it could run them.

## What changed

- Capture the handler result and assert on `result.err()` instead of calling `expect_err`.
- Keep the same `FunctionCallError::RespondToModel` assertion for the rejected service tier.

## Verification

- `cargo test -p codex-core spawn_agent_role_service_tier_does_not_hide_invalid_spawn_request`
