### PR TITLE
[codex] Remove Bedrock OSS models from catalog

### DIFF
--- a/codex-rs/model-provider/src/amazon_bedrock/catalog.rs
+++ b/codex-rs/model-provider/src/amazon_bedrock/catalog.rs
@@ -1,19 +1,9 @@
 use codex_model_provider_info::AMAZON_BEDROCK_GPT_5_4_MODEL_ID;
 use codex_model_provider_info::AMAZON_BEDROCK_GPT_5_5_MODEL_ID;
 use codex_models_manager::bundled_models_response;
-use codex_models_manager::model_info::BASE_INSTRUCTIONS;
-use codex_protocol::config_types::ReasoningSummary;
-use codex_protocol::openai_models::ConfigShellToolType;
-use codex_protocol::openai_models::InputModality;
 use codex_protocol::openai_models::ModelInfo;
-use codex_protocol::openai_models::ModelVisibility;
 use codex_protocol::openai_models::ModelsResponse;
-use codex_protocol::openai_models::ReasoningEffort;
-use codex_protocol::openai_models::ReasoningEffortPreset;
-use codex_protocol::openai_models::TruncationPolicyConfig;
-use codex_protocol::openai_models::WebSearchToolType;
 
-const GPT_OSS_CONTEXT_WINDOW: i64 = 128_000;
 const GPT_5_BEDROCK_CONTEXT_WINDOW: i64 = 272_000;
 const GPT_5_5_OPENAI_MODEL_ID: &str = "gpt-5.5";
 const GPT_5_4_OPENAI_MODEL_ID: &str = "gpt-5.4";
@@ -30,16 +20,6 @@ pub(crate) fn static_model_catalog() -> ModelsResponse {
                 GPT_5_4_OPENAI_MODEL_ID,
                 AMAZON_BEDROCK_GPT_5_4_MODEL_ID,
                 /*priority*/ 1,
-            ),
-            bedrock_oss_model(
-                "openai.gpt-oss-120b",
-                "GPT OSS 120B on Bedrock",
-                /*priority*/ 2,
-            ),
-            bedrock_oss_model(
-                "openai.gpt-oss-20b",
-                "GPT OSS 20B on Bedrock",
-                /*priority*/ 3,
             ),
         ],
     }
@@ -63,63 +43,6 @@ fn bundled_openai_model(slug: &str) -> ModelInfo {
         .unwrap_or_else(|| panic!("bundled models.json should include {slug}"))
 }
 
-fn bedrock_oss_model(slug: &str, display_name: &str, priority: i32) -> ModelInfo {
-    ModelInfo {
-        slug: slug.to_string(),
-        display_name: display_name.to_string(),
-        description: Some(display_name.to_string()),
-        default_reasoning_level: Some(ReasoningEffort::Medium),
-        supported_reasoning_levels: vec![
-            reasoning_effort_preset(ReasoningEffort::Low),
-            reasoning_effort_preset(ReasoningEffort::Medium),
-            reasoning_effort_preset(ReasoningEffort::High),
-        ],
-        shell_type: ConfigShellToolType::ShellCommand,
-        visibility: ModelVisibility::List,
-        supported_in_api: true,
-        priority,
-        additional_speed_tiers: Vec::new(),
-        service_tiers: Vec::new(),
-        default_service_tier: None,
-        availability_nux: None,
-        upgrade: None,
-        base_instructions: BASE_INSTRUCTIONS.to_string(),
-        model_messages: None,
-        supports_reasoning_summaries: true,
-        default_reasoning_summary: ReasoningSummary::None,
-        support_verbosity: false,
-        default_verbosity: None,
-        apply_patch_tool_type: None,
-        web_search_tool_type: WebSearchToolType::Text,
-        truncation_policy: TruncationPolicyConfig::tokens(/*limit*/ 10_000),
-        supports_parallel_tool_calls: true,
-        supports_image_detail_original: false,
-        context_window: Some(GPT_OSS_CONTEXT_WINDOW),
-        max_context_window: Some(GPT_OSS_CONTEXT_WINDOW),
-        auto_compact_token_limit: None,
-        effective_context_window_percent: 95,
-        experimental_supported_tools: Vec::new(),
-        input_modalities: vec![InputModality::Text],
-        used_fallback_model_metadata: false,
-        supports_search_tool: false,
-    }
-}
-
-fn reasoning_effort_preset(effort: ReasoningEffort) -> ReasoningEffortPreset {
-    ReasoningEffortPreset {
-        effort,
-        description: match effort {
-            ReasoningEffort::None => "No reasoning",
-            ReasoningEffort::Minimal => "Minimal reasoning",
-            ReasoningEffort::Low => "Fast responses with lighter reasoning",
-            ReasoningEffort::Medium => "Balances speed and reasoning depth for everyday tasks",
-            ReasoningEffort::High => "Greater reasoning depth for complex problems",
-            ReasoningEffort::XHigh => "Extra high reasoning depth for complex problems",
-        }
-        .to_string(),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use pretty_assertions::assert_eq;
@@ -130,11 +53,9 @@ mod tests {
     fn catalog_uses_mantle_model_ids_as_slugs() {
         let catalog = static_model_catalog();
 
-        assert_eq!(catalog.models.len(), 4);
+        assert_eq!(catalog.models.len(), 2);
         assert_eq!(catalog.models[0].slug, AMAZON_BEDROCK_GPT_5_5_MODEL_ID);
         assert_eq!(catalog.models[1].slug, AMAZON_BEDROCK_GPT_5_4_MODEL_ID);
-        assert_eq!(catalog.models[2].slug, "openai.gpt-oss-120b");
-        assert_eq!(catalog.models[3].slug, "openai.gpt-oss-20b");
     }
 
     #[test]

--- a/codex-rs/model-provider/src/provider.rs
+++ b/codex-rs/model-provider/src/provider.rs
@@ -507,15 +507,7 @@ mod tests {
             .map(|model| model.slug.as_str())
             .collect::<Vec<_>>();
 
-        assert_eq!(
-            model_ids,
-            vec![
-                "openai.gpt-5.5",
-                "openai.gpt-5.4",
-                "openai.gpt-oss-120b",
-                "openai.gpt-oss-20b"
-            ]
-        );
+        assert_eq!(model_ids, vec!["openai.gpt-5.5", "openai.gpt-5.4"]);
 
         let default_model = manager
             .list_models(RefreshStrategy::Online)


### PR DESCRIPTION
Remove the GPT OSS 120B and 20B entries from the Amazon Bedrock static model catalog, as they are no longer supported.