### PR TITLE
Hide deferred tools from code mode prompt

### DIFF
--- a/codex-rs/core/src/tools/spec_plan.rs
+++ b/codex-rs/core/src/tools/spec_plan.rs
@@ -378,8 +378,21 @@ fn build_code_mode_executors(
         })
         .collect::<Vec<_>>();
     let namespace_descriptions = code_mode_namespace_descriptions(&code_mode_nested_tool_specs);
+    let code_mode_exec_prompt_tool_specs = executors
+        .iter()
+        .filter_map(|executor| {
+            if matches!(
+                executor.exposure(),
+                ToolExposure::DirectModelOnly | ToolExposure::Deferred
+            ) {
+                return None;
+            }
+
+            executor.spec()
+        })
+        .collect::<Vec<_>>();
     let mut enabled_tools =
-        collect_code_mode_exec_prompt_tool_definitions(code_mode_nested_tool_specs.iter());
+        collect_code_mode_exec_prompt_tool_definitions(code_mode_exec_prompt_tool_specs.iter());
     enabled_tools
         .sort_by(|left, right| compare_code_mode_tools(left, right, &namespace_descriptions));
 

--- a/codex-rs/core/src/tools/spec_plan.rs
+++ b/codex-rs/core/src/tools/spec_plan.rs
@@ -736,11 +736,10 @@ fn prepend_code_mode_executors(
     planned_tools: &mut PlannedTools,
 ) {
     let turn_context = context.turn_context;
-    let deferred_tools_available = search_tool_enabled(turn_context)
-        && planned_tools
-            .runtimes()
-            .iter()
-            .any(|executor| executor.exposure() == ToolExposure::Deferred);
+    let deferred_tools_available = planned_tools
+        .runtimes()
+        .iter()
+        .any(|executor| executor.exposure() == ToolExposure::Deferred);
     let code_mode_executors = build_code_mode_executors(
         turn_context,
         planned_tools.runtimes(),


### PR DESCRIPTION
## Why

The latest merged `main` `rust-ci-full` run (`26134557979`) repeatedly failed `codex-core::all::suite::code_mode::code_mode_only_guides_all_tools_search_and_calls_deferred_app_tools` on shard 3 across:

- macOS aarch64: https://github.com/openai/codex/actions/runs/26134557979/job/76867975877
- Linux x64 remote: https://github.com/openai/codex/actions/runs/26134557979/job/76868559368
- Linux arm64: https://github.com/openai/codex/actions/runs/26134557979/job/76868638671
- Windows x64: https://github.com/openai/codex/actions/runs/26134557979/job/76868885206
- Windows arm64: https://github.com/openai/codex/actions/runs/26134557979/job/76869440479

The failing assertion was `!exec_description.contains("calendar_timezone_option_99")`. Deferred tools were correctly available to code mode at execution time, but they were also leaking into the prompt-only `exec` tool description. That violated the test contract: deferred tools should stay callable through code mode runtime surfaces such as `tools` / `ALL_TOOLS`, but should not bloat the large `exec` description prompt.

## What Changed

- Kept `ToolExposure::Deferred` specs in the nested code mode tool set used for runtime dispatch.
- Excluded `ToolExposure::Deferred` specs only from the prompt description source passed to `collect_code_mode_exec_prompt_tool_definitions(...)`.
- Preserved deferred-tool discovery guidance when deferred nested tools still exist but search-tool support is absent.

## Verification

- Original repro evidence: `rust-ci-full` run `26134557979`, job links above, all failed with the same `calendar_timezone_option_99` assertion.
- Targeted repro workflow evidence: https://github.com/openai/codex/actions/runs/26137073247 selected only the Windows x64 shard 3 code-mode testcase and reproduced the same `calendar_timezone_option_99` assertion in https://github.com/openai/codex/actions/runs/26137073247/job/76876429929.
- CI on this PR is the authoritative validation path.