### PR TITLE
Materialize compressed rollouts before append

### DIFF
--- a/codex-rs/rollout/Cargo.toml
+++ b/codex-rs/rollout/Cargo.toml
@@ -27,6 +27,7 @@ codex-utils-string = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+tempfile = { workspace = true }
 time = { workspace = true, features = [
     "formatting",
     "local-offset",
@@ -48,4 +49,3 @@ zstd = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
-tempfile = { workspace = true }

--- a/codex-rs/rollout/src/compression.rs
+++ b/codex-rs/rollout/src/compression.rs
@@ -1,12 +1,25 @@
+use std::ffi::OsStr;
+use std::fs::File;
+use std::fs::Permissions;
 use std::io;
 use std::io::Read;
+use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
+
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 
 const COMPRESSED_SUFFIX: &str = ".zst";
 const MAX_NOT_FOUND_RETRIES: usize = 3;
 const OPEN_ROLLOUT_LINE_READER_RETRY_DELAY: Duration = Duration::from_millis(50);
+const TEMP_SUFFIX: &str = ".tmp";
+static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// Returns the modified time for the existing plain or compressed rollout file.
 pub(crate) async fn file_modified_time(path: &Path) -> io::Result<Option<time::OffsetDateTime>> {
@@ -36,8 +49,71 @@ pub async fn open_rollout_line_reader(path: &Path) -> io::Result<RolloutLineRead
 }
 
 /// Returns the compressed `.jsonl.zst` path for a rollout path.
+#[cfg(test)]
 pub(crate) fn compressed_rollout_path(path: &Path) -> PathBuf {
     path::compressed_rollout_path(path)
+}
+
+/// Materializes a compressed rollout back to plain `.jsonl` for async append paths.
+pub(crate) async fn materialize_rollout_for_append(path: &Path) -> io::Result<PathBuf> {
+    let path = path.to_path_buf();
+    tokio::task::spawn_blocking(move || materialize_rollout_for_append_blocking(path.as_path()))
+        .await
+        .map_err(io::Error::other)?
+}
+
+/// Materializes a compressed rollout back to plain `.jsonl` for blocking append paths.
+pub(crate) fn materialize_rollout_for_append_blocking(path: &Path) -> io::Result<PathBuf> {
+    let plain_path = plain_rollout_path(path);
+    if plain_path.exists() {
+        return Ok(plain_path);
+    }
+    let compressed_path = path::compressed_rollout_path(plain_path.as_path());
+    if !compressed_path.exists() {
+        return Ok(plain_path);
+    }
+
+    let temp_path = temp_path_for(plain_path.as_path(), "decompress");
+    if let Some(parent) = plain_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let result: io::Result<()> = (|| {
+        let permissions = std::fs::metadata(compressed_path.as_path())?.permissions();
+        {
+            let input = File::open(compressed_path.as_path())?;
+            let mut decoder = zstd::stream::read::Decoder::new(input)?;
+            let mut output = create_file_with_permissions(temp_path.as_path(), &permissions)?;
+            io::copy(&mut decoder, &mut output)?;
+            output.flush()?;
+            output.sync_all()?;
+        }
+        match std::fs::hard_link(temp_path.as_path(), plain_path.as_path()) {
+            Ok(()) => {}
+            Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {}
+            Err(_) => persist_temp_file_noclobber(temp_path.as_path(), plain_path.as_path())?,
+        }
+        let _ = std::fs::remove_file(temp_path.as_path());
+        match std::fs::remove_file(compressed_path.as_path()) {
+            Ok(()) => {}
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+            Err(err) => return Err(err),
+        }
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(temp_path.as_path());
+    }
+    result?;
+    Ok(plain_path)
+}
+
+fn persist_temp_file_noclobber(temp_path: &Path, destination: &Path) -> io::Result<()> {
+    let temp_path = tempfile::TempPath::try_from_path(temp_path)?;
+    match temp_path.persist_noclobber(destination) {
+        Ok(()) => Ok(()),
+        Err(err) if err.error.kind() == io::ErrorKind::AlreadyExists => Ok(()),
+        Err(err) => Err(err.error),
+    }
 }
 
 /// Returns the plain `.jsonl` path for a plain or compressed rollout path.
@@ -245,6 +321,40 @@ mod reader {
             inner: RolloutLineReaderInner::Plain(tokio::io::BufReader::new(file).lines()),
         })
     }
+}
+
+#[cfg(unix)]
+fn create_file_with_permissions(path: &Path, permissions: &Permissions) -> io::Result<File> {
+    let file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(permissions.mode() & 0o7777)
+        .open(path)?;
+    file.set_permissions(permissions.clone())?;
+    Ok(file)
+}
+
+#[cfg(not(unix))]
+fn create_file_with_permissions(path: &Path, permissions: &Permissions) -> io::Result<File> {
+    let file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)?;
+    file.set_permissions(permissions.clone())?;
+    Ok(file)
+}
+
+fn temp_path_for(path: &Path, operation: &str) -> PathBuf {
+    let mut file_name = path
+        .file_name()
+        .map(OsStr::to_os_string)
+        .unwrap_or_else(|| OsStr::new("rollout").to_os_string());
+    let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    file_name.push(format!(
+        ".{operation}.{}.{counter}{TEMP_SUFFIX}",
+        std::process::id()
+    ));
+    path.with_file_name(file_name)
 }
 
 #[cfg(test)]

--- a/codex-rs/rollout/src/compression_tests.rs
+++ b/codex-rs/rollout/src/compression_tests.rs
@@ -1,4 +1,6 @@
 use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 
 use codex_protocol::ThreadId;
 use codex_protocol::protocol::EventMsg;
@@ -14,6 +16,7 @@ use uuid::Uuid;
 
 use super::*;
 use crate::RolloutRecorder;
+use crate::append_rollout_item_to_path;
 
 #[tokio::test]
 async fn load_rollout_items_reads_compressed_rollout() -> anyhow::Result<()> {
@@ -64,6 +67,93 @@ fn rollout_file_from_path_hides_compressed_sibling_when_plain_exists() -> anyhow
         RolloutFile::from_path(compressed_rollout_path(&rollout_path)),
         None
     );
+    Ok(())
+}
+
+#[tokio::test]
+async fn append_rollout_item_materializes_compressed_rollout() -> anyhow::Result<()> {
+    let home = TempDir::new()?;
+    let uuid = Uuid::from_u128(2);
+    let thread_id = ThreadId::from_string(&uuid.to_string())?;
+    let rollout_path = rollout_path(home.path(), "2025-01-03T12-00-00", uuid);
+    write_rollout(&rollout_path, thread_id, "hello before append")?;
+    compress_now(&rollout_path)?;
+
+    append_rollout_item_to_path(
+        &rollout_path,
+        &RolloutItem::EventMsg(EventMsg::UserMessage(UserMessageEvent {
+            message: "hello after append".to_string(),
+            ..Default::default()
+        })),
+    )
+    .await?;
+
+    assert!(rollout_path.exists());
+    assert!(!compressed_rollout_path(&rollout_path).exists());
+    let (items, loaded_thread_id, parse_errors) =
+        RolloutRecorder::load_rollout_items(&rollout_path).await?;
+    assert_eq!(loaded_thread_id, Some(thread_id));
+    assert_eq!(parse_errors, 0);
+    assert_eq!(items.len(), 3);
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn append_materialization_preserves_compressed_rollout_permissions() -> anyhow::Result<()> {
+    let home = TempDir::new()?;
+    let uuid = Uuid::from_u128(6);
+    let thread_id = ThreadId::from_string(&uuid.to_string())?;
+    let rollout_path = rollout_path(home.path(), "2025-01-03T12-00-00", uuid);
+    write_rollout(&rollout_path, thread_id, "restricted transcript")?;
+    compress_now(&rollout_path)?;
+    let compressed_path = compressed_rollout_path(&rollout_path);
+    fs::set_permissions(&compressed_path, fs::Permissions::from_mode(0o600))?;
+
+    append_rollout_item_to_path(
+        &rollout_path,
+        &RolloutItem::EventMsg(EventMsg::UserMessage(UserMessageEvent {
+            message: "materialize restricted transcript".to_string(),
+            ..Default::default()
+        })),
+    )
+    .await?;
+
+    assert!(rollout_path.exists());
+    assert!(!compressed_path.exists());
+    assert_eq!(
+        fs::metadata(&rollout_path)?.permissions().mode() & 0o777,
+        0o600
+    );
+    Ok(())
+}
+
+#[test]
+fn persist_temp_file_noclobber_installs_completed_temp() -> anyhow::Result<()> {
+    let home = TempDir::new()?;
+    let temp_path = home.path().join("rollout.jsonl.tmp");
+    let destination = home.path().join("rollout.jsonl");
+    fs::write(&temp_path, "completed rollout")?;
+
+    persist_temp_file_noclobber(&temp_path, &destination)?;
+
+    assert!(!temp_path.exists());
+    assert_eq!(fs::read_to_string(destination)?, "completed rollout");
+    Ok(())
+}
+
+#[test]
+fn persist_temp_file_noclobber_does_not_replace_existing_destination() -> anyhow::Result<()> {
+    let home = TempDir::new()?;
+    let temp_path = home.path().join("rollout.jsonl.tmp");
+    let destination = home.path().join("rollout.jsonl");
+    fs::write(&temp_path, "candidate rollout")?;
+    fs::write(&destination, "existing rollout")?;
+
+    persist_temp_file_noclobber(&temp_path, &destination)?;
+
+    assert!(!temp_path.exists());
+    assert_eq!(fs::read_to_string(destination)?, "existing rollout");
     Ok(())
 }
 

--- a/codex-rs/rollout/src/compression_tests.rs
+++ b/codex-rs/rollout/src/compression_tests.rs
@@ -128,35 +128,6 @@ async fn append_materialization_preserves_compressed_rollout_permissions() -> an
     Ok(())
 }
 
-#[test]
-fn persist_temp_file_noclobber_installs_completed_temp() -> anyhow::Result<()> {
-    let home = TempDir::new()?;
-    let temp_path = home.path().join("rollout.jsonl.tmp");
-    let destination = home.path().join("rollout.jsonl");
-    fs::write(&temp_path, "completed rollout")?;
-
-    persist_temp_file_noclobber(&temp_path, &destination)?;
-
-    assert!(!temp_path.exists());
-    assert_eq!(fs::read_to_string(destination)?, "completed rollout");
-    Ok(())
-}
-
-#[test]
-fn persist_temp_file_noclobber_does_not_replace_existing_destination() -> anyhow::Result<()> {
-    let home = TempDir::new()?;
-    let temp_path = home.path().join("rollout.jsonl.tmp");
-    let destination = home.path().join("rollout.jsonl");
-    fs::write(&temp_path, "candidate rollout")?;
-    fs::write(&destination, "existing rollout")?;
-
-    persist_temp_file_noclobber(&temp_path, &destination)?;
-
-    assert!(!temp_path.exists());
-    assert_eq!(fs::read_to_string(destination)?, "existing rollout");
-    Ok(())
-}
-
 #[tokio::test]
 async fn find_thread_path_by_id_handles_compressed_rollout_filenames() -> anyhow::Result<()> {
     let home = TempDir::new()?;

--- a/codex-rs/rollout/src/recorder.rs
+++ b/codex-rs/rollout/src/recorder.rs
@@ -695,17 +695,20 @@ impl RolloutRecorder {
 
                 (None, Some(log_file_info), path, Some(session_meta))
             }
-            RolloutRecorderParams::Resume { path } => (
-                Some(
-                    tokio::fs::OpenOptions::new()
-                        .append(true)
-                        .open(&path)
-                        .await?,
-                ),
-                None,
-                path,
-                None,
-            ),
+            RolloutRecorderParams::Resume { path } => {
+                let path = compression::materialize_rollout_for_append(path.as_path()).await?;
+                (
+                    Some(
+                        tokio::fs::OpenOptions::new()
+                            .append(true)
+                            .open(&path)
+                            .await?,
+                    ),
+                    None,
+                    path,
+                    None,
+                )
+            }
         };
 
         // Clone the cwd for the spawned task to collect git info asynchronously
@@ -1359,6 +1362,7 @@ fn precompute_log_file_info(
 }
 
 fn open_log_file(path: &Path) -> std::io::Result<File> {
+    let path = compression::materialize_rollout_for_append_blocking(path)?;
     let Some(parent) = path.parent() else {
         return Err(IoError::other(format!(
             "rollout path has no parent: {}",
@@ -1618,6 +1622,7 @@ pub async fn append_rollout_item_to_path(
     rollout_path: &Path,
     item: &RolloutItem,
 ) -> std::io::Result<()> {
+    let rollout_path = compression::materialize_rollout_for_append(rollout_path).await?;
     let file = tokio::fs::OpenOptions::new()
         .append(true)
         .open(rollout_path)

--- a/codex-rs/thread-store/src/local/update_thread_metadata.rs
+++ b/codex-rs/thread-store/src/local/update_thread_metadata.rs
@@ -68,13 +68,14 @@ pub(super) async fn update_thread_metadata(
     if live_writer::rollout_path(store, thread_id).await.is_ok() {
         live_writer::persist_thread(store, thread_id).await?;
     }
-    let resolved_rollout_path =
+    let mut resolved_rollout_path =
         resolve_rollout_path(store, thread_id, params.include_archived).await?;
     let name = patch.name;
     let git_info = patch.git_info;
     if let Some(memory_mode) = patch.memory_mode {
         apply_thread_memory_mode(resolved_rollout_path.path.as_path(), thread_id, memory_mode)
             .await?;
+        refresh_resolved_rollout_path(&mut resolved_rollout_path).await;
     }
 
     let state_db_ctx = store.state_db().await;
@@ -142,6 +143,7 @@ pub(super) async fn update_thread_metadata(
             memory_mode.as_deref(),
         )
         .await?;
+        refresh_resolved_rollout_path(&mut resolved_rollout_path).await;
         apply_thread_git_info(store, thread_id, sha, branch, origin_url).await?;
     }
 
@@ -170,6 +172,12 @@ pub(super) async fn update_thread_metadata(
         thread.git_info = git_info_from_parts(sha, branch, origin_url);
     }
     Ok(thread)
+}
+
+async fn refresh_resolved_rollout_path(resolved: &mut ResolvedRolloutPath) {
+    if let Some(path) = codex_rollout::existing_rollout_path(resolved.path.as_path()).await {
+        resolved.path = path;
+    }
 }
 
 async fn apply_metadata_update(


### PR DESCRIPTION
## Rollout compression stack

This stack splits #24941 into reviewable steps for local rollout compression. The design is intentionally staged:

1. Teach readers, listing, search, and lookup to understand compressed rollouts.
2. Make append and resume paths materialize compressed rollouts back to plain JSONL before writing.
3. Add a disabled-by-default worker that can compress cold archived rollouts behind `local_thread_store_compression`.

The key invariant is that writers append to plain `.jsonl`. A `.jsonl.zst` file is a cold/read representation; if a write is needed, the compressed file is materialized back to plain JSONL first. Readers prefer plain `.jsonl` when both forms exist and can fall back to the compressed sibling during transitions.

The worker is deliberately the last PR and remains behind an under-development feature flag. It currently scans only `archived_sessions`, not active `sessions`, because active sessions have the highest resume/append race risk. That means this stack does not yet compress most unarchived local history.

## Known race / follow-up

The remaining unresolved design question is writer/compressor coordination. Even for archived rollouts, a resume or metadata update can append while the worker is replacing the plain file with `.jsonl.zst`; the current double-stat checks narrow but do not fully eliminate the window where a writer has opened the plain file before unlink. Do not treat the worker PR as production-ready until we either:

- prevent append/resume paths from racing archived compression, or
- introduce a shared representation/append lock or equivalent coordination.

The first two PRs are useful independently: they make compressed rollouts readable and make append paths safely recover back to plain JSONL. The third PR isolates the worker behavior so that coordination issue is reviewable separately.

## Validation

Focused local validation for the stack includes:

- `just test -p codex-rollout`
- `just test -p codex-thread-store` where thread-store paths were touched
- `just test -p codex-features` for the feature flag slice
- `just bazel-lock-check` after dependency graph changes
- scoped `just fix -p ...` passes for changed crates

CI is still the source of truth for the full platform matrix.

## This PR in the stack

This is PR 2/3, based on #25087. It adds the write-side transition: recorder resume, blocking append opens, and raw append helpers materialize `.jsonl.zst` back to plain `.jsonl` before writing. It also preserves permissions and uses a no-clobber publish path so fallback materialization does not expose a partially copied plain rollout.

Stack order:

1. #25087: read compressed local rollouts.
2. This PR: materialize compressed rollouts before append.
3. #25089: add the disabled local compression worker.
