### PR TITLE
Keep standalone web search schema within tool schema budget

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/web_search.rs
+++ b/codex-rs/app-server/tests/suite/v2/web_search.rs
@@ -112,9 +112,12 @@ async fn standalone_web_search_round_trips_encrypted_output() -> Result<()> {
     assert_eq!(requests.len(), 2);
 
     let first_response = requests[0].body_json();
-    assert!(
-        requests[0].tool_by_name("web", "run").is_some(),
-        "web.run should be sent to the model"
+    let web_run = requests[0]
+        .tool_by_name("web", "run")
+        .context("web.run should be sent to the model")?;
+    assert_eq!(
+        web_run.pointer("/parameters/properties/time/items/properties/utc_offset/description"),
+        Some(&json!("UTC offset formatted like \"+03:00\"."))
     );
     assert!(
         !has_hosted_web_search(&first_response),

--- a/codex-rs/codex-api/src/search.rs
+++ b/codex-rs/codex-api/src/search.rs
@@ -30,37 +30,26 @@ pub enum SearchInput {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, JsonSchema)]
 pub struct SearchCommands {
-    /// Query the internet search engine for a given list of queries.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub search_query: Option<Vec<SearchQuery>>,
-    /// Query the image search engine for a given list of queries.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub image_query: Option<Vec<SearchQuery>>,
-    /// Open pages by reference id or URL.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub open: Option<Vec<OpenOperation>>,
-    /// Open links from previously opened pages.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub click: Option<Vec<ClickOperation>>,
-    /// Find text patterns in pages.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub find: Option<Vec<FindOperation>>,
-    /// Take screenshots of PDF pages.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub screenshot: Option<Vec<ScreenshotOperation>>,
-    /// Look up prices for the given stock symbols.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub finance: Option<Vec<FinanceOperation>>,
-    /// Look up weather forecasts.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub weather: Option<Vec<WeatherOperation>>,
-    /// Look up sports schedules and standings.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sports: Option<Vec<SportsOperation>>,
-    /// Get time for the given UTC offsets.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub time: Option<Vec<TimeOperation>>,
-    /// Set the length of the response to be returned.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub response_length: Option<SearchResponseLength>,
 }


### PR DESCRIPTION
## Summary

Standalone `web.run` currently exceeds the generic tool-schema compaction budget because command-family descriptions repeat information already supplied by its tool description and examples. Compaction then strips useful nested argument guidance from the model-visible schema.

- Remove redundant top-level `SearchCommands` descriptions while retaining nested argument descriptions.
- Assert in the existing app-server round trip that representative nested guidance is sent with `web.run`.

This reduces the normalized schema from 4,280 to 3,653 bytes, keeping it under the existing 4,000-byte budget without a web-search-specific bypass.

## Tests

- `cargo test -p codex-api`
- `cargo test -p codex-app-server standalone_web_search_round_trips_encrypted_output`