### PR TITLE
Wire metrics client into memories extension

### DIFF
--- a/codex-rs/app-server/src/extensions.rs
+++ b/codex-rs/app-server/src/extensions.rs
@@ -18,7 +18,7 @@ where
 {
     let mut builder = ExtensionRegistryBuilder::<Config>::new();
     codex_guardian::install(&mut builder, guardian_agent_spawner);
-    codex_memories_extension::install(&mut builder);
+    codex_memories_extension::install(&mut builder, codex_otel::global());
     Arc::new(builder.build())
 }
 

--- a/codex-rs/ext/memories/Cargo.toml
+++ b/codex-rs/ext/memories/Cargo.toml
@@ -17,6 +17,7 @@ async-trait = { workspace = true }
 codex-core = { workspace = true }
 codex-extension-api = { workspace = true }
 codex-features = { workspace = true }
+codex-otel = { workspace = true }
 codex-tools = { workspace = true }
 codex-utils-absolute-path = { workspace = true }
 codex-utils-output-truncation = { workspace = true }

--- a/codex-rs/ext/memories/src/extension.rs
+++ b/codex-rs/ext/memories/src/extension.rs
@@ -10,6 +10,7 @@ use codex_extension_api::ThreadLifecycleContributor;
 use codex_extension_api::ThreadStartInput;
 use codex_extension_api::ToolContributor;
 use codex_features::Feature;
+use codex_otel::MetricsClient;
 use codex_utils_absolute_path::AbsolutePathBuf;
 
 use crate::local::LocalMemoriesBackend;
@@ -17,8 +18,18 @@ use crate::prompts::build_memory_tool_developer_instructions;
 use crate::tools;
 
 /// Contributes Codex memory read-path prompt context and memory read tools.
-#[derive(Clone, Copy, Debug, Default)]
-pub(crate) struct MemoriesExtension;
+#[derive(Clone, Default)]
+pub(crate) struct MemoriesExtension {
+    _metrics_client: Option<MetricsClient>,
+}
+
+impl MemoriesExtension {
+    fn new(metrics_client: Option<MetricsClient>) -> Self {
+        Self {
+            _metrics_client: metrics_client,
+        }
+    }
+}
 
 #[derive(Clone, Debug)]
 pub(crate) struct MemoriesExtensionConfig {
@@ -97,8 +108,11 @@ impl ToolContributor for MemoriesExtension {
 }
 
 /// Installs the memories extension contributors into the extension registry.
-pub fn install(registry: &mut ExtensionRegistryBuilder<Config>) {
-    let extension = Arc::new(MemoriesExtension);
+pub fn install(
+    registry: &mut ExtensionRegistryBuilder<Config>,
+    metrics_client: Option<MetricsClient>,
+) {
+    let extension = Arc::new(MemoriesExtension::new(metrics_client));
     registry.thread_lifecycle_contributor(extension.clone());
     registry.config_contributor(extension.clone());
     registry.prompt_contributor(extension);

--- a/codex-rs/ext/memories/src/tests.rs
+++ b/codex-rs/ext/memories/src/tests.rs
@@ -23,7 +23,7 @@ use crate::local::LocalMemoriesBackend;
 
 #[test]
 fn tools_are_not_contributed_without_thread_config() {
-    let extension = MemoriesExtension;
+    let extension = MemoriesExtension::default();
 
     assert!(
         extension
@@ -37,7 +37,7 @@ fn tools_are_not_contributed_without_thread_config() {
 
 #[test]
 fn tools_are_not_contributed_when_disabled() {
-    let extension = MemoriesExtension;
+    let extension = MemoriesExtension::default();
     let thread_store = ExtensionData::new("thread");
     thread_store.insert(MemoriesExtensionConfig {
         enabled: false,
@@ -53,7 +53,7 @@ fn tools_are_not_contributed_when_disabled() {
 
 #[test]
 fn tools_are_contributed_when_enabled() {
-    let extension = MemoriesExtension;
+    let extension = MemoriesExtension::default();
     let thread_store = ExtensionData::new("thread");
     thread_store.insert(MemoriesExtensionConfig {
         enabled: true,
@@ -111,7 +111,7 @@ async fn prompt_contribution_uses_memory_summary_when_enabled() {
     .await
     .expect("write memory summary");
 
-    let extension = MemoriesExtension;
+    let extension = MemoriesExtension::default();
     let thread_store = ExtensionData::new("thread");
     thread_store.insert(MemoriesExtensionConfig {
         enabled: true,


### PR DESCRIPTION
## Summary

- let the memories extension capture the process-global OTEL metrics client at install time
- keep app-server/TUI/exec extension construction APIs unchanged
- store the metrics client for future memory metrics without emitting any metrics yet

## Test plan

- `just fmt`
- `just bazel-lock-update`
- `just bazel-lock-check`
- Not run: tests/clippy per request; CI will cover them
