### PR TITLE
fix(core): prevent automatic turn span nesting

### DIFF
--- a/codex-rs/core/src/codex_thread.rs
+++ b/codex-rs/core/src/codex_thread.rs
@@ -5,6 +5,8 @@ use crate::goals::GoalRuntimeEvent;
 use crate::session::Codex;
 use crate::session::SessionSettingsUpdate;
 use crate::session::SteerInputError;
+#[cfg(test)]
+use crate::tasks::TurnSpanParent;
 use codex_features::Feature;
 use codex_otel::SessionTelemetry;
 use codex_protocol::config_types::ApprovalsReviewer;
@@ -414,7 +416,10 @@ impl CodexThread {
                 .input_queue
                 .queue_response_items_for_next_turn(items)
                 .await;
-            self.codex.session.maybe_start_turn_for_pending_work().await;
+            self.codex
+                .session
+                .maybe_start_turn_for_pending_work(TurnSpanParent::Current)
+                .await;
         }
 
         Ok(submission_id)

--- a/codex-rs/core/src/goals.rs
+++ b/codex-rs/core/src/goals.rs
@@ -13,6 +13,7 @@ use crate::session::turn_context::TurnContext;
 use crate::state::ActiveTurn;
 use crate::state::TurnState;
 use crate::tasks::RegularTask;
+use crate::tasks::TurnSpanParent;
 use crate::tools::handlers::goal_spec::UPDATE_GOAL_TOOL_NAME;
 use anyhow::Context;
 use codex_features::Feature;
@@ -1268,7 +1269,8 @@ impl Session {
     }
 
     async fn maybe_continue_goal_if_idle_runtime(self: &Arc<Self>) {
-        self.maybe_start_turn_for_pending_work().await;
+        self.maybe_start_turn_for_pending_work(TurnSpanParent::Root)
+            .await;
         self.maybe_start_goal_continuation_turn().await;
     }
 
@@ -1353,8 +1355,13 @@ impl Session {
                 .await;
             return;
         }
-        self.start_task(turn_context, Vec::new(), RegularTask::new())
-            .await;
+        self.start_task(
+            turn_context,
+            Vec::new(),
+            RegularTask::new(),
+            TurnSpanParent::Root,
+        )
+        .await;
     }
 
     async fn goal_continuation_candidate_if_active(

--- a/codex-rs/core/src/session/handlers.rs
+++ b/codex-rs/core/src/session/handlers.rs
@@ -22,6 +22,7 @@ use crate::realtime_conversation::prefix_realtime_v2_text;
 use crate::review_prompts::resolve_review_request;
 use crate::session::spawn_review_thread;
 use crate::tasks::CompactTask;
+use crate::tasks::TurnSpanParent;
 use crate::tasks::UserShellCommandMode;
 use crate::tasks::UserShellCommandTask;
 use crate::tasks::execute_user_shell_command;
@@ -316,7 +317,7 @@ pub async fn inter_agent_communication(
         .enqueue_mailbox_communication(communication)
         .await;
     if trigger_turn {
-        sess.maybe_start_turn_for_pending_work_with_sub_id(sub_id)
+        sess.maybe_start_turn_for_pending_work_with_sub_id(sub_id, TurnSpanParent::Current)
             .await;
     }
 }

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -5892,7 +5892,7 @@ async fn root_task_turn_span_does_not_inherit_current_trace_context() {
     .instrument(request_span)
     .await;
 
-    let evt = tokio::time::timeout(StdDuration::from_secs(2), rx.recv())
+    let evt = tokio::time::timeout(StdDuration::from_secs(/*secs*/ 2), rx.recv())
         .await
         .expect("timeout waiting for turn completion")
         .expect("event");
@@ -5911,6 +5911,52 @@ async fn root_task_turn_span_does_not_inherit_current_trace_context() {
         task_context.span().span_context().trace_id(),
         request_context.span().span_context().trace_id()
     );
+}
+
+#[tokio::test]
+async fn rooted_regular_turn_does_not_emit_parent_trace_id() {
+    let _trace_test_context = install_test_tracing("codex-core-tests");
+    let request_parent = W3cTraceContext {
+        traceparent: Some("00-00000000000000000000000000000011-0000000000000022-01".into()),
+        tracestate: Some("vendor=value".into()),
+    };
+    let request_span = tracing::info_span!("completed_turn");
+    assert!(set_parent_from_w3c_trace_context(
+        &request_span,
+        &request_parent
+    ));
+
+    let (sess, tc, rx) = make_session_and_context_with_rx()
+        .instrument(request_span.clone())
+        .await;
+    assert_eq!(
+        tc.trace_id.as_deref(),
+        Some("00000000000000000000000000000011")
+    );
+
+    async {
+        sess.start_task(
+            Arc::clone(&tc),
+            Vec::new(),
+            crate::tasks::RegularTask::new(),
+            TurnSpanParent::Root,
+        )
+        .await;
+    }
+    .instrument(request_span)
+    .await;
+
+    let first = tokio::time::timeout(StdDuration::from_secs(/*secs*/ 2), rx.recv())
+        .await
+        .expect("timeout waiting for turn start")
+        .expect("event");
+    let EventMsg::TurnStarted(turn_started) = first.msg else {
+        panic!("expected turn started event");
+    };
+    assert!(turn_started.trace_id.is_some());
+    assert_ne!(turn_started.trace_id, tc.trace_id);
+
+    sess.abort_all_tasks(TurnAbortReason::Interrupted).await;
 }
 
 #[cfg(debug_assertions)]

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -66,6 +66,7 @@ use crate::state::ActiveTurn;
 use crate::state::TaskKind;
 use crate::tasks::SessionTask;
 use crate::tasks::SessionTaskContext;
+use crate::tasks::TurnSpanParent;
 use crate::tasks::UserShellCommandMode;
 use crate::tasks::execute_user_shell_command;
 use crate::tools::ToolRouter;
@@ -5827,6 +5828,88 @@ async fn spawn_task_turn_span_inherits_dispatch_trace_context() {
     assert_ne!(
         task_context.span().span_context().span_id(),
         dispatch_span_id
+    );
+}
+
+#[tokio::test]
+async fn root_task_turn_span_does_not_inherit_current_trace_context() {
+    struct TraceCaptureTask {
+        captured_trace: Arc<std::sync::Mutex<Option<W3cTraceContext>>>,
+    }
+
+    impl SessionTask for TraceCaptureTask {
+        fn kind(&self) -> TaskKind {
+            TaskKind::Regular
+        }
+
+        fn span_name(&self) -> &'static str {
+            "session_task.root_trace_capture"
+        }
+
+        async fn run(
+            self: Arc<Self>,
+            _session: Arc<SessionTaskContext>,
+            _ctx: Arc<TurnContext>,
+            _input: Vec<TurnInput>,
+            _cancellation_token: CancellationToken,
+        ) -> Option<String> {
+            let mut trace = self
+                .captured_trace
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            *trace = current_span_w3c_trace_context();
+            None
+        }
+    }
+
+    let _trace_test_context = install_test_tracing("codex-core-tests");
+    let request_parent = W3cTraceContext {
+        traceparent: Some("00-00000000000000000000000000000011-0000000000000022-01".into()),
+        tracestate: Some("vendor=value".into()),
+    };
+    let request_span = tracing::info_span!("completed_turn");
+    assert!(set_parent_from_w3c_trace_context(
+        &request_span,
+        &request_parent
+    ));
+
+    let (sess, tc, rx) = make_session_and_context_with_rx().await;
+    let captured_trace = Arc::new(std::sync::Mutex::new(None));
+    let request_trace = async {
+        let request_trace =
+            current_span_w3c_trace_context().expect("request span should have trace context");
+        sess.start_task(
+            Arc::clone(&tc),
+            Vec::new(),
+            TraceCaptureTask {
+                captured_trace: Arc::clone(&captured_trace),
+            },
+            TurnSpanParent::Root,
+        )
+        .await;
+        request_trace
+    }
+    .instrument(request_span)
+    .await;
+
+    let evt = tokio::time::timeout(StdDuration::from_secs(2), rx.recv())
+        .await
+        .expect("timeout waiting for turn completion")
+        .expect("event");
+    assert!(matches!(evt.msg, EventMsg::TurnComplete(_)));
+
+    let task_trace = captured_trace
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone()
+        .expect("turn task should capture the current span trace context");
+    let request_context =
+        codex_otel::context_from_w3c_trace_context(&request_trace).expect("request");
+    let task_context = codex_otel::context_from_w3c_trace_context(&task_trace).expect("task");
+
+    assert_ne!(
+        task_context.span().span_context().trace_id(),
+        request_context.span().span_context().trace_id()
     );
 }
 

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -64,6 +64,14 @@ const GRACEFULL_INTERRUPTION_TIMEOUT_MS: u64 = 100;
 const TASK_COMPACT_METRIC: &str = "codex.task.compact";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TurnSpanParent {
+    /// Preserve the active request or dispatch context for externally started work.
+    Current,
+    /// Avoid nesting automatic follow-on turns under the completed turn that launched them.
+    Root,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum InterruptedTurnHistoryMarker {
     Disabled,
     ContextualUser,
@@ -307,7 +315,8 @@ impl Session {
     ) {
         self.abort_all_tasks(TurnAbortReason::Replaced).await;
         self.clear_connector_selection().await;
-        self.start_task(turn_context, input, task).await;
+        self.start_task(turn_context, input, task, TurnSpanParent::Current)
+            .await;
     }
 
     pub(crate) async fn start_task<T: SessionTask>(
@@ -315,6 +324,7 @@ impl Session {
         turn_context: Arc<TurnContext>,
         input: Vec<TurnInput>,
         task: T,
+        span_parent: TurnSpanParent,
     ) {
         let task: Arc<dyn AnySessionTask> = Arc::new(task);
         let task_kind = task.kind();
@@ -386,7 +396,12 @@ impl Session {
         // Task-owned turn spans keep a core-owned span open for the
         // full task lifecycle after the submission dispatch span ends.
         let reasoning_effort = turn_context.effective_reasoning_effort_for_tracing();
+        let parent_span_id = match span_parent {
+            TurnSpanParent::Current => Span::current().id(),
+            TurnSpanParent::Root => None,
+        };
         let task_span = info_span!(
+            parent: parent_span_id,
             "turn",
             otel.name = span_name,
             thread.id = %self.conversation_id,
@@ -457,9 +472,15 @@ impl Session {
     ///
     /// This helper generates a fresh sub-id for the synthetic turn before delegating to the
     /// explicit-sub-id variant.
-    pub(crate) async fn maybe_start_turn_for_pending_work(self: &Arc<Self>) {
-        self.maybe_start_turn_for_pending_work_with_sub_id(uuid::Uuid::new_v4().to_string())
-            .await;
+    pub(crate) async fn maybe_start_turn_for_pending_work(
+        self: &Arc<Self>,
+        span_parent: TurnSpanParent,
+    ) {
+        self.maybe_start_turn_for_pending_work_with_sub_id(
+            uuid::Uuid::new_v4().to_string(),
+            span_parent,
+        )
+        .await;
     }
 
     /// Starts a regular turn with the provided sub-id when pending work should wake an idle
@@ -470,6 +491,7 @@ impl Session {
     pub(crate) async fn maybe_start_turn_for_pending_work_with_sub_id(
         self: &Arc<Self>,
         sub_id: String,
+        span_parent: TurnSpanParent,
     ) {
         if !self
             .input_queue
@@ -491,7 +513,7 @@ impl Session {
         let turn_context = self.new_default_turn_with_sub_id(sub_id).await;
         self.maybe_emit_unknown_model_warning_for_turn(turn_context.as_ref())
             .await;
-        self.start_task(turn_context, Vec::new(), RegularTask::new())
+        self.start_task(turn_context, Vec::new(), RegularTask::new(), span_parent)
             .await;
     }
 
@@ -530,7 +552,8 @@ impl Session {
             self.input_queue.clear_pending(&active_turn).await;
         }
         if reason == TurnAbortReason::Interrupted && aborted_turn {
-            self.maybe_start_turn_for_pending_work().await;
+            self.maybe_start_turn_for_pending_work(TurnSpanParent::Current)
+                .await;
         }
     }
 
@@ -577,7 +600,8 @@ impl Session {
         self.input_queue.clear_pending(&active_turn).await;
 
         if reason == TurnAbortReason::Interrupted {
-            self.maybe_start_turn_for_pending_work().await;
+            self.maybe_start_turn_for_pending_work(TurnSpanParent::Current)
+                .await;
         }
 
         true

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -174,13 +174,19 @@ fn bool_tag(value: bool) -> &'static str {
 pub(crate) struct SessionTaskContext {
     session: Arc<Session>,
     turn_extension_data: Arc<ExtensionData>,
+    turn_trace_id_override: Option<String>,
 }
 
 impl SessionTaskContext {
-    pub(crate) fn new(session: Arc<Session>, turn_extension_data: Arc<ExtensionData>) -> Self {
+    pub(crate) fn new(
+        session: Arc<Session>,
+        turn_extension_data: Arc<ExtensionData>,
+        turn_trace_id_override: Option<String>,
+    ) -> Self {
         Self {
             session,
             turn_extension_data,
+            turn_trace_id_override,
         }
     }
 
@@ -385,10 +391,6 @@ impl Session {
         let turn = active.get_or_insert_with(ActiveTurn::default);
         debug_assert!(turn.task.is_none());
         let done_clone = Arc::clone(&done);
-        let session_ctx = Arc::new(SessionTaskContext::new(
-            Arc::clone(self),
-            Arc::clone(&turn_extension_data),
-        ));
         let ctx = Arc::clone(&turn_context);
         let task_for_run = Arc::clone(&task);
         let task_input = input;
@@ -415,6 +417,17 @@ impl Session {
             codex.turn.token_usage.reasoning_output_tokens = field::Empty,
             codex.turn.token_usage.total_tokens = field::Empty,
         );
+        // A rooted automatic turn is created beneath the finishing turn, so its
+        // captured context trace must not override the task span's fresh trace.
+        let turn_trace_id_override = match span_parent {
+            TurnSpanParent::Current => None,
+            TurnSpanParent::Root => task_span.in_scope(codex_otel::current_span_trace_id),
+        };
+        let session_ctx = Arc::new(SessionTaskContext::new(
+            Arc::clone(self),
+            Arc::clone(&turn_extension_data),
+            turn_trace_id_override,
+        ));
         let handle = tokio::spawn(
             async move {
                 let ctx_for_finish = Arc::clone(&ctx);
@@ -873,6 +886,7 @@ impl Session {
         let session_ctx = Arc::new(SessionTaskContext::new(
             Arc::clone(self),
             Arc::clone(&task.turn_extension_data),
+            /*turn_trace_id_override*/ None,
         ));
         session_task
             .abort(session_ctx, Arc::clone(&task.turn_context))

--- a/codex-rs/core/src/tasks/regular.rs
+++ b/codex-rs/core/src/tasks/regular.rs
@@ -47,7 +47,10 @@ impl SessionTask for RegularTask {
         // not wait on startup prewarm resolution.
         let event = EventMsg::TurnStarted(TurnStartedEvent {
             turn_id: ctx.sub_id.clone(),
-            trace_id: ctx.trace_id.clone(),
+            trace_id: session
+                .turn_trace_id_override
+                .clone()
+                .or_else(|| ctx.trace_id.clone()),
             started_at: ctx.turn_timing_state.started_at_unix_secs().await,
             model_context_window: ctx.model_context_window(),
             collaboration_mode_kind: ctx.collaboration_mode.mode,


### PR DESCRIPTION
## Why

Automatic `/goal` continuation turns are currently started while the completing `turn` tracing span is still active. The SQLite log store persists full span ancestry in each event body, so successive automatic turns can serialize an increasingly deep `turn{...}:turn{...}` chain. In #23340, that produced hundreds-of-kilobyte log rows and a 34 GB log database within a day.

This addresses the nested-span amplification. Repeated invalid skill/icon diagnostic warnings remain a separate problem covered by the proposed reopening/follow-up to #21274.

Fixes #23340.

## What changed

- Added an explicit `TurnSpanParent` policy for task-owned `turn` spans.
- Preserved the current tracing parent for externally initiated, interrupted, test-helper, and inter-agent work.
- Started automatic goal idle-continuation turns, including queued work consumed on that path, with root `turn` spans.
- Ensured rooted regular turns publish the fresh task-span trace ID in `TurnStarted` rather than the completed parent trace.
- Added regression coverage for both rooted span ancestry and emitted trace correlation while retaining normal-dispatch coverage.

## How to Test

Automated verification run:

- `just test -p codex-core spawn_task_turn_span_inherits_dispatch_trace_context`
- `just test -p codex-core regular_turn_emits_turn_started_with_trace_id_without_waiting_for_startup_prewarm`
- `just test -p codex-core root_task_turn_span_does_not_inherit_current_trace_context`
- `just test -p codex-core rooted_regular_turn_does_not_emit_parent_trace_id`
- `just fmt`
- `just fix -p codex-core`

Additional checks attempted:

- `just test -p codex-core` currently fails in unrelated existing/environment-sensitive tests: `thread_manager::tests::start_thread_uses_all_default_environments_from_codex_home` timed out, and `suite::user_shell_cmd::user_shell_command_does_not_set_network_sandbox_env_var` observes `CODEX_SANDBOX_NETWORK_DISABLED=1` in this sandbox.
- `just argument-comment-lint` is blocked before checking source by the Bazel LLVM `compiler-rt` target missing `include/sanitizer/*.h`; the touched Rust callsites were manually inspected and the introduced opaque literal callsites are annotated.

Manual verification:

1. Run a goal that schedules several automatic continuation turns.
2. Inspect the SQLite log feedback bodies for continuation events.
3. Confirm each automatic turn no longer accumulates nested `turn{...}` ancestors and its `TurnStarted.trace_id` names the new task trace, while a directly submitted turn still correlates to its submission trace.