### PR TITLE
Move Bazel Windows jobs onto codex-runners

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -141,7 +141,9 @@ jobs:
           - 2
           - 3
           - 4
-    runs-on: windows-latest
+    runs-on:
+      group: codex-runners
+      labels: codex-windows-x64
     name: Bazel test on windows-latest for x86_64-pc-windows-gnullvm shard ${{ matrix.shard }}/4
 
     steps:
@@ -246,7 +248,9 @@ jobs:
     # it a larger timeout.
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     timeout-minutes: 40
-    runs-on: windows-latest
+    runs-on:
+      group: codex-runners
+      labels: codex-windows-x64
     name: Bazel test on windows-latest for x86_64-pc-windows-gnullvm (native main)
 
     steps:
@@ -332,7 +336,10 @@ jobs:
             target: aarch64-apple-darwin
           - os: windows-latest
             target: x86_64-pc-windows-gnullvm
-    runs-on: ${{ matrix.os }}
+            runs_on:
+              group: codex-runners
+              labels: codex-windows-x64
+    runs-on: ${{ matrix.runs_on || matrix.os }}
     name: Bazel clippy on ${{ matrix.os }} for ${{ matrix.target }}
 
     steps:
@@ -422,7 +429,10 @@ jobs:
             target: aarch64-apple-darwin
           - os: windows-latest
             target: x86_64-pc-windows-gnullvm
-    runs-on: ${{ matrix.os }}
+            runs_on:
+              group: codex-runners
+              labels: codex-windows-x64
+    runs-on: ${{ matrix.runs_on || matrix.os }}
     name: Verify release build on ${{ matrix.os }} for ${{ matrix.target }}
 
     steps:


### PR DESCRIPTION
The codex-windows runner group should be much faster than the default GHA runners. Since bazel jobs on windows are frequently the long pole for PRs checks, this will hopefully get people landing a bit faster.