### PR TITLE
Add onboarding interactive tools feature flag

### DIFF
--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -500,6 +500,9 @@
             "network_proxy": {
               "$ref": "#/definitions/FeatureToml_for_NetworkProxyConfigToml"
             },
+            "onboarding_interactive_tools": {
+              "type": "boolean"
+            },
             "personality": {
               "type": "boolean"
             },
@@ -4430,6 +4433,9 @@
         },
         "network_proxy": {
           "$ref": "#/definitions/FeatureToml_for_NetworkProxyConfigToml"
+        },
+        "onboarding_interactive_tools": {
+          "type": "boolean"
         },
         "personality": {
           "type": "boolean"

--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -174,6 +174,8 @@ pub enum Feature {
     MentionsV2,
     /// Allow request_user_input in Default collaboration mode.
     DefaultModeRequestUserInput,
+    /// Allow onboarding-only interactive tools.
+    OnboardingInteractiveTools,
     /// Enable automatic review for approval prompts.
     GuardianApproval,
     /// Enable persisted thread goals and automatic goal continuation.
@@ -1065,6 +1067,12 @@ pub const FEATURES: &[FeatureSpec] = &[
     FeatureSpec {
         id: Feature::DefaultModeRequestUserInput,
         key: "default_mode_request_user_input",
+        stage: Stage::UnderDevelopment,
+        default_enabled: false,
+    },
+    FeatureSpec {
+        id: Feature::OnboardingInteractiveTools,
+        key: "onboarding_interactive_tools",
         stage: Stage::UnderDevelopment,
         default_enabled: false,
     },

--- a/codex-rs/tools/src/tool_config.rs
+++ b/codex-rs/tools/src/tool_config.rs
@@ -27,8 +27,9 @@ pub fn request_user_input_available_modes(features: &Features) -> Vec<ModeKind> 
         .into_iter()
         .filter(|mode| {
             mode.allows_request_user_input()
-                || (features.enabled(Feature::DefaultModeRequestUserInput)
-                    && *mode == ModeKind::Default)
+                || (*mode == ModeKind::Default
+                    && (features.enabled(Feature::DefaultModeRequestUserInput)
+                        || features.enabled(Feature::OnboardingInteractiveTools)))
         })
         .collect()
 }


### PR DESCRIPTION
## Summary

We are adding a new onboarding thread experience. In order to do that, we need to add some new tools (context and options picker)  and we want to gate these to the onboarding experience only. That's why we add the `onboarding_interactive_tools` param to the thread, so we can enable these new tools

In addition, the `request_user_input` tool is currently gated for plan mode only (or for folks in a ff). We also want that to be enabled for onboarding mode, that's why we have our check in `codex-rs/tools/src/tool_config.rs`

https://github.com/user-attachments/assets/4afb9b3e-46c2-48f7-8d9b-bba639b0cc85

