### PR TITLE
Align TUI permissions labels with app

### DIFF
--- a/codex-rs/tui/src/app/config_persistence.rs
+++ b/codex-rs/tui/src/app/config_persistence.rs
@@ -398,7 +398,7 @@ impl App {
                         serde_json::json!(auto_review_preset.approvals_reviewer.to_string()),
                     ));
                     if previous_approvals_reviewer != auto_review_preset.approvals_reviewer {
-                        permissions_history_label = Some("Auto-review");
+                        permissions_history_label = Some("Approve for me");
                     }
                 } else if !effective_enabled {
                     feature_edits.push(crate::config_update::clear_config_value(
@@ -406,7 +406,7 @@ impl App {
                     ));
                     feature_config.approvals_reviewer = ApprovalsReviewer::User;
                     if previous_approvals_reviewer != ApprovalsReviewer::User {
-                        permissions_history_label = Some("Default");
+                        permissions_history_label = Some("Ask for approval");
                     }
                 }
                 approvals_reviewer_override = Some(feature_config.approvals_reviewer);
@@ -419,7 +419,7 @@ impl App {
                 if !self.try_set_approval_policy_on_config(
                     &mut feature_config,
                     auto_review_preset.approval_policy,
-                    "Failed to enable Auto-review",
+                    "Failed to enable Approve for me",
                     "failed to set auto-review approval policy on staged config",
                 ) {
                     continue;
@@ -428,7 +428,7 @@ impl App {
                     .try_set_builtin_active_permission_profile_on_config(
                         &mut feature_config,
                         auto_review_preset.active_permission_profile.clone(),
-                        "Failed to enable Auto-review",
+                        "Failed to enable Approve for me",
                         "failed to set auto-review permission profile on staged config",
                     )
                 else {
@@ -546,7 +546,7 @@ impl App {
                 "failed to set auto-review permission profile on chat config"
             );
             self.chat_widget
-                .add_error_message(format!("Failed to enable Auto-review: {err}"));
+                .add_error_message(format!("Failed to enable Approve for me: {err}"));
         }
         if permission_profile_override.is_some() {
             self.runtime_permission_profile_override =
@@ -818,7 +818,7 @@ impl App {
                     "failed to sync effective approval policy after an overridden write"
                 );
                 self.chat_widget.add_error_message(format!(
-                    "Failed to refresh overridden Auto-review settings: {err}"
+                    "Failed to refresh overridden Approve for me settings: {err}"
                 ));
             } else {
                 self.chat_widget.set_approval_policy(policy);
@@ -846,7 +846,7 @@ impl App {
         let Some(permission_profile) = self.try_set_builtin_active_permission_profile_on_config(
             &mut config,
             auto_review_preset.active_permission_profile.clone(),
-            "Failed to refresh overridden Auto-review settings",
+            "Failed to refresh overridden Approve for me settings",
             "failed to sync overridden Auto-review permission profile",
         ) else {
             return;
@@ -864,7 +864,7 @@ impl App {
                 "failed to sync overridden Auto-review permission profile on chat config"
             );
             self.chat_widget.add_error_message(format!(
-                "Failed to refresh overridden Auto-review settings: {err}"
+                "Failed to refresh overridden Approve for me settings: {err}"
             ));
             return;
         }

--- a/codex-rs/tui/src/app/tests.rs
+++ b/codex-rs/tui/src/app/tests.rs
@@ -1820,7 +1820,7 @@ async fn update_feature_flags_enabling_guardian_selects_auto_review() -> Result<
         .map(|line| line.to_string())
         .collect::<Vec<_>>()
         .join("\n");
-    assert!(rendered.contains("Permissions updated to Auto-review"));
+    assert!(rendered.contains("Permissions updated to Approve for me"));
 
     let config = std::fs::read_to_string(codex_home.path().join("config.toml"))?;
     assert!(config.contains("guardian_approval = true"));
@@ -1915,7 +1915,7 @@ async fn update_feature_flags_disabling_guardian_clears_review_policy_and_restor
         .map(|line| line.to_string())
         .collect::<Vec<_>>()
         .join("\n");
-    assert!(rendered.contains("Permissions updated to Default"));
+    assert!(rendered.contains("Permissions updated to Ask for approval"));
 
     let config = std::fs::read_to_string(codex_home.path().join("config.toml"))?;
     assert!(!config.contains("guardian_approval = true"));

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -464,7 +464,9 @@ use unicode_segmentation::UnicodeSegmentation;
 
 const USER_SHELL_COMMAND_HELP_TITLE: &str = "Prefix a command with ! to run it locally";
 const USER_SHELL_COMMAND_HELP_HINT: &str = "Example: !ls";
-const AUTO_REVIEW_DESCRIPTION: &str = "Same workspace-write permissions as Default, but eligible `on-request` approvals are routed through the auto-reviewer subagent.";
+const ASK_FOR_APPROVAL_LABEL: &str = "Ask for approval";
+const APPROVE_FOR_ME_LABEL: &str = "Approve for me";
+const AUTO_REVIEW_DESCRIPTION: &str = "Only ask for actions detected as potentially unsafe.";
 const DEFAULT_OPENAI_BASE_URL: &str = "https://api.openai.com/v1";
 const DEFAULT_STATUS_LINE_ITEMS: [&str; 2] = ["model-with-reasoning", "current-dir"];
 const MAX_AGENT_COPY_HISTORY: usize = 32;

--- a/codex-rs/tui/src/chatwidget/permission_popups.rs
+++ b/codex-rs/tui/src/chatwidget/permission_popups.rs
@@ -56,7 +56,9 @@ impl ChatWidget {
                 continue;
             }
             let base_name = if preset.id == "auto" && windows_degraded_sandbox_enabled {
-                "Default (non-admin sandbox)".to_string()
+                format!("{ASK_FOR_APPROVAL_LABEL} (non-admin sandbox)")
+            } else if preset.id == "auto" {
+                ASK_FOR_APPROVAL_LABEL.to_string()
             } else {
                 preset.label.to_string()
             };
@@ -100,7 +102,7 @@ impl ChatWidget {
 
                 if guardian_approval_enabled {
                     items.push(SelectionItem {
-                        name: "Auto-review".to_string(),
+                        name: APPROVE_FOR_ME_LABEL.to_string(),
                         description: Some(AUTO_REVIEW_DESCRIPTION.to_string()),
                         is_current: current_review_policy == ApprovalsReviewer::AutoReview
                             && Self::preset_matches_current(
@@ -111,7 +113,7 @@ impl ChatWidget {
                             ),
                         actions: self.permission_mode_actions(
                             &preset,
-                            "Auto-review".to_string(),
+                            APPROVE_FOR_ME_LABEL.to_string(),
                             ApprovalsReviewer::AutoReview,
                             /*profile_selection*/ None,
                             /*return_to_permissions*/ !include_read_only,

--- a/codex-rs/tui/src/chatwidget/permissions_menu.rs
+++ b/codex-rs/tui/src/chatwidget/permissions_menu.rs
@@ -94,10 +94,10 @@ impl ChatWidget {
         approval_policy: AskForApproval,
         approvals_reviewer: ApprovalsReviewer,
     ) -> SelectionItem {
-        let label = if approvals_reviewer == ApprovalsReviewer::AutoReview {
-            "Auto-review"
-        } else {
-            preset.label
+        let label = match (preset.id, approvals_reviewer) {
+            ("auto", ApprovalsReviewer::AutoReview) => APPROVE_FOR_ME_LABEL,
+            ("auto", ApprovalsReviewer::User) => ASK_FOR_APPROVAL_LABEL,
+            _ => preset.label,
         };
         let active_profile_id = self
             .config

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__approvals_selection_popup.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__approvals_selection_popup.snap
@@ -4,11 +4,11 @@ expression: popup
 ---
   Update Model Permissions
 
-› 1. Default      Codex can read and edit files in the current workspace, and
-                  run commands. Approval is required to access the internet or
-                  edit other files.
-  2. Full Access  Codex can edit files outside this workspace and access the
-                  internet without asking for approval. Exercise caution when
-                  using.
+› 1. Ask for approval  Codex can read and edit files in the current workspace,
+                       and run commands. Approval is required to access the
+                       internet or edit other files.
+  2. Full Access       Codex can edit files outside this workspace and access
+                       the internet without asking for approval. Exercise
+                       caution when using.
 
   Press enter to confirm or esc to go back

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__approvals_selection_popup@windows.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__approvals_selection_popup@windows.snap
@@ -7,7 +7,7 @@ expression: popup
 › 1. Read Only (current)  Codex can read files in the current workspace.
                           Approval is required to edit files or access the
                           internet.
-  2. Default              Codex can read and edit files in the current
+  2. Ask for approval     Codex can read and edit files in the current
                           workspace, and run commands. Approval is required to
                           access the internet or edit other files.
   3. Full Access          Codex can edit files outside this workspace and

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__approvals_selection_popup@windows_degraded.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__approvals_selection_popup@windows_degraded.snap
@@ -5,17 +5,17 @@ expression: popup
 ---
   Update Model Permissions
 
-› 1. Read Only (current)             Codex can read files in the current
-                                     workspace. Approval is required to edit
-                                     files or access the internet.
-  2. Default (non-admin sandbox)  Codex can read and edit files in the
-                                     current workspace, and run commands.
-                                     Approval is required to access the
-                                     internet or edit other files.
-  3. Full Access                     Codex can edit files outside this
-                                     workspace and access the internet without
-                                     asking for approval. Exercise caution
-                                     when using.
+› 1. Read Only (current)                   Codex can read files in the current
+                                           workspace. Approval is required to
+                                           edit files or access the internet.
+  2. Ask for approval (non-admin sandbox)  Codex can read and edit files in the
+                                           current workspace, and run commands.
+                                           Approval is required to access the
+                                           internet or edit other files.
+  3. Full Access                           Codex can edit files outside this
+                                           workspace and access the internet
+                                           without asking for approval. Exercise
+                                           caution when using.
 
   The non-admin sandbox protects your files and prevents network access under
   most circumstances. However, it carries greater risk if prompt injected. To

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__permissions_selection_history_full_access_to_default.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__permissions_selection_history_full_access_to_default.snap
@@ -1,5 +1,5 @@
 ---
-source: tui/src/chatwidget/tests.rs
+source: tui/src/chatwidget/tests/permissions.rs
 expression: "lines_to_single_string(&cells[0])"
 ---
-• Permissions updated to Default
+• Permissions updated to Ask for approval

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__permissions_selection_history_full_access_to_default@windows.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__permissions_selection_history_full_access_to_default@windows.snap
@@ -2,4 +2,4 @@
 source: tui/src/chatwidget/tests.rs
 expression: "lines_to_single_string(&cells[0])"
 ---
-• Permissions updated to Default (non-admin sandbox)
+• Permissions updated to Ask for approval (non-admin sandbox)

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__profile_permissions_selection_popup.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__profile_permissions_selection_popup.snap
@@ -4,17 +4,17 @@ expression: "render_bottom_popup(&chat, 80)"
 ---
   Update Model Permissions
 
-› 1. Default (current)  Codex can read and edit files in the current
-                        workspace, and run commands. Approval is required to
-                        access the internet or edit other files.
-  2. Auto-review        Same workspace-write permissions as Default, but
-                        eligible `on-request` approvals are routed through the
-                        auto-reviewer subagent.
-  3. Full Access        Codex can edit files outside this workspace and access
-                        the internet without asking for approval. Exercise
-                        caution when using.
-  4. Read Only          Codex can read files in the current workspace.
-                        Approval is required to edit files or access the
-                        internet.
+› 1. Ask for approval (current)  Codex can read and edit files in the current
+                                 workspace, and run commands. Approval is
+                                 required to access the internet or edit other
+                                 files.
+  2. Approve for me              Only ask for actions detected as potentially
+                                 unsafe.
+  3. Full Access                 Codex can edit files outside this workspace
+                                 and access the internet without asking for
+                                 approval. Exercise caution when using.
+  4. Read Only                   Codex can read files in the current
+                                 workspace. Approval is required to edit files
+                                 or access the internet.
 
   Press enter to confirm or esc to go back

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__profile_permissions_selection_popup_with_custom_profiles.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__profile_permissions_selection_popup_with_custom_profiles.snap
@@ -4,12 +4,11 @@ expression: "render_bottom_popup(&chat, 80)"
 ---
   Update Model Permissions
 
-  1. Default                Codex can read and edit files in the current
+  1. Ask for approval       Codex can read and edit files in the current
                             workspace, and run commands. Approval is required
                             to access the internet or edit other files.
-  2. Auto-review            Same workspace-write permissions as Default, but
-                            eligible `on-request` approvals are routed through
-                            the auto-reviewer subagent.
+  2. Approve for me         Only ask for actions detected as potentially
+                            unsafe.
   3. Full Access            Codex can edit files outside this workspace and
                             access the internet without asking for approval.
                             Exercise caution when using.

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__status_surface_previews_hardcoded_only.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__status_surface_previews_hardcoded_only.snap
@@ -2,5 +2,5 @@
 source: tui/src/chatwidget/tests/status_surface_previews.rs
 expression: snapshot
 ---
-status line: my-project · feat/awesome-feature · thread title · Read Only · on-request
+status line: my-project · feat/awesome-feature · thread title · Read Only · Ask for approval
 terminal title: thread title | feat/awesome-feature | Tasks 0/0

--- a/codex-rs/tui/src/chatwidget/status_surfaces.rs
+++ b/codex-rs/tui/src/chatwidget/status_surfaces.rs
@@ -1016,13 +1016,14 @@ fn permissions_display(config: &Config) -> String {
 
 fn approval_mode_display(config: &Config) -> String {
     let approval_policy = AskForApproval::from(config.permissions.approval_policy.value());
-    if approval_policy == AskForApproval::OnRequest
-        && config.approvals_reviewer == ApprovalsReviewer::AutoReview
-    {
-        "auto-review".to_string()
-    } else {
-        config.permissions.approval_policy.value().to_string()
+    if approval_policy == AskForApproval::OnRequest {
+        return match config.approvals_reviewer {
+            ApprovalsReviewer::AutoReview => "Approve for me".to_string(),
+            ApprovalsReviewer::User => "Ask for approval".to_string(),
+        };
     }
+
+    config.permissions.approval_policy.value().to_string()
 }
 
 fn parse_items_with_invalids<T>(ids: impl IntoIterator<Item = String>) -> (Vec<T>, Vec<String>)

--- a/codex-rs/tui/src/chatwidget/tests/permissions.rs
+++ b/codex-rs/tui/src/chatwidget/tests/permissions.rs
@@ -143,7 +143,7 @@ async fn profile_permissions_selection_emits_named_profile_event_only() {
             approval_policy: Some(AskForApproval::OnRequest),
             approvals_reviewer: Some(ApprovalsReviewer::User),
             display_label,
-        }) if profile_id == ":workspace" && display_label == "Default"
+        }) if profile_id == ":workspace" && display_label == "Ask for approval"
     ));
 }
 
@@ -208,7 +208,7 @@ async fn profile_permissions_selection_emits_auto_review_mode_event() {
             approval_policy: Some(AskForApproval::OnRequest),
             approvals_reviewer: Some(ApprovalsReviewer::AutoReview),
             display_label,
-        }) if profile_id == ":workspace" && display_label == "Auto-review"
+        }) if profile_id == ":workspace" && display_label == "Approve for me"
     ));
 }
 
@@ -256,7 +256,7 @@ async fn approvals_selection_popup_snapshot_windows_degraded_sandbox() {
 
     let popup = render_bottom_popup(&chat, /*width*/ 80);
     assert!(
-        popup.contains("Default (non-admin sandbox)"),
+        popup.contains("Ask for approval (non-admin sandbox)"),
         "expected degraded sandbox label in approvals popup: {popup}"
     );
     assert!(
@@ -285,7 +285,7 @@ async fn preset_matching_accepts_workspace_write_with_extra_roots() {
             cwd.as_path(),
             &preset
         ),
-        "WorkspaceWrite with extra roots should still match the Default preset"
+        "WorkspaceWrite with extra roots should still match the Ask for approval preset"
     );
     assert!(
         !ChatWidget::preset_matches_current(
@@ -629,7 +629,7 @@ async fn permissions_selection_history_snapshot_full_access_to_default() {
     chat.open_permissions_popup();
     let popup = render_bottom_popup(&chat, /*width*/ 120);
     chat.handle_key_event(KeyEvent::from(KeyCode::Up));
-    if popup.contains("Auto-review") {
+    if popup.contains("Approve for me") {
         chat.handle_key_event(KeyEvent::from(KeyCode::Up));
     }
     chat.handle_key_event(KeyEvent::from(KeyCode::Enter));
@@ -699,8 +699,8 @@ async fn permissions_selection_hides_auto_review_when_feature_disabled() {
     let popup = render_bottom_popup(&chat, /*width*/ 120);
 
     assert!(
-        !popup.contains("Auto-review"),
-        "expected Auto-review to stay hidden until the feature is enabled: {popup}"
+        !popup.contains("Approve for me"),
+        "expected Approve for me to stay hidden until the feature is enabled: {popup}"
     );
 }
 
@@ -730,8 +730,8 @@ async fn permissions_selection_hides_auto_review_when_feature_disabled_even_if_a
     let popup = render_bottom_popup(&chat, /*width*/ 120);
 
     assert!(
-        !popup.contains("Auto-review"),
-        "expected Auto-review to stay hidden when the feature is disabled: {popup}"
+        !popup.contains("Approve for me"),
+        "expected Approve for me to stay hidden when the feature is disabled: {popup}"
     );
 }
 
@@ -776,8 +776,8 @@ async fn permissions_selection_marks_auto_review_current_after_session_configure
     let popup = render_bottom_popup(&chat, /*width*/ 120);
 
     assert!(
-        popup.contains("Auto-review (current)"),
-        "expected Auto-review to be current after SessionConfigured sync: {popup}"
+        popup.contains("Approve for me (current)"),
+        "expected Approve for me to be current after SessionConfigured sync: {popup}"
     );
 }
 
@@ -826,8 +826,8 @@ async fn permissions_selection_marks_auto_review_current_with_custom_workspace_w
     let popup = render_bottom_popup(&chat, /*width*/ 120);
 
     assert!(
-        popup.contains("Auto-review (current)"),
-        "expected Auto-review to be current even with custom workspace-write details: {popup}"
+        popup.contains("Approve for me (current)"),
+        "expected Approve for me to be current even with custom workspace-write details: {popup}"
     );
 }
 
@@ -861,7 +861,7 @@ async fn permissions_selection_can_disable_auto_review() {
             event,
             AppEvent::UpdateApprovalsReviewer(ApprovalsReviewer::User)
         )),
-        "expected selecting Default from Auto-review to switch back to manual approval review: {events:?}"
+        "expected selecting Ask for approval from Approve for me to switch back to manual approval review: {events:?}"
     );
     assert!(
         !events
@@ -906,8 +906,8 @@ async fn permissions_selection_sends_approvals_reviewer_in_override_turn_context
     assert!(
         popup
             .lines()
-            .any(|line| line.contains("Auto-review") && line.contains('›')),
-        "expected one Down from Default to select Auto-review: {popup}"
+            .any(|line| line.contains("Approve for me") && line.contains('›')),
+        "expected one Down from Ask for approval to select Approve for me: {popup}"
     );
     chat.handle_key_event(KeyEvent::from(KeyCode::Enter));
 

--- a/codex-rs/tui/src/status/card.rs
+++ b/codex-rs/tui/src/status/card.rs
@@ -682,13 +682,14 @@ fn status_approval_label(
     approvals_reviewer: ApprovalsReviewer,
     approval: &str,
 ) -> String {
-    if approval_policy == AskForApproval::OnRequest
-        && approvals_reviewer == ApprovalsReviewer::AutoReview
-    {
-        "auto-review".to_string()
-    } else {
-        approval.to_string()
+    if approval_policy == AskForApproval::OnRequest {
+        return match approvals_reviewer {
+            ApprovalsReviewer::AutoReview => "Approve for me".to_string(),
+            ApprovalsReviewer::User => "Ask for approval".to_string(),
+        };
     }
+
+    approval.to_string()
 }
 
 impl HistoryCell for StatusHistoryCell {

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_cached_limits_hide_credits_without_flag.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_cached_limits_hide_credits_without_flag.snap
@@ -4,20 +4,20 @@ expression: sanitized
 ---
 /status
 
-╭───────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.0)                                             │
-│                                                                       │
-│ Visit https://chatgpt.com/codex/settings/usage for up-to-date         │
-│ information on rate limits and credits                                │
-│                                                                       │
-│  Model:            gpt-5.1-codex (reasoning none, summaries auto)     │
-│  Directory: [[workspace]]                                             │
-│  Permissions:      Custom (workspace with network access, on-request) │
-│  Agents.md:        <none>                                             │
-│                                                                       │
-│  Token usage:      1.05K total  (700 input + 350 output)              │
-│  Context window:   100% left (1.45K used / 272K)                      │
-│  5h limit:         [████████░░░░░░░░░░░░] 40% left (resets 11:32)     │
-│  Weekly limit:     [█████████████░░░░░░░] 65% left (resets 11:52)     │
-│  Warning:          limits may be stale - start new turn to refresh.   │
-╰───────────────────────────────────────────────────────────────────────╯
+╭─────────────────────────────────────────────────────────────────────────────╮
+│  >_ OpenAI Codex (v0.0.0)                                                   │
+│                                                                             │
+│ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
+│ information on rate limits and credits                                      │
+│                                                                             │
+│  Model:            gpt-5.1-codex (reasoning none, summaries auto)           │
+│  Directory: [[workspace]]                                                   │
+│  Permissions:      Custom (workspace with network access, Ask for approval) │
+│  Agents.md:        <none>                                                   │
+│                                                                             │
+│  Token usage:      1.05K total  (700 input + 350 output)                    │
+│  Context window:   100% left (1.45K used / 272K)                            │
+│  5h limit:         [████████░░░░░░░░░░░░] 40% left (resets 11:32)           │
+│  Weekly limit:     [█████████████░░░░░░░] 65% left (resets 11:52)           │
+│  Warning:          limits may be stale - start new turn to refresh.         │
+╰─────────────────────────────────────────────────────────────────────────────╯

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_credits_and_limits.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_credits_and_limits.snap
@@ -4,20 +4,20 @@ expression: sanitized
 ---
 /status
 
-╭───────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.0)                                             │
-│                                                                       │
-│ Visit https://chatgpt.com/codex/settings/usage for up-to-date         │
-│ information on rate limits and credits                                │
-│                                                                       │
-│  Model:            gpt-5.1-codex (reasoning none, summaries auto)     │
-│  Directory: [[workspace]]                                             │
-│  Permissions:      Custom (workspace with network access, on-request) │
-│  Agents.md:        <none>                                             │
-│                                                                       │
-│  Token usage:      2K total  (1.4K input + 600 output)                │
-│  Context window:   100% left (2.2K used / 272K)                       │
-│  5h limit:         [███████████░░░░░░░░░] 55% left (resets 09:25)     │
-│  Weekly limit:     [██████████████░░░░░░] 70% left (resets 09:55)     │
-│  Credits:          38 credits                                         │
-╰───────────────────────────────────────────────────────────────────────╯
+╭─────────────────────────────────────────────────────────────────────────────╮
+│  >_ OpenAI Codex (v0.0.0)                                                   │
+│                                                                             │
+│ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
+│ information on rate limits and credits                                      │
+│                                                                             │
+│  Model:            gpt-5.1-codex (reasoning none, summaries auto)           │
+│  Directory: [[workspace]]                                                   │
+│  Permissions:      Custom (workspace with network access, Ask for approval) │
+│  Agents.md:        <none>                                                   │
+│                                                                             │
+│  Token usage:      2K total  (1.4K input + 600 output)                      │
+│  Context window:   100% left (2.2K used / 272K)                             │
+│  5h limit:         [███████████░░░░░░░░░] 55% left (resets 09:25)           │
+│  Weekly limit:     [██████████████░░░░░░] 70% left (resets 09:55)           │
+│  Credits:          38 credits                                               │
+╰─────────────────────────────────────────────────────────────────────────────╯

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_forked_from.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_forked_from.snap
@@ -4,20 +4,20 @@ expression: sanitized
 ---
 /status
 
-╭───────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.0)                                             │
-│                                                                       │
-│ Visit https://chatgpt.com/codex/settings/usage for up-to-date         │
-│ information on rate limits and credits                                │
-│                                                                       │
-│  Model:            gpt-5.1-codex-max (reasoning none, summaries auto) │
-│  Directory: [[workspace]]                                             │
-│  Permissions:      Custom (workspace with network access, on-request) │
-│  Agents.md:        <none>                                             │
-│  Session:          0f0f3c13-6cf9-4aa4-8b80-7d49c2f1be2e               │
-│  Forked from:      e9f18a88-8081-4e51-9d4e-8af5cde2d8dd               │
-│                                                                       │
-│  Token usage:      1.2K total  (800 input + 400 output)               │
-│  Context window:   100% left (1.2K used / 272K)                       │
-│  Limits:           data not available yet                             │
-╰───────────────────────────────────────────────────────────────────────╯
+╭─────────────────────────────────────────────────────────────────────────────╮
+│  >_ OpenAI Codex (v0.0.0)                                                   │
+│                                                                             │
+│ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
+│ information on rate limits and credits                                      │
+│                                                                             │
+│  Model:            gpt-5.1-codex-max (reasoning none, summaries auto)       │
+│  Directory: [[workspace]]                                                   │
+│  Permissions:      Custom (workspace with network access, Ask for approval) │
+│  Agents.md:        <none>                                                   │
+│  Session:          0f0f3c13-6cf9-4aa4-8b80-7d49c2f1be2e                     │
+│  Forked from:      e9f18a88-8081-4e51-9d4e-8af5cde2d8dd                     │
+│                                                                             │
+│  Token usage:      1.2K total  (800 input + 400 output)                     │
+│  Context window:   100% left (1.2K used / 272K)                             │
+│  Limits:           data not available yet                                   │
+╰─────────────────────────────────────────────────────────────────────────────╯

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_monthly_limit.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_monthly_limit.snap
@@ -4,18 +4,18 @@ expression: sanitized
 ---
 /status
 
-╭────────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.0)                                                  │
-│                                                                            │
-│ Visit https://chatgpt.com/codex/settings/usage for up-to-date              │
-│ information on rate limits and credits                                     │
-│                                                                            │
-│  Model:            gpt-5.1-codex-max (reasoning none, summaries auto)      │
-│  Directory: [[workspace]]                                                  │
-│  Permissions:      Custom (workspace with network access, on-request)      │
-│  Agents.md:        <none>                                                  │
-│                                                                            │
-│  Token usage:      1.2K total  (800 input + 400 output)                    │
-│  Context window:   100% left (1.2K used / 272K)                            │
-│  Monthly limit:    [██████████████████░░] 88% left (resets 07:08 on 7 May) │
-╰────────────────────────────────────────────────────────────────────────────╯
+╭─────────────────────────────────────────────────────────────────────────────╮
+│  >_ OpenAI Codex (v0.0.0)                                                   │
+│                                                                             │
+│ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
+│ information on rate limits and credits                                      │
+│                                                                             │
+│  Model:            gpt-5.1-codex-max (reasoning none, summaries auto)       │
+│  Directory: [[workspace]]                                                   │
+│  Permissions:      Custom (workspace with network access, Ask for approval) │
+│  Agents.md:        <none>                                                   │
+│                                                                             │
+│  Token usage:      1.2K total  (800 input + 400 output)                     │
+│  Context window:   100% left (1.2K used / 272K)                             │
+│  Monthly limit:    [██████████████████░░] 88% left (resets 07:08 on 7 May)  │
+╰─────────────────────────────────────────────────────────────────────────────╯

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_reasoning_details.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_reasoning_details.snap
@@ -12,7 +12,7 @@ expression: sanitized
 │                                                                           │
 │  Model:            gpt-5.1-codex-max (reasoning high, summaries detailed) │
 │  Directory: [[workspace]]                                                 │
-│  Permissions:      Workspace (on-request)                                 │
+│  Permissions:      Workspace (Ask for approval)                           │
 │  Agents.md:        <none>                                                 │
 │                                                                           │
 │  Token usage:      1.9K total  (1K input + 900 output)                    │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_active_user_defined_profile.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_active_user_defined_profile.snap
@@ -12,7 +12,7 @@ expression: sanitized
 │                                                                       │
 │  Model:            gpt-5.1-codex-max (reasoning none, summaries auto) │
 │  Directory: [[workspace]]                                             │
-│  Permissions:      Profile locked (read-only, on-request)             │
+│  Permissions:      Profile locked (read-only, Ask for approval)       │
 │  Agents.md:        <none>                                             │
 │                                                                       │
 │  Token usage:      0 total  (0 input + 0 output)                      │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_auto_review_permissions.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_auto_review_permissions.snap
@@ -12,7 +12,7 @@ expression: sanitized
 │                                                                       │
 │  Model:            gpt-5.1-codex-max (reasoning none, summaries auto) │
 │  Directory: [[workspace]]                                             │
-│  Permissions:      Workspace (auto-review)                            │
+│  Permissions:      Workspace (Approve for me)                         │
 │  Agents.md:        <none>                                             │
 │                                                                       │
 │  Token usage:      0 total  (0 input + 0 output)                      │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_missing_limits_message.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_missing_limits_message.snap
@@ -4,18 +4,18 @@ expression: sanitized
 ---
 /status
 
-╭───────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.0)                                             │
-│                                                                       │
-│ Visit https://chatgpt.com/codex/settings/usage for up-to-date         │
-│ information on rate limits and credits                                │
-│                                                                       │
-│  Model:            gpt-5.1-codex-max (reasoning none, summaries auto) │
-│  Directory: [[workspace]]                                             │
-│  Permissions:      Custom (workspace with network access, on-request) │
-│  Agents.md:        <none>                                             │
-│                                                                       │
-│  Token usage:      750 total  (500 input + 250 output)                │
-│  Context window:   100% left (750 used / 272K)                        │
-│  Limits:           data not available yet                             │
-╰───────────────────────────────────────────────────────────────────────╯
+╭─────────────────────────────────────────────────────────────────────────────╮
+│  >_ OpenAI Codex (v0.0.0)                                                   │
+│                                                                             │
+│ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
+│ information on rate limits and credits                                      │
+│                                                                             │
+│  Model:            gpt-5.1-codex-max (reasoning none, summaries auto)       │
+│  Directory: [[workspace]]                                                   │
+│  Permissions:      Custom (workspace with network access, Ask for approval) │
+│  Agents.md:        <none>                                                   │
+│                                                                             │
+│  Token usage:      750 total  (500 input + 250 output)                      │
+│  Context window:   100% left (750 used / 272K)                              │
+│  Limits:           data not available yet                                   │
+╰─────────────────────────────────────────────────────────────────────────────╯

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_refreshing_limits_notice.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_refreshing_limits_notice.snap
@@ -4,19 +4,19 @@ expression: sanitized
 ---
 /status
 
-╭───────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.0)                                             │
-│                                                                       │
-│ Visit https://chatgpt.com/codex/settings/usage for up-to-date         │
-│ information on rate limits and credits                                │
-│                                                                       │
-│  Model:            gpt-5.1-codex-max (reasoning none, summaries auto) │
-│  Directory: [[workspace]]                                             │
-│  Permissions:      Custom (workspace with network access, on-request) │
-│  Agents.md:        <none>                                             │
-│                                                                       │
-│  Token usage:      750 total  (500 input + 250 output)                │
-│  Context window:   100% left (750 used / 272K)                        │
-│  5h limit:         [███████████░░░░░░░░░] 55% left (resets 08:24)     │
-│  Weekly limit:     [██████████████░░░░░░] 70% left (resets 08:54)     │
-╰───────────────────────────────────────────────────────────────────────╯
+╭─────────────────────────────────────────────────────────────────────────────╮
+│  >_ OpenAI Codex (v0.0.0)                                                   │
+│                                                                             │
+│ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
+│ information on rate limits and credits                                      │
+│                                                                             │
+│  Model:            gpt-5.1-codex-max (reasoning none, summaries auto)       │
+│  Directory: [[workspace]]                                                   │
+│  Permissions:      Custom (workspace with network access, Ask for approval) │
+│  Agents.md:        <none>                                                   │
+│                                                                             │
+│  Token usage:      750 total  (500 input + 250 output)                      │
+│  Context window:   100% left (750 used / 272K)                              │
+│  5h limit:         [███████████░░░░░░░░░] 55% left (resets 08:24)           │
+│  Weekly limit:     [██████████████░░░░░░] 70% left (resets 08:54)           │
+╰─────────────────────────────────────────────────────────────────────────────╯

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_stale_limits_message.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_stale_limits_message.snap
@@ -4,20 +4,20 @@ expression: sanitized
 ---
 /status
 
-╭───────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.0)                                             │
-│                                                                       │
-│ Visit https://chatgpt.com/codex/settings/usage for up-to-date         │
-│ information on rate limits and credits                                │
-│                                                                       │
-│  Model:            gpt-5.1-codex-max (reasoning none, summaries auto) │
-│  Directory: [[workspace]]                                             │
-│  Permissions:      Custom (workspace with network access, on-request) │
-│  Agents.md:        <none>                                             │
-│                                                                       │
-│  Token usage:      1.9K total  (1K input + 900 output)                │
-│  Context window:   100% left (2.25K used / 272K)                      │
-│  5h limit:         [██████░░░░░░░░░░░░░░] 28% left (resets 03:14)     │
-│  Weekly limit:     [████████████░░░░░░░░] 60% left (resets 03:34)     │
-│  Warning:          limits may be stale - start new turn to refresh.   │
-╰───────────────────────────────────────────────────────────────────────╯
+╭─────────────────────────────────────────────────────────────────────────────╮
+│  >_ OpenAI Codex (v0.0.0)                                                   │
+│                                                                             │
+│ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
+│ information on rate limits and credits                                      │
+│                                                                             │
+│  Model:            gpt-5.1-codex-max (reasoning none, summaries auto)       │
+│  Directory: [[workspace]]                                                   │
+│  Permissions:      Custom (workspace with network access, Ask for approval) │
+│  Agents.md:        <none>                                                   │
+│                                                                             │
+│  Token usage:      1.9K total  (1K input + 900 output)                      │
+│  Context window:   100% left (2.25K used / 272K)                            │
+│  5h limit:         [██████░░░░░░░░░░░░░░] 28% left (resets 03:14)           │
+│  Weekly limit:     [████████████░░░░░░░░] 60% left (resets 03:34)           │
+│  Warning:          limits may be stale - start new turn to refresh.         │
+╰─────────────────────────────────────────────────────────────────────────────╯

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_unavailable_limits_message.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_unavailable_limits_message.snap
@@ -4,18 +4,18 @@ expression: sanitized
 ---
 /status
 
-╭───────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.0)                                             │
-│                                                                       │
-│ Visit https://chatgpt.com/codex/settings/usage for up-to-date         │
-│ information on rate limits and credits                                │
-│                                                                       │
-│  Model:            gpt-5.1-codex-max (reasoning none, summaries auto) │
-│  Directory: [[workspace]]                                             │
-│  Permissions:      Custom (workspace with network access, on-request) │
-│  Agents.md:        <none>                                             │
-│                                                                       │
-│  Token usage:      750 total  (500 input + 250 output)                │
-│  Context window:   100% left (750 used / 272K)                        │
-│  Limits:           not available for this account                     │
-╰───────────────────────────────────────────────────────────────────────╯
+╭─────────────────────────────────────────────────────────────────────────────╮
+│  >_ OpenAI Codex (v0.0.0)                                                   │
+│                                                                             │
+│ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
+│ information on rate limits and credits                                      │
+│                                                                             │
+│  Model:            gpt-5.1-codex-max (reasoning none, summaries auto)       │
+│  Directory: [[workspace]]                                                   │
+│  Permissions:      Custom (workspace with network access, Ask for approval) │
+│  Agents.md:        <none>                                                   │
+│                                                                             │
+│  Token usage:      750 total  (500 input + 250 output)                      │
+│  Context window:   100% left (750 used / 272K)                              │
+│  Limits:           not available for this account                           │
+╰─────────────────────────────────────────────────────────────────────────────╯

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_treats_refreshing_empty_limits_as_unavailable.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_treats_refreshing_empty_limits_as_unavailable.snap
@@ -4,18 +4,18 @@ expression: sanitized
 ---
 /status
 
-╭───────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.0)                                             │
-│                                                                       │
-│ Visit https://chatgpt.com/codex/settings/usage for up-to-date         │
-│ information on rate limits and credits                                │
-│                                                                       │
-│  Model:            gpt-5.1-codex-max (reasoning none, summaries auto) │
-│  Directory: [[workspace]]                                             │
-│  Permissions:      Custom (workspace with network access, on-request) │
-│  Agents.md:        <none>                                             │
-│                                                                       │
-│  Token usage:      750 total  (500 input + 250 output)                │
-│  Context window:   100% left (750 used / 272K)                        │
-│  Limits:           not available for this account                     │
-╰───────────────────────────────────────────────────────────────────────╯
+╭─────────────────────────────────────────────────────────────────────────────╮
+│  >_ OpenAI Codex (v0.0.0)                                                   │
+│                                                                             │
+│ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
+│ information on rate limits and credits                                      │
+│                                                                             │
+│  Model:            gpt-5.1-codex-max (reasoning none, summaries auto)       │
+│  Directory: [[workspace]]                                                   │
+│  Permissions:      Custom (workspace with network access, Ask for approval) │
+│  Agents.md:        <none>                                                   │
+│                                                                             │
+│  Token usage:      750 total  (500 input + 250 output)                      │
+│  Context window:   100% left (750 used / 272K)                              │
+│  Limits:           not available for this account                           │
+╰─────────────────────────────────────────────────────────────────────────────╯

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_truncates_in_narrow_terminal.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_truncates_in_narrow_terminal.snap
@@ -12,7 +12,7 @@ expression: sanitized
 │                                                                    │
 │  Model:            gpt-5.1-codex-max (reasoning high, summaries de │
 │  Directory: [[workspace]]                                          │
-│  Permissions:      Custom (workspace with network access, on-reque │
+│  Permissions:      Custom (workspace with network access, Ask for  │
 │  Agents.md:        <none>                                          │
 │                                                                    │
 │  Token usage:      1.9K total  (1K input + 900 output)             │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_uses_default_reasoning_when_config_empty.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_uses_default_reasoning_when_config_empty.snap
@@ -4,21 +4,21 @@ expression: sanitized
 ---
 /status
 
-╭──────────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.0)                                                │
-│                                                                          │
-│ Visit https://chatgpt.com/codex/settings/usage for up-to-date            │
-│ information on rate limits and credits                                   │
-│                                                                          │
-│  Remote:           unix:///tmp/codex-home/app-server-control/app-server- │
-│                    control.sock (v0.133.0)                               │
-│                                                                          │
-│  Model:            gpt-5.1-codex-max (reasoning medium, summaries auto)  │
-│  Directory: [[workspace]]                                                │
-│  Permissions:      Custom (workspace with network access, on-request)    │
-│  Agents.md:        <none>                                                │
-│                                                                          │
-│  Token usage:      750 total  (500 input + 250 output)                   │
-│  Context window:   100% left (750 used / 272K)                           │
-│  Limits:           data not available yet                                │
-╰──────────────────────────────────────────────────────────────────────────╯
+╭─────────────────────────────────────────────────────────────────────────────╮
+│  >_ OpenAI Codex (v0.0.0)                                                   │
+│                                                                             │
+│ Visit https://chatgpt.com/codex/settings/usage for up-to-date               │
+│ information on rate limits and credits                                      │
+│                                                                             │
+│  Remote:           unix:///tmp/codex-home/app-server-control/app-server-    │
+│                    control.sock (v0.133.0)                                  │
+│                                                                             │
+│  Model:            gpt-5.1-codex-max (reasoning medium, summaries auto)     │
+│  Directory: [[workspace]]                                                   │
+│  Permissions:      Custom (workspace with network access, Ask for approval) │
+│  Agents.md:        <none>                                                   │
+│                                                                             │
+│  Token usage:      750 total  (500 input + 250 output)                      │
+│  Context window:   100% left (750 used / 272K)                              │
+│  Limits:           data not available yet                                   │
+╰─────────────────────────────────────────────────────────────────────────────╯

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_uses_generic_limit_labels_for_unsupported_windows.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_uses_generic_limit_labels_for_unsupported_windows.snap
@@ -12,7 +12,7 @@ expression: sanitized
 │                                                                              │
 │  Model:                   gpt-5.1-codex-max (reasoning none, summaries auto) │
 │  Directory: [[workspace]]                                                    │
-│  Permissions:             Custom (workspace with network access, on-request) │
+│  Permissions:             Custom (workspace with network access, Ask for app │
 │  Agents.md:               <none>                                             │
 │                                                                              │
 │  Token usage:             1.2K total  (800 input + 400 output)               │

--- a/codex-rs/tui/src/status/tests.rs
+++ b/codex-rs/tui/src/status/tests.rs
@@ -291,7 +291,7 @@ async fn status_permissions_non_default_workspace_write_uses_workspace_label() {
 
     assert_eq!(
         permissions_text_for(&config).as_deref(),
-        Some("Custom (workspace with network access, on-request)")
+        Some("Custom (workspace with network access, Ask for approval)")
     );
 }
 
@@ -314,7 +314,7 @@ async fn status_permissions_named_read_only_profile_shows_builtin_label() {
 
     assert_eq!(
         permissions_text_for(&config).as_deref(),
-        Some("Read Only (on-request)")
+        Some("Read Only (Ask for approval)")
     );
 }
 
@@ -344,7 +344,7 @@ async fn status_permissions_read_only_profile_shows_additional_writable_roots() 
 
     assert_eq!(
         permissions_text_for(&config).as_deref(),
-        Some("Read Only (on-request)")
+        Some("Read Only (Ask for approval)")
     );
 }
 
@@ -367,7 +367,7 @@ async fn status_permissions_named_workspace_profile_shows_builtin_label() {
 
     assert_eq!(
         permissions_text_for(&config).as_deref(),
-        Some("Workspace (on-request)")
+        Some("Workspace (Ask for approval)")
     );
 }
 
@@ -391,7 +391,7 @@ async fn status_permissions_workspace_auto_review_shows_reviewer_label() {
 
     assert_eq!(
         permissions_text_for(&config).as_deref(),
-        Some("Workspace (auto-review)")
+        Some("Workspace (Approve for me)")
     );
 }
 
@@ -420,7 +420,7 @@ async fn status_permissions_named_profile_shows_additional_writable_roots() {
 
     assert_eq!(
         permissions_text_for(&config).as_deref(),
-        Some("Workspace (on-request)")
+        Some("Workspace (Ask for approval)")
     );
 }
 
@@ -449,7 +449,10 @@ async fn status_permissions_workspace_roots_show_additional_directories() {
 
     assert_eq!(
         permissions_text_for(&config),
-        Some(format!("Workspace [{}] (on-request)", extra_root.display()))
+        Some(format!(
+            "Workspace [{}] (Ask for approval)",
+            extra_root.display()
+        ))
     );
 }
 
@@ -483,7 +486,7 @@ async fn status_permissions_workspace_roots_include_profile_defined_directories(
     assert_eq!(
         permissions_text_for(&config),
         Some(format!(
-            "Workspace [{}] (on-request)",
+            "Workspace [{}] (Ask for approval)",
             profile_root.display()
         ))
     );
@@ -513,7 +516,7 @@ async fn status_permissions_broadened_workspace_profile_shows_builtin_label() {
 
     assert_eq!(
         permissions_text_for(&config).as_deref(),
-        Some("Workspace with network access (on-request)")
+        Some("Workspace with network access (Ask for approval)")
     );
 }
 
@@ -531,7 +534,7 @@ async fn status_permissions_user_defined_profile_shows_name() {
 
     assert_eq!(
         permissions_text_for(&config).as_deref(),
-        Some("Profile locked (read-only, on-request)")
+        Some("Profile locked (read-only, Ask for approval)")
     );
 }
 
@@ -756,7 +759,7 @@ async fn status_permissions_full_disk_managed_with_network_is_danger_full_access
 
     assert_eq!(
         permissions_text_for(&config).as_deref(),
-        Some("Custom (danger-full-access, on-request)")
+        Some("Custom (danger-full-access, Ask for approval)")
     );
 }
 
@@ -779,7 +782,7 @@ async fn status_permissions_full_disk_managed_without_network_is_external_sandbo
 
     assert_eq!(
         permissions_text_for(&config).as_deref(),
-        Some("Custom (external-sandbox, on-request)")
+        Some("Custom (external-sandbox, Ask for approval)")
     );
 }
 


### PR DESCRIPTION
## Summary

The desktop app now presents the on-request permissions mode as `Ask for approval` and the manual-review-backed mode as `Approve for me`. The TUI still exposed older/internal labels like `Default` and `Auto-review`, which made the same underlying settings look different across clients.

This updates the TUI UX copy to match the app without changing the underlying default behavior. Fresh threads continue to use the existing on-request approval mode, now displayed as `Ask for approval`.

The label changes cover `/permissions`, explicit profile permissions menus, status surfaces, config persistence history/error text, and the corresponding TUI snapshots.

### Before
<img width="1181" height="119" alt="Screenshot 2026-05-28 at 10 19 47 PM" src="https://github.com/user-attachments/assets/0664846b-b6dd-4931-b4dd-d0af0d42058e" />
<img width="523" height="19" alt="Screenshot 2026-05-28 at 10 21 29 PM" src="https://github.com/user-attachments/assets/7899c33e-b35d-4684-8389-97e357803423" />

### After
<img width="1216" height="117" alt="Screenshot 2026-05-28 at 10 19 32 PM" src="https://github.com/user-attachments/assets/015aab43-ac97-411f-8031-75cdd887251b" />
<img width="567" height="18" alt="Screenshot 2026-05-28 at 10 20 24 PM" src="https://github.com/user-attachments/assets/28b6422c-b823-4298-b221-c83d46d09d66" />
