### PR TITLE
fix(tui): make startup header handoff atomic [2 of 5]

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -1229,6 +1229,10 @@ See the Codex keymap documentation for supported actions and examples."
         app_server: &mut AppServerSession,
         event: TuiEvent,
     ) -> Result<AppRunControl> {
+        if self.should_defer_draw_for_session_header_commit(&event) {
+            return Ok(AppRunControl::Continue);
+        }
+
         let terminal_resize_reflow_enabled = self.terminal_resize_reflow_enabled();
         if terminal_resize_reflow_enabled && matches!(event, TuiEvent::Draw | TuiEvent::Resize) {
             self.handle_draw_pre_render(tui)?;
@@ -1303,6 +1307,11 @@ See the Codex keymap documentation for supported actions and examples."
             }
         }
         Ok(AppRunControl::Continue)
+    }
+
+    fn should_defer_draw_for_session_header_commit(&self, event: &TuiEvent) -> bool {
+        self.chat_widget.is_session_header_commit_pending()
+            && matches!(event, TuiEvent::Draw | TuiEvent::Resize)
     }
 
     pub(super) fn show_shutdown_feedback(&mut self, tui: &mut tui::Tui) -> Result<()> {

--- a/codex-rs/tui/src/app/event_dispatch.rs
+++ b/codex-rs/tui/src/app/event_dispatch.rs
@@ -197,6 +197,8 @@ impl App {
                 self.begin_thread_switch_history_replay_buffer();
             }
             AppEvent::InsertHistoryCell(cell) => {
+                self.chat_widget
+                    .complete_session_header_commit_if_pending(cell.as_ref());
                 let cell: Arc<dyn HistoryCell> = cell.into();
                 if let Some(Overlay::Transcript(t)) = &mut self.overlay {
                     t.insert_cell(cell.clone());

--- a/codex-rs/tui/src/app/tests/startup.rs
+++ b/codex-rs/tui/src/app/tests/startup.rs
@@ -135,6 +135,78 @@ fn startup_waiting_gate_not_applied_for_resume_or_fork_session_selection() {
     );
 }
 
+fn install_startup_placeholder_widget(app: &mut App) {
+    let config = app.config.clone();
+    let model = crate::legacy_core::test_support::get_model_offline(config.model.as_deref());
+    app.chat_widget = ChatWidget::new_with_app_event(ChatWidgetInit {
+        config,
+        frame_requester: crate::tui::FrameRequester::test_dummy(),
+        app_event_tx: app.app_event_tx.clone(),
+        workspace_command_runner: None,
+        initial_user_message: None,
+        enhanced_keys_supported: false,
+        has_chatgpt_account: false,
+        model_catalog: app.model_catalog.clone(),
+        feedback: codex_feedback::CodexFeedback::new(),
+        is_first_run: false,
+        status_account_display: None,
+        runtime_model_provider_base_url: None,
+        initial_plan_type: None,
+        model: Some(model),
+        startup_tooltip_override: None,
+        status_line_invalid_items_warned: app.status_line_invalid_items_warned.clone(),
+        terminal_title_invalid_items_warned: app.terminal_title_invalid_items_warned.clone(),
+        session_telemetry: app.session_telemetry.clone(),
+    });
+}
+
+#[tokio::test]
+async fn startup_header_commit_defers_draw_until_session_info_is_committed() {
+    let (mut app, mut app_event_rx, _op_rx) = make_test_app_with_channels().await;
+    install_startup_placeholder_widget(&mut app);
+
+    app.chat_widget.handle_thread_session(test_thread_session(
+        ThreadId::new(),
+        test_path_buf("/tmp/project"),
+    ));
+
+    assert!(app.chat_widget.is_session_header_commit_pending());
+    assert!(app.should_defer_draw_for_session_header_commit(&crate::tui::TuiEvent::Draw));
+    assert!(app.should_defer_draw_for_session_header_commit(&crate::tui::TuiEvent::Resize));
+
+    let header = loop {
+        match app_event_rx.try_recv() {
+            Ok(AppEvent::InsertHistoryCell(cell))
+                if cell.as_any().is::<crate::history_cell::SessionInfoCell>() =>
+            {
+                break cell;
+            }
+            Ok(_) => continue,
+            other => panic!("expected queued configured header, got {other:?}"),
+        }
+    };
+    app.chat_widget
+        .complete_session_header_commit_if_pending(header.as_ref());
+
+    assert!(!app.chat_widget.is_session_header_commit_pending());
+    assert!(!app.should_defer_draw_for_session_header_commit(&crate::tui::TuiEvent::Draw));
+}
+
+#[tokio::test]
+async fn quiet_session_configuration_does_not_defer_draw_for_header_commit() {
+    let (mut app, _app_event_rx, _op_rx) = make_test_app_with_channels().await;
+    install_startup_placeholder_widget(&mut app);
+
+    app.chat_widget
+        .handle_thread_session_quiet(test_thread_session(
+            ThreadId::new(),
+            test_path_buf("/tmp/project"),
+        ));
+
+    assert!(!app.chat_widget.is_session_header_commit_pending());
+    assert!(!app.should_defer_draw_for_session_header_commit(&crate::tui::TuiEvent::Draw));
+}
+
 #[tokio::test]
 async fn startup_thread_started_submits_queued_startup_input() {
     let (mut app, _app_event_rx, mut op_rx) = make_test_app_with_channels().await;

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -636,9 +636,9 @@ pub(crate) struct ChatWidget {
     show_welcome_banner: bool,
     // One-shot tooltip override for the primary startup session.
     startup_tooltip_override: Option<String>,
-    // When resuming an existing session (selected via resume picker), avoid an
-    // immediate redraw on SessionConfigured to prevent a gratuitous UI flicker.
-    suppress_session_configured_redraw: bool,
+    // A replacement for the provisional session header has been queued for terminal history.
+    // Until it is committed, drawing would expose a transient composer-only frame.
+    session_header_commit_pending: bool,
     // During snapshot restore, defer startup prompt submission until replayed
     // history has been rendered so resumed/forked prompts keep chronological
     // order.
@@ -1497,10 +1497,24 @@ impl ChatWidget {
             false
         };
 
+        if merged_header {
+            self.session_header_commit_pending = true;
+        }
         self.flush_active_cell();
 
         if !merged_header && let Some(cell) = session_info_cell {
             self.add_boxed_history(cell);
+        }
+    }
+
+    pub(crate) fn is_session_header_commit_pending(&self) -> bool {
+        self.session_header_commit_pending
+    }
+
+    pub(crate) fn complete_session_header_commit_if_pending(&mut self, cell: &dyn HistoryCell) {
+        if self.session_header_commit_pending && cell.as_any().is::<history_cell::SessionInfoCell>()
+        {
+            self.session_header_commit_pending = false;
         }
     }
 

--- a/codex-rs/tui/src/chatwidget/constructor.rs
+++ b/codex-rs/tui/src/chatwidget/constructor.rs
@@ -187,7 +187,7 @@ impl ChatWidget {
             queued_message_edit_hint_binding,
             show_welcome_banner: is_first_run,
             startup_tooltip_override,
-            suppress_session_configured_redraw: false,
+            session_header_commit_pending: false,
             suppress_initial_user_message_submit: false,
             pending_notification: None,
             quit_shortcut_expires_at: None,

--- a/codex-rs/tui/src/chatwidget/session_flow.rs
+++ b/codex-rs/tui/src/chatwidget/session_flow.rs
@@ -141,7 +141,10 @@ impl ChatWidget {
         {
             self.emit_forked_thread_event(forked_from_id, fork_parent_title);
         }
-        if !self.suppress_session_configured_redraw {
+        // Normal display queues session info into terminal history, which schedules the frame
+        // that commits the header and repaints the composer atomically. Redrawing before that
+        // history insert is processed can briefly show the composer without its header.
+        if display != SessionConfiguredDisplay::Normal {
             self.request_redraw();
         }
     }

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__startup_header_handoff_visible_states.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__startup_header_handoff_visible_states.snap
@@ -1,0 +1,28 @@
+---
+source: tui/src/chatwidget/tests/status_and_layout.rs
+expression: "format!(\"provisional live frame:\\n{placeholder}\\n\\ncommitted history:\\n{committed_header}\")"
+---
+provisional live frame:
+"                                                                                "
+"╭───────────────────────────────────────╮                                       "
+"│ >_ OpenAI Codex (v0.0.0)              │                                       "
+"│                                       │                                       "
+"│ model:     loading   /model to change │                                       "
+"│ directory: /tmp/project               │                                       "
+"╰───────────────────────────────────────╯                                       "
+"                                                                                "
+"                                                                                "
+"› Explain this codebase                                                         "
+"                                                                                "
+"  gpt-5.5 default · /tmp/project                                                "
+
+
+committed history:
+╭────────────────────────────────────────────────╮
+│ >_ OpenAI Codex (v0.0.0)                       │
+│                                                │
+│ model:     configured-model   /model to change │
+│ directory: /tmp/project                        │
+╰────────────────────────────────────────────────╯
+
+  Tip: This is a test announcement

--- a/codex-rs/tui/src/chatwidget/tests/helpers.rs
+++ b/codex-rs/tui/src/chatwidget/tests/helpers.rs
@@ -63,6 +63,25 @@ pub(super) fn normalize_snapshot_paths(text: impl Into<String>) -> String {
     }
 }
 
+/// Normalizes platform-specific test paths without collapsing box alignment.
+pub(super) fn normalize_box_snapshot_paths(text: &str) -> String {
+    text.lines()
+        .map(|rendered| {
+            let normalized = normalize_snapshot_paths(rendered);
+            let padding = rendered
+                .chars()
+                .count()
+                .saturating_sub(normalized.chars().count());
+            if let Some((content, suffix)) = normalized.rsplit_once('│') {
+                format!("{content}{}│{suffix}", " ".repeat(padding))
+            } else {
+                normalized
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 pub(super) fn normalized_backend_snapshot<T: std::fmt::Display>(value: &T) -> String {
     let platform_test_cwd = test_path_display("/tmp/project");
     let rendered = format!("{value}");
@@ -79,7 +98,7 @@ pub(super) fn normalized_backend_snapshot<T: std::fmt::Display>(value: &T) -> St
                 .and_then(|line| line.strip_suffix('"'))
             {
                 let width = content.chars().count();
-                let normalized = normalize_snapshot_paths(content);
+                let normalized = normalize_box_snapshot_paths(content);
                 format!("\"{normalized:width$}\"")
             } else {
                 normalize_snapshot_paths(line)

--- a/codex-rs/tui/src/chatwidget/tests/helpers.rs
+++ b/codex-rs/tui/src/chatwidget/tests/helpers.rs
@@ -65,7 +65,8 @@ pub(super) fn normalize_snapshot_paths(text: impl Into<String>) -> String {
 
 /// Normalizes platform-specific test paths without collapsing box alignment.
 pub(super) fn normalize_box_snapshot_paths(text: &str) -> String {
-    text.lines()
+    let mut normalized = text
+        .lines()
         .map(|rendered| {
             let normalized = normalize_snapshot_paths(rendered);
             let padding = rendered
@@ -79,7 +80,11 @@ pub(super) fn normalize_box_snapshot_paths(text: &str) -> String {
             }
         })
         .collect::<Vec<_>>()
-        .join("\n")
+        .join("\n");
+    if text.ends_with('\n') {
+        normalized.push('\n');
+    }
+    normalized
 }
 
 pub(super) fn normalized_backend_snapshot<T: std::fmt::Display>(value: &T) -> String {
@@ -90,7 +95,7 @@ pub(super) fn normalized_backend_snapshot<T: std::fmt::Display>(value: &T) -> St
         return rendered;
     }
 
-    rendered
+    let mut normalized = rendered
         .lines()
         .map(|line| {
             if let Some(content) = line
@@ -105,7 +110,11 @@ pub(super) fn normalized_backend_snapshot<T: std::fmt::Display>(value: &T) -> St
             }
         })
         .collect::<Vec<_>>()
-        .join("\n")
+        .join("\n");
+    if rendered.ends_with('\n') {
+        normalized.push('\n');
+    }
+    normalized
 }
 
 pub(super) fn invalid_value(

--- a/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
+++ b/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
@@ -1698,24 +1698,7 @@ async fn startup_header_handoff_visible_states_snapshot() {
                 if cell.as_any().is::<history_cell::SessionInfoCell>() =>
             {
                 let rendered = lines_to_single_string(&cell.display_lines(width));
-                let normalized = normalize_snapshot_paths(&rendered);
-                // Keep box alignment after shortening Windows test paths.
-                break normalized
-                    .lines()
-                    .zip(rendered.lines())
-                    .map(|(normalized, rendered)| {
-                        let padding = rendered
-                            .chars()
-                            .count()
-                            .saturating_sub(normalized.chars().count());
-                        if let Some(content) = normalized.strip_suffix('│') {
-                            format!("{content}{}│", " ".repeat(padding))
-                        } else {
-                            normalized.to_string()
-                        }
-                    })
-                    .collect::<Vec<_>>()
-                    .join("\n");
+                break normalize_box_snapshot_paths(&rendered);
             }
             Ok(_) => continue,
             other => panic!("expected queued configured header, got {other:?}"),

--- a/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
+++ b/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
@@ -1697,7 +1697,7 @@ async fn startup_header_handoff_visible_states_snapshot() {
             Ok(AppEvent::InsertHistoryCell(cell))
                 if cell.as_any().is::<history_cell::SessionInfoCell>() =>
             {
-                break lines_to_single_string(&cell.display_lines(width));
+                break normalize_snapshot_paths(lines_to_single_string(&cell.display_lines(width)));
             }
             Ok(_) => continue,
             other => panic!("expected queued configured header, got {other:?}"),

--- a/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
+++ b/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
@@ -1697,7 +1697,25 @@ async fn startup_header_handoff_visible_states_snapshot() {
             Ok(AppEvent::InsertHistoryCell(cell))
                 if cell.as_any().is::<history_cell::SessionInfoCell>() =>
             {
-                break normalize_snapshot_paths(lines_to_single_string(&cell.display_lines(width)));
+                let rendered = lines_to_single_string(&cell.display_lines(width));
+                let normalized = normalize_snapshot_paths(&rendered);
+                // Keep box alignment after shortening Windows test paths.
+                break normalized
+                    .lines()
+                    .zip(rendered.lines())
+                    .map(|(normalized, rendered)| {
+                        let padding = rendered
+                            .chars()
+                            .count()
+                            .saturating_sub(normalized.chars().count());
+                        if let Some(content) = normalized.strip_suffix('│') {
+                            format!("{content}{}│", " ".repeat(padding))
+                        } else {
+                            normalized.to_string()
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
             }
             Ok(_) => continue,
             other => panic!("expected queued configured header, got {other:?}"),

--- a/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
+++ b/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
@@ -1629,6 +1629,88 @@ async fn ui_snapshots_small_heights_task_running() {
 }
 
 #[tokio::test]
+async fn startup_header_handoff_visible_states_snapshot() {
+    let (tx_raw, mut rx) = unbounded_channel::<AppEvent>();
+    let tx = AppEventSender::new(tx_raw);
+    let cfg = test_config().await;
+    let resolved_model = crate::legacy_core::test_support::get_model_offline(cfg.model.as_deref());
+    let init = ChatWidgetInit {
+        config: cfg.clone(),
+        frame_requester: FrameRequester::test_dummy(),
+        app_event_tx: tx,
+        workspace_command_runner: None,
+        initial_user_message: None,
+        enhanced_keys_supported: false,
+        has_chatgpt_account: false,
+        model_catalog: test_model_catalog(&cfg),
+        feedback: codex_feedback::CodexFeedback::new(),
+        is_first_run: false,
+        status_account_display: None,
+        runtime_model_provider_base_url: None,
+        initial_plan_type: None,
+        model: Some(resolved_model.clone()),
+        startup_tooltip_override: Some("This is a test announcement".to_string()),
+        status_line_invalid_items_warned: Arc::new(AtomicBool::new(false)),
+        terminal_title_invalid_items_warned: Arc::new(AtomicBool::new(false)),
+        session_telemetry: test_session_telemetry(&cfg, resolved_model.as_str()),
+    };
+    let mut chat = ChatWidget::new_with_app_event(init);
+    chat.normal_placeholder_text = "Explain this codebase".to_string();
+    chat.bottom_pane
+        .set_placeholder_text(chat.normal_placeholder_text.clone());
+    let width = 80;
+    let height = chat.desired_height(width);
+    let mut terminal =
+        ratatui::Terminal::new(TestBackend::new(width, height)).expect("create terminal");
+    terminal
+        .draw(|f| chat.render(f.area(), f.buffer_mut()))
+        .expect("draw placeholder header");
+    let placeholder = normalized_backend_snapshot(terminal.backend());
+
+    let rollout_file = NamedTempFile::new().expect("rollout file");
+    chat.handle_thread_session(crate::session_state::ThreadSessionState {
+        thread_id: ThreadId::new(),
+        forked_from_id: None,
+        fork_parent_title: None,
+        thread_name: None,
+        model: "configured-model".to_string(),
+        model_provider_id: "test-provider".to_string(),
+        service_tier: None,
+        approval_policy: AskForApproval::Never,
+        approvals_reviewer: ApprovalsReviewer::User,
+        permission_profile: PermissionProfile::read_only(),
+        active_permission_profile: None,
+        cwd: test_path_buf("/tmp/project").abs(),
+        runtime_workspace_roots: Vec::new(),
+        instruction_source_paths: Vec::new(),
+        reasoning_effort: None,
+        collaboration_mode: None,
+        personality: None,
+        message_history: None,
+        network_proxy: None,
+        rollout_path: Some(rollout_file.path().to_path_buf()),
+    });
+
+    assert!(chat.is_session_header_commit_pending());
+    let committed_header = loop {
+        match rx.try_recv() {
+            Ok(AppEvent::InsertHistoryCell(cell))
+                if cell.as_any().is::<history_cell::SessionInfoCell>() =>
+            {
+                break lines_to_single_string(&cell.display_lines(width));
+            }
+            Ok(_) => continue,
+            other => panic!("expected queued configured header, got {other:?}"),
+        }
+    };
+
+    assert_chatwidget_snapshot!(
+        "startup_header_handoff_visible_states",
+        format!("provisional live frame:\n{placeholder}\n\ncommitted history:\n{committed_header}")
+    );
+}
+
+#[tokio::test]
 #[serial]
 async fn ambient_pet_stays_hidden_until_a_pet_is_selected() {
     use ratatui::layout::Rect;


### PR DESCRIPTION
## Why

When startup session information replaces the provisional header, an intermediate redraw can briefly paint the composer without the committed session header. The flash is independent of MCP inventory behavior and should be fixed at the TUI history handoff boundary.

## What Changed

- Track when a replacement session header has been queued but not committed to terminal history.
- Defer `Draw` and `Resize` frames during that narrow window.
- Clear the pending state when the queued `SessionInfoCell` enters history.
- Add snapshot and event-loop regression coverage for visible and quiet session configuration flows.

## Stack

1. [#25212](https://github.com/openai/codex/pull/25212) background MCP startup status
2. #25213 atomic startup header handoff (this PR)
3. [#25214](https://github.com/openai/codex/pull/25214) explicit MCP dependency readiness
4. [#25211](https://github.com/openai/codex/pull/25211) lazy tool-search registration
5. [#24987](https://github.com/openai/codex/pull/24987) pending MCP inventory integration

## How to Test

1. Start the TUI and observe the initial header and composer frame.
2. Confirm the final session header and composer appear together without an intermediate composer-only flash.
3. Exercise a quiet session configuration update and confirm normal redraws are not delayed.

Targeted tests:
- `just test -p codex-tui -E 'test(startup_header_commit_defers_draw_until_session_info_is_committed) | test(quiet_session_configuration_does_not_defer_draw_for_header_commit)'`
