### PR TITLE
Add Agent matcher alias for spawn_agent hooks

### DIFF
--- a/codex-rs/core/src/tools/hook_names.rs
+++ b/codex-rs/core/src/tools/hook_names.rs
@@ -38,6 +38,18 @@ impl HookToolName {
         }
     }
 
+    /// Returns the hook identity for spawning sub-agents.
+    ///
+    /// The serialized name remains `spawn_agent`, while `Agent` is accepted as
+    /// a matcher alias for compatibility with hook configurations that describe
+    /// sub-agent creation using Claude Code-style names.
+    pub(crate) fn spawn_agent() -> Self {
+        Self {
+            name: "spawn_agent".to_string(),
+            matcher_aliases: vec!["Agent".to_string()],
+        }
+    }
+
     /// Returns the hook identity historically used for shell-like tools.
     pub(crate) fn bash() -> Self {
         Self::new("Bash")

--- a/codex-rs/core/src/tools/registry.rs
+++ b/codex-rs/core/src/tools/registry.rs
@@ -19,6 +19,7 @@ use crate::tools::context::ToolInvocation;
 use crate::tools::context::ToolOutput;
 use crate::tools::context::ToolPayload;
 use crate::tools::flat_tool_name;
+use crate::tools::handlers::multi_agents_spec::MULTI_AGENT_V1_NAMESPACE;
 use crate::tools::hook_names::HookToolName;
 use crate::tools::lifecycle::notify_tool_finish;
 use crate::tools::lifecycle::notify_tool_start;
@@ -672,6 +673,15 @@ async fn handle_any_tool(
 }
 
 fn function_hook_tool_name(invocation: &ToolInvocation) -> HookToolName {
+    if invocation.tool_name.name == "spawn_agent"
+        && matches!(
+            invocation.tool_name.namespace.as_deref(),
+            None | Some(MULTI_AGENT_V1_NAMESPACE)
+        )
+    {
+        return HookToolName::spawn_agent();
+    }
+
     HookToolName::new(flat_tool_name(&invocation.tool_name).into_owned())
 }
 

--- a/codex-rs/core/src/tools/registry_tests.rs
+++ b/codex-rs/core/src/tools/registry_tests.rs
@@ -242,6 +242,46 @@ async fn function_hook_input_defaults_empty_arguments_to_object() {
 }
 
 #[tokio::test]
+async fn spawn_agent_function_tools_use_agent_matcher_alias() {
+    let (session, turn) = crate::session::tests::make_session_and_context().await;
+    let session = Arc::new(session);
+    let turn = Arc::new(turn);
+
+    let hook_payloads = [
+        codex_tools::ToolName::plain("spawn_agent"),
+        codex_tools::ToolName::namespaced(MULTI_AGENT_V1_NAMESPACE, "spawn_agent"),
+    ]
+    .into_iter()
+    .map(|tool_name| {
+        let handler = TestHandler {
+            tool_name: tool_name.clone(),
+        };
+        let invocation = ToolInvocation {
+            payload: ToolPayload::Function {
+                arguments: serde_json::json!({ "message": "inspect this repo" }).to_string(),
+            },
+            ..test_invocation(Arc::clone(&session), Arc::clone(&turn), "call-1", tool_name)
+        };
+        handler.pre_tool_use_payload(&invocation)
+    })
+    .collect::<Vec<_>>();
+
+    assert_eq!(
+        hook_payloads,
+        vec![
+            Some(PreToolUsePayload {
+                tool_name: HookToolName::spawn_agent(),
+                tool_input: serde_json::json!({ "message": "inspect this repo" }),
+            }),
+            Some(PreToolUsePayload {
+                tool_name: HookToolName::spawn_agent(),
+                tool_input: serde_json::json!({ "message": "inspect this repo" }),
+            }),
+        ]
+    );
+}
+
+#[tokio::test]
 async fn code_mode_wait_does_not_expose_default_hook_payloads() {
     let (session, turn) = crate::session::tests::make_session_and_context().await;
     let output = crate::tools::context::FunctionToolOutput::from_text("ok".to_string(), Some(true));


### PR DESCRIPTION
# Why

`#23757` defaults function tools into tool hooks, but sub-agent spawning has one compatibility wrinkle: hook configs may refer to that tool as `Agent`.

This keeps the hook payload's canonical tool name as `spawn_agent` while accepting `Agent` as a matcher alias for the built-in plain and v1 namespaced spawn-agent tool surfaces.

# What

- Add `HookToolName::spawn_agent()` with `Agent` as a matcher alias.
- Normalize only the built-in `spawn_agent` function tools onto that hook identity.
- Add focused coverage for both plain and v1 namespaced `spawn_agent`.

Validation:

- `just fmt`
- `cargo test -p codex-core spawn_agent_function_tools_use_agent_matcher_alias`

Note: `cargo test -p codex-core` built successfully but aborted in unrelated existing coverage with a stack overflow in `mcp_tool_call::tests::guardian_mode_mcp_denial_returns_rationale_message`.
