### PR TITLE
Avoid repeated marketplace upgrades for alternate layouts

### DIFF
--- a/codex-rs/core-plugins/src/marketplace_upgrade.rs
+++ b/codex-rs/core-plugins/src/marketplace_upgrade.rs
@@ -6,6 +6,7 @@ use self::activation::installed_marketplace_metadata_matches;
 use self::activation::write_installed_marketplace_metadata;
 use self::git::clone_git_source;
 use self::git::git_remote_revision;
+use crate::marketplace::find_marketplace_manifest_path;
 use crate::marketplace::validate_marketplace_root;
 use codex_config::CONFIG_TOML_FILE;
 use codex_config::ConfigLayerStack;
@@ -176,9 +177,7 @@ fn upgrade_configured_git_marketplace(
         MARKETPLACE_UPGRADE_GIT_TIMEOUT,
     )?;
     let destination = install_root.join(&marketplace.name);
-    if destination
-        .join(".agents/plugins/marketplace.json")
-        .is_file()
+    if find_marketplace_manifest_path(&destination).is_some()
         && marketplace.last_revision.as_deref() == Some(remote_revision.as_str())
         && installed_marketplace_metadata_matches(&destination, marketplace, &remote_revision)
     {


### PR DESCRIPTION
Fixes #24249.

## Why

Codex already supports discovering marketplaces under both `.agents/plugins/marketplace.json` and `.claude-plugin/marketplace.json`. The Git marketplace auto-upgrade no-op check only looked for the `.agents` layout. That meant an installed `.claude-plugin` marketplace with matching revision metadata still looked absent, so plugin list/startup upgrade work could stage and re-activate the same marketplace again.

That matches the failure shape in #24249: the report called out repeated marketplace sync/cache refresh logs and a large recently-touched `.tmp/marketplaces/.staging` directory. This change makes the auto-upgrade path recognize the installed `.claude-plugin` marketplace as already current, which should remove that staging/activation feedback loop.

## What changed

`codex-rs/core-plugins/src/marketplace_upgrade.rs` now uses the existing supported marketplace manifest discovery helper when deciding whether an installed Git marketplace is already current. Existing local plugin source validation is unchanged; `source: "./"` still remains invalid.

## Confidence

Confidence is high that this fixes the repeated marketplace upgrade path: the old hardcoded layout check was definitely wrong for installed `.claude-plugin` marketplaces, and the reported staging churn points directly at that path.

Confidence is not 100% because we do not have a CPU profile or a fully re-run reporter repro. A malformed marketplace entry can still be logged as invalid if another caller repeatedly lists plugins; this PR fixes the staging/upgrade feedback loop that likely made the failure pathological, not every possible source of repeated marketplace resolution.
