### PR TITLE
Add sync-only Codex Apps connector scope

### DIFF
--- a/codex-rs/codex-mcp/src/codex_apps.rs
+++ b/codex-rs/codex-mcp/src/codex_apps.rs
@@ -12,6 +12,7 @@ use crate::mcp::CODEX_APPS_MCP_SERVER_NAME;
 use crate::runtime::emit_duration;
 use crate::tools::MCP_TOOLS_CACHE_WRITE_DURATION_METRIC;
 use crate::tools::ToolInfo;
+use codex_config::types::AppsMcpConnectorAccess;
 use codex_login::CodexAuth;
 use codex_utils_plugins::mcp_connector::is_connector_id_allowed;
 use codex_utils_plugins::mcp_connector::sanitize_name;
@@ -27,13 +28,19 @@ pub struct CodexAppsToolsCacheKey {
     pub(crate) account_id: Option<String>,
     pub(crate) chatgpt_user_id: Option<String>,
     pub(crate) is_workspace_account: bool,
+    #[serde(default)]
+    pub(crate) apps_mcp_connector_access: Option<AppsMcpConnectorAccess>,
 }
 
-pub fn codex_apps_tools_cache_key(auth: Option<&CodexAuth>) -> CodexAppsToolsCacheKey {
+pub fn codex_apps_tools_cache_key(
+    auth: Option<&CodexAuth>,
+    apps_mcp_connector_access: Option<AppsMcpConnectorAccess>,
+) -> CodexAppsToolsCacheKey {
     CodexAppsToolsCacheKey {
         account_id: auth.and_then(CodexAuth::get_account_id),
         chatgpt_user_id: auth.and_then(CodexAuth::get_chatgpt_user_id),
         is_workspace_account: auth.is_some_and(CodexAuth::is_workspace_account),
+        apps_mcp_connector_access,
     }
 }
 

--- a/codex-rs/codex-mcp/src/connection_manager_tests.rs
+++ b/codex-rs/codex-mcp/src/connection_manager_tests.rs
@@ -18,6 +18,7 @@ use crate::tools::normalize_tools_for_model;
 use crate::tools::tool_with_model_visible_input_schema;
 use codex_config::Constrained;
 use codex_config::McpServerConfig;
+use codex_config::types::AppsMcpConnectorAccess;
 use codex_protocol::ToolName;
 use codex_protocol::models::PermissionProfile;
 use codex_protocol::protocol::GranularApprovalConfig;
@@ -84,6 +85,7 @@ fn create_codex_apps_tools_cache_context(
             account_id: account_id.map(ToOwned::to_owned),
             chatgpt_user_id: chatgpt_user_id.map(ToOwned::to_owned),
             is_workspace_account: false,
+            apps_mcp_connector_access: None,
         },
     }
 }
@@ -585,6 +587,31 @@ fn codex_apps_tools_cache_is_scoped_per_user() {
 }
 
 #[test]
+fn codex_apps_tools_cache_is_scoped_per_connector_access() {
+    let codex_home = tempdir().expect("tempdir");
+    let full_access_context = create_codex_apps_tools_cache_context(
+        codex_home.path().to_path_buf(),
+        Some("account-one"),
+        Some("user-one"),
+    );
+    let sync_only_context = CodexAppsToolsCacheContext {
+        codex_home: codex_home.path().to_path_buf(),
+        user_key: CodexAppsToolsCacheKey {
+            account_id: Some("account-one".to_string()),
+            chatgpt_user_id: Some("user-one".to_string()),
+            is_workspace_account: false,
+            apps_mcp_connector_access: Some(AppsMcpConnectorAccess::SyncOnly),
+        },
+    };
+
+    assert_ne!(
+        full_access_context.cache_path(),
+        sync_only_context.cache_path(),
+        "connector access scope should isolate Codex Apps cache files"
+    );
+}
+
+#[test]
 fn codex_apps_tools_cache_filters_disallowed_connectors() {
     let codex_home = tempdir().expect("tempdir");
     let cache_context = create_codex_apps_tools_cache_context(
@@ -925,6 +952,7 @@ async fn no_local_runtime_fails_local_stdio_but_keeps_local_http_server() {
             account_id: None,
             chatgpt_user_id: None,
             is_workspace_account: false,
+            apps_mcp_connector_access: None,
         },
         /*host_owned_codex_apps_enabled*/ false,
         ElicitationCapability::default(),

--- a/codex-rs/codex-mcp/src/mcp/mod.rs
+++ b/codex-rs/codex-mcp/src/mcp/mod.rs
@@ -22,6 +22,7 @@ use codex_config::McpServerConfig;
 use codex_config::McpServerTransportConfig;
 use codex_config::types::AppToolApproval;
 use codex_config::types::ApprovalsReviewer;
+use codex_config::types::AppsMcpConnectorAccess;
 use codex_config::types::OAuthCredentialsStoreMode;
 use codex_login::CodexAuth;
 use codex_plugin::PluginCapabilitySummary;
@@ -45,6 +46,9 @@ pub const CODEX_APPS_MCP_SERVER_NAME: &str = "codex_apps";
 const MCP_TOOL_NAME_PREFIX: &str = "mcp";
 const MCP_TOOL_NAME_DELIMITER: &str = "__";
 const CODEX_CONNECTORS_TOKEN_ENV_VAR: &str = "CODEX_CONNECTORS_TOKEN";
+const CONSUMER_LOCKDOWN_CONNECTOR_ACCESS_HEADER: &str =
+    "X-OpenAI-Consumer-Lockdown-Connector-Access";
+const CONSUMER_LOCKDOWN_CONNECTOR_ACCESS_SYNC_ONLY: &str = "sync_only";
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum McpSnapshotDetail {
@@ -111,6 +115,8 @@ pub struct McpConfig {
     pub apps_mcp_path_override: Option<String>,
     /// Optional product SKU forwarded to the host-owned apps MCP server.
     pub apps_mcp_product_sku: Option<String>,
+    /// Optional connector access scope for the host-owned apps MCP server.
+    pub apps_mcp_connector_access: Option<AppsMcpConnectorAccess>,
     /// Codex home directory used for MCP OAuth state and app-tool cache files.
     pub codex_home: PathBuf,
     /// Preferred credential store for MCP OAuth tokens.
@@ -286,7 +292,7 @@ pub async fn read_mcp_resource(
         PermissionProfile::default(),
         runtime_environment,
         config.codex_home.clone(),
-        codex_apps_tools_cache_key(auth),
+        codex_apps_tools_cache_key(auth, config.apps_mcp_connector_access),
         host_owned_codex_apps_enabled,
         config.client_elicitation_capability.clone(),
         tool_plugin_provenance(config),
@@ -355,7 +361,7 @@ pub async fn collect_mcp_server_status_snapshot_with_detail(
         PermissionProfile::default(),
         runtime_environment,
         config.codex_home.clone(),
-        codex_apps_tools_cache_key(auth),
+        codex_apps_tools_cache_key(auth, config.apps_mcp_connector_access),
         host_owned_codex_apps_enabled,
         config.client_elicitation_capability.clone(),
         tool_plugin_provenance,
@@ -440,9 +446,20 @@ fn codex_apps_mcp_url_for_base_url(base_url: &str, apps_mcp_path_override: Optio
 
 fn codex_apps_mcp_server_config(config: &McpConfig) -> McpServerConfig {
     let url = codex_apps_mcp_url(config);
-    let http_headers = config.apps_mcp_product_sku.as_ref().map(|product_sku| {
-        HashMap::from([("X-OpenAI-Product-Sku".to_string(), product_sku.clone())])
-    });
+    let mut http_headers = HashMap::new();
+    if matches!(
+        config.apps_mcp_connector_access,
+        Some(AppsMcpConnectorAccess::SyncOnly)
+    ) {
+        http_headers.insert(
+            CONSUMER_LOCKDOWN_CONNECTOR_ACCESS_HEADER.to_string(),
+            CONSUMER_LOCKDOWN_CONNECTOR_ACCESS_SYNC_ONLY.to_string(),
+        );
+    }
+    if let Some(product_sku) = config.apps_mcp_product_sku.as_ref() {
+        http_headers.insert("X-OpenAI-Product-Sku".to_string(), product_sku.clone());
+    }
+    let http_headers = (!http_headers.is_empty()).then_some(http_headers);
 
     McpServerConfig {
         transport: McpServerTransportConfig::StreamableHttp {

--- a/codex-rs/codex-mcp/src/mcp/mod_tests.rs
+++ b/codex-rs/codex-mcp/src/mcp/mod_tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use codex_config::Constrained;
 use codex_config::types::AppToolApproval;
 use codex_config::types::ApprovalsReviewer;
+use codex_config::types::AppsMcpConnectorAccess;
 use codex_login::CodexAuth;
 use codex_plugin::AppConnectorId;
 use codex_plugin::PluginCapabilitySummary;
@@ -19,6 +20,7 @@ fn test_mcp_config(codex_home: PathBuf) -> McpConfig {
         chatgpt_base_url: "https://chatgpt.com".to_string(),
         apps_mcp_path_override: None,
         apps_mcp_product_sku: None,
+        apps_mcp_connector_access: None,
         codex_home,
         mcp_oauth_credentials_store_mode: OAuthCredentialsStoreMode::default(),
         mcp_oauth_callback_port: None,
@@ -297,6 +299,40 @@ fn codex_apps_server_config_forwards_configured_product_sku_header() {
             assert!(env_http_headers.is_none());
         }
         other => panic!("expected streamable http transport, got {other:?}"),
+    }
+}
+
+#[test]
+fn codex_apps_server_config_forwards_sync_only_connector_access() {
+    let mut config = test_mcp_config(PathBuf::from("/tmp"));
+    config.apps_mcp_connector_access = Some(AppsMcpConnectorAccess::SyncOnly);
+    config.apps_enabled = true;
+    let auth = CodexAuth::create_dummy_chatgpt_auth_for_testing();
+
+    let servers = with_codex_apps_mcp(HashMap::new(), Some(&auth), &config);
+    let server = servers
+        .get(CODEX_APPS_MCP_SERVER_NAME)
+        .expect("codex apps should be present when apps is enabled");
+    let config = server
+        .configured_config()
+        .expect("codex apps should use configured transport");
+
+    match &config.transport {
+        McpServerTransportConfig::StreamableHttp {
+            http_headers,
+            env_http_headers,
+            ..
+        } => {
+            assert_eq!(
+                http_headers,
+                &Some(HashMap::from([(
+                    "X-OpenAI-Consumer-Lockdown-Connector-Access".to_string(),
+                    "sync_only".to_string(),
+                )]))
+            );
+            assert!(env_http_headers.is_none());
+        }
+        _ => panic!("expected streamable http transport for codex apps"),
     }
 }
 

--- a/codex-rs/config/src/config_toml.rs
+++ b/codex-rs/config/src/config_toml.rs
@@ -10,6 +10,7 @@ use crate::profile_toml::ConfigProfile;
 use crate::types::AnalyticsConfigToml;
 use crate::types::ApprovalsReviewer;
 use crate::types::AppsConfigToml;
+use crate::types::AppsMcpConnectorAccess;
 use crate::types::AuthCredentialsStoreMode;
 use crate::types::FeedbackConfigToml;
 use crate::types::History;
@@ -367,6 +368,9 @@ pub struct ConfigToml {
 
     /// Optional product SKU forwarded on host-owned Codex Apps MCP requests.
     pub apps_mcp_product_sku: Option<String>,
+
+    /// Optional connector access scope for host-owned Codex Apps MCP requests.
+    pub apps_mcp_connector_access: Option<AppsMcpConnectorAccess>,
 
     /// Base URL override for the built-in `openai` model provider.
     pub openai_base_url: Option<String>,

--- a/codex-rs/config/src/loader/mod.rs
+++ b/codex-rs/config/src/loader/mod.rs
@@ -61,6 +61,7 @@ const DEFAULT_PROGRAM_DATA_DIR_WINDOWS: &str = r"C:\ProgramData";
 const PROJECT_LOCAL_CONFIG_DENYLIST: &[&str] = &[
     "openai_base_url",
     "chatgpt_base_url",
+    "apps_mcp_connector_access",
     "apps_mcp_product_sku",
     "model_provider",
     "model_providers",

--- a/codex-rs/config/src/types.rs
+++ b/codex-rs/config/src/types.rs
@@ -112,6 +112,12 @@ pub enum OAuthCredentialsStoreMode {
     Keyring,
 }
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AppsMcpConnectorAccess {
+    SyncOnly,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum WindowsSandboxModeToml {

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -218,6 +218,12 @@
       },
       "type": "object"
     },
+    "AppsMcpConnectorAccess": {
+      "enum": [
+        "sync_only"
+      ],
+      "type": "string"
+    },
     "AppsMcpPathOverrideConfigToml": {
       "additionalProperties": false,
       "properties": {
@@ -4070,6 +4076,14 @@
       ],
       "default": null,
       "description": "Settings for app-specific controls."
+    },
+    "apps_mcp_connector_access": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/AppsMcpConnectorAccess"
+        }
+      ],
+      "description": "Optional connector access scope for host-owned Codex Apps MCP requests."
     },
     "apps_mcp_product_sku": {
       "description": "Optional product SKU forwarded on host-owned Codex Apps MCP requests.",

--- a/codex-rs/core/src/config/config_loader_tests.rs
+++ b/codex-rs/core/src/config/config_loader_tests.rs
@@ -2345,6 +2345,7 @@ model = "project-model"
 model_instructions_file = "instructions.md"
 openai_base_url = "https://attacker.example/v1"
 chatgpt_base_url = "https://attacker.example/backend-api"
+apps_mcp_connector_access = "sync_only"
 apps_mcp_product_sku = "attacker"
 model_provider = "attacker"
 notify = ["sh", "-c", "echo attacker"]
@@ -2397,6 +2398,7 @@ wire_api = "responses"
     let ignored_project_config_keys = vec![
         "openai_base_url",
         "chatgpt_base_url",
+        "apps_mcp_connector_access",
         "apps_mcp_product_sku",
         "model_provider",
         "model_providers",

--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -33,6 +33,7 @@ use codex_config::permissions_toml::WorkspaceRootsToml;
 use codex_config::profile_toml::ConfigProfile;
 use codex_config::types::AppToolApproval;
 use codex_config::types::ApprovalsReviewer;
+use codex_config::types::AppsMcpConnectorAccess;
 use codex_config::types::BundledSkillsConfig;
 use codex_config::types::FeedbackConfigToml;
 use codex_config::types::HistoryPersistence;
@@ -5234,6 +5235,7 @@ async fn to_mcp_config_preserves_apps_feature_from_config() -> std::io::Result<(
 
     config.apps_mcp_path_override = Some("/custom/mcp".to_string());
     config.apps_mcp_product_sku = Some("tpp".to_string());
+    config.apps_mcp_connector_access = Some(AppsMcpConnectorAccess::SyncOnly);
     let mcp_config = config.to_mcp_config(&plugins_manager).await;
     assert!(mcp_config.apps_enabled);
     assert_eq!(
@@ -5241,6 +5243,10 @@ async fn to_mcp_config_preserves_apps_feature_from_config() -> std::io::Result<(
         Some("/custom/mcp")
     );
     assert_eq!(mcp_config.apps_mcp_product_sku.as_deref(), Some("tpp"));
+    assert_eq!(
+        mcp_config.apps_mcp_connector_access,
+        Some(AppsMcpConnectorAccess::SyncOnly)
+    );
 
     let _ = config.features.disable(Feature::Apps);
     let mcp_config = config.to_mcp_config(&plugins_manager).await;
@@ -8054,6 +8060,7 @@ async fn test_precedence_fixture_with_o3_profile() -> std::io::Result<()> {
             chatgpt_base_url: "https://chatgpt.com/backend-api/".to_string(),
             apps_mcp_path_override: None,
             apps_mcp_product_sku: None,
+            apps_mcp_connector_access: None,
             realtime_audio: RealtimeAudioConfig::default(),
             experimental_realtime_start_instructions: None,
             experimental_realtime_ws_base_url: None,
@@ -8533,6 +8540,7 @@ async fn test_precedence_fixture_with_gpt3_profile() -> std::io::Result<()> {
         chatgpt_base_url: "https://chatgpt.com/backend-api/".to_string(),
         apps_mcp_path_override: None,
         apps_mcp_product_sku: None,
+        apps_mcp_connector_access: None,
         realtime_audio: RealtimeAudioConfig::default(),
         experimental_realtime_start_instructions: None,
         experimental_realtime_ws_base_url: None,
@@ -8701,6 +8709,7 @@ async fn test_precedence_fixture_with_zdr_profile() -> std::io::Result<()> {
         chatgpt_base_url: "https://chatgpt.com/backend-api/".to_string(),
         apps_mcp_path_override: None,
         apps_mcp_product_sku: None,
+        apps_mcp_connector_access: None,
         realtime_audio: RealtimeAudioConfig::default(),
         experimental_realtime_start_instructions: None,
         experimental_realtime_ws_base_url: None,
@@ -8854,6 +8863,7 @@ async fn test_precedence_fixture_with_gpt5_profile() -> std::io::Result<()> {
         chatgpt_base_url: "https://chatgpt.com/backend-api/".to_string(),
         apps_mcp_path_override: None,
         apps_mcp_product_sku: None,
+        apps_mcp_connector_access: None,
         realtime_audio: RealtimeAudioConfig::default(),
         experimental_realtime_start_instructions: None,
         experimental_realtime_ws_base_url: None,
@@ -9592,6 +9602,30 @@ apps_mcp_product_sku = "tpp"
     .await?;
 
     assert_eq!(config.apps_mcp_product_sku.as_deref(), Some("tpp"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn config_loads_apps_mcp_connector_access_from_toml() -> std::io::Result<()> {
+    let codex_home = TempDir::new()?;
+    let toml = r#"
+model = "gpt-5.4"
+apps_mcp_connector_access = "sync_only"
+"#;
+    let cfg: ConfigToml =
+        toml::from_str(toml).expect("TOML deserialization should succeed for apps MCP access");
+
+    let config = Config::load_from_base_config_with_overrides(
+        cfg,
+        ConfigOverrides::default(),
+        codex_home.abs(),
+    )
+    .await?;
+
+    assert_eq!(
+        config.apps_mcp_connector_access,
+        Some(AppsMcpConnectorAccess::SyncOnly)
+    );
     Ok(())
 }
 

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -36,6 +36,7 @@ use codex_config::loader::project_trust_key;
 use codex_config::profile_toml::ConfigProfile;
 use codex_config::sandbox_mode_requirement_for_permission_profile;
 use codex_config::types::ApprovalsReviewer;
+use codex_config::types::AppsMcpConnectorAccess;
 use codex_config::types::AuthCredentialsStoreMode;
 use codex_config::types::History;
 use codex_config::types::McpServerConfig;
@@ -894,6 +895,9 @@ pub struct Config {
     /// Optional product SKU forwarded to the host-owned apps MCP server.
     pub apps_mcp_product_sku: Option<String>,
 
+    /// Optional connector access scope for the host-owned apps MCP server.
+    pub apps_mcp_connector_access: Option<AppsMcpConnectorAccess>,
+
     /// Machine-local realtime audio device preferences used by realtime voice.
     pub realtime_audio: RealtimeAudioConfig,
 
@@ -1326,6 +1330,7 @@ impl Config {
             chatgpt_base_url: self.chatgpt_base_url.clone(),
             apps_mcp_path_override: self.apps_mcp_path_override.clone(),
             apps_mcp_product_sku: self.apps_mcp_product_sku.clone(),
+            apps_mcp_connector_access: self.apps_mcp_connector_access,
             codex_home: self.codex_home.to_path_buf(),
             mcp_oauth_credentials_store_mode: self.mcp_oauth_credentials_store_mode,
             mcp_oauth_callback_port: self.mcp_oauth_callback_port,
@@ -3528,6 +3533,7 @@ impl Config {
                 .unwrap_or("https://chatgpt.com/backend-api/".to_string()),
             apps_mcp_path_override,
             apps_mcp_product_sku: cfg.apps_mcp_product_sku.clone(),
+            apps_mcp_connector_access: cfg.apps_mcp_connector_access,
             realtime_audio: cfg
                 .audio
                 .map_or_else(RealtimeAudioConfig::default, |audio| RealtimeAudioConfig {

--- a/codex-rs/core/src/connectors.rs
+++ b/codex-rs/core/src/connectors.rs
@@ -278,7 +278,7 @@ pub async fn list_accessible_connectors_from_mcp_tools_with_environment_manager(
             config.cwd.to_path_buf(),
         ),
         config.codex_home.to_path_buf(),
-        codex_apps_tools_cache_key(auth.as_ref()),
+        codex_apps_tools_cache_key(auth.as_ref(), mcp_config.apps_mcp_connector_access),
         host_owned_codex_apps_enabled,
         mcp_config.client_elicitation_capability,
         ToolPluginProvenance::default(),

--- a/codex-rs/core/src/mcp_tool_call_tests.rs
+++ b/codex-rs/core/src/mcp_tool_call_tests.rs
@@ -1243,7 +1243,10 @@ async fn install_host_owned_codex_apps_manager(session: &Session, turn_context: 
             },
         ),
         turn_context.config.codex_home.to_path_buf(),
-        codex_mcp::codex_apps_tools_cache_key(auth.as_ref()),
+        codex_mcp::codex_apps_tools_cache_key(
+            auth.as_ref(),
+            turn_context.config.apps_mcp_connector_access,
+        ),
         /*host_owned_codex_apps_enabled*/ true,
         rmcp::model::ElicitationCapability::default(),
         codex_mcp::ToolPluginProvenance::default(),

--- a/codex-rs/core/src/session/mcp.rs
+++ b/codex-rs/core/src/session/mcp.rs
@@ -355,7 +355,7 @@ impl Session {
             turn_context.permission_profile(),
             mcp_runtime_environment,
             config.codex_home.to_path_buf(),
-            codex_apps_tools_cache_key(auth.as_ref()),
+            codex_apps_tools_cache_key(auth.as_ref(), mcp_config.apps_mcp_connector_access),
             host_owned_codex_apps_enabled,
             mcp_config.client_elicitation_capability,
             tool_plugin_provenance,

--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -1157,7 +1157,7 @@ impl Session {
                 session_configuration.permission_profile(),
                 mcp_runtime_environment,
                 config.codex_home.to_path_buf(),
-                codex_apps_tools_cache_key(auth),
+                codex_apps_tools_cache_key(auth, config.apps_mcp_connector_access),
                 host_owned_codex_apps_enabled,
                 client_elicitation_capability,
                 tool_plugin_provenance,

--- a/codex-rs/thread-manager-sample/src/main.rs
+++ b/codex-rs/thread-manager-sample/src/main.rs
@@ -252,6 +252,7 @@ fn new_config(model: Option<String>, arg0_paths: Arg0DispatchPaths) -> anyhow::R
         chatgpt_base_url: "https://chatgpt.com/backend-api/".to_string(),
         apps_mcp_path_override: None,
         apps_mcp_product_sku: None,
+        apps_mcp_connector_access: None,
         realtime_audio: RealtimeAudioConfig::default(),
         experimental_realtime_ws_base_url: None,
         experimental_realtime_ws_model: None,


### PR DESCRIPTION
## Summary
- add a narrow `apps_mcp_connector_access = "sync_only"` config for host-owned Codex Apps MCP requests
- forward the internal consumer-lockdown sync-only header only when that thread config is set, and scope the Codex Apps disk cache by connector access so locked-down sessions cannot reuse full-access tool snapshots
- deny project-local config from setting this host-owned connector access knob, keeping Codex product defaults unchanged unless a caller explicitly supplies the thread config

## Validation
- Ran `cargo run -p codex-core --bin codex-write-config-schema`
- Ran `cargo test -p codex-mcp codex_apps_`
- Ran `cargo test -p codex-core config_loads_apps_mcp_connector_access_from_toml`
- Ran `cargo test -p codex-core project_layer_ignores_unsupported_config_keys`
- Ran `cargo fmt --check`
- Ran `git diff --check`