### PR TITLE
docs: add description to codex-cli/package.json

### DIFF
--- a/codex-cli/package.json
+++ b/codex-cli/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@openai/codex",
   "version": "0.0.0-dev",
+  "description": "Codex CLI is a coding agent from OpenAI that runs locally on your computer.",
   "license": "Apache-2.0",
   "bin": {
     "codex": "bin/codex.js"


### PR DESCRIPTION
Fix this eyesore where our lack of a `"description"` was causing our `README.md` to be used for previews on npm.

<img width="1291" height="178" alt="image" src="https://github.com/user-attachments/assets/a9bc08c5-0def-4755-8bcc-0c90e096b9c2" />
