### PR TITLE
chore: use Codex Linux runners for Rust releases

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -180,25 +180,25 @@ jobs:
             binaries: "codex-app-server"
             build_dmg: "false"
           # Release artifacts intentionally ship MUSL-linked Linux binaries.
-          - runner: ubuntu-24.04
+          - runner: codex-linux-x64-xl
             target: x86_64-unknown-linux-musl
             bundle: primary
             artifact_name: x86_64-unknown-linux-musl
             binaries: "codex codex-responses-api-proxy bwrap"
             build_dmg: "false"
-          - runner: ubuntu-24.04
+          - runner: codex-linux-x64-xl
             target: x86_64-unknown-linux-musl
             bundle: app-server
             artifact_name: x86_64-unknown-linux-musl-app-server
             binaries: "codex-app-server"
             build_dmg: "false"
-          - runner: ubuntu-24.04-arm
+          - runner: codex-linux-arm64
             target: aarch64-unknown-linux-musl
             bundle: primary
             artifact_name: aarch64-unknown-linux-musl
             binaries: "codex codex-responses-api-proxy bwrap"
             build_dmg: "false"
-          - runner: ubuntu-24.04-arm
+          - runner: codex-linux-arm64
             target: aarch64-unknown-linux-musl
             bundle: app-server
             artifact_name: aarch64-unknown-linux-musl-app-server


### PR DESCRIPTION
## Why

Linux release jobs build the MUSL artifacts that ship in Codex releases, including both the primary CLI bundle and the app-server bundle. Those builds should run on the Codex Linux runner pools instead of generic Ubuntu-hosted runners so release builds use the x64 and arm64 capacity intended for Codex artifacts.

## What Changed

- Moves the `x86_64-unknown-linux-musl` release matrix entries in `.github/workflows/rust-release.yml` from `ubuntu-24.04` to `codex-linux-x64-xl`.
- Moves the `aarch64-unknown-linux-musl` release matrix entries from `ubuntu-24.04-arm` to `codex-linux-arm64`.
- Leaves macOS release jobs, target triples, bundle names, and artifact names unchanged.

## Verification

- Reviewed the workflow matrix diff for `.github/workflows/rust-release.yml`.
- Not run locally; this is a GitHub Actions runner configuration change.