### PR TITLE
release: build macOS x64 zsh artifact

### DIFF
--- a/.github/dotslash-zsh-config.json
+++ b/.github/dotslash-zsh-config.json
@@ -7,6 +7,11 @@
           "format": "tar.gz",
           "path": "codex-zsh/bin/zsh"
         },
+        "macos-x86_64": {
+          "name": "codex-zsh-x86_64-apple-darwin.tar.gz",
+          "format": "tar.gz",
+          "path": "codex-zsh/bin/zsh"
+        },
         "linux-x86_64": {
           "name": "codex-zsh-x86_64-unknown-linux-musl.tar.gz",
           "format": "tar.gz",

--- a/.github/workflows/rust-release-zsh.yml
+++ b/.github/workflows/rust-release-zsh.yml
@@ -69,6 +69,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - runner: macos-15-large
+            target: x86_64-apple-darwin
+            variant: macos-15
+            archive_name: codex-zsh-x86_64-apple-darwin.tar.gz
           - runner: macos-15-xlarge
             target: aarch64-apple-darwin
             variant: macos-15


### PR DESCRIPTION
## Why

The zsh release workflow currently publishes macOS arm64 and Linux zsh fork artifacts, but no macOS x64 artifact. That leaves `x86_64-apple-darwin` Codex packages without a bundled `codex-resources/zsh/bin/zsh`, so `shell_zsh_fork` cannot be enabled from the package layout on macOS x64.

## What Changed

- Added an `x86_64-apple-darwin` row to the macOS zsh release matrix.
- Runs that row on `macos-15-large`, the Intel macOS runner appropriate for the native zsh build.
- Added the matching `macos-x86_64` platform to `.github/dotslash-zsh-config.json` so the generated DotSlash release manifest can reference the new tarball.

## Testing

- `ruby -e "require \"yaml\"; YAML.load_file(\".github/workflows/rust-release-zsh.yml\"); puts \"ok\""`
- `python3 -m json.tool .github/dotslash-zsh-config.json`