### PR TITLE
[codex] Remove Python SDK language classifiers

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -14,7 +14,6 @@ keywords = ["codex", "sdk", "llm", "ai", "agents"]
 classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
-  "Programming Language :: Python :: 3",
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = ["pydantic>=2.12", "openai-codex-cli-bin==0.132.0"]

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -15,10 +15,6 @@ classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: 3.13",
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = ["pydantic>=2.12", "openai-codex-cli-bin==0.132.0"]


### PR DESCRIPTION
## Summary
- Remove the Python language classifiers from the Python SDK package metadata.
- Keep `requires-python = ">=3.10"` as the package's interpreter compatibility constraint.
- Avoid presenting a curated version-support list in PyPI metadata.

## Validation
- Not run locally; relying on online CI for this metadata-only change.

## Release
- Land this change before publishing the next Python SDK beta.