### PR TITLE
Nudge users toward auto-compaction

### DIFF
--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -288,7 +288,7 @@ async fn run_compact_task_inner_impl(
     sess.emit_turn_item_completed(&turn_context, compaction_item)
         .await;
     let warning = EventMsg::Warning(WarningEvent {
-        message: "Heads up: Long threads and multiple compactions can cause the model to be less accurate. Start a new thread when possible to keep threads small and targeted.".to_string(),
+        message: "Heads up: Codex automatically compacts long conversations".to_string(),
     });
     sess.send_event(&turn_context, warning).await;
     Ok(summary_suffix)

--- a/codex-rs/core/tests/suite/compact.rs
+++ b/codex-rs/core/tests/suite/compact.rs
@@ -76,7 +76,8 @@ const FUNCTION_CALL_LIMIT_MSG: &str = "function call limit push";
 const POST_AUTO_USER_MSG: &str = "post auto follow-up";
 const PRETURN_CONTEXT_DIFF_CWD: &str = "/tmp/PRETURN_CONTEXT_DIFF_CWD";
 
-pub(super) const COMPACT_WARNING_MESSAGE: &str = "Heads up: Long threads and multiple compactions can cause the model to be less accurate. Start a new thread when possible to keep threads small and targeted.";
+pub(super) const COMPACT_WARNING_MESSAGE: &str =
+    "Heads up: Codex automatically compacts long conversations";
 
 fn ev_shell_command_call(call_id: &str, command: &str) -> serde_json::Value {
     ev_function_call(

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -82,7 +82,9 @@ impl SlashCommand {
             SlashCommand::Feedback => "send logs to maintainers",
             SlashCommand::New => "start a new chat during a conversation",
             SlashCommand::Init => "create an AGENTS.md file with instructions for Codex",
-            SlashCommand::Compact => "summarize conversation to prevent hitting the context limit",
+            SlashCommand::Compact => {
+                "summarize conversation to prevent hitting the context limit, we recommend relying on auto-compaction"
+            }
             SlashCommand::Review => "review my current changes and find issues",
             SlashCommand::Rename => "rename the current thread",
             SlashCommand::Resume => "resume a saved chat",


### PR DESCRIPTION
Many users prefer to manually compact and there's often backlash when we hide things like current context window usage. I'm thinking it might be a good idea to nudge users in the opposite direction when they manually compact. Not actual friction but just reminders that our auto-compact is good.