### PR TITLE
[codex] Fix budget-limited goal edits

### DIFF
--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -499,7 +499,7 @@ Experimental: use `memory/reset` to clear local memory artifacts and sqlite-back
 
 ### Example: Set and update a thread goal
 
-Use `thread/goal/set` to create or update the current goal for a materialized thread. Clients can set `budgetLimited` when they stop because a token budget is exhausted or nearly exhausted, `blocked` when progress is waiting on outside intervention, and `usageLimited` when usage availability stops further work. The system also sets `budgetLimited` when accounting crosses a configured token budget and `usageLimited` when a turn ends on a hard usage-limit error.
+Use `thread/goal/set` to create or update the current goal for a materialized thread. Clients can set `budgetLimited` when they stop because a token budget is exhausted or nearly exhausted, `blocked` when progress is waiting on outside intervention, and `usageLimited` when usage availability stops further work. The system also sets `budgetLimited` when accounting crosses a configured token budget and `usageLimited` when a turn ends on a hard usage-limit error. Setting a different objective on a `budgetLimited` goal starts a replacement goal with fresh usage counters; when `tokenBudget` is omitted, the replacement inherits the previous budget.
 
 ```json
 { "method": "thread/goal/set", "id": 27, "params": {

--- a/codex-rs/app-server/src/request_processors/thread_goal_processor.rs
+++ b/codex-rs/app-server/src/request_processors/thread_goal_processor.rs
@@ -157,26 +157,41 @@ impl ThreadGoalRequestProcessor {
                 .map_err(|err| invalid_request(err.to_string()))?;
             if let Some(goal) = existing_goal.as_ref() {
                 let previous_status = ExternalGoalPreviousStatus::from(goal);
-                state_db
-                    .thread_goals()
-                    .update_thread_goal(
-                        thread_id,
-                        codex_state::GoalUpdate {
-                            objective: Some(objective.to_string()),
-                            status,
-                            token_budget: params.token_budget,
-                            expected_goal_id: Some(goal.goal_id.clone()),
-                        },
-                    )
-                    .await
-                    .and_then(|goal| {
-                        goal.ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "cannot update goal for thread {thread_id}: no goal exists"
-                            )
+                if goal.status == codex_state::ThreadGoalStatus::BudgetLimited
+                    && goal.objective != objective
+                {
+                    state_db
+                        .thread_goals()
+                        .replace_thread_goal(
+                            thread_id,
+                            objective,
+                            status.unwrap_or(codex_state::ThreadGoalStatus::Active),
+                            params.token_budget.unwrap_or(goal.token_budget),
+                        )
+                        .await
+                        .map(|goal| (goal, previous_status))
+                } else {
+                    state_db
+                        .thread_goals()
+                        .update_thread_goal(
+                            thread_id,
+                            codex_state::GoalUpdate {
+                                objective: Some(objective.to_string()),
+                                status,
+                                token_budget: params.token_budget,
+                                expected_goal_id: Some(goal.goal_id.clone()),
+                            },
+                        )
+                        .await
+                        .and_then(|goal| {
+                            goal.ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "cannot update goal for thread {thread_id}: no goal exists"
+                                )
+                            })
                         })
-                    })
-                    .map(|goal| (goal, previous_status))
+                        .map(|goal| (goal, previous_status))
+                }
             } else {
                 let previous_status = ExternalGoalPreviousStatus::NewGoal;
                 state_db

--- a/codex-rs/app-server/tests/suite/v2/thread_resume.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_resume.rs
@@ -1053,7 +1053,7 @@ async fn thread_goal_set_persists_resumable_stopped_statuses() -> Result<()> {
 }
 
 #[tokio::test]
-async fn thread_goal_set_edits_objective_without_resetting_usage() -> Result<()> {
+async fn thread_goal_set_restarts_budget_limited_goal_with_changed_objective() -> Result<()> {
     let server = create_mock_responses_server_repeating_assistant("Done").await;
     let codex_home = TempDir::new()?;
     create_config_toml(codex_home.path(), &server.uri())?;
@@ -1091,7 +1091,7 @@ async fn thread_goal_set_edits_objective_without_resetting_usage() -> Result<()>
         mcp.read_stream_until_response_message(RequestId::Integer(goal_id)),
     )
     .await??;
-    let goal: ThreadGoalSetResponse = to_response(goal_resp)?;
+    let _goal: ThreadGoalSetResponse = to_response(goal_resp)?;
     timeout(
         DEFAULT_READ_TIMEOUT,
         mcp.read_stream_until_notification_message("thread/goal/updated"),
@@ -1128,8 +1128,6 @@ async fn thread_goal_set_edits_objective_without_resetting_usage() -> Result<()>
             Some(json!({
                 "threadId": thread_id.to_string(),
                 "objective": "keep polishing with clearer wording",
-                "status": "active",
-                "tokenBudget": 40,
             })),
         )
         .await?;
@@ -1149,14 +1147,13 @@ async fn thread_goal_set_edits_objective_without_resetting_usage() -> Result<()>
         .await?
         .expect("thread metadata should still exist");
 
-    assert_eq!(persisted_goal.goal_id, updated_goal.goal_id);
+    assert_ne!(persisted_goal.goal_id, updated_goal.goal_id);
     assert_eq!(thread_metadata.preview.as_deref(), Some("keep polishing"));
     assert_eq!(edit.goal.objective, "keep polishing with clearer wording");
-    assert_eq!(edit.goal.status, ThreadGoalStatus::BudgetLimited);
+    assert_eq!(edit.goal.status, ThreadGoalStatus::Active);
     assert_eq!(edit.goal.token_budget, Some(40));
-    assert_eq!(edit.goal.tokens_used, 50);
-    assert_eq!(edit.goal.time_used_seconds, 12);
-    assert_eq!(edit.goal.created_at, goal.goal.created_at);
+    assert_eq!(edit.goal.tokens_used, 0);
+    assert_eq!(edit.goal.time_used_seconds, 0);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- treat a changed objective on a `budgetLimited` thread goal as a replacement goal
- reset consumed usage counters while inheriting the existing token budget when the client omits one
- preserve the existing terminal behavior when the objective is unchanged
- document the endpoint behavior and cover it with an app-server regression test

## Root cause
The desktop goal editor submits an updated objective through `thread/goal/set`. The app server previously updated that goal in place, preserving its terminal `budgetLimited` status and exhausted usage. As a result, editing the text could not make the goal actionable again.

## User impact
After a budget-limited goal is edited to a new objective, it resumes as a fresh active goal using the prior budget by default. This makes the existing edit flow useful after a goal reaches its budget.

## Validation
- `just fmt`
- `just test -p codex-app-server` (791 tests passed; required bench-smoke step completed)