### PR TITLE
[codex] derive window generation from effective rollout lineage

### DIFF
--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -398,6 +398,14 @@ impl ModelClient {
         self.state
             .window_generation
             .store(window_generation, Ordering::Relaxed);
+        self.store_cached_websocket_session(WebsocketSession::default());
+    }
+
+    /// Restores persisted window lineage without changing WebSocket continuation state.
+    pub(crate) fn restore_window_generation(&self, window_generation: u64) {
+        self.state
+            .window_generation
+            .store(window_generation, Ordering::Relaxed);
     }
 
     pub(crate) fn advance_window_generation(&self) {

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -185,7 +185,7 @@ struct ModelClientState {
     include_attestation: bool,
     attestation_provider: Option<Arc<dyn AttestationProvider>>,
     disable_websockets: AtomicBool,
-    cached_websocket_session: StdMutex<CachedWebsocketSession>,
+    cached_websocket_session: StdMutex<WebsocketSession>,
 }
 
 /// Resolved API client setup for a single request attempt.
@@ -242,7 +242,6 @@ pub struct ModelClient {
 pub struct ModelClientSession {
     client: ModelClient,
     websocket_session: WebsocketSession,
-    websocket_cache_generation: u64,
     /// Turn state for sticky routing.
     ///
     /// This is an `OnceLock` that stores the turn state value received from the server
@@ -269,12 +268,6 @@ struct WebsocketSession {
     last_response_rx: Option<oneshot::Receiver<LastResponse>>,
     last_response_from_untraced_warmup: bool,
     connection_reused: StdMutex<bool>,
-}
-
-#[derive(Debug, Default)]
-struct CachedWebsocketSession {
-    generation: u64,
-    session: WebsocketSession,
 }
 
 impl WebsocketSession {
@@ -365,7 +358,7 @@ impl ModelClient {
                 include_attestation,
                 attestation_provider,
                 disable_websockets: AtomicBool::new(false),
-                cached_websocket_session: StdMutex::new(CachedWebsocketSession::default()),
+                cached_websocket_session: StdMutex::new(WebsocketSession::default()),
             }),
             prompt_cache_key_override: None,
         }
@@ -390,11 +383,9 @@ impl ModelClient {
     /// This constructor does not perform network I/O itself; the session opens a websocket lazily
     /// when the first stream request is issued.
     pub fn new_session(&self) -> ModelClientSession {
-        let (websocket_cache_generation, websocket_session) = self.take_cached_websocket_session();
         ModelClientSession {
             client: self.clone(),
-            websocket_session,
-            websocket_cache_generation,
+            websocket_session: self.take_cached_websocket_session(),
             turn_state: Arc::new(OnceLock::new()),
         }
     }
@@ -407,12 +398,12 @@ impl ModelClient {
         self.state
             .window_generation
             .store(window_generation, Ordering::Relaxed);
-        self.invalidate_cached_websocket_session();
+        self.store_cached_websocket_session(WebsocketSession::default());
     }
 
     pub(crate) fn advance_window_generation(&self) {
         self.state.window_generation.fetch_add(1, Ordering::Relaxed);
-        self.invalidate_cached_websocket_session();
+        self.store_cached_websocket_session(WebsocketSession::default());
     }
 
     pub(crate) fn current_window_id(&self) -> String {
@@ -421,36 +412,21 @@ impl ModelClient {
         format!("{thread_id}:{window_generation}")
     }
 
-    pub(crate) fn invalidate_cached_websocket_session(&self) {
+    fn take_cached_websocket_session(&self) -> WebsocketSession {
         let mut cached_websocket_session = self
             .state
             .cached_websocket_session
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        cached_websocket_session.generation = cached_websocket_session.generation.saturating_add(1);
-        cached_websocket_session.session = WebsocketSession::default();
+        std::mem::take(&mut *cached_websocket_session)
     }
 
-    fn take_cached_websocket_session(&self) -> (u64, WebsocketSession) {
-        let mut cached_websocket_session = self
+    fn store_cached_websocket_session(&self, websocket_session: WebsocketSession) {
+        *self
             .state
             .cached_websocket_session
             .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let generation = cached_websocket_session.generation;
-        let session = std::mem::take(&mut cached_websocket_session.session);
-        (generation, session)
-    }
-
-    fn store_cached_websocket_session(&self, generation: u64, websocket_session: WebsocketSession) {
-        let mut cached_websocket_session = self
-            .state
-            .cached_websocket_session
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        if cached_websocket_session.generation == generation {
-            cached_websocket_session.session = websocket_session;
-        }
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = websocket_session;
     }
 
     pub(crate) fn force_http_fallback(
@@ -470,7 +446,7 @@ impl ModelClient {
             );
         }
 
-        self.invalidate_cached_websocket_session();
+        self.store_cached_websocket_session(WebsocketSession::default());
         activated
     }
 
@@ -1001,7 +977,7 @@ impl Drop for ModelClientSession {
     fn drop(&mut self) {
         let websocket_session = std::mem::take(&mut self.websocket_session);
         self.client
-            .store_cached_websocket_session(self.websocket_cache_generation, websocket_session);
+            .store_cached_websocket_session(websocket_session);
     }
 }
 

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -172,6 +172,8 @@ pub(crate) struct CompactConversationRequestSettings {
 struct ModelClientState {
     session_id: SessionId,
     thread_id: ThreadId,
+    // Monotonic context epoch used to avoid reusing remotely cached state after history rewrites.
+    // Forks may inherit a nonzero epoch when their initial history already contains rewrites.
     window_generation: AtomicU64,
     installation_id: String,
     provider: SharedModelProvider,

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -172,8 +172,6 @@ pub(crate) struct CompactConversationRequestSettings {
 struct ModelClientState {
     session_id: SessionId,
     thread_id: ThreadId,
-    // Monotonic context epoch used to avoid reusing remotely cached state after history rewrites.
-    // Forks may inherit a nonzero epoch when their initial history already contains rewrites.
     window_generation: AtomicU64,
     installation_id: String,
     provider: SharedModelProvider,
@@ -187,7 +185,7 @@ struct ModelClientState {
     include_attestation: bool,
     attestation_provider: Option<Arc<dyn AttestationProvider>>,
     disable_websockets: AtomicBool,
-    cached_websocket_session: StdMutex<WebsocketSession>,
+    cached_websocket_session: StdMutex<CachedWebsocketSession>,
 }
 
 /// Resolved API client setup for a single request attempt.
@@ -244,7 +242,7 @@ pub struct ModelClient {
 pub struct ModelClientSession {
     client: ModelClient,
     websocket_session: WebsocketSession,
-    window_generation: u64,
+    websocket_cache_generation: u64,
     /// Turn state for sticky routing.
     ///
     /// This is an `OnceLock` that stores the turn state value received from the server
@@ -271,6 +269,12 @@ struct WebsocketSession {
     last_response_rx: Option<oneshot::Receiver<LastResponse>>,
     last_response_from_untraced_warmup: bool,
     connection_reused: StdMutex<bool>,
+}
+
+#[derive(Debug, Default)]
+struct CachedWebsocketSession {
+    generation: u64,
+    session: WebsocketSession,
 }
 
 impl WebsocketSession {
@@ -361,7 +365,7 @@ impl ModelClient {
                 include_attestation,
                 attestation_provider,
                 disable_websockets: AtomicBool::new(false),
-                cached_websocket_session: StdMutex::new(WebsocketSession::default()),
+                cached_websocket_session: StdMutex::new(CachedWebsocketSession::default()),
             }),
             prompt_cache_key_override: None,
         }
@@ -386,10 +390,11 @@ impl ModelClient {
     /// This constructor does not perform network I/O itself; the session opens a websocket lazily
     /// when the first stream request is issued.
     pub fn new_session(&self) -> ModelClientSession {
+        let (websocket_cache_generation, websocket_session) = self.take_cached_websocket_session();
         ModelClientSession {
             client: self.clone(),
-            websocket_session: self.take_cached_websocket_session(),
-            window_generation: self.state.window_generation.load(Ordering::Relaxed),
+            websocket_session,
+            websocket_cache_generation,
             turn_state: Arc::new(OnceLock::new()),
         }
     }
@@ -402,12 +407,12 @@ impl ModelClient {
         self.state
             .window_generation
             .store(window_generation, Ordering::Relaxed);
-        self.store_cached_websocket_session(WebsocketSession::default());
+        self.invalidate_cached_websocket_session();
     }
 
     pub(crate) fn advance_window_generation(&self) {
         self.state.window_generation.fetch_add(1, Ordering::Relaxed);
-        self.store_cached_websocket_session(WebsocketSession::default());
+        self.invalidate_cached_websocket_session();
     }
 
     pub(crate) fn current_window_id(&self) -> String {
@@ -416,21 +421,36 @@ impl ModelClient {
         format!("{thread_id}:{window_generation}")
     }
 
-    fn take_cached_websocket_session(&self) -> WebsocketSession {
+    pub(crate) fn invalidate_cached_websocket_session(&self) {
         let mut cached_websocket_session = self
             .state
             .cached_websocket_session
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        std::mem::take(&mut *cached_websocket_session)
+        cached_websocket_session.generation = cached_websocket_session.generation.saturating_add(1);
+        cached_websocket_session.session = WebsocketSession::default();
     }
 
-    fn store_cached_websocket_session(&self, websocket_session: WebsocketSession) {
-        *self
+    fn take_cached_websocket_session(&self) -> (u64, WebsocketSession) {
+        let mut cached_websocket_session = self
             .state
             .cached_websocket_session
             .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner) = websocket_session;
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let generation = cached_websocket_session.generation;
+        let session = std::mem::take(&mut cached_websocket_session.session);
+        (generation, session)
+    }
+
+    fn store_cached_websocket_session(&self, generation: u64, websocket_session: WebsocketSession) {
+        let mut cached_websocket_session = self
+            .state
+            .cached_websocket_session
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if cached_websocket_session.generation == generation {
+            cached_websocket_session.session = websocket_session;
+        }
     }
 
     pub(crate) fn force_http_fallback(
@@ -450,7 +470,7 @@ impl ModelClient {
             );
         }
 
-        self.store_cached_websocket_session(WebsocketSession::default());
+        self.invalidate_cached_websocket_session();
         activated
     }
 
@@ -979,13 +999,9 @@ impl ModelClient {
 
 impl Drop for ModelClientSession {
     fn drop(&mut self) {
-        // A history invalidation may advance the generation before an older turn session drops.
-        if self.window_generation != self.client.state.window_generation.load(Ordering::Relaxed) {
-            return;
-        }
         let websocket_session = std::mem::take(&mut self.websocket_session);
         self.client
-            .store_cached_websocket_session(websocket_session);
+            .store_cached_websocket_session(self.websocket_cache_generation, websocket_session);
     }
 }
 

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -398,7 +398,6 @@ impl ModelClient {
         self.state
             .window_generation
             .store(window_generation, Ordering::Relaxed);
-        self.store_cached_websocket_session(WebsocketSession::default());
     }
 
     pub(crate) fn advance_window_generation(&self) {

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -244,6 +244,7 @@ pub struct ModelClient {
 pub struct ModelClientSession {
     client: ModelClient,
     websocket_session: WebsocketSession,
+    window_generation: u64,
     /// Turn state for sticky routing.
     ///
     /// This is an `OnceLock` that stores the turn state value received from the server
@@ -388,6 +389,7 @@ impl ModelClient {
         ModelClientSession {
             client: self.clone(),
             websocket_session: self.take_cached_websocket_session(),
+            window_generation: self.state.window_generation.load(Ordering::Relaxed),
             turn_state: Arc::new(OnceLock::new()),
         }
     }
@@ -977,6 +979,10 @@ impl ModelClient {
 
 impl Drop for ModelClientSession {
     fn drop(&mut self) {
+        // A history invalidation may advance the generation before an older turn session drops.
+        if self.window_generation != self.client.state.window_generation.load(Ordering::Relaxed) {
+            return;
+        }
         let websocket_session = std::mem::take(&mut self.websocket_session);
         self.client
             .store_cached_websocket_session(websocket_session);

--- a/codex-rs/core/src/client_tests.rs
+++ b/codex-rs/core/src/client_tests.rs
@@ -2,6 +2,7 @@ use super::AuthRequestTelemetryContext;
 use super::ModelClient;
 use super::PendingUnauthorizedRetry;
 use super::UnauthorizedRecoveryExecution;
+use super::WebsocketSession;
 use super::X_CODEX_INSTALLATION_ID_HEADER;
 use super::X_CODEX_PARENT_THREAD_ID_HEADER;
 use super::X_CODEX_TURN_METADATA_HEADER;
@@ -323,6 +324,34 @@ fn build_ws_client_metadata_includes_window_lineage_and_turn_metadata() {
             ),
         ])
     );
+}
+
+#[test]
+fn restore_window_generation_preserves_cached_websocket_session() {
+    let client = test_model_client(SessionSource::Cli);
+    let websocket_session = WebsocketSession::default();
+    websocket_session.set_connection_reused(/*connection_reused*/ true);
+    client.store_cached_websocket_session(websocket_session);
+
+    client.restore_window_generation(/*window_generation*/ 2);
+
+    assert_eq!(
+        client.current_window_id(),
+        format!("{}:2", client.state.thread_id)
+    );
+    assert!(client.take_cached_websocket_session().connection_reused());
+
+    let websocket_session = WebsocketSession::default();
+    websocket_session.set_connection_reused(/*connection_reused*/ true);
+    client.store_cached_websocket_session(websocket_session);
+
+    client.set_window_generation(/*window_generation*/ 3);
+
+    assert_eq!(
+        client.current_window_id(),
+        format!("{}:3", client.state.thread_id)
+    );
+    assert!(!client.take_cached_websocket_session().connection_reused());
 }
 
 #[tokio::test]

--- a/codex-rs/core/src/session/handlers.rs
+++ b/codex-rs/core/src/session/handlers.rs
@@ -568,6 +568,11 @@ pub async fn thread_rollback(sess: &Arc<Session>, sub_id: String, num_turns: u32
     sess.apply_rollout_reconstruction(turn_context.as_ref(), replay_items.as_slice())
         .await;
     sess.recompute_token_usage(turn_context.as_ref()).await;
+    sess.services.model_client.set_window_generation(
+        super::rollout_reconstruction::effective_window_generation_from_rollout(
+            replay_items.as_slice(),
+        ),
+    );
 
     sess.persist_rollout_items(&[RolloutItem::EventMsg(rollback_msg.clone())])
         .await;

--- a/codex-rs/core/src/session/handlers.rs
+++ b/codex-rs/core/src/session/handlers.rs
@@ -568,7 +568,9 @@ pub async fn thread_rollback(sess: &Arc<Session>, sub_id: String, num_turns: u32
     sess.apply_rollout_reconstruction(turn_context.as_ref(), replay_items.as_slice())
         .await;
     sess.recompute_token_usage(turn_context.as_ref()).await;
-    sess.services.model_client.advance_window_generation();
+    sess.services
+        .model_client
+        .invalidate_cached_websocket_session();
 
     sess.persist_rollout_items(&[RolloutItem::EventMsg(rollback_msg.clone())])
         .await;

--- a/codex-rs/core/src/session/handlers.rs
+++ b/codex-rs/core/src/session/handlers.rs
@@ -568,11 +568,6 @@ pub async fn thread_rollback(sess: &Arc<Session>, sub_id: String, num_turns: u32
     sess.apply_rollout_reconstruction(turn_context.as_ref(), replay_items.as_slice())
         .await;
     sess.recompute_token_usage(turn_context.as_ref()).await;
-    sess.services.model_client.set_window_generation(
-        super::rollout_reconstruction::effective_window_generation_from_rollout(
-            replay_items.as_slice(),
-        ),
-    );
 
     sess.persist_rollout_items(&[RolloutItem::EventMsg(rollback_msg.clone())])
         .await;

--- a/codex-rs/core/src/session/handlers.rs
+++ b/codex-rs/core/src/session/handlers.rs
@@ -568,9 +568,6 @@ pub async fn thread_rollback(sess: &Arc<Session>, sub_id: String, num_turns: u32
     sess.apply_rollout_reconstruction(turn_context.as_ref(), replay_items.as_slice())
         .await;
     sess.recompute_token_usage(turn_context.as_ref()).await;
-    sess.services
-        .model_client
-        .invalidate_cached_websocket_session();
 
     sess.persist_rollout_items(&[RolloutItem::EventMsg(rollback_msg.clone())])
         .await;

--- a/codex-rs/core/src/session/handlers.rs
+++ b/codex-rs/core/src/session/handlers.rs
@@ -568,6 +568,7 @@ pub async fn thread_rollback(sess: &Arc<Session>, sub_id: String, num_turns: u32
     sess.apply_rollout_reconstruction(turn_context.as_ref(), replay_items.as_slice())
         .await;
     sess.recompute_token_usage(turn_context.as_ref()).await;
+    sess.services.model_client.advance_window_generation();
 
     sess.persist_rollout_items(&[RolloutItem::EventMsg(rollback_msg.clone())])
         .await;

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -622,7 +622,6 @@ impl Codex {
             inherited_shell_snapshot,
             user_shell_override,
         };
-
         // Generate a unique ID for the lifetime of this Codex session.
         let session_source_clone = session_configuration.session_source.clone();
         let (agent_status_tx, agent_status_rx) = watch::channel(AgentStatus::PendingInit);
@@ -1202,7 +1201,18 @@ impl Session {
         state.clear_connector_selection();
     }
 
+    #[cfg(test)]
     async fn record_initial_history(&self, conversation_history: InitialHistory) {
+        let initial_history =
+            rollout_reconstruction::PreparedInitialHistory::new(conversation_history);
+        self.record_prepared_initial_history(initial_history).await;
+    }
+
+    async fn record_prepared_initial_history(
+        &self,
+        initial_history: rollout_reconstruction::PreparedInitialHistory,
+    ) {
+        let (conversation_history, reconstruction_plan) = initial_history.into_parts();
         let is_subagent = {
             let state = self.state.lock().await;
             state
@@ -1215,18 +1225,22 @@ impl Session {
             let mut state = self.state.lock().await;
             state.set_next_turn_is_first(!has_prior_user_turns);
         }
-        match conversation_history {
-            InitialHistory::New | InitialHistory::Cleared => {
+        match (conversation_history, reconstruction_plan) {
+            (InitialHistory::New | InitialHistory::Cleared, None) => {
                 // Defer initial context insertion until the first real turn starts so
                 // turn/start overrides can be merged before we write model-visible context.
                 self.set_previous_turn_settings(/*previous_turn_settings*/ None)
                     .await;
             }
-            InitialHistory::Resumed(resumed_history) => {
+            (InitialHistory::Resumed(resumed_history), Some(reconstruction_plan)) => {
                 let turn_context = self.new_default_turn().await;
                 let rollout_items = resumed_history.history;
                 let previous_turn_settings = self
-                    .apply_rollout_reconstruction(&turn_context, &rollout_items)
+                    .apply_rollout_reconstruction_plan(
+                        &turn_context,
+                        &rollout_items,
+                        reconstruction_plan,
+                    )
                     .await;
 
                 // If resuming, warn when the last recorded model differs from the current one.
@@ -1262,10 +1276,14 @@ impl Session {
                     let _ = self.flush_rollout().await;
                 }
             }
-            InitialHistory::Forked(rollout_items) => {
+            (InitialHistory::Forked(rollout_items), Some(reconstruction_plan)) => {
                 let turn_context = self.new_default_turn().await;
-                self.apply_rollout_reconstruction(&turn_context, &rollout_items)
-                    .await;
+                self.apply_rollout_reconstruction_plan(
+                    &turn_context,
+                    &rollout_items,
+                    reconstruction_plan,
+                )
+                .await;
 
                 // Seed usage info from the recorded rollout so UIs can show token counts
                 // immediately on resume/fork.
@@ -1287,6 +1305,7 @@ impl Session {
                     let _ = self.flush_rollout().await;
                 }
             }
+            _ => unreachable!("prepared initial history must match its reconstruction"),
         }
     }
 
@@ -1298,7 +1317,34 @@ impl Session {
         let reconstructed_rollout = self
             .reconstruct_history_from_rollout(turn_context, rollout_items)
             .await;
+        self.apply_reconstructed_rollout(turn_context, reconstructed_rollout)
+            .await
+    }
+
+    async fn apply_rollout_reconstruction_plan(
+        &self,
+        turn_context: &TurnContext,
+        rollout_items: &[RolloutItem],
+        reconstruction_plan: rollout_reconstruction::RolloutReconstructionPlan,
+    ) -> Option<PreviousTurnSettings> {
+        let reconstructed_rollout = Self::materialize_rollout_reconstruction(
+            turn_context.truncation_policy,
+            rollout_items,
+            reconstruction_plan,
+        );
+        self.apply_reconstructed_rollout(turn_context, reconstructed_rollout)
+            .await
+    }
+
+    async fn apply_reconstructed_rollout(
+        &self,
+        turn_context: &TurnContext,
+        reconstructed_rollout: rollout_reconstruction::RolloutReconstruction,
+    ) -> Option<PreviousTurnSettings> {
         let previous_turn_settings = reconstructed_rollout.previous_turn_settings.clone();
+        self.services
+            .model_client
+            .restore_window_generation(reconstructed_rollout.window_generation);
         self.replace_history(
             reconstructed_rollout.history,
             reconstructed_rollout.reference_context_item,

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -622,6 +622,7 @@ impl Codex {
             inherited_shell_snapshot,
             user_shell_override,
         };
+
         // Generate a unique ID for the lifetime of this Codex session.
         let session_source_clone = session_configuration.session_source.clone();
         let (agent_status_tx, agent_status_rx) = watch::channel(AgentStatus::PendingInit);

--- a/codex-rs/core/src/session/rollout_reconstruction.rs
+++ b/codex-rs/core/src/session/rollout_reconstruction.rs
@@ -8,6 +8,54 @@ pub(super) struct RolloutReconstruction {
     pub(super) history: Vec<ResponseItem>,
     pub(super) previous_turn_settings: Option<PreviousTurnSettings>,
     pub(super) reference_context_item: Option<TurnContextItem>,
+    pub(super) window_generation: u64,
+}
+
+#[derive(Debug)]
+pub(super) struct RolloutReconstructionPlan {
+    base_replacement_history_index: Option<usize>,
+    rollout_suffix_start_index: usize,
+    previous_turn_settings: Option<PreviousTurnSettings>,
+    reference_context_item: Option<TurnContextItem>,
+    window_generation: u64,
+}
+
+#[derive(Debug)]
+pub(super) struct PreparedInitialHistory {
+    history: InitialHistory,
+    reconstruction_plan: Option<RolloutReconstructionPlan>,
+}
+
+impl PreparedInitialHistory {
+    pub(super) fn new(history: InitialHistory) -> Self {
+        let reconstruction_plan = match &history {
+            InitialHistory::Resumed(resumed_history) => {
+                Some(Session::reconstruct_rollout_plan(&resumed_history.history))
+            }
+            InitialHistory::Forked(rollout_items) => {
+                Some(Session::reconstruct_rollout_plan(rollout_items))
+            }
+            InitialHistory::New | InitialHistory::Cleared => None,
+        };
+        Self {
+            history,
+            reconstruction_plan,
+        }
+    }
+
+    pub(super) fn history(&self) -> &InitialHistory {
+        &self.history
+    }
+
+    pub(super) fn window_generation(&self) -> u64 {
+        self.reconstruction_plan
+            .as_ref()
+            .map_or(0, |plan| plan.window_generation)
+    }
+
+    pub(super) fn into_parts(self) -> (InitialHistory, Option<RolloutReconstructionPlan>) {
+        (self.history, self.reconstruction_plan)
+    }
 }
 
 #[derive(Debug, Default)]
@@ -27,87 +75,13 @@ enum TurnReferenceContextItem {
 }
 
 #[derive(Debug, Default)]
-struct ActiveReplaySegment<'a> {
+struct ActiveReplaySegment {
     turn_id: Option<String>,
     counts_as_user_turn: bool,
+    compaction_count: u64,
     previous_turn_settings: Option<PreviousTurnSettings>,
     reference_context_item: TurnReferenceContextItem,
-    base_replacement_history: Option<&'a [ResponseItem]>,
-}
-
-#[derive(Debug, Default)]
-struct WindowGenerationReplaySegment {
-    counts_as_user_turn: bool,
-    compaction_count: u64,
-}
-
-fn finalize_window_generation_segment(
-    active_segment: WindowGenerationReplaySegment,
-    window_generation: &mut u64,
-    pending_rollback_turns: &mut usize,
-) {
-    if *pending_rollback_turns > 0 {
-        if active_segment.counts_as_user_turn {
-            *pending_rollback_turns -= 1;
-        }
-        return;
-    }
-
-    *window_generation = window_generation.saturating_add(active_segment.compaction_count);
-}
-
-/// Replays rollout segments newest-to-oldest so compactions in rolled-back suffixes do not
-/// contribute to the public context-window lineage generation.
-pub(super) fn effective_window_generation_from_rollout(rollout_items: &[RolloutItem]) -> u64 {
-    let mut window_generation = 0u64;
-    let mut pending_rollback_turns = 0usize;
-    let mut active_segment: Option<WindowGenerationReplaySegment> = None;
-
-    for item in rollout_items.iter().rev() {
-        match item {
-            RolloutItem::Compacted(_) => {
-                let active_segment =
-                    active_segment.get_or_insert_with(WindowGenerationReplaySegment::default);
-                active_segment.compaction_count = active_segment.compaction_count.saturating_add(1);
-            }
-            RolloutItem::EventMsg(EventMsg::ThreadRolledBack(rollback)) => {
-                pending_rollback_turns = pending_rollback_turns
-                    .saturating_add(usize::try_from(rollback.num_turns).unwrap_or(usize::MAX));
-            }
-            RolloutItem::EventMsg(EventMsg::TurnStarted(_)) => {
-                if let Some(active_segment) = active_segment.take() {
-                    finalize_window_generation_segment(
-                        active_segment,
-                        &mut window_generation,
-                        &mut pending_rollback_turns,
-                    );
-                }
-            }
-            RolloutItem::EventMsg(EventMsg::UserMessage(_)) => {
-                active_segment
-                    .get_or_insert_with(WindowGenerationReplaySegment::default)
-                    .counts_as_user_turn = true;
-            }
-            RolloutItem::ResponseItem(response_item) => {
-                let active_segment =
-                    active_segment.get_or_insert_with(WindowGenerationReplaySegment::default);
-                active_segment.counts_as_user_turn |= is_user_turn_boundary(response_item);
-            }
-            RolloutItem::EventMsg(_)
-            | RolloutItem::TurnContext(_)
-            | RolloutItem::SessionMeta(_) => {}
-        }
-    }
-
-    if let Some(active_segment) = active_segment {
-        finalize_window_generation_segment(
-            active_segment,
-            &mut window_generation,
-            &mut pending_rollback_turns,
-        );
-    }
-
-    window_generation
+    base_replacement_history_index: Option<usize>,
 }
 
 fn turn_ids_are_compatible(active_turn_id: Option<&str>, item_turn_id: Option<&str>) -> bool {
@@ -115,12 +89,14 @@ fn turn_ids_are_compatible(active_turn_id: Option<&str>, item_turn_id: Option<&s
         .is_none_or(|turn_id| item_turn_id.is_none_or(|item_turn_id| item_turn_id == turn_id))
 }
 
-fn finalize_active_segment<'a>(
-    active_segment: ActiveReplaySegment<'a>,
-    base_replacement_history: &mut Option<&'a [ResponseItem]>,
+fn finalize_active_segment(
+    active_segment: ActiveReplaySegment,
+    base_replacement_history_index: &mut Option<usize>,
     previous_turn_settings: &mut Option<PreviousTurnSettings>,
     reference_context_item: &mut TurnReferenceContextItem,
+    window_generation: &mut u64,
     pending_rollback_turns: &mut usize,
+    reconstruction_complete: bool,
 ) {
     // Thread rollback drops the newest surviving real user-message boundaries. In replay, that
     // means skipping the next finalized segments that contain a non-contextual
@@ -132,12 +108,19 @@ fn finalize_active_segment<'a>(
         return;
     }
 
+    *window_generation = window_generation.saturating_add(active_segment.compaction_count);
+
+    if reconstruction_complete {
+        return;
+    }
+
     // A surviving replacement-history checkpoint is a complete history base. Once we
     // know the newest surviving one, older rollout items do not affect rebuilt history.
-    if base_replacement_history.is_none()
-        && let Some(segment_base_replacement_history) = active_segment.base_replacement_history
+    if base_replacement_history_index.is_none()
+        && let Some(segment_base_replacement_history_index) =
+            active_segment.base_replacement_history_index
     {
-        *base_replacement_history = Some(segment_base_replacement_history);
+        *base_replacement_history_index = Some(segment_base_replacement_history_index);
     }
 
     // `previous_turn_settings` come from the newest surviving user turn that established them.
@@ -159,47 +142,48 @@ fn finalize_active_segment<'a>(
 }
 
 impl Session {
-    pub(super) async fn reconstruct_history_from_rollout(
-        &self,
-        turn_context: &TurnContext,
-        rollout_items: &[RolloutItem],
-    ) -> RolloutReconstruction {
+    fn reconstruct_rollout_plan(rollout_items: &[RolloutItem]) -> RolloutReconstructionPlan {
         // Replay metadata should already match the shape of the future lazy reverse loader, even
-        // while history materialization still uses an eager bridge. Scan newest-to-oldest,
-        // stopping once a surviving replacement-history checkpoint and the required resume metadata
-        // are both known; then replay only the buffered surviving tail forward to preserve exact
-        // history semantics.
-        let mut base_replacement_history: Option<&[ResponseItem]> = None;
+        // while history materialization still uses an eager bridge. Scan newest-to-oldest once to
+        // derive the surviving history base, hydration metadata, and window lineage together.
+        let mut base_replacement_history_index = None;
+        let mut rollout_suffix_start_index = 0;
         let mut previous_turn_settings = None;
         let mut reference_context_item = TurnReferenceContextItem::NeverSet;
+        let mut window_generation = 0u64;
+        // Preserve the existing history and hydration result once the original reconstruction
+        // stopping condition is met, while the same loop continues only to derive window lineage.
+        let mut reconstruction_complete = false;
         // Rollback is "drop the newest N user turns". While scanning in reverse, that becomes
         // "skip the next N user-turn segments we finalize".
         let mut pending_rollback_turns = 0usize;
-        // Borrowed suffix of rollout items newer than the newest surviving replacement-history
-        // checkpoint. If no such checkpoint exists, this remains the full rollout.
-        let mut rollout_suffix = rollout_items;
         // Reverse replay accumulates rollout items into the newest in-progress turn segment until
         // we hit its matching `TurnStarted`, at which point the segment can be finalized.
-        let mut active_segment: Option<ActiveReplaySegment<'_>> = None;
+        let mut active_segment: Option<ActiveReplaySegment> = None;
 
         for (index, item) in rollout_items.iter().enumerate().rev() {
             match item {
                 RolloutItem::Compacted(compacted) => {
                     let active_segment =
                         active_segment.get_or_insert_with(ActiveReplaySegment::default);
+                    active_segment.compaction_count =
+                        active_segment.compaction_count.saturating_add(1);
                     // Looking backward, compaction clears any older baseline unless a newer
                     // `TurnContextItem` in this same segment has already re-established it.
-                    if matches!(
-                        active_segment.reference_context_item,
-                        TurnReferenceContextItem::NeverSet
-                    ) {
+                    if !reconstruction_complete
+                        && matches!(
+                            active_segment.reference_context_item,
+                            TurnReferenceContextItem::NeverSet
+                        )
+                    {
                         active_segment.reference_context_item = TurnReferenceContextItem::Cleared;
                     }
-                    if active_segment.base_replacement_history.is_none()
-                        && let Some(replacement_history) = &compacted.replacement_history
+                    if !reconstruction_complete
+                        && active_segment.base_replacement_history_index.is_none()
+                        && compacted.replacement_history.is_some()
                     {
-                        active_segment.base_replacement_history = Some(replacement_history);
-                        rollout_suffix = &rollout_items[index + 1..];
+                        active_segment.base_replacement_history_index = Some(index);
+                        rollout_suffix_start_index = index + 1;
                     }
                 }
                 RolloutItem::EventMsg(EventMsg::ThreadRolledBack(rollback)) => {
@@ -242,10 +226,12 @@ impl Session {
                     if active_segment.turn_id.is_none() {
                         active_segment.turn_id = ctx.turn_id.clone();
                     }
-                    if turn_ids_are_compatible(
-                        active_segment.turn_id.as_deref(),
-                        ctx.turn_id.as_deref(),
-                    ) {
+                    if !reconstruction_complete
+                        && turn_ids_are_compatible(
+                            active_segment.turn_id.as_deref(),
+                            ctx.turn_id.as_deref(),
+                        )
+                    {
                         active_segment.previous_turn_settings = Some(PreviousTurnSettings {
                             model: ctx.model.clone(),
                             realtime_active: ctx.realtime_active,
@@ -270,10 +256,12 @@ impl Session {
                     {
                         finalize_active_segment(
                             active_segment,
-                            &mut base_replacement_history,
+                            &mut base_replacement_history_index,
                             &mut previous_turn_settings,
                             &mut reference_context_item,
+                            &mut window_generation,
                             &mut pending_rollback_turns,
+                            reconstruction_complete,
                         );
                     }
                 }
@@ -285,47 +273,78 @@ impl Session {
                 RolloutItem::EventMsg(_) | RolloutItem::SessionMeta(_) => {}
             }
 
-            if base_replacement_history.is_some()
+            if !reconstruction_complete
+                && base_replacement_history_index.is_some()
                 && previous_turn_settings.is_some()
                 && !matches!(reference_context_item, TurnReferenceContextItem::NeverSet)
             {
-                // At this point we have both eager resume metadata values and the replacement-
-                // history base for the surviving tail, so older rollout items cannot affect this
-                // result.
-                break;
+                reconstruction_complete = true;
             }
         }
 
         if let Some(active_segment) = active_segment.take() {
             finalize_active_segment(
                 active_segment,
-                &mut base_replacement_history,
+                &mut base_replacement_history_index,
                 &mut previous_turn_settings,
                 &mut reference_context_item,
+                &mut window_generation,
                 &mut pending_rollback_turns,
+                reconstruction_complete,
             );
         }
 
-        let mut history = ContextManager::new();
-        let mut saw_legacy_compaction_without_replacement_history = false;
-        if let Some(base_replacement_history) = base_replacement_history {
-            history.replace(base_replacement_history.to_vec());
+        let reference_context_item = match reference_context_item {
+            TurnReferenceContextItem::NeverSet | TurnReferenceContextItem::Cleared => None,
+            TurnReferenceContextItem::Latest(turn_reference_context_item) => {
+                Some(*turn_reference_context_item)
+            }
+        };
+
+        RolloutReconstructionPlan {
+            base_replacement_history_index,
+            rollout_suffix_start_index,
+            previous_turn_settings,
+            reference_context_item,
+            window_generation,
         }
+    }
+
+    pub(super) fn materialize_rollout_reconstruction(
+        truncation_policy: TruncationPolicy,
+        rollout_items: &[RolloutItem],
+        plan: RolloutReconstructionPlan,
+    ) -> RolloutReconstruction {
+        let RolloutReconstructionPlan {
+            base_replacement_history_index,
+            rollout_suffix_start_index,
+            previous_turn_settings,
+            reference_context_item,
+            window_generation,
+        } = plan;
+        let mut history = ContextManager::new();
+        if let Some(index) = base_replacement_history_index {
+            let Some(RolloutItem::Compacted(compacted)) = rollout_items.get(index) else {
+                unreachable!("rollout reconstruction base must be a compaction");
+            };
+            let Some(replacement_history) = &compacted.replacement_history else {
+                unreachable!("rollout reconstruction base must have replacement history");
+            };
+            history.replace(replacement_history.clone());
+        }
+        let rollout_suffix = &rollout_items[rollout_suffix_start_index..];
+
+        let mut saw_legacy_compaction_without_replacement_history = false;
         // Materialize exact history semantics from the replay-derived suffix. The eventual lazy
         // design should keep this same replay shape, but drive it from a resumable reverse source
         // instead of an eagerly loaded `&[RolloutItem]`.
         for item in rollout_suffix {
             match item {
                 RolloutItem::ResponseItem(response_item) => {
-                    history.record_items(
-                        std::iter::once(response_item),
-                        turn_context.truncation_policy,
-                    );
+                    history.record_items(std::iter::once(response_item), truncation_policy);
                 }
                 RolloutItem::Compacted(compacted) => {
                     if let Some(replacement_history) = &compacted.replacement_history {
-                        // This should actually never happen, because the reverse loop above (to build rollout_suffix)
-                        // should stop before any compaction that has Some replacement_history
                         history.replace(replacement_history.clone());
                     } else {
                         saw_legacy_compaction_without_replacement_history = true;
@@ -355,12 +374,6 @@ impl Session {
             }
         }
 
-        let reference_context_item = match reference_context_item {
-            TurnReferenceContextItem::NeverSet | TurnReferenceContextItem::Cleared => None,
-            TurnReferenceContextItem::Latest(turn_reference_context_item) => {
-                Some(*turn_reference_context_item)
-            }
-        };
         let reference_context_item = if saw_legacy_compaction_without_replacement_history {
             None
         } else {
@@ -371,6 +384,20 @@ impl Session {
             history: history.raw_items().to_vec(),
             previous_turn_settings,
             reference_context_item,
+            window_generation,
         }
+    }
+
+    pub(super) async fn reconstruct_history_from_rollout(
+        &self,
+        turn_context: &TurnContext,
+        rollout_items: &[RolloutItem],
+    ) -> RolloutReconstruction {
+        let plan = Self::reconstruct_rollout_plan(rollout_items);
+        Self::materialize_rollout_reconstruction(
+            turn_context.truncation_policy,
+            rollout_items,
+            plan,
+        )
     }
 }

--- a/codex-rs/core/src/session/rollout_reconstruction.rs
+++ b/codex-rs/core/src/session/rollout_reconstruction.rs
@@ -79,6 +79,7 @@ struct ActiveReplaySegment {
     turn_id: Option<String>,
     counts_as_user_turn: bool,
     compaction_count: u64,
+    pre_user_compaction_count: u64,
     previous_turn_settings: Option<PreviousTurnSettings>,
     reference_context_item: TurnReferenceContextItem,
     base_replacement_history_index: Option<usize>,
@@ -103,6 +104,8 @@ fn finalize_active_segment(
     // `EventMsg::UserMessage`.
     if *pending_rollback_turns > 0 {
         if active_segment.counts_as_user_turn {
+            *window_generation =
+                window_generation.saturating_add(active_segment.pre_user_compaction_count);
             *pending_rollback_turns -= 1;
         }
         return;
@@ -168,6 +171,12 @@ impl Session {
                         active_segment.get_or_insert_with(ActiveReplaySegment::default);
                     active_segment.compaction_count =
                         active_segment.compaction_count.saturating_add(1);
+                    // A compaction seen after the user boundary in reverse replay occurred before
+                    // the user input, so it survives rollback of that user turn.
+                    if active_segment.counts_as_user_turn {
+                        active_segment.pre_user_compaction_count =
+                            active_segment.pre_user_compaction_count.saturating_add(1);
+                    }
                     // Looking backward, compaction clears any older baseline unless a newer
                     // `TurnContextItem` in this same segment has already re-established it.
                     if !reconstruction_complete

--- a/codex-rs/core/src/session/rollout_reconstruction.rs
+++ b/codex-rs/core/src/session/rollout_reconstruction.rs
@@ -35,6 +35,81 @@ struct ActiveReplaySegment<'a> {
     base_replacement_history: Option<&'a [ResponseItem]>,
 }
 
+#[derive(Debug, Default)]
+struct WindowGenerationReplaySegment {
+    counts_as_user_turn: bool,
+    compaction_count: u64,
+}
+
+fn finalize_window_generation_segment(
+    active_segment: WindowGenerationReplaySegment,
+    window_generation: &mut u64,
+    pending_rollback_turns: &mut usize,
+) {
+    if *pending_rollback_turns > 0 {
+        if active_segment.counts_as_user_turn {
+            *pending_rollback_turns -= 1;
+        }
+        return;
+    }
+
+    *window_generation = window_generation.saturating_add(active_segment.compaction_count);
+}
+
+/// Replays rollout segments newest-to-oldest so compactions in rolled-back suffixes do not
+/// contribute to the public context-window lineage generation.
+pub(super) fn effective_window_generation_from_rollout(rollout_items: &[RolloutItem]) -> u64 {
+    let mut window_generation = 0u64;
+    let mut pending_rollback_turns = 0usize;
+    let mut active_segment: Option<WindowGenerationReplaySegment> = None;
+
+    for item in rollout_items.iter().rev() {
+        match item {
+            RolloutItem::Compacted(_) => {
+                let active_segment =
+                    active_segment.get_or_insert_with(WindowGenerationReplaySegment::default);
+                active_segment.compaction_count = active_segment.compaction_count.saturating_add(1);
+            }
+            RolloutItem::EventMsg(EventMsg::ThreadRolledBack(rollback)) => {
+                pending_rollback_turns = pending_rollback_turns
+                    .saturating_add(usize::try_from(rollback.num_turns).unwrap_or(usize::MAX));
+            }
+            RolloutItem::EventMsg(EventMsg::TurnStarted(_)) => {
+                if let Some(active_segment) = active_segment.take() {
+                    finalize_window_generation_segment(
+                        active_segment,
+                        &mut window_generation,
+                        &mut pending_rollback_turns,
+                    );
+                }
+            }
+            RolloutItem::EventMsg(EventMsg::UserMessage(_)) => {
+                active_segment
+                    .get_or_insert_with(WindowGenerationReplaySegment::default)
+                    .counts_as_user_turn = true;
+            }
+            RolloutItem::ResponseItem(response_item) => {
+                let active_segment =
+                    active_segment.get_or_insert_with(WindowGenerationReplaySegment::default);
+                active_segment.counts_as_user_turn |= is_user_turn_boundary(response_item);
+            }
+            RolloutItem::EventMsg(_)
+            | RolloutItem::TurnContext(_)
+            | RolloutItem::SessionMeta(_) => {}
+        }
+    }
+
+    if let Some(active_segment) = active_segment {
+        finalize_window_generation_segment(
+            active_segment,
+            &mut window_generation,
+            &mut pending_rollback_turns,
+        );
+    }
+
+    window_generation
+}
+
 fn turn_ids_are_compatible(active_turn_id: Option<&str>, item_turn_id: Option<&str>) -> bool {
     active_turn_id
         .is_none_or(|turn_id| item_turn_id.is_none_or(|item_turn_id| item_turn_id == turn_id))

--- a/codex-rs/core/src/session/rollout_reconstruction.rs
+++ b/codex-rs/core/src/session/rollout_reconstruction.rs
@@ -28,15 +28,12 @@ pub(super) struct PreparedInitialHistory {
 
 impl PreparedInitialHistory {
     pub(super) fn new(history: InitialHistory) -> Self {
-        let reconstruction_plan = match &history {
-            InitialHistory::Resumed(resumed_history) => {
-                Some(Session::reconstruct_rollout_plan(&resumed_history.history))
-            }
-            InitialHistory::Forked(rollout_items) => {
-                Some(Session::reconstruct_rollout_plan(rollout_items))
-            }
+        let rollout_items = match &history {
+            InitialHistory::Resumed(resumed_history) => Some(resumed_history.history.as_slice()),
+            InitialHistory::Forked(rollout_items) => Some(rollout_items.as_slice()),
             InitialHistory::New | InitialHistory::Cleared => None,
         };
+        let reconstruction_plan = rollout_items.map(Session::reconstruct_rollout_plan);
         Self {
             history,
             reconstruction_plan,

--- a/codex-rs/core/src/session/rollout_reconstruction.rs
+++ b/codex-rs/core/src/session/rollout_reconstruction.rs
@@ -14,7 +14,6 @@ pub(super) struct RolloutReconstruction {
 #[derive(Debug)]
 pub(super) struct RolloutReconstructionPlan {
     base_replacement_history_index: Option<usize>,
-    rollout_suffix_start_index: usize,
     previous_turn_settings: Option<PreviousTurnSettings>,
     reference_context_item: Option<TurnContextItem>,
     window_generation: u64,
@@ -94,7 +93,6 @@ fn finalize_active_segment(
     reference_context_item: &mut TurnReferenceContextItem,
     window_generation: &mut u64,
     pending_rollback_turns: &mut usize,
-    reconstruction_complete: bool,
 ) {
     // Thread rollback drops the newest surviving real user-message boundaries. In replay, that
     // means skipping the next finalized segments that contain a non-contextual
@@ -109,10 +107,6 @@ fn finalize_active_segment(
     }
 
     *window_generation = window_generation.saturating_add(active_segment.compaction_count);
-
-    if reconstruction_complete {
-        return;
-    }
 
     // A surviving replacement-history checkpoint is a complete history base. Once we
     // know the newest surviving one, older rollout items do not affect rebuilt history.
@@ -147,13 +141,9 @@ impl Session {
         // while history materialization still uses an eager bridge. Scan newest-to-oldest once to
         // derive the surviving history base, hydration metadata, and window lineage together.
         let mut base_replacement_history_index = None;
-        let mut rollout_suffix_start_index = 0;
         let mut previous_turn_settings = None;
         let mut reference_context_item = TurnReferenceContextItem::NeverSet;
         let mut window_generation = 0u64;
-        // Preserve the existing history and hydration result once the original reconstruction
-        // stopping condition is met, while the same loop continues only to derive window lineage.
-        let mut reconstruction_complete = false;
         // Rollback is "drop the newest N user turns". While scanning in reverse, that becomes
         // "skip the next N user-turn segments we finalize".
         let mut pending_rollback_turns = 0usize;
@@ -176,7 +166,7 @@ impl Session {
                     }
                     // Looking backward, compaction clears any older baseline unless a newer
                     // `TurnContextItem` in this same segment has already re-established it.
-                    if !reconstruction_complete
+                    if matches!(reference_context_item, TurnReferenceContextItem::NeverSet)
                         && matches!(
                             active_segment.reference_context_item,
                             TurnReferenceContextItem::NeverSet
@@ -184,12 +174,11 @@ impl Session {
                     {
                         active_segment.reference_context_item = TurnReferenceContextItem::Cleared;
                     }
-                    if !reconstruction_complete
+                    if base_replacement_history_index.is_none()
                         && active_segment.base_replacement_history_index.is_none()
                         && compacted.replacement_history.is_some()
                     {
                         active_segment.base_replacement_history_index = Some(index);
-                        rollout_suffix_start_index = index + 1;
                     }
                 }
                 RolloutItem::EventMsg(EventMsg::ThreadRolledBack(rollback)) => {
@@ -232,20 +221,25 @@ impl Session {
                     if active_segment.turn_id.is_none() {
                         active_segment.turn_id = ctx.turn_id.clone();
                     }
-                    if !reconstruction_complete
+                    if (previous_turn_settings.is_none()
+                        || matches!(reference_context_item, TurnReferenceContextItem::NeverSet))
                         && turn_ids_are_compatible(
                             active_segment.turn_id.as_deref(),
                             ctx.turn_id.as_deref(),
                         )
                     {
-                        active_segment.previous_turn_settings = Some(PreviousTurnSettings {
-                            model: ctx.model.clone(),
-                            realtime_active: ctx.realtime_active,
-                        });
-                        if matches!(
-                            active_segment.reference_context_item,
-                            TurnReferenceContextItem::NeverSet
-                        ) {
+                        if previous_turn_settings.is_none() {
+                            active_segment.previous_turn_settings = Some(PreviousTurnSettings {
+                                model: ctx.model.clone(),
+                                realtime_active: ctx.realtime_active,
+                            });
+                        }
+                        if matches!(reference_context_item, TurnReferenceContextItem::NeverSet)
+                            && matches!(
+                                active_segment.reference_context_item,
+                                TurnReferenceContextItem::NeverSet
+                            )
+                        {
                             active_segment.reference_context_item =
                                 TurnReferenceContextItem::Latest(Box::new(ctx.clone()));
                         }
@@ -267,7 +261,6 @@ impl Session {
                             &mut reference_context_item,
                             &mut window_generation,
                             &mut pending_rollback_turns,
-                            reconstruction_complete,
                         );
                     }
                 }
@@ -277,14 +270,6 @@ impl Session {
                     active_segment.counts_as_user_turn |= is_user_turn_boundary(response_item);
                 }
                 RolloutItem::EventMsg(_) | RolloutItem::SessionMeta(_) => {}
-            }
-
-            if !reconstruction_complete
-                && base_replacement_history_index.is_some()
-                && previous_turn_settings.is_some()
-                && !matches!(reference_context_item, TurnReferenceContextItem::NeverSet)
-            {
-                reconstruction_complete = true;
             }
         }
 
@@ -296,7 +281,6 @@ impl Session {
                 &mut reference_context_item,
                 &mut window_generation,
                 &mut pending_rollback_turns,
-                reconstruction_complete,
             );
         }
 
@@ -309,7 +293,6 @@ impl Session {
 
         RolloutReconstructionPlan {
             base_replacement_history_index,
-            rollout_suffix_start_index,
             previous_turn_settings,
             reference_context_item,
             window_generation,
@@ -323,7 +306,6 @@ impl Session {
     ) -> RolloutReconstruction {
         let RolloutReconstructionPlan {
             base_replacement_history_index,
-            rollout_suffix_start_index,
             previous_turn_settings,
             reference_context_item,
             window_generation,
@@ -338,6 +320,8 @@ impl Session {
             };
             history.replace(replacement_history.clone());
         }
+        let rollout_suffix_start_index =
+            base_replacement_history_index.map_or(0, |index| index + 1);
         let rollout_suffix = &rollout_items[rollout_suffix_start_index..];
 
         let mut saw_legacy_compaction_without_replacement_history = false;

--- a/codex-rs/core/src/session/rollout_reconstruction_tests.rs
+++ b/codex-rs/core/src/session/rollout_reconstruction_tests.rs
@@ -796,6 +796,10 @@ async fn record_initial_history_resumed_rollback_drops_incomplete_user_turn_comp
             codex_protocol::protocol::ThreadRolledBackEvent { num_turns: 1 },
         )),
     ];
+    let reconstructed = session
+        .reconstruct_history_from_rollout(&turn_context, &rollout_items)
+        .await;
+    assert_eq!(reconstructed.window_generation, 0);
 
     session
         .record_initial_history(InitialHistory::Resumed(ResumedHistory {

--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -517,17 +517,6 @@ impl Session {
             }
             InitialHistory::Resumed(resumed_history) => resumed_history.conversation_id,
         };
-        let window_generation = match &initial_history {
-            InitialHistory::Resumed(resumed_history) => {
-                super::rollout_reconstruction::effective_window_generation_from_rollout(
-                    &resumed_history.history,
-                )
-            }
-            InitialHistory::Forked(history) => {
-                super::rollout_reconstruction::effective_window_generation_from_rollout(history)
-            }
-            InitialHistory::New | InitialHistory::Cleared => 0,
-        };
         // Kick off independent async setup tasks in parallel to reduce startup latency.
         //
         // - initialize thread persistence with new or resumed session info
@@ -666,6 +655,9 @@ impl Session {
             );
         }
 
+        let initial_history =
+            super::rollout_reconstruction::PreparedInitialHistory::new(initial_history);
+        let window_generation = initial_history.window_generation();
         let mut live_thread_init =
             LiveThreadInitGuard::new(thread_persistence_result.map_err(|e| {
                 error!("failed to initialize thread persistence: {e:#}");
@@ -1076,7 +1068,7 @@ impl Session {
             }
             // Dispatch the SessionConfiguredEvent first and then report any errors.
             // If resuming, include converted initial messages in the payload so UIs can render them immediately.
-            let initial_messages = initial_history.get_event_msgs();
+            let initial_messages = initial_history.history().get_event_msgs();
             let events = std::iter::once(Event {
                 id: INITIAL_SUBMIT_ID.to_owned(),
                 msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
@@ -1219,7 +1211,7 @@ impl Session {
             }
             sess.schedule_startup_prewarm(session_configuration.base_instructions.clone())
                 .await;
-            let session_start_source = match &initial_history {
+            let session_start_source = match initial_history.history() {
                 InitialHistory::Resumed(_) => codex_hooks::SessionStartSource::Resume,
                 InitialHistory::New | InitialHistory::Forked(_) => {
                     codex_hooks::SessionStartSource::Startup
@@ -1227,8 +1219,9 @@ impl Session {
                 InitialHistory::Cleared => codex_hooks::SessionStartSource::Clear,
             };
 
-            // record_initial_history can emit events. We record only after the SessionConfiguredEvent is emitted.
-            Box::pin(sess.record_initial_history(initial_history)).await;
+            // record_prepared_initial_history can emit events. We record only after the
+            // SessionConfiguredEvent is emitted.
+            Box::pin(sess.record_prepared_initial_history(initial_history)).await;
             {
                 let mut state = sess.state.lock().await;
                 state.queue_pending_session_start_source(session_start_source);

--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -16,6 +16,25 @@ use codex_protocol::protocol::TurnEnvironmentSelections;
 use std::sync::OnceLock;
 use tokio::sync::Semaphore;
 
+// This is a request-cache invalidation epoch, not a hash of logical context. A rollback must use a
+// new generation even when it reconstructs a previously seen prefix, because the remote window
+// with the old ID may already include requests from the rolled-back suffix.
+fn window_generation_from_history_invalidations(items: &[RolloutItem]) -> u64 {
+    u64::try_from(
+        items
+            .iter()
+            .filter(|item| {
+                matches!(
+                    item,
+                    RolloutItem::Compacted(_)
+                        | RolloutItem::EventMsg(EventMsg::ThreadRolledBack(_))
+                )
+            })
+            .count(),
+    )
+    .unwrap_or(u64::MAX)
+}
+
 /// Context for an initialized model agent
 ///
 /// A session has at most 1 running task at a time, and can be interrupted by user input.
@@ -518,15 +537,13 @@ impl Session {
             InitialHistory::Resumed(resumed_history) => resumed_history.conversation_id,
         };
         let window_generation = match &initial_history {
-            InitialHistory::Resumed(resumed_history) => u64::try_from(
-                resumed_history
-                    .history
-                    .iter()
-                    .filter(|item| matches!(item, RolloutItem::Compacted(_)))
-                    .count(),
-            )
-            .unwrap_or(u64::MAX),
-            InitialHistory::New | InitialHistory::Cleared | InitialHistory::Forked(_) => 0,
+            InitialHistory::Resumed(resumed_history) => {
+                window_generation_from_history_invalidations(&resumed_history.history)
+            }
+            InitialHistory::Forked(history) => {
+                window_generation_from_history_invalidations(history)
+            }
+            InitialHistory::New | InitialHistory::Cleared => 0,
         };
         // Kick off independent async setup tasks in parallel to reduce startup latency.
         //

--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -16,25 +16,6 @@ use codex_protocol::protocol::TurnEnvironmentSelections;
 use std::sync::OnceLock;
 use tokio::sync::Semaphore;
 
-// This is a request-cache invalidation epoch, not a hash of logical context. A rollback must use a
-// new generation even when it reconstructs a previously seen prefix, because the remote window
-// with the old ID may already include requests from the rolled-back suffix.
-fn window_generation_from_history_invalidations(items: &[RolloutItem]) -> u64 {
-    u64::try_from(
-        items
-            .iter()
-            .filter(|item| {
-                matches!(
-                    item,
-                    RolloutItem::Compacted(_)
-                        | RolloutItem::EventMsg(EventMsg::ThreadRolledBack(_))
-                )
-            })
-            .count(),
-    )
-    .unwrap_or(u64::MAX)
-}
-
 /// Context for an initialized model agent
 ///
 /// A session has at most 1 running task at a time, and can be interrupted by user input.
@@ -537,13 +518,15 @@ impl Session {
             InitialHistory::Resumed(resumed_history) => resumed_history.conversation_id,
         };
         let window_generation = match &initial_history {
-            InitialHistory::Resumed(resumed_history) => {
-                window_generation_from_history_invalidations(&resumed_history.history)
-            }
-            InitialHistory::Forked(history) => {
-                window_generation_from_history_invalidations(history)
-            }
-            InitialHistory::New | InitialHistory::Cleared => 0,
+            InitialHistory::Resumed(resumed_history) => u64::try_from(
+                resumed_history
+                    .history
+                    .iter()
+                    .filter(|item| matches!(item, RolloutItem::Compacted(_)))
+                    .count(),
+            )
+            .unwrap_or(u64::MAX),
+            InitialHistory::New | InitialHistory::Cleared | InitialHistory::Forked(_) => 0,
         };
         // Kick off independent async setup tasks in parallel to reduce startup latency.
         //

--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -518,15 +518,15 @@ impl Session {
             InitialHistory::Resumed(resumed_history) => resumed_history.conversation_id,
         };
         let window_generation = match &initial_history {
-            InitialHistory::Resumed(resumed_history) => u64::try_from(
-                resumed_history
-                    .history
-                    .iter()
-                    .filter(|item| matches!(item, RolloutItem::Compacted(_)))
-                    .count(),
-            )
-            .unwrap_or(u64::MAX),
-            InitialHistory::New | InitialHistory::Cleared | InitialHistory::Forked(_) => 0,
+            InitialHistory::Resumed(resumed_history) => {
+                super::rollout_reconstruction::effective_window_generation_from_rollout(
+                    &resumed_history.history,
+                )
+            }
+            InitialHistory::Forked(history) => {
+                super::rollout_reconstruction::effective_window_generation_from_rollout(history)
+            }
+            InitialHistory::New | InitialHistory::Cleared => 0,
         };
         // Kick off independent async setup tasks in parallel to reduce startup latency.
         //

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -1586,6 +1586,7 @@ async fn reconstruct_history_matches_live_compactions() {
         .await;
 
     assert_eq!(expected, reconstructed.history);
+    assert_eq!(reconstructed.window_generation, 2);
 }
 
 #[tokio::test]
@@ -1620,6 +1621,7 @@ async fn reconstruct_history_uses_replacement_history_verbatim() {
         .await;
 
     assert_eq!(reconstructed.history, replacement_history);
+    assert_eq!(reconstructed.window_generation, 1);
 }
 
 #[tokio::test]

--- a/codex-rs/core/tests/suite/agent_websocket.rs
+++ b/codex-rs/core/tests/suite/agent_websocket.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
 use codex_features::Feature;
 use codex_protocol::config_types::ServiceTier;
+use codex_protocol::protocol::EventMsg;
+use codex_protocol::protocol::Op;
 use core_test_support::responses::WebSocketConnectionConfig;
 use core_test_support::responses::ev_assistant_message;
 use core_test_support::responses::ev_completed;
@@ -10,6 +12,7 @@ use core_test_support::responses::start_websocket_server;
 use core_test_support::responses::start_websocket_server_with_headers;
 use core_test_support::skip_if_no_network;
 use core_test_support::test_codex::test_codex;
+use core_test_support::wait_for_event;
 use pretty_assertions::assert_eq;
 use serde_json::Value;
 use std::time::Duration;
@@ -250,6 +253,69 @@ async fn websocket_v2_test_codex_shell_chain() -> Result<()> {
         handshake.header("openai-beta"),
         Some(WS_V2_BETA_HEADER_VALUE.to_string())
     );
+
+    server.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn websocket_v2_rollback_opens_new_connection_for_rewritten_history() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_websocket_server(vec![
+        vec![
+            vec![ev_response_created("warm-1"), ev_completed("warm-1")],
+            vec![
+                ev_response_created("resp-1"),
+                ev_assistant_message("msg-1", "kept"),
+                ev_completed("resp-1"),
+            ],
+            vec![
+                ev_response_created("resp-2"),
+                ev_assistant_message("msg-2", "discarded"),
+                ev_completed("resp-2"),
+            ],
+            vec![
+                ev_response_created("should-not-be-used"),
+                ev_completed("should-not-be-used"),
+            ],
+        ],
+        vec![vec![
+            ev_response_created("resp-3"),
+            ev_assistant_message("msg-3", "after rollback"),
+            ev_completed("resp-3"),
+        ]],
+    ])
+    .await;
+
+    let mut builder = test_codex().with_config(|config| {
+        config
+            .features
+            .enable(Feature::ResponsesWebsocketsV2)
+            .expect("test config should allow feature update");
+    });
+    let test = builder.build_with_websocket_server(&server).await?;
+
+    test.submit_turn("before rollback").await?;
+    test.submit_turn("discard me").await?;
+    test.codex
+        .submit(Op::ThreadRollback { num_turns: 1 })
+        .await?;
+    wait_for_event(&test.codex, |event| {
+        matches!(event, EventMsg::ThreadRolledBack(_))
+    })
+    .await;
+    test.submit_turn("after rollback").await?;
+
+    assert_eq!(server.handshakes().len(), 2);
+    let connections = server.connections();
+    assert_eq!(connections.len(), 2);
+    assert_eq!(connections[0].len(), 3);
+    assert_eq!(connections[1].len(), 1);
+
+    let after_rollback = connections[1][0].body_json();
+    assert_eq!(after_rollback["type"].as_str(), Some("response.create"));
+    assert_eq!(after_rollback.get("previous_response_id"), None);
 
     server.shutdown().await;
     Ok(())

--- a/codex-rs/core/tests/suite/agent_websocket.rs
+++ b/codex-rs/core/tests/suite/agent_websocket.rs
@@ -1,8 +1,12 @@
 use anyhow::Result;
 use codex_features::Feature;
+use codex_login::CodexAuth;
 use codex_protocol::config_types::ServiceTier;
+use codex_protocol::protocol::CompactedItem;
 use codex_protocol::protocol::EventMsg;
+use codex_protocol::protocol::InitialHistory;
 use codex_protocol::protocol::Op;
+use codex_protocol::protocol::RolloutItem;
 use core_test_support::responses::WebSocketConnectionConfig;
 use core_test_support::responses::ev_assistant_message;
 use core_test_support::responses::ev_completed;
@@ -122,6 +126,67 @@ async fn websocket_first_turn_uses_startup_prewarm_and_create() -> Result<()> {
     )?;
     assert_eq!(turn_metadata["request_kind"].as_str(), Some("turn"));
 
+    server.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn websocket_forked_history_prewarm_uses_effective_window_generation() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_websocket_server(vec![
+        vec![vec![
+            ev_response_created("warm-initial"),
+            ev_completed("warm-initial"),
+        ]],
+        vec![vec![
+            ev_response_created("warm-fork"),
+            ev_completed("warm-fork"),
+        ]],
+    ])
+    .await;
+
+    let mut builder = test_codex();
+    let initial = builder.build_with_websocket_server(&server).await?;
+    server
+        .wait_for_request(/*connection_index*/ 0, /*request_index*/ 0)
+        .await;
+    initial.codex.shutdown_and_wait().await?;
+
+    let forked = initial
+        .thread_manager
+        .resume_thread_with_history(
+            initial.config.clone(),
+            InitialHistory::Forked(vec![RolloutItem::Compacted(CompactedItem {
+                message: "summary".to_string(),
+                replacement_history: Some(Vec::new()),
+            })]),
+            codex_core::test_support::auth_manager_from_auth(CodexAuth::from_api_key("dummy")),
+            /*parent_trace*/ None,
+        )
+        .await?;
+    let warmup = server
+        .wait_for_request(/*connection_index*/ 1, /*request_index*/ 0)
+        .await
+        .body_json();
+
+    assert_eq!(warmup["generate"].as_bool(), Some(false));
+    let window_id = warmup["client_metadata"]["x-codex-window-id"]
+        .as_str()
+        .expect("warmup window id");
+    assert_eq!(
+        window_id.rsplit_once(':').map(|(_, generation)| generation),
+        Some("1")
+    );
+    let metadata: Value = serde_json::from_str(
+        warmup["client_metadata"]["x-codex-turn-metadata"]
+            .as_str()
+            .expect("warmup turn metadata"),
+    )?;
+    assert_eq!(metadata["request_kind"].as_str(), Some("prewarm"));
+    assert_eq!(metadata["window_id"].as_str(), Some(window_id));
+
+    forked.thread.shutdown_and_wait().await?;
     server.shutdown().await;
     Ok(())
 }

--- a/codex-rs/core/tests/suite/agent_websocket.rs
+++ b/codex-rs/core/tests/suite/agent_websocket.rs
@@ -259,33 +259,27 @@ async fn websocket_v2_test_codex_shell_chain() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn websocket_v2_rollback_opens_new_connection_for_rewritten_history() -> Result<()> {
+async fn websocket_v2_rollback_reuses_connection_without_previous_response_id() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
-    let server = start_websocket_server(vec![
+    let server = start_websocket_server(vec![vec![
+        vec![ev_response_created("warm-1"), ev_completed("warm-1")],
         vec![
-            vec![ev_response_created("warm-1"), ev_completed("warm-1")],
-            vec![
-                ev_response_created("resp-1"),
-                ev_assistant_message("msg-1", "kept"),
-                ev_completed("resp-1"),
-            ],
-            vec![
-                ev_response_created("resp-2"),
-                ev_assistant_message("msg-2", "discarded"),
-                ev_completed("resp-2"),
-            ],
-            vec![
-                ev_response_created("should-not-be-used"),
-                ev_completed("should-not-be-used"),
-            ],
+            ev_response_created("resp-1"),
+            ev_assistant_message("msg-1", "kept"),
+            ev_completed("resp-1"),
         ],
-        vec![vec![
+        vec![
+            ev_response_created("resp-2"),
+            ev_assistant_message("msg-2", "discarded"),
+            ev_completed("resp-2"),
+        ],
+        vec![
             ev_response_created("resp-3"),
             ev_assistant_message("msg-3", "after rollback"),
             ev_completed("resp-3"),
-        ]],
-    ])
+        ],
+    ]])
     .await;
 
     let mut builder = test_codex().with_config(|config| {
@@ -307,13 +301,12 @@ async fn websocket_v2_rollback_opens_new_connection_for_rewritten_history() -> R
     .await;
     test.submit_turn("after rollback").await?;
 
-    assert_eq!(server.handshakes().len(), 2);
+    assert_eq!(server.handshakes().len(), 1);
     let connections = server.connections();
-    assert_eq!(connections.len(), 2);
-    assert_eq!(connections[0].len(), 3);
-    assert_eq!(connections[1].len(), 1);
+    assert_eq!(connections.len(), 1);
+    assert_eq!(connections[0].len(), 4);
 
-    let after_rollback = connections[1][0].body_json();
+    let after_rollback = connections[0][3].body_json();
     assert_eq!(after_rollback["type"].as_str(), Some("response.create"));
     assert_eq!(after_rollback.get("previous_response_id"), None);
 

--- a/codex-rs/core/tests/suite/window_headers.rs
+++ b/codex-rs/core/tests/suite/window_headers.rs
@@ -21,8 +21,7 @@ use pretty_assertions::assert_eq;
 use std::sync::Arc;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn window_id_advances_after_compact_persists_on_resume_and_resets_on_empty_fork() -> Result<()>
-{
+async fn window_id_advances_after_compact_persists_on_resume_and_resets_on_fork() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
     let server = start_mock_server().await;
@@ -103,7 +102,7 @@ async fn window_id_advances_after_compact_persists_on_resume_and_resets_on_empty
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn window_id_advances_after_rollback_and_persists_on_resume() -> Result<()> {
+async fn window_id_stays_stable_after_rollback_and_resume() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
     let server = start_mock_server().await;
@@ -157,91 +156,8 @@ async fn window_id_advances_after_rollback_and_persists_on_resume() -> Result<()
         vec![
             (initial_thread_id.clone(), 0),
             (initial_thread_id.clone(), 0),
-            (initial_thread_id.clone(), 1),
-            (initial_thread_id, 1),
-        ]
-    );
-
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn forked_compacted_history_keeps_window_generation_on_resume() -> Result<()> {
-    skip_if_no_network!(Ok(()));
-
-    let server = start_mock_server().await;
-    let request_log = mount_sse_sequence(
-        &server,
-        vec![
-            sse(vec![
-                ev_assistant_message("msg-1", "first reply"),
-                ev_completed("resp-1"),
-            ]),
-            sse(vec![
-                ev_assistant_message("msg-2", "summary"),
-                ev_completed("resp-2"),
-            ]),
-            sse(vec![ev_completed("resp-3")]),
-            sse(vec![ev_completed("resp-4")]),
-        ],
-    )
-    .await;
-
-    let mut builder = test_codex().with_config(|config| {
-        config.model_provider.name = "Non-OpenAI Model provider".to_string();
-        config.compact_prompt = Some(SUMMARIZATION_PROMPT.to_string());
-    });
-    let initial = builder.build(&server).await?;
-    let initial_thread = Arc::clone(&initial.codex);
-    let rollout_path = initial
-        .session_configured
-        .rollout_path
-        .clone()
-        .expect("rollout path");
-
-    submit_user_turn(&initial_thread, "before compact").await?;
-    submit_compact_turn(&initial_thread).await?;
-    shutdown_thread(&initial_thread).await?;
-
-    let forked = initial
-        .thread_manager
-        .fork_thread(
-            /*snapshot*/ usize::MAX,
-            initial.config.clone(),
-            rollout_path,
-            /*thread_source*/ None,
-            /*persist_extended_history*/ false,
-            /*parent_trace*/ None,
-        )
-        .await?;
-    let fork_rollout_path = forked
-        .session_configured
-        .rollout_path
-        .clone()
-        .expect("fork rollout path");
-    submit_user_turn(&forked.thread, "after fork").await?;
-    shutdown_thread(&forked.thread).await?;
-
-    let resumed = builder
-        .resume(&server, initial.home.clone(), fork_rollout_path)
-        .await?;
-    submit_user_turn(&resumed.codex, "after fork resume").await?;
-    shutdown_thread(&resumed.codex).await?;
-
-    let requests = request_log.requests();
-    assert_eq!(requests.len(), 4, "expected four model requests");
-
-    let window_ids = requests.iter().map(window_id_parts).collect::<Vec<_>>();
-    let initial_thread_id = window_ids[0].0.clone();
-    let forked_thread_id = window_ids[2].0.clone();
-    assert_ne!(forked_thread_id, initial_thread_id);
-    assert_eq!(
-        window_ids,
-        vec![
             (initial_thread_id.clone(), 0),
             (initial_thread_id, 0),
-            (forked_thread_id.clone(), 1),
-            (forked_thread_id, 1),
         ]
     );
 

--- a/codex-rs/core/tests/suite/window_headers.rs
+++ b/codex-rs/core/tests/suite/window_headers.rs
@@ -11,6 +11,7 @@ use codex_protocol::user_input::UserInput;
 use core_test_support::responses::ResponsesRequest;
 use core_test_support::responses::ev_assistant_message;
 use core_test_support::responses::ev_completed;
+use core_test_support::responses::ev_completed_with_tokens;
 use core_test_support::responses::mount_sse_sequence;
 use core_test_support::responses::sse;
 use core_test_support::responses::start_mock_server;
@@ -231,6 +232,84 @@ async fn window_id_rolls_back_across_compaction_and_persists_on_resume() -> Resu
             (initial_thread_id.clone(), 1),
             (initial_thread_id.clone(), 0),
             (initial_thread_id, 0),
+        ]
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn window_id_keeps_pre_turn_compaction_after_rolling_back_its_user_turn() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let request_log = mount_sse_sequence(
+        &server,
+        vec![
+            sse(vec![ev_completed_with_tokens(
+                "resp-1", /*total_tokens*/ 50,
+            )]),
+            sse(vec![ev_completed_with_tokens(
+                "resp-2", /*total_tokens*/ 150,
+            )]),
+            sse(vec![
+                ev_assistant_message("msg-3", "summary"),
+                ev_completed_with_tokens("resp-3", /*total_tokens*/ 30),
+            ]),
+            sse(vec![
+                ev_assistant_message("msg-4", "rolled back"),
+                ev_completed_with_tokens("resp-4", /*total_tokens*/ 30),
+            ]),
+            sse(vec![ev_completed("resp-5")]),
+        ],
+    )
+    .await;
+
+    let mut builder = test_codex().with_config(|config| {
+        config.model_provider.name = "Non-OpenAI Model provider".to_string();
+        config.compact_prompt = Some(SUMMARIZATION_PROMPT.to_string());
+        config.model_context_window = Some(1_000);
+        config.model_auto_compact_token_limit = Some(100);
+    });
+    let initial = builder.build(&server).await?;
+    let initial_thread = Arc::clone(&initial.codex);
+    let rollout_path = initial
+        .session_configured
+        .rollout_path
+        .clone()
+        .expect("rollout path");
+
+    submit_user_turn(&initial_thread, "first").await?;
+    submit_user_turn(&initial_thread, "second").await?;
+    submit_user_turn(&initial_thread, "rolled back after pre-turn compact").await?;
+    initial_thread
+        .submit(Op::ThreadRollback { num_turns: 1 })
+        .await?;
+    wait_for_event(&initial_thread, |event| {
+        matches!(event, EventMsg::ThreadRolledBack(_))
+    })
+    .await;
+    shutdown_thread(&initial_thread).await?;
+
+    let resumed = builder
+        .resume(&server, initial.home.clone(), rollout_path)
+        .await?;
+    submit_user_turn(&resumed.codex, "after resume").await?;
+    shutdown_thread(&resumed.codex).await?;
+
+    let requests = request_log.requests();
+    assert_eq!(requests.len(), 5, "expected five model requests");
+
+    let window_ids = requests.iter().map(window_id_parts).collect::<Vec<_>>();
+    let thread_id = window_ids[0].0.clone();
+    assert_eq!(
+        window_ids,
+        vec![
+            (thread_id.clone(), 0),
+            (thread_id.clone(), 0),
+            (thread_id.clone(), 0),
+            (thread_id.clone(), 1),
+            (thread_id, 1),
         ]
     );
 

--- a/codex-rs/core/tests/suite/window_headers.rs
+++ b/codex-rs/core/tests/suite/window_headers.rs
@@ -21,7 +21,8 @@ use pretty_assertions::assert_eq;
 use std::sync::Arc;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn window_id_advances_after_compact_persists_on_resume_and_resets_on_fork() -> Result<()> {
+async fn window_id_advances_after_compact_persists_on_resume_and_resets_on_empty_fork() -> Result<()>
+{
     skip_if_no_network!(Ok(()));
 
     let server = start_mock_server().await;
@@ -97,6 +98,152 @@ async fn window_id_advances_after_compact_persists_on_resume_and_resets_on_fork(
     assert_eq!(after_resume_generation, 1);
     assert_ne!(after_fork_thread_id, initial_thread_id);
     assert_eq!(after_fork_generation, 0);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn window_id_advances_after_rollback_and_persists_on_resume() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let request_log = mount_sse_sequence(
+        &server,
+        vec![
+            sse(vec![ev_completed("resp-1")]),
+            sse(vec![ev_completed("resp-2")]),
+            sse(vec![ev_completed("resp-3")]),
+            sse(vec![ev_completed("resp-4")]),
+        ],
+    )
+    .await;
+
+    let mut builder = test_codex().with_config(|config| {
+        config.model_provider.name = "Non-OpenAI Model provider".to_string();
+    });
+    let initial = builder.build(&server).await?;
+    let initial_thread = Arc::clone(&initial.codex);
+    let rollout_path = initial
+        .session_configured
+        .rollout_path
+        .clone()
+        .expect("rollout path");
+
+    submit_user_turn(&initial_thread, "before rollback").await?;
+    submit_user_turn(&initial_thread, "discard me").await?;
+    initial_thread
+        .submit(Op::ThreadRollback { num_turns: 1 })
+        .await?;
+    wait_for_event(&initial_thread, |event| {
+        matches!(event, EventMsg::ThreadRolledBack(_))
+    })
+    .await;
+    submit_user_turn(&initial_thread, "after rollback").await?;
+    shutdown_thread(&initial_thread).await?;
+
+    let resumed = builder
+        .resume(&server, initial.home.clone(), rollout_path)
+        .await?;
+    submit_user_turn(&resumed.codex, "after resume").await?;
+    shutdown_thread(&resumed.codex).await?;
+
+    let requests = request_log.requests();
+    assert_eq!(requests.len(), 4, "expected four model requests");
+
+    let window_ids = requests.iter().map(window_id_parts).collect::<Vec<_>>();
+    let initial_thread_id = window_ids[0].0.clone();
+    assert_eq!(
+        window_ids,
+        vec![
+            (initial_thread_id.clone(), 0),
+            (initial_thread_id.clone(), 0),
+            (initial_thread_id.clone(), 1),
+            (initial_thread_id, 1),
+        ]
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn forked_compacted_history_keeps_window_generation_on_resume() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let request_log = mount_sse_sequence(
+        &server,
+        vec![
+            sse(vec![
+                ev_assistant_message("msg-1", "first reply"),
+                ev_completed("resp-1"),
+            ]),
+            sse(vec![
+                ev_assistant_message("msg-2", "summary"),
+                ev_completed("resp-2"),
+            ]),
+            sse(vec![ev_completed("resp-3")]),
+            sse(vec![ev_completed("resp-4")]),
+        ],
+    )
+    .await;
+
+    let mut builder = test_codex().with_config(|config| {
+        config.model_provider.name = "Non-OpenAI Model provider".to_string();
+        config.compact_prompt = Some(SUMMARIZATION_PROMPT.to_string());
+    });
+    let initial = builder.build(&server).await?;
+    let initial_thread = Arc::clone(&initial.codex);
+    let rollout_path = initial
+        .session_configured
+        .rollout_path
+        .clone()
+        .expect("rollout path");
+
+    submit_user_turn(&initial_thread, "before compact").await?;
+    submit_compact_turn(&initial_thread).await?;
+    shutdown_thread(&initial_thread).await?;
+
+    let forked = initial
+        .thread_manager
+        .fork_thread(
+            /*snapshot*/ usize::MAX,
+            initial.config.clone(),
+            rollout_path,
+            /*thread_source*/ None,
+            /*persist_extended_history*/ false,
+            /*parent_trace*/ None,
+        )
+        .await?;
+    let fork_rollout_path = forked
+        .session_configured
+        .rollout_path
+        .clone()
+        .expect("fork rollout path");
+    submit_user_turn(&forked.thread, "after fork").await?;
+    shutdown_thread(&forked.thread).await?;
+
+    let resumed = builder
+        .resume(&server, initial.home.clone(), fork_rollout_path)
+        .await?;
+    submit_user_turn(&resumed.codex, "after fork resume").await?;
+    shutdown_thread(&resumed.codex).await?;
+
+    let requests = request_log.requests();
+    assert_eq!(requests.len(), 4, "expected four model requests");
+
+    let window_ids = requests.iter().map(window_id_parts).collect::<Vec<_>>();
+    let initial_thread_id = window_ids[0].0.clone();
+    let forked_thread_id = window_ids[2].0.clone();
+    assert_ne!(forked_thread_id, initial_thread_id);
+    assert_eq!(
+        window_ids,
+        vec![
+            (initial_thread_id.clone(), 0),
+            (initial_thread_id, 0),
+            (forked_thread_id.clone(), 1),
+            (forked_thread_id, 1),
+        ]
+    );
 
     Ok(())
 }

--- a/codex-rs/core/tests/suite/window_headers.rs
+++ b/codex-rs/core/tests/suite/window_headers.rs
@@ -164,6 +164,162 @@ async fn window_id_stays_stable_after_rollback_and_resume() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn window_id_rolls_back_across_compaction_and_persists_on_resume() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let request_log = mount_sse_sequence(
+        &server,
+        vec![
+            sse(vec![
+                ev_assistant_message("msg-1", "first reply"),
+                ev_completed("resp-1"),
+            ]),
+            sse(vec![
+                ev_assistant_message("msg-2", "summary"),
+                ev_completed("resp-2"),
+            ]),
+            sse(vec![ev_completed("resp-3")]),
+            sse(vec![ev_completed("resp-4")]),
+            sse(vec![ev_completed("resp-5")]),
+        ],
+    )
+    .await;
+
+    let mut builder = test_codex().with_config(|config| {
+        config.model_provider.name = "Non-OpenAI Model provider".to_string();
+        config.compact_prompt = Some(SUMMARIZATION_PROMPT.to_string());
+    });
+    let initial = builder.build(&server).await?;
+    let initial_thread = Arc::clone(&initial.codex);
+    let rollout_path = initial
+        .session_configured
+        .rollout_path
+        .clone()
+        .expect("rollout path");
+
+    submit_user_turn(&initial_thread, "before compact").await?;
+    submit_compact_turn(&initial_thread).await?;
+    submit_user_turn(&initial_thread, "discard me").await?;
+    initial_thread
+        .submit(Op::ThreadRollback { num_turns: 2 })
+        .await?;
+    wait_for_event(&initial_thread, |event| {
+        matches!(event, EventMsg::ThreadRolledBack(_))
+    })
+    .await;
+    submit_user_turn(&initial_thread, "after rollback").await?;
+    shutdown_thread(&initial_thread).await?;
+
+    let resumed = builder
+        .resume(&server, initial.home.clone(), rollout_path)
+        .await?;
+    submit_user_turn(&resumed.codex, "after resume").await?;
+    shutdown_thread(&resumed.codex).await?;
+
+    let requests = request_log.requests();
+    assert_eq!(requests.len(), 5, "expected five model requests");
+
+    let window_ids = requests.iter().map(window_id_parts).collect::<Vec<_>>();
+    let initial_thread_id = window_ids[0].0.clone();
+    assert_eq!(
+        window_ids,
+        vec![
+            (initial_thread_id.clone(), 0),
+            (initial_thread_id.clone(), 0),
+            (initial_thread_id.clone(), 1),
+            (initial_thread_id.clone(), 0),
+            (initial_thread_id, 0),
+        ]
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn forked_compacted_history_inherits_effective_generation_on_resume() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let request_log = mount_sse_sequence(
+        &server,
+        vec![
+            sse(vec![
+                ev_assistant_message("msg-1", "first reply"),
+                ev_completed("resp-1"),
+            ]),
+            sse(vec![
+                ev_assistant_message("msg-2", "summary"),
+                ev_completed("resp-2"),
+            ]),
+            sse(vec![ev_completed("resp-3")]),
+            sse(vec![ev_completed("resp-4")]),
+        ],
+    )
+    .await;
+
+    let mut builder = test_codex().with_config(|config| {
+        config.model_provider.name = "Non-OpenAI Model provider".to_string();
+        config.compact_prompt = Some(SUMMARIZATION_PROMPT.to_string());
+    });
+    let initial = builder.build(&server).await?;
+    let initial_thread = Arc::clone(&initial.codex);
+    let rollout_path = initial
+        .session_configured
+        .rollout_path
+        .clone()
+        .expect("rollout path");
+
+    submit_user_turn(&initial_thread, "before compact").await?;
+    submit_compact_turn(&initial_thread).await?;
+    shutdown_thread(&initial_thread).await?;
+
+    let forked = initial
+        .thread_manager
+        .fork_thread(
+            /*snapshot*/ usize::MAX,
+            initial.config.clone(),
+            rollout_path,
+            /*thread_source*/ None,
+            /*persist_extended_history*/ false,
+            /*parent_trace*/ None,
+        )
+        .await?;
+    let fork_rollout_path = forked
+        .session_configured
+        .rollout_path
+        .clone()
+        .expect("fork rollout path");
+    submit_user_turn(&forked.thread, "after fork").await?;
+    shutdown_thread(&forked.thread).await?;
+
+    let resumed = builder
+        .resume(&server, initial.home.clone(), fork_rollout_path)
+        .await?;
+    submit_user_turn(&resumed.codex, "after fork resume").await?;
+    shutdown_thread(&resumed.codex).await?;
+
+    let requests = request_log.requests();
+    assert_eq!(requests.len(), 4, "expected four model requests");
+
+    let window_ids = requests.iter().map(window_id_parts).collect::<Vec<_>>();
+    let initial_thread_id = window_ids[0].0.clone();
+    let forked_thread_id = window_ids[2].0.clone();
+    assert_ne!(forked_thread_id, initial_thread_id);
+    assert_eq!(
+        window_ids,
+        vec![
+            (initial_thread_id.clone(), 0),
+            (initial_thread_id, 0),
+            (forked_thread_id.clone(), 1),
+            (forked_thread_id, 1),
+        ]
+    );
+
+    Ok(())
+}
+
 async fn submit_user_turn(codex: &Arc<CodexThread>, text: &str) -> Result<()> {
     codex
         .submit(Op::UserInput {

--- a/codex-rs/core/tests/suite/window_headers.rs
+++ b/codex-rs/core/tests/suite/window_headers.rs
@@ -282,7 +282,6 @@ async fn forked_compacted_history_inherits_effective_generation_on_resume() -> R
             initial.config.clone(),
             rollout_path,
             /*thread_source*/ None,
-            /*persist_extended_history*/ false,
             /*parent_trace*/ None,
         )
         .await?;


### PR DESCRIPTION
## Summary

`x-codex-window-id` should identify the effective compaction-window lineage, including after rollback, resume, and retained-history fork. Previously, rollback could drop or later restore the wrong generation because reconstruction did not derive generation from the effective rollout history.

This PR derives window generation in the existing rollout reconstruction loop. It also preserves a pre-turn compaction when the user turn that follows it is rolled back.

## Design

`reconstruct_rollout_plan` remains the single source of truth for reconstructed history, hydration metadata, and surviving compaction count. The reverse replay continues past the existing history stopping condition only to derive window lineage; it does not add a second replay algorithm.

For a rolled-back user-turn segment, only compactions that occurred before the user input survive. Mid-turn and post-user compactions remain associated with the rolled-back turn.

Rollout reconstruction uses `restore_window_generation`, so restoring lineage does not change the existing `set_window_generation` cache invalidation behavior or manually invalidate WebSocket state.

## Cases

```text
# Rollback across compaction
before: thread:0 -> compact -> thread:1 -> rollback -> thread:1
after:  thread:0 -> compact -> thread:1 -> rollback -> thread:0

# Resume after rollback
before: thread:0 -> compact -> thread:1 -> rollback -> thread:0 -> resume -> thread:1
after:  thread:0 -> compact -> thread:1 -> rollback -> thread:0 -> resume -> thread:0

# Rollback after pre-turn compaction
before: thread:0 -> pre-turn compact -> thread:1 -> rollback current turn -> resume -> thread:0
after:  thread:0 -> pre-turn compact -> thread:1 -> rollback current turn -> resume -> thread:1

# Retained-history fork
before: parent:1 -> fork child:0 -> resume child:1
after:  parent:1 -> fork child:1 -> resume child:1
```

## Impact

- Changes only populated window-lineage values: `x-codex-window-id` and matching turn metadata `window_id`.
- Does not change reconstructed history, hydration metadata, WebSocket reuse, or `previous_response_id` behavior.
- Adds no network request, handshake, schema, analytics table, DAG, pipeline, or export change.
- Resume/fork startup performs one in-memory reverse rollout scan.

## Validation

- Rebased onto `origin/main` at `85fd52f7e` with no conflicts; rebased head is `ff0779880`.
- `git range-diff` reports 7 commits patch-equivalent and 2 with context-only changes from upstream's `TurnEnvironmentSelections` rename; the PR changes themselves are unchanged.
- Focused validation passed `13/13`: rollback/resume/fork, pre-turn compaction, startup prewarm, WebSocket continuation, metadata construction, and direct rollout-reconstruction tests.
- Complete directly affected modules passed `33/33` with one test thread: all rollout-reconstruction, window-header, and agent-WebSocket tests.
- Complete local compaction and compact-resume/fork modules passed `33/33`; one unrelated summarize-context test passed on its automatic retry.
- Remote compaction and parity modules completed `30/39`; all parity and request-shape coverage passed, while 9 long-running remote-compaction tests hit nextest's local 60-second timeout. None of those tests assert window generation.
- A full `codex-core` run was attempted. Broad unrelated event-deadline and fixture failures appeared under local parallel load; representative failures from additional-context, compaction, and shell modules all passed when rerun in isolation with one test thread.
- `just fix -p codex-core`, `just fmt`, and `git diff --check origin/main...HEAD` passed.
- Nextest reported two passing tests as `LEAK`; no assertions or test processes failed.
- The final rebased head passed fresh GitHub CI with `29 passed / 0 failed / 0 pending`, including the full Bazel test matrix across Linux, macOS, and Windows.
