### PR TITLE
Use environment secrets for Azure signing

### DIFF
--- a/.github/workflows/rust-release-windows.yml
+++ b/.github/workflows/rust-release-windows.yml
@@ -6,19 +6,6 @@ on:
       release-lto:
         required: true
         type: string
-    secrets:
-      AZURE_TRUSTED_SIGNING_CLIENT_ID:
-        required: true
-      AZURE_TRUSTED_SIGNING_TENANT_ID:
-        required: true
-      AZURE_TRUSTED_SIGNING_SUBSCRIPTION_ID:
-        required: true
-      AZURE_TRUSTED_SIGNING_ENDPOINT:
-        required: true
-      AZURE_TRUSTED_SIGNING_ACCOUNT_NAME:
-        required: true
-      AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME:
-        required: true
 
 jobs:
   build-windows-binaries:
@@ -141,6 +128,9 @@ jobs:
       - build-windows-binaries
     name: Build - ${{ matrix.runner }} - ${{ matrix.target }}
     runs-on: ${{ matrix.runs_on }}
+    environment:
+      name: azure-artifact-signing
+      deployment: false
     timeout-minutes: 90
     permissions:
       contents: read

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -874,7 +874,6 @@ jobs:
     uses: ./.github/workflows/rust-release-windows.yml
     with:
       release-lto: ${{ contains(github.ref_name, '-alpha') && 'thin' || 'fat' }}
-    secrets: inherit
 
   argument-comment-lint-release-assets:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.release_mode != 'promote_signed' }}


### PR DESCRIPTION
## Summary
- Move Azure Trusted Signing values out of reusable workflow-call secrets and into the `azure-artifact-signing` environment scope
- Attach the Windows signing job to the `azure-artifact-signing` environment so it can resolve the signing secrets directly
- Stop inheriting caller secrets for the Windows release reusable workflow

## Validation
- `git diff --check -- .github/workflows/rust-release.yml .github/workflows/rust-release-windows.yml`
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "ok #{path}" }' .github/workflows/rust-release.yml .github/workflows/rust-release-windows.yml`