### PR TITLE
[codex] benchmark Windows Bazel test concurrency

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -166,7 +166,7 @@ common:ci-windows-cross --config=remote
 common:ci-windows-cross --host_platform=//:rbe
 common:ci-windows-cross --strategy=remote
 common:ci-windows-cross --strategy=TestRunner=local
-common:ci-windows-cross --local_test_jobs=4
+common:ci-windows-cross --local_test_jobs=8
 common:ci-windows-cross --test_env=RUST_TEST_THREADS=1
 # Native Windows CI still covers the PowerShell tests. The cross-built gnullvm
 # binaries currently hang in PowerShell AST parser tests when those binaries are

--- a/.bazelrc
+++ b/.bazelrc
@@ -166,7 +166,7 @@ common:ci-windows-cross --config=remote
 common:ci-windows-cross --host_platform=//:rbe
 common:ci-windows-cross --strategy=remote
 common:ci-windows-cross --strategy=TestRunner=local
-common:ci-windows-cross --local_test_jobs=16
+common:ci-windows-cross --local_test_jobs=12
 common:ci-windows-cross --test_env=RUST_TEST_THREADS=1
 # Native Windows CI still covers the PowerShell tests. The cross-built gnullvm
 # binaries currently hang in PowerShell AST parser tests when those binaries are

--- a/.bazelrc
+++ b/.bazelrc
@@ -166,7 +166,7 @@ common:ci-windows-cross --config=remote
 common:ci-windows-cross --host_platform=//:rbe
 common:ci-windows-cross --strategy=remote
 common:ci-windows-cross --strategy=TestRunner=local
-common:ci-windows-cross --local_test_jobs=8
+common:ci-windows-cross --local_test_jobs=16
 common:ci-windows-cross --test_env=RUST_TEST_THREADS=1
 # Native Windows CI still covers the PowerShell tests. The cross-built gnullvm
 # binaries currently hang in PowerShell AST parser tests when those binaries are

--- a/.bazelrc
+++ b/.bazelrc
@@ -167,7 +167,7 @@ common:ci-windows-cross --host_platform=//:rbe
 common:ci-windows-cross --strategy=remote
 common:ci-windows-cross --strategy=TestRunner=local
 common:ci-windows-cross --local_test_jobs=16
-common:ci-windows-cross --test_env=RUST_TEST_THREADS=2
+common:ci-windows-cross --test_env=RUST_TEST_THREADS=1
 # Native Windows CI still covers the PowerShell tests. The cross-built gnullvm
 # binaries currently hang in PowerShell AST parser tests when those binaries are
 # run on the Windows runner.

--- a/.bazelrc
+++ b/.bazelrc
@@ -167,7 +167,7 @@ common:ci-windows-cross --host_platform=//:rbe
 common:ci-windows-cross --strategy=remote
 common:ci-windows-cross --strategy=TestRunner=local
 common:ci-windows-cross --local_test_jobs=16
-common:ci-windows-cross --test_env=RUST_TEST_THREADS=1
+common:ci-windows-cross --test_env=RUST_TEST_THREADS=2
 # Native Windows CI still covers the PowerShell tests. The cross-built gnullvm
 # binaries currently hang in PowerShell AST parser tests when those binaries are
 # run on the Windows runner.

--- a/codex-rs/core/tests/all.rs
+++ b/codex-rs/core/tests/all.rs
@@ -6,5 +6,5 @@ mod suite;
 
 #[test]
 fn windows_bazel_concurrency_experiment_cache_bust_marker() {
-    println!("windows Bazel concurrency experiment: baseline_jobs4_threads1");
+    println!("windows Bazel concurrency experiment: jobs8_threads1");
 }

--- a/codex-rs/core/tests/all.rs
+++ b/codex-rs/core/tests/all.rs
@@ -3,3 +3,8 @@
 pub use codex_protocol::error;
 
 mod suite;
+
+#[test]
+fn windows_bazel_concurrency_experiment_cache_bust_marker() {
+    println!("windows Bazel concurrency experiment: baseline_jobs4_threads1");
+}

--- a/codex-rs/core/tests/all.rs
+++ b/codex-rs/core/tests/all.rs
@@ -6,5 +6,5 @@ mod suite;
 
 #[test]
 fn windows_bazel_concurrency_experiment_cache_bust_marker() {
-    println!("windows Bazel concurrency experiment: jobs16_threads2");
+    println!("windows Bazel concurrency experiment: jobs16_threads1_confirm");
 }

--- a/codex-rs/core/tests/all.rs
+++ b/codex-rs/core/tests/all.rs
@@ -6,5 +6,5 @@ mod suite;
 
 #[test]
 fn windows_bazel_concurrency_experiment_cache_bust_marker() {
-    println!("windows Bazel concurrency experiment: jobs8_threads1");
+    println!("windows Bazel concurrency experiment: jobs16_threads1");
 }

--- a/codex-rs/core/tests/all.rs
+++ b/codex-rs/core/tests/all.rs
@@ -6,5 +6,5 @@ mod suite;
 
 #[test]
 fn windows_bazel_concurrency_experiment_cache_bust_marker() {
-    println!("windows Bazel concurrency experiment: jobs16_threads1_confirm");
+    println!("windows Bazel concurrency experiment: jobs12_threads1");
 }

--- a/codex-rs/core/tests/all.rs
+++ b/codex-rs/core/tests/all.rs
@@ -6,5 +6,5 @@ mod suite;
 
 #[test]
 fn windows_bazel_concurrency_experiment_cache_bust_marker() {
-    println!("windows Bazel concurrency experiment: jobs16_threads1");
+    println!("windows Bazel concurrency experiment: jobs16_threads2");
 }


### PR DESCRIPTION
Measure whether the Windows Bazel shard runners are unnecessarily throttled by the current local test concurrency settings.

This draft is an experiment branch. Each measured commit changes a temporary printed marker in `codex-rs/core/tests/all.rs` so the core-bearing Windows shard cannot reuse the previous `codex_core` test result. The marker invalidates core targets only; other targets in a shard may remain cached.

Measurements (Windows Bazel workflow; core-bearing shard is the comparison point):

| Variant | `local_test_jobs` | `RUST_TEST_THREADS` | Core-bearing shard wall time | Result |
| --- | ---: | ---: | ---: | --- |
| baseline (`f6fff80`) | 4 | 1 | 11m32s | pass; `core-all-test` 95.3s max / 48.7s avg |
| `jobs8_threads1` (`8e89edf`) | 8 | 1 | 11m15s | pass; `core-all-test` 195.0s max / 103.6s avg |
| `jobs16_threads1` (`e23a81f`) | 16 | 1 | 9m04s | pass; `core-all-test` 242.3s max / 187.2s avg |
| `jobs16_threads2` (`c7e7955`) | 16 | 2 | 12m04s | fail; two `codex-hooks` tests failed on shard 1/4 |
| `jobs16_threads1_confirm` (`939b57d`) | 16 | 1 | 11m05s | pass; `core-all-test` flaky, 259.9s max / 208.9s avg over 17 runs |
| `jobs12_threads1` (`54e0952`) | 12 | 1 | 10m51s | pass; `core-all-test` 261.1s max / 167.7s avg |

Reading: `RUST_TEST_THREADS=1` is justified: raising it to `2` made the run slower and caused Windows failures. More Bazel-level fanout has possible upside, but the benefit is noisy and increases core contention: `jobs=12` saved 41s without a retry, while `jobs=16` ranged from a 2m28s win to a flaky 27s win. This draft does not establish a safe permanent replacement for `local_test_jobs=4`; it does identify `12` as the least alarming follow-up point if repeated samples are desired.

Validation outside CI: `just fmt` completed Rust formatting, then failed during its Python phase because `openai-codex-cli-bin==0.132.0` has no wheel for this glibc Linux environment. `just test -p codex-core` compiled and ran 2,592 tests for the baseline marker; 2,586 passed and six environment-sensitive tests failed locally (config/home/git/realtime-context/sandbox-env coverage).