### PR TITLE
fix(process-hardening): preserve macos malloc diagnostics

### DIFF
--- a/codex-rs/process-hardening/README.md
+++ b/codex-rs/process-hardening/README.md
@@ -4,5 +4,4 @@ This crate provides `pre_main_hardening()`, which is designed to be called pre-`
 
 - disabling core dumps
 - disabling ptrace attach on Linux and macOS
-- removing dangerous or noisy environment variables such as `LD_PRELOAD`,
-  `DYLD_*`, and macOS malloc stack-logging controls
+- removing dangerous environment variables such as `LD_PRELOAD` and `DYLD_*`

--- a/codex-rs/process-hardening/src/lib.rs
+++ b/codex-rs/process-hardening/src/lib.rs
@@ -8,8 +8,7 @@ use std::os::unix::ffi::OsStrExt;
 /// various process hardening steps, such as
 /// - disabling core dumps
 /// - disabling ptrace attach on Linux and macOS.
-/// - removing dangerous or noisy environment variables such as LD_PRELOAD,
-///   DYLD_*, and macOS malloc stack-logging controls
+/// - removing dangerous environment variables such as LD_PRELOAD and DYLD_*
 pub fn pre_main_hardening() {
     #[cfg(any(target_os = "linux", target_os = "android"))]
     pre_main_hardening_linux();
@@ -98,12 +97,6 @@ pub(crate) fn pre_main_hardening_macos() {
     // Remove all DYLD_ environment variables, which can be used to subvert
     // library loading.
     remove_env_vars_with_prefix(b"DYLD_");
-
-    // Remove macOS malloc stack-logging controls so allocator diagnostics from
-    // Codex or inherited child processes do not get sprayed into the TUI:
-    // https://github.com/openai/codex/issues/11555
-    remove_env_vars_with_prefix(b"MallocStackLogging");
-    remove_env_vars_with_prefix(b"MallocLogFile");
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary

Follow-up to #24459 and partial behavioral revert of `a71fc47` / #16699.

- Stop removing `MallocStackLogging*` and `MallocLogFile*` from macOS pre-main hardening.
- Remove documentation that claims Codex suppresses those allocator diagnostic controls.
- Retain the shared `remove_env_vars_with_prefix` refactor and existing `LD_` / `DYLD_` hardening.

## Why

#24459 fixes the composer-corruption problem at the terminal stderr boundary while preserving redirected stderr. With that guard in place, stripping macOS malloc diagnostic settings is unnecessary and can hide diagnostics intentionally enabled by callers.

## Validation

- `just fmt`
- `just test -p codex-process-hardening`
- `just argument-comment-lint-from-source -p codex-process-hardening`
- `git diff --check`