### PR TITLE
bazel: keep local remote cache uploads read only

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -41,6 +41,9 @@ common --test_output=errors
 common --bes_results_url=https://app.buildbuddy.io/invocation/
 common --bes_backend=grpcs://remote.buildbuddy.io
 common --remote_cache=grpcs://remote.buildbuddy.io
+# Local builds should read shared cache entries but not publish machine-specific
+# local action results into the shared cache.
+common --noremote_upload_local_results
 common --remote_download_toplevel
 common --nobuild_runfile_links
 common --remote_timeout=3600
@@ -56,6 +59,7 @@ common --jobs=30
 
 common:remote --extra_execution_platforms=//:rbe
 common:remote --remote_executor=grpcs://remote.buildbuddy.io
+common:remote --remote_upload_local_results
 common:remote --jobs=800
 # TODO(team): Evaluate if this actually helps, zbarsky is not sure, everything seems bottlenecked on `core` either way.
 # Enable pipelined compilation since we are not bound by local CPU count.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -396,6 +396,14 @@ crate.annotation(
     ],
 )
 
+crate.annotation(
+    crate = "webrtc-sys-build",
+    patch_args = ["-p1"],
+    patches = [
+        "//patches:webrtc-sys-build_hermetic_scratch.patch",
+    ],
+)
+
 # Fix readme inclusions
 crate.annotation(
     crate = "windows-link",

--- a/patches/BUILD.bazel
+++ b/patches/BUILD.bazel
@@ -21,6 +21,7 @@ exports_files([
     "v8_bazel_rules.patch",
     "v8_module_deps.patch",
     "v8_source_portability.patch",
+    "webrtc-sys-build_hermetic_scratch.patch",
     "webrtc-sys_hermetic_darwin_sysroot.patch",
     "windows-link.patch",
     "xz_windows_stack_args.patch",

--- a/patches/webrtc-sys-build_hermetic_scratch.patch
+++ b/patches/webrtc-sys-build_hermetic_scratch.patch
@@ -1,5 +1,5 @@
 diff --git a/src/lib.rs b/src/lib.rs
-index a240dd6..6e64dfd 100644
+index a240dd6..7dcf631 100644
 --- a/src/lib.rs
 +++ b/src/lib.rs
 @@ -89,7 +89,7 @@ pub fn custom_dir() -> Option<path::PathBuf> {
@@ -7,7 +7,7 @@ index a240dd6..6e64dfd 100644
  /// This also has the benefit of not re-downloading the binaries for each crate
  pub fn prebuilt_dir() -> path::PathBuf {
 -    let target_dir = scratch::path(SCRATH_PATH);
-+    let target_dir = scratch_dir();
++    let target_dir = PathBuf::from(env::var("OUT_DIR").unwrap()).join(SCRATH_PATH);
      path::Path::new(&target_dir).join(format!(
          "livekit/{}-{}/{}",
          webrtc_triple(),
@@ -16,17 +16,7 @@ index a240dd6..6e64dfd 100644
  
  pub fn download_webrtc() -> Result<()> {
 -    let dir = scratch::path(SCRATH_PATH);
-+    let dir = scratch_dir();
++    let dir = PathBuf::from(env::var("OUT_DIR").unwrap()).join(SCRATH_PATH);
      // temporary fix to avoid github workflow issue
      fs::create_dir_all(&dir).context("Failed to create scratch_path")?;
      let flock = File::create(dir.join(".lock"))
-@@ -233,5 +233,9 @@ pub fn download_webrtc() -> Result<()> {
-     Ok(())
- }
- 
-+fn scratch_dir() -> PathBuf {
-+    PathBuf::from(env::var("OUT_DIR").unwrap()).join(SCRATH_PATH)
-+}
-+
- pub fn android_ndk_toolchain() -> Result<path::PathBuf> {
-     let host_os = host_os();

--- a/patches/webrtc-sys-build_hermetic_scratch.patch
+++ b/patches/webrtc-sys-build_hermetic_scratch.patch
@@ -20,7 +20,7 @@ index a240dd6..6e64dfd 100644
      // temporary fix to avoid github workflow issue
      fs::create_dir_all(&dir).context("Failed to create scratch_path")?;
      let flock = File::create(dir.join(".lock"))
-@@ -233,6 +233,10 @@ pub fn download_webrtc() -> Result<()> {
+@@ -233,5 +233,9 @@ pub fn download_webrtc() -> Result<()> {
      Ok(())
  }
  

--- a/patches/webrtc-sys-build_hermetic_scratch.patch
+++ b/patches/webrtc-sys-build_hermetic_scratch.patch
@@ -30,4 +30,3 @@ index a240dd6..6e64dfd 100644
 +
  pub fn android_ndk_toolchain() -> Result<path::PathBuf> {
      let host_os = host_os();
- 

--- a/patches/webrtc-sys-build_hermetic_scratch.patch
+++ b/patches/webrtc-sys-build_hermetic_scratch.patch
@@ -1,0 +1,32 @@
+diff --git a/src/lib.rs b/src/lib.rs
+index 3316604..fcdd7c7 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -84,7 +84,7 @@ pub fn custom_dir() -> Option<path::PathBuf> {
+ /// across multiple crates without dependencies constraints
+ /// This also has the benefit of not re-downloading the binaries for each crate
+ pub fn prebuilt_dir() -> path::PathBuf {
+-    let target_dir = scratch::path(SCRATH_PATH);
++    let target_dir = scratch_dir();
+     path::Path::new(&target_dir).join(format!(
+         "livekit/{}-{}/{}",
+         webrtc_triple(),
+@@ -197,8 +197,12 @@ pub fn configure_jni_symbols() -> Result<()> {
+ }
+ 
+ pub fn download_webrtc() -> Result<()> {
+-    let dir = scratch::path(SCRATH_PATH);
++    let dir = scratch_dir();
+     // temporary fix to avoid github workflow issue
+     fs::create_dir_all(&dir).context("Failed to create scratch_path")?;
+@@ -223,6 +227,10 @@ pub fn download_webrtc() -> Result<()> {
+     Ok(())
+ }
+ 
++fn scratch_dir() -> PathBuf {
++    PathBuf::from(env::var("OUT_DIR").unwrap()).join(SCRATH_PATH)
++}
++
+ fn android_ndk_toolchain() -> Result<path::PathBuf> {
+     let ndk_home = env::var("ANDROID_NDK_HOME")
+         .or_else(|_| env::var("ANDROID_NDK_ROOT"))

--- a/patches/webrtc-sys-build_hermetic_scratch.patch
+++ b/patches/webrtc-sys-build_hermetic_scratch.patch
@@ -19,7 +19,7 @@ index 3316604..fcdd7c7 100644
 +    let dir = scratch_dir();
      // temporary fix to avoid github workflow issue
      fs::create_dir_all(&dir).context("Failed to create scratch_path")?;
-@@ -223,6 +227,10 @@ pub fn download_webrtc() -> Result<()> {
+@@ -231,6 +235,10 @@ pub fn download_webrtc() -> Result<()> {
      Ok(())
  }
  
@@ -27,6 +27,6 @@ index 3316604..fcdd7c7 100644
 +    PathBuf::from(env::var("OUT_DIR").unwrap()).join(SCRATH_PATH)
 +}
 +
- fn android_ndk_toolchain() -> Result<path::PathBuf> {
+ pub fn android_ndk_toolchain() -> Result<path::PathBuf> {
      let ndk_home = env::var("ANDROID_NDK_HOME")
          .or_else(|_| env::var("ANDROID_NDK_ROOT"))

--- a/patches/webrtc-sys-build_hermetic_scratch.patch
+++ b/patches/webrtc-sys-build_hermetic_scratch.patch
@@ -1,8 +1,8 @@
 diff --git a/src/lib.rs b/src/lib.rs
-index 3316604..fcdd7c7 100644
+index a240dd6..6e64dfd 100644
 --- a/src/lib.rs
 +++ b/src/lib.rs
-@@ -84,7 +84,7 @@ pub fn custom_dir() -> Option<path::PathBuf> {
+@@ -89,7 +89,7 @@ pub fn custom_dir() -> Option<path::PathBuf> {
  /// across multiple crates without dependencies constraints
  /// This also has the benefit of not re-downloading the binaries for each crate
  pub fn prebuilt_dir() -> path::PathBuf {
@@ -11,7 +11,7 @@ index 3316604..fcdd7c7 100644
      path::Path::new(&target_dir).join(format!(
          "livekit/{}-{}/{}",
          webrtc_triple(),
-@@ -197,8 +197,12 @@ pub fn configure_jni_symbols() -> Result<()> {
+@@ -197,7 +197,7 @@ pub fn configure_jni_symbols() -> Result<()> {
  }
  
  pub fn download_webrtc() -> Result<()> {
@@ -19,7 +19,8 @@ index 3316604..fcdd7c7 100644
 +    let dir = scratch_dir();
      // temporary fix to avoid github workflow issue
      fs::create_dir_all(&dir).context("Failed to create scratch_path")?;
-@@ -231,6 +235,10 @@ pub fn download_webrtc() -> Result<()> {
+     let flock = File::create(dir.join(".lock"))
+@@ -233,6 +233,10 @@ pub fn download_webrtc() -> Result<()> {
      Ok(())
  }
  
@@ -28,5 +29,5 @@ index 3316604..fcdd7c7 100644
 +}
 +
  pub fn android_ndk_toolchain() -> Result<path::PathBuf> {
-     let ndk_home = env::var("ANDROID_NDK_HOME")
-         .or_else(|_| env::var("ANDROID_NDK_ROOT"))
+     let host_os = host_os();
+ 

--- a/patches/webrtc-sys_hermetic_darwin_sysroot.patch
+++ b/patches/webrtc-sys_hermetic_darwin_sysroot.patch
@@ -6,6 +6,10 @@ index 3b4a24a..6aa06ff 100644
 -use std::path::Path;
 +use std::fs;
 +use std::path::Path;
+@@ -28,0 +30,3 @@
++    // Keep cxx-build inside Bazel's per-action output tree instead of the
++    // scratch crate's compile-time OUT_DIR from whichever machine built it.
++    env::set_var("CARGO_TARGET_DIR", env::var_os("OUT_DIR").unwrap());
 @@ -118,1 +119,9 @@
 -    println!("cargo:rustc-link-search=native={}", webrtc_lib.to_str().unwrap());
 +    let webrtc_link_lib = if env::var_os("WEBRTC_SYS_LINK_OUT_DIR").is_some() {


### PR DESCRIPTION
## Problem

Local Bazel builds read from the shared BuildBuddy cache and currently also upload local action results by default. We reproduced the earlier cache-pollution failure where a local `bazel build //codex-rs/cli:codex` reused a cached Rust build-script artifact containing another developer's absolute Bazel sandbox path, then failed locally.

Reproduced failure:

```text
cxxbridge error: Failed to create directory `/Users/anp/Library/Caches/bazel/_bazel_anp/.../external/rules_rs++crate+crates__scratch-1.0.9/_bs.out_dir/cxxbridge/rust`

Caused by:
    Operation not permitted (os error 1)
```

This matches the prior April 2026 incident discussed in Slack and the earlier closed attempt in https://github.com/openai/codex/pull/17743, where the same failure appeared with `/Users/neil/...`.

## Root Cause

Two issues combine here:

1. Local Bazel runs are allowed to upload local action results into the shared BuildBuddy cache by default.
2. `webrtc-sys` / `webrtc-sys-build` use `cxx-build` and `scratch` in a way that can bake a compiling machine's Bazel sandbox `OUT_DIR` into cached build-script artifacts. When another machine reuses that artifact, downstream build-script work can try to write into the foreign `/Users/...` path.

## Fix

- Keep local shared-cache reads enabled, but default local builds to `--noremote_upload_local_results`.
- Re-enable `--remote_upload_local_results` only under the existing `remote` config, so CI/RBE-backed builds remain cache writers.
- Patch `webrtc-sys` so `cxx-build` uses Bazel's per-action `OUT_DIR` as `CARGO_TARGET_DIR` instead of falling back to `scratch::path("cxxbridge")`.
- Patch `webrtc-sys-build` so its WebRTC scratch/download path also lives under the current action `OUT_DIR` instead of `scratch::path(...)`.

This intentionally blocks **local-produced** remote cache uploads, not CI/BuildBuddy ones. CI paths such as `ci-linux`, `ci-macos`, and `ci-windows-cross` already include `--config=remote`, which re-enables remote uploads.

## Validation

- `bazel build --announce_rc --nobuild //codex-rs/cli:codex` shows inherited `--noremote_upload_local_results`.
- `bazel build --announce_rc --config=remote --nobuild //codex-rs/cli:codex` shows `common:remote` re-enables `--remote_upload_local_results`.
- After clearing damaged local Bazel/repo caches, local `bazel --noexperimental_remote_repo_contents_cache build --disk_cache= --bes_backend= --bes_results_url= //codex-rs/cli:codex` completed successfully on this branch.
- Successful clean proof: `15369 processes: 10146 remote cache hit, 5144 internal, 79 darwin-sandbox` (`99.2%` cacheable hit rate).
- Immediate warm rerun completed in `4.543s`.
