### PR TITLE
[codex] Use IPv6 loopback for managed macOS HTTP proxy

### DIFF
--- a/codex-rs/network-proxy/src/proxy.rs
+++ b/codex-rs/network-proxy/src/proxy.rs
@@ -233,6 +233,14 @@ impl NetworkProxyBuilder {
 fn reserve_loopback_ephemeral_listeners(
     reserve_socks_listener: bool,
 ) -> Result<ReservedListenerSet> {
+    #[cfg(target_os = "macos")]
+    let http_listener = {
+        // Some clients, including gRPC, use an IPv4-mapped IPv6 socket for an IPv4 proxy
+        // endpoint. Seatbelt does not classify that representation as localhost.
+        StdTcpListener::bind(SocketAddr::from((std::net::Ipv6Addr::LOCALHOST, 0)))
+            .context("reserve HTTP proxy listener on IPv6 loopback")?
+    };
+    #[cfg(not(target_os = "macos"))]
     let http_listener =
         reserve_loopback_ephemeral_listener().context("reserve HTTP proxy listener")?;
     let socks_listener = if reserve_socks_listener {
@@ -791,6 +799,8 @@ mod tests {
     use pretty_assertions::assert_eq;
     use std::net::IpAddr;
     use std::net::Ipv4Addr;
+    #[cfg(target_os = "macos")]
+    use std::net::Ipv6Addr;
 
     #[tokio::test]
     async fn managed_proxy_builder_uses_loopback_ports() {
@@ -821,6 +831,18 @@ mod tests {
 
         assert!(proxy.http_addr.ip().is_loopback());
         assert!(proxy.socks_addr.ip().is_loopback());
+        #[cfg(target_os = "macos")]
+        {
+            assert_eq!(proxy.http_addr.ip(), IpAddr::V6(Ipv6Addr::LOCALHOST));
+            assert_eq!(proxy.socks_addr.ip(), IpAddr::V4(Ipv4Addr::LOCALHOST));
+
+            let mut env = HashMap::new();
+            proxy.apply_to_env(&mut env);
+            assert_eq!(
+                env.get("HTTPS_PROXY"),
+                Some(&format!("http://[::1]:{}", proxy.http_addr.port()))
+            );
+        }
         #[cfg(target_os = "windows")]
         {
             assert_eq!(proxy.http_addr, http_addr);


### PR DESCRIPTION
## Why

Managed macOS network sessions inject an HTTP proxy endpoint for sandboxed child processes. The endpoint is currently bound to `127.0.0.1`, but Python gRPC connects to an IPv4 proxy endpoint using an IPv4-mapped IPv6 socket (`::ffff:127.0.0.1`). Seatbelt does not recognize that socket representation as `localhost`, so it denies the proxy connection before any HTTP CONNECT request reaches ProxyF.

This presents as gRPC-based commands hanging or timing out even though ProxyF is active and ordinary HTTP clients can reach an allowed destination through the same proxy.

## What changed

- Bind Codex-managed macOS **HTTP** proxy listeners on native IPv6 loopback (`[::1]`) instead of IPv4 loopback.
- Leave SOCKS listener behavior unchanged, preserving the existing macOS `nc`/SSH proxy-command path.
- Extend proxy tests to assert the macOS managed HTTP listener and injected `HTTPS_PROXY` URL use IPv6 loopback.

This keeps the existing Seatbelt `localhost:<proxy-port>` boundary intact; it avoids adding a wildcard-port allowance that would permit direct egress to arbitrary remote hosts on the proxy port.

## Validation

- Reproduced the failure under Seatbelt: an IPv4 HTTP proxy endpoint works with `requests`, while gRPC fails with `connect: Operation not permitted`; a raw `AF_INET6` connection to `::ffff:127.0.0.1` fails the same way.
- Verified the safe route: placing a native IPv6 loopback listener in front of the same ProxyF endpoint makes the same sandboxed gRPC connection succeed.
- Ran `just fmt`.
- Ran `just test -p codex-network-proxy` (`166` tests passed).
- Ran `just fix -p codex-network-proxy`.