### PR TITLE
[codex] Remove Python SDK beta warning note

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -3,9 +3,6 @@
 Build Python applications that start Codex threads, run turns, stream progress,
 and control workspace access.
 
-> [!NOTE]
-> `openai-codex` is in beta. Public APIs may change before `1.0`.
-
 ## Install
 
 Install the SDK:


### PR DESCRIPTION
## Summary
- Remove the beta warning callout from the PyPI-facing Python SDK README.
- Keep the existing Beta title and install/usage guidance unchanged.

## Validation
- Not run locally; relying on online CI for this documentation-only change.

## Release
- Land this change before publishing the next Python SDK beta.