### PR TITLE
[compaction] normalize legacy context compaction history

### DIFF
--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -359,6 +359,8 @@ impl ContextManager {
     /// 2. every output has a corresponding call entry
     /// 3. when images are unsupported, image content is stripped from messages and tool outputs
     fn normalize_history(&mut self, input_modalities: &[InputModality]) {
+        normalize_legacy_context_compaction_items(&mut self.items);
+
         // all function/tool calls must have a corresponding output
         normalize::ensure_call_outputs_present(&mut self.items);
 
@@ -389,6 +391,11 @@ impl ContextManager {
                 call_id: call_id.clone(),
                 name: name.clone(),
                 output: truncate_function_output_payload(output, policy_with_serialization_budget),
+            },
+            ResponseItem::ContextCompaction {
+                encrypted_content: Some(encrypted_content),
+            } => ResponseItem::Compaction {
+                encrypted_content: encrypted_content.clone(),
             },
             ResponseItem::Message { .. }
             | ResponseItem::Reasoning { .. }
@@ -454,6 +461,21 @@ impl ContextManager {
     }
 }
 
+fn normalize_legacy_context_compaction_items(items: &mut Vec<ResponseItem>) {
+    *items = std::mem::take(items)
+        .into_iter()
+        .filter_map(|item| match item {
+            ResponseItem::ContextCompaction {
+                encrypted_content: Some(encrypted_content),
+            } => Some(ResponseItem::Compaction { encrypted_content }),
+            ResponseItem::ContextCompaction {
+                encrypted_content: None,
+            } => None,
+            item => Some(item),
+        })
+        .collect();
+}
+
 pub(crate) fn truncate_function_output_payload(
     output: &FunctionCallOutputPayload,
     policy: TruncationPolicy,
@@ -490,9 +512,14 @@ fn is_api_message(message: &ResponseItem) -> bool {
         | ResponseItem::WebSearchCall { .. }
         | ResponseItem::ImageGenerationCall { .. }
         | ResponseItem::Compaction { .. }
-        | ResponseItem::ContextCompaction { .. } => true,
-        ResponseItem::CompactionTrigger => false,
-        ResponseItem::Other => false,
+        | ResponseItem::ContextCompaction {
+            encrypted_content: Some(_),
+        } => true,
+        ResponseItem::ContextCompaction {
+            encrypted_content: None,
+        }
+        | ResponseItem::CompactionTrigger
+        | ResponseItem::Other => false,
     }
 }
 

--- a/codex-rs/core/src/context_manager/history_tests.rs
+++ b/codex-rs/core/src/context_manager/history_tests.rs
@@ -307,6 +307,46 @@ fn for_prompt_preserves_inter_agent_assistant_messages() {
 }
 
 #[test]
+fn legacy_context_compaction_items_are_not_sent_to_prompt() {
+    let legacy_compaction = ResponseItem::ContextCompaction {
+        encrypted_content: Some("encrypted-legacy-context".to_string()),
+    };
+    let lifecycle_marker = ResponseItem::ContextCompaction {
+        encrypted_content: None,
+    };
+    let history = create_history_with_items(vec![legacy_compaction, lifecycle_marker]);
+
+    assert_eq!(
+        history.raw_items(),
+        vec![ResponseItem::Compaction {
+            encrypted_content: "encrypted-legacy-context".to_string(),
+        }]
+    );
+
+    let user = user_msg("after compaction");
+    let mut history = ContextManager::new();
+    history.replace(vec![
+        ResponseItem::ContextCompaction {
+            encrypted_content: Some("encrypted-legacy-context".to_string()),
+        },
+        ResponseItem::ContextCompaction {
+            encrypted_content: None,
+        },
+        user.clone(),
+    ]);
+
+    assert_eq!(
+        history.for_prompt(&default_input_modalities()),
+        vec![
+            ResponseItem::Compaction {
+                encrypted_content: "encrypted-legacy-context".to_string(),
+            },
+            user,
+        ]
+    );
+}
+
+#[test]
 fn drop_last_n_user_turns_treats_inter_agent_assistant_messages_as_instruction_turns() {
     let first_turn = user_input_text_msg("first");
     let first_reply = assistant_msg("done");


### PR DESCRIPTION
## Why

This follows up on https://github.com/openai/codex/pull/22809.

Older persisted sessions can still contain `context_compaction` history items from before the remote-compaction wire contract moved to `compaction_trigger` inputs and `compaction` outputs. If those legacy items are sent through the prompt path unchanged, the backend rejects the request with an invalid enum error, which can leave compaction retrying and consuming quota.

Issues resolved:

- https://openai.slack.com/archives/C08MGJXUCUQ/p1779307547227439
- https://openai.sentry.io/issues/7495947083/
- https://github.com/openai/codex/issues/23018

## What changed

- Normalize legacy `ResponseItem::ContextCompaction` entries before prompt history is prepared.
- Convert legacy entries that still have encrypted content into current `ResponseItem::Compaction` entries so compacted history survives.
- Drop payload-less legacy context-compaction entries.
- Treat any remaining `context_compaction` entries as non-API messages alongside `compaction_trigger`.
- Add coverage for the legacy history normalization path.

## Verification

- Added `legacy_context_compaction_items_are_not_sent_to_prompt` in `codex-rs/core/src/context_manager/history_tests.rs`.
