### PR TITLE
windows-sandbox: fix capture cancellation test roots

### DIFF
--- a/codex-rs/windows-sandbox-rs/src/unified_exec/tests.rs
+++ b/codex-rs/windows-sandbox-rs/src/unified_exec/tests.rs
@@ -477,7 +477,7 @@ fn legacy_capture_cancellation_is_not_reported_as_timeout() {
     let started_at = Instant::now();
     let result = run_windows_sandbox_capture(
         &permission_profile,
-        cwd.as_path(),
+        workspace_roots_for(cwd.as_path()).as_slice(),
         codex_home.path(),
         vec![
             pwsh.display().to_string(),


### PR DESCRIPTION
## Why

The Windows Bazel job on `main` started failing after #24108 because one Windows-only capture test still passed `cwd.as_path()` to `run_windows_sandbox_capture`. That helper now expects the explicit `workspace_roots` slice introduced by #24108, so the Windows test target no longer compiled.

## What Changed

- Updates `legacy_capture_cancellation_is_not_reported_as_timeout` to pass `workspace_roots_for(cwd.as_path()).as_slice()`, matching the adjacent capture test and the new runner signature.

## Verification

- GitHub Actions CI is the important validation for this Windows-only compile path.
- Created quickly to get Windows CI running while the separate Ubuntu `compact_resume_fork` timeout is still under investigation.
