### PR TITLE
dotslash: publish Codex entrypoints from package archives

### DIFF
--- a/.github/dotslash-config.json
+++ b/.github/dotslash-config.json
@@ -3,56 +3,56 @@
     "codex": {
       "platforms": {
         "macos-aarch64": {
-          "regex": "^codex-aarch64-apple-darwin\\.zst$",
-          "path": "codex"
+          "regex": "^codex-package-aarch64-apple-darwin\\.tar\\.zst$",
+          "path": "bin/codex"
         },
         "macos-x86_64": {
-          "regex": "^codex-x86_64-apple-darwin\\.zst$",
-          "path": "codex"
+          "regex": "^codex-package-x86_64-apple-darwin\\.tar\\.zst$",
+          "path": "bin/codex"
         },
         "linux-x86_64": {
-          "regex": "^codex-x86_64-unknown-linux-musl-bundle\\.tar\\.zst$",
-          "path": "codex"
+          "regex": "^codex-package-x86_64-unknown-linux-musl\\.tar\\.zst$",
+          "path": "bin/codex"
         },
         "linux-aarch64": {
-          "regex": "^codex-aarch64-unknown-linux-musl-bundle\\.tar\\.zst$",
-          "path": "codex"
+          "regex": "^codex-package-aarch64-unknown-linux-musl\\.tar\\.zst$",
+          "path": "bin/codex"
         },
         "windows-x86_64": {
-          "regex": "^codex-x86_64-pc-windows-msvc\\.exe\\.zst$",
-          "path": "codex.exe"
+          "regex": "^codex-package-x86_64-pc-windows-msvc\\.tar\\.zst$",
+          "path": "bin/codex.exe"
         },
         "windows-aarch64": {
-          "regex": "^codex-aarch64-pc-windows-msvc\\.exe\\.zst$",
-          "path": "codex.exe"
+          "regex": "^codex-package-aarch64-pc-windows-msvc\\.tar\\.zst$",
+          "path": "bin/codex.exe"
         }
       }
     },
     "codex-app-server": {
       "platforms": {
         "macos-aarch64": {
-          "regex": "^codex-app-server-aarch64-apple-darwin\\.zst$",
-          "path": "codex-app-server"
+          "regex": "^codex-app-server-package-aarch64-apple-darwin\\.tar\\.zst$",
+          "path": "bin/codex-app-server"
         },
         "macos-x86_64": {
-          "regex": "^codex-app-server-x86_64-apple-darwin\\.zst$",
-          "path": "codex-app-server"
+          "regex": "^codex-app-server-package-x86_64-apple-darwin\\.tar\\.zst$",
+          "path": "bin/codex-app-server"
         },
         "linux-x86_64": {
-          "regex": "^codex-app-server-x86_64-unknown-linux-musl\\.zst$",
-          "path": "codex-app-server"
+          "regex": "^codex-app-server-package-x86_64-unknown-linux-musl\\.tar\\.zst$",
+          "path": "bin/codex-app-server"
         },
         "linux-aarch64": {
-          "regex": "^codex-app-server-aarch64-unknown-linux-musl\\.zst$",
-          "path": "codex-app-server"
+          "regex": "^codex-app-server-package-aarch64-unknown-linux-musl\\.tar\\.zst$",
+          "path": "bin/codex-app-server"
         },
         "windows-x86_64": {
-          "regex": "^codex-app-server-x86_64-pc-windows-msvc\\.exe\\.zst$",
-          "path": "codex-app-server.exe"
+          "regex": "^codex-app-server-package-x86_64-pc-windows-msvc\\.tar\\.zst$",
+          "path": "bin/codex-app-server.exe"
         },
         "windows-aarch64": {
-          "regex": "^codex-app-server-aarch64-pc-windows-msvc\\.exe\\.zst$",
-          "path": "codex-app-server.exe"
+          "regex": "^codex-app-server-package-aarch64-pc-windows-msvc\\.tar\\.zst$",
+          "path": "bin/codex-app-server.exe"
         }
       }
     },

--- a/.github/scripts/build-codex-package-archive.sh
+++ b/.github/scripts/build-codex-package-archive.sh
@@ -97,9 +97,14 @@ else
   python_bin="python"
 fi
 
+if ! command -v zstd >/dev/null 2>&1 && [[ -x "${repo_root}/.github/workflows/zstd" ]]; then
+  export PATH="${repo_root}/.github/workflows:${PATH}"
+fi
+
 mkdir -p "$archive_dir"
 package_dir="${RUNNER_TEMP:-/tmp}/${archive_stem}-${target}"
-archive_path="${archive_dir}/${archive_stem}-${target}.tar.gz"
+gzip_archive_path="${archive_dir}/${archive_stem}-${target}.tar.gz"
+zstd_archive_path="${archive_dir}/${archive_stem}-${target}.tar.zst"
 rm -rf "$package_dir"
 
 "$python_bin" "${repo_root}/scripts/build_codex_package.py" \
@@ -108,5 +113,6 @@ rm -rf "$package_dir"
   --entrypoint-bin "${entrypoint_dir%/}/${entrypoint_name}${exe_suffix}" \
   --cargo-profile release \
   --package-dir "$package_dir" \
-  --archive-output "$archive_path" \
+  --archive-output "$gzip_archive_path" \
+  --archive-output "$zstd_archive_path" \
   --force

--- a/.github/workflows/rust-release-windows.yml
+++ b/.github/workflows/rust-release-windows.yml
@@ -220,6 +220,9 @@ jobs:
               "$dest/${binary}-${{ matrix.target }}.exe"
           done
 
+      - name: Install DotSlash
+        uses: facebook/install-dotslash@1e4e7b3e07eaca387acb98f1d4720e0bee8dbb6a # v2
+
       - name: Build Codex package archives
         shell: bash
         run: |
@@ -274,9 +277,6 @@ jobs:
           path: python-runtime-dist/${{ matrix.target }}/*.whl
           if-no-files-found: error
 
-      - name: Install DotSlash
-        uses: facebook/install-dotslash@1e4e7b3e07eaca387acb98f1d4720e0bee8dbb6a # v2
-
       - name: Compress artifacts
         shell: bash
         run: |
@@ -295,7 +295,7 @@ jobs:
             base="$(basename "$f")"
             # Skip files that are already archives (shouldn't happen, but be
             # safe).
-            if [[ "$base" == *.tar.gz || "$base" == *.zip || "$base" == *.dmg ]]; then
+            if [[ "$base" == *.tar.gz || "$base" == *.tar.zst || "$base" == *.zip || "$base" == *.dmg ]]; then
               continue
             fi
 

--- a/scripts/codex_package/cli.py
+++ b/scripts/codex_package/cli.py
@@ -50,9 +50,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--archive-output",
         type=Path,
+        action="append",
+        default=[],
         help=(
-            "Optional archive output path. Supported suffixes: .tar.gz, .tgz, "
-            ".tar.zst, .zip."
+            "Optional archive output path. May be repeated. Supported suffixes: "
+            ".tar.gz, .tgz, .tar.zst, .zip."
         ),
     )
     parser.add_argument(
@@ -130,8 +132,7 @@ def main() -> int:
     build_package_dir(package_dir, version, variant, spec, inputs)
     validate_package_dir(package_dir, variant, spec)
 
-    archive_output = args.archive_output
-    if archive_output is not None:
+    for archive_output in args.archive_output:
         archive_path = archive_output.resolve()
         write_archive(package_dir, archive_path, force=args.force)
         print(f"Built Codex package archive at {archive_path}")


### PR DESCRIPTION

## Summary

DotSlash should resolve the same canonical package archives used by standalone installers and npm platform packages, rather than continuing to point at single-binary zstd artifacts or the older Linux bundle archive.

This updates the Codex CLI and `codex-app-server` DotSlash release config entries to match `codex-package-<target>.tar.gz` and `codex-app-server-package-<target>.tar.gz`, with paths that select `bin/codex` or `bin/codex-app-server` inside the extracted package. The other helper outputs stay on their existing per-binary artifacts for now.

## Test plan

- `python3 -m json.tool .github/dotslash-config.json > /dev/null`
- Ran a Python regex smoke test that checked every updated `codex` and `codex-app-server` platform entry against the archive names emitted by `.github/scripts/build-codex-package-archive.sh`.










