### PR TITLE
[codex] Simplify Python SDK install guidance

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -14,18 +14,6 @@ Install the SDK:
 pip install openai-codex
 ```
 
-For reproducible environments, install this release exactly:
-
-```bash
-pip install openai-codex==0.1.0b1
-```
-
-The SDK requires Python `>=3.10` and installs its compatible Codex runtime
-dependency automatically. While beta releases are the only published SDK
-releases, the normal install command selects the latest beta. After a stable
-release exists, use `pip install --pre openai-codex` to explicitly select a
-newer prerelease.
-
 ## Quickstart
 
 The SDK reuses your existing Codex authentication when one is already


### PR DESCRIPTION
## Summary
- Remove the exact-version install snippet from the PyPI-facing Python SDK README.
- Remove the release-selection explanation so the install section presents the standard `pip install openai-codex` path directly.

## Validation
- Not run locally; relying on online CI for this documentation-only change.