### PR TITLE
Add CODEX_ENV_FILE hook persistence

### DIFF
--- a/codex-rs/core/src/hook_env.rs
+++ b/codex-rs/core/src/hook_env.rs
@@ -27,15 +27,13 @@ impl HookEnvFile {
         }
     }
 
-    pub(crate) fn path(&self) -> &AbsolutePathBuf {
+    /// Returns the path after best-effort creation of its parent directory.
+    pub(crate) fn prepare_path(&self) -> &AbsolutePathBuf {
+        self.create_parent_dir();
         &self.path
     }
 
-    pub(crate) fn add_to_env(&self, env: &mut HashMap<String, String>) {
-        add_env_file_vars(env, &self.path);
-    }
-
-    pub(crate) fn ensure_parent_dir(&self) {
+    fn create_parent_dir(&self) {
         let Some(parent) = self.path.as_path().parent() else {
             return;
         };

--- a/codex-rs/core/src/hook_env.rs
+++ b/codex-rs/core/src/hook_env.rs
@@ -1,0 +1,73 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use codex_protocol::ThreadId;
+use codex_utils_absolute_path::AbsolutePathBuf;
+
+const HOOK_ENV_DIR: &str = "env";
+
+#[derive(Debug)]
+pub(crate) struct HookEnvFile {
+    path: AbsolutePathBuf,
+}
+
+impl HookEnvFile {
+    pub(crate) fn new(codex_home: &AbsolutePathBuf, thread_id: ThreadId) -> Self {
+        if let Some(path) = env_path(codex_hooks::CODEX_ENV_FILE_ENV_VAR)
+            .or_else(|| env_path(codex_hooks::CLAUDE_ENV_FILE_ENV_VAR))
+        {
+            return Self { path };
+        }
+
+        Self {
+            path: codex_home
+                .join("tmp")
+                .join(HOOK_ENV_DIR)
+                .join(format!("{thread_id}-{}.sh", uuid::Uuid::new_v4())),
+        }
+    }
+
+    pub(crate) fn path(&self) -> &AbsolutePathBuf {
+        &self.path
+    }
+
+    pub(crate) fn add_to_env(&self, env: &mut HashMap<String, String>) {
+        add_env_file_vars(env, &self.path);
+    }
+
+    pub(crate) fn ensure_parent_dir(&self) {
+        let Some(parent) = self.path.as_path().parent() else {
+            return;
+        };
+        if let Err(err) = std::fs::create_dir_all(parent) {
+            tracing::warn!(
+                path = %parent.display(),
+                "failed to create hook env file directory: {err}"
+            );
+        }
+    }
+}
+
+pub(crate) fn add_env_file_vars(env: &mut HashMap<String, String>, path: &AbsolutePathBuf) {
+    let path = path.display().to_string();
+    env.insert(
+        codex_hooks::CODEX_ENV_FILE_ENV_VAR.to_string(),
+        path.clone(),
+    );
+    env.insert(codex_hooks::CLAUDE_ENV_FILE_ENV_VAR.to_string(), path);
+}
+
+fn env_path(name: &str) -> Option<AbsolutePathBuf> {
+    let value = std::env::var_os(name)?;
+    if value.as_os_str().is_empty() {
+        return None;
+    }
+
+    let path = PathBuf::from(value);
+    let path = if path.is_absolute() {
+        path
+    } else {
+        std::env::current_dir().ok()?.join(path)
+    };
+    AbsolutePathBuf::from_absolute_path(path).ok()
+}

--- a/codex-rs/core/src/hook_runtime.rs
+++ b/codex-rs/core/src/hook_runtime.rs
@@ -124,6 +124,13 @@ pub(crate) async fn run_pending_session_start_hooks(
                 source: session_start_source,
             },
         };
+        let env_file_path = if matches!(&target, StartHookTarget::SessionStart { .. }) {
+            let env_file = sess.hook_env_file();
+            env_file.ensure_parent_dir();
+            Some(env_file.path().clone())
+        } else {
+            None
+        };
         let request = codex_hooks::SessionStartRequest {
             session_id: sess.session_id().into(),
             #[allow(deprecated)]
@@ -131,6 +138,7 @@ pub(crate) async fn run_pending_session_start_hooks(
             transcript_path: sess.hook_transcript_path().await,
             model: turn_context.model_info.slug.clone(),
             permission_mode: hook_permission_mode(turn_context),
+            env_file_path,
             target,
         };
         let hooks = sess.hooks();

--- a/codex-rs/core/src/hook_runtime.rs
+++ b/codex-rs/core/src/hook_runtime.rs
@@ -124,13 +124,8 @@ pub(crate) async fn run_pending_session_start_hooks(
                 source: session_start_source,
             },
         };
-        let env_file_path = if matches!(&target, StartHookTarget::SessionStart { .. }) {
-            let env_file = sess.hook_env_file();
-            env_file.ensure_parent_dir();
-            Some(env_file.path().clone())
-        } else {
-            None
-        };
+        let is_session_start = matches!(&target, StartHookTarget::SessionStart { .. });
+        let env_file_path = is_session_start.then(|| sess.hook_env_file().path().clone());
         let request = codex_hooks::SessionStartRequest {
             session_id: sess.session_id().into(),
             #[allow(deprecated)]
@@ -143,6 +138,12 @@ pub(crate) async fn run_pending_session_start_hooks(
         };
         let hooks = sess.hooks();
         let preview_runs = hooks.preview_session_start(&request);
+        // The default env file path lives under codex_home/tmp. Create that
+        // directory only when a real SessionStart handler will receive it, so a
+        // no-hook startup does not leave local artifacts behind.
+        if is_session_start && !preview_runs.is_empty() {
+            sess.hook_env_file().ensure_parent_dir();
+        }
         if run_context_injecting_hook(
             sess,
             turn_context,

--- a/codex-rs/core/src/hook_runtime.rs
+++ b/codex-rs/core/src/hook_runtime.rs
@@ -125,24 +125,20 @@ pub(crate) async fn run_pending_session_start_hooks(
             },
         };
         let is_session_start = matches!(&target, StartHookTarget::SessionStart { .. });
-        let env_file_path = is_session_start.then(|| sess.hook_env_file().path().clone());
-        let request = codex_hooks::SessionStartRequest {
+        let mut request = codex_hooks::SessionStartRequest {
             session_id: sess.session_id().into(),
             #[allow(deprecated)]
             cwd: turn_context.cwd.clone(),
             transcript_path: sess.hook_transcript_path().await,
             model: turn_context.model_info.slug.clone(),
             permission_mode: hook_permission_mode(turn_context),
-            env_file_path,
+            env_file_path: None,
             target,
         };
         let hooks = sess.hooks();
         let preview_runs = hooks.preview_session_start(&request);
-        // The default env file path lives under codex_home/tmp. Create that
-        // directory only when a real SessionStart handler will receive it, so a
-        // no-hook startup does not leave local artifacts behind.
         if is_session_start && !preview_runs.is_empty() {
-            sess.hook_env_file().ensure_parent_dir();
+            request.env_file_path = Some(sess.hook_env_file().prepare_path().clone());
         }
         if run_context_injecting_hook(
             sess,

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -41,6 +41,7 @@ mod goals;
 pub use goals::ExternalGoalPreviousStatus;
 pub use goals::ExternalGoalSet;
 mod guardian;
+mod hook_env;
 mod hook_runtime;
 mod installation_id;
 pub(crate) mod landlock;

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -3265,6 +3265,10 @@ impl Session {
         self.services.hooks.load_full()
     }
 
+    pub(crate) fn hook_env_file(&self) -> &crate::hook_env::HookEnvFile {
+        &self.services.hook_env_file
+    }
+
     pub(crate) fn user_shell(&self) -> Arc<shell::Shell> {
         Arc::clone(&self.services.user_shell)
     }

--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -935,6 +935,8 @@ impl Session {
                     (None, None)
                 };
 
+            let hook_env_file = crate::hook_env::HookEnvFile::new(&config.codex_home, thread_id);
+            hook_env_file.ensure_parent_dir();
             let hooks =
                 build_hooks_for_config(&config, plugins_manager.as_ref(), &default_shell).await;
             for warning in hooks.startup_warnings() {
@@ -994,6 +996,7 @@ impl Session {
                 main_execve_wrapper_exe: config.main_execve_wrapper_exe.clone(),
                 analytics_events_client,
                 hooks: arc_swap::ArcSwap::from_pointee(hooks),
+                hook_env_file,
                 rollout_thread_trace,
                 user_shell: Arc::new(default_shell),
                 shell_snapshot_tx,

--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -936,7 +936,6 @@ impl Session {
                 };
 
             let hook_env_file = crate::hook_env::HookEnvFile::new(&config.codex_home, thread_id);
-            hook_env_file.ensure_parent_dir();
             let hooks =
                 build_hooks_for_config(&config, plugins_manager.as_ref(), &default_shell).await;
             for warning in hooks.startup_warnings() {

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -555,6 +555,7 @@ async fn preview_session_start_hooks(
             transcript_path: None,
             model: "gpt-5.2".to_string(),
             permission_mode: "default".to_string(),
+            env_file_path: None,
             target: codex_hooks::StartHookTarget::SessionStart {
                 source: codex_hooks::SessionStartSource::Startup,
             },
@@ -1326,6 +1327,7 @@ async fn reload_user_config_layer_refreshes_hooks() -> anyhow::Result<()> {
         transcript_path: None,
         model: "gpt-5.2".to_string(),
         permission_mode: "default".to_string(),
+        env_file_path: None,
         target: codex_hooks::StartHookTarget::SessionStart {
             source: codex_hooks::SessionStartSource::Startup,
         },
@@ -1433,6 +1435,7 @@ async fn refresh_runtime_config_refreshes_hooks() -> anyhow::Result<()> {
         transcript_path: None,
         model: "gpt-5.2".to_string(),
         permission_mode: "default".to_string(),
+        env_file_path: None,
         target: codex_hooks::StartHookTarget::SessionStart {
             source: codex_hooks::SessionStartSource::Startup,
         },
@@ -4544,6 +4547,7 @@ pub(crate) async fn make_session_and_context() -> (Session, TurnContext) {
             legacy_notify_argv: config.notify.clone(),
             ..HooksConfig::default()
         })),
+        hook_env_file: crate::hook_env::HookEnvFile::new(&config.codex_home, thread_id),
         rollout_thread_trace: codex_rollout_trace::ThreadTraceContext::disabled(),
         user_shell: Arc::new(default_user_shell()),
         shell_snapshot_tx: watch::channel(None).0,
@@ -6379,6 +6383,7 @@ where
             legacy_notify_argv: config.notify.clone(),
             ..HooksConfig::default()
         })),
+        hook_env_file: crate::hook_env::HookEnvFile::new(&config.codex_home, thread_id),
         rollout_thread_trace: codex_rollout_trace::ThreadTraceContext::disabled(),
         user_shell: Arc::new(default_user_shell()),
         shell_snapshot_tx: watch::channel(None).0,

--- a/codex-rs/core/src/state/service.rs
+++ b/codex-rs/core/src/state/service.rs
@@ -10,6 +10,7 @@ use crate::config::StartedNetworkProxy;
 use crate::exec_policy::ExecPolicyManager;
 use crate::guardian::GuardianRejection;
 use crate::guardian::GuardianRejectionCircuitBreaker;
+use crate::hook_env::HookEnvFile;
 use crate::mcp::McpManager;
 use crate::tools::code_mode::CodeModeService;
 use crate::tools::network_approval::NetworkApprovalService;
@@ -48,6 +49,7 @@ pub(crate) struct SessionServices {
     pub(crate) main_execve_wrapper_exe: Option<PathBuf>,
     pub(crate) analytics_events_client: AnalyticsEventsClient,
     pub(crate) hooks: ArcSwap<Hooks>,
+    pub(crate) hook_env_file: HookEnvFile,
     pub(crate) rollout_thread_trace: ThreadTraceContext,
     pub(crate) user_shell: Arc<crate::shell::Shell>,
     pub(crate) shell_snapshot_tx: watch::Sender<Option<Arc<crate::shell_snapshot::ShellSnapshot>>>,

--- a/codex-rs/core/src/tasks/user_shell.rs
+++ b/codex-rs/core/src/tasks/user_shell.rs
@@ -15,6 +15,7 @@ use crate::exec::ExecCapturePolicy;
 use crate::exec::StdoutStream;
 use crate::exec::execute_exec_request;
 use crate::exec_env::create_env;
+use crate::hook_env::add_env_file_vars;
 use crate::sandboxing::ExecRequest;
 use crate::session::TurnInput;
 use crate::session::turn_context::TurnContext;
@@ -133,8 +134,8 @@ pub(crate) async fn execute_user_shell_command(
         &turn_context.shell_environment_policy,
         Some(session.conversation_id),
     );
-    let env_file_path = session.hook_env_file().path();
-    session.hook_env_file().add_to_env(&mut exec_env_map);
+    let env_file_path = session.hook_env_file().prepare_path();
+    add_env_file_vars(&mut exec_env_map, env_file_path);
     if exec_env_map.contains_key(PROXY_ACTIVE_ENV_KEY) {
         for key in PROXY_ENV_KEYS {
             exec_env_map.remove(*key);

--- a/codex-rs/core/src/tasks/user_shell.rs
+++ b/codex-rs/core/src/tasks/user_shell.rs
@@ -20,6 +20,7 @@ use crate::session::TurnInput;
 use crate::session::turn_context::TurnContext;
 use crate::state::TaskKind;
 use crate::tools::format_exec_output_str;
+use crate::tools::runtimes::maybe_source_hook_env_file;
 use crate::tools::runtimes::maybe_wrap_shell_lc_with_snapshot;
 use crate::turn_timing::now_unix_timestamp_ms;
 use crate::user_shell_command::user_shell_command_record_item;
@@ -148,13 +149,13 @@ pub(crate) async fn execute_user_shell_command(
             exec_env_map.remove(PROXY_GIT_SSH_COMMAND_ENV_KEY);
         }
     }
+    let exec_command = maybe_source_hook_env_file(&display_command, Some(env_file_path));
     let exec_command = maybe_wrap_shell_lc_with_snapshot(
-        &display_command,
+        &exec_command,
         session_shell.as_ref(),
         #[allow(deprecated)]
         &turn_context.cwd,
         &turn_context.shell_environment_policy.r#set,
-        Some(env_file_path),
         &exec_env_map,
     );
 

--- a/codex-rs/core/src/tasks/user_shell.rs
+++ b/codex-rs/core/src/tasks/user_shell.rs
@@ -132,6 +132,8 @@ pub(crate) async fn execute_user_shell_command(
         &turn_context.shell_environment_policy,
         Some(session.conversation_id),
     );
+    let env_file_path = session.hook_env_file().path();
+    session.hook_env_file().add_to_env(&mut exec_env_map);
     if exec_env_map.contains_key(PROXY_ACTIVE_ENV_KEY) {
         for key in PROXY_ENV_KEYS {
             exec_env_map.remove(*key);
@@ -152,6 +154,7 @@ pub(crate) async fn execute_user_shell_command(
         #[allow(deprecated)]
         &turn_context.cwd,
         &turn_context.shell_environment_policy.r#set,
+        Some(env_file_path),
         &exec_env_map,
     );
 

--- a/codex-rs/core/src/tasks/user_shell.rs
+++ b/codex-rs/core/src/tasks/user_shell.rs
@@ -16,6 +16,7 @@ use crate::exec::StdoutStream;
 use crate::exec::execute_exec_request;
 use crate::exec_env::create_env;
 use crate::hook_env::add_env_file_vars;
+use crate::hook_runtime::run_pending_session_start_hooks;
 use crate::sandboxing::ExecRequest;
 use crate::session::TurnInput;
 use crate::session::turn_context::TurnContext;
@@ -122,6 +123,12 @@ pub(crate) async fn execute_user_shell_command(
             collaboration_mode_kind: turn_context.collaboration_mode.mode,
         });
         session.send_event(turn_context.as_ref(), event).await;
+    }
+
+    // A standalone `/shell` command can be the first action in a session,
+    // before the regular turn path has a chance to consume SessionStart hooks.
+    if run_pending_session_start_hooks(&session, &turn_context).await {
+        return;
     }
 
     // Execute the user's script under their default shell when known; this

--- a/codex-rs/core/src/tools/handlers/shell.rs
+++ b/codex-rs/core/src/tools/handlers/shell.rs
@@ -177,6 +177,14 @@ async fn run_exec_like(args: RunExecLikeArgs) -> Result<FunctionToolOutput, Func
         })
         .await;
 
+    let env_file_path = if turn_environment.environment.is_remote() {
+        None
+    } else {
+        let hook_env_file = session.hook_env_file();
+        hook_env_file.ensure_parent_dir();
+        Some(hook_env_file.path().clone())
+    };
+
     let req = ShellRequest {
         command: exec_params.command.clone(),
         shell_type,
@@ -185,11 +193,7 @@ async fn run_exec_like(args: RunExecLikeArgs) -> Result<FunctionToolOutput, Func
         timeout_ms: exec_params.expiration.timeout_ms(),
         env: exec_params.env.clone(),
         explicit_env_overrides,
-        env_file_path: if turn_environment.environment.is_remote() {
-            None
-        } else {
-            Some(session.hook_env_file().path().clone())
-        },
+        env_file_path,
         network: exec_params.network.clone(),
         sandbox_permissions: effective_additional_permissions.sandbox_permissions,
         additional_permissions: normalized_additional_permissions,

--- a/codex-rs/core/src/tools/handlers/shell.rs
+++ b/codex-rs/core/src/tools/handlers/shell.rs
@@ -185,6 +185,11 @@ async fn run_exec_like(args: RunExecLikeArgs) -> Result<FunctionToolOutput, Func
         timeout_ms: exec_params.expiration.timeout_ms(),
         env: exec_params.env.clone(),
         explicit_env_overrides,
+        env_file_path: if turn_environment.environment.is_remote() {
+            None
+        } else {
+            Some(session.hook_env_file().path().clone())
+        },
         network: exec_params.network.clone(),
         sandbox_permissions: effective_additional_permissions.sandbox_permissions,
         additional_permissions: normalized_additional_permissions,

--- a/codex-rs/core/src/tools/handlers/shell.rs
+++ b/codex-rs/core/src/tools/handlers/shell.rs
@@ -180,9 +180,7 @@ async fn run_exec_like(args: RunExecLikeArgs) -> Result<FunctionToolOutput, Func
     let env_file_path = if turn_environment.environment.is_remote() {
         None
     } else {
-        let hook_env_file = session.hook_env_file();
-        hook_env_file.ensure_parent_dir();
-        Some(hook_env_file.path().clone())
+        Some(session.hook_env_file().prepare_path().clone())
     };
 
     let req = ShellRequest {

--- a/codex-rs/core/src/tools/runtimes/mod.rs
+++ b/codex-rs/core/src/tools/runtimes/mod.rs
@@ -100,42 +100,24 @@ pub(crate) fn disable_powershell_profile_for_elevated_windows_sandbox(
 }
 
 /// POSIX-only helper: for commands produced by `Shell::derive_exec_args`
-/// for Bash/Zsh/sh of the form `[shell_path, "-lc", "<script>"]`, and
-/// when a snapshot is configured on the session shell, rewrite the argv
-/// to a single non-login shell that can source runtime shell state before
-/// running the original script:
+/// for Bash/Zsh/sh of the form `[shell_path, "-lc", "<script>"]` or
+/// `[shell_path, "-c", "<script>"]`, prepend the hook env file source to the
+/// script itself.
 ///
-///   shell -lc "<script>"
-///   => user_shell -c ". SNAPSHOT (best effort); . CODEX_ENV_FILE; exec shell -c <script>"
-///
-/// This wrapper script uses POSIX constructs (`if`, `.`, `exec`) so it can
-/// be run by Bash/Zsh/sh. On non-matching commands, or when neither a matching
-/// snapshot nor an env file is available, this is a no-op.
-///
-/// `explicit_env_overrides` and `env` are intentionally separate inputs.
-/// `explicit_env_overrides` contains policy-driven shell env overrides that
-/// should win after the snapshot is sourced and before the env file is sourced,
-/// while `env` is the full live exec environment. We need access to both so
-/// snapshot restore logic can preserve runtime-only vars like `CODEX_THREAD_ID`
-/// without pretending they came from the explicit override policy.
-pub(crate) fn maybe_wrap_shell_lc_with_snapshot(
+/// The hook env file is explicit shell script authored by hooks, so it stays
+/// part of the command's own shell script instead of being folded into shell
+/// snapshot restore logic.
+pub(crate) fn maybe_source_hook_env_file(
     command: &[String],
-    session_shell: &Shell,
-    cwd: &AbsolutePathBuf,
-    explicit_env_overrides: &HashMap<String, String>,
     env_file_path: Option<&AbsolutePathBuf>,
-    env: &HashMap<String, String>,
 ) -> Vec<String> {
     if cfg!(windows) {
         return command.to_vec();
     }
 
-    let snapshot_path = session_shell
-        .shell_snapshot()
-        .filter(|snapshot| snapshot.path.exists())
-        .filter(|snapshot| path_utils::paths_match_after_normalization(snapshot.cwd.as_path(), cwd))
-        .map(|snapshot| snapshot.path.clone());
-
+    let Some(env_file_path) = env_file_path else {
+        return command.to_vec();
+    };
     if command.len() < 3 {
         return command.to_vec();
     }
@@ -144,57 +126,98 @@ pub(crate) fn maybe_wrap_shell_lc_with_snapshot(
     if flag != "-lc" && flag != "-c" {
         return command.to_vec();
     }
-    if snapshot_path.is_none() && env_file_path.is_none() {
+
+    let env_file_path = shell_single_quote(env_file_path.to_string_lossy().as_ref());
+    let mut command = command.to_vec();
+    command[2] = format!(
+        "if [ -f '{env_file_path}' ]; then . '{env_file_path}'; fi\n\n{}",
+        command[2]
+    );
+    command
+}
+
+/// POSIX-only helper: for commands produced by `Shell::derive_exec_args`
+/// for Bash/Zsh/sh of the form `[shell_path, "-lc", "<script>"]`, and
+/// when a snapshot is configured on the session shell, rewrite the argv
+/// to a single non-login shell that sources the snapshot before running
+/// the original script:
+///
+///   shell -lc "<script>"
+///   => user_shell -c ". SNAPSHOT (best effort); exec shell -c <script>"
+///
+/// This wrapper script uses POSIX constructs (`if`, `.`, `exec`) so it can
+/// be run by Bash/Zsh/sh. On non-matching commands, or when command cwd does
+/// not match the snapshot cwd, this is a no-op.
+///
+/// `explicit_env_overrides` and `env` are intentionally separate inputs.
+/// `explicit_env_overrides` contains policy-driven shell env overrides that
+/// should win after the snapshot is sourced, while `env` is the full live exec
+/// environment. We need access to both so snapshot restore logic can preserve
+/// runtime-only vars like `CODEX_THREAD_ID` without pretending they came from
+/// the explicit override policy.
+pub(crate) fn maybe_wrap_shell_lc_with_snapshot(
+    command: &[String],
+    session_shell: &Shell,
+    cwd: &AbsolutePathBuf,
+    explicit_env_overrides: &HashMap<String, String>,
+    env: &HashMap<String, String>,
+) -> Vec<String> {
+    if cfg!(windows) {
         return command.to_vec();
     }
 
+    let Some(snapshot) = session_shell.shell_snapshot() else {
+        return command.to_vec();
+    };
+
+    if !snapshot.path.exists() {
+        return command.to_vec();
+    }
+
+    if !path_utils::paths_match_after_normalization(snapshot.cwd.as_path(), cwd) {
+        return command.to_vec();
+    }
+
+    if command.len() < 3 {
+        return command.to_vec();
+    }
+
+    let flag = command[1].as_str();
+    if flag != "-lc" {
+        return command.to_vec();
+    }
+
+    let snapshot_path = snapshot.path.to_string_lossy();
     let shell_path = session_shell.shell_path.to_string_lossy();
     let original_shell = shell_single_quote(&command[0]);
     let original_script = shell_single_quote(&command[2]);
+    let snapshot_path = shell_single_quote(snapshot_path.as_ref());
     let trailing_args = command[3..]
         .iter()
         .map(|arg| format!(" '{}'", shell_single_quote(arg)))
         .collect::<String>();
-    let (explicit_captures, explicit_exports) =
-        build_override_exports("__CODEX_SNAPSHOT_OVERRIDE", explicit_env_overrides);
-    let mut runtime_env = HashMap::new();
+    let mut override_env = explicit_env_overrides.clone();
     if let Some(thread_id) = env.get(CODEX_THREAD_ID_ENV_VAR) {
-        runtime_env.insert(CODEX_THREAD_ID_ENV_VAR.to_string(), thread_id.clone());
+        override_env.insert(CODEX_THREAD_ID_ENV_VAR.to_string(), thread_id.clone());
     }
-    let (runtime_captures, runtime_exports) =
-        build_override_exports("__CODEX_SNAPSHOT_RUNTIME_OVERRIDE", &runtime_env);
+    let (override_captures, override_exports) = build_override_exports(&override_env);
     let (proxy_captures, proxy_exports) = build_proxy_env_exports();
-    let captures = join_shell_blocks([explicit_captures, runtime_captures, proxy_captures]);
-    let source_snapshot = snapshot_path
-        .as_ref()
-        .map(|snapshot_path| {
-            let snapshot_path = shell_single_quote(snapshot_path.to_string_lossy().as_ref());
-            format!("if . '{snapshot_path}' >/dev/null 2>&1; then :; fi")
-        })
-        .unwrap_or_default();
-    let source_env_file = env_file_path
-        .map(|env_file_path| {
-            let env_file_path = shell_single_quote(env_file_path.to_string_lossy().as_ref());
-            format!("if [ -f '{env_file_path}' ]; then . '{env_file_path}'; fi")
-        })
-        .unwrap_or_default();
-    let runtime_exports = join_shell_blocks([runtime_exports, proxy_exports]);
-    let body = join_shell_blocks([
-        source_snapshot,
-        explicit_exports,
-        source_env_file,
-        runtime_exports,
-        format!("exec '{original_shell}' -c '{original_script}'{trailing_args}"),
-    ]);
-    let rewritten_script = join_shell_blocks([captures, body]);
+    let override_captures = join_shell_blocks([override_captures, proxy_captures]);
+    let override_exports = join_shell_blocks([override_exports, proxy_exports]);
+    let rewritten_script = if override_exports.is_empty() {
+        format!(
+            "if . '{snapshot_path}' >/dev/null 2>&1; then :; fi\n\nexec '{original_shell}' -c '{original_script}'{trailing_args}"
+        )
+    } else {
+        format!(
+            "{override_captures}\n\nif . '{snapshot_path}' >/dev/null 2>&1; then :; fi\n\n{override_exports}\n\nexec '{original_shell}' -c '{original_script}'{trailing_args}"
+        )
+    };
 
     vec![shell_path.to_string(), "-c".to_string(), rewritten_script]
 }
 
-fn build_override_exports(
-    variable_prefix: &str,
-    explicit_env_overrides: &HashMap<String, String>,
-) -> (String, String) {
+fn build_override_exports(explicit_env_overrides: &HashMap<String, String>) -> (String, String) {
     let mut keys = explicit_env_overrides
         .keys()
         .map(String::as_str)
@@ -202,7 +225,7 @@ fn build_override_exports(
         .collect::<Vec<_>>();
     keys.sort_unstable();
 
-    build_override_exports_for_keys(variable_prefix, &keys)
+    build_override_exports_for_keys("__CODEX_SNAPSHOT_OVERRIDE", &keys)
 }
 
 fn build_proxy_env_exports() -> (String, String) {

--- a/codex-rs/core/src/tools/runtimes/mod.rs
+++ b/codex-rs/core/src/tools/runtimes/mod.rs
@@ -18,6 +18,10 @@ use codex_network_proxy::PROXY_ENV_KEYS;
 use codex_network_proxy::PROXY_GIT_SSH_COMMAND_ENV_KEY;
 use codex_protocol::config_types::WindowsSandboxLevel;
 use codex_protocol::models::AdditionalPermissionProfile;
+use codex_protocol::models::FileSystemPermissions;
+use codex_protocol::permissions::FileSystemAccessMode;
+use codex_protocol::permissions::FileSystemPath;
+use codex_protocol::permissions::FileSystemSandboxEntry;
 use codex_sandboxing::SandboxCommand;
 use codex_sandboxing::SandboxType;
 use codex_utils_absolute_path::AbsolutePathBuf;
@@ -45,6 +49,32 @@ pub(crate) fn build_sandbox_command(
         env: env.clone(),
         additional_permissions,
     })
+}
+
+/// Adds an exact read grant for the hook env file so sandboxed commands can
+/// source it while the file stays in Codex-managed storage.
+pub(crate) fn additional_permissions_with_env_file_read(
+    mut additional_permissions: Option<AdditionalPermissionProfile>,
+    env_file_path: Option<&AbsolutePathBuf>,
+) -> Option<AdditionalPermissionProfile> {
+    let Some(env_file_path) = env_file_path else {
+        return additional_permissions;
+    };
+    let entry = FileSystemSandboxEntry {
+        path: FileSystemPath::Path {
+            path: env_file_path.clone(),
+        },
+        access: FileSystemAccessMode::Read,
+    };
+    let permissions =
+        additional_permissions.get_or_insert_with(AdditionalPermissionProfile::default);
+    let file_system = permissions
+        .file_system
+        .get_or_insert_with(FileSystemPermissions::default);
+    if !file_system.entries.contains(&entry) {
+        file_system.entries.push(entry);
+    }
+    additional_permissions
 }
 
 pub(crate) fn exec_env_for_sandbox_permissions(

--- a/codex-rs/core/src/tools/runtimes/mod.rs
+++ b/codex-rs/core/src/tools/runtimes/mod.rs
@@ -102,85 +102,99 @@ pub(crate) fn disable_powershell_profile_for_elevated_windows_sandbox(
 /// POSIX-only helper: for commands produced by `Shell::derive_exec_args`
 /// for Bash/Zsh/sh of the form `[shell_path, "-lc", "<script>"]`, and
 /// when a snapshot is configured on the session shell, rewrite the argv
-/// to a single non-login shell that sources the snapshot before running
-/// the original script:
+/// to a single non-login shell that can source runtime shell state before
+/// running the original script:
 ///
 ///   shell -lc "<script>"
-///   => user_shell -c ". SNAPSHOT (best effort); exec shell -c <script>"
+///   => user_shell -c ". SNAPSHOT (best effort); . CODEX_ENV_FILE; exec shell -c <script>"
 ///
 /// This wrapper script uses POSIX constructs (`if`, `.`, `exec`) so it can
-/// be run by Bash/Zsh/sh. On non-matching commands, or when command cwd does
-/// not match the snapshot cwd, this is a no-op.
+/// be run by Bash/Zsh/sh. On non-matching commands, or when neither a matching
+/// snapshot nor an env file is available, this is a no-op.
 ///
 /// `explicit_env_overrides` and `env` are intentionally separate inputs.
 /// `explicit_env_overrides` contains policy-driven shell env overrides that
-/// should win after the snapshot is sourced, while `env` is the full live exec
-/// environment. We need access to both so snapshot restore logic can preserve
-/// runtime-only vars like `CODEX_THREAD_ID` without pretending they came from
-/// the explicit override policy.
+/// should win after the snapshot is sourced and before the env file is sourced,
+/// while `env` is the full live exec environment. We need access to both so
+/// snapshot restore logic can preserve runtime-only vars like `CODEX_THREAD_ID`
+/// without pretending they came from the explicit override policy.
 pub(crate) fn maybe_wrap_shell_lc_with_snapshot(
     command: &[String],
     session_shell: &Shell,
     cwd: &AbsolutePathBuf,
     explicit_env_overrides: &HashMap<String, String>,
+    env_file_path: Option<&AbsolutePathBuf>,
     env: &HashMap<String, String>,
 ) -> Vec<String> {
     if cfg!(windows) {
         return command.to_vec();
     }
 
-    let Some(snapshot) = session_shell.shell_snapshot() else {
-        return command.to_vec();
-    };
-
-    if !snapshot.path.exists() {
-        return command.to_vec();
-    }
-
-    if !path_utils::paths_match_after_normalization(snapshot.cwd.as_path(), cwd) {
-        return command.to_vec();
-    }
+    let snapshot_path = session_shell
+        .shell_snapshot()
+        .filter(|snapshot| snapshot.path.exists())
+        .filter(|snapshot| path_utils::paths_match_after_normalization(snapshot.cwd.as_path(), cwd))
+        .map(|snapshot| snapshot.path.clone());
 
     if command.len() < 3 {
         return command.to_vec();
     }
 
     let flag = command[1].as_str();
-    if flag != "-lc" {
+    if flag != "-lc" && flag != "-c" {
+        return command.to_vec();
+    }
+    if snapshot_path.is_none() && env_file_path.is_none() {
         return command.to_vec();
     }
 
-    let snapshot_path = snapshot.path.to_string_lossy();
     let shell_path = session_shell.shell_path.to_string_lossy();
     let original_shell = shell_single_quote(&command[0]);
     let original_script = shell_single_quote(&command[2]);
-    let snapshot_path = shell_single_quote(snapshot_path.as_ref());
     let trailing_args = command[3..]
         .iter()
         .map(|arg| format!(" '{}'", shell_single_quote(arg)))
         .collect::<String>();
-    let mut override_env = explicit_env_overrides.clone();
+    let (explicit_captures, explicit_exports) =
+        build_override_exports("__CODEX_SNAPSHOT_OVERRIDE", explicit_env_overrides);
+    let mut runtime_env = HashMap::new();
     if let Some(thread_id) = env.get(CODEX_THREAD_ID_ENV_VAR) {
-        override_env.insert(CODEX_THREAD_ID_ENV_VAR.to_string(), thread_id.clone());
+        runtime_env.insert(CODEX_THREAD_ID_ENV_VAR.to_string(), thread_id.clone());
     }
-    let (override_captures, override_exports) = build_override_exports(&override_env);
+    let (runtime_captures, runtime_exports) =
+        build_override_exports("__CODEX_SNAPSHOT_RUNTIME_OVERRIDE", &runtime_env);
     let (proxy_captures, proxy_exports) = build_proxy_env_exports();
-    let override_captures = join_shell_blocks([override_captures, proxy_captures]);
-    let override_exports = join_shell_blocks([override_exports, proxy_exports]);
-    let rewritten_script = if override_exports.is_empty() {
-        format!(
-            "if . '{snapshot_path}' >/dev/null 2>&1; then :; fi\n\nexec '{original_shell}' -c '{original_script}'{trailing_args}"
-        )
-    } else {
-        format!(
-            "{override_captures}\n\nif . '{snapshot_path}' >/dev/null 2>&1; then :; fi\n\n{override_exports}\n\nexec '{original_shell}' -c '{original_script}'{trailing_args}"
-        )
-    };
+    let captures = join_shell_blocks([explicit_captures, runtime_captures, proxy_captures]);
+    let source_snapshot = snapshot_path
+        .as_ref()
+        .map(|snapshot_path| {
+            let snapshot_path = shell_single_quote(snapshot_path.to_string_lossy().as_ref());
+            format!("if . '{snapshot_path}' >/dev/null 2>&1; then :; fi")
+        })
+        .unwrap_or_default();
+    let source_env_file = env_file_path
+        .map(|env_file_path| {
+            let env_file_path = shell_single_quote(env_file_path.to_string_lossy().as_ref());
+            format!("if [ -f '{env_file_path}' ]; then . '{env_file_path}'; fi")
+        })
+        .unwrap_or_default();
+    let runtime_exports = join_shell_blocks([runtime_exports, proxy_exports]);
+    let body = join_shell_blocks([
+        source_snapshot,
+        explicit_exports,
+        source_env_file,
+        runtime_exports,
+        format!("exec '{original_shell}' -c '{original_script}'{trailing_args}"),
+    ]);
+    let rewritten_script = join_shell_blocks([captures, body]);
 
     vec![shell_path.to_string(), "-c".to_string(), rewritten_script]
 }
 
-fn build_override_exports(explicit_env_overrides: &HashMap<String, String>) -> (String, String) {
+fn build_override_exports(
+    variable_prefix: &str,
+    explicit_env_overrides: &HashMap<String, String>,
+) -> (String, String) {
     let mut keys = explicit_env_overrides
         .keys()
         .map(String::as_str)
@@ -188,7 +202,7 @@ fn build_override_exports(explicit_env_overrides: &HashMap<String, String>) -> (
         .collect::<Vec<_>>();
     keys.sort_unstable();
 
-    build_override_exports_for_keys("__CODEX_SNAPSHOT_OVERRIDE", &keys)
+    build_override_exports_for_keys(variable_prefix, &keys)
 }
 
 fn build_proxy_env_exports() -> (String, String) {

--- a/codex-rs/core/src/tools/runtimes/mod_tests.rs
+++ b/codex-rs/core/src/tools/runtimes/mod_tests.rs
@@ -144,6 +144,59 @@ async fn explicit_escalation_prepares_exec_without_managed_network() -> anyhow::
 }
 
 #[test]
+fn additional_permissions_with_env_file_read_adds_exact_read_grant() {
+    let dir = tempdir().expect("create temp dir");
+    let env_file_path = dir.path().join("codex-env.sh").abs();
+
+    let permissions = additional_permissions_with_env_file_read(
+        /*additional_permissions*/ None,
+        Some(&env_file_path),
+    );
+
+    assert_eq!(
+        permissions,
+        Some(AdditionalPermissionProfile {
+            network: None,
+            file_system: Some(FileSystemPermissions {
+                entries: vec![FileSystemSandboxEntry {
+                    path: FileSystemPath::Path {
+                        path: env_file_path,
+                    },
+                    access: FileSystemAccessMode::Read,
+                }],
+                glob_scan_max_depth: None,
+            }),
+        })
+    );
+}
+
+#[test]
+fn additional_permissions_with_env_file_read_preserves_existing_permissions() {
+    let dir = tempdir().expect("create temp dir");
+    let env_file_path = dir.path().join("codex-env.sh").abs();
+    let existing = Some(AdditionalPermissionProfile {
+        network: None,
+        file_system: Some(FileSystemPermissions {
+            entries: vec![FileSystemSandboxEntry {
+                path: FileSystemPath::Path {
+                    path: env_file_path.clone(),
+                },
+                access: FileSystemAccessMode::Read,
+            }],
+            glob_scan_max_depth: None,
+        }),
+    });
+
+    let permissions =
+        additional_permissions_with_env_file_read(existing.clone(), Some(&env_file_path));
+    assert_eq!(permissions, existing);
+
+    let permissions =
+        additional_permissions_with_env_file_read(existing.clone(), /*env_file_path*/ None);
+    assert_eq!(permissions, existing);
+}
+
+#[test]
 fn explicit_escalation_keeps_user_proxy_env_without_codex_marker() {
     let env = HashMap::from([
         (

--- a/codex-rs/core/src/tools/runtimes/mod_tests.rs
+++ b/codex-rs/core/src/tools/runtimes/mod_tests.rs
@@ -184,6 +184,7 @@ fn maybe_wrap_shell_lc_with_snapshot_bootstraps_in_user_shell() {
         &session_shell,
         &dir.path().abs(),
         &HashMap::new(),
+        None,
         &HashMap::new(),
     );
 
@@ -191,6 +192,48 @@ fn maybe_wrap_shell_lc_with_snapshot_bootstraps_in_user_shell() {
     assert_eq!(rewritten[1], "-c");
     assert!(rewritten[2].contains("if . '"));
     assert!(rewritten[2].contains("exec '/bin/bash' -c 'echo hello'"));
+}
+
+#[test]
+fn maybe_wrap_shell_lc_with_snapshot_sources_env_file_before_command() {
+    let dir = tempdir().expect("create temp dir");
+    let env_file_path = dir.path().join("codex-env.sh");
+    std::fs::write(
+        &env_file_path,
+        "export FROM_ENV_FILE=ready\nexport PATH=\"$PATH:/env-bin\"\n",
+    )
+    .expect("write env file");
+    let (_tx, shell_snapshot) = watch::channel(None);
+    let session_shell = Shell {
+        shell_type: ShellType::Bash,
+        shell_path: PathBuf::from("/bin/bash"),
+        shell_snapshot,
+    };
+    let command = vec![
+        "/bin/bash".to_string(),
+        "-c".to_string(),
+        "printf '%s|%s' \"$FROM_ENV_FILE\" \"$PATH\"".to_string(),
+    ];
+    let explicit_env_overrides = HashMap::from([("PATH".to_string(), "/worktree/bin".to_string())]);
+    let rewritten = maybe_wrap_shell_lc_with_snapshot(
+        &command,
+        &session_shell,
+        &dir.path().abs(),
+        &explicit_env_overrides,
+        Some(&env_file_path.abs()),
+        &HashMap::from([("PATH".to_string(), "/worktree/bin".to_string())]),
+    );
+    let output = Command::new(&rewritten[0])
+        .args(&rewritten[1..])
+        .env("PATH", "/worktree/bin")
+        .output()
+        .expect("run rewritten command");
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "ready|/worktree/bin:/env-bin"
+    );
 }
 
 #[test]
@@ -215,6 +258,7 @@ fn maybe_wrap_shell_lc_with_snapshot_escapes_single_quotes() {
         &session_shell,
         &dir.path().abs(),
         &HashMap::new(),
+        None,
         &HashMap::new(),
     );
 
@@ -243,6 +287,7 @@ fn maybe_wrap_shell_lc_with_snapshot_uses_bash_bootstrap_shell() {
         &session_shell,
         &dir.path().abs(),
         &HashMap::new(),
+        None,
         &HashMap::new(),
     );
 
@@ -274,6 +319,7 @@ fn maybe_wrap_shell_lc_with_snapshot_uses_sh_bootstrap_shell() {
         &session_shell,
         &dir.path().abs(),
         &HashMap::new(),
+        None,
         &HashMap::new(),
     );
 
@@ -307,6 +353,7 @@ fn maybe_wrap_shell_lc_with_snapshot_preserves_trailing_args() {
         &session_shell,
         &dir.path().abs(),
         &HashMap::new(),
+        None,
         &HashMap::new(),
     );
 
@@ -342,6 +389,7 @@ fn maybe_wrap_shell_lc_with_snapshot_skips_when_cwd_mismatch() {
         &session_shell,
         &command_cwd.abs(),
         &HashMap::new(),
+        None,
         &HashMap::new(),
     );
 
@@ -371,6 +419,7 @@ fn maybe_wrap_shell_lc_with_snapshot_accepts_dot_alias_cwd() {
         &session_shell,
         &command_cwd.abs(),
         &HashMap::new(),
+        None,
         &HashMap::new(),
     );
 
@@ -407,6 +456,7 @@ fn maybe_wrap_shell_lc_with_snapshot_restores_explicit_override_precedence() {
         &session_shell,
         &dir.path().abs(),
         &explicit_env_overrides,
+        None,
         &HashMap::from([("TEST_ENV_SNAPSHOT".to_string(), "worktree".to_string())]),
     );
     let output = Command::new(&rewritten[0])
@@ -447,6 +497,7 @@ fn maybe_wrap_shell_lc_with_snapshot_restores_codex_thread_id_from_env() {
         &session_shell,
         &dir.path().abs(),
         &HashMap::new(),
+        None,
         &HashMap::from([("CODEX_THREAD_ID".to_string(), "nested-thread".to_string())]),
     );
     let output = Command::new(&rewritten[0])
@@ -489,6 +540,7 @@ fn maybe_wrap_shell_lc_with_snapshot_restores_proxy_env_from_process_env() {
         &session_shell,
         &dir.path().abs(),
         &HashMap::new(),
+        None,
         &HashMap::new(),
     );
     let output = Command::new(&rewritten[0])
@@ -546,6 +598,7 @@ fn maybe_wrap_shell_lc_with_snapshot_refreshes_codex_proxy_git_ssh_command() {
         &session_shell,
         &dir.path().abs(),
         &HashMap::new(),
+        None,
         &HashMap::new(),
     );
     let output = Command::new(&rewritten[0])
@@ -591,6 +644,7 @@ fn maybe_wrap_shell_lc_with_snapshot_restores_custom_git_ssh_command() {
         &session_shell,
         &dir.path().abs(),
         &HashMap::new(),
+        None,
         &HashMap::new(),
     );
     let output = Command::new(&rewritten[0])
@@ -637,6 +691,7 @@ fn maybe_wrap_shell_lc_with_snapshot_clears_stale_codex_git_ssh_command_without_
         &session_shell,
         &dir.path().abs(),
         &HashMap::new(),
+        None,
         &HashMap::new(),
     );
     let output = Command::new(&rewritten[0])
@@ -674,6 +729,7 @@ fn maybe_wrap_shell_lc_with_snapshot_keeps_user_proxy_env_when_proxy_inactive() 
         &session_shell,
         &dir.path().abs(),
         &HashMap::new(),
+        None,
         &HashMap::new(),
     );
     let mut command = Command::new(&rewritten[0]);
@@ -724,6 +780,7 @@ fn maybe_wrap_shell_lc_with_snapshot_restores_live_env_when_snapshot_proxy_activ
         &session_shell,
         &dir.path().abs(),
         &HashMap::new(),
+        None,
         &HashMap::from([(
             "HTTP_PROXY".to_string(),
             "http://user.proxy:8080".to_string(),
@@ -769,6 +826,7 @@ fn maybe_wrap_shell_lc_with_snapshot_keeps_snapshot_path_without_override() {
         &session_shell,
         &dir.path().abs(),
         &HashMap::new(),
+        None,
         &HashMap::new(),
     );
     let output = Command::new(&rewritten[0])
@@ -806,6 +864,7 @@ fn maybe_wrap_shell_lc_with_snapshot_applies_explicit_path_override() {
         &session_shell,
         &dir.path().abs(),
         &explicit_env_overrides,
+        None,
         &HashMap::from([("PATH".to_string(), "/worktree/bin".to_string())]),
     );
     let output = Command::new(&rewritten[0])
@@ -847,6 +906,7 @@ fn maybe_wrap_shell_lc_with_snapshot_does_not_embed_override_values_in_argv() {
         &session_shell,
         &dir.path().abs(),
         &explicit_env_overrides,
+        None,
         &HashMap::from([(
             "OPENAI_API_KEY".to_string(),
             "super-secret-value".to_string(),
@@ -895,6 +955,7 @@ fn maybe_wrap_shell_lc_with_snapshot_preserves_unset_override_variables() {
         &session_shell,
         &dir.path().abs(),
         &explicit_env_overrides,
+        None,
         &HashMap::new(),
     );
 

--- a/codex-rs/core/src/tools/runtimes/mod_tests.rs
+++ b/codex-rs/core/src/tools/runtimes/mod_tests.rs
@@ -184,7 +184,6 @@ fn maybe_wrap_shell_lc_with_snapshot_bootstraps_in_user_shell() {
         &session_shell,
         &dir.path().abs(),
         &HashMap::new(),
-        None,
         &HashMap::new(),
     );
 
@@ -195,7 +194,7 @@ fn maybe_wrap_shell_lc_with_snapshot_bootstraps_in_user_shell() {
 }
 
 #[test]
-fn maybe_wrap_shell_lc_with_snapshot_sources_env_file_before_command() {
+fn maybe_source_hook_env_file_sources_env_file_before_command() {
     let dir = tempdir().expect("create temp dir");
     let env_file_path = dir.path().join("codex-env.sh");
     std::fs::write(
@@ -203,26 +202,12 @@ fn maybe_wrap_shell_lc_with_snapshot_sources_env_file_before_command() {
         "export FROM_ENV_FILE=ready\nexport PATH=\"$PATH:/env-bin\"\n",
     )
     .expect("write env file");
-    let (_tx, shell_snapshot) = watch::channel(None);
-    let session_shell = Shell {
-        shell_type: ShellType::Bash,
-        shell_path: PathBuf::from("/bin/bash"),
-        shell_snapshot,
-    };
     let command = vec![
         "/bin/bash".to_string(),
         "-c".to_string(),
         "printf '%s|%s' \"$FROM_ENV_FILE\" \"$PATH\"".to_string(),
     ];
-    let explicit_env_overrides = HashMap::from([("PATH".to_string(), "/worktree/bin".to_string())]);
-    let rewritten = maybe_wrap_shell_lc_with_snapshot(
-        &command,
-        &session_shell,
-        &dir.path().abs(),
-        &explicit_env_overrides,
-        Some(&env_file_path.abs()),
-        &HashMap::from([("PATH".to_string(), "/worktree/bin".to_string())]),
-    );
+    let rewritten = maybe_source_hook_env_file(&command, Some(&env_file_path.abs()));
     let output = Command::new(&rewritten[0])
         .args(&rewritten[1..])
         .env("PATH", "/worktree/bin")
@@ -233,6 +218,50 @@ fn maybe_wrap_shell_lc_with_snapshot_sources_env_file_before_command() {
     assert_eq!(
         String::from_utf8_lossy(&output.stdout),
         "ready|/worktree/bin:/env-bin"
+    );
+}
+
+#[test]
+fn maybe_source_hook_env_file_composes_with_snapshot_after_policy_restore() {
+    let dir = tempdir().expect("create temp dir");
+    let snapshot_path = dir.path().join("snapshot.sh");
+    std::fs::write(
+        &snapshot_path,
+        "# Snapshot file\nexport PATH='/snapshot/bin'\n",
+    )
+    .expect("write snapshot");
+    let env_file_path = dir.path().join("codex-env.sh");
+    std::fs::write(&env_file_path, "export PATH=\"$PATH:/env-bin\"\n").expect("write env file");
+    let session_shell = shell_with_snapshot(
+        ShellType::Bash,
+        "/bin/bash",
+        snapshot_path.abs(),
+        dir.path().abs(),
+    );
+    let command = vec![
+        "/bin/bash".to_string(),
+        "-lc".to_string(),
+        "printf '%s' \"$PATH\"".to_string(),
+    ];
+    let explicit_env_overrides = HashMap::from([("PATH".to_string(), "/worktree/bin".to_string())]);
+    let command = maybe_source_hook_env_file(&command, Some(&env_file_path.abs()));
+    let rewritten = maybe_wrap_shell_lc_with_snapshot(
+        &command,
+        &session_shell,
+        &dir.path().abs(),
+        &explicit_env_overrides,
+        &HashMap::from([("PATH".to_string(), "/worktree/bin".to_string())]),
+    );
+    let output = Command::new(&rewritten[0])
+        .args(&rewritten[1..])
+        .env("PATH", "/worktree/bin")
+        .output()
+        .expect("run rewritten command");
+
+    assert!(output.status.success(), "command failed: {output:?}");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "/worktree/bin:/env-bin"
     );
 }
 
@@ -258,7 +287,6 @@ fn maybe_wrap_shell_lc_with_snapshot_escapes_single_quotes() {
         &session_shell,
         &dir.path().abs(),
         &HashMap::new(),
-        None,
         &HashMap::new(),
     );
 
@@ -287,7 +315,6 @@ fn maybe_wrap_shell_lc_with_snapshot_uses_bash_bootstrap_shell() {
         &session_shell,
         &dir.path().abs(),
         &HashMap::new(),
-        None,
         &HashMap::new(),
     );
 
@@ -319,7 +346,6 @@ fn maybe_wrap_shell_lc_with_snapshot_uses_sh_bootstrap_shell() {
         &session_shell,
         &dir.path().abs(),
         &HashMap::new(),
-        None,
         &HashMap::new(),
     );
 
@@ -353,7 +379,6 @@ fn maybe_wrap_shell_lc_with_snapshot_preserves_trailing_args() {
         &session_shell,
         &dir.path().abs(),
         &HashMap::new(),
-        None,
         &HashMap::new(),
     );
 
@@ -389,7 +414,6 @@ fn maybe_wrap_shell_lc_with_snapshot_skips_when_cwd_mismatch() {
         &session_shell,
         &command_cwd.abs(),
         &HashMap::new(),
-        None,
         &HashMap::new(),
     );
 
@@ -419,7 +443,6 @@ fn maybe_wrap_shell_lc_with_snapshot_accepts_dot_alias_cwd() {
         &session_shell,
         &command_cwd.abs(),
         &HashMap::new(),
-        None,
         &HashMap::new(),
     );
 
@@ -456,7 +479,6 @@ fn maybe_wrap_shell_lc_with_snapshot_restores_explicit_override_precedence() {
         &session_shell,
         &dir.path().abs(),
         &explicit_env_overrides,
-        None,
         &HashMap::from([("TEST_ENV_SNAPSHOT".to_string(), "worktree".to_string())]),
     );
     let output = Command::new(&rewritten[0])
@@ -497,7 +519,6 @@ fn maybe_wrap_shell_lc_with_snapshot_restores_codex_thread_id_from_env() {
         &session_shell,
         &dir.path().abs(),
         &HashMap::new(),
-        None,
         &HashMap::from([("CODEX_THREAD_ID".to_string(), "nested-thread".to_string())]),
     );
     let output = Command::new(&rewritten[0])
@@ -540,7 +561,6 @@ fn maybe_wrap_shell_lc_with_snapshot_restores_proxy_env_from_process_env() {
         &session_shell,
         &dir.path().abs(),
         &HashMap::new(),
-        None,
         &HashMap::new(),
     );
     let output = Command::new(&rewritten[0])
@@ -598,7 +618,6 @@ fn maybe_wrap_shell_lc_with_snapshot_refreshes_codex_proxy_git_ssh_command() {
         &session_shell,
         &dir.path().abs(),
         &HashMap::new(),
-        None,
         &HashMap::new(),
     );
     let output = Command::new(&rewritten[0])
@@ -644,7 +663,6 @@ fn maybe_wrap_shell_lc_with_snapshot_restores_custom_git_ssh_command() {
         &session_shell,
         &dir.path().abs(),
         &HashMap::new(),
-        None,
         &HashMap::new(),
     );
     let output = Command::new(&rewritten[0])
@@ -691,7 +709,6 @@ fn maybe_wrap_shell_lc_with_snapshot_clears_stale_codex_git_ssh_command_without_
         &session_shell,
         &dir.path().abs(),
         &HashMap::new(),
-        None,
         &HashMap::new(),
     );
     let output = Command::new(&rewritten[0])
@@ -729,7 +746,6 @@ fn maybe_wrap_shell_lc_with_snapshot_keeps_user_proxy_env_when_proxy_inactive() 
         &session_shell,
         &dir.path().abs(),
         &HashMap::new(),
-        None,
         &HashMap::new(),
     );
     let mut command = Command::new(&rewritten[0]);
@@ -780,7 +796,6 @@ fn maybe_wrap_shell_lc_with_snapshot_restores_live_env_when_snapshot_proxy_activ
         &session_shell,
         &dir.path().abs(),
         &HashMap::new(),
-        None,
         &HashMap::from([(
             "HTTP_PROXY".to_string(),
             "http://user.proxy:8080".to_string(),
@@ -826,7 +841,6 @@ fn maybe_wrap_shell_lc_with_snapshot_keeps_snapshot_path_without_override() {
         &session_shell,
         &dir.path().abs(),
         &HashMap::new(),
-        None,
         &HashMap::new(),
     );
     let output = Command::new(&rewritten[0])
@@ -864,7 +878,6 @@ fn maybe_wrap_shell_lc_with_snapshot_applies_explicit_path_override() {
         &session_shell,
         &dir.path().abs(),
         &explicit_env_overrides,
-        None,
         &HashMap::from([("PATH".to_string(), "/worktree/bin".to_string())]),
     );
     let output = Command::new(&rewritten[0])
@@ -906,7 +919,6 @@ fn maybe_wrap_shell_lc_with_snapshot_does_not_embed_override_values_in_argv() {
         &session_shell,
         &dir.path().abs(),
         &explicit_env_overrides,
-        None,
         &HashMap::from([(
             "OPENAI_API_KEY".to_string(),
             "super-secret-value".to_string(),
@@ -955,7 +967,6 @@ fn maybe_wrap_shell_lc_with_snapshot_preserves_unset_override_variables() {
         &session_shell,
         &dir.path().abs(),
         &explicit_env_overrides,
-        None,
         &HashMap::new(),
     );
 

--- a/codex-rs/core/src/tools/runtimes/shell.rs
+++ b/codex-rs/core/src/tools/runtimes/shell.rs
@@ -23,6 +23,7 @@ use crate::tools::network_approval::NetworkApprovalSpec;
 use crate::tools::runtimes::build_sandbox_command;
 use crate::tools::runtimes::disable_powershell_profile_for_elevated_windows_sandbox;
 use crate::tools::runtimes::exec_env_for_sandbox_permissions;
+use crate::tools::runtimes::maybe_source_hook_env_file;
 use crate::tools::runtimes::maybe_wrap_shell_lc_with_snapshot;
 use crate::tools::sandboxing::Approvable;
 use crate::tools::sandboxing::ApprovalCtx;
@@ -236,12 +237,12 @@ impl ToolRuntime<ShellRequest, ExecToolCallOutput> for ShellRuntime {
         if let Some(env_file_path) = &req.env_file_path {
             crate::hook_env::add_env_file_vars(&mut env, env_file_path);
         }
+        let command = maybe_source_hook_env_file(&req.command, req.env_file_path.as_ref());
         let command = maybe_wrap_shell_lc_with_snapshot(
-            &req.command,
+            &command,
             session_shell.as_ref(),
             &req.cwd,
             &req.explicit_env_overrides,
-            req.env_file_path.as_ref(),
             &env,
         );
         let command = disable_powershell_profile_for_elevated_windows_sandbox(

--- a/codex-rs/core/src/tools/runtimes/shell.rs
+++ b/codex-rs/core/src/tools/runtimes/shell.rs
@@ -20,6 +20,7 @@ use crate::shell::ShellType;
 use crate::tools::flat_tool_name;
 use crate::tools::network_approval::NetworkApprovalMode;
 use crate::tools::network_approval::NetworkApprovalSpec;
+use crate::tools::runtimes::additional_permissions_with_env_file_read;
 use crate::tools::runtimes::build_sandbox_command;
 use crate::tools::runtimes::disable_powershell_profile_for_elevated_windows_sandbox;
 use crate::tools::runtimes::exec_env_for_sandbox_permissions;
@@ -237,6 +238,10 @@ impl ToolRuntime<ShellRequest, ExecToolCallOutput> for ShellRuntime {
         if let Some(env_file_path) = &req.env_file_path {
             crate::hook_env::add_env_file_vars(&mut env, env_file_path);
         }
+        let additional_permissions = additional_permissions_with_env_file_read(
+            req.additional_permissions.clone(),
+            req.env_file_path.as_ref(),
+        );
         let command = maybe_source_hook_env_file(&req.command, req.env_file_path.as_ref());
         let command = maybe_wrap_shell_lc_with_snapshot(
             &command,
@@ -258,7 +263,16 @@ impl ToolRuntime<ShellRequest, ExecToolCallOutput> for ShellRuntime {
         };
 
         if self.backend == ShellRuntimeBackend::ShellCommandZshFork {
-            match zsh_fork_backend::maybe_run_shell_command(req, attempt, ctx, &command).await? {
+            match zsh_fork_backend::maybe_run_shell_command(
+                req,
+                attempt,
+                ctx,
+                &command,
+                &env,
+                additional_permissions.clone(),
+            )
+            .await?
+            {
                 Some(out) => return Ok(out),
                 None => {
                     tracing::warn!(
@@ -268,8 +282,7 @@ impl ToolRuntime<ShellRequest, ExecToolCallOutput> for ShellRuntime {
             }
         }
 
-        let command =
-            build_sandbox_command(&command, &req.cwd, &env, req.additional_permissions.clone())?;
+        let command = build_sandbox_command(&command, &req.cwd, &env, additional_permissions)?;
         let mut expiration: crate::exec::ExecExpiration = req.timeout_ms.into();
         if let Some(cancellation) = attempt.network_denial_cancellation_token.clone() {
             expiration = expiration.with_cancellation(cancellation);

--- a/codex-rs/core/src/tools/runtimes/shell.rs
+++ b/codex-rs/core/src/tools/runtimes/shell.rs
@@ -54,6 +54,7 @@ pub struct ShellRequest {
     pub timeout_ms: Option<u64>,
     pub env: HashMap<String, String>,
     pub explicit_env_overrides: HashMap<String, String>,
+    pub env_file_path: Option<AbsolutePathBuf>,
     pub network: Option<NetworkProxy>,
     pub sandbox_permissions: SandboxPermissions,
     pub additional_permissions: Option<AdditionalPermissionProfile>,
@@ -231,12 +232,16 @@ impl ToolRuntime<ShellRequest, ExecToolCallOutput> for ShellRuntime {
         let session_shell = ctx.session.user_shell();
         let managed_network =
             managed_network_for_sandbox_permissions(req.network.as_ref(), req.sandbox_permissions);
-        let env = exec_env_for_sandbox_permissions(&req.env, req.sandbox_permissions);
+        let mut env = exec_env_for_sandbox_permissions(&req.env, req.sandbox_permissions);
+        if let Some(env_file_path) = &req.env_file_path {
+            crate::hook_env::add_env_file_vars(&mut env, env_file_path);
+        }
         let command = maybe_wrap_shell_lc_with_snapshot(
             &req.command,
             session_shell.as_ref(),
             &req.cwd,
             &req.explicit_env_overrides,
+            req.env_file_path.as_ref(),
             &env,
         );
         let command = disable_powershell_profile_for_elevated_windows_sandbox(

--- a/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
+++ b/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
@@ -15,7 +15,6 @@ use crate::sandboxing::ExecRequest;
 use crate::sandboxing::SandboxPermissions;
 use crate::shell::ShellType;
 use crate::tools::runtimes::build_sandbox_command;
-use crate::tools::runtimes::exec_env_for_sandbox_permissions;
 use crate::tools::sandboxing::PermissionRequestPayload;
 use crate::tools::sandboxing::SandboxAttempt;
 use crate::tools::sandboxing::ToolCtx;
@@ -102,6 +101,8 @@ pub(super) async fn try_run_zsh_fork(
     attempt: &SandboxAttempt<'_>,
     ctx: &ToolCtx,
     command: &[String],
+    env: &HashMap<String, String>,
+    additional_permissions: Option<AdditionalPermissionProfile>,
 ) -> Result<Option<ExecToolCallOutput>, ToolError> {
     let Some(shell_zsh_path) = ctx.session.services.shell_zsh_path.as_ref() else {
         tracing::warn!("ZshFork backend specified, but shell_zsh_path is not configured.");
@@ -116,9 +117,7 @@ pub(super) async fn try_run_zsh_fork(
         return Ok(None);
     }
 
-    let env = exec_env_for_sandbox_permissions(&req.env, req.sandbox_permissions);
-    let command =
-        build_sandbox_command(command, &req.cwd, &env, req.additional_permissions.clone())?;
+    let command = build_sandbox_command(command, &req.cwd, env, additional_permissions)?;
     let options = ExecOptions {
         expiration: req.timeout_ms.into(),
         capture_policy: ExecCapturePolicy::ShellTool,

--- a/codex-rs/core/src/tools/runtimes/shell/zsh_fork_backend.rs
+++ b/codex-rs/core/src/tools/runtimes/shell/zsh_fork_backend.rs
@@ -6,7 +6,9 @@ use crate::tools::sandboxing::ToolCtx;
 use crate::tools::sandboxing::ToolError;
 use crate::unified_exec::SpawnLifecycleHandle;
 use codex_protocol::exec_output::ExecToolCallOutput;
+use codex_protocol::models::AdditionalPermissionProfile;
 use codex_tools::ZshForkConfig;
+use std::collections::HashMap;
 
 pub(crate) struct PreparedUnifiedExecSpawn {
     pub(crate) exec_request: ExecRequest,
@@ -23,8 +25,10 @@ pub(crate) async fn maybe_run_shell_command(
     attempt: &SandboxAttempt<'_>,
     ctx: &ToolCtx,
     command: &[String],
+    env: &HashMap<String, String>,
+    additional_permissions: Option<AdditionalPermissionProfile>,
 ) -> Result<Option<ExecToolCallOutput>, ToolError> {
-    imp::maybe_run_shell_command(req, attempt, ctx, command).await
+    imp::maybe_run_shell_command(req, attempt, ctx, command, env, additional_permissions).await
 }
 
 /// Prepares unified exec to launch through the zsh-fork backend when the
@@ -76,8 +80,11 @@ mod imp {
         attempt: &SandboxAttempt<'_>,
         ctx: &ToolCtx,
         command: &[String],
+        env: &HashMap<String, String>,
+        additional_permissions: Option<AdditionalPermissionProfile>,
     ) -> Result<Option<ExecToolCallOutput>, ToolError> {
-        unix_escalation::try_run_zsh_fork(req, attempt, ctx, command).await
+        unix_escalation::try_run_zsh_fork(req, attempt, ctx, command, env, additional_permissions)
+            .await
     }
 
     pub(super) async fn maybe_prepare_unified_exec(
@@ -118,8 +125,10 @@ mod imp {
         attempt: &SandboxAttempt<'_>,
         ctx: &ToolCtx,
         command: &[String],
+        env: &HashMap<String, String>,
+        additional_permissions: Option<AdditionalPermissionProfile>,
     ) -> Result<Option<ExecToolCallOutput>, ToolError> {
-        let _ = (req, attempt, ctx, command);
+        let _ = (req, attempt, ctx, command, env, additional_permissions);
         Ok(None)
     }
 

--- a/codex-rs/core/src/tools/runtimes/unified_exec.rs
+++ b/codex-rs/core/src/tools/runtimes/unified_exec.rs
@@ -17,6 +17,7 @@ use crate::shell::ShellType;
 use crate::tools::flat_tool_name;
 use crate::tools::network_approval::NetworkApprovalMode;
 use crate::tools::network_approval::NetworkApprovalSpec;
+use crate::tools::runtimes::additional_permissions_with_env_file_read;
 use crate::tools::runtimes::build_sandbox_command;
 use crate::tools::runtimes::disable_powershell_profile_for_elevated_windows_sandbox;
 use crate::tools::runtimes::exec_env_for_sandbox_permissions;
@@ -266,6 +267,10 @@ impl<'a> ToolRuntime<UnifiedExecRequest, UnifiedExecProcess> for UnifiedExecRunt
         if let Some(network) = managed_network {
             network.apply_to_env(&mut env);
         }
+        let additional_permissions = additional_permissions_with_env_file_read(
+            req.additional_permissions.clone(),
+            req.env_file_path.as_ref(),
+        );
         let environment_is_remote = req.environment.is_remote();
         let command = if environment_is_remote {
             base_command.to_vec()
@@ -293,7 +298,7 @@ impl<'a> ToolRuntime<UnifiedExecRequest, UnifiedExecProcess> for UnifiedExecRunt
 
         if let UnifiedExecShellMode::ZshFork(zsh_fork_config) = &self.shell_mode {
             let command =
-                build_sandbox_command(&command, &req.cwd, &env, req.additional_permissions.clone())
+                build_sandbox_command(&command, &req.cwd, &env, additional_permissions.clone())
                     .map_err(|_| ToolError::Rejected("missing command line for PTY".to_string()))?;
             let options = unified_exec_options(attempt.network_denial_cancellation_token.clone());
             let mut exec_env = attempt
@@ -343,9 +348,8 @@ impl<'a> ToolRuntime<UnifiedExecRequest, UnifiedExecProcess> for UnifiedExecRunt
                 }
             }
         }
-        let command =
-            build_sandbox_command(&command, &req.cwd, &env, req.additional_permissions.clone())
-                .map_err(|_| ToolError::Rejected("missing command line for PTY".to_string()))?;
+        let command = build_sandbox_command(&command, &req.cwd, &env, additional_permissions)
+            .map_err(|_| ToolError::Rejected("missing command line for PTY".to_string()))?;
         let options = unified_exec_options(attempt.network_denial_cancellation_token.clone());
         let mut exec_env = attempt
             .env_for(command, options, managed_network)

--- a/codex-rs/core/src/tools/runtimes/unified_exec.rs
+++ b/codex-rs/core/src/tools/runtimes/unified_exec.rs
@@ -20,6 +20,7 @@ use crate::tools::network_approval::NetworkApprovalSpec;
 use crate::tools::runtimes::build_sandbox_command;
 use crate::tools::runtimes::disable_powershell_profile_for_elevated_windows_sandbox;
 use crate::tools::runtimes::exec_env_for_sandbox_permissions;
+use crate::tools::runtimes::maybe_source_hook_env_file;
 use crate::tools::runtimes::maybe_wrap_shell_lc_with_snapshot;
 use crate::tools::runtimes::shell::zsh_fork_backend;
 use crate::tools::sandboxing::Approvable;
@@ -269,12 +270,12 @@ impl<'a> ToolRuntime<UnifiedExecRequest, UnifiedExecProcess> for UnifiedExecRunt
         let command = if environment_is_remote {
             base_command.to_vec()
         } else {
+            let command = maybe_source_hook_env_file(base_command, req.env_file_path.as_ref());
             maybe_wrap_shell_lc_with_snapshot(
-                base_command,
+                &command,
                 session_shell.as_ref(),
                 &req.cwd,
                 &req.explicit_env_overrides,
-                req.env_file_path.as_ref(),
                 &env,
             )
         };

--- a/codex-rs/core/src/tools/runtimes/unified_exec.rs
+++ b/codex-rs/core/src/tools/runtimes/unified_exec.rs
@@ -66,6 +66,7 @@ pub struct UnifiedExecRequest {
     pub env: HashMap<String, String>,
     pub exec_server_env_config: Option<ExecServerEnvConfig>,
     pub explicit_env_overrides: HashMap<String, String>,
+    pub env_file_path: Option<AbsolutePathBuf>,
     pub network: Option<NetworkProxy>,
     pub tty: bool,
     pub sandbox_permissions: SandboxPermissions,
@@ -258,6 +259,9 @@ impl<'a> ToolRuntime<UnifiedExecRequest, UnifiedExecProcess> for UnifiedExecRunt
         let managed_network =
             managed_network_for_sandbox_permissions(req.network.as_ref(), req.sandbox_permissions);
         let mut env = exec_env_for_sandbox_permissions(&req.env, req.sandbox_permissions);
+        if let Some(env_file_path) = &req.env_file_path {
+            crate::hook_env::add_env_file_vars(&mut env, env_file_path);
+        }
         if let Some(network) = managed_network {
             network.apply_to_env(&mut env);
         }
@@ -270,6 +274,7 @@ impl<'a> ToolRuntime<UnifiedExecRequest, UnifiedExecProcess> for UnifiedExecRunt
                 session_shell.as_ref(),
                 &req.cwd,
                 &req.explicit_env_overrides,
+                req.env_file_path.as_ref(),
                 &env,
             )
         };
@@ -418,6 +423,7 @@ mod tests {
             env: HashMap::new(),
             exec_server_env_config: None,
             explicit_env_overrides: HashMap::new(),
+            env_file_path: None,
             network: None,
             tty: false,
             sandbox_permissions: SandboxPermissions::UseDefault,

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -1042,9 +1042,7 @@ impl UnifiedExecProcessManager {
         let env_file_path = if request.environment.is_remote() {
             None
         } else {
-            let hook_env_file = context.session.hook_env_file();
-            hook_env_file.ensure_parent_dir();
-            Some(hook_env_file.path().clone())
+            Some(context.session.hook_env_file().prepare_path().clone())
         };
 
         let req = UnifiedExecToolRequest {

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -1039,6 +1039,14 @@ impl UnifiedExecProcessManager {
                 prefix_rule: request.prefix_rule.clone(),
             })
             .await;
+        let env_file_path = if request.environment.is_remote() {
+            None
+        } else {
+            let hook_env_file = context.session.hook_env_file();
+            hook_env_file.ensure_parent_dir();
+            Some(hook_env_file.path().clone())
+        };
+
         let req = UnifiedExecToolRequest {
             command: request.command.clone(),
             shell_type: request.shell_type.clone(),
@@ -1050,11 +1058,7 @@ impl UnifiedExecProcessManager {
             env,
             exec_server_env_config: Some(exec_server_env_config),
             explicit_env_overrides: context.turn.shell_environment_policy.r#set.clone(),
-            env_file_path: if request.environment.is_remote() {
-                None
-            } else {
-                Some(context.session.hook_env_file().path().clone())
-            },
+            env_file_path,
             network: request.network.clone(),
             tty: request.tty,
             sandbox_permissions: request.sandbox_permissions,

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -1050,6 +1050,11 @@ impl UnifiedExecProcessManager {
             env,
             exec_server_env_config: Some(exec_server_env_config),
             explicit_env_overrides: context.turn.shell_environment_policy.r#set.clone(),
+            env_file_path: if request.environment.is_remote() {
+                None
+            } else {
+                Some(context.session.hook_env_file().path().clone())
+            },
             network: request.network.clone(),
             tty: request.tty,
             sandbox_permissions: request.sandbox_permissions,

--- a/codex-rs/core/tests/suite/hooks.rs
+++ b/codex-rs/core/tests/suite/hooks.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 use anyhow::Context;
 use anyhow::Result;
+use codex_config::HooksFile;
 use codex_core::config::Config;
 use codex_core::config::Constrained;
 use codex_features::Feature;
@@ -102,6 +103,79 @@ fn trust_plugin_hooks(config: &mut Config, plugin_hook_sources: Vec<PluginHookSo
         "trusted plugin hook fixture should discover at least one hook"
     );
     trust_hooks(config, listed.hooks);
+}
+
+fn write_path_persisting_plugin(
+    home: &Path,
+) -> Result<(Vec<PluginHookSource>, std::path::PathBuf)> {
+    let plugin_root = home.join("plugins/cache/test/sample/local");
+    let hooks_dir = plugin_root.join("hooks");
+    let plugin_data = home.join("plugins/data/sample-test");
+    fs::create_dir_all(plugin_root.join(".codex-plugin"))
+        .context("create plugin manifest directory")?;
+    fs::create_dir_all(&hooks_dir).context("create plugin hooks directory")?;
+    fs::write(
+        plugin_root.join(".codex-plugin/plugin.json"),
+        r#"{"name":"sample"}"#,
+    )
+    .context("write plugin manifest")?;
+    fs::write(
+        home.join("config.toml"),
+        r#"[plugins."sample@test"]
+enabled = true
+"#,
+    )
+    .context("write plugin config")?;
+
+    let script_path = hooks_dir.join("session_start_hook.py");
+    fs::write(
+        &script_path,
+        r##"import os
+from pathlib import Path
+
+env_file = os.environ.get("CODEX_ENV_FILE")
+if not env_file or env_file != os.environ.get("CLAUDE_ENV_FILE"):
+    raise SystemExit("missing CODEX_ENV_FILE/CLAUDE_ENV_FILE")
+
+bin_dir = Path(os.environ["PLUGIN_DATA"]) / "bin"
+bin_dir.mkdir(parents=True, exist_ok=True)
+shim = bin_dir / "adam-shim"
+shim.write_text("#!/bin/sh\nprintf shim-ok\n", encoding="utf-8")
+shim.chmod(0o755)
+
+with open(env_file, "a", encoding="utf-8") as handle:
+    handle.write(f'export PATH="{bin_dir}:$PATH"\n')
+"##,
+    )
+    .context("write plugin session start hook script")?;
+    let plugin_hooks_json = r#"{
+  "hooks": {
+    "SessionStart": [{
+      "matcher": "startup",
+      "hooks": [{
+        "type": "command",
+        "command": "python3 ${PLUGIN_ROOT}/hooks/session_start_hook.py"
+      }]
+    }]
+  }
+}"#;
+    let plugin_hooks_path = hooks_dir.join("hooks.json");
+    fs::write(&plugin_hooks_path, plugin_hooks_json).context("write plugin hooks config")?;
+
+    let plugin_hook_sources = vec![PluginHookSource {
+        plugin_id: PluginId::parse("sample@test").context("plugin id")?,
+        plugin_root: AbsolutePathBuf::try_from(plugin_root).context("absolute plugin root")?,
+        plugin_data_root: AbsolutePathBuf::try_from(plugin_data.clone())
+            .context("absolute plugin data root")?,
+        source_path: AbsolutePathBuf::try_from(plugin_hooks_path)
+            .context("absolute plugin hooks path")?,
+        source_relative_path: "hooks/hooks.json".to_string(),
+        hooks: serde_json::from_str::<HooksFile>(plugin_hooks_json)
+            .context("parse plugin hooks")?
+            .hooks,
+    }];
+
+    Ok((plugin_hook_sources, plugin_data))
 }
 
 fn write_stop_hook(home: &Path, block_prompts: &[&str]) -> Result<()> {
@@ -2971,6 +3045,100 @@ print(json.dumps({{
     assert_eq!(hook_inputs[0]["tool_name"], "Bash");
     assert_eq!(hook_inputs[0]["tool_use_id"], call_id);
     assert_eq!(hook_inputs[0]["tool_input"]["command"], command);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn plugin_session_start_env_file_path_persists_for_shell_and_exec_command() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+    skip_if_windows!(Ok(()));
+
+    let server = start_mock_server().await;
+    let shell_call_id = "plugin-env-file-shell-command";
+    let exec_call_id = "plugin-env-file-exec-command";
+    let shell_args = serde_json::json!({ "command": "adam-shim" });
+    let exec_args = serde_json::json!({ "cmd": "adam-shim" });
+    let responses = mount_sse_sequence(
+        &server,
+        vec![
+            sse(vec![
+                ev_response_created("resp-1"),
+                ev_function_call(
+                    shell_call_id,
+                    "shell_command",
+                    &serde_json::to_string(&shell_args)?,
+                ),
+                ev_completed("resp-1"),
+            ]),
+            sse(vec![
+                ev_response_created("resp-2"),
+                ev_function_call(
+                    exec_call_id,
+                    "exec_command",
+                    &serde_json::to_string(&exec_args)?,
+                ),
+                ev_completed("resp-2"),
+            ]),
+            sse(vec![
+                ev_response_created("resp-3"),
+                ev_assistant_message("msg-1", "both shim calls worked"),
+                ev_completed("resp-3"),
+            ]),
+        ],
+    )
+    .await;
+
+    let home = Arc::new(TempDir::new()?);
+    let (plugin_hook_sources, plugin_data) = write_path_persisting_plugin(home.path())?;
+    let mut builder = test_codex()
+        .with_home(Arc::clone(&home))
+        .with_config(move |config| {
+            config.use_experimental_unified_exec_tool = true;
+            config
+                .features
+                .enable(Feature::Plugins)
+                .expect("test config should allow feature update");
+            config
+                .features
+                .enable(Feature::UnifiedExec)
+                .expect("test config should allow feature update");
+            trust_plugin_hooks(config, plugin_hook_sources);
+        });
+    let test = builder.build(&server).await?;
+
+    test.submit_turn_with_permission_profile(
+        "run the plugin shim by name with shell and exec",
+        PermissionProfile::Disabled,
+    )
+    .await?;
+
+    assert!(
+        plugin_data.join("bin/adam-shim").exists(),
+        "session start hook should create the shim under plugin data"
+    );
+    let requests = responses.requests();
+    assert_eq!(requests.len(), 3);
+
+    let shell_output_item = requests[1].function_call_output(shell_call_id);
+    let shell_output = shell_output_item
+        .get("output")
+        .and_then(Value::as_str)
+        .expect("shell command output string");
+    assert!(
+        shell_output.contains("shim-ok"),
+        "shell command should find the shim through CODEX_ENV_FILE PATH"
+    );
+
+    let exec_output_item = requests[2].function_call_output(exec_call_id);
+    let exec_output = exec_output_item
+        .get("output")
+        .and_then(Value::as_str)
+        .expect("exec command output string");
+    assert!(
+        exec_output.contains("shim-ok"),
+        "exec command should find the shim through CODEX_ENV_FILE PATH"
+    );
 
     Ok(())
 }

--- a/codex-rs/core/tests/suite/hooks.rs
+++ b/codex-rs/core/tests/suite/hooks.rs
@@ -3144,6 +3144,60 @@ async fn plugin_session_start_env_file_path_persists_for_shell_and_exec_command(
 }
 
 #[tokio::test]
+async fn plugin_session_start_env_file_path_persists_for_initial_shell_command() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+    skip_if_windows!(Ok(()));
+
+    let server = start_mock_server().await;
+    let home = Arc::new(TempDir::new()?);
+    let (plugin_hook_sources, plugin_data) = write_path_persisting_plugin(home.path())?;
+    let mut builder = test_codex()
+        .with_home(Arc::clone(&home))
+        .with_config(move |config| {
+            config
+                .features
+                .enable(Feature::Plugins)
+                .expect("test config should allow feature update");
+            trust_plugin_hooks(config, plugin_hook_sources);
+        });
+    let test = builder.build(&server).await?;
+
+    test.codex
+        .submit(Op::RunUserShellCommand {
+            command: "adam-shim".to_string(),
+        })
+        .await?;
+
+    let event = wait_for_event(&test.codex, |event| {
+        matches!(event, EventMsg::ExecCommandEnd(_))
+    })
+    .await;
+    let EventMsg::ExecCommandEnd(event) = event else {
+        unreachable!("wait_for_event matched ExecCommandEnd");
+    };
+    assert_eq!(
+        event.exit_code, 0,
+        "initial /shell command should run successfully. stdout=`{}`, stderr=`{}`",
+        event.stdout, event.stderr
+    );
+    assert!(
+        event.stdout.contains("shim-ok"),
+        "initial /shell command should find the shim through CODEX_ENV_FILE PATH"
+    );
+    assert!(
+        plugin_data.join("bin/adam-shim").exists(),
+        "session start hook should create the shim under plugin data"
+    );
+
+    wait_for_event(&test.codex, |event| {
+        matches!(event, EventMsg::TurnComplete(_))
+    })
+    .await;
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn pre_tool_use_blocks_shell_when_defined_in_config_toml() -> Result<()> {
     skip_if_no_network!(Ok(()));
 

--- a/codex-rs/hooks/src/engine/mod_tests.rs
+++ b/codex-rs/hooks/src/engine/mod_tests.rs
@@ -31,6 +31,9 @@ use tempfile::tempdir;
 use super::ClaudeHooksEngine;
 use super::CommandShell;
 use crate::events::pre_tool_use::PreToolUseRequest;
+use crate::events::session_start::SessionStartRequest;
+use crate::events::session_start::SessionStartSource;
+use crate::events::session_start::StartHookTarget;
 
 fn cwd() -> AbsolutePathBuf {
     AbsolutePathBuf::current_dir().expect("current dir")
@@ -1251,6 +1254,114 @@ print(json.dumps({
         serde_json::json!({
             "plugin": plugin_root.display().to_string(),
             "claude": plugin_root.display().to_string(),
+        })
+    );
+}
+
+#[tokio::test]
+async fn session_start_hooks_receive_codex_env_file_and_claude_alias() {
+    let temp = tempdir().expect("create temp dir");
+    let script_path = temp.path().join("env_file_hook.py");
+    fs::write(
+        &script_path,
+        r#"import json
+import os
+
+print(json.dumps({
+    "systemMessage": json.dumps({
+        "codex": os.environ.get("CODEX_ENV_FILE"),
+        "claude": os.environ.get("CLAUDE_ENV_FILE"),
+    })
+}))
+"#,
+    )
+    .expect("write hook script");
+    let config_path =
+        AbsolutePathBuf::try_from(temp.path().join("config.toml")).expect("absolute config path");
+    let env_file_path =
+        AbsolutePathBuf::try_from(temp.path().join("codex-env.sh")).expect("absolute env path");
+    let mut config_toml = TomlValue::Table(Default::default());
+    let TomlValue::Table(config_table) = &mut config_toml else {
+        unreachable!("config TOML root should be a table");
+    };
+    let mut hooks_table = TomlValue::Table(Default::default());
+    let TomlValue::Table(hooks_entries) = &mut hooks_table else {
+        unreachable!("hooks entry should be a table");
+    };
+    let mut session_start_group = TomlValue::Table(Default::default());
+    let TomlValue::Table(session_start_group_entries) = &mut session_start_group else {
+        unreachable!("SessionStart group should be a table");
+    };
+    session_start_group_entries.insert(
+        "matcher".to_string(),
+        TomlValue::String("startup".to_string()),
+    );
+    let mut handler = TomlValue::Table(Default::default());
+    let TomlValue::Table(handler_entries) = &mut handler else {
+        unreachable!("SessionStart handler should be a table");
+    };
+    handler_entries.insert("type".to_string(), TomlValue::String("command".to_string()));
+    handler_entries.insert(
+        "command".to_string(),
+        TomlValue::String(format!("python3 {}", script_path.display())),
+    );
+    session_start_group_entries.insert("hooks".to_string(), TomlValue::Array(vec![handler]));
+    hooks_entries.insert(
+        "SessionStart".to_string(),
+        TomlValue::Array(vec![session_start_group]),
+    );
+    config_table.insert("hooks".to_string(), hooks_table);
+    let config_layer_stack = ConfigLayerStack::new(
+        vec![ConfigLayerEntry::new(
+            ConfigLayerSource::User {
+                file: config_path,
+                profile: None,
+            },
+            config_toml,
+        )],
+        ConfigRequirements::default(),
+        ConfigRequirementsToml::default(),
+    )
+    .expect("config layer stack");
+    let engine = ClaudeHooksEngine::new(
+        /*enabled*/ true,
+        /*bypass_hook_trust*/ true,
+        Some(&config_layer_stack),
+        Vec::new(),
+        Vec::new(),
+        CommandShell {
+            program: String::new(),
+            args: Vec::new(),
+        },
+    );
+
+    let outcome = engine
+        .run_session_start(
+            SessionStartRequest {
+                session_id: ThreadId::new(),
+                cwd: cwd(),
+                transcript_path: None,
+                model: "gpt-test".to_string(),
+                permission_mode: "default".to_string(),
+                env_file_path: Some(env_file_path.clone()),
+                target: StartHookTarget::SessionStart {
+                    source: SessionStartSource::Startup,
+                },
+            },
+            Some("turn-1".to_string()),
+        )
+        .await;
+
+    assert_eq!(outcome.hook_events.len(), 1);
+    assert_eq!(outcome.hook_events[0].run.status, HookRunStatus::Completed);
+    let logged: serde_json::Value =
+        serde_json::from_str(&outcome.hook_events[0].run.entries[0].text)
+            .expect("parse env payload");
+    assert_eq!(
+        logged,
+        serde_json::json!({
+            "codex": env_file_path.display().to_string(),
+            "claude": env_file_path.display().to_string(),
         })
     );
 }

--- a/codex-rs/hooks/src/events/session_start.rs
+++ b/codex-rs/hooks/src/events/session_start.rs
@@ -45,6 +45,7 @@ pub struct SessionStartRequest {
     pub transcript_path: Option<PathBuf>,
     pub model: String,
     pub permission_mode: String,
+    pub env_file_path: Option<AbsolutePathBuf>,
     pub target: StartHookTarget,
 }
 
@@ -111,7 +112,7 @@ pub(crate) async fn run(
     request: SessionStartRequest,
     turn_id: Option<String>,
 ) -> SessionStartOutcome {
-    let matched = dispatcher::select_handlers(
+    let mut matched = dispatcher::select_handlers(
         handlers,
         request.target.event_name(),
         Some(request.target.matcher_input()),
@@ -123,6 +124,11 @@ pub(crate) async fn run(
             stop_reason: None,
             additional_contexts: Vec::new(),
         };
+    }
+    if matches!(&request.target, StartHookTarget::SessionStart { .. })
+        && let Some(env_file_path) = &request.env_file_path
+    {
+        apply_env_file_to_handlers(&mut matched, env_file_path);
     }
 
     let (input_json, turn_id) = match request.target {
@@ -205,6 +211,20 @@ pub(crate) async fn run(
         should_stop,
         stop_reason,
         additional_contexts,
+    }
+}
+
+fn apply_env_file_to_handlers(handlers: &mut [ConfiguredHandler], env_file_path: &AbsolutePathBuf) {
+    let env_file_path = env_file_path.display().to_string();
+    for handler in handlers {
+        handler.env.insert(
+            crate::CODEX_ENV_FILE_ENV_VAR.to_string(),
+            env_file_path.clone(),
+        );
+        handler.env.insert(
+            crate::CLAUDE_ENV_FILE_ENV_VAR.to_string(),
+            env_file_path.clone(),
+        );
     }
 }
 

--- a/codex-rs/hooks/src/lib.rs
+++ b/codex-rs/hooks/src/lib.rs
@@ -10,6 +10,9 @@ mod types;
 
 use codex_protocol::protocol::HookEventName;
 
+pub const CODEX_ENV_FILE_ENV_VAR: &str = "CODEX_ENV_FILE";
+pub const CLAUDE_ENV_FILE_ENV_VAR: &str = "CLAUDE_ENV_FILE";
+
 pub use config_rules::hook_states_from_stack;
 pub use declarations::PluginHookDeclaration;
 pub use declarations::plugin_hook_declarations;


### PR DESCRIPTION
# Why
CC has `CLAUDE_ENV_FILE` as a shell script path that gets sourced before Bash commands so hook-written exports can persist across later commands - https://code.claude.com/docs/en/env-vars#variables

Codex needs the same so `SessionStart` hooks can make `PATH`, virtualenv, conda, and similar setup visible to shell tools without mutating persistent config or rewriting the user-visible command

# What
- Add a session-scoped `CODEX_ENV_FILE`, with `CLAUDE_ENV_FILE` as a compatibility alias for real `SessionStart` hooks.
- Source that env file before local `shell_command`, `exec_command`, and `/shell` command execution while preserving the original command for approval, hooks, and display.
- Keep hook env-file sourcing separate from shell snapshot wrapping, so snapshot policy restoration remains unchanged.
- Use a fresh env file under `tmp/env` unless the process explicitly provides `CODEX_ENV_FILE` or `CLAUDE_ENV_FILE`, and create the parent directory lazily only when a hook or local shell command needs it.
