### PR TITLE
[codex] Track used Codex app connectors

### DIFF
--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -79,6 +79,7 @@ pub(crate) mod mentions {
 }
 mod sandbox_tags;
 pub mod sandboxing;
+mod sensitive_connector_policy;
 mod session_prefix;
 mod session_startup_prewarm;
 mod shell_detect;

--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -18,6 +18,7 @@ use crate::hook_runtime::run_permission_request_hooks;
 use crate::mcp_openai_file::rewrite_mcp_tool_arguments_for_openai_files;
 use crate::mcp_tool_approval_templates::RenderedMcpToolApprovalParam;
 use crate::mcp_tool_approval_templates::render_mcp_tool_approval_template;
+use crate::sensitive_connector_policy;
 use crate::session::session::Session;
 use crate::session::turn_context::TurnContext;
 use crate::tools::hook_names::HookToolName;
@@ -200,6 +201,41 @@ pub(crate) async fn handle_mcp_tool_call(
         .as_ref()
         .and_then(|metadata| metadata.connector_name.clone());
 
+    if server == CODEX_APPS_MCP_SERVER_NAME
+        && let Some(connector_id) = connector_id.as_deref()
+    {
+        let used_connector_ids = sess.get_used_connector_ids().await;
+        if !sensitive_connector_policy::connector_allowed_after_sensitive_usage(
+            &used_connector_ids,
+            connector_id,
+        ) {
+            let result = notify_mcp_tool_call_skip(
+                sess.as_ref(),
+                turn_context.as_ref(),
+                &call_id,
+                invocation,
+                item_metadata.clone(),
+                "This conversation has used Finances. For security, other connectors are disabled for this thread.".to_string(),
+                /*already_started*/ false,
+            )
+            .await;
+            let status = if result.is_ok() { "ok" } else { "error" };
+            emit_mcp_call_metrics(
+                turn_context.as_ref(),
+                status,
+                &tool_name,
+                Some(connector_id),
+                connector_name.as_deref(),
+                /*duration*/ None,
+            );
+            return HandledMcpToolCall {
+                result: CallToolResult::from_result(result),
+                tool_input: arguments_value
+                    .unwrap_or_else(|| JsonValue::Object(serde_json::Map::new())),
+            };
+        }
+    }
+
     notify_mcp_tool_call_started(
         sess.as_ref(),
         turn_context.as_ref(),
@@ -339,8 +375,14 @@ async fn handle_approved_mcp_tool_call(
     };
     let result = async {
         let rewritten_arguments = rewrite?;
-        let request_meta =
-            build_mcp_tool_call_request_meta(turn_context, &server, call_id, metadata);
+        let used_connector_ids = sess.get_used_connector_ids().await;
+        let request_meta = build_mcp_tool_call_request_meta(
+            turn_context,
+            &server,
+            call_id,
+            metadata,
+            &used_connector_ids,
+        );
         let result = execute_mcp_tool_call(
             sess,
             turn_context,
@@ -381,6 +423,11 @@ async fn handle_approved_mcp_tool_call(
         truncate_mcp_tool_result_for_event(&result),
     )
     .await;
+    if server == CODEX_APPS_MCP_SERVER_NAME
+        && let Some(connector_id) = connector_id
+    {
+        sess.record_used_connector_id(connector_id).await;
+    }
     maybe_track_codex_app_used(sess, turn_context, &server, &tool_name).await;
 
     let status = if result.is_ok() { "ok" } else { "error" };
@@ -931,6 +978,9 @@ async fn maybe_track_codex_app_used(
     let (connector_id, app_name) = metadata
         .map(|metadata| (metadata.connector_id, metadata.app_name))
         .unwrap_or((None, None));
+    if let Some(connector_id) = connector_id.as_deref() {
+        sess.record_used_connector_id(connector_id).await;
+    }
     let invocation_type = if let Some(connector_id) = connector_id.as_deref() {
         let mentioned_connector_ids = sess.get_connector_selection().await;
         if mentioned_connector_ids.contains(connector_id) {
@@ -1038,6 +1088,7 @@ fn build_mcp_tool_call_request_meta(
     server: &str,
     call_id: &str,
     metadata: Option<&McpToolApprovalMetadata>,
+    used_connector_ids: &[String],
 ) -> Option<serde_json::Value> {
     let mut request_meta = serde_json::Map::new();
 
@@ -1061,6 +1112,16 @@ fn build_mcp_tool_call_request_meta(
         codex_apps_meta.insert(
             "call_id".to_string(),
             serde_json::Value::String(call_id.to_string()),
+        );
+        codex_apps_meta.insert(
+            sensitive_connector_policy::USED_CONNECTOR_IDS_META_KEY.to_string(),
+            serde_json::Value::Array(
+                used_connector_ids
+                    .iter()
+                    .cloned()
+                    .map(serde_json::Value::String)
+                    .collect(),
+            ),
         );
         request_meta.insert(
             MCP_TOOL_CODEX_APPS_META_KEY.to_string(),

--- a/codex-rs/core/src/mcp_tool_call_tests.rs
+++ b/codex-rs/core/src/mcp_tool_call_tests.rs
@@ -1034,6 +1034,7 @@ async fn mcp_tool_call_request_meta_includes_turn_metadata_for_custom_server() {
         "custom_server",
         "call-custom",
         /*metadata*/ None,
+        &[],
     )
     .expect("custom servers should receive turn metadata");
     let turn_metadata = meta
@@ -1076,6 +1077,7 @@ async fn mcp_tool_call_request_meta_includes_turn_started_at_unix_ms() {
         "custom_server",
         "call-custom",
         /*metadata*/ None,
+        &[],
     )
     .expect("custom servers should receive turn metadata");
     let turn_metadata = meta
@@ -1105,7 +1107,13 @@ async fn plugin_mcp_tool_call_request_meta_includes_plugin_id() {
     metadata.plugin_id = Some("sample@test".to_string());
 
     assert_eq!(
-        build_mcp_tool_call_request_meta(&turn_context, "sample", "call-plugin", Some(&metadata),),
+        build_mcp_tool_call_request_meta(
+            &turn_context,
+            "sample",
+            "call-plugin",
+            Some(&metadata),
+            &[],
+        ),
         Some(serde_json::json!({
             crate::X_CODEX_TURN_METADATA_HEADER: expected_turn_metadata,
             MCP_TOOL_PLUGIN_ID_META_KEY: "sample@test",
@@ -1182,6 +1190,7 @@ async fn codex_apps_tool_call_request_meta_includes_turn_metadata_and_codex_apps
             CODEX_APPS_MCP_SERVER_NAME,
             "call_abc123xyz789",
             Some(&metadata),
+            &[],
         ),
         Some(serde_json::json!({
             crate::X_CODEX_TURN_METADATA_HEADER: expected_turn_metadata,
@@ -1190,6 +1199,7 @@ async fn codex_apps_tool_call_request_meta_includes_turn_metadata_and_codex_apps
                 "resource_uri": "connector://calendar/tools/calendar_create_event",
                 "contains_mcp_source": true,
                 "connector_id": "calendar",
+                "used_connector_ids": [],
             },
         }))
     );
@@ -1209,13 +1219,43 @@ async fn codex_apps_tool_call_request_meta_includes_call_id_without_existing_cod
             CODEX_APPS_MCP_SERVER_NAME,
             "call_abc123xyz789",
             /*metadata*/ None,
+            &[],
         ),
         Some(serde_json::json!({
             crate::X_CODEX_TURN_METADATA_HEADER: expected_turn_metadata,
             MCP_TOOL_CODEX_APPS_META_KEY: {
                 "call_id": "call_abc123xyz789",
+                "used_connector_ids": [],
             },
         }))
+    );
+}
+
+#[tokio::test]
+async fn codex_apps_tool_call_request_meta_includes_used_connector_ids() {
+    let (_, turn_context) = make_session_and_context().await;
+    let used_connector_ids = vec![
+        "connector_calendar".to_string(),
+        "connector_drive".to_string(),
+    ];
+
+    let meta = build_mcp_tool_call_request_meta(
+        &turn_context,
+        CODEX_APPS_MCP_SERVER_NAME,
+        "call_abc123xyz789",
+        /*metadata*/ None,
+        &used_connector_ids,
+    )
+    .expect("codex apps tool call metadata");
+
+    assert_eq!(
+        meta.get(MCP_TOOL_CODEX_APPS_META_KEY)
+            .and_then(serde_json::Value::as_object)
+            .and_then(|meta| meta.get(sensitive_connector_policy::USED_CONNECTOR_IDS_META_KEY)),
+        Some(&serde_json::json!([
+            "connector_calendar",
+            "connector_drive"
+        ]))
     );
 }
 

--- a/codex-rs/core/src/mcp_tool_exposure.rs
+++ b/codex-rs/core/src/mcp_tool_exposure.rs
@@ -7,6 +7,7 @@ use codex_mcp::tool_is_model_visible;
 
 use crate::config::Config;
 use crate::connectors;
+use crate::sensitive_connector_policy;
 
 pub(crate) const DIRECT_MCP_TOOL_EXPOSURE_THRESHOLD: usize = 100;
 
@@ -20,6 +21,7 @@ pub(crate) fn build_mcp_tool_exposure(
     connectors: Option<&[connectors::AppInfo]>,
     config: &Config,
     search_tool_enabled: bool,
+    used_connector_ids: &[String],
 ) -> McpToolExposure {
     let mut deferred_tools = filter_non_codex_apps_mcp_tools_only(all_mcp_tools);
     if let Some(connectors) = connectors {
@@ -27,6 +29,7 @@ pub(crate) fn build_mcp_tool_exposure(
             all_mcp_tools,
             connectors,
             config,
+            used_connector_ids,
         ));
     }
 
@@ -63,6 +66,7 @@ fn filter_codex_apps_mcp_tools(
     mcp_tools: &[McpToolInfo],
     connectors: &[connectors::AppInfo],
     config: &Config,
+    used_connector_ids: &[String],
 ) -> Vec<McpToolInfo> {
     let allowed: HashSet<&str> = connectors
         .iter()
@@ -81,7 +85,12 @@ fn filter_codex_apps_mcp_tools(
             let Some(connector_id) = tool.connector_id.as_deref() else {
                 return false;
             };
-            allowed.contains(connector_id) && connectors::codex_app_tool_is_enabled(config, tool)
+            allowed.contains(connector_id)
+                && sensitive_connector_policy::connector_allowed_after_sensitive_usage(
+                    used_connector_ids,
+                    connector_id,
+                )
+                && connectors::codex_app_tool_is_enabled(config, tool)
         })
         .cloned()
         .collect()

--- a/codex-rs/core/src/mcp_tool_exposure_test.rs
+++ b/codex-rs/core/src/mcp_tool_exposure_test.rs
@@ -13,6 +13,7 @@ use rmcp::model::Tool;
 use super::*;
 use crate::config::test_config;
 use crate::connectors::AppInfo;
+use crate::sensitive_connector_policy;
 
 fn make_connector(id: &str, name: &str) -> AppInfo {
     AppInfo {
@@ -97,7 +98,11 @@ async fn directly_exposes_small_effective_tool_sets() {
     let mcp_tools = numbered_mcp_tools(DIRECT_MCP_TOOL_EXPOSURE_THRESHOLD - 1);
 
     let exposure = build_mcp_tool_exposure(
-        &mcp_tools, /*connectors*/ None, &config, /*search_tool_enabled*/ true,
+        &mcp_tools,
+        /*connectors*/ None,
+        &config,
+        /*search_tool_enabled*/ true,
+        &[],
     );
 
     assert_eq!(tool_names(&exposure.direct_tools), tool_names(&mcp_tools));
@@ -173,6 +178,7 @@ async fn excludes_tools_hidden_from_model_exposure() {
         Some(connectors.as_slice()),
         &config,
         /*search_tool_enabled*/ false,
+        &[],
     );
 
     assert_eq!(
@@ -188,7 +194,11 @@ async fn searches_large_effective_tool_sets() {
     let mcp_tools = numbered_mcp_tools(DIRECT_MCP_TOOL_EXPOSURE_THRESHOLD);
 
     let exposure = build_mcp_tool_exposure(
-        &mcp_tools, /*connectors*/ None, &config, /*search_tool_enabled*/ true,
+        &mcp_tools,
+        /*connectors*/ None,
+        &config,
+        /*search_tool_enabled*/ true,
+        &[],
     );
 
     assert!(exposure.direct_tools.is_empty());
@@ -231,6 +241,7 @@ async fn always_defer_feature_defers_apps_too() {
         Some(connectors.as_slice()),
         &config,
         /*search_tool_enabled*/ true,
+        &[],
     );
 
     assert!(exposure.direct_tools.is_empty());
@@ -244,4 +255,48 @@ async fn always_defer_feature_defers_apps_too() {
         "mcp__codex_apps__calendar",
         "_create_event"
     )));
+}
+
+#[tokio::test]
+async fn excludes_other_connector_tools_after_finances_was_used() {
+    let config = test_config().await;
+    let mcp_tools = vec![
+        make_mcp_tool(
+            CODEX_APPS_MCP_SERVER_NAME,
+            "finances_search",
+            "mcp__codex_apps__finances",
+            "search",
+            Some(sensitive_connector_policy::FINANCES_CONNECTOR_ID),
+            Some("Finances"),
+        ),
+        make_mcp_tool(
+            CODEX_APPS_MCP_SERVER_NAME,
+            "calendar_read",
+            "mcp__codex_apps__calendar",
+            "read",
+            Some("connector_calendar"),
+            Some("Calendar"),
+        ),
+    ];
+    let connectors = vec![
+        make_connector(
+            sensitive_connector_policy::FINANCES_CONNECTOR_ID,
+            "Finances",
+        ),
+        make_connector("connector_calendar", "Calendar"),
+    ];
+    let used_connector_ids = vec![sensitive_connector_policy::FINANCES_CONNECTOR_ID.to_string()];
+
+    let exposure = build_mcp_tool_exposure(
+        &mcp_tools,
+        Some(connectors.as_slice()),
+        &config,
+        /*search_tool_enabled*/ false,
+        &used_connector_ids,
+    );
+
+    assert_eq!(
+        tool_names(&exposure.direct_tools),
+        HashSet::from([ToolName::namespaced("mcp__codex_apps__finances", "search")])
+    );
 }

--- a/codex-rs/core/src/sensitive_connector_policy.rs
+++ b/codex-rs/core/src/sensitive_connector_policy.rs
@@ -1,0 +1,69 @@
+use crate::connectors::AppInfo;
+
+pub(crate) const FINANCES_CONNECTOR_ID: &str = "connector_693864f100e4819093e6ed9b651239f1";
+pub(crate) const USED_CONNECTOR_IDS_META_KEY: &str = "used_connector_ids";
+
+pub(crate) fn used_finances_connector(used_connector_ids: &[String]) -> bool {
+    used_connector_ids
+        .iter()
+        .any(|connector_id| connector_id == FINANCES_CONNECTOR_ID)
+}
+
+pub(crate) fn connector_allowed_after_sensitive_usage(
+    used_connector_ids: &[String],
+    connector_id: &str,
+) -> bool {
+    !used_finances_connector(used_connector_ids) || connector_id == FINANCES_CONNECTOR_ID
+}
+
+pub(crate) fn filter_connectors_after_sensitive_usage(
+    connectors: Vec<AppInfo>,
+    used_connector_ids: &[String],
+) -> Vec<AppInfo> {
+    if !used_finances_connector(used_connector_ids) {
+        return connectors;
+    }
+
+    connectors
+        .into_iter()
+        .filter(|connector| connector.id == FINANCES_CONNECTOR_ID)
+        .collect()
+}
+
+pub(crate) fn append_used_connector_id(used_connector_ids: &mut Vec<String>, connector_id: &str) {
+    if !used_connector_ids
+        .iter()
+        .any(|used_connector_id| used_connector_id == connector_id)
+    {
+        used_connector_ids.push(connector_id.to_string());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finances_usage_limits_future_connector_ids_to_finances() {
+        let used_connector_ids = vec![FINANCES_CONNECTOR_ID.to_string()];
+
+        assert!(connector_allowed_after_sensitive_usage(
+            &used_connector_ids,
+            FINANCES_CONNECTOR_ID
+        ));
+        assert!(!connector_allowed_after_sensitive_usage(
+            &used_connector_ids,
+            "connector_calendar"
+        ));
+    }
+
+    #[test]
+    fn non_finances_usage_does_not_limit_future_connector_ids() {
+        let used_connector_ids = vec!["connector_calendar".to_string()];
+
+        assert!(connector_allowed_after_sensitive_usage(
+            &used_connector_ids,
+            "connector_drive"
+        ));
+    }
+}

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -138,6 +138,7 @@ use codex_thread_store::LocalThreadStore;
 use codex_thread_store::ReadThreadParams;
 use codex_thread_store::ResumeThreadParams;
 use codex_thread_store::ThreadEventPersistenceMode;
+use codex_thread_store::ThreadMetadataPatch;
 use codex_thread_store::ThreadPersistenceMetadata;
 use codex_thread_store::ThreadStore;
 use codex_utils_output_truncation::TruncationPolicy;
@@ -1165,6 +1166,37 @@ impl Session {
     pub(crate) async fn clear_connector_selection(&self) {
         let mut state = self.state.lock().await;
         state.clear_connector_selection();
+    }
+
+    pub(crate) async fn record_used_connector_id(&self, connector_id: &str) {
+        let used_connector_ids = {
+            let mut state = self.state.lock().await;
+            state.record_used_connector_id(connector_id)
+        };
+        let Some(used_connector_ids) = used_connector_ids else {
+            return;
+        };
+
+        let Some(live_thread) = self.live_thread() else {
+            return;
+        };
+        if let Err(err) = live_thread
+            .update_metadata(
+                ThreadMetadataPatch {
+                    used_connector_ids: Some(used_connector_ids),
+                    ..Default::default()
+                },
+                /*include_archived*/ true,
+            )
+            .await
+        {
+            warn!("failed to persist used connector metadata: {err}");
+        }
+    }
+
+    pub(crate) async fn get_used_connector_ids(&self) -> Vec<String> {
+        let state = self.state.lock().await;
+        state.get_used_connector_ids()
     }
 
     async fn record_initial_history(&self, conversation_history: InitialHistory) {

--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -875,7 +875,20 @@ impl Session {
             session_configuration.thread_name = thread_name.clone();
             validate_config_lock_if_configured(&session_configuration).await?;
             export_config_lock_if_configured(&session_configuration, thread_id).await?;
-            let state = SessionState::new(session_configuration.clone());
+            let initial_used_connector_ids = if let Some(state_db) = state_db_ctx.as_ref() {
+                match state_db.get_thread(thread_id).await {
+                    Ok(Some(metadata)) => metadata.used_connector_ids,
+                    Ok(None) => Vec::new(),
+                    Err(err) => {
+                        warn!("failed to load used connector metadata for {thread_id}: {err}");
+                        Vec::new()
+                    }
+                }
+            } else {
+                Vec::new()
+            };
+            let mut state = SessionState::new(session_configuration.clone());
+            state.set_used_connector_ids(initial_used_connector_ids);
             let managed_network_requirements_configured = config
                 .config_layer_stack
                 .requirements_toml()

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -37,6 +37,7 @@ use crate::mentions::collect_tool_mentions_from_messages;
 use crate::plugins::build_plugin_injections;
 use crate::responses_retry::ResponsesStreamRequest;
 use crate::responses_retry::handle_retryable_response_stream_error;
+use crate::sensitive_connector_policy;
 use crate::session::PreviousTurnSettings;
 use crate::session::TurnInput;
 use crate::session::session::Session;
@@ -497,6 +498,7 @@ async fn build_skills_and_plugins(
     } else {
         Vec::new()
     };
+    let used_connector_ids = sess.get_used_connector_ids().await;
     let available_connectors = if turn_context.apps_enabled() {
         let connectors = codex_connectors::merge::merge_plugin_connectors_with_accessible(
             loaded_plugins
@@ -505,7 +507,10 @@ async fn build_skills_and_plugins(
                 .map(|connector_id| connector_id.0),
             connectors::accessible_connectors_from_mcp_tools(&mcp_tools),
         );
-        connectors::with_app_enabled_state(connectors, &turn_context.config)
+        sensitive_connector_policy::filter_connectors_after_sensitive_usage(
+            connectors::with_app_enabled_state(connectors, &turn_context.config),
+            &used_connector_ids,
+        )
     } else {
         Vec::new()
     };
@@ -558,6 +563,12 @@ async fn build_skills_and_plugins(
         build_plugin_injections(&mentioned_plugins, &mcp_tools, &available_connectors);
     let mut explicitly_enabled_connectors = collect_explicit_app_ids(&user_input);
     explicitly_enabled_connectors.extend(skill_connector_ids);
+    explicitly_enabled_connectors.retain(|connector_id| {
+        sensitive_connector_policy::connector_allowed_after_sensitive_usage(
+            &used_connector_ids,
+            connector_id,
+        )
+    });
     let connector_names_by_id = available_connectors
         .iter()
         .map(|connector| (connector.id.as_str(), connector.name.as_str()))
@@ -1055,9 +1066,13 @@ pub(crate) async fn built_tools(
     let apps_enabled = turn_context.apps_enabled();
     let accessible_connectors =
         apps_enabled.then(|| connectors::accessible_connectors_from_mcp_tools(&all_mcp_tools));
+    let used_connector_ids = sess.get_used_connector_ids().await;
     let accessible_connectors_with_enabled_state =
         accessible_connectors.as_ref().map(|connectors| {
-            connectors::with_app_enabled_state(connectors.clone(), &turn_context.config)
+            sensitive_connector_policy::filter_connectors_after_sensitive_usage(
+                connectors::with_app_enabled_state(connectors.clone(), &turn_context.config),
+                &used_connector_ids,
+            )
         });
     let connectors = if apps_enabled {
         let connectors = codex_connectors::merge::merge_plugin_connectors_with_accessible(
@@ -1067,10 +1082,12 @@ pub(crate) async fn built_tools(
                 .map(|connector_id| connector_id.0),
             accessible_connectors.clone().unwrap_or_default(),
         );
-        Some(connectors::with_app_enabled_state(
-            connectors,
-            &turn_context.config,
-        ))
+        Some(
+            sensitive_connector_policy::filter_connectors_after_sensitive_usage(
+                connectors::with_app_enabled_state(connectors, &turn_context.config),
+                &used_connector_ids,
+            ),
+        )
     } else {
         None
     };
@@ -1108,6 +1125,7 @@ pub(crate) async fn built_tools(
         connectors.as_deref(),
         &turn_context.config,
         search_tool_enabled(turn_context),
+        &used_connector_ids,
     );
     let mcp_tools = has_mcp_servers.then_some(mcp_tool_exposure.direct_tools);
     let deferred_mcp_tools = mcp_tool_exposure.deferred_tools;

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -10,6 +10,7 @@ use super::AdditionalContextStore;
 use super::auto_compact_window::AutoCompactWindow;
 use super::auto_compact_window::AutoCompactWindowSnapshot;
 use crate::context_manager::ContextManager;
+use crate::sensitive_connector_policy;
 use crate::session::PreviousTurnSettings;
 use crate::session::session::SessionConfiguration;
 use crate::session_startup_prewarm::SessionStartupPrewarmHandle;
@@ -36,6 +37,7 @@ pub(crate) struct SessionState {
     /// Startup prewarmed session prepared during session initialization.
     pub(crate) startup_prewarm: Option<SessionStartupPrewarmHandle>,
     pub(crate) active_connector_selection: HashSet<String>,
+    used_connector_ids: Vec<String>,
     pub(crate) pending_session_start_sources: VecDeque<codex_hooks::SessionStartSource>,
     granted_permissions: Option<AdditionalPermissionProfile>,
     next_turn_is_first: bool,
@@ -56,6 +58,7 @@ impl SessionState {
             auto_compact_window: AutoCompactWindow::new(),
             startup_prewarm: None,
             active_connector_selection: HashSet::new(),
+            used_connector_ids: Vec::new(),
             pending_session_start_sources: VecDeque::new(),
             granted_permissions: None,
             next_turn_is_first: true,
@@ -220,6 +223,33 @@ impl SessionState {
     // Removes all currently tracked connector selections.
     pub(crate) fn clear_connector_selection(&mut self) {
         self.active_connector_selection.clear();
+    }
+
+    pub(crate) fn set_used_connector_ids(&mut self, used_connector_ids: Vec<String>) {
+        self.used_connector_ids = Vec::new();
+        for connector_id in used_connector_ids {
+            sensitive_connector_policy::append_used_connector_id(
+                &mut self.used_connector_ids,
+                &connector_id,
+            );
+        }
+    }
+
+    pub(crate) fn record_used_connector_id(&mut self, connector_id: &str) -> Option<Vec<String>> {
+        if self
+            .used_connector_ids
+            .iter()
+            .any(|used_connector_id| used_connector_id == connector_id)
+        {
+            return None;
+        }
+
+        self.used_connector_ids.push(connector_id.to_string());
+        Some(self.used_connector_ids.clone())
+    }
+
+    pub(crate) fn get_used_connector_ids(&self) -> Vec<String> {
+        self.used_connector_ids.clone()
     }
 
     pub(crate) fn queue_pending_session_start_source(

--- a/codex-rs/core/src/state/session_tests.rs
+++ b/codex-rs/core/src/state/session_tests.rs
@@ -35,6 +35,26 @@ async fn clear_connector_selection_removes_entries() {
 }
 
 #[tokio::test]
+async fn record_used_connector_id_preserves_first_use_order() {
+    let session_configuration = make_session_configuration_for_tests().await;
+    let mut state = SessionState::new(session_configuration);
+
+    assert_eq!(
+        state.record_used_connector_id("calendar"),
+        Some(vec!["calendar".to_string()])
+    );
+    assert_eq!(state.record_used_connector_id("calendar"), None);
+    assert_eq!(
+        state.record_used_connector_id("drive"),
+        Some(vec!["calendar".to_string(), "drive".to_string()])
+    );
+    assert_eq!(
+        state.get_used_connector_ids(),
+        vec!["calendar".to_string(), "drive".to_string()]
+    );
+}
+
+#[tokio::test]
 async fn set_rate_limits_defaults_limit_id_to_codex_when_missing() {
     let session_configuration = make_session_configuration_for_tests().await;
     let mut state = SessionState::new(session_configuration);

--- a/codex-rs/state/migrations/0036_threads_used_connector_ids.sql
+++ b/codex-rs/state/migrations/0036_threads_used_connector_ids.sql
@@ -1,0 +1,1 @@
+ALTER TABLE threads ADD COLUMN used_connector_ids TEXT NOT NULL DEFAULT '[]';

--- a/codex-rs/state/src/extract.rs
+++ b/codex-rs/state/src/extract.rs
@@ -493,6 +493,7 @@ mod tests {
             git_sha: None,
             git_branch: None,
             git_origin_url: None,
+            used_connector_ids: Vec::new(),
         }
     }
 

--- a/codex-rs/state/src/model/thread_metadata.rs
+++ b/codex-rs/state/src/model/thread_metadata.rs
@@ -107,6 +107,8 @@ pub struct ThreadMetadata {
     pub git_branch: Option<String>,
     /// The git origin URL, if known.
     pub git_origin_url: Option<String>,
+    /// Connector IDs used by this thread, in first-use order.
+    pub used_connector_ids: Vec<String>,
 }
 
 /// Builder data required to construct [`ThreadMetadata`] without parsing filenames.
@@ -221,6 +223,7 @@ impl ThreadMetadataBuilder {
             git_sha: self.git_sha.clone(),
             git_branch: self.git_branch.clone(),
             git_origin_url: self.git_origin_url.clone(),
+            used_connector_ids: Vec::new(),
         }
     }
 }
@@ -311,6 +314,9 @@ impl ThreadMetadata {
         if self.git_origin_url != other.git_origin_url {
             diffs.push("git_origin_url");
         }
+        if self.used_connector_ids != other.used_connector_ids {
+            diffs.push("used_connector_ids");
+        }
         diffs
     }
 }
@@ -345,6 +351,7 @@ pub(crate) struct ThreadRow {
     git_sha: Option<String>,
     git_branch: Option<String>,
     git_origin_url: Option<String>,
+    used_connector_ids: String,
 }
 
 impl ThreadRow {
@@ -374,6 +381,7 @@ impl ThreadRow {
             git_sha: row.try_get("git_sha")?,
             git_branch: row.try_get("git_branch")?,
             git_origin_url: row.try_get("git_origin_url")?,
+            used_connector_ids: row.try_get("used_connector_ids")?,
         })
     }
 }
@@ -407,11 +415,14 @@ impl TryFrom<ThreadRow> for ThreadMetadata {
             git_sha,
             git_branch,
             git_origin_url,
+            used_connector_ids,
         } = row;
         let thread_source = thread_source
             .map(|thread_source| thread_source.parse())
             .transpose()
             .map_err(anyhow::Error::msg)?;
+        let used_connector_ids = serde_json::from_str::<Vec<String>>(&used_connector_ids)
+            .map_err(|err| anyhow::anyhow!("invalid used_connector_ids JSON: {err}"))?;
         Ok(Self {
             id: ThreadId::try_from(id)?,
             rollout_path: PathBuf::from(rollout_path),
@@ -438,6 +449,7 @@ impl TryFrom<ThreadRow> for ThreadMetadata {
             git_sha,
             git_branch,
             git_origin_url,
+            used_connector_ids,
         })
     }
 }
@@ -524,6 +536,7 @@ mod tests {
             git_sha: None,
             git_branch: None,
             git_origin_url: None,
+            used_connector_ids: "[]".to_string(),
         }
     }
 
@@ -554,6 +567,7 @@ mod tests {
             git_sha: None,
             git_branch: None,
             git_origin_url: None,
+            used_connector_ids: Vec::new(),
         }
     }
 

--- a/codex-rs/state/src/runtime/memories.rs
+++ b/codex-rs/state/src/runtime/memories.rs
@@ -190,7 +190,8 @@ SELECT
     threads.archived_at,
     threads.git_sha,
     threads.git_branch,
-    threads.git_origin_url
+    threads.git_origin_url,
+    threads.used_connector_ids
 FROM threads
             "#,
         );
@@ -560,7 +561,8 @@ SELECT
     threads.archived_at,
     threads.git_sha,
     threads.git_branch,
-    threads.git_origin_url
+    threads.git_origin_url,
+    threads.used_connector_ids
 FROM threads
 WHERE threads.id = ? AND threads.memory_mode = 'enabled'
             "#,

--- a/codex-rs/state/src/runtime/test_support.rs
+++ b/codex-rs/state/src/runtime/test_support.rs
@@ -67,5 +67,6 @@ pub(super) fn test_thread_metadata(
         git_sha: None,
         git_branch: None,
         git_origin_url: None,
+        used_connector_ids: Vec::new(),
     }
 }

--- a/codex-rs/state/src/runtime/threads.rs
+++ b/codex-rs/state/src/runtime/threads.rs
@@ -31,7 +31,8 @@ SELECT
     threads.archived_at,
     threads.git_sha,
     threads.git_branch,
-    threads.git_origin_url
+    threads.git_origin_url,
+    threads.used_connector_ids
 FROM threads
 WHERE threads.id = ?
             "#,
@@ -506,8 +507,9 @@ INSERT INTO threads (
     git_sha,
     git_branch,
     git_origin_url,
+    used_connector_ids,
     memory_mode
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(id) DO NOTHING
             "#,
         )
@@ -547,6 +549,7 @@ ON CONFLICT(id) DO NOTHING
         .bind(metadata.git_sha.as_deref())
         .bind(metadata.git_branch.as_deref())
         .bind(metadata.git_origin_url.as_deref())
+        .bind(used_connector_ids_json(&metadata.used_connector_ids)?)
         .bind("enabled")
         .execute(self.pool.as_ref())
         .await?;
@@ -562,6 +565,19 @@ ON CONFLICT(id) DO NOTHING
     ) -> anyhow::Result<bool> {
         let result = sqlx::query("UPDATE threads SET memory_mode = ? WHERE id = ?")
             .bind(memory_mode)
+            .bind(thread_id.to_string())
+            .execute(self.pool.as_ref())
+            .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    pub async fn set_thread_used_connector_ids(
+        &self,
+        thread_id: ThreadId,
+        used_connector_ids: &[String],
+    ) -> anyhow::Result<bool> {
+        let result = sqlx::query("UPDATE threads SET used_connector_ids = ? WHERE id = ?")
+            .bind(used_connector_ids_json(used_connector_ids)?)
             .bind(thread_id.to_string())
             .execute(self.pool.as_ref())
             .await?;
@@ -712,8 +728,9 @@ INSERT INTO threads (
     git_sha,
     git_branch,
     git_origin_url,
+    used_connector_ids,
     memory_mode
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(id) DO UPDATE SET
     rollout_path = excluded.rollout_path,
     created_at = excluded.created_at,
@@ -740,7 +757,8 @@ ON CONFLICT(id) DO UPDATE SET
     archived_at = excluded.archived_at,
     git_sha = COALESCE(threads.git_sha, excluded.git_sha),
     git_branch = COALESCE(threads.git_branch, excluded.git_branch),
-    git_origin_url = COALESCE(threads.git_origin_url, excluded.git_origin_url)
+    git_origin_url = COALESCE(threads.git_origin_url, excluded.git_origin_url),
+    used_connector_ids = threads.used_connector_ids
             "#,
         )
         .bind(metadata.id.to_string())
@@ -779,6 +797,7 @@ ON CONFLICT(id) DO UPDATE SET
         .bind(metadata.git_sha.as_deref())
         .bind(metadata.git_branch.as_deref())
         .bind(metadata.git_origin_url.as_deref())
+        .bind(used_connector_ids_json(&metadata.used_connector_ids)?)
         .bind(creation_memory_mode.unwrap_or("enabled"))
         .execute(self.pool.as_ref())
         .await?;
@@ -942,9 +961,15 @@ SELECT
     threads.archived_at,
     threads.git_sha,
     threads.git_branch,
-    threads.git_origin_url
+    threads.git_origin_url,
+    threads.used_connector_ids
 "#,
     );
+}
+
+fn used_connector_ids_json(used_connector_ids: &[String]) -> anyhow::Result<String> {
+    serde_json::to_string(used_connector_ids)
+        .map_err(|err| anyhow::anyhow!("failed to serialize used connector ids: {err}"))
 }
 
 pub(super) fn extract_memory_mode(items: &[RolloutItem]) -> Option<String> {
@@ -1142,6 +1167,51 @@ mod tests {
                 .await
                 .expect("memory mode should remain readable");
         assert_eq!(memory_mode, "disabled");
+    }
+
+    #[tokio::test]
+    async fn used_connector_ids_are_updated_explicitly_and_preserved_by_upsert() {
+        let codex_home = unique_temp_dir();
+        let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
+            .await
+            .expect("state db should initialize");
+        let thread_id =
+            ThreadId::from_string("00000000-0000-0000-0000-000000000123").expect("valid thread id");
+        let mut metadata = test_thread_metadata(&codex_home, thread_id, codex_home.clone());
+
+        runtime
+            .upsert_thread(&metadata)
+            .await
+            .expect("initial insert should succeed");
+        runtime
+            .set_thread_used_connector_ids(
+                thread_id,
+                &[
+                    "connector_calendar".to_string(),
+                    "connector_drive".to_string(),
+                ],
+            )
+            .await
+            .expect("used connector update should succeed");
+
+        metadata.title = "updated title".to_string();
+        runtime
+            .upsert_thread(&metadata)
+            .await
+            .expect("upsert should succeed");
+
+        let persisted = runtime
+            .get_thread(thread_id)
+            .await
+            .expect("thread should load")
+            .expect("thread should exist");
+        assert_eq!(
+            persisted.used_connector_ids,
+            vec![
+                "connector_calendar".to_string(),
+                "connector_drive".to_string()
+            ]
+        );
     }
 
     #[tokio::test]

--- a/codex-rs/thread-store/src/local/update_thread_metadata.rs
+++ b/codex-rs/thread-store/src/local/update_thread_metadata.rs
@@ -295,11 +295,20 @@ async fn apply_metadata_update(
                 metadata.git_branch = branch;
                 metadata.git_origin_url = origin_url;
             }
+            if let Some(used_connector_ids) = patch.used_connector_ids {
+                metadata.used_connector_ids = used_connector_ids;
+            }
             state_db
                 .upsert_thread(&metadata)
                 .await
                 .map_err(|err| ThreadStoreError::Internal {
                     message: format!("failed to update thread metadata for {thread_id}: {err}"),
+                })?;
+            state_db
+                .set_thread_used_connector_ids(thread_id, &metadata.used_connector_ids)
+                .await
+                .map_err(|err| ThreadStoreError::Internal {
+                    message: format!("failed to update used connector ids for {thread_id}: {err}"),
                 })?;
             if let Some(memory_mode) = patch.memory_mode {
                 state_db

--- a/codex-rs/thread-store/src/types.rs
+++ b/codex-rs/thread-store/src/types.rs
@@ -529,6 +529,8 @@ pub struct ThreadMetadataPatch {
     pub git_info: Option<GitInfoPatch>,
     /// Thread memory behavior.
     pub memory_mode: Option<MemoryMode>,
+    /// Connector IDs used by this thread, in first-use order.
+    pub used_connector_ids: Option<Vec<String>>,
 }
 
 impl ThreadMetadataPatch {
@@ -606,6 +608,9 @@ impl ThreadMetadataPatch {
         if next.memory_mode.is_some() {
             self.memory_mode = next.memory_mode;
         }
+        if next.used_connector_ids.is_some() {
+            self.used_connector_ids = next.used_connector_ids;
+        }
     }
 
     pub fn is_empty(&self) -> bool {
@@ -631,6 +636,7 @@ impl ThreadMetadataPatch {
             && self.first_user_message.is_none()
             && self.git_info.is_none()
             && self.memory_mode.is_none()
+            && self.used_connector_ids.is_none()
     }
 }
 


### PR DESCRIPTION
## Summary

- persist the list of Codex Apps connector IDs used by a thread in typed thread metadata
- include the used connector ID list in Codex Apps MCP tool-call `_meta`
- filter/guard Codex Apps exposure and calls after the Finances connector has been used

## Context

This is the codex-rs side of the Finances launch requirement: once Finances has been used in a conversation, other connectors should no longer be available. The backend can consume the `_codex_apps.used_connector_ids` metadata to keep the final security policy server-side.

## Validation

- `just fmt`
- `cargo check -p codex-core -p codex-state -p codex-thread-store`
- `just test -p codex-core used_connector` passed the focused nextest filter before `just test` continued into the repo bench-smoke target
- `just fix -p codex-core -p codex-state -p codex-thread-store`

Did not run the full `just test` suite locally.