### PR TITLE
test: clean up apply_patch allow-session artifact

### DIFF
--- a/codex-rs/core/tests/suite/approvals.rs
+++ b/codex-rs/core/tests/suite/approvals.rs
@@ -2073,6 +2073,7 @@ async fn approving_apply_patch_for_session_skips_future_prompts_for_same_file() 
 
     let target = TargetPath::OutsideWorkspace("apply_patch_allow_session.txt");
     let (path, patch_path) = target.resolve_for_patch(&test);
+    let _path_cleanup = tempfile::TempPath::try_from_path(path.clone())?;
     let _ = fs::remove_file(&path);
 
     let patch_add = build_add_file_patch(&patch_path, "before");


### PR DESCRIPTION
## Why

The `approving_apply_patch_for_session_skips_future_prompts_for_same_file` integration test writes `apply_patch_allow_session.txt` under the process cwd while exercising outside-workspace patch approval behavior. With `just test` now being the normal validation path, that file can be left behind in the checkout when the test runs or fails, creating confusing untracked state.

## What changed

- Registers the resolved `apply_patch_allow_session.txt` path with `tempfile::TempPath` before the test removes and recreates it through `apply_patch`.
- Preserves the existing outside-workspace path shape so the approval behavior under test does not change.
- Lets `TempPath` remove the generated file when the test exits, including panic paths.

## Verification

- `just test -p codex-core --test all approving_apply_patch_for_session_skips_future_prompts_for_same_file`