### PR TITLE
fix(core): preserve explicit MCP dependency readiness [3 of 5]

### DIFF
--- a/codex-rs/codex-mcp/src/connection_manager.rs
+++ b/codex-rs/codex-mcp/src/connection_manager.rs
@@ -149,6 +149,29 @@ impl McpConnectionManager {
         !self.clients.is_empty()
     }
 
+    pub fn is_server_startup_pending(&self, server_name: &str) -> bool {
+        self.clients
+            .get(server_name)
+            .is_some_and(|client| !client.startup_complete.load(Ordering::Acquire))
+    }
+
+    /// Returns an owned future for the Codex Apps tools already available from
+    /// startup cache or a ready client.
+    pub fn codex_apps_tools_if_ready_or_cached(
+        &self,
+    ) -> impl std::future::Future<Output = Vec<ToolInfo>> + Send + 'static + use<> {
+        let client = self.clients.get(CODEX_APPS_MCP_SERVER_NAME).cloned();
+        async move {
+            let Some(client) = client else {
+                return Vec::new();
+            };
+            client
+                .listed_tools_if_ready_or_cached()
+                .await
+                .unwrap_or_default()
+        }
+    }
+
     /// Drain all MCP clients from this manager and return a future that stops
     /// them and terminates their stdio server processes.
     pub fn begin_shutdown(&mut self) -> impl std::future::Future<Output = ()> + Send + 'static {

--- a/codex-rs/codex-mcp/src/connection_manager_tests.rs
+++ b/codex-rs/codex-mcp/src/connection_manager_tests.rs
@@ -1004,6 +1004,9 @@ async fn list_ready_or_cached_tools_skips_pending_client_without_cached_tool_inf
         },
     );
 
+    assert!(manager.is_server_startup_pending("optional"));
+    assert!(!manager.is_server_startup_pending("missing"));
+
     let tools = tokio::time::timeout(
         Duration::from_millis(/*millis*/ 10),
         manager.list_ready_or_cached_tools(),

--- a/codex-rs/codex-mcp/src/connection_manager_tests.rs
+++ b/codex-rs/codex-mcp/src/connection_manager_tests.rs
@@ -1005,7 +1005,7 @@ async fn list_ready_or_cached_tools_skips_pending_client_without_cached_tool_inf
     );
 
     let tools = tokio::time::timeout(
-        Duration::from_millis(10),
+        Duration::from_millis(/*millis*/ 10),
         manager.list_ready_or_cached_tools(),
     )
     .await

--- a/codex-rs/core-skills/src/injection.rs
+++ b/codex-rs/core-skills/src/injection.rs
@@ -118,6 +118,38 @@ pub fn collect_explicit_skill_mentions(
     disabled_paths: &HashSet<AbsolutePathBuf>,
     connector_slug_counts: &HashMap<String, usize>,
 ) -> Vec<SkillMetadata> {
+    collect_skill_mentions(
+        inputs,
+        skills,
+        disabled_paths,
+        connector_slug_counts,
+        /*include_plain_names*/ true,
+    )
+}
+
+/// Collect structured skill selections and linked skill paths that can be
+/// resolved without app inventory.
+pub fn collect_unambiguous_skill_mentions(
+    inputs: &[UserInput],
+    skills: &[SkillMetadata],
+    disabled_paths: &HashSet<AbsolutePathBuf>,
+) -> Vec<SkillMetadata> {
+    collect_skill_mentions(
+        inputs,
+        skills,
+        disabled_paths,
+        &HashMap::new(),
+        /*include_plain_names*/ false,
+    )
+}
+
+fn collect_skill_mentions(
+    inputs: &[UserInput],
+    skills: &[SkillMetadata],
+    disabled_paths: &HashSet<AbsolutePathBuf>,
+    connector_slug_counts: &HashMap<String, usize>,
+    include_plain_names: bool,
+) -> Vec<SkillMetadata> {
     let skill_name_counts = build_skill_name_counts(skills, disabled_paths).0;
 
     let selection_context = SkillSelectionContext {
@@ -164,6 +196,7 @@ pub fn collect_explicit_skill_mentions(
                 &mut seen_names,
                 &mut seen_paths,
                 &mut selected,
+                include_plain_names,
             );
         }
     }
@@ -326,6 +359,7 @@ fn select_skills_from_mentions(
     seen_names: &mut HashSet<String>,
     seen_paths: &mut HashSet<AbsolutePathBuf>,
     selected: &mut Vec<SkillMetadata>,
+    include_plain_names: bool,
 ) {
     if mentions.is_empty() {
         return;
@@ -357,6 +391,10 @@ fn select_skills_from_mentions(
             seen_names.insert(skill.name.clone());
             selected.push(skill.clone());
         }
+    }
+
+    if !include_plain_names {
+        return;
     }
 
     for skill in selection_context.skills {

--- a/codex-rs/core-skills/src/injection_tests.rs
+++ b/codex-rs/core-skills/src/injection_tests.rs
@@ -294,6 +294,24 @@ fn collect_explicit_skill_mentions_allows_explicit_path_with_connector_conflict(
 }
 
 #[test]
+fn collect_unambiguous_skill_mentions_selects_linked_path_but_not_plain_name() {
+    let alpha = make_skill("alpha-skill", "/tmp/alpha");
+    let beta = make_skill("beta-skill", "/tmp/beta");
+    let skills = vec![alpha, beta.clone()];
+    let inputs = vec![UserInput::Text {
+        text: format!(
+            "use $alpha-skill and {}",
+            linked_skill_mention("beta-skill", "/tmp/beta")
+        ),
+        text_elements: Vec::new(),
+    }];
+
+    let selected = collect_unambiguous_skill_mentions(&inputs, &skills, &HashSet::new());
+
+    assert_eq!(selected, vec![beta]);
+}
+
+#[test]
 fn collect_explicit_skill_mentions_skips_when_linked_path_disabled() {
     let alpha = make_skill("demo-skill", "/tmp/alpha");
     let beta = make_skill("demo-skill", "/tmp/beta");

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -3582,7 +3582,7 @@ impl Config {
                 .tui
                 .as_ref()
                 .map(|t| t.show_mcp_startup_status)
-                .unwrap_or(false),
+                .unwrap_or(/*default*/ false),
             model_availability_nux: cfg
                 .tui
                 .as_ref()

--- a/codex-rs/core/src/connectors.rs
+++ b/codex-rs/core/src/connectors.rs
@@ -97,21 +97,6 @@ pub async fn list_accessible_connectors_from_mcp_tools(
     )
 }
 
-pub(crate) async fn list_accessible_and_enabled_connectors_from_manager(
-    mcp_connection_manager: &McpConnectionManager,
-    config: &Config,
-) -> Vec<AppInfo> {
-    with_app_enabled_state(
-        accessible_connectors_from_mcp_tools(
-            &mcp_connection_manager.list_ready_or_cached_tools().await,
-        ),
-        config,
-    )
-    .into_iter()
-    .filter(|connector| connector.is_accessible && connector.is_enabled)
-    .collect()
-}
-
 pub(crate) async fn list_tool_suggest_discoverable_tools_with_auth(
     config: &Config,
     plugins_manager: &PluginsManager,

--- a/codex-rs/core/src/connectors.rs
+++ b/codex-rs/core/src/connectors.rs
@@ -97,6 +97,12 @@ pub async fn list_accessible_connectors_from_mcp_tools(
     )
 }
 
+pub(crate) fn should_include_apps_instructions(mcp_tools: &[ToolInfo], config: &Config) -> bool {
+    with_app_enabled_state(accessible_connectors_from_mcp_tools(mcp_tools), config)
+        .into_iter()
+        .any(|connector| connector.is_accessible && connector.is_enabled)
+}
+
 pub(crate) async fn list_tool_suggest_discoverable_tools_with_auth(
     config: &Config,
     plugins_manager: &PluginsManager,

--- a/codex-rs/core/src/context/apps_instructions.rs
+++ b/codex-rs/core/src/context/apps_instructions.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 use codex_app_server_protocol::AppInfo;
 use codex_mcp::CODEX_APPS_MCP_SERVER_NAME;
 use codex_protocol::protocol::APPS_INSTRUCTIONS_CLOSE_TAG;
@@ -8,6 +9,7 @@ use super::ContextualUserFragment;
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct AppsInstructions;
 
+#[cfg(test)]
 impl AppsInstructions {
     pub(crate) fn from_connectors(connectors: &[AppInfo]) -> Option<Self> {
         connectors

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -91,6 +91,7 @@ pub(crate) use skills::build_available_skills;
 pub(crate) use skills::build_skill_injections;
 pub(crate) use skills::build_skill_name_counts;
 pub(crate) use skills::collect_explicit_skill_mentions;
+pub(crate) use skills::collect_unambiguous_skill_mentions;
 pub(crate) use skills::default_skill_metadata_budget;
 pub(crate) use skills::injection;
 pub(crate) use skills::manager;

--- a/codex-rs/core/src/mcp_skill_dependencies.rs
+++ b/codex-rs/core/src/mcp_skill_dependencies.rs
@@ -37,49 +37,54 @@ pub(crate) async fn maybe_prompt_and_install_mcp_dependencies(
     cancellation_token: &CancellationToken,
     mentioned_skills: &[SkillMetadata],
     elicitation_reviewer: Option<ElicitationReviewerHandle>,
-) {
+) -> HashSet<String> {
+    if mentioned_skills.is_empty() {
+        return HashSet::new();
+    }
+
     let originator_value = originator().value;
-    if !is_first_party_originator(originator_value.as_str()) {
-        // Only support first-party clients for now.
-        return;
-    }
-
     let config = turn_context.config.clone();
-    if mentioned_skills.is_empty()
-        || !config
-            .features
-            .enabled(codex_features::Feature::SkillMcpDependencyInstall)
-    {
-        return;
-    }
-
     let installed = sess
         .services
         .mcp_manager
         .configured_servers(config.as_ref())
         .await;
+    let mut dependency_servers =
+        collect_configured_mcp_dependency_server_names(mentioned_skills, &installed);
+    if !is_first_party_originator(originator_value.as_str())
+        || !config
+            .features
+            .enabled(codex_features::Feature::SkillMcpDependencyInstall)
+    {
+        // Existing skill dependencies remain explicit even if auto-install is unavailable.
+        return dependency_servers;
+    }
+
     let missing = collect_missing_mcp_dependencies(mentioned_skills, &installed);
     if missing.is_empty() {
-        return;
+        return dependency_servers;
     }
 
     let unprompted_missing = filter_prompted_mcp_dependencies(sess, &missing).await;
     if unprompted_missing.is_empty() {
-        return;
+        return dependency_servers;
     }
 
     if should_install_mcp_dependencies(sess, turn_context, &unprompted_missing, cancellation_token)
         .await
     {
-        maybe_install_mcp_dependencies(
-            sess,
-            turn_context,
-            config.as_ref(),
-            mentioned_skills,
-            elicitation_reviewer,
-        )
-        .await;
+        dependency_servers.extend(
+            maybe_install_mcp_dependencies(
+                sess,
+                turn_context,
+                config.as_ref(),
+                mentioned_skills,
+                elicitation_reviewer,
+            )
+            .await,
+        );
     }
+    dependency_servers
 }
 
 pub(crate) async fn maybe_install_mcp_dependencies(
@@ -88,27 +93,27 @@ pub(crate) async fn maybe_install_mcp_dependencies(
     config: &crate::config::Config,
     mentioned_skills: &[SkillMetadata],
     elicitation_reviewer: Option<ElicitationReviewerHandle>,
-) {
+) -> HashSet<String> {
     if mentioned_skills.is_empty()
         || !config
             .features
             .enabled(codex_features::Feature::SkillMcpDependencyInstall)
     {
-        return;
+        return HashSet::new();
     }
 
     let codex_home = config.codex_home.clone();
     let installed = sess.services.mcp_manager.configured_servers(config).await;
     let missing = collect_missing_mcp_dependencies(mentioned_skills, &installed);
     if missing.is_empty() {
-        return;
+        return HashSet::new();
     }
 
     let mut servers = match load_global_mcp_servers(&codex_home).await {
         Ok(servers) => servers,
         Err(err) => {
             warn!("failed to load MCP servers while installing skill dependencies: {err}");
-            return;
+            return HashSet::new();
         }
     };
 
@@ -124,7 +129,7 @@ pub(crate) async fn maybe_install_mcp_dependencies(
     }
 
     if !updated {
-        return;
+        return HashSet::new();
     }
 
     if let Err(err) = ConfigEditsBuilder::new(&codex_home)
@@ -133,9 +138,13 @@ pub(crate) async fn maybe_install_mcp_dependencies(
         .await
     {
         warn!("failed to persist MCP dependencies for mentioned skills: {err}");
-        return;
+        return HashSet::new();
     }
 
+    let added_server_names = added
+        .iter()
+        .map(|(name, _)| name.clone())
+        .collect::<HashSet<_>>();
     for (name, server_config) in added {
         let oauth_config = match oauth_login_support(&server_config.transport).await {
             McpOAuthLoginSupport::Supported(config) => config,
@@ -207,6 +216,7 @@ pub(crate) async fn maybe_install_mcp_dependencies(
         elicitation_reviewer,
     )
     .await;
+    added_server_names
 }
 
 async fn should_install_mcp_dependencies(
@@ -409,6 +419,25 @@ fn mcp_dependency_to_server_config(
     }
 
     Err(format!("unsupported transport {transport}"))
+}
+
+fn collect_configured_mcp_dependency_server_names(
+    mentioned_skills: &[SkillMetadata],
+    installed: &HashMap<String, McpServerConfig>,
+) -> HashSet<String> {
+    let dependency_keys = mentioned_skills
+        .iter()
+        .filter_map(|skill| skill.dependencies.as_ref())
+        .flat_map(|dependencies| dependencies.tools.iter())
+        .filter(|tool| tool.r#type.eq_ignore_ascii_case("mcp"))
+        .filter_map(|tool| canonical_mcp_dependency_key(tool).ok())
+        .collect::<HashSet<_>>();
+
+    installed
+        .iter()
+        .filter(|(name, config)| dependency_keys.contains(&canonical_mcp_server_key(name, config)))
+        .map(|(name, _)| name.clone())
+        .collect()
 }
 
 fn collect_missing_mcp_dependencies(

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -18,6 +18,7 @@ use crate::build_available_skills;
 use crate::compact;
 use crate::config::ManagedFeatures;
 use crate::config::resolve_tool_suggest_config_from_layer_stack;
+use crate::connectors;
 use crate::context::ApprovedCommandPrefixSaved;
 use crate::context::AppsInstructions;
 use crate::context::AvailablePluginsInstructions;
@@ -61,6 +62,7 @@ use codex_login::AuthManager;
 use codex_login::CodexAuth;
 use codex_login::auth_env_telemetry::collect_auth_env_telemetry;
 use codex_login::default_client::originator;
+use codex_mcp::CODEX_APPS_MCP_SERVER_NAME;
 use codex_mcp::McpConnectionManager;
 use codex_mcp::McpRuntimeContext;
 use codex_mcp::codex_apps_tools_cache_key;
@@ -2811,7 +2813,24 @@ impl Session {
                     .push(PersonalitySpecInstructions::new(personality_message).render());
             }
         }
-        if turn_context.config.include_apps_instructions && turn_context.apps_enabled() {
+        let include_apps_instructions =
+            if turn_context.config.include_apps_instructions && turn_context.apps_enabled() {
+                let codex_apps_tools = {
+                    let mcp_connection_manager = self.services.mcp_connection_manager.read().await;
+                    (!mcp_connection_manager.is_server_startup_pending(CODEX_APPS_MCP_SERVER_NAME))
+                        .then(|| mcp_connection_manager.codex_apps_tools_if_ready_or_cached())
+                };
+                match codex_apps_tools {
+                    None => true,
+                    Some(codex_apps_tools) => connectors::should_include_apps_instructions(
+                        &codex_apps_tools.await,
+                        &turn_context.config,
+                    ),
+                }
+            } else {
+                false
+            };
+        if include_apps_instructions {
             developer_sections.push(AppsInstructions.render());
         }
         if turn_context.config.include_skill_instructions {

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -18,7 +18,6 @@ use crate::build_available_skills;
 use crate::compact;
 use crate::config::ManagedFeatures;
 use crate::config::resolve_tool_suggest_config_from_layer_stack;
-use crate::connectors;
 use crate::context::ApprovedCommandPrefixSaved;
 use crate::context::AppsInstructions;
 use crate::context::AvailablePluginsInstructions;
@@ -2721,10 +2720,6 @@ impl Session {
         }
     }
 
-    #[expect(
-        clippy::await_holding_invalid_type,
-        reason = "MCP app context rendering reads through the session-owned manager guard"
-    )]
     pub(crate) async fn build_initial_context(
         &self,
         turn_context: &TurnContext,
@@ -2817,18 +2812,7 @@ impl Session {
             }
         }
         if turn_context.config.include_apps_instructions && turn_context.apps_enabled() {
-            let mcp_connection_manager = self.services.mcp_connection_manager.read().await;
-            let accessible_and_enabled_connectors =
-                connectors::list_accessible_and_enabled_connectors_from_manager(
-                    &mcp_connection_manager,
-                    &turn_context.config,
-                )
-                .await;
-            if let Some(apps_instructions) =
-                AppsInstructions::from_connectors(&accessible_and_enabled_connectors)
-            {
-                developer_sections.push(apps_instructions.render());
-            }
+            developer_sections.push(AppsInstructions.render());
         }
         if turn_context.config.include_skill_instructions {
             let available_skills = build_available_skills(

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -511,7 +511,8 @@ async fn build_skills_and_plugins(
     )
     .await;
     let structured_skill_may_reference_apps =
-        skill_injections_may_reference_apps(&skill_injections);
+        skill_injections_may_reference_apps(&skill_injections)
+            || structured_skill_inputs_may_reference_apps(&structured_skill_input).await;
     // Plain text skill mentions can collide with app slugs, so preserve their
     // existing app-inventory resolution behavior.
     let text_skill_input = user_input
@@ -798,13 +799,31 @@ async fn wait_for_explicit_mcp_servers(
 fn skill_injections_may_reference_apps(
     skill_injections: &[crate::injection::SkillInjection],
 ) -> bool {
-    skill_injections.iter().any(|skill| {
-        let mentions = extract_tool_mentions(&skill.contents);
-        mentions.plain_names().next().is_some()
-            || mentions
-                .paths()
-                .any(|path| tool_kind_for_path(path) == ToolMentionKind::App)
-    })
+    skill_injections
+        .iter()
+        .any(|skill| skill_contents_may_reference_apps(&skill.contents))
+}
+
+async fn structured_skill_inputs_may_reference_apps(inputs: &[UserInput]) -> bool {
+    for input in inputs {
+        let UserInput::Skill { path, .. } = input else {
+            continue;
+        };
+        if let Ok(contents) = tokio::fs::read_to_string(path).await
+            && skill_contents_may_reference_apps(&contents)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+fn skill_contents_may_reference_apps(contents: &str) -> bool {
+    let mentions = extract_tool_mentions(contents);
+    mentions.plain_names().next().is_some()
+        || mentions
+            .paths()
+            .any(|path| tool_kind_for_path(path) == ToolMentionKind::App)
 }
 
 async fn track_turn_resolved_config_analytics(

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -9,6 +9,7 @@ use crate::client::ModelClientSession;
 use crate::client_common::Prompt;
 use crate::client_common::ResponseEvent;
 use crate::collect_explicit_skill_mentions;
+use crate::collect_unambiguous_skill_mentions;
 use crate::compact::InitialContextInjection;
 use crate::compact::run_inline_auto_compact_task;
 use crate::compact::should_use_remote_compact_task;
@@ -484,32 +485,26 @@ async fn build_skills_and_plugins(
         collect_explicit_plugin_mentions(&user_input, loaded_plugins.capability_summaries());
     let explicitly_mentioned_apps = collect_explicit_app_ids(&user_input);
     let skills_outcome = turn_context.turn_skills.outcome.as_ref();
-    // Structured skill selections are unambiguous without app inventory. Load
-    // them before deciding whether the pending Apps MCP is a dependency of this
-    // turn, then reuse the injections below so loading and telemetry happen once.
-    let structured_skill_input = user_input
-        .iter()
-        .filter(|item| matches!(item, UserInput::Skill { .. }))
-        .cloned()
-        .collect::<Vec<_>>();
-    let structured_mentioned_skills = collect_explicit_skill_mentions(
-        &structured_skill_input,
+    // Structured selections and linked skill paths are unambiguous without app
+    // inventory. Load them before deciding whether the pending Apps MCP is a
+    // dependency of this turn, then reuse the injections below.
+    let unambiguous_mentioned_skills = collect_unambiguous_skill_mentions(
+        &user_input,
         &skills_outcome.skills,
         &skills_outcome.disabled_paths,
-        &HashMap::new(),
     );
     let SkillInjections {
         items: mut skill_injections,
         warnings: mut skill_warnings,
     } = build_skill_injections(
-        &structured_mentioned_skills,
+        &unambiguous_mentioned_skills,
         Some(skills_outcome),
         Some(&turn_context.session_telemetry),
         &sess.services.analytics_events_client,
         tracking.clone(),
     )
     .await;
-    let structured_skill_may_reference_apps =
+    let unambiguous_skill_may_reference_apps =
         skill_injections_may_reference_apps(&skill_injections);
     // Plain text skill mentions can collide with app slugs, so preserve their
     // existing app-inventory resolution behavior.
@@ -518,14 +513,23 @@ async fn build_skills_and_plugins(
         .filter(|item| matches!(item, UserInput::Text { .. }))
         .cloned()
         .collect::<Vec<_>>();
+    let unambiguous_text_skill_paths = collect_unambiguous_skill_mentions(
+        &text_skill_input,
+        &skills_outcome.skills,
+        &skills_outcome.disabled_paths,
+    )
+    .into_iter()
+    .map(|skill| skill.path_to_skills_md)
+    .collect::<HashSet<_>>();
     let text_may_select_skill_requiring_app_resolution = turn_context.apps_enabled()
-        && !collect_explicit_skill_mentions(
+        && collect_explicit_skill_mentions(
             &text_skill_input,
             &skills_outcome.skills,
             &skills_outcome.disabled_paths,
             &HashMap::new(),
         )
-        .is_empty();
+        .iter()
+        .any(|skill| !unambiguous_text_skill_paths.contains(&skill.path_to_skills_md));
     let mut explicitly_requested_mcp_servers = mentioned_plugins
         .iter()
         .flat_map(|plugin| plugin.mcp_server_names.iter().cloned())
@@ -536,7 +540,7 @@ async fn build_skills_and_plugins(
     if turn_context.apps_enabled()
         && (!explicitly_mentioned_apps.is_empty()
             || mentioned_plugin_uses_apps
-            || structured_skill_may_reference_apps
+            || unambiguous_skill_may_reference_apps
             || text_may_select_skill_requiring_app_resolution)
     {
         explicitly_requested_mcp_servers.insert(CODEX_APPS_MCP_SERVER_NAME.to_string());
@@ -639,13 +643,13 @@ async fn build_skills_and_plugins(
         }
     }
 
-    let structured_skill_paths = structured_mentioned_skills
+    let preloaded_skill_paths = unambiguous_mentioned_skills
         .iter()
         .map(|skill| &skill.path_to_skills_md)
         .collect::<HashSet<_>>();
     let remaining_mentioned_skills = mentioned_skills
         .iter()
-        .filter(|skill| !structured_skill_paths.contains(&skill.path_to_skills_md))
+        .filter(|skill| !preloaded_skill_paths.contains(&skill.path_to_skills_md))
         .cloned()
         .collect::<Vec<_>>();
     let SkillInjections {

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -509,32 +509,13 @@ async fn build_skills_and_plugins(
     {
         explicitly_requested_mcp_servers.insert(CODEX_APPS_MCP_SERVER_NAME.to_string());
     }
-    if !explicitly_requested_mcp_servers.is_empty() {
-        let mut explicitly_requested_mcp_servers = explicitly_requested_mcp_servers
-            .into_iter()
-            .collect::<Vec<_>>();
-        explicitly_requested_mcp_servers.sort();
-        let readiness = {
-            let mcp_connection_manager = sess.services.mcp_connection_manager.read().await;
-            mcp_connection_manager.wait_for_servers_ready(&explicitly_requested_mcp_servers)
-        };
-        let failures = match readiness.or_cancel(cancellation_token).await {
-            Ok(failures) => failures,
-            Err(_) => return None,
-        };
-        for failure in failures {
-            sess.send_event(
-                turn_context,
-                EventMsg::Warning(WarningEvent {
-                    message: format!(
-                        "MCP dependency `{}` requested for this turn is unavailable: {}",
-                        failure.server, failure.error
-                    ),
-                }),
-            )
-            .await;
-        }
-    }
+    wait_for_explicit_mcp_servers(
+        sess,
+        turn_context,
+        cancellation_token,
+        explicitly_requested_mcp_servers,
+    )
+    .await?;
     let mcp_tools = if turn_context.apps_enabled() || !mentioned_plugins.is_empty() {
         // Plugin mentions need raw MCP/app inventory even when app tools
         // are normally hidden so we can describe the plugin's currently
@@ -579,7 +560,7 @@ async fn build_skills_and_plugins(
         &skills_outcome.disabled_paths,
         &connector_slug_counts,
     );
-    maybe_prompt_and_install_mcp_dependencies(
+    let skill_dependency_servers = maybe_prompt_and_install_mcp_dependencies(
         sess,
         turn_context,
         cancellation_token,
@@ -587,6 +568,13 @@ async fn build_skills_and_plugins(
         Some(sess.mcp_elicitation_reviewer()),
     )
     .await;
+    wait_for_explicit_mcp_servers(
+        sess,
+        turn_context,
+        cancellation_token,
+        skill_dependency_servers,
+    )
+    .await?;
 
     let SkillInjections {
         items: skill_injections,
@@ -699,6 +687,37 @@ async fn build_extension_turn_input_items(
     }
 
     Some(items)
+}
+
+async fn wait_for_explicit_mcp_servers(
+    sess: &Session,
+    turn_context: &TurnContext,
+    cancellation_token: &CancellationToken,
+    servers: HashSet<String>,
+) -> Option<()> {
+    if servers.is_empty() {
+        return Some(());
+    }
+    let mut servers = servers.into_iter().collect::<Vec<_>>();
+    servers.sort();
+    let readiness = {
+        let mcp_connection_manager = sess.services.mcp_connection_manager.read().await;
+        mcp_connection_manager.wait_for_servers_ready(&servers)
+    };
+    let failures = readiness.or_cancel(cancellation_token).await.ok()?;
+    for failure in failures {
+        sess.send_event(
+            turn_context,
+            EventMsg::Warning(WarningEvent {
+                message: format!(
+                    "MCP dependency `{}` requested for this turn is unavailable: {}",
+                    failure.server, failure.error
+                ),
+            }),
+        )
+        .await;
+    }
+    Some(())
 }
 
 async fn track_turn_resolved_config_analytics(

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -26,6 +26,7 @@ use crate::hook_runtime::run_pending_session_start_hooks;
 use crate::hook_runtime::run_turn_stop_hooks;
 use crate::injection::ToolMentionKind;
 use crate::injection::app_id_from_path;
+use crate::injection::extract_tool_mentions;
 use crate::injection::tool_kind_for_path;
 use crate::mcp_skill_dependencies::maybe_prompt_and_install_mcp_dependencies;
 use crate::mcp_tool_exposure::build_mcp_tool_exposure;
@@ -484,12 +485,43 @@ async fn build_skills_and_plugins(
         collect_explicit_plugin_mentions(&user_input, loaded_plugins.capability_summaries());
     let explicitly_mentioned_apps = collect_explicit_app_ids(&user_input);
     let skills_outcome = turn_context.turn_skills.outcome.as_ref();
-    // Skill injection can contain app references, and plain skill mentions share
-    // resolution space with apps. Preserve explicit-turn behavior by resolving
-    // app inventory before finalizing any selected skill.
-    let has_explicit_skill_selection = turn_context.apps_enabled()
+    // Structured skill selections are unambiguous without app inventory. Load
+    // them before deciding whether the pending Apps MCP is a dependency of this
+    // turn, then reuse the injections below so loading and telemetry happen once.
+    let structured_skill_input = user_input
+        .iter()
+        .filter(|item| matches!(item, UserInput::Skill { .. }))
+        .cloned()
+        .collect::<Vec<_>>();
+    let structured_mentioned_skills = collect_explicit_skill_mentions(
+        &structured_skill_input,
+        &skills_outcome.skills,
+        &skills_outcome.disabled_paths,
+        &HashMap::new(),
+    );
+    let SkillInjections {
+        items: mut skill_injections,
+        warnings: mut skill_warnings,
+    } = build_skill_injections(
+        &structured_mentioned_skills,
+        Some(skills_outcome),
+        Some(&turn_context.session_telemetry),
+        &sess.services.analytics_events_client,
+        tracking.clone(),
+    )
+    .await;
+    let structured_skill_may_reference_apps =
+        skill_injections_may_reference_apps(&skill_injections);
+    // Plain text skill mentions can collide with app slugs, so preserve their
+    // existing app-inventory resolution behavior.
+    let text_skill_input = user_input
+        .iter()
+        .filter(|item| matches!(item, UserInput::Text { .. }))
+        .cloned()
+        .collect::<Vec<_>>();
+    let text_may_select_skill_requiring_app_resolution = turn_context.apps_enabled()
         && !collect_explicit_skill_mentions(
-            &user_input,
+            &text_skill_input,
             &skills_outcome.skills,
             &skills_outcome.disabled_paths,
             &HashMap::new(),
@@ -505,7 +537,8 @@ async fn build_skills_and_plugins(
     if turn_context.apps_enabled()
         && (!explicitly_mentioned_apps.is_empty()
             || mentioned_plugin_uses_apps
-            || has_explicit_skill_selection)
+            || structured_skill_may_reference_apps
+            || text_may_select_skill_requiring_app_resolution)
     {
         explicitly_requested_mcp_servers.insert(CODEX_APPS_MCP_SERVER_NAME.to_string());
     }
@@ -583,17 +616,28 @@ async fn build_skills_and_plugins(
         .await?;
     }
 
+    let structured_skill_paths = structured_mentioned_skills
+        .iter()
+        .map(|skill| &skill.path_to_skills_md)
+        .collect::<HashSet<_>>();
+    let remaining_mentioned_skills = mentioned_skills
+        .iter()
+        .filter(|skill| !structured_skill_paths.contains(&skill.path_to_skills_md))
+        .cloned()
+        .collect::<Vec<_>>();
     let SkillInjections {
-        items: skill_injections,
-        warnings: skill_warnings,
+        items: remaining_skill_injections,
+        warnings: remaining_skill_warnings,
     } = build_skill_injections(
-        &mentioned_skills,
+        &remaining_mentioned_skills,
         Some(skills_outcome),
         Some(&turn_context.session_telemetry),
         &sess.services.analytics_events_client,
         tracking.clone(),
     )
     .await;
+    skill_injections.extend(remaining_skill_injections);
+    skill_warnings.extend(remaining_skill_warnings);
 
     for message in skill_warnings {
         sess.send_event(turn_context, EventMsg::Warning(WarningEvent { message }))
@@ -725,6 +769,18 @@ async fn wait_for_explicit_mcp_servers(
         .await;
     }
     Some(())
+}
+
+fn skill_injections_may_reference_apps(
+    skill_injections: &[crate::injection::SkillInjection],
+) -> bool {
+    skill_injections.iter().any(|skill| {
+        let mentions = extract_tool_mentions(&skill.contents);
+        mentions.plain_names().next().is_some()
+            || mentions
+                .paths()
+                .any(|path| tool_kind_for_path(path) == ToolMentionKind::App)
+    })
 }
 
 async fn track_turn_resolved_config_analytics(

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -551,7 +551,7 @@ async fn build_skills_and_plugins(
         explicitly_requested_mcp_servers,
     )
     .await?;
-    let mcp_tools = if turn_context.apps_enabled() || !mentioned_plugins.is_empty() {
+    let mut mcp_tools = if turn_context.apps_enabled() || !mentioned_plugins.is_empty() {
         // Plugin mentions need raw MCP/app inventory even when app tools
         // are normally hidden so we can describe the plugin's currently
         // usable capabilities for this turn.
@@ -571,7 +571,7 @@ async fn build_skills_and_plugins(
     } else {
         Vec::new()
     };
-    let available_connectors = if turn_context.apps_enabled() {
+    let mut available_connectors = if turn_context.apps_enabled() {
         let connectors = codex_connectors::merge::merge_plugin_connectors_with_accessible(
             loaded_plugins
                 .effective_apps()
@@ -614,6 +614,30 @@ async fn build_skills_and_plugins(
             skill_dependency_servers,
         )
         .await?;
+        mcp_tools = match sess
+            .services
+            .mcp_connection_manager
+            .read()
+            .await
+            .list_ready_or_cached_tools()
+            .or_cancel(cancellation_token)
+            .await
+        {
+            Ok(mcp_tools) => mcp_tools,
+            Err(_) if turn_context.apps_enabled() => return None,
+            Err(_) => Vec::new(),
+        };
+        if turn_context.apps_enabled() {
+            let connectors = codex_connectors::merge::merge_plugin_connectors_with_accessible(
+                loaded_plugins
+                    .effective_apps()
+                    .into_iter()
+                    .map(|connector_id| connector_id.0),
+                connectors::accessible_connectors_from_mcp_tools(&mcp_tools),
+            );
+            available_connectors =
+                connectors::with_app_enabled_state(connectors, &turn_context.config);
+        }
     }
 
     let structured_skill_paths = structured_mentioned_skills

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -483,11 +483,30 @@ async fn build_skills_and_plugins(
     let mentioned_plugins =
         collect_explicit_plugin_mentions(&user_input, loaded_plugins.capability_summaries());
     let explicitly_mentioned_apps = collect_explicit_app_ids(&user_input);
+    let skills_outcome = turn_context.turn_skills.outcome.as_ref();
+    // Skill injection can contain app references, and plain skill mentions share
+    // resolution space with apps. Preserve explicit-turn behavior by resolving
+    // app inventory before finalizing any selected skill.
+    let has_explicit_skill_selection = turn_context.apps_enabled()
+        && !collect_explicit_skill_mentions(
+            &user_input,
+            &skills_outcome.skills,
+            &skills_outcome.disabled_paths,
+            &HashMap::new(),
+        )
+        .is_empty();
     let mut explicitly_requested_mcp_servers = mentioned_plugins
         .iter()
         .flat_map(|plugin| plugin.mcp_server_names.iter().cloned())
         .collect::<HashSet<_>>();
-    if turn_context.apps_enabled() && !explicitly_mentioned_apps.is_empty() {
+    let mentioned_plugin_uses_apps = mentioned_plugins
+        .iter()
+        .any(|plugin| !plugin.app_connector_ids.is_empty());
+    if turn_context.apps_enabled()
+        && (!explicitly_mentioned_apps.is_empty()
+            || mentioned_plugin_uses_apps
+            || has_explicit_skill_selection)
+    {
         explicitly_requested_mcp_servers.insert(CODEX_APPS_MCP_SERVER_NAME.to_string());
     }
     if !explicitly_requested_mcp_servers.is_empty() {
@@ -548,7 +567,6 @@ async fn build_skills_and_plugins(
     } else {
         Vec::new()
     };
-    let skills_outcome = turn_context.turn_skills.outcome.as_ref();
     let connector_slug_counts = build_connector_slug_counts(&available_connectors);
     let extension_injection_items =
         build_extension_turn_input_items(sess, turn_context, &user_input, cancellation_token)

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -26,7 +26,6 @@ use crate::hook_runtime::run_pending_session_start_hooks;
 use crate::hook_runtime::run_turn_stop_hooks;
 use crate::injection::ToolMentionKind;
 use crate::injection::app_id_from_path;
-use crate::injection::extract_tool_mentions;
 use crate::injection::tool_kind_for_path;
 use crate::mcp_skill_dependencies::maybe_prompt_and_install_mcp_dependencies;
 use crate::mcp_tool_exposure::build_mcp_tool_exposure;
@@ -511,8 +510,7 @@ async fn build_skills_and_plugins(
     )
     .await;
     let structured_skill_may_reference_apps =
-        skill_injections_may_reference_apps(&skill_injections)
-            || structured_skill_inputs_may_reference_apps(&structured_skill_input).await;
+        skill_injections_may_reference_apps(&skill_injections);
     // Plain text skill mentions can collide with app slugs, so preserve their
     // existing app-inventory resolution behavior.
     let text_skill_input = user_input
@@ -804,22 +802,8 @@ fn skill_injections_may_reference_apps(
         .any(|skill| skill_contents_may_reference_apps(&skill.contents))
 }
 
-async fn structured_skill_inputs_may_reference_apps(inputs: &[UserInput]) -> bool {
-    for input in inputs {
-        let UserInput::Skill { path, .. } = input else {
-            continue;
-        };
-        if let Ok(contents) = tokio::fs::read_to_string(path).await
-            && skill_contents_may_reference_apps(&contents)
-        {
-            return true;
-        }
-    }
-    false
-}
-
 fn skill_contents_may_reference_apps(contents: &str) -> bool {
-    let mentions = extract_tool_mentions(contents);
+    let mentions = crate::injection::extract_tool_mentions(contents);
     mentions.plain_names().next().is_some()
         || mentions
             .paths()

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -509,6 +509,8 @@ async fn build_skills_and_plugins(
     {
         explicitly_requested_mcp_servers.insert(CODEX_APPS_MCP_SERVER_NAME.to_string());
     }
+    let explicit_mcp_servers_to_rewait_after_skill_install =
+        explicitly_requested_mcp_servers.clone();
     wait_for_explicit_mcp_servers(
         sess,
         turn_context,
@@ -560,7 +562,7 @@ async fn build_skills_and_plugins(
         &skills_outcome.disabled_paths,
         &connector_slug_counts,
     );
-    let skill_dependency_servers = maybe_prompt_and_install_mcp_dependencies(
+    let mut skill_dependency_servers = maybe_prompt_and_install_mcp_dependencies(
         sess,
         turn_context,
         cancellation_token,
@@ -568,13 +570,18 @@ async fn build_skills_and_plugins(
         Some(sess.mcp_elicitation_reviewer()),
     )
     .await;
-    wait_for_explicit_mcp_servers(
-        sess,
-        turn_context,
-        cancellation_token,
-        skill_dependency_servers,
-    )
-    .await?;
+    if !skill_dependency_servers.is_empty() {
+        // Installing a dependency refreshes the manager and restarts any app or
+        // plugin server already awaited for this same explicit invocation.
+        skill_dependency_servers.extend(explicit_mcp_servers_to_rewait_after_skill_install);
+        wait_for_explicit_mcp_servers(
+            sess,
+            turn_context,
+            cancellation_token,
+            skill_dependency_servers,
+        )
+        .await?;
+    }
 
     let SkillInjections {
         items: skill_injections,

--- a/codex-rs/core/src/skills.rs
+++ b/codex-rs/core/src/skills.rs
@@ -25,6 +25,7 @@ pub use codex_core_skills::injection;
 pub use codex_core_skills::injection::SkillInjections;
 pub use codex_core_skills::injection::build_skill_injections;
 pub use codex_core_skills::injection::collect_explicit_skill_mentions;
+pub use codex_core_skills::injection::collect_unambiguous_skill_mentions;
 pub use codex_core_skills::loader;
 pub use codex_core_skills::manager;
 pub use codex_core_skills::model;

--- a/codex-rs/core/tests/common/apps_test_server.rs
+++ b/codex-rs/core/tests/common/apps_test_server.rs
@@ -74,6 +74,7 @@ impl AppsTestServer {
             CONNECTOR_DESCRIPTION.to_string(),
             /*searchable*/ true,
             /*include_app_only_tool*/ false,
+            /*include_connector_tools*/ true,
             /*tools_list_delay*/ None,
         )
         .await;
@@ -107,6 +108,7 @@ impl AppsTestServer {
             CONNECTOR_DESCRIPTION.to_string(),
             /*searchable*/ false,
             /*include_app_only_tool*/ false,
+            /*include_connector_tools*/ true,
             tools_list_delay,
         )
         .await;
@@ -127,6 +129,25 @@ impl AppsTestServer {
             CONNECTOR_DESCRIPTION.to_string(),
             matches!(tool_loading, AppsTestToolLoading::Searchable),
             /*include_app_only_tool*/ true,
+            /*include_connector_tools*/ true,
+            /*tools_list_delay*/ None,
+        )
+        .await;
+        Ok(Self {
+            chatgpt_base_url: server.uri(),
+        })
+    }
+
+    pub async fn mount_without_tools(server: &MockServer) -> Result<Self> {
+        mount_oauth_metadata(server).await;
+        mount_connectors_directory(server).await;
+        mount_streamable_http_json_rpc(
+            server,
+            CONNECTOR_NAME.to_string(),
+            CONNECTOR_DESCRIPTION.to_string(),
+            /*searchable*/ false,
+            /*include_app_only_tool*/ false,
+            /*include_connector_tools*/ false,
             /*tools_list_delay*/ None,
         )
         .await;
@@ -282,6 +303,7 @@ async fn mount_streamable_http_json_rpc(
     connector_description: String,
     searchable: bool,
     include_app_only_tool: bool,
+    include_connector_tools: bool,
     tools_list_delay: Option<Duration>,
 ) {
     Mock::given(method("POST"))
@@ -291,6 +313,7 @@ async fn mount_streamable_http_json_rpc(
             connector_description,
             searchable,
             include_app_only_tool,
+            include_connector_tools,
             tools_list_delay,
         })
         .mount(server)
@@ -302,6 +325,7 @@ struct CodexAppsJsonRpcResponder {
     connector_description: String,
     searchable: bool,
     include_app_only_tool: bool,
+    include_connector_tools: bool,
     tools_list_delay: Option<Duration>,
 }
 
@@ -446,6 +470,13 @@ impl Respond for CodexAppsJsonRpcResponder {
                         "nextCursor": null
                     }
                 });
+                if !self.include_connector_tools
+                    && let Some(tools) = response
+                        .pointer_mut("/result/tools")
+                        .and_then(Value::as_array_mut)
+                {
+                    tools.clear();
+                }
                 if self.searchable
                     && let Some(tools) = response
                         .pointer_mut("/result/tools")

--- a/codex-rs/core/tests/common/apps_test_server.rs
+++ b/codex-rs/core/tests/common/apps_test_server.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use crate::test_codex::TestCodexBuilder;
 use crate::test_codex::test_codex;
 use anyhow::Result;
@@ -72,6 +74,7 @@ impl AppsTestServer {
             CONNECTOR_DESCRIPTION.to_string(),
             /*searchable*/ true,
             /*include_app_only_tool*/ false,
+            /*tools_list_delay*/ None,
         )
         .await;
         Ok(Self {
@@ -83,6 +86,19 @@ impl AppsTestServer {
         server: &MockServer,
         connector_name: &str,
     ) -> Result<Self> {
+        Self::mount_with_connector_name_and_tools_list_delay(
+            server,
+            connector_name,
+            /*tools_list_delay*/ None,
+        )
+        .await
+    }
+
+    pub async fn mount_with_connector_name_and_tools_list_delay(
+        server: &MockServer,
+        connector_name: &str,
+        tools_list_delay: Option<Duration>,
+    ) -> Result<Self> {
         mount_oauth_metadata(server).await;
         mount_connectors_directory(server).await;
         mount_streamable_http_json_rpc(
@@ -91,6 +107,7 @@ impl AppsTestServer {
             CONNECTOR_DESCRIPTION.to_string(),
             /*searchable*/ false,
             /*include_app_only_tool*/ false,
+            tools_list_delay,
         )
         .await;
         Ok(Self {
@@ -110,6 +127,7 @@ impl AppsTestServer {
             CONNECTOR_DESCRIPTION.to_string(),
             matches!(tool_loading, AppsTestToolLoading::Searchable),
             /*include_app_only_tool*/ true,
+            /*tools_list_delay*/ None,
         )
         .await;
         Ok(Self {
@@ -264,6 +282,7 @@ async fn mount_streamable_http_json_rpc(
     connector_description: String,
     searchable: bool,
     include_app_only_tool: bool,
+    tools_list_delay: Option<Duration>,
 ) {
     Mock::given(method("POST"))
         .and(path_regex("^/api/codex/apps/?$"))
@@ -272,6 +291,7 @@ async fn mount_streamable_http_json_rpc(
             connector_description,
             searchable,
             include_app_only_tool,
+            tools_list_delay,
         })
         .mount(server)
         .await;
@@ -282,6 +302,7 @@ struct CodexAppsJsonRpcResponder {
     connector_description: String,
     searchable: bool,
     include_app_only_tool: bool,
+    tools_list_delay: Option<Duration>,
 }
 
 impl Respond for CodexAppsJsonRpcResponder {
@@ -475,7 +496,12 @@ impl Respond for CodexAppsJsonRpcResponder {
                         }
                     }));
                 }
-                ResponseTemplate::new(200).set_body_json(response)
+                let response = ResponseTemplate::new(/*s*/ 200).set_body_json(response);
+                if let Some(delay) = self.tools_list_delay {
+                    response.set_delay(delay)
+                } else {
+                    response
+                }
             }
             "tools/call" => {
                 let id = body.get("id").cloned().unwrap_or(Value::Null);

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -1316,6 +1316,126 @@ async fn includes_apps_guidance_as_developer_message_for_chatgpt_auth() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn includes_apps_guidance_while_apps_inventory_is_pending() {
+    skip_if_no_network!();
+    let server = MockServer::start().await;
+    let apps_server = AppsTestServer::mount_with_connector_name_and_tools_list_delay(
+        &server,
+        "Google Calendar",
+        Some(std::time::Duration::from_secs(/*secs*/ 5)),
+    )
+    .await
+    .expect("mount delayed apps MCP mock");
+    let apps_base_url = apps_server.chatgpt_base_url.clone();
+
+    let resp_mock = mount_sse_once(
+        &server,
+        sse(vec![ev_response_created("resp1"), ev_completed("resp1")]),
+    )
+    .await;
+
+    let mut builder = test_codex()
+        .with_auth(create_dummy_codex_auth())
+        .with_config(move |config| {
+            config
+                .features
+                .enable(Feature::Apps)
+                .expect("test config should allow feature update");
+            config.chatgpt_base_url = apps_base_url;
+        });
+    let codex = builder
+        .build(&server)
+        .await
+        .expect("create new conversation")
+        .codex;
+
+    tokio::time::timeout(std::time::Duration::from_secs(/*secs*/ 2), async {
+        codex
+            .submit(Op::UserInput {
+                environments: None,
+                items: vec![UserInput::Text {
+                    text: "hello".into(),
+                    text_elements: Vec::new(),
+                }],
+                final_output_json_schema: None,
+                responsesapi_client_metadata: None,
+                additional_context: Default::default(),
+                thread_settings: Default::default(),
+            })
+            .await
+            .unwrap();
+        wait_for_event(&codex, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+    })
+    .await
+    .expect("ordinary turn should not wait for pending apps inventory");
+
+    let request = resp_mock.single_request();
+    assert!(
+        message_input_text_contains(&request, "developer", "<apps_instructions>"),
+        "expected apps instructions while inventory is pending, got {:?}",
+        request.body_json()["input"]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn omits_apps_guidance_when_apps_inventory_is_empty() {
+    skip_if_no_network!();
+    let server = MockServer::start().await;
+    let apps_server = AppsTestServer::mount_without_tools(&server)
+        .await
+        .expect("mount empty apps MCP mock");
+    let apps_base_url = apps_server.chatgpt_base_url.clone();
+
+    let resp_mock = mount_sse_once(
+        &server,
+        sse(vec![ev_response_created("resp1"), ev_completed("resp1")]),
+    )
+    .await;
+
+    let mut builder = test_codex()
+        .with_auth(create_dummy_codex_auth())
+        .with_config(move |config| {
+            config
+                .features
+                .enable(Feature::Apps)
+                .expect("test config should allow feature update");
+            config.chatgpt_base_url = apps_base_url;
+        });
+    let codex = builder
+        .build(&server)
+        .await
+        .expect("create new conversation")
+        .codex;
+    wait_for_mcp_server(&codex, "codex_apps")
+        .await
+        .expect("wait for apps MCP startup");
+
+    codex
+        .submit(Op::UserInput {
+            environments: None,
+            items: vec![UserInput::Text {
+                text: "hello".into(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+            responsesapi_client_metadata: None,
+            additional_context: Default::default(),
+            thread_settings: Default::default(),
+        })
+        .await
+        .unwrap();
+
+    wait_for_event(&codex, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+
+    let request = resp_mock.single_request();
+    assert!(
+        !message_input_text_contains(&request, "developer", "<apps_instructions>"),
+        "did not expect apps instructions for empty inventory, got {:?}",
+        request.body_json()["input"]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn omits_apps_guidance_for_api_key_auth_even_when_feature_enabled() {
     skip_if_no_network!();
     let server = MockServer::start().await;

--- a/codex-rs/core/tests/suite/plugins.rs
+++ b/codex-rs/core/tests/suite/plugins.rs
@@ -517,11 +517,11 @@ async fn selected_skill_rewaits_for_app_after_installing_mcp_dependency() -> Res
     .expect("write plugin app skill");
     let skill_agents_dir = skill_path.parent().expect("skill dir").join("agents");
     std::fs::create_dir_all(&skill_agents_dir).expect("create skill agents dir");
-    let dependency_command = stdio_server_bin()?;
+    let dependency_url = format!("{}/api/codex/apps", server.uri());
     std::fs::write(
         skill_agents_dir.join("openai.yaml"),
         format!(
-            "dependencies:\n  tools:\n    - type: \"mcp\"\n      value: \"dependency\"\n      transport: \"stdio\"\n      command: \"{dependency_command}\"\n"
+            "dependencies:\n  tools:\n    - type: \"mcp\"\n      value: \"dependency\"\n      transport: \"streamable_http\"\n      url: \"{dependency_url}\"\n"
         ),
     )
     .expect("write plugin skill dependencies");
@@ -556,7 +556,9 @@ async fn selected_skill_rewaits_for_app_after_installing_mcp_dependency() -> Res
         "expected app referenced by selected skill after dependency installation refresh"
     );
     assert!(
-        request.tool_by_name("mcp__dependency", "echo").is_some(),
+        request
+            .tool_by_name("mcp__dependency", "calendar_list_events")
+            .is_some(),
         "expected newly installed MCP dependency on the first turn"
     );
 

--- a/codex-rs/core/tests/suite/plugins.rs
+++ b/codex-rs/core/tests/suite/plugins.rs
@@ -103,11 +103,11 @@ fn write_plugin_app_plugin(home: &TempDir) {
 
 async fn build_analytics_plugin_test_codex(
     server: &MockServer,
-    codex_home: Arc<TempDir>,
+    codex_home: &Arc<TempDir>,
 ) -> Result<TestCodex> {
     let chatgpt_base_url = server.uri();
     let mut builder = test_codex()
-        .with_home(codex_home)
+        .with_home(Arc::clone(codex_home))
         .with_auth(CodexAuth::create_dummy_chatgpt_auth_for_testing())
         .with_model("gpt-5.2")
         .with_config(move |config| {
@@ -121,11 +121,11 @@ async fn build_analytics_plugin_test_codex(
 
 async fn build_apps_enabled_plugin_test_codex(
     server: &MockServer,
-    codex_home: Arc<TempDir>,
+    codex_home: &Arc<TempDir>,
     chatgpt_base_url: String,
 ) -> Result<TestCodex> {
     let mut builder = test_codex()
-        .with_home(codex_home)
+        .with_home(Arc::clone(codex_home))
         .with_auth(CodexAuth::create_dummy_chatgpt_auth_for_testing())
         .with_config(move |config| {
             config
@@ -172,12 +172,9 @@ async fn capability_sections_render_in_developer_message_in_order() -> Result<()
     let codex_home = Arc::new(TempDir::new()?);
     write_plugin_skill_plugin(codex_home.as_ref());
     write_plugin_app_plugin(codex_home.as_ref());
-    let test_codex = build_apps_enabled_plugin_test_codex(
-        &server,
-        Arc::clone(&codex_home),
-        apps_server.chatgpt_base_url,
-    )
-    .await?;
+    let test_codex =
+        build_apps_enabled_plugin_test_codex(&server, &codex_home, apps_server.chatgpt_base_url)
+            .await?;
     let codex = Arc::clone(&test_codex.codex);
     wait_for_mcp_server(&codex, "codex_apps").await?;
 
@@ -257,7 +254,7 @@ async fn explicit_plugin_mentions_inject_plugin_guidance() -> Result<()> {
     write_plugin_app_plugin(codex_home.as_ref());
 
     let test_codex =
-        build_apps_enabled_plugin_test_codex(&server, codex_home, apps_server.chatgpt_base_url)
+        build_apps_enabled_plugin_test_codex(&server, &codex_home, apps_server.chatgpt_base_url)
             .await?;
     let codex = Arc::clone(&test_codex.codex);
     wait_for_mcp_server(&codex, "sample").await?;
@@ -351,7 +348,7 @@ async fn explicit_app_only_plugin_mention_waits_for_pending_apps_startup() -> Re
     let codex_home = Arc::new(TempDir::new()?);
     write_plugin_app_plugin(codex_home.as_ref());
     let codex =
-        build_apps_enabled_plugin_test_codex(&server, codex_home, apps_server.chatgpt_base_url)
+        build_apps_enabled_plugin_test_codex(&server, &codex_home, apps_server.chatgpt_base_url)
             .await?;
 
     codex
@@ -411,7 +408,7 @@ async fn explicitly_selected_skill_waits_for_pending_apps_startup() -> Result<()
     )
     .expect("write plugin app skill");
     let codex =
-        build_apps_enabled_plugin_test_codex(&server, codex_home, apps_server.chatgpt_base_url)
+        build_apps_enabled_plugin_test_codex(&server, &codex_home, apps_server.chatgpt_base_url)
             .await?;
 
     codex
@@ -458,7 +455,7 @@ async fn explicitly_selected_non_app_skill_does_not_wait_for_pending_apps_startu
     let codex_home = Arc::new(TempDir::new()?);
     let skill_path = write_plugin_skill_plugin(codex_home.as_ref());
     let codex =
-        build_apps_enabled_plugin_test_codex(&server, codex_home, apps_server.chatgpt_base_url)
+        build_apps_enabled_plugin_test_codex(&server, &codex_home, apps_server.chatgpt_base_url)
             .await?;
 
     let completed = tokio::time::timeout(Duration::from_secs(/*secs*/ 2), async {
@@ -529,7 +526,7 @@ async fn selected_skill_rewaits_for_app_after_installing_mcp_dependency() -> Res
     )
     .expect("write plugin skill dependencies");
     let codex =
-        build_apps_enabled_plugin_test_codex(&server, codex_home, apps_server.chatgpt_base_url)
+        build_apps_enabled_plugin_test_codex(&server, &codex_home, apps_server.chatgpt_base_url)
             .await?;
 
     codex
@@ -578,7 +575,7 @@ async fn explicit_plugin_mentions_track_plugin_used_analytics() -> Result<()> {
 
     let codex_home = Arc::new(TempDir::new()?);
     write_plugin_skill_plugin(codex_home.as_ref());
-    let test_codex = build_analytics_plugin_test_codex(&server, codex_home).await?;
+    let test_codex = build_analytics_plugin_test_codex(&server, &codex_home).await?;
     let codex = Arc::clone(&test_codex.codex);
 
     codex

--- a/codex-rs/core/tests/suite/plugins.rs
+++ b/codex-rs/core/tests/suite/plugins.rs
@@ -493,6 +493,62 @@ async fn explicitly_selected_non_app_skill_does_not_wait_for_pending_apps_startu
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn linked_non_app_skill_text_does_not_wait_for_pending_apps_startup() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+    let server = start_mock_server().await;
+    let apps_server = AppsTestServer::mount_with_connector_name_and_tools_list_delay(
+        &server,
+        "Google Calendar",
+        Some(Duration::from_secs(/*secs*/ 5)),
+    )
+    .await?;
+    let mock = mount_sse_once(
+        &server,
+        sse(vec![ev_response_created("resp-1"), ev_completed("resp-1")]),
+    )
+    .await;
+
+    let codex_home = Arc::new(TempDir::new()?);
+    let skill_path = write_plugin_skill_plugin(codex_home.as_ref());
+    let codex =
+        build_apps_enabled_plugin_test_codex(&server, &codex_home, apps_server.chatgpt_base_url)
+            .await?;
+
+    let completed = tokio::time::timeout(Duration::from_secs(/*secs*/ 2), async {
+        codex
+            .submit(Op::UserInput {
+                environments: None,
+                items: vec![codex_protocol::user_input::UserInput::Text {
+                    text: format!("Use [$sample]({}).", skill_path.display()),
+                    text_elements: Vec::new(),
+                }],
+                final_output_json_schema: None,
+                responsesapi_client_metadata: None,
+                additional_context: Default::default(),
+                thread_settings: Default::default(),
+            })
+            .await?;
+        wait_for_event(&codex, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+        Ok::<_, anyhow::Error>(())
+    })
+    .await;
+    completed
+        .expect("linked non-app skill should not wait for apps startup")
+        .expect("linked non-app skill turn should complete");
+
+    let request = mock.single_request();
+    assert!(
+        request
+            .message_input_texts("user")
+            .iter()
+            .any(|text| text.contains("<name>sample:sample-search</name>")),
+        "expected linked non-app skill to be injected on the first turn"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn selected_skill_rewaits_for_app_after_installing_mcp_dependency() -> Result<()> {
     skip_if_no_network!(Ok(()));
     let server = start_mock_server().await;

--- a/codex-rs/core/tests/suite/plugins.rs
+++ b/codex-rs/core/tests/suite/plugins.rs
@@ -64,7 +64,7 @@ fn write_plugin_skill_plugin(home: &TempDir) -> std::path::PathBuf {
         "---\ndescription: inspect sample data\n---\n\n# body\n",
     )
     .expect("write plugin skill");
-    skill_dir.join("SKILL.md")
+    std::fs::canonicalize(skill_dir.join("SKILL.md")).expect("canonicalize plugin skill")
 }
 
 fn write_plugin_mcp_plugin(home: &TempDir, command: &str) {

--- a/codex-rs/core/tests/suite/plugins.rs
+++ b/codex-rs/core/tests/suite/plugins.rs
@@ -331,6 +331,113 @@ async fn explicit_plugin_mentions_inject_plugin_guidance() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn explicit_app_only_plugin_mention_waits_for_pending_apps_startup() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+    let server = start_mock_server().await;
+    let apps_server = AppsTestServer::mount_with_connector_name_and_tools_list_delay(
+        &server,
+        "Google Calendar",
+        Some(Duration::from_millis(/*millis*/ 250)),
+    )
+    .await?;
+    let mock = mount_sse_once(
+        &server,
+        sse(vec![ev_response_created("resp-1"), ev_completed("resp-1")]),
+    )
+    .await;
+
+    let codex_home = Arc::new(TempDir::new()?);
+    write_plugin_app_plugin(codex_home.as_ref());
+    let codex =
+        build_apps_enabled_plugin_test_codex(&server, codex_home, apps_server.chatgpt_base_url)
+            .await?;
+
+    codex
+        .submit(Op::UserInput {
+            environments: None,
+            items: vec![codex_protocol::user_input::UserInput::Mention {
+                name: "sample".into(),
+                path: format!("plugin://{SAMPLE_PLUGIN_CONFIG_NAME}"),
+            }],
+            final_output_json_schema: None,
+            responsesapi_client_metadata: None,
+            additional_context: Default::default(),
+            thread_settings: Default::default(),
+        })
+        .await?;
+    wait_for_event(&codex, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+
+    let request = mock.single_request();
+    let developer_messages = request.message_input_texts("developer");
+    assert!(
+        developer_messages
+            .iter()
+            .any(|text| text.contains("Apps from this plugin")),
+        "expected plugin app guidance after delayed startup: {developer_messages:?}"
+    );
+    assert!(
+        tool_names(&request.body_json())
+            .iter()
+            .any(|name| name == "mcp__codex_apps__google_calendar"),
+        "expected explicitly invoked plugin app tools on the first turn"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn explicitly_selected_skill_waits_for_pending_apps_startup() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+    let server = start_mock_server().await;
+    let apps_server = AppsTestServer::mount_with_connector_name_and_tools_list_delay(
+        &server,
+        "Google Calendar",
+        Some(Duration::from_millis(/*millis*/ 250)),
+    )
+    .await?;
+    let mock = mount_sse_once(
+        &server,
+        sse(vec![ev_response_created("resp-1"), ev_completed("resp-1")]),
+    )
+    .await;
+
+    let codex_home = Arc::new(TempDir::new()?);
+    let skill_path = write_plugin_skill_plugin(codex_home.as_ref());
+    std::fs::write(
+        &skill_path,
+        "---\ndescription: inspect sample data\n---\n\nUse [$calendar](app://calendar).\n",
+    )
+    .expect("write plugin app skill");
+    let codex =
+        build_apps_enabled_plugin_test_codex(&server, codex_home, apps_server.chatgpt_base_url)
+            .await?;
+
+    codex
+        .submit(Op::UserInput {
+            environments: None,
+            items: vec![codex_protocol::user_input::UserInput::Skill {
+                name: "sample:sample-search".into(),
+                path: skill_path,
+            }],
+            final_output_json_schema: None,
+            responsesapi_client_metadata: None,
+            additional_context: Default::default(),
+            thread_settings: Default::default(),
+        })
+        .await?;
+    wait_for_event(&codex, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+
+    assert!(
+        tool_names(&mock.single_request().body_json())
+            .iter()
+            .any(|name| name == "mcp__codex_apps__google_calendar"),
+        "expected app referenced by selected skill on the first turn"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn explicit_plugin_mentions_track_plugin_used_analytics() -> Result<()> {
     skip_if_no_network!(Ok(()));
     let server = start_mock_server().await;

--- a/codex-rs/core/tests/suite/plugins.rs
+++ b/codex-rs/core/tests/suite/plugins.rs
@@ -8,6 +8,8 @@ use std::time::Instant;
 use anyhow::Result;
 use codex_features::Feature;
 use codex_login::CodexAuth;
+use codex_protocol::models::PermissionProfile;
+use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::Op;
 use core_test_support::apps_test_server::AppsTestServer;
@@ -432,6 +434,77 @@ async fn explicitly_selected_skill_waits_for_pending_apps_startup() -> Result<()
             .iter()
             .any(|name| name == "mcp__codex_apps__google_calendar"),
         "expected app referenced by selected skill on the first turn"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn selected_skill_rewaits_for_app_after_installing_mcp_dependency() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+    let server = start_mock_server().await;
+    let apps_server = AppsTestServer::mount_with_connector_name_and_tools_list_delay(
+        &server,
+        "Google Calendar",
+        Some(Duration::from_secs(/*secs*/ 2)),
+    )
+    .await?;
+    let mock = mount_sse_once(
+        &server,
+        sse(vec![ev_response_created("resp-1"), ev_completed("resp-1")]),
+    )
+    .await;
+
+    let codex_home = Arc::new(TempDir::new()?);
+    let skill_path = write_plugin_skill_plugin(codex_home.as_ref());
+    std::fs::write(
+        &skill_path,
+        "---\ndescription: inspect sample data\n---\n\nUse [$calendar](app://calendar).\n",
+    )
+    .expect("write plugin app skill");
+    let skill_agents_dir = skill_path.parent().expect("skill dir").join("agents");
+    std::fs::create_dir_all(&skill_agents_dir).expect("create skill agents dir");
+    let dependency_command = stdio_server_bin()?;
+    std::fs::write(
+        skill_agents_dir.join("openai.yaml"),
+        format!(
+            "dependencies:\n  tools:\n    - type: \"mcp\"\n      value: \"dependency\"\n      transport: \"stdio\"\n      command: \"{dependency_command}\"\n"
+        ),
+    )
+    .expect("write plugin skill dependencies");
+    let codex =
+        build_apps_enabled_plugin_test_codex(&server, codex_home, apps_server.chatgpt_base_url)
+            .await?;
+
+    codex
+        .submit(Op::UserInput {
+            environments: None,
+            items: vec![codex_protocol::user_input::UserInput::Skill {
+                name: "sample:sample-search".into(),
+                path: skill_path,
+            }],
+            final_output_json_schema: None,
+            responsesapi_client_metadata: None,
+            additional_context: Default::default(),
+            thread_settings: codex_protocol::protocol::ThreadSettingsOverrides {
+                approval_policy: Some(AskForApproval::Never),
+                permission_profile: Some(PermissionProfile::Disabled),
+                ..Default::default()
+            },
+        })
+        .await?;
+    wait_for_event(&codex, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+
+    let request = mock.single_request();
+    assert!(
+        tool_names(&request.body_json())
+            .iter()
+            .any(|name| name == "mcp__codex_apps__google_calendar"),
+        "expected app referenced by selected skill after dependency installation refresh"
+    );
+    assert!(
+        request.tool_by_name("mcp__dependency", "echo").is_some(),
+        "expected newly installed MCP dependency on the first turn"
     );
 
     Ok(())

--- a/codex-rs/core/tests/suite/plugins.rs
+++ b/codex-rs/core/tests/suite/plugins.rs
@@ -440,6 +440,62 @@ async fn explicitly_selected_skill_waits_for_pending_apps_startup() -> Result<()
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn explicitly_selected_non_app_skill_does_not_wait_for_pending_apps_startup() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+    let server = start_mock_server().await;
+    let apps_server = AppsTestServer::mount_with_connector_name_and_tools_list_delay(
+        &server,
+        "Google Calendar",
+        Some(Duration::from_secs(/*secs*/ 5)),
+    )
+    .await?;
+    let mock = mount_sse_once(
+        &server,
+        sse(vec![ev_response_created("resp-1"), ev_completed("resp-1")]),
+    )
+    .await;
+
+    let codex_home = Arc::new(TempDir::new()?);
+    let skill_path = write_plugin_skill_plugin(codex_home.as_ref());
+    let codex =
+        build_apps_enabled_plugin_test_codex(&server, codex_home, apps_server.chatgpt_base_url)
+            .await?;
+
+    let completed = tokio::time::timeout(Duration::from_secs(/*secs*/ 2), async {
+        codex
+            .submit(Op::UserInput {
+                environments: None,
+                items: vec![codex_protocol::user_input::UserInput::Skill {
+                    name: "sample:sample-search".into(),
+                    path: skill_path,
+                }],
+                final_output_json_schema: None,
+                responsesapi_client_metadata: None,
+                additional_context: Default::default(),
+                thread_settings: Default::default(),
+            })
+            .await?;
+        wait_for_event(&codex, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+        Ok::<_, anyhow::Error>(())
+    })
+    .await;
+    completed
+        .expect("non-app skill selection should not wait for apps startup")
+        .expect("non-app skill turn should complete");
+
+    let request = mock.single_request();
+    assert!(
+        request
+            .message_input_texts("user")
+            .iter()
+            .any(|text| text.contains("<name>sample:sample-search</name>")),
+        "expected selected non-app skill to be injected on the first turn"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn selected_skill_rewaits_for_app_after_installing_mcp_dependency() -> Result<()> {
     skip_if_no_network!(Ok(()));
     let server = start_mock_server().await;

--- a/codex-rs/core/tests/suite/skills.rs
+++ b/codex-rs/core/tests/suite/skills.rs
@@ -2,6 +2,8 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use anyhow::Result;
+use codex_config::types::McpServerConfig;
+use codex_config::types::McpServerTransportConfig;
 use codex_exec_server::CreateDirectoryOptions;
 use codex_exec_server::ExecutorFileSystem;
 use codex_protocol::models::PermissionProfile;
@@ -9,6 +11,7 @@ use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::Op;
 use codex_protocol::user_input::UserInput;
 use codex_utils_absolute_path::AbsolutePathBuf;
+use core_test_support::apps_test_server::AppsTestServer;
 use core_test_support::responses::ev_assistant_message;
 use core_test_support::responses::ev_completed;
 use core_test_support::responses::ev_response_created;
@@ -19,6 +22,7 @@ use core_test_support::skip_if_no_network;
 use core_test_support::test_codex::test_codex;
 use core_test_support::test_codex::turn_permission_fields;
 use std::sync::Arc;
+use std::time::Duration;
 
 async fn write_repo_skill(
     cwd: AbsolutePathBuf,
@@ -123,6 +127,118 @@ async fn user_turn_includes_skill_instructions() -> Result<()> {
                 && text.contains(skill_path_str.as_ref())
         }),
         "expected skill instructions in user input, got {user_texts:?}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn selected_skill_waits_for_configured_mcp_dependency_startup() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    AppsTestServer::mount_with_connector_name_and_tools_list_delay(
+        &server,
+        "Dependency",
+        Some(Duration::from_secs(/*secs*/ 2)),
+    )
+    .await?;
+    let dependency_url = format!("{}/api/codex/apps", server.uri());
+    let skill_dependency_url = dependency_url.clone();
+    let mut builder = test_codex()
+        .with_workspace_setup(move |cwd, fs| {
+            let skill_dependency_url = skill_dependency_url;
+            async move {
+                write_repo_skill(cwd.clone(), Arc::clone(&fs), "demo", "demo skill", "body")
+                    .await?;
+                let agents_dir = cwd.join(".agents/skills/demo/agents");
+                fs.create_directory(
+                    &agents_dir,
+                    CreateDirectoryOptions { recursive: true },
+                    /*sandbox*/ None,
+                )
+                .await?;
+                let metadata = format!(
+                    "dependencies:\n  tools:\n    - type: \"mcp\"\n      value: \"dependency\"\n      transport: \"streamable_http\"\n      url: \"{skill_dependency_url}\"\n"
+                );
+                fs.write_file(
+                    &agents_dir.join("openai.yaml"),
+                    metadata.into_bytes(),
+                    /*sandbox*/ None,
+                )
+                .await?;
+                Ok(())
+            }
+        })
+        .with_config(move |config| {
+            let mut servers = config.mcp_servers.get().clone();
+            servers.insert(
+                "dependency".to_string(),
+                McpServerConfig {
+                    transport: McpServerTransportConfig::StreamableHttp {
+                        url: dependency_url,
+                        bearer_token_env_var: None,
+                        http_headers: None,
+                        env_http_headers: None,
+                    },
+                    environment_id: "local".to_string(),
+                    enabled: true,
+                    required: false,
+                    supports_parallel_tool_calls: false,
+                    disabled_reason: None,
+                    startup_timeout_sec: Some(Duration::from_secs(/*secs*/ 10)),
+                    tool_timeout_sec: None,
+                    default_tools_approval_mode: None,
+                    enabled_tools: None,
+                    disabled_tools: None,
+                    scopes: None,
+                    oauth: None,
+                    oauth_resource: None,
+                    tools: Default::default(),
+                },
+            );
+            config
+                .mcp_servers
+                .set(servers)
+                .expect("test mcp servers should accept any configuration");
+        });
+    let test = builder.build_with_remote_env(&server).await?;
+    let skill_path = test
+        .config
+        .cwd
+        .join(".agents/skills/demo/SKILL.md")
+        .canonicalize()
+        .unwrap_or_else(|_| test.config.cwd.join(".agents/skills/demo/SKILL.md"))
+        .to_path_buf();
+    let mock = mount_sse_once(
+        &server,
+        sse(vec![ev_response_created("resp-1"), ev_completed("resp-1")]),
+    )
+    .await;
+
+    test.codex
+        .submit(Op::UserInput {
+            items: vec![UserInput::Skill {
+                name: "demo".to_string(),
+                path: skill_path,
+            }],
+            environments: None,
+            final_output_json_schema: None,
+            responsesapi_client_metadata: None,
+            additional_context: Default::default(),
+            thread_settings: Default::default(),
+        })
+        .await?;
+    core_test_support::wait_for_event(test.codex.as_ref(), |event| {
+        matches!(event, codex_protocol::protocol::EventMsg::TurnComplete(_))
+    })
+    .await;
+
+    assert!(
+        mock.single_request()
+            .tool_by_name("mcp__dependency", "calendar_create_event")
+            .is_some(),
+        "expected selected skill MCP dependency tool on the first turn"
     );
 
     Ok(())

--- a/codex-rs/thread-manager-sample/src/main.rs
+++ b/codex-rs/thread-manager-sample/src/main.rs
@@ -198,6 +198,7 @@ fn new_config(model: Option<String>, arg0_paths: Arg0DispatchPaths) -> anyhow::R
         tui_notifications: TuiNotificationSettings::default(),
         animations: true,
         show_tooltips: true,
+        tui_show_mcp_startup_status: false,
         model_availability_nux: ModelAvailabilityNuxConfig::default(),
         tui_alternate_screen: AltScreenMode::Auto,
         tui_status_line: None,

--- a/codex-rs/thread-manager-sample/src/main.rs
+++ b/codex-rs/thread-manager-sample/src/main.rs
@@ -198,7 +198,6 @@ fn new_config(model: Option<String>, arg0_paths: Arg0DispatchPaths) -> anyhow::R
         tui_notifications: TuiNotificationSettings::default(),
         animations: true,
         show_tooltips: true,
-        tui_show_mcp_startup_status: false,
         model_availability_nux: ModelAvailabilityNuxConfig::default(),
         tui_alternate_screen: AltScreenMode::Auto,
         tui_status_line: None,

--- a/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
+++ b/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
@@ -1650,8 +1650,8 @@ async fn startup_header_handoff_visible_states_snapshot() {
         initial_plan_type: None,
         model: Some(resolved_model.clone()),
         startup_tooltip_override: Some("This is a test announcement".to_string()),
-        status_line_invalid_items_warned: Arc::new(AtomicBool::new(false)),
-        terminal_title_invalid_items_warned: Arc::new(AtomicBool::new(false)),
+        status_line_invalid_items_warned: Arc::new(AtomicBool::new(/*v*/ false)),
+        terminal_title_invalid_items_warned: Arc::new(AtomicBool::new(/*v*/ false)),
         session_telemetry: test_session_telemetry(&cfg, resolved_model.as_str()),
     };
     let mut chat = ChatWidget::new_with_app_event(init);


### PR DESCRIPTION
## Why

Moving optional MCP startup out of the ordinary turn path must not weaken explicit app, plugin, or skill invocations. If the user requests a capability, that turn should wait for the relevant server and report an actionable failure.

## What Changed

- Preserve app guidance while MCP inventory is still initializing.
- Collect MCP servers required by explicit app, plugin, and selected skill references.
- Wait only for dependencies required by the current turn.
- Re-wait after skill dependency installation refreshes MCP configuration.
- Avoid waiting for unrelated skills while keeping explicit dependency failures visible.

## Stack

1. [#25212](https://github.com/openai/codex/pull/25212) background MCP startup status
2. [#25213](https://github.com/openai/codex/pull/25213) atomic startup header handoff
3. #25214 explicit MCP dependency readiness (this PR)
4. [#25211](https://github.com/openai/codex/pull/25211) lazy tool-search registration
5. [#24987](https://github.com/openai/codex/pull/24987) pending MCP inventory integration

## How to Test

1. Configure slow app, plugin, and skill MCP dependencies.
2. Submit an unrelated prompt and confirm it can proceed without waiting for those servers.
3. Explicitly select each backed capability and confirm its turn waits for readiness.
4. Configure a failing dependency and confirm the warning identifies the requested unavailable server.

Targeted coverage:
- `just test -p codex-core selected_skill_waits_for_configured_mcp_dependency_startup`
- `just test -p codex-core explicit_plugin_mentions`
