### PR TITLE
package: add x64 macOS codex-zsh artifact

### DIFF
--- a/scripts/codex_package/codex-zsh
+++ b/scripts/codex_package/codex-zsh
@@ -6,36 +6,48 @@
     "macos-aarch64": {
       "size": 358776,
       "hash": "sha256",
-      "digest": "c6dbb063a0135b947ab1cacc655b2b750874699472f412ec7daba97543a90c3c",
+      "digest": "49dec9832379688c9090666694a3449502ac5ebd4d76b9ffde1d0999cd088205",
       "format": "tar.gz",
       "path": "codex-zsh/bin/zsh",
       "providers": [
         {
-          "url": "https://github.com/openai/codex/releases/download/rust-v0.132.0/codex-zsh-aarch64-apple-darwin.tar.gz"
+          "url": "https://github.com/openai/codex/releases/download/rust-v0.134.0-alpha.3/codex-zsh-aarch64-apple-darwin.tar.gz"
+        }
+      ]
+    },
+    "macos-x86_64": {
+      "size": 391161,
+      "hash": "sha256",
+      "digest": "0246fd4703bb540ae74f13ec739ca365ebd607df44a1f21e335eb7a421352923",
+      "format": "tar.gz",
+      "path": "codex-zsh/bin/zsh",
+      "providers": [
+        {
+          "url": "https://github.com/openai/codex/releases/download/rust-v0.134.0-alpha.3/codex-zsh-x86_64-apple-darwin.tar.gz"
         }
       ]
     },
     "linux-x86_64": {
-      "size": 433413,
+      "size": 433412,
       "hash": "sha256",
-      "digest": "5f42d9fc8e9c8c399a727512002906006ae9de966ea7b3d87ca36b47efc59938",
+      "digest": "e7f760998c9644448d2cb8a821084a0134d6820c14b284bd7f39d7f32262ad40",
       "format": "tar.gz",
       "path": "codex-zsh/bin/zsh",
       "providers": [
         {
-          "url": "https://github.com/openai/codex/releases/download/rust-v0.132.0/codex-zsh-x86_64-unknown-linux-musl.tar.gz"
+          "url": "https://github.com/openai/codex/releases/download/rust-v0.134.0-alpha.3/codex-zsh-x86_64-unknown-linux-musl.tar.gz"
         }
       ]
     },
     "linux-aarch64": {
-      "size": 411653,
+      "size": 411655,
       "hash": "sha256",
-      "digest": "6c6e32c297425db02b4dbffb10925895875d14647fc3eb2f18767be97dc6a945",
+      "digest": "8d50cff5dfabc97e37e1138513da022d9247a802c2ff996ab91654bf1892c7d5",
       "format": "tar.gz",
       "path": "codex-zsh/bin/zsh",
       "providers": [
         {
-          "url": "https://github.com/openai/codex/releases/download/rust-v0.132.0/codex-zsh-aarch64-unknown-linux-musl.tar.gz"
+          "url": "https://github.com/openai/codex/releases/download/rust-v0.134.0-alpha.3/codex-zsh-aarch64-unknown-linux-musl.tar.gz"
         }
       ]
     }


### PR DESCRIPTION
## Why

The package builder has an Intel macOS release target (`x86_64-apple-darwin`) whose DotSlash platform is `macos-x86_64`, but `scripts/codex_package/codex-zsh` only listed Apple Silicon macOS plus Linux platforms. Because zsh is fetched with `missing_ok=True`, Intel macOS packages could miss the patched zsh resource instead of resolving a prebuilt artifact.

The `rust-v0.134.0-alpha.3` release now publishes `codex-zsh-x86_64-apple-darwin.tar.gz`, so the manifest can cover that platform. See the release assets in https://github.com/openai/codex/releases/tag/rust-v0.134.0-alpha.3 and the completed release job at https://github.com/openai/codex/actions/runs/26319528477/job/77485808896.

Relevant existing mappings:

- `x86_64-apple-darwin` maps to `macos-x86_64`: https://github.com/openai/codex/blob/main/scripts/codex_package/targets.py#L88-L93
- zsh resources are resolved from `scripts/codex_package/codex-zsh`: https://github.com/openai/codex/blob/main/scripts/codex_package/zsh.py#L14-L22

## What Changed

- Updated existing `codex-zsh` DotSlash entries to `rust-v0.134.0-alpha.3` release URLs and refreshed their size and SHA-256 metadata.
- Added a `macos-x86_64` entry for `codex-zsh-x86_64-apple-darwin.tar.gz`.

## Verification

- Downloaded the four `codex-zsh-*.tar.gz` release assets from `rust-v0.134.0-alpha.3`, computed their `wc -c` sizes and `shasum -a 256` digests, and verified each archive contains `codex-zsh/bin/zsh`.
- `python3 -m unittest discover -s scripts/codex_package -p 'test_*.py'`