### PR TITLE
refactor(permissions): remove duplicate enforcement resolution paths

### DIFF
--- a/codex-rs/core/src/apply_patch.rs
+++ b/codex-rs/core/src/apply_patch.rs
@@ -6,7 +6,7 @@ use crate::tools::sandboxing::ExecApprovalRequirement;
 use codex_apply_patch::ApplyPatchAction;
 use codex_apply_patch::ApplyPatchFileChange;
 use codex_protocol::protocol::FileChange;
-use codex_protocol::protocol::FileSystemSandboxPolicy;
+use codex_sandboxing::EffectiveFilesystemPermissions;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
@@ -32,14 +32,14 @@ pub(crate) struct ApplyPatchRuntimeInvocation {
 
 pub(crate) async fn apply_patch(
     turn_context: &TurnContext,
-    file_system_sandbox_policy: &FileSystemSandboxPolicy,
+    effective_filesystem_permissions: &EffectiveFilesystemPermissions,
     action: ApplyPatchAction,
 ) -> InternalApplyPatchInvocation {
     match assess_patch_safety(
         &action,
         turn_context.approval_policy.value(),
         &turn_context.permission_profile(),
-        file_system_sandbox_policy,
+        effective_filesystem_permissions,
         &action.cwd,
         turn_context.windows_sandbox_level,
     ) {

--- a/codex-rs/core/src/exec.rs
+++ b/codex-rs/core/src/exec.rs
@@ -39,11 +39,15 @@ use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::ExecCommandOutputDeltaEvent;
 use codex_protocol::protocol::ExecOutputStream;
 use codex_protocol::protocol::SandboxPolicy;
+use codex_sandboxing::EffectiveFilesystemPermissions;
+#[cfg(test)]
+use codex_sandboxing::FilesystemPermissionsContext;
 use codex_sandboxing::SandboxCommand;
 use codex_sandboxing::SandboxManager;
 use codex_sandboxing::SandboxTransformRequest;
 use codex_sandboxing::SandboxType;
 use codex_sandboxing::SandboxablePreference;
+use codex_sandboxing::compatibility_sandbox_policy_for_permission_profile;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use codex_utils_pty::DEFAULT_OUTPUT_BYTES_CAP;
 use codex_utils_pty::process_group::kill_child_process_group;
@@ -371,7 +375,7 @@ pub fn build_exec_request(
         expiration,
         capture_policy,
     };
-    let mut exec_req = manager
+    let request = manager
         .transform(SandboxTransformRequest {
             command,
             permissions: permission_profile,
@@ -384,37 +388,44 @@ pub fn build_exec_request(
             windows_sandbox_level,
             windows_sandbox_private_desktop,
         })
-        .map(|request| {
-            let windows_sandbox_policy_cwd = AbsolutePathBuf::try_from(sandbox_cwd.to_path_buf())
-                .unwrap_or_else(|_| request.cwd.clone());
-            ExecRequest::from_sandbox_exec_request(request, options, windows_sandbox_policy_cwd)
-        })
         .map_err(CodexErr::from)?;
     let use_windows_elevated_backend = windows_sandbox_uses_elevated_backend(
-        exec_req.windows_sandbox_level,
-        exec_req.network.is_some(),
+        request.windows_sandbox_level,
+        request.network.is_some(),
     );
-    let sandbox_policy = exec_req.compatibility_sandbox_policy();
-    exec_req.windows_sandbox_filesystem_overrides = if use_windows_elevated_backend {
-        resolve_windows_elevated_filesystem_overrides(
-            exec_req.sandbox,
+    let sandbox_policy = compatibility_sandbox_policy_for_permission_profile(
+        &request.permission_profile,
+        &request.file_system_sandbox_policy,
+        request.network_sandbox_policy,
+        sandbox_cwd.as_path(),
+    );
+    let windows_sandbox_filesystem_overrides = if use_windows_elevated_backend {
+        resolve_windows_elevated_filesystem_overrides_from_effective_permissions(
+            request.sandbox,
             &sandbox_policy,
-            &exec_req.file_system_sandbox_policy,
-            exec_req.network_sandbox_policy,
+            &request.file_system_sandbox_policy,
+            &request.effective_filesystem_permissions,
+            request.network_sandbox_policy,
             sandbox_cwd,
             use_windows_elevated_backend,
         )
     } else {
-        resolve_windows_restricted_token_filesystem_overrides(
-            exec_req.sandbox,
+        resolve_windows_restricted_token_filesystem_overrides_from_effective_permissions(
+            request.sandbox,
             &sandbox_policy,
-            &exec_req.file_system_sandbox_policy,
-            exec_req.network_sandbox_policy,
+            &request.file_system_sandbox_policy,
+            &request.effective_filesystem_permissions,
+            request.network_sandbox_policy,
             sandbox_cwd,
-            exec_req.windows_sandbox_level,
+            request.windows_sandbox_level,
         )
     }
     .map_err(CodexErr::UnsupportedOperation)?;
+    let windows_sandbox_policy_cwd = AbsolutePathBuf::try_from(sandbox_cwd.to_path_buf())
+        .unwrap_or_else(|_| request.cwd.clone());
+    let mut exec_req =
+        ExecRequest::from_sandbox_exec_request(request, options, windows_sandbox_policy_cwd);
+    exec_req.windows_sandbox_filesystem_overrides = windows_sandbox_filesystem_overrides;
     Ok(exec_req)
 }
 
@@ -976,7 +987,7 @@ fn should_use_windows_restricted_token_sandbox(
         )
 }
 
-#[cfg_attr(not(test), allow(dead_code))]
+#[cfg(test)]
 pub(crate) fn unsupported_windows_restricted_token_sandbox_reason(
     sandbox: SandboxType,
     sandbox_policy: &SandboxPolicy,
@@ -1008,10 +1019,36 @@ pub(crate) fn unsupported_windows_restricted_token_sandbox_reason(
     }
 }
 
+#[cfg(test)]
 pub(crate) fn resolve_windows_restricted_token_filesystem_overrides(
     sandbox: SandboxType,
     sandbox_policy: &SandboxPolicy,
     file_system_sandbox_policy: &FileSystemSandboxPolicy,
+    network_sandbox_policy: NetworkSandboxPolicy,
+    sandbox_policy_cwd: &AbsolutePathBuf,
+    windows_sandbox_level: WindowsSandboxLevel,
+) -> std::result::Result<Option<WindowsSandboxFilesystemOverrides>, String> {
+    let effective_filesystem_permissions = effective_windows_filesystem_permissions_for_test(
+        file_system_sandbox_policy,
+        network_sandbox_policy,
+        sandbox_policy_cwd,
+    )?;
+    resolve_windows_restricted_token_filesystem_overrides_from_effective_permissions(
+        sandbox,
+        sandbox_policy,
+        file_system_sandbox_policy,
+        &effective_filesystem_permissions,
+        network_sandbox_policy,
+        sandbox_policy_cwd,
+        windows_sandbox_level,
+    )
+}
+
+fn resolve_windows_restricted_token_filesystem_overrides_from_effective_permissions(
+    sandbox: SandboxType,
+    sandbox_policy: &SandboxPolicy,
+    file_system_sandbox_policy: &FileSystemSandboxPolicy,
+    effective_filesystem_permissions: &EffectiveFilesystemPermissions,
     network_sandbox_policy: NetworkSandboxPolicy,
     sandbox_policy_cwd: &AbsolutePathBuf,
     windows_sandbox_level: WindowsSandboxLevel,
@@ -1049,7 +1086,7 @@ pub(crate) fn resolve_windows_restricted_token_filesystem_overrides(
     // but its WRITE_RESTRICTED token does not make capability SID deny-read ACEs
     // participate in read access checks. Read restrictions therefore require the
     // elevated backend, even when the filesystem root remains readable.
-    if !windows_policy_has_root_read_access(file_system_sandbox_policy, sandbox_policy_cwd) {
+    if !windows_policy_has_root_read_access(effective_filesystem_permissions, sandbox_policy_cwd) {
         return Err(
             "windows unelevated restricted-token sandbox cannot enforce split filesystem read restrictions directly; refusing to run unsandboxed"
                 .to_string(),
@@ -1057,7 +1094,7 @@ pub(crate) fn resolve_windows_restricted_token_filesystem_overrides(
     }
 
     let additional_deny_read_paths = codex_windows_sandbox::resolve_windows_deny_read_paths(
-        file_system_sandbox_policy,
+        effective_filesystem_permissions,
         sandbox_policy_cwd,
     )?;
     if !additional_deny_read_paths.is_empty() {
@@ -1068,8 +1105,7 @@ pub(crate) fn resolve_windows_restricted_token_filesystem_overrides(
     }
 
     let legacy_writable_roots = sandbox_policy.get_writable_roots_with_cwd(sandbox_policy_cwd);
-    let split_writable_roots =
-        file_system_sandbox_policy.get_writable_roots_with_cwd(sandbox_policy_cwd);
+    let split_writable_roots = &effective_filesystem_permissions.writable_roots;
     let legacy_root_paths: BTreeSet<PathBuf> = legacy_writable_roots
         .iter()
         .map(|root| normalize_windows_override_path(root.root.as_path()))
@@ -1086,7 +1122,7 @@ pub(crate) fn resolve_windows_restricted_token_filesystem_overrides(
         );
     }
 
-    for writable_root in &split_writable_roots {
+    for writable_root in split_writable_roots {
         for read_only_subpath in &writable_root.read_only_subpaths {
             if split_writable_roots.iter().any(|candidate| {
                 candidate.root.as_path() != writable_root.root.as_path()
@@ -1104,7 +1140,7 @@ pub(crate) fn resolve_windows_restricted_token_filesystem_overrides(
     }
 
     let mut additional_deny_write_paths = BTreeSet::new();
-    for split_root in &split_writable_roots {
+    for split_root in split_writable_roots {
         let split_root_path = normalize_windows_override_path(split_root.root.as_path())?;
         let Some(legacy_root) = legacy_writable_roots.iter().find(|candidate| {
             normalize_windows_override_path(candidate.root.as_path())
@@ -1152,19 +1188,45 @@ fn normalize_windows_override_path(path: &Path) -> std::result::Result<PathBuf, 
 }
 
 fn windows_policy_has_root_read_access(
-    file_system_sandbox_policy: &FileSystemSandboxPolicy,
+    effective_filesystem_permissions: &EffectiveFilesystemPermissions,
     cwd: &AbsolutePathBuf,
 ) -> bool {
     let Some(root) = cwd.as_path().ancestors().last() else {
         return false;
     };
-    file_system_sandbox_policy.can_read_path_with_cwd(root, cwd.as_path())
+    effective_filesystem_permissions.can_read(root)
 }
 
+#[cfg(test)]
 pub(crate) fn resolve_windows_elevated_filesystem_overrides(
     sandbox: SandboxType,
     sandbox_policy: &SandboxPolicy,
     file_system_sandbox_policy: &FileSystemSandboxPolicy,
+    network_sandbox_policy: NetworkSandboxPolicy,
+    sandbox_policy_cwd: &AbsolutePathBuf,
+    use_windows_elevated_backend: bool,
+) -> std::result::Result<Option<WindowsSandboxFilesystemOverrides>, String> {
+    let effective_filesystem_permissions = effective_windows_filesystem_permissions_for_test(
+        file_system_sandbox_policy,
+        network_sandbox_policy,
+        sandbox_policy_cwd,
+    )?;
+    resolve_windows_elevated_filesystem_overrides_from_effective_permissions(
+        sandbox,
+        sandbox_policy,
+        file_system_sandbox_policy,
+        &effective_filesystem_permissions,
+        network_sandbox_policy,
+        sandbox_policy_cwd,
+        use_windows_elevated_backend,
+    )
+}
+
+fn resolve_windows_elevated_filesystem_overrides_from_effective_permissions(
+    sandbox: SandboxType,
+    sandbox_policy: &SandboxPolicy,
+    file_system_sandbox_policy: &FileSystemSandboxPolicy,
+    effective_filesystem_permissions: &EffectiveFilesystemPermissions,
     network_sandbox_policy: NetworkSandboxPolicy,
     sandbox_policy_cwd: &AbsolutePathBuf,
     use_windows_elevated_backend: bool,
@@ -1185,13 +1247,12 @@ pub(crate) fn resolve_windows_elevated_filesystem_overrides(
     }
 
     let additional_deny_read_paths = codex_windows_sandbox::resolve_windows_deny_read_paths(
-        file_system_sandbox_policy,
+        effective_filesystem_permissions,
         sandbox_policy_cwd,
     )?;
 
-    let split_writable_roots =
-        file_system_sandbox_policy.get_writable_roots_with_cwd(sandbox_policy_cwd);
-    if has_reopened_writable_descendant(&split_writable_roots) {
+    let split_writable_roots = &effective_filesystem_permissions.writable_roots;
+    if has_reopened_writable_descendant(split_writable_roots) {
         return Err(
             "windows elevated sandbox cannot reopen writable descendants under read-only carveouts directly; refusing to run unsandboxed"
                 .to_string(),
@@ -1206,9 +1267,10 @@ pub(crate) fn resolve_windows_elevated_filesystem_overrides(
         .iter()
         .map(|root| normalize_path(root.root.to_path_buf()))
         .collect();
-    let split_readable_roots: Vec<PathBuf> = file_system_sandbox_policy
-        .get_readable_roots_with_cwd(sandbox_policy_cwd)
-        .into_iter()
+    let split_readable_roots: Vec<PathBuf> = effective_filesystem_permissions
+        .readable_roots
+        .iter()
+        .cloned()
         .map(codex_utils_absolute_path::AbsolutePathBuf::into_path_buf)
         .map(&normalize_path)
         .collect();
@@ -1223,7 +1285,7 @@ pub(crate) fn resolve_windows_elevated_filesystem_overrides(
     // whether the baseline still reads from the filesystem root and only needs
     // additional deny ACLs layered on top.
     let split_has_root_read_access =
-        windows_policy_has_root_read_access(file_system_sandbox_policy, sandbox_policy_cwd);
+        windows_policy_has_root_read_access(effective_filesystem_permissions, sandbox_policy_cwd);
     let read_roots_override = if split_has_root_read_access {
         None
     } else {
@@ -1238,7 +1300,7 @@ pub(crate) fn resolve_windows_elevated_filesystem_overrides(
 
     let additional_deny_write_paths = if needs_direct_runtime_enforcement {
         let mut deny_paths = BTreeSet::new();
-        for writable_root in &split_writable_roots {
+        for writable_root in split_writable_roots {
             let writable_root_path = normalize_path(writable_root.root.to_path_buf());
             let legacy_root = legacy_writable_roots.iter().find(|candidate| {
                 normalize_path(candidate.root.to_path_buf()) == writable_root_path
@@ -1280,12 +1342,34 @@ pub(crate) fn resolve_windows_elevated_filesystem_overrides(
 
     Ok(Some(WindowsSandboxFilesystemOverrides {
         read_roots_include_platform_defaults: read_roots_override.is_some()
-            && file_system_sandbox_policy.include_platform_defaults(),
+            && effective_filesystem_permissions.include_platform_defaults,
         read_roots_override,
         write_roots_override,
         additional_deny_read_paths,
         additional_deny_write_paths,
     }))
+}
+
+#[cfg(test)]
+fn effective_windows_filesystem_permissions_for_test(
+    file_system_sandbox_policy: &FileSystemSandboxPolicy,
+    network_sandbox_policy: NetworkSandboxPolicy,
+    sandbox_policy_cwd: &AbsolutePathBuf,
+) -> std::result::Result<EffectiveFilesystemPermissions, String> {
+    let file_system_sandbox_policy = file_system_sandbox_policy
+        .clone()
+        .materialize_project_roots_with_workspace_roots(std::slice::from_ref(sandbox_policy_cwd));
+    let permission_profile = PermissionProfile::from_runtime_permissions(
+        &file_system_sandbox_policy,
+        network_sandbox_policy,
+    );
+    EffectiveFilesystemPermissions::from_profile(
+        &permission_profile,
+        FilesystemPermissionsContext {
+            policy_evaluation_cwd: sandbox_policy_cwd,
+        },
+    )
+    .map_err(|err| err.to_string())
 }
 
 fn has_reopened_writable_descendant(

--- a/codex-rs/core/src/exec_policy.rs
+++ b/codex-rs/core/src/exec_policy.rs
@@ -24,6 +24,8 @@ use codex_protocol::models::PermissionProfile;
 use codex_protocol::permissions::FileSystemSandboxKind;
 use codex_protocol::permissions::FileSystemSandboxPolicy;
 use codex_protocol::protocol::AskForApproval;
+use codex_sandboxing::EffectiveFilesystemPermissions;
+use codex_sandboxing::FilesystemPermissionsContext;
 use codex_shell_command::is_dangerous_command::command_might_be_dangerous;
 use codex_shell_command::is_safe_command::is_known_safe_command;
 use thiserror::Error;
@@ -754,15 +756,32 @@ fn profile_is_managed_read_only(
     file_system_sandbox_policy: &FileSystemSandboxPolicy,
     sandbox_cwd: &Path,
 ) -> bool {
-    matches!(permission_profile, PermissionProfile::Managed { .. })
-        && matches!(
+    if !matches!(permission_profile, PermissionProfile::Managed { .. })
+        || !matches!(
             file_system_sandbox_policy.kind,
             FileSystemSandboxKind::Restricted
         )
-        && !file_system_sandbox_policy.has_full_disk_write_access()
-        && file_system_sandbox_policy
-            .get_writable_roots_with_cwd(sandbox_cwd)
-            .is_empty()
+    {
+        return false;
+    }
+    let Ok(policy_evaluation_cwd) = AbsolutePathBuf::from_absolute_path(sandbox_cwd) else {
+        return true;
+    };
+    let effective_permission_profile = PermissionProfile::from_runtime_permissions_with_enforcement(
+        permission_profile.enforcement(),
+        file_system_sandbox_policy,
+        permission_profile.network_sandbox_policy(),
+    );
+    let Ok(effective_filesystem_permissions) = EffectiveFilesystemPermissions::from_profile(
+        &effective_permission_profile,
+        FilesystemPermissionsContext {
+            policy_evaluation_cwd: &policy_evaluation_cwd,
+        },
+    ) else {
+        return true;
+    };
+    !effective_filesystem_permissions.has_full_disk_write_access()
+        && effective_filesystem_permissions.writable_roots.is_empty()
 }
 
 fn default_policy_path(codex_home: &Path) -> PathBuf {

--- a/codex-rs/core/src/exec_policy_tests.rs
+++ b/codex-rs/core/src/exec_policy_tests.rs
@@ -1181,6 +1181,9 @@ fn known_safe_on_request_still_prompts_for_restricted_sandbox_escalation() {
 
 #[test]
 fn managed_cwd_write_profile_is_not_read_only() {
+    let workspace_root_path = host_absolute_path(&["tmp", "project"]);
+    let workspace_root = AbsolutePathBuf::from_absolute_path(Path::new(&workspace_root_path))
+        .expect("absolute workspace root");
     let file_system_sandbox_policy = FileSystemSandboxPolicy::restricted(vec![
         FileSystemSandboxEntry {
             path: FileSystemPath::Special {
@@ -1194,7 +1197,8 @@ fn managed_cwd_write_profile_is_not_read_only() {
             },
             access: FileSystemAccessMode::Write,
         },
-    ]);
+    ])
+    .materialize_project_roots_with_workspace_roots(std::slice::from_ref(&workspace_root));
     let permission_profile = PermissionProfile::from_runtime_permissions(
         &file_system_sandbox_policy,
         NetworkSandboxPolicy::Restricted,
@@ -1203,7 +1207,7 @@ fn managed_cwd_write_profile_is_not_read_only() {
     assert!(!profile_is_managed_read_only(
         &permission_profile,
         &file_system_sandbox_policy,
-        Path::new("/tmp/project")
+        Path::new(&workspace_root_path)
     ));
 }
 

--- a/codex-rs/core/src/safety.rs
+++ b/codex-rs/core/src/safety.rs
@@ -7,8 +7,8 @@ use codex_apply_patch::ApplyPatchAction;
 use codex_apply_patch::ApplyPatchFileChange;
 use codex_protocol::config_types::WindowsSandboxLevel;
 use codex_protocol::models::PermissionProfile;
-use codex_protocol::permissions::FileSystemSandboxPolicy;
 use codex_protocol::protocol::AskForApproval;
+use codex_sandboxing::EffectiveFilesystemPermissions;
 use codex_sandboxing::SandboxType;
 use codex_sandboxing::get_platform_sandbox;
 use codex_utils_absolute_path::AbsolutePathBuf;
@@ -34,7 +34,7 @@ pub fn assess_patch_safety(
     action: &ApplyPatchAction,
     policy: AskForApproval,
     permission_profile: &PermissionProfile,
-    file_system_sandbox_policy: &FileSystemSandboxPolicy,
+    effective_filesystem_permissions: &EffectiveFilesystemPermissions,
     cwd: &AbsolutePathBuf,
     windows_sandbox_level: WindowsSandboxLevel,
 ) -> SafetyCheck {
@@ -67,7 +67,7 @@ pub fn assess_patch_safety(
     // Even though the patch appears to be constrained to writable paths, it is
     // possible that paths in the patch are hard links to files outside the
     // writable roots, so we should still run `apply_patch` in a sandbox in that case.
-    if is_write_patch_constrained_to_writable_paths(action, file_system_sandbox_policy, cwd)
+    if is_write_patch_constrained_to_writable_paths(action, effective_filesystem_permissions, cwd)
         || matches!(policy, AskForApproval::OnFailure)
     {
         if matches!(
@@ -94,8 +94,7 @@ pub fn assess_patch_safety(
                         SafetyCheck::Reject {
                             reason: patch_rejection_reason(
                                 permission_profile,
-                                file_system_sandbox_policy,
-                                cwd,
+                                effective_filesystem_permissions,
                             )
                             .to_string(),
                         }
@@ -107,7 +106,7 @@ pub fn assess_patch_safety(
         }
     } else if rejects_sandbox_approval {
         SafetyCheck::Reject {
-            reason: patch_rejection_reason(permission_profile, file_system_sandbox_policy, cwd)
+            reason: patch_rejection_reason(permission_profile, effective_filesystem_permissions)
                 .to_string(),
         }
     } else {
@@ -117,15 +116,12 @@ pub fn assess_patch_safety(
 
 fn patch_rejection_reason(
     permission_profile: &PermissionProfile,
-    file_system_sandbox_policy: &FileSystemSandboxPolicy,
-    cwd: &AbsolutePathBuf,
+    effective_filesystem_permissions: &EffectiveFilesystemPermissions,
 ) -> &'static str {
     match permission_profile {
         PermissionProfile::Managed { .. }
-            if !file_system_sandbox_policy.has_full_disk_write_access()
-                && file_system_sandbox_policy
-                    .get_writable_roots_with_cwd(cwd.as_path())
-                    .is_empty() =>
+            if !effective_filesystem_permissions.has_full_disk_write_access()
+                && effective_filesystem_permissions.writable_roots.is_empty() =>
         {
             PATCH_REJECTED_READ_ONLY_REASON
         }
@@ -137,7 +133,7 @@ fn patch_rejection_reason(
 
 fn is_write_patch_constrained_to_writable_paths(
     action: &ApplyPatchAction,
-    file_system_sandbox_policy: &FileSystemSandboxPolicy,
+    effective_filesystem_permissions: &EffectiveFilesystemPermissions,
     cwd: &AbsolutePathBuf,
 ) -> bool {
     // Normalize a path by removing `.` and resolving `..` without touching the
@@ -166,7 +162,7 @@ fn is_write_patch_constrained_to_writable_paths(
             None => return false,
         };
 
-        file_system_sandbox_policy.can_write_path_with_cwd(&abs, cwd)
+        effective_filesystem_permissions.can_write(&abs)
     };
 
     for (path, change) in action.changes() {

--- a/codex-rs/core/src/safety_tests.rs
+++ b/codex-rs/core/src/safety_tests.rs
@@ -1,15 +1,38 @@
 use super::*;
 use codex_protocol::models::PermissionProfile;
+use codex_protocol::permissions::FileSystemSandboxPolicy;
 use codex_protocol::permissions::NetworkSandboxPolicy;
 use codex_protocol::protocol::FileSystemAccessMode;
 use codex_protocol::protocol::FileSystemPath;
 use codex_protocol::protocol::FileSystemSandboxEntry;
 use codex_protocol::protocol::FileSystemSpecialPath;
 use codex_protocol::protocol::GranularApprovalConfig;
+use codex_sandboxing::EffectiveFilesystemPermissions;
+use codex_sandboxing::FilesystemPermissionsContext;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use core_test_support::PathExt;
 use pretty_assertions::assert_eq;
 use tempfile::TempDir;
+
+fn effective_permissions(
+    file_system_sandbox_policy: &FileSystemSandboxPolicy,
+    cwd: &AbsolutePathBuf,
+) -> EffectiveFilesystemPermissions {
+    let file_system_sandbox_policy = file_system_sandbox_policy
+        .clone()
+        .materialize_project_roots_with_workspace_roots(std::slice::from_ref(cwd));
+    let permission_profile = PermissionProfile::from_runtime_permissions(
+        &file_system_sandbox_policy,
+        NetworkSandboxPolicy::Restricted,
+    );
+    EffectiveFilesystemPermissions::from_profile(
+        &permission_profile,
+        FilesystemPermissionsContext {
+            policy_evaluation_cwd: cwd,
+        },
+    )
+    .expect("derive effective filesystem permissions")
+}
 
 #[test]
 fn test_writable_roots_constraint() {
@@ -36,13 +59,13 @@ fn test_writable_roots_constraint() {
 
     assert!(is_write_patch_constrained_to_writable_paths(
         &add_inside,
-        &workspace_only_file_system_policy,
+        &effective_permissions(&workspace_only_file_system_policy, &cwd),
         &cwd,
     ));
 
     assert!(!is_write_patch_constrained_to_writable_paths(
         &add_outside,
-        &workspace_only_file_system_policy,
+        &effective_permissions(&workspace_only_file_system_policy, &cwd),
         &cwd,
     ));
 
@@ -55,7 +78,7 @@ fn test_writable_roots_constraint() {
     );
     assert!(is_write_patch_constrained_to_writable_paths(
         &add_outside,
-        &file_system_policy_with_parent,
+        &effective_permissions(&file_system_policy_with_parent, &cwd),
         &cwd,
     ));
 }
@@ -77,7 +100,7 @@ fn external_sandbox_auto_approves_in_on_request() {
             &add_inside,
             AskForApproval::OnRequest,
             &permission_profile,
-            &file_system_sandbox_policy,
+            &effective_permissions(&file_system_sandbox_policy, &cwd),
             &cwd,
             WindowsSandboxLevel::Disabled
         ),
@@ -108,7 +131,7 @@ fn granular_with_all_flags_true_matches_on_request_for_out_of_root_patch() {
             &add_outside,
             AskForApproval::OnRequest,
             &permission_profile,
-            &file_system_sandbox_policy,
+            &effective_permissions(&file_system_sandbox_policy, &cwd),
             &cwd,
             WindowsSandboxLevel::Disabled,
         ),
@@ -125,7 +148,7 @@ fn granular_with_all_flags_true_matches_on_request_for_out_of_root_patch() {
                 mcp_elicitations: true,
             }),
             &permission_profile,
-            &file_system_sandbox_policy,
+            &effective_permissions(&file_system_sandbox_policy, &cwd),
             &cwd,
             WindowsSandboxLevel::Disabled,
         ),
@@ -159,7 +182,7 @@ fn granular_sandbox_approval_false_rejects_out_of_root_patch() {
                 mcp_elicitations: true,
             }),
             &permission_profile,
-            &file_system_sandbox_policy,
+            &effective_permissions(&file_system_sandbox_policy, &cwd),
             &cwd,
             WindowsSandboxLevel::Disabled,
         ),
@@ -180,7 +203,7 @@ fn read_only_policy_rejects_patch_with_read_only_reason() {
 
     assert!(!is_write_patch_constrained_to_writable_paths(
         &action,
-        &file_system_sandbox_policy,
+        &effective_permissions(&file_system_sandbox_policy, &cwd),
         &cwd,
     ));
     assert_eq!(
@@ -188,7 +211,7 @@ fn read_only_policy_rejects_patch_with_read_only_reason() {
             &action,
             AskForApproval::Never,
             &permission_profile,
-            &file_system_sandbox_policy,
+            &effective_permissions(&file_system_sandbox_policy, &cwd),
             &cwd,
             WindowsSandboxLevel::Disabled,
         ),
@@ -224,7 +247,7 @@ fn explicit_unreadable_paths_prevent_auto_approval_for_external_sandbox() {
 
     assert!(!is_write_patch_constrained_to_writable_paths(
         &action,
-        &file_system_sandbox_policy,
+        &effective_permissions(&file_system_sandbox_policy, &cwd),
         &cwd,
     ));
     assert_eq!(
@@ -232,7 +255,7 @@ fn explicit_unreadable_paths_prevent_auto_approval_for_external_sandbox() {
             &action,
             AskForApproval::OnRequest,
             &permission_profile,
-            &file_system_sandbox_policy,
+            &effective_permissions(&file_system_sandbox_policy, &cwd),
             &cwd,
             WindowsSandboxLevel::Disabled,
         ),
@@ -268,7 +291,7 @@ fn explicit_read_only_subpaths_prevent_auto_approval_for_external_sandbox() {
 
     assert!(!is_write_patch_constrained_to_writable_paths(
         &action,
-        &file_system_sandbox_policy,
+        &effective_permissions(&file_system_sandbox_policy, &cwd),
         &cwd,
     ));
     assert_eq!(
@@ -276,7 +299,7 @@ fn explicit_read_only_subpaths_prevent_auto_approval_for_external_sandbox() {
             &action,
             AskForApproval::OnRequest,
             &permission_profile,
-            &file_system_sandbox_policy,
+            &effective_permissions(&file_system_sandbox_policy, &cwd),
             &cwd,
             WindowsSandboxLevel::Disabled,
         ),
@@ -308,7 +331,7 @@ fn missing_project_dot_codex_config_requires_approval() {
 
     assert!(!is_write_patch_constrained_to_writable_paths(
         &action,
-        &file_system_sandbox_policy,
+        &effective_permissions(&file_system_sandbox_policy, &cwd),
         &cwd,
     ));
     assert_eq!(
@@ -316,7 +339,7 @@ fn missing_project_dot_codex_config_requires_approval() {
             &action,
             AskForApproval::OnRequest,
             &permission_profile,
-            &file_system_sandbox_policy,
+            &effective_permissions(&file_system_sandbox_policy, &cwd),
             &cwd,
             WindowsSandboxLevel::Disabled,
         ),

--- a/codex-rs/core/src/sandboxing/mod.rs
+++ b/codex-rs/core/src/sandboxing/mod.rs
@@ -22,10 +22,8 @@ use codex_protocol::models::PermissionProfile;
 pub use codex_protocol::models::SandboxPermissions;
 use codex_protocol::permissions::FileSystemSandboxPolicy;
 use codex_protocol::permissions::NetworkSandboxPolicy;
-use codex_protocol::protocol::SandboxPolicy;
 use codex_sandboxing::SandboxExecRequest;
 use codex_sandboxing::SandboxType;
-use codex_sandboxing::compatibility_sandbox_policy_for_permission_profile;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use std::collections::HashMap;
 
@@ -97,15 +95,6 @@ impl ExecRequest {
             windows_sandbox_filesystem_overrides: None,
             arg0,
         }
-    }
-
-    pub(crate) fn compatibility_sandbox_policy(&self) -> SandboxPolicy {
-        compatibility_sandbox_policy_for_permission_profile(
-            &self.permission_profile,
-            &self.file_system_sandbox_policy,
-            self.network_sandbox_policy,
-            self.windows_sandbox_policy_cwd.as_path(),
-        )
     }
 
     pub(crate) fn from_sandbox_exec_request(

--- a/codex-rs/core/src/tools/handlers/apply_patch.rs
+++ b/codex-rs/core/src/tools/handlers/apply_patch.rs
@@ -270,7 +270,7 @@ async fn effective_patch_permissions(
     (
         Vec<AbsolutePathBuf>,
         crate::tools::handlers::EffectiveAdditionalPermissions,
-        codex_protocol::permissions::FileSystemSandboxPolicy,
+        EffectiveFilesystemPermissions,
     ),
     FunctionCallError,
 > {
@@ -281,7 +281,6 @@ async fn effective_patch_permissions(
     );
     let effective_permission_profile =
         effective_permission_profile(&turn.permission_profile(), granted_permissions.as_ref());
-    let file_system_sandbox_policy = effective_permission_profile.file_system_sandbox_policy();
     let effective_filesystem_permissions = EffectiveFilesystemPermissions::from_profile(
         &effective_permission_profile,
         FilesystemPermissionsContext {
@@ -304,7 +303,7 @@ async fn effective_patch_permissions(
     Ok((
         file_paths,
         effective_additional_permissions,
-        file_system_sandbox_policy,
+        effective_filesystem_permissions,
     ))
 }
 
@@ -363,11 +362,18 @@ impl ToolExecutor<ToolInvocation> for ApplyPatchHandler {
             .await
         {
             codex_apply_patch::MaybeApplyPatchVerified::Body(changes) => {
-                let (file_paths, effective_additional_permissions, file_system_sandbox_policy) =
-                    effective_patch_permissions(session.as_ref(), turn.as_ref(), &changes, &cwd)
-                        .await?;
-                match apply_patch::apply_patch(turn.as_ref(), &file_system_sandbox_policy, changes)
-                    .await
+                let (
+                    file_paths,
+                    effective_additional_permissions,
+                    effective_filesystem_permissions,
+                ) = effective_patch_permissions(session.as_ref(), turn.as_ref(), &changes, &cwd)
+                    .await?;
+                match apply_patch::apply_patch(
+                    turn.as_ref(),
+                    &effective_filesystem_permissions,
+                    changes,
+                )
+                .await
                 {
                     InternalApplyPatchInvocation::Output(item) => {
                         let content = item?;
@@ -516,10 +522,14 @@ pub(crate) async fn intercept_apply_patch(
         .await
     {
         codex_apply_patch::MaybeApplyPatchVerified::Body(changes) => {
-            let (approval_keys, effective_additional_permissions, file_system_sandbox_policy) =
+            let (approval_keys, effective_additional_permissions, effective_filesystem_permissions) =
                 effective_patch_permissions(session.as_ref(), turn.as_ref(), &changes, cwd).await?;
-            match apply_patch::apply_patch(turn.as_ref(), &file_system_sandbox_policy, changes)
-                .await
+            match apply_patch::apply_patch(
+                turn.as_ref(),
+                &effective_filesystem_permissions,
+                changes,
+            )
+            .await
             {
                 InternalApplyPatchInvocation::Output(item) => {
                     let content = item?;

--- a/codex-rs/windows-sandbox-rs/src/deny_read_resolver.rs
+++ b/codex-rs/windows-sandbox-rs/src/deny_read_resolver.rs
@@ -1,12 +1,9 @@
-use codex_protocol::models::PermissionProfile;
 use codex_protocol::permissions::FileSystemAccessMode;
 use codex_protocol::permissions::FileSystemPath;
 use codex_protocol::permissions::FileSystemSandboxEntry;
 use codex_protocol::permissions::FileSystemSandboxPolicy;
-use codex_protocol::permissions::NetworkSandboxPolicy;
 use codex_protocol::permissions::ReadDenyMatcher;
 use codex_sandboxing::EffectiveFilesystemPermissions;
-use codex_sandboxing::FilesystemPermissionsContext;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use std::collections::HashSet;
 use std::path::Path;
@@ -25,28 +22,6 @@ struct GlobScanPlan {
 /// already exist under their literal scan root; future exact paths are handled
 /// later by materializing them before the deny ACE is applied.
 pub fn resolve_windows_deny_read_paths(
-    file_system_sandbox_policy: &FileSystemSandboxPolicy,
-    cwd: &AbsolutePathBuf,
-) -> Result<Vec<AbsolutePathBuf>, String> {
-    let file_system_sandbox_policy = file_system_sandbox_policy
-        .clone()
-        .materialize_project_roots_with_workspace_roots(std::slice::from_ref(cwd));
-    let permission_profile = PermissionProfile::from_runtime_permissions(
-        &file_system_sandbox_policy,
-        NetworkSandboxPolicy::Restricted,
-    );
-    let effective_file_system = EffectiveFilesystemPermissions::from_profile(
-        &permission_profile,
-        FilesystemPermissionsContext {
-            policy_evaluation_cwd: cwd,
-        },
-    )
-    .map_err(|err| err.to_string())?;
-    resolve_windows_deny_read_paths_from_effective_permissions(&effective_file_system, cwd)
-}
-
-/// Resolves effective read-deny entries into concrete Windows ACL targets.
-pub fn resolve_windows_deny_read_paths_from_effective_permissions(
     effective_file_system: &EffectiveFilesystemPermissions,
     cwd: &AbsolutePathBuf,
 ) -> Result<Vec<AbsolutePathBuf>, String> {
@@ -219,10 +194,14 @@ fn effective_glob_scan_max_depth(
 mod tests {
     use super::glob_scan_plan;
     use super::resolve_windows_deny_read_paths;
+    use codex_protocol::models::PermissionProfile;
     use codex_protocol::permissions::FileSystemAccessMode;
     use codex_protocol::permissions::FileSystemPath;
     use codex_protocol::permissions::FileSystemSandboxEntry;
     use codex_protocol::permissions::FileSystemSandboxPolicy;
+    use codex_protocol::permissions::NetworkSandboxPolicy;
+    use codex_sandboxing::EffectiveFilesystemPermissions;
+    use codex_sandboxing::FilesystemPermissionsContext;
     use codex_utils_absolute_path::AbsolutePathBuf;
     use pretty_assertions::assert_eq;
     use std::collections::HashSet;
@@ -246,6 +225,25 @@ mod tests {
             },
             access: FileSystemAccessMode::Deny,
         }
+    }
+
+    fn resolve_policy_deny_read_paths(
+        policy: &FileSystemSandboxPolicy,
+        cwd: &AbsolutePathBuf,
+    ) -> Result<Vec<AbsolutePathBuf>, String> {
+        let policy = policy
+            .clone()
+            .materialize_project_roots_with_workspace_roots(std::slice::from_ref(cwd));
+        let permission_profile =
+            PermissionProfile::from_runtime_permissions(&policy, NetworkSandboxPolicy::Restricted);
+        let effective_file_system = EffectiveFilesystemPermissions::from_profile(
+            &permission_profile,
+            FilesystemPermissionsContext {
+                policy_evaluation_cwd: cwd,
+            },
+        )
+        .map_err(|err| err.to_string())?;
+        resolve_windows_deny_read_paths(&effective_file_system, cwd)
     }
 
     #[test]
@@ -304,7 +302,7 @@ mod tests {
         let policy = FileSystemSandboxPolicy::restricted(vec![unreadable_path_entry(missing)]);
 
         assert_eq!(
-            resolve_windows_deny_read_paths(&policy, &cwd).expect("resolve"),
+            resolve_policy_deny_read_paths(&policy, &cwd).expect("resolve"),
             vec![
                 AbsolutePathBuf::from_absolute_path(
                     dunce::canonicalize(tmp.path())
@@ -332,7 +330,7 @@ mod tests {
             tmp.path().display()
         ))]);
 
-        let actual: HashSet<PathBuf> = resolve_windows_deny_read_paths(&policy, &cwd)
+        let actual: HashSet<PathBuf> = resolve_policy_deny_read_paths(&policy, &cwd)
             .expect("resolve")
             .into_iter()
             .map(AbsolutePathBuf::into_path_buf)
@@ -351,7 +349,7 @@ mod tests {
             tmp.path().display()
         ))]);
 
-        let err = resolve_windows_deny_read_paths(&policy, &cwd).expect_err("invalid glob");
+        let err = resolve_policy_deny_read_paths(&policy, &cwd).expect_err("invalid glob");
         assert!(
             err.contains("invalid deny-read glob pattern"),
             "unexpected error: {err}"
@@ -374,7 +372,7 @@ mod tests {
         ))]);
 
         assert_eq!(
-            resolve_windows_deny_read_paths(&policy, &cwd).expect("resolve"),
+            resolve_policy_deny_read_paths(&policy, &cwd).expect("resolve"),
             vec![AbsolutePathBuf::from_absolute_path(root_env).expect("absolute root env")]
         );
     }
@@ -397,7 +395,7 @@ mod tests {
             unreadable_glob_entry(format!("{}/**/*.env", alias_b.display())),
         ]);
 
-        let actual: HashSet<PathBuf> = resolve_windows_deny_read_paths(&policy, &cwd)
+        let actual: HashSet<PathBuf> = resolve_policy_deny_read_paths(&policy, &cwd)
             .expect("resolve")
             .into_iter()
             .map(AbsolutePathBuf::into_path_buf)

--- a/codex-rs/windows-sandbox-rs/src/lib.rs
+++ b/codex-rs/windows-sandbox-rs/src/lib.rs
@@ -124,7 +124,6 @@ pub use deny_read_acl::apply_deny_read_acls;
 #[cfg(target_os = "windows")]
 pub use deny_read_acl::plan_deny_read_acl_paths;
 pub use deny_read_resolver::resolve_windows_deny_read_paths;
-pub use deny_read_resolver::resolve_windows_deny_read_paths_from_effective_permissions;
 #[cfg(target_os = "windows")]
 pub use deny_read_state::sync_persistent_deny_read_acls;
 #[cfg(target_os = "windows")]


### PR DESCRIPTION
## Why

After effective filesystem permissions are available to every enforcement backend, enforcement call sites should stop independently deriving effective roots and deny inputs. Keeping those paths in parallel makes access decisions harder to audit and easier to drift.

## What changed

- Routed core Windows override construction through the effective filesystem permissions already produced by `SandboxManager` before compatibility request conversion.
- Made apply-patch safety reuse effective permissions for write checks and managed read-only rejection messaging.
- Derived command preflight's managed read-only classification at that enforcement boundary.
- Removed the retained policy-facing Windows deny resolver adapter; concrete ACL target expansion now accepts effective deny inputs directly.
- Removed the now-unused `ExecRequest` compatibility-policy helper made obsolete by the earlier Windows override resolution point.

## Security and compatibility

Enforcement decisions migrated here now consume effective filesystem facts rather than reconstructing roots or deny inputs. Policy use remains where it represents compatibility behavior or classifies an existing enforcement route, and Windows still performs concrete deny-target expansion at launch time. Network policy, compatibility wire types, UI surfaces, and platform selection behavior are unchanged.

## Validation

- `just test -p codex-core safety`
- `just test -p codex-core exec_policy`
- `just test -p codex-core windows_`
- `just test -p codex-core apply_patch` (run outside the enclosing macOS sandbox for nested Seatbelt cases)
- `just test -p codex-windows-sandbox`
- `just test -p codex-exec-server file_system` (run outside the enclosing macOS sandbox for nested Seatbelt cases)
- `cargo clippy --tests -p codex-sandboxing -p codex-core -p codex-linux-sandbox -p codex-windows-sandbox -p codex-cli`

## Stack

Review these incremental PRs in order; each describes only its own diff.

| Step | Pull request | Incremental change |
| --- | --- | --- |
| 1 | [#24762](https://github.com/openai/codex/pull/24762) | Introduce `EffectiveFilesystemPermissions` |
| 2 | [#24768](https://github.com/openai/codex/pull/24768) | Use effective permissions for enforcement preflight |
| 3 | [#24769](https://github.com/openai/codex/pull/24769) | Lower Seatbelt from effective permissions |
| 4 | [#24773](https://github.com/openai/codex/pull/24773) | Lower Linux enforcement from effective permissions |
| 5 | [#24776](https://github.com/openai/codex/pull/24776) | Lower Windows enforcement from effective permissions |
| **6** | **[#24791](https://github.com/openai/codex/pull/24791) (this PR)** | **Remove duplicate enforcement resolution paths** |
