### PR TITLE
make direct only allowed caller for standalone websearch

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/web_search.rs
+++ b/codex-rs/app-server/tests/suite/v2/web_search.rs
@@ -129,6 +129,10 @@ async fn standalone_web_search_round_trips_encrypted_output() -> Result<()> {
         })
     );
     assert_eq!(
+        search_body["settings"]["allowed_callers"],
+        json!(["direct"])
+    );
+    assert_eq!(
         search_body["input"]
             .as_array()
             .context("search input should be an array")?

--- a/codex-rs/ext/web-search/src/extension.rs
+++ b/codex-rs/ext/web-search/src/extension.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use codex_api::AllowedCaller;
 use codex_api::ApproximateLocation;
 use codex_api::LocationType;
 use codex_api::SearchContextSize;
@@ -71,6 +72,7 @@ fn search_settings(config: &Config, web_search_mode: WebSearchMode) -> SearchSet
                 allowed_domains: filters.allowed_domains.clone(),
                 blocked_domains: None,
             }),
+        allowed_callers: Some(vec![AllowedCaller::Direct]),
         external_web_access: Some(match web_search_mode {
             WebSearchMode::Live => true,
             WebSearchMode::Cached | WebSearchMode::Disabled => false,


### PR DESCRIPTION
only allow `Direct` callers of the standalone websearch tool because its not supported in codemode