### PR TITLE
Add targeted rust-ci repro inputs

### DIFF
--- a/.github/workflows/rust-ci-full-nextest-platform.yml
+++ b/.github/workflows/rust-ci-full-nextest-platform.yml
@@ -47,6 +47,18 @@ on:
         required: false
         default: false
         type: boolean
+      nextest_filterset:
+        required: false
+        default: "all()"
+        type: string
+      selected_shard:
+        required: false
+        default: 0
+        type: number
+      repeat_count:
+        required: false
+        default: 1
+        type: number
 
 # Caller workflow-level env does not flow through workflow_call, so keep the
 # Cargo git transport hardening on the archive and shard jobs directly here.
@@ -75,6 +87,19 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: Validate targeted test inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          if (( ${{ inputs.selected_shard }} < 0 || ${{ inputs.selected_shard }} > 4 )); then
+            echo "selected_shard must be between 0 and 4" >&2
+            exit 1
+          fi
+          if (( ${{ inputs.repeat_count }} < 1 )); then
+            echo "repeat_count must be at least 1" >&2
+            exit 1
+          fi
 
       - name: Configure Dev Drive (Windows)
         if: ${{ runner.os == 'Windows' }}
@@ -300,7 +325,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: ${{ inputs.selected_shard == 0 && fromJSON('[1,2,3,4]') || fromJSON(format('[{0}]', inputs.selected_shard)) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -392,6 +417,7 @@ jobs:
             --archive-file "${archive_file}"
             --workspace-remap "${workspace_root}"
             --partition "hash:${{ matrix.shard }}/4"
+            --filterset "${{ inputs.nextest_filterset }}"
           )
           if [[ "${{ inputs.test_threads }}" != "0" ]]; then
             nextest_args+=(--test-threads "${{ inputs.test_threads }}")
@@ -417,7 +443,10 @@ jobs:
             )
           fi
 
-          "${test_command[@]}"
+          for attempt in $(seq 1 "${{ inputs.repeat_count }}"); do
+            echo "nextest attempt ${attempt}/${{ inputs.repeat_count }}"
+            "${test_command[@]}"
+          done
         env:
           RUST_BACKTRACE: 1
           RUST_MIN_STACK: "8388608" # 8 MiB

--- a/.github/workflows/rust-ci-full-nextest-platform.yml
+++ b/.github/workflows/rust-ci-full-nextest-platform.yml
@@ -417,7 +417,7 @@ jobs:
             --archive-file "${archive_file}"
             --workspace-remap "${workspace_root}"
             --partition "hash:${{ matrix.shard }}/4"
-            --filterset "${{ inputs.nextest_filterset }}"
+            --filterset "${NEXTEST_FILTERSET}"
           )
           if [[ "${{ inputs.test_threads }}" != "0" ]]; then
             nextest_args+=(--test-threads "${{ inputs.test_threads }}")
@@ -448,6 +448,7 @@ jobs:
             "${test_command[@]}"
           done
         env:
+          NEXTEST_FILTERSET: ${{ inputs.nextest_filterset }}
           RUST_BACKTRACE: 1
           RUST_MIN_STACK: "8388608" # 8 MiB
           NEXTEST_STATUS_LEVEL: leak

--- a/.github/workflows/rust-ci-full-nextest-platform.yml
+++ b/.github/workflows/rust-ci-full-nextest-platform.yml
@@ -312,7 +312,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   shard:
-    name: Tests shard ${{ matrix.shard }}/4
+    name: Tests ${{ matrix.shard == 0 && 'all selected tests' || format('shard {0}/4', matrix.shard) }}
     needs: archive
     runs-on: ${{ inputs.runner_group != '' && fromJSON(format('{{"group":"{0}","labels":"{1}"}}', inputs.runner_group, inputs.runner_labels)) || inputs.runner }}
     timeout-minutes: 60
@@ -325,7 +325,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: ${{ inputs.selected_shard == 0 && fromJSON('[1,2,3,4]') || fromJSON(format('[{0}]', inputs.selected_shard)) }}
+        shard: ${{ inputs.selected_shard == 0 && fromJSON('[0]') || fromJSON(format('[{0}]', inputs.selected_shard)) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -416,9 +416,11 @@ jobs:
             --no-fail-fast
             --archive-file "${archive_file}"
             --workspace-remap "${workspace_root}"
-            --partition "hash:${{ matrix.shard }}/4"
             --filterset "${NEXTEST_FILTERSET}"
           )
+          if [[ "${{ matrix.shard }}" != "0" ]]; then
+            nextest_args+=(--partition "hash:${{ matrix.shard }}/4")
+          fi
           if [[ "${{ inputs.test_threads }}" != "0" ]]; then
             nextest_args+=(--test-threads "${{ inputs.test_threads }}")
           fi

--- a/.github/workflows/rust-ci-full.yml
+++ b/.github/workflows/rust-ci-full.yml
@@ -24,7 +24,7 @@ on:
         default: all()
         type: string
       shard:
-        description: Full-CI shard to reproduce. Use 0 to run all four shards.
+        description: Full-CI shard to reproduce. Use 0 to run selected tests without sharding.
         required: true
         default: 0
         type: number

--- a/.github/workflows/rust-ci-full.yml
+++ b/.github/workflows/rust-ci-full.yml
@@ -5,6 +5,34 @@ on:
       - main
       - "**full-ci**"
   workflow_dispatch:
+    inputs:
+      repro_platform:
+        description: Platform lane to run. Use all for the normal full workflow.
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - macos-aarch64
+          - linux-x64-remote
+          - linux-arm64
+          - windows-x64
+          - windows-arm64
+      nextest_filterset:
+        description: cargo-nextest filterset selecting the tests to run.
+        required: true
+        default: all()
+        type: string
+      shard:
+        description: Full-CI shard to reproduce. Use 0 to run all four shards.
+        required: true
+        default: 0
+        type: number
+      repeat_count:
+        description: Number of times to rerun the selected shard/filterset in one job.
+        required: true
+        default: 1
+        type: number
 
 # CI builds in debug (dev) for faster signal.
 env:
@@ -16,6 +44,7 @@ env:
 jobs:
   # --- CI that doesn't need specific targets ---------------------------------
   general:
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.repro_platform == 'all' }}
     name: Format / etc
     runs-on: ubuntu-24.04
     defaults:
@@ -32,6 +61,7 @@ jobs:
         run: cargo fmt -- --config imports_granularity=Item --check
 
   cargo_shear:
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.repro_platform == 'all' }}
     name: cargo shear
     runs-on: ubuntu-24.04
     defaults:
@@ -49,6 +79,7 @@ jobs:
         run: cargo shear --deny-warnings
 
   argument_comment_lint_package:
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.repro_platform == 'all' }}
     name: Argument comment lint package
     runs-on: ubuntu-24.04
     env:
@@ -90,6 +121,7 @@ jobs:
           RUST_MIN_STACK: "8388608" # 8 MiB
 
   argument_comment_lint_prebuilt:
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.repro_platform == 'all' }}
     name: Argument comment lint - ${{ matrix.name }}
     runs-on: ${{ matrix.runs_on || matrix.runner }}
     timeout-minutes: 30
@@ -149,6 +181,7 @@ jobs:
 
   # --- CI to validate on different os/targets --------------------------------
   lint_build:
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.repro_platform == 'all' }}
     name: Lint/Build — ${{ matrix.runner }} - ${{ matrix.target }}${{ matrix.profile == 'release' && ' (release)' || '' }}
     runs-on: ${{ matrix.runs_on || matrix.runner }}
     timeout-minutes: 30
@@ -522,6 +555,7 @@ jobs:
           key: apt-${{ matrix.runner }}-${{ matrix.target }}-v1
 
   tests_macos_aarch64:
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.repro_platform == 'all' || github.event.inputs.repro_platform == 'macos-aarch64' }}
     name: Tests — macos-15-xlarge - aarch64-apple-darwin
     uses: ./.github/workflows/rust-ci-full-nextest-platform.yml
     with:
@@ -530,9 +564,13 @@ jobs:
       profile: ci-test
       artifact_id: macos-aarch64
       use_sccache: true
+      nextest_filterset: ${{ github.event.inputs.nextest_filterset || 'all()' }}
+      selected_shard: ${{ fromJSON(github.event.inputs.shard || '0') }}
+      repeat_count: ${{ fromJSON(github.event.inputs.repeat_count || '1') }}
     secrets: inherit
 
   tests_linux_x64_remote:
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.repro_platform == 'all' || github.event.inputs.repro_platform == 'linux-x64-remote' }}
     name: Tests — ubuntu-24.04 - x86_64-unknown-linux-gnu (remote)
     uses: ./.github/workflows/rust-ci-full-nextest-platform.yml
     with:
@@ -544,9 +582,13 @@ jobs:
       artifact_id: linux-x64-remote
       remote_env: true
       use_sccache: true
+      nextest_filterset: ${{ github.event.inputs.nextest_filterset || 'all()' }}
+      selected_shard: ${{ fromJSON(github.event.inputs.shard || '0') }}
+      repeat_count: ${{ fromJSON(github.event.inputs.repeat_count || '1') }}
     secrets: inherit
 
   tests_linux_arm64:
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.repro_platform == 'all' || github.event.inputs.repro_platform == 'linux-arm64' }}
     name: Tests — ubuntu-24.04-arm - aarch64-unknown-linux-gnu
     uses: ./.github/workflows/rust-ci-full-nextest-platform.yml
     with:
@@ -557,9 +599,13 @@ jobs:
       profile: ci-test
       artifact_id: linux-arm64
       use_sccache: true
+      nextest_filterset: ${{ github.event.inputs.nextest_filterset || 'all()' }}
+      selected_shard: ${{ fromJSON(github.event.inputs.shard || '0') }}
+      repeat_count: ${{ fromJSON(github.event.inputs.repeat_count || '1') }}
     secrets: inherit
 
   tests_windows_x64:
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.repro_platform == 'all' || github.event.inputs.repro_platform == 'windows-x64' }}
     name: Tests — windows-x64 - x86_64-pc-windows-msvc
     uses: ./.github/workflows/rust-ci-full-nextest-platform.yml
     with:
@@ -570,9 +616,13 @@ jobs:
       profile: ci-test
       artifact_id: windows-x64
       test_threads: 8
+      nextest_filterset: ${{ github.event.inputs.nextest_filterset || 'all()' }}
+      selected_shard: ${{ fromJSON(github.event.inputs.shard || '0') }}
+      repeat_count: ${{ fromJSON(github.event.inputs.repeat_count || '1') }}
     secrets: inherit
 
   tests_windows_arm64:
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.repro_platform == 'all' || github.event.inputs.repro_platform == 'windows-arm64' }}
     name: Tests — windows-arm64 - aarch64-pc-windows-msvc
     uses: ./.github/workflows/rust-ci-full-nextest-platform.yml
     with:
@@ -587,6 +637,9 @@ jobs:
       artifact_id: windows-arm64
       test_threads: 8
       use_sccache: true
+      nextest_filterset: ${{ github.event.inputs.nextest_filterset || 'all()' }}
+      selected_shard: ${{ fromJSON(github.event.inputs.shard || '0') }}
+      repeat_count: ${{ fromJSON(github.event.inputs.repeat_count || '1') }}
     secrets: inherit
 
   # --- Gatherer job for the full post-merge workflow --------------------------
@@ -621,16 +674,29 @@ jobs:
           echo "test arm64 : ${{ needs.tests_linux_arm64.result }}"
           echo "test winx64: ${{ needs.tests_windows_x64.result }}"
           echo "test winarm: ${{ needs.tests_windows_arm64.result }}"
-          [[ '${{ needs.argument_comment_lint_package.result }}' == 'success' ]] || { echo 'argument_comment_lint_package failed'; exit 1; }
-          [[ '${{ needs.argument_comment_lint_prebuilt.result }}' == 'success' ]] || { echo 'argument_comment_lint_prebuilt failed'; exit 1; }
-          [[ '${{ needs.general.result }}' == 'success' ]] || { echo 'general failed'; exit 1; }
-          [[ '${{ needs.cargo_shear.result }}' == 'success' ]] || { echo 'cargo_shear failed'; exit 1; }
-          [[ '${{ needs.lint_build.result }}' == 'success' ]] || { echo 'lint_build failed'; exit 1; }
-          [[ '${{ needs.tests_macos_aarch64.result }}' == 'success' ]] || { echo 'tests_macos_aarch64 failed'; exit 1; }
-          [[ '${{ needs.tests_linux_x64_remote.result }}' == 'success' ]] || { echo 'tests_linux_x64_remote failed'; exit 1; }
-          [[ '${{ needs.tests_linux_arm64.result }}' == 'success' ]] || { echo 'tests_linux_arm64 failed'; exit 1; }
-          [[ '${{ needs.tests_windows_x64.result }}' == 'success' ]] || { echo 'tests_windows_x64 failed'; exit 1; }
-          [[ '${{ needs.tests_windows_arm64.result }}' == 'success' ]] || { echo 'tests_windows_arm64 failed'; exit 1; }
+          if [[ '${{ github.event_name }}' == 'workflow_dispatch' && '${{ github.event.inputs.repro_platform }}' != 'all' ]]; then
+            selected_result=''
+            case '${{ github.event.inputs.repro_platform }}' in
+              macos-aarch64) selected_result='${{ needs.tests_macos_aarch64.result }}' ;;
+              linux-x64-remote) selected_result='${{ needs.tests_linux_x64_remote.result }}' ;;
+              linux-arm64) selected_result='${{ needs.tests_linux_arm64.result }}' ;;
+              windows-x64) selected_result='${{ needs.tests_windows_x64.result }}' ;;
+              windows-arm64) selected_result='${{ needs.tests_windows_arm64.result }}' ;;
+              *) echo 'unknown repro_platform'; exit 1 ;;
+            esac
+            [[ "${selected_result}" == 'success' ]] || { echo "selected repro platform failed: ${selected_result}"; exit 1; }
+          else
+            [[ '${{ needs.argument_comment_lint_package.result }}' == 'success' ]] || { echo 'argument_comment_lint_package failed'; exit 1; }
+            [[ '${{ needs.argument_comment_lint_prebuilt.result }}' == 'success' ]] || { echo 'argument_comment_lint_prebuilt failed'; exit 1; }
+            [[ '${{ needs.general.result }}' == 'success' ]] || { echo 'general failed'; exit 1; }
+            [[ '${{ needs.cargo_shear.result }}' == 'success' ]] || { echo 'cargo_shear failed'; exit 1; }
+            [[ '${{ needs.lint_build.result }}' == 'success' ]] || { echo 'lint_build failed'; exit 1; }
+            [[ '${{ needs.tests_macos_aarch64.result }}' == 'success' ]] || { echo 'tests_macos_aarch64 failed'; exit 1; }
+            [[ '${{ needs.tests_linux_x64_remote.result }}' == 'success' ]] || { echo 'tests_linux_x64_remote failed'; exit 1; }
+            [[ '${{ needs.tests_linux_arm64.result }}' == 'success' ]] || { echo 'tests_linux_arm64 failed'; exit 1; }
+            [[ '${{ needs.tests_windows_x64.result }}' == 'success' ]] || { echo 'tests_windows_x64 failed'; exit 1; }
+            [[ '${{ needs.tests_windows_arm64.result }}' == 'success' ]] || { echo 'tests_windows_arm64 failed'; exit 1; }
+          fi
 
       - name: sccache summary note
         if: always()


### PR DESCRIPTION
## Why

`rust-ci-full` currently proves that a full platform shard failed, but it is cumbersome to rerun just the suspect tests on one chosen lane while debugging CI-only flakes. The latest merged `main` run (`26134557979`) surfaced exactly that need across code-mode, unified-exec, and ambient-tempdir failures.

## What Changed

- Added targeted `workflow_dispatch` inputs to the existing `rust-ci-full` workflow so one selected platform lane can run a chosen `cargo-nextest` filterset, optional shard, and repeat count.
- Extended the reusable per-platform nextest workflow with matching filter/shard/repeat inputs while preserving the existing default full-matrix behavior.
- In targeted repro mode, unrelated lint/build jobs are skipped and the result gate only requires the selected repro lane to pass.
- `shard=0` runs the selected filterset without partitioning; `shard=1..4` reproduces an individual full-CI shard.
- Passed the dispatched nextest filterset through the step environment before invoking Bash so user-supplied filter text is treated as data rather than shell source.

## Verification

- Targeted Windows x64 code-mode repro: https://github.com/openai/codex/actions/runs/26137073247 reproduced the selected testcase failure in https://github.com/openai/codex/actions/runs/26137073247/job/76876429929.
- Targeted Linux x64 remote shard 3 repro: https://github.com/openai/codex/actions/runs/26137097959 reproduced both the code-mode assertion and `unified_exec_network_denial_emits_failed_background_end_event` in https://github.com/openai/codex/actions/runs/26137097959/job/76876104957.
- Targeted Linux x64 remote shard 4 repro: https://github.com/openai/codex/actions/runs/26137094301 reproduced `unified_exec_short_lived_network_denial_emits_failed_end_event` in https://github.com/openai/codex/actions/runs/26137094301/job/76876222111.
- Targeted Linux arm64 ambient-tempdir filterset: https://github.com/openai/codex/actions/runs/26137094490 completed successfully and did not reproduce on demand.
- Default `workflow_dispatch` inputs preserve the normal full workflow.
- CI on this PR is the authoritative validation path.
