### PR TITLE
Fix guardian review test user input

### DIFF
--- a/codex-rs/core/tests/suite/guardian_review.rs
+++ b/codex-rs/core/tests/suite/guardian_review.rs
@@ -118,6 +118,7 @@ printf '%s\n' "${@: -1}" >> "${payload_path}""#,
             }],
             final_output_json_schema: None,
             responsesapi_client_metadata: None,
+            additional_context: Default::default(),
             thread_settings: codex_protocol::protocol::ThreadSettingsOverrides {
                 cwd: Some(test.cwd.path().to_path_buf()),
                 approval_policy: Some(approval_policy),


### PR DESCRIPTION
## Summary
- Add the missing additional_context field to the guardian review Op::UserInput test initializer.

## Test plan
- just fmt
- just test -p codex-core guardian_review
- just test -p codex-core (compiles, then fails on local environment issues: sandbox-exec Operation not permitted, missing test_stdio_server helper binary, and unrelated timeouts)