### PR TITLE
Persist local marketplace source on plugin install

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/plugin_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/plugin_list.rs
@@ -8,7 +8,9 @@ use app_test_support::to_response;
 use app_test_support::write_chatgpt_auth;
 use codex_app_server_protocol::JSONRPCResponse;
 use codex_app_server_protocol::PluginAuthPolicy;
+use codex_app_server_protocol::PluginInstallParams;
 use codex_app_server_protocol::PluginInstallPolicy;
+use codex_app_server_protocol::PluginInstallResponse;
 use codex_app_server_protocol::PluginInstalledParams;
 use codex_app_server_protocol::PluginInstalledResponse;
 use codex_app_server_protocol::PluginListMarketplaceKind;
@@ -213,6 +215,83 @@ enabled = true
 
     assert_eq!(response.marketplaces, Vec::new());
     assert_eq!(response.marketplace_load_errors, Vec::new());
+    Ok(())
+}
+
+#[tokio::test]
+async fn plugin_install_records_local_marketplace_for_projectless_installed_listing() -> Result<()>
+{
+    let codex_home = TempDir::new()?;
+    let repo_root = TempDir::new()?;
+    let plugin_root = repo_root.path().join("plugins/sales");
+    std::fs::create_dir_all(repo_root.path().join(".git"))?;
+    std::fs::create_dir_all(repo_root.path().join(".agents/plugins"))?;
+    std::fs::create_dir_all(plugin_root.join(".codex-plugin"))?;
+    write_plugins_enabled_config(codex_home.path())?;
+    let marketplace_path =
+        AbsolutePathBuf::try_from(repo_root.path().join(".agents/plugins/marketplace.json"))?;
+    std::fs::write(
+        marketplace_path.as_path(),
+        r#"{
+  "name": "oai-maintained-plugins",
+  "plugins": [
+    {
+      "name": "sales",
+      "source": {
+        "source": "local",
+        "path": "./plugins/sales"
+      }
+    }
+  ]
+}"#,
+    )?;
+    std::fs::write(
+        plugin_root.join(".codex-plugin/plugin.json"),
+        r#"{"name":"sales"}"#,
+    )?;
+
+    let mut mcp = McpProcess::new(codex_home.path()).await?;
+    timeout(DEFAULT_TIMEOUT, mcp.initialize()).await??;
+
+    let request_id = mcp
+        .send_plugin_install_request(PluginInstallParams {
+            marketplace_path: Some(marketplace_path),
+            remote_marketplace_name: None,
+            plugin_name: "sales".to_string(),
+        })
+        .await?;
+
+    let response: JSONRPCResponse = timeout(
+        DEFAULT_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+    let _: PluginInstallResponse = to_response(response)?;
+
+    let request_id = mcp
+        .send_plugin_installed_request(PluginInstalledParams {
+            cwds: None,
+            install_suggestion_plugin_names: None,
+        })
+        .await?;
+
+    let response: JSONRPCResponse = timeout(
+        DEFAULT_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+    let response: PluginInstalledResponse = to_response(response)?;
+
+    assert_eq!(response.marketplaces.len(), 1);
+    assert_eq!(response.marketplaces[0].name, "oai-maintained-plugins");
+    assert_eq!(
+        response.marketplaces[0]
+            .plugins
+            .iter()
+            .map(|plugin| (plugin.id.clone(), plugin.installed, plugin.enabled))
+            .collect::<Vec<_>>(),
+        vec![("sales@oai-maintained-plugins".to_string(), true, true)]
+    );
     Ok(())
 }
 

--- a/codex-rs/core-plugins/src/manager.rs
+++ b/codex-rs/core-plugins/src/manager.rs
@@ -31,6 +31,7 @@ use crate::marketplace::find_installable_marketplace_plugin;
 use crate::marketplace::find_marketplace_plugin;
 use crate::marketplace::list_marketplaces;
 use crate::marketplace::load_marketplace;
+use crate::marketplace::marketplace_root_dir;
 use crate::marketplace::plugin_interface_with_marketplace_category;
 use crate::marketplace_upgrade::ConfiguredMarketplaceUpgradeError;
 use crate::marketplace_upgrade::ConfiguredMarketplaceUpgradeOutcome;
@@ -49,10 +50,13 @@ use crate::store::PluginInstallResult as StorePluginInstallResult;
 use crate::store::PluginStore;
 use crate::store::PluginStoreError;
 use codex_analytics::AnalyticsEventsClient;
+use codex_config::CONFIG_TOML_FILE;
 use codex_config::ConfigLayerStack;
+use codex_config::MarketplaceConfigUpdate;
 use codex_config::PluginConfigEdit;
 use codex_config::apply_user_plugin_config_edits;
 use codex_config::clear_user_plugin;
+use codex_config::record_user_marketplace;
 use codex_config::set_user_plugin_enabled;
 use codex_config::types::PluginConfig;
 use codex_config::version_for_toml;
@@ -71,6 +75,8 @@ use codex_utils_absolute_path::AbsolutePathBuf;
 use codex_utils_plugins::PluginSkillRoot;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::fs;
+use std::io::ErrorKind;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::RwLock;
@@ -817,7 +823,8 @@ impl PluginsManager {
             &request.plugin_name,
             self.restriction_product,
         )?;
-        self.install_resolved_plugin(resolved).await
+        self.install_resolved_plugin(&request.marketplace_path, resolved)
+            .await
     }
 
     pub async fn install_plugin_with_remote_sync(
@@ -840,11 +847,13 @@ impl PluginsManager {
         )
         .await
         .map_err(PluginInstallError::from)?;
-        self.install_resolved_plugin(resolved).await
+        self.install_resolved_plugin(&request.marketplace_path, resolved)
+            .await
     }
 
     async fn install_resolved_plugin(
         &self,
+        marketplace_path: &AbsolutePathBuf,
         resolved: ResolvedMarketplacePlugin,
     ) -> Result<PluginInstallOutcome, PluginInstallError> {
         let auth_policy = resolved.policy.authentication;
@@ -875,6 +884,43 @@ impl PluginsManager {
         })
         .await
         .map_err(PluginInstallError::join)??;
+
+        let marketplace_name = result.plugin_id.marketplace_name.clone();
+        if marketplace_name != OPENAI_CURATED_MARKETPLACE_NAME {
+            let config_path = self.codex_home.join(CONFIG_TOML_FILE);
+            let marketplace_already_configured = match fs::read_to_string(&config_path) {
+                Ok(config) => {
+                    let config: toml::Value = toml::from_str(&config)
+                        .map_err(|err| PluginInstallError::Config(anyhow::Error::from(err)))?;
+                    config
+                        .get("marketplaces")
+                        .and_then(toml::Value::as_table)
+                        .is_some_and(|marketplaces| marketplaces.contains_key(&marketplace_name))
+                }
+                Err(err) if err.kind() == ErrorKind::NotFound => false,
+                Err(err) => return Err(PluginInstallError::Config(anyhow::Error::from(err))),
+            };
+
+            if !marketplace_already_configured {
+                let marketplace_root = marketplace_root_dir(marketplace_path)?;
+                let marketplace_source = marketplace_root.as_path().display().to_string();
+                let last_updated =
+                    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+                record_user_marketplace(
+                    &self.codex_home,
+                    &marketplace_name,
+                    &MarketplaceConfigUpdate {
+                        last_updated: &last_updated,
+                        last_revision: None,
+                        source_type: "local",
+                        source: &marketplace_source,
+                        ref_name: None,
+                        sparse_paths: &[],
+                    },
+                )
+                .map_err(|err| PluginInstallError::Config(anyhow::Error::from(err)))?;
+            }
+        }
 
         set_user_plugin_enabled(
             &self.codex_home,

--- a/codex-rs/core-plugins/src/manager_tests.rs
+++ b/codex-rs/core-plugins/src/manager_tests.rs
@@ -1209,6 +1209,117 @@ async fn install_plugin_updates_config_with_relative_path_and_plugin_key() {
     let config = fs::read_to_string(tmp.path().join("config.toml")).unwrap();
     assert!(config.contains(r#"[plugins."sample-plugin@debug"]"#));
     assert!(config.contains("enabled = true"));
+    let config: Value = toml::from_str(&config).unwrap();
+    assert_eq!(
+        config["marketplaces"]["debug"]["source_type"].as_str(),
+        Some("local")
+    );
+    assert_eq!(
+        config["marketplaces"]["debug"]["source"].as_str(),
+        Some(repo_root.display().to_string().as_str())
+    );
+}
+
+#[tokio::test]
+async fn install_plugin_preserves_existing_marketplace_source_config() {
+    let tmp = tempfile::tempdir().unwrap();
+    let marketplace_root = marketplace_install_root(tmp.path()).join("debug");
+    fs::create_dir_all(marketplace_root.join(".agents/plugins")).unwrap();
+    write_plugin(&marketplace_root, "plugins/sample-plugin", "sample-plugin");
+    fs::write(
+        marketplace_root.join(".agents/plugins/marketplace.json"),
+        r#"{
+  "name": "debug",
+  "plugins": [
+    {
+      "name": "sample-plugin",
+      "source": {
+        "source": "local",
+        "path": "./plugins/sample-plugin"
+      }
+    }
+  ]
+}"#,
+    )
+    .unwrap();
+    write_file(
+        &tmp.path().join(CONFIG_TOML_FILE),
+        r#"[features]
+plugins = true
+
+[marketplaces.debug]
+last_updated = "2026-04-10T12:34:56Z"
+source_type = "git"
+source = "https://github.com/example/debug-marketplace.git"
+"#,
+    );
+
+    PluginsManager::new(tmp.path().to_path_buf())
+        .install_plugin(PluginInstallRequest {
+            plugin_name: "sample-plugin".to_string(),
+            marketplace_path: AbsolutePathBuf::try_from(
+                marketplace_root.join(".agents/plugins/marketplace.json"),
+            )
+            .unwrap(),
+        })
+        .await
+        .unwrap();
+
+    let config = fs::read_to_string(tmp.path().join(CONFIG_TOML_FILE)).unwrap();
+    let config: Value = toml::from_str(&config).unwrap();
+    assert_eq!(
+        config["marketplaces"]["debug"]["source_type"].as_str(),
+        Some("git")
+    );
+    assert_eq!(
+        config["marketplaces"]["debug"]["source"].as_str(),
+        Some("https://github.com/example/debug-marketplace.git")
+    );
+}
+
+#[tokio::test]
+async fn install_plugin_does_not_record_marketplace_when_materialization_fails() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo_root = tmp.path().join("repo");
+    fs::create_dir_all(repo_root.join(".git")).unwrap();
+    fs::create_dir_all(repo_root.join(".agents/plugins")).unwrap();
+    fs::write(
+        repo_root.join(".agents/plugins/marketplace.json"),
+        r#"{
+  "name": "debug",
+  "plugins": [
+    {
+      "name": "sample-plugin",
+      "source": {
+        "source": "local",
+        "path": "./missing-plugin"
+      }
+    }
+  ]
+}"#,
+    )
+    .unwrap();
+
+    let err = PluginsManager::new(tmp.path().to_path_buf())
+        .install_plugin(PluginInstallRequest {
+            plugin_name: "sample-plugin".to_string(),
+            marketplace_path: AbsolutePathBuf::try_from(
+                repo_root.join(".agents/plugins/marketplace.json"),
+            )
+            .unwrap(),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(
+        err.to_string().contains("missing plugin.json"),
+        "unexpected error: {err}"
+    );
+    let config = fs::read_to_string(tmp.path().join(CONFIG_TOML_FILE)).unwrap_or_default();
+    let config: Value =
+        toml::from_str(&config).unwrap_or_else(|_| Value::Table(Default::default()));
+    assert!(config.get("marketplaces").is_none());
+    assert!(config.get("plugins").is_none());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem
Installing a plugin from a local marketplace can leave Codex with only the plugin entry persisted, for example:

```toml
[plugins."sales@oai-maintained-plugins"]
enabled = true
```

If the marketplace itself is not also recorded in `config.toml`, project-scoped sessions can still discover the plugin through the project cwd, but projectless Chats have no cwd/catalog to use. After an app restart, `plugin/installed` can then omit the installed plugin from plain Chat @-mentions even though its skills still load from the plugin cache.

## Change
- When installing from a non-curated local marketplace, persist a matching `[marketplaces.<name>]` entry if one is not already configured.
- Preserve any existing marketplace source config instead of overwriting it, including git-backed marketplace entries.
- Keep the existing behavior that `plugin/installed` does not synthesize plugin rows from cache alone; it still requires a catalog, but install now records the catalog source needed for future projectless calls.

## User Impact
After installing Sales from the local `oai-maintained-plugins` marketplace and restarting the app, a plain Chats conversation can discover the Sales plugin in @-mentions. Previously this worked in project chats but not in projectless Chats.

## Tests
- [x] `just fmt`
- [x] `just test -p codex-core-plugins install_plugin_`
- [x] `just test -p codex-app-server plugin_install_records_local_marketplace_for_projectless_installed_listing`

Manual verification: installed Sales from `/Users/nm/code/oai-maintained-plugins`, restarted the app, and confirmed `@sales` is available from plain Chats.