### PR TITLE
feat: define queued turn payload contract

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol/v2/thread.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2/thread.rs
@@ -9,6 +9,7 @@ use super::ThreadSource;
 use super::Turn;
 use super::TurnEnvironmentParams;
 use super::TurnItemsView;
+use super::TurnStartParams;
 use super::shared::v2_enum_from_core;
 use codex_experimental_api_macros::ExperimentalApi;
 use codex_protocol::config_types::Personality;
@@ -19,6 +20,8 @@ use codex_protocol::protocol::TokenUsage as CoreTokenUsage;
 use codex_protocol::protocol::TokenUsageInfo as CoreTokenUsageInfo;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use schemars::JsonSchema;
+use schemars::r#gen::SchemaGenerator;
+use schemars::schema::Schema;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_json::Value as JsonValue;
@@ -657,6 +660,27 @@ pub struct ThreadGoalClearParams {
 #[ts(export_to = "v2/")]
 pub struct ThreadGoalClearResponse {
     pub cleared: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
+pub struct ThreadQueueAddParams {
+    pub thread_id: String,
+    #[schemars(with = "QueuedTurnStartParamsSchema")]
+    pub turn_start_params: TurnStartParams,
+}
+
+struct QueuedTurnStartParamsSchema;
+
+impl JsonSchema for QueuedTurnStartParamsSchema {
+    fn schema_name() -> String {
+        "QueuedTurnStartParams".to_string()
+    }
+
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+        TurnStartParams::json_schema(generator)
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]


### PR DESCRIPTION
# Summary

Queued follow-ups need to preserve the same turn payload a normal app-server turn receives. This PR adds that shared protocol contract first, so later queue storage and dispatch work can reuse the existing `TurnStartParams` shape instead of inventing a second serialization path.

# What changed

- Adds `ThreadQueueAddParams` to the v2 app-server protocol.
- Reuses `TurnStartParams` as the queued payload boundary.
- Adds the schema export hook needed for queued turn payload generation.

# Stack

1. **Current PR:** [#23617](https://github.com/openai/codex/pull/23617) payload persistence contract
2. [#23618](https://github.com/openai/codex/pull/23618) queue store and durable state model
3. [#23619](https://github.com/openai/codex/pull/23619) queue JSON-RPC surface and notifications
4. [#23620](https://github.com/openai/codex/pull/23620) app-server dispatcher and failure semantics

# Testing

Tests: targeted app-server protocol schema and fixture coverage.
