### PR TITLE
[codex] Stabilize subagent start hook test

### DIFF
--- a/codex-rs/core/tests/suite/subagent_notifications.rs
+++ b/codex-rs/core/tests/suite/subagent_notifications.rs
@@ -519,8 +519,7 @@ async fn subagent_start_replaces_session_start_and_injects_context() -> Result<(
         .await?;
 
     test.submit_turn(TURN_1_PROMPT).await?;
-    let child_requests = wait_for_requests(&child_request_log).await?;
-    assert_eq!(child_requests.len(), 1);
+    let _ = wait_for_requests(&child_request_log).await?;
 
     let start_inputs = wait_for_hook_log(
         test.codex_home_path(),


### PR DESCRIPTION
## What

Remove the exact captured request-count assertion from the `SubagentStart` hook integration test while still waiting for the child request that matches the injected hook context.

## Why

The test owns the start-hook behavior and already verifies that the child request reaches the context matcher plus that the start/session hook logs have the expected invocations. Counting every request captured by the response mock makes the test sensitive to lifecycle timing outside that contract and has been flaky in CI.

## Testing

- `cargo test -p codex-core --test all suite::subagent_notifications::subagent_start_replaces_session_start_and_injects_context -- --exact`
