### PR TITLE
[codex] Start idle turns without reservations

### DIFF
--- a/codex-rs/core/src/goals.rs
+++ b/codex-rs/core/src/goals.rs
@@ -10,8 +10,6 @@ use crate::context::GoalContext;
 use crate::session::TurnInput;
 use crate::session::session::Session;
 use crate::session::turn_context::TurnContext;
-use crate::state::ActiveTurn;
-use crate::state::TurnState;
 use crate::tasks::RegularTask;
 use crate::tools::handlers::goal_spec::UPDATE_GOAL_TOOL_NAME;
 use anyhow::Context;
@@ -898,16 +896,6 @@ impl Session {
         }
     }
 
-    async fn clear_reserved_goal_continuation_turn(&self, turn_state: &Arc<Mutex<TurnState>>) {
-        let mut active_turn_guard = self.active_turn.lock().await;
-        if let Some(active_turn) = active_turn_guard.as_ref()
-            && active_turn.task.is_none()
-            && Arc::ptr_eq(&active_turn.turn_state, turn_state)
-        {
-            *active_turn_guard = None;
-        }
-    }
-
     async fn finish_thread_goal_turn(
         self: &Arc<Self>,
         turn_context: &TurnContext,
@@ -1281,14 +1269,6 @@ impl Session {
             return;
         };
 
-        let turn_state = {
-            let mut active_turn = self.active_turn.lock().await;
-            if active_turn.is_some() {
-                return;
-            }
-            let active_turn = active_turn.get_or_insert_with(ActiveTurn::default);
-            Arc::clone(&active_turn.turn_state)
-        };
         let goal_is_current = match self.state_db_for_thread_goals().await {
             Ok(Some(state_db)) => match state_db
                 .thread_goals()
@@ -1322,39 +1302,20 @@ impl Session {
             }
         };
         if !goal_is_current {
-            self.clear_reserved_goal_continuation_turn(&turn_state)
-                .await;
             return;
         }
-        self.input_queue
-            .extend_pending_input_for_turn_state(
-                turn_state.as_ref(),
-                candidate
-                    .items
-                    .into_iter()
-                    .map(TurnInput::ResponseInputItem)
-                    .collect(),
-            )
-            .await;
 
-        let turn_context = self
-            .new_default_turn_with_sub_id(uuid::Uuid::new_v4().to_string())
-            .await;
-        self.maybe_emit_unknown_model_warning_for_turn(turn_context.as_ref())
-            .await;
-        let still_reserved = {
-            let active_turn = self.active_turn.lock().await;
-            active_turn.as_ref().is_some_and(|active_turn| {
-                active_turn.task.is_none() && Arc::ptr_eq(&active_turn.turn_state, &turn_state)
-            })
-        };
-        if !still_reserved {
-            self.clear_reserved_goal_continuation_turn(&turn_state)
-                .await;
-            return;
-        }
-        self.start_task(turn_context, Vec::new(), RegularTask::new())
-            .await;
+        let turn_context = self.new_default_turn().await;
+        self.try_start_turn_if_idle(
+            turn_context,
+            candidate
+                .items
+                .into_iter()
+                .map(TurnInput::ResponseInputItem)
+                .collect(),
+            RegularTask::new(),
+        )
+        .await;
     }
 
     async fn goal_continuation_candidate_if_active(

--- a/codex-rs/core/src/session/handlers.rs
+++ b/codex-rs/core/src/session/handlers.rs
@@ -260,7 +260,7 @@ pub(super) async fn user_input_or_turn_inner(
             if !items.is_empty() {
                 task_input.push(TurnInput::UserInput(items));
             }
-            sess.spawn_task(
+            sess.replace_turn(
                 Arc::clone(&current_context),
                 task_input,
                 crate::tasks::RegularTask::new(),
@@ -308,7 +308,6 @@ async fn mirror_user_text_to_realtime(sess: &Arc<Session>, items: &[UserInput]) 
 /// decide whether an idle session should start a regular turn.
 pub async fn inter_agent_communication(
     sess: &Arc<Session>,
-    sub_id: String,
     communication: InterAgentCommunication,
 ) {
     let trigger_turn = communication.trigger_turn;
@@ -316,8 +315,7 @@ pub async fn inter_agent_communication(
         .enqueue_mailbox_communication(communication)
         .await;
     if trigger_turn {
-        sess.maybe_start_turn_for_pending_work_with_sub_id(sub_id)
-            .await;
+        sess.maybe_start_turn_for_pending_work().await;
     }
 }
 
@@ -340,7 +338,7 @@ pub async fn run_user_shell_command(sess: &Arc<Session>, sub_id: String, command
     }
 
     let turn_context = sess.new_default_turn_with_sub_id(sub_id).await;
-    sess.spawn_task(
+    sess.replace_turn(
         Arc::clone(&turn_context),
         Vec::new(),
         UserShellCommandTask::new(command),
@@ -474,7 +472,7 @@ pub async fn reload_user_config(sess: &Arc<Session>) {
 pub async fn compact(sess: &Arc<Session>, sub_id: String) {
     let turn_context = sess.new_default_turn_with_sub_id(sub_id).await;
 
-    sess.spawn_task(Arc::clone(&turn_context), Vec::new(), CompactTask)
+    sess.replace_turn(Arc::clone(&turn_context), Vec::new(), CompactTask)
         .await;
 }
 
@@ -779,7 +777,7 @@ pub(super) async fn submission_loop(
                     false
                 }
                 Op::InterAgentCommunication { communication } => {
-                    inter_agent_communication(&sess, sub.id.clone(), communication).await;
+                    inter_agent_communication(&sess, communication).await;
                     false
                 }
                 Op::ExecApproval {

--- a/codex-rs/core/src/session/review.rs
+++ b/codex-rs/core/src/session/review.rs
@@ -144,10 +144,10 @@ pub(super) async fn spawn_review_thread(
     }])];
     let tc = Arc::new(review_turn_context);
     tc.turn_metadata_state.spawn_git_enrichment_task();
-    // TODO(ccunningham): Review turns currently rely on `spawn_task` for TurnComplete but do not
+    // TODO(ccunningham): Review turns currently rely on `replace_turn` for TurnComplete but do not
     // emit a parent TurnStarted. Consider giving review a full parent turn lifecycle
     // (TurnStarted + TurnComplete) for consistency with other standalone tasks.
-    sess.spawn_task(tc.clone(), input, ReviewTask::new()).await;
+    sess.replace_turn(tc.clone(), input, ReviewTask).await;
 
     // Announce entering review mode so UIs can switch modes.
     let review_request = ReviewRequest {

--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -31,6 +31,8 @@ pub(crate) struct Session {
     pub(super) features: ManagedFeatures,
     pub(super) pending_mcp_server_refresh_config: Mutex<Option<McpServerRefreshConfig>>,
     pub(crate) conversation: Arc<RealtimeConversationManager>,
+    /// Serializes turn admission policy without representing idle work as an active turn.
+    pub(crate) turn_admission_lock: Mutex<()>,
     pub(crate) active_turn: Mutex<Option<ActiveTurn>>,
     pub(crate) input_queue: InputQueue,
     pub(crate) goal_runtime: GoalRuntimeState,
@@ -1055,6 +1057,7 @@ impl Session {
                 features: config.features.clone(),
                 pending_mcp_server_refresh_config: Mutex::new(None),
                 conversation: Arc::new(RealtimeConversationManager::new()),
+                turn_admission_lock: Mutex::new(()),
                 active_turn: Mutex::new(None),
                 input_queue: InputQueue::new(),
                 goal_runtime: GoalRuntimeState::new(),

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -299,7 +299,7 @@ async fn regular_turn_emits_turn_started_with_trace_id_without_waiting_for_start
         ),
     )
     .await;
-    sess.spawn_task(
+    sess.try_start_turn_if_idle(
         Arc::clone(&tc),
         Vec::new(),
         crate::tasks::RegularTask::new(),
@@ -380,7 +380,7 @@ async fn interrupting_regular_turn_waiting_on_startup_prewarm_emits_turn_aborted
         ),
     )
     .await;
-    sess.spawn_task(
+    sess.try_start_turn_if_idle(
         Arc::clone(&tc),
         Vec::new(),
         crate::tasks::RegularTask::new(),
@@ -2018,7 +2018,7 @@ async fn turn_start_lifecycle_exposes_turn_metadata_and_token_baseline() {
     };
 
     let sess = Arc::new(session);
-    sess.spawn_task(
+    sess.try_start_turn_if_idle(
         Arc::new(turn_context),
         Vec::new(),
         NeverEndingTask {
@@ -4640,6 +4640,7 @@ pub(crate) async fn make_session_and_context() -> (Session, TurnContext) {
         features: config.features.clone(),
         pending_mcp_server_refresh_config: Mutex::new(None),
         conversation: Arc::new(RealtimeConversationManager::new()),
+        turn_admission_lock: Mutex::new(()),
         active_turn: Mutex::new(None),
         input_queue: super::input_queue::InputQueue::new(),
         goal_runtime: crate::goals::GoalRuntimeState::new(),
@@ -5732,7 +5733,7 @@ async fn duplicate_turn_environment_returns_error_without_mutating_session() {
 }
 
 #[tokio::test]
-async fn spawn_task_turn_span_inherits_dispatch_trace_context() {
+async fn try_start_turn_if_idle_turn_span_inherits_dispatch_trace_context() {
     struct TraceCaptureTask {
         captured_trace: Arc<std::sync::Mutex<Option<W3cTraceContext>>>,
     }
@@ -5790,7 +5791,7 @@ async fn spawn_task_turn_span_inherits_dispatch_trace_context() {
     let captured_trace = Arc::new(std::sync::Mutex::new(None));
 
     async {
-        sess.spawn_task(
+        sess.try_start_turn_if_idle(
             Arc::clone(&tc),
             vec![TurnInput::UserInput(vec![UserInput::Text {
                 text: "hello".to_string(),
@@ -5976,7 +5977,7 @@ async fn submission_loop_channel_close_aborts_active_turn_before_thread_stop_lif
 
     let session = Arc::new(session);
     session
-        .spawn_task(
+        .try_start_turn_if_idle(
             Arc::new(turn_context),
             Vec::new(),
             NeverEndingTask {
@@ -6475,6 +6476,7 @@ where
         features: config.features.clone(),
         pending_mcp_server_refresh_config: Mutex::new(None),
         conversation: Arc::new(RealtimeConversationManager::new()),
+        turn_admission_lock: Mutex::new(()),
         active_turn: Mutex::new(None),
         input_queue: super::input_queue::InputQueue::new(),
         goal_runtime: crate::goals::GoalRuntimeState::new(),
@@ -6600,7 +6602,7 @@ async fn refresh_mcp_servers_is_deferred_until_next_turn() {
 }
 
 #[tokio::test]
-async fn spawn_task_does_not_update_previous_turn_settings_for_non_run_turn_tasks() {
+async fn try_start_turn_if_idle_does_not_update_previous_turn_settings_for_non_run_turn_tasks() {
     let (sess, tc, _rx) = make_session_and_context_with_rx().await;
     sess.set_previous_turn_settings(/*previous_turn_settings*/ None)
         .await;
@@ -6609,7 +6611,7 @@ async fn spawn_task_does_not_update_previous_turn_settings_for_non_run_turn_task
         text_elements: Vec::new(),
     }])];
 
-    sess.spawn_task(
+    sess.try_start_turn_if_idle(
         Arc::clone(&tc),
         input,
         NeverEndingTask {
@@ -7877,7 +7879,7 @@ async fn guardian_auto_review_interrupts_after_three_consecutive_denials() {
         text: "trigger guardian denials".to_string(),
         text_elements: Vec::new(),
     }])];
-    sess.spawn_task(Arc::clone(&tc), input, GuardianDeniedApprovalTask)
+    sess.try_start_turn_if_idle(Arc::clone(&tc), input, GuardianDeniedApprovalTask)
         .await;
 
     let mut observed = Vec::new();
@@ -7908,7 +7910,7 @@ async fn guardian_helper_review_interrupts_after_three_consecutive_denials() {
         text: "keep turn active for helper reviews".to_string(),
         text_elements: Vec::new(),
     }])];
-    sess.spawn_task(
+    sess.try_start_turn_if_idle(
         Arc::clone(&tc),
         input,
         NeverEndingTask {
@@ -7968,7 +7970,7 @@ async fn abort_regular_task_emits_turn_aborted_only() {
         text: "hello".to_string(),
         text_elements: Vec::new(),
     }])];
-    sess.spawn_task(
+    sess.try_start_turn_if_idle(
         Arc::clone(&tc),
         input,
         NeverEndingTask {
@@ -8001,7 +8003,7 @@ async fn abort_gracefully_emits_turn_aborted_only() {
         text: "hello".to_string(),
         text_elements: Vec::new(),
     }])];
-    sess.spawn_task(
+    sess.try_start_turn_if_idle(
         Arc::clone(&tc),
         input,
         NeverEndingTask {
@@ -8034,7 +8036,7 @@ async fn task_finish_emits_turn_item_lifecycle_for_leftover_pending_user_input()
         text: "hello".to_string(),
         text_elements: Vec::new(),
     }])];
-    sess.spawn_task(
+    sess.try_start_turn_if_idle(
         Arc::clone(&tc),
         input,
         NeverEndingTask {
@@ -8171,7 +8173,7 @@ async fn steer_input_enforces_expected_turn_id() {
         text: "hello".to_string(),
         text_elements: Vec::new(),
     }])];
-    sess.spawn_task(
+    sess.try_start_turn_if_idle(
         Arc::clone(&tc),
         input,
         NeverEndingTask {
@@ -8218,7 +8220,7 @@ async fn steer_input_rejects_non_regular_turns() {
             text_elements: Vec::new(),
         }])];
         let turn_context = sess.new_default_turn_with_sub_id("turn".to_string()).await;
-        sess.spawn_task(
+        sess.try_start_turn_if_idle(
             turn_context,
             input,
             NeverEndingTask {
@@ -8255,7 +8257,7 @@ async fn steer_input_returns_active_turn_id() {
         text: "hello".to_string(),
         text_elements: Vec::new(),
     }])];
-    sess.spawn_task(
+    sess.try_start_turn_if_idle(
         Arc::clone(&tc),
         input,
         NeverEndingTask {
@@ -8298,7 +8300,7 @@ async fn queued_response_items_for_next_turn_move_into_next_active_turn() {
         .queue_response_items_for_next_turn(vec![queued_item.clone()])
         .await;
 
-    sess.spawn_task(
+    sess.try_start_turn_if_idle(
         Arc::clone(&tc),
         Vec::new(),
         NeverEndingTask {
@@ -8385,7 +8387,7 @@ async fn interrupt_accounts_active_goal_without_pausing() -> anyhow::Result<()> 
     )
     .await?;
 
-    sess.spawn_task(
+    sess.try_start_turn_if_idle(
         Arc::clone(&tc),
         Vec::new(),
         NeverEndingTask {
@@ -8764,7 +8766,7 @@ async fn budget_limited_accounting_steers_active_turn_without_aborting() -> anyh
         token_usage: TokenUsage::default(),
     })
     .await?;
-    sess.spawn_task(
+    sess.try_start_turn_if_idle(
         Arc::clone(&tc),
         Vec::new(),
         NeverEndingTask {
@@ -8871,7 +8873,7 @@ async fn usage_limit_runtime_stops_active_goal_and_prevents_idle_continuation() 
         token_usage: TokenUsage::default(),
     })
     .await?;
-    sess.spawn_task(
+    sess.try_start_turn_if_idle(
         Arc::clone(&tc),
         Vec::new(),
         NeverEndingTask {
@@ -8916,7 +8918,7 @@ async fn external_goal_mutation_accounts_active_turn_before_status_change() -> a
         },
     )
     .await?;
-    sess.spawn_task(
+    sess.try_start_turn_if_idle(
         Arc::clone(&tc),
         Vec::new(),
         NeverEndingTask {
@@ -8978,7 +8980,7 @@ async fn external_goal_mutation_accounts_active_turn_before_status_change() -> a
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn external_objective_change_steers_active_turn() -> anyhow::Result<()> {
     let (sess, tc, _rx, _codex_home) = make_goal_session_and_context_with_rx().await;
-    sess.spawn_task(
+    sess.try_start_turn_if_idle(
         Arc::clone(&tc),
         Vec::new(),
         NeverEndingTask {
@@ -9044,7 +9046,7 @@ async fn external_objective_change_steers_active_turn() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn external_active_goal_set_marks_current_turn_for_accounting() -> anyhow::Result<()> {
     let (sess, tc, _rx, _codex_home) = make_goal_session_and_context_with_rx().await;
-    sess.spawn_task(
+    sess.try_start_turn_if_idle(
         Arc::clone(&tc),
         Vec::new(),
         NeverEndingTask {
@@ -9215,7 +9217,7 @@ async fn queue_only_mailbox_mail_waits_for_next_turn_after_answer_boundary() {
         "late queue-only update".to_string(),
         /*trigger_turn*/ false,
     );
-    sess.spawn_task(
+    sess.try_start_turn_if_idle(
         Arc::clone(&tc),
         Vec::new(),
         NeverEndingTask {
@@ -9254,7 +9256,7 @@ async fn queue_only_mailbox_mail_waits_for_next_turn_after_answer_boundary() {
 #[tokio::test]
 async fn trigger_turn_mailbox_mail_waits_for_next_turn_after_answer_boundary() {
     let (sess, tc, _rx) = make_session_and_context_with_rx().await;
-    sess.spawn_task(
+    sess.try_start_turn_if_idle(
         Arc::clone(&tc),
         Vec::new(),
         NeverEndingTask {
@@ -9297,7 +9299,7 @@ async fn steered_input_reopens_mailbox_delivery_for_current_turn() {
         "queued child update".to_string(),
         /*trigger_turn*/ false,
     );
-    sess.spawn_task(
+    sess.try_start_turn_if_idle(
         Arc::clone(&tc),
         Vec::new(),
         NeverEndingTask {
@@ -9347,7 +9349,7 @@ async fn stale_defer_mailbox_delivery_does_not_override_steered_input() {
         "queued child update".to_string(),
         /*trigger_turn*/ false,
     );
-    sess.spawn_task(
+    sess.try_start_turn_if_idle(
         Arc::clone(&tc),
         Vec::new(),
         NeverEndingTask {
@@ -9401,7 +9403,7 @@ async fn tool_calls_reopen_mailbox_delivery_for_current_turn() {
         "queued child update".to_string(),
         /*trigger_turn*/ false,
     );
-    sess.spawn_task(
+    sess.try_start_turn_if_idle(
         Arc::clone(&tc),
         Vec::new(),
         NeverEndingTask {
@@ -9454,7 +9456,7 @@ async fn abort_review_task_emits_exited_then_aborted_and_records_history() {
         text: "start review".to_string(),
         text_elements: Vec::new(),
     }])];
-    sess.spawn_task(Arc::clone(&tc), input, ReviewTask::new())
+    sess.try_start_turn_if_idle(Arc::clone(&tc), input, ReviewTask::new())
         .await;
 
     sess.abort_all_tasks(TurnAbortReason::Interrupted).await;

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -33,6 +33,7 @@ use crate::session::turn_context::TurnContext;
 use crate::state::ActiveTurn;
 use crate::state::RunningTask;
 use crate::state::TaskKind;
+use crate::state::TurnState;
 use codex_analytics::TurnTokenUsageFact;
 use codex_login::AuthManager;
 use codex_models_manager::manager::SharedModelsManager;
@@ -299,26 +300,30 @@ where
 }
 
 impl Session {
-    pub async fn spawn_task<T: SessionTask>(
+    pub(crate) async fn replace_turn(
         self: &Arc<Self>,
         turn_context: Arc<TurnContext>,
         input: Vec<TurnInput>,
-        task: T,
+        task: impl SessionTask,
     ) {
+        let _admission = self.turn_admission_lock.lock().await;
         self.abort_all_tasks(TurnAbortReason::Replaced).await;
         self.clear_connector_selection().await;
-        self.start_task(turn_context, input, task).await;
+        let mut active = self.active_turn.lock().await;
+        debug_assert!(active.is_none());
+        *active = Some(self.start_turn(turn_context, input, task));
     }
 
-    pub(crate) async fn start_task<T: SessionTask>(
-        self: &Arc<Self>,
+    async fn run_turn(
+        self: Arc<Self>,
         turn_context: Arc<TurnContext>,
-        input: Vec<TurnInput>,
-        task: T,
+        turn_state: Arc<tokio::sync::Mutex<TurnState>>,
+        task_for_run: Arc<dyn AnySessionTask>,
+        session_ctx: Arc<SessionTaskContext>,
+        task_input: Vec<TurnInput>,
+        task_cancellation_token: CancellationToken,
+        done_clone: Arc<Notify>,
     ) {
-        let task: Arc<dyn AnySessionTask> = Arc::new(task);
-        let task_kind = task.kind();
-        let span_name = task.span_name();
         let started_at = Instant::now();
         let turn_started_at_unix_ms = turn_context
             .turn_timing_state
@@ -328,9 +333,6 @@ impl Session {
             .turn_metadata_state
             .set_turn_started_at_unix_ms(turn_started_at_unix_ms);
         let token_usage_at_turn_start = self.total_token_usage().await.unwrap_or_default();
-
-        let cancellation_token = CancellationToken::new();
-        let done = Arc::new(Notify::new());
 
         self.services
             .guardian_rejection_circuit_breaker
@@ -352,12 +354,6 @@ impl Session {
             .take_queued_response_items_for_next_turn()
             .await;
         let mailbox_items = self.input_queue.get_pending_input(&self.active_turn).await;
-        let turn_state = {
-            let mut active = self.active_turn.lock().await;
-            let turn = active.get_or_insert_with(ActiveTurn::default);
-            debug_assert!(turn.task.is_none());
-            Arc::clone(&turn.turn_state)
-        };
         turn_state.lock().await.token_usage_at_turn_start = token_usage_at_turn_start.clone();
         let mut pending_items = queued_response_items
             .into_iter()
@@ -369,17 +365,60 @@ impl Session {
             .await;
         self.emit_turn_start_lifecycle(turn_context.as_ref(), &token_usage_at_turn_start)
             .await;
+        if task_cancellation_token.is_cancelled() {
+            done_clone.notify_waiters();
+            return;
+        }
 
+        let ctx = turn_context;
+        let ctx_for_finish = Arc::clone(&ctx);
+        let last_agent_message = task_for_run
+            .run(
+                Arc::clone(&session_ctx),
+                ctx,
+                task_input,
+                task_cancellation_token.child_token(),
+            )
+            .await;
+        let sess = session_ctx.clone_session();
+        if let Err(err) = sess.flush_rollout().await {
+            warn!("failed to flush rollout before completing turn: {err}");
+            sess.send_event(
+                ctx_for_finish.as_ref(),
+                EventMsg::Warning(WarningEvent {
+                    message: format!(
+                        "Failed to save the conversation transcript; Codex will continue retrying. Error: {err}"
+                    ),
+                }),
+            )
+            .await;
+        }
+        if !task_cancellation_token.is_cancelled() {
+            // Emit completion uniformly from spawn site so all tasks share the same lifecycle.
+            sess.on_task_finished(Arc::clone(&ctx_for_finish), last_agent_message)
+                .await;
+        }
+        done_clone.notify_waiters();
+    }
+
+    fn start_turn(
+        self: &Arc<Self>,
+        turn_context: Arc<TurnContext>,
+        input: Vec<TurnInput>,
+        task: impl SessionTask,
+    ) -> ActiveTurn {
+        let task: Arc<dyn AnySessionTask> = Arc::new(task);
+        let task_kind = task.kind();
+        let span_name = task.span_name();
+        let cancellation_token = CancellationToken::new();
+        let done = Arc::new(Notify::new());
+        let turn_state = Arc::new(tokio::sync::Mutex::new(TurnState::default()));
         let turn_extension_data = Arc::clone(&turn_context.extension_data);
-        let mut active = self.active_turn.lock().await;
-        let turn = active.get_or_insert_with(ActiveTurn::default);
-        debug_assert!(turn.task.is_none());
         let done_clone = Arc::clone(&done);
         let session_ctx = Arc::new(SessionTaskContext::new(
             Arc::clone(self),
             Arc::clone(&turn_extension_data),
         ));
-        let ctx = Arc::clone(&turn_context);
         let task_for_run = Arc::clone(&task);
         let task_input = input;
         let task_cancellation_token = cancellation_token.child_token();
@@ -401,37 +440,17 @@ impl Session {
             codex.turn.token_usage.total_tokens = field::Empty,
         );
         let handle = tokio::spawn(
-            async move {
-                let ctx_for_finish = Arc::clone(&ctx);
-                let last_agent_message = task_for_run
-                    .run(
-                        Arc::clone(&session_ctx),
-                        ctx,
-                        task_input,
-                        task_cancellation_token.child_token(),
-                    )
-                    .await;
-                let sess = session_ctx.clone_session();
-                if let Err(err) = sess.flush_rollout().await {
-                    warn!("failed to flush rollout before completing turn: {err}");
-                    sess.send_event(
-                        ctx_for_finish.as_ref(),
-                        EventMsg::Warning(WarningEvent {
-                            message: format!(
-                                "Failed to save the conversation transcript; Codex will continue retrying. Error: {err}"
-                            ),
-                        }),
-                    )
-                    .await;
-                }
-                if !task_cancellation_token.is_cancelled() {
-                    // Emit completion uniformly from spawn site so all tasks share the same lifecycle.
-                    sess.on_task_finished(Arc::clone(&ctx_for_finish), last_agent_message)
-                        .await;
-                }
-                done_clone.notify_waiters();
-            }
-            .instrument(task_span),
+            Arc::clone(self)
+                .run_turn(
+                    Arc::clone(&turn_context),
+                    Arc::clone(&turn_state),
+                    task_for_run,
+                    session_ctx,
+                    task_input,
+                    task_cancellation_token,
+                    done_clone,
+                )
+                .instrument(task_span),
         );
         let timer = turn_context
             .session_telemetry
@@ -447,30 +466,31 @@ impl Session {
             turn_extension_data,
             _timer: timer,
         };
-        turn.task = Some(running_task);
+        ActiveTurn {
+            task: Some(running_task),
+            turn_state,
+        }
     }
 
-    /// Starts a regular turn when the session is idle and pending work is waiting.
-    ///
-    /// Pending work currently includes queued next-turn items and mailbox mail marked with
-    /// `trigger_turn`.
-    ///
-    /// This helper generates a fresh sub-id for the synthetic turn before delegating to the
-    /// explicit-sub-id variant.
-    pub(crate) async fn maybe_start_turn_for_pending_work(self: &Arc<Self>) {
-        self.maybe_start_turn_for_pending_work_with_sub_id(uuid::Uuid::new_v4().to_string())
-            .await;
+    pub(crate) async fn try_start_turn_if_idle(
+        self: &Arc<Self>,
+        turn_context: Arc<TurnContext>,
+        input: Vec<TurnInput>,
+        task: impl SessionTask,
+    ) {
+        let _admission = self.turn_admission_lock.lock().await;
+        let mut active = self.active_turn.lock().await;
+        if active.is_some() {
+            return;
+        }
+        *active = Some(self.start_turn(turn_context, input, task));
     }
 
-    /// Starts a regular turn with the provided sub-id when pending work should wake an idle
-    /// session.
+    /// Starts a regular turn when pending work should wake an idle session.
     ///
     /// The turn is created only when there are queued next-turn items or mailbox mail marked with
     /// `trigger_turn`, and only if the session is currently idle.
-    pub(crate) async fn maybe_start_turn_for_pending_work_with_sub_id(
-        self: &Arc<Self>,
-        sub_id: String,
-    ) {
+    pub(crate) async fn maybe_start_turn_for_pending_work(self: &Arc<Self>) {
         if !self
             .input_queue
             .has_queued_response_items_for_next_turn()
@@ -480,18 +500,8 @@ impl Session {
             return;
         }
 
-        {
-            let mut active_turn = self.active_turn.lock().await;
-            if active_turn.is_some() {
-                return;
-            }
-            *active_turn = Some(ActiveTurn::default());
-        }
-
-        let turn_context = self.new_default_turn_with_sub_id(sub_id).await;
-        self.maybe_emit_unknown_model_warning_for_turn(turn_context.as_ref())
-            .await;
-        self.start_task(turn_context, Vec::new(), RegularTask::new())
+        let turn_context = self.new_default_turn().await;
+        self.try_start_turn_if_idle(turn_context, Vec::new(), RegularTask::new())
             .await;
     }
 


### PR DESCRIPTION
## Why

Goal continuation currently reserves an `ActiveTurn` without a running task while it revalidates persisted goal state. That creates a partial-active state just to schedule later work, and gives goals a separate turn-start flow from other idle work.

## What changed

- Add `try_start_turn_if_idle` as the shared idle-only entry point, with task construction/spawning in `start_turn` and task execution in `run_turn`.
- Keep `replace_turn` preemptive for user turns, standalone shell commands, compaction, and review.
- Add `turn_admission_lock` so explicit replacement and idle-only startup cannot race during admission without using a taskless `ActiveTurn` reservation.
- Start goal continuation and queued pending work only when idle admission succeeds, removing goal-specific turn reservation and cleanup.
- Use `new_default_turn()` for automatic idle wake-ups so they follow one internal turn-id allocation path.
- Publish a real running task when idle startup wins, rather than reserving a taskless active turn before launch.

## Behavior tradeoffs

- Goal continuation no longer claims an idle slot while checking that its goal is still current; explicit replacement retains priority when it competes with automatic idle work.
- Trigger-turn inter-agent wake-ups now use an internally allocated turn id instead of preserving the triggering submission id as the new turn id.
- Goal continuation and queued pending-work startup no longer use their prior pre-launch unknown-model warning call path.

## Validation

- `git diff --check`
- Tests not run, per request to defer tests.
