### PR TITLE
[codex-analytics] add grouped session id to runtime events

### DIFF
--- a/codex-rs/analytics/src/analytics_client_tests.rs
+++ b/codex-rs/analytics/src/analytics_client_tests.rs
@@ -1213,6 +1213,7 @@ fn compaction_event_serializes_expected_shape() {
                 completed_at: 106,
                 duration_ms: Some(6543),
             },
+            "session-thread-1".to_string(),
             sample_app_server_client_metadata(),
             sample_runtime_metadata(),
             Some(ThreadSource::User),
@@ -1229,6 +1230,7 @@ fn compaction_event_serializes_expected_shape() {
             "event_type": "codex_compaction_event",
             "event_params": {
                 "thread_id": "thread-1",
+                "session_id": "session-thread-1",
                 "turn_id": "turn-1",
                 "app_server_client": {
                     "product_client_id": DEFAULT_ORIGINATOR,
@@ -1307,6 +1309,7 @@ fn thread_initialized_event_serializes_expected_shape() {
         event_type: "codex_thread_initialized",
         event_params: ThreadInitializedEventParams {
             thread_id: "thread-0".to_string(),
+            session_id: "session-thread-0".to_string(),
             app_server_client: CodexAppServerClientMetadata {
                 product_client_id: DEFAULT_ORIGINATOR.to_string(),
                 client_name: Some("codex-tui".to_string()),
@@ -1338,6 +1341,7 @@ fn thread_initialized_event_serializes_expected_shape() {
             "event_type": "codex_thread_initialized",
             "event_params": {
                 "thread_id": "thread-0",
+                "session_id": "session-thread-0",
                 "app_server_client": {
                     "product_client_id": DEFAULT_ORIGINATOR,
                     "client_name": "codex-tui",
@@ -1605,6 +1609,7 @@ async fn initialize_caches_client_and_thread_lifecycle_publishes_once_initialize
     let payload = serde_json::to_value(&events).expect("serialize events");
     assert_eq!(payload.as_array().expect("events array").len(), 1);
     assert_eq!(payload[0]["event_type"], "codex_thread_initialized");
+    assert_eq!(payload[0]["event_params"]["session_id"], "session-thread-1");
     assert_eq!(
         payload[0]["event_params"]["app_server_client"]["product_client_id"],
         DEFAULT_ORIGINATOR
@@ -1781,6 +1786,7 @@ async fn compaction_event_ingests_custom_fact() {
     let payload = serde_json::to_value(&events).expect("serialize events");
     assert_eq!(payload.as_array().expect("events array").len(), 1);
     assert_eq!(payload[0]["event_type"], "codex_compaction_event");
+    assert_eq!(payload[0]["event_params"]["session_id"], "session-thread-1");
     assert_eq!(payload[0]["event_params"]["thread_id"], "thread-1");
     assert_eq!(payload[0]["event_params"]["turn_id"], "turn-compact");
     assert_eq!(
@@ -1905,6 +1911,10 @@ async fn guardian_review_event_ingests_custom_fact_with_optional_target_item() {
     let payload = serde_json::to_value(&events).expect("serialize events");
     assert_eq!(payload.as_array().expect("events array").len(), 1);
     assert_eq!(payload[0]["event_type"], "codex_guardian_review");
+    assert_eq!(
+        payload[0]["event_params"]["session_id"],
+        "session-thread-guardian"
+    );
     assert_eq!(payload[0]["event_params"]["thread_id"], "thread-guardian");
     assert_eq!(payload[0]["event_params"]["turn_id"], "turn-guardian");
     assert_eq!(payload[0]["event_params"]["review_id"], "review-guardian");
@@ -2397,6 +2407,7 @@ async fn item_review_summaries_do_not_cross_threads_with_reused_item_ids() {
 fn subagent_thread_started_review_serializes_expected_shape() {
     let event = TrackEventRequest::ThreadInitialized(subagent_thread_started_event_request(
         SubAgentThreadStartedInput {
+            session_id: "session-root".to_string(),
             thread_id: "thread-review".to_string(),
             parent_thread_id: None,
             product_client_id: "codex-tui".to_string(),
@@ -2440,6 +2451,7 @@ fn subagent_thread_started_thread_spawn_serializes_parent_thread_id() {
             .expect("valid thread id");
     let event = TrackEventRequest::ThreadInitialized(subagent_thread_started_event_request(
         SubAgentThreadStartedInput {
+            session_id: "session-root".to_string(),
             thread_id: "thread-spawn".to_string(),
             parent_thread_id: None,
             product_client_id: "codex-tui".to_string(),
@@ -2459,18 +2471,21 @@ fn subagent_thread_started_thread_spawn_serializes_parent_thread_id() {
     ));
 
     let payload = serde_json::to_value(&event).expect("serialize thread spawn subagent event");
+    assert_eq!(payload["event_params"]["thread_id"], "thread-spawn");
     assert_eq!(payload["event_params"]["thread_source"], "subagent");
     assert_eq!(payload["event_params"]["subagent_source"], "thread_spawn");
     assert_eq!(
         payload["event_params"]["parent_thread_id"],
         "11111111-1111-1111-1111-111111111111"
     );
+    assert_eq!(payload["event_params"]["session_id"], "session-root");
 }
 
 #[test]
 fn subagent_thread_started_memory_consolidation_serializes_expected_shape() {
     let event = TrackEventRequest::ThreadInitialized(subagent_thread_started_event_request(
         SubAgentThreadStartedInput {
+            session_id: "session-root".to_string(),
             thread_id: "thread-memory".to_string(),
             parent_thread_id: None,
             product_client_id: "codex-tui".to_string(),
@@ -2496,6 +2511,7 @@ fn subagent_thread_started_memory_consolidation_serializes_expected_shape() {
 fn subagent_thread_started_other_serializes_expected_shape() {
     let event = TrackEventRequest::ThreadInitialized(subagent_thread_started_event_request(
         SubAgentThreadStartedInput {
+            session_id: "session-root".to_string(),
             thread_id: "thread-guardian".to_string(),
             parent_thread_id: None,
             product_client_id: "codex-tui".to_string(),
@@ -2517,6 +2533,7 @@ fn subagent_thread_started_other_serializes_expected_shape() {
 fn subagent_thread_started_other_serializes_explicit_parent_thread_id() {
     let event = TrackEventRequest::ThreadInitialized(subagent_thread_started_event_request(
         SubAgentThreadStartedInput {
+            session_id: "session-root".to_string(),
             thread_id: "thread-guardian".to_string(),
             parent_thread_id: Some("parent-thread-guardian".to_string()),
             product_client_id: "codex-tui".to_string(),
@@ -2546,6 +2563,7 @@ async fn subagent_thread_started_publishes_without_initialize() {
         .ingest(
             AnalyticsFact::Custom(CustomAnalyticsFact::SubAgentThreadStarted(
                 SubAgentThreadStartedInput {
+                    session_id: "session-root".to_string(),
                     thread_id: "thread-review".to_string(),
                     parent_thread_id: None,
                     product_client_id: "codex-tui".to_string(),
@@ -2619,6 +2637,7 @@ async fn subagent_thread_started_inherits_parent_connection_for_new_thread() {
         .ingest(
             AnalyticsFact::Custom(CustomAnalyticsFact::SubAgentThreadStarted(
                 SubAgentThreadStartedInput {
+                    session_id: "session-root".to_string(),
                     thread_id: "thread-review".to_string(),
                     parent_thread_id: None,
                     product_client_id: "parent-client".to_string(),
@@ -2666,6 +2685,8 @@ async fn subagent_thread_started_inherits_parent_connection_for_new_thread() {
         .await;
 
     let payload = serde_json::to_value(&events).expect("serialize events");
+    assert_eq!(payload[0]["event_params"]["session_id"], "session-root");
+    assert_eq!(payload[0]["event_params"]["thread_id"], "thread-review");
     assert_eq!(
         payload[0]["event_params"]["app_server_client"]["product_client_id"],
         "parent-client"
@@ -2686,6 +2707,7 @@ async fn subagent_tool_items_inherit_parent_connection_metadata() {
         .ingest(
             AnalyticsFact::Custom(CustomAnalyticsFact::SubAgentThreadStarted(
                 SubAgentThreadStartedInput {
+                    session_id: "session-root".to_string(),
                     thread_id: "thread-subagent".to_string(),
                     parent_thread_id: Some("thread-1".to_string()),
                     product_client_id: "codex-tui".to_string(),
@@ -3191,6 +3213,7 @@ fn turn_event_serializes_expected_shape() {
         event_type: "codex_turn_event",
         event_params: crate::events::CodexTurnEventParams {
             thread_id: "thread-2".to_string(),
+            session_id: "session-thread-2".to_string(),
             turn_id: "turn-2".to_string(),
             app_server_client: sample_app_server_client_metadata(),
             runtime: sample_runtime_metadata(),
@@ -3241,6 +3264,7 @@ fn turn_event_serializes_expected_shape() {
             "event_type": "codex_turn_event",
             "event_params": {
                 "thread_id": "thread-2",
+                "session_id": "session-thread-2",
                 "turn_id": "turn-2",
                 "submission_type": null,
                 "app_server_client": {
@@ -3342,6 +3366,10 @@ async fn accepted_turn_steer_emits_expected_event() {
     let payload = serde_json::to_value(&out[0]).expect("serialize turn steer event");
     assert_eq!(payload["event_type"], json!("codex_turn_steer_event"));
     assert_eq!(payload["event_params"]["thread_id"], json!("thread-2"));
+    assert_eq!(
+        payload["event_params"]["session_id"],
+        json!("session-thread-2")
+    );
     assert_eq!(payload["event_params"]["expected_turn_id"], json!("turn-2"));
     assert_eq!(payload["event_params"]["accepted_turn_id"], json!("turn-2"));
     assert_eq!(payload["event_params"]["num_input_images"], json!(1));
@@ -3559,6 +3587,10 @@ async fn turn_lifecycle_emits_turn_event() {
     let payload = serde_json::to_value(&out[0]).expect("serialize turn event");
     assert_eq!(payload["event_type"], json!("codex_turn_event"));
     assert_eq!(payload["event_params"]["thread_id"], json!("thread-2"));
+    assert_eq!(
+        payload["event_params"]["session_id"],
+        json!("session-thread-2")
+    );
     assert_eq!(payload["event_params"]["turn_id"], json!("turn-2"));
     assert_eq!(
         payload["event_params"]["app_server_client"],

--- a/codex-rs/analytics/src/events.rs
+++ b/codex-rs/analytics/src/events.rs
@@ -147,6 +147,7 @@ pub(crate) struct CodexRuntimeMetadata {
 #[derive(Serialize)]
 pub(crate) struct ThreadInitializedEventParams {
     pub(crate) thread_id: String,
+    pub(crate) session_id: String,
     pub(crate) app_server_client: CodexAppServerClientMetadata,
     pub(crate) runtime: CodexRuntimeMetadata,
     pub(crate) model: String,
@@ -420,6 +421,7 @@ impl GuardianReviewAnalyticsResult {
 
 #[derive(Serialize)]
 pub(crate) struct GuardianReviewEventPayload {
+    pub(crate) session_id: String,
     pub(crate) app_server_client: CodexAppServerClientMetadata,
     pub(crate) runtime: CodexRuntimeMetadata,
     #[serde(flatten)]
@@ -738,6 +740,7 @@ pub(crate) struct CodexHookRunEventRequest {
 #[derive(Serialize)]
 pub(crate) struct CodexCompactionEventParams {
     pub(crate) thread_id: String,
+    pub(crate) session_id: String,
     pub(crate) turn_id: String,
     pub(crate) app_server_client: CodexAppServerClientMetadata,
     pub(crate) runtime: CodexRuntimeMetadata,
@@ -767,6 +770,7 @@ pub(crate) struct CodexCompactionEventRequest {
 #[derive(Serialize)]
 pub(crate) struct CodexTurnEventParams {
     pub(crate) thread_id: String,
+    pub(crate) session_id: String,
     pub(crate) turn_id: String,
     // TODO(rhan-oai): Populate once queued/default submission type is plumbed from
     // the turn/start callsites instead of always being reported as None.
@@ -821,6 +825,7 @@ pub(crate) struct CodexTurnEventRequest {
 #[derive(Serialize)]
 pub(crate) struct CodexTurnSteerEventParams {
     pub(crate) thread_id: String,
+    pub(crate) session_id: String,
     pub(crate) expected_turn_id: Option<String>,
     pub(crate) accepted_turn_id: Option<String>,
     pub(crate) app_server_client: CodexAppServerClientMetadata,
@@ -926,6 +931,7 @@ pub(crate) fn codex_plugin_metadata(plugin: PluginTelemetryMetadata) -> CodexPlu
 
 pub(crate) fn codex_compaction_event_params(
     input: CodexCompactionEvent,
+    session_id: String,
     app_server_client: CodexAppServerClientMetadata,
     runtime: CodexRuntimeMetadata,
     thread_source: Option<ThreadSource>,
@@ -934,6 +940,7 @@ pub(crate) fn codex_compaction_event_params(
 ) -> CodexCompactionEventParams {
     CodexCompactionEventParams {
         thread_id: input.thread_id,
+        session_id,
         turn_id: input.turn_id,
         app_server_client,
         runtime,
@@ -1026,6 +1033,7 @@ pub(crate) fn subagent_thread_started_event_request(
 ) -> ThreadInitializedEvent {
     let event_params = ThreadInitializedEventParams {
         thread_id: input.thread_id,
+        session_id: input.session_id,
         app_server_client: CodexAppServerClientMetadata {
             product_client_id: input.product_client_id,
             client_name: Some(input.client_name),

--- a/codex-rs/analytics/src/facts.rs
+++ b/codex-rs/analytics/src/facts.rs
@@ -199,6 +199,7 @@ pub struct AppInvocation {
 
 #[derive(Clone)]
 pub struct SubAgentThreadStartedInput {
+    pub session_id: String,
     pub thread_id: String,
     pub parent_thread_id: Option<String>,
     pub product_client_id: String,

--- a/codex-rs/analytics/src/reducer.rs
+++ b/codex-rs/analytics/src/reducer.rs
@@ -146,6 +146,7 @@ struct ConnectionState {
 #[derive(Default)]
 struct ThreadAnalyticsState {
     connection_id: Option<u64>,
+    session_id: Option<String>,
     metadata: Option<ThreadMetadataState>,
 }
 
@@ -225,6 +226,7 @@ impl<'a> AnalyticsDropSite<'a> {
 
 enum MissingAnalyticsContext {
     ThreadConnection,
+    ThreadSessionId,
     Connection { connection_id: u64 },
     ThreadMetadata,
 }
@@ -523,6 +525,9 @@ impl AnalyticsReducer {
             .and_then(|thread| thread.connection_id);
         let thread_state = self.threads.entry(input.thread_id.clone()).or_default();
         thread_state
+            .session_id
+            .get_or_insert_with(|| input.session_id.clone());
+        thread_state
             .metadata
             .get_or_insert_with(|| ThreadMetadataState {
                 thread_source: Some(ThreadSource::Subagent),
@@ -543,15 +548,18 @@ impl AnalyticsReducer {
         input: GuardianReviewEventParams,
         out: &mut Vec<TrackEventRequest>,
     ) {
-        let Some(connection_state) =
-            self.thread_connection_or_warn(AnalyticsDropSite::guardian(&input))
-        else {
+        let drop_site = AnalyticsDropSite::guardian(&input);
+        let Some(connection_state) = self.thread_connection_or_warn(drop_site) else {
+            return;
+        };
+        let Some(session_id) = self.thread_session_id_or_warn(drop_site) else {
             return;
         };
         out.push(TrackEventRequest::GuardianReview(Box::new(
             GuardianReviewEventRequest {
                 event_type: "codex_guardian_review",
                 event_params: GuardianReviewEventPayload {
+                    session_id: session_id.to_string(),
                     app_server_client: connection_state.app_server_client.clone(),
                     runtime: connection_state.runtime.clone(),
                     guardian_review: input,
@@ -1231,6 +1239,7 @@ impl AnalyticsReducer {
         out: &mut Vec<TrackEventRequest>,
     ) {
         let session_source: SessionSource = thread.source.into();
+        let session_id = thread.session_id;
         let thread_id = thread.id;
         let Some(connection_state) = self.connections.get(&connection_id) else {
             return;
@@ -1244,6 +1253,7 @@ impl AnalyticsReducer {
             thread_id.clone(),
             ThreadAnalyticsState {
                 connection_id: Some(connection_id),
+                session_id: Some(session_id.clone()),
                 metadata: Some(thread_metadata.clone()),
             },
         );
@@ -1252,6 +1262,7 @@ impl AnalyticsReducer {
                 event_type: "codex_thread_initialized",
                 event_params: ThreadInitializedEventParams {
                     thread_id,
+                    session_id,
                     app_server_client: connection_state.app_server_client.clone(),
                     runtime: connection_state.runtime.clone(),
                     model,
@@ -1267,9 +1278,12 @@ impl AnalyticsReducer {
     }
 
     fn ingest_compaction(&mut self, input: CodexCompactionEvent, out: &mut Vec<TrackEventRequest>) {
-        let Some((connection_state, thread_metadata)) =
-            self.thread_context_or_warn(AnalyticsDropSite::compaction(&input))
+        let drop_site = AnalyticsDropSite::compaction(&input);
+        let Some((connection_state, thread_metadata)) = self.thread_context_or_warn(drop_site)
         else {
+            return;
+        };
+        let Some(session_id) = self.thread_session_id_or_warn(drop_site) else {
             return;
         };
         out.push(TrackEventRequest::Compaction(Box::new(
@@ -1277,6 +1291,7 @@ impl AnalyticsReducer {
                 event_type: "codex_compaction_event",
                 event_params: codex_compaction_event_params(
                     input,
+                    session_id.to_string(),
                     connection_state.app_server_client.clone(),
                     connection_state.runtime.clone(),
                     thread_metadata.thread_source,
@@ -1375,10 +1390,14 @@ impl AnalyticsReducer {
             warn_missing_analytics_context(&drop_site, MissingAnalyticsContext::ThreadMetadata);
             return;
         };
+        let Some(session_id) = self.thread_session_id_or_warn(drop_site) else {
+            return;
+        };
         out.push(TrackEventRequest::TurnSteer(CodexTurnSteerEventRequest {
             event_type: "codex_turn_steer_event",
             event_params: CodexTurnSteerEventParams {
                 thread_id: pending_request.thread_id,
+                session_id: session_id.to_string(),
                 expected_turn_id: Some(pending_request.expected_turn_id),
                 accepted_turn_id,
                 app_server_client: connection_state.app_server_client.clone(),
@@ -1494,12 +1513,16 @@ impl AnalyticsReducer {
             warn_missing_analytics_context(&drop_site, MissingAnalyticsContext::ThreadMetadata);
             return;
         };
+        let Some(session_id) = self.thread_session_id_or_warn(drop_site) else {
+            return;
+        };
         let turn_event = TrackEventRequest::TurnEvent(Box::new(CodexTurnEventRequest {
             event_type: "codex_turn_event",
             event_params: codex_turn_event_params(
                 connection_state.app_server_client.clone(),
                 connection_state.runtime.clone(),
                 turn_id.to_string(),
+                session_id.to_string(),
                 turn_state,
                 thread_metadata,
             ),
@@ -1551,6 +1574,18 @@ impl AnalyticsReducer {
         };
         Some((connection_state, thread_metadata))
     }
+
+    fn thread_session_id_or_warn(&self, drop_site: AnalyticsDropSite<'_>) -> Option<&str> {
+        let Some(session_id) = self
+            .threads
+            .get(drop_site.thread_id)
+            .and_then(|thread| thread.session_id.as_deref())
+        else {
+            warn_missing_analytics_context(&drop_site, MissingAnalyticsContext::ThreadSessionId);
+            return None;
+        };
+        Some(session_id)
+    }
 }
 
 fn warn_missing_analytics_context(
@@ -1559,6 +1594,7 @@ fn warn_missing_analytics_context(
 ) {
     let (missing_context, connection_id) = match missing {
         MissingAnalyticsContext::ThreadConnection => ("thread_connection", None),
+        MissingAnalyticsContext::ThreadSessionId => ("thread_session_id", None),
         MissingAnalyticsContext::Connection { connection_id } => {
             ("connection", Some(connection_id))
         }
@@ -2411,6 +2447,7 @@ fn codex_turn_event_params(
     app_server_client: CodexAppServerClientMetadata,
     runtime: CodexRuntimeMetadata,
     turn_id: String,
+    session_id: String,
     turn_state: &TurnState,
     thread_metadata: &ThreadMetadataState,
 ) -> CodexTurnEventParams {
@@ -2447,6 +2484,7 @@ fn codex_turn_event_params(
     let token_usage = turn_state.token_usage.clone();
     CodexTurnEventParams {
         thread_id,
+        session_id,
         turn_id,
         app_server_client,
         runtime,

--- a/codex-rs/analytics/src/reducer.rs
+++ b/codex-rs/analytics/src/reducer.rs
@@ -146,7 +146,6 @@ struct ConnectionState {
 #[derive(Default)]
 struct ThreadAnalyticsState {
     connection_id: Option<u64>,
-    session_id: Option<String>,
     metadata: Option<ThreadMetadataState>,
 }
 
@@ -226,7 +225,6 @@ impl<'a> AnalyticsDropSite<'a> {
 
 enum MissingAnalyticsContext {
     ThreadConnection,
-    ThreadSessionId,
     Connection { connection_id: u64 },
     ThreadMetadata,
 }
@@ -257,6 +255,7 @@ struct ItemReviewSummary {
 
 #[derive(Clone)]
 struct ThreadMetadataState {
+    session_id: String,
     thread_source: Option<ThreadSource>,
     initialization_mode: ThreadInitializationMode,
     subagent_source: Option<String>,
@@ -265,6 +264,7 @@ struct ThreadMetadataState {
 
 impl ThreadMetadataState {
     fn from_thread_metadata(
+        session_id: String,
         session_source: &SessionSource,
         thread_source: Option<ThreadSource>,
         initialization_mode: ThreadInitializationMode,
@@ -283,6 +283,7 @@ impl ThreadMetadataState {
             | SessionSource::Unknown => (None, None),
         };
         Self {
+            session_id,
             thread_source,
             initialization_mode,
             subagent_source,
@@ -525,11 +526,9 @@ impl AnalyticsReducer {
             .and_then(|thread| thread.connection_id);
         let thread_state = self.threads.entry(input.thread_id.clone()).or_default();
         thread_state
-            .session_id
-            .get_or_insert_with(|| input.session_id.clone());
-        thread_state
             .metadata
             .get_or_insert_with(|| ThreadMetadataState {
+                session_id: input.session_id.clone(),
                 thread_source: Some(ThreadSource::Subagent),
                 initialization_mode: ThreadInitializationMode::New,
                 subagent_source: Some(subagent_source_name(&input.subagent_source)),
@@ -548,18 +547,16 @@ impl AnalyticsReducer {
         input: GuardianReviewEventParams,
         out: &mut Vec<TrackEventRequest>,
     ) {
-        let drop_site = AnalyticsDropSite::guardian(&input);
-        let Some(connection_state) = self.thread_connection_or_warn(drop_site) else {
-            return;
-        };
-        let Some(session_id) = self.thread_session_id_or_warn(drop_site) else {
+        let Some((connection_state, thread_metadata)) =
+            self.thread_context_or_warn(AnalyticsDropSite::guardian(&input))
+        else {
             return;
         };
         out.push(TrackEventRequest::GuardianReview(Box::new(
             GuardianReviewEventRequest {
                 event_type: "codex_guardian_review",
                 event_params: GuardianReviewEventPayload {
-                    session_id: session_id.to_string(),
+                    session_id: thread_metadata.session_id.clone(),
                     app_server_client: connection_state.app_server_client.clone(),
                     runtime: connection_state.runtime.clone(),
                     guardian_review: input,
@@ -1245,6 +1242,7 @@ impl AnalyticsReducer {
             return;
         };
         let thread_metadata = ThreadMetadataState::from_thread_metadata(
+            session_id.clone(),
             &session_source,
             thread.thread_source.map(Into::into),
             initialization_mode,
@@ -1253,7 +1251,6 @@ impl AnalyticsReducer {
             thread_id.clone(),
             ThreadAnalyticsState {
                 connection_id: Some(connection_id),
-                session_id: Some(session_id.clone()),
                 metadata: Some(thread_metadata.clone()),
             },
         );
@@ -1278,12 +1275,9 @@ impl AnalyticsReducer {
     }
 
     fn ingest_compaction(&mut self, input: CodexCompactionEvent, out: &mut Vec<TrackEventRequest>) {
-        let drop_site = AnalyticsDropSite::compaction(&input);
-        let Some((connection_state, thread_metadata)) = self.thread_context_or_warn(drop_site)
+        let Some((connection_state, thread_metadata)) =
+            self.thread_context_or_warn(AnalyticsDropSite::compaction(&input))
         else {
-            return;
-        };
-        let Some(session_id) = self.thread_session_id_or_warn(drop_site) else {
             return;
         };
         out.push(TrackEventRequest::Compaction(Box::new(
@@ -1291,7 +1285,7 @@ impl AnalyticsReducer {
                 event_type: "codex_compaction_event",
                 event_params: codex_compaction_event_params(
                     input,
-                    session_id.to_string(),
+                    thread_metadata.session_id.clone(),
                     connection_state.app_server_client.clone(),
                     connection_state.runtime.clone(),
                     thread_metadata.thread_source,
@@ -1390,14 +1384,11 @@ impl AnalyticsReducer {
             warn_missing_analytics_context(&drop_site, MissingAnalyticsContext::ThreadMetadata);
             return;
         };
-        let Some(session_id) = self.thread_session_id_or_warn(drop_site) else {
-            return;
-        };
         out.push(TrackEventRequest::TurnSteer(CodexTurnSteerEventRequest {
             event_type: "codex_turn_steer_event",
             event_params: CodexTurnSteerEventParams {
                 thread_id: pending_request.thread_id,
-                session_id: session_id.to_string(),
+                session_id: thread_metadata.session_id.clone(),
                 expected_turn_id: Some(pending_request.expected_turn_id),
                 accepted_turn_id,
                 app_server_client: connection_state.app_server_client.clone(),
@@ -1513,16 +1504,12 @@ impl AnalyticsReducer {
             warn_missing_analytics_context(&drop_site, MissingAnalyticsContext::ThreadMetadata);
             return;
         };
-        let Some(session_id) = self.thread_session_id_or_warn(drop_site) else {
-            return;
-        };
         let turn_event = TrackEventRequest::TurnEvent(Box::new(CodexTurnEventRequest {
             event_type: "codex_turn_event",
             event_params: codex_turn_event_params(
                 connection_state.app_server_client.clone(),
                 connection_state.runtime.clone(),
                 turn_id.to_string(),
-                session_id.to_string(),
                 turn_state,
                 thread_metadata,
             ),
@@ -1574,18 +1561,6 @@ impl AnalyticsReducer {
         };
         Some((connection_state, thread_metadata))
     }
-
-    fn thread_session_id_or_warn(&self, drop_site: AnalyticsDropSite<'_>) -> Option<&str> {
-        let Some(session_id) = self
-            .threads
-            .get(drop_site.thread_id)
-            .and_then(|thread| thread.session_id.as_deref())
-        else {
-            warn_missing_analytics_context(&drop_site, MissingAnalyticsContext::ThreadSessionId);
-            return None;
-        };
-        Some(session_id)
-    }
 }
 
 fn warn_missing_analytics_context(
@@ -1594,7 +1569,6 @@ fn warn_missing_analytics_context(
 ) {
     let (missing_context, connection_id) = match missing {
         MissingAnalyticsContext::ThreadConnection => ("thread_connection", None),
-        MissingAnalyticsContext::ThreadSessionId => ("thread_session_id", None),
         MissingAnalyticsContext::Connection { connection_id } => {
             ("connection", Some(connection_id))
         }
@@ -2447,7 +2421,6 @@ fn codex_turn_event_params(
     app_server_client: CodexAppServerClientMetadata,
     runtime: CodexRuntimeMetadata,
     turn_id: String,
-    session_id: String,
     turn_state: &TurnState,
     thread_metadata: &ThreadMetadataState,
 ) -> CodexTurnEventParams {
@@ -2484,7 +2457,7 @@ fn codex_turn_event_params(
     let token_usage = turn_state.token_usage.clone();
     CodexTurnEventParams {
         thread_id,
-        session_id,
+        session_id: thread_metadata.session_id.clone(),
         turn_id,
         app_server_client,
         runtime,

--- a/codex-rs/app-server/tests/suite/v2/analytics.rs
+++ b/codex-rs/app-server/tests/suite/v2/analytics.rs
@@ -168,11 +168,13 @@ pub(crate) fn thread_initialized_event(payload: &Value) -> Result<&Value> {
 pub(crate) fn assert_basic_thread_initialized_event(
     event: &Value,
     thread_id: &str,
+    session_id: &str,
     expected_model: &str,
     initialization_mode: &str,
     expected_thread_source: &str,
 ) {
     assert_eq!(event["event_params"]["thread_id"], thread_id);
+    assert_eq!(event["event_params"]["session_id"], session_id);
     assert_eq!(
         event["event_params"]["app_server_client"]["product_client_id"],
         DEFAULT_CLIENT_NAME

--- a/codex-rs/app-server/tests/suite/v2/thread_fork.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_fork.rs
@@ -405,7 +405,14 @@ async fn thread_fork_tracks_thread_initialized_analytics() -> Result<()> {
 
     let payload = wait_for_analytics_payload(&server, DEFAULT_READ_TIMEOUT).await?;
     let event = thread_initialized_event(&payload)?;
-    assert_basic_thread_initialized_event(event, &thread.id, "mock-model", "forked", "user");
+    assert_basic_thread_initialized_event(
+        event,
+        &thread.id,
+        &thread.session_id,
+        "mock-model",
+        "forked",
+        "user",
+    );
     Ok(())
 }
 

--- a/codex-rs/app-server/tests/suite/v2/thread_resume.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_resume.rs
@@ -422,7 +422,14 @@ async fn thread_resume_tracks_thread_initialized_analytics() -> Result<()> {
 
     let payload = wait_for_analytics_payload(&server, DEFAULT_READ_TIMEOUT).await?;
     let event = thread_initialized_event(&payload)?;
-    assert_basic_thread_initialized_event(event, &thread.id, "gpt-5.3-codex", "resumed", "user");
+    assert_basic_thread_initialized_event(
+        event,
+        &thread.id,
+        &thread.session_id,
+        "gpt-5.3-codex",
+        "resumed",
+        "user",
+    );
     assert_eq!(event["event_params"]["thread_source"], "user");
     Ok(())
 }

--- a/codex-rs/app-server/tests/suite/v2/thread_start.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_start.rs
@@ -439,7 +439,14 @@ async fn thread_start_tracks_thread_initialized_analytics() -> Result<()> {
     let payload = wait_for_analytics_payload(&server, DEFAULT_READ_TIMEOUT).await?;
     assert_eq!(payload["events"].as_array().expect("events array").len(), 1);
     let event = thread_initialized_event(&payload)?;
-    assert_basic_thread_initialized_event(event, &thread.id, "mock-model", "new", "user");
+    assert_basic_thread_initialized_event(
+        event,
+        &thread.id,
+        &thread.session_id,
+        "mock-model",
+        "new",
+        "user",
+    );
     Ok(())
 }
 

--- a/codex-rs/app-server/tests/suite/v2/turn_start.rs
+++ b/codex-rs/app-server/tests/suite/v2/turn_start.rs
@@ -862,6 +862,7 @@ async fn turn_start_tracks_turn_event_analytics() -> Result<()> {
 
     let event = wait_for_analytics_event(&server, DEFAULT_READ_TIMEOUT, "codex_turn_event").await?;
     assert_eq!(event["event_params"]["thread_id"], thread.id);
+    assert_eq!(event["event_params"]["session_id"], thread.session_id);
     assert_eq!(event["event_params"]["turn_id"], turn.id);
     assert_eq!(
         event["event_params"]["app_server_client"]["product_client_id"],

--- a/codex-rs/app-server/tests/suite/v2/turn_steer.rs
+++ b/codex-rs/app-server/tests/suite/v2/turn_steer.rs
@@ -306,6 +306,7 @@ async fn turn_steer_returns_active_turn_id() -> Result<()> {
     let event =
         wait_for_analytics_event(&server, DEFAULT_READ_TIMEOUT, "codex_turn_steer_event").await?;
     assert_eq!(event["event_params"]["thread_id"], thread.id);
+    assert_eq!(event["event_params"]["session_id"], thread.session_id);
     assert_eq!(event["event_params"]["result"], "accepted");
     assert_eq!(event["event_params"]["num_input_images"], 0);
     assert_eq!(event["event_params"]["expected_turn_id"], turn.id);

--- a/codex-rs/core/src/agent/control.rs
+++ b/codex-rs/core/src/agent/control.rs
@@ -317,6 +317,7 @@ impl AgentControl {
                     .services
                     .analytics_events_client,
                 client_metadata,
+                new_thread.thread.codex.session.session_id(),
                 new_thread.thread_id,
                 /*parent_thread_id*/ None,
                 thread_config,

--- a/codex-rs/core/src/codex_delegate.rs
+++ b/codex-rs/core/src/codex_delegate.rs
@@ -109,6 +109,7 @@ pub(crate) async fn run_codex_thread_interactive(
     emit_subagent_session_started(
         &parent_session.services.analytics_events_client,
         client_metadata,
+        codex.session.session_id(),
         codex.session.conversation_id,
         Some(parent_session.conversation_id),
         thread_config,

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -72,6 +72,7 @@ use codex_network_proxy::normalize_host;
 use codex_otel::current_span_trace_id;
 use codex_otel::current_span_w3c_trace_context;
 use codex_otel::set_parent_from_w3c_trace_context;
+use codex_protocol::SessionId;
 use codex_protocol::ThreadId;
 use codex_protocol::approvals::ElicitationRequestEvent;
 use codex_protocol::approvals::ExecPolicyAmendment;
@@ -3302,6 +3303,7 @@ impl Session {
 pub(crate) fn emit_subagent_session_started(
     analytics_events_client: &AnalyticsEventsClient,
     client_metadata: AppServerClientMetadata,
+    session_id: SessionId,
     thread_id: ThreadId,
     parent_thread_id: Option<ThreadId>,
     thread_config: ThreadConfigSnapshot,
@@ -3320,6 +3322,7 @@ pub(crate) fn emit_subagent_session_started(
         .unwrap_or_default()
         .as_secs();
     analytics_events_client.track_subagent_thread_started(SubAgentThreadStartedInput {
+        session_id: session_id.to_string(),
         thread_id: thread_id.to_string(),
         parent_thread_id: parent_thread_id.map(|thread_id| thread_id.to_string()),
         product_client_id: client_name.clone(),


### PR DESCRIPTION
## Why
- Runtime analytics events report `thread_id`, which identifies the individual thread emitting an event
- They don't report `session_id`, which identifies the shared session for a root thread and its subagent threads
- Emitting both identifiers allows analytics to group related activity

## What Changed
- Adds `session_id` to relevant analytics events (thread_initalized, turn, turn_steer, compaction, guardian_review)
- Tracks each thread's session ID in the analytics reducer so subsequent thread scoped events emit the same value
- Carries the shared session ID through subagent initialization

## Verification
- `just test -p codex-analytics` validates event payloads and subagent session grouping.
- Focused `codex-app-server` tests validate session IDs for thread, turn, and steer events.
- Focused `codex-core` tests validate root and subagent session ID propagation.