### PR TITLE
[codex] Fix Guardian argument comment lint

### DIFF
--- a/codex-rs/core/src/guardian/review_session.rs
+++ b/codex-rs/core/src/guardian/review_session.rs
@@ -1209,7 +1209,10 @@ mod tests {
         );
         assert_eq!(
             None,
-            prompt_cache_key_override_for_review_session(&session_source, None)
+            prompt_cache_key_override_for_review_session(
+                &session_source,
+                /*parent_thread_id*/ None
+            )
         );
     }
 


### PR DESCRIPTION
## Summary
- Add the required `/*parent_thread_id*/` argument comment at the Guardian review session test callsite flagged by CI.

## Validation
- `just fmt`
- Not run: clippy/tests, per request; CI will cover them.