### PR TITLE
Add MITM proxy and Linux sandbox code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,5 +5,10 @@
 # MITM proxy ownership.
 /codex-rs/network-proxy/ @viyatb-oai @winston-openai
 
+# Linux sandbox ownership.
+/codex-rs/linux-sandbox/ @viyatb-oai
+/codex-rs/sandboxing/ @viyatb-oai
+/codex-rs/bwrap/ @viyatb-oai
+
 # Keep ownership changes reviewed by the same team.
 /.github/CODEOWNERS @openai/codex-core-agent-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,8 @@
 /codex-rs/core/ @openai/codex-core-agent-team
 /codex-rs/ext/extension-api/ @openai/codex-core-agent-team
 
+# MITM proxy ownership.
+/codex-rs/network-proxy/ @viyatb-oai @winston-openai
+
 # Keep ownership changes reviewed by the same team.
 /.github/CODEOWNERS @openai/codex-core-agent-team


### PR DESCRIPTION
## Summary
- add @viyatb-oai and @winston-openai as CODEOWNERS for codex-rs/network-proxy/
- add @viyatb-oai as CODEOWNER for codex-rs/linux-sandbox/, codex-rs/sandboxing/, and codex-rs/bwrap/

## Testing
- git diff --check