### PR TITLE
feat: add manual and remote_v2 tags to compaction metric

### DIFF
--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -50,6 +50,7 @@ use crate::stream_events_utils::last_assistant_message_from_item;
 use crate::stream_events_utils::mark_thread_memory_mode_polluted_if_external_context;
 use crate::stream_events_utils::raw_assistant_output_text_from_item;
 use crate::stream_events_utils::record_completed_response_item_with_finalized_facts;
+use crate::tasks::emit_compact_metric;
 use crate::tools::ToolRouter;
 use crate::tools::context::SharedTurnDiffTracker;
 use crate::tools::parallel::ToolCallRuntime;
@@ -778,6 +779,11 @@ async fn run_auto_compact(
 ) -> CodexResult<()> {
     if should_use_remote_compact_task(turn_context.provider.info()) {
         if turn_context.features.enabled(Feature::RemoteCompactionV2) {
+            emit_compact_metric(
+                &sess.services.session_telemetry,
+                "remote_v2",
+                /*manual*/ false,
+            );
             run_inline_remote_auto_compact_task_v2(
                 Arc::clone(sess),
                 Arc::clone(turn_context),
@@ -789,6 +795,11 @@ async fn run_auto_compact(
             .await?;
             return Ok(());
         }
+        emit_compact_metric(
+            &sess.services.session_telemetry,
+            "remote",
+            /*manual*/ false,
+        );
         run_inline_remote_auto_compact_task(
             Arc::clone(sess),
             Arc::clone(turn_context),
@@ -798,6 +809,11 @@ async fn run_auto_compact(
         )
         .await?;
     } else {
+        emit_compact_metric(
+            &sess.services.session_telemetry,
+            "local",
+            /*manual*/ false,
+        );
         run_inline_auto_compact_task(
             Arc::clone(sess),
             Arc::clone(turn_context),

--- a/codex-rs/core/src/tasks/compact.rs
+++ b/codex-rs/core/src/tasks/compact.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use super::SessionTask;
 use super::SessionTaskContext;
+use super::emit_compact_metric;
 use crate::session::TurnInput;
 use crate::session::turn_context::TurnContext;
 use crate::state::TaskKind;
@@ -29,24 +30,29 @@ impl SessionTask for CompactTask {
     ) -> Option<String> {
         let session = session.clone_session();
         let _ = if crate::compact::should_use_remote_compact_task(ctx.provider.info()) {
-            session.services.session_telemetry.counter(
-                "codex.task.compact",
-                /*inc*/ 1,
-                &[("type", "remote")],
-            );
             if ctx
                 .features
                 .enabled(codex_features::Feature::RemoteCompactionV2)
             {
+                emit_compact_metric(
+                    &session.services.session_telemetry,
+                    "remote_v2",
+                    /*manual*/ true,
+                );
                 crate::compact_remote_v2::run_remote_compact_task(session.clone(), ctx).await
             } else {
+                emit_compact_metric(
+                    &session.services.session_telemetry,
+                    "remote",
+                    /*manual*/ true,
+                );
                 crate::compact_remote::run_remote_compact_task(session.clone(), ctx).await
             }
         } else {
-            session.services.session_telemetry.counter(
-                "codex.task.compact",
-                /*inc*/ 1,
-                &[("type", "local")],
+            emit_compact_metric(
+                &session.services.session_telemetry,
+                "local",
+                /*manual*/ true,
             );
             let input = vec![UserInput::Text {
                 text: ctx.compact_prompt().to_string(),

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -62,6 +62,7 @@ pub(crate) use user_shell::UserShellCommandTask;
 pub(crate) use user_shell::execute_user_shell_command;
 
 const GRACEFULL_INTERRUPTION_TIMEOUT_MS: u64 = 100;
+const TASK_COMPACT_METRIC: &str = "codex.task.compact";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum InterruptedTurnHistoryMarker {
@@ -142,6 +143,18 @@ fn emit_turn_memory_metric(
             ("config_use_memories", bool_tag(config_enabled)),
             ("has_citations", bool_tag(has_citations)),
         ],
+    );
+}
+
+pub(crate) fn emit_compact_metric(
+    session_telemetry: &SessionTelemetry,
+    compact_type: &'static str,
+    manual: bool,
+) {
+    session_telemetry.counter(
+        TASK_COMPACT_METRIC,
+        /*inc*/ 1,
+        &[("type", compact_type), ("manual", bool_tag(manual))],
     );
 }
 

--- a/codex-rs/core/src/tasks/mod_tests.rs
+++ b/codex-rs/core/src/tasks/mod_tests.rs
@@ -1,3 +1,5 @@
+use super::TASK_COMPACT_METRIC;
+use super::emit_compact_metric;
 use super::emit_turn_memory_metric;
 use super::emit_turn_network_proxy_metric;
 use codex_otel::MetricsClient;
@@ -175,6 +177,48 @@ fn emit_turn_memory_metric_records_config_disabled_without_citations() {
             ("feature_enabled".to_string(), "true".to_string()),
             ("has_citations".to_string(), "false".to_string()),
             ("read_allowed".to_string(), "false".to_string()),
+        ])
+    );
+}
+
+#[test]
+fn emit_compact_metric_records_manual_remote_v2() {
+    let session_telemetry = test_session_telemetry();
+
+    emit_compact_metric(&session_telemetry, "remote_v2", /*manual*/ true);
+
+    let snapshot = session_telemetry
+        .snapshot_metrics()
+        .expect("runtime metrics snapshot");
+    let (attrs, value) = metric_point(&snapshot, TASK_COMPACT_METRIC);
+
+    assert_eq!(value, 1);
+    assert_eq!(
+        attrs,
+        BTreeMap::from([
+            ("manual".to_string(), "true".to_string()),
+            ("type".to_string(), "remote_v2".to_string()),
+        ])
+    );
+}
+
+#[test]
+fn emit_compact_metric_records_auto_local() {
+    let session_telemetry = test_session_telemetry();
+
+    emit_compact_metric(&session_telemetry, "local", /*manual*/ false);
+
+    let snapshot = session_telemetry
+        .snapshot_metrics()
+        .expect("runtime metrics snapshot");
+    let (attrs, value) = metric_point(&snapshot, TASK_COMPACT_METRIC);
+
+    assert_eq!(value, 1);
+    assert_eq!(
+        attrs,
+        BTreeMap::from([
+            ("manual".to_string(), "false".to_string()),
+            ("type".to_string(), "local".to_string()),
         ])
     );
 }


### PR DESCRIPTION
## Why
`codex.task.compact` only distinguished `local` vs `remote`, which made it hard to answer simple counter questions in Statsig. Manual `/compact` and automatic compaction were collapsed together, and the legacy remote path was also collapsed with `remote_compaction_v2`.

## What Changed
- route `codex.task.compact` through a shared helper in `core/src/tasks/mod.rs`
- add a `manual=true|false` tag so manual and automatic compaction can be counted separately
- split the remote tag into `remote` and `remote_v2`
- emit the metric from the inline auto-compaction path in `core/src/session/turn.rs` as well as the manual `CompactTask` path in `core/src/tasks/compact.rs`
- add focused unit coverage for the new tag shapes in `core/src/tasks/mod_tests.rs`

## Verification
- added unit coverage in `core/src/tasks/mod_tests.rs` covering manual `remote_v2` tags and automatic `local` tags
