### PR TITLE
fix(tui): avoid modifyOtherKeys for unknown tmux formats

### DIFF
--- a/codex-rs/tui/src/tui/keyboard_modes.rs
+++ b/codex-rs/tui/src/tui/keyboard_modes.rs
@@ -160,10 +160,10 @@ fn tmux_should_enable_modify_other_keys_for(
     running_in_tmux_session: bool,
     extended_keys_format: Option<&str>,
 ) -> bool {
-    // If tmux cannot be queried, still request mode 2; otherwise csi-u panes
-    // can stay in VT10x. Explicit xterm format is avoided because crossterm
-    // does not parse tmux's xterm-style extended-key sequences as Enter.
-    running_in_tmux_session && matches!(extended_keys_format, Some("csi-u") | None)
+    // Only request mode 2 when tmux confirms csi-u formatting. Older tmux
+    // versions do not expose this option and may emit xterm-style sequences,
+    // which crossterm does not parse consistently for modified keys.
+    running_in_tmux_session && matches!(extended_keys_format, Some("csi-u"))
 }
 
 fn read_tmux_extended_keys_format() -> Option<String> {
@@ -371,12 +371,12 @@ mod tests {
     }
 
     #[test]
-    fn tmux_modify_other_keys_requests_csi_u_or_unknown_format() {
+    fn tmux_modify_other_keys_only_requests_confirmed_csi_u_format() {
         assert!(tmux_should_enable_modify_other_keys_for(
             /*running_in_tmux_session*/ true,
             Some("csi-u")
         ));
-        assert!(tmux_should_enable_modify_other_keys_for(
+        assert!(!tmux_should_enable_modify_other_keys_for(
             /*running_in_tmux_session*/ true, /*extended_keys_format*/ None
         ));
         assert!(!tmux_should_enable_modify_other_keys_for(


### PR DESCRIPTION
## Why

Codex 0.131 started enabling tmux `modifyOtherKeys` mode 2 when the active tmux session reported `extended-keys-format csi-u`, and also when that format could not be queried. The fallback was meant to help compatible tmux panes enter extended-key mode, but it breaks iTerm2 control-mode sessions on older tmux.

Issue #23711 reproduces with:

```bash
ssh -t ubuntu@192.168.68.149 'tmux -CC new -A -s main'
```

On tmux 3.2a, `extended-keys-format` is not available. With mode 2 enabled, `Ctrl-C` is delivered as `^[[27;5;99~` instead of the normal interrupt/control key path, so Codex does not handle it. Running with `CODEX_TUI_DISABLE_KEYBOARD_ENHANCEMENT=1` restores `Ctrl-C`, which points at keyboard mode setup rather than chat input routing.

## What Changed

- Only request `modifyOtherKeys` mode 2 when tmux explicitly reports `extended-keys-format csi-u`.
- Treat an unknown or unavailable tmux extended-key format as unsupported for this mode.
- Update the keyboard mode unit coverage so `None` no longer opts into `modifyOtherKeys`.

This preserves the explicit modern tmux `csi-u` path from #21943 while avoiding the unsafe fallback on older or unqueryable tmux setups.

## How to Test

Regression path from #23711:

1. Start iTerm2 tmux integration against an older tmux host:
   ```bash
   ssh -t ubuntu@192.168.68.149 'tmux -CC new -A -s main'
   ```
2. Start patched Codex.
3. Run `/keymap debug`, press a regular key, then press `Ctrl-C`.
4. Confirm `Ctrl-C` closes the inspector and Codex remains responsive without `CODEX_TUI_DISABLE_KEYBOARD_ENHANCEMENT=1`.
5. Confirm `Shift+Enter` still inserts a newline in the same session.

Modern tmux compatibility path:

1. Start an ordinary tmux 3.6a server with explicit `csi-u`:
   ```bash
   tmux -L codex-csiu -f /dev/null new-session -d -s repro
   tmux -L codex-csiu set-option -g extended-keys on
   tmux -L codex-csiu set-option -g extended-keys-format csi-u
   tmux -L codex-csiu attach -t repro
   ```
2. Start patched Codex.
3. From another terminal, confirm the Codex pane reports `mode=Ext 2`:
   ```bash
   tmux -L codex-csiu list-panes -a -F '#{pane_id} mode=#{pane_key_mode} cmd=#{pane_current_command}'
   ```
4. Type `one`, press `Shift+Enter`, type `two`, and confirm the composer shows two lines without submitting.
5. Press `Ctrl-C` and confirm Codex handles it normally.

Targeted tests:

- `./tools/argument-comment-lint/run.py -p codex-tui -- --lib`
- `just test -p codex-tui` runs the new keyboard mode test successfully; the full run currently reports two unrelated guardian feature-flag test failures:
  - `app::tests::update_feature_flags_disabling_guardian_clears_manual_review_policy_without_history`
  - `app::tests::update_feature_flags_disabling_guardian_clears_review_policy_and_restores_default`

No documentation update is needed.