### PR TITLE
Export Guardian prompt cache key helper

### DIFF
--- a/codex-rs/core/src/guardian/mod.rs
+++ b/codex-rs/core/src/guardian/mod.rs
@@ -40,6 +40,7 @@ pub(crate) use review::review_approval_request_with_cancel;
 pub(crate) use review::routes_approval_to_guardian;
 pub(crate) use review::spawn_approval_request_review;
 pub(crate) use review_session::GuardianReviewSessionManager;
+pub(crate) use review_session::prompt_cache_key_override_for_review_session;
 
 pub(crate) const GUARDIAN_REVIEW_TIMEOUT: Duration = Duration::from_secs(90);
 pub(crate) const GUARDIAN_REVIEWER_NAME: &str = "guardian";


### PR DESCRIPTION
Split from the Guardian prompt cache key change. This PR only updates codex-rs/core/src/guardian/mod.rs. Validation was not run per request; this branch is expected to rely on the companion split PRs.