### PR TITLE
fix(app-server-transport): discard stale pairing responses

### DIFF
--- a/codex-rs/app-server-transport/src/transport/remote_control/mod.rs
+++ b/codex-rs/app-server-transport/src/transport/remote_control/mod.rs
@@ -31,6 +31,8 @@ use std::io;
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tokio::sync::watch;
@@ -57,8 +59,23 @@ pub struct RemoteControlHandle {
     enabled_tx: Arc<watch::Sender<bool>>,
     status_tx: Arc<watch::Sender<RemoteControlStatusChangedNotification>>,
     state_db_available: bool,
-    pairing_client: Arc<StdMutex<Option<RemoteControlPairingClient>>>,
+    pairing: PairingClientState,
     auth_change_rx: Arc<StdMutex<watch::Receiver<u64>>>,
+}
+
+#[derive(Clone)]
+pub(super) struct PairingClientState {
+    client: Arc<StdMutex<Option<RemoteControlPairingClient>>>,
+    generation: Arc<AtomicU64>,
+}
+
+impl PairingClientState {
+    fn new() -> Self {
+        Self {
+            client: Arc::new(StdMutex::new(None)),
+            generation: Arc::new(AtomicU64::new(0)),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -115,7 +132,7 @@ impl RemoteControlHandle {
             *state = false;
             changed
         });
-        clear_pairing_client(&self.pairing_client);
+        clear_pairing_client(&self.pairing);
 
         let status = self.status();
         info!(
@@ -147,11 +164,15 @@ impl RemoteControlHandle {
                 "remote control pairing requires remote control to be enabled",
             ));
         }
+        if self.status().status != RemoteControlConnectionStatus::Connected {
+            return Err(Self::pairing_unavailable_error());
+        }
 
         let auth_change_revision = self.auth_change_revision();
         let pairing_client = {
             let mut pairing_client = self
-                .pairing_client
+                .pairing
+                .client
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             let current_pairing_client = pairing_client
@@ -174,6 +195,9 @@ impl RemoteControlHandle {
         if self.auth_change_revision() != auth_change_revision {
             return Err(Self::pairing_unavailable_error());
         }
+        if pairing_response.is_ok() && !self.pairing_client_is_current(&pairing_client) {
+            return Err(Self::pairing_unavailable_error());
+        }
         pairing_response
     }
 
@@ -190,6 +214,20 @@ impl RemoteControlHandle {
             io::ErrorKind::InvalidInput,
             "remote control pairing is unavailable until enrollment completes",
         )
+    }
+
+    fn pairing_client_is_current(&self, pairing_client: &RemoteControlPairingClient) -> bool {
+        *self.enabled_tx.borrow()
+            && self.status().status == RemoteControlConnectionStatus::Connected
+            && self
+                .pairing
+                .client
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .as_ref()
+                .is_some_and(|current_pairing_client| {
+                    current_pairing_client.generation() == pairing_client.generation()
+                })
     }
 
     fn publish_status(
@@ -239,10 +277,12 @@ fn remote_control_status_with_connection_status(
     }
 }
 
-fn clear_pairing_client(pairing_client: &Arc<StdMutex<Option<RemoteControlPairingClient>>>) {
-    *pairing_client
+fn clear_pairing_client(pairing: &PairingClientState) {
+    *pairing
+        .client
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+    pairing.generation.fetch_add(1, Ordering::Relaxed);
 }
 
 pub async fn start_remote_control(
@@ -267,8 +307,8 @@ pub async fn start_remote_control(
     };
 
     let (enabled_tx, enabled_rx) = watch::channel(initial_enabled);
-    let pairing_client = Arc::new(StdMutex::new(None));
-    let websocket_pairing_client = Arc::clone(&pairing_client);
+    let pairing = PairingClientState::new();
+    let websocket_pairing = pairing.clone();
     let auth_change_rx = Arc::new(StdMutex::new(auth_manager.auth_change_receiver()));
     let server_name = gethostname().to_string_lossy().trim().to_string();
     let remote_control_url = config.remote_control_url;
@@ -317,7 +357,7 @@ pub async fn start_remote_control(
             RemoteControlChannels {
                 transport_event_tx,
                 status_publisher,
-                pairing_client: websocket_pairing_client,
+                pairing: websocket_pairing,
             },
             shutdown_token,
             enabled_rx,
@@ -362,7 +402,7 @@ pub async fn start_remote_control(
             enabled_tx: Arc::new(enabled_tx),
             status_tx: Arc::new(status_tx),
             state_db_available,
-            pairing_client,
+            pairing,
             auth_change_rx,
         },
     ))

--- a/codex-rs/app-server-transport/src/transport/remote_control/pairing.rs
+++ b/codex-rs/app-server-transport/src/transport/remote_control/pairing.rs
@@ -20,6 +20,7 @@ pub(super) struct RemoteControlPairingClient {
     environment_id: String,
     expires_at: OffsetDateTime,
     auth_change_revision: u64,
+    generation: u64,
 }
 
 impl RemoteControlPairingClient {
@@ -30,6 +31,7 @@ impl RemoteControlPairingClient {
         environment_id: String,
         expires_at: OffsetDateTime,
         auth_change_revision: u64,
+        generation: u64,
     ) -> Self {
         Self {
             pairing_url: remote_control_target.pair_url.clone(),
@@ -38,11 +40,16 @@ impl RemoteControlPairingClient {
             environment_id,
             expires_at,
             auth_change_revision,
+            generation,
         }
     }
 
     pub(super) fn matches_auth_change_revision(&self, auth_change_revision: u64) -> bool {
         self.auth_change_revision == auth_change_revision
+    }
+
+    pub(super) fn generation(&self) -> u64 {
+        self.generation
     }
 
     pub(super) async fn start(

--- a/codex-rs/app-server-transport/src/transport/remote_control/pairing_tests.rs
+++ b/codex-rs/app-server-transport/src/transport/remote_control/pairing_tests.rs
@@ -94,19 +94,7 @@ async fn start_remote_control_pairing_uses_server_token_and_maps_response() {
             .await
             .expect("response should write");
     });
-    let client = RemoteControlPairingClient::new(
-        &RemoteControlTarget {
-            websocket_url: "ws://unused".to_string(),
-            enroll_url: "http://unused".to_string(),
-            refresh_url: "http://unused".to_string(),
-            pair_url,
-        },
-        "remote-control-token".to_string(),
-        "server-id".to_string(),
-        "environment-id".to_string(),
-        OffsetDateTime::from_unix_timestamp(33_336_362_096).expect("future timestamp should parse"),
-        /*auth_change_revision*/ 0,
-    );
+    let client = pairing_client(pair_url);
 
     let response = client
         .start(StartRemoteControlPairingRequest { manual_code: true })
@@ -163,19 +151,7 @@ async fn start_remote_control_pairing_preserves_backend_error_context() {
             .await
             .expect("response should write");
     });
-    let client = RemoteControlPairingClient::new(
-        &RemoteControlTarget {
-            websocket_url: "ws://unused".to_string(),
-            enroll_url: "http://unused".to_string(),
-            refresh_url: "http://unused".to_string(),
-            pair_url,
-        },
-        "remote-control-token".to_string(),
-        "server-id".to_string(),
-        "environment-id".to_string(),
-        OffsetDateTime::from_unix_timestamp(33_336_362_096).expect("future timestamp should parse"),
-        /*auth_change_revision*/ 0,
-    );
+    let client = pairing_client(pair_url);
 
     let err = client
         .start(StartRemoteControlPairingRequest { manual_code: false })
@@ -204,6 +180,8 @@ async fn start_remote_control_pairing_rejects_expired_server_token() {
         "server-id".to_string(),
         "environment-id".to_string(),
         OffsetDateTime::from_unix_timestamp(0).expect("expired timestamp should parse"),
+        /*auth_change_revision*/ 0,
+        /*generation*/ 0,
     );
 
     let err = client
@@ -262,18 +240,7 @@ async fn start_remote_control_pairing_rejects_mismatched_enrollment() {
             .await
             .expect("response should write");
     });
-    let client = RemoteControlPairingClient::new(
-        &RemoteControlTarget {
-            websocket_url: "ws://unused".to_string(),
-            enroll_url: "http://unused".to_string(),
-            refresh_url: "http://unused".to_string(),
-            pair_url,
-        },
-        "remote-control-token".to_string(),
-        "server-id".to_string(),
-        "environment-id".to_string(),
-        OffsetDateTime::from_unix_timestamp(33_336_362_096).expect("future timestamp should parse"),
-    );
+    let client = pairing_client(pair_url);
 
     let err = client
         .start(StartRemoteControlPairingRequest { manual_code: false })
@@ -286,4 +253,21 @@ async fn start_remote_control_pairing_rejects_mismatched_enrollment() {
         err.to_string(),
         "remote control pairing returned mismatched enrollment: expected server_id=server-id, environment_id=environment-id; got server_id=other-server-id, environment_id=other-environment-id"
     );
+}
+
+fn pairing_client(pair_url: String) -> RemoteControlPairingClient {
+    RemoteControlPairingClient::new(
+        &RemoteControlTarget {
+            websocket_url: "ws://unused".to_string(),
+            enroll_url: "http://unused".to_string(),
+            refresh_url: "http://unused".to_string(),
+            pair_url,
+        },
+        "remote-control-token".to_string(),
+        "server-id".to_string(),
+        "environment-id".to_string(),
+        OffsetDateTime::from_unix_timestamp(33_336_362_096).expect("future timestamp should parse"),
+        /*auth_change_revision*/ 0,
+        /*generation*/ 0,
+    )
 }

--- a/codex-rs/app-server-transport/src/transport/remote_control/tests.rs
+++ b/codex-rs/app-server-transport/src/transport/remote_control/tests.rs
@@ -151,12 +151,16 @@ fn remote_control_handle_with_pairing_client(
         "env_test".to_string(),
         OffsetDateTime::from_unix_timestamp(33_336_362_096).expect("future timestamp should parse"),
         /*auth_change_revision*/ 0,
+        /*generation*/ 0,
     ))));
     RemoteControlHandle {
         enabled_tx: Arc::new(enabled_tx),
         status_tx: Arc::new(status_tx),
         state_db_available: true,
-        pairing_client,
+        pairing: PairingClientState {
+            client: pairing_client,
+            generation: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+        },
         auth_change_rx: Arc::new(StdMutex::new(auth_change_rx)),
     }
 }
@@ -1044,6 +1048,49 @@ async fn remote_control_handle_discards_pairing_response_after_auth_change() {
             .await
             .expect("pairing task should join")
             .expect_err("stale pairing response should be discarded")
+            .to_string(),
+        "remote control pairing is unavailable until enrollment completes"
+    );
+}
+
+#[tokio::test]
+async fn remote_control_handle_discards_pairing_response_after_disable() {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("listener should bind");
+    let remote_control_url = remote_control_url_for_listener(&listener);
+    let remote_handle = remote_control_handle_with_pairing_client(
+        &remote_control_url,
+        watch::channel(/*init*/ 0u64).1,
+    );
+    let pairing_task = tokio::spawn({
+        let remote_handle = remote_handle.clone();
+        async move {
+            remote_handle
+                .start_pairing(RemoteControlPairingStartParams::default())
+                .await
+        }
+    });
+
+    let pairing_request = accept_http_request(&listener).await;
+    remote_handle.disable();
+    respond_with_json(
+        pairing_request.stream,
+        json!({
+            "pairing_code": "stale-pairing-code",
+            "manual_pairing_code": "ABCD-EFGH",
+            "server_id": "srv_e_test",
+            "environment_id": "env_test",
+            "expires_at": "3026-05-22T12:34:56Z",
+        }),
+    )
+    .await;
+
+    assert_eq!(
+        pairing_task
+            .await
+            .expect("pairing task should join")
+            .expect_err("disabled remote control should discard pairing response")
             .to_string(),
         "remote control pairing is unavailable until enrollment completes"
     );

--- a/codex-rs/app-server-transport/src/transport/remote_control/websocket.rs
+++ b/codex-rs/app-server-transport/src/transport/remote_control/websocket.rs
@@ -1,3 +1,4 @@
+use super::PairingClientState;
 use crate::transport::TransportEvent;
 use crate::transport::remote_control::client_tracker::ClientTracker;
 use crate::transport::remote_control::client_tracker::REMOTE_CONTROL_IDLE_SWEEP_INTERVAL;
@@ -41,7 +42,7 @@ use std::collections::VecDeque;
 use std::io;
 use std::io::ErrorKind;
 use std::sync::Arc;
-use std::sync::Mutex as StdMutex;
+use std::sync::atomic::Ordering;
 use tokio::net::TcpStream;
 use tokio::sync::Mutex;
 use tokio::sync::mpsc;
@@ -254,7 +255,7 @@ pub(crate) struct RemoteControlWebsocket {
     enrollment: Option<RemoteControlEnrollment>,
     auth_recovery: UnauthorizedRecovery,
     auth_change_rx: watch::Receiver<u64>,
-    pairing_client: Arc<StdMutex<Option<RemoteControlPairingClient>>>,
+    pairing: PairingClientState,
     client_tracker: Arc<Mutex<ClientTracker>>,
     state: Arc<Mutex<WebsocketState>>,
     server_event_rx: Arc<Mutex<mpsc::Receiver<super::QueuedServerEnvelope>>>,
@@ -294,7 +295,7 @@ enum ConnectionEndReason {
 pub(super) struct RemoteControlChannels {
     pub(super) transport_event_tx: mpsc::Sender<TransportEvent>,
     pub(super) status_publisher: RemoteControlStatusPublisher,
-    pub(super) pairing_client: Arc<StdMutex<Option<RemoteControlPairingClient>>>,
+    pub(super) pairing: PairingClientState,
 }
 
 #[derive(Clone)]
@@ -411,7 +412,7 @@ impl RemoteControlWebsocket {
             enrollment: None,
             auth_recovery,
             auth_change_rx,
-            pairing_client: channels.pairing_client,
+            pairing: channels.pairing,
             client_tracker: Arc::new(Mutex::new(client_tracker)),
             state: Arc::new(Mutex::new(WebsocketState {
                 outbound_buffer,
@@ -619,7 +620,7 @@ impl RemoteControlWebsocket {
                     &mut self.enrollment,
                     connect_options,
                     &self.status_publisher,
-                    &self.pairing_client,
+                    &self.pairing,
                 ) => connect_result,
             };
 
@@ -750,7 +751,7 @@ impl RemoteControlWebsocket {
             }
             _ = join_set.join_next() => ConnectionEndReason::ConnectionWorkerStopped,
         };
-        clear_pairing_client(&self.pairing_client);
+        clear_pairing_client(&self.pairing);
         shutdown_token.cancel();
 
         Self::join_connection_workers(&mut join_set, REMOTE_CONTROL_CONNECTION_SHUTDOWN_TIMEOUT)
@@ -1247,7 +1248,7 @@ pub(super) async fn connect_remote_control_websocket(
     enrollment: &mut Option<RemoteControlEnrollment>,
     connect_options: RemoteControlConnectOptions<'_>,
     status_publisher: &RemoteControlStatusPublisher,
-    pairing_client: &Arc<StdMutex<Option<RemoteControlPairingClient>>>,
+    pairing: &PairingClientState,
 ) -> io::Result<(
     WebSocketStream<MaybeTlsStream<TcpStream>>,
     tungstenite::http::Response<()>,
@@ -1256,7 +1257,7 @@ pub(super) async fn connect_remote_control_websocket(
 
     let Some(state_db) = state_db else {
         *enrollment = None;
-        clear_pairing_client(pairing_client);
+        clear_pairing_client(pairing);
         return Err(io::Error::new(
             ErrorKind::NotFound,
             "remote control requires sqlite state db",
@@ -1270,7 +1271,7 @@ pub(super) async fn connect_remote_control_websocket(
             if err.kind() == ErrorKind::PermissionDenied {
                 *enrollment = None;
                 status_publisher.publish_environment_id(/*environment_id*/ None);
-                clear_pairing_client(pairing_client);
+                clear_pairing_client(pairing);
             }
             return Err(err);
         }
@@ -1287,7 +1288,7 @@ pub(super) async fn connect_remote_control_websocket(
         );
         *enrollment = None;
         status_publisher.publish_environment_id(/*environment_id*/ None);
-        clear_pairing_client(pairing_client);
+        clear_pairing_client(pairing);
     }
 
     if let Some(enrollment) = enrollment.as_ref() {
@@ -1365,7 +1366,7 @@ pub(super) async fn connect_remote_control_websocket(
                     connect_options.app_server_client_name,
                     enrollment,
                     status_publisher,
-                    pairing_client,
+                    pairing,
                 )
                 .await;
                 enroll_remote_control_server_if_missing(
@@ -1423,7 +1424,7 @@ pub(super) async fn connect_remote_control_websocket(
     match websocket_connect_result {
         Ok((websocket_stream, response)) => {
             set_pairing_client(
-                pairing_client,
+                pairing,
                 remote_control_target,
                 enrollment_ref,
                 auth_change_revision,
@@ -1431,7 +1432,7 @@ pub(super) async fn connect_remote_control_websocket(
             Ok((websocket_stream, response.map(|_| ())))
         }
         Err(err) => {
-            clear_pairing_client(pairing_client);
+            clear_pairing_client(pairing);
             match &err {
                 tungstenite::Error::Http(response) if response.status().as_u16() == 404 => {
                     info!(
@@ -1448,7 +1449,7 @@ pub(super) async fn connect_remote_control_websocket(
                         connect_options.app_server_client_name,
                         enrollment,
                         status_publisher,
-                        pairing_client,
+                        pairing,
                     )
                     .await;
                 }
@@ -1463,7 +1464,7 @@ pub(super) async fn connect_remote_control_websocket(
                             )
                         })?
                         .clear_server_token();
-                    clear_pairing_client(pairing_client);
+                    clear_pairing_client(pairing);
                     return Err(io::Error::other(format!(
                         "remote control websocket auth failed with HTTP {}; refreshing server token before reconnect",
                         response.status()
@@ -1488,7 +1489,7 @@ async fn clear_remote_control_enrollment(
     app_server_client_name: Option<&str>,
     enrollment: &mut Option<RemoteControlEnrollment>,
     status_publisher: &RemoteControlStatusPublisher,
-    pairing_client: &Arc<StdMutex<Option<RemoteControlPairingClient>>>,
+    pairing: &PairingClientState,
 ) {
     if let Err(clear_err) = update_persisted_remote_control_enrollment(
         Some(state_db),
@@ -1503,11 +1504,11 @@ async fn clear_remote_control_enrollment(
     }
     *enrollment = None;
     status_publisher.publish_environment_id(/*environment_id*/ None);
-    clear_pairing_client(pairing_client);
+    clear_pairing_client(pairing);
 }
 
 fn set_pairing_client(
-    pairing_client: &Arc<StdMutex<Option<RemoteControlPairingClient>>>,
+    pairing: &PairingClientState,
     remote_control_target: &RemoteControlTarget,
     enrollment: &RemoteControlEnrollment,
     auth_change_revision: u64,
@@ -1524,7 +1525,12 @@ fn set_pairing_client(
             "remote control pairing is unavailable until enrollment completes",
         )
     })?;
-    *pairing_client
+    let generation = pairing
+        .generation
+        .fetch_add(1, Ordering::Relaxed)
+        .wrapping_add(1);
+    *pairing
+        .client
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner) =
         Some(RemoteControlPairingClient::new(
@@ -1534,6 +1540,7 @@ fn set_pairing_client(
             enrollment.environment_id.clone(),
             expires_at,
             auth_change_revision,
+            generation,
         ));
     Ok(())
 }
@@ -1726,8 +1733,8 @@ mod tests {
         }
     }
 
-    fn test_pairing_client() -> Arc<StdMutex<Option<RemoteControlPairingClient>>> {
-        Arc::new(StdMutex::new(None))
+    fn test_pairing() -> PairingClientState {
+        PairingClientState::new()
     }
 
     #[test]
@@ -1883,7 +1890,7 @@ mod tests {
         let mut enrollment = Some(remote_control_enrollment(Some(
             TEST_REMOTE_CONTROL_SERVER_TOKEN,
         )));
-        let pairing_client = test_pairing_client();
+        let pairing = test_pairing();
         let (status_publisher, status_rx) = remote_control_status_channel();
 
         let err = match connect_remote_control_websocket(
@@ -1902,7 +1909,7 @@ mod tests {
                 app_server_client_name: None,
             },
             &status_publisher,
-            &pairing_client,
+            &pairing,
         )
         .await
         {
@@ -1913,7 +1920,8 @@ mod tests {
         server_task.await.expect("server task should succeed");
         assert_eq!(err.to_string(), expected_error);
         assert!(
-            pairing_client
+            pairing
+                .client
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .is_none()
@@ -1945,7 +1953,7 @@ mod tests {
         let mut enrollment = Some(remote_control_enrollment(Some(
             TEST_REMOTE_CONTROL_SERVER_TOKEN,
         )));
-        let pairing_client = test_pairing_client();
+        let pairing = test_pairing();
         let (status_publisher, status_rx) = remote_control_status_channel();
 
         let server_task = tokio::spawn(async move {
@@ -1973,7 +1981,7 @@ mod tests {
                 app_server_client_name: None,
             },
             &status_publisher,
-            &pairing_client,
+            &pairing,
         )
         .await
         .expect_err("unauthorized response should fail the websocket connect");
@@ -1999,7 +2007,8 @@ mod tests {
             ))
         );
         assert_eq!(
-            pairing_client
+            pairing
+                .client
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .is_none(),
@@ -2066,7 +2075,7 @@ mod tests {
                 app_server_client_name: None,
             },
             &status_publisher,
-            &test_pairing_client(),
+            &test_pairing(),
         )
         .await
         .expect_err("unauthorized enrollment should fail the websocket connect");
@@ -2161,7 +2170,7 @@ mod tests {
                 app_server_client_name: None,
             },
             &status_publisher,
-            &test_pairing_client(),
+            &test_pairing(),
         )
         .await
         .expect_err("unauthorized refresh should fail the websocket connect");
@@ -2227,7 +2236,7 @@ mod tests {
                 app_server_client_name: None,
             },
             &status_publisher,
-            &test_pairing_client(),
+            &test_pairing(),
         )
         .await
         .expect_err("missing sqlite state db should fail remote control");
@@ -2278,7 +2287,7 @@ mod tests {
                 app_server_client_name: None,
             },
             &status_publisher,
-            &test_pairing_client(),
+            &test_pairing(),
         )
         .await
         .expect_err("missing auth should fail remote control");
@@ -2330,7 +2339,7 @@ mod tests {
                     RemoteControlChannels {
                         transport_event_tx,
                         status_publisher,
-                        pairing_client: test_pairing_client(),
+                        pairing: test_pairing(),
                     },
                     shutdown_token,
                     enabled_rx,


### PR DESCRIPTION
## Summary
- bind pairing responses to the live pairing client generation
- stacked on `codex/remote-control-pairing-refresh-in-place`

## Test Plan
- `RUSTUP_TOOLCHAIN=1.95.0 just fmt`
- `CARGO_TARGET_DIR=/Users/apanasenko/code/codex/codex-rs/target RUSTUP_TOOLCHAIN=1.95.0 just test -p codex-app-server-transport`
- `CARGO_TARGET_DIR=/Users/apanasenko/code/codex/codex-rs/target RUSTUP_TOOLCHAIN=1.95.0 just fix -p codex-app-server-transport`