### PR TITLE
docs: update README.md to mention curl-based installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-<p align="center"><code>npm i -g @openai/codex</code><br />or <code>brew install --cask codex</code></p>
 <p align="center"><strong>Codex CLI</strong> is a coding agent from OpenAI that runs locally on your computer.
 <p align="center">
   <img src="https://github.com/openai/codex/blob/main/.github/codex-cli-splash.png" alt="Codex CLI splash" width="80%" />
@@ -14,7 +13,19 @@ If you want Codex in your code editor (VS Code, Cursor, Windsurf), <a href="http
 
 ### Installing and running Codex CLI
 
-Install globally with your preferred package manager:
+Run the following on Mac or Linux to install Codex CLI:
+
+```shell
+curl -fsSL https://chatgpt.com/codex/install.sh | sh
+```
+
+Run the following on Windows to install Codex CLI:
+
+```
+powershell -ExecutionPolicy ByPass -c "irm https://chatgpt.com/codex/install.ps1 | iex"
+```
+
+Codex CLI can also be installed via the following package managers:
 
 ```shell
 # Install using npm

--- a/codex-rs/tui/src/update_action.rs
+++ b/codex-rs/tui/src/update_action.rs
@@ -47,7 +47,12 @@ impl UpdateAction {
             ),
             UpdateAction::StandaloneWindows => (
                 "powershell",
-                &["-c", "irm https://chatgpt.com/codex/install.ps1|iex"],
+                &[
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-c",
+                    "irm https://chatgpt.com/codex/install.ps1 | iex",
+                ],
             ),
         }
     }
@@ -142,7 +147,12 @@ mod tests {
             UpdateAction::StandaloneWindows.command_args(),
             (
                 "powershell",
-                &["-c", "irm https://chatgpt.com/codex/install.ps1|iex"][..],
+                &[
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-c",
+                    "irm https://chatgpt.com/codex/install.ps1 | iex"
+                ][..],
             )
         );
     }


### PR DESCRIPTION
Now that users can install via `curl` (or `irm`), we should tell them about it so they no longer need to use `npm`!

Note that on one Windows machine I tested on, when I ran:

```
irm https://chatgpt.com/codex/install.ps1 | iex
```

I got this error:

```
iex : The property 'OSArchitecture' cannot be found on this object. Verify that the property exists.
At line:1 char:45
+ irm https://chatgpt.com/codex/install.ps1 | iex
+                                             ~~~
    + CategoryInfo          : NotSpecified: (:) [Invoke-Expression], PropertyNotFoundException
    + FullyQualifiedErrorId : PropertyNotFoundStrict,Microsoft.PowerShell.Commands.InvokeExpressionCommand
```

so we'll recommend the following that works from both `cmd.exe` and PowerShell:

```
powershell -ExecutionPolicy ByPass -c "irm https://chatgpt.com/codex/install.ps1 | iex"
```

This PR makes a slight update to `codex-rs/tui/src/update_action.rs` to match.