### PR TITLE
release: build macOS x64 zsh artifact

### DIFF
--- a/.github/dotslash-zsh-config.json
+++ b/.github/dotslash-zsh-config.json
@@ -7,6 +7,11 @@
           "format": "tar.gz",
           "path": "codex-zsh/bin/zsh"
         },
+        "macos-x86_64": {
+          "name": "codex-zsh-x86_64-apple-darwin.tar.gz",
+          "format": "tar.gz",
+          "path": "codex-zsh/bin/zsh"
+        },
         "linux-x86_64": {
           "name": "codex-zsh-x86_64-unknown-linux-musl.tar.gz",
           "format": "tar.gz",

--- a/.github/workflows/rust-release-zsh.yml
+++ b/.github/workflows/rust-release-zsh.yml
@@ -69,6 +69,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - runner: macos-15-large
+            target: x86_64-apple-darwin
+            variant: macos-15
+            archive_name: codex-zsh-x86_64-apple-darwin.tar.gz
           - runner: macos-15-xlarge
             target: aarch64-apple-darwin
             variant: macos-15


### PR DESCRIPTION
## Why

The zsh release workflow currently publishes macOS arm64 and Linux zsh fork artifacts, but no macOS x64 artifact. The Codex package builder therefore cannot include codex-resources/zsh/bin/zsh for x86_64-apple-darwin packages.

## What Changed

- Added an x86_64-apple-darwin row to the macOS zsh release matrix.
- Runs that row on macos-15-large, the Intel macOS runner appropriate for the native zsh build.
- Added the matching macos-x86_64 platform to the zsh DotSlash publish config so the generated release manifest can reference the new tarball.
