### PR TITLE
Drop legacy remote sandbox requirements

### DIFF
--- a/codex-rs/config/src/config_requirements.rs
+++ b/codex-rs/config/src/config_requirements.rs
@@ -770,29 +770,12 @@ pub struct ConfigRequirementsToml {
     pub guardian_policy_config: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ConfigDeprecationNotice {
-    /// Concise summary of what is deprecated.
-    pub summary: String,
-    /// Optional extra guidance, such as migration steps or rationale.
-    pub details: Option<String>,
-}
-
-const LEGACY_REMOTE_SANDBOX_CONFIG_SUMMARY: &str =
-    "`[[remote_sandbox_config]]` requirements are deprecated";
-const LEGACY_REMOTE_SANDBOX_CONFIG_DETAILS: &str = "Use keyed `[remote_sandbox_config.<name>]` tables instead. Keep the same `hostname_patterns` and `allowed_sandbox_modes` fields under each named table.";
-
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct RemoteSandboxConfigsToml {
     pub entries: Vec<RemoteSandboxConfigToml>,
-    legacy_array_shape: bool,
 }
 
 impl RemoteSandboxConfigsToml {
-    fn uses_legacy_array_shape(&self) -> bool {
-        self.legacy_array_shape
-    }
-
     fn matching_allowed_sandbox_modes(
         &self,
         hostname: &str,
@@ -812,10 +795,7 @@ impl RemoteSandboxConfigsToml {
 
 impl From<Vec<RemoteSandboxConfigToml>> for RemoteSandboxConfigsToml {
     fn from(entries: Vec<RemoteSandboxConfigToml>) -> Self {
-        Self {
-            entries,
-            legacy_array_shape: false,
-        }
+        Self { entries }
     }
 }
 
@@ -825,24 +805,16 @@ impl<'de> Deserialize<'de> for RemoteSandboxConfigsToml {
         D: Deserializer<'de>,
     {
         match TomlValue::deserialize(deserializer)? {
-            TomlValue::Array(entries) => Ok(Self {
-                entries: entries
-                    .into_iter()
-                    .map(RemoteSandboxConfigToml::deserialize)
-                    .collect::<Result<Vec<_>, _>>()
-                    .map_err(D::Error::custom)?,
-                legacy_array_shape: true,
-            }),
+            TomlValue::Array(_) => Err(D::Error::custom(
+                "`[[remote_sandbox_config]]` is no longer supported; use keyed `[remote_sandbox_config.<name>]` tables instead",
+            )),
             TomlValue::Table(entries) => {
                 let entries = entries
                     .into_iter()
                     .map(|(_, entry)| RemoteSandboxConfigToml::deserialize(entry))
                     .collect::<Result<Vec<_>, _>>()
                     .map_err(D::Error::custom)?;
-                Ok(Self {
-                    entries,
-                    legacy_array_shape: false,
-                })
+                Ok(Self { entries })
             }
             value => Err(D::Error::custom(format!(
                 "expected array or table for remote_sandbox_config, got {value:?}"
@@ -899,7 +871,6 @@ pub struct ConfigRequirementsWithSources {
     pub network: Option<Sourced<NetworkRequirementsToml>>,
     pub permissions: Option<Sourced<PermissionsRequirementsToml>>,
     pub guardian_policy_config: Option<Sourced<String>>,
-    pub deprecation_notices: Vec<ConfigDeprecationNotice>,
 }
 
 impl ConfigRequirementsWithSources {
@@ -917,8 +888,6 @@ impl ConfigRequirementsWithSources {
                 )+
             };
         }
-
-        self.extend_deprecation_notices(other.deprecation_notices());
 
         // Destructure without `..` so adding fields to `ConfigRequirementsToml`
         // forces this merge logic to be updated.
@@ -986,18 +955,6 @@ impl ConfigRequirementsWithSources {
         }
     }
 
-    pub fn deprecation_notices(&self) -> &[ConfigDeprecationNotice] {
-        &self.deprecation_notices
-    }
-
-    fn extend_deprecation_notices(&mut self, notices: Vec<ConfigDeprecationNotice>) {
-        for notice in notices {
-            if !self.deprecation_notices.contains(&notice) {
-                self.deprecation_notices.push(notice);
-            }
-        }
-    }
-
     pub fn into_toml(self) -> ConfigRequirementsToml {
         let ConfigRequirementsWithSources {
             allowed_approval_policies,
@@ -1018,7 +975,6 @@ impl ConfigRequirementsWithSources {
             network,
             permissions,
             guardian_policy_config,
-            deprecation_notices: _,
         } = self;
         ConfigRequirementsToml {
             allowed_approval_policies: allowed_approval_policies.map(|sourced| sourced.value),
@@ -1091,21 +1047,6 @@ pub enum ResidencyRequirement {
 }
 
 impl ConfigRequirementsToml {
-    pub fn deprecation_notices(&self) -> Vec<ConfigDeprecationNotice> {
-        let mut notices = Vec::new();
-        if self
-            .remote_sandbox_config
-            .as_ref()
-            .is_some_and(RemoteSandboxConfigsToml::uses_legacy_array_shape)
-        {
-            notices.push(ConfigDeprecationNotice {
-                summary: LEGACY_REMOTE_SANDBOX_CONFIG_SUMMARY.to_string(),
-                details: Some(LEGACY_REMOTE_SANDBOX_CONFIG_DETAILS.to_string()),
-            });
-        }
-        notices
-    }
-
     pub fn apply_remote_sandbox_config(&mut self, hostname: Option<&str>) {
         let Some(remote_sandbox_config) = self.remote_sandbox_config.as_ref() else {
             return;
@@ -1188,7 +1129,6 @@ impl TryFrom<ConfigRequirementsWithSources> for ConfigRequirements {
             network,
             permissions,
             guardian_policy_config,
-            deprecation_notices: _,
         } = toml;
 
         let approval_policy = match allowed_approval_policies {
@@ -1478,7 +1418,6 @@ mod tests {
     }
 
     fn with_unknown_source(toml: ConfigRequirementsToml) -> ConfigRequirementsWithSources {
-        let deprecation_notices = toml.deprecation_notices();
         let ConfigRequirementsToml {
             allowed_approval_policies,
             allowed_approvals_reviewers,
@@ -1529,7 +1468,6 @@ mod tests {
             permissions: permissions.map(|value| Sourced::new(value, RequirementSource::Unknown)),
             guardian_policy_config: guardian_policy_config
                 .map(|value| Sourced::new(value, RequirementSource::Unknown)),
-            deprecation_notices,
         }
     }
 
@@ -1750,7 +1688,6 @@ mod tests {
                 network: None,
                 permissions: None,
                 guardian_policy_config: Some(Sourced::new(guardian_policy_config, source)),
-                deprecation_notices: Vec::new(),
             }
         );
     }
@@ -1794,7 +1731,6 @@ mod tests {
                 network: None,
                 permissions: None,
                 guardian_policy_config: None,
-                deprecation_notices: Vec::new(),
             }
         );
         Ok(())
@@ -1846,7 +1782,6 @@ mod tests {
                 network: None,
                 permissions: None,
                 guardian_policy_config: None,
-                deprecation_notices: Vec::new(),
             }
         );
         Ok(())
@@ -2569,7 +2504,7 @@ allowed_approvals_reviewers = ["user"]
     #[test]
     fn deserialize_remote_sandbox_config_requires_hostname_patterns_list() -> Result<()> {
         let toml_str = r#"
-            [[remote_sandbox_config]]
+            [remote_sandbox_config.org]
             hostname_patterns = ["*.org", "runner-??.ci"]
             allowed_sandbox_modes = ["read-only", "workspace-write"]
         "#;
@@ -2585,13 +2520,12 @@ allowed_approvals_reviewers = ["user"]
                         SandboxModeRequirement::WorkspaceWrite,
                     ],
                 }],
-                legacy_array_shape: true,
             })
         );
 
         let err = from_str::<ConfigRequirementsToml>(
             r#"
-                [[remote_sandbox_config]]
+                [remote_sandbox_config.org]
                 hostname_patterns = "*.org"
                 allowed_sandbox_modes = ["read-only"]
             "#,
@@ -2603,6 +2537,24 @@ allowed_approvals_reviewers = ["user"]
         );
 
         Ok(())
+    }
+
+    #[test]
+    fn deserialize_remote_sandbox_config_rejects_legacy_array() {
+        let err = from_str::<ConfigRequirementsToml>(
+            r#"
+                [[remote_sandbox_config]]
+                hostname_patterns = ["*.org"]
+                allowed_sandbox_modes = ["read-only"]
+            "#,
+        )
+        .expect_err("legacy remote_sandbox_config arrays should be rejected");
+
+        assert!(
+            err.to_string()
+                .contains("`[[remote_sandbox_config]]` is no longer supported"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]
@@ -2647,42 +2599,6 @@ allowed_approvals_reviewers = ["user"]
                 .into()
             )
         );
-
-        Ok(())
-    }
-
-    #[test]
-    fn remote_sandbox_config_legacy_array_adds_deprecation_notice() -> Result<()> {
-        let config: ConfigRequirementsToml = from_str(
-            r#"
-                [[remote_sandbox_config]]
-                hostname_patterns = ["*.org"]
-                allowed_sandbox_modes = ["read-only"]
-            "#,
-        )?;
-
-        assert_eq!(
-            config.deprecation_notices(),
-            vec![ConfigDeprecationNotice {
-                summary: LEGACY_REMOTE_SANDBOX_CONFIG_SUMMARY.to_string(),
-                details: Some(LEGACY_REMOTE_SANDBOX_CONFIG_DETAILS.to_string()),
-            }]
-        );
-
-        Ok(())
-    }
-
-    #[test]
-    fn remote_sandbox_config_keyed_map_has_no_deprecation_notice() -> Result<()> {
-        let config: ConfigRequirementsToml = from_str(
-            r#"
-                [remote_sandbox_config.devboxes]
-                hostname_patterns = ["*.org"]
-                allowed_sandbox_modes = ["read-only"]
-            "#,
-        )?;
-
-        assert_eq!(config.deprecation_notices(), Vec::new());
 
         Ok(())
     }
@@ -2737,7 +2653,7 @@ allowed_approvals_reviewers = ["user"]
             r#"
                 allowed_sandbox_modes = ["read-only"]
 
-                [[remote_sandbox_config]]
+                [remote_sandbox_config.build]
                 hostname_patterns = ["build-*.example.com"]
                 allowed_sandbox_modes = ["read-only", "workspace-write"]
             "#,
@@ -2774,7 +2690,7 @@ allowed_approvals_reviewers = ["user"]
 
         let mut low_precedence: ConfigRequirementsToml = from_str(
             r#"
-                [[remote_sandbox_config]]
+                [remote_sandbox_config.ci]
                 hostname_patterns = ["runner-*.ci.example.com"]
                 allowed_sandbox_modes = ["read-only", "workspace-write"]
             "#,

--- a/codex-rs/config/src/lib.rs
+++ b/codex-rs/config/src/lib.rs
@@ -40,7 +40,6 @@ pub use config_requirements::AppToolRequirementToml;
 pub use config_requirements::AppToolsRequirementsToml;
 pub use config_requirements::AppsRequirementsToml;
 pub use config_requirements::ComputerUseRequirementsToml;
-pub use config_requirements::ConfigDeprecationNotice;
 pub use config_requirements::ConfigRequirements;
 pub use config_requirements::ConfigRequirementsToml;
 pub use config_requirements::ConfigRequirementsWithSources;

--- a/codex-rs/config/src/loader/mod.rs
+++ b/codex-rs/config/src/loader/mod.rs
@@ -376,13 +376,11 @@ pub async fn load_config_layers_state(
         ));
     }
 
-    let config_deprecation_notices = config_requirements_toml.deprecation_notices().to_vec();
     let config_layer_stack = ConfigLayerStack::new(
         layers,
         config_requirements_toml.clone().try_into()?,
         config_requirements_toml.into_toml(),
     )?
-    .with_config_deprecation_notices(config_deprecation_notices)
     .with_user_and_project_exec_policy_rules_ignored(ignore_user_and_project_exec_policy_rules);
     Ok(match startup_warnings {
         Some(startup_warnings) => config_layer_stack.with_startup_warnings(startup_warnings),

--- a/codex-rs/config/src/state.rs
+++ b/codex-rs/config/src/state.rs
@@ -1,4 +1,3 @@
-use crate::config_requirements::ConfigDeprecationNotice;
 use crate::config_requirements::ConfigRequirements;
 use crate::config_requirements::ConfigRequirementsToml;
 
@@ -232,9 +231,6 @@ pub struct ConfigLayerStack {
     /// surfaced via APIs.
     requirements_toml: ConfigRequirementsToml,
 
-    /// Deprecation notices discovered while loading config requirements.
-    config_deprecation_notices: Vec<ConfigDeprecationNotice>,
-
     /// Whether execpolicy should skip `.rules` files from user and project config-layer folders.
     ignore_user_and_project_exec_policy_rules: bool,
 
@@ -257,7 +253,6 @@ impl ConfigLayerStack {
             user_layer_index,
             requirements,
             requirements_toml,
-            config_deprecation_notices: Vec::new(),
             ignore_user_and_project_exec_policy_rules: false,
             startup_warnings: None,
         })
@@ -268,14 +263,6 @@ impl ConfigLayerStack {
         ignore_user_and_project_exec_policy_rules: bool,
     ) -> Self {
         self.ignore_user_and_project_exec_policy_rules = ignore_user_and_project_exec_policy_rules;
-        self
-    }
-
-    pub fn with_config_deprecation_notices(
-        mut self,
-        config_deprecation_notices: Vec<ConfigDeprecationNotice>,
-    ) -> Self {
-        self.config_deprecation_notices = config_deprecation_notices;
         self
     }
 
@@ -355,10 +342,6 @@ impl ConfigLayerStack {
         &self.requirements_toml
     }
 
-    pub fn config_deprecation_notices(&self) -> &[ConfigDeprecationNotice] {
-        &self.config_deprecation_notices
-    }
-
     /// Creates a new [ConfigLayerStack] using the specified values to inject one
     /// user layer into the stack. If such a layer already exists, it is replaced;
     /// otherwise, it is inserted into the stack at the appropriate position
@@ -417,7 +400,6 @@ impl ConfigLayerStack {
             user_layer_index,
             requirements: self.requirements.clone(),
             requirements_toml: self.requirements_toml.clone(),
-            config_deprecation_notices: self.config_deprecation_notices.clone(),
             ignore_user_and_project_exec_policy_rules: self
                 .ignore_user_and_project_exec_policy_rules,
             startup_warnings: self.startup_warnings.clone(),
@@ -460,7 +442,6 @@ impl ConfigLayerStack {
             user_layer_index,
             requirements: self.requirements.clone(),
             requirements_toml: self.requirements_toml.clone(),
-            config_deprecation_notices: self.config_deprecation_notices.clone(),
             ignore_user_and_project_exec_policy_rules: self
                 .ignore_user_and_project_exec_policy_rules,
             startup_warnings: self.startup_warnings.clone(),

--- a/codex-rs/core/src/config/config_loader_tests.rs
+++ b/codex-rs/core/src/config/config_loader_tests.rs
@@ -5,7 +5,6 @@ use codex_app_server_protocol::ConfigLayerSource;
 use codex_config::CONFIG_TOML_FILE;
 use codex_config::CloudRequirementsLoadError;
 use codex_config::CloudRequirementsLoader;
-use codex_config::ConfigDeprecationNotice;
 use codex_config::ConfigError;
 use codex_config::ConfigLayerEntry;
 use codex_config::ConfigLayerStackOrdering;
@@ -1209,7 +1208,7 @@ async fn system_remote_sandbox_config_keeps_cloud_sandbox_modes() -> anyhow::Res
     tokio::fs::write(
         &requirements_file,
         r#"
-[[remote_sandbox_config]]
+[remote_sandbox_config.any_host]
 hostname_patterns = ["*"]
 allowed_sandbox_modes = ["read-only", "workspace-write"]
 "#,
@@ -1833,54 +1832,6 @@ async fn load_config_layers_applies_matching_remote_sandbox_config() -> anyhow::
             .permission_profile
             .can_set(&PermissionProfile::workspace_write())
             .is_ok()
-    );
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn load_preserves_legacy_remote_sandbox_config_deprecation_notice() -> anyhow::Result<()> {
-    let tmp = tempdir()?;
-    let codex_home = tmp.path().join("home");
-    tokio::fs::create_dir_all(&codex_home).await?;
-    let cwd = AbsolutePathBuf::from_absolute_path(tmp.path())?;
-
-    let requirements: ConfigRequirementsToml = toml::from_str(
-        r#"
-            [[remote_sandbox_config]]
-            hostname_patterns = ["*"]
-            allowed_sandbox_modes = ["read-only", "workspace-write"]
-        "#,
-    )?;
-    let cloud_requirements = CloudRequirementsLoader::new(async move { Ok(Some(requirements)) });
-    let layers = load_config_layers_state(
-        LOCAL_FS.as_ref(),
-        &codex_home,
-        Some(cwd),
-        &[] as &[(String, TomlValue)],
-        LoaderOverrides::default(),
-        cloud_requirements,
-        &codex_config::NoopThreadConfigLoader,
-    )
-    .await?;
-
-    assert_eq!(
-        layers.config_deprecation_notices(),
-        [ConfigDeprecationNotice {
-            summary: "`[[remote_sandbox_config]]` requirements are deprecated".to_string(),
-            details: Some(
-                "Use keyed `[remote_sandbox_config.<name>]` tables instead. Keep the same `hostname_patterns` and `allowed_sandbox_modes` fields under each named table."
-                    .to_string()
-            ),
-        }]
-    );
-    assert_eq!(layers.requirements_toml().remote_sandbox_config, None);
-    assert_eq!(
-        layers.requirements_toml().allowed_sandbox_modes,
-        Some(vec![
-            codex_config::SandboxModeRequirement::ReadOnly,
-            codex_config::SandboxModeRequirement::WorkspaceWrite,
-        ])
     );
 
     Ok(())

--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -726,15 +726,6 @@ impl Session {
                     }),
                 });
             }
-            for notice in config.config_layer_stack.config_deprecation_notices() {
-                post_session_configured_events.push(Event {
-                    id: INITIAL_SUBMIT_ID.to_owned(),
-                    msg: EventMsg::DeprecationNotice(DeprecationNoticeEvent {
-                        summary: notice.summary.clone(),
-                        details: notice.details.clone(),
-                    }),
-                });
-            }
             for message in &config.startup_warnings {
                 post_session_configured_events.push(Event {
                     id: "".to_owned(),


### PR DESCRIPTION
# Why

This is the final step in the `remote_sandbox_config` migration. After the keyed format has shipped, top customers have migrated, and users have had enough notice from the deprecation PR, Codex should stop accepting the legacy array-of-tables shape.

# What

- Removes support for `[[remote_sandbox_config]]`.
- Rejects the legacy shape with a targeted parse error that points admins to keyed `[remote_sandbox_config.<name>]` tables.
- Removes the temporary deprecation-notice plumbing from the previous migration step.
- Updates remote sandbox config tests and fixtures to use the keyed format.

# Stack

1. https://github.com/openai/codex/pull/24839
2. https://github.com/openai/codex/pull/24840
3. https://github.com/openai/codex/pull/24841

# Rollout

Keep this PR as draft until the warning has shipped for the desired notice window. Merge it only after we are comfortable that remaining managed requirements have moved to keyed tables.
