### PR TITLE
[exec-server] Kill dropped filesystem helpers

### DIFF
--- a/codex-rs/exec-server/src/fs_sandbox.rs
+++ b/codex-rs/exec-server/src/fs_sandbox.rs
@@ -298,6 +298,7 @@ fn spawn_command(
     command.stdin(std::process::Stdio::piped());
     command.stdout(std::process::Stdio::piped());
     command.stderr(std::process::Stdio::piped());
+    command.kill_on_drop(true);
     command.spawn().map_err(io_error)
 }
 


### PR DESCRIPTION
## Summary
- terminate sandbox filesystem helpers when the Tokio child handle is dropped

## Why
A sandbox filesystem helper can stall during process startup before reading stdin. If the owning async operation is cancelled or torn down, the spawned helper should not remain running as an orphaned process.

Setting `kill_on_drop(true)` gives the filesystem helper the cleanup behavior that Tokio child processes otherwise do not enable by default.

This intentionally does not add a timeout. It does not detect or recover an active hung file edit while the owning future remains alive. A more precise startup-health mechanism can be handled separately.

## Validation
- `just test -p codex-exec-server` (186 tests passed; benchmark smoke passed)
- `just fmt`
- `just fix -p codex-exec-server`
- `git diff --check`
