### PR TITLE
[core] Allow plugin guidance to drive app installs

### DIFF
--- a/codex-rs/core/src/plugins/render.rs
+++ b/codex-rs/core/src/plugins/render.rs
@@ -48,6 +48,18 @@ pub(crate) fn render_explicit_plugin_instructions(
         ));
     }
 
+    if !plugin.app_connector_ids.is_empty() {
+        lines.push(format!(
+            "- App IDs declared by this plugin, including templates: {}.",
+            plugin
+                .app_connector_ids
+                .iter()
+                .map(|connector_id| format!("`{}`", connector_id.0))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+
     if lines.len() == 1 {
         return None;
     }

--- a/codex-rs/core/src/plugins/render_tests.rs
+++ b/codex-rs/core/src/plugins/render_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use codex_plugin::AppConnectorId;
 use pretty_assertions::assert_eq;
 
 #[test]
@@ -20,4 +21,26 @@ fn render_plugins_section_includes_descriptions_and_skill_naming_guidance() {
     let expected = "<plugins_instructions>\n## Plugins\nA plugin is a local bundle of skills, MCP servers, and apps. Below is the list of plugins that are enabled and available in this session.\n### Available plugins\n- `sample`: inspect sample data\n### How to use plugins\n- Discovery: The list above is the plugins available in this session.\n- Skill naming: If a plugin contributes skills, those skill entries are prefixed with `plugin_name:` in the Skills list.\n- Trigger rules: If the user explicitly names a plugin, prefer capabilities associated with that plugin for that turn.\n- Relationship to capabilities: Plugins are not invoked directly. Use their underlying skills, MCP tools, and app tools to help solve the task.\n- Preference: When a relevant plugin is available, prefer using capabilities associated with that plugin over standalone capabilities that provide similar functionality.\n- Missing/blocked: If the user requests a plugin that is not listed above, or the plugin does not have relevant callable capabilities for the task, say so briefly and continue with the best fallback.\n</plugins_instructions>";
 
     assert_eq!(rendered, expected);
+}
+
+#[test]
+fn render_explicit_plugin_instructions_include_declared_app_ids() {
+    let rendered = render_explicit_plugin_instructions(
+        &PluginCapabilitySummary {
+            display_name: "sample".to_string(),
+            app_connector_ids: vec![
+                AppConnectorId("connector_calendar".to_string()),
+                AppConnectorId("templated_apps_Databricks".to_string()),
+            ],
+            ..PluginCapabilitySummary::default()
+        },
+        &[],
+        &[],
+    )
+    .expect("plugin app IDs should render");
+
+    assert_eq!(
+        rendered,
+        "Capabilities from the `sample` plugin:\n- App IDs declared by this plugin, including templates: `connector_calendar`, `templated_apps_Databricks`.\nUse these plugin-associated capabilities to help solve the task."
+    );
 }

--- a/codex-rs/core/src/tools/handlers/request_plugin_install_spec.rs
+++ b/codex-rs/core/src/tools/handlers/request_plugin_install_spec.rs
@@ -32,7 +32,7 @@ pub(crate) fn create_request_plugin_install_tool() -> ToolSpec {
     ]);
 
     let description = format!(
-        "# Request plugin/connector install\n\nUse this tool only after `{LIST_AVAILABLE_PLUGINS_TO_INSTALL_TOOL_NAME}` returns a plugin or connector that exactly matches the user's explicit request.\n\nDo not use it for adjacent capabilities, broad recommendations, or tools that merely seem useful. Pass the returned `tool_type` through directly, and pass the returned `id` as `tool_id`.\n\nIMPORTANT: DO NOT call this tool in parallel with other tools."
+        "# Request plugin/connector install\n\nUse this tool only when either:\n- `{LIST_AVAILABLE_PLUGINS_TO_INSTALL_TOOL_NAME}` returns a plugin or connector that exactly matches the user's explicit request.\n- An active plugin's invocation guidance provides an exact concrete app ID for a connector required by the user's explicit request.\n\nDo not use it for adjacent capabilities, broad recommendations, or tools that merely seem useful. When using a list result, pass the returned `tool_type` through directly and pass the returned `id` as `tool_id`. When using an active plugin's invocation guidance, use `connector` as `tool_type` and pass the concrete app ID as `tool_id`. Do not pass template IDs such as `templated_apps_*`.\n\nIMPORTANT: DO NOT call this tool in parallel with other tools."
     );
 
     ToolSpec::Function(ResponsesApiTool {
@@ -65,8 +65,10 @@ mod tests {
     fn create_request_plugin_install_tool_uses_expected_wire_shape() {
         let expected_description = concat!(
             "# Request plugin/connector install\n\n",
-            "Use this tool only after `list_available_plugins_to_install` returns a plugin or connector that exactly matches the user's explicit request.\n\n",
-            "Do not use it for adjacent capabilities, broad recommendations, or tools that merely seem useful. Pass the returned `tool_type` through directly, and pass the returned `id` as `tool_id`.\n\n",
+            "Use this tool only when either:\n",
+            "- `list_available_plugins_to_install` returns a plugin or connector that exactly matches the user's explicit request.\n",
+            "- An active plugin's invocation guidance provides an exact concrete app ID for a connector required by the user's explicit request.\n\n",
+            "Do not use it for adjacent capabilities, broad recommendations, or tools that merely seem useful. When using a list result, pass the returned `tool_type` through directly and pass the returned `id` as `tool_id`. When using an active plugin's invocation guidance, use `connector` as `tool_type` and pass the concrete app ID as `tool_id`. Do not pass template IDs such as `templated_apps_*`.\n\n",
             "IMPORTANT: DO NOT call this tool in parallel with other tools.",
         );
 

--- a/codex-rs/core/src/tools/spec_plan_tests.rs
+++ b/codex-rs/core/src/tools/spec_plan_tests.rs
@@ -652,7 +652,7 @@ async fn install_suggestion_tools_stay_visible_without_tool_search() {
 }
 
 #[tokio::test]
-async fn request_plugin_install_description_defers_inventory_to_list_tool() {
+async fn request_plugin_install_description_accepts_list_or_active_plugin_guidance() {
     let plan = probe_with(
         |turn| {
             set_features(
@@ -686,7 +686,10 @@ async fn request_plugin_install_description_defers_inventory_to_list_tool() {
         panic!("expected request_plugin_install function spec");
     };
     assert!(request_description.contains(
-        "Use this tool only after `list_available_plugins_to_install` returns a plugin or connector that exactly matches the user's explicit request."
+        "- `list_available_plugins_to_install` returns a plugin or connector that exactly matches the user's explicit request."
+    ));
+    assert!(request_description.contains(
+        "- An active plugin's invocation guidance provides an exact concrete app ID for a connector required by the user's explicit request."
     ));
     assert!(!request_description.contains("github"));
 }


### PR DESCRIPTION
## Summary

- include plugin-declared app IDs, including templates, in explicit plugin invocation guidance
- allow `request_plugin_install` to use a concrete app ID supplied by active plugin guidance without requiring `list_available_plugins_to_install` first
- retain list-based discovery for unrelated installs and explicitly reject `templated_apps_*` IDs as install arguments

## Notes

- the direct path still depends on session-loaded plugin app IDs being included in the tool-suggest candidate allowlist; that fix is tracked separately in #25172

## Validation

- `just fmt`
- `git diff --check`
- `cargo check -p codex-core`
- not run: `just test -p codex-core request_plugin_install` (`cargo-nextest` is not installed locally)
