### PR TITLE
ci: run Codex package builder tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Verify Bazel clippy flags match Cargo workspace lints
         run: python3 .github/scripts/verify_bazel_clippy_lints.py
 
+      - name: Test Codex package builder
+        run: python3 -m unittest discover -s scripts/codex_package -p 'test_*.py'
+
       - name: Setup pnpm
         uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
         with:


### PR DESCRIPTION
## Why

#23752 and #23759 add Python unit tests for the Codex package builder, but the root CI workflow did not run tests under `scripts/codex_package`. That left the `zstd` resolution and prebuilt-resource packaging behavior covered locally without a CI check.

## What changed

- Add a root CI step in `.github/workflows/ci.yml` that runs `python3 -m unittest discover -s scripts/codex_package -p "test_*.py"`.
- Keep the step with the existing Python verification checks before Node/pnpm setup.

## Verification

- `python3 -m unittest discover -s scripts/codex_package -p "test_*.py"`
- `python3 -m py_compile scripts/codex_package/*.py`


