### PR TITLE
tui: label compact rate-limit percentages

### DIFF
--- a/codex-rs/tui/src/bottom_pane/status_line_setup.rs
+++ b/codex-rs/tui/src/bottom_pane/status_line_setup.rs
@@ -638,7 +638,7 @@ mod tests {
                 ),
                 (
                     StatusLineItem::WeeklyLimit.preview_item(),
-                    "weekly 82%".to_string(),
+                    "weekly 82% left".to_string(),
                 ),
             ]),
             AppEventSender::new(tx_raw),

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__status_line_setup_popup_rate_limits.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__status_line_setup_popup_rate_limits.snap
@@ -16,5 +16,5 @@ expression: status_line_popup_snapshot(&mut chat)
   [ ] current-dir           Current working directory
   [ ] project-name          Project name (omitted when unavailable)
 
-  monthly 65% · weekly 50%
+  monthly 65% left · weekly 50% left
   Press space to toggle; ←/→ to move; enter to confirm and close; esc to close

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__status_surface_previews_rate_limits.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__status_surface_previews_rate_limits.snap
@@ -2,5 +2,5 @@
 source: tui/src/chatwidget/tests/status_surface_previews.rs
 expression: snapshot
 ---
-status line: monthly 65% · weekly 50%
-terminal title: monthly 65% | weekly 50%
+status line: monthly 65% left · weekly 50% left
+terminal title: monthly 65% left | weekly 50% left

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__terminal_title_setup_popup_rate_limits.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__terminal_title_setup_popup_rate_limits.snap
@@ -16,5 +16,5 @@ expression: terminal_title_popup_snapshot(&mut chat)
   [ ] run-state      Compact session run-state text (Ready, Working, Thinking)
   [ ] thread-title   Current thread title, or thread identifier when unnamed
 
-  monthly 65% | weekly 50%
+  monthly 65% left | weekly 50% left
   Press space to toggle; ←/→ to move; enter to confirm and close; esc to close

--- a/codex-rs/tui/src/chatwidget/status_controls.rs
+++ b/codex-rs/tui/src/chatwidget/status_controls.rs
@@ -377,7 +377,7 @@ impl ChatWidget {
     ) -> Option<String> {
         let window = window?;
         let remaining = (100.0f64 - window.used_percent).clamp(0.0f64, 100.0f64);
-        Some(format!("{label} {remaining:.0}%"))
+        Some(format!("{label} {remaining:.0}% left"))
     }
 
     pub(super) fn status_line_reasoning_effort_label(

--- a/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
+++ b/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
@@ -586,7 +586,7 @@ async fn status_line_uses_secondary_fallback_for_unsupported_window() {
 
     assert_eq!(
         chat.status_line_value_for_item(crate::bottom_pane::StatusLineItem::WeeklyLimit),
-        Some("secondary usage 50%".to_string())
+        Some("secondary usage 50% left".to_string())
     );
 }
 
@@ -614,11 +614,11 @@ async fn status_line_legacy_limit_items_prefer_matching_windows() {
 
     assert_eq!(
         chat.status_line_value_for_item(crate::bottom_pane::StatusLineItem::FiveHourLimit),
-        Some("5h 60%".to_string())
+        Some("5h 60% left".to_string())
     );
     assert_eq!(
         chat.status_line_value_for_item(crate::bottom_pane::StatusLineItem::WeeklyLimit),
-        Some("weekly 6%".to_string())
+        Some("weekly 6% left".to_string())
     );
 }
 
@@ -646,11 +646,11 @@ async fn status_line_shows_secondary_non_weekly_when_primary_is_weekly() {
 
     assert_eq!(
         chat.status_line_value_for_item(crate::bottom_pane::StatusLineItem::FiveHourLimit),
-        Some("monthly 65%".to_string())
+        Some("monthly 65% left".to_string())
     );
     assert_eq!(
         chat.status_line_value_for_item(crate::bottom_pane::StatusLineItem::WeeklyLimit),
-        Some("weekly 6%".to_string())
+        Some("weekly 6% left".to_string())
     );
 }
 
@@ -678,7 +678,7 @@ async fn status_line_five_hour_item_omits_weekly_only_limit() {
     );
     assert_eq!(
         chat.status_line_value_for_item(crate::bottom_pane::StatusLineItem::WeeklyLimit),
-        Some("weekly 91%".to_string())
+        Some("weekly 91% left".to_string())
     );
 }
 
@@ -702,7 +702,7 @@ async fn status_line_single_monthly_primary_omits_weekly_limit_item() {
 
     assert_eq!(
         chat.status_line_value_for_item(crate::bottom_pane::StatusLineItem::FiveHourLimit),
-        Some("monthly 65%".to_string())
+        Some("monthly 65% left".to_string())
     );
     assert_eq!(
         chat.status_line_value_for_item(crate::bottom_pane::StatusLineItem::WeeklyLimit),
@@ -734,7 +734,7 @@ async fn status_line_secondary_only_non_weekly_limit_omits_primary_limit_item() 
     );
     assert_eq!(
         chat.status_line_value_for_item(crate::bottom_pane::StatusLineItem::WeeklyLimit),
-        Some("monthly 65%".to_string())
+        Some("monthly 65% left".to_string())
     );
 }
 

--- a/codex-rs/tui/src/chatwidget/tests/status_surface_previews.rs
+++ b/codex-rs/tui/src/chatwidget/tests/status_surface_previews.rs
@@ -246,7 +246,7 @@ async fn status_surface_preview_omits_unavailable_rate_limit_items() {
             &mut chat,
             &[StatusLineItem::FiveHourLimit, StatusLineItem::WeeklyLimit]
         ),
-        "weekly 91%"
+        "weekly 91% left"
     );
     assert_eq!(
         title_preview_line(
@@ -256,7 +256,7 @@ async fn status_surface_preview_omits_unavailable_rate_limit_items() {
                 TerminalTitleItem::WeeklyLimit
             ],
         ),
-        "weekly 91%"
+        "weekly 91% left"
     );
 }
 


### PR DESCRIPTION
## Summary

The compact TUI status line already renders rate-limit percentages as remaining capacity, but the text did not say so. That made high-usage red indicators ambiguous because values like `weekly 6%` could be read as either used or remaining.

This PR labels the compact rate-limit values explicitly as `left` across the status line, terminal title, and setup previews.

Addresses #24274