### PR TITLE
Keep network denial tests off remote exec path

### DIFF
--- a/codex-rs/core/tests/suite/unified_exec.rs
+++ b/codex-rs/core/tests/suite/unified_exec.rs
@@ -927,7 +927,7 @@ allow_local_binding = true
                 .set_permission_profile(permission_profile_for_config)
                 .expect("set permission profile");
         });
-    let test = builder.build_with_remote_env(server).await?;
+    let test = builder.build(server).await?;
     assert!(
         test.config.permissions.network.is_some(),
         "expected managed network proxy config to be present"


### PR DESCRIPTION
## Why

The latest merged `main` `rust-ci-full` run (`26134557979`) failed these Linux remote shard tests:

- `codex-core::all::suite::unified_exec::unified_exec_network_denial_emits_failed_background_end_event` in https://github.com/openai/codex/actions/runs/26134557979/job/76868559368
- `codex-core::all::suite::unified_exec::unified_exec_short_lived_network_denial_emits_failed_end_event` in https://github.com/openai/codex/actions/runs/26134557979/job/76868559385

Both failures occurred before the tests reached the managed network-denial behavior they are meant to assert. The logs show `exec_command` routed through the remote exec-server path and failing with `exec-server rejected request (-32603): No such file or directory (os error 2)`, after which the tests timed out waiting for `ExecCommandEnd`.

## What Changed

- Updated the shared network-denial test helper in `codex-rs/core/tests/suite/unified_exec.rs` so these two tests use the normal local test environment instead of opting into the unrelated remote exec-server path.

## Verification

- Original repro evidence: `rust-ci-full` run `26134557979`, job links above, both failed with the same remote exec-server startup rejection before timing out.
- Targeted repro workflow evidence: https://github.com/openai/codex/actions/runs/26137097959 reproduced `unified_exec_network_denial_emits_failed_background_end_event` in https://github.com/openai/codex/actions/runs/26137097959/job/76876104957, and https://github.com/openai/codex/actions/runs/26137094301 reproduced `unified_exec_short_lived_network_denial_emits_failed_end_event` in https://github.com/openai/codex/actions/runs/26137094301/job/76876222111.
- CI on this PR is green and is the authoritative validation path.