### PR TITLE
feat(core): enable default-mode user questions

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/turn_start.rs
+++ b/codex-rs/app-server/tests/suite/v2/turn_start.rs
@@ -1318,8 +1318,7 @@ async fn turn_start_accepts_collaboration_mode_override_v2() -> Result<()> {
 }
 
 #[tokio::test]
-async fn turn_start_uses_thread_feature_overrides_for_request_user_input_tool_description_v2()
--> Result<()> {
+async fn turn_start_includes_default_mode_request_user_input_tool_description_v2() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
     let server = responses::start_mock_server().await;
@@ -1344,10 +1343,6 @@ async fn turn_start_uses_thread_feature_overrides_for_request_user_input_tool_de
     let thread_req = mcp
         .send_thread_start_request(ThreadStartParams {
             model: Some("gpt-5.3-codex".to_string()),
-            config: Some(HashMap::from([(
-                "features.default_mode_request_user_input".to_string(),
-                json!(true),
-            )])),
             ..Default::default()
         })
         .await?;

--- a/codex-rs/collaboration-mode-templates/templates/default.md
+++ b/codex-rs/collaboration-mode-templates/templates/default.md
@@ -8,4 +8,4 @@ Your active mode changes only when new developer instructions with a different `
 
 Use the `request_user_input` tool only when it is listed in the available tools for this turn.
 
-In Default mode, strongly prefer making reasonable assumptions and executing the user's request rather than stopping to ask questions. If you absolutely must ask a question because the answer cannot be discovered from local context and a reasonable assumption would be risky, ask the user directly with a concise plain-text question. Never write a multiple choice question as a textual assistant message.
+In Default mode, strongly prefer making reasonable assumptions and executing the user's request rather than stopping to ask questions. If you absolutely must ask a question because the answer cannot be discovered from local context and a reasonable assumption would be risky, use `request_user_input` when it is available. If the tool is unavailable, ask the user directly with a concise plain-text question. Never write a multiple choice question as a textual assistant message.

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -8524,10 +8524,6 @@ async fn pending_request_user_input_does_not_spawn_extra_goal_continuation() -> 
             .features
             .enable(Feature::Goals)
             .expect("goal mode should be enableable in tests");
-        config
-            .features
-            .enable(Feature::DefaultModeRequestUserInput)
-            .expect("default-mode request_user_input should be enableable in tests");
     });
     let test = builder.build(&server).await?;
     let responses = mount_sse_sequence(

--- a/codex-rs/core/src/tools/handlers/request_user_input.rs
+++ b/codex-rs/core/src/tools/handlers/request_user_input.rs
@@ -11,6 +11,7 @@ use crate::tools::handlers::request_user_input_spec::request_user_input_tool_des
 use crate::tools::handlers::request_user_input_spec::request_user_input_unavailable_message;
 use crate::tools::registry::CoreToolRuntime;
 use crate::tools::registry::ToolExecutor;
+use crate::tools::registry::ToolExposure;
 use codex_protocol::config_types::ModeKind;
 use codex_protocol::request_user_input::RequestUserInputArgs;
 use codex_tools::ToolName;
@@ -28,6 +29,10 @@ impl ToolExecutor<ToolInvocation> for RequestUserInputHandler {
 
     fn spec(&self) -> ToolSpec {
         create_request_user_input_tool(request_user_input_tool_description(&self.available_modes))
+    }
+
+    fn exposure(&self) -> ToolExposure {
+        ToolExposure::DirectModelOnly
     }
 
     async fn handle(

--- a/codex-rs/core/src/tools/handlers/request_user_input_spec_tests.rs
+++ b/codex-rs/core/src/tools/handlers/request_user_input_spec_tests.rs
@@ -1,20 +1,12 @@
 use super::*;
-use codex_features::Feature;
-use codex_features::Features;
 use codex_protocol::config_types::ModeKind;
 use codex_tools::JsonSchema;
 use codex_tools::request_user_input_available_modes;
 use pretty_assertions::assert_eq;
 use std::collections::BTreeMap;
 
-fn default_mode_enabled_available_modes() -> Vec<ModeKind> {
-    let mut features = Features::with_defaults();
-    features.enable(Feature::DefaultModeRequestUserInput);
-    request_user_input_available_modes(&features)
-}
-
-fn default_available_modes() -> Vec<ModeKind> {
-    request_user_input_available_modes(&Features::with_defaults())
+fn available_modes() -> Vec<ModeKind> {
+    request_user_input_available_modes()
 }
 
 #[test]
@@ -103,31 +95,21 @@ fn request_user_input_tool_includes_questions_schema() {
 }
 
 #[test]
-fn request_user_input_unavailable_messages_respect_default_mode_feature_flag() {
+fn request_user_input_unavailable_messages_respect_supported_modes() {
     assert_eq!(
-        request_user_input_unavailable_message(ModeKind::Plan, &default_available_modes()),
+        request_user_input_unavailable_message(ModeKind::Plan, &available_modes()),
         None
     );
     assert_eq!(
-        request_user_input_unavailable_message(ModeKind::Default, &default_available_modes()),
-        Some("request_user_input is unavailable in Default mode".to_string())
-    );
-    assert_eq!(
-        request_user_input_unavailable_message(
-            ModeKind::Default,
-            &default_mode_enabled_available_modes()
-        ),
+        request_user_input_unavailable_message(ModeKind::Default, &available_modes()),
         None
     );
     assert_eq!(
-        request_user_input_unavailable_message(ModeKind::Execute, &default_available_modes()),
+        request_user_input_unavailable_message(ModeKind::Execute, &available_modes()),
         Some("request_user_input is unavailable in Execute mode".to_string())
     );
     assert_eq!(
-        request_user_input_unavailable_message(
-            ModeKind::PairProgramming,
-            &default_available_modes()
-        ),
+        request_user_input_unavailable_message(ModeKind::PairProgramming, &available_modes()),
         Some("request_user_input is unavailable in Pair Programming mode".to_string())
     );
 }
@@ -135,11 +117,7 @@ fn request_user_input_unavailable_messages_respect_default_mode_feature_flag() {
 #[test]
 fn request_user_input_tool_description_mentions_available_modes() {
     assert_eq!(
-        request_user_input_tool_description(&default_available_modes()),
-        "Request user input for one to three short questions and wait for the response. This tool is only available in Plan mode.".to_string()
-    );
-    assert_eq!(
-        request_user_input_tool_description(&default_mode_enabled_available_modes()),
+        request_user_input_tool_description(&available_modes()),
         "Request user input for one to three short questions and wait for the response. This tool is only available in Default or Plan mode.".to_string()
     );
 }

--- a/codex-rs/core/src/tools/spec_plan.rs
+++ b/codex-rs/core/src/tools/spec_plan.rs
@@ -568,9 +568,13 @@ fn add_core_utility_tools(context: &CoreToolPlanContext<'_>, planned_tools: &mut
         planned_tools.add(UpdateGoalHandler);
     }
 
-    planned_tools.add(RequestUserInputHandler {
-        available_modes: request_user_input_available_modes(),
-    });
+    if !turn_context.session_source.is_non_root_agent()
+        && !matches!(&turn_context.session_source, SessionSource::Exec)
+    {
+        planned_tools.add(RequestUserInputHandler {
+            available_modes: request_user_input_available_modes(),
+        });
+    }
 
     if features.enabled(Feature::RequestPermissionsTool) {
         planned_tools.add(RequestPermissionsHandler);

--- a/codex-rs/core/src/tools/spec_plan.rs
+++ b/codex-rs/core/src/tools/spec_plan.rs
@@ -569,7 +569,7 @@ fn add_core_utility_tools(context: &CoreToolPlanContext<'_>, planned_tools: &mut
     }
 
     planned_tools.add(RequestUserInputHandler {
-        available_modes: request_user_input_available_modes(features),
+        available_modes: request_user_input_available_modes(),
     });
 
     if features.enabled(Feature::RequestPermissionsTool) {

--- a/codex-rs/core/src/tools/spec_plan_tests.rs
+++ b/codex-rs/core/src/tools/spec_plan_tests.rs
@@ -443,6 +443,33 @@ async fn host_context_gates_goal_and_agent_job_tools() {
 }
 
 #[tokio::test]
+async fn request_user_input_is_hidden_from_unsupported_session_sources() {
+    let interactive_root = probe(|turn| {
+        turn.session_source = SessionSource::VSCode;
+    })
+    .await;
+    interactive_root.assert_visible_contains(&["request_user_input"]);
+
+    let exec = probe(|turn| {
+        turn.session_source = SessionSource::Exec;
+    })
+    .await;
+    exec.assert_visible_lacks(&["request_user_input"]);
+
+    let sub_agent = probe(|turn| {
+        turn.session_source = SessionSource::SubAgent(SubAgentSource::ThreadSpawn {
+            parent_thread_id: Default::default(),
+            depth: 1,
+            agent_path: None,
+            agent_nickname: None,
+            agent_role: None,
+        });
+    })
+    .await;
+    sub_agent.assert_visible_lacks(&["request_user_input"]);
+}
+
+#[tokio::test]
 async fn mcp_and_tool_search_follow_direct_and_deferred_tool_exposure() {
     let direct_mcp = probe_with(
         |_| {},
@@ -700,6 +727,7 @@ async fn code_mode_only_exposes_code_executor_and_hides_nested_tools() {
 #[tokio::test]
 async fn code_mode_only_keeps_request_user_input_as_a_direct_modal_tool() {
     let plan = probe(|turn| {
+        turn.session_source = SessionSource::VSCode;
         set_features(turn, &[Feature::CodeMode, Feature::CodeModeOnly]);
     })
     .await;
@@ -897,6 +925,7 @@ async fn multi_agent_v2_namespace_is_ignored_without_provider_namespace_support(
 #[tokio::test]
 async fn code_mode_only_can_expose_namespaced_multi_agent_v2_as_normal_tools() {
     let plan = probe(|turn| {
+        turn.session_source = SessionSource::VSCode;
         set_features(
             turn,
             &[

--- a/codex-rs/core/src/tools/spec_plan_tests.rs
+++ b/codex-rs/core/src/tools/spec_plan_tests.rs
@@ -698,6 +698,21 @@ async fn code_mode_only_exposes_code_executor_and_hides_nested_tools() {
 }
 
 #[tokio::test]
+async fn code_mode_only_keeps_request_user_input_as_a_direct_modal_tool() {
+    let plan = probe(|turn| {
+        set_features(turn, &[Feature::CodeMode, Feature::CodeModeOnly]);
+    })
+    .await;
+
+    // Modal prompts must not be routed through a yielded exec cell.
+    plan.assert_visible_contains(&["request_user_input"]);
+    assert_eq!(
+        plan.exposure("request_user_input"),
+        ToolExposure::DirectModelOnly
+    );
+}
+
+#[tokio::test]
 async fn multi_agent_feature_selects_one_agent_tool_family() {
     let v1 = probe(|turn| {
         set_feature(turn, Feature::Collab, /*enabled*/ true);
@@ -897,7 +912,10 @@ async fn code_mode_only_can_expose_namespaced_multi_agent_v2_as_normal_tools() {
     })
     .await;
 
-    assert_eq!(plan.visible_names, vec!["exec", "wait", "agents"]);
+    assert_eq!(
+        plan.visible_names,
+        vec!["exec", "wait", "request_user_input", "agents"]
+    );
     for tool_name in [
         "spawn_agent",
         "send_message",

--- a/codex-rs/core/tests/suite/request_user_input.rs
+++ b/codex-rs/core/tests/suite/request_user_input.rs
@@ -2,7 +2,6 @@
 
 use std::collections::HashMap;
 
-use codex_features::Feature;
 use codex_protocol::config_types::CollaborationMode;
 use codex_protocol::config_types::ModeKind;
 use codex_protocol::config_types::Settings;
@@ -82,24 +81,12 @@ async fn request_user_input_round_trip_for_mode(mode: ModeKind) -> anyhow::Resul
 
     let server = start_mock_server().await;
 
-    let builder = test_codex();
-    #[allow(clippy::expect_used)]
     let TestCodex {
         codex,
         cwd,
         session_configured,
         ..
-    } = builder
-        .with_config(move |config| {
-            if mode == ModeKind::Default {
-                config
-                    .features
-                    .enable(Feature::DefaultModeRequestUserInput)
-                    .expect("test config should allow feature update");
-            }
-        })
-        .build(&server)
-        .await?;
+    } = test_codex().build(&server).await?;
 
     let call_id = "user-input-call";
     let request_args = json!({
@@ -429,20 +416,7 @@ async fn request_user_input_rejected_in_execute_mode_alias() -> anyhow::Result<(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn request_user_input_rejected_in_default_mode_by_default() -> anyhow::Result<()> {
-    assert_request_user_input_rejected("Default", |model| CollaborationMode {
-        mode: ModeKind::Default,
-        settings: Settings {
-            model,
-            reasoning_effort: None,
-            developer_instructions: None,
-        },
-    })
-    .await
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn request_user_input_round_trip_in_default_mode_with_feature() -> anyhow::Result<()> {
+async fn request_user_input_round_trip_in_default_mode() -> anyhow::Result<()> {
     request_user_input_round_trip_for_mode(ModeKind::Default).await
 }
 

--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -172,7 +172,7 @@ pub enum Feature {
     SkillEnvVarDependencyPrompt,
     /// Enable the unified mention popup prototype.
     MentionsV2,
-    /// Allow request_user_input in Default collaboration mode.
+    /// Removed compatibility flag; request_user_input is always available in Default mode.
     DefaultModeRequestUserInput,
     /// Enable automatic review for approval prompts.
     GuardianApproval,
@@ -438,6 +438,9 @@ impl Features {
                     continue;
                 }
                 "skill_env_var_dependency_prompt" => {
+                    continue;
+                }
+                "default_mode_request_user_input" => {
                     continue;
                 }
                 "use_legacy_landlock" => {
@@ -1068,7 +1071,7 @@ pub const FEATURES: &[FeatureSpec] = &[
     FeatureSpec {
         id: Feature::DefaultModeRequestUserInput,
         key: "default_mode_request_user_input",
-        stage: Stage::UnderDevelopment,
+        stage: Stage::Removed,
         default_enabled: false,
     },
     FeatureSpec {

--- a/codex-rs/features/src/tests.rs
+++ b/codex-rs/features/src/tests.rs
@@ -289,6 +289,19 @@ fn js_repl_features_are_removed_feature_keys() {
 }
 
 #[test]
+fn default_mode_request_user_input_is_a_removed_feature_key() {
+    assert_eq!(Feature::DefaultModeRequestUserInput.stage(), Stage::Removed);
+    assert_eq!(
+        Feature::DefaultModeRequestUserInput.default_enabled(),
+        false
+    );
+    assert_eq!(
+        feature_for_key("default_mode_request_user_input"),
+        Some(Feature::DefaultModeRequestUserInput)
+    );
+}
+
+#[test]
 fn tool_call_mcp_elicitation_is_stable_and_enabled_by_default() {
     assert_eq!(Feature::ToolCallMcpElicitation.stage(), Stage::Stable);
     assert_eq!(Feature::ToolCallMcpElicitation.default_enabled(), true);
@@ -470,6 +483,25 @@ fn from_sources_ignores_removed_js_repl_feature_keys() {
         ("js_repl".to_string(), true),
         ("js_repl_tools_only".to_string(), true),
     ]));
+
+    let features = Features::from_sources(
+        FeatureConfigSource {
+            features: Some(&features_toml),
+            ..Default::default()
+        },
+        FeatureConfigSource::default(),
+        FeatureOverrides::default(),
+    );
+
+    assert_eq!(features, Features::with_defaults());
+}
+
+#[test]
+fn from_sources_ignores_removed_default_mode_request_user_input_feature_key() {
+    let features_toml = FeaturesToml::from(BTreeMap::from([(
+        "default_mode_request_user_input".to_string(),
+        true,
+    )]));
 
     let features = Features::from_sources(
         FeatureConfigSource {

--- a/codex-rs/models-manager/src/collaboration_mode_presets_tests.rs
+++ b/codex-rs/models-manager/src/collaboration_mode_presets_tests.rs
@@ -30,7 +30,8 @@ fn default_mode_instructions_replace_mode_names_placeholder() {
     assert!(default_instructions.contains(
         "Use the `request_user_input` tool only when it is listed in the available tools"
     ));
-    assert!(
-        default_instructions.contains("ask the user directly with a concise plain-text question")
-    );
+    assert!(default_instructions.contains("use `request_user_input` when it is available"));
+    assert!(default_instructions.contains(
+        "If the tool is unavailable, ask the user directly with a concise plain-text question"
+    ));
 }

--- a/codex-rs/protocol/src/config_types.rs
+++ b/codex-rs/protocol/src/config_types.rs
@@ -612,7 +612,7 @@ impl ModeKind {
     }
 
     pub const fn allows_request_user_input(self) -> bool {
-        matches!(self, Self::Plan)
+        matches!(self, Self::Default | Self::Plan)
     }
 }
 

--- a/codex-rs/tools/src/tool_config.rs
+++ b/codex-rs/tools/src/tool_config.rs
@@ -22,14 +22,10 @@ pub enum ToolUserShellType {
     Cmd,
 }
 
-pub fn request_user_input_available_modes(features: &Features) -> Vec<ModeKind> {
+pub fn request_user_input_available_modes() -> Vec<ModeKind> {
     TUI_VISIBLE_COLLABORATION_MODES
         .into_iter()
-        .filter(|mode| {
-            mode.allows_request_user_input()
-                || (features.enabled(Feature::DefaultModeRequestUserInput)
-                    && *mode == ModeKind::Default)
-        })
+        .filter(|mode| mode.allows_request_user_input())
         .collect()
 }
 

--- a/codex-rs/tools/src/tool_config_tests.rs
+++ b/codex-rs/tools/src/tool_config_tests.rs
@@ -110,17 +110,9 @@ fn shell_command_backend_requires_both_shell_tool_and_zsh_fork() {
 }
 
 #[test]
-fn request_user_input_modes_follow_default_mode_feature() {
-    let mut features = Features::with_defaults();
-    features.disable(Feature::DefaultModeRequestUserInput);
+fn request_user_input_modes_include_default_and_plan() {
     assert_eq!(
-        request_user_input_available_modes(&features),
-        vec![ModeKind::Plan]
-    );
-
-    features.enable(Feature::DefaultModeRequestUserInput);
-    assert_eq!(
-        request_user_input_available_modes(&features),
+        request_user_input_available_modes(),
         vec![ModeKind::Default, ModeKind::Plan]
     );
 }


### PR DESCRIPTION
## Why

`request_user_input` is intended to be modal: once the model asks a question, the current turn must stop until the user answers.

Before this PR there were two problems in Default mode:

1. The tool is only exposed when `features.default_mode_request_user_input = true`, even though asking a clarification question is normal Default-mode behavior.
2. When that flag is enabled together with code mode, `request_user_input` has ordinary direct-tool exposure. This makes it eligible for code-mode nesting. With `code_mode_only` enabled, the modal tool is hidden from the normal model-visible tool list and routed through `exec` instead.

The second behavior violates the tool contract. An `exec` call can continue, complete, or be torn down while the UI is still waiting for a response to the nested question. From a user's perspective, the question appears, but the model does not actually pause; if they do not answer quickly, the pending question appears to expire or time out.

## History

Default-mode question support was originally introduced by Charley Cunningham in #12735, merged on February 25, 2026. That PR allowed `request_user_input` in Default mode, but shipped it behind the `default_mode_request_user_input` opt-in flag.

A later closed, unmerged PR (#13798) explored making the feature default-on before moving it back behind `/experimental`. I did not find a documented product or technical reason for keeping Default-mode questions opt-in.

This PR completes the original Default-mode behavior without the feature flag and fixes the modal-routing issue exposed when `request_user_input` interacts with code mode.

## What Changed

- Make `request_user_input` available in Default and Plan modes without an opt-in feature flag.
- Treat `features.default_mode_request_user_input` as a removed, accepted no-op key so existing configs do not fail.
- Set `request_user_input` to `ToolExposure::DirectModelOnly`, keeping it directly model-visible under `code_mode` and `code_mode_only` while excluding it from the nested `exec` surface.
- Align Default-mode instructions to use the modal tool when it is available, while preserving the plain-text fallback for hosts without it.
- Do not advertise `request_user_input` in `codex exec` or non-root agent tool plans, whose handlers cannot service a modal question.
- Update regression coverage for mode availability, Default-mode round trips, direct modal exposure, unsupported session sources, legacy config handling, and the app-server tool description.

## How to Test

1. Start Codex in normal Default mode without setting `features.default_mode_request_user_input`.
2. Prompt: `Before doing anything, ask me exactly one multiple-choice clarification question about whether to use notes.txt, draft.txt, or todo.txt, then stop and wait for my answer.`
3. Confirm that the question UI appears and the turn remains blocked until an answer is selected.
4. Enable `code_mode` and `code_mode_only`, repeat the prompt, and confirm that `request_user_input` is still a direct modal tool rather than being routed through `exec`.
5. Leave the question unanswered briefly and confirm that it remains pending until the user responds.

Targeted automated tests:

- `just test -p codex-core --retries 0 request_user_input_is_hidden_from_unsupported_session_sources`
- `just test -p codex-core --retries 0 code_mode_only`
- `just test -p codex-models-manager --retries 0 default_mode_instructions_replace_mode_names_placeholder`

All three commands pass; each recipe also completes `just bench-smoke`.

## Validation Notes

- `just fmt` and `just fix -p codex-core -p codex-models-manager` completed for the review follow-up.
- `./tools/argument-comment-lint/run.py -p codex-core -p codex-models-manager` completed successfully for the modified Rust crates.
- Earlier feature validation also completed `just write-config-schema` and scoped `just fix` across the initially affected crates.
