### PR TITLE
Add Bedrock Mantle GovCloud region

### DIFF
--- a/codex-rs/model-provider/src/amazon_bedrock/mantle.rs
+++ b/codex-rs/model-provider/src/amazon_bedrock/mantle.rs
@@ -7,10 +7,11 @@ use super::auth::BedrockAuthMethod;
 use super::auth::resolve_auth_method;
 
 const BEDROCK_MANTLE_SERVICE_NAME: &str = "bedrock-mantle";
-const BEDROCK_MANTLE_SUPPORTED_REGIONS: [&str; 12] = [
+const BEDROCK_MANTLE_SUPPORTED_REGIONS: [&str; 13] = [
     "us-east-2",
     "us-east-1",
     "us-west-2",
+    "us-gov-west-1",
     "ap-southeast-3",
     "ap-south-1",
     "ap-northeast-1",
@@ -71,6 +72,10 @@ mod tests {
         assert_eq!(
             base_url("ap-northeast-1").expect("supported region"),
             "https://bedrock-mantle.ap-northeast-1.api.aws/openai/v1"
+        );
+        assert_eq!(
+            base_url("us-gov-west-1").expect("supported region"),
+            "https://bedrock-mantle.us-gov-west-1.api.aws/openai/v1"
         );
     }
 


### PR DESCRIPTION
## Summary
- Add us-gov-west-1 to the Bedrock Mantle supported region list
- Cover the GovCloud endpoint URL in the existing base_url unit test

## Test
- cargo test -p codex-model-provider