### PR TITLE
Handle missing ChatGPT refresh tokens in auth flow

### DIFF
--- a/codex-rs/app-server/tests/suite/auth.rs
+++ b/codex-rs/app-server/tests/suite/auth.rs
@@ -255,6 +255,46 @@ async fn get_auth_status_with_api_key_refresh_requested() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_auth_status_with_chatgpt_without_refresh_token() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    create_config_toml(codex_home.path())?;
+    write_chatgpt_auth(
+        codex_home.path(),
+        ChatGptAuthFixture::new("access-chatgpt")
+            .refresh_token("")
+            .email("user@example.com")
+            .plan_type("pro"),
+        AuthCredentialsStoreMode::File,
+    )?;
+
+    let mut mcp = McpProcess::new_with_env(codex_home.path(), &[("OPENAI_API_KEY", None)]).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let request_id = mcp
+        .send_get_auth_status_request(GetAuthStatusParams {
+            include_token: Some(true),
+            refresh_token: Some(true),
+        })
+        .await?;
+
+    let resp: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+    let status: GetAuthStatusResponse = to_response(resp)?;
+    assert_eq!(
+        status,
+        GetAuthStatusResponse {
+            auth_method: Some(AuthMode::Chatgpt),
+            auth_token: Some("access-chatgpt".to_string()),
+            requires_openai_auth: Some(true),
+        }
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn get_auth_status_omits_token_after_permanent_refresh_failure() -> Result<()> {
     let codex_home = TempDir::new()?;
     create_config_toml(codex_home.path())?;

--- a/codex-rs/login/src/auth/auth_tests.rs
+++ b/codex-rs/login/src/auth/auth_tests.rs
@@ -252,6 +252,51 @@ async fn pro_account_with_no_api_key_uses_chatgpt_auth() {
 
 #[tokio::test]
 #[serial(codex_auth_env)]
+async fn chatgpt_auth_without_refresh_token_loads() {
+    let codex_home = tempdir().unwrap();
+    let _access_token_guard = remove_access_token_env_var();
+    let fake_jwt = fake_jwt_for_auth_file_params(&AuthFileParams {
+        openai_api_key: None,
+        chatgpt_plan_type: Some("pro".to_string()),
+        chatgpt_account_id: Some(WORKSPACE_ID_ALLOWED.to_string()),
+    })
+    .expect("failed to build fake jwt");
+    let auth_json_data = json!({
+        "auth_mode": "chatgpt",
+        "tokens": {
+            "id_token": fake_jwt,
+            "access_token": "test-access-token",
+            "account_id": WORKSPACE_ID_ALLOWED,
+        },
+        "last_refresh": Utc::now(),
+    });
+    std::fs::write(
+        get_auth_file(codex_home.path()),
+        serde_json::to_string_pretty(&auth_json_data).unwrap(),
+    )
+    .expect("failed to write auth file");
+
+    let auth = super::load_auth(
+        codex_home.path(),
+        /*enable_codex_api_key_env*/ false,
+        AuthCredentialsStoreMode::File,
+        /*chatgpt_base_url*/ None,
+    )
+    .await
+    .expect("auth should load")
+    .expect("auth should be present");
+
+    let token_data = auth.get_token_data().expect("token data should load");
+    assert_eq!(auth.auth_mode(), AuthMode::Chatgpt);
+    assert_eq!(
+        auth.get_token().expect("access token should be available"),
+        "test-access-token"
+    );
+    assert!(!token_data.has_refresh_token());
+}
+
+#[tokio::test]
+#[serial(codex_auth_env)]
 async fn loads_api_key_from_auth_json() {
     let dir = tempdir().unwrap();
     let _access_token_guard = remove_access_token_env_var();

--- a/codex-rs/login/src/auth/manager.rs
+++ b/codex-rs/login/src/auth/manager.rs
@@ -1694,6 +1694,9 @@ impl AuthManager {
         {
             return Ok(());
         }
+        // Some managed ChatGPT auth files are refreshed by an external provider
+        // and intentionally omit the refresh token. In that mode we should only
+        // reload storage and never start a competing OAuth refresh.
         if let Some(CodexAuth::Chatgpt(chatgpt_auth)) = auth_before_reload.as_ref()
             && !chatgpt_auth
                 .current_token_data()
@@ -1831,6 +1834,9 @@ impl AuthManager {
             Some(auth_dot_json) => auth_dot_json,
             None => return false,
         };
+        // Without a refresh token, freshness is owned by the external writer
+        // that updates auth.json; local proactive refresh would only compete
+        // with that owner.
         let Some(tokens) = auth_dot_json
             .tokens
             .as_ref()

--- a/codex-rs/login/src/auth/manager.rs
+++ b/codex-rs/login/src/auth/manager.rs
@@ -1694,6 +1694,14 @@ impl AuthManager {
         {
             return Ok(());
         }
+        if let Some(CodexAuth::Chatgpt(chatgpt_auth)) = auth_before_reload.as_ref()
+            && !chatgpt_auth
+                .current_token_data()
+                .is_some_and(|token_data| token_data.has_refresh_token())
+        {
+            self.reload().await;
+            return Ok(());
+        }
         let expected_account_id = auth_before_reload
             .as_ref()
             .and_then(CodexAuth::get_account_id);
@@ -1753,6 +1761,10 @@ impl AuthManager {
                         "Token data is not available.",
                     ))
                 })?;
+                if !token_data.has_refresh_token() {
+                    tracing::info!("Skipping token refresh because auth has no refresh token.");
+                    return Ok(());
+                }
                 self.refresh_and_persist_chatgpt_token(&chatgpt_auth, token_data.refresh_token)
                     .await
             }
@@ -1819,9 +1831,14 @@ impl AuthManager {
             Some(auth_dot_json) => auth_dot_json,
             None => return false,
         };
-        if let Some(tokens) = auth_dot_json.tokens.as_ref()
-            && let Ok(Some(expires_at)) = parse_jwt_expiration(&tokens.access_token)
-        {
+        let Some(tokens) = auth_dot_json
+            .tokens
+            .as_ref()
+            .filter(|tokens| tokens.has_refresh_token())
+        else {
+            return false;
+        };
+        if let Ok(Some(expires_at)) = parse_jwt_expiration(&tokens.access_token) {
             return expires_at
                 <= Utc::now()
                     + chrono::Duration::minutes(CHATGPT_ACCESS_TOKEN_REFRESH_WINDOW_MINUTES);

--- a/codex-rs/login/src/auth/revoke.rs
+++ b/codex-rs/login/src/auth/revoke.rs
@@ -83,7 +83,7 @@ pub(crate) fn should_revoke_auth_tokens(
 
 fn revocable_token(auth_dot_json: &AuthDotJson) -> Option<(&str, RevokeTokenKind)> {
     let tokens = managed_chatgpt_tokens(auth_dot_json)?;
-    if !tokens.refresh_token.is_empty() {
+    if tokens.has_refresh_token() {
         Some((tokens.refresh_token.as_str(), RevokeTokenKind::Refresh))
     } else if !tokens.access_token.is_empty() {
         Some((tokens.access_token.as_str(), RevokeTokenKind::Access))

--- a/codex-rs/login/src/token_data.rs
+++ b/codex-rs/login/src/token_data.rs
@@ -19,9 +19,16 @@ pub struct TokenData {
     /// This is a JWT.
     pub access_token: String,
 
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub refresh_token: String,
 
     pub account_id: Option<String>,
+}
+
+impl TokenData {
+    pub(crate) fn has_refresh_token(&self) -> bool {
+        !self.refresh_token.is_empty()
+    }
 }
 
 /// Flat subset of useful claims in id_token from auth.json.


### PR DESCRIPTION
Motivation is to allow for refreshing `chatgpt` credentials externally and inject `auth.json` into remote hosts without `refresh_token` to avoid refresh race/conflicts.


---


## Summary
- Allow managed ChatGPT `auth.json` entries to omit `refresh_token` without failing load or refresh paths.
- Skip OAuth refresh attempts when no refresh token exists, and keep proactive refresh/revoke logic consistent with that state.
- Add coverage for loading and app-server auth status with ChatGPT auth that only has an access token.

## Testing
- `just fmt`
- `just test -p codex-login`
- `just test -p codex-app-server get_auth_status_with_chatgpt_without_refresh_token`
- `just test -p codex-app-server` was also run; the new auth test passed, while unrelated sandbox/PATH-sensitive tests failed in this environment.