### PR TITLE
otel: drop legacy profile usage telemetry

### DIFF
--- a/codex-rs/core/src/agent/role.rs
+++ b/codex-rs/core/src/agent/role.rs
@@ -2,9 +2,9 @@
 //!
 //! Roles are selected at spawn time and are loaded with the same config machinery as
 //! `config.toml`. This module resolves built-in and user-defined role files, inserts the role as a
-//! high-precedence layer, and preserves the caller's current profile/provider unless the role
-//! explicitly takes ownership of model selection. It does not decide when to spawn a sub-agent or
-//! which role to use; the multi-agent tool handler owns that orchestration.
+//! high-precedence layer, and preserves the caller's current provider and service tier unless the
+//! role layer sets them. It does not decide when to spawn a sub-agent or which role to use; the
+//! multi-agent tool handler owns that orchestration.
 
 use crate::config::AgentRoleConfig;
 use crate::config::Config;
@@ -29,14 +29,12 @@ use toml::Value as TomlValue;
 pub const DEFAULT_ROLE_NAME: &str = "default";
 const AGENT_TYPE_UNAVAILABLE_ERROR: &str = "agent type is currently not available";
 
-/// Applies a named role layer to `config` while preserving caller-owned model selection.
+/// Applies a named role layer to `config` while preserving caller-owned provider settings.
 ///
 /// The role layer is inserted at session-flag precedence so it can override persisted config, but
-/// the caller's current `profile` and `model_provider` remain sticky runtime choices unless the
-/// role explicitly sets `profile`, explicitly sets `model_provider`, or rewrites the active
-/// profile's `model_provider` in place. Rebuilding the config without those overrides would make a
-/// spawned agent silently fall back to the default provider, which is the bug this preservation
-/// logic avoids.
+/// the caller's current `model_provider` and `service_tier` remain sticky runtime choices unless
+/// the role explicitly sets the corresponding top-level config key. Rebuilding the config without
+/// those overrides would make a spawned agent silently fall back to default settings.
 pub(crate) async fn apply_role_to_config(
     config: &mut Config,
     role_name: Option<&str>,

--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -816,7 +816,6 @@ impl Session {
                     .permissions
                     .legacy_sandbox_policy(session_configuration.cwd.as_path()),
                 mcp_servers.keys().map(String::as_str).collect(),
-                /*active_profile*/ None,
             );
 
             let use_zsh_fork_shell = config.features.enabled(Feature::ShellZshFork);

--- a/codex-rs/otel/src/events/session_telemetry.rs
+++ b/codex-rs/otel/src/events/session_telemetry.rs
@@ -10,7 +10,6 @@ use crate::metrics::MetricsConfig;
 use crate::metrics::MetricsError;
 use crate::metrics::PLUGIN_INSTALL_ELICITATION_SENT_METRIC;
 use crate::metrics::PLUGIN_INSTALL_SUGGESTION_METRIC;
-use crate::metrics::PROFILE_USAGE_METRIC;
 use crate::metrics::RESPONSES_API_ENGINE_IAPI_TBT_DURATION_METRIC;
 use crate::metrics::RESPONSES_API_ENGINE_IAPI_TTFT_DURATION_METRIC;
 use crate::metrics::RESPONSES_API_ENGINE_SERVICE_TBT_DURATION_METRIC;
@@ -447,11 +446,7 @@ impl SessionTelemetry {
         approval_policy: AskForApproval,
         sandbox_policy: SandboxPolicy,
         mcp_servers: Vec<&str>,
-        active_profile: Option<String>,
     ) {
-        if active_profile.is_some() {
-            self.counter(PROFILE_USAGE_METRIC, /*inc*/ 1, &[]);
-        }
         log_and_trace_event!(
             self,
             common: {
@@ -472,11 +467,9 @@ impl SessionTelemetry {
             },
             log: {
                 mcp_servers = mcp_servers.join(", "),
-                active_profile = active_profile,
             },
             trace: {
                 mcp_server_count = mcp_servers.len() as i64,
-                active_profile_present = active_profile.is_some(),
             },
         );
     }

--- a/codex-rs/otel/src/metrics/names.rs
+++ b/codex-rs/otel/src/metrics/names.rs
@@ -36,7 +36,6 @@ pub const GOAL_USAGE_LIMITED_METRIC: &str = "codex.goal.usage_limited";
 pub const GOAL_BLOCKED_METRIC: &str = "codex.goal.blocked";
 pub const GOAL_TOKEN_COUNT_METRIC: &str = "codex.goal.token_count";
 pub const GOAL_DURATION_SECONDS_METRIC: &str = "codex.goal.duration_s";
-pub const PROFILE_USAGE_METRIC: &str = "codex.profile.usage";
 pub const PLUGIN_INSTALL_ELICITATION_SENT_METRIC: &str = "codex.plugins.install_elicitation.sent";
 pub const PLUGIN_INSTALL_SUGGESTION_METRIC: &str = "codex.plugins.install_suggestion";
 pub const CURATED_PLUGINS_STARTUP_SYNC_METRIC: &str = "codex.plugins.startup_sync";

--- a/codex-rs/otel/tests/suite/otel_export_routing_policy.rs
+++ b/codex-rs/otel/tests/suite/otel_export_routing_policy.rs
@@ -510,7 +510,6 @@ fn otel_export_routing_policy_routes_api_request_auth_observability() {
             AskForApproval::Never,
             SandboxPolicy::DangerFullAccess,
             Vec::new(),
-            /*active_profile*/ None,
         );
         manager.record_api_request(
             /*attempt*/ 1,


### PR DESCRIPTION
## Summary
- drop the dead legacy profile usage metric and active-profile conversation-start fields
- update role comments so they describe provider and service-tier preservation without legacy config-profile wording
- pair the code cleanup with the file-backed profile docs update in openai/developers-website#1476

## Testing
- `just fmt`
- `cargo test -p codex-otel`
- `cargo test -p codex-core` *(fails: existing stack overflow in `mcp_tool_call::tests::guardian_mode_mcp_denial_returns_rationale_message`)*
- `cargo test -p codex-core --lib mcp_tool_call::tests::guardian_mode_mcp_denial_returns_rationale_message` *(fails with the same stack overflow)*