### PR TITLE
feat(usage): attribute token usage [2 of 4]

### DIFF
--- a/codex-rs/core/src/client_common.rs
+++ b/codex-rs/core/src/client_common.rs
@@ -1,3 +1,4 @@
+use crate::usage::UsagePromptAttribution;
 pub use codex_api::ResponseEvent;
 use codex_config::types::Personality;
 use codex_protocol::error::Result;
@@ -33,6 +34,8 @@ pub struct Prompt {
     /// Whether parallel tool calls are permitted for this prompt.
     pub(crate) parallel_tool_calls: bool,
 
+    pub(crate) usage_attribution: UsagePromptAttribution,
+
     pub base_instructions: BaseInstructions,
 
     /// Optionally specify the personality of the model.
@@ -51,6 +54,7 @@ impl Default for Prompt {
             input: Vec::new(),
             tools: Vec::new(),
             parallel_tool_calls: false,
+            usage_attribution: UsagePromptAttribution::default(),
             base_instructions: BaseInstructions::default(),
             personality: None,
             output_schema: None,

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -194,6 +194,7 @@ async fn run_remote_compact_task_inner_impl(
         input: prompt_input,
         tools: tool_router.model_visible_specs(),
         parallel_tool_calls: turn_context.model_info.supports_parallel_tool_calls,
+        usage_attribution: Default::default(),
         base_instructions,
         personality: turn_context.personality,
         output_schema: None,

--- a/codex-rs/core/src/compact_remote_v2.rs
+++ b/codex-rs/core/src/compact_remote_v2.rs
@@ -211,6 +211,7 @@ async fn run_remote_compact_task_inner_impl(
         input,
         tools: tool_router.model_visible_specs(),
         parallel_tool_calls: turn_context.model_info.supports_parallel_tool_calls,
+        usage_attribution: Default::default(),
         base_instructions,
         personality: turn_context.personality,
         output_schema: None,

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -99,6 +99,7 @@ pub(crate) use skills::skills_load_input_from_config;
 mod stream_events_utils;
 pub mod test_support;
 mod unified_exec;
+mod usage;
 pub mod windows_sandbox;
 pub use client::X_RESPONSESAPI_INCLUDE_TIMING_METRICS_HEADER;
 pub use codex_protocol::config_types::ModelProviderAuthInfo;

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -2947,6 +2947,36 @@ impl Session {
         }
     }
 
+    pub(crate) async fn record_usage_attribution(
+        &self,
+        turn_context: &TurnContext,
+        prompt: &crate::client_common::Prompt,
+        response_id: &str,
+        token_usage: Option<&TokenUsage>,
+    ) {
+        let Some(token_usage) = token_usage else {
+            return;
+        };
+        let occurred_at = chrono::Utc::now().timestamp();
+        let attribution = prompt.usage_attribution.complete(
+            format!("{}:{response_id}", self.conversation_id),
+            turn_context.sub_id.clone(),
+            response_id.to_string(),
+            occurred_at,
+            token_usage.clone(),
+        );
+        if let Some(state_db) = self.state_db()
+            && let Err(err) = state_db
+                .record_usage_sample(&codex_state::UsageSample {
+                    thread_id: self.conversation_id,
+                    attribution,
+                })
+                .await
+        {
+            warn!("failed to persist usage sample: {err}");
+        }
+    }
+
     pub(crate) async fn recompute_token_usage(&self, turn_context: &TurnContext) {
         let history = self.clone_history().await;
         let base_instructions = self.get_base_instructions().await;

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -900,10 +900,16 @@ pub(crate) fn build_prompt(
     turn_context: &TurnContext,
     base_instructions: BaseInstructions,
 ) -> Prompt {
+    let usage_attribution = crate::usage::UsagePromptAttribution::from_prompt(
+        &input,
+        router,
+        base_instructions.text.as_str(),
+    );
     Prompt {
         input,
         tools: router.model_visible_specs(),
         parallel_tool_calls: turn_context.model_info.supports_parallel_tool_calls,
+        usage_attribution,
         base_instructions,
         personality: turn_context.personality,
         output_schema: turn_context.final_output_json_schema.clone(),
@@ -2004,6 +2010,13 @@ async fn try_run_sampling_request(
                     &turn_context,
                     plan_mode_state.as_mut(),
                     &mut assistant_message_stream_parsers,
+                )
+                .await;
+                sess.record_usage_attribution(
+                    &turn_context,
+                    prompt,
+                    response_id.as_str(),
+                    token_usage.as_ref(),
                 )
                 .await;
                 sess.record_token_usage_info(&turn_context, token_usage.as_ref())

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -900,14 +900,16 @@ pub(crate) fn build_prompt(
     turn_context: &TurnContext,
     base_instructions: BaseInstructions,
 ) -> Prompt {
+    let tools = router.model_visible_specs();
     let usage_attribution = crate::usage::UsagePromptAttribution::from_prompt(
         &input,
+        &tools,
         router,
         base_instructions.text.as_str(),
     );
     Prompt {
         input,
-        tools: router.model_visible_specs(),
+        tools,
         parallel_tool_calls: turn_context.model_info.supports_parallel_tool_calls,
         usage_attribution,
         base_instructions,

--- a/codex-rs/core/src/tools/code_mode/execute_handler.rs
+++ b/codex-rs/core/src/tools/code_mode/execute_handler.rs
@@ -5,6 +5,7 @@ use crate::tools::context::ToolPayload;
 use crate::tools::context::boxed_tool_output;
 use crate::tools::registry::CoreToolRuntime;
 use crate::tools::registry::ToolExecutor;
+use codex_protocol::protocol::UsageContributor;
 use codex_tools::ToolName;
 use codex_tools::ToolSpec;
 
@@ -16,13 +17,19 @@ use super::is_exec_tool_name;
 pub struct CodeModeExecuteHandler {
     spec: ToolSpec,
     nested_tool_specs: Vec<ToolSpec>,
+    usage_contributors: Vec<UsageContributor>,
 }
 
 impl CodeModeExecuteHandler {
-    pub(crate) fn new(spec: ToolSpec, nested_tool_specs: Vec<ToolSpec>) -> Self {
+    pub(crate) fn new(
+        spec: ToolSpec,
+        nested_tool_specs: Vec<ToolSpec>,
+        usage_contributors: Vec<UsageContributor>,
+    ) -> Self {
         Self {
             spec,
             nested_tool_specs,
+            usage_contributors,
         }
     }
 
@@ -117,6 +124,10 @@ impl ToolExecutor<ToolInvocation> for CodeModeExecuteHandler {
 }
 
 impl CoreToolRuntime for CodeModeExecuteHandler {
+    fn usage_contributors(&self) -> Vec<UsageContributor> {
+        self.usage_contributors.clone()
+    }
+
     fn matches_kind(&self, payload: &ToolPayload) -> bool {
         matches!(payload, ToolPayload::Custom { .. })
     }

--- a/codex-rs/core/src/tools/handlers/mcp.rs
+++ b/codex-rs/core/src/tools/handlers/mcp.rs
@@ -17,6 +17,8 @@ use crate::tools::registry::ToolExecutor;
 use crate::tools::registry::ToolTelemetryTags;
 use crate::tools::tool_search_entry::ToolSearchInfo;
 use codex_mcp::ToolInfo;
+use codex_protocol::protocol::UsageContributor;
+use codex_protocol::protocol::UsageContributorKind;
 use codex_tools::ResponsesApiNamespace;
 use codex_tools::ResponsesApiNamespaceTool;
 use codex_tools::ToolName;
@@ -131,6 +133,38 @@ impl ToolExecutor<ToolInvocation> for McpHandler {
 }
 
 impl CoreToolRuntime for McpHandler {
+    fn usage_contributors(&self) -> Vec<UsageContributor> {
+        let mut contributors = Vec::new();
+        if let Some(connector_id) = self.tool_info.connector_id.as_ref() {
+            contributors.push(UsageContributor {
+                kind: UsageContributorKind::App,
+                id: connector_id.clone(),
+                label: self
+                    .tool_info
+                    .connector_name
+                    .clone()
+                    .unwrap_or_else(|| connector_id.clone()),
+            });
+        } else {
+            contributors.push(UsageContributor {
+                kind: UsageContributorKind::McpServer,
+                id: self.tool_info.server_name.clone(),
+                label: self.tool_info.server_name.clone(),
+            });
+        }
+        contributors.extend(
+            self.tool_info
+                .plugin_display_names
+                .iter()
+                .map(|plugin_name| UsageContributor {
+                    kind: UsageContributorKind::Plugin,
+                    id: plugin_name.clone(),
+                    label: plugin_name.clone(),
+                }),
+        );
+        contributors
+    }
+
     fn search_info(&self) -> Option<ToolSearchInfo> {
         let source_name = self
             .tool_info

--- a/codex-rs/core/src/tools/parallel.rs
+++ b/codex-rs/core/src/tools/parallel.rs
@@ -423,6 +423,8 @@ mod tests {
         let router = Arc::new(ToolRouter::from_parts(
             ToolRegistry::from_tools([handler]),
             Vec::new(),
+            Vec::new(),
+            std::collections::HashMap::new(),
         ));
         let tracker = Arc::new(tokio::sync::Mutex::new(TurnDiffTracker::new()));
         let runtime = ToolCallRuntime::new(router, session, turn_context, tracker);

--- a/codex-rs/core/src/tools/parallel.rs
+++ b/codex-rs/core/src/tools/parallel.rs
@@ -497,6 +497,8 @@ mod tests {
         let router = Arc::new(ToolRouter::from_parts(
             ToolRegistry::from_tools([handler]),
             Vec::new(),
+            Vec::new(),
+            std::collections::HashMap::new(),
         ));
         let tracker = Arc::new(tokio::sync::Mutex::new(TurnDiffTracker::new()));
         let runtime = ToolCallRuntime::new(router, session, turn_context, tracker);

--- a/codex-rs/core/src/tools/registry.rs
+++ b/codex-rs/core/src/tools/registry.rs
@@ -311,6 +311,10 @@ impl CoreToolRuntime for ExposureOverride {
         self.handler.post_tool_use_payload(invocation, result)
     }
 
+    fn usage_contributors(&self) -> Vec<UsageContributor> {
+        self.handler.usage_contributors()
+    }
+
     fn with_updated_hook_input(
         &self,
         invocation: ToolInvocation,

--- a/codex-rs/core/src/tools/registry.rs
+++ b/codex-rs/core/src/tools/registry.rs
@@ -30,6 +30,7 @@ use codex_extension_api::ToolCallOutcome;
 use codex_protocol::models::FunctionCallOutputPayload;
 use codex_protocol::models::ResponseInputItem;
 use codex_protocol::protocol::EventMsg;
+use codex_protocol::protocol::UsageContributor;
 use codex_tools::ToolName;
 use codex_tools::ToolSpec;
 use futures::future::BoxFuture;
@@ -102,6 +103,10 @@ pub(crate) trait CoreToolRuntime: ToolExecutor<ToolInvocation> {
                     serde_json::to_value(body).ok()
                 })?,
         })
+    }
+
+    fn usage_contributors(&self) -> Vec<UsageContributor> {
+        Vec::new()
     }
 
     fn pre_tool_use_payload(&self, invocation: &ToolInvocation) -> Option<PreToolUsePayload> {

--- a/codex-rs/core/src/tools/router.rs
+++ b/codex-rs/core/src/tools/router.rs
@@ -17,6 +17,7 @@ use codex_tools::ToolCall as ExtensionToolCall;
 use codex_tools::ToolExecutor;
 use codex_tools::ToolName;
 use codex_tools::ToolSpec;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use tokio_util::sync::CancellationToken;
@@ -34,6 +35,9 @@ pub struct ToolCall {
 pub struct ToolRouter {
     registry: ToolRegistry,
     model_visible_specs: Vec<ToolSpec>,
+    usage_contributors: Vec<crate::usage::UsagePromptContributor>,
+    usage_contributors_by_tool_name:
+        HashMap<ToolName, Vec<codex_protocol::protocol::UsageContributor>>,
 }
 
 pub(crate) struct ToolRouterParams<'a> {
@@ -49,15 +53,39 @@ impl ToolRouter {
         build_tool_router(turn_context, params)
     }
 
-    pub(crate) fn from_parts(registry: ToolRegistry, model_visible_specs: Vec<ToolSpec>) -> Self {
+    pub(crate) fn from_parts(
+        registry: ToolRegistry,
+        model_visible_specs: Vec<ToolSpec>,
+        usage_contributors: Vec<crate::usage::UsagePromptContributor>,
+        usage_contributors_by_tool_name: HashMap<
+            ToolName,
+            Vec<codex_protocol::protocol::UsageContributor>,
+        >,
+    ) -> Self {
         Self {
             registry,
             model_visible_specs,
+            usage_contributors,
+            usage_contributors_by_tool_name,
         }
     }
 
     pub fn model_visible_specs(&self) -> Vec<ToolSpec> {
         self.model_visible_specs.clone()
+    }
+
+    pub(crate) fn usage_contributors(&self) -> Vec<crate::usage::UsagePromptContributor> {
+        self.usage_contributors.clone()
+    }
+
+    pub(crate) fn usage_contributors_for_tool_name(
+        &self,
+        tool_name: &ToolName,
+    ) -> Vec<codex_protocol::protocol::UsageContributor> {
+        self.usage_contributors_by_tool_name
+            .get(tool_name)
+            .cloned()
+            .unwrap_or_default()
     }
 
     #[cfg(test)]

--- a/codex-rs/core/src/tools/router.rs
+++ b/codex-rs/core/src/tools/router.rs
@@ -74,18 +74,17 @@ impl ToolRouter {
         self.model_visible_specs.clone()
     }
 
-    pub(crate) fn usage_contributors(&self) -> Vec<crate::usage::UsagePromptContributor> {
-        self.usage_contributors.clone()
+    pub(crate) fn usage_contributors(&self) -> &[crate::usage::UsagePromptContributor] {
+        &self.usage_contributors
     }
 
     pub(crate) fn usage_contributors_for_tool_name(
         &self,
         tool_name: &ToolName,
-    ) -> Vec<codex_protocol::protocol::UsageContributor> {
+    ) -> &[codex_protocol::protocol::UsageContributor] {
         self.usage_contributors_by_tool_name
             .get(tool_name)
-            .cloned()
-            .unwrap_or_default()
+            .map_or(&[], Vec::as_slice)
     }
 
     #[cfg(test)]

--- a/codex-rs/core/src/tools/spec_plan.rs
+++ b/codex-rs/core/src/tools/spec_plan.rs
@@ -80,6 +80,7 @@ use codex_tools::request_user_input_available_modes;
 use codex_tools::shell_command_backend_for_features;
 use codex_tools::shell_type_for_model_and_features;
 use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
 use tracing::warn;
@@ -146,14 +147,25 @@ pub(crate) fn build_tool_router(
     turn_context: &TurnContext,
     params: ToolRouterParams<'_>,
 ) -> ToolRouter {
-    let (model_visible_specs, registry) = build_tool_specs_and_registry(turn_context, params);
-    ToolRouter::from_parts(registry, model_visible_specs)
+    let (model_visible_specs, registry, usage_contributors, usage_contributors_by_tool_name) =
+        build_tool_specs_and_registry(turn_context, params);
+    ToolRouter::from_parts(
+        registry,
+        model_visible_specs,
+        usage_contributors,
+        usage_contributors_by_tool_name,
+    )
 }
 
 fn build_tool_specs_and_registry(
     turn_context: &TurnContext,
     params: ToolRouterParams<'_>,
-) -> (Vec<ToolSpec>, ToolRegistry) {
+) -> (
+    Vec<ToolSpec>,
+    ToolRegistry,
+    Vec<crate::usage::UsagePromptContributor>,
+    HashMap<ToolName, Vec<codex_protocol::protocol::UsageContributor>>,
+) {
     let ToolRouterParams {
         mcp_tools,
         deferred_mcp_tools,
@@ -183,12 +195,19 @@ fn build_tool_specs_and_registry(
 fn build_model_visible_specs_and_registry(
     turn_context: &TurnContext,
     planned_tools: PlannedTools,
-) -> (Vec<ToolSpec>, ToolRegistry) {
+) -> (
+    Vec<ToolSpec>,
+    ToolRegistry,
+    Vec<crate::usage::UsagePromptContributor>,
+    HashMap<ToolName, Vec<codex_protocol::protocol::UsageContributor>>,
+) {
     let PlannedTools {
         runtimes,
         hosted_specs,
     } = planned_tools;
     let mut specs = Vec::new();
+    let mut usage_contributors = Vec::new();
+    let mut usage_contributors_by_tool_name = HashMap::new();
     let mut seen_tool_names = HashSet::new();
     for runtime in &runtimes {
         let tool_name = runtime.tool_name();
@@ -199,6 +218,16 @@ fn build_model_visible_specs_and_registry(
         if exposure.is_direct() && !is_hidden_by_code_mode_only(turn_context, &tool_name, exposure)
         {
             let spec = runtime.spec();
+            let estimated_tokens = crate::usage::estimate_serialized_tokens(&spec);
+            let runtime_usage_contributors = runtime.usage_contributors();
+            usage_contributors_by_tool_name
+                .insert(tool_name.clone(), runtime_usage_contributors.clone());
+            usage_contributors.extend(runtime_usage_contributors.into_iter().map(|contributor| {
+                crate::usage::UsagePromptContributor {
+                    contributor,
+                    source_estimated_tokens: estimated_tokens,
+                }
+            }));
             specs.push(spec_for_model_request(turn_context, exposure, spec));
         }
     }
@@ -220,7 +249,12 @@ fn build_model_visible_specs_and_registry(
         })
         .collect();
 
-    (model_visible_specs, registry)
+    (
+        model_visible_specs,
+        registry,
+        usage_contributors,
+        usage_contributors_by_tool_name,
+    )
 }
 
 fn spec_for_model_request(

--- a/codex-rs/core/src/tools/spec_plan.rs
+++ b/codex-rs/core/src/tools/spec_plan.rs
@@ -215,20 +215,25 @@ fn build_model_visible_specs_and_registry(
             continue;
         }
         let exposure = runtime.exposure();
-        if exposure.is_direct() && !is_hidden_by_code_mode_only(turn_context, &tool_name, exposure)
-        {
-            let spec = runtime.spec();
-            let estimated_tokens = crate::usage::estimate_serialized_tokens(&spec);
-            let runtime_usage_contributors = runtime.usage_contributors();
+        let runtime_usage_contributors = runtime.usage_contributors();
+        if !runtime_usage_contributors.is_empty() {
             usage_contributors_by_tool_name
                 .insert(tool_name.clone(), runtime_usage_contributors.clone());
+        }
+        if exposure.is_direct() && !is_hidden_by_code_mode_only(turn_context, &tool_name, exposure)
+        {
+            let spec = spec_for_model_request(turn_context, exposure, runtime.spec());
+            if !namespace_tools_enabled(turn_context) && matches!(spec, ToolSpec::Namespace(_)) {
+                continue;
+            }
+            let estimated_tokens = crate::usage::estimate_serialized_tokens(&spec);
             usage_contributors.extend(runtime_usage_contributors.into_iter().map(|contributor| {
                 crate::usage::UsagePromptContributor {
                     contributor,
                     source_estimated_tokens: estimated_tokens,
                 }
             }));
-            specs.push(spec_for_model_request(turn_context, exposure, spec));
+            specs.push(spec);
         }
     }
     for spec in hosted_specs {

--- a/codex-rs/core/src/tools/spec_plan.rs
+++ b/codex-rs/core/src/tools/spec_plan.rs
@@ -62,6 +62,7 @@ use codex_protocol::openai_models::ConfigShellToolType;
 use codex_protocol::openai_models::InputModality;
 use codex_protocol::protocol::SessionSource;
 use codex_protocol::protocol::SubAgentSource;
+use codex_protocol::protocol::UsageContributor;
 use codex_tools::DiscoverableTool;
 use codex_tools::ResponsesApiNamespace;
 use codex_tools::ResponsesApiNamespaceTool;
@@ -206,7 +207,6 @@ fn build_model_visible_specs_and_registry(
         hosted_specs,
     } = planned_tools;
     let mut specs = Vec::new();
-    let mut usage_contributors = Vec::new();
     let mut usage_contributors_by_tool_name = HashMap::new();
     let mut seen_tool_names = HashSet::new();
     for runtime in &runtimes {
@@ -226,13 +226,6 @@ fn build_model_visible_specs_and_registry(
             if !namespace_tools_enabled(turn_context) && matches!(spec, ToolSpec::Namespace(_)) {
                 continue;
             }
-            let estimated_tokens = crate::usage::estimate_serialized_tokens(&spec);
-            usage_contributors.extend(runtime_usage_contributors.into_iter().map(|contributor| {
-                crate::usage::UsagePromptContributor {
-                    contributor,
-                    source_estimated_tokens: estimated_tokens,
-                }
-            }));
             specs.push(spec);
         }
     }
@@ -247,12 +240,14 @@ fn build_model_visible_specs_and_registry(
     }
 
     let registry = ToolRegistry::from_tools(runtimes);
-    let model_visible_specs = merge_into_namespaces(specs)
+    let model_visible_specs: Vec<ToolSpec> = merge_into_namespaces(specs)
         .into_iter()
         .filter(|spec| {
             namespace_tools_enabled(turn_context) || !matches!(spec, ToolSpec::Namespace(_))
         })
         .collect();
+    let usage_contributors =
+        prompt_usage_contributors(&model_visible_specs, &usage_contributors_by_tool_name);
 
     (
         model_visible_specs,
@@ -260,6 +255,50 @@ fn build_model_visible_specs_and_registry(
         usage_contributors,
         usage_contributors_by_tool_name,
     )
+}
+
+fn prompt_usage_contributors(
+    specs: &[ToolSpec],
+    contributors_by_tool_name: &HashMap<ToolName, Vec<UsageContributor>>,
+) -> Vec<crate::usage::UsagePromptContributor> {
+    let mut prompt_contributors = Vec::new();
+    for spec in specs {
+        let mut spec_contributors = Vec::new();
+        match spec {
+            ToolSpec::Namespace(namespace) => {
+                for tool in &namespace.tools {
+                    let ResponsesApiNamespaceTool::Function(tool) = tool;
+                    let tool_name = ToolName::namespaced(&namespace.name, &tool.name);
+                    if let Some(contributors) = contributors_by_tool_name.get(&tool_name) {
+                        for contributor in contributors {
+                            if !spec_contributors.contains(contributor) {
+                                spec_contributors.push(contributor.clone());
+                            }
+                        }
+                    }
+                }
+            }
+            ToolSpec::Function(_)
+            | ToolSpec::ToolSearch { .. }
+            | ToolSpec::ImageGeneration { .. }
+            | ToolSpec::WebSearch { .. }
+            | ToolSpec::Freeform(_) => {
+                if let Some(contributors) =
+                    contributors_by_tool_name.get(&ToolName::plain(spec.name()))
+                {
+                    spec_contributors.extend(contributors.iter().cloned());
+                }
+            }
+        }
+        let source_estimated_tokens = crate::usage::estimate_serialized_tokens(spec);
+        prompt_contributors.extend(spec_contributors.into_iter().map(|contributor| {
+            crate::usage::UsagePromptContributor {
+                contributor,
+                source_estimated_tokens,
+            }
+        }));
+    }
+    prompt_contributors
 }
 
 fn spec_for_model_request(
@@ -431,6 +470,7 @@ fn build_code_mode_executors(
 
     let mut code_mode_nested_tool_specs = Vec::new();
     let mut exec_prompt_tool_specs = Vec::new();
+    let mut exec_prompt_usage_contributors = Vec::new();
     for executor in executors {
         let exposure = executor.exposure();
         if exposure == ToolExposure::DirectModelOnly {
@@ -444,6 +484,11 @@ fn build_code_mode_executors(
 
         if exposure != ToolExposure::Deferred {
             exec_prompt_tool_specs.push(spec.clone());
+            for contributor in executor.usage_contributors() {
+                if !exec_prompt_usage_contributors.contains(&contributor) {
+                    exec_prompt_usage_contributors.push(contributor);
+                }
+            }
         }
         code_mode_nested_tool_specs.push(spec);
     }
@@ -463,6 +508,7 @@ fn build_code_mode_executors(
                 deferred_tools_available,
             ),
             code_mode_nested_tool_specs,
+            exec_prompt_usage_contributors,
         )),
         Arc::new(CodeModeWaitHandler),
     ]

--- a/codex-rs/core/src/tools/spec_plan_tests.rs
+++ b/codex-rs/core/src/tools/spec_plan_tests.rs
@@ -88,8 +88,8 @@ impl ToolPlanProbe {
             .collect::<Vec<_>>();
         let prompt_usage_contributor_labels = router
             .usage_contributors()
-            .into_iter()
-            .map(|contributor| contributor.contributor.label)
+            .iter()
+            .map(|contributor| contributor.contributor.label.clone())
             .collect::<Vec<_>>();
         let tool_usage_contributor_labels = registered_tool_names
             .iter()
@@ -99,8 +99,8 @@ impl ToolPlanProbe {
                     (
                         name.to_string(),
                         contributors
-                            .into_iter()
-                            .map(|contributor| contributor.label)
+                            .iter()
+                            .map(|contributor| contributor.label.clone())
                             .collect::<Vec<_>>(),
                     )
                 })

--- a/codex-rs/core/src/tools/spec_plan_tests.rs
+++ b/codex-rs/core/src/tools/spec_plan_tests.rs
@@ -48,6 +48,8 @@ struct ToolPlanProbe {
     visible_specs: Vec<ToolSpec>,
     visible_names: Vec<String>,
     namespace_functions: BTreeMap<String, Vec<String>>,
+    prompt_usage_contributor_labels: Vec<String>,
+    tool_usage_contributor_labels: BTreeMap<String, Vec<String>>,
     registered_names: Vec<String>,
     exposures: BTreeMap<String, ToolExposure>,
 }
@@ -84,6 +86,26 @@ impl ToolPlanProbe {
             .iter()
             .map(ToString::to_string)
             .collect::<Vec<_>>();
+        let prompt_usage_contributor_labels = router
+            .usage_contributors()
+            .into_iter()
+            .map(|contributor| contributor.contributor.label)
+            .collect::<Vec<_>>();
+        let tool_usage_contributor_labels = registered_tool_names
+            .iter()
+            .filter_map(|name| {
+                let contributors = router.usage_contributors_for_tool_name(name);
+                (!contributors.is_empty()).then(|| {
+                    (
+                        name.to_string(),
+                        contributors
+                            .into_iter()
+                            .map(|contributor| contributor.label)
+                            .collect::<Vec<_>>(),
+                    )
+                })
+            })
+            .collect::<BTreeMap<_, _>>();
         let exposures = registered_tool_names
             .iter()
             .filter_map(|name| {
@@ -97,6 +119,8 @@ impl ToolPlanProbe {
             visible_specs,
             visible_names,
             namespace_functions,
+            prompt_usage_contributor_labels,
+            tool_usage_contributor_labels,
             registered_names,
             exposures,
         }
@@ -150,6 +174,12 @@ impl ToolPlanProbe {
     fn namespace_function_names(&self, namespace: &str) -> &[String] {
         self.namespace_functions
             .get(namespace)
+            .map_or(&[], Vec::as_slice)
+    }
+
+    fn tool_usage_contributor_labels(&self, tool_name: &str) -> &[String] {
+        self.tool_usage_contributor_labels
+            .get(tool_name)
             .map_or(&[], Vec::as_slice)
     }
 
@@ -490,6 +520,10 @@ async fn mcp_and_tool_search_follow_direct_and_deferred_tool_exposure() {
         direct_mcp.namespace_function_names("mcp__direct"),
         &["lookup".to_string()]
     );
+    assert_eq!(
+        direct_mcp.prompt_usage_contributor_labels,
+        vec!["direct".to_string()]
+    );
 
     let searchable_mcp = ToolPlanInputs {
         deferred_mcp_tools: Some(vec![mcp_tool("searchable", "mcp__searchable", "lookup")]),
@@ -533,6 +567,22 @@ async fn mcp_and_tool_search_follow_direct_and_deferred_tool_exposure() {
     .await;
     bedrock_namespace_capability.assert_visible_contains(&["tool_search"]);
 
+    let bedrock_namespace_spec = probe_with(
+        |turn| {
+            use_bedrock_provider(turn);
+        },
+        ToolPlanInputs {
+            mcp_tools: Some(vec![mcp_tool("bedrock", "mcp__bedrock__", "lookup")]),
+            ..ToolPlanInputs::default()
+        },
+    )
+    .await;
+    bedrock_namespace_spec.assert_visible_contains(&["mcp__bedrock__"]);
+    assert_eq!(
+        bedrock_namespace_spec.prompt_usage_contributor_labels,
+        vec!["bedrock".to_string()]
+    );
+
     let enabled = probe_with(
         |turn| {
             turn.model_info.supports_search_tool = true;
@@ -541,10 +591,12 @@ async fn mcp_and_tool_search_follow_direct_and_deferred_tool_exposure() {
     )
     .await;
     enabled.assert_visible_contains(&["tool_search"]);
-    enabled.assert_registered_contains(&[
-        "tool_search",
-        &ToolName::namespaced("mcp__searchable", "lookup").to_string(),
-    ]);
+    let searchable_tool_name = ToolName::namespaced("mcp__searchable", "lookup").to_string();
+    enabled.assert_registered_contains(&["tool_search", searchable_tool_name.as_str()]);
+    assert_eq!(
+        enabled.tool_usage_contributor_labels(&searchable_tool_name),
+        ["searchable".to_string()].as_slice()
+    );
 }
 
 #[tokio::test]

--- a/codex-rs/core/src/tools/spec_plan_tests.rs
+++ b/codex-rs/core/src/tools/spec_plan_tests.rs
@@ -525,6 +525,22 @@ async fn mcp_and_tool_search_follow_direct_and_deferred_tool_exposure() {
         vec!["direct".to_string()]
     );
 
+    let merged_mcp = probe_with(
+        |_| {},
+        ToolPlanInputs {
+            mcp_tools: Some(vec![
+                mcp_tool("merged", "mcp__merged", "lookup"),
+                mcp_tool("merged", "mcp__merged", "search"),
+            ]),
+            ..ToolPlanInputs::default()
+        },
+    )
+    .await;
+    assert_eq!(
+        merged_mcp.prompt_usage_contributor_labels,
+        vec!["merged".to_string()]
+    );
+
     let searchable_mcp = ToolPlanInputs {
         deferred_mcp_tools: Some(vec![mcp_tool("searchable", "mcp__searchable", "lookup")]),
         ..ToolPlanInputs::default()
@@ -758,6 +774,7 @@ async fn code_mode_only_exposes_code_executor_and_hides_nested_tools() {
             set_features(turn, &[Feature::CodeMode, Feature::CodeModeOnly]);
         },
         ToolPlanInputs {
+            mcp_tools: Some(vec![mcp_tool("nested", "mcp__nested", "lookup")]),
             dynamic_tools: vec![dynamic_tool(
                 Some("codex_app"),
                 "lookup",
@@ -774,6 +791,10 @@ async fn code_mode_only_exposes_code_executor_and_hides_nested_tools() {
     assert_eq!(
         code_mode_only.namespace_function_names("codex_app"),
         Vec::<String>::new().as_slice()
+    );
+    assert_eq!(
+        code_mode_only.prompt_usage_contributor_labels,
+        vec!["nested".to_string()]
     );
 }
 

--- a/codex-rs/core/src/usage.rs
+++ b/codex-rs/core/src/usage.rs
@@ -1,0 +1,363 @@
+use crate::tools::router::ToolRouter;
+use codex_protocol::models::ContentItem;
+use codex_protocol::models::ResponseItem;
+use codex_protocol::protocol::TokenUsage;
+use codex_protocol::protocol::UsageAttributionContributor;
+use codex_protocol::protocol::UsageAttributionItem;
+use codex_protocol::protocol::UsageContributor;
+use codex_protocol::protocol::UsageContributorKind;
+use codex_tools::ToolName;
+use codex_utils_output_truncation::approx_token_count;
+use std::collections::BTreeMap;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct UsagePromptAttribution {
+    pub(crate) prompt_estimated_tokens: i64,
+    pub(crate) contributors: Vec<UsagePromptContributor>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct UsagePromptContributor {
+    pub(crate) contributor: UsageContributor,
+    pub(crate) source_estimated_tokens: i64,
+}
+
+impl UsagePromptAttribution {
+    pub(crate) fn from_prompt(
+        input: &[ResponseItem],
+        router: &ToolRouter,
+        base_instructions: &str,
+    ) -> Self {
+        let mut contributors = skill_contributors(input);
+        contributors.extend(router.usage_contributors());
+        contributors.extend(tool_result_contributors(input, router));
+        let input_tokens = input
+            .iter()
+            .map(estimate_response_item_tokens)
+            .fold(0i64, i64::saturating_add);
+        let tool_tokens = router
+            .model_visible_specs()
+            .iter()
+            .map(estimate_serialized_tokens)
+            .fold(0i64, i64::saturating_add);
+        let base_tokens = i64::try_from(approx_token_count(base_instructions)).unwrap_or(i64::MAX);
+        Self {
+            prompt_estimated_tokens: base_tokens
+                .saturating_add(input_tokens)
+                .saturating_add(tool_tokens),
+            contributors: aggregate_contributors(contributors),
+        }
+    }
+
+    pub(crate) fn complete(
+        &self,
+        sample_id: String,
+        turn_id: String,
+        response_id: String,
+        occurred_at: i64,
+        token_usage: TokenUsage,
+    ) -> UsageAttributionItem {
+        let non_cached_input = token_usage.non_cached_input();
+        let contributors = self
+            .contributors
+            .iter()
+            .map(|contributor| UsageAttributionContributor {
+                contributor: contributor.contributor.clone(),
+                source_estimated_tokens: contributor.source_estimated_tokens,
+                attributed_tokens: attributable_tokens(
+                    non_cached_input,
+                    contributor.source_estimated_tokens,
+                    self.prompt_estimated_tokens,
+                ),
+            })
+            .filter(|contributor| contributor.attributed_tokens > 0)
+            .collect();
+        UsageAttributionItem {
+            sample_id,
+            turn_id,
+            response_id,
+            occurred_at,
+            token_usage,
+            prompt_estimated_tokens: self.prompt_estimated_tokens,
+            contributors,
+        }
+    }
+}
+
+pub(crate) fn estimate_serialized_tokens<T: serde::Serialize>(value: &T) -> i64 {
+    serde_json::to_string(value)
+        .map(|serialized| i64::try_from(approx_token_count(&serialized)).unwrap_or(i64::MAX))
+        .unwrap_or(/*default*/ 0)
+}
+
+fn estimate_response_item_tokens(item: &ResponseItem) -> i64 {
+    estimate_serialized_tokens(item)
+}
+
+fn skill_contributors(input: &[ResponseItem]) -> Vec<UsagePromptContributor> {
+    input.iter().filter_map(skill_contributor).collect()
+}
+
+fn tool_result_contributors(
+    input: &[ResponseItem],
+    router: &ToolRouter,
+) -> Vec<UsagePromptContributor> {
+    let contributors_by_call_id = input
+        .iter()
+        .filter_map(|item| tool_call_contributors(item, router))
+        .collect::<HashMap<_, _>>();
+    input
+        .iter()
+        .filter_map(|item| tool_result_contributor(item, &contributors_by_call_id))
+        .flatten()
+        .collect()
+}
+
+fn tool_call_contributors(
+    item: &ResponseItem,
+    router: &ToolRouter,
+) -> Option<(String, Vec<UsageContributor>)> {
+    let (call_id, tool_name) = match item {
+        ResponseItem::FunctionCall {
+            call_id,
+            name,
+            namespace,
+            ..
+        } => (call_id, ToolName::new(namespace.clone(), name)),
+        ResponseItem::CustomToolCall { call_id, name, .. } => (call_id, ToolName::plain(name)),
+        _ => return None,
+    };
+    let contributors = router.usage_contributors_for_tool_name(&tool_name);
+    (!contributors.is_empty()).then(|| (call_id.clone(), contributors))
+}
+
+fn tool_result_contributor(
+    item: &ResponseItem,
+    contributors_by_call_id: &HashMap<String, Vec<UsageContributor>>,
+) -> Option<Vec<UsagePromptContributor>> {
+    let call_id = match item {
+        ResponseItem::FunctionCallOutput { call_id, .. }
+        | ResponseItem::CustomToolCallOutput { call_id, .. } => call_id,
+        _ => return None,
+    };
+    let source_estimated_tokens = estimate_response_item_tokens(item);
+    Some(
+        contributors_by_call_id
+            .get(call_id)?
+            .iter()
+            .cloned()
+            .map(|contributor| UsagePromptContributor {
+                contributor,
+                source_estimated_tokens,
+            })
+            .collect(),
+    )
+}
+
+fn skill_contributor(item: &ResponseItem) -> Option<UsagePromptContributor> {
+    let ResponseItem::Message { content, .. } = item else {
+        return None;
+    };
+    let text = content.iter().find_map(|content| match content {
+        ContentItem::InputText { text } if text.contains("<skill>") => Some(text.as_str()),
+        _ => None,
+    })?;
+    let name = tag_contents(text, "name")?;
+    let path = tag_contents(text, "path")?;
+    Some(UsagePromptContributor {
+        contributor: UsageContributor {
+            kind: UsageContributorKind::Skill,
+            id: path.to_string(),
+            label: name.to_string(),
+        },
+        source_estimated_tokens: i64::try_from(approx_token_count(text)).unwrap_or(i64::MAX),
+    })
+}
+
+fn tag_contents<'a>(text: &'a str, tag: &str) -> Option<&'a str> {
+    let open = format!("<{tag}>");
+    let close = format!("</{tag}>");
+    let start = text.find(open.as_str())? + open.len();
+    let end = text[start..].find(close.as_str())? + start;
+    Some(text[start..end].trim())
+}
+
+fn aggregate_contributors(
+    contributors: Vec<UsagePromptContributor>,
+) -> Vec<UsagePromptContributor> {
+    let mut aggregated = BTreeMap::new();
+    for contributor in contributors {
+        let key = (
+            contributor.contributor.kind as u8,
+            contributor.contributor.id.clone(),
+            contributor.contributor.label.clone(),
+        );
+        aggregated
+            .entry(key)
+            .and_modify(|existing: &mut UsagePromptContributor| {
+                existing.source_estimated_tokens = existing
+                    .source_estimated_tokens
+                    .saturating_add(contributor.source_estimated_tokens);
+            })
+            .or_insert(contributor);
+    }
+    aggregated.into_values().collect()
+}
+
+fn attributable_tokens(non_cached_input: i64, source_tokens: i64, prompt_tokens: i64) -> i64 {
+    if non_cached_input <= 0 || source_tokens <= 0 || prompt_tokens <= 0 {
+        return 0;
+    }
+    non_cached_input
+        .saturating_mul(source_tokens)
+        .saturating_add(prompt_tokens / 2)
+        / prompt_tokens
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tools::registry::ToolRegistry;
+    use codex_protocol::models::FunctionCallOutputPayload;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn complete_attributes_only_non_cached_input_tokens() {
+        let attribution = UsagePromptAttribution {
+            prompt_estimated_tokens: 100,
+            contributors: vec![
+                usage_prompt_contributor(
+                    UsageContributorKind::Skill,
+                    "/skills/tmux",
+                    "tmux",
+                    /*source_estimated_tokens*/ 25,
+                ),
+                usage_prompt_contributor(
+                    UsageContributorKind::App,
+                    "slack",
+                    "Slack",
+                    /*source_estimated_tokens*/ 10,
+                ),
+            ],
+        };
+
+        let usage = attribution.complete(
+            "sample".to_string(),
+            "turn".to_string(),
+            "response".to_string(),
+            /*occurred_at*/ 1_700_000_000,
+            TokenUsage {
+                input_tokens: 100,
+                cached_input_tokens: 40,
+                output_tokens: 20,
+                reasoning_output_tokens: 0,
+                total_tokens: 120,
+            },
+        );
+
+        assert_eq!(
+            usage.contributors,
+            vec![
+                UsageAttributionContributor {
+                    contributor: usage_contributor(
+                        UsageContributorKind::Skill,
+                        "/skills/tmux",
+                        "tmux",
+                    ),
+                    source_estimated_tokens: 25,
+                    attributed_tokens: 15,
+                },
+                UsageAttributionContributor {
+                    contributor: usage_contributor(UsageContributorKind::App, "slack", "Slack"),
+                    source_estimated_tokens: 10,
+                    attributed_tokens: 6,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn skill_contributors_use_skill_path_as_stable_id() {
+        let item = ResponseItem::Message {
+            id: None,
+            role: "developer".to_string(),
+            content: vec![ContentItem::InputText {
+                text: "<skill><name>tmux</name><path>/skills/tmux/SKILL.md</path></skill>"
+                    .to_string(),
+            }],
+            phase: None,
+        };
+
+        assert_eq!(
+            skill_contributors(&[item]),
+            vec![UsagePromptContributor {
+                contributor: usage_contributor(
+                    UsageContributorKind::Skill,
+                    "/skills/tmux/SKILL.md",
+                    "tmux",
+                ),
+                source_estimated_tokens: i64::try_from(approx_token_count(
+                    "<skill><name>tmux</name><path>/skills/tmux/SKILL.md</path></skill>",
+                ))
+                .expect("skill prompt token estimate should fit in i64"),
+            }]
+        );
+    }
+
+    #[test]
+    fn tool_results_reuse_tool_usage_provenance() {
+        let contributor = usage_contributor(UsageContributorKind::App, "slack", "Slack");
+        let tool_name = ToolName::plain("mcp__slack__search");
+        let router = ToolRouter::from_parts(
+            ToolRegistry::from_tools(Vec::<
+                std::sync::Arc<dyn crate::tools::registry::CoreToolRuntime>,
+            >::new()),
+            Vec::new(),
+            Vec::new(),
+            HashMap::from([(tool_name.clone(), vec![contributor.clone()])]),
+        );
+        let tool_result = ResponseItem::FunctionCallOutput {
+            call_id: "call-1".to_string(),
+            output: FunctionCallOutputPayload::from_text("result".to_string()),
+        };
+        let input = vec![
+            ResponseItem::FunctionCall {
+                id: None,
+                name: tool_name.name,
+                namespace: tool_name.namespace,
+                arguments: "{}".to_string(),
+                call_id: "call-1".to_string(),
+            },
+            tool_result.clone(),
+        ];
+
+        assert_eq!(
+            tool_result_contributors(&input, &router),
+            vec![UsagePromptContributor {
+                contributor,
+                source_estimated_tokens: estimate_response_item_tokens(&tool_result),
+            }]
+        );
+    }
+
+    fn usage_prompt_contributor(
+        kind: UsageContributorKind,
+        id: &str,
+        label: &str,
+        source_estimated_tokens: i64,
+    ) -> UsagePromptContributor {
+        UsagePromptContributor {
+            contributor: usage_contributor(kind, id, label),
+            source_estimated_tokens,
+        }
+    }
+
+    fn usage_contributor(kind: UsageContributorKind, id: &str, label: &str) -> UsageContributor {
+        UsageContributor {
+            kind,
+            id: id.to_string(),
+            label: label.to_string(),
+        }
+    }
+}

--- a/codex-rs/core/src/usage.rs
+++ b/codex-rs/core/src/usage.rs
@@ -7,6 +7,7 @@ use codex_protocol::protocol::UsageAttributionItem;
 use codex_protocol::protocol::UsageContributor;
 use codex_protocol::protocol::UsageContributorKind;
 use codex_tools::ToolName;
+use codex_tools::ToolSpec;
 use codex_utils_output_truncation::approx_token_count;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
@@ -26,18 +27,18 @@ pub(crate) struct UsagePromptContributor {
 impl UsagePromptAttribution {
     pub(crate) fn from_prompt(
         input: &[ResponseItem],
+        tools: &[ToolSpec],
         router: &ToolRouter,
         base_instructions: &str,
     ) -> Self {
         let mut contributors = skill_contributors(input);
-        contributors.extend(router.usage_contributors());
+        contributors.extend_from_slice(router.usage_contributors());
         contributors.extend(tool_result_contributors(input, router));
         let input_tokens = input
             .iter()
             .map(estimate_response_item_tokens)
             .fold(0i64, i64::saturating_add);
-        let tool_tokens = router
-            .model_visible_specs()
+        let tool_tokens = tools
             .iter()
             .map(estimate_serialized_tokens)
             .fold(0i64, i64::saturating_add);
@@ -105,54 +106,45 @@ fn tool_result_contributors(
 ) -> Vec<UsagePromptContributor> {
     let contributors_by_call_id = input
         .iter()
-        .filter_map(|item| tool_call_contributors(item, router))
+        .filter_map(|item| {
+            let (call_id, tool_name) = match item {
+                ResponseItem::FunctionCall {
+                    call_id,
+                    name,
+                    namespace,
+                    ..
+                } => (call_id, ToolName::new(namespace.clone(), name)),
+                ResponseItem::CustomToolCall { call_id, name, .. } => {
+                    (call_id, ToolName::plain(name))
+                }
+                _ => return None,
+            };
+            let contributors = router.usage_contributors_for_tool_name(&tool_name);
+            (!contributors.is_empty()).then(|| (call_id.clone(), contributors))
+        })
         .collect::<HashMap<_, _>>();
     input
         .iter()
-        .filter_map(|item| tool_result_contributor(item, &contributors_by_call_id))
+        .filter_map(|item| {
+            let call_id = match item {
+                ResponseItem::FunctionCallOutput { call_id, .. }
+                | ResponseItem::CustomToolCallOutput { call_id, .. } => call_id,
+                _ => return None,
+            };
+            let source_estimated_tokens = estimate_response_item_tokens(item);
+            Some(
+                contributors_by_call_id
+                    .get(call_id)?
+                    .iter()
+                    .cloned()
+                    .map(move |contributor| UsagePromptContributor {
+                        contributor,
+                        source_estimated_tokens,
+                    }),
+            )
+        })
         .flatten()
         .collect()
-}
-
-fn tool_call_contributors(
-    item: &ResponseItem,
-    router: &ToolRouter,
-) -> Option<(String, Vec<UsageContributor>)> {
-    let (call_id, tool_name) = match item {
-        ResponseItem::FunctionCall {
-            call_id,
-            name,
-            namespace,
-            ..
-        } => (call_id, ToolName::new(namespace.clone(), name)),
-        ResponseItem::CustomToolCall { call_id, name, .. } => (call_id, ToolName::plain(name)),
-        _ => return None,
-    };
-    let contributors = router.usage_contributors_for_tool_name(&tool_name);
-    (!contributors.is_empty()).then(|| (call_id.clone(), contributors))
-}
-
-fn tool_result_contributor(
-    item: &ResponseItem,
-    contributors_by_call_id: &HashMap<String, Vec<UsageContributor>>,
-) -> Option<Vec<UsagePromptContributor>> {
-    let call_id = match item {
-        ResponseItem::FunctionCallOutput { call_id, .. }
-        | ResponseItem::CustomToolCallOutput { call_id, .. } => call_id,
-        _ => return None,
-    };
-    let source_estimated_tokens = estimate_response_item_tokens(item);
-    Some(
-        contributors_by_call_id
-            .get(call_id)?
-            .iter()
-            .cloned()
-            .map(|contributor| UsagePromptContributor {
-                contributor,
-                source_estimated_tokens,
-            })
-            .collect(),
-    )
 }
 
 fn skill_contributor(item: &ResponseItem) -> Option<UsagePromptContributor> {

--- a/codex-rs/core/tests/common/responses.rs
+++ b/codex-rs/core/tests/common/responses.rs
@@ -664,6 +664,27 @@ pub fn ev_completed_with_tokens(id: &str, total_tokens: i64) -> Value {
     })
 }
 
+pub fn ev_completed_with_usage(
+    id: &str,
+    input_tokens: i64,
+    cached_input_tokens: i64,
+    output_tokens: i64,
+) -> Value {
+    serde_json::json!({
+        "type": "response.completed",
+        "response": {
+            "id": id,
+            "usage": {
+                "input_tokens": input_tokens,
+                "input_tokens_details": { "cached_tokens": cached_input_tokens },
+                "output_tokens": output_tokens,
+                "output_tokens_details": null,
+                "total_tokens": input_tokens + output_tokens
+            }
+        }
+    })
+}
+
 /// Convenience: SSE event for a single assistant message output item.
 pub fn ev_assistant_message(id: &str, text: &str) -> Value {
     serde_json::json!({

--- a/codex-rs/core/tests/suite/sqlite_state.rs
+++ b/codex-rs/core/tests/suite/sqlite_state.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
 use codex_config::types::McpServerConfig;
 use codex_config::types::McpServerTransportConfig;
+use codex_exec_server::CreateDirectoryOptions;
+use codex_exec_server::ExecutorFileSystem;
 use codex_features::Feature;
 use codex_protocol::ThreadId;
 use codex_protocol::dynamic_tools::DynamicToolSpec;
@@ -15,6 +17,7 @@ use codex_protocol::protocol::SessionMetaLine;
 use codex_protocol::protocol::SessionSource;
 use codex_protocol::protocol::UserMessageEvent;
 use codex_protocol::user_input::UserInput;
+use codex_utils_absolute_path::AbsolutePathBuf;
 use core_test_support::responses;
 use core_test_support::responses::ev_completed;
 use core_test_support::responses::ev_function_call;
@@ -33,9 +36,30 @@ use pretty_assertions::assert_eq;
 use serde_json::json;
 use std::collections::HashMap;
 use std::fs;
+use std::sync::Arc;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
 use tokio::time::Duration;
 use tracing_subscriber::prelude::*;
 use uuid::Uuid;
+
+async fn write_usage_skill(cwd: AbsolutePathBuf, fs: Arc<dyn ExecutorFileSystem>) -> Result<()> {
+    let skill_dir = cwd.join(".agents").join("skills").join("usage-e2e");
+    fs.create_directory(
+        &skill_dir,
+        CreateDirectoryOptions { recursive: true },
+        /*sandbox*/ None,
+    )
+    .await?;
+    fs.write_file(
+        &skill_dir.join("SKILL.md"),
+        b"---\nname: usage-e2e\ndescription: usage metric test\n---\n\nUse the rmcp echo tool.\n"
+            .to_vec(),
+        /*sandbox*/ None,
+    )
+    .await?;
+    Ok(())
+}
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn new_thread_is_recorded_in_state_db() -> Result<()> {
@@ -513,6 +537,164 @@ async fn mcp_call_marks_thread_memory_mode_polluted_when_configured() -> Result<
     }
 
     assert_eq!(memory_mode.as_deref(), Some("polluted"));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn usage_records_blended_tokens_for_skill_and_mcp_context() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let call_id = "call-usage";
+    let server_name = "rmcp";
+    let namespace = format!("mcp__{server_name}");
+    mount_sse_once(
+        &server,
+        responses::sse(vec![
+            ev_response_created("resp-usage-1"),
+            responses::ev_function_call_with_namespace(
+                call_id,
+                &namespace,
+                "echo",
+                "{\"message\":\"ping\"}",
+            ),
+            responses::ev_completed_with_usage(
+                "resp-usage-1",
+                /*input_tokens*/ 1_200,
+                /*cached_input_tokens*/ 200,
+                /*output_tokens*/ 100,
+            ),
+        ]),
+    )
+    .await;
+    mount_sse_once(
+        &server,
+        responses::sse(vec![
+            responses::ev_assistant_message("msg-usage", "rmcp echo tool completed."),
+            responses::ev_completed_with_usage(
+                "resp-usage-2",
+                /*input_tokens*/ 1_400,
+                /*cached_input_tokens*/ 1_000,
+                /*output_tokens*/ 80,
+            ),
+        ]),
+    )
+    .await;
+
+    let rmcp_test_server_bin = stdio_server_bin()?;
+    let mut builder = test_codex()
+        .with_workspace_setup(|cwd, fs| async move { write_usage_skill(cwd, fs).await })
+        .with_config(move |config| {
+            config
+                .features
+                .enable(Feature::Sqlite)
+                .expect("test config should allow feature update");
+
+            let mut servers = config.mcp_servers.get().clone();
+            servers.insert(
+                server_name.to_string(),
+                McpServerConfig {
+                    transport: McpServerTransportConfig::Stdio {
+                        command: rmcp_test_server_bin,
+                        args: Vec::new(),
+                        env: Some(HashMap::from([(
+                            "MCP_TEST_VALUE".to_string(),
+                            "propagated-env".to_string(),
+                        )])),
+                        env_vars: Vec::new(),
+                        cwd: None,
+                    },
+                    environment_id: "local".to_string(),
+                    enabled: true,
+                    required: false,
+                    supports_parallel_tool_calls: false,
+                    disabled_reason: None,
+                    startup_timeout_sec: Some(Duration::from_secs(10)),
+                    tool_timeout_sec: None,
+                    default_tools_approval_mode: None,
+                    enabled_tools: None,
+                    disabled_tools: None,
+                    scopes: None,
+                    oauth: None,
+                    oauth_resource: None,
+                    tools: HashMap::new(),
+                },
+            );
+            config
+                .mcp_servers
+                .set(servers)
+                .expect("test mcp servers should accept any configuration");
+        });
+    let test = builder.build(&server).await?;
+    let db = test.codex.state_db().expect("state db enabled");
+    let cwd = test.cwd_path().to_path_buf();
+    let skill_path = cwd
+        .join(".agents/skills/usage-e2e/SKILL.md")
+        .canonicalize()
+        .unwrap_or_else(|_| cwd.join(".agents/skills/usage-e2e/SKILL.md"))
+        .to_path_buf();
+    let (sandbox_policy, permission_profile) =
+        turn_permission_fields(PermissionProfile::read_only(), cwd.as_path());
+
+    test.codex
+        .submit(Op::UserInput {
+            items: vec![
+                UserInput::Text {
+                    text: "use $usage-e2e and call the rmcp echo tool".to_string(),
+                    text_elements: Vec::new(),
+                },
+                UserInput::Skill {
+                    name: "usage-e2e".to_string(),
+                    path: skill_path.clone(),
+                },
+            ],
+            environments: None,
+            final_output_json_schema: None,
+            responsesapi_client_metadata: None,
+            additional_context: Default::default(),
+            thread_settings: codex_protocol::protocol::ThreadSettingsOverrides {
+                cwd: Some(cwd),
+                approval_policy: Some(AskForApproval::Never),
+                sandbox_policy: Some(sandbox_policy),
+                permission_profile,
+                collaboration_mode: Some(codex_protocol::config_types::CollaborationMode {
+                    mode: codex_protocol::config_types::ModeKind::Default,
+                    settings: codex_protocol::config_types::Settings {
+                        model: test.session_configured.model.clone(),
+                        reasoning_effort: None,
+                        developer_instructions: None,
+                    },
+                }),
+                ..Default::default()
+            },
+        })
+        .await?;
+    wait_for_event(&test.codex, |event| {
+        matches!(event, EventMsg::McpToolCallEnd(_))
+    })
+    .await;
+    wait_for_event_match(&test.codex, |event| match event {
+        EventMsg::Error(err) => Some(Err(anyhow::anyhow!(err.message.clone()))),
+        EventMsg::TurnComplete(_) => Some(Ok(())),
+        _ => None,
+    })
+    .await?;
+
+    let now = i64::try_from(SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs())? + 1;
+    let report = db
+        .read_usage_report(codex_state::UsageRange::Day, now)
+        .await?;
+
+    assert_eq!(report.total_tokens, 1_580);
+    assert!(report.tracked_from.is_some());
+    assert_eq!(report.skills.len(), 1);
+    assert_eq!(report.skills[0].label, "usage-e2e");
+    assert_eq!(report.skills[0].id, skill_path.to_string_lossy());
+    assert!(report.skills[0].attributed_tokens > 0);
+    assert_eq!(report.mcp_servers.len(), 1);
+    assert_eq!(report.mcp_servers[0].label, server_name);
+    assert!(report.mcp_servers[0].attributed_tokens > 0);
+
     Ok(())
 }
 


### PR DESCRIPTION
## Why

The storage layer needs real contributor samples before any report can be useful. This PR records the prompt/tool provenance needed to explain which local features consumed tokens.

## What Changed

- Tracks prompt attribution for skills, model-visible tools, tool results, apps, MCP servers, and plugins.
- Persists completed response token usage into the local usage storage layer.
- Keeps attribution out of rollout files.

## How to Test

Targeted tests:
- `cargo test -p codex-core usage`

## Stack

1. [#24121](https://github.com/openai/codex/pull/24121) - Usage storage
2. [#24122](https://github.com/openai/codex/pull/24122) - Usage attribution (this PR)
3. [#24123](https://github.com/openai/codex/pull/24123) - App-server usage API
4. [#24124](https://github.com/openai/codex/pull/24124) - TUI `/usage` command
