### PR TITLE
[codex] Update pnpm to 11.4.0

### DIFF
--- a/codex-cli/package.json
+++ b/codex-cli/package.json
@@ -18,5 +18,5 @@
     "url": "git+https://github.com/openai/codex.git",
     "directory": "codex-cli"
   },
-  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
+  "packageManager": "pnpm@11.4.0+sha512.f0febc7e37552ab485494a914241b338e0b3580b93d54ce31f00933015880863129038a1b4ae4e414a0ee63ac35bf21197e990172c4a68256450b5636310968f"
 }

--- a/codex-rs/responses-api-proxy/npm/package.json
+++ b/codex-rs/responses-api-proxy/npm/package.json
@@ -18,5 +18,5 @@
     "url": "git+https://github.com/openai/codex.git",
     "directory": "codex-rs/responses-api-proxy/npm"
   },
-  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
+  "packageManager": "pnpm@11.4.0+sha512.f0febc7e37552ab485494a914241b338e0b3580b93d54ce31f00933015880863129038a1b4ae4e414a0ee63ac35bf21197e990172c4a68256450b5636310968f"
 }

--- a/package.json
+++ b/package.json
@@ -8,29 +8,11 @@
     "write-hooks-schema": "cargo run --manifest-path ./codex-rs/Cargo.toml -p codex-hooks --bin write_hooks_schema_fixtures"
   },
   "devDependencies": {
-    "prettier": "^3.5.3"
-  },
-  "resolutions": {
-    "@modelcontextprotocol/sdk": "1.26.0",
-    "braces": "^3.0.3",
-    "flatted": "3.4.2",
-    "glob@10.4.5": "10.5.0",
-    "handlebars": "4.7.9",
-    "micromatch": "^4.0.8",
-    "minimatch@3.1.2": "3.1.4",
-    "minimatch@9.0.5": "9.0.7",
-    "path-to-regexp": "8.4.0",
-    "picomatch@2.3.1": "2.3.2",
-    "picomatch@4.0.3": "4.0.4",
-    "rollup": "4.59.0",
-    "semver": "^7.7.1"
-  },
-  "overrides": {
-    "punycode": "^2.3.1"
+    "prettier": "3.5.3"
   },
   "engines": {
     "node": ">=22",
-    "pnpm": ">=10.33.0"
+    "pnpm": "11.4.0"
   },
-  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
+  "packageManager": "pnpm@11.4.0+sha512.f0febc7e37552ab485494a914241b338e0b3580b93d54ce31f00933015880863129038a1b4ae4e414a0ee63ac35bf21197e990172c4a68256450b5636310968f"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,25 +6,26 @@ settings:
 
 overrides:
   '@modelcontextprotocol/sdk': 1.26.0
-  braces: ^3.0.3
+  braces: 3.0.3
   flatted: 3.4.2
   glob@10.4.5: 10.5.0
   handlebars: 4.7.9
-  micromatch: ^4.0.8
+  micromatch: 4.0.8
   minimatch@3.1.2: 3.1.4
   minimatch@9.0.5: 9.0.7
   path-to-regexp: 8.4.0
   picomatch@2.3.1: 2.3.2
   picomatch@4.0.3: 4.0.4
+  punycode: 2.3.1
   rollup: 4.59.0
-  semver: ^7.7.1
+  semver: 7.7.2
 
 importers:
 
   .:
     devDependencies:
       prettier:
-        specifier: ^3.5.3
+        specifier: 3.5.3
         version: 3.5.3
 
   codex-cli: {}
@@ -37,52 +38,52 @@ importers:
         specifier: 1.26.0
         version: 1.26.0(zod@3.25.76)
       '@types/jest':
-        specifier: ^29.5.14
+        specifier: 29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: ^20.19.18
+        specifier: 20.19.18
         version: 20.19.18
       eslint:
-        specifier: ^9.36.0
+        specifier: 9.36.0
         version: 9.36.0
       eslint-config-prettier:
-        specifier: ^9.1.2
+        specifier: 9.1.2
         version: 9.1.2(eslint@9.36.0)
       eslint-plugin-jest:
-        specifier: ^29.0.1
+        specifier: 29.0.1
         version: 29.0.1(@typescript-eslint/eslint-plugin@8.45.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0)(typescript@5.9.2))(eslint@9.36.0)(typescript@5.9.2))(eslint@9.36.0)(jest@29.7.0(@types/node@20.19.18)(ts-node@10.9.2(@types/node@20.19.18)(typescript@5.9.2)))(typescript@5.9.2)
       eslint-plugin-node-import:
-        specifier: ^1.0.5
+        specifier: 1.0.5
         version: 1.0.5(eslint@9.36.0)
       jest:
-        specifier: ^29.7.0
+        specifier: 29.7.0
         version: 29.7.0(@types/node@20.19.18)(ts-node@10.9.2(@types/node@20.19.18)(typescript@5.9.2))
       prettier:
-        specifier: ^3.6.2
+        specifier: 3.6.2
         version: 3.6.2
       ts-jest:
-        specifier: ^29.3.4
+        specifier: 29.4.4
         version: 29.4.4(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(esbuild@0.25.10)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.18)(ts-node@10.9.2(@types/node@20.19.18)(typescript@5.9.2)))(typescript@5.9.2)
       ts-jest-mock-import-meta:
-        specifier: ^1.3.1
+        specifier: 1.3.1
         version: 1.3.1(ts-jest@29.4.4(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(esbuild@0.25.10)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.18)(ts-node@10.9.2(@types/node@20.19.18)(typescript@5.9.2)))(typescript@5.9.2))
       ts-node:
-        specifier: ^10.9.2
+        specifier: 10.9.2
         version: 10.9.2(@types/node@20.19.18)(typescript@5.9.2)
       tsup:
-        specifier: ^8.5.0
-        version: 8.5.0(postcss@8.5.6)(typescript@5.9.2)(yaml@2.8.1)
+        specifier: 8.5.0
+        version: 8.5.0(typescript@5.9.2)
       typescript:
-        specifier: ^5.9.2
+        specifier: 5.9.2
         version: 5.9.2
       typescript-eslint:
-        specifier: ^8.45.0
+        specifier: 8.45.0
         version: 8.45.0(eslint@9.36.0)(typescript@5.9.2)
       zod:
-        specifier: ^3.24.2
+        specifier: 3.25.76
         version: 3.25.76
       zod-to-json-schema:
-        specifier: ^3.24.6
+        specifier: 3.24.6
         version: 3.24.6(zod@3.25.76)
 
 packages:
@@ -1450,7 +1451,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -1897,11 +1898,6 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -2053,10 +2049,6 @@ packages:
       yaml:
         optional: true
 
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
-    engines: {node: ^10 || ^12 || >=14}
-
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -2089,10 +2081,6 @@ packages:
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
-
-  qs@6.14.0:
-    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
-    engines: {node: '>=0.6'}
 
   qs@6.15.1:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
@@ -2220,10 +2208,6 @@ packages:
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
-
-  source-map-js@1.2.1:
-    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
-    engines: {node: '>=0.10.0'}
 
   source-map-support@0.5.13:
     resolution: {integrity: sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==}
@@ -2520,11 +2504,6 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
-
-  yaml@2.8.1:
-    resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
-    engines: {node: '>= 14.6'}
-    hasBin: true
 
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
@@ -3879,7 +3858,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.14.0
+      qs: 6.15.1
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.0
@@ -4612,9 +4591,6 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.11:
-    optional: true
-
   natural-compare@1.4.0: {}
 
   negotiator@1.0.0: {}
@@ -4726,19 +4702,9 @@ snapshots:
       mlly: 1.8.0
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(postcss@8.5.6)(yaml@2.8.1):
+  postcss-load-config@6.0.1:
     dependencies:
       lilconfig: 3.1.3
-    optionalDependencies:
-      postcss: 8.5.6
-      yaml: 2.8.1
-
-  postcss@8.5.6:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-    optional: true
 
   prelude-ls@1.2.1: {}
 
@@ -4765,10 +4731,6 @@ snapshots:
   punycode@2.3.1: {}
 
   pure-rand@6.1.0: {}
-
-  qs@6.14.0:
-    dependencies:
-      side-channel: 1.1.0
 
   qs@6.15.1:
     dependencies:
@@ -4931,9 +4893,6 @@ snapshots:
 
   slash@3.0.0: {}
 
-  source-map-js@1.2.1:
-    optional: true
-
   source-map-support@0.5.13:
     dependencies:
       buffer-from: 1.1.2
@@ -5090,7 +5049,7 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  tsup@8.5.0(postcss@8.5.6)(typescript@5.9.2)(yaml@2.8.1):
+  tsup@8.5.0(typescript@5.9.2):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.10)
       cac: 6.7.14
@@ -5101,7 +5060,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.6)(yaml@2.8.1)
+      postcss-load-config: 6.0.1
       resolve-from: 5.0.0
       rollup: 4.59.0
       source-map: 0.8.0-beta.0
@@ -5110,7 +5069,6 @@ snapshots:
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.5.6
       typescript: 5.9.2
     transitivePeerDependencies:
       - jiti
@@ -5218,9 +5176,6 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
-
-  yaml@2.8.1:
-    optional: true
 
   yargs-parser@21.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,10 +3,17 @@ packages:
   - codex-rs/responses-api-proxy/npm
   - sdk/typescript
 
-ignoredBuiltDependencies:
-  - esbuild
+# pnpm 11 reads project settings from pnpm-workspace.yaml rather than .npmrc.
+shamefullyHoist: true
+strictPeerDependencies: false
+nodeLinker: hoisted
+preferWorkspacePackages: true
+saveExact: true
+savePrefix: ''
 
 minimumReleaseAge: 10080
+minimumReleaseAgeStrict: true
+minimumReleaseAgeIgnoreMissingTime: false
 minimumReleaseAgeExclude: []
 
 blockExoticSubdeps: true
@@ -14,4 +21,21 @@ strictDepBuilds: true
 trustPolicy: no-downgrade
 trustPolicyIgnoreAfter: 10080
 trustPolicyExclude: []
-allowBuilds: {}
+allowBuilds:
+  esbuild: false
+
+overrides:
+  '@modelcontextprotocol/sdk': 1.26.0
+  braces: 3.0.3
+  flatted: 3.4.2
+  glob@10.4.5: 10.5.0
+  handlebars: 4.7.9
+  micromatch: 4.0.8
+  minimatch@3.1.2: 3.1.4
+  minimatch@9.0.5: 9.0.7
+  path-to-regexp: 8.4.0
+  picomatch@2.3.1: 2.3.2
+  picomatch@4.0.3: 4.0.4
+  punycode: 2.3.1
+  rollup: 4.59.0
+  semver: 7.7.2

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -45,23 +45,23 @@
     "prepare": "pnpm run build"
   },
   "devDependencies": {
-    "@modelcontextprotocol/sdk": "^1.24.0",
-    "@types/jest": "^29.5.14",
-    "@types/node": "^20.19.18",
-    "eslint": "^9.36.0",
-    "eslint-config-prettier": "^9.1.2",
-    "eslint-plugin-jest": "^29.0.1",
-    "eslint-plugin-node-import": "^1.0.5",
-    "jest": "^29.7.0",
-    "prettier": "^3.6.2",
-    "ts-jest": "^29.3.4",
-    "ts-jest-mock-import-meta": "^1.3.1",
-    "ts-node": "^10.9.2",
-    "tsup": "^8.5.0",
-    "typescript": "^5.9.2",
-    "typescript-eslint": "^8.45.0",
-    "zod": "^3.24.2",
-    "zod-to-json-schema": "^3.24.6"
+    "@modelcontextprotocol/sdk": "1.26.0",
+    "@types/jest": "29.5.14",
+    "@types/node": "20.19.18",
+    "eslint": "9.36.0",
+    "eslint-config-prettier": "9.1.2",
+    "eslint-plugin-jest": "29.0.1",
+    "eslint-plugin-node-import": "1.0.5",
+    "jest": "29.7.0",
+    "prettier": "3.6.2",
+    "ts-jest": "29.4.4",
+    "ts-jest-mock-import-meta": "1.3.1",
+    "ts-node": "10.9.2",
+    "tsup": "8.5.0",
+    "typescript": "5.9.2",
+    "typescript-eslint": "8.45.0",
+    "zod": "3.25.76",
+    "zod-to-json-schema": "3.24.6"
   },
-  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
+  "packageManager": "pnpm@11.4.0+sha512.f0febc7e37552ab485494a914241b338e0b3580b93d54ce31f00933015880863129038a1b4ae4e414a0ee63ac35bf21197e990172c4a68256450b5636310968f"
 }


### PR DESCRIPTION
## Summary
- Update all pnpm `packageManager` pins to pnpm 11.4.0 with the sha512 integrity suffix.
- Move pnpm v11 workspace policy into `pnpm-workspace.yaml`, including exact-save defaults, strict release-age/build-script policy, and exact overrides.
- Make package specs exact and refresh `pnpm-lock.yaml` with pnpm 11.4.0.

## Validation
- Downloaded the pnpm 11.4.0 tarball and verified its sha512 digest matches the `packageManager` pin.
- `node /private/tmp/codex-pnpm-11.4.0/package/bin/pnpm.cjs install --frozen-lockfile --lockfile-only`
- Exact tracked package spec check across `package.json` files and `pnpm-workspace.yaml` overrides.
- `git diff --check`