### PR TITLE
[codex] Support cmd.exe session env files

### DIFF
--- a/codex-rs/core/src/shell_env_file.rs
+++ b/codex-rs/core/src/shell_env_file.rs
@@ -7,6 +7,7 @@ use anyhow::Result;
 use anyhow::anyhow;
 use anyhow::bail;
 use codex_protocol::ThreadId;
+use codex_protocol::exec_output::bytes_to_string_smart;
 use codex_protocol::shell_environment::CLAUDE_ENV_FILE_ENV_VAR;
 use codex_protocol::shell_environment::CODEX_ENV_FILE_ENV_VAR;
 use codex_protocol::shell_environment::CODEX_THREAD_ID_ENV_VAR;
@@ -141,6 +142,7 @@ impl ShellEnvFile {
 enum ShellEnvCapture {
     Posix,
     PowerShell,
+    Cmd,
 }
 
 impl ShellEnvCapture {
@@ -148,7 +150,7 @@ impl ShellEnvCapture {
         match shell_type {
             ShellType::Zsh | ShellType::Bash | ShellType::Sh => Some(Self::Posix),
             ShellType::PowerShell => Some(Self::PowerShell),
-            ShellType::Cmd => None,
+            ShellType::Cmd => Some(Self::Cmd),
         }
     }
 
@@ -156,6 +158,7 @@ impl ShellEnvCapture {
         match self {
             Self::Posix => ".sh",
             Self::PowerShell => ".ps1",
+            Self::Cmd => ".cmd",
         }
     }
 
@@ -169,6 +172,7 @@ impl ShellEnvCapture {
                 POWERSHELL_DUMP_ENV_SCRIPT,
                 POWERSHELL_SOURCE_ENV_FILE_AND_DUMP_ENV_SCRIPT,
             ),
+            Self::Cmd => (CMD_DUMP_ENV_SCRIPT, CMD_SOURCE_ENV_FILE_AND_DUMP_ENV_SCRIPT),
         }
     }
 
@@ -201,6 +205,7 @@ impl ShellEnvCapture {
         match self {
             Self::Posix => vec!["-c", script],
             Self::PowerShell => vec!["-NoLogo", "-NoProfile", "-Command", script],
+            Self::Cmd => vec!["/d", "/c", script],
         }
     }
 
@@ -208,6 +213,7 @@ impl ShellEnvCapture {
         match self {
             Self::Posix => parse_posix_env_output(output),
             Self::PowerShell => parse_powershell_env_output(output),
+            Self::Cmd => Ok(parse_cmd_env_output(output)),
         }
     }
 }
@@ -248,6 +254,10 @@ Get-ChildItem Env: | Sort-Object Name | ForEach-Object {
 }
 ConvertTo-Json -InputObject $items -Compress -Depth 2"#;
 
+const CMD_DUMP_ENV_SCRIPT: &str = "set";
+
+const CMD_SOURCE_ENV_FILE_AND_DUMP_ENV_SCRIPT: &str = "if defined CODEX_ENV_FILE if exist \"%CODEX_ENV_FILE%\" call \"%CODEX_ENV_FILE%\" >nul 2>&1\r\nset";
+
 fn parse_posix_env_output(output: &[u8]) -> Result<HashMap<String, String>> {
     let mut env = HashMap::new();
     for entry in output.split(|byte| *byte == 0) {
@@ -276,6 +286,16 @@ fn parse_powershell_env_output(output: &[u8]) -> Result<HashMap<String, String>>
     let output: HashMap<String, String> =
         serde_json::from_str(output).context("failed to parse captured PowerShell environment")?;
     Ok(output)
+}
+
+fn parse_cmd_env_output(output: &[u8]) -> HashMap<String, String> {
+    bytes_to_string_smart(output)
+        .lines()
+        .filter_map(|line| {
+            let (key, value) = line.split_once('=')?;
+            (!key.is_empty()).then(|| (key.to_string(), value.to_string()))
+        })
+        .collect()
 }
 
 fn diff_env(

--- a/codex-rs/core/src/shell_env_file_tests.rs
+++ b/codex-rs/core/src/shell_env_file_tests.rs
@@ -114,14 +114,15 @@ fn shell_env_file_for_session_uses_powershell_script_suffix() -> Result<()> {
 }
 
 #[test]
-fn shell_env_file_for_session_skips_cmd() -> Result<()> {
-    let shell = Shell {
-        shell_type: ShellType::Cmd,
-        shell_path: PathBuf::from("cmd.exe"),
-        shell_snapshot: empty_shell_snapshot_receiver(),
-    };
+fn shell_env_file_for_session_uses_cmd_script_suffix() -> Result<()> {
+    let shell = test_cmd_shell();
+    let env_file = ShellEnvFile::for_session(ThreadId::new(), &shell)?
+        .expect("cmd should support a session env file");
 
-    assert!(ShellEnvFile::for_session(ThreadId::new(), &shell)?.is_none());
+    assert_eq!(
+        env_file.path().extension().and_then(|ext| ext.to_str()),
+        Some("cmd")
+    );
 
     Ok(())
 }
@@ -137,6 +138,18 @@ fn powershell_env_output_parser_accepts_json_object() -> Result<()> {
     );
 
     Ok(())
+}
+
+#[test]
+fn cmd_env_output_parser_accepts_set_output() {
+    assert_eq!(
+        parse_cmd_env_output(b"=C:=C:\\worktree\r\nEMPTY=\r\nONLY=one\r\nWITH_EQUALS=a=b\r\n"),
+        HashMap::from([
+            ("EMPTY".to_string(), "".to_string()),
+            ("ONLY".to_string(), "one".to_string()),
+            ("WITH_EQUALS".to_string(), "a=b".to_string()),
+        ])
+    );
 }
 
 #[cfg(windows)]
@@ -203,10 +216,80 @@ Remove-Item Env:REMOVED_BY_HOOK -ErrorAction SilentlyContinue
     Ok(())
 }
 
+#[cfg(windows)]
+#[tokio::test]
+async fn cmd_env_file_applies_exports_without_exposing_writable_path() -> Result<()> {
+    let env_file = ShellEnvFile::new(ThreadId::new(), ShellEnvCapture::Cmd)?;
+    let base_env = HashMap::from([
+        ("BASE".to_string(), "keep".to_string()),
+        (
+            CODEX_THREAD_ID_ENV_VAR.to_string(),
+            "real-thread".to_string(),
+        ),
+        ("REMOVED_BY_HOOK".to_string(), "remove-me".to_string()),
+    ]);
+    std::fs::write(
+        env_file.path(),
+        "\
+@echo off\r
+set CODEX_SESSION_START_TEST=from-session-start\r
+set CODEX_ENV_FILE=C:\\poison\r
+set CLAUDE_ENV_FILE=C:\\poison\r
+set CODEX_THREAD_ID=poisoned-thread\r
+set EXPLICIT_OVERRIDE=from-hook\r
+set REMOVED_BY_HOOK=\r
+",
+    )?;
+    let cwd = std::env::current_dir()?;
+    env_file
+        .capture_exports(&test_cmd_shell(), cwd.as_path(), &base_env)
+        .await?;
+
+    let mut env = base_env;
+    env.insert(
+        CODEX_ENV_FILE_ENV_VAR.to_string(),
+        env_file.path().display().to_string(),
+    );
+    env.insert(
+        CLAUDE_ENV_FILE_ENV_VAR.to_string(),
+        env_file.path().display().to_string(),
+    );
+    let explicit_env_overrides =
+        HashMap::from([("EXPLICIT_OVERRIDE".to_string(), "from-policy".to_string())]);
+
+    env_file.apply_exports(&mut env, &explicit_env_overrides);
+
+    assert_eq!(
+        env,
+        HashMap::from([
+            ("BASE".to_string(), "keep".to_string()),
+            (
+                "CODEX_SESSION_START_TEST".to_string(),
+                "from-session-start".to_string(),
+            ),
+            (
+                CODEX_THREAD_ID_ENV_VAR.to_string(),
+                "real-thread".to_string(),
+            ),
+            ("EXPLICIT_OVERRIDE".to_string(), "from-policy".to_string()),
+        ])
+    );
+
+    Ok(())
+}
+
 fn test_powershell_shell() -> Shell {
     Shell {
         shell_type: ShellType::PowerShell,
         shell_path: PathBuf::from("powershell.exe"),
+        shell_snapshot: empty_shell_snapshot_receiver(),
+    }
+}
+
+fn test_cmd_shell() -> Shell {
+    Shell {
+        shell_type: ShellType::Cmd,
+        shell_path: PathBuf::from("cmd.exe"),
         shell_snapshot: empty_shell_snapshot_receiver(),
     }
 }


### PR DESCRIPTION
# Why

Stacked on #24805.

That PR adds `CODEX_ENV_FILE` / `CLAUDE_ENV_FILE` support for POSIX shells and PowerShell. It intentionally punts on `cmd.exe` so its already-large diff stays reviewable.

# What

- create `.cmd` session env files when Command Prompt is the selected shell
- invoke the env file with `call` and capture the resulting environment with `set`
- decode native Command Prompt output with the existing smart shell-output decoder
- add focused parser coverage and a Windows-only end-to-end capture test

# Validation

- `just fmt`
- `cargo nextest run -p codex-core shell_env_file`
- `just fix -p codex-core`
- `git diff --check`
- `just argument-comment-lint -p codex-core` *(blocked: the pinned `nightly-2025-09-18` toolchain is Rust 1.92, while current `sqlx 0.9.0` requires Rust 1.94)*
