### PR TITLE
[codex] Remove obsolete goal continuation turn marker

### DIFF
--- a/codex-rs/core/src/goals.rs
+++ b/codex-rs/core/src/goals.rs
@@ -172,7 +172,6 @@ pub(crate) struct GoalRuntimeState {
     pub(crate) budget_limit_reported_goal_id: Mutex<Option<String>>,
     accounting_lock: Semaphore,
     accounting: Mutex<GoalAccountingSnapshot>,
-    continuation_turn_id: Mutex<Option<String>>,
     pub(crate) continuation_lock: Semaphore,
 }
 
@@ -188,7 +187,6 @@ impl GoalRuntimeState {
             budget_limit_reported_goal_id: Mutex::new(None),
             accounting_lock: Semaphore::new(/*permits*/ 1),
             accounting: Mutex::new(GoalAccountingSnapshot::new()),
-            continuation_turn_id: Mutex::new(None),
             continuation_lock: Semaphore::new(/*permits*/ 1),
         }
     }
@@ -900,20 +898,6 @@ impl Session {
         }
     }
 
-    async fn mark_thread_goal_continuation_turn_started(&self, turn_id: String) {
-        *self.goal_runtime.continuation_turn_id.lock().await = Some(turn_id);
-    }
-
-    async fn take_thread_goal_continuation_turn(&self, turn_id: &str) -> bool {
-        let mut continuation_turn_id = self.goal_runtime.continuation_turn_id.lock().await;
-        if continuation_turn_id.as_deref() == Some(turn_id) {
-            *continuation_turn_id = None;
-            true
-        } else {
-            false
-        }
-    }
-
     async fn clear_reserved_goal_continuation_turn(&self, turn_state: &Arc<Mutex<TurnState>>) {
         let mut active_turn_guard = self.active_turn.lock().await;
         if let Some(active_turn) = active_turn_guard.as_ref()
@@ -941,8 +925,6 @@ impl Session {
             tracing::warn!("failed to account thread goal progress at turn end: {err}");
         }
 
-        self.take_thread_goal_continuation_turn(&turn_context.sub_id)
-            .await;
         if turn_completed {
             let mut accounting = self.goal_runtime.accounting.lock().await;
             if accounting
@@ -957,8 +939,6 @@ impl Session {
 
     async fn handle_thread_goal_task_abort(&self, turn_context: Option<&TurnContext>) {
         if let Some(turn_context) = turn_context {
-            self.take_thread_goal_continuation_turn(&turn_context.sub_id)
-                .await;
             if let Err(err) = self
                 .account_thread_goal_progress(
                     turn_context,
@@ -1373,8 +1353,6 @@ impl Session {
                 .await;
             return;
         }
-        self.mark_thread_goal_continuation_turn_started(turn_context.sub_id.clone())
-            .await;
         self.start_task(turn_context, Vec::new(), RegularTask::new())
             .await;
     }


### PR DESCRIPTION
## Why

`continuation_turn_id` was introduced to distinguish synthetic goal continuation turns for the no-tool continuation suppression heuristic. #20523 removed that heuristic, but left the marker behind. It is still written and cleared without affecting any runtime decision.

## What Changed

- Remove `GoalRuntimeState::continuation_turn_id`.
- Remove the marker setter/clearer and their now-no-op start, finish, and abort call sites.

## Testing

- Not run yet (deferred at request).
