### PR TITLE
Avoid repeated marketplace upgrades for alternate layouts

### DIFF
--- a/codex-rs/core-plugins/src/marketplace.rs
+++ b/codex-rs/core-plugins/src/marketplace.rs
@@ -531,10 +531,7 @@ fn resolve_local_plugin_source_path(
         });
     };
     if path.is_empty() {
-        return Err(MarketplaceError::InvalidMarketplaceFile {
-            path: marketplace_path.to_path_buf(),
-            message: "local plugin source path must not be empty".to_string(),
-        });
+        return marketplace_root_dir(marketplace_path);
     }
 
     let relative_source_path = Path::new(path);

--- a/codex-rs/core-plugins/src/marketplace_tests.rs
+++ b/codex-rs/core-plugins/src/marketplace_tests.rs
@@ -113,6 +113,63 @@ fn find_marketplace_plugin_supports_alternate_layout_and_string_local_source() {
 }
 
 #[test]
+fn find_marketplace_plugin_supports_marketplace_root_local_source() {
+    let tmp = tempdir().unwrap();
+    let repo_root = tmp.path().join("repo");
+    fs::create_dir_all(repo_root.join(".git")).unwrap();
+    let marketplace_path = write_alternate_marketplace(
+        &repo_root,
+        r#"{
+  "name": "alternate-marketplace",
+  "plugins": [
+    {
+      "name": "root-plugin",
+      "source": "./"
+    }
+  ]
+}"#,
+    );
+    write_alternate_plugin_manifest(
+        &repo_root,
+        r#"{
+  "name": "root-plugin",
+  "version": "1.2.3",
+  "interface": {
+    "displayName": "Root Plugin"
+  }
+}"#,
+    );
+
+    let expected_path = AbsolutePathBuf::try_from(repo_root).unwrap();
+    let expected_manifest = load_plugin_manifest(expected_path.as_path());
+    let resolved = find_marketplace_plugin(&marketplace_path, "root-plugin").unwrap();
+
+    assert_eq!(
+        resolved,
+        ResolvedMarketplacePlugin {
+            plugin_id: PluginId::new(
+                "root-plugin".to_string(),
+                "alternate-marketplace".to_string()
+            )
+            .unwrap(),
+            source: MarketplacePluginSource::Local {
+                path: expected_path,
+            },
+            policy: MarketplacePluginPolicy {
+                installation: MarketplacePluginInstallPolicy::Available,
+                authentication: MarketplacePluginAuthPolicy::OnInstall,
+                products: None,
+            },
+            interface: Some(PluginManifestInterface {
+                display_name: Some("Root Plugin".to_string()),
+                ..Default::default()
+            }),
+            manifest: expected_manifest,
+        }
+    );
+}
+
+#[test]
 fn find_marketplace_plugin_supports_git_subdir_sources() {
     let tmp = tempdir().unwrap();
     let repo_root = tmp.path().join("repo");


### PR DESCRIPTION
Fixes #24249.

## Why

Codex already supports discovering marketplaces under both `.agents/plugins/marketplace.json` and `.claude-plugin/marketplace.json`. The Git marketplace auto-upgrade no-op check only looked for the `.agents` layout, though. That meant an installed `.claude-plugin` marketplace with matching revision metadata still looked absent, so plugin list/startup upgrade work could stage and re-activate the same marketplace again. In #24249, that repeated upgrade path lined up with a malformed `source: "./"` plugin entry and produced the observed marketplace sync churn.

## What changed

- `codex-rs/core-plugins/src/marketplace_upgrade.rs` now uses the existing supported marketplace manifest discovery helper when deciding whether an installed Git marketplace is already current.
- Existing local plugin source validation is unchanged; `source: "./"` still remains invalid.

## Verification

- `just test -p codex-core-plugins`
