### PR TITLE
[codex] Stage Python SDK beta versions from release tags

### DIFF
--- a/.github/workflows/python-sdk-release.yml
+++ b/.github/workflows/python-sdk-release.yml
@@ -23,11 +23,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.12"
-
       - name: Validate tag and build Python SDK package
         shell: bash
         run: |
@@ -36,14 +31,6 @@ jobs:
           sdk_version="${GITHUB_REF_NAME#python-v}"
           if [[ ! "${sdk_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+b[0-9]+$ ]]; then
             echo "Python SDK release tags must identify a beta release, for example python-v0.1.0b1."
-            exit 1
-          fi
-
-          configured_version="$(
-            python -c 'import tomllib; print(tomllib.load(open("sdk/python/pyproject.toml", "rb"))["project"]["version"])'
-          )"
-          if [[ "${configured_version}" != "${sdk_version}" ]]; then
-            echo "Tag version ${sdk_version} does not match sdk/python/pyproject.toml version ${configured_version}."
             exit 1
           fi
 

--- a/sdk/python/docs/faq.md
+++ b/sdk/python/docs/faq.md
@@ -10,7 +10,7 @@ After a stable release exists, pass `--pre` to opt into newer prereleases.
 ## Why does the SDK install a runtime package?
 
 The SDK and runtime packages are versioned independently. Each SDK release
-pins one compatible runtime dependency, so `openai-codex==0.1.0b1` installs
+pins one compatible runtime dependency, so `openai-codex==0.1.0b2` installs
 `openai-codex-cli-bin==0.132.0` automatically.
 
 ## Thread vs turn

--- a/sdk/python/docs/faq.md
+++ b/sdk/python/docs/faq.md
@@ -10,8 +10,7 @@ After a stable release exists, pass `--pre` to opt into newer prereleases.
 ## Why does the SDK install a runtime package?
 
 The SDK and runtime packages are versioned independently. Each SDK release
-pins one compatible runtime dependency, so `openai-codex==0.1.0b2` installs
-`openai-codex-cli-bin==0.132.0` automatically.
+pins and installs one compatible runtime dependency automatically.
 
 ## Thread vs turn
 

--- a/sdk/python/docs/getting-started.md
+++ b/sdk/python/docs/getting-started.md
@@ -14,7 +14,7 @@ pip install openai-codex
 For a reproducible install of this release:
 
 ```bash
-pip install openai-codex==0.1.0b1
+pip install openai-codex==0.1.0b2
 ```
 
 Requirements:

--- a/sdk/python/docs/getting-started.md
+++ b/sdk/python/docs/getting-started.md
@@ -11,12 +11,6 @@ Install the SDK:
 pip install openai-codex
 ```
 
-For a reproducible install of this release:
-
-```bash
-pip install openai-codex==0.1.0b2
-```
-
 Requirements:
 
 - Python `>=3.10`

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "openai-codex"
-version = "0.1.0b2"
+version = "0.0.0-dev"
 description = "Python SDK for Codex"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "openai-codex"
-version = "0.1.0b1"
+version = "0.1.0b2"
 description = "Python SDK for Codex"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk/python/tests/test_artifact_workflow_and_binaries.py
+++ b/sdk/python/tests/test_artifact_workflow_and_binaries.py
@@ -239,17 +239,17 @@ def test_runtime_distribution_name_is_consistent() -> None:
     )
 
 
-def test_source_sdk_package_pins_published_runtime() -> None:
-    """The source package metadata should pin the runtime wheel that ships schemas."""
+def test_source_sdk_template_pins_published_runtime() -> None:
+    """The source template should carry a development version and reviewed runtime pin."""
     script = _load_update_script_module()
     pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text())
 
     assert {
-        "sdk_version": pyproject["project"]["version"],
+        "sdk_template_version": pyproject["project"]["version"],
         "runtime_pin": script.pinned_runtime_version(),
         "dependencies": pyproject["project"]["dependencies"],
     } == {
-        "sdk_version": "0.1.0b2",
+        "sdk_template_version": "0.0.0-dev",
         "runtime_pin": "0.132.0",
         "dependencies": [
             "pydantic>=2.12",
@@ -319,7 +319,7 @@ def test_runtime_setup_reads_independent_runtime_pin_and_release_tags() -> None:
 
     assert {
         "package_name": runtime_setup.PACKAGE_NAME,
-        "sdk_version": pyproject["project"]["version"],
+        "sdk_template_version": pyproject["project"]["version"],
         "runtime_pin": runtime_setup.pinned_runtime_version(),
         "normalized_release_version": runtime_setup._normalized_package_version(
             "rust-v0.116.0-alpha.1"
@@ -327,7 +327,7 @@ def test_runtime_setup_reads_independent_runtime_pin_and_release_tags() -> None:
         "release_tag": runtime_setup._release_tag("0.116.0a1"),
     } == {
         "package_name": "openai-codex-cli-bin",
-        "sdk_version": "0.1.0b2",
+        "sdk_template_version": "0.0.0-dev",
         "runtime_pin": "0.132.0",
         "normalized_release_version": "0.116.0a1",
         "release_tag": "rust-v0.116.0-alpha.1",

--- a/sdk/python/tests/test_artifact_workflow_and_binaries.py
+++ b/sdk/python/tests/test_artifact_workflow_and_binaries.py
@@ -249,7 +249,7 @@ def test_source_sdk_package_pins_published_runtime() -> None:
         "runtime_pin": script.pinned_runtime_version(),
         "dependencies": pyproject["project"]["dependencies"],
     } == {
-        "sdk_version": "0.1.0b1",
+        "sdk_version": "0.1.0b2",
         "runtime_pin": "0.132.0",
         "dependencies": [
             "pydantic>=2.12",
@@ -327,7 +327,7 @@ def test_runtime_setup_reads_independent_runtime_pin_and_release_tags() -> None:
         "release_tag": runtime_setup._release_tag("0.116.0a1"),
     } == {
         "package_name": "openai-codex-cli-bin",
-        "sdk_version": "0.1.0b1",
+        "sdk_version": "0.1.0b2",
         "runtime_pin": "0.132.0",
         "normalized_release_version": "0.116.0a1",
         "release_tag": "rust-v0.116.0-alpha.1",

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -282,7 +282,7 @@ wheels = [
 
 [[package]]
 name = "openai-codex"
-version = "0.1.0b2"
+version = "0.0.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "openai-codex-cli-bin" },

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -282,7 +282,7 @@ wheels = [
 
 [[package]]
 name = "openai-codex"
-version = "0.1.0b1"
+version = "0.1.0b2"
 source = { editable = "." }
 dependencies = [
     { name = "openai-codex-cli-bin" },


### PR DESCRIPTION
## Summary
- Treat `sdk/python` as a development template with source version `0.0.0-dev`, matching the existing Python runtime packaging pattern.
- Have `python-v*` tags supply the published SDK beta version through the existing `stage-sdk --sdk-version` path.
- Remove the workflow check requiring a source version bump for each beta release and remove its now-unused host Python setup step.
- Keep the reviewed runtime dependency pin at `openai-codex-cli-bin==0.132.0`.
- Remove beta-number-specific documentation so it does not need editing for each publish.

## Why
The package staging script already writes the release version into the artifact. Requiring the checked-in SDK template version to match every tag adds release-only source churn without changing the package users receive.

## Validation
- Not run locally; relying on online CI for this workflow and metadata change.

## Release
After this PR lands, publish the next beta by pushing tag `python-v0.1.0b2` from merged `main`.