### PR TITLE
Fix extension turn item emitter test event ordering

### DIFF
--- a/codex-rs/core/src/tools/handlers/extension_tools.rs
+++ b/codex-rs/core/src/tools/handlers/extension_tools.rs
@@ -271,6 +271,11 @@ mod tests {
         session
             .record_conversation_items(&turn, std::slice::from_ref(&history_item))
             .await;
+        let raw_history_event = rx.recv().await.expect("history raw response item event");
+        let EventMsg::RawResponseItem(raw_history_item) = raw_history_event.msg else {
+            panic!("expected raw response item event");
+        };
+        assert_eq!(raw_history_item.item, history_item);
         let invocation = ToolInvocation {
             session,
             turn,


### PR DESCRIPTION
## Why

PR #24813 added extension `TurnItemEmitter` coverage and introduced a test that records a conversation history item before asserting extension-emitted turn item events.

`record_conversation_items()` also emits a `RawResponseItem` event to observers. The test was reading from the same event receiver and expected the next event to be `ItemStarted`, so the test failed reliably once the setup history item was present.

## What Changed

Update `passes_turn_fields_and_scoped_turn_item_emitter_to_extension_call` to consume and assert the expected setup `RawResponseItem` before checking the extension `ItemStarted`, `WebSearchBegin`, `ItemCompleted`, and `WebSearchEnd` events.

This is test-only and does not change extension runtime behavior.

## Verification

- `cargo nextest run --no-fail-fast -p codex-core tools::handlers::extension_tools::tests::passes_turn_fields_and_scoped_turn_item_emitter_to_extension_call`
