### PR TITLE
[codex] Remove stale composer narrative doc references

### DIFF
--- a/codex-rs/tui/src/bottom_pane/AGENTS.md
+++ b/codex-rs/tui/src/bottom_pane/AGENTS.md
@@ -4,8 +4,6 @@ When changing the paste-burst or chat-composer state machines in this folder, ke
 
 - Update the relevant module docs (`chat_composer.rs` and/or `paste_burst.rs`) so they remain a
   readable, top-down explanation of the current behavior.
-- Update the narrative doc `docs/tui-chat-composer.md` whenever behavior/assumptions change (Enter
-  handling, retro-capture, flush/clear rules, `disable_paste_burst`, non-ASCII/IME handling).
 - Keep implementations/docstrings aligned unless a divergence is intentional and documented.
 
 Practical check:

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -111,7 +111,6 @@
 //! composer flushes/clears any in-flight burst state so it cannot leak into subsequent input.
 //!
 //! For the detailed burst state machine, see `codex-rs/tui/src/bottom_pane/paste_burst.rs`.
-//! For a narrative overview of the combined state machine, see `docs/tui-chat-composer.md`.
 //!
 //! # PasteBurst Integration Points
 //!

--- a/codex-rs/tui/src/bottom_pane/paste_burst.rs
+++ b/codex-rs/tui/src/bottom_pane/paste_burst.rs
@@ -16,9 +16,6 @@
 //! - buffer a burst as a single pasted string, or
 //! - let input flow through as normal typing.
 //!
-//! For the higher-level view of how `PasteBurst` integrates with `ChatComposer`, see
-//! `docs/tui-chat-composer.md`.
-//!
 //! # Call Pattern
 //!
 //! `PasteBurst` is a pure state machine: it never mutates the textarea directly. The caller feeds


### PR DESCRIPTION
## Context

`docs/tui-chat-composer.md` was removed by #20896 as part of removing local-only docs/specs from the repository. I checked the #20896 file list and the merge commit: the composer doc was deleted, not moved or copied, and current `main` does not contain a replacement composer narrative doc.

Current guidance should keep contributors and agents focused on the docs that still exist: the module docs in `chat_composer.rs` and `paste_burst.rs`.

## Summary

- Removes the scoped TUI bottom-pane AGENTS.md requirement to update `docs/tui-chat-composer.md`.
- Removes stale module-doc references to that deleted narrative doc from `chat_composer.rs` and `paste_burst.rs`.

## Validation

- Checked #20896 and the merge commit with rename/copy detection to confirm `docs/tui-chat-composer.md` was deleted rather than moved.
- Searched current `main` for a replacement composer narrative doc.
- Not run; documentation-only change.