### PR TITLE
[codex] Remove Carver from agent names

### DIFF
--- a/codex-rs/core/src/agent/agent_names.txt
+++ b/codex-rs/core/src/agent/agent_names.txt
@@ -51,7 +51,6 @@ Chandrasekhar
 Sagan
 Goodall
 Carson
-Carver
 Socrates
 Plato
 Aristotle


### PR DESCRIPTION
## What

Remove `Carver` from the default agent nickname list.