### PR TITLE
Stabilize compact remote parity skills normalization

### DIFF
--- a/codex-rs/core/tests/suite/compact_remote_parity.rs
+++ b/codex-rs/core/tests/suite/compact_remote_parity.rs
@@ -933,6 +933,10 @@ fn normalize_string(value: &str) -> String {
         return "<UUID>".to_string();
     }
 
+    if value.starts_with("<skills_instructions>\n") && value.ends_with("\n</skills_instructions>") {
+        return "<skills_instructions>\n...\n</skills_instructions>".to_string();
+    }
+
     let mut text = value.to_string();
     normalize_tmp_prefix_before_marker(&mut text, "/skills/");
     normalize_tmp_prefix_before_marker(&mut text, "\\skills\\");
@@ -1026,6 +1030,15 @@ fn normalize_string_rewrites_windows_temp_skill_paths() {
         "file: <CODEX_HOME>/skills/.system/imagegen/SKILL.md and \
          <CODEX_HOME>\\skills\\custom\\SKILL.md"
     );
+}
+
+#[test]
+fn normalize_string_rewrites_skills_instructions_body() {
+    let text = normalize_string(
+        "<skills_instructions>\n## Skills\n- imagegen: ...\n</skills_instructions>",
+    );
+
+    assert_eq!(text, "<skills_instructions>\n...\n</skills_instructions>");
 }
 
 #[test]


### PR DESCRIPTION
## Why

`rust-ci-full` run `26138722960` failed `codex-core::all::suite::compact_remote_parity::remote_compaction_parity_v2_api_key_sends_service_tier_upgrade` on `macos-aarch64-shard-3` because the parity snapshot compared the full ambient `<skills_instructions>` body.

That body is environment-derived and can vary independently of the compaction behavior the parity test is trying to compare.

## What Changed

- Normalize the contents of a top-level `<skills_instructions>` block while preserving the block marker itself.
- Add a focused normalization test for that case.

## Verification

- Source-grounded against the failing CI log from run `26138722960` / job `76881308783`.
- `just fmt`
- `git diff --check`
- A post-edit devbox rerun was attempted but blocked before Bazel by local SSH-agent signing failure to `dev`.
