### PR TITLE
[codex-analytics] split compaction v2 analytics implementation

### DIFF
--- a/codex-rs/analytics/src/analytics_client_tests.rs
+++ b/codex-rs/analytics/src/analytics_client_tests.rs
@@ -1263,6 +1263,14 @@ fn compaction_event_serializes_expected_shape() {
 }
 
 #[test]
+fn compaction_implementation_serializes_remote_v2() {
+    let payload = serde_json::to_value(CompactionImplementation::ResponsesCompactionV2)
+        .expect("serialize compaction implementation");
+
+    assert_eq!(payload, json!("responses_compaction_v2"));
+}
+
+#[test]
 fn app_used_dedupe_is_keyed_by_turn_and_connector() {
     let (sender, _receiver) = mpsc::channel(1);
     let queue = AnalyticsEventsQueue {

--- a/codex-rs/analytics/src/facts.rs
+++ b/codex-rs/analytics/src/facts.rs
@@ -229,6 +229,7 @@ pub enum CompactionReason {
 #[serde(rename_all = "snake_case")]
 pub enum CompactionImplementation {
     Responses,
+    ResponsesCompactionV2,
     ResponsesCompact,
 }
 

--- a/codex-rs/core/src/compact_remote_v2.rs
+++ b/codex-rs/core/src/compact_remote_v2.rs
@@ -111,7 +111,7 @@ async fn run_remote_compact_task_inner(
         turn_context.as_ref(),
         trigger,
         reason,
-        CompactionImplementation::Responses,
+        CompactionImplementation::ResponsesCompactionV2,
         phase,
     )
     .await;


### PR DESCRIPTION
## What changed

- Add a distinct `responses_compaction_v2` value for `CodexCompactionEvent.implementation`.
- Emit that value from the remote compaction v2 path.
- Keep local compaction as `responses` and legacy `/responses/compact` as `responses_compact`.

## Why

Remote compaction v2 and local prompt-based compaction were both reported as `responses`, which made the analytics table collapse two different compaction mechanisms into one implementation bucket.

## Validation

- `just fmt`
- `just test -p codex-analytics`

`just test -p codex-core` was started locally, but this PR is intentionally being pushed for CI to finish the remaining validation.